### PR TITLE
Disable dynamic memory rebalancing by default, add --memory-rebalance flag

### DIFF
--- a/config_resolution.go
+++ b/config_resolution.go
@@ -20,6 +20,7 @@ type configCLIInputs struct {
 	MemoryLimit      string
 	Threads          int
 	MemoryBudget     string
+	MemoryRebalance  bool
 	MaxWorkers       int
 	MinWorkers       int
 }
@@ -152,6 +153,9 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		if fileCfg.MemoryBudget != "" {
 			cfg.MemoryBudget = fileCfg.MemoryBudget
 		}
+		if fileCfg.MemoryRebalance != nil {
+			cfg.MemoryRebalance = *fileCfg.MemoryRebalance
+		}
 		if fileCfg.MaxWorkers != 0 {
 			cfg.MaxWorkers = fileCfg.MaxWorkers
 		}
@@ -247,6 +251,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if v := getenv("DUCKGRES_MEMORY_BUDGET"); v != "" {
 		cfg.MemoryBudget = v
 	}
+	if v := getenv("DUCKGRES_MEMORY_REBALANCE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.MemoryRebalance = b
+		} else {
+			warn("Invalid DUCKGRES_MEMORY_REBALANCE: " + err.Error())
+		}
+	}
 	if v := getenv("DUCKGRES_MIN_WORKERS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			cfg.MinWorkers = n
@@ -295,6 +306,9 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	}
 	if cli.Set["memory-budget"] {
 		cfg.MemoryBudget = cli.MemoryBudget
+	}
+	if cli.Set["memory-rebalance"] {
+		cfg.MemoryRebalance = cli.MemoryRebalance
 	}
 	if cli.Set["min-workers"] {
 		cfg.MinWorkers = cli.MinWorkers

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type FileConfig struct {
 	MemoryLimit      string              `yaml:"memory_limit"`      // DuckDB memory_limit per session (e.g., "4GB")
 	Threads          int                 `yaml:"threads"`           // DuckDB threads per session
 	MemoryBudget     string              `yaml:"memory_budget"`     // Total memory for all sessions (e.g., "24GB")
+	MemoryRebalance  *bool               `yaml:"memory_rebalance"`  // Enable dynamic per-connection memory reallocation
 	MaxWorkers       int                 `yaml:"max_workers"`       // Max worker processes (control-plane mode)
 	MinWorkers       int                 `yaml:"min_workers"`       // Pre-warm worker count (control-plane mode)
 	PassthroughUsers []string            `yaml:"passthrough_users"` // Users that bypass transpiler + pg_catalog
@@ -128,6 +129,7 @@ func main() {
 	memoryLimit := flag.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
 	threads := flag.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
 	memoryBudget := flag.String("memory-budget", "", "Total memory for all DuckDB sessions (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
+	memoryRebalance := flag.Bool("memory-rebalance", false, "Enable dynamic per-connection memory reallocation (control-plane mode) (env: DUCKGRES_MEMORY_REBALANCE)")
 	repl := flag.Bool("repl", false, "Start an interactive SQL shell instead of the server")
 	psql := flag.Bool("psql", false, "Launch psql connected to the local Duckgres server")
 	showVersion := flag.Bool("version", false, "Show version and exit")
@@ -162,6 +164,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_LIMIT       DuckDB memory_limit per session (e.g., 4GB)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_THREADS            DuckDB threads per session\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_BUDGET      Total memory for all DuckDB sessions (e.g., 24GB)\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_REBALANCE   Enable dynamic per-connection memory reallocation (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MIN_WORKERS        Pre-warm worker count (control-plane mode)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MAX_WORKERS        Max worker processes (control-plane mode)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_DUCKDB_LISTEN      DuckDB service listen address (duckdb-service mode)\n")
@@ -236,6 +239,7 @@ func main() {
 		MemoryLimit:      *memoryLimit,
 		Threads:          *threads,
 		MemoryBudget:     *memoryBudget,
+		MemoryRebalance:  *memoryRebalance,
 		MinWorkers:       *minWorkers,
 		MaxWorkers:       *maxWorkers,
 	}, os.Getenv, func(msg string) {

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,12 @@ type Config struct {
 	// If empty, defaults to 75% of system RAM.
 	MemoryBudget string
 
+	// MemoryRebalance enables dynamic per-connection memory reallocation in control-plane mode.
+	// When enabled, the memory budget is redistributed across all active sessions on every
+	// connect/disconnect. When disabled (default), each session gets a static allocation
+	// of budget/max_workers at creation time.
+	MemoryRebalance bool
+
 	// MaxWorkers is the maximum number of worker processes in control-plane mode.
 	// 0 means unlimited.
 	MaxWorkers int


### PR DESCRIPTION
## Summary
- Disables dynamic per-connection memory reallocation by default in control-plane mode
- Each session now gets a static allocation (`budget/max_workers`) at creation time instead of redistributing memory across all sessions on every connect/disconnect
- Adds `--memory-rebalance` flag (+ `DUCKGRES_MEMORY_REBALANCE` env var + `memory_rebalance` YAML config) to opt back into the old behavior

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests for disabled rebalancer: `TestDisabledRebalancerRequestIsNoop`, `TestDisabledRebalancerStaticAllocation`
- [ ] Manual: verify control-plane mode starts with `memory_rebalance=false` logged
- [ ] Manual: verify `--memory-rebalance` re-enables dynamic behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)