### PR TITLE
Fix current_database() column name in wire protocol

### DIFF
--- a/transpiler/transform/funcalias.go
+++ b/transpiler/transform/funcalias.go
@@ -1,0 +1,103 @@
+package transform
+
+import (
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// FuncAliasTransform adds column aliases to function calls that PostgreSQL
+// would normally display without parentheses. For example, "SELECT current_database()"
+// returns column name "current_database" in PostgreSQL, not "current_database()".
+type FuncAliasTransform struct{}
+
+func NewFuncAliasTransform() *FuncAliasTransform {
+	return &FuncAliasTransform{}
+}
+
+func (t *FuncAliasTransform) Name() string {
+	return "funcalias"
+}
+
+// Functions that should have their parentheses stripped from column names
+var funcAliasMapping = map[string]string{
+	"current_database": "current_database",
+	"current_schema":   "current_schema",
+	"current_user":     "current_user",
+	"session_user":     "session_user",
+	"current_catalog":  "current_catalog",
+}
+
+func (t *FuncAliasTransform) Transform(tree *pg_query.ParseResult, result *Result) (bool, error) {
+	changed := false
+
+	for _, stmt := range tree.Stmts {
+		if stmt.Stmt == nil {
+			continue
+		}
+
+		if selectStmt := stmt.Stmt.GetSelectStmt(); selectStmt != nil {
+			if t.transformSelectTargets(selectStmt) {
+				changed = true
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+func (t *FuncAliasTransform) transformSelectTargets(stmt *pg_query.SelectStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := false
+
+	for _, target := range stmt.TargetList {
+		if resTarget := target.GetResTarget(); resTarget != nil {
+			// Only add alias if one isn't already set
+			if resTarget.Name == "" {
+				if funcCall := resTarget.Val.GetFuncCall(); funcCall != nil {
+					if alias := t.getFuncAlias(funcCall); alias != "" {
+						resTarget.Name = alias
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	// Recurse into subqueries (UNION, etc.)
+	if stmt.Larg != nil {
+		if t.transformSelectTargets(stmt.Larg) {
+			changed = true
+		}
+	}
+	if stmt.Rarg != nil {
+		if t.transformSelectTargets(stmt.Rarg) {
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func (t *FuncAliasTransform) getFuncAlias(fc *pg_query.FuncCall) string {
+	if fc == nil || len(fc.Funcname) == 0 {
+		return ""
+	}
+
+	// Get the function name (last element)
+	var funcName string
+	for _, name := range fc.Funcname {
+		if str := name.GetString_(); str != nil {
+			funcName = strings.ToLower(str.Sval)
+		}
+	}
+
+	if alias, ok := funcAliasMapping[funcName]; ok {
+		return alias
+	}
+
+	return ""
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -44,19 +44,22 @@ func New(cfg Config) *Transpiler {
 	// 5. Function mappings (array_agg->list, string_to_array->string_split, etc.)
 	t.transforms = append(t.transforms, transform.NewFunctionTransform())
 
-	// 6. Operator mappings (regex operators, etc.)
+	// 6. Function alias normalization (current_database() -> AS current_database)
+	t.transforms = append(t.transforms, transform.NewFuncAliasTransform())
+
+	// 7. Operator mappings (regex operators, etc.)
 	t.transforms = append(t.transforms, transform.NewOperatorTransform())
 
-	// 7. version() replacement
+	// 8. version() replacement
 	t.transforms = append(t.transforms, transform.NewVersionTransform())
 
-	// 8. SET/SHOW command handling
+	// 9. SET/SHOW command handling
 	t.transforms = append(t.transforms, transform.NewSetShowTransform())
 
-	// 9. _pg_expandarray handling (PostgreSQL array expansion function used by JDBC)
+	// 10. _pg_expandarray handling (PostgreSQL array expansion function used by JDBC)
 	t.transforms = append(t.transforms, transform.NewExpandArrayTransform())
 
-	// 10. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
+	// 11. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
 	t.transforms = append(t.transforms, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode))
 
 	// DDL transforms only when DuckLake mode is enabled


### PR DESCRIPTION
## Summary
PostgreSQL returns `current_database` as the column name for `SELECT current_database()`, not `current_database()` with parentheses. JDBC clients may depend on the exact column name for metadata introspection.

## Changes
Adds `FuncAliasTransform` that automatically adds AS aliases to function calls that should display without parentheses:
- `SELECT current_database()` → `SELECT current_database() AS current_database`
- `SELECT current_schema()` → `SELECT current_schema() AS current_schema`

Functions with explicit aliases are unchanged:
- `SELECT current_database() AS db` → unchanged

## Test
```sql
-- Before
SELECT current_database();
 current_database() 
--------------------
 ducklake

-- After  
SELECT current_database();
 current_database 
------------------
 ducklake
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)