### PR TITLE
chore: Map DuckDB error prefixes to specific PostgreSQL SQLSTATEs

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -366,7 +366,9 @@ func isDuckLakeMetadataConnectionLost(err error) bool {
 
 // classifyErrorCode returns the most appropriate PostgreSQL SQLSTATE for a
 // DuckDB error. Transaction conflicts get 40001 (serialization_failure), which
-// signals PG-aware clients to retry. Query cancellations get 57014.
+// signals PG-aware clients to retry. Query cancellations get 57014. Remaining
+// errors are classified by DuckDB's exception-type prefix; the prefix is the
+// only signal the Go driver exposes today, so we parse the message string.
 func classifyErrorCode(err error) string {
 	if isQueryCancelled(err) {
 		return "57014"
@@ -374,7 +376,92 @@ func classifyErrorCode(err error) string {
 	if isDuckLakeTransactionConflict(err) {
 		return "40001" // serialization_failure — client should retry
 	}
+
+	msg := err.Error()
+	switch {
+	case strings.HasPrefix(msg, "Catalog Error:"):
+		return catalogErrorCode(msg)
+	case strings.HasPrefix(msg, "Binder Error:"):
+		return binderErrorCode(msg)
+	case strings.HasPrefix(msg, "Parser Error:"):
+		return "42601" // syntax_error
+	case strings.HasPrefix(msg, "Conversion Error:"):
+		return "22P02" // invalid_text_representation
+	case strings.HasPrefix(msg, "Out of Range Error:"):
+		return "22003" // numeric_value_out_of_range
+	case strings.HasPrefix(msg, "Constraint Error:"):
+		return constraintErrorCode(msg)
+	case strings.HasPrefix(msg, "Permission Error:"):
+		return "42501" // insufficient_privilege
+	case strings.HasPrefix(msg, "Transaction Error:"):
+		return "25000" // invalid_transaction_state
+	case strings.HasPrefix(msg, "Dependency Error:"):
+		return "2BP01" // dependent_objects_still_exist
+	}
 	return "42000"
+}
+
+// catalogErrorCode narrows a "Catalog Error: …" message to a specific SQLSTATE
+func catalogErrorCode(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "table with name") && strings.Contains(lower, "does not exist"):
+		return "42P01" // undefined_table
+	case strings.Contains(lower, "view with name") && strings.Contains(lower, "does not exist"):
+		return "42P01" // undefined_table (views share the code)
+	case strings.Contains(lower, "schema") && strings.Contains(lower, "does not exist"):
+		return "3F000" // invalid_schema_name
+	case strings.Contains(lower, "function") && (strings.Contains(lower, "does not exist") || strings.Contains(lower, "with these arguments")):
+		return "42883" // undefined_function
+	case strings.Contains(lower, "no function matches"):
+		return "42883" // undefined_function — DuckDB's overload-resolution failure
+	case strings.Contains(lower, "type") && strings.Contains(lower, "does not exist"):
+		return "42704" // undefined_object
+	case strings.Contains(lower, "does not exist"):
+		return "42704" // undefined_object (generic fallback)
+	case strings.Contains(lower, "already exists"):
+		if strings.Contains(lower, "function") {
+			return "42723" // duplicate_function
+		}
+		if strings.Contains(lower, "schema") {
+			return "42P06" // duplicate_schema
+		}
+		return "42P07" // duplicate_table
+	}
+	return "42000"
+}
+
+// binderErrorCode narrows a "Binder Error: …" message. The binder raises on
+// semantic problems discovered after parsing, most commonly missing columns.
+func binderErrorCode(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "referenced column") && strings.Contains(lower, "not found"):
+		return "42703" // undefined_column
+	case strings.Contains(lower, "column") && strings.Contains(lower, "does not exist"):
+		return "42703"
+	case strings.Contains(lower, "ambiguous"):
+		return "42702" // ambiguous_column
+	}
+	return "42601" // syntax_error — binder failures without a narrower match
+}
+
+// constraintErrorCode narrows a "Constraint Error: …" message to one of the
+// integrity_constraint_violation family codes. DuckDB's messages name the
+// violated constraint explicitly, so substring matching is reliable.
+func constraintErrorCode(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "duplicate key") || strings.Contains(lower, "unique"):
+		return "23505" // unique_violation
+	case strings.Contains(lower, "not null") || strings.Contains(lower, "null value"):
+		return "23502" // not_null_violation
+	case strings.Contains(lower, "foreign key"):
+		return "23503" // foreign_key_violation
+	case strings.Contains(lower, "check constraint"):
+		return "23514" // check_violation
+	}
+	return "23000" // integrity_constraint_violation
 }
 
 // logQueryError logs a query execution failure with additional context for

--- a/server/conn.go
+++ b/server/conn.go
@@ -386,15 +386,17 @@ func classifyErrorCode(err error) string {
 	case strings.HasPrefix(msg, "Parser Error:"):
 		return "42601" // syntax_error
 	case strings.HasPrefix(msg, "Conversion Error:"):
-		return "22P02" // invalid_text_representation
+		return conversionErrorCode(msg)
 	case strings.HasPrefix(msg, "Out of Range Error:"):
 		return "22003" // numeric_value_out_of_range
 	case strings.HasPrefix(msg, "Constraint Error:"):
 		return constraintErrorCode(msg)
 	case strings.HasPrefix(msg, "Permission Error:"):
 		return "42501" // insufficient_privilege
-	case strings.HasPrefix(msg, "Transaction Error:"):
-		return "25000" // invalid_transaction_state
+	case strings.HasPrefix(msg, "Transaction Error:"),
+		strings.HasPrefix(msg, "TransactionContext Error:"):
+		return "25000" // invalid_transaction_state — DuckDB emits both prefixes
+
 	case strings.HasPrefix(msg, "Dependency Error:"):
 		return "2BP01" // dependent_objects_still_exist
 	}
@@ -405,12 +407,12 @@ func classifyErrorCode(err error) string {
 func catalogErrorCode(msg string) string {
 	lower := strings.ToLower(msg)
 	switch {
+	case strings.Contains(lower, "schema") && strings.Contains(lower, "does not exist"):
+		return "3F000" // invalid_schema_name
 	case strings.Contains(lower, "table with name") && strings.Contains(lower, "does not exist"):
 		return "42P01" // undefined_table
 	case strings.Contains(lower, "view with name") && strings.Contains(lower, "does not exist"):
 		return "42P01" // undefined_table (views share the code)
-	case strings.Contains(lower, "schema") && strings.Contains(lower, "does not exist"):
-		return "3F000" // invalid_schema_name
 	case strings.Contains(lower, "function") && (strings.Contains(lower, "does not exist") || strings.Contains(lower, "with these arguments")):
 		return "42883" // undefined_function
 	case strings.Contains(lower, "no function matches"):
@@ -442,8 +444,26 @@ func binderErrorCode(msg string) string {
 		return "42703"
 	case strings.Contains(lower, "ambiguous"):
 		return "42702" // ambiguous_column
+	case strings.Contains(lower, "referenced table") && strings.Contains(lower, "not found"):
+		return "42P01" // undefined_table — DuckDB raises this for unknown aliases
+	case strings.Contains(lower, "no function matches"):
+		return "42883" // undefined_function — overload-resolution failure
 	}
 	return "42601" // syntax_error — binder failures without a narrower match
+}
+
+// conversionErrorCode narrows a "Conversion Error: …" message. DuckDB uses
+// this prefix for both invalid text representations and numeric overflows
+// during casts (e.g. CAST(1000 AS TINYINT));
+func conversionErrorCode(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "out of range"),
+		strings.Contains(lower, "overflow"),
+		strings.Contains(lower, "would be out of range"):
+		return "22003" // numeric_value_out_of_range
+	}
+	return "22P02" // invalid_text_representation
 }
 
 // constraintErrorCode narrows a "Constraint Error: …" message to one of the

--- a/server/conn.go
+++ b/server/conn.go
@@ -396,7 +396,6 @@ func classifyErrorCode(err error) string {
 	case strings.HasPrefix(msg, "Transaction Error:"),
 		strings.HasPrefix(msg, "TransactionContext Error:"):
 		return "25000" // invalid_transaction_state — DuckDB emits both prefixes
-
 	case strings.HasPrefix(msg, "Dependency Error:"):
 		return "2BP01" // dependent_objects_still_exist
 	}

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1549,7 +1549,7 @@ func TestExecuteSelectQueryReturnsErrorDetails(t *testing.T) {
 		ctx:    context.Background(),
 		cancel: func() {},
 		executor: &queryErrorExecutor{
-			err: errors.New("relation missing_table does not exist"),
+			err: errors.New("Catalog Error: Table with name missing_table does not exist!"),
 		},
 	}
 
@@ -1560,12 +1560,99 @@ func TestExecuteSelectQueryReturnsErrorDetails(t *testing.T) {
 	if rowCount != 0 {
 		t.Fatalf("expected rowCount=0, got %d", rowCount)
 	}
-	if errCode != "42000" {
-		t.Fatalf("expected error code 42000, got %q", errCode)
+	if errCode != "42P01" {
+		t.Fatalf("expected error code 42P01 (undefined_table), got %q", errCode)
 	}
 	if !strings.Contains(errMsg, "missing_table") {
 		t.Fatalf("expected error message mentioning missing_table, got %q", errMsg)
 	}
+}
+
+// TestHandleQueryEmitsCorrectSQLSTATEOnDuckDBErrors exercises the full
+// handleQuery → wire-frame path so PG-aware clients (psycopg2, SQLAlchemy,
+// dlt) receive the SQLSTATE they branch on. The test injects canonical
+// DuckDB error strings via the executor mock, then parses the resulting
+// ErrorResponse frame out of the writer buffer and asserts the 'C' field.
+func TestHandleQueryEmitsCorrectSQLSTATEOnDuckDBErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		duckErr  string
+		wantCode string
+	}{
+		{"missing table", "Catalog Error: Table with name nope does not exist!", "42P01"},
+		{"missing schema", "Catalog Error: Schema with name missing_schema does not exist!", "3F000"},
+		{"missing function", "Catalog Error: Scalar Function with name no_such_func does not exist!", "42883"},
+		{"missing column", "Binder Error: Referenced column \"missing_col\" not found in FROM clause!", "42703"},
+		{"parser syntax", "Parser Error: syntax error at or near \"FORM\"", "42601"},
+		{"conversion", "Conversion Error: Could not convert string 'abc' to INT32", "22P02"},
+		{"unique violation", "Constraint Error: Duplicate key \"id: 1\" violates primary key constraint", "23505"},
+		{"permission", "Permission Error: not allowed to write here", "42501"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientSide, serverSide := net.Pipe()
+			defer func() { _ = clientSide.Close() }()
+			defer func() { _ = serverSide.Close() }()
+
+			var out bytes.Buffer
+			c := &clientConn{
+				server:   &Server{activeQueries: make(map[BackendKey]context.CancelFunc)},
+				conn:     clientSide,
+				reader:   bufio.NewReader(clientSide),
+				writer:   bufio.NewWriter(&out),
+				ctx:      context.Background(),
+				cancel:   func() {},
+				txStatus: txStatusIdle,
+				executor: &queryErrorExecutor{err: errors.New(tc.duckErr)},
+			}
+
+			if err := c.handleQuery([]byte("SELECT 1\x00")); err != nil {
+				t.Fatalf("handleQuery returned error: %v", err)
+			}
+
+			code := extractErrorResponseField(t, out.Bytes(), 'C')
+			if code != tc.wantCode {
+				t.Fatalf("SQLSTATE: got %q, want %q (duckErr=%q)", code, tc.wantCode, tc.duckErr)
+			}
+		})
+	}
+}
+
+// extractErrorResponseField scans wire-protocol frames for an ErrorResponse
+// ('E') message and returns the requested field value (e.g., 'C' for
+// SQLSTATE, 'M' for primary message). Fails the test if no ErrorResponse
+// is found or the field is absent.
+func extractErrorResponseField(t *testing.T, buf []byte, field byte) string {
+	t.Helper()
+	for i := 0; i+5 <= len(buf); {
+		msgType := buf[i]
+		length := int(binary.BigEndian.Uint32(buf[i+1 : i+5]))
+		if length < 4 || i+1+length > len(buf) {
+			return ""
+		}
+		body := buf[i+5 : i+1+length]
+		if msgType == 'E' {
+			for j := 0; j < len(body); {
+				code := body[j]
+				if code == 0 {
+					break
+				}
+				end := bytes.IndexByte(body[j+1:], 0)
+				if end < 0 {
+					return ""
+				}
+				if code == field {
+					return string(body[j+1 : j+1+end])
+				}
+				j += 1 + end + 1
+			}
+			t.Fatalf("ErrorResponse found but field %q missing", field)
+		}
+		i += 1 + length
+	}
+	t.Fatalf("no ErrorResponse frame in output (%d bytes)", len(buf))
+	return ""
 }
 
 func TestExecuteSingleStatementRecoversAbortedAutocommitAlterViewFallback(t *testing.T) {

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -1931,7 +1931,7 @@ func TestExecuteSelectQueryDoesNotRollbackInsideUserTransaction(t *testing.T) {
 	if rowCount != 0 {
 		t.Fatalf("expected rowCount=0, got %d", rowCount)
 	}
-	if errCode != "42000" || !strings.Contains(errMsg, "Current transaction is aborted") {
+	if errCode != "25000" || !strings.Contains(errMsg, "Current transaction is aborted") {
 		t.Fatalf("expected aborted transaction error details, got code=%q msg=%q", errCode, errMsg)
 	}
 	if exec.rollbackCalls != 0 {

--- a/server/transient_test.go
+++ b/server/transient_test.go
@@ -293,6 +293,35 @@ func TestClassifyErrorCode(t *testing.T) {
 		{"query cancelled", errors.New("context canceled"), "57014"},
 		{"generic error", errors.New("syntax error"), "42000"},
 		{"SSL closed is not conflict", errors.New("SSL connection has been closed unexpectedly"), "42000"},
+
+		{"catalog missing table", errors.New("Catalog Error: Table with name users does not exist!"), "42P01"},
+		{"catalog missing table with suggestion", errors.New("Catalog Error: Table with name stg_customers__dbt_tmp does not exist!\nDid you mean \"stg_customers\"?"), "42P01"},
+		{"catalog missing view", errors.New("Catalog Error: View with name v does not exist!"), "42P01"},
+		{"catalog missing schema", errors.New("Catalog Error: Schema with name \"missing\" does not exist!"), "3F000"},
+		{"catalog missing function", errors.New("Catalog Error: Scalar Function with name no_such_func does not exist!"), "42883"},
+		{"catalog function bad args", errors.New("Catalog Error: No function matches the given name and argument types 'foo(INTEGER)'. You might need to add explicit type casts."), "42883"},
+		{"catalog missing type", errors.New("Catalog Error: Type with name mytype does not exist!"), "42704"},
+		{"catalog table already exists", errors.New("Catalog Error: Table with name \"t\" already exists!"), "42P07"},
+		{"catalog schema already exists", errors.New("Catalog Error: Schema with name \"s\" already exists!"), "42P06"},
+		{"catalog function already exists", errors.New("Catalog Error: Function with name \"f\" already exists!"), "42723"},
+
+		{"binder missing column", errors.New("Binder Error: Referenced column \"missing_col\" not found in FROM clause!"), "42703"},
+		{"binder ambiguous column", errors.New("Binder Error: Ambiguous reference to column \"id\""), "42702"},
+		{"binder other", errors.New("Binder Error: cannot use alter table on a view because this object is not a table; use ALTER VIEW instead"), "42601"},
+
+		{"parser syntax", errors.New("Parser Error: syntax error at or near \"FORM\""), "42601"},
+		{"conversion error", errors.New("Conversion Error: Could not convert string 'abc' to INT32"), "22P02"},
+		{"out of range", errors.New("Out of Range Error: Overflow in multiplication of INT32"), "22003"},
+
+		{"constraint unique", errors.New("Constraint Error: Duplicate key \"id: 1\" violates primary key constraint"), "23505"},
+		{"constraint not null", errors.New("Constraint Error: NOT NULL constraint failed: t.col"), "23502"},
+		{"constraint foreign key", errors.New("Constraint Error: Violates foreign key constraint because key is still referenced"), "23503"},
+		{"constraint check", errors.New("Constraint Error: CHECK constraint failed: positive"), "23514"},
+		{"constraint generic", errors.New("Constraint Error: some other constraint failure"), "23000"},
+
+		{"permission denied", errors.New("Permission Error: not allowed to write here"), "42501"},
+		{"transaction invalid", errors.New("Transaction Error: cannot begin within an existing transaction"), "25000"},
+		{"dependency error", errors.New("Dependency Error: Cannot drop entry because there are other entries that depend on it"), "2BP01"},
 	}
 
 	for _, tt := range tests {

--- a/server/transient_test.go
+++ b/server/transient_test.go
@@ -298,8 +298,8 @@ func TestClassifyErrorCode(t *testing.T) {
 		{"catalog missing table with suggestion", errors.New("Catalog Error: Table with name stg_customers__dbt_tmp does not exist!\nDid you mean \"stg_customers\"?"), "42P01"},
 		{"catalog missing view", errors.New("Catalog Error: View with name v does not exist!"), "42P01"},
 		{"catalog missing schema", errors.New("Catalog Error: Schema with name \"missing\" does not exist!"), "3F000"},
+		{"catalog schema-qualified table, missing schema", errors.New("Catalog Error: Table with name \"missing_schema.t\" does not exist because schema \"missing_schema\" does not exist."), "3F000"},
 		{"catalog missing function", errors.New("Catalog Error: Scalar Function with name no_such_func does not exist!"), "42883"},
-		{"catalog function bad args", errors.New("Catalog Error: No function matches the given name and argument types 'foo(INTEGER)'. You might need to add explicit type casts."), "42883"},
 		{"catalog missing type", errors.New("Catalog Error: Type with name mytype does not exist!"), "42704"},
 		{"catalog table already exists", errors.New("Catalog Error: Table with name \"t\" already exists!"), "42P07"},
 		{"catalog schema already exists", errors.New("Catalog Error: Schema with name \"s\" already exists!"), "42P06"},
@@ -307,10 +307,14 @@ func TestClassifyErrorCode(t *testing.T) {
 
 		{"binder missing column", errors.New("Binder Error: Referenced column \"missing_col\" not found in FROM clause!"), "42703"},
 		{"binder ambiguous column", errors.New("Binder Error: Ambiguous reference to column \"id\""), "42702"},
+		{"binder missing table alias", errors.New("Binder Error: Referenced table \"t\" not found!\nCandidate tables: \"users\""), "42P01"},
+		{"binder function overload", errors.New("Binder Error: No function matches the given name and argument types 'foo(INTEGER)'. You might need to add explicit type casts."), "42883"},
 		{"binder other", errors.New("Binder Error: cannot use alter table on a view because this object is not a table; use ALTER VIEW instead"), "42601"},
 
 		{"parser syntax", errors.New("Parser Error: syntax error at or near \"FORM\""), "42601"},
 		{"conversion error", errors.New("Conversion Error: Could not convert string 'abc' to INT32"), "22P02"},
+		{"conversion out of range cast", errors.New("Conversion Error: Type INT32 with value 1000 can't be cast because the value is out of range for the destination type INT8"), "22003"},
+		{"conversion overflow", errors.New("Conversion Error: Overflow in cast from DOUBLE to INT32"), "22003"},
 		{"out of range", errors.New("Out of Range Error: Overflow in multiplication of INT32"), "22003"},
 
 		{"constraint unique", errors.New("Constraint Error: Duplicate key \"id: 1\" violates primary key constraint"), "23505"},
@@ -321,6 +325,7 @@ func TestClassifyErrorCode(t *testing.T) {
 
 		{"permission denied", errors.New("Permission Error: not allowed to write here"), "42501"},
 		{"transaction invalid", errors.New("Transaction Error: cannot begin within an existing transaction"), "25000"},
+		{"transaction context nested begin", errors.New("TransactionContext Error: cannot start a transaction within a transaction"), "25000"},
 		{"dependency error", errors.New("Dependency Error: Cannot drop entry because there are other entries that depend on it"), "2BP01"},
 	}
 

--- a/server/transient_test.go
+++ b/server/transient_test.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
 )
 
 func TestIsTransientDuckLakeError(t *testing.T) {
@@ -336,6 +339,65 @@ func TestClassifyErrorCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestClassifyErrorCodeAgainstRealDuckDB drives queries that reliably
+// produce each error prefix the classifier branches on, against a real
+// in-memory DuckDB, and asserts the SQLSTATE we map to.
+func TestClassifyErrorCodeAgainstRealDuckDB(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("setup create: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t VALUES (1, 1)`); err != nil {
+		t.Fatalf("setup insert: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		query    string
+		wantCode string
+	}{
+		{"missing table", `SELECT * FROM no_such_table_xyz`, "42P01"},
+		{"missing column", `SELECT no_such_col FROM t`, "42703"},
+		{"parser syntax", `SELEC 1`, "42601"},
+		{"bad cast", `SELECT CAST('abc' AS INTEGER)`, "22P02"},
+		{"cast overflow", `SELECT CAST(1000 AS TINYINT)`, "22003"},
+		{"unique violation", `INSERT INTO t VALUES (1, 2)`, "23505"},
+		{"not null violation", `INSERT INTO t (id) VALUES (2)`, "23502"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := db.Exec(tc.query)
+			if err == nil {
+				t.Fatalf("expected error from %q, got nil", tc.query)
+			}
+			if got := classifyErrorCode(err); got != tc.wantCode {
+				t.Fatalf("classifyErrorCode for %q = %q, want %q (raw err: %v)", tc.query, got, tc.wantCode, err)
+			}
+		})
+	}
+
+	t.Run("nested begin", func(t *testing.T) {
+		if _, err := db.Exec(`BEGIN`); err != nil {
+			t.Fatalf("outer begin: %v", err)
+		}
+		defer func() { _, _ = db.Exec(`ROLLBACK`) }()
+
+		_, err := db.Exec(`BEGIN`)
+		if err == nil {
+			t.Fatal("expected error on nested BEGIN, got nil")
+		}
+		if got := classifyErrorCode(err); got != "25000" {
+			t.Fatalf("nested BEGIN SQLSTATE = %q, want %q (raw err: %v)", got, "25000", err)
+		}
+	})
 }
 
 func TestIsAlterTableNotTableErrorDoesNotTreatMissingObjectSuggestionAsWrongType(t *testing.T) {


### PR DESCRIPTION
Every DuckDB query error previously surfaced as 42000, forcing PG-aware clients (psycopg2, SQLAlchemy, dlt, ORMs) into the generic SyntaxErrorOrAccessRuleViolation bucket even for missing tables, missing columns, unique violations, etc. classifyErrorCode now branches on DuckDB's exception-type prefix and maps CATALOG/BINDER/PARSER/CONVERSION/ OUTOFRANGE/CONSTRAINT/PERMISSION/TRANSACTION/DEPENDENCY errors to the appropriate SQLSTATE (42P01, 3F000, 42703, 42883, 22P02, 23505, ...).

The DuckDB Go driver does not expose a typed ExceptionType, so the classifier parses the error string — this is the same approach as the existing isDropTableOnViewError helper.

Add unit coverage for every branch and a wire-level test that drives canonical DuckDB errors through handleQuery and asserts the SQLSTATE on the ErrorResponse frame.