### PR TITLE
Fix described flag set before RowDescription is actually sent

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1068,7 +1068,6 @@ func (c *clientConn) handleDescribe(body []byte) {
 			c.sendError("ERROR", "34000", fmt.Sprintf("portal %q does not exist", name))
 			return
 		}
-		p.described = true
 
 		// For non-SELECT, send NoData
 		upperQuery := strings.ToUpper(strings.TrimSpace(p.stmt.query))
@@ -1105,6 +1104,9 @@ func (c *clientConn) handleDescribe(body []byte) {
 			return
 		}
 
+		// Only mark as described when we actually send RowDescription.
+		// If we sent NoData above, Execute should still send RowDescription.
+		p.described = true
 		c.sendRowDescription(cols, colTypes)
 
 	default:


### PR DESCRIPTION
## Summary

Moves `p.described = true` to only be set when we actually send RowDescription, not at the start of Describe handling.

**The bug:** The `described` flag was set unconditionally at the start of Describe portal handling, but then the code might send `NoData` instead of `RowDescription` in several cases:
- Query is non-SELECT
- Describe query fails
- Columns are empty

When Execute ran and saw `p.described = true`, it skipped sending RowDescription. But Describe only sent NoData, so the client received DataRows without field structure.

**Error:** `Received resultset tuples, but no field structure for them`

## Test plan

- [ ] Deploy and retry Fivetran connection validation
- [ ] Verify SELECT queries work when Describe sends NoData

🤖 Generated with [Claude Code](https://claude.com/claude-code)