### PR TITLE
feat(controlplane): stamp duckgres/active-org on worker pod at activation

### DIFF
--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -20,8 +20,16 @@ import (
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/ducklake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
+
+// activeOrgLabelKey is the pod label that per-warehouse Cilium policies
+// select on. The Crossplane Duckling composition pre-creates a
+// CiliumClusterwideNetworkPolicy keyed on this label + the org name, so
+// stamping the label at activation time is what causes the policy to
+// snap onto the worker pod via label selector — no per-pod CRD writes.
+const activeOrgLabelKey = "duckgres/active-org"
 
 type SharedWorkerActivator struct {
 	clientset              kubernetes.Interface
@@ -155,6 +163,17 @@ func (a *SharedWorkerActivator) ActivateReservedWorker(ctx context.Context, work
 
 	err = activate()
 
+	// Stamp the active-org label on the worker pod so the per-warehouse
+	// CiliumClusterwideNetworkPolicy (pre-created by the Crossplane
+	// Duckling composition) snaps onto this pod via label selector.
+	// Best-effort and idempotent: a failure here does not fail activation;
+	// the worker still functions, it just won't have its per-tenant
+	// network policy applied until something patches the label later.
+	// See also docs on activeOrgLabelKey.
+	if err == nil {
+		a.stampActiveOrgLabel(ctx, worker.PodName(), payload.OrgID)
+	}
+
 	// Clear the migration lock after the worker finishes activation
 	// (whether it succeeded or failed). New connections can proceed.
 	if payload.DuckLake.Migrate {
@@ -186,6 +205,28 @@ func (a *SharedWorkerActivator) ActivateReservedWorker(ctx context.Context, work
 	}
 
 	return err
+}
+
+// stampActiveOrgLabel patches the worker pod with `duckgres/active-org=<org>`.
+// Strategic-merge so re-activations (e.g. credential refresh) are no-ops
+// once the label is set. Logs and swallows errors; the activation has
+// already completed by the time we get here, and the label is a security
+// optimisation rather than a functional requirement.
+func (a *SharedWorkerActivator) stampActiveOrgLabel(ctx context.Context, podName, orgID string) {
+	if a.clientset == nil || podName == "" || orgID == "" {
+		return
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, activeOrgLabelKey, orgID)
+	if _, err := a.clientset.CoreV1().Pods(a.defaultNamespace).Patch(
+		ctx,
+		podName,
+		types.StrategicMergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+	); err != nil {
+		slog.Warn("Failed to stamp active-org label on worker pod.",
+			"pod", podName, "org", orgID, "error", err)
+	}
 }
 
 // RefreshCredentials brokers a fresh STS session for the worker's org and

--- a/controlplane/shared_worker_activator_label_test.go
+++ b/controlplane/shared_worker_activator_label_test.go
@@ -1,0 +1,118 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestStampActiveOrgLabel verifies the post-activation label patch lands
+// on the worker pod. The pre-provisioned per-warehouse Cilium policy
+// keys on this label, so the patch is what causes the policy to apply.
+func TestStampActiveOrgLabel(t *testing.T) {
+	const (
+		ns      = "duckgres"
+		podName = "duckgres-cp-worker-7"
+		orgID   = "tenant-alpha"
+	)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app":                "duckgres-worker",
+				"duckgres/worker-id": "7",
+			},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+	a := &SharedWorkerActivator{clientset: cs, defaultNamespace: ns}
+
+	a.stampActiveOrgLabel(context.Background(), podName, orgID)
+
+	got, err := cs.CoreV1().Pods(ns).Get(context.Background(), podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if got.Labels[activeOrgLabelKey] != orgID {
+		t.Errorf("label %s: got %q, want %q", activeOrgLabelKey, got.Labels[activeOrgLabelKey], orgID)
+	}
+	// Existing labels must be preserved (strategic-merge, not replace).
+	if got.Labels["duckgres/worker-id"] != "7" {
+		t.Errorf("strategic-merge dropped existing label duckgres/worker-id")
+	}
+}
+
+// TestStampActiveOrgLabelIdempotent verifies that re-stamping the same
+// label is a no-op — the credential-refresh path re-enters activation
+// for already-running workers, so we must not error or churn the pod.
+func TestStampActiveOrgLabelIdempotent(t *testing.T) {
+	const (
+		ns      = "duckgres"
+		podName = "duckgres-cp-worker-7"
+		orgID   = "tenant-alpha"
+	)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels:    map[string]string{activeOrgLabelKey: orgID},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+	a := &SharedWorkerActivator{clientset: cs, defaultNamespace: ns}
+
+	a.stampActiveOrgLabel(context.Background(), podName, orgID)
+	a.stampActiveOrgLabel(context.Background(), podName, orgID)
+
+	got, _ := cs.CoreV1().Pods(ns).Get(context.Background(), podName, metav1.GetOptions{})
+	if got.Labels[activeOrgLabelKey] != orgID {
+		t.Errorf("label clobbered after repeated stamping: got %q", got.Labels[activeOrgLabelKey])
+	}
+}
+
+// TestStampActiveOrgLabelSwallowsErrors verifies the patch is best-effort:
+// a Patch failure (e.g. pod was just retired and 404s) must not panic or
+// surface back to the activation caller.
+func TestStampActiveOrgLabelSwallowsErrors(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated apiserver failure")
+	})
+	a := &SharedWorkerActivator{clientset: cs, defaultNamespace: "duckgres"}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("stampActiveOrgLabel panicked on Patch error: %v", r)
+		}
+	}()
+	a.stampActiveOrgLabel(context.Background(), "duckgres-cp-worker-99", "tenant-x")
+}
+
+// TestStampActiveOrgLabelGuardsEmptyInputs covers the trivial guards —
+// an empty pod name or org ID must be a silent no-op (no apiserver call,
+// no panic). This protects the credential-refresh and re-activation paths
+// where the worker may not have a pod handle in unit tests.
+func TestStampActiveOrgLabelGuardsEmptyInputs(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	called := false
+	cs.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		called = true
+		return true, nil, nil
+	})
+	a := &SharedWorkerActivator{clientset: cs, defaultNamespace: "duckgres"}
+
+	a.stampActiveOrgLabel(context.Background(), "", "tenant-x")
+	a.stampActiveOrgLabel(context.Background(), "duckgres-cp-worker-1", "")
+	if called {
+		t.Error("Patch was called despite empty pod name / org ID guard")
+	}
+}


### PR DESCRIPTION
## Summary

Step 1 of the per-tenant network-policy plan we agreed on after the cluster-wide CCNP merged in charts#10949.

Patches \`duckgres/active-org=<orgID>\` onto the worker pod after \`ActivateTenant\` returns success. This is what a per-warehouse \`CiliumClusterwideNetworkPolicy\` (created by the Crossplane Duckling composition in the next step) will select on — pre-existing policy snaps onto a freshly-labelled worker via label selector, no per-pod CRD writes per activation.

## Properties

- **One K8s Patch per activation** (strategic-merge so other labels are preserved).
- **Best-effort**: a Patch failure logs a warning and does not fail the activation. The worker still functions; it just won't be covered by its per-tenant network policy until the next attempt.
- **Idempotent**: re-stamping with the same value is a no-op. This matters for the credential-refresh path (\`RefreshCredentials\` re-enters the activation flow on already-activated workers).
- **No behaviour change yet** — nothing reads the label until the Crossplane composition + default-policy changes land. This PR just produces the label so the data is in place when the policy machinery arrives.

## Tests

- \`TestStampActiveOrgLabel\` — patch lands and preserves existing labels.
- \`TestStampActiveOrgLabelIdempotent\` — repeated stamping is a no-op.
- \`TestStampActiveOrgLabelSwallowsErrors\` — Patch failure does not panic / surface to caller.
- \`TestStampActiveOrgLabelGuardsEmptyInputs\` — empty pod name or org ID is a silent no-op (no apiserver call).

## Test plan

- [x] Unit tests pass (\`go test -tags kubernetes ./controlplane/\`).
- [ ] Deploy to mw-dev, activate a worker (\`SELECT 1\` against ben2), verify the \`duckgres/active-org=ben2\` label appears via \`kubectl --context=posthog-mw-dev -n duckgres get pods -l app=duckgres-worker -L duckgres/active-org\`.