### PR TITLE
Keep idle workers alive for reuse (fix Fivetran worker churn)

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -130,8 +130,10 @@ func (sm *SessionManager) DestroySession(pid int32) {
 		}
 	}
 
-	// Retire the dedicated worker (1:1 model)
-	sm.pool.RetireWorker(session.WorkerID)
+	// Release the worker back to the idle pool for reuse.
+	// The worker process stays alive so the next connection can skip
+	// extension loading and catalog attach.
+	sm.pool.ReleaseWorker(session.WorkerID)
 
 	slog.Debug("Session destroyed.", "pid", pid, "worker", session.WorkerID)
 

--- a/controlplane/worker_mgr_test.go
+++ b/controlplane/worker_mgr_test.go
@@ -258,7 +258,7 @@ func makeFakeWorker(t *testing.T, id int) (*ManagedWorker, func()) {
 }
 
 func TestAcquireWorkerBlocksUntilSlotAvailable(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 2)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 2, 0)
 
 	// Pre-populate 2 busy workers so the pool is at capacity.
 	w0, cleanup0 := makeFakeWorker(t, 0)
@@ -307,7 +307,7 @@ func TestAcquireWorkerBlocksUntilSlotAvailable(t *testing.T) {
 }
 
 func TestAcquireWorkerRespectsContextCancellation(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 1)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 1, 0)
 
 	// Fill the single semaphore slot.
 	pool.workerSem <- struct{}{}
@@ -325,7 +325,7 @@ func TestAcquireWorkerRespectsContextCancellation(t *testing.T) {
 }
 
 func TestAcquireWorkerUnlimitedWhenMaxZero(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 0)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 0, 0)
 
 	if pool.workerSem != nil {
 		t.Fatal("expected nil workerSem when maxWorkers=0")
@@ -344,7 +344,7 @@ func TestAcquireWorkerUnlimitedWhenMaxZero(t *testing.T) {
 }
 
 func TestAcquireWorkerShutdownUnblocksWaiters(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 1)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 1, 0)
 
 	// Fill the single semaphore slot.
 	pool.workerSem <- struct{}{}
@@ -371,7 +371,7 @@ func TestAcquireWorkerShutdownUnblocksWaiters(t *testing.T) {
 }
 
 func TestRetireWorkerIfNoSessions_ReleasesClaimOnFailure(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 1)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 1, 0)
 
 	// Manually inject a worker with 1 active session (as if AcquireWorker just returned it)
 	w, cleanup := makeFakeWorker(t, 1)
@@ -405,7 +405,7 @@ func TestRetireWorkerIfNoSessions_ReleasesClaimOnFailure(t *testing.T) {
 func TestAcquireWorker_AtomicClaimRace(t *testing.T) {
 	// Tests that two concurrent acquisitions don't pick the same idle worker.
 	const n = 5
-	pool := NewFlightWorkerPool(t.TempDir(), "", 10)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 10, 0)
 
 	// Pre-warm with n idle workers
 	for i := 1; i <= n; i++ {
@@ -439,7 +439,7 @@ func TestAcquireWorker_AtomicClaimRace(t *testing.T) {
 }
 
 func TestRetireWorker_ReleasesAllSessions(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 5)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 5, 0)
 
 	// Inject a worker with 2 sessions
 	w, cleanup := makeFakeWorker(t, 1)
@@ -466,7 +466,7 @@ func TestRetireWorker_ReleasesAllSessions(t *testing.T) {
 }
 
 func TestCrashReleasesSemaphoreSlots(t *testing.T) {
-	pool := NewFlightWorkerPool(t.TempDir(), "", 2)
+	pool := NewFlightWorkerPool(t.TempDir(), "", 2, 0)
 
 	// Create a worker that exits immediately (simulates crash).
 	cmd := exec.Command("true")

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type FileConfig struct {
 	MaxWorkers                int                 `yaml:"max_workers"`           // Max worker processes (control-plane mode)
 	MinWorkers                int                 `yaml:"min_workers"`           // Pre-warm worker count (control-plane mode)
 	WorkerQueueTimeout        string              `yaml:"worker_queue_timeout"`  // e.g., "5m"
+	WorkerIdleTTL             string              `yaml:"worker_idle_ttl"`       // e.g., "30s"
 	PassthroughUsers          []string            `yaml:"passthrough_users"` // Users that bypass transpiler + pg_catalog
 }
 
@@ -176,6 +177,7 @@ func main() {
 	minWorkers := flag.Int("min-workers", 0, "Pre-warm worker count at startup (control-plane mode) (env: DUCKGRES_MIN_WORKERS)")
 	maxWorkers := flag.Int("max-workers", 0, "Max worker processes, 0=unlimited (control-plane mode) (env: DUCKGRES_MAX_WORKERS)")
 	workerQueueTimeout := flag.String("worker-queue-timeout", "", "How long to wait for an available worker slot (e.g., '5m') (env: DUCKGRES_WORKER_QUEUE_TIMEOUT)")
+	workerIdleTTL := flag.String("worker-idle-ttl", "", "How long idle workers stay alive for reuse (e.g., '30s', '0' to disable) (env: DUCKGRES_WORKER_IDLE_TTL)")
 	socketDir := flag.String("socket-dir", "/var/run/duckgres", "Unix socket directory (control-plane mode)")
 	handoverSocket := flag.String("handover-socket", "", "Handover socket for graceful deployment (control-plane mode)")
 
@@ -300,6 +302,7 @@ func main() {
 		MinWorkers:                *minWorkers,
 		MaxWorkers:                *maxWorkers,
 		WorkerQueueTimeout:        *workerQueueTimeout,
+		WorkerIdleTTL:             *workerIdleTTL,
 		ACMEDomain:                *acmeDomain,
 		ACMEEmail:                 *acmeEmail,
 		ACMECacheDir:              *acmeCacheDir,
@@ -423,6 +426,7 @@ func main() {
 			ConfigPath:         *configFile,
 			HandoverSocket:     *handoverSocket,
 			WorkerQueueTimeout: resolved.WorkerQueueTimeout,
+			WorkerIdleTTL:      resolved.WorkerIdleTTL,
 			MetricsServer:      metricsSrv,
 		}
 		controlplane.RunControlPlane(cpCfg)


### PR DESCRIPTION
## Summary

- Workers are now released back to an idle pool on disconnect instead of being immediately killed
- The next connection reuses the warm worker instantly, skipping the full ~1.5s startup (extension loading, S3 secret creation, DuckLake catalog attach)
- Idle workers are automatically reaped after a configurable TTL (default 30s)
- Configurable via `--worker-idle-ttl`, `worker_idle_ttl` in YAML, or `DUCKGRES_WORKER_IDLE_TTL` env var (set to `0` to disable)

## Problem

Fivetran's connection pattern is rapid connect → query → disconnect cycles. In control-plane mode, every connection spawned a new worker process that had to load extensions, create S3 secrets, and attach the DuckLake catalog (~1.5s each). When the client disconnected, the worker was immediately killed. Logs showed 70+ workers spawned and killed in 35 seconds.

## How it works

- `DestroySession` now calls `ReleaseWorker` instead of `RetireWorker`
- `ReleaseWorker` decrements active sessions and marks idle timestamp — worker process stays alive
- `AcquireWorker` already had `findIdleWorkerLocked()` for pre-warmed workers — it now finds these released idle workers too
- Health check loop reaps workers idle longer than TTL
- When `worker_idle_ttl` is `0`, falls back to the old `RetireWorker` behavior

## Test plan

- [x] All existing tests pass (including `TestAcquireWorker_AtomicClaimRace` which exercises idle worker reuse)
- [ ] Deploy to staging and verify Fivetran sync completes without worker churn
- [ ] Verify idle workers are reaped after TTL expires
- [ ] Verify `--worker-idle-ttl 0` preserves old behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)