### PR TITLE
feat(controlplane): per-org passthrough users

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -125,7 +125,7 @@ type apiStore interface {
 	ListUsers() ([]configstore.OrgUser, error)
 	CreateUser(user *configstore.OrgUser) error
 	GetUser(orgID, username string) (*configstore.OrgUser, error)
-	UpdateUser(orgID, username, passwordHash string) (*configstore.OrgUser, bool, error)
+	UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error)
 	DeleteUser(orgID, username string) (bool, error)
 
 	GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error)
@@ -248,10 +248,25 @@ func (s *gormAPIStore) GetUser(orgID, username string) (*configstore.OrgUser, er
 	return &user, nil
 }
 
-func (s *gormAPIStore) UpdateUser(orgID, username, passwordHash string) (*configstore.OrgUser, bool, error) {
+func (s *gormAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error) {
 	updates := map[string]interface{}{}
 	if passwordHash != "" {
 		updates["password"] = passwordHash
+	}
+	if passthrough != nil {
+		updates["passthrough"] = *passthrough
+	}
+	if len(updates) == 0 {
+		// Nothing to change — return the current row so callers can still
+		// distinguish "user not found" from "no-op update".
+		user, err := s.GetUser(orgID, username)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		return user, true, nil
 	}
 	result := s.db().Model(&configstore.OrgUser{}).Where("org_id = ? AND username = ?", orgID, username).Updates(updates)
 	if result.Error != nil {
@@ -807,9 +822,10 @@ func (h *apiHandler) listUsers(c *gin.Context) {
 func (h *apiHandler) createUser(c *gin.Context) {
 	// Use a raw struct because OrgUser.Password has json:"-"
 	var raw struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
-		OrgID    string `json:"org_id"`
+		Username    string `json:"username"`
+		Password    string `json:"password"`
+		OrgID       string `json:"org_id"`
+		Passthrough bool   `json:"passthrough"`
 	}
 	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -829,9 +845,10 @@ func (h *apiHandler) createUser(c *gin.Context) {
 		return
 	}
 	user := configstore.OrgUser{
-		Username: raw.Username,
-		Password: hash,
-		OrgID:    raw.OrgID,
+		Username:    raw.Username,
+		Password:    hash,
+		OrgID:       raw.OrgID,
+		Passthrough: raw.Passthrough,
 	}
 	if err := h.store.CreateUser(&user); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
@@ -854,8 +871,11 @@ func (h *apiHandler) getUser(c *gin.Context) {
 func (h *apiHandler) updateUser(c *gin.Context) {
 	orgID := c.Param("id")
 	username := c.Param("username")
+	// Passthrough is *bool so omitting it preserves the stored value; sending
+	// `false` explicitly clears the flag.
 	var raw struct {
-		Password string `json:"password"`
+		Password    string `json:"password"`
+		Passthrough *bool  `json:"passthrough,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -870,7 +890,7 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 		}
 		passwordHash = hash
 	}
-	user, ok, err := h.store.UpdateUser(orgID, username, passwordHash)
+	user, ok, err := h.store.UpdateUser(orgID, username, passwordHash, raw.Passthrough)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -109,7 +109,7 @@ func (s *fakeAPIStore) GetUser(orgID, username string) (*configstore.OrgUser, er
 	return &clone, nil
 }
 
-func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string) (*configstore.OrgUser, bool, error) {
+func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error) {
 	key := orgID + "/" + username
 	user, ok := s.users[key]
 	if !ok {
@@ -117,6 +117,9 @@ func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string) (*config
 	}
 	if passwordHash != "" {
 		user.Password = passwordHash
+	}
+	if passthrough != nil {
+		user.Passthrough = *passthrough
 	}
 	clone := *user
 	return &clone, true, nil
@@ -1114,6 +1117,110 @@ func TestPatchTenantPinningReturnsNotFoundForMissingOrg(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestCreateUserPersistsPassthroughFlag(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"org_id":"analytics","username":"raw","password":"hunter2","passthrough":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	stored := store.users["analytics/raw"]
+	if stored == nil {
+		t.Fatal("user not stored")
+	}
+	if !stored.Passthrough {
+		t.Errorf("Passthrough = false, want true")
+	}
+}
+
+func TestCreateUserDefaultsPassthroughFalse(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"org_id":"analytics","username":"alice","password":"hunter2"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	stored := store.users["analytics/alice"]
+	if stored == nil {
+		t.Fatal("user not stored")
+	}
+	if stored.Passthrough {
+		t.Error("Passthrough = true, want false (default)")
+	}
+}
+
+func TestUpdateUserClearsPassthroughWithoutTouchingPassword(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.users["analytics/raw"] = &configstore.OrgUser{
+		OrgID:       "analytics",
+		Username:    "raw",
+		Password:    "stored-hash",
+		Passthrough: true,
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"passthrough":false}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/raw", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.users["analytics/raw"]
+	if stored.Passthrough {
+		t.Error("Passthrough not cleared")
+	}
+	if stored.Password != "stored-hash" {
+		t.Errorf("Password = %q, want preserved %q", stored.Password, "stored-hash")
+	}
+}
+
+func TestUpdateUserOmittingPassthroughPreservesIt(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.users["analytics/raw"] = &configstore.OrgUser{
+		OrgID:       "analytics",
+		Username:    "raw",
+		Password:    "stored-hash",
+		Passthrough: true,
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"password":"new-pw"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/raw", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.users["analytics/raw"]
+	if !stored.Passthrough {
+		t.Error("Passthrough cleared by partial update; should preserve when field omitted")
+	}
+	if stored.Password == "stored-hash" {
+		t.Error("Password not updated")
 	}
 }
 

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -1195,6 +1195,53 @@ func TestUpdateUserClearsPassthroughWithoutTouchingPassword(t *testing.T) {
 	}
 }
 
+func TestUpdateUserEmptyBodyReturnsCurrentRow(t *testing.T) {
+	// Pre-existing handler returned 404 here even though the user existed —
+	// the empty body produced an empty updates map, which GORM treats as a
+	// no-op (RowsAffected=0 → "user not found"). The new short-circuit makes
+	// no-op PUTs return 200 with the stored row so the response no longer
+	// lies about the user's existence.
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.users["analytics/raw"] = &configstore.OrgUser{
+		OrgID:       "analytics",
+		Username:    "raw",
+		Password:    "stored-hash",
+		Passthrough: true,
+	}
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/raw", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.users["analytics/raw"]
+	if stored.Password != "stored-hash" || !stored.Passthrough {
+		t.Errorf("no-op PUT changed stored row: password=%q passthrough=%v", stored.Password, stored.Passthrough)
+	}
+}
+
+func TestUpdateUserEmptyBodyOnMissingUserReturns404(t *testing.T) {
+	// The no-op short-circuit must still surface "user not found" when the
+	// underlying user genuinely doesn't exist.
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/ghost", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
 func TestUpdateUserOmittingPassthroughPreservesIt(t *testing.T) {
 	store := newFakeAPIStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}

--- a/controlplane/admin/static/orgs.html
+++ b/controlplane/admin/static/orgs.html
@@ -76,9 +76,17 @@
                     '<th class="p-3">Memory Budget</th><th class="p-3">Actions</th></tr></thead><tbody>';
                 orgs.forEach(t => {
                     const safeName = esc(t.name);
+                    const users = t.users || [];
+                    const passthroughCount = users.filter(u => u.passthrough).length;
+                    // Surface passthrough usage at a glance — operators reviewing
+                    // an org's surface area need to see which logins bypass the
+                    // PG compatibility layer without drilling into every user.
+                    const userCell = passthroughCount > 0
+                        ? `${users.length} <span class="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-purple-900 text-purple-300" title="${passthroughCount} passthrough user${passthroughCount === 1 ? '' : 's'}">${passthroughCount} passthrough</span>`
+                        : `${users.length}`;
                     html += `<tr class="border-b border-gray-700 hover:bg-gray-750">
                         <td class="p-3 font-medium">${safeName}</td>
-                        <td class="p-3">${(t.users || []).length}</td>
+                        <td class="p-3">${userCell}</td>
                         <td class="p-3">${t.max_workers || 'unlimited'}</td>
                         <td class="p-3">${esc(t.memory_budget || 'default')}</td>
                         <td class="p-3">

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -20,12 +20,19 @@ type Org struct {
 func (Org) TableName() string { return "duckgres_orgs" }
 
 // OrgUser maps a username to an org with credentials.
+//
+// Passthrough flips a per-user flag that bypasses the PostgreSQL compatibility
+// layer (SQL transpiler + pg_catalog initialization) and forwards SQL straight
+// to DuckDB. Used by clients that already speak DuckDB SQL natively. Scoped to
+// (org_id, username) so the same login name can be passthrough in one tenant
+// and not in another.
 type OrgUser struct {
-	OrgID     string    `gorm:"primaryKey;size:255" json:"org_id"`
-	Username  string    `gorm:"primaryKey;size:255" json:"username"`
-	Password  string    `gorm:"size:255;not null" json:"-"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	OrgID       string    `gorm:"primaryKey;size:255" json:"org_id"`
+	Username    string    `gorm:"primaryKey;size:255" json:"username"`
+	Password    string    `gorm:"size:255;not null" json:"-"`
+	Passthrough bool      `gorm:"not null;default:false" json:"passthrough"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 func (OrgUser) TableName() string { return "duckgres_org_users" }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -244,6 +244,10 @@ func (cs *ConfigStore) ValidateOrgUser(orgID, username, password string) bool {
 // IsOrgUserPassthrough reports whether the given (org, user) is configured to
 // bypass the PostgreSQL compatibility layer. Returns false for unknown users —
 // callers must validate credentials separately before trusting this.
+//
+// Prefer ValidateOrgUserAndGetPassthrough when both auth and passthrough are
+// needed at the same point; this method is exposed for introspection (e.g.
+// admin dashboards) where credentials aren't being checked.
 func (cs *ConfigStore) IsOrgUserPassthrough(orgID, username string) bool {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
@@ -251,6 +255,32 @@ func (cs *ConfigStore) IsOrgUserPassthrough(orgID, username string) bool {
 		return false
 	}
 	return cs.snapshot.OrgUserPassthrough[OrgUserKey{OrgID: orgID, Username: username}]
+}
+
+// ValidateOrgUserAndGetPassthrough validates credentials AND reads the
+// passthrough flag against the same snapshot, eliminating the swap window
+// that two separate ValidateOrgUser + IsOrgUserPassthrough calls would
+// expose. valid=false always returns passthrough=false — never leak the
+// flag for failed auth or unknown users.
+func (cs *ConfigStore) ValidateOrgUserAndGetPassthrough(orgID, username, password string) (valid, passthrough bool) {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.snapshot == nil {
+		// Match ValidateOrgUser's timing-leak guard: still spend bcrypt time
+		// on failed auth so unknown-user paths look the same as wrong-password.
+		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		return false, false
+	}
+	key := OrgUserKey{OrgID: orgID, Username: username}
+	storedHash, ok := cs.snapshot.OrgUserPassword[key]
+	if !ok {
+		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		return false, false
+	}
+	if bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) != nil {
+		return false, false
+	}
+	return true, cs.snapshot.OrgUserPassthrough[key]
 }
 
 // FindAndValidateUser scans all orgs to find and authenticate a user by username/password.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -29,13 +29,14 @@ var ErrWorkerOwnerEpochMismatch = errors.New("worker owner epoch mismatch")
 
 // Snapshot holds a point-in-time copy of all config data for fast lookups.
 type Snapshot struct {
-	Orgs            map[string]*OrgConfig
-	DatabaseOrg     map[string]string     // database name -> org ID
-	OrgUserPassword map[OrgUserKey]string // (orgID, username) -> bcrypt hash
-	Global          GlobalConfig
-	DuckLake        DuckLakeConfig
-	RateLimit       RateLimitConfig
-	QueryLog        QueryLogConfig
+	Orgs               map[string]*OrgConfig
+	DatabaseOrg        map[string]string     // database name -> org ID
+	OrgUserPassword    map[OrgUserKey]string // (orgID, username) -> bcrypt hash
+	OrgUserPassthrough map[OrgUserKey]bool   // (orgID, username) -> passthrough flag
+	Global             GlobalConfig
+	DuckLake           DuckLakeConfig
+	RateLimit          RateLimitConfig
+	QueryLog           QueryLogConfig
 }
 
 // ConfigStore manages configuration stored in a PostgreSQL database.
@@ -168,13 +169,14 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 	cs.db.First(&queryLog, 1)
 
 	snap := &Snapshot{
-		Orgs:            make(map[string]*OrgConfig),
-		DatabaseOrg:     make(map[string]string),
-		OrgUserPassword: make(map[OrgUserKey]string),
-		Global:          global,
-		DuckLake:        duckLake,
-		RateLimit:       rateLimit,
-		QueryLog:        queryLog,
+		Orgs:               make(map[string]*OrgConfig),
+		DatabaseOrg:        make(map[string]string),
+		OrgUserPassword:    make(map[OrgUserKey]string),
+		OrgUserPassthrough: make(map[OrgUserKey]bool),
+		Global:             global,
+		DuckLake:           duckLake,
+		RateLimit:          rateLimit,
+		QueryLog:           queryLog,
 	}
 
 	for _, o := range orgs {
@@ -194,7 +196,11 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 		}
 		for _, u := range o.Users {
 			oc.Users[u.Username] = u.Password
-			snap.OrgUserPassword[OrgUserKey{OrgID: o.Name, Username: u.Username}] = u.Password
+			key := OrgUserKey{OrgID: o.Name, Username: u.Username}
+			snap.OrgUserPassword[key] = u.Password
+			if u.Passthrough {
+				snap.OrgUserPassthrough[key] = true
+			}
 		}
 		snap.Orgs[o.Name] = oc
 	}
@@ -233,6 +239,18 @@ func (cs *ConfigStore) ValidateOrgUser(orgID, username, password string) bool {
 		return false
 	}
 	return bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) == nil
+}
+
+// IsOrgUserPassthrough reports whether the given (org, user) is configured to
+// bypass the PostgreSQL compatibility layer. Returns false for unknown users —
+// callers must validate credentials separately before trusting this.
+func (cs *ConfigStore) IsOrgUserPassthrough(orgID, username string) bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.snapshot == nil {
+		return false
+	}
+	return cs.snapshot.OrgUserPassthrough[OrgUserKey{OrgID: orgID, Username: username}]
 }
 
 // FindAndValidateUser scans all orgs to find and authenticate a user by username/password.

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -204,6 +204,48 @@ func TestIsOrgUserPassthrough(t *testing.T) {
 	}
 }
 
+func TestValidateOrgUserAndGetPassthrough(t *testing.T) {
+	hash := mustHash(t, "secret1")
+	cs := &ConfigStore{
+		snapshot: &Snapshot{
+			OrgUserPassword: map[OrgUserKey]string{
+				{OrgID: "analytics", Username: "alice"}: hash,
+				{OrgID: "analytics", Username: "raw"}:   hash,
+			},
+			OrgUserPassthrough: map[OrgUserKey]bool{
+				{OrgID: "analytics", Username: "raw"}: true,
+			},
+		},
+	}
+
+	// Valid creds + passthrough flag set -> (true, true).
+	valid, pt := cs.ValidateOrgUserAndGetPassthrough("analytics", "raw", "secret1")
+	if !valid || !pt {
+		t.Errorf("raw with secret1 = (%v,%v), want (true,true)", valid, pt)
+	}
+	// Valid creds + flag absent -> (true, false).
+	valid, pt = cs.ValidateOrgUserAndGetPassthrough("analytics", "alice", "secret1")
+	if !valid || pt {
+		t.Errorf("alice with secret1 = (%v,%v), want (true,false)", valid, pt)
+	}
+	// Wrong password -> (false, false). Passthrough must NOT leak through.
+	valid, pt = cs.ValidateOrgUserAndGetPassthrough("analytics", "raw", "wrong")
+	if valid || pt {
+		t.Errorf("raw with wrong pw = (%v,%v), want (false,false)", valid, pt)
+	}
+	// Unknown user -> (false, false).
+	valid, pt = cs.ValidateOrgUserAndGetPassthrough("analytics", "ghost", "secret1")
+	if valid || pt {
+		t.Errorf("ghost = (%v,%v), want (false,false)", valid, pt)
+	}
+	// nil snapshot -> (false, false), no panic.
+	empty := &ConfigStore{}
+	valid, pt = empty.ValidateOrgUserAndGetPassthrough("analytics", "raw", "secret1")
+	if valid || pt {
+		t.Errorf("empty store = (%v,%v), want (false,false)", valid, pt)
+	}
+}
+
 func TestHashPassword(t *testing.T) {
 	hash, err := HashPassword("testpass")
 	if err != nil {

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -177,6 +177,33 @@ func TestSnapshotBuild(t *testing.T) {
 	}
 }
 
+func TestIsOrgUserPassthrough(t *testing.T) {
+	cs := &ConfigStore{
+		snapshot: &Snapshot{
+			OrgUserPassthrough: map[OrgUserKey]bool{
+				{OrgID: "analytics", Username: "raw"}: true,
+			},
+		},
+	}
+
+	if !cs.IsOrgUserPassthrough("analytics", "raw") {
+		t.Error("IsOrgUserPassthrough(raw) = false, want true")
+	}
+	// Unknown user -> false (no false-positive).
+	if cs.IsOrgUserPassthrough("analytics", "alice") {
+		t.Error("IsOrgUserPassthrough(unknown) = true, want false")
+	}
+	// Unknown org -> false.
+	if cs.IsOrgUserPassthrough("other-org", "raw") {
+		t.Error("IsOrgUserPassthrough(other-org/raw) = true, want false")
+	}
+	// nil snapshot -> false (no panic).
+	empty := &ConfigStore{}
+	if empty.IsOrgUserPassthrough("analytics", "raw") {
+		t.Error("IsOrgUserPassthrough on empty store = true, want false")
+	}
+}
+
 func TestHashPassword(t *testing.T) {
 	hash, err := HashPassword("testpass")
 	if err != nil {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -159,6 +159,7 @@ type ControlPlane struct {
 type ConfigStoreInterface interface {
 	ResolveDatabase(database string) (orgID string)
 	ValidateOrgUser(orgID, username, password string) bool
+	IsOrgUserPassthrough(orgID, username string) bool
 	FindAndValidateUser(username, password string) (orgID string, ok bool) // for Flight SQL (no database param)
 	UpsertFlightSessionRecord(record *configstore.FlightSessionRecord) error
 	GetFlightSessionRecord(sessionToken string) (*configstore.FlightSessionRecord, error)
@@ -830,7 +831,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Authenticate
 	// In multi-tenant mode, the database name maps to an org.
 	// User uniqueness is scoped to the org.
-	var orgID string
+	var (
+		orgID           string
+		passthroughUser bool
+	)
 	if cp.configStore != nil {
 		// Resolve the effective database name based on SNI routing mode.
 		// "off"         - legacy: use the startup `database` param.
@@ -893,6 +897,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			_ = writer.Flush()
 			return
 		}
+		passthroughUser = cp.configStore.IsOrgUserPassthrough(orgID, username)
 		// From here on, `database` reflects the SNI-resolved org. This is what
 		// gets passed to the worker as the logical database (drives the
 		// `current_database()` macro and pg_database view) so observability
@@ -1013,22 +1018,27 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		}
 	}()
 
-	initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
-	err = sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, database)
-	if err != nil {
+	// Passthrough users skip pg_catalog initialization and DuckLake catalog
+	// detection — they bypass the PG compatibility layer entirely, so the
+	// metadata setup that drives logical catalog mapping is unused for them.
+	var duckLakeAttached bool
+	if !passthroughUser {
+		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
+		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, database); err != nil {
+			initCancel()
+			slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
+			_ = writer.Flush()
+			return
+		}
+		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
 		initCancel()
-		slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
-		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
-		_ = writer.Flush()
-		return
-	}
-	duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
-	initCancel()
-	if err != nil {
-		slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
-		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
-		_ = writer.Flush()
-		return
+		if err != nil {
+			slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
+			_ = writer.Flush()
+			return
+		}
 	}
 
 	// Register the TCP connection so OnWorkerCrash can close it to unblock
@@ -1038,6 +1048,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Create real clientConn with FlightExecutor and worker assignment
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
 	server.SetLogicalCatalogMapping(cc, duckLakeAttached)
+	server.SetPassthrough(cc, passthroughUser)
 
 	// Send ReadyForQuery to signal that the handshake is complete
 	if err := server.WriteReadyForQuery(writer, 'I'); err != nil {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -159,7 +159,11 @@ type ControlPlane struct {
 type ConfigStoreInterface interface {
 	ResolveDatabase(database string) (orgID string)
 	ValidateOrgUser(orgID, username, password string) bool
-	IsOrgUserPassthrough(orgID, username string) bool
+	// ValidateOrgUserAndGetPassthrough does both lookups against the same
+	// snapshot — the auth path needs both, and a single read closes the
+	// window where the snapshot could swap between two separate calls.
+	// passthrough is always false when valid is false.
+	ValidateOrgUserAndGetPassthrough(orgID, username, password string) (valid, passthrough bool)
 	FindAndValidateUser(username, password string) (orgID string, ok bool) // for Flight SQL (no database param)
 	UpsertFlightSessionRecord(record *configstore.FlightSessionRecord) error
 	GetFlightSessionRecord(sessionToken string) (*configstore.FlightSessionRecord, error)
@@ -887,7 +891,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			_ = writer.Flush()
 			return
 		}
-		if !cp.configStore.ValidateOrgUser(orgID, username, password) {
+		// Single combined lookup: validate credentials and read the
+		// passthrough flag against the same snapshot so a config-store poll
+		// that swaps the snapshot between two reads can't produce a stale
+		// passthrough flag for an authenticated session.
+		valid, isPassthrough := cp.configStore.ValidateOrgUserAndGetPassthrough(orgID, username, password)
+		if !valid {
 			slog.Warn("Authentication failed.", "user", username, "org", orgID, "database", effectiveDatabase, "remote_addr", remoteAddr)
 			banned := server.RecordFailedAuthAttempt(cp.rateLimiter, remoteAddr)
 			if banned {
@@ -897,7 +906,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			_ = writer.Flush()
 			return
 		}
-		passthroughUser = cp.configStore.IsOrgUserPassthrough(orgID, username)
+		passthroughUser = isPassthrough
 		// From here on, `database` reflects the SNI-resolved org. This is what
 		// gets passed to the worker as the logical database (drives the
 		// `current_database()` macro and pg_database view) so observability
@@ -1049,6 +1058,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
 	server.SetLogicalCatalogMapping(cc, duckLakeAttached)
 	server.SetPassthrough(cc, passthroughUser)
+	if orgID != "" {
+		observeOrgPgSessionAccepted(orgID, passthroughUser)
+	}
 
 	// Send ReadyForQuery to signal that the handshake is complete
 	if err := server.WriteReadyForQuery(writer, 'I'); err != nil {

--- a/controlplane/flight_ingress_metrics_k8s.go
+++ b/controlplane/flight_ingress_metrics_k8s.go
@@ -34,6 +34,15 @@ var orgWorkerCrashesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Total worker crashes per org",
 }, []string{"org"})
 
+// orgPgSessionsAcceptedCounter tracks every PG session that completes auth and
+// is dispatched to a worker, partitioned by org and passthrough mode. Useful
+// for spotting unexpected passthrough usage spikes (a misconfigured client) or
+// validating that a newly onboarded org is actually getting traffic.
+var orgPgSessionsAcceptedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_org_pg_sessions_accepted_total",
+	Help: "Total PG sessions accepted by the control plane, partitioned by org and passthrough mode",
+}, []string{"org", "passthrough"})
+
 func observeOrgWorkersActive(org string, count int) {
 	orgWorkersActiveGauge.WithLabelValues(org).Set(float64(count))
 }
@@ -52,4 +61,12 @@ func observeOrgWorkerSpawn(org string) {
 
 func observeOrgWorkerCrash(org string) {
 	orgWorkerCrashesCounter.WithLabelValues(org).Inc()
+}
+
+func observeOrgPgSessionAccepted(org string, passthrough bool) {
+	mode := "false"
+	if passthrough {
+		mode = "true"
+	}
+	orgPgSessionsAcceptedCounter.WithLabelValues(org, mode).Inc()
 }

--- a/controlplane/flight_ingress_metrics_stub.go
+++ b/controlplane/flight_ingress_metrics_stub.go
@@ -3,3 +3,5 @@
 package controlplane
 
 func observeOrgSessionsActive(string, int) {}
+
+func observeOrgPgSessionAccepted(string, bool) {}

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -120,6 +120,11 @@ func (f *fakeConfigStore) FindAndValidateUser(user, pass string) (string, bool) 
 	}
 	return f.findAndValidateUser(user, pass)
 }
+func (f *fakeConfigStore) IsOrgUserPassthrough(string, string) bool {
+	// SNI tests don't exercise passthrough; the real flag lookup is covered
+	// elsewhere. Returning false keeps the existing assertions intact.
+	return false
+}
 func (f *fakeConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
 	panic("UpsertFlightSessionRecord should not be called from SNI tests")
 }

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -125,6 +125,12 @@ func (f *fakeConfigStore) IsOrgUserPassthrough(string, string) bool {
 	// elsewhere. Returning false keeps the existing assertions intact.
 	return false
 }
+func (f *fakeConfigStore) ValidateOrgUserAndGetPassthrough(orgID, user, pass string) (bool, bool) {
+	// SNI tests drive Flight SQL, not the PG auth path that uses the
+	// combined call. Forward to ValidateOrgUser so the test fakes that set
+	// validateOrgUser still work unchanged.
+	return f.ValidateOrgUser(orgID, user, pass), false
+}
 func (f *fakeConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
 	panic("UpsertFlightSessionRecord should not be called from SNI tests")
 }

--- a/server/exports.go
+++ b/server/exports.go
@@ -93,6 +93,17 @@ func SetLogicalCatalogMapping(cc *clientConn, enabled bool) {
 	}
 }
 
+// SetPassthrough flips this session into passthrough mode (bypasses the SQL
+// transpiler + pg_catalog). The control plane resolves the per-org flag from
+// the config store after auth and calls this before the message loop starts.
+// Single-tenant mode keeps using server.Config.PassthroughUsers and never
+// calls this.
+func SetPassthrough(cc *clientConn, enabled bool) {
+	if cc != nil {
+		cc.passthrough = enabled
+	}
+}
+
 // HasAttachedCatalog and InitSessionDatabaseMetadata moved to
 // server/sessionmeta. Re-exports kept here for the dozen call sites in
 // the control plane and elsewhere; new code should import server/sessionmeta


### PR DESCRIPTION
## Summary
- Adds `OrgUser.Passthrough bool` so the same login can be transpiled in one tenant and raw-DuckDB in another (single-tenant `server.Config.PassthroughUsers` doesn't fit MTCP, where usernames aren't globally unique).
- CP looks up the flag right after `ValidateOrgUser` and propagates it to the per-conn state via a new `server.SetPassthrough` setter (mirrors `SetLogicalCatalogMapping`). Passthrough sessions also skip `InitSessionDatabaseMetadata` + `HasAttachedCatalog` since neither applies to raw-DuckDB clients.
- Admin API: `POST /users` accepts `passthrough`; `PUT /orgs/:id/users/:username` accepts `passthrough` as `*bool` so omitting it preserves the stored value.

Motivated by Portola onboarding to MTCP — they have a `duckgres-duckdb` passthrough user from their EC2 setup that needs to keep working on the multi-tenant CP without leaking the username to other tenants.

## Test plan
- [x] `go test -tags kubernetes ./controlplane/configstore/... ./controlplane/admin/... ./server/...`
- [x] New unit tests cover: snapshot lookup, create-with-passthrough, default-false on create, partial-update clears, partial-update without `passthrough` preserves
- [ ] Integration check after deploy: create a user with `passthrough=true`, connect, send `SELECT current_database()` (DuckDB-flavored — no PG transpile needed), confirm pg_catalog probes are not run during session init

## Notes
- Existing rows get `Passthrough=false` via the `gorm:"not null;default:false"` tag — Postgres applies the default during `ALTER TABLE ... ADD COLUMN`. No data migration needed.
- Single-tenant mode is untouched. `server.Config.PassthroughUsers` still drives passthrough there; the new setter only fires on the MTCP path.
- Pre-existing `controlplane/admin/api_postgres_test.go` failures (legacy `docker-compose` not on PATH) are environmental, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)