### PR TITLE
feat: expose DuckDB tunables (threads and memory limit)

### DIFF
--- a/.sprite
+++ b/.sprite
@@ -1,0 +1,4 @@
+{
+  "organization": "ducky",
+  "sprite": "hoge"
+}

--- a/controlplane/pool.go
+++ b/controlplane/pool.go
@@ -488,6 +488,8 @@ func buildConfigureRequest(cfg server.Config) *pb.ConfigureRequest {
 		TlsCertFile:   cfg.TLSCertFile,
 		TlsKeyFile:    cfg.TLSKeyFile,
 		Users:         cfg.Users,
+		DuckdbThreads:     int32(cfg.DuckDBThreads),
+		DuckdbMemoryLimit: cfg.DuckDBMemoryLimit,
 	}
 
 	if cfg.DuckLake.MetadataStore != "" {

--- a/controlplane/proto/worker.pb.go
+++ b/controlplane/proto/worker.pb.go
@@ -32,9 +32,12 @@ type ConfigureRequest struct {
 	// DuckLake configuration
 	Ducklake *DuckLakeConfig `protobuf:"bytes,6,opt,name=ducklake,proto3" json:"ducklake,omitempty"`
 	// Authentication - map of username -> password
-	Users         map[string]string `protobuf:"bytes,7,rep,name=users,proto3" json:"users,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Users map[string]string `protobuf:"bytes,7,rep,name=users,proto3" json:"users,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// DuckDB configuration
+	DuckdbThreads     int32  `protobuf:"varint,8,opt,name=duckdb_threads,json=duckdbThreads,proto3" json:"duckdb_threads,omitempty"`
+	DuckdbMemoryLimit string `protobuf:"bytes,9,opt,name=duckdb_memory_limit,json=duckdbMemoryLimit,proto3" json:"duckdb_memory_limit,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ConfigureRequest) Reset() {
@@ -114,6 +117,20 @@ func (x *ConfigureRequest) GetUsers() map[string]string {
 		return x.Users
 	}
 	return nil
+}
+
+func (x *ConfigureRequest) GetDuckdbThreads() int32 {
+	if x != nil {
+		return x.DuckdbThreads
+	}
+	return 0
+}
+
+func (x *ConfigureRequest) GetDuckdbMemoryLimit() string {
+	if x != nil {
+		return x.DuckdbMemoryLimit
+	}
+	return ""
 }
 
 type DuckLakeConfig struct {

--- a/controlplane/proto/worker.proto
+++ b/controlplane/proto/worker.proto
@@ -42,6 +42,10 @@ message ConfigureRequest {
 
   // Authentication - map of username -> password
   map<string, string> users = 7;
+
+  // DuckDB configuration
+  int32 duckdb_threads = 8;
+  string duckdb_memory_limit = 9;
 }
 
 message DuckLakeConfig {

--- a/controlplane/worker.go
+++ b/controlplane/worker.go
@@ -207,6 +207,9 @@ func (w *Worker) Configure(_ context.Context, req *pb.ConfigureRequest) (*pb.Con
 		TLSCertFile: req.TlsCertFile,
 		TLSKeyFile:  req.TlsKeyFile,
 		Users:       req.Users,
+
+		DuckDBThreads:     int(req.DuckdbThreads),
+		DuckDBMemoryLimit: req.DuckdbMemoryLimit,
 	}
 
 	if req.Ducklake != nil {


### PR DESCRIPTION
This PR adds support for configuring DuckDB threads and memory limit via CLI flags, environment variables, or config file. This allows for better resource management in different environments.