### PR TITLE
Use patched httpfs extension to fix stoi crash on remote parquet files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ ARG COMMIT=unknown
 ARG BUILD_TAGS=""
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.1
+ARG HTTPFS_EXTENSION_TAG=v1.5.1-stoi-fix
 RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres .
 RUN mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
-    && curl -fsSL "http://extensions.duckdb.org/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension.gz" \
-      | gzip -dc > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension"
+    && curl -fsSL "https://github.com/benben/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
+      -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension"
 
 FROM debian:bookworm-slim
 

--- a/server/server.go
+++ b/server/server.go
@@ -697,7 +697,11 @@ func (s *Server) createDBConnection(username string) (*sql.DB, error) {
 // threads, memory limit, temp directory, extensions, and cache_httpfs settings.
 // This shared setup is used by both regular and passthrough connections.
 func openBaseDB(cfg Config, username string) (*sql.DB, error) {
-	db, err := sql.Open("duckdb", ":memory:")
+	// allow_unsigned_extensions is a startup-only DuckDB config — it must be
+	// in the DSN, not via SET. Required for loading the patched httpfs extension
+	// (benben/duckdb-httpfs) which fixes stoi/stoll crashes on HTTP headers
+	// but isn't signed with DuckDB's release key.
+	db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open duckdb: %w", err)
 	}


### PR DESCRIPTION
## Summary

`read_parquet('https://...large_file.parquet')` crashes with `Invalid Error: stoi` in control-plane mode. Root cause: DuckDB's stock v1.5.1 httpfs extension calls `std::stoi`/`stoll` on HTTP `Content-Length` headers without error handling (`httpfs_curl_client.cpp:254`, `httpfs.cpp:338`).

No upstream fix exists — the bug is still on `main` of [duckdb/duckdb-httpfs](https://github.com/duckdb/duckdb-httpfs).

## Fix

Two changes:

1. **Dockerfile** — replace the stock extension download from `extensions.duckdb.org` with a patched build from [`benben/duckdb-httpfs`](https://github.com/benben/duckdb-httpfs/releases/tag/v1.5.1-stoi-fix). The patch wraps the bare `stoi`/`stoll` calls in try-catch and logs the raw header value for diagnostics. The extension is statically linked against curl and openssl via vcpkg — no `libcurl4` runtime dependency needed.

2. **server/server.go** — pass `allow_unsigned_extensions=true` in the DuckDB DSN. This is a startup-only config required because the patched extension isn't signed with DuckDB's release key.

## Patched extension

Source: https://github.com/benben/duckdb-httpfs (forked from `duckdb/duckdb-httpfs` at the v1.5.1-pinned commit `0de1997`)

Two commits:
- [`69b698f`](https://github.com/benben/duckdb-httpfs/commit/69b698f) — try-catch around both `stoi`/`stoll` call sites
- [`1cbcc6f`](https://github.com/benben/duckdb-httpfs/commit/1cbcc6f) — log the raw unparseable header value for diagnostics

Pre-built for three platforms (all statically linked, no runtime deps):
- `httpfs-linux-arm64.duckdb_extension` — 19.3 MB
- `httpfs-linux-amd64.duckdb_extension` — 20.6 MB
- `httpfs-osx-arm64.duckdb_extension` — 18.1 MB

## Verified on EKS

\`\`\`sql
SELECT count(*) FROM read_parquet('https://datasets.clickhouse.com/hits_compatible/hits.parquet', binary_as_string=True);

 count_star()
--------------
     99997497
\`\`\`

No errors, no duckgres-side workarounds, no fallback code. The extension fix resolves the root cause.

## Test plan

- [x] Local macOS test: `LIMIT 0` query that previously triggered stoi now returns instantly
- [x] EKS deployment: full 99M-row ClickBench dataset loaded over HTTPS through Flight SQL
- [x] `go vet ./server/...` — clean
- [ ] CI build with the new Dockerfile (downloads pre-built extension from GitHub release)