### PR TITLE
ci: add CodeQL workflow for fork PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           languages: go
           build-mode: manual
-      - run: go build ./...
+      - run: go build .
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,5 +24,6 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@v3
+          build-mode: manual
+      - run: go build ./...
       - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Adds an explicit CodeQL workflow file so code scanning runs on PRs from forks
- The GitHub "default setup" CodeQL doesn't trigger on fork PRs, which blocks merging when CodeQL is a required status check (e.g. #300)

## Notes

After merging, disable the "default setup" CodeQL in repo settings (Settings > Code security and analysis) to avoid duplicate runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)