### PR TITLE
Ignore SET ROLE to fix unrecognized parameter error

### DIFF
--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -56,6 +56,9 @@ func NewSetShowTransform() *SetShowTransform {
 			// Encoding (DuckDB is always UTF-8)
 			"client_encoding": true,
 
+			// Role settings
+			"role": true,
+
 			// PostgreSQL-specific features
 			"row_security":             true,
 			"check_function_bodies":    true,

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -677,6 +677,17 @@ func TestTranspile_SetShow(t *testing.T) {
 		}
 	})
 
+	// Test SET ROLE NONE is ignored
+	t.Run("SET ROLE NONE ignored", func(t *testing.T) {
+		result, err := tr.Transpile("SET ROLE NONE")
+		if err != nil {
+			t.Fatalf("Transpile error: %v", err)
+		}
+		if !result.IsIgnoredSet {
+			t.Error("SET ROLE NONE should be marked as ignored")
+		}
+	})
+
 	// Test various SET SESSION CHARACTERISTICS variations
 	t.Run("SET SESSION CHARACTERISTICS variations", func(t *testing.T) {
 		tests := []string{


### PR DESCRIPTION
## Summary
- Clients (e.g. Fivetran) send `SET ROLE NONE` after connecting, which DuckDB rejects with `unrecognized configuration parameter "role"`
- Add `"role"` to the transpiler's ignored params list so it's silently accepted, matching how we handle other PG-specific SET commands
- Add test case for `SET ROLE NONE`

## Test plan
- [x] New test `SET ROLE NONE ignored` passes
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)