### PR TITLE
fix(ci): worker smoke test — provide TLS certs + tighten error check

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -137,22 +137,57 @@ jobs:
                   echo "✓ --version OK"
                   echo "::endgroup::"
 
+                  # Worker's TCP listen path requires TLS — duckdbservice.Serve
+                  # always loads certs from cfg.TLSCertFile/KeyFile (default
+                  # ./certs/server.crt + .key) when listener.Network()=="tcp".
+                  # In prod the K8s pool mounts these via a Secret. For smoke
+                  # we generate an ephemeral self-signed pair and bind-mount
+                  # it; DUCKGRES_CERT / DUCKGRES_KEY env feed configresolve.
+                  # Without this, the binary boots far enough to log
+                  # "Starting DuckDB service" then dies in Serve(), which
+                  # the prior version of this step false-passed under (see
+                  # PR #528 follow-up).
+                  echo "::group::generate ephemeral TLS pair"
+                  CERT_DIR="$(mktemp -d)"
+                  openssl req -x509 -newkey rsa:2048 -nodes \
+                      -keyout "$CERT_DIR/server.key" \
+                      -out "$CERT_DIR/server.crt" \
+                      -days 1 -subj '/CN=worker-smoke' >/dev/null 2>&1
+                  chmod 644 "$CERT_DIR"/server.crt "$CERT_DIR"/server.key
+                  echo "::endgroup::"
+
                   echo "::group::boot smoke"
-                  docker run -d --name worker-smoke "$IMAGE" \
+                  docker run -d --name worker-smoke \
+                      -v "$CERT_DIR:/etc/worker-smoke-tls:ro" \
+                      -e DUCKGRES_CERT=/etc/worker-smoke-tls/server.crt \
+                      -e DUCKGRES_KEY=/etc/worker-smoke-tls/server.key \
+                      "$IMAGE" \
                       --mode duckdb-service \
                       --duckdb-listen :8816
-                  trap 'docker rm -f worker-smoke >/dev/null 2>&1 || true' EXIT
+                  trap 'docker rm -f worker-smoke >/dev/null 2>&1 || true; rm -rf "$CERT_DIR"' EXIT
 
+                  # Three exit paths: ok, container-exited, 30s timeout.
+                  # The level=ERROR substring check defends against the race
+                  # where the binary logs "Starting DuckDB service" and then
+                  # crashes inside Serve() before docker ps notices — the
+                  # previous version of this step false-passed under that
+                  # exact pattern.
                   status=fail
                   for i in $(seq 1 30); do
-                      if ! docker ps --format '{{.Names}}' | grep -qx worker-smoke; then
-                          echo "✗ worker-smoke exited before listening:"
-                          docker logs worker-smoke 2>&1 | tail -80
+                      logs=$(docker logs worker-smoke 2>&1)
+                      if grep -q "level=ERROR" <<<"$logs"; then
+                          echo "✗ worker logged level=ERROR before reaching ready state:"
+                          tail -80 <<<"$logs"
                           break
                       fi
-                      if docker logs worker-smoke 2>&1 | grep -q "Starting DuckDB service"; then
+                      if ! docker ps --format '{{.Names}}' | grep -qx worker-smoke; then
+                          echo "✗ worker-smoke exited before listening:"
+                          tail -80 <<<"$logs"
+                          break
+                      fi
+                      if grep -q "Starting DuckDB service" <<<"$logs"; then
                           echo "✓ worker reached 'Starting DuckDB service' after ${i}s"
-                          docker logs worker-smoke 2>&1 | tail -20
+                          tail -20 <<<"$logs"
                           status=ok
                           break
                       fi

--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -149,6 +149,12 @@ jobs:
                   # PR #528 follow-up).
                   echo "::group::generate ephemeral TLS pair"
                   CERT_DIR="$(mktemp -d)"
+                  # `-nodes` (skip private key encryption) is required: Go's
+                  # tls.LoadX509KeyPair expects an unencrypted PEM. The cert
+                  # lives in CI for ~30s, is never published, never reused,
+                  # and protects nothing real — so the unencrypted key is
+                  # the desired property here, not a vulnerability.
+                  # nosemgrep: trailofbits.generic.openssl-insecure-flags.openssl-insecure-flags
                   openssl req -x509 -newkey rsa:2048 -nodes \
                       -keyout "$CERT_DIR/server.key" \
                       -out "$CERT_DIR/server.crt" \


### PR DESCRIPTION
## Summary

Fixes the worker smoke step landed in #528. The first real CD run after #528 merged (`bbf912f`) revealed two related issues:

1. **All four worker matrix cells actually crashed at startup** with `load worker RPC TLS certificates: open ./certs/server.crt: no such file or directory`. `duckdbservice.Serve` unconditionally loads TLS certs from `cfg.TLSCertFile/KeyFile` when the listener is TCP. In K8s prod the pod spec mounts these via a Secret; the smoke step didn't, so the binary booted far enough to log `Starting DuckDB service` then died in `Serve()`.

2. **Three of four cells correctly failed smoke; one false-passed.** The wait loop's `docker ps` check at iteration 1 caught the container-exited state for three cells. For 1.5.1/arm64 it didn't — the container was still listed as running when iteration 1 ran (binary hadn't fully unwound), the `Starting DuckDB service` log line had already landed, `status=ok`, false pass.

## Two-part fix

1. **Provide certs.** Pre-generate an ephemeral self-signed pair via `openssl` on the runner, bind-mount into the container, set `DUCKGRES_CERT` / `DUCKGRES_KEY` env vars. `configresolve.ResolveEffective` writes them into `cfg.TLSCertFile / TLSKeyFile`. Mirrors the K8s pool's Secret-mount contract.

2. **Tighten the wait loop with a `level=ERROR` substring check.** Runs before the `docker ps` and success-grep checks, so any error logged at any point during the wait window fails smoke. Defends against the same race re-emerging if a future regression introduces a post-log-line crash.

## Local validation
- ✅ With certs mounted: clean boot, port listens, no errors. (`Worker pre-warmed successfully. duration=40ms` then `Starting DuckDB service`.)
- ✅ Without certs (reproducing the CD failure): `level=ERROR` appears right after `Starting DuckDB service` — the new check catches it.
- ✅ YAML valid (`yaml.safe_load`).

## Why CP wasn't fixed
- CP smoke passed cleanly in the same CD run (`cmd/duckgres-controlplane` auto-generates certs via `server.EnsureCertificates`).
- Adding the same `level=ERROR` defense-in-depth there is a separate concern, scope-creep against this fix.

## Test plan
- [x] YAML valid
- [x] Local smoke with cert mount: clean boot
- [x] Local smoke without cert mount: produces the exact `level=ERROR` line the new check looks for
- [x] Diff scope: 1 file, +40/-5
- [ ] **Will know post-merge**: next CD run (or `workflow_dispatch`) is the proof. Expect all four matrix cells to pass smoke and the manifest job to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)