### PR TITLE
Detach DuckLake on client disconnect to prevent RDS connection leaks

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -88,6 +88,12 @@ func (c *clientConn) serve() error {
 	// Ensure the database connection is closed when this client disconnects
 	defer func() {
 		if c.db != nil {
+			// Detach DuckLake to release the RDS metadata connection
+			if c.server.cfg.DuckLake.MetadataStore != "" {
+				if _, err := c.db.Exec("DETACH ducklake"); err != nil {
+					log.Printf("Warning: failed to detach DuckLake for user %q: %v", c.username, err)
+				}
+			}
 			c.db.Close()
 			log.Printf("Closed DuckDB connection for user %q", c.username)
 		}


### PR DESCRIPTION
## Summary
- Explicitly detaches DuckLake catalog before closing DuckDB connection
- Prevents RDS metadata connection leaks when clients disconnect

## Problem
When duckgres clients disconnect, the DuckLake extension wasn't releasing its connection to the RDS PostgreSQL metadata store. This caused connection leaks:

```sql
SELECT usename, application_name, state, count(*) 
FROM pg_stat_activity 
GROUP BY 1,2,3;

     usename     |    application_name    | state  | count
-----------------+------------------------+--------+-------
 ducklingexample |                        | idle   |   170  -- leaked connections!
```

Eventually RDS runs out of connection slots:
```
FATAL: remaining connection slots are reserved for roles with privileges of the "rds_reserved" role
```

## Solution
Run `DETACH ducklake` before `db.Close()` when a client disconnects. This ensures the DuckLake extension properly closes its RDS connection.

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Deploy and verify RDS connection count stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)