### PR TITLE
fix: remove epoch/cpInstanceID checks from worker health checks

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -205,28 +205,22 @@ func sameTenantActivationRuntime(current, next ActivationPayload) bool {
 }
 
 func (p *SessionPool) validateControlMetadata(meta server.WorkerControlMetadata) error {
+	// Epoch and CP instance ID checks are intentionally omitted here.
+	// Worker ownership is already serialized by the config store's transactional
+	// ClaimIdleWorker / ClaimHotIdleWorker / TakeOverWorker operations, and a
+	// worker's org assignment never changes after activation (hot → hot-idle
+	// stays on the same org until TTL expiry). Validating epoch/cpInstanceID
+	// on every health check caused cascading worker kills during CP rolling
+	// updates: the fresh CP starts with epoch 0 while workers remember a
+	// higher epoch from the previous CP, so all health checks fail and all
+	// workers get deleted.
 	if !p.sharedWarmMode {
 		return nil
-	}
-	if meta.OwnerEpoch < 0 {
-		return fmt.Errorf("owner_epoch must be non-negative")
 	}
 
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	if p.workerID > 0 && meta.WorkerID != 0 && meta.WorkerID != p.workerID {
-		return fmt.Errorf("stale worker_id %d (current %d)", meta.WorkerID, p.workerID)
-	}
-	if p.activation == nil && p.ownerCPInstanceID == "" {
-		return nil
-	}
-	if meta.OwnerEpoch != p.ownerEpoch {
-		return fmt.Errorf("stale owner epoch %d (current %d)", meta.OwnerEpoch, p.ownerEpoch)
-	}
-	if p.ownerCPInstanceID != "" && meta.CPInstanceID != p.ownerCPInstanceID {
-		return fmt.Errorf("stale cp_instance_id %q (current %q)", meta.CPInstanceID, p.ownerCPInstanceID)
-	}
-	if p.workerID > 0 && meta.WorkerID != p.workerID {
 		return fmt.Errorf("stale worker_id %d (current %d)", meta.WorkerID, p.workerID)
 	}
 	return nil

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -265,7 +265,7 @@ func TestSessionPoolActivateTenantRejectsSameEpochOwnerChange(t *testing.T) {
 	}
 }
 
-func TestSessionPoolValidateControlMetadataRejectsMismatchedCPInstanceID(t *testing.T) {
+func TestSessionPoolValidateControlMetadataAcceptsMismatchedCPInstanceID(t *testing.T) {
 	pool := &SessionPool{
 		sharedWarmMode:    true,
 		ownerEpoch:        4,
@@ -273,13 +273,59 @@ func TestSessionPoolValidateControlMetadataRejectsMismatchedCPInstanceID(t *test
 		workerID:          17,
 	}
 
+	// CP instance ID mismatches are no longer rejected — any CP should be
+	// able to health-check any worker. Ownership is managed by the config store.
 	err := pool.validateControlMetadata(server.WorkerControlMetadata{
 		WorkerID:     17,
 		OwnerEpoch:   4,
 		CPInstanceID: "cp-other:boot-b",
 	})
-	if err == nil {
-		t.Fatal("expected mismatched cp_instance_id to be rejected")
+	if err != nil {
+		t.Fatalf("expected mismatched cp_instance_id to be accepted, got: %v", err)
+	}
+}
+
+// TestHealthCheckFailsAfterCPRollingRestart reproduces the epoch mismatch
+// that causes worker pod cascading deaths during a CP rolling update.
+//
+// Scenario:
+//   1. CP-old activates a worker with epoch=1
+//   2. CP-old is killed in a rolling update
+//   3. CP-new starts fresh — it discovers the worker pod via K8s informer
+//      but hasn't re-activated it yet, so its in-memory epoch is 0
+//   4. CP-new's health check loop sends a health check with epoch=0
+//   5. Worker rejects: "stale owner epoch 0 (current 1)"
+//   6. After 3 consecutive rejections, CP-new deletes the worker pod
+//
+// The health check should not kill a worker just because the CP restarted.
+// The worker is healthy and serving queries — the epoch mismatch only means
+// the CP hasn't re-activated ownership yet.
+func TestHealthCheckFailsAfterCPRollingRestart(t *testing.T) {
+	// Worker was activated by CP-old with epoch=1
+	pool := &SessionPool{
+		sharedWarmMode:    true,
+		ownerEpoch:        1,
+		ownerCPInstanceID: "cp-old:boot-a",
+		workerID:          42,
+	}
+
+	// CP-new starts fresh after rolling update. It discovers the worker via
+	// K8s informer but hasn't re-activated it. Its in-memory epoch for this
+	// worker is 0 (default). This is exactly what the health check loop at
+	// k8s_pool.go:2270-2278 sends.
+	err := pool.validateControlMetadata(server.WorkerControlMetadata{
+		WorkerID:     42,
+		OwnerEpoch:   0,
+		CPInstanceID: "cp-new:boot-b",
+	})
+
+	// BUG: This currently fails with "stale owner epoch 0 (current 1)".
+	// The health check loop treats this as a failure, and after 3 consecutive
+	// failures it deletes the worker pod — even though the worker is perfectly
+	// healthy. This cascades to all workers, causing a full cluster outage
+	// on every rolling deployment.
+	if err != nil {
+		t.Fatalf("health check after CP rolling restart should not kill the worker, but got: %v", err)
 	}
 }
 

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -108,7 +108,7 @@ func TestHealthCheckReturnsImmediatelyAfterWarmup(t *testing.T) {
 	}
 }
 
-func TestHealthCheckRejectsMissingOwnerEpochInSharedWarmMode(t *testing.T) {
+func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),
 		stopRefresh:    make(map[string]func()),
@@ -124,9 +124,12 @@ func TestHealthCheckRejectsMissingOwnerEpochInSharedWarmMode(t *testing.T) {
 	handler := &FlightSQLHandler{pool: pool}
 	stream := &mockDoActionStream{}
 
+	// Health checks no longer validate epoch — a fresh CP with epoch 0 should
+	// be able to health-check workers activated by a previous CP. Ownership is
+	// serialized by the config store, not by worker-side epoch checks.
 	err := handler.doHealthCheck([]byte(`{}`), stream)
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("expected FailedPrecondition, got %v", err)
+	if err != nil {
+		t.Fatalf("health check should succeed regardless of epoch mismatch, got %v", err)
 	}
 }
 
@@ -212,15 +215,16 @@ func TestActivateTenantRejectsDifferentTenantAfterActivation(t *testing.T) {
 	}
 }
 
-func TestCreateSessionRejectsStaleOwnerEpochInSharedWarmMode(t *testing.T) {
+func TestCreateSessionAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),
 		stopRefresh:    make(map[string]func()),
 		warmupDone:     make(chan struct{}),
 		startTime:      time.Now(),
-		cfg:            server.Config{},
+		cfg:            server.Config{Users: map[string]string{"alice": "pass"}},
 		sharedWarmMode: true,
 		ownerEpoch:     4,
+		duckLakeSem:    make(chan struct{}, 1),
 		activation: &activatedTenantRuntime{
 			payload: ActivationPayload{
 				WorkerControlMetadata: server.WorkerControlMetadata{OwnerEpoch: 4},
@@ -229,10 +233,16 @@ func TestCreateSessionRejectsStaleOwnerEpochInSharedWarmMode(t *testing.T) {
 		},
 	}
 	close(pool.warmupDone)
+	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
+		return sql.Open("duckdb", "")
+	}
 
 	handler := &FlightSQLHandler{pool: pool}
 	stream := &mockDoActionStream{}
 
+	// Session creation with a mismatched epoch should now succeed past the
+	// validateControlMetadata check. Epoch/CP-instance validation is no longer
+	// enforced on the worker side.
 	body, err := json.Marshal(server.WorkerCreateSessionPayload{
 		WorkerControlMetadata: server.WorkerControlMetadata{
 			OwnerEpoch: 3,
@@ -244,12 +254,12 @@ func TestCreateSessionRejectsStaleOwnerEpochInSharedWarmMode(t *testing.T) {
 	}
 
 	err = handler.doCreateSession(body, stream)
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("expected FailedPrecondition, got %v", err)
+	if err != nil {
+		t.Fatalf("create session should succeed regardless of epoch mismatch, got %v", err)
 	}
 }
 
-func TestSessionFromContextRejectsStaleOwnerEpoch(t *testing.T) {
+func TestSessionFromContextAcceptsMismatchedEpoch(t *testing.T) {
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),
 		stopRefresh:    make(map[string]func()),
@@ -271,9 +281,11 @@ func TestSessionFromContextRejectsStaleOwnerEpoch(t *testing.T) {
 		"x-duckgres-cp-instance-id", "cp-live:boot-a",
 	))
 
+	// Epoch mismatches are no longer rejected — ownership is serialized
+	// by the config store, not worker-side epoch checks.
 	_, err := handler.sessionFromContext(ctx)
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("expected FailedPrecondition, got %v", err)
+	if err != nil {
+		t.Fatalf("expected mismatched epoch to be accepted, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove epoch and CP instance ID validation from `validateControlMetadata()` in the worker's session pool
- This fixes cascading worker pod kills during CP rolling updates
- Add `TestHealthCheckFailsAfterCPRollingRestart` that reproduces the exact bug

## Problem

During a CP rolling update, the fresh CP starts with epoch 0 while workers remember a higher epoch from the previous CP. Every health check fails with `"stale owner epoch 0 (current 1)"`, and after 3 consecutive failures the CP deletes the worker pod. This cascades to all workers, causing a full cluster outage on every deployment.

## Why the checks are redundant

- **Ownership is serialized by the config store** — `ClaimIdleWorker`, `ClaimHotIdleWorker`, and `TakeOverWorker` all use database transactions with row-level locking
- **Workers never change org after activation** — the lifecycle is `idle → reserved → activating → hot → hot-idle (same org) → reclaimed by same org or TTL expired`. `ClaimHotIdleWorker` filters by `org_id`, so a different org can never steal a hot-idle worker
- **Epoch on the activation path is unchanged** — `activateTenant()` still enforces monotonic epochs during tenant activation

## Test plan

- [x] `TestHealthCheckFailsAfterCPRollingRestart` — reproduces the exact error, passes with fix
- [x] All existing `duckdbservice` tests pass (43/43)
- [ ] Deploy to dev cluster and verify workers survive a CP rolling update
- [ ] Run ClickBench queries against the serverless endpoint without connection drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)