### PR TITLE
Add DuckLake schema versions metadata index

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1591,6 +1591,10 @@ var duckLakeMetadataIndexes = []duckLakeMetadataIndex{
 		name: "idx_ducklake_table_col_stats_tbl",
 		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_table_col_stats_tbl ON ducklake_table_column_stats (table_id)",
 	},
+	{
+		name: "idx_ducklake_schema_versions_tbl_schema_version",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_schema_versions_tbl_schema_version ON ducklake_schema_versions (table_id, schema_version)",
+	},
 }
 
 // ensureDuckLakeMetadataIndexes connects directly to the DuckLake PostgreSQL

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -370,6 +370,9 @@ func TestDuckLakeMetadataIndexesNamesMatchStatements(t *testing.T) {
 		}
 		seen[ix.name] = struct{}{}
 	}
+	if _, ok := seen["idx_ducklake_schema_versions_tbl_schema_version"]; !ok {
+		t.Errorf("expected ducklake_schema_versions table/schema_version index")
+	}
 }
 
 func TestStartCredentialRefresh_NoOpForStaticCredentials(t *testing.T) {


### PR DESCRIPTION
## Summary
- add idx_ducklake_schema_versions_tbl_schema_version to the DuckLake metadata indexes created by the server
- cover the new index in the existing metadata index consistency test

## Context
We manually validated that ducklake_schema_versions(table_id, schema_version) changes the metadata lookup for a table schema version from a parallel sequential scan to a fast index scan.

## Tests
- go test ./server -run TestDuckLakeMetadataIndexesNamesMatchStatements -count=1
- go test ./server -count=1
- just lint