### PR TITLE
Increase DuckLake max retry count to 100 for concurrent connections

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -406,6 +406,16 @@ func (s *Server) attachDuckLake(db *sql.DB) error {
 	}
 
 	log.Printf("Attached DuckLake catalog successfully")
+
+	// Set DuckLake max retry count to handle concurrent connections
+	// DuckLake uses optimistic concurrency - when multiple connections commit
+	// simultaneously, they may conflict on snapshot IDs. Default of 10 is too low
+	// for tools like Fivetran that open many concurrent connections.
+	if _, err := db.Exec("SET ducklake_max_retry_count = 100"); err != nil {
+		log.Printf("Warning: failed to set ducklake_max_retry_count: %v", err)
+		// Don't fail - this is not critical, DuckLake will use its default
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Sets `ducklake_max_retry_count = 100` immediately after attaching DuckLake catalog
- Fixes transaction conflicts when tools like Fivetran open many concurrent connections

## Problem
DuckLake uses optimistic concurrency control. When multiple connections try to commit simultaneously, they race to insert the next snapshot ID into the PostgreSQL metadata store. With the default retry count of 10, this causes failures:

```
TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
Exceeded the maximum retry count of 10 set by the ducklake_max_retry_count setting.
Failed to write new snapshot to DuckLake: duplicate key value violates unique constraint "ducklake_snapshot_pkey"
Key (snapshot_id)=(47984) already exists.
```

## Solution
Always set retry count to 100 on DuckLake attachment. This gives concurrent connections more attempts to resolve conflicts without failing.

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Deploy and verify Fivetran loads succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)