### PR TITLE
Accept same-owner activation retries

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -65,7 +65,7 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 		if reflect.DeepEqual(current.payload, payload) {
 			return nil
 		}
-		if payload.OwnerEpoch <= currentOwnerEpoch {
+		if payload.OwnerEpoch <= currentOwnerEpoch && !sameOwnerActivationAttempt(current.payload, payload) {
 			return fmt.Errorf("same-tenant takeover requires newer owner epoch %d (current %d)", payload.OwnerEpoch, currentOwnerEpoch)
 		}
 		if p.reuseExistingActivation(payload) {
@@ -166,8 +166,10 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 		return false
 	}
 	if !reflect.DeepEqual(current, payload) && payload.OwnerEpoch <= current.OwnerEpoch {
-		p.mu.Unlock()
-		return false
+		if !sameOwnerActivationAttempt(current, payload) {
+			p.mu.Unlock()
+			return false
+		}
 	}
 
 	// needsRefresh is keyed on DuckLake creds because the activator
@@ -251,7 +253,9 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 		return false
 	}
 	if !reflect.DeepEqual(live, payload) && payload.OwnerEpoch <= live.OwnerEpoch {
-		return false
+		if !sameOwnerActivationAttempt(live, payload) {
+			return false
+		}
 	}
 
 	p.activation.payload = payload
@@ -266,6 +270,12 @@ func s3CredentialsChanged(a, b server.DuckLakeConfig) bool {
 	return a.S3AccessKey != b.S3AccessKey ||
 		a.S3SecretKey != b.S3SecretKey ||
 		a.S3SessionToken != b.S3SessionToken
+}
+
+func sameOwnerActivationAttempt(current, next ActivationPayload) bool {
+	return current.WorkerID == next.WorkerID &&
+		current.CPInstanceID == next.CPInstanceID &&
+		current.OwnerEpoch == next.OwnerEpoch
 }
 
 // sameTenantActivationRuntime compares all structural DuckLake fields except

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -283,6 +283,87 @@ func TestSessionPoolActivateTenantRejectsSameEpochOwnerChange(t *testing.T) {
 	}
 }
 
+func TestSessionPoolActivateTenantAllowsSameOwnerSameEpochCredentialRetry(t *testing.T) {
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		cfg:            server.Config{Users: map[string]string{"postgres": "postgres"}},
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+
+	var opened *sql.DB
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		opened = db
+		return PairFromMain(db), nil
+	}
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		return nil
+	}
+	defer func() {
+		if opened != nil {
+			_ = opened.Close()
+		}
+	}()
+
+	first := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{
+			OwnerEpoch:   2,
+			CPInstanceID: "cp-live:boot-a",
+			WorkerID:     17,
+		},
+		OrgID: "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore:  "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:    "s3://analytics/warehouse/",
+			S3AccessKey:    "OLD_ACCESS_KEY",
+			S3SecretKey:    "OLD_SECRET_KEY",
+			S3SessionToken: "OLD_SESSION_TOKEN",
+		},
+	}
+	if err := pool.activateTenant(first); err != nil {
+		t.Fatalf("first ActivateTenant: %v", err)
+	}
+
+	var refreshCalls int
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		refreshCalls++
+		if dlCfg.S3AccessKey != "NEW_ACCESS_KEY" {
+			t.Fatalf("expected refresh with new credentials, got %q", dlCfg.S3AccessKey)
+		}
+		return nil
+	}
+
+	second := first
+	second.DuckLake.S3AccessKey = "NEW_ACCESS_KEY"
+	second.DuckLake.S3SecretKey = "NEW_SECRET_KEY"
+	second.DuckLake.S3SessionToken = "NEW_SESSION_TOKEN"
+	if err := pool.activateTenant(second); err != nil {
+		t.Fatalf("same-owner same-epoch credential retry should be accepted: %v", err)
+	}
+
+	if refreshCalls != 1 {
+		t.Fatalf("expected one credential refresh, got %d", refreshCalls)
+	}
+	current := pool.currentActivation()
+	if current == nil {
+		t.Fatal("expected activation to remain present")
+	}
+	if current.payload.DuckLake.S3AccessKey != "NEW_ACCESS_KEY" {
+		t.Fatalf("expected activation payload to be refreshed, got %q", current.payload.DuckLake.S3AccessKey)
+	}
+	if current.payload.OwnerEpoch != 2 {
+		t.Fatalf("expected owner epoch to remain 2, got %d", current.payload.OwnerEpoch)
+	}
+}
+
 func TestSessionPoolValidateControlMetadataAcceptsMismatchedCPInstanceID(t *testing.T) {
 	pool := &SessionPool{
 		sharedWarmMode:    true,


### PR DESCRIPTION
## Summary
- allow same-owner, same-epoch tenant activation retries to refresh rotated STS credentials instead of failing as stale takeovers
- keep same-epoch owner changes rejected so real ownership transfer still requires a bumped owner epoch
- add regression coverage for rotated S3 credential retry behavior

## Context
During 30-way transaction-hold QA against the production Duckgres endpoint, some same-org connection attempts failed with:

```
same-tenant takeover requires newer owner epoch 1 (current 1)
```

The worker had already accepted activation for the same worker / CP / epoch. A duplicate activation could carry newly brokered STS credentials, making the full payload not DeepEqual even though it is the same owner retry. This patch treats that narrow case as idempotent and lets the existing credential refresh path update the secret.

## Tests
- `go test ./duckdbservice -run 'TestSessionPoolActivateTenant(AllowsSameOwnerSameEpochCredentialRetry|RejectsSameEpochOwnerChange|AllowsSameOrgTakeover)|TestReuseExistingActivationDoesNotBlockHealthChecks'`
- `go test ./duckdbservice`