### PR TITLE
fix(logging): quote attr values that contain spaces or '='

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/posthog/duckgres/server"
 
@@ -35,16 +37,45 @@ func (h *stampedHandler) Handle(_ context.Context, r slog.Record) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "time=%s level=%s", r.Time.UTC().Format(time.RFC3339Nano), r.Level.String())
 	for _, a := range h.stamp {
-		fmt.Fprintf(&b, " %s=%s", a.Key, a.Value.String())
+		writeAttr(&b, a)
 	}
 	fmt.Fprintf(&b, " msg=%q", r.Message)
 	r.Attrs(func(a slog.Attr) bool {
-		fmt.Fprintf(&b, " %s=%s", a.Key, a.Value.String())
+		writeAttr(&b, a)
 		return true
 	})
 	b.WriteByte('\n')
 	_, err := io.WriteString(h.out, b.String())
 	return err
+}
+
+// writeAttr appends " key=value" to b, quoting the value if it contains
+// whitespace, '=', '"', or unprintable runes — matching slog's TextHandler.
+// Without this, an attr like error="flight worker is dead" prints as
+// `error=flight worker is dead worker=41757`, which makes downstream
+// key=value parsing think `is`, `dead`, etc. are bare keys.
+func writeAttr(b *strings.Builder, a slog.Attr) {
+	b.WriteByte(' ')
+	b.WriteString(a.Key)
+	b.WriteByte('=')
+	v := a.Value.String()
+	if needsQuoting(v) {
+		b.WriteString(strconv.Quote(v))
+	} else {
+		b.WriteString(v)
+	}
+}
+
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, r := range s {
+		if r == ' ' || r == '=' || r == '"' || r == '\\' || !unicode.IsPrint(r) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *stampedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/logging_test.go
+++ b/logging_test.go
@@ -3,10 +3,63 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 )
+
+// TestStampedHandlerQuotesValuesWithSpaces guards against regressions where
+// the text encoder emits unquoted multi-word values (e.g. error strings),
+// which break key=value parsers downstream.
+func TestStampedHandlerQuotesValuesWithSpaces(t *testing.T) {
+	tests := []struct {
+		name      string
+		attrs     []slog.Attr
+		wantSub   string
+		notWant   string
+	}{
+		{
+			name:    "error with spaces is quoted",
+			attrs:   []slog.Attr{slog.Any("error", errors.New("flight worker is dead")), slog.Int("worker", 41757)},
+			wantSub: `error="flight worker is dead" worker=41757`,
+			notWant: "error=flight worker is dead",
+		},
+		{
+			name:    "value with embedded equals is quoted",
+			attrs:   []slog.Attr{slog.String("dsn", "host=foo dbname=bar")},
+			wantSub: `dsn="host=foo dbname=bar"`,
+		},
+		{
+			name:    "simple alphanumeric stays unquoted",
+			attrs:   []slog.Attr{slog.String("worker_pod", "duckgres-5fdb-worker-40772"), slog.Int("count", 3)},
+			wantSub: `worker_pod=duckgres-5fdb-worker-40772 count=3`,
+			notWant: `"duckgres-5fdb-worker-40772"`,
+		},
+		{
+			name:    "empty string is quoted to stay unambiguous",
+			attrs:   []slog.Attr{slog.String("reason", "")},
+			wantSub: `reason=""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := &stampedHandler{out: &buf, level: slog.LevelDebug}
+			logger := slog.New(h)
+			logger.LogAttrs(context.Background(), slog.LevelInfo, "msg", tt.attrs...)
+			out := buf.String()
+			if !strings.Contains(out, tt.wantSub) {
+				t.Errorf("missing %q in:\n%s", tt.wantSub, out)
+			}
+			if tt.notWant != "" && strings.Contains(out, tt.notWant) {
+				t.Errorf("unexpected %q in:\n%s", tt.notWant, out)
+			}
+		})
+	}
+}
 
 func TestRedactingHandler(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- ` stampedHandler` now quotes attr values containing whitespace, ` =`, ` \"`, ` \\`, or unprintable runes — matching ` slog.TextHandler` behavior
- Plain identifiers (` worker_pod=duckgres-... ` , ` count=3 ` ) stay unquoted

## Why
Today log lines like ` error=flight worker is dead worker=41757 ` are emitted unquoted. ` slog.TextHandler ` would have rendered ` error=\"flight worker is dead\" worker=41757 ` , but our custom ` stampedHandler ` (which we use to put ` pod ` /` node ` up front for kubectl-logs scannability) was using a bare ` %s=%s ` printf — so any value with spaces broke key=value parsing.

This matters because Loki ` | logfmt ` , Grafana panels, and ad-hoc grep all read ` is ` , ` dead ` , ` worker=41757 ` as separate keys when the error string is unquoted, dropping the actual error label.

## Test plan
- [x] ` go test -run StampedHandler . `  — covers spaces, embedded ` = ` , empty value, and the alphanumeric-stays-unquoted case
- [x] Existing ` TestRedactingHandler ` still passes