### PR TITLE
Mark releases as pre-release by default for canary gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           tag_name: build-${{ steps.sha.outputs.short }}
           name: Build ${{ steps.sha.outputs.short }}
+          prerelease: true
           body: |
             Automated build from commit ${{ github.sha }}
           files: |
@@ -96,15 +97,12 @@ jobs:
         with:
           tag_name: latest
           name: Latest Build
+          prerelease: true
           body: |
             Latest build from commit ${{ github.sha }}
 
-            For a stable URL, use:
-            ```
-            https://github.com/PostHog/duckgres/releases/latest/download/duckgres-linux-amd64
-            https://github.com/PostHog/duckgres/releases/latest/download/duckgres-linux-arm64
-            https://github.com/PostHog/duckgres/releases/latest/download/checksums.txt
-            ```
+            This is a **pre-release** (canary). It auto-deploys to the canary duckling.
+            To promote to customer ducklings: edit this release and uncheck "pre-release".
           files: |
             artifacts/duckgres-linux-amd64/duckgres-linux-amd64
             artifacts/duckgres-linux-arm64/duckgres-linux-arm64


### PR DESCRIPTION
## Summary
- Both `build-<sha>` and `latest` releases are now created as **pre-releases**
- Canary duckling auto-deploys on every pre-release (via infra PR [#6680](https://github.com/PostHog/posthog-cloud-infra/pull/6680))
- To promote to customer ducklings: edit the `latest` release in GitHub UI and uncheck "pre-release"

## How it works together with posthog-cloud-infra#6680

| Event | Canary (posthog duckling) | Customers (portola, etc.) |
|---|---|---|
| Push to main | Deploys (pre-release) | No deploy |
| Uncheck pre-release on `latest` | Already deployed | Deploys within 5 min |

## Companion PR
- https://github.com/PostHog/posthog-cloud-infra/pull/6680

🤖 Generated with [Claude Code](https://claude.com/claude-code)