### PR TITLE
docs: update worker-upgrades runbook for binary split + admin pinning API

### DIFF
--- a/docs/runbooks/worker-upgrades.md
+++ b/docs/runbooks/worker-upgrades.md
@@ -6,7 +6,7 @@ Duckgres supports running multiple versions of DuckDB and DuckLake workers simul
 
 The control plane manages a heterogeneous pool of workers. The target build for any given connection is resolved with the following precedence:
 
-1.  **Tenant Override:** The `image` and `ducklake_version` fields in the `managed_warehouses` table (Config Store).
+1.  **Tenant Override:** The `image` and `ducklake_version` columns on the tenant's row in `duckgres_managed_warehouses` (Config Store).
 2.  **Global Fallback:** The `k8s.worker_image` and `ducklake.default_spec_version` set in the Control Plane's `duckgres.yaml`.
 
 ### 1. Setting Global Defaults
@@ -16,42 +16,84 @@ Maintainers define the "stable" fleet version in the Control Plane configuration
 ```yaml
 # duckgres.yaml
 k8s:
-  worker_image: "posthog/duckgres:v1.1.0"
+  # Use the multi-arch GHCR manifest (or its ECR mirror). The bare :<sha>
+  # and :latest tags always point at the default DuckDB version (1.5.2 today)
+  # produced by the matrix CD.
+  worker_image: "ghcr.io/posthog/duckgres-worker:latest"
   worker_image_pull_policy: "IfNotPresent"
 
 ducklake:
-  # Default DuckLake spec version for migration checks
+  # Default DuckLake spec version for migration checks (major.minor only)
   default_spec_version: "1.0"
 ```
 
-When the Control Plane starts, the **Janitor** will ensure that the shared "neutral" warm pool is populated with pods running this image.
+When the Control Plane starts, the **Janitor** ensures that the shared "neutral" warm pool is populated with pods running this image.
 
-### 2. Canarying a New Build
+### 2. Available Worker Builds
 
-To test a new build (e.g., a DuckDB upgrade) for a specific subset of tenants without affecting the rest of the fleet:
+Worker images are produced by [`.github/workflows/container-image-worker-cd.yml`](../../.github/workflows/container-image-worker-cd.yml) on every push to `main`. Each push produces a multi-arch (arm64 + amd64) manifest per DuckDB version in the matrix.
 
-1.  **Update the Tenant Config:** Set the `image` field for the target org in the Config Store database.
+**Tag conventions:**
 
-    ```sql
-    UPDATE managed_warehouses
-    SET image = 'posthog/duckgres:v1.2.0-beta.1'
-    WHERE org_id = 'org-uuid-123';
-    ```
+| Tag                                              | Points at                                   |
+|--------------------------------------------------|---------------------------------------------|
+| `ghcr.io/posthog/duckgres-worker:<sha>`          | Default DuckDB version, this commit         |
+| `ghcr.io/posthog/duckgres-worker:latest`         | Default DuckDB version, latest `main`       |
+| `ghcr.io/posthog/duckgres-worker:<sha>-duckdb<X.Y.Z>` | Specific DuckDB version, this commit   |
 
-2.  **Automatic Recycling:** The Control Plane detects this change during the next connection attempt:
-    *   It will **refuse to reuse** any existing "hot-idle" workers for that org if their image doesn't match the new target.
-    *   It will spawn a **fresh worker pod** using the specific canary image.
-    *   The old workers will be naturally retired by the Janitor.
+The same tags exist mirrored in ECR at `795637471508.dkr.ecr.us-east-1.amazonaws.com/duckgres-worker:...`.
 
-### 3. Managing DuckLake Spec Upgrades
+To list what's currently available:
 
-If a new worker build requires a newer DuckLake metadata schema (e.g., moving from v1.0 to v1.1), you must also designate the target spec version to trigger the migration logic.
+```bash
+# GHCR
+gh api /users/posthog/packages/container/duckgres-worker/versions --jq '.[].metadata.container.tags[]' | sort -u
 
-```sql
-UPDATE managed_warehouses
-SET image = 'posthog/duckgres:v1.2.0',
-    ducklake_version = '1.1'
-WHERE org_id = 'org-uuid-123';
+# ECR (requires AWS auth)
+aws ecr list-images --repository-name duckgres-worker --region us-east-1 \
+  --query 'imageIds[].imageTag' --output text | tr '\t' '\n' | sort -u
+```
+
+The DuckDB versions in the matrix are defined in `container-image-worker-cd.yml`'s `strategy.matrix.duckdb`. To pin a tenant to a non-default DuckDB version, you need a `:<sha>-duckdb<version>` tag from a commit where that version was in the matrix.
+
+### 3. Canarying a New Build
+
+To test a new build (e.g., a DuckDB upgrade) for a specific subset of tenants without affecting the rest of the fleet, use the admin API. **Do not run direct `UPDATE duckgres_managed_warehouses` SQL** — the API endpoint goes through a row-locked transaction so it serializes correctly with concurrent operator mutations.
+
+```bash
+# Pin org-uuid-123 to a specific DuckDB 1.5.1 build
+curl -X PATCH "https://<cp-host>/api/v1/orgs/org-uuid-123/warehouse/pinning" \
+  -H "Authorization: Bearer $DUCKGRES_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": "ghcr.io/posthog/duckgres-worker:abc1234-duckdb1.5.1"
+  }'
+```
+
+The response is the updated managed warehouse JSON. The endpoint accepts:
+
+- `image` (string, optional): the worker image. Pass `""` to clear back to the global default.
+- `ducklake_version` (string, optional): the DuckLake spec version (`major.minor` only — e.g., `"0.4"`, `"1.0"`, `"1.1"`). Pass `""` to clear back to the global default.
+
+At least one of the two fields must be present; an empty body is rejected. Missing fields preserve the stored value (this is a true `PATCH`, not a `PUT`).
+
+**Automatic Recycling:** the Control Plane detects the change on the next connection attempt:
+*   It will **refuse to reuse** any existing "hot-idle" workers for that org if their image doesn't match the new target.
+*   It spawns a **fresh worker pod** using the canary image.
+*   The old workers are naturally retired by the Janitor.
+
+### 4. Managing DuckLake Spec Upgrades
+
+If a new worker build requires a newer DuckLake metadata schema (e.g., moving from 1.0 to 1.1), pin both fields together so the migration logic kicks in:
+
+```bash
+curl -X PATCH "https://<cp-host>/api/v1/orgs/org-uuid-123/warehouse/pinning" \
+  -H "Authorization: Bearer $DUCKGRES_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": "ghcr.io/posthog/duckgres-worker:def5678-duckdb1.5.2",
+    "ducklake_version": "1.1"
+  }'
 ```
 
 **The Control Plane Authority:**
@@ -60,12 +102,26 @@ The Control Plane (CP) performs a "pre-flight" migration check before activating
 *   The CP then signals the worker to perform `AUTOMATIC_MIGRATION TRUE` during attachment.
 
 > [!CAUTION]
-> **One-Way Door:** DuckLake migrations are irreversible. Once a tenant's metadata is upgraded to v1.1, older workers (v1.0) will no longer be able to attach to it. Pinning the `image` and `ducklake_version` together ensures a tenant doesn't accidentally flip-flop between incompatible builds.
+> **One-Way Door:** DuckLake migrations are irreversible. Once a tenant's metadata is upgraded to 1.1, older workers (1.0) will no longer be able to attach to it. Pin `image` and `ducklake_version` together so a tenant doesn't accidentally flip-flop between incompatible builds.
+
+### 5. Reverting a Pin
+
+To roll a tenant back to the global default for either or both knobs, send empty strings:
+
+```bash
+# Clear both: tenant follows global k8s.worker_image and ducklake.default_spec_version
+curl -X PATCH "https://<cp-host>/api/v1/orgs/org-uuid-123/warehouse/pinning" \
+  -H "Authorization: Bearer $DUCKGRES_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"image": "", "ducklake_version": ""}'
+```
+
+Note: clearing `ducklake_version` does NOT downgrade the metadata schema (one-way door); it just stops asserting a per-tenant target. The tenant's existing schema remains at whatever level it last migrated to.
 
 ## Operational Safety
 
 ### Hot-Idle Recycling
-The system is "version-aware" during worker reclamation. If a tenant is sitting on a "hot" worker (DuckLake already attached) and you update their target image in the DB, the control plane will:
+The system is "version-aware" during worker reclamation. If a tenant is sitting on a "hot" worker (DuckLake already attached) and you change their target image via the pinning endpoint, the control plane will:
 1.  See the mismatch.
 2.  Log: `Hot-idle worker image mismatch, skipping reclamation.`
 3.  Retire the old worker.
@@ -73,3 +129,12 @@ The system is "version-aware" during worker reclamation. If a tenant is sitting 
 
 ### Neutral Pool
 The global "Neutral Warm Pool" (idle workers waiting for any org) **always** uses the global default image. This ensures that the most common path is always fast (sub-second connection). Tenants on custom/canary builds will experience a "cold start" (pod spawn penalty) on their first connection.
+
+## Background
+
+The duckgres binary was split into two specialized images in the PRs around #500–#503:
+
+- **`duckgres-worker`** — the per-DuckDB-version image, links libduckdb. Comes in a matrix of DuckDB versions (currently 1.5.1 + 1.5.2) so operators can pin tenants for canary or rollback.
+- **`duckgres-controlplane`** — duckdb-go-free, version-agnostic. One image fits all worker fleets.
+
+The `posthog/duckgres` repo (the legacy all-in-one image) is still produced and used by deployments that need both the CP and worker bundled, but new tenant pinning should target the `duckgres-worker` images.


### PR DESCRIPTION
## Summary

Two pieces of [`docs/runbooks/worker-upgrades.md`](../blob/main/docs/runbooks/worker-upgrades.md) went stale during the recent binary-split work. This PR brings the runbook back in sync with what landed.

### What was wrong

1. **Canary instructions used direct SQL.** The runbook said \"set the `image` field for the target org in the Config Store database\" and showed a literal `UPDATE duckgres_managed_warehouses SET image=...`. PR #506 replaced that with a row-locked admin endpoint: `PATCH /api/v1/orgs/:id/warehouse/pinning`. Direct SQL bypasses the transaction lock so concurrent operator mutations can clobber each other.
2. **Image format was the legacy all-in-one.** Examples used `posthog/duckgres:vX.Y.Z` — but PRs #500-#503 split that into a per-DuckDB-version `duckgres-worker` matrix CD producing `ghcr.io/posthog/duckgres-worker:<sha>-duckdb<version>` (and the ECR mirror provisioned in posthog-cloud-infra#7848).

### Changes

- Every \"canary a build\" example now uses the `PATCH /api/v1/orgs/:id/warehouse/pinning` endpoint with `curl` + bearer-token shape, and an explicit \"do not run direct UPDATE SQL\" note.
- New **Available Worker Builds** section: tag conventions table (GHCR + ECR), `gh api` and `aws ecr list-images` snippets to enumerate what's currently in the registry, and an explanation of why pinning a non-default DuckDB version requires a specific `<sha>-duckdb<version>` tag (there's no `latest-duckdb<version>` convention).
- New **Reverting a Pin** section: documents the empty-string semantics for clearing fields back to the global default, with a caution that clearing `ducklake_version` does NOT downgrade an already-migrated tenant (one-way door — already noted elsewhere in the doc).
- Fixes `ducklake_version` format in examples to `major.minor` only (\"0.4\", \"1.0\", \"1.1\") matching the validator added in #506.
- New **Background** section briefly linking the two-image story back to the binary-split PRs for future maintainers.

## Test plan

Doc-only — no code changes. CI lint should pass; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)