### PR TITLE
refactor: shorten worker pod names by stripping CP pod-hash suffix

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2281,10 +2281,7 @@ func (p *K8sWorkerPool) healthCheckPayloadForWorker(worker *ManagedWorker) serve
 // podNameForWorker returns the pod name for a given worker ID,
 // including the org ID if set (multi-tenant mode).
 func (p *K8sWorkerPool) podNameForWorker(id int) string {
-	if p.orgID != "" {
-		return fmt.Sprintf("duckgres-worker-%s-%s-%d", p.cpID, p.orgID, id)
-	}
-	return fmt.Sprintf("duckgres-worker-%s-%d", p.cpID, id)
+	return fmt.Sprintf("%s-%d", p.workerPodNamePrefix(), id)
 }
 
 func (p *K8sWorkerPool) workerPodName(worker *ManagedWorker) string {
@@ -2298,10 +2295,32 @@ func (p *K8sWorkerPool) workerPodName(worker *ManagedWorker) string {
 }
 
 func (p *K8sWorkerPool) workerPodNamePrefix() string {
+	base := trimK8sPodHashSuffix(p.cpID)
 	if p.orgID != "" {
-		return fmt.Sprintf("duckgres-worker-%s-%s", p.cpID, p.orgID)
+		return fmt.Sprintf("%s-worker-%s", base, p.orgID)
 	}
-	return fmt.Sprintf("duckgres-worker-%s", p.cpID)
+	return fmt.Sprintf("%s-worker", base)
+}
+
+// trimK8sPodHashSuffix removes the trailing 5-character random pod-hash
+// segment from a K8s deployment pod name (e.g. "duckgres-7b667c7bfd-7745x"
+// → "duckgres-7b667c7bfd"). Names that don't end in a plausible pod-hash
+// segment are returned unchanged.
+func trimK8sPodHashSuffix(name string) string {
+	idx := strings.LastIndex(name, "-")
+	if idx <= 0 {
+		return name
+	}
+	suffix := name[idx+1:]
+	if len(suffix) != 5 {
+		return name
+	}
+	for _, r := range suffix {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return name
+		}
+	}
+	return name[:idx]
 }
 
 // SetMaxWorkers updates the maximum number of workers. 0 means unlimited.

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1173,8 +1173,8 @@ func TestK8sPoolReserveSharedWorkerCreatesRuntimeSpawningSlotWhenPoolIsCold(t *t
 	if store.spawnOwnerEpoch != 1 {
 		t.Fatalf("expected spawn owner epoch 1, got %d", store.spawnOwnerEpoch)
 	}
-	if store.spawnPodNamePrefix != "duckgres-worker-test-cp" {
-		t.Fatalf("expected pod name prefix duckgres-worker-test-cp, got %q", store.spawnPodNamePrefix)
+	if store.spawnPodNamePrefix != "test-cp-worker" {
+		t.Fatalf("expected pod name prefix test-cp-worker, got %q", store.spawnPodNamePrefix)
 	}
 	if store.spawnMaxOrgWorkers != 2 {
 		t.Fatalf("expected max org workers 2, got %d", store.spawnMaxOrgWorkers)
@@ -1217,8 +1217,8 @@ func TestK8sPoolSpawnWarmWorkerAllocatesRuntimeSlotWhenIDZero(t *testing.T) {
 	if store.neutralSpawnCalls != 1 {
 		t.Fatalf("expected one runtime neutral spawn slot allocation, got %d", store.neutralSpawnCalls)
 	}
-	if store.neutralSpawnPodPrefix != "duckgres-worker-test-cp" {
-		t.Fatalf("expected pod name prefix duckgres-worker-test-cp, got %q", store.neutralSpawnPodPrefix)
+	if store.neutralSpawnPodPrefix != "test-cp-worker" {
+		t.Fatalf("expected pod name prefix test-cp-worker, got %q", store.neutralSpawnPodPrefix)
 	}
 }
 
@@ -1568,7 +1568,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	for _, env := range c.Env {
 		if env.Name == "DUCKGRES_DUCKDB_TOKEN" && env.ValueFrom != nil &&
 			env.ValueFrom.SecretKeyRef != nil &&
-			env.ValueFrom.SecretKeyRef.Name == "test-secret-duckgres-worker-test-cp-0" {
+			env.ValueFrom.SecretKeyRef.Name == "test-secret-test-cp-worker-0" {
 			foundEnv = true
 		}
 		if env.Name == "DUCKGRES_SHARED_WARM_WORKER" && env.Value == "true" {
@@ -1597,7 +1597,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	foundWorkerRPCSecret := false
 	for _, volume := range pod.Spec.Volumes {
 		if volume.Name == "worker-rpc-tls" && volume.Secret != nil &&
-			volume.Secret.SecretName == "test-secret-duckgres-worker-test-cp-0" {
+			volume.Secret.SecretName == "test-secret-test-cp-worker-0" {
 			foundWorkerRPCSecret = true
 		}
 	}


### PR DESCRIPTION
## Summary

- Rename K8s worker pods from `duckgres-worker-{cpID}-{id}` to `{cpID-without-pod-hash}-worker-{id}`, e.g. `duckgres-7b667c7bfd-worker-3676` instead of `duckgres-worker-duckgres-7b667c7bfd-7745x-3676`.
- The duplicated `duckgres-` prefix and the CP's random pod-hash suffix added noise without contributing to uniqueness — worker IDs are already globally unique PKs from the configstore.
- `duckgres/control-plane` pod label still carries the full cpID, so CP→worker attribution, orphan sweeps, and label-based selection are unchanged.
- Per-worker mTLS secrets (`duckgres-worker-token-{podName}`) derive from the pod name at runtime and continue to work; new secret names are well under the 253-char K8s limit.

## Test plan

- [x] `go test -tags kubernetes ./controlplane/...` passes
- [ ] Deploy to dev and verify worker pod names render as expected
- [ ] Confirm orphan sweep and tenant isolation still work end-to-end in dev