### PR TITLE
Make session init timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ flight_session_reap_interval: "1m"
 flight_handle_idle_ttl: "15m"
 flight_session_token_ttl: "1h"
 data_dir: "./data"
+session_init_timeout: "10s"
 
 tls:
   cert: "./certs/server.crt"
@@ -214,6 +215,7 @@ Run with config file:
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
 | `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |
 | `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` |
+| `DUCKGRES_SESSION_INIT_TIMEOUT` | Session startup metadata initialization and catalog probe timeout | `10s` |
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_K8S_SHARED_WARM_TARGET` | Global neutral shared warm-worker target for K8s multi-tenant mode (`0` disables prewarm; subject to `DUCKGRES_K8S_MAX_WORKERS`) | `0` |
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |

--- a/config_resolution.go
+++ b/config_resolution.go
@@ -26,6 +26,7 @@ type configCLIInputs struct {
 	FilePersistence             bool
 	ProcessIsolation            bool
 	IdleTimeout                 string
+	SessionInitTimeout          string
 	MemoryLimit                 string
 	Threads                     int
 	MemoryBudget                string
@@ -76,6 +77,7 @@ type resolvedConfig struct {
 	ProcessMinWorkers          int
 	ProcessMaxWorkers          int
 	ProcessRetireOnSessionEnd  bool
+	SessionInitTimeout         time.Duration
 	WorkerQueueTimeout         time.Duration
 	WorkerIdleTimeout          time.Duration
 	HandoverDrainTimeout       time.Duration
@@ -118,6 +120,7 @@ func defaultServerConfig() server.Config {
 		FlightHandleIdleTTL:       15 * time.Minute,
 		FlightSessionTokenTTL:     1 * time.Hour,
 		DataDir:                   "./data",
+		SessionInitTimeout:        server.DefaultSessionInitTimeout,
 		TLSCertFile:               "./certs/server.crt",
 		TLSKeyFile:                "./certs/server.key",
 		Users: map[string]string{
@@ -317,6 +320,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 				cfg.IdleTimeout = d
 			} else {
 				warn("Invalid idle_timeout duration: " + err.Error())
+			}
+		}
+		if fileCfg.SessionInitTimeout != "" {
+			if d, err := time.ParseDuration(fileCfg.SessionInitTimeout); err == nil {
+				cfg.SessionInitTimeout = d
+			} else {
+				warn("Invalid session_init_timeout duration: " + err.Error())
 			}
 		}
 		if fileCfg.MemoryLimit != "" {
@@ -600,6 +610,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 			warn("Invalid DUCKGRES_IDLE_TIMEOUT duration: " + err.Error())
 		}
 	}
+	if v := getenv("DUCKGRES_SESSION_INIT_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.SessionInitTimeout = d
+		} else {
+			warn("Invalid DUCKGRES_SESSION_INIT_TIMEOUT duration: " + err.Error())
+		}
+	}
 	if v := getenv("DUCKGRES_MEMORY_LIMIT"); v != "" {
 		cfg.MemoryLimit = v
 	}
@@ -868,6 +885,13 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 			warn("Invalid --idle-timeout duration: " + err.Error())
 		}
 	}
+	if cli.Set["session-init-timeout"] {
+		if d, err := time.ParseDuration(cli.SessionInitTimeout); err == nil {
+			cfg.SessionInitTimeout = d
+		} else {
+			warn("Invalid --session-init-timeout duration: " + err.Error())
+		}
+	}
 	if cli.Set["memory-limit"] {
 		cfg.MemoryLimit = cli.MemoryLimit
 	}
@@ -1059,6 +1083,7 @@ func resolveEffectiveConfig(fileCfg *FileConfig, cli configCLIInputs, getenv fun
 		ProcessMinWorkers:          processMinWorkers,
 		ProcessMaxWorkers:          processMaxWorkers,
 		ProcessRetireOnSessionEnd:  processRetireOnSessionEnd,
+		SessionInitTimeout:         cfg.SessionInitTimeout,
 		WorkerQueueTimeout:         workerQueueTimeout,
 		WorkerIdleTimeout:          workerIdleTimeout,
 		HandoverDrainTimeout:       handoverDrainTimeout,

--- a/configloader/file_config.go
+++ b/configloader/file_config.go
@@ -29,6 +29,7 @@ type FileConfig struct {
 	FilePersistence           bool                `yaml:"file_persistence"`
 	ProcessIsolation          bool                `yaml:"process_isolation"`
 	IdleTimeout               string              `yaml:"idle_timeout"`
+	SessionInitTimeout        string              `yaml:"session_init_timeout"`
 	MemoryLimit               string              `yaml:"memory_limit"`
 	Threads                   int                 `yaml:"threads"`
 	MemoryBudget              string              `yaml:"memory_budget"`

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -189,6 +189,9 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	if cfg.WorkerIdleTimeout == 0 {
 		cfg.WorkerIdleTimeout = 5 * time.Minute
 	}
+	if cfg.SessionInitTimeout == 0 {
+		cfg.SessionInitTimeout = server.DefaultSessionInitTimeout
+	}
 	if cfg.HandoverDrainTimeout == 0 {
 		// Remote mode: no internal drain timeout. The CP waits for active
 		// sessions to finish for as long as it takes; k8s
@@ -571,6 +574,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		"k8s_max_workers", k8sMaxWorkers,
 		"k8s_shared_warm_target", k8sSharedWarmTarget,
 		"worker_queue_timeout", cfg.WorkerQueueTimeout,
+		"session_init_timeout", cfg.SessionInitTimeout,
 		"memory_budget", formatBytes(rebalancer.memoryBudget),
 		"memory_rebalance", cfg.MemoryRebalance)
 
@@ -1009,7 +1013,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		}
 	}()
 
-	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
 	err = sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, database)
 	if err != nil {
 		initCancel()

--- a/controlplane/shared_startup_config.go
+++ b/controlplane/shared_startup_config.go
@@ -22,6 +22,7 @@ var allowedSharedStartupConfigKeys = map[string]struct{}{
 	"memory_limit":         {},
 	"memory_rebalance":     {},
 	"query_log":            {},
+	"session_init_timeout": {},
 	"threads":              {},
 	"worker_idle_timeout":  {},
 	"worker_queue_timeout": {},

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -63,6 +63,7 @@ Key flags for Kubernetes multitenant mode:
 |------|---------|-------------|
 | `--worker-backend remote` | - | Use K8s remote workers in config-store-backed multitenant mode |
 | `--config-store` | `DUCKGRES_CONFIG_STORE` | PostgreSQL config-store connection string required for remote mode |
+| `--session-init-timeout` | `DUCKGRES_SESSION_INIT_TIMEOUT` | Session startup metadata initialization and catalog probe timeout (`10s` default) |
 | `--handover-drain-timeout` | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns/upgrades before forced exit (`15m` default in remote mode) |
 | `--k8s-worker-image` | `DUCKGRES_K8S_WORKER_IMAGE` | Docker image for worker pods |
 | `--k8s-worker-image-pull-policy` | `DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY` | Image pull policy (`Never`, `IfNotPresent`, `Always`) |

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func main() {
 	filePersistence := flag.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
 	processIsolation := flag.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
 	idleTimeout := flag.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
+	sessionInitTimeout := flag.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
 	memoryLimit := flag.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
 	threads := flag.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
 	memoryBudget := flag.String("memory-budget", "", "Total memory for all DuckDB sessions (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
@@ -186,6 +187,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_FILE_PERSISTENCE   Persist DuckDB to <data_dir>/<username>.duckdb (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_ISOLATION  Enable process isolation (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_IDLE_TIMEOUT       Connection idle timeout (e.g., 30m, 1h, -1 to disable)\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_SESSION_INIT_TIMEOUT  Session startup metadata/probe timeout (default: 10s)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_LIMIT       DuckDB memory_limit per session (e.g., 4GB)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_THREADS            DuckDB threads per session\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_BUDGET      Total memory for all DuckDB sessions (e.g., 24GB)\n")
@@ -300,6 +302,7 @@ func main() {
 		FilePersistence:             *filePersistence,
 		ProcessIsolation:            *processIsolation,
 		IdleTimeout:                 *idleTimeout,
+		SessionInitTimeout:          *sessionInitTimeout,
 		MemoryLimit:                 *memoryLimit,
 		Threads:                     *threads,
 		MemoryBudget:                *memoryBudget,

--- a/main_test.go
+++ b/main_test.go
@@ -644,6 +644,40 @@ func TestResolveEffectiveConfigFlightIngressDurations(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveConfigSessionInitTimeout(t *testing.T) {
+	resolved := resolveEffectiveConfig(nil, configCLIInputs{}, nil, nil)
+	if resolved.SessionInitTimeout != 10*time.Second {
+		t.Fatalf("expected default session init timeout 10s, got %s", resolved.SessionInitTimeout)
+	}
+	if resolved.Server.SessionInitTimeout != 10*time.Second {
+		t.Fatalf("expected server default session init timeout 10s, got %s", resolved.Server.SessionInitTimeout)
+	}
+}
+
+func TestResolveEffectiveConfigSessionInitTimeoutPrecedence(t *testing.T) {
+	fileCfg := &FileConfig{
+		SessionInitTimeout: "7s",
+	}
+
+	env := map[string]string{
+		"DUCKGRES_SESSION_INIT_TIMEOUT": "9s",
+	}
+
+	resolved := resolveEffectiveConfig(fileCfg, configCLIInputs{
+		Set: map[string]bool{
+			"session-init-timeout": true,
+		},
+		SessionInitTimeout: "11s",
+	}, envFromMap(env), nil)
+
+	if resolved.SessionInitTimeout != 11*time.Second {
+		t.Fatalf("expected CLI session_init_timeout, got %s", resolved.SessionInitTimeout)
+	}
+	if resolved.Server.SessionInitTimeout != 11*time.Second {
+		t.Fatalf("expected server CLI session_init_timeout, got %s", resolved.Server.SessionInitTimeout)
+	}
+}
+
 func TestResolveEffectiveConfigFlightIngressDurationsFromFile(t *testing.T) {
 	fileCfg := &FileConfig{
 		FlightSessionIdleTTL:      "7m",

--- a/server/conn.go
+++ b/server/conn.go
@@ -936,7 +936,11 @@ func (c *clientConn) serve() error {
 	}()
 
 	if !c.passthrough {
-		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		initTimeout := c.server.cfg.SessionInitTimeout
+		if initTimeout == 0 {
+			initTimeout = DefaultSessionInitTimeout
+		}
+		initCtx, initCancel := context.WithTimeout(context.Background(), initTimeout)
 		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, c.database); err != nil {
 			initCancel()
 			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to initialize session database metadata: %v", err))
@@ -2474,7 +2478,7 @@ func countDollarParams(query string) int {
 // isEmptyQuery and stripLeadingComments moved to server/sqlcore so the
 // Flight client can call them without importing server. Local thin wrappers
 // preserve the unexported call-site spellings used throughout this file.
-func isEmptyQuery(query string) bool         { return sqlcore.IsEmptyQuery(query) }
+func isEmptyQuery(query string) bool           { return sqlcore.IsEmptyQuery(query) }
 func stripLeadingComments(query string) string { return sqlcore.StripLeadingComments(query) }
 
 // stripLeadingNoise strips leading whitespace, comments, and parentheses from

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,9 @@ type DuckLakeConfig = ducklake.Config
 // constant under the server package before the migration code moved.
 const DefaultDuckLakeSpecVersion = ducklake.DefaultSpecVersion
 
+// DefaultSessionInitTimeout bounds startup metadata initialization and catalog probes.
+const DefaultSessionInitTimeout = 10 * time.Second
+
 // Re-exports of the migration / backup / delta-path entry points so callers
 // that referenced them under the server package continue to compile after
 // the implementation moved to server/ducklake. New code should import
@@ -229,6 +232,10 @@ type Config struct {
 	// uncleanly. Default: 24 hours. Set to a negative value (e.g., -1) to disable.
 	IdleTimeout time.Duration
 
+	// SessionInitTimeout bounds startup metadata initialization and catalog probes.
+	// Default: 10 seconds.
+	SessionInitTimeout time.Duration
+
 	// FilePersistence stores DuckDB data in <DataDir>/<username>.duckdb instead of :memory:.
 	// DuckDB memory-maps the file and serves queries from RAM, so performance is similar
 	// to in-memory mode while data persists across connections and restarts.
@@ -275,7 +282,6 @@ type QueryLogConfig struct {
 	CompactInterval      time.Duration
 	DataInliningRowLimit int
 }
-
 
 // fileDBEntry tracks a shared *sql.DB for file-persistence mode.
 // One entry per user file; multiple PG connections share the pool via pinned *sql.Conn.
@@ -366,6 +372,9 @@ func New(cfg Config) (*Server, error) {
 		cfg.IdleTimeout = 24 * time.Hour
 	} else if cfg.IdleTimeout < 0 {
 		cfg.IdleTimeout = 0
+	}
+	if cfg.SessionInitTimeout == 0 {
+		cfg.SessionInitTimeout = DefaultSessionInitTimeout
 	}
 
 	if cfg.ACMEDNSProvider != "" && cfg.ACMEDomain == "" {


### PR DESCRIPTION
## Why
Remote k8s worker mode was surfacing startup failures like `failed to initialize session database metadata` and `failed to detect ducklake catalog attachment` when the control plane timed out waiting for the worker over Flight SQL. The underlying logs showed `DeadlineExceeded` during the post-session metadata/catalog probe path, but that path was using a hard-coded 5s deadline shared across session metadata initialization and DuckLake catalog detection. Making this timeout configurable, with a less aggressive 10s default, gives production deployments room for slower warm/hot worker transitions while keeping a bounded startup failure mode.

## Summary
- add session_init_timeout config via YAML, env, and CLI with a 10s default
- use the configured timeout for pgwire/control-plane session metadata initialization and catalog probes
- document the new option and allow it in shared worker startup config

## Tests
- just test-unit
- just lint