### PR TITLE
Fix version() column name to return "version"

### DIFF
--- a/transpiler/transform/version.go
+++ b/transpiler/transform/version.go
@@ -203,13 +203,15 @@ func (t *VersionTransform) getFuncCall(node *pg_query.Node) *pg_query.FuncCall {
 	return nil
 }
 
-// isVersionCall checks if a FuncCall is version()
+// isVersionCall checks if a FuncCall is version() or pg_catalog.version()
 func (t *VersionTransform) isVersionCall(fc *pg_query.FuncCall) bool {
-	if fc == nil || len(fc.Funcname) != 1 || len(fc.Args) != 0 {
+	if fc == nil || len(fc.Funcname) == 0 || len(fc.Args) != 0 {
 		return false
 	}
-	if first := fc.Funcname[0]; first != nil {
-		if str := first.GetString_(); str != nil {
+	// Check the last part of the function name (handles both version() and pg_catalog.version())
+	last := fc.Funcname[len(fc.Funcname)-1]
+	if last != nil {
+		if str := last.GetString_(); str != nil {
 			return strings.EqualFold(str.Sval, "version")
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes `SELECT version()` returning column name `memory.main."version"()` instead of `version`
- The issue was transform ordering: PgCatalogTransform was adding `memory.main.` prefix before VersionTransform could replace the function call

## Changes
- Move VersionTransform to run before PgCatalogTransform
- Update `isVersionCall()` to handle both `version()` and `pg_catalog.version()`

## Before
```
postgres=> SELECT version();
                              memory.main."version"()                              
-----------------------------------------------------------------------------------
 PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)
```

## After
```
postgres=> SELECT version();
                                      version                                      
-----------------------------------------------------------------------------------
 PostgreSQL 15.0 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit (Duckgres/DuckDB)
```

## Test plan
- [x] `SELECT version()` returns column name `version`
- [x] `SELECT pg_catalog.version()` returns column name `version`
- [x] All transpiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)