### PR TITLE
refactor(server): extract ClickHouse SQL macro initializer into server/chsql

### DIFF
--- a/server/chsql/chsql.go
+++ b/server/chsql/chsql.go
@@ -1,15 +1,15 @@
-package server
+package chsql
 
 import (
 	"database/sql"
 	"log/slog"
 )
 
-// initClickHouseMacros registers ClickHouse SQL function macros so that
+// InitMacros registers ClickHouse SQL function macros so that
 // ClickHouse-flavoured queries work out of the box against DuckDB.
 // This is a subset of the chsql community extension's functions, implemented
 // as plain SQL macros following the same pattern as initUtilityMacros.
-func initClickHouseMacros(db *sql.DB) {
+func InitMacros(db *sql.DB) {
 	macros := []string{
 		// -- Type conversion --
 		`CREATE OR REPLACE MACRO toString(x) AS CAST(x AS VARCHAR)`,

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for direct PostgreSQL connections
 	"github.com/posthog/duckgres/server/auth"
+	"github.com/posthog/duckgres/server/chsql"
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sysinfo"
@@ -1004,7 +1005,7 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 	}
 
 	// Register ClickHouse SQL macros (chsql compat)
-	initClickHouseMacros(db)
+	chsql.InitMacros(db)
 
 	// Attach DuckLake catalog if configured (but don't set as default yet)
 	duckLakeMode := false
@@ -1102,7 +1103,7 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 	initUtilityMacros(db, serverStartTime, processStartTime, serverVersion, processVersion)
 
 	// Register ClickHouse SQL macros (chsql compat)
-	initClickHouseMacros(db)
+	chsql.InitMacros(db)
 
 	// Attach DuckLake catalog if configured (same data, no pg_catalog views)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {


### PR DESCRIPTION
## Summary

Small extraction: moves `initClickHouseMacros` (the registrar for ClickHouse-style SQL function macros — `toString`, `intDiv`, `splitByChar`, etc.) out of `server/` into a new `server/chsql` subpackage.

Renamed: `initClickHouseMacros` → `chsql.InitMacros` (package name supplies the context).

`server/server.go`'s two call sites (in standalone DB setup) updated to `chsql.InitMacros(db)`. No other callers — the function is internal-only, so no aliases needed.

`go list -deps ./server/chsql | grep duckdb-go` returns empty.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go list -deps ./server/chsql | grep duckdb-go` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)