### PR TITLE
refactor(server): drop duckdb.Interval from conn.go's formatValue / formatInterval

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -4440,6 +4440,7 @@ func formatValue(v interface{}) string {
 	if v == nil {
 		return ""
 	}
+	v = normalizeDriverValue(v)
 
 	switch val := v.(type) {
 	case []byte:
@@ -4477,12 +4478,12 @@ func formatValue(v interface{}) string {
 	case []any:
 		// PostgreSQL array text format: {1,2,3}
 		return formatArrayValue(val)
-	case duckdb.Interval:
-		// PostgreSQL interval text format: "1 year 2 mons 3 days 04:05:06.123456"
-		return formatInterval(val)
 	case arrowmap.IntervalValue:
-		// Arrow Flight returns arrowmap.IntervalValue instead of duckdb.Interval
-		return formatInterval(duckdb.Interval{Months: val.Months, Days: val.Days, Micros: val.Micros})
+		// PostgreSQL interval text format: "1 year 2 mons 3 days 04:05:06.123456".
+		// Driver-specific interval types (e.g. duckdb.Interval) are converted to
+		// arrowmap.IntervalValue by normalizeDriverValue before reaching this
+		// switch — see server/value_normalize.go.
+		return formatInterval(val)
 	case map[string]any:
 		// STRUCT text format: {"key1": val1, "key2": val2}
 		return formatMapValue(val)
@@ -4494,9 +4495,10 @@ func formatValue(v interface{}) string {
 	}
 }
 
-// formatInterval formats a duckdb.Interval as a PostgreSQL-compatible interval string.
-// Examples: "00:13:08.917797", "1 day 02:30:00", "1 year 2 mons 3 days 04:05:06".
-func formatInterval(iv duckdb.Interval) string {
+// formatInterval formats an arrowmap.IntervalValue as a PostgreSQL-compatible
+// interval string. Examples: "00:13:08.917797", "1 day 02:30:00",
+// "1 year 2 mons 3 days 04:05:06".
+func formatInterval(iv arrowmap.IntervalValue) string {
 	var parts []string
 	if iv.Months != 0 {
 		years := iv.Months / 12

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"testing"
 
-	duckdb "github.com/duckdb/duckdb-go/v2"
 	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/wire"
 )
 
@@ -3271,39 +3271,39 @@ func TestParseMultiLineCSV(t *testing.T) {
 func TestFormatInterval(t *testing.T) {
 	tests := []struct {
 		name     string
-		interval duckdb.Interval
+		interval arrowmap.IntervalValue
 		want     string
 	}{
 		// Zero
-		{"zero", duckdb.Interval{}, "00:00:00"},
+		{"zero", arrowmap.IntervalValue{}, "00:00:00"},
 
 		// Time only
-		{"seconds", duckdb.Interval{Micros: 5_000_000}, "00:00:05"},
-		{"minutes and seconds", duckdb.Interval{Micros: 788_000_000}, "00:13:08"},
-		{"hours minutes seconds", duckdb.Interval{Micros: 3_661_000_000}, "01:01:01"},
-		{"fractional seconds", duckdb.Interval{Micros: 788_917_797}, "00:13:08.917797"},
-		{"exact microseconds", duckdb.Interval{Micros: 1}, "00:00:00.000001"},
+		{"seconds", arrowmap.IntervalValue{Micros: 5_000_000}, "00:00:05"},
+		{"minutes and seconds", arrowmap.IntervalValue{Micros: 788_000_000}, "00:13:08"},
+		{"hours minutes seconds", arrowmap.IntervalValue{Micros: 3_661_000_000}, "01:01:01"},
+		{"fractional seconds", arrowmap.IntervalValue{Micros: 788_917_797}, "00:13:08.917797"},
+		{"exact microseconds", arrowmap.IntervalValue{Micros: 1}, "00:00:00.000001"},
 
 		// Days
-		{"one day", duckdb.Interval{Days: 1}, "1 day"},
-		{"multiple days", duckdb.Interval{Days: 5}, "5 days"},
-		{"days and time", duckdb.Interval{Days: 3, Micros: 9_000_000_000}, "3 days 02:30:00"},
+		{"one day", arrowmap.IntervalValue{Days: 1}, "1 day"},
+		{"multiple days", arrowmap.IntervalValue{Days: 5}, "5 days"},
+		{"days and time", arrowmap.IntervalValue{Days: 3, Micros: 9_000_000_000}, "3 days 02:30:00"},
 
 		// Months
-		{"one month", duckdb.Interval{Months: 1}, "1 mon"},
-		{"multiple months", duckdb.Interval{Months: 7}, "7 mons"},
-		{"one year", duckdb.Interval{Months: 12}, "1 year"},
-		{"years and months", duckdb.Interval{Months: 14}, "1 year 2 mons"},
-		{"multiple years", duckdb.Interval{Months: 36}, "3 years"},
+		{"one month", arrowmap.IntervalValue{Months: 1}, "1 mon"},
+		{"multiple months", arrowmap.IntervalValue{Months: 7}, "7 mons"},
+		{"one year", arrowmap.IntervalValue{Months: 12}, "1 year"},
+		{"years and months", arrowmap.IntervalValue{Months: 14}, "1 year 2 mons"},
+		{"multiple years", arrowmap.IntervalValue{Months: 36}, "3 years"},
 
 		// Mixed
-		{"full interval", duckdb.Interval{Months: 14, Days: 3, Micros: 14_706_123_456}, "1 year 2 mons 3 days 04:05:06.123456"},
+		{"full interval", arrowmap.IntervalValue{Months: 14, Days: 3, Micros: 14_706_123_456}, "1 year 2 mons 3 days 04:05:06.123456"},
 
 		// Negative
-		{"negative time", duckdb.Interval{Micros: -3_600_000_000}, "-01:00:00"},
-		{"negative days", duckdb.Interval{Days: -2}, "-2 days"},
-		{"negative months", duckdb.Interval{Months: -1}, "-1 mon"},
-		{"negative years", duckdb.Interval{Months: -14}, "-1 year -2 mons"},
+		{"negative time", arrowmap.IntervalValue{Micros: -3_600_000_000}, "-01:00:00"},
+		{"negative days", arrowmap.IntervalValue{Days: -2}, "-2 days"},
+		{"negative months", arrowmap.IntervalValue{Months: -1}, "-1 mon"},
+		{"negative years", arrowmap.IntervalValue{Months: -14}, "-1 year -2 mons"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Continues the PR #494 pattern. `server/conn.go`'s `formatValue` used to switch on `duckdb.Interval` directly, and `formatInterval` took `duckdb.Interval` as parameter. Both required the duckdb-go driver to be imported in this file.

This PR uses the existing `normalizeDriverValue` hook (registered by `duckdbservice`'s `init` in PR #494):

- `formatValue` calls `normalizeDriverValue(v)` at entry — driver-specific interval types convert to `arrowmap.IntervalValue` before the switch
- The `duckdb.Interval` case is removed; only `arrowmap.IntervalValue` remains
- `formatInterval`'s signature is now `formatInterval(arrowmap.IntervalValue)`

`server/conn_test.go`'s `TestFormatInterval` table-test field was `duckdb.Interval` — switched to `arrowmap.IntervalValue` (same layout: `Months int32, Days int32, Micros int64`) and dropped the now-unused `duckdb` import from the test file.

## What's left in conn.go

`server/conn.go` still has `duckdb.Appender` / `duckdb.NewAppenderFromConn` (four lines for COPY support). Handling that needs a build-tag or separate file split — deferred to a follow-up. After this PR, `conn.go`'s duckdb-go usage is reduced to just the COPY codepath (4 lines + 1 comment).

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short -timeout 60s ./server/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)