### PR TITLE
fix(server): rotate iceberg secret alongside DuckLake on STS expiry

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -170,8 +170,17 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 		return false
 	}
 
+	// needsRefresh is keyed on DuckLake creds because the activator
+	// populates DuckLake.S3* with the STS-minted credentials for the
+	// per-tenant IAM role, and the iceberg_sigv4 secret reuses the same
+	// values. So a single change-detection covers both downstream
+	// consumers. The guard "something is actually using S3" expands here
+	// to include iceberg — there are tenants (e.g. metadata-only DuckLake)
+	// where ObjectStore is empty but Iceberg.Enabled is true, and on
+	// those the iceberg secret still needs to be rotated.
 	needsRefresh := false
-	if p.activation.db != nil && payload.DuckLake.ObjectStore != "" &&
+	if p.activation.db != nil &&
+		(payload.DuckLake.ObjectStore != "" || payload.Iceberg.Enabled) &&
 		!reflect.DeepEqual(current.DuckLake, payload.DuckLake) {
 		needsRefresh = s3CredentialsChanged(current.DuckLake, payload.DuckLake)
 		if !needsRefresh {
@@ -193,6 +202,7 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 		refreshDB = p.activation.db
 	}
 	refreshFn := p.refreshS3Secret
+	refreshIcebergFn := p.refreshIcebergSecret
 	sem := p.duckLakeSem
 	p.mu.Unlock()
 
@@ -206,9 +216,24 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 		if refreshFn == nil {
 			refreshFn = server.RefreshS3Secret
 		}
-		if err := refreshFn(refreshDB, payload.DuckLake, sem); err != nil {
-			slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
-			return false
+		if refreshIcebergFn == nil {
+			refreshIcebergFn = server.RefreshIcebergSecret
+		}
+		if payload.DuckLake.ObjectStore != "" {
+			if err := refreshFn(refreshDB, payload.DuckLake, sem); err != nil {
+				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
+				return false
+			}
+		}
+		if payload.Iceberg.Enabled {
+			if err := refreshIcebergFn(refreshDB, payload.Iceberg, sem,
+				payload.DuckLake.S3AccessKey,
+				payload.DuckLake.S3SecretKey,
+				payload.DuckLake.S3SessionToken,
+			); err != nil {
+				slog.Warn("Failed to refresh Iceberg credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
+				return false
+			}
 		}
 	}
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -77,6 +77,13 @@ type SessionPool struct {
 	// inject a stub to verify the credential-refresh path is non-blocking
 	// (see TestReuseExistingActivationDoesNotBlockHealthChecks).
 	refreshS3Secret func(*sql.DB, server.DuckLakeConfig, chan struct{}) error
+	// refreshIcebergSecret is the sibling indirection for rotating the
+	// iceberg_sigv4 secret. Runs alongside refreshS3Secret on hot-idle
+	// reuse whenever the tenant has iceberg enabled — without it, iceberg
+	// queries on a long-lived worker would 403 after STS rotation while
+	// DuckLake stays fresh. Defaults to server.RefreshIcebergSecret;
+	// stubbed by tests the same way refreshS3Secret is.
+	refreshIcebergSecret func(*sql.DB, server.IcebergConfig, chan struct{}, string, string, string) error
 }
 
 type trackedTx struct {
@@ -134,6 +141,7 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		createDBPair:         CreateWorkerDBPair,
 		activateDBConnection: server.ActivateDBConnection,
 		refreshS3Secret:      server.RefreshS3Secret,
+		refreshIcebergSecret: server.RefreshIcebergSecret,
 	}
 	pool.activateTenantFunc = pool.activateTenant
 	go pool.reapLoop()

--- a/server/iceberg_refresh_test.go
+++ b/server/iceberg_refresh_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// TestRefreshIcebergSecretRotatesCredentials exercises the full refresh
+// path against an in-memory DuckDB with the iceberg extension loaded:
+// initial CREATE, then a rotated CREATE OR REPLACE, both must succeed
+// without DuckDB rejecting the SQL form. This is the regression net for
+// "iceberg queries 403 after STS rotation on a long-lived hot-idle
+// worker" — without RefreshIcebergSecret, only DuckLake's secret would
+// be rotated and the iceberg_sigv4 secret would keep its expired creds.
+//
+// Skips when the iceberg extension can't be installed/loaded (air-gapped
+// sandbox); same posture as TestIcebergSecretAcceptedByDuckDB.
+func TestRefreshIcebergSecretRotatesCredentials(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec("INSTALL iceberg"); err != nil {
+		t.Skipf("iceberg extension unavailable (network or sandbox): %v", err)
+	}
+	if _, err := db.Exec("LOAD iceberg"); err != nil {
+		t.Skipf("iceberg extension load failed: %v", err)
+	}
+
+	ic := IcebergConfig{
+		Enabled:     true,
+		TableBucket: "arn:aws:s3tables:us-east-1:000000000000:bucket/refresh-test",
+		Region:      "us-east-1",
+	}
+
+	if err := RefreshIcebergSecret(db, ic, nil, "AKIA_INITIAL", "initial-secret", "initial-token"); err != nil {
+		t.Fatalf("initial refresh rejected by DuckDB: %v", err)
+	}
+	if err := RefreshIcebergSecret(db, ic, nil, "AKIA_ROTATED", "rotated-secret", "rotated-token"); err != nil {
+		t.Fatalf("rotated refresh rejected by DuckDB: %v", err)
+	}
+}
+
+// TestRefreshIcebergSecretNoOpWhenDisabled confirms that the refresh
+// path returns nil without touching DuckDB when iceberg isn't enabled
+// for the tenant — important because the activation layer calls this
+// unconditionally on every credential-change refresh and shouldn't
+// require iceberg to be enabled.
+func TestRefreshIcebergSecretNoOpWhenDisabled(t *testing.T) {
+	if err := RefreshIcebergSecret(nil, IcebergConfig{Enabled: false}, nil, "k", "s", "t"); err != nil {
+		t.Fatalf("expected no-op when iceberg disabled, got: %v", err)
+	}
+}
+
+// TestRefreshIcebergSecretRejectsEmptyCredentials guards the invariant
+// that "credentials are required when iceberg is enabled" applies to
+// refresh too, not just initial attach. A silent fallback here would
+// either re-introduce credential_chain (the bug fixed by PR #562) or
+// emit an empty-cred config secret that fails opaquely at attach time.
+func TestRefreshIcebergSecretRejectsEmptyCredentials(t *testing.T) {
+	err := RefreshIcebergSecret(nil, IcebergConfig{Enabled: true, TableBucket: "arn:..."}, nil, "", "", "")
+	if err == nil {
+		t.Fatal("expected error when iceberg enabled with empty credentials, got nil")
+	}
+	if !strings.Contains(err.Error(), "no AWS credentials") {
+		t.Fatalf("error message should name the missing-credentials cause, got: %v", err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1957,6 +1957,52 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 	return nil
 }
 
+// RefreshIcebergSecret replaces the DuckDB iceberg-extension S3 secret
+// (iceberg_sigv4) with updated credentials. Used when a hot-idle worker
+// is reclaimed and the STS credentials minted by the control plane have
+// rotated. Without this, iceberg queries on a long-lived worker would
+// start 403'ing after the first STS rotation (~1h) while DuckLake stays
+// fresh.
+//
+// Unlike AttachIcebergCatalog this does NOT short-circuit when the
+// iceberg catalog is already attached — the whole point is to overwrite
+// the existing secret in place. ATTACH state on the catalog itself is
+// unaffected; DuckDB resolves the secret at request time, so the new
+// credentials take effect for the next iceberg query without an
+// explicit reattach.
+//
+// Same auth model as AttachIcebergCatalog: explicit credentials are the
+// only supported path. A refresh with missing credentials is a config
+// bug (the activator failed to populate fresh STS credentials in the
+// payload) and surfaces as an explicit error rather than a silent
+// fallback to credential_chain.
+func RefreshIcebergSecret(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID, secretKey, sessionToken string) error {
+	if !ic.Enabled {
+		return nil
+	}
+	if keyID == "" || secretKey == "" {
+		return fmt.Errorf("iceberg refresh: no AWS credentials in activation payload — control plane STS broker did not populate DuckLake S3 credentials")
+	}
+	if sem != nil {
+		sem <- struct{}{}
+		defer func() { <-sem }()
+	}
+
+	secretStmt := iceberg.BuildIcebergSecretStmt(ic, keyID, secretKey, sessionToken)
+	if _, err := db.Exec(secretStmt); err != nil {
+		if isTransactionAborted(err) {
+			_, _ = db.Exec("ROLLBACK")
+			if _, retryErr := db.Exec(secretStmt); retryErr != nil {
+				return fmt.Errorf("refresh iceberg secret after rollback: %w", retryErr)
+			}
+		} else {
+			return fmt.Errorf("refresh iceberg secret: %w", err)
+		}
+	}
+	slog.Debug("Refreshed iceberg secret for hot-idle reuse.", "table_bucket", ic.TableBucket)
+	return nil
+}
+
 // resolveS3SecretTransport picks the URL_STYLE and USE_SSL values to embed in
 // the DuckDB S3 secret. When the cache proxy is in front of the worker
 // (HTTPProxy set), we force url_style=path + use_ssl=false so all S3


### PR DESCRIPTION
## Summary

Follow-up to [#562](https://github.com/PostHog/duckgres/pull/562). That PR fixed the initial-attach path so iceberg works at session activation, but the hot-idle credential-refresh path in [\`duckdbservice/activation.go\`](https://github.com/PostHog/duckgres/blob/main/duckdbservice/activation.go) only rotates the DuckLake S3 secret (\`ducklake_s3\`). The iceberg secret (\`iceberg_sigv4\`) shares the same STS-minted credentials but was never being re-emitted, so iceberg queries on a long-lived worker would 403 ~1h after activation while DuckLake stayed fresh.

This PR adds the missing rotation.

## What changed

### \`server/server.go\` — new \`RefreshIcebergSecret\`

Mirrors \`RefreshS3Secret\`:
- No-op when iceberg is disabled.
- Rejects empty credentials with the same error shape as \`AttachIcebergCatalog\` (no silent fallback to credential_chain — that path was removed in #562).
- Re-emits the \`iceberg_sigv4\` secret via the existing \`BuildIcebergSecretStmt\`.
- Handles DuckDB's \"Current transaction is aborted\" recovery the same way the S3 refresh does.

Importantly, \`RefreshIcebergSecret\` does **not** short-circuit when the iceberg catalog is already attached (unlike \`AttachIcebergCatalog\`). The whole point of refresh is to overwrite the existing secret in place; DuckDB resolves secrets at request time, so the new credentials take effect for the next iceberg query without an explicit reattach.

### \`duckdbservice/service.go\` — \`refreshIcebergSecret\` indirection

New field on \`SessionPool\`, defaulted to \`server.RefreshIcebergSecret\`. Same shape as the existing \`refreshS3Secret\` so tests can inject a stub.

### \`duckdbservice/activation.go\` (\`reuseExistingActivation\`)

Two changes:

1. **\`needsRefresh\` predicate** now triggers when \`Iceberg.Enabled\` **or** \`DuckLake.ObjectStore\` is set. Previously, an iceberg-only tenant (DuckLake metadata-only, S3 bucket empty, iceberg enabled — e.g. \`test-org-smoke-1778167994\` in dev) would skip refresh entirely because \`ObjectStore==\"\"\` gated it out — even though \`Iceberg.Enabled=true\` and the credentials *were* in the payload. The activator populates \`DuckLake.S3*\` from STS regardless of whether DuckLake itself uses S3.

2. **Refresh block** now invokes both refresh functions, each gated on its own enable check. They share the same \`DuckLake.S3*\` triple because the per-tenant IAM role grants both \`s3:*\` and \`s3tables:*\` and STS returns one credential bundle covering both.

### \`server/iceberg_refresh_test.go\` — new tests

Three tests in the server package (so they can exercise the exported \`RefreshIcebergSecret\` while the \`server/iceberg\` subpackage stays free of \`server\`-package imports):

- **\`TestRefreshIcebergSecretRotatesCredentials\`** uses an in-memory DuckDB with the iceberg extension to verify back-to-back \`CREATE OR REPLACE\` with different credentials both succeed — the exact behavior STS rotation depends on. Skips when the extension can't be installed (air-gapped CI), same posture as the existing integration test.
- **\`TestRefreshIcebergSecretNoOpWhenDisabled\`** confirms the activation layer can call this unconditionally without harm when the tenant hasn't opted in to iceberg.
- **\`TestRefreshIcebergSecretRejectsEmptyCredentials\`** locks in the \"fail loud, no silent fallback\" invariant for the refresh path, matching what #562 established for the attach path.

## Test plan

- [x] \`go test ./server/ -run RefreshIceberg -v\` — three new tests run (not skipped) and pass
- [x] \`go test ./server/... ./duckdbservice/...\` — full regression sweep including existing \`TestReuseExistingActivationDoesNotBlockHealthChecks\` (which exercises the refresh path with a stub)
- [ ] On dev, after this lands: let a worker for an iceberg-enabled tenant sit hot-idle past STS expiry (~1h) without a query, then run an iceberg query and verify it doesn't 403. Before this PR: 403 after ~1h. After: should keep working indefinitely (until the worker is naturally retired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)