### PR TITLE
Preserve CASCADE on DROP SCHEMA in DuckLake mode

### DIFF
--- a/transpiler/transform/ddl.go
+++ b/transpiler/transform/ddl.go
@@ -53,9 +53,14 @@ func (t *DDLTransform) Transform(tree *pg_query.ParseResult, result *Result) (bo
 				// DuckLake doesn't support CASCADE on DROP TABLE/VIEW.
 				// Strip CASCADE by converting to RESTRICT (same approach as dbt-duckdb).
 				// See: https://github.com/duckdb/dbt-duckdb/pull/557
+				// Note: DROP SCHEMA CASCADE is supported by DuckDB natively, so preserve it.
 				if n.DropStmt.Behavior == pg_query.DropBehavior_DROP_CASCADE {
-					n.DropStmt.Behavior = pg_query.DropBehavior_DROP_RESTRICT
-					changed = true
+					if n.DropStmt.RemoveType == pg_query.ObjectType_OBJECT_TABLE ||
+						n.DropStmt.RemoveType == pg_query.ObjectType_OBJECT_VIEW ||
+						n.DropStmt.RemoveType == pg_query.ObjectType_OBJECT_MATVIEW {
+						n.DropStmt.Behavior = pg_query.DropBehavior_DROP_RESTRICT
+						changed = true
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Fixes an issue where `DROP SCHEMA ... CASCADE` was incorrectly being transpiled to `DROP SCHEMA ...` (without CASCADE)
- The DDL transform was stripping CASCADE from all DROP statements, but DROP SCHEMA CASCADE is natively supported by DuckDB
- Now only strips CASCADE for DROP TABLE/VIEW/MATVIEW (which DuckLake doesn't support)

## Problem
Fivetran and other tools use `DROP SCHEMA IF EXISTS ... CASCADE` to clean up schemas, but the transpiler was removing CASCADE, causing errors like:
```
Cannot drop schema "xyz" because there are entries that depend on it
```

## Test plan
- [x] Updated existing test to verify DROP SCHEMA CASCADE is preserved
- [x] Verified DROP TABLE/VIEW CASCADE is still stripped (DuckLake limitation)
- [x] Tested manually against local duckgres with DuckLake

🤖 Generated with [Claude Code](https://claude.com/claude-code)