### PR TITLE
Fix Flight listener handover and health checks

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -104,6 +104,7 @@ type ControlPlane struct {
 	rateLimiter     *server.RateLimiter
 	tlsConfig       *tls.Config
 	pgListener      net.Listener
+	flightListener  net.Listener
 	upgrader        *tableflip.Upgrader
 	parentPID       int // tableflip parent PID (0 if first generation)
 	activeConns     int64
@@ -241,6 +242,16 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		os.Exit(1)
 	}
 
+	var flightLn net.Listener
+	if cfg.FlightPort > 0 {
+		flightAddr := fmt.Sprintf("%s:%d", cfg.Host, cfg.FlightPort)
+		flightLn, err = upg.Listen("tcp", flightAddr)
+		if err != nil {
+			slog.Error("Failed to listen.", "addr", flightAddr, "error", err)
+			os.Exit(1)
+		}
+	}
+
 	// Save the tableflip parent PID before it potentially exits and we get
 	// reparented to init. We need this to kill a stuck parent during future
 	// upgrades (tableflip requires the parent to exit before the child can
@@ -249,6 +260,9 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	if upg.HasParent() {
 		parentPID = os.Getppid()
 		slog.Info("Upgrade complete, inherited PG listener.", "addr", pgLn.Addr().String())
+		if flightLn != nil {
+			slog.Info("Upgrade complete, inherited Flight listener.", "addr", flightLn.Addr().String())
+		}
 	}
 
 	if !isK8s {
@@ -334,6 +348,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		rateLimiter:     server.NewRateLimiter(cfg.RateLimit),
 		tlsConfig:       tlsCfg,
 		pgListener:      pgLn,
+		flightListener:  flightLn,
 		upgrader:        upg,
 		parentPID:       parentPID,
 		acmeManager:     acmeMgr,
@@ -343,7 +358,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 
 	// Multi-tenant mode: config store + per-org pools (K8s remote backend only)
 	if cfg.WorkerBackend == "remote" {
-		store, adapter, apiServer, runtimeTracker, janitorLeader, err := SetupMultiTenant(cfg, srv, memBudget, k8sMaxWorkers)
+		store, adapter, apiServer, runtimeTracker, janitorLeader, err := SetupMultiTenant(cfg, srv, memBudget, k8sMaxWorkers, cp.healthReady)
 		if err != nil {
 			slog.Error("Failed to set up multi-tenant config store.", "error", err)
 			os.Exit(1)
@@ -447,11 +462,9 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		go pool.HealthCheckLoop(makeShutdownCtx(), cfg.HealthCheckInterval, onCrash, onProgress)
 	}
 
-	// Flight ingress is created AFTER upgrade so the old CP can keep
-	// serving Flight SQL clients until it shuts down its listener in
-	// drainAfterUpgrade. This minimizes the Flight unavailability
-	// window to just the brief port rebind, rather than the entire
-	// upgrade + pre-warm duration.
+	// Flight ingress is created after worker/session wiring, but the TCP
+	// listener itself is pre-bound via tableflip so upgrades inherit the
+	// socket instead of racing a re-bind on the old process's 8815 listener.
 	cp.startFlightIngress()
 
 	// Handle SIGUSR1 for graceful upgrade (process mode only)
@@ -1236,6 +1249,19 @@ func (cp *ControlPlane) isDraining() bool {
 	return cp.runtimeTracker != nil && cp.runtimeTracker.Draining()
 }
 
+func (cp *ControlPlane) healthReady() bool {
+	if cp == nil {
+		return false
+	}
+	if cp.isDraining() {
+		return false
+	}
+	if cp.cfg.FlightPort <= 0 {
+		return true
+	}
+	return cp.flight != nil && cp.flight.Healthy()
+}
+
 func (cp *ControlPlane) stopQueryLogger() {
 	if cp.srv != nil && cp.srv.QueryLogger() != nil {
 		cp.srv.QueryLogger().Stop()
@@ -1411,8 +1437,6 @@ func (cp *ControlPlane) drainAfterUpgrade() {
 }
 
 // startFlightIngress creates and starts the Flight SQL ingress listener.
-// During upgrade, the old CP's Flight listener may still be shutting down,
-// so we retry port binding briefly before giving up.
 func (cp *ControlPlane) startFlightIngress() {
 	if cp.cfg.FlightPort <= 0 {
 		return
@@ -1458,17 +1482,14 @@ func (cp *ControlPlane) startFlightIngress() {
 		WorkerQueueTimeout: cp.cfg.WorkerQueueTimeout,
 	}
 
-	var flightIngress *FlightIngress
-	var err error
-	for attempt := 0; attempt < 10; attempt++ {
+	var (
+		flightIngress *FlightIngress
+		err           error
+	)
+	if cp.flightListener != nil {
+		flightIngress, err = NewFlightIngressFromListener(cp.flightListener, cp.tlsConfig, validator, provider, cp.rateLimiter, flightCfg)
+	} else {
 		flightIngress, err = NewFlightIngress(cp.cfg.Host, cp.cfg.FlightPort, cp.tlsConfig, validator, provider, cp.rateLimiter, flightCfg)
-		if err == nil {
-			break
-		}
-		if attempt < 9 {
-			slog.Warn("Flight ingress port not yet available, retrying...", "attempt", attempt+1, "error", err)
-			time.Sleep(500 * time.Millisecond)
-		}
 	}
 	if err != nil {
 		slog.Error("Failed to initialize Flight ingress, continuing without Flight SQL.", "error", err)

--- a/controlplane/flight_ingress.go
+++ b/controlplane/flight_ingress.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -21,6 +22,16 @@ type FlightIngress = flightsqlingress.FlightIngress
 // NewFlightIngress creates a control-plane Flight SQL ingress listener.
 func NewFlightIngress(host string, port int, tlsConfig *tls.Config, validator flightsqlingress.CredentialValidator, provider flightsqlingress.SessionProvider, rateLimiter *server.RateLimiter, cfg FlightIngressConfig) (*FlightIngress, error) {
 	return flightsqlingress.NewFlightIngress(host, port, tlsConfig, validator, provider, cfg, flightsqlingress.Options{
+		RateLimiter: rateLimiter,
+		Hooks: flightsqlingress.Hooks{
+			OnSessionCountChanged: observeFlightAuthSessions,
+			OnSessionsReaped:      observeFlightSessionsReaped,
+		},
+	})
+}
+
+func NewFlightIngressFromListener(listener net.Listener, tlsConfig *tls.Config, validator flightsqlingress.CredentialValidator, provider flightsqlingress.SessionProvider, rateLimiter *server.RateLimiter, cfg FlightIngressConfig) (*FlightIngress, error) {
+	return flightsqlingress.NewFlightIngressFromListener(listener, tlsConfig, validator, provider, cfg, flightsqlingress.Options{
 		RateLimiter: rateLimiter,
 		Hooks: flightsqlingress.Hooks{
 			OnSessionCountChanged: observeFlightAuthSessions,

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -130,6 +130,7 @@ func SetupMultiTenant(
 	srv *server.Server,
 	memBudget uint64,
 	maxWorkers int,
+	isHealthy func() bool,
 ) (ConfigStoreInterface, OrgRouterInterface, *http.Server, *ControlPlaneRuntimeTracker, *JanitorLeaderManager, error) {
 	pollInterval := cfg.ConfigPollInterval
 	if pollInterval <= 0 {
@@ -281,7 +282,7 @@ func SetupMultiTenant(
 	engine.Use(gin.Recovery())
 
 	// Health endpoint (unauthenticated, used by K8s probes)
-	engine.GET("/health", newHealthHandler(runtimeTracker.Draining))
+	engine.GET("/health", newHealthHandler(isHealthy))
 
 	// Authenticated API
 	api := engine.Group("/api/v1", admin.APIAuthMiddleware(internalSecret))
@@ -316,10 +317,10 @@ func resolveK8sNamespace(namespace string) (string, error) {
 	return string(ns), nil
 }
 
-func newHealthHandler(isDraining func() bool) gin.HandlerFunc {
+func newHealthHandler(isHealthy func() bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if isDraining != nil && isDraining() {
-			c.String(http.StatusServiceUnavailable, "draining")
+		if isHealthy != nil && !isHealthy() {
+			c.String(http.StatusServiceUnavailable, "unhealthy")
 			return
 		}
 		c.String(http.StatusOK, "ok")

--- a/controlplane/multitenant_stub.go
+++ b/controlplane/multitenant_stub.go
@@ -15,6 +15,7 @@ func SetupMultiTenant(
 	srv *server.Server,
 	memBudget uint64,
 	maxWorkers int,
+	isHealthy func() bool,
 ) (ConfigStoreInterface, OrgRouterInterface, *http.Server, *ControlPlaneRuntimeTracker, *JanitorLeaderManager, error) {
 	return nil, nil, nil, nil, nil, fmt.Errorf("multi-tenant mode requires -tags kubernetes build")
 }

--- a/controlplane/multitenant_test.go
+++ b/controlplane/multitenant_test.go
@@ -10,24 +10,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestHealthHandlerReturnsServiceUnavailableWhenDraining(t *testing.T) {
+func TestHealthHandlerReturnsServiceUnavailableWhenUnhealthy(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
-	engine.GET("/health", newHealthHandler(func() bool { return true }))
+	engine.GET("/health", newHealthHandler(func() bool { return false }))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 	engine.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 while draining, got %d", rec.Code)
+		t.Fatalf("expected 503 while unhealthy, got %d", rec.Code)
 	}
 }
 
-func TestHealthHandlerReturnsOKWhenNotDraining(t *testing.T) {
+func TestHealthHandlerReturnsOKWhenHealthy(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
-	engine.GET("/health", newHealthHandler(func() bool { return false }))
+	engine.GET("/health", newHealthHandler(func() bool { return true }))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()

--- a/server/flightsqlingress/ingress.go
+++ b/server/flightsqlingress/ingress.go
@@ -154,6 +154,7 @@ type FlightIngress struct {
 	listenerAddr  string
 	shutdownOnce  sync.Once
 	shutdownState atomic.Bool
+	servingState  atomic.Bool
 	wg            sync.WaitGroup
 }
 
@@ -161,10 +162,28 @@ func NewFlightIngress(host string, port int, tlsConfig *tls.Config, validator Cr
 	if port <= 0 {
 		return nil, fmt.Errorf("invalid flight port: %d", port)
 	}
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	baseListener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("flight listen %s: %w", addr, err)
+	}
+
+	ingress, err := NewFlightIngressFromListener(baseListener, tlsConfig, validator, provider, cfg, opts)
+	if err != nil {
+		_ = baseListener.Close()
+		return nil, err
+	}
+	return ingress, nil
+}
+
+func NewFlightIngressFromListener(baseListener net.Listener, tlsConfig *tls.Config, validator CredentialValidator, provider SessionProvider, cfg Config, opts Options) (*FlightIngress, error) {
+	if baseListener == nil {
+		return nil, fmt.Errorf("listener is required for Flight ingress")
+	}
 	if tlsConfig == nil {
 		return nil, fmt.Errorf("TLS config is required for Flight ingress")
 	}
-	addr := fmt.Sprintf("%s:%d", host, port)
 
 	// gRPC requires ALPN "h2" for TLS transport.
 	flightTLSConfig := tlsConfig.Clone()
@@ -172,10 +191,7 @@ func NewFlightIngress(host string, port int, tlsConfig *tls.Config, validator Cr
 		flightTLSConfig.NextProtos = append(flightTLSConfig.NextProtos, "h2")
 	}
 
-	ln, err := tls.Listen("tcp", addr, flightTLSConfig)
-	if err != nil {
-		return nil, fmt.Errorf("flight listen %s: %w", addr, err)
-	}
+	ln := tls.NewListener(baseListener, flightTLSConfig)
 
 	if cfg.SessionIdleTTL <= 0 {
 		cfg.SessionIdleTTL = defaultFlightSessionIdleTTL
@@ -222,13 +238,22 @@ func (fi *FlightIngress) Addr() string {
 
 // Start begins serving in the background.
 func (fi *FlightIngress) Start() {
+	fi.servingState.Store(true)
 	fi.wg.Add(1)
 	go func() {
 		defer fi.wg.Done()
+		defer fi.servingState.Store(false)
 		if err := fi.flightSrv.Serve(); err != nil && !fi.shutdownState.Load() {
 			slog.Error("Flight ingress server exited.", "error", err)
 		}
 	}()
+}
+
+func (fi *FlightIngress) Healthy() bool {
+	if fi == nil || fi.shutdownState.Load() || !fi.servingState.Load() {
+		return false
+	}
+	return fi.sessionStore == nil || !fi.sessionStore.Draining()
 }
 
 func (fi *FlightIngress) BeginDrain() {

--- a/tests/controlplane/controlplane_test.go
+++ b/tests/controlplane/controlplane_test.go
@@ -230,6 +230,17 @@ func (h *cpHarness) waitForLog(substr string, timeout time.Duration) error {
 	return fmt.Errorf("log %q not found after %v", substr, timeout)
 }
 
+func (h *cpHarness) waitForLogCount(substr string, want int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Count(h.logBuf.String(), substr) >= want {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("log %q not found %d times after %v", substr, want, timeout)
+}
+
 func (h *cpHarness) cleanup(t *testing.T) {
 	t.Helper()
 

--- a/tests/controlplane/flight_ingress_test.go
+++ b/tests/controlplane/flight_ingress_test.go
@@ -214,3 +214,35 @@ func TestFlightIngressServerIssuedSessionTokenAllowsTokenOnlyAuth(t *testing.T) 
 		t.Fatalf("token+basic GetTables failed: %v", err)
 	}
 }
+
+func TestFlightIngressAcceptsNewConnectionsAfterHandover(t *testing.T) {
+	h := startControlPlane(t, cpOpts{
+		flightPort: freePort(t),
+		maxWorkers: 1,
+	})
+	readyLogCount := strings.Count(h.logBuf.String(), "Control plane listening.")
+
+	client1 := newFlightClient(t, h.flightPort)
+	defer func() { _ = client1.Close() }()
+
+	ctx1, cancel1 := context.WithTimeout(flightAuthContext("testuser", "testpass"), 20*time.Second)
+	if _, err := client1.GetTables(ctx1, &flightsql.GetTablesOpts{}); err != nil {
+		cancel1()
+		t.Fatalf("pre-handover Flight bootstrap failed: %v", err)
+	}
+	cancel1()
+
+	h.doHandover(t)
+	if err := h.waitForLogCount("Control plane listening.", readyLogCount+1, 30*time.Second); err != nil {
+		t.Fatalf("child control plane did not reach ready state after handover: %v\nLogs:\n%s", err, h.logBuf.String())
+	}
+
+	client2 := newFlightClient(t, h.flightPort)
+	defer func() { _ = client2.Close() }()
+
+	ctx2, cancel2 := context.WithTimeout(flightAuthContext("testuser", "testpass"), 20*time.Second)
+	defer cancel2()
+	if _, err := client2.GetTables(ctx2, &flightsql.GetTablesOpts{}); err != nil {
+		t.Fatalf("post-handover Flight bootstrap failed: %v\nLogs:\n%s", err, h.logBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- inherit the Flight listener through tableflip so reloads do not lose port 8815
- make control-plane /health report unhealthy until Flight is actually serving, while preserving drain semantics
- tighten the Flight handover regression test to wait for the child ready signal before asserting post-handover connectivity

## Testing
- go test ./controlplane/... ./server/flightsqlingress/...
- go test ./tests/controlplane -run TestFlightIngressAcceptsNewConnectionsAfterHandover -count=1
- go test -tags kubernetes ./controlplane -run TestHealthHandler -count=1