### PR TITLE
Fix DuckLake boolean predicate comparisons

### DIFF
--- a/tests/controlplane/controlplane_test.go
+++ b/tests/controlplane/controlplane_test.go
@@ -107,8 +107,11 @@ type cpHarness struct {
 }
 
 type cpOpts struct {
-	flightPort int
-	maxWorkers int
+	flightPort           int
+	maxWorkers           int
+	duckLake             bool
+	duckLakeMetadataPort int
+	duckLakeMinIOPort    int
 }
 
 func defaultOpts() cpOpts {
@@ -171,6 +174,18 @@ users:
 	cmd.Env = []string{
 		"HOME=" + os.Getenv("HOME"),
 		"PATH=" + os.Getenv("PATH"),
+	}
+	if opts.duckLake {
+		cmd.Env = append(cmd.Env,
+			fmt.Sprintf("DUCKGRES_DUCKLAKE_METADATA_STORE=postgres:host=127.0.0.1 port=%d user=ducklake password=ducklake dbname=ducklake", opts.duckLakeMetadataPort),
+			"DUCKGRES_DUCKLAKE_OBJECT_STORE=s3://ducklake/data/",
+			fmt.Sprintf("DUCKGRES_DUCKLAKE_S3_ENDPOINT=127.0.0.1:%d", opts.duckLakeMinIOPort),
+			"DUCKGRES_DUCKLAKE_S3_PROVIDER=config",
+			"DUCKGRES_DUCKLAKE_S3_ACCESS_KEY=minioadmin",
+			"DUCKGRES_DUCKLAKE_S3_SECRET_KEY=minioadmin",
+			"DUCKGRES_DUCKLAKE_S3_REGION=us-east-1",
+			"DUCKGRES_DUCKLAKE_S3_URL_STYLE=path",
+		)
 	}
 	// Put CP in its own process group so cleanup can kill the entire tree
 	// (CP + upgraded new CPs + all workers) with a single signal.

--- a/tests/controlplane/ducklake_bool_merge_test.go
+++ b/tests/controlplane/ducklake_bool_merge_test.go
@@ -1,0 +1,219 @@
+//go:build linux || darwin
+
+package controlplane_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	integration "github.com/posthog/duckgres/tests/integration"
+)
+
+const (
+	duckLakeMetadataPort = 35433
+	duckLakeMinIOPort    = 39000
+)
+
+func ensureDuckLakeInfra(t *testing.T) {
+	t.Helper()
+
+	if integration.IsDuckLakeInfraRunning(duckLakeMetadataPort, duckLakeMinIOPort) {
+		return
+	}
+	if err := integration.StartDuckLakeInfraContainers(); err != nil {
+		t.Fatalf("StartDuckLakeInfraContainers: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := integration.StopPostgresContainer(); err != nil {
+			t.Fatalf("StopPostgresContainer: %v", err)
+		}
+	})
+	if err := integration.WaitForDuckLakeInfra(duckLakeMetadataPort, duckLakeMinIOPort, 30*time.Second); err != nil {
+		t.Fatalf("WaitForDuckLakeInfra: %v", err)
+	}
+}
+
+func queryIntPairs(t *testing.T, db *sql.DB, query string) [][2]int {
+	t.Helper()
+
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("Query(%q): %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var pairs [][2]int
+	for rows.Next() {
+		var left, right int
+		if err := rows.Scan(&left, &right); err != nil {
+			t.Fatalf("Scan(%q): %v", query, err)
+		}
+		pairs = append(pairs, [2]int{left, right})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Rows(%q): %v", query, err)
+	}
+	return pairs
+}
+
+func queryInts(t *testing.T, db *sql.DB, query string) []int {
+	t.Helper()
+
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("Query(%q): %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var values []int
+	for rows.Next() {
+		var value int
+		if err := rows.Scan(&value); err != nil {
+			t.Fatalf("Scan(%q): %v", query, err)
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Rows(%q): %v", query, err)
+	}
+	return values
+}
+
+func TestDuckLakeBooleanPredicatesAndMergeInControlPlane(t *testing.T) {
+	ensureDuckLakeInfra(t)
+
+	h := startControlPlane(t, cpOpts{
+		duckLake:             true,
+		duckLakeMetadataPort: duckLakeMetadataPort,
+		duckLakeMinIOPort:    duckLakeMinIOPort,
+	})
+	db := h.openConn(t)
+
+	setup := []string{
+		"DROP SCHEMA IF EXISTS merge_debug CASCADE",
+		"CREATE SCHEMA merge_debug",
+		"CREATE TABLE merge_debug.sub_tgt(id INT, val INT)",
+		"CREATE TABLE merge_debug.sub_data(id INT, val INT, active BOOLEAN)",
+		"INSERT INTO merge_debug.sub_tgt VALUES (1, 10)",
+		"INSERT INTO merge_debug.sub_data VALUES (1, 100, true), (2, 20, true), (3, 30, false), (4, 40, NULL)",
+	}
+	for _, stmt := range setup {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("Exec(%q): %v", stmt, err)
+		}
+	}
+
+	boolCases := []struct {
+		name  string
+		query string
+		want  []int
+	}{
+		{
+			name:  "equals true",
+			query: "SELECT id FROM merge_debug.sub_data WHERE active = true ORDER BY id",
+			want:  []int{1, 2},
+		},
+		{
+			name:  "equals false",
+			query: "SELECT id FROM merge_debug.sub_data WHERE active = false ORDER BY id",
+			want:  []int{3},
+		},
+		{
+			name:  "not equals true",
+			query: "SELECT id FROM merge_debug.sub_data WHERE active != true ORDER BY id",
+			want:  []int{3},
+		},
+		{
+			name:  "not equals false",
+			query: "SELECT id FROM merge_debug.sub_data WHERE active != false ORDER BY id",
+			want:  []int{1, 2},
+		},
+		{
+			name:  "subquery equals true",
+			query: "SELECT id FROM (SELECT id FROM merge_debug.sub_data WHERE active = true) s ORDER BY id",
+			want:  []int{1, 2},
+		},
+		{
+			name:  "not of not equals true excludes null",
+			query: "SELECT id FROM merge_debug.sub_data WHERE NOT (active != true) ORDER BY id",
+			want:  []int{1, 2},
+		},
+		{
+			name:  "case when condition rewrites",
+			query: "SELECT id FROM merge_debug.sub_data WHERE CASE WHEN active = true THEN true ELSE false END ORDER BY id",
+			want:  []int{1, 2},
+		},
+	}
+
+	for _, tc := range boolCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := queryInts(t, db, tc.query)
+			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Fatalf("Query(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+
+	mergeSubquery := `
+MERGE INTO merge_debug.sub_tgt AS t
+USING (SELECT id, val FROM merge_debug.sub_data WHERE active = true) AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET val = s.val
+WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val)
+`
+	if _, err := db.Exec(mergeSubquery); err != nil {
+		t.Fatalf("Exec(merge subquery): %v", err)
+	}
+	if got, want := queryIntPairs(t, db, "TABLE merge_debug.sub_tgt ORDER BY id"), [][2]int{{1, 100}, {2, 20}}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("subquery MERGE result = %v, want %v", got, want)
+	}
+
+	if _, err := db.Exec("TRUNCATE merge_debug.sub_tgt"); err != nil {
+		t.Fatalf("TRUNCATE sub_tgt: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO merge_debug.sub_tgt VALUES (1, 10)"); err != nil {
+		t.Fatalf("reseed sub_tgt: %v", err)
+	}
+
+	mergeCTE := `
+MERGE INTO merge_debug.sub_tgt AS t
+USING (
+	WITH active_rows AS (
+		SELECT id, val FROM merge_debug.sub_data WHERE active = true
+	)
+	SELECT id, val FROM active_rows
+) AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET val = s.val
+WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val)
+`
+	if _, err := db.Exec(mergeCTE); err != nil {
+		t.Fatalf("Exec(merge cte): %v", err)
+	}
+	if got, want := queryIntPairs(t, db, "TABLE merge_debug.sub_tgt ORDER BY id"), [][2]int{{1, 100}, {2, 20}}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("cte MERGE result = %v, want %v", got, want)
+	}
+
+	if _, err := db.Exec("TRUNCATE merge_debug.sub_tgt"); err != nil {
+		t.Fatalf("TRUNCATE sub_tgt before base MERGE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO merge_debug.sub_tgt VALUES (1, 10)"); err != nil {
+		t.Fatalf("reseed sub_tgt before base MERGE: %v", err)
+	}
+
+	mergeBaseTable := `
+MERGE INTO merge_debug.sub_tgt AS t
+USING merge_debug.sub_data AS s
+ON t.id = s.id
+WHEN MATCHED AND s.active IS TRUE THEN UPDATE SET val = s.val
+WHEN NOT MATCHED AND s.active IS TRUE THEN INSERT VALUES (s.id, s.val)
+`
+	if _, err := db.Exec(mergeBaseTable); err != nil {
+		t.Fatalf("Exec(base table MERGE): %v", err)
+	}
+	if got, want := queryIntPairs(t, db, "TABLE merge_debug.sub_tgt ORDER BY id"), [][2]int{{1, 100}, {2, 20}}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("base table MERGE result = %v, want %v", got, want)
+	}
+}

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -650,14 +650,19 @@ func dockerComposeArgs(composeFile string, command string, args ...string) []str
 	return append(composeArgs, args...)
 }
 
+func dockerComposeCommand(composeFile string, command string, args ...string) (string, []string) {
+	return "docker", append([]string{"compose"}, dockerComposeArgs(composeFile, command, args...)...)
+}
+
 func runDockerCompose(command string, args ...string) error {
 	testDir := getTestDir()
 	composeFile := filepath.Join(testDir, "docker-compose.yml")
-	cmd := exec.Command("docker-compose", dockerComposeArgs(composeFile, command, args...)...)
+	cmdName, cmdArgs := dockerComposeCommand(composeFile, command, args...)
+	cmd := exec.Command(cmdName, cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker-compose %s %s: %w", command, strings.Join(args, " "), err)
+		return fmt.Errorf("docker compose %s %s: %w", command, strings.Join(args, " "), err)
 	}
 	return nil
 }
@@ -684,7 +689,8 @@ func StartDuckLakeInfraContainers() error {
 // StopPostgresContainer stops the PostgreSQL Docker container
 func StopPostgresContainer() error {
 	testDir := getTestDir()
-	cmd := exec.Command("docker-compose", dockerComposeArgs(filepath.Join(testDir, "docker-compose.yml"), "down", "-v")...)
+	cmdName, cmdArgs := dockerComposeCommand(filepath.Join(testDir, "docker-compose.yml"), "down", "-v")
+	cmd := exec.Command(cmdName, cmdArgs...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 	return cmd.Run()

--- a/tests/integration/harness_test.go
+++ b/tests/integration/harness_test.go
@@ -36,6 +36,19 @@ func TestDockerComposeArgsWithoutServices(t *testing.T) {
 	}
 }
 
+func TestDockerComposeCommandUsesDockerCLIPlugin(t *testing.T) {
+	composeFile := filepath.Join("/tmp", "docker-compose.yml")
+
+	gotName, gotArgs := dockerComposeCommand(composeFile, "up", "-d", "ducklake-metadata")
+	wantArgs := []string{"compose", "-f", composeFile, "up", "-d", "ducklake-metadata"}
+	if gotName != "docker" {
+		t.Fatalf("dockerComposeCommand() name = %q, want %q", gotName, "docker")
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("dockerComposeCommand() args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
 func TestIsEphemeralPostgresRuntimeSchema(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/transpiler/boolpredicates.go
+++ b/transpiler/boolpredicates.go
@@ -1,0 +1,40 @@
+package transpiler
+
+import (
+	"regexp"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/posthog/duckgres/transpiler/transform"
+)
+
+var booleanPredicatePattern = regexp.MustCompile(`(?is)(?:\btrue\b|\bfalse\b)\s*(?:=|!=|<>)|(?:=|!=|<>)\s*(?:\btrue\b|\bfalse\b)`)
+
+func NeedsBooleanPredicateRewrite(sql string) bool {
+	return booleanPredicatePattern.MatchString(sql)
+}
+
+func RewriteBooleanPredicates(sql string) (string, bool, error) {
+	sql = strings.TrimSpace(sql)
+	if sql == "" || !NeedsBooleanPredicateRewrite(sql) {
+		return sql, false, nil
+	}
+
+	tree, err := pg_query.Parse(sql)
+	if err != nil {
+		return sql, false, nil
+	}
+
+	result := &transform.Result{}
+	changed, err := transform.NewBooleanPredicateTransform().Transform(tree, result)
+	if err != nil || !changed {
+		return sql, false, err
+	}
+
+	rewritten, err := pg_query.Deparse(tree)
+	if err != nil {
+		return sql, false, nil
+	}
+
+	return rewritten, true, nil
+}

--- a/transpiler/transform/boolpredicates.go
+++ b/transpiler/transform/boolpredicates.go
@@ -1,0 +1,393 @@
+package transform
+
+import (
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// BooleanPredicateTransform normalizes boolean literal comparisons in
+// predicate-valued contexts so DuckLake doesn't see `= true/false` or
+// `!= true/false` there. Traversal is explicit to avoid descending into
+// scalar-expression wrappers where `IS TRUE/FALSE` is not semantics-preserving.
+type BooleanPredicateTransform struct{}
+
+func NewBooleanPredicateTransform() *BooleanPredicateTransform {
+	return &BooleanPredicateTransform{}
+}
+
+func (t *BooleanPredicateTransform) Name() string {
+	return "boolean_predicates"
+}
+
+func (t *BooleanPredicateTransform) Transform(tree *pg_query.ParseResult, result *Result) (bool, error) {
+	changed := false
+	for _, stmt := range tree.Stmts {
+		if stmt.Stmt != nil && t.visitStatement(stmt.Stmt) {
+			changed = true
+		}
+	}
+	return changed, nil
+}
+
+func (t *BooleanPredicateTransform) visitStatement(node *pg_query.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch {
+	case node.GetSelectStmt() != nil:
+		return t.visitSelect(node.GetSelectStmt())
+	case node.GetInsertStmt() != nil:
+		return t.visitInsert(node.GetInsertStmt())
+	case node.GetUpdateStmt() != nil:
+		return t.visitUpdate(node.GetUpdateStmt())
+	case node.GetDeleteStmt() != nil:
+		return t.visitDelete(node.GetDeleteStmt())
+	case node.GetMergeStmt() != nil:
+		return t.visitMerge(node.GetMergeStmt())
+	default:
+		return false
+	}
+}
+
+func (t *BooleanPredicateTransform) visitSelect(stmt *pg_query.SelectStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := t.visitPredicateField(&stmt.WhereClause, false)
+	if t.visitPredicateField(&stmt.HavingClause, false) {
+		changed = true
+	}
+	for _, from := range stmt.FromClause {
+		if t.visitFromItem(from) {
+			changed = true
+		}
+	}
+	if t.visitWithClause(stmt.WithClause) {
+		changed = true
+	}
+	if stmt.Larg != nil && t.visitSelect(stmt.Larg) {
+		changed = true
+	}
+	if stmt.Rarg != nil && t.visitSelect(stmt.Rarg) {
+		changed = true
+	}
+
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitInsert(stmt *pg_query.InsertStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := t.visitWithClause(stmt.WithClause)
+	if stmt.SelectStmt != nil && t.visitStatement(stmt.SelectStmt) {
+		changed = true
+	}
+	if stmt.OnConflictClause != nil {
+		if t.visitPredicateField(&stmt.OnConflictClause.WhereClause, false) {
+			changed = true
+		}
+		if stmt.OnConflictClause.Infer != nil && t.visitPredicateField(&stmt.OnConflictClause.Infer.WhereClause, false) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitUpdate(stmt *pg_query.UpdateStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := t.visitWithClause(stmt.WithClause)
+	if t.visitPredicateField(&stmt.WhereClause, false) {
+		changed = true
+	}
+	for _, from := range stmt.FromClause {
+		if t.visitFromItem(from) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitDelete(stmt *pg_query.DeleteStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := t.visitWithClause(stmt.WithClause)
+	if t.visitPredicateField(&stmt.WhereClause, false) {
+		changed = true
+	}
+	for _, from := range stmt.UsingClause {
+		if t.visitFromItem(from) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitMerge(stmt *pg_query.MergeStmt) bool {
+	if stmt == nil {
+		return false
+	}
+
+	changed := t.visitWithClause(stmt.WithClause)
+	if stmt.SourceRelation != nil && t.visitFromItem(stmt.SourceRelation) {
+		changed = true
+	}
+	if t.visitPredicateField(&stmt.JoinCondition, false) {
+		changed = true
+	}
+	for _, clauseNode := range stmt.MergeWhenClauses {
+		clause := clauseNode.GetMergeWhenClause()
+		if clause == nil {
+			continue
+		}
+		if t.visitPredicateField(&clause.Condition, false) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitWithClause(withClause *pg_query.WithClause) bool {
+	if withClause == nil {
+		return false
+	}
+
+	changed := false
+	for _, cte := range withClause.Ctes {
+		cteExpr := cte.GetCommonTableExpr()
+		if cteExpr != nil && t.visitStatement(cteExpr.Ctequery) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitFromItem(node *pg_query.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	changed := false
+	if joinExpr := node.GetJoinExpr(); joinExpr != nil {
+		if t.visitPredicateField(&joinExpr.Quals, false) {
+			changed = true
+		}
+		if t.visitFromItem(joinExpr.Larg) {
+			changed = true
+		}
+		if t.visitFromItem(joinExpr.Rarg) {
+			changed = true
+		}
+	}
+	if rangeSubselect := node.GetRangeSubselect(); rangeSubselect != nil {
+		if t.visitStatement(rangeSubselect.Subquery) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) visitPredicateField(field **pg_query.Node, preserveNull bool) bool {
+	if field == nil || *field == nil {
+		return false
+	}
+	rewritten, changed := t.rewritePredicate(*field, preserveNull)
+	if changed {
+		*field = rewritten
+	}
+	return changed
+}
+
+func (t *BooleanPredicateTransform) rewritePredicate(node *pg_query.Node, preserveNull bool) (*pg_query.Node, bool) {
+	if node == nil {
+		return nil, false
+	}
+
+	if replacement := rewriteBooleanLiteralComparison(node.GetAExpr(), preserveNull); replacement != nil {
+		return replacement, true
+	}
+
+	switch n := node.Node.(type) {
+	case *pg_query.Node_BoolExpr:
+		changed := false
+		nextPreserveNull := preserveNull
+		if n.BoolExpr.Boolop == pg_query.BoolExprType_NOT_EXPR {
+			nextPreserveNull = true
+		}
+		for i, arg := range n.BoolExpr.Args {
+			rewritten, ok := t.rewritePredicate(arg, nextPreserveNull)
+			if ok {
+				n.BoolExpr.Args[i] = rewritten
+				changed = true
+			}
+		}
+		return node, changed
+
+	case *pg_query.Node_CaseExpr:
+		// Only searched CASE has predicate-valued WHEN conditions. The payload
+		// expressions remain scalar and must not be rewritten here.
+		if n.CaseExpr.Arg != nil {
+			return node, false
+		}
+		changed := false
+		for _, whenNode := range n.CaseExpr.Args {
+			when := whenNode.GetCaseWhen()
+			if when == nil {
+				continue
+			}
+			rewritten, ok := t.rewritePredicate(when.Expr, false)
+			if ok {
+				when.Expr = rewritten
+				changed = true
+			}
+		}
+		return node, changed
+
+	case *pg_query.Node_SubLink:
+		changed := t.visitStatement(n.SubLink.Subselect)
+		return node, changed
+
+	default:
+		return node, false
+	}
+}
+
+func rewriteBooleanLiteralComparison(aexpr *pg_query.A_Expr, preserveNull bool) *pg_query.Node {
+	if aexpr == nil || aexpr.Kind != pg_query.A_Expr_Kind_AEXPR_OP {
+		return nil
+	}
+
+	op := operatorName(aexpr)
+	if op == "" {
+		return nil
+	}
+
+	boolValue, expr, ok := booleanComparisonArg(aexpr.Lexpr, aexpr.Rexpr)
+	if !ok {
+		return nil
+	}
+
+	boolTestType, ok := boolComparisonRewrite(op, boolValue)
+	if !ok {
+		return nil
+	}
+
+	if preserveNull {
+		return wrapBooleanTestWithNullCase(expr, boolTestType, aexpr.Location)
+	}
+	return booleanTestNode(expr, boolTestType, aexpr.Location)
+}
+
+func operatorName(aexpr *pg_query.A_Expr) string {
+	if aexpr == nil || len(aexpr.Name) == 0 {
+		return ""
+	}
+	for i := len(aexpr.Name) - 1; i >= 0; i-- {
+		if str := aexpr.Name[i].GetString_(); str != nil {
+			return str.Sval
+		}
+	}
+	return ""
+}
+
+func booleanComparisonArg(left, right *pg_query.Node) (bool, *pg_query.Node, bool) {
+	if value, ok := booleanLiteralValue(right); ok && !isBooleanLiteral(left) {
+		return value, left, true
+	}
+	if value, ok := booleanLiteralValue(left); ok && !isBooleanLiteral(right) {
+		return value, right, true
+	}
+	return false, nil, false
+}
+
+func isBooleanLiteral(node *pg_query.Node) bool {
+	_, ok := booleanLiteralValue(node)
+	return ok
+}
+
+func booleanLiteralValue(node *pg_query.Node) (bool, bool) {
+	if node == nil {
+		return false, false
+	}
+	aConst := node.GetAConst()
+	if aConst == nil || aConst.GetBoolval() == nil {
+		return false, false
+	}
+	return aConst.GetBoolval().Boolval, true
+}
+
+func boolComparisonRewrite(op string, value bool) (pg_query.BoolTestType, bool) {
+	switch op {
+	case "=":
+		if value {
+			return pg_query.BoolTestType_IS_TRUE, true
+		}
+		return pg_query.BoolTestType_IS_FALSE, true
+	case "!=", "<>":
+		if value {
+			return pg_query.BoolTestType_IS_FALSE, true
+		}
+		return pg_query.BoolTestType_IS_TRUE, true
+	default:
+		return pg_query.BoolTestType_BOOL_TEST_TYPE_UNDEFINED, false
+	}
+}
+
+func booleanTestNode(expr *pg_query.Node, boolTestType pg_query.BoolTestType, location int32) *pg_query.Node {
+	return &pg_query.Node{
+		Node: &pg_query.Node_BooleanTest{
+			BooleanTest: &pg_query.BooleanTest{
+				Arg:          expr,
+				Booltesttype: boolTestType,
+				Location:     location,
+			},
+		},
+	}
+}
+
+func wrapBooleanTestWithNullCase(expr *pg_query.Node, boolTestType pg_query.BoolTestType, location int32) *pg_query.Node {
+	return &pg_query.Node{
+		Node: &pg_query.Node_CaseExpr{
+			CaseExpr: &pg_query.CaseExpr{
+				Args: []*pg_query.Node{
+					{
+						Node: &pg_query.Node_CaseWhen{
+							CaseWhen: &pg_query.CaseWhen{
+								Expr: &pg_query.Node{
+									Node: &pg_query.Node_NullTest{
+										NullTest: &pg_query.NullTest{
+											Arg:          expr,
+											Nulltesttype: pg_query.NullTestType_IS_NULL,
+											Location:     location,
+										},
+									},
+								},
+								Result: nullConstNode(location),
+							},
+						},
+					},
+				},
+				Defresult: booleanTestNode(expr, boolTestType, location),
+				Location:  location,
+			},
+		},
+	}
+}
+
+func nullConstNode(location int32) *pg_query.Node {
+	return &pg_query.Node{
+		Node: &pg_query.Node_AConst{
+			AConst: &pg_query.A_Const{
+				Isnull:   true,
+				Location: location,
+			},
+		},
+	}
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -14,25 +14,26 @@ import (
 type TransformFlags uint32
 
 const (
-	FlagWritableCTE  TransformFlags = 1 << iota // Writable CTE rewrite
-	FlagVersion                                 // version() replacement
-	FlagPgCatalog                               // pg_catalog schema/view mappings
-	FlagInfoSchema                              // information_schema mappings
-	FlagPublicSchema                            // public -> main schema mapping
-	FlagLogicalCatalog                          // logical database catalog -> physical catalog mapping
-	FlagTypeMapping                             // Type mappings (JSONB->JSON, etc.)
-	FlagTypeCast                                // Type casts (::regtype -> ::varchar)
-	FlagFunctions                               // Function mappings (array_agg->list, etc.)
-	FlagFuncAlias                               // Function alias normalization
-	FlagOperators                               // Operator mappings (regex, JSON)
-	FlagSetShow                                 // SET/SHOW command handling
-	FlagExpandArray                             // _pg_expandarray handling
-	FlagOnConflict                              // ON CONFLICT handling
-	FlagLocking                                 // FOR UPDATE/SHARE removal
-	FlagCtid                                    // ctid -> rowid mapping
-	FlagDDL                                     // DDL constraint stripping
-	FlagPlaceholder                             // $1/$2 placeholder conversion
-	flagSentinel                                // must be last — used to derive FlagAll
+	FlagWritableCTE       TransformFlags = 1 << iota // Writable CTE rewrite
+	FlagVersion                                      // version() replacement
+	FlagPgCatalog                                    // pg_catalog schema/view mappings
+	FlagInfoSchema                                   // information_schema mappings
+	FlagPublicSchema                                 // public -> main schema mapping
+	FlagLogicalCatalog                               // logical database catalog -> physical catalog mapping
+	FlagTypeMapping                                  // Type mappings (JSONB->JSON, etc.)
+	FlagTypeCast                                     // Type casts (::regtype -> ::varchar)
+	FlagFunctions                                    // Function mappings (array_agg->list, etc.)
+	FlagFuncAlias                                    // Function alias normalization
+	FlagBooleanPredicates                            // Boolean predicate normalization (= true -> IS TRUE)
+	FlagOperators                                    // Operator mappings (regex, JSON)
+	FlagSetShow                                      // SET/SHOW command handling
+	FlagExpandArray                                  // _pg_expandarray handling
+	FlagOnConflict                                   // ON CONFLICT handling
+	FlagLocking                                      // FOR UPDATE/SHARE removal
+	FlagCtid                                         // ctid -> rowid mapping
+	FlagDDL                                          // DDL constraint stripping
+	FlagPlaceholder                                  // $1/$2 placeholder conversion
+	flagSentinel                                     // must be last — used to derive FlagAll
 
 	FlagAll TransformFlags = flagSentinel - 1 // All flags set
 )
@@ -100,22 +101,25 @@ func New(cfg Config) *Transpiler {
 	// 7. Function alias normalization (current_database() -> AS current_database)
 	t.transforms = append(t.transforms, taggedTransform{FlagFuncAlias, transform.NewFuncAliasTransform()})
 
-	// 8. Operator mappings (regex operators, etc.)
+	// 8. Boolean predicate normalization for DuckLake/worker execution.
+	t.transforms = append(t.transforms, taggedTransform{FlagBooleanPredicates, transform.NewBooleanPredicateTransform()})
+
+	// 9. Operator mappings (regex operators, etc.)
 	t.transforms = append(t.transforms, taggedTransform{FlagOperators, transform.NewOperatorTransform()})
 
-	// 9. SET/SHOW command handling
+	// 10. SET/SHOW command handling
 	t.transforms = append(t.transforms, taggedTransform{FlagSetShow, transform.NewSetShowTransform()})
 
-	// 10. _pg_expandarray handling (PostgreSQL array expansion function used by JDBC)
+	// 11. _pg_expandarray handling (PostgreSQL array expansion function used by JDBC)
 	t.transforms = append(t.transforms, taggedTransform{FlagExpandArray, transform.NewExpandArrayTransform()})
 
-	// 11. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
+	// 12. ON CONFLICT handling (strips ON CONFLICT in DuckLake mode since constraints don't exist)
 	t.transforms = append(t.transforms, taggedTransform{FlagOnConflict, transform.NewOnConflictTransformWithConfig(cfg.DuckLakeMode)})
 
-	// 12. Locking clause removal (FOR UPDATE, FOR SHARE, etc.) - DuckDB doesn't support these
+	// 13. Locking clause removal (FOR UPDATE, FOR SHARE, etc.) - DuckDB doesn't support these
 	t.transforms = append(t.transforms, taggedTransform{FlagLocking, transform.NewLockingTransform()})
 
-	// 13. ctid → rowid mapping (PostgreSQL system column to DuckDB equivalent)
+	// 14. ctid → rowid mapping (PostgreSQL system column to DuckDB equivalent)
 	t.transforms = append(t.transforms, taggedTransform{FlagCtid, transform.NewCtidTransform()})
 
 	// DDL transforms only when DuckLake mode is enabled
@@ -408,6 +412,10 @@ func Classify(sql string, cfg Config) Classification {
 		"CURRENT_USER", "CURRENT_CATALOG(", "SESSION_USER",
 	) {
 		flags |= FlagFuncAlias
+	}
+
+	if NeedsBooleanPredicateRewrite(sql) {
+		flags |= FlagBooleanPredicates
 	}
 
 	// Operators: JSON arrows and regex.

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -3226,6 +3226,255 @@ func TestTranspile_RegexOperators(t *testing.T) {
 	}
 }
 
+func TestTranspile_BooleanPredicateComparisons(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		excludes string
+	}{
+		{
+			name:     "where equals true becomes is true",
+			input:    "SELECT * FROM users WHERE active = true",
+			contains: "active IS TRUE",
+			excludes: " = true",
+		},
+		{
+			name:     "where equals false becomes is false",
+			input:    "SELECT * FROM users WHERE active = false",
+			contains: "active IS FALSE",
+			excludes: " = false",
+		},
+		{
+			name:     "where not equals true becomes is false",
+			input:    "SELECT * FROM users WHERE active != true",
+			contains: "active IS FALSE",
+			excludes: " != true",
+		},
+		{
+			name:     "where not equals false becomes is true",
+			input:    "SELECT * FROM users WHERE active != false",
+			contains: "active IS TRUE",
+			excludes: " != false",
+		},
+		{
+			name:     "merge subquery predicate is rewritten",
+			input:    "MERGE INTO target t USING (SELECT id, val FROM src WHERE active = true) s ON t.id = s.id WHEN MATCHED THEN UPDATE SET val = s.val WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val)",
+			contains: "active IS TRUE",
+			excludes: " = true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if !strings.Contains(result.SQL, tt.contains) {
+				t.Fatalf("Transpile(%q) = %q, want to contain %q", tt.input, result.SQL, tt.contains)
+			}
+			if tt.excludes != "" && strings.Contains(result.SQL, tt.excludes) {
+				t.Fatalf("Transpile(%q) = %q, should not contain %q", tt.input, result.SQL, tt.excludes)
+			}
+		})
+	}
+}
+
+func TestTranspile_BooleanPredicateComparisonsSkipScalarWrappers(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		excludes string
+	}{
+		{
+			name:     "null test wrapper preserves equality",
+			input:    "SELECT * FROM users WHERE (active = true) IS NULL",
+			contains: "active = true",
+			excludes: "active IS TRUE",
+		},
+		{
+			name:     "function argument wrapper preserves equality",
+			input:    "SELECT * FROM users WHERE coalesce(active = true, false)",
+			contains: "active = true",
+			excludes: "active IS TRUE",
+		},
+		{
+			name:     "case expression payload preserves equality",
+			input:    "SELECT * FROM users WHERE CASE WHEN id = 1 THEN active = true ELSE false END",
+			contains: "active = true",
+			excludes: "active IS TRUE",
+		},
+		{
+			name:     "not equals true preserves null semantics",
+			input:    "SELECT * FROM users WHERE NOT (active != true)",
+			contains: "CASE WHEN active IS NULL THEN NULL ELSE active IS FALSE END",
+			excludes: "NOT active IS FALSE",
+		},
+		{
+			name:     "not equals false preserves null semantics",
+			input:    "SELECT * FROM users WHERE NOT (active != false)",
+			contains: "CASE WHEN active IS NULL THEN NULL ELSE active IS TRUE END",
+			excludes: "NOT active IS TRUE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if !strings.Contains(result.SQL, tt.contains) {
+				t.Fatalf("Transpile(%q) = %q, want to contain %q", tt.input, result.SQL, tt.contains)
+			}
+			if tt.excludes != "" && strings.Contains(result.SQL, tt.excludes) {
+				t.Fatalf("Transpile(%q) = %q, should not contain %q", tt.input, result.SQL, tt.excludes)
+			}
+		})
+	}
+}
+
+func TestTranspile_BooleanPredicateComparisonsWithDMLCTEs(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name: "insert with cte source rewrites filter",
+			input: "WITH src AS (SELECT id FROM users WHERE active = true) " +
+				"INSERT INTO dst (id) SELECT id FROM src",
+			contains: "active IS TRUE",
+		},
+		{
+			name: "update with cte source rewrites filter",
+			input: "WITH src AS (SELECT id FROM users WHERE active = true) " +
+				"UPDATE dst SET flag = true FROM src WHERE dst.id = src.id",
+			contains: "active IS TRUE",
+		},
+		{
+			name: "delete with cte source rewrites filter",
+			input: "WITH src AS (SELECT id FROM users WHERE active = true) " +
+				"DELETE FROM dst USING src WHERE dst.id = src.id",
+			contains: "active IS TRUE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if !strings.Contains(result.SQL, tt.contains) {
+				t.Fatalf("Transpile(%q) = %q, want to contain %q", tt.input, result.SQL, tt.contains)
+			}
+		})
+	}
+}
+
+func TestTranspile_BooleanPredicateComparisonsInInsertOnConflictPredicates(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		excludes string
+	}{
+		{
+			name: "conflict target predicate is rewritten",
+			input: "INSERT INTO users (id, active) VALUES (1, true) " +
+				"ON CONFLICT (id) WHERE active = true DO UPDATE SET active = EXCLUDED.active",
+			contains: "WHERE active IS TRUE",
+			excludes: "WHERE active = true",
+		},
+		{
+			name: "conflict action predicate is rewritten",
+			input: "INSERT INTO users (id, active) VALUES (1, true) " +
+				"ON CONFLICT (id) DO UPDATE SET active = EXCLUDED.active WHERE users.active = true",
+			contains: "WHERE users.active IS TRUE",
+			excludes: "WHERE users.active = true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if !strings.Contains(result.SQL, tt.contains) {
+				t.Fatalf("Transpile(%q) = %q, want to contain %q", tt.input, result.SQL, tt.contains)
+			}
+			if tt.excludes != "" && strings.Contains(result.SQL, tt.excludes) {
+				t.Fatalf("Transpile(%q) = %q, should not contain %q", tt.input, result.SQL, tt.excludes)
+			}
+		})
+	}
+}
+
+func TestTranspile_BooleanPredicateComparisonsInCaseWhenConditions(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	result, err := tr.Transpile("SELECT * FROM users WHERE CASE WHEN active = true THEN true ELSE false END")
+	if err != nil {
+		t.Fatalf("Transpile(CASE WHEN) error: %v", err)
+	}
+	if !strings.Contains(result.SQL, "active IS TRUE") {
+		t.Fatalf("Transpile(CASE WHEN) = %q, want CASE condition rewritten to active IS TRUE", result.SQL)
+	}
+}
+
+func TestTranspile_BooleanPredicateComparisonsInMergePredicates(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		excludes string
+	}{
+		{
+			name: "merge join condition is rewritten",
+			input: "MERGE INTO target t USING src s ON t.id = s.id AND s.active = true " +
+				"WHEN MATCHED THEN UPDATE SET val = s.val",
+			contains: "s.active IS TRUE",
+			excludes: "s.active = true",
+		},
+		{
+			name: "merge when condition is rewritten",
+			input: "MERGE INTO target t USING src s ON t.id = s.id " +
+				"WHEN MATCHED AND s.active = true THEN UPDATE SET val = s.val",
+			contains: "s.active IS TRUE",
+			excludes: "s.active = true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if !strings.Contains(result.SQL, tt.contains) {
+				t.Fatalf("Transpile(%q) = %q, want to contain %q", tt.input, result.SQL, tt.contains)
+			}
+			if tt.excludes != "" && strings.Contains(result.SQL, tt.excludes) {
+				t.Fatalf("Transpile(%q) = %q, should not contain %q", tt.input, result.SQL, tt.excludes)
+			}
+		})
+	}
+}
+
 func TestTranspile_SimilarTo(t *testing.T) {
 	// Test SIMILAR TO pattern matching
 	// PostgreSQL converts SIMILAR TO to use similar_to_escape() and regex matching
@@ -3858,6 +4107,7 @@ func TestClassify_NeedsTransform(t *testing.T) {
 		{"::regclass cast", "SELECT 'users'::regclass", FlagTypeCast | FlagPgCatalog},
 		{"array_agg function", "SELECT array_agg(x) FROM t", FlagFunctions | FlagPgCatalog},
 		{"current_database", "SELECT current_database()", FlagFuncAlias | FlagPgCatalog},
+		{"boolean predicate", "SELECT * FROM t WHERE active = true", FlagBooleanPredicates},
 		{"JSON arrow", "SELECT data->>'name' FROM t", FlagOperators | FlagPgCatalog},
 		{"regex operator", "SELECT * FROM t WHERE name ~ '^A'", FlagOperators | FlagPgCatalog},
 		{"FOR UPDATE", "SELECT * FROM t FOR UPDATE", FlagLocking},


### PR DESCRIPTION
## Summary
- add an explicit predicate-context walker for boolean literal comparison rewrites
- preserve NULL semantics for negated predicates while avoiding scalar-expression rewrites
- add transpiler and control-plane coverage for CASE/NOT/DML CTEs, ON CONFLICT predicates, and MERGE predicate paths

## Repro
1. Start the local DuckHog test stack so queries run through Duckgres control-plane mode backed by DuckLake.
2. Create a target table and a source table with a boolean `active` column, then insert a mix of `true`, `false`, and `NULL` rows.
3. Run `SELECT ... WHERE active = true` and compare it to `SELECT ... WHERE active IS TRUE`.
4. Run a `MERGE` whose source is a subquery or CTE filtered by `active = true`.
5. On a broken build, the equality-filtered source comes back empty and the `MERGE` no-ops. With this change, the filtered rows are returned and the `MERGE` updates/inserts as expected.

## Testing
- `go test ./transpiler -run 'TestTranspile_BooleanPredicateComparisons(InInsertOnConflictPredicates|InMergePredicates)$' -count=1`
- `go test ./transpiler -count=1`
- `go test ./tests/controlplane -run TestDuckLakeBooleanPredicatesAndMergeInControlPlane -count=1`
- `just lint`
