### PR TITLE
CI: build + publish cache-proxy image (arm64)

### DIFF
--- a/.github/workflows/container-image-cache-proxy-cd.yml
+++ b/.github/workflows/container-image-cache-proxy-cd.yml
@@ -1,0 +1,100 @@
+name: Cache Proxy Container Image CD
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "cmd/cache-proxy/**"
+            - ".github/workflows/container-image-cache-proxy-cd.yml"
+    workflow_dispatch:
+
+env:
+    ECR_REGISTRY: 795637471508.dkr.ecr.us-east-1.amazonaws.com
+    GHCR_REGISTRY: ghcr.io
+    IMAGE_NAME: duckgres-cache-proxy
+
+jobs:
+    build:
+        name: Build and deploy (arm64)
+        if: github.repository == 'PostHog/duckgres'
+        runs-on: ubuntu-24.04-arm
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+              with:
+                  role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: aws-ecr
+              uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+            - name: Login to GHCR
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              with:
+                  registry: ${{ env.GHCR_REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push
+              id: build
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+              with:
+                  context: .
+                  file: cmd/cache-proxy/Dockerfile
+                  push: true
+                  platforms: linux/arm64
+                  tags: |
+                      ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                      ${{ env.GHCR_REGISTRY }}/posthog/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                      ${{ env.GHCR_REGISTRY }}/posthog/${{ env.IMAGE_NAME }}:latest
+                  build-args: |
+                      VERSION=build-${{ github.sha }}
+                      COMMIT=${{ github.sha }}
+                  cache-from: type=gha,scope=cache-proxy-arm64
+                  cache-to: type=gha,mode=max,scope=cache-proxy-arm64
+
+            - name: Get image digest
+              id: digest
+              run: |
+                  digest=$(docker buildx imagetools inspect --raw ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} | sha256sum | awk '{print "sha256:"$1}')
+                  echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+            - name: Get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+              with:
+                  app_id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+
+            - name: Trigger deployment via Charts repo
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ github.sha }}@${{ steps.digest.outputs.digest }}"
+                          }
+                        },
+                        "release": "duckgres-cache-proxy",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": [],
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow mirroring `container-image-cd.yml` but scoped to the cache-proxy:

- Triggers on pushes to `main` that touch `cmd/cache-proxy/**` or the workflow itself (paths filter)
- Builds `linux/arm64` only — the duckgres-workers nodepool is ARM exclusively, so amd64 is dead weight
- Pushes `ECR: duckgres-cache-proxy` and `GHCR: posthog/duckgres-cache-proxy` (tags `:<sha>` + `:latest`)
- Dispatches `commit_state_update` to `PostHog/charts` with release name `duckgres-cache-proxy` so the deploy bot updates `state.yaml` and ArgoCD rolls the DaemonSet

Depends on the new ECR repository `duckgres-cache-proxy` existing (separate infra PR) and the charts-side chart being merged (PostHog/charts#10346).

## Test plan

- [ ] Merge this after the ECR repo + charts PRs land.
- [ ] First push to main touching `cmd/cache-proxy/` should build arm64, push, and open a state.yaml update PR in charts.
- [ ] Verify ArgoCD picks up the new SHA and rolls the `duckgres-cache-proxy` DaemonSet in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)