### PR TITLE
Add baseline Prometheus metrics for S3 I/O and scan performance

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1141,7 +1141,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 
 		execResult, err := runExec()
-		enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor)
+		enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -1347,7 +1347,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			},
 		)
 	}
-	enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor)
+	enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 	execSpan.End()
 	if err != nil {
 		errCode := classifyErrorCode(err)

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,23 @@ var ducklakeConflictRetriesExhaustedTotal = promauto.NewCounter(prometheus.Count
 	Help: "Total number of DuckLake transaction conflicts where all retries were exhausted",
 })
 
+var s3BytesReadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_s3_bytes_read_total",
+	Help: "Total bytes read from S3 by DuckDB",
+}, []string{"org"})
+
+var scanWallSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_scan_wall_seconds",
+	Help:    "Estimated wall-clock scan time per query",
+	Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60},
+}, []string{"org"})
+
+var scanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_scan_rows_per_second",
+	Help:    "Scan throughput: estimated wall-clock rows scanned per second",
+	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9},
+}, []string{"org"})
+
 // BackendKey uniquely identifies a backend connection for cancel requests
 type BackendKey struct {
 	Pid       int32

--- a/server/tracing.go
+++ b/server/tracing.go
@@ -91,7 +91,8 @@ func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64
 
 // enrichSpanWithProfiling creates child spans from DuckDB profiling output
 // showing where execution time was spent: planning, scanning (I/O), and compute.
-func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor QueryExecutor) {
+// Also emits Prometheus metrics for baseline measurement.
+func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor QueryExecutor, orgID string) {
 	output := executor.LastProfilingOutput()
 	if output == "" {
 		return
@@ -141,6 +142,19 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 	if totalOpTime > 0 {
 		scanWall = execWall * (scanTime / totalOpTime)
 		computeWall = execWall * (computeTime / totalOpTime)
+	}
+
+	// Emit Prometheus metrics for baseline measurement.
+	s3BytesReadTotal.WithLabelValues(orgID).Add(float64(m.TotalBytesRead))
+	scanWallSecondsHistogram.WithLabelValues(orgID).Observe(scanWall)
+	scanRowsWallEstimate := scanRows
+	if m.CPUTime > 0 && m.Latency > 0 {
+		if p := m.CPUTime / m.Latency; p > 1 {
+			scanRowsWallEstimate = scanRows / p
+		}
+	}
+	if scanWall > 0 && scanRowsWallEstimate > 0 {
+		scanRowsPerSecondHistogram.WithLabelValues(orgID).Observe(scanRowsWallEstimate / scanWall)
 	}
 
 	if scanTime > 0 {


### PR DESCRIPTION
## Summary

Add Prometheus metrics that track DuckDB's S3 I/O volume and scan performance per query. These establish a baseline before rolling out the distributed NVMe cache proxy, so we can measure its impact.

## Changes

**New Prometheus metrics** (from DuckDB profiling data, emitted per query):

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `duckgres_s3_bytes_read_total` | counter | org | Total bytes downloaded from S3 |
| `duckgres_scan_wall_seconds` | histogram | org | Estimated wall-clock scan time per query |
| `duckgres_scan_rows_per_second` | histogram | org | Scan throughput (rows/sec) |

**Files modified:**
- `server/server.go` — metric registrations
- `server/tracing.go` — emit metrics in `enrichSpanWithProfiling()`, added `orgID` parameter
- `server/conn.go` — pass `c.orgID` to `enrichSpanWithProfiling()`

## Grafana queries

```promql
# S3 download rate by org
rate(duckgres_s3_bytes_read_total[5m])

# Scan latency p95
histogram_quantile(0.95, rate(duckgres_scan_wall_seconds_bucket[5m]))

# Average S3 bytes per query
rate(duckgres_s3_bytes_read_total[5m]) / rate(duckgres_query_duration_seconds_count[5m])
```

## Testing

- `go test ./server/ ./duckdbservice/` — all pass