### PR TITLE
fix(worker): per-DuckDB-version pin was silently no-op

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -13,7 +13,15 @@ FROM golang:1.25-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ libc6-dev curl gzip && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-COPY go.mod go.sum ./
+# Copy the full source first. The earlier layout (COPY go.mod go.sum;
+# go get; COPY . .) silently broke per-DuckDB-version pinning: the second
+# COPY overlaid the host's go.mod/go.sum on top of the downgraded ones,
+# undoing the `go get`. Symptom: the duckgres-worker:<sha>-duckdb1.5.1
+# image was actually statically linked against duckdb-go-bindings@v0.10502.0
+# (DuckDB 1.5.2), with bundled 0.4 extensions sitting at /app/extensions/v1.5.1/
+# where the 1.5.2 runtime never looks. Catalog attach failed at runtime
+# with "extension requires version 1.0". COPY-then-pin avoids it.
+COPY . .
 
 ARG VERSION=dev
 ARG COMMIT=unknown
@@ -39,7 +47,6 @@ RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
     fi
 
 RUN go mod download
-COPY . .
 
 ARG DUCKDB_EXTENSION_VERSION=1.5.2
 ARG HTTPFS_EXTENSION_TAG=v1.5.2-stoi-fix
@@ -50,6 +57,23 @@ RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" \
     -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     -o duckgres-worker \
     ./cmd/duckgres-worker
+
+# Defense-in-depth: assert the binary actually links against the bindings
+# version the build args asked for. If a future Dockerfile change re-breaks
+# the pinning, this fails the build instead of shipping a silently-wrong
+# image. The DUCKDB_BINDINGS_VERSION arg encodes DuckDB minor (e.g.
+# v0.10501.0 -> DuckDB 1.5.1); the embedded module info in the binary must
+# match exactly.
+RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
+      embedded=$(go version -m ./duckgres-worker | awk '$2 == "github.com/duckdb/duckdb-go-bindings" { print $3 }') ; \
+      if [ "$embedded" != "$DUCKDB_BINDINGS_VERSION" ]; then \
+        echo "ERROR: bindings pin mismatch — wanted $DUCKDB_BINDINGS_VERSION, got $embedded" >&2 ; \
+        echo "       (full embedded module info follows)" >&2 ; \
+        go version -m ./duckgres-worker | grep duckdb >&2 ; \
+        exit 1 ; \
+      fi ; \
+      echo "Verified: duckgres-worker linked against duckdb-go-bindings@$embedded" ; \
+    fi
 
 RUN mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/benben/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \


### PR DESCRIPTION
## Summary

`Dockerfile.worker`'s per-DuckDB-version pin (e.g. `duckdb1.5.1`) was a silent no-op. The layout was `COPY go.mod go.sum` → `go get @<pinned>` → `COPY . .` → `go build`. The second `COPY` overlays the host's go.mod / go.sum (always at main's version) on top of the downgraded ones, undoing the pin. Result: every `duckgres-worker:<sha>-duckdb1.5.1` image ever published is statically linked against `duckdb-go-bindings@v0.10502.0` (DuckDB 1.5.2), with bundled DuckLake 0.4 extension sitting at `/app/extensions/v1.5.1/` where the 1.5.2 runtime never looks.

Surfaced during Portola onboarding to MTCP: connection succeeded all the way through routing + auth + worker spawn, then attach failed with `DuckLake catalog version mismatch: catalog version is 0.4, but the extension requires version 1.0`. Per [ducklake.select/release_calendar](https://ducklake.select/release_calendar#compatibility-matrix), DuckDB 1.5.1 ships with extension 0.4 supporting spec 0.4 — so the pin to 1.5.1 SHOULD have worked. `go version -m` on the binary inside the existing `<sha>-duckdb1.5.1` image confirmed: it reports `duckdb-go-bindings v0.10502.0`.

## Changes

1. **Move `COPY . .` before the per-version `go get` block** so the downgrade is the final word on go.mod / go.sum.
2. **Post-build assertion**: `go version -m duckgres-worker` is grepped for the duckdb-go-bindings version, compared to `DUCKDB_BINDINGS_VERSION` build arg, build fails on mismatch. Stops a future Dockerfile change from re-breaking this silently.

## Test plan

- [x] Reproduce: `docker run` against existing `<sha>-duckdb1.5.1` image, `go version -m duckgres-worker` reports `v0.10502.0` (wrong).
- [x] Verify the awk pattern correctly extracts the bindings version from `go version -m` output.
- [ ] After merge, container-image-worker-cd builds new images. New `<sha>-duckdb1.5.1` should report `v0.10501.0` (correct). The build's own assertion gates this.
- [ ] Re-PATCH Portola's `image` field on MTCP to the new sha, retry psql, confirm DuckLake attach succeeds against the 0.4 catalog without migration.

## Caveats

- **Every prior `<sha>-duckdb1.5.1` image is broken.** Only post-merge builds are trustworthy. Tags can stay (back-compat for any operator who happened to pin to a specific old sha) but no consumer should be using them.
- No application code change. No memory migration. The user's "never migrate any ducklakes" constraint stands; with this fix DuckDB 1.5.1 reads Portola's 0.4 catalog natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)