### PR TITLE
refactor(server): drop duckdb-go from conn.go via DuckDBAppender hook

### DIFF
--- a/duckdbservice/duckdb_appender.go
+++ b/duckdbservice/duckdb_appender.go
@@ -1,0 +1,65 @@
+package duckdbservice
+
+import (
+	"database/sql/driver"
+	"fmt"
+
+	duckdb "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/sqlcore"
+)
+
+// init wires the real duckdb-go Appender implementation into server's
+// COPY codepath. Binaries that link duckdbservice (worker, all-in-one)
+// get full Appender support; binaries that don't (a future control-plane-
+// only binary) hit the unavailable fallback in server and naturally fall
+// back to batched INSERT statements.
+func init() {
+	server.RegisterDuckDBAppender(appendDuckDBRows)
+}
+
+// appendDuckDBRows is the real DuckDB Appender implementation. Mirrors the
+// logic that previously lived inline in (*clientConn).appendWithDuckDBAppender.
+func appendDuckDBRows(rawConn sqlcore.RawConn, parts []string, rows [][]any) (int, error) {
+	var rowCount int
+	err := rawConn.Raw(func(driverConn any) error {
+		dc, ok := driverConn.(driver.Conn)
+		if !ok {
+			return fmt.Errorf("underlying connection does not implement driver.Conn")
+		}
+
+		var appender *duckdb.Appender
+		var appErr error
+		switch len(parts) {
+		case 1:
+			appender, appErr = duckdb.NewAppenderFromConn(dc, "", parts[0])
+		case 2:
+			appender, appErr = duckdb.NewAppenderFromConn(dc, parts[0], parts[1])
+		default:
+			appender, appErr = duckdb.NewAppender(dc, parts[0], parts[1], parts[2])
+		}
+		if appErr != nil {
+			return fmt.Errorf("failed to create Appender: %w", appErr)
+		}
+
+		for i, row := range rows {
+			driverVals := make([]driver.Value, len(row))
+			for j, v := range row {
+				driverVals[j] = v
+			}
+			if appErr = appender.AppendRow(driverVals...); appErr != nil {
+				_ = appender.Close()
+				return fmt.Errorf("AppendRow failed at row %d: %w", i+1, appErr)
+			}
+		}
+
+		if appErr = appender.Close(); appErr != nil {
+			return fmt.Errorf("Appender.Close failed: %w", appErr)
+		}
+
+		rowCount = len(rows)
+		return nil
+	})
+
+	return rowCount, err
+}

--- a/server/conn.go
+++ b/server/conn.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
-	"database/sql/driver"
 	"encoding/binary"
 	"encoding/csv"
 	"errors"
@@ -22,7 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	duckdb "github.com/duckdb/duckdb-go/v2"
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
@@ -4012,59 +4010,6 @@ func splitQualifiedName(name string) []string {
 
 // appendWithDuckDBAppender uses the DuckDB Appender API for fast bulk inserts.
 // Only works for full-column inserts (no column subset).
-func (c *clientConn) appendWithDuckDBAppender(tableName string, rows [][]interface{}) (int, error) {
-	parts := splitQualifiedName(tableName)
-
-	ctx := context.Background()
-	sqlConn, err := c.executor.ConnContext(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get DB connection: %w", err)
-	}
-	defer sqlConn.Close() //nolint:errcheck
-
-	var rowCount int
-	err = sqlConn.Raw(func(driverConn interface{}) error {
-		dc, ok := driverConn.(driver.Conn)
-		if !ok {
-			return fmt.Errorf("underlying connection does not implement driver.Conn")
-		}
-
-		var appender *duckdb.Appender
-		var appErr error
-		switch len(parts) {
-		case 1:
-			appender, appErr = duckdb.NewAppenderFromConn(dc, "", parts[0])
-		case 2:
-			appender, appErr = duckdb.NewAppenderFromConn(dc, parts[0], parts[1])
-		default:
-			appender, appErr = duckdb.NewAppender(dc, parts[0], parts[1], parts[2])
-		}
-		if appErr != nil {
-			return fmt.Errorf("failed to create Appender: %w", appErr)
-		}
-
-		for i, row := range rows {
-			driverVals := make([]driver.Value, len(row))
-			for j, v := range row {
-				driverVals[j] = v
-			}
-			if appErr = appender.AppendRow(driverVals...); appErr != nil {
-				_ = appender.Close()
-				return fmt.Errorf("AppendRow failed at row %d: %w", i+1, appErr)
-			}
-		}
-
-		if appErr = appender.Close(); appErr != nil {
-			return fmt.Errorf("Appender.Close failed: %w", appErr)
-		}
-
-		rowCount = len(rows)
-		return nil
-	})
-
-	return rowCount, err
-}
-
 // batchInsertRows inserts rows using batched multi-row INSERT statements.
 // Used as fallback when Appender can't be used (column subsets, unsupported types).
 func (c *clientConn) batchInsertRows(tableName, columnList string, cols []string, rows [][]interface{}) (int, error) {

--- a/server/duckdb_appender.go
+++ b/server/duckdb_appender.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/posthog/duckgres/server/sqlcore"
+)
+
+// DuckDBAppendFunc bulk-inserts rows into a DuckDB table using the duckdb-go
+// Appender API. The implementation calls rawConn.Raw to extract the
+// underlying driver.Conn and then drives duckdb.NewAppender* against it.
+//
+// The signature lives in the server package (rather than in duckdbservice)
+// because the COPY codepath in clientConn dispatches through it; the
+// duckdbservice package registers the actual implementation at init time
+// via RegisterDuckDBAppender, which keeps server/conn.go itself free of any
+// duckdb-go imports.
+//
+// parts is the result of splitQualifiedName(tableName) — a 1, 2, or 3
+// element slice of catalog/schema/table parts (preserving the precise
+// args the original switch passed to NewAppender* / NewAppenderFromConn).
+type DuckDBAppendFunc func(rawConn sqlcore.RawConn, parts []string, rows [][]any) (int, error)
+
+// duckdbAppender is loaded once via RegisterDuckDBAppender. Reads on the
+// COPY hot path are lock-free.
+var duckdbAppender atomic.Value // DuckDBAppendFunc
+
+// RegisterDuckDBAppender wires a real DuckDB Appender implementation into
+// the COPY codepath. duckdbservice's init() calls this; binaries that
+// don't link duckdbservice get the unavailable fallback below.
+func RegisterDuckDBAppender(f DuckDBAppendFunc) {
+	if f == nil {
+		return
+	}
+	duckdbAppender.Store(f)
+}
+
+// errDuckDBAppenderUnavailable is returned by appendWithDuckDBAppender when
+// no implementation has been registered (typically a control-plane build
+// that doesn't link duckdbservice). Callers fall back to batchInsertRows.
+var errDuckDBAppenderUnavailable = errors.New("duckdb Appender support not linked in this build")
+
+// appendWithDuckDBAppender dispatches to the registered DuckDB Appender, if
+// any. Returns errDuckDBAppenderUnavailable when no implementation has been
+// registered so callers can choose a fallback.
+func (c *clientConn) appendWithDuckDBAppender(tableName string, rows [][]any) (int, error) {
+	fn, _ := duckdbAppender.Load().(DuckDBAppendFunc)
+	if fn == nil {
+		return 0, errDuckDBAppenderUnavailable
+	}
+
+	parts := splitQualifiedName(tableName)
+
+	ctx := context.Background()
+	rawConn, err := c.executor.ConnContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get DB connection: %w", err)
+	}
+	defer rawConn.Close() //nolint:errcheck
+
+	return fn(rawConn, parts, rows)
+}


### PR DESCRIPTION
## Summary

`server/conn.go`'s `appendWithDuckDBAppender` was the last block of `duckdb-go` references in `conn.go` — the COPY FROM bulk-insert path that uses the duckdb `Appender` API. This PR factors it out the same way PR #482 split `AppendValue`: `server` holds the registration hook, `duckdbservice`'s `init()` registers the real implementation.

## Changes

- **`server/duckdb_appender.go`** (new): `DuckDBAppendFunc` type + `RegisterDuckDBAppender` + a thin `(*clientConn).appendWithDuckDBAppender` that dispatches to the registered implementation. Returns a sentinel `errDuckDBAppenderUnavailable` when nothing is registered, so callers can fall back to `batchInsertRows`.
- **`duckdbservice/duckdb_appender.go`** (new): the real implementation. Registers in `init()` so any binary that links `duckdbservice` gets full Appender support. Mirrors the logic that previously lived inline in `conn.go` (`Raw` → `driver.Conn` → `duckdb.NewAppender*` → AppendRow loop).
- **`server/conn.go`**: the inline implementation is removed; the unused `"database/sql/driver"` and `"github.com/duckdb/duckdb-go/v2"` imports are dropped.

## After this PR

```
grep duckdb server/conn.go    # only an arrowmap import + SQL strings, no duckdb-go imports
```

The whole `server` package still links `duckdb-go` via `server.go`, `querylog.go`, and `checkpoint.go`, but `conn.go` itself is fully clean. Three down (types.go format/encode, conn.go format, conn.go appender), three to go (server.go's `_ "duckdb-go"` blank import + `sql.Open("duckdb", ...)` calls; querylog.go's `sql.Open("duckdb", ...)`; checkpoint.go's `sql.Open("duckdb", ...)`).

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/ ./duckdbservice/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)