### PR TITLE
feat(controlplane): persist STS expiry and refresh credentials before they go stale

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -160,16 +160,16 @@ func (GlobalConfig) TableName() string { return "duckgres_global_config" }
 // DuckLakeConfig is a singleton row (ID=1) for legacy cluster-wide DuckLake settings.
 // In multi-tenant mode, the managed-warehouse contract is the intended per-org source of truth.
 type DuckLakeConfig struct {
-	ID            uint      `gorm:"primaryKey" json:"-"`
-	MetadataStore string    `gorm:"size:1024" json:"metadata_store"`
-	ObjectStore   string    `gorm:"size:1024" json:"object_store"`
-	DataPath      string    `gorm:"size:1024" json:"data_path"`
-	S3Provider    string    `gorm:"size:64" json:"s3_provider"`
-	S3Endpoint    string    `gorm:"size:512" json:"s3_endpoint"`
-	S3AccessKey   string    `gorm:"size:255" json:"s3_access_key"`
-	S3SecretKey   string    `gorm:"size:255" json:"-"`
-	S3Region      string    `gorm:"size:64" json:"s3_region"`
-	S3UseSSL      bool      `json:"s3_use_ssl"`
+	ID                  uint      `gorm:"primaryKey" json:"-"`
+	MetadataStore       string    `gorm:"size:1024" json:"metadata_store"`
+	ObjectStore         string    `gorm:"size:1024" json:"object_store"`
+	DataPath            string    `gorm:"size:1024" json:"data_path"`
+	S3Provider          string    `gorm:"size:64" json:"s3_provider"`
+	S3Endpoint          string    `gorm:"size:512" json:"s3_endpoint"`
+	S3AccessKey         string    `gorm:"size:255" json:"s3_access_key"`
+	S3SecretKey         string    `gorm:"size:255" json:"-"`
+	S3Region            string    `gorm:"size:64" json:"s3_region"`
+	S3UseSSL            bool      `json:"s3_use_ssl"`
 	S3URLStyle          string    `gorm:"size:16" json:"s3_url_style"`
 	S3Chain             string    `gorm:"size:255" json:"s3_chain"`
 	S3Profile           string    `gorm:"size:255" json:"s3_profile"`
@@ -260,8 +260,17 @@ type WorkerRecord struct {
 	ActivationStartedAt *time.Time  `json:"activation_started_at,omitempty"`
 	LastHeartbeatAt     time.Time   `json:"last_heartbeat_at"`
 	RetireReason        string      `gorm:"size:64" json:"retire_reason"`
-	CreatedAt           time.Time   `json:"created_at"`
-	UpdatedAt           time.Time   `json:"updated_at"`
+	// S3CredentialsExpiresAt is when the most recent STS-brokered S3
+	// credentials currently active in the worker's DuckDB ducklake_s3 secret
+	// will expire. Stamped when the control plane mints creds (initial
+	// activation, takeover, scheduled refresh) and consulted by the
+	// credential refresh scheduler to pick workers nearing expiry. NULL on
+	// workers that haven't had creds issued yet (warm pool) and on legacy
+	// rows from before this column existed — both are treated as "due now"
+	// by the scheduler so they get refreshed eagerly.
+	S3CredentialsExpiresAt *time.Time `gorm:"index" json:"s3_credentials_expires_at,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              time.Time  `json:"updated_at"`
 }
 
 func (WorkerRecord) TableName() string { return "worker_records" }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -478,7 +478,7 @@ func (cs *ConfigStore) ExpireDrainingControlPlaneInstances(before time.Time) (in
 func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
 	if err := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "worker_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "updated_at"}),
+		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at"}),
 	}).Create(record).Error; err != nil {
 		return fmt.Errorf("upsert worker record: %w", err)
 	}
@@ -708,6 +708,106 @@ func (cs *ConfigStore) RetireOrphanWorker(workerID int, reason string) (bool, er
 		})
 	if result.Error != nil {
 		return false, fmt.Errorf("retire orphan worker %d: %w", workerID, result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
+// ListWorkersDueForCredentialRefresh returns workers owned by the given CP
+// whose S3 credentials are about to expire (or have already expired) and
+// therefore need a refresh. The cutoff defines "soon": typically the
+// scheduler passes (now + half the STS session duration), so a worker is
+// picked up well before its session token actually goes invalid.
+//
+// NULL s3_credentials_expires_at is treated as "due immediately". This
+// covers two cases: warm-pool rows that haven't been activated yet (these
+// have no creds, so the predicate is irrelevant — they're filtered out by
+// the state set anyway since neutral idle workers shouldn't carry creds),
+// and pre-migration rows that existed before this column was introduced
+// (these get refreshed eagerly so we converge to the new state).
+//
+// Only active states are considered: retired/lost/draining(-out) rows
+// don't need creds. We include `idle` deliberately — an idle worker that
+// belongs to an org (post-activation) still has live creds in DuckDB and
+// will need them on the next session.
+func (cs *ConfigStore) ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]WorkerRecord, error) {
+	var workers []WorkerRecord
+	credEligibleStates := []WorkerState{
+		WorkerStateIdle,
+		WorkerStateReserved,
+		WorkerStateActivating,
+		WorkerStateHot,
+		WorkerStateHotIdle,
+	}
+	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("owner_cp_instance_id = ?", ownerCPInstanceID).
+		Where("state IN ?", credEligibleStates).
+		// Org-bound rows only: a neutral warm row (org_id='') hasn't been
+		// activated, so it has no STS-brokered creds yet.
+		Where("org_id <> ''").
+		Where("s3_credentials_expires_at IS NULL OR s3_credentials_expires_at <= ?", cutoff).
+		Order("s3_credentials_expires_at ASC NULLS FIRST, worker_id ASC").
+		Find(&workers).Error
+	if err != nil {
+		return nil, fmt.Errorf("list workers due for credential refresh: %w", err)
+	}
+	return workers, nil
+}
+
+// BumpWorkerEpoch atomically increments owner_epoch on a worker we
+// already own, returning the new epoch. Used by the credential-refresh
+// scheduler before re-sending ActivateTenant with rotated STS creds: the
+// worker's reuseExistingActivation guard requires payload.OwnerEpoch >
+// current, so the scheduler bumps here, applies the new epoch on the
+// in-memory ManagedWorker, then dispatches the activation. If another CP
+// has already taken over the row (different owner_cp_instance_id or
+// already-bumped epoch), this returns ErrWorkerOwnerEpochMismatch and the
+// caller drops the in-flight refresh.
+func (cs *ConfigStore) BumpWorkerEpoch(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (int64, error) {
+	var newEpoch int64
+	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+			Where("worker_id = ? AND owner_cp_instance_id = ? AND owner_epoch = ?",
+				workerID, ownerCPInstanceID, expectedOwnerEpoch).
+			Updates(map[string]any{
+				"owner_epoch": gorm.Expr("owner_epoch + 1"),
+				"updated_at":  time.Now(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrWorkerOwnerEpochMismatch
+		}
+		var current WorkerRecord
+		if err := tx.Table(cs.runtimeTable(current.TableName())).
+			Where("worker_id = ?", workerID).
+			Take(&current).Error; err != nil {
+			return err
+		}
+		newEpoch = current.OwnerEpoch
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return newEpoch, nil
+}
+
+// MarkCredentialsRefreshed conditionally stamps a new S3 credential
+// expiration onto a worker row. The update only takes effect when the
+// caller is still the owner (same owner_cp_instance_id and owner_epoch);
+// any drift means another CP took over the worker and the caller's just-
+// minted creds are stale — we discard them rather than trample. Returns
+// true when the row was updated.
+func (cs *ConfigStore) MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error) {
+	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("worker_id = ? AND owner_cp_instance_id = ? AND owner_epoch = ?", workerID, ownerCPInstanceID, expectedOwnerEpoch).
+		Updates(map[string]any{
+			"s3_credentials_expires_at": expiresAt,
+			"updated_at":                time.Now(),
+		})
+	if result.Error != nil {
+		return false, fmt.Errorf("mark credentials refreshed for worker %d: %w", workerID, result.Error)
 	}
 	return result.RowsAffected > 0, nil
 }

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
-
 const (
 	janitorRetireReasonOrphaned        = "orphaned"
 	janitorRetireReasonStuckActivating = "stuck_activating"
@@ -22,6 +21,8 @@ type controlPlaneExpiryStore interface {
 	ExpireFlightSessionRecords(before time.Time) (int64, error)
 	ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error)
 	RetireHotIdleWorker(workerID int) (bool, error)
+	ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error)
+	MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error)
 }
 
 type ControlPlaneJanitor struct {
@@ -40,6 +41,7 @@ type ControlPlaneJanitor struct {
 	reconcileWarmCapacity         func()
 	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
+	refreshExpiringCredentials    func() // re-activates workers whose STS-brokered S3 credentials are about to expire (leader-only)
 }
 
 func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeout time.Duration) *ControlPlaneJanitor {
@@ -181,6 +183,17 @@ func (j *ControlPlaneJanitor) runOnce() {
 
 	if j.reconcileWarmCapacity != nil {
 		j.reconcileWarmCapacity()
+	}
+
+	// Refresh STS-brokered S3 credentials on workers we own that are
+	// approaching expiry. Runs every tick on the leader; the underlying
+	// query is cheap (indexed lookup on owner + expires_at) and only does
+	// work when there's actually a worker due. Keeps long-running queries
+	// healthy across the STS session-duration boundary by re-activating
+	// the worker via a side connection rather than blocking on the
+	// session's pinned *sql.Conn.
+	if j.refreshExpiringCredentials != nil {
+		j.refreshExpiringCredentials()
 	}
 }
 

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -84,6 +84,39 @@ func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(workerID int) (bool
 	return true, nil
 }
 
+func (s *captureControlPlaneExpiryStore) ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return nil, nil
+}
+
+func (s *captureControlPlaneExpiryStore) MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return true, nil
+}
+
+// TestControlPlaneJanitorRunCallsRefreshExpiringCredentials proves the
+// scheduler hook fires every tick on the leader. The actual STS / RPC
+// work is exercised by the postgres-backed and integration tests; here
+// we just verify wiring so a future regression in runOnce can't silently
+// drop the credential refresh.
+func TestControlPlaneJanitorRunCallsRefreshExpiringCredentials(t *testing.T) {
+	store := &captureControlPlaneExpiryStore{}
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.now = func() time.Time { return time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC) }
+
+	var calls int
+	janitor.refreshExpiringCredentials = func() { calls++ }
+
+	janitor.runOnce()
+	janitor.runOnce()
+
+	if calls != 2 {
+		t.Fatalf("expected refreshExpiringCredentials to fire on each runOnce; got %d calls in 2 ticks", calls)
+	}
+}
+
 func TestControlPlaneJanitorRunExpiresStaleInstances(t *testing.T) {
 	store := &captureControlPlaneExpiryStore{}
 	now := time.Date(2026, time.March, 26, 15, 0, 0, 0, time.UTC)

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -181,9 +181,9 @@ func SetupMultiTenant(
 		WorkerCPURequest:      cfg.K8s.WorkerCPURequest,
 		WorkerMemoryRequest:   cfg.K8s.WorkerMemoryRequest,
 		WorkerNodeSelector:    parseNodeSelector(cfg.K8s.WorkerNodeSelector),
-		WorkerTolerationKey:        cfg.K8s.WorkerTolerationKey,
+		WorkerTolerationKey:   cfg.K8s.WorkerTolerationKey,
 		WorkerTolerationValue: cfg.K8s.WorkerTolerationValue,
-		WorkerExclusiveNode:  cfg.K8s.WorkerExclusiveNode,
+		WorkerExclusiveNode:   cfg.K8s.WorkerExclusiveNode,
 		ResolveOrgConfig: func(orgID string) (*configstore.OrgConfig, error) {
 			snap := store.Snapshot()
 			if snap == nil {
@@ -264,6 +264,70 @@ func SetupMultiTenant(
 		defer cancel()
 		if n := router.sharedPool.cleanupOrphanedWorkerPods(ctx, 2*time.Minute); n > 0 {
 			slog.Info("Stranded worker pods reconciled.", "count", n)
+		}
+	}
+
+	// Scheduler-side activator: a single SharedWorkerActivator instance
+	// that the credential-refresh tick uses to re-broker STS sessions for
+	// any worker we own. It's distinct from the per-org activators created
+	// inside createOrgStack (those are wired into the worker-claim path);
+	// this one operates across all orgs by looking each up in the snapshot.
+	refreshActivator := NewSharedWorkerActivator(
+		router.sharedPool,
+		stsBroker,
+		cfg.DuckLakeDefaultSpecVersion,
+		func(orgID string) (*configstore.OrgConfig, error) {
+			snap := store.Snapshot()
+			if snap == nil {
+				return nil, fmt.Errorf("config snapshot unavailable for org %s", orgID)
+			}
+			org, ok := snap.Orgs[orgID]
+			if !ok {
+				return nil, fmt.Errorf("org %s not found in config snapshot", orgID)
+			}
+			return org, nil
+		},
+	)
+	if refreshActivator != nil {
+		refreshActivator.resolveDucklingStatus = resolveDucklingStatus
+	}
+
+	// Half the configured STS session duration: a worker due for refresh
+	// gets picked up well before its current session token actually goes
+	// stale, with a full half-life of slack to retry transient STS / RPC
+	// failures on subsequent ticks.
+	const credentialRefreshLookahead = stsSessionDuration / 2
+
+	janitor.refreshExpiringCredentials = func() {
+		if refreshActivator == nil {
+			return
+		}
+		cutoff := time.Now().Add(credentialRefreshLookahead)
+		due, err := store.ListWorkersDueForCredentialRefresh(cpInstanceID, cutoff)
+		if err != nil {
+			slog.Warn("Janitor failed to list workers due for credential refresh.", "error", err)
+			return
+		}
+		if len(due) == 0 {
+			return
+		}
+		slog.Info("Refreshing S3 credentials on workers nearing expiry.", "count", len(due))
+		for i := range due {
+			rec := due[i]
+			worker, ok := router.sharedPool.Worker(rec.WorkerID)
+			if !ok {
+				// Worker isn't in this CP's in-memory pool right now —
+				// could be mid-takeover, mid-retire, or just briefly
+				// dropped. Skip; if it comes back to us next tick we'll
+				// pick it up then.
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := refreshActivator.RefreshCredentials(ctx, worker); err != nil {
+				slog.Warn("Failed to refresh worker S3 credentials.",
+					"worker_id", rec.WorkerID, "org", rec.OrgID, "error", err)
+			}
+			cancel()
 		}
 	}
 	janitorLeader, err := NewJanitorLeaderManager(namespace, cpInstanceID, janitor)

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
@@ -26,6 +27,7 @@ type SharedWorkerActivator struct {
 	defaultNamespace       string
 	defaultSpecVersion     string
 	stsBroker              *STSBroker
+	runtimeStore           credentialExpiryStore
 	resolveOrgConfig       func(string) (*configstore.OrgConfig, error)
 	resolveDucklingStatus  func(context.Context, string) (*provisioner.DucklingStatus, error)
 	activateReservedWorker func(context.Context, *ManagedWorker, TenantActivationPayload) error
@@ -39,17 +41,35 @@ type SharedWorkerActivator struct {
 	migrationChecked sync.Map // orgID (string) → bool (needed)
 }
 
+// credentialExpiryStore is the slice of the runtime store the activator uses
+// to record when STS-brokered S3 credentials expire on a worker, and to
+// bump the owner epoch atomically when re-activating a worker for refresh.
+// Defined as an interface so tests can substitute a fake without standing
+// up Postgres.
+type credentialExpiryStore interface {
+	MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error)
+	BumpWorkerEpoch(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (int64, error)
+}
+
 type TenantActivationPayload struct {
 	OrgID     string                `json:"org_id"`
 	Usernames []string              `json:"usernames,omitempty"`
 	DuckLake  server.DuckLakeConfig `json:"ducklake"`
+	// S3CredentialsExpiresAt is the absolute expiration time of the STS
+	// credentials embedded in DuckLake.{S3AccessKey,S3SecretKey,S3SessionToken}.
+	// nil for non-STS payloads (config-store-driven warehouses use static
+	// credentials with no expiration). When set, the activator persists it
+	// onto the worker_records row after a successful activation so the
+	// credential refresh scheduler can pick the worker up before the token
+	// goes stale.
+	S3CredentialsExpiresAt *time.Time `json:"s3_credentials_expires_at,omitempty"`
 }
 
 func NewSharedWorkerActivator(shared *K8sWorkerPool, stsBroker *STSBroker, defaultSpecVersion string, resolveOrgConfig func(string) (*configstore.OrgConfig, error)) *SharedWorkerActivator {
 	if shared == nil {
 		return nil
 	}
-	return &SharedWorkerActivator{
+	a := &SharedWorkerActivator{
 		clientset:              shared.clientset,
 		defaultNamespace:       shared.namespace,
 		defaultSpecVersion:     defaultSpecVersion,
@@ -57,6 +77,15 @@ func NewSharedWorkerActivator(shared *K8sWorkerPool, stsBroker *STSBroker, defau
 		resolveOrgConfig:       resolveOrgConfig,
 		activateReservedWorker: shared.ActivateReservedWorker,
 	}
+	// The K8s pool already wraps the underlying configstore via its
+	// runtimeStore; the activator can borrow it for the credential-refresh
+	// stamp. Tests that construct a pool without a runtime store get a nil
+	// here, which is fine — the persist step is skipped (the stamp is best-
+	// effort; the next scheduler tick will retry).
+	if rs, ok := shared.runtimeStore.(credentialExpiryStore); ok {
+		a.runtimeStore = rs
+	}
+	return a
 }
 
 func (a *SharedWorkerActivator) ActivateReservedWorker(ctx context.Context, worker *ManagedWorker) error {
@@ -138,7 +167,97 @@ func (a *SharedWorkerActivator) ActivateReservedWorker(ctx context.Context, work
 		}
 	}
 
+	// Stamp the STS expiration onto the worker_records row so the
+	// credential-refresh scheduler can pick this worker up before its
+	// session token goes stale. Best-effort: a failure here doesn't fail
+	// the activation. The next scheduler tick will see a NULL or stale
+	// expiry and refresh inline.
+	if err == nil && payload.S3CredentialsExpiresAt != nil && a.runtimeStore != nil {
+		if _, mErr := a.runtimeStore.MarkCredentialsRefreshed(
+			worker.ID,
+			worker.OwnerCPInstanceID(),
+			worker.OwnerEpoch(),
+			*payload.S3CredentialsExpiresAt,
+		); mErr != nil {
+			slog.Warn("Failed to record S3 credential expiry on activation.",
+				"worker_id", worker.ID, "org", payload.OrgID, "error", mErr)
+		}
+	}
+
 	return err
+}
+
+// RefreshCredentials brokers a fresh STS session for the worker's org and
+// re-sends ActivateTenant so the worker's DuckDB ducklake_s3 secret picks
+// up the new (AccessKey, SecretKey, SessionToken). Used by the
+// credential-refresh scheduler to keep long-running workers alive across
+// the STS session-duration boundary without ever touching a session's
+// pinned *sql.Conn.
+//
+// The owner_epoch is bumped atomically in the runtime store before the
+// RPC; the in-memory ManagedWorker is updated to match, then the
+// ActivateTenant RPC carries the new epoch so the worker's
+// reuseExistingActivation guard accepts the payload. On RPC success the
+// worker's in-memory state is replaced and MarkCredentialsRefreshed
+// stamps the new expiry. Any of these steps can fail — a failure aborts
+// without trampling the worker's existing (still-valid-for-now) creds,
+// and the next scheduler tick retries.
+func (a *SharedWorkerActivator) RefreshCredentials(ctx context.Context, worker *ManagedWorker) error {
+	if worker == nil {
+		return fmt.Errorf("worker is required for credential refresh")
+	}
+	if a.runtimeStore == nil {
+		return fmt.Errorf("credential refresh requires a runtime store")
+	}
+	state := worker.SharedState()
+	if state.Assignment == nil || state.Assignment.OrgID == "" {
+		return fmt.Errorf("worker %d has no org assignment to refresh credentials for", worker.ID)
+	}
+
+	org, err := a.lookupOrgConfig(state.Assignment.OrgID)
+	if err != nil {
+		return err
+	}
+	payload, err := a.BuildActivationRequest(ctx, org, state.Assignment)
+	if err != nil {
+		return err
+	}
+	if payload.S3CredentialsExpiresAt == nil {
+		// Static-cred warehouses don't need refresh — defensive guard so we
+		// don't incorrectly mark expiry on rows that genuinely have none.
+		return nil
+	}
+
+	currentEpoch := worker.OwnerEpoch()
+	cpInstanceID := worker.OwnerCPInstanceID()
+	newEpoch, err := a.runtimeStore.BumpWorkerEpoch(worker.ID, cpInstanceID, currentEpoch)
+	if err != nil {
+		return fmt.Errorf("bump owner epoch for refresh: %w", err)
+	}
+	worker.SetOwnerEpoch(newEpoch)
+
+	rpcPayload := server.WorkerActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{
+			WorkerID:     worker.ID,
+			OwnerEpoch:   newEpoch,
+			CPInstanceID: cpInstanceID,
+		},
+		OrgID:    payload.OrgID,
+		DuckLake: payload.DuckLake,
+	}
+	if err := worker.ActivateTenant(ctx, rpcPayload); err != nil {
+		return fmt.Errorf("activate tenant for refresh: %w", err)
+	}
+
+	if _, err := a.runtimeStore.MarkCredentialsRefreshed(
+		worker.ID, cpInstanceID, newEpoch, *payload.S3CredentialsExpiresAt,
+	); err != nil {
+		// The worker has new creds in DuckDB; we just couldn't record the
+		// new expiry. Next tick will see a stale expiry and refresh again.
+		slog.Warn("Failed to record refreshed credential expiry.",
+			"worker_id", worker.ID, "org", payload.OrgID, "error", err)
+	}
+	return nil
 }
 
 func (a *SharedWorkerActivator) BuildActivationRequest(ctx context.Context, org *configstore.OrgConfig, assignment *WorkerAssignment) (TenantActivationPayload, error) {
@@ -153,17 +272,20 @@ func (a *SharedWorkerActivator) BuildActivationRequest(ctx context.Context, org 
 	}
 
 	var dl server.DuckLakeConfig
+	var expiresAt *time.Time
 	var err error
 
 	// Try reading infrastructure details from the Duckling CR first (Crossplane-provisioned).
 	// Fall back to the config store path for non-Crossplane warehouses (manual seed, MinIO, etc.).
 	if a.resolveDucklingStatus != nil {
-		dl, err = a.buildDuckLakeConfigFromDuckling(ctx, assignment.OrgID)
+		dl, expiresAt, err = a.buildDuckLakeConfigFromDuckling(ctx, assignment.OrgID)
 		if err != nil {
 			slog.Warn("Duckling CR activation failed, falling back to config store.", "org", assignment.OrgID, "error", err)
 		}
 	}
 	if a.resolveDucklingStatus == nil || err != nil {
+		// Config-store warehouses use static creds (no STS), so expiresAt
+		// stays nil and the credential refresh scheduler skips them.
 		dl, err = a.buildDuckLakeConfigFromConfigStore(ctx, org.Warehouse)
 	}
 	if err != nil {
@@ -187,29 +309,32 @@ func (a *SharedWorkerActivator) BuildActivationRequest(ctx context.Context, org 
 	dl.SpecVersion = targetSpecVersion
 
 	return TenantActivationPayload{
-		OrgID:     assignment.OrgID,
-		Usernames: usernames,
-		DuckLake:  dl,
+		OrgID:                  assignment.OrgID,
+		Usernames:              usernames,
+		DuckLake:               dl,
+		S3CredentialsExpiresAt: expiresAt,
 	}, nil
 }
 
 // buildDuckLakeConfigFromDuckling reads all infrastructure details from the Duckling CR
 // and uses STS to broker S3 credentials. Used for Crossplane-provisioned ducklings.
-func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Context, orgID string) (server.DuckLakeConfig, error) {
+// The returned *time.Time is the STS credentials' expiration; nil for paths that
+// don't broker temporary credentials.
+func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Context, orgID string) (server.DuckLakeConfig, *time.Time, error) {
 	status, err := a.resolveDucklingStatus(ctx, orgID)
 	if err != nil {
-		return server.DuckLakeConfig{}, fmt.Errorf("resolve duckling CR %q: %w", orgID, err)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("resolve duckling CR %q: %w", orgID, err)
 	}
 	if status.MetadataStore.Password == "" {
-		return server.DuckLakeConfig{}, fmt.Errorf("duckling CR %q has no metadata store password", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no metadata store password", orgID)
 	}
 	if status.DataStore.BucketName == "" {
-		return server.DuckLakeConfig{}, fmt.Errorf("duckling CR %q has no data store bucket", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no data store bucket", orgID)
 	}
 
 	host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, orgID)
 	if err != nil {
-		return server.DuckLakeConfig{}, err
+		return server.DuckLakeConfig{}, nil, err
 	}
 
 	dl := server.DuckLakeConfig{
@@ -229,21 +354,22 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 
 	// Broker S3 credentials via STS AssumeRole
 	if status.IAMRoleARN == "" {
-		return server.DuckLakeConfig{}, fmt.Errorf("duckling CR %q has no IAM role ARN for shared warm activation", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no IAM role ARN for shared warm activation", orgID)
 	}
 	if a.stsBroker == nil {
-		return server.DuckLakeConfig{}, fmt.Errorf("STS broker is required for shared warm activation for org %q", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("STS broker is required for shared warm activation for org %q", orgID)
 	}
 	creds, err := a.stsBroker.AssumeRole(ctx, status.IAMRoleARN)
 	if err != nil {
-		return server.DuckLakeConfig{}, fmt.Errorf("STS AssumeRole for org %q: %w", orgID, err)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("STS AssumeRole for org %q: %w", orgID, err)
 	}
 	dl.S3Provider = "config"
 	dl.S3AccessKey = creds.AccessKeyID
 	dl.S3SecretKey = creds.SecretAccessKey
 	dl.S3SessionToken = creds.SessionToken
 
-	return dl, nil
+	expiresAt := creds.Expiration
+	return dl, &expiresAt, nil
 }
 
 func ducklingMetadataStoreAddress(status *provisioner.DucklingStatus, orgID string) (host string, port int, viaPgBouncer bool, err error) {
@@ -287,8 +413,8 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.C
 			metadataPassword,
 			warehouse.MetadataStore.DatabaseName,
 		),
-		ObjectStore: buildManagedWarehouseObjectStore(warehouse.S3),
-		S3Endpoint:  warehouse.S3.Endpoint,
+		ObjectStore:         buildManagedWarehouseObjectStore(warehouse.S3),
+		S3Endpoint:          warehouse.S3.Endpoint,
 		S3Region:            warehouse.S3.Region,
 		S3UseSSL:            warehouse.S3.UseSSL,
 		S3URLStyle:          warehouse.S3.URLStyle,

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -459,11 +459,32 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		return nil, cfgErr
 	}
 
-	stop := server.StartCredentialRefresh(conn, cfg.DuckLake, func() bool {
-		session.mu.Lock()
-		defer session.mu.Unlock()
-		return len(session.txns) > 0
-	})
+	// In shared-warm (multi-tenant) mode the control plane drives credential
+	// refresh by re-activating the worker with a freshly-brokered STS payload
+	// before the current creds expire (see controlplane/janitor scheduler +
+	// activator.RefreshActivationCredentials). Running the in-process ticker
+	// here is wrong for that mode for two reasons:
+	//   1. It executes on this session's pinned *sql.Conn, so it serializes
+	//      behind any in-flight user query. A long query can starve the
+	//      ticker until creds have already expired.
+	//   2. For provider="config" with a session token (the multi-tenant
+	//      activation shape) the ticker falls into the `else` branch and
+	//      replaces the org's STS-brokered secret with a credential_chain
+	//      one. DuckDB's built-in chain doesn't see EKS Pod Identity, so
+	//      the resulting secret can't actually authenticate against the
+	//      org's bucket — quietly downgrading correctness.
+	// The single-tenant standalone path still benefits from the ticker (no
+	// control plane to drive refreshes), so we only skip it in shared-warm.
+	var stop func()
+	if p.sharedWarmMode {
+		stop = func() {}
+	} else {
+		stop = server.StartCredentialRefresh(conn, cfg.DuckLake, func() bool {
+			session.mu.Lock()
+			defer session.mu.Unlock()
+			return len(session.txns) > 0
+		})
+	}
 
 	p.mu.Lock()
 	p.reserved--

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -874,6 +874,229 @@ func TestRetireOrphanWorkerNoOpOnTerminalStates(t *testing.T) {
 	}
 }
 
+// TestListWorkersDueForCredentialRefreshScopesByOwner: only workers owned
+// by the calling CP are returned. Workers owned by another CP — even if
+// their creds have expired — are that CP's problem.
+func TestListWorkersDueForCredentialRefreshScopesByOwner(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-1 * time.Hour)
+
+	mine := &configstore.WorkerRecord{
+		WorkerID:               1,
+		PodName:                "duckgres-worker-1",
+		State:                  configstore.WorkerStateHot,
+		OrgID:                  "acme",
+		OwnerCPInstanceID:      "cp-me:boot-a",
+		OwnerEpoch:             3,
+		LastHeartbeatAt:        now,
+		S3CredentialsExpiresAt: &expired,
+	}
+	other := &configstore.WorkerRecord{
+		WorkerID:               2,
+		PodName:                "duckgres-worker-2",
+		State:                  configstore.WorkerStateHot,
+		OrgID:                  "acme",
+		OwnerCPInstanceID:      "cp-other:boot-b",
+		OwnerEpoch:             5,
+		LastHeartbeatAt:        now,
+		S3CredentialsExpiresAt: &expired,
+	}
+	for _, w := range []*configstore.WorkerRecord{mine, other} {
+		if err := store.UpsertWorkerRecord(w); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", w.WorkerID, err)
+		}
+	}
+
+	due, err := store.ListWorkersDueForCredentialRefresh("cp-me:boot-a", now)
+	if err != nil {
+		t.Fatalf("ListWorkersDueForCredentialRefresh: %v", err)
+	}
+	if len(due) != 1 || due[0].WorkerID != 1 {
+		t.Fatalf("expected only worker 1 (mine), got %#v", due)
+	}
+}
+
+// TestListWorkersDueForCredentialRefreshTreatsNullAsDue: a row with
+// s3_credentials_expires_at = NULL needs immediate refresh. This covers
+// pre-migration rows and any path where activation forgot to stamp.
+func TestListWorkersDueForCredentialRefreshTreatsNullAsDue(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          7,
+		PodName:           "duckgres-worker-7",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "acme",
+		OwnerCPInstanceID: "cp-me:boot-a",
+		OwnerEpoch:        1,
+		LastHeartbeatAt:   now,
+		// S3CredentialsExpiresAt deliberately left nil
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+
+	due, err := store.ListWorkersDueForCredentialRefresh("cp-me:boot-a", now)
+	if err != nil {
+		t.Fatalf("ListWorkersDueForCredentialRefresh: %v", err)
+	}
+	if len(due) != 1 || due[0].WorkerID != 7 {
+		t.Fatalf("expected worker 7 (NULL expiry treated as due), got %#v", due)
+	}
+}
+
+// TestListWorkersDueForCredentialRefreshSkipsHealthyAndNeutral:
+//   - Healthy row (expiry comfortably in the future): not returned.
+//   - Neutral warm row (org_id=”): not returned regardless of expiry.
+//     A pre-activation worker has no STS creds to refresh.
+//   - Terminal row (retired): not returned.
+func TestListWorkersDueForCredentialRefreshSkipsHealthyAndNeutral(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+	farFuture := now.Add(2 * time.Hour)
+	pastDue := now.Add(-1 * time.Minute)
+
+	rows := []*configstore.WorkerRecord{
+		{
+			WorkerID: 10, PodName: "duckgres-worker-10",
+			State: configstore.WorkerStateHot, OrgID: "acme",
+			OwnerCPInstanceID: "cp-me:boot-a", OwnerEpoch: 1,
+			LastHeartbeatAt: now, S3CredentialsExpiresAt: &farFuture,
+		},
+		{
+			WorkerID: 11, PodName: "duckgres-worker-11",
+			State: configstore.WorkerStateIdle, OrgID: "",
+			OwnerCPInstanceID: "cp-me:boot-a", OwnerEpoch: 1,
+			LastHeartbeatAt: now, S3CredentialsExpiresAt: &pastDue,
+		},
+		{
+			WorkerID: 12, PodName: "duckgres-worker-12",
+			State: configstore.WorkerStateRetired, OrgID: "acme",
+			OwnerCPInstanceID: "cp-me:boot-a", OwnerEpoch: 1,
+			LastHeartbeatAt: now, S3CredentialsExpiresAt: &pastDue,
+			RetireReason: "normal",
+		},
+	}
+	for _, w := range rows {
+		if err := store.UpsertWorkerRecord(w); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", w.WorkerID, err)
+		}
+	}
+
+	due, err := store.ListWorkersDueForCredentialRefresh("cp-me:boot-a", now)
+	if err != nil {
+		t.Fatalf("ListWorkersDueForCredentialRefresh: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("expected no rows returned (healthy / neutral / terminal), got %#v", due)
+	}
+}
+
+// TestMarkCredentialsRefreshedSucceeds: happy path — same owner, same
+// epoch, write goes through and returns true.
+func TestMarkCredentialsRefreshedSucceeds(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+	oldExpiry := now.Add(-1 * time.Minute)
+	newExpiry := now.Add(1 * time.Hour)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:               20,
+		PodName:                "duckgres-worker-20",
+		State:                  configstore.WorkerStateHot,
+		OrgID:                  "acme",
+		OwnerCPInstanceID:      "cp-me:boot-a",
+		OwnerEpoch:             3,
+		LastHeartbeatAt:        now,
+		S3CredentialsExpiresAt: &oldExpiry,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+
+	updated, err := store.MarkCredentialsRefreshed(20, "cp-me:boot-a", 3, newExpiry)
+	if err != nil {
+		t.Fatalf("MarkCredentialsRefreshed: %v", err)
+	}
+	if !updated {
+		t.Fatalf("expected MarkCredentialsRefreshed to update the row, got false")
+	}
+
+	persisted, err := store.GetWorkerRecord(20)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.S3CredentialsExpiresAt == nil || !persisted.S3CredentialsExpiresAt.Equal(newExpiry) {
+		t.Fatalf("expected expires_at = %v, got %v", newExpiry, persisted.S3CredentialsExpiresAt)
+	}
+}
+
+// TestMarkCredentialsRefreshedFailsOnEpochMismatch: another CP took over
+// the worker (bumped owner_epoch), and our just-minted creds are stale —
+// the conditional update returns false rather than overwriting.
+func TestMarkCredentialsRefreshedFailsOnEpochMismatch(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+	oldExpiry := now.Add(-1 * time.Minute)
+	originalExpiryRow := oldExpiry
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:               21,
+		PodName:                "duckgres-worker-21",
+		State:                  configstore.WorkerStateHot,
+		OrgID:                  "acme",
+		OwnerCPInstanceID:      "cp-me:boot-a",
+		OwnerEpoch:             7, // newer than the caller will pass
+		LastHeartbeatAt:        now,
+		S3CredentialsExpiresAt: &originalExpiryRow,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+
+	updated, err := store.MarkCredentialsRefreshed(21, "cp-me:boot-a", 6, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("MarkCredentialsRefreshed: %v", err)
+	}
+	if updated {
+		t.Fatalf("expected stale-epoch caller to be rejected, got updated=true")
+	}
+
+	persisted, err := store.GetWorkerRecord(21)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.S3CredentialsExpiresAt == nil || !persisted.S3CredentialsExpiresAt.Equal(originalExpiryRow) {
+		t.Fatalf("expected expires_at to be unchanged after epoch mismatch, got %v", persisted.S3CredentialsExpiresAt)
+	}
+}
+
+// TestMarkCredentialsRefreshedFailsOnOwnerMismatch: another CP took
+// ownership entirely. Same conditional-update protection.
+func TestMarkCredentialsRefreshedFailsOnOwnerMismatch(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          22,
+		PodName:           "duckgres-worker-22",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "acme",
+		OwnerCPInstanceID: "cp-other:boot-b",
+		OwnerEpoch:        2,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+
+	updated, err := store.MarkCredentialsRefreshed(22, "cp-me:boot-a", 2, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("MarkCredentialsRefreshed: %v", err)
+	}
+	if updated {
+		t.Fatalf("expected wrong-owner caller to be rejected, got updated=true")
+	}
+}
+
 func TestExpireFlightSessionRecordsPostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.March, 27, 15, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

Closes the credential-expiration bug behind the `ExpiredToken` errors observed in mw-prod-us. The control plane now persists the STS session expiration on each worker row and runs a leader-side scheduler that refreshes the worker's DuckDB `ducklake_s3` secret before the token actually expires. The fix is invariant across all the modes the user called out: many small queries, one super-long query, hot-idle, plain-idle.

Pairs with PostHog/duckgres#470 (cache-proxy status passthrough), which made this bug debuggable in the first place.

## What was broken

1. The worker-side `StartCredentialRefresh` ticker ran on the session's **pinned `*sql.Conn`**, so any in-flight user query serialized the refresh — a query > 1h could starve refresh past the STS session boundary.
2. The same ticker had **no `case \"config\"` branch**: in multi-tenant mode (provider=`config` with explicit STS session token), it fell into the `else` and called `buildCredentialChainSecret`, swapping the org's working STS-brokered secret for a `credential_chain` one DuckDB's built-in chain can't satisfy on EKS Pod Identity.

## What changes

### Schema
`worker_records` gets `s3_credentials_expires_at TIMESTAMPTZ NULL` (indexed). Set by the activator after STS AssumeRole; consulted by the scheduler to pick workers near expiry. NULL is treated as \"due now\" so unstamped / pre-migration rows get refreshed eagerly.

### Configstore
- `ListWorkersDueForCredentialRefresh(ownerCPInstanceID, cutoff)` — workers we own in active org-bound states whose creds expire by `cutoff` (or have NULL expiry).
- `MarkCredentialsRefreshed(workerID, ownerCPInstanceID, expectedOwnerEpoch, expiresAt)` — conditional UPDATE; only stamps when ownership still matches.
- `BumpWorkerEpoch(workerID, ownerCPInstanceID, expectedOwnerEpoch)` — atomic +1 on `owner_epoch` for the refresh path. The worker's `reuseExistingActivation` guard requires `payload.OwnerEpoch > current`, so we bump before re-sending ActivateTenant.

Postgres-backed regression coverage on all three: owner-scoping, NULL-as-due, healthy/neutral/terminal exclusions, conditional-update failure modes (epoch-mismatch, owner-mismatch).

### Worker
Skip `StartCredentialRefresh` in shared-warm mode. The standalone single-tenant path keeps the ticker (no control plane to drive refreshes there). Inline comment explains both failure modes the ticker was hitting in multi-tenant.

### Activator
- `TenantActivationPayload.S3CredentialsExpiresAt` carries the STS `Expiration` through from `buildDuckLakeConfigFromDuckling`. Static-cred warehouses (config-store path) leave it nil and the scheduler skips them.
- `ActivateReservedWorker` stamps the expiry post-activation via `runtimeStore.MarkCredentialsRefreshed`. Best-effort.
- New `RefreshCredentials(ctx, worker)` brokers fresh STS creds, bumps `owner_epoch`, sends `ActivateTenant` with the new payload, and stamps the new expiry. The worker's existing `reuseExistingActivation` path (`activation.go:162`) already calls `RefreshS3Secret` on a *separate* `*sql.DB` connection — so the refresh applies even while a long query holds the per-session pinned `*sql.Conn`.

### Janitor scheduler
New `refreshExpiringCredentials` lambda (leader-only). Every tick: list workers with creds expiring within `stsSessionDuration / 2` (= 30 min today), resolve the in-memory `*ManagedWorker`, dispatch `activator.RefreshCredentials`. State lives in `worker_records`, so a CP failover doesn't lose the schedule — the next leader queries the same column. Workers not in the leader's local pool are skipped silently and picked up on the next tick.

## How it satisfies the four invariants

| Mode | What happens |
|---|---|
| Many small queries | Refresh fires every ~5s on the leader; bumps epoch + re-activates well before the 1h boundary. |
| One super-long query | Refresh runs on a *side* connection (`*sql.DB`-level, not the session's pinned `*sql.Conn`), so it doesn't wait for the query. The new DuckDB secret is process-global and applies to subsequent S3 calls. |
| Hot-idle | Same scheduler; hot-idle is one of the eligible states. |
| Idle (org-bound) | Same scheduler; `idle` with `org_id != ''` is eligible. Neutral warm rows (`org_id=''`) are excluded — they have no STS creds. |

## Tests

- 6 new postgres-backed configstore tests in `tests/configstore/runtime_store_postgres_test.go`.
- New janitor-side wiring test (`TestControlPlaneJanitorRunCallsRefreshExpiringCredentials`) ensuring `runOnce` always invokes the lambda — guards against a future regression where the hook is silently dropped.
- All existing tests pass with and without `-tags kubernetes`.
- I can't run the postgres-backed tests locally (no Docker on this machine); CI exercises them.

## Operational

- mw-prod-us: after rolling this image, the leader CP starts populating `s3_credentials_expires_at` on every active worker. Existing workers (NULL expiry) are refreshed eagerly on the next tick. The next 1h-boundary worth of `ExpiredToken` errors should drop to zero. Watch:
  ```
  kubectl logs -n duckgres -l app.kubernetes.io/name=duckgres | grep -E 'Refreshing S3 credentials|Failed to refresh worker S3'
  ```
- Half-life lookahead (30 min for a 1h STS) leaves 30 minutes of slack for transient STS or RPC failures across multiple ticks.
- A future PR can wire the same expiry into a Grafana panel: `min(s3_credentials_expires_at - now)` is the cushion before the next refresh has to succeed.

## Out of scope (followups worth doing)

- Inline refresh on the *takeover* path: a CP claiming an orphan or hot-idle worker reads `s3_credentials_expires_at` and refreshes immediately if `< now + 5 min`, rather than waiting for the next scheduler tick.
- Surface `duckgres_worker_credentials_expires_at_seconds` as a gauge metric per worker so alerting doesn't depend on log-grep.