### PR TITLE
Fix wire protocol OID types for pg_catalog columns

### DIFF
--- a/server/types.go
+++ b/server/types.go
@@ -58,7 +58,7 @@ func mapDuckDBType(typeName string) TypeInfo {
 	case upper == "UTINYINT" || upper == "USMALLINT":
 		return TypeInfo{OID: OidInt4, Size: 4}
 	case upper == "UINTEGER":
-		return TypeInfo{OID: OidInt8, Size: 8}
+		return TypeInfo{OID: OidOid, Size: 4} // PostgreSQL oid type for pg_catalog columns
 	case upper == "UBIGINT":
 		return TypeInfo{OID: OidNumeric, Size: -1}
 	case upper == "REAL" || upper == "FLOAT4" || upper == "FLOAT":

--- a/server/types_test.go
+++ b/server/types_test.go
@@ -35,7 +35,7 @@ func TestMapDuckDBType(t *testing.T) {
 		// Unsigned integers
 		{"UTINYINT", "UTINYINT", OidInt4, 4},
 		{"USMALLINT", "USMALLINT", OidInt4, 4},
-		{"UINTEGER", "UINTEGER", OidInt8, 8},
+		{"UINTEGER", "UINTEGER", OidOid, 4}, // Maps to PostgreSQL oid type for pg_catalog columns
 		{"UBIGINT", "UBIGINT", OidNumeric, -1},
 
 		// Float types


### PR DESCRIPTION
## Summary
- Cast oid-type columns (`atttypid`, `attrelid`, `attcollation`, `oid`, `typnamespace`, `typowner`, `typrelid`, `typelem`, `typarray`, `typbasetype`, `typcollation`) to UINTEGER in pg_type and pg_attribute views
- Map UINTEGER to PostgreSQL OID 26 (oid type) in wire protocol
- Cast `attnum` and `attndims` to SMALLINT for correct type compatibility

This ensures JDBC clients (like Hex) receive the correct wire protocol type OIDs for oid columns, which should fix metadata introspection issues.

## Test plan
- [x] Verified all 3 Hex JDBC queries execute successfully on local duckgres with DuckLake
- [x] Compared query results with Digital Ocean PostgreSQL - data values match
- [x] Verified atttypid column now uses UINTEGER which maps to OID 26 in wire protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)