### PR TITLE
Extend scan_rows_per_second buckets to capture cache hits

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -123,9 +123,10 @@ var scanWallSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts
 }, []string{"org"})
 
 var scanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "duckgres_scan_rows_per_second",
-	Help:    "Scan throughput: estimated wall-clock rows scanned per second",
-	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9},
+	Name: "duckgres_scan_rows_per_second",
+	Help: "Scan throughput: estimated wall-clock rows scanned per second. High values (>1e10) indicate buffer pool/cache hits.",
+	// Range spans S3 cold reads (1e5-1e8) through in-memory cache hits (1e9-1e12).
+	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 1e10, 1e11, 1e12},
 }, []string{"org"})
 
 // BackendKey uniquely identifies a backend connection for cancel requests


### PR DESCRIPTION
## Summary

Add higher histogram buckets (1e10, 1e11, 1e12) to `duckgres_scan_rows_per_second` so cache hits can be measured accurately.

## Why

Cached queries scan billions of rows in milliseconds (e.g. 2.7B rows/sec when buffer pool serves everything). Previous top bucket was 1e9, so these values all fell into `+Inf` and distorted the p50/p95 percentiles on the Scan Throughput panel.

With the extended buckets:
- S3 cold reads: 1e5 - 1e8 rows/sec
- VPC peer fetches: 1e8 - 1e10 rows/sec
- Local NVMe / buffer pool hits: 1e10 - 1e12 rows/sec

This makes the metric actually useful for measuring the cache impact.