### PR TITLE
refactor(server): extract Tracer + connection metrics into server/observe

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -26,6 +26,7 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
+	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sqlcore"
 	"github.com/posthog/duckgres/server/wire"
 	"github.com/posthog/duckgres/transpiler"
@@ -555,7 +556,7 @@ func (c *clientConn) logQueryStarted(query string) {
 		"query", query,
 		"worker", c.workerID,
 		"worker_pod", c.workerPod,
-		"trace_id", traceIDFromContext(c.ctx))
+		"trace_id", observe.TraceIDFromContext(c.ctx))
 }
 
 // logQueryFinished records a query terminating on the worker. Counter-
@@ -576,7 +577,7 @@ func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64,
 		"rows", rows,
 		"worker", c.workerID,
 		"worker_pod", c.workerPod,
-		"trace_id", traceIDFromContext(c.ctx),
+		"trace_id", observe.TraceIDFromContext(c.ctx),
 	}
 	if err != nil {
 		attrs = append(attrs, "error", err.Error())
@@ -1217,12 +1218,12 @@ func (c *clientConn) handleQuery(body []byte) error {
 	start := time.Now()
 	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 
-	ctx, span := tracer.Start(c.ctx, "duckgres.query",
+	ctx, span := observe.Tracer().Start(c.ctx, "duckgres.query",
 		trace.WithAttributes(
 			attribute.String("duckgres.protocol", "simple"),
 			attribute.String("duckgres.org_id", c.orgID),
 			attribute.String("db.user", c.username),
-			attribute.String("db.statement", truncateForSpan(query)),
+			attribute.String("db.statement", observe.TruncateForSpan(query)),
 		),
 	)
 	defer span.End()
@@ -1297,7 +1298,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 	}
 
 	// Transpile PostgreSQL SQL to DuckDB-compatible SQL
-	_, transpileSpan := tracer.Start(c.ctx, "duckgres.transpile")
+	_, transpileSpan := observe.Tracer().Start(c.ctx, "duckgres.transpile")
 	tr := c.newTranspiler(false)
 	result, err := tr.Transpile(query)
 	transpileSpan.End()
@@ -1387,7 +1388,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		defer cleanup()
 
 		execStart := time.Now()
-		execCtx, execSpan := tracer.Start(ctx, "duckgres.execute")
+		execCtx, execSpan := observe.Tracer().Start(ctx, "duckgres.execute")
 		runExec := func() (ExecResult, error) {
 			execResult, err := c.executor.ExecContext(ctx, query)
 			if err != nil {
@@ -1408,7 +1409,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 
 		execResult, err := runExec()
-		enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -1591,7 +1592,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	defer cleanup()
 
 	execStart := time.Now()
-	execCtx, execSpan := tracer.Start(ctx, "duckgres.execute")
+	execCtx, execSpan := observe.Tracer().Start(ctx, "duckgres.execute")
 	c.logQueryStarted(query)
 	runQuery := func() (RowSet, error) {
 		return c.executor.QueryContext(ctx, query)
@@ -1615,7 +1616,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			},
 		)
 	}
-	enrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+	observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 	execSpan.End()
 	if err != nil {
 		errCode := classifyErrorCode(err)
@@ -1656,7 +1657,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		return 0, errCode, errMsg, nil
 	}
 
-	_, sendSpan := tracer.Start(ctx, "duckgres.send_results")
+	_, sendSpan := observe.Tracer().Start(ctx, "duckgres.send_results")
 	defer sendSpan.End()
 
 	if err := c.sendRowDescription(cols, colTypes); err != nil {
@@ -5238,12 +5239,12 @@ func (c *clientConn) handleExecute(body []byte) {
 	start := time.Now()
 	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 
-	_, span := tracer.Start(c.ctx, "duckgres.query",
+	_, span := observe.Tracer().Start(c.ctx, "duckgres.query",
 		trace.WithAttributes(
 			attribute.String("duckgres.protocol", "extended"),
 			attribute.String("duckgres.org_id", c.orgID),
 			attribute.String("db.user", c.username),
-			attribute.String("db.statement", truncateForSpan(p.stmt.query)),
+			attribute.String("db.statement", observe.TruncateForSpan(p.stmt.query)),
 		),
 	)
 	defer span.End()

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -1,0 +1,44 @@
+package observe
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// connectionsGauge tracks the number of currently open client connections.
+// Use IncrementOpenConnections / DecrementOpenConnections to mutate it.
+var connectionsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "duckgres_connections_open",
+	Help: "Number of currently open client connections",
+})
+
+// IncrementOpenConnections increments the open connections gauge.
+func IncrementOpenConnections() { connectionsGauge.Inc() }
+
+// DecrementOpenConnections decrements the open connections gauge.
+func DecrementOpenConnections() { connectionsGauge.Dec() }
+
+// S3BytesReadTotal counts bytes read from S3 by DuckDB, labeled by org.
+// Bumped from EnrichSpanWithProfiling when DuckDB reports total_bytes_read
+// in its profiling output.
+var S3BytesReadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_s3_bytes_read_total",
+	Help: "Total bytes read from S3 by DuckDB",
+}, []string{"org"})
+
+// ScanWallSecondsHistogram observes estimated wall-clock scan time per query.
+var ScanWallSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_scan_wall_seconds",
+	Help:    "Estimated wall-clock scan time per query",
+	Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60},
+}, []string{"org"})
+
+// ScanRowsPerSecondHistogram observes scan throughput (estimated wall-clock
+// rows scanned per second). High values (>1e10) indicate buffer pool / cache
+// hits; the bucket range spans S3 cold reads (1e5-1e8) through in-memory
+// cache hits (1e9-1e12).
+var ScanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_scan_rows_per_second",
+	Help:    "Scan throughput: estimated wall-clock rows scanned per second. High values (>1e10) indicate buffer pool/cache hits.",
+	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 1e10, 1e11, 1e12},
+}, []string{"org"})

--- a/server/observe/tracing.go
+++ b/server/observe/tracing.go
@@ -1,4 +1,9 @@
-package server
+// Package observe holds duckgres' OpenTelemetry tracing helpers, the
+// connection-count gauge, and the per-query Prometheus metrics emitted from
+// the trace path. The package has no dependency on github.com/duckdb/duckdb-go,
+// so the control plane and other duckdb-free callers can use it without
+// linking libduckdb.
+package observe
 
 import (
 	"context"
@@ -9,19 +14,19 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/posthog/duckgres/server/sqlcore"
 )
 
-// tracer is the package-level tracer for the server package.
+// tracer is the package-level OTEL tracer. Exposed via Tracer() so callers
+// outside this package can start spans linked to server operations.
 var tracer = otel.Tracer("duckgres/server")
 
-// Tracer returns the server package tracer for use by other packages
-// that need to create spans linked to server operations.
-func Tracer() trace.Tracer {
-	return tracer
-}
+// Tracer returns the package-level tracer.
+func Tracer() trace.Tracer { return tracer }
 
-// truncateForSpan truncates a query string for use as a span attribute.
-func truncateForSpan(q string) string {
+// TruncateForSpan truncates a query string for use as a span attribute.
+func TruncateForSpan(q string) string {
 	const maxLen = 256
 	if len(q) <= maxLen {
 		return q
@@ -29,20 +34,22 @@ func truncateForSpan(q string) string {
 	return q[:maxLen] + "..."
 }
 
-// profilingRoot represents the top-level DuckDB JSON profiling output.
+// ProfilingRoot represents the top-level DuckDB JSON profiling output.
+type ProfilingRoot = profilingRoot
+
 type profilingRoot struct {
-	Latency                  float64           `json:"latency"`
-	CPUTime                  float64           `json:"cpu_time"`
-	RowsReturned             uint64            `json:"rows_returned"`
-	ResultSetSize            uint64            `json:"result_set_size"`
-	TotalMemoryAllocated     uint64            `json:"total_memory_allocated"`
-	PeakBufferMemory         uint64            `json:"system_peak_buffer_memory"`
-	TotalBytesRead           uint64            `json:"total_bytes_read"`
-	Planner                  float64           `json:"planner"`
-	PlannerBinding           float64           `json:"planner_binding"`
-	CumulativeOptimizerTiming float64          `json:"cumulative_optimizer_timing"`
-	PhysicalPlanner          float64           `json:"physical_planner"`
-	Children                 []profilingOperator `json:"children"`
+	Latency                   float64             `json:"latency"`
+	CPUTime                   float64             `json:"cpu_time"`
+	RowsReturned              uint64              `json:"rows_returned"`
+	ResultSetSize             uint64              `json:"result_set_size"`
+	TotalMemoryAllocated      uint64              `json:"total_memory_allocated"`
+	PeakBufferMemory          uint64              `json:"system_peak_buffer_memory"`
+	TotalBytesRead            uint64              `json:"total_bytes_read"`
+	Planner                   float64             `json:"planner"`
+	PlannerBinding            float64             `json:"planner_binding"`
+	CumulativeOptimizerTiming float64             `json:"cumulative_optimizer_timing"`
+	PhysicalPlanner           float64             `json:"physical_planner"`
+	Children                  []profilingOperator `json:"children"`
 }
 
 type profilingOperator struct {
@@ -53,7 +60,15 @@ type profilingOperator struct {
 	Children            []profilingOperator `json:"children"`
 }
 
-// parseProfilingOutput extracts the full profiling tree from DuckDB's JSON output.
+// ParseProfilingOutput extracts the full profiling tree from DuckDB's JSON
+// output. Exposed for the integration test in package server, which captures
+// real DuckDB profiling JSON and verifies our parser handles it.
+func ParseProfilingOutput(jsonStr string) (profilingRoot, bool) {
+	return parseProfilingOutput(jsonStr)
+}
+
+// parseProfilingOutput is the internal worker — kept private so the rest of
+// observe can switch on the lowercase type without exposing it.
 func parseProfilingOutput(jsonStr string) (profilingRoot, bool) {
 	if jsonStr == "" {
 		return profilingRoot{}, false
@@ -89,10 +104,10 @@ func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64
 	return
 }
 
-// enrichSpanWithProfiling creates child spans from DuckDB profiling output
+// EnrichSpanWithProfiling creates child spans from DuckDB profiling output
 // showing where execution time was spent: planning, scanning (I/O), and compute.
 // Also emits Prometheus metrics for baseline measurement.
-func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor QueryExecutor, orgID string) {
+func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor sqlcore.QueryExecutor, orgID string) {
 	output := executor.LastProfilingOutput()
 	if output == "" {
 		return
@@ -102,7 +117,6 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		return
 	}
 
-	// Set top-level metrics on the execute span.
 	span.SetAttributes(
 		attribute.Float64("duckdb.latency_s", m.Latency),
 		attribute.Int64("duckdb.rows_returned", int64(m.RowsReturned)),
@@ -112,9 +126,6 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 	)
 
-	// Create child spans with explicit timestamps for the planning, scan,
-	// and compute phases. These are approximate — operators may overlap in
-	// parallel execution — but give a useful visual breakdown.
 	planningDur := m.Planner + m.PlannerBinding + m.CumulativeOptimizerTiming + m.PhysicalPlanner
 	scanTime, scanRows, computeTime := collectOperatorTimings(m.Children)
 
@@ -131,10 +142,6 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		planSpan.End(trace.WithTimestamp(cursor))
 	}
 
-	// Estimate wall-clock time for scan vs compute. DuckDB runs operators in
-	// parallel, so cumulative times exceed wall-clock. Use the ratio of
-	// cumulative scan/(scan+compute) applied to the execution wall-clock
-	// (latency minus planning) to approximate each phase's wall-clock share.
 	execWall := m.Latency - planningDur
 	totalOpTime := scanTime + computeTime
 	scanWall := execWall
@@ -144,9 +151,8 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		computeWall = execWall * (computeTime / totalOpTime)
 	}
 
-	// Emit Prometheus metrics for baseline measurement.
-	s3BytesReadTotal.WithLabelValues(orgID).Add(float64(m.TotalBytesRead))
-	scanWallSecondsHistogram.WithLabelValues(orgID).Observe(scanWall)
+	S3BytesReadTotal.WithLabelValues(orgID).Add(float64(m.TotalBytesRead))
+	ScanWallSecondsHistogram.WithLabelValues(orgID).Observe(scanWall)
 	scanRowsWallEstimate := scanRows
 	if m.CPUTime > 0 && m.Latency > 0 {
 		if p := m.CPUTime / m.Latency; p > 1 {
@@ -154,12 +160,10 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		}
 	}
 	if scanWall > 0 && scanRowsWallEstimate > 0 {
-		scanRowsPerSecondHistogram.WithLabelValues(orgID).Observe(scanRowsWallEstimate / scanWall)
+		ScanRowsPerSecondHistogram.WithLabelValues(orgID).Observe(scanRowsWallEstimate / scanWall)
 	}
 
 	if scanTime > 0 {
-		// Estimate actual rows scanned (deduplicated across threads).
-		// scan_rows_cumulative counts each thread's rows independently.
 		scanRowsWall := scanRows
 		if m.CPUTime > 0 && m.Latency > 0 {
 			parallelism := m.CPUTime / m.Latency
@@ -190,8 +194,8 @@ func enrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 	}
 }
 
-// traceIDFromContext returns the hex trace ID from the span context, or "".
-func traceIDFromContext(ctx context.Context) string {
+// TraceIDFromContext returns the hex trace ID from the span context, or "".
+func TraceIDFromContext(ctx context.Context) string {
 	sc := trace.SpanContextFromContext(ctx)
 	if sc.HasTraceID() {
 		return sc.TraceID().String()
@@ -199,8 +203,8 @@ func traceIDFromContext(ctx context.Context) string {
 	return ""
 }
 
-// spanIDFromContext returns the hex span ID from the span context, or "".
-func spanIDFromContext(ctx context.Context) string {
+// SpanIDFromContext returns the hex span ID from the span context, or "".
+func SpanIDFromContext(ctx context.Context) string {
 	sc := trace.SpanContextFromContext(ctx)
 	if sc.HasSpanID() {
 		return sc.SpanID().String()

--- a/server/observe_aliases.go
+++ b/server/observe_aliases.go
@@ -1,0 +1,9 @@
+package server
+
+import "github.com/posthog/duckgres/server/observe"
+
+// Tracer re-exports observe.Tracer for callers that previously imported it
+// from this package. The tracing helpers, profiling-output enrichment, and
+// connection counters all live in server/observe; new code should import
+// that package directly.
+var Tracer = observe.Tracer

--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+
+	"github.com/posthog/duckgres/server/observe"
 )
 
 func TestProfilingOutputToFile(t *testing.T) {
@@ -49,7 +51,7 @@ func TestProfilingOutputToFile(t *testing.T) {
 	}
 
 	// Parse and verify key fields
-	m, ok := parseProfilingOutput(string(data))
+	m, ok := observe.ParseProfilingOutput(string(data))
 	if !ok {
 		t.Fatalf("failed to parse profiling output: %s", data[:min(200, len(data))])
 	}

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -14,6 +14,7 @@ import (
 	"unicode"
 
 	"github.com/posthog/duckgres/server/ducklake"
+	"github.com/posthog/duckgres/server/observe"
 )
 
 // QueryLogEntry represents a single entry in the query log.
@@ -520,8 +521,8 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 		WorkerID:        c.workerID,
 		IsTranspiled:    transpiled != nil,
 		Protocol:        protocol,
-		TraceID:         traceIDFromContext(c.ctx),
-		SpanID:          spanIDFromContext(c.ctx),
+		TraceID:         observe.TraceIDFromContext(c.ctx),
+		SpanID:          observe.SpanIDFromContext(c.ctx),
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for direct PostgreSQL connections
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/ducklake"
+	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sysinfo"
 	"github.com/posthog/duckgres/server/wire"
 	"github.com/prometheus/client_golang/prometheus"
@@ -110,17 +111,13 @@ func setExtensionDirectory(db *sql.DB, dataDir string) error {
 // passwordPattern matches password=<value> or password: <value> with quoted or unquoted values.
 var passwordPattern = regexp.MustCompile(`(?i)(password\s*[=:]\s*)("[^"]*"|[^\s"]+)`)
 
-var connectionsGauge = promauto.NewGauge(prometheus.GaugeOpts{
-	Name: "duckgres_connections_open",
-	Help: "Number of currently open client connections",
-})
-
-// IncrementOpenConnections increments the open connections gauge.
-// Used by the control plane which handles connections separately from the standalone server.
-func IncrementOpenConnections() { connectionsGauge.Inc() }
-
-// DecrementOpenConnections decrements the open connections gauge.
-func DecrementOpenConnections() { connectionsGauge.Dec() }
+// connectionsGauge, IncrementOpenConnections, DecrementOpenConnections moved
+// to server/observe. The aliases below preserve the existing server.X
+// spellings for the call sites in this package and the control plane.
+var (
+	IncrementOpenConnections = observe.IncrementOpenConnections
+	DecrementOpenConnections = observe.DecrementOpenConnections
+)
 
 var queryDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "duckgres_query_duration_seconds",
@@ -158,23 +155,8 @@ var ducklakeConflictRetriesExhaustedTotal = promauto.NewCounter(prometheus.Count
 	Help: "Total number of DuckLake transaction conflicts where all retries were exhausted",
 })
 
-var s3BytesReadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "duckgres_s3_bytes_read_total",
-	Help: "Total bytes read from S3 by DuckDB",
-}, []string{"org"})
-
-var scanWallSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "duckgres_scan_wall_seconds",
-	Help:    "Estimated wall-clock scan time per query",
-	Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60},
-}, []string{"org"})
-
-var scanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name: "duckgres_scan_rows_per_second",
-	Help: "Scan throughput: estimated wall-clock rows scanned per second. High values (>1e10) indicate buffer pool/cache hits.",
-	// Range spans S3 cold reads (1e5-1e8) through in-memory cache hits (1e9-1e12).
-	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 1e10, 1e11, 1e12},
-}, []string{"org"})
+// s3BytesReadTotal, scanWallSecondsHistogram, scanRowsPerSecondHistogram
+// moved to server/observe alongside the tracing helpers that bump them.
 
 // BackendKey moved to server/wire. Alias kept for back-compat with the
 // dozens of references to server.BackendKey across this package and the
@@ -1422,7 +1404,7 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 		slog.Info("Attaching DuckLake catalog.", "metadata", redactConnectionString(dlCfg.MetadataStore))
 	}
 
-	_, attachSpan := tracer.Start(context.Background(), "duckgres.ducklake_attach")
+	_, attachSpan := observe.Tracer().Start(context.Background(), "duckgres.ducklake_attach")
 	if err := retryOnTransientAttach(func() error {
 		_, err := db.Exec(attachStmt)
 		return err
@@ -2101,10 +2083,10 @@ func (s *Server) handleConnectionInProcess(conn net.Conn, remoteAddr net.Addr) {
 
 	// Track active connections (only after rate limiting passes)
 	atomic.AddInt64(&s.activeConns, 1)
-	connectionsGauge.Inc()
+	observe.IncrementOpenConnections()
 	defer func() {
 		atomic.AddInt64(&s.activeConns, -1)
-		connectionsGauge.Dec()
+		observe.DecrementOpenConnections()
 	}()
 
 	// Ensure we unregister when done
@@ -2218,7 +2200,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 		// We spawn a child process to handle TLS and everything after.
 		// Track active connections
 		atomic.AddInt64(&s.activeConns, 1)
-		connectionsGauge.Inc()
+		observe.IncrementOpenConnections()
 
 		// Spawn child process - it will do TLS handshake and read the startup message
 		child, err := s.spawnChildForTLS(conn)
@@ -2226,7 +2208,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 			slog.Error("Failed to spawn child process.", "remote_addr", remoteAddr, "error", err)
 			s.rateLimiter.UnregisterConnection(remoteAddr)
 			atomic.AddInt64(&s.activeConns, -1)
-			connectionsGauge.Dec()
+			observe.DecrementOpenConnections()
 			_ = conn.Close()
 			return
 		}
@@ -2239,7 +2221,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 			s.monitorChild(child)
 			s.rateLimiter.UnregisterConnection(remoteAddr)
 			atomic.AddInt64(&s.activeConns, -1)
-			connectionsGauge.Dec()
+			observe.DecrementOpenConnections()
 		}()
 	} else {
 		// No SSL request - reject connection (TLS is required)


### PR DESCRIPTION
## Summary

Carves the OpenTelemetry tracing helpers, the connection-count gauge, and the per-query Prometheus metrics emitted from the tracing path out of `server/` into a new `server/observe` subpackage with **zero `duckdb-go` dependency**.

Symbols moved:

| From | To | Notes |
|---|---|---|
| (private) `tracer` | `observe.Tracer()` | accessor func |
| (private) `truncateForSpan` | `observe.TruncateForSpan` | |
| (private) `profilingRoot/Operator` | private to observe | |
| (private) `parseProfilingOutput` | `observe.ParseProfilingOutput` | exposed because `server/profiling_test.go` captures real DuckDB JSON and needs the parser |
| (private) `enrichSpanWithProfiling` | `observe.EnrichSpanWithProfiling` | |
| (private) `traceIDFromContext` / `spanIDFromContext` | `observe.TraceIDFromContext` / `observe.SpanIDFromContext` | |
| (private) `connectionsGauge` | private to observe | |
| `server.IncrementOpenConnections` / `server.DecrementOpenConnections` | `observe.IncrementOpenConnections` / etc. | re-exported via `var` in server/ |
| (private) `s3BytesReadTotal`, `scanWallSecondsHistogram`, `scanRowsPerSecondHistogram` | `observe.S3BytesReadTotal`, `observe.ScanWallSecondsHistogram`, `observe.ScanRowsPerSecondHistogram` | exported because `EnrichSpanWithProfiling` bumps them |

Backward compatibility preserved via:
- `var IncrementOpenConnections = observe.IncrementOpenConnections` (and Decrement) in `server/server.go`
- `var Tracer = observe.Tracer` in a new `server/observe_aliases.go`

Internal callers in `server/conn.go`, `server/server.go`, and `server/querylog.go` updated to call `observe.X` directly.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/observe/... ./server/... ./controlplane/... ./duckdbservice/...` — green except the pre-existing `server/tlscert` hang on real ACME calls (reproduces on main, unrelated)
- [x] `go list -deps ./server/observe | grep duckdb-go` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)