### PR TITLE
fix(worker): make concurrent same-payload activations idempotent

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -110,13 +110,30 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	if p.workerID > 0 && payload.WorkerID != p.workerID {
 		return fmt.Errorf("stale worker_id %d (current %d)", payload.WorkerID, p.workerID)
 	}
+	// Idempotent same-payload check FIRST, before the epoch guard. This is
+	// the dup-call race: two concurrent ActivateTenant goroutines can both
+	// pass Phase 1 (currentOwnerEpoch=0), both run Phase 2 (the slow
+	// activateDBConnection), then race Phase 3. Whichever lands second
+	// observes p.ownerEpoch already bumped to its own payload value and,
+	// without this early-return, would fall through to the epoch guard
+	// below and return "stale owner epoch N (current N)" — even though
+	// the activation it intended to commit is *byte-identical* to the one
+	// already committed. The CP would then treat the failure as fatal and
+	// retire a perfectly-good worker (rollout-race incident on dev
+	// 2026-05-05).
+	//
+	// Genuine takeover races (different cp_instance_ids / different
+	// payloads) still fall through to the epoch guard and are arbitrated
+	// by "highest epoch wins" as before.
+	if p.activation != nil &&
+		sameTenantActivationRuntime(p.activation.payload, payload) &&
+		reflect.DeepEqual(p.activation.payload, payload) {
+		return nil
+	}
 	if payload.OwnerEpoch <= p.ownerEpoch {
 		return fmt.Errorf("stale owner epoch %d (current %d)", payload.OwnerEpoch, p.ownerEpoch)
 	}
 	if p.activation != nil {
-		if sameTenantActivationRuntime(p.activation.payload, payload) && reflect.DeepEqual(p.activation.payload, payload) {
-			return nil
-		}
 		return fmt.Errorf("worker already activated for org %q", p.activation.payload.OrgID)
 	}
 

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -483,3 +483,128 @@ func TestReuseExistingActivationDoesNotBlockHealthChecks(t *testing.T) {
 		t.Fatalf("expected ownerEpoch=2 after refresh, got %d", pool.ownerEpoch)
 	}
 }
+
+// TestConcurrentActivateTenantSamePayloadBothSucceed reproduces the
+// rollout-race seen on dev 2026-05-05: a single CP can issue two
+// ActivateTenant RPCs concurrently for the same warm worker (e.g. one from
+// startup reconciliation + one from an inbound session-create), with
+// identical payloads. Both pass Phase 1's epoch check (currentOwnerEpoch
+// is still 0), both run the slow Phase 2 (activateDBConnection — the
+// ATTACH DUCKLAKE / SET DEFAULT CATALOG sequence), then race Phase 3.
+//
+// In the buggy ordering, Phase 3's first guard is
+//
+//	if payload.OwnerEpoch <= p.ownerEpoch { return "stale owner epoch" }
+//
+// so the second call observes p.ownerEpoch already bumped to its own
+// payload value by the first call's commit and fails before reaching the
+// `if p.activation != nil` idempotency branch. The CP then treats the
+// failure as fatal, retires the worker, and we lose a perfectly-good
+// just-activated worker — even though the FIRST call succeeded.
+//
+// The fix is to check idempotency before the epoch guard: if the
+// committed activation has the exact same payload, return nil — these are
+// concurrent same-payload calls, not a takeover.
+//
+// Without the worker-side fix, this test fails with one goroutine seeing
+// `stale owner epoch N (current N)`.
+func TestConcurrentActivateTenantSamePayloadBothSucceed(t *testing.T) {
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		cfg:            server.Config{Users: map[string]string{"postgres": "postgres"}},
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return PairFromMain(db), nil
+	}
+
+	// activateDBConnection is the slow Phase 2. We block it until BOTH
+	// goroutines have entered, then release them simultaneously. That
+	// forces both to observe `currentOwnerEpoch=0` in their Phase 1 RLock
+	// and leaves Phase 3 acquisition order as the only race source —
+	// exactly the production race where two concurrent paths overlap.
+	const N = 2
+	bothEntered := make(chan struct{}, N)
+	releasePhase2 := make(chan struct{})
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		bothEntered <- struct{}{}
+		<-releasePhase2
+		return nil
+	}
+
+	payload := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{
+			OwnerEpoch:   1,
+			CPInstanceID: "cp-live:boot-a",
+			WorkerID:     17,
+		},
+		OrgID: "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore: "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:   "s3://analytics/warehouse/",
+		},
+	}
+
+	errs := make(chan error, N)
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- pool.activateTenant(payload)
+		}()
+	}
+
+	// Wait for both goroutines to be parked at the start of Phase 2.
+	for i := 0; i < N; i++ {
+		select {
+		case <-bothEntered:
+		case <-time.After(2 * time.Second):
+			close(releasePhase2)
+			t.Fatalf("timed out waiting for both goroutines to enter Phase 2 (got %d of %d)", i, N)
+		}
+	}
+	// Both have observed identical pre-Phase-1 state. Release them; they
+	// race Phase 3 next.
+	close(releasePhase2)
+	wg.Wait()
+	close(errs)
+
+	var failures []error
+	for err := range errs {
+		if err != nil {
+			failures = append(failures, err)
+		}
+	}
+	if len(failures) != 0 {
+		t.Fatalf("expected both concurrent same-payload activations to succeed, %d failed:\n%v\n\n"+
+			"This is the rollout-race symptom: two concurrent ActivateTenant RPCs for the same\n"+
+			"worker race Phase 3 commit, the epoch check fires before the idempotency check,\n"+
+			"the second call returns 'stale owner epoch N (current N)' even though its payload\n"+
+			"is identical to the just-committed activation.",
+			len(failures), failures)
+	}
+
+	// Final state check — exactly one activation committed, with our payload.
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	if pool.activation == nil {
+		t.Fatal("expected activation to be set after concurrent activations")
+	}
+	if pool.ownerEpoch != payload.OwnerEpoch {
+		t.Errorf("ownerEpoch = %d, want %d", pool.ownerEpoch, payload.OwnerEpoch)
+	}
+	if pool.workerID != payload.WorkerID {
+		t.Errorf("workerID = %d, want %d", pool.workerID, payload.WorkerID)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 3 of ` activateTenant `  in ` duckdbservice/activation.go `  used to fire its epoch guard before its idempotency check, so two concurrent same-payload calls left the second call returning ` stale owner epoch N (current N) ` .
- Reorder so the idempotency case (` p.activation != nil &&  reflect.DeepEqual(p.activation.payload, payload) ` ) returns nil first; only then does the epoch guard run.
- New test reproduces the race deterministically — verified failing on the pre-fix code with the exact production error string.

## Why

Observed on dev during a CP rollout: a single warm worker received TWO complete activations within 65 ms of each other (visible as two ` Set DuckLake as default catalog `  lines on the worker), and the CP then retired the worker because the second call returned ` stale owner epoch 2 (current 2) ` :

` ` ` 
13:28:37.089  worker: Attaching DuckLake catalog with data path...
13:28:37.251  worker: Set DuckLake as default catalog.       ← first activation finishing
13:28:37.316  worker: Set DuckLake as default catalog.       ← SECOND activation finishing
13:28:37.323  CP: Worker activation failed. error="stale owner epoch 2 (current 2)"
13:28:37.327  CP: Retiring K8s worker. id=7573
13:28:37.373  worker: Shutting down DuckDB service...
` ` ` 

Why two activations from one session-create? CP-side reconciliation race during rollout — the new pod's startup reconcile and an inbound session-create both fire ` ActivateTenant `  for the same warm worker, with byte-identical payloads. Both pass Phase 1's epoch check (p.ownerEpoch is still 0), both run the slow Phase 2 ATTACH-DUCKLAKE block, then race Phase 3:

` ` ` go
// Phase 3 (BEFORE):
p.mu.Lock()
defer p.mu.Unlock()
if p.workerID > 0 && payload.WorkerID != p.workerID { ... }
if payload.OwnerEpoch <= p.ownerEpoch {                     // ← fires first
    return fmt.Errorf("stale owner epoch %d (current %d)", ...)
}
if p.activation != nil {
    if sameTenantActivationRuntime(...) && reflect.DeepEqual(p.activation.payload, payload) {
        return nil                                          // ← never reached
    }
    return fmt.Errorf("worker already activated for org %q", ...)
}
` ` ` 

Whichever goroutine commits first sets ` p.ownerEpoch=2 `  and ` p.activation ` . The second wakes up to find ` p.ownerEpoch `  already at its target value, trips the epoch guard, and returns the stale-epoch error — even though the activation it intended to commit is byte-identical to the one that just landed. The CP marks the activation failed and retires the worker (rolling back a successful activation).

## Fix

Run the idempotency check before the epoch guard:

` ` ` go
// Phase 3 (AFTER):
p.mu.Lock()
defer p.mu.Unlock()
if p.workerID > 0 && payload.WorkerID != p.workerID { ... }
if p.activation != nil &&
    sameTenantActivationRuntime(p.activation.payload, payload) &&
    reflect.DeepEqual(p.activation.payload, payload) {
    return nil                                              // dup-call → no-op
}
if payload.OwnerEpoch <= p.ownerEpoch { ... }              // takeover guard, only for genuinely-different payloads
if p.activation != nil { ... }
// commit
` ` ` 

### Behavioral matrix

| Scenario | Before | After |
|---|---|---|
| Same CP, dup call, same payload, ` p.ownerEpoch == payload.OwnerEpoch ` | ` stale owner epoch ` | nil (dup-call no-op) |
| Different CPs racing, different ` cp_instance_id ` , higher epoch wins | epoch guard fires, lower-epoch loses | epoch guard fires, lower-epoch loses (unchanged) |
| Single fresh activation, ` p.activation == nil ` | commits | commits (unchanged) |
| Different tenant payload, ` p.activation != nil ` | "worker already activated for org X" | "worker already activated for org X" (unchanged) |

The only behavior change is the dup-call case becoming a no-op success.

## Test plan
- [x] ` TestConcurrentActivateTenantSamePayloadBothSucceed `  — spins two goroutines at ` activateTenant `  with identical payloads, blocks both at the Phase 2 boundary via a stub ` activateDBConnection ` , releases simultaneously, asserts both return nil and a single activation is committed. **Confirmed this fails on master with the exact production error string** (` stale owner epoch 1 (current 1) ` ) — i.e. the test would catch a regression.
- [x] 20-iteration ` -race `  stress on the new test passes.
- [x] Existing ` ./duckdbservice/ `  ` ./controlplane/ `  ` ./server/ `  suites green.