### PR TITLE
[codex] Fix timestamp aliases in Arrow schema mapping

### DIFF
--- a/duckdbservice/arrow_helpers.go
+++ b/duckdbservice/arrow_helpers.go
@@ -133,8 +133,8 @@ func DuckDBTypeToArrow(dbType string) arrow.DataType {
 		// irrecoverably lost at the driver level.
 		return arrow.FixedWidthTypes.Time64us
 
-	// Timestamps (no timezone → empty TimeZone string)
-	case "TIMESTAMP":
+	case "TIMESTAMP", "TIMESTAMP WITHOUT TIME ZONE":
+		// No timezone means an empty Arrow TimeZone string.
 		return &arrow.TimestampType{Unit: arrow.Microsecond}
 	case "TIMESTAMP_S":
 		return &arrow.TimestampType{Unit: arrow.Second}
@@ -142,7 +142,7 @@ func DuckDBTypeToArrow(dbType string) arrow.DataType {
 		return &arrow.TimestampType{Unit: arrow.Millisecond}
 	case "TIMESTAMP_NS":
 		return &arrow.TimestampType{Unit: arrow.Nanosecond}
-	case "TIMESTAMPTZ":
+	case "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE":
 		return &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
 
 	// Interval

--- a/duckdbservice/arrow_helpers_test.go
+++ b/duckdbservice/arrow_helpers_test.go
@@ -65,11 +65,15 @@ func TestDuckDBTypeToArrow(t *testing.T) {
 
 		// Timestamps — plain TIMESTAMP must NOT have timezone
 		{"TIMESTAMP", &arrow.TimestampType{Unit: arrow.Microsecond}},
+		{"TIMESTAMP WITHOUT TIME ZONE", &arrow.TimestampType{Unit: arrow.Microsecond}},
+		{"timestamp without time zone", &arrow.TimestampType{Unit: arrow.Microsecond}},
 		{"TIMESTAMP_S", &arrow.TimestampType{Unit: arrow.Second}},
 		{"TIMESTAMP_MS", &arrow.TimestampType{Unit: arrow.Millisecond}},
 		{"TIMESTAMP_NS", &arrow.TimestampType{Unit: arrow.Nanosecond}},
 		// TIMESTAMPTZ must have UTC timezone
 		{"TIMESTAMPTZ", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}},
+		{"TIMESTAMP WITH TIME ZONE", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}},
+		{"timestamp with time zone", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}},
 
 		// Interval
 		{"INTERVAL", arrow.FixedWidthTypes.MonthDayNanoInterval},
@@ -171,11 +175,11 @@ func TestParseDecimalParams(t *testing.T) {
 		{"DECIMAL(10,5)", 10, 5},
 		{"DECIMAL(38,0)", 38, 0},
 		{"NUMERIC(5,3)", 5, 3},
-		{"DECIMAL", 18, 3},   // default fallback
-		{"DECIMAL()", 18, 3}, // empty parens
-		{"DECIMAL(abc,def)", 18, 3},  // non-numeric
-		{"DECIMAL(18,)", 18, 3},      // missing scale
-		{"DECIMAL(,2)", 18, 3},       // missing precision
+		{"DECIMAL", 18, 3},          // default fallback
+		{"DECIMAL()", 18, 3},        // empty parens
+		{"DECIMAL(abc,def)", 18, 3}, // non-numeric
+		{"DECIMAL(18,)", 18, 3},     // missing scale
+		{"DECIMAL(,2)", 18, 3},      // missing precision
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fix `duckdbservice.DuckDBTypeToArrow` so PostgreSQL-style timestamp names map to Arrow timestamps instead of falling through to Arrow string.

Specifically:
- `TIMESTAMP WITHOUT TIME ZONE` maps to Arrow timestamp without timezone.
- `TIMESTAMP WITH TIME ZONE` maps to Arrow timestamp with `UTC` timezone.
- Existing `TIMESTAMP` and `TIMESTAMPTZ` behavior is unchanged.

## Root Cause

Flight SQL `GetTables(include_schema=true)` can build schemas from `information_schema.columns.data_type`. DuckDB/Duckgres metadata can expose timestamp types as PostgreSQL-style strings like `timestamp with time zone`. The mapper only recognized `TIMESTAMP` and `TIMESTAMPTZ`, so those aliases fell through to Arrow string and clients such as DuckHog displayed the columns as `varchar`.

## Validation

- Verified the new regression cases fail against the old mapper with `STRING, want TIMESTAMP`.
- `go test ./duckdbservice -run TestDuckDBTypeToArrow`
- `go test ./duckdbservice`
- `go test ./server/flightsqlingress`
- `git diff --check`

## Local DuckHog Smoke

Tested with DuckDB 1.5.2 and the community DuckHog extension:

```sql
INSTALL duckhog FROM community;
LOAD duckhog;
ATTACH 'hog:memory?user=postgres&password=postgres&flight_server=grpc+tls://127.0.0.1:18815&tls_skip_verify=true' AS remote;
CREATE OR REPLACE TABLE remote.main.duckhog_timestamp_smoke(ts_tz TIMESTAMPTZ, ts_plain TIMESTAMP);
DETACH remote;
ATTACH 'hog:memory?user=postgres&password=postgres&flight_server=grpc+tls://127.0.0.1:18815&tls_skip_verify=true' AS remote2;
SELECT column_name, data_type
FROM information_schema.columns
WHERE table_catalog = 'remote2'
  AND table_schema = 'main'
  AND table_name = 'duckhog_timestamp_smoke'
ORDER BY ordinal_position;
```

PR binary result:

```text
ts_tz     TIMESTAMP WITH TIME ZONE
ts_plain  TIMESTAMP
```

The older local `./duckgres` binary on the same smoke path reproduced the bug:

```text
ts_tz     VARCHAR
ts_plain  TIMESTAMP
```