### PR TITLE
Add scan_rows_wall and scan_rows_cumulative to scan span

### DIFF
--- a/server/tracing.go
+++ b/server/tracing.go
@@ -144,11 +144,21 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 	}
 
 	if scanTime > 0 {
+		// Estimate actual rows scanned (deduplicated across threads).
+		// scan_rows_cumulative counts each thread's rows independently.
+		scanRowsWall := scanRows
+		if m.CPUTime > 0 && m.Latency > 0 {
+			parallelism := m.CPUTime / m.Latency
+			if parallelism > 1 {
+				scanRowsWall = scanRows / parallelism
+			}
+		}
 		_, scanSpan := tracer.Start(ctx, "duckdb.scan", trace.WithTimestamp(cursor))
 		scanSpan.SetAttributes(
 			attribute.Float64("duckdb.scan_wall_s", scanWall),
 			attribute.Float64("duckdb.scan_thread_s", scanTime),
-			attribute.Float64("duckdb.scan_rows", scanRows),
+			attribute.Float64("duckdb.scan_rows_wall", scanRowsWall),
+			attribute.Float64("duckdb.scan_rows_cumulative", scanRows),
 			attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 		)
 		cursor = cursor.Add(time.Duration(scanWall * float64(time.Second)))


### PR DESCRIPTION
## Summary

Split `scan_rows` into two attributes to clarify the parallel execution ambiguity.

## Changes

- `duckdb.scan_rows_cumulative` — raw sum across all parallel threads (was `scan_rows`)
- `duckdb.scan_rows_wall` — estimated actual unique rows, divided by observed parallelism (`cpu_time / latency`)

For a 99M row table running on ~46 threads, `scan_rows_cumulative` was 4.6B (misleading). `scan_rows_wall` will show ~99M.

## Testing

- `go test ./server/ ./duckdbservice/` — all pass