### PR TITLE
Add configurable retire-on-session-end mode for process workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ extensions:
 ducklake:
   metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
+process:
+  min_workers: 0
+  max_workers: 0
+  retire_on_session_end: false
+
 rate_limit:
   max_failed_attempts: 5
   failed_attempt_window: "5m"
@@ -198,6 +203,7 @@ Run with config file:
 | `DUCKGRES_MEMORY_LIMIT` | DuckDB memory_limit per session (e.g., `4GB`) | Auto-detected |
 | `DUCKGRES_THREADS` | DuckDB threads per session | `runtime.NumCPU()` |
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
+| `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |
 | `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` |
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_K8S_SHARED_WARM_TARGET` | Neutral shared warm-worker target for K8s multi-tenant mode (`0` disables prewarm) | `0` |
@@ -250,6 +256,8 @@ Options:
   -mode string             Run mode: standalone (default), control-plane, or duckdb-service
   -process-min-workers int Pre-warm process worker count at startup (control-plane mode, default 0)
   -process-max-workers int Max process workers, 0=auto-derived (control-plane mode)
+  -process-retire-on-session-end
+                          Retire a process worker immediately after its last session ends instead of keeping it warm for reuse (control-plane mode)
   -memory-budget string    Total memory for all DuckDB sessions (e.g., '24GB')
   -socket-dir string       Unix socket directory (control-plane mode)
   -handover-socket string  Handover socket for graceful deployment (control-plane mode)

--- a/config_resolution.go
+++ b/config_resolution.go
@@ -31,6 +31,7 @@ type configCLIInputs struct {
 	MemoryRebalance           bool
 	ProcessMinWorkers         int
 	ProcessMaxWorkers         int
+	ProcessRetireOnSessionEnd bool
 	WorkerQueueTimeout        string
 	WorkerIdleTimeout         string
 	HandoverDrainTimeout      string
@@ -65,33 +66,34 @@ type configCLIInputs struct {
 }
 
 type resolvedConfig struct {
-	Server                   server.Config
-	ProcessMinWorkers        int
-	ProcessMaxWorkers        int
-	WorkerQueueTimeout       time.Duration
-	WorkerIdleTimeout        time.Duration
-	HandoverDrainTimeout     time.Duration
-	WorkerBackend            string
-	K8sWorkerImage           string
-	K8sWorkerNamespace       string
-	K8sControlPlaneID        string
-	K8sWorkerPort            int
-	K8sWorkerSecret          string
-	K8sWorkerConfigMap       string
-	K8sWorkerImagePullPolicy string
-	K8sWorkerServiceAccount  string
-	K8sMaxWorkers            int
-	K8sSharedWarmTarget      int
-	K8sWorkerCPURequest      string
-	K8sWorkerMemoryRequest   string
-	K8sWorkerNodeSelector    string
-	K8sWorkerTolerationKey   string
-	K8sWorkerTolerationValue string
-	K8sWorkerExclusiveNode   bool
-	AWSRegion                string
-	ConfigStoreConn          string
-	ConfigPollInterval       time.Duration
-	InternalSecret           string
+	Server                    server.Config
+	ProcessMinWorkers         int
+	ProcessMaxWorkers         int
+	ProcessRetireOnSessionEnd bool
+	WorkerQueueTimeout        time.Duration
+	WorkerIdleTimeout         time.Duration
+	HandoverDrainTimeout      time.Duration
+	WorkerBackend             string
+	K8sWorkerImage            string
+	K8sWorkerNamespace        string
+	K8sControlPlaneID         string
+	K8sWorkerPort             int
+	K8sWorkerSecret           string
+	K8sWorkerConfigMap        string
+	K8sWorkerImagePullPolicy  string
+	K8sWorkerServiceAccount   string
+	K8sMaxWorkers             int
+	K8sSharedWarmTarget       int
+	K8sWorkerCPURequest       string
+	K8sWorkerMemoryRequest    string
+	K8sWorkerNodeSelector     string
+	K8sWorkerTolerationKey    string
+	K8sWorkerTolerationValue  string
+	K8sWorkerExclusiveNode    bool
+	AWSRegion                 string
+	ConfigStoreConn           string
+	ConfigPollInterval        time.Duration
+	InternalSecret            string
 }
 
 func intPtr(n int) *int { return &n }
@@ -113,7 +115,7 @@ func defaultServerConfig() server.Config {
 		},
 		Extensions: []string{"ducklake"},
 		DuckLake: server.DuckLakeConfig{
-			CheckpointInterval:  24 * time.Hour,
+			CheckpointInterval:   24 * time.Hour,
 			DataInliningRowLimit: intPtr(0),
 		},
 		QueryLog: server.QueryLogConfig{
@@ -143,6 +145,7 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	var workerIdleTimeout time.Duration
 	var handoverDrainTimeout time.Duration
 	var processMinWorkers, processMaxWorkers int
+	var processRetireOnSessionEnd bool
 	var workerBackend string
 	var k8sWorkerImage, k8sWorkerNamespace, k8sControlPlaneID string
 	var k8sWorkerPort int
@@ -311,6 +314,9 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		}
 		if fileCfg.Process.MaxWorkers != 0 {
 			processMaxWorkers = fileCfg.Process.MaxWorkers
+		}
+		if fileCfg.Process.RetireOnSessionEnd != nil {
+			processRetireOnSessionEnd = *fileCfg.Process.RetireOnSessionEnd
 		}
 		if fileCfg.WorkerQueueTimeout != "" {
 			if d, err := time.ParseDuration(fileCfg.WorkerQueueTimeout); err == nil {
@@ -583,6 +589,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 			warn("Invalid DUCKGRES_PROCESS_MAX_WORKERS: " + err.Error())
 		}
 	}
+	if v := getenv("DUCKGRES_PROCESS_RETIRE_ON_SESSION_END"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			processRetireOnSessionEnd = b
+		} else {
+			warn("Invalid DUCKGRES_PROCESS_RETIRE_ON_SESSION_END: " + err.Error())
+		}
+	}
 	if v := getenv("DUCKGRES_WORKER_QUEUE_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			workerQueueTimeout = d
@@ -822,6 +835,9 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if cli.Set["process-max-workers"] {
 		processMaxWorkers = cli.ProcessMaxWorkers
 	}
+	if cli.Set["process-retire-on-session-end"] {
+		processRetireOnSessionEnd = cli.ProcessRetireOnSessionEnd
+	}
 	if cli.Set["worker-queue-timeout"] {
 		if d, err := time.ParseDuration(cli.WorkerQueueTimeout); err == nil {
 			workerQueueTimeout = d
@@ -967,32 +983,33 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	}
 
 	return resolvedConfig{
-		Server:                   cfg,
-		ProcessMinWorkers:        processMinWorkers,
-		ProcessMaxWorkers:        processMaxWorkers,
-		WorkerQueueTimeout:       workerQueueTimeout,
-		WorkerIdleTimeout:        workerIdleTimeout,
-		HandoverDrainTimeout:     handoverDrainTimeout,
-		WorkerBackend:            workerBackend,
-		K8sWorkerImage:           k8sWorkerImage,
-		K8sWorkerNamespace:       k8sWorkerNamespace,
-		K8sControlPlaneID:        k8sControlPlaneID,
-		K8sWorkerPort:            k8sWorkerPort,
-		K8sWorkerSecret:          k8sWorkerSecret,
-		K8sWorkerConfigMap:       k8sWorkerConfigMap,
-		K8sWorkerImagePullPolicy: k8sWorkerImagePullPolicy,
-		K8sWorkerServiceAccount:  k8sWorkerServiceAccount,
-		K8sMaxWorkers:            k8sMaxWorkers,
-		K8sSharedWarmTarget:      k8sSharedWarmTarget,
-		K8sWorkerCPURequest:     k8sWorkerCPURequest,
-		K8sWorkerMemoryRequest:  k8sWorkerMemoryRequest,
-		K8sWorkerNodeSelector:   k8sWorkerNodeSelector,
-		K8sWorkerTolerationKey:   k8sWorkerTolerationKey,
-		K8sWorkerTolerationValue: k8sWorkerTolerationValue,
-		K8sWorkerExclusiveNode:  k8sWorkerExclusiveNode,
-		AWSRegion:                awsRegion,
-		ConfigStoreConn:          configStoreConn,
-		ConfigPollInterval:       configPollInterval,
-		InternalSecret:           internalSecret,
+		Server:                    cfg,
+		ProcessMinWorkers:         processMinWorkers,
+		ProcessMaxWorkers:         processMaxWorkers,
+		ProcessRetireOnSessionEnd: processRetireOnSessionEnd,
+		WorkerQueueTimeout:        workerQueueTimeout,
+		WorkerIdleTimeout:         workerIdleTimeout,
+		HandoverDrainTimeout:      handoverDrainTimeout,
+		WorkerBackend:             workerBackend,
+		K8sWorkerImage:            k8sWorkerImage,
+		K8sWorkerNamespace:        k8sWorkerNamespace,
+		K8sControlPlaneID:         k8sControlPlaneID,
+		K8sWorkerPort:             k8sWorkerPort,
+		K8sWorkerSecret:           k8sWorkerSecret,
+		K8sWorkerConfigMap:        k8sWorkerConfigMap,
+		K8sWorkerImagePullPolicy:  k8sWorkerImagePullPolicy,
+		K8sWorkerServiceAccount:   k8sWorkerServiceAccount,
+		K8sMaxWorkers:             k8sMaxWorkers,
+		K8sSharedWarmTarget:       k8sSharedWarmTarget,
+		K8sWorkerCPURequest:       k8sWorkerCPURequest,
+		K8sWorkerMemoryRequest:    k8sWorkerMemoryRequest,
+		K8sWorkerNodeSelector:     k8sWorkerNodeSelector,
+		K8sWorkerTolerationKey:    k8sWorkerTolerationKey,
+		K8sWorkerTolerationValue:  k8sWorkerTolerationValue,
+		K8sWorkerExclusiveNode:    k8sWorkerExclusiveNode,
+		AWSRegion:                 awsRegion,
+		ConfigStoreConn:           configStoreConn,
+		ConfigPollInterval:        configPollInterval,
+		InternalSecret:            internalSecret,
 	}
 }

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -38,6 +38,7 @@ type ControlPlaneConfig struct {
 	HealthCheckInterval  time.Duration
 	WorkerQueueTimeout   time.Duration // How long to wait for an available worker slot (default: 5m)
 	WorkerIdleTimeout    time.Duration // How long to keep an idle worker alive (default: 5m)
+	RetireOnSessionEnd   bool          // When true, process workers are retired immediately after their last session ends.
 	HandoverDrainTimeout time.Duration // How long to wait for connections to drain during upgrade (default: 24h)
 	MetricsServer        *http.Server  // Optional metrics server to shut down during upgrade
 
@@ -386,6 +387,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		// Single-tenant mode: one shared process pool + session manager
 		procPool := NewFlightWorkerPool(cfg.SocketDir, cfg.ConfigPath, processMinWorkers, processMaxWorkers)
 		procPool.idleTimeout = cfg.WorkerIdleTimeout
+		procPool.retireOnSessionEnd = cfg.RetireOnSessionEnd
 
 		// Pre-bind worker sockets. On upgrade with EROFS, this may fail —
 		// that's OK, workers will fall back to effectiveSocketDir (/tmp).

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -25,24 +25,24 @@ import (
 
 // ManagedWorker represents a duckdb-service worker process.
 type ManagedWorker struct {
-	ID             int
-	podName        string
-	cmd            *exec.Cmd
-	socketPath     string
-	bearerToken    string
-	client         *flightsql.Client
-	parentListener net.Listener    // CP-side listener; lifecycle managed by releaseSocket
-	prebound       *preboundSocket // non-nil if using a pre-bound socket slot
-	releaseOnce    sync.Once       // ensures releaseWorkerSocket body runs exactly once
-	done           chan struct{}   // closed when process exits
-	exitErr        error
-	activeSessions int       // Number of sessions currently assigned to this worker
-	lastUsed       time.Time // Last time a session was destroyed on this worker
-	sharedState    SharedWorkerState
-	reservedAt     time.Time //nolint:unused // only set in kubernetes warm-pool reservation path
-	peakSessions   int       // High-water mark of concurrent sessions (for retirement metrics)
-	ownerEpoch     int64
-	ownerCPInstanceID      string
+	ID                      int
+	podName                 string
+	cmd                     *exec.Cmd
+	socketPath              string
+	bearerToken             string
+	client                  *flightsql.Client
+	parentListener          net.Listener    // CP-side listener; lifecycle managed by releaseSocket
+	prebound                *preboundSocket // non-nil if using a pre-bound socket slot
+	releaseOnce             sync.Once       // ensures releaseWorkerSocket body runs exactly once
+	done                    chan struct{}   // closed when process exits
+	exitErr                 error
+	activeSessions          int       // Number of sessions currently assigned to this worker
+	lastUsed                time.Time // Last time a session was destroyed on this worker
+	sharedState             SharedWorkerState
+	reservedAt              time.Time //nolint:unused // only set in kubernetes warm-pool reservation path
+	peakSessions            int       // High-water mark of concurrent sessions (for retirement metrics)
+	ownerEpoch              int64
+	ownerCPInstanceID       string
 	hotIdleReclaimed        bool //nolint:unused // only set in kubernetes hot-idle reclaim path
 	cachedActivationPayload any  //nolint:unused // *TenantActivationPayload, cached in kubernetes activation path
 }
@@ -98,25 +98,26 @@ type preboundSocket struct {
 }
 
 type FlightWorkerPool struct {
-	mu                sync.RWMutex
-	workers           map[int]*ManagedWorker
-	nextWorkerID      int // auto-incrementing worker ID
-	spawning          int // number of workers currently being spawned (not yet in workers map)
-	socketDir         string
-	fallbackSocketDir string // set lazily when socketDir is EROFS; empty means use primary
-	configPath        string
-	binaryPath        string
-	maxWorkers        int           // 0 = unlimited; caps the number of live worker processes
-	minWorkers        int           // minimum number of workers to keep alive
-	idleTimeout       time.Duration // how long to keep an idle worker alive
-	shuttingDown      bool
-	shutdownCh        chan struct{} // closed by ShutdownAll to stop idle reaper
+	mu                 sync.RWMutex
+	workers            map[int]*ManagedWorker
+	nextWorkerID       int // auto-incrementing worker ID
+	spawning           int // number of workers currently being spawned (not yet in workers map)
+	socketDir          string
+	fallbackSocketDir  string // set lazily when socketDir is EROFS; empty means use primary
+	configPath         string
+	binaryPath         string
+	maxWorkers         int           // 0 = unlimited; caps the number of live worker processes
+	minWorkers         int           // minimum number of workers to keep alive
+	idleTimeout        time.Duration // how long to keep an idle worker alive
+	retireOnSessionEnd bool          // when true, retire a worker as soon as its last session ends
+	shuttingDown       bool
+	shutdownCh         chan struct{} // closed by ShutdownAll to stop idle reaper
 
 	preboundMu sync.Mutex
 	prebound   []*preboundSocket // available pre-bound socket slots
 
-	ducklakeMigrateMu sync.Mutex  // serializes worker spawns during migration
-	ducklakeMigrate   bool        // when true, pass DUCKGRES_DUCKLAKE_MIGRATE=true to workers
+	ducklakeMigrateMu sync.Mutex // serializes worker spawns during migration
+	ducklakeMigrate   bool       // when true, pass DUCKGRES_DUCKLAKE_MIGRATE=true to workers
 }
 
 // NewFlightWorkerPool creates a new worker pool.
@@ -716,14 +717,24 @@ func (p *FlightWorkerPool) AcquireWorker(ctx context.Context) (*ManagedWorker, e
 // ReleaseWorker decrements the active session count for a worker and updates its lastUsed time.
 func (p *FlightWorkerPool) ReleaseWorker(id int) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	w, ok := p.workers[id]
-	if ok {
-		if w.activeSessions > 0 {
-			w.activeSessions--
-		}
-		w.lastUsed = time.Now()
+	if !ok {
+		p.mu.Unlock()
+		return
 	}
+	if w.activeSessions > 0 {
+		w.activeSessions--
+	}
+	if p.retireOnSessionEnd && w.activeSessions == 0 {
+		delete(p.workers, id)
+		workerCount := len(p.workers)
+		p.mu.Unlock()
+		observeControlPlaneWorkers(workerCount)
+		go p.retireWorkerProcess(w)
+		return
+	}
+	w.lastUsed = time.Now()
+	p.mu.Unlock()
 }
 
 // idleReaper periodically retires workers that have been idle for longer than idleTimeout.

--- a/controlplane/worker_mgr_process_test.go
+++ b/controlplane/worker_mgr_process_test.go
@@ -471,6 +471,44 @@ func TestRetireWorkerIfNoSessions_RetiresWhenLastSession(t *testing.T) {
 	}
 }
 
+func TestReleaseWorker_RetiresWhenLastSessionAndEnabled(t *testing.T) {
+	pool := NewFlightWorkerPool(t.TempDir(), "", 0, 1)
+	pool.retireOnSessionEnd = true
+
+	w, cleanup := makeFakeWorker(t, 1)
+	defer cleanup()
+	w.activeSessions = 1
+
+	pool.mu.Lock()
+	pool.workers[1] = w
+	pool.mu.Unlock()
+
+	pool.ReleaseWorker(1)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := pool.Worker(1); ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		select {
+		case <-w.done:
+			return
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	if _, ok := pool.Worker(1); ok {
+		t.Fatal("worker should have been retired after its last session ended")
+	}
+	select {
+	case <-w.done:
+	default:
+		t.Fatal("worker process should have exited after retire-on-session-end")
+	}
+}
+
 func TestAcquireWorker_AtomicClaimRace(t *testing.T) {
 	// Tests that two concurrent acquisitions don't pick the same idle worker.
 	const n = 5

--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -93,8 +93,11 @@ ducklake:
 # process:
 #   # min_workers: pre-warm process workers at startup for instant connection handling.
 #   # max_workers: cap on total process workers (0 = auto-derived).
+#   # retire_on_session_end: retire a process worker immediately after its last
+#   # session ends instead of keeping it warm for reuse.
 #   min_workers: 0
 #   max_workers: 0
+#   retire_on_session_end: false
 
 # Kubernetes multi-tenant shared warm-pool settings
 # k8s:

--- a/main.go
+++ b/main.go
@@ -56,8 +56,9 @@ type FileConfig struct {
 }
 
 type ProcessFileConfig struct {
-	MinWorkers int `yaml:"min_workers"`
-	MaxWorkers int `yaml:"max_workers"`
+	MinWorkers         int   `yaml:"min_workers"`
+	MaxWorkers         int   `yaml:"max_workers"`
+	RetireOnSessionEnd *bool `yaml:"retire_on_session_end"`
 }
 
 // K8sFileConfig holds Kubernetes worker configuration from YAML.
@@ -229,6 +230,7 @@ func main() {
 	mode := flag.String("mode", "standalone", "Run mode: standalone, control-plane, or duckdb-service")
 	processMinWorkers := flag.Int("process-min-workers", 0, "Pre-warm worker count at startup for process workers (control-plane mode) (env: DUCKGRES_PROCESS_MIN_WORKERS)")
 	processMaxWorkers := flag.Int("process-max-workers", 0, "Max process workers, 0=auto-derived (control-plane mode) (env: DUCKGRES_PROCESS_MAX_WORKERS)")
+	processRetireOnSessionEnd := flag.Bool("process-retire-on-session-end", false, "Retire a process worker immediately after its last session ends instead of keeping it warm for reuse (control-plane mode) (env: DUCKGRES_PROCESS_RETIRE_ON_SESSION_END)")
 	workerQueueTimeout := flag.String("worker-queue-timeout", "", "How long to wait for an available worker slot (e.g., '5m') (env: DUCKGRES_WORKER_QUEUE_TIMEOUT)")
 	workerIdleTimeout := flag.String("worker-idle-timeout", "", "How long to keep an idle worker alive (e.g., '5m') (env: DUCKGRES_WORKER_IDLE_TIMEOUT)")
 	handoverDrainTimeout := flag.String("handover-drain-timeout", "", "How long to wait for planned shutdowns/upgrades to drain before forcing exit (default: '24h' in process mode, '15m' in remote mode) (env: DUCKGRES_HANDOVER_DRAIN_TIMEOUT)")
@@ -293,6 +295,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_REBALANCE   Enable dynamic per-connection memory reallocation (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_MIN_WORKERS  Pre-warm worker count for process workers (control-plane mode)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_MAX_WORKERS  Max process workers (control-plane mode)\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_RETIRE_ON_SESSION_END  Retire process workers immediately after their last session ends (control-plane mode)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_WORKER_QUEUE_TIMEOUT  Worker queue timeout (default: 5m)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_HANDOVER_DRAIN_TIMEOUT  Planned shutdown/upgrade drain timeout (default: 24h in process mode, 15m in remote mode)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_ACME_DOMAIN        Domain for ACME/Let's Encrypt certificate\n")
@@ -405,6 +408,7 @@ func main() {
 		MemoryRebalance:           *memoryRebalance,
 		ProcessMinWorkers:         *processMinWorkers,
 		ProcessMaxWorkers:         *processMaxWorkers,
+		ProcessRetireOnSessionEnd: *processRetireOnSessionEnd,
 		WorkerQueueTimeout:        *workerQueueTimeout,
 		WorkerIdleTimeout:         *workerIdleTimeout,
 		HandoverDrainTimeout:      *handoverDrainTimeout,
@@ -556,6 +560,7 @@ func main() {
 			ConfigPath:           *configFile,
 			WorkerQueueTimeout:   resolved.WorkerQueueTimeout,
 			WorkerIdleTimeout:    resolved.WorkerIdleTimeout,
+			RetireOnSessionEnd:   resolved.ProcessRetireOnSessionEnd,
 			HandoverDrainTimeout: resolved.HandoverDrainTimeout,
 			MetricsServer:        metricsSrv,
 			WorkerBackend:        resolved.WorkerBackend,
@@ -563,23 +568,23 @@ func main() {
 			ConfigPollInterval:   resolved.ConfigPollInterval,
 			InternalSecret:       resolved.InternalSecret,
 			K8s: controlplane.K8sConfig{
-				WorkerImage:       resolved.K8sWorkerImage,
-				WorkerNamespace:   resolved.K8sWorkerNamespace,
-				ControlPlaneID:    resolved.K8sControlPlaneID,
-				WorkerPort:        resolved.K8sWorkerPort,
-				WorkerSecret:      resolved.K8sWorkerSecret,
-				WorkerConfigMap:   resolved.K8sWorkerConfigMap,
-				ImagePullPolicy:   resolved.K8sWorkerImagePullPolicy,
-				ServiceAccount:    resolved.K8sWorkerServiceAccount,
-				MaxWorkers:        resolved.K8sMaxWorkers,
-				SharedWarmTarget:    resolved.K8sSharedWarmTarget,
-				WorkerCPURequest:    resolved.K8sWorkerCPURequest,
-				WorkerMemoryRequest: resolved.K8sWorkerMemoryRequest,
-				WorkerNodeSelector:  resolved.K8sWorkerNodeSelector,
+				WorkerImage:           resolved.K8sWorkerImage,
+				WorkerNamespace:       resolved.K8sWorkerNamespace,
+				ControlPlaneID:        resolved.K8sControlPlaneID,
+				WorkerPort:            resolved.K8sWorkerPort,
+				WorkerSecret:          resolved.K8sWorkerSecret,
+				WorkerConfigMap:       resolved.K8sWorkerConfigMap,
+				ImagePullPolicy:       resolved.K8sWorkerImagePullPolicy,
+				ServiceAccount:        resolved.K8sWorkerServiceAccount,
+				MaxWorkers:            resolved.K8sMaxWorkers,
+				SharedWarmTarget:      resolved.K8sSharedWarmTarget,
+				WorkerCPURequest:      resolved.K8sWorkerCPURequest,
+				WorkerMemoryRequest:   resolved.K8sWorkerMemoryRequest,
+				WorkerNodeSelector:    resolved.K8sWorkerNodeSelector,
 				WorkerTolerationKey:   resolved.K8sWorkerTolerationKey,
 				WorkerTolerationValue: resolved.K8sWorkerTolerationValue,
-				WorkerExclusiveNode:  resolved.K8sWorkerExclusiveNode,
-				AWSRegion:           resolved.AWSRegion,
+				WorkerExclusiveNode:   resolved.K8sWorkerExclusiveNode,
+				AWSRegion:             resolved.AWSRegion,
 			},
 		}
 		controlplane.RunControlPlane(cpCfg)

--- a/main_test.go
+++ b/main_test.go
@@ -321,12 +321,14 @@ func TestResolveEffectiveConfigInvalidMemoryLimit(t *testing.T) {
 }
 
 func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
+	retireTrue := true
 	// YAML only
 	fileCfg := &FileConfig{
 		MemoryBudget: "24GB",
 		Process: ProcessFileConfig{
-			MinWorkers: 2,
-			MaxWorkers: 10,
+			MinWorkers:         2,
+			MaxWorkers:         10,
+			RetireOnSessionEnd: &retireTrue,
 		},
 		K8s: K8sFileConfig{
 			MaxWorkers: 12,
@@ -342,16 +344,20 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	if resolved.ProcessMaxWorkers != 10 {
 		t.Fatalf("expected process.max_workers from file, got %d", resolved.ProcessMaxWorkers)
 	}
+	if !resolved.ProcessRetireOnSessionEnd {
+		t.Fatal("expected process.retire_on_session_end from file")
+	}
 	if resolved.K8sMaxWorkers != 12 {
 		t.Fatalf("expected k8s.max_workers from file, got %d", resolved.K8sMaxWorkers)
 	}
 
 	// Env overrides file
 	env := map[string]string{
-		"DUCKGRES_MEMORY_BUDGET":       "32GB",
-		"DUCKGRES_PROCESS_MIN_WORKERS": "4",
-		"DUCKGRES_PROCESS_MAX_WORKERS": "20",
-		"DUCKGRES_K8S_MAX_WORKERS":     "24",
+		"DUCKGRES_MEMORY_BUDGET":                 "32GB",
+		"DUCKGRES_PROCESS_MIN_WORKERS":           "4",
+		"DUCKGRES_PROCESS_MAX_WORKERS":           "20",
+		"DUCKGRES_PROCESS_RETIRE_ON_SESSION_END": "false",
+		"DUCKGRES_K8S_MAX_WORKERS":               "24",
 	}
 	resolved = resolveEffectiveConfig(fileCfg, configCLIInputs{}, envFromMap(env), nil)
 	if resolved.Server.MemoryBudget != "32GB" {
@@ -363,17 +369,21 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	if resolved.ProcessMaxWorkers != 20 {
 		t.Fatalf("expected process.max_workers from env, got %d", resolved.ProcessMaxWorkers)
 	}
+	if resolved.ProcessRetireOnSessionEnd {
+		t.Fatal("expected process.retire_on_session_end from env")
+	}
 	if resolved.K8sMaxWorkers != 24 {
 		t.Fatalf("expected k8s.max_workers from env, got %d", resolved.K8sMaxWorkers)
 	}
 
 	// CLI overrides env
 	resolved = resolveEffectiveConfig(fileCfg, configCLIInputs{
-		Set:               map[string]bool{"memory-budget": true, "process-min-workers": true, "process-max-workers": true, "k8s-max-workers": true},
-		MemoryBudget:      "48GB",
-		ProcessMinWorkers: 8,
-		ProcessMaxWorkers: 50,
-		K8sMaxWorkers:     64,
+		Set:                       map[string]bool{"memory-budget": true, "process-min-workers": true, "process-max-workers": true, "process-retire-on-session-end": true, "k8s-max-workers": true},
+		MemoryBudget:              "48GB",
+		ProcessMinWorkers:         8,
+		ProcessMaxWorkers:         50,
+		ProcessRetireOnSessionEnd: true,
+		K8sMaxWorkers:             64,
 	}, envFromMap(env), nil)
 	if resolved.Server.MemoryBudget != "48GB" {
 		t.Fatalf("expected memory_budget from CLI, got %q", resolved.Server.MemoryBudget)
@@ -383,6 +393,9 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	}
 	if resolved.ProcessMaxWorkers != 50 {
 		t.Fatalf("expected process.max_workers from CLI, got %d", resolved.ProcessMaxWorkers)
+	}
+	if !resolved.ProcessRetireOnSessionEnd {
+		t.Fatal("expected process.retire_on_session_end from CLI")
 	}
 	if resolved.K8sMaxWorkers != 64 {
 		t.Fatalf("expected k8s.max_workers from CLI, got %d", resolved.K8sMaxWorkers)
@@ -446,9 +459,10 @@ func TestResolveEffectiveConfigInvalidMemoryBudget(t *testing.T) {
 
 func TestResolveEffectiveConfigInvalidWorkerEnvVars(t *testing.T) {
 	env := map[string]string{
-		"DUCKGRES_PROCESS_MIN_WORKERS": "not-a-number",
-		"DUCKGRES_PROCESS_MAX_WORKERS": "also-bad",
-		"DUCKGRES_K8S_MAX_WORKERS":     "still-bad",
+		"DUCKGRES_PROCESS_MIN_WORKERS":           "not-a-number",
+		"DUCKGRES_PROCESS_MAX_WORKERS":           "also-bad",
+		"DUCKGRES_PROCESS_RETIRE_ON_SESSION_END": "definitely-not-bool",
+		"DUCKGRES_K8S_MAX_WORKERS":               "still-bad",
 	}
 
 	var warns []string
@@ -465,10 +479,14 @@ func TestResolveEffectiveConfigInvalidWorkerEnvVars(t *testing.T) {
 	if resolved.K8sMaxWorkers != 0 {
 		t.Fatalf("expected default k8s.max_workers, got %d", resolved.K8sMaxWorkers)
 	}
+	if resolved.ProcessRetireOnSessionEnd {
+		t.Fatal("expected default process.retire_on_session_end")
+	}
 
 	wantWarnings := []string{
 		"Invalid DUCKGRES_PROCESS_MIN_WORKERS",
 		"Invalid DUCKGRES_PROCESS_MAX_WORKERS",
+		"Invalid DUCKGRES_PROCESS_RETIRE_ON_SESSION_END",
 		"Invalid DUCKGRES_K8S_MAX_WORKERS",
 	}
 	for _, w := range wantWarnings {


### PR DESCRIPTION
## Summary
- Introduce an optional process-worker mode that retires a worker as soon as its last session ends instead of keeping it idle for reuse
- Expose the mode via YAML, CLI, env, and config resolution so it follows the normal precedence rules
- Wire the setting into single-tenant control-plane process worker pools
- Document the option in the README and example config and add config/lifecycle coverage for the toggle

## Testing
- `just test-unit`
- `just test-controlplane`