### PR TITLE
fix(server): log infra-driven query cancellations at Error, not Info

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -336,9 +336,34 @@ func (c *clientConn) startDisconnectMonitor(ctx context.Context) (stop func()) {
 	}
 }
 
-// isQueryCancelled checks if an error is due to query cancellation
+// isQueryCancelled checks whether an error string indicates that *some*
+// context cancellation was involved. It does NOT distinguish caller-driven
+// cancellation (Ctrl-C, client disconnect, deadline) from infra-driven
+// cancellation (worker died, CP closed the gRPC client) — both surface here
+// as a wrapped "context canceled" string. Use it for SQLSTATE classification
+// where 57014 is correct either way; do not use it to gate error logging,
+// since infra cancels are real failures we want surfaced. Use
+// (*clientConn).isCallerCancellation for that.
 func isQueryCancelled(err error) bool {
 	return err == context.Canceled || (err != nil && strings.Contains(err.Error(), "context canceled"))
+}
+
+// isCallerCancellation reports whether err is a cancellation that the caller
+// asked for — either through pgwire CancelRequest, an explicit ctx cancel, or
+// a deadline. Distinct from a gRPC Canceled status that bubbles up purely
+// because the CP closed the worker connection (worker death, takeover): in
+// that case c.ctx is still healthy, c.ctx.Err() is nil, and the surface error
+// must be logged as an infra failure rather than suppressed as "user
+// cancelled". This matters for alerting — "Query execution errored." should
+// fire on worker kills, not get silently downgraded to "Query finished.".
+func (c *clientConn) isCallerCancellation(err error) bool {
+	if !isQueryCancelled(err) {
+		return false
+	}
+	if c == nil || c.ctx == nil {
+		return false
+	}
+	return c.ctx.Err() != nil
 }
 
 // isDuckLakeTransactionConflict returns true if the error is a DuckLake
@@ -372,6 +397,10 @@ func isDuckLakeMetadataConnectionLost(err error) bool {
 // errors are classified by DuckDB's exception-type prefix; the prefix is the
 // only signal the Go driver exposes today, so we parse the message string.
 func classifyErrorCode(err error) string {
+	// Wire-side SQLSTATE: 57014 is correct for any cancellation regardless of
+	// whether the caller drove it. Use isQueryCancelled here, not the
+	// clientConn-aware variant — classifyErrorCode is called from contexts
+	// that don't have a *clientConn (e.g., direct test fixtures).
 	if isQueryCancelled(err) {
 		return "57014"
 	}
@@ -521,16 +550,16 @@ var userErrorSQLSTATEClasses = map[string]struct{}{
 // execution errored."). The discriminator is the SQLSTATE class —
 // already computed via classifyErrorCode for the pgwire response.
 //
-// 57014 (query_canceled) is technically class 57 (operator
-// intervention, otherwise treated as infra) but in our usage it means
-// the client pressed Ctrl-C, which is a user-initiated event — short-
-// circuit it back into the user bucket.
+// Cancellations (SQLSTATE 57014) are NOT short-circuited as user errors
+// here. The call sites (logQueryError, the clientConn error paths) gate
+// caller-driven cancellations upstream via clientConn.isCallerCancellation,
+// so by the time isUserQueryError sees a cancel-shaped err the cancellation
+// was infra-driven (gRPC client closed because the worker died, the worker
+// was retired, etc.) and class 57 = operator intervention is the right
+// bucket — that's a real failure we want surfaced at Error level.
 func isUserQueryError(err error) bool {
 	if err == nil {
 		return false
-	}
-	if isQueryCancelled(err) {
-		return true
 	}
 	code := classifyErrorCode(err)
 	if len(code) < 2 {
@@ -1433,7 +1462,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 			if err != nil {
 				errCode := classifyErrorCode(err)
 				errMsg := err.Error()
-				if isQueryCancelled(err) {
+				if c.isCallerCancellation(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
 					c.logQueryError(query, err)
@@ -1509,7 +1538,7 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 		if err != nil {
 			errCode := classifyErrorCode(err)
 			errMsg := err.Error()
-			if isQueryCancelled(err) {
+			if c.isCallerCancellation(err) {
 				errMsg = "canceling statement due to user request"
 			} else {
 				c.logQueryError(query, err)
@@ -1624,7 +1653,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	if err != nil {
 		errCode := classifyErrorCode(err)
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
 			c.logQueryError(query, err)
@@ -1699,7 +1728,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	if err := rows.Err(); err != nil {
 		errCode := "42000"
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errCode = "57014"
 			errMsg = "canceling statement due to user request"
 			c.sendError("ERROR", errCode, errMsg)
@@ -1803,7 +1832,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			}
 			if cursor.rows == nil {
 				if err := c.openCursor(cursor); err != nil {
-					if isQueryCancelled(err) {
+					if c.isCallerCancellation(err) {
 						c.sendError("ERROR", "57014", "canceling statement due to user request")
 					} else {
 						c.sendError("ERROR", "42000", err.Error())
@@ -1852,7 +1881,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 				rowCount++
 			}
 			if err := cursor.rows.Err(); err != nil {
-				if isQueryCancelled(err) {
+				if c.isCallerCancellation(err) {
 					c.sendError("ERROR", "57014", "canceling statement due to user request")
 				} else {
 					c.sendError("ERROR", "42000", err.Error())
@@ -2001,7 +2030,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			if err != nil {
 				errCode := classifyErrorCode(err)
 				errMsg := err.Error()
-				if isQueryCancelled(err) {
+				if c.isCallerCancellation(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
 					c.logQueryError(executedQuery, err)
@@ -2051,7 +2080,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 	if err != nil {
 		errCode := classifyErrorCode(err)
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
 			c.logQueryError(executedQuery, err)
@@ -2360,7 +2389,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 	}
 
 	if err := rows.Err(); err != nil {
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
 			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
@@ -2435,7 +2464,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 	}
 
 	if err := rows.Err(); err != nil {
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
 			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
@@ -5290,7 +5319,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			if err != nil {
 				errCode := classifyErrorCode(err)
 				errMsg := err.Error()
-				if isQueryCancelled(err) {
+				if c.isCallerCancellation(err) {
 					errMsg = "canceling statement due to user request"
 				} else {
 					c.logQueryError(convertedQuery, err)
@@ -5336,7 +5365,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	if err != nil {
 		errCode := classifyErrorCode(err)
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errMsg = "canceling statement due to user request"
 		} else {
 			c.logQueryError(convertedQuery, err)
@@ -5405,7 +5434,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	if err := rows.Err(); err != nil {
 		errCode := "42000"
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errCode = "57014"
 			errMsg = "canceling statement due to user request"
 			c.sendError("ERROR", errCode, errMsg)
@@ -5951,7 +5980,7 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 		if err := c.openCursor(cursor); err != nil {
 			errCode := "42000"
 			errMsg := err.Error()
-			if isQueryCancelled(err) {
+			if c.isCallerCancellation(err) {
 				errCode = "57014"
 				errMsg = "canceling statement due to user request"
 			}
@@ -6026,7 +6055,7 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 	if err := cursor.rows.Err(); err != nil {
 		errCode := "42000"
 		errMsg := err.Error()
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			errCode = "57014"
 			errMsg = "canceling statement due to user request"
 		}
@@ -6093,7 +6122,7 @@ func (c *clientConn) handleFetchCursorExtended(p *portal) {
 	// Open cursor on first FETCH
 	if cursor.rows == nil {
 		if err := c.openCursor(cursor); err != nil {
-			if isQueryCancelled(err) {
+			if c.isCallerCancellation(err) {
 				c.sendError("ERROR", "57014", "canceling statement due to user request")
 			} else {
 				c.sendError("ERROR", "42000", err.Error())
@@ -6134,7 +6163,7 @@ func (c *clientConn) handleFetchCursorExtended(p *portal) {
 	}
 
 	if err := cursor.rows.Err(); err != nil {
-		if isQueryCancelled(err) {
+		if c.isCallerCancellation(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
 			c.sendError("ERROR", "42000", err.Error())

--- a/server/transient_test.go
+++ b/server/transient_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -379,10 +382,12 @@ func TestIsUserQueryError(t *testing.T) {
 		{"missing schema (3F000)", errors.New("Catalog Error: Schema with name \"missing\" does not exist!"), true},
 		{"dependent objects (2BP01)", errors.New("Dependency Error: Cannot drop entry because there are other entries that depend on it"), true},
 
-		// 57014 cancellation — class 57 is otherwise infra, but client-
-		// initiated cancels are user events. The short-circuit in
-		// isUserQueryError must keep this in the user bucket.
-		{"client cancellation (57014)", errors.New("context canceled"), true},
+		// 57014 cancellation — class 57 is "operator intervention". Caller-
+		// driven cancellation (Ctrl-C, deadline, client disconnect) is filtered
+		// at the call site via clientConn.isCallerCancellation, so any
+		// cancellation reaching isUserQueryError is infra (gRPC client closed
+		// because the worker died, takeover, etc.) and must surface at Error.
+		{"infra cancellation (57014)", errors.New("context canceled"), false},
 
 		// Infra classes — must NOT be treated as user errors.
 		{"unknown error → XX000", errors.New("something went wrong"), false},
@@ -529,5 +534,98 @@ func TestIsDropTableOnViewError(t *testing.T) {
 				t.Fatalf("isDropTableOnViewError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsCallerCancellation pins down the discriminator that makes the
+// difference between "user pressed Ctrl-C" and "the worker died and gRPC
+// surfaced a Canceled status with a healthy request ctx." The latter must
+// NOT be classified as caller-driven, otherwise the error is silently
+// suppressed and infra failures don't show up in alerting.
+func TestIsCallerCancellation(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "infra-driven gRPC Canceled with healthy ctx is NOT caller cancel",
+			ctx:  context.Background(),
+			err:  errors.New("flight execute: rpc error: code = Canceled desc = context canceled"),
+			want: false,
+		},
+		{
+			name: "user Ctrl-C: ctx canceled and err propagates",
+			ctx:  cancelledCtx,
+			err:  errors.New("flight execute: rpc error: code = Canceled desc = context canceled"),
+			want: true,
+		},
+		{
+			name: "raw context.Canceled with cancelled ctx",
+			ctx:  cancelledCtx,
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "non-cancel error with cancelled ctx is not classified as cancel",
+			ctx:  cancelledCtx,
+			err:  errors.New("Catalog Error: table does not exist"),
+			want: false,
+		},
+		{
+			name: "nil err",
+			ctx:  cancelledCtx,
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "client connection closing (worker died)",
+			ctx:  context.Background(),
+			err:  errors.New("flight execute: rpc error: code = Canceled desc = grpc: the client connection is closing"),
+			want: false, // pre-fix this would have looked like a user cancel via the substring match
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &clientConn{ctx: tt.ctx}
+			if got := c.isCallerCancellation(tt.err); got != tt.want {
+				t.Errorf("isCallerCancellation = %v, want %v (err=%v, ctx.Err=%v)",
+					got, tt.want, tt.err, tt.ctx.Err())
+			}
+		})
+	}
+}
+
+// TestLogQueryErrorRoutesInfraCancelToErrorLevel locks in the alerting
+// invariant: a worker-death cancellation (gRPC Canceled bubbling up while
+// c.ctx is still healthy) must produce slog.LevelError "Query execution
+// errored.", not Info "Query execution failed." — because the latter gets
+// filtered out of alerting and drove the dev/prod observability blind spot
+// reported on 2026-05-04 (PR #516).
+func TestLogQueryErrorRoutesInfraCancelToErrorLevel(t *testing.T) {
+	prevLogger := slog.Default()
+	defer slog.SetDefault(prevLogger)
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	c := &clientConn{ctx: context.Background(), username: "test"}
+	infraErr := errors.New("flight execute: rpc error: code = Canceled desc = context canceled")
+	c.logQueryError("SELECT 1", infraErr)
+
+	out := buf.String()
+	if !strings.Contains(out, `level=ERROR`) {
+		t.Errorf("expected ERROR level for infra cancel, got:\n%s", out)
+	}
+	if !strings.Contains(out, `Query execution errored.`) {
+		t.Errorf("expected message 'Query execution errored.', got:\n%s", out)
+	}
+	if strings.Contains(out, `Query execution failed.`) {
+		t.Errorf("infra cancel should NOT emit 'Query execution failed.':\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- Distinguish user-driven cancellation (Ctrl-C, ctx deadline, client TCP close) from infra-driven cancellation (worker died, gRPC client closed by CP).
- Caller-driven → keep current Info-level "Query finished." with the friendly errMsg.
- Infra-driven → log Error "Query execution errored." so alerting actually fires.

## Why

Looking at the mw-prod-us deadlock incident on 2026-05-04: ~10 worker pods/hour killed by the CP (` K8s worker unresponsive ` ). The in-flight queries on those workers all failed with ` flight execute: rpc error: code = Canceled desc = context canceled ` — but the LogQL query

` ` ` 
sum(count_over_time({namespace=\"duckgres\"} |~ \"Query execution errored.\" [5m])) by (error)
` ` ` 

returned zero hits across the whole incident. Looked at conn.go and the cancel-handling logic conflates two cases:

| Case | ` c.ctx.Err() ` | Error string | Should log? |
|---|---|---|---|
| User Ctrl-C / pgwire CancelRequest / deadline | non-nil | ` rpc error: code = Canceled desc = context canceled ` | No — just suppress |
| Worker died / CP closed gRPC client | nil | ` rpc error: code = Canceled desc = context canceled `  *or*  ` ...desc = grpc: the client connection is closing ` | **Yes** — Error |

` isQueryCancelled ` does a substring match on ` \"context canceled\" ` , so it matches both. Two consequences:

1. ` server/conn.go:1627 `  short-circuits ` c.logQueryError ` for any cancel-shaped err. Worker-kill failures silently emit only ` Query finished. ` (Info) with the error attribute — invisible to alerting that filters on ` Query execution errored. ` .
2. ` isUserQueryError `  has a hard-coded ` if isQueryCancelled(err) { return true } ` shortcut. So even if logQueryError did run, it routed to Info-level ` Query execution failed. `  — still invisible to alerting.

## Fix

` ` ` go
func (c *clientConn) isCallerCancellation(err error) bool {
    if !isQueryCancelled(err) { return false }
    if c == nil || c.ctx == nil { return false }
    return c.ctx.Err() != nil
}
` ` ` 

- 17 call sites in ` clientConn `  methods switch from ` isQueryCancelled(err) `  to ` c.isCallerCancellation(err) ` .
- ` classifyErrorCode `  keeps ` isQueryCancelled `  — SQLSTATE 57014 is the right pgwire response for any cancellation regardless of cause; ` classifyErrorCode `  also runs from contexts without a ` *clientConn ` .
- ` isUserQueryError ` 's cancel shortcut is dropped. The caller-cancellation filter is now upstream, so any cancel-shaped err reaching ` isUserQueryError `  is infra by definition. SQLSTATE class 57 (\"operator intervention\") then correctly routes it to Error.

## Test plan
- [x] ` TestIsCallerCancellation `  — table tests covering: gRPC Canceled with healthy ctx (false), user Ctrl-C with cancelled ctx (true), grpc client-closing wrap (false), nil err, raw ` context.Canceled ` , unrelated err with cancelled ctx.
- [x] ` TestLogQueryErrorRoutesInfraCancelToErrorLevel `  — captures slog output and asserts a worker-death-shaped error produces ` level=ERROR `  ` Query execution errored. `  (not the Info ` Query execution failed. ` ).
- [x] Existing ` TestIsUserQueryError ` 's ` client cancellation `  case flipped from ` true ` → ` false `  with comment explaining the new caller-vs-infra split.
- [x] Full ` ./server/ ` suite green.
- [ ] After deploy: confirm the next infra cancel on mw-dev produces a ` Query execution errored. `  log in Loki.

Follow-up to PR #516.