### PR TITLE
fix(controlplane): stamp warm idle workers with creating CP id to stop orphan churn

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2570,13 +2570,18 @@ func (p *K8sWorkerPool) workerRecordFor(id int, worker *ManagedWorker, ownerEpoc
 		record.ActivationStartedAt = &startedAt
 	}
 	if worker == nil {
-		if state == configstore.WorkerStateIdle {
-			record.OwnerCPInstanceID = ""
-		}
+		// OwnerCPInstanceID is already this CP's id from the struct literal
+		// above. Stamping warm/idle workers with the creating CP keeps
+		// last_heartbeat_at fresh via the CP heartbeat — without it, the
+		// orphan reconciler matches case (2) (NULLIF(owner_cp_instance_id,
+		// '') IS NULL AND last_heartbeat_at <= before) the moment the row
+		// crosses orphanGrace, so warm workers get reaped on a ~30s loop.
 		return record
 	}
 	record.PodName = p.workerPodName(worker)
-	record.OwnerCPInstanceID = worker.OwnerCPInstanceID()
+	if owner := worker.OwnerCPInstanceID(); owner != "" {
+		record.OwnerCPInstanceID = owner
+	}
 	if worker.image != "" {
 		record.Image = worker.image
 	}
@@ -2584,7 +2589,6 @@ func (p *K8sWorkerPool) workerRecordFor(id int, worker *ManagedWorker, ownerEpoc
 		record.OrgID = assignment.OrgID
 	}
 	if state == configstore.WorkerStateIdle {
-		record.OwnerCPInstanceID = ""
 		record.OrgID = ""
 	}
 	return record

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1499,6 +1499,46 @@ func TestK8sPoolActivateReservedWorkerPersistsActivatingThenHotWorkerRecord(t *t
 	}
 }
 
+// TestK8sPoolWorkerRecordForIdleStampsOwnerCPInstanceID guards against the
+// warm-pool churn loop. workerRecordFor used to clear OwnerCPInstanceID
+// whenever state==Idle, which left every freshly-spawned warm worker
+// matching ListOrphanedWorkers case (2) (NULLIF(owner_cp_instance_id, '') IS
+// NULL AND last_heartbeat_at <= before) the moment it crossed the orphan
+// grace. The janitor then retired it, the warm pool replenished, and the
+// loop repeated indefinitely. Stamping warm workers with the creating CP's
+// id makes case (1) handle them via the existing CP heartbeat instead.
+func TestK8sPoolWorkerRecordForIdleStampsOwnerCPInstanceID(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+
+	// worker == nil branch: spawn path before the in-memory ManagedWorker
+	// exists. Used by the warm-slot creation flow.
+	rec := pool.workerRecordFor(11, nil, 0, configstore.WorkerStateIdle, "", nil)
+	if rec.OwnerCPInstanceID != pool.cpInstanceID {
+		t.Fatalf("worker==nil idle: expected OwnerCPInstanceID %q, got %q", pool.cpInstanceID, rec.OwnerCPInstanceID)
+	}
+
+	// worker != nil branch with the worker already stamped: ManagedWorker
+	// owner is preserved.
+	w := &ManagedWorker{ID: 12, done: make(chan struct{})}
+	w.SetOwnerCPInstanceID(pool.cpInstanceID)
+	rec = pool.workerRecordFor(w.ID, w, 0, configstore.WorkerStateIdle, "", nil)
+	if rec.OwnerCPInstanceID != pool.cpInstanceID {
+		t.Fatalf("worker!=nil idle: expected OwnerCPInstanceID %q, got %q", pool.cpInstanceID, rec.OwnerCPInstanceID)
+	}
+	if rec.OrgID != "" {
+		t.Fatalf("idle workers must have empty OrgID, got %q", rec.OrgID)
+	}
+
+	// worker != nil branch with the worker not yet stamped (e.g. the spawn
+	// path's transition into Idle before SetOwnerCPInstanceID has run):
+	// fall back to this CP's id rather than persisting an empty owner.
+	w2 := &ManagedWorker{ID: 13, done: make(chan struct{})}
+	rec = pool.workerRecordFor(w2.ID, w2, 0, configstore.WorkerStateIdle, "", nil)
+	if rec.OwnerCPInstanceID != pool.cpInstanceID {
+		t.Fatalf("worker!=nil unstamped idle: expected OwnerCPInstanceID %q, got %q", pool.cpInstanceID, rec.OwnerCPInstanceID)
+	}
+}
+
 func TestK8sPoolRetireWorkerPersistsRetiredWorkerRecord(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	store := &captureRuntimeWorkerStore{}


### PR DESCRIPTION
## Summary

Stops the warm-pool churn loop where every freshly-spawned warm worker
was orphan-reaped within ~35s and immediately replaced.

## What was happening

`workerRecordFor` cleared `OwnerCPInstanceID` whenever `state==Idle`, so
warm workers were persisted with an empty owner. That row matched
`ListOrphanedWorkers` case (2):

```sql
OR (NULLIF(w.owner_cp_instance_id, '') IS NULL
    AND w.last_heartbeat_at <= $before)
```

…the moment it crossed the 30s orphan grace, because there is no
periodic heartbeat refresh for rows that just sit in `Idle` —
`persistWorkerRecord` is only called on lifecycle transitions. So the
janitor retired the worker, `reconcileWarmCapacity` replaced it, and the
loop ran continuously.

Observed in production: a steady ~500-600 retire+respawn cycles per
hour, every hour, even with zero client traffic. Side effects:
constant kube-scheduler / image-cache / cache-proxy load, transient
`failed to initialize session database metadata` errors during
spawn/orphan-reap races, and worker nodes that never go idle long
enough for Karpenter to consolidate.

## The fix

Persist warm workers with the creating CP's instance id. They then
match orphan SQL case (1) instead — bounded by the active CP's 5s
`cp_instances.last_heartbeat_at` heartbeat, which is already maintained
by `ControlPlaneRuntimeTracker`. If the CP genuinely dies, the existing
CP-expiry path flips its rows to `expired` and the 30s orphan grace
still applies as designed, so dead-CP cleanup is unchanged.

`OrgID` is still cleared on the idle transition (semantically correct
— an idle worker has no org assignment).

## Test plan

- [x] New `TestK8sPoolWorkerRecordForIdleStampsOwnerCPInstanceID` covers all three branches of `workerRecordFor`'s idle path: `worker==nil` (warm-slot creation), `worker!=nil` already stamped (active → idle), `worker!=nil` unstamped (spawn → idle before `SetOwnerCPInstanceID`).
- [x] Full `controlplane` package suite passes (with and without `-tags kubernetes`).
- [x] `controlplane/configstore` and `tests/configstore` `TestListOrphanedWorkers*` regression suite still passes — confirms case (2) cleanup still triggers when an ownerless+stale row does appear.
- [x] `just lint` clean (0 issues).
- [ ] Post-deploy: `kubectl logs -n duckgres <leader-cp> | grep "Janitor retiring orphaned workers"` rate should drop from ~10/min to ~0 in steady state.

## 🤖 Agent context

Discovered while QAing a deployed cluster end-to-end. Mechanism traced
from K8s events → leader CP logs (continuous orphan-retirement spam) →
`ListOrphanedWorkers` SQL → `workerRecordFor`'s `state==Idle` clears.
Empirically confirmed the rate is load-independent (steady for 12h
spanning periods of zero QA activity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)