### PR TITLE
Fix DuckLake concurrent attachment and DDL rewriting for ETL tools

### DIFF
--- a/server/ducklake_test.go
+++ b/server/ducklake_test.go
@@ -150,6 +150,17 @@ func TestRewriteForDuckLake(t *testing.T) {
 				created_at TIMESTAMP
 			)`,
 		},
+		// ETL tool queries with comment prefix and double spaces
+		{
+			name:     "comment prefix with PRIMARY KEY",
+			input:    `/*ETL*/CREATE  TABLE "schema"."table" ( "id" CHARACTER VARYING(256) , "created_at" TIMESTAMP WITH TIME ZONE , PRIMARY KEY ("id") )`,
+			expected: `/*ETL*/CREATE  TABLE "schema"."table" ( "id" CHARACTER VARYING(256) , "created_at" TIMESTAMP WITH TIME ZONE  )`,
+		},
+		{
+			name:     "multiple comment prefixes",
+			input:    `/* comment 1 */ /* comment 2 */ CREATE TABLE test (id INTEGER PRIMARY KEY)`,
+			expected: `/* comment 1 */ /* comment 2 */ CREATE TABLE test (id INTEGER)`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Two fixes for DuckLake compatibility issues seen in production:

### 1. Fix DDL rewriting for ETL tool queries
- **Problem**: `rewriteForDuckLake` didn't recognize CREATE TABLE statements with comment prefixes (`/*ETL*/`) or multiple spaces (`CREATE  TABLE`)
- **Result**: PRIMARY KEY constraints weren't stripped, causing "PRIMARY KEY/UNIQUE constraints are not supported in DuckLake" errors
- **Fix**: 
  - Strip leading SQL comments before detecting CREATE TABLE
  - Use regex to handle multiple spaces between keywords

### 2. Fix DuckLake attachment race condition
- **Problem**: Multiple connections attaching DuckLake simultaneously caused "database with name '__ducklake_metadata_ducklake' already exists" errors
- **Fix**:
  - Move mutex to `attachDuckLake` to serialize both secret creation and catalog attachment
  - Check if DuckLake catalog already exists before attempting attachment

## Test plan
- [x] Existing tests pass
- [x] Added test case for comment-prefixed CREATE TABLE with PRIMARY KEY
- [ ] Deploy to staging and verify no more constraint or attachment errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)