### PR TITLE
fix(tests/perf): move publishRunDir + publishArtifactsIfConfigured into a non-test file

### DIFF
--- a/tests/perf/harness_publish.go
+++ b/tests/perf/harness_publish.go
@@ -1,0 +1,27 @@
+package perf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/posthog/duckgres/tests/perf/publisher"
+)
+
+// publishRunDir is the seam tests use to mock out publisher.PublishRunDir.
+// It must live in a non-test file because harness_artifacts.go calls it
+// (via publishArtifactsIfConfigured) under a regular `go build` — declaring
+// it in *_test.go would make the build fail for non-test consumers.
+var publishRunDir = publisher.PublishRunDir
+
+// publishArtifactsIfConfigured invokes publishRunDir for cfg if it's
+// enabled, returning a wrapped error so callers see context. A no-op when
+// the publisher is disabled.
+func publishArtifactsIfConfigured(ctx context.Context, cfg publisher.Config, runDir string) error {
+	if !cfg.Enabled() {
+		return nil
+	}
+	if err := publishRunDir(ctx, cfg, runDir); err != nil {
+		return fmt.Errorf("publish perf artifacts: %w", err)
+	}
+	return nil
+}

--- a/tests/perf/harness_test.go
+++ b/tests/perf/harness_test.go
@@ -44,8 +44,6 @@ var (
 	perfPublishBootstrap      = flag.Bool("perf-publish-bootstrap-schema", envBoolOrDefault("DUCKGRES_PERF_PUBLISH_BOOTSTRAP_SCHEMA", true), "bootstrap publisher schema/table definitions before inserting rows")
 )
 
-var publishRunDir = publisher.PublishRunDir
-
 func TestGoldenQueryPerformanceHarness(t *testing.T) {
 	if !*perfRun {
 		t.Skip("set -perf-run to execute the perf harness")
@@ -202,16 +200,6 @@ func currentPublisherConfig() publisher.Config {
 		Schema:          *perfPublishSchema,
 		BootstrapSchema: *perfPublishBootstrap,
 	}
-}
-
-func publishArtifactsIfConfigured(ctx context.Context, cfg publisher.Config, runDir string) error {
-	if !cfg.Enabled() {
-		return nil
-	}
-	if err := publishRunDir(ctx, cfg, runDir); err != nil {
-		return fmt.Errorf("publish perf artifacts: %w", err)
-	}
-	return nil
 }
 
 func envOrDefault(key, fallback string) string {


### PR DESCRIPTION
## Summary

`publishRunDir` (a test-seam var) and `publishArtifactsIfConfigured` (the function that uses it) lived in `tests/perf/harness_test.go`, but `tests/perf/harness_artifacts.go` (a non-test file) calls `publishArtifactsIfConfigured`. `go test` compiled fine because it includes `_test.go` files, but `go build ./tests/perf/...` and `go vet -tags kubernetes ./...` both fail with `undefined: publishArtifactsIfConfigured` because non-test compilations don't see `_test.go` declarations.

This is a latent foot-gun: it doesn't break the existing CI test path (everything goes through `go test`), but it fails any future tooling that does a plain build, IDE-level vet, or attempts to run `go list -e -compiled` over the perf package.

## Changes

- New `tests/perf/harness_publish.go` holds:
  - `var publishRunDir = publisher.PublishRunDir`
  - `func publishArtifactsIfConfigured(...)`
- `tests/perf/harness_test.go` drops the same two declarations.
- The test seam pattern is preserved — `harness_publisher_test.go`'s `publishRunDir = func(…) { … }` overrides still work because the var is still package-level.

## Test plan

- [x] `go test -tags kubernetes -count=1 ./tests/perf` passes (all `TestPublishArtifactsIfConfigured*` cases green)
- [x] `go build -tags kubernetes ./tests/perf/...` clean (was failing on main)
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)