### PR TITLE
fix(ci): chmod 755 worker-smoke cert dir so container UID can traverse

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -159,6 +159,11 @@ jobs:
                       -keyout "$CERT_DIR/server.key" \
                       -out "$CERT_DIR/server.crt" \
                       -days 1 -subj '/CN=worker-smoke' >/dev/null 2>&1
+                  # mktemp -d defaults to 0700, which the container's
+                  # non-root duckgres UID can't traverse via the bind
+                  # mount → "permission denied" loading the cert. 0755 on
+                  # the dir + 0644 on the files lets any UID read.
+                  chmod 755 "$CERT_DIR"
                   chmod 644 "$CERT_DIR"/server.crt "$CERT_DIR"/server.key
                   echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

Worker smoke from #530 generated certs in a `mktemp -d` directory (default `0700`) and bind-mounted it into the container. The container's non-root `duckgres` UID can't traverse a `0700` host dir via bind mount, so the worker crashed at TLS load with:

```
load worker RPC TLS certificates: open /etc/worker-smoke-tls/server.crt: permission denied
```

One-line fix: `chmod 755 "$CERT_DIR"` immediately after `openssl`.

## What worked, what didn't, in #530
- ✅ `level=ERROR` substring check from #530 worked perfectly: caught the failure consistently across **all four** matrix cells (no false-pass this time, race fix confirmed).
- ✅ TLS cert mount approach is correct — verified locally inside the actual container that the worker boots cleanly with this fix.
- ❌ #530 missed the dir-perm gate. My local validation in #530 ran the worker binary directly as my host user against my own `mktemp -d`, which trivially passed; the bind-mount-via-container-UID gate was the unmet assumption.

## Local validation (this time, in container)
- Pulled `ghcr.io/posthog/duckgres-worker:a5402196...-duckdb1.5.2-arm64` (the failing image).
- With `0700` dir: exact same `level=ERROR` line as CI.
- With `0755` dir + `644` files: `Worker pre-warmed successfully` (~72ms), `Starting DuckDB service`, container `Up`.

## Test plan
- [x] YAML valid
- [x] Failure mode reproduced locally with the actual published failing image
- [x] Fix verified locally with the same docker run + bind mount sequence the smoke step uses
- [x] Diff scope: 1 file, +5 lines (chmod + one rationale comment)
- [ ] **Will know post-merge**: next CD run is the proof. Expect all four matrix cells to pass smoke and the manifest job to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)