### PR TITLE
fix: allow perf publish bootstrap on ducklake

### DIFF
--- a/tests/perf/publisher/publisher.go
+++ b/tests/perf/publisher/publisher.go
@@ -311,7 +311,7 @@ func bootstrapSchema(ctx context.Context, tx txHandle, schema string) error {
 )`, schema),
 		fmt.Sprintf("ALTER TABLE %s.query_results ADD COLUMN IF NOT EXISTS measure_iteration INTEGER", schema),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.runs (
-  run_id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
   dataset_version TEXT NOT NULL,
   started_at TIMESTAMPTZ NOT NULL,
   finished_at TIMESTAMPTZ NOT NULL,

--- a/tests/perf/publisher/publisher_test.go
+++ b/tests/perf/publisher/publisher_test.go
@@ -185,6 +185,25 @@ func TestPublishArtifactsBootstrapsAndReplacesRunData(t *testing.T) {
 	}
 }
 
+func TestBootstrapSchemaDoesNotUseUnsupportedConstraints(t *testing.T) {
+	tx := &fakeTx{}
+
+	if err := bootstrapSchema(context.Background(), tx, "duckgres_perf"); err != nil {
+		t.Fatalf("bootstrapSchema returned error: %v", err)
+	}
+	if len(tx.execs) != 4 {
+		t.Fatalf("expected 4 bootstrap statements, got %d", len(tx.execs))
+	}
+
+	runsDDL := tx.execs[3].query
+	if !strings.Contains(runsDDL, "CREATE TABLE IF NOT EXISTS duckgres_perf.runs") {
+		t.Fatalf("unexpected runs ddl: %s", runsDDL)
+	}
+	if strings.Contains(runsDDL, "PRIMARY KEY") || strings.Contains(runsDDL, "UNIQUE") {
+		t.Fatalf("runs ddl should not use unsupported constraints: %s", runsDDL)
+	}
+}
+
 func TestPublishArtifactsRollsBackOnInsertFailure(t *testing.T) {
 	runDir := writeFixtureRunDir(t)
 	artifacts, err := loadArtifacts(runDir)


### PR DESCRIPTION
## Summary
- remove the unsupported PRIMARY KEY constraint from the bootstrapped perf publisher runs table
- keep the existing perf publish schema bootstrap flow intact for DuckLake-backed targets
- add a regression test that asserts the bootstrap DDL does not emit PRIMARY KEY or UNIQUE constraints

## Testing
- go test ./tests/perf/publisher
- one-off verification on the prod-us perf runner: temporarily checked out this commit on the runner, ran duckgres-perf-nightly.service, and the manual perf run completed successfully