### PR TITLE
Bypass transpiler for file COPY statements

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1168,17 +1168,19 @@ func (c *clientConn) handleQuery(body []byte) error {
 		return c.executeQueryDirect(query, cmdType)
 	}
 
-	// Route COPY TO STDOUT / COPY FROM STDIN directly to handleCopy()
+	// Route COPY directly to handleCopy()
 	// before transpilation, because:
-	// 1. The inner SELECT may contain DuckDB-specific syntax (QUALIFY, ASOF, struct literals)
+	// 1. File COPY options such as FORMAT 'parquet' must reach DuckDB intact;
+	//    pg_query deparses them into PostgreSQL's FORMAT parquet form.
+	// 2. The inner SELECT may contain DuckDB-specific syntax (QUALIFY, ASOF, struct literals)
 	//    that pg_query can't parse
-	// 2. handleCopyOut() already extracts and transpiles the inner SELECT separately
-	// 3. validateWithDuckDB() can't EXPLAIN COPY with FORMAT "binary"
+	// 3. handleCopyOut() already extracts and transpiles the inner SELECT separately
+	// 4. validateWithDuckDB() can't EXPLAIN COPY with FORMAT "binary"
 	//
 	// NOTE: This must stay above queryContext(). handleCopyIn reads from
 	// c.reader directly, which would race with the disconnect monitor.
 	upperQueryEarly := strings.ToUpper(query)
-	if copyToStdoutRegex.MatchString(upperQueryEarly) || copyFromStdinRegex.MatchString(upperQueryEarly) {
+	if shouldHandleCopyBeforeTranspile(query) {
 		return c.handleCopy(query, upperQueryEarly)
 	}
 
@@ -3020,6 +3022,11 @@ func (c *clientConn) buildCommandTag(cmdType string, result ExecResult) string {
 	default:
 		return cmdType
 	}
+}
+
+func shouldHandleCopyBeforeTranspile(query string) bool {
+	trimmed := strings.TrimSpace(query)
+	return strings.HasPrefix(strings.ToUpper(trimmed), "COPY")
 }
 
 // Regular expressions for parsing COPY commands

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -2013,6 +2013,48 @@ func TestCopyToStdoutRegex(t *testing.T) {
 	}
 }
 
+func TestShouldHandleCopyBeforeTranspile(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			name: "copy query to file",
+			sql:  "COPY (SELECT 1) TO 's3://bucket/probe.parquet' (FORMAT 'parquet')",
+			want: true,
+		},
+		{
+			name: "copy table to file",
+			sql:  "COPY users TO '/tmp/users.parquet' (FORMAT 'parquet')",
+			want: true,
+		},
+		{
+			name: "copy to stdout",
+			sql:  "COPY users TO STDOUT WITH (FORMAT CSV)",
+			want: true,
+		},
+		{
+			name: "copy from stdin",
+			sql:  "COPY users FROM STDIN WITH (FORMAT CSV)",
+			want: true,
+		},
+		{
+			name: "select",
+			sql:  "SELECT 1",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldHandleCopyBeforeTranspile(tt.sql); got != tt.want {
+				t.Fatalf("shouldHandleCopyBeforeTranspile(%q) = %v, want %v", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCopyFromStdinRegex(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary
- route all top-level COPY statements directly to the COPY handler before transpilation
- preserve DuckDB COPY file options such as FORMAT 'parquet' instead of allowing pg_query deparse to normalize them to PostgreSQL-style FORMAT parquet
- add coverage for file COPY, COPY TO STDOUT, and COPY FROM STDIN early routing

## Test plan
- go test ./server -run 'TestShouldHandleCopyBeforeTranspile|TestCopyToStdoutRegex|TestCopyFromStdinRegex' -count=1
- just lint