### PR TITLE
Fix psql catalog command compatibility tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.25.4
 
 require (
 	github.com/duckdb/duckdb-go/v2 v2.5.3
+	github.com/lib/pq v1.10.9
+	github.com/pganalyze/pg_query_go/v6 v6.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -23,8 +25,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
-	github.com/pganalyze/pg_query_go/v6 v6.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect

--- a/tests/integration/catalog_test.go
+++ b/tests/integration/catalog_test.go
@@ -194,7 +194,6 @@ func TestCatalogPsqlCommands(t *testing.T) {
 				ORDER BY 1, 2
 				LIMIT 20
 			`,
-			DuckgresOnly: true,
 		},
 
 		// \dn - list schemas
@@ -207,7 +206,6 @@ func TestCatalogPsqlCommands(t *testing.T) {
 				WHERE n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'
 				ORDER BY 1
 			`,
-			DuckgresOnly: true,
 		},
 
 		// \l - list databases
@@ -220,7 +218,6 @@ func TestCatalogPsqlCommands(t *testing.T) {
 				FROM pg_catalog.pg_database d
 				ORDER BY 1
 			`,
-			DuckgresOnly: true,
 		},
 	}
 	runQueryTests(t, tests)

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -274,7 +274,9 @@ func (h *TestHarness) cleanupDuckLakeTables() error {
 	}
 
 	// Drop tables in reverse dependency order
+	// Include both fixture tables and tables created by other tests (DDL tests, etc.)
 	tables := []string{
+		// Fixture tables
 		"test_schema.schema_test",
 		"array_test",
 		"documents",
@@ -290,6 +292,47 @@ func (h *TestHarness) cleanupDuckLakeTables() error {
 		"products",
 		"users",
 		"types_test",
+		// DDL test tables that may persist in DuckLake
+		"ddl_test_basic",
+		"ddl_test_types",
+		"ddl_test_pk",
+		"ddl_test_notnull",
+		"ddl_test_default",
+		"ddl_test_unique",
+		"ddl_test_as",
+		"ddl_alter_test",
+		"ddl_drop_test1",
+		"ddl_drop_test2",
+		"ddl_drop_test3",
+		"ddl_index_test",
+		"ddl_truncate_test",
+		"ddl_comment_test",
+		"ddl_constraint_pk",
+		"ddl_constraint_unique",
+		"ddl_constraint_check",
+		"ddl_constraint_fk",
+		// DML test tables
+		"dml_insert_test",
+		"dml_insert_target",
+		"dml_insert_default",
+		"dml_returning_test",
+		"dml_upsert_test",
+		"dml_update_test",
+		"dml_update_returning",
+		"dml_update_target",
+		"dml_update_source",
+		"dml_delete_test",
+		"dml_delete_returning",
+		"dml_delete_main",
+		"dml_delete_filter",
+		"dml_cte_source",
+		"dml_cte_target",
+		// Protocol test tables
+		"protocol_insert_test",
+		"tx_test",
+		"tx_rollback_test",
+		"tx_isolation_test",
+		"interleave_test",
 	}
 
 	for _, t := range tables {


### PR DESCRIPTION
## Summary
- Fixes `TestCatalogPsqlCommands` tests (`psql_dt`, `psql_dn`, `psql_l`)
- Improves PostgreSQL compatibility for psql meta-commands (\dt, \dn, \l)
- Updates test harness to properly clean up DuckLake persistent tables

## Changes

### pg_database view (fixes `psql_l`)
- Returns standard PostgreSQL databases: postgres, template0, template1, testdb
- Uses appropriate owner OID (10 for postgres user)

### pg_namespace view (fixes `psql_dn`) 
- Maps DuckDB's 'main' schema to PostgreSQL's 'public' for compatibility
- Sets correct owner OIDs (6171 for pg_database_owner, 10 for postgres)

### pg_class_full view (fixes `psql_dt`)
- Filters out internal Duckgres views so they don't appear in \dt output
- Excludes pg_*, information_schema_*, and __duckgres_* objects

### Transpiler updates
- Added pg_namespace to view mappings
- In DuckLake mode, fully qualifies wrapper views with memory.main prefix

### Test harness cleanup
- Extended cleanup to handle tables from DDL/DML/Protocol tests
- Prevents leftover tables in DuckLake from affecting catalog tests

## Test plan
- [x] Run `go test ./tests/integration/... -run TestCatalogPsqlCommands` - all 3 subtests pass
- [x] Run `go test ./tests/integration/... -run TestCatalog` - all catalog tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)