### PR TITLE
test(k8s): replace CP-deletion GC test with version-mismatch reaper test

### DIFF
--- a/tests/k8s/k8s_test.go
+++ b/tests/k8s/k8s_test.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/lib/pq"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -284,107 +285,89 @@ func TestK8sWorkerSecurityContext(t *testing.T) {
 	}
 }
 
-func TestK8sCPDeletionGarbageCollects(t *testing.T) {
-	// Ensure a worker exists
+// TestK8sVersionMismatchedWorkerIsReaped verifies the leader-driven
+// rolling-replacement behavior introduced when the startup orphan sweep was
+// removed: when a shared warm worker pod's duckgres/control-plane label
+// identifies a different Deployment ReplicaSet than the running CP's, the
+// janitor leader retires it via an atomic idle->retired CAS and deletes the
+// pod. Together with reconcileWarmCapacity in the same tick the slot is
+// refilled with a current-version worker, so deployment rollouts replace
+// shared workers gradually instead of in a destructive cross-CP sweep.
+//
+// We simulate the version mismatch by mutating an existing warm worker's
+// label to a fake Deployment hash. The reaper has no way to distinguish a
+// genuine prior-rollout pod from this fake one, which is precisely what we
+// want to assert.
+func TestK8sVersionMismatchedWorkerIsReaped(t *testing.T) {
+	// Make sure at least one shared warm worker is up.
 	if err := retryQueryWithReconnect("SELECT 1", 30*time.Second); err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
 
-	// List worker pods
+	// Brief idle window so the worker settles back into idle state in the
+	// configstore — RetireIdleWorker is a state-conditional CAS that no-ops
+	// on busy/reserved/hot rows.
+	time.Sleep(3 * time.Second)
+
 	workerPods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "app=duckgres-worker",
 	})
 	if err != nil {
-		t.Fatalf("failed to list worker pods: %v", err)
+		t.Fatalf("list worker pods: %v", err)
 	}
-	if len(workerPods.Items) == 0 {
-		t.Skip("no worker pods found — cannot test GC")
-	}
-
-	ownedWorkers := workerPodsByControlPlaneLabel(workerPods.Items)
-	if len(ownedWorkers) == 0 {
-		t.Skip("no worker pods with duckgres/control-plane label found")
-	}
-
-	// Delete a CP pod that currently owns at least one worker.
-	var cpName string
-	var workerNames []string
-	for ownerName, owned := range ownedWorkers {
-		if len(owned) > 0 {
-			cpName = ownerName
-			workerNames = append([]string(nil), owned...)
-			break
+	var target *corev1.Pod
+	for i := range workerPods.Items {
+		p := &workerPods.Items[i]
+		// Shared warm workers (no duckgres/org label) only — the version
+		// reaper currently runs against the shared pool.
+		if p.Labels["duckgres/org"] != "" {
+			continue
 		}
-	}
-	if cpName == "" {
-		t.Skip("no control-plane-owned worker pods found")
-	}
-
-	cpPods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=duckgres-control-plane",
-	})
-	if err != nil || len(cpPods.Items) == 0 {
-		t.Fatalf("failed to find CP pod: %v", err)
-	}
-	foundCP := false
-	for _, pod := range cpPods.Items {
-		if pod.Name == cpName {
-			foundCP = true
-			break
+		if p.Labels["duckgres/control-plane"] == "" || p.Labels["duckgres/worker-id"] == "" {
+			continue
 		}
-	}
-	if !foundCP {
-		t.Skipf("control-plane pod %s no longer exists", cpName)
-	}
-	gracePeriodSeconds := int64(0)
-	t.Logf("Force deleting CP pod %s to test crash-style garbage collection", cpName)
-	err = clientset.CoreV1().Pods(namespace).Delete(context.Background(), cpName, metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriodSeconds,
-	})
-	if err != nil {
-		t.Fatalf("failed to delete CP pod: %v", err)
-	}
-
-	// Wait for the deleted control plane's worker pods to be retired.
-	allGone := false
-	deadline := time.Now().Add(90 * time.Second)
-	for time.Now().Before(deadline) {
-		remaining := 0
-		for _, name := range workerNames {
-			_, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
-			switch {
-			case err == nil:
-				remaining++
-			case isPodGoneError(err):
-				continue
-			default:
-				t.Logf("transient error checking worker pod %s deletion: %v", name, err)
-				remaining++
-			}
+		if p.DeletionTimestamp != nil {
+			continue
 		}
-		if remaining == 0 {
-			allGone = true
-			break
+		if p.Status.Phase != corev1.PodRunning {
+			continue
 		}
-		time.Sleep(2 * time.Second)
+		target = p
+		break
 	}
-	if !allGone {
-		t.Error("worker pods were not garbage-collected after CP deletion within 90s")
-	}
-
-	// Wait for the deployment to recreate the CP
-	if err := waitForDeployment(namespace, "duckgres-control-plane", 120*time.Second); err != nil {
-		t.Fatalf("CP deployment did not recover: %v", err)
+	if target == nil {
+		t.Skip("no eligible shared warm worker pod found")
 	}
 
-	// Restart port-forward since the old CP pod is gone
-	if err := restartPortForward(); err != nil {
-		t.Fatalf("failed to restart port-forward: %v", err)
+	originalCPLabel := target.Labels["duckgres/control-plane"]
+	// Pick a pod-template-hash segment that's clearly different from the
+	// real one so trimK8sPodHashSuffix yields a distinct version prefix.
+	fakeCPLabel := "duckgres-control-plane-deadbeef00-fake1"
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"duckgres/control-plane":%q}}}`, fakeCPLabel))
+	if _, err := clientset.CoreV1().Pods(namespace).Patch(
+		context.Background(),
+		target.Name,
+		k8stypes.StrategicMergePatchType,
+		patch,
+		metav1.PatchOptions{},
+	); err != nil {
+		t.Fatalf("patch pod %s control-plane label: %v", target.Name, err)
+	}
+	t.Logf("Mutated pod %s control-plane label %q -> %q; expecting leader version reaper to retire it",
+		target.Name, originalCPLabel, fakeCPLabel)
+
+	// Janitor leader runs every 5s; allow generous slack for leader lease
+	// acquisition, configstore CAS, pod delete + grace.
+	waitForPodGone(t, namespace, target.Name, 90*time.Second)
+	if _, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), target.Name, metav1.GetOptions{}); !isPodGoneError(err) {
+		t.Fatalf("pod %s with mismatched-version label was not reaped within 90s (err=%v)", target.Name, err)
 	}
 
-	// Verify the system works again
-	if err := retryQueryWithReconnect("SELECT 1", 60*time.Second); err != nil {
-		t.Fatalf("query failed after CP recreation: %v", err)
+	// System should still serve traffic — replenishment happens in the same
+	// janitor tick that retired the mismatched worker, so there should be no
+	// observable capacity dip.
+	if err := retryQueryWithReconnect("SELECT 1", 30*time.Second); err != nil {
+		t.Fatalf("query after version reaper retired worker failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #415. Replace the obsolete `TestK8sCPDeletionGarbageCollects` integration test with one that exercises the new leader-driven version-aware reaper.

## Why

`TestK8sCPDeletionGarbageCollects` asserted the contract #415 deliberately removed: that worker pods labeled with a force-deleted CP's instance ID would be cleaned up within ~90s. The old startup orphan sweep made that cleanup near-instant; with it gone, the only mechanism is the periodic janitor's `ListOrphanedWorkers`, which needs `expiryTimeout (20s) + orphanGrace (30s) = 50s` minimum to even start. The test was flaky (sometimes passed by incidental side effects in the spawn path's "delete stale pod with same name" line, sometimes timed out at 90s).

## What

`TestK8sVersionMismatchedWorkerIsReaped`:
1. Triggers a query so a shared warm worker exists.
2. Picks a running shared warm worker pod (no `duckgres/org` label, has `duckgres/control-plane` and `duckgres/worker-id` labels).
3. Patches its `duckgres/control-plane` label to a fake `duckgres-control-plane-deadbeef00-fake1`, simulating a worker spawned by an older Deployment ReplicaSet.
4. Waits up to 90s for the janitor leader (5s tick) to detect the version mismatch, atomic-CAS the configstore row from idle→retired, and delete the pod.
5. Confirms the system still serves traffic afterwards (replenishment runs in the same janitor tick).

The reaper has no way to distinguish a real prior-rollout pod from this fake one — that's the property under test.

## Test plan

- [x] `go build -tags k8s_integration ./tests/k8s/...` clean.
- [x] `go test ./tests/k8s/...` (non-integration unit tests in the package) passes.
- [ ] CI `k8s-integration-tests` job exercises the new test against kind.