### PR TITLE
fix(controlplane): stream COPY FROM STDIN bytes to remote workers

### DIFF
--- a/duckdbservice/copy_from_stdin.go
+++ b/duckdbservice/copy_from_stdin.go
@@ -1,0 +1,135 @@
+package duckdbservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"github.com/posthog/duckgres/server/flightclient"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// IsCopyFromStdinDescriptor reports whether desc is the custom DoPut
+// descriptor used by the control plane to stream a CSV spool file for
+// COPY FROM STDIN. customActionServer.DoPut peeks at the first frame
+// of every DoPut stream and routes here when this returns true.
+func IsCopyFromStdinDescriptor(desc *flight.FlightDescriptor) bool {
+	if desc == nil {
+		return false
+	}
+	if desc.Type != flight.DescriptorPATH {
+		return false
+	}
+	if len(desc.Path) == 0 {
+		return false
+	}
+	return desc.Path[0] == flightclient.CopyFromStdinDescriptorPath
+}
+
+// doCopyFromStdin handles a CSV spool DoPut from the control plane.
+// It writes streamed bytes to a worker-local tempfile, executes the
+// COPY SQL with the placeholder substituted, and returns the row count
+// in the standard DoPutUpdateResult AppMetadata so the existing client
+// drain path continues to work.
+func (h *FlightSQLHandler) doCopyFromStdin(
+	ctx context.Context,
+	first *flight.FlightData,
+	stream flight.FlightService_DoPutServer,
+) error {
+	session, err := h.sessionFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	desc := first.GetFlightDescriptor()
+	if desc == nil || len(desc.Cmd) == 0 {
+		return status.Error(codes.InvalidArgument, "copy-from-stdin: missing COPY SQL in descriptor.Cmd")
+	}
+	copySQL := string(desc.Cmd)
+	if !strings.Contains(copySQL, flightclient.CopyFromStdinPathPlaceholder) {
+		return status.Errorf(codes.InvalidArgument,
+			"copy-from-stdin: COPY SQL missing %q placeholder", flightclient.CopyFromStdinPathPlaceholder)
+	}
+
+	tmpFile, err := os.CreateTemp("", "duckgres-worker-copy-*.csv")
+	if err != nil {
+		return status.Errorf(codes.Internal, "copy-from-stdin: create tempfile: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	var bytesWritten int64
+	var frames int
+	closed := false
+	closeOnce := func() {
+		if !closed {
+			_ = tmpFile.Close()
+			closed = true
+		}
+	}
+	defer closeOnce()
+
+	// Drain the byte stream from the CP. The CP closes send after the
+	// last chunk; that surfaces here as io.EOF.
+	for {
+		// First frame is already in hand from customActionServer.DoPut;
+		// any byte payload on it is part of the data stream.
+		var data *flight.FlightData
+		if first != nil {
+			data = first
+			first = nil
+		} else {
+			data, err = stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return status.Errorf(codes.Aborted, "copy-from-stdin: recv: %v", err)
+			}
+		}
+		body := data.GetDataBody()
+		if len(body) == 0 {
+			continue
+		}
+		n, werr := tmpFile.Write(body)
+		if werr != nil {
+			return status.Errorf(codes.Internal, "copy-from-stdin: write tempfile: %v", werr)
+		}
+		bytesWritten += int64(n)
+		frames++
+	}
+	closeOnce()
+
+	finalSQL := strings.ReplaceAll(copySQL, flightclient.CopyFromStdinPathPlaceholder, tmpPath)
+	slog.Debug("copy-from-stdin: executing COPY",
+		"frames", frames, "bytes", bytesWritten, "tmp", tmpPath)
+
+	res, execErr := session.Conn.ExecContext(ctx, finalSQL)
+	if execErr != nil {
+		return status.Errorf(codes.InvalidArgument, "failed to execute update: %v", execErr)
+	}
+	var rowCount int64
+	if res != nil {
+		rowCount, _ = res.RowsAffected()
+	}
+
+	updateResult := &pb.DoPutUpdateResult{RecordCount: rowCount}
+	app, mErr := proto.Marshal(updateResult)
+	if mErr != nil {
+		return status.Errorf(codes.Internal, "marshal DoPutUpdateResult: %v", mErr)
+	}
+	if err := stream.Send(&flight.PutResult{AppMetadata: app}); err != nil {
+		return fmt.Errorf("copy-from-stdin: send PutResult: %w", err)
+	}
+	return nil
+}

--- a/duckdbservice/copy_from_stdin_test.go
+++ b/duckdbservice/copy_from_stdin_test.go
@@ -1,0 +1,290 @@
+package duckdbservice
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"github.com/posthog/duckgres/server/flightclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestIsCopyFromStdinDescriptor(t *testing.T) {
+	if IsCopyFromStdinDescriptor(nil) {
+		t.Error("nil descriptor should not match")
+	}
+	if IsCopyFromStdinDescriptor(&flight.FlightDescriptor{Type: flight.DescriptorCMD, Cmd: []byte("anything")}) {
+		t.Error("DescriptorCMD should not match")
+	}
+	if IsCopyFromStdinDescriptor(&flight.FlightDescriptor{Type: flight.DescriptorPATH}) {
+		t.Error("PATH descriptor with empty path should not match")
+	}
+	if IsCopyFromStdinDescriptor(&flight.FlightDescriptor{
+		Type: flight.DescriptorPATH, Path: []string{"some-other-path"},
+	}) {
+		t.Error("PATH descriptor with wrong path should not match")
+	}
+	if !IsCopyFromStdinDescriptor(&flight.FlightDescriptor{
+		Type: flight.DescriptorPATH, Path: []string{flightclient.CopyFromStdinDescriptorPath},
+	}) {
+		t.Error("PATH descriptor with our path SHOULD match")
+	}
+}
+
+// fakeDoPutStream simulates a DoPut stream by replaying preloaded inbound
+// FlightData frames and capturing the server's PutResult sends. Tests run
+// single-goroutine, so no synchronization is needed.
+type fakeDoPutStream struct {
+	grpc.ServerStream
+
+	ctx context.Context
+
+	inbound  []*flight.FlightData
+	idx      int
+	outbound []*flight.PutResult
+
+	// recvErrAt and recvErr simulate transport-level errors mid-stream
+	// (e.g. a cancelled gRPC stream after the CP returned early on
+	// CopyFail). When recvErr is non-nil and idx has reached recvErrAt,
+	// Recv returns recvErr instead of the next frame / io.EOF.
+	recvErrAt int
+	recvErr   error
+}
+
+func (f *fakeDoPutStream) Context() context.Context     { return f.ctx }
+func (f *fakeDoPutStream) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeDoPutStream) SendHeader(metadata.MD) error { return nil }
+func (f *fakeDoPutStream) SetTrailer(metadata.MD)       {}
+func (f *fakeDoPutStream) SendMsg(m any) error          { return nil }
+func (f *fakeDoPutStream) RecvMsg(m any) error          { return nil }
+func (f *fakeDoPutStream) Send(r *pb.PutResult) error {
+	f.outbound = append(f.outbound, r)
+	return nil
+}
+func (f *fakeDoPutStream) Recv() (*flight.FlightData, error) {
+	if f.recvErr != nil && f.idx >= f.recvErrAt {
+		return nil, f.recvErr
+	}
+	if f.idx >= len(f.inbound) {
+		return nil, io.EOF
+	}
+	fd := f.inbound[f.idx]
+	f.idx++
+	return fd, nil
+}
+
+func newSessionWithInMemoryDuckDB(t *testing.T) (*Session, func()) {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("sql.Open duckdb: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("db.Conn: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, "CREATE TABLE t (a INTEGER, b TEXT)"); err != nil {
+		_ = conn.Close()
+		_ = db.Close()
+		t.Fatalf("create table: %v", err)
+	}
+	s := &Session{
+		ID:        "test-session",
+		DB:        db,
+		Conn:      conn,
+		Username:  "tester",
+		CreatedAt: time.Now(),
+	}
+	s.lastUsed.Store(time.Now().UnixNano())
+	cleanup := func() {
+		_ = conn.Close()
+		_ = db.Close()
+	}
+	return s, cleanup
+}
+
+func TestDoCopyFromStdinIngestsCSVAndRunsCOPY(t *testing.T) {
+	session, cleanup := newSessionWithInMemoryDuckDB(t)
+	defer cleanup()
+
+	pool := &SessionPool{sessions: map[string]*Session{session.ID: session}}
+	handler := &FlightSQLHandler{pool: pool}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", session.ID))
+
+	copySQL := "COPY t (a, b) FROM '" + flightclient.CopyFromStdinPathPlaceholder +
+		"' (FORMAT CSV, HEADER false)"
+
+	csv := []byte("1,one\n2,two\n3,three\n")
+	first := &flight.FlightData{
+		FlightDescriptor: &flight.FlightDescriptor{
+			Type: flight.DescriptorPATH,
+			Path: []string{flightclient.CopyFromStdinDescriptorPath},
+			Cmd:  []byte(copySQL),
+		},
+	}
+	chunks := []*flight.FlightData{
+		{DataBody: csv[:7]},
+		{DataBody: csv[7:]},
+	}
+
+	stream := &fakeDoPutStream{
+		ctx:     ctx,
+		inbound: chunks,
+	}
+
+	if err := handler.doCopyFromStdin(ctx, first, stream); err != nil {
+		t.Fatalf("doCopyFromStdin: %v", err)
+	}
+
+	if len(stream.outbound) != 1 {
+		t.Fatalf("expected 1 PutResult, got %d", len(stream.outbound))
+	}
+	var got pb.DoPutUpdateResult
+	if err := proto.Unmarshal(stream.outbound[0].AppMetadata, &got); err != nil {
+		t.Fatalf("unmarshal DoPutUpdateResult: %v", err)
+	}
+	if got.RecordCount != 3 {
+		t.Errorf("RecordCount = %d, want 3", got.RecordCount)
+	}
+
+	// Confirm rows actually landed.
+	row := session.Conn.QueryRowContext(ctx, "SELECT count(*) FROM t")
+	var n int
+	if err := row.Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("table row count = %d, want 3", n)
+	}
+}
+
+func TestDoCopyFromStdinRejectsMissingPlaceholder(t *testing.T) {
+	session, cleanup := newSessionWithInMemoryDuckDB(t)
+	defer cleanup()
+
+	pool := &SessionPool{sessions: map[string]*Session{session.ID: session}}
+	handler := &FlightSQLHandler{pool: pool}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", session.ID))
+
+	first := &flight.FlightData{
+		FlightDescriptor: &flight.FlightDescriptor{
+			Type: flight.DescriptorPATH,
+			Path: []string{flightclient.CopyFromStdinDescriptorPath},
+			Cmd:  []byte("COPY t FROM '/no-placeholder' (FORMAT CSV)"),
+		},
+	}
+	stream := &fakeDoPutStream{ctx: ctx}
+
+	err := handler.doCopyFromStdin(ctx, first, stream)
+	if err == nil {
+		t.Fatal("expected error when placeholder missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "placeholder") {
+		t.Errorf("error should mention placeholder, got: %v", err)
+	}
+}
+
+func TestDoCopyFromStdinRequiresSession(t *testing.T) {
+	pool := &SessionPool{sessions: map[string]*Session{}}
+	handler := &FlightSQLHandler{pool: pool}
+
+	// No x-duckgres-session metadata.
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+
+	first := &flight.FlightData{
+		FlightDescriptor: &flight.FlightDescriptor{
+			Type: flight.DescriptorPATH,
+			Path: []string{flightclient.CopyFromStdinDescriptorPath},
+			Cmd:  []byte("COPY t FROM '" + flightclient.CopyFromStdinPathPlaceholder + "' (FORMAT CSV)"),
+		},
+	}
+	stream := &fakeDoPutStream{ctx: ctx}
+
+	err := handler.doCopyFromStdin(ctx, first, stream)
+	if err == nil {
+		t.Fatal("expected auth error when session metadata missing")
+	}
+	// Don't pin to specific gRPC code spelling — just confirm we didn't
+	// silently no-op or panic.
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("expected non-EOF auth error, got: %v", err)
+	}
+}
+
+// TestDoCopyFromStdinAbortsOnStreamCancellation pins down the corrected
+// cancellation path: when the CP cancels the gRPC stream mid-CSV (because
+// the wire client sent CopyFail), the worker's Recv returns Canceled
+// before EOF; the worker MUST return the error and MUST NOT run COPY on
+// the partial bytes already buffered to the tempfile.
+func TestDoCopyFromStdinAbortsOnStreamCancellation(t *testing.T) {
+	session, cleanup := newSessionWithInMemoryDuckDB(t)
+	defer cleanup()
+
+	pool := &SessionPool{sessions: map[string]*Session{session.ID: session}}
+	handler := &FlightSQLHandler{pool: pool}
+
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("x-duckgres-session", session.ID))
+
+	copySQL := "COPY t (a, b) FROM '" + flightclient.CopyFromStdinPathPlaceholder +
+		"' (FORMAT CSV, HEADER false)"
+
+	first := &flight.FlightData{
+		FlightDescriptor: &flight.FlightDescriptor{
+			Type: flight.DescriptorPATH,
+			Path: []string{flightclient.CopyFromStdinDescriptorPath},
+			Cmd:  []byte(copySQL),
+		},
+	}
+	// One legitimate chunk, then the stream errors as if the gRPC client
+	// cancelled (which is what happens after the CP's reader returned
+	// errCopyAborted and the deferred cancel() fired).
+	chunks := []*flight.FlightData{
+		{DataBody: []byte("1,one\n")},
+	}
+	stream := &fakeDoPutStream{
+		ctx:       ctx,
+		inbound:   chunks,
+		recvErrAt: 1,
+		recvErr:   status.Error(codes.Canceled, "client cancelled"),
+	}
+
+	err := handler.doCopyFromStdin(ctx, first, stream)
+	if err == nil {
+		t.Fatal("expected error from cancelled stream, got nil")
+	}
+	if status.Code(err) != codes.Aborted {
+		t.Errorf("expected codes.Aborted, got %v: %v", status.Code(err), err)
+	}
+
+	// The smoking gun: even though one row's worth of CSV was buffered to
+	// the worker tempfile, the COPY must NOT have run.
+	row := session.Conn.QueryRowContext(ctx, "SELECT count(*) FROM t")
+	var n int
+	if err := row.Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rows landed despite cancellation: got %d, want 0", n)
+	}
+
+	// And the worker did not send a PutResult.
+	if len(stream.outbound) != 0 {
+		t.Errorf("worker should not send PutResult on cancellation, got %d", len(stream.outbound))
+	}
+}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -878,6 +878,48 @@ func (s *customActionServer) DoAction(cmd *flight.Action, stream flight.FlightSe
 	}
 }
 
+// DoPut peeks at the first FlightData frame and routes a duckgres custom
+// CSV-spool stream to doCopyFromStdin. Anything else is delegated to the
+// standard Flight SQL DoPut router (CommandStatementUpdate etc.).
+//
+// We have to consume the first frame to check the descriptor, so we
+// hand the custom handler a reference to it and the rest of the stream;
+// for non-custom streams we wrap the underlying server with a small
+// adapter that returns the buffered first frame on the first Recv()
+// call so the standard handler sees the full stream.
+func (s *customActionServer) DoPut(stream flight.FlightService_DoPutServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if IsCopyFromStdinDescriptor(first.GetFlightDescriptor()) {
+		return s.handler.doCopyFromStdin(stream.Context(), first, stream)
+	}
+	return s.FlightServer.DoPut(&prebufferedDoPutServer{
+		FlightService_DoPutServer: stream,
+		buffered:                  first,
+	})
+}
+
+// prebufferedDoPutServer returns a single buffered FlightData frame on
+// the first Recv() call, then delegates to the wrapped stream. Used by
+// customActionServer.DoPut so that consuming the first frame for
+// descriptor-routing doesn't strip it from the stream the underlying
+// handler sees.
+type prebufferedDoPutServer struct {
+	flight.FlightService_DoPutServer
+	buffered *flight.FlightData
+}
+
+func (p *prebufferedDoPutServer) Recv() (*flight.FlightData, error) {
+	if p.buffered != nil {
+		fd := p.buffered
+		p.buffered = nil
+		return fd, nil
+	}
+	return p.FlightService_DoPutServer.Recv()
+}
+
 // NewFlightSQLHandler creates a new multi-session Flight SQL handler.
 func NewFlightSQLHandler(pool *SessionPool) *FlightSQLHandler {
 	h := &FlightSQLHandler{

--- a/server/conn.go
+++ b/server/conn.go
@@ -24,6 +24,7 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
+	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/sqlcore"
@@ -3842,7 +3843,16 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	_ = c.writer.Flush()
 	slog.Debug("COPY FROM STDIN sent CopyInResponse, waiting for data.", "user", c.username)
 
-	// Create temp file upfront and stream data directly to it (avoids memory buffering)
+	// Remote-worker (Flight) executors implement CopyFromStdinExecutor so the
+	// CSV bytes are streamed to the worker pod via DoPut and spooled to the
+	// worker's filesystem there. The legacy local-tempfile path below works
+	// only when CP and worker share a filesystem (standalone / process
+	// backend), so prefer the streaming path when it's available.
+	if streamer, ok := c.executor.(sqlcore.CopyFromStdinExecutor); ok {
+		return c.handleCopyInRemoteStreaming(query, opts, copyStartTime, streamer)
+	}
+
+	// Create temp file upfront and stream data directly to it (avoids memory buffering).
 	// This approach leverages DuckDB's highly optimized CSV parser which handles
 	// type conversions automatically and can load millions of rows in seconds.
 	tmpFile, err := os.CreateTemp("", "duckgres-copy-*.csv")
@@ -3964,6 +3974,156 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			return nil
 		}
 	}
+}
+
+// handleCopyInRemoteStreaming handles COPY FROM STDIN when the executor is
+// remote (e.g. Flight, multitenant K8s worker). The control plane does not
+// share a filesystem with the worker pod, so the legacy "spool to local
+// /tmp, run COPY FROM <path>" approach fails with "No files found". This
+// path streams the wire CopyData bytes through the executor's
+// CopyFromStdin method, which ships them to the worker via Flight DoPut
+// and runs the COPY against a worker-local spool file.
+func (c *clientConn) handleCopyInRemoteStreaming(
+	query string,
+	opts *CopyFromOptions,
+	copyStartTime time.Time,
+	streamer sqlcore.CopyFromStdinExecutor,
+) error {
+	tableName := opts.TableName
+	columnList := opts.ColumnList
+
+	// Build the COPY SQL with the path placeholder; the worker substitutes
+	// in its own tempfile path before executing.
+	copySQL := BuildDuckDBCopyFromSQL(tableName, columnList, flightclient.CopyFromStdinPathPlaceholder, opts)
+	slog.Debug("COPY FROM STDIN streaming to remote worker.",
+		"user", c.username, "sql", copySQL, "worker", c.workerID, "worker_pod", c.workerPod)
+
+	r := &copyDataWireReader{c: c}
+
+	loadStart := time.Now()
+	c.logQueryStarted(copySQL)
+	rowCount, err := streamer.CopyFromStdin(c.ctx, copySQL, r)
+	c.logQueryFinished(copySQL, loadStart, rowCount, err)
+
+	// On wire-level CopyFail / unexpected message, the reader returns a
+	// non-EOF error so the streamer aborts the gRPC stream (its deferred
+	// cancel() prevents the worker from running COPY on partial bytes).
+	// We then surface the precise cause via the sticky flags below before
+	// falling through to the generic transport-error branch.
+	if r.cancelled {
+		exception := fmt.Sprintf("COPY failed: %s", r.cancelMsg)
+		c.sendError("ERROR", "57014", exception)
+		c.setTxError()
+		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "57014", exception, "simple")
+		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+		_ = c.writer.Flush()
+		return nil
+	}
+	if r.protoErr != "" {
+		c.sendError("ERROR", "08P01", r.protoErr)
+		c.setTxError()
+		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "08P01", r.protoErr, "simple")
+		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+		_ = c.writer.Flush()
+		return nil
+	}
+	if err != nil {
+		slog.Error("COPY FROM STDIN remote streaming failed.",
+			"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		errMsg := fmt.Sprintf("COPY failed: %v", err)
+		c.sendError("ERROR", "22P02", errMsg)
+		c.setTxError()
+		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "22P02", errMsg, "simple")
+		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+		_ = c.writer.Flush()
+		return nil
+	}
+
+	totalElapsed := time.Since(copyStartTime)
+	loadElapsed := time.Since(loadStart)
+	slog.Info("COPY FROM STDIN completed (remote streaming).",
+		"user", c.username, "rows", rowCount, "bytes", r.bytesRead,
+		"total_duration", totalElapsed, "load_duration", loadElapsed,
+		"worker", c.workerID, "worker_pod", c.workerPod)
+
+	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+	c.logQuery(copyStartTime, query, query, "COPY", 0, rowCount, "", "", "simple")
+	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+	_ = c.writer.Flush()
+	return nil
+}
+
+// errCopyAborted is returned from copyDataWireReader.Read when the client
+// signalled CopyFail or sent an unexpected wire message mid-stream. The
+// streamer propagates this; the deferred gRPC context cancel then fires,
+// which causes the worker's Recv to fail with Canceled and skip running
+// the partially-uploaded COPY. handleCopyInRemoteStreaming inspects the
+// reader's sticky flags to decide the client-facing error code (57014 for
+// cancellation vs 08P01 for protocol error).
+var errCopyAborted = errors.New("copy data stream aborted")
+
+// copyDataWireReader adapts the PostgreSQL wire CopyData stream into an
+// io.Reader so it can be fed straight into a remote-worker upload. Behavior:
+//   - CopyDone           → io.EOF (clean end-of-stream)
+//   - CopyFail           → errCopyAborted, with cancelled / cancelMsg sticky
+//   - unexpected message → errCopyAborted, with protoErr sticky
+//   - wire transport err → that error is returned verbatim
+//
+// Returning a non-EOF error on cancellation matters for correctness:
+// if the reader pretended cancellation was a clean EOF, the streamer would
+// CloseSend cleanly and the worker would happily run COPY on the partial
+// bytes already received.
+type copyDataWireReader struct {
+	c *clientConn
+
+	pending   []byte
+	bytesRead int64
+
+	done      bool
+	cancelled bool
+	cancelMsg string
+	protoErr  string
+}
+
+func (r *copyDataWireReader) Read(p []byte) (int, error) {
+	for len(r.pending) == 0 {
+		if r.done {
+			if r.cancelled || r.protoErr != "" {
+				return 0, errCopyAborted
+			}
+			return 0, io.EOF
+		}
+		msgType, body, err := wire.ReadMessage(r.c.reader)
+		if err != nil {
+			r.done = true
+			return 0, err
+		}
+		switch msgType {
+		case wire.MsgCopyData:
+			// Skip the PostgreSQL text COPY end-of-data marker (\.\n).
+			if (len(body) == 3 && body[0] == '\\' && body[1] == '.' && body[2] == '\n') ||
+				(len(body) == 2 && body[0] == '\\' && body[1] == '.') {
+				continue
+			}
+			r.pending = body
+		case wire.MsgCopyDone:
+			r.done = true
+			return 0, io.EOF
+		case wire.MsgCopyFail:
+			r.done = true
+			r.cancelled = true
+			r.cancelMsg = string(bytes.TrimRight(body, "\x00"))
+			return 0, errCopyAborted
+		default:
+			r.done = true
+			r.protoErr = fmt.Sprintf("unexpected message type during COPY: %c", msgType)
+			return 0, errCopyAborted
+		}
+	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	r.bytesRead += int64(n)
+	return n, nil
 }
 
 // handleCopyInCSVWithBlob handles COPY FROM STDIN for tables that contain BLOB columns.

--- a/server/flightclient/copyfromstdin.go
+++ b/server/flightclient/copyfromstdin.go
@@ -1,0 +1,117 @@
+package flightclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"google.golang.org/protobuf/proto"
+)
+
+// CopyFromStdinDescriptorPath is the FlightDescriptor path that marks a
+// DoPut stream as a CSV-spool-and-COPY upload rather than a standard
+// Flight SQL CommandStatementUpdate. The duckdbservice worker matches
+// on this path and routes to its CopyFromStdin handler.
+const CopyFromStdinDescriptorPath = "duckgres-copy-from-stdin"
+
+// CopyFromStdinPathPlaceholder is the substring inside the COPY SQL that
+// the worker replaces with the worker-local spool file path before
+// executing the COPY. The control plane builds the COPY SQL with
+// BuildDuckDBCopyFromSQL using this token as the file path.
+const CopyFromStdinPathPlaceholder = "__DUCKGRES_COPY_PATH__"
+
+// CopyFromStdinChunkSize is the byte size of each FlightData frame sent
+// from the control plane to the worker during a COPY upload. Large
+// enough to amortise per-frame overhead, small enough to keep memory
+// bounded if the worker is slow to drain.
+const CopyFromStdinChunkSize = 1 << 20 // 1 MiB
+
+// CopyFromStdin streams CSV bytes from r to a remote worker, then runs
+// copySQL on the worker against a worker-local spool file. copySQL must
+// contain CopyFromStdinPathPlaceholder where the file path should appear.
+// Returns the number of rows the worker reports COPY-affected.
+//
+// Wire layout:
+//
+//	frame 0: FlightDescriptor{Type=PATH, Path=[CopyFromStdinDescriptorPath], Cmd=copySQL}
+//	frame 1..N: DataBody=<chunk of CSV bytes>
+//	(client closes send)
+//	server: PutResult{AppMetadata=DoPutUpdateResult{RecordCount=N}}
+func (e *FlightExecutor) CopyFromStdin(ctx context.Context, copySQL string, r io.Reader) (int64, error) {
+	if e.dead.Load() {
+		return 0, ErrWorkerDead
+	}
+
+	reqCtx, cancel := e.mergedContext(ctx)
+	defer cancel()
+	reqCtx = e.withSession(reqCtx)
+
+	stream, err := e.client.Client.DoPut(reqCtx)
+	if err != nil {
+		return 0, fmt.Errorf("flight doput: %w", err)
+	}
+
+	// Frame 0: descriptor + COPY SQL.
+	desc := &flight.FlightDescriptor{
+		Type: flight.DescriptorPATH,
+		Path: []string{CopyFromStdinDescriptorPath},
+		Cmd:  []byte(copySQL),
+	}
+	if err := stream.Send(&flight.FlightData{FlightDescriptor: desc}); err != nil {
+		return 0, fmt.Errorf("flight doput send descriptor: %w", err)
+	}
+
+	// Frames 1..N: CSV byte chunks. We re-use one buffer; gRPC marshals the
+	// proto synchronously inside Send, so reusing is safe across iterations.
+	//
+	// On a non-EOF read error we return immediately WITHOUT calling
+	// CloseSend. The deferred cancel() then aborts the gRPC stream, so the
+	// worker's Recv fails with Canceled and the worker bails before
+	// running COPY on a partial spool file. This is what makes wire-level
+	// COPY cancellation correct end-to-end.
+	buf := make([]byte, CopyFromStdinChunkSize)
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			if sendErr := stream.Send(&flight.FlightData{DataBody: buf[:n]}); sendErr != nil {
+				return 0, fmt.Errorf("flight doput send chunk: %w", sendErr)
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return 0, fmt.Errorf("read csv stream: %w", readErr)
+		}
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		return 0, fmt.Errorf("flight doput close-send: %w", err)
+	}
+
+	res, err := stream.Recv()
+	if err != nil {
+		return 0, fmt.Errorf("flight doput recv: %w", err)
+	}
+
+	// Drain to EOF so any trailing metadata is materialised.
+	for {
+		_, err := stream.Recv()
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		return 0, err
+	}
+
+	var updateResult pb.DoPutUpdateResult
+	if err := proto.Unmarshal(res.GetAppMetadata(), &updateResult); err != nil {
+		return 0, fmt.Errorf("unmarshal DoPutUpdateResult: %w", err)
+	}
+	return updateResult.GetRecordCount(), nil
+}

--- a/server/flightclient/copyfromstdin_test.go
+++ b/server/flightclient/copyfromstdin_test.go
@@ -1,0 +1,118 @@
+package flightclient
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeCopyFromStdinServer captures the descriptor and assembled CSV bytes
+// from a CopyFromStdin DoPut and replies with a fixed RecordCount.
+type fakeCopyFromStdinServer struct {
+	pb.UnimplementedFlightServiceServer
+
+	rowsAffected int64
+
+	gotDescriptor *flight.FlightDescriptor
+	gotBytes      bytes.Buffer
+	frames        int
+}
+
+func (s *fakeCopyFromStdinServer) DoPut(stream pb.FlightService_DoPutServer) error {
+	for {
+		fd, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if d := fd.GetFlightDescriptor(); d != nil {
+			s.gotDescriptor = d
+		}
+		body := fd.GetDataBody()
+		if len(body) > 0 {
+			s.gotBytes.Write(body)
+			s.frames++
+		}
+	}
+
+	updateResult := &pb.DoPutUpdateResult{RecordCount: s.rowsAffected}
+	metaBytes, err := proto.Marshal(updateResult)
+	if err != nil {
+		return err
+	}
+	return stream.Send(&pb.PutResult{AppMetadata: metaBytes})
+}
+
+func TestCopyFromStdinStreamsBytesAndDescriptor(t *testing.T) {
+	srv := &fakeCopyFromStdinServer{rowsAffected: 1234}
+
+	grpcSrv := grpc.NewServer()
+	pb.RegisterFlightServiceServer(grpcSrv, srv)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = grpcSrv.Serve(lis) }()
+	defer grpcSrv.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	flightCli, err := flight.NewClientWithMiddlewareCtx(
+		ctx, lis.Addr().String(), nil, nil,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("flight client: %v", err)
+	}
+	defer func() { _ = flightCli.Close() }()
+	sqlClient := &flightsql.Client{Client: flightCli}
+
+	exec := NewFlightExecutorFromClient(sqlClient, "test-session")
+	defer func() { _ = exec.Close() }()
+
+	// Build a CSV payload bigger than one chunk so we exercise multi-frame send.
+	payload := bytes.Repeat([]byte("a,b,c\n"), CopyFromStdinChunkSize/3)
+	copySQL := "COPY t FROM '" + CopyFromStdinPathPlaceholder + "' (FORMAT CSV)"
+
+	rows, err := exec.CopyFromStdin(ctx, copySQL, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("CopyFromStdin: %v", err)
+	}
+	if rows != 1234 {
+		t.Errorf("rows = %d, want 1234", rows)
+	}
+
+	if srv.gotDescriptor == nil {
+		t.Fatal("server did not receive FlightDescriptor")
+	}
+	if srv.gotDescriptor.Type != flight.DescriptorPATH ||
+		len(srv.gotDescriptor.Path) == 0 ||
+		srv.gotDescriptor.Path[0] != CopyFromStdinDescriptorPath {
+		t.Errorf("descriptor routing wrong: %+v", srv.gotDescriptor)
+	}
+	if string(srv.gotDescriptor.Cmd) != copySQL {
+		t.Errorf("descriptor.Cmd = %q, want %q", srv.gotDescriptor.Cmd, copySQL)
+	}
+	if !bytes.Equal(srv.gotBytes.Bytes(), payload) {
+		t.Errorf("payload mismatch: got %d bytes, want %d", srv.gotBytes.Len(), len(payload))
+	}
+	if srv.frames < 2 {
+		t.Errorf("expected multiple frames for multi-MB payload, got %d", srv.frames)
+	}
+	if !strings.Contains(copySQL, CopyFromStdinPathPlaceholder) {
+		t.Fatalf("test bug: copySQL must contain placeholder")
+	}
+}

--- a/server/sqlcore/interfaces.go
+++ b/server/sqlcore/interfaces.go
@@ -9,7 +9,10 @@
 // import this package without dragging the DuckDB driver in.
 package sqlcore
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // ColumnTyper provides type name information for a database column.
 // *sql.ColumnType satisfies this interface.
@@ -54,4 +57,20 @@ type QueryExecutor interface {
 	// executed query, or "" if profiling is not enabled or not available
 	// (e.g. Flight SQL mode where the query ran on a remote worker).
 	LastProfilingOutput() string
+}
+
+// CopyFromStdinExecutor is an optional capability implemented by executors
+// that need the CSV bytes shipped to a different filesystem than the one
+// the COPY FROM STDIN handler is running on. The remote (Flight) executor
+// implements this to spool the bytes onto the worker pod, where the
+// worker can then run COPY FROM <path>. Local executors do not need to
+// implement it; the standard local-tempfile path works for them since
+// the executor and the COPY FROM SQL run in the same process / host.
+//
+// copySQLTemplate must contain a path placeholder that the receiver
+// substitutes with the destination spool path before executing. The
+// placeholder string is defined alongside the implementation
+// (flightclient.CopyFromStdinPathPlaceholder).
+type CopyFromStdinExecutor interface {
+	CopyFromStdin(ctx context.Context, copySQLTemplate string, csv io.Reader) (rowCount int64, err error)
 }


### PR DESCRIPTION
## TL;DR

`COPY FROM STDIN` from any client (Fivetran, dbt, psql `\copy`, etc.) is broken on the multitenant K8s control plane and has been since that backend shipped. Every COPY fails with:

```
IO Error: No files found that match the pattern "/tmp/duckgres-copy-*.csv"
```

This PR fixes it by streaming the CSV bytes through Flight DoPut to the worker pod instead of relying on a shared filesystem.

## Root cause (kept in case you skipped #551)

`server/conn.go handleCopyIn` spooled CSV bytes into the **control plane** pod's local `/tmp`, then sent `COPY <table> FROM '/tmp/<spool>' (...)` to the executor. In standalone and process-backend topologies the worker shares that filesystem; in remote-worker mode the worker is a separate pod (CP only mounts `/app/certs`, workers have an independent `/data` emptyDir) so the path resolves to nothing on the worker.

`server/flightclient/flight_executor.go:269` already flagged this — it explicitly errors out of `ConnContext` with "use batched INSERT for COPY FROM" — but `handleCopyIn` had no Flight-aware branch.

## The fix

Add an optional capability `sqlcore.CopyFromStdinExecutor` that the wire handler delegates to when the executor implements it. The Flight executor does; standalone and process-backend executors don't (they keep the existing local-tempfile path unchanged).

### Wire layout (CP → worker, on a single Flight DoPut stream)

```
frame 0:   FlightDescriptor{
             Type = PATH,
             Path = ["duckgres-copy-from-stdin"],
             Cmd  = "COPY t (...) FROM '__DUCKGRES_COPY_PATH__' (FORMAT CSV, ...)"
           }
frame 1+:  DataBody = <1 MiB chunk of CSV bytes>
...
(client closes send)
server:    PutResult{ AppMetadata = DoPutUpdateResult{RecordCount = N} }
```

The CP builds the COPY SQL with `BuildDuckDBCopyFromSQL` as before, except the path is the placeholder. The worker writes the streamed bytes to its **own** `/tmp`, replaces the placeholder with the worker-local path, then runs the COPY against `session.Conn`.

### Worker dispatch

`customActionServer.DoPut` peeks at the first FlightData frame and routes:

- If the descriptor matches `IsCopyFromStdinDescriptor` → `doCopyFromStdin` handles the rest of the stream.
- Otherwise → standard Flight SQL DoPut handler runs, with a small `prebufferedDoPutServer` adapter that replays the first frame so the standard handler sees the full stream.

This means existing `CommandStatementUpdate` traffic continues unchanged. The only new wire interaction is gated on a descriptor type that no other client produces.

### CP wire reader

`copyDataWireReader` in `server/conn.go` adapts the wire `MsgCopyData` / `MsgCopyDone` / `MsgCopyFail` stream into an `io.Reader`. CopyDone surfaces as clean `io.EOF`; CopyFail and unexpected messages set sticky flags the caller checks after the streamer returns. Avoids any double-buffering on the CP — bytes go wire → io.Reader → DoPut frame → worker tempfile.

## Files

- **server/sqlcore/interfaces.go** — new `CopyFromStdinExecutor` optional capability.
- **server/flightclient/copyfromstdin.go** — CP-side `(*FlightExecutor).CopyFromStdin` + descriptor / placeholder constants.
- **duckdbservice/copy_from_stdin.go** — worker-side handler `doCopyFromStdin` and `IsCopyFromStdinDescriptor`.
- **duckdbservice/service.go** — `DoPut` interceptor on `customActionServer` and `prebufferedDoPutServer` adapter.
- **server/conn.go** — `handleCopyIn` delegates to `handleCopyInRemoteStreaming` when the executor implements the capability; new `copyDataWireReader`.

## Tests

- `server/flightclient/copyfromstdin_test.go` — fake gRPC server, asserts CP sends correct descriptor (path, COPY SQL in `Cmd`), splits the payload into multiple frames for >1 MiB inputs, parses the `DoPutUpdateResult.RecordCount` from the response.
- `duckdbservice/copy_from_stdin_test.go`:
  - `IsCopyFromStdinDescriptor` matcher coverage (nil, wrong type, wrong path, correct).
  - `doCopyFromStdin` end-to-end against an in-memory DuckDB session: ingests a 3-row CSV split across two FlightData frames, runs the COPY, asserts `DoPutUpdateResult.RecordCount == 3` and that rows actually landed in the table.
  - Rejects a COPY SQL that's missing the path placeholder.
  - Rejects calls without a session token in metadata.

`go test ./...` and `go test -tags kubernetes ./...` are green (the two pre-existing `controlplane/admin` failures are missing-`docker-compose` on my laptop, unrelated).

## Test plan (post-merge)

- [ ] Deploy to staging MTCP, replay a Fivetran sync of `posthog_data_import → billing_*`. Confirm rows land in DuckLake-backed tables and the worker-side `/tmp/duckgres-worker-copy-*.csv` files come and go.
- [ ] Spot-check a `psql \copy ... FROM STDIN` against a remote-worker session.
- [ ] Confirm standalone and process-backend behavior is unchanged (same `duckgres-copy-*.csv` path, same logs).

## Related

- Closes #551 (the diagnosis-only PR I opened earlier).
- Pairs with #550 (DDL transpile gating in MTCP). With both merged, Fivetran's first stage (PK declaration) and second stage (CSV ingest) both work end-to-end on multitenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)