### PR TITLE
Support multiple posthog api keys for logging

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__acp__Bash",
+      "mcp__acp__Edit"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Run with config file:
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export | - |
 | `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
+| `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |
 | `DUCKGRES_IDENTIFIER` | Suffix appended to the OTel `service.name` in PostHog logs (e.g., `duckgres-acme`); only used when `POSTHOG_API_KEY` is set | - |
 
 ### PostHog Logging


### PR DESCRIPTION
Add ADDITIONAL_POSTHOG_API_KEYS environment variable to publish logs to
multiple PostHog projects. Refactor logging setup to create exporters for
each API key, with primary key required and additional keys best-effort.
Include validation to skip empty keys and warn on duplicates.
