### PR TITLE
fix: disable DuckLake metadata TLS cache before attach

### DIFF
--- a/config_resolution.go
+++ b/config_resolution.go
@@ -248,6 +248,7 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		if fileCfg.DuckLake.DataPath != "" {
 			cfg.DuckLake.DataPath = fileCfg.DuckLake.DataPath
 		}
+		cfg.DuckLake.DisableMetadataThreadLocalCache = fileCfg.DuckLake.DisableMetadataThreadLocalCache
 		if fileCfg.DuckLake.S3Provider != "" {
 			cfg.DuckLake.S3Provider = fileCfg.DuckLake.S3Provider
 		}
@@ -479,6 +480,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	}
 	if v := getenv("DUCKGRES_DUCKLAKE_OBJECT_STORE"); v != "" {
 		cfg.DuckLake.ObjectStore = v
+	}
+	if v := getenv("DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DuckLake.DisableMetadataThreadLocalCache = b
+		} else {
+			warn("Invalid DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE: " + err.Error())
+		}
 	}
 	if v := getenv("DUCKGRES_DUCKLAKE_S3_PROVIDER"); v != "" {
 		cfg.DuckLake.S3Provider = v

--- a/config_resolution.go
+++ b/config_resolution.go
@@ -115,8 +115,9 @@ func defaultServerConfig() server.Config {
 		},
 		Extensions: []string{"ducklake"},
 		DuckLake: server.DuckLakeConfig{
-			CheckpointInterval:   24 * time.Hour,
-			DataInliningRowLimit: intPtr(0),
+			CheckpointInterval:                24 * time.Hour,
+			DataInliningRowLimit:              intPtr(0),
+			DisableMetadataThreadLocalCache:   true,
 		},
 		QueryLog: server.QueryLogConfig{
 			Enabled:              true,
@@ -248,7 +249,9 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		if fileCfg.DuckLake.DataPath != "" {
 			cfg.DuckLake.DataPath = fileCfg.DuckLake.DataPath
 		}
-		cfg.DuckLake.DisableMetadataThreadLocalCache = fileCfg.DuckLake.DisableMetadataThreadLocalCache
+		if fileCfg.DuckLake.DisableMetadataThreadLocalCache != nil {
+			cfg.DuckLake.DisableMetadataThreadLocalCache = *fileCfg.DuckLake.DisableMetadataThreadLocalCache
+		}
 		if fileCfg.DuckLake.S3Provider != "" {
 			cfg.DuckLake.S3Provider = fileCfg.DuckLake.S3Provider
 		}

--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -54,6 +54,11 @@ ducklake:
   # depends on, causing cascading failures. Connect directly to PostgreSQL instead.
   # metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
+  # Disable postgres_scanner thread-local metadata connection caching before
+  # ATTACH creates the hidden DuckLake metadata pool. This reduces retained
+  # metadata connections at the cost of some warm-reuse performance.
+  # disable_metadata_thread_local_cache: true
+
   # S3-compatible object storage for data files (optional)
   # If not specified, data is stored alongside the metadata
   # object_store: "s3://bucket/path/"

--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -55,9 +55,10 @@ ducklake:
   # metadata_store: "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
 
   # Disable postgres_scanner thread-local metadata connection caching before
-  # ATTACH creates the hidden DuckLake metadata pool. This reduces retained
-  # metadata connections at the cost of some warm-reuse performance.
-  # disable_metadata_thread_local_cache: true
+  # ATTACH creates the hidden DuckLake metadata pool. This is enabled by
+  # default to reduce retained metadata connections. Set false to opt back
+  # into thread-local warm reuse.
+  # disable_metadata_thread_local_cache: false
 
   # S3-compatible object storage for data files (optional)
   # If not specified, data is stored alongside the metadata

--- a/main.go
+++ b/main.go
@@ -110,6 +110,10 @@ type DuckLakeFileConfig struct {
 	ObjectStore   string `yaml:"object_store"`   // e.g., "s3://bucket/path/" for S3/MinIO storage
 	DataPath      string `yaml:"data_path"`      // Local file path for data storage (alternative to object_store)
 
+	// Disable metadata postgres_scanner thread-local cache before ATTACH creates
+	// the hidden metadata pool.
+	DisableMetadataThreadLocalCache bool `yaml:"disable_metadata_thread_local_cache"`
+
 	// S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
 	S3Provider string `yaml:"s3_provider"`
 

--- a/main.go
+++ b/main.go
@@ -111,8 +111,8 @@ type DuckLakeFileConfig struct {
 	DataPath      string `yaml:"data_path"`      // Local file path for data storage (alternative to object_store)
 
 	// Disable metadata postgres_scanner thread-local cache before ATTACH creates
-	// the hidden metadata pool.
-	DisableMetadataThreadLocalCache bool `yaml:"disable_metadata_thread_local_cache"`
+	// the hidden metadata pool. Nil means use the server default.
+	DisableMetadataThreadLocalCache *bool `yaml:"disable_metadata_thread_local_cache"`
 
 	// S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
 	S3Provider string `yaml:"s3_provider"`

--- a/main_test.go
+++ b/main_test.go
@@ -115,14 +115,16 @@ func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
 		ProcessIsolation: true,
 		IdleTimeout:      "45m",
 		DuckLake: DuckLakeFileConfig{
-			S3UseSSL: true,
+			S3UseSSL:                        true,
+			DisableMetadataThreadLocalCache: true,
 		},
 	}
 
 	env := map[string]string{
-		"DUCKGRES_PROCESS_ISOLATION":   "not-a-bool",
-		"DUCKGRES_DUCKLAKE_S3_USE_SSL": "not-a-bool",
-		"DUCKGRES_IDLE_TIMEOUT":        "bad-duration",
+		"DUCKGRES_PROCESS_ISOLATION":                            "not-a-bool",
+		"DUCKGRES_DUCKLAKE_S3_USE_SSL":                          "not-a-bool",
+		"DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE": "not-a-bool",
+		"DUCKGRES_IDLE_TIMEOUT":                                 "bad-duration",
 	}
 
 	var warns []string
@@ -136,6 +138,9 @@ func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
 	if !resolved.Server.DuckLake.S3UseSSL {
 		t.Fatalf("invalid env S3_USE_SSL should not override valid file value")
 	}
+	if !resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatalf("invalid env disable_metadata_thread_local_cache should not override valid file value")
+	}
 	if resolved.Server.IdleTimeout != 45*time.Minute {
 		t.Fatalf("invalid env idle timeout should not override valid file value, got %s", resolved.Server.IdleTimeout)
 	}
@@ -143,6 +148,7 @@ func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
 	wantWarnings := []string{
 		"Invalid DUCKGRES_PROCESS_ISOLATION",
 		"Invalid DUCKGRES_DUCKLAKE_S3_USE_SSL",
+		"Invalid DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE",
 		"Invalid DUCKGRES_IDLE_TIMEOUT duration",
 	}
 	for _, w := range wantWarnings {
@@ -156,6 +162,33 @@ func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
 		if !found {
 			t.Fatalf("expected warning containing %q, warnings: %v", w, warns)
 		}
+	}
+}
+
+func TestResolveEffectiveConfigDuckLakeDisableMetadataThreadLocalCache(t *testing.T) {
+	fileCfg := &FileConfig{
+		DuckLake: DuckLakeFileConfig{
+			DisableMetadataThreadLocalCache: true,
+		},
+	}
+
+	resolved := resolveEffectiveConfig(fileCfg, configCLIInputs{}, envFromMap(nil), nil)
+	if !resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatal("expected ducklake.disable_metadata_thread_local_cache from YAML to be true")
+	}
+
+	env := map[string]string{
+		"DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE": "false",
+	}
+	resolved = resolveEffectiveConfig(fileCfg, configCLIInputs{}, envFromMap(env), nil)
+	if resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatal("expected env false to override file true for ducklake.disable_metadata_thread_local_cache")
+	}
+
+	env["DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE"] = "true"
+	resolved = resolveEffectiveConfig(&FileConfig{}, configCLIInputs{}, envFromMap(env), nil)
+	if !resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatal("expected env true to enable ducklake.disable_metadata_thread_local_cache")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -111,12 +111,13 @@ func TestResolveEffectiveConfigEnvOverridesFile(t *testing.T) {
 }
 
 func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
+	enabled := true
 	fileCfg := &FileConfig{
 		ProcessIsolation: true,
 		IdleTimeout:      "45m",
 		DuckLake: DuckLakeFileConfig{
 			S3UseSSL:                        true,
-			DisableMetadataThreadLocalCache: true,
+			DisableMetadataThreadLocalCache: &enabled,
 		},
 	}
 
@@ -166,9 +167,10 @@ func TestResolveEffectiveConfigInvalidEnvValues(t *testing.T) {
 }
 
 func TestResolveEffectiveConfigDuckLakeDisableMetadataThreadLocalCache(t *testing.T) {
+	enabled := true
 	fileCfg := &FileConfig{
 		DuckLake: DuckLakeFileConfig{
-			DisableMetadataThreadLocalCache: true,
+			DisableMetadataThreadLocalCache: &enabled,
 		},
 	}
 
@@ -189,6 +191,23 @@ func TestResolveEffectiveConfigDuckLakeDisableMetadataThreadLocalCache(t *testin
 	resolved = resolveEffectiveConfig(&FileConfig{}, configCLIInputs{}, envFromMap(env), nil)
 	if !resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
 		t.Fatal("expected env true to enable ducklake.disable_metadata_thread_local_cache")
+	}
+}
+
+func TestResolveEffectiveConfigDuckLakeDisableMetadataThreadLocalCacheDefaultsTrue(t *testing.T) {
+	resolved := resolveEffectiveConfig(&FileConfig{}, configCLIInputs{}, envFromMap(nil), nil)
+	if !resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatal("expected ducklake.disable_metadata_thread_local_cache to default to true")
+	}
+
+	disabled := false
+	resolved = resolveEffectiveConfig(&FileConfig{
+		DuckLake: DuckLakeFileConfig{
+			DisableMetadataThreadLocalCache: &disabled,
+		},
+	}, configCLIInputs{}, envFromMap(nil), nil)
+	if resolved.Server.DuckLake.DisableMetadataThreadLocalCache {
+		t.Fatal("expected YAML false to disable ducklake.disable_metadata_thread_local_cache")
 	}
 }
 

--- a/server/checkpoint.go
+++ b/server/checkpoint.go
@@ -59,6 +59,11 @@ func NewDuckLakeCheckpointer(cfg Config) (*DuckLakeCheckpointer, error) {
 		}
 	}
 
+	if err := applyDuckLakePreAttachSettings(db, dlCfg); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("checkpoint: pre-attach settings: %w", err)
+	}
+
 	attachStmt := buildDuckLakeAttachStmt(dlCfg, duckLakeMigrationNeeded())
 	if _, err := db.Exec(attachStmt); err != nil {
 		_ = db.Close()

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -99,6 +99,11 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 		}
 	}
 
+	if err := applyDuckLakePreAttachSettings(db, dlCfg); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("querylog: pre-attach settings: %w", err)
+	}
+
 	// Attach DuckLake
 	attachStmt := buildDuckLakeAttachStmt(dlCfg, duckLakeMigrationNeeded())
 	if _, err := db.Exec(attachStmt); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -257,6 +257,12 @@ type DuckLakeConfig struct {
 	// Format: "postgres:host=<host> user=<user> password=<password> dbname=<db>"
 	MetadataStore string
 
+	// DisableMetadataThreadLocalCache disables postgres_scanner thread-local
+	// connection caching for the hidden DuckLake metadata pool as early as
+	// possible, before ATTACH creates that pool. This trades some warm-reuse
+	// performance for a lower retained metadata-connection footprint.
+	DisableMetadataThreadLocalCache bool
+
 	// ObjectStore is the S3-compatible storage path for DuckLake data files
 	// Format: "s3://bucket/path/" for S3/MinIO
 	// If not specified, uses DataPath for local storage
@@ -353,7 +359,6 @@ type Server struct {
 	// Each user gets one *sql.DB; PG connections share it via pinned *sql.Conn.
 	fileDBsMu sync.Mutex
 	fileDBs   map[string]*fileDBEntry
-
 
 	// DuckLake checkpoint scheduler
 	checkpointer *DuckLakeCheckpointer
@@ -1169,6 +1174,45 @@ func LoadExtensions(db *sql.DB, extensions []string) error {
 	return lastErr
 }
 
+func buildDuckLakePreAttachStatements(dlCfg DuckLakeConfig) []string {
+	var statements []string
+	if dlCfg.DisableMetadataThreadLocalCache {
+		statements = append(statements, "SET GLOBAL pg_pool_enable_thread_local_cache = false")
+	}
+	return statements
+}
+
+func isMissingDuckLakePoolSettingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unrecognized configuration parameter")
+}
+
+func applyDuckLakePreAttachSettings(db *sql.DB, dlCfg DuckLakeConfig) error {
+	statements := buildDuckLakePreAttachStatements(dlCfg)
+	if len(statements) == 0 {
+		return nil
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			if isMissingDuckLakePoolSettingError(err) {
+				if loadErr := LoadExtensions(db, []string{"postgres_scanner"}); loadErr != nil {
+					return fmt.Errorf("load postgres_scanner for pre-attach settings: %w", loadErr)
+				}
+				if _, retryErr := db.Exec(stmt); retryErr != nil {
+					return fmt.Errorf("apply DuckLake pre-attach setting %q after loading postgres_scanner: %w", stmt, retryErr)
+				}
+				continue
+			}
+			return fmt.Errorf("apply DuckLake pre-attach setting %q: %w", stmt, err)
+		}
+	}
+	return nil
+}
+
 // hasCacheHTTPFS checks if cache_httpfs is in the extensions list.
 func hasCacheHTTPFS(extensions []string) bool {
 	for _, ext := range extensions {
@@ -1253,6 +1297,9 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 
 	// Build the ATTACH statement.
 	// See: https://ducklake.select/docs/stable/duckdb/usage/connecting
+	if err := applyDuckLakePreAttachSettings(db, dlCfg); err != nil {
+		return err
+	}
 	migrate := dlCfg.Migrate || duckLakeMigrationNeeded()
 	attachStmt := buildDuckLakeAttachStmt(dlCfg, migrate)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -140,9 +140,11 @@ func TestBuildDuckLakePreAttachStatements(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "default no statements",
-			cfg:  DuckLakeConfig{},
-			want: nil,
+			name: "default disables metadata tls cache",
+			cfg: DuckLakeConfig{
+				DisableMetadataThreadLocalCache: true,
+			},
+			want: []string{"SET GLOBAL pg_pool_enable_thread_local_cache = false"},
 		},
 		{
 			name: "disable metadata tls cache",
@@ -150,6 +152,13 @@ func TestBuildDuckLakePreAttachStatements(t *testing.T) {
 				DisableMetadataThreadLocalCache: true,
 			},
 			want: []string{"SET GLOBAL pg_pool_enable_thread_local_cache = false"},
+		},
+		{
+			name: "explicitly keep metadata tls cache enabled",
+			cfg: DuckLakeConfig{
+				DisableMetadataThreadLocalCache: false,
+			},
+			want: nil,
 		},
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -133,6 +133,73 @@ func TestNeedsCredentialRefresh(t *testing.T) {
 	}
 }
 
+func TestBuildDuckLakePreAttachStatements(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  DuckLakeConfig
+		want []string
+	}{
+		{
+			name: "default no statements",
+			cfg:  DuckLakeConfig{},
+			want: nil,
+		},
+		{
+			name: "disable metadata tls cache",
+			cfg: DuckLakeConfig{
+				DisableMetadataThreadLocalCache: true,
+			},
+			want: []string{"SET GLOBAL pg_pool_enable_thread_local_cache = false"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDuckLakePreAttachStatements(tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("statement count = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("statement[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsMissingDuckLakePoolSettingError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "matches duckdb text",
+			err:  errors.New("Catalog Error: unrecognized configuration parameter \"pg_pool_enable_thread_local_cache\""),
+			want: true,
+		},
+		{
+			name: "different error",
+			err:  errors.New("permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMissingDuckLakePoolSettingError(tt.err); got != tt.want {
+				t.Fatalf("isMissingDuckLakePoolSettingError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStartCredentialRefresh_NoOpForStaticCredentials(t *testing.T) {
 	// Static credentials should return a no-op stop function immediately
 	stop := StartCredentialRefresh(nil, DuckLakeConfig{


### PR DESCRIPTION
## Summary
- default DuckLake metadata `postgres_scanner` thread-local cache disable to on
- apply the setting before `ATTACH` creates the hidden metadata pool in the main attach path and the query-log/checkpoint DuckLake connections
- keep YAML/env opt-out support and document the new default

## Why
DuckLake stores table metadata in Postgres and accesses it through DuckDB's `postgres_scanner` pool. That pool can keep one cached Postgres connection per DuckDB thread. Under metadata-heavy workloads, that behavior can turn a single Duckgres worker into a large number of retained metadata Postgres connections.

This change is primarily meant to stop that connection-per-thread growth for DuckLake metadata access by disabling the metadata pool's thread-local cache.

The ordering also matters because we want to enforce this setting before ducklake ATTACH, which itself already triggers some metadata queries.

## Behavior
- default behavior is now to disable metadata thread-local cache for DuckLake metadata pools
- operators can opt back into the old behavior with `ducklake.disable_metadata_thread_local_cache: false` or `DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE=false`

## Testing
- `go test ./server -run 'Test(BuildDuckLakePreAttachStatements|IsMissingDuckLakePoolSettingError|BuildDuckLakeAttachStmt|InjectPostgresKeepalive|NeedsCredentialRefresh)'`
- `go test . -run 'TestResolveEffectiveConfig(InvalidEnvValues|DuckLakeDisableMetadataThreadLocalCache|DuckLakeDisableMetadataThreadLocalCacheDefaultsTrue)'`
