### PR TITLE
fix(admin): admit iceberg fields in warehouse PUT strict-decode

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -523,6 +523,7 @@ type managedWarehouseRequest struct {
 	MetadataStore                  configstore.ManagedWarehouseMetadataStore     `json:"metadata_store"`
 	PgBouncer                      configstore.ManagedWarehousePgBouncer         `json:"pgbouncer"`
 	S3                             configstore.ManagedWarehouseS3                `json:"s3"`
+	Iceberg                        configstore.ManagedWarehouseIceberg           `json:"iceberg"`
 	WorkerIdentity                 configstore.ManagedWarehouseWorkerIdentity    `json:"worker_identity"`
 	WarehouseDatabaseCredentials   configstore.SecretRef                         `json:"warehouse_database_credentials"`
 	MetadataStoreCredentials       configstore.SecretRef                         `json:"metadata_store_credentials"`
@@ -536,6 +537,8 @@ type managedWarehouseRequest struct {
 	MetadataStoreStatusMessage     string                                        `json:"metadata_store_status_message"`
 	S3State                        configstore.ManagedWarehouseProvisioningState `json:"s3_state"`
 	S3StatusMessage                string                                        `json:"s3_status_message"`
+	IcebergState                   configstore.ManagedWarehouseProvisioningState `json:"iceberg_state"`
+	IcebergStatusMessage           string                                        `json:"iceberg_status_message"`
 	IdentityState                  configstore.ManagedWarehouseProvisioningState `json:"identity_state"`
 	IdentityStatusMessage          string                                        `json:"identity_status_message"`
 	SecretsState                   configstore.ManagedWarehouseProvisioningState `json:"secrets_state"`

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -532,6 +532,25 @@ func TestPutWarehouseDisablesPgBouncerWhenSetToFalse(t *testing.T) {
 	}
 }
 
+func TestPutWarehouseEnablesIcebergWhenSetToTrue(t *testing.T) {
+	store := newFakeAPIStore()
+	seedOrgWithWarehouse(store, "analytics")
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"iceberg": {"enabled": true}}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/warehouse", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !store.warehouses["analytics"].Iceberg.Enabled {
+		t.Fatal("expected iceberg.enabled=true after PUT")
+	}
+}
+
 func TestPutWarehousePreservesNestedFieldsOnPartialUpdate(t *testing.T) {
 	store := newFakeAPIStore()
 	seedOrgWithWarehouse(store, "analytics")


### PR DESCRIPTION
## Summary
Closes a missing piece in #554. PR #554 added the Iceberg fields to `ManagedWarehouse` and to the upsert column allowlist, but missed `managedWarehouseRequest` — the strict-decode struct that gates which top-level keys a PUT body may carry. Without this, `PUT /orgs/<id>/warehouse -d '{"iceberg":{"enabled":true}}'` returns:

```
HTTP/1.1 400 Bad Request
{"error":"json: unknown field \"iceberg\""}
```

— defeating the entire admin-API path that the drift correction in #555 was built around.

The doc comment on `managedWarehouseRequest` explicitly warns about this trap. Caught while attempting to enable iceberg for the posthog org on prod-us.

## Test plan
- [x] New `TestPutWarehouseEnablesIcebergWhenSetToTrue` mirrors the pgbouncer pattern (`TestPutWarehouseDisablesPgBouncerWhenSetToFalse`).
- [x] `go build -tags kubernetes ./...` clean.
- [x] `go test -tags kubernetes ./controlplane/admin/...` green.
- [ ] Manual: redeploy duckgres to prod-us, retry `PUT /api/v1/orgs/<posthog>/warehouse -d '{"iceberg":{"enabled":true}}'`, expect 200 + `iceberg.enabled=true` in GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)