### PR TITLE
feat(configloader): extract YAML schema + LoadFile into a shared package

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -7,8 +7,9 @@
 //
 //	go list -deps ./cmd/duckgres-controlplane | grep duckdb-go   # empty
 //
-// At runtime, attempts to use standalone or worker modes are rejected at
-// startup; this binary only supports `--mode control-plane`.
+// At runtime, this binary only supports control-plane mode; standalone /
+// duckdb-service modes belong in the all-in-one duckgres binary or
+// cmd/duckgres-worker respectively.
 package main
 
 import (
@@ -17,7 +18,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/posthog/duckgres/controlplane"
+	"github.com/posthog/duckgres/configloader"
+	_ "github.com/posthog/duckgres/controlplane" // keep the import live so go list -deps reflects the real CP graph
 )
 
 func main() {
@@ -29,9 +31,10 @@ func main() {
 		fmt.Fprintln(os.Stderr, "via Arrow Flight SQL.")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Configuration mirrors the all-in-one duckgres binary running in")
-		fmt.Fprintln(os.Stderr, "`--mode control-plane --worker-backend remote`. See the duckgres")
-		fmt.Fprintln(os.Stderr, "README for the full flag set; this stub accepts a single -config")
-		fmt.Fprintln(os.Stderr, "flag pointing at a YAML file for now.")
+		fmt.Fprintln(os.Stderr, "`--mode control-plane --worker-backend remote`. The CLI/env")
+		fmt.Fprintln(os.Stderr, "flag plumbing currently lives in the all-in-one main.go and")
+		fmt.Fprintln(os.Stderr, "will be lifted into a shared package in a follow-up PR; until")
+		fmt.Fprintln(os.Stderr, "then this binary loads -config <path> as the source of truth.")
 		flag.PrintDefaults()
 	}
 
@@ -43,12 +46,27 @@ func main() {
 		os.Exit(2)
 	}
 
-	// TODO: load YAML, resolve effective config, build ControlPlaneConfig.
-	// For the first cut this binary only proves the import graph stays
-	// duckdb-free; wiring it through the existing config-resolution code in
-	// main.go (which lives in the same package as the all-in-one binary) is
-	// the follow-up. Until then, error out clearly.
-	slog.Error("duckgres-controlplane stub: config loading is not wired up yet — use the all-in-one duckgres binary in --mode control-plane while this is being built out.")
-	_ = controlplane.RunControlPlane // keep the import live so go list -deps reflects the real CP graph
+	cfg, err := configloader.LoadFile(*configPath)
+	if err != nil {
+		slog.Error("failed to load config", "path", *configPath, "error", err)
+		os.Exit(1)
+	}
+	slog.Info("duckgres-controlplane: loaded config",
+		"path", *configPath,
+		"data_dir", cfg.DataDir,
+		"port", cfg.Port,
+		"flight_port", cfg.FlightPort,
+		"worker_backend", cfg.WorkerBackend,
+		"k8s_worker_image", cfg.K8s.WorkerImage,
+		"ducklake_default_spec_version", cfg.DuckLake.DefaultSpecVersion,
+	)
+
+	// TODO: build controlplane.ControlPlaneConfig from cfg, then call
+	// controlplane.RunControlPlane(cpCfg). Today resolveEffectiveConfig in
+	// the all-in-one main.go does this — lifting it into a shared
+	// resolution package both binaries can call is the follow-up to PR
+	// #505 (which extracted the YAML schema). Until then, error out so
+	// no one mistakes this for a working CP binary.
+	slog.Error("duckgres-controlplane: config-resolution wiring is still in the all-in-one main.go — use the all-in-one duckgres binary in --mode control-plane while this is being built out.")
 	os.Exit(1)
 }

--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -6,12 +6,6 @@
 // shape spawned by the control plane over Unix sockets / TCP). The
 // standalone PG-wire path is not exposed here — for that, use the
 // all-in-one duckgres binary in `--mode standalone`.
-//
-// Configuration mirrors the all-in-one duckgres binary running in
-// `--mode duckdb-service`. See the duckgres README for the full flag set;
-// this stub accepts a single -config flag pointing at a YAML file for now.
-// Wiring config resolution out of the all-in-one main package and into a
-// shared package both binaries can use is a follow-up PR.
 package main
 
 import (
@@ -20,7 +14,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/posthog/duckgres/duckdbservice"
+	"github.com/posthog/duckgres/configloader"
+	_ "github.com/posthog/duckgres/duckdbservice" // keep the import live so the worker binary actually links libduckdb via duckdbservice
 )
 
 func main() {
@@ -45,13 +40,25 @@ func main() {
 		os.Exit(2)
 	}
 
-	// TODO: load YAML, resolve effective config, build duckdbservice.ServiceConfig.
-	// For the first cut this binary only proves the worker entry point exists
-	// and the duckdbservice import graph is healthy; wiring it through the
-	// existing config-resolution code in main.go (which lives in the same
-	// package as the all-in-one binary) is the follow-up. Until then, error
-	// out clearly.
-	slog.Error("duckgres-worker stub: config loading is not wired up yet — use the all-in-one duckgres binary in --mode duckdb-service while this is being built out.")
-	_ = duckdbservice.Run // keep the import live so the worker binary actually links libduckdb via duckdbservice
+	cfg, err := configloader.LoadFile(*configPath)
+	if err != nil {
+		slog.Error("failed to load config", "path", *configPath, "error", err)
+		os.Exit(1)
+	}
+	slog.Info("duckgres-worker: loaded config",
+		"path", *configPath,
+		"data_dir", cfg.DataDir,
+		"memory_limit", cfg.MemoryLimit,
+		"threads", cfg.Threads,
+		"ducklake_metadata_store_set", cfg.DuckLake.MetadataStore != "",
+	)
+
+	// TODO: build duckdbservice.ServiceConfig from cfg, then call
+	// duckdbservice.Run. Today resolveEffectiveConfig in the all-in-one
+	// main.go does this — lifting it into a shared resolution package
+	// both binaries can call is the follow-up to PR #505 (which
+	// extracted the YAML schema). Until then, error out so no one
+	// mistakes this for a working worker binary.
+	slog.Error("duckgres-worker: config-resolution wiring is still in the all-in-one main.go — use the all-in-one duckgres binary in --mode duckdb-service while this is being built out.")
 	os.Exit(1)
 }

--- a/configloader/file_config.go
+++ b/configloader/file_config.go
@@ -1,0 +1,138 @@
+// Package configloader holds duckgres' YAML configuration schema and the
+// helper that loads + parses a config file. It's the shared piece between
+// the all-in-one duckgres binary, cmd/duckgres-controlplane, and
+// cmd/duckgres-worker — each of which needs to read the same duckgres.yaml.
+//
+// Nothing here depends on github.com/duckdb/duckdb-go: a configloader
+// import is safe in the duckdb-free CP binary.
+package configloader
+
+// FileConfig represents the YAML configuration file structure shared
+// across all duckgres binaries. Mode-specific fields are present in
+// every binary's view of the file even when they're irrelevant to that
+// mode (e.g., the worker binary reads but ignores ControlPlane fields);
+// the cost is one parsed-but-unused struct field per binary.
+type FileConfig struct {
+	Host                      string              `yaml:"host"`
+	Port                      int                 `yaml:"port"`
+	FlightPort                int                 `yaml:"flight_port"`                  // Control-plane Flight SQL ingress port (0 disables)
+	FlightSessionIdleTTL      string              `yaml:"flight_session_idle_ttl"`      // e.g., "10m"
+	FlightSessionReapInterval string              `yaml:"flight_session_reap_interval"` // e.g., "1m"
+	FlightHandleIdleTTL       string              `yaml:"flight_handle_idle_ttl"`       // e.g., "15m"
+	FlightSessionTokenTTL     string              `yaml:"flight_session_token_ttl"`     // e.g., "1h"
+	DataDir                   string              `yaml:"data_dir"`
+	TLS                       TLSConfig           `yaml:"tls"`
+	Users                     map[string]string   `yaml:"users"`
+	RateLimit                 RateLimitFileConfig `yaml:"rate_limit"`
+	Extensions                []string            `yaml:"extensions"`
+	DuckLake                  DuckLakeFileConfig  `yaml:"ducklake"`
+	FilePersistence           bool                `yaml:"file_persistence"`
+	ProcessIsolation          bool                `yaml:"process_isolation"`
+	IdleTimeout               string              `yaml:"idle_timeout"`
+	MemoryLimit               string              `yaml:"memory_limit"`
+	Threads                   int                 `yaml:"threads"`
+	MemoryBudget              string              `yaml:"memory_budget"`
+	MemoryRebalance           *bool               `yaml:"memory_rebalance"`
+	Process                   ProcessFileConfig   `yaml:"process"`
+	WorkerQueueTimeout        string              `yaml:"worker_queue_timeout"`
+	WorkerIdleTimeout         string              `yaml:"worker_idle_timeout"`
+	HandoverDrainTimeout      string              `yaml:"handover_drain_timeout"`
+	PassthroughUsers          []string            `yaml:"passthrough_users"`
+	LogLevel                  string              `yaml:"log_level"`
+	QueryLog                  QueryLogFileConfig  `yaml:"query_log"`
+
+	// Worker backend configuration
+	WorkerBackend string        `yaml:"worker_backend"` // "process" (default) or "remote"
+	K8s           K8sFileConfig `yaml:"k8s"`
+}
+
+type ProcessFileConfig struct {
+	MinWorkers         int   `yaml:"min_workers"`
+	MaxWorkers         int   `yaml:"max_workers"`
+	RetireOnSessionEnd *bool `yaml:"retire_on_session_end"`
+}
+
+// K8sFileConfig holds Kubernetes worker configuration from YAML.
+type K8sFileConfig struct {
+	WorkerImage           string `yaml:"worker_image"`
+	WorkerNamespace       string `yaml:"worker_namespace"`
+	ControlPlaneID        string `yaml:"control_plane_id"`
+	WorkerPort            int    `yaml:"worker_port"`
+	WorkerSecret          string `yaml:"worker_secret"`
+	WorkerConfigMap       string `yaml:"worker_configmap"`
+	WorkerImagePullPolicy string `yaml:"worker_image_pull_policy"`
+	WorkerServiceAccount  string `yaml:"worker_service_account"`
+	MaxWorkers            int    `yaml:"max_workers"`
+	SharedWarmTarget      int    `yaml:"shared_warm_target"`
+}
+
+type QueryLogFileConfig struct {
+	Enabled              *bool  `yaml:"enabled"`
+	FlushInterval        string `yaml:"flush_interval"`
+	BatchSize            int    `yaml:"batch_size"`
+	CompactInterval      string `yaml:"compact_interval"`
+	DataInliningRowLimit int    `yaml:"data_inlining_row_limit"`
+}
+
+type TLSConfig struct {
+	Cert string     `yaml:"cert"`
+	Key  string     `yaml:"key"`
+	ACME ACMEConfig `yaml:"acme"`
+}
+
+type ACMEConfig struct {
+	Domain      string `yaml:"domain"`
+	Email       string `yaml:"email"`
+	CacheDir    string `yaml:"cache_dir"`
+	DNSProvider string `yaml:"dns_provider"`
+	DNSZoneID   string `yaml:"dns_zone_id"`
+}
+
+type RateLimitFileConfig struct {
+	MaxFailedAttempts   int    `yaml:"max_failed_attempts"`
+	FailedAttemptWindow string `yaml:"failed_attempt_window"`
+	BanDuration         string `yaml:"ban_duration"`
+	MaxConnectionsPerIP int    `yaml:"max_connections_per_ip"`
+	MaxConnections      int    `yaml:"max_connections"`
+}
+
+type DuckLakeFileConfig struct {
+	MetadataStore string `yaml:"metadata_store"`
+	ObjectStore   string `yaml:"object_store"`
+	DataPath      string `yaml:"data_path"`
+
+	// Delta catalog attachment. When enabled without an explicit path, the
+	// catalog path is derived as a sibling delta/ prefix at the object store root.
+	DeltaCatalogEnabled *bool  `yaml:"delta_catalog_enabled"`
+	DeltaCatalogPath    string `yaml:"delta_catalog_path"`
+
+	// Disable metadata postgres_scanner thread-local cache before ATTACH creates
+	// the hidden metadata pool. Nil means use the server default.
+	DisableMetadataThreadLocalCache *bool `yaml:"disable_metadata_thread_local_cache"`
+
+	// S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
+	S3Provider string `yaml:"s3_provider"`
+
+	// Config provider settings (explicit credentials)
+	S3Endpoint  string `yaml:"s3_endpoint"`
+	S3AccessKey string `yaml:"s3_access_key"`
+	S3SecretKey string `yaml:"s3_secret_key"`
+	S3Region    string `yaml:"s3_region"`
+	S3UseSSL    bool   `yaml:"s3_use_ssl"`
+	S3URLStyle  string `yaml:"s3_url_style"`
+
+	// Credential chain provider settings (AWS SDK credential chain)
+	S3Chain   string `yaml:"s3_chain"`
+	S3Profile string `yaml:"s3_profile"`
+
+	// Checkpoint interval for DuckLake maintenance (e.g., "24h", "6h")
+	CheckpointInterval string `yaml:"checkpoint_interval"`
+
+	// DataInliningRowLimit controls max rows inlined in metadata per insert.
+	// Default: 0 (disabled). Set to a positive value to enable inlining.
+	DataInliningRowLimit *int `yaml:"data_inlining_row_limit"`
+
+	// DefaultSpecVersion is the global default DuckLake spec version
+	// used for migration checks when an org doesn't specify an override.
+	DefaultSpecVersion string `yaml:"default_spec_version"`
+}

--- a/configloader/load.go
+++ b/configloader/load.go
@@ -1,0 +1,33 @@
+package configloader
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadFile reads a duckgres.yaml file from disk and parses it. Returns the
+// caller-friendly error from os.ReadFile (so a missing file is recognizable
+// via os.IsNotExist) or a wrapped yaml-parsing error.
+func LoadFile(path string) (*FileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg FileConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+	return &cfg, nil
+}
+
+// Env returns the value of the named environment variable, falling back to
+// defaultVal when unset or empty. Shared by every duckgres binary so the
+// override semantics are identical.
+func Env(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}

--- a/main.go
+++ b/main.go
@@ -13,159 +13,37 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/posthog/duckgres/configloader"
 	"github.com/posthog/duckgres/controlplane"
 	"github.com/posthog/duckgres/duckdbservice"
 	"github.com/posthog/duckgres/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"gopkg.in/yaml.v3"
 )
 
-// FileConfig represents the YAML configuration file structure
-type FileConfig struct {
-	Host                      string              `yaml:"host"`
-	Port                      int                 `yaml:"port"`
-	FlightPort                int                 `yaml:"flight_port"`                  // Control-plane Flight SQL ingress port (0 disables)
-	FlightSessionIdleTTL      string              `yaml:"flight_session_idle_ttl"`      // e.g., "10m"
-	FlightSessionReapInterval string              `yaml:"flight_session_reap_interval"` // e.g., "1m"
-	FlightHandleIdleTTL       string              `yaml:"flight_handle_idle_ttl"`       // e.g., "15m"
-	FlightSessionTokenTTL     string              `yaml:"flight_session_token_ttl"`     // e.g., "1h"
-	DataDir                   string              `yaml:"data_dir"`
-	TLS                       TLSConfig           `yaml:"tls"`
-	Users                     map[string]string   `yaml:"users"`
-	RateLimit                 RateLimitFileConfig `yaml:"rate_limit"`
-	Extensions                []string            `yaml:"extensions"`
-	DuckLake                  DuckLakeFileConfig  `yaml:"ducklake"`
-	FilePersistence           bool                `yaml:"file_persistence"`  // Persist DuckDB to <data_dir>/<username>.duckdb instead of :memory:
-	ProcessIsolation          bool                `yaml:"process_isolation"` // Enable process isolation per connection
-	IdleTimeout               string              `yaml:"idle_timeout"`      // e.g., "24h", "1h", "-1" to disable
-	MemoryLimit               string              `yaml:"memory_limit"`      // DuckDB memory_limit per session (e.g., "4GB")
-	Threads                   int                 `yaml:"threads"`           // DuckDB threads per session
-	MemoryBudget              string              `yaml:"memory_budget"`     // Total memory for all sessions (e.g., "24GB")
-	MemoryRebalance           *bool               `yaml:"memory_rebalance"`  // Enable dynamic per-connection memory reallocation
-	Process                   ProcessFileConfig   `yaml:"process"`
-	WorkerQueueTimeout        string              `yaml:"worker_queue_timeout"`   // e.g., "5m"
-	WorkerIdleTimeout         string              `yaml:"worker_idle_timeout"`    // e.g., "5m"
-	HandoverDrainTimeout      string              `yaml:"handover_drain_timeout"` // e.g., "24h"
-	PassthroughUsers          []string            `yaml:"passthrough_users"`      // Users that bypass transpiler + pg_catalog
-	LogLevel                  string              `yaml:"log_level"`              // Log level: debug, info, warn, error
-	QueryLog                  QueryLogFileConfig  `yaml:"query_log"`              // Query log configuration
+// FileConfig is the YAML configuration schema, sourced from the
+// configloader package so the new cmd/duckgres-controlplane and
+// cmd/duckgres-worker binaries parse the same shape.
+type FileConfig = configloader.FileConfig
 
-	// Worker backend configuration
-	WorkerBackend string        `yaml:"worker_backend"` // "process" (default) or "remote" for config-store-backed K8s multitenant mode
-	K8s           K8sFileConfig `yaml:"k8s"`
-}
+// Type aliases for the nested configloader types so the rest of main.go's
+// resolveEffectiveConfig logic continues to compile unchanged.
+type (
+	ProcessFileConfig   = configloader.ProcessFileConfig
+	K8sFileConfig       = configloader.K8sFileConfig
+	QueryLogFileConfig  = configloader.QueryLogFileConfig
+	TLSConfig           = configloader.TLSConfig
+	ACMEConfig          = configloader.ACMEConfig
+	RateLimitFileConfig = configloader.RateLimitFileConfig
+	DuckLakeFileConfig  = configloader.DuckLakeFileConfig
+)
 
-type ProcessFileConfig struct {
-	MinWorkers         int   `yaml:"min_workers"`
-	MaxWorkers         int   `yaml:"max_workers"`
-	RetireOnSessionEnd *bool `yaml:"retire_on_session_end"`
-}
-
-// K8sFileConfig holds Kubernetes worker configuration from YAML.
-type K8sFileConfig struct {
-	WorkerImage           string `yaml:"worker_image"`
-	WorkerNamespace       string `yaml:"worker_namespace"`
-	ControlPlaneID        string `yaml:"control_plane_id"`
-	WorkerPort            int    `yaml:"worker_port"`
-	WorkerSecret          string `yaml:"worker_secret"`
-	WorkerConfigMap       string `yaml:"worker_configmap"`
-	WorkerImagePullPolicy string `yaml:"worker_image_pull_policy"`
-	WorkerServiceAccount  string `yaml:"worker_service_account"`
-	MaxWorkers            int    `yaml:"max_workers"`
-	SharedWarmTarget      int    `yaml:"shared_warm_target"`
-}
-
-type QueryLogFileConfig struct {
-	Enabled              *bool  `yaml:"enabled"`                 // nil = default (true when DuckLake configured)
-	FlushInterval        string `yaml:"flush_interval"`          // e.g., "5s"
-	BatchSize            int    `yaml:"batch_size"`              // max entries per batch INSERT
-	CompactInterval      string `yaml:"compact_interval"`        // e.g., "10m"
-	DataInliningRowLimit int    `yaml:"data_inlining_row_limit"` // DuckLake inlining threshold
-}
-
-type TLSConfig struct {
-	Cert string     `yaml:"cert"`
-	Key  string     `yaml:"key"`
-	ACME ACMEConfig `yaml:"acme"`
-}
-
-type ACMEConfig struct {
-	Domain      string `yaml:"domain"`
-	Email       string `yaml:"email"`
-	CacheDir    string `yaml:"cache_dir"`
-	DNSProvider string `yaml:"dns_provider"` // "route53" for DNS-01 challenges
-	DNSZoneID   string `yaml:"dns_zone_id"`  // Route53 hosted zone ID
-}
-
-type RateLimitFileConfig struct {
-	MaxFailedAttempts   int    `yaml:"max_failed_attempts"`
-	FailedAttemptWindow string `yaml:"failed_attempt_window"` // e.g., "5m"
-	BanDuration         string `yaml:"ban_duration"`          // e.g., "15m"
-	MaxConnectionsPerIP int    `yaml:"max_connections_per_ip"`
-	MaxConnections      int    `yaml:"max_connections"`
-}
-
-type DuckLakeFileConfig struct {
-	MetadataStore string `yaml:"metadata_store"` // e.g., "postgres:host=localhost user=ducklake password=secret dbname=ducklake"
-	ObjectStore   string `yaml:"object_store"`   // e.g., "s3://bucket/path/" for S3/MinIO storage
-	DataPath      string `yaml:"data_path"`      // Local file path for data storage (alternative to object_store)
-
-	// Delta catalog attachment. When enabled without an explicit path, the
-	// catalog path is derived as a sibling delta/ prefix at the object store root.
-	DeltaCatalogEnabled *bool  `yaml:"delta_catalog_enabled"`
-	DeltaCatalogPath    string `yaml:"delta_catalog_path"`
-
-	// Disable metadata postgres_scanner thread-local cache before ATTACH creates
-	// the hidden metadata pool. Nil means use the server default.
-	DisableMetadataThreadLocalCache *bool `yaml:"disable_metadata_thread_local_cache"`
-
-	// S3 credential provider: "config" (explicit) or "credential_chain" (AWS SDK)
-	S3Provider string `yaml:"s3_provider"`
-
-	// Config provider settings (explicit credentials)
-	S3Endpoint  string `yaml:"s3_endpoint"`   // e.g., "localhost:9000" for MinIO
-	S3AccessKey string `yaml:"s3_access_key"` // S3 access key ID
-	S3SecretKey string `yaml:"s3_secret_key"` // S3 secret access key
-	S3Region    string `yaml:"s3_region"`     // S3 region (default: us-east-1)
-	S3UseSSL    bool   `yaml:"s3_use_ssl"`    // Use HTTPS for S3 connections
-	S3URLStyle  string `yaml:"s3_url_style"`  // "path" or "vhost" (default: path)
-
-	// Credential chain provider settings (AWS SDK credential chain)
-	S3Chain   string `yaml:"s3_chain"`   // e.g., "env;config" - which credential sources to check
-	S3Profile string `yaml:"s3_profile"` // AWS profile name for config chain
-
-	// Checkpoint interval for DuckLake maintenance (e.g., "24h", "6h")
-	CheckpointInterval string `yaml:"checkpoint_interval"`
-
-	// DataInliningRowLimit controls max rows inlined in metadata per insert.
-	// Default: 0 (disabled). Set to a positive value to enable inlining.
-	DataInliningRowLimit *int `yaml:"data_inlining_row_limit"`
-
-	// DefaultSpecVersion is the global default DuckLake spec version
-	// used for migration checks when an org doesn't specify an override.
-	DefaultSpecVersion string `yaml:"default_spec_version"`
-}
-
-// loadConfigFile loads configuration from a YAML file
-func loadConfigFile(path string) (*FileConfig, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var cfg FileConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
-	return &cfg, nil
-}
-
-// env returns the environment variable value or a default
-func env(key, defaultVal string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return defaultVal
-}
+// loadConfigFile + env are thin wrappers around configloader for back-compat
+// with the rest of this file. New binaries should call configloader.LoadFile
+// and configloader.Env directly.
+var (
+	loadConfigFile = configloader.LoadFile
+	env            = configloader.Env
+)
 
 // initMetrics starts the Prometheus metrics HTTP server on :9090/metrics.
 // Returns the http.Server instance so it can be shut down during handover.


### PR DESCRIPTION
## Summary

Lifts the `FileConfig` / `TLSConfig` / `ACMEConfig` / `RateLimitFileConfig` / `DuckLakeFileConfig` / `ProcessFileConfig` / `K8sFileConfig` / `QueryLogFileConfig` YAML structs out of the all-in-one `main.go` into a new `configloader` package, plus the `loadConfigFile` + `env` helpers.

`main.go` keeps its `FileConfig` name (now a `type FileConfig = configloader.FileConfig` alias) plus aliases for each nested type, so the rest of `resolveEffectiveConfig` and the CLI flag handling continue to compile unchanged. `loadConfigFile` and `env` become `var` aliases pointing at `configloader.LoadFile` / `configloader.Env`.

## What the new binaries can do now

The two new binary entry points (`cmd/duckgres-controlplane`, `cmd/duckgres-worker`) now actually load YAML at startup via `configloader.LoadFile` and log the parsed config before exiting with the existing "config-resolution wiring not yet in place" stub error. That gives the binaries a real first interaction with config files; the next PR lifts `resolveEffectiveConfig` (also pure Go, also duckdb-free) into the same package so the binaries can build their respective `ControlPlaneConfig` / `ServiceConfig` and call into `controlplane.RunControlPlane` / `duckdbservice.Run`.

## Test plan

- [x] `go build ./...` clean (all-in-one `duckgres` binary unchanged)
- [x] `go build -tags kubernetes ./...` clean
- [x] `go list -deps ./cmd/duckgres-controlplane | grep duckdb-go` is empty (the CP-only contract held — `configloader` is pure YAML plumbing, no DuckDB dep)
- [x] `go list -deps ./cmd/duckgres-worker` shows `duckdb-go` as expected (the worker links it via `duckdbservice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)