### PR TITLE
tracing: re-apply profiling settings per session in cluster mode

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -440,6 +440,13 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 	// Since the DB is shared, we must set session-local parameters here.
 	initSearchPath(conn, username)
 
+	// Re-apply DuckDB profiling settings on the freshly-pooled connection.
+	// ConfigureMainDB sets these once at warmup, but in cluster mode the
+	// per-session evictConnFromPool call discards the settings along with
+	// the conn — so for every session after the first we need to re-apply.
+	// DuckDB rejects `SET GLOBAL` for these keys, so this is the only path.
+	server.ApplyProfilingSettings(context.Background(), conn)
+
 	// Apply initial resource limits if provided (optimizes handshake by avoiding
 	// roundtrips from control plane).
 	if memoryLimit != "" {

--- a/server/profiling.go
+++ b/server/profiling.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+)
+
+// ProfilingOutputPath is where DuckDB writes the per-query profile JSON.
+// The duckdbservice worker reads this file after each query and forwards
+// the contents to the control plane via gRPC trailer (see
+// duckdbservice.sendProfilingMetadata) where EnrichSpanWithProfiling turns
+// it into OTEL child spans.
+const ProfilingOutputPath = "/tmp/duckgres-profiling.json"
+
+// ProfilingSetupSQL returns the SQL statements that configure DuckDB
+// profiling so the output is written to outputPath. These are
+// session-scoped — DuckDB rejects `SET GLOBAL` for each one — so any
+// caller that hands out fresh connections (e.g. after evictConnFromPool)
+// must re-run them per connection.
+func ProfilingSetupSQL(outputPath string) []string {
+	return []string{
+		// 'json' enables profiling and selects JSON output (the format the
+		// control-plane parser expects).
+		"SET enable_profiling = 'json'",
+		// 'detailed' adds operator-level timings on top of the standard
+		// query-level latency / row counts.
+		"SET profiling_mode = 'detailed'",
+		// Default coverage is 'SELECT', which silently skips writing the
+		// profile file for INSERT / bare CREATE TABLE / etc. — see
+		// TestProfilingCoverageAllCoversNonSelect.
+		"SET profiling_coverage = 'ALL'",
+		"SET profiling_output = '" + outputPath + "'",
+	}
+}
+
+// ApplyProfilingSettings runs ProfilingSetupSQL against the given
+// connection, writing profiles to ProfilingOutputPath. Use this for
+// connections that bypass ConfigureMainDB — primarily fresh per-session
+// connections in the cluster-mode worker, where eviction between sessions
+// discards whatever settings ConfigureMainDB applied.
+func ApplyProfilingSettings(ctx context.Context, conn *sql.Conn) {
+	for _, stmt := range ProfilingSetupSQL(ProfilingOutputPath) {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			slog.Warn("Failed to apply DuckDB profiling setting on session conn.", "stmt", stmt, "error", err)
+		}
+	}
+}

--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"os"
 	"testing"
@@ -150,4 +152,108 @@ func TestProfilingCoverageAllCoversNonSelect(t *testing.T) {
 			t.Errorf("expected positive latency, got %f", m.Latency)
 		}
 	})
+}
+
+// TestProfilingSettingsArePerConnection reproduces the cluster-mode bug:
+// DuckDB profiling settings are session-scoped (DuckDB rejects `SET GLOBAL`
+// for `enable_profiling` etc.), so when the worker's evictConnFromPool
+// discards a session's connection between sessions, the next fresh
+// connection has no profiling configured and the profile file stays
+// untouched. ProfilingSetupSQL applied per-connection is the fix.
+func TestProfilingSettingsArePerConnection(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	// Two slots so we can pin two distinct underlying connections.
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(2)
+
+	ctx := context.Background()
+	tmpFile := t.TempDir() + "/profiling.json"
+	setup := ProfilingSetupSQL(tmpFile)
+
+	// Connection A: full setup, simulates the warmup conn that ConfigureMainDB
+	// ran on. Apply the production setup statements directly so we're testing
+	// the same SQL the real code path uses.
+	connA, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn A: %v", err)
+	}
+	defer func() { _ = connA.Close() }()
+	if _, err := connA.ExecContext(ctx, "CREATE TABLE t (x INT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	for _, s := range setup {
+		if _, err := connA.ExecContext(ctx, s); err != nil {
+			t.Fatalf("connA %s: %v", s, err)
+		}
+	}
+
+	// Connection B: pretend we've evicted A and the pool handed out a fresh
+	// conn. Without per-session re-application, this conn has no profiling
+	// settings.
+	connB, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn B: %v", err)
+	}
+	defer func() { _ = connB.Close() }()
+
+	_ = os.Remove(tmpFile)
+	if _, err := connB.ExecContext(ctx, "INSERT INTO t VALUES (1)"); err != nil {
+		t.Fatalf("connB pre-fix INSERT: %v", err)
+	}
+	if data, err := os.ReadFile(tmpFile); err == nil && len(data) > 0 {
+		t.Fatalf("pre-fix sanity: fresh conn should not produce profile JSON, got %d bytes", len(data))
+	}
+
+	// Now apply the same setup to connB and re-run the INSERT — this is what
+	// duckdbservice.CreateSession does via server.ApplyProfilingSettings.
+	for _, s := range setup {
+		if _, err := connB.ExecContext(ctx, s); err != nil {
+			t.Fatalf("connB re-apply %s: %v", s, err)
+		}
+	}
+	_ = os.Remove(tmpFile)
+	if _, err := connB.ExecContext(ctx, "INSERT INTO t VALUES (2)"); err != nil {
+		t.Fatalf("connB post-fix INSERT: %v", err)
+	}
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("read profile after re-apply: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("post-fix: profile file is empty after INSERT — re-applying setup should have re-enabled profiling")
+	}
+	m, ok := observe.ParseProfilingOutput(string(data))
+	if !ok {
+		t.Fatalf("failed to parse profile JSON: %s", data[:min(200, len(data))])
+	}
+	if m.Latency <= 0 {
+		t.Errorf("expected positive latency, got %f", m.Latency)
+	}
+
+	// Belt-and-braces: confirm a fresh conn after eviction really has empty
+	// settings — i.e. nothing about ProfilingSetupSQL silently sets state on
+	// the underlying driver/connector that survives across connections.
+	_ = connB.Raw(func(any) error { return driver.ErrBadConn })
+	connC, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn C: %v", err)
+	}
+	defer func() { _ = connC.Close() }()
+	rows, err := connC.QueryContext(ctx, "SELECT value FROM duckdb_settings() WHERE name = 'enable_profiling'")
+	if err != nil {
+		t.Fatalf("connC query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		t.Fatal("expected one row from duckdb_settings()")
+	}
+	var got string
+	_ = rows.Scan(&got)
+	if got != "" {
+		t.Fatalf("fresh conn C should have empty enable_profiling, got %q — settings unexpectedly survived", got)
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -876,23 +876,16 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 	// (just clock_gettime per operator boundary).
 	// Output goes to a fixed temp file; in K8s mode the worker reads it
 	// after each query and sends it to the control plane via gRPC trailer.
-	if _, err := db.Exec("SET enable_profiling = 'json'"); err != nil {
-		slog.Warn("Failed to enable DuckDB profiling.", "error", err)
-	}
-	if _, err := db.Exec("SET profiling_mode = 'detailed'"); err != nil {
-		slog.Warn("Failed to set DuckDB profiling mode.", "error", err)
-	}
-	// Default profiling_coverage is 'SELECT', which silently skips writing
-	// the profile file for some non-SELECT statements — INSERT and bare
-	// DDL like CREATE TABLE are the most visible cases. When that happens,
-	// /tmp/duckgres-profiling.json stays unchanged, the worker's gRPC
-	// trailer comes back empty, and EnrichSpanWithProfiling no-ops on the
-	// control plane. See TestProfilingCoverageAllCoversNonSelect.
-	if _, err := db.Exec("SET profiling_coverage = 'ALL'"); err != nil {
-		slog.Warn("Failed to set DuckDB profiling coverage.", "error", err)
-	}
-	if _, err := db.Exec("SET profiling_output = '/tmp/duckgres-profiling.json'"); err != nil {
-		slog.Warn("Failed to set DuckDB profiling output path.", "error", err)
+	//
+	// These SETs are session-scoped in DuckDB and cannot be set globally,
+	// so they only apply to whichever connection runs them now. In cluster
+	// mode (sharedWarmMode) the worker evicts connections between sessions
+	// (see duckdbservice.evictConnFromPool), so per-session re-application
+	// is required — see ApplyProfilingSettings.
+	for _, stmt := range ProfilingSetupSQL(ProfilingOutputPath) {
+		if _, err := db.Exec(stmt); err != nil {
+			slog.Warn("Failed to apply DuckDB profiling setting.", "stmt", stmt, "error", err)
+		}
 	}
 
 	// Configure cache_httpfs cache directory if the extension is loaded.


### PR DESCRIPTION
## Summary
Closes the follow-up flagged in #544: profiling settings weren't sticking on the connection that served queries.

DuckDB profiling settings (`enable_profiling`, `profiling_mode`, `profiling_coverage`, `profiling_output`) are session-scoped — DuckDB rejects `SET GLOBAL` for each one. `ConfigureMainDB` only applies them to whichever pooled connection it ran on. In cluster mode (`sharedWarmMode`), `evictConnFromPool` discards every session's connection on tear-down, so the next session is handed a fresh DuckDB connection with profiling unconfigured.

The visible symptom was: every session after the first emitted no profile JSON, the worker's gRPC trailer came back empty, and `EnrichSpanWithProfiling` no-op'd on the control plane — leaving `duckgres.execute` spans without any `duckdb.*` attributes for every session after the first. (This matches the side-finding noted in #544: "enable_profiling came back empty until I re-issued the SETs in the psql session.")

## Changes
- Extract the profiling SETs into `server.ProfilingSetupSQL(outputPath)` and `server.ApplyProfilingSettings(ctx, conn)` (`server/profiling.go`).
- `ConfigureMainDB` now calls the helper instead of inlining the SETs.
- `duckdbservice.CreateSession` calls `server.ApplyProfilingSettings` on every freshly-pooled session connection, alongside `initSearchPath` and the per-session `memory_limit` / `threads` SETs.
- Add `TestProfilingSettingsArePerConnection` that pins the bug and the fix:
  - a fresh conn after another conn's setup has empty `enable_profiling`;
  - an INSERT on the unconfigured conn produces no profile JSON;
  - re-applying the SETs on that conn lets the same INSERT produce a parseable profile with positive latency.

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 -timeout 60s ./server/`
- [x] `go test -count=1 -timeout 120s ./duckdbservice/`
- [ ] Deploy to dev, run two psql sessions back-to-back against a Flight worker, confirm both produce `duckdb.latency_s` etc. on `duckgres.execute`. Without the fix only the first session's spans would carry those attributes.