### PR TITLE
Fix double EXPLAIN when validating DuckDB-specific queries

### DIFF
--- a/tests/integration/fallback_test.go
+++ b/tests/integration/fallback_test.go
@@ -83,6 +83,18 @@ func TestFallbackToNativeDuckDB(t *testing.T) {
 			Query:        "SELECT list_filter([1, 2, 3, 4, 5], x -> x > 2) AS filtered",
 			DuckgresOnly: true,
 		},
+		// EXPLAIN with DuckDB-specific FROM-first syntax (regression: was producing EXPLAIN EXPLAIN)
+		{
+			Name:         "explain_from_first",
+			Query:        "EXPLAIN FROM users SELECT name",
+			DuckgresOnly: true,
+		},
+		// EXPLAIN ANALYZE with DuckDB-specific syntax
+		{
+			Name:         "explain_analyze_from_first",
+			Query:        "EXPLAIN ANALYZE FROM users SELECT name",
+			DuckgresOnly: true,
+		},
 	}
 	runQueryTests(t, tests)
 }


### PR DESCRIPTION
## Summary
- When a query like `EXPLAIN FROM users SELECT name` failed PostgreSQL parsing, the fallback `validateWithDuckDB()` would prepend another `EXPLAIN`, producing `EXPLAIN EXPLAIN FROM ...` which DuckDB rejects
- Fix: skip EXPLAIN-based validation for queries that already start with EXPLAIN — they'll be passed straight through to DuckDB
- Added regression tests for `EXPLAIN` and `EXPLAIN ANALYZE` with DuckDB FROM-first syntax

## Test plan
- [ ] `EXPLAIN FROM users SELECT name` returns query plan instead of erroring
- [ ] `EXPLAIN ANALYZE FROM users SELECT name` works
- [ ] Normal EXPLAIN (e.g. `EXPLAIN SELECT 1`) still works (goes through PG parser, not fallback)
- [ ] Invalid syntax still errors (e.g. `EXPLAIN BLAHBLAH`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)