### PR TITLE
fix: don't start metrics server in duckdb-service workers

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,7 +341,9 @@ func main() {
 			fatal("Failed to create data directory: " + err.Error())
 		}
 
-		initMetrics()
+		// No initMetrics() here — in control-plane mode, workers are spawned
+		// with --mode duckdb-service and would all fight over :9090. The
+		// control plane process owns the metrics endpoint.
 
 		duckdbservice.Run(duckdbservice.ServiceConfig{
 			ListenAddr:   listenAddr,


### PR DESCRIPTION
## Summary
- Workers are spawned by the control plane with `--mode duckdb-service`, and each was calling `initMetrics()` which tries to bind `:9090`
- With the retry loop from #201, every worker would spin forever retrying the port — the CP holds it and never releases it
- Fix: remove `initMetrics()` from the duckdb-service code path. The control plane owns the metrics endpoint; workers don't need their own

## Test plan
- [x] All controlplane tests pass
- [ ] Deploy and verify no metrics retry warnings from worker processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)