### PR TITLE
Reject sessions when warm worker capacity is exhausted

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -661,7 +661,15 @@ func createSessionWithRegisteredCancel(
 }
 
 func sessionCreationErrorResponse(err error) (code string, message string) {
+	var capacityErr *WarmCapacityExhaustedError
 	switch {
+	case errors.As(err, &capacityErr):
+		retryAfter := capacityErr.RetryAfter
+		if retryAfter <= 0 {
+			retryAfter = DefaultWarmCapacityRetryAfter
+		}
+		retrySeconds := int((retryAfter + time.Second - 1) / time.Second)
+		return "53300", fmt.Sprintf("no warm Duckgres worker is currently available; retry in about %d seconds", retrySeconds)
 	case errors.Is(err, context.Canceled):
 		return "57014", "canceling authentication due to user request"
 	case errors.Is(err, context.DeadlineExceeded):

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -83,6 +83,17 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 		}
 	})
 
+	t.Run("warm capacity exhausted", func(t *testing.T) {
+		code, message := sessionCreationErrorResponse(NewWarmCapacityExhaustedError(45 * time.Second))
+		if code != "53300" {
+			t.Fatalf("code = %q, want 53300", code)
+		}
+		want := "no warm Duckgres worker is currently available; retry in about 45 seconds"
+		if message != want {
+			t.Fatalf("message = %q, want %q", message, want)
+		}
+	})
+
 	t.Run("generic error", func(t *testing.T) {
 		code, message := sessionCreationErrorResponse(errors.New("worker activation failed"))
 		if code != "58000" {

--- a/controlplane/flight_ingress_metrics.go
+++ b/controlplane/flight_ingress_metrics.go
@@ -35,6 +35,11 @@ var controlPlaneWorkerQueueDepthGauge = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Approximate number of session requests waiting on worker acquisition.",
 })
 
+var controlPlaneWorkerAcquireFailuresCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_control_plane_worker_acquire_failures_total",
+	Help: "Total worker acquisition failures by reason.",
+}, []string{"reason"})
+
 var controlPlaneWorkerQueueDepth atomic.Int64
 
 var flightSessionsReapedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -77,6 +82,10 @@ func observeControlPlaneWorkerQueueDepthDelta(delta int64) {
 		newDepth = 0
 	}
 	controlPlaneWorkerQueueDepthGauge.Set(float64(newDepth))
+}
+
+func observeControlPlaneWorkerAcquireFailure(reason string) {
+	controlPlaneWorkerAcquireFailuresCounter.WithLabelValues(reason).Inc()
 }
 
 func observeFlightSessionsReaped(trigger string, count int) {

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1351,7 +1351,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 					if assignment.Image != "" && hotClaimed.Image != assignment.Image {
 						slog.Info("Hot-idle worker image mismatch, retiring mismatched worker.", "worker_id", hotClaimed.WorkerID, "expected", assignment.Image, "got", hotClaimed.Image)
 						p.retireClaimedWorker(hotClaimed, RetireReasonMismatchedVersion)
-						// Fall through to neutral idle claim or spawn.
+						// Fall through to neutral idle claim or capacity backpressure.
 					} else {
 						worker, reserveErr := p.reserveClaimedWorker(ctx, hotClaimed, assignment)
 						if reserveErr == nil {
@@ -1364,7 +1364,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 						}
 						slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", hotClaimed.WorkerID, "error", reserveErr)
 						p.retireClaimedWorker(hotClaimed, RetireReasonCrash)
-						// Fall through to neutral idle claim
+						// Fall through to neutral idle claim.
 					}
 				}
 			}
@@ -1387,6 +1387,8 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				p.retireClaimedWorker(claimed, RetireReasonCrash)
 				continue
 			}
+
+			return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
 		}
 
 		p.mu.Lock()
@@ -1397,17 +1399,15 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 
 		p.cleanDeadWorkersLocked()
 
-		// In-memory warm-pool fallback for the case where pool.workers has
-		// a worker that the runtime store doesn't (e.g. ClaimIdleWorker just
-		// returned nil because of state-transition skew). Filtered by
-		// assignment.Image so a per-org pin is honored: if the assignment
-		// names a specific image and no in-memory warm worker matches, fall
-		// through to the spawn block — which already does the right thing.
-		// Without this filter, MTCP could hand a pinned org a default-image
+		// Runtime-store-less K8s mode uses the local worker map as its source
+		// of truth. Filter by assignment.Image so a per-org pin is honored: if
+		// the assignment names a specific image and no in-memory warm worker
+		// matches, fail fast with warm-capacity backpressure. Warm capacity is
+		// supplied by configured warm reconciliation rather than by the
+		// foreground user connection.
+		// Without this filter, a pinned org could be handed a default-image
 		// warm worker, and activation would fail with a DuckLake/extension
-		// version mismatch (observed in prod-us 2026-05-06 for Portola,
-		// which pins to duckgres-worker:<sha>-duckdb1.5.1 while the warm
-		// pool runs the default 1.5.2 image).
+		// version mismatch.
 		idle := p.findReservableWarmWorkerLocked(assignment.Image)
 		if idle != nil {
 			nextState, err := idle.SharedState().Transition(WorkerLifecycleReserved, assignment)
@@ -1451,87 +1451,9 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			return idle, nil
 		}
 
-		liveCount := p.liveWorkerCountLocked()
-		if p.maxWorkers == 0 || liveCount < p.maxWorkers {
-			if p.runtimeStore != nil {
-				image := assignment.Image
-				if image == "" {
-					image = p.workerImage
-				}
-				slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
-					p.cpInstanceID,
-					assignment.OrgID,
-					image,
-					1,
-					p.workerPodNamePrefix(),
-					assignment.MaxWorkers,
-					p.maxWorkers,
-				)
-				if err != nil {
-					p.mu.Unlock()
-					return nil, err
-				}
-				if slot == nil {
-					p.mu.Unlock()
-					select {
-					case <-ctx.Done():
-						return nil, ctx.Err()
-					case <-time.After(100 * time.Millisecond):
-					}
-					continue
-				}
-				p.spawning++
-				p.mu.Unlock()
-
-				err = p.spawnReservedWorker(ctx, slot)
-
-				p.mu.Lock()
-				p.spawning--
-				if err == nil {
-					observeWarmPoolLifecycleGauges(p.workers)
-				}
-				p.mu.Unlock()
-
-				if err != nil {
-					p.retireClaimedWorker(slot, RetireReasonCrash)
-					return nil, err
-				}
-				worker, reserveErr := p.reserveClaimedWorker(ctx, slot, assignment)
-				if reserveErr == nil {
-					return worker, nil
-				}
-				if stderrors.Is(reserveErr, errStaleRuntimeWorkerClaim) {
-					slog.Warn("Spawned worker claim was stale, retrying.", "worker_id", slot.WorkerID, "worker_pod", slot.PodName, "error", reserveErr)
-					continue
-				}
-				return nil, reserveErr
-			}
-
-			id := p.allocateWorkerIDLocked()
-			p.spawning++
-			p.mu.Unlock()
-
-			err := p.spawnWarmWorker(ctx, id, p.workerImage)
-
-			p.mu.Lock()
-			p.spawning--
-			if err == nil {
-				observeWarmPoolLifecycleGauges(p.workers)
-			}
-			p.mu.Unlock()
-
-			if err != nil {
-				return nil, err
-			}
-			continue
-		}
-
 		p.mu.Unlock()
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
+
+		return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
 	}
 }
 

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -723,14 +723,9 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	}
 	pool.workers[stale.ID] = stale
 
+	spawnCalls := 0
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		pool.mu.Lock()
-		defer pool.mu.Unlock()
-		worker := &ManagedWorker{ID: id, done: make(chan struct{})}
-		if err := worker.SetSharedState(SharedWorkerState{Lifecycle: WorkerLifecycleIdle}); err != nil {
-			return err
-		}
-		pool.workers[id] = worker
+		spawnCalls++
 		return nil
 	}
 
@@ -746,11 +741,12 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	got, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
 		OrgID: "analytics",
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion after stale worker, got worker=%#v err=%v", got, err)
 	}
-	if got.ID == stale.ID {
-		t.Fatalf("expected stale worker to be skipped, got %d", got.ID)
+	if got != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", got.ID)
 	}
 	if checks == 0 {
 		t.Fatal("expected liveness recheck before reservation")
@@ -758,8 +754,8 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	if _, ok := pool.Worker(stale.ID); ok {
 		t.Fatal("expected stale worker to be retired")
 	}
-	if got.SharedState().Assignment == nil || got.SharedState().Assignment.OrgID != "analytics" {
-		t.Fatalf("expected returned worker reserved for analytics, got %#v", got.SharedState().Assignment)
+	if spawnCalls != 0 {
+		t.Fatalf("did not expect warm backfill spawn, got %d calls", spawnCalls)
 	}
 }
 
@@ -1106,17 +1102,16 @@ func TestK8sPoolFindIdleWorkerSkipsReservedSharedWorker(t *testing.T) {
 	}
 }
 
-func TestK8sPoolReserveSharedWorkerReservesIdleWorkerWithoutLocalReplenishmentInRuntimeMode(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerRuntimeMissDoesNotUseInMemoryFallback(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	pool.minWorkers = 1
 	store := &captureRuntimeWorkerStore{}
 	pool.runtimeStore = store
 	idle := &ManagedWorker{ID: 7, done: make(chan struct{})}
 	pool.workers[idle.ID] = idle
+	healthChecks := 0
 	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
-		if worker != idle {
-			t.Fatalf("expected liveness check for idle worker %d, got %#v", idle.ID, worker)
-		}
+		healthChecks++
 		return nil
 	}
 
@@ -1136,43 +1131,29 @@ func TestK8sPoolReserveSharedWorkerReservesIdleWorkerWithoutLocalReplenishmentIn
 	worker, err := pool.ReserveSharedWorker(ctx, &WorkerAssignment{
 		OrgID: "analytics",
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
-	if worker.ID != idle.ID {
-		t.Fatalf("expected worker %d, got %d", idle.ID, worker.ID)
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-
-	state := worker.SharedState()
-	if state.Lifecycle != WorkerLifecycleReserved {
-		t.Fatalf("expected reserved lifecycle, got %q", state.Lifecycle)
+	if store.claimCalls != 1 {
+		t.Fatalf("expected one runtime idle claim, got %d", store.claimCalls)
 	}
-	if state.Assignment == nil || state.Assignment.OrgID != "analytics" {
-		t.Fatalf("expected analytics assignment, got %#v", state.Assignment)
+	if idle.SharedState().Assignment != nil {
+		t.Fatalf("local idle worker should not have been reserved, got assignment %#v", idle.SharedState().Assignment)
 	}
-	if worker.ownerEpoch != 1 {
-		t.Fatalf("expected owner epoch 1 after reservation, got %d", worker.ownerEpoch)
+	if idle.ownerEpoch != 0 {
+		t.Fatalf("local idle worker owner epoch should not change, got %d", idle.ownerEpoch)
+	}
+	if healthChecks != 0 {
+		t.Fatalf("did not expect liveness check for unclaimed local worker, got %d checks", healthChecks)
 	}
 
 	records := store.snapshot()
-	if len(records) == 0 {
-		t.Fatal("expected reservation to persist a worker record")
-	}
-	last := records[len(records)-1]
-	if last.WorkerID != worker.ID {
-		t.Fatalf("expected worker_id %d, got %d", worker.ID, last.WorkerID)
-	}
-	if last.State != configstore.WorkerStateReserved {
-		t.Fatalf("expected reserved worker record, got %q", last.State)
-	}
-	if last.OwnerCPInstanceID != pool.cpInstanceID {
-		t.Fatalf("expected owner_cp_instance_id %q, got %q", pool.cpInstanceID, last.OwnerCPInstanceID)
-	}
-	if last.OwnerEpoch != 1 {
-		t.Fatalf("expected owner_epoch 1, got %d", last.OwnerEpoch)
-	}
-	if last.OrgID != "analytics" {
-		t.Fatalf("expected org_id analytics, got %q", last.OrgID)
+	if len(records) != 0 {
+		t.Fatalf("did not expect runtime records from local fallback, got %#v", records)
 	}
 
 	select {
@@ -1182,15 +1163,12 @@ func TestK8sPoolReserveSharedWorkerReservesIdleWorkerWithoutLocalReplenishmentIn
 	}
 }
 
-// TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage ensures the
-// in-memory warm-pool fallback honors per-org image pinning. Without the
-// image filter on findReservableWarmWorkerLocked, ReserveSharedWorker would
-// return a default-image warm worker to a pinned org and the subsequent
-// activation (DuckLake ATTACH inside the worker) would fail with the
-// extension's version-mismatch error. Observed in prod-us 2026-05-06 for
-// Portola, which pins to duckgres-worker:<sha>-duckdb1.5.1 while the warm
-// pool runs the default 1.5.2 single-binary image.
-func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage(t *testing.T) {
+// TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRuntimeStore
+// ensures the runtime-store-less warm-pool path honors per-org image pinning.
+// Without the image filter on findReservableWarmWorkerLocked,
+// ReserveSharedWorker would return a default-image warm worker to a pinned org
+// and the subsequent activation would fail with a version-mismatch error.
+func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRuntimeStore(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 
 	// A warm-idle worker built from the cluster default image — a tempting
@@ -1203,50 +1181,26 @@ func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImage(t *testing
 	pool.workers[defaultWorker.ID] = defaultWorker
 
 	pinnedImage := "duckgres-worker:abc123-duckdb1.5.1"
-	store := &captureRuntimeWorkerStore{
-		// ClaimIdleWorker returns nil (no DB row matches the pinned image),
-		// CreateSpawningWorkerSlot returns a slot for the pinned image so
-		// the spawn path is what serves the request.
-		spawned: &configstore.WorkerRecord{
-			WorkerID:          42,
-			PodName:           "duckgres-worker-test-cp-42",
-			State:             configstore.WorkerStateSpawning,
-			OrgID:             "portola",
-			Image:             pinnedImage,
-			OwnerCPInstanceID: pool.cpInstanceID,
-			OwnerEpoch:        1,
-		},
-	}
-	pool.runtimeStore = store
-
+	spawnCalls := 0
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		pool.workers[id] = &ManagedWorker{
-			ID:      id,
-			image:   pinnedImage,
-			podName: "duckgres-worker-test-cp-42",
-			done:    make(chan struct{}),
-		}
+		spawnCalls++
 		return nil
 	}
-	pool.healthCheckFunc = func(ctx context.Context, w *ManagedWorker) error { return nil }
 
 	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
 		OrgID:      "portola",
 		Image:      pinnedImage,
 		MaxWorkers: 2,
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
-
-	if worker.ID == defaultWorker.ID {
-		t.Fatalf("default-image warm worker (id %d) was returned despite image pin %q", defaultWorker.ID, pinnedImage)
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-	if worker.ID != 42 {
-		t.Fatalf("expected spawned worker id 42, got %d", worker.ID)
-	}
-	if store.spawnImage != pinnedImage {
-		t.Fatalf("spawn image = %q, want %q", store.spawnImage, pinnedImage)
+	if spawnCalls != 0 {
+		t.Fatalf("did not expect foreground or async spawn, got %d calls", spawnCalls)
 	}
 	if defaultWorker.SharedState().Lifecycle == WorkerLifecycleReserved {
 		t.Fatalf("default-image warm worker was reserved despite image mismatch")
@@ -1424,27 +1378,36 @@ func TestK8sPoolReserveClaimedWorkerRejectsStaleInMemoryEpoch(t *testing.T) {
 	}
 }
 
-func TestK8sPoolReserveSharedWorkerFallsBackWhenRuntimeClaimReturnsNil(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerBackpressuresWhenRuntimeClaimReturnsNil(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	store := &captureRuntimeWorkerStore{}
 	pool.runtimeStore = store
 	idle := &ManagedWorker{ID: 8, done: make(chan struct{})}
 	pool.workers[idle.ID] = idle
+	healthChecks := 0
 	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
+		healthChecks++
 		return nil
 	}
 
 	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
 		OrgID: "analytics",
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
-	if worker.ID != idle.ID {
-		t.Fatalf("expected fallback idle worker %d, got %d", idle.ID, worker.ID)
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
 	if store.claimCalls != 1 {
-		t.Fatalf("expected one claim attempt before fallback, got %d", store.claimCalls)
+		t.Fatalf("expected one claim attempt before backpressure, got %d", store.claimCalls)
+	}
+	if idle.SharedState().Assignment != nil {
+		t.Fatalf("local idle worker should not have been reserved, got assignment %#v", idle.SharedState().Assignment)
+	}
+	if healthChecks != 0 {
+		t.Fatalf("did not expect liveness check for unclaimed local worker, got %d checks", healthChecks)
 	}
 }
 
@@ -1456,15 +1419,22 @@ func TestK8sPoolReserveSharedWorkerPassesOrgCapToRuntimeClaim(t *testing.T) {
 	pool.workers[idle.ID] = idle
 	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error { return nil }
 
-	_, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
 		OrgID:      "analytics",
 		MaxWorkers: 3,
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
+	}
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
 	if store.claimMaxOrgWorkers != 3 {
 		t.Fatalf("expected claim max org workers 3, got %d", store.claimMaxOrgWorkers)
+	}
+	if idle.SharedState().Assignment != nil {
+		t.Fatalf("local idle worker should not have been reserved, got assignment %#v", idle.SharedState().Assignment)
 	}
 }
 
@@ -1600,11 +1570,6 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 			WorkerID: 7,
 			Image:    "duckgres:v1",
 		},
-		spawned: &configstore.WorkerRecord{
-			WorkerID: 42,
-			PodName:  "test-cp-worker-42",
-			Image:    "duckgres:v2",
-		},
 	}
 	pool.runtimeStore = store
 
@@ -1614,52 +1579,15 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 		Image: "duckgres:v2",
 	}
 
-	// Mock spawnWarmWorker since we don't have real pods
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error { return nil }
-	// Mock health check since we don't have real worker binaries
-	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error { return nil }
-	// Mock connection since we don't have real pods
-	pool.connectWorkerFunc = func(ctx context.Context, podName, podIP, bearerToken string) (*flightsql.Client, error) {
-		return nil, nil
-	}
-
-	// Provide a mock secret for the spawned pod (worker 42)
-	podName := "test-cp-worker-42"
-	secretName := pool.workerRPCSecretName(podName)
-
-	// Minimal valid PEM blocks for a self-signed cert/key to satisfy parsing.
-	certPEM := []byte("-----BEGIN CERTIFICATE-----\nMIICojCCAYqgAwIBAgIQI6v5m9mN6L3Xv8O5/0u/2zANBgkqhkiG9w0BAQsFADAV\nMRMwEQYDVQQDEwpkdWNra2dyZXMwHhcNMjYwNDI3MDEwODIyWhcNMjYwNTI3MDEw\nODIyWjAVMRMwEQYDVQQDEwpkdWNra2dyZXMwggEiMA0GCSqGSIb3DQEBAQUAA4IB\nDwAwggEKAoIBAQC8u9+9\n-----END CERTIFICATE-----\n")
-	keyPEM := []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAvLvf\n-----END RSA PRIVATE KEY-----\n")
-
-	_, _ = pool.clientset.CoreV1().Secrets(pool.namespace).Create(context.Background(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: secretName},
-		Data: map[string][]byte{
-			"bearer-token":      []byte("secret"),
-			"tls.crt":           certPEM,
-			"tls.key":           keyPEM,
-			"worker-rpc-ca.crt": certPEM,
-		},
-	}, metav1.CreateOptions{})
-
-	// Provide mock pod
-	_, _ = pool.clientset.CoreV1().Pods(pool.namespace).Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   podName,
-			Labels: map[string]string{"duckgres/worker-id": "42"},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			PodIP: "10.0.0.42",
-		},
-	}, metav1.CreateOptions{})
 
 	got, err := pool.ReserveSharedWorker(context.Background(), assignment)
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", got, err)
 	}
-
-	if got.ID != 42 {
-		t.Fatalf("expected to spawn new worker 42, got %d (v1 worker was incorrectly reclaimed)", got.ID)
+	if got != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", got.ID)
 	}
 
 	// Verify v1 worker was retired
@@ -1669,69 +1597,64 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 	if store.retireIdleOrHotIdleCalledReasons[0] != RetireReasonMismatchedVersion {
 		t.Fatalf("expected reason %q, got %q", RetireReasonMismatchedVersion, store.retireIdleOrHotIdleCalledReasons[0])
 	}
+	if store.spawnCalls != 0 || store.perImageSpawnCalls != 0 {
+		t.Fatalf("did not expect foreground or async spawn, got foreground=%d per_image=%d", store.spawnCalls, store.perImageSpawnCalls)
+	}
 }
 
-func TestK8sPoolReserveSharedWorkerCreatesRuntimeSpawningSlotWhenPoolIsCold(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerColdRuntimeBackpressuresWithoutSpawning(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
-	store := &captureRuntimeWorkerStore{
-		spawned: &configstore.WorkerRecord{
-			WorkerID:          31,
-			PodName:           "duckgres-worker-test-cp-31",
-			State:             configstore.WorkerStateSpawning,
-			OrgID:             "analytics",
-			OwnerCPInstanceID: pool.cpInstanceID,
-			OwnerEpoch:        1,
-		},
-	}
+	store := &captureRuntimeWorkerStore{}
 	pool.runtimeStore = store
-	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		worker := &ManagedWorker{ID: id, podName: "duckgres-worker-test-cp-31", done: make(chan struct{})}
-		pool.workers[id] = worker
-		return nil
-	}
-	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
-		if worker == nil || worker.ID != 31 {
-			t.Fatalf("expected spawned runtime worker 31, got %#v", worker)
-		}
-		return nil
-	}
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error { return nil }
 
 	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
 		OrgID:      "analytics",
 		MaxWorkers: 2,
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
-	if worker.ID != 31 {
-		t.Fatalf("expected spawned worker 31, got %d", worker.ID)
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-	if store.spawnCalls != 1 {
-		t.Fatalf("expected one spawning slot allocation, got %d", store.spawnCalls)
+	if store.spawnCalls != 0 {
+		t.Fatalf("did not expect foreground org-bound spawn, got %d calls", store.spawnCalls)
 	}
-	if store.spawnOwnerCPID != pool.cpInstanceID {
-		t.Fatalf("expected spawn owner cp-instance %q, got %q", pool.cpInstanceID, store.spawnOwnerCPID)
+	if store.neutralSpawnCalls != 0 || store.perImageSpawnCalls != 0 {
+		t.Fatalf("did not expect async warm backfill, got neutral=%d per_image=%d", store.neutralSpawnCalls, store.perImageSpawnCalls)
 	}
-	if store.spawnOrgID != "analytics" {
-		t.Fatalf("expected spawn org analytics, got %q", store.spawnOrgID)
+}
+
+func TestK8sPoolReserveSharedWorkerColdBackpressuresWhenWarmupBlockedByGlobalCap(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 1)
+	pool.SetWarmCapacityTarget(1)
+	store := &captureRuntimeWorkerStore{}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 7, done: make(chan struct{}), activeSessions: 1}
+	if err := worker.SetSharedState(SharedWorkerState{
+		Lifecycle:  WorkerLifecycleHot,
+		Assignment: &WorkerAssignment{OrgID: "analytics"},
+	}); err != nil {
+		t.Fatalf("SetSharedState: %v", err)
 	}
-	if store.spawnOwnerEpoch != 1 {
-		t.Fatalf("expected spawn owner epoch 1, got %d", store.spawnOwnerEpoch)
+	pool.workers[7] = worker
+
+	got, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+		OrgID:      "billing",
+		MaxWorkers: 1,
+	})
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", got, err)
 	}
-	if store.spawnPodNamePrefix != "test-cp-worker" {
-		t.Fatalf("expected pod name prefix test-cp-worker, got %q", store.spawnPodNamePrefix)
+	if got != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", got.ID)
 	}
-	if store.spawnMaxOrgWorkers != 2 {
-		t.Fatalf("expected max org workers 2, got %d", store.spawnMaxOrgWorkers)
-	}
-	if store.spawnMaxGlobalWorks != 5 {
-		t.Fatalf("expected max global workers 5, got %d", store.spawnMaxGlobalWorks)
-	}
-	if worker.OwnerEpoch() != 1 {
-		t.Fatalf("expected owner epoch 1, got %d", worker.OwnerEpoch())
-	}
-	if worker.SharedState().Lifecycle != WorkerLifecycleReserved {
-		t.Fatalf("expected reserved lifecycle, got %q", worker.SharedState().Lifecycle)
+	if store.spawnCalls != 0 || store.neutralSpawnCalls != 0 || store.perImageSpawnCalls != 0 {
+		t.Fatalf("did not expect any foreground or async spawn while at cap: spawn=%d neutral=%d per_image=%d", store.spawnCalls, store.neutralSpawnCalls, store.perImageSpawnCalls)
 	}
 }
 
@@ -1978,15 +1901,11 @@ func TestK8sPoolHealthCheckLoopReplenishesWarmCapacityAfterIdleWorkerCrash(t *te
 	}
 }
 
-func TestK8sPoolReserveSharedWorkerSpawnsWhenPoolIsCold(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerColdPoolBackpressuresWithoutSpawning(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
-	pool.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
-		return nil
-	}
+	spawnCalls := 0
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		pool.mu.Lock()
-		pool.workers[id] = &ManagedWorker{ID: id, done: make(chan struct{})}
-		pool.mu.Unlock()
+		spawnCalls++
 		return nil
 	}
 
@@ -1996,15 +1915,15 @@ func TestK8sPoolReserveSharedWorkerSpawnsWhenPoolIsCold(t *testing.T) {
 	worker, err := pool.ReserveSharedWorker(ctx, &WorkerAssignment{
 		OrgID: "billing",
 	})
-	if err != nil {
-		t.Fatalf("ReserveSharedWorker: %v", err)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
-	if worker == nil {
-		t.Fatal("expected reserved worker")
-		return
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-	if got := worker.SharedState().Lifecycle; got != WorkerLifecycleReserved {
-		t.Fatalf("expected reserved lifecycle after cold start, got %q", got)
+	if spawnCalls != 0 {
+		t.Fatalf("did not expect warm backfill spawn, got %d calls", spawnCalls)
 	}
 }
 

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -8,11 +8,18 @@ import (
 	"time"
 )
 
+func addNeutralWarmWorker(shared *K8sWorkerPool, id int) *ManagedWorker {
+	worker := &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
+	shared.workers[id] = worker
+	return worker
+}
+
 func TestOrgReservedPoolAcquireReservesOrgWorker(t *testing.T) {
 	shared, _ := newTestK8sPool(t, 5)
 	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
 		return nil
 	}
+	addNeutralWarmWorker(shared, 1)
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
 		// Mirror production SpawnWorker behavior: the spawned worker carries
@@ -62,6 +69,7 @@ func TestOrgReservedPoolAcquireSkipsOtherOrgsWorkers(t *testing.T) {
 		t.Fatalf("SetSharedState(other): %v", err)
 	}
 	shared.workers[other.ID] = other
+	addNeutralWarmWorker(shared, 2)
 
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
@@ -127,6 +135,7 @@ func TestOrgReservedWorkerPoolAcquireActivatesReservedWorkerWhenEnabledWithOrgCo
 	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
 		return nil
 	}
+	addNeutralWarmWorker(shared, 1)
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
 		// Mirror production SpawnWorker behavior: the spawned worker carries
@@ -164,6 +173,7 @@ func TestOrgReservedWorkerPoolAcquireDelegatesActivationWithoutCachedTenantRunti
 	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
 		return nil
 	}
+	addNeutralWarmWorker(shared, 1)
 	shared.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
 		shared.mu.Lock()
 		// Mirror production SpawnWorker behavior: the spawned worker carries

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -135,6 +135,7 @@ func TestOrgRouterCreateOrgStackActivatesUsingLatestSnapshotThroughSharedWorkerA
 		sharedPool.mu.Unlock()
 		return nil
 	}
+	sharedPool.workers[1] = &ManagedWorker{ID: 1, done: make(chan struct{})}
 
 	for name, value := range map[string]string{
 		"analytics-metadata-old": "old-password",

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -66,14 +67,14 @@ func (sm *SessionManager) ReservePID() int32 {
 	return sm.nextPID.Add(1)
 }
 
-// CreateSession acquires a worker (reusing an idle one or spawning a new one),
-// creates a session on it, and rebalances memory/thread limits across all active sessions.
+// CreateSession acquires a worker from the configured pool, creates a session
+// on it, and rebalances memory/thread limits across all active sessions.
 // If pid is 0, a new one is generated.
 func (sm *SessionManager) CreateSession(ctx context.Context, username string, pid int32, memoryLimit string, threads int) (int32, *flightclient.FlightExecutor, error) {
 	memoryLimit, threads = sm.resolveSessionLimits(memoryLimit, threads)
 
-	// Acquire a worker: reuses idle pre-warmed workers or spawns a new one.
-	// When a backend-specific max worker cap is set, this blocks until a slot is available.
+	// Acquire a worker. Backend implementations may reuse warm workers, queue,
+	// spawn, or return a typed capacity error when no worker is immediately available.
 	observeControlPlaneWorkerQueueDepthDelta(1)
 	defer observeControlPlaneWorkerQueueDepthDelta(-1)
 
@@ -83,6 +84,18 @@ func (sm *SessionManager) CreateSession(ctx context.Context, username string, pi
 	worker, err := sm.pool.AcquireWorker(ctx)
 	acquireSpan.End()
 	if err != nil {
+		var capacityErr *WarmCapacityExhaustedError
+		if errors.As(err, &capacityErr) {
+			observeControlPlaneWorkerAcquireFailure("warm_capacity_exhausted")
+			slog.Warn("Worker acquisition failed.",
+				"pid", pid,
+				"user", username,
+				"duration", time.Since(acquireStart),
+				"reason", "warm_capacity_exhausted",
+				"retry_after", capacityErr.RetryAfter,
+				"error", err,
+			)
+		}
 		return 0, nil, fmt.Errorf("acquire worker: %w", err)
 	}
 	slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -3,12 +3,16 @@
 package controlplane
 
 import (
+	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/posthog/duckgres/server/flightclient"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // mockCloser tracks whether Close was called.
@@ -19,6 +23,62 @@ type mockCloser struct {
 func (m *mockCloser) Close() error {
 	m.closed.Store(true)
 	return nil
+}
+
+type acquireErrorPool struct {
+	err error
+}
+
+func (p *acquireErrorPool) AcquireWorker(ctx context.Context) (*ManagedWorker, error) {
+	return nil, p.err
+}
+
+func (p *acquireErrorPool) ReleaseWorker(id int) {}
+
+func (p *acquireErrorPool) RetireWorker(id int) {}
+
+func (p *acquireErrorPool) RetireWorkerIfNoSessions(id int) bool {
+	return false
+}
+
+func (p *acquireErrorPool) Worker(id int) (*ManagedWorker, bool) {
+	return nil, false
+}
+
+func (p *acquireErrorPool) SpawnMinWorkers(count int) error {
+	return nil
+}
+
+func (p *acquireErrorPool) HealthCheckLoop(ctx context.Context, interval time.Duration, onCrash WorkerCrashHandler, onProgress ProgressHandler) {
+}
+
+func (p *acquireErrorPool) SetMaxWorkers(n int) {}
+
+func (p *acquireErrorPool) ShutdownAll() {}
+
+func TestCreateSessionObservesWarmCapacityExhaustion(t *testing.T) {
+	controlPlaneWorkerAcquireFailuresCounter.Reset()
+	sm := NewSessionManager(&acquireErrorPool{
+		err: NewWarmCapacityExhaustedError(30 * time.Second),
+	}, nil)
+
+	_, _, err := sm.CreateSession(context.Background(), "root", 1001, "", 0)
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity error, got %v", err)
+	}
+
+	counter, counterErr := controlPlaneWorkerAcquireFailuresCounter.GetMetricWithLabelValues("warm_capacity_exhausted")
+	if counterErr != nil {
+		t.Fatalf("failed to read warm capacity counter: %v", counterErr)
+	}
+	metric := &dto.Metric{}
+	if err := counter.Write(metric); err != nil {
+		t.Fatalf("failed to write warm capacity counter: %v", err)
+	}
+	if got := metric.GetCounter().GetValue(); got != 1 {
+		t.Fatalf("expected one warm capacity acquisition failure, got %v", got)
+	}
 }
 
 func TestOnWorkerCrash_MarksExecutorsDead(t *testing.T) {

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -9,6 +9,30 @@ import (
 )
 
 const DefaultK8sWorkerServiceAccount = "duckgres-worker"
+const DefaultWarmCapacityRetryAfter = 45 * time.Second
+
+// WarmCapacityExhaustedError is returned when a user request misses the ready
+// warm pool. The caller should fail fast with a retryable capacity response
+// instead of waiting for a foreground cold worker spawn.
+type WarmCapacityExhaustedError struct {
+	// RetryAfter is the client-facing retry hint for protocol-specific error responses.
+	RetryAfter time.Duration
+}
+
+func (e *WarmCapacityExhaustedError) Error() string {
+	retryAfter := e.RetryAfter
+	if retryAfter <= 0 {
+		retryAfter = DefaultWarmCapacityRetryAfter
+	}
+	return fmt.Sprintf("warm worker capacity exhausted; retry in about %s", retryAfter.Round(time.Second))
+}
+
+func NewWarmCapacityExhaustedError(retryAfter time.Duration) error {
+	if retryAfter <= 0 {
+		retryAfter = DefaultWarmCapacityRetryAfter
+	}
+	return &WarmCapacityExhaustedError{RetryAfter: retryAfter}
+}
 
 // WorkerPool abstracts the lifecycle and scheduling of Flight SQL workers.
 // Two implementations exist:
@@ -59,19 +83,19 @@ type K8sWorkerPoolConfig struct {
 	ConfigMap             string // ConfigMap name for duckgres.yaml
 	MaxWorkers            int
 	IdleTimeout           time.Duration
-	ConfigPath            string            // Path inside worker pod where config is mounted
-	ImagePullPolicy       string            // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
-	ServiceAccount        string            // Neutral ServiceAccount name for worker pods (default: "duckgres-worker")
-	WorkerCPURequest      string            // CPU request for worker pods (e.g., "500m"). Empty = BestEffort.
-	WorkerMemoryRequest   string            // Memory request for worker pods (e.g., "1Gi"). Empty = BestEffort.
-	WorkerNodeSelector    map[string]string // Node selector for worker pods. Nil = no selector.
-	WorkerTolerationKey   string            // Taint key for worker pod NoSchedule toleration. Empty = no toleration.
-	WorkerTolerationValue string            // Taint value for worker pod NoSchedule toleration.
-	WorkerExclusiveNode bool                             // One worker per node via pod anti-affinity.
-	OrgID               string                           // Org ID for pod labels (multi-tenant mode)
-	WorkerIDGenerator   func() int                       // Shared ID generator across orgs (nil = internal counter)
-	ResolveOrgConfig    func(string) (*configstore.OrgConfig, error) // Optional: resolve org config for version-aware reaping
-	RuntimeStore        RuntimeWorkerStore
+	ConfigPath            string                                       // Path inside worker pod where config is mounted
+	ImagePullPolicy       string                                       // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
+	ServiceAccount        string                                       // Neutral ServiceAccount name for worker pods (default: "duckgres-worker")
+	WorkerCPURequest      string                                       // CPU request for worker pods (e.g., "500m"). Empty = BestEffort.
+	WorkerMemoryRequest   string                                       // Memory request for worker pods (e.g., "1Gi"). Empty = BestEffort.
+	WorkerNodeSelector    map[string]string                            // Node selector for worker pods. Nil = no selector.
+	WorkerTolerationKey   string                                       // Taint key for worker pod NoSchedule toleration. Empty = no toleration.
+	WorkerTolerationValue string                                       // Taint value for worker pod NoSchedule toleration.
+	WorkerExclusiveNode   bool                                         // One worker per node via pod anti-affinity.
+	OrgID                 string                                       // Org ID for pod labels (multi-tenant mode)
+	WorkerIDGenerator     func() int                                   // Shared ID generator across orgs (nil = internal counter)
+	ResolveOrgConfig      func(string) (*configstore.OrgConfig, error) // Optional: resolve org config for version-aware reaping
+	RuntimeStore          RuntimeWorkerStore
 }
 
 type RuntimeWorkerStore interface {

--- a/tests/k8s/runtime_helper_test.go
+++ b/tests/k8s/runtime_helper_test.go
@@ -22,6 +22,8 @@ func isTransientDBError(err error) bool {
 		"lost connection to pod",
 		"i/o timeout",
 		"no route to host",
+		"no warm duckgres worker",
+		"warm worker capacity exhausted",
 	} {
 		if strings.Contains(msg, fragment) {
 			return true

--- a/tests/k8s/runtime_helpers_test.go
+++ b/tests/k8s/runtime_helpers_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -23,6 +23,7 @@ func TestIsTransientDBError(t *testing.T) {
 		{name: "broken pipe", err: errors.New("write: broken pipe"), want: true},
 		{name: "bad connection", err: errors.New("driver: bad connection"), want: true},
 		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:5432: connect: connection refused"), want: true},
+		{name: "warm capacity", err: errors.New("pq: no warm Duckgres worker is currently available; retry in about 45 seconds"), want: true},
 		{name: "not transient", err: errors.New("authentication failed"), want: false},
 		{name: "nil", err: nil, want: false},
 	}


### PR DESCRIPTION
## Summary
- add a typed warm-capacity exhaustion error mapped to SQLSTATE 53300
- stop foreground cold spawning in ReserveSharedWorker when no ready warm worker is available
- make runtime-store mode fail fast when durable worker claims miss instead of falling back to the local in-memory worker map
- emit a worker-acquisition failure metric/log for warm-capacity rejects
- keep maxWorkers as a cap only here; dynamic warm backfill based on misses is split into #578
- update tests so org reservation/router coverage seeds warm workers instead of relying on cold spawn

## Tests
- go test -count=1 ./controlplane
- go test -count=1 -tags kubernetes ./controlplane
- go test -count=1 ./tests/k8s -run TestIsTransientDBError