### PR TITLE
Use native ARM runner for arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           - os: ubuntu-latest
             goos: linux
             goarch: amd64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
 


### PR DESCRIPTION
## Summary
- Uses `ubuntu-24.04-arm` runner for arm64 builds instead of cross-compiling

DuckDB has CGO bindings that cannot be cross-compiled, so we need native ARM runners.

## Test plan
- [ ] Verify both amd64 and arm64 builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)