### PR TITLE
fix(server): use TYPE S3 credential_chain for iceberg s3_tables auth

### DIFF
--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -14,16 +14,26 @@ const DefaultRegion = "us-east-1"
 // worker) would require generalizing this.
 const CatalogName = "iceberg"
 
-// BuildIcebergSecretStmt builds the CREATE SECRET statement for SigV4 auth
-// against AWS S3 Tables. The DuckDB iceberg extension picks up the secret by
-// type (TYPE ICEBERG) when there's no SECRET name on the ATTACH.
+// BuildIcebergSecretStmt builds the CREATE SECRET statement that the
+// DuckDB iceberg extension uses to sign AWS S3 Tables requests when an
+// `ATTACH ... (TYPE iceberg, ENDPOINT_TYPE 's3_tables')` is opened.
+//
+// DuckDB's TYPE ICEBERG secret is OAuth2-only — it has a single provider
+// ('config') registered by OAuth2Authorization::CreateCatalogSecretFunction.
+// Trying to pass AUTHORIZATION_TYPE/REGION on TYPE ICEBERG fails with
+// "Unknown parameter ... with default provider 'config'".
+//
+// For s3_tables the iceberg extension internally signs with SigV4 and pulls
+// the AWS credentials from any TYPE S3 secret in scope. credential_chain
+// lets us reuse whatever the worker pod already has (IRSA web identity, EKS
+// Pod Identity container creds, or env vars) without baking access keys in.
 func BuildIcebergSecretStmt(cfg Config) string {
 	region := cfg.Region
 	if region == "" {
 		region = DefaultRegion
 	}
 	return fmt.Sprintf(
-		"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION '%s')",
+		"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION '%s')",
 		escapeSQLStringLiteral(region),
 	)
 }

--- a/server/iceberg/migration_test.go
+++ b/server/iceberg/migration_test.go
@@ -25,7 +25,7 @@ func TestBuildIcebergAttachStmtEscapesSingleQuotes(t *testing.T) {
 
 func TestBuildIcebergSecretStmt(t *testing.T) {
 	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"})
-	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION 'us-west-2')"
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-west-2')"
 	if got != want {
 		t.Fatalf("BuildIcebergSecretStmt mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -33,7 +33,7 @@ func TestBuildIcebergSecretStmt(t *testing.T) {
 
 func TestBuildIcebergSecretStmtDefaultsRegion(t *testing.T) {
 	got := BuildIcebergSecretStmt(Config{})
-	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION 'us-east-1')"
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-east-1')"
 	if got != want {
 		t.Fatalf("BuildIcebergSecretStmt should default to us-east-1:\n got: %s\nwant: %s", got, want)
 	}


### PR DESCRIPTION
## Summary

Prod-us iceberg workers were failing tenant activation with:

\`\`\`
create Iceberg secret: Binder Error: Unknown parameter 'region' for
secret type 'iceberg' with default provider 'config'
\`\`\`

Root cause: \`BuildIcebergSecretStmt\` produces:

\`\`\`sql
CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION '...')
\`\`\`

But DuckDB's iceberg extension only registers an OAuth2 secret function for TYPE ICEBERG (provider 'config'). \`AUTHORIZATION_TYPE\` / \`REGION\` aren't recognized — only OAuth2 fields are valid on TYPE ICEBERG.

For \`ATTACH ... (TYPE iceberg, ENDPOINT_TYPE 's3_tables')\` the extension signs requests with SigV4 internally and pulls AWS credentials from any **TYPE S3** secret in scope. Switch to a TYPE S3 secret with \`PROVIDER credential_chain\` so the worker reuses whatever AWS creds it already has (IRSA web identity / EKS Pod Identity / env vars) — no key material baked into the SQL.

## Empirical validation

Reproduced against the same DuckDB version duckgres bundles (\`duckdb-go v2.10502.0\` = DuckDB 1.5.2, iceberg extension \`11fea8ed\`):

\`\`\`sh
# Old SQL — Binder Error
\$ docker run --rm datacatering/duckdb:v1.5.2 -c \"INSTALL iceberg; LOAD iceberg;
  CREATE OR REPLACE SECRET t (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION 'us-east-1');\"
Binder Error: Unknown parameter 'authorization_type' for secret type 'iceberg' with default provider 'config'

# New SQL — parses cleanly; ATTACH reaches AWS and signs SigV4 correctly
# (HTTP 403 just because the test creds aren't authorized)
\$ docker run --rm datacatering/duckdb:v1.5.2 -c \"INSTALL iceberg; LOAD iceberg;
  CREATE OR REPLACE SECRET t (TYPE S3, PROVIDER credential_chain, REGION 'us-east-1');
  ATTACH 'arn:aws:s3tables:...' AS iceberg (TYPE ICEBERG, ENDPOINT_TYPE 's3_tables');\"
Invalid Configuration Error: ... s3tables.us-east-1.amazonaws.com ... Forbidden_403
\`\`\`

Same secret *name* (\`iceberg_sigv4\`) so the ATTACH path doesn't change.

## Test plan

- [x] Unit tests in \`server/iceberg/migration_test.go\` updated and passing locally
- [ ] After deploy, confirm a worker pod with iceberg.enabled successfully activates and no longer logs \"create Iceberg secret: Binder Error\"
- [ ] Confirm a DuckDB client can \`ATTACH\` and list tables in the iceberg namespace