### PR TITLE
fix: right-size DuckLake pg pool to threads+4, not flat 64

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1251,15 +1251,28 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 			"Consider connecting directly to PostgreSQL instead.")
 	}
 
-	// Raise the postgres_scanner connection pool limit before ATTACH. DuckDB 1.5.2
-	// reduced the default from 64 (unbounded wait) to max(num_cpus, 8) with a 30s
-	// timeout; DuckLake piggybacks on postgres_scanner for its metadata store and,
-	// with thread-local connection caching, each DuckDB worker pins a pool slot,
-	// saturating the pool under catalog-enumerating workloads (e.g. duckdb_tables(),
-	// information_schema.tables). Plain `SET` does NOT propagate to DuckLake's
-	// internal __ducklake_metadata_* catalog; only `SET GLOBAL` does.
+	// Size the postgres_scanner connection pool to match this session's thread
+	// count (plus a small margin). DuckDB 1.5.2 reduced the pool default from 64
+	// to max(num_cpus, 8) with a 30s timeout; DuckLake piggybacks on
+	// postgres_scanner for its metadata store and, with thread-local connection
+	// caching enabled, each DuckDB worker thread pins one pool slot. If
+	// pool_max < threads, threads beyond the cap time out after 30s (#434 bumped
+	// to a flat 64 to fix that, but that caps RDS occupancy at sessions*64).
+	//
+	// Sizing to `threads + 4` gives every worker thread a cached slot plus a
+	// small buffer for transient acquirers (reaper, migration probe, parallel
+	// scan fan-out) without inflating steady-state RDS connection count.
+	//
+	// Plain `SET` does NOT propagate to DuckLake's internal
+	// __ducklake_metadata_* catalog; only `SET GLOBAL` does.
 	// See: https://github.com/duckdb/ducklake/issues/1031
-	if _, err := db.Exec("SET GLOBAL pg_pool_max_connections = 64"); err != nil {
+	var threadCount int64
+	if err := db.QueryRow("SELECT current_setting('threads')::BIGINT").Scan(&threadCount); err != nil {
+		slog.Warn("Failed to read DuckDB threads setting; using fallback pool size.", "error", err)
+		threadCount = int64(runtime.NumCPU() * 2)
+	}
+	poolMax := threadCount + 4
+	if _, err := db.Exec(fmt.Sprintf("SET GLOBAL pg_pool_max_connections = %d", poolMax)); err != nil {
 		slog.Warn("Failed to set pg_pool_max_connections.", "error", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1268,12 +1268,15 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// See: https://github.com/duckdb/ducklake/issues/1031
 	var threadCount int64
 	if err := db.QueryRow("SELECT current_setting('threads')::BIGINT").Scan(&threadCount); err != nil {
-		slog.Warn("Failed to read DuckDB threads setting; using fallback pool size.", "error", err)
-		threadCount = int64(runtime.NumCPU() * 2)
-	}
-	poolMax := threadCount + 4
-	if _, err := db.Exec(fmt.Sprintf("SET GLOBAL pg_pool_max_connections = %d", poolMax)); err != nil {
-		slog.Warn("Failed to set pg_pool_max_connections.", "error", err)
+		// Skip the SET and let DuckDB's default apply — runtime.NumCPU() reports
+		// the host's CPU count, not the pod's cgroup limit, so any fallback
+		// computed here would be wrong in K8s.
+		slog.Warn("Failed to read DuckDB threads setting; leaving pg_pool_max_connections at default.", "error", err)
+	} else {
+		poolMax := threadCount + 4
+		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL pg_pool_max_connections = %d", poolMax)); err != nil {
+			slog.Warn("Failed to set pg_pool_max_connections.", "error", err)
+		}
 	}
 
 	// Build the ATTACH statement.

--- a/server/server.go
+++ b/server/server.go
@@ -1276,6 +1276,8 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 		poolMax := threadCount + 4
 		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL pg_pool_max_connections = %d", poolMax)); err != nil {
 			slog.Warn("Failed to set pg_pool_max_connections.", "error", err)
+		} else {
+			slog.Info("Set DuckLake metadata pg_pool_max_connections.", "pool_max", poolMax, "threads", threadCount)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Replace the flat `pg_pool_max_connections = 64` from #434 with a per-session size of `threads + 4`
- Each duckgres session owns its own DuckDB + postgres_scanner pool, so the flat 64 meant steady-state RDS occupancy of `sessions × 64`. In prod this produced a large spike on the metadata RDS.
- Thread-local caching is still wanted (warm pg connection per worker keeps metadata-query latency low), so the correct ceiling is *one slot per DuckDB worker thread* plus a small margin for transient acquirers (reaper thread, migration probe, parallel scan fan-out).

## Why `threads + 4`

- `pool_max ≥ threads` is required or threads beyond the cap hit the 30s timeout (the bug #434 fixed).
- `+4` covers short-lived non-query connections: the postgres_scanner reaper thread, DuckLake's migration probe, any parallel scan state that briefly holds >1 connection per thread before settling back to cache.

## Impact

For an 8-core prod box with default `threads = NumCPU * 2 = 16`:
- Before (#434): per-session max = 64 → RDS occupancy ceiling `sessions × 64`
- After: per-session max = 20 → RDS occupancy ceiling `sessions × 20`

3.2× lower connection count, same timeout fix, thread-local caching preserved.

## Test plan

- [ ] CI integration-tests green (same suite that #434 fixed)
- [ ] Watch metadata RDS connection count drop on next deploy