### PR TITLE
Demote noisy io.EOF startup logs to DEBUG

### DIFF
--- a/server/worker.go
+++ b/server/worker.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -195,7 +196,11 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 	// Read startup message (sent by client after TLS handshake)
 	params, err := readStartupMessage(reader)
 	if err != nil {
-		slog.Error("Failed to read startup message", "error", err)
+		if err == io.EOF || errors.Is(err, io.EOF) {
+			slog.Debug("Client closed connection after TLS handshake but before sending startup message.")
+		} else {
+			slog.Error("Failed to read startup message", "error", err)
+		}
 		return ExitError
 	}
 


### PR DESCRIPTION
TCP health checks and probes frequently open a connection and close it immediately before sending a startup message. This results in an 'io.EOF' error when reading the 4-byte length header.

Previously, these were logged at ERROR level, creating noise in production logs. This PR demotes these specific errors to DEBUG level across the control plane and worker processes while preserving ERROR logging for other types of read failures.