### PR TITLE
[codex] Fix SQL BEGIN transaction tracking

### DIFF
--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -553,18 +553,7 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	}
 
 	// Track SQL-level transaction state for BEGIN/COMMIT/ROLLBACK sent as raw SQL.
-	if isTxControl {
-		upper := strings.ToUpper(strings.TrimSpace(query))
-		if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START") {
-			if execErr == nil {
-				session.sqlTxActive.Store(true)
-			}
-		} else {
-			// COMMIT/ROLLBACK/END: transaction is over regardless of success/failure.
-			// Even if COMMIT fails, the transaction is dead.
-			session.sqlTxActive.Store(false)
-		}
-	}
+	trackSQLTransactionState(query, execErr, &session.sqlTxActive)
 	// Conflict retry for autocommit only (see GetFlightInfoStatement comment).
 	if execErr != nil && tx == nil && isDuckLakeTransactionConflict(execErr) {
 		ducklakeConflictTotal.Inc()

--- a/duckdbservice/transient.go
+++ b/duckdbservice/transient.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -23,6 +24,22 @@ func isTransactionControlStmt(query string) bool {
 	return strings.HasPrefix(upper, "COMMIT") ||
 		strings.HasPrefix(upper, "ROLLBACK") ||
 		strings.HasPrefix(upper, "END")
+}
+
+func trackSQLTransactionState(query string, execErr error, sqlTxActive *atomic.Bool) {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	if len(upper) == 0 {
+		return
+	}
+	if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START") {
+		if execErr == nil {
+			sqlTxActive.Store(true)
+		}
+		return
+	}
+	if isTransactionControlStmt(upper) {
+		sqlTxActive.Store(false)
+	}
 }
 
 // isTransientDuckLakeError returns true if the error message indicates a

--- a/duckdbservice/transient_test.go
+++ b/duckdbservice/transient_test.go
@@ -287,16 +287,7 @@ func TestRecoverAbortedTransactionReturnsRollbackFailure(t *testing.T) {
 func TestSQLTxActiveTracking(t *testing.T) {
 	var flag atomic.Bool
 
-	// Simulate DoPutCommandStatementUpdate tracking logic for BEGIN.
-	query := "BEGIN"
-	if isTransactionControlStmt(query) {
-		t.Fatal("BEGIN should NOT be a transaction control stmt")
-	}
-	// After successful BEGIN, set sqlTxActive.
-	upper := strings.ToUpper(strings.TrimSpace(query))
-	if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START") {
-		flag.Store(true)
-	}
+	trackSQLTransactionState("BEGIN", nil, &flag)
 	if !flag.Load() {
 		t.Fatal("sqlTxActive should be true after BEGIN")
 	}
@@ -307,14 +298,18 @@ func TestSQLTxActiveTracking(t *testing.T) {
 		t.Fatal("should be in transaction after BEGIN")
 	}
 
-	// After COMMIT (success or failure), clear sqlTxActive.
-	query = "COMMIT"
-	if !isTransactionControlStmt(query) {
-		t.Fatal("COMMIT should be a transaction control stmt")
-	}
-	flag.Store(false)
+	trackSQLTransactionState("COMMIT", nil, &flag)
 	if flag.Load() {
 		t.Fatal("sqlTxActive should be false after COMMIT")
+	}
+}
+
+func TestSQLTxActiveTrackingDoesNotStartOnFailedBegin(t *testing.T) {
+	var flag atomic.Bool
+
+	trackSQLTransactionState("BEGIN", errors.New("boom"), &flag)
+	if flag.Load() {
+		t.Fatal("sqlTxActive should remain false after failed BEGIN")
 	}
 }
 
@@ -395,18 +390,12 @@ func TestSQLTxActiveAllowsRetryOutsideTransaction(t *testing.T) {
 func TestStartTransactionTracking(t *testing.T) {
 	var flag atomic.Bool
 
-	// START TRANSACTION is an alias for BEGIN.
-	query := "START TRANSACTION"
-	upper := strings.ToUpper(strings.TrimSpace(query))
-	if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START") {
-		flag.Store(true)
-	}
+	trackSQLTransactionState("START TRANSACTION", nil, &flag)
 	if !flag.Load() {
 		t.Fatal("sqlTxActive should be true after START TRANSACTION")
 	}
 
-	// ROLLBACK clears it.
-	flag.Store(false)
+	trackSQLTransactionState("ROLLBACK", nil, &flag)
 	if flag.Load() {
 		t.Fatal("sqlTxActive should be false after ROLLBACK")
 	}


### PR DESCRIPTION
## Summary
- track raw SQL `BEGIN` and `START TRANSACTION` statements in the shared SQL transaction-state helper
- update the Flight SQL update path to always apply SQL transaction-state tracking after statement execution
- add regression coverage for successful and failed SQL-level transaction starts

## Why
A raw SQL `BEGIN` was intentionally excluded from `isTransactionControlStmt`, but `session.sqlTxActive` was only updated inside the transaction-control guard. That meant SQL-level transactions were not marked active after `BEGIN`, so later statements could be retried as if they were autocommit and mask the original transaction failure.

## Validation
- `go test ./duckdbservice/...`
- `just lint`