### PR TITLE
feat(controlplane): keep at least 1 warm worker per active DuckDB image

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1073,6 +1073,77 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 	return created, nil
 }
 
+// CreateNeutralWarmWorkerSlotForImage creates a durable spawning worker row
+// for the shared neutral warm pool, but the per-image target is enforced
+// against workers using the same image only — letting the per-image warm
+// floor coexist with the cluster-default warm pool without one starving the
+// other. Same advisory-lock + global-cap protections as the image-blind
+// sibling. A nil result means the per-image target is already met or the
+// global worker cap blocked the spawn.
+func (cs *ConfigStore) CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, podNamePrefix, image string, perImageTarget, maxGlobalWorkers int) (*WorkerRecord, error) {
+	if strings.TrimSpace(podNamePrefix) == "" {
+		return nil, fmt.Errorf("pod name prefix is required")
+	}
+	if strings.TrimSpace(image) == "" {
+		return nil, fmt.Errorf("image is required for per-image warm slot")
+	}
+
+	var created *WorkerRecord
+	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", advisoryLockKey("duckgres:shared-warm-target")).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", advisoryLockKey("duckgres:global-worker-capacity")).Error; err != nil {
+			return err
+		}
+
+		if perImageTarget > 0 {
+			count, err := cs.countNeutralWarmWorkersForImage(tx, image)
+			if err != nil {
+				return err
+			}
+			if count >= int64(perImageTarget) {
+				return nil
+			}
+		}
+
+		if maxGlobalWorkers > 0 {
+			count, err := cs.countActiveWorkers(tx)
+			if err != nil {
+				return err
+			}
+			if count >= int64(maxGlobalWorkers) {
+				return nil
+			}
+		}
+
+		var workerID int64
+		if err := tx.Raw("SELECT COALESCE(MAX(worker_id), 0) + 1 FROM " + cs.runtimeTable((&WorkerRecord{}).TableName())).Scan(&workerID).Error; err != nil {
+			return err
+		}
+		now := time.Now()
+		record := &WorkerRecord{
+			WorkerID:          int(workerID),
+			PodName:           fmt.Sprintf("%s-%d", podNamePrefix, workerID),
+			Image:             image,
+			State:             WorkerStateSpawning,
+			OrgID:             "",
+			OwnerCPInstanceID: ownerCPInstanceID,
+			OwnerEpoch:        0,
+			LastHeartbeatAt:   now,
+		}
+		if err := tx.Table(cs.runtimeTable(record.TableName())).Create(record).Error; err != nil {
+			return err
+		}
+		created = record
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create neutral warm worker slot for image: %w", err)
+	}
+	return created, nil
+}
+
 // CreateNeutralWarmWorkerSlot creates a durable spawning worker row for the shared
 // neutral warm pool under advisory-lock protected cluster-wide warm-target and
 // global capacity checks. A nil result means capacity already satisfies the target
@@ -1288,6 +1359,18 @@ func (cs *ConfigStore) countNeutralWarmWorkers(tx *gorm.DB) (int64, error) {
 	var count int64
 	if err := tx.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
 		Where("org_id = ''").
+		Where("state IN ?", []WorkerState{WorkerStateIdle, WorkerStateSpawning}).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (cs *ConfigStore) countNeutralWarmWorkersForImage(tx *gorm.DB, image string) (int64, error) {
+	var count int64
+	if err := tx.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("org_id = ''").
+		Where("image = ?", image).
 		Where("state IN ?", []WorkerState{WorkerStateIdle, WorkerStateSpawning}).
 		Count(&count).Error; err != nil {
 		return 0, err

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -45,9 +45,14 @@ type K8sWorkerPool struct {
 	spawning     int
 	maxWorkers   int
 	minWorkers   int
-	idleTimeout  time.Duration
-	shuttingDown bool
-	shutdownCh   chan struct{}
+	// perImageWarmTarget is an additive floor on top of minWorkers: for each
+	// image listed, the pool aims to keep at least N warm-idle workers of
+	// that exact image alive so a per-org pin always has a hot pod waiting.
+	// minWorkers still drives the cluster-default warm count separately.
+	perImageWarmTarget map[string]int
+	idleTimeout        time.Duration
+	shuttingDown       bool
+	shutdownCh         chan struct{}
 
 	clientset             kubernetes.Interface
 	namespace             string
@@ -1860,6 +1865,102 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 	return stderrors.Join(errs...)
 }
 
+// SpawnMinWorkersForImage ensures at least count warm-idle workers exist for
+// the given image, additive to (and independent of) the cluster-default warm
+// pool managed by SpawnMinWorkers. Per-image floor lets a per-org image pin
+// always find a hot pod waiting instead of paying a cold spawn on first
+// connection.
+//
+// Image-aware DB count and the per-image advisory lock keep this safe for
+// concurrent reconcilers across multiple control planes.
+func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image string, count int) error {
+	if count <= 0 || strings.TrimSpace(image) == "" {
+		return nil
+	}
+	if p.runtimeStore == nil {
+		// Single-CP / no-runtime-store mode is not multi-tenant, so per-image
+		// pinning doesn't apply — caller's image == p.workerImage.
+		return nil
+	}
+
+	p.mu.Lock()
+	if p.shuttingDown {
+		p.mu.Unlock()
+		return nil
+	}
+	p.cleanDeadWorkersLocked()
+	idleByImage := p.idleWarmWorkerCountByImageLocked()
+	missing := count - idleByImage[image]
+	if missing <= 0 {
+		p.mu.Unlock()
+		return nil
+	}
+	if p.maxWorkers > 0 {
+		room := p.maxWorkers - p.liveWorkerCountLocked()
+		if room <= 0 {
+			p.mu.Unlock()
+			return nil
+		}
+		if missing > room {
+			missing = room
+		}
+	}
+	p.mu.Unlock()
+
+	var slots []*configstore.WorkerRecord
+	for i := 0; i < missing; i++ {
+		slot, err := p.runtimeStore.CreateNeutralWarmWorkerSlotForImage(
+			p.cpInstanceID,
+			p.workerPodNamePrefix(),
+			image,
+			count,
+			p.maxWorkers,
+		)
+		if err != nil {
+			for _, s := range slots {
+				p.retireClaimedWorker(s, RetireReasonCrash)
+			}
+			return err
+		}
+		if slot == nil {
+			break
+		}
+		slots = append(slots, slot)
+	}
+
+	if len(slots) == 0 {
+		return nil
+	}
+
+	p.mu.Lock()
+	p.spawning += len(slots)
+	p.mu.Unlock()
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(slots))
+	for i, slot := range slots {
+		wg.Add(1)
+		go func(i int, slot *configstore.WorkerRecord) {
+			defer wg.Done()
+			err := p.spawnWarmWorker(ctx, slot.WorkerID, slot.Image)
+
+			p.mu.Lock()
+			p.spawning--
+			if err == nil {
+				observeWarmPoolLifecycleGauges(p.workers)
+			}
+			p.mu.Unlock()
+
+			if err != nil {
+				p.retireClaimedWorker(slot, RetireReasonCrash)
+				errs[i] = err
+			}
+		}(i, slot)
+	}
+	wg.Wait()
+	return stderrors.Join(errs...)
+}
+
 // HealthCheckLoop periodically checks worker health.
 func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Duration, onCrash WorkerCrashHandler, onProgress ProgressHandler) {
 	ticker := time.NewTicker(interval)
@@ -2515,6 +2616,24 @@ func (p *K8sWorkerPool) idleWarmWorkerCountLocked() int {
 	return count
 }
 
+// idleWarmWorkerCountByImageLocked returns warm-idle counts bucketed by the
+// image each worker was spawned with. Used by the per-image warm floor to
+// decide whether to spawn a new worker of a specific pinned image.
+func (p *K8sWorkerPool) idleWarmWorkerCountByImageLocked() map[string]int {
+	counts := make(map[string]int)
+	for _, w := range p.workers {
+		select {
+		case <-w.done:
+			continue
+		default:
+		}
+		if p.isWarmIdleWorkerLocked(w) {
+			counts[w.image]++
+		}
+	}
+	return counts
+}
+
 func (p *K8sWorkerPool) shouldReplenishWarmCapacityLocked() bool {
 	if p.runtimeStore != nil {
 		return false
@@ -2739,6 +2858,35 @@ func (p *K8sWorkerPool) WarmCapacityTarget() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.minWorkers
+}
+
+// SetPerImageWarmTargets replaces the per-image warm-worker floor. Each entry
+// asks the pool to keep at least N warm-idle workers running with the given
+// image. This is layered on top of SetWarmCapacityTarget — the per-image floor
+// guarantees coverage for pinned org images that wouldn't otherwise be served
+// by the cluster-default warm pool. Pass an empty map to disable.
+func (p *K8sWorkerPool) SetPerImageWarmTargets(targets map[string]int) {
+	clean := make(map[string]int, len(targets))
+	for image, n := range targets {
+		if image == "" || n <= 0 {
+			continue
+		}
+		clean[image] = n
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.perImageWarmTarget = clean
+}
+
+// PerImageWarmTargets returns a snapshot of the per-image warm floor.
+func (p *K8sWorkerPool) PerImageWarmTargets() map[string]int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make(map[string]int, len(p.perImageWarmTarget))
+	for k, v := range p.perImageWarmTarget {
+		out[k] = v
+	}
+	return out
 }
 
 func boolPtr(b bool) *bool    { return &b }

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1351,6 +1351,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			if claimed != nil {
 				worker, reserveErr := p.reserveClaimedWorker(ctx, claimed, assignment)
 				if reserveErr == nil {
+					p.triggerPerImageReplenish(claimed.Image)
 					return worker, nil
 				}
 				slog.Warn("Claimed idle worker could not be reserved, retiring claimed pod.", "worker_id", claimed.WorkerID, "worker_pod", claimed.PodName, "error", reserveErr)
@@ -1417,6 +1418,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			if shouldReplenish {
 				p.spawnWarmWorkerBackground(replenishID, p.workerImage)
 			}
+			p.triggerPerImageReplenish(idle.image)
 			return idle, nil
 		}
 
@@ -1863,6 +1865,29 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 	}
 	wg.Wait()
 	return stderrors.Join(errs...)
+}
+
+// triggerPerImageReplenish kicks off a background spawn for image if the
+// per-image warm floor isn't met. Fire-and-forget; the janitor catches any
+// we miss on its next 5s tick. Cuts the gap between consuming a pinned warm
+// worker and seeing a fresh one in its place from up-to-5s down to ~now.
+func (p *K8sWorkerPool) triggerPerImageReplenish(image string) {
+	if strings.TrimSpace(image) == "" || p.runtimeStore == nil {
+		return
+	}
+	p.mu.RLock()
+	target := p.perImageWarmTarget[image]
+	p.mu.RUnlock()
+	if target <= 0 {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := p.SpawnMinWorkersForImage(ctx, image, target); err != nil {
+			slog.Warn("Per-image warm replenish failed.", "image", image, "error", err)
+		}
+	}()
 }
 
 // SpawnMinWorkersForImage ensures at least count warm-idle workers exist for

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -942,6 +942,46 @@ func TestK8sPoolSpawnMinWorkersForImageSpawnsWhenIdleCountBelowTarget(t *testing
 	}
 }
 
+func TestK8sPoolSpawnMinWorkersForImageSpawnsOnlyTheDeficit(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawned: &configstore.WorkerRecord{
+			WorkerID:          82,
+			PodName:           "duckgres-worker-test-cp-82",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			Image:             "duckgres:v1.5.1",
+		},
+	}
+	pool.runtimeStore = store
+
+	// One warm-idle worker for the requested image already exists. Asking
+	// for target=2 should spawn exactly one more — not two.
+	pool.workers[1] = &ManagedWorker{ID: 1, done: make(chan struct{}), image: "duckgres:v1.5.1"}
+
+	var spawnedIDs []int
+	var mu sync.Mutex
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		mu.Lock()
+		spawnedIDs = append(spawnedIDs, id)
+		mu.Unlock()
+		return nil
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), "duckgres:v1.5.1", 2); err != nil {
+		t.Fatalf("SpawnMinWorkersForImage: %v", err)
+	}
+	if store.perImageSpawnCalls != 1 {
+		t.Fatalf("expected one slot allocation for the single-worker deficit, got %d", store.perImageSpawnCalls)
+	}
+	if store.perImageSpawnTarget != 2 {
+		t.Fatalf("expected per-image target 2 forwarded to runtime store, got %d", store.perImageSpawnTarget)
+	}
+	if len(spawnedIDs) != 1 || spawnedIDs[0] != 82 {
+		t.Fatalf("expected to spawn exactly worker id 82, got %v", spawnedIDs)
+	}
+}
+
 func TestK8sPoolSpawnMinWorkersForImageNoOpWhenIdleCountAtTarget(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	store := &captureRuntimeWorkerStore{}
@@ -983,6 +1023,63 @@ func TestK8sPoolSpawnMinWorkersForImageRespectsMaxWorkers(t *testing.T) {
 	}
 	if store.perImageSpawnCalls != 0 {
 		t.Fatalf("expected no slot allocation at max workers, got %d", store.perImageSpawnCalls)
+	}
+}
+
+func TestK8sPoolTriggerPerImageReplenishSpawnsWhenTargetSet(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	spawned := make(chan struct{}, 1)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawnedFunc: func(image string) *configstore.WorkerRecord {
+			defer func() {
+				select {
+				case spawned <- struct{}{}:
+				default:
+				}
+			}()
+			return &configstore.WorkerRecord{
+				WorkerID:          91,
+				PodName:           "duckgres-worker-test-cp-91",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				Image:             image,
+			}
+		},
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error { return nil }
+
+	pool.SetPerImageWarmTargets(map[string]int{"duckgres:v1.5.1": 1})
+
+	pool.triggerPerImageReplenish("duckgres:v1.5.1")
+
+	select {
+	case <-spawned:
+	case <-time.After(time.Second):
+		t.Fatal("expected per-image spawn to fire within 1s")
+	}
+	if store.perImageSpawnImage != "duckgres:v1.5.1" {
+		t.Fatalf("expected spawn for v1.5.1, got %q", store.perImageSpawnImage)
+	}
+}
+
+func TestK8sPoolTriggerPerImageReplenishNoOpWhenImageNotInTargets(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawnedFunc: func(image string) *configstore.WorkerRecord {
+			t.Fatalf("did not expect spawn when image %q has no per-image target", image)
+			return nil
+		},
+	}
+	pool.runtimeStore = store
+
+	// No SetPerImageWarmTargets call → empty floor.
+	pool.triggerPerImageReplenish("duckgres:v1.5.1")
+
+	// Brief wait to let any rogue goroutine fire.
+	time.Sleep(50 * time.Millisecond)
+	if store.perImageSpawnCalls != 0 {
+		t.Fatalf("expected no spawn calls, got %d", store.perImageSpawnCalls)
 	}
 }
 

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -51,6 +51,15 @@ type captureRuntimeWorkerStore struct {
 	neutralSpawnImage                string
 	neutralSpawnTarget               int
 	neutralSpawnMaxGlobal            int
+	perImageSpawned                  *configstore.WorkerRecord
+	perImageSpawnedFunc              func(image string) *configstore.WorkerRecord
+	perImageSpawnErr                 error
+	perImageSpawnCalls               int
+	perImageSpawnOwnerCPID           string
+	perImageSpawnPodPrefix           string
+	perImageSpawnImage               string
+	perImageSpawnTarget              int
+	perImageSpawnMaxGlobal           int
 	hotIdleClaimResult               *configstore.WorkerRecord
 	hotIdleClaimCPID                 string
 	hotIdleClaimOrgID                string
@@ -187,6 +196,36 @@ func (s *captureRuntimeWorkerStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceI
 		return nil, nil
 	}
 	spawned := *s.neutralSpawned
+	return &spawned, nil
+}
+
+func (s *captureRuntimeWorkerStore) CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, podNamePrefix, image string, perImageTarget, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.perImageSpawnCalls++
+	s.perImageSpawnOwnerCPID = ownerCPInstanceID
+	s.perImageSpawnPodPrefix = podNamePrefix
+	s.perImageSpawnImage = image
+	s.perImageSpawnTarget = perImageTarget
+	s.perImageSpawnMaxGlobal = maxGlobalWorkers
+	if s.perImageSpawnErr != nil {
+		return nil, s.perImageSpawnErr
+	}
+	if s.perImageSpawnedFunc != nil {
+		rec := s.perImageSpawnedFunc(image)
+		if rec == nil {
+			return nil, nil
+		}
+		copy := *rec
+		return &copy, nil
+	}
+	if s.perImageSpawned == nil {
+		return nil, nil
+	}
+	spawned := *s.perImageSpawned
+	if spawned.Image == "" {
+		spawned.Image = image
+	}
 	return &spawned, nil
 }
 
@@ -857,6 +896,93 @@ func TestK8sPoolSpawnMinWorkersCountsOnlyNeutralIdleWorkersAsWarmCapacity(t *tes
 
 	if len(spawned) != 2 {
 		t.Fatalf("expected SpawnMinWorkers to spawn 2 neutral warm workers, got %d", len(spawned))
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersForImageSpawnsWhenIdleCountBelowTarget(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawned: &configstore.WorkerRecord{
+			WorkerID:          71,
+			PodName:           "duckgres-worker-test-cp-71",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: pool.cpInstanceID,
+		},
+	}
+	pool.runtimeStore = store
+
+	// Pool already has one warm-idle worker on a DIFFERENT image; the
+	// per-image floor must spawn a fresh pod for "v1.5.1" anyway.
+	otherImageWorker := &ManagedWorker{ID: 1, done: make(chan struct{}), image: "duckgres:test"}
+	pool.workers[1] = otherImageWorker
+
+	var spawnedIDs []int
+	var mu sync.Mutex
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		mu.Lock()
+		spawnedIDs = append(spawnedIDs, id)
+		mu.Unlock()
+		return nil
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), "duckgres:v1.5.1", 1); err != nil {
+		t.Fatalf("SpawnMinWorkersForImage: %v", err)
+	}
+	if store.perImageSpawnCalls != 1 {
+		t.Fatalf("expected one per-image slot allocation, got %d", store.perImageSpawnCalls)
+	}
+	if store.perImageSpawnImage != "duckgres:v1.5.1" {
+		t.Fatalf("expected slot image duckgres:v1.5.1, got %q", store.perImageSpawnImage)
+	}
+	if store.perImageSpawnTarget != 1 {
+		t.Fatalf("expected per-image target 1, got %d", store.perImageSpawnTarget)
+	}
+	if len(spawnedIDs) != 1 || spawnedIDs[0] != 71 {
+		t.Fatalf("expected to spawn worker id 71, got %v", spawnedIDs)
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersForImageNoOpWhenIdleCountAtTarget(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{}
+	pool.runtimeStore = store
+
+	// One warm-idle worker already exists for the requested image.
+	pool.workers[1] = &ManagedWorker{ID: 1, done: make(chan struct{}), image: "duckgres:v1.5.1"}
+
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		t.Fatalf("did not expect spawn when target already met (id %d)", id)
+		return nil
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), "duckgres:v1.5.1", 1); err != nil {
+		t.Fatalf("SpawnMinWorkersForImage: %v", err)
+	}
+	if store.perImageSpawnCalls != 0 {
+		t.Fatalf("expected no slot allocation when target met, got %d", store.perImageSpawnCalls)
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersForImageRespectsMaxWorkers(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 2)
+	store := &captureRuntimeWorkerStore{}
+	pool.runtimeStore = store
+
+	// Two workers already running, both for a different image. We're at the
+	// global cap, so no per-image spawn should occur.
+	pool.workers[1] = &ManagedWorker{ID: 1, done: make(chan struct{}), image: "duckgres:test"}
+	pool.workers[2] = &ManagedWorker{ID: 2, done: make(chan struct{}), image: "duckgres:test"}
+
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		t.Fatalf("did not expect spawn when at max workers (id %d)", id)
+		return nil
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), "duckgres:v1.5.1", 1); err != nil {
+		t.Fatalf("SpawnMinWorkersForImage: %v", err)
+	}
+	if store.perImageSpawnCalls != 0 {
+		t.Fatalf("expected no slot allocation at max workers, got %d", store.perImageSpawnCalls)
 	}
 }
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -256,13 +257,24 @@ func SetupMultiTenant(
 		// Per-image warm floor: ensure at least one warm pod for each
 		// distinct DuckDB version image in active use, so per-org pins
 		// always find a hot pod waiting instead of paying a cold spawn.
-		for image, count := range router.sharedPool.PerImageWarmTargets() {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			err := router.sharedPool.SpawnMinWorkersForImage(ctx, image, count)
-			cancel()
-			if err != nil {
-				slog.Warn("Janitor failed to reconcile per-image warm capacity.", "image", image, "target", count, "error", err)
+		// Run in parallel — SpawnMinWorkersForImage blocks on pod startup,
+		// and a slow image must not block the others (and the next janitor
+		// tick) for N×30s.
+		perImage := router.sharedPool.PerImageWarmTargets()
+		if len(perImage) > 0 {
+			var wg sync.WaitGroup
+			for image, count := range perImage {
+				wg.Add(1)
+				go func(image string, count int) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					if err := router.sharedPool.SpawnMinWorkersForImage(ctx, image, count); err != nil {
+						slog.Warn("Janitor failed to reconcile per-image warm capacity.", "image", image, "target", count, "error", err)
+					}
+				}(image, count)
 			}
+			wg.Wait()
 		}
 	}
 	janitor.retireMismatchedVersionWorker = func() {

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -246,12 +246,23 @@ func SetupMultiTenant(
 	}
 	janitor.reconcileWarmCapacity = func() {
 		target := router.sharedPool.WarmCapacityTarget()
-		if target <= 0 {
-			return
+		if target > 0 {
+			observeOrgWorkerSpawn("shared")
+			if err := router.sharedPool.SpawnMinWorkers(target); err != nil {
+				slog.Warn("Janitor failed to reconcile shared warm capacity.", "target", target, "error", err)
+			}
 		}
-		observeOrgWorkerSpawn("shared")
-		if err := router.sharedPool.SpawnMinWorkers(target); err != nil {
-			slog.Warn("Janitor failed to reconcile shared warm capacity.", "target", target, "error", err)
+
+		// Per-image warm floor: ensure at least one warm pod for each
+		// distinct DuckDB version image in active use, so per-org pins
+		// always find a hot pod waiting instead of paying a cold spawn.
+		for image, count := range router.sharedPool.PerImageWarmTargets() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			err := router.sharedPool.SpawnMinWorkersForImage(ctx, image, count)
+			cancel()
+			if err != nil {
+				slog.Warn("Janitor failed to reconcile per-image warm capacity.", "image", image, "target", count, "error", err)
+			}
 		}
 	}
 	janitor.retireMismatchedVersionWorker = func() {

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -380,6 +381,35 @@ func (tr *OrgRouter) reconcileWarmCapacity(snap *configstore.Snapshot) {
 	}
 
 	tr.sharedPool.SetWarmCapacityTarget(target)
+	tr.sharedPool.SetPerImageWarmTargets(tr.computePerImageWarmTargetsLocked(snap))
+}
+
+// computePerImageWarmTargetsLocked returns "keep at least 1 warm worker for
+// each distinct image" — covering the cluster default plus every pinned
+// Warehouse.Image used by an org that currently has an active stack. Orgs
+// without a live stack (e.g. warehouse not yet ready) are skipped so we don't
+// pre-warm pods for images nobody can route to yet.
+func (tr *OrgRouter) computePerImageWarmTargetsLocked(snap *configstore.Snapshot) map[string]int {
+	targets := make(map[string]int)
+	if defaultImage := strings.TrimSpace(tr.baseCfg.WorkerImage); defaultImage != "" {
+		targets[defaultImage] = 1
+	}
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+	for orgID := range tr.orgs {
+		tc, ok := snap.Orgs[orgID]
+		if !ok || tc == nil {
+			continue
+		}
+		image := strings.TrimSpace(workerImageForOrg(tc, tr.baseCfg.WorkerImage))
+		if image == "" {
+			continue
+		}
+		if _, exists := targets[image]; !exists {
+			targets[image] = 1
+		}
+	}
+	return targets
 }
 
 func (tr *OrgRouter) onSharedWorkerCrash(workerID int) {

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -381,15 +381,15 @@ func (tr *OrgRouter) reconcileWarmCapacity(snap *configstore.Snapshot) {
 	}
 
 	tr.sharedPool.SetWarmCapacityTarget(target)
-	tr.sharedPool.SetPerImageWarmTargets(tr.computePerImageWarmTargetsLocked(snap))
+	tr.sharedPool.SetPerImageWarmTargets(tr.computePerImageWarmTargets(snap))
 }
 
-// computePerImageWarmTargetsLocked returns "keep at least 1 warm worker for
-// each distinct image" — covering the cluster default plus every pinned
+// computePerImageWarmTargets returns "keep at least 1 warm worker for each
+// distinct image" — covering the cluster default plus every pinned
 // Warehouse.Image used by an org that currently has an active stack. Orgs
 // without a live stack (e.g. warehouse not yet ready) are skipped so we don't
 // pre-warm pods for images nobody can route to yet.
-func (tr *OrgRouter) computePerImageWarmTargetsLocked(snap *configstore.Snapshot) map[string]int {
+func (tr *OrgRouter) computePerImageWarmTargets(snap *configstore.Snapshot) map[string]int {
 	targets := make(map[string]int)
 	if defaultImage := strings.TrimSpace(tr.baseCfg.WorkerImage); defaultImage != "" {
 		targets[defaultImage] = 1
@@ -405,9 +405,7 @@ func (tr *OrgRouter) computePerImageWarmTargetsLocked(snap *configstore.Snapshot
 		if image == "" {
 			continue
 		}
-		if _, exists := targets[image]; !exists {
-			targets[image] = 1
-		}
+		targets[image] = 1
 	}
 	return targets
 }

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -314,3 +314,87 @@ func TestWorkerImageForOrg(t *testing.T) {
 		})
 	}
 }
+
+func TestOrgRouterReconcileWarmCapacityFloorsOnePerActiveImage(t *testing.T) {
+	sharedPool, _ := newTestK8sPool(t, 10)
+
+	tr := &OrgRouter{
+		sharedPool: sharedPool,
+		baseCfg: K8sWorkerPoolConfig{
+			WorkerImage: "posthog/duckgres:default",
+		},
+		globalCfg: ControlPlaneConfig{},
+		orgs: map[string]*OrgStack{
+			"analytics": {Config: &configstore.OrgConfig{Name: "analytics"}},
+			"billing":   {Config: &configstore.OrgConfig{Name: "billing"}},
+			// orphans-without-stack — should NOT contribute to per-image floor
+		},
+	}
+
+	snap := &configstore.Snapshot{
+		Orgs: map[string]*configstore.OrgConfig{
+			"analytics": {
+				Name: "analytics",
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					Image: "posthog/duckgres:v1.5.1",
+				},
+			},
+			"billing": {
+				Name: "billing",
+				// no Warehouse pin → falls back to cluster default
+			},
+			"dormant": {
+				Name: "dormant",
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					Image: "posthog/duckgres:v1.4.0",
+				},
+				// not in tr.orgs → skipped
+			},
+		},
+	}
+
+	tr.reconcileWarmCapacity(snap)
+
+	got := sharedPool.PerImageWarmTargets()
+	want := map[string]int{
+		"posthog/duckgres:default": 1,
+		"posthog/duckgres:v1.5.1":  1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected per-image targets %v, got %v", want, got)
+	}
+}
+
+func TestOrgRouterReconcileWarmCapacitySkipsEmptyClusterDefault(t *testing.T) {
+	sharedPool, _ := newTestK8sPool(t, 10)
+
+	tr := &OrgRouter{
+		sharedPool: sharedPool,
+		baseCfg:    K8sWorkerPoolConfig{}, // WorkerImage unset
+		globalCfg:  ControlPlaneConfig{},
+		orgs: map[string]*OrgStack{
+			"analytics": {Config: &configstore.OrgConfig{Name: "analytics"}},
+		},
+	}
+
+	snap := &configstore.Snapshot{
+		Orgs: map[string]*configstore.OrgConfig{
+			"analytics": {
+				Name: "analytics",
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					Image: "posthog/duckgres:v1.5.1",
+				},
+			},
+		},
+	}
+
+	tr.reconcileWarmCapacity(snap)
+
+	got := sharedPool.PerImageWarmTargets()
+	want := map[string]int{
+		"posthog/duckgres:v1.5.1": 1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected per-image targets %v, got %v", want, got)
+	}
+}

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -80,6 +80,7 @@ type RuntimeWorkerStore interface {
 	ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, error)
 	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
+	CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, podNamePrefix, image string, perImageTarget, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
 	RetireIdleWorker(workerID int, reason string) (bool, error)

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -583,6 +583,65 @@ func TestCreateNeutralWarmWorkerSlotRespectsSharedWarmTarget(t *testing.T) {
 	}
 }
 
+func TestCreateNeutralWarmWorkerSlotForImageEnforcesPerImageTarget(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 7, 12, 0, 0, 0, time.UTC)
+
+	// One existing warm-idle worker on a DIFFERENT image: should not block
+	// spawning a fresh per-image slot for "duckgres:v1.5.1".
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          20,
+		PodName:           "duckgres-worker-existing-20",
+		Image:             "duckgres:v1.4.0",
+		State:             configstore.WorkerStateIdle,
+		OrgID:             "",
+		OwnerCPInstanceID: "cp-a:boot-1",
+		OwnerEpoch:        0,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(other-image): %v", err)
+	}
+
+	slot, err := store.CreateNeutralWarmWorkerSlotForImage("cp-b:boot-2", "duckgres-worker-test-cp", "duckgres:v1.5.1", 1, 5)
+	if err != nil {
+		t.Fatalf("CreateNeutralWarmWorkerSlotForImage: %v", err)
+	}
+	if slot == nil {
+		t.Fatal("expected per-image slot to be created when no warm worker for that image exists")
+		return
+	}
+	if slot.Image != "duckgres:v1.5.1" {
+		t.Fatalf("expected slot image duckgres:v1.5.1, got %q", slot.Image)
+	}
+	if slot.State != configstore.WorkerStateSpawning {
+		t.Fatalf("expected spawning state, got %q", slot.State)
+	}
+	if slot.OrgID != "" {
+		t.Fatalf("expected neutral org, got %q", slot.OrgID)
+	}
+
+	// Second call with the same target=1 should be a no-op — the just-spawned
+	// row counts as a warm-or-spawning worker for this image.
+	again, err := store.CreateNeutralWarmWorkerSlotForImage("cp-b:boot-2", "duckgres-worker-test-cp", "duckgres:v1.5.1", 1, 5)
+	if err != nil {
+		t.Fatalf("CreateNeutralWarmWorkerSlotForImage(repeat): %v", err)
+	}
+	if again != nil {
+		t.Fatalf("expected per-image target to block second spawn, got %#v", again)
+	}
+
+	// Global cap still applies: with maxGlobalWorkers=2 and two existing rows
+	// (the v1.4.0 idle plus the v1.5.1 spawning), a third image's request
+	// must be blocked.
+	capped, err := store.CreateNeutralWarmWorkerSlotForImage("cp-b:boot-2", "duckgres-worker-test-cp", "duckgres:v1.6.0", 1, 2)
+	if err != nil {
+		t.Fatalf("CreateNeutralWarmWorkerSlotForImage(global cap): %v", err)
+	}
+	if capped != nil {
+		t.Fatalf("expected global cap to block third image spawn, got %#v", capped)
+	}
+}
+
 func TestListOrphanedAndStuckWorkersPostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.March, 27, 14, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

Multi-tenant control planes only pre-warmed pods built from the cluster default `--k8s-worker-image`. Per-org image pins (e.g. `duckgres:v1.5.1`) had to pay a cold spawn on every first connection — reserving a warm worker only succeeded when its image matched the pin (since #539). This PR adds an additive per-image warm floor so every distinct DuckDB-version image in active use keeps at least one warm-idle pod ready.

## Changes

- **`controlplane/k8s_pool.go`**: `K8sWorkerPool` gains a `perImageWarmTarget map[string]int` field plus `SetPerImageWarmTargets` / `PerImageWarmTargets`, an `idleWarmWorkerCountByImageLocked` helper, and a `SpawnMinWorkersForImage(ctx, image, count)` reconciler. Mirrors the existing `SpawnMinWorkers` runtime-store branch, but image-aware.
- **`controlplane/configstore/store.go`**: New `CreateNeutralWarmWorkerSlotForImage` enforces the per-image target against workers using the same image only (via a sibling `countNeutralWarmWorkersForImage`). Same advisory-lock + global-cap guards as `CreateNeutralWarmWorkerSlot` so concurrent reconcilers across CPs don't double-spawn.
- **`controlplane/worker_pool.go`**: Adds the new method to the `RuntimeWorkerStore` interface.
- **`controlplane/org_router.go`**: `reconcileWarmCapacity` now also calls `SetPerImageWarmTargets`. The target map is the cluster default plus every distinct `Warehouse.Image` of an org with a currently-active stack — orgs whose warehouse isn't ready yet are skipped so we don't pre-warm pods nothing can route to.
- **`controlplane/multitenant.go`**: Janitor's `reconcileWarmCapacity` closure now iterates `PerImageWarmTargets()` after the existing `SpawnMinWorkers(target)` call. Each per-image spawn gets a 30s timeout.
- **Tests**: Two new `OrgRouter` tests cover the image-enumeration logic; three new K8s-pool tests cover the spawn-when-needed / no-op-when-met / max-cap paths; one Postgres-backed test in `tests/configstore/` covers the actual SQL transaction with per-image enforcement and global-cap interaction.

The cluster-default warm pool managed by `--k8s-shared-warm-target` still works exactly as before; the per-image floor layers additively on top.

## Test plan

- [ ] `go test -tags kubernetes ./controlplane/...`
- [ ] `go test ./tests/configstore/...` (needs the integration Postgres on :35432)
- [ ] On a multi-tenant cluster with at least one org pinned to a non-default image, confirm a warm pod for that image stays alive across worker reaps and is reused on the org's next connection (no cold spawn in logs).

## Rollback

Revert this PR. The new method on `RuntimeWorkerStore` is the only API surface change; reverting removes it cleanly. No DB schema changes.