### PR TITLE
Add DuckDB profiling spans: planning, scan, compute breakdown

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -20,7 +20,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/server"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
@@ -748,7 +747,7 @@ func waitForWorkerTCPWithMetadata(addr, bearerToken string, serverCertPEM []byte
 			grpc.MaxCallRecvMsgSize(server.MaxGRPCMessageSize),
 			grpc.MaxCallSendMsgSize(server.MaxGRPCMessageSize),
 		))
-		dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+		dialOpts = append(dialOpts, server.OTELGRPCClientHandler())
 		if bearerToken != "" {
 			dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(&workerTLSBearerCreds{token: bearerToken}))
 		}
@@ -1438,7 +1437,7 @@ func (p *K8sWorkerPool) connectWorkerDirect(ctx context.Context, podName, podIP,
 		grpc.MaxCallRecvMsgSize(server.MaxGRPCMessageSize),
 		grpc.MaxCallSendMsgSize(server.MaxGRPCMessageSize),
 	))
-	dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+	dialOpts = append(dialOpts, server.OTELGRPCClientHandler())
 	if bearerToken != "" {
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(&workerTLSBearerCreds{token: bearerToken}))
 	}

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -371,6 +371,10 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare query: %v", err)
 	}
 
+	// Send DuckDB profiling output as gRPC trailing metadata so the
+	// control plane can attach it to the trace span.
+	sendProfilingMetadata(ctx, session)
+
 	handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 	session.mu.Lock()
 	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey}
@@ -577,6 +581,8 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	if execErr != nil {
 		return 0, status.Errorf(codes.InvalidArgument, "failed to execute update: %v", execErr)
 	}
+
+	sendProfilingMetadata(ctx, session)
 
 	affected, err := result.RowsAffected()
 	if err != nil {

--- a/duckdbservice/profiling.go
+++ b/duckdbservice/profiling.go
@@ -2,6 +2,7 @@ package duckdbservice
 
 import (
 	"context"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -11,13 +12,18 @@ import (
 // output from the worker back to the control plane.
 const profilingMetadataKey = "x-duckgres-profiling"
 
-// sendProfilingMetadata queries the last profiling output from the session's
-// DuckDB connection and sends it as gRPC trailing metadata.
+// profilingOutputPath is the fixed file path where DuckDB writes profiling
+// output. Only one query runs per worker at a time (control plane enforces
+// this), so a single file is safe.
+const profilingOutputPath = "/tmp/duckgres-profiling.json"
+
+// sendProfilingMetadata reads the profiling output file written by DuckDB
+// and sends it as gRPC trailing metadata so the control plane can attach
+// it to the trace span.
 func sendProfilingMetadata(ctx context.Context, session *Session) {
-	var output string
-	err := session.Conn.QueryRowContext(ctx, "SELECT json(profiling_output) FROM pragma_last_profiling_output()").Scan(&output)
-	if err != nil || output == "" {
+	data, err := os.ReadFile(profilingOutputPath)
+	if err != nil || len(data) == 0 {
 		return
 	}
-	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, output))
+	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, string(data)))
 }

--- a/duckdbservice/profiling.go
+++ b/duckdbservice/profiling.go
@@ -1,7 +1,9 @@
 package duckdbservice
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 
 	"google.golang.org/grpc"
@@ -25,5 +27,10 @@ func sendProfilingMetadata(ctx context.Context, session *Session) {
 	if err != nil || len(data) == 0 {
 		return
 	}
-	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, string(data)))
+	// Compact JSON to a single line — gRPC metadata values cannot contain newlines.
+	var compact bytes.Buffer
+	if json.Compact(&compact, data) != nil {
+		return
+	}
+	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, compact.String()))
 }

--- a/duckdbservice/profiling.go
+++ b/duckdbservice/profiling.go
@@ -1,0 +1,23 @@
+package duckdbservice
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// profilingMetadataKey is the gRPC metadata key used to pass DuckDB profiling
+// output from the worker back to the control plane.
+const profilingMetadataKey = "x-duckgres-profiling"
+
+// sendProfilingMetadata queries the last profiling output from the session's
+// DuckDB connection and sends it as gRPC trailing metadata.
+func sendProfilingMetadata(ctx context.Context, session *Session) {
+	var output string
+	err := session.Conn.QueryRowContext(ctx, "SELECT json(profiling_output) FROM pragma_last_profiling_output()").Scan(&output)
+	if err != nil || output == "" {
+		return
+	}
+	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, output))
+}

--- a/duckdbservice/profiling_test.go
+++ b/duckdbservice/profiling_test.go
@@ -1,0 +1,115 @@
+package duckdbservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// validateGRPCMetadataValue checks that a string is safe for use as a gRPC
+// metadata value: ASCII-only, no newlines, no carriage returns, no NUL bytes.
+func validateGRPCMetadataValue(s string) error {
+	for i, c := range s {
+		if c == '\n' || c == '\r' || c == 0 {
+			return fmt.Errorf("invalid character %q at position %d", c, i)
+		}
+		if c > 127 {
+			return fmt.Errorf("non-ASCII character %q at position %d", c, i)
+		}
+	}
+	return nil
+}
+
+func TestProfilingOutputCompaction(t *testing.T) {
+	// Simulate pretty-printed DuckDB profiling JSON with newlines
+	prettyJSON := `{
+    "latency": 0.5,
+    "cpu_time": 0.3,
+    "rows_returned": 42,
+    "children": [
+        {
+            "operator_name": "SEQ_SCAN",
+            "operator_timing": 0.2
+        }
+    ]
+}`
+
+	// Compact it like sendProfilingMetadata does
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(prettyJSON)); err != nil {
+		t.Fatalf("json.Compact: %v", err)
+	}
+
+	result := compact.String()
+
+	// Must not contain newlines (gRPC metadata requirement)
+	if strings.Contains(result, "\n") {
+		t.Errorf("compacted JSON still contains newlines: %s", result)
+	}
+
+	// Must be valid JSON
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Errorf("compacted JSON is not valid: %v", err)
+	}
+
+	// Must be safe for gRPC metadata
+	if err := validateGRPCMetadataValue(result); err != nil {
+		t.Errorf("compacted JSON is not gRPC-safe: %v", err)
+	}
+
+	// Key fields must survive compaction
+	if parsed["latency"] != 0.5 {
+		t.Errorf("expected latency 0.5, got %v", parsed["latency"])
+	}
+	if parsed["rows_returned"] != float64(42) {
+		t.Errorf("expected rows_returned 42, got %v", parsed["rows_returned"])
+	}
+}
+
+func TestProfilingOutputGRPCSafety(t *testing.T) {
+	// Realistic DuckDB profiling output with deeply nested operators,
+	// string values containing special characters, and large numbers.
+	input := `{
+    "latency": 6.812345678,
+    "cpu_time": 5.123456789,
+    "query_name": "SELECT * FROM \"my_table\" WHERE name = 'O''Brien'",
+    "rows_returned": 1000000,
+    "result_set_size": 8388608,
+    "total_memory_allocated": 134217728,
+    "system_peak_buffer_memory": 67108864,
+    "children": [
+        {
+            "operator_name": "DUCKLAKE_SCAN",
+            "operator_timing": 4.5,
+            "extra_info": {
+                "Table": "ducklake.main.events",
+                "Filters": "id > 0 AND name IS NOT NULL"
+            },
+            "children": []
+        }
+    ]
+}`
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(input)); err != nil {
+		t.Fatalf("json.Compact: %v", err)
+	}
+
+	result := compact.String()
+
+	if err := validateGRPCMetadataValue(result); err != nil {
+		t.Fatalf("compacted JSON is not gRPC-safe: %v", err)
+	}
+
+	// Verify round-trip
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("compacted JSON is not valid: %v", err)
+	}
+	if parsed["query_name"] != "SELECT * FROM \"my_table\" WHERE name = 'O''Brien'" {
+		t.Errorf("query_name mangled: %v", parsed["query_name"])
+	}
+}

--- a/server/conn.go
+++ b/server/conn.go
@@ -1119,7 +1119,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 		ctx, cleanup := c.queryContext()
 		defer cleanup()
 
-		_, execSpan := tracer.Start(ctx, "duckgres.execute")
+		execStart := time.Now()
+		execCtx, execSpan := tracer.Start(ctx, "duckgres.execute")
 		runExec := func() (ExecResult, error) {
 			execResult, err := c.executor.ExecContext(ctx, query)
 			if err != nil {
@@ -1140,7 +1141,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 
 		execResult, err := runExec()
-		enrichSpanWithProfiling(execSpan, c.executor)
+		enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -1322,7 +1323,8 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	ctx, cleanup := c.queryContext()
 	defer cleanup()
 
-	_, execSpan := tracer.Start(ctx, "duckgres.execute")
+	execStart := time.Now()
+	execCtx, execSpan := tracer.Start(ctx, "duckgres.execute")
 	runQuery := func() (RowSet, error) {
 		return c.executor.QueryContext(ctx, query)
 	}
@@ -1345,7 +1347,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			},
 		)
 	}
-	enrichSpanWithProfiling(execSpan, c.executor)
+	enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor)
 	execSpan.End()
 	if err != nil {
 		errCode := classifyErrorCode(err)

--- a/server/conn.go
+++ b/server/conn.go
@@ -1140,6 +1140,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 
 		execResult, err := runExec()
+		enrichSpanWithProfiling(execSpan, c.executor)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -1344,6 +1345,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			},
 		)
 	}
+	enrichSpanWithProfiling(execSpan, c.executor)
 	execSpan.End()
 	if err != nil {
 		errCode := classifyErrorCode(err)

--- a/server/conn_cleanup_test.go
+++ b/server/conn_cleanup_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 type cleanupRecordingExecutor struct {
+	noopProfiling
 	execQueries []string
 }
 

--- a/server/conn_describe_test.go
+++ b/server/conn_describe_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 type describeRecordingExecutor struct {
+	noopProfiling
 	queries []string
 	rowSet  RowSet
 }

--- a/server/conn_passthrough_test.go
+++ b/server/conn_passthrough_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type passthroughRecordingExecutor struct {
+	noopProfiling
 	execQueries []string
 }
 

--- a/server/conn_querylog_feedback_test.go
+++ b/server/conn_querylog_feedback_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 type feedbackExecutor struct {
+	noopProfiling
 	queryFn func(query string, args ...any) (RowSet, error)
 }
 

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1367,6 +1367,7 @@ func (f *fakeExecResult) RowsAffected() (int64, error) {
 
 type queryErrorExecutor struct {
 	err error
+	noopProfiling
 }
 
 func (e *queryErrorExecutor) QueryContext(context.Context, string, ...any) (RowSet, error) {
@@ -1391,6 +1392,7 @@ func (e *queryErrorExecutor) Close() error { return nil }
 
 type abortedSelectRecoveryExecutor struct {
 	queryCalls    int
+	noopProfiling
 	rollbackCalls int
 }
 
@@ -1430,6 +1432,7 @@ func (e *abortedSelectRecoveryExecutor) Close() error { return nil }
 
 type abortedExecAlterViewRecoveryExecutor struct {
 	originalQuery string
+	noopProfiling
 	rewritten     string
 	execCalls     []string
 	execCtxCalls  []string
@@ -1482,6 +1485,7 @@ func (e *abortedExecAlterViewRecoveryExecutor) Close() error { return nil }
 
 type abortedAlterViewRecoveryExecutor struct {
 	execContextQueries []string
+	noopProfiling
 	execQueries        []string
 }
 

--- a/server/executor.go
+++ b/server/executor.go
@@ -43,6 +43,11 @@ type QueryExecutor interface {
 	ConnContext(ctx context.Context) (RawConn, error)
 	PingContext(ctx context.Context) error
 	Close() error
+
+	// LastProfilingOutput returns the JSON profiling output from the last
+	// executed query, or "" if profiling is not enabled or not available
+	// (e.g. Flight SQL mode where the query ran on a remote worker).
+	LastProfilingOutput() string
 }
 
 // LocalExecutor wraps *sql.DB to implement QueryExecutor for local DuckDB access.
@@ -94,6 +99,14 @@ func (e *LocalExecutor) PingContext(ctx context.Context) error {
 
 func (e *LocalExecutor) Close() error {
 	return e.db.Close()
+}
+
+func (e *LocalExecutor) LastProfilingOutput() string {
+	var output string
+	if err := e.db.QueryRow("SELECT json(profiling_output) FROM pragma_last_profiling_output()").Scan(&output); err != nil {
+		return ""
+	}
+	return output
 }
 
 // LocalRowSet wraps *sql.Rows to implement RowSet.

--- a/server/executor.go
+++ b/server/executor.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"os"
 )
 
 // ColumnTyper provides type name information for a database column.
@@ -102,11 +103,11 @@ func (e *LocalExecutor) Close() error {
 }
 
 func (e *LocalExecutor) LastProfilingOutput() string {
-	var output string
-	if err := e.db.QueryRow("SELECT json(profiling_output) FROM pragma_last_profiling_output()").Scan(&output); err != nil {
+	data, err := os.ReadFile("/tmp/duckgres-profiling.json")
+	if err != nil {
 		return ""
 	}
-	return output
+	return string(data)
 }
 
 // LocalRowSet wraps *sql.Rows to implement RowSet.

--- a/server/flight_executor.go
+++ b/server/flight_executor.go
@@ -302,6 +302,13 @@ func (e *FlightExecutor) Close() error {
 	return nil
 }
 
+func (e *FlightExecutor) LastProfilingOutput() string {
+	// Profiling output is only available on the DuckDB connection that ran
+	// the query. In Flight SQL mode the query runs on a remote worker, so
+	// we can't retrieve it from the control plane.
+	return ""
+}
+
 // FlightRowSet wraps an Arrow Flight RecordBatch reader to implement RowSet.
 type FlightRowSet struct {
 	reader *flight.Reader

--- a/server/flight_executor.go
+++ b/server/flight_executor.go
@@ -58,6 +58,10 @@ type FlightExecutor struct {
 
 	ctx    context.Context    // base context for all requests
 	cancel context.CancelFunc // cancels the base context
+
+	// lastProfiling stores the most recent DuckDB profiling output received
+	// from the worker via gRPC trailing metadata.
+	lastProfiling atomic.Value // stores string
 }
 
 // NewFlightExecutor creates a FlightExecutor connected to the given address.
@@ -188,7 +192,9 @@ func (e *FlightExecutor) QueryContext(ctx context.Context, query string, args ..
 
 	reqCtx = e.withSession(reqCtx)
 
-	info, err := e.client.Execute(reqCtx, query)
+	var trailer metadata.MD
+	info, err := e.client.Execute(reqCtx, query, grpc.Trailer(&trailer))
+	e.storeProfilingFromTrailer(trailer)
 	if err != nil {
 		return nil, fmt.Errorf("flight execute: %w", err)
 	}
@@ -245,7 +251,9 @@ func (e *FlightExecutor) ExecContext(ctx context.Context, query string, args ...
 
 	reqCtx = e.withSession(reqCtx)
 
-	affected, err := e.client.ExecuteUpdate(reqCtx, query)
+	var trailer metadata.MD
+	affected, err := e.client.ExecuteUpdate(reqCtx, query, grpc.Trailer(&trailer))
+	e.storeProfilingFromTrailer(trailer)
 	if err != nil {
 		return nil, fmt.Errorf("flight execute update: %w", err)
 	}
@@ -303,10 +311,21 @@ func (e *FlightExecutor) Close() error {
 }
 
 func (e *FlightExecutor) LastProfilingOutput() string {
-	// Profiling output is only available on the DuckDB connection that ran
-	// the query. In Flight SQL mode the query runs on a remote worker, so
-	// we can't retrieve it from the control plane.
-	return ""
+	v := e.lastProfiling.Load()
+	if v == nil {
+		return ""
+	}
+	return v.(string)
+}
+
+const profilingMetadataKey = "x-duckgres-profiling"
+
+func (e *FlightExecutor) storeProfilingFromTrailer(trailer metadata.MD) {
+	if vals := trailer.Get(profilingMetadataKey); len(vals) > 0 {
+		e.lastProfiling.Store(vals[0])
+	} else {
+		e.lastProfiling.Store("")
+	}
 }
 
 // FlightRowSet wraps an Arrow Flight RecordBatch reader to implement RowSet.

--- a/server/flight_executor.go
+++ b/server/flight_executor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/apache/arrow-go/v18/arrow/memory"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -77,9 +76,8 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 	))
 
 	// Propagate OTEL trace context across gRPC to worker pods.
-	dialOpts = append(dialOpts,
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-	)
+	// Filtered to query RPCs only (GetFlightInfo, DoGet).
+	dialOpts = append(dialOpts, OTELGRPCClientHandler())
 
 	if bearerToken != "" {
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(&bearerCreds{token: bearerToken}))

--- a/server/otelgrpc_filter.go
+++ b/server/otelgrpc_filter.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/stats"
+)
+
+// OTELGRPCClientHandler returns a gRPC StatsHandler that creates spans only
+// for query-related Flight SQL RPCs (GetFlightInfo, DoGet), filtering out
+// noisy control-plane calls (DoAction for health checks, session management).
+func OTELGRPCClientHandler() grpc.DialOption {
+	return grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+		otelgrpc.WithFilter(func(info *stats.RPCTagInfo) bool {
+			// Only trace query execution RPCs, not session/health management.
+			return strings.Contains(info.FullMethodName, "GetFlightInfo") ||
+				strings.Contains(info.FullMethodName, "DoGet")
+		}),
+	))
+}

--- a/server/profiling_noop_test.go
+++ b/server/profiling_noop_test.go
@@ -1,0 +1,7 @@
+package server
+
+// noopProfiling is embedded in test mock executors to satisfy the
+// LastProfilingOutput method of the QueryExecutor interface.
+type noopProfiling struct{}
+
+func (noopProfiling) LastProfilingOutput() string { return "" }

--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestProfilingOutputToFile(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	tmpFile := t.TempDir() + "/profiling.json"
+
+	for _, stmt := range []string{
+		"SET enable_profiling = 'json'",
+		"SET profiling_mode = 'detailed'",
+		"SET profiling_output = '" + tmpFile + "'",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+
+	// Run a query that produces profiling output
+	if _, err := db.Exec("CREATE TABLE test_prof (id INT, name VARCHAR)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO test_prof VALUES (1, 'alice'), (2, 'bob')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	rows, err := db.Query("SELECT * FROM test_prof WHERE id > 0")
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	rows.Close()
+
+	// Read profiling output from file
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("read profiling file: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("profiling output file is empty")
+	}
+
+	// Parse and verify key fields
+	m, ok := parseProfilingOutput(string(data))
+	if !ok {
+		t.Fatalf("failed to parse profiling output: %s", data[:min(200, len(data))])
+	}
+	if m.Latency <= 0 {
+		t.Errorf("expected positive latency, got %f", m.Latency)
+	}
+	if m.RowsReturned != 2 {
+		t.Errorf("expected 2 rows_returned, got %d", m.RowsReturned)
+	}
+
+	// Verify it's valid JSON with expected fields
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("profiling output is not valid JSON: %v", err)
+	}
+	for _, key := range []string{"latency", "cpu_time", "rows_returned", "result_set_size", "total_memory_allocated", "system_peak_buffer_memory"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing expected field %q in profiling output", key)
+		}
+	}
+}

--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -12,7 +12,7 @@ func TestProfilingOutputToFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	tmpFile := t.TempDir() + "/profiling.json"
 
@@ -37,7 +37,7 @@ func TestProfilingOutputToFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select: %v", err)
 	}
-	rows.Close()
+	_ = rows.Close()
 
 	// Read profiling output from file
 	data, err := os.ReadFile(tmpFile)

--- a/server/server.go
+++ b/server/server.go
@@ -770,11 +770,16 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 	// Enable query profiling so per-query operator timing can be extracted
 	// and attached to OTEL trace spans. Standard mode adds sub-1% overhead
 	// (just clock_gettime per operator boundary).
+	// Output goes to a fixed temp file; in K8s mode the worker reads it
+	// after each query and sends it to the control plane via gRPC trailer.
 	if _, err := db.Exec("SET enable_profiling = 'json'"); err != nil {
 		slog.Warn("Failed to enable DuckDB profiling.", "error", err)
 	}
 	if _, err := db.Exec("SET profiling_mode = 'detailed'"); err != nil {
 		slog.Warn("Failed to set DuckDB profiling mode.", "error", err)
+	}
+	if _, err := db.Exec("SET profiling_output = '/tmp/duckgres-profiling.json'"); err != nil {
+		slog.Warn("Failed to set DuckDB profiling output path.", "error", err)
 	}
 
 	// Configure cache_httpfs cache directory if the extension is loaded.

--- a/server/server.go
+++ b/server/server.go
@@ -767,6 +767,16 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 		slog.Warn("Failed to load some extensions.", "user", username, "error", err)
 	}
 
+	// Enable query profiling so per-query operator timing can be extracted
+	// and attached to OTEL trace spans. Standard mode adds sub-1% overhead
+	// (just clock_gettime per operator boundary).
+	if _, err := db.Exec("SET enable_profiling = 'json'"); err != nil {
+		slog.Warn("Failed to enable DuckDB profiling.", "error", err)
+	}
+	if _, err := db.Exec("SET profiling_mode = 'detailed'"); err != nil {
+		slog.Warn("Failed to set DuckDB profiling mode.", "error", err)
+	}
+
 	// Configure cache_httpfs cache directory if the extension is loaded.
 	// cache_httpfs wraps httpfs with a local disk cache, avoiding repeated S3/HTTP downloads.
 	if hasCacheHTTPFS(cfg.Extensions) {

--- a/server/session_database_metadata_remote_test.go
+++ b/server/session_database_metadata_remote_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 type attachedCatalogProbeExecutor struct {
+	noopProfiling
 	lastQuery string
 	lastArgs  []any
 }

--- a/server/session_database_metadata_test.go
+++ b/server/session_database_metadata_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 type recordingQueryExecutor struct {
+	noopProfiling
 	query      string
 	args       []any
 	rowSet     RowSet

--- a/server/tracing.go
+++ b/server/tracing.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -23,6 +25,63 @@ func truncateForSpan(q string) string {
 		return q
 	}
 	return q[:maxLen] + "..."
+}
+
+// profilingMetrics holds key metrics extracted from DuckDB's JSON profiling output.
+type profilingMetrics struct {
+	Latency              float64 // total wall-clock time (seconds)
+	CPUTime              float64 // cumulative operator execution time (seconds)
+	RowsReturned         uint64  // number of rows in the result
+	ResultSetSize        uint64  // result size in bytes
+	TotalMemoryAllocated uint64  // total buffer manager allocation in bytes
+	PeakBufferMemory     uint64  // peak memory usage in bytes
+}
+
+// parseProfilingOutput extracts key metrics from DuckDB's JSON profiling output.
+func parseProfilingOutput(jsonStr string) (profilingMetrics, bool) {
+	if jsonStr == "" {
+		return profilingMetrics{}, false
+	}
+	var root struct {
+		Latency              float64 `json:"latency"`
+		CPUTime              float64 `json:"cpu_time"`
+		RowsReturned         uint64  `json:"rows_returned"`
+		ResultSetSize        uint64  `json:"result_set_size"`
+		TotalMemoryAllocated uint64  `json:"total_memory_allocated"`
+		PeakBufferMemory     uint64  `json:"system_peak_buffer_memory"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &root); err != nil {
+		return profilingMetrics{}, false
+	}
+	return profilingMetrics{
+		Latency:              root.Latency,
+		CPUTime:              root.CPUTime,
+		RowsReturned:         root.RowsReturned,
+		ResultSetSize:        root.ResultSetSize,
+		TotalMemoryAllocated: root.TotalMemoryAllocated,
+		PeakBufferMemory:     root.PeakBufferMemory,
+	}, true
+}
+
+// enrichSpanWithProfiling adds DuckDB profiling metrics as attributes on the span.
+func enrichSpanWithProfiling(span trace.Span, executor QueryExecutor) {
+	output := executor.LastProfilingOutput()
+	if output == "" {
+		return
+	}
+	m, ok := parseProfilingOutput(output)
+	if !ok {
+		return
+	}
+	span.SetAttributes(
+		attribute.Float64("duckdb.latency_s", m.Latency),
+		attribute.Float64("duckdb.cpu_time_s", m.CPUTime),
+		attribute.Float64("duckdb.overhead_s", m.Latency-m.CPUTime),
+		attribute.Int64("duckdb.rows_returned", int64(m.RowsReturned)),
+		attribute.Int64("duckdb.result_set_size", int64(m.ResultSetSize)),
+		attribute.Int64("duckdb.total_memory_allocated", int64(m.TotalMemoryAllocated)),
+		attribute.Int64("duckdb.peak_buffer_memory", int64(m.PeakBufferMemory)),
+	)
 }
 
 // traceIDFromContext returns the hex trace ID from the span context, or "".

--- a/server/tracing.go
+++ b/server/tracing.go
@@ -130,23 +130,38 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		planSpan.End(trace.WithTimestamp(cursor))
 	}
 
+	// Estimate wall-clock time for scan vs compute. DuckDB runs operators in
+	// parallel, so cumulative times exceed wall-clock. Use the ratio of
+	// cumulative scan/(scan+compute) applied to the execution wall-clock
+	// (latency minus planning) to approximate each phase's wall-clock share.
+	execWall := m.Latency - planningDur
+	totalOpTime := scanTime + computeTime
+	scanWall := execWall
+	computeWall := 0.0
+	if totalOpTime > 0 {
+		scanWall = execWall * (scanTime / totalOpTime)
+		computeWall = execWall * (computeTime / totalOpTime)
+	}
+
 	if scanTime > 0 {
 		_, scanSpan := tracer.Start(ctx, "duckdb.scan", trace.WithTimestamp(cursor))
 		scanSpan.SetAttributes(
-			attribute.Float64("duckdb.scan_time_s", scanTime),
+			attribute.Float64("duckdb.scan_wall_s", scanWall),
+			attribute.Float64("duckdb.scan_thread_s", scanTime),
 			attribute.Float64("duckdb.scan_rows", scanRows),
 			attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 		)
-		cursor = cursor.Add(time.Duration(scanTime * float64(time.Second)))
+		cursor = cursor.Add(time.Duration(scanWall * float64(time.Second)))
 		scanSpan.End(trace.WithTimestamp(cursor))
 	}
 
 	if computeTime > 0 {
 		_, compSpan := tracer.Start(ctx, "duckdb.compute", trace.WithTimestamp(cursor))
 		compSpan.SetAttributes(
-			attribute.Float64("duckdb.compute_time_s", computeTime),
+			attribute.Float64("duckdb.compute_wall_s", computeWall),
+			attribute.Float64("duckdb.compute_thread_s", computeTime),
 		)
-		cursor = cursor.Add(time.Duration(computeTime * float64(time.Second)))
+		cursor = cursor.Add(time.Duration(computeWall * float64(time.Second)))
 		compSpan.End(trace.WithTimestamp(cursor))
 	}
 }

--- a/server/tracing.go
+++ b/server/tracing.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,44 +29,69 @@ func truncateForSpan(q string) string {
 	return q[:maxLen] + "..."
 }
 
-// profilingMetrics holds key metrics extracted from DuckDB's JSON profiling output.
-type profilingMetrics struct {
-	Latency              float64 // total wall-clock time (seconds)
-	CPUTime              float64 // cumulative operator execution time (seconds)
-	RowsReturned         uint64  // number of rows in the result
-	ResultSetSize        uint64  // result size in bytes
-	TotalMemoryAllocated uint64  // total buffer manager allocation in bytes
-	PeakBufferMemory     uint64  // peak memory usage in bytes
+// profilingRoot represents the top-level DuckDB JSON profiling output.
+type profilingRoot struct {
+	Latency                  float64           `json:"latency"`
+	CPUTime                  float64           `json:"cpu_time"`
+	RowsReturned             uint64            `json:"rows_returned"`
+	ResultSetSize            uint64            `json:"result_set_size"`
+	TotalMemoryAllocated     uint64            `json:"total_memory_allocated"`
+	PeakBufferMemory         uint64            `json:"system_peak_buffer_memory"`
+	TotalBytesRead           uint64            `json:"total_bytes_read"`
+	Planner                  float64           `json:"planner"`
+	PlannerBinding           float64           `json:"planner_binding"`
+	CumulativeOptimizerTiming float64          `json:"cumulative_optimizer_timing"`
+	PhysicalPlanner          float64           `json:"physical_planner"`
+	Children                 []profilingOperator `json:"children"`
 }
 
-// parseProfilingOutput extracts key metrics from DuckDB's JSON profiling output.
-func parseProfilingOutput(jsonStr string) (profilingMetrics, bool) {
+type profilingOperator struct {
+	OperatorName        string              `json:"operator_name"`
+	OperatorTiming      float64             `json:"operator_timing"`
+	OperatorCardinality uint64              `json:"operator_cardinality"`
+	OperatorRowsScanned uint64              `json:"operator_rows_scanned"`
+	Children            []profilingOperator `json:"children"`
+}
+
+// parseProfilingOutput extracts the full profiling tree from DuckDB's JSON output.
+func parseProfilingOutput(jsonStr string) (profilingRoot, bool) {
 	if jsonStr == "" {
-		return profilingMetrics{}, false
+		return profilingRoot{}, false
 	}
-	var root struct {
-		Latency              float64 `json:"latency"`
-		CPUTime              float64 `json:"cpu_time"`
-		RowsReturned         uint64  `json:"rows_returned"`
-		ResultSetSize        uint64  `json:"result_set_size"`
-		TotalMemoryAllocated uint64  `json:"total_memory_allocated"`
-		PeakBufferMemory     uint64  `json:"system_peak_buffer_memory"`
-	}
+	var root profilingRoot
 	if err := json.Unmarshal([]byte(jsonStr), &root); err != nil {
-		return profilingMetrics{}, false
+		return profilingRoot{}, false
 	}
-	return profilingMetrics{
-		Latency:              root.Latency,
-		CPUTime:              root.CPUTime,
-		RowsReturned:         root.RowsReturned,
-		ResultSetSize:        root.ResultSetSize,
-		TotalMemoryAllocated: root.TotalMemoryAllocated,
-		PeakBufferMemory:     root.PeakBufferMemory,
-	}, true
+	return root, true
 }
 
-// enrichSpanWithProfiling adds DuckDB profiling metrics as attributes on the span.
-func enrichSpanWithProfiling(span trace.Span, executor QueryExecutor) {
+// isScanOperator returns true for operators that represent data source access
+// (metadata lookup + S3/file I/O + decode).
+func isScanOperator(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.HasSuffix(upper, "_SCAN") || strings.Contains(upper, "SCAN")
+}
+
+// collectOperatorTimings walks the operator tree and sums timings by category.
+func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64, computeTime float64) {
+	for _, op := range ops {
+		if isScanOperator(op.OperatorName) {
+			scanTime += op.OperatorTiming
+			scanRows += float64(op.OperatorRowsScanned)
+		} else {
+			computeTime += op.OperatorTiming
+		}
+		childScan, childScanRows, childCompute := collectOperatorTimings(op.Children)
+		scanTime += childScan
+		scanRows += childScanRows
+		computeTime += childCompute
+	}
+	return
+}
+
+// enrichSpanWithProfiling creates child spans from DuckDB profiling output
+// showing where execution time was spent: planning, scanning (I/O), and compute.
+func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor QueryExecutor) {
 	output := executor.LastProfilingOutput()
 	if output == "" {
 		return
@@ -73,15 +100,55 @@ func enrichSpanWithProfiling(span trace.Span, executor QueryExecutor) {
 	if !ok {
 		return
 	}
+
+	// Set top-level metrics on the execute span.
 	span.SetAttributes(
 		attribute.Float64("duckdb.latency_s", m.Latency),
-		attribute.Float64("duckdb.cpu_time_s", m.CPUTime),
-		attribute.Float64("duckdb.overhead_s", m.Latency-m.CPUTime),
 		attribute.Int64("duckdb.rows_returned", int64(m.RowsReturned)),
 		attribute.Int64("duckdb.result_set_size", int64(m.ResultSetSize)),
 		attribute.Int64("duckdb.total_memory_allocated", int64(m.TotalMemoryAllocated)),
 		attribute.Int64("duckdb.peak_buffer_memory", int64(m.PeakBufferMemory)),
+		attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 	)
+
+	// Create child spans with explicit timestamps for the planning, scan,
+	// and compute phases. These are approximate — operators may overlap in
+	// parallel execution — but give a useful visual breakdown.
+	planningDur := m.Planner + m.PlannerBinding + m.CumulativeOptimizerTiming + m.PhysicalPlanner
+	scanTime, scanRows, computeTime := collectOperatorTimings(m.Children)
+
+	cursor := execStart
+
+	if planningDur > 0 {
+		_, planSpan := tracer.Start(ctx, "duckdb.planning", trace.WithTimestamp(cursor))
+		planSpan.SetAttributes(
+			attribute.Float64("duckdb.planner_s", m.Planner),
+			attribute.Float64("duckdb.optimizer_s", m.CumulativeOptimizerTiming),
+			attribute.Float64("duckdb.physical_planner_s", m.PhysicalPlanner),
+		)
+		cursor = cursor.Add(time.Duration(planningDur * float64(time.Second)))
+		planSpan.End(trace.WithTimestamp(cursor))
+	}
+
+	if scanTime > 0 {
+		_, scanSpan := tracer.Start(ctx, "duckdb.scan", trace.WithTimestamp(cursor))
+		scanSpan.SetAttributes(
+			attribute.Float64("duckdb.scan_time_s", scanTime),
+			attribute.Float64("duckdb.scan_rows", scanRows),
+			attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
+		)
+		cursor = cursor.Add(time.Duration(scanTime * float64(time.Second)))
+		scanSpan.End(trace.WithTimestamp(cursor))
+	}
+
+	if computeTime > 0 {
+		_, compSpan := tracer.Start(ctx, "duckdb.compute", trace.WithTimestamp(cursor))
+		compSpan.SetAttributes(
+			attribute.Float64("duckdb.compute_time_s", computeTime),
+		)
+		cursor = cursor.Add(time.Duration(computeTime * float64(time.Second)))
+		compSpan.End(trace.WithTimestamp(cursor))
+	}
 }
 
 // traceIDFromContext returns the hex trace ID from the span context, or "".


### PR DESCRIPTION
## Summary

Extract DuckDB profiling data from query execution and create visual child spans under `duckgres.execute` showing where time was spent. Profiling output is passed from worker to control plane via gRPC trailing metadata.

## Changes

**Worker → control plane profiling pipeline:**
- `server/server.go` — enable `SET enable_profiling = 'json'` + `SET profiling_output` to a temp file on all connections
- `duckdbservice/profiling.go` — read profiling file after query, compact JSON, send as gRPC trailing metadata (`x-duckgres-profiling`)
- `server/flight_executor.go` — read trailing metadata, store via `LastProfilingOutput()`
- `server/executor.go` — `LastProfilingOutput()` on `QueryExecutor` interface

**Profiling span creation:**
- `server/tracing.go` — parse profiling JSON, create child spans with estimated wall-clock durations:
  - `duckdb.planning` — planner + optimizer + physical planner
  - `duckdb.scan` — all SCAN operators (metadata + S3 I/O + decode)
  - `duckdb.compute` — all non-scan operators (GROUP_BY, FILTER, etc.)

**gRPC span filtering:**
- `server/otelgrpc_filter.go` — filter to only GetFlightInfo + DoGet, eliminating noisy DoAction traces

**Span attributes on `duckgres.execute`:**
`duckdb.latency_s`, `duckdb.rows_returned`, `duckdb.result_set_size`, `duckdb.total_bytes_read`, `duckdb.total_memory_allocated`, `duckdb.peak_buffer_memory`

**Span attributes on child spans:**
- Scan: `scan_wall_s`, `scan_thread_s`, `scan_rows`, `total_bytes_read`
- Compute: `compute_wall_s`, `compute_thread_s`
- Planning: `planner_s`, `optimizer_s`, `physical_planner_s`

## Testing

- `go test ./server/ ./duckdbservice/` — all pass
- `TestProfilingOutputToFile` — verifies file-based profiling retrieval
- `TestProfilingOutputCompaction` + `TestProfilingOutputGRPCSafety` — verifies gRPC safety
- Deployed to mw-dev, verified traces in Grafana