### PR TITLE
fix(controlplane): propagate iceberg status in reconcileReady

### DIFF
--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -219,22 +219,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 	// When the composition writes status.iceberg.tableBucketArn, the bucket
 	// (Workspace) is reconciled and we persist the ARN + region back to the
 	// configstore so the worker activator can feed it into IcebergConfig.
-	if w.Iceberg.Enabled {
-		if status.Iceberg.TableBucketArn != "" {
-			if w.Iceberg.TableBucketArn != status.Iceberg.TableBucketArn {
-				updates["iceberg_table_bucket_arn"] = status.Iceberg.TableBucketArn
-			}
-			if w.Iceberg.Region != status.Iceberg.Region && status.Iceberg.Region != "" {
-				updates["iceberg_region"] = status.Iceberg.Region
-			}
-			if w.Iceberg.Namespace != status.Iceberg.NamespaceName && status.Iceberg.NamespaceName != "" {
-				updates["iceberg_namespace"] = status.Iceberg.NamespaceName
-			}
-			if w.IcebergState != configstore.ManagedWarehouseStateReady {
-				updates["iceberg_state"] = configstore.ManagedWarehouseStateReady
-			}
-		}
-	}
+	addIcebergStatusUpdates(updates, w, status)
 
 	// Infrastructure is ready when all components are provisioned AND the
 	// Crossplane Ready condition is True. The Ready condition ensures all
@@ -311,6 +296,57 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 		if err := c.duckling.SetIcebergEnabled(ctx, w.OrgID, w.Iceberg.Enabled); err != nil {
 			log.Warn("Failed to patch Duckling CR iceberg.enabled.", "error", err)
 		}
+	}
+
+	// Propagate the Duckling's status.iceberg.tableBucketArn back to the
+	// configstore even after the warehouse has transitioned to Ready. This
+	// covers the late-enable case: the iceberg block can be flipped on via
+	// the admin API long after the warehouse first became Ready, and the
+	// Crossplane composition will only emit the bucket Workspace + populate
+	// status.iceberg.tableBucketArn after that flip. Without this, the ARN
+	// would only land in the configstore if the warehouse was still in
+	// Provisioning when the composition completed — never on a re-enable.
+	if w.Iceberg.Enabled {
+		status, err := c.duckling.Get(ctx, w.OrgID)
+		if err != nil {
+			log.Warn("Failed to read Duckling status for iceberg propagation.", "error", err)
+			return
+		}
+		updates := map[string]interface{}{}
+		addIcebergStatusUpdates(updates, w, status)
+		if len(updates) > 0 {
+			if err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateReady, updates); err != nil {
+				log.Warn("Failed to persist iceberg status to configstore.", "error", err)
+			} else {
+				log.Info("Iceberg status persisted to configstore.", "updates", updates)
+			}
+		}
+	}
+}
+
+// addIcebergStatusUpdates copies the Duckling's reported iceberg status
+// (ARN, region, namespace) into the configstore update map when fields
+// differ. Idempotent. Called from both reconcileProvisioning (initial
+// turn-up) and reconcileReady (late iceberg enable on an existing
+// warehouse). Without the reconcileReady call site, a warehouse that
+// became Ready before iceberg was opted in would never get its ARN
+// propagated to the configstore — the worker activator would then run
+// AttachIcebergCatalog with an empty TableBucket and skip the attach.
+func addIcebergStatusUpdates(updates map[string]interface{}, w *configstore.ManagedWarehouse, status *DucklingStatus) {
+	if !w.Iceberg.Enabled || status.Iceberg.TableBucketArn == "" {
+		return
+	}
+	if w.Iceberg.TableBucketArn != status.Iceberg.TableBucketArn {
+		updates["iceberg_table_bucket_arn"] = status.Iceberg.TableBucketArn
+	}
+	if w.Iceberg.Region != status.Iceberg.Region && status.Iceberg.Region != "" {
+		updates["iceberg_region"] = status.Iceberg.Region
+	}
+	if w.Iceberg.Namespace != status.Iceberg.NamespaceName && status.Iceberg.NamespaceName != "" {
+		updates["iceberg_namespace"] = status.Iceberg.NamespaceName
+	}
+	if w.IcebergState != configstore.ManagedWarehouseStateReady {
+		updates["iceberg_state"] = configstore.ManagedWarehouseStateReady
 	}
 }
 

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -89,6 +89,14 @@ func (s *fakeStore) UpdateWarehouseState(orgID string, expectedState configstore
 		case "provisioning_started_at":
 			t := v.(time.Time)
 			w.ProvisioningStartedAt = &t
+		case "iceberg_table_bucket_arn":
+			w.Iceberg.TableBucketArn = v.(string)
+		case "iceberg_region":
+			w.Iceberg.Region = v.(string)
+		case "iceberg_namespace":
+			w.Iceberg.Namespace = v.(string)
+		case "iceberg_state":
+			w.IcebergState = v.(configstore.ManagedWarehouseProvisioningState)
 		}
 	}
 	return nil
@@ -394,6 +402,68 @@ func TestReconcileReadyPatchesCRWhenIcebergFlippedOff(t *testing.T) {
 	iceberg := spec["iceberg"].(map[string]interface{})
 	if iceberg["enabled"] != false {
 		t.Fatalf("expected iceberg.enabled=false after drift patch, got %v", iceberg["enabled"])
+	}
+}
+
+func TestReconcileReadyPropagatesIcebergStatusToConfigstore(t *testing.T) {
+	// Covers the late-iceberg-enable case: warehouse is already Ready,
+	// then iceberg gets opted in via admin API. The Crossplane composition
+	// eventually populates status.iceberg.tableBucketArn on the Duckling.
+	// reconcileReady must copy that back to the configstore — otherwise
+	// the worker activator's IcebergConfig.TableBucket stays empty and
+	// AttachIcebergCatalog skips the attach.
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-iceberg-late"] = &configstore.ManagedWarehouse{
+		OrgID: "org-iceberg-late",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			// TableBucketArn / Region / Namespace are intentionally empty —
+			// this is the configstore state right after an admin API PUT
+			// that just flipped iceberg.enabled=true.
+		},
+	}
+	const tableBucketArn = "arn:aws:s3tables:us-east-1:123456789012:bucket/org-iceberg-late-iceberg"
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata": map[string]interface{}{
+			"name":      ducklingName("org-iceberg-late"),
+			"namespace": ducklingNamespace,
+		},
+		"spec": map[string]interface{}{
+			"metadataStore": map[string]interface{}{"type": "aurora"},
+			"dataStore":     map[string]interface{}{"type": "s3bucket"},
+			"iceberg":       map[string]interface{}{"enabled": true},
+		},
+		"status": map[string]interface{}{
+			"iceberg": map[string]interface{}{
+				"tableBucketArn": tableBucketArn,
+				"region":         "us-east-1",
+				"namespaceName":  "main",
+			},
+		},
+	}}
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(context.Background(), cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.reconcile(context.Background())
+
+	got := fs.warehouses["org-iceberg-late"]
+	if got.Iceberg.TableBucketArn != tableBucketArn {
+		t.Fatalf("expected configstore iceberg.table_bucket_arn=%q, got %q", tableBucketArn, got.Iceberg.TableBucketArn)
+	}
+	if got.Iceberg.Region != "us-east-1" {
+		t.Fatalf("expected iceberg.region=us-east-1, got %q", got.Iceberg.Region)
+	}
+	if got.Iceberg.Namespace != "main" {
+		t.Fatalf("expected iceberg.namespace=main, got %q", got.Iceberg.Namespace)
+	}
+	if got.IcebergState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("expected iceberg_state=ready, got %q", got.IcebergState)
 	}
 }
 


### PR DESCRIPTION
## Summary
Follow-up #1 from the iceberg rollout on managed-warehouse-prod-us.

The Duckling-status → configstore propagation for iceberg currently lives only in `reconcileProvisioning`. Once a warehouse transitions to `Ready`, the controller stops pulling status fields from the Duckling CR.

That's wrong for the **late-iceberg-enable** case:
1. Admin flips `iceberg.enabled=true` via the admin API on a warehouse that's already `Ready`
2. #555's drift correction patches `spec.iceberg.enabled=true` on the Duckling CR
3. Crossplane composition provisions the bucket and writes `status.iceberg.tableBucketArn`
4. **But the controller never reads that status back** — warehouse is still `Ready`, never moved through `Provisioning`
5. The configstore's `iceberg.table_bucket_arn` stays empty
6. Worker activator's `IcebergConfig.TableBucket` stays empty → `AttachIcebergCatalog` gets gated out → iceberg never actually attaches

## Observed
Hit this exactly on prod-us today: the cascade completed at the Crossplane layer (`Duckling.status.iceberg.tableBucketArn` populated, bucket exists in AWS) but `iceberg_state` in the configstore never flipped from `""` to `"ready"`. Recovery required a manual admin API PUT to write the fields directly.

## Fix
Extract the propagation logic into `addIcebergStatusUpdates(updates, w, status)`. Call from both:
- `reconcileProvisioning` — initial turn-up, unchanged behavior
- `reconcileReady` — late enable, new call site

Added `TestReconcileReadyPropagatesIcebergStatusToConfigstore` covering the bug. Existing 10 reconcile tests still pass.

## Test plan
- [x] `go build ./controlplane/provisioner/`
- [x] `go test ./controlplane/provisioner/ -run TestReconcile -count=1 -tags=kubernetes` — 11/11 pass including new test
- [ ] Manual on dev: enable iceberg on an existing Ready warehouse, watch configstore `iceberg_state` flip to `ready` automatically (no admin API PUT needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)