### PR TITLE
Fix information_schema views for DuckLake mode

### DIFF
--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -105,31 +105,31 @@ func TestTranspile_InformationSchema(t *testing.T) {
 		{
 			name:     "information_schema.columns -> compat view",
 			input:    "SELECT * FROM information_schema.columns",
-			contains: "information_schema_columns_compat",
+			contains: "memory.main.information_schema_columns_compat",
 			excludes: "information_schema.columns",
 		},
 		{
 			name:     "information_schema.tables -> compat view",
 			input:    "SELECT * FROM information_schema.tables",
-			contains: "information_schema_tables_compat",
+			contains: "memory.main.information_schema_tables_compat",
 			excludes: "information_schema.tables",
 		},
 		{
 			name:     "information_schema.schemata -> compat view",
 			input:    "SELECT * FROM information_schema.schemata",
-			contains: "information_schema_schemata_compat",
+			contains: "memory.main.information_schema_schemata_compat",
 			excludes: "information_schema.schemata",
 		},
 		{
 			name:     "INFORMATION_SCHEMA.COLUMNS uppercase -> compat view",
 			input:    "SELECT * FROM INFORMATION_SCHEMA.COLUMNS",
-			contains: "information_schema_columns_compat",
+			contains: "memory.main.information_schema_columns_compat",
 			excludes: "information_schema.columns",
 		},
 		{
 			name:     "aliased information_schema query",
 			input:    "SELECT c.column_name FROM information_schema.columns c WHERE c.table_name = 'test'",
-			contains: "information_schema_columns_compat",
+			contains: "memory.main.information_schema_columns_compat",
 			excludes: "information_schema.columns",
 		},
 		{
@@ -169,14 +169,14 @@ func TestTranspile_InformationSchema_DuckLakeMode(t *testing.T) {
 		contains string
 	}{
 		{
-			name:     "information_schema.columns with DuckLake -> main qualified",
+			name:     "information_schema.columns with DuckLake -> memory.main qualified",
 			input:    "SELECT * FROM information_schema.columns",
-			contains: "main.information_schema_columns_compat",
+			contains: "memory.main.information_schema_columns_compat",
 		},
 		{
-			name:     "information_schema.tables with DuckLake -> main qualified",
+			name:     "information_schema.tables with DuckLake -> memory.main qualified",
 			input:    "SELECT * FROM information_schema.tables",
-			contains: "main.information_schema_tables_compat",
+			contains: "memory.main.information_schema_tables_compat",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fixes Fivetran and other tools failing to query `information_schema.columns` in DuckLake mode
- Views are now created as temporary per-connection views in `memory.main` before `USE ducklake`
- Transpiler rewrites to `memory.main.information_schema_*_compat` to find the per-connection views

## Problem

In DuckLake mode, information_schema queries were failing with:
```
Catalog Error: Table with name information_schema_columns_compat does not exist!
```

The issue was that:
1. Views were being created after `USE ducklake`, putting them in `ducklake.main` (shared catalog)
2. The transpiler referenced `memory.main.` prefix which couldn't find views in ducklake.main
3. Per-connection views in memory.main couldn't be accessed after USE ducklake

## Solution

1. Split `attachDuckLake` into two phases:
   - `attachDuckLake`: just attaches the catalog (no USE)
   - `setDuckLakeDefault`: runs USE ducklake

2. Create views BEFORE `USE ducklake` so they go into `memory.main`

3. Views query from unqualified `information_schema` which resolves to the default catalog's information_schema at query time

4. Transpiler rewrites to `memory.main.information_schema_*_compat` which finds the per-connection views

## Test plan

- [x] Build succeeds
- [x] Transpiler tests pass
- [x] Tested with DuckLake locally - Fivetran-style queries work
- [x] Multiple connections each get their own views
- [x] Views correctly show DuckLake table metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)