### PR TITLE
Auto-load duckgres.yaml config file when present

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,7 +171,14 @@ func main() {
 		Extensions: []string{"ducklake"},
 	}
 
-	// Load config file if specified
+	// Auto-detect duckgres.yaml if no config file was explicitly specified
+	if *configFile == "" {
+		if _, err := os.Stat("duckgres.yaml"); err == nil {
+			*configFile = "duckgres.yaml"
+		}
+	}
+
+	// Load config file if specified (or auto-detected)
 	if *configFile != "" {
 		fileCfg, err := loadConfigFile(*configFile)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Automatically loads `duckgres.yaml` from the working directory if no config is explicitly specified
- Explicit `--config` flag or `DUCKGRES_CONFIG` env var still takes full precedence
- No behavior change when the file doesn't exist

## Test plan
- [x] Builds and lint passes
- [ ] Without `duckgres.yaml` present: defaults are used (no change)
- [ ] With `duckgres.yaml` present: config is auto-loaded
- [ ] With `--config other.yaml`: explicit config is used, `duckgres.yaml` is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)