### PR TITLE
Redact passwords from DuckLake connection string logs

### DIFF
--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -224,3 +224,51 @@ func TestGetCommandType(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactConnectionString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "postgres connection string with password",
+			input:    "postgres:host=localhost user=postgres password=secretpass dbname=ducklake",
+			expected: "postgres:host=localhost user=postgres password=[REDACTED] dbname=ducklake",
+		},
+		{
+			name:     "connection string with password= format",
+			input:    "host=localhost password=mysecret user=admin",
+			expected: "host=localhost password=[REDACTED] user=admin",
+		},
+		{
+			name:     "connection string with PASSWORD uppercase",
+			input:    "host=localhost PASSWORD=mysecret user=admin",
+			expected: "host=localhost PASSWORD=[REDACTED] user=admin",
+		},
+		{
+			name:     "connection string without password",
+			input:    "host=localhost user=postgres dbname=test",
+			expected: "host=localhost user=postgres dbname=test",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "password with special characters",
+			input:    "host=localhost password=p@ss!word123 user=admin",
+			expected: "host=localhost password=[REDACTED] user=admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := redactConnectionString(tt.input)
+			if result != tt.expected {
+				t.Errorf("redactConnectionString(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `redactConnectionString()` helper function to remove passwords from connection strings before logging
- Prevents credentials from being exposed in server logs when attaching DuckLake catalog
- Uses case-insensitive regex to match `password=xxx` patterns

## Example
Before: `Attaching DuckLake catalog: postgres:host=localhost password=secretpass dbname=test`
After: `Attaching DuckLake catalog: postgres:host=localhost password=[REDACTED] dbname=test`

## Test plan
- [x] Added unit tests for `redactConnectionString()` covering various formats
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)