### PR TITLE
Add AUTO_DETECT FALSE and explicit ESCAPE for COPY CSV parsing

### DIFF
--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1274,7 +1274,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				HasHeader:  false,
 				NullString: "\\N",
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL '\\N', DELIMITER '\t')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, NULL '\\N', DELIMITER '\t')",
 		},
 		{
 			name:       "CSV with header",
@@ -1287,7 +1287,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, HEADER, NULL '\\N', DELIMITER ',', QUOTE '\"', ESCAPE '\"')",
 		},
 		{
 			name:       "with column list",
@@ -1300,7 +1300,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY users (id, name) FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL '\\N', QUOTE '\"')",
+			want: "COPY users (id, name) FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, NULL '\\N', DELIMITER ',', QUOTE '\"', ESCAPE '\"')",
 		},
 		{
 			name:       "custom NULL string",
@@ -1313,7 +1313,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "NA",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, NULL 'NA', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, NULL 'NA', DELIMITER ',', QUOTE '\"', ESCAPE '\"')",
 		},
 		{
 			name:       "empty NULL string",
@@ -1326,7 +1326,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "",
 				Quote:      `"`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '', QUOTE '\"')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, HEADER, NULL '', DELIMITER ',', QUOTE '\"', ESCAPE '\"')",
 		},
 		{
 			name:       "schema qualified table",
@@ -1339,7 +1339,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				NullString: "\\N",
 				Quote:      `"`,
 			},
-			want: "COPY public.users (id, name, email) FROM '/var/tmp/copy-123.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', DELIMITER '\t', QUOTE '\"')",
+			want: "COPY public.users (id, name, email) FROM '/var/tmp/copy-123.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, HEADER, NULL '\\N', DELIMITER '\t', QUOTE '\"', ESCAPE '\"')",
 		},
 		{
 			name:       "CSV with custom escape character",
@@ -1353,7 +1353,7 @@ func TestBuildDuckDBCopyFromSQL(t *testing.T) {
 				Quote:      `"`,
 				Escape:     `\`,
 			},
-			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, STRICT_MODE FALSE, HEADER, NULL '\\N', QUOTE '\"', ESCAPE '\\')",
+			want: "COPY users  FROM '/tmp/data.csv' (FORMAT CSV, AUTO_DETECT FALSE, STRICT_MODE FALSE, HEADER, NULL '\\N', DELIMITER ',', QUOTE '\"', ESCAPE '\\')",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add `AUTO_DETECT FALSE` to disable DuckDB's sniffer which was overriding our settings
- Always set `DELIMITER` explicitly (required when AUTO_DETECT is off)
- Set `ESCAPE` to match `QUOTE` for RFC 4180 compliance (doubled quotes like `""`)

## Problem
Fivetran COPY operations were failing with errors like:
- `escape = (empty) (Auto-Detected)` - causing `""` to not be recognized as escaped quotes
- `strict_mode = true (Auto-Detected)` - overriding our `STRICT_MODE FALSE`
- `new_line = Single-Line File (Auto-Detected)` - sniffer misdetecting file format

## Solution
Disable auto-detection entirely and set all CSV options explicitly so DuckDB uses our settings.

## Test plan
- [x] Unit tests pass
- [ ] Test COPY FROM STDIN with Fivetran data containing doubled quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)