### PR TITLE
fix(cache-proxy): log forward-proxy non-GET requests + non-2xx responses

### DIFF
--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -349,9 +349,17 @@ func (p *CacheProxy) serveBody(w http.ResponseWriter, data []byte, rangeHeader, 
 
 // forwardUncached forwards a request to the origin without caching. Used for
 // HEAD and other non-GET methods that shouldn't consume cache space.
+//
+// Logs symmetrically with HandleProxy's GET path so a non-2xx PUT/POST
+// (e.g. an S3 501 on a parquet write) is visible in Loki — without this,
+// the non-cached path was a black hole and an upstream-rejected write
+// surfaced only as a DuckDB-side "HTTP code 501" with no proxy-side
+// breadcrumb to correlate against.
 func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
 	if err != nil {
+		slog.Warn("Forward-proxy request build failed.",
+			"method", r.Method, "url", r.URL.String(), "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -367,6 +375,8 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := p.client.Do(req)
 	if err != nil {
+		slog.Warn("Forward-proxy origin transport failed.",
+			"method", r.Method, "url", r.URL.String(), "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -380,8 +390,27 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(k, v)
 		}
 	}
+
+	// Capture the body for the log preview on non-2xx responses so the
+	// origin's error envelope (e.g. S3's <Error><Code>...</Code>...) is
+	// available without an additional debug round-trip. On 2xx we pass the
+	// body straight through to the client without buffering — successful
+	// writes can be large.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		w.WriteHeader(resp.StatusCode)
+		n, _ := io.Copy(w, resp.Body)
+		slog.Info("Forward-proxy served.",
+			"method", r.Method, "url", r.URL.String(),
+			"status", resp.StatusCode, "bytes", n)
+		return
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	slog.Warn("Forward-proxy origin returned non-2xx.",
+		"method", r.Method, "url", r.URL.String(),
+		"status", resp.StatusCode, "body_preview", previewBody(body))
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	_, _ = w.Write(body)
 }
 
 // HandlePeerHas responds to "do you have this cache key?" from peers.

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -1,14 +1,28 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+// captureSlog redirects slog.Default to a buffer for the duration of a test
+// and returns the buffer + a restore function. Used by the forward-uncached
+// logging tests to assert presence of the request/response log lines that
+// were missing pre-PR (every PUT/POST through the proxy was a black hole).
+func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	prev := slog.Default()
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return &buf, func() { slog.SetDefault(prev) }
+}
 
 // newTestProxy wires a CacheProxy with no peers and a tempdir-backed store.
 func newTestProxy(t *testing.T) *CacheProxy {
@@ -397,5 +411,95 @@ func TestServeBodyContentLength(t *testing.T) {
 	got, _ := io.ReadAll(rec.Body)
 	if string(got) != string(payload) {
 		t.Errorf("body = %q, want %q", got, payload)
+	}
+}
+
+// TestForwardUncachedLogsSuccess locks in the invariant that a successful
+// PUT/POST through the forward-proxy path produces a log line. Pre-PR this
+// path was completely silent, leaving operators with no proxy-side
+// breadcrumb to correlate against a downstream client error.
+func TestForwardUncachedLogsSuccess(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	proxy := newTestProxy(t)
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ack"))
+	})
+
+	rec := doForwardProxyRequest(proxy, http.MethodPut, originURL+"/b/k", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `msg="Forward-proxy served."`) {
+		t.Errorf("expected Forward-proxy served. log on success, got:\n%s", out)
+	}
+	if !strings.Contains(out, `method=PUT`) {
+		t.Errorf("expected method=PUT in log, got:\n%s", out)
+	}
+	if !strings.Contains(out, `status=200`) {
+		t.Errorf("expected status=200 in log, got:\n%s", out)
+	}
+}
+
+// TestForwardUncachedLogsNon2xxWithBodyPreview is the symptomatic case
+// the PR addresses: when an upstream rejects a PUT/POST (e.g. an S3
+// endpoint returning 501 Not Implemented for a parquet write), the proxy
+// must surface the status AND the response body preview so the
+// client-side "HTTP code 501" error has a matching server-side
+// breadcrumb. The previewBody helper truncates at 256 bytes to keep log
+// volume bounded.
+func TestForwardUncachedLogsNon2xxWithBodyPreview(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	proxy := newTestProxy(t)
+	originBody := `<?xml version="1.0"?><Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message></Error>`
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write([]byte(originBody))
+	})
+
+	rec := doForwardProxyRequest(proxy, http.MethodPut, originURL+"/b/k.parquet", nil)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", rec.Code)
+	}
+	if got := rec.Body.String(); got != originBody {
+		t.Errorf("body forwarded as %q, want verbatim origin XML", got)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `msg="Forward-proxy origin returned non-2xx."`) {
+		t.Errorf("expected non-2xx Warn, got:\n%s", out)
+	}
+	if !strings.Contains(out, `status=501`) {
+		t.Errorf("expected status=501, got:\n%s", out)
+	}
+	if !strings.Contains(out, `<Code>NotImplemented</Code>`) {
+		t.Errorf("expected origin XML <Code> prefix in body_preview, got:\n%s", out)
+	}
+}
+
+// TestForwardUncachedTruncatesLargeBodyInLog verifies previewBody is
+// applied — a multi-KiB error envelope must not flood log storage.
+func TestForwardUncachedTruncatesLargeBodyInLog(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	proxy := newTestProxy(t)
+	huge := strings.Repeat("X", 4096)
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(huge))
+	})
+
+	_ = doForwardProxyRequest(proxy, http.MethodPut, originURL+"/b/k", nil)
+
+	out := buf.String()
+	if !strings.Contains(out, `...(truncated)`) {
+		t.Errorf("expected previewBody truncation marker in log, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- ` forwardUncached `  (the path PUT/POST/DELETE/HEAD requests take through the cache proxy) had zero ` slog `  calls. It's now symmetric with ` HandleProxy ` 's GET path: ` Info ` /` Warn `  per request with method, url, status, and body preview on non-2xx.

## Why

The forward-proxy path is the only path DuckDB httpfs writes go through — every parquet upload, multipart-upload PUT, manifest write, etc. When something downstream surfaces a generic "HTTP code 501" error from httpfs, the natural debugging step is to look at the cache proxy log for the matching request. Pre-PR, the log was empty: ` forwardUncached `  did the request and copied the response with no log lines anywhere.

That's especially bad for non-2xx responses, where the upstream's response body (e.g. an S3 ` <Error><Code>NotImplemented</Code><Message>... ` ) was being forwarded to DuckDB but not surfaced in the proxy's logs at all. The client got ` HTTP code 501 `  and the operator was left guessing whether the proxy was even reached.

## Fix

` forwardUncached `  now mirrors the existing logging shape:

| Outcome | Level | Message | Attrs |
|---|---|---|---|
| 2xx success | Info | ` Forward-proxy served. ` | method, url, status, bytes |
| Non-2xx | Warn | ` Forward-proxy origin returned non-2xx. ` | method, url, status, body_preview |
| Request-build failure | Warn | ` Forward-proxy request build failed. ` | method, url, error |
| Transport failure (DNS/TLS/refused) | Warn | ` Forward-proxy origin transport failed. ` | method, url, error |

Body capture for the log is gated to non-2xx — successful writes can be tens of MB and still stream straight through ` io.Copy ` . Non-2xx bodies tend to be small XML envelopes, and the ` previewBody `  helper truncates at 256 B regardless.

## Test plan
- [x] ` TestForwardUncachedLogsSuccess `  — PUT through proxy, status 200, asserts ` Forward-proxy served. ` 
- [x] ` TestForwardUncachedLogsNon2xxWithBodyPreview `  — origin returns 501 + XML envelope, asserts the ` <Code>...</Code> ` prefix appears in the log line and the body is forwarded verbatim to the client
- [x] ` TestForwardUncachedTruncatesLargeBodyInLog `  — 4 KiB body shows ` ...(truncated) `  marker so log volume stays bounded
- [x] Existing ` ./cmd/cache-proxy/ `  tests green