### PR TITLE
Fix pg_matviews not found by always qualifying pg_catalog views with memory.main

### DIFF
--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -47,15 +47,15 @@ func TestTranspile_PgCatalog(t *testing.T) {
 		excludes string
 	}{
 		{
-			name:     "pg_catalog.pg_class -> pg_class_full",
+			name:     "pg_catalog.pg_class -> memory.main.pg_class_full",
 			input:    "SELECT * FROM pg_catalog.pg_class",
-			contains: "pg_class_full",
+			contains: "memory.main.pg_class_full",
 			excludes: "pg_catalog",
 		},
 		{
-			name:     "pg_catalog.pg_database -> pg_database",
+			name:     "pg_catalog.pg_database -> memory.main.pg_database",
 			input:    "SELECT * FROM pg_catalog.pg_database",
-			contains: "pg_database",
+			contains: "memory.main.pg_database",
 			excludes: "pg_catalog",
 		},
 		{


### PR DESCRIPTION
## Summary
- **Fix**: Always qualify pg_catalog views with `memory.main`, matching the existing behavior for `information_schema` views
- Adds test cases to verify pg_catalog views (including `pg_matviews`) are correctly transformed

## Problem

When using DuckLake (either configured via `metadata_store` or attached manually), queries to pg_catalog views like `pg_matviews` would fail with:

```
Catalog Error: Table with name pg_matviews does not exist!
Did you mean "__ducklake_metadata_ducklake.pg_catalog.pg_matviews or memory.pg_matviews"?
```

## Root Cause

The pg_catalog transform only qualified views with `memory.main.` in DuckLakeMode. But information_schema views were **always** qualified with `memory.main.` regardless of mode. This inconsistency meant:

- If `metadata_store` config was set -> DuckLakeMode = true -> views qualified -> works
- If DuckLake attached manually without config -> DuckLakeMode = false -> views not qualified -> fails

## Fix

Changed pg_catalog transform to always use `memory.main.` qualification, matching the information_schema behavior. Now queries like:

```sql
SELECT * FROM pg_matviews
SELECT * FROM pg_catalog.pg_class
```

Are always transformed to:

```sql
SELECT * FROM memory.main.pg_matviews
SELECT * FROM memory.main.pg_class_full
```

## Test plan
- [x] All transpiler tests pass
- [x] All server tests pass
- [x] New `TestTranspile_PgCatalog_DuckLakeMode` test covers pg_matviews transformation
- [x] Updated existing `TestTranspile_PgCatalog` tests to verify `memory.main` qualification

🤖 Generated with [Claude Code](https://claude.com/claude-code)