### PR TITLE
fix(server): use explicit STS credentials for iceberg secret

### DIFF
--- a/server/iceberg/integration_test.go
+++ b/server/iceberg/integration_test.go
@@ -1,0 +1,100 @@
+package iceberg_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/posthog/duckgres/server/iceberg"
+)
+
+// TestIcebergSecretAcceptedByDuckDB is a regression test for the bug
+// fixed by PR #562 (this PR): PR #560's `TYPE S3, PROVIDER credential_chain`
+// secret form parsed cleanly but failed validation at CREATE time on
+// workers without an AWS identity reachable through DuckDB's built-in
+// chain. The earlier `TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4'` form
+// (pre-#560) failed at bind time with "Unknown parameter ... with default
+// provider 'config'".
+//
+// We exercise the actual SQL string against an in-memory DuckDB with the
+// iceberg extension loaded, so any future change that re-introduces a
+// non-parseable or validation-failing secret form is caught at unit-test
+// time without needing AWS credentials or network reach to S3 Tables.
+//
+// The test is gated on the iceberg extension being available locally
+// (INSTALL pulls from DuckDB's repository on first run). When the
+// extension cannot be installed/loaded — e.g. air-gapped CI — the test
+// is skipped rather than failed so the regression coverage exists where
+// it can run and disappears cleanly where it can't.
+func TestIcebergSecretAcceptedByDuckDB(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec("INSTALL iceberg"); err != nil {
+		t.Skipf("iceberg extension unavailable (network or sandbox): %v", err)
+	}
+	if _, err := db.Exec("LOAD iceberg"); err != nil {
+		t.Skipf("iceberg extension load failed: %v", err)
+	}
+
+	// Explicit-credentials cases: must succeed cleanly. PROVIDER config with
+	// inlined KEY_ID/SECRET does not depend on any host-side AWS state, so
+	// there's no legitimate reason for these to error in any test
+	// environment. A failure here is the regression we are guarding against.
+	strictCases := []struct {
+		name         string
+		region       string
+		keyID        string
+		secret       string
+		sessionToken string
+	}{
+		{"explicit creds with session token", "us-east-1", "AKIA_TEST", "shh", "session-token-fake"},
+		{"explicit creds without session token", "us-west-2", "AKIA_TEST", "shh", ""},
+	}
+	for _, tc := range strictCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := iceberg.BuildIcebergSecretStmt(
+				iceberg.Config{Region: tc.region},
+				tc.keyID, tc.secret, tc.sessionToken,
+			)
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("explicit-credential secret rejected by DuckDB: %v\nstmt: %s", err, stmt)
+			}
+		})
+	}
+
+	// Credential-chain fallback: the secret form must parse and be
+	// recognized by DuckDB, but the credential walk itself depends on the
+	// host having AWS credentials reachable through DuckDB's built-in
+	// chain. Locally and in sandboxed CI this typically fails with
+	// "Secret Validation Failure" — same shape as the original PR #560
+	// bug on EKS workers. Tolerate that specific failure mode while still
+	// catching binder/parser/type errors that would indicate the SQL form
+	// itself regressed.
+	t.Run("credential chain fallback", func(t *testing.T) {
+		stmt := iceberg.BuildIcebergSecretStmt(iceberg.Config{Region: "us-east-1"}, "", "", "")
+		_, err := db.Exec(stmt)
+		if err == nil {
+			return
+		}
+		lower := strings.ToLower(err.Error())
+		fatalSignals := []string{
+			"unknown parameter",
+			"binder error",
+			"parser error",
+			"unknown secret type",
+			"unknown provider",
+		}
+		for _, sig := range fatalSignals {
+			if strings.Contains(lower, sig) {
+				t.Fatalf("credential_chain SQL form rejected by DuckDB: %v\nstmt: %s", err, stmt)
+			}
+		}
+		t.Logf("credential_chain create failed at validation (expected when host has no AWS identity): %v", err)
+	})
+}

--- a/server/iceberg/integration_test.go
+++ b/server/iceberg/integration_test.go
@@ -2,7 +2,6 @@ package iceberg_test
 
 import (
 	"database/sql"
-	"strings"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
@@ -10,24 +9,28 @@ import (
 	"github.com/posthog/duckgres/server/iceberg"
 )
 
-// TestIcebergSecretAcceptedByDuckDB is a regression test for the bug
-// fixed by PR #562 (this PR): PR #560's `TYPE S3, PROVIDER credential_chain`
-// secret form parsed cleanly but failed validation at CREATE time on
-// workers without an AWS identity reachable through DuckDB's built-in
-// chain. The earlier `TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4'` form
-// (pre-#560) failed at bind time with "Unknown parameter ... with default
-// provider 'config'".
+// TestIcebergSecretAcceptedByDuckDB is a regression test for the bug fixed
+// by PR #562. Earlier history on the same code:
+//   - Pre-#560 form (TYPE ICEBERG, AUTHORIZATION_TYPE 'SIGV4', REGION ...)
+//     failed at bind time: "Unknown parameter ... with default provider
+//     'config'". TYPE ICEBERG is OAuth2-only in the iceberg extension.
+//   - #560 form (TYPE S3, PROVIDER credential_chain, REGION ...) parsed
+//     fine but failed validation at CREATE time on workers without an AWS
+//     identity reachable through DuckDB's built-in chain — which is every
+//     worker on the PostHog multitenant deploy. The credential_chain path
+//     has been removed entirely; iceberg now requires explicit STS-minted
+//     credentials shipped in the activation payload (same as DuckLake).
 //
-// We exercise the actual SQL string against an in-memory DuckDB with the
-// iceberg extension loaded, so any future change that re-introduces a
-// non-parseable or validation-failing secret form is caught at unit-test
-// time without needing AWS credentials or network reach to S3 Tables.
+// This test exercises the actual SQL string against an in-memory DuckDB
+// with the iceberg extension loaded, so any future change that
+// re-introduces a non-parseable or validation-failing secret form is
+// caught at unit-test time without needing AWS credentials or network
+// reach to S3 Tables.
 //
-// The test is gated on the iceberg extension being available locally
-// (INSTALL pulls from DuckDB's repository on first run). When the
+// Gated on the iceberg extension being installable locally. When the
 // extension cannot be installed/loaded — e.g. air-gapped CI — the test
-// is skipped rather than failed so the regression coverage exists where
-// it can run and disappears cleanly where it can't.
+// skips rather than fails so the regression coverage exists where it can
+// run and disappears cleanly where it can't.
 func TestIcebergSecretAcceptedByDuckDB(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {
@@ -42,11 +45,12 @@ func TestIcebergSecretAcceptedByDuckDB(t *testing.T) {
 		t.Skipf("iceberg extension load failed: %v", err)
 	}
 
-	// Explicit-credentials cases: must succeed cleanly. PROVIDER config with
-	// inlined KEY_ID/SECRET does not depend on any host-side AWS state, so
-	// there's no legitimate reason for these to error in any test
-	// environment. A failure here is the regression we are guarding against.
-	strictCases := []struct {
+	// PROVIDER config with inlined KEY_ID/SECRET does not depend on any
+	// host-side AWS state, so there is no legitimate reason for these to
+	// error in any test environment. A failure here is the regression we
+	// are guarding against. SESSION_TOKEN is optional in the DDL (omitted
+	// for static IAM users); both shapes must be accepted.
+	cases := []struct {
 		name         string
 		region       string
 		keyID        string
@@ -56,7 +60,7 @@ func TestIcebergSecretAcceptedByDuckDB(t *testing.T) {
 		{"explicit creds with session token", "us-east-1", "AKIA_TEST", "shh", "session-token-fake"},
 		{"explicit creds without session token", "us-west-2", "AKIA_TEST", "shh", ""},
 	}
-	for _, tc := range strictCases {
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stmt := iceberg.BuildIcebergSecretStmt(
 				iceberg.Config{Region: tc.region},
@@ -67,34 +71,4 @@ func TestIcebergSecretAcceptedByDuckDB(t *testing.T) {
 			}
 		})
 	}
-
-	// Credential-chain fallback: the secret form must parse and be
-	// recognized by DuckDB, but the credential walk itself depends on the
-	// host having AWS credentials reachable through DuckDB's built-in
-	// chain. Locally and in sandboxed CI this typically fails with
-	// "Secret Validation Failure" — same shape as the original PR #560
-	// bug on EKS workers. Tolerate that specific failure mode while still
-	// catching binder/parser/type errors that would indicate the SQL form
-	// itself regressed.
-	t.Run("credential chain fallback", func(t *testing.T) {
-		stmt := iceberg.BuildIcebergSecretStmt(iceberg.Config{Region: "us-east-1"}, "", "", "")
-		_, err := db.Exec(stmt)
-		if err == nil {
-			return
-		}
-		lower := strings.ToLower(err.Error())
-		fatalSignals := []string{
-			"unknown parameter",
-			"binder error",
-			"parser error",
-			"unknown secret type",
-			"unknown provider",
-		}
-		for _, sig := range fatalSignals {
-			if strings.Contains(lower, sig) {
-				t.Fatalf("credential_chain SQL form rejected by DuckDB: %v\nstmt: %s", err, stmt)
-			}
-		}
-		t.Logf("credential_chain create failed at validation (expected when host has no AWS identity): %v", err)
-	})
 }

--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -21,21 +21,47 @@ const CatalogName = "iceberg"
 // DuckDB's TYPE ICEBERG secret is OAuth2-only — it has a single provider
 // ('config') registered by OAuth2Authorization::CreateCatalogSecretFunction.
 // Trying to pass AUTHORIZATION_TYPE/REGION on TYPE ICEBERG fails with
-// "Unknown parameter ... with default provider 'config'".
+// "Unknown parameter ... with default provider 'config'". For s3_tables
+// the iceberg extension internally signs with SigV4 and pulls credentials
+// from any TYPE S3 secret in scope.
 //
-// For s3_tables the iceberg extension internally signs with SigV4 and pulls
-// the AWS credentials from any TYPE S3 secret in scope. credential_chain
-// lets us reuse whatever the worker pod already has (IRSA web identity, EKS
-// Pod Identity container creds, or env vars) without baking access keys in.
-func BuildIcebergSecretStmt(cfg Config) string {
+// When keyID is non-empty the secret is built with PROVIDER config and the
+// supplied short-lived credentials inlined directly. This is the multitenant
+// production path: the control plane assumes the per-tenant IAM role via
+// STS and ships the resulting temporary credentials in the worker
+// activation payload, identical to how the DuckLake S3 secret is built (see
+// buildConfigSecret in server/server.go). The same role has both s3:* and
+// s3tables:* permissions on the tenant's data and table buckets, so reusing
+// the credentials here is correct.
+//
+// When keyID is empty the secret falls back to PROVIDER credential_chain.
+// This preserves the legacy/standalone path where the host running the
+// worker has its own AWS identity reachable via env vars, ~/.aws, or IMDS.
+// On EKS deployments without IRSA/Pod Identity on the worker pod (the
+// PostHog production topology) this fallback will fail at create time —
+// callers in that topology must supply explicit credentials.
+func BuildIcebergSecretStmt(cfg Config, keyID, secret, sessionToken string) string {
 	region := cfg.Region
 	if region == "" {
 		region = DefaultRegion
 	}
-	return fmt.Sprintf(
-		"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION '%s')",
+	if keyID == "" {
+		return fmt.Sprintf(
+			"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION '%s')",
+			escapeSQLStringLiteral(region),
+		)
+	}
+	stmt := fmt.Sprintf(
+		"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID '%s', SECRET '%s', REGION '%s'",
+		escapeSQLStringLiteral(keyID),
+		escapeSQLStringLiteral(secret),
 		escapeSQLStringLiteral(region),
 	)
+	if sessionToken != "" {
+		stmt += fmt.Sprintf(", SESSION_TOKEN '%s'", escapeSQLStringLiteral(sessionToken))
+	}
+	stmt += ")"
+	return stmt
 }
 
 // BuildIcebergAttachStmt builds the ATTACH statement for the Iceberg

--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -25,31 +25,24 @@ const CatalogName = "iceberg"
 // the iceberg extension internally signs with SigV4 and pulls credentials
 // from any TYPE S3 secret in scope.
 //
-// When keyID is non-empty the secret is built with PROVIDER config and the
-// supplied short-lived credentials inlined directly. This is the multitenant
-// production path: the control plane assumes the per-tenant IAM role via
-// STS and ships the resulting temporary credentials in the worker
-// activation payload, identical to how the DuckLake S3 secret is built (see
+// The secret is always built with PROVIDER config and the supplied
+// short-lived credentials inlined directly. This is the only supported
+// auth model: the control plane assumes the per-tenant IAM role via STS
+// and ships the resulting temporary credentials in the worker activation
+// payload, identical to how the DuckLake S3 secret is built (see
 // buildConfigSecret in server/server.go). The same role has both s3:* and
-// s3tables:* permissions on the tenant's data and table buckets, so reusing
-// the credentials here is correct.
+// s3tables:* permissions on the tenant's data and table buckets, so
+// reusing the credentials here is correct.
 //
-// When keyID is empty the secret falls back to PROVIDER credential_chain.
-// This preserves the legacy/standalone path where the host running the
-// worker has its own AWS identity reachable via env vars, ~/.aws, or IMDS.
-// On EKS deployments without IRSA/Pod Identity on the worker pod (the
-// PostHog production topology) this fallback will fail at create time —
-// callers in that topology must supply explicit credentials.
+// keyID and secret are required — callers must validate upstream and emit
+// a clear error if the activation payload is missing them when iceberg is
+// enabled. sessionToken is optional (omitted from the DDL when empty) to
+// support the rare static-IAM-user case, though STS:AssumeRole always
+// returns one in production.
 func BuildIcebergSecretStmt(cfg Config, keyID, secret, sessionToken string) string {
 	region := cfg.Region
 	if region == "" {
 		region = DefaultRegion
-	}
-	if keyID == "" {
-		return fmt.Sprintf(
-			"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION '%s')",
-			escapeSQLStringLiteral(region),
-		)
 	}
 	stmt := fmt.Sprintf(
 		"CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID '%s', SECRET '%s', REGION '%s'",

--- a/server/iceberg/migration_test.go
+++ b/server/iceberg/migration_test.go
@@ -23,18 +23,45 @@ func TestBuildIcebergAttachStmtEscapesSingleQuotes(t *testing.T) {
 	}
 }
 
-func TestBuildIcebergSecretStmt(t *testing.T) {
-	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"})
-	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-west-2')"
+func TestBuildIcebergSecretStmtWithExplicitCreds(t *testing.T) {
+	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"}, "AKIA_TEST", "shh", "tok123")
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID 'AKIA_TEST', SECRET 'shh', REGION 'us-west-2', SESSION_TOKEN 'tok123')"
 	if got != want {
 		t.Fatalf("BuildIcebergSecretStmt mismatch:\n got: %s\nwant: %s", got, want)
 	}
 }
 
+func TestBuildIcebergSecretStmtWithoutSessionToken(t *testing.T) {
+	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"}, "AKIA_TEST", "shh", "")
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID 'AKIA_TEST', SECRET 'shh', REGION 'us-west-2')"
+	if got != want {
+		t.Fatalf("BuildIcebergSecretStmt without session token mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildIcebergSecretStmtFallsBackToCredentialChain(t *testing.T) {
+	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"}, "", "", "")
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-west-2')"
+	if got != want {
+		t.Fatalf("BuildIcebergSecretStmt should fall back to credential_chain when keyID is empty:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 func TestBuildIcebergSecretStmtDefaultsRegion(t *testing.T) {
-	got := BuildIcebergSecretStmt(Config{})
+	got := BuildIcebergSecretStmt(Config{}, "", "", "")
 	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-east-1')"
 	if got != want {
 		t.Fatalf("BuildIcebergSecretStmt should default to us-east-1:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildIcebergSecretStmtEscapesQuotesInCreds(t *testing.T) {
+	// Defensive: STS creds shouldn't contain single quotes in practice, but
+	// the helper escapes them anyway so an attacker-controlled value can't
+	// break out of the SQL string literal.
+	got := BuildIcebergSecretStmt(Config{Region: "us-east-1"}, "key'with'quotes", "secret'too", "tok'en")
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID 'key''with''quotes', SECRET 'secret''too', REGION 'us-east-1', SESSION_TOKEN 'tok''en')"
+	if got != want {
+		t.Fatalf("BuildIcebergSecretStmt did not escape quotes in creds:\n got: %s\nwant: %s", got, want)
 	}
 }

--- a/server/iceberg/migration_test.go
+++ b/server/iceberg/migration_test.go
@@ -39,17 +39,9 @@ func TestBuildIcebergSecretStmtWithoutSessionToken(t *testing.T) {
 	}
 }
 
-func TestBuildIcebergSecretStmtFallsBackToCredentialChain(t *testing.T) {
-	got := BuildIcebergSecretStmt(Config{Region: "us-west-2"}, "", "", "")
-	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-west-2')"
-	if got != want {
-		t.Fatalf("BuildIcebergSecretStmt should fall back to credential_chain when keyID is empty:\n got: %s\nwant: %s", got, want)
-	}
-}
-
 func TestBuildIcebergSecretStmtDefaultsRegion(t *testing.T) {
-	got := BuildIcebergSecretStmt(Config{}, "", "", "")
-	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER credential_chain, REGION 'us-east-1')"
+	got := BuildIcebergSecretStmt(Config{}, "AKIA_TEST", "shh", "tok")
+	want := "CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE S3, PROVIDER config, KEY_ID 'AKIA_TEST', SECRET 'shh', REGION 'us-east-1', SESSION_TOKEN 'tok')"
 	if got != want {
 		t.Fatalf("BuildIcebergSecretStmt should default to us-east-1:\n got: %s\nwant: %s", got, want)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1086,7 +1086,7 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 		}
 		slog.Warn("Failed to attach Delta catalog.", "user", username, "error", err)
 	}
-	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem); err != nil {
+	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem, cfg.DuckLake.S3AccessKey, cfg.DuckLake.S3SecretKey, cfg.DuckLake.S3SessionToken); err != nil {
 		if cfg.Iceberg.Enabled {
 			return fmt.Errorf("iceberg catalog configured but attachment failed: %w", err)
 		}
@@ -1124,7 +1124,7 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 	if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
 		return fmt.Errorf("delta catalog configured but attachment failed: %w", err)
 	}
-	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem); err != nil {
+	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem, cfg.DuckLake.S3AccessKey, cfg.DuckLake.S3SecretKey, cfg.DuckLake.S3SessionToken); err != nil {
 		return fmt.Errorf("iceberg catalog configured but attachment failed: %w", err)
 	}
 
@@ -1180,7 +1180,7 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 		}
 		slog.Warn("Failed to attach Delta catalog.", "user", username, "error", err)
 	}
-	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem); err != nil {
+	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem, cfg.DuckLake.S3AccessKey, cfg.DuckLake.S3SecretKey, cfg.DuckLake.S3SessionToken); err != nil {
 		if cfg.Iceberg.Enabled {
 			_ = db.Close()
 			return nil, fmt.Errorf("iceberg catalog configured but attachment failed: %w", err)
@@ -1604,7 +1604,14 @@ func isDeltaCatalogEmptyError(err error) bool {
 // Iceberg.Enabled, idempotent if the catalog is already attached, and
 // fail-soft for the "fresh tenant, no namespaces yet" case so a worker
 // activation isn't blocked by an empty catalog.
-func AttachIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}) error {
+//
+// keyID/secret/sessionToken are short-lived AWS credentials produced by the
+// control plane's STS AssumeRole on the per-tenant IAM role. They are the
+// same credentials DuckLake uses (see buildConfigSecret) — the per-tenant
+// role has both s3:* and s3tables:* permissions, so reusing them here is
+// correct. When empty, BuildIcebergSecretStmt falls back to
+// PROVIDER credential_chain (for standalone/host-AWS-identity deployments).
+func AttachIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID, secret, sessionToken string) error {
 	if !ic.Enabled || ic.TableBucket == "" {
 		return nil
 	}
@@ -1630,7 +1637,7 @@ func AttachIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}) error
 		return fmt.Errorf("load iceberg extension: %w", err)
 	}
 
-	if _, err := db.Exec(iceberg.BuildIcebergSecretStmt(ic)); err != nil {
+	if _, err := db.Exec(iceberg.BuildIcebergSecretStmt(ic, keyID, secret, sessionToken)); err != nil {
 		return fmt.Errorf("create Iceberg secret: %w", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1605,15 +1605,21 @@ func isDeltaCatalogEmptyError(err error) bool {
 // fail-soft for the "fresh tenant, no namespaces yet" case so a worker
 // activation isn't blocked by an empty catalog.
 //
-// keyID/secret/sessionToken are short-lived AWS credentials produced by the
-// control plane's STS AssumeRole on the per-tenant IAM role. They are the
-// same credentials DuckLake uses (see buildConfigSecret) — the per-tenant
+// keyID/secret/sessionToken are short-lived AWS credentials produced by
+// the control plane's STS AssumeRole on the per-tenant IAM role — the
+// same credentials DuckLake uses (see buildConfigSecret). The per-tenant
 // role has both s3:* and s3tables:* permissions, so reusing them here is
-// correct. When empty, BuildIcebergSecretStmt falls back to
-// PROVIDER credential_chain (for standalone/host-AWS-identity deployments).
+// correct. This is the only supported auth model for iceberg: we do NOT
+// fall back to DuckDB's credential_chain because the worker pod has no
+// AWS identity of its own on the multitenant production topology. Missing
+// credentials when iceberg is enabled is a configuration bug and surfaces
+// as an explicit error rather than a silent fallback.
 func AttachIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID, secret, sessionToken string) error {
 	if !ic.Enabled || ic.TableBucket == "" {
 		return nil
+	}
+	if keyID == "" || secret == "" {
+		return fmt.Errorf("iceberg catalog enabled (table_bucket=%q) but no AWS credentials in activation payload — control plane STS broker did not populate DuckLake S3 credentials", ic.TableBucket)
 	}
 
 	select {


### PR DESCRIPTION
## Summary

PR [#560](https://github.com/PostHog/duckgres/pull/560) wired the iceberg S3 secret to `PROVIDER credential_chain`. DuckDB's built-in credential chain does not support EKS Pod Identity (the comment on [`fetchAWSSDKCredentials`](https://github.com/PostHog/duckgres/blob/main/server/server.go#L2060) calls this out explicitly), and on the PostHog multitenant deploy the worker pod has **no AWS identity of its own at all** — the `duckgres-worker` SA has no IRSA annotation, no Pod Identity association, no AWS env vars. So \`CREATE SECRET\` fails at validation time:

> Invalid Configuration Error: Secret Validation Failure: during \`create\` using the following: Credential Chain: 'config'

DuckLake doesn't hit this because the control plane runs \`STS:AssumeRole\` on the per-tenant IAM role and ships the resulting short-lived credentials inline in the worker activation payload. The DuckLake S3 secret is then built with \`PROVIDER config\` and those explicit credentials (see [\`buildConfigSecret\`](https://github.com/PostHog/duckgres/blob/main/server/server.go#L1979)).

The [per-tenant IAM role rendered by the duckling Crossplane Composition](https://github.com/PostHog/charts/blob/main/charts/crossplane-config/templates/composition.yaml) already grants both \`s3:*\` (data bucket) and \`s3tables:*\` (iceberg table bucket) when \`spec.iceberg.enabled=true\`. The credentials in \`cfg.DuckLake.S3AccessKey/SecretKey/SessionToken\` are already authorized for S3 Tables — they just need to be threaded into the iceberg secret too.

## What changed

- **\`server/iceberg/migration.go\`** — \`BuildIcebergSecretStmt\` now requires \`keyID\`/\`secret\` (with optional \`sessionToken\`) and always emits \`PROVIDER config\` with the explicit credentials inlined. **There is no fallback to \`PROVIDER credential_chain\`** — the activator-managed STS-minted credentials are the only supported auth model.
- **\`server/server.go\`** — \`AttachIcebergCatalog\` accepts the three credential strings and validates them up-front. If \`ic.Enabled\` but \`keyID\`/\`secret\` are empty, returns: \`iceberg catalog enabled (table_bucket=...) but no AWS credentials in activation payload — control plane STS broker did not populate DuckLake S3 credentials\`. All three call sites (initial connect, shared warm activation, passthrough) pass \`cfg.DuckLake.S3AccessKey/SecretKey/SessionToken\` — same credentials DuckLake uses on the same per-tenant role.
- **\`server/iceberg/migration_test.go\`** — string-level coverage of the new SQL shape: with and without session token, region default, quote-escaping defense against attacker-controlled credential values.
- **\`server/iceberg/integration_test.go\`** — DuckDB-level regression test (added pre-PR in \`8213934\` as a regression net for #560's bug class). Updated to drop the obsolete \`credential chain fallback\` subtest — that subtest exercised an empty-credential SQL form that no longer exists, and its assertion was so permissive it was logging-and-passing instead of testing anything meaningful.

## Why no credential_chain fallback?

Earlier iterations of this PR included a fallback: when \`keyID\` was empty, emit a \`PROVIDER credential_chain\` secret as before. It was removed because:

1. The fallback was never validated for iceberg — no test, no caller, no doc justified its existence.
2. In production it would mask a real config bug (e.g., STS broker failure) behind a silent fallback that then fails opaquely at attach time anyway. Better to fail at the validation boundary with a message naming the affected tenant.
3. The whole multitenant architecture is \"control plane mints credentials, worker has no AWS identity.\" Falling back to \"let DuckDB walk its chain on the worker\" contradicts that architecture by design.

\`buildCredentialChainSecret\` (for **DuckLake**, in \`server.go\`) is a separate code path used by the Ansible single-tenant EC2 deploy (\`posthog-cloud-infra/ansible/roles/duckgres/templates/duckgres.yaml.j2:36\`) and is **not affected** by this PR. Iceberg never had a live deployment using credential_chain.

## Known follow-up (not in this PR)

\`RefreshS3Secret\` ([server.go:1906](https://github.com/PostHog/duckgres/blob/main/server/server.go#L1906)) rotates the DuckLake secret when STS credentials expire (~1h), but no equivalent yet rotates the iceberg secret. After this PR lands, a long-lived hot-idle worker will start 403'ing iceberg queries after the first STS rotation. Fix is a sibling \`RefreshIcebergSecret\` invoked from \`duckdbservice/activation.go\`'s refresh path. Scoped out here for an immediate follow-up PR.

Other follow-ups identified during this review:
- **No E2E coverage exists for iceberg.** Five PRs shipped without any test that exercises session-activation-to-S3-Tables-query. Worth adding an \`iceberg-test\` skill (analog of \`ducklake-test\`) and an opt-in \`TestIcebergE2E\` integration test gated on \`ICEBERG_E2E_TEST_BUCKET_ARN\`.
- **\`aws_sdk\` S3 provider is dead code** in all deployed configurations (zero refs in \`charts\` or \`posthog-cloud-infra\`). Safe to delete in a cleanup PR.
- Slim \`/warehouse/status\` endpoint doesn't expose iceberg state — orthogonal QoL fix.

## Test plan

- [x] \`go test ./server/iceberg/...\` — 6 string-comparison tests + 2 DuckDB-execution subtests all pass
- [x] \`go test ./server/... ./controlplane/... ./duckdbservice/...\` — full regression sweep, no failures
- [ ] Deploy to dev, reconnect to \`test-org-smoke-1778167994\`, run \`SHOW DATABASES\` and confirm \`iceberg\` appears alongside \`ducklake\`, then \`USE iceberg.main; CREATE TABLE smoke (id INTEGER); INSERT INTO smoke VALUES (1); SELECT * FROM smoke;\`
- [ ] Verify on dev worker logs that the emitted SQL is \`PROVIDER config, KEY_ID 'ASIA...'\`, not anything credential_chain shaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)