### PR TITLE
feat(controlplane): parallelize worker health checks and reduce default interval

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -60,7 +60,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		cfg.SocketDir = "/var/run/duckgres"
 	}
 	if cfg.HealthCheckInterval == 0 {
-		cfg.HealthCheckInterval = 5 * time.Second
+		cfg.HealthCheckInterval = 2 * time.Second
 	}
 
 	// Enforce secure defaults for control-plane mode.


### PR DESCRIPTION
This PR improves control plane reliability by parallelizing worker health checks, ensuring that slow or unresponsive workers do not delay checks for others. It also reduces the default health check interval from 5s to 2s for faster crash detection.