### PR TITLE
fix(cache-proxy): forward inbound body framing transparently

### DIFF
--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -399,6 +399,22 @@ func (p *CacheProxy) serveBody(w http.ResponseWriter, data []byte, rangeHeader, 
 // the non-cached path was a black hole and an upstream-rejected write
 // surfaced only as a DuckDB-side "HTTP code 501" with no proxy-side
 // breadcrumb to correlate against.
+//
+// Transparency: the proxy must not silently mutate the request shape DuckDB
+// chose, because AWS Sigv4 signs `host;x-amz-content-sha256;x-amz-date` (see
+// duckdb-httpfs/src/s3fs.cpp:84) — which means Content-Length and
+// Transfer-Encoding are NOT signed and we're free to set them, but we
+// should match what the client sent so the wire shape is preserved.
+//
+// The bug we're fixing here: http.NewRequestWithContext only auto-populates
+// req.ContentLength when the body is *bytes.Buffer / *bytes.Reader /
+// *strings.Reader (per its docstring). For a generic io.ReadCloser like
+// http.Request.Body, ContentLength stays 0 and Go's Transport falls back
+// to Transfer-Encoding: chunked on the outbound. AWS S3 returns
+// 501 NotImplemented for chunked PUT — so even though DuckDB sent a clean
+// Content-Length-bearing PUT, the proxy was rewriting it as chunked and
+// S3 rejected it. The fix is to mirror ContentLength + TransferEncoding +
+// Trailer from the inbound request so the proxy is wire-shape-transparent.
 func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
 	if err != nil {
@@ -407,6 +423,11 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	// Mirror body-framing fields the inbound request had so Go's Transport
+	// sends the same encoding (Content-Length vs chunked) as DuckDB chose.
+	req.ContentLength = r.ContentLength
+	req.TransferEncoding = r.TransferEncoding
+	req.Trailer = r.Trailer
 	for k, vv := range r.Header {
 		if hopByHop[strings.ToLower(k)] {
 			continue

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -647,3 +647,249 @@ func TestForwardUncachedTruncatesLargeBodyInLog(t *testing.T) {
 		t.Errorf("expected previewBody truncation marker in log, got:\n%s", out)
 	}
 }
+
+// TestForwardUncachedPropagatesContentLength is the regression test for the
+// AWS S3 "501 Not Implemented" error on parquet PUTs. The proxy used to
+// build its outbound request via http.NewRequestWithContext with the
+// inbound r.Body as the body — and because r.Body is a generic
+// io.ReadCloser (not one of the *bytes.Buffer / *bytes.Reader /
+// *strings.Reader types Go auto-detects), Go's Transport saw ContentLength=0
+// and fell back to Transfer-Encoding: chunked. S3 rejects chunked PUT with
+// 501 even though DuckDB sent a perfectly valid Content-Length-bearing
+// request. After the fix, the outbound request must carry over the inbound's
+// ContentLength so the wire shape is preserved.
+func TestForwardUncachedPropagatesContentLength(t *testing.T) {
+	proxy := newTestProxy(t)
+	payload := []byte("parquet-bytes-of-known-length")
+
+	var (
+		gotMethod        string
+		gotContentLength int64
+		gotTE            string
+		gotBody          []byte
+	)
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentLength = r.ContentLength
+		gotTE = r.Header.Get("Transfer-Encoding")
+		// httputil sometimes also strips Transfer-Encoding into r.TransferEncoding
+		if gotTE == "" && len(r.TransferEncoding) > 0 {
+			gotTE = strings.Join(r.TransferEncoding, ",")
+		}
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, originURL+"/b/k.parquet", bytes.NewReader(payload))
+	req.Host = req.URL.Host
+	// httptest.NewRequest only auto-sets ContentLength for the special body
+	// types; do it explicitly so we're modeling the inbound shape DuckDB
+	// uses (Content-Length present, no Transfer-Encoding).
+	req.ContentLength = int64(len(payload))
+	rec := httptest.NewRecorder()
+
+	proxy.HandleProxy(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("origin saw method %q, want PUT", gotMethod)
+	}
+	if gotContentLength != int64(len(payload)) {
+		t.Errorf("origin saw ContentLength=%d, want %d (proxy not propagating)", gotContentLength, len(payload))
+	}
+	if gotTE == "chunked" {
+		t.Errorf("origin saw Transfer-Encoding: chunked — proxy is rewriting Content-Length-bearing PUTs as chunked, AWS S3 returns 501 for this")
+	}
+	if !bytes.Equal(gotBody, payload) {
+		t.Errorf("body mismatch:\n  got:  %q\n  want: %q", gotBody, payload)
+	}
+}
+
+// TestForwardUncachedPreservesRequestHeaders verifies that arbitrary
+// non-hop-by-hop request headers (Authorization, x-amz-*, custom) round-trip
+// to the origin unchanged. Critical for AWS Sigv4: any header in the signed
+// list (host;x-amz-content-sha256;x-amz-date) being mutated would invalidate
+// the signature; the rest still matter for content addressability.
+func TestForwardUncachedPreservesRequestHeaders(t *testing.T) {
+	proxy := newTestProxy(t)
+	want := map[string]string{
+		"Authorization":        "AWS4-HMAC-SHA256 Credential=AKIA/...",
+		"X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD",
+		"X-Amz-Date":           "20260505T120000Z",
+		"X-Amz-Security-Token": "FwoGZ...",
+		"Content-Type":         "application/octet-stream",
+		"X-Custom-Header":      "verbatim",
+	}
+
+	got := map[string]string{}
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		for k := range want {
+			got[k] = r.Header.Get(k)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, originURL+"/b/k", bytes.NewReader([]byte("x")))
+	req.Host = req.URL.Host
+	req.ContentLength = 1
+	for k, v := range want {
+		req.Header.Set(k, v)
+	}
+
+	proxy.HandleProxy(httptest.NewRecorder(), req)
+
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("header %s: got %q, want %q", k, got[k], w)
+		}
+	}
+}
+
+// TestForwardUncachedStripsHopByHopBothDirections verifies that
+// hop-by-hop headers (per RFC 7230 §6.1) are NOT forwarded in either
+// direction. Forwarding hop-by-hop headers can confuse origin / client
+// parsers — Connection, Keep-Alive, TE, Trailers, Transfer-Encoding,
+// Upgrade, Proxy-Authorization, Proxy-Authenticate.
+func TestForwardUncachedStripsHopByHopBothDirections(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	var originSawConnection, originSawKeepAlive string
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		originSawConnection = r.Header.Get("Connection")
+		originSawKeepAlive = r.Header.Get("Keep-Alive")
+		w.Header().Set("Connection", "should-not-leak")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Allowed", "yes")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, originURL+"/b/k", bytes.NewReader([]byte("x")))
+	req.Host = req.URL.Host
+	req.ContentLength = 1
+	req.Header.Set("Connection", "close")
+	req.Header.Set("Keep-Alive", "timeout=5")
+	rec := httptest.NewRecorder()
+
+	proxy.HandleProxy(rec, req)
+
+	if originSawConnection != "" {
+		t.Errorf("origin saw Connection header from inbound, hop-by-hop should be stripped: %q", originSawConnection)
+	}
+	if originSawKeepAlive != "" {
+		t.Errorf("origin saw Keep-Alive header from inbound, hop-by-hop should be stripped: %q", originSawKeepAlive)
+	}
+	if got := rec.Header().Get("Connection"); got != "" {
+		t.Errorf("client saw response Connection header from origin, hop-by-hop should be stripped: %q", got)
+	}
+	if got := rec.Header().Get("Keep-Alive"); got != "" {
+		t.Errorf("client saw response Keep-Alive header, hop-by-hop should be stripped: %q", got)
+	}
+	if got := rec.Header().Get("X-Allowed"); got != "yes" {
+		t.Errorf("client lost non-hop-by-hop response header X-Allowed: %q", got)
+	}
+}
+
+// TestForwardUncachedPreservesQueryString covers AWS S3 multipart-upload
+// query params (?uploads, ?partNumber=N&uploadId=...). Sigv4's canonical
+// request includes the query string, so any mutation would 403.
+func TestForwardUncachedPreservesQueryString(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	var gotQuery string
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	})
+
+	url := originURL + "/b/k.parquet?uploads=&partNumber=3&uploadId=ABC%3DDEF"
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte("x")))
+	req.Host = req.URL.Host
+	req.ContentLength = 1
+	proxy.HandleProxy(httptest.NewRecorder(), req)
+
+	if gotQuery != "uploads=&partNumber=3&uploadId=ABC%3DDEF" {
+		t.Errorf("query mutated:\n  got:  %q\n  want: %q", gotQuery, "uploads=&partNumber=3&uploadId=ABC%3DDEF")
+	}
+}
+
+// TestForwardUncachedPreservesResponseBodyBytewise locks in that 2xx
+// response bodies are forwarded byte-for-byte (no compression / no
+// transcoding). DuckDB downstream may parse this as XML / parquet and
+// any mutation would corrupt it.
+func TestForwardUncachedPreservesResponseBodyBytewise(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	originBody := []byte("\x00\x01\x02\x03 binary <xml/> body \xff\xfe")
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(originBody)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, originURL+"/b/k", bytes.NewReader([]byte("x")))
+	req.Host = req.URL.Host
+	req.ContentLength = 1
+	rec := httptest.NewRecorder()
+	proxy.HandleProxy(rec, req)
+
+	if !bytes.Equal(rec.Body.Bytes(), originBody) {
+		t.Errorf("response body mutated:\n  got:  %q\n  want: %q", rec.Body.Bytes(), originBody)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type lost: got %q", got)
+	}
+}
+
+// TestForwardUncachedPreservesNon2xxResponseBodyBytewise covers the
+// log-preview path on non-2xx — the proxy reads the full body for the
+// body_preview log attr, but must still forward it verbatim to the client.
+// Specifically the AWS S3 XML error envelope has to reach DuckDB so its
+// own error parsing can extract the <Code>...</Code>.
+func TestForwardUncachedPreservesNon2xxResponseBodyBytewise(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	originBody := []byte(`<?xml version="1.0"?><Error><Code>NotImplemented</Code><Message>foo</Message></Error>`)
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write(originBody)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, originURL+"/b/k", bytes.NewReader([]byte("x")))
+	req.Host = req.URL.Host
+	req.ContentLength = 1
+	rec := httptest.NewRecorder()
+	proxy.HandleProxy(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), originBody) {
+		t.Errorf("non-2xx body mutated:\n  got:  %q\n  want: %q", rec.Body.Bytes(), originBody)
+	}
+}
+
+// TestForwardUncachedPreservesMethod walks every method that hits the
+// non-GET path and checks the origin saw the same method. Ensures we
+// don't accidentally specialise on PUT/POST and break HEAD/DELETE/etc.
+func TestForwardUncachedPreservesMethod(t *testing.T) {
+	for _, method := range []string{http.MethodPut, http.MethodPost, http.MethodDelete, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			proxy := newTestProxy(t)
+			var gotMethod string
+			_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(method, originURL+"/b/k", bytes.NewReader([]byte("x")))
+			req.Host = req.URL.Host
+			req.ContentLength = 1
+			proxy.HandleProxy(httptest.NewRecorder(), req)
+			if gotMethod != method {
+				t.Errorf("method mutated: got %q, want %q", gotMethod, method)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- One-line behavioural fix: ` forwardUncached `  now mirrors ` ContentLength `  / ` TransferEncoding `  / ` Trailer `  from the inbound request to the outbound, so the proxy stops rewriting Content-Length-bearing PUTs as chunked Transfer-Encoding.
- Six new transparency tests asserting the proxy is invisible to both client and origin (headers, query, body bytes, method, hop-by-hop strip, status pass-through).

## Why

Investigating the AWS S3 ` 501 Not Implemented `  error on parquet writes turned out to be a goose chase through duckdb-httpfs and DuckLake — only to find the actual root cause in our own forward proxy.

The chain:

1. DuckDB httpfs sends ` PUT ... Content-Length: N ... `  correctly (httplib's ` send_with_content_provider `  takes the ` (body, content_length) `  branch which sets ` Content-Length ` , not chunked — see ` httplib.hpp:9531-9532 ` ).
2. Our cache proxy receives that request. Inbound ` r.ContentLength == N ` , ` r.Body `  is the request body reader.
3. ` forwardUncached `  builds the outbound request with:
   ` ` ` go
   req, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
   ` ` ` 
4. Per [Go's docs for ` NewRequestWithContext ` ](https://pkg.go.dev/net/http#NewRequestWithContext):
   > When body is of type ` *bytes.Buffer ` , ` *bytes.Reader ` , or ` *strings.Reader ` , the returned request's ContentLength is set [...]. For other types, the default is left as 0; the body is then sent using chunked transfer encoding.
5. ` r.Body `  is a generic ` io.ReadCloser ` , not one of those special types. So ` req.ContentLength `  stays ` 0 `  and Go's ` Transport `  falls back to ` Transfer-Encoding: chunked `  on the outbound.
6. AWS S3 returns ` 501 NotImplemented `  for chunked PUT/POST, regardless of whether the client wanted chunked.

So even though DuckDB sent a clean Content-Length PUT, the proxy was rewriting it as chunked and S3 rejected it. The original ` flight execute update: ... HTTP code 501 `  errors users were seeing originated entirely from the proxy.

## Fix

` ` ` go
req.ContentLength = r.ContentLength
req.TransferEncoding = r.TransferEncoding
req.Trailer = r.Trailer
` ` ` 

That's it. The wire shape DuckDB chose now flows through unchanged.

**Sigv4 safety**: I verified in ` duckdb-httpfs/src/s3fs.cpp:84 `  that the signed headers list is ` host;x-amz-content-sha256;x-amz-date `  — neither ` Content-Length `  nor ` Transfer-Encoding `  is signed. So this change can never invalidate a Sigv4 signature.

## What's NOT in this PR (deliberately)

I audited the rest of ` forwardUncached `  for hidden mutations and found these are still present, but I left them alone because they're either correct or intentional:

| Behaviour | Verdict |
|---|---|
| Hop-by-hop headers stripped per RFC 7230 §6.1 | Correct (and now tested). |
| ` req.Host = r.Host `  preserved | Correct (and now tested). |
| Query string preserved via ` r.URL.String() `  | Correct (and now tested). |
| Method preserved | Correct (and now tested). |
| 2xx response body streamed via ` io.Copy `  without buffering | Correct (large parquet downloads stay efficient). |
| Non-2xx response body buffered for log preview, then forwarded byte-for-byte | Intentional — gives us the S3 XML error envelope in Loki. Body still reaches client unchanged. |

## Test plan

The new tests assert "the proxy is invisible to client and origin" by checking each property:

- [x] ` TestForwardUncachedPropagatesContentLength `  — regression test for the bug. **Verified that with the fix reverted the test fails** showing ` origin saw ContentLength=-1 `  and ` Transfer-Encoding: chunked ` .
- [x] ` TestForwardUncachedPreservesRequestHeaders `  — Authorization / x-amz-* / x-amz-date / x-amz-security-token / Content-Type / arbitrary custom headers all reach the origin verbatim.
- [x] ` TestForwardUncachedStripsHopByHopBothDirections `  — Connection / Keep-Alive are stripped both inbound and outbound; non-hop-by-hop headers (e.g. ` X-Allowed ` ) pass through.
- [x] ` TestForwardUncachedPreservesQueryString `  — multipart-upload query (` ?uploads=&partNumber=3&uploadId=ABC%3DDEF ` ) round-trips exactly, including URL encoding.
- [x] ` TestForwardUncachedPreservesResponseBodyBytewise `  — 2xx response body containing binary + XML bytes (` \x00\x01... \xff\xfe ` ) reaches the client byte-for-byte.
- [x] ` TestForwardUncachedPreservesNon2xxResponseBodyBytewise `  — the buffer-then-forward path for non-2xx (used for log preview) still passes the S3 ` <Error><Code>... `  envelope verbatim to DuckDB.
- [x] ` TestForwardUncachedPreservesMethod `  — PUT / POST / DELETE / HEAD all reach origin unchanged.
- [x] Existing ` ./cmd/cache-proxy/ `  tests green.
- [ ] After deploy: a fresh write produces ` Forward-proxy served. method=PUT status=200 `  in cache-proxy logs.

Followup to #516 / #518 / #519 / #524 / #525 / #526.