### PR TITLE
Remove pg_type from ViewMappings to fix JDBC compatibility

### DIFF
--- a/transpiler/transform/pgcatalog.go
+++ b/transpiler/transform/pgcatalog.go
@@ -49,7 +49,6 @@ func NewPgCatalogTransformWithConfig(duckLakeMode bool) *PgCatalogTransform {
 			"pg_stat_user_tables":   "pg_stat_user_tables",
 			"pg_stat_statements":    "pg_stat_statements",
 			"pg_partitioned_table":  "pg_partitioned_table",
-			"pg_type":               "pg_type",
 			"pg_attribute":          "pg_attribute",
 		},
 		Functions: map[string]bool{


### PR DESCRIPTION
## Summary
Remove pg_type from ViewMappings so queries hit DuckDB's built-in pg_type.

## Problem
Hex sync broke after PR #90 and #91. The working commit (6ddcad6) did NOT have pg_type in ViewMappings.

Adding pg_type to ViewMappings causes `pg_catalog.pg_type` to be rewritten to `memory.main.pg_type` in DuckLake mode. Something about this rewriting is breaking JDBC.

## Solution
Remove pg_type from ViewMappings. The pg_type wrapper view remains for explicit access, but JDBC queries like:
```sql
JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid)
```
Will hit DuckDB's built-in pg_type directly.

## Test plan
- [ ] Deploy to duckling2
- [ ] Test Hex sync

🤖 Generated with [Claude Code](https://claude.ai/code)