### PR TITLE
fix: enable pg_pool reaper + idle/lifetime timeouts for DuckLake metadata

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1292,6 +1292,27 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 		// Don't fail - this is not critical, DuckLake will use its default
 	}
 
+	// Reclaim idle metadata connections. DuckDB 1.5.2 / DuckLake 1.0 introduced
+	// thread-local connection caching for postgres_scanner (default ON) but
+	// ships with reaper_thread=off and both idle/lifetime timeouts=0, so every
+	// connection a DuckDB worker thread ever caches stays pinned forever.
+	// That produced a large steady-state spike in metadata RDS connections
+	// post-upgrade. Enabling the reaper with a modest idle timeout lets idle
+	// cached connections close while active workers keep the warm-connection
+	// latency benefit of TLC. 10-min max lifetime is a belt-and-braces cap
+	// against stuck connections (NAT table churn, pgbouncer-style kills).
+	// See: https://github.com/duckdb/ducklake/issues/1031 and
+	// https://github.com/duckdb/duckdb-postgres/pull/430
+	if _, err := db.Exec("SET GLOBAL pg_pool_enable_reaper_thread = true"); err != nil {
+		slog.Warn("Failed to enable pg_pool reaper thread.", "error", err)
+	}
+	if _, err := db.Exec("SET GLOBAL pg_pool_idle_timeout_millis = 60000"); err != nil {
+		slog.Warn("Failed to set pg_pool_idle_timeout_millis.", "error", err)
+	}
+	if _, err := db.Exec("SET GLOBAL pg_pool_max_lifetime_millis = 600000"); err != nil {
+		slog.Warn("Failed to set pg_pool_max_lifetime_millis.", "error", err)
+	}
+
 	// Ensure performance indexes exist on the DuckLake metadata tables.
 	// Run in a goroutine so it doesn't block the DuckLake semaphore or
 	// delay connection setup. Uses atomic flag to retry on transient failures.

--- a/server/server.go
+++ b/server/server.go
@@ -1301,16 +1301,22 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// cached connections close while active workers keep the warm-connection
 	// latency benefit of TLC. 10-min max lifetime is a belt-and-braces cap
 	// against stuck connections (NAT table churn, pgbouncer-style kills).
+	//
+	// Use postgres_configure_pool() (not SET GLOBAL) to reconfigure the pool
+	// that was just created by ATTACH. SET GLOBAL only affects pools created
+	// after it runs, so it's a no-op for the pool baked during ATTACH above.
 	// See: https://github.com/duckdb/ducklake/issues/1031 and
 	// https://github.com/duckdb/duckdb-postgres/pull/430
-	if _, err := db.Exec("SET GLOBAL pg_pool_enable_reaper_thread = true"); err != nil {
-		slog.Warn("Failed to enable pg_pool reaper thread.", "error", err)
-	}
-	if _, err := db.Exec("SET GLOBAL pg_pool_idle_timeout_millis = 60000"); err != nil {
-		slog.Warn("Failed to set pg_pool_idle_timeout_millis.", "error", err)
-	}
-	if _, err := db.Exec("SET GLOBAL pg_pool_max_lifetime_millis = 600000"); err != nil {
-		slog.Warn("Failed to set pg_pool_max_lifetime_millis.", "error", err)
+	rows, err := db.Query(`SELECT * FROM postgres_configure_pool(
+		catalog_name := '__ducklake_metadata_ducklake',
+		enable_reaper_thread := true,
+		idle_timeout_millis := 60000,
+		max_lifetime_millis := 600000
+	)`)
+	if err != nil {
+		slog.Warn("Failed to configure DuckLake metadata pg pool.", "error", err)
+	} else {
+		_ = rows.Close()
 	}
 
 	// Ensure performance indexes exist on the DuckLake metadata tables.


### PR DESCRIPTION
## Summary

- Turn on the postgres_scanner connection pool reaper for the DuckLake metadata catalog
- Add a 60s idle timeout and a 10-min max-lifetime cap
- Leave `pg_pool_max_connections` alone — DuckLake 1.0 ships a 64-slot cap by default, that's fine

## Root cause of the prod RDS spike

DuckDB 1.5.2 / DuckLake 1.0 introduced thread-local connection caching for postgres_scanner. Each DuckDB worker thread that runs a metadata query grabs a pg connection and stashes it in a thread-local cache so future queries on the same thread reuse it (latency win).

Defaults shipped:

| Setting | Default | Problem |
|---|---|---|
| `pg_pool_enable_thread_local_cache` | `true` | each thread pins one connection |
| `pg_pool_enable_reaper_thread` | `false` | nothing cleans up idle pinned connections |
| `pg_pool_idle_timeout_millis` | `0` (unlimited) | cached connections never expire |
| `pg_pool_max_lifetime_millis` | `0` (unlimited) | connections live forever |

So every pg connection a DuckDB thread ever cached stays pinned to that thread for the life of the duckgres process. Per-worker steady-state RDS connection count climbs toward the ceiling and stays there.

Verified with `SELECT * FROM postgres_configure_pool();` in prod: `max_connections=64`, `available_connections=0`, `reaper_thread_running=f`, `idle_timeout_millis=0`, `max_lifetime_millis=0`.

## Why reaper + timeouts instead of lowering the cap

The 64-slot cap is not the issue — it's a ceiling, not a driver. The problem is that without a reaper, cached connections never release, so the pool saturates and stays saturated. Enabling the reaper keeps the warm-connection latency benefit for active workers while letting idle slots close.

Upstream tracking: https://github.com/duckdb/ducklake/issues/1031

## Test plan

- [ ] CI green
- [ ] Deploy to a worker, observe `SELECT reaper_thread_running, idle_timeout_millis, max_lifetime_millis FROM postgres_configure_pool();` now reports `t, 60000, 600000`
- [ ] Watch metadata RDS connection count drop after rollout