### PR TITLE
Make idle timeout configurable and increase default to 24 hours

### DIFF
--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -64,7 +64,7 @@ ducklake:
 
 # Connection idle timeout (optional)
 # Connections with no activity for this duration will be closed.
-# Default: 24h (24 hours). Set to "0" to disable.
+# Default: 24h (24 hours). Set to "-1" to disable.
 # idle_timeout: "24h"
 
 # Rate limiting configuration (optional - these are the defaults)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ type FileConfig struct {
 	Extensions       []string            `yaml:"extensions"`
 	DuckLake         DuckLakeFileConfig  `yaml:"ducklake"`
 	ProcessIsolation bool                `yaml:"process_isolation"` // Enable process isolation per connection
-	IdleTimeout      string              `yaml:"idle_timeout"`      // e.g., "10m", "1h", "0" to disable
+	IdleTimeout      string              `yaml:"idle_timeout"`      // e.g., "24h", "1h", "-1" to disable
 }
 
 type TLSConfig struct {
@@ -113,7 +113,7 @@ func main() {
 	certFile := flag.String("cert", "", "TLS certificate file (env: DUCKGRES_CERT)")
 	keyFile := flag.String("key", "", "TLS private key file (env: DUCKGRES_KEY)")
 	processIsolation := flag.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
-	idleTimeout := flag.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '0' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
+	idleTimeout := flag.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
 	showHelp := flag.Bool("help", false, "Show help message")
 
 	flag.Usage = func() {
@@ -129,7 +129,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_CERT               TLS certificate file (default: ./certs/server.crt)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_KEY                TLS private key file (default: ./certs/server.key)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_ISOLATION  Enable process isolation (1 or true)\n")
-		fmt.Fprintf(os.Stderr, "  DUCKGRES_IDLE_TIMEOUT       Connection idle timeout (e.g., 30m, 1h, 0 to disable)\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_IDLE_TIMEOUT       Connection idle timeout (e.g., 30m, 1h, -1 to disable)\n")
 		fmt.Fprintf(os.Stderr, "\nPrecedence: CLI flags > environment variables > config file > defaults\n")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ type Config struct {
 
 	// IdleTimeout is the maximum time a connection can be idle before being closed.
 	// This prevents accumulation of zombie connections from clients that disconnect
-	// uncleanly. Default: 24 hours. Set to 0 to disable.
+	// uncleanly. Default: 24 hours. Set to a negative value (e.g., -1) to disable.
 	IdleTimeout time.Duration
 
 	// ProcessIsolation enables spawning each client connection in a separate OS process.
@@ -187,8 +187,11 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	// Use default idle timeout if not specified (24 hours)
+	// Negative value means explicitly disabled (set to 0)
 	if cfg.IdleTimeout == 0 {
 		cfg.IdleTimeout = 24 * time.Hour
+	} else if cfg.IdleTimeout < 0 {
+		cfg.IdleTimeout = 0
 	}
 
 	s := &Server{


### PR DESCRIPTION
## Summary

- Increases the default idle timeout from 10 minutes to 24 hours
- Adds `idle_timeout` configuration via YAML config file
- Adds `DUCKGRES_IDLE_TIMEOUT` environment variable
- Adds `--idle-timeout` CLI flag
- Adds startup log message showing the configured timeout
- Use `"-1"` (negative duration) to disable the idle timeout entirely

Fixes customer reports of connections being dropped after 10 minutes of inactivity.

## Test plan

- [ ] Verify server starts with default 24h timeout (check startup logs)
- [ ] Test `--idle-timeout=1m` CLI flag works
- [ ] Test `DUCKGRES_IDLE_TIMEOUT=1m` env var works
- [ ] Test `idle_timeout: "1m"` in YAML config works
- [ ] Test `--idle-timeout=-1` disables timeout (logs show "Idle timeout disabled")

🤖 Generated with [Claude Code](https://claude.com/claude-code)