### PR TITLE
feat(controlplane): add session lifecycle logging

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -117,8 +117,27 @@ func (sm *SessionManager) ReconnectFlightSession(ctx context.Context, username s
 
 func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username string, pid int32, memoryLimit string, threads int, worker *ManagedWorker, protocol string, retireOnFailure bool) (int32, *flightclient.FlightExecutor, error) {
 	createStart := time.Now()
+	slog.Info("Creating session on worker.",
+		"pid", pid,
+		"worker", worker.ID,
+		"user", username,
+		"protocol", protocol,
+		"memory_limit", memoryLimit,
+		"threads", threads,
+		"owner_cp_instance_id", worker.OwnerCPInstanceID(),
+		"owner_epoch", worker.OwnerEpoch(),
+	)
 	sessionToken, err := worker.CreateSession(ctx, username, memoryLimit, threads)
 	if err != nil {
+		slog.Warn("Failed to create session on worker.",
+			"pid", pid,
+			"worker", worker.ID,
+			"user", username,
+			"protocol", protocol,
+			"duration", time.Since(createStart),
+			"retire_on_failure", retireOnFailure,
+			"error", err,
+		)
 		if retireOnFailure {
 			sm.pool.RetireWorkerIfNoSessions(worker.ID)
 		}
@@ -143,9 +162,21 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	sm.mu.Lock()
 	sm.sessions[pid] = session
 	sm.byWorker[worker.ID] = append(sm.byWorker[worker.ID], pid)
+	sessionCount := len(sm.sessions)
+	workerSessionCount := len(sm.byWorker[worker.ID])
 	sm.mu.Unlock()
 
-	slog.Debug("Session created on worker.", "pid", pid, "worker", worker.ID, "user", username, "create_duration", time.Since(createStart))
+	slog.Info("Session created on worker.",
+		"pid", pid,
+		"worker", worker.ID,
+		"user", username,
+		"protocol", protocol,
+		"create_duration", time.Since(createStart),
+		"session_count", sessionCount,
+		"worker_session_count", workerSessionCount,
+		"owner_cp_instance_id", worker.OwnerCPInstanceID(),
+		"owner_epoch", worker.OwnerEpoch(),
+	)
 	if sm.rebalancer != nil {
 		sm.rebalancer.RequestRebalance()
 	}
@@ -155,10 +186,12 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 // DestroySession destroys a session, retires its dedicated worker, and rebalances
 // memory/thread limits across remaining sessions.
 func (sm *SessionManager) DestroySession(pid int32) {
+	destroyStart := time.Now()
 	sm.mu.Lock()
 	session, ok := sm.sessions[pid]
 	if !ok {
 		sm.mu.Unlock()
+		slog.Warn("DestroySession called for unknown session.", "pid", pid)
 		return
 	}
 	delete(sm.sessions, pid)
@@ -171,7 +204,17 @@ func (sm *SessionManager) DestroySession(pid int32) {
 			break
 		}
 	}
+	sessionCount := len(sm.sessions)
+	workerSessionCount := len(sm.byWorker[session.WorkerID])
 	sm.mu.Unlock()
+
+	slog.Info("Destroying session.",
+		"pid", pid,
+		"worker", session.WorkerID,
+		"protocol", session.Protocol,
+		"remaining_sessions", sessionCount,
+		"remaining_worker_sessions", workerSessionCount,
+	)
 
 	// Close the executor
 	if session.Executor != nil {
@@ -184,21 +227,43 @@ func (sm *SessionManager) DestroySession(pid int32) {
 	// enforces single-session isolation; releasing early would let a new
 	// session block on db.Conn() or, worse, share catalog state).
 	worker, ok := sm.pool.Worker(session.WorkerID)
+	workerDestroyAttempted := false
+	workerAlreadyDead := false
+	var workerDestroyErr error
 	if ok {
 		select {
 		case <-worker.done:
+			workerAlreadyDead = true
 			// Worker already dead, skip RPC
 		default:
+			workerDestroyAttempted = true
+			workerDestroyStart := time.Now()
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_ = worker.DestroySession(ctx, session.SessionToken)
+			workerDestroyErr = worker.DestroySession(ctx, session.SessionToken)
 			cancel()
+			slog.Info("Worker session destroy RPC completed.",
+				"pid", pid,
+				"worker", session.WorkerID,
+				"protocol", session.Protocol,
+				"duration", time.Since(workerDestroyStart),
+				"error", workerDestroyErr,
+			)
 		}
 	}
 
 	// Release the worker for reuse after cleanup is complete.
 	sm.pool.ReleaseWorker(session.WorkerID)
 
-	slog.Debug("Session destroyed.", "pid", pid, "worker", session.WorkerID)
+	slog.Info("Session destroyed.",
+		"pid", pid,
+		"worker", session.WorkerID,
+		"protocol", session.Protocol,
+		"duration", time.Since(destroyStart),
+		"worker_found", ok,
+		"worker_already_dead", workerAlreadyDead,
+		"worker_destroy_attempted", workerDestroyAttempted,
+		"worker_destroy_error", workerDestroyErr,
+	)
 
 	// Rebalance remaining sessions
 	if sm.rebalancer != nil {
@@ -224,9 +289,10 @@ func (sm *SessionManager) OnWorkerCrash(workerID int, errorFn func(pid int32)) {
 	}
 	sm.mu.Unlock()
 
-	slog.Warn("Worker crashed, notifying sessions.", "worker", workerID, "sessions", len(pids))
+	slog.Warn("Worker crashed, notifying sessions.", "worker", workerID, "sessions", len(pids), "pids", pids)
 
 	for _, pid := range pids {
+		cleanupStart := time.Now()
 		errorFn(pid)
 		sm.mu.Lock()
 		session, ok := sm.sessions[pid]
@@ -245,7 +311,15 @@ func (sm *SessionManager) OnWorkerCrash(workerID int, errorFn func(pid int32)) {
 				_ = session.connCloser.Close()
 			}
 		}
+		remainingSessions := len(sm.sessions)
 		sm.mu.Unlock()
+		slog.Info("Worker crash session cleanup completed.",
+			"pid", pid,
+			"worker", workerID,
+			"session_found", ok,
+			"duration", time.Since(cleanupStart),
+			"remaining_sessions", remainingSessions,
+		)
 	}
 
 	sm.mu.Lock()


### PR DESCRIPTION
## Summary

Promote and expand the `controlplane/session_mgr.go` lifecycle logs so session create/destroy paths leave a structured trace at INFO level. Useful for diagnosing per-session establishment latency and worker-bind/release transitions on prod where Debug-level logs aren't on.

## Changes

`controlplane/session_mgr.go`:

- **`createSessionOnWorker`**: emit `Creating session on worker` at INFO before the worker RPC (with pid, worker, user, protocol, memory_limit, threads, owner_cp_instance_id, owner_epoch). Promote the existing `Session created on worker` log from Debug → Info and add session_count + worker_session_count + create_duration. Add a `Failed to create session on worker` Warn on the error path with the same context.
- **`DestroySession`**:
  - Warn when called for an unknown pid (currently silently early-returns).
  - Info `Destroying session` at entry with remaining session counts.
  - Info `Worker session destroy RPC completed` after the worker RPC, including its duration and any error.
  - Promote terminal `Session destroyed` Debug → Info with the full disposition (`worker_found`, `worker_already_dead`, `worker_destroy_attempted`, `worker_destroy_error`, total duration).
- **`OnWorkerCrash`**: include `pids` in the existing Warn so operators can correlate crash events with affected sessions, and surface per-pid cleanup timing.

## Why now

Session establishment had ~5-22s tails in recent prod QA, with Debug-level visibility we couldn't tell from logs whether time was being spent in CP-side worker acquisition, the worker RPC, or session-init metadata. This patch adds the timestamps without changing any behavior, so subsequent investigations can read the trace directly from `kubectl logs`.

## Test plan

- `go build ./controlplane/...` clean
- `go vet ./controlplane/...` clean
- `go test ./controlplane/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)