### PR TITLE
Set DuckLake as default catalog after attaching

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -327,7 +327,13 @@ func (s *Server) attachDuckLake(db *sql.DB) error {
 		return fmt.Errorf("failed to attach DuckLake: %w", err)
 	}
 
-	log.Printf("Attached DuckLake catalog successfully")
+	// Set DuckLake as the default catalog so all queries use it
+	// See: https://duckdb.org/docs/stable/core_extensions/ducklake#usage
+	if _, err := db.Exec("USE ducklake"); err != nil {
+		return fmt.Errorf("failed to set DuckLake as default catalog: %w", err)
+	}
+
+	log.Printf("Attached DuckLake catalog successfully and set as default")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- After attaching DuckLake, run `USE ducklake` to set it as the default catalog
- This follows the [DuckDB documentation recommendation](https://duckdb.org/docs/stable/core_extensions/ducklake#usage)
- All queries will now automatically use DuckLake without needing to prefix table names with `ducklake.`

## Test plan
- [ ] Deploy and verify DuckLake is used by default for queries
- [ ] Verify CREATE TABLE and SELECT work without `ducklake.` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)