### PR TITLE
tracing: capture trailer from streaming ExecuteUpdate (DoPut)

### DIFF
--- a/server/flightclient/exec_update_trailer.go
+++ b/server/flightclient/exec_update_trailer.go
@@ -1,0 +1,96 @@
+package flightclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// executeUpdateWithTrailer is a hand-rolled equivalent of
+// flightsql.Client.ExecuteUpdate that exposes the gRPC trailer.
+//
+// ExecuteUpdate is a bidirectional-streaming RPC (DoPut). Passing
+// grpc.Trailer(&md) as a CallOption is documented to work for unary RPCs;
+// for streams the trailer is only reachable via stream.Trailer() *after*
+// stream.Recv has returned a non-nil error (typically io.EOF). The
+// standard ExecuteUpdate hides the stream so that's not possible from
+// outside, which means the worker's per-query profiling JSON (sent as a
+// trailer) was silently dropped on the control-plane side for every
+// non-result-returning query.
+//
+// This re-implements the same wire interaction (descriptor + CommandStatementUpdate),
+// then drains the stream to io.EOF and pulls the trailer.
+func executeUpdateWithTrailer(ctx context.Context, c *flightsql.Client, query string) (int64, metadata.MD, error) {
+	cmd := &pb.CommandStatementUpdate{Query: query}
+
+	var anyMsg anypb.Any
+	if err := anyMsg.MarshalFrom(cmd); err != nil {
+		return 0, nil, fmt.Errorf("marshal CommandStatementUpdate: %w", err)
+	}
+	descBytes, err := proto.Marshal(&anyMsg)
+	if err != nil {
+		return 0, nil, fmt.Errorf("marshal Any: %w", err)
+	}
+	desc := &flight.FlightDescriptor{
+		Type: flight.DescriptorCMD,
+		Cmd:  descBytes,
+	}
+
+	stream, err := c.Client.DoPut(ctx)
+	if err != nil {
+		return 0, nil, fmt.Errorf("flight doput: %w", err)
+	}
+
+	if err := stream.Send(&flight.FlightData{FlightDescriptor: desc}); err != nil {
+		return 0, stream.Trailer(), fmt.Errorf("flight doput send: %w", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		return 0, stream.Trailer(), fmt.Errorf("flight doput close-send: %w", err)
+	}
+
+	res, err := stream.Recv()
+	if err != nil {
+		return 0, stream.Trailer(), err
+	}
+
+	// Drain to io.EOF so the trailer is materialised. The worker sends a
+	// single PutResult and closes the stream, so this Recv should return
+	// io.EOF immediately.
+	if drainErr := drainToEOF(stream); drainErr != nil {
+		// Surface the error, but the trailer may still be valid.
+		return 0, stream.Trailer(), drainErr
+	}
+
+	trailer := stream.Trailer()
+
+	var updateResult pb.DoPutUpdateResult
+	if err := proto.Unmarshal(res.GetAppMetadata(), &updateResult); err != nil {
+		return 0, trailer, fmt.Errorf("unmarshal DoPutUpdateResult: %w", err)
+	}
+	return updateResult.GetRecordCount(), trailer, nil
+}
+
+// drainToEOF reads from the stream until io.EOF or another non-nil error.
+// Per the gRPC contract, the trailer is only reachable after Recv returns
+// a non-nil error — io.EOF is the expected terminator for a clean
+// DoPut/ExecuteUpdate exchange.
+func drainToEOF(stream pb.FlightService_DoPutClient) error {
+	for {
+		_, err := stream.Recv()
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+}

--- a/server/flightclient/exec_update_trailer_test.go
+++ b/server/flightclient/exec_update_trailer_test.go
@@ -1,0 +1,92 @@
+package flightclient
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeFlightServer implements just the DoPut method so we can verify the
+// gRPC trailer flows through. Anything else returns Unimplemented via the
+// embedded UnimplementedFlightServiceServer.
+type fakeFlightServer struct {
+	pb.UnimplementedFlightServiceServer
+	rowsAffected int64
+	trailer      metadata.MD
+}
+
+func (s *fakeFlightServer) DoPut(stream pb.FlightService_DoPutServer) error {
+	// Consume the FlightDescriptor sent by the client. We don't bother
+	// decoding it — the test only cares about the trailer round-trip.
+	if _, err := stream.Recv(); err != nil {
+		return err
+	}
+
+	updateResult := &pb.DoPutUpdateResult{RecordCount: s.rowsAffected}
+	metaBytes, err := proto.Marshal(updateResult)
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&pb.PutResult{AppMetadata: metaBytes}); err != nil {
+		return err
+	}
+
+	if s.trailer != nil {
+		stream.SetTrailer(s.trailer)
+	}
+	return nil
+}
+
+// TestExecuteUpdateWithTrailerCapturesProfilingMetadata locks in the fix
+// for the bidi-streaming trailer bug: ExecuteUpdate is a DoPut stream and
+// grpc.Trailer(&md) as a CallOption only works for unary RPCs, so the
+// previous implementation silently dropped the worker's per-query
+// profiling metadata. executeUpdateWithTrailer drains the stream to EOF
+// and reads stream.Trailer() instead.
+func TestExecuteUpdateWithTrailerCapturesProfilingMetadata(t *testing.T) {
+	expected := metadata.Pairs("x-duckgres-profiling", `{"latency": 0.001}`)
+	srv := &fakeFlightServer{rowsAffected: 7, trailer: expected}
+
+	grpcSrv := grpc.NewServer()
+	pb.RegisterFlightServiceServer(grpcSrv, srv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = grpcSrv.Serve(lis) }()
+	defer grpcSrv.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	flightCli, err := flight.NewClientWithMiddlewareCtx(
+		ctx, lis.Addr().String(), nil, nil,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("flight client: %v", err)
+	}
+	defer func() { _ = flightCli.Close() }()
+	sqlClient := &flightsql.Client{Client: flightCli}
+
+	affected, trailer, err := executeUpdateWithTrailer(ctx, sqlClient, "INSERT INTO t VALUES (1)")
+	if err != nil {
+		t.Fatalf("executeUpdateWithTrailer: %v", err)
+	}
+	if affected != 7 {
+		t.Errorf("rows affected: got %d, want 7", affected)
+	}
+	got := trailer.Get("x-duckgres-profiling")
+	if len(got) != 1 || got[0] != `{"latency": 0.001}` {
+		t.Fatalf("trailer x-duckgres-profiling: got %#v, want one entry %q", got, `{"latency": 0.001}`)
+	}
+}

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -242,8 +242,14 @@ func (e *FlightExecutor) ExecContext(ctx context.Context, query string, args ...
 
 	reqCtx = e.withSession(reqCtx)
 
-	var trailer metadata.MD
-	affected, err := e.client.ExecuteUpdate(reqCtx, query, grpc.Trailer(&trailer))
+	// Note: we hand-roll the DoPut here instead of calling
+	// flightsql.Client.ExecuteUpdate so we can capture the gRPC trailer.
+	// ExecuteUpdate is a bidi-streaming RPC and grpc.Trailer(&md) as a
+	// CallOption only works for unary RPCs — for streams the trailer is
+	// only reachable via stream.Trailer() after Recv returns io.EOF.
+	// Without that capture the worker's per-query profiling JSON is
+	// silently dropped on this side. See executeUpdateWithTrailer.
+	affected, trailer, err := executeUpdateWithTrailer(reqCtx, e.client, query)
 	e.storeProfilingFromTrailer(trailer)
 	if err != nil {
 		return nil, fmt.Errorf("flight execute update: %w", err)


### PR DESCRIPTION
## Summary
Closes the last gap in the CTAS/INSERT trace investigation. The validation in #545 confirmed:
- ✅ Worker now writes profile JSON for non-SELECT queries (`profiling_coverage = 'ALL'`).
- ✅ Settings stick on per-session connections (`ApplyProfilingSettings`).
- ✅ `arrow.flight.protocol.FlightService/DoPut` shows up as a span.
- ❌ But `duckgres.execute` for those queries still has no `duckdb.*` attributes — the profile JSON wasn't reaching `EnrichSpanWithProfiling`.

Root cause: `flightsql.Client.ExecuteUpdate` is a **bidirectional-streaming** gRPC (DoPut). `grpc.Trailer(&md)` as a `CallOption` only works for unary RPCs — for streams the trailer is only reachable via `ClientStream.Trailer()` after `Recv` returns a non-nil error (typically `io.EOF`). The upstream `ExecuteUpdate` hides the stream, so the trailer set by `sendProfilingMetadata` on the worker was silently dropped on the control-plane side.

This is consistent with what we already saw working: SELECTs go through the unary `GetFlightInfo` path where `grpc.Trailer(&md)` works fine, so they got the full breakdown. Only the DoPut path was broken.

## Changes
- New `server/flightclient/exec_update_trailer.go`: hand-rolled `executeUpdateWithTrailer` that mirrors upstream's `CommandStatementUpdate`/`FlightDescriptor` build, owns the stream, drains it to `io.EOF`, and reads `stream.Trailer()`.
- `flight_executor.ExecContext` now calls `executeUpdateWithTrailer` instead of `client.ExecuteUpdate(..., grpc.Trailer(&md))`.
- New `TestExecuteUpdateWithTrailerCapturesProfilingMetadata` spins up an in-process gRPC server that sets a known trailer and asserts the helper captures it. This locks the contract in so future "simplifications" back to `client.ExecuteUpdate` would fail loudly.

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 -timeout 120s ./server/...`
- [x] `go test -count=1 -timeout 120s ./duckdbservice/...`
- [ ] Deploy to dev, run the same CTAS that produced the bare `duckgres.execute` span; confirm it now carries `duckdb.latency_s`, `duckdb.scan/*`, `duckdb.compute/*` etc. and emits the planning/scan/compute child spans.