### PR TITLE
feat(controlplane): show the configured managed hostname in SNI rejections

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -652,6 +652,27 @@ const (
 	SNIRoutingEnforce     = "enforce"     // reject connections without a managed hostname
 )
 
+// managedHostnameHint formats the configured ManagedHostnameSuffixes into a
+// "<org-id>.dw.<env>.postwh.com" string suitable for user-facing error
+// messages and migration warnings. The leading dot of each suffix is
+// preserved so the result is a syntactically valid hostname template.
+//
+// Examples:
+//   - [".dw.dev.postwh.com"]                       → "<org-id>.dw.dev.postwh.com"
+//   - [".dw.us.postwh.com", ".dw.eu.postwh.com"]   → "<org-id>.dw.us.postwh.com or <org-id>.dw.eu.postwh.com"
+//   - []                                           → "<org-id>.<managed-suffix>" (generic, indicates misconfig)
+func (cp *ControlPlane) managedHostnameHint() string {
+	suffixes := cp.cfg.ManagedHostnameSuffixes
+	if len(suffixes) == 0 {
+		return "<org-id>.<managed-suffix>"
+	}
+	parts := make([]string, len(suffixes))
+	for i, s := range suffixes {
+		parts[i] = "<org-id>" + s
+	}
+	return strings.Join(parts, " or ")
+}
+
 func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr()
 	slog.Info("Connection accepted.", "remote_addr", remoteAddr)
@@ -809,10 +830,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		switch cp.cfg.SNIRoutingMode {
 		case SNIRoutingEnforce:
 			if !isManaged {
+				hint := cp.managedHostnameHint()
 				slog.Warn("Postgres connection rejected: SNI does not match a managed hostname.",
-					"sni", sni, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
+					"sni", sni, "expected", hint, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
 				_ = server.WriteErrorResponse(writer, "FATAL", "08006",
-					"this server requires connecting via a managed hostname (e.g. <org>.dw.<env>.postwh.com)")
+					fmt.Sprintf("this server requires connecting via %s", hint))
 				_ = writer.Flush()
 				return
 			}
@@ -826,10 +848,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 				}
 			} else if sni == "" {
 				slog.Warn("Postgres client connected without SNI; please migrate to a managed hostname.",
-					"remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
+					"expected", cp.managedHostnameHint(), "remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
 			} else {
 				slog.Warn("Postgres client using legacy hostname; please migrate to a managed hostname.",
-					"sni", sni, "remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
+					"sni", sni, "expected", cp.managedHostnameHint(), "remote_addr", remoteAddr, "database", database, "user", username, "application_name", applicationName)
 			}
 		default: // SNIRoutingOff or unset — legacy behavior, no SNI handling
 		}
@@ -1538,7 +1560,7 @@ func (v *cpFlightCredentialValidator) ValidateCredentialsForSNI(sni, username, p
 	case SNIRoutingEnforce:
 		if !isManaged {
 			slog.Warn("Flight auth rejected: SNI does not match a managed hostname.",
-				"sni", sni, "user", username)
+				"sni", sni, "expected", cp.managedHostnameHint(), "user", username)
 			return false
 		}
 		return v.authForOrgName(sni, orgName, username, password)
@@ -1548,10 +1570,10 @@ func (v *cpFlightCredentialValidator) ValidateCredentialsForSNI(sni, username, p
 		}
 		if sni == "" {
 			slog.Warn("Flight client connected without SNI; please migrate to a managed hostname.",
-				"user", username)
+				"expected", cp.managedHostnameHint(), "user", username)
 		} else {
 			slog.Warn("Flight client using legacy hostname; please migrate to a managed hostname.",
-				"sni", sni, "user", username)
+				"sni", sni, "expected", cp.managedHostnameHint(), "user", username)
 		}
 		return v.authByScan(username, password)
 	default: // SNIRoutingOff or unset

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -49,6 +49,43 @@ func TestExtractOrgFromSNIEmptySuffixes(t *testing.T) {
 	}
 }
 
+func TestManagedHostnameHint(t *testing.T) {
+	cases := []struct {
+		name     string
+		suffixes []string
+		want     string
+	}{
+		{
+			name:     "single dev suffix",
+			suffixes: []string{".dw.dev.postwh.com"},
+			want:     "<org-id>.dw.dev.postwh.com",
+		},
+		{
+			name:     "single prod-us suffix",
+			suffixes: []string{".dw.us.postwh.com"},
+			want:     "<org-id>.dw.us.postwh.com",
+		},
+		{
+			name:     "multiple suffixes are listed with 'or'",
+			suffixes: []string{".dw.us.postwh.com", ".dw.eu.postwh.com"},
+			want:     "<org-id>.dw.us.postwh.com or <org-id>.dw.eu.postwh.com",
+		},
+		{
+			name:     "empty suffixes fall back to a generic placeholder",
+			suffixes: nil,
+			want:     "<org-id>.<managed-suffix>",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &ControlPlane{cfg: ControlPlaneConfig{ManagedHostnameSuffixes: tc.suffixes}}
+			if got := cp.managedHostnameHint(); got != tc.want {
+				t.Fatalf("managedHostnameHint() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // fakeConfigStore captures calls and lets each test choose what each method
 // returns. Only methods used by cpFlightCredentialValidator are exercised;
 // the rest are stubbed to fail loudly if hit.


### PR DESCRIPTION
## Summary

The Postgres FATAL on enforce-mode rejection used a hardcoded placeholder:

```
FATAL: this server requires connecting via a managed hostname (e.g. <org>.dw.<env>.postwh.com)
```

Customers had to figure out the env-specific suffix on their own. With this change the message is formatted from the live \`ManagedHostnameSuffixes\` config:

| Env | New message |
|---|---|
| mw-dev (\`.dw.dev.postwh.com\`) | \`this server requires connecting via <org-id>.dw.dev.postwh.com\` |
| mw-prod-us (\`.dw.us.postwh.com\`) | \`this server requires connecting via <org-id>.dw.us.postwh.com\` |
| Multiple suffixes | \`<org-id>.dw.us.postwh.com or <org-id>.dw.eu.postwh.com\` |
| Empty config (misconfig) | \`<org-id>.<managed-suffix>\` (generic placeholder so the message is still grammatical) |

## Bonus: expected hostname on legacy warn logs

The same hint is added as an \`expected\` key on the four migration-tracking warn logs (Postgres + Flight, no-SNI + legacy-hostname). Operators tailing the logs now see exactly what to point clients at:

```
WARN Postgres client using legacy hostname; please migrate to a managed hostname.
  sni=duckgres-db.internal.ec2.us-east-1.dev.posthog.dev
  expected=<org-id>.dw.dev.postwh.com
  remote_addr=10.x.x.x  database=acme  user=admin  application_name=django
```

## Implementation

- New helper \`(*ControlPlane).managedHostnameHint()\` formats the suffix list (or returns a generic fallback if unset). Unit-tested via \`TestManagedHostnameHint\` covering single / multiple / empty cases.
- Used in:
  - Postgres enforce-mode rejection (FATAL message + warn log)
  - Postgres passthrough no-SNI / legacy-hostname warn logs
  - Flight SQL enforce-mode warn log
  - Flight SQL passthrough no-SNI / legacy-hostname warn logs

## Test plan
- [x] \`TestManagedHostnameHint\` passes (single dev, single prod, multiple, empty).
- [x] Existing TestFlightValidator* still passes — the warn-log changes are visible in the test output (\`expected=<org-id>.dw.us.postwh.com\`).
- [ ] Manual: in mw-dev, connect via legacy hostname → confirm FATAL says \`<org-id>.dw.dev.postwh.com\` instead of the old \`<env>\` placeholder.