### PR TITLE
ci: smoke-test pushed worker + controlplane images before manifest

### DIFF
--- a/.github/workflows/container-image-controlplane-cd.yml
+++ b/.github/workflows/container-image-controlplane-cd.yml
@@ -80,6 +80,64 @@ jobs:
                   cache-from: type=gha,scope=cp-${{ steps.slug.outputs.arch }}
                   cache-to: type=gha,mode=max,scope=cp-${{ steps.slug.outputs.arch }}
 
+            # Smoke test the freshly-pushed image. Same shape as the
+            # worker-cd smoke step (which see for full rationale): pull
+            # from GHCR, run the binary on the runner's native arch, assert
+            # `--version` works, then boot the binary in process-backend
+            # control-plane mode and confirm "Control plane listening" lands
+            # in the logs within 30s. If smoke fails the dependent
+            # `manifest` job is skipped so the unsuffixed multi-arch tag
+            # never gets produced.
+            - name: Smoke test pushed image
+              env:
+                  IMAGE: ${{ env.GHCR_REGISTRY }}/posthog/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ steps.slug.outputs.arch }}
+                  EXPECTED_VERSION: build-${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  docker pull "$IMAGE"
+
+                  echo "::group::--version"
+                  out=$(docker run --rm "$IMAGE" --version)
+                  echo "$out"
+                  if ! grep -qF "duckgres version $EXPECTED_VERSION" <<<"$out"; then
+                      echo "✗ --version output did not include 'duckgres version $EXPECTED_VERSION'"
+                      exit 1
+                  fi
+                  echo "✓ --version OK"
+                  echo "::endgroup::"
+
+                  echo "::group::boot smoke"
+                  docker run -d --name cp-smoke "$IMAGE" \
+                      --mode control-plane \
+                      --host 127.0.0.1 \
+                      --port 25432 \
+                      --socket-dir /tmp/sockets \
+                      --process-min-workers 0 \
+                      --process-max-workers 1
+                  trap 'docker rm -f cp-smoke >/dev/null 2>&1 || true' EXIT
+
+                  status=fail
+                  for i in $(seq 1 30); do
+                      if ! docker ps --format '{{.Names}}' | grep -qx cp-smoke; then
+                          echo "✗ cp-smoke exited before listening:"
+                          docker logs cp-smoke 2>&1 | tail -80
+                          break
+                      fi
+                      if docker logs cp-smoke 2>&1 | grep -q "Control plane listening"; then
+                          echo "✓ cp reached 'Control plane listening' after ${i}s"
+                          docker logs cp-smoke 2>&1 | tail -20
+                          status=ok
+                          break
+                      fi
+                      sleep 1
+                  done
+                  if [ "$status" != "ok" ] && [ "$i" = "30" ]; then
+                      echo "✗ cp did not log 'Control plane listening' within 30s"
+                      docker logs cp-smoke 2>&1 | tail -80
+                  fi
+                  echo "::endgroup::"
+                  [ "$status" = "ok" ]
+
     manifest:
         name: Multi-arch manifest controlplane
         needs: build

--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -103,6 +103,68 @@ jobs:
                   cache-from: type=gha,scope=worker-${{ matrix.duckdb.version }}-${{ matrix.platform.slug }}
                   cache-to: type=gha,mode=max,scope=worker-${{ matrix.duckdb.version }}-${{ matrix.platform.slug }}
 
+            # Smoke test the freshly-pushed image. We pull from GHCR (cheaper
+            # than ECR) and run the binary on the runner's native arch, so no
+            # qemu is needed. Two assertions:
+            #   1. `--version` exits 0 and prints the expected build identity.
+            #      Catches stub-binary regressions like the pre-#521 exit-1
+            #      stub that shipped to ECR for weeks before being noticed.
+            #   2. The binary boots with the same arg shape the K8s pool
+            #      hardcodes (`--mode duckdb-service --duckdb-listen :8816`)
+            #      and reaches the "Starting DuckDB service" log line within
+            #      30s. Catches flag.Parse regressions like the missing
+            #      `--mode` flag fixed in #522, and any boot-time linkage
+            #      failure that only manifests at runtime.
+            # If smoke fails for any matrix cell, the dependent `manifest`
+            # job is skipped (default `needs:` behavior), so the unsuffixed
+            # multi-arch tag is never produced and downstream Charts dispatch
+            # never picks up a broken image.
+            - name: Smoke test pushed image
+              env:
+                  IMAGE: ${{ env.GHCR_REGISTRY }}/posthog/${{ env.IMAGE_NAME }}:${{ github.sha }}-duckdb${{ matrix.duckdb.version }}-${{ matrix.platform.slug }}
+                  EXPECTED_VERSION: build-${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  docker pull "$IMAGE"
+
+                  echo "::group::--version"
+                  out=$(docker run --rm "$IMAGE" --version)
+                  echo "$out"
+                  if ! grep -qF "duckgres version $EXPECTED_VERSION" <<<"$out"; then
+                      echo "✗ --version output did not include 'duckgres version $EXPECTED_VERSION'"
+                      exit 1
+                  fi
+                  echo "✓ --version OK"
+                  echo "::endgroup::"
+
+                  echo "::group::boot smoke"
+                  docker run -d --name worker-smoke "$IMAGE" \
+                      --mode duckdb-service \
+                      --duckdb-listen :8816
+                  trap 'docker rm -f worker-smoke >/dev/null 2>&1 || true' EXIT
+
+                  status=fail
+                  for i in $(seq 1 30); do
+                      if ! docker ps --format '{{.Names}}' | grep -qx worker-smoke; then
+                          echo "✗ worker-smoke exited before listening:"
+                          docker logs worker-smoke 2>&1 | tail -80
+                          break
+                      fi
+                      if docker logs worker-smoke 2>&1 | grep -q "Starting DuckDB service"; then
+                          echo "✓ worker reached 'Starting DuckDB service' after ${i}s"
+                          docker logs worker-smoke 2>&1 | tail -20
+                          status=ok
+                          break
+                      fi
+                      sleep 1
+                  done
+                  if [ "$status" != "ok" ] && [ "$i" = "30" ]; then
+                      echo "✗ worker did not log 'Starting DuckDB service' within 30s"
+                      docker logs worker-smoke 2>&1 | tail -80
+                  fi
+                  echo "::endgroup::"
+                  [ "$status" = "ok" ]
+
     manifest:
         name: Multi-arch manifest worker ${{ matrix.duckdb.version }}
         needs: build


### PR DESCRIPTION
## Summary

Adds a smoke-test step to the per-arch build jobs in both
`container-image-worker-cd.yml` and `container-image-controlplane-cd.yml`. After each image is pushed to ECR + GHCR but before the multi-arch manifest job runs, the runner pulls from GHCR, executes the image on its native arch (no qemu), and asserts:

1. **`--version` exits 0 and prints `duckgres version build-<sha>`** — catches stub-binary regressions like the pre-#521 exit-1 stub that shipped to ECR for weeks before being noticed.
2. **The binary boots with the K8s-shape arg list and reaches its "service listening" log line within 30s** — catches `flag.Parse` regressions like the missing `--mode` flag fixed in #522, and any boot-time linkage failure that only manifests at runtime.

   - Worker: `--mode duckdb-service --duckdb-listen :8816` → grep for `Starting DuckDB service`
   - CP: `--mode control-plane --host 127.0.0.1 --port 25432 --socket-dir /tmp/sockets --process-min-workers 0 --process-max-workers 1` → grep for `Control plane listening`

If smoke fails for any matrix cell, the dependent `manifest` job is skipped via the default `needs:` behavior, so the unsuffixed multi-arch tag is never produced and downstream Charts dispatch / tenant-image pinning never picks up a broken image. Per-arch failures don't fail-fast across the matrix (`fail-fast: false` is unchanged) so a single arch issue still surfaces all the others' results.

## Why this exists
The Phase A4 validation pass after #521 surfaced that the matrix CD pipeline has been pushing broken `cmd/duckgres-worker` and `cmd/duckgres-controlplane` images for weeks — first as exit-1 stubs (pre-#521 / pre-CP-wiring), then briefly as exit-2 stubs from the missing `--mode` flag (#521-only, fixed in #522). Nothing in CD verified the image actually started, so the issue went undetected. This PR closes that observability gap.

The smoke test is the highest-leverage process fix because it would have caught **both** of the bugs the validation pass found, and any future regression of the same shape (stub binary, missing-flag crash, broken libduckdb link, etc).

## Test plan
- [x] YAML validity confirmed (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Local sanity: ran the worker binary with the same arg shape (`--mode duckdb-service --duckdb-listen :18816`) — confirmed `Starting DuckDB service` lands in stderr within ~70ms (well under the 30s budget)
- [x] Local sanity: equivalent CP binary smoke run earlier in this arc confirmed `Control plane listening` log line works
- [x] Both Dockerfiles run as `duckgres` user with writable `/app/data` + `/app/certs`, so the smoke commands succeed inside the container with default flags
- [ ] **Will know post-merge**: the actual GitHub Actions runs against a real merge sha. The first CD run after this lands is the proof.

## Notes for the reviewer
- Pulling from GHCR not ECR — GHCR is faster from GitHub runners and we just pushed there in the previous step. ECR is still pushed; not testing it directly is a deliberate trade-off.
- arm64 cells run on `ubuntu-24.04-arm` (native arm64 runner) so smoke runs natively without qemu.
- The smoke step does NOT block on long-running behavior (no real query execution, no DuckLake attach). Goal is "the binary started" not "the binary is functionally correct" — feature correctness is owned by the existing integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)