### PR TITLE
Fix search_path failure leaving session in aborted transaction state

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -520,6 +520,8 @@ func dropTemporary(ctx context.Context, conn *sql.Conn, query, dropFmt string) {
 func initSearchPath(conn *sql.Conn, username string) {
 	if _, err := conn.ExecContext(context.Background(), fmt.Sprintf("SET search_path = '%s,main'", username)); err != nil {
 		slog.Debug("User schema not found, using default search_path.", "user", username)
+		// Clear the aborted transaction state before retrying.
+		_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
 		if _, err := conn.ExecContext(context.Background(), "SET search_path = 'main'"); err != nil {
 			slog.Warn("Failed to set search_path for session.", "user", username, "error", err)
 		}


### PR DESCRIPTION
## Summary

- When a user's schema doesn't exist (common in DuckLake mode), `initSearchPath` runs `SET search_path = 'username,main'` which fails and puts the DuckDB connection into an aborted transaction state
- Without a `ROLLBACK`, the fallback `SET search_path = 'main'` also fails, and every subsequent command on that session fails with "Current transaction is aborted (please ROLLBACK)" — including `SET memory_limit`, `SET threads`, `BEGIN`, user queries, and session cleanup
- Fix: issue a `ROLLBACK` after the failed `SET` to clear the aborted state before retrying

## Test plan

- [ ] Deploy to a DuckLake environment where user schema doesn't exist and verify sessions work correctly
- [ ] Verify `search_path` fallback to `'main'` succeeds after the `ROLLBACK`
- [ ] Confirm `SET memory_limit` and `SET threads` no longer fail on session init

🤖 Generated with [Claude Code](https://claude.com/claude-code)