### PR TITLE
Default process isolation on, add panic recovery and pgbouncer warning

### DIFF
--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -36,6 +36,9 @@ ducklake:
   # Examples:
   #   - "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
   #   - "postgres:host=ducklake.example.com user=ducklake password=secret dbname=ducklake"
+  # WARNING: Do not use pgbouncer (port 6432) for the metadata store connection.
+  # pgbouncer's connection lifecycle management can kill connections that DuckLake
+  # depends on, causing cascading failures. Connect directly to PostgreSQL instead.
   # metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
   # S3-compatible object storage for data files (optional)
@@ -61,6 +64,12 @@ ducklake:
   # s3_chain: "env;config"             # Which sources to check (env, config, sts, sso, instance, process)
   # s3_profile: "my-profile"           # AWS profile name (for config chain)
   # s3_region: "us-west-2"             # Override auto-detected region
+
+# Process isolation (default: true)
+# Each client connection spawns a separate OS process, so a DuckDB crash
+# (e.g., from a failed DuckLake metadata connection) only kills that session,
+# not the entire server. Set to false only for debugging or low-resource environments.
+process_isolation: true
 
 # Connection idle timeout (optional)
 # Connections with no activity for this duration will be closed.


### PR DESCRIPTION
## Summary

- **Default `--process-isolation` to `true`** — isolates DuckDB crashes to individual child processes, preventing cascading failures when DuckLake metadata connections die
- **Add panic recovery** in `handleConnectionInProcess()` — catches Go-level panics from the DuckDB CGO boundary so one connection's panic doesn't crash the server
- **Warn about pgbouncer for DuckLake metadata** — pgbouncer's connection lifecycle management (port 6432) can kill connections DuckLake depends on

## Context

A production DuckLake deployment experienced cascading connection failures: when the DuckLake metadata PostgreSQL connection (via pgbouncer) died, DuckDB's C++ code crashed fatally, killing the entire Duckgres process and all active connections.

## Test plan

- [ ] `go build -o duckgres .` compiles cleanly
- [ ] Default behavior spawns child processes (log shows "Process isolation enabled")
- [ ] `--process-isolation=false` disables isolation
- [ ] `DUCKGRES_PROCESS_ISOLATION=false` disables isolation
- [ ] YAML `process_isolation: false` disables isolation
- [ ] YAML without `process_isolation` key keeps default (true)
- [ ] DuckLake metadata store with port 6432 logs pgbouncer warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)