### PR TITLE
Strip ON CONFLICT clause in DuckLake mode

### DIFF
--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -48,8 +48,8 @@ func New(cfg Config) *Transpiler {
 	// 8. SET/SHOW command handling
 	t.transforms = append(t.transforms, transform.NewSetShowTransform())
 
-	// 9. ON CONFLICT handling
-	t.transforms = append(t.transforms, transform.NewOnConflictTransform())
+	// 9. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
+	t.transforms = append(t.transforms, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode))
 
 	// DDL transforms only when DuckLake mode is enabled
 	if cfg.DuckLakeMode {

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -740,6 +740,42 @@ func TestTranspile_OnConflict(t *testing.T) {
 	}
 }
 
+func TestTranspile_OnConflict_DuckLakeMode(t *testing.T) {
+	// In DuckLake mode, ON CONFLICT is stripped because PRIMARY KEY/UNIQUE constraints don't exist
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "ON CONFLICT DO NOTHING stripped",
+			input: "INSERT INTO users (id, name) VALUES (1, 'test') ON CONFLICT (id) DO NOTHING",
+		},
+		{
+			name:  "ON CONFLICT DO UPDATE stripped",
+			input: "INSERT INTO users (id, name) VALUES (1, 'test') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name",
+		},
+	}
+
+	tr := New(Config{DuckLakeMode: true})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			// ON CONFLICT should be stripped in DuckLake mode
+			if strings.Contains(strings.ToUpper(result.SQL), "ON CONFLICT") {
+				t.Errorf("Transpile(%q) = %q, should NOT contain ON CONFLICT in DuckLake mode", tt.input, result.SQL)
+			}
+			// But the INSERT should still work
+			if !strings.Contains(strings.ToUpper(result.SQL), "INSERT INTO") {
+				t.Errorf("Transpile(%q) = %q, should still contain INSERT INTO", tt.input, result.SQL)
+			}
+		})
+	}
+}
+
 func TestTranspile_JSONOperators(t *testing.T) {
 	// DuckDB supports -> and ->> operators
 	tests := []struct {


### PR DESCRIPTION
## Summary
Strip `ON CONFLICT` clause in DuckLake mode to fix Fivetran load failures.

## Root Cause
Fivetran was failing with:
```
Binder Error: The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX
```

This happened because:
1. Fivetran sends `ALTER TABLE ADD PRIMARY KEY (id)` → we return success (no-op, constraint not created)
2. Fivetran sends `INSERT ... ON CONFLICT (id) DO UPDATE ...` → DuckDB fails because there's no constraint

## Fix
Strip `ON CONFLICT` clause entirely in DuckLake mode since there are no constraints to conflict with. The INSERT becomes a regular INSERT. Fivetran's DELETE + INSERT pattern handles updates, so ON CONFLICT is not needed for data correctness.

## Live Testing
**Without fix:**
```
ERROR: Binder Error: The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX
```

**With fix:**
```
INSERT 0 1
```

## Test plan
- [x] Added tests for ON CONFLICT stripping in DuckLake mode
- [x] Verified ON CONFLICT is preserved in non-DuckLake mode
- [x] Manual testing against DuckLake confirmed queries work

🤖 Generated with [Claude Code](https://claude.com/claude-code)