### PR TITLE
tracing: profile non-SELECT queries and trace DoPut RPCs

### DIFF
--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -73,3 +73,81 @@ func TestProfilingOutputToFile(t *testing.T) {
 		}
 	}
 }
+
+// TestProfilingCoverageAllCoversNonSelect pins the behavior that motivates
+// `SET profiling_coverage = 'ALL'` in ConfigureMainDB: with the default
+// coverage ('SELECT') DuckDB silently skips writing the profile file for
+// some non-SELECT statements (notably INSERT and bare CREATE TABLE), so
+// the worker's gRPC trailer comes back empty and EnrichSpanWithProfiling
+// no-ops on the control plane. INSERT is used here because in DuckDB
+// v1.5.2 it's the cleanest reproduction — CTAS already gets profiled
+// under the default because of its embedded SELECT.
+func TestProfilingCoverageAllCoversNonSelect(t *testing.T) {
+	mustExec := func(t *testing.T, db *sql.DB, stmts ...string) {
+		t.Helper()
+		for _, s := range stmts {
+			if _, err := db.Exec(s); err != nil {
+				t.Fatalf("%s: %v", s, err)
+			}
+		}
+	}
+
+	// Default coverage ('SELECT'): INSERT must NOT produce profile JSON.
+	// If DuckDB ever changes the default to cover INSERT this will catch it
+	// and we can re-evaluate whether the explicit 'ALL' is still needed.
+	t.Run("default coverage skips INSERT", func(t *testing.T) {
+		db, err := sql.Open("duckdb", ":memory:")
+		if err != nil {
+			t.Fatalf("open duckdb: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		tmpFile := t.TempDir() + "/profiling.json"
+		mustExec(t, db,
+			"CREATE TABLE t (x INT)",
+			"SET enable_profiling = 'json'",
+			"SET profiling_mode = 'detailed'",
+			"SET profiling_output = '"+tmpFile+"'",
+		)
+		mustExec(t, db, "INSERT INTO t VALUES (1), (2), (3)")
+
+		data, err := os.ReadFile(tmpFile)
+		if err == nil && len(data) > 0 {
+			t.Fatalf("expected no profile JSON for INSERT under default coverage, got %d bytes", len(data))
+		}
+	})
+
+	// coverage = 'ALL': INSERT must produce a parseable profile.
+	t.Run("coverage=ALL covers INSERT", func(t *testing.T) {
+		db, err := sql.Open("duckdb", ":memory:")
+		if err != nil {
+			t.Fatalf("open duckdb: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		tmpFile := t.TempDir() + "/profiling.json"
+		mustExec(t, db,
+			"CREATE TABLE t (x INT)",
+			"SET enable_profiling = 'json'",
+			"SET profiling_mode = 'detailed'",
+			"SET profiling_coverage = 'ALL'",
+			"SET profiling_output = '"+tmpFile+"'",
+		)
+		mustExec(t, db, "INSERT INTO t VALUES (1), (2), (3)")
+
+		data, err := os.ReadFile(tmpFile)
+		if err != nil {
+			t.Fatalf("read profiling file: %v", err)
+		}
+		if len(data) == 0 {
+			t.Fatal("profiling output file is empty after INSERT with coverage='ALL'")
+		}
+		m, ok := observe.ParseProfilingOutput(string(data))
+		if !ok {
+			t.Fatalf("failed to parse profiling output: %s", data[:min(200, len(data))])
+		}
+		if m.Latency <= 0 {
+			t.Errorf("expected positive latency, got %f", m.Latency)
+		}
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -882,6 +882,13 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 	if _, err := db.Exec("SET profiling_mode = 'detailed'"); err != nil {
 		slog.Warn("Failed to set DuckDB profiling mode.", "error", err)
 	}
+	// Default profiling_coverage is 'SELECT', which silently skips
+	// CTAS / INSERT / UPDATE / DELETE / DDL — so /tmp/duckgres-profiling.json
+	// stays unchanged for those queries and the gRPC trailer comes back empty,
+	// which makes EnrichSpanWithProfiling no-op on the control plane.
+	if _, err := db.Exec("SET profiling_coverage = 'ALL'"); err != nil {
+		slog.Warn("Failed to set DuckDB profiling coverage.", "error", err)
+	}
 	if _, err := db.Exec("SET profiling_output = '/tmp/duckgres-profiling.json'"); err != nil {
 		slog.Warn("Failed to set DuckDB profiling output path.", "error", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -882,10 +882,12 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 	if _, err := db.Exec("SET profiling_mode = 'detailed'"); err != nil {
 		slog.Warn("Failed to set DuckDB profiling mode.", "error", err)
 	}
-	// Default profiling_coverage is 'SELECT', which silently skips
-	// CTAS / INSERT / UPDATE / DELETE / DDL — so /tmp/duckgres-profiling.json
-	// stays unchanged for those queries and the gRPC trailer comes back empty,
-	// which makes EnrichSpanWithProfiling no-op on the control plane.
+	// Default profiling_coverage is 'SELECT', which silently skips writing
+	// the profile file for some non-SELECT statements — INSERT and bare
+	// DDL like CREATE TABLE are the most visible cases. When that happens,
+	// /tmp/duckgres-profiling.json stays unchanged, the worker's gRPC
+	// trailer comes back empty, and EnrichSpanWithProfiling no-ops on the
+	// control plane. See TestProfilingCoverageAllCoversNonSelect.
 	if _, err := db.Exec("SET profiling_coverage = 'ALL'"); err != nil {
 		slog.Warn("Failed to set DuckDB profiling coverage.", "error", err)
 	}

--- a/server/sqlcore/otel.go
+++ b/server/sqlcore/otel.go
@@ -9,14 +9,17 @@ import (
 )
 
 // OTELGRPCClientHandler returns a gRPC StatsHandler that creates spans only
-// for query-related Flight SQL RPCs (GetFlightInfo, DoGet), filtering out
-// noisy control-plane calls (DoAction for health checks, session management).
+// for query-related Flight SQL RPCs (GetFlightInfo, DoGet, DoPut), filtering
+// out noisy control-plane calls (DoAction for health checks, session
+// management). DoPut covers ExecuteUpdate (non-result-returning queries:
+// CTAS, INSERT, UPDATE, DELETE, DDL) — without it those queries had no
+// Flight wall-time visibility in traces.
 func OTELGRPCClientHandler() grpc.DialOption {
 	return grpc.WithStatsHandler(otelgrpc.NewClientHandler(
 		otelgrpc.WithFilter(func(info *stats.RPCTagInfo) bool {
-			// Only trace query execution RPCs, not session/health management.
 			return strings.Contains(info.FullMethodName, "GetFlightInfo") ||
-				strings.Contains(info.FullMethodName, "DoGet")
+				strings.Contains(info.FullMethodName, "DoGet") ||
+				strings.Contains(info.FullMethodName, "DoPut")
 		}),
 	))
 }


### PR DESCRIPTION
## Summary
- DuckDB's `profiling_coverage` defaults to `SELECT`, so even with `enable_profiling = 'json'` the worker silently skipped writing the profile file for INSERT and bare CREATE TABLE. The empty file produced an empty gRPC trailer, which made `EnrichSpanWithProfiling` no-op on the control plane and left `duckgres.execute` spans without any `duckdb.*` attributes for those queries. Add `SET profiling_coverage = 'ALL'` to `ConfigureMainDB`.
- The OTel gRPC client interceptor in `server/sqlcore/otel.go` whitelisted only `GetFlightInfo` and `DoGet`, but non-result-returning queries go through `ExecuteUpdate` / `DoPut`. Add `DoPut` to the filter so Flight wall time shows up in traces even when DuckDB profiling is unavailable.
- Pin the new behavior with `TestProfilingCoverageAllCoversNonSelect`: a "default coverage skips INSERT" subtest reproduces the bug, and a "coverage=ALL covers INSERT" subtest verifies the fix.

## Notes
- INSERT is the cleanest reproduction in DuckDB v1.5.2 — CTAS gets profiled under the default because of its embedded SELECT, so the user-visible "no breakdown for CTAS" is a related but separate symptom (see follow-up below).
- Outstanding follow-up (separate PR): some duckgres sessions show `enable_profiling` as empty when queried via `duckdb_settings()`, which suggests the `ConfigureMainDB` SETs aren't sticking on every connection in the pool. Worth investigating once this lands.

## Test plan
- [x] `go build ./...`
- [x] `go test -run TestProfiling -count=1 ./server/` (existing + new tests pass)
- [ ] Deploy to dev, run an INSERT against a Flight worker, confirm the trace's `duckgres.execute` span now has `duckdb.latency_s` etc. and an `arrow.flight.protocol.FlightService/DoPut` client span.
- [ ] Run a SELECT to confirm no regression — full breakdown should still appear.