### PR TITLE
Skip RowDescription for queries with 0 columns

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1188,7 +1188,9 @@ func (c *clientConn) handleExecute(body []byte) {
 	// Send RowDescription if Describe wasn't called before Execute.
 	// Some clients skip Describe and go straight to Execute, but still
 	// need the column metadata before receiving data rows.
-	if !p.described {
+	// Skip if there are no columns - queries that return 0 columns (like
+	// DDL accidentally routed here) don't need RowDescription.
+	if !p.described && len(cols) > 0 {
 		if err := c.sendRowDescription(cols, colTypes); err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary

Adds `&& len(cols) > 0` check before sending RowDescription in Execute.

PR #15 introduced sending RowDescription when Describe wasn't called. However, this caused issues with Fivetran's permission test - queries like `/*Fivetran*/CREATE SCHEMA` have leading comments that cause them to be misidentified as SELECT queries. These DDL queries return 0 columns, and sending RowDescription with 0 columns confuses JDBC clients.

## Root cause

1. `/*Fivetran*/CREATE SCHEMA ...` is misidentified as SELECT (leading comment)
2. Goes through SELECT code path, calls `db.Query()`
3. DuckDB executes DDL successfully, returns 0 columns
4. PR #15 sends RowDescription with 0 columns
5. JDBC client confused by unexpected RowDescription

## Fix

Skip sending RowDescription when there are 0 columns. This restores the behavior that worked before PR #15 for these edge cases.

## Test plan

- [ ] Deploy and retry Fivetran connection validation
- [ ] Verify permission test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)