### PR TITLE
Handle empty queries in extended query protocol

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1913,6 +1913,13 @@ func (c *clientConn) handleExecute(body []byte) {
 
 	log.Printf("[%s] Execute %q with %d params: %s", c.username, portalName, len(args), p.stmt.query)
 
+	// Handle empty queries - PostgreSQL returns EmptyQueryResponse for these
+	trimmedQuery := strings.TrimSpace(p.stmt.query)
+	if trimmedQuery == "" || isEmptyQuery(trimmedQuery) {
+		writeEmptyQueryResponse(c.writer)
+		return
+	}
+
 	// Check if this is a PostgreSQL-specific SET command that should be ignored
 	// (determined by transpiler during Parse)
 	if p.stmt.isIgnoredSet {


### PR DESCRIPTION
## Summary

- Fix Hex schema refresh failing when connecting via JDBC
- Return proper `EmptyQueryResponse` ('I' message) for empty queries in extended query protocol
- The simple query path already handled this correctly; this adds the same handling to `handleExecute`

## Problem

The JDBC driver (used by Hex) sends empty queries through the Parse/Bind/Execute flow as part of connection initialization:

```
[duckgres] Prepared statement "":
[duckgres] Execute "" with 0 params:
[duckgres] Execute error: empty query
```

Per PostgreSQL protocol spec, empty queries should return `EmptyQueryResponse` (type 'I'), not an error. The error response caused Hex to interpret the schema refresh as failed, even though subsequent queries succeeded.

## Test plan

- [x] Existing `TestIsEmptyQuery` tests pass
- [x] Build succeeds
- [ ] Manual test with Hex connection to verify schema refresh now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)