### PR TITLE
fix: update duckLakeSpecVersion to 1.0 for automatic migration

### DIFF
--- a/server/ducklake_migration.go
+++ b/server/ducklake_migration.go
@@ -16,8 +16,7 @@ import (
 // duckLakeSpecVersion is the DuckLake spec version that this build of duckgres expects.
 // When the metadata store is at an older version, we backup and migrate automatically.
 // This must match the DuckLake version bundled with the current DuckDB driver.
-// DuckDB 1.5.x ships DuckLake 0.4 which supports AUTOMATIC_MIGRATION.
-const duckLakeSpecVersion = "0.4"
+const duckLakeSpecVersion = "1.0"
 
 // dlMigration holds the result of the migration check.
 // The check retries on transient errors (e.g., metadata store not reachable yet)


### PR DESCRIPTION
## Summary

Update `duckLakeSpecVersion` from `"0.4"` to `"1.0"` so the migration check detects the version mismatch and adds `AUTOMATIC_MIGRATION TRUE` to the DuckLake ATTACH statement.

## Problem

The new ducklake extension requires catalog version 1.0, but the metadata store is at 0.4. The migration check compares `duckLakeSpecVersion` (hardcoded `"0.4"`) against the metadata store version (also `"0.4"`), finds no mismatch, and skips migration. Workers then fail with:

```
DuckLake catalog version mismatch: catalog version is 0.4,
but the extension requires version 1.0.
To automatically migrate, set AUTOMATIC_MIGRATION to TRUE when attaching.
```

## Fix

One-line change: `duckLakeSpecVersion = "1.0"`. The existing migration machinery handles the rest — it detects the 0.4→1.0 mismatch, backs up the metadata store, and attaches with `AUTOMATIC_MIGRATION TRUE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)