### PR TITLE
feat: bundle PostHog ducklake fork (v1.0-posthog.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,17 @@ ARG BUILD_TAGS=""
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.2
 ARG HTTPFS_EXTENSION_TAG=v1.5.2-stoi-fix
+ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.1
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 ARG DUCKDB_NIGHTLY_EXTENSION_REPOSITORY=http://nightly-extensions.duckdb.org
 RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres .
 RUN mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/benben/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
-    && for ext in ducklake json; do \
-         curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/${ext}.duckdb_extension.gz" \
-           | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/${ext}.duckdb_extension"; \
-       done \
+    && curl -fsSL "https://github.com/PostHog/ducklake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
+      -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/ducklake.duckdb_extension" \
+    && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
+      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${DUCKDB_NIGHTLY_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension"
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -50,6 +50,7 @@ RUN go mod download
 
 ARG DUCKDB_EXTENSION_VERSION=1.5.2
 ARG HTTPFS_EXTENSION_TAG=v1.5.2-stoi-fix
+ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.1
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 ARG DUCKDB_NIGHTLY_EXTENSION_REPOSITORY=http://nightly-extensions.duckdb.org
 
@@ -78,10 +79,10 @@ RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
 RUN mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/benben/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
-    && for ext in ducklake json; do \
-         curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/${ext}.duckdb_extension.gz" \
-           | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/${ext}.duckdb_extension"; \
-       done \
+    && curl -fsSL "https://github.com/PostHog/ducklake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
+      -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/ducklake.duckdb_extension" \
+    && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
+      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${DUCKDB_NIGHTLY_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension"
 

--- a/server/bundled_extensions_test.go
+++ b/server/bundled_extensions_test.go
@@ -114,41 +114,6 @@ func TestSeedBundledExtensionsReplacesExistingFilesWithUpdatedContents(t *testin
 	}
 }
 
-func TestSeedBundledExtensionsRefreshesDucklake(t *testing.T) {
-	srcRoot := t.TempDir()
-	dstRoot := t.TempDir()
-
-	srcDir := filepath.Join(srcRoot, "v1.5.2", "linux_arm64")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatalf("mkdir src: %v", err)
-	}
-	srcExt := filepath.Join(srcDir, "ducklake.duckdb_extension")
-	if err := os.WriteFile(srcExt, []byte("posthog-fork"), 0o644); err != nil {
-		t.Fatalf("write src extension: %v", err)
-	}
-
-	dstDir := filepath.Join(dstRoot, "v1.5.2", "linux_arm64")
-	if err := os.MkdirAll(dstDir, 0o755); err != nil {
-		t.Fatalf("mkdir dst: %v", err)
-	}
-	dstExt := filepath.Join(dstDir, "ducklake.duckdb_extension")
-	if err := os.WriteFile(dstExt, []byte("upstream"), 0o644); err != nil {
-		t.Fatalf("write dst extension: %v", err)
-	}
-
-	if err := seedBundledExtensions(srcRoot, dstRoot); err != nil {
-		t.Fatalf("seedBundledExtensions: %v", err)
-	}
-
-	got, err := os.ReadFile(dstExt)
-	if err != nil {
-		t.Fatalf("read dst extension: %v", err)
-	}
-	if string(got) != "posthog-fork" {
-		t.Fatalf("expected cached ducklake to be replaced by bundled fork, got %q", string(got))
-	}
-}
-
 func TestSeedBundledExtensionsPreservesNonTargetedChangedFiles(t *testing.T) {
 	srcRoot := t.TempDir()
 	dstRoot := t.TempDir()

--- a/server/bundled_extensions_test.go
+++ b/server/bundled_extensions_test.go
@@ -114,6 +114,41 @@ func TestSeedBundledExtensionsReplacesExistingFilesWithUpdatedContents(t *testin
 	}
 }
 
+func TestSeedBundledExtensionsRefreshesDucklake(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+
+	srcDir := filepath.Join(srcRoot, "v1.5.2", "linux_arm64")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	srcExt := filepath.Join(srcDir, "ducklake.duckdb_extension")
+	if err := os.WriteFile(srcExt, []byte("posthog-fork"), 0o644); err != nil {
+		t.Fatalf("write src extension: %v", err)
+	}
+
+	dstDir := filepath.Join(dstRoot, "v1.5.2", "linux_arm64")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("mkdir dst: %v", err)
+	}
+	dstExt := filepath.Join(dstDir, "ducklake.duckdb_extension")
+	if err := os.WriteFile(dstExt, []byte("upstream"), 0o644); err != nil {
+		t.Fatalf("write dst extension: %v", err)
+	}
+
+	if err := seedBundledExtensions(srcRoot, dstRoot); err != nil {
+		t.Fatalf("seedBundledExtensions: %v", err)
+	}
+
+	got, err := os.ReadFile(dstExt)
+	if err != nil {
+		t.Fatalf("read dst extension: %v", err)
+	}
+	if string(got) != "posthog-fork" {
+		t.Fatalf("expected cached ducklake to be replaced by bundled fork, got %q", string(got))
+	}
+}
+
 func TestSeedBundledExtensionsPreservesNonTargetedChangedFiles(t *testing.T) {
 	srcRoot := t.TempDir()
 	dstRoot := t.TempDir()

--- a/server/server.go
+++ b/server/server.go
@@ -983,7 +983,11 @@ func seedBundledExtensions(srcRoot, dstRoot string) error {
 }
 
 func shouldRefreshBundledExtension(srcPath string) bool {
-	return filepath.Base(srcPath) == "postgres_scanner.duckdb_extension"
+	switch filepath.Base(srcPath) {
+	case "postgres_scanner.duckdb_extension", "ducklake.duckdb_extension":
+		return true
+	}
+	return false
 }
 
 func copyFile(srcPath, dstPath string, mode os.FileMode) error {

--- a/tests/k8s/k8s_test.go
+++ b/tests/k8s/k8s_test.go
@@ -188,6 +188,36 @@ func TestK8sSharedWarmWorkerActivation(t *testing.T) {
 	}
 }
 
+// expectedDucklakeExtensionVersion is the short SHA of the commit
+// PostHog/ducklake's v1.0-posthog.1 tag points at. DuckDB's
+// EXT_VERSION_DUCKLAKE macro embeds this string at build time and exposes
+// it via duckdb_extensions().extension_version. Bump this in lock-step
+// with DUCKLAKE_EXTENSION_TAG in Dockerfile / Dockerfile.worker.
+const expectedDucklakeExtensionVersion = "90dc1f24"
+
+// TestK8sDucklakeExtensionIsBundledFork asserts the worker pods load the
+// PostHog ducklake fork bundled by Dockerfile.worker, not the upstream
+// build that DuckDB would otherwise fetch from extensions.duckdb.org.
+// The version string is the short SHA of the fork's tagged commit.
+func TestK8sDucklakeExtensionIsBundledFork(t *testing.T) {
+	if err := retryQueryWithReconnect("SELECT 1", 30*time.Second); err != nil {
+		t.Fatalf("warm-up query failed: %v", err)
+	}
+
+	var version string
+	if err := retryScanStringWithReconnect(
+		"SELECT extension_version FROM duckdb_extensions() WHERE extension_name = 'ducklake' AND loaded",
+		60*time.Second, &version,
+	); err != nil {
+		t.Fatalf("query ducklake extension_version: %v", err)
+	}
+	if version != expectedDucklakeExtensionVersion {
+		t.Fatalf("ducklake extension_version = %q, want %q (PostHog fork v1.0-posthog.1). "+
+			"If the bundled fork was upgraded, update expectedDucklakeExtensionVersion alongside DUCKLAKE_EXTENSION_TAG.",
+			version, expectedDucklakeExtensionVersion)
+	}
+}
+
 func TestK8sWorkerCrashRecovery(t *testing.T) {
 	// Run a query to ensure a worker exists
 	if err := retryQueryWithReconnect("SELECT 1", 30*time.Second); err != nil {
@@ -734,6 +764,12 @@ func retryQueryWithReconnect(query string, timeout time.Duration) error {
 }
 
 func retryScanIntWithReconnect(query string, timeout time.Duration, dest *int) error {
+	return retryDBOperationWithReconnectAs("postgres", "postgres", timeout, fmt.Sprintf("query %q", query), func(ctx context.Context, db *sql.DB) error {
+		return db.QueryRowContext(ctx, query).Scan(dest)
+	})
+}
+
+func retryScanStringWithReconnect(query string, timeout time.Duration, dest *string) error {
 	return retryDBOperationWithReconnectAs("postgres", "postgres", timeout, fmt.Sprintf("query %q", query), func(ctx context.Context, db *sql.DB) error {
 		return db.QueryRowContext(ctx, query).Scan(dest)
 	})


### PR DESCRIPTION
## Summary

- Swap the bundled `ducklake.duckdb_extension` in both `Dockerfile` and `Dockerfile.worker` from the upstream `extensions.duckdb.org` build to PostHog's fork at https://github.com/PostHog/ducklake/releases/tag/v1.0-posthog.1. Mirrors the existing httpfs override pattern (benben/duckdb-httpfs fork). Tag is parameterised via `--build-arg DUCKLAKE_EXTENSION_TAG=...` for future bumps.
- Add `ducklake.duckdb_extension` to `shouldRefreshBundledExtension` so the cached copy on a long-lived data-dir PVC is replaced when the image ships an updated fork build — same rationale as `postgres_scanner` (the previous symptom was stale cached extensions silently outlasting image upgrades).

The runtime path is unchanged: `bootstrapBundledExtensions` seeds `<data-dir>/extensions/v1.5.2/linux_<arch>/`, the DSN already sets `allow_unsigned_extensions=true`, and `INSTALL ducklake; LOAD ducklake` (server.go:1217) finds the pre-seeded binary without a network fetch.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server -run 'BundledExtensions|SeedBundled'` — added `TestSeedBundledExtensionsRefreshesDucklake` covering the new refresh-allowlist behaviour.
- [ ] CI: image build downloads the fork's `ducklake-linux-{amd64,arm64}.duckdb_extension` assets (verified to exist on the release).
- [ ] Smoke test in dev: spin up a fresh worker, `LOAD ducklake;` succeeds, and `SELECT * FROM duckdb_extensions() WHERE extension_name='ducklake'` shows the fork's extension binary loaded from the local cache.
- [ ] Confirm fork is built against the DuckDB 1.5.2 extension ABI — otherwise `LOAD` will fail with a version mismatch (same failure mode called out in `Dockerfile.worker:18-23`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)