### PR TITLE
add delta catalog worker boot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ ducklake:
   # hidden DuckLake metadata pool to reduce retained metadata connections.
   # Set to false to opt back into warm connection reuse.
   disable_metadata_thread_local_cache: true
+  # Default: false. Also attach a Delta Lake catalog/table on worker boot.
+  # Without delta_catalog_path, defaults to a sibling top-level delta/ prefix
+  # beside the configured DuckLake object_store prefix.
+  delta_catalog_enabled: false
+  # delta_catalog_path: "s3://bucket/delta/"
 
 process:
   min_workers: 0
@@ -212,6 +217,8 @@ Run with config file:
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_K8S_SHARED_WARM_TARGET` | Neutral shared warm-worker target for K8s multi-tenant mode (`0` disables prewarm) | `0` |
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
+| `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` | Attach a Delta Lake catalog/table during worker boot/activation | `false` |
+| `DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH` | Delta Lake catalog/table path; defaults to sibling `delta/` prefix at the DuckLake object-store root when enabled | Derived |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export | - |
 | `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |
@@ -293,11 +300,20 @@ ducklake:
   # hidden DuckLake metadata pool before ATTACH creates it.
   # Set to false to opt back into warm connection reuse.
   disable_metadata_thread_local_cache: true
+
+  # Also attach a Delta Lake catalog/table as catalog "delta" during worker
+  # boot/activation. If delta_catalog_path is omitted, Duckgres derives
+  # s3://<bucket>/delta/ from ducklake.object_store. Prefer that isolated
+  # prefix over the bucket root so DuckLake and Delta files do not collide.
+  delta_catalog_enabled: false
+  # delta_catalog_path: "s3://my-bucket/delta/"
 ```
 
 This runs the equivalent of:
 ```sql
 ATTACH 'ducklake:postgres:host=ducklake.example.com user=ducklake password=secret dbname=ducklake' AS ducklake;
+-- when delta_catalog_enabled=true:
+ATTACH 's3://my-bucket/delta/' AS delta (TYPE delta);
 ```
 
 See [DuckLake documentation](https://ducklake.select/docs/stable/duckdb/usage/connecting) for more details.
@@ -353,6 +369,7 @@ DuckLake can store data files in S3-compatible object storage (AWS S3, MinIO, et
 ducklake:
   metadata_store: "postgres:host=localhost port=5433 user=ducklake password=ducklake dbname=ducklake"
   object_store: "s3://ducklake/data/"
+  delta_catalog_enabled: true       # attaches s3://ducklake/delta/ by default
   s3_provider: "config"            # Explicit credentials (default if s3_access_key is set)
   s3_endpoint: "localhost:9000"    # MinIO or custom S3 endpoint
   s3_access_key: "minioadmin"
@@ -390,6 +407,8 @@ See [DuckDB S3 API docs](https://duckdb.org/docs/stable/core_extensions/httpfs/s
 
 All S3 settings can be configured via environment variables:
 - `DUCKGRES_DUCKLAKE_OBJECT_STORE` - S3 path (e.g., `s3://bucket/path/`)
+- `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` - attach Delta catalog (`true`/`false`)
+- `DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH` - Delta catalog/table path (e.g., `s3://bucket/delta/`)
 - `DUCKGRES_DUCKLAKE_S3_PROVIDER` - `config` or `credential_chain`
 - `DUCKGRES_DUCKLAKE_S3_ENDPOINT` - S3 endpoint (for MinIO)
 - `DUCKGRES_DUCKLAKE_S3_ACCESS_KEY` - Access key ID

--- a/config_resolution.go
+++ b/config_resolution.go
@@ -12,57 +12,59 @@ import (
 type configCLIInputs struct {
 	Set map[string]bool
 
-	Host                      string
-	Port                      int
-	FlightPort                int
-	FlightSessionIdleTTL      string
-	FlightSessionReapInterval string
-	FlightHandleIdleTTL       string
-	FlightSessionTokenTTL     string
-	DataDir                   string
-	CertFile                  string
-	KeyFile                   string
-	FilePersistence           bool
-	ProcessIsolation          bool
-	IdleTimeout               string
-	MemoryLimit               string
-	Threads                   int
-	MemoryBudget              string
-	MemoryRebalance           bool
-	ProcessMinWorkers         int
-	ProcessMaxWorkers         int
-	ProcessRetireOnSessionEnd bool
-	WorkerQueueTimeout        string
-	WorkerIdleTimeout         string
-	HandoverDrainTimeout      string
-	ACMEDomain                string
-	ACMEEmail                 string
-	ACMECacheDir              string
-	ACMEDNSProvider           string
-	ACMEDNSZoneID             string
-	MaxConnections            int
-	ConfigStoreConn           string
-	ConfigPollInterval        string
-	InternalSecret            string
-	WorkerBackend             string
-	K8sWorkerImage            string
-	K8sWorkerNamespace        string
-	K8sControlPlaneID         string
-	K8sWorkerPort             int
-	K8sWorkerSecret           string
-	K8sWorkerConfigMap        string
-	K8sWorkerImagePullPolicy  string
-	K8sWorkerServiceAccount   string
-	K8sMaxWorkers             int
-	K8sSharedWarmTarget       int
-	K8sWorkerCPURequest       string
-	K8sWorkerMemoryRequest    string
-	K8sWorkerNodeSelector     string
-	K8sWorkerTolerationKey    string
-	K8sWorkerTolerationValue  string
-	K8sWorkerExclusiveNode    bool
-	AWSRegion                 string
-	QueryLog                  bool
+	Host                        string
+	Port                        int
+	FlightPort                  int
+	FlightSessionIdleTTL        string
+	FlightSessionReapInterval   string
+	FlightHandleIdleTTL         string
+	FlightSessionTokenTTL       string
+	DataDir                     string
+	CertFile                    string
+	KeyFile                     string
+	FilePersistence             bool
+	ProcessIsolation            bool
+	IdleTimeout                 string
+	MemoryLimit                 string
+	Threads                     int
+	MemoryBudget                string
+	MemoryRebalance             bool
+	DuckLakeDeltaCatalogEnabled bool
+	DuckLakeDeltaCatalogPath    string
+	ProcessMinWorkers           int
+	ProcessMaxWorkers           int
+	ProcessRetireOnSessionEnd   bool
+	WorkerQueueTimeout          string
+	WorkerIdleTimeout           string
+	HandoverDrainTimeout        string
+	ACMEDomain                  string
+	ACMEEmail                   string
+	ACMECacheDir                string
+	ACMEDNSProvider             string
+	ACMEDNSZoneID               string
+	MaxConnections              int
+	ConfigStoreConn             string
+	ConfigPollInterval          string
+	InternalSecret              string
+	WorkerBackend               string
+	K8sWorkerImage              string
+	K8sWorkerNamespace          string
+	K8sControlPlaneID           string
+	K8sWorkerPort               int
+	K8sWorkerSecret             string
+	K8sWorkerConfigMap          string
+	K8sWorkerImagePullPolicy    string
+	K8sWorkerServiceAccount     string
+	K8sMaxWorkers               int
+	K8sSharedWarmTarget         int
+	K8sWorkerCPURequest         string
+	K8sWorkerMemoryRequest      string
+	K8sWorkerNodeSelector       string
+	K8sWorkerTolerationKey      string
+	K8sWorkerTolerationValue    string
+	K8sWorkerExclusiveNode      bool
+	AWSRegion                   string
+	QueryLog                    bool
 }
 
 type resolvedConfig struct {
@@ -249,6 +251,12 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		}
 		if fileCfg.DuckLake.DataPath != "" {
 			cfg.DuckLake.DataPath = fileCfg.DuckLake.DataPath
+		}
+		if fileCfg.DuckLake.DeltaCatalogEnabled != nil {
+			cfg.DuckLake.DeltaCatalogEnabled = *fileCfg.DuckLake.DeltaCatalogEnabled
+		}
+		if fileCfg.DuckLake.DeltaCatalogPath != "" {
+			cfg.DuckLake.DeltaCatalogPath = fileCfg.DuckLake.DeltaCatalogPath
 		}
 		if fileCfg.DuckLake.DisableMetadataThreadLocalCache != nil {
 			cfg.DuckLake.DisableMetadataThreadLocalCache = boolPtr(*fileCfg.DuckLake.DisableMetadataThreadLocalCache)
@@ -484,6 +492,16 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	}
 	if v := getenv("DUCKGRES_DUCKLAKE_OBJECT_STORE"); v != "" {
 		cfg.DuckLake.ObjectStore = v
+	}
+	if v := getenv("DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DuckLake.DeltaCatalogEnabled = b
+		} else {
+			warn("Invalid DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED: " + err.Error())
+		}
+	}
+	if v := getenv("DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH"); v != "" {
+		cfg.DuckLake.DeltaCatalogPath = v
 	}
 	if v := getenv("DUCKGRES_DUCKLAKE_DISABLE_METADATA_THREAD_LOCAL_CACHE"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
@@ -841,6 +859,12 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if cli.Set["memory-rebalance"] {
 		cfg.MemoryRebalance = cli.MemoryRebalance
 	}
+	if cli.Set["ducklake-delta-catalog-enabled"] {
+		cfg.DuckLake.DeltaCatalogEnabled = cli.DuckLakeDeltaCatalogEnabled
+	}
+	if cli.Set["ducklake-delta-catalog-path"] {
+		cfg.DuckLake.DeltaCatalogPath = cli.DuckLakeDeltaCatalogPath
+	}
 	if cli.Set["process-min-workers"] {
 		processMinWorkers = cli.ProcessMinWorkers
 	}
@@ -992,6 +1016,12 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if cfg.QueryLog.CompactInterval <= 0 {
 		warn("DUCKGRES_QUERY_LOG_COMPACT_INTERVAL must be > 0; using default")
 		cfg.QueryLog.CompactInterval = defaultQueryLog.CompactInterval
+	}
+	if cfg.DuckLake.DeltaCatalogEnabled && cfg.DuckLake.DeltaCatalogPath == "" {
+		cfg.DuckLake.DeltaCatalogPath = server.DefaultDeltaCatalogPath(cfg.DuckLake)
+		if cfg.DuckLake.DeltaCatalogPath == "" {
+			warn("ducklake.delta_catalog_enabled requires ducklake.delta_catalog_path when no ducklake.object_store or ducklake.data_path is configured")
+		}
 	}
 
 	return resolvedConfig{

--- a/docs/runbooks/delta-catalog-activation.md
+++ b/docs/runbooks/delta-catalog-activation.md
@@ -1,0 +1,21 @@
+# Delta Catalog Activation
+
+## When To Use
+
+- Workers fail during boot or tenant activation after enabling `ducklake.delta_catalog_enabled`.
+- Logs include `Delta catalog configured but attachment failed`.
+- Queries against catalog `delta` fail after a rollout that changed object-store settings.
+
+## Checks
+
+1. Confirm the configured location. If `ducklake.delta_catalog_path` is empty, Duckgres derives `s3://<bucket>/delta/` from `ducklake.object_store`; it does not use the bucket root.
+2. Verify the Delta table exists and contains `_delta_log` at the configured path.
+3. Check that the worker can load the DuckDB `delta` extension from its configured `extension_directory`.
+4. Verify S3 credentials, endpoint, region, `s3_use_ssl`, and `s3_url_style`; the Delta catalog reuses the DuckLake S3 secret settings.
+5. During shutdown, workers switch to `memory`, detach `delta`, then detach `ducklake`. If shutdown hangs, inspect logs for `Failed to detach worker Delta catalog during shutdown` before forcing pod/process retirement.
+
+## Recovery
+
+1. Disable `ducklake.delta_catalog_enabled` and roll workers if the Delta path is unavailable but DuckLake service must continue.
+2. Fix the path or object-store credentials, then re-enable the setting.
+3. Prefer an isolated prefix such as `s3://<bucket>/delta/`; do not place Delta directly at the bucket root used by DuckLake.

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -193,6 +193,8 @@ func sameTenantActivationRuntime(current, next ActivationPayload) bool {
 	return a.MetadataStore == b.MetadataStore &&
 		a.ObjectStore == b.ObjectStore &&
 		a.DataPath == b.DataPath &&
+		a.DeltaCatalogEnabled == b.DeltaCatalogEnabled &&
+		a.DeltaCatalogPath == b.DeltaCatalogPath &&
 		a.S3Provider == b.S3Provider &&
 		a.S3Endpoint == b.S3Endpoint &&
 		a.S3Region == b.S3Region &&

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -583,41 +583,61 @@ func (p *SessionPool) CloseAll() {
 		}
 	}
 
-	cleanupCfg := p.cfg
-	if p.activation != nil {
-		cleanupCfg.DuckLake = p.activation.payload.DuckLake
-	}
-
 	if p.warmupDB != nil {
-		cleanupWorkerCatalogs(p.warmupDB, cleanupCfg)
+		cleanupWorkerCatalogs(p.warmupDB)
 		_ = p.warmupDB.Close()
 	}
 	if p.fallbackDB != nil && p.fallbackDB != p.warmupDB {
-		cleanupWorkerCatalogs(p.fallbackDB, cleanupCfg)
+		cleanupWorkerCatalogs(p.fallbackDB)
 		_ = p.fallbackDB.Close()
 	}
 	if p.activation != nil && p.activation.db != nil && p.activation.db != p.warmupDB && p.activation.db != p.fallbackDB {
-		cleanupWorkerCatalogs(p.activation.db, cleanupCfg)
+		cleanupWorkerCatalogs(p.activation.db)
 		_ = p.activation.db.Close()
 	}
 }
 
-func cleanupWorkerCatalogs(db *sql.DB, cfg server.Config) {
-	if db == nil || (!cfg.DuckLake.DeltaCatalogEnabled && cfg.DuckLake.MetadataStore == "") {
+// cleanupWorkerCatalogs detaches the lake catalogs that are actually attached
+// on db before shutdown. Probing duckdb_databases() avoids spurious "failed to
+// detach" warnings on the warmup/fallback DBs that never had a tenant catalog
+// attached, while still cleaning up the activation DB that does.
+func cleanupWorkerCatalogs(db *sql.DB) {
+	if db == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	rows, err := db.QueryContext(ctx, "SELECT database_name FROM duckdb_databases() WHERE database_name IN ('delta', 'ducklake')")
+	if err != nil {
+		slog.Debug("Failed to list attached catalogs during shutdown.", "error", err)
+		return
+	}
+	attached := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			slog.Debug("Failed to scan attached catalog name during shutdown.", "error", err)
+			return
+		}
+		attached[name] = true
+	}
+	_ = rows.Close()
+
+	if !attached["delta"] && !attached["ducklake"] {
+		return
+	}
 	if _, err := db.ExecContext(ctx, "USE memory"); err != nil {
 		slog.Warn("Failed to switch worker DB to memory during shutdown.", "error", err)
 		return
 	}
-	if cfg.DuckLake.DeltaCatalogEnabled {
+	if attached["delta"] {
 		if _, err := db.ExecContext(ctx, "DETACH delta"); err != nil {
 			slog.Warn("Failed to detach worker Delta catalog during shutdown.", "error", err)
 		}
 	}
-	if cfg.DuckLake.MetadataStore != "" {
+	if attached["ducklake"] {
 		if _, err := db.ExecContext(ctx, "DETACH ducklake"); err != nil {
 			slog.Warn("Failed to detach worker DuckLake catalog during shutdown.", "error", err)
 		}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -583,14 +583,44 @@ func (p *SessionPool) CloseAll() {
 		}
 	}
 
+	cleanupCfg := p.cfg
+	if p.activation != nil {
+		cleanupCfg.DuckLake = p.activation.payload.DuckLake
+	}
+
 	if p.warmupDB != nil {
+		cleanupWorkerCatalogs(p.warmupDB, cleanupCfg)
 		_ = p.warmupDB.Close()
 	}
 	if p.fallbackDB != nil && p.fallbackDB != p.warmupDB {
+		cleanupWorkerCatalogs(p.fallbackDB, cleanupCfg)
 		_ = p.fallbackDB.Close()
 	}
 	if p.activation != nil && p.activation.db != nil && p.activation.db != p.warmupDB && p.activation.db != p.fallbackDB {
+		cleanupWorkerCatalogs(p.activation.db, cleanupCfg)
 		_ = p.activation.db.Close()
+	}
+}
+
+func cleanupWorkerCatalogs(db *sql.DB, cfg server.Config) {
+	if db == nil || (!cfg.DuckLake.DeltaCatalogEnabled && cfg.DuckLake.MetadataStore == "") {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, "USE memory"); err != nil {
+		slog.Warn("Failed to switch worker DB to memory during shutdown.", "error", err)
+		return
+	}
+	if cfg.DuckLake.DeltaCatalogEnabled {
+		if _, err := db.ExecContext(ctx, "DETACH delta"); err != nil {
+			slog.Warn("Failed to detach worker Delta catalog during shutdown.", "error", err)
+		}
+	}
+	if cfg.DuckLake.MetadataStore != "" {
+		if _, err := db.ExecContext(ctx, "DETACH ducklake"); err != nil {
+			slog.Warn("Failed to detach worker DuckLake catalog during shutdown.", "error", err)
+		}
 	}
 }
 

--- a/duckgres.example.yaml
+++ b/duckgres.example.yaml
@@ -64,6 +64,14 @@ ducklake:
   # If not specified, data is stored alongside the metadata
   # object_store: "s3://bucket/path/"
 
+  # Also attach a Delta Lake catalog/table at worker boot/activation.
+  # Default: false. If delta_catalog_path is omitted, Duckgres derives a
+  # sibling top-level prefix from object_store, e.g. s3://bucket/ducklake/
+  # becomes s3://bucket/delta/. Avoid using the bucket root directly so
+  # DuckLake and Delta metadata/data stay isolated.
+  # delta_catalog_enabled: false
+  # delta_catalog_path: "s3://bucket/delta/"
+
   # S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
   # Default: "config" if s3_access_key is set, otherwise "credential_chain"
   # s3_provider: "config"

--- a/main.go
+++ b/main.go
@@ -110,6 +110,11 @@ type DuckLakeFileConfig struct {
 	ObjectStore   string `yaml:"object_store"`   // e.g., "s3://bucket/path/" for S3/MinIO storage
 	DataPath      string `yaml:"data_path"`      // Local file path for data storage (alternative to object_store)
 
+	// Delta catalog attachment. When enabled without an explicit path, the
+	// catalog path is derived as a sibling delta/ prefix at the object store root.
+	DeltaCatalogEnabled *bool  `yaml:"delta_catalog_enabled"`
+	DeltaCatalogPath    string `yaml:"delta_catalog_path"`
+
 	// Disable metadata postgres_scanner thread-local cache before ATTACH creates
 	// the hidden metadata pool. Nil means use the server default.
 	DisableMetadataThreadLocalCache *bool `yaml:"disable_metadata_thread_local_cache"`
@@ -222,6 +227,8 @@ func main() {
 	threads := flag.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
 	memoryBudget := flag.String("memory-budget", "", "Total memory for all DuckDB sessions (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
 	memoryRebalance := flag.Bool("memory-rebalance", false, "Enable dynamic per-connection memory reallocation (control-plane mode) (env: DUCKGRES_MEMORY_REBALANCE)")
+	duckLakeDeltaCatalogEnabled := flag.Bool("ducklake-delta-catalog-enabled", false, "Attach a Delta Lake catalog during DuckLake worker boot (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED)")
+	duckLakeDeltaCatalogPath := flag.String("ducklake-delta-catalog-path", "", "Delta Lake catalog/table path to attach, defaults to sibling delta/ prefix at DuckLake object-store root (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH)")
 	logLevel := flag.String("log-level", "", "Log level: debug, info, warn, error (env: DUCKGRES_LOG_LEVEL)")
 	repl := flag.Bool("repl", false, "Start an interactive SQL shell instead of the server")
 	psql := flag.Bool("psql", false, "Launch psql connected to the local Duckgres server")
@@ -394,52 +401,54 @@ func main() {
 	}
 
 	resolved := resolveEffectiveConfig(fileCfg, configCLIInputs{
-		Set:                       cliSet,
-		Host:                      *host,
-		Port:                      *port,
-		FlightPort:                *flightPort,
-		FlightSessionIdleTTL:      *flightSessionIdleTTL,
-		FlightSessionReapInterval: *flightSessionReapInterval,
-		FlightHandleIdleTTL:       *flightHandleIdleTTL,
-		FlightSessionTokenTTL:     *flightSessionTokenTTL,
-		DataDir:                   *dataDir,
-		CertFile:                  *certFile,
-		KeyFile:                   *keyFile,
-		FilePersistence:           *filePersistence,
-		ProcessIsolation:          *processIsolation,
-		IdleTimeout:               *idleTimeout,
-		MemoryLimit:               *memoryLimit,
-		Threads:                   *threads,
-		MemoryBudget:              *memoryBudget,
-		MemoryRebalance:           *memoryRebalance,
-		ProcessMinWorkers:         *processMinWorkers,
-		ProcessMaxWorkers:         *processMaxWorkers,
-		ProcessRetireOnSessionEnd: *processRetireOnSessionEnd,
-		WorkerQueueTimeout:        *workerQueueTimeout,
-		WorkerIdleTimeout:         *workerIdleTimeout,
-		HandoverDrainTimeout:      *handoverDrainTimeout,
-		ACMEDomain:                *acmeDomain,
-		ACMEEmail:                 *acmeEmail,
-		ACMECacheDir:              *acmeCacheDir,
-		ACMEDNSProvider:           *acmeDNSProvider,
-		ACMEDNSZoneID:             *acmeDNSZoneID,
-		MaxConnections:            *maxConnections,
-		ConfigStoreConn:           *configStore,
-		ConfigPollInterval:        *configPollInterval,
-		InternalSecret:            *internalSecret,
-		WorkerBackend:             *workerBackend,
-		K8sWorkerImage:            *k8sWorkerImage,
-		K8sWorkerNamespace:        *k8sWorkerNamespace,
-		K8sControlPlaneID:         *k8sControlPlaneID,
-		K8sWorkerPort:             *k8sWorkerPort,
-		K8sWorkerSecret:           *k8sWorkerSecret,
-		K8sWorkerConfigMap:        *k8sWorkerConfigMap,
-		K8sWorkerImagePullPolicy:  *k8sWorkerImagePullPolicy,
-		K8sWorkerServiceAccount:   *k8sWorkerServiceAccount,
-		K8sMaxWorkers:             *k8sMaxWorkers,
-		K8sSharedWarmTarget:       *k8sSharedWarmTarget,
-		AWSRegion:                 *awsRegion,
-		QueryLog:                  *queryLog,
+		Set:                         cliSet,
+		Host:                        *host,
+		Port:                        *port,
+		FlightPort:                  *flightPort,
+		FlightSessionIdleTTL:        *flightSessionIdleTTL,
+		FlightSessionReapInterval:   *flightSessionReapInterval,
+		FlightHandleIdleTTL:         *flightHandleIdleTTL,
+		FlightSessionTokenTTL:       *flightSessionTokenTTL,
+		DataDir:                     *dataDir,
+		CertFile:                    *certFile,
+		KeyFile:                     *keyFile,
+		FilePersistence:             *filePersistence,
+		ProcessIsolation:            *processIsolation,
+		IdleTimeout:                 *idleTimeout,
+		MemoryLimit:                 *memoryLimit,
+		Threads:                     *threads,
+		MemoryBudget:                *memoryBudget,
+		MemoryRebalance:             *memoryRebalance,
+		DuckLakeDeltaCatalogEnabled: *duckLakeDeltaCatalogEnabled,
+		DuckLakeDeltaCatalogPath:    *duckLakeDeltaCatalogPath,
+		ProcessMinWorkers:           *processMinWorkers,
+		ProcessMaxWorkers:           *processMaxWorkers,
+		ProcessRetireOnSessionEnd:   *processRetireOnSessionEnd,
+		WorkerQueueTimeout:          *workerQueueTimeout,
+		WorkerIdleTimeout:           *workerIdleTimeout,
+		HandoverDrainTimeout:        *handoverDrainTimeout,
+		ACMEDomain:                  *acmeDomain,
+		ACMEEmail:                   *acmeEmail,
+		ACMECacheDir:                *acmeCacheDir,
+		ACMEDNSProvider:             *acmeDNSProvider,
+		ACMEDNSZoneID:               *acmeDNSZoneID,
+		MaxConnections:              *maxConnections,
+		ConfigStoreConn:             *configStore,
+		ConfigPollInterval:          *configPollInterval,
+		InternalSecret:              *internalSecret,
+		WorkerBackend:               *workerBackend,
+		K8sWorkerImage:              *k8sWorkerImage,
+		K8sWorkerNamespace:          *k8sWorkerNamespace,
+		K8sControlPlaneID:           *k8sControlPlaneID,
+		K8sWorkerPort:               *k8sWorkerPort,
+		K8sWorkerSecret:             *k8sWorkerSecret,
+		K8sWorkerConfigMap:          *k8sWorkerConfigMap,
+		K8sWorkerImagePullPolicy:    *k8sWorkerImagePullPolicy,
+		K8sWorkerServiceAccount:     *k8sWorkerServiceAccount,
+		K8sMaxWorkers:               *k8sMaxWorkers,
+		K8sSharedWarmTarget:         *k8sSharedWarmTarget,
+		AWSRegion:                   *awsRegion,
+		QueryLog:                    *queryLog,
 	}, os.Getenv, func(msg string) {
 		slog.Warn(msg)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -211,6 +211,53 @@ func TestResolveEffectiveConfigDuckLakeDisableMetadataThreadLocalCacheDefaultsTr
 	}
 }
 
+func TestResolveEffectiveConfigDuckLakeDeltaCatalog(t *testing.T) {
+	fileEnabled := true
+	resolved := resolveEffectiveConfig(&FileConfig{
+		DuckLake: DuckLakeFileConfig{
+			ObjectStore:         "s3://warehouse/ducklake/",
+			DeltaCatalogEnabled: &fileEnabled,
+		},
+	}, configCLIInputs{}, envFromMap(nil), nil)
+	if !resolved.Server.DuckLake.DeltaCatalogEnabled {
+		t.Fatal("expected YAML ducklake.delta_catalog_enabled to enable Delta catalog")
+	}
+	if got, want := resolved.Server.DuckLake.DeltaCatalogPath, "s3://warehouse/delta/"; got != want {
+		t.Fatalf("expected derived Delta catalog path %q, got %q", want, got)
+	}
+
+	resolved = resolveEffectiveConfig(&FileConfig{
+		DuckLake: DuckLakeFileConfig{
+			DeltaCatalogEnabled: &fileEnabled,
+			DeltaCatalogPath:    "s3://warehouse/custom-delta/",
+		},
+	}, configCLIInputs{}, envFromMap(map[string]string{
+		"DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED": "false",
+		"DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH":    "s3://warehouse/env-delta/",
+	}), nil)
+	if resolved.Server.DuckLake.DeltaCatalogEnabled {
+		t.Fatal("expected env DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED=false to override YAML")
+	}
+	if got, want := resolved.Server.DuckLake.DeltaCatalogPath, "s3://warehouse/env-delta/"; got != want {
+		t.Fatalf("expected env Delta catalog path %q, got %q", want, got)
+	}
+
+	resolved = resolveEffectiveConfig(nil, configCLIInputs{
+		Set:                         map[string]bool{"ducklake-delta-catalog-enabled": true, "ducklake-delta-catalog-path": true},
+		DuckLakeDeltaCatalogEnabled: true,
+		DuckLakeDeltaCatalogPath:    "s3://warehouse/cli-delta/",
+	}, envFromMap(map[string]string{
+		"DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED": "false",
+		"DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH":    "s3://warehouse/env-delta/",
+	}), nil)
+	if !resolved.Server.DuckLake.DeltaCatalogEnabled {
+		t.Fatal("expected CLI --ducklake-delta-catalog-enabled to override env")
+	}
+	if got, want := resolved.Server.DuckLake.DeltaCatalogPath, "s3://warehouse/cli-delta/"; got != want {
+		t.Fatalf("expected CLI Delta catalog path %q, got %q", want, got)
+	}
+}
+
 func TestResolveEffectiveConfigInvalidQueryLogEnvValues(t *testing.T) {
 	env := map[string]string{
 		"DUCKGRES_QUERY_LOG_FLUSH_INTERVAL":   "0s",

--- a/server/conn.go
+++ b/server/conn.go
@@ -605,8 +605,9 @@ func (c *clientConn) safeCleanupDB() {
 		}
 	}
 
-	// Detach DuckLake to release the RDS metadata connection (only if connection is healthy)
-	if connHealthy && c.server.cfg.DuckLake.MetadataStore != "" {
+	// Detach attached lake catalogs to release remote metadata/object-store handles
+	// before closing the DuckDB connection.
+	if connHealthy && (c.server.cfg.DuckLake.MetadataStore != "" || c.server.cfg.DuckLake.DeltaCatalogEnabled) {
 		// Must switch away from ducklake before detaching - DuckDB doesn't allow
 		// detaching the default database
 		ctx3, cancel3 := context.WithTimeout(context.Background(), cleanupTimeout)
@@ -620,11 +621,22 @@ func (c *clientConn) safeCleanupDB() {
 		}
 
 		if connHealthy {
-			ctx4, cancel4 := context.WithTimeout(context.Background(), cleanupTimeout)
-			_, err := c.executor.ExecContext(ctx4, "DETACH ducklake")
-			cancel4()
-			if err != nil {
-				slog.Warn("Failed to detach DuckLake.", "user", c.username, "error", err)
+			if c.server.cfg.DuckLake.DeltaCatalogEnabled {
+				ctxDelta, cancelDelta := context.WithTimeout(context.Background(), cleanupTimeout)
+				_, err := c.executor.ExecContext(ctxDelta, "DETACH delta")
+				cancelDelta()
+				if err != nil {
+					slog.Warn("Failed to detach Delta catalog.", "user", c.username, "error", err)
+				}
+			}
+
+			if c.server.cfg.DuckLake.MetadataStore != "" {
+				ctx4, cancel4 := context.WithTimeout(context.Background(), cleanupTimeout)
+				_, err := c.executor.ExecContext(ctx4, "DETACH ducklake")
+				cancel4()
+				if err != nil {
+					slog.Warn("Failed to detach DuckLake.", "user", c.username, "error", err)
+				}
 			}
 		}
 	}

--- a/server/conn_cleanup_test.go
+++ b/server/conn_cleanup_test.go
@@ -46,7 +46,9 @@ func TestSafeCleanupDBUsesValidDuckLakeHealthProbe(t *testing.T) {
 		server: &Server{
 			cfg: Config{
 				DuckLake: DuckLakeConfig{
-					MetadataStore: "postgres:host=127.0.0.1 dbname=ducklake",
+					MetadataStore:       "postgres:host=127.0.0.1 dbname=ducklake",
+					DeltaCatalogEnabled: true,
+					DeltaCatalogPath:    "s3://warehouse/delta/",
 				},
 			},
 		},
@@ -59,6 +61,7 @@ func TestSafeCleanupDBUsesValidDuckLakeHealthProbe(t *testing.T) {
 	want := []string{
 		"SELECT 1 FROM duckdb_tables() WHERE database_name = 'ducklake' LIMIT 1",
 		"USE memory",
+		"DETACH delta",
 		"DETACH ducklake",
 	}
 	if len(exec.execQueries) != len(want) {

--- a/server/ducklake_migration.go
+++ b/server/ducklake_migration.go
@@ -563,3 +563,41 @@ func buildDuckLakeAttachStmt(dlCfg DuckLakeConfig, migrate bool) string {
 	}
 	return fmt.Sprintf("ATTACH 'ducklake:%s' AS ducklake", connStr)
 }
+
+// DefaultDeltaCatalogPath returns the default Delta Lake catalog location for a
+// DuckLake-backed worker. For object stores, keep Delta in its own top-level
+// prefix beside the DuckLake prefix rather than at the bucket root.
+func DefaultDeltaCatalogPath(dlCfg DuckLakeConfig) string {
+	if dlCfg.ObjectStore != "" {
+		return objectStoreRootPrefix(dlCfg.ObjectStore) + "delta/"
+	}
+	if dlCfg.DataPath != "" {
+		return filepath.Join(filepath.Dir(filepath.Clean(dlCfg.DataPath)), "delta")
+	}
+	return ""
+}
+
+func objectStoreRootPrefix(path string) string {
+	schemeIdx := strings.Index(path, "://")
+	if schemeIdx < 0 {
+		return strings.TrimRight(path, "/") + "/"
+	}
+	prefixEnd := schemeIdx + len("://")
+	rest := path[prefixEnd:]
+	slashIdx := strings.IndexByte(rest, '/')
+	if slashIdx < 0 {
+		return path + "/"
+	}
+	return path[:prefixEnd+slashIdx+1]
+}
+
+func deltaCatalogPath(dlCfg DuckLakeConfig) string {
+	if dlCfg.DeltaCatalogPath != "" {
+		return dlCfg.DeltaCatalogPath
+	}
+	return DefaultDeltaCatalogPath(dlCfg)
+}
+
+func buildDeltaCatalogAttachStmt(dlCfg DuckLakeConfig) string {
+	return fmt.Sprintf("ATTACH '%s' AS delta (TYPE delta)", escapeSQLStringLiteral(deltaCatalogPath(dlCfg)))
+}

--- a/server/ducklake_migration.go
+++ b/server/ducklake_migration.go
@@ -565,11 +565,12 @@ func buildDuckLakeAttachStmt(dlCfg DuckLakeConfig, migrate bool) string {
 }
 
 // DefaultDeltaCatalogPath returns the default Delta Lake catalog location for a
-// DuckLake-backed worker. For object stores, keep Delta in its own top-level
-// prefix beside the DuckLake prefix rather than at the bucket root.
+// DuckLake-backed worker as a sibling of the DuckLake prefix at the same parent
+// level. For s3://bucket/team/ducklake/ this returns s3://bucket/team/delta/, so
+// per-tenant prefixes do not collapse to a shared bucket-root delta/.
 func DefaultDeltaCatalogPath(dlCfg DuckLakeConfig) string {
 	if dlCfg.ObjectStore != "" {
-		return objectStoreRootPrefix(dlCfg.ObjectStore) + "delta/"
+		return objectStoreParentPrefix(dlCfg.ObjectStore) + "delta/"
 	}
 	if dlCfg.DataPath != "" {
 		return filepath.Join(filepath.Dir(filepath.Clean(dlCfg.DataPath)), "delta")
@@ -577,18 +578,26 @@ func DefaultDeltaCatalogPath(dlCfg DuckLakeConfig) string {
 	return ""
 }
 
-func objectStoreRootPrefix(path string) string {
+// objectStoreParentPrefix returns the parent directory of a URI-style object
+// store path, preserving the trailing slash. For s3://bucket/team/ducklake/ it
+// returns s3://bucket/team/; for s3://bucket/ducklake/ it returns s3://bucket/.
+// A bare bucket (s3://bucket or s3://bucket/) is treated as its own parent.
+func objectStoreParentPrefix(path string) string {
 	schemeIdx := strings.Index(path, "://")
-	if schemeIdx < 0 {
-		return strings.TrimRight(path, "/") + "/"
+	var scheme string
+	rest := path
+	if schemeIdx >= 0 {
+		scheme = path[:schemeIdx+len("://")]
+		rest = path[schemeIdx+len("://"):]
 	}
-	prefixEnd := schemeIdx + len("://")
-	rest := path[prefixEnd:]
-	slashIdx := strings.IndexByte(rest, '/')
-	if slashIdx < 0 {
-		return path + "/"
+	rest = strings.TrimRight(rest, "/")
+	if rest == "" {
+		return scheme
 	}
-	return path[:prefixEnd+slashIdx+1]
+	if idx := strings.LastIndexByte(rest, '/'); idx >= 0 {
+		return scheme + rest[:idx+1]
+	}
+	return scheme + rest + "/"
 }
 
 func deltaCatalogPath(dlCfg DuckLakeConfig) string {

--- a/server/ducklake_test.go
+++ b/server/ducklake_test.go
@@ -61,3 +61,18 @@ func TestGetCommandTypeWithConstraints(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDeltaCatalogAttachStmt(t *testing.T) {
+	cfg := DuckLakeConfig{
+		ObjectStore:         "s3://warehouse/ducklake/",
+		DeltaCatalogEnabled: true,
+	}
+	if got, want := buildDeltaCatalogAttachStmt(cfg), "ATTACH 's3://warehouse/delta/' AS delta (TYPE delta)"; got != want {
+		t.Fatalf("buildDeltaCatalogAttachStmt() = %q, want %q", got, want)
+	}
+
+	cfg.DeltaCatalogPath = "s3://warehouse/custom-delta/"
+	if got, want := buildDeltaCatalogAttachStmt(cfg), "ATTACH 's3://warehouse/custom-delta/' AS delta (TYPE delta)"; got != want {
+		t.Fatalf("buildDeltaCatalogAttachStmt() = %q, want %q", got, want)
+	}
+}

--- a/server/ducklake_test.go
+++ b/server/ducklake_test.go
@@ -76,3 +76,57 @@ func TestBuildDeltaCatalogAttachStmt(t *testing.T) {
 		t.Fatalf("buildDeltaCatalogAttachStmt() = %q, want %q", got, want)
 	}
 }
+
+func TestDeltaCatalogNeedsS3Secret(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		cfg  DuckLakeConfig
+		want bool
+	}{
+		{
+			name: "default credential chain for explicit s3 delta path",
+			path: "s3://warehouse/delta/",
+			cfg:  DuckLakeConfig{},
+			want: true,
+		},
+		{
+			name: "local delta path",
+			path: "/var/lib/duckgres/delta",
+			cfg:  DuckLakeConfig{},
+			want: false,
+		},
+		{
+			name: "explicit config credentials",
+			path: "s3://warehouse/delta/",
+			cfg: DuckLakeConfig{
+				S3AccessKey: "AKIA...",
+			},
+			want: true,
+		},
+		{
+			name: "aws sdk provider",
+			path: "s3://warehouse/delta/",
+			cfg: DuckLakeConfig{
+				S3Provider: "aws_sdk",
+			},
+			want: true,
+		},
+		{
+			name: "credential chain profile",
+			path: "s3://warehouse/delta/",
+			cfg: DuckLakeConfig{
+				S3Profile: "prod",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deltaCatalogNeedsS3Secret(tt.path, tt.cfg); got != tt.want {
+				t.Fatalf("deltaCatalogNeedsS3Secret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/ducklake_test.go
+++ b/server/ducklake_test.go
@@ -77,6 +77,95 @@ func TestBuildDeltaCatalogAttachStmt(t *testing.T) {
 	}
 }
 
+func TestDefaultDeltaCatalogPath(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  DuckLakeConfig
+		want string
+	}{
+		{
+			name: "object store at bucket root",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse/ducklake/"},
+			want: "s3://warehouse/delta/",
+		},
+		{
+			name: "object store nested under tenant prefix",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse/team-a/ducklake/"},
+			want: "s3://warehouse/team-a/delta/",
+		},
+		{
+			name: "object store deeply nested",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse/region/team-a/ducklake/"},
+			want: "s3://warehouse/region/team-a/delta/",
+		},
+		{
+			name: "object store with no trailing slash",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse/ducklake"},
+			want: "s3://warehouse/delta/",
+		},
+		{
+			name: "bare bucket",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse"},
+			want: "s3://warehouse/delta/",
+		},
+		{
+			name: "bare bucket with trailing slash",
+			cfg:  DuckLakeConfig{ObjectStore: "s3://warehouse/"},
+			want: "s3://warehouse/delta/",
+		},
+		{
+			name: "local data path",
+			cfg:  DuckLakeConfig{DataPath: "/var/lib/duckgres/ducklake"},
+			want: "/var/lib/duckgres/delta",
+		},
+		{
+			name: "no object store or data path",
+			cfg:  DuckLakeConfig{},
+			want: "",
+		},
+		{
+			name: "explicit delta path is not overridden by default derivation",
+			cfg: DuckLakeConfig{
+				ObjectStore:      "s3://warehouse/team-a/ducklake/",
+				DeltaCatalogPath: "s3://other/explicit/",
+			},
+			want: "s3://warehouse/team-a/delta/", // default ignores explicit; deltaCatalogPath() handles override
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DefaultDeltaCatalogPath(tt.cfg); got != tt.want {
+				t.Fatalf("DefaultDeltaCatalogPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectStoreParentPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "scheme with multi-segment path", path: "s3://bucket/team/ducklake/", want: "s3://bucket/team/"},
+		{name: "scheme with single-segment path", path: "s3://bucket/ducklake/", want: "s3://bucket/"},
+		{name: "scheme with no trailing slash", path: "s3://bucket/ducklake", want: "s3://bucket/"},
+		{name: "scheme with bare bucket", path: "s3://bucket", want: "s3://bucket/"},
+		{name: "scheme with bare bucket trailing slash", path: "s3://bucket/", want: "s3://bucket/"},
+		{name: "no scheme, multi-segment path", path: "/var/lib/duckgres/ducklake/", want: "/var/lib/duckgres/"},
+		{name: "no scheme, no trailing slash", path: "/var/lib/duckgres/ducklake", want: "/var/lib/duckgres/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := objectStoreParentPrefix(tt.path); got != tt.want {
+				t.Fatalf("objectStoreParentPrefix(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDeltaCatalogNeedsS3Secret(t *testing.T) {
 	tests := []struct {
 		name string

--- a/server/server.go
+++ b/server/server.go
@@ -1573,7 +1573,7 @@ func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) err
 	if _, err := db.Exec(attachStmt); err != nil {
 		return fmt.Errorf("failed to attach Delta catalog: %w", err)
 	}
-	slog.Info("Attached Delta catalog successfully.")
+	slog.Info("Attached Delta catalog successfully.", "path", catalogPath)
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -310,6 +310,12 @@ type DuckLakeConfig struct {
 	// Used when ObjectStore is not set (for local/non-S3 storage)
 	DataPath string
 
+	// DeltaCatalogEnabled attaches the DuckDB Delta extension catalog at worker
+	// startup/activation in addition to DuckLake. DeltaCatalogPath defaults to a
+	// sibling delta/ prefix at the DuckLake object-store root when omitted.
+	DeltaCatalogEnabled bool
+	DeltaCatalogPath    string
+
 	// S3 credential provider: "config" (explicit credentials) or "credential_chain" (AWS SDK chain)
 	// Default: "config" if S3AccessKey is set, otherwise "credential_chain"
 	S3Provider string
@@ -1115,6 +1121,12 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 			// Non-fatal: continue with DuckDB-based pg_namespace
 		}
 	}
+	if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
+		if cfg.DuckLake.DeltaCatalogEnabled {
+			return fmt.Errorf("delta catalog configured but attachment failed: %w", err)
+		}
+		slog.Warn("Failed to attach Delta catalog.", "user", username, "error", err)
+	}
 
 	// Initialize information_schema compatibility views in memory.main
 	// Must be done AFTER attaching DuckLake (so views can reference ducklake.information_schema)
@@ -1143,6 +1155,9 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		return fmt.Errorf("DuckLake configured but attachment failed: %w", err)
+	}
+	if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
+		return fmt.Errorf("delta catalog configured but attachment failed: %w", err)
 	}
 
 	if err := recreatePgClassForDuckLake(db); err != nil {
@@ -1189,6 +1204,13 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 			_ = db.Close()
 			return nil, fmt.Errorf("failed to set DuckLake as default: %w", err)
 		}
+	}
+	if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
+		if cfg.DuckLake.DeltaCatalogEnabled {
+			_ = db.Close()
+			return nil, fmt.Errorf("delta catalog configured but attachment failed: %w", err)
+		}
+		slog.Warn("Failed to attach Delta catalog.", "user", username, "error", err)
 	}
 
 	return db, nil
@@ -1508,6 +1530,58 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// See: https://github.com/duckdb/ducklake/issues/859
 	go ensureDuckLakeMetadataIndexes(dlCfg)
 
+	return nil
+}
+
+// AttachDeltaCatalog attaches the configured Delta Lake catalog/table alongside
+// DuckLake. It reuses the DuckLake S3 secret settings so Delta scans can access
+// the same object store credentials.
+func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) error {
+	if !dlCfg.DeltaCatalogEnabled {
+		return nil
+	}
+	catalogPath := deltaCatalogPath(dlCfg)
+	if catalogPath == "" {
+		return fmt.Errorf("delta catalog path is empty")
+	}
+
+	select {
+	case sem <- struct{}{}:
+		defer func() { <-sem }()
+	case <-time.After(30 * time.Second):
+		return fmt.Errorf("timeout waiting for Delta catalog attachment lock")
+	}
+
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'delta'").Scan(&count)
+	if err == nil && count > 0 {
+		return nil
+	}
+
+	if err := LoadExtensions(db, []string{"delta"}); err != nil {
+		return fmt.Errorf("load delta extension: %w", err)
+	}
+
+	if strings.Contains(catalogPath, "://") {
+		needsSecret := dlCfg.S3Endpoint != "" ||
+			dlCfg.S3AccessKey != "" ||
+			dlCfg.S3Provider == "credential_chain" ||
+			dlCfg.S3Provider == "aws_sdk" ||
+			dlCfg.S3Chain != "" ||
+			dlCfg.S3Profile != ""
+		if needsSecret {
+			if err := createS3Secret(db, dlCfg); err != nil {
+				return fmt.Errorf("failed to create S3 secret: %w", err)
+			}
+		}
+	}
+
+	attachStmt := buildDeltaCatalogAttachStmt(dlCfg)
+	slog.Info("Attaching Delta catalog.", "path", catalogPath)
+	if _, err := db.Exec(attachStmt); err != nil {
+		return fmt.Errorf("failed to attach Delta catalog: %w", err)
+	}
+	slog.Info("Attached Delta catalog successfully.")
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1562,17 +1562,9 @@ func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) err
 		return fmt.Errorf("load delta extension: %w", err)
 	}
 
-	if strings.Contains(catalogPath, "://") {
-		needsSecret := dlCfg.S3Endpoint != "" ||
-			dlCfg.S3AccessKey != "" ||
-			dlCfg.S3Provider == "credential_chain" ||
-			dlCfg.S3Provider == "aws_sdk" ||
-			dlCfg.S3Chain != "" ||
-			dlCfg.S3Profile != ""
-		if needsSecret {
-			if err := createS3Secret(db, dlCfg); err != nil {
-				return fmt.Errorf("failed to create S3 secret: %w", err)
-			}
+	if deltaCatalogNeedsS3Secret(catalogPath, dlCfg) {
+		if err := createS3Secret(db, dlCfg); err != nil {
+			return fmt.Errorf("failed to create S3 secret: %w", err)
 		}
 	}
 
@@ -1583,6 +1575,19 @@ func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) err
 	}
 	slog.Info("Attached Delta catalog successfully.")
 	return nil
+}
+
+func deltaCatalogNeedsS3Secret(catalogPath string, dlCfg DuckLakeConfig) bool {
+	if !strings.Contains(catalogPath, "://") {
+		return false
+	}
+	provider := S3ProviderForConfig(dlCfg)
+	return dlCfg.S3Endpoint != "" ||
+		dlCfg.S3AccessKey != "" ||
+		provider == "credential_chain" ||
+		provider == "aws_sdk" ||
+		dlCfg.S3Chain != "" ||
+		dlCfg.S3Profile != ""
 }
 
 // duckLakeIndexDone tracks whether metadata indexes have been successfully created.


### PR DESCRIPTION
## Summary

Adds an optional DuckLake-adjacent Delta catalog setting so workers can attach a DuckDB Delta catalog/table during boot or shared warm-worker activation.

## What changed

- Added `ducklake.delta_catalog_enabled` and `ducklake.delta_catalog_path` config with env and CLI equivalents.
- Derives the default Delta location as a sibling top-level `delta/` prefix from the DuckLake object store, e.g. `s3://bucket/ducklake/` -> `s3://bucket/delta/`, avoiding bucket-root collisions.
- Attaches the Delta catalog as `delta` during regular connection initialization, passthrough connection initialization, and shared warm-worker tenant activation.
- Detaches `delta` before `ducklake` during connection and worker shutdown.
- Documented the defaults and added a Delta catalog activation runbook.

## Validation

- `GOCACHE=/tmp/duckgres-gocache just test-unit`
- `PATH=/home/james/go/bin:$PATH GOCACHE=/tmp/duckgres-gocache GOLANGCI_LINT_CACHE=/tmp/duckgres-golangci-lint-cache just lint`
