### PR TITLE
security: fix SnakeYAML deserialization vulnerability in JDBC tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ certs/
 *.swp
 *.swo
 
+# Dashboard UI
+dashboard/ui/node_modules/
+dashboard/ui/.svelte-kit/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/scripts/client-compat/clients/jdbc/src/main/java/com/duckgres/compat/JdbcCompatTest.java
+++ b/scripts/client-compat/clients/jdbc/src/main/java/com/duckgres/compat/JdbcCompatTest.java
@@ -15,7 +15,9 @@ import java.nio.file.Path;
 import java.sql.*;
 import java.util.*;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public class JdbcCompatTest {
 
@@ -112,7 +114,7 @@ public class JdbcCompatTest {
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> loadQueries(String path) throws Exception {
         String content = Files.readString(Path.of(path));
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         return yaml.load(content);
     }
 

--- a/scripts/client-compat/clients/jdbc/src/main/java/com/posthog/compat/JdbcCompatTest.java
+++ b/scripts/client-compat/clients/jdbc/src/main/java/com/posthog/compat/JdbcCompatTest.java
@@ -1,6 +1,8 @@
 package com.posthog.compat;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -345,7 +347,7 @@ public final class JdbcCompatTest {
     }
 
     private static List<Map<String, Object>> loadQueries(String path) throws IOException {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try (InputStream in = Files.newInputStream(Path.of(path))) {
             Object loaded = yaml.load(in);
             if (!(loaded instanceof List<?> list)) {


### PR DESCRIPTION
Wiz identified a vulnerability where SnakeYAML was used without SafeConstructor, potentially allowing arbitrary class instantiation during YAML deserialization.

This PR:
1. Explicitly uses SafeConstructor with LoaderOptions in both JdbcCompatTest implementations.
2. Updates .gitignore to exclude dashboard UI build artifacts discovered during implementation.

Fixes: SnakeYAML deserialization vulnerability reported by Wiz.