### PR TITLE
Disable strict mode for COPY FROM STDIN CSV parsing

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1430,7 +1430,8 @@ func ParseCopyToOptions(query string) (*CopyToOptions, error) {
 // BuildDuckDBCopyFromSQL generates a DuckDB COPY FROM statement
 func BuildDuckDBCopyFromSQL(tableName, columnList, filePath string, opts *CopyFromOptions) string {
 	// DuckDB syntax: COPY table FROM 'file' (FORMAT CSV, HEADER, NULL 'value', DELIMITER ',', QUOTE '"')
-	copyOptions := []string{"FORMAT CSV"}
+	// STRICT_MODE FALSE allows reading rows that don't strictly comply with CSV standard
+	copyOptions := []string{"FORMAT CSV", "STRICT_MODE FALSE"}
 	if opts.HasHeader {
 		copyOptions = append(copyOptions, "HEADER")
 	}

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1274,7 +1274,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				HasHeader:  false,
 				NullString: "\\N",
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, NULL '\\N', DELIMITER '\t')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL '\\N', DELIMITER '\t')",
 		},
 		{
 			name:       "CSV with header",
@@ -1287,7 +1287,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, HEADER, NULL '\\N', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', QUOTE '\"')",
 		},
 		{
 			name:       "with column list",
@@ -1300,7 +1300,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY users (id, name) FROM '/tmp/data.csv' (FORMAT CSV, NULL '\\N', QUOTE '\"')",
+			want: "COPY users (id, name) FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL '\\N', QUOTE '\"')",
 		},
 		{
 			name:       "custom NULL string",
@@ -1313,7 +1313,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "NA",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, NULL 'NA', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL 'NA', QUOTE '\"')",
 		},
 		{
 			name:       "empty NULL string",
@@ -1326,7 +1326,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, HEADER, NULL '', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '', QUOTE '\"')",
 		},
 		{
 			name:       "schema qualified table",
@@ -1339,7 +1339,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY public.users (id, name, email) FROM '/var/tmp/copy-123.csv' (FORMAT CSV, HEADER, NULL '\\N', DELIMITER '\t', QUOTE '\"')",
+			want: "COPY public.users (id, name, email) FROM '/var/tmp/copy-123.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', DELIMITER '\t', QUOTE '\"')",
 		},
 		{
 			name:       "CSV with custom escape character",
@@ -1353,7 +1353,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				Quote:      `"`,
 				Escape:     `\`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, HEADER, NULL '\\N', QUOTE '\"', ESCAPE '\\')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', QUOTE '\"', ESCAPE '\\')",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add `STRICT_MODE FALSE` to DuckDB COPY command for more lenient CSV parsing
- Improves compatibility with data sources like Fivetran that may have edge cases in CSV formatting

## Context
Fivetran reported errors like:
```
CSV Error on Line: 179522
Value with unterminated quote found.
```

With strict mode disabled, DuckDB will be more lenient with CSV parsing.

## Test plan
- [ ] Test COPY FROM STDIN with valid CSV data
- [ ] Test COPY FROM STDIN with edge case CSV data (doubled quotes, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)