### PR TITLE
Fix multi-CP warm worker churn and stale idle row leak

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -422,6 +422,20 @@ func (cs *ConfigStore) GetControlPlaneInstance(id string) (*ControlPlaneInstance
 	return &instance, nil
 }
 
+// ListActiveControlPlaneInstanceIDs returns the IDs of control-plane instances
+// currently in the active state. Used by the K8s pool's startup orphan sweep
+// to distinguish "owned by a live peer" from "owned by a dead CP" without
+// needing N round-trips.
+func (cs *ConfigStore) ListActiveControlPlaneInstanceIDs() ([]string, error) {
+	var ids []string
+	if err := cs.db.Table(cs.runtimeTable((&ControlPlaneInstance{}).TableName())).
+		Where("state = ?", ControlPlaneInstanceStateActive).
+		Pluck("id", &ids).Error; err != nil {
+		return nil, fmt.Errorf("list active control plane instance ids: %w", err)
+	}
+	return ids, nil
+}
+
 // ExpireControlPlaneInstances marks stale control-plane instance rows as expired.
 func (cs *ConfigStore) ExpireControlPlaneInstances(cutoff time.Time) (int64, error) {
 	now := time.Now()
@@ -464,6 +478,26 @@ func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
 		return fmt.Errorf("upsert worker record: %w", err)
 	}
 	return nil
+}
+
+// ListWorkerRecordsByStatesBefore returns worker rows in any of the given
+// states whose updated_at is at or before the given cutoff. The age filter is
+// what makes this safe to use against in-flight spawns: callers pass a cutoff
+// well in the past (e.g. now - 30s) so a row that another CP is currently
+// touching will not appear in the result.
+func (cs *ConfigStore) ListWorkerRecordsByStatesBefore(states []WorkerState, updatedBefore time.Time) ([]WorkerRecord, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+	var workers []WorkerRecord
+	if err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("state IN ?", states).
+		Where("updated_at <= ?", updatedBefore).
+		Order("worker_id ASC").
+		Find(&workers).Error; err != nil {
+		return nil, fmt.Errorf("list worker records by state before: %w", err)
+	}
+	return workers, nil
 }
 
 // GetWorkerRecord returns a runtime worker row by worker id.

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -169,8 +169,9 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		pool.cpInstanceID = pool.cpID
 	}
 
-	// Clean up orphaned worker pods from previous CP instances before starting.
-	pool.cleanupOrphanedWorkerPods()
+	// Clean up orphaned worker pods from dead CP instances and reconcile any
+	// DB rows that no longer have a backing pod.
+	pool.cleanupOrphanedWorkers()
 
 	// Start SharedInformer for watching worker pods
 	pool.startInformer()
@@ -181,11 +182,29 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 	return pool, nil
 }
 
-// cleanupOrphanedWorkerPods deletes worker pods that were created by a
-// previous control plane instance. These orphans occupy nodes and prevent
-// the current CP from scheduling its own workers. Deletes run concurrently
-// (bounded by retireSem) so cleanup doesn't stall on slow API responses.
-func (p *K8sWorkerPool) cleanupOrphanedWorkerPods() {
+// staleWorkerRowGracePeriod is the minimum age of a worker row before phase 2
+// of the orphan sweep is willing to mark it as lost. The owner-active filter
+// is the primary safety net, but the time filter offers belt-and-braces in
+// case a future code path persists an idle row before its pod is K8s-visible.
+const staleWorkerRowGracePeriod = 30 * time.Second
+
+// cleanupOrphanedWorkers reconciles K8s pods and config-store worker rows
+// against the live control-plane membership. It runs once at CP startup in
+// two phases:
+//
+//  1. Phase 1 (K8s → DB direction): list every worker pod in the namespace
+//     and delete any whose duckgres/cp-instance-id label points at a control
+//     plane that is *not* in the active set. Live peers' pods are explicitly
+//     left alone — without this filter the sweep would wipe warm workers
+//     spawned by alive peer CPs every time a deployment rolls.
+//
+//  2. Phase 2 (DB → K8s direction): list idle and spawning worker rows and
+//     mark as lost any whose pod is gone (or was just deleted in phase 1)
+//     and whose owning CP is not active. This rescues stale `idle` rows
+//     left behind when a CP died abruptly without retiring its warm workers
+//     — those rows have an empty owner_cp_instance_id by design and are
+//     unreachable from the periodic orphan janitor's cp_instances join.
+func (p *K8sWorkerPool) cleanupOrphanedWorkers() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -197,13 +216,36 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods() {
 		return
 	}
 
-	myInstanceID := controlPlaneIDLabelValue(p.cpInstanceID)
+	// Build the set of currently-active CP instance IDs (both raw and label-
+	// sanitized forms) so phase 1 can compare against pod labels and phase 2
+	// can compare against owner_cp_instance_id columns.
+	activeCPIDs := map[string]bool{}
+	activeCPLabels := map[string]bool{}
+	if p.runtimeStore != nil {
+		ids, err := p.runtimeStore.ListActiveControlPlaneInstanceIDs()
+		if err != nil {
+			slog.Warn("Failed to list active control-plane instances for orphan cleanup; skipping sweep to avoid wiping live peers.", "error", err)
+			return
+		}
+		for _, id := range ids {
+			activeCPIDs[id] = true
+			activeCPLabels[controlPlaneIDLabelValue(id)] = true
+		}
+	}
+	// Always treat the current CP as active so the sweep is safe in
+	// non-runtime-store deployments and during the brief window before this
+	// CP's heartbeat is first written.
+	activeCPIDs[p.cpInstanceID] = true
+	activeCPLabels[controlPlaneIDLabelValue(p.cpInstanceID)] = true
+
+	// Phase 1: delete pods owned by dead CPs.
 	gracePeriod := int64(10)
 	var wg sync.WaitGroup
 	var deleted atomic.Int32
+	var deletedNames sync.Map
 	for _, pod := range pods.Items {
 		podInstanceID := pod.Labels["duckgres/cp-instance-id"]
-		if podInstanceID == myInstanceID || podInstanceID == "" {
+		if podInstanceID == "" || activeCPLabels[podInstanceID] {
 			continue
 		}
 		wg.Add(1)
@@ -212,19 +254,68 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods() {
 			p.retireSem <- struct{}{}
 			defer func() { <-p.retireSem }()
 
-			slog.Info("Deleting orphaned worker pod from previous CP.", "pod", podName, "old_cp", oldCP)
+			slog.Info("Deleting orphaned worker pod from dead CP.", "pod", podName, "old_cp", oldCP)
 			if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 				GracePeriodSeconds: &gracePeriod,
 			}); err != nil {
 				slog.Warn("Failed to delete orphaned worker pod.", "pod", podName, "error", err)
-			} else {
-				deleted.Add(1)
+				return
 			}
+			deleted.Add(1)
+			deletedNames.Store(podName, struct{}{})
 		}(pod.Name, podInstanceID)
 	}
 	wg.Wait()
 	if n := deleted.Load(); n > 0 {
 		slog.Info("Cleaned up orphaned worker pods.", "count", n)
+	}
+
+	// Phase 2: reconcile idle/spawning DB rows against the K8s pod set.
+	if p.runtimeStore == nil {
+		return
+	}
+	rows, err := p.runtimeStore.ListWorkerRecordsByStatesBefore(
+		[]configstore.WorkerState{configstore.WorkerStateIdle, configstore.WorkerStateSpawning},
+		time.Now().Add(-staleWorkerRowGracePeriod),
+	)
+	if err != nil {
+		slog.Warn("Failed to list worker records for stale row sweep.", "error", err)
+		return
+	}
+	livePodNames := map[string]bool{}
+	for _, pod := range pods.Items {
+		if _, gone := deletedNames.Load(pod.Name); gone {
+			continue
+		}
+		livePodNames[pod.Name] = true
+	}
+	now := time.Now()
+	var marked int
+	for _, row := range rows {
+		if livePodNames[row.PodName] {
+			continue // pod is alive in K8s; row reflects reality
+		}
+		if row.OwnerCPInstanceID != "" && activeCPIDs[row.OwnerCPInstanceID] {
+			continue // a live owner is responsible for this row's lifecycle
+		}
+		record := row
+		record.State = configstore.WorkerStateLost
+		record.RetireReason = "pod_missing"
+		record.LastHeartbeatAt = now
+		if err := p.runtimeStore.UpsertWorkerRecord(&record); err != nil {
+			slog.Warn("Failed to mark stale worker row lost.", "worker_id", row.WorkerID, "error", err)
+			continue
+		}
+		slog.Info("Marked stale worker row lost.",
+			"worker_id", row.WorkerID,
+			"pod", row.PodName,
+			"prior_state", row.State,
+			"prior_owner", row.OwnerCPInstanceID,
+		)
+		marked++
+	}
+	if marked > 0 {
+		slog.Info("Reconciled stale worker rows.", "count", marked)
 	}
 }
 

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -56,6 +56,13 @@ type captureRuntimeWorkerStore struct {
 	takeOverOwnerCPID     string
 	takeOverOrgID         string
 	takeOverExpectedEpoch int64
+	activeCPIDs           []string
+	activeCPIDsErr        error
+	stateBeforeRows       []configstore.WorkerRecord
+	stateBeforeErr        error
+	stateBeforeCalls      int
+	stateBeforeStates     []configstore.WorkerState
+	stateBeforeCutoff     time.Time
 }
 
 func (s *captureRuntimeWorkerStore) UpsertWorkerRecord(record *configstore.WorkerRecord) error {
@@ -181,6 +188,43 @@ func (s *captureRuntimeWorkerStore) TakeOverWorker(workerID int, ownerCPInstance
 	}
 	record := *s.takenOver
 	return &record, nil
+}
+
+func (s *captureRuntimeWorkerStore) ListActiveControlPlaneInstanceIDs() ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeCPIDsErr != nil {
+		return nil, s.activeCPIDsErr
+	}
+	out := make([]string, len(s.activeCPIDs))
+	copy(out, s.activeCPIDs)
+	return out, nil
+}
+
+func (s *captureRuntimeWorkerStore) ListWorkerRecordsByStatesBefore(states []configstore.WorkerState, updatedBefore time.Time) ([]configstore.WorkerRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stateBeforeCalls++
+	s.stateBeforeStates = append([]configstore.WorkerState(nil), states...)
+	s.stateBeforeCutoff = updatedBefore
+	if s.stateBeforeErr != nil {
+		return nil, s.stateBeforeErr
+	}
+	stateSet := make(map[configstore.WorkerState]bool, len(states))
+	for _, st := range states {
+		stateSet[st] = true
+	}
+	var out []configstore.WorkerRecord
+	for _, r := range s.stateBeforeRows {
+		if !stateSet[r.State] {
+			continue
+		}
+		if !r.UpdatedAt.IsZero() && r.UpdatedAt.After(updatedBefore) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
 }
 
 func newTestK8sPool(t *testing.T, maxWorkers int) (*K8sWorkerPool, *fake.Clientset) {
@@ -1861,11 +1905,13 @@ func TestSetWorkerResources(t *testing.T) {
 	}
 }
 
-func TestCleanupOrphanedWorkerPods(t *testing.T) {
+func TestCleanupOrphanedWorkers_DeletesPodsFromDeadCPs(t *testing.T) {
 	pool, cs := newTestK8sPool(t, 5)
 	pool.cpInstanceID = "new-cp:boot-123"
 
-	// Create pods: 2 from old CP, 1 from current CP, 1 with no instance ID
+	// Create pods: 2 from a dead CP, 1 from current CP, 1 unlabeled.
+	// No runtimeStore: the sweep falls back to "current CP only is active",
+	// matching the original single-CP behavior.
 	for _, tc := range []struct {
 		name       string
 		instanceID string
@@ -1887,7 +1933,7 @@ func TestCleanupOrphanedWorkerPods(t *testing.T) {
 		}
 	}
 
-	pool.cleanupOrphanedWorkerPods()
+	pool.cleanupOrphanedWorkers()
 
 	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
 		LabelSelector: "app=duckgres-worker",
@@ -1898,19 +1944,228 @@ func TestCleanupOrphanedWorkerPods(t *testing.T) {
 		remaining[p.Name] = true
 	}
 
-	// Old CP pods should be deleted
 	if remaining["duckgres-worker-old-1"] {
 		t.Error("expected old-1 to be deleted")
 	}
 	if remaining["duckgres-worker-old-2"] {
 		t.Error("expected old-2 to be deleted")
 	}
-	// Current CP pod and unlabeled pod should survive
 	if !remaining["duckgres-worker-mine"] {
 		t.Error("expected mine to survive")
 	}
 	if !remaining["duckgres-worker-nolabel"] {
 		t.Error("expected nolabel to survive")
+	}
+}
+
+func TestCleanupOrphanedWorkers_PreservesLivePeerPods(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	pool.cpInstanceID = "cp-self:boot-123"
+	livePeerID := "cp-peer:boot-456"
+	deadCPID := "cp-dead:boot-789"
+
+	store := &captureRuntimeWorkerStore{
+		activeCPIDs: []string{"cp-self:boot-123", livePeerID},
+	}
+	pool.runtimeStore = store
+
+	for _, tc := range []struct {
+		name       string
+		instanceID string
+	}{
+		{"duckgres-worker-self", controlPlaneIDLabelValue("cp-self:boot-123")},
+		{"duckgres-worker-peer", controlPlaneIDLabelValue(livePeerID)},
+		{"duckgres-worker-dead", controlPlaneIDLabelValue(deadCPID)},
+	} {
+		_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tc.name,
+				Namespace: "default",
+				Labels: map[string]string{
+					"app":                     "duckgres-worker",
+					"duckgres/cp-instance-id": tc.instanceID,
+				},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pool.cleanupOrphanedWorkers()
+
+	remaining := map[string]bool{}
+	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=duckgres-worker",
+	})
+	for _, p := range pods.Items {
+		remaining[p.Name] = true
+	}
+	if !remaining["duckgres-worker-self"] {
+		t.Error("expected current CP's pod to survive")
+	}
+	if !remaining["duckgres-worker-peer"] {
+		t.Error("expected live peer CP's pod to survive — this is the multi-CP regression")
+	}
+	if remaining["duckgres-worker-dead"] {
+		t.Error("expected dead CP's pod to be deleted")
+	}
+}
+
+func TestCleanupOrphanedWorkers_MarksStaleIdleRowsLost(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	pool.cpInstanceID = "cp-self:boot-123"
+
+	// One pod actually exists in K8s (the live one). Two stale DB rows
+	// remain from a previous CP whose pods are long gone — this is the
+	// exact failure mode where idle rows with empty owner_cp_instance_id
+	// can't be reaped by the periodic orphan janitor.
+	livePodName := "duckgres-worker-self-1"
+	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      livePodName,
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                     "duckgres-worker",
+				"duckgres/cp-instance-id": controlPlaneIDLabelValue("cp-self:boot-123"),
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := time.Now().Add(-2 * time.Hour)
+	store := &captureRuntimeWorkerStore{
+		activeCPIDs: []string{"cp-self:boot-123"},
+		stateBeforeRows: []configstore.WorkerRecord{
+			{
+				WorkerID:          1,
+				PodName:           livePodName,
+				State:             configstore.WorkerStateIdle,
+				OwnerCPInstanceID: "",
+				UpdatedAt:         stale,
+			},
+			{
+				WorkerID:          2,
+				PodName:           "duckgres-worker-stale-2",
+				State:             configstore.WorkerStateIdle,
+				OwnerCPInstanceID: "",
+				UpdatedAt:         stale,
+			},
+			{
+				WorkerID:          3,
+				PodName:           "duckgres-worker-stale-3",
+				State:             configstore.WorkerStateIdle,
+				OwnerCPInstanceID: "",
+				UpdatedAt:         stale,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	pool.cleanupOrphanedWorkers()
+
+	upserted := store.snapshot()
+	if len(upserted) != 2 {
+		t.Fatalf("expected 2 stale rows to be marked lost, got %d: %#v", len(upserted), upserted)
+	}
+	gotIDs := map[int]configstore.WorkerRecord{}
+	for _, r := range upserted {
+		gotIDs[r.WorkerID] = r
+	}
+	for _, id := range []int{2, 3} {
+		r, ok := gotIDs[id]
+		if !ok {
+			t.Errorf("expected worker %d to be marked lost", id)
+			continue
+		}
+		if r.State != configstore.WorkerStateLost {
+			t.Errorf("worker %d: expected state lost, got %q", id, r.State)
+		}
+		if r.RetireReason != "pod_missing" {
+			t.Errorf("worker %d: expected retire_reason pod_missing, got %q", id, r.RetireReason)
+		}
+	}
+	if _, touched := gotIDs[1]; touched {
+		t.Error("expected worker 1 (live pod) to be left untouched")
+	}
+}
+
+func TestCleanupOrphanedWorkers_PreservesInflightSpawnsByLivePeers(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	pool.cpInstanceID = "cp-self:boot-123"
+	peerID := "cp-peer:boot-456"
+
+	stale := time.Now().Add(-2 * time.Hour)
+	store := &captureRuntimeWorkerStore{
+		activeCPIDs: []string{"cp-self:boot-123", peerID},
+		stateBeforeRows: []configstore.WorkerRecord{
+			// In-flight spawn owned by a live peer: pod isn't visible to us
+			// yet (e.g. slow image pull), but the peer is alive and will
+			// finish or retire it. Must NOT be touched.
+			{
+				WorkerID:          11,
+				PodName:           "duckgres-worker-peer-inflight",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: peerID,
+				UpdatedAt:         stale,
+			},
+			// Genuinely abandoned spawn from a dead CP — pod gone, owner gone.
+			{
+				WorkerID:          12,
+				PodName:           "duckgres-worker-dead-spawn",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: "cp-dead:boot-789",
+				UpdatedAt:         stale,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	pool.cleanupOrphanedWorkers()
+
+	upserted := store.snapshot()
+	if len(upserted) != 1 || upserted[0].WorkerID != 12 {
+		t.Fatalf("expected only worker 12 (dead CP's spawn) to be marked lost, got %#v", upserted)
+	}
+	if upserted[0].State != configstore.WorkerStateLost {
+		t.Fatalf("expected lost state, got %q", upserted[0].State)
+	}
+}
+
+func TestCleanupOrphanedWorkers_GracePeriodProtectsFreshRows(t *testing.T) {
+	// The mock honors the cutoff itself, so passing a fresh updated_at row
+	// exercises the grace-period filter end-to-end: the sweep asks for rows
+	// older than (now - 30s), the mock filters them out, and nothing is
+	// marked lost.
+	pool, _ := newTestK8sPool(t, 5)
+	pool.cpInstanceID = "cp-self:boot-123"
+
+	store := &captureRuntimeWorkerStore{
+		activeCPIDs: []string{"cp-self:boot-123"},
+		stateBeforeRows: []configstore.WorkerRecord{
+			{
+				WorkerID:          21,
+				PodName:           "duckgres-worker-fresh",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: "",
+				UpdatedAt:         time.Now(),
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	pool.cleanupOrphanedWorkers()
+
+	if rows := store.snapshot(); len(rows) != 0 {
+		t.Fatalf("expected fresh row to be skipped by grace period, got upserts: %#v", rows)
+	}
+	if store.stateBeforeCalls != 1 {
+		t.Fatalf("expected one ListWorkerRecordsByStatesBefore call, got %d", store.stateBeforeCalls)
+	}
+	if cutoff := store.stateBeforeCutoff; cutoff.IsZero() || time.Since(cutoff) < staleWorkerRowGracePeriod {
+		t.Fatalf("expected cutoff at least %s in the past, got %v (now-cutoff=%s)", staleWorkerRowGracePeriod, cutoff, time.Since(cutoff))
 	}
 }
 

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -81,6 +81,8 @@ type RuntimeWorkerStore interface {
 	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
+	ListActiveControlPlaneInstanceIDs() ([]string, error)
+	ListWorkerRecordsByStatesBefore(states []configstore.WorkerState, updatedBefore time.Time) ([]configstore.WorkerRecord, error)
 }
 
 // K8sPoolFactory creates a K8sWorkerPool. Registered at init time by the


### PR DESCRIPTION
## Summary

In a multi-replica control-plane deployment with shared neutral warm workers, two coupled bugs combine to keep the warm pool stuck at one worker even with \`DUCKGRES_K8S_SHARED_WARM_TARGET=3\`. Diagnosed today live in the \`duckgres\` namespace — DB had 3 \`idle\` rows, K8s had 1 pod, the discrepancy was self-reinforcing.

### Bug 1 — \`cleanupOrphanedWorkerPods\` deletes pods owned by live peers

The startup sweep added in #403 deletes any worker pod whose \`duckgres/cp-instance-id\` label doesn't match the current CP, with no check for whether that other CP is still alive. In a 3-replica deploy each new CP that joins wipes the warm workers spawned by its alive peers, leaving only the worker spawned after the *last* CP joined.

Timeline from a real CP log (\`jkfqd\`):

\`\`\`
12:42:51 jkfqd spawned 3056
12:47:48 z2gdw started   ←  new CP joined
12:47:49 worker 3056 terminated phase=Succeeded   (z2gdw killed it as orphan)
12:47:54 jkfqd respawned 3057
12:48:05 8tqp2 started   ←  new CP joined
12:48:06 worker 3057 terminated phase=Succeeded   (8tqp2 killed it)
12:48:08 jkfqd spawned 3058   (no more new CPs → 3058 survives)
\`\`\`

Graceful CP shutdown already retires its own workers via \`drainAndShutdown → ShutdownAll → markWorkerRetiredLocked\` (#404 and existing code) — the K8s startup scan only needs to handle abrupt-death cases, not live peers.

### Bug 2 — Idle rows with empty \`owner_cp_instance_id\` are unrecoverable

\`workerRecordFor\` intentionally clears \`owner_cp_instance_id\` when transitioning a worker to \`idle\` because idle workers belong to the shared neutral pool and aren't owned by any CP:

\`\`\`go
if state == configstore.WorkerStateIdle {
    record.OwnerCPInstanceID = \"\"
    record.OrgID = \"\"
}
\`\`\`

Side effect: \`ListOrphanedWorkers\` finds expired-CP workers via \`JOIN cp_instances ON cp.id = w.owner_cp_instance_id\`. Idle rows with empty owner can never match. When bug 1 (or any abrupt CP death) leaves a stale idle row whose pod is gone, **nothing** in the system reaps it:

- The orphan janitor can't see it (no CP join match).
- The K8s startup label scan deletes pods, never DB rows.
- The hot-idle TTL only handles \`hot_idle\`, not \`idle\`.

\`countNeutralWarmWorkers\` keeps counting it forever, blocking warm spawns because \`target <= count\` is satisfied by ghost rows. In the duckgres-dev cluster right now there are stale \`idle\` rows from \`duckgres-7c9f985595-jml9r\` (a CP that died ~10 hours ago) plus the live \`jkfqd-3058\` row → count=3, target=3 → no spawn. Forever.

## Fix

\`cleanupOrphanedWorkers\` (renamed from \`cleanupOrphanedWorkerPods\`) now runs in two phases at CP startup, sharing one K8s pod list and one \`cp_instances\` snapshot:

**Phase 1** — list active control-plane instances from \`cp_instances\` and only delete worker pods whose \`cp-instance-id\` label is NOT in the active set. Live peers' workers are explicitly preserved.

**Phase 2** — list \`idle\`+\`spawning\` worker rows older than a 30s grace period and mark as \`lost\` any whose pod is gone (or was just deleted in phase 1) AND whose owning CP is also not active. The owner-active filter protects in-flight spawns by live peers; the grace period is a belt-and-braces safety net for any future code path that might persist a row before its pod is K8s-visible.

Two new \`ConfigStore\` methods support the sweep:
- \`ListActiveControlPlaneInstanceIDs() ([]string, error)\`
- \`ListWorkerRecordsByStatesBefore(states, cutoff) ([]WorkerRecord, error)\`

In a deploy without \`runtimeStore\` configured, phase 1 falls back to \"only the current CP is active\" so single-CP behavior is unchanged, and phase 2 is skipped entirely.

### What we expect to see in the cluster after deploy

The cluster currently has:
- 3 CP pods, \`DUCKGRES_K8S_SHARED_WARM_TARGET=3\`, 1 worker pod
- 3 \`idle\` rows: \`3052\`, \`3053\` (from a CP that died 10h ago) and \`3058\` (the live one)

After this deploys, the rolling restart will:
1. New CPs come up. Phase 1 leaves each peer's pod alone (live owner). Phase 2 finds rows \`3052\` and \`3053\` whose pods don't exist and whose owners aren't in the active set → marks both as \`lost\` with \`retire_reason=pod_missing\`.
2. \`countNeutralWarmWorkers\` drops to 1 → janitor's \`reconcileWarmCapacity\` calls \`SpawnMinWorkers(3)\` → \`CreateNeutralWarmWorkerSlot\` creates 2 new spawning slots → 2 new warm workers come up.
3. Steady state: 3 worker pods + 3 \`idle\` rows.

## Test plan

- [x] \`go test -tags kubernetes -run TestCleanupOrphanedWorkers ./controlplane\` — five test cases:
  - dead-CP pods deleted (preserves the original #403 single-CP behavior)
  - live peer pods survive the sweep (the multi-CP regression)
  - stale idle rows with no backing pod marked as \`lost\` with \`retire_reason=pod_missing\`
  - in-flight spawning rows owned by a live peer NOT touched
  - grace period filter honored end-to-end (the cutoff is at least 30s in the past)
- [x] \`go test ./controlplane/... ./tests/configstore/...\` — all green (Postgres-backed integration tests included)
- [x] \`go test -tags kubernetes ./controlplane/...\` — all green
- [x] \`go vet ./controlplane/... ./controlplane/configstore/...\` — clean
- [ ] Watch the duckgres-dev cluster after rollout: confirm phase 2 marks rows \`3052\` and \`3053\` lost on first CP startup, and the warm pool refills to 3 within one janitor cycle