### PR TITLE
test(k8s): refuse to run unless kubeconfig points at a local kind cluster

### DIFF
--- a/tests/k8s/k8s_test.go
+++ b/tests/k8s/k8s_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -56,11 +58,22 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	// Build kubeconfig clientset
-	kubeconfig = envOr("DUCKGRES_K8S_TEST_KUBECONFIG", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
+	// SAFETY: require an explicit kubeconfig path. Falling back to
+	// ~/.kube/config is how this suite once ran against the live mw-dev
+	// cluster and wiped the duckgres namespace via setupMultiTenant's
+	// `kubectl delete namespace duckgres`. Always fail loudly instead.
+	kubeconfig = os.Getenv("DUCKGRES_K8S_TEST_KUBECONFIG")
+	if kubeconfig == "" {
+		log.Fatalf("DUCKGRES_K8S_TEST_KUBECONFIG is required. Run via `just test-k8s-integration` (which sets it to a kind kubeconfig) or set it explicitly. Refusing to fall back to the user's default kubeconfig because this suite is destructive.")
+	}
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		log.Fatalf("Failed to load kubeconfig: %v", err)
+	}
+	// SAFETY: confirm the resolved kubeconfig actually points at a local
+	// kind cluster before running anything destructive.
+	if err := requireLocalKindCluster(kubeconfig, config); err != nil {
+		log.Fatalf("REFUSING to run k8s integration tests: %v", err)
 	}
 	clientset, err = kubernetes.NewForConfig(config)
 	if err != nil {
@@ -467,6 +480,47 @@ func waitForPort(port int, timeout time.Duration) error {
 		time.Sleep(500 * time.Millisecond)
 	}
 	return fmt.Errorf("port %d not reachable after %s", port, timeout)
+}
+
+// requireLocalKindCluster errors out unless the resolved kubeconfig points
+// at a loopback API server AND the current-context name mentions "kind".
+// Two independent signals so a misconfigured local proxy can't masquerade
+// as kind, and so a kind kubeconfig that's been edited to reach a remote
+// cluster (somehow) is also rejected.
+//
+// Why it matters: setupMultiTenant() begins with
+//
+//	kubectl delete namespace duckgres --ignore-not-found --wait=true
+//
+// against the resolved kubeconfig. If that resolves to a real cluster, the
+// command silently succeeds and wipes production data. The loopback check
+// is the reliable fingerprint — managed clusters (EKS, GKE, AKS) always
+// expose a cloud DNS hostname; kind always exposes 127.0.0.1.
+func requireLocalKindCluster(kubeconfigPath string, cfg *rest.Config) error {
+	u, err := url.Parse(cfg.Host)
+	if err != nil {
+		return fmt.Errorf("parse API server URL %q: %w", cfg.Host, err)
+	}
+	host := u.Hostname()
+	switch host {
+	case "127.0.0.1", "localhost", "::1":
+		// loopback — kind cluster, proceed.
+	default:
+		return fmt.Errorf(
+			"API server at %q is not loopback. The k8s integration suite is destructive (it deletes the duckgres namespace at startup) and must only run against a local kind cluster. Run via `just test-k8s-integration` or point DUCKGRES_K8S_TEST_KUBECONFIG at a kind kubeconfig",
+			cfg.Host)
+	}
+
+	raw, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("load kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	if !strings.Contains(strings.ToLower(raw.CurrentContext), "kind") {
+		return fmt.Errorf(
+			"current-context %q in %s does not look like a kind cluster (expected name containing \"kind\")",
+			raw.CurrentContext, kubeconfigPath)
+	}
+	return nil
 }
 
 func commandEnv() []string {


### PR DESCRIPTION
## Summary

Two safety guardrails on the k8s_integration test suite after a near-miss where it ran against the live `posthog-mw-dev` cluster and wiped the `duckgres` namespace via `setupMultiTenant()`'s

```bash
kubectl delete namespace duckgres --ignore-not-found --wait=true
```

## Root cause

`tests/k8s/k8s_test.go` had a silent fallback to `~/.kube/config`:

```go
kubeconfig = envOr("DUCKGRES_K8S_TEST_KUBECONFIG", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
```

So a plain `go test -tags k8s_integration ./tests/k8s/...` (anything that bypasses the `just test-k8s-integration` recipe) targets whatever the user's current `kubectl` context happens to be. The justfile recipe sets `DUCKGRES_K8S_TEST_KUBECONFIG=/tmp/duckgres-kind-kubeconfig`, but nothing forced direct `go test` callers to do the same. First destructive command in setup wipes whatever namespace called `duckgres` exists in that context.

## Fix

1. **`DUCKGRES_K8S_TEST_KUBECONFIG` is now mandatory.** No more silent fallback. If unset → `log.Fatalf` with a clear message pointing at `just test-k8s-integration`.

2. **`requireLocalKindCluster()` validates two independent signals before any `kubectl` runs:**
   - The resolved API server `Host` is loopback (`127.0.0.1` / `localhost` / `::1`). Managed clusters (EKS/GKE/AKS) always expose a cloud DNS hostname; kind always exposes 127.0.0.1, so this is a reliable fingerprint.
   - The current-context name contains `\"kind\"`. Defense in depth against a misconfigured local proxy that happens to listen on loopback.
   - Either check failing → `log.Fatalf` with the actual host / context name in the message.

## What this catches

| Scenario | Before | After |
|---|---|---|
| `just test-k8s-integration` (env set, kind cluster up) | works | works |
| Direct `go test`, env unset, current ctx = kind | works (lucky) | refuses, asks for env var |
| Direct `go test`, env unset, current ctx = posthog-mw-dev | **wipes prod ns** | refuses, asks for env var |
| Env set to a non-kind kubeconfig (e.g. accidentally pasted EKS path) | runs anyway | refuses (loopback check) |
| Env set to a kind kubeconfig that's been edited to add a remote cluster | runs anyway | refuses (context-name check) |

## Test plan
- [ ] `just test-k8s-integration` still works end-to-end (CI).
- [ ] `go test -tags k8s_integration ./tests/k8s/...` without the env var → exits with the new fatal message, no kubectl invocation.
- [ ] Same with the env pointing at a non-loopback kubeconfig → exits with the loopback message.

## Out of scope (followups worth considering)

- Belt-and-suspenders: pass `--context=$ctx` explicitly to every `kubectl` shell-out, so a future bug in env-var propagation can't redirect destructive commands.
- Top-of-recipe sentry in `justfile` for `cleanup-multitenant-kind` / `run-multitenant-kind` that does the same loopback check before any `kubectl` runs.