### PR TITLE
Add COPY protocol, graceful shutdown, and enhanced pg_catalog support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# Claude Code Context for Duckgres
+
+This file provides context for Claude Code sessions working on this codebase.
+
+## Project Overview
+
+Duckgres is a PostgreSQL wire protocol server backed by DuckDB. It allows any PostgreSQL client (psql, pgAdmin, lib/pq, psycopg2, JDBC, etc.) to connect and execute queries against DuckDB databases.
+
+## Architecture
+
+```
+PostgreSQL Client → TLS → Duckgres Server → DuckDB (per-user database)
+```
+
+### Key Components
+
+- **main.go**: Entry point, configuration loading (CLI flags, env vars, YAML)
+- **server/server.go**: Server struct, connection handling, graceful shutdown
+- **server/conn.go**: Client connection handling, query execution, COPY protocol
+- **server/protocol.go**: PostgreSQL wire protocol message encoding/decoding
+- **server/catalog.go**: pg_catalog compatibility (views, functions, query rewriting)
+- **server/types.go**: Type OID mapping between DuckDB and PostgreSQL
+- **server/ratelimit.go**: Rate limiting for brute-force protection
+- **server/tls.go**: Auto-generation of self-signed TLS certificates
+
+## PostgreSQL Wire Protocol
+
+The server implements the PostgreSQL v3 protocol:
+
+### Message Types (server/protocol.go)
+- **Frontend (client→server)**: Query, Parse, Bind, Describe, Execute, Sync, Close, CopyData, CopyDone
+- **Backend (server→client)**: AuthOK, RowDescription, DataRow, CommandComplete, ReadyForQuery, CopyInResponse, CopyOutResponse
+
+### Query Flow
+1. Client sends Query message ('Q')
+2. Server parses SQL, rewrites pg_catalog references
+3. Server executes via DuckDB's database/sql driver
+4. Server sends RowDescription + DataRow messages
+5. Server sends CommandComplete + ReadyForQuery
+
+### Extended Query Protocol
+Supports prepared statements (Parse/Bind/Execute) for parameterized queries and binary result formats.
+
+## pg_catalog Compatibility (server/catalog.go)
+
+psql and other clients expect PostgreSQL system catalogs. We provide compatibility by:
+
+1. **Creating views** in main schema that mirror pg_catalog tables:
+   - `pg_database`, `pg_class_full`, `pg_collation`, `pg_policy`, `pg_roles`
+   - `pg_statistic_ext`, `pg_publication`, `pg_publication_rel`, `pg_inherits`, etc.
+
+2. **Creating macros** for PostgreSQL functions:
+   - `pg_get_userbyid`, `pg_table_is_visible`, `format_type`, `pg_get_expr`
+   - `obj_description`, `col_description`, `pg_get_indexdef`, etc.
+
+3. **Query rewriting** to replace PostgreSQL-specific syntax:
+   - `pg_catalog.pg_class` → `pg_class_full`
+   - `OPERATOR(pg_catalog.~)` → `~`
+   - `::pg_catalog.regtype` → `::VARCHAR`
+
+## COPY Protocol (server/conn.go)
+
+Supports bulk data transfer:
+- **COPY TO STDOUT**: Streams query results to client
+- **COPY FROM STDIN**: Receives data from client, inserts row by row
+- Supports CSV format with HEADER option
+
+## Configuration
+
+Three-tier configuration (highest to lowest priority):
+1. CLI flags (`--port`, `--config`, etc.)
+2. Environment variables (`DUCKGRES_PORT`, etc.)
+3. YAML config file
+4. Built-in defaults
+
+## Testing
+
+```bash
+# Build
+go build -o duckgres .
+
+# Run on non-standard port
+./duckgres --port 35437
+
+# Connect with psql
+PGPASSWORD=postgres psql "host=127.0.0.1 port=35437 user=postgres sslmode=require"
+
+# Test commands
+\dt          # List tables
+\d tablename # Describe table
+\l           # List databases
+```
+
+## Common Development Tasks
+
+### Adding a new pg_catalog view
+1. Add view creation SQL in `initPgCatalog()` in `catalog.go`
+2. Add regex pattern to rewrite `pg_catalog.viewname` to `viewname`
+3. Add the replacement in `rewritePgCatalogQuery()`
+
+### Adding a new PostgreSQL function
+1. Add `CREATE MACRO` in the `functions` slice in `initPgCatalog()`
+2. Add function name to `pgCatalogFunctions` slice for query rewriting
+
+### Adding protocol support
+1. Add message type constant in `protocol.go`
+2. Add write function (e.g., `writeCopyData()`)
+3. Handle in message loop in `conn.go`
+
+## Dependencies
+
+- `github.com/duckdb/duckdb-go/v2` - DuckDB Go driver
+- `gopkg.in/yaml.v3` - YAML config parsing
+
+## Known Limitations
+
+- Single process (all users share one process)
+- No replication
+- Some pg_catalog tables are stubs (return empty)
+- Type OID mapping is incomplete (some types show as "unknown")
+
+## TODO Reference
+
+See `TODO.md` for the full feature roadmap and known issues.

--- a/TODO.md
+++ b/TODO.md
@@ -16,26 +16,26 @@
 
 ### Protocol Compatibility
 - [ ] **Binary Format Support**: Encode results in binary format for better performance with some clients
-- [ ] **COPY Protocol**: Support `COPY FROM`/`COPY TO` for bulk data loading
+- [x] **COPY Protocol**: Support `COPY FROM`/`COPY TO` for bulk data loading
 - [ ] **Cancel Request Handling**: Properly cancel long-running queries
 
 ### Compatibility
 - [x] **System Catalog Emulation**: Basic `pg_catalog` compatibility for psql
   - [x] `\dt` (list tables) - working
   - [x] `\l` (list databases) - working
-  - [ ] `\d <table>` (describe table) - needs more pg_class columns
+  - [x] `\d <table>` (describe table) - working
 - [ ] **Information Schema**: Emulate PostgreSQL's `information_schema`
 - [ ] **Session Variables**: Support `SET` commands (timezone, search_path, etc.)
 - [ ] **Type OID Mapping**: Proper PostgreSQL OID mapping for all DuckDB types
 
 ### Features
-- [ ] **Extensions**: Load DuckDB extensions on startup
+- [x] **Extensions**: Load DuckDB extensions on startup
 
 ### Operations
 - [ ] **Hot Reload**: Reload config without restart
 - [ ] **Admin Commands**: `\duckgres status`, `\duckgres users`, etc.
 - [ ] **Docker Image**: Official container image
-- [ ] **Graceful Shutdown**: Finish in-flight queries before shutdown
+- [x] **Graceful Shutdown**: Finish in-flight queries before shutdown
 
 ## Medium Priority
 
@@ -73,7 +73,7 @@
 ## Known Issues
 
 - [ ] Some PostgreSQL drivers may fail with unsupported OIDs
-- [ ] `\d` commands in psql don't work (need system catalog)
+- [x] `\d` commands in psql don't work (need system catalog) - fixed
 - [ ] Transaction isolation may differ from PostgreSQL behavior
 - [ ] Large result sets may cause memory issues (no streaming)
 

--- a/server/catalog.go
+++ b/server/catalog.go
@@ -27,6 +27,184 @@ func initPgCatalog(db *sql.DB) error {
 	`
 	db.Exec(pgDatabaseSQL)
 
+	// Create pg_class wrapper that adds missing columns psql expects
+	// DuckDB's pg_catalog.pg_class is missing relforcerowsecurity
+	pgClassSQL := `
+		CREATE OR REPLACE VIEW pg_class_full AS
+		SELECT
+			oid,
+			relname,
+			relnamespace,
+			reltype,
+			reloftype,
+			relowner,
+			relam,
+			relfilenode,
+			reltablespace,
+			relpages,
+			reltuples,
+			relallvisible,
+			reltoastrelid,
+			reltoastidxid,
+			relhasindex,
+			relisshared,
+			relpersistence,
+			relkind,
+			relnatts,
+			relchecks,
+			relhasoids,
+			relhaspkey,
+			relhasrules,
+			relhastriggers,
+			relhassubclass,
+			relrowsecurity,
+			false AS relforcerowsecurity,
+			relispopulated,
+			relreplident,
+			relispartition,
+			relrewrite,
+			relfrozenxid,
+			relminmxid,
+			relacl,
+			reloptions,
+			relpartbound
+		FROM pg_catalog.pg_class
+	`
+	db.Exec(pgClassSQL)
+
+	// Create pg_collation view (DuckDB doesn't have this)
+	pgCollationSQL := `
+		CREATE OR REPLACE VIEW pg_collation AS
+		SELECT
+			0::BIGINT AS oid,
+			'default' AS collname,
+			0::BIGINT AS collnamespace,
+			0::INTEGER AS collowner,
+			'c' AS collprovider,
+			true AS collisdeterministic,
+			0::INTEGER AS collencoding,
+			'C' AS collcollate,
+			'C' AS collctype,
+			NULL AS collversion
+		WHERE false
+	`
+	db.Exec(pgCollationSQL)
+
+	// Create pg_policy view for row-level security (empty, DuckDB doesn't support RLS)
+	pgPolicySQL := `
+		CREATE OR REPLACE VIEW pg_policy AS
+		SELECT
+			0::BIGINT AS oid,
+			'' AS polname,
+			0::BIGINT AS polrelid,
+			'*' AS polcmd,
+			true AS polpermissive,
+			ARRAY[]::BIGINT[] AS polroles,
+			NULL AS polqual,
+			NULL AS polwithcheck
+		WHERE false
+	`
+	db.Exec(pgPolicySQL)
+
+	// Create pg_roles view (minimal for psql compatibility)
+	pgRolesSQL := `
+		CREATE OR REPLACE VIEW pg_roles AS
+		SELECT
+			0::BIGINT AS oid,
+			'duckdb' AS rolname,
+			true AS rolsuper,
+			true AS rolinherit,
+			true AS rolcreaterole,
+			true AS rolcreatedb,
+			true AS rolcanlogin,
+			false AS rolreplication,
+			false AS rolbypassrls,
+			-1::INTEGER AS rolconnlimit,
+			NULL AS rolpassword,
+			NULL AS rolvaliduntil,
+			ARRAY[]::VARCHAR[] AS rolconfig
+	`
+	db.Exec(pgRolesSQL)
+
+	// Create pg_statistic_ext view (extended statistics, empty)
+	pgStatisticExtSQL := `
+		CREATE OR REPLACE VIEW pg_statistic_ext AS
+		SELECT
+			0::BIGINT AS oid,
+			0::BIGINT AS stxrelid,
+			0::BIGINT AS stxnamespace,
+			'' AS stxname,
+			0::INTEGER AS stxowner,
+			0::INTEGER AS stxstattarget,
+			ARRAY[]::VARCHAR[] AS stxkeys,
+			ARRAY[]::VARCHAR[] AS stxkind
+		WHERE false
+	`
+	db.Exec(pgStatisticExtSQL)
+
+	// Create pg_publication_tables view (logical replication, empty)
+	pgPublicationTablesSQL := `
+		CREATE OR REPLACE VIEW pg_publication_tables AS
+		SELECT
+			'' AS pubname,
+			'' AS schemaname,
+			'' AS tablename
+		WHERE false
+	`
+	db.Exec(pgPublicationTablesSQL)
+
+	// Create pg_rules view (empty, DuckDB doesn't have rules)
+	pgRulesSQL := `
+		CREATE OR REPLACE VIEW pg_rules AS
+		SELECT
+			'' AS schemaname,
+			'' AS tablename,
+			'' AS rulename,
+			'' AS definition
+		WHERE false
+	`
+	db.Exec(pgRulesSQL)
+
+	// Create pg_publication view (logical replication, empty)
+	pgPublicationSQL := `
+		CREATE OR REPLACE VIEW pg_publication AS
+		SELECT
+			0::BIGINT AS oid,
+			'' AS pubname,
+			0::INTEGER AS pubowner,
+			false AS puballtables,
+			false AS pubinsert,
+			false AS pubupdate,
+			false AS pubdelete,
+			false AS pubtruncate,
+			false AS pubviaroot
+		WHERE false
+	`
+	db.Exec(pgPublicationSQL)
+
+	// Create pg_publication_rel view (publication-relation mapping, empty)
+	pgPublicationRelSQL := `
+		CREATE OR REPLACE VIEW pg_publication_rel AS
+		SELECT
+			0::BIGINT AS oid,
+			0::BIGINT AS prpubid,
+			0::BIGINT AS prrelid
+		WHERE false
+	`
+	db.Exec(pgPublicationRelSQL)
+
+	// Create pg_inherits view (table inheritance, empty - DuckDB doesn't support inheritance)
+	pgInheritsSQL := `
+		CREATE OR REPLACE VIEW pg_inherits AS
+		SELECT
+			0::BIGINT AS inhrelid,
+			0::BIGINT AS inhparent,
+			0::INTEGER AS inhseqno,
+			false AS inhdetachpending
+		WHERE false
+	`
+	db.Exec(pgInheritsSQL)
+
 	// Create helper macros/functions that psql expects but DuckDB doesn't have
 	// These need to be created without schema prefix so DuckDB finds them
 	functions := []string{
@@ -69,12 +247,20 @@ func initPgCatalog(db *sql.DB) error {
 		`CREATE OR REPLACE MACRO col_description(table_oid, col_num) AS NULL`,
 		// shobj_description - get shared object comment
 		`CREATE OR REPLACE MACRO shobj_description(oid, catalog) AS NULL`,
+		// pg_get_expr - deparse an expression (used for defaults, etc.)
+		// Use default parameter so it works with both 2 and 3 args
+		`DROP MACRO IF EXISTS pg_get_expr`,
+		`CREATE MACRO pg_get_expr(expr, relid, pretty := false) AS NULL`,
 		// pg_get_indexdef - get index definition
 		`CREATE OR REPLACE MACRO pg_get_indexdef(index_oid) AS ''`,
 		`CREATE OR REPLACE MACRO pg_get_indexdef(index_oid, col, pretty) AS ''`,
 		// pg_get_constraintdef - get constraint definition
 		`CREATE OR REPLACE MACRO pg_get_constraintdef(constraint_oid) AS ''`,
 		`CREATE OR REPLACE MACRO pg_get_constraintdef(constraint_oid, pretty) AS ''`,
+		// pg_get_statisticsobjdef_columns - get column list for extended statistics
+		`CREATE OR REPLACE MACRO pg_get_statisticsobjdef_columns(stat_oid) AS ''`,
+		// pg_relation_is_publishable - check if relation can be published
+		`CREATE OR REPLACE MACRO pg_relation_is_publishable(rel_oid) AS false`,
 		// current_setting - get config setting
 		`CREATE OR REPLACE MACRO current_setting(name) AS
 			CASE name
@@ -108,6 +294,9 @@ var pgCatalogFunctions = []string{
 	"shobj_description",
 	"pg_get_indexdef",
 	"pg_get_constraintdef",
+	"pg_get_partkeydef",
+	"pg_get_statisticsobjdef_columns",
+	"pg_relation_is_publishable",
 	"current_setting",
 	"pg_is_in_recovery",
 	"has_schema_privilege",
@@ -132,10 +321,36 @@ var (
 	collateRegex = regexp.MustCompile(`(?i)\s+COLLATE\s+pg_catalog\."?default"?`)
 	// pg_catalog.pg_database -> pg_database (use our view)
 	pgDatabaseRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_database`)
+	// pg_catalog.pg_class -> pg_class_full (use our wrapper view with extra columns)
+	pgClassRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_class\b`)
+	// pg_catalog.pg_collation -> pg_collation (use our view)
+	pgCollationRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_collation\b`)
+	// pg_catalog.pg_policy -> pg_policy (use our view)
+	pgPolicyRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_policy\b`)
+	// pg_catalog.pg_roles -> pg_roles (use our view)
+	pgRolesRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_roles\b`)
+	// pg_catalog.pg_statistic_ext -> pg_statistic_ext (use our view)
+	pgStatisticExtRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_statistic_ext\b`)
+	// pg_catalog.pg_publication_tables -> pg_publication_tables (use our view)
+	pgPublicationTablesRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_publication_tables\b`)
+	// pg_catalog.pg_rules -> pg_rules (use our view)
+	pgRulesRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_rules\b`)
+	// pg_catalog.pg_publication -> pg_publication (use our view)
+	pgPublicationRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_publication\b`)
+	// pg_catalog.pg_publication_rel -> pg_publication_rel (use our view)
+	pgPublicationRelRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_publication_rel\b`)
+	// pg_catalog.pg_inherits -> pg_inherits (use our view)
+	pgInheritsRegex = regexp.MustCompile(`(?i)pg_catalog\.pg_inherits\b`)
 	// ::pg_catalog.regtype::pg_catalog.text -> ::VARCHAR (PostgreSQL type cast)
 	regtypeTextCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.regtype::pg_catalog\.text`)
 	// ::pg_catalog.regtype -> ::VARCHAR
 	regtypeCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.regtype`)
+	// ::pg_catalog.regclass -> ::VARCHAR
+	regclassCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.regclass`)
+	// ::pg_catalog.regnamespace::pg_catalog.text -> ::VARCHAR
+	regnamespaceTextCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.regnamespace::pg_catalog\.text`)
+	// ::pg_catalog.regnamespace -> ::VARCHAR
+	regnamespaceCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.regnamespace`)
 	// ::pg_catalog.text -> ::VARCHAR
 	textCastRegex = regexp.MustCompile(`(?i)::pg_catalog\.text`)
 )
@@ -154,9 +369,42 @@ func rewritePgCatalogQuery(query string) string {
 	// Replace pg_catalog.pg_database with pg_database (our view in main schema)
 	query = pgDatabaseRegex.ReplaceAllString(query, "pg_database")
 
+	// Replace pg_catalog.pg_class with pg_class_full (our wrapper view with extra columns)
+	query = pgClassRegex.ReplaceAllString(query, "pg_class_full")
+
+	// Replace pg_catalog.pg_collation with pg_collation (our empty view)
+	query = pgCollationRegex.ReplaceAllString(query, "pg_collation")
+
+	// Replace pg_catalog.pg_policy with pg_policy (our empty view)
+	query = pgPolicyRegex.ReplaceAllString(query, "pg_policy")
+
+	// Replace pg_catalog.pg_roles with pg_roles (our view)
+	query = pgRolesRegex.ReplaceAllString(query, "pg_roles")
+
+	// Replace pg_catalog.pg_statistic_ext with pg_statistic_ext (our view)
+	query = pgStatisticExtRegex.ReplaceAllString(query, "pg_statistic_ext")
+
+	// Replace pg_catalog.pg_publication_tables with pg_publication_tables (our view)
+	query = pgPublicationTablesRegex.ReplaceAllString(query, "pg_publication_tables")
+
+	// Replace pg_catalog.pg_rules with pg_rules (our view)
+	query = pgRulesRegex.ReplaceAllString(query, "pg_rules")
+
+	// Replace pg_catalog.pg_publication with pg_publication (our view)
+	query = pgPublicationRegex.ReplaceAllString(query, "pg_publication")
+
+	// Replace pg_catalog.pg_publication_rel with pg_publication_rel (our view)
+	query = pgPublicationRelRegex.ReplaceAllString(query, "pg_publication_rel")
+
+	// Replace pg_catalog.pg_inherits with pg_inherits (our view)
+	query = pgInheritsRegex.ReplaceAllString(query, "pg_inherits")
+
 	// Replace PostgreSQL type casts (order matters - most specific first)
 	query = regtypeTextCastRegex.ReplaceAllString(query, "::VARCHAR")
 	query = regtypeCastRegex.ReplaceAllString(query, "::VARCHAR")
+	query = regclassCastRegex.ReplaceAllString(query, "::VARCHAR")
+	query = regnamespaceTextCastRegex.ReplaceAllString(query, "::VARCHAR")
+	query = regnamespaceCastRegex.ReplaceAllString(query, "::VARCHAR")
 	query = textCastRegex.ReplaceAllString(query, "::VARCHAR")
 
 	return query


### PR DESCRIPTION
## Summary

- **COPY Protocol**: Full support for `COPY TO STDOUT` and `COPY FROM STDIN` for bulk data import/export with CSV/tab-delimited formats
- **Graceful Shutdown**: Waits for in-flight queries to complete with configurable timeout before closing connections
- **Enhanced pg_catalog**: Full support for psql `\d tablename` command through comprehensive system catalog emulation
- **CLAUDE.md**: Added codebase context file for AI assistant sessions

## Details

### COPY Protocol
- Added `CopyData`, `CopyDone`, `CopyFail`, `CopyInResponse`, `CopyOutResponse` message types
- Supports both text and CSV formats with headers
- Works with psql's `\copy` command and programmatic COPY from PostgreSQL drivers

### Graceful Shutdown
- Active connection tracking with atomic counter
- Configurable `ShutdownTimeout` (default 30s)
- `Shutdown(ctx)` method for context-based shutdown
- Logs active connection count during shutdown

### pg_catalog Enhancements
New views and functions added:
- `pg_class_full` with `relforcerowsecurity` column
- `pg_collation`, `pg_policy`, `pg_roles`, `pg_statistic_ext`
- `pg_publication`, `pg_publication_rel`, `pg_publication_tables`
- `pg_inherits` with `inhdetachpending`
- `pg_get_expr` macro with optional `pretty` parameter
- Query rewrites for `::regclass` and `::regnamespace` casts

## Test plan

- [x] Test `COPY tablename TO STDOUT` with psql
- [x] Test `COPY tablename TO STDOUT WITH CSV HEADER`
- [x] Test `COPY tablename FROM STDIN` with psql
- [x] Test `\d tablename` in psql
- [x] Test graceful shutdown with active connections
- [x] Verify `\dt` still works after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)