### PR TITLE
feat(ducklake): route metadata catalog through per-Duckling PgBouncer

### DIFF
--- a/controlplane/org_activation_test.go
+++ b/controlplane/org_activation_test.go
@@ -240,11 +240,12 @@ func TestSharedWorkerActivatorDucklingCRRequiresSTSBroker(t *testing.T) {
 			}
 			return &provisioner.DucklingStatus{
 				MetadataStore: struct {
-					Type     string
-					Endpoint string
-					Password string
-					User     string
-					Database string
+					Type              string
+					Endpoint          string
+					PgBouncerEndpoint string
+					Password          string
+					User              string
+					Database          string
 				}{
 					Endpoint: "test-org.cluster.rds.amazonaws.com",
 					Password: "duckling-password-123",
@@ -295,11 +296,12 @@ func TestSharedWorkerActivatorPrefersSecretRefOverDucklingCR(t *testing.T) {
 			ducklingCalled = true
 			return &provisioner.DucklingStatus{
 				MetadataStore: struct {
-					Type     string
-					Endpoint string
-					Password string
-					User     string
-					Database string
+					Type              string
+					Endpoint          string
+					PgBouncerEndpoint string
+					Password          string
+					User              string
+					Database          string
 				}{Password: "cr-password"},
 			}, nil
 		},

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -331,6 +331,34 @@ func TestParseDucklingStatusSyncedFalse(t *testing.T) {
 	}
 }
 
+func TestParseDucklingStatusPgBouncerEndpoint(t *testing.T) {
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"metadataStore": map[string]interface{}{
+					"type":              "aurora",
+					"endpoint":          "posthog-duckling-foo.cluster-xyz.us-east-1.rds.amazonaws.com",
+					"pgbouncerEndpoint": "pgbouncer-duckling-foo.ducklings.svc.cluster.local:6543",
+					"user":              "postgres",
+					"database":          "postgres",
+					"password":          "s3cret",
+				},
+			},
+		},
+	}
+
+	status, err := parseDucklingStatus(cr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := status.MetadataStore.PgBouncerEndpoint; got != "pgbouncer-duckling-foo.ducklings.svc.cluster.local:6543" {
+		t.Fatalf("PgBouncerEndpoint = %q, want pooler DNS", got)
+	}
+	if got := status.MetadataStore.Endpoint; got != "posthog-duckling-foo.cluster-xyz.us-east-1.rds.amazonaws.com" {
+		t.Fatalf("Endpoint = %q, want Aurora DNS", got)
+	}
+}
+
 func TestParseDucklingStatusEmpty(t *testing.T) {
 	cr := &unstructured.Unstructured{
 		Object: map[string]interface{}{},

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -27,11 +27,12 @@ const ducklingNamespace = "ducklings"
 // but not K8s workloads — those are managed by the duckgres Helm chart.
 type DucklingStatus struct {
 	MetadataStore struct {
-		Type     string
-		Endpoint string
-		Password string
-		User     string
-		Database string
+		Type              string
+		Endpoint          string
+		PgBouncerEndpoint string
+		Password          string
+		User              string
+		Database          string
 	}
 	DataStore struct {
 		Type       string
@@ -140,6 +141,7 @@ func parseDucklingStatus(cr *unstructured.Unstructured) (*DucklingStatus, error)
 	if md, ok := status["metadataStore"].(map[string]interface{}); ok {
 		ds.MetadataStore.Type = getNestedString(md, "type")
 		ds.MetadataStore.Endpoint = getNestedString(md, "endpoint")
+		ds.MetadataStore.PgBouncerEndpoint = getNestedString(md, "pgbouncerEndpoint")
 		ds.MetadataStore.Password = getNestedString(md, "password")
 		ds.MetadataStore.User = getNestedString(md, "user")
 		ds.MetadataStore.Database = getNestedString(md, "database")

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -193,18 +195,40 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 		return server.DuckLakeConfig{}, fmt.Errorf("duckling CR %q has no data store bucket", orgID)
 	}
 
+	// Prefer the PgBouncer endpoint when the Duckling exposes one — the
+	// Crossplane composition sets status.metadataStore.pgbouncerEndpoint
+	// (as "<host>:<port>") when a per-Duckling pooler is provisioned.
+	// Otherwise connect directly to the metadata store on its default port.
+	host := status.MetadataStore.Endpoint
+	port := 5432 // Aurora always uses 5432
+	viaPgBouncer := false
+	if pgb := status.MetadataStore.PgBouncerEndpoint; pgb != "" {
+		h, p, err := net.SplitHostPort(pgb)
+		if err != nil {
+			return server.DuckLakeConfig{}, fmt.Errorf("parse pgbouncerEndpoint %q for org %q: %w", pgb, orgID, err)
+		}
+		portNum, err := strconv.Atoi(p)
+		if err != nil {
+			return server.DuckLakeConfig{}, fmt.Errorf("parse pgbouncerEndpoint port %q for org %q: %w", p, orgID, err)
+		}
+		host = h
+		port = portNum
+		viaPgBouncer = true
+	}
+
 	dl := server.DuckLakeConfig{
 		MetadataStore: buildDuckLakeMetadataStoreDSN(
-			status.MetadataStore.Endpoint,
-			5432, // Aurora always uses 5432
+			host,
+			port,
 			status.MetadataStore.User,
 			status.MetadataStore.Password,
 			status.MetadataStore.Database,
 		),
-		ObjectStore: fmt.Sprintf("s3://%s/", status.DataStore.BucketName),
-		S3Region:    status.DataStore.S3Region,
-		S3UseSSL:    true,
-		S3URLStyle:  "vhost",
+		ViaPgBouncer: viaPgBouncer,
+		ObjectStore:  fmt.Sprintf("s3://%s/", status.DataStore.BucketName),
+		S3Region:     status.DataStore.S3Region,
+		S3UseSSL:     true,
+		S3URLStyle:   "vhost",
 	}
 
 	// Broker S3 credentials via STS AssumeRole

--- a/server/server.go
+++ b/server/server.go
@@ -337,6 +337,14 @@ type DuckLakeConfig struct {
 	// re-running the version check. This avoids redundant backups and
 	// long-running checks in worker processes.
 	Migrate bool `json:"migrate,omitempty" yaml:"-"`
+
+	// ViaPgBouncer is set by the control plane when the DuckLake metadata
+	// connection is routed through a network-level pooler (e.g. PgBouncer)
+	// rather than direct to Postgres. When true, the worker disables the
+	// postgres_scanner in-process pool via `SET GLOBAL pg_pool_max_connections = 0`.
+	// See duckdb/ducklake#1031: behind a network pooler, client-side pooling
+	// is redundant and prevents the pooler from reclaiming idle connections.
+	ViaPgBouncer bool `json:"via_pgbouncer,omitempty" yaml:"-"`
 }
 
 // fileDBEntry tracks a shared *sql.DB for file-persistence mode.
@@ -1233,6 +1241,9 @@ func buildDuckLakePreAttachStatements(dlCfg DuckLakeConfig) []string {
 	var statements []string
 	if duckLakeDisableMetadataThreadLocalCacheEnabled(dlCfg) {
 		statements = append(statements, "SET GLOBAL pg_pool_enable_thread_local_cache = false")
+	}
+	if dlCfg.ViaPgBouncer {
+		statements = append(statements, "SET GLOBAL pg_pool_max_connections = 0")
 	}
 	return statements
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -185,6 +185,24 @@ func TestBuildDuckLakePreAttachStatements(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "via pgbouncer disables in-process pool",
+			cfg: DuckLakeConfig{
+				DisableMetadataThreadLocalCache: boolPtr(false),
+				ViaPgBouncer:                    true,
+			},
+			want: []string{"SET GLOBAL pg_pool_max_connections = 0"},
+		},
+		{
+			name: "via pgbouncer with tls cache disabled emits both",
+			cfg: DuckLakeConfig{
+				ViaPgBouncer: true,
+			},
+			want: []string{
+				"SET GLOBAL pg_pool_enable_thread_local_cache = false",
+				"SET GLOBAL pg_pool_max_connections = 0",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Wire DuckLake's Postgres metadata connection through the per-Duckling PgBouncer pooler provisioned by the Crossplane composition in [PostHog/charts#10400](https://github.com/PostHog/charts/pull/10400). Two coupled changes that only take effect when a Duckling opts in via `spec.metadataStore.pgbouncer.enabled`; otherwise behaviour is unchanged.

## Changes

### Why

DuckLake via DuckDB's `postgres_scanner` extension opens many long-lived connections per worker and creates overflow connections on DDL-heavy workloads ([duckdb/ducklake#1031](https://github.com/duckdb/ducklake/issues/1031)). The charts-side PR provisions a PgBouncer Service per Duckling. This PR teaches the duckgres control plane and workers to use it.

### 1. Control plane prefers `status.metadataStore.pgbouncerEndpoint`

When the Duckling CR status exposes `pgbouncerEndpoint` (format `<host>:<port>`, e.g. `pgbouncer-duckling-foo.ducklings.svc.cluster.local:6543`), the activator parses it with `net.SplitHostPort` and builds the worker DSN against the pooler instead of the Aurora endpoint. When absent, unchanged — direct to Postgres endpoint on 5432.

- `DucklingStatus.MetadataStore` gains `PgBouncerEndpoint` (`controlplane/provisioner/k8s_client.go`); `parseDucklingStatus` reads the new status field.
- `buildDuckLakeConfigFromDuckling` (`controlplane/shared_worker_activator.go`) parses the endpoint and sets `DuckLakeConfig.ViaPgBouncer`.

### 2. Worker disables the in-process pool when behind PgBouncer

`DuckLakeConfig` gains `ViaPgBouncer`. When true, `buildDuckLakePreAttachStatements` emits `SET GLOBAL pg_pool_max_connections = 0` before ATTACH so the setting propagates into the `__ducklake_metadata_*` catalog (per [duckdb/duckdb-postgres#445](https://github.com/duckdb/duckdb-postgres/pull/445)).

**Rationale** — from [duckdb/ducklake#1031](https://github.com/duckdb/ducklake/issues/1031): behind a network pooler, client-side pooling is redundant and counter-productive. The `postgres_scanner` thread-local cache pins one server conn per DuckDB worker thread and holds it indefinitely, starving the pool and preventing PgBouncer from reclaiming idle connections. The maintainer (`staticlibs`) directly recommends `pg_pool_max_connections = 0` for PgBouncer-fronted deployments.

### Safety audit

Audited DuckLake (`~/opt/ph/ducklake`) and postgres_scanner (`~/opt/ph/duckdb-postgres`) before wiring this up: no SQL `PREPARE`, no named extended-protocol prepared statements (unnamed only — no `max_prepared_statements` needed), no advisory locks, no `LISTEN`/`NOTIFY`, no `WITH HOLD` cursors. 1:1 DuckDB↔Postgres transaction mapping. Safe in both session and transaction pool modes; charts-side default is session for lower-variance rollout.

### Test coverage

- `TestParseDucklingStatusPgBouncerEndpoint` — CR status round trips the new field.
- `TestBuildDuckLakePreAttachStatements` — two new cases cover `ViaPgBouncer=true` emission, alone and combined with the existing thread-local-cache disable.
- Inline struct literals in `org_activation_test.go` updated to match the new `DucklingStatus.MetadataStore` shape (additive only).

## Test plan

- [x] `go build -tags kubernetes ./...` compiles (one pre-existing unrelated failure in `tests/perf`, confirmed on `main`).
- [x] `go test ./server/` passes.
- [x] `go test -tags kubernetes ./controlplane/...` passes (admin suite has a pre-existing Postgres-container startup failure unrelated to this change).
- [x] `go vet -tags kubernetes ./server/ ./controlplane/ ./controlplane/provisioner/` clean.
- [ ] After the charts PR merges and a dev Duckling is opted in (`spec.metadataStore.pgbouncer.enabled: true`), smoke test that a worker attaches DuckLake via the pooler and logs show `SET GLOBAL pg_pool_max_connections = 0` being applied.

## Rollback

Revert this PR. No Duckling in production has `pgbouncer.enabled: true` yet, so reverting is a no-op for current state. Per-Duckling opt-out is also possible by setting `pgbouncer.enabled: false` — the control plane will immediately resume direct connections on the next activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)