### PR TITLE
fix(controlplane): honor per-org image pin in warm-pool reserve fallback

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1362,7 +1362,18 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 
 		p.cleanDeadWorkersLocked()
 
-		idle := p.findReservableWarmWorkerLocked()
+		// In-memory warm-pool fallback for the case where pool.workers has
+		// a worker that the runtime store doesn't (e.g. ClaimIdleWorker just
+		// returned nil because of state-transition skew). Filtered by
+		// assignment.Image so a per-org pin is honored: if the assignment
+		// names a specific image and no in-memory warm worker matches, fall
+		// through to the spawn block — which already does the right thing.
+		// Without this filter, MTCP could hand a pinned org a default-image
+		// warm worker, and activation would fail with a DuckLake/extension
+		// version mismatch (observed in prod-us 2026-05-06 for Portola,
+		// which pins to duckgres-worker:<sha>-duckdb1.5.1 while the warm
+		// pool runs the default 1.5.2 image).
+		idle := p.findReservableWarmWorkerLocked(assignment.Image)
 		if idle != nil {
 			nextState, err := idle.SharedState().Transition(WorkerLifecycleReserved, assignment)
 			if err != nil {
@@ -2467,12 +2478,20 @@ func (p *K8sWorkerPool) isWarmIdleWorkerLocked(w *ManagedWorker) bool {
 	return w.activeSessions == 0 && p.isGenericSessionSchedulableWorkerLocked(w)
 }
 
-func (p *K8sWorkerPool) findReservableWarmWorkerLocked() *ManagedWorker {
+// findReservableWarmWorkerLocked returns a warm-idle worker that is safe to
+// reserve. When image is non-empty, only workers whose image matches are
+// considered — used by ReserveSharedWorker so per-org image pins aren't
+// silently bypassed when the in-memory map and runtime store disagree.
+// Pass "" to skip the image filter (legacy non-pinned callers).
+func (p *K8sWorkerPool) findReservableWarmWorkerLocked(image string) *ManagedWorker {
 	for _, w := range p.workers {
 		select {
 		case <-w.done:
 			continue
 		default:
+		}
+		if image != "" && w.image != image {
+			continue
 		}
 		if p.isWarmIdleWorkerLocked(w) {
 			return w

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -959,6 +959,77 @@ func TestK8sPoolReserveSharedWorkerReservesIdleWorkerWithoutLocalReplenishmentIn
 	}
 }
 
+// TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage ensures the
+// in-memory warm-pool fallback honors per-org image pinning. Without the
+// image filter on findReservableWarmWorkerLocked, ReserveSharedWorker would
+// return a default-image warm worker to a pinned org and the subsequent
+// activation (DuckLake ATTACH inside the worker) would fail with the
+// extension's version-mismatch error. Observed in prod-us 2026-05-06 for
+// Portola, which pins to duckgres-worker:<sha>-duckdb1.5.1 while the warm
+// pool runs the default 1.5.2 single-binary image.
+func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+
+	// A warm-idle worker built from the cluster default image — a tempting
+	// candidate for ReserveSharedWorker if the image filter is missing.
+	defaultWorker := &ManagedWorker{
+		ID:    7,
+		image: "duckgres:default-1.5.2",
+		done:  make(chan struct{}),
+	}
+	pool.workers[defaultWorker.ID] = defaultWorker
+
+	pinnedImage := "duckgres-worker:abc123-duckdb1.5.1"
+	store := &captureRuntimeWorkerStore{
+		// ClaimIdleWorker returns nil (no DB row matches the pinned image),
+		// CreateSpawningWorkerSlot returns a slot for the pinned image so
+		// the spawn path is what serves the request.
+		spawned: &configstore.WorkerRecord{
+			WorkerID:          42,
+			PodName:           "duckgres-worker-test-cp-42",
+			State:             configstore.WorkerStateSpawning,
+			OrgID:             "portola",
+			Image:             pinnedImage,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        1,
+		},
+	}
+	pool.runtimeStore = store
+
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		pool.workers[id] = &ManagedWorker{
+			ID:      id,
+			image:   pinnedImage,
+			podName: "duckgres-worker-test-cp-42",
+			done:    make(chan struct{}),
+		}
+		return nil
+	}
+	pool.healthCheckFunc = func(ctx context.Context, w *ManagedWorker) error { return nil }
+
+	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+		OrgID:      "portola",
+		Image:      pinnedImage,
+		MaxWorkers: 2,
+	})
+	if err != nil {
+		t.Fatalf("ReserveSharedWorker: %v", err)
+	}
+
+	if worker.ID == defaultWorker.ID {
+		t.Fatalf("default-image warm worker (id %d) was returned despite image pin %q", defaultWorker.ID, pinnedImage)
+	}
+	if worker.ID != 42 {
+		t.Fatalf("expected spawned worker id 42, got %d", worker.ID)
+	}
+	if store.spawnImage != pinnedImage {
+		t.Fatalf("spawn image = %q, want %q", store.spawnImage, pinnedImage)
+	}
+	if defaultWorker.SharedState().Lifecycle == WorkerLifecycleReserved {
+		t.Fatalf("default-image warm worker was reserved despite image mismatch")
+	}
+}
+
 func TestK8sPoolReserveSharedWorkerClaimsRuntimeWorkerAndAdoptsPod(t *testing.T) {
 	pool, cs := newTestK8sPool(t, 5)
 	pool.minWorkers = 0

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -15,7 +15,10 @@ func TestOrgReservedPoolAcquireReservesOrgWorker(t *testing.T) {
 	}
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
-		shared.workers[id] = &ManagedWorker{ID: id, done: make(chan struct{})}
+		// Mirror production SpawnWorker behavior: the spawned worker carries
+		// the image it was built from. Required since findReservableWarmWorkerLocked
+		// filters by assignment.Image.
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
 		shared.mu.Unlock()
 		return nil
 	}
@@ -62,7 +65,10 @@ func TestOrgReservedPoolAcquireSkipsOtherOrgsWorkers(t *testing.T) {
 
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
-		shared.workers[id] = &ManagedWorker{ID: id, done: make(chan struct{})}
+		// Mirror production SpawnWorker behavior: the spawned worker carries
+		// the image it was built from. Required since findReservableWarmWorkerLocked
+		// filters by assignment.Image.
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
 		shared.mu.Unlock()
 		return nil
 	}
@@ -123,7 +129,10 @@ func TestOrgReservedWorkerPoolAcquireActivatesReservedWorkerWhenEnabledWithOrgCo
 	}
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
-		shared.workers[id] = &ManagedWorker{ID: id, done: make(chan struct{})}
+		// Mirror production SpawnWorker behavior: the spawned worker carries
+		// the image it was built from. Required since findReservableWarmWorkerLocked
+		// filters by assignment.Image.
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
 		shared.mu.Unlock()
 		return nil
 	}
@@ -157,7 +166,10 @@ func TestOrgReservedWorkerPoolAcquireDelegatesActivationWithoutCachedTenantRunti
 	}
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
-		shared.workers[id] = &ManagedWorker{ID: id, done: make(chan struct{})}
+		// Mirror production SpawnWorker behavior: the spawned worker carries
+		// the image it was built from. Required since findReservableWarmWorkerLocked
+		// filters by assignment.Image.
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
 		shared.mu.Unlock()
 		return nil
 	}


### PR DESCRIPTION
## Summary

`K8sWorkerPool.ReserveSharedWorker` has two candidate-selection paths: a runtime-store path (image-aware via SQL `WHERE image = ?`) and an in-memory fallback (`findReservableWarmWorkerLocked`) for the case where `pool.workers` and the DB diverge briefly during state transitions. The fallback was **image-blind** — it returned the first warm-idle worker regardless of which image it was spawned from.

Effect on a pinned org whose warm pool is built from the cluster default image:
1. `ClaimHotIdleWorker(orgID)` → no hot-idle for the org → nil.
2. `ClaimIdleWorker(orgID, pinned-image)` → no DB row matches the pinned image → nil.
3. **Fallback** → returns a default-image warm worker.
4. Activation RPCs into that worker, tries `ATTACH ducklake:…`, the bundled DuckLake extension rejects the catalog with a version-mismatch error.
5. Concurrently the activation-failure path retires the wrong worker and spawns a fresh pinned one, so the *second* connection succeeds.

Observed in prod-us 2026-05-06: Portola is pinned to `duckgres-worker:<sha>-duckdb1.5.1`, the warm pool runs the default `duckgres:<sha>` (1.5.2) single-binary image. Every cold connection got the version-mismatch error once before a follow-up succeeded.

## Changes

- `findReservableWarmWorkerLocked(image string)` — new param. Skips workers whose `.image` doesn't equal `image`. Empty `image` preserves the unfiltered behavior so non-pinned callers and process-backend deployments are unaffected.
- Caller in `ReserveSharedWorker` passes `assignment.Image`.
- New regression test: `TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage`. Seeds a default-image warm worker, calls `ReserveSharedWorker` with a different image pin, asserts the default-image worker is not returned and `CreateSpawningWorkerSlot` was called with the pinned image.
- Drive-by: 4 `org_reserved_pool_test.go` tests' `spawnWarmWorkerFunc` mocks were stuffing workers into `pool.workers` without setting `.image`. Production `SpawnWorker` (`k8s_pool.go:777`) sets it; the tests now match. They passed before only because the fallback didn't filter on it.

## Test plan
- [x] `go test -tags kubernetes ./controlplane/...` — all green, including the existing `TestK8sPoolReserveSharedWorkerReservesIdleWorkerWithoutLocalReplenishmentInRuntimeMode` which intentionally exercises the in-memory fallback in runtime-store mode (passes because that test uses empty `assignment.Image`).
- [x] Full sweep `./controlplane/... ./server/...` — green.
- [ ] After deploy, retry `psql` against Portola from a cold CP. Expectation: first connection no longer fails; one cold-spawn pause (~10s) instead of fail-then-retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)