### PR TITLE
Cap default max_workers by CPU count

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -131,12 +132,13 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	memBudget = tempRebalancer.memoryBudget // capture auto-detected value
 
 	// If max_workers is not set, derive a reasonable concurrency cap from
-	// the memory budget (budget / 256MB).
+	// the memory budget and CPU count.
 	if maxWorkers == 0 {
 		maxWorkers = tempRebalancer.DefaultMaxWorkers()
-		slog.Info("Derived max_workers from memory budget.",
+		slog.Info("Derived max_workers from memory budget and CPU count.",
 			"max_workers", maxWorkers,
-			"memory_budget", formatBytes(memBudget))
+			"memory_budget", formatBytes(memBudget),
+			"num_cpu", runtime.NumCPU())
 	}
 
 	rebalancer := NewMemoryRebalancer(memBudget, 0, nil, cfg.MemoryRebalance)


### PR DESCRIPTION
## Summary

- `DefaultMaxWorkers()` previously only considered memory (`budget / 256MB`), which derived 24 workers on an m7g.large (2 vCPUs, 8GB RAM)
- 22+ DuckDB worker processes on 2 vCPUs caused CPU starvation, cascading health check `DeadlineExceeded` timeouts, worker crashes, and force-kills
- Now takes `min(budget/256MB, numCPU*4)` with a floor of 1 — caps at 8 workers on m7g.large instead of 24

## Test plan

- [x] `TestDefaultMaxWorkers` updated with table-driven tests covering memory-limited, CPU-limited, equal, floor, and large instance cases
- [x] All `controlplane` tests pass
- [ ] Deploy to m7g.large and verify health check timeouts stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)