### PR TITLE
fix(worker): accept --mode duckdb-service + force DUCKGRES_MODE env

### DIFF
--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -56,6 +56,15 @@ func main() {
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	showHelp := flag.Bool("help", false, "Show help message")
 
+	// --mode is accepted but must be "duckdb-service". The K8s control
+	// plane spawns workers with `--mode duckdb-service` hardcoded
+	// (controlplane/k8s_pool.go), and the all-in-one duckgres binary
+	// uses --mode to route between standalone/control-plane/duckdb-service.
+	// This binary is duckdb-service by definition; we accept the flag so
+	// existing CP pod specs don't crash flag.Parse with "flag provided but
+	// not defined", and reject any other value to surface misuse loudly.
+	mode := flag.String("mode", "duckdb-service", "Run mode (must be 'duckdb-service'; accepted for compatibility with the control plane's hardcoded pod spec)")
+
 	// DuckDB execution
 	dataDir := flag.String("data-dir", "", "Directory for DuckDB files (env: DUCKGRES_DATA_DIR)")
 	memoryLimit := flag.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
@@ -112,6 +121,21 @@ func main() {
 		flag.Usage()
 		os.Exit(0)
 	}
+
+	// Reject any --mode other than duckdb-service. This binary is
+	// duckdb-service by construction; --mode exists only for compatibility
+	// with the all-in-one binary's CLI shape.
+	if *mode != "duckdb-service" {
+		fmt.Fprintf(os.Stderr, "duckgres-worker only supports --mode duckdb-service (got %q). Use the all-in-one duckgres binary for standalone or control-plane modes.\n", *mode)
+		os.Exit(2)
+	}
+
+	// duckdbservice.SessionPool.Warmup() gates pre-warm on
+	// DUCKGRES_MODE == "duckdb-service" (duckdbservice/service.go). The K8s
+	// pool sets this env var when spawning workers, but we set it here
+	// defensively so the binary works identically when invoked directly
+	// (local smoke runs, custom orchestrators, etc.). No-op when already set.
+	_ = os.Setenv("DUCKGRES_MODE", "duckdb-service")
 
 	// Track explicitly-set flags so configresolve precedence (CLI > env > YAML > default) is consistent.
 	cliSet := make(map[string]bool)


### PR DESCRIPTION
## Summary

The K8s control plane spawns worker pods with `--mode duckdb-service` hardcoded ([controlplane/k8s_pool.go:561-564](https://github.com/PostHog/duckgres/blob/main/controlplane/k8s_pool.go#L561-L564)). After #521, `cmd/duckgres-worker` actually executes — but it does not define a `--mode` flag, so `flag.Parse()` exits 2 with `flag provided but not defined: -mode`. **Every worker pod scheduled with the matrix-CD `:<sha>-duckdb<VERSION>` image would crash-loop at startup.** This PR is the one-line fix that makes those images viable.

Two changes:

1. **Accept `--mode duckdb-service`.** Default value is `duckdb-service`; any other value is rejected with a clear error and exit 2. The binary is duckdb-service by construction, so we accept the flag for compatibility with the all-in-one CLI shape and reject misuse loudly.

2. **Force-set `DUCKGRES_MODE=duckdb-service` env var in `main()`.** `duckdbservice.SessionPool.Warmup()` gates pre-warming on this env ([duckdbservice/service.go:153](https://github.com/PostHog/duckgres/blob/main/duckdbservice/service.go#L153)). The K8s pool sets it externally, but setting it in `main()` too means local invocations and any future orchestrator that spawns this binary directly also trigger warmup. Matches the binary's identity instead of relying on a caller convention.

## Why this exists
Found while doing a post-#521 validation pass on the K8s spawn path. The matrix-CD pipeline has been pushing `cmd/duckgres-worker` images for weeks; before #521 they were exit-1 stubs, after #521 they would have been exit-2 stubs from the missing `--mode` flag. This PR is the minimum unblocker for the original org `4dc8564d…` pinning workflow that motivated the binary split.

## Test plan
- [x] `go build ./cmd/duckgres-worker` clean
- [x] `go vet ./cmd/duckgres-worker` clean
- [x] `just test-unit` green
- [x] `duckgres-worker --mode standalone` exits 2 with `duckgres-worker only supports --mode duckdb-service (got "standalone")...`
- [x] `duckgres-worker --mode duckdb-service --duckdb-listen unix:///tmp/x.sock` reaches `Warmup()` — startup log now includes `Pre-warming worker DuckDB instance...` (it didn't before this fix because `DUCKGRES_MODE` was unset locally)
- [x] `duckgres-worker --duckdb-listen :8816` (no `--mode`) defaults to duckdb-service and runs
- [ ] **Deferred to user-side**: a fresh matrix-CD run after merge produces images that no longer crash-loop in MTCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)