### PR TITLE
Stop subdividing threads across sessions

### DIFF
--- a/controlplane/memory_rebalancer_test.go
+++ b/controlplane/memory_rebalancer_test.go
@@ -42,22 +42,10 @@ func TestPerSessionThreads(t *testing.T) {
 	r := NewMemoryRebalancer(24*1024*1024*1024, 8, &mockSessionLister{})
 	t.Cleanup(r.Stop)
 
-	tests := []struct {
-		sessions int
-		want     int
-	}{
-		{1, 8},
-		{2, 4},
-		{4, 2},
-		{8, 1},
-		{16, 1}, // floor
-	}
-
-	for _, tt := range tests {
-		got := r.PerSessionThreads(tt.sessions)
-		if got != tt.want {
-			t.Errorf("PerSessionThreads(%d) = %d, want %d", tt.sessions, got, tt.want)
-		}
+	// Threads are not subdivided — every session gets the full budget
+	got := r.PerSessionThreads()
+	if got != 8 {
+		t.Errorf("PerSessionThreads() = %d, want 8", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Each DuckDB session now gets the full thread budget instead of splitting threads across active sessions
- DuckDB's thread pool is cooperative — giving each session access to all cores lets it use available CPU when other sessions are idle, without harmful contention
- Removes `perSessionThreads()` helper and simplifies `PerSessionThreads()` to return the full budget directly

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./controlplane/ -count=1` passes
- [x] Updated `TestPerSessionThreads` to verify threads are no longer subdivided

🤖 Generated with [Claude Code](https://claude.com/claude-code)