### PR TITLE
Add SHA256 checksums to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,13 @@ jobs:
         id: sha
         run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum duckgres-linux-amd64/duckgres-linux-amd64 duckgres-linux-arm64/duckgres-linux-arm64 | \
+            sed 's|duckgres-linux-\([^/]*\)/||g' > checksums.txt
+          cat checksums.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -71,6 +78,7 @@ jobs:
           files: |
             artifacts/duckgres-linux-amd64/duckgres-linux-amd64
             artifacts/duckgres-linux-arm64/duckgres-linux-arm64
+            artifacts/checksums.txt
 
       - name: Delete existing latest release
         run: gh release delete latest --yes || true
@@ -94,7 +102,9 @@ jobs:
             ```
             https://github.com/PostHog/duckgres/releases/latest/download/duckgres-linux-amd64
             https://github.com/PostHog/duckgres/releases/latest/download/duckgres-linux-arm64
+            https://github.com/PostHog/duckgres/releases/latest/download/checksums.txt
             ```
           files: |
             artifacts/duckgres-linux-amd64/duckgres-linux-amd64
             artifacts/duckgres-linux-arm64/duckgres-linux-arm64
+            artifacts/checksums.txt


### PR DESCRIPTION
## Summary
- Generates `checksums.txt` with SHA256 hashes for all binaries
- Uploads checksums file to both versioned and `latest` releases

Enables checksum verification when downloading, e.g., with Ansible:

```yaml
- name: Download checksums file
  get_url:
    url: "https://github.com/PostHog/duckgres/releases/latest/download/checksums.txt"
    dest: /tmp/duckgres-checksums.txt

- name: Get checksum for arm64 binary
  shell: grep 'duckgres-linux-arm64' /tmp/duckgres-checksums.txt | awk '{print $1}'
  register: duckgres_checksum

- name: Download duckgres binary with checksum verification
  get_url:
    url: "https://github.com/PostHog/duckgres/releases/latest/download/duckgres-linux-arm64"
    dest: "{{ duckgres_install_dir }}/duckgres"
    checksum: "sha256:{{ duckgres_checksum.stdout }}"
```

## Test plan
- [ ] Verify checksums.txt is generated and uploaded to release

🤖 Generated with [Claude Code](https://claude.com/claude-code)