### PR TITLE
refactor(server): drop the _ "duckdb-go" blank import from server.go

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	_ "github.com/duckdb/duckdb-go/v2"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for direct PostgreSQL connections
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/chsql"

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	_ "github.com/posthog/duckgres/duckdbservice" // registers the "duckdb" sql driver and the duckdb-go value normalizer / Appender hooks
 	"github.com/posthog/duckgres/server"
 )
 


### PR DESCRIPTION
## Summary

`server/server.go` used to blank-import `github.com/duckdb/duckdb-go/v2` to register the `"duckdb"` `sql/driver`. The all-in-one binary already imports `duckdbservice` (which itself imports `duckdb-go` via the appender + value normalizer hooks added in PR #482, #494, #496), so the driver gets registered through that chain — `server.go`'s blank import is redundant in production.

## Test binary handling

Server-package tests already blank-import `duckdb-go` in the files that need a real DuckDB connection (`bundled_extensions_test.go`, `catalog_test.go`, `chsql_test.go`, `transient_test.go`, `session_database_metadata_test.go`, `types_test.go`), so removing the production blank import doesn't break those test binaries.

The integration test binary (`tests/integration/`) imported `server` but not `duckdbservice`, so it relied on `server.go`'s blank import for driver registration. Added a blank import of `duckdbservice` in `tests/integration/harness.go` to compensate — same effect, just routed through the package that's now responsible for registering all duckdb-go hooks (driver, `AppendValue` handler, value normalizer, COPY appender).

## What's left

After this PR, `server/server.go` has **zero `import` statements that pull duckdb-go** into the package's import graph. `server` still links `duckdb-go` overall via `querylog.go` and `checkpoint.go` (both call `sql.Open("duckdb", ...)` directly), but that's about runtime use of an already-registered driver rather than a Go-level package import. The follow-up PRs that move querylog and checkpoint into `server/exec/` will close out the file-level duckdb-go references in `server/`.

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags kubernetes ./...` clean
- [x] `go test -short ./server/ ./duckdbservice/... ./controlplane/... ./` — all green
- [x] `go test -short -timeout 60s ./tests/integration/...` — same failures as main (`TestFallbackUtilityCommands` etc.); confirmed pre-existing via `git stash` + re-run; unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)