### PR TITLE
feat(controlplane): SNI-based org routing with off / passthrough / enforce modes

### DIFF
--- a/config_resolution.go
+++ b/config_resolution.go
@@ -47,6 +47,8 @@ type configCLIInputs struct {
 	ConfigStoreConn             string
 	ConfigPollInterval          string
 	InternalSecret              string
+	SNIRoutingMode              string
+	ManagedHostnameSuffixes     string
 	WorkerBackend               string
 	K8sWorkerImage              string
 	K8sWorkerNamespace          string
@@ -97,6 +99,8 @@ type resolvedConfig struct {
 	ConfigStoreConn            string
 	ConfigPollInterval         time.Duration
 	InternalSecret             string
+	SNIRoutingMode             string
+	ManagedHostnameSuffixes    []string
 	DuckLakeDefaultSpecVersion string
 }
 
@@ -165,6 +169,8 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	var configStoreConn string
 	var configPollInterval time.Duration
 	var internalSecret string
+	var sniRoutingMode string
+	var managedHostnameSuffixes []string
 
 	if fileCfg != nil {
 		if fileCfg.Host != "" {
@@ -690,6 +696,12 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if v := getenv("DUCKGRES_INTERNAL_SECRET"); v != "" {
 		internalSecret = v
 	}
+	if v := getenv("DUCKGRES_SNI_ROUTING_MODE"); v != "" {
+		sniRoutingMode = v
+	}
+	if v := getenv("DUCKGRES_MANAGED_HOSTNAME_SUFFIXES"); v != "" {
+		managedHostnameSuffixes = splitAndTrim(v, ",")
+	}
 	if v := getenv("DUCKGRES_WORKER_BACKEND"); v != "" {
 		workerBackend = v
 	}
@@ -937,6 +949,12 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 	if cli.Set["internal-secret"] {
 		internalSecret = cli.InternalSecret
 	}
+	if cli.Set["sni-routing-mode"] {
+		sniRoutingMode = cli.SNIRoutingMode
+	}
+	if cli.Set["managed-hostname-suffixes"] {
+		managedHostnameSuffixes = splitAndTrim(cli.ManagedHostnameSuffixes, ",")
+	}
 	if cli.Set["worker-backend"] {
 		workerBackend = cli.WorkerBackend
 	}
@@ -1064,6 +1082,24 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		ConfigStoreConn:            configStoreConn,
 		ConfigPollInterval:         configPollInterval,
 		InternalSecret:             internalSecret,
+		SNIRoutingMode:             sniRoutingMode,
+		ManagedHostnameSuffixes:    managedHostnameSuffixes,
 		DuckLakeDefaultSpecVersion: cfg.DuckLake.SpecVersion,
 	}
+}
+
+// splitAndTrim splits s on sep, trims whitespace from each part, and drops
+// any empty resulting strings.
+func splitAndTrim(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	raw := strings.Split(s, sep)
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -64,6 +64,25 @@ type ControlPlaneConfig struct {
 	// When empty, a random secret is generated and logged at startup.
 	InternalSecret string
 
+	// SNIRoutingMode controls hostname-based org routing. Values:
+	//   "" or "off"   - SNI is ignored; legacy database-param routing only
+	//                   (default).
+	//   "passthrough" - SNI determines org when it matches a managed suffix;
+	//                   otherwise fall back to legacy with a warn log
+	//                   identifying the legacy caller.
+	//   "enforce"     - Reject connections whose SNI doesn't match a managed
+	//                   suffix.
+	// Only consulted in multi-tenant control-plane builds (kubernetes tag);
+	// other builds always behave as "off".
+	SNIRoutingMode string
+
+	// ManagedHostnameSuffixes lists DNS suffixes (each starting with a dot)
+	// for which the TLS hostname is authoritative for org routing. When the
+	// SNI matches one of these suffixes, the single-label prefix is treated
+	// as the org name (e.g. SNI "acme.dw.us.postwh.com" with suffix
+	// ".dw.us.postwh.com" resolves to org "acme").
+	ManagedHostnameSuffixes []string
+
 	// DuckLakeDefaultSpecVersion is the global default DuckLake spec version
 	// used for migration checks when an org doesn't specify an override.
 	DuckLakeDefaultSpecVersion string
@@ -626,8 +645,13 @@ func sessionCreationErrorResponse(err error) (code string, message string) {
 	}
 }
 
-// extractOrgFromSNI parses the org identifier from the TLS ServerName.
-// "acme.warehouse.posthog.com" with base "warehouse.posthog.com" returns ("acme", true).
+// SNI routing modes (values for ControlPlaneConfig.SNIRoutingMode).
+const (
+	SNIRoutingOff         = "off"         // ignore SNI entirely (default)
+	SNIRoutingPassthrough = "passthrough" // prefer SNI; fall back + log on miss
+	SNIRoutingEnforce     = "enforce"     // reject connections without a managed hostname
+)
+
 func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr()
 	slog.Info("Connection accepted.", "remote_addr", remoteAddr)
@@ -773,21 +797,58 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// User uniqueness is scoped to the org.
 	var orgID string
 	if cp.configStore != nil {
-		if database == "" {
+		// Resolve the effective database name based on SNI routing mode.
+		// "off"         - legacy: use the startup `database` param.
+		// "passthrough" - prefer SNI when it matches a managed suffix; fall
+		//                 back to `database` with a warn log otherwise.
+		// "enforce"     - require SNI to match a managed suffix; reject
+		//                 connections that don't.
+		sni := tlsConn.ConnectionState().ServerName
+		orgName, isManaged := cp.extractOrgFromSNI(sni)
+		effectiveDatabase := database
+		switch cp.cfg.SNIRoutingMode {
+		case SNIRoutingEnforce:
+			if !isManaged {
+				slog.Warn("Postgres connection rejected: SNI does not match a managed hostname.",
+					"sni", sni, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
+				_ = server.WriteErrorResponse(writer, "FATAL", "08006",
+					"this server requires connecting via a managed hostname (e.g. <org>.dw.<env>.postwh.com)")
+				_ = writer.Flush()
+				return
+			}
+			effectiveDatabase = orgName
+		case SNIRoutingPassthrough:
+			if isManaged {
+				effectiveDatabase = orgName
+				if database != "" && database != orgName {
+					slog.Info("Postgres SNI overrides database param.",
+						"sni", sni, "sni_org", orgName, "database_param", database, "remote_addr", remoteAddr)
+				}
+			} else if sni == "" {
+				slog.Warn("Postgres client connected without SNI; please migrate to a managed hostname.",
+					"remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
+			} else {
+				slog.Warn("Postgres client using legacy hostname; please migrate to a managed hostname.",
+					"sni", sni, "remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
+			}
+		default: // SNIRoutingOff or unset — legacy behavior, no SNI handling
+		}
+
+		if effectiveDatabase == "" {
 			slog.Warn("Connection rejected: no database specified.", "remote_addr", remoteAddr)
 			_ = server.WriteErrorResponse(writer, "FATAL", "28000", "database name is required")
 			_ = writer.Flush()
 			return
 		}
-		orgID = cp.configStore.ResolveDatabase(database)
+		orgID = cp.configStore.ResolveDatabase(effectiveDatabase)
 		if orgID == "" {
-			slog.Warn("Unknown database.", "database", database, "remote_addr", remoteAddr)
-			_ = server.WriteErrorResponse(writer, "FATAL", "3D000", fmt.Sprintf("database %q does not exist", database))
+			slog.Warn("Unknown database.", "database", effectiveDatabase, "remote_addr", remoteAddr)
+			_ = server.WriteErrorResponse(writer, "FATAL", "3D000", fmt.Sprintf("database %q does not exist", effectiveDatabase))
 			_ = writer.Flush()
 			return
 		}
 		if !cp.configStore.ValidateOrgUser(orgID, username, password) {
-			slog.Warn("Authentication failed.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr)
+			slog.Warn("Authentication failed.", "user", username, "org", orgID, "database", effectiveDatabase, "remote_addr", remoteAddr)
 			banned := server.RecordFailedAuthAttempt(cp.rateLimiter, remoteAddr)
 			if banned {
 				slog.Warn("IP banned after too many failed auth attempts.", "remote_addr", remoteAddr)
@@ -1449,6 +1510,82 @@ func (cp *ControlPlane) drainAfterUpgrade() {
 }
 
 // startFlightIngress creates and starts the Flight SQL ingress listener.
+// cpFlightCredentialValidator authenticates Flight SQL clients in
+// multi-tenant mode. It implements both flightsqlingress.CredentialValidator
+// (legacy: scan all orgs to find the user) and SNIAwareCredentialValidator
+// (preferred: derive org from SNI, scope to that org's users only).
+// Behavior is gated on cp.cfg.SNIRoutingMode just like the Postgres path.
+type cpFlightCredentialValidator struct {
+	cp          *ControlPlane
+	orgProvider *orgRoutedSessionProvider
+}
+
+func (v *cpFlightCredentialValidator) ValidateCredentials(username, password string) bool {
+	return v.ValidateCredentialsForSNI("", username, password)
+}
+
+func (v *cpFlightCredentialValidator) ValidateCredentialsForSNI(sni, username, password string) bool {
+	cp := v.cp
+	orgName, isManaged := cp.extractOrgFromSNI(sni)
+
+	switch cp.cfg.SNIRoutingMode {
+	case SNIRoutingEnforce:
+		if !isManaged {
+			slog.Warn("Flight auth rejected: SNI does not match a managed hostname.",
+				"sni", sni, "user", username)
+			return false
+		}
+		return v.authForOrgName(sni, orgName, username, password)
+	case SNIRoutingPassthrough:
+		if isManaged {
+			return v.authForOrgName(sni, orgName, username, password)
+		}
+		if sni == "" {
+			slog.Warn("Flight client connected without SNI; please migrate to a managed hostname.",
+				"user", username)
+		} else {
+			slog.Warn("Flight client using legacy hostname; please migrate to a managed hostname.",
+				"sni", sni, "user", username)
+		}
+		return v.authByScan(username, password)
+	default: // SNIRoutingOff or unset
+		return v.authByScan(username, password)
+	}
+}
+
+// authForOrgName validates (username, password) against a single org
+// resolved from the SNI-derived org name. Used by enforce / matched-passthrough.
+func (v *cpFlightCredentialValidator) authForOrgName(sni, orgName, username, password string) bool {
+	cp := v.cp
+	orgID := cp.configStore.ResolveDatabase(orgName)
+	if orgID == "" {
+		slog.Warn("Flight client SNI references unknown org.",
+			"sni", sni, "sni_org", orgName, "user", username)
+		return false
+	}
+	if !cp.configStore.ValidateOrgUser(orgID, username, password) {
+		return false
+	}
+	v.orgProvider.mu.Lock()
+	v.orgProvider.userOrg[username] = orgID
+	v.orgProvider.mu.Unlock()
+	return true
+}
+
+// authByScan is the legacy Flight auth path: scan all orgs to find a user
+// matching (username, password). First match wins.
+func (v *cpFlightCredentialValidator) authByScan(username, password string) bool {
+	cp := v.cp
+	orgID, ok := cp.configStore.FindAndValidateUser(username, password)
+	if !ok {
+		return false
+	}
+	v.orgProvider.mu.Lock()
+	v.orgProvider.userOrg[username] = orgID
+	v.orgProvider.mu.Unlock()
+	return true
+}
+
 func (cp *ControlPlane) startFlightIngress() {
 	if cp.cfg.FlightPort <= 0 {
 		return
@@ -1460,22 +1597,17 @@ func (cp *ControlPlane) startFlightIngress() {
 	switch {
 	case cp.configStore != nil && cp.orgRouter != nil:
 		// Multi-tenant: auth via config store, sessions routed per-org.
-		// Flight SQL doesn't have SNI, so we scan orgs to find the user.
+		// When the client connected via a managed hostname, the SNI is
+		// authoritative for org routing; otherwise we fall back to scanning
+		// orgs by (username, password) and log a warning so legacy callers
+		// can be migrated.
 		orgProvider := &orgRoutedSessionProvider{
 			orgRouter:   cp.orgRouter,
 			configStore: cp.configStore,
 			pidSession:  make(map[int32]flightOwnedSession),
 			userOrg:     make(map[string]string),
 		}
-		validator = flightsqlingress.FuncCredentialValidator(func(username, password string) bool {
-			orgID, ok := cp.configStore.FindAndValidateUser(username, password)
-			if ok {
-				orgProvider.mu.Lock()
-				orgProvider.userOrg[username] = orgID
-				orgProvider.mu.Unlock()
-			}
-			return ok
-		})
+		validator = &cpFlightCredentialValidator{cp: cp, orgProvider: orgProvider}
 		provider = orgProvider
 	case cp.sessions != nil:
 		// Single-tenant: static users map, single session manager.

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -857,6 +857,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			_ = writer.Flush()
 			return
 		}
+		// From here on, `database` reflects the SNI-resolved org. This is what
+		// gets passed to the worker as the logical database (drives the
+		// `current_database()` macro and pg_database view) so observability
+		// surfaces the actual routing decision rather than whatever the
+		// client typed in the startup packet.
+		database = effectiveDatabase
 	} else {
 		// Single-tenant: static users map
 		if !server.ValidateUserPassword(cp.cfg.Users, username, password) {

--- a/controlplane/sni_kubernetes.go
+++ b/controlplane/sni_kubernetes.go
@@ -1,0 +1,29 @@
+//go:build kubernetes
+
+package controlplane
+
+import "strings"
+
+// extractOrgFromSNI parses the org identifier from a TLS ServerName.
+// Returns the prefix as orgName when sni == "<orgName>" + one of the
+// configured ManagedHostnameSuffixes, where orgName is a single DNS label
+// (no dots). Returns ("", false) when sni is empty, doesn't match any
+// suffix, or has a multi-label prefix — caller should fall back to legacy
+// routing (in passthrough mode) or reject the connection (in enforce mode).
+//
+// Single-label restriction: the wildcard cert *.dw.{env}.postwh.com only
+// covers single-label prefixes, so a multi-label SNI ("evil.acme.dw...")
+// would have already failed TLS — but we keep the check as defense in depth.
+func (cp *ControlPlane) extractOrgFromSNI(sni string) (string, bool) {
+	for _, suffix := range cp.cfg.ManagedHostnameSuffixes {
+		if !strings.HasSuffix(sni, suffix) {
+			continue
+		}
+		prefix := strings.TrimSuffix(sni, suffix)
+		if prefix == "" || strings.ContainsRune(prefix, '.') {
+			continue
+		}
+		return prefix, true
+	}
+	return "", false
+}

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -1,0 +1,45 @@
+//go:build kubernetes
+
+package controlplane
+
+import "testing"
+
+func TestExtractOrgFromSNI(t *testing.T) {
+	cp := &ControlPlane{
+		cfg: ControlPlaneConfig{
+			ManagedHostnameSuffixes: []string{".dw.us.postwh.com", ".dw.dev.postwh.com"},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		sni       string
+		wantOrg   string
+		wantMatch bool
+	}{
+		{"empty SNI", "", "", false},
+		{"single-label match prod", "acme.dw.us.postwh.com", "acme", true},
+		{"single-label match dev", "betalabs.dw.dev.postwh.com", "betalabs", true},
+		{"unmanaged hostname", "duckgres-db.internal.ec2.us-east-1.dev.posthog.dev", "", false},
+		{"bare suffix only (no prefix)", ".dw.us.postwh.com", "", false},
+		{"multi-label prefix", "evil.acme.dw.us.postwh.com", "", false},
+		{"different domain entirely", "example.com", "", false},
+		{"prefix with hyphens is fine", "my-org.dw.us.postwh.com", "my-org", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotOrg, gotMatch := cp.extractOrgFromSNI(tc.sni)
+			if gotOrg != tc.wantOrg || gotMatch != tc.wantMatch {
+				t.Fatalf("extractOrgFromSNI(%q) = (%q, %v); want (%q, %v)",
+					tc.sni, gotOrg, gotMatch, tc.wantOrg, tc.wantMatch)
+			}
+		})
+	}
+}
+
+func TestExtractOrgFromSNIEmptySuffixes(t *testing.T) {
+	cp := &ControlPlane{cfg: ControlPlaneConfig{}}
+	if org, ok := cp.extractOrgFromSNI("acme.dw.us.postwh.com"); ok || org != "" {
+		t.Fatalf("with no suffixes configured, want (\"\", false); got (%q, %v)", org, ok)
+	}
+}

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -2,7 +2,12 @@
 
 package controlplane
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
 
 func TestExtractOrgFromSNI(t *testing.T) {
 	cp := &ControlPlane{
@@ -41,5 +46,214 @@ func TestExtractOrgFromSNIEmptySuffixes(t *testing.T) {
 	cp := &ControlPlane{cfg: ControlPlaneConfig{}}
 	if org, ok := cp.extractOrgFromSNI("acme.dw.us.postwh.com"); ok || org != "" {
 		t.Fatalf("with no suffixes configured, want (\"\", false); got (%q, %v)", org, ok)
+	}
+}
+
+// fakeConfigStore captures calls and lets each test choose what each method
+// returns. Only methods used by cpFlightCredentialValidator are exercised;
+// the rest are stubbed to fail loudly if hit.
+type fakeConfigStore struct {
+	resolveDatabase     func(string) string
+	validateOrgUser     func(orgID, user, pass string) bool
+	findAndValidateUser func(user, pass string) (string, bool)
+
+	resolveDatabaseCalls     int
+	validateOrgUserCalls     int
+	findAndValidateUserCalls int
+}
+
+func (f *fakeConfigStore) ResolveDatabase(database string) string {
+	f.resolveDatabaseCalls++
+	if f.resolveDatabase == nil {
+		return ""
+	}
+	return f.resolveDatabase(database)
+}
+func (f *fakeConfigStore) ValidateOrgUser(orgID, user, pass string) bool {
+	f.validateOrgUserCalls++
+	if f.validateOrgUser == nil {
+		return false
+	}
+	return f.validateOrgUser(orgID, user, pass)
+}
+func (f *fakeConfigStore) FindAndValidateUser(user, pass string) (string, bool) {
+	f.findAndValidateUserCalls++
+	if f.findAndValidateUser == nil {
+		return "", false
+	}
+	return f.findAndValidateUser(user, pass)
+}
+func (f *fakeConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
+	panic("UpsertFlightSessionRecord should not be called from SNI tests")
+}
+func (f *fakeConfigStore) GetFlightSessionRecord(string) (*configstore.FlightSessionRecord, error) {
+	panic("GetFlightSessionRecord should not be called from SNI tests")
+}
+func (f *fakeConfigStore) TouchFlightSessionRecord(string, time.Time) error {
+	panic("TouchFlightSessionRecord should not be called from SNI tests")
+}
+func (f *fakeConfigStore) CloseFlightSessionRecord(string, time.Time) error {
+	panic("CloseFlightSessionRecord should not be called from SNI tests")
+}
+
+func newFlightValidator(t *testing.T, mode string, store *fakeConfigStore) *cpFlightCredentialValidator {
+	t.Helper()
+	cp := &ControlPlane{
+		cfg: ControlPlaneConfig{
+			SNIRoutingMode:          mode,
+			ManagedHostnameSuffixes: []string{".dw.us.postwh.com"},
+		},
+		configStore: store,
+	}
+	provider := &orgRoutedSessionProvider{
+		userOrg: make(map[string]string),
+	}
+	return &cpFlightCredentialValidator{cp: cp, orgProvider: provider}
+}
+
+// TestFlightValidatorOff: SNI ignored entirely. Both legacy and new
+// hostnames go through FindAndValidateUser; ResolveDatabase / ValidateOrgUser
+// are never called regardless of SNI.
+func TestFlightValidatorOff(t *testing.T) {
+	store := &fakeConfigStore{
+		findAndValidateUser: func(user, pass string) (string, bool) {
+			return "org-by-scan", user == "alice" && pass == "secret"
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingOff, store)
+
+	cases := []struct {
+		name string
+		sni  string
+	}{
+		{"matching SNI", "acme.dw.us.postwh.com"},
+		{"empty SNI", ""},
+		{"unmanaged SNI", "duckgres-db.internal.ec2.us-east-1.dev.posthog.dev"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !v.ValidateCredentialsForSNI(tc.sni, "alice", "secret") {
+				t.Fatalf("expected valid credentials to pass in off mode")
+			}
+		})
+	}
+	if store.resolveDatabaseCalls != 0 || store.validateOrgUserCalls != 0 {
+		t.Fatalf("off mode must not consult ResolveDatabase / ValidateOrgUser; got %d / %d",
+			store.resolveDatabaseCalls, store.validateOrgUserCalls)
+	}
+	if store.findAndValidateUserCalls != len(cases) {
+		t.Fatalf("expected %d FindAndValidateUser calls, got %d",
+			len(cases), store.findAndValidateUserCalls)
+	}
+}
+
+// TestFlightValidatorPassthroughMatchedSNI: SNI matches, so we resolve and
+// validate against a single org, never falling through to the scan.
+func TestFlightValidatorPassthroughMatchedSNI(t *testing.T) {
+	store := &fakeConfigStore{
+		resolveDatabase: func(name string) string {
+			if name == "acme" {
+				return "org-acme"
+			}
+			return ""
+		},
+		validateOrgUser: func(orgID, user, pass string) bool {
+			return orgID == "org-acme" && user == "alice" && pass == "secret"
+		},
+		findAndValidateUser: func(string, string) (string, bool) {
+			t.Fatalf("FindAndValidateUser must not be called when SNI resolves an org")
+			return "", false
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingPassthrough, store)
+
+	if !v.ValidateCredentialsForSNI("acme.dw.us.postwh.com", "alice", "secret") {
+		t.Fatalf("expected SNI-resolved org with valid creds to pass")
+	}
+	if store.resolveDatabaseCalls != 1 || store.validateOrgUserCalls != 1 {
+		t.Fatalf("expected one ResolveDatabase + one ValidateOrgUser; got %d / %d",
+			store.resolveDatabaseCalls, store.validateOrgUserCalls)
+	}
+	if got := v.orgProvider.userOrg["alice"]; got != "org-acme" {
+		t.Fatalf("expected userOrg['alice'] = org-acme; got %q", got)
+	}
+}
+
+// TestFlightValidatorPassthroughUnknownOrg: SNI matches the suffix, but the
+// resolved org name doesn't exist in the config store. Must return false
+// WITHOUT falling through to the scan (a managed hostname is authoritative —
+// silently routing to a different org would defeat the boundary).
+func TestFlightValidatorPassthroughUnknownOrg(t *testing.T) {
+	store := &fakeConfigStore{
+		resolveDatabase: func(string) string { return "" }, // unknown
+		findAndValidateUser: func(string, string) (string, bool) {
+			t.Fatalf("FindAndValidateUser must not be called for unknown SNI org")
+			return "", false
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingPassthrough, store)
+
+	if v.ValidateCredentialsForSNI("ghostorg.dw.us.postwh.com", "alice", "secret") {
+		t.Fatalf("unknown SNI org must not authenticate")
+	}
+}
+
+// TestFlightValidatorPassthroughLegacyHostname: SNI doesn't match a managed
+// suffix → fall back to the scan path (with a warn log we don't assert here).
+func TestFlightValidatorPassthroughLegacyHostname(t *testing.T) {
+	store := &fakeConfigStore{
+		findAndValidateUser: func(user, pass string) (string, bool) {
+			return "org-from-scan", user == "alice" && pass == "secret"
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingPassthrough, store)
+
+	if !v.ValidateCredentialsForSNI("duckgres-db.internal.ec2.us-east-1.dev.posthog.dev", "alice", "secret") {
+		t.Fatalf("legacy hostname should pass via scan in passthrough mode")
+	}
+	if store.findAndValidateUserCalls != 1 {
+		t.Fatalf("expected scan fallback; got %d FindAndValidateUser calls", store.findAndValidateUserCalls)
+	}
+	if got := v.orgProvider.userOrg["alice"]; got != "org-from-scan" {
+		t.Fatalf("expected userOrg['alice'] = org-from-scan; got %q", got)
+	}
+}
+
+// TestFlightValidatorEnforceMatchedSNI: same as passthrough+matched.
+func TestFlightValidatorEnforceMatchedSNI(t *testing.T) {
+	store := &fakeConfigStore{
+		resolveDatabase: func(name string) string {
+			if name == "acme" {
+				return "org-acme"
+			}
+			return ""
+		},
+		validateOrgUser: func(orgID, user, pass string) bool {
+			return orgID == "org-acme" && user == "alice" && pass == "secret"
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingEnforce, store)
+	if !v.ValidateCredentialsForSNI("acme.dw.us.postwh.com", "alice", "secret") {
+		t.Fatalf("expected enforce+matched to pass")
+	}
+}
+
+// TestFlightValidatorEnforceLegacyHostnameRejected: the contract of enforce.
+// Even with otherwise-valid credentials, a non-managed hostname must fail
+// without hitting the scan.
+func TestFlightValidatorEnforceLegacyHostnameRejected(t *testing.T) {
+	store := &fakeConfigStore{
+		findAndValidateUser: func(string, string) (string, bool) {
+			t.Fatalf("FindAndValidateUser must not be called in enforce mode")
+			return "", false
+		},
+	}
+	v := newFlightValidator(t, SNIRoutingEnforce, store)
+
+	if v.ValidateCredentialsForSNI("", "alice", "secret") {
+		t.Fatalf("enforce must reject empty SNI")
+	}
+	if v.ValidateCredentialsForSNI("duckgres-db.internal.ec2.us-east-1.dev.posthog.dev", "alice", "secret") {
+		t.Fatalf("enforce must reject legacy hostname")
 	}
 }

--- a/controlplane/sni_other.go
+++ b/controlplane/sni_other.go
@@ -1,0 +1,12 @@
+//go:build !kubernetes
+
+package controlplane
+
+// extractOrgFromSNI is a no-op stub in non-kubernetes builds. The
+// multi-tenant control-plane code paths that consume this method are gated
+// at runtime on cp.configStore != nil, which is only true in the
+// kubernetes-tagged build, so this stub exists solely to satisfy the
+// compiler in single-tenant / local-dev builds.
+func (cp *ControlPlane) extractOrgFromSNI(_ string) (string, bool) {
+	return "", false
+}

--- a/k8s/kind/control-plane.yaml
+++ b/k8s/kind/control-plane.yaml
@@ -67,6 +67,10 @@ spec:
             - "/certs/server.key"
             - "--flight-port"
             - "8815"
+            - "--sni-routing-mode"
+            - "passthrough"
+            - "--managed-hostname-suffixes"
+            - ".dw.test.local"
             - "--config"
             - "/etc/duckgres/duckgres.yaml"
           ports:

--- a/main.go
+++ b/main.go
@@ -269,6 +269,8 @@ func main() {
 	configStore := flag.String("config-store", "", "PostgreSQL connection string for config store (env: DUCKGRES_CONFIG_STORE)")
 	configPollInterval := flag.String("config-poll-interval", "", "How often to poll config store for changes (default: 30s) (env: DUCKGRES_CONFIG_POLL_INTERVAL)")
 	internalSecret := flag.String("internal-secret", "", "Shared secret for API authentication (env: DUCKGRES_INTERNAL_SECRET)")
+	sniRoutingMode := flag.String("sni-routing-mode", "", "Hostname-based org routing: 'off' (default), 'passthrough' (prefer SNI, log legacy), 'enforce' (reject without managed hostname). Multi-tenant only. (env: DUCKGRES_SNI_ROUTING_MODE)")
+	managedHostnameSuffixes := flag.String("managed-hostname-suffixes", "", "Comma-separated DNS suffixes (each starting with '.') treated as authoritative for org routing, e.g. '.dw.us.postwh.com'. (env: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES)")
 
 	// ACME/Let's Encrypt flags
 	acmeDomain := flag.String("acme-domain", "", "Domain for ACME/Let's Encrypt certificate (env: DUCKGRES_ACME_DOMAIN)")
@@ -442,6 +444,8 @@ func main() {
 		ConfigStoreConn:             *configStore,
 		ConfigPollInterval:          *configPollInterval,
 		InternalSecret:              *internalSecret,
+		SNIRoutingMode:              *sniRoutingMode,
+		ManagedHostnameSuffixes:     *managedHostnameSuffixes,
 		WorkerBackend:               *workerBackend,
 		K8sWorkerImage:              *k8sWorkerImage,
 		K8sWorkerNamespace:          *k8sWorkerNamespace,
@@ -588,6 +592,8 @@ func main() {
 			ConfigStoreConn:            resolved.ConfigStoreConn,
 			ConfigPollInterval:         resolved.ConfigPollInterval,
 			InternalSecret:             resolved.InternalSecret,
+			SNIRoutingMode:             resolved.SNIRoutingMode,
+			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
 			DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
 			K8s: controlplane.K8sConfig{
 				WorkerImage:           resolved.K8sWorkerImage,

--- a/server/flightsqlingress/ingress.go
+++ b/server/flightsqlingress/ingress.go
@@ -26,6 +26,7 @@ import (
 	"github.com/posthog/duckgres/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -117,6 +118,15 @@ type durableSessionStoreProvider interface {
 // CredentialValidator abstracts username/password authentication.
 type CredentialValidator interface {
 	ValidateCredentials(username, password string) bool
+}
+
+// SNIAwareCredentialValidator is an optional extension. When the validator
+// implements it, the Flight handler passes the TLS SNI value alongside the
+// credentials so the validator can use the hostname for org routing
+// (instead of scanning all orgs to match a username/password pair).
+// Validators that don't implement this interface keep the legacy behavior.
+type SNIAwareCredentialValidator interface {
+	ValidateCredentialsForSNI(sni, username, password string) bool
 }
 
 // MapCredentialValidator wraps a static users map (single-tenant / tests).
@@ -341,7 +351,7 @@ func (h *ControlPlaneFlightSQLHandler) sessionFromContextWithTokenMetadata(ctx c
 	if sessionToken := incomingSessionToken(md); sessionToken != "" {
 		var authenticatedUsername string
 		if hasAuthorizationHeader(md) {
-			username, err := h.authenticateBasicCredentials(md, remoteAddr)
+			username, err := h.authenticateBasicCredentials(ctx, md, remoteAddr)
 			if err != nil {
 				return nil, err
 			}
@@ -382,7 +392,7 @@ func (h *ControlPlaneFlightSQLHandler) sessionFromContextWithTokenMetadata(ctx c
 		return nil, status.Error(codes.ResourceExhausted, "authentication rate limit exceeded")
 	}
 
-	username, err := h.authenticateBasicCredentials(md, remoteAddr)
+	username, err := h.authenticateBasicCredentials(ctx, md, remoteAddr)
 	if err != nil {
 		observeFlightIngressSessionOutcome("auth_failed")
 		return nil, err
@@ -404,7 +414,7 @@ func hasAuthorizationHeader(md metadata.MD) bool {
 	return len(md.Get("authorization")) > 0
 }
 
-func (h *ControlPlaneFlightSQLHandler) authenticateBasicCredentials(md metadata.MD, remoteAddr net.Addr) (string, error) {
+func (h *ControlPlaneFlightSQLHandler) authenticateBasicCredentials(ctx context.Context, md metadata.MD, remoteAddr net.Addr) (string, error) {
 	authHeaders := md.Get("authorization")
 	if len(authHeaders) == 0 {
 		server.RecordFailedAuthAttempt(h.rateLimiter, remoteAddr)
@@ -417,7 +427,17 @@ func (h *ControlPlaneFlightSQLHandler) authenticateBasicCredentials(md metadata.
 		return "", status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	if !h.validator.ValidateCredentials(username, password) {
+	// Hand SNI to the validator when it can use it for org routing. SNI is
+	// only available on real TLS connections; in tests (no TLS layer) the
+	// AuthInfo cast fails and the empty value falls through to the legacy
+	// CredentialValidator path.
+	ok := false
+	if sniAware, isSNIAware := h.validator.(SNIAwareCredentialValidator); isSNIAware {
+		ok = sniAware.ValidateCredentialsForSNI(sniFromContext(ctx), username, password)
+	} else {
+		ok = h.validator.ValidateCredentials(username, password)
+	}
+	if !ok {
 		banned := server.RecordFailedAuthAttempt(h.rateLimiter, remoteAddr)
 		if banned {
 			slog.Warn("Flight client IP banned after auth failures.", "remote_addr", remoteAddr)
@@ -426,6 +446,20 @@ func (h *ControlPlaneFlightSQLHandler) authenticateBasicCredentials(md metadata.
 	}
 	server.RecordSuccessfulAuthAttempt(h.rateLimiter, remoteAddr)
 	return username, nil
+}
+
+// sniFromContext returns the TLS ServerName the client sent, or "" if the
+// connection isn't TLS-terminated by this server (e.g. in unit tests).
+func sniFromContext(ctx context.Context) string {
+	pr, ok := peer.FromContext(ctx)
+	if !ok || pr == nil {
+		return ""
+	}
+	tlsInfo, ok := pr.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return ""
+	}
+	return tlsInfo.State.ServerName
 }
 
 func incomingSessionToken(md metadata.MD) string {

--- a/tests/k8s/sni_test.go
+++ b/tests/k8s/sni_test.go
@@ -1,0 +1,144 @@
+//go:build k8s_integration
+
+package k8s_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SNI integration tests rely on the kind manifest at k8s/kind/control-plane.yaml
+// running the control plane with --sni-routing-mode=passthrough and
+// --managed-hostname-suffixes=.dw.test.local. The seeded org has database
+// name "duckgres" with user postgres/postgres (k8s/kind/config-store.seed.sql).
+
+const (
+	sniManagedSuffix      = ".dw.test.local"
+	sniSeedDatabaseName   = "duckgres"
+	sniSeedUser           = "postgres"
+	sniSeedPassword       = "postgres"
+	sniBogusDatabaseParam = "ignored-by-test"
+)
+
+// connectWithSNI dials the control plane via port-forward, sets the TLS SNI
+// to the provided ServerName, and attempts a Postgres handshake with the
+// given database / user / password. Returns the error from the handshake or
+// nil on success. Caller must close the conn if non-nil.
+func connectWithSNI(ctx context.Context, sni, database, user, password string) (*pgx.Conn, error) {
+	if portForward == nil {
+		return nil, errors.New("port-forward not initialized")
+	}
+	pgPort := portForward.currentPort()
+	if pgPort == 0 {
+		return nil, errors.New("port-forward port not available")
+	}
+
+	cfg, err := pgx.ParseConfig(fmt.Sprintf(
+		"postgres://%s:%s@127.0.0.1:%d/%s?sslmode=require&connect_timeout=15",
+		user, password, pgPort, database,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	// Override SNI without changing the dial host. ServerName is the only
+	// knob the control plane reads; InsecureSkipVerify is fine because the
+	// kind cluster uses self-signed certs and port-forward already breaks
+	// the canonical hostname.
+	cfg.TLSConfig = &tls.Config{ServerName: sni, InsecureSkipVerify: true}
+
+	return pgx.ConnectConfig(ctx, cfg)
+}
+
+// TestSNI_MatchedHostnameOverridesDatabaseParam: the SNI resolves to the
+// seeded org regardless of what database name the client passes in the
+// startup packet. Proves SNI is authoritative when it matches a managed
+// suffix (passthrough mode).
+func TestSNI_MatchedHostnameOverridesDatabaseParam(t *testing.T) {
+	if err := waitForDBReady(60 * time.Second); err != nil {
+		t.Fatalf("waitForDBReady: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := connectWithSNI(ctx, sniSeedDatabaseName+sniManagedSuffix,
+		sniBogusDatabaseParam, sniSeedUser, sniSeedPassword)
+	if err != nil {
+		t.Fatalf("expected SNI=%q to override database param %q and authenticate; got: %v",
+			sniSeedDatabaseName+sniManagedSuffix, sniBogusDatabaseParam, err)
+	}
+	defer conn.Close(ctx)
+
+	var current string
+	if err := conn.QueryRow(ctx, "SELECT current_database()").Scan(&current); err != nil {
+		t.Fatalf("SELECT current_database(): %v", err)
+	}
+	if current != sniSeedDatabaseName {
+		t.Fatalf("SNI routing should land us in the SNI-named database; got %q, want %q",
+			current, sniSeedDatabaseName)
+	}
+}
+
+// TestSNI_MatchedHostnameWithUnknownOrg: SNI matches the managed suffix but
+// the prefix doesn't resolve to a real org. The control plane must reject
+// (no fallback to the database param) — silently routing to a different org
+// would defeat the boundary. Error code is 3D000 (database does not exist).
+func TestSNI_MatchedHostnameWithUnknownOrg(t *testing.T) {
+	if err := waitForDBReady(60 * time.Second); err != nil {
+		t.Fatalf("waitForDBReady: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := connectWithSNI(ctx, "ghostorg"+sniManagedSuffix,
+		sniSeedDatabaseName, sniSeedUser, sniSeedPassword)
+	if err == nil {
+		t.Fatalf("expected unknown SNI org to be rejected even with a valid database param")
+	}
+	if !strings.Contains(err.Error(), "ghostorg") || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected 'database \"ghostorg\" does not exist' error; got: %v", err)
+	}
+}
+
+// TestSNI_LegacyHostnameFallsThroughInPassthrough: with the kind setup in
+// passthrough mode, an SNI that doesn't match a managed suffix falls back
+// to the database startup param. The connection should succeed AND the
+// control plane should emit a warn log identifying the legacy caller.
+// (We can't easily assert the log line from here without log scraping; the
+// happy path itself proves the fallback works.)
+func TestSNI_LegacyHostnameFallsThroughInPassthrough(t *testing.T) {
+	if err := waitForDBReady(60 * time.Second); err != nil {
+		t.Fatalf("waitForDBReady: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Use 127.0.0.1 as the SNI (matches what lib/pq would send when
+	// connecting via port-forward without override). Definitely not on
+	// .dw.test.local, so it falls through to the legacy database-param
+	// path with a warn log.
+	conn, err := connectWithSNI(ctx, "127.0.0.1",
+		sniSeedDatabaseName, sniSeedUser, sniSeedPassword)
+	if err != nil {
+		t.Fatalf("legacy hostname should still authenticate via database-param fallback in passthrough mode; got: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	var current string
+	if err := conn.QueryRow(ctx, "SELECT current_database()").Scan(&current); err != nil {
+		t.Fatalf("SELECT current_database(): %v", err)
+	}
+	if current != sniSeedDatabaseName {
+		t.Fatalf("legacy fallback should land us in the param-named database; got %q, want %q",
+			current, sniSeedDatabaseName)
+	}
+}


### PR DESCRIPTION
## Summary

The customer-facing per-org hostnames (`*.dw.{env}.postwh.com`) and the in-VPC split-horizon zones are now in place ([infra #7793](https://github.com/PostHog/posthog-cloud-infra/pull/7793), [infra #7795](https://github.com/PostHog/posthog-cloud-infra/pull/7795)). This PR teaches the control plane to actually **use** the SNI as the authoritative org signal, with a config flag to roll the change out gradually.

## Three modes

New `SNIRoutingMode` config (CLI: `--sni-routing-mode`, env: `DUCKGRES_SNI_ROUTING_MODE`):

| Mode | Postgres / Flight behavior |
|---|---|
| `off` (default) | SNI ignored; legacy database-param / username-scan routing only. No new logs. |
| `passthrough` | Prefer SNI when it matches a managed suffix; otherwise fall back to legacy with a `warn` log identifying the legacy caller. Nothing is rejected. |
| `enforce` | SNI **must** match a managed suffix; connections that don't are rejected at auth time. |

`ManagedHostnameSuffixes` (CLI: `--managed-hostname-suffixes`, env: `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES`) is a comma-separated list of trailing DNS suffixes (e.g. `.dw.us.postwh.com`).

## Rollout plan (per follow-up charts PR)

| Env | Mode | Why |
|---|---|---|
| mw-dev | `enforce` | Force everyone onto the new pattern; if anything breaks we discover it in dev. |
| mw-prod-us | `passthrough` | Collect logs of legacy callers, migrate them, flip to enforce later. |

## Implementation notes

- **Build-tag gated.** The SNI implementation lives in `controlplane/sni_kubernetes.go` (`//go:build kubernetes`) with a stub at `controlplane/sni_other.go` (`//go:build !kubernetes`) that always returns `("", false)`. Non-kubernetes / single-tenant builds compile but have zero SNI runtime behavior.
- **Single-label prefixes only.** The wildcard cert `*.dw.{env}.postwh.com` only covers single-label prefixes, so a multi-label SNI (`evil.acme.dw...`) fails TLS before reaching us; the parser also rejects it as defense in depth.
- **Org name = database name.** `extractOrgFromSNI` returns the prefix; we then call `configStore.ResolveDatabase(prefix)` to map to `orgID`. So `acme.dw.us.postwh.com` requires that an org with database name `acme` exists.
- **Backward-compatible interface.** `flightsqlingress.CredentialValidator` is unchanged. A new optional `SNIAwareCredentialValidator` interface is what the SNI path implements; the handler dispatches based on type assertion. Existing tests using `MapCredentialValidator` keep working via the legacy method.
- **Postgres precedence:** SNI org wins over the `database` startup param when both are present (logged at info if they differ).
- **Flight SQL:** when SNI matches, we resolve a single org and validate against just that org's users — eliminates the username-collision-across-orgs ambiguity in `FindAndValidateUser`.

## Logs to watch in passthrough mode

- `"Postgres client connected without SNI; please migrate to a managed hostname."` — client didn't send SNI at all (libpq before TLS-13 ALPN, or a misconfigured driver).
- `"Postgres client using legacy hostname; please migrate to a managed hostname."` — connected to the public NLB hostname, the internal `duckgres-db.internal.ec2....` alias, or anything else not on `.dw.{env}.postwh.com`.
- Same two messages prefixed `"Flight client ..."` for the Flight SQL path.

Each log line includes `remote_addr`, `database`, `user`, and (for Postgres) `application_name`, so you can identify the caller and reach out.

## Test plan

- [x] Unit tests for `extractOrgFromSNI` covering empty / matching / non-matching / bare-suffix / multi-label / no-suffixes-configured.
- [x] `go build ./controlplane/... ./server/... .` clean (both with and without `-tags kubernetes`).
- [x] `go test -tags kubernetes ./controlplane/... ./server/flightsqlingress/...` passes (excluding pre-existing docker-compose dependent tests).
- [ ] Manual smoke (after image roll to mw-dev with `enforce`):
  - [ ] `psql "host=acme.dw.dev.postwh.com port=5432 dbname=anything"` works (SNI overrides dbname).
  - [ ] `psql "host=duckgres-db.internal.ec2.us-east-1.dev.posthog.dev port=5432"` is rejected with the new error message.
- [ ] Soak in mw-prod-us on `passthrough` for at least a week, watch logs for legacy callers, file migration tickets.