### PR TITLE
Give every session the full memory budget (75% system RAM)

### DIFF
--- a/server/sysinfo.go
+++ b/server/sysinfo.go
@@ -53,8 +53,9 @@ var (
 )
 
 // autoMemoryLimit computes a DuckDB memory_limit based on system memory.
-// Formula: totalMem * 0.75 / 4, with a floor of 256MB.
-// The /4 accounts for typical concurrency (multiple sessions sharing RAM).
+// Formula: totalMem * 0.75, with a floor of 256MB.
+// Every session gets the full budget — DuckDB will spill to disk/swap if
+// aggregate usage exceeds physical RAM.
 // Returns "4GB" as a safe default if system memory cannot be detected.
 // The result is computed once and cached since system memory doesn't change.
 func autoMemoryLimit() string {
@@ -68,7 +69,7 @@ func autoMemoryLimit() string {
 		const mb = 1024 * 1024
 		const gb = 1024 * mb
 
-		limitBytes := totalBytes * 3 / 4 / 4 // 75% / 4 sessions
+		limitBytes := totalBytes * 3 / 4 // 75% of system RAM
 		if limitBytes < 256*mb {
 			limitBytes = 256 * mb
 		}


### PR DESCRIPTION
## Summary
- Every DuckDB session now gets the full memory budget (`totalRAM * 75%`) instead of dividing it across sessions/workers
- Previously, auto-derived `max_workers = budget / 256MB` combined with static allocation `budget / max_workers` always produced the 256MB floor — regardless of machine size or active session count
- On a 371GB machine, sessions were getting 256MB instead of ~278GB
- DuckDB will spill to disk/swap if aggregate usage exceeds physical RAM

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./server/ -count=1` passes
- [x] `go test ./controlplane/ -count=1` passes
- [ ] Deploy to staging and verify `PRAGMA memory_limit` shows full budget on a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)