### PR TITLE
refactor: replace startup orphan sweep with janitor-driven version-aware reaper

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -649,6 +649,23 @@ func (cs *ConfigStore) RetireHotIdleWorker(workerID int) (bool, error) {
 	return result.RowsAffected > 0, nil
 }
 
+// RetireIdleWorker atomically transitions a worker from idle to retired.
+// Returns true if the transition happened, false if the worker was no longer
+// idle (e.g. claimed by another CP between the list query and this call).
+func (cs *ConfigStore) RetireIdleWorker(workerID int, reason string) (bool, error) {
+	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("worker_id = ? AND state = ?", workerID, WorkerStateIdle).
+		Updates(map[string]any{
+			"state":         WorkerStateRetired,
+			"retire_reason": reason,
+			"updated_at":    time.Now(),
+		})
+	if result.Error != nil {
+		return false, fmt.Errorf("retire idle worker %d: %w", workerID, result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
 // TakeOverWorker transfers durable worker ownership to a new control-plane
 // instance when the caller still has the expected prior owner_epoch.
 func (cs *ConfigStore) TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*WorkerRecord, error) {

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -25,18 +25,19 @@ type controlPlaneExpiryStore interface {
 }
 
 type ControlPlaneJanitor struct {
-	store                 controlPlaneExpiryStore
-	interval              time.Duration
-	expiryTimeout         time.Duration
-	orphanGrace           time.Duration
-	spawnTimeout          time.Duration
-	activateTimeout       time.Duration
-	maxDrainTimeout       time.Duration
-	hotIdleTTL            time.Duration
-	now                   func() time.Time
-	retireWorker          func(record configstore.WorkerRecord, reason string)
-	retireLocalWorker     func(workerID int, reason string) bool // retires from in-memory pool + pod, returns false if not local
-	reconcileWarmCapacity func()
+	store                         controlPlaneExpiryStore
+	interval                      time.Duration
+	expiryTimeout                 time.Duration
+	orphanGrace                   time.Duration
+	spawnTimeout                  time.Duration
+	activateTimeout               time.Duration
+	maxDrainTimeout               time.Duration
+	hotIdleTTL                    time.Duration
+	now                           func() time.Time
+	retireWorker                  func(record configstore.WorkerRecord, reason string)
+	retireLocalWorker             func(workerID int, reason string) bool // retires from in-memory pool + pod, returns false if not local
+	reconcileWarmCapacity         func()
+	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 }
 
 func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeout time.Duration) *ControlPlaneJanitor {
@@ -147,6 +148,14 @@ func (j *ControlPlaneJanitor) runOnce() {
 
 	if _, err := j.store.ExpireFlightSessionRecords(j.now()); err != nil {
 		slog.Warn("Janitor failed to expire stale Flight sessions.", "error", err)
+	}
+
+	// Gradual rolling replacement of warm workers whose Deployment version
+	// differs from this CP's. Runs only when this CP holds the janitor
+	// leader lease, so at most one CP at a time is retiring workers and the
+	// process stalls until a new-version CP is elected leader.
+	if j.retireMismatchedVersionWorker != nil {
+		j.retireMismatchedVersionWorker()
 	}
 
 	if j.reconcileWarmCapacity != nil {

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -195,6 +195,35 @@ func TestControlPlaneJanitorRunReconcilesWarmCapacity(t *testing.T) {
 	}
 }
 
+func TestControlPlaneJanitorRunInvokesVersionReaperBeforeReconcile(t *testing.T) {
+	// The version-aware reaper must run before reconcileWarmCapacity in the
+	// same tick so that a retired-this-tick worker's warm slot is replenished
+	// immediately rather than waiting a full interval.
+	store := &captureControlPlaneExpiryStore{}
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+
+	var mu sync.Mutex
+	var order []string
+	janitor.retireMismatchedVersionWorker = func() {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, "reap")
+	}
+	janitor.reconcileWarmCapacity = func() {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, "reconcile")
+	}
+
+	janitor.runOnce()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 || order[0] != "reap" || order[1] != "reconcile" {
+		t.Fatalf("expected reap→reconcile ordering, got %v", order)
+	}
+}
+
 func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 	store := &captureControlPlaneExpiryStore{
 		expireErr: errors.New("boom"),

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"crypto/x509"
@@ -169,10 +168,6 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		pool.cpInstanceID = pool.cpID
 	}
 
-	// Clean up orphaned worker pods from dead CP instances and reconcile any
-	// DB rows that no longer have a backing pod.
-	pool.cleanupOrphanedWorkers()
-
 	// Start SharedInformer for watching worker pods
 	pool.startInformer()
 
@@ -182,159 +177,84 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 	return pool, nil
 }
 
-// staleWorkerRowGracePeriod is the minimum age of a worker row before phase 2
-// of the orphan sweep is willing to mark it as lost. The owner-active filter
-// is the primary safety net, but the time filter offers belt-and-braces in
-// case a future code path persists an idle row before its pod is K8s-visible.
-const staleWorkerRowGracePeriod = 30 * time.Second
-
-// cleanupOrphanedWorkers reconciles K8s pods and config-store worker rows
-// against the live control-plane membership. It runs once at CP startup in
-// two phases:
+// RetireOneMismatchedVersionWorker scans all shared warm-worker pods in the
+// namespace for one whose duckgres/control-plane label identifies a different
+// Deployment ReplicaSet (pod-template-hash) than this CP, atomically marks
+// its idle runtime-store row retired, and deletes the pod.
 //
-//  1. Phase 1 (K8s → DB direction): list every worker pod in the namespace
-//     and delete any whose duckgres/cp-instance-id label points at a control
-//     plane that is *not* in the active set. Live peers' pods are explicitly
-//     left alone — without this filter the sweep would wipe warm workers
-//     spawned by alive peer CPs every time a deployment rolls.
+// The janitor leader is expected to invoke this once per tick: together with
+// warm-pool replenishment via reconcileWarmCapacity, old-version workers are
+// replaced one at a time with pods spawned from the leader's current binary.
+// This gives gradual rolling worker replacement driven entirely by leader
+// election — no cross-CP sweeps needed.
 //
-//  2. Phase 2 (DB → K8s direction): list idle and spawning worker rows and
-//     mark as lost any whose pod is gone (or was just deleted in phase 1)
-//     and whose owning CP is not active. This rescues stale `idle` rows
-//     left behind when a CP died abruptly without retiring its warm workers
-//     — those rows have an empty owner_cp_instance_id by design and are
-//     unreachable from the periodic orphan janitor's cp_instances join.
-func (p *K8sWorkerPool) cleanupOrphanedWorkers() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+// Retirement is limited to workers currently in WorkerStateIdle. Busy or
+// hot-idle workers are left alone so in-flight sessions aren't disturbed;
+// they'll be retired on a subsequent tick once they become idle (or when
+// their hot-idle TTL expires).
+//
+// Returns true when a worker was retired this call.
+func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bool {
+	if p.runtimeStore == nil || p.clientset == nil {
+		return false
+	}
+	myVersion := trimK8sPodHashSuffix(p.cpID)
+	if myVersion == p.cpID {
+		// cpID doesn't carry a Deployment pod-template-hash suffix (e.g.
+		// bare pod or StatefulSet). Without that we can't compare versions
+		// across pods, so nothing to do.
+		return false
+	}
 
 	pods, err := p.clientset.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "app=duckgres-worker",
 	})
 	if err != nil {
-		slog.Warn("Failed to list worker pods for orphan cleanup.", "error", err)
-		return
+		slog.Warn("Version-aware reaper failed to list worker pods.", "error", err)
+		return false
 	}
 
-	// Build the set of currently-live CP instance IDs (both raw and label-
-	// sanitized forms) so phase 1 can compare against pod labels and phase 2
-	// can compare against owner_cp_instance_id columns.
-	//
-	// "Live" includes both `active` and `draining` states. A draining CP
-	// is mid-graceful-shutdown waiting on in-flight queries to finish — its
-	// worker pods are still serving traffic and must NOT be treated as
-	// orphans. Only `expired` CPs are dead enough to clean up after.
-	liveCPIDs := map[string]bool{}
-	liveCPLabels := map[string]bool{}
-	if p.runtimeStore != nil {
-		ids, err := p.runtimeStore.ListLiveControlPlaneInstanceIDs()
+	for _, pod := range pods.Items {
+		label := pod.Labels["duckgres/control-plane"]
+		if label == "" {
+			continue
+		}
+		if trimK8sPodHashSuffix(label) == myVersion {
+			continue
+		}
+		idStr := pod.Labels["duckgres/worker-id"]
+		if idStr == "" {
+			continue
+		}
+		workerID, err := strconv.Atoi(idStr)
 		if err != nil {
-			slog.Warn("Failed to list live control-plane instances for orphan cleanup; skipping sweep to avoid wiping live peers.", "error", err)
-			return
-		}
-		for _, id := range ids {
-			// The DB may lag behind K8s: a CP marked "active" in the DB
-			// could have been force-deleted (crash, preemption) and the
-			// janitor hasn't expired it yet. Verify the CP's pod actually
-			// exists before trusting the DB. The instance ID format is
-			// "pod-name:boot-id" — extract the pod name and check K8s.
-			podName := strings.SplitN(id, ":", 2)[0]
-			if podName != "" && id != p.cpInstanceID && podName != p.cpID {
-				_, getErr := p.clientset.CoreV1().Pods(p.namespace).Get(ctx, podName, metav1.GetOptions{})
-				if errors.IsNotFound(getErr) {
-					slog.Info("Live CP in DB but pod is gone; treating as dead for orphan sweep.", "cp", id, "pod", podName)
-					continue
-				}
-			}
-			liveCPIDs[id] = true
-			liveCPLabels[controlPlaneIDLabelValue(id)] = true
-		}
-	}
-	// Always treat the current CP as live so the sweep is safe in
-	// non-runtime-store deployments and during the brief window before this
-	// CP's heartbeat is first written.
-	liveCPIDs[p.cpInstanceID] = true
-	liveCPLabels[controlPlaneIDLabelValue(p.cpInstanceID)] = true
-
-	// Phase 1: delete pods owned by dead CPs.
-	gracePeriod := int64(10)
-	var wg sync.WaitGroup
-	var deleted atomic.Int32
-	var deletedNames sync.Map
-	for _, pod := range pods.Items {
-		podInstanceID := pod.Labels["duckgres/cp-instance-id"]
-		if podInstanceID == "" || liveCPLabels[podInstanceID] {
 			continue
 		}
-		wg.Add(1)
-		go func(podName, oldCP string) {
-			defer wg.Done()
-			p.retireSem <- struct{}{}
-			defer func() { <-p.retireSem }()
-
-			slog.Info("Deleting orphaned worker pod from dead CP.", "pod", podName, "old_cp", oldCP)
-			if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
-				GracePeriodSeconds: &gracePeriod,
-			}); err != nil {
-				slog.Warn("Failed to delete orphaned worker pod.", "pod", podName, "error", err)
-				return
-			}
-			deleted.Add(1)
-			deletedNames.Store(podName, struct{}{})
-		}(pod.Name, podInstanceID)
-	}
-	wg.Wait()
-	if n := deleted.Load(); n > 0 {
-		slog.Info("Cleaned up orphaned worker pods.", "count", n)
-	}
-
-	// Phase 2: reconcile idle/spawning DB rows against the K8s pod set.
-	if p.runtimeStore == nil {
-		return
-	}
-	rows, err := p.runtimeStore.ListWorkerRecordsByStatesBefore(
-		[]configstore.WorkerState{configstore.WorkerStateIdle, configstore.WorkerStateSpawning},
-		time.Now().Add(-staleWorkerRowGracePeriod),
-	)
-	if err != nil {
-		slog.Warn("Failed to list worker records for stale row sweep.", "error", err)
-		return
-	}
-	livePodNames := map[string]bool{}
-	for _, pod := range pods.Items {
-		if _, gone := deletedNames.Load(pod.Name); gone {
+		retired, err := p.runtimeStore.RetireIdleWorker(workerID, "version_mismatch")
+		if err != nil {
+			slog.Warn("Version-aware reaper failed to retire idle row.", "worker_id", workerID, "error", err)
 			continue
 		}
-		livePodNames[pod.Name] = true
-	}
-	now := time.Now()
-	var marked int
-	for _, row := range rows {
-		if livePodNames[row.PodName] {
-			continue // pod is alive in K8s; row reflects reality
-		}
-		if row.OwnerCPInstanceID != "" && liveCPIDs[row.OwnerCPInstanceID] {
-			continue // a live owner is responsible for this row's lifecycle
-		}
-		record := row
-		record.State = configstore.WorkerStateLost
-		record.RetireReason = "pod_missing"
-		record.LastHeartbeatAt = now
-		if err := p.runtimeStore.UpsertWorkerRecord(&record); err != nil {
-			slog.Warn("Failed to mark stale worker row lost.", "worker_id", row.WorkerID, "error", err)
+		if !retired {
+			// Not currently idle (busy, reserved, hot-idle, or already
+			// retired). Leave it for a later tick.
 			continue
 		}
-		slog.Info("Marked stale worker row lost.",
-			"worker_id", row.WorkerID,
-			"pod", row.PodName,
-			"prior_state", row.State,
-			"prior_owner", row.OwnerCPInstanceID,
+		slog.Info("Retiring mismatched-version worker pod.",
+			"worker_id", workerID,
+			"pod", pod.Name,
+			"pod_version", trimK8sPodHashSuffix(label),
+			"my_version", myVersion,
 		)
-		marked++
+		gracePeriod := int64(10)
+		if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriod,
+		}); err != nil && !errors.IsNotFound(err) {
+			slog.Warn("Version-aware reaper failed to delete pod.", "pod", pod.Name, "error", err)
+		}
+		return true
 	}
-	if marked > 0 {
-		slog.Info("Reconciled stale worker rows.", "count", marked)
-	}
+	return false
 }
 
 func (p *K8sWorkerPool) resolveCPUID(ctx context.Context) error {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -56,13 +56,11 @@ type captureRuntimeWorkerStore struct {
 	takeOverOwnerCPID     string
 	takeOverOrgID         string
 	takeOverExpectedEpoch int64
-	liveCPIDs             []string
-	liveCPIDsErr          error
-	stateBeforeRows       []configstore.WorkerRecord
-	stateBeforeErr        error
-	stateBeforeCalls      int
-	stateBeforeStates     []configstore.WorkerState
-	stateBeforeCutoff     time.Time
+	retireIdleCalls         int
+	retireIdleCalledIDs     []int
+	retireIdleCalledReasons []string
+	retireIdleErr           error
+	retireIdleMisses        map[int]bool
 }
 
 func (s *captureRuntimeWorkerStore) UpsertWorkerRecord(record *configstore.WorkerRecord) error {
@@ -190,41 +188,19 @@ func (s *captureRuntimeWorkerStore) TakeOverWorker(workerID int, ownerCPInstance
 	return &record, nil
 }
 
-func (s *captureRuntimeWorkerStore) ListLiveControlPlaneInstanceIDs() ([]string, error) {
+func (s *captureRuntimeWorkerStore) RetireIdleWorker(workerID int, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.liveCPIDsErr != nil {
-		return nil, s.liveCPIDsErr
+	s.retireIdleCalls++
+	s.retireIdleCalledIDs = append(s.retireIdleCalledIDs, workerID)
+	s.retireIdleCalledReasons = append(s.retireIdleCalledReasons, reason)
+	if s.retireIdleErr != nil {
+		return false, s.retireIdleErr
 	}
-	out := make([]string, len(s.liveCPIDs))
-	copy(out, s.liveCPIDs)
-	return out, nil
-}
-
-func (s *captureRuntimeWorkerStore) ListWorkerRecordsByStatesBefore(states []configstore.WorkerState, updatedBefore time.Time) ([]configstore.WorkerRecord, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stateBeforeCalls++
-	s.stateBeforeStates = append([]configstore.WorkerState(nil), states...)
-	s.stateBeforeCutoff = updatedBefore
-	if s.stateBeforeErr != nil {
-		return nil, s.stateBeforeErr
+	if s.retireIdleMisses[workerID] {
+		return false, nil
 	}
-	stateSet := make(map[configstore.WorkerState]bool, len(states))
-	for _, st := range states {
-		stateSet[st] = true
-	}
-	var out []configstore.WorkerRecord
-	for _, r := range s.stateBeforeRows {
-		if !stateSet[r.State] {
-			continue
-		}
-		if !r.UpdatedAt.IsZero() && r.UpdatedAt.After(updatedBefore) {
-			continue
-		}
-		out = append(out, r)
-	}
-	return out, nil
+	return true, nil
 }
 
 func newTestK8sPool(t *testing.T, maxWorkers int) (*K8sWorkerPool, *fake.Clientset) {
@@ -1905,405 +1881,6 @@ func TestSetWorkerResources(t *testing.T) {
 	}
 }
 
-func TestCleanupOrphanedWorkers_DeletesPodsFromDeadCPs(t *testing.T) {
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "new-cp:boot-123"
-
-	// Create pods: 2 from a dead CP, 1 from current CP, 1 unlabeled.
-	// No runtimeStore: the sweep falls back to "current CP only is active",
-	// matching the original single-CP behavior.
-	for _, tc := range []struct {
-		name       string
-		instanceID string
-	}{
-		{"duckgres-worker-old-1", controlPlaneIDLabelValue("old-cp:boot-000")},
-		{"duckgres-worker-old-2", controlPlaneIDLabelValue("old-cp:boot-000")},
-		{"duckgres-worker-mine", controlPlaneIDLabelValue("new-cp:boot-123")},
-		{"duckgres-worker-nolabel", ""},
-	} {
-		labels := map[string]string{"app": "duckgres-worker"}
-		if tc.instanceID != "" {
-			labels["duckgres/cp-instance-id"] = tc.instanceID
-		}
-		_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: tc.name, Namespace: "default", Labels: labels},
-		}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	pool.cleanupOrphanedWorkers()
-
-	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=duckgres-worker",
-	})
-
-	remaining := map[string]bool{}
-	for _, p := range pods.Items {
-		remaining[p.Name] = true
-	}
-
-	if remaining["duckgres-worker-old-1"] {
-		t.Error("expected old-1 to be deleted")
-	}
-	if remaining["duckgres-worker-old-2"] {
-		t.Error("expected old-2 to be deleted")
-	}
-	if !remaining["duckgres-worker-mine"] {
-		t.Error("expected mine to survive")
-	}
-	if !remaining["duckgres-worker-nolabel"] {
-		t.Error("expected nolabel to survive")
-	}
-}
-
-func TestCleanupOrphanedWorkers_DeletesPodsFromCrashedLivePeer(t *testing.T) {
-	// A CP that is still "active" in the config store but whose pod was
-	// force-deleted (crash, preemption) should be treated as dead by the
-	// startup sweep. Without this, the worker pods from the crashed CP
-	// would linger until the janitor expires the heartbeat (~50s), failing
-	// the TestK8sCPDeletionGarbageCollects integration test.
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-	crashedPeerID := "cp-crashed:boot-456"
-
-	store := &captureRuntimeWorkerStore{
-		// DB says cp-crashed is live (janitor hasn't expired it yet)
-		liveCPIDs: []string{"cp-self:boot-123", crashedPeerID},
-	}
-	pool.runtimeStore = store
-
-	// Create the self CP pod (must exist) but NOT the crashed peer's pod.
-	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cp-self",
-			Namespace: "default",
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Note: no "cp-crashed" pod created — simulates force-delete.
-
-	// Worker pod from the crashed peer.
-	_, err = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "duckgres-worker-crashed-peer",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":                     "duckgres-worker",
-				"duckgres/cp-instance-id": controlPlaneIDLabelValue(crashedPeerID),
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pool.cleanupOrphanedWorkers()
-
-	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=duckgres-worker",
-	})
-	for _, p := range pods.Items {
-		if p.Name == "duckgres-worker-crashed-peer" {
-			t.Error("expected crashed peer's worker pod to be deleted — CP pod is gone even though DB says 'active'")
-		}
-	}
-}
-
-func TestCleanupOrphanedWorkers_PreservesLivePeerPods(t *testing.T) {
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-	livePeerID := "cp-peer:boot-456"
-	deadCPID := "cp-dead:boot-789"
-
-	store := &captureRuntimeWorkerStore{
-		liveCPIDs: []string{"cp-self:boot-123", livePeerID},
-	}
-	pool.runtimeStore = store
-
-	// Create the live peer's CP pod so the pod-existence check passes.
-	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "cp-peer", Namespace: "default"},
-	}, metav1.CreateOptions{})
-
-	for _, tc := range []struct {
-		name       string
-		instanceID string
-	}{
-		{"duckgres-worker-self", controlPlaneIDLabelValue("cp-self:boot-123")},
-		{"duckgres-worker-peer", controlPlaneIDLabelValue(livePeerID)},
-		{"duckgres-worker-dead", controlPlaneIDLabelValue(deadCPID)},
-	} {
-		_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tc.name,
-				Namespace: "default",
-				Labels: map[string]string{
-					"app":                     "duckgres-worker",
-					"duckgres/cp-instance-id": tc.instanceID,
-				},
-			},
-		}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	pool.cleanupOrphanedWorkers()
-
-	remaining := map[string]bool{}
-	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=duckgres-worker",
-	})
-	for _, p := range pods.Items {
-		remaining[p.Name] = true
-	}
-	if !remaining["duckgres-worker-self"] {
-		t.Error("expected current CP's pod to survive")
-	}
-	if !remaining["duckgres-worker-peer"] {
-		t.Error("expected live peer CP's pod to survive — this is the multi-CP regression")
-	}
-	if remaining["duckgres-worker-dead"] {
-		t.Error("expected dead CP's pod to be deleted")
-	}
-}
-
-func TestCleanupOrphanedWorkers_MarksStaleIdleRowsLost(t *testing.T) {
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-
-	// One pod actually exists in K8s (the live one). Two stale DB rows
-	// remain from a previous CP whose pods are long gone — this is the
-	// exact failure mode where idle rows with empty owner_cp_instance_id
-	// can't be reaped by the periodic orphan janitor.
-	livePodName := "duckgres-worker-self-1"
-	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      livePodName,
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":                     "duckgres-worker",
-				"duckgres/cp-instance-id": controlPlaneIDLabelValue("cp-self:boot-123"),
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stale := time.Now().Add(-2 * time.Hour)
-	store := &captureRuntimeWorkerStore{
-		liveCPIDs: []string{"cp-self:boot-123"},
-		stateBeforeRows: []configstore.WorkerRecord{
-			{
-				WorkerID:          1,
-				PodName:           livePodName,
-				State:             configstore.WorkerStateIdle,
-				OwnerCPInstanceID: "",
-				UpdatedAt:         stale,
-			},
-			{
-				WorkerID:          2,
-				PodName:           "duckgres-worker-stale-2",
-				State:             configstore.WorkerStateIdle,
-				OwnerCPInstanceID: "",
-				UpdatedAt:         stale,
-			},
-			{
-				WorkerID:          3,
-				PodName:           "duckgres-worker-stale-3",
-				State:             configstore.WorkerStateIdle,
-				OwnerCPInstanceID: "",
-				UpdatedAt:         stale,
-			},
-		},
-	}
-	pool.runtimeStore = store
-
-	pool.cleanupOrphanedWorkers()
-
-	upserted := store.snapshot()
-	if len(upserted) != 2 {
-		t.Fatalf("expected 2 stale rows to be marked lost, got %d: %#v", len(upserted), upserted)
-	}
-	gotIDs := map[int]configstore.WorkerRecord{}
-	for _, r := range upserted {
-		gotIDs[r.WorkerID] = r
-	}
-	for _, id := range []int{2, 3} {
-		r, ok := gotIDs[id]
-		if !ok {
-			t.Errorf("expected worker %d to be marked lost", id)
-			continue
-		}
-		if r.State != configstore.WorkerStateLost {
-			t.Errorf("worker %d: expected state lost, got %q", id, r.State)
-		}
-		if r.RetireReason != "pod_missing" {
-			t.Errorf("worker %d: expected retire_reason pod_missing, got %q", id, r.RetireReason)
-		}
-	}
-	if _, touched := gotIDs[1]; touched {
-		t.Error("expected worker 1 (live pod) to be left untouched")
-	}
-}
-
-func TestCleanupOrphanedWorkers_PreservesInflightSpawnsByLivePeers(t *testing.T) {
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-	peerID := "cp-peer:boot-456"
-
-	// Create the live peer's CP pod so the pod-existence check passes.
-	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "cp-peer", Namespace: "default"},
-	}, metav1.CreateOptions{})
-
-	stale := time.Now().Add(-2 * time.Hour)
-	store := &captureRuntimeWorkerStore{
-		liveCPIDs: []string{"cp-self:boot-123", peerID},
-		stateBeforeRows: []configstore.WorkerRecord{
-			// In-flight spawn owned by a live peer: pod isn't visible to us
-			// yet (e.g. slow image pull), but the peer is alive and will
-			// finish or retire it. Must NOT be touched.
-			{
-				WorkerID:          11,
-				PodName:           "duckgres-worker-peer-inflight",
-				State:             configstore.WorkerStateSpawning,
-				OwnerCPInstanceID: peerID,
-				UpdatedAt:         stale,
-			},
-			// Genuinely abandoned spawn from a dead CP — pod gone, owner gone.
-			{
-				WorkerID:          12,
-				PodName:           "duckgres-worker-dead-spawn",
-				State:             configstore.WorkerStateSpawning,
-				OwnerCPInstanceID: "cp-dead:boot-789",
-				UpdatedAt:         stale,
-			},
-		},
-	}
-	pool.runtimeStore = store
-
-	pool.cleanupOrphanedWorkers()
-
-	upserted := store.snapshot()
-	if len(upserted) != 1 || upserted[0].WorkerID != 12 {
-		t.Fatalf("expected only worker 12 (dead CP's spawn) to be marked lost, got %#v", upserted)
-	}
-	if upserted[0].State != configstore.WorkerStateLost {
-		t.Fatalf("expected lost state, got %q", upserted[0].State)
-	}
-}
-
-func TestCleanupOrphanedWorkers_PreservesDrainingPeerWorkers(t *testing.T) {
-	// A draining CP is mid-graceful-shutdown, still serving in-flight queries
-	// on its worker pods. The startup sweep must treat draining CPs as live
-	// (state <> 'expired'), otherwise it would delete the worker pods and
-	// kill the queries the draining CP is waiting to finish.
-	pool, cs := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-	drainingPeerID := "cp-draining-peer:boot-456"
-
-	// Create the draining peer's CP pod — it's still running (draining, not dead).
-	_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "cp-draining-peer", Namespace: "default"},
-	}, metav1.CreateOptions{})
-
-	// The mock returns whatever the test sets in liveCPIDs; the production
-	// store query is `state <> expired` so callers always get both active
-	// and draining CPs in this list.
-	store := &captureRuntimeWorkerStore{
-		liveCPIDs: []string{"cp-self:boot-123", drainingPeerID},
-		stateBeforeRows: []configstore.WorkerRecord{
-			// A warm idle row owned (still!) by the draining peer. Even
-			// though idle rows have empty owner in the production code,
-			// exercise the owner-active path here to make sure draining
-			// owners are honored.
-			{
-				WorkerID:          50,
-				PodName:           "duckgres-worker-draining-warm",
-				State:             configstore.WorkerStateIdle,
-				OwnerCPInstanceID: drainingPeerID,
-				UpdatedAt:         time.Now().Add(-2 * time.Hour),
-			},
-		},
-	}
-	pool.runtimeStore = store
-
-	// Worker pod owned by the draining peer — pretend it's serving a
-	// long-running query right now.
-	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "duckgres-worker-draining-busy",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":                     "duckgres-worker",
-				"duckgres/cp-instance-id": controlPlaneIDLabelValue(drainingPeerID),
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pool.cleanupOrphanedWorkers()
-
-	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=duckgres-worker",
-	})
-	survived := false
-	for _, p := range pods.Items {
-		if p.Name == "duckgres-worker-draining-busy" {
-			survived = true
-		}
-	}
-	if !survived {
-		t.Fatal("draining peer's worker pod was deleted — would kill in-flight queries")
-	}
-
-	if rows := store.snapshot(); len(rows) != 0 {
-		t.Fatalf("draining peer's idle row was marked lost: %#v", rows)
-	}
-}
-
-func TestCleanupOrphanedWorkers_GracePeriodProtectsFreshRows(t *testing.T) {
-	// The mock honors the cutoff itself, so passing a fresh updated_at row
-	// exercises the grace-period filter end-to-end: the sweep asks for rows
-	// older than (now - 30s), the mock filters them out, and nothing is
-	// marked lost.
-	pool, _ := newTestK8sPool(t, 5)
-	pool.cpInstanceID = "cp-self:boot-123"
-
-	store := &captureRuntimeWorkerStore{
-		liveCPIDs: []string{"cp-self:boot-123"},
-		stateBeforeRows: []configstore.WorkerRecord{
-			{
-				WorkerID:          21,
-				PodName:           "duckgres-worker-fresh",
-				State:             configstore.WorkerStateSpawning,
-				OwnerCPInstanceID: "",
-				UpdatedAt:         time.Now(),
-			},
-		},
-	}
-	pool.runtimeStore = store
-
-	pool.cleanupOrphanedWorkers()
-
-	if rows := store.snapshot(); len(rows) != 0 {
-		t.Fatalf("expected fresh row to be skipped by grace period, got upserts: %#v", rows)
-	}
-	if store.stateBeforeCalls != 1 {
-		t.Fatalf("expected one ListWorkerRecordsByStatesBefore call, got %d", store.stateBeforeCalls)
-	}
-	if cutoff := store.stateBeforeCutoff; cutoff.IsZero() || time.Since(cutoff) < staleWorkerRowGracePeriod {
-		t.Fatalf("expected cutoff at least %s in the past, got %v (now-cutoff=%s)", staleWorkerRowGracePeriod, cutoff, time.Since(cutoff))
-	}
-}
 
 func TestWorkerScheduling_NodeSelectorAndToleration(t *testing.T) {
 	pool := &K8sWorkerPool{
@@ -2368,5 +1945,146 @@ func TestParseNodeSelector(t *testing.T) {
 	// Invalid JSON
 	if parseNodeSelector("not-json") != nil {
 		t.Fatal("expected nil for invalid JSON")
+	}
+}
+
+// mismatchVersionTestPool builds a pool whose cpID looks like a Deployment
+// pod ("duckgres-<rshash>-<podhash>") so trimK8sPodHashSuffix yields a
+// comparable version prefix.
+func mismatchVersionTestPool(t *testing.T, cpID string, store RuntimeWorkerStore) (*K8sWorkerPool, *fake.Clientset) {
+	t.Helper()
+	cs := fake.NewClientset()
+	pool := &K8sWorkerPool{
+		workers:      make(map[int]*ManagedWorker),
+		shutdownCh:   make(chan struct{}),
+		stopInform:   make(chan struct{}),
+		clientset:    cs,
+		namespace:    "default",
+		cpID:         cpID,
+		cpInstanceID: cpID + "-boot",
+		runtimeStore: store,
+		retireSem:    make(chan struct{}, 5),
+	}
+	return pool, cs
+}
+
+func createMismatchWorkerPod(t *testing.T, cs *fake.Clientset, name, controlPlaneLabel, workerIDLabel string) {
+	t.Helper()
+	_, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                    "duckgres-worker",
+				"duckgres/control-plane": controlPlaneLabel,
+				"duckgres/worker-id":     workerIDLabel,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create pod %q: %v", name, err)
+	}
+}
+
+func TestRetireOneMismatchedVersionWorker_RetiresOlderVersionIdleWorker(t *testing.T) {
+	store := &captureRuntimeWorkerStore{}
+	pool, cs := mismatchVersionTestPool(t, "duckgres-newhash-aaaaa", store)
+	createMismatchWorkerPod(t, cs, "duckgres-oldhash-worker-7", "duckgres-oldhash-zzzzz", "7")
+
+	if !pool.RetireOneMismatchedVersionWorker(context.Background()) {
+		t.Fatal("expected reaper to retire one mismatched worker")
+	}
+	if store.retireIdleCalls != 1 || len(store.retireIdleCalledIDs) != 1 || store.retireIdleCalledIDs[0] != 7 {
+		t.Fatalf("expected one RetireIdleWorker(7) call, got calls=%d ids=%v", store.retireIdleCalls, store.retireIdleCalledIDs)
+	}
+	if reason := store.retireIdleCalledReasons[0]; reason != "version_mismatch" {
+		t.Fatalf("expected reason version_mismatch, got %q", reason)
+	}
+	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if len(pods.Items) != 0 {
+		t.Fatalf("expected pod to be deleted, got %d remaining", len(pods.Items))
+	}
+}
+
+func TestRetireOneMismatchedVersionWorker_LeavesSameVersionWorkersAlone(t *testing.T) {
+	store := &captureRuntimeWorkerStore{}
+	pool, cs := mismatchVersionTestPool(t, "duckgres-samehash-aaaaa", store)
+	createMismatchWorkerPod(t, cs, "duckgres-samehash-worker-1", "duckgres-samehash-bbbbb", "1")
+	createMismatchWorkerPod(t, cs, "duckgres-samehash-worker-2", "duckgres-samehash-ccccc", "2")
+
+	if pool.RetireOneMismatchedVersionWorker(context.Background()) {
+		t.Fatal("expected reaper to find nothing to retire when all workers share the version")
+	}
+	if store.retireIdleCalls != 0 {
+		t.Fatalf("expected no retirement calls, got %d", store.retireIdleCalls)
+	}
+	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if len(pods.Items) != 2 {
+		t.Fatalf("expected both pods to survive, got %d", len(pods.Items))
+	}
+}
+
+func TestRetireOneMismatchedVersionWorker_RetiresOnePerCall(t *testing.T) {
+	store := &captureRuntimeWorkerStore{}
+	pool, cs := mismatchVersionTestPool(t, "duckgres-new-aaaaa", store)
+	createMismatchWorkerPod(t, cs, "duckgres-old-worker-10", "duckgres-old-xxxxx", "10")
+	createMismatchWorkerPod(t, cs, "duckgres-old-worker-11", "duckgres-old-yyyyy", "11")
+	createMismatchWorkerPod(t, cs, "duckgres-old-worker-12", "duckgres-old-zzzzz", "12")
+
+	// Each call should retire at most one pod so replenishment can refill the
+	// slot with a new-version pod between ticks.
+	for i := 0; i < 3; i++ {
+		if !pool.RetireOneMismatchedVersionWorker(context.Background()) {
+			t.Fatalf("expected a retirement on call %d", i+1)
+		}
+	}
+	if pool.RetireOneMismatchedVersionWorker(context.Background()) {
+		t.Fatal("expected no more retirements after all mismatched pods removed")
+	}
+	if store.retireIdleCalls != 3 {
+		t.Fatalf("expected exactly 3 retirement attempts, got %d", store.retireIdleCalls)
+	}
+}
+
+func TestRetireOneMismatchedVersionWorker_SkipsWhenNotIdle(t *testing.T) {
+	// RetireIdleWorker returns false when the row is no longer idle (busy,
+	// reserved, hot-idle, etc.). The reaper must skip those pods and leave
+	// them running — it will try again on the next tick.
+	store := &captureRuntimeWorkerStore{
+		retireIdleMisses: map[int]bool{5: true},
+	}
+	pool, cs := mismatchVersionTestPool(t, "duckgres-new-aaaaa", store)
+	createMismatchWorkerPod(t, cs, "duckgres-old-worker-5", "duckgres-old-zzzzz", "5")
+	createMismatchWorkerPod(t, cs, "duckgres-old-worker-6", "duckgres-old-zzzzz", "6")
+
+	if !pool.RetireOneMismatchedVersionWorker(context.Background()) {
+		t.Fatal("expected reaper to skip busy worker 5 and retire worker 6")
+	}
+	remaining := map[string]bool{}
+	pods, _ := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	for _, p := range pods.Items {
+		remaining[p.Name] = true
+	}
+	if !remaining["duckgres-old-worker-5"] {
+		t.Fatal("expected busy worker 5 pod to survive (atomic CAS returned false)")
+	}
+	if remaining["duckgres-old-worker-6"] {
+		t.Fatal("expected idle worker 6 pod to be deleted")
+	}
+}
+
+func TestRetireOneMismatchedVersionWorker_NoopWhenCPIDHasNoHashSuffix(t *testing.T) {
+	// Standalone/StatefulSet deployments won't have a ReplicaSet hash in the
+	// CP pod name, so version comparison isn't meaningful. The reaper must be
+	// a no-op rather than retiring everything it can't parse.
+	store := &captureRuntimeWorkerStore{}
+	pool, cs := mismatchVersionTestPool(t, "some-bare-hostname", store)
+	createMismatchWorkerPod(t, cs, "stray-worker-1", "duckgres-somehash-aaaaa", "1")
+
+	if pool.RetireOneMismatchedVersionWorker(context.Background()) {
+		t.Fatal("expected no-op when cpID has no pod-hash suffix")
+	}
+	if store.retireIdleCalls != 0 {
+		t.Fatalf("expected no retirement calls, got %d", store.retireIdleCalls)
 	}
 }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -239,6 +239,11 @@ func SetupMultiTenant(
 			slog.Warn("Janitor failed to reconcile shared warm capacity.", "target", target, "error", err)
 		}
 	}
+	janitor.retireMismatchedVersionWorker = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		router.sharedPool.RetireOneMismatchedVersionWorker(ctx)
+	}
 	janitorLeader, err := NewJanitorLeaderManager(namespace, cpInstanceID, janitor)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -81,8 +81,7 @@ type RuntimeWorkerStore interface {
 	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
-	ListLiveControlPlaneInstanceIDs() ([]string, error)
-	ListWorkerRecordsByStatesBefore(states []configstore.WorkerState, updatedBefore time.Time) ([]configstore.WorkerRecord, error)
+	RetireIdleWorker(workerID int, reason string) (bool, error)
 }
 
 // K8sPoolFactory creates a K8sWorkerPool. Registered at init time by the


### PR DESCRIPTION
## Summary

Remove the CP startup orphan sweep and replace it with a janitor-leader-driven version-aware reaper that gradually retires warm workers spawned by older Deployment versions.

## Background

The startup sweep (`cleanupOrphanedWorkers`) deleted worker pods whose `duckgres/cp-instance-id` label pointed at a CP it deemed dead. Two problems compounded during the recent rollout (#414):

1. **Parse bug**: the pod-existence check split the CP instance ID on `:`, but `makeControlPlaneInstanceID` joins with `-`. Every peer CP came back NotFound and was flagged as dead.
2. **Wrong premise**: shared warm workers are jointly usable by all CPs. No CP should be authoritative over another CP's pods. Even with a correct parse, the sweep would delete healthy peer workers during rolling deployments.

The combination caused a ping-pong loop: new CP swept peer workers → peer CPs replenished them with old-version binaries → new CP swept again, repeat until old CPs exited.

## Design

Leader-driven gradual replacement, built on existing primitives:

- `K8sWorkerPool.RetireOneMismatchedVersionWorker(ctx)` lists shared worker pods, finds one whose `duckgres/control-plane` label (trimmed via `trimK8sPodHashSuffix`) differs from this CP's, atomically transitions its DB row from `idle` to `retired` (new `ConfigStore.RetireIdleWorker` CAS), and deletes the pod. Busy / hot-idle workers are left for a later tick.
- `ControlPlaneJanitor.runOnce` invokes the reaper each tick, but because the janitor is wrapped by `JanitorLeaderManager`, only the lease holder ever executes it — single writer, no races, no ping-pong.
- Combined with the existing `reconcileWarmCapacity` call that follows, the retired slot is immediately refilled with a new-version worker spawned by the leader.

During a rolling update:
1. Old leader sees all workers match its version → no-op.
2. Lease eventually transfers to a new-version CP.
3. New leader gradually reaps old-version workers, warm pool refills with new-version pods.

The comparable-version prefix is derived from the existing `duckgres/control-plane` pod label, same trimming function as #414. No new label needed. Naturally degrades to a no-op for non-Deployment CP pods (bare host, StatefulSet).

## Changes

- **`controlplane/configstore/store.go`**: add `RetireIdleWorker(workerID, reason)` atomic CAS.
- **`controlplane/worker_pool.go`**: swap `ListLiveControlPlaneInstanceIDs` / `ListWorkerRecordsByStatesBefore` for `RetireIdleWorker` on the `RuntimeWorkerStore` interface (the removed methods have no remaining callers).
- **`controlplane/k8s_pool.go`**: delete `cleanupOrphanedWorkers` and its startup call, add `RetireOneMismatchedVersionWorker`.
- **`controlplane/janitor.go`**: add `retireMismatchedVersionWorker` hook, invoked before `reconcileWarmCapacity` so replenishment immediately refills retired slots.
- **`controlplane/multitenant.go`**: wire the hook to `router.sharedPool`.
- **Tests**: remove all `TestCleanupOrphanedWorkers_*` tests, add 5 tests for the new reaper + a janitor ordering test.

## Test plan

- [x] `go test -tags kubernetes ./controlplane/... ./server/... ./transpiler/... ./duckdbservice/...` passes.
- [ ] CI covers the docker-backed admin/configstore integration tests.
- [ ] Deploy to dev, trigger a rolling update, confirm:
  - No workers are reaped at the new CP's startup.
  - Once lease transfers, workers are replaced gradually (one per janitor tick) with new-version pods.
  - No ping-pong; no worker-count dips beyond the warm target.