### PR TITLE
Pass through DuckDB SHOW commands (TABLES, DATABASES, ALL)

### DIFF
--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -690,6 +690,46 @@ func TestTranspile_SetShow(t *testing.T) {
 		}
 	})
 
+	// Test DuckDB SHOW commands pass through unchanged
+	t.Run("SHOW TABLES passthrough", func(t *testing.T) {
+		result, err := tr.Transpile("SHOW TABLES")
+		if err != nil {
+			t.Fatalf("Transpile error: %v", err)
+		}
+		if result.Error != nil {
+			t.Fatalf("SHOW TABLES should not error, got: %v", result.Error)
+		}
+		if !strings.Contains(strings.ToUpper(result.SQL), "SHOW TABLES") {
+			t.Errorf("SHOW TABLES should pass through, got: %q", result.SQL)
+		}
+	})
+
+	t.Run("SHOW DATABASES passthrough", func(t *testing.T) {
+		result, err := tr.Transpile("SHOW DATABASES")
+		if err != nil {
+			t.Fatalf("Transpile error: %v", err)
+		}
+		if result.Error != nil {
+			t.Fatalf("SHOW DATABASES should not error, got: %v", result.Error)
+		}
+		if !strings.Contains(strings.ToUpper(result.SQL), "SHOW DATABASES") {
+			t.Errorf("SHOW DATABASES should pass through, got: %q", result.SQL)
+		}
+	})
+
+	t.Run("SHOW ALL passthrough", func(t *testing.T) {
+		result, err := tr.Transpile("SHOW ALL")
+		if err != nil {
+			t.Fatalf("Transpile error: %v", err)
+		}
+		if result.Error != nil {
+			t.Fatalf("SHOW ALL should not error, got: %v", result.Error)
+		}
+		if !strings.Contains(strings.ToUpper(result.SQL), "SHOW ALL") {
+			t.Errorf("SHOW ALL should pass through, got: %q", result.SQL)
+		}
+	})
+
 	// Test SET application_name is ignored
 	t.Run("SET application_name ignored", func(t *testing.T) {
 		result, err := tr.Transpile("SET application_name = 'fivetran'")


### PR DESCRIPTION
## Summary

- `SHOW TABLES`, `SHOW DATABASES`, and `SHOW ALL` were rejected with "unrecognized configuration parameter" because the SetShow transpiler catch-all treated any single-word SHOW argument as a PostgreSQL config parameter
- Added a passthrough list for DuckDB-specific SHOW commands so they're forwarded to DuckDB unchanged
- `SHOW ALL TABLES` already worked via the `FallbackToNative` path (pg_query can't parse it)

## Test plan

- [x] Added unit tests for `SHOW TABLES`, `SHOW DATABASES`, `SHOW ALL` passthrough
- [x] Verified manually via psql
- [x] `golangci-lint` clean