### PR TITLE
fix(controlplane): refresh STS credentials per CP, not only on janitor leader

### DIFF
--- a/controlplane/credential_refresh_scheduler.go
+++ b/controlplane/credential_refresh_scheduler.go
@@ -1,0 +1,95 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// credentialRefreshScheduleStore is the slice of the runtime store the
+// scheduler depends on. Defined narrowly so unit tests can fake it without
+// pulling in the full store.
+type credentialRefreshScheduleStore interface {
+	ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error)
+}
+
+// credentialRefreshScheduler re-brokers STS-backed S3 credentials for the
+// workers this CP currently owns. It runs as a per-CP background goroutine,
+// not under the janitor's leader lease — credential expiry is per-worker and
+// doesn't coordinate across CPs, so each CP must refresh its own workers
+// regardless of whether it holds the janitor leader lease.
+type credentialRefreshScheduler struct {
+	interval       time.Duration
+	lookahead      time.Duration
+	cpInstanceID   string
+	store          credentialRefreshScheduleStore
+	workerByID     func(int) (*ManagedWorker, bool)
+	refresh        func(ctx context.Context, w *ManagedWorker) error
+	refreshTimeout time.Duration
+	now            func() time.Time
+}
+
+func (s *credentialRefreshScheduler) Run(ctx context.Context) {
+	if s == nil || s.store == nil || s.workerByID == nil || s.refresh == nil {
+		return
+	}
+	if s.interval <= 0 {
+		s.interval = 5 * time.Second
+	}
+	if s.refreshTimeout <= 0 {
+		s.refreshTimeout = 30 * time.Second
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+
+	s.tick(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *credentialRefreshScheduler) tick(ctx context.Context) {
+	cutoff := s.now().Add(s.lookahead)
+	due, err := s.store.ListWorkersDueForCredentialRefresh(s.cpInstanceID, cutoff)
+	if err != nil {
+		slog.Warn("Credential refresh scheduler failed to list due workers.", "error", err)
+		return
+	}
+	if len(due) == 0 {
+		return
+	}
+	slog.Info("Refreshing S3 credentials on workers nearing expiry.", "count", len(due))
+	for i := range due {
+		rec := due[i]
+		worker, ok := s.workerByID(rec.WorkerID)
+		if !ok {
+			// Worker isn't in this CP's in-memory pool right now — could be
+			// mid-takeover, mid-retire, or just briefly dropped. The DB row
+			// still says we own it; if it comes back to us next tick we'll
+			// pick it up then. Until then, the worker either retires or its
+			// owner_cp_instance_id changes and the next tick's query won't
+			// return it.
+			continue
+		}
+		refreshCtx, cancel := context.WithTimeout(ctx, s.refreshTimeout)
+		if err := s.refresh(refreshCtx, worker); err != nil {
+			slog.Warn("Failed to refresh worker S3 credentials.",
+				"worker_id", rec.WorkerID, "org", rec.OrgID, "error", err)
+		}
+		cancel()
+	}
+}

--- a/controlplane/credential_refresh_scheduler_test.go
+++ b/controlplane/credential_refresh_scheduler_test.go
@@ -1,0 +1,206 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+type fakeCredRefreshStore struct {
+	mu      sync.Mutex
+	due     []configstore.WorkerRecord
+	listErr error
+	calls   int
+	cutoffs []time.Time
+	owners  []string
+}
+
+func (f *fakeCredRefreshStore) ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.cutoffs = append(f.cutoffs, cutoff)
+	f.owners = append(f.owners, ownerCPInstanceID)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]configstore.WorkerRecord, len(f.due))
+	copy(out, f.due)
+	return out, nil
+}
+
+// TestCredentialRefreshSchedulerTickRefreshesDueWorkers proves the scheduler
+// looks each due worker up in the local pool and fires the refresh hook for
+// each one it finds.
+func TestCredentialRefreshSchedulerTickRefreshesDueWorkers(t *testing.T) {
+	w1 := &ManagedWorker{ID: 101}
+	w2 := &ManagedWorker{ID: 102}
+	store := &fakeCredRefreshStore{
+		due: []configstore.WorkerRecord{
+			{WorkerID: 101, OrgID: "org-a"},
+			{WorkerID: 102, OrgID: "org-b"},
+		},
+	}
+
+	pool := map[int]*ManagedWorker{101: w1, 102: w2}
+	var refreshed []int
+	var mu sync.Mutex
+	scheduler := &credentialRefreshScheduler{
+		interval:     time.Millisecond,
+		lookahead:    30 * time.Minute,
+		cpInstanceID: "cp-me",
+		store:        store,
+		now:          func() time.Time { return time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC) },
+		workerByID: func(id int) (*ManagedWorker, bool) {
+			w, ok := pool[id]
+			return w, ok
+		},
+		refresh: func(ctx context.Context, w *ManagedWorker) error {
+			mu.Lock()
+			defer mu.Unlock()
+			refreshed = append(refreshed, w.ID)
+			return nil
+		},
+	}
+
+	scheduler.tick(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(refreshed) != 2 || refreshed[0] != 101 || refreshed[1] != 102 {
+		t.Fatalf("expected workers 101 and 102 to be refreshed in order, got %v", refreshed)
+	}
+	if len(store.owners) == 0 || store.owners[0] != "cp-me" {
+		t.Fatalf("expected query to filter on cpInstanceID 'cp-me', got %v", store.owners)
+	}
+	wantCutoff := time.Date(2026, time.April, 30, 12, 30, 0, 0, time.UTC)
+	if !store.cutoffs[0].Equal(wantCutoff) {
+		t.Fatalf("expected cutoff %v, got %v", wantCutoff, store.cutoffs[0])
+	}
+}
+
+// TestCredentialRefreshSchedulerTickSkipsMissingFromPool ensures workers we
+// no longer hold in the in-memory pool are silently skipped — we'll catch
+// them on a later tick if they come back.
+func TestCredentialRefreshSchedulerTickSkipsMissingFromPool(t *testing.T) {
+	store := &fakeCredRefreshStore{
+		due: []configstore.WorkerRecord{{WorkerID: 999, OrgID: "org-x"}},
+	}
+	var refreshed int
+	scheduler := &credentialRefreshScheduler{
+		lookahead:    30 * time.Minute,
+		cpInstanceID: "cp-me",
+		store:        store,
+		now:          time.Now,
+		workerByID:   func(int) (*ManagedWorker, bool) { return nil, false },
+		refresh: func(context.Context, *ManagedWorker) error {
+			refreshed++
+			return nil
+		},
+	}
+
+	scheduler.tick(context.Background())
+
+	if refreshed != 0 {
+		t.Fatalf("expected refresh hook not to fire when worker is missing from pool, got %d calls", refreshed)
+	}
+}
+
+// TestCredentialRefreshSchedulerTickContinuesAfterRefreshError makes sure a
+// refresh failure for one worker does not abort the rest of the batch — each
+// worker is independent and a single STS hiccup should not block the others.
+func TestCredentialRefreshSchedulerTickContinuesAfterRefreshError(t *testing.T) {
+	w1 := &ManagedWorker{ID: 1}
+	w2 := &ManagedWorker{ID: 2}
+	store := &fakeCredRefreshStore{
+		due: []configstore.WorkerRecord{
+			{WorkerID: 1, OrgID: "org-a"},
+			{WorkerID: 2, OrgID: "org-b"},
+		},
+	}
+	pool := map[int]*ManagedWorker{1: w1, 2: w2}
+	var refreshed []int
+	scheduler := &credentialRefreshScheduler{
+		lookahead:    30 * time.Minute,
+		cpInstanceID: "cp-me",
+		store:        store,
+		now:          time.Now,
+		workerByID: func(id int) (*ManagedWorker, bool) {
+			w, ok := pool[id]
+			return w, ok
+		},
+		refresh: func(ctx context.Context, w *ManagedWorker) error {
+			refreshed = append(refreshed, w.ID)
+			if w.ID == 1 {
+				return errors.New("sts boom")
+			}
+			return nil
+		},
+	}
+
+	scheduler.tick(context.Background())
+
+	if len(refreshed) != 2 || refreshed[0] != 1 || refreshed[1] != 2 {
+		t.Fatalf("expected scheduler to keep going after worker 1 errored, got %v", refreshed)
+	}
+}
+
+// TestCredentialRefreshSchedulerTickHandlesListError ensures a transient DB
+// error doesn't crash the scheduler — the next tick will retry.
+func TestCredentialRefreshSchedulerTickHandlesListError(t *testing.T) {
+	store := &fakeCredRefreshStore{listErr: errors.New("db down")}
+	scheduler := &credentialRefreshScheduler{
+		lookahead:    30 * time.Minute,
+		cpInstanceID: "cp-me",
+		store:        store,
+		now:          time.Now,
+		workerByID:   func(int) (*ManagedWorker, bool) { return nil, false },
+		refresh:      func(context.Context, *ManagedWorker) error { return nil },
+	}
+
+	scheduler.tick(context.Background()) // would panic on a nil deref if not handled
+}
+
+// TestCredentialRefreshSchedulerRunStopsOnContextCancel confirms ctx
+// cancellation actually unblocks Run — required so SetupMultiTenant doesn't
+// leak the goroutine on shutdown.
+func TestCredentialRefreshSchedulerRunStopsOnContextCancel(t *testing.T) {
+	store := &fakeCredRefreshStore{}
+	scheduler := &credentialRefreshScheduler{
+		interval:     10 * time.Millisecond,
+		lookahead:    30 * time.Minute,
+		cpInstanceID: "cp-me",
+		store:        store,
+		now:          time.Now,
+		workerByID:   func(int) (*ManagedWorker, bool) { return nil, false },
+		refresh:      func(context.Context, *ManagedWorker) error { return nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		scheduler.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not stop after context cancellation")
+	}
+
+	store.mu.Lock()
+	if store.calls < 1 {
+		t.Errorf("expected scheduler to tick at least once before cancel, got %d", store.calls)
+	}
+	store.mu.Unlock()
+}

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -21,8 +21,6 @@ type controlPlaneExpiryStore interface {
 	ExpireFlightSessionRecords(before time.Time) (int64, error)
 	ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error)
 	RetireHotIdleWorker(workerID int) (bool, error)
-	ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error)
-	MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error)
 }
 
 type ControlPlaneJanitor struct {
@@ -41,7 +39,6 @@ type ControlPlaneJanitor struct {
 	reconcileWarmCapacity         func()
 	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
-	refreshExpiringCredentials    func() // re-activates workers whose STS-brokered S3 credentials are about to expire (leader-only)
 }
 
 func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeout time.Duration) *ControlPlaneJanitor {
@@ -183,17 +180,6 @@ func (j *ControlPlaneJanitor) runOnce() {
 
 	if j.reconcileWarmCapacity != nil {
 		j.reconcileWarmCapacity()
-	}
-
-	// Refresh STS-brokered S3 credentials on workers we own that are
-	// approaching expiry. Runs every tick on the leader; the underlying
-	// query is cheap (indexed lookup on owner + expires_at) and only does
-	// work when there's actually a worker due. Keeps long-running queries
-	// healthy across the STS session-duration boundary by re-activating
-	// the worker via a side connection rather than blocking on the
-	// session's pinned *sql.Conn.
-	if j.refreshExpiringCredentials != nil {
-		j.refreshExpiringCredentials()
 	}
 }
 

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -84,39 +84,6 @@ func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(workerID int) (bool
 	return true, nil
 }
 
-func (s *captureControlPlaneExpiryStore) ListWorkersDueForCredentialRefresh(ownerCPInstanceID string, cutoff time.Time) ([]configstore.WorkerRecord, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return nil, nil
-}
-
-func (s *captureControlPlaneExpiryStore) MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return true, nil
-}
-
-// TestControlPlaneJanitorRunCallsRefreshExpiringCredentials proves the
-// scheduler hook fires every tick on the leader. The actual STS / RPC
-// work is exercised by the postgres-backed and integration tests; here
-// we just verify wiring so a future regression in runOnce can't silently
-// drop the credential refresh.
-func TestControlPlaneJanitorRunCallsRefreshExpiringCredentials(t *testing.T) {
-	store := &captureControlPlaneExpiryStore{}
-	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
-	janitor.now = func() time.Time { return time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC) }
-
-	var calls int
-	janitor.refreshExpiringCredentials = func() { calls++ }
-
-	janitor.runOnce()
-	janitor.runOnce()
-
-	if calls != 2 {
-		t.Fatalf("expected refreshExpiringCredentials to fire on each runOnce; got %d calls in 2 ticks", calls)
-	}
-}
-
 func TestControlPlaneJanitorRunExpiresStaleInstances(t *testing.T) {
 	store := &captureControlPlaneExpiryStore{}
 	now := time.Date(2026, time.March, 26, 15, 0, 0, 0, time.UTC)

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -298,37 +298,21 @@ func SetupMultiTenant(
 	// failures on subsequent ticks.
 	const credentialRefreshLookahead = stsSessionDuration / 2
 
-	janitor.refreshExpiringCredentials = func() {
-		if refreshActivator == nil {
-			return
+	// Per-CP scheduler — runs on every CP regardless of leader status, since
+	// each CP refreshes only the workers it owns (filtered by cpInstanceID in
+	// the SQL). Running this on the janitor leader only would leave workers
+	// owned by non-leader CPs to expire naturally, breaking long-running
+	// queries.
+	if refreshActivator != nil {
+		scheduler := &credentialRefreshScheduler{
+			interval:     5 * time.Second,
+			lookahead:    credentialRefreshLookahead,
+			cpInstanceID: cpInstanceID,
+			store:        store,
+			workerByID:   router.sharedPool.Worker,
+			refresh:      refreshActivator.RefreshCredentials,
 		}
-		cutoff := time.Now().Add(credentialRefreshLookahead)
-		due, err := store.ListWorkersDueForCredentialRefresh(cpInstanceID, cutoff)
-		if err != nil {
-			slog.Warn("Janitor failed to list workers due for credential refresh.", "error", err)
-			return
-		}
-		if len(due) == 0 {
-			return
-		}
-		slog.Info("Refreshing S3 credentials on workers nearing expiry.", "count", len(due))
-		for i := range due {
-			rec := due[i]
-			worker, ok := router.sharedPool.Worker(rec.WorkerID)
-			if !ok {
-				// Worker isn't in this CP's in-memory pool right now —
-				// could be mid-takeover, mid-retire, or just briefly
-				// dropped. Skip; if it comes back to us next tick we'll
-				// pick it up then.
-				continue
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			if err := refreshActivator.RefreshCredentials(ctx, worker); err != nil {
-				slog.Warn("Failed to refresh worker S3 credentials.",
-					"worker_id", rec.WorkerID, "org", rec.OrgID, "error", err)
-			}
-			cancel()
-		}
+		go scheduler.Run(context.Background())
 	}
 	janitorLeader, err := NewJanitorLeaderManager(namespace, cpInstanceID, janitor)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Per-CP credential refresh scheduler runs on every CP regardless of leader status
- Each CP refreshes only the workers it owns (filtered by ` cpInstanceID` in SQL)
- Extracts the tick into a testable ` credentialRefreshScheduler` type

## Why
PR #471 wired the credential refresh into the janitor's leader-only ` runOnce` loop. In production we have ~10 CPs but only one janitor leader at a time, so workers owned by the other ~9 CPs never had their STS-brokered S3 credentials re-brokered. After the original 1h session naturally expired, any long-running query on those workers failed with ` ExpiredToken`.

Concrete repro: in mw-prod-us today worker 40772 was owned by CP ` cqcvz` (non-leader). Its ` s3_credentials_expires_at` stayed at the value set during initial activation; once that timestamp passed, every customer query routed through that worker burned with ` ExpiredToken`.

## Fix
Move the refresh out of ` ControlPlaneJanitor.runOnce` and into ` credentialRefreshScheduler.Run`, spawned as a per-CP goroutine from ` SetupMultiTenant`. The SQL behind ` ListWorkersDueForCredentialRefresh` is already filtered by ` owner_cp_instance_id = $1`, so each CP only sees its own workers — no coordination needed.

The existing 5s interval, half-life lookahead (` stsSessionDuration / 2 ` = 30 min), and worker-not-in-pool skip behavior are preserved verbatim.

## Test plan
- [x] ` go build -tags kubernetes ./controlplane/... ./server/...` clean
- [x] New unit tests cover: due workers refreshed, missing-from-pool skipped, refresh-error doesn't abort batch, list-error doesn't crash, ` ctx` cancel stops ` Run`
- [x] Existing janitor tests pass (` TestControlPlaneJanitorRun*`)
- [ ] Deploy to mw-dev, confirm scheduler logs ` Refreshing S3 credentials...` from a non-leader CP
- [ ] Deploy to mw-prod-us, watch ` worker_records.s3_credentials_expires_at` advance for workers across all CPs (not just the leader)