### PR TITLE
Increase default MaxConnectionsPerIP to 500

### DIFF
--- a/server/ratelimit.go
+++ b/server/ratelimit.go
@@ -26,7 +26,7 @@ func DefaultRateLimitConfig() RateLimitConfig {
 		MaxFailedAttempts:   5,
 		FailedAttemptWindow: 5 * time.Minute,
 		BanDuration:         15 * time.Minute,
-		MaxConnectionsPerIP: 100,
+		MaxConnectionsPerIP: 500,
 		MaxConnections:      1024,
 	}
 }

--- a/server/ratelimit_test.go
+++ b/server/ratelimit_test.go
@@ -369,8 +369,8 @@ func TestDefaultRateLimitConfig(t *testing.T) {
 	if cfg.BanDuration != 15*time.Minute {
 		t.Errorf("BanDuration = %v, want 15m", cfg.BanDuration)
 	}
-	if cfg.MaxConnectionsPerIP != 100 {
-		t.Errorf("MaxConnectionsPerIP = %d, want 100", cfg.MaxConnectionsPerIP)
+	if cfg.MaxConnectionsPerIP != 500 {
+		t.Errorf("MaxConnectionsPerIP = %d, want 500", cfg.MaxConnectionsPerIP)
 	}
 	if cfg.MaxConnections != 1024 {
 		t.Errorf("MaxConnections = %d, want 1024", cfg.MaxConnections)


### PR DESCRIPTION
Logs showed connections being rejected from IP addresses like 35.234.176.144 with 'too many connections from your IP address'. 

High-concurrency analytical clients (like Fivetran) often open many parallel connections. Increasing the default limit from 100 to 500 provides more headroom for these workloads while still protecting against simple connection floods.