### PR TITLE
refactor(server): extract TLS / ACME helpers into server/tlscert

### DIFF
--- a/server/tlscert/acme.go
+++ b/server/tlscert/acme.go
@@ -1,4 +1,4 @@
-package server
+package tlscert
 
 import (
 	"context"

--- a/server/tlscert/acme_dns.go
+++ b/server/tlscert/acme_dns.go
@@ -1,4 +1,4 @@
-package server
+package tlscert
 
 import (
 	"context"

--- a/server/tlscert/acme_dns_test.go
+++ b/server/tlscert/acme_dns_test.go
@@ -1,4 +1,4 @@
-package server
+package tlscert
 
 import (
 	"os"

--- a/server/tlscert/acme_test.go
+++ b/server/tlscert/acme_test.go
@@ -1,4 +1,4 @@
-package server
+package tlscert
 
 import (
 	"os"

--- a/server/tlscert/certs.go
+++ b/server/tlscert/certs.go
@@ -1,4 +1,4 @@
-package server
+package tlscert
 
 import (
 	"crypto/ecdsa"
@@ -31,7 +31,7 @@ func EnsureCertificates(certFile, keyFile string) error {
 	}
 
 	// Generate new certificates
-	return generateSelfSignedCert(certFile, keyFile)
+	return GenerateSelfSignedCert(certFile, keyFile)
 }
 
 func fileExists(path string) bool {
@@ -39,7 +39,11 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-func generateSelfSignedCert(certFile, keyFile string) error {
+// GenerateSelfSignedCert writes a fresh self-signed certificate and ECDSA
+// private key to the given paths. Used directly by tests that need a cert
+// pair on disk without going through EnsureCertificates' file-existence
+// check.
+func GenerateSelfSignedCert(certFile, keyFile string) error {
 	// Generate ECDSA private key
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/server/tlscert_aliases.go
+++ b/server/tlscert_aliases.go
@@ -1,0 +1,21 @@
+package server
+
+import "github.com/posthog/duckgres/server/tlscert"
+
+// Re-exports kept here so existing references to server.ACMEManager,
+// server.ACMEDNSManager, server.NewACMEManager, server.NewACMEDNSManager,
+// and server.EnsureCertificates continue to compile after the TLS / ACME
+// helpers moved into server/tlscert. New code should import server/tlscert
+// and use tlscert.X directly.
+
+type (
+	ACMEManager    = tlscert.ACMEManager
+	ACMEDNSManager = tlscert.ACMEDNSManager
+)
+
+var (
+	NewACMEManager        = tlscert.NewACMEManager
+	NewACMEDNSManager     = tlscert.NewACMEDNSManager
+	EnsureCertificates    = tlscert.EnsureCertificates
+	generateSelfSignedCert = tlscert.GenerateSelfSignedCert // server_test.go calls this directly
+)


### PR DESCRIPTION
## Summary

- Step 4 of the binary-split plan, **stacked on PR #483**
- Extracts the TLS-cert and ACME (HTTP-01, DNS-01) helpers out of `server/` into a focused `server/tlscert/` subpackage with zero `duckdb-go` dependency
- 5 files moved (3 source + 2 test); backward compatibility preserved via type aliases and re-export shims in `server/tlscert_aliases.go`
- `go list -deps ./server/tlscert | grep duckdb-go` returns empty

## Files moved

| From | To |
|---|---|
| `server/certs.go` | `server/tlscert/certs.go` |
| `server/acme.go` | `server/tlscert/acme.go` |
| `server/acme_dns.go` | `server/tlscert/acme_dns.go` |
| `server/acme_test.go` | `server/tlscert/acme_test.go` |
| `server/acme_dns_test.go` | `server/tlscert/acme_dns_test.go` |

## Backward-compat shim

`server/tlscert_aliases.go` keeps existing references compiling unchanged:

```go
type (
    ACMEManager    = tlscert.ACMEManager
    ACMEDNSManager = tlscert.ACMEDNSManager
)
var (
    NewACMEManager        = tlscert.NewACMEManager
    NewACMEDNSManager     = tlscert.NewACMEDNSManager
    EnsureCertificates    = tlscert.EnsureCertificates
    generateSelfSignedCert = tlscert.GenerateSelfSignedCert
)
```

The previously-private `generateSelfSignedCert` is now exported as `tlscert.GenerateSelfSignedCert` because `server_test.go` calls it directly to generate cert pairs without the `EnsureCertificates` file-existence check.

## Note on scope

PR #4 originally targeted `querylog.go` + `checkpoint.go` extraction (those would do more for the goal — they directly link `duckdb-go` via `sql.Open("duckdb", ...)`). That hit a chicken-and-egg problem: those constructors take `server.Config` (which embeds `DuckLakeConfig` and `QueryLogConfig`), and the duckdb-bound config types haven't moved to a leaf package on this branch yet. PR #1.5 (a parallel branch) does that work for `DuckLakeConfig`. Once #1.5 merges and this stack rebases, the querylog/checkpoint extraction lands in a follow-up PR.

Pivoted to TLS/ACME for this PR because it's clean, self-contained, and progresses the goal in the same shape as PR #3.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/tlscert/... ./server/... ./controlplane/...` — all green
- [x] `go list -deps ./server/tlscert | grep duckdb-go` returns empty

## Stack

- ✅ PR #477 (#1): arrowmap extraction
- ✅ PR #480 (#1.5): ducklake extraction (parallel branch)
- ✅ PR #482 (#2): AppendValue split
- ✅ PR #483 (#3): auth + sysinfo subpackages — **base of this PR**
- ⚠️ This PR (#4): tlscert subpackage
- ⏳ PR #5 (after #1.5 merges): querylog + checkpoint into `server/exec/`
- ⏳ PR #6: split `server.go` / `conn.go` / `types.go`'s duckdb-bound branches
- ⏳ PR #7: introduce `cmd/duckgres-controlplane` and `cmd/duckgres-worker`
- ⏳ PR #8: flip CI/CD + Helm + per-DuckDB-version matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)