### PR TITLE
log: thread worker pod name through session-level logs

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -851,7 +851,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	secretKey := server.GenerateSecretKey()
 
 	// Use a temporary clientConn just to send initial params
-	tmpCC := server.NewClientConn(cp.srv, nil, nil, writer, username, orgID, database, applicationName, nil, pid, secretKey, -1)
+	tmpCC := server.NewClientConn(cp.srv, nil, nil, writer, username, orgID, database, applicationName, nil, pid, secretKey, -1, "")
 	defer server.CancelClientConn(tmpCC)
 	server.SendInitialParams(tmpCC)
 	if err := writer.Flush(); err != nil {
@@ -889,6 +889,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		_ = writer.Flush()
 		return
 	}
+	// Worker is now assigned — capture identity for log correlation.
+	workerID := sessions.WorkerIDForPID(pid)
+	workerPod := sessions.WorkerPodNameForPID(pid)
 	if orgID != "" {
 		observeOrgSessionsActive(orgID, sessions.SessionCount())
 	}
@@ -903,7 +906,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	err = server.InitSessionDatabaseMetadata(initCtx, executor, database)
 	if err != nil {
 		initCancel()
-		slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err)
+		slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
 		_ = writer.Flush()
 		return
@@ -911,7 +914,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	duckLakeAttached, err := server.HasAttachedCatalog(initCtx, executor, "ducklake")
 	initCancel()
 	if err != nil {
-		slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err)
+		slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
 		_ = writer.Flush()
 		return
@@ -922,27 +925,26 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	sessions.SetConnCloser(pid, tlsConn)
 
 	// Create real clientConn with FlightExecutor and worker assignment
-	workerID := sessions.WorkerIDForPID(pid)
-	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID)
+	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
 	server.SetLogicalCatalogMapping(cc, duckLakeAttached)
 
 	// Send ReadyForQuery to signal that the handshake is complete
 	if err := server.WriteReadyForQuery(writer, 'I'); err != nil {
-		slog.Error("Failed to send ReadyForQuery.", "remote_addr", remoteAddr, "error", err)
+		slog.Error("Failed to send ReadyForQuery.", "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 		return
 	}
 	if err := writer.Flush(); err != nil {
-		slog.Error("Failed to flush writer.", "remote_addr", remoteAddr, "error", err)
+		slog.Error("Failed to flush writer.", "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 		return
 	}
 
 	// Run message loop
 	if err := server.RunMessageLoop(cc); err != nil {
-		slog.Error("Message loop error.", "user", username, "remote_addr", remoteAddr, "error", err)
+		slog.Error("Message loop error.", "user", username, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 		return
 	}
 
-	slog.Info("Client disconnected.", "user", username, "remote_addr", remoteAddr)
+	slog.Info("Client disconnected.", "user", username, "remote_addr", remoteAddr, "worker", workerID, "worker_pod", workerPod)
 }
 
 // workerDuckDBLimits derives DuckDB memory_limit and threads from the worker

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -251,7 +251,7 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 		}
 		slog.Info("Retiring mismatched-version worker pod.",
 			"worker_id", workerID,
-			"pod", pod.Name,
+			"worker_pod", pod.Name,
 			"pod_version", trimK8sPodHashSuffix(label),
 			"my_version", myVersion,
 		)
@@ -259,7 +259,7 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 		if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriod,
 		}); err != nil && !errors.IsNotFound(err) {
-			slog.Warn("Version-aware reaper failed to delete pod.", "pod", pod.Name, "error", err)
+			slog.Warn("Version-aware reaper failed to delete pod.", "worker_pod", pod.Name, "error", err)
 		}
 		return true
 	}
@@ -326,11 +326,11 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods(ctx context.Context, minAge ti
 		if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriod,
 		}); err != nil && !errors.IsNotFound(err) {
-			slog.Warn("Stranded-pod reconciler failed to delete pod.", "pod", pod.Name, "worker_id", workerID, "error", err)
+			slog.Warn("Stranded-pod reconciler failed to delete pod.", "worker_pod", pod.Name, "worker_id", workerID, "error", err)
 			continue
 		}
 		_ = p.deleteWorkerRPCSecret(ctx, pod.Name)
-		slog.Info("Stranded worker pod reconciled.", "pod", pod.Name, "worker_id", workerID, "db_state", dbState)
+		slog.Info("Stranded worker pod reconciled.", "worker_pod", pod.Name, "worker_id", workerID, "db_state", dbState)
 		deleted++
 	}
 	return deleted
@@ -437,7 +437,7 @@ func (p *K8sWorkerPool) onPodTerminated(pod *corev1.Pod) {
 	case <-w.done:
 		// Already closed
 	default:
-		slog.Warn("Worker pod terminated.", "id", id, "pod", pod.Name, "phase", pod.Status.Phase)
+		slog.Warn("Worker pod terminated.", "id", id, "worker_pod", pod.Name, "phase", pod.Status.Phase)
 		close(w.done)
 	}
 }
@@ -728,7 +728,7 @@ func (p *K8sWorkerPool) SpawnWorker(ctx context.Context, id int) error {
 	p.persistWorkerRecord(p.workerRecordFor(id, w, w.OwnerEpoch(), configstore.WorkerStateIdle, "", nil))
 	observeControlPlaneWorkers(workerCount)
 
-	slog.Info("K8s worker spawned.", "id", id, "pod", podName, "addr", addr)
+	slog.Info("K8s worker spawned.", "id", id, "worker_pod", podName, "addr", addr)
 	return nil
 }
 
@@ -793,7 +793,7 @@ func (p *K8sWorkerPool) createPodWithBackoff(ctx context.Context, pod *corev1.Po
 			return fmt.Errorf("create worker pod %s after %d retries: %w", pod.Name, maxRetries, err)
 		}
 		slog.Warn("Transient K8s API error creating pod, retrying.",
-			"pod", pod.Name, "attempt", attempt+1, "backoff", backoff, "error", err)
+			"worker_pod", pod.Name, "attempt", attempt+1, "backoff", backoff, "error", err)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -1280,7 +1280,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				if reserveErr == nil {
 					return worker, nil
 				}
-				slog.Warn("Claimed idle worker could not be reserved, retiring claimed pod.", "worker_id", claimed.WorkerID, "pod", claimed.PodName, "error", reserveErr)
+				slog.Warn("Claimed idle worker could not be reserved, retiring claimed pod.", "worker_id", claimed.WorkerID, "worker_pod", claimed.PodName, "error", reserveErr)
 				p.retireClaimedWorker(claimed, RetireReasonCrash)
 				continue
 			}
@@ -1466,7 +1466,7 @@ func (p *K8sWorkerPool) reserveClaimedWorker(ctx context.Context, claimed *confi
 		p.persistWorkerRecord(reservedRecord)
 	}
 	if err := p.checkReservedWorkerLiveness(ctx, worker); err != nil {
-		slog.Warn("Claimed worker failed liveness recheck.", "worker", worker.ID, "pod", worker.PodName(), "error", err)
+		slog.Warn("Claimed worker failed liveness recheck.", "worker", worker.ID, "worker_pod", worker.PodName(), "error", err)
 		p.retireWorkerWithReason(worker.ID, RetireReasonCrash)
 		return nil, err
 	}
@@ -1908,7 +1908,7 @@ func (p *K8sWorkerPool) ShutdownAll() {
 	ctx := context.Background()
 	for _, w := range workers {
 		podName := p.workerPodName(w)
-		slog.Info("Shutting down K8s worker.", "id", w.ID, "pod", podName)
+		slog.Info("Shutting down K8s worker.", "id", w.ID, "worker_pod", podName)
 
 		// Step 1: CAS to draining. Skip the worker on CAS miss or error —
 		// there's no safe way to proceed if we don't own the row.
@@ -1933,7 +1933,7 @@ func (p *K8sWorkerPool) ShutdownAll() {
 			GracePeriodSeconds: &gracePeriod,
 		}); err != nil && !errors.IsNotFound(err) {
 			slog.Warn("ShutdownAll: pod delete failed; worker left in draining for orphan sweep/reconciler.",
-				"id", w.ID, "pod", podName, "error", err)
+				"id", w.ID, "worker_pod", podName, "error", err)
 			continue
 		}
 		_ = p.deleteWorkerRPCSecret(ctx, podName)
@@ -1972,7 +1972,7 @@ func (p *K8sWorkerPool) retireWorkerPod(id int, w *ManagedWorker) {
 	defer func() { <-p.retireSem }()
 
 	podName := p.workerPodName(w)
-	slog.Info("Retiring K8s worker.", "id", id, "pod", podName)
+	slog.Info("Retiring K8s worker.", "id", id, "worker_pod", podName)
 	if w.client != nil {
 		_ = w.client.Close()
 	}
@@ -1981,10 +1981,10 @@ func (p *K8sWorkerPool) retireWorkerPod(id int, w *ManagedWorker) {
 	if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 		GracePeriodSeconds: int64Ptr(10),
 	}); err != nil {
-		slog.Warn("Failed to delete worker pod.", "id", id, "pod", podName, "error", err)
+		slog.Warn("Failed to delete worker pod.", "id", id, "worker_pod", podName, "error", err)
 	}
 	if err := p.deleteWorkerRPCSecret(ctx, podName); err != nil {
-		slog.Warn("Failed to delete worker RPC secret.", "id", id, "pod", podName, "error", err)
+		slog.Warn("Failed to delete worker RPC secret.", "id", id, "worker_pod", podName, "error", err)
 	}
 }
 

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -292,6 +292,22 @@ func (sm *SessionManager) WorkerIDForPID(pid int32) int {
 	return -1
 }
 
+// WorkerPodNameForPID returns the K8s pod name of the worker hosting the
+// session, or "" if not found or not running on K8s.
+func (sm *SessionManager) WorkerPodNameForPID(pid int32) string {
+	sm.mu.RLock()
+	s, ok := sm.sessions[pid]
+	sm.mu.RUnlock()
+	if !ok {
+		return ""
+	}
+	worker, ok := sm.pool.Worker(s.WorkerID)
+	if !ok || worker == nil {
+		return ""
+	}
+	return worker.PodName()
+}
+
 // GetProgress returns the cached query progress for a session, or nil.
 func (sm *SessionManager) GetProgress(pid int32) *SessionProgress {
 	sm.mu.RLock()

--- a/controlplane/worker_rpc_security.go
+++ b/controlplane/worker_rpc_security.go
@@ -122,7 +122,7 @@ func (p *K8sWorkerPool) ensureWorkerRPCSecret(ctx context.Context, podName strin
 		if _, err := p.clientset.CoreV1().Secrets(p.namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
 			return "", fmt.Errorf("update secret %s with worker RPC data: %w", secretName, err)
 		}
-		slog.Info("Populated missing worker RPC secret data.", "name", secretName, "pod", podName)
+		slog.Info("Populated missing worker RPC secret data.", "name", secretName, "worker_pod", podName)
 		return secretName, nil
 	}
 	if !k8serrors.IsNotFound(err) {
@@ -151,7 +151,7 @@ func (p *K8sWorkerPool) ensureWorkerRPCSecret(ctx context.Context, podName strin
 	if _, err := p.clientset.CoreV1().Secrets(p.namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return "", fmt.Errorf("create secret %s: %w", secretName, err)
 	}
-	slog.Info("Created worker RPC secret.", "name", secretName, "pod", podName)
+	slog.Info("Created worker RPC secret.", "name", secretName, "worker_pod", podName)
 	return secretName, nil
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -180,6 +180,7 @@ type clientConn struct {
 	currentQuery    atomic.Value // stores string — current/last query (lock-free)
 	queryStart      atomic.Value // stores time.Time — when current query started (lock-free)
 	workerID        int          // control plane worker ID, -1 for standalone
+	workerPod       string       // K8s pod name of the worker, empty for standalone or in-process workers
 }
 
 // newTranspiler creates a transpiler configured for this connection.
@@ -487,20 +488,26 @@ func constraintErrorCode(msg string) string {
 	return "23000" // integrity_constraint_violation
 }
 
+// workerLogAttrs returns slog key/values for the worker that this connection
+// is bound to. Use with `slog.Xxx("...", args, c.workerLogAttrs()...)` so
+// every connection-attributable log line carries the same worker fields.
+func (c *clientConn) workerLogAttrs() []any {
+	return []any{"worker", c.workerID, "worker_pod", c.workerPod}
+}
+
 // logQueryError logs a query execution failure with additional context for
 // DuckLake-specific errors (transaction conflicts and metadata connection loss).
-func logQueryError(user, query string, err error) {
+func (c *clientConn) logQueryError(query string, err error) {
+	attrs := []any{"user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod}
 	if isDuckLakeTransactionConflict(err) {
-		slog.Warn("DuckLake transaction conflict.",
-			"user", user, "query", query, "error", err)
+		slog.Warn("DuckLake transaction conflict.", attrs...)
 		return
 	}
 	if isDuckLakeMetadataConnectionLost(err) {
-		slog.Warn("DuckLake metadata connection lost during transaction.",
-			"user", user, "query", query, "error", err)
+		slog.Warn("DuckLake metadata connection lost during transaction.", attrs...)
 		return
 	}
-	slog.Error("Query execution failed.", "user", user, "query", query, "error", err)
+	slog.Error("Query execution failed.", attrs...)
 }
 
 // isConnectionBroken checks if an error indicates a broken connection
@@ -554,12 +561,12 @@ func (c *clientConn) safeCleanupDB() {
 			cancel()
 			if err != nil {
 				slog.Warn("Failed to rollback transaction during cleanup.",
-					"user", c.username, "error", err)
+					"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			}
 		}
 		// Close returns the pinned *sql.Conn to the pool (does not close the DB).
 		if err := c.executor.Close(); err != nil {
-			slog.Warn("Failed to return connection to pool.", "user", c.username, "error", err)
+			slog.Warn("Failed to return connection to pool.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		}
 		c.server.releaseFileDB(c.username)
 		return
@@ -577,13 +584,13 @@ func (c *clientConn) safeCleanupDB() {
 		_, err := c.executor.ExecContext(ctx, "SELECT 1 FROM duckdb_tables() WHERE database_name = 'ducklake' LIMIT 1")
 		if err != nil {
 			slog.Warn("DuckLake connection unhealthy during cleanup, skipping SQL cleanup.",
-				"user", c.username, "error", err)
+				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			connHealthy = false
 		}
 	} else {
 		if err := c.executor.PingContext(ctx); err != nil {
 			slog.Warn("Database connection unhealthy during cleanup, skipping SQL cleanup.",
-				"user", c.username, "error", err)
+				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			connHealthy = false
 		}
 	}
@@ -598,7 +605,7 @@ func (c *clientConn) safeCleanupDB() {
 		cancel2()
 		if err != nil {
 			slog.Warn("Failed to rollback transaction during cleanup.",
-				"user", c.username, "error", err)
+				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			if isConnectionBroken(err) {
 				connHealthy = false
 			}
@@ -614,7 +621,7 @@ func (c *clientConn) safeCleanupDB() {
 		_, err := c.executor.ExecContext(ctx3, "USE memory")
 		cancel3()
 		if err != nil {
-			slog.Warn("Failed to switch to memory.", "user", c.username, "error", err)
+			slog.Warn("Failed to switch to memory.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			if isConnectionBroken(err) {
 				connHealthy = false
 			}
@@ -626,7 +633,7 @@ func (c *clientConn) safeCleanupDB() {
 				_, err := c.executor.ExecContext(ctxDelta, "DETACH delta")
 				cancelDelta()
 				if err != nil {
-					slog.Warn("Failed to detach Delta catalog.", "user", c.username, "error", err)
+					slog.Warn("Failed to detach Delta catalog.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				}
 			}
 
@@ -635,7 +642,7 @@ func (c *clientConn) safeCleanupDB() {
 				_, err := c.executor.ExecContext(ctx4, "DETACH ducklake")
 				cancel4()
 				if err != nil {
-					slog.Warn("Failed to detach DuckLake.", "user", c.username, "error", err)
+					slog.Warn("Failed to detach DuckLake.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				}
 			}
 		}
@@ -645,7 +652,7 @@ func (c *clientConn) safeCleanupDB() {
 	// If the connection is broken, this may still throw, but we've done our best
 	// to clean up the transaction state first.
 	if err := c.executor.Close(); err != nil {
-		slog.Warn("Failed to close database.", "user", c.username, "error", err)
+		slog.Warn("Failed to close database.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 	}
 }
 
@@ -1326,7 +1333,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 				if isQueryCancelled(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
-					logQueryError(c.username, query, err)
+					c.logQueryError(query, err)
 				}
 				c.sendError("ERROR", errCode, errMsg)
 				c.setTxError()
@@ -1402,7 +1409,7 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 			if isQueryCancelled(err) {
 				errMsg = "canceling statement due to user request"
 			} else {
-				logQueryError(c.username, query, err)
+				c.logQueryError(query, err)
 			}
 			c.sendError("ERROR", errCode, errMsg)
 			c.setTxError()
@@ -1516,7 +1523,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		if isQueryCancelled(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
-			logQueryError(c.username, query, err)
+			c.logQueryError(query, err)
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
@@ -1592,7 +1599,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			errMsg = "canceling statement due to user request"
 			c.sendError("ERROR", errCode, errMsg)
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "error", err)
+			slog.Error("Row iteration error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", errCode, errMsg)
 		}
 		c.setTxError()
@@ -1891,7 +1898,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 				if isQueryCancelled(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
-					logQueryError(c.username, executedQuery, err)
+					c.logQueryError(executedQuery, err)
 				}
 				c.sendError("ERROR", errCode, errMsg)
 				c.setTxError()
@@ -1941,7 +1948,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 		if isQueryCancelled(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
-			logQueryError(c.username, executedQuery, err)
+			c.logQueryError(executedQuery, err)
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
@@ -2035,7 +2042,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		slog.Debug("Multi-stmt setup.", "user", c.username, "step", i+1, "total", len(statements)-1, "stmt", stmt)
 		_, err := c.executor.Exec(stmt)
 		if err != nil {
-			slog.Error("Multi-stmt setup error.", "user", c.username, "query", stmt, "error", err)
+			slog.Error("Multi-stmt setup error.", "user", c.username, "query", stmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			// On error, still try to cleanup (best effort)
 			c.executeCleanup(cleanup)
@@ -2056,7 +2063,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		// Result-returning query: obtain cursor FIRST, cleanup SECOND, stream THIRD
 		rows, err := c.executor.Query(finalStmt)
 		if err != nil {
-			slog.Error("Multi-stmt final query error.", "user", c.username, "query", finalStmt, "error", err)
+			slog.Error("Multi-stmt final query error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -2077,7 +2084,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		// Non-result query (DML without RETURNING, DDL, etc.): execute then cleanup
 		result, err := c.executor.Exec(finalStmt)
 		if err != nil {
-			slog.Error("Multi-stmt final exec error.", "user", c.username, "query", finalStmt, "error", err)
+			slog.Error("Multi-stmt final exec error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -2105,7 +2112,7 @@ func (c *clientConn) executeCleanup(cleanup []string) {
 		_, err := c.executor.Exec(stmt)
 		if err != nil {
 			// Log but don't fail - cleanup is best effort
-			slog.Warn("Multi-stmt cleanup error (ignored).", "user", c.username, "error", err)
+			slog.Warn("Multi-stmt cleanup error (ignored).", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		}
 	}
 }
@@ -2137,7 +2144,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		slog.Debug("Multi-stmt-ext setup.", "user", c.username, "step", i+1, "total", len(statements)-1, "stmt", stmt)
 		_, err := c.executor.Exec(stmt, args...)
 		if err != nil {
-			slog.Error("Multi-stmt-ext setup error.", "user", c.username, "query", stmt, "error", err)
+			slog.Error("Multi-stmt-ext setup error.", "user", c.username, "query", stmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			// On error, still try to cleanup (best effort)
 			c.executeCleanup(cleanup)
@@ -2156,7 +2163,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		// Result-returning query: obtain cursor FIRST, cleanup SECOND, stream THIRD
 		rows, err := c.executor.Query(finalStmt, args...)
 		if err != nil {
-			slog.Error("Multi-stmt-ext final query error.", "user", c.username, "query", finalStmt, "error", err)
+			slog.Error("Multi-stmt-ext final query error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -2174,7 +2181,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		// Non-result query (DML without RETURNING, DDL, etc.): execute then cleanup
 		result, err := c.executor.Exec(finalStmt, args...)
 		if err != nil {
-			slog.Error("Multi-stmt-ext final exec error.", "user", c.username, "query", finalStmt, "error", err)
+			slog.Error("Multi-stmt-ext final exec error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -2197,7 +2204,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 	// Get column info
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err)
+		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		return
@@ -2205,7 +2212,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
-		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err)
+		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		return
@@ -2234,7 +2241,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 		}
 
 		if err := rows.Scan(valuePtrs...); err != nil {
-			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err)
+			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			return
@@ -2250,7 +2257,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 		if isQueryCancelled(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err)
+			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", "42000", err.Error())
 		}
 		c.setTxError()
@@ -2268,7 +2275,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 	// Get column info
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err)
+		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		_ = writeReadyForQuery(c.writer, c.txStatus)
@@ -2278,7 +2285,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
-		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err)
+		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		_ = writeReadyForQuery(c.writer, c.txStatus)
@@ -2307,7 +2314,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		}
 
 		if err := rows.Scan(valuePtrs...); err != nil {
-			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err)
+			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			_ = writeReadyForQuery(c.writer, c.txStatus)
@@ -2325,7 +2332,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		if isQueryCancelled(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err)
+			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", "42000", err.Error())
 		}
 		c.setTxError()
@@ -3257,7 +3264,7 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 	// Execute the query
 	rows, err := c.executor.Query(selectQuery)
 	if err != nil {
-		slog.Error("COPY TO query failed.", "user", c.username, "query", selectQuery, "error", err)
+		slog.Error("COPY TO query failed.", "user", c.username, "query", selectQuery, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
@@ -3269,7 +3276,7 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("COPY TO failed to get columns.", "user", c.username, "query", selectQuery, "error", err)
+		slog.Error("COPY TO failed to get columns.", "user", c.username, "query", selectQuery, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
@@ -3536,7 +3543,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	}
 	testRows, err := c.executor.Query(colQuery)
 	if err != nil {
-		slog.Error("COPY FROM table check failed.", "user", c.username, "table", tableName, "error", err)
+		slog.Error("COPY FROM table check failed.", "user", c.username, "table", tableName, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		errMsg := fmt.Sprintf("relation \"%s\" does not exist", tableName)
 		c.sendError("ERROR", "42P01", errMsg)
 		c.setTxError()
@@ -3580,7 +3587,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	// type conversions automatically and can load millions of rows in seconds.
 	tmpFile, err := os.CreateTemp("", "duckgres-copy-*.csv")
 	if err != nil {
-		slog.Error("COPY FROM STDIN failed to create temp file.", "user", c.username, "error", err)
+		slog.Error("COPY FROM STDIN failed to create temp file.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		errMsg := fmt.Sprintf("failed to create temp file: %v", err)
 		c.sendError("ERROR", "58000", errMsg)
 		c.setTxError()
@@ -3601,7 +3608,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	for {
 		msgType, body, err := readMessage(c.reader)
 		if err != nil {
-			slog.Error("COPY FROM STDIN error reading message.", "user", c.username, "error", err)
+			slog.Error("COPY FROM STDIN error reading message.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			_ = tmpFile.Close()
 			return err
 		}
@@ -3616,7 +3623,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			}
 			n, err := tmpFile.Write(body)
 			if err != nil {
-				slog.Error("COPY FROM STDIN failed to write to temp file.", "user", c.username, "error", err)
+				slog.Error("COPY FROM STDIN failed to write to temp file.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				_ = tmpFile.Close()
 				errMsg := fmt.Sprintf("failed to write to temp file: %v", err)
 				c.sendError("ERROR", "58000", errMsg)
@@ -3645,7 +3652,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 
 			result, err := c.executor.Exec(copySQL)
 			if err != nil {
-				slog.Error("COPY FROM STDIN DuckDB COPY failed.", "user", c.username, "error", err)
+				slog.Error("COPY FROM STDIN DuckDB COPY failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -3784,7 +3791,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			loadStart := time.Now()
 			rowCount, err := c.batchInsertRows(opts.TableName, opts.ColumnList, cols, rows)
 			if err != nil {
-				slog.Error("COPY FROM STDIN (BLOB fallback) INSERT failed.", "user", c.username, "error", err)
+				slog.Error("COPY FROM STDIN (BLOB fallback) INSERT failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -3849,7 +3856,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 	for {
 		msgType, body, err := readMessage(c.reader)
 		if err != nil {
-			slog.Error("COPY FROM STDIN binary: error reading message.", "user", c.username, "error", err)
+			slog.Error("COPY FROM STDIN binary: error reading message.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			return err
 		}
 
@@ -3862,7 +3869,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 			data := buf.Bytes()
 			rowCount, err := c.parseBinaryCopyAndInsert(data, opts.TableName, opts.ColumnList, cols, typeOIDs)
 			if err != nil {
-				slog.Error("COPY FROM STDIN binary: parse/insert failed.", "user", c.username, "error", err)
+				slog.Error("COPY FROM STDIN binary: parse/insert failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -5256,7 +5263,7 @@ func (c *clientConn) handleExecute(body []byte) {
 				if isQueryCancelled(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
-					logQueryError(c.username, convertedQuery, err)
+					c.logQueryError(convertedQuery, err)
 				}
 				c.sendError("ERROR", errCode, errMsg)
 				c.setTxError()
@@ -5302,7 +5309,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		if isQueryCancelled(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
-			logQueryError(c.username, convertedQuery, err)
+			c.logQueryError(convertedQuery, err)
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
@@ -5313,7 +5320,7 @@ func (c *clientConn) handleExecute(body []byte) {
 
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("Columns error.", "user", c.username, "error", err)
+		slog.Error("Columns error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, "42000", err.Error(), "extended")
@@ -5373,7 +5380,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			errMsg = "canceling statement due to user request"
 			c.sendError("ERROR", errCode, errMsg)
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "error", err)
+			slog.Error("Row iteration error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
 			c.sendError("ERROR", errCode, errMsg)
 		}
 		c.setTxError()

--- a/server/conn.go
+++ b/server/conn.go
@@ -488,13 +488,6 @@ func constraintErrorCode(msg string) string {
 	return "23000" // integrity_constraint_violation
 }
 
-// workerLogAttrs returns slog key/values for the worker that this connection
-// is bound to. Use with `slog.Xxx("...", args, c.workerLogAttrs()...)` so
-// every connection-attributable log line carries the same worker fields.
-func (c *clientConn) workerLogAttrs() []any {
-	return []any{"worker", c.workerID, "worker_pod", c.workerPod}
-}
-
 // logQueryError logs a query execution failure with additional context for
 // DuckLake-specific errors (transaction conflicts and metadata connection loss).
 func (c *clientConn) logQueryError(query string, err error) {

--- a/server/exports.go
+++ b/server/exports.go
@@ -47,7 +47,7 @@ func WriteBackendKeyData(w io.Writer, pid, secretKey int32) error {
 // the control plane worker. The returned value is opaque (*clientConn) but
 // can be used with SendInitialParams and RunMessageLoop.
 func NewClientConn(s *Server, conn net.Conn, reader *bufio.Reader, writer *bufio.Writer,
-	username, orgID, database, applicationName string, executor QueryExecutor, pid, secretKey int32, workerID int) *clientConn {
+	username, orgID, database, applicationName string, executor QueryExecutor, pid, secretKey int32, workerID int, workerPod string) *clientConn {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &clientConn{
@@ -71,6 +71,7 @@ func NewClientConn(s *Server, conn net.Conn, reader *bufio.Reader, writer *bufio
 		cancel:          cancel,
 		backendStart:    time.Now(),
 		workerID:        workerID,
+		workerPod:       workerPod,
 	}
 }
 


### PR DESCRIPTION
## What

Adds a `worker_pod` parsed field to session-level error/lifecycle logs so Loki queries can correlate a failing client session to the k8s worker pod that served it.

## Why

A recent `billing_temporal` incident logged `Current transaction is aborted` with no way to tell which worker pod was bound to the session — worker assignment was DEBUG-only.

After this:
```logql
{app="duckgres"} | logfmt | user="billing_temporal" | worker_pod="duckgres-worker-abc123"
```

## Changes

- `SessionManager.WorkerPodNameForPID` resolves the worker pod name (empty in standalone / in-process worker modes).
- `clientConn` carries `workerID` + `workerPod`, captured once at session creation — per-line cost is a string field read.
- `(c *clientConn).logQueryError` consolidates the three query-failure log shapes; all 33 `slog.Error/Warn` sites in `conn.go` carrying `c.username` now include both worker fields.
- In `controlplane/control.go`, worker fields are looked up right after `CreateSession` so all post-assignment failures (init metadata, detect catalog, ReadyForQuery, flush, message loop, disconnect) carry them.
- Renamed 16 existing slog `"pod"` → `"worker_pod"` in `controlplane/k8s_pool.go` and `controlplane/worker_rpc_security.go` to disambiguate from Loki's structured-metadata `pod` (which is the emitting pod, not the worker pod).

## Test plan

- [x] `go build` and `go vet` clean across server/, controlplane/, duckdbservice/
- [x] No tests reference the changed signatures
- [ ] After merge, confirm `worker_pod` populates on session errors in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)