### PR TITLE
Fix cache_httpfs cache directory path missing trailing slash

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -504,7 +504,7 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 		cacheDir := filepath.Join(cfg.DataDir, "cache")
 		if err := os.MkdirAll(cacheDir, 0750); err != nil {
 			slog.Warn("Failed to create cache_httpfs cache directory.", "cache_directory", cacheDir, "error", err)
-		} else if _, err := db.Exec(fmt.Sprintf("SET cache_httpfs_cache_directory = '%s'", cacheDir)); err != nil {
+		} else if _, err := db.Exec(fmt.Sprintf("SET cache_httpfs_cache_directory = '%s/'", cacheDir)); err != nil {
 			// NOTE: cache directory path comes from trusted server config (DataDir), not user input.
 			slog.Warn("Failed to set cache_httpfs cache directory.", "cache_directory", cacheDir, "error", err)
 		} else {


### PR DESCRIPTION
## Summary
- `cache_httpfs` treats `cache_httpfs_cache_directory` as a **path prefix**, not a directory path. Without a trailing `/`, cache files are written as `/data/cacheb78b64f5.parquet` instead of `/data/cache/b78b64f5.parquet`.
- Adds trailing `/` to the SET so the directory is used correctly.

## Context
After landing #147 (cache_httpfs support), we observed cache files being created in the wrong location on production duckling instances — files appeared as `/data/cache<hash>.parquet` directly in `/data/` rather than inside the `/data/cache/` subdirectory.

Same path-prefix behavior is visible in upstream issue: https://github.com/dentiny/duck-read-cache-fs/issues/403

## Test plan
- [x] Existing `TestParseExtensionName` and `TestHasCacheHTTPFS` pass
- [ ] Deploy and verify cache files appear under `/data/cache/<file>` not `/data/cache<file>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)