### PR TITLE
Add PostgreSQL-compatible version() function

### DIFF
--- a/server/catalog.go
+++ b/server/catalog.go
@@ -270,6 +270,9 @@ func initPgCatalog(db *sql.DB) error {
 			END`,
 		// pg_is_in_recovery - check if in recovery mode
 		`CREATE OR REPLACE MACRO pg_is_in_recovery() AS false`,
+		// version - return PostgreSQL-compatible version string
+		// Fivetran and other tools check this to determine compatibility
+		`CREATE OR REPLACE MACRO version() AS 'PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)'`,
 	}
 
 	for _, f := range functions {


### PR DESCRIPTION
## Summary
- PostgreSQL clients call `SELECT version()` to check database compatibility
- DuckDB's native `version()` returns `v1.1.0 ...` which doesn't match PostgreSQL format
- Adds a macro that overrides `version()` to return a PostgreSQL-compatible string:
  `PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)`

## Test plan
- [ ] Run `SELECT version()` via psql and verify it returns the PostgreSQL-compatible string
- [ ] Verify PostgreSQL clients can successfully connect and check version

🤖 Generated with [Claude Code](https://claude.com/claude-code)