### PR TITLE
Add /ducklake-test skill for local DuckLake testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,61 +100,6 @@ PGPASSWORD=postgres psql "host=127.0.0.1 port=35437 user=postgres sslmode=requir
 \l           # List databases
 ```
 
-## Running with DuckLake
-
-To test duckgres with DuckLake (S3-backed storage with PostgreSQL metadata):
-
-### 1. Start dependencies (PostgreSQL + MinIO)
-```bash
-docker-compose up -d
-```
-
-This starts:
-- PostgreSQL on port 5433 (metadata store)
-- MinIO on port 9000 (S3-compatible object storage)
-- Creates `ducklake` bucket automatically
-
-### 2. Create local test config
-Create `duckgres_local_test.yaml`:
-```yaml
-host: "0.0.0.0"
-port: 35437
-data_dir: "./data"
-
-users:
-  postgres: "postgres"
-
-extensions:
-  - ducklake
-
-ducklake:
-  metadata_store: "postgres:host=localhost port=5433 user=ducklake password=ducklake dbname=ducklake"
-  object_store: "s3://ducklake/data/"
-  s3_provider: "config"
-  s3_endpoint: "localhost:9000"
-  s3_access_key: "minioadmin"
-  s3_secret_key: "minioadmin"
-  s3_region: "us-east-1"
-  s3_use_ssl: false
-  s3_url_style: "path"
-```
-
-### 3. Build and run
-```bash
-go build -o duckgres . && ./duckgres --config duckgres_local_test.yaml
-```
-
-### 4. Connect and test
-```bash
-PGPASSWORD=postgres psql "host=127.0.0.1 port=35437 user=postgres sslmode=require"
-```
-
-### Cleanup
-```bash
-pkill -f duckgres
-docker-compose down
-```
-
 ## Common Development Tasks
 
 ### Adding a new pg_catalog view


### PR DESCRIPTION
## Summary
- Add `/ducklake-test` Claude skill for running duckgres with DuckLake locally
- Provides step-by-step instructions for starting dependencies, building, and connecting

## Changes
- `.claude/skills/ducklake-test/SKILL.md`: New skill with DuckLake testing workflow

## Usage
Invoke with `/ducklake-test` in Claude Code to get instructions for:
1. Starting PostgreSQL (metadata) and MinIO (S3) via docker-compose
2. Creating the config file
3. Building and running duckgres
4. Connecting with psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)