### PR TITLE
Add Docker image build and push to ECR

### DIFF
--- a/.github/workflows/container-image-cd.yml
+++ b/.github/workflows/container-image-cd.yml
@@ -21,29 +21,31 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v4
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
               with:
                   role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
                   aws-region: us-east-1
 
             - name: Login to Amazon ECR
               id: aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
             - name: Build and push container image
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   push: true
-                  tags: |
-                      ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-                      ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                  platforms: linux/amd64,linux/arm64
+                  tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
                   build-args: |
                       VERSION=build-${{ github.sha }}
                       COMMIT=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ RUN CGO_ENABLED=1 go build -ldflags "-X main.version=${VERSION} -X main.commit=$
 
 FROM debian:bookworm-slim
 
+RUN groupadd -r duckgres && useradd -r -g duckgres -d /app duckgres
+
 WORKDIR /app
 COPY --from=builder /build/duckgres .
-RUN mkdir -p data certs
+RUN mkdir -p data certs && chown -R duckgres:duckgres /app
+
+USER duckgres
 
 EXPOSE 5432 9090
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds the duckgres Docker image and pushes it to ECR on every push to `main`
- Uses the same ECR registry as the rest of PostHog prod (`795637471508.dkr.ecr.us-east-1.amazonaws.com/duckgres`)
- Tags: `latest` (floating) + `$GITHUB_SHA` (immutable per commit)
- Auth: GitHub OIDC via `AWS_ECR_PUBLISH_IAM_ROLE` (same pattern as posthog, billing, etc.)
- Uses GitHub Actions cache for Docker layer caching

## Prerequisite: infra changes needed
This workflow won't work until these changes are applied in `posthog-cloud-infra`:

1. **ECR repository** - add to `terraform/environments/aws-accnt-root/ecr.tf`:
   ```hcl
   module "ecr_duckgres" {
     source               = "../../modules/ecr"
     name                 = "duckgres"
     image_tag_mutability = "MUTABLE"
     retention            = 14
   }
   ```
   And add to `locals.ecr_repositories`:
   ```hcl
   duckgres = module.ecr_duckgres.ecr_name
   ```

2. **OIDC trust policy** - add to `terraform/environments/aws-accnt-root/github-ecr.tf` `allowed_subjects`:
   ```hcl
   "repo:PostHog/duckgres:*",
   ```

3. **Secret scope** - add `"duckgres"` to `AWS_ECR_PUBLISH_IAM_ROLE` selected_repositories in `terraform/environments/github/org/secrets/terragrunt.hcl`

## Test plan
- [ ] Apply infra changes above
- [ ] Merge this PR and verify the workflow runs successfully on the next push to main
- [ ] Verify image is pullable: `docker pull 795637471508.dkr.ecr.us-east-1.amazonaws.com/duckgres:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)