### PR TITLE
Fix missing RowDescription when Describe is skipped

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1176,7 +1176,14 @@ func (c *clientConn) handleExecute(body []byte) {
 		typeOIDs[i] = getTypeInfo(ct).OID
 	}
 
-	// Don't send RowDescription here - it should come from Describe
+	// Send RowDescription if Describe wasn't called before Execute.
+	// Some clients skip Describe and go straight to Execute, but still
+	// need the column metadata before receiving data rows.
+	if !p.described {
+		if err := c.sendRowDescription(cols, colTypes); err != nil {
+			return
+		}
+	}
 
 	// Send rows with the format codes from Bind
 	rowCount := 0


### PR DESCRIPTION
## Summary

- Send RowDescription in Execute when Describe wasn't called beforehand
- Uses the existing `portal.described` flag to track whether column metadata was already sent

In the extended query protocol, the Describe step is optional. Some clients (like Fivetran) skip Describe and go directly from Bind to Execute. The server was not sending RowDescription in this case, causing:

```
Received resultset tuples, but no field structure for them
```

## Test plan

- [ ] Deploy with PR #14 and retry Fivetran connection validation
- [ ] Verify SELECT queries work with clients that skip Describe

🤖 Generated with [Claude Code](https://claude.com/claude-code)