### PR TITLE
server: emulate server-side cursors for DECLARE/FETCH/CLOSE

### DIFF
--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -12,50 +12,10 @@ import (
 // paramRegex matches PostgreSQL-style $N parameter placeholders
 var paramRegex = regexp.MustCompile(`\$(\d+)`)
 
-// TransformFlags is a bitmask indicating which transforms a query needs.
-type TransformFlags uint32
-
-const (
-	FlagWritableCTE  TransformFlags = 1 << iota // Writable CTE rewrite
-	FlagVersion                                  // version() replacement
-	FlagPgCatalog                                // pg_catalog schema/view mappings
-	FlagInfoSchema                               // information_schema mappings
-	FlagPublicSchema                             // public -> main schema mapping
-	FlagTypeMapping                              // Type mappings (JSONB->JSON, etc.)
-	FlagTypeCast                                 // Type casts (::regtype -> ::varchar)
-	FlagFunctions                                // Function mappings (array_agg->list, etc.)
-	FlagFuncAlias                                // Function alias normalization
-	FlagOperators                                // Operator mappings (regex, JSON)
-	FlagSetShow                                  // SET/SHOW command handling
-	FlagExpandArray                              // _pg_expandarray handling
-	FlagOnConflict                               // ON CONFLICT handling
-	FlagLocking                                  // FOR UPDATE/SHARE removal
-	FlagCtid                                     // ctid -> rowid mapping
-	FlagDDL                                      // DDL constraint stripping
-	FlagPlaceholder                              // $1/$2 placeholder conversion
-	flagSentinel                                 // must be last — used to derive FlagAll
-
-	FlagAll TransformFlags = flagSentinel - 1 // All flags set
-)
-
-// Classification is the result of pre-parse query classification.
-type Classification struct {
-	// Direct means the query needs no transforms and can go straight to DuckDB.
-	Direct bool
-	// Flags indicates which transforms are needed (only meaningful when Direct is false).
-	Flags TransformFlags
-}
-
-// taggedTransform pairs a transform with its bitmask flag for selective execution.
-type taggedTransform struct {
-	flag TransformFlags
-	tr   transform.Transform
-}
-
 // Transpiler converts PostgreSQL SQL to DuckDB-compatible SQL
 type Transpiler struct {
 	config     Config
-	transforms []taggedTransform
+	transforms []transform.Transform
 }
 
 // New creates a Transpiler with the given configuration.
@@ -63,118 +23,81 @@ type Transpiler struct {
 func New(cfg Config) *Transpiler {
 	t := &Transpiler{
 		config:     cfg,
-		transforms: make([]taggedTransform, 0),
+		transforms: make([]transform.Transform, 0),
 	}
 
-	// Core transforms - always registered
+	// Core transforms - always applied
 	// Order matters: more specific transforms should come first
 
 	// 0. Writable CTE transform - MUST BE FIRST
-	t.transforms = append(t.transforms, taggedTransform{FlagWritableCTE, transform.NewWritableCTETransform()})
+	// This transform rewrites PostgreSQL writable CTEs into multi-statement sequences.
+	// It must run before other transforms because it completely rewrites the query structure.
+	t.transforms = append(t.transforms, transform.NewWritableCTETransform())
 
 	// 1. version() replacement - MUST run before PgCatalogTransform
-	t.transforms = append(t.transforms, taggedTransform{FlagVersion, transform.NewVersionTransform()})
+	// Otherwise PgCatalogTransform adds memory.main. prefix and VersionTransform won't match it
+	t.transforms = append(t.transforms, transform.NewVersionTransform())
 
 	// 2. pg_catalog schema and view mappings
-	t.transforms = append(t.transforms, taggedTransform{FlagPgCatalog, transform.NewPgCatalogTransformWithConfig(cfg.DuckLakeMode)})
+	t.transforms = append(t.transforms, transform.NewPgCatalogTransformWithConfig(cfg.DuckLakeMode))
 
 	// 3. information_schema mappings to compat views
-	t.transforms = append(t.transforms, taggedTransform{FlagInfoSchema, transform.NewInformationSchemaTransformWithConfig(cfg.DuckLakeMode)})
+	t.transforms = append(t.transforms, transform.NewInformationSchemaTransformWithConfig(cfg.DuckLakeMode))
 
 	// 3.1 Map PostgreSQL "public" schema to DuckDB "main"
-	t.transforms = append(t.transforms, taggedTransform{FlagPublicSchema, transform.NewPublicSchemaTransform()})
+	t.transforms = append(t.transforms, transform.NewPublicSchemaTransform())
 
 	// 4. Type mappings (JSONB->JSON, CHAR->TEXT, etc.)
-	t.transforms = append(t.transforms, taggedTransform{FlagTypeMapping, transform.NewTypeMappingTransform()})
+	t.transforms = append(t.transforms, transform.NewTypeMappingTransform())
 
 	// 5. Type casts (::regtype -> ::varchar)
-	t.transforms = append(t.transforms, taggedTransform{FlagTypeCast, transform.NewTypeCastTransform()})
+	t.transforms = append(t.transforms, transform.NewTypeCastTransform())
 
 	// 6. Function mappings (array_agg->list, string_to_array->string_split, etc.)
-	t.transforms = append(t.transforms, taggedTransform{FlagFunctions, transform.NewFunctionTransform()})
+	t.transforms = append(t.transforms, transform.NewFunctionTransform())
 
 	// 7. Function alias normalization (current_database() -> AS current_database)
-	t.transforms = append(t.transforms, taggedTransform{FlagFuncAlias, transform.NewFuncAliasTransform()})
+	t.transforms = append(t.transforms, transform.NewFuncAliasTransform())
 
 	// 8. Operator mappings (regex operators, etc.)
-	t.transforms = append(t.transforms, taggedTransform{FlagOperators, transform.NewOperatorTransform()})
+	t.transforms = append(t.transforms, transform.NewOperatorTransform())
 
 	// 9. SET/SHOW command handling
-	t.transforms = append(t.transforms, taggedTransform{FlagSetShow, transform.NewSetShowTransform()})
+	t.transforms = append(t.transforms, transform.NewSetShowTransform())
 
 	// 10. _pg_expandarray handling (PostgreSQL array expansion function used by JDBC)
-	t.transforms = append(t.transforms, taggedTransform{FlagExpandArray, transform.NewExpandArrayTransform()})
+	t.transforms = append(t.transforms, transform.NewExpandArrayTransform())
 
 	// 11. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
-	t.transforms = append(t.transforms, taggedTransform{FlagOnConflict, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode)})
+	t.transforms = append(t.transforms, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode))
 
 	// 12. Locking clause removal (FOR UPDATE, FOR SHARE, etc.) - DuckDB doesn't support these
-	t.transforms = append(t.transforms, taggedTransform{FlagLocking, transform.NewLockingTransform()})
+	t.transforms = append(t.transforms, transform.NewLockingTransform())
 
 	// 13. ctid → rowid mapping (PostgreSQL system column to DuckDB equivalent)
-	t.transforms = append(t.transforms, taggedTransform{FlagCtid, transform.NewCtidTransform()})
+	t.transforms = append(t.transforms, transform.NewCtidTransform())
 
 	// DDL transforms only when DuckLake mode is enabled
 	if cfg.DuckLakeMode {
-		t.transforms = append(t.transforms, taggedTransform{FlagDDL, transform.NewDDLTransform()})
+		t.transforms = append(t.transforms, transform.NewDDLTransform())
 	}
 
 	// Placeholder transform only when needed (extended query protocol)
 	if cfg.ConvertPlaceholders {
-		t.transforms = append(t.transforms, taggedTransform{FlagPlaceholder, transform.NewPlaceholderTransform()})
+		t.transforms = append(t.transforms, transform.NewPlaceholderTransform())
 	}
 
 	return t
 }
 
 // Transpile converts a PostgreSQL SQL statement to DuckDB-compatible SQL.
-// It classifies the query first to skip unnecessary work:
-//   - Tier 0: No PG-specific patterns detected → return original SQL directly (no parse)
-//   - Tier 1: PG-specific patterns detected → parse and apply only relevant transforms
-//   - Tier 2: Error-driven retry (ALTER TABLE→VIEW, DROP TABLE→VIEW) handled by caller
-//
-// Note: Tier 0 queries never set FallbackToNative (they bypass parsing entirely).
-// DuckDB-native syntax (DESCRIBE, PIVOT, etc.) is returned as-is, which is correct
-// since conn.go sends the SQL to DuckDB either way. The only difference is that
-// conn.go won't call validateWithDuckDB() for Tier 0 queries, but that validation
-// is a courtesy for better error messages, not a correctness requirement.
+// Returns the Result containing the transformed SQL and metadata.
 func (t *Transpiler) Transpile(sql string) (*Result, error) {
 	sql = strings.TrimSpace(sql)
 	if sql == "" {
 		return &Result{SQL: sql}, nil
 	}
 
-	// Tier 0: Pre-parse classification
-	cls := Classify(sql, t.config)
-	if cls.Direct {
-		// No PG-specific patterns found — send directly to DuckDB.
-		// For ConvertPlaceholders mode, count params with regex (no parse needed).
-		paramCount := 0
-		if t.config.ConvertPlaceholders {
-			paramCount = countParametersRegex(sql)
-		}
-		return &Result{
-			SQL:        sql,
-			ParamCount: paramCount,
-		}, nil
-	}
-
-	// Tier 1: Selective transform execution
-	return t.transpileWithFlags(sql, cls.Flags)
-}
-
-// TranspileAll bypasses classification and runs all transforms unconditionally.
-// This is useful for testing and benchmarking the full pipeline.
-func (t *Transpiler) TranspileAll(sql string) (*Result, error) {
-	sql = strings.TrimSpace(sql)
-	if sql == "" {
-		return &Result{SQL: sql}, nil
-	}
-	return t.transpileWithFlags(sql, FlagAll)
-}
-
-// transpileWithFlags parses the SQL and applies only transforms whose flag is set.
-func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Result, error) {
 	// Parse the SQL into an AST
 	tree, err := pg_query.Parse(sql)
 	if err != nil {
@@ -190,13 +113,9 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 	// Create transform result to collect metadata from transforms
 	transformResult := &transform.Result{}
 
-	// Apply selected transforms
-	for _, tt := range t.transforms {
-		if tt.flag&flags == 0 {
-			continue // Skip transforms not needed for this query
-		}
-
-		changed, err := tt.tr.Transform(tree, transformResult)
+	// Apply all transforms
+	for _, tr := range t.transforms {
+		changed, err := tr.Transform(tree, transformResult)
 		if err != nil {
 			return nil, err
 		}
@@ -252,214 +171,6 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 		NoOpTag:      transformResult.NoOpTag,
 		IsIgnoredSet: transformResult.IsIgnoredSet,
 	}, nil
-}
-
-// Classify performs fast pre-parse classification of a SQL query.
-// It does case-insensitive substring matching to detect PostgreSQL-specific patterns.
-// Conservative: false positives (unnecessary transforms) are fine; false negatives are bugs.
-func Classify(sql string, cfg Config) Classification {
-	upper := strings.ToUpper(sql)
-
-	var flags TransformFlags
-
-	// SET/SHOW/RESET/DISCARD/BEGIN/START TRANSACTION — always process these
-	// because they produce IsIgnoredSet/IsNoOp/Error side effects that conn.go depends on
-	if hasAnyPrefix(upper, "SET ", "SHOW ", "RESET ", "DISCARD ", "BEGIN", "START TRANSACTION", "START ") {
-		flags |= FlagSetShow
-	}
-
-	// pg_catalog references (tables, functions, types)
-	if containsAny(upper,
-		"PG_CATALOG", "PG_CLASS", "PG_TYPE", "PG_ATTRIBUTE", "PG_NAMESPACE",
-		"PG_INDEX", "PG_CONSTRAINT", "PG_DATABASE", "PG_ROLES", "PG_STAT",
-		"PG_STATIO", "PG_COLLATION", "PG_POLICY", "PG_PUBLICATION",
-		"PG_INHERITS", "PG_MATVIEWS", "PG_ENUM", "PG_INDEXES",
-		"PG_ATTRDEF", "PG_AM", "PG_DESCRIPTION", "PG_DEPEND",
-		"PG_SHDESCRIPTION", "PG_PROC", "PG_EXTENSION",
-		"PG_AVAILABLE_EXTENSIONS", "PG_SETTINGS",
-		"FORMAT_TYPE", "OBJ_DESCRIPTION", "COL_DESCRIPTION",
-		"PG_GET_EXPR", "PG_GET_USERBYID", "PG_TABLE_IS_VISIBLE",
-		"PG_GET_INDEXDEF", "PG_GET_CONSTRAINTDEF", "PG_GET_SERIAL_SEQUENCE",
-		"PG_RELATION_SIZE", "PG_TOTAL_RELATION_SIZE",
-		"SIMILAR_TO_ESCAPE",
-	) {
-		flags |= FlagPgCatalog
-	}
-
-	// information_schema references
-	if strings.Contains(upper, "INFORMATION_SCHEMA") {
-		flags |= FlagInfoSchema
-	}
-
-	// public.table references (but not catalog.public.table which is 3-part)
-	if strings.Contains(upper, "PUBLIC.") {
-		flags |= FlagPublicSchema
-	}
-
-	// version() function
-	if strings.Contains(upper, "VERSION(") {
-		flags |= FlagVersion | FlagPgCatalog
-	}
-
-	// PostgreSQL type names that need mapping
-	if containsAny(upper,
-		"JSONB", "BYTEA", "INET", "CIDR", "MACADDR",
-		"MONEY", "BPCHAR", "TSVECTOR", "TSQUERY",
-		"REGPROC", "REGTYPE", "REGCLASS", "REGNAMESPACE",
-		"PG_CATALOG.INT", "PG_CATALOG.VARCHAR", "PG_CATALOG.TEXT",
-		"PG_CATALOG.BOOL", "PG_CATALOG.FLOAT", "PG_CATALOG.JSON",
-		"PG_CATALOG.\"DEFAULT\"",
-	) {
-		flags |= FlagTypeMapping
-	}
-
-	// Type casts that need rewriting
-	if containsAny(upper, "::REGTYPE", "::REGCLASS", "::REGNAMESPACE", "::REGPROC", "::OID") {
-		flags |= FlagTypeCast
-	}
-	// Also catch pg_catalog. qualified casts
-	if strings.Contains(upper, "::PG_CATALOG.") {
-		flags |= FlagTypeCast | FlagTypeMapping
-	}
-
-	// PostgreSQL functions that need mapping
-	if containsAny(upper,
-		"ARRAY_AGG(", "STRING_TO_ARRAY(", "REGEXP_MATCHES(", "PG_TYPEOF(",
-		"JSON_BUILD_OBJECT(", "JSONB_BUILD_OBJECT(", "ARRAY_TO_STRING(",
-		"JSON_AGG(", "JSONB_AGG(", "ARRAY_UPPER(", "ARRAY_LENGTH(",
-		"JSON_OBJECT(",
-	) {
-		flags |= FlagFunctions
-	}
-
-	// Function alias normalization
-	if containsAny(upper, "CURRENT_DATABASE(", "CURRENT_SCHEMA(", "CURRENT_SCHEMAS(") {
-		flags |= FlagFuncAlias
-	}
-
-	// Operators: JSON arrows and regex.
-	// Note: "~" is aggressive — it matches column names and string literals too.
-	// This is acceptable: false positive just runs the operator transform (cheap),
-	// while a false negative would break PostgreSQL regex queries that DuckDB
-	// handles via regexp_matches rewrite.
-	if containsAny(upper, "->", "~") {
-		flags |= FlagOperators
-	}
-	// Also check for SIMILAR TO which gets transformed through operators
-	if strings.Contains(upper, "SIMILAR TO") {
-		flags |= FlagOperators | FlagPgCatalog
-	}
-	// COLLATE pg_catalog."default" is handled by operators/pgcatalog
-	if strings.Contains(upper, "COLLATE") {
-		flags |= FlagOperators | FlagPgCatalog
-	}
-
-	// FOR UPDATE/SHARE/NO KEY UPDATE/KEY SHARE locking clauses
-	if containsAny(upper, "FOR UPDATE", "FOR SHARE", "FOR NO KEY UPDATE", "FOR KEY SHARE") {
-		flags |= FlagLocking
-	}
-
-	// ctid system column.
-	// Substring match may false-positive on names like "DOCTID" — acceptable
-	// since the ctid transform only rewrites actual ctid column references in the AST.
-	if strings.Contains(upper, "CTID") {
-		flags |= FlagCtid
-	}
-
-	// _pg_expandarray (JDBC pattern)
-	if strings.Contains(upper, "_PG_EXPANDARRAY") {
-		flags |= FlagExpandArray
-	}
-
-	// ON CONFLICT (DuckLake mode only, but always flag it so the transform can decide)
-	if strings.Contains(upper, "ON CONFLICT") {
-		flags |= FlagOnConflict
-	}
-
-	// DDL patterns (DuckLake mode only).
-	// "UNIQUE" and "REFERENCES" may false-positive in non-DDL contexts (e.g.,
-	// SELECT ... WHERE col = 'UNIQUE'), but the DDL transform only acts on
-	// CREATE TABLE / ALTER TABLE AST nodes, so false positives are harmless.
-	if cfg.DuckLakeMode {
-		if containsAny(upper, "CREATE INDEX", "DROP INDEX", "VACUUM", "GRANT ", "REVOKE ",
-			"PRIMARY KEY", "UNIQUE", "REFERENCES", "SERIAL", "BIGSERIAL",
-			"DEFAULT NOW()", "FOREIGN KEY", "ALTER TABLE", "CASCADE",
-			"REINDEX", "CLUSTER", "COMMENT ON", "REFRESH ") {
-			flags |= FlagDDL
-		}
-	}
-
-	// Writable CTEs: WITH ... (INSERT|UPDATE|DELETE).
-	// This can false-positive on read-only queries containing these keywords
-	// (e.g., WHERE action = 'UPDATE'), but the writable CTE transform checks
-	// the actual AST and is a no-op for non-writable CTEs.
-	if strings.Contains(upper, "WITH ") {
-		if containsAny(upper, "INSERT ", "UPDATE ", "DELETE ") {
-			flags |= FlagWritableCTE
-		}
-	}
-
-	// Parameter placeholders
-	if cfg.ConvertPlaceholders && strings.Contains(sql, "$") {
-		flags |= FlagPlaceholder
-	}
-
-	// pg_query's parser adds pg_catalog. prefix to many built-in functions during parsing.
-	// Ensure PgCatalog transform runs whenever function-related transforms are needed,
-	// to strip these prefixes before they reach DuckDB.
-	if flags&(FlagFunctions|FlagFuncAlias|FlagOperators|FlagTypeCast|FlagTypeMapping) != 0 {
-		flags |= FlagPgCatalog
-	}
-
-	if flags == 0 {
-		return Classification{Direct: true}
-	}
-	return Classification{Flags: flags}
-}
-
-// containsAny returns true if s contains any of the given substrings.
-func containsAny(s string, substrs ...string) bool {
-	for _, sub := range substrs {
-		if strings.Contains(s, sub) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasAnyPrefix returns true if s starts with any of the given prefixes.
-// The check is performed after trimming leading whitespace, line comments (-- ...),
-// and block comments (/* ... */).
-func hasAnyPrefix(s string, prefixes ...string) bool {
-	trimmed := strings.TrimLeft(s, " \t\n\r")
-
-	// Skip leading comments (line comments and block comments)
-	for {
-		if strings.HasPrefix(trimmed, "--") {
-			// Line comment: skip to end of line
-			nl := strings.IndexByte(trimmed, '\n')
-			if nl < 0 {
-				return false // entire string is a comment
-			}
-			trimmed = strings.TrimLeft(trimmed[nl+1:], " \t\n\r")
-		} else if strings.HasPrefix(trimmed, "/*") {
-			// Block comment: skip to closing */
-			end := strings.Index(trimmed, "*/")
-			if end < 0 {
-				return false // unclosed block comment
-			}
-			trimmed = strings.TrimLeft(trimmed[end+2:], " \t\n\r")
-		} else {
-			break
-		}
-	}
-
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(trimmed, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 // CountParameters parses SQL and counts $N placeholders without applying any transforms.

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -581,10 +581,6 @@ func TestTranspile_DDL_NoOps(t *testing.T) {
 		{"ALTER TABLE DROP NOT NULL", "ALTER TABLE users ALTER COLUMN name DROP NOT NULL", "ALTER TABLE"},
 		{"ALTER TABLE SET DEFAULT", "ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active'", "ALTER TABLE"},
 		{"ALTER TABLE DROP DEFAULT", "ALTER TABLE users ALTER COLUMN status DROP DEFAULT", "ALTER TABLE"},
-		{"REINDEX", "REINDEX TABLE users", "REINDEX"},
-		{"CLUSTER", "CLUSTER users USING idx_name", "CLUSTER"},
-		{"COMMENT ON", "COMMENT ON TABLE users IS 'User accounts'", "COMMENT"},
-		{"REFRESH MATERIALIZED VIEW", "REFRESH MATERIALIZED VIEW my_view", "REFRESH MATERIALIZED VIEW"},
 	}
 
 	tr := New(Config{DuckLakeMode: true})
@@ -1705,16 +1701,14 @@ func TestCountParameters(t *testing.T) {
 
 func TestTranspile_FallbackToNative(t *testing.T) {
 	// Test that FallbackToNative is set correctly when PostgreSQL parsing fails
-	// during Tier 1 (query has PG patterns but is invalid PG syntax).
-	// DuckDB-specific queries with no PG patterns go through Tier 0 (Direct)
-	// and return original SQL without FallbackToNative (no parse needed).
+	// but the query might be valid DuckDB syntax
 	tr := New(DefaultConfig())
 
 	tests := []struct {
 		name         string
 		input        string
 		wantFallback bool
-		wantSQL      string // expected SQL in result (original for direct/fallback)
+		wantSQL      string // expected SQL in result (original for fallback)
 		wantErrNil   bool   // whether err should be nil
 	}{
 		{
@@ -1735,92 +1729,108 @@ func TestTranspile_FallbackToNative(t *testing.T) {
 			wantFallback: false,
 			wantErrNil:   true,
 		},
-		// DuckDB-specific syntax: no PG patterns → Tier 0 Direct → original SQL returned.
-		// These used to trigger FallbackToNative (pg_query.Parse failed), but now the
-		// classifier returns Direct and the query goes to DuckDB without parsing at all.
+		// Note: COPY syntax is valid PostgreSQL, so it doesn't trigger fallback
+		// even if the FORMAT PARQUET is DuckDB-specific
 		{
-			name:       "DuckDB DESCRIBE statement - direct",
-			input:      "DESCRIBE SELECT * FROM users",
-			wantSQL:    "DESCRIBE SELECT * FROM users",
-			wantErrNil: true,
+			name:         "DuckDB DESCRIBE statement - fallback",
+			input:        "DESCRIBE SELECT * FROM users",
+			wantFallback: true,
+			wantSQL:      "DESCRIBE SELECT * FROM users",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB SUMMARIZE statement - direct",
-			input:      "SUMMARIZE SELECT * FROM users",
-			wantSQL:    "SUMMARIZE SELECT * FROM users",
-			wantErrNil: true,
+			name:         "DuckDB SUMMARIZE statement - fallback",
+			input:        "SUMMARIZE SELECT * FROM users",
+			wantFallback: true,
+			wantSQL:      "SUMMARIZE SELECT * FROM users",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB PIVOT syntax - direct",
-			input:      "PIVOT cities ON year USING sum(population)",
-			wantSQL:    "PIVOT cities ON year USING sum(population)",
-			wantErrNil: true,
+			name:         "DuckDB PIVOT syntax - fallback",
+			input:        "PIVOT cities ON year USING sum(population)",
+			wantFallback: true,
+			wantSQL:      "PIVOT cities ON year USING sum(population)",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB UNPIVOT syntax - direct",
-			input:      "UNPIVOT monthly_sales ON jan, feb, mar INTO NAME month VALUE sales",
-			wantSQL:    "UNPIVOT monthly_sales ON jan, feb, mar INTO NAME month VALUE sales",
-			wantErrNil: true,
+			name:         "DuckDB UNPIVOT syntax - fallback",
+			input:        "UNPIVOT monthly_sales ON jan, feb, mar INTO NAME month VALUE sales",
+			wantFallback: true,
+			wantSQL:      "UNPIVOT monthly_sales ON jan, feb, mar INTO NAME month VALUE sales",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB FROM-first syntax - direct",
-			input:      "FROM users SELECT name, email",
-			wantSQL:    "FROM users SELECT name, email",
-			wantErrNil: true,
+			name:         "DuckDB FROM-first syntax - fallback",
+			input:        "FROM users SELECT name, email",
+			wantFallback: true,
+			wantSQL:      "FROM users SELECT name, email",
+			wantErrNil:   true,
+		},
+		// Note: read_parquet() and read_csv() are valid PostgreSQL syntax
+		// (just function calls), so they don't trigger fallback.
+		// They only fail at execution time if the function doesn't exist.
+		{
+			name:         "DuckDB INSTALL extension - fallback",
+			input:        "INSTALL httpfs",
+			wantFallback: true,
+			wantSQL:      "INSTALL httpfs",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB INSTALL extension - direct",
-			input:      "INSTALL httpfs",
-			wantSQL:    "INSTALL httpfs",
-			wantErrNil: true,
+			name:         "DuckDB LOAD extension - fallback",
+			input:        "LOAD httpfs",
+			wantFallback: true,
+			wantSQL:      "LOAD httpfs",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB LOAD extension - direct",
-			input:      "LOAD httpfs",
-			wantSQL:    "LOAD httpfs",
-			wantErrNil: true,
+			name:         "DuckDB ATTACH database - fallback",
+			input:        "ATTACH 'my.db' AS mydb",
+			wantFallback: true,
+			wantSQL:      "ATTACH 'my.db' AS mydb",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB ATTACH database - direct",
-			input:      "ATTACH 'my.db' AS mydb",
-			wantSQL:    "ATTACH 'my.db' AS mydb",
-			wantErrNil: true,
+			name:         "DuckDB USE database - fallback",
+			input:        "USE mydb",
+			wantFallback: true,
+			wantSQL:      "USE mydb",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB USE database - direct",
-			input:      "USE mydb",
-			wantSQL:    "USE mydb",
-			wantErrNil: true,
+			name:         "DuckDB PRAGMA statement - fallback",
+			input:        "PRAGMA database_list",
+			wantFallback: true,
+			wantSQL:      "PRAGMA database_list",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB PRAGMA statement - direct",
-			input:      "PRAGMA database_list",
-			wantSQL:    "PRAGMA database_list",
-			wantErrNil: true,
+			name:         "DuckDB CREATE MACRO - fallback",
+			input:        "CREATE MACRO add(a, b) AS a + b",
+			wantFallback: true,
+			wantSQL:      "CREATE MACRO add(a, b) AS a + b",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB CREATE MACRO - direct",
-			input:      "CREATE MACRO add(a, b) AS a + b",
-			wantSQL:    "CREATE MACRO add(a, b) AS a + b",
-			wantErrNil: true,
+			name:         "DuckDB SELECT with EXCLUDE - fallback",
+			input:        "SELECT * EXCLUDE (password) FROM users",
+			wantFallback: true,
+			wantSQL:      "SELECT * EXCLUDE (password) FROM users",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB SELECT with EXCLUDE - direct",
-			input:      "SELECT * EXCLUDE (password) FROM users",
-			wantSQL:    "SELECT * EXCLUDE (password) FROM users",
-			wantErrNil: true,
+			name:         "DuckDB SELECT with REPLACE - fallback",
+			input:        "SELECT * REPLACE (upper(name) AS name) FROM users",
+			wantFallback: true,
+			wantSQL:      "SELECT * REPLACE (upper(name) AS name) FROM users",
+			wantErrNil:   true,
 		},
 		{
-			name:       "DuckDB SELECT with REPLACE - direct",
-			input:      "SELECT * REPLACE (upper(name) AS name) FROM users",
-			wantSQL:    "SELECT * REPLACE (upper(name) AS name) FROM users",
-			wantErrNil: true,
-		},
-		{
-			name:       "DuckDB QUALIFY clause - direct",
-			input:      "SELECT * FROM sales QUALIFY row_number() OVER (PARTITION BY region) = 1",
-			wantSQL:    "SELECT * FROM sales QUALIFY row_number() OVER (PARTITION BY region) = 1",
-			wantErrNil: true,
+			name:         "DuckDB QUALIFY clause - fallback",
+			input:        "SELECT * FROM sales QUALIFY row_number() OVER (PARTITION BY region) = 1",
+			wantFallback: true,
+			wantSQL:      "SELECT * FROM sales QUALIFY row_number() OVER (PARTITION BY region) = 1",
+			wantErrNil:   true,
 		},
 		{
 			name:         "valid PostgreSQL CTE - no fallback",
@@ -1858,8 +1868,8 @@ func TestTranspile_FallbackToNative(t *testing.T) {
 					tt.input, result.FallbackToNative, tt.wantFallback)
 			}
 
-			// For direct/fallback cases, SQL should be the original query
-			if tt.wantSQL != "" && result.SQL != tt.wantSQL {
+			// For fallback cases, SQL should be the original query
+			if tt.wantFallback && tt.wantSQL != "" && result.SQL != tt.wantSQL {
 				t.Errorf("Transpile(%q) SQL = %q, want %q",
 					tt.input, result.SQL, tt.wantSQL)
 			}
@@ -2257,51 +2267,43 @@ func TestTranspile_SQLSyntaxFunctions(t *testing.T) {
 }
 
 func TestTranspile_FallbackParamCount(t *testing.T) {
-	// Test that DuckDB-specific syntax with ConvertPlaceholders=true still correctly
-	// counts $N parameter placeholders.
-	// Queries with $ go through Tier 1 (FlagPlaceholder) → pg_query fails → FallbackToNative
-	// Queries without $ go through Tier 0 (Direct) → param count via regex (returns 0)
+	// Test that when pg_query fails to parse DuckDB-specific syntax,
+	// the transpiler still correctly counts $N parameter placeholders
+	// using regex-based counting.
 	tests := []struct {
-		name           string
-		input          string
-		paramCount     int
-		wantFallback   bool // true for Tier 1 (has $), false for Tier 0 (no $)
+		name       string
+		input      string
+		paramCount int
 	}{
 		{
-			name:         "DuckDB FROM-first with parameter",
-			input:        "FROM users SELECT name WHERE id = $1",
-			paramCount:   1,
-			wantFallback: true,
+			name:       "DuckDB FROM-first with parameter",
+			input:      "FROM users SELECT name WHERE id = $1",
+			paramCount: 1,
 		},
 		{
-			name:         "DuckDB SELECT EXCLUDE with parameter",
-			input:        "SELECT * EXCLUDE (email) FROM users WHERE id = $1",
-			paramCount:   1,
-			wantFallback: true,
+			name:       "DuckDB SELECT EXCLUDE with parameter",
+			input:      "SELECT * EXCLUDE (email) FROM users WHERE id = $1",
+			paramCount: 1,
 		},
 		{
-			name:         "DuckDB DESCRIBE with no params - Tier 0 Direct",
-			input:        "DESCRIBE SELECT 1 AS num",
-			paramCount:   0,
-			wantFallback: false, // No $ → no FlagPlaceholder → Tier 0 Direct
+			name:       "DuckDB DESCRIBE with no params",
+			input:      "DESCRIBE SELECT 1 AS num",
+			paramCount: 0,
 		},
 		{
-			name:         "DuckDB QUALIFY with multiple params",
-			input:        "SELECT id, name FROM users WHERE status = $1 QUALIFY row_number() OVER (ORDER BY id) <= $2",
-			paramCount:   2,
-			wantFallback: true,
+			name:       "DuckDB QUALIFY with multiple params",
+			input:      "SELECT id, name FROM users WHERE status = $1 QUALIFY row_number() OVER (ORDER BY id) <= $2",
+			paramCount: 2,
 		},
 		{
-			name:         "DuckDB list_filter with param",
-			input:        "SELECT list_filter([1, 2, 3, 4, 5], x -> x > $1) AS filtered",
-			paramCount:   1,
-			wantFallback: true,
+			name:       "DuckDB list_filter with param",
+			input:      "SELECT list_filter([1, 2, 3, 4, 5], x -> x > $1) AS filtered",
+			paramCount: 1,
 		},
 		{
-			name:         "Out of order params",
-			input:        "FROM users SELECT $3, $1, $2",
-			paramCount:   3,
-			wantFallback: true,
+			name:       "Out of order params",
+			input:      "FROM users SELECT $3, $1, $2",
+			paramCount: 3,
 		},
 	}
 
@@ -2313,8 +2315,8 @@ func TestTranspile_FallbackParamCount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
 			}
-			if result.FallbackToNative != tt.wantFallback {
-				t.Errorf("Transpile(%q) FallbackToNative = %v, want %v", tt.input, result.FallbackToNative, tt.wantFallback)
+			if !result.FallbackToNative {
+				t.Errorf("Transpile(%q) should set FallbackToNative=true for DuckDB-specific syntax", tt.input)
 			}
 			if result.ParamCount != tt.paramCount {
 				t.Errorf("Transpile(%q) ParamCount = %d, want %d", tt.input, result.ParamCount, tt.paramCount)
@@ -2890,252 +2892,5 @@ func TestTranspile_CustomMacros_DuckLakeMode(t *testing.T) {
 				t.Errorf("Transpile(%q) = %q, should contain %q", tt.input, result.SQL, tt.contains)
 			}
 		})
-	}
-}
-
-// --- Three-Tier Intercept Tests ---
-
-func TestClassify_Direct(t *testing.T) {
-	// Plain queries with no PostgreSQL-specific patterns should be classified as Direct
-	cfg := DefaultConfig()
-
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"simple select", "SELECT 1"},
-		{"select from table", "SELECT * FROM users"},
-		{"select with where", "SELECT * FROM users WHERE id = 1"},
-		{"insert", "INSERT INTO users (name) VALUES ('test')"},
-		{"update", "UPDATE users SET name = 'test' WHERE id = 1"},
-		{"delete", "DELETE FROM users WHERE id = 1"},
-		{"create table", "CREATE TABLE users (id INTEGER, name VARCHAR)"},
-		{"drop table", "DROP TABLE users"},
-		{"create schema", "CREATE SCHEMA test"},
-		{"CTE read-only", "WITH active AS (SELECT * FROM users WHERE active) SELECT * FROM active"},
-		{"subquery", "SELECT * FROM (SELECT id, name FROM users) AS u"},
-		{"JOIN", "SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id"},
-		{"UNION", "SELECT name FROM users UNION SELECT name FROM admins"},
-		{"comment prefix", "/* sync_id:abc123 */ SELECT * FROM users"},
-		{"DuckDB DESCRIBE", "DESCRIBE SELECT * FROM users"},
-		{"DuckDB PRAGMA", "PRAGMA database_list"},
-		{"DuckDB FROM-first", "FROM users SELECT name"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cls := Classify(tt.input, cfg)
-			if !cls.Direct {
-				t.Errorf("Classify(%q) = {Direct: false, Flags: %d}, want Direct", tt.input, cls.Flags)
-			}
-		})
-	}
-}
-
-func TestClassify_NeedsTransform(t *testing.T) {
-	// Queries with PostgreSQL-specific patterns should return correct flags
-	cfg := DefaultConfig()
-
-	tests := []struct {
-		name      string
-		input     string
-		wantFlags TransformFlags // flags that MUST be set (may have more)
-	}{
-		{"SET command", "SET application_name = 'test'", FlagSetShow},
-		{"SHOW command", "SHOW server_version", FlagSetShow},
-		{"RESET command", "RESET ALL", FlagSetShow},
-		{"BEGIN", "BEGIN", FlagSetShow},
-		{"pg_catalog table", "SELECT * FROM pg_catalog.pg_class", FlagPgCatalog},
-		{"pg_class unqualified", "SELECT * FROM pg_class", FlagPgCatalog},
-		{"information_schema", "SELECT * FROM information_schema.columns", FlagInfoSchema},
-		{"public schema", "SELECT * FROM public.users", FlagPublicSchema},
-		{"version()", "SELECT version()", FlagVersion | FlagPgCatalog},
-		{"JSONB type", "CREATE TABLE t (data JSONB)", FlagTypeMapping | FlagPgCatalog},
-		{"BYTEA type", "CREATE TABLE t (data BYTEA)", FlagTypeMapping | FlagPgCatalog},
-		{"::regtype cast", "SELECT typname::regtype FROM pg_type", FlagTypeCast | FlagPgCatalog},
-		{"::regclass cast", "SELECT 'users'::regclass", FlagTypeCast | FlagPgCatalog},
-		{"array_agg function", "SELECT array_agg(x) FROM t", FlagFunctions | FlagPgCatalog},
-		{"current_database", "SELECT current_database()", FlagFuncAlias | FlagPgCatalog},
-		{"JSON arrow", "SELECT data->>'name' FROM t", FlagOperators | FlagPgCatalog},
-		{"regex operator", "SELECT * FROM t WHERE name ~ '^A'", FlagOperators | FlagPgCatalog},
-		{"FOR UPDATE", "SELECT * FROM t FOR UPDATE", FlagLocking},
-		{"ctid", "SELECT ctid FROM t", FlagCtid},
-		{"_pg_expandarray", "SELECT (_pg_expandarray(arr)).n FROM t", FlagExpandArray},
-		{"ON CONFLICT", "INSERT INTO t (id) VALUES (1) ON CONFLICT DO NOTHING", FlagOnConflict},
-		{"placeholder $1", "SELECT * FROM users WHERE id = $1", FlagPlaceholder},
-		{"SIMILAR TO", "SELECT 'hello' SIMILAR TO 'h%'", FlagOperators | FlagPgCatalog},
-		{"COLLATE", "SELECT * FROM t ORDER BY name COLLATE pg_catalog.default", FlagOperators | FlagPgCatalog},
-		{"SET with comment prefix", "/* ETL */ SET statement_timeout = 5000", FlagSetShow},
-		{"SET with line comment prefix", "-- setup\nSET statement_timeout = 5000", FlagSetShow},
-		{"SHOW after multiple comments", "-- first\n-- second\nSHOW server_version", FlagSetShow},
-		{"SET after mixed comments", "/* block */\n-- line\nSET search_path = 'main'", FlagSetShow},
-	}
-
-	for _, tt := range tests {
-		cfgToUse := cfg
-		// Enable ConvertPlaceholders for placeholder test
-		if tt.wantFlags&FlagPlaceholder != 0 {
-			cfgToUse = Config{ConvertPlaceholders: true}
-		}
-
-		t.Run(tt.name, func(t *testing.T) {
-			cls := Classify(tt.input, cfgToUse)
-			if cls.Direct {
-				t.Errorf("Classify(%q) = Direct, want flags containing %d", tt.input, tt.wantFlags)
-				return
-			}
-			if cls.Flags&tt.wantFlags != tt.wantFlags {
-				t.Errorf("Classify(%q) flags = %d, want flags to contain %d (missing: %d)",
-					tt.input, cls.Flags, tt.wantFlags, tt.wantFlags&^cls.Flags)
-			}
-		})
-	}
-}
-
-func TestClassify_DuckLakeMode(t *testing.T) {
-	cfg := Config{DuckLakeMode: true}
-
-	tests := []struct {
-		name      string
-		input     string
-		wantFlags TransformFlags
-	}{
-		{"CREATE INDEX is DDL", "CREATE INDEX idx ON users (name)", FlagDDL},
-		{"PRIMARY KEY is DDL", "CREATE TABLE t (id INT PRIMARY KEY)", FlagDDL},
-		{"SERIAL is DDL", "CREATE TABLE t (id SERIAL)", FlagDDL},
-		{"ALTER TABLE is DDL", "ALTER TABLE users ADD CONSTRAINT pk PRIMARY KEY (id)", FlagDDL},
-		{"VACUUM is DDL", "VACUUM users", FlagDDL},
-		{"CASCADE is DDL", "DROP TABLE users CASCADE", FlagDDL},
-		{"REINDEX is DDL", "REINDEX TABLE users", FlagDDL},
-		{"CLUSTER is DDL", "CLUSTER users USING idx_name", FlagDDL},
-		{"COMMENT ON is DDL", "COMMENT ON TABLE users IS 'desc'", FlagDDL},
-		{"REFRESH is DDL", "REFRESH MATERIALIZED VIEW my_view", FlagDDL},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cls := Classify(tt.input, cfg)
-			if cls.Direct {
-				t.Errorf("Classify(%q, DuckLake) = Direct, want flags containing %d", tt.input, tt.wantFlags)
-				return
-			}
-			if cls.Flags&tt.wantFlags != tt.wantFlags {
-				t.Errorf("Classify(%q, DuckLake) flags = %d, want flags to contain %d",
-					tt.input, cls.Flags, tt.wantFlags)
-			}
-		})
-	}
-
-	// Same queries should be Direct in non-DuckLake mode (except ones with other PG patterns)
-	nonDLCfg := DefaultConfig()
-	t.Run("CREATE INDEX direct in non-DuckLake", func(t *testing.T) {
-		cls := Classify("CREATE INDEX idx ON users (name)", nonDLCfg)
-		if !cls.Direct {
-			t.Errorf("CREATE INDEX should be Direct in non-DuckLake mode, got flags %d", cls.Flags)
-		}
-	})
-}
-
-func TestTier0MatchesTier1(t *testing.T) {
-	// Verify that queries classified as Direct produce the same result
-	// as running through the full pipeline via TranspileAll.
-	// This ensures the classifier doesn't miss any needed transforms.
-	tr := New(DefaultConfig())
-
-	directQueries := []string{
-		"SELECT 1",
-		"SELECT * FROM users",
-		"SELECT * FROM users WHERE id = 1",
-		"INSERT INTO users (name) VALUES ('test')",
-		"UPDATE users SET name = 'test' WHERE id = 1",
-		"DELETE FROM users WHERE id = 1",
-		"CREATE TABLE users (id INTEGER, name VARCHAR)",
-		"DROP TABLE users",
-		"SELECT u.name FROM users u JOIN orders o ON u.id = o.user_id",
-		"SELECT name FROM users UNION SELECT name FROM admins",
-		"WITH cte AS (SELECT 1 AS id) SELECT * FROM cte",
-	}
-
-	for _, sql := range directQueries {
-		t.Run(sql, func(t *testing.T) {
-			// Verify it's classified as Direct
-			cls := Classify(sql, DefaultConfig())
-			if !cls.Direct {
-				t.Fatalf("Expected Direct classification for %q, got flags %d", sql, cls.Flags)
-			}
-
-			// Get Tier 0 result (Direct)
-			tier0Result, err := tr.Transpile(sql)
-			if err != nil {
-				t.Fatalf("Transpile(%q) error: %v", sql, err)
-			}
-
-			// Get full pipeline result
-			tier1Result, err := tr.TranspileAll(sql)
-			if err != nil {
-				t.Fatalf("TranspileAll(%q) error: %v", sql, err)
-			}
-
-			// Both should produce equivalent results
-			// Tier 0 returns original SQL; Tier 1 does parse+deparse which may normalize
-			// So we just check that both are non-empty and have the same metadata
-			if tier0Result.SQL == "" {
-				t.Error("Tier 0 returned empty SQL")
-			}
-			if tier1Result.SQL == "" {
-				t.Error("Tier 1 returned empty SQL")
-			}
-			if tier0Result.IsNoOp != tier1Result.IsNoOp {
-				t.Errorf("IsNoOp mismatch: Tier 0 = %v, Tier 1 = %v", tier0Result.IsNoOp, tier1Result.IsNoOp)
-			}
-			if tier0Result.IsIgnoredSet != tier1Result.IsIgnoredSet {
-				t.Errorf("IsIgnoredSet mismatch: Tier 0 = %v, Tier 1 = %v", tier0Result.IsIgnoredSet, tier1Result.IsIgnoredSet)
-			}
-			if tier0Result.FallbackToNative != tier1Result.FallbackToNative {
-				t.Errorf("FallbackToNative mismatch: Tier 0 = %v, Tier 1 = %v", tier0Result.FallbackToNative, tier1Result.FallbackToNative)
-			}
-		})
-	}
-}
-
-func BenchmarkTranspile_Direct(b *testing.B) {
-	// Tier 0: No PG patterns → skip parse entirely
-	tr := New(DefaultConfig())
-	query := "SELECT * FROM users WHERE id = 1"
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = tr.Transpile(query)
-	}
-}
-
-func BenchmarkTranspile_OldAllTransforms(b *testing.B) {
-	// Full pipeline (TranspileAll) for comparison with Tier 0
-	tr := New(DefaultConfig())
-	query := "SELECT * FROM users WHERE id = 1"
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = tr.TranspileAll(query)
-	}
-}
-
-func BenchmarkClassify(b *testing.B) {
-	cfg := DefaultConfig()
-	query := "SELECT * FROM users WHERE id = 1"
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Classify(query, cfg)
-	}
-}
-
-func BenchmarkClassify_PgCatalog(b *testing.B) {
-	cfg := DefaultConfig()
-	query := "SELECT * FROM pg_catalog.pg_class WHERE relkind = 'r'"
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Classify(query, cfg)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds connection-level cursor emulation so PostgreSQL clients (Fivetran, JDBC, psycopg2 named cursors) can use `DECLARE CURSOR` / `FETCH` / `CLOSE` against DuckDB
- Intercepts cursor operations at the PG wire protocol layer in both Simple Query and Extended Query protocol paths (including multi-statement batches)
- On DECLARE: extracts and transpiles the inner SELECT, stores cursor state per connection
- On FETCH: lazily executes query on first fetch, streams N rows from the open result set across subsequent fetches
- Cursors are forward-only; FETCH BACKWARD/ABSOLUTE/RELATIVE and negative counts return an error
- Cursors are cleaned up on CLOSE, CLOSE ALL, COMMIT/ROLLBACK, or connection close
- Works for both normal and passthrough users (inner SELECT transpilation skipped for passthrough)
- Handles Describe for both statements ('S') and portals ('P') with cursor operations

## Test plan

- [x] `go build` compiles, `go test ./server/... ./transpiler/...` passes
- [x] Simple Query: DECLARE, FETCH N, FETCH ALL, FETCH NEXT, FETCH FORWARD, CLOSE, CLOSE ALL via psql
- [x] Extended Query: psycopg2 named cursors with fetchmany/fetchall/iteration
- [x] FETCH 0 returns 0 rows without advancing cursor position
- [x] MOVE N advances cursor without returning rows, MOVE 0 doesn't advance
- [x] FETCH BACKWARD/ABSOLUTE/RELATIVE rejected with error
- [x] FETCH with negative count (`FETCH -1`, `FETCH -5`) rejected with error
- [x] Multiple concurrent cursors with interleaved fetches
- [x] Cursor name collision (re-DECLARE replaces old cursor)
- [x] Quoted cursor names (`"my cursor"`)
- [x] Empty result set cursor
- [x] ROLLBACK/COMMIT close all cursors
- [x] Connection close with open cursors (cleanup)
- [x] Connection isolation (same cursor name on different connections)
- [x] Fivetran-like FETCH loop pattern (FETCH 10000 until exhausted)
- [x] Cursor with transpiler-relevant PG syntax (type casts, information_schema, current_database())
- [x] Multi-statement batch with cursor ops (psql `-c`)
- [x] Large result set streaming (10K rows)
- [x] Multiple data types (int, float, text, bool, NULL)
- [x] CTE + JOIN query cursor
- [x] Cursor outside explicit transaction
- [x] Describe portal ('P') returns correct RowDescription for FETCH
- [x] Extended Protocol column metadata (cur.description) correct after FETCH
- [x] All tests run against control-plane mode with Flight SQL workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)