### PR TITLE
Rewrite version() to return PostgreSQL-compatible string

### DIFF
--- a/server/catalog.go
+++ b/server/catalog.go
@@ -364,6 +364,8 @@ var (
 	showApplicationNameRegex = regexp.MustCompile(`(?i)^SHOW\s+application_name\s*;?\s*$`)
 	// Regex to extract SET parameter name
 	setParameterRegex = regexp.MustCompile(`(?i)^SET\s+(?:SESSION\s+|LOCAL\s+)?(\w+)`)
+	// version() -> PostgreSQL-compatible version string (DuckDB's built-in can't be overridden by macro)
+	versionFuncRegex = regexp.MustCompile(`(?i)\bversion\s*\(\s*\)`)
 )
 
 // PostgreSQL-specific SET parameters that DuckDB doesn't support.
@@ -553,6 +555,10 @@ func rewritePgCatalogQuery(query string) string {
 	query = setApplicationNameRegex.ReplaceAllString(query, "SET VARIABLE application_name =")
 	query = setApplicationNameToRegex.ReplaceAllString(query, "SET VARIABLE application_name =")
 	query = showApplicationNameRegex.ReplaceAllString(query, "SELECT getvariable('application_name') AS application_name")
+
+	// Replace version() with PostgreSQL-compatible version string
+	// DuckDB's built-in version() can't be overridden by macros
+	query = versionFuncRegex.ReplaceAllString(query, "'PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)'")
 
 	return query
 }


### PR DESCRIPTION
## Summary
- PostgreSQL clients call `SELECT version()` to check database compatibility
- DuckDB's native `version()` returns `v1.4.2` which doesn't match PostgreSQL format
- DuckDB macros cannot override built-in functions like `version()`
- This rewrites `version()` calls in queries to return a PostgreSQL-compatible string:
  `PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)`

## Test plan
- [ ] Run `SELECT version()` via psql and verify it returns the PostgreSQL-compatible string
- [ ] Verify PostgreSQL clients can connect and check version successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)