### PR TITLE
Ignore SIGPIPE to prevent worker crashes on broken network connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,6 +135,12 @@ func initMetrics() *http.Server {
 }
 
 func main() {
+	// Ignore SIGPIPE to prevent DuckDB's C++ code (and libraries like libpq
+	// inside DuckLake) from crashing the process when a network connection
+	// drops mid-query. Go already converts EPIPE to errors on Write; the
+	// default SIGPIPE handler is a legacy Unix footgun that kills the process.
+	signal.Ignore(syscall.SIGPIPE)
+
 	// Set version on server package so catalog macros can expose it
 	server.SetProcessVersion(version)
 


### PR DESCRIPTION
## Summary

- Adds `signal.Ignore(syscall.SIGPIPE)` at the top of `main()`, before any mode branching, so it covers all run modes (standalone, control-plane, duckdb-service, child worker)
- Prevents DuckDB's C++ code and libpq (inside the DuckLake extension) from crashing the worker process when a network connection drops mid-query
- Go already converts EPIPE to errors on Write calls, so ignoring the signal is safe and lets DuckDB handle broken connections gracefully via error returns

## Context

A production SQLMesh restate job (97/204 batches) was killed when worker 6 crashed with `signal: broken pipe` (SIGPIPE) during a large INSERT query reading from DuckLake. The DuckLake extension uses libpq for PostgreSQL metadata and S3 for data — if either connection drops during a long-running query, the C++ code writes to the dead socket, receives SIGPIPE, and the default handler terminates the process.

No OOM kill was found in dmesg/journalctl, no core dump was generated, and the host had ~393GB memory available — ruling out memory pressure. The `signal: broken pipe` exit status directly indicates SIGPIPE.

## Test plan

- [x] `go build` succeeds
- [ ] Deploy and verify long-running DuckLake queries survive transient network blips instead of crashing the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)