### PR TITLE
fix(duckdbservice): isolate session-cleanup contexts and discard poisoned conns

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -538,11 +539,19 @@ func (p *SessionPool) DestroySession(token string) error {
 		// so they'd leak into the next session that gets the same connection.
 		cleanupStart := time.Now()
 		slog.Debug("Cleaning up session state.", "user", session.Username)
-		cleanupSessionState(session.Conn)
-		slog.Debug("Session state cleaned up.", "user", session.Username, "duration", time.Since(cleanupStart))
+		clean := cleanupSessionState(session.Conn)
+		slog.Debug("Session state cleaned up.", "user", session.Username, "duration", time.Since(cleanupStart), "clean", clean)
+		if !clean {
+			// Cleanup failed — likely the conn is in an aborted/INTERRUPT'd state
+			// from the prior cancelled query. Returning it to the pool would poison
+			// the next session that gets it (every operation fails until the conn
+			// is forcibly recycled). Mark it bad via Raw so database/sql discards
+			// it instead. The next Conn() call gets a fresh DuckDB connection.
+			_ = session.Conn.Raw(func(any) error { return driver.ErrBadConn })
+		}
 		connCloseStart := time.Now()
 		_ = session.Conn.Close()
-		slog.Debug("Session connection closed (returned to pool).", "user", session.Username, "duration", time.Since(connCloseStart))
+		slog.Debug("Session connection closed.", "user", session.Username, "duration", time.Since(connCloseStart), "discarded", !clean)
 	}
 	// Do NOT close session.DB if it is a shared DB (warmup or fallback)
 	p.mu.RLock()
@@ -667,29 +676,46 @@ func cleanupWorkerCatalogs(db *sql.DB) {
 
 // cleanupSessionState drops temporary tables and views on the connection so
 // that session-scoped state doesn't leak when the connection is returned to
-// the pool.
-func cleanupSessionState(conn *sql.Conn) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+// the pool. Returns true if every step succeeded and the connection is safe
+// to reuse; false if any operation failed (typically because the prior query
+// was cancelled and the conn is in an aborted/INTERRUPT'd state).
+func cleanupSessionState(conn *sql.Conn) bool {
+	// Clear any aborted-transaction state from the prior query before running
+	// the cleanup operations. After a cancelled query, DuckDB can leave the
+	// session in a state where every subsequent statement returns "INTERRUPT
+	// Error: Interrupted!" until ROLLBACK runs. Same pattern as initSearchPath.
+	rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	if _, err := conn.ExecContext(rollbackCtx, "ROLLBACK"); err != nil {
+		// ROLLBACK with no active txn returns a no-op error in some drivers; not fatal.
+		slog.Debug("ROLLBACK during cleanup returned an error.", "error", err)
+	}
+	rollbackCancel()
 
-	// Drop temporary tables
-	dropTemporary(ctx, conn,
+	ok := dropTemporary(conn,
 		"SELECT table_name FROM duckdb_tables() WHERE temporary = true",
 		`DROP TABLE IF EXISTS temp."%s"`,
 	)
-
-	// Drop temporary views
-	dropTemporary(ctx, conn,
+	// Run views even if tables failed — gives best-effort progress and a
+	// consistent ok=false signal if anything didn't complete.
+	ok = dropTemporary(conn,
 		"SELECT view_name FROM duckdb_views() WHERE temporary = true",
 		`DROP VIEW IF EXISTS temp."%s"`,
-	)
+	) && ok
+	return ok
 }
 
-func dropTemporary(ctx context.Context, conn *sql.Conn, query, dropFmt string) {
-	rows, err := conn.QueryContext(ctx, query)
+func dropTemporary(conn *sql.Conn, query, dropFmt string) bool {
+	// Per-step contexts: previously a single 5s context spanned both the
+	// SELECT and every DROP. A slow SELECT could exhaust the budget before
+	// a single DROP ran, causing all DROPs to fail with deadline-exceeded
+	// in lockstep. Now SELECT has its own 3s and each DROP its own 1s, so
+	// the failure of one operation doesn't cascade into the next.
+	enumCtx, enumCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer enumCancel()
+	rows, err := conn.QueryContext(enumCtx, query)
 	if err != nil {
 		slog.Warn("Failed to query temporary objects for cleanup.", "error", err)
-		return
+		return false
 	}
 	var names []string
 	for rows.Next() {
@@ -703,11 +729,16 @@ func dropTemporary(ctx context.Context, conn *sql.Conn, query, dropFmt string) {
 	}
 	_ = rows.Close()
 
+	ok := true
 	for _, name := range names {
-		if _, err := conn.ExecContext(ctx, fmt.Sprintf(dropFmt, name)); err != nil {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		if _, err := conn.ExecContext(dropCtx, fmt.Sprintf(dropFmt, name)); err != nil {
 			slog.Warn("Failed to drop temporary object during cleanup.", "name", name, "error", err)
+			ok = false
 		}
+		dropCancel()
 	}
+	return ok
 }
 
 // initSearchPath sets the DuckDB search_path for a session connection.

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -63,6 +63,92 @@ func TestInitSearchPath(t *testing.T) {
 	})
 }
 
+func TestCleanupSessionState(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open DuckDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	t.Run("no temp objects returns true", func(t *testing.T) {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get connection: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if ok := cleanupSessionState(conn); !ok {
+			t.Errorf("cleanupSessionState() = false on a clean connection, want true")
+		}
+	})
+
+	t.Run("drops user-created temp tables and views", func(t *testing.T) {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get connection: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, err := conn.ExecContext(context.Background(), "CREATE TEMP TABLE t1 (x INTEGER)"); err != nil {
+			t.Fatalf("create temp table: %v", err)
+		}
+		if _, err := conn.ExecContext(context.Background(), "CREATE TEMP VIEW v1 AS SELECT 1 AS x"); err != nil {
+			t.Fatalf("create temp view: %v", err)
+		}
+
+		// cleanupSessionState may also DROP IF EXISTS many DuckDB-managed system
+		// views via the temp schema (most are in other schemas, so the DROPs are
+		// no-ops). Only assert that the user-created objects are gone.
+		_ = cleanupSessionState(conn)
+
+		var n int
+		if err := conn.QueryRowContext(context.Background(),
+			"SELECT count(*) FROM duckdb_tables() WHERE temporary = true AND table_name = 't1'",
+		).Scan(&n); err != nil {
+			t.Fatalf("count t1: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("user temp table t1 not dropped (remaining = %d)", n)
+		}
+
+		if err := conn.QueryRowContext(context.Background(),
+			"SELECT count(*) FROM duckdb_views() WHERE temporary = true AND view_name = 'v1'",
+		).Scan(&n); err != nil {
+			t.Fatalf("count v1: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("user temp view v1 not dropped (remaining = %d)", n)
+		}
+	})
+
+	t.Run("rollback clears aborted transaction state", func(t *testing.T) {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get connection: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Open a txn and leave it dangling — cleanup should ROLLBACK before
+		// running its own statements. Without the rollback, the SELECT against
+		// duckdb_tables() would surface the dangling txn's aborted state.
+		if _, err := conn.ExecContext(context.Background(), "BEGIN TRANSACTION"); err != nil {
+			t.Fatalf("begin txn: %v", err)
+		}
+		if _, err := conn.ExecContext(context.Background(), "CREATE TEMP TABLE leak (x INTEGER)"); err != nil {
+			t.Fatalf("create temp inside txn: %v", err)
+		}
+
+		if ok := cleanupSessionState(conn); !ok {
+			t.Errorf("cleanupSessionState() = false after rollback path, want true")
+		}
+
+		// After cleanup we should be out of the txn — a fresh statement should succeed.
+		if _, err := conn.ExecContext(context.Background(), "SELECT 1"); err != nil {
+			t.Errorf("post-cleanup SELECT failed: %v", err)
+		}
+	})
+}
+
 func TestRunExitsWhenBundledExtensionBootstrapFails(t *testing.T) {
 	prevBootstrap := bootstrapBundledExtensions
 	prevExit := exitProcess


### PR DESCRIPTION
## Summary

Cancelled queries can leave a worker's connection in an aborted/INTERRUPT'd state where every subsequent statement returns `INTERRUPT Error: Interrupted!` until `ROLLBACK` runs. `cleanupSessionState` then runs SELECT + N×DROP inside a single 5s context — the SELECT consumes the budget, every DROP fails with `context deadline exceeded`, and the dirty connection returns to the pool. The next session pulled from the pool fails its first metadata statement (e.g. `USE memory`) under the control plane's 5s session-init context. Surfaces from the client as `failed to initialize session database metadata` / `failed to detect ducklake catalog attachment` — same symptoms as #478, separate root cause.

## Changes

`duckdbservice/service.go`:

1. **`ROLLBACK` before cleanup** to clear aborted-txn state. Same pattern `initSearchPath` already uses.
2. **Per-step contexts**: 3s for each enumeration SELECT, 1s for each DROP (was: one shared 5s context). A slow SELECT no longer eats the budget for all DROPs.
3. **`cleanupSessionState` returns clean/dirty**. On dirty, `DestroySession` marks the conn bad via `Conn.Raw → driver.ErrBadConn` so `database/sql` evicts it from the pool instead of handing it to the next session.

## Verification

Reproduced on the dev cluster: cancel a clickbench scan via `pg_cancel_backend`, the next session on the same worker fails with `failed to initialize session database metadata: switch to memory catalog: flight execute update: deadline exceeded`. The worker is then reaped by k8s health checks ~3 minutes later.

`TestCleanupSessionState` covers three cases against real DuckDB: empty cleanup, user temp-object drops, and rollback of a dangling `BEGIN`. The full poisoning chain is dev-cluster integration territory rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)