### PR TITLE
fix(duckdbservice): discard pooled conn after every session in cluster mode

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -539,34 +539,33 @@ func (p *SessionPool) DestroySession(token string) error {
 		// leak into the next session that gets the same pooled connection.
 		//
 		// Two strategies:
-		//   - Cluster mode (sharedWarmMode): always discard the conn. The
+		//   - Cluster mode (sharedWarmMode): always evict the conn. The
 		//     worker is bound to a single org via activateTenant, so security
 		//     boundaries align with worker lifecycle, and the per-session
 		//     cleanup loop is mostly wasted work (a typical SELECT-1 session
 		//     creates zero user temp objects but the cleanup still issues
 		//     ~46 DROP IF EXISTS no-ops against system views in non-temp
-		//     schemas). Discarding is also more correct: the existing
-		//     cleanup only handles temp tables/views, not temp macros, types,
-		//     or sequences — those still leak through pooled-conn reuse.
-		//     Conn discard kills all of them.
+		//     schemas). Eviction is also more correct: the existing cleanup
+		//     only handles temp tables/views, not temp macros, types, or
+		//     sequences — those still leak through pooled-conn reuse.
 		//   - Standalone mode: pooled conns can be reused across orgs, so
-		//     scrubbing per-conn state is required. Falls back to the same
-		//     conn-discard if the cleanup fails.
+		//     scrubbing per-conn state is required. Falls back to eviction
+		//     if the cleanup fails.
 		cleanupStart := time.Now()
-		var discarded bool
+		var evicted bool
 		if p.sharedWarmMode {
-			slog.Debug("Discarding session connection (cluster mode).", "user", session.Username)
-			_ = session.Conn.Raw(func(any) error { return driver.ErrBadConn })
-			discarded = true
+			slog.Debug("Evicting session connection from pool (cluster mode).", "user", session.Username)
+			evictConnFromPool(session.Conn)
+			evicted = true
 		} else {
 			slog.Debug("Cleaning up session state (standalone mode).", "user", session.Username)
 			clean := cleanupSessionState(session.Conn)
 			slog.Debug("Session state cleaned up.", "user", session.Username, "duration", time.Since(cleanupStart), "clean", clean)
 			if !clean {
 				// Cleanup failed — likely an aborted/INTERRUPT'd conn from a
-				// cancelled query. Discard rather than poison the next session.
-				_ = session.Conn.Raw(func(any) error { return driver.ErrBadConn })
-				discarded = true
+				// cancelled query. Evict rather than poison the next session.
+				evictConnFromPool(session.Conn)
+				evicted = true
 			}
 		}
 		connCloseStart := time.Now()
@@ -574,7 +573,7 @@ func (p *SessionPool) DestroySession(token string) error {
 		slog.Debug("Session connection closed.", "user", session.Username,
 			"cleanup_duration", time.Since(cleanupStart),
 			"close_duration", time.Since(connCloseStart),
-			"discarded", discarded)
+			"evicted", evicted)
 	}
 	// Do NOT close session.DB if it is a shared DB (warmup or fallback)
 	p.mu.RLock()
@@ -695,6 +694,19 @@ func cleanupWorkerCatalogs(db *sql.DB) {
 			slog.Warn("Failed to detach worker DuckLake catalog during shutdown.", "error", err)
 		}
 	}
+}
+
+// evictConnFromPool removes a *sql.Conn's underlying driver connection from
+// the *sql.DB pool so it's not reused by a future caller.
+//
+// The standard library exposes no direct API for this, so the idiom is to
+// return driver.ErrBadConn from Conn.Raw — the database/sql pool checks for
+// that error specifically and discards rather than re-pools the conn (see
+// putConn in database/sql). The connection isn't actually broken; we just
+// don't want it pooled. The Go team has acknowledged the API gap (see
+// golang/go#40722) but no cleaner replacement exists today.
+func evictConnFromPool(conn *sql.Conn) {
+	_ = conn.Raw(func(any) error { return driver.ErrBadConn })
 }
 
 // cleanupSessionState drops temporary tables and views on the connection so

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -533,25 +533,48 @@ func (p *SessionPool) DestroySession(token string) error {
 		stop()
 	}
 	if session.Conn != nil {
-		// Drop temporary tables before returning the connection to the pool.
 		// sql.Conn.Close() returns the underlying driver connection to sql.DB's
-		// pool rather than closing it. DuckDB temp tables are connection-scoped,
-		// so they'd leak into the next session that gets the same connection.
+		// pool rather than closing it. DuckDB temp tables, temp views, and
+		// temp macros are connection-scoped, so without intervention they'd
+		// leak into the next session that gets the same pooled connection.
+		//
+		// Two strategies:
+		//   - Cluster mode (sharedWarmMode): always discard the conn. The
+		//     worker is bound to a single org via activateTenant, so security
+		//     boundaries align with worker lifecycle, and the per-session
+		//     cleanup loop is mostly wasted work (a typical SELECT-1 session
+		//     creates zero user temp objects but the cleanup still issues
+		//     ~46 DROP IF EXISTS no-ops against system views in non-temp
+		//     schemas). Discarding is also more correct: the existing
+		//     cleanup only handles temp tables/views, not temp macros, types,
+		//     or sequences — those still leak through pooled-conn reuse.
+		//     Conn discard kills all of them.
+		//   - Standalone mode: pooled conns can be reused across orgs, so
+		//     scrubbing per-conn state is required. Falls back to the same
+		//     conn-discard if the cleanup fails.
 		cleanupStart := time.Now()
-		slog.Debug("Cleaning up session state.", "user", session.Username)
-		clean := cleanupSessionState(session.Conn)
-		slog.Debug("Session state cleaned up.", "user", session.Username, "duration", time.Since(cleanupStart), "clean", clean)
-		if !clean {
-			// Cleanup failed — likely the conn is in an aborted/INTERRUPT'd state
-			// from the prior cancelled query. Returning it to the pool would poison
-			// the next session that gets it (every operation fails until the conn
-			// is forcibly recycled). Mark it bad via Raw so database/sql discards
-			// it instead. The next Conn() call gets a fresh DuckDB connection.
+		var discarded bool
+		if p.sharedWarmMode {
+			slog.Debug("Discarding session connection (cluster mode).", "user", session.Username)
 			_ = session.Conn.Raw(func(any) error { return driver.ErrBadConn })
+			discarded = true
+		} else {
+			slog.Debug("Cleaning up session state (standalone mode).", "user", session.Username)
+			clean := cleanupSessionState(session.Conn)
+			slog.Debug("Session state cleaned up.", "user", session.Username, "duration", time.Since(cleanupStart), "clean", clean)
+			if !clean {
+				// Cleanup failed — likely an aborted/INTERRUPT'd conn from a
+				// cancelled query. Discard rather than poison the next session.
+				_ = session.Conn.Raw(func(any) error { return driver.ErrBadConn })
+				discarded = true
+			}
 		}
 		connCloseStart := time.Now()
 		_ = session.Conn.Close()
-		slog.Debug("Session connection closed.", "user", session.Username, "duration", time.Since(connCloseStart), "discarded", !clean)
+		slog.Debug("Session connection closed.", "user", session.Username,
+			"cleanup_duration", time.Since(cleanupStart),
+			"close_duration", time.Since(connCloseStart),
+			"discarded", discarded)
 	}
 	// Do NOT close session.DB if it is a shared DB (warmup or fallback)
 	p.mu.RLock()

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -190,9 +190,9 @@ func TestDestroySessionClusterModeDiscardsConn(t *testing.T) {
 	}
 
 	// Open a fresh conn from the same pool and verify the macro is gone.
-	// In cluster mode the prior conn was marked bad via Conn.Raw, so the
-	// driver pool discarded it; this fresh conn opens a new DuckDB connection
-	// that never had the macro defined.
+	// In cluster mode the prior conn was evicted via evictConnFromPool, so
+	// this fresh conn opens a new DuckDB connection that never had the
+	// macro defined.
 	fresh, err := db.Conn(context.Background())
 	if err != nil {
 		t.Fatalf("acquire fresh conn: %v", err)

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -149,6 +149,123 @@ func TestCleanupSessionState(t *testing.T) {
 	})
 }
 
+func TestDestroySessionClusterModeDiscardsConn(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		warmupDB:       db,
+		sharedWarmMode: true,
+	}
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("acquire conn: %v", err)
+	}
+
+	// Create a temp macro on this conn — current cleanupSessionState does NOT
+	// drop temp macros (only tables/views), so without conn discard a macro
+	// would leak via the pool to the next session that reuses the conn.
+	if _, err := conn.ExecContext(context.Background(),
+		"CREATE OR REPLACE TEMP MACRO leak_check() AS 'leaked'",
+	); err != nil {
+		t.Fatalf("create temp macro: %v", err)
+	}
+
+	const token = "tok-cluster"
+	pool.sessions[token] = &Session{
+		ID:       token,
+		DB:       db,
+		Conn:     conn,
+		Username: "test_user",
+	}
+
+	if err := pool.DestroySession(token); err != nil {
+		t.Fatalf("DestroySession: %v", err)
+	}
+
+	// Open a fresh conn from the same pool and verify the macro is gone.
+	// In cluster mode the prior conn was marked bad via Conn.Raw, so the
+	// driver pool discarded it; this fresh conn opens a new DuckDB connection
+	// that never had the macro defined.
+	fresh, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("acquire fresh conn: %v", err)
+	}
+	defer func() { _ = fresh.Close() }()
+
+	var v string
+	err = fresh.QueryRowContext(context.Background(), "SELECT leak_check()").Scan(&v)
+	if err == nil {
+		t.Errorf("temp macro leaked across sessions: got value %q, expected error", v)
+	}
+}
+
+func TestDestroySessionStandaloneModeRunsCleanup(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		warmupDB:       db,
+		sharedWarmMode: false, // standalone mode — cleanup path runs
+	}
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("acquire conn: %v", err)
+	}
+
+	// Create a user-level temp table — this is what the standalone cleanup
+	// path is responsible for scrubbing before returning the conn to the pool.
+	if _, err := conn.ExecContext(context.Background(),
+		"CREATE TEMP TABLE standalone_leak (x INTEGER)",
+	); err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+
+	const token = "tok-standalone"
+	pool.sessions[token] = &Session{
+		ID:       token,
+		DB:       db,
+		Conn:     conn,
+		Username: "test_user",
+	}
+
+	if err := pool.DestroySession(token); err != nil {
+		t.Fatalf("DestroySession: %v", err)
+	}
+
+	// In standalone mode the cleanup ran and dropped the temp table,
+	// then the conn was returned to the pool (since cleanup succeeded).
+	// A fresh conn shouldn't see standalone_leak regardless of which
+	// driver conn it gets.
+	fresh, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("acquire fresh conn: %v", err)
+	}
+	defer func() { _ = fresh.Close() }()
+
+	var n int
+	if err := fresh.QueryRowContext(context.Background(),
+		"SELECT count(*) FROM duckdb_tables() WHERE table_name = 'standalone_leak'",
+	).Scan(&n); err != nil {
+		t.Fatalf("count standalone_leak: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("standalone_leak survived cleanup: count=%d", n)
+	}
+}
+
 func TestRunExitsWhenBundledExtensionBootstrapFails(t *testing.T) {
 	prevBootstrap := bootstrapBundledExtensions
 	prevExit := exitProcess

--- a/tests/k8s/tenant_isolation_helper_test.go
+++ b/tests/k8s/tenant_isolation_helper_test.go
@@ -192,8 +192,14 @@ func waitForWorkerReplacement(oldPodName string, timeout time.Duration) (corev1.
 func findActiveOrgWorkerPodSince(orgID string, since time.Time, timeout time.Duration) (string, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		// hot_idle workers are still bound to the org (org_id stays set on
+		// the runtime record) — they're the right answer when the session
+		// has just ended and the worker is sitting idle waiting for a
+		// re-claim from the same org. Including hot_idle here keeps the
+		// test correct when session teardown is fast enough that a worker
+		// transitions out of 'hot' before the polling loop catches it.
 		row, err := queryRuntimeStoreRow(fmt.Sprintf(
-			"SELECT pod_name, state FROM cp_runtime.worker_records WHERE org_id = '%s' AND updated_at >= TIMESTAMPTZ '%s' AND state IN ('reserved', 'activating', 'hot', 'draining') ORDER BY updated_at DESC LIMIT 1",
+			"SELECT pod_name, state FROM cp_runtime.worker_records WHERE org_id = '%s' AND updated_at >= TIMESTAMPTZ '%s' AND state IN ('reserved', 'activating', 'hot', 'hot_idle', 'draining') ORDER BY updated_at DESC LIMIT 1",
 			psqlLiteral(orgID),
 			since.UTC().Format(time.RFC3339Nano),
 		))


### PR DESCRIPTION
## Summary

In cluster mode, every worker is bound to a single org via `activateTenant`. The security boundary already aligns with the worker lifecycle, so per-session scrubbing of pooled conns isn't needed for cross-org isolation. This PR makes cluster mode evict the conn at session-end instead of running the cleanup loop.

## Why

The current cleanup is, in cluster mode:
- **Mostly wasted work.** A typical billing-style session creates zero user temp objects, but `cleanupSessionState` still issues ~46 `DROP IF EXISTS temp."<name>"` no-ops against DuckDB-internal views that live in non-temp schemas.
- **Incomplete.** It handles temp tables and temp views but not temp macros / types / sequences, which still leak across pooled-conn reuse — verified on dev.

Empirically motivated: prod was reaping ~29 workers/hr because bursts of session-end events ran hundreds of cleanup round-trips concurrently on a single worker, blocking the gRPC health-check thread for 6+ seconds and tripping `consecutive_failures=3`. The cleanup itself was correct (post-#481); the aggregate throughput was the bottleneck.

## Changes

`duckdbservice/service.go`:
- `DestroySession` branches on `p.sharedWarmMode`. Cluster mode evicts the conn from the pool unconditionally; standalone mode keeps the existing cleanup path with the post-#481 fallback.
- New `evictConnFromPool` helper wraps the `Conn.Raw → driver.ErrBadConn` idiom (`database/sql`'s only way to remove a conn from the pool — see [golang/go#40722](https://github.com/golang/go/issues/40722)) with a doc comment so call sites read clearly.

## Tests

- `TestDestroySessionClusterModeDiscardsConn` — creates a TEMP MACRO (which the old cleanup *doesn't* drop), asserts it doesn't survive a fresh conn after cluster-mode `DestroySession`.
- `TestDestroySessionStandaloneModeRunsCleanup` — creates a temp table, asserts cleanup ran and dropped it.

## Expected effect on prod

~48 SQL round-trips per session-end → 0 (just `evictConnFromPool` + `Close`). The gRPC-unresponsiveness window during burst session-ends should disappear; 29-reaps-per-hour pattern should drop substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)