### PR TITLE
Support quoted native_duckdb in SET/SHOW commands

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -170,18 +170,16 @@ func (c *clientConn) isNativeDuckDBCommand(query string) (isSet bool, isShow boo
 		return false, false, false
 	}
 
-	// Parse the value
-	// Remove SET native_duckdb and any surrounding whitespace
-	rest := strings.TrimSpace(query[len("SET native_duckdb"):])
-	rest = strings.TrimSuffix(rest, ";")
+	// Parse the value by finding = or TO in the original query.
+	// We can't use a fixed offset because the identifier may be quoted.
+	rest := strings.TrimSuffix(query, ";")
+	upperRest := strings.ToUpper(rest)
 
-	// Must have = or TO
-	if strings.HasPrefix(strings.ToUpper(rest), "=") {
-		rest = strings.TrimSpace(rest[1:])
-	} else if strings.HasPrefix(strings.ToUpper(rest), " TO ") {
-		rest = strings.TrimSpace(rest[4:])
-	} else if strings.HasPrefix(strings.ToUpper(rest), "TO ") {
-		rest = strings.TrimSpace(rest[3:])
+	// Find the value after = or TO
+	if idx := strings.Index(upperRest, "="); idx != -1 {
+		rest = strings.TrimSpace(rest[idx+1:])
+	} else if idx := strings.Index(upperRest, " TO "); idx != -1 {
+		rest = strings.TrimSpace(rest[idx+4:])
 	} else {
 		return false, false, false
 	}

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1458,6 +1458,43 @@ func TestIsNativeDuckDBCommand(t *testing.T) {
 			expectValue:  false,
 		},
 
+		// Quoted identifier
+		{
+			name:         `SET "native_duckdb" = on`,
+			query:        `SET "native_duckdb" = on`,
+			expectIsSet:  true,
+			expectIsShow: false,
+			expectValue:  true,
+		},
+		{
+			name:         `set "native_duckdb" to 1`,
+			query:        `set "native_duckdb" to 1`,
+			expectIsSet:  true,
+			expectIsShow: false,
+			expectValue:  true,
+		},
+		{
+			name:         `SET "native_duckdb" = off;`,
+			query:        `SET "native_duckdb" = off;`,
+			expectIsSet:  true,
+			expectIsShow: false,
+			expectValue:  false,
+		},
+		{
+			name:         `SHOW "native_duckdb"`,
+			query:        `SHOW "native_duckdb"`,
+			expectIsSet:  false,
+			expectIsShow: true,
+			expectValue:  false,
+		},
+		{
+			name:         `SHOW "native_duckdb";`,
+			query:        `SHOW "native_duckdb";`,
+			expectIsSet:  false,
+			expectIsShow: true,
+			expectValue:  false,
+		},
+
 		// With trailing semicolon
 		{
 			name:       "SET native_duckdb = on;",


### PR DESCRIPTION
## Summary
- Fixes parsing of `SET "native_duckdb" = value` and `SHOW "native_duckdb"` commands
- The previous implementation used a fixed offset which failed when the identifier was quoted
- Now finds the `=` or `TO` delimiter position instead

## Test plan
- [x] Added test cases for quoted identifier variants
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)