### PR TITLE
Add LockingTransform to strip FOR UPDATE/SHARE clauses

### DIFF
--- a/transpiler/transform/locking.go
+++ b/transpiler/transform/locking.go
@@ -1,0 +1,39 @@
+package transform
+
+import (
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// LockingTransform strips SELECT locking clauses (FOR UPDATE, FOR SHARE, etc.)
+// that DuckDB doesn't support.
+type LockingTransform struct{}
+
+// NewLockingTransform creates a new LockingTransform.
+func NewLockingTransform() *LockingTransform {
+	return &LockingTransform{}
+}
+
+func (t *LockingTransform) Name() string {
+	return "locking"
+}
+
+func (t *LockingTransform) Transform(tree *pg_query.ParseResult, result *Result) (bool, error) {
+	changed := false
+
+	for _, stmt := range tree.Stmts {
+		if stmt.Stmt == nil {
+			continue
+		}
+
+		switch n := stmt.Stmt.Node.(type) {
+		case *pg_query.Node_SelectStmt:
+			if n.SelectStmt != nil && len(n.SelectStmt.LockingClause) > 0 {
+				// Strip the locking clause
+				n.SelectStmt.LockingClause = nil
+				changed = true
+			}
+		}
+	}
+
+	return changed, nil
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -63,6 +63,9 @@ func New(cfg Config) *Transpiler {
 	// 11. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
 	t.transforms = append(t.transforms, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode))
 
+	// 12. Locking clause removal (FOR UPDATE, FOR SHARE, etc.) - DuckDB doesn't support these
+	t.transforms = append(t.transforms, transform.NewLockingTransform())
+
 	// DDL transforms only when DuckLake mode is enabled
 	if cfg.DuckLakeMode {
 		t.transforms = append(t.transforms, transform.NewDDLTransform())


### PR DESCRIPTION
## Summary

- Adds a new `LockingTransform` that strips SELECT locking clauses (`FOR UPDATE`, `FOR SHARE`, `FOR NO KEY UPDATE`, `FOR KEY SHARE`)
- DuckDB does not support row-level locking, so these clauses cause syntax errors

## Problem

When using PostgreSQL-compatible tools like SQLMesh, queries may include `FOR UPDATE` clauses for row-level locking during migrations:

```sql
SELECT name, identifier, snapshot FROM sqlmesh._snapshots WHERE FALSE FOR UPDATE
```

This causes DuckDB to error with:
```
Parser Error: SELECT locking clause is not supported!
```

## Solution

The `LockingTransform` removes the `LockingClause` from `SelectStmt` nodes before the query is executed. This allows compatibility with tools that use locking without breaking DuckDB.

## Implementation

- New file: `transpiler/transform/locking.go`
- Transform is always enabled (not just DuckLake mode) since DuckDB never supports locking clauses
- Added to transform pipeline after `OnConflictTransform`

## Test plan

- [x] Tested with SQLMesh migration that uses `FOR UPDATE`
- [x] Verified queries execute successfully after stripping locking clause
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)