### PR TITLE
Add MD5 authentication support

### DIFF
--- a/server/protocol.go
+++ b/server/protocol.go
@@ -176,6 +176,14 @@ func writeAuthCleartextPassword(w io.Writer) error {
 	return writeMessage(w, msgAuth, data)
 }
 
+// writeAuthMD5Password requests MD5-hashed password with a 4-byte salt
+func writeAuthMD5Password(w io.Writer, salt [4]byte) error {
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint32(data, authMD5Pwd)
+	copy(data[4:], salt[:])
+	return writeMessage(w, msgAuth, data)
+}
+
 // writeParameterStatus sends a parameter status message
 func writeParameterStatus(w io.Writer, name, value string) error {
 	data := []byte(name)

--- a/server/server.go
+++ b/server/server.go
@@ -55,11 +55,25 @@ func redactConnectionString(connStr string) string {
 	return passwordPattern.ReplaceAllString(connStr, "${1}[REDACTED]")
 }
 
+// AuthMethod represents the authentication method to use
+type AuthMethod string
+
+const (
+	// AuthCleartext uses cleartext password (default, protected by TLS)
+	AuthCleartext AuthMethod = "cleartext"
+	// AuthMD5 uses MD5 hashed password (PostgreSQL standard)
+	AuthMD5 AuthMethod = "md5"
+)
+
 type Config struct {
 	Host    string
 	Port    int
 	DataDir string
 	Users   map[string]string // username -> password
+
+	// AuthMethod specifies the authentication method.
+	// Supported values: "cleartext" (default), "md5".
+	AuthMethod AuthMethod
 
 	// TLS configuration (required)
 	TLSCertFile string // Path to TLS certificate file


### PR DESCRIPTION
## Summary
- Implements PostgreSQL MD5 password authentication
- Alternative to cleartext auth (both protected by TLS)

## Changes
- Add `AuthMethod` config type with "cleartext" (default) and "md5" options
- Add `writeAuthMD5Password()` to send 4-byte random salt
- Add `verifyMD5Password()` to validate MD5 hash response
- Add `auth_method` YAML config and `DUCKGRES_AUTH_METHOD` env var

## MD5 Auth Flow
1. Server generates random 4-byte salt
2. Server sends AuthenticationMD5Password message with salt
3. Client computes: `"md5" + md5(md5(password + username) + salt)`
4. Server verifies the hash matches

## Configuration
```yaml
auth_method: "md5"  # or via DUCKGRES_AUTH_METHOD=md5
```

## Test plan
- [ ] Set auth_method to md5, connect with psql - should authenticate
- [ ] Verify wrong password fails authentication
- [ ] Verify cleartext still works as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)