### PR TITLE
fix: raise DuckLake pg_pool_max_connections to 64

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1250,6 +1250,18 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 			"Consider connecting directly to PostgreSQL instead.")
 	}
 
+	// Raise the postgres_scanner connection pool limit before ATTACH. DuckDB 1.5.2
+	// reduced the default from 64 (unbounded wait) to max(num_cpus, 8) with a 30s
+	// timeout; DuckLake piggybacks on postgres_scanner for its metadata store and,
+	// with thread-local connection caching, each DuckDB worker pins a pool slot,
+	// saturating the pool under catalog-enumerating workloads (e.g. duckdb_tables(),
+	// information_schema.tables). Plain `SET` does NOT propagate to DuckLake's
+	// internal __ducklake_metadata_* catalog; only `SET GLOBAL` does.
+	// See: https://github.com/duckdb/ducklake/issues/1031
+	if _, err := db.Exec("SET GLOBAL pg_pool_max_connections = 64"); err != nil {
+		slog.Warn("Failed to set pg_pool_max_connections.", "error", err)
+	}
+
 	// Build the ATTACH statement.
 	// See: https://ducklake.select/docs/stable/duckdb/usage/connecting
 	migrate := dlCfg.Migrate || duckLakeMigrationNeeded()

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -148,13 +148,6 @@ func (h *TestHarness) startDuckgres(harnessCfg HarnessConfig) error {
 
 	// Configure DuckLake if enabled
 	if harnessCfg.UseDuckLake {
-		// CI and local integration runs reuse a long-lived pgwire session.
-		// In DuckLake mode, catalog queries fan out to the metadata Postgres via
-		// DuckDB worker threads, so the runtime default can exhaust the metadata
-		// store and poison the shared session for later tests. Keep the harness
-		// explicit and conservative here instead of inheriting production defaults.
-		cfg.Threads = 1
-
 		metadataPort := harnessCfg.DuckLakeMetadataPort
 
 		// If latency injection is requested, start a TCP proxy in front of the


### PR DESCRIPTION
## Summary

- Explicitly `SET GLOBAL pg_pool_max_connections = 64` before `ATTACH 'ducklake:postgres:...'` to restore the pre-1.5.2 pool behavior
- Drop the `cfg.Threads = 1` integration-harness workaround added in #431 — it was masking the issue, not fixing it

## Root cause

Integration tests started failing on the DuckDB 1.5.2 upgrade (#431) with:

> Invalid Error: Connection pool timeout: all 8 connections in use, waited 30000ms

on `SELECT * FROM duckdb_tables() LIMIT 3`, `information_schema_tables_compat`, and `information_schema_columns_compat` — all queries that fan out to the DuckLake metadata Postgres.

DuckDB 1.5.2 bundles a new `postgres_scanner` (duckdb/duckdb-postgres#430) that changed the pool default from **64 with unbounded wait** to **`max(num_cpus, 8)` with a 30s timeout**. DuckLake piggybacks on `postgres_scanner` for its internal `__ducklake_metadata_*` catalog, and with thread-local connection caching each DuckDB worker thread pins one pool slot. Under catalog-enumerating queries, the 8 slots saturate and every subsequent query waits 30s before failing.

Upstream tracking issue (maintainer-confirmed): https://github.com/duckdb/ducklake/issues/1031

Plain `SET pg_pool_max_connections` does **not** propagate into the `__ducklake_metadata_*` catalog (maintainer-acknowledged bug); only `SET GLOBAL` does.

## Test plan

- [ ] CI integration-tests job goes green (was red on `ce61a8f`: TestFallbackToNativeDuckDB/duckdb_tables, TestPgwireLogicalCatalogMapping, TestPgStatActivityStubView)
- [ ] `just test-unit` passes locally