### PR TITLE
refactor(server): drop duckdb-go imports from types.go via a value-normalizer hook

### DIFF
--- a/duckdbservice/appender_init.go
+++ b/duckdbservice/appender_init.go
@@ -6,17 +6,44 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
+	"github.com/posthog/duckgres/server"
 )
 
 // init registers handlers for the duckdb-go driver value types so that any
-// caller (including arrowmap.AppendValue and the wrapper duckdbservice.AppendValue)
-// gets full type coverage when this package is linked into the binary.
+// caller gets full type coverage when this package is linked into the binary:
+//   - arrowmap.AppendValue gets a hook for the Arrow array builders that
+//     receive duckdb.Interval / Decimal / UUID / OrderedMap / Map values
+//   - server.normalizeDriverValue gets a hook so the PG binary-format
+//     encoders in server/types.go convert duckdb.Interval and duckdb.Decimal
+//     into their arrowmap equivalents (IntervalValue, DecimalValue) before
+//     dispatching
 //
 // Binaries that don't link duckdbservice (e.g., a future control-plane-only
 // binary) won't see these registrations — which is correct, because they
 // also won't be the ones scanning rows from a duckdb-go driver connection.
 func init() {
 	arrowmap.RegisterAppender(handleDuckDBValue)
+	server.RegisterValueNormalizer(normalizeDuckDBValue)
+}
+
+// normalizeDuckDBValue converts the duckdb-go driver's interval and decimal
+// types to their duckdb-free arrowmap equivalents. Other inputs pass
+// through unchanged.
+func normalizeDuckDBValue(v any) any {
+	switch x := v.(type) {
+	case duckdb.Interval:
+		return arrowmap.IntervalValue{
+			Months: x.Months,
+			Days:   x.Days,
+			Micros: x.Micros,
+		}
+	case duckdb.Decimal:
+		return arrowmap.DecimalValue{
+			Value: x.Value,
+			Scale: int(x.Scale),
+		}
+	}
+	return v
 }
 
 // handleDuckDBValue implements arrowmap.Appender for duckdb-go's driver

--- a/duckdbservice/arrowmap/arrowmap.go
+++ b/duckdbservice/arrowmap/arrowmap.go
@@ -323,6 +323,16 @@ type IntervalValue struct {
 	Micros int64
 }
 
+// DecimalValue is the duckdb-free representation of a fixed-precision
+// decimal (the unscaled integer plus the scale). Used by the binary-format
+// encoder in server/types.go so it can switch on this type without
+// importing the duckdb-go driver. duckdbservice's value-normalizer hook
+// converts duckdb.Decimal to arrowmap.DecimalValue at scan time.
+type DecimalValue struct {
+	Value *big.Int
+	Scale int
+}
+
 // Appender is a hook that handles append for value types arrowmap doesn't
 // know about (typically driver-specific types like duckdb.Interval). It
 // reports whether it handled the value; arrowmap.AppendValue falls back to

--- a/server/types.go
+++ b/server/types.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 )
 
@@ -611,21 +610,15 @@ func decodeTime(data []byte) (string, error) {
 // encodeInterval encodes an INTERVAL value in PostgreSQL binary format:
 // int64 microseconds + int32 days + int32 months = 16 bytes.
 func encodeInterval(v interface{}) []byte {
+	v = normalizeDriverValue(v)
 	buf := make([]byte, 16)
-	switch val := v.(type) {
-	case duckdb.Interval:
-		binary.BigEndian.PutUint64(buf[0:8], uint64(val.Micros))
-		binary.BigEndian.PutUint32(buf[8:12], uint32(val.Days))
-		binary.BigEndian.PutUint32(buf[12:16], uint32(val.Months))
-	case arrowmap.IntervalValue:
-		// Arrow Flight returns arrowmap.IntervalValue instead of duckdb.Interval
-		binary.BigEndian.PutUint64(buf[0:8], uint64(val.Micros))
-		binary.BigEndian.PutUint32(buf[8:12], uint32(val.Days))
-		binary.BigEndian.PutUint32(buf[12:16], uint32(val.Months))
-	default:
-		_ = val
+	val, ok := v.(arrowmap.IntervalValue)
+	if !ok {
 		return nil
 	}
+	binary.BigEndian.PutUint64(buf[0:8], uint64(val.Micros))
+	binary.BigEndian.PutUint32(buf[8:12], uint32(val.Days))
+	binary.BigEndian.PutUint32(buf[12:16], uint32(val.Months))
 	return buf
 }
 
@@ -690,8 +683,8 @@ func encodeNumeric(v interface{}) []byte {
 	var val *big.Int
 	var dscale int16
 
-	switch x := v.(type) {
-	case duckdb.Decimal:
+	switch x := normalizeDriverValue(v).(type) {
+	case arrowmap.DecimalValue:
 		val = new(big.Int).Set(x.Value)
 		dscale = int16(x.Scale)
 	case *big.Int:

--- a/server/types_test.go
+++ b/server/types_test.go
@@ -9,7 +9,26 @@ import (
 	"time"
 
 	duckdb "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 )
+
+// In the all-in-one binary, duckdbservice's init() registers a normalizer
+// that converts duckdb.Interval / duckdb.Decimal to arrowmap.IntervalValue /
+// arrowmap.DecimalValue before encode*Funcs dispatch. We can't import
+// duckdbservice from a server test (import cycle), so register the same
+// hook here so TestEncodeNumeric / TestEncodeInterval keep working.
+func init() {
+	RegisterValueNormalizer(func(v any) any {
+		switch x := v.(type) {
+		case duckdb.Interval:
+			return arrowmap.IntervalValue{Months: x.Months, Days: x.Days, Micros: x.Micros}
+		case duckdb.Decimal:
+			return arrowmap.DecimalValue{Value: x.Value, Scale: int(x.Scale)}
+		}
+		return v
+	})
+}
 
 func TestMapDuckDBType(t *testing.T) {
 	tests := []struct {

--- a/server/value_normalize.go
+++ b/server/value_normalize.go
@@ -1,0 +1,46 @@
+package server
+
+import "sync/atomic"
+
+// ValueNormalizer is a hook that converts driver-specific value types
+// (e.g., duckdb.Interval, duckdb.Decimal) into the duckdb-free equivalents
+// in arrowmap (IntervalValue, DecimalValue) so the binary-format encoders
+// in types.go can handle them without importing the duckdb-go driver.
+//
+// A normalizer must return the input unchanged when it doesn't recognize
+// the type; the encode helpers fall back to AppendNull/return nil when
+// the final value still isn't a recognized type.
+type ValueNormalizer func(any) any
+
+// driverNormalizers is loaded once into an atomic.Value as []ValueNormalizer.
+// Reads on the hot path (every encoded row value) are lock-free; registration
+// happens at init time so contention is rare.
+var driverNormalizers atomic.Value // []ValueNormalizer
+
+// RegisterValueNormalizer adds a hook consulted by normalizeDriverValue
+// before the binary encoders dispatch on the value's type. Intended for use
+// from init() in importers that own driver-specific value types — duckdbservice
+// registers a normalizer that converts duckdb.Interval and duckdb.Decimal to
+// their arrowmap equivalents.
+func RegisterValueNormalizer(n ValueNormalizer) {
+	if n == nil {
+		return
+	}
+	cur, _ := driverNormalizers.Load().([]ValueNormalizer)
+	next := make([]ValueNormalizer, 0, len(cur)+1)
+	next = append(next, cur...)
+	next = append(next, n)
+	driverNormalizers.Store(next)
+}
+
+// normalizeDriverValue runs every registered ValueNormalizer over the value.
+// Each normalizer returns the input unchanged when it doesn't claim it; the
+// final value is whatever the chain produced (or the original input if no
+// normalizers ran or none matched).
+func normalizeDriverValue(v any) any {
+	hooks, _ := driverNormalizers.Load().([]ValueNormalizer)
+	for _, h := range hooks {
+		v = h(v)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary

`server/types.go`'s `encodeInterval` and `encodeNumeric` used to switch on `duckdb.Interval` / `duckdb.Decimal` directly, dragging the duckdb-go driver into the package's import graph. This PR replaces the direct type-switch arms with a registration hook in the same shape as `arrowmap.RegisterAppender` (PR #482).

After this PR:
```
grep duckdb server/types.go     # only a comment, no imports
```

The whole `server` package still links duckdb-go via `server.go`, `conn.go`, `querylog.go`, and `checkpoint.go` — but `types.go` is one fewer file forcing it.

## How it works

- `server/value_normalize.go` adds `RegisterValueNormalizer` and `normalizeDriverValue`. Reads on the hot path are lock-free via `atomic.Value`; registration runs at init time.
- `duckdbservice`'s existing `init()` now also registers a normalizer that converts:
  - `duckdb.Interval` → `arrowmap.IntervalValue`
  - `duckdb.Decimal` → `arrowmap.DecimalValue` (new type, parallel to `IntervalValue` / `OrderedMapValue`)
- `server/types.go`'s `encodeInterval` and `encodeNumeric` call `normalizeDriverValue(v)` first, then dispatch only on the duckdb-free arrowmap types.

In binaries that link `duckdbservice` (worker, all-in-one), the normalizer runs and `duckdb.Interval` / `duckdb.Decimal` values get converted automatically. In a future control-plane-only binary, the normalizer isn't registered — but those values can only originate from a duckdb-go driver `Scan`, so they never reach the encoder in CP-only paths.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/ ./duckdbservice/...` — all green
- [x] `server/types_test.go` registers the same normalizer in its own `init()` (it can't blank-import `duckdbservice` due to an import cycle), so `TestEncodeNumeric` / `TestEncodeInterval` keep working with their `duckdb.Decimal` / `duckdb.Interval` test inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)