### PR TITLE
feat: wire cmd/duckgres-controlplane via shared CLIInputs flag registrar

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -13,60 +13,227 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/posthog/duckgres/configloader"
-	_ "github.com/posthog/duckgres/controlplane" // keep the import live so go list -deps reflects the real CP graph
+	"github.com/posthog/duckgres/configresolve"
+	"github.com/posthog/duckgres/controlplane"
+	"github.com/posthog/duckgres/internal/cliboot"
+	"github.com/posthog/duckgres/server"
 )
 
+// Each duckgres binary owns its own package-main version/commit/date because
+// -ldflags -X main.* can only target package-main symbols. The actual
+// build-info logic lives in internal/cliboot.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+func buildInfo() cliboot.BuildInfo {
+	bi := cliboot.BuildInfo{Version: version, Commit: commit, Date: date}
+	bi.Enrich()
+	return bi
+}
+
 func main() {
+	// Ignore SIGPIPE so libpq inside DuckLake metadata access (and any
+	// other cgo libraries the CP transitively reaches) don't crash the
+	// process on dropped network connections. Same rationale as the
+	// all-in-one binary.
+	signal.Ignore(syscall.SIGPIPE)
+
+	// CLIInputs-backed flags are registered via the shared helper so this
+	// binary and the all-in-one duckgres binary cannot drift on the
+	// resolver's CLI surface. The bespoke flags below (--config,
+	// --log-level, --mode, --socket-dir, --version, --help) don't flow
+	// through ResolveEffective.
+	harvestCLIInputs := configresolve.RegisterCLIInputsFlags(flag.CommandLine)
+
+	configFile := flag.String("config", configloader.Env("DUCKGRES_CONFIG", ""), "Path to YAML config file (env: DUCKGRES_CONFIG)")
+	logLevel := flag.String("log-level", "", "Log level: debug, info, warn, error (env: DUCKGRES_LOG_LEVEL)")
+	showVersion := flag.Bool("version", false, "Show version and exit")
+	showHelp := flag.Bool("help", false, "Show help message")
+	socketDir := flag.String("socket-dir", "/var/run/duckgres", "Unix socket directory for process worker backend")
+	// --mode is accepted but must be "control-plane". Symmetry with
+	// cmd/duckgres-worker, which accepts --mode duckdb-service for
+	// compatibility with hardcoded pod-spec args. This binary is
+	// control-plane by definition; any other value is loud misuse.
+	mode := flag.String("mode", "control-plane", "Run mode (must be 'control-plane'; accepted for symmetry with the all-in-one binary's CLI shape)")
+
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
-		fmt.Fprintln(os.Stderr)
+		fmt.Fprintf(os.Stderr, "Duckgres control plane %s — PostgreSQL wire protocol + Flight ingress\n\n", version)
 		fmt.Fprintln(os.Stderr, "Control-plane-only duckgres binary. Does NOT link libduckdb.")
 		fmt.Fprintln(os.Stderr, "Routes all SQL execution to remote duckdb-service worker pods")
 		fmt.Fprintln(os.Stderr, "via Arrow Flight SQL.")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Configuration mirrors the all-in-one duckgres binary running in")
-		fmt.Fprintln(os.Stderr, "`--mode control-plane --worker-backend remote`. The CLI/env")
-		fmt.Fprintln(os.Stderr, "flag plumbing currently lives in the all-in-one main.go and")
-		fmt.Fprintln(os.Stderr, "will be lifted into a shared package in a follow-up PR; until")
-		fmt.Fprintln(os.Stderr, "then this binary loads -config <path> as the source of truth.")
+		fmt.Fprintln(os.Stderr, "`--mode control-plane`. The CLI flags backed by CLIInputs share")
+		fmt.Fprintln(os.Stderr, "their definitions with the all-in-one binary via")
+		fmt.Fprintln(os.Stderr, "configresolve.RegisterCLIInputsFlags so the two cannot drift.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Options:")
 		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Precedence: CLI flags > environment variables > config file > defaults")
 	}
 
-	configPath := flag.String("config", "", "path to duckgres.yaml configuration")
+	// -v shorthand before flag.Parse (Go's flag package has no short aliases).
+	for _, arg := range os.Args[1:] {
+		if arg == "-v" {
+			fmt.Println(buildInfo().String())
+			os.Exit(0)
+		}
+	}
+
 	flag.Parse()
 
-	if *configPath == "" {
+	if *showVersion {
+		fmt.Println(buildInfo().String())
+		os.Exit(0)
+	}
+	if *showHelp {
 		flag.Usage()
+		os.Exit(0)
+	}
+	if *mode != "control-plane" {
+		fmt.Fprintf(os.Stderr, "duckgres-controlplane only supports --mode control-plane (got %q). Use the all-in-one duckgres binary for standalone or duckdb-service modes, or cmd/duckgres-worker for worker pods.\n", *mode)
 		os.Exit(2)
 	}
 
-	cfg, err := configloader.LoadFile(*configPath)
-	if err != nil {
-		slog.Error("failed to load config", "path", *configPath, "error", err)
+	// Auto-detect duckgres.yaml when no --config was given.
+	if *configFile == "" {
+		if _, err := os.Stat("duckgres.yaml"); err == nil {
+			*configFile = "duckgres.yaml"
+		}
+	}
+
+	var fileCfg *configloader.FileConfig
+	if *configFile != "" {
+		loaded, err := configloader.LoadFile(*configFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load config file: %s\n", err)
+			os.Exit(1)
+		}
+		fileCfg = loaded
+	}
+
+	// Log level: CLI flag > env > YAML > default.
+	if *logLevel != "" {
+		_ = os.Setenv("DUCKGRES_LOG_LEVEL", *logLevel)
+	} else if os.Getenv("DUCKGRES_LOG_LEVEL") == "" && fileCfg != nil && fileCfg.LogLevel != "" {
+		_ = os.Setenv("DUCKGRES_LOG_LEVEL", fileCfg.LogLevel)
+	}
+
+	loggingShutdown := cliboot.InitLogging()
+	defer loggingShutdown()
+	tracingShutdown := cliboot.InitTracing()
+	defer tracingShutdown()
+
+	buildInfo().Log("control-plane")
+	server.SetProcessVersion(version)
+
+	if fileCfg != nil {
+		slog.Info("Loaded configuration", "path", *configFile)
+	}
+
+	fatal := func(msg string) {
+		slog.Error(msg)
+		loggingShutdown()
 		os.Exit(1)
 	}
-	slog.Info("duckgres-controlplane: loaded config",
-		"path", *configPath,
-		"data_dir", cfg.DataDir,
-		"port", cfg.Port,
-		"flight_port", cfg.FlightPort,
-		"worker_backend", cfg.WorkerBackend,
-		"k8s_worker_image", cfg.K8s.WorkerImage,
-		"ducklake_default_spec_version", cfg.DuckLake.DefaultSpecVersion,
-	)
 
-	// TODO: build controlplane.ControlPlaneConfig from cfg, then call
-	// controlplane.RunControlPlane(cpCfg). Today resolveEffectiveConfig in
-	// the all-in-one main.go does this — lifting it into a shared
-	// resolution package both binaries can call is the follow-up to PR
-	// #505 (which extracted the YAML schema). Until then, error out so
-	// no one mistakes this for a working CP binary.
-	slog.Error("duckgres-controlplane: config-resolution wiring is still in the all-in-one main.go — use the all-in-one duckgres binary in --mode control-plane while this is being built out.")
-	os.Exit(1)
+	resolved := configresolve.ResolveEffective(fileCfg, harvestCLIInputs(), os.Getenv, func(msg string) {
+		slog.Warn(msg)
+	})
+	cfg := resolved.Server
+
+	// Process isolation is incompatible with control-plane mode — that mode
+	// already provides process-level isolation via the worker pool.
+	if cfg.ProcessIsolation {
+		cfg.ProcessIsolation = false
+		slog.Info("Process isolation disabled (not applicable in control-plane mode)")
+	}
+
+	metricsSrv := cliboot.InitMetrics()
+
+	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
+		fatal("Failed to create data directory: " + err.Error())
+	}
+
+	// Auto-generate self-signed certificates when ACME is not configured.
+	if cfg.ACMEDomain == "" {
+		if err := server.EnsureCertificates(cfg.TLSCertFile, cfg.TLSKeyFile); err != nil {
+			fatal("Failed to ensure TLS certificates: " + err.Error())
+		}
+		slog.Info("Using TLS certificates", "cert_file", cfg.TLSCertFile, "key_file", cfg.TLSKeyFile)
+	} else if cfg.ACMEDNSProvider != "" {
+		slog.Info("ACME DNS-01 mode enabled", "domain", cfg.ACMEDomain, "provider", cfg.ACMEDNSProvider)
+	} else {
+		slog.Info("ACME/Let's Encrypt mode enabled", "domain", cfg.ACMEDomain)
+	}
+
+	// Wire up SIGINT/SIGTERM so the metrics server gets a clean shutdown
+	// during pod termination. RunControlPlane handles its own graceful
+	// shutdown for the wire-protocol listeners + worker pool, but the
+	// metrics server is owned here.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		slog.Info("Shutting down metrics server...")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = metricsSrv.Shutdown(ctx)
+	}()
+
+	cpCfg := controlplane.ControlPlaneConfig{
+		Config: cfg,
+		Process: controlplane.ProcessConfig{
+			MinWorkers: resolved.ProcessMinWorkers,
+			MaxWorkers: resolved.ProcessMaxWorkers,
+		},
+		SocketDir:                  *socketDir,
+		ConfigPath:                 *configFile,
+		WorkerQueueTimeout:         resolved.WorkerQueueTimeout,
+		WorkerIdleTimeout:          resolved.WorkerIdleTimeout,
+		RetireOnSessionEnd:         resolved.ProcessRetireOnSessionEnd,
+		HandoverDrainTimeout:       resolved.HandoverDrainTimeout,
+		MetricsServer:              metricsSrv,
+		WorkerBackend:              resolved.WorkerBackend,
+		ConfigStoreConn:            resolved.ConfigStoreConn,
+		ConfigPollInterval:         resolved.ConfigPollInterval,
+		InternalSecret:             resolved.InternalSecret,
+		SNIRoutingMode:             resolved.SNIRoutingMode,
+		ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
+		DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
+		K8s: controlplane.K8sConfig{
+			WorkerImage:           resolved.K8sWorkerImage,
+			WorkerNamespace:       resolved.K8sWorkerNamespace,
+			ControlPlaneID:        resolved.K8sControlPlaneID,
+			WorkerPort:            resolved.K8sWorkerPort,
+			WorkerSecret:          resolved.K8sWorkerSecret,
+			WorkerConfigMap:       resolved.K8sWorkerConfigMap,
+			ImagePullPolicy:       resolved.K8sWorkerImagePullPolicy,
+			ServiceAccount:        resolved.K8sWorkerServiceAccount,
+			MaxWorkers:            resolved.K8sMaxWorkers,
+			SharedWarmTarget:      resolved.K8sSharedWarmTarget,
+			WorkerCPURequest:      resolved.K8sWorkerCPURequest,
+			WorkerMemoryRequest:   resolved.K8sWorkerMemoryRequest,
+			WorkerNodeSelector:    resolved.K8sWorkerNodeSelector,
+			WorkerTolerationKey:   resolved.K8sWorkerTolerationKey,
+			WorkerTolerationValue: resolved.K8sWorkerTolerationValue,
+			WorkerExclusiveNode:   resolved.K8sWorkerExclusiveNode,
+			AWSRegion:             resolved.AWSRegion,
+		},
+	}
+	controlplane.RunControlPlane(cpCfg)
 }

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -1,0 +1,135 @@
+package configresolve
+
+import "flag"
+
+// RegisterCLIInputsFlags registers every CLIInputs-backed CLI flag onto fs
+// and returns a harvest closure that — once fs.Parse has run — produces a
+// fully populated CLIInputs (including the Set map indicating which flags
+// were explicitly provided on the command line). Each duckgres binary calls
+// this to share one source of truth for the resolver's CLI surface; flags
+// that don't flow through ResolveEffective (--mode, --config, --log-level,
+// --repl, --psql, --socket-dir, --duckdb-*) remain bespoke per binary.
+//
+// A handful of CLIInputs fields (the K8s pod-scheduling knobs:
+// K8sWorkerCPURequest, K8sWorkerMemoryRequest, K8sWorkerNodeSelector,
+// K8sWorkerTolerationKey, K8sWorkerTolerationValue, K8sWorkerExclusiveNode)
+// are env-only by design — see CLAUDE.md "K8s pod scheduling knobs are
+// env-only." They stay zero in the harvested CLIInputs and ResolveEffective
+// reads them directly from os.Getenv. Adding a flag for any of them is a
+// fine future change; just add it here and the harvest closure below.
+//
+// The flag-coverage test in cliflags_test.go asserts every CLI-backed
+// CLIInputs field is registered, so adding a new field without a flag
+// fails CI loudly instead of silently doing nothing.
+func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
+	host := fs.String("host", "", "Host to bind to (env: DUCKGRES_HOST)")
+	port := fs.Int("port", 0, "Port to listen on (env: DUCKGRES_PORT)")
+	flightPort := fs.Int("flight-port", 0, "Control-plane Arrow Flight SQL ingress port, 0=disabled (env: DUCKGRES_FLIGHT_PORT)")
+	flightSessionIdleTTL := fs.String("flight-session-idle-ttl", "", "Flight auth session idle TTL (e.g., '10m') (env: DUCKGRES_FLIGHT_SESSION_IDLE_TTL)")
+	flightSessionReapInterval := fs.String("flight-session-reap-interval", "", "Flight auth session reap interval (e.g., '1m') (env: DUCKGRES_FLIGHT_SESSION_REAP_INTERVAL)")
+	flightHandleIdleTTL := fs.String("flight-handle-idle-ttl", "", "Flight prepared/query handle idle TTL (e.g., '15m') (env: DUCKGRES_FLIGHT_HANDLE_IDLE_TTL)")
+	flightSessionTokenTTL := fs.String("flight-session-token-ttl", "", "Flight issued session token absolute TTL (e.g., '1h') (env: DUCKGRES_FLIGHT_SESSION_TOKEN_TTL)")
+	dataDir := fs.String("data-dir", "", "Directory for DuckDB files (env: DUCKGRES_DATA_DIR)")
+	certFile := fs.String("cert", "", "TLS certificate file (env: DUCKGRES_CERT)")
+	keyFile := fs.String("key", "", "TLS private key file (env: DUCKGRES_KEY)")
+	filePersistence := fs.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
+	processIsolation := fs.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
+	idleTimeout := fs.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
+	sessionInitTimeout := fs.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
+	memoryLimit := fs.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
+	threads := fs.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
+	memoryBudget := fs.String("memory-budget", "", "Total memory for all DuckDB sessions (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
+	memoryRebalance := fs.Bool("memory-rebalance", false, "Enable dynamic per-connection memory reallocation (control-plane mode) (env: DUCKGRES_MEMORY_REBALANCE)")
+	duckLakeDeltaCatalogEnabled := fs.Bool("ducklake-delta-catalog-enabled", false, "Attach a Delta Lake catalog during DuckLake worker boot (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED)")
+	duckLakeDeltaCatalogPath := fs.String("ducklake-delta-catalog-path", "", "Delta Lake catalog/table path to attach, defaults to sibling delta/ prefix at DuckLake object-store root (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH)")
+	duckLakeDefaultSpecVersion := fs.String("ducklake-default-spec-version", "", "Default DuckLake spec version for migration checks (env: DUCKGRES_DUCKLAKE_DEFAULT_SPEC_VERSION)")
+	processMinWorkers := fs.Int("process-min-workers", 0, "Pre-warm worker count at startup for process workers (control-plane mode) (env: DUCKGRES_PROCESS_MIN_WORKERS)")
+	processMaxWorkers := fs.Int("process-max-workers", 0, "Max process workers, 0=auto-derived (control-plane mode) (env: DUCKGRES_PROCESS_MAX_WORKERS)")
+	processRetireOnSessionEnd := fs.Bool("process-retire-on-session-end", false, "Retire a process worker immediately after its last session ends instead of keeping it warm for reuse (control-plane mode) (env: DUCKGRES_PROCESS_RETIRE_ON_SESSION_END)")
+	workerQueueTimeout := fs.String("worker-queue-timeout", "", "How long to wait for an available worker slot (e.g., '5m') (env: DUCKGRES_WORKER_QUEUE_TIMEOUT)")
+	workerIdleTimeout := fs.String("worker-idle-timeout", "", "How long to keep an idle worker alive (e.g., '5m') (env: DUCKGRES_WORKER_IDLE_TIMEOUT)")
+	handoverDrainTimeout := fs.String("handover-drain-timeout", "", "How long to wait for planned shutdowns/upgrades to drain before forcing exit (default: '24h' in process mode, '15m' in remote mode) (env: DUCKGRES_HANDOVER_DRAIN_TIMEOUT)")
+	acmeDomain := fs.String("acme-domain", "", "Domain for ACME/Let's Encrypt certificate (env: DUCKGRES_ACME_DOMAIN)")
+	acmeEmail := fs.String("acme-email", "", "Contact email for Let's Encrypt notifications (env: DUCKGRES_ACME_EMAIL)")
+	acmeCacheDir := fs.String("acme-cache-dir", "", "Directory for ACME certificate cache (env: DUCKGRES_ACME_CACHE_DIR)")
+	acmeDNSProvider := fs.String("acme-dns-provider", "", "DNS provider for ACME DNS-01 challenges, e.g. 'route53' (env: DUCKGRES_ACME_DNS_PROVIDER)")
+	acmeDNSZoneID := fs.String("acme-dns-zone-id", "", "Route53 hosted zone ID for ACME DNS-01 challenges (env: DUCKGRES_ACME_DNS_ZONE_ID)")
+	maxConnections := fs.Int("max-connections", 0, "Max concurrent connections, 0=unlimited (env: DUCKGRES_MAX_CONNECTIONS)")
+	configStoreConn := fs.String("config-store", "", "PostgreSQL connection string for config store (env: DUCKGRES_CONFIG_STORE)")
+	configPollInterval := fs.String("config-poll-interval", "", "How often to poll config store for changes (default: 30s) (env: DUCKGRES_CONFIG_POLL_INTERVAL)")
+	internalSecret := fs.String("internal-secret", "", "Shared secret for API authentication (env: DUCKGRES_INTERNAL_SECRET)")
+	sniRoutingMode := fs.String("sni-routing-mode", "", "Hostname-based org routing: 'off' (default), 'passthrough' (prefer SNI, log legacy), 'enforce' (reject without managed hostname). Multi-tenant only. (env: DUCKGRES_SNI_ROUTING_MODE)")
+	managedHostnameSuffixes := fs.String("managed-hostname-suffixes", "", "Comma-separated DNS suffixes (each starting with '.') treated as authoritative for org routing, e.g. '.dw.us.postwh.com'. (env: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES)")
+	workerBackend := fs.String("worker-backend", "", "Worker backend: process (default) or remote for config-store-backed K8s multitenant mode (env: DUCKGRES_WORKER_BACKEND)")
+	k8sWorkerImage := fs.String("k8s-worker-image", "", "Container image for K8s worker pods (env: DUCKGRES_K8S_WORKER_IMAGE)")
+	k8sWorkerNamespace := fs.String("k8s-worker-namespace", "", "K8s namespace for worker pods (env: DUCKGRES_K8S_WORKER_NAMESPACE)")
+	k8sControlPlaneID := fs.String("k8s-control-plane-id", "", "Unique CP identifier for labeling worker pods (env: DUCKGRES_K8S_CONTROL_PLANE_ID)")
+	k8sWorkerPort := fs.Int("k8s-worker-port", 0, "gRPC port on K8s worker pods (default: 8816) (env: DUCKGRES_K8S_WORKER_PORT)")
+	k8sWorkerSecret := fs.String("k8s-worker-secret", "", "K8s Secret name for worker bearer token (env: DUCKGRES_K8S_WORKER_SECRET)")
+	k8sWorkerConfigMap := fs.String("k8s-worker-configmap", "", "ConfigMap name for worker duckgres.yaml (env: DUCKGRES_K8S_WORKER_CONFIGMAP)")
+	k8sWorkerImagePullPolicy := fs.String("k8s-worker-image-pull-policy", "", "Image pull policy for K8s worker pods: Always, IfNotPresent, Never (env: DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY)")
+	k8sWorkerServiceAccount := fs.String("k8s-worker-service-account", "", "Neutral ServiceAccount name for K8s worker pods (default: duckgres-worker) (env: DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT)")
+	k8sMaxWorkers := fs.Int("k8s-max-workers", 0, "Max K8s workers in the shared pool, 0=auto-derived (env: DUCKGRES_K8S_MAX_WORKERS)")
+	k8sSharedWarmTarget := fs.Int("k8s-shared-warm-target", 0, "Neutral shared warm-worker target for K8s multi-tenant mode, 0=disabled (env: DUCKGRES_K8S_SHARED_WARM_TARGET)")
+	awsRegion := fs.String("aws-region", "", "AWS region for STS client (env: DUCKGRES_AWS_REGION)")
+	queryLog := fs.Bool("query-log", true, "Enable/disable DuckLake query log (use --query-log=false to disable; env: DUCKGRES_QUERY_LOG_ENABLED)")
+
+	return func() CLIInputs {
+		cli := CLIInputs{Set: map[string]bool{}}
+		fs.Visit(func(f *flag.Flag) {
+			cli.Set[f.Name] = true
+		})
+		cli.Host = *host
+		cli.Port = *port
+		cli.FlightPort = *flightPort
+		cli.FlightSessionIdleTTL = *flightSessionIdleTTL
+		cli.FlightSessionReapInterval = *flightSessionReapInterval
+		cli.FlightHandleIdleTTL = *flightHandleIdleTTL
+		cli.FlightSessionTokenTTL = *flightSessionTokenTTL
+		cli.DataDir = *dataDir
+		cli.CertFile = *certFile
+		cli.KeyFile = *keyFile
+		cli.FilePersistence = *filePersistence
+		cli.ProcessIsolation = *processIsolation
+		cli.IdleTimeout = *idleTimeout
+		cli.SessionInitTimeout = *sessionInitTimeout
+		cli.MemoryLimit = *memoryLimit
+		cli.Threads = *threads
+		cli.MemoryBudget = *memoryBudget
+		cli.MemoryRebalance = *memoryRebalance
+		cli.DuckLakeDeltaCatalogEnabled = *duckLakeDeltaCatalogEnabled
+		cli.DuckLakeDeltaCatalogPath = *duckLakeDeltaCatalogPath
+		cli.DuckLakeDefaultSpecVersion = *duckLakeDefaultSpecVersion
+		cli.ProcessMinWorkers = *processMinWorkers
+		cli.ProcessMaxWorkers = *processMaxWorkers
+		cli.ProcessRetireOnSessionEnd = *processRetireOnSessionEnd
+		cli.WorkerQueueTimeout = *workerQueueTimeout
+		cli.WorkerIdleTimeout = *workerIdleTimeout
+		cli.HandoverDrainTimeout = *handoverDrainTimeout
+		cli.ACMEDomain = *acmeDomain
+		cli.ACMEEmail = *acmeEmail
+		cli.ACMECacheDir = *acmeCacheDir
+		cli.ACMEDNSProvider = *acmeDNSProvider
+		cli.ACMEDNSZoneID = *acmeDNSZoneID
+		cli.MaxConnections = *maxConnections
+		cli.ConfigStoreConn = *configStoreConn
+		cli.ConfigPollInterval = *configPollInterval
+		cli.InternalSecret = *internalSecret
+		cli.SNIRoutingMode = *sniRoutingMode
+		cli.ManagedHostnameSuffixes = *managedHostnameSuffixes
+		cli.WorkerBackend = *workerBackend
+		cli.K8sWorkerImage = *k8sWorkerImage
+		cli.K8sWorkerNamespace = *k8sWorkerNamespace
+		cli.K8sControlPlaneID = *k8sControlPlaneID
+		cli.K8sWorkerPort = *k8sWorkerPort
+		cli.K8sWorkerSecret = *k8sWorkerSecret
+		cli.K8sWorkerConfigMap = *k8sWorkerConfigMap
+		cli.K8sWorkerImagePullPolicy = *k8sWorkerImagePullPolicy
+		cli.K8sWorkerServiceAccount = *k8sWorkerServiceAccount
+		cli.K8sMaxWorkers = *k8sMaxWorkers
+		cli.K8sSharedWarmTarget = *k8sSharedWarmTarget
+		cli.AWSRegion = *awsRegion
+		cli.QueryLog = *queryLog
+		return cli
+	}
+}

--- a/configresolve/cliflags_test.go
+++ b/configresolve/cliflags_test.go
@@ -1,0 +1,193 @@
+package configresolve
+
+import (
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// envOnlyCLIInputsFields lists CLIInputs struct fields that are intentionally
+// not registered as CLI flags — they are populated from env vars only by
+// design. CLAUDE.md ("K8s pod scheduling knobs are env-only") owns this list.
+// If you add a flag for one of these, remove it from the set; if you add a
+// new env-only field to CLIInputs, add it here.
+var envOnlyCLIInputsFields = map[string]bool{
+	"K8sWorkerCPURequest":      true,
+	"K8sWorkerMemoryRequest":   true,
+	"K8sWorkerNodeSelector":    true,
+	"K8sWorkerTolerationKey":   true,
+	"K8sWorkerTolerationValue": true,
+	"K8sWorkerExclusiveNode":   true,
+}
+
+// fieldNameToFlagName converts a CLIInputs Go field name (PascalCase) into
+// the kebab-case flag name. The mapping follows the convention used in
+// root main.go and cliflags.go: insert hyphens between word boundaries,
+// lowercase everything, and apply specific rewrites for acronyms (TTL,
+// ACME, DNS, K8s, SNI, AWS, ID) so the generated names round-trip.
+func fieldNameToFlagName(name string) string {
+	// Acronym splits — the order matters: longer acronyms first so we
+	// don't accidentally split inside a longer match.
+	rewrites := []struct{ from, to string }{
+		{"DuckLakeDeltaCatalogEnabled", "ducklake-delta-catalog-enabled"},
+		{"DuckLakeDeltaCatalogPath", "ducklake-delta-catalog-path"},
+		{"DuckLakeDefaultSpecVersion", "ducklake-default-spec-version"},
+		{"FlightSessionIdleTTL", "flight-session-idle-ttl"},
+		{"FlightSessionReapInterval", "flight-session-reap-interval"},
+		{"FlightHandleIdleTTL", "flight-handle-idle-ttl"},
+		{"FlightSessionTokenTTL", "flight-session-token-ttl"},
+		{"FlightPort", "flight-port"},
+		{"K8sWorkerImagePullPolicy", "k8s-worker-image-pull-policy"},
+		{"K8sWorkerServiceAccount", "k8s-worker-service-account"},
+		{"K8sControlPlaneID", "k8s-control-plane-id"},
+		{"K8sWorkerNamespace", "k8s-worker-namespace"},
+		{"K8sWorkerConfigMap", "k8s-worker-configmap"},
+		{"K8sSharedWarmTarget", "k8s-shared-warm-target"},
+		{"K8sWorkerImage", "k8s-worker-image"},
+		{"K8sWorkerSecret", "k8s-worker-secret"},
+		{"K8sWorkerPort", "k8s-worker-port"},
+		{"K8sMaxWorkers", "k8s-max-workers"},
+		{"ACMEDNSProvider", "acme-dns-provider"},
+		{"ACMEDNSZoneID", "acme-dns-zone-id"},
+		{"ACMECacheDir", "acme-cache-dir"},
+		{"ACMEDomain", "acme-domain"},
+		{"ACMEEmail", "acme-email"},
+		{"AWSRegion", "aws-region"},
+		{"SNIRoutingMode", "sni-routing-mode"},
+		{"ManagedHostnameSuffixes", "managed-hostname-suffixes"},
+		{"ConfigStoreConn", "config-store"},
+		{"ConfigPollInterval", "config-poll-interval"},
+		{"InternalSecret", "internal-secret"},
+		{"WorkerBackend", "worker-backend"},
+		{"WorkerQueueTimeout", "worker-queue-timeout"},
+		{"WorkerIdleTimeout", "worker-idle-timeout"},
+		{"HandoverDrainTimeout", "handover-drain-timeout"},
+		{"ProcessMinWorkers", "process-min-workers"},
+		{"ProcessMaxWorkers", "process-max-workers"},
+		{"ProcessRetireOnSessionEnd", "process-retire-on-session-end"},
+		{"ProcessIsolation", "process-isolation"},
+		{"FilePersistence", "file-persistence"},
+		{"IdleTimeout", "idle-timeout"},
+		{"SessionInitTimeout", "session-init-timeout"},
+		{"MemoryLimit", "memory-limit"},
+		{"MemoryBudget", "memory-budget"},
+		{"MemoryRebalance", "memory-rebalance"},
+		{"MaxConnections", "max-connections"},
+		{"DataDir", "data-dir"},
+		{"CertFile", "cert"},
+		{"KeyFile", "key"},
+		{"QueryLog", "query-log"},
+		{"Threads", "threads"},
+		{"Host", "host"},
+		{"Port", "port"},
+	}
+	for _, rw := range rewrites {
+		if name == rw.from {
+			return rw.to
+		}
+	}
+	return strings.ToLower(name) // fallback; the test will fail if a new field misses a rewrite
+}
+
+// TestRegisterCLIInputsFlagsCoversEveryCLIBackedField guards against drift
+// between the CLIInputs struct and the flag registrar. Every CLI-backed
+// CLIInputs field must have a corresponding flag registered; every flag
+// registered by RegisterCLIInputsFlags must map to a CLIInputs field.
+func TestRegisterCLIInputsFlagsCoversEveryCLIBackedField(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	harvest := RegisterCLIInputsFlags(fs)
+
+	// Build the set of flag names that were registered.
+	registered := map[string]bool{}
+	fs.VisitAll(func(f *flag.Flag) {
+		registered[f.Name] = true
+	})
+
+	// Walk CLIInputs; every non-Set, non-env-only field must be registered.
+	cliType := reflect.TypeOf(CLIInputs{})
+	for i := 0; i < cliType.NumField(); i++ {
+		field := cliType.Field(i)
+		if field.Name == "Set" {
+			continue
+		}
+		if envOnlyCLIInputsFields[field.Name] {
+			continue
+		}
+		flagName := fieldNameToFlagName(field.Name)
+		if !registered[flagName] {
+			t.Errorf("CLIInputs field %s expects flag --%s but it was not registered by RegisterCLIInputsFlags", field.Name, flagName)
+		}
+	}
+
+	// Every registered flag name must map to a CLIInputs field.
+	cliFieldsByFlagName := map[string]string{}
+	for i := 0; i < cliType.NumField(); i++ {
+		field := cliType.Field(i)
+		if field.Name == "Set" {
+			continue
+		}
+		cliFieldsByFlagName[fieldNameToFlagName(field.Name)] = field.Name
+	}
+	for name := range registered {
+		if _, ok := cliFieldsByFlagName[name]; !ok {
+			t.Errorf("flag --%s is registered but no CLIInputs field maps to it", name)
+		}
+	}
+
+	// Harvest closure should not panic with an empty parse.
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cli := harvest()
+	if cli.Set == nil {
+		t.Error("harvested CLIInputs.Set is nil; expected initialized empty map")
+	}
+	if len(cli.Set) != 0 {
+		t.Errorf("harvested CLIInputs.Set should be empty after no-arg parse; got %v", cli.Set)
+	}
+}
+
+// TestRegisterCLIInputsFlagsHarvestPropagatesValuesAndSet exercises the
+// happy path: parse a few flags, confirm both the value field and the Set
+// map reflect what the CLI provided.
+func TestRegisterCLIInputsFlagsHarvestPropagatesValuesAndSet(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	harvest := RegisterCLIInputsFlags(fs)
+	if err := fs.Parse([]string{
+		"--port", "5433",
+		"--data-dir", "/tmp/duckgres-test",
+		"--memory-limit", "2GB",
+		"--query-log=false",
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cli := harvest()
+	if cli.Port != 5433 {
+		t.Errorf("Port: want 5433, got %d", cli.Port)
+	}
+	if cli.DataDir != "/tmp/duckgres-test" {
+		t.Errorf("DataDir: want /tmp/duckgres-test, got %q", cli.DataDir)
+	}
+	if cli.MemoryLimit != "2GB" {
+		t.Errorf("MemoryLimit: want 2GB, got %q", cli.MemoryLimit)
+	}
+	if cli.QueryLog != false {
+		t.Errorf("QueryLog: want false, got %v", cli.QueryLog)
+	}
+	for _, name := range []string{"port", "data-dir", "memory-limit", "query-log"} {
+		if !cli.Set[name] {
+			t.Errorf("Set[%q] should be true after explicit --%s", name, name)
+		}
+	}
+	if cli.Set["host"] {
+		t.Error("Set[host] should be false; --host was not provided")
+	}
+	// Default values should land on un-set fields.
+	if cli.Host != "" {
+		t.Errorf("Host should default to empty string; got %q", cli.Host)
+	}
+	if cli.Threads != 0 {
+		t.Errorf("Threads should default to 0; got %d", cli.Threads)
+	}
+}

--- a/internal/cliboot/metrics.go
+++ b/internal/cliboot/metrics.go
@@ -1,0 +1,38 @@
+package cliboot
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// InitMetrics starts the Prometheus metrics HTTP server on :9090/metrics
+// and returns the *http.Server so callers can shut it down during graceful
+// shutdown / handover. The listener loops on transient errors with a 1s
+// backoff — production duckgres processes have run into ephemeral port
+// rebinds during handover and we don't want metrics scraping to silently
+// die. Workers in --mode duckdb-service intentionally do NOT call this:
+// in K8s all worker pods would fight over :9090 since the control plane
+// owns the metrics endpoint there.
+func InitMetrics() *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{
+		Addr:    ":9090",
+		Handler: mux,
+	}
+	go func() {
+		for {
+			slog.Info("Starting metrics server", "addr", srv.Addr)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Warn("Metrics server error, retrying in 1s.", "error", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			return
+		}
+	}()
+	return srv
+}

--- a/justfile
+++ b/justfile
@@ -260,7 +260,7 @@ test:
 # Run unit tests only
 [group('test')]
 test-unit:
-    go test -v -p 1 . ./duckdbservice/... ./server/... ./transpiler/... ./internal/...
+    go test -v -p 1 . ./configresolve/... ./duckdbservice/... ./server/... ./transpiler/... ./internal/...
 
 # Run integration tests
 [group('test')]

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -19,7 +18,6 @@ import (
 	"github.com/posthog/duckgres/duckdbservice"
 	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // FileConfig is the YAML configuration schema, sourced from the
@@ -49,29 +47,6 @@ var (
 	env            = configloader.Env
 )
 
-// initMetrics starts the Prometheus metrics HTTP server on :9090/metrics.
-// Returns the http.Server instance so it can be shut down during handover.
-func initMetrics() *http.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	srv := &http.Server{
-		Addr:    ":9090",
-		Handler: mux,
-	}
-	go func() {
-		for {
-			slog.Info("Starting metrics server", "addr", srv.Addr)
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				slog.Warn("Metrics server error, retrying in 1s.", "error", err)
-				time.Sleep(1 * time.Second)
-				continue
-			}
-			return
-		}
-	}()
-	return srv
-}
-
 func main() {
 	// Ignore SIGPIPE to prevent DuckDB's C++ code (and libraries like libpq
 	// inside DuckLake) from crashing the process when a network connection
@@ -94,78 +69,24 @@ func main() {
 		return // RunChildMode calls os.Exit
 	}
 
-	// Define CLI flags with environment variable fallbacks
+	// CLIInputs-backed flags (host/port/data-dir/k8s-*/etc) live in
+	// configresolve so cmd/duckgres-controlplane can register the same set
+	// without two copies of the table drifting. The harvest closure
+	// produces a populated CLIInputs (with cli.Set) post-Parse.
+	harvestCLIInputs := configresolve.RegisterCLIInputsFlags(flag.CommandLine)
+
+	// Bespoke flags: not in CLIInputs because they don't flow through
+	// ResolveEffective. --mode/--repl/--psql/--socket-dir/--duckdb-* are
+	// consumed directly below; --config/--log-level/--version/--help are
+	// pre-resolver runtime knobs.
 	configFile := flag.String("config", env("DUCKGRES_CONFIG", ""), "Path to YAML config file (env: DUCKGRES_CONFIG)")
-	host := flag.String("host", "", "Host to bind to (env: DUCKGRES_HOST)")
-	port := flag.Int("port", 0, "Port to listen on (env: DUCKGRES_PORT)")
-	flightPort := flag.Int("flight-port", 0, "Control-plane Arrow Flight SQL ingress port, 0=disabled (env: DUCKGRES_FLIGHT_PORT)")
-	flightSessionIdleTTL := flag.String("flight-session-idle-ttl", "", "Flight auth session idle TTL (e.g., '10m') (env: DUCKGRES_FLIGHT_SESSION_IDLE_TTL)")
-	flightSessionReapInterval := flag.String("flight-session-reap-interval", "", "Flight auth session reap interval (e.g., '1m') (env: DUCKGRES_FLIGHT_SESSION_REAP_INTERVAL)")
-	flightHandleIdleTTL := flag.String("flight-handle-idle-ttl", "", "Flight prepared/query handle idle TTL (e.g., '15m') (env: DUCKGRES_FLIGHT_HANDLE_IDLE_TTL)")
-	flightSessionTokenTTL := flag.String("flight-session-token-ttl", "", "Flight issued session token absolute TTL (e.g., '1h') (env: DUCKGRES_FLIGHT_SESSION_TOKEN_TTL)")
-	dataDir := flag.String("data-dir", "", "Directory for DuckDB files (env: DUCKGRES_DATA_DIR)")
-	certFile := flag.String("cert", "", "TLS certificate file (env: DUCKGRES_CERT)")
-	keyFile := flag.String("key", "", "TLS private key file (env: DUCKGRES_KEY)")
-	filePersistence := flag.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
-	processIsolation := flag.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
-	idleTimeout := flag.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
-	sessionInitTimeout := flag.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
-	memoryLimit := flag.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
-	threads := flag.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")
-	memoryBudget := flag.String("memory-budget", "", "Total memory for all DuckDB sessions (e.g., '24GB') (env: DUCKGRES_MEMORY_BUDGET)")
-	memoryRebalance := flag.Bool("memory-rebalance", false, "Enable dynamic per-connection memory reallocation (control-plane mode) (env: DUCKGRES_MEMORY_REBALANCE)")
-	duckLakeDeltaCatalogEnabled := flag.Bool("ducklake-delta-catalog-enabled", false, "Attach a Delta Lake catalog during DuckLake worker boot (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED)")
-	duckLakeDeltaCatalogPath := flag.String("ducklake-delta-catalog-path", "", "Delta Lake catalog/table path to attach, defaults to sibling delta/ prefix at DuckLake object-store root (env: DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH)")
-	duckLakeDefaultSpecVersion := flag.String("ducklake-default-spec-version", "", "Default DuckLake spec version for migration checks (env: DUCKGRES_DUCKLAKE_DEFAULT_SPEC_VERSION)")
 	logLevel := flag.String("log-level", "", "Log level: debug, info, warn, error (env: DUCKGRES_LOG_LEVEL)")
 	repl := flag.Bool("repl", false, "Start an interactive SQL shell instead of the server")
 	psql := flag.Bool("psql", false, "Launch psql connected to the local Duckgres server")
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	showHelp := flag.Bool("help", false, "Show help message")
-
-	// Rate limiting flags
-	maxConnections := flag.Int("max-connections", 0, "Max concurrent connections, 0=unlimited (env: DUCKGRES_MAX_CONNECTIONS)")
-
-	// Control plane flags
 	mode := flag.String("mode", "standalone", "Run mode: standalone, control-plane, or duckdb-service")
-	processMinWorkers := flag.Int("process-min-workers", 0, "Pre-warm worker count at startup for process workers (control-plane mode) (env: DUCKGRES_PROCESS_MIN_WORKERS)")
-	processMaxWorkers := flag.Int("process-max-workers", 0, "Max process workers, 0=auto-derived (control-plane mode) (env: DUCKGRES_PROCESS_MAX_WORKERS)")
-	processRetireOnSessionEnd := flag.Bool("process-retire-on-session-end", false, "Retire a process worker immediately after its last session ends instead of keeping it warm for reuse (control-plane mode) (env: DUCKGRES_PROCESS_RETIRE_ON_SESSION_END)")
-	workerQueueTimeout := flag.String("worker-queue-timeout", "", "How long to wait for an available worker slot (e.g., '5m') (env: DUCKGRES_WORKER_QUEUE_TIMEOUT)")
-	workerIdleTimeout := flag.String("worker-idle-timeout", "", "How long to keep an idle worker alive (e.g., '5m') (env: DUCKGRES_WORKER_IDLE_TIMEOUT)")
-	handoverDrainTimeout := flag.String("handover-drain-timeout", "", "How long to wait for planned shutdowns/upgrades to drain before forcing exit (default: '24h' in process mode, '15m' in remote mode) (env: DUCKGRES_HANDOVER_DRAIN_TIMEOUT)")
 	socketDir := flag.String("socket-dir", "/var/run/duckgres", "Unix socket directory (control-plane mode)")
-	workerBackend := flag.String("worker-backend", "", "Worker backend: process (default) or remote for config-store-backed K8s multitenant mode (env: DUCKGRES_WORKER_BACKEND)")
-	k8sWorkerImage := flag.String("k8s-worker-image", "", "Container image for K8s worker pods (env: DUCKGRES_K8S_WORKER_IMAGE)")
-	k8sWorkerNamespace := flag.String("k8s-worker-namespace", "", "K8s namespace for worker pods (env: DUCKGRES_K8S_WORKER_NAMESPACE)")
-	k8sControlPlaneID := flag.String("k8s-control-plane-id", "", "Unique CP identifier for labeling worker pods (env: DUCKGRES_K8S_CONTROL_PLANE_ID)")
-	k8sWorkerPort := flag.Int("k8s-worker-port", 0, "gRPC port on K8s worker pods (default: 8816) (env: DUCKGRES_K8S_WORKER_PORT)")
-	k8sWorkerSecret := flag.String("k8s-worker-secret", "", "K8s Secret name for worker bearer token (env: DUCKGRES_K8S_WORKER_SECRET)")
-	k8sWorkerConfigMap := flag.String("k8s-worker-configmap", "", "ConfigMap name for worker duckgres.yaml (env: DUCKGRES_K8S_WORKER_CONFIGMAP)")
-	k8sWorkerImagePullPolicy := flag.String("k8s-worker-image-pull-policy", "", "Image pull policy for K8s worker pods: Always, IfNotPresent, Never (env: DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY)")
-	k8sWorkerServiceAccount := flag.String("k8s-worker-service-account", "", "Neutral ServiceAccount name for K8s worker pods (default: duckgres-worker) (env: DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT)")
-	k8sMaxWorkers := flag.Int("k8s-max-workers", 0, "Max K8s workers in the shared pool, 0=auto-derived (env: DUCKGRES_K8S_MAX_WORKERS)")
-	k8sSharedWarmTarget := flag.Int("k8s-shared-warm-target", 0, "Neutral shared warm-worker target for K8s multi-tenant mode, 0=disabled (env: DUCKGRES_K8S_SHARED_WARM_TARGET)")
-	awsRegion := flag.String("aws-region", "", "AWS region for STS client (env: DUCKGRES_AWS_REGION)")
-
-	// Config store flags (multi-tenant mode)
-	configStore := flag.String("config-store", "", "PostgreSQL connection string for config store (env: DUCKGRES_CONFIG_STORE)")
-	configPollInterval := flag.String("config-poll-interval", "", "How often to poll config store for changes (default: 30s) (env: DUCKGRES_CONFIG_POLL_INTERVAL)")
-	internalSecret := flag.String("internal-secret", "", "Shared secret for API authentication (env: DUCKGRES_INTERNAL_SECRET)")
-	sniRoutingMode := flag.String("sni-routing-mode", "", "Hostname-based org routing: 'off' (default), 'passthrough' (prefer SNI, log legacy), 'enforce' (reject without managed hostname). Multi-tenant only. (env: DUCKGRES_SNI_ROUTING_MODE)")
-	managedHostnameSuffixes := flag.String("managed-hostname-suffixes", "", "Comma-separated DNS suffixes (each starting with '.') treated as authoritative for org routing, e.g. '.dw.us.postwh.com'. (env: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES)")
-
-	// ACME/Let's Encrypt flags
-	acmeDomain := flag.String("acme-domain", "", "Domain for ACME/Let's Encrypt certificate (env: DUCKGRES_ACME_DOMAIN)")
-	acmeEmail := flag.String("acme-email", "", "Contact email for Let's Encrypt notifications (env: DUCKGRES_ACME_EMAIL)")
-	acmeCacheDir := flag.String("acme-cache-dir", "", "Directory for ACME certificate cache (env: DUCKGRES_ACME_CACHE_DIR)")
-	acmeDNSProvider := flag.String("acme-dns-provider", "", "DNS provider for ACME DNS-01 challenges, e.g. 'route53' (env: DUCKGRES_ACME_DNS_PROVIDER)")
-	acmeDNSZoneID := flag.String("acme-dns-zone-id", "", "Route53 hosted zone ID for ACME DNS-01 challenges (env: DUCKGRES_ACME_DNS_ZONE_ID)")
-
-	// Query log flags
-	queryLog := flag.Bool("query-log", true, "Enable/disable DuckLake query log (use --query-log=false to disable; env: DUCKGRES_QUERY_LOG_ENABLED)")
-
-	// DuckDB service flags
 	duckdbListen := flag.String("duckdb-listen", "", "DuckDB service listen address (duckdb-service mode, env: DUCKGRES_DUCKDB_LISTEN)")
 	duckdbListenFD := flag.Int("duckdb-listen-fd", 0, "Inherit a pre-bound listener FD instead of creating a new socket (duckdb-service mode, set by control plane)")
 	duckdbToken := flag.String("duckdb-token", "", "Bearer token for DuckDB service auth (duckdb-service mode, env: DUCKGRES_DUCKDB_TOKEN)")
@@ -235,12 +156,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Track explicitly-set CLI flags so precedence is consistent.
-	cliSet := make(map[string]bool)
-	flag.Visit(func(f *flag.Flag) {
-		cliSet[f.Name] = true
-	})
-
 	// Auto-detect duckgres.yaml if no config file was explicitly specified
 	if *configFile == "" {
 		if _, err := os.Stat("duckgres.yaml"); err == nil {
@@ -291,60 +206,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	resolved := configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{
-		Set:                         cliSet,
-		Host:                        *host,
-		Port:                        *port,
-		FlightPort:                  *flightPort,
-		FlightSessionIdleTTL:        *flightSessionIdleTTL,
-		FlightSessionReapInterval:   *flightSessionReapInterval,
-		FlightHandleIdleTTL:         *flightHandleIdleTTL,
-		FlightSessionTokenTTL:       *flightSessionTokenTTL,
-		DataDir:                     *dataDir,
-		CertFile:                    *certFile,
-		KeyFile:                     *keyFile,
-		FilePersistence:             *filePersistence,
-		ProcessIsolation:            *processIsolation,
-		IdleTimeout:                 *idleTimeout,
-		SessionInitTimeout:          *sessionInitTimeout,
-		MemoryLimit:                 *memoryLimit,
-		Threads:                     *threads,
-		MemoryBudget:                *memoryBudget,
-		MemoryRebalance:             *memoryRebalance,
-		DuckLakeDeltaCatalogEnabled: *duckLakeDeltaCatalogEnabled,
-		DuckLakeDeltaCatalogPath:    *duckLakeDeltaCatalogPath,
-		DuckLakeDefaultSpecVersion:  *duckLakeDefaultSpecVersion,
-		ProcessMinWorkers:           *processMinWorkers,
-		ProcessMaxWorkers:           *processMaxWorkers,
-		ProcessRetireOnSessionEnd:   *processRetireOnSessionEnd,
-		WorkerQueueTimeout:          *workerQueueTimeout,
-		WorkerIdleTimeout:           *workerIdleTimeout,
-		HandoverDrainTimeout:        *handoverDrainTimeout,
-		ACMEDomain:                  *acmeDomain,
-		ACMEEmail:                   *acmeEmail,
-		ACMECacheDir:                *acmeCacheDir,
-		ACMEDNSProvider:             *acmeDNSProvider,
-		ACMEDNSZoneID:               *acmeDNSZoneID,
-		MaxConnections:              *maxConnections,
-		ConfigStoreConn:             *configStore,
-		ConfigPollInterval:          *configPollInterval,
-		InternalSecret:              *internalSecret,
-		SNIRoutingMode:              *sniRoutingMode,
-		ManagedHostnameSuffixes:     *managedHostnameSuffixes,
-		WorkerBackend:               *workerBackend,
-		K8sWorkerImage:              *k8sWorkerImage,
-		K8sWorkerNamespace:          *k8sWorkerNamespace,
-		K8sControlPlaneID:           *k8sControlPlaneID,
-		K8sWorkerPort:               *k8sWorkerPort,
-		K8sWorkerSecret:             *k8sWorkerSecret,
-		K8sWorkerConfigMap:          *k8sWorkerConfigMap,
-		K8sWorkerImagePullPolicy:    *k8sWorkerImagePullPolicy,
-		K8sWorkerServiceAccount:     *k8sWorkerServiceAccount,
-		K8sMaxWorkers:               *k8sMaxWorkers,
-		K8sSharedWarmTarget:         *k8sSharedWarmTarget,
-		AWSRegion:                   *awsRegion,
-		QueryLog:                    *queryLog,
-	}, os.Getenv, func(msg string) {
+	resolved := configresolve.ResolveEffective(fileCfg, harvestCLIInputs(), os.Getenv, func(msg string) {
 		slog.Warn(msg)
 	})
 	cfg := resolved.Server
@@ -439,7 +301,7 @@ func main() {
 		return
 	}
 
-	metricsSrv := initMetrics()
+	metricsSrv := cliboot.InitMetrics()
 
 	// Create data directory if it doesn't exist
 	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {


### PR DESCRIPTION
## Summary

Wires `cmd/duckgres-controlplane` to actually run, and lifts the ~50 CLIInputs-backed flag declarations out of root `main.go` into a shared registrar so the two binaries can never drift on the resolver's CLI surface.

**`configresolve.RegisterCLIInputsFlags(*flag.FlagSet) func() CLIInputs`** registers every CLIInputs-backed CLI flag onto the provided FlagSet and returns a harvest closure that produces a populated `CLIInputs` (with `Set`) post-Parse. Each binary calls this then adds its own bespoke (b)-bucket flags. The new `TestRegisterCLIInputsFlagsCoversEveryCLIBackedField` test uses reflection to assert every CLIInputs field has a corresponding flag — adding a new field without a flag now fails CI loudly instead of silently doing nothing. The 6 env-only K8s pod-scheduling fields (CLAUDE.md-documented) are explicitly excluded by name.

**`cmd/duckgres-controlplane`** is no longer a stub. It:
- Registers the shared CLIInputs flags.
- Adds bespoke `--config`, `--log-level`, `--mode`, `--socket-dir`, `--version`, `--help`. (`--mode` accepts only `control-plane`; symmetric with `cmd/duckgres-worker`'s `--mode duckdb-service`. Loud rejection on misuse, exit 2.)
- Loads config, resolves via `configresolve.ResolveEffective`, ensures TLS certs (or hands off to ACME), starts the metrics server, builds `controlplane.ControlPlaneConfig`, and calls `controlplane.RunControlPlane`.
- Mirrors the all-in-one's `--mode control-plane` branch and **does not import `duckdbservice`** — CI guard #499 (`go list -deps ./cmd/duckgres-controlplane | grep duckdb-go` empty) is preserved.

**Root `main.go`** drops ~75 lines of inline `flag.*` declarations and the corresponding ~55-line `CLIInputs{...}` literal in favour of `harvestCLIInputs := configresolve.RegisterCLIInputsFlags(flag.CommandLine)` + `cli := harvestCLIInputs()`. Bespoke flags stay inline.

**`cliboot.InitMetrics`** is lifted from root `main.go` so both binaries share the Prometheus metrics-server bring-up loop with identical retry behaviour. The all-in-one binary calls it; the CP-only binary calls it; the worker correctly does not (workers in `--mode duckdb-service` would all fight over `:9090`).

`just test-unit` now also runs `./configresolve/...` so the drift guard fires on every CI pass.

## Why this exists
Phase B of the post-#521 validation pass concluded that two ~60-flag tables would inevitably drift over time, while the (b)-bucket of mode/runtime/transport flags doesn't fit a single unified registrar. The shape we landed — shared registrar for the (a) bucket, bespoke flags per binary for (b) — keeps the resolver's CLI surface honest without forcing unnatural coupling on `--mode`, `--repl`, `--psql`, `--duckdb-*`, etc.

This unblocks one of two latent gaps surfaced in the validation pass: `cmd/duckgres-controlplane` was a crash-loop stub in every matrix-CD image until now. Pre-existing `cmd/duckgres-worker` fixes (#521, #522) handle the worker side.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `just test-unit` green (now includes `./configresolve/...`)
- [x] `go test -count=1 ./controlplane/...` green
- [x] `TestRegisterCLIInputsFlagsCoversEveryCLIBackedField` passes — every CLI-backed CLIInputs field maps to a registered flag, every registered flag maps to a CLIInputs field
- [x] `TestRegisterCLIInputsFlagsHarvestPropagatesValuesAndSet` passes — values and `Set` map populated correctly post-Parse
- [x] CP binary `--version` / `--help` / `--mode standalone` (rejected) all behave correctly
- [x] CP binary smoke run with `--worker-backend process`: binds PG-wire (127.0.0.1:25432), serves Prometheus on :9090, accepts TCP handshake, generates self-signed certs
- [x] `go list -deps ./cmd/duckgres-controlplane | grep duckdb-go` is empty (CI guard #499 preserved)
- [ ] **Deferred to user-side**: validate the live multitenant CP picks up the new image after a fresh CD run

🤖 Generated with [Claude Code](https://claude.com/claude-code)