### PR TITLE
Add extra_float_digits to ignored SET parameters

### DIFF
--- a/server/catalog.go
+++ b/server/catalog.go
@@ -383,6 +383,7 @@ var ignoredSetParameters = map[string]bool{
 	"log_min_messages":             true,
 	"log_min_duration_statement":   true,
 	"log_statement":                true,
+	"extra_float_digits":           true,
 
 	// Transaction settings (DuckDB handles these differently)
 	"default_transaction_isolation":  true,


### PR DESCRIPTION
## Summary
- PostgreSQL clients set `extra_float_digits` to control floating-point precision in output
- DuckDB doesn't support this parameter, causing `Catalog Error: unrecognized configuration parameter "extra_float_digits"`
- This adds `extra_float_digits` to the ignored SET parameters list

## Test plan
- [ ] Verify `SET extra_float_digits = 3` no longer causes errors
- [ ] Verify PostgreSQL clients can connect without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)