### PR TITLE
Fix SET SESSION CHARACTERISTICS parser error

### DIFF
--- a/tests/integration/session_test.go
+++ b/tests/integration/session_test.go
@@ -106,6 +106,33 @@ func TestSessionSetCommands(t *testing.T) {
 			Query:        "SET default_transaction_isolation = 'read committed'",
 			DuckgresOnly: true,
 		},
+
+		// Test SET SESSION CHARACTERISTICS commands
+		{
+			Name:         "set_session_characteristics_isolation_level",
+			Query:        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED",
+			DuckgresOnly: true,
+		},
+		{
+			Name:         "set_session_characteristics_read_only",
+			Query:        "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+			DuckgresOnly: true,
+		},
+		{
+			Name:         "set_session_characteristics_read_committed",
+			Query:        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED",
+			DuckgresOnly: true,
+		},
+		{
+			Name:         "set_session_characteristics_repeatable_read",
+			Query:        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+			DuckgresOnly: true,
+		},
+		{
+			Name:         "set_session_characteristics_serializable",
+			Query:        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+			DuckgresOnly: true,
+		},
 	}
 	runQueryTests(t, tests)
 }

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -422,6 +422,37 @@ func TestTranspile_SetShow(t *testing.T) {
 			t.Error("SET application_name should be marked as ignored")
 		}
 	})
+
+	// Test SET SESSION CHARACTERISTICS is ignored
+	t.Run("SET SESSION CHARACTERISTICS ignored", func(t *testing.T) {
+		result, err := tr.Transpile("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+		if err != nil {
+			t.Fatalf("Transpile error: %v", err)
+		}
+		if !result.IsIgnoredSet {
+			t.Error("SET SESSION CHARACTERISTICS should be marked as ignored")
+		}
+	})
+
+	// Test various SET SESSION CHARACTERISTICS variations
+	t.Run("SET SESSION CHARACTERISTICS variations", func(t *testing.T) {
+		tests := []string{
+			"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED",
+			"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+			"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+			"SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+			"SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE",
+		}
+		for _, query := range tests {
+			result, err := tr.Transpile(query)
+			if err != nil {
+				t.Errorf("Transpile(%q) error: %v", query, err)
+			}
+			if !result.IsIgnoredSet {
+				t.Errorf("Transpile(%q) should be marked as ignored", query)
+			}
+		}
+	})
 }
 
 func TestTranspile_ComplexQueries(t *testing.T) {


### PR DESCRIPTION
Ignore PostgreSQL transaction isolation commands (SET SESSION CHARACTERISTICS, SET TRANSACTION) since DuckDB/DuckLake use fixed isolation levels (SERIALIZABLE/snapshot isolation).