### PR TITLE
fix(cache-proxy): log HTTPS CONNECT tunnel lifecycle

### DIFF
--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -96,38 +96,82 @@ func (p *CacheProxy) shouldCache(r *http.Request) bool {
 // handleConnect tunnels an HTTPS CONNECT request. We don't cache — just copy
 // bytes between client and origin. Required because SET GLOBAL http_proxy
 // makes DuckDB tunnel all HTTPS through us, including external sources.
+//
+// What we CAN log: tunnel open (Info), dial / hijack errors (Warn / Error),
+// final byte counts and duration on close (Info). What we CANNOT log: the
+// actual HTTP request / response inside the tunnel — TLS terminates between
+// the worker and the origin, so the encrypted bytes flowing past us are
+// opaque. An S3 501 with an XML error envelope going through CONNECT is
+// invisible to us at the body level; only "CONNECT to s3:443 → N bytes
+// in / M bytes out / closed in T ms" is recoverable.
+//
+// We log this anyway because a black hole is worse than a partial trail —
+// at least we can confirm a request was attempted, see the target host,
+// and spot dial failures. For full request/response visibility on writes,
+// DuckDB has to actually use plain HTTP via forwardUncached (s3_use_ssl =
+// false), which httpfs has been observed ignoring for some PUT paths.
 func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
-	upstream, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	connectStart := time.Now()
+	target := r.Host
+	upstream, err := net.DialTimeout("tcp", target, 10*time.Second)
 	if err != nil {
+		slog.Warn("Forward-proxy CONNECT dial failed.", "target", target, "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		_ = upstream.Close()
+		slog.Error("Forward-proxy CONNECT hijack unsupported.", "target", target)
 		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
 		return
 	}
 	client, _, err := hijacker.Hijack()
 	if err != nil {
 		_ = upstream.Close()
+		slog.Warn("Forward-proxy CONNECT hijack failed.", "target", target, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		_ = upstream.Close()
 		_ = client.Close()
+		slog.Warn("Forward-proxy CONNECT 200 write failed.", "target", target, "error", err)
 		return
 	}
+	slog.Info("Forward-proxy CONNECT opened.", "target", target)
+
+	// Track byte counts in both directions and emit a single closed log
+	// once both legs finish, so a single CONNECT produces exactly one
+	// opened + one closed pair with the bytes transferred. Wait on both
+	// goroutines so the close-log fires once, not racy.
+	var sentToUpstream, recvFromUpstream int64
+	upstreamDone := make(chan struct{})
+	clientDone := make(chan struct{})
+
 	go func() {
-		defer func() { _ = upstream.Close() }()
-		defer func() { _ = client.Close() }()
-		_, _ = io.Copy(upstream, client)
+		defer close(upstreamDone)
+		n, _ := io.Copy(upstream, client)
+		sentToUpstream = n
+		_ = upstream.Close()
+		_ = client.Close()
 	}()
 	go func() {
-		defer func() { _ = upstream.Close() }()
-		defer func() { _ = client.Close() }()
-		_, _ = io.Copy(client, upstream)
+		defer close(clientDone)
+		n, _ := io.Copy(client, upstream)
+		recvFromUpstream = n
+		_ = upstream.Close()
+		_ = client.Close()
+	}()
+
+	go func() {
+		<-upstreamDone
+		<-clientDone
+		slog.Info("Forward-proxy CONNECT closed.",
+			"target", target,
+			"sent_bytes", sentToUpstream,
+			"recv_bytes", recvFromUpstream,
+			"duration_ms", time.Since(connectStart).Milliseconds())
 	}()
 }
 

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // captureSlog redirects slog.Default to a buffer for the duration of a test
@@ -480,6 +483,147 @@ func TestForwardUncachedLogsNon2xxWithBodyPreview(t *testing.T) {
 	}
 	if !strings.Contains(out, `<Code>NotImplemented</Code>`) {
 		t.Errorf("expected origin XML <Code> prefix in body_preview, got:\n%s", out)
+	}
+}
+
+// TestHandleConnectLogsOpenAndClose drives a real HTTPS CONNECT tunnel
+// through the proxy and asserts that:
+//
+//   - "Forward-proxy CONNECT opened." fires when the tunnel is established;
+//   - "Forward-proxy CONNECT closed." fires once both legs finish, with the
+//     correct sent/recv byte counts.
+//
+// Without this, every HTTPS-routed write through the proxy (which is the
+// path AWS S3 PUT/POST uses by default) was invisible in proxy-side logs.
+// The client still got error codes from upstream, but operators couldn't
+// confirm the request even reached the proxy.
+func TestHandleConnectLogsOpenAndClose(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	// Origin: simple echo server that reflects exactly the bytes it reads.
+	originDone := make(chan struct{})
+	origin, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("origin listen: %v", err)
+	}
+	defer func() { _ = origin.Close() }()
+	go func() {
+		defer close(originDone)
+		c, err := origin.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, 16)
+		n, _ := c.Read(buf)
+		if n > 0 {
+			_, _ = c.Write(buf[:n])
+		}
+	}()
+
+	// Proxy: wrap HandleProxy in an httptest server. CONNECT requests go
+	// through Go's standard server hijack path, which is what the real
+	// cache-proxy does in production.
+	proxy := newTestProxy(t)
+	proxySrv := httptest.NewServer(http.HandlerFunc(proxy.HandleProxy))
+	defer proxySrv.Close()
+	proxyURL, _ := url.Parse(proxySrv.URL)
+
+	// Hand-craft the CONNECT exchange over a raw TCP connection — the
+	// stdlib Transport hides CONNECT inside its HTTPS path, but for unit
+	// testing we want the bytes-on-the-wire visibility.
+	pconn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = pconn.Close() }()
+
+	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", origin.Addr().String(), origin.Addr().String())
+	if _, err := pconn.Write([]byte(connectReq)); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+
+	// Read the proxy's "200 Connection Established" response line + headers.
+	resp := make([]byte, 256)
+	n, err := pconn.Read(resp)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if !strings.Contains(string(resp[:n]), "200") {
+		t.Fatalf("expected 200 from proxy, got %q", string(resp[:n]))
+	}
+
+	payload := []byte("ping-bytes")
+	if _, err := pconn.Write(payload); err != nil {
+		t.Fatalf("write tunnel payload: %v", err)
+	}
+	echo := make([]byte, len(payload))
+	if _, err := io.ReadFull(pconn, echo); err != nil {
+		t.Fatalf("read tunnel echo: %v", err)
+	}
+	if string(echo) != string(payload) {
+		t.Fatalf("tunnel echo = %q, want %q", echo, payload)
+	}
+
+	// Close the client side; this should propagate to both io.Copy
+	// goroutines and trigger the "closed" log emission.
+	_ = pconn.Close()
+	<-originDone
+
+	// The "closed" log fires from a separate goroutine after both legs
+	// finish; poll briefly so the test isn't flaky.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), `Forward-proxy CONNECT closed.`) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `msg="Forward-proxy CONNECT opened."`) {
+		t.Errorf("expected open log, got:\n%s", out)
+	}
+	if !strings.Contains(out, `msg="Forward-proxy CONNECT closed."`) {
+		t.Errorf("expected close log, got:\n%s", out)
+	}
+	if !strings.Contains(out, fmt.Sprintf(`target=%s`, origin.Addr().String())) {
+		t.Errorf("expected target= attr matching origin addr, got:\n%s", out)
+	}
+}
+
+// TestHandleConnectLogsDialFailure: when the upstream is unreachable, the
+// proxy must respond 502 to the client AND emit a Warn so the failure is
+// visible in proxy-side logs.
+func TestHandleConnectLogsDialFailure(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	proxy := newTestProxy(t)
+	proxySrv := httptest.NewServer(http.HandlerFunc(proxy.HandleProxy))
+	defer proxySrv.Close()
+	proxyURL, _ := url.Parse(proxySrv.URL)
+
+	pconn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = pconn.Close() }()
+
+	// 127.0.0.1:1 is reserved/unbound — kernel rejects the dial fast.
+	connectReq := "CONNECT 127.0.0.1:1 HTTP/1.1\r\nHost: 127.0.0.1:1\r\n\r\n"
+	if _, err := pconn.Write([]byte(connectReq)); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+	resp := make([]byte, 256)
+	n, _ := pconn.Read(resp)
+	if !strings.Contains(string(resp[:n]), "502") {
+		t.Fatalf("expected 502 on dial failure, got %q", string(resp[:n]))
+	}
+
+	if !strings.Contains(buf.String(), `Forward-proxy CONNECT dial failed.`) {
+		t.Errorf("expected dial-failed Warn, got:\n%s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add Info ` Forward-proxy CONNECT opened. `  / ` closed. `  log lines (with target, byte counts, duration), and Warn on dial/hijack failures.
- ` handleConnect `  was previously a black hole — the prior PR added logging to ` forwardUncached `  but missed the CONNECT path that HTTPS-routed S3 traffic takes.

## Why
The session-level ` SET GLOBAL s3_use_ssl = false `  is supposed to keep all S3 traffic on plain HTTP through ` forwardUncached `  / ` HandleProxy ` , but DuckDB httpfs has been observed ignoring that flag for some PUT/POST paths and tunnelling via HTTPS CONNECT instead. That meant a write that downstream surfaced as a generic ` HTTP code 501 `  produced **zero** proxy-side log lines — operators couldn't even confirm the request reached the proxy, let alone what the target host or byte counts were.

## What we get / don't get
What we get from CONNECT logging:
- ` Forward-proxy CONNECT opened. `  / ` closed. `  with ` target= ` , ` sent_bytes= ` , ` recv_bytes= ` , ` duration_ms= ` 
- Warn on dial / hijack / 200-write failures with the underlying error

What we explicitly **cannot** get (called out in the code comment):
- The actual HTTP request inside the tunnel (URL, headers, body) — TLS terminates between the worker and the origin, so the encrypted bytes flowing past us are opaque
- The HTTP status the origin returned
- The response body (e.g. an S3 ` <Error><Code>NotImplemented</Code>... `  XML envelope)

For full request/response visibility on writes, the worker has to actually keep using plain HTTP via ` forwardUncached ` . That's a separate investigation (why does httpfs ignore ` s3_use_ssl=false `  for some paths?) — out of scope for this PR. But logging the tunnel anyway is still a big win: dial failures, mis-routed targets, and the "did the request even reach the proxy" question are all answerable now.

## Test plan
- [x] ` TestHandleConnectLogsOpenAndClose `  — drives a real CONNECT exchange through the proxy against a TCP echo origin, asserts both open + close logs and the ` target= `  attribute
- [x] ` TestHandleConnectLogsDialFailure `  — CONNECT to an unbound port, asserts 502 is returned and the dial-failed Warn fires
- [x] Existing ` ./cmd/cache-proxy/ `  tests green