### PR TITLE
refactor(server): extract session database metadata into server/sessionmeta

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -26,6 +26,7 @@ import (
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/flightsqlingress"
+	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -1009,7 +1010,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	}()
 
 	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	err = server.InitSessionDatabaseMetadata(initCtx, executor, database)
+	err = sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, database)
 	if err != nil {
 		initCancel()
 		slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
@@ -1017,7 +1018,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		_ = writer.Flush()
 		return
 	}
-	duckLakeAttached, err := server.HasAttachedCatalog(initCtx, executor, "ducklake")
+	duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
 	initCancel()
 	if err != nil {
 		slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)

--- a/server/conn.go
+++ b/server/conn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/observe"
+	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/sqlcore"
 	"github.com/posthog/duckgres/server/wire"
 	"github.com/posthog/duckgres/transpiler"
@@ -938,12 +939,12 @@ func (c *clientConn) serve() error {
 
 	if !c.passthrough {
 		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := InitSessionDatabaseMetadata(initCtx, c.executor, c.database); err != nil {
+		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, c.database); err != nil {
 			initCancel()
 			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to initialize session database metadata: %v", err))
 			return err
 		}
-		duckLakeAttached, err := hasAttachedCatalog(initCtx, c.executor, "ducklake")
+		duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, c.executor, "ducklake")
 		initCancel()
 		if err != nil {
 			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to detect ducklake catalog attachment: %v", err))

--- a/server/exports.go
+++ b/server/exports.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/wire"
 )
 
@@ -92,11 +93,14 @@ func SetLogicalCatalogMapping(cc *clientConn, enabled bool) {
 	}
 }
 
-// HasAttachedCatalog reports whether the named catalog is attached in the
-// current session.
-func HasAttachedCatalog(ctx context.Context, executor QueryExecutor, catalog string) (bool, error) {
-	return hasAttachedCatalog(ctx, executor, catalog)
-}
+// HasAttachedCatalog and InitSessionDatabaseMetadata moved to
+// server/sessionmeta. Re-exports kept here for the dozen call sites in
+// the control plane and elsewhere; new code should import server/sessionmeta
+// directly.
+var (
+	HasAttachedCatalog           = sessionmeta.HasAttachedCatalog
+	InitSessionDatabaseMetadata  = sessionmeta.InitSessionDatabaseMetadata
+)
 
 // SendInitialParams sends the initial parameter status messages and backend key data.
 func SendInitialParams(cc *clientConn) {

--- a/server/session_database_metadata_remote_test.go
+++ b/server/session_database_metadata_remote_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/posthog/duckgres/server/sessionmeta"
 )
 
 type attachedCatalogProbeExecutor struct {
@@ -86,9 +88,9 @@ func (r *attachedCatalogProbeRowSet) Err() error {
 func TestHasAttachedCatalogUsesEmbeddedCatalogLiteral(t *testing.T) {
 	executor := &attachedCatalogProbeExecutor{}
 
-	attached, err := hasAttachedCatalog(context.Background(), executor, "ducklake")
+	attached, err := sessionmeta.HasAttachedCatalog(context.Background(), executor, "ducklake")
 	if err != nil {
-		t.Fatalf("hasAttachedCatalog returned error: %v", err)
+		t.Fatalf("sessionmeta.HasAttachedCatalog returned error: %v", err)
 	}
 	if !attached {
 		t.Fatal("expected ducklake catalog to be reported as attached")

--- a/server/session_database_metadata_test.go
+++ b/server/session_database_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server/sessionmeta"
 )
 
 type recordingQueryExecutor struct {
@@ -67,9 +68,9 @@ func TestHasAttachedCatalogEmbedsCatalogNameWithoutBoundArgs(t *testing.T) {
 		rowSet: &staticCountRowSet{count: 1},
 	}
 
-	attached, err := hasAttachedCatalog(context.Background(), exec, "ducklake")
+	attached, err := sessionmeta.HasAttachedCatalog(context.Background(), exec, "ducklake")
 	if err != nil {
-		t.Fatalf("hasAttachedCatalog returned error: %v", err)
+		t.Fatalf("sessionmeta.HasAttachedCatalog returned error: %v", err)
 	}
 	if !attached {
 		t.Fatal("expected attached catalog to be detected")
@@ -91,7 +92,7 @@ func TestInitSessionDatabaseMetadataOverridesCurrentDatabaseAndPgDatabase(t *tes
 	defer func() { _ = db.Close() }()
 
 	executor := NewLocalExecutor(db)
-	if err := initSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
+	if err := sessionmeta.InitSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
 		t.Fatalf("init session database metadata: %v", err)
 	}
 
@@ -146,7 +147,7 @@ func TestInitSessionDatabaseMetadataOverridesInformationSchemaCatalogColumns(t *
 	}
 
 	executor := NewLocalExecutor(db)
-	if err := initSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
+	if err := sessionmeta.InitSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
 		t.Fatalf("init session database metadata: %v", err)
 	}
 
@@ -208,7 +209,7 @@ func TestInitSessionDatabaseMetadataExcludesInternalDuckLakeMetadataCatalogs(t *
 	}
 
 	executor := NewLocalExecutor(db)
-	if err := initSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
+	if err := sessionmeta.InitSessionDatabaseMetadata(context.Background(), executor, "analytics"); err != nil {
 		t.Fatalf("init session database metadata: %v", err)
 	}
 

--- a/server/sessionmeta/sessionmeta.go
+++ b/server/sessionmeta/sessionmeta.go
@@ -1,14 +1,23 @@
-package server
+// Package sessionmeta installs session-local catalog/metadata overrides on
+// a duckgres connection (current_database, pg_database, information_schema
+// views) so they reflect the client-visible database name on the PG wire.
+//
+// Pure helpers — no dependency on github.com/duckdb/duckdb-go. The control
+// plane and other duckdb-free callers use this package without linking
+// libduckdb.
+package sessionmeta
 
 import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/posthog/duckgres/server/sqlcore"
 )
 
 // InitSessionDatabaseMetadata installs session-local overrides for metadata
 // surfaces that should reflect the client-visible database name on pgwire.
-func InitSessionDatabaseMetadata(ctx context.Context, executor QueryExecutor, database string) error {
+func InitSessionDatabaseMetadata(ctx context.Context, executor sqlcore.QueryExecutor, database string) error {
 	if executor == nil {
 		return fmt.Errorf("session executor is required")
 	}
@@ -25,7 +34,7 @@ func InitSessionDatabaseMetadata(ctx context.Context, executor QueryExecutor, da
 		return fmt.Errorf("create current_database() macro: %w", err)
 	}
 
-	duckLakeAttached, err := hasAttachedCatalog(ctx, executor, "ducklake")
+	duckLakeAttached, err := HasAttachedCatalog(ctx, executor, "ducklake")
 	if err != nil {
 		return fmt.Errorf("detect ducklake attachment: %w", err)
 	}
@@ -51,11 +60,7 @@ func InitSessionDatabaseMetadata(ctx context.Context, executor QueryExecutor, da
 	return nil
 }
 
-func initSessionDatabaseMetadata(ctx context.Context, executor QueryExecutor, database string) error {
-	return InitSessionDatabaseMetadata(ctx, executor, database)
-}
-
-func hasAttachedCatalog(ctx context.Context, executor QueryExecutor, catalog string) (bool, error) {
+func HasAttachedCatalog(ctx context.Context, executor sqlcore.QueryExecutor, catalog string) (bool, error) {
 	query := fmt.Sprintf(
 		"SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = %s",
 		quoteSQLStringLiteral(catalog),


### PR DESCRIPTION
## Summary

Carves the session-local catalog/metadata override helpers out of `server/` into a new `server/sessionmeta` subpackage with **zero `duckdb-go` dependency**.

The helpers install per-session DuckDB views/macros that make `current_database`, `pg_database`, and the various `information_schema_*_compat` views reflect the client-visible database name on the PG wire — used by both the standalone server's `clientConn` and the control plane's session bring-up.

Symbols moved from `server/session_database_metadata.go` to `server/sessionmeta/sessionmeta.go`:
- `InitSessionDatabaseMetadata` (exported)
- `HasAttachedCatalog` (was private `hasAttachedCatalog`; now exported)
- All `buildSession*` / `sessionColumn*` SQL builder helpers (private)
- `quoteSQLStringLiteral` (private)

The `QueryExecutor` parameter is now `sqlcore.QueryExecutor` (the interface moved in PR #488) instead of `server.QueryExecutor`.

## Backward compatibility

`server/exports.go` keeps re-export `var`s for the externally-used symbols, so existing `server.HasAttachedCatalog` / `server.InitSessionDatabaseMetadata` callers (control plane, etc.) compile unchanged. Internal callers in `server/conn.go` and `controlplane/control.go` now use `sessionmeta.X` directly.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/...` — green except the pre-existing `server/tlscert` hang on real ACME calls (unrelated)
- [x] `go list -deps ./server/sessionmeta | grep duckdb-go` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)