### PR TITLE
chore: Pin GitHub Actions to SHA digests and bump to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -77,12 +77,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -120,12 +120,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -153,12 +153,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -186,12 +186,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -223,11 +223,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Install kind

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -59,7 +59,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -88,6 +88,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -47,7 +47,7 @@ jobs:
           go build -ldflags "-X main.version=build-${SHORT_SHA} -X main.commit=${{ github.sha }} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres-${{ matrix.goos }}-${{ matrix.goarch }} .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: duckgres-${{ matrix.goos }}-${{ matrix.goarch }}
           path: duckgres-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
Pins every `uses:` reference in `ci.yml`, `codeql.yml`, and `release.yml` to a 40-char commit SHA (with the version as a trailing comment) and bumps the built-in actions to their latest major versions. Brings these workflows in line with [container-image-cd.yml](https://github.com/PostHog/duckgres/blob/main/.github/workflows/container-image-cd.yml) and [container-image-cache-proxy-cd.yml](https://github.com/PostHog/duckgres/blob/main/.github/workflows/container-image-cache-proxy-cd.yml) (already fully SHA-pinned) and closes the retagging-attack window on `GITHUB_TOKEN` and the release publishing path.

## Changes made
- `actions/checkout` `v4` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `actions/setup-go` `v5` → `@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0`
- `actions/upload-artifact` `v4` → `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
- `actions/download-artifact` `v4` → `@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`
- `github/codeql-action/{init,analyze}` `v4` → `@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2`

`extractions/setup-just`, `golangci/golangci-lint-action`, and `softprops/action-gh-release` were already SHA-pinned in these files — unchanged.

<details><summary>Why this matters — real-world GitHub Actions supply-chain incidents</summary>

GitHub Action retagging is an active attack vector: the attacker force-pushes a mutable tag (like `v1`) to a malicious commit, and every consumer that pins by tag picks it up on the next workflow run. Pinning to a 40-char SHA is the only mitigation — tags are advisory, commits are immutable.

Known incidents:

- **`tj-actions/changed-files`** ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066), March 2025) — existing version tags were retagged to a commit that dumped secrets from the runner process memory to workflow logs. Affected 23,000+ repos.
- **`reviewdog/action-setup`** ([CVE-2025-30154](https://nvd.nist.gov/vuln/detail/CVE-2025-30154), March 2025) — the upstream compromise that enabled the `tj-actions` attack. Retagging dumped runner memory to logs, leaking `tj-actions`' PAT.
- **Trivy, KICS, LiteLLM — `TeamCityPCP` attack** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634), 2026) — coordinated retagging of three popular security-scanning actions. See the [Wiz write-up on KICS](https://www.wiz.io/blog/teampcp-attack-kics-github-action) and the [LiteLLM advisory](https://docs.litellm.ai/blog/security-update-march-2026).

In each case, consumers that pinned by SHA were unaffected; consumers that pinned by tag or branch executed the malicious code on their next run.

`release.yml` in this repo has `contents: write` and updates the `latest` release that customer ducklings pull — an unpinned action there could ship arbitrary code into the customer build artifact.
</details>

## Follow-up recommendations (not in this PR)

<details><summary>Pin Docker base images in production Dockerfiles</summary>

Use `docker buildx imagetools inspect <image>:<tag>` to resolve `@sha256:<digest>` for:
- `Dockerfile:1` `golang:1.25-bookworm`
- `Dockerfile:28` `debian:bookworm-slim`
- `cmd/cache-proxy/Dockerfile:1` `golang:1.25-bookworm`
- `cmd/cache-proxy/Dockerfile:12` `debian:bookworm-slim`
</details>

<details><summary>Replace <code>:latest</code> Docker tags in compose and CI</summary>

- `docker-compose.yaml:20` `minio/minio:latest`
- `docker-compose.yaml:39` `minio/mc:latest`
- `tests/integration/docker-compose.yml:45` `minio/minio:latest`
- `tests/integration/docker-compose.yml:64` `minio/mc:latest`
- `.github/workflows/ci.yml:98` `docker run quay.io/minio/minio:latest`
- `scripts/client-compat/clients/harlequin/Dockerfile:3` `ghcr.io/astral-sh/uv:latest`

Replace each with a specific release tag + `@sha256:<digest>`.
</details>

<details><summary>Pin tag-only Docker images in CI and compose</summary>

- `docker-compose.yaml:3` `postgres:16-alpine`
- `tests/integration/docker-compose.yml:6` and `:27` `postgres:16-alpine`
- `.github/workflows/ci.yml:50,65,141,174,211` `public.ecr.aws/docker/library/postgres:16-alpine`
- Base images across `scripts/client-compat/clients/{dbt,jdbc,node-postgres,pgadmin,pgx,psql,psycopg,sqlalchemy,tokio-postgres}/Dockerfile`

Append `@sha256:<digest>` to each.
</details>

<details><summary>Verify checksums on raw binary downloads in CI</summary>

- `.github/workflows/ci.yml:108` — `mc` client pulled from `https://dl.min.io/client/mc/release/linux-arm64/mc` with no version pin or checksum. Pin to a specific `mc.RELEASE.YYYY-MM-DDTHH-MM-SSZ` archive and verify the published `.sha256sum` before `chmod +x`.
- `.github/workflows/ci.yml:235-239` — `kind` is version-pinned (`v0.24.0`) but not checksum-verified. Add `sha256sum -c` against the known-good digest for `kind-linux-arm64` v0.24.0.
</details>

<details><summary>Add Dependabot or Renovate so SHA pins don't rot</summary>

Without automation the new pins will drift. Create `.github/dependabot.yml` with entries for:
- `package-ecosystem: github-actions`
- `package-ecosystem: gomod` (root + `scripts/client-compat/clients/pgx/`)
- `package-ecosystem: docker`

Set [`cooldown.default-days`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) ≥ 3 (prefer 7) on each.

Or, with Renovate, extend [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) and set [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) ≥ 3 days.
</details>