### PR TITLE
Increase default MaxConnections to 1024

### DIFF
--- a/server/ratelimit.go
+++ b/server/ratelimit.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -28,7 +27,7 @@ func DefaultRateLimitConfig() RateLimitConfig {
 		FailedAttemptWindow: 5 * time.Minute,
 		BanDuration:         15 * time.Minute,
 		MaxConnectionsPerIP: 100,
-		MaxConnections:      runtime.NumCPU() * 2,
+		MaxConnections:      1024,
 	}
 }
 

--- a/server/ratelimit_test.go
+++ b/server/ratelimit_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net"
-	"runtime"
 	"testing"
 	"time"
 )
@@ -373,7 +372,7 @@ func TestDefaultRateLimitConfig(t *testing.T) {
 	if cfg.MaxConnectionsPerIP != 100 {
 		t.Errorf("MaxConnectionsPerIP = %d, want 100", cfg.MaxConnectionsPerIP)
 	}
-	if cfg.MaxConnections != runtime.NumCPU()*2 {
-		t.Errorf("MaxConnections = %d, want %d", cfg.MaxConnections, runtime.NumCPU()*2)
+	if cfg.MaxConnections != 1024 {
+		t.Errorf("MaxConnections = %d, want 1024", cfg.MaxConnections)
 	}
 }


### PR DESCRIPTION
The previous default of runtime.NumCPU() * 2 was too restrictive, especially for the control plane where TCP connections are held open while waiting in the worker queue. This caused premature 'too many concurrent connections' rejections even when worker slots were available or queuing was intended.

Increased the default to 1024 to provide a sane safety cap without breaking the queuing model.