### PR TITLE
Fix DateTime type and function compatibility

### DIFF
--- a/transpiler/transform/pgcatalog.go
+++ b/transpiler/transform/pgcatalog.go
@@ -88,8 +88,6 @@ func NewPgCatalogTransformWithConfig(duckLakeMode bool) *PgCatalogTransform {
 			"to_char":      true,
 			"to_date":      true,
 			"to_timestamp": true,
-			"make_time":    true,
-			"age":          true,
 
 			// Numeric functions
 			"width_bucket": true,
@@ -144,8 +142,6 @@ func NewPgCatalogTransformWithConfig(duckLakeMode bool) *PgCatalogTransform {
 			"to_char":      true,
 			"to_date":      true,
 			"to_timestamp": true,
-			"make_time":    true,
-			"age":          true,
 
 			// Numeric functions
 			"width_bucket": true,


### PR DESCRIPTION
## Summary
- Fix TIME type wire protocol serialization
- Fix INTERVAL type wire protocol serialization  
- Improve to_char, to_date, to_timestamp macros
- Use DuckDB native make_time and age functions

## Changes

### Wire Protocol Fixes (server/conn.go)
- **TIME type**: Detect when DuckDB returns time.Time with date 0001-01-01 and output only time portion
- **INTERVAL type**: Add `duckdb.Interval` handling with proper PostgreSQL format
  - Format as "X years Y mons Z days HH:MM:SS"

### Macro Fixes (server/catalog.go)
- **to_char**: Add Day, Month, Mon format codes for day/month names
- **to_date**: Use CASE statement for common date formats (strptime requires constant format)
- **to_timestamp**: Use CASE statement for common timestamp formats
- **Removed**: make_time and age macros (DuckDB has native functions)

## Test Results
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Pass | 622 | 636 | +14 |
| Fail | 99 | 85 | -14 |
| Rate | 86.3% | **88.2%** | +1.9% |

## Remaining DateTime Failure
- `to_char_number`: PostgreSQL number formatting not supported (to_char for numbers is a separate feature)

## Test plan
- [x] Run integration tests: `go test ./tests/integration/...`
- [x] Verify TIME serialization: `SELECT TIME '12:30:45'`
- [x] Verify INTERVAL serialization: `SELECT INTERVAL '1 day'`
- [x] Verify to_date: `SELECT to_date('2024-06-15', 'YYYY-MM-DD')`
- [x] Verify age function: `SELECT age(TIMESTAMP '2024-06-15', TIMESTAMP '2020-01-01')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)