### PR TITLE
fix(worker): rotate STS secret on a side conn, off the activation lock

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -87,12 +87,14 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	db := p.warmupDB
 	if db == nil {
 		if p.fallbackDB == nil {
-			var err error
-			p.fallbackDB, err = p.createDBConnection(p.sharedWarmupConfig(), p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
+			pair, err := p.createDBPair(p.sharedWarmupConfig(), p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
 			if err != nil {
 				p.mu.Unlock()
 				return fmt.Errorf("create activation-ready runtime: %w", err)
 			}
+			p.fallbackDB = pair.Main
+			p.activePair = pair
+			p.controlDB = pair.Control
 		}
 		db = p.fallbackDB
 		p.warmupDB = db
@@ -129,41 +131,80 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 }
 
 func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
+	// Phase 1 (locked): inspect current activation, decide whether to refresh,
+	// and capture everything we need to perform the refresh outside the lock.
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.reuseExistingActivationLocked(payload)
-}
-
-func (p *SessionPool) reuseExistingActivationLocked(payload ActivationPayload) bool {
 	if p.activation == nil {
+		p.mu.Unlock()
 		return false
 	}
 	current := p.activation.payload
 	if !sameTenantActivationRuntime(current, payload) {
+		p.mu.Unlock()
 		return false
 	}
 	if !reflect.DeepEqual(current, payload) && payload.OwnerEpoch <= current.OwnerEpoch {
+		p.mu.Unlock()
 		return false
 	}
 
-	// Refresh the DuckDB S3 secret when credentials may have changed.
-	// Skip when the entire DuckLake config is identical (pure control metadata
-	// change like epoch bump), since credentials can't have changed.
+	needsRefresh := false
 	if p.activation.db != nil && payload.DuckLake.ObjectStore != "" &&
 		!reflect.DeepEqual(current.DuckLake, payload.DuckLake) {
-		needsRefresh := s3CredentialsChanged(current.DuckLake, payload.DuckLake)
+		needsRefresh = s3CredentialsChanged(current.DuckLake, payload.DuckLake)
 		if !needsRefresh {
 			// For aws_sdk/credential_chain, the underlying IAM credentials
 			// may have expired even though the payload fields haven't changed.
 			provider := server.S3ProviderForConfig(payload.DuckLake)
 			needsRefresh = provider == "aws_sdk" || provider == "credential_chain"
 		}
-		if needsRefresh {
-			if err := server.RefreshS3Secret(p.activation.db, payload.DuckLake, p.duckLakeSem); err != nil {
-				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
-				return false
-			}
+	}
+
+	// Pick the connection used to swap the secret. controlDB is a side
+	// connection sharing the same DuckDB instance via *duckdb.Connector, with
+	// its own independent pool — so the CREATE OR REPLACE SECRET below never
+	// queues behind a long-running client query on the main DB. Fall back to
+	// the activation DB only when controlDB hasn't been wired (older/test
+	// paths that bypass createDBPair).
+	refreshDB := p.controlDB
+	if refreshDB == nil {
+		refreshDB = p.activation.db
+	}
+	refreshFn := p.refreshS3Secret
+	sem := p.duckLakeSem
+	p.mu.Unlock()
+
+	// Phase 2 (unlocked): perform the slow I/O. Holding p.mu across this is a
+	// bug — RefreshS3Secret runs a CREATE OR REPLACE SECRET which can block
+	// indefinitely if the active client query is monopolising a single-conn
+	// *sql.DB, and any concurrent health check needs p.mu.RLock to snapshot
+	// sessions for stall detection. Releasing the lock here keeps the gRPC
+	// health check responsive even when the secret rotation has to wait.
+	if needsRefresh {
+		if refreshFn == nil {
+			refreshFn = server.RefreshS3Secret
 		}
+		if err := refreshFn(refreshDB, payload.DuckLake, sem); err != nil {
+			slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
+			return false
+		}
+	}
+
+	// Phase 3 (locked): re-validate state and commit. The activation may have
+	// been concurrently reset, taken over by a higher epoch, or migrated away
+	// while we were running RefreshS3Secret without the lock — re-check before
+	// stamping the new payload over it.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.activation == nil {
+		return false
+	}
+	live := p.activation.payload
+	if !sameTenantActivationRuntime(live, payload) {
+		return false
+	}
+	if !reflect.DeepEqual(live, payload) && payload.OwnerEpoch <= live.OwnerEpoch {
+		return false
 	}
 
 	p.activation.payload = payload

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -26,13 +26,13 @@ func TestSessionPoolActivateTenantConfiguresTenantRuntime(t *testing.T) {
 	var captured server.Config
 	var opened *sql.DB
 	pool.sharedWarmMode = true
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
 		opened = db
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		captured = cfg
@@ -84,12 +84,12 @@ func TestSessionPoolActivateTenantRejectsSecondActivation(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -136,12 +136,12 @@ func TestSessionPoolActivateTenantRejectsStaleOwnerEpoch(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -181,12 +181,12 @@ func TestSessionPoolActivateTenantAllowsSameOrgTakeover(t *testing.T) {
 	close(pool.warmupDone)
 
 	var activateCalls int
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		activateCalls++
@@ -250,12 +250,12 @@ func TestSessionPoolActivateTenantRejectsSameEpochOwnerChange(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -383,12 +383,12 @@ func TestReuseExistingActivationDoesNotBlockHealthChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open main duckdb: %v", err)
 	}
-	defer mainDB.Close()
+	defer func() { _ = mainDB.Close() }()
 	controlDB, err := sql.Open("duckdb", "")
 	if err != nil {
 		t.Fatalf("open control duckdb: %v", err)
 	}
-	defer controlDB.Close()
+	defer func() { _ = controlDB.Close() }()
 
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -2,6 +2,7 @@ package duckdbservice
 
 import (
 	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,13 +26,13 @@ func TestSessionPoolActivateTenantConfiguresTenantRuntime(t *testing.T) {
 	var captured server.Config
 	var opened *sql.DB
 	pool.sharedWarmMode = true
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
 		opened = db
-		return db, nil
+		return server.PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		captured = cfg
@@ -83,8 +84,12 @@ func TestSessionPoolActivateTenantRejectsSecondActivation(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
-		return sql.Open("duckdb", "")
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return server.PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -131,8 +136,12 @@ func TestSessionPoolActivateTenantRejectsStaleOwnerEpoch(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
-		return sql.Open("duckdb", "")
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return server.PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -172,8 +181,12 @@ func TestSessionPoolActivateTenantAllowsSameOrgTakeover(t *testing.T) {
 	close(pool.warmupDone)
 
 	var activateCalls int
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
-		return sql.Open("duckdb", "")
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return server.PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		activateCalls++
@@ -237,8 +250,12 @@ func TestSessionPoolActivateTenantRejectsSameEpochOwnerChange(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
-		return sql.Open("duckdb", "")
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return server.PairFromMain(db), nil
 	}
 	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
 		return nil
@@ -290,13 +307,13 @@ func TestSessionPoolValidateControlMetadataAcceptsMismatchedCPInstanceID(t *test
 // that causes worker pod cascading deaths during a CP rolling update.
 //
 // Scenario:
-//   1. CP-old activates a worker with epoch=1
-//   2. CP-old is killed in a rolling update
-//   3. CP-new starts fresh — it discovers the worker pod via K8s informer
-//      but hasn't re-activated it yet, so its in-memory epoch is 0
-//   4. CP-new's health check loop sends a health check with epoch=0
-//   5. Worker rejects: "stale owner epoch 0 (current 1)"
-//   6. After 3 consecutive rejections, CP-new deletes the worker pod
+//  1. CP-old activates a worker with epoch=1
+//  2. CP-old is killed in a rolling update
+//  3. CP-new starts fresh — it discovers the worker pod via K8s informer
+//     but hasn't re-activated it yet, so its in-memory epoch is 0
+//  4. CP-new's health check loop sends a health check with epoch=0
+//  5. Worker rejects: "stale owner epoch 0 (current 1)"
+//  6. After 3 consecutive rejections, CP-new deletes the worker pod
 //
 // The health check should not kill a worker just because the CP restarted.
 // The worker is healthy and serving queries — the epoch mismatch only means
@@ -346,5 +363,123 @@ func TestSessionPoolValidateControlMetadataRejectsMismatchedWorkerID(t *testing.
 	if err == nil {
 		t.Fatal("expected mismatched worker_id to be rejected")
 		return
+	}
+}
+
+// TestReuseExistingActivationDoesNotBlockHealthChecks pins down the deadlock
+// that killed workers in mw-prod-us 2026-05-04: reuseExistingActivation used
+// to run RefreshS3Secret while still holding p.mu.Lock, so any concurrent
+// RLock acquirer (the gRPC health-check goroutine snapshotting sessions)
+// stalled until the secret SQL finished — and the secret SQL itself blocked
+// on the single client-query connection. After 3 health-check timeouts (~9s)
+// the CP force-deleted the worker.
+//
+// We simulate the slow refresh with a channel and assert that an RLock
+// acquirer in another goroutine returns within 100ms while the refresh is
+// in-flight. This fails on the pre-fix code path (RLock blocks until the
+// channel is closed) and passes on the lock-released path.
+func TestReuseExistingActivationDoesNotBlockHealthChecks(t *testing.T) {
+	mainDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open main duckdb: %v", err)
+	}
+	defer mainDB.Close()
+	controlDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open control duckdb: %v", err)
+	}
+	defer controlDB.Close()
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+		warmupDB:       mainDB,
+		controlDB:      controlDB,
+		activation: &activatedTenantRuntime{
+			payload: ActivationPayload{
+				WorkerControlMetadata: server.WorkerControlMetadata{OwnerEpoch: 1},
+				OrgID:                 "analytics",
+				DuckLake: server.DuckLakeConfig{
+					MetadataStore: "postgres:host=meta port=5432 user=u password=p dbname=d",
+					ObjectStore:   "s3://analytics/",
+					S3AccessKey:   "OLD_ACCESS_KEY",
+					S3SecretKey:   "OLD_SECRET_KEY",
+				},
+			},
+			db: mainDB,
+		},
+		ownerEpoch: 1,
+	}
+	close(pool.warmupDone)
+
+	released := make(chan struct{})
+	refreshStarted := make(chan struct{})
+	var refreshDB *sql.DB
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		refreshDB = db
+		close(refreshStarted)
+		<-released // simulate a CREATE OR REPLACE SECRET stuck behind a long query
+		return nil
+	}
+
+	newPayload := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{OwnerEpoch: 2},
+		OrgID:                 "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore: "postgres:host=meta port=5432 user=u password=p dbname=d",
+			ObjectStore:   "s3://analytics/",
+			S3AccessKey:   "NEW_ACCESS_KEY",
+			S3SecretKey:   "NEW_SECRET_KEY",
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if !pool.reuseExistingActivation(newPayload) {
+			t.Errorf("reuseExistingActivation returned false; expected true after refresh")
+		}
+	}()
+
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start within 1s")
+	}
+
+	rlockAcquired := make(chan struct{})
+	go func() {
+		pool.mu.RLock()
+		close(rlockAcquired)
+		pool.mu.RUnlock()
+	}()
+
+	select {
+	case <-rlockAcquired:
+		// Good — RLock returned while RefreshS3Secret is still running.
+	case <-time.After(100 * time.Millisecond):
+		close(released) // unblock the goroutine so wg.Wait doesn't hang
+		t.Fatal("RLock blocked while refresh was in flight: deadlock regression — reuseExistingActivation is holding p.mu.Lock across the slow secret rotation")
+	}
+
+	close(released)
+	wg.Wait()
+
+	// Fix #2 assertion: the slow refresh must run on controlDB (the side
+	// connection), not on the main client-query DB.
+	if refreshDB != controlDB {
+		t.Errorf("expected refresh to run on controlDB, ran on %p (controlDB=%p, mainDB=%p)", refreshDB, controlDB, mainDB)
+	}
+
+	// Sanity: the new payload must be committed.
+	if pool.activation == nil || pool.activation.payload.DuckLake.S3AccessKey != "NEW_ACCESS_KEY" {
+		t.Fatalf("expected new credentials committed to activation payload; got %#v", pool.activation)
+	}
+	if pool.ownerEpoch != 2 {
+		t.Fatalf("expected ownerEpoch=2 after refresh, got %d", pool.ownerEpoch)
 	}
 }

--- a/duckdbservice/duckdb_pair.go
+++ b/duckdbservice/duckdb_pair.go
@@ -1,17 +1,14 @@
-package server
+package duckdbservice
 
 import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	duckdb "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server"
 )
 
 // DuckDBPair holds two *sql.DBs that share the same underlying DuckDB instance:
@@ -27,6 +24,11 @@ import (
 // means catalogs, the SecretManager, and registered extensions are all visible
 // across both. The main session running a query benefits from a fresh secret
 // the moment Control swaps it — see RefreshS3Secret callers for the rationale.
+//
+// Lives in duckdbservice (not server) so the control-plane binary, which
+// imports server but not duckdbservice, doesn't transitively pull in the
+// libduckdb-linked duckdb-go-v2 driver. CI's "does-not-link-libduckdb" check
+// enforces this boundary.
 //
 // The owner must call Close on the pair when shutting down. Close on the
 // individual *sql.DBs goes through a non-closing wrapper, so the underlying
@@ -85,8 +87,8 @@ func (*nonClosingConnector) Close() error { return nil }
 // *sql.DB sharing it. The Main DB still goes through the same configuration
 // path as openBaseDB (threads, memory_limit, extensions, profiling, cache
 // settings); the Control DB is intentionally minimal.
-func OpenDuckDBPair(cfg Config, username string) (*DuckDBPair, error) {
-	dsn, err := duckDBDSN(cfg, username)
+func OpenDuckDBPair(cfg server.Config, username string) (*DuckDBPair, error) {
+	dsn, err := server.DuckDBDSN(cfg, username)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func OpenDuckDBPair(cfg Config, username string) (*DuckDBPair, error) {
 		return nil, fmt.Errorf("failed to ping duckdb (control): %w", err)
 	}
 
-	if err := configureMainDB(mainDB, cfg, username); err != nil {
+	if err := server.ConfigureMainDB(mainDB, cfg, username); err != nil {
 		_ = mainDB.Close()
 		_ = controlDB.Close()
 		_ = connector.Close()
@@ -139,12 +141,12 @@ func OpenDuckDBPair(cfg Config, username string) (*DuckDBPair, error) {
 // state — it sees the same Database (and therefore the same SecretManager and
 // attached catalogs) thanks to the shared connector, so no per-conn init is
 // needed for credential rotation.
-func CreateWorkerDBPair(cfg Config, duckLakeSem chan struct{}, username string, serverStartTime time.Time, serverVersion string) (*DuckDBPair, error) {
+func CreateWorkerDBPair(cfg server.Config, duckLakeSem chan struct{}, username string, serverStartTime time.Time, serverVersion string) (*DuckDBPair, error) {
 	pair, err := OpenDuckDBPair(cfg, username)
 	if err != nil {
 		return nil, err
 	}
-	if err := ConfigureDBConnection(pair.Main, cfg, duckLakeSem, username, serverStartTime, serverVersion); err != nil {
+	if err := server.ConfigureDBConnection(pair.Main, cfg, duckLakeSem, username, serverStartTime, serverVersion); err != nil {
 		_ = pair.Close()
 		return nil, err
 	}
@@ -157,21 +159,4 @@ func CreateWorkerDBPair(cfg Config, duckLakeSem chan struct{}, username string, 
 // CreateWorkerDBPair, which returns a real pair.
 func PairFromMain(db *sql.DB) *DuckDBPair {
 	return &DuckDBPair{Main: db, Control: db}
-}
-
-// duckDBDSN returns the DSN openBaseDB would build for cfg/username. Kept
-// separate so OpenDuckDBPair and openBaseDB stay in lock-step.
-func duckDBDSN(cfg Config, username string) (string, error) {
-	dsn := ":memory:?allow_unsigned_extensions=true"
-	if cfg.FilePersistence && cfg.DataDir != "" && username != "" {
-		if strings.ContainsAny(username, "/\\") || strings.Contains(username, "..") {
-			return "", fmt.Errorf("invalid username for file persistence: %q (contains path separator or ..)", username)
-		}
-		if err := os.MkdirAll(cfg.DataDir, 0750); err != nil {
-			return "", fmt.Errorf("failed to create data directory %s: %w", cfg.DataDir, err)
-		}
-		dsn = filepath.Join(cfg.DataDir, username+".duckdb") + "?allow_unsigned_extensions=true"
-		slog.Info("Opening file-backed DuckDB.", "path", dsn)
-	}
-	return dsn, nil
 }

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -110,12 +110,12 @@ func TestHealthCheckReturnsImmediatelyAfterWarmup(t *testing.T) {
 
 func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
-		sessions:       make(map[string]*Session),
-		stopRefresh:    make(map[string]func()),
-		warmupDone:     make(chan struct{}),
-		startTime:      time.Now(),
-		sharedWarmMode: true,
-		ownerEpoch:     5,
+		sessions:          make(map[string]*Session),
+		stopRefresh:       make(map[string]func()),
+		warmupDone:        make(chan struct{}),
+		startTime:         time.Now(),
+		sharedWarmMode:    true,
+		ownerEpoch:        5,
 		ownerCPInstanceID: "cp-live:boot-a",
 		workerID:          17,
 	}
@@ -171,8 +171,8 @@ func TestActivateTenantRejectsDifferentTenantAfterActivation(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBConnection = func(server.Config, chan struct{}, string, time.Time, string) (*sql.DB, error) {
-		return &sql.DB{}, nil
+	pool.createDBPair = func(server.Config, chan struct{}, string, time.Time, string) (*server.DuckDBPair, error) {
+		return server.PairFromMain(&sql.DB{}), nil
 	}
 	pool.activateDBConnection = func(*sql.DB, server.Config, chan struct{}, string) error {
 		return nil
@@ -233,8 +233,12 @@ func TestCreateSessionAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 		},
 	}
 	close(pool.warmupDone)
-	pool.createDBConnection = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*sql.DB, error) {
-		return sql.Open("duckdb", "")
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return server.PairFromMain(db), nil
 	}
 
 	handler := &FlightSQLHandler{pool: pool}
@@ -261,12 +265,12 @@ func TestCreateSessionAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 
 func TestSessionFromContextAcceptsMismatchedEpoch(t *testing.T) {
 	pool := &SessionPool{
-		sessions:       make(map[string]*Session),
-		stopRefresh:    make(map[string]func()),
-		warmupDone:     make(chan struct{}),
-		startTime:      time.Now(),
-		sharedWarmMode: true,
-		ownerEpoch:     5,
+		sessions:          make(map[string]*Session),
+		stopRefresh:       make(map[string]func()),
+		warmupDone:        make(chan struct{}),
+		startTime:         time.Now(),
+		sharedWarmMode:    true,
+		ownerEpoch:        5,
 		ownerCPInstanceID: "cp-live:boot-a",
 		workerID:          17,
 	}
@@ -291,14 +295,14 @@ func TestSessionFromContextAcceptsMismatchedEpoch(t *testing.T) {
 
 func TestSessionFromContextRejectsMismatchedControlIdentity(t *testing.T) {
 	pool := &SessionPool{
-		sessions:           make(map[string]*Session),
-		stopRefresh:        make(map[string]func()),
-		warmupDone:         make(chan struct{}),
-		startTime:          time.Now(),
-		sharedWarmMode:     true,
-		ownerEpoch:         5,
-		ownerCPInstanceID:  "cp-live:boot-a",
-		workerID:           17,
+		sessions:          make(map[string]*Session),
+		stopRefresh:       make(map[string]func()),
+		warmupDone:        make(chan struct{}),
+		startTime:         time.Now(),
+		sharedWarmMode:    true,
+		ownerEpoch:        5,
+		ownerCPInstanceID: "cp-live:boot-a",
+		workerID:          17,
 	}
 	close(pool.warmupDone)
 	pool.sessions["session-1"] = &Session{ID: "session-1"}

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -171,8 +171,8 @@ func TestActivateTenantRejectsDifferentTenantAfterActivation(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	pool.createDBPair = func(server.Config, chan struct{}, string, time.Time, string) (*server.DuckDBPair, error) {
-		return server.PairFromMain(&sql.DB{}), nil
+	pool.createDBPair = func(server.Config, chan struct{}, string, time.Time, string) (*DuckDBPair, error) {
+		return PairFromMain(&sql.DB{}), nil
 	}
 	pool.activateDBConnection = func(*sql.DB, server.Config, chan struct{}, string) error {
 		return nil
@@ -233,12 +233,12 @@ func TestCreateSessionAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 		},
 	}
 	close(pool.warmupDone)
-	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*server.DuckDBPair, error) {
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
 		db, err := sql.Open("duckdb", "")
 		if err != nil {
 			return nil, err
 		}
-		return server.PairFromMain(db), nil
+		return PairFromMain(db), nil
 	}
 
 	handler := &FlightSQLHandler{pool: pool}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -53,6 +53,16 @@ type SessionPool struct {
 	dbInitOnce  sync.Once     // Serializes fallback CreateDBConnection when warmup fails
 	fallbackDB  *sql.DB       // Lazily created if warmup fails
 	fallbackErr error         // Cached error from fallback creation
+	// activePair is the DuckDBPair backing whichever of warmupDB/fallbackDB is
+	// currently in use. It owns the underlying *duckdb.Connector and a
+	// secondary *sql.DB (Control) sharing the same DuckDB instance —
+	// see duckdbservice's credential-refresh path for why we need a side
+	// connection that doesn't queue behind a long-running client query.
+	activePair *server.DuckDBPair
+	// controlDB is activePair.Control, surfaced for direct use by control-side
+	// ops (CREATE OR REPLACE SECRET on STS rotation). Always nil before
+	// activation; nil-check before use and fall back to the main DB.
+	controlDB *sql.DB
 
 	sharedWarmMode       bool
 	activation           *activatedTenantRuntime
@@ -60,8 +70,13 @@ type SessionPool struct {
 	ownerCPInstanceID    string
 	workerID             int
 	activateTenantFunc   func(ActivationPayload) error
-	createDBConnection   func(server.Config, chan struct{}, string, time.Time, string) (*sql.DB, error)
+	createDBPair         func(server.Config, chan struct{}, string, time.Time, string) (*server.DuckDBPair, error)
 	activateDBConnection func(*sql.DB, server.Config, chan struct{}, string) error
+	// refreshS3Secret is the indirection used for credential rotation on the
+	// active tenant. Defaults to server.RefreshS3Secret in production; tests
+	// inject a stub to verify the credential-refresh path is non-blocking
+	// (see TestReuseExistingActivationDoesNotBlockHealthChecks).
+	refreshS3Secret func(*sql.DB, server.DuckLakeConfig, chan struct{}) error
 }
 
 type trackedTx struct {
@@ -116,8 +131,9 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		stopCh:               make(chan struct{}),
 		warmupDone:           make(chan struct{}),
 		sharedWarmMode:       cfg.RequireActivation || sharedWarmWorkerEnabled(),
-		createDBConnection:   server.CreateDBConnection,
+		createDBPair:         server.CreateWorkerDBPair,
 		activateDBConnection: server.ActivateDBConnection,
+		refreshS3Secret:      server.RefreshS3Secret,
 	}
 	pool.activateTenantFunc = pool.activateTenant
 	go pool.reapLoop()
@@ -147,13 +163,15 @@ func (p *SessionPool) Warmup() error {
 	// Included in the pre-warm duration so slow proxy startup is visible.
 	waitForCacheProxy()
 	// Use a system-level username for warmup
-	db, err := p.createDBConnection(p.sharedWarmupConfig(), p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
+	pair, err := p.createDBPair(p.sharedWarmupConfig(), p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
 	if err != nil {
 		return fmt.Errorf("warmup failed after %v: %w", time.Since(start), err)
 	}
 
 	p.mu.Lock()
-	p.warmupDB = db
+	p.warmupDB = pair.Main
+	p.activePair = pair
+	p.controlDB = pair.Control
 	p.mu.Unlock()
 
 	slog.Info("Worker pre-warmed successfully.", "duration", time.Since(start))
@@ -383,7 +401,14 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		// concurrent LOAD of the same C++ extension corrupts the heap.
 		fallbackStart := time.Now()
 		p.dbInitOnce.Do(func() {
-			p.fallbackDB, p.fallbackErr = p.createDBConnection(cfg, p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
+			pair, err := p.createDBPair(cfg, p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
+			if err != nil {
+				p.fallbackErr = err
+				return
+			}
+			p.fallbackDB = pair.Main
+			p.activePair = pair
+			p.controlDB = pair.Control
 		})
 		if p.fallbackErr != nil {
 			p.mu.Lock()
@@ -638,15 +663,33 @@ func (p *SessionPool) CloseAll() {
 
 	if p.warmupDB != nil {
 		cleanupWorkerCatalogs(p.warmupDB)
-		_ = p.warmupDB.Close()
 	}
 	if p.fallbackDB != nil && p.fallbackDB != p.warmupDB {
 		cleanupWorkerCatalogs(p.fallbackDB)
-		_ = p.fallbackDB.Close()
 	}
 	if p.activation != nil && p.activation.db != nil && p.activation.db != p.warmupDB && p.activation.db != p.fallbackDB {
 		cleanupWorkerCatalogs(p.activation.db)
 		_ = p.activation.db.Close()
+	}
+	// activePair owns the underlying *duckdb.Connector and the Control side
+	// connection; closing it tears the DuckDB instance down once. Both
+	// warmupDB and fallbackDB are p.activePair.Main for in-pool DBs, so this
+	// supersedes the old per-DB close calls.
+	if p.activePair != nil {
+		_ = p.activePair.Close()
+		p.activePair = nil
+		p.warmupDB = nil
+		p.fallbackDB = nil
+		p.controlDB = nil
+	} else {
+		// Fallback path for tests that bypass the pair factory and assigned
+		// warmupDB/fallbackDB directly without an activePair.
+		if p.warmupDB != nil {
+			_ = p.warmupDB.Close()
+		}
+		if p.fallbackDB != nil && p.fallbackDB != p.warmupDB {
+			_ = p.fallbackDB.Close()
+		}
 	}
 }
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -58,7 +58,7 @@ type SessionPool struct {
 	// secondary *sql.DB (Control) sharing the same DuckDB instance —
 	// see duckdbservice's credential-refresh path for why we need a side
 	// connection that doesn't queue behind a long-running client query.
-	activePair *server.DuckDBPair
+	activePair *DuckDBPair
 	// controlDB is activePair.Control, surfaced for direct use by control-side
 	// ops (CREATE OR REPLACE SECRET on STS rotation). Always nil before
 	// activation; nil-check before use and fall back to the main DB.
@@ -70,7 +70,7 @@ type SessionPool struct {
 	ownerCPInstanceID    string
 	workerID             int
 	activateTenantFunc   func(ActivationPayload) error
-	createDBPair         func(server.Config, chan struct{}, string, time.Time, string) (*server.DuckDBPair, error)
+	createDBPair         func(server.Config, chan struct{}, string, time.Time, string) (*DuckDBPair, error)
 	activateDBConnection func(*sql.DB, server.Config, chan struct{}, string) error
 	// refreshS3Secret is the indirection used for credential rotation on the
 	// active tenant. Defaults to server.RefreshS3Secret in production; tests
@@ -131,7 +131,7 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		stopCh:               make(chan struct{}),
 		warmupDone:           make(chan struct{}),
 		sharedWarmMode:       cfg.RequireActivation || sharedWarmWorkerEnabled(),
-		createDBPair:         server.CreateWorkerDBPair,
+		createDBPair:         CreateWorkerDBPair,
 		activateDBConnection: server.ActivateDBConnection,
 		refreshS3Secret:      server.RefreshS3Secret,
 	}

--- a/server/duckdb_pair.go
+++ b/server/duckdb_pair.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	duckdb "github.com/duckdb/duckdb-go/v2"
+)
+
+// DuckDBPair holds two *sql.DBs that share the same underlying DuckDB instance:
+//
+//   - Main is the client-query DB (MaxOpenConns=1, single-session isolation for
+//     the user's pgwire session — this is the existing behavior).
+//   - Control is reserved for the control plane's non-blocking ops (CREATE OR
+//     REPLACE SECRET on credential refresh, ATTACH/DETACH) and is also
+//     MaxOpenConns=1 so a control DDL can't fight itself, but it has its own
+//     pool so it never queues behind a long-running client query.
+//
+// Both *sql.DBs share one *duckdb.Connector / one DuckDB Database handle, which
+// means catalogs, the SecretManager, and registered extensions are all visible
+// across both. The main session running a query benefits from a fresh secret
+// the moment Control swaps it — see RefreshS3Secret callers for the rationale.
+//
+// The owner must call Close on the pair when shutting down. Close on the
+// individual *sql.DBs goes through a non-closing wrapper, so the underlying
+// DuckDB instance only goes away when DuckDBPair.Close fires.
+type DuckDBPair struct {
+	Main      *sql.DB
+	Control   *sql.DB
+	connector *duckdb.Connector
+}
+
+// Close closes both *sql.DBs and the underlying DuckDB instance. Safe to call
+// multiple times.
+func (p *DuckDBPair) Close() error {
+	if p == nil {
+		return nil
+	}
+	var firstErr error
+	if p.Main != nil {
+		if err := p.Main.Close(); err != nil {
+			firstErr = err
+		}
+		p.Main = nil
+	}
+	if p.Control != nil {
+		if err := p.Control.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		p.Control = nil
+	}
+	if p.connector != nil {
+		if err := p.connector.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		p.connector = nil
+	}
+	return firstErr
+}
+
+// nonClosingConnector turns Close into a noop so the wrapped Connector can be
+// shared across multiple sql.OpenDB calls. Each *sql.DB's Close goes through
+// this wrapper; the real connector is closed by the owner via DuckDBPair.Close.
+type nonClosingConnector struct {
+	inner driver.Connector
+}
+
+func (n *nonClosingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	return n.inner.Connect(ctx)
+}
+
+func (n *nonClosingConnector) Driver() driver.Driver { return n.inner.Driver() }
+
+func (*nonClosingConnector) Close() error { return nil }
+
+// OpenDuckDBPair builds the DSN that openBaseDB would have used, opens one
+// DuckDB Database via *duckdb.Connector, and returns a Main + Control
+// *sql.DB sharing it. The Main DB still goes through the same configuration
+// path as openBaseDB (threads, memory_limit, extensions, profiling, cache
+// settings); the Control DB is intentionally minimal.
+func OpenDuckDBPair(cfg Config, username string) (*DuckDBPair, error) {
+	dsn, err := duckDBDSN(cfg, username)
+	if err != nil {
+		return nil, err
+	}
+
+	connector, err := duckdb.NewConnector(dsn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open duckdb connector: %w", err)
+	}
+
+	wrapped := &nonClosingConnector{inner: connector}
+	mainDB := sql.OpenDB(wrapped)
+	controlDB := sql.OpenDB(wrapped)
+
+	mainDB.SetMaxOpenConns(1)
+	mainDB.SetMaxIdleConns(1)
+	controlDB.SetMaxOpenConns(1)
+	controlDB.SetMaxIdleConns(1)
+
+	if err := mainDB.Ping(); err != nil {
+		_ = mainDB.Close()
+		_ = controlDB.Close()
+		_ = connector.Close()
+		return nil, fmt.Errorf("failed to ping duckdb (main): %w", err)
+	}
+	if err := controlDB.Ping(); err != nil {
+		_ = mainDB.Close()
+		_ = controlDB.Close()
+		_ = connector.Close()
+		return nil, fmt.Errorf("failed to ping duckdb (control): %w", err)
+	}
+
+	if err := configureMainDB(mainDB, cfg, username); err != nil {
+		_ = mainDB.Close()
+		_ = controlDB.Close()
+		_ = connector.Close()
+		return nil, err
+	}
+
+	return &DuckDBPair{
+		Main:      mainDB,
+		Control:   controlDB,
+		connector: connector,
+	}, nil
+}
+
+// CreateWorkerDBPair is the worker-process factory: it opens a shared-connector
+// DuckDB pair and runs ConfigureDBConnection on Main (pg_catalog,
+// information_schema, DuckLake attach) so it matches what the existing
+// CreateDBConnection produces. Control is left in its minimal post-Ping
+// state — it sees the same Database (and therefore the same SecretManager and
+// attached catalogs) thanks to the shared connector, so no per-conn init is
+// needed for credential rotation.
+func CreateWorkerDBPair(cfg Config, duckLakeSem chan struct{}, username string, serverStartTime time.Time, serverVersion string) (*DuckDBPair, error) {
+	pair, err := OpenDuckDBPair(cfg, username)
+	if err != nil {
+		return nil, err
+	}
+	if err := ConfigureDBConnection(pair.Main, cfg, duckLakeSem, username, serverStartTime, serverVersion); err != nil {
+		_ = pair.Close()
+		return nil, err
+	}
+	return pair, nil
+}
+
+// PairFromMain builds a *DuckDBPair that points Main and Control at the same
+// *sql.DB and owns no connector. Intended for test fixtures that don't
+// exercise the connector-sharing properties — production code uses
+// CreateWorkerDBPair, which returns a real pair.
+func PairFromMain(db *sql.DB) *DuckDBPair {
+	return &DuckDBPair{Main: db, Control: db}
+}
+
+// duckDBDSN returns the DSN openBaseDB would build for cfg/username. Kept
+// separate so OpenDuckDBPair and openBaseDB stay in lock-step.
+func duckDBDSN(cfg Config, username string) (string, error) {
+	dsn := ":memory:?allow_unsigned_extensions=true"
+	if cfg.FilePersistence && cfg.DataDir != "" && username != "" {
+		if strings.ContainsAny(username, "/\\") || strings.Contains(username, "..") {
+			return "", fmt.Errorf("invalid username for file persistence: %q (contains path separator or ..)", username)
+		}
+		if err := os.MkdirAll(cfg.DataDir, 0750); err != nil {
+			return "", fmt.Errorf("failed to create data directory %s: %w", cfg.DataDir, err)
+		}
+		dsn = filepath.Join(cfg.DataDir, username+".duckdb") + "?allow_unsigned_extensions=true"
+		slog.Info("Opening file-backed DuckDB.", "path", dsn)
+	}
+	return dsn, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -781,7 +781,7 @@ func (s *Server) releaseFileDB(username string) {
 // so performance is equivalent to in-memory while data persists across restarts.
 // When DataDir is empty, falls back to a pure in-memory database.
 func openBaseDB(cfg Config, username string) (*sql.DB, error) {
-	dsn, err := duckDBDSN(cfg, username)
+	dsn, err := DuckDBDSN(cfg, username)
 	if err != nil {
 		return nil, err
 	}
@@ -802,18 +802,37 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to ping duckdb: %w", err)
 	}
 
-	if err := configureMainDB(db, cfg, username); err != nil {
+	if err := ConfigureMainDB(db, cfg, username); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return db, nil
 }
 
-// configureMainDB applies the per-instance DuckDB settings (threads, memory,
+// DuckDBDSN returns the DSN openBaseDB / the duckdbservice pair builder use
+// for cfg/username. Exported so duckdbservice (which holds the duckdb-go-v2
+// import) can build a *duckdb.Connector against the same DSN that openBaseDB
+// would have passed to sql.Open.
+func DuckDBDSN(cfg Config, username string) (string, error) {
+	dsn := ":memory:?allow_unsigned_extensions=true"
+	if cfg.FilePersistence && cfg.DataDir != "" && username != "" {
+		if strings.ContainsAny(username, "/\\") || strings.Contains(username, "..") {
+			return "", fmt.Errorf("invalid username for file persistence: %q (contains path separator or ..)", username)
+		}
+		if err := os.MkdirAll(cfg.DataDir, 0750); err != nil {
+			return "", fmt.Errorf("failed to create data directory %s: %w", cfg.DataDir, err)
+		}
+		dsn = filepath.Join(cfg.DataDir, username+".duckdb") + "?allow_unsigned_extensions=true"
+		slog.Info("Opening file-backed DuckDB.", "path", dsn)
+	}
+	return dsn, nil
+}
+
+// ConfigureMainDB applies the per-instance DuckDB settings (threads, memory,
 // temp dir, extensions, profiling) that the client-query DB needs. Shared
 // between openBaseDB (single-DB path) and OpenDuckDBPair (shared-connector
 // path) so the main DB is configured identically either way.
-func configureMainDB(db *sql.DB, cfg Config, username string) error {
+func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 	// Set DuckDB threads
 	threads := cfg.Threads
 	if threads == 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -781,18 +781,9 @@ func (s *Server) releaseFileDB(username string) {
 // so performance is equivalent to in-memory while data persists across restarts.
 // When DataDir is empty, falls back to a pure in-memory database.
 func openBaseDB(cfg Config, username string) (*sql.DB, error) {
-	// allow_unsigned_extensions is a startup-only DuckDB config — it must be
-	// in the DSN, not via SET.
-	dsn := ":memory:?allow_unsigned_extensions=true"
-	if cfg.FilePersistence && cfg.DataDir != "" && username != "" {
-		if strings.ContainsAny(username, "/\\") || strings.Contains(username, "..") {
-			return nil, fmt.Errorf("invalid username for file persistence: %q (contains path separator or ..)", username)
-		}
-		if err := os.MkdirAll(cfg.DataDir, 0750); err != nil {
-			return nil, fmt.Errorf("failed to create data directory %s: %w", cfg.DataDir, err)
-		}
-		dsn = filepath.Join(cfg.DataDir, username+".duckdb") + "?allow_unsigned_extensions=true"
-		slog.Info("Opening file-backed DuckDB.", "path", dsn)
+	dsn, err := duckDBDSN(cfg, username)
+	if err != nil {
+		return nil, err
 	}
 	db, err := sql.Open("duckdb", dsn)
 	if err != nil {
@@ -811,6 +802,18 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to ping duckdb: %w", err)
 	}
 
+	if err := configureMainDB(db, cfg, username); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// configureMainDB applies the per-instance DuckDB settings (threads, memory,
+// temp dir, extensions, profiling) that the client-query DB needs. Shared
+// between openBaseDB (single-DB path) and OpenDuckDBPair (shared-connector
+// path) so the main DB is configured identically either way.
+func configureMainDB(db *sql.DB, cfg Config, username string) error {
 	// Set DuckDB threads
 	threads := cfg.Threads
 	if threads == 0 {
@@ -844,8 +847,7 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 	}
 
 	if err := setExtensionDirectory(db, cfg.DataDir); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to configure extension_directory: %w", err)
+		return fmt.Errorf("failed to configure extension_directory: %w", err)
 	}
 
 	// Load configured extensions
@@ -881,8 +883,7 @@ func openBaseDB(cfg Config, username string) (*sql.DB, error) {
 			slog.Debug("Set cache_httpfs cache directory.", "cache_directory", cacheDir)
 		}
 	}
-
-	return db, nil
+	return nil
 }
 
 func seedBundledExtensions(srcRoot, dstRoot string) error {


### PR DESCRIPTION
## Summary
- Rotate the DuckDB S3 secret on a **side connection** that shares the same DuckDB instance as the main client-query DB but has its own Go connection pool — so ` CREATE OR REPLACE SECRET ` never queues behind a long-running client query.
- Run the rotation **outside** ` p.mu.Lock ` in ` reuseExistingActivation ` , so a slow refresh can't starve concurrent ` p.mu.RLock ` acquirers (the gRPC health-check goroutine snapshotting sessions for stall detection).

## Why
mw-prod-us 2026-05-04: ~10 worker pods/hour killed with ` K8s worker unresponsive, deleting pod ` , every kill ~10 s after a ` Refreshing S3 credentials... ` log. Workers were idle on CPU/memory — pure deadlock.

Root cause:

| Step | What | Where |
|------|------|-------|
| 1 | Credential refresh sends ` ActivateTenant ` | ` controlplane/multitenant.go ` (now per-CP after #474) |
| 2 | Worker enters ` reuseExistingActivation ` , takes ` p.mu.Lock ` | ` duckdbservice/activation.go ` |
| 3 | Calls ` RefreshS3Secret ` → ` db.Exec(\"CREATE OR REPLACE SECRET ...\") ` on the activation DB | ` server/server.go ` |
| 4 | Activation DB has ` MaxOpenConns=1 ` ; an active client query holds the conn → ` db.Exec ` queues indefinitely | — |
| 5 | gRPC health-check needs ` p.mu.RLock ` → starved behind ` p.mu.Lock ` | ` duckdbservice/flight_handler.go:212 ` |
| 6 | 3 × 3 s health-check timeouts = 9 s of unresponsive → CP force-deletes the pod | ` controlplane/worker_mgr.go ` |

## Fix

**Side-connection for control DDL**

` server/duckdb_pair.go ` introduces ` server.OpenDuckDBPair ` :
- One ` *duckdb.Connector ` (one DuckDB Database)
- Two ` *sql.DB ` s built via ` sql.OpenDB ` , each ` MaxOpenConns(1) `
- Wrapped in ` nonClosingConnector ` so ` *sql.DB.Close ` doesn't kill the underlying instance

` SessionPool ` now stores a ` *DuckDBPair ` ; ` controlDB ` is exposed for credential rotation. Both DBs see the same SecretManager and attached catalogs. The running query picks up the new STS token on its **next** S3 request — strictly better than today's \"no rotation possible while a query holds the conn\" behavior.

**Lock-released refresh**

` reuseExistingActivation ` is now three phases:
1. **Locked**: inspect activation, decide if refresh is needed, capture refresh fn / DB / sem.
2. **Unlocked**: run ` RefreshS3Secret ` on ` controlDB ` .
3. **Locked**: re-validate (activation may have changed) and commit the new payload.

Health-check ` RLock ` acquisition no longer waits for the secret to commit.

## Test plan
- [x] ` TestReuseExistingActivationDoesNotBlockHealthChecks ` — injects a blocking ` refreshS3Secret ` stub, asserts a concurrent ` p.mu.RLock ` acquirer returns within 100 ms during the slow refresh, and asserts the rotation runs on ` controlDB ` (not Main).
- [x] Confirmed the test **FAILS** on the pre-fix code path (locally simulated by reverting the unlock — RLock blocked, test fired its deadlock-regression message).
- [x] All existing ` ./duckdbservice/ ` , ` ./server/ ` , ` ./controlplane/ ` tests pass with ` -tags kubernetes ` .
- [ ] Deploy to mw-dev, watch ` Refreshing S3 credentials... ` complete cleanly while a long query is in flight.
- [ ] Deploy to mw-prod-us, confirm ` K8s worker unresponsive ` rate drops to zero on managed-warehouse workers.