### PR TITLE
Support multiple worker versions in k8s multi-tenant CP

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -251,6 +251,7 @@ type WorkerRecord struct {
 	WorkerID            int         `gorm:"primaryKey" json:"worker_id"`
 	PodName             string      `gorm:"size:255;not null;uniqueIndex" json:"pod_name"`
 	PodUID              string      `gorm:"size:255" json:"pod_uid"`
+	Image               string      `gorm:"size:512" json:"image"`
 	State               WorkerState `gorm:"size:32;not null;index" json:"state"`
 	OrgID               string      `gorm:"size:255;index" json:"org_id"`
 	OwnerCPInstanceID   string      `gorm:"size:255;index" json:"owner_cp_instance_id"`

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -526,7 +526,7 @@ func (cs *ConfigStore) GetWorkerRecord(workerID int) (*WorkerRecord, error) {
 // The selected row is locked with SKIP LOCKED and transitioned to reserved while
 // incrementing owner_epoch. When maxOrgWorkers is set, org claims are serialized
 // under the same advisory lock used for spawn-slot allocation.
-func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*WorkerRecord, error) {
+func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*WorkerRecord, error) {
 	var claimed *WorkerRecord
 	err := cs.db.Transaction(func(tx *gorm.DB) error {
 		if orgID != "" {
@@ -545,11 +545,15 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID string, maxOrgWo
 		}
 
 		var current WorkerRecord
-		err := tx.Table(cs.runtimeTable(current.TableName())).
+		query := tx.Table(cs.runtimeTable(current.TableName())).
 			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-			Where("state = ?", WorkerStateIdle).
-			Order("worker_id ASC").
-			Take(&current).Error
+			Where("state = ?", WorkerStateIdle)
+
+		if image != "" {
+			query = query.Where("image = ?", image)
+		}
+
+		err := query.Order("worker_id ASC").Take(&current).Error
 		if err != nil {
 			if err == gorm.ErrRecordNotFound {
 				return nil
@@ -789,7 +793,7 @@ func (cs *ConfigStore) TakeOverWorker(workerID int, ownerCPInstanceID, orgID str
 
 // CreateSpawningWorkerSlot creates a durable spawning worker row under advisory-lock
 // protected org/global capacity checks. A nil result means capacity blocked the spawn.
-func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*WorkerRecord, error) {
+func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*WorkerRecord, error) {
 	if strings.TrimSpace(podNamePrefix) == "" {
 		return nil, fmt.Errorf("pod name prefix is required")
 	}
@@ -833,6 +837,7 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID string,
 		record := &WorkerRecord{
 			WorkerID:          int(workerID),
 			PodName:           fmt.Sprintf("%s-%d", podNamePrefix, workerID),
+			Image:             image,
 			State:             WorkerStateSpawning,
 			OrgID:             orgID,
 			OwnerCPInstanceID: ownerCPInstanceID,
@@ -855,7 +860,7 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID string,
 // neutral warm pool under advisory-lock protected cluster-wide warm-target and
 // global capacity checks. A nil result means capacity already satisfies the target
 // or the global worker cap blocked the spawn.
-func (cs *ConfigStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix string, targetWarmWorkers, maxGlobalWorkers int) (*WorkerRecord, error) {
+func (cs *ConfigStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*WorkerRecord, error) {
 	if strings.TrimSpace(podNamePrefix) == "" {
 		return nil, fmt.Errorf("pod name prefix is required")
 	}
@@ -897,6 +902,7 @@ func (cs *ConfigStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePre
 		record := &WorkerRecord{
 			WorkerID:          int(workerID),
 			PodName:           fmt.Sprintf("%s-%d", podNamePrefix, workerID),
+			Image:             image,
 			State:             WorkerStateSpawning,
 			OrgID:             "",
 			OwnerCPInstanceID: ownerCPInstanceID,

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -445,7 +445,7 @@ func (p *K8sWorkerPool) onPodTerminated(pod *corev1.Pod) {
 // SpawnWorker creates a new worker pod and waits for it to become ready.
 // It acquires the spawn semaphore to limit concurrent K8s API calls and
 // retries transient API errors with exponential backoff.
-func (p *K8sWorkerPool) SpawnWorker(ctx context.Context, id int) error {
+func (p *K8sWorkerPool) SpawnWorker(ctx context.Context, id int, image string) error {
 	// Acquire spawn semaphore to limit concurrent pod creates.
 	select {
 	case p.spawnSem <- struct{}{}:
@@ -496,7 +496,7 @@ func (p *K8sWorkerPool) SpawnWorker(ctx context.Context, id int) error {
 			Containers: []corev1.Container{
 				{
 					Name:            "duckdb-worker",
-					Image:           p.workerImage,
+					Image:           image,
 					ImagePullPolicy: p.imagePullPolicy,
 					Args: []string{
 						"--mode", "duckdb-service",
@@ -950,7 +950,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context) (*ManagedWorker, erro
 					p.mu.Unlock()
 					slog.Debug("Assigned to least-loaded worker, spawning new worker in background.",
 						"worker", w.ID, "active_sessions", w.activeSessions, "background_worker", id)
-					go p.spawnWorkerBackground(id)
+					go p.spawnWorkerBackground(id, p.workerImage)
 				} else {
 					p.mu.Unlock()
 					slog.Debug("Assigned to least-loaded worker (at capacity).",
@@ -967,7 +967,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context) (*ManagedWorker, erro
 			p.mu.Unlock()
 
 			slog.Info("No live workers, blocking on spawn.", "worker", id)
-			err := p.SpawnWorker(ctx, id)
+			err := p.SpawnWorker(ctx, id, p.workerImage)
 
 			p.mu.Lock()
 			p.spawning--
@@ -1002,11 +1002,11 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context) (*ManagedWorker, erro
 
 // spawnWorkerBackground spawns a worker pod without blocking AcquireWorker.
 // The new worker becomes available for future sessions once ready.
-func (p *K8sWorkerPool) spawnWorkerBackground(id int) {
+func (p *K8sWorkerPool) spawnWorkerBackground(id int, image string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	err := p.spawnWarmWorker(ctx, id)
+	err := p.spawnWarmWorker(ctx, id, image)
 
 	p.mu.Lock()
 	p.spawning--
@@ -1260,18 +1260,25 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 					return nil, err
 				}
 				if hotClaimed != nil {
-					worker, reserveErr := p.reserveClaimedWorker(ctx, hotClaimed, assignment)
-					if reserveErr == nil {
-						worker.hotIdleReclaimed = true
-						return worker, nil
+					// Check if image matches (hot-idle reclamation is strict on version)
+					if assignment.Image != "" && hotClaimed.Image != assignment.Image {
+						slog.Info("Hot-idle worker image mismatch, skipping reclamation.", "worker_id", hotClaimed.WorkerID, "expected", assignment.Image, "got", hotClaimed.Image)
+						// We can't use this hot-idle worker, let the janitor eventually reap it.
+						// Fall through to neutral idle claim or spawn.
+					} else {
+						worker, reserveErr := p.reserveClaimedWorker(ctx, hotClaimed, assignment)
+						if reserveErr == nil {
+							worker.hotIdleReclaimed = true
+							return worker, nil
+						}
+						slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", hotClaimed.WorkerID, "error", reserveErr)
+						p.retireClaimedWorker(hotClaimed, RetireReasonCrash)
+						// Fall through to neutral idle claim
 					}
-					slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", hotClaimed.WorkerID, "error", reserveErr)
-					p.retireClaimedWorker(hotClaimed, RetireReasonCrash)
-					// Fall through to neutral idle claim
 				}
 			}
 
-			claimed, err := p.runtimeStore.ClaimIdleWorker(p.cpInstanceID, assignment.OrgID, assignment.MaxWorkers)
+			claimed, err := p.runtimeStore.ClaimIdleWorker(p.cpInstanceID, assignment.OrgID, assignment.Image, assignment.MaxWorkers)
 			if err != nil {
 				return nil, err
 			}
@@ -1331,7 +1338,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			}
 
 			if shouldReplenish {
-				p.spawnWarmWorkerBackground(replenishID)
+				p.spawnWarmWorkerBackground(replenishID, p.workerImage)
 			}
 			return idle, nil
 		}
@@ -1339,9 +1346,14 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 		liveCount := p.liveWorkerCountLocked()
 		if p.maxWorkers == 0 || liveCount < p.maxWorkers {
 			if p.runtimeStore != nil {
+				image := assignment.Image
+				if image == "" {
+					image = p.workerImage
+				}
 				slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
 					p.cpInstanceID,
 					assignment.OrgID,
+					image,
 					1,
 					p.workerPodNamePrefix(),
 					assignment.MaxWorkers,
@@ -1363,7 +1375,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				p.spawning++
 				p.mu.Unlock()
 
-				err = p.spawnWarmWorker(ctx, slot.WorkerID)
+				err = p.spawnWarmWorker(ctx, slot.WorkerID, slot.Image)
 
 				p.mu.Lock()
 				p.spawning--
@@ -1383,7 +1395,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			p.spawning++
 			p.mu.Unlock()
 
-			err := p.spawnWarmWorker(ctx, id)
+			err := p.spawnWarmWorker(ctx, id, p.workerImage)
 
 			p.mu.Lock()
 			p.spawning--
@@ -1490,6 +1502,11 @@ func (p *K8sWorkerPool) claimSpecificWorker(ctx context.Context, workerID int, e
 	if record == nil {
 		return nil, fmt.Errorf("worker %d could not be claimed", workerID)
 	}
+
+	if assignment.Image != "" && record.Image != assignment.Image {
+		return nil, fmt.Errorf("worker %d image mismatch (expected %q, got %q)", workerID, assignment.Image, record.Image)
+	}
+
 	return p.reserveClaimedWorker(ctx, record, assignment)
 }
 
@@ -1644,6 +1661,7 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 			slot, err := p.runtimeStore.CreateNeutralWarmWorkerSlot(
 				p.cpInstanceID,
 				p.workerPodNamePrefix(),
+				p.workerImage,
 				count,
 				p.maxWorkers,
 			)
@@ -1676,7 +1694,7 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 			wg.Add(1)
 			go func(i int, slot *configstore.WorkerRecord) {
 				defer wg.Done()
-				err := p.spawnWarmWorker(ctx, slot.WorkerID)
+				err := p.spawnWarmWorker(ctx, slot.WorkerID, slot.Image)
 
 				p.mu.Lock()
 				p.spawning--
@@ -1723,7 +1741,7 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 		wg.Add(1)
 		go func(i int, id int) {
 			defer wg.Done()
-			err := p.spawnWarmWorker(ctx, id)
+			err := p.spawnWarmWorker(ctx, id, p.workerImage)
 
 			p.mu.Lock()
 			p.spawning--
@@ -1800,7 +1818,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 						})
 						delCancel()
 						if shouldReplenish {
-							p.spawnWarmWorkerBackground(replacementID)
+							p.spawnWarmWorkerBackground(replacementID, p.workerImage)
 						}
 					default:
 						// Worker alive, do health check
@@ -1847,7 +1865,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 									_ = w.client.Close()
 								}
 								if shouldReplenish {
-									p.spawnWarmWorkerBackground(replacementID)
+									p.spawnWarmWorkerBackground(replacementID, p.workerImage)
 								}
 							}
 						} else {
@@ -2120,7 +2138,7 @@ func (p *K8sWorkerPool) reapStuckActivatingWorkers() {
 			go p.retireWorkerPod(entry.id, entry.w)
 		}
 		for _, id := range spawnIDs {
-			p.spawnWarmWorkerBackground(id)
+			p.spawnWarmWorkerBackground(id, p.workerImage)
 		}
 	}
 }
@@ -2257,7 +2275,7 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 	if removedAny {
 		observeControlPlaneWorkers(len(p.workers))
 		for _, id := range spawnIDs {
-			go p.spawnWarmWorkerBackground(id)
+			go p.spawnWarmWorkerBackground(id, p.workerImage)
 		}
 	}
 }
@@ -2372,11 +2390,15 @@ func (p *K8sWorkerPool) shouldReplenishWarmCapacityLocked() bool {
 	return p.maxWorkers == 0 || liveCount < p.maxWorkers
 }
 
-func (p *K8sWorkerPool) spawnWarmWorker(ctx context.Context, id int) error {
+func (p *K8sWorkerPool) spawnWarmWorker(ctx context.Context, id int, image string) error {
 	if id <= 0 && p.runtimeStore != nil {
+		if image == "" {
+			image = p.workerImage
+		}
 		slot, err := p.runtimeStore.CreateNeutralWarmWorkerSlot(
 			p.cpInstanceID,
 			p.workerPodNamePrefix(),
+			image,
 			p.minWorkers,
 			p.maxWorkers,
 		)
@@ -2387,19 +2409,20 @@ func (p *K8sWorkerPool) spawnWarmWorker(ctx context.Context, id int) error {
 			return nil
 		}
 		id = slot.WorkerID
+		image = slot.Image
 	}
 	if p.spawnWarmWorkerFunc != nil {
 		return p.spawnWarmWorkerFunc(ctx, id)
 	}
-	return p.SpawnWorker(ctx, id)
+	return p.SpawnWorker(ctx, id, image)
 }
 
-func (p *K8sWorkerPool) spawnWarmWorkerBackground(id int) {
+func (p *K8sWorkerPool) spawnWarmWorkerBackground(id int, image string) {
 	if p.spawnWarmWorkerBackgroundFunc != nil {
 		p.spawnWarmWorkerBackgroundFunc(id)
 		return
 	}
-	go p.spawnWorkerBackground(id)
+	go p.spawnWorkerBackground(id, image)
 }
 
 func (p *K8sWorkerPool) markWorkerRetiredLocked(w *ManagedWorker, reason string) {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -30,12 +30,14 @@ type captureRuntimeWorkerStore struct {
 	claimCalls            int
 	claimOwnerCPID        string
 	claimOrgID            string
+	claimImage            string
 	claimMaxOrgWorkers    int
 	spawned               *configstore.WorkerRecord
 	spawnErr              error
 	spawnCalls            int
 	spawnOwnerCPID        string
 	spawnOrgID            string
+	spawnImage            string
 	spawnOwnerEpoch       int64
 	spawnPodNamePrefix    string
 	spawnMaxOrgWorkers    int
@@ -46,6 +48,7 @@ type captureRuntimeWorkerStore struct {
 	neutralSpawnCalls     int
 	neutralSpawnOwnerCPID string
 	neutralSpawnPodPrefix string
+	neutralSpawnImage     string
 	neutralSpawnTarget    int
 	neutralSpawnMaxGlobal  int
 	hotIdleClaimResult     *configstore.WorkerRecord
@@ -104,12 +107,13 @@ func (s *captureRuntimeWorkerStore) snapshot() []configstore.WorkerRecord {
 	return out
 }
 
-func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.claimCalls++
 	s.claimOwnerCPID = ownerCPInstanceID
 	s.claimOrgID = orgID
+	s.claimImage = image
 	s.claimMaxOrgWorkers = maxOrgWorkers
 	if s.claimErr != nil {
 		return nil, s.claimErr
@@ -133,12 +137,13 @@ func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID 
 	return nil, nil
 }
 
-func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.spawnCalls++
 	s.spawnOwnerCPID = ownerCPInstanceID
 	s.spawnOrgID = orgID
+	s.spawnImage = image
 	s.spawnOwnerEpoch = ownerEpoch
 	s.spawnPodNamePrefix = podNamePrefix
 	s.spawnMaxOrgWorkers = maxOrgWorkers
@@ -153,12 +158,13 @@ func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, 
 	return &spawned, nil
 }
 
-func (s *captureRuntimeWorkerStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.neutralSpawnCalls++
 	s.neutralSpawnOwnerCPID = ownerCPInstanceID
 	s.neutralSpawnPodPrefix = podNamePrefix
+	s.neutralSpawnImage = image
 	s.neutralSpawnTarget = targetWarmWorkers
 	s.neutralSpawnMaxGlobal = maxGlobalWorkers
 	if s.neutralSpawnErr != nil {
@@ -1272,7 +1278,7 @@ func TestK8sPoolSpawnWarmWorkerAllocatesRuntimeSlotWhenIDZero(t *testing.T) {
 		return nil
 	}
 
-	if err := pool.spawnWarmWorker(context.Background(), 0); err != nil {
+	if err := pool.spawnWarmWorker(context.Background(), 0, pool.workerImage); err != nil {
 		t.Fatalf("spawnWarmWorker: %v", err)
 	}
 	if spawnedID != 41 {
@@ -1555,7 +1561,7 @@ func TestK8sPool_SpawnWorkerCreatesCorrectPod(t *testing.T) {
 	// real pod running, but we can verify the pod was created correctly.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_ = pool.SpawnWorker(ctx, 0)
+	_ = pool.SpawnWorker(ctx, 0, pool.workerImage)
 
 	pods, err := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
 		LabelSelector: "duckgres/control-plane=test-cp",

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -16,15 +16,17 @@ type OrgReservedPool struct {
 	shared                 *K8sWorkerPool
 	orgID                  string
 	maxWorkers             int
+	image                  string
 	stsBroker              *STSBroker
 	activateReservedWorker func(context.Context, *ManagedWorker) error
 }
 
-func NewOrgReservedPool(shared *K8sWorkerPool, orgID string, maxWorkers int, stsBroker *STSBroker) *OrgReservedPool {
+func NewOrgReservedPool(shared *K8sWorkerPool, orgID string, maxWorkers int, image string, stsBroker *STSBroker) *OrgReservedPool {
 	pool := &OrgReservedPool{
 		shared:     shared,
 		orgID:      orgID,
 		maxWorkers: maxWorkers,
+		image:      image,
 		stsBroker:  stsBroker,
 	}
 	pool.activateReservedWorker = pool.activateReservedWorkerDefault
@@ -61,7 +63,9 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context) (*ManagedWorker, er
 			p.shared.mu.Unlock()
 
 			worker, err := p.shared.ReserveSharedWorker(ctx, &WorkerAssignment{
-				OrgID: p.orgID,
+				OrgID:      p.orgID,
+				MaxWorkers: p.maxWorkers,
+				Image:      p.image,
 			})
 			if err != nil {
 				return nil, err
@@ -276,6 +280,7 @@ func (p *OrgReservedPool) ReconnectFlightWorker(ctx context.Context, workerID in
 	worker, err := p.shared.claimSpecificWorker(ctx, workerID, ownerEpoch, &WorkerAssignment{
 		OrgID:      p.orgID,
 		MaxWorkers: p.maxWorkers,
+		Image:      p.image,
 	})
 	if err != nil {
 		return nil, err

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -20,7 +20,7 @@ func TestOrgReservedPoolAcquireReservesOrgWorker(t *testing.T) {
 		return nil
 	}
 
-	pool := NewOrgReservedPool(shared, "analytics", 2, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
 	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		return nil
 	}
@@ -67,7 +67,7 @@ func TestOrgReservedPoolAcquireSkipsOtherOrgsWorkers(t *testing.T) {
 		return nil
 	}
 
-	pool := NewOrgReservedPool(shared, "analytics", 2, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
 	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		return nil
 	}
@@ -101,7 +101,7 @@ func TestOrgReservedPoolReleaseWorkerTransitionsToHotIdleOnLastSession(t *testin
 	}
 	shared.workers[worker.ID] = worker
 
-	pool := NewOrgReservedPool(shared, "analytics", 1, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 1, shared.workerImage, nil)
 	pool.ReleaseWorker(worker.ID)
 
 	w, ok := shared.Worker(worker.ID)
@@ -129,7 +129,7 @@ func TestOrgReservedWorkerPoolAcquireActivatesReservedWorkerWhenEnabledWithOrgCo
 	}
 
 	activated := false
-	pool := NewOrgReservedPool(shared, "analytics", 2, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
 	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		activated = true
 		return nil
@@ -162,7 +162,7 @@ func TestOrgReservedWorkerPoolAcquireDelegatesActivationWithoutCachedTenantRunti
 		return nil
 	}
 
-	pool := NewOrgReservedPool(shared, "analytics", 2, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
 	activated := 0
 	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		activated++
@@ -200,7 +200,7 @@ func TestOrgReservedPoolAcquireWaitsWhenSharedWarmWorkerBusyAtCapacity(t *testin
 	}
 	shared.workers[worker.ID] = worker
 
-	pool := NewOrgReservedPool(shared, "analytics", 1, nil)
+	pool := NewOrgReservedPool(shared, "analytics", 1, shared.workerImage, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -117,7 +117,12 @@ func (tr *OrgRouter) createOrgStack(tc *configstore.OrgConfig) (*OrgStack, error
 		tr.sharedPool.SetWorkerResources(cpu, mem)
 	}
 
-	pool := NewOrgReservedPool(tr.sharedPool, tc.Name, maxWorkers, tr.stsBroker)
+	image := tr.baseCfg.WorkerImage
+	if tc.Warehouse != nil && tc.Warehouse.Image != "" {
+		image = tc.Warehouse.Image
+	}
+
+	pool := NewOrgReservedPool(tr.sharedPool, tc.Name, maxWorkers, image, tr.stsBroker)
 	activator := NewSharedWorkerActivator(tr.sharedPool, tr.stsBroker, func(orgID string) (*configstore.OrgConfig, error) {
 		snap := tr.configStore.Snapshot()
 		if snap == nil {

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -47,7 +47,7 @@ func TestOrgRouterReconcileWarmCapacityUsesExplicitSharedWarmTarget(t *testing.T
 
 func TestOrgRouterHandleConfigChangeRefreshesRuntimeOnlyUpdates(t *testing.T) {
 	sharedPool, _ := newTestK8sPool(t, 10)
-	pool := NewOrgReservedPool(sharedPool, "analytics", 2, nil)
+	pool := NewOrgReservedPool(sharedPool, "analytics", 2, sharedPool.workerImage, nil)
 
 	oldTC := &configstore.OrgConfig{
 		Name: "analytics",

--- a/controlplane/warm_pool_metrics_test.go
+++ b/controlplane/warm_pool_metrics_test.go
@@ -161,7 +161,7 @@ func TestActivateWorkerForOrgUpdatesActivatingGauge(t *testing.T) {
 	pool.workers[1] = worker
 	observeWarmPoolLifecycleGauges(pool.workers)
 
-	orgPool := NewOrgReservedPool(pool, "org-1", 1, nil)
+	orgPool := NewOrgReservedPool(pool, "org-1", 1, pool.workerImage, nil)
 	orgPool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		assertGaugeValue(t, reservedWorkersGauge, 0)
 		assertGaugeValue(t, activatingWorkersGauge, 1)
@@ -182,7 +182,7 @@ func TestActivateWorkerForOrgRecordsActivationDurationWhenWorkerAlreadyHot(t *te
 	worker.reservedAt = time.Now().Add(-2 * time.Second)
 	pool.workers[1] = worker
 
-	orgPool := NewOrgReservedPool(pool, "org-1", 1, nil)
+	orgPool := NewOrgReservedPool(pool, "org-1", 1, pool.workerImage, nil)
 	orgPool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
 		nextState, err := worker.SharedState().Transition(WorkerLifecycleHot, nil)
 		if err != nil {

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -75,10 +75,10 @@ type K8sWorkerPoolConfig struct {
 
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
-	ClaimIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*configstore.WorkerRecord, error)
+	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, error)
 	ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, error)
-	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
-	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
+	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
+	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
 	RetireIdleWorker(workerID int, reason string) (bool, error)

--- a/controlplane/worker_state.go
+++ b/controlplane/worker_state.go
@@ -22,6 +22,7 @@ const (
 type WorkerAssignment struct {
 	OrgID      string
 	MaxWorkers int
+	Image      string
 }
 
 // SharedWorkerState holds the additive lifecycle/assignment model for shared


### PR DESCRIPTION
This PR introduces support for heterogeneous worker pools where different tenants can run different DuckDB/DuckLake versions.

Key changes:
- Added  field to  in the config store (DB).
- Updated  interface to handle image-aware allocation.
- Modified  to respect  affinity when claiming idle workers or spawning new ones.
- Updated  to resolve the target image from  (with global fallback).
- Updated all relevant tests and mocks.