### PR TITLE
fix(controlplane): prevent connection drops during zero-downtime handover

### DIFF
--- a/tests/controlplane/controlplane_test.go
+++ b/tests/controlplane/controlplane_test.go
@@ -689,3 +689,58 @@ func TestHandoverChildCrashThenRetry(t *testing.T) {
 		t.Fatalf("Expected 42, got %d", v)
 	}
 }
+
+// TestHandoverDrainsBeforeExit verifies that the old control plane process
+// stays alive after the handover to drain in-flight connections, rather than
+// exiting immediately when acceptLoop returns.
+//
+// Regression test: without the fix (select {} in acceptLoop), closing the
+// PG listener causes acceptLoop to return, which unwinds through
+// RunControlPlane() → main() → process exit. All connection goroutines
+// are killed before the drain logic in handleHandoverRequest runs.
+//
+// Instead of relying on query timing (fast machines complete queries before
+// the race triggers), this test holds an idle connection open. The idle
+// connection keeps the old CP's WaitGroup at 1, so the drain blocks until
+// we explicitly close the connection. This makes the test deterministic.
+func TestHandoverDrainsBeforeExit(t *testing.T) {
+	h := startControlPlane(t, defaultOpts())
+
+	db := h.openConn(t)
+	var warmup int
+	if err := db.QueryRow("SELECT 1").Scan(&warmup); err != nil {
+		t.Fatalf("Warmup query failed: %v", err)
+	}
+
+	// Trigger handover while the connection is idle in the pool.
+	// The old CP's handleConnection goroutine is blocked in ReadMessage,
+	// waiting for the next query. This keeps wg at 1, so drain blocks.
+	h.doHandover(t)
+	oldPid := h.cmd.Process.Pid
+
+	// Wait long enough for the race to manifest. Without the fix, main()
+	// returns within milliseconds of acceptLoop detecting the closed
+	// listener, killing the handleConnection goroutine.
+	time.Sleep(3 * time.Second)
+
+	// The old CP process must still be alive — it should be waiting for
+	// this idle connection to close (drain). Without the fix, main()
+	// already returned and the process exited.
+	if err := syscall.Kill(oldPid, 0); err != nil {
+		t.Fatalf("Old CP (pid %d) died while connection still open.\n"+
+			"acceptLoop returned and main() exited before drain completed.\n"+
+			"Logs:\n%s", oldPid, h.logBuf.String())
+	}
+	t.Logf("Old CP (pid %d) still alive 3s after handover — drain is active", oldPid)
+
+	// Close the connection to unblock the drain.
+	_ = db.Close()
+
+	// Verify the old CP went through the proper drain → exit path
+	if err := h.waitForLog("All connections drained after handover.", 30*time.Second); err != nil {
+		t.Fatalf("Old CP did not drain properly.\nLogs:\n%s", h.logBuf.String())
+	}
+	if err := h.waitForLog("Old control plane exiting after handover.", 10*time.Second); err != nil {
+		t.Fatalf("Old CP did not exit via handover path.\nLogs:\n%s", h.logBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- When the PG listener is closed during handover, `acceptLoop` returned, causing `RunControlPlane()` → `main()` to exit and kill all in-flight connection goroutines before the drain logic in `handleHandoverRequest` could complete
- Fix: replace `return` with `select {}` so the main goroutine blocks until the handover/shutdown handler calls `os.Exit(0)` after properly draining connections
- Added `TestHandoverDrainsBeforeExit` regression test that holds an idle connection open during handover and verifies the old CP stays alive to drain it

## Test plan
- [x] `TestHandoverDrainsBeforeExit` passes with fix, fails without it
- [x] All 9 existing handover tests pass
- [ ] Deploy to canary and verify `systemctl reload duckgres` preserves active psql sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)