### PR TITLE
refactor(server): extract wire-level types into server/wire

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
@@ -14,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/big"
 	"net"
 	"os"
 	"regexp"
@@ -29,6 +27,7 @@ import (
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/sqlcore"
+	"github.com/posthog/duckgres/server/wire"
 	"github.com/posthog/duckgres/transpiler"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -196,15 +195,10 @@ func (c *clientConn) newTranspiler(convertPlaceholders bool) *transpiler.Transpi
 	})
 }
 
-// generateSecretKey generates a cryptographically random secret key for cancel requests.
-func generateSecretKey() int32 {
-	n, err := rand.Int(rand.Reader, big.NewInt(1<<31))
-	if err != nil {
-		// Fallback to time-based key if crypto/rand fails
-		return int32(time.Now().UnixNano() & 0x7FFFFFFF)
-	}
-	return int32(n.Int64())
-}
+// generateSecretKey is a thin alias for wire.GenerateSecretKey kept for the
+// internal call sites in this file. New code should call wire.GenerateSecretKey
+// directly.
+var generateSecretKey = wire.GenerateSecretKey
 
 // backendKey returns the backend key for this connection, used for cancel requests.
 func (c *clientConn) backendKey() BackendKey {

--- a/server/exports.go
+++ b/server/exports.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"time"
+
+	"github.com/posthog/duckgres/server/wire"
 )
 
 // Exported wrappers for protocol functions used by the control plane worker.
@@ -122,10 +124,10 @@ func InitMinimalServer(s *Server, cfg Config, queryCancelCh <-chan struct{}) {
 	s.conns = make(map[int32]*clientConn)
 }
 
-// GenerateSecretKey generates a cryptographically random secret key for cancel requests.
-func GenerateSecretKey() int32 {
-	return generateSecretKey()
-}
+// GenerateSecretKey re-exports wire.GenerateSecretKey so existing callers
+// that imported it from server keep compiling. New code should use
+// server/wire directly.
+var GenerateSecretKey = wire.GenerateSecretKey
 
 
 // SetQueryLogger sets the query logger on a Server. Used by the control plane

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/sysinfo"
+	"github.com/posthog/duckgres/server/wire"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -175,11 +176,10 @@ var scanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOp
 	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 1e10, 1e11, 1e12},
 }, []string{"org"})
 
-// BackendKey uniquely identifies a backend connection for cancel requests
-type BackendKey struct {
-	Pid       int32
-	SecretKey int32
-}
+// BackendKey moved to server/wire. Alias kept for back-compat with the
+// dozens of references to server.BackendKey across this package and the
+// control plane.
+type BackendKey = wire.BackendKey
 
 // RedactSecrets replaces password=<value> (and password: <value>) patterns with
 // password=[REDACTED] for safe logging and error reporting. It handles both quoted

--- a/server/wire/backend_key.go
+++ b/server/wire/backend_key.go
@@ -1,0 +1,30 @@
+// Package wire holds duckgres wire-level types and helpers shared between
+// the PG protocol layer and the control plane / worker RPC paths. The
+// package has no dependency on github.com/duckdb/duckdb-go so callers
+// (notably the control plane) can use it without linking libduckdb.
+package wire
+
+import (
+	"crypto/rand"
+	"math/big"
+	"time"
+)
+
+// BackendKey identifies a backend connection for PostgreSQL cancel requests.
+// Pid is the backend process id surfaced to the client; SecretKey is the
+// matching secret a cancel request must present.
+type BackendKey struct {
+	Pid       int32
+	SecretKey int32
+}
+
+// GenerateSecretKey returns a cryptographically random secret key suitable
+// for embedding in a BackendKey. Falls back to a time-based key if
+// crypto/rand fails.
+func GenerateSecretKey() int32 {
+	n, err := rand.Int(rand.Reader, big.NewInt(1<<31))
+	if err != nil {
+		return int32(time.Now().UnixNano() & 0x7FFFFFFF)
+	}
+	return int32(n.Int64())
+}

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -1,0 +1,41 @@
+package wire
+
+import "github.com/posthog/duckgres/server/ducklake"
+
+// WorkerControlMetadata identifies the logical worker owner on a control
+// plane → worker request.
+type WorkerControlMetadata struct {
+	WorkerID     int    `json:"worker_id"`
+	OwnerEpoch   int64  `json:"owner_epoch"`
+	CPInstanceID string `json:"cp_instance_id,omitempty"`
+}
+
+// WorkerActivationPayload is the tenant runtime material delivered to a
+// shared warm worker over the control plane RPC path.
+type WorkerActivationPayload struct {
+	WorkerControlMetadata
+	OrgID    string          `json:"org_id"`
+	DuckLake ducklake.Config `json:"ducklake"`
+}
+
+// WorkerCreateSessionPayload is the control plane request body for creating
+// a worker-local session.
+type WorkerCreateSessionPayload struct {
+	WorkerControlMetadata
+	Username    string `json:"username"`
+	MemoryLimit string `json:"memory_limit"`
+	Threads     int    `json:"threads"`
+}
+
+// WorkerDestroySessionPayload is the control plane request body for
+// destroying a worker-local session.
+type WorkerDestroySessionPayload struct {
+	WorkerControlMetadata
+	SessionToken string `json:"session_token"`
+}
+
+// WorkerHealthCheckPayload is the control plane request body for
+// health-checking a worker.
+type WorkerHealthCheckPayload struct {
+	WorkerControlMetadata
+}

--- a/server/worker_activation.go
+++ b/server/worker_activation.go
@@ -1,9 +1,8 @@
 package server
 
-// WorkerActivationPayload is the tenant runtime material delivered to a shared
-// warm worker over the control-plane RPC path.
-type WorkerActivationPayload struct {
-	WorkerControlMetadata
-	OrgID    string         `json:"org_id"`
-	DuckLake DuckLakeConfig `json:"ducklake"`
-}
+import "github.com/posthog/duckgres/server/wire"
+
+// WorkerActivationPayload moved to server/wire so the control plane can use
+// it without importing the rest of server. The alias preserves the existing
+// server.WorkerActivationPayload spelling for current call sites.
+type WorkerActivationPayload = wire.WorkerActivationPayload

--- a/server/worker_control.go
+++ b/server/worker_control.go
@@ -1,31 +1,16 @@
 package server
 
-// WorkerControlMetadata identifies the logical worker owner on a control-plane
-// to worker request.
-type WorkerControlMetadata struct {
-	WorkerID     int    `json:"worker_id"`
-	OwnerEpoch   int64  `json:"owner_epoch"`
-	CPInstanceID string `json:"cp_instance_id,omitempty"`
-}
+import "github.com/posthog/duckgres/server/wire"
 
-// WorkerCreateSessionPayload is the control-plane request body for creating a
-// worker-local session.
-type WorkerCreateSessionPayload struct {
-	WorkerControlMetadata
-	Username    string `json:"username"`
-	MemoryLimit string `json:"memory_limit"`
-	Threads     int    `json:"threads"`
-}
+// Aliases retained so existing references to server.WorkerControlMetadata,
+// server.WorkerCreateSessionPayload, server.WorkerDestroySessionPayload and
+// server.WorkerHealthCheckPayload continue to compile after the types
+// moved to server/wire. New code should import server/wire and use
+// wire.X directly.
 
-// WorkerDestroySessionPayload is the control-plane request body for destroying
-// a worker-local session.
-type WorkerDestroySessionPayload struct {
-	WorkerControlMetadata
-	SessionToken string `json:"session_token"`
-}
-
-// WorkerHealthCheckPayload is the control-plane request body for health-checking
-// a worker.
-type WorkerHealthCheckPayload struct {
-	WorkerControlMetadata
-}
+type (
+	WorkerControlMetadata       = wire.WorkerControlMetadata
+	WorkerCreateSessionPayload  = wire.WorkerCreateSessionPayload
+	WorkerDestroySessionPayload = wire.WorkerDestroySessionPayload
+	WorkerHealthCheckPayload    = wire.WorkerHealthCheckPayload
+)


### PR DESCRIPTION
## Summary

Carves the small CP↔worker RPC types and PG cancel-request helpers out of `server/` into a new `server/wire` subpackage with **zero `duckdb-go` dependency**.

Symbols moved:

| From | To |
|---|---|
| `server.BackendKey` | `wire.BackendKey` (alias kept in server) |
| `server.GenerateSecretKey` | `wire.GenerateSecretKey` (re-export var kept) |
| `server.WorkerControlMetadata` | `wire.WorkerControlMetadata` (alias kept) |
| `server.WorkerActivationPayload` | `wire.WorkerActivationPayload` (alias kept) |
| `server.WorkerCreateSessionPayload` | `wire.WorkerCreateSessionPayload` (alias kept) |
| `server.WorkerDestroySessionPayload` | `wire.WorkerDestroySessionPayload` (alias kept) |
| `server.WorkerHealthCheckPayload` | `wire.WorkerHealthCheckPayload` (alias kept) |

`WorkerActivationPayload`'s `DuckLake` field is now typed as `ducklake.Config` directly rather than via the `server.DuckLakeConfig` alias.

Also drops two now-unused imports from `server/conn.go` (`crypto/rand` and `math/big`) — both were only used by the moved `generateSecretKey`.

## Why

Continuation of the binary-split plan. Each subpackage extraction reduces the CP's transitive dependency on the larger `server` package, working toward a CP-only binary that doesn't link libduckdb. PRs already merged: arrowmap (#477), ducklake (#480), AppendValue + auth/sysinfo (#482), tlscert + flightclient + sqlcore (#488). After this PR lands, more CP-used symbols live outside `server`.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/wire/... ./server/... ./controlplane/... ./duckdbservice/...` — all green
- [x] `go list -deps ./server/wire | grep duckdb-go` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)