### PR TITLE
fix(ci): stop release workflow from overwriting promoted builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,31 @@ jobs:
             sed 's|duckgres-linux-\([^/]*\)/||g' > checksums.txt
           cat checksums.txt
 
+      - name: Check if build release already exists
+        id: check-existing
+        run: |
+          TAG="build-${{ steps.sha.outputs.short }}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists — skipping to avoid overwriting a promoted release"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
+        if: steps.check-existing.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: build-${{ steps.sha.outputs.short }}
           name: Build ${{ steps.sha.outputs.short }}
           prerelease: true
+          make_latest: false
           body: |
             Automated build from commit ${{ github.sha }}
+
+            To promote this build to customer ducklings: edit this release and uncheck "pre-release".
           files: |
             artifacts/duckgres-linux-amd64/duckgres-linux-amd64
             artifacts/duckgres-linux-arm64/duckgres-linux-arm64
@@ -98,11 +115,12 @@ jobs:
           tag_name: latest
           name: Latest Build
           prerelease: true
+          make_latest: false
           body: |
             Latest build from commit ${{ github.sha }}
 
-            This is a **pre-release** (canary). It auto-deploys to the canary duckling.
-            To promote to customer ducklings: edit this release and uncheck "pre-release".
+            This is a **pre-release** (canary). It auto-deploys to dev and canary ducklings.
+            To promote a build to customer ducklings: find the specific `build-*` release and uncheck "pre-release".
           files: |
             artifacts/duckgres-linux-amd64/duckgres-linux-amd64
             artifacts/duckgres-linux-arm64/duckgres-linux-arm64


### PR DESCRIPTION
## Summary

The release workflow was interfering with the promotion flow (unchecking "pre-release" on a `build-*` release to deploy to customers) in two ways:

1. **Workflow re-runs could overwrite promoted releases.** `softprops/action-gh-release@v2` updates existing releases if the tag exists — so re-running the workflow for a promoted build would reset it to `prerelease: true`.

2. **The `latest` tag release body text told users to promote *it* instead of `build-*` releases.** Since CI deletes and recreates the `latest` release on every push to `main`, any promotion on it was immediately reverted. This caused the rollback to `build-da5a7c9` on customer instances.

### Changes

- **Skip `build-*` release creation if the tag already exists** — prevents workflow re-runs from overwriting promoted releases
- **Add `make_latest: false`** to both release steps — prevents interfering with GitHub's "Latest" label on promoted builds
- **Fix body text** — promotion instructions now point to `build-*` releases, not the `latest` tag

### Promotion flow (unchanged)

1. Every push to `main` creates a `build-*` pre-release → auto-deploys to dev + canary
2. To promote: find the specific `build-*` release on GitHub, edit it, uncheck "pre-release"
3. `posthog-cloud-infra` deployment picks it up via `/releases/latest` and deploys to customers

## Test plan

- [ ] Push to main → `build-*` pre-release created, `latest` tag release recreated as pre-release
- [ ] Promote a `build-*` release (uncheck pre-release) → survives subsequent pushes to main
- [ ] Re-run workflow for the same commit → promoted release is NOT overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)