### PR TITLE
Handle nested BEGIN with warning instead of error

### DIFF
--- a/server/protocol.go
+++ b/server/protocol.go
@@ -223,6 +223,32 @@ func writeErrorResponse(w io.Writer, severity, code, message string) error {
 	return writeMessage(w, msgErrorResponse, data)
 }
 
+// writeNoticeResponse sends a notice/warning to the client
+// Unlike errors, notices are informational and don't terminate the command
+func writeNoticeResponse(w io.Writer, severity, code, message string) error {
+	var data []byte
+
+	// Severity (WARNING, NOTICE, INFO, DEBUG, LOG)
+	data = append(data, 'S')
+	data = append(data, []byte(severity)...)
+	data = append(data, 0)
+
+	// SQLSTATE code
+	data = append(data, 'C')
+	data = append(data, []byte(code)...)
+	data = append(data, 0)
+
+	// Message
+	data = append(data, 'M')
+	data = append(data, []byte(message)...)
+	data = append(data, 0)
+
+	// Terminator
+	data = append(data, 0)
+
+	return writeMessage(w, msgNoticeResponse, data)
+}
+
 // writeCommandComplete sends a command completion message
 func writeCommandComplete(w io.Writer, tag string) error {
 	data := []byte(tag)


### PR DESCRIPTION
## Summary
Match PostgreSQL behavior for nested BEGIN transactions:

**PostgreSQL:**
```sql
BEGIN;
BEGIN;  -- WARNING: there is already a transaction in progress
```

**DuckDB (before this fix):**
```sql
BEGIN;
BEGIN;  -- ERROR: cannot start a transaction within a transaction
```

## Changes
- Add `writeNoticeResponse()` in protocol.go for sending non-fatal notices/warnings
- Add `sendNotice()` helper method on clientConn
- Intercept BEGIN when already in transaction (`txStatus == 'T'`) and send warning
- Return success (`CommandComplete: BEGIN`) instead of passing to DuckDB
- Handle in both simple query and extended query protocols

## Test plan
- [x] Unit test for nested BEGIN detection
- [ ] Test with dbt postgres adapter
- [ ] Verify `psql` shows warning on nested BEGIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)