### PR TITLE
Add query cancellation support

### DIFF
--- a/server/protocol.go
+++ b/server/protocol.go
@@ -74,7 +74,17 @@ func readStartupMessage(r io.Reader) (map[string]string, error) {
 	}
 
 	// Check for cancel request (80877102)
+	// Format: 4 bytes length, 4 bytes request code, 4 bytes pid, 4 bytes secret key
 	if protocolVersion == 80877102 {
+		if len(remaining) >= 12 {
+			cancelPid := binary.BigEndian.Uint32(remaining[4:8])
+			cancelSecretKey := binary.BigEndian.Uint32(remaining[8:12])
+			return map[string]string{
+				"__cancel_request":    "true",
+				"__cancel_pid":        fmt.Sprintf("%d", cancelPid),
+				"__cancel_secret_key": fmt.Sprintf("%d", cancelSecretKey),
+			}, nil
+		}
 		return map[string]string{"__cancel_request": "true"}, nil
 	}
 


### PR DESCRIPTION
## Summary
- Implements PostgreSQL query cancellation via cancel request messages (80877102)
- Tracks active queries by backend key (pid + secretKey) with context.CancelFunc
- Cancels queries when matching cancel request received
- Returns SQLSTATE 57014 (query_canceled) on cancellation

## Changes
- Add `activeQueries` map and mutex to Server struct for tracking
- Add `RegisterQuery()`, `UnregisterQuery()`, `CancelQuery()` methods
- Generate cryptographic secret key per connection
- Parse cancel request pid/secretKey from protocol message
- Add `duckgres_query_cancellations_total` Prometheus metric

## Test plan
- [ ] Connect with psql, run long query, press Ctrl+C - query should cancel
- [ ] Verify metric increments on cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)