### PR TITLE
Fix DuckLake detach by switching away from default database first

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -89,6 +89,9 @@ func (c *clientConn) serve() error {
 		if c.db != nil {
 			// Detach DuckLake to release the RDS metadata connection
 			if c.server.cfg.DuckLake.MetadataStore != "" {
+				// Must switch away from ducklake before detaching - DuckDB doesn't allow
+				// detaching the default database
+				c.db.Exec("USE memory")
 				if _, err := c.db.Exec("DETACH ducklake"); err != nil {
 					log.Printf("Warning: failed to detach DuckLake for user %q: %v", c.username, err)
 				}


### PR DESCRIPTION
## Summary

- Fixes connection cleanup error in DuckLake mode: `Cannot detach database "ducklake" because it is the default database`
- Adds `USE memory` before `DETACH ducklake` to switch away from the default database first

## Problem

When DuckLake is configured, we set it as the default database with `USE ducklake`. On connection close, attempting to `DETACH ducklake` fails because DuckDB doesn't allow detaching the current default database.

Production logs showed:
```
Warning: failed to detach DuckLake for user "duckgres": Binder Error: Cannot detach database "ducklake" because it is the default database. Select a different database using `USE` to allow detaching this database
```

## Test plan

- [x] Build succeeds
- [x] Tested with 3 sequential connections - no detach errors
- [x] Tested with 10 concurrent connections - no detach errors
- [x] Server shuts down gracefully with "All connections closed gracefully"

🤖 Generated with [Claude Code](https://claude.com/claude-code)