### PR TITLE
fix: increase default DuckDB thread count to 2x CPU

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -505,7 +505,7 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 	// Set DuckDB threads
 	threads := cfg.Threads
 	if threads == 0 {
-		threads = runtime.NumCPU()
+		threads = runtime.NumCPU() * 2
 	}
 	if _, err := db.Exec(fmt.Sprintf("SET threads = %d", threads)); err != nil {
 		slog.Warn("Failed to set DuckDB threads.", "threads", threads, "error", err)


### PR DESCRIPTION
Following the deep review, this PR increases the default DuckDB thread count from 1x to 2x the number of CPUs. This typically provides better query parallelism and throughput for DuckDB's analytical workloads.