### PR TITLE
perf(sessionmeta): batch per-session view setup into one ExecContext

### DIFF
--- a/server/sessionmeta/sessionmeta.go
+++ b/server/sessionmeta/sessionmeta.go
@@ -51,10 +51,8 @@ func InitSessionDatabaseMetadata(ctx context.Context, executor sqlcore.QueryExec
 		}
 	}()
 
-	for _, stmt := range buildSessionMetadataSQL(database) {
-		if _, err := executor.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("apply session metadata override: %w", err)
-		}
+	if _, err := executor.ExecContext(ctx, buildSessionMetadataSQL(database)); err != nil {
+		return fmt.Errorf("apply session metadata override: %w", err)
 	}
 
 	return nil
@@ -112,8 +110,18 @@ func HasAttachedCatalog(ctx context.Context, executor sqlcore.QueryExecutor, cat
 	return count > 0, rows.Err()
 }
 
-func buildSessionMetadataSQL(database string) []string {
-	return []string{
+// buildSessionMetadataSQL returns a single SQL script containing all the
+// per-session catalog/metadata setup statements concatenated with semicolons.
+// The DuckDB driver executes the script as a multi-statement batch in one
+// ExecContext call (one Flight RPC from the control plane to the worker
+// instead of N), which materially cuts session establishment latency on
+// remote-worker setups where each round-trip is non-trivial.
+//
+// All statements are independent: each is CREATE OR REPLACE VIEW or
+// CREATE TABLE IF NOT EXISTS, with no cross-statement dependencies that would
+// require ordering beyond the order they appear in the script.
+func buildSessionMetadataSQL(database string) string {
+	parts := []string{
 		sessionColumnMetadataTableSQL(),
 		buildSessionPgDatabaseViewSQL(database),
 		buildSessionInformationSchemaColumnsViewSQL(),
@@ -121,6 +129,7 @@ func buildSessionMetadataSQL(database string) []string {
 		buildSessionInformationSchemaSchemataViewSQL(),
 		buildSessionInformationSchemaViewsViewSQL(),
 	}
+	return strings.Join(parts, ";\n") + ";"
 }
 
 func sessionColumnMetadataTableSQL() string {

--- a/server/sessionmeta/sessionmeta_test.go
+++ b/server/sessionmeta/sessionmeta_test.go
@@ -1,0 +1,124 @@
+package sessionmeta
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/server/sqlcore"
+)
+
+type countingExecutor struct {
+	execCalls   int
+	execQueries []string
+	queryRows   sqlcore.RowSet
+}
+
+func (e *countingExecutor) QueryContext(_ context.Context, _ string, _ ...any) (sqlcore.RowSet, error) {
+	if e.queryRows == nil {
+		return nil, errors.New("no query rows configured")
+	}
+	return e.queryRows, nil
+}
+
+func (e *countingExecutor) ExecContext(_ context.Context, query string, _ ...any) (sqlcore.ExecResult, error) {
+	e.execCalls++
+	e.execQueries = append(e.execQueries, query)
+	return nil, nil
+}
+
+func (e *countingExecutor) Query(string, ...any) (sqlcore.RowSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *countingExecutor) Exec(string, ...any) (sqlcore.ExecResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *countingExecutor) ConnContext(context.Context) (sqlcore.RawConn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *countingExecutor) PingContext(context.Context) error { return nil }
+func (e *countingExecutor) Close() error                      { return nil }
+func (e *countingExecutor) LastProfilingOutput() string       { return "" }
+
+type singleIntRow struct {
+	v        int
+	consumed bool
+}
+
+func (r *singleIntRow) Columns() ([]string, error) { return []string{"count"}, nil }
+func (r *singleIntRow) ColumnTypes() ([]sqlcore.ColumnTyper, error) {
+	return nil, errors.New("not used")
+}
+func (r *singleIntRow) Next() bool {
+	if r.consumed {
+		return false
+	}
+	r.consumed = true
+	return true
+}
+func (r *singleIntRow) Scan(dest ...any) error {
+	if len(dest) != 1 {
+		return errors.New("expected 1 dest")
+	}
+	ptr, ok := dest[0].(*any)
+	if !ok {
+		return errors.New("expected *any dest")
+	}
+	*ptr = int64(r.v)
+	return nil
+}
+func (r *singleIntRow) Close() error                  { return nil }
+func (r *singleIntRow) Err() error                    { return nil }
+func (r *singleIntRow) RowsAffected() (int64, error)  { return 0, nil }
+func (r *singleIntRow) LastInsertId() (int64, error)  { return 0, nil }
+func (r *singleIntRow) LastProfilingOutput() string   { return "" }
+
+func TestInitSessionDatabaseMetadataBatchesPerSessionStatements(t *testing.T) {
+	exec := &countingExecutor{
+		queryRows: &singleIntRow{v: 1}, // pretend ducklake is attached for HasAttachedCatalog
+	}
+
+	if err := InitSessionDatabaseMetadata(context.Background(), exec, "analytics"); err != nil {
+		t.Fatalf("InitSessionDatabaseMetadata: %v", err)
+	}
+
+	// Per-conn statements that intrinsically run as separate calls:
+	//   1. CREATE OR REPLACE TEMP MACRO current_database()
+	//   2. USE memory
+	//   3. USE ducklake               (deferred)
+	//   4. SET search_path            (deferred)
+	// Plus one batched ExecContext for the metadata views (was 6 calls).
+	const expectedExecCalls = 5
+	if exec.execCalls != expectedExecCalls {
+		t.Errorf("ExecContext call count = %d, want %d.\nQueries:\n%s",
+			exec.execCalls, expectedExecCalls,
+			strings.Join(exec.execQueries, "\n---\n"))
+	}
+}
+
+func TestBuildSessionMetadataSQLContainsAllExpectedStatements(t *testing.T) {
+	got := buildSessionMetadataSQL("analytics")
+
+	wants := []string{
+		"CREATE TABLE IF NOT EXISTS main.__duckgres_column_metadata",
+		"CREATE OR REPLACE VIEW main.pg_database",
+		"CREATE OR REPLACE VIEW main.information_schema_columns_compat",
+		"CREATE OR REPLACE VIEW main.information_schema_tables_compat",
+		"CREATE OR REPLACE VIEW main.information_schema_schemata_compat",
+		"CREATE OR REPLACE VIEW main.information_schema_views_compat",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("buildSessionMetadataSQL missing %q", w)
+		}
+	}
+
+	// Database literal should appear (used in pg_database view).
+	if !strings.Contains(got, "'analytics'") {
+		t.Errorf("buildSessionMetadataSQL did not interpolate database literal")
+	}
+}


### PR DESCRIPTION
## Summary

`InitSessionDatabaseMetadata` issued 6 sequential `ExecContext` calls to install the per-session catalog/metadata views. On a remote worker each call is a separate Flight RPC — the cumulative cost is a measurable fraction of new-session establishment latency.

This PR concatenates the 6 statements into one semicolon-separated SQL script and sends it in a single `ExecContext` call. The duckdb-go driver handles multi-statement scripts natively (parses and executes them as a sequence of prepared statements on the same conn).

## Why

Tracing a 5-7s session-init in prod showed the gap was almost entirely CP-side serial RPCs to the worker. The catalog-detect query itself runs in microseconds; the cost is N round-trips × DuckDB lock-acquire jitter per statement.

Reducing the round-trip count is the highest-leverage no-code-restructure win available. This PR removes 5 of them in the hot path.

Remaining per-session RPCs (intrinsically per-conn, can't be batched):
- `CREATE OR REPLACE TEMP MACRO current_database()` (per-conn)
- `HasAttachedCatalog` (read query)
- `USE memory`, `USE ducklake`, `SET search_path` (per-conn settings)

## Verification

- `go test ./server/sessionmeta/...` passes — new unit tests assert the call count and the concatenated script contents.
- `go test ./server/...` passes — the existing real-DuckDB tests (`TestInitSessionDatabaseMetadataOverridesCurrentDatabaseAndPgDatabase` etc.) verify state-after correctness against the actual driver, confirming multi-statement support works end-to-end.
- `go build ./...` and `go vet ./...` clean.

## Risks

- **Driver multi-statement support.** The duckdb-go driver supports it (verified by existing tests passing). If a future driver version drops it, the existing real-DuckDB tests would catch it immediately.
- **Error attribution.** A failure in any statement now reports the whole batch as the failing query rather than the specific one. Acceptable trade-off; if a single statement starts failing in prod the worker-side error message still names the SQL fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)