### PR TITLE
Add data_path config option for local DuckLake storage

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type RateLimitFileConfig struct {
 type DuckLakeFileConfig struct {
 	MetadataStore string `yaml:"metadata_store"` // e.g., "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 	ObjectStore   string `yaml:"object_store"`   // e.g., "s3://bucket/path/" for S3/MinIO storage
+	DataPath      string `yaml:"data_path"`      // Local file path for data storage (alternative to object_store)
 
 	// S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
 	S3Provider string `yaml:"s3_provider"`
@@ -186,6 +187,9 @@ func main() {
 		}
 		if fileCfg.DuckLake.ObjectStore != "" {
 			cfg.DuckLake.ObjectStore = fileCfg.DuckLake.ObjectStore
+		}
+		if fileCfg.DuckLake.DataPath != "" {
+			cfg.DuckLake.DataPath = fileCfg.DuckLake.DataPath
 		}
 		if fileCfg.DuckLake.S3Provider != "" {
 			cfg.DuckLake.S3Provider = fileCfg.DuckLake.S3Provider


### PR DESCRIPTION
## Summary

- Adds a `data_path` configuration option for local filesystem storage of DuckLake data files
- Enables DuckLake usage without requiring S3/MinIO infrastructure
- Useful for local development, testing, and simple deployments

## Use Case

When integrating with tools like SQLMesh, users may want to test DuckLake functionality without setting up S3/MinIO. This change allows using a local directory for data storage while still using SQLite or PostgreSQL for metadata.

## Example Configuration

```yaml
ducklake:
  metadata_store: "sqlite:./data/ducklake_meta.db"
  data_path: "./data/ducklake_data/"
```

## Behavior

- When `object_store` is set, it takes precedence (existing behavior)
- When only `data_path` is set, it's used for the DuckLake `DATA_PATH` parameter
- When neither is set, DuckLake will fail to create new instances (existing behavior)

## Test plan

- [x] Tested with SQLMesh integration using local DuckLake storage
- [x] Verified seed, incremental, and full models work correctly
- [x] Confirmed existing S3/MinIO path still works when `object_store` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)