### PR TITLE
Update perf harness runbook for prod-us k8s runner flow

### DIFF
--- a/docs/perf-harness-runbook.md
+++ b/docs/perf-harness-runbook.md
@@ -56,23 +56,26 @@ go test ./tests/perf \
 
 The perf runner is configured by code in `posthog-cloud-infra`:
 
-- Terraform creates `duckling-perf-runner` and `duckling-perf-duckgres` in `aws-accnt-managed-warehouse-prod-us`.
-- Nightly result publishing writes the canonical `query_results.csv` artifact into `duckling-posthog` schema `duckgres_perf`.
+- The runner host remains the dedicated EC2 instance `duckling-perf-runner` in `aws-accnt-managed-warehouse-prod-us`.
+- The benchmark target is the prod-us k8s Duckgres endpoint, currently `duckgres-db-mw-prod-us-e635a11acac3ee9c.elb.us-east-1.amazonaws.com`.
+- Nightly result publishing writes the canonical `query_results.csv` artifact back into the prod-us k8s `perf` database in schema `duckgres_perf`.
 - Ansible role `ansible/roles/perf_runner` installs the runner script plus a systemd timer.
 
 From `posthog-cloud-infra` repository root, configure the runner:
 
 ```bash
 ansible-playbook ansible/perf-runner-setup-playbook.yml \
-  -i ansible/hosts/duckgres.yml \
+  -i ansible/hosts/duckgres-perf-runner.yml \
   -e "target_hosts=managed_warehouse_perf_runner"
 ```
+
+Treat this setup playbook as runner reconciliation. Run it after perf-runner code/config changes, or manually if the runner looks stale or drifted from the expected benchmark setup.
 
 Run the perf job manually (code-first trigger, no SSH needed):
 
 ```bash
 ansible-playbook ansible/perf-runner-run-playbook.yml \
-  -i ansible/hosts/duckgres.yml \
+  -i ansible/hosts/duckgres-perf-runner.yml \
   -e "target_hosts=managed_warehouse_perf_runner"
 ```
 
@@ -80,50 +83,45 @@ Nightly runs are handled by systemd timer `duckgres-perf-nightly.timer` installe
 
 GitHub Actions equivalents in `posthog-cloud-infra`:
 
-- `Duckgres Config (Managed Warehouse)` configures duckgres + perf runner on deploy/update.
+- `Duckgres Perf Runner Config` reconciles the perf runner on perf-runner config changes or manual dispatch.
 - `Duckgres Perf Runner` is a manual workflow dispatch that starts an on-demand perf run now.
 
 ## AWS Setup (Generic)
 
 Provision and update AWS resources through `posthog-cloud-infra` (Terraform/Terragrunt), not ad-hoc AWS CLI scripts.
 
-Use the prod-us managed warehouse stacks:
+Use the prod-us managed warehouse runner stack:
 
-- `terraform/environments/aws-accnt-managed-warehouse-prod-us/us-east-1/duckling-perf`
 - `terraform/environments/aws-accnt-managed-warehouse-prod-us/us-east-1/duckling-perf-runner`
 
-From the `posthog-cloud-infra` repository root:
+Do not provision a dedicated `duckling-perf` EC2 benchmark target stack. The benchmark target is the prod-us k8s Duckgres deployment plus the `perf` org/team provisioned through the Duckgres control-plane/admin path.
+
+From the `posthog-cloud-infra` repository root, if you need to reprovision or update the runner host itself:
 
 ```bash
 set -euo pipefail
 
 terragrunt run-all plan \
   --working-dir terraform/environments/aws-accnt-managed-warehouse-prod-us/us-east-1 \
-  --queue-include-dir duckling-perf \
   --queue-include-dir duckling-perf-runner
 
 terragrunt run-all apply \
   --working-dir terraform/environments/aws-accnt-managed-warehouse-prod-us/us-east-1 \
-  --queue-include-dir duckling-perf \
   --queue-include-dir duckling-perf-runner
 ```
 
-After apply, configure Duckgres and the perf runner from the same `posthog-cloud-infra` repo:
+After runner changes, reconcile the perf runner from the same `posthog-cloud-infra` repo:
 
 ```bash
-ansible-playbook ansible/duckgres-setup-playbook.yml \
-  -i ansible/hosts/duckgres.yml \
-  -e "target_hosts=managed_warehouse_prod_us_perf"
-
 ansible-playbook ansible/perf-runner-setup-playbook.yml \
-  -i ansible/hosts/duckgres.yml \
+  -i ansible/hosts/duckgres-perf-runner.yml \
   -e "target_hosts=managed_warehouse_perf_runner"
 ```
 
-This configures:
+This configures the runner with:
 
-- benchmark target: `duckling-perf-duckgres`
-- writer target: `duckling-posthog-duckgres`
+- benchmark target: prod-us k8s Duckgres endpoint
+- publish target: the same prod-us k8s `perf` database
 - publish table: `duckgres_perf.query_results`
 
 ## Publish Path Contract (v2)
@@ -169,8 +167,8 @@ Publisher configuration:
 
 ## Grafana
 
-The repo-managed dashboard now lives in `posthog-cloud-infra` prod-us Grafana and queries
-`duckgres_perf.query_results` through the manually created `posthog-duckling` datasource.
+The repo-managed dashboard now lives in `grafana-dashboards` under `managed-warehouse/duckgres-perf.json` and queries
+`duckgres_perf.query_results` through the existing prod-us datasource.
 
 ## Frozen Dataset Bootstrap
 
@@ -205,6 +203,7 @@ The script writes metadata to `ducklake.main.dataset_manifest` (override with `D
 ## Failure Recovery
 
 1. If run hangs: collect `runner.log`, Duckgres logs, and `server_metrics.prom`.
-2. If protocol errors spike: rerun with explicit catalog (`tests/perf/queries/smoke.yaml` or `tests/perf/queries/ducklake_frozen.yaml`) and inspect per-query rows/errors.
-3. If manifest check fails: verify `ducklake.main.dataset_manifest` includes the dataset version and rerun.
-4. If artifact corruption occurs: rerun with a new `DUCKGRES_PERF_RUN_ID` and preserve the failed run directory.
+2. If the runner configuration looks stale or drifted after code or environment changes: rerun `ansible/perf-runner-setup-playbook.yml` against `ansible/hosts/duckgres-perf-runner.yml` before retrying the benchmark.
+3. If protocol errors spike: rerun with explicit catalog (`tests/perf/queries/smoke.yaml` or `tests/perf/queries/ducklake_frozen.yaml`) and inspect per-query rows/errors.
+4. If manifest check fails: verify `ducklake.main.dataset_manifest` includes the dataset version and rerun.
+5. If artifact corruption occurs: rerun with a new `DUCKGRES_PERF_RUN_ID` and preserve the failed run directory.


### PR DESCRIPTION
## Summary
- update the perf harness runbook to describe the current prod-us k8s benchmark target
- switch operator examples to 
- document the simpler model where rerunning perf setup is the first response to runner drift
- update the dashboard location from  to 

## Testing
- updated markdown only
-  is clean