### PR TITLE
feat(provisioner): Lakekeeper-as-Iceberg-catalog — PR1 (provisioning machinery)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ data-test/
 bench-results/
 /cache-proxy
 /cmd/cache-proxy/cache-proxy
+
+# Local prototype/scratch dirs (e.g. tmp/lakekeeper-proto/)
+tmp/

--- a/controlplane/configstore/iceberg_backend_test.go
+++ b/controlplane/configstore/iceberg_backend_test.go
@@ -1,0 +1,23 @@
+package configstore
+
+import "testing"
+
+func TestManagedWarehouseIceberg_ResolvedBackend(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    ManagedWarehouseIceberg
+		want  string
+	}{
+		{"empty defaults to lakekeeper", ManagedWarehouseIceberg{}, IcebergBackendLakekeeper},
+		{"explicit lakekeeper", ManagedWarehouseIceberg{Backend: IcebergBackendLakekeeper}, IcebergBackendLakekeeper},
+		{"explicit s3_tables", ManagedWarehouseIceberg{Backend: IcebergBackendS3Tables}, IcebergBackendS3Tables},
+		{"unknown passthrough", ManagedWarehouseIceberg{Backend: "future"}, "future"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.in.ResolvedBackend(); got != c.want {
+				t.Errorf("ResolvedBackend() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -150,9 +150,20 @@ type ManagedWarehouseIceberg struct {
 
 	// Lakekeeper fields (Backend == "lakekeeper"). Populated by the
 	// provisioner after the per-org Lakekeeper is ready.
-	LakekeeperEndpoint        string `gorm:"size:512" json:"lakekeeper_endpoint,omitempty"`
+	LakekeeperEndpoint string `gorm:"size:512" json:"lakekeeper_endpoint,omitempty"`
+
+	// LakekeeperWarehouse is the warehouse NAME (e.g. "org-acme"), not the
+	// UUID. Iceberg REST clients pass this as the `warehouse` parameter to
+	// /v1/config and the server returns the UUID as a prefix for subsequent
+	// calls. PR2's worker-side ATTACH SQL uses this value directly.
 	LakekeeperWarehouse       string `gorm:"size:128" json:"lakekeeper_warehouse,omitempty"`
 	LakekeeperClientID        string `gorm:"size:128" json:"lakekeeper_client_id,omitempty"`
+
+	// LakekeeperOAuth2ServerURI is the OAuth2 token endpoint URI for the
+	// duckling-side CREATE SECRET. Empty during PR1 (allowall mode);
+	// populated by PR3 once OIDC SA-token auth is wired. PR2 worker code
+	// must guard against empty and either skip the OAuth2 fields on the
+	// CREATE SECRET statement or emit a different secret shape.
 	LakekeeperOAuth2ServerURI string `gorm:"size:512" json:"lakekeeper_oauth2_server_uri,omitempty"`
 
 	// LakekeeperClientCredentials holds the OAuth2 client_secret used by

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -115,17 +115,66 @@ type ManagedWarehouseWorkerIdentity struct {
 	IAMRoleARN         string `gorm:"size:512" json:"iam_role_arn"`
 }
 
-// ManagedWarehouseIceberg captures per-org opt-in state for the per-tenant
-// Iceberg catalog (AWS S3 Tables). When Enabled is true, the provisioner
-// controller sets spec.iceberg.enabled on the Duckling CR; the composition
-// provisions a fresh table bucket and the controller writes TableBucketArn
-// back here once the bucket is Ready. The worker activator reads these
-// fields and feeds them into server.IcebergConfig at activation time.
+// ManagedWarehouseIceberg captures per-org Iceberg catalog config. Two
+// backends are supported, selected by Backend:
+//
+//   - "lakekeeper" (default): a per-org Lakekeeper instance vends the
+//     Iceberg REST catalog. The provisioner creates the Lakekeeper CR + a
+//     warehouse pointing at the org's existing S3 bucket (path
+//     <s3.path-prefix>/lakekeeper/<orgid>/) and persists the endpoint +
+//     OAuth2 client credentials back here. The worker activator reads
+//     these and emits a (TYPE ICEBERG, CLIENT_ID/CLIENT_SECRET/
+//     OAUTH2_SERVER_URI) DuckDB SECRET + ATTACH at session init.
+//
+//   - "s3_tables" (legacy): provisioner controller sets spec.iceberg.enabled
+//     on the Duckling CR; the composition provisions a fresh S3 Tables
+//     bucket and writes TableBucketArn back here. Kept as a safety net /
+//     escape hatch — new orgs default to Lakekeeper.
 type ManagedWarehouseIceberg struct {
-	Enabled        bool   `json:"enabled"`
-	TableBucketArn string `gorm:"size:512" json:"table_bucket_arn"`
-	Region         string `gorm:"size:64" json:"region"`
-	Namespace      string `gorm:"size:255" json:"namespace"`
+	Enabled bool `json:"enabled"`
+
+	// Backend selects the catalog backend. Empty/unset is treated as
+	// "lakekeeper" by callers.
+	Backend string `gorm:"size:32;default:'lakekeeper'" json:"backend"`
+
+	// Namespace is the default Iceberg namespace inside the catalog. Used
+	// for both backends.
+	Namespace string `gorm:"size:255" json:"namespace"`
+
+	// Region applies to both backends (S3 region for S3 Tables; AWS region
+	// for the Lakekeeper warehouse storage profile).
+	Region string `gorm:"size:64" json:"region"`
+
+	// S3 Tables fields (Backend == "s3_tables"). Empty otherwise.
+	TableBucketArn string `gorm:"size:512" json:"table_bucket_arn,omitempty"`
+
+	// Lakekeeper fields (Backend == "lakekeeper"). Populated by the
+	// provisioner after the per-org Lakekeeper is ready.
+	LakekeeperEndpoint        string `gorm:"size:512" json:"lakekeeper_endpoint,omitempty"`
+	LakekeeperWarehouse       string `gorm:"size:128" json:"lakekeeper_warehouse,omitempty"`
+	LakekeeperClientID        string `gorm:"size:128" json:"lakekeeper_client_id,omitempty"`
+	LakekeeperOAuth2ServerURI string `gorm:"size:512" json:"lakekeeper_oauth2_server_uri,omitempty"`
+
+	// LakekeeperClientCredentials holds the OAuth2 client_secret used by
+	// the duckling to authenticate to Lakekeeper. The control plane
+	// resolves this just before sending the activation payload.
+	LakekeeperClientCredentials SecretRef `gorm:"embedded;embeddedPrefix:lakekeeper_client_credentials_" json:"lakekeeper_client_credentials"`
+}
+
+// IcebergBackend constants — string-typed to keep the GORM tag happy.
+const (
+	IcebergBackendLakekeeper = "lakekeeper"
+	IcebergBackendS3Tables   = "s3_tables"
+)
+
+// ResolvedBackend returns Backend with the empty-string default applied.
+// Callers should prefer this over reading Backend directly so that rows
+// migrated from earlier schemas (no Backend column) behave correctly.
+func (i ManagedWarehouseIceberg) ResolvedBackend() string {
+	if i.Backend == "" {
+		return IcebergBackendLakekeeper
+	}
+	return i.Backend
 }
 
 // ManagedWarehouse is the config-store source of truth for an org's managed warehouse metadata.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -408,6 +408,13 @@ func (cs *ConfigStore) ListWarehousesByStates(states []ManagedWarehouseProvision
 
 // UpdateWarehouseState performs a compare-and-swap update on a warehouse row.
 // Only updates if the current state matches expectedState, preventing races.
+// ErrWarehouseStateMismatch is returned (wrapped) by UpdateWarehouseState
+// when the CAS guard fails — the row is missing or no longer in the
+// expected state. Callers that want to treat that as benign (because
+// another writer has already advanced the state machine) can detect via
+// errors.Is(err, configstore.ErrWarehouseStateMismatch).
+var ErrWarehouseStateMismatch = errors.New("warehouse not in expected state")
+
 func (cs *ConfigStore) UpdateWarehouseState(orgID string, expectedState ManagedWarehouseProvisioningState, updates map[string]interface{}) error {
 	result := cs.db.Model(&ManagedWarehouse{}).
 		Where("org_id = ? AND state = ?", orgID, expectedState).
@@ -416,7 +423,7 @@ func (cs *ConfigStore) UpdateWarehouseState(orgID string, expectedState ManagedW
 		return fmt.Errorf("update warehouse state: %w", result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("warehouse %q not in expected state %q", orgID, expectedState)
+		return fmt.Errorf("warehouse %q expected state %q: %w", orgID, expectedState, ErrWarehouseStateMismatch)
 	}
 	return nil
 }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -88,6 +88,9 @@ func NewConfigStore(connStr string, pollInterval time.Duration) (*ConfigStore, e
 	if err := migrateDeltaCatalogDefaultEnabled(db); err != nil {
 		return nil, fmt.Errorf("migrate delta catalog default: %w", err)
 	}
+	if err := migrateIcebergBackendBackfill(db); err != nil {
+		return nil, fmt.Errorf("migrate iceberg backend backfill: %w", err)
+	}
 
 	runtimeSchema, err := resolveRuntimeSchema(db)
 	if err != nil {
@@ -490,6 +493,53 @@ func migrateDeltaCatalogDefaultEnabled(db *gorm.DB) error {
 			return fmt.Errorf("record schema migration: %w", err)
 		}
 		slog.Info("Backfilled delta_catalog_enabled=true on existing config rows.")
+		return nil
+	})
+}
+
+// migrateIcebergBackendBackfill stamps iceberg_backend = 's3_tables' on any
+// existing row whose iceberg_table_bucket_arn is populated but whose
+// iceberg_backend is empty. Without this, ResolvedBackend() on those rows
+// would return "lakekeeper" (the empty-default semantics) and the worker
+// activator + controller reconcile loop would treat them as Lakekeeper
+// orgs — silently breaking S3 Tables ATTACH AND firing redundant
+// Lakekeeper provisioning attempts.
+//
+// New rows inserted after the GORM `default:'lakekeeper'` migration get
+// the default at insert time, so this migration only matters for rows
+// that predate the column. One-shot, tracked in duckgres_schema_migrations.
+const icebergBackendBackfillMigrationName = "2026_05_iceberg_backend_backfill"
+
+func migrateIcebergBackendBackfill(db *gorm.DB) error {
+	var existing SchemaMigration
+	err := db.Where("name = ?", icebergBackendBackfillMigrationName).First(&existing).Error
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("check schema migration: %w", err)
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		// Backfill rows that have a populated S3 Tables ARN but no
+		// explicit backend — these are pre-feature rows whose semantics
+		// would change without this stamp.
+		res := tx.Exec(
+			`UPDATE duckgres_managed_warehouses
+			   SET iceberg_backend = 's3_tables'
+			 WHERE COALESCE(iceberg_table_bucket_arn, '') <> ''
+			   AND COALESCE(iceberg_backend, '') = ''`,
+		)
+		if res.Error != nil {
+			return fmt.Errorf("backfill iceberg_backend: %w", res.Error)
+		}
+		if err := tx.Create(&SchemaMigration{
+			Name:      icebergBackendBackfillMigrationName,
+			AppliedAt: time.Now().UTC(),
+		}).Error; err != nil {
+			return fmt.Errorf("record schema migration: %w", err)
+		}
+		slog.Info("Backfilled iceberg_backend=s3_tables on pre-Lakekeeper rows.",
+			"rows", res.RowsAffected)
 		return nil
 	})
 }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -415,6 +415,32 @@ func (cs *ConfigStore) ListWarehousesByStates(states []ManagedWarehouseProvision
 // errors.Is(err, configstore.ErrWarehouseStateMismatch).
 var ErrWarehouseStateMismatch = errors.New("warehouse not in expected state")
 
+// ErrWarehouseNotFound is returned by row-targeted updates when the orgID
+// has no row in duckgres_managed_warehouses.
+var ErrWarehouseNotFound = errors.New("warehouse not found")
+
+// UpdateIcebergConfig writes the supplied column updates to the org's
+// warehouse row without CAS'ing on the top-level state. Used by the
+// Lakekeeper provisioner — Iceberg sub-state runs in parallel with the
+// main warehouse state machine, so persisting the Lakekeeper endpoint
+// after a top-level state transition shouldn't silently no-op.
+//
+// Caller-side discipline: the updates map should only contain
+// iceberg_* columns. Untyped to keep the controller's WarehouseStore
+// interface independent of the column list.
+func (cs *ConfigStore) UpdateIcebergConfig(orgID string, updates map[string]interface{}) error {
+	result := cs.db.Model(&ManagedWarehouse{}).
+		Where("org_id = ?", orgID).
+		Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update iceberg config: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("warehouse %q: %w", orgID, ErrWarehouseNotFound)
+	}
+	return nil
+}
+
 func (cs *ConfigStore) UpdateWarehouseState(orgID string, expectedState ManagedWarehouseProvisioningState, updates map[string]interface{}) error {
 	result := cs.db.Model(&ManagedWarehouse{}).
 		Where("org_id = ? AND state = ?", orgID, expectedState).

--- a/controlplane/provisioner/cleanup_helpers_test.go
+++ b/controlplane/provisioner/cleanup_helpers_test.go
@@ -1,0 +1,25 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// cleanupDB attempts to drop a database. Best-effort: logs but does not fail.
+func cleanupDB(t *testing.T, dsn, name string) {
+	t.Helper()
+	if dsn == "" {
+		return
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Logf("cleanup open %s: %v", name, err)
+		return
+	}
+	defer db.Close()
+	if _, err := db.Exec("DROP DATABASE IF EXISTS " + quoteIdent(name)); err != nil {
+		t.Logf("cleanup drop %s: %v", name, err)
+	}
+}

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -16,6 +16,13 @@ import (
 type WarehouseStore interface {
 	ListWarehousesByStates(states []configstore.ManagedWarehouseProvisioningState) ([]configstore.ManagedWarehouse, error)
 	UpdateWarehouseState(orgID string, expectedState configstore.ManagedWarehouseProvisioningState, updates map[string]interface{}) error
+	// UpdateIcebergConfig writes per-org Iceberg/Lakekeeper config without
+	// CAS'ing on the top-level warehouse state. The Lakekeeper provisioner
+	// uses this because Iceberg provisioning runs in parallel with the
+	// top-level Duckling state machine — by the time we're ready to persist
+	// the Lakekeeper endpoint, the warehouse may already have transitioned
+	// to Ready, and a state-CAS update would silently no-op.
+	UpdateIcebergConfig(orgID string, updates map[string]interface{}) error
 }
 
 // Controller polls the config store for actionable warehouses and reconciles

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -97,6 +97,24 @@ func (s *fakeStore) UpdateWarehouseState(orgID string, expectedState configstore
 			w.Iceberg.Namespace = v.(string)
 		case "iceberg_state":
 			w.IcebergState = v.(configstore.ManagedWarehouseProvisioningState)
+		case "iceberg_enabled":
+			w.Iceberg.Enabled = v.(bool)
+		case "iceberg_backend":
+			w.Iceberg.Backend = v.(string)
+		case "iceberg_lakekeeper_endpoint":
+			w.Iceberg.LakekeeperEndpoint = v.(string)
+		case "iceberg_lakekeeper_warehouse":
+			w.Iceberg.LakekeeperWarehouse = v.(string)
+		case "iceberg_lakekeeper_client_id":
+			w.Iceberg.LakekeeperClientID = v.(string)
+		case "iceberg_lakekeeper_oauth2_server_uri":
+			w.Iceberg.LakekeeperOAuth2ServerURI = v.(string)
+		case "iceberg_lakekeeper_client_credentials_namespace":
+			w.Iceberg.LakekeeperClientCredentials.Namespace = v.(string)
+		case "iceberg_lakekeeper_client_credentials_name":
+			w.Iceberg.LakekeeperClientCredentials.Name = v.(string)
+		case "iceberg_lakekeeper_client_credentials_key":
+			w.Iceberg.LakekeeperClientCredentials.Key = v.(string)
 		}
 	}
 	return nil

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -4,6 +4,8 @@ package provisioner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -41,10 +43,10 @@ func (s *fakeStore) ListWarehousesByStates(states []configstore.ManagedWarehouse
 func (s *fakeStore) UpdateWarehouseState(orgID string, expectedState configstore.ManagedWarehouseProvisioningState, updates map[string]interface{}) error {
 	w, ok := s.warehouses[orgID]
 	if !ok {
-		return nil
+		return fmt.Errorf("warehouse %q: %w", orgID, configstore.ErrWarehouseStateMismatch)
 	}
 	if w.State != expectedState {
-		return nil
+		return fmt.Errorf("warehouse %q expected %q got %q: %w", orgID, expectedState, w.State, configstore.ErrWarehouseStateMismatch)
 	}
 	for k, v := range updates {
 		switch k {
@@ -751,12 +753,13 @@ func TestFakeStoreUpdateWarehouseState(t *testing.T) {
 		t.Fatalf("expected provisioning state, got %q", fs.warehouses["org-x"].State)
 	}
 
-	// CAS update with wrong expected state should be no-op
+	// CAS update with wrong expected state should return ErrWarehouseStateMismatch
+	// and leave the row unchanged.
 	err = fs.UpdateWarehouseState("org-x", configstore.ManagedWarehouseStatePending, map[string]interface{}{
 		"state": configstore.ManagedWarehouseStateFailed,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, configstore.ErrWarehouseStateMismatch) {
+		t.Fatalf("expected ErrWarehouseStateMismatch, got: %v", err)
 	}
 	if fs.warehouses["org-x"].State != configstore.ManagedWarehouseStateProvisioning {
 		t.Fatalf("expected state to remain provisioning, got %q", fs.warehouses["org-x"].State)

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -122,6 +122,46 @@ func (s *fakeStore) UpdateWarehouseState(orgID string, expectedState configstore
 	return nil
 }
 
+// UpdateIcebergConfig writes per-org Iceberg/Lakekeeper fields without a
+// top-level state CAS. Mirrors the real configstore method's contract.
+func (s *fakeStore) UpdateIcebergConfig(orgID string, updates map[string]interface{}) error {
+	w, ok := s.warehouses[orgID]
+	if !ok {
+		return fmt.Errorf("warehouse %q: %w", orgID, configstore.ErrWarehouseNotFound)
+	}
+	for k, v := range updates {
+		switch k {
+		case "iceberg_enabled":
+			w.Iceberg.Enabled = v.(bool)
+		case "iceberg_backend":
+			w.Iceberg.Backend = v.(string)
+		case "iceberg_namespace":
+			w.Iceberg.Namespace = v.(string)
+		case "iceberg_region":
+			w.Iceberg.Region = v.(string)
+		case "iceberg_table_bucket_arn":
+			w.Iceberg.TableBucketArn = v.(string)
+		case "iceberg_state":
+			w.IcebergState = v.(configstore.ManagedWarehouseProvisioningState)
+		case "iceberg_lakekeeper_endpoint":
+			w.Iceberg.LakekeeperEndpoint = v.(string)
+		case "iceberg_lakekeeper_warehouse":
+			w.Iceberg.LakekeeperWarehouse = v.(string)
+		case "iceberg_lakekeeper_client_id":
+			w.Iceberg.LakekeeperClientID = v.(string)
+		case "iceberg_lakekeeper_oauth2_server_uri":
+			w.Iceberg.LakekeeperOAuth2ServerURI = v.(string)
+		case "iceberg_lakekeeper_client_credentials_namespace":
+			w.Iceberg.LakekeeperClientCredentials.Namespace = v.(string)
+		case "iceberg_lakekeeper_client_credentials_name":
+			w.Iceberg.LakekeeperClientCredentials.Name = v.(string)
+		case "iceberg_lakekeeper_client_credentials_key":
+			w.Iceberg.LakekeeperClientCredentials.Key = v.(string)
+		}
+	}
+	return nil
+}
+
 // Compile-time check that fakeStore satisfies WarehouseStore.
 var _ WarehouseStore = (*fakeStore)(nil)
 

--- a/controlplane/provisioner/lakekeeper_client.go
+++ b/controlplane/provisioner/lakekeeper_client.go
@@ -35,6 +35,13 @@ func NewLakekeeperClient(baseURL string) *LakekeeperClient {
 	}
 }
 
+// WithBearer sets the bearer token used on subsequent requests. The token
+// must be a single-line string (no CR/LF) — Go's http.Header.Set won't error
+// on construction but http.Client.Do will reject malformed headers at send.
+//
+// NOT safe to call concurrently with in-flight requests. Build the client
+// once, configure it, then share read-only across goroutines. PR3 will add
+// proper rotation primitives when OIDC refresh lands.
 func (c *LakekeeperClient) WithBearer(token string) *LakekeeperClient {
 	c.bearer = token
 	return c
@@ -134,21 +141,42 @@ type listWarehousesResponse struct {
 
 // EnsureWarehouse creates the warehouse if it doesn't exist, otherwise returns
 // the existing one. Match is by warehouse-name within the default project.
+//
+// Idempotent under concurrent callers: if two callers both observe an empty
+// list and both POST, the second POST will 409 and we re-list to return the
+// winner. Callers that need stronger ordering should hold a per-org lock
+// outside this method.
 func (c *LakekeeperClient) EnsureWarehouse(ctx context.Context, req CreateWarehouseRequest) (*Warehouse, error) {
-	existing, err := c.findWarehouseByName(ctx, req.WarehouseName)
-	if err != nil {
+	if existing, err := c.findWarehouseByName(ctx, req.WarehouseName); err != nil {
 		return nil, err
-	}
-	if existing != nil {
+	} else if existing != nil {
 		return existing, nil
 	}
 	var out Warehouse
-	if err := c.do(ctx, http.MethodPost, "/management/v1/warehouse", req, &out); err != nil {
-		return nil, fmt.Errorf("create warehouse %q: %w", req.WarehouseName, err)
+	err := c.do(ctx, http.MethodPost, "/management/v1/warehouse", req, &out)
+	if err == nil {
+		return &out, nil
 	}
-	return &out, nil
+	// 409 → another caller (or a previous attempt) won the race. Re-list and
+	// return the existing warehouse rather than surface the conflict.
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Status == http.StatusConflict {
+		existing, lookupErr := c.findWarehouseByName(ctx, req.WarehouseName)
+		if lookupErr != nil {
+			return nil, fmt.Errorf("create warehouse %q hit 409, lookup failed: %w", req.WarehouseName, lookupErr)
+		}
+		if existing != nil {
+			return existing, nil
+		}
+		// 409 but nothing matches by name — pass the original error through.
+	}
+	return nil, fmt.Errorf("create warehouse %q: %w", req.WarehouseName, err)
 }
 
+// findWarehouseByName scans the first page of the warehouse list for a name
+// match. Lakekeeper paginates the list endpoint; we assume one warehouse per
+// per-org Lakekeeper instance, so a single page is enough today. If we ever
+// host multiple warehouses per instance, revisit to honor `next-page-token`.
 func (c *LakekeeperClient) findWarehouseByName(ctx context.Context, name string) (*Warehouse, error) {
 	var resp listWarehousesResponse
 	if err := c.do(ctx, http.MethodGet, "/management/v1/warehouse", nil, &resp); err != nil {

--- a/controlplane/provisioner/lakekeeper_client.go
+++ b/controlplane/provisioner/lakekeeper_client.go
@@ -1,0 +1,214 @@
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// LakekeeperClient is a thin HTTP client for the Lakekeeper management +
+// catalog REST surface that the provisioner needs to drive: bootstrap the
+// server, create the per-org warehouse, and check ready/bootstrapped state.
+//
+// One client instance addresses one Lakekeeper deployment. Per-org Lakekeeper
+// deployments get their own client instances built ad-hoc by the provisioner.
+//
+// Authentication: a static bearer token can be set via WithBearer. In the
+// current allowall + NetworkPolicy deployment model the token is unused; the
+// field is kept so the OIDC follow-up (PR3) can plug in without changing
+// callers.
+type LakekeeperClient struct {
+	baseURL string
+	hc      *http.Client
+	bearer  string
+}
+
+func NewLakekeeperClient(baseURL string) *LakekeeperClient {
+	return &LakekeeperClient{
+		baseURL: baseURL,
+		hc:      &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *LakekeeperClient) WithBearer(token string) *LakekeeperClient {
+	c.bearer = token
+	return c
+}
+
+func (c *LakekeeperClient) WithHTTPClient(hc *http.Client) *LakekeeperClient {
+	c.hc = hc
+	return c
+}
+
+// ServerInfo is the subset of GET /management/v1/info the provisioner cares
+// about. Bootstrapped flips to true after the first POST /management/v1/bootstrap.
+type ServerInfo struct {
+	Version          string `json:"version"`
+	Bootstrapped     bool   `json:"bootstrapped"`
+	ServerID         string `json:"server-id"`
+	AuthzBackend     string `json:"authz-backend"`
+	DefaultProjectID string `json:"default-project-id"`
+}
+
+// Info fetches the server info. Returns ErrServerNotReady if the endpoint is
+// reachable but the server reports itself as not yet ready (rare; treated as
+// transient by the caller).
+func (c *LakekeeperClient) Info(ctx context.Context) (*ServerInfo, error) {
+	var out ServerInfo
+	if err := c.do(ctx, http.MethodGet, "/management/v1/info", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Bootstrap is the one-shot init of a fresh Lakekeeper server. Returns nil if
+// the server was already bootstrapped (Lakekeeper responds 409 in that case;
+// we treat it as success).
+func (c *LakekeeperClient) Bootstrap(ctx context.Context) error {
+	body := map[string]any{
+		"accept-terms-of-use": true,
+		"is-operator":         true,
+	}
+	err := c.do(ctx, http.MethodPost, "/management/v1/bootstrap", body, nil)
+	if err == nil {
+		return nil
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Status == http.StatusConflict {
+		// Already bootstrapped — idempotent success.
+		return nil
+	}
+	return err
+}
+
+// WarehouseStorageProfile is the subset of fields we send for an S3 / S3-compat
+// warehouse. The Lakekeeper API accepts more; we only set what we need.
+type WarehouseStorageProfile struct {
+	Type                 string `json:"type"`                   // "s3"
+	Bucket               string `json:"bucket"`
+	KeyPrefix            string `json:"key-prefix"`
+	Endpoint             string `json:"endpoint,omitempty"`     // e.g. http://minio:9000; omit for real AWS
+	STSEndpoint          string `json:"sts-endpoint,omitempty"` // optional
+	Region               string `json:"region"`
+	PathStyleAccess      bool   `json:"path-style-access"`
+	Flavor               string `json:"flavor"`                  // "s3-compat" for MinIO, "aws" for AWS
+	STSEnabled           bool   `json:"sts-enabled"`
+	RemoteSigningEnabled bool   `json:"remote-signing-enabled"`
+}
+
+// WarehouseStorageCredential supports access-key creds (dev/MinIO) and
+// instance-profile / IRSA-style creds (prod AWS, no static key).
+type WarehouseStorageCredential struct {
+	Type              string `json:"type"`            // "s3"
+	CredentialType    string `json:"credential-type"` // "access-key" or "aws-system-identity"
+	AWSAccessKeyID    string `json:"aws-access-key-id,omitempty"`
+	AWSSecretAccessKey string `json:"aws-secret-access-key,omitempty"`
+}
+
+// CreateWarehouseRequest is the body of POST /management/v1/warehouse.
+type CreateWarehouseRequest struct {
+	WarehouseName     string                     `json:"warehouse-name"`
+	ProjectID         string                     `json:"project-id,omitempty"`
+	StorageProfile    WarehouseStorageProfile    `json:"storage-profile"`
+	StorageCredential WarehouseStorageCredential `json:"storage-credential"`
+}
+
+// Warehouse is the subset of the create/list response we use.
+type Warehouse struct {
+	ID            string `json:"id"`
+	WarehouseID   string `json:"warehouse-id"`
+	Name          string `json:"name"`
+	ProjectID     string `json:"project-id"`
+	Status        string `json:"status"`
+}
+
+// listWarehousesResponse wraps the list endpoint response.
+type listWarehousesResponse struct {
+	Warehouses []Warehouse `json:"warehouses"`
+}
+
+// EnsureWarehouse creates the warehouse if it doesn't exist, otherwise returns
+// the existing one. Match is by warehouse-name within the default project.
+func (c *LakekeeperClient) EnsureWarehouse(ctx context.Context, req CreateWarehouseRequest) (*Warehouse, error) {
+	existing, err := c.findWarehouseByName(ctx, req.WarehouseName)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+	var out Warehouse
+	if err := c.do(ctx, http.MethodPost, "/management/v1/warehouse", req, &out); err != nil {
+		return nil, fmt.Errorf("create warehouse %q: %w", req.WarehouseName, err)
+	}
+	return &out, nil
+}
+
+func (c *LakekeeperClient) findWarehouseByName(ctx context.Context, name string) (*Warehouse, error) {
+	var resp listWarehousesResponse
+	if err := c.do(ctx, http.MethodGet, "/management/v1/warehouse", nil, &resp); err != nil {
+		return nil, fmt.Errorf("list warehouses: %w", err)
+	}
+	for i := range resp.Warehouses {
+		if resp.Warehouses[i].Name == name {
+			return &resp.Warehouses[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// APIError is returned for non-2xx responses. Status holds the HTTP code;
+// Body holds the raw response body (often a JSON error envelope from
+// Lakekeeper that we don't bother unmarshalling).
+type APIError struct {
+	Status int
+	Method string
+	Path   string
+	Body   string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("lakekeeper %s %s: HTTP %d: %s", e.Method, e.Path, e.Status, e.Body)
+}
+
+func (c *LakekeeperClient) do(ctx context.Context, method, path string, body, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal %s %s body: %w", method, path, err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{Status: resp.StatusCode, Method: method, Path: path, Body: string(respBody)}
+	}
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode %s %s response: %w", method, path, err)
+	}
+	return nil
+}

--- a/controlplane/provisioner/lakekeeper_client.go
+++ b/controlplane/provisioner/lakekeeper_client.go
@@ -227,7 +227,7 @@ func (c *LakekeeperClient) do(ctx context.Context, method, path string, body, ou
 	if err != nil {
 		return fmt.Errorf("%s %s: %w", method, path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &APIError{Status: resp.StatusCode, Method: method, Path: path, Body: string(respBody)}

--- a/controlplane/provisioner/lakekeeper_client_smoke_test.go
+++ b/controlplane/provisioner/lakekeeper_client_smoke_test.go
@@ -1,0 +1,58 @@
+package provisioner
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Smoke-test against a real running Lakekeeper. Skipped unless
+// LAKEKEEPER_SMOKE_URL is set (e.g. http://localhost:8181). Pair with
+// LAKEKEEPER_SMOKE_BEARER if the server has OIDC enabled.
+//
+// To run against the tmp/lakekeeper-proto stack:
+//
+//	export LAKEKEEPER_SMOKE_URL=http://localhost:8181
+//	export LAKEKEEPER_SMOKE_BEARER="$(docker exec lkproto-oidc python /srv/mkjwt.py 300)"
+//	go test ./controlplane/provisioner/ -run TestSmoke -v
+func TestSmoke_InfoAgainstLiveLakekeeper(t *testing.T) {
+	base := os.Getenv("LAKEKEEPER_SMOKE_URL")
+	if base == "" {
+		t.Skip("LAKEKEEPER_SMOKE_URL not set; skipping live smoke test")
+	}
+	if _, err := url.Parse(base); err != nil {
+		t.Fatalf("LAKEKEEPER_SMOKE_URL invalid: %v", err)
+	}
+	c := NewLakekeeperClient(strings.TrimRight(base, "/"))
+	if tok := os.Getenv("LAKEKEEPER_SMOKE_BEARER"); tok != "" {
+		c.WithBearer(tok)
+	}
+	info, err := c.Info(context.Background())
+	if err != nil {
+		// Distinguish auth from connectivity.
+		var apiErr *APIError
+		if asAPIErr(err, &apiErr) && apiErr.Status == http.StatusUnauthorized {
+			t.Fatalf("Lakekeeper requires bearer (set LAKEKEEPER_SMOKE_BEARER): %v", err)
+		}
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Version == "" {
+		t.Fatalf("expected non-empty version, got %+v", info)
+	}
+	t.Logf("live lakekeeper info: version=%s authz=%s bootstrapped=%v", info.Version, info.AuthzBackend, info.Bootstrapped)
+}
+
+// helper so this file doesn't need errors.As import duplication
+func asAPIErr(err error, target **APIError) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(*APIError); ok {
+		*target = e
+		return true
+	}
+	return false
+}

--- a/controlplane/provisioner/lakekeeper_client_smoke_test.go
+++ b/controlplane/provisioner/lakekeeper_client_smoke_test.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,7 +35,7 @@ func TestSmoke_InfoAgainstLiveLakekeeper(t *testing.T) {
 	if err != nil {
 		// Distinguish auth from connectivity.
 		var apiErr *APIError
-		if asAPIErr(err, &apiErr) && apiErr.Status == http.StatusUnauthorized {
+		if errors.As(err, &apiErr) && apiErr.Status == http.StatusUnauthorized {
 			t.Fatalf("Lakekeeper requires bearer (set LAKEKEEPER_SMOKE_BEARER): %v", err)
 		}
 		t.Fatalf("Info: %v", err)
@@ -43,16 +44,4 @@ func TestSmoke_InfoAgainstLiveLakekeeper(t *testing.T) {
 		t.Fatalf("expected non-empty version, got %+v", info)
 	}
 	t.Logf("live lakekeeper info: version=%s authz=%s bootstrapped=%v", info.Version, info.AuthzBackend, info.Bootstrapped)
-}
-
-// helper so this file doesn't need errors.As import duplication
-func asAPIErr(err error, target **APIError) bool {
-	if err == nil {
-		return false
-	}
-	if e, ok := err.(*APIError); ok {
-		*target = e
-		return true
-	}
-	return false
 }

--- a/controlplane/provisioner/lakekeeper_client_test.go
+++ b/controlplane/provisioner/lakekeeper_client_test.go
@@ -116,6 +116,36 @@ func TestEnsureWarehouse_CreatesWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestEnsureWarehouse_ResolvesRaceOn409(t *testing.T) {
+	// Simulate concurrent reconcilers: first GET sees empty list, POST loses
+	// the race (409), follow-up GET returns the winner's warehouse.
+	step := 0
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && step == 0:
+			step = 1
+			_, _ = io.WriteString(w, `{"warehouses":[]}`)
+		case r.Method == http.MethodPost && step == 1:
+			step = 2
+			w.WriteHeader(http.StatusConflict)
+			_, _ = io.WriteString(w, `{"error":{"message":"warehouse exists"}}`)
+		case r.Method == http.MethodGet && step == 2:
+			_, _ = io.WriteString(w, `{"warehouses":[{"warehouse-id":"winner","name":"org-acme","status":"active"}]}`)
+		default:
+			t.Fatalf("unexpected request at step %d: %s %s", step, r.Method, r.URL.Path)
+		}
+	}))
+	defer stop()
+
+	wh, err := c.EnsureWarehouse(context.Background(), CreateWarehouseRequest{WarehouseName: "org-acme"})
+	if err != nil {
+		t.Fatalf("EnsureWarehouse should resolve 409 via re-list: %v", err)
+	}
+	if wh.WarehouseID != "winner" {
+		t.Fatalf("expected winner warehouse, got %+v", wh)
+	}
+}
+
 func TestEnsureWarehouse_NoOpWhenPresent(t *testing.T) {
 	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {

--- a/controlplane/provisioner/lakekeeper_client_test.go
+++ b/controlplane/provisioner/lakekeeper_client_test.go
@@ -1,0 +1,152 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(handler http.Handler) (*LakekeeperClient, func()) {
+	srv := httptest.NewServer(handler)
+	return NewLakekeeperClient(srv.URL), srv.Close
+}
+
+func TestInfo_OK(t *testing.T) {
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/management/v1/info" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"version":"0.11.6","bootstrapped":true,"server-id":"sid","authz-backend":"allow-all"}`)
+	}))
+	defer stop()
+
+	info, err := c.Info(context.Background())
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if !info.Bootstrapped || info.Version != "0.11.6" || info.AuthzBackend != "allow-all" {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+}
+
+func TestBootstrap_AlreadyBootstrappedIsIdempotent(t *testing.T) {
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"error":{"message":"already bootstrapped"}}`)
+	}))
+	defer stop()
+
+	if err := c.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("expected idempotent success on 409, got: %v", err)
+	}
+}
+
+func TestBootstrap_ServerErrorPropagates(t *testing.T) {
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer stop()
+
+	err := c.Bootstrap(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got: %v", err)
+	}
+	if apiErr.Status != http.StatusInternalServerError || apiErr.Path != "/management/v1/bootstrap" {
+		t.Fatalf("unexpected APIError: %+v", apiErr)
+	}
+}
+
+func TestEnsureWarehouse_CreatesWhenAbsent(t *testing.T) {
+	var sawCreate bool
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/management/v1/warehouse":
+			_, _ = io.WriteString(w, `{"warehouses":[]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/management/v1/warehouse":
+			sawCreate = true
+			var req CreateWarehouseRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if req.WarehouseName != "org-acme" {
+				t.Fatalf("warehouse name = %q, want org-acme", req.WarehouseName)
+			}
+			if !req.StorageProfile.STSEnabled || req.StorageProfile.Flavor != "s3-compat" {
+				t.Fatalf("storage profile must enable STS + s3-compat flavor, got %+v", req.StorageProfile)
+			}
+			if req.StorageProfile.RemoteSigningEnabled {
+				t.Fatalf("remote-signing-enabled must be false for DuckDB-compatible vending")
+			}
+			_, _ = io.WriteString(w, `{"warehouse-id":"wh-uuid","name":"org-acme","status":"active"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer stop()
+
+	req := CreateWarehouseRequest{
+		WarehouseName: "org-acme",
+		StorageProfile: WarehouseStorageProfile{
+			Type: "s3", Bucket: "warehouse", KeyPrefix: "org-acme",
+			Endpoint: "http://minio:9000", Region: "us-east-1",
+			PathStyleAccess: true, Flavor: "s3-compat",
+			STSEnabled: true, RemoteSigningEnabled: false,
+		},
+		StorageCredential: WarehouseStorageCredential{
+			Type: "s3", CredentialType: "access-key",
+			AWSAccessKeyID: "minioadmin", AWSSecretAccessKey: "minioadmin",
+		},
+	}
+	wh, err := c.EnsureWarehouse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("EnsureWarehouse: %v", err)
+	}
+	if !sawCreate {
+		t.Fatalf("create POST was not sent")
+	}
+	if wh.Name != "org-acme" || wh.WarehouseID != "wh-uuid" {
+		t.Fatalf("unexpected warehouse: %+v", wh)
+	}
+}
+
+func TestEnsureWarehouse_NoOpWhenPresent(t *testing.T) {
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatalf("create should not be called when warehouse already exists")
+		}
+		_, _ = io.WriteString(w, `{"warehouses":[{"warehouse-id":"existing","name":"org-acme","status":"active"}]}`)
+	}))
+	defer stop()
+
+	wh, err := c.EnsureWarehouse(context.Background(), CreateWarehouseRequest{WarehouseName: "org-acme"})
+	if err != nil {
+		t.Fatalf("EnsureWarehouse: %v", err)
+	}
+	if wh.WarehouseID != "existing" {
+		t.Fatalf("expected existing warehouse, got %+v", wh)
+	}
+}
+
+func TestBearerHeaderIsSetWhenConfigured(t *testing.T) {
+	var sawAuth string
+	c, stop := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"version":"x","bootstrapped":true}`)
+	}))
+	defer stop()
+	c.WithBearer("abc.def.ghi")
+
+	if _, err := c.Info(context.Background()); err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if !strings.HasPrefix(sawAuth, "Bearer abc") {
+		t.Fatalf("Authorization header = %q, want Bearer abc...", sawAuth)
+	}
+}

--- a/controlplane/provisioner/lakekeeper_e2e_helpers_test.go
+++ b/controlplane/provisioner/lakekeeper_e2e_helpers_test.go
@@ -1,0 +1,53 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func ensureNamespace(t *testing.T, kc kubernetes.Interface, name string) error {
+	t.Helper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if _, err := kc.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func metav1DeleteOpts() metav1.DeleteOptions {
+	policy := metav1.DeletePropagationBackground
+	return metav1.DeleteOptions{PropagationPolicy: &policy}
+}
+
+// dropDatabaseAndRole removes both the DB and the role created by EnsureRole.
+// Used by the e2e test's t.Cleanup. Best-effort — logs but doesn't fail.
+func dropDatabaseAndRole(t *testing.T, dsn, dbName string) {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Logf("cleanup open: %v", err)
+		return
+	}
+	defer db.Close()
+	roleName := dbName
+	_, _ = db.Exec("REASSIGN OWNED BY " + quoteIdent(roleName) + " TO CURRENT_USER")
+	_, _ = db.Exec("DROP OWNED BY " + quoteIdent(roleName))
+	if _, err := db.Exec("DROP DATABASE IF EXISTS " + quoteIdent(dbName)); err != nil {
+		t.Logf("cleanup drop database %s: %v", dbName, err)
+	}
+	if _, err := db.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", quoteIdent(roleName))); err != nil {
+		t.Logf("cleanup drop role %s: %v", roleName, err)
+	}
+}

--- a/controlplane/provisioner/lakekeeper_e2e_test.go
+++ b/controlplane/provisioner/lakekeeper_e2e_test.go
@@ -1,0 +1,174 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TestE2E_LakekeeperProvisionerOnOrbstack drives EnsureForOrg against a real
+// Kubernetes cluster (orbstack) with the lakekeeper-operator installed and a
+// Postgres + MinIO running on the host (via tmp/lakekeeper-proto/docker-compose).
+//
+// Skipped unless LAKEKEEPER_E2E_KUBECONFIG is set. To run:
+//
+//	export LAKEKEEPER_E2E_KUBECONFIG=$HOME/.kube/config
+//	export PG_ADMIN_DSN='postgres://lakekeeper:lakekeeper@localhost:5434/lakekeeper?sslmode=disable'
+//	go test -tags kubernetes ./controlplane/provisioner/ -run TestE2E_LakekeeperProvisionerOnOrbstack -v
+//
+// What's exercised:
+//   - Real K8s API server (not the fake dynamic client) so CR field
+//     types are validated against the operator's CRD OpenAPI schema
+//   - Real Postgres so EnsureDatabase + EnsureRole + the GRANT chain run
+//     end-to-end (verifies the previously-missing CREATE ROLE bug stays
+//     fixed)
+//   - Real lakekeeper-operator reconciling the CR — status.bootstrappedAt
+//     flips when the operator actually completes bootstrap
+//   - Real Lakekeeper pod calling /management/v1/warehouse, which exercises
+//     our HTTP client against a real Lakekeeper server (not httptest)
+func TestE2E_LakekeeperProvisionerOnOrbstack(t *testing.T) {
+	kubeconfig := os.Getenv("LAKEKEEPER_E2E_KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("LAKEKEEPER_E2E_KUBECONFIG not set; skipping orbstack e2e test")
+	}
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Fatal("PG_ADMIN_DSN is required for e2e test")
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("load kubeconfig: %v", err)
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	kc, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("kube client: %v", err)
+	}
+
+	orgID := fmt.Sprintf("e2e%d", time.Now().Unix()) // alnum-only so it passes the label-value rule
+	t.Logf("orgID=%s", orgID)
+
+	const namespace = "lakekeeper" // separate from lakekeeper-operator's own namespace
+	if err := ensureNamespace(t, kc, namespace); err != nil {
+		t.Fatalf("ensure namespace %s: %v", namespace, err)
+	}
+
+	k8sClient := NewLakekeeperK8sClientWithClients(dc, kc, namespace)
+
+	store := newFakeStore()
+	store.warehouses[orgID] = &configstore.ManagedWarehouse{
+		OrgID: orgID,
+		State: configstore.ManagedWarehouseStateProvisioning,
+	}
+
+	// The provisioner computes a baseURL like
+	// http://lakekeeper-<orgid>.lakekeeper.svc:8181 — that hostname is only
+	// resolvable inside the cluster. From the host, we go through the API
+	// server's service-proxy subresource. WithClientFactory swaps the
+	// baseURL for the proxy URL on every NewLakekeeperClient call.
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		t.Fatalf("rest http client: %v", err)
+	}
+	apiBase := cfg.Host
+	clientFor := func(baseURL string) *LakekeeperClient {
+		// The provisioner passes a baseURL like
+		//   http://lakekeeper-<orgid>.lakekeeper.svc:8181
+		// (no /catalog suffix — management API lives at the root). From the
+		// host we route via the API server's service-proxy subresource.
+		proxyBase := fmt.Sprintf("%s/api/v1/namespaces/%s/services/http:%s:8181/proxy",
+			apiBase, namespace, LakekeeperResourceName(orgID))
+		c := NewLakekeeperClient(proxyBase)
+		c.WithHTTPClient(httpClient)
+		return c
+	}
+	p := NewLakekeeperProvisioner(store, k8sClient,
+		WithImage("quay.io/lakekeeper/catalog:latest"),
+		WithClientFactory(clientFor),
+	)
+
+	in := ProvisioningInputs{
+		AdminDSN:  dsn,
+		PGHost:    "host.docker.internal", // reachable from orbstack pods
+		PGPort:    5434,
+		PGSSLMode: "disable", // prototype PG has no TLS
+		S3: S3StorageConfig{
+			Bucket:    "warehouse",
+			KeyPrefix: orgID,
+			Endpoint:  "http://host.docker.internal:9100",
+			Region:    "us-east-1",
+			Flavor:    "s3-compat",
+			// MinIO doesn't actually do STS-compat with these creds, but
+			// the warehouse-create call only validates the credential is
+			// well-formed; the actual S3 operations happen later when a
+			// duckling tries to write.
+			StaticAccessKeyID:     "minioadmin",
+			StaticAccessKeySecret: "minioadmin",
+		},
+	}
+
+	t.Cleanup(func() {
+		// Cleanup: drop the per-org PG database + role, delete the CR + Secret.
+		// Keep best-effort — failures here shouldn't break the test result.
+		ctx := context.Background()
+		_ = k8sClient.dynamic.Resource(lakekeeperGVR).Namespace(namespace).
+			Delete(ctx, LakekeeperResourceName(orgID), metav1DeleteOpts())
+		_ = k8sClient.kubernetes.CoreV1().Secrets(namespace).
+			Delete(ctx, LakekeeperResourceName(orgID), metav1DeleteOpts())
+		dropDatabaseAndRole(t, dsn, lakekeeperDBName(orgID))
+	})
+
+	// Retry EnsureForOrg until bootstrap completes (or timeout). The real
+	// operator's bootstrap takes 10–30s including image pull on first run.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	startedAt := time.Now()
+	var lastErr error
+	for ctx.Err() == nil {
+		lastErr = p.EnsureForOrg(ctx, store.warehouses[orgID], in)
+		if lastErr == nil {
+			t.Logf("EnsureForOrg succeeded after %s", time.Since(startedAt))
+			break
+		}
+		if errors.Is(lastErr, ErrBootstrapPending) {
+			t.Logf("[%s] bootstrap pending, requeueing...", time.Since(startedAt).Round(time.Second))
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		t.Fatalf("EnsureForOrg returned fatal error: %v", lastErr)
+	}
+	if lastErr != nil {
+		t.Fatalf("EnsureForOrg timed out: %v", lastErr)
+	}
+
+	w := store.warehouses[orgID]
+	if !w.Iceberg.Enabled {
+		t.Errorf("Iceberg.Enabled not flipped on")
+	}
+	if w.Iceberg.LakekeeperEndpoint == "" {
+		t.Errorf("LakekeeperEndpoint not persisted")
+	}
+	if w.Iceberg.LakekeeperWarehouse != lakekeeperWarehouseName(orgID) {
+		t.Errorf("LakekeeperWarehouse = %q, want %q", w.Iceberg.LakekeeperWarehouse, lakekeeperWarehouseName(orgID))
+	}
+	if w.Iceberg.LakekeeperClientID != oauthClientID(orgID) {
+		t.Errorf("LakekeeperClientID = %q, want %q", w.Iceberg.LakekeeperClientID, oauthClientID(orgID))
+	}
+	t.Logf("warehouse row: endpoint=%s warehouse=%s client_id=%s",
+		w.Iceberg.LakekeeperEndpoint, w.Iceberg.LakekeeperWarehouse, w.Iceberg.LakekeeperClientID)
+}

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -5,6 +5,7 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +16,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// k8sLabelValue matches the Kubernetes label-value grammar
+// (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])? with ≤63 chars. We use it to
+// validate org IDs before stamping them on labels, so a malformed ID
+// surfaces as a clear error rather than an opaque API server rejection.
+var k8sLabelValue = regexp.MustCompile(`^([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)$`)
+
+func isValidOrgIDLabel(orgID string) bool {
+	return len(orgID) > 0 && len(orgID) <= 63 && k8sLabelValue.MatchString(orgID)
+}
 
 // LakekeeperNamespace is the Kubernetes namespace where per-org Lakekeeper
 // instances live. The lakekeeper-operator and its CRD watch every namespace
@@ -103,7 +114,15 @@ const (
 // updates it if it already exists. Update semantics: the four keys are
 // replaced wholesale on every call — callers must pass the full desired
 // state, not a delta.
+//
+// On a Get/Update resourceVersion conflict (concurrent recreator between
+// our IsAlreadyExists branch and our Update), the returned error wraps the
+// apierrors.IsConflict-detectable original so the reconciler can treat it
+// as transient and requeue.
 func (c *LakekeeperK8sClient) EnsureSecret(ctx context.Context, orgID string, data LakekeeperSecretData) error {
+	if !isValidOrgIDLabel(orgID) {
+		return fmt.Errorf("EnsureSecret: orgID %q is not a valid K8s label value", orgID)
+	}
 	name := LakekeeperResourceName(orgID)
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -163,8 +182,17 @@ type LakekeeperCRSpec struct {
 }
 
 // EnsureCR creates the Lakekeeper CR for the given org or patches it to match
-// spec if it already exists. We use Server-Side Apply for idempotency.
+// spec if it already exists.
+//
+// Like EnsureSecret, Update conflicts surface as apierrors.IsConflict-detectable
+// errors so the reconciler can treat them as transient and requeue.
 func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpec) error {
+	if spec.OrgID == "" {
+		return fmt.Errorf("EnsureCR: spec.OrgID is required")
+	}
+	if !isValidOrgIDLabel(spec.OrgID) {
+		return fmt.Errorf("EnsureCR: orgID %q is not a valid K8s label value", spec.OrgID)
+	}
 	if spec.Image == "" || spec.PGHost == "" || spec.PGDatabase == "" || spec.SecretName == "" {
 		return fmt.Errorf("EnsureCR: missing required field in spec: %+v", spec)
 	}

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -262,12 +262,20 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 	if !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("create lakekeeper CR %s: %w", name, err)
 	}
-	// Update path. Fetch the existing CR to carry over resourceVersion.
+	// Update path. Fetch the existing CR to carry over resourceVersion and
+	// status. Real K8s separates status into a subresource, so an Update
+	// against the main resource shouldn't touch status — but the fake
+	// dynamic client doesn't honor that split, and the behaviour we want
+	// either way is "spec drift correction never overwrites the operator's
+	// status." So copy the existing status into the desired CR.
 	existing, getErr := resource.Get(ctx, name, metav1.GetOptions{})
 	if getErr != nil {
 		return fmt.Errorf("get lakekeeper CR %s for update: %w", name, getErr)
 	}
 	cr.SetResourceVersion(existing.GetResourceVersion())
+	if status, ok := existing.Object["status"]; ok {
+		cr.Object["status"] = status
+	}
 	if _, err := resource.Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update lakekeeper CR %s: %w", name, err)
 	}

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -124,6 +124,12 @@ func (c *LakekeeperK8sClient) EnsureSecret(ctx context.Context, orgID string, da
 		return fmt.Errorf("EnsureSecret: orgID %q is not a valid K8s label value", orgID)
 	}
 	name := LakekeeperResourceName(orgID)
+	// Write to Data (bytes) rather than StringData (strings). The K8s API
+	// server converts StringData → Data on write and clears StringData on
+	// read, so production code that reads the Secret only ever sees Data
+	// populated. The dynamic-fake clientset doesn't do that conversion, so
+	// writing Data directly makes the fake's behavior match real K8s for
+	// downstream readers like secretFromExisting.
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -134,11 +140,11 @@ func (c *LakekeeperK8sClient) EnsureSecret(ctx context.Context, orgID string, da
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
-		StringData: map[string]string{
-			SecretKeyDBUser:             data.DBUser,
-			SecretKeyDBPassword:         data.DBPassword,
-			SecretKeyEncryptionKey:      data.EncryptionKey,
-			SecretKeyOAuth2ClientSecret: data.OAuth2ClientSecret,
+		Data: map[string][]byte{
+			SecretKeyDBUser:             []byte(data.DBUser),
+			SecretKeyDBPassword:         []byte(data.DBPassword),
+			SecretKeyEncryptionKey:      []byte(data.EncryptionKey),
+			SecretKeyOAuth2ClientSecret: []byte(data.OAuth2ClientSecret),
 		},
 	}
 

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -185,6 +185,10 @@ type LakekeeperCRSpec struct {
 	// BaseURI is the externally-visible URL clients (ducklings) use to reach
 	// Lakekeeper. In-cluster: http://lakekeeper-<orgid>.lakekeeper.svc:8181
 	BaseURI string
+	// PGSSLMode is the Postgres SSL mode the Lakekeeper pod uses to connect.
+	// Defaults to "require" (the operator's default). Set to "disable" for
+	// local/dev where PG runs without TLS.
+	PGSSLMode string
 }
 
 // EnsureCR creates the Lakekeeper CR for the given org or patches it to match
@@ -227,23 +231,29 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 				"replicas": int64(spec.Replicas),
 				"database": map[string]interface{}{
 					"type": "postgres",
-					"postgres": map[string]interface{}{
-						"host":     spec.PGHost,
-						"port":     int64(spec.PGPort),
-						"database": spec.PGDatabase,
-						"userSecretRef": map[string]interface{}{
-							"name": spec.SecretName,
-							"key":  SecretKeyDBUser,
-						},
-						"passwordSecretRef": map[string]interface{}{
-							"name": spec.SecretName,
-							"key":  SecretKeyDBPassword,
-						},
-						"encryptionKeySecretRef": map[string]interface{}{
-							"name": spec.SecretName,
-							"key":  SecretKeyEncryptionKey,
-						},
-					},
+					"postgres": func() map[string]interface{} {
+						pg := map[string]interface{}{
+							"host":     spec.PGHost,
+							"port":     int64(spec.PGPort),
+							"database": spec.PGDatabase,
+							"userSecretRef": map[string]interface{}{
+								"name": spec.SecretName,
+								"key":  SecretKeyDBUser,
+							},
+							"passwordSecretRef": map[string]interface{}{
+								"name": spec.SecretName,
+								"key":  SecretKeyDBPassword,
+							},
+							"encryptionKeySecretRef": map[string]interface{}{
+								"name": spec.SecretName,
+								"key":  SecretKeyEncryptionKey,
+							},
+						}
+						if spec.PGSSLMode != "" {
+							pg["sslMode"] = spec.PGSSLMode
+						}
+						return pg
+					}(),
 				},
 				"authorization": map[string]interface{}{
 					"backend": "allowall",

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -1,0 +1,287 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// LakekeeperNamespace is the Kubernetes namespace where per-org Lakekeeper
+// instances live. The lakekeeper-operator and its CRD watch every namespace
+// by default but we co-locate the CRs to keep RBAC tight.
+const LakekeeperNamespace = "lakekeeper"
+
+// lakekeeperGVR matches the operator at /Users/james/opt/ph/lakekeeper-operator.
+var lakekeeperGVR = schema.GroupVersionResource{
+	Group:    "lakekeeper.k8s.lakekeeper.io",
+	Version:  "v1alpha1",
+	Resource: "lakekeepers",
+}
+
+// LakekeeperK8sClient bundles the dynamic client (for the Lakekeeper CR) and
+// the typed clientset (for the backing Secret) so the provisioner can drive
+// both with one dependency. Construction mirrors DucklingClient.
+type LakekeeperK8sClient struct {
+	dynamic    dynamic.Interface
+	kubernetes kubernetes.Interface
+	namespace  string
+}
+
+// NewLakekeeperK8sClient builds a client from in-cluster config.
+func NewLakekeeperK8sClient() (*LakekeeperK8sClient, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("in-cluster config: %w", err)
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic client: %w", err)
+	}
+	kc, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+	return &LakekeeperK8sClient{dynamic: dc, kubernetes: kc, namespace: LakekeeperNamespace}, nil
+}
+
+// NewLakekeeperK8sClientWithClients is used by tests with fakes.
+func NewLakekeeperK8sClientWithClients(dc dynamic.Interface, kc kubernetes.Interface, namespace string) *LakekeeperK8sClient {
+	if namespace == "" {
+		namespace = LakekeeperNamespace
+	}
+	return &LakekeeperK8sClient{dynamic: dc, kubernetes: kc, namespace: namespace}
+}
+
+// LakekeeperResourceName derives the K8s resource name (CR + Secret) for an
+// org. Matches the ducklingName transform — strips hyphens so UUID-style
+// org IDs land under the 63-char K8s name limit.
+func LakekeeperResourceName(orgID string) string {
+	return "lakekeeper-" + lakekeeperResourceSuffix(orgID)
+}
+
+func lakekeeperResourceSuffix(orgID string) string {
+	// Inline to avoid coupling to ducklingName which lives in another file
+	// under the same build tag.
+	out := make([]byte, 0, len(orgID))
+	for i := 0; i < len(orgID); i++ {
+		if orgID[i] == '-' {
+			continue
+		}
+		out = append(out, orgID[i])
+	}
+	return string(out)
+}
+
+// LakekeeperSecretData is the strongly-typed contents of the per-org Secret
+// that the CR's *SecretRef fields point at. All values are required.
+type LakekeeperSecretData struct {
+	DBUser              string
+	DBPassword          string
+	EncryptionKey       string // 32-byte key used by Lakekeeper for at-rest secret encryption
+	OAuth2ClientSecret  string // client_secret minted for the duckling
+}
+
+// SecretKey* are the keys inside the Secret. Stable contract with the CR.
+const (
+	SecretKeyDBUser             = "db-user"
+	SecretKeyDBPassword         = "db-password"
+	SecretKeyEncryptionKey      = "encryption-key"
+	SecretKeyOAuth2ClientSecret = "oauth2-client-secret"
+)
+
+// EnsureSecret creates the per-org Secret in the lakekeeper namespace or
+// updates it if it already exists. Update semantics: the four keys are
+// replaced wholesale on every call — callers must pass the full desired
+// state, not a delta.
+func (c *LakekeeperK8sClient) EnsureSecret(ctx context.Context, orgID string, data LakekeeperSecretData) error {
+	name := LakekeeperResourceName(orgID)
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.namespace,
+			Labels: map[string]string{
+				"app":                 "lakekeeper",
+				"duckgres/active-org": orgID,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			SecretKeyDBUser:             data.DBUser,
+			SecretKeyDBPassword:         data.DBPassword,
+			SecretKeyEncryptionKey:      data.EncryptionKey,
+			SecretKeyOAuth2ClientSecret: data.OAuth2ClientSecret,
+		},
+	}
+
+	secrets := c.kubernetes.CoreV1().Secrets(c.namespace)
+	_, err := secrets.Create(ctx, desired, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create secret %s: %w", name, err)
+	}
+	// Update path: fetch resourceVersion + replace.
+	existing, getErr := secrets.Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get secret %s for update: %w", name, getErr)
+	}
+	desired.ResourceVersion = existing.ResourceVersion
+	if _, err := secrets.Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// LakekeeperCRSpec carries the inputs we need to render a Lakekeeper CR.
+// One CR per org. PG connection points at the org's existing managed-warehouse
+// Aurora cluster, with the lakekeeper_<orgid> database created by
+// EnsureDatabase.
+type LakekeeperCRSpec struct {
+	OrgID      string
+	Image      string // e.g. quay.io/lakekeeper/catalog:0.11.6
+	Replicas   int32
+	PGHost     string
+	PGPort     int32
+	PGDatabase string
+	// SecretName is the K8s Secret holding db-user, db-password, encryption-key,
+	// oauth2-client-secret. Typically LakekeeperResourceName(OrgID).
+	SecretName string
+	// BaseURI is the externally-visible URL clients (ducklings) use to reach
+	// Lakekeeper. In-cluster: http://lakekeeper-<orgid>.lakekeeper.svc:8181
+	BaseURI string
+}
+
+// EnsureCR creates the Lakekeeper CR for the given org or patches it to match
+// spec if it already exists. We use Server-Side Apply for idempotency.
+func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpec) error {
+	if spec.Image == "" || spec.PGHost == "" || spec.PGDatabase == "" || spec.SecretName == "" {
+		return fmt.Errorf("EnsureCR: missing required field in spec: %+v", spec)
+	}
+	if spec.Replicas == 0 {
+		spec.Replicas = 1
+	}
+	if spec.PGPort == 0 {
+		spec.PGPort = 5432
+	}
+
+	name := LakekeeperResourceName(spec.OrgID)
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "lakekeeper.k8s.lakekeeper.io/v1alpha1",
+			"kind":       "Lakekeeper",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": c.namespace,
+				"labels": map[string]interface{}{
+					"app":                 "lakekeeper",
+					"duckgres/active-org": spec.OrgID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"image":    spec.Image,
+				"replicas": int64(spec.Replicas),
+				"database": map[string]interface{}{
+					"type": "postgres",
+					"postgres": map[string]interface{}{
+						"host":     spec.PGHost,
+						"port":     int64(spec.PGPort),
+						"database": spec.PGDatabase,
+						"userSecretRef": map[string]interface{}{
+							"name": spec.SecretName,
+							"key":  SecretKeyDBUser,
+						},
+						"passwordSecretRef": map[string]interface{}{
+							"name": spec.SecretName,
+							"key":  SecretKeyDBPassword,
+						},
+						"encryptionKeySecretRef": map[string]interface{}{
+							"name": spec.SecretName,
+							"key":  SecretKeyEncryptionKey,
+						},
+					},
+				},
+				"authorization": map[string]interface{}{
+					"backend": "allowall",
+				},
+				"bootstrap": map[string]interface{}{
+					"enabled": true,
+				},
+				"server": map[string]interface{}{
+					"listenPort":           int64(8181),
+					"enableDefaultProject": true,
+					"baseURI":              spec.BaseURI,
+				},
+			},
+		},
+	}
+
+	resource := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace)
+	_, err := resource.Create(ctx, cr, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create lakekeeper CR %s: %w", name, err)
+	}
+	// Update path. Fetch the existing CR to carry over resourceVersion.
+	existing, getErr := resource.Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get lakekeeper CR %s for update: %w", name, getErr)
+	}
+	cr.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := resource.Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update lakekeeper CR %s: %w", name, err)
+	}
+	return nil
+}
+
+// LakekeeperCRStatus is the subset of status fields the provisioner reads.
+type LakekeeperCRStatus struct {
+	Bootstrapped  bool
+	ServerID      string
+	ReadyReplicas int32
+}
+
+// GetCR fetches the current status of the Lakekeeper CR. Returns
+// (nil, nil) if the CR does not exist yet, matching the "not provisioned"
+// state the provisioner reconciler treats as a no-op.
+func (c *LakekeeperK8sClient) GetCR(ctx context.Context, orgID string) (*LakekeeperCRStatus, error) {
+	name := LakekeeperResourceName(orgID)
+	cr, err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get lakekeeper CR %s: %w", name, err)
+	}
+	st := &LakekeeperCRStatus{}
+	status, _ := cr.Object["status"].(map[string]interface{})
+	if status == nil {
+		return st, nil
+	}
+	if v, _ := status["bootstrappedAt"].(string); v != "" {
+		st.Bootstrapped = true
+	}
+	if v, _ := status["serverID"].(string); v != "" {
+		st.ServerID = v
+	}
+	// readyReplicas may be int64 or float64 depending on the decoder path.
+	switch v := status["readyReplicas"].(type) {
+	case int64:
+		st.ReadyReplicas = int32(v)
+	case float64:
+		st.ReadyReplicas = int32(v)
+	}
+	return st, nil
+}

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -1,0 +1,204 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func newFakeLakekeeperClient() (*LakekeeperK8sClient, *dynamicfake.FakeDynamicClient, *kubefake.Clientset) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "lakekeeper.k8s.lakekeeper.io", Version: "v1alpha1", Kind: "Lakekeeper",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "lakekeeper.k8s.lakekeeper.io", Version: "v1alpha1", Kind: "LakekeeperList",
+	}, &unstructured.UnstructuredList{})
+	dc := dynamicfake.NewSimpleDynamicClient(scheme)
+	kc := kubefake.NewClientset()
+	c := NewLakekeeperK8sClientWithClients(dc, kc, "lakekeeper")
+	return c, dc, kc
+}
+
+func TestLakekeeperResourceName(t *testing.T) {
+	cases := map[string]string{
+		"acme":                 "lakekeeper-acme",
+		"019e417b-18c4-7a41":   "lakekeeper-019e417b18c47a41",
+		"00000000-0000-0000-0000-000000000000": "lakekeeper-00000000000000000000000000000000",
+	}
+	for in, want := range cases {
+		if got := LakekeeperResourceName(in); got != want {
+			t.Errorf("LakekeeperResourceName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEnsureSecret_CreateThenUpdate(t *testing.T) {
+	c, _, kc := newFakeLakekeeperClient()
+	ctx := context.Background()
+	orgID := "acme"
+
+	data := LakekeeperSecretData{
+		DBUser:             "lakekeeper_acme",
+		DBPassword:         "pw-1",
+		EncryptionKey:      "key-1",
+		OAuth2ClientSecret: "oauth-1",
+	}
+	if err := c.EnsureSecret(ctx, orgID, data); err != nil {
+		t.Fatalf("EnsureSecret create: %v", err)
+	}
+	got, err := kc.CoreV1().Secrets("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	assertSecretData(t, got, data)
+	if lbl := got.Labels["duckgres/active-org"]; lbl != "acme" {
+		t.Errorf("active-org label = %q, want acme", lbl)
+	}
+
+	// Idempotent update: change one field, verify it lands.
+	data.DBPassword = "pw-2"
+	if err := c.EnsureSecret(ctx, orgID, data); err != nil {
+		t.Fatalf("EnsureSecret update: %v", err)
+	}
+	got, err = kc.CoreV1().Secrets("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret after update: %v", err)
+	}
+	assertSecretData(t, got, data)
+}
+
+func assertSecretData(t *testing.T, s *corev1.Secret, want LakekeeperSecretData) {
+	t.Helper()
+	// kubefake honors StringData by populating Data with the same bytes.
+	get := func(k string) string {
+		if v, ok := s.StringData[k]; ok {
+			return v
+		}
+		return string(s.Data[k])
+	}
+	if get(SecretKeyDBUser) != want.DBUser {
+		t.Errorf("db-user = %q, want %q", get(SecretKeyDBUser), want.DBUser)
+	}
+	if get(SecretKeyDBPassword) != want.DBPassword {
+		t.Errorf("db-password = %q, want %q", get(SecretKeyDBPassword), want.DBPassword)
+	}
+	if get(SecretKeyEncryptionKey) != want.EncryptionKey {
+		t.Errorf("encryption-key = %q, want %q", get(SecretKeyEncryptionKey), want.EncryptionKey)
+	}
+	if get(SecretKeyOAuth2ClientSecret) != want.OAuth2ClientSecret {
+		t.Errorf("oauth2-client-secret = %q, want %q", get(SecretKeyOAuth2ClientSecret), want.OAuth2ClientSecret)
+	}
+}
+
+func TestEnsureCR_ValidatesRequiredFields(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	err := c.EnsureCR(context.Background(), LakekeeperCRSpec{OrgID: "acme"})
+	if err == nil {
+		t.Fatal("expected error for missing required fields")
+	}
+}
+
+func TestEnsureCR_CreateAndShape(t *testing.T) {
+	c, dc, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID:      "acme",
+		Image:      "quay.io/lakekeeper/catalog:0.11.6",
+		PGHost:     "acme-pg.local",
+		PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme",
+		BaseURI:    "http://lakekeeper-acme.lakekeeper.svc:8181",
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+
+	got, err := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR: %v", err)
+	}
+	// Drill into the structure
+	specMap := got.Object["spec"].(map[string]interface{})
+	if specMap["image"] != spec.Image {
+		t.Errorf("image = %v, want %s", specMap["image"], spec.Image)
+	}
+	authz := specMap["authorization"].(map[string]interface{})
+	if authz["backend"] != "allowall" {
+		t.Errorf("authz.backend = %v, want allowall", authz["backend"])
+	}
+	boot := specMap["bootstrap"].(map[string]interface{})
+	if boot["enabled"] != true {
+		t.Errorf("bootstrap.enabled = %v, want true", boot["enabled"])
+	}
+	server := specMap["server"].(map[string]interface{})
+	if server["baseURI"] != spec.BaseURI {
+		t.Errorf("server.baseURI = %v, want %s", server["baseURI"], spec.BaseURI)
+	}
+	pg := specMap["database"].(map[string]interface{})["postgres"].(map[string]interface{})
+	if pg["host"] != spec.PGHost || pg["database"] != spec.PGDatabase {
+		t.Errorf("pg host/db = %v/%v, want %s/%s", pg["host"], pg["database"], spec.PGHost, spec.PGDatabase)
+	}
+}
+
+func TestEnsureCR_IdempotentUpdate(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("first EnsureCR: %v", err)
+	}
+	spec.Image = "img:v2"
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("second EnsureCR (update): %v", err)
+	}
+}
+
+func TestGetCR_NotFoundReturnsNilNil(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	st, err := c.GetCR(context.Background(), "ghost-org")
+	if err != nil || st != nil {
+		t.Fatalf("expected (nil, nil) for absent CR, got (%v, %v)", st, err)
+	}
+}
+
+func TestGetCR_ParsesStatus(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	if err := c.EnsureCR(ctx, LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	// Patch status on the fake. The fake dynamic client lets us mutate.
+	cr, _ := c.dynamic.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	cr.Object["status"] = map[string]interface{}{
+		"bootstrappedAt": "2026-05-19T12:00:00Z",
+		"serverID":       "abc-123",
+		"readyReplicas":  int64(2),
+	}
+	if _, err := c.dynamic.Resource(lakekeeperGVR).Namespace("lakekeeper").Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("inject status: %v", err)
+	}
+
+	st, err := c.GetCR(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetCR: %v", err)
+	}
+	if !st.Bootstrapped || st.ServerID != "abc-123" || st.ReadyReplicas != 2 {
+		t.Errorf("status parse mismatch: %+v", st)
+	}
+}

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -80,13 +80,7 @@ func TestEnsureSecret_CreateThenUpdate(t *testing.T) {
 
 func assertSecretData(t *testing.T, s *corev1.Secret, want LakekeeperSecretData) {
 	t.Helper()
-	// kubefake honors StringData by populating Data with the same bytes.
-	get := func(k string) string {
-		if v, ok := s.StringData[k]; ok {
-			return v
-		}
-		return string(s.Data[k])
-	}
+	get := func(k string) string { return string(s.Data[k]) }
 	if get(SecretKeyDBUser) != want.DBUser {
 		t.Errorf("db-user = %q, want %q", get(SecretKeyDBUser), want.DBUser)
 	}

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -151,7 +152,7 @@ func TestEnsureCR_CreateAndShape(t *testing.T) {
 }
 
 func TestEnsureCR_IdempotentUpdate(t *testing.T) {
-	c, _, _ := newFakeLakekeeperClient()
+	c, dc, _ := newFakeLakekeeperClient()
 	ctx := context.Background()
 	spec := LakekeeperCRSpec{
 		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
@@ -163,6 +164,69 @@ func TestEnsureCR_IdempotentUpdate(t *testing.T) {
 	spec.Image = "img:v2"
 	if err := c.EnsureCR(ctx, spec); err != nil {
 		t.Fatalf("second EnsureCR (update): %v", err)
+	}
+	// Read back the CR and confirm the update actually landed.
+	got, err := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR after update: %v", err)
+	}
+	if image := got.Object["spec"].(map[string]interface{})["image"]; image != "img:v2" {
+		t.Errorf("image after update = %v, want img:v2", image)
+	}
+}
+
+func TestEnsureCR_RejectsEmptyOrgID(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_x",
+		SecretName: "lakekeeper-x", BaseURI: "http://x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "OrgID is required") {
+		t.Fatalf("expected OrgID-required error, got: %v", err)
+	}
+}
+
+func TestEnsureCR_RejectsUnsafeOrgID(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	for _, bad := range []string{"With Space", "trailing-", "-leading", "UPPER ok but space bad"} {
+		err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+			OrgID: bad, Image: "img:v1", PGHost: "h", PGDatabase: "x",
+			SecretName: "lakekeeper-x", BaseURI: "http://x",
+		})
+		if err == nil {
+			t.Errorf("expected error for orgID %q, got nil", bad)
+		}
+	}
+}
+
+func TestEnsureSecret_RejectsUnsafeOrgID(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	err := c.EnsureSecret(context.Background(), "bad value", LakekeeperSecretData{
+		DBUser: "u", DBPassword: "p", EncryptionKey: "k", OAuth2ClientSecret: "s",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a valid K8s label value") {
+		t.Fatalf("expected label-value error, got: %v", err)
+	}
+}
+
+func TestIsValidOrgIDLabel(t *testing.T) {
+	cases := map[string]bool{
+		"acme":                                    true,
+		"019e417b-18c4-7a41-bfec-e9ae3a02deb8":    true, // UUID
+		"a":                                       true,
+		"a.b_c-d":                                 true,
+		"":                                        false,
+		"-leading":                                false,
+		"trailing-":                               false,
+		".":                                       false,
+		"has space":                               false,
+		// 64 chars (over the 63 limit)
+		"a234567890123456789012345678901234567890123456789012345678901234": false,
+	}
+	for in, want := range cases {
+		if got := isValidOrgIDLabel(in); got != want {
+			t.Errorf("isValidOrgIDLabel(%q) = %v, want %v", in, got, want)
+		}
 	}
 }
 

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	corev1 "k8s.io/api/core/v1"
@@ -28,11 +27,10 @@ import (
 // caller so the provisioner doesn't bake in secret-lookup logic — PR2 wiring
 // will compute them from the Duckling CR status + K8s Secrets.
 type LakekeeperProvisioner struct {
-	store            WarehouseStore
-	k8s              *LakekeeperK8sClient
-	image            string
-	bootstrapTimeout time.Duration
-	clientFor        ClientFactory
+	store     WarehouseStore
+	k8s       *LakekeeperK8sClient
+	image     string
+	clientFor ClientFactory
 }
 
 // ClientFactory builds a LakekeeperClient for a base URL. Lets tests inject
@@ -83,13 +81,6 @@ func WithImage(img string) LakekeeperProvisionerOption {
 	return func(p *LakekeeperProvisioner) { p.image = img }
 }
 
-// WithBootstrapTimeout sets the max wait for status.bootstrappedAt.
-// Default 30s — the operator's bootstrap typically completes in <10s once
-// the Deployment is ready.
-func WithBootstrapTimeout(d time.Duration) LakekeeperProvisionerOption {
-	return func(p *LakekeeperProvisioner) { p.bootstrapTimeout = d }
-}
-
 // WithClientFactory overrides how LakekeeperClient instances are built.
 // Tests use this to point at httptest.Server.
 func WithClientFactory(f ClientFactory) LakekeeperProvisionerOption {
@@ -105,11 +96,10 @@ const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:0.11.6"
 // same interface the existing controller uses for persistence.
 func NewLakekeeperProvisioner(store WarehouseStore, k8s *LakekeeperK8sClient, opts ...LakekeeperProvisionerOption) *LakekeeperProvisioner {
 	p := &LakekeeperProvisioner{
-		store:            store,
-		k8s:              k8s,
-		image:            DefaultLakekeeperImage,
-		bootstrapTimeout: 30 * time.Second,
-		clientFor:        NewLakekeeperClient,
+		store:     store,
+		k8s:       k8s,
+		image:     DefaultLakekeeperImage,
+		clientFor: NewLakekeeperClient,
 	}
 	for _, o := range opts {
 		o(p)
@@ -156,6 +146,15 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		return fmt.Errorf("ensure lakekeeper secret: %w", err)
 	}
 
+	// 2b. Ensure the Postgres role exists with the password matching the
+	// Secret. A freshly-created database has no users by default; without
+	// this, the Lakekeeper pod's CreateAdminUser-style startup would fail
+	// with "role does not exist". EnsureRole is idempotent and rotates the
+	// password to match the Secret on re-runs.
+	if err := EnsureRole(ctx, in.AdminDSN, creds.DBUser, creds.DBPassword, dbName); err != nil {
+		return fmt.Errorf("ensure lakekeeper pg role: %w", err)
+	}
+
 	// 3. Apply the Lakekeeper CR pointing at the org's PG + the Secret.
 	pgPort := in.PGPort
 	if pgPort == 0 {
@@ -174,10 +173,10 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		return fmt.Errorf("ensure lakekeeper cr: %w", err)
 	}
 
-	// 4. Wait for the operator to mark bootstrap complete. We don't drive
-	// bootstrap from here — `spec.bootstrap.enabled=true` on the CR tells
-	// the operator to do it, and status.bootstrappedAt flips when done.
-	if err := p.waitForBootstrap(ctx, w.OrgID); err != nil {
+	// 4. Check whether the operator has marked bootstrap complete. If not,
+	// return ErrBootstrapPending so the outer reconcile loop can requeue
+	// without blocking other orgs.
+	if err := p.checkBootstrap(ctx, w.OrgID); err != nil {
 		return err
 	}
 
@@ -225,51 +224,29 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		"iceberg_state": configstore.ManagedWarehouseStateReady,
 	}
 	_ = creds // creds are written into the Secret; the row only references them
-	err = p.store.UpdateWarehouseState(w.OrgID, w.State, updates)
-	if err != nil {
-		// Another writer (e.g. the top-level Duckling state machine)
-		// transitioned the row out from under us between when the caller
-		// fetched w and now. The Lakekeeper resources are already
-		// provisioned — the next reconcile loop iteration will retry
-		// the persist step with the fresh state. Not fatal.
-		if errors.Is(err, configstore.ErrWarehouseStateMismatch) {
-			return nil
-		}
+	if err := p.store.UpdateIcebergConfig(w.OrgID, updates); err != nil {
 		return fmt.Errorf("persist lakekeeper config: %w", err)
 	}
 	return nil
 }
 
-// waitForBootstrap polls the Lakekeeper CR status until bootstrappedAt is
-// non-empty or the configured timeout elapses. Returns ErrBootstrapPending on
-// timeout so the caller can requeue.
-//
-// Uses a single time.Timer reused across iterations rather than time.After,
-// which would allocate a fresh timer channel per poll (a minor leak that
-// accumulates over the bootstrap window).
-func (p *LakekeeperProvisioner) waitForBootstrap(ctx context.Context, orgID string) error {
-	deadline := time.Now().Add(p.bootstrapTimeout)
-	const pollInterval = 500 * time.Millisecond
-	t := time.NewTimer(pollInterval)
-	defer t.Stop()
-	for {
-		st, err := p.k8s.GetCR(ctx, orgID)
-		if err != nil {
-			return fmt.Errorf("get lakekeeper cr status: %w", err)
-		}
-		if st != nil && st.Bootstrapped {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return ErrBootstrapPending
-		}
-		t.Reset(pollInterval)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-t.C:
-		}
+// checkBootstrap reads the Lakekeeper CR status once. Returns nil when
+// bootstrappedAt is non-empty, ErrBootstrapPending otherwise. The caller —
+// typically the warehouse-reconcile loop — is responsible for requeueing on
+// ErrBootstrapPending. We intentionally don't poll here: the outer loop
+// iterates over many orgs per tick, and a per-org sleep would stall every
+// other org behind a slow bootstrap. The operator's bootstrap typically
+// completes in <10s once the Deployment is ready, well within a normal
+// reconcile cadence.
+func (p *LakekeeperProvisioner) checkBootstrap(ctx context.Context, orgID string) error {
+	st, err := p.k8s.GetCR(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("get lakekeeper cr status: %w", err)
 	}
+	if st == nil || !st.Bootstrapped {
+		return ErrBootstrapPending
+	}
+	return nil
 }
 
 // resolveOrGenerateSecret reads the existing per-org Secret if present, or
@@ -287,8 +264,8 @@ func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, org
 	// Generate fresh credentials.
 	data := LakekeeperSecretData{
 		DBUser:             dbName, // Lakekeeper connects as a role named after its DB
-		DBPassword:         mustRandomHex(16),
-		EncryptionKey:      mustRandomHex(16),
+		DBPassword:         mustRandomHex(32),
+		EncryptionKey:      mustRandomHex(32), // 32 bytes ⇒ 64 hex chars; safely covers any 256-bit key expectation
 		OAuth2ClientSecret: mustRandomHex(32),
 	}
 	if err := p.k8s.EnsureSecret(ctx, orgID, data); err != nil {

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -225,7 +225,16 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		"iceberg_state": configstore.ManagedWarehouseStateReady,
 	}
 	_ = creds // creds are written into the Secret; the row only references them
-	if err := p.store.UpdateWarehouseState(w.OrgID, w.State, updates); err != nil {
+	err = p.store.UpdateWarehouseState(w.OrgID, w.State, updates)
+	if err != nil {
+		// Another writer (e.g. the top-level Duckling state machine)
+		// transitioned the row out from under us between when the caller
+		// fetched w and now. The Lakekeeper resources are already
+		// provisioned — the next reconcile loop iteration will retry
+		// the persist step with the fresh state. Not fatal.
+		if errors.Is(err, configstore.ErrWarehouseStateMismatch) {
+			return nil
+		}
 		return fmt.Errorf("persist lakekeeper config: %w", err)
 	}
 	return nil
@@ -234,9 +243,15 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 // waitForBootstrap polls the Lakekeeper CR status until bootstrappedAt is
 // non-empty or the configured timeout elapses. Returns ErrBootstrapPending on
 // timeout so the caller can requeue.
+//
+// Uses a single time.Timer reused across iterations rather than time.After,
+// which would allocate a fresh timer channel per poll (a minor leak that
+// accumulates over the bootstrap window).
 func (p *LakekeeperProvisioner) waitForBootstrap(ctx context.Context, orgID string) error {
 	deadline := time.Now().Add(p.bootstrapTimeout)
 	const pollInterval = 500 * time.Millisecond
+	t := time.NewTimer(pollInterval)
+	defer t.Stop()
 	for {
 		st, err := p.k8s.GetCR(ctx, orgID)
 		if err != nil {
@@ -248,10 +263,11 @@ func (p *LakekeeperProvisioner) waitForBootstrap(ctx context.Context, orgID stri
 		if time.Now().After(deadline) {
 			return ErrBootstrapPending
 		}
+		t.Reset(pollInterval)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(pollInterval):
+		case <-t.C:
 		}
 	}
 }
@@ -281,18 +297,18 @@ func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, org
 	return data, nil
 }
 
+// secretFromExisting decodes the per-org Secret keys back into a typed
+// value. Reads only from Data — the K8s API server clears StringData on
+// read and base64-decodes everything into Data, so checking StringData
+// first would be dead code in production. The fake clientset echoes
+// StringData back; assertSecretData in the unit tests covers both, so
+// coverage is unchanged.
 func secretFromExisting(s *corev1.Secret) LakekeeperSecretData {
-	get := func(k string) string {
-		if v, ok := s.StringData[k]; ok {
-			return v
-		}
-		return string(s.Data[k])
-	}
 	return LakekeeperSecretData{
-		DBUser:             get(SecretKeyDBUser),
-		DBPassword:         get(SecretKeyDBPassword),
-		EncryptionKey:      get(SecretKeyEncryptionKey),
-		OAuth2ClientSecret: get(SecretKeyOAuth2ClientSecret),
+		DBUser:             string(s.Data[SecretKeyDBUser]),
+		DBPassword:         string(s.Data[SecretKeyDBPassword]),
+		EncryptionKey:      string(s.Data[SecretKeyEncryptionKey]),
+		OAuth2ClientSecret: string(s.Data[SecretKeyOAuth2ClientSecret]),
 	}
 }
 

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -51,6 +51,10 @@ type ProvisioningInputs struct {
 	PGHost string
 	PGPort int32
 
+	// PGSSLMode the Lakekeeper pod sets when connecting. Default "require".
+	// Set to "disable" for local/dev environments where PG has no TLS.
+	PGSSLMode string
+
 	// S3 storage profile for the warehouse Lakekeeper hands out. For prod
 	// AWS, leave Endpoint empty and Flavor "aws". For MinIO / s3-compat,
 	// set Endpoint and Flavor "s3-compat".
@@ -169,6 +173,7 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		PGDatabase: dbName,
 		SecretName: secretName,
 		BaseURI:    baseURL,
+		PGSSLMode:  in.PGSSLMode,
 	}); err != nil {
 		return fmt.Errorf("ensure lakekeeper cr: %w", err)
 	}
@@ -181,7 +186,11 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	}
 
 	// 5. Idempotently create the org's warehouse via Lakekeeper's REST API.
-	lkClient := p.clientFor(baseURL + "/catalog")
+	// LakekeeperClient calls /management/v1/* which are at the server root,
+	// NOT under /catalog. The /catalog prefix is only for the Iceberg REST
+	// API that ducklings hit later — that's the value we persist in
+	// LakekeeperEndpoint below.
+	lkClient := p.clientFor(baseURL)
 	whReq := CreateWarehouseRequest{
 		WarehouseName: lakekeeperWarehouseName(w.OrgID),
 		StorageProfile: WarehouseStorageProfile{

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -1,0 +1,350 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LakekeeperProvisioner advances an org's Lakekeeper through a fixed pipeline:
+//
+//	create lakekeeper_<orgid> DB → ensure K8s Secret with creds →
+//	ensure Lakekeeper CR → wait for operator bootstrap →
+//	ensure Iceberg warehouse via REST → persist endpoint+client_id back to
+//	the warehouse row.
+//
+// Every step is idempotent so EnsureForOrg can be called repeatedly. The
+// pure dependencies (admin DSN, PG host, S3 config) are passed in by the
+// caller so the provisioner doesn't bake in secret-lookup logic — PR2 wiring
+// will compute them from the Duckling CR status + K8s Secrets.
+type LakekeeperProvisioner struct {
+	store            WarehouseStore
+	k8s              *LakekeeperK8sClient
+	image            string
+	bootstrapTimeout time.Duration
+	clientFor        ClientFactory
+}
+
+// ClientFactory builds a LakekeeperClient for a base URL. Lets tests inject
+// httptest.Server URLs without rebuilding the provisioner.
+type ClientFactory func(baseURL string) *LakekeeperClient
+
+// ProvisioningInputs are everything the provisioner needs about the org's
+// environment that doesn't live in the warehouse row yet.
+type ProvisioningInputs struct {
+	// AdminDSN is a pgx-compatible DSN with permission to CREATE DATABASE
+	// on the org's Aurora cluster. Caller resolves this from a K8s Secret
+	// managed by Crossplane.
+	AdminDSN string
+
+	// PG host/port the Lakekeeper pod uses to reach the same cluster. Often
+	// the same hostname as AdminDSN but routed differently (e.g. through
+	// PgBouncer). Empty Port defaults to 5432.
+	PGHost string
+	PGPort int32
+
+	// S3 storage profile for the warehouse Lakekeeper hands out. For prod
+	// AWS, leave Endpoint empty and Flavor "aws". For MinIO / s3-compat,
+	// set Endpoint and Flavor "s3-compat".
+	S3 S3StorageConfig
+}
+
+// S3StorageConfig captures the bucket + credentials Lakekeeper uses.
+type S3StorageConfig struct {
+	Bucket    string
+	KeyPrefix string
+	Endpoint  string
+	Region    string
+	// Flavor is "aws" or "s3-compat".
+	Flavor string
+
+	// Static creds — present for MinIO/dev. For prod AWS, leave empty and
+	// Lakekeeper uses its pod IRSA identity (allow-direct-system-credentials
+	// in the operator config).
+	StaticAccessKeyID     string
+	StaticAccessKeySecret string
+}
+
+// LakekeeperProvisionerOption tunes the provisioner.
+type LakekeeperProvisionerOption func(*LakekeeperProvisioner)
+
+// WithImage sets the Lakekeeper container image. Defaults to a pinned tag.
+func WithImage(img string) LakekeeperProvisionerOption {
+	return func(p *LakekeeperProvisioner) { p.image = img }
+}
+
+// WithBootstrapTimeout sets the max wait for status.bootstrappedAt.
+// Default 30s — the operator's bootstrap typically completes in <10s once
+// the Deployment is ready.
+func WithBootstrapTimeout(d time.Duration) LakekeeperProvisionerOption {
+	return func(p *LakekeeperProvisioner) { p.bootstrapTimeout = d }
+}
+
+// WithClientFactory overrides how LakekeeperClient instances are built.
+// Tests use this to point at httptest.Server.
+func WithClientFactory(f ClientFactory) LakekeeperProvisionerOption {
+	return func(p *LakekeeperProvisioner) { p.clientFor = f }
+}
+
+// DefaultLakekeeperImage is the pinned image we deploy by default.
+// Bumps to this constant should be paired with a Lakekeeper-operator
+// version compatibility check.
+const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:0.11.6"
+
+// NewLakekeeperProvisioner builds a provisioner. The WarehouseStore is the
+// same interface the existing controller uses for persistence.
+func NewLakekeeperProvisioner(store WarehouseStore, k8s *LakekeeperK8sClient, opts ...LakekeeperProvisionerOption) *LakekeeperProvisioner {
+	p := &LakekeeperProvisioner{
+		store:            store,
+		k8s:              k8s,
+		image:            DefaultLakekeeperImage,
+		bootstrapTimeout: 30 * time.Second,
+		clientFor:        NewLakekeeperClient,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// ErrBootstrapPending signals "the operator hasn't finished initial bootstrap
+// of the Lakekeeper CR yet". Callers should requeue rather than treat this
+// as a failure.
+var ErrBootstrapPending = errors.New("lakekeeper bootstrap pending")
+
+// EnsureForOrg drives the pipeline. Idempotent: re-running on an
+// already-provisioned org reads existing state and only emits writes for
+// genuine drift.
+func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore.ManagedWarehouse, in ProvisioningInputs) error {
+	if w == nil {
+		return errors.New("EnsureForOrg: warehouse is nil")
+	}
+	if !isValidOrgIDLabel(w.OrgID) {
+		return fmt.Errorf("EnsureForOrg: orgID %q is not a valid K8s label value", w.OrgID)
+	}
+	if err := validateInputs(in); err != nil {
+		return err
+	}
+
+	dbName := lakekeeperDBName(w.OrgID)
+	secretName := LakekeeperResourceName(w.OrgID)
+	resourceName := LakekeeperResourceName(w.OrgID)
+	// In-cluster Service DNS — operator names the Service after the CR.
+	baseURL := fmt.Sprintf("http://%s.%s.svc:8181", resourceName, p.k8s.namespace)
+
+	// 1. CREATE DATABASE lakekeeper_<orgid> if absent.
+	if err := EnsureDatabase(ctx, in.AdminDSN, dbName); err != nil {
+		return fmt.Errorf("ensure lakekeeper db: %w", err)
+	}
+
+	// 2. Resolve or generate the per-org credentials, and ensure the K8s
+	// Secret holds them. On re-runs we read the existing Secret rather than
+	// rotating its values — Lakekeeper's DB password would otherwise drift
+	// from the Postgres user's actual password.
+	creds, err := p.resolveOrGenerateSecret(ctx, w.OrgID, dbName, secretName)
+	if err != nil {
+		return fmt.Errorf("ensure lakekeeper secret: %w", err)
+	}
+
+	// 3. Apply the Lakekeeper CR pointing at the org's PG + the Secret.
+	pgPort := in.PGPort
+	if pgPort == 0 {
+		pgPort = 5432
+	}
+	if err := p.k8s.EnsureCR(ctx, LakekeeperCRSpec{
+		OrgID:      w.OrgID,
+		Image:      p.image,
+		Replicas:   1,
+		PGHost:     in.PGHost,
+		PGPort:     pgPort,
+		PGDatabase: dbName,
+		SecretName: secretName,
+		BaseURI:    baseURL,
+	}); err != nil {
+		return fmt.Errorf("ensure lakekeeper cr: %w", err)
+	}
+
+	// 4. Wait for the operator to mark bootstrap complete. We don't drive
+	// bootstrap from here — `spec.bootstrap.enabled=true` on the CR tells
+	// the operator to do it, and status.bootstrappedAt flips when done.
+	if err := p.waitForBootstrap(ctx, w.OrgID); err != nil {
+		return err
+	}
+
+	// 5. Idempotently create the org's warehouse via Lakekeeper's REST API.
+	lkClient := p.clientFor(baseURL + "/catalog")
+	whReq := CreateWarehouseRequest{
+		WarehouseName: lakekeeperWarehouseName(w.OrgID),
+		StorageProfile: WarehouseStorageProfile{
+			Type:                 "s3",
+			Bucket:               in.S3.Bucket,
+			KeyPrefix:            in.S3.KeyPrefix,
+			Endpoint:             in.S3.Endpoint,
+			Region:               in.S3.Region,
+			PathStyleAccess:      in.S3.Flavor == "s3-compat",
+			Flavor:               in.S3.Flavor,
+			STSEnabled:           true,
+			RemoteSigningEnabled: false,
+		},
+		StorageCredential: storageCredFor(in.S3),
+	}
+	wh, err := lkClient.EnsureWarehouse(ctx, whReq)
+	if err != nil {
+		return fmt.Errorf("ensure lakekeeper warehouse: %w", err)
+	}
+
+	// 6. Persist endpoint+credentials back into the warehouse row. Iceberg
+	// state flips to Ready as part of the same write. Callers that don't
+	// own the row (e.g. integration tests) pass a fake store; production
+	// uses configstore's Compare-And-Swap UpdateWarehouseState.
+	// In PR1, Lakekeeper runs in allowall mode and the OAuth2 server URI is
+	// not used at the wire layer (the duckling's CREATE SECRET sends
+	// CLIENT_ID/CLIENT_SECRET but Lakekeeper accepts unauthenticated
+	// requests from within the org's NetworkPolicy). PR3 fills in the
+	// real token endpoint when OIDC SA-token auth lands.
+	updates := map[string]interface{}{
+		"iceberg_enabled":                                 true,
+		"iceberg_backend":                                 configstore.IcebergBackendLakekeeper,
+		"iceberg_lakekeeper_endpoint":                     baseURL + "/catalog",
+		"iceberg_lakekeeper_warehouse":                    wh.Name,
+		"iceberg_lakekeeper_client_id":                    oauthClientID(w.OrgID),
+		"iceberg_lakekeeper_oauth2_server_uri":            "", // PR3
+		"iceberg_lakekeeper_client_credentials_namespace": p.k8s.namespace,
+		"iceberg_lakekeeper_client_credentials_name":      secretName,
+		"iceberg_lakekeeper_client_credentials_key":       SecretKeyOAuth2ClientSecret,
+		"iceberg_state": configstore.ManagedWarehouseStateReady,
+	}
+	_ = creds // creds are written into the Secret; the row only references them
+	if err := p.store.UpdateWarehouseState(w.OrgID, w.State, updates); err != nil {
+		return fmt.Errorf("persist lakekeeper config: %w", err)
+	}
+	return nil
+}
+
+// waitForBootstrap polls the Lakekeeper CR status until bootstrappedAt is
+// non-empty or the configured timeout elapses. Returns ErrBootstrapPending on
+// timeout so the caller can requeue.
+func (p *LakekeeperProvisioner) waitForBootstrap(ctx context.Context, orgID string) error {
+	deadline := time.Now().Add(p.bootstrapTimeout)
+	const pollInterval = 500 * time.Millisecond
+	for {
+		st, err := p.k8s.GetCR(ctx, orgID)
+		if err != nil {
+			return fmt.Errorf("get lakekeeper cr status: %w", err)
+		}
+		if st != nil && st.Bootstrapped {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return ErrBootstrapPending
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// resolveOrGenerateSecret reads the existing per-org Secret if present, or
+// generates fresh credentials and writes a new Secret. Generating ONLY on
+// first run keeps the Postgres user's password stable across re-runs —
+// rotating the Secret would silently de-sync it from the actual PG password.
+func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, orgID, dbName, secretName string) (LakekeeperSecretData, error) {
+	existing, err := p.k8s.kubernetes.CoreV1().Secrets(p.k8s.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err == nil {
+		return secretFromExisting(existing), nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return LakekeeperSecretData{}, fmt.Errorf("get existing secret: %w", err)
+	}
+	// Generate fresh credentials.
+	data := LakekeeperSecretData{
+		DBUser:             dbName, // Lakekeeper connects as a role named after its DB
+		DBPassword:         mustRandomHex(16),
+		EncryptionKey:      mustRandomHex(16),
+		OAuth2ClientSecret: mustRandomHex(32),
+	}
+	if err := p.k8s.EnsureSecret(ctx, orgID, data); err != nil {
+		return LakekeeperSecretData{}, err
+	}
+	return data, nil
+}
+
+func secretFromExisting(s *corev1.Secret) LakekeeperSecretData {
+	get := func(k string) string {
+		if v, ok := s.StringData[k]; ok {
+			return v
+		}
+		return string(s.Data[k])
+	}
+	return LakekeeperSecretData{
+		DBUser:             get(SecretKeyDBUser),
+		DBPassword:         get(SecretKeyDBPassword),
+		EncryptionKey:      get(SecretKeyEncryptionKey),
+		OAuth2ClientSecret: get(SecretKeyOAuth2ClientSecret),
+	}
+}
+
+func validateInputs(in ProvisioningInputs) error {
+	if in.AdminDSN == "" {
+		return errors.New("ProvisioningInputs.AdminDSN is required")
+	}
+	if in.PGHost == "" {
+		return errors.New("ProvisioningInputs.PGHost is required")
+	}
+	if in.S3.Bucket == "" || in.S3.Region == "" {
+		return errors.New("ProvisioningInputs.S3 Bucket+Region are required")
+	}
+	if in.S3.Flavor == "" {
+		return errors.New("ProvisioningInputs.S3.Flavor is required (\"aws\" or \"s3-compat\")")
+	}
+	return nil
+}
+
+func storageCredFor(s3 S3StorageConfig) WarehouseStorageCredential {
+	if s3.StaticAccessKeyID != "" {
+		return WarehouseStorageCredential{
+			Type:               "s3",
+			CredentialType:     "access-key",
+			AWSAccessKeyID:     s3.StaticAccessKeyID,
+			AWSSecretAccessKey: s3.StaticAccessKeySecret,
+		}
+	}
+	return WarehouseStorageCredential{
+		Type:           "s3",
+		CredentialType: "aws-system-identity",
+	}
+}
+
+func lakekeeperDBName(orgID string) string {
+	return "lakekeeper_" + lakekeeperResourceSuffix(orgID)
+}
+
+func lakekeeperWarehouseName(orgID string) string {
+	return "org-" + lakekeeperResourceSuffix(orgID)
+}
+
+func oauthClientID(orgID string) string {
+	return "duckling-" + lakekeeperResourceSuffix(orgID)
+}
+
+func mustRandomHex(byteLen int) string {
+	b := make([]byte, byteLen)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand on Linux/macOS doesn't fail in practice; if it does,
+		// we cannot proceed safely.
+		panic(fmt.Sprintf("crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -5,6 +5,7 @@ package provisioner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -212,28 +213,9 @@ func TestEnsureForOrg_BootstrapTimeoutReturnsTransient(t *testing.T) {
 			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
 		},
 	})
-	if err == nil {
-		t.Fatal("expected ErrBootstrapPending")
-	}
-	// Use errors.Is so wrapped errors also match.
-	if !isErrBootstrap(err) {
+	if !errors.Is(err, ErrBootstrapPending) {
 		t.Fatalf("expected ErrBootstrapPending, got: %v", err)
 	}
-}
-
-func isErrBootstrap(err error) bool {
-	for cur := err; cur != nil; {
-		if cur == ErrBootstrapPending {
-			return true
-		}
-		type u interface{ Unwrap() error }
-		if v, ok := cur.(u); ok {
-			cur = v.Unwrap()
-			continue
-		}
-		break
-	}
-	return false
 }
 
 func TestEnsureForOrg_RejectsInvalidInputs(t *testing.T) {
@@ -254,6 +236,57 @@ func TestEnsureForOrg_RejectsInvalidInputs(t *testing.T) {
 				t.Errorf("expected validation error for %s", name)
 			}
 		})
+	}
+}
+
+// TestEnsureForOrg_StateMismatchIsBenign covers the case where the warehouse
+// row transitions out of the expected state between when the caller fetched
+// w and when EnsureForOrg's persist step runs. The Lakekeeper resources are
+// provisioned; the persist step fails the CAS; EnsureForOrg returns nil so
+// the next reconcile iteration can retry with the fresh state.
+func TestEnsureForOrg_StateMismatchIsBenign(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("cas-test", configstore.ManagedWarehouseStateProvisioning)
+	// Caller's view of the warehouse, with stale state.
+	staleW := &configstore.ManagedWarehouse{
+		OrgID: "cas-test",
+		State: configstore.ManagedWarehouseStateProvisioning,
+	}
+	// Simulate concurrent transition: the actual row is now `ready`.
+	store.warehouses["cas-test"].State = configstore.ManagedWarehouseStateReady
+
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "cas-test", Image: "stub", PGHost: "stub", PGDatabase: "stub", SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "cas-test")
+
+	p := NewLakekeeperProvisioner(store, c,
+		WithBootstrapTimeout(2*time.Second),
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_castest") })
+
+	err := p.EnsureForOrg(context.Background(), staleW, ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434,
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "cas-test", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected nil on benign CAS mismatch, got: %v", err)
+	}
+	// Lakekeeper-side write should have happened (warehouse created) even
+	// though the row update was skipped.
+	if len(fake.warehouses) != 1 {
+		t.Errorf("warehouse create count = %d, want 1", len(fake.warehouses))
 	}
 }
 

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -1,0 +1,278 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// fakeLakekeeperServer is an httptest stand-in for Lakekeeper. Tracks calls
+// and lets us assert the right requests landed.
+type fakeLakekeeperServer struct {
+	t          *testing.T
+	srv        *httptest.Server
+	warehouses []CreateWarehouseRequest
+	bootstraps int
+}
+
+func newFakeLakekeeperServer(t *testing.T) *fakeLakekeeperServer {
+	t.Helper()
+	f := &fakeLakekeeperServer{t: t}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/management/v1/info":
+			_, _ = io.WriteString(w, `{"version":"0.11.6","bootstrapped":true}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/management/v1/bootstrap":
+			f.bootstraps++
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/management/v1/warehouse":
+			resp := listWarehousesResponse{Warehouses: nil}
+			for i, req := range f.warehouses {
+				resp.Warehouses = append(resp.Warehouses, Warehouse{
+					Name: req.WarehouseName, WarehouseID: stableID(i),
+				})
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == http.MethodPost && r.URL.Path == "/management/v1/warehouse":
+			var req CreateWarehouseRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			f.warehouses = append(f.warehouses, req)
+			_ = json.NewEncoder(w).Encode(Warehouse{
+				Name: req.WarehouseName, WarehouseID: stableID(len(f.warehouses) - 1),
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func stableID(i int) string {
+	return "wh-" + string(rune('a'+i))
+}
+
+func newFakeProvisionerStore(orgID string, state configstore.ManagedWarehouseProvisioningState) *fakeStore {
+	fs := newFakeStore()
+	fs.warehouses[orgID] = &configstore.ManagedWarehouse{
+		OrgID: orgID,
+		State: state,
+	}
+	return fs
+}
+
+// markBootstrapped helps EnsureForOrg's wait-for-bootstrap step succeed under
+// the fake dynamic client (which doesn't run the operator's reconciler).
+func markBootstrapped(t *testing.T, c *LakekeeperK8sClient, orgID string) {
+	t.Helper()
+	name := LakekeeperResourceName(orgID)
+	cr, err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR to mark bootstrapped: %v", err)
+	}
+	cr.Object["status"] = map[string]interface{}{
+		"bootstrappedAt": "2026-05-19T12:00:00Z",
+		"serverID":       "test-server",
+	}
+	if _, err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).Update(context.Background(), cr, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("mark bootstrapped: %v", err)
+	}
+}
+
+func TestEnsureForOrg_HappyPath_Fakes(t *testing.T) {
+	// This test exercises everything EXCEPT the actual Postgres CREATE
+	// DATABASE — that's covered by EnsureDatabase_AgainstLivePG. We point
+	// AdminDSN at the local prototype Postgres if available, otherwise
+	// skip the test.
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set; happy-path test needs a real Postgres for CREATE DATABASE")
+	}
+
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("acme", configstore.ManagedWarehouseStateProvisioning)
+	p := NewLakekeeperProvisioner(store, c,
+		WithImage("img:test"),
+		WithBootstrapTimeout(2*time.Second),
+		WithClientFactory(func(baseURL string) *LakekeeperClient {
+			// Redirect "in-cluster" base URL to the fake test server.
+			return NewLakekeeperClient(fake.srv.URL)
+		}),
+	)
+
+	// We need the CR to exist before EnsureForOrg's wait-for-bootstrap step,
+	// and we need it marked bootstrapped (the fake k8s client doesn't run
+	// the operator). EnsureForOrg's k8s.EnsureCR call creates the CR; we
+	// then need to inject status concurrently. Simpler: pre-create the CR
+	// with status set, so EnsureForOrg's EnsureCR Update path executes
+	// instead of Create.
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "acme", Image: "stub", PGHost: "stub", PGDatabase: "stub", SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "acme")
+
+	in := ProvisioningInputs{
+		AdminDSN: dsn,
+		PGHost:   "localhost",
+		PGPort:   5434,
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "org-acme",
+			Endpoint: "http://minio:9000", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	}
+	t.Cleanup(func() {
+		// Drop the lakekeeper_acme DB created by EnsureDatabase.
+		dropDatabase(t, dsn, "lakekeeper_acme")
+	})
+
+	if err := p.EnsureForOrg(context.Background(), store.warehouses["acme"], in); err != nil {
+		t.Fatalf("EnsureForOrg: %v", err)
+	}
+
+	// Warehouse row should now carry Lakekeeper config.
+	w := store.warehouses["acme"]
+	if !w.Iceberg.Enabled {
+		t.Errorf("Iceberg.Enabled not flipped on")
+	}
+	if w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
+		t.Errorf("Backend = %q, want lakekeeper", w.Iceberg.Backend)
+	}
+	if !strings.HasSuffix(w.Iceberg.LakekeeperEndpoint, "/catalog") {
+		t.Errorf("Endpoint = %q, want /catalog suffix", w.Iceberg.LakekeeperEndpoint)
+	}
+	if w.Iceberg.LakekeeperWarehouse != "org-acme" {
+		t.Errorf("Warehouse = %q, want org-acme", w.Iceberg.LakekeeperWarehouse)
+	}
+	if w.Iceberg.LakekeeperClientID != "duckling-acme" {
+		t.Errorf("ClientID = %q, want duckling-acme", w.Iceberg.LakekeeperClientID)
+	}
+	if w.Iceberg.LakekeeperClientCredentials.Name != LakekeeperResourceName("acme") {
+		t.Errorf("ClientCredentials.Name = %q, want %q", w.Iceberg.LakekeeperClientCredentials.Name, LakekeeperResourceName("acme"))
+	}
+	if w.IcebergState != configstore.ManagedWarehouseStateReady {
+		t.Errorf("IcebergState = %q, want ready", w.IcebergState)
+	}
+
+	// Fake Lakekeeper should have received exactly one warehouse create.
+	if len(fake.warehouses) != 1 {
+		t.Fatalf("warehouse creates = %d, want 1", len(fake.warehouses))
+	}
+	got := fake.warehouses[0]
+	if got.WarehouseName != "org-acme" {
+		t.Errorf("WarehouseName = %q, want org-acme", got.WarehouseName)
+	}
+	if !got.StorageProfile.STSEnabled || got.StorageProfile.Flavor != "s3-compat" {
+		t.Errorf("storage profile must be sts-enabled + s3-compat, got %+v", got.StorageProfile)
+	}
+
+	// Idempotency: a second call should be a no-op on writes.
+	beforeCalls := len(fake.warehouses)
+	if err := p.EnsureForOrg(context.Background(), w, in); err != nil {
+		t.Fatalf("EnsureForOrg (second call): %v", err)
+	}
+	if len(fake.warehouses) != beforeCalls {
+		t.Errorf("second EnsureForOrg created another warehouse (want idempotent)")
+	}
+}
+
+func TestEnsureForOrg_BootstrapTimeoutReturnsTransient(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	store := newFakeProvisionerStore("acme2", configstore.ManagedWarehouseStateProvisioning)
+	p := NewLakekeeperProvisioner(store, c,
+		WithBootstrapTimeout(200*time.Millisecond), // short
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_acme2") })
+
+	err := p.EnsureForOrg(context.Background(), store.warehouses["acme2"], ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434,
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "org-acme2", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected ErrBootstrapPending")
+	}
+	// Use errors.Is so wrapped errors also match.
+	if !isErrBootstrap(err) {
+		t.Fatalf("expected ErrBootstrapPending, got: %v", err)
+	}
+}
+
+func isErrBootstrap(err error) bool {
+	for cur := err; cur != nil; {
+		if cur == ErrBootstrapPending {
+			return true
+		}
+		type u interface{ Unwrap() error }
+		if v, ok := cur.(u); ok {
+			cur = v.Unwrap()
+			continue
+		}
+		break
+	}
+	return false
+}
+
+func TestEnsureForOrg_RejectsInvalidInputs(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	store := newFakeProvisionerStore("acme", configstore.ManagedWarehouseStateProvisioning)
+	p := NewLakekeeperProvisioner(store, c)
+
+	cases := map[string]ProvisioningInputs{
+		"missing AdminDSN":   {PGHost: "h", S3: S3StorageConfig{Bucket: "b", Region: "r", Flavor: "aws"}},
+		"missing PGHost":     {AdminDSN: "d", S3: S3StorageConfig{Bucket: "b", Region: "r", Flavor: "aws"}},
+		"missing S3 bucket":  {AdminDSN: "d", PGHost: "h", S3: S3StorageConfig{Region: "r", Flavor: "aws"}},
+		"missing S3 region":  {AdminDSN: "d", PGHost: "h", S3: S3StorageConfig{Bucket: "b", Flavor: "aws"}},
+		"missing S3 flavor":  {AdminDSN: "d", PGHost: "h", S3: S3StorageConfig{Bucket: "b", Region: "r"}},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := p.EnsureForOrg(context.Background(), store.warehouses["acme"], in); err == nil {
+				t.Errorf("expected validation error for %s", name)
+			}
+		})
+	}
+}
+
+func TestEnsureForOrg_RejectsInvalidOrgID(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	store := newFakeProvisionerStore("bad org", configstore.ManagedWarehouseStateProvisioning)
+	p := NewLakekeeperProvisioner(store, c)
+	err := p.EnsureForOrg(context.Background(), store.warehouses["bad org"], ProvisioningInputs{
+		AdminDSN: "d", PGHost: "h",
+		S3: S3StorageConfig{Bucket: "b", Region: "r", Flavor: "aws"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a valid K8s label value") {
+		t.Fatalf("expected label-value error, got: %v", err)
+	}
+}
+
+// dropDatabase is a t.Cleanup helper that best-effort removes a DB.
+func dropDatabase(t *testing.T, dsn, name string) {
+	t.Helper()
+	dropDSN := dsn // pgx accepts the same DSN; CREATE/DROP from any current DB.
+	cleanupDB(t, dropDSN, name)
+}

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,7 +108,6 @@ func TestEnsureForOrg_HappyPath_Fakes(t *testing.T) {
 	store := newFakeProvisionerStore("acme", configstore.ManagedWarehouseStateProvisioning)
 	p := NewLakekeeperProvisioner(store, c,
 		WithImage("img:test"),
-		WithBootstrapTimeout(2*time.Second),
 		WithClientFactory(func(baseURL string) *LakekeeperClient {
 			// Redirect "in-cluster" base URL to the fake test server.
 			return NewLakekeeperClient(fake.srv.URL)
@@ -194,16 +192,17 @@ func TestEnsureForOrg_HappyPath_Fakes(t *testing.T) {
 	}
 }
 
-func TestEnsureForOrg_BootstrapTimeoutReturnsTransient(t *testing.T) {
+// EnsureForOrg returns ErrBootstrapPending when the operator hasn't yet
+// flipped status.bootstrappedAt — caller (the warehouse-reconcile loop)
+// is responsible for requeueing without blocking other orgs.
+func TestEnsureForOrg_NotBootstrappedReturnsTransient(t *testing.T) {
 	dsn := os.Getenv("PG_ADMIN_DSN")
 	if dsn == "" {
 		t.Skip("PG_ADMIN_DSN not set")
 	}
 	c, _, _ := newFakeLakekeeperClient()
 	store := newFakeProvisionerStore("acme2", configstore.ManagedWarehouseStateProvisioning)
-	p := NewLakekeeperProvisioner(store, c,
-		WithBootstrapTimeout(200*time.Millisecond), // short
-	)
+	p := NewLakekeeperProvisioner(store, c)
 	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_acme2") })
 
 	err := p.EnsureForOrg(context.Background(), store.warehouses["acme2"], ProvisioningInputs{
@@ -239,54 +238,51 @@ func TestEnsureForOrg_RejectsInvalidInputs(t *testing.T) {
 	}
 }
 
-// TestEnsureForOrg_StateMismatchIsBenign covers the case where the warehouse
-// row transitions out of the expected state between when the caller fetched
-// w and when EnsureForOrg's persist step runs. The Lakekeeper resources are
-// provisioned; the persist step fails the CAS; EnsureForOrg returns nil so
-// the next reconcile iteration can retry with the fresh state.
-func TestEnsureForOrg_StateMismatchIsBenign(t *testing.T) {
+// TestEnsureForOrg_PersistsAfterTopLevelStateMoved covers the case where
+// the warehouse row's top-level state has already transitioned to Ready
+// (e.g. the Duckling controller moved it ahead of us). The new persist
+// path uses UpdateIcebergConfig which doesn't CAS on top-level state, so
+// Lakekeeper config still lands.
+func TestEnsureForOrg_PersistsAfterTopLevelStateMoved(t *testing.T) {
 	dsn := os.Getenv("PG_ADMIN_DSN")
 	if dsn == "" {
 		t.Skip("PG_ADMIN_DSN not set")
 	}
 	c, _, _ := newFakeLakekeeperClient()
 	fake := newFakeLakekeeperServer(t)
-	store := newFakeProvisionerStore("cas-test", configstore.ManagedWarehouseStateProvisioning)
-	// Caller's view of the warehouse, with stale state.
+	store := newFakeProvisionerStore("ready-test", configstore.ManagedWarehouseStateProvisioning)
+	// Simulate the Duckling state machine racing ahead.
+	store.warehouses["ready-test"].State = configstore.ManagedWarehouseStateReady
+	// Caller's snapshot of w is stale.
 	staleW := &configstore.ManagedWarehouse{
-		OrgID: "cas-test",
+		OrgID: "ready-test",
 		State: configstore.ManagedWarehouseStateProvisioning,
 	}
-	// Simulate concurrent transition: the actual row is now `ready`.
-	store.warehouses["cas-test"].State = configstore.ManagedWarehouseStateReady
 
 	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
-		OrgID: "cas-test", Image: "stub", PGHost: "stub", PGDatabase: "stub", SecretName: "stub", BaseURI: "http://stub",
+		OrgID: "ready-test", Image: "stub", PGHost: "stub", PGDatabase: "stub", SecretName: "stub", BaseURI: "http://stub",
 	}); err != nil {
 		t.Fatalf("seed CR: %v", err)
 	}
-	markBootstrapped(t, c, "cas-test")
+	markBootstrapped(t, c, "ready-test")
 
 	p := NewLakekeeperProvisioner(store, c,
-		WithBootstrapTimeout(2*time.Second),
 		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
 	)
-	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_castest") })
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_readytest") })
 
 	err := p.EnsureForOrg(context.Background(), staleW, ProvisioningInputs{
 		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434,
 		S3: S3StorageConfig{
-			Bucket: "warehouse", KeyPrefix: "cas-test", Region: "us-east-1", Flavor: "s3-compat",
+			Bucket: "warehouse", KeyPrefix: "ready-test", Region: "us-east-1", Flavor: "s3-compat",
 			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
 		},
 	})
 	if err != nil {
-		t.Fatalf("expected nil on benign CAS mismatch, got: %v", err)
+		t.Fatalf("expected nil, got: %v", err)
 	}
-	// Lakekeeper-side write should have happened (warehouse created) even
-	// though the row update was skipped.
-	if len(fake.warehouses) != 1 {
-		t.Errorf("warehouse create count = %d, want 1", len(fake.warehouses))
+	if w := store.warehouses["ready-test"]; w.Iceberg.LakekeeperEndpoint == "" {
+		t.Errorf("expected LakekeeperEndpoint persisted even though top-level state was Ready")
 	}
 }
 

--- a/controlplane/provisioner/postgres_admin.go
+++ b/controlplane/provisioner/postgres_admin.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -72,24 +73,10 @@ func quoteIdent(s string) string {
 }
 
 // isDuplicateDatabase reports whether err is a Postgres 42P04 (database
-// already exists) — the only race outcome we consider benign.
+// already exists) — the only race outcome we consider benign. Uses
+// errors.As so multi-error chains (e.g. errors.Join) are handled too.
 func isDuplicateDatabase(err error) bool {
-	if err == nil {
-		return false
-	}
 	type sqlStater interface{ SQLState() string }
 	var s sqlStater
-	for cur := err; cur != nil; {
-		if v, ok := cur.(sqlStater); ok {
-			s = v
-			break
-		}
-		type unwrapper interface{ Unwrap() error }
-		if u, ok := cur.(unwrapper); ok {
-			cur = u.Unwrap()
-			continue
-		}
-		break
-	}
-	return s != nil && s.SQLState() == "42P04"
+	return errors.As(err, &s) && s.SQLState() == "42P04"
 }

--- a/controlplane/provisioner/postgres_admin.go
+++ b/controlplane/provisioner/postgres_admin.go
@@ -1,0 +1,95 @@
+package provisioner
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// EnsureDatabase creates dbName on the Postgres server addressed by adminDSN
+// if it does not already exist. Idempotent: returns nil when the database is
+// already present. Caller owns the DSN's credential lifetime.
+//
+// CREATE DATABASE cannot run in a transaction and Postgres does not support
+// CREATE DATABASE IF NOT EXISTS, so we probe pg_database first and only fire
+// CREATE DATABASE when the row is missing. There is a TOCTOU race against
+// concurrent callers; we handle the duplicate_database SQLSTATE (42P04) as
+// a benign collision rather than an error.
+func EnsureDatabase(ctx context.Context, adminDSN, dbName string) error {
+	if !isSafePGIdent(dbName) {
+		return fmt.Errorf("ensure database: unsafe identifier %q", dbName)
+	}
+	db, err := sql.Open("pgx", adminDSN)
+	if err != nil {
+		return fmt.Errorf("open admin connection: %w", err)
+	}
+	defer db.Close()
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)", dbName).Scan(&exists); err != nil {
+		return fmt.Errorf("probe pg_database: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	// Identifier validated above. CREATE DATABASE does not accept parameters.
+	if _, err := db.ExecContext(ctx, "CREATE DATABASE "+quoteIdent(dbName)); err != nil {
+		if isDuplicateDatabase(err) {
+			return nil
+		}
+		return fmt.Errorf("create database %s: %w", dbName, err)
+	}
+	return nil
+}
+
+// isSafePGIdent restricts database names to a conservative whitelist. Names
+// we generate look like "lakekeeper_<orgid>" where orgid is itself
+// constrained; the regex catches accidental typos and any attempt to inject
+// SQL via the name. Real escaping is still done with quoteIdent below — this
+// is a belt-and-suspenders check.
+var safePGIdent = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`)
+
+func isSafePGIdent(s string) bool { return safePGIdent.MatchString(s) }
+
+// quoteIdent wraps an identifier in double quotes and escapes embedded quotes
+// per Postgres rules. Used after isSafePGIdent so this is defensive.
+func quoteIdent(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	out = append(out, '"')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			out = append(out, '"', '"')
+		} else {
+			out = append(out, s[i])
+		}
+	}
+	out = append(out, '"')
+	return string(out)
+}
+
+// isDuplicateDatabase reports whether err is a Postgres 42P04 (database
+// already exists) — the only race outcome we consider benign.
+func isDuplicateDatabase(err error) bool {
+	if err == nil {
+		return false
+	}
+	type sqlStater interface{ SQLState() string }
+	var s sqlStater
+	for cur := err; cur != nil; {
+		if v, ok := cur.(sqlStater); ok {
+			s = v
+			break
+		}
+		type unwrapper interface{ Unwrap() error }
+		if u, ok := cur.(unwrapper); ok {
+			cur = u.Unwrap()
+			continue
+		}
+		break
+	}
+	return s != nil && s.SQLState() == "42P04"
+}

--- a/controlplane/provisioner/postgres_admin.go
+++ b/controlplane/provisioner/postgres_admin.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -113,7 +114,74 @@ func EnsureRole(ctx context.Context, adminDSN, role, password, ownedDB string) e
 	if _, err := db.ExecContext(ctx, "GRANT ALL PRIVILEGES ON DATABASE "+quoteIdent(ownedDB)+" TO "+quoteIdent(role)); err != nil {
 		return fmt.Errorf("grant on database %s to %s: %w", ownedDB, role, err)
 	}
+
+	// Postgres 15+ revokes CREATE on the public schema for non-owner roles.
+	// Lakekeeper's `migrate` step needs DDL inside that schema, so make the
+	// role the database OWNER (which carries schema-creation privileges by
+	// default). Also ALTER SCHEMA public OWNER as belt-and-suspenders for
+	// older PG versions where the database OWNER doesn't automatically own
+	// pre-existing schemas in the new DB.
+	if _, err := db.ExecContext(ctx, "ALTER DATABASE "+quoteIdent(ownedDB)+" OWNER TO "+quoteIdent(role)); err != nil {
+		return fmt.Errorf("alter database owner %s -> %s: %w", ownedDB, role, err)
+	}
+	// Run the schema-owner ALTER inside the target database — schema
+	// ownership is local to each database.
+	dbScoped, err := sql.Open("pgx", reDSN(adminDSN, ownedDB))
+	if err != nil {
+		return fmt.Errorf("open admin connection to %s: %w", ownedDB, err)
+	}
+	defer dbScoped.Close()
+	if _, err := dbScoped.ExecContext(ctx, "ALTER SCHEMA public OWNER TO "+quoteIdent(role)); err != nil {
+		return fmt.Errorf("alter schema public owner -> %s: %w", role, err)
+	}
 	return nil
+}
+
+// reDSN rewrites the dbname component of a Postgres URL-style DSN. Used to
+// connect to a specific database with the same admin credentials.
+func reDSN(dsn, dbName string) string {
+	// pgx accepts both URL and keyword/value DSNs. Detect the URL form by
+	// the postgres:// prefix.
+	const urlPrefix = "postgres://"
+	const urlPrefix2 = "postgresql://"
+	if strings.HasPrefix(dsn, urlPrefix) || strings.HasPrefix(dsn, urlPrefix2) {
+		// Find the last "/" after the "@" — that's the path component.
+		at := strings.Index(dsn, "@")
+		slash := -1
+		if at >= 0 {
+			slash = strings.Index(dsn[at:], "/")
+			if slash >= 0 {
+				slash += at
+			}
+		}
+		if slash < 0 {
+			// No dbname segment; append one.
+			if q := strings.Index(dsn, "?"); q >= 0 {
+				return dsn[:q] + "/" + dbName + dsn[q:]
+			}
+			return dsn + "/" + dbName
+		}
+		// Replace the segment between slash+1 and the next "?" (or end).
+		rest := dsn[slash+1:]
+		q := strings.Index(rest, "?")
+		if q < 0 {
+			return dsn[:slash+1] + dbName
+		}
+		return dsn[:slash+1] + dbName + rest[q:]
+	}
+	// Keyword/value form: replace dbname=... or append.
+	return strings.NewReplacer("dbname="+extractDBName(dsn), "dbname="+dbName).Replace(dsn)
+}
+
+func extractDBName(dsn string) string {
+	// Best-effort extract for the keyword/value form. We only use this when
+	// pgx URL prefix isn't present, which is rare in our codebase.
+	for _, kv := range strings.Fields(dsn) {
+		if strings.HasPrefix(kv, "dbname=") {
+			return strings.TrimPrefix(kv, "dbname=")
+		}
+	}
+	return ""
 }
 
 // isSafePGPassword restricts passwords we generate to a printable ASCII

--- a/controlplane/provisioner/postgres_admin.go
+++ b/controlplane/provisioner/postgres_admin.go
@@ -47,6 +47,108 @@ func EnsureDatabase(ctx context.Context, adminDSN, dbName string) error {
 	return nil
 }
 
+// EnsureRole creates a login role with the given password, or rotates the
+// password if the role already exists. Used by the Lakekeeper provisioner to
+// make sure Lakekeeper's pod can connect with the credentials stored in its
+// K8s Secret — a freshly-created database has no users by default.
+//
+// On a re-run with the same password the ALTER ROLE is a no-op for Postgres
+// internals. On a re-run with a different password we explicitly rotate;
+// callers must keep the password in their Secret in sync with whatever was
+// last passed here. The Lakekeeper provisioner achieves this by reading the
+// existing Secret on every run (resolveOrGenerateSecret) rather than
+// regenerating, so the same password threads through to EnsureRole.
+//
+// Grants the role ALL PRIVILEGES on the named database. Cluster admin
+// permissions are not granted.
+func EnsureRole(ctx context.Context, adminDSN, role, password, ownedDB string) error {
+	if !isSafePGIdent(role) {
+		return fmt.Errorf("ensure role: unsafe role name %q", role)
+	}
+	if !isSafePGIdent(ownedDB) {
+		return fmt.Errorf("ensure role: unsafe db name %q", ownedDB)
+	}
+	if password == "" {
+		return fmt.Errorf("ensure role: empty password")
+	}
+	db, err := sql.Open("pgx", adminDSN)
+	if err != nil {
+		return fmt.Errorf("open admin connection: %w", err)
+	}
+	defer db.Close()
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)", role).Scan(&exists); err != nil {
+		return fmt.Errorf("probe pg_roles: %w", err)
+	}
+	if !exists {
+		// CREATE ROLE accepts password as a literal — pgx's parameter
+		// binding doesn't apply to DDL. Validate as identifier so embedded
+		// quotes can't break out (passwords from mustRandomHex are pure
+		// hex so this is belt-and-suspenders).
+		if !isSafePGPassword(password) {
+			return fmt.Errorf("ensure role: password contains unsafe characters")
+		}
+		stmt := fmt.Sprintf("CREATE ROLE %s WITH LOGIN PASSWORD %s", quoteIdent(role), quoteLiteral(password))
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			if isDuplicateObject(err) {
+				// Concurrent creator beat us — fall through to ALTER + GRANT.
+			} else {
+				return fmt.Errorf("create role %s: %w", role, err)
+			}
+		}
+	} else {
+		// Role exists; rotate the password to whatever the caller passed
+		// (matches the contract that the secret + role stay in sync).
+		if !isSafePGPassword(password) {
+			return fmt.Errorf("ensure role: password contains unsafe characters")
+		}
+		stmt := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s", quoteIdent(role), quoteLiteral(password))
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("alter role %s: %w", role, err)
+		}
+	}
+
+	// GRANT is idempotent — Postgres ignores a re-grant of an existing privilege.
+	if _, err := db.ExecContext(ctx, "GRANT ALL PRIVILEGES ON DATABASE "+quoteIdent(ownedDB)+" TO "+quoteIdent(role)); err != nil {
+		return fmt.Errorf("grant on database %s to %s: %w", ownedDB, role, err)
+	}
+	return nil
+}
+
+// isSafePGPassword restricts passwords we generate to a printable ASCII
+// subset that can't break out of a single-quoted SQL literal. Our generator
+// (mustRandomHex) produces pure hex which trivially passes; the check
+// exists so an external caller can't sneak in newlines / quotes.
+var safePGPassword = regexp.MustCompile(`^[A-Za-z0-9_\-+=./]{1,256}$`)
+
+func isSafePGPassword(s string) bool { return safePGPassword.MatchString(s) }
+
+// quoteLiteral wraps a string in single quotes and doubles any embedded
+// single quotes per Postgres rules. Identifiers use double quotes
+// (quoteIdent); string literals use single quotes.
+func quoteLiteral(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	out = append(out, '\'')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\'', '\'')
+		} else {
+			out = append(out, s[i])
+		}
+	}
+	out = append(out, '\'')
+	return string(out)
+}
+
+// isDuplicateObject reports whether err is Postgres 42710 (duplicate_object)
+// — used for the CREATE ROLE concurrent-create race.
+func isDuplicateObject(err error) bool {
+	type sqlStater interface{ SQLState() string }
+	var s sqlStater
+	return errors.As(err, &s) && s.SQLState() == "42710"
+}
+
 // isSafePGIdent restricts database names to a conservative whitelist. Names
 // we generate look like "lakekeeper_<orgid>" where orgid is itself
 // constrained; the regex catches accidental typos and any attempt to inject

--- a/controlplane/provisioner/postgres_admin.go
+++ b/controlplane/provisioner/postgres_admin.go
@@ -28,7 +28,7 @@ func EnsureDatabase(ctx context.Context, adminDSN, dbName string) error {
 	if err != nil {
 		return fmt.Errorf("open admin connection: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	var exists bool
 	if err := db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)", dbName).Scan(&exists); err != nil {
@@ -76,7 +76,7 @@ func EnsureRole(ctx context.Context, adminDSN, role, password, ownedDB string) e
 	if err != nil {
 		return fmt.Errorf("open admin connection: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	var exists bool
 	if err := db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)", role).Scan(&exists); err != nil {
@@ -130,7 +130,7 @@ func EnsureRole(ctx context.Context, adminDSN, role, password, ownedDB string) e
 	if err != nil {
 		return fmt.Errorf("open admin connection to %s: %w", ownedDB, err)
 	}
-	defer dbScoped.Close()
+	defer func() { _ = dbScoped.Close() }()
 	if _, err := dbScoped.ExecContext(ctx, "ALTER SCHEMA public OWNER TO "+quoteIdent(role)); err != nil {
 		return fmt.Errorf("alter schema public owner -> %s: %w", role, err)
 	}

--- a/controlplane/provisioner/postgres_admin_test.go
+++ b/controlplane/provisioner/postgres_admin_test.go
@@ -1,0 +1,117 @@
+package provisioner
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsSafePGIdent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"lakekeeper_acme", true},
+		{"a", true},
+		{"_underscore_start", true},
+		{"with-hyphen", false},
+		{"1starts_with_digit", false},
+		{"has space", false},
+		{`"injection"`, false},
+		{`; DROP TABLE`, false},
+		{"", false},
+		// Postgres identifier max 63 — 64 chars should reject.
+		{"x" + string(make([]byte, 63)), false}, // 64 NULs after x
+	}
+	// Build a 63-char valid ident and verify it passes.
+	maxOK := make([]byte, 63)
+	for i := range maxOK {
+		maxOK[i] = 'a'
+	}
+	cases = append(cases, struct {
+		in   string
+		want bool
+	}{string(maxOK), true})
+
+	for _, c := range cases {
+		if got := isSafePGIdent(c.in); got != c.want {
+			t.Errorf("isSafePGIdent(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestQuoteIdent(t *testing.T) {
+	cases := map[string]string{
+		"plain":       `"plain"`,
+		`with"quote`:  `"with""quote"`,
+		"":            `""`,
+	}
+	for in, want := range cases {
+		if got := quoteIdent(in); got != want {
+			t.Errorf("quoteIdent(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestEnsureDatabase_AgainstLivePG is an integration test against a real
+// Postgres. Skipped unless PG_ADMIN_DSN is set. Pair with the
+// docker-compose stack at tmp/lakekeeper-proto:
+//
+//	export PG_ADMIN_DSN='postgres://lakekeeper:lakekeeper@localhost:5434/lakekeeper?sslmode=disable'
+//	go test ./controlplane/provisioner/ -run TestEnsureDatabase -v
+func TestEnsureDatabase_AgainstLivePG(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set; skipping live Postgres test")
+	}
+
+	dbName := fmt.Sprintf("lakekeeper_test_%d", os.Getpid())
+	t.Cleanup(func() {
+		// Best-effort drop. Use a fresh connection because EnsureDatabase
+		// closes its own.
+		db, err := sql.Open("pgx", dsn)
+		if err != nil {
+			t.Logf("cleanup open: %v", err)
+			return
+		}
+		defer db.Close()
+		if _, err := db.Exec("DROP DATABASE IF EXISTS " + quoteIdent(dbName)); err != nil {
+			t.Logf("cleanup drop: %v", err)
+		}
+	})
+
+	// First call creates.
+	if err := EnsureDatabase(context.Background(), dsn, dbName); err != nil {
+		t.Fatalf("EnsureDatabase (first): %v", err)
+	}
+	// Second call is a no-op (idempotent).
+	if err := EnsureDatabase(context.Background(), dsn, dbName); err != nil {
+		t.Fatalf("EnsureDatabase (idempotent): %v", err)
+	}
+	// Verify the database actually exists.
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("verify open: %v", err)
+	}
+	defer db.Close()
+	var exists bool
+	if err := db.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)", dbName).Scan(&exists); err != nil {
+		t.Fatalf("verify query: %v", err)
+	}
+	if !exists {
+		t.Fatalf("database %s not found after EnsureDatabase", dbName)
+	}
+}
+
+func TestEnsureDatabase_RejectsUnsafeIdent(t *testing.T) {
+	err := EnsureDatabase(context.Background(), "postgres://stub", `evil"; DROP DATABASE foo;--`)
+	if err == nil {
+		t.Fatal("expected error for unsafe identifier, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsafe identifier") {
+		t.Fatalf("expected 'unsafe identifier' error, got: %v", err)
+	}
+}

--- a/controlplane/provisioner/postgres_admin_test.go
+++ b/controlplane/provisioner/postgres_admin_test.go
@@ -106,6 +106,117 @@ func TestEnsureDatabase_AgainstLivePG(t *testing.T) {
 	}
 }
 
+// TestEnsureRole_AgainstLivePG verifies the role create/alter/grant path
+// against a real Postgres. Skipped unless PG_ADMIN_DSN is set.
+func TestEnsureRole_AgainstLivePG(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	dbName := fmt.Sprintf("lakekeeper_role_test_%d", os.Getpid())
+	roleName := dbName
+	pw1 := "abcdef0123456789"
+	pw2 := "fedcba9876543210"
+	t.Cleanup(func() {
+		db, _ := sql.Open("pgx", dsn)
+		defer db.Close()
+		// Order matters: drop privs before dropping the role.
+		_, _ = db.Exec("REASSIGN OWNED BY " + quoteIdent(roleName) + " TO CURRENT_USER")
+		_, _ = db.Exec("DROP OWNED BY " + quoteIdent(roleName))
+		_, _ = db.Exec("DROP DATABASE IF EXISTS " + quoteIdent(dbName))
+		_, _ = db.Exec("DROP ROLE IF EXISTS " + quoteIdent(roleName))
+	})
+
+	ctx := context.Background()
+	if err := EnsureDatabase(ctx, dsn, dbName); err != nil {
+		t.Fatalf("EnsureDatabase: %v", err)
+	}
+	if err := EnsureRole(ctx, dsn, roleName, pw1, dbName); err != nil {
+		t.Fatalf("EnsureRole (create): %v", err)
+	}
+	// Idempotent: second call with same password is a no-op-ish ALTER.
+	if err := EnsureRole(ctx, dsn, roleName, pw1, dbName); err != nil {
+		t.Fatalf("EnsureRole (idempotent): %v", err)
+	}
+	// Verify the role can actually connect with pw1.
+	connDSN := fmt.Sprintf("postgres://%s:%s@localhost:5434/%s?sslmode=disable", roleName, pw1, dbName)
+	if connDB, err := sql.Open("pgx", connDSN); err != nil {
+		t.Fatalf("open as role: %v", err)
+	} else {
+		var one int
+		if err := connDB.QueryRow("SELECT 1").Scan(&one); err != nil {
+			t.Errorf("connect+query as role with pw1 failed: %v", err)
+		}
+		connDB.Close()
+	}
+	// Rotate the password and verify the new one connects.
+	if err := EnsureRole(ctx, dsn, roleName, pw2, dbName); err != nil {
+		t.Fatalf("EnsureRole (rotate): %v", err)
+	}
+	connDSN2 := fmt.Sprintf("postgres://%s:%s@localhost:5434/%s?sslmode=disable", roleName, pw2, dbName)
+	if connDB, err := sql.Open("pgx", connDSN2); err != nil {
+		t.Fatalf("open as role with rotated pw: %v", err)
+	} else {
+		var one int
+		if err := connDB.QueryRow("SELECT 1").Scan(&one); err != nil {
+			t.Errorf("connect+query with rotated password failed: %v", err)
+		}
+		connDB.Close()
+	}
+}
+
+func TestIsSafePGPassword(t *testing.T) {
+	cases := map[string]bool{
+		"abc123":                                       true,
+		"hex0123456789abcdef":                          true,
+		"with-allowed-chars_=.+/":                      true,
+		"":                                             false,
+		"has space":                                    false,
+		"has'quote":                                    false,
+		`has"doublequote`:                              false,
+		"has\nnewline":                                 false,
+		"has;semicolon":                                false,
+	}
+	for in, want := range cases {
+		if got := isSafePGPassword(in); got != want {
+			t.Errorf("isSafePGPassword(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestQuoteLiteral(t *testing.T) {
+	cases := map[string]string{
+		"plain":           `'plain'`,
+		"with'quote":      `'with''quote'`,
+		"":                `''`,
+		`multiple''ticks`: `'multiple''''ticks'`,
+	}
+	for in, want := range cases {
+		if got := quoteLiteral(in); got != want {
+			t.Errorf("quoteLiteral(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEnsureRole_RejectsUnsafeInput(t *testing.T) {
+	ctx := context.Background()
+	// Unsafe role
+	if err := EnsureRole(ctx, "postgres://stub", "bad role", "abc123", "db"); err == nil ||
+		!strings.Contains(err.Error(), "unsafe role name") {
+		t.Errorf("expected unsafe role error, got: %v", err)
+	}
+	// Unsafe db
+	if err := EnsureRole(ctx, "postgres://stub", "role", "abc123", "bad db"); err == nil ||
+		!strings.Contains(err.Error(), "unsafe db name") {
+		t.Errorf("expected unsafe db error, got: %v", err)
+	}
+	// Empty password
+	if err := EnsureRole(ctx, "postgres://stub", "role", "", "db"); err == nil ||
+		!strings.Contains(err.Error(), "empty password") {
+		t.Errorf("expected empty password error, got: %v", err)
+	}
+}
+
 func TestEnsureDatabase_RejectsUnsafeIdent(t *testing.T) {
 	err := EnsureDatabase(context.Background(), "postgres://stub", `evil"; DROP DATABASE foo;--`)
 	if err == nil {

--- a/controlplane/provisioner/postgres_admin_test.go
+++ b/controlplane/provisioner/postgres_admin_test.go
@@ -77,7 +77,7 @@ func TestEnsureDatabase_AgainstLivePG(t *testing.T) {
 			t.Logf("cleanup open: %v", err)
 			return
 		}
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 		if _, err := db.Exec("DROP DATABASE IF EXISTS " + quoteIdent(dbName)); err != nil {
 			t.Logf("cleanup drop: %v", err)
 		}
@@ -96,7 +96,7 @@ func TestEnsureDatabase_AgainstLivePG(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify open: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	var exists bool
 	if err := db.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)", dbName).Scan(&exists); err != nil {
 		t.Fatalf("verify query: %v", err)
@@ -119,7 +119,7 @@ func TestEnsureRole_AgainstLivePG(t *testing.T) {
 	pw2 := "fedcba9876543210"
 	t.Cleanup(func() {
 		db, _ := sql.Open("pgx", dsn)
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 		// Order matters: drop privs before dropping the role.
 		_, _ = db.Exec("REASSIGN OWNED BY " + quoteIdent(roleName) + " TO CURRENT_USER")
 		_, _ = db.Exec("DROP OWNED BY " + quoteIdent(roleName))
@@ -147,7 +147,7 @@ func TestEnsureRole_AgainstLivePG(t *testing.T) {
 		if err := connDB.QueryRow("SELECT 1").Scan(&one); err != nil {
 			t.Errorf("connect+query as role with pw1 failed: %v", err)
 		}
-		connDB.Close()
+		_ = connDB.Close()
 	}
 	// Rotate the password and verify the new one connects.
 	if err := EnsureRole(ctx, dsn, roleName, pw2, dbName); err != nil {
@@ -161,7 +161,7 @@ func TestEnsureRole_AgainstLivePG(t *testing.T) {
 		if err := connDB.QueryRow("SELECT 1").Scan(&one); err != nil {
 			t.Errorf("connect+query with rotated password failed: %v", err)
 		}
-		connDB.Close()
+		_ = connDB.Close()
 	}
 }
 

--- a/k8s/lakekeeper-networkpolicy.yaml
+++ b/k8s/lakekeeper-networkpolicy.yaml
@@ -1,0 +1,90 @@
+# Baseline NetworkPolicy for the per-org Lakekeeper instances duckgres
+# provisions in the `lakekeeper` namespace. Default-deny on both ingress
+# and egress so a misconfigured Lakekeeper instance can't talk to (or be
+# talked to by) anything not explicitly allowed below.
+#
+# Per-org allow rules are NOT in this file. The lakekeeper-operator
+# stamps only the standard app.kubernetes.io/{name,instance,managed-by}
+# labels on its Deployment pods today, so a NetworkPolicy keyed on
+# `duckgres/active-org` would never match. Per-org isolation needs either:
+#
+#   (a) an upstream patch to the operator that propagates CR labels onto
+#       the Deployment template (then add an ingress rule below that
+#       matches on duckgres/active-org), or
+#   (b) per-org CiliumClusterwideNetworkPolicy resources templated in
+#       the charts repo, matching on app.kubernetes.io/instance=
+#       lakekeeper-<orgid-suffix>.
+#
+# Today both are TODO. Until one ships, the rules below only allow
+# duckgres workers (any org) to reach Lakekeeper. That's coarser than
+# the final story but matches the "allowall + NetworkPolicy" PR1 model:
+# cluster boundary holds, intra-cluster org boundary lands in PR3 with
+# OIDC + the label-propagation work.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: lakekeeper-default-deny
+  namespace: lakekeeper
+spec:
+  podSelector: {}  # all pods in the lakekeeper namespace
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: lakekeeper-ingress-from-duckgres-workers
+  namespace: lakekeeper
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: lakekeeper
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: duckgres
+          podSelector:
+            matchLabels:
+              app: duckgres-worker
+      ports:
+        - port: 8181
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: lakekeeper-egress-to-pg-and-s3
+  namespace: lakekeeper
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: lakekeeper
+  policyTypes:
+    - Egress
+  egress:
+    # DNS so service hostnames resolve.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Postgres (the org's managed-warehouse Aurora). Open to any IP since
+    # Aurora endpoints aren't necessarily in-cluster.
+    - ports:
+        - port: 5432
+          protocol: TCP
+    # HTTPS to S3 (and to the Lakekeeper-Operator-managed webhook /
+    # metrics endpoints we may add later).
+    - ports:
+        - port: 443
+          protocol: TCP
+    # MinIO / S3-compat in-cluster (dev clusters). Harmless in prod where
+    # MinIO isn't running.
+    - ports:
+        - port: 9000
+          protocol: TCP

--- a/k8s/lakekeeper-networkpolicy.yaml
+++ b/k8s/lakekeeper-networkpolicy.yaml
@@ -38,6 +38,10 @@ metadata:
   name: lakekeeper-ingress-from-duckgres-workers
   namespace: lakekeeper
 spec:
+  # `app.kubernetes.io/name: lakekeeper` is what the lakekeeper-operator
+  # stamps on its Deployment pods (see operator's getLabels). The CR and
+  # the K8s Secret we create alongside it use `app: lakekeeper`, but
+  # those are non-pod objects so they don't intersect with this selector.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: lakekeeper


### PR DESCRIPTION
## Summary

First of three PRs adding Lakekeeper as the default Iceberg catalog for duckgres workers. This PR is provisioning scaffolding only — no worker behavior change.

PR1 (this PR) builds:
- A thin Lakekeeper REST client (`Info`, `Bootstrap`, `EnsureWarehouse`)
- A Postgres admin helper (`EnsureDatabase`) for creating the per-org `lakekeeper_<orgid>` database inside the org's existing managed-warehouse Aurora cluster
- K8s `EnsureCR` / `EnsureSecret` / `GetCR` helpers for the `Lakekeeper` CR from the lakekeeper-operator
- The `LakekeeperProvisioner.EnsureForOrg` reconciler that chains it all together idempotently
- Schema additions to `ManagedWarehouseIceberg` (Backend selector + Lakekeeper-side config fields)
- A default-deny baseline NetworkPolicy in the `lakekeeper` namespace

PR2 (next) will add the worker-side ATTACH SQL and activation-payload wiring. PR3 will swap allowall + NetworkPolicy isolation for OIDC SA-token auth.

## Background

Prototype validation at `tmp/lakekeeper-proto/` (not in this PR) empirically confirmed:
- DuckDB 1.5.2 + the bundled iceberg extension can `ATTACH` a Lakekeeper REST catalog and CREATE/INSERT/SELECT through it end-to-end (parquet/manifest/snapshot all land in S3).
- Lakekeeper warehouse storage profile needs `sts-enabled: true`, `flavor: s3-compat` (for MinIO; `aws` for AWS), and `remote-signing-enabled: false` for DuckDB to authenticate to S3.
- Token rotation in DuckDB-iceberg is handled internally via the OAuth2 client_credentials flow — caller only manages long-lived CLIENT_ID/CLIENT_SECRET.

A `FINDINGS.md` writeup of the prototype is intentionally kept in `tmp/` so it's clear it's not the source of truth for production code.

## Design decisions captured

- **Default for new orgs**: `ManagedWarehouseIceberg.Backend` defaults to `"lakekeeper"`. Legacy `"s3_tables"` stays as an explicit escape hatch. `ResolvedBackend()` handles the empty-string case for rows that predate the column.
- **Reuse org's existing Aurora**: per-org `lakekeeper_<orgid>` database, not a dedicated PG cluster. The provisioner takes the admin DSN as an injected dependency so the secret-lookup logic isn't baked in here — PR2 wires it to the K8s Secret managed by Crossplane.
- **Lazy provisioning**: triggered from the worker activator at first activation. The reconciler is synchronous and idempotent; `ErrBootstrapPending` signals "requeue, not fail".
- **Status preservation in EnsureCR**: spec drift correction never clobbers operator-set status. The fix was load-bearing for the fake-client tests but is also the right contract for real K8s.
- **CAS-mismatch is benign**: configstore gained a typed `ErrWarehouseStateMismatch` sentinel. EnsureForOrg returns `nil` on a CAS miss because the Lakekeeper REST write is already committed by then.

## Test plan

- [ ] CI passes both default and `-tags kubernetes` test suites
- [ ] Manual `EnsureForOrg` against a dev cluster with the lakekeeper-operator installed (PostHog/charts companion PR)
- [ ] Live integration tests against the prototype stack at `tmp/lakekeeper-proto/` (`PG_ADMIN_DSN`, `LAKEKEEPER_SMOKE_URL` env-gated) pass locally
- [ ] No worker behavior change — ducklings still use the S3 Tables path on every existing org

## Companion PR

PostHog/charts: `feat(lakekeeper-operator): vendor chart + add dev AppSet` — installs the operator + CRD on `posthog-dev`. The duckgres provisioner assumes the CRD is available; the charts PR provides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)