### PR TITLE
Rename cache-proxy 'S3 proxy' log line

### DIFF
--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -151,9 +151,9 @@ func main() {
 
 	// Start servers
 	go func() {
-		slog.Info("S3 proxy listening.", "addr", listenAddr)
+		slog.Info("Forward HTTP proxy listening.", "addr", listenAddr)
 		if err := s3Server.ListenAndServe(); err != http.ErrServerClosed {
-			slog.Error("S3 proxy error.", "error", err)
+			slog.Error("Forward HTTP proxy error.", "error", err)
 		}
 	}()
 	go func() {


### PR DESCRIPTION
The cache proxy listener handles all httpfs traffic (S3 bucket URLs cached, external HTTPS CONNECT-tunneled, non-bucket HTTP forwarded uncached). The startup log said 'S3 proxy listening' which was misleading. Changed to 'Forward HTTP proxy listening'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)