### PR TITLE
Timeout QueryProgress CGO call to prevent health check stalls

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -233,6 +233,19 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkers() {
 			return
 		}
 		for _, id := range ids {
+			// The DB may lag behind K8s: a CP marked "active" in the DB
+			// could have been force-deleted (crash, preemption) and the
+			// janitor hasn't expired it yet. Verify the CP's pod actually
+			// exists before trusting the DB. The instance ID format is
+			// "pod-name:boot-id" — extract the pod name and check K8s.
+			podName := strings.SplitN(id, ":", 2)[0]
+			if podName != "" && id != p.cpInstanceID && podName != p.cpID {
+				_, getErr := p.clientset.CoreV1().Pods(p.namespace).Get(ctx, podName, metav1.GetOptions{})
+				if errors.IsNotFound(getErr) {
+					slog.Info("Live CP in DB but pod is gone; treating as dead for orphan sweep.", "cp", id, "pod", podName)
+					continue
+				}
+			}
 			liveCPIDs[id] = true
 			liveCPLabels[controlPlaneIDLabelValue(id)] = true
 		}

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1958,6 +1958,61 @@ func TestCleanupOrphanedWorkers_DeletesPodsFromDeadCPs(t *testing.T) {
 	}
 }
 
+func TestCleanupOrphanedWorkers_DeletesPodsFromCrashedLivePeer(t *testing.T) {
+	// A CP that is still "active" in the config store but whose pod was
+	// force-deleted (crash, preemption) should be treated as dead by the
+	// startup sweep. Without this, the worker pods from the crashed CP
+	// would linger until the janitor expires the heartbeat (~50s), failing
+	// the TestK8sCPDeletionGarbageCollects integration test.
+	pool, cs := newTestK8sPool(t, 5)
+	pool.cpInstanceID = "cp-self:boot-123"
+	crashedPeerID := "cp-crashed:boot-456"
+
+	store := &captureRuntimeWorkerStore{
+		// DB says cp-crashed is live (janitor hasn't expired it yet)
+		liveCPIDs: []string{"cp-self:boot-123", crashedPeerID},
+	}
+	pool.runtimeStore = store
+
+	// Create the self CP pod (must exist) but NOT the crashed peer's pod.
+	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp-self",
+			Namespace: "default",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Note: no "cp-crashed" pod created — simulates force-delete.
+
+	// Worker pod from the crashed peer.
+	_, err = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "duckgres-worker-crashed-peer",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                     "duckgres-worker",
+				"duckgres/cp-instance-id": controlPlaneIDLabelValue(crashedPeerID),
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pool.cleanupOrphanedWorkers()
+
+	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=duckgres-worker",
+	})
+	for _, p := range pods.Items {
+		if p.Name == "duckgres-worker-crashed-peer" {
+			t.Error("expected crashed peer's worker pod to be deleted — CP pod is gone even though DB says 'active'")
+		}
+	}
+}
+
 func TestCleanupOrphanedWorkers_PreservesLivePeerPods(t *testing.T) {
 	pool, cs := newTestK8sPool(t, 5)
 	pool.cpInstanceID = "cp-self:boot-123"
@@ -1968,6 +2023,11 @@ func TestCleanupOrphanedWorkers_PreservesLivePeerPods(t *testing.T) {
 		liveCPIDs: []string{"cp-self:boot-123", livePeerID},
 	}
 	pool.runtimeStore = store
+
+	// Create the live peer's CP pod so the pod-existence check passes.
+	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-peer", Namespace: "default"},
+	}, metav1.CreateOptions{})
 
 	for _, tc := range []struct {
 		name       string
@@ -2093,9 +2153,14 @@ func TestCleanupOrphanedWorkers_MarksStaleIdleRowsLost(t *testing.T) {
 }
 
 func TestCleanupOrphanedWorkers_PreservesInflightSpawnsByLivePeers(t *testing.T) {
-	pool, _ := newTestK8sPool(t, 5)
+	pool, cs := newTestK8sPool(t, 5)
 	pool.cpInstanceID = "cp-self:boot-123"
 	peerID := "cp-peer:boot-456"
+
+	// Create the live peer's CP pod so the pod-existence check passes.
+	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-peer", Namespace: "default"},
+	}, metav1.CreateOptions{})
 
 	stale := time.Now().Add(-2 * time.Hour)
 	store := &captureRuntimeWorkerStore{
@@ -2142,6 +2207,11 @@ func TestCleanupOrphanedWorkers_PreservesDrainingPeerWorkers(t *testing.T) {
 	pool, cs := newTestK8sPool(t, 5)
 	pool.cpInstanceID = "cp-self:boot-123"
 	drainingPeerID := "cp-draining-peer:boot-456"
+
+	// Create the draining peer's CP pod — it's still running (draining, not dead).
+	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-draining-peer", Namespace: "default"},
+	}, metav1.CreateOptions{})
 
 	// The mock returns whatever the test sets in liveCPIDs; the production
 	// store query is `state <> expired` so callers always get both active

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -176,61 +176,109 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 	<-h.pool.warmupDone
 
 	// Poll DuckDB query progress for each active session.
+	//
+	// QueryProgress is a CGO call into DuckDB that *should* return instantly
+	// (it reads atomic progress counters), but can block if DuckDB holds an
+	// internal lock — for example, when the httpfs extension is mid-download
+	// on a large remote parquet file. If that happens while we hold the pool
+	// RLock, both the health check and any session create/close operations
+	// stall, the CP's 3-second health check timeout fires, and after 3
+	// consecutive failures the CP kills the worker — even though it's alive
+	// and making progress on the download.
+	//
+	// To prevent this:
+	// 1. Snapshot the session data we need under RLock, then release it.
+	// 2. Call QueryProgress outside the lock, with a per-session timeout.
+	//    If the CGO call doesn't return within queryProgressTimeout, we
+	//    report the session as "busy" (pct=-1) and skip stall detection
+	//    for this cycle. The health check always responds promptly.
+	//
+	// Real crashes (process death) are detected by the K8s pod informer
+	// independently of health checks, so skipping stall detection during
+	// I/O-heavy operations doesn't create a blind spot for crash recovery.
 	type sessionProgressInfo struct {
 		Pct     float64 `json:"pct"`
 		Rows    uint64  `json:"rows"`
 		Total   uint64  `json:"total"`
 		Stalled bool    `json:"stalled,omitempty"`
 	}
-	sessionProgress := make(map[string]sessionProgressInfo)
+
+	type sessionSnapshot struct {
+		key      string
+		conn     duckdbConnHandle
+		progress *progressState
+	}
 
 	h.pool.mu.RLock()
+	snapshots := make([]sessionSnapshot, 0, len(h.pool.sessions))
 	for token, session := range h.pool.sessions {
 		if session.duckdbConn.Ptr == nil {
 			continue
 		}
-
-		qp := bindings.QueryProgress(session.duckdbConn)
-		pct, rows, total := bindings.QueryProgressTypeMembers(&qp)
-
-		// Use truncated token as key to avoid leaking full bearer tokens
-		// in the health check JSON response. 16 hex chars = 8 bytes of entropy,
-		// sufficient for matching on the control plane side.
 		key := token
 		if len(key) > 16 {
 			key = key[:16]
 		}
-
-		stalled := false
-
-		if !session.progress.queryActive.Load() {
-			// No query running — reset stall tracking.
-			session.progress.lastRowsProcessed.Store(0)
-			session.progress.stalledChecks.Store(0)
-		} else if pct < 0 {
-			// pct == -1 means DuckDB can't track this query; skip stall detection.
-		} else {
-			if rows == session.progress.lastRowsProcessed.Load() {
-				session.progress.stalledChecks.Add(1)
-			} else {
-				session.progress.lastRowsProcessed.Store(rows)
-				session.progress.stalledChecks.Store(0)
-			}
-
-			if session.progress.stalledChecks.Load() >= stallCheckThreshold {
-				stalled = true
-				// Log once when first crossing the threshold (exact match avoids log spam).
-				if session.progress.stalledChecks.Load() == stallCheckThreshold {
-					slog.Warn("Query appears stuck — no progress detected.",
-						"session", key, "rows_processed", rows, "total_rows", total,
-						"stalled_checks", stallCheckThreshold)
-				}
-			}
-		}
-
-		sessionProgress[key] = sessionProgressInfo{Pct: pct, Rows: rows, Total: total, Stalled: stalled}
+		snapshots = append(snapshots, sessionSnapshot{
+			key:      key,
+			conn:     session.duckdbConn,
+			progress: &session.progress,
+		})
 	}
 	h.pool.mu.RUnlock()
+
+	sessionProgress := make(map[string]sessionProgressInfo, len(snapshots))
+	for _, snap := range snapshots {
+		if !snap.progress.queryActive.Load() {
+			snap.progress.lastRowsProcessed.Store(0)
+			snap.progress.stalledChecks.Store(0)
+			sessionProgress[snap.key] = sessionProgressInfo{}
+			continue
+		}
+
+		type qpResult struct {
+			pct   float64
+			rows  uint64
+			total uint64
+		}
+		ch := make(chan qpResult, 1)
+		go func(conn duckdbConnHandle) {
+			qp := bindings.QueryProgress(conn)
+			pct, rows, total := bindings.QueryProgressTypeMembers(&qp)
+			ch <- qpResult{pct, rows, total}
+		}(snap.conn)
+
+		select {
+		case pr := <-ch:
+			stalled := false
+			if pr.pct < 0 {
+				// pct == -1 means DuckDB can't track this query; skip stall detection.
+			} else {
+				if pr.rows == snap.progress.lastRowsProcessed.Load() {
+					snap.progress.stalledChecks.Add(1)
+				} else {
+					snap.progress.lastRowsProcessed.Store(pr.rows)
+					snap.progress.stalledChecks.Store(0)
+				}
+				if snap.progress.stalledChecks.Load() >= stallCheckThreshold {
+					stalled = true
+					if snap.progress.stalledChecks.Load() == stallCheckThreshold {
+						slog.Warn("Query appears stuck — no progress detected.",
+							"session", snap.key, "rows_processed", pr.rows, "total_rows", pr.total,
+							"stalled_checks", stallCheckThreshold)
+					}
+				}
+			}
+			sessionProgress[snap.key] = sessionProgressInfo{Pct: pr.pct, Rows: pr.rows, Total: pr.total, Stalled: stalled}
+
+		case <-time.After(queryProgressTimeout):
+			// CGO call blocked — DuckDB is busy with I/O (e.g., httpfs
+			// download). Report as untrackable and don't advance stall
+			// counters so a legitimately slow operation doesn't get
+			// flagged as stuck.
+			sessionProgress[snap.key] = sessionProgressInfo{Pct: -1}
+		}
+	}
 
 	resp, _ := json.Marshal(map[string]interface{}{
 		"healthy":          true,

--- a/duckdbservice/progress.go
+++ b/duckdbservice/progress.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	bindings "github.com/duckdb/duckdb-go-bindings"
@@ -18,6 +19,16 @@ type duckdbConnHandle = bindings.Connection
 // with zero progress change before a session is considered stalled.
 // 300 checks × 2s = ~10 minutes of zero progress.
 const stallCheckThreshold = 300
+
+// queryProgressTimeout is the maximum time the health check waits for a
+// single QueryProgress CGO call before treating the session as "busy
+// (untrackable)". DuckDB's QueryProgress is normally instant (reads
+// atomic counters), but can block when the connection holds an internal
+// mutex — e.g., during a long httpfs download. Without this timeout the
+// health check itself stalls, the CP's 3-second gRPC deadline fires, and
+// after 3 consecutive failures the CP kills the worker even though it's
+// alive and working.
+const queryProgressTimeout = 500 * time.Millisecond
 
 // progressState tracks query activity and stall detection for a session.
 // All fields are atomic because queryActive is written by query goroutines

--- a/duckdbservice/progress_test.go
+++ b/duckdbservice/progress_test.go
@@ -3,7 +3,9 @@ package duckdbservice
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
+	"time"
 
 	bindings "github.com/duckdb/duckdb-go-bindings"
 	_ "github.com/duckdb/duckdb-go/v2"
@@ -42,5 +44,90 @@ func TestStallCheckThreshold(t *testing.T) {
 	// Verify the constant value matches the documented 300 checks × 2s = ~10 minutes.
 	if stallCheckThreshold != 300 {
 		t.Errorf("expected stallCheckThreshold=300, got %d", stallCheckThreshold)
+	}
+}
+
+func TestQueryProgressTimeout(t *testing.T) {
+	// Verify the timeout is long enough for normal QueryProgress calls
+	// but short enough to prevent health check stalls.
+	if queryProgressTimeout < 100*time.Millisecond {
+		t.Errorf("queryProgressTimeout too short: %v", queryProgressTimeout)
+	}
+	if queryProgressTimeout > 2*time.Second {
+		t.Errorf("queryProgressTimeout too long (must be well under the 3s health check gRPC deadline): %v", queryProgressTimeout)
+	}
+}
+
+func TestHealthCheckRespondsWhenQueryProgressBlocks(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		startTime:   time.Now(),
+	}
+	close(pool.warmupDone)
+
+	// Create a session with a fake DuckDB connection whose QueryProgress
+	// would block. We can't actually block the CGO call in a unit test,
+	// but we CAN verify the restructured code path: snapshot sessions
+	// outside the RLock, call QueryProgress per-session, and always
+	// produce a response.
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	duckConn, err := extractDuckDBConnection(conn)
+	if err != nil {
+		t.Fatalf("extractDuckDBConnection: %v", err)
+	}
+
+	session := &Session{ID: "test-session", duckdbConn: duckConn}
+	session.progress.queryActive.Store(true) // simulate active query
+	pool.sessions["abcdef1234567890xx"] = session
+
+	handler := &FlightSQLHandler{pool: pool}
+	stream := &mockDoActionStream{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- handler.doHealthCheck([]byte(`{}`), stream)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("health check returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("health check blocked longer than 2s — would trigger CP timeout")
+	}
+
+	if len(stream.results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(stream.results))
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(stream.results[0].Body, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["healthy"] != true {
+		t.Errorf("expected healthy=true, got %v", resp["healthy"])
+	}
+
+	// Verify session progress is reported (with pct=-1 since no real query)
+	sp, ok := resp["session_progress"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected session_progress map, got %T", resp["session_progress"])
+	}
+	if len(sp) != 1 {
+		t.Fatalf("expected 1 session in progress, got %d", len(sp))
 	}
 }


### PR DESCRIPTION
## Summary

The health check's `QueryProgress` CGO call can block when DuckDB is busy with certain operations (observed: `read_parquet` over HTTPS on a 14GB file). When this happens, the health check goroutine stalls inside the pool `RLock`, the CP's 3-second gRPC deadline fires, and after 3 consecutive failures the CP kills the worker — even though the worker process is alive.

**Observed in production**: `read_parquet('https://datasets.clickhouse.com/hits_compatible/hits.parquet')` (14GB) caused both warm workers to be declared unresponsive and deleted within ~8 seconds of query submission.

**What we verified empirically**:
- Worker process stays alive throughout (gRPC server listening, pod in Running state)
- Health check fails with `DeadlineExceeded`, not `Unavailable` or `connection refused`
- The same query in a standalone REPL inside the worker pod hangs (timeout, exit code 124)
- Small parquet files over HTTPS work fine from the same worker
- Raw HTTP range requests to the same URL succeed from the worker (openssl test)
- The worker has internet access, valid CA certs, and DNS resolution works

We did NOT verify the exact internal mechanism inside DuckDB that causes `QueryProgress` to block — it could be a connection-level mutex, a blocked syscall, or something else. The fix is correct regardless: it makes the health check non-blocking so the worker doesn't get killed while busy.

## Fix

### Commit 1: Timeout QueryProgress CGO call

Two structural changes to `doHealthCheck` in `flight_handler.go`:

1. **Snapshot then release** — collect session handles under `RLock`, release the lock, then call `QueryProgress` outside the lock. Previously the `RLock` was held for the entire loop including CGO calls, so a blocked `QueryProgress` also prevented session create/close operations from acquiring the write lock.

2. **Per-session timeout** — run each `QueryProgress` call in a goroutine with a **500ms timeout** (`queryProgressTimeout`). If the CGO call doesn't return in time, report the session as "busy (pct=-1)" and skip stall detection for that cycle. The health check always responds within 500ms per session, well under the CP's 3-second gRPC deadline.

**What still detects real crashes**: the K8s pod informer fires immediately when the worker process dies (`w.done` channel in `HealthCheckLoop`). This is independent of the gRPC health check.

**What still detects stalled queries**: `QueryProgress` returns instantly for most queries (the common case). The timeout only fires when the CGO call blocks for whatever reason. For operations that do block it, the client's own statement timeout is the appropriate kill mechanism.

### Commit 2: Verify CP pod existence during startup orphan sweep

Follow-up fix for PR #408. When a CP pod is force-deleted (crash, preemption), the `cp_instances` row stays "active" until the janitor expires the heartbeat (~50s total). If the deployment recreates the CP before that, the startup sweep sees the dead CP as "live" in the DB and skips its orphaned workers.

The fix: for each "live" CP from the DB, extract the pod name from the instance ID and verify the pod exists in K8s. If it's gone, treat the CP as dead. K8s is authoritative on pod existence; the DB may lag behind.

This fixes `TestK8sCPDeletionGarbageCollects` which force-deletes a CP and expects its workers to be cleaned up within 90s.

## Test plan

- [x] `TestHealthCheckRespondsWhenQueryProgressBlocks` — creates a session with an active query, runs `doHealthCheck`, asserts it completes within 2s and returns `healthy=true`.
- [x] `TestQueryProgressTimeout` — validates the timeout constant is within sane bounds (100ms < timeout < 2s).
- [x] `TestCleanupOrphanedWorkers_DeletesPodsFromCrashedLivePeer` — CP is "active" in DB but pod is gone in K8s; its workers are deleted.
- [x] All existing health check and orphan cleanup tests pass.
- [x] `go test -tags kubernetes ./controlplane/...` — all green.
- [x] `go test ./duckdbservice/...` — all green.