### PR TITLE
Fall back to no-LIMIT schema probe when LIMIT 0 triggers DuckDB bugs

### DIFF
--- a/duckdbservice/arrow_helpers.go
+++ b/duckdbservice/arrow_helpers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"reflect"
 	"strings"
@@ -569,21 +570,44 @@ func isNil(i contextQueryer) bool {
 }
 
 // GetQuerySchema executes a query with LIMIT 0 to discover the result schema.
+// If the LIMIT 0 probe fails (e.g., DuckDB's httpfs throws "stoi" when parsing
+// HTTP headers for remote parquet files), the function retries with the original
+// query and closes immediately after reading the column types. This avoids a
+// full table scan — database/sql's Rows.Close cancels the in-progress query.
 func GetQuerySchema(ctx context.Context, db contextQueryer, query string, tx contextQueryer) (*arrow.Schema, error) {
 	q := strings.TrimRight(strings.TrimSpace(query), ";")
 	queryWithLimit := q
+	addedLimit := false
 	upper := strings.ToUpper(q)
 	// Only append LIMIT 0 for SELECT/WITH/VALUES/TABLE statements.
 	// SHOW, DESCRIBE, EXPLAIN, PRAGMA, CALL etc. don't support LIMIT.
 	if !strings.Contains(upper, "LIMIT") && supportsLimit(upper) {
 		queryWithLimit = q + " LIMIT 0"
+		addedLimit = true
 	}
+
+	schema, err := executeSchemaProbe(ctx, db, tx, queryWithLimit)
+	if err != nil && addedLimit && isLimitZeroProbeBug(err) {
+		// LIMIT 0 triggered a DuckDB bug (e.g., httpfs stoi/stoll parsing
+		// failure on remote files). Retry with the original query — Close()
+		// will cancel the scan after we read the column types.
+		slog.Warn("LIMIT 0 schema probe failed, retrying without LIMIT.",
+			"error", err, "query_prefix", truncateQuery(q, 120))
+		schema, err = executeSchemaProbe(ctx, db, tx, q)
+	}
+	return schema, err
+}
+
+// executeSchemaProbe runs a query and extracts the Arrow schema from the
+// result column types. The caller is responsible for choosing whether to
+// pass a LIMIT 0 variant or the original query.
+func executeSchemaProbe(ctx context.Context, db contextQueryer, tx contextQueryer, query string) (*arrow.Schema, error) {
 	var rows *sql.Rows
 	var err error
 	if !isNil(tx) {
-		rows, err = tx.QueryContext(ctx, queryWithLimit)
+		rows, err = tx.QueryContext(ctx, query)
 	} else {
-		rows, err = db.QueryContext(ctx, queryWithLimit)
+		rows, err = db.QueryContext(ctx, query)
 	}
 	if err != nil {
 		return nil, err
@@ -602,6 +626,28 @@ func GetQuerySchema(ctx context.Context, db contextQueryer, query string, tx con
 		fields[i] = arrow.Field{Name: ct.Name(), Type: DuckDBTypeToArrow(ct.DatabaseTypeName()), Nullable: true}
 	}
 	return arrow.NewSchema(fields, nil), nil
+}
+
+// isLimitZeroProbeBug returns true if the error is a known DuckDB bug
+// triggered specifically by the LIMIT 0 schema probe path. These errors
+// don't occur when the same query runs without LIMIT 0.
+func isLimitZeroProbeBug(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// httpfs stoi/stoll: std::stoi or std::stoll throws when parsing HTTP
+	// Content-Length or Content-Range headers from certain CDNs. The LIMIT 0
+	// code path in DuckDB's parquet reader triggers different HTTP request
+	// patterns that hit this bug while the non-LIMIT path doesn't.
+	return strings.Contains(msg, "stoi") || strings.Contains(msg, "stoll")
+}
+
+func truncateQuery(q string, maxLen int) string {
+	if len(q) <= maxLen {
+		return q
+	}
+	return q[:maxLen] + "..."
 }
 
 // supportsLimit returns true if the (uppercased) query is a statement type

--- a/duckdbservice/arrow_helpers_test.go
+++ b/duckdbservice/arrow_helpers_test.go
@@ -1231,6 +1231,117 @@ func TestGetQuerySchemaTrailingSemicolon(t *testing.T) {
 	}
 }
 
+func TestIsLimitZeroProbeBug(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		expect bool
+	}{
+		{"nil error", nil, false},
+		{"generic error", fmt.Errorf("something went wrong"), false},
+		{"stoi error", fmt.Errorf("Invalid Error: stoi"), true},
+		{"stoll error", fmt.Errorf("Invalid Error: stoll"), true},
+		{"stoi nested", fmt.Errorf("failed to prepare: %w", fmt.Errorf("Invalid Error: stoi")), true},
+		{"syntax error", fmt.Errorf("syntax error at or near LIMIT"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLimitZeroProbeBug(tt.err); got != tt.expect {
+				t.Errorf("isLimitZeroProbeBug(%v) = %v, want %v", tt.err, got, tt.expect)
+			}
+		})
+	}
+}
+
+// mockFailingQueryer returns a configurable error on the first call to
+// QueryContext, then delegates to the real DB on subsequent calls. This
+// simulates the LIMIT 0 probe failing while the retry (without LIMIT)
+// succeeds.
+type mockFailingQueryer struct {
+	real      contextQueryer
+	callCount int
+	failErr   error
+}
+
+func (m *mockFailingQueryer) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	m.callCount++
+	if m.callCount == 1 && m.failErr != nil {
+		return nil, m.failErr
+	}
+	return m.real.QueryContext(ctx, query, args...)
+}
+
+func TestGetQuerySchemaFallsBackOnStoiError(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open DuckDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock := &mockFailingQueryer{
+		real:    db,
+		failErr: fmt.Errorf("Invalid Error: stoi"),
+	}
+
+	schema, err := GetQuerySchema(context.Background(), mock, "SELECT 42 AS answer", nil)
+	if err != nil {
+		t.Fatalf("GetQuerySchema should have succeeded on retry, got: %v", err)
+	}
+	if schema.NumFields() != 1 {
+		t.Fatalf("expected 1 field, got %d", schema.NumFields())
+	}
+	if schema.Field(0).Name != "answer" {
+		t.Fatalf("expected field name 'answer', got %q", schema.Field(0).Name)
+	}
+	if mock.callCount != 2 {
+		t.Fatalf("expected 2 QueryContext calls (LIMIT 0 fail + retry), got %d", mock.callCount)
+	}
+}
+
+func TestGetQuerySchemaNoFallbackOnOtherErrors(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open DuckDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock := &mockFailingQueryer{
+		real:    db,
+		failErr: fmt.Errorf("Table with name foo does not exist"),
+	}
+
+	_, err = GetQuerySchema(context.Background(), mock, "SELECT * FROM foo", nil)
+	if err == nil {
+		t.Fatal("expected error for non-stoi failure, got nil")
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 QueryContext call (no retry for non-stoi errors), got %d", mock.callCount)
+	}
+}
+
+func TestGetQuerySchemaNoFallbackWhenLimitAlreadyPresent(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open DuckDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock := &mockFailingQueryer{
+		real:    db,
+		failErr: fmt.Errorf("Invalid Error: stoi"),
+	}
+
+	// Query already has LIMIT — GetQuerySchema won't add LIMIT 0,
+	// so addedLimit is false and no fallback should be attempted.
+	_, err = GetQuerySchema(context.Background(), mock, "SELECT 1 LIMIT 1", nil)
+	if err == nil {
+		t.Fatal("expected stoi error to propagate when query already has LIMIT")
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 call (no retry when LIMIT was not added by us), got %d", mock.callCount)
+	}
+}
+
 func TestSplitTopLevelCommas(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

\`read_parquet('https://...large_file.parquet')\` fails with \`Invalid Error: stoi\` in control-plane mode but works in standalone mode. Root cause: DuckDB's stock v1.5.1 httpfs extension calls \`std::stoi\` on HTTP \`Content-Length\` headers without error handling (\`httpfs_curl_client.cpp:254\`). The \`LIMIT 0\` code path in \`GetQuerySchema\` triggers different HTTP request patterns in DuckDB's parquet reader that hit this bug, while the same query without \`LIMIT 0\` works fine.

Standalone mode never calls \`GetQuerySchema\` — the simple query protocol sends queries directly to DuckDB. Control-plane mode uses Flight SQL, which always probes the schema first via \`GetQuerySchema\` → \`LIMIT 0\`.

## Fix

When the \`LIMIT 0\` probe fails with an error containing "stoi" or "stoll", retry with the original query (no LIMIT). \`database/sql\`'s \`Rows.Close()\` cancels the in-progress scan after reading column types, so no full table scan occurs.

## Verified live on EKS

Built locally with Apple \`container\`, pushed to \`ghcr.io/benben/duckgres:fix-httpfs-stoi-76536e5\`, patched into the \`duckgres\` namespace deployment.

Worker log showing the fallback:
\`\`\`
level=WARN msg="LIMIT 0 schema probe failed, retrying without LIMIT."
  error="Invalid Error: stoi"
  query_prefix="SELECT count(*) FROM read_parquet('https://datasets.clickhouse.com/hits_compatible/hits.parquet'..."
\`\`\`

Query result:
\`\`\`
 count_star()
--------------
     99997497
(1 row)
\`\`\`

The full 99,997,497-row ClickBench hits dataset loaded successfully over HTTPS through the control-plane Flight SQL path.

## Test plan

- [x] \`go test ./duckdbservice/...\` — all green
- [x] \`go vet ./duckdbservice/...\` — clean
- [x] Live test on EKS: \`read_parquet('https://datasets.clickhouse.com/hits_compatible/hits.parquet', binary_as_string=True)\` returns 99,997,497 rows
- [x] Fallback log line confirmed in worker pod logs
- [x] Worker stays alive throughout (health check fix from #409 also deployed)