### PR TITLE
feat(metrics): add org label and custom buckets to query duration

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -948,7 +948,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 	}()
 
 	start := time.Now()
-	defer func() { queryDurationHistogram.Observe(time.Since(start).Seconds()) }()
+	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 	slog.Debug("Query received.", "user", c.username, "query", query)
 
 	// Check for cursor operations (DECLARE, FETCH, CLOSE) before passthrough
@@ -4361,7 +4361,7 @@ func (c *clientConn) sendError(severity, code, message string) {
 	if strings.HasPrefix(code, "28") {
 		authFailuresCounter.Inc()
 	} else if severity == "ERROR" {
-		queryErrorsCounter.Inc()
+		queryErrorsCounter.WithLabelValues(c.orgID).Inc()
 	}
 	slog.Debug("Sending error to client.", "user", c.username, "severity", severity, "code", code, "message", message)
 	_ = writeErrorResponse(c.writer, severity, code, message)
@@ -4960,7 +4960,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	}
 
 	start := time.Now()
-	defer func() { queryDurationHistogram.Observe(time.Since(start).Seconds()) }()
+	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 
 	// Convert parameter values to interface{}, handling binary format
 	args, err := p.decodeParams()

--- a/server/server.go
+++ b/server/server.go
@@ -60,16 +60,16 @@ func IncrementOpenConnections() { connectionsGauge.Inc() }
 // DecrementOpenConnections decrements the open connections gauge.
 func DecrementOpenConnections() { connectionsGauge.Dec() }
 
-var queryDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+var queryDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "duckgres_query_duration_seconds",
 	Help:    "Query execution duration in seconds",
-	Buckets: prometheus.DefBuckets,
-})
+	Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 18000, 36000},
+}, []string{"org"})
 
-var queryErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+var queryErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "duckgres_query_errors_total",
 	Help: "Total number of failed queries",
-})
+}, []string{"org"})
 
 var authFailuresCounter = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "duckgres_auth_failures_total",


### PR DESCRIPTION
This PR improves the observability of query performance by:
- Adding an  label to  and  metrics, allowing for per-tenant grouping in dashboards.
- Replacing the default Prometheus buckets for query duration with a custom set of "human-friendly" boundaries (0.1s, 0.5s, 1s, ..., 1h, 2h, 5h, 10h). This ensures better resolution for long-running analytical queries while maintaining sub-second precision for fast lookups.
- Updating all call sites in  to correctly propagate the  from the client connection.

Verification:
- The  package compiles successfully.
- Metric labels and bucket boundaries have been verified against the Prometheus client implementation.