### PR TITLE
fix(pgwire): label client-write failures explicitly in Error logs

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1734,7 +1734,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 	if err := c.sendRowDescription(cols, colTypes); err != nil {
 		queryFinalErr = err
 		if !c.isCallerCancellation(err) {
-			c.logQueryError(query, err)
+			c.logQueryError(query, fmt.Errorf("pgwire client write failed sending row description: %w", err))
 		}
 		return 0, "", "", err
 	}
@@ -1769,7 +1769,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		if err := c.sendDataRowWithFormats(values, nil, typeOIDs); err != nil {
 			queryFinalErr = err
 			if !c.isCallerCancellation(err) {
-				c.logQueryError(query, err)
+				c.logQueryError(query, fmt.Errorf("pgwire client write failed during result streaming: %w", err))
 			}
 			return 0, "", "", err
 		}

--- a/server/conn_querylog_lifecycle_test.go
+++ b/server/conn_querylog_lifecycle_test.go
@@ -286,6 +286,12 @@ func TestExecuteSelectQuery_LogsErrorOnWireWriteFailure(t *testing.T) {
 	if !strings.Contains(out, `level=ERROR msg="Query execution errored."`) {
 		t.Errorf("expected Error-level 'Query execution errored.' in:\n%s", out)
 	}
+	// Error message must explicitly identify this as a pgwire client write
+	// failure, not a generic "write tcp …" string. Operators reading the
+	// alert shouldn't have to know that port 5432 means pgwire.
+	if !strings.Contains(out, "pgwire client write failed") {
+		t.Errorf("expected wrapped 'pgwire client write failed' prefix in error attr:\n%s", out)
+	}
 	// Lifecycle pair must still fire so Loki filters on Started/Finished
 	// catch the failed query.
 	assertLifecyclePair(t, buf, "executeSelectQuery-wire-error")


### PR DESCRIPTION
## Summary

Follow-up to #535. The Error log emitted for mid-stream pgwire write failures previously surfaced the raw \`*net.OpError\` as its sole error context:

\`\`\`
level=ERROR msg=\"Query execution errored.\"
  error=\"write tcp 10.60.150.57:5432->10.60.21.57:16073: write: connection timed out\"
\`\`\`

Identifying which side of the connection failed (client vs worker vs catalog) requires the reader to know that port 5432 is the pgwire listener. This wraps the two unambiguously client-direction call sites with an explicit prefix:

\`\`\`
level=ERROR msg=\"Query execution errored.\"
  error=\"pgwire client write failed during result streaming: write tcp 10.60.150.57:5432->10.60.21.57:16073: write: connection timed out\"
\`\`\`

## Scope

Only \`sendRowDescription\` and \`sendDataRowWithFormats\` get the wrap — those are 100% client-direction (\`c.writer\` is the bufio over \`c.conn\` from \`pgListener.Accept()\`).

The other mid-stream paths in \`executeSelectQuery\` that #535 also routed through \`logQueryError\` (\`Columns\`, \`ColumnTypes\`, \`Scan\`, \`rows.Err\`) bubble up from the Flight gRPC stream or driver layer and are not unambiguously client-direction, so they keep their raw errors.

## Test plan

- [x] \`TestExecuteSelectQuery_LogsErrorOnWireWriteFailure\` extended with a substring assertion on \`pgwire client write failed\` in the captured slog output.
- [ ] Verify in dev that the next genuine wire-write failure logs the wrapped form. (#535's empirical repro can be rerun against this branch once deployed.)

## Notes

- Underlying error chained via \`%w\` — \`errors.Is\` / \`errors.As\` callers stay intact.
- No protocol-visible change. Wrap is in the slog \`error=\` attribute only; the SQLSTATE-class severity router and the wire-protocol \`ErrorResponse\` text still operate on the unwrapped error.