### PR TITLE
feat(admin): PATCH /orgs/:id/warehouse/pinning for tenant image+ducklake

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -83,6 +83,10 @@ func registerAPIWithStore(r *gin.RouterGroup, store apiStore, info OrgStackInfo)
 	r.DELETE("/orgs/:id", h.deleteOrg)
 	r.GET("/orgs/:id/warehouse", h.getManagedWarehouse)
 	r.PUT("/orgs/:id/warehouse", h.putManagedWarehouse)
+	// Focused endpoint for pinning a tenant to a specific worker image and
+	// DuckLake spec version — the operator workflow we want to be able to
+	// run without ever touching the config-store DB directly.
+	r.PATCH("/orgs/:id/warehouse/pinning", h.patchTenantPinning)
 
 	// Users CRUD
 	r.GET("/users", h.listUsers)
@@ -357,6 +361,7 @@ func (s *gormAPIStore) MutateManagedWarehouse(orgID string, mutate func(*configs
 func managedWarehouseUpsertColumns() []string {
 	return []string{
 		"image",
+		"ducklake_version",
 		"aurora_min_acu",
 		"aurora_max_acu",
 		"warehouse_database_region",
@@ -475,6 +480,8 @@ type apiHandler struct {
 // add a field here without a matching tag on ManagedWarehouse, strict decode
 // will accept it and the merge will silently drop it.
 type managedWarehouseRequest struct {
+	Image                          string                                        `json:"image"`
+	DuckLakeVersion                string                                        `json:"ducklake_version"`
 	WarehouseDatabase              configstore.ManagedWarehouseDatabase          `json:"warehouse_database"`
 	MetadataStore                  configstore.ManagedWarehouseMetadataStore     `json:"metadata_store"`
 	PgBouncer                      configstore.ManagedWarehousePgBouncer         `json:"pgbouncer"`
@@ -678,6 +685,106 @@ func (h *apiHandler) putManagedWarehouse(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, stored)
+}
+
+// tenantPinningRequest carries the two columns that determine which worker
+// image and DuckLake spec version a tenant pins to. Both fields are
+// optional — omitting one preserves the stored value, mirroring the partial
+// patch semantics of putManagedWarehouse.
+//
+// We use *string instead of string so the JSON decoder can distinguish
+// "field absent" (preserve) from "field present and empty" (clear). Clearing
+// the image falls back to the global default; clearing ducklake_version
+// likewise falls back to the global default. We don't allow both to be nil
+// after the patch — that's a no-op which is almost certainly a caller bug.
+type tenantPinningRequest struct {
+	Image           *string `json:"image,omitempty"`
+	DuckLakeVersion *string `json:"ducklake_version,omitempty"`
+}
+
+const maxPinningPatchBodyBytes = 4 << 10 // 4 KiB; the body is two strings
+
+// patchTenantPinning sets the image and/or ducklake_version columns on a
+// tenant's managed_warehouses row without touching the rest of the
+// warehouse config. This replaces the operational shape of running
+// `UPDATE duckgres_managed_warehouses SET image=..., ducklake_version=...`
+// against the config store directly — which is fine for one-offs but
+// creates audit + concurrency risks at any scale.
+//
+// Returns 200 with the updated warehouse on success, 400 for malformed
+// requests (unknown fields, both fields absent, invalid version format),
+// 404 if the org has no managed warehouse row, and 500 on store errors.
+func (h *apiHandler) patchTenantPinning(c *gin.Context) {
+	orgID := c.Param("id")
+
+	body, err := io.ReadAll(http.MaxBytesReader(c.Writer, c.Request.Body, maxPinningPatchBodyBytes))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	var req tenantPinningRequest
+	if err := dec.Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Image == nil && req.DuckLakeVersion == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one of image or ducklake_version must be set"})
+		return
+	}
+	if req.DuckLakeVersion != nil && *req.DuckLakeVersion != "" {
+		if !isValidDuckLakeSpecVersion(*req.DuckLakeVersion) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ducklake_version must be a major.minor string like \"0.4\" or \"1.0\""})
+			return
+		}
+	}
+
+	stored, ok, err := h.store.MutateManagedWarehouse(orgID, func(w *configstore.ManagedWarehouse) error {
+		if req.Image != nil {
+			w.Image = *req.Image
+		}
+		if req.DuckLakeVersion != nil {
+			w.DuckLakeVersion = *req.DuckLakeVersion
+		}
+		return nil
+	})
+	if err != nil {
+		var badReq warehouseBadRequestError
+		if errors.As(err, &badReq) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": badReq.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "org not found"})
+		return
+	}
+	c.JSON(http.StatusOK, stored)
+}
+
+// isValidDuckLakeSpecVersion accepts the same major.minor format that
+// server/ducklake.versionLessThan parses (e.g., "0.4", "1.0", "0.10"). We
+// don't import server/ducklake here to avoid a cross-cutting dependency
+// from the admin API onto a server subpackage; the check is just a shape
+// gate to catch typos before the value gets persisted.
+func isValidDuckLakeSpecVersion(v string) bool {
+	dot := -1
+	for i := 0; i < len(v); i++ {
+		if v[i] == '.' {
+			if dot >= 0 {
+				return false // multiple dots
+			}
+			dot = i
+			continue
+		}
+		if v[i] < '0' || v[i] > '9' {
+			return false
+		}
+	}
+	return dot > 0 && dot < len(v)-1
 }
 
 // --- Users ---

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -950,4 +950,192 @@ func TestManagedWarehouseUpsertColumnsExcludeCreatedAt(t *testing.T) {
 	if !slices.Contains(columns, "metadata_store_database_name") {
 		t.Fatal("expected metadata_store_database_name to be included in managed warehouse upserts")
 	}
+	// Regression guards: image and ducklake_version must be in the upsert
+	// column list so the per-tenant pinning patch endpoint actually
+	// persists. If either is missing, PATCH /orgs/:id/warehouse/pinning
+	// silently no-ops and the matrix-build cutover breaks.
+	if !slices.Contains(columns, "image") {
+		t.Fatal("expected image to be included in managed warehouse upserts (tenant pinning)")
+	}
+	if !slices.Contains(columns, "ducklake_version") {
+		t.Fatal("expected ducklake_version to be included in managed warehouse upserts (tenant pinning)")
+	}
+}
+
+func TestPatchTenantPinningSetsImageAndDuckLakeVersion(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{
+		OrgID:           "analytics",
+		Image:           "old-image:1.0",
+		DuckLakeVersion: "0.3",
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"image":"posthog/duckgres-worker:abc-duckdb1.5.1","ducklake_version":"0.4"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	got := store.warehouses["analytics"]
+	if got.Image != "posthog/duckgres-worker:abc-duckdb1.5.1" {
+		t.Errorf("image = %q, want posthog/duckgres-worker:abc-duckdb1.5.1", got.Image)
+	}
+	if got.DuckLakeVersion != "0.4" {
+		t.Errorf("ducklake_version = %q, want 0.4", got.DuckLakeVersion)
+	}
+}
+
+func TestPatchTenantPinningPreservesUntouchedField(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{
+		OrgID:           "analytics",
+		Image:           "existing-image:1.0",
+		DuckLakeVersion: "0.4",
+	}
+	router := newTestAPIRouter(store)
+
+	// Only set image; ducklake_version absent ⇒ preserve.
+	body := []byte(`{"image":"new-image:2.0"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	got := store.warehouses["analytics"]
+	if got.Image != "new-image:2.0" {
+		t.Errorf("image = %q, want new-image:2.0", got.Image)
+	}
+	if got.DuckLakeVersion != "0.4" {
+		t.Errorf("ducklake_version = %q, want 0.4 (untouched)", got.DuckLakeVersion)
+	}
+}
+
+func TestPatchTenantPinningEmptyStringClearsField(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{
+		OrgID:           "analytics",
+		Image:           "pinned:1.0",
+		DuckLakeVersion: "0.4",
+	}
+	router := newTestAPIRouter(store)
+
+	// Explicit "" — distinct from absent — falls back to global default.
+	body := []byte(`{"image":""}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	got := store.warehouses["analytics"]
+	if got.Image != "" {
+		t.Errorf("image = %q, want empty (cleared)", got.Image)
+	}
+	if got.DuckLakeVersion != "0.4" {
+		t.Errorf("ducklake_version = %q, want 0.4 (untouched)", got.DuckLakeVersion)
+	}
+}
+
+func TestPatchTenantPinningRejectsEmptyBody(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{OrgID: "analytics"}
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader([]byte(`{}`)))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPatchTenantPinningRejectsBadVersion(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{OrgID: "analytics"}
+	router := newTestAPIRouter(store)
+
+	cases := []string{
+		`{"ducklake_version":"foo"}`,
+		`{"ducklake_version":"1"}`,
+		`{"ducklake_version":"1.0.0"}`,
+		`{"ducklake_version":"1."}`,
+		`{"ducklake_version":".1"}`,
+	}
+	for _, body := range cases {
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader([]byte(body)))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want %d", body, rec.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestPatchTenantPinningRejectsUnknownFields(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.warehouses["analytics"] = &configstore.ManagedWarehouse{OrgID: "analytics"}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"image":"x","aurora_max_acu":42}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPatchTenantPinningReturnsNotFoundForMissingOrg(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"image":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/missing/warehouse/pinning", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestIsValidDuckLakeSpecVersion(t *testing.T) {
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"0.3", true},
+		{"0.4", true},
+		{"1.0", true},
+		{"0.10", true},
+		{"1.5", true},
+		{"", false},
+		{"1", false},
+		{"1.", false},
+		{".1", false},
+		{"1.0.0", false},
+		{"foo", false},
+		{"1.x", false},
+		{"-1.0", false},
+	}
+	for _, tc := range cases {
+		if got := isValidDuckLakeSpecVersion(tc.v); got != tc.want {
+			t.Errorf("isValidDuckLakeSpecVersion(%q) = %v, want %v", tc.v, got, tc.want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/v1/orgs/:id/warehouse/pinning` so operators can pin a tenant's worker `image` and `ducklake_version` without running direct `UPDATE` SQL against the config store.
- Adds the missing `ducklake_version` column to `managedWarehouseUpsertColumns()` — it was silently no-oping on PUT/MUTATE — plus a regression-guard test for both `image` and `ducklake_version`.
- Adds `image` and `ducklake_version` to the strict-decode whitelist on `managedWarehouseRequest` so the existing PUT path can also carry them.

This is the operator-facing closing piece of the pinning + matrix-CD work (#462, #501–#503): you can now run a request like
```
PATCH /api/v1/orgs/<org-id>/warehouse/pinning
{"image": "posthog/duckgres-worker:<sha>-duckdb1.5.1", "ducklake_version": "0.4"}
```
to pin a tenant — no DB shell required.

Body shape uses `*string` so the decoder distinguishes "field absent" (preserve) from "field present and empty" (clear → fall back to the global default). At least one of `image` / `ducklake_version` must be present.

## Test plan
- [x] `go test -tags kubernetes ./controlplane/admin/...` (new endpoint tests + extended upsert-columns regression test pass)
- [x] `go build -tags kubernetes ./controlplane/admin/...` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)