### PR TITLE
Extend column type mappings to match PostgreSQL wire protocol

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1464,6 +1464,10 @@ func (c *clientConn) mapTypeSizeWithColumnName(colName string, colType *sql.Colu
 			return 64 // name is 64 bytes
 		case OidChar:
 			return 1 // "char" is 1 byte
+		case OidText:
+			return -1 // text is variable length
+		case OidInt2:
+			return 2 // smallint is 2 bytes
 		}
 	}
 	return getTypeInfo(colType).Size

--- a/server/types.go
+++ b/server/types.go
@@ -51,13 +51,26 @@ var pgCatalogColumnOIDs = map[string]int32{
 	"usename":            OidName,
 	"current_database()": OidName,
 	"current_database":   OidName,
+	// JDBC metadata query aliases that should be NAME type
+	"TABLE_SCHEM":   OidName,
+	"TABLE_CATALOG": OidName,
+	"table_schem":   OidName,
+	"table_name":    OidName,
 	// "char" type columns (OID 18) - single-byte internal type
-	"typtype":      OidChar,
-	"typcategory":  OidChar,
-	"typalign":     OidChar,
-	"typstorage":   OidChar,
-	"relkind":      OidChar,
+	"typtype":       OidChar,
+	"typcategory":   OidChar,
+	"typalign":      OidChar,
+	"typstorage":    OidChar,
+	"relkind":       OidChar,
 	"relpersistence": OidChar,
+	"attidentity":   OidChar,
+	"attgenerated":  OidChar,
+	// text type columns (OID 25)
+	"table_type":  OidText,
+	"adsrc":       OidText,
+	"description": OidText,
+	// smallint columns (OID 21)
+	"attlen": OidInt2,
 }
 
 // TypeInfo contains PostgreSQL type information


### PR DESCRIPTION
## Summary
Extends the column name -> OID mappings so that JDBC metadata queries return identical column types to PostgreSQL.

## Changes
Added mappings in `pgCatalogColumnOIDs`:
- `TABLE_SCHEM`, `TABLE_CATALOG`, `table_schem`, `table_name` → NAME (OID 19)
- `table_type`, `adsrc`, `description` → TEXT (OID 25)
- `attidentity`, `attgenerated` → CHAR (OID 18)
- `attlen` → INT2 (OID 21)

Updated `mapTypeSizeWithColumnName` to return correct sizes for TEXT (-1) and INT2 (2).

## Verification
All 3 Hex JDBC metadata queries now return identical column types to PostgreSQL:

| Query | Column Types |
|-------|--------------|
| Query 1: Schemas | `TABLE_SCHEM(NAME), TABLE_CATALOG(NAME)` ✓ |
| Query 2: Tables | `table_schem(NAME), table_name(NAME), table_type(TEXT)` ✓ |
| Query 3: Columns | All 15 columns match ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)