### PR TITLE
feat: wire cmd/duckgres-worker via shared internal/cliboot

### DIFF
--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -13,52 +13,220 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
 
 	"github.com/posthog/duckgres/configloader"
-	_ "github.com/posthog/duckgres/duckdbservice" // keep the import live so the worker binary actually links libduckdb via duckdbservice
+	"github.com/posthog/duckgres/configresolve"
+	"github.com/posthog/duckgres/duckdbservice"
+	"github.com/posthog/duckgres/internal/cliboot"
+	"github.com/posthog/duckgres/server"
 )
 
+// Each duckgres binary owns its own package-main version/commit/date because
+// -ldflags -X main.* can only target package-main symbols. The actual
+// build-info logic lives in internal/cliboot.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+func buildInfo() cliboot.BuildInfo {
+	bi := cliboot.BuildInfo{Version: version, Commit: commit, Date: date}
+	bi.Enrich()
+	return bi
+}
+
 func main() {
+	// Ignore SIGPIPE so DuckDB's C++ code (and libraries like libpq used by
+	// DuckLake) don't crash the process when a network connection drops
+	// mid-query. Same rationale as the all-in-one binary.
+	signal.Ignore(syscall.SIGPIPE)
+
+	// Worker-relevant flag subset. The all-in-one duckgres binary registers
+	// ~60 flags covering standalone / control-plane / duckdb-service. The
+	// worker only needs the bits that feed server.Config (DuckDB execution,
+	// DuckLake, query log) plus the duckdb-service transport flags. The
+	// rest (TLS/ACME, PG wire, control-plane pool, K8s, config-store,
+	// process-isolation, REPL/psql) intentionally do not exist here.
+	configFile := flag.String("config", configloader.Env("DUCKGRES_CONFIG", ""), "Path to YAML config file (env: DUCKGRES_CONFIG)")
+	logLevel := flag.String("log-level", "", "Log level: debug, info, warn, error (env: DUCKGRES_LOG_LEVEL)")
+	showVersion := flag.Bool("version", false, "Show version and exit")
+	showHelp := flag.Bool("help", false, "Show help message")
+
+	// DuckDB execution
+	dataDir := flag.String("data-dir", "", "Directory for DuckDB files (env: DUCKGRES_DATA_DIR)")
+	memoryLimit := flag.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
+	threads := flag.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
+	memoryBudget := flag.String("memory-budget", "", "Total memory budget for all sessions on this worker (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
+	filePersistence := flag.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
+	idleTimeout := flag.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
+	sessionInitTimeout := flag.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
+
+	// DuckLake (workers attach DuckLake)
+	duckLakeDeltaCatalogEnabled := flag.Bool("ducklake-delta-catalog-enabled", false, "Attach a Delta Lake catalog during DuckLake worker boot (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED)")
+	duckLakeDeltaCatalogPath := flag.String("ducklake-delta-catalog-path", "", "Delta Lake catalog/table path to attach (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH)")
+	duckLakeDefaultSpecVersion := flag.String("ducklake-default-spec-version", "", "Default DuckLake spec version for migration checks (env: DUCKGRES_DUCKLAKE_DEFAULT_SPEC_VERSION)")
+
+	// Query log
+	queryLog := flag.Bool("query-log", true, "Enable/disable DuckLake query log (use --query-log=false to disable; env: DUCKGRES_QUERY_LOG_ENABLED)")
+
+	// DuckDB-service transport
+	duckdbListen := flag.String("duckdb-listen", "", "Service listen address: 'unix:///path' or 'host:port' (env: DUCKGRES_DUCKDB_LISTEN)")
+	duckdbListenFD := flag.Int("duckdb-listen-fd", 0, "Inherit a pre-bound listener FD instead of creating a new socket; set by control plane to avoid EROFS under ProtectSystem=strict")
+	duckdbToken := flag.String("duckdb-token", "", "Bearer token for gRPC auth (env: DUCKGRES_DUCKDB_TOKEN)")
+	duckdbMaxSessions := flag.Int("duckdb-max-sessions", 0, "Max concurrent sessions, 0=unlimited (env: DUCKGRES_DUCKDB_MAX_SESSIONS)")
+
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
-		fmt.Fprintln(os.Stderr)
+		fmt.Fprintf(os.Stderr, "Duckgres worker %s — DuckDB Arrow Flight SQL service\n\n", version)
 		fmt.Fprintln(os.Stderr, "DuckDB-service-only duckgres binary. Links libduckdb.")
 		fmt.Fprintln(os.Stderr, "Serves Arrow Flight SQL on a local Unix socket or TCP port,")
 		fmt.Fprintln(os.Stderr, "spawned by the control plane.")
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "This binary is the target of the per-DuckDB-version matrix build")
-		fmt.Fprintln(os.Stderr, "in CI: a worker pod ships exactly one DuckDB version, pinned via")
-		fmt.Fprintln(os.Stderr, "go.mod + the Dockerfile DUCKDB_EXTENSION_VERSION build arg.")
+		fmt.Fprintln(os.Stderr, "Each worker pod ships exactly one DuckDB version, pinned via")
+		fmt.Fprintln(os.Stderr, "go.mod + the Dockerfile.worker DUCKDB_EXTENSION_VERSION build arg.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Options:")
 		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Precedence: CLI flags > environment variables > config file > defaults")
 	}
 
-	configPath := flag.String("config", "", "path to duckgres.yaml configuration")
+	// -v shorthand before flag.Parse (Go's flag package has no short aliases).
+	for _, arg := range os.Args[1:] {
+		if arg == "-v" {
+			fmt.Println(buildInfo().String())
+			os.Exit(0)
+		}
+	}
+
 	flag.Parse()
 
-	if *configPath == "" {
+	if *showVersion {
+		fmt.Println(buildInfo().String())
+		os.Exit(0)
+	}
+	if *showHelp {
 		flag.Usage()
+		os.Exit(0)
+	}
+
+	// Track explicitly-set flags so configresolve precedence (CLI > env > YAML > default) is consistent.
+	cliSet := make(map[string]bool)
+	flag.Visit(func(f *flag.Flag) {
+		cliSet[f.Name] = true
+	})
+
+	// Auto-detect duckgres.yaml when no --config was given. Mirrors the
+	// all-in-one binary so a worker pod can boot from a mounted ConfigMap
+	// without needing the flag wired.
+	if *configFile == "" {
+		if _, err := os.Stat("duckgres.yaml"); err == nil {
+			*configFile = "duckgres.yaml"
+		}
+	}
+
+	var fileCfg *configloader.FileConfig
+	if *configFile != "" {
+		loaded, err := configloader.LoadFile(*configFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load config file: %s\n", err)
+			os.Exit(1)
+		}
+		fileCfg = loaded
+	}
+
+	// Log level: CLI flag > env > YAML > default. Set the env var so any
+	// downstream goroutines that re-read it pick up the resolved level.
+	if *logLevel != "" {
+		_ = os.Setenv("DUCKGRES_LOG_LEVEL", *logLevel)
+	} else if os.Getenv("DUCKGRES_LOG_LEVEL") == "" && fileCfg != nil && fileCfg.LogLevel != "" {
+		_ = os.Setenv("DUCKGRES_LOG_LEVEL", fileCfg.LogLevel)
+	}
+
+	loggingShutdown := cliboot.InitLogging()
+	defer loggingShutdown()
+	tracingShutdown := cliboot.InitTracing()
+	defer tracingShutdown()
+
+	// Surface the running build identity for kubectl-logs triage. "worker"
+	// here mirrors the mode label the control plane uses when spawning us.
+	buildInfo().Log("worker")
+	duckdbservice.LogCacheProxyStatus()
+
+	server.SetProcessVersion(version)
+
+	if fileCfg != nil {
+		slog.Info("Loaded configuration", "path", *configFile)
+	}
+
+	// Sparse CLIInputs: only the worker-relevant fields are populated.
+	// configresolve.ResolveEffective still reads the full env+YAML surface,
+	// but CP-only fields land in Resolved slots the worker simply doesn't
+	// read. Keeps a single source of truth for resolution rules.
+	resolved := configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{
+		Set:                         cliSet,
+		DataDir:                     *dataDir,
+		FilePersistence:             *filePersistence,
+		IdleTimeout:                 *idleTimeout,
+		SessionInitTimeout:          *sessionInitTimeout,
+		MemoryLimit:                 *memoryLimit,
+		Threads:                     *threads,
+		MemoryBudget:                *memoryBudget,
+		DuckLakeDeltaCatalogEnabled: *duckLakeDeltaCatalogEnabled,
+		DuckLakeDeltaCatalogPath:    *duckLakeDeltaCatalogPath,
+		DuckLakeDefaultSpecVersion:  *duckLakeDefaultSpecVersion,
+		QueryLog:                    *queryLog,
+	}, os.Getenv, func(msg string) {
+		slog.Warn(msg)
+	})
+	cfg := resolved.Server
+
+	// duckdb-service transport: CLI > env. ResolveEffective doesn't own
+	// these because they're transport-shape, not server.Config; they live
+	// in ServiceConfig directly.
+	listenAddr := *duckdbListen
+	if listenAddr == "" {
+		listenAddr = configloader.Env("DUCKGRES_DUCKDB_LISTEN", "")
+	}
+	if *duckdbListenFD == 0 && listenAddr == "" {
+		fmt.Fprintln(os.Stderr, "duckgres-worker requires --duckdb-listen, DUCKGRES_DUCKDB_LISTEN, or an inherited --duckdb-listen-fd from the control plane")
 		os.Exit(2)
 	}
 
-	cfg, err := configloader.LoadFile(*configPath)
-	if err != nil {
-		slog.Error("failed to load config", "path", *configPath, "error", err)
+	token := *duckdbToken
+	if token == "" {
+		token = configloader.Env("DUCKGRES_DUCKDB_TOKEN", "")
+	}
+
+	maxSessions := *duckdbMaxSessions
+	if maxSessions == 0 {
+		if v := configloader.Env("DUCKGRES_DUCKDB_MAX_SESSIONS", ""); v != "" {
+			if n, err := strconv.Atoi(v); err != nil {
+				slog.Warn("Invalid DUCKGRES_DUCKDB_MAX_SESSIONS", "value", v)
+			} else {
+				maxSessions = n
+			}
+		}
+	}
+
+	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create data directory %q: %s\n", cfg.DataDir, err)
 		os.Exit(1)
 	}
-	slog.Info("duckgres-worker: loaded config",
-		"path", *configPath,
-		"data_dir", cfg.DataDir,
-		"memory_limit", cfg.MemoryLimit,
-		"threads", cfg.Threads,
-		"ducklake_metadata_store_set", cfg.DuckLake.MetadataStore != "",
-	)
 
-	// TODO: build duckdbservice.ServiceConfig from cfg, then call
-	// duckdbservice.Run. Today resolveEffectiveConfig in the all-in-one
-	// main.go does this — lifting it into a shared resolution package
-	// both binaries can call is the follow-up to PR #505 (which
-	// extracted the YAML schema). Until then, error out so no one
-	// mistakes this for a working worker binary.
-	slog.Error("duckgres-worker: config-resolution wiring is still in the all-in-one main.go — use the all-in-one duckgres binary in --mode duckdb-service while this is being built out.")
-	os.Exit(1)
+	// No initMetrics() here. In control-plane mode all worker pods would
+	// fight over :9090; the control plane process owns the metrics
+	// endpoint. The duckdb-service exposes per-session metrics via its own
+	// gRPC surface.
+	duckdbservice.Run(duckdbservice.ServiceConfig{
+		ListenAddr:   listenAddr,
+		ListenFD:     *duckdbListenFD,
+		ServerConfig: cfg,
+		BearerToken:  token,
+		MaxSessions:  maxSessions,
+	})
 }
+

--- a/internal/cliboot/buildinfo.go
+++ b/internal/cliboot/buildinfo.go
@@ -1,0 +1,77 @@
+// Package cliboot owns the cross-binary boot scaffolding shared by the
+// all-in-one duckgres binary, cmd/duckgres-worker, and cmd/duckgres-controlplane.
+// It centralizes build-info reporting, slog/redaction wiring, and OTLP
+// log/trace exporters so production observability stays identical regardless
+// of which entry point runs.
+package cliboot
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+)
+
+// BuildInfo carries the version/commit/date triple that each binary
+// receives via -ldflags -X main.* at link time. Each package main owns
+// its own var version/commit/date because ldflags can only target
+// package-main symbols; cliboot just reads them via a value-typed struct.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+// Enrich backfills Commit/Date from runtime/debug VCS settings when
+// ldflags did not provide them — useful for local `go run` / `go build`
+// where the linker flags aren't passed. ldflags-supplied values always
+// win; the dirty marker only applies to VCS-backfilled commits because
+// the release pipeline owns ldflags-injected values.
+func (b *BuildInfo) Enrich() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	commitFromVCS := b.Commit == "unknown"
+	var dirty bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if commitFromVCS && s.Value != "" {
+				b.Commit = s.Value
+				if len(b.Commit) > 12 {
+					b.Commit = b.Commit[:12]
+				}
+			}
+		case "vcs.time":
+			if b.Date == "unknown" && s.Value != "" {
+				b.Date = s.Value
+			}
+		case "vcs.modified":
+			if s.Value == "true" {
+				dirty = true
+			}
+		}
+	}
+	if dirty && commitFromVCS && b.Commit != "unknown" {
+		b.Commit += "-dirty"
+	}
+}
+
+// String renders the human-readable single-line version string used by
+// `--version` / `-v`.
+func (b BuildInfo) String() string {
+	return fmt.Sprintf("duckgres version %s (commit: %s, built: %s)", b.Version, b.Commit, b.Date)
+}
+
+// Log emits the canonical startup line tagging the binary's mode and
+// build identity. Call once per process at startup so log readers can
+// correlate behavior to a specific build, especially in K8s where
+// worker pods often inherit the control plane image.
+func (b BuildInfo) Log(mode string) {
+	slog.Info("Duckgres build info.",
+		"mode", mode,
+		"version", b.Version,
+		"commit", b.Commit,
+		"built", b.Date,
+	)
+}

--- a/internal/cliboot/logging.go
+++ b/internal/cliboot/logging.go
@@ -1,4 +1,4 @@
-package main
+package cliboot
 
 import (
 	"context"
@@ -20,20 +20,20 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-// stampedHandler emits records as: time, level, pod, node, msg, attrs.
+// StampedHandler emits records as: time, level, pod, node, msg, attrs.
 // slog.TextHandler forces attrs after msg, which pushes pod/node to the end
 // of long lines. Putting them up front makes kubectl-logs triage scannable.
-type stampedHandler struct {
+type StampedHandler struct {
 	out   io.Writer
 	level slog.Level
 	stamp []slog.Attr
 }
 
-func (h *stampedHandler) Enabled(_ context.Context, l slog.Level) bool {
+func (h *StampedHandler) Enabled(_ context.Context, l slog.Level) bool {
 	return l >= h.level
 }
 
-func (h *stampedHandler) Handle(_ context.Context, r slog.Record) error {
+func (h *StampedHandler) Handle(_ context.Context, r slog.Record) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "time=%s level=%s", r.Time.UTC().Format(time.RFC3339Nano), r.Level.String())
 	for _, a := range h.stamp {
@@ -78,16 +78,18 @@ func needsQuoting(s string) bool {
 	return false
 }
 
-func (h *stampedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (h *StampedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	nh := *h
 	nh.stamp = append(append([]slog.Attr{}, h.stamp...), attrs...)
 	return &nh
 }
 
-func (h *stampedHandler) WithGroup(_ string) slog.Handler { return h }
+func (h *StampedHandler) WithGroup(_ string) slog.Handler { return h }
 
-// newStampedHandler returns a handler with pod/node env vars pre-attached.
-func newStampedHandler(level slog.Level) *stampedHandler {
+// NewStampedHandler returns a handler with pod/node env vars pre-attached,
+// writing to the provided writer. Tests pass a bytes.Buffer; production
+// passes os.Stderr via newStderrStampedHandler.
+func NewStampedHandler(out io.Writer, level slog.Level) *StampedHandler {
 	var stamp []slog.Attr
 	if pod := os.Getenv("POD_NAME"); pod != "" {
 		stamp = append(stamp, slog.String("pod", pod))
@@ -95,20 +97,24 @@ func newStampedHandler(level slog.Level) *stampedHandler {
 	if node := os.Getenv("NODE_NAME"); node != "" {
 		stamp = append(stamp, slog.String("node", node))
 	}
-	return &stampedHandler{out: os.Stderr, level: level, stamp: stamp}
+	return &StampedHandler{out: out, level: level, stamp: stamp}
 }
 
-// redactingHandler wraps an slog.Handler and scrubs password values from
+func newStderrStampedHandler(level slog.Level) *StampedHandler {
+	return NewStampedHandler(os.Stderr, level)
+}
+
+// RedactingHandler wraps an slog.Handler and scrubs password values from
 // log messages and string attributes before forwarding to the inner handler.
-type redactingHandler struct {
-	inner slog.Handler
+type RedactingHandler struct {
+	Inner slog.Handler
 }
 
-func (h *redactingHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return h.inner.Enabled(ctx, level)
+func (h *RedactingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.Inner.Enabled(ctx, level)
 }
 
-func (h *redactingHandler) Handle(ctx context.Context, r slog.Record) error {
+func (h *RedactingHandler) Handle(ctx context.Context, r slog.Record) error {
 	r.Message = server.RedactSecrets(r.Message)
 
 	// Rebuild attrs with redacted string values.
@@ -120,19 +126,19 @@ func (h *redactingHandler) Handle(ctx context.Context, r slog.Record) error {
 	// Create a new record with the redacted attrs.
 	nr := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
 	nr.AddAttrs(redacted...)
-	return h.inner.Handle(ctx, nr)
+	return h.Inner.Handle(ctx, nr)
 }
 
-func (h *redactingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (h *RedactingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	redacted := make([]slog.Attr, len(attrs))
 	for i, a := range attrs {
 		redacted[i] = redactAttr(a)
 	}
-	return &redactingHandler{inner: h.inner.WithAttrs(redacted)}
+	return &RedactingHandler{Inner: h.Inner.WithAttrs(redacted)}
 }
 
-func (h *redactingHandler) WithGroup(name string) slog.Handler {
-	return &redactingHandler{inner: h.inner.WithGroup(name)}
+func (h *RedactingHandler) WithGroup(name string) slog.Handler {
+	return &RedactingHandler{Inner: h.Inner.WithGroup(name)}
 }
 
 func redactAttr(a slog.Attr) slog.Attr {
@@ -242,13 +248,13 @@ func parseLogLevel() slog.Level {
 	}
 }
 
-// initLogging configures slog to send logs to PostHog via OTLP when
+// InitLogging configures slog to send logs to PostHog via OTLP when
 // POSTHOG_API_KEY is set. Additional PostHog projects can be targeted by
 // setting ADDITIONAL_POSTHOG_API_KEYS to a comma-separated list of API keys.
 // Logs always go to stderr; PostHog is additive.
 // The log level is controlled by DUCKGRES_LOG_LEVEL (debug, info, warn, error).
 // Returns a shutdown function that flushes all OTLP batch processors.
-func initLogging() func() {
+func InitLogging() func() {
 	level := parseLogLevel()
 
 	apiKey := os.Getenv("POSTHOG_API_KEY")
@@ -256,7 +262,7 @@ func initLogging() func() {
 		if os.Getenv("ADDITIONAL_POSTHOG_API_KEYS") != "" {
 			fmt.Fprintln(os.Stderr, "ADDITIONAL_POSTHOG_API_KEYS is set but POSTHOG_API_KEY is not; ignoring additional keys")
 		}
-		slog.SetDefault(slog.New(&redactingHandler{inner: newStampedHandler(level)}))
+		slog.SetDefault(slog.New(&RedactingHandler{Inner: newStderrStampedHandler(level)}))
 		fmt.Fprintln(os.Stderr, "PostHog logging disabled (POSTHOG_API_KEY not set)")
 		return func() {}
 	}
@@ -290,7 +296,7 @@ func initLogging() func() {
 	// The primary exporter must succeed; additional ones are best-effort.
 	primaryExp := newPostHogExporter(ctx, host, apiKey)
 	if primaryExp == nil {
-		slog.SetDefault(slog.New(&redactingHandler{inner: newStampedHandler(level)}))
+		slog.SetDefault(slog.New(&RedactingHandler{Inner: newStderrStampedHandler(level)}))
 		fmt.Fprintln(os.Stderr, "Primary PostHog exporter failed to initialize, continuing with stderr only")
 		return func() {}
 	}
@@ -312,8 +318,8 @@ func initLogging() func() {
 
 	otelHandler := otelslog.NewHandler("duckgres", otelslog.WithLoggerProvider(provider))
 
-	slog.SetDefault(slog.New(&redactingHandler{inner: &multiHandler{
-		handlers: []slog.Handler{newStampedHandler(level), otelHandler},
+	slog.SetDefault(slog.New(&RedactingHandler{Inner: &multiHandler{
+		handlers: []slog.Handler{newStderrStampedHandler(level), otelHandler},
 	}}))
 
 	slog.Info("PostHog logging enabled.", "host", host, "exporters", len(processors))

--- a/internal/cliboot/logging_test.go
+++ b/internal/cliboot/logging_test.go
@@ -1,4 +1,4 @@
-package main
+package cliboot
 
 import (
 	"bytes"
@@ -15,10 +15,10 @@ import (
 // which break key=value parsers downstream.
 func TestStampedHandlerQuotesValuesWithSpaces(t *testing.T) {
 	tests := []struct {
-		name      string
-		attrs     []slog.Attr
-		wantSub   string
-		notWant   string
+		name    string
+		attrs   []slog.Attr
+		wantSub string
+		notWant string
 	}{
 		{
 			name:    "error with spaces is quoted",
@@ -47,7 +47,7 @@ func TestStampedHandlerQuotesValuesWithSpaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			h := &stampedHandler{out: &buf, level: slog.LevelDebug}
+			h := &StampedHandler{out: &buf, level: slog.LevelDebug}
 			logger := slog.New(h)
 			logger.LogAttrs(context.Background(), slog.LevelInfo, "msg", tt.attrs...)
 			out := buf.String()
@@ -114,7 +114,7 @@ func TestRedactingHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-			handler := &redactingHandler{inner: inner}
+			handler := &RedactingHandler{Inner: inner}
 			logger := slog.New(handler)
 
 			logger.LogAttrs(context.Background(), slog.LevelInfo, tt.msg, tt.attrs...)

--- a/internal/cliboot/otel_resource.go
+++ b/internal/cliboot/otel_resource.go
@@ -1,4 +1,4 @@
-package main
+package cliboot
 
 import (
 	"os"

--- a/internal/cliboot/tracing.go
+++ b/internal/cliboot/tracing.go
@@ -1,4 +1,4 @@
-package main
+package cliboot
 
 import (
 	"context"
@@ -13,12 +13,12 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// initTracing configures an OTLP trace exporter when
+// InitTracing configures an OTLP trace exporter when
 // OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (or DUCKGRES_TRACE_ENDPOINT) is set.
 // When no endpoint is configured, the global TracerProvider remains the
 // default no-op, adding zero overhead.
 // Returns a shutdown function that flushes the batch span processor.
-func initTracing() func() {
+func InitTracing() func() {
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 	if endpoint == "" {
 		endpoint = os.Getenv("DUCKGRES_TRACE_ENDPOINT")

--- a/justfile
+++ b/justfile
@@ -260,7 +260,7 @@ test:
 # Run unit tests only
 [group('test')]
 test-unit:
-    go test -v -p 1 . ./duckdbservice/... ./server/... ./transpiler/...
+    go test -v -p 1 . ./duckdbservice/... ./server/... ./transpiler/... ./internal/...
 
 # Run integration tests
 [group('test')]

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/posthog/duckgres/configresolve"
 	"github.com/posthog/duckgres/controlplane"
 	"github.com/posthog/duckgres/duckdbservice"
+	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -84,9 +85,9 @@ func main() {
 	// Check if we're running as a child worker process
 	if os.Getenv("DUCKGRES_CHILD_MODE") == "1" {
 		// Use the same logging/tracing setup as parent for consistent format
-		loggingShutdown := initLogging()
+		loggingShutdown := cliboot.InitLogging()
 		defer loggingShutdown()
-		tracingShutdown := initTracing()
+		tracingShutdown := cliboot.InitTracing()
 		defer tracingShutdown()
 		duckdbservice.LogCacheProxyStatus()
 		server.RunChildMode()
@@ -222,7 +223,7 @@ func main() {
 	// Handle -v shorthand before flag.Parse (Go's flag package doesn't support short aliases)
 	for _, arg := range os.Args[1:] {
 		if arg == "-v" {
-			fmt.Println(versionString())
+			fmt.Println(buildInfo().String())
 			os.Exit(0)
 		}
 	}
@@ -230,7 +231,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Println(versionString())
+		fmt.Println(buildInfo().String())
 		os.Exit(0)
 	}
 
@@ -247,7 +248,7 @@ func main() {
 		}
 	}
 
-	// Load config file early so log_level from YAML can feed into initLogging().
+	// Load config file early so log_level from YAML can feed into cliboot.InitLogging().
 	var fileCfg *FileConfig
 	if *configFile != "" {
 		loadedCfg, err := loadConfigFile(*configFile)
@@ -259,20 +260,20 @@ func main() {
 	}
 
 	// Resolve log level: CLI flag > env var > YAML config > default (info).
-	// Set the env var so workers inherit it and parseLogLevel() picks it up.
+	// Set the env var so workers inherit it and cliboot's parseLogLevel picks it up.
 	if *logLevel != "" {
 		_ = os.Setenv("DUCKGRES_LOG_LEVEL", *logLevel)
 	} else if os.Getenv("DUCKGRES_LOG_LEVEL") == "" && fileCfg != nil && fileCfg.LogLevel != "" {
 		_ = os.Setenv("DUCKGRES_LOG_LEVEL", fileCfg.LogLevel)
 	}
 
-	loggingShutdown := initLogging()
+	loggingShutdown := cliboot.InitLogging()
 	defer loggingShutdown()
 
-	tracingShutdown := initTracing()
+	tracingShutdown := cliboot.InitTracing()
 	defer tracingShutdown()
 
-	logBuildInfo(*mode)
+	buildInfo().Log(*mode)
 	duckdbservice.LogCacheProxyStatus()
 
 	if fileCfg != nil {

--- a/version.go
+++ b/version.go
@@ -1,78 +1,20 @@
 package main
 
-import (
-	"fmt"
-	"log/slog"
-	"runtime/debug"
-	"sync"
-)
+import "github.com/posthog/duckgres/internal/cliboot"
 
 // version, commit and date are populated at link time via -ldflags -X by the
-// Dockerfile, justfile and release workflow. When the binary is built without
-// those flags (local `go run`/`go build`), enrichBuildInfo backfills commit
-// and date from runtime/debug.BuildInfo VCS settings, which the go toolchain
-// embeds automatically from the local git checkout (Go 1.18+). ldflags values
-// always win — the fallback only fires when the default sentinel is still set.
+// Dockerfile, justfile and release workflow. Each duckgres binary
+// (root, cmd/duckgres-worker, cmd/duckgres-controlplane) holds its own
+// package-main copy because ldflags can only target package-main symbols.
+// The actual build-info logic lives in internal/cliboot.
 var (
 	version = "dev"
 	commit  = "unknown"
 	date    = "unknown"
 )
 
-var enrichBuildInfoOnce sync.Once
-
-func enrichBuildInfo() {
-	enrichBuildInfoOnce.Do(func() {
-		info, ok := debug.ReadBuildInfo()
-		if !ok {
-			return
-		}
-		// Only backfill commit from VCS when ldflags did not provide one.
-		// The dirty marker is scoped to the VCS-backfilled case too — if
-		// ldflags injected a commit, the release pipeline owns that value
-		// and we should not mutate it.
-		commitFromVCS := commit == "unknown"
-		var dirty bool
-		for _, s := range info.Settings {
-			switch s.Key {
-			case "vcs.revision":
-				if commitFromVCS && s.Value != "" {
-					commit = s.Value
-					if len(commit) > 12 {
-						commit = commit[:12]
-					}
-				}
-			case "vcs.time":
-				if date == "unknown" && s.Value != "" {
-					date = s.Value
-				}
-			case "vcs.modified":
-				if s.Value == "true" {
-					dirty = true
-				}
-			}
-		}
-		if dirty && commitFromVCS && commit != "unknown" {
-			commit += "-dirty"
-		}
-	})
-}
-
-func versionString() string {
-	enrichBuildInfo()
-	return fmt.Sprintf("duckgres version %s (commit: %s, built: %s)", version, commit, date)
-}
-
-// logBuildInfo emits a single startup line identifying the binary's version,
-// git commit and build time, tagged with the run mode. Call once per process
-// at startup so log readers can quickly correlate behavior with a specific
-// build, especially in K8s where worker pods inherit the control plane image.
-func logBuildInfo(mode string) {
-	enrichBuildInfo()
-	slog.Info("Duckgres build info.",
-		"mode", mode,
-		"version", version,
-		"commit", commit,
-		"built", date,
-	)
+func buildInfo() cliboot.BuildInfo {
+	bi := cliboot.BuildInfo{Version: version, Commit: commit, Date: date}
+	bi.Enrich()
+	return bi
 }


### PR DESCRIPTION
## Summary
- Wires **`cmd/duckgres-worker`** to actually call `duckdbservice.Run` via `configresolve.ResolveEffective` — the binary is no longer a stub. It now serves Arrow Flight SQL on a Unix socket or TCP port, ready to be the target of the per-DuckDB-version matrix CD images.
- Lifts shared boot scaffolding (logging with `RedactingHandler`, OTLP tracing, OTel resource, build-info) from root `package main` into a new **`internal/cliboot`** package so the worker, the future `cmd/duckgres-controlplane` wiring, and the all-in-one binary all inherit identical PostHog log shipping, password redaction, and tracing.
- Worker-only flag subset (~14 flags): DuckDB execution, DuckLake, query log, and duckdb-service transport. TLS/ACME, PG wire, control-plane pool, K8s, and config-store flags intentionally do not exist on this binary. YAML and env still carry the full surface — a worker pod can boot from the same ConfigMap as the CP; CP-only fields land in `Resolved` slots the worker simply doesn't read.
- Each `cmd/` binary keeps its own package-main `var version/commit/date` (the only place `-ldflags -X main.*` can land); `cliboot.BuildInfo` carries the logic.
- `just test-unit` now also runs `./internal/...` so the redaction tests fire on every CI pass.

## Why this PR exists
The cmd/ stubs were introduced in #498 / #500 alongside the per-DuckDB-version matrix CD pipeline (#502, #501) so we could ship multiple worker images in parallel — the prerequisite for pinning specific tenants to older DuckDB/DuckLake versions. The stubs build, push to ECR, and pass CI guard checks (#499) but error out at startup. This PR makes `cmd/duckgres-worker` actually executable end-to-end, which unblocks the original tenant-pinning workflow that motivated the binary split.

`cmd/duckgres-controlplane` remains a stub for now — its ~60-flag surface justifies first lifting a shared `RegisterAllFlags(*flag.FlagSet) *CLIInputs` helper in `configresolve/`, which is a separate follow-up so the all-in-one binary and the CP-only binary never carry two divergent flag tables.

## Test plan
- [x] `just test-unit` — all packages green, including new `./internal/cliboot/...`
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./controlplane ./controlplane/configstore ./controlplane/provisioning` green (verifying no regression from the boot scaffolding lift)
- [x] `go build ./cmd/duckgres-worker` produces a working binary
- [x] `duckgres-worker --version` and `--help` render expected output
- [x] Local smoke run on a Unix socket: worker binds, accepts a connection, and responds with an HTTP/2 SETTINGS frame (gRPC handshake)
- [ ] **Deferred:** end-to-end test against the live multitenant CP, using a `:<sha>-duckdb1.5.1` matrix image, to confirm the org `4dc8564d…` pinning workflow is operational. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)