### PR TITLE
Skip public→main rewrite for fully qualified names

### DIFF
--- a/transpiler/transform/publicschema.go
+++ b/transpiler/transform/publicschema.go
@@ -31,8 +31,10 @@ func (t *PublicSchemaTransform) Transform(tree *pg_query.ParseResult, _ *Result)
 			return true
 		}
 
-		// Rewrite public → main regardless of whether a catalog is present.
-		if strings.EqualFold(rv.Schemaname, "public") {
+		// Only rewrite 2-part names like public.table → main.table.
+		// Fully qualified 3-part names (catalog.public.table) are left as-is
+		// for DuckDB to resolve against the named catalog.
+		if rv.Catalogname == "" && strings.EqualFold(rv.Schemaname, "public") {
 			rv.Schemaname = "main"
 			changed = true
 		}

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -303,14 +303,14 @@ func TestTranspile_PublicSchema(t *testing.T) {
 			excludes: "public.new_table",
 		},
 		{
-			name:     "3-part catalog.public.table -> catalog.main.table",
+			name:     "3-part catalog.public.table unchanged",
 			input:    "SELECT * FROM postgres.public.users",
-			expected: "SELECT * FROM postgres.main.users",
+			expected: "SELECT * FROM postgres.public.users",
 		},
 		{
-			name:     "3-part catalog.public.table in INSERT",
+			name:     "3-part catalog.public.table in INSERT unchanged",
 			input:    "INSERT INTO mydb.public.events (id) VALUES (1)",
-			expected: "INSERT INTO mydb.main.events (id) VALUES (1)",
+			expected: "INSERT INTO mydb.public.events (id) VALUES (1)",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Fully qualified 3-part names like `postgres.public.users` are now left untouched, letting DuckDB resolve them against the named catalog
- 2-part names like `public.users` still rewrite to `main.users` as before
- This is correct because the `public` schema may actually exist in an attached catalog (e.g. a Postgres-backed DuckLake catalog)

## Test plan
- [x] 2-part `public.table` still rewrites to `main.table`
- [x] 3-part `catalog.public.table` passes through unchanged
- [x] Full transpiler and server test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)