### PR TITLE
Fix COPY FROM STDIN regex to handle transpiled SQL

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -608,7 +608,7 @@ func (c *clientConn) buildCommandTag(cmdType string, result sql.Result) string {
 // Regular expressions for parsing COPY commands
 var (
 	copyToStdoutRegex   = regexp.MustCompile(`(?i)COPY\s+(.+?)\s+TO\s+STDOUT`)
-	copyFromStdinRegex  = regexp.MustCompile(`(?i)COPY\s+(\S+)\s+(?:\(([^)]+)\)\s+)?FROM\s+STDIN`)
+	copyFromStdinRegex  = regexp.MustCompile(`(?i)COPY\s+(\S+)\s*(?:\(([^)]+)\)\s*)?FROM\s+STDIN`)
 	copyWithCSVRegex    = regexp.MustCompile(`(?i)\bCSV\b`)
 	copyWithHeaderRegex = regexp.MustCompile(`(?i)\bHEADER\b`)
 	copyDelimiterRegex  = regexp.MustCompile(`(?i)\bDELIMITER\s+['"](.)['"]\b`)


### PR DESCRIPTION
## Summary

Fix COPY FROM STDIN failing with error:
```
IO Error: No files found that match the pattern "/dev/stdin"
```

## Root Cause

The transpiler removes the space between table name and column list when deparsing:
- **Input**: `COPY "stripe_test"."tax_amount" ("type", ...) FROM STDIN`
- **Transpiled**: `COPY stripe_test.tax_amount(type, ...) FROM STDIN`

The regex expected a required space (`\s+`) between the table name and opening parenthesis, so it didn't match the transpiled SQL. This caused the COPY command to fall through to DuckDB which tried to read `/dev/stdin` as a file.

## Fix

Updated regex from `\s+` to `\s*` (optional space) so it matches both formats.

## Test plan

- [x] Verified regex matches both quoted and unquoted table names
- [x] Verified regex matches with and without spaces before column list
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)