### PR TITLE
Add statement timeout support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 *.test
 *.out
 coverage.html
+
+# Local planning docs
+PLAN.md

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,11 @@ var rateLimitedIPsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of currently rate-limited IP addresses",
 })
 
+var queryTimeoutsCounter = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_query_timeouts_total",
+	Help: "Total number of queries that timed out",
+})
+
 func redactConnectionString(connStr string) string {
 	return passwordPattern.ReplaceAllString(connStr, "${1}[REDACTED]")
 }
@@ -81,6 +86,11 @@ type Config struct {
 	// This prevents accumulation of zombie connections from clients that disconnect
 	// uncleanly. Default: 10 minutes. Set to 0 to disable.
 	IdleTimeout time.Duration
+
+	// QueryTimeout is the maximum time a query can run before being cancelled.
+	// This prevents runaway queries from blocking connections forever.
+	// Default: 0 (no timeout). Common values: 30s, 1m, 5m.
+	QueryTimeout time.Duration
 }
 
 // DuckLakeConfig configures DuckLake catalog attachment


### PR DESCRIPTION
## Summary
- Adds configurable query timeout to prevent runaway queries
- Queries exceeding timeout are cancelled with SQLSTATE 57014

## Changes
- Add `QueryTimeout` to Config struct (default: 0 = disabled)
- Add `query_timeout` YAML config and `DUCKGRES_QUERY_TIMEOUT` env var
- Create `queryContext()` helper that wraps queries with timeout
- Update all `db.Query`/`db.Exec` calls to use context
- Add `duckgres_query_timeouts_total` Prometheus metric

## Configuration
```yaml
query_timeout: "30s"  # or via DUCKGRES_QUERY_TIMEOUT=30s
```

## Test plan
- [ ] Set short timeout, run slow query - should timeout with error
- [ ] Verify metric increments on timeout
- [ ] Verify queries complete normally when under timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)