### PR TITLE
ci: guard cmd/duckgres-controlplane against duckdb-go regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,55 @@ jobs:
         with:
           version: v2.11.4
 
+  controlplane-no-libduckdb:
+    name: Verify cmd/duckgres-controlplane does not link libduckdb
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build cmd/duckgres-controlplane (default tags)
+        run: go build ./cmd/duckgres-controlplane/...
+
+      - name: Build cmd/duckgres-controlplane (-tags kubernetes)
+        run: go build -tags kubernetes ./cmd/duckgres-controlplane/...
+
+      # Lock in the binary-split goal: cmd/duckgres-controlplane must remain
+      # free of github.com/duckdb/duckdb-go in its transitive import graph,
+      # both with and without the kubernetes build tag. If this guard breaks,
+      # someone added an import that pulls libduckdb into the CP build —
+      # likely via a server/* leaf that grew a duckdb-go dependency. Find
+      # the offending package with `go list -deps -json ./cmd/duckgres-controlplane`
+      # and route around it (subpackage extraction, registration hook, or
+      # interface boundary) rather than relaxing this check.
+      - name: go list -deps controlplane is duckdb-free (default tags)
+        run: |
+          set -euo pipefail
+          if go list -deps ./cmd/duckgres-controlplane | grep -F "github.com/duckdb/duckdb-go"; then
+            echo "::error::cmd/duckgres-controlplane transitively imports duckdb-go (default tags)" >&2
+            exit 1
+          fi
+          if go list -deps ./controlplane | grep -F "github.com/duckdb/duckdb-go"; then
+            echo "::error::controlplane package transitively imports duckdb-go (default tags)" >&2
+            exit 1
+          fi
+
+      - name: go list -deps controlplane is duckdb-free (-tags kubernetes)
+        run: |
+          set -euo pipefail
+          if go list -tags kubernetes -deps ./cmd/duckgres-controlplane | grep -F "github.com/duckdb/duckdb-go"; then
+            echo "::error::cmd/duckgres-controlplane transitively imports duckdb-go (-tags kubernetes)" >&2
+            exit 1
+          fi
+          if go list -tags kubernetes -deps ./controlplane | grep -F "github.com/duckdb/duckdb-go"; then
+            echo "::error::controlplane package transitively imports duckdb-go (-tags kubernetes)" >&2
+            exit 1
+          fi
+
   unit-tests:
     runs-on: ubuntu-24.04-arm
     steps:


### PR DESCRIPTION
## Summary

Adds a `controlplane-no-libduckdb` job that builds `cmd/duckgres-controlplane` (both default tags and `-tags kubernetes`) and then runs:

```
go list -deps ./cmd/duckgres-controlplane | grep duckdb-go
go list -deps ./controlplane              | grep duckdb-go
```

If anything matches, the job fails the build.

This **locks in** the binary-split achievement from PRs #477-#498. Without this guard, someone could land a `server/*` extraction that grows a new duckdb-go transitive import and silently re-link libduckdb into the CP build — which would defeat the matrix-build per-DuckDB-version goal.

The error message points at the right diagnostic command and suggests the right fix (subpackage extraction / registration hook / interface boundary) rather than encouraging anyone to suppress the check.

## Test plan

Verified locally:

- [x] `go list -deps ./cmd/duckgres-controlplane | grep duckdb-go` is empty
- [x] `go list -deps ./controlplane              | grep duckdb-go` is empty
- [x] same with `-tags kubernetes`
- [x] YAML parses cleanly via `python3 -c "import yaml; yaml.safe_load(open(...))"`

The guard will run on this PR's CI as part of the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)