### PR TITLE
Add pg_type wrapper view to fix NULL values for JDBC compatibility

### DIFF
--- a/transpiler/transform/pgcatalog.go
+++ b/transpiler/transform/pgcatalog.go
@@ -49,6 +49,7 @@ func NewPgCatalogTransformWithConfig(duckLakeMode bool) *PgCatalogTransform {
 			"pg_stat_user_tables":   "pg_stat_user_tables",
 			"pg_stat_statements":    "pg_stat_statements",
 			"pg_partitioned_table":  "pg_partitioned_table",
+			"pg_type":               "pg_type",
 			"pg_attribute":          "pg_attribute",
 		},
 		Functions: map[string]bool{


### PR DESCRIPTION
## Summary
- Adds pg_type wrapper view with COALESCE to fix NULL values that break JDBC clients
- Fixes Hex sync failures after PR #90 was deployed

## Problem
After deploying PR #90 (comprehensive pg_attribute type mappings), Hex sync started failing. The root cause:

1. PR #90 fixed pg_attribute to return correct PostgreSQL type OIDs
2. This made the `JOIN pg_type ON atttypid = oid` succeed (previously it failed, returning 0 rows)
3. But DuckDB's pg_type has NULL for several columns (typtypmod, typbasetype, typndims, typnotnull)
4. JDBC clients expect integers, not NULL, causing failures

## Solution
Create a pg_type wrapper view that provides proper defaults:
- `typlen` → COALESCE to -1 (variable length)
- `typnotnull` → COALESCE to false
- `typbasetype` → COALESCE to 0 (not a domain)
- `typtypmod` → COALESCE to -1 (no modifier)
- `typndims` → COALESCE to 0 (non-array)

## Test plan
- [ ] Deploy to duckling2
- [ ] Test Hex sync with existing tables (dagster_test, airflow_test)
- [ ] Test Hex sync with test_numeric table
- [ ] Verify typtypmod returns -1 instead of NULL

🤖 Generated with [Claude Code](https://claude.ai/code)