### PR TITLE
feat(cmd/duckgres-controlplane): add a CP-only binary that does not link libduckdb

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -1,0 +1,54 @@
+// duckgres-controlplane is a control-plane-only entry point that does NOT
+// link the embedded DuckDB driver. It accepts the same configuration as the
+// all-in-one duckgres binary running in `--mode control-plane`, but routes
+// queries exclusively to remote duckdb-service workers over Arrow Flight SQL.
+//
+// The build is verified to be duckdb-go-free via:
+//
+//	go list -deps ./cmd/duckgres-controlplane | grep duckdb-go   # empty
+//
+// At runtime, attempts to use standalone or worker modes are rejected at
+// startup; this binary only supports `--mode control-plane`.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/posthog/duckgres/controlplane"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Control-plane-only duckgres binary. Does NOT link libduckdb.")
+		fmt.Fprintln(os.Stderr, "Routes all SQL execution to remote duckdb-service worker pods")
+		fmt.Fprintln(os.Stderr, "via Arrow Flight SQL.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Configuration mirrors the all-in-one duckgres binary running in")
+		fmt.Fprintln(os.Stderr, "`--mode control-plane --worker-backend remote`. See the duckgres")
+		fmt.Fprintln(os.Stderr, "README for the full flag set; this stub accepts a single -config")
+		fmt.Fprintln(os.Stderr, "flag pointing at a YAML file for now.")
+		flag.PrintDefaults()
+	}
+
+	configPath := flag.String("config", "", "path to duckgres.yaml configuration")
+	flag.Parse()
+
+	if *configPath == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	// TODO: load YAML, resolve effective config, build ControlPlaneConfig.
+	// For the first cut this binary only proves the import graph stays
+	// duckdb-free; wiring it through the existing config-resolution code in
+	// main.go (which lives in the same package as the all-in-one binary) is
+	// the follow-up. Until then, error out clearly.
+	slog.Error("duckgres-controlplane stub: config loading is not wired up yet — use the all-in-one duckgres binary in --mode control-plane while this is being built out.")
+	_ = controlplane.RunControlPlane // keep the import live so go list -deps reflects the real CP graph
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

After the long sequence of subpackage extractions (PRs #477-#497), the controlplane import graph is fully free of `github.com/duckdb/duckdb-go`:

```
go list -deps ./controlplane                                | grep duckdb-go   # empty
go list -tags kubernetes -deps ./controlplane               | grep duckdb-go   # empty
go list -deps ./cmd/duckgres-controlplane                   | grep duckdb-go   # empty
go list -tags kubernetes -deps ./cmd/duckgres-controlplane  | grep duckdb-go   # empty
```

This PR adds the corresponding entry-point binary at `cmd/duckgres-controlplane`. The binary builds and links **without libduckdb**, but the actual config-loading + `RunControlPlane` wiring is still a stub that errors out at runtime — duckgres' YAML / CLI / env config resolution lives in the package `main` file at the repo root alongside the all-in-one binary, and lifting that into a shared config-resolution package is its own focused PR.

## What this PR locks in

The point of this PR is the import-graph win: a CP-only build is now possible. Future PRs will:

- Move `resolveEffectiveConfig` + the YAML/env/CLI plumbing out of `main.go` (repo root) into a shared package both binaries can import (still duckdb-free, since it's pure config wrangling).
- Wire that into `cmd/duckgres-controlplane/main.go` and remove the stub error.
- Add a CI step that runs the deps check above and fails the build if duckdb-go ever creeps back in.
- Introduce `cmd/duckgres-worker` for the duckdb-service path so the matrix-build CI in the binary-split plan can target it.

## Test plan

- [x] `go build ./cmd/duckgres-controlplane/...` clean
- [x] `go build -tags kubernetes ./cmd/duckgres-controlplane/...` clean
- [x] `go list -deps ./cmd/duckgres-controlplane | grep duckdb-go` returns empty
- [x] same with `-tags kubernetes`
- [x] The all-in-one duckgres binary at the repo root continues to build and run unchanged (it imports `duckdbservice`, which still pulls `duckdb-go` — that's expected for the worker / standalone modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)