### PR TITLE
Fix DuckLake ATTACH command format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ extensions:
   - httpfs
 
 ducklake:
-  metadata_store: "postgres:dbname=ducklake"
-  data_path: "s3://my-bucket/ducklake-data/"
+  metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
 rate_limit:
   max_failed_attempts: 5
@@ -97,8 +96,7 @@ Run with config file:
 | `DUCKGRES_DATA_DIR` | Directory for DuckDB files | `./data` |
 | `DUCKGRES_CERT` | TLS certificate file | `./certs/server.crt` |
 | `DUCKGRES_KEY` | TLS private key file | `./certs/server.key` |
-| `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata store | - |
-| `DUCKGRES_DUCKLAKE_DATA_PATH` | DuckLake data path | - |
+| `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 
 ### CLI Flags
 
@@ -133,15 +131,13 @@ DuckLake provides a SQL-based lakehouse format. When configured, the DuckLake ca
 
 ```yaml
 ducklake:
-  # Metadata store (required to enable DuckLake catalog)
-  metadata_store: "postgres:host=localhost dbname=ducklake"
-  # Data path for table files
-  data_path: "s3://my-bucket/ducklake-data/"
+  # Full connection string for the DuckLake metadata database
+  metadata_store: "postgres:host=ducklake.example.com user=ducklake password=secret dbname=ducklake"
 ```
 
 This runs the equivalent of:
 ```sql
-ATTACH 'ducklake:postgres:host=localhost dbname=ducklake' (DATA_PATH 's3://my-bucket/ducklake-data/')
+ATTACH 'ducklake:postgres:host=ducklake.example.com user=ducklake password=secret dbname=ducklake' AS ducklake;
 ```
 
 See [DuckLake documentation](https://ducklake.select/docs/stable/duckdb/usage/connecting) for more details.

--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -32,18 +32,11 @@ extensions:
 # When configured, DuckLake catalog is automatically attached on connection
 # See: https://ducklake.select/docs/stable/duckdb/usage/connecting
 ducklake:
-  # Metadata store connection string (required to enable DuckLake)
+  # Full connection string for the DuckLake metadata database
   # Examples:
-  #   - "postgres:dbname=ducklake"
-  #   - "postgres:host=localhost dbname=ducklake user=postgres password=secret"
-  #   - "sqlite:ducklake.db"
-  # metadata_store: "postgres:dbname=ducklake"
-
-  # Data path for table data files (optional)
-  # Examples:
-  #   - "s3://my-bucket/ducklake-data/"
-  #   - "/local/path/to/data/"
-  # data_path: "s3://my-bucket/ducklake-data/"
+  #   - "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
+  #   - "postgres:host=ducklake.example.com user=ducklake password=secret dbname=ducklake"
+  # metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
 # Rate limiting configuration (optional - these are the defaults)
 rate_limit:

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ type RateLimitFileConfig struct {
 }
 
 type DuckLakeFileConfig struct {
-	MetadataStore string `yaml:"metadata_store"` // e.g., "postgres:dbname=ducklake"
-	DataPath      string `yaml:"data_path"`      // e.g., "s3://my-bucket/data/"
+	MetadataStore string `yaml:"metadata_store"` // e.g., "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 }
 
 // loadConfigFile loads configuration from a YAML file
@@ -178,9 +177,6 @@ func main() {
 		if fileCfg.DuckLake.MetadataStore != "" {
 			cfg.DuckLake.MetadataStore = fileCfg.DuckLake.MetadataStore
 		}
-		if fileCfg.DuckLake.DataPath != "" {
-			cfg.DuckLake.DataPath = fileCfg.DuckLake.DataPath
-		}
 	}
 
 	// Apply environment variables (override config file)
@@ -203,9 +199,6 @@ func main() {
 	}
 	if v := os.Getenv("DUCKGRES_DUCKLAKE_METADATA_STORE"); v != "" {
 		cfg.DuckLake.MetadataStore = v
-	}
-	if v := os.Getenv("DUCKGRES_DUCKLAKE_DATA_PATH"); v != "" {
-		cfg.DuckLake.DataPath = v
 	}
 
 	// Apply CLI flags (highest priority)


### PR DESCRIPTION
## Summary

- Add `AS ducklake` alias to ATTACH statement for proper catalog naming
- Remove unused `data_path` config option
- Update connection string examples to show full PostgreSQL format

## Details

The DuckLake ATTACH command was missing the `AS ducklake` alias, which is required for the catalog to be properly named. The correct format is:

```sql
ATTACH 'ducklake:postgres:host=localhost user=ducklake password=secret dbname=ducklake' AS ducklake;
```

Also removed the `data_path` config option which wasn't being used in the connection string format.

## Test plan

- [x] Verify ATTACH statement generates correct format
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)