### PR TITLE
tracing: add DuckDB profiling breakdown to extended-query path

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -5388,7 +5388,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	start := time.Now()
 	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 
-	_, span := observe.Tracer().Start(c.ctx, "duckgres.query",
+	queryCtx, span := observe.Tracer().Start(c.ctx, "duckgres.query",
 		trace.WithAttributes(
 			attribute.String("duckgres.protocol", "extended"),
 			attribute.String("duckgres.org_id", c.orgID),
@@ -5484,7 +5484,11 @@ func (c *clientConn) handleExecute(body []byte) {
 			return result, err
 		}
 
+		execStart := time.Now()
+		execCtx, execSpan := observe.Tracer().Start(queryCtx, "duckgres.execute")
 		result, err := runExec()
+		observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
 				ducklakeConflictTotal.Inc()
@@ -5533,6 +5537,8 @@ func (c *clientConn) handleExecute(body []byte) {
 		return c.executor.Query(convertedQuery, args...)
 	}
 
+	execStart := time.Now()
+	execCtx, execSpan := observe.Tracer().Start(queryCtx, "duckgres.execute")
 	rows, err := runQuery()
 	if err != nil && c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
 		ducklakeConflictTotal.Inc()
@@ -5549,6 +5555,8 @@ func (c *clientConn) handleExecute(body []byte) {
 			runQuery,
 		)
 	}
+	observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+	execSpan.End()
 	if err != nil {
 		queryFinalErr = err
 		errCode := classifyErrorCode(err)


### PR DESCRIPTION
## Summary
- The simple-query path wraps each statement in a `duckgres.execute` child span and calls `observe.EnrichSpanWithProfiling`, which parses DuckDB's profiling JSON and emits `duckdb.planning` / `duckdb.scan` / `duckdb.compute` child spans plus `duckdb.*` attributes.
- The extended-query path (`handleExecute`) was missing both. Traces with `duckgres.protocol = extended` only showed `duckgres.query` / `duckgres.transpile` and an attribute-less `duckgres.execute`.
- This mirrors the simple-path treatment in `handleExecute` for both the non-result-returning and result-returning branches: capture `queryCtx` from the `duckgres.query` span, wrap the executor call(s) in a `duckgres.execute` child span, and call `EnrichSpanWithProfiling` once execution returns.

## Test plan
- [ ] Build passes (`go build ./...`).
- [ ] Run a SELECT via a client that uses the extended protocol (e.g. psycopg with parameter binding) and confirm the trace now contains `duckdb.planning`, `duckdb.scan`, `duckdb.compute` child spans plus `duckdb.*` attributes on `duckgres.execute`.
- [ ] Confirm a SELECT via simple protocol still produces the same breakdown (no regression).
- [ ] Confirm an extended-protocol SET / utility statement still completes cleanly (no profiling expected — `LastProfilingOutput()` is empty so `EnrichSpanWithProfiling` is a no-op).