### PR TITLE
fix(pgwire): tighten keepalive + log mid-stream wire-write errors

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cloudflare/tableflip"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/internal/netkeepalive"
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/flightclient"
@@ -625,11 +626,7 @@ func (cp *ControlPlane) acceptLoop() {
 			continue
 		}
 
-		// Enable TCP keepalive
-		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			_ = tcpConn.SetKeepAlive(true)
-			_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
-		}
+		netkeepalive.TuneAcceptedConn(conn)
 
 		cp.wg.Add(1)
 		go func() {

--- a/internal/netkeepalive/keepalive.go
+++ b/internal/netkeepalive/keepalive.go
@@ -1,0 +1,58 @@
+// Package netkeepalive tunes accepted TCP connections so dead peers and
+// stalled writes are surfaced quickly.
+//
+// The defaults net.TCPConn ships with — and even SetKeepAlivePeriod alone —
+// are not enough behind an AWS NLB. The NLB's idle timeout is 350s, and a
+// stuck downstream (e.g. a pod whose host kernel stopped acking) can leave a
+// CP write blocked on TCP retransmits for ~15 minutes before the connection
+// finally errors. That window swallows the symptom: the CP keeps the query
+// "open" with no error log, the pgwire client has long since given up, and
+// the operator only sees a Query finished. line at Info severity once the
+// kernel finally collapses the socket.
+//
+// TuneAcceptedConn does two things to bound the window to ~60s:
+//   - Tighter SO_KEEPALIVE: probe every 10s after 30s idle, give up after 3
+//     missed acks. ~60s detection on read-idle sockets.
+//   - TCP_USER_TIMEOUT (Linux only): if data is sitting unacked in the send
+//     buffer for 60s, the kernel marks the socket dead instead of waiting on
+//     the default ~15min retransmit ladder. Critical for the NLB-stall case
+//     because a hung write does not benefit from KEEPALIVE — keepalive only
+//     fires on idle sockets.
+package netkeepalive
+
+import (
+	"net"
+	"time"
+)
+
+// KeepAliveConfig parameters tuned for ~60s detection of dead peers behind
+// an AWS NLB (350s idle timeout). Probes start after 30s idle, repeat every
+// 10s, and after 3 missed acks the kernel marks the connection broken.
+const (
+	keepAliveIdle     = 30 * time.Second
+	keepAliveInterval = 10 * time.Second
+	keepAliveCount    = 3
+
+	// userTimeout bounds the time a write can sit unacked before the kernel
+	// declares the socket dead. Matches the keepalive budget so the two
+	// detection paths agree on a ~60s ceiling.
+	userTimeout = 60 * time.Second
+)
+
+// TuneAcceptedConn applies keepalive + user-timeout settings to a freshly
+// accepted connection. Non-TCP connections and best-effort syscall failures
+// are silently ignored — a misconfigured socket should not block the listener
+// from serving traffic.
+func TuneAcceptedConn(conn net.Conn) {
+	tcpConn, ok := conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	_ = tcpConn.SetKeepAliveConfig(net.KeepAliveConfig{
+		Enable:   true,
+		Idle:     keepAliveIdle,
+		Interval: keepAliveInterval,
+		Count:    keepAliveCount,
+	})
+	_ = setUserTimeout(tcpConn, userTimeout)
+}

--- a/internal/netkeepalive/keepalive_linux_test.go
+++ b/internal/netkeepalive/keepalive_linux_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package netkeepalive
+
+import (
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Linux setsockopt names for the keepalive triplet. Declared locally to
+// avoid a hard dep on golang.org/x/sys/unix; values match <netinet/tcp.h>.
+const (
+	tcpKeepIdle  = 4 // TCP_KEEPIDLE
+	tcpKeepIntvl = 5 // TCP_KEEPINTVL
+	tcpKeepCnt   = 6 // TCP_KEEPCNT
+)
+
+// TestTuneAcceptedConn_LinuxSocketOptions reads back the actual sockopts
+// after TuneAcceptedConn so the kernel's view — not just Go's KeepAliveConfig
+// API — is what we assert on. This is the canary for the prod fix: the bug
+// was that the unset TCP_USER_TIMEOUT let dead writes hang ~15 minutes; the
+// regression is "we shipped a build where TCP_USER_TIMEOUT was no longer
+// applied," which only this round-trip catches.
+func TestTuneAcceptedConn_LinuxSocketOptions(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer listener.Close()
+
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			dialed <- nil
+			return
+		}
+		dialed <- c
+	}()
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	defer conn.Close()
+	defer func() {
+		if c := <-dialed; c != nil {
+			_ = c.Close()
+		}
+	}()
+
+	TuneAcceptedConn(conn)
+
+	tcpConn := conn.(*net.TCPConn)
+	raw, err := tcpConn.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+
+	var (
+		keepalive int
+		idle      int
+		interval  int
+		count     int
+		userTO    int
+		getErr    error
+	)
+	ctrlErr := raw.Control(func(fd uintptr) {
+		ifd := int(fd)
+		if keepalive, getErr = syscall.GetsockoptInt(ifd, syscall.SOL_SOCKET, syscall.SO_KEEPALIVE); getErr != nil {
+			return
+		}
+		if idle, getErr = syscall.GetsockoptInt(ifd, syscall.IPPROTO_TCP, tcpKeepIdle); getErr != nil {
+			return
+		}
+		if interval, getErr = syscall.GetsockoptInt(ifd, syscall.IPPROTO_TCP, tcpKeepIntvl); getErr != nil {
+			return
+		}
+		if count, getErr = syscall.GetsockoptInt(ifd, syscall.IPPROTO_TCP, tcpKeepCnt); getErr != nil {
+			return
+		}
+		userTO, getErr = syscall.GetsockoptInt(ifd, syscall.IPPROTO_TCP, tcpUserTimeout)
+	})
+	if ctrlErr != nil {
+		t.Fatalf("raw.Control: %v", ctrlErr)
+	}
+	if getErr != nil {
+		t.Fatalf("GetsockoptInt: %v", getErr)
+	}
+
+	if keepalive == 0 {
+		t.Errorf("SO_KEEPALIVE: got 0, want non-zero (enabled)")
+	}
+	if want := int(keepAliveIdle / time.Second); idle != want {
+		t.Errorf("TCP_KEEPIDLE: got %d, want %d", idle, want)
+	}
+	if want := int(keepAliveInterval / time.Second); interval != want {
+		t.Errorf("TCP_KEEPINTVL: got %d, want %d", interval, want)
+	}
+	if count != keepAliveCount {
+		t.Errorf("TCP_KEEPCNT: got %d, want %d", count, keepAliveCount)
+	}
+	if want := int(userTimeout / time.Millisecond); userTO != want {
+		t.Errorf("TCP_USER_TIMEOUT: got %d ms, want %d ms", userTO, want)
+	}
+}

--- a/internal/netkeepalive/keepalive_linux_test.go
+++ b/internal/netkeepalive/keepalive_linux_test.go
@@ -30,7 +30,7 @@ func TestTuneAcceptedConn_LinuxSocketOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	dialed := make(chan net.Conn, 1)
 	go func() {
@@ -46,7 +46,7 @@ func TestTuneAcceptedConn_LinuxSocketOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Accept: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	defer func() {
 		if c := <-dialed; c != nil {
 			_ = c.Close()

--- a/internal/netkeepalive/keepalive_test.go
+++ b/internal/netkeepalive/keepalive_test.go
@@ -1,0 +1,58 @@
+package netkeepalive
+
+import (
+	"net"
+	"testing"
+)
+
+// TestTuneAcceptedConn_NonTCP confirms TuneAcceptedConn is a no-op (no panic,
+// no error) on connections that are not *net.TCPConn. The accept loop should
+// stay generic — keepalive tuning is best-effort.
+func TestTuneAcceptedConn_NonTCP(t *testing.T) {
+	t.Parallel()
+
+	// io.Pipe doesn't give us a net.Conn, so use a local socketpair via
+	// net.Pipe — both ends are *pipe (an in-memory net.Conn) which fails
+	// the *net.TCPConn assertion inside TuneAcceptedConn.
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	TuneAcceptedConn(a)
+}
+
+// TestTuneAcceptedConn_TCP confirms TuneAcceptedConn returns cleanly for an
+// accepted TCP connection. The platform-specific assertions (Linux getsockopt
+// roundtrip) live in keepalive_linux_test.go.
+func TestTuneAcceptedConn_TCP(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer listener.Close()
+
+	dialErrCh := make(chan error, 1)
+	go func() {
+		c, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			dialErrCh <- err
+			return
+		}
+		_ = c.Close()
+		dialErrCh <- nil
+	}()
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	defer conn.Close()
+
+	TuneAcceptedConn(conn)
+
+	if err := <-dialErrCh; err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+}

--- a/internal/netkeepalive/keepalive_test.go
+++ b/internal/netkeepalive/keepalive_test.go
@@ -15,8 +15,8 @@ func TestTuneAcceptedConn_NonTCP(t *testing.T) {
 	// net.Pipe — both ends are *pipe (an in-memory net.Conn) which fails
 	// the *net.TCPConn assertion inside TuneAcceptedConn.
 	a, b := net.Pipe()
-	defer a.Close()
-	defer b.Close()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
 
 	TuneAcceptedConn(a)
 }
@@ -31,7 +31,7 @@ func TestTuneAcceptedConn_TCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	dialErrCh := make(chan error, 1)
 	go func() {
@@ -48,7 +48,7 @@ func TestTuneAcceptedConn_TCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Accept: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	TuneAcceptedConn(conn)
 

--- a/internal/netkeepalive/usertimeout_linux.go
+++ b/internal/netkeepalive/usertimeout_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package netkeepalive
+
+import (
+	"net"
+	"syscall"
+	"time"
+)
+
+// tcpUserTimeout is the Linux setsockopt level=IPPROTO_TCP option for
+// TCP_USER_TIMEOUT. Defined in <netinet/tcp.h> as 18; not exposed by Go's
+// stdlib syscall package, so we declare the constant locally rather than
+// pull in golang.org/x/sys/unix as a direct dependency for one integer.
+const tcpUserTimeout = 18
+
+func setUserTimeout(conn *net.TCPConn, d time.Duration) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	ms := int(d / time.Millisecond)
+	var setErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		setErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, tcpUserTimeout, ms)
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return setErr
+}

--- a/internal/netkeepalive/usertimeout_other.go
+++ b/internal/netkeepalive/usertimeout_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package netkeepalive
+
+import (
+	"net"
+	"time"
+)
+
+// setUserTimeout is a no-op outside Linux. macOS / BSD kernels do not expose
+// TCP_USER_TIMEOUT; the keepalive budget remains the only detection path on
+// developer machines, which is fine — production runs on Linux.
+func setUserTimeout(_ *net.TCPConn, _ time.Duration) error {
+	return nil
+}

--- a/scripts/repro_pgwire_write_stall.sh
+++ b/scripts/repro_pgwire_write_stall.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Reproducer for the posthog-mw-prod-us pgwire-write-stall incident.
+#
+# Goal: drive a CP into the same kernel state seen during the incident — a
+# long-running SELECT whose return path is silently dropped (NLB tore down
+# the idle 350s+ connection while the CP was streaming results). Without the
+# TCP_USER_TIMEOUT fix the CP blocks on the unacked write for ~15 minutes
+# before the kernel collapses the socket, and the only log line emitted is
+# Info-level "Query finished.". With the fix the CP fails the write in ~60s
+# and emits Error-level "Query execution errored.".
+#
+# How the simulation works:
+#   - socat is started as a transparent TCP middlebox between psql and the CP.
+#   - psql connects to socat, socat connects to the CP.
+#   - We run a streaming SELECT that produces rows continuously.
+#   - Once results start flowing we SIGSTOP socat. socat's userspace stops
+#     draining its receive buffer; once that buffer fills, socat's kernel
+#     stops advertising window space; the CP's writes stall waiting for
+#     window to open. This is the same kernel state an NLB-induced black
+#     hole produces — a half-dead socket that still appears connected to
+#     the CP's TCP stack but accepts no more data.
+#
+# Usage:
+#   CP_HOST=cp.dev.example.com CP_PORT=5432 PGUSER=postgres PGPASSWORD=… \
+#     ./scripts/repro_pgwire_write_stall.sh
+#
+# Then watch the CP's logs and confirm:
+#   - Pre-fix: ~15 min of silence, then a single "Query finished." Info line.
+#   - Post-fix: ~60 s, then "Query execution errored." at Error level with
+#     SQLSTATE 57P03 (or class 08 connection_exception, depending on how the
+#     kernel surfaces the ETIMEDOUT).
+set -euo pipefail
+
+CP_HOST="${CP_HOST:?CP_HOST required (e.g. cp.dev.example.com)}"
+CP_PORT="${CP_PORT:-5432}"
+LOCAL_PORT="${LOCAL_PORT:-25432}"
+STREAM_ROWS="${STREAM_ROWS:-100000000}"
+STALL_AFTER="${STALL_AFTER:-5}"   # seconds of streaming before SIGSTOPing socat
+
+command -v socat >/dev/null || { echo "socat not found — brew install socat / apt install socat" >&2; exit 1; }
+command -v psql >/dev/null || { echo "psql not found" >&2; exit 1; }
+
+cleanup() {
+  if [[ -n "${SOCAT_PID:-}" ]] && kill -0 "$SOCAT_PID" 2>/dev/null; then
+    kill -CONT "$SOCAT_PID" 2>/dev/null || true
+    kill "$SOCAT_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${PSQL_PID:-}" ]] && kill -0 "$PSQL_PID" 2>/dev/null; then
+    kill "$PSQL_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "[$(date +%H:%M:%S)] starting socat middlebox: 127.0.0.1:$LOCAL_PORT -> $CP_HOST:$CP_PORT"
+socat TCP-LISTEN:"$LOCAL_PORT",reuseaddr,fork TCP:"$CP_HOST":"$CP_PORT" &
+SOCAT_PID=$!
+sleep 1
+
+# Streaming SELECT: deliberately CPU-light so the CP's row-emit loop is
+# bottlenecked on socket writes, not on DuckDB. Each row is ~50 bytes so
+# the kernel send buffer (default ~4 MB) fills in well under a second of
+# stalled writes, so the CP starts blocking on Write() immediately after
+# the SIGSTOP.
+QUERY="SELECT range::BIGINT AS n, md5(range::TEXT) AS h FROM range(0, $STREAM_ROWS)"
+
+echo "[$(date +%H:%M:%S)] starting psql streaming query (rows=$STREAM_ROWS)"
+PGPASSWORD="${PGPASSWORD:-}" psql \
+  "host=127.0.0.1 port=$LOCAL_PORT user=${PGUSER:-postgres} sslmode=disable dbname=${PGDATABASE:-postgres}" \
+  -c "$QUERY" \
+  >/dev/null 2>/tmp/repro_psql.err &
+PSQL_PID=$!
+
+sleep "$STALL_AFTER"
+echo "[$(date +%H:%M:%S)] SIGSTOPing socat — return path is now black-holed"
+kill -STOP "$SOCAT_PID"
+
+echo "[$(date +%H:%M:%S)] socat stopped. Watch the CP logs now."
+echo
+echo "  kubectl -n duckgres logs -f -l app=duckgres-cp --tail=100 \\"
+echo "      | grep -E 'Query (started|finished|execution errored)'"
+echo
+echo "Expected timeline:"
+echo "  pre-fix : ~15 min until ETIMEDOUT, then Info-level 'Query finished.'"
+echo "  post-fix: ~60 s until TCP_USER_TIMEOUT fires, then Error-level"
+echo "            'Query execution errored.' with the wire-write error."
+echo
+echo "Press Ctrl-C to clean up and exit."
+wait "$PSQL_PID" || true

--- a/server/conn.go
+++ b/server/conn.go
@@ -1696,6 +1696,9 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		queryFinalErr = err
 		errCode := "42000"
 		errMsg := err.Error()
+		if !c.isCallerCancellation(err) {
+			c.logQueryError(query, err)
+		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -1708,6 +1711,9 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		queryFinalErr = err
 		errCode := "42000"
 		errMsg := err.Error()
+		if !c.isCallerCancellation(err) {
+			c.logQueryError(query, err)
+		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -1718,8 +1724,18 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	_, sendSpan := observe.Tracer().Start(ctx, "duckgres.send_results")
 	defer sendSpan.End()
 
+	// Mid-stream wire-write failures (sendRowDescription / sendDataRowWithFormats)
+	// surface a broken socket — typically the AWS NLB tearing down a stalled
+	// connection, or the kernel collapsing the socket after TCP_USER_TIMEOUT.
+	// They must route through logQueryError so the SQLSTATE-class severity
+	// router fires Error-level "Query execution errored." for alerts.
+	// Pre-fix the only signal was Info-level "Query finished." from the
+	// deferred lifecycle log, which silently disappears below alerting.
 	if err := c.sendRowDescription(cols, colTypes); err != nil {
 		queryFinalErr = err
+		if !c.isCallerCancellation(err) {
+			c.logQueryError(query, err)
+		}
 		return 0, "", "", err
 	}
 
@@ -1740,6 +1756,9 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			queryFinalErr = err
 			errCode := "42000"
 			errMsg := err.Error()
+			if !c.isCallerCancellation(err) {
+				c.logQueryError(query, err)
+			}
 			c.sendError("ERROR", errCode, errMsg)
 			c.setTxError()
 			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -1749,6 +1768,9 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 
 		if err := c.sendDataRowWithFormats(values, nil, typeOIDs); err != nil {
 			queryFinalErr = err
+			if !c.isCallerCancellation(err) {
+				c.logQueryError(query, err)
+			}
 			return 0, "", "", err
 		}
 		rowCount++
@@ -1762,11 +1784,10 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		if c.isCallerCancellation(err) {
 			errCode = "57014"
 			errMsg = "canceling statement due to user request"
-			c.sendError("ERROR", errCode, errMsg)
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
-			c.sendError("ERROR", errCode, errMsg)
+			c.logQueryError(query, err)
 		}
+		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
 		_ = c.writer.Flush()

--- a/server/conn_querylog_lifecycle_test.go
+++ b/server/conn_querylog_lifecycle_test.go
@@ -205,6 +205,92 @@ func TestLifecyclePairFiresOnHandleExecuteExec(t *testing.T) {
 	assertLifecyclePair(t, buf, "handleExecute-Exec")
 }
 
+// streamingRowSet is a fake RowSet that yields a fixed number of single-column
+// string rows. Used to drive executeSelectQuery past the rows.Next() gate so
+// the test can exercise mid-stream wire-write failures.
+type streamingRowSet struct {
+	rows      [][]any
+	idx       int
+	cols      []string
+	colTypers []ColumnTyper
+	closed    bool
+}
+
+func (s *streamingRowSet) Columns() ([]string, error)          { return s.cols, nil }
+func (s *streamingRowSet) ColumnTypes() ([]ColumnTyper, error) { return s.colTypers, nil }
+func (s *streamingRowSet) Next() bool {
+	if s.idx >= len(s.rows) {
+		return false
+	}
+	s.idx++
+	return true
+}
+func (s *streamingRowSet) Scan(dest ...any) error {
+	row := s.rows[s.idx-1]
+	for i, v := range row {
+		if p, ok := dest[i].(*interface{}); ok {
+			*p = v
+		}
+	}
+	return nil
+}
+func (s *streamingRowSet) Close() error { s.closed = true; return nil }
+func (s *streamingRowSet) Err() error   { return nil }
+
+// stringColumnTyper is a tiny ColumnTyper that reports VARCHAR. Sufficient for
+// the streaming-write test, which only cares that pgwire encodes a column.
+type stringColumnTyper struct{}
+
+func (stringColumnTyper) DatabaseTypeName() string { return "VARCHAR" }
+
+// failingWriter returns a fixed error on every Write. Wrapped by a small
+// bufio.Writer so a wire-message Write triggers an underlying flush that
+// surfaces the error to the caller — simulating the prod symptom where the
+// AWS NLB tore down a stalled pgwire socket and the pgwire send-row write
+// failed mid-stream.
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write(_ []byte) (int, error) { return 0, f.err }
+
+// TestExecuteSelectQuery_LogsErrorOnWireWriteFailure verifies the regression
+// from the posthog-mw-prod-us TCP-write-timeout incident: when a mid-stream
+// wire write fails (sendRowDescription / sendDataRowWithFormats), the CP must
+// emit Error-level "Query execution errored." so alerts fire. Pre-fix only
+// the deferred Info-level "Query finished." was emitted, hiding the failure
+// below alerting thresholds.
+func TestExecuteSelectQuery_LogsErrorOnWireWriteFailure(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	c, cleanup := newLifecycleClientConn(t)
+	defer cleanup()
+
+	// 16-byte buffer + failing underlying writer: any wire message larger
+	// than 16 bytes (every real pgwire message) triggers an underlying Write
+	// that returns the configured error.
+	c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 16)
+
+	c.executor = &lifecycleExecutor{
+		queryRows: &streamingRowSet{
+			cols:      []string{"c"},
+			colTypers: []ColumnTyper{stringColumnTyper{}},
+			rows:      [][]any{{"hello"}},
+		},
+	}
+	c.username = "alice"
+	c.workerID = 7777
+
+	_, _, _, _ = c.executeSelectQuery("SELECT 'hello'", "SELECT")
+
+	out := buf.String()
+	if !strings.Contains(out, `level=ERROR msg="Query execution errored."`) {
+		t.Errorf("expected Error-level 'Query execution errored.' in:\n%s", out)
+	}
+	// Lifecycle pair must still fire so Loki filters on Started/Finished
+	// catch the failed query.
+	assertLifecyclePair(t, buf, "executeSelectQuery-wire-error")
+}
+
 // TestLifecyclePairFiresOnHandleExecuteQuery covers the extended-query Query
 // path (handleExecute → executor.Query for SELECTs). Same rationale as the
 // Exec test above — modern drivers go through this path for every SELECT.

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for direct PostgreSQL connections
+	"github.com/posthog/duckgres/internal/netkeepalive"
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/chsql"
 	"github.com/posthog/duckgres/server/ducklake"
@@ -488,11 +489,7 @@ func (s *Server) ListenAndServe() error {
 			continue
 		}
 
-		// Enable TCP keepalive to detect dead connections
-		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			_ = tcpConn.SetKeepAlive(true)
-			_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
-		}
+		netkeepalive.TuneAcceptedConn(conn)
 
 		s.wg.Add(1)
 		go func() {


### PR DESCRIPTION
## Summary

Two server-side hygiene fixes motivated by a long-running query that hung silently for ~20 minutes after the client connection went dead. The customer was using DataGrip; the prod symptom is consistent with a sleeping laptop / sleeping NIC / network blip mid-query — i.e. a write-stall, not a read-idle stall.

This PR is **operator-facing**, not customer-facing. It does not keep customer queries alive across network events. Customers whose long-running queries hit DataGrip / JDBC / driver timeouts on their side will continue to do so. What it does:

- Bounds the time the CP wastes writing into a black-holed peer from **indefinite** (zero-window stalls have no default kernel-level timeout) to ~60 s, so the worker slot frees and subsequent reconnects don't hit "no available worker".
- Surfaces the failure as Error-level \`Query execution errored.\` instead of only Info-level \`Query finished.\`, so on-call dashboards and alerts catch it.

## Why kernel SO_KEEPALIVE alone wasn't enough

\`SetKeepAlive(true)\` + \`SetKeepAlivePeriod(30s)\` has been on the pgwire listener since Dec 2025 (server) and Feb 2026 (CP). For a *read-idle* connection (no traffic in either direction), 30 s probes catch a dead peer in ~2 min.

The prod incident shape — and the regression this PR addresses — is different: the CP has unacked or zero-window-blocked data in the kernel send buffer.

- Kernel keepalive does not fire while there is pending data in the send buffer.
- For unacked data the kernel uses retransmits (\`tcp_retries2\` ≈ 15 min).
- For zero-window-stalled data (peer ACK'd but is advertising window=0) the kernel uses the persist timer with **no default timeout at all** — connection stays open indefinitely.

\`TCP_USER_TIMEOUT\` is the only setsockopt that bounds *both* of these cases.

## Empirical pre-fix evidence (from posthog-mw-dev)

Reproduced via socat-as-middlebox + SIGSTOP from a debug pod inside the cluster:

| Event | Time |
|---|---|
| Query started | 08:59:19 |
| socat SIGSTOP'd → CP write-stall begins | 08:59:21 |
| Operator killed psql client (RST forwarded) | 09:19:00 |
| CP emits \`Query finished.\` at **Info** level | 09:19:05 (\`duration_ms=1185696\`, \`rows=0\`, \`error=\"write tcp …: connection reset by peer\"\`) |

Without the operator-side kill, the CP would have remained wedged indefinitely. No Error-level log was emitted at any point during the 19+ minute stall.

This matches the prod symptom: long silent hang, single trailing Info-level lifecycle line with the wire-write error in the \`error=\` attribute, invisible to severity-based alerts.

## Changes

- New \`internal/netkeepalive\` package. \`TuneAcceptedConn\` applies \`KeepAliveConfig{Idle:30s, Interval:10s, Count:3}\` and (Linux) \`TCP_USER_TIMEOUT=60s\`. Wired into \`server/server.go\` and \`controlplane/control.go\` accept loops, replacing the inline \`SetKeepAlive\` lines.
- \`server/conn.go\` \`executeSelectQuery\` mid-stream error paths (\`Columns\` / \`ColumnTypes\` / \`sendRowDescription\` / \`Scan\` / \`sendDataRowWithFormats\` / \`rows.Err\`) route through \`logQueryError\` so the SQLSTATE-class severity router fires Error-level instead of only the deferred Info-level \`Query finished.\`. Caller-driven cancellations are still gated out via \`isCallerCancellation\`.

## Tests

- \`internal/netkeepalive/keepalive_linux_test.go\` getsockopt round-trips the keepalive triplet + \`TCP_USER_TIMEOUT\` so the kernel's view — not just Go's API — is what we regress on.
- \`TestExecuteSelectQuery_LogsErrorOnWireWriteFailure\` swaps in a small bufio.Writer over a failing underlying writer, drives a streaming \`SELECT\` past \`rows.Next()\`, and asserts the captured slog output contains both \`level=ERROR msg=\"Query execution errored.\"\` and the lifecycle Started/Finished pair.

## Reproducer

\`scripts/repro_pgwire_write_stall.sh\` documents the operational reproducer using \`socat\` as a transparent TCP middlebox between psql and the CP. SIGSTOPing socat halts userspace draining; the receive buffer fills, window collapses, the CP's writes stall against a half-dead peer.

Note: the simpler "long idle wire" pattern (e.g. \`SELECT pg_sleep(360)\`) does **not** demonstrate the fix because the existing 30 s keepalive already prevents NLB tear-down for read-idle connections (verified empirically — pg_sleep(360) returned cleanly through the dev NLB in 6 minutes).

## Test plan

- [ ] CI passes on Linux (keepalive getsockopt assertions run there).
- [ ] Deploy to dev and rerun the socat repro from a debug pod. Capture the post-fix timeline — expecting ~60 s + Error-level \`Query execution errored.\`, vs. the empirical 19+ min indefinite stall + Info-level documented above.
- [ ] Confirm normal traffic on dev shows no spurious Error-level \`Query execution errored.\` lines (i.e. \`isCallerCancellation\` continues to gate caller-driven disconnects out of the alerting bucket).

## What this does NOT fix

- Customer-side timeouts in DataGrip / JDBC / psql / etc. — those fire client-side based on the client's own statement timeout or socket read timeout, regardless of any server-side change.
- Long-running queries surviving across a network event. Postgres wire protocol generates no traffic from server → client while a query executes; if a customer's path goes silent mid-query, the only signals that travel are kernel-level keepalive probes (which only fire when the wire is fully idle, including no unacked data on either side). Genuinely keeping long queries alive across network events would require application-level pings (e.g. periodic \`NoticeResponse\` frames during query execution), which is a separate feature.