### PR TITLE
Adjust warm targets after capacity misses

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -675,7 +675,7 @@ func sessionCreationErrorResponse(err error) (code string, message string) {
 			retryAfter = DefaultWarmCapacityRetryAfter
 		}
 		retrySeconds := int((retryAfter + time.Second - 1) / time.Second)
-		return "53300", fmt.Sprintf("no warm Duckgres worker is currently available; retry in about %d seconds", retrySeconds)
+		return "53300", fmt.Sprintf("no warm Duckgres worker is currently available; additional capacity is starting, retry in about %d seconds", retrySeconds)
 	case errors.Is(err, context.Canceled):
 		return "57014", "canceling authentication due to user request"
 	case errors.Is(err, context.DeadlineExceeded):

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -88,7 +88,7 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 		if code != "53300" {
 			t.Fatalf("code = %q, want 53300", code)
 		}
-		want := "no warm Duckgres worker is currently available; retry in about 45 seconds"
+		want := "no warm Duckgres worker is currently available; additional capacity is starting, retry in about 45 seconds"
 		if message != want {
 			t.Fatalf("message = %q, want %q", message, want)
 		}

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -35,26 +35,40 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const defaultActivatingTimeout = 2 * time.Minute
+const (
+	defaultActivatingTimeout       = 2 * time.Minute
+	warmCapacityDemandTTL          = 10 * time.Minute
+	warmCapacityDemandBumpInterval = DefaultWarmCapacityRetryAfter
+)
 
 var errStaleRuntimeWorkerClaim = stderrors.New("stale runtime worker claim")
 
 // K8sWorkerPool manages worker pods in Kubernetes.
 type K8sWorkerPool struct {
-	mu           sync.RWMutex
-	workers      map[int]*ManagedWorker
-	nextWorkerID int
-	spawning     int
-	maxWorkers   int
-	minWorkers   int
+	mu                   sync.RWMutex
+	workers              map[int]*ManagedWorker
+	nextWorkerID         int
+	spawning             int
+	maxWorkers           int
+	minWorkers           int
+	warmBaseTarget       int
+	warmDemandTarget     int
+	warmDemandUntil      time.Time
+	warmDemandLastBump   time.Time
+	warmBackfillInFlight bool
 	// perImageWarmTarget is an additive floor on top of minWorkers: for each
 	// image listed, the pool aims to keep at least N warm-idle workers of
 	// that exact image alive so a per-org pin always has a hot pod waiting.
 	// minWorkers still drives the cluster-default warm count separately.
-	perImageWarmTarget map[string]int
-	idleTimeout        time.Duration
-	shuttingDown       bool
-	shutdownCh         chan struct{}
+	perImageWarmTarget           map[string]int
+	perImageWarmBaseTarget       map[string]int
+	perImageWarmDemandTarget     map[string]int
+	perImageWarmDemandUntil      map[string]time.Time
+	perImageWarmDemandLastBump   map[string]time.Time
+	perImageWarmBackfillInFlight map[string]bool
+	idleTimeout                  time.Duration
+	shuttingDown                 bool
+	shutdownCh                   chan struct{}
 
 	clientset             kubernetes.Interface
 	namespace             string
@@ -1388,6 +1402,14 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				continue
 			}
 
+			p.mu.Lock()
+			liveCount := p.liveWorkerCountLocked()
+			canSpawn := p.maxWorkers == 0 || liveCount < p.maxWorkers
+			p.mu.Unlock()
+			if canSpawn {
+				p.triggerWarmCapacityBackfill(assignment)
+			}
+
 			return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
 		}
 
@@ -1451,7 +1473,13 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			return idle, nil
 		}
 
+		liveCount := p.liveWorkerCountLocked()
+		canSpawn := p.maxWorkers == 0 || liveCount < p.maxWorkers
 		p.mu.Unlock()
+
+		if canSpawn {
+			p.triggerWarmCapacityBackfill(assignment)
+		}
 
 		return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
 	}
@@ -1852,6 +1880,168 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 	}
 	wg.Wait()
 	return stderrors.Join(errs...)
+}
+
+func (p *K8sWorkerPool) triggerWarmCapacityBackfill(assignment *WorkerAssignment) {
+	if assignment == nil {
+		return
+	}
+	image := strings.TrimSpace(assignment.Image)
+	if image != "" {
+		target, shouldStart := p.bumpPerImageWarmDemandTarget(image)
+		if target <= 0 || !shouldStart {
+			return
+		}
+		go func() {
+			defer p.finishPerImageWarmBackfill(image)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := p.SpawnMinWorkersForImage(ctx, image, target); err != nil {
+				slog.Warn("Warm-capacity backfill failed.", "image", image, "target", target, "error", err)
+			}
+		}()
+		return
+	}
+
+	target, shouldStart := p.bumpNeutralWarmDemandTarget()
+	if target <= 0 || !shouldStart {
+		return
+	}
+	go func() {
+		defer p.finishNeutralWarmBackfill()
+		if err := p.SpawnMinWorkers(target); err != nil {
+			slog.Warn("Warm-capacity backfill failed.", "target", target, "error", err)
+		}
+	}()
+}
+
+func (p *K8sWorkerPool) bumpNeutralWarmDemandTarget() (int, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	if p.warmBackfillInFlight {
+		if p.warmDemandTarget > 0 {
+			p.warmDemandUntil = now.Add(warmCapacityDemandTTL)
+		}
+		p.recomputeWarmTargetsLocked()
+		return p.minWorkers, false
+	}
+	if p.warmDemandTarget == 0 || now.Sub(p.warmDemandLastBump) >= warmCapacityDemandBumpInterval {
+		current := maxInt(p.warmBaseTarget, p.warmDemandTarget)
+		next := current + 1
+		if next < 1 {
+			next = 1
+		}
+		if p.maxWorkers > 0 && next > p.maxWorkers {
+			next = p.maxWorkers
+		}
+		if next > p.warmDemandTarget {
+			p.warmDemandTarget = next
+		}
+		p.warmDemandLastBump = now
+	}
+	p.warmDemandUntil = now.Add(warmCapacityDemandTTL)
+	p.recomputeWarmTargetsLocked()
+	if p.minWorkers <= 0 {
+		return p.minWorkers, false
+	}
+	p.warmBackfillInFlight = true
+	return p.minWorkers, true
+}
+
+func (p *K8sWorkerPool) bumpPerImageWarmDemandTarget(image string) (int, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if image == "" {
+		return 0, false
+	}
+	if p.perImageWarmDemandTarget == nil {
+		p.perImageWarmDemandTarget = make(map[string]int)
+	}
+	if p.perImageWarmDemandUntil == nil {
+		p.perImageWarmDemandUntil = make(map[string]time.Time)
+	}
+	if p.perImageWarmDemandLastBump == nil {
+		p.perImageWarmDemandLastBump = make(map[string]time.Time)
+	}
+	if p.perImageWarmBackfillInFlight == nil {
+		p.perImageWarmBackfillInFlight = make(map[string]bool)
+	}
+	now := time.Now()
+	if p.perImageWarmBackfillInFlight[image] {
+		if p.perImageWarmDemandTarget[image] > 0 {
+			p.perImageWarmDemandUntil[image] = now.Add(warmCapacityDemandTTL)
+		}
+		p.recomputeWarmTargetsLocked()
+		return p.perImageWarmTarget[image], false
+	}
+	if p.perImageWarmDemandTarget[image] == 0 || now.Sub(p.perImageWarmDemandLastBump[image]) >= warmCapacityDemandBumpInterval {
+		current := maxInt(p.perImageWarmBaseTarget[image], p.perImageWarmDemandTarget[image])
+		next := current + 1
+		if next < 1 {
+			next = 1
+		}
+		if p.maxWorkers > 0 && next > p.maxWorkers {
+			next = p.maxWorkers
+		}
+		if next > p.perImageWarmDemandTarget[image] {
+			p.perImageWarmDemandTarget[image] = next
+		}
+		p.perImageWarmDemandLastBump[image] = now
+	}
+	p.perImageWarmDemandUntil[image] = now.Add(warmCapacityDemandTTL)
+	p.recomputeWarmTargetsLocked()
+	target := p.perImageWarmTarget[image]
+	if target <= 0 {
+		return target, false
+	}
+	p.perImageWarmBackfillInFlight[image] = true
+	return target, true
+}
+
+func (p *K8sWorkerPool) finishNeutralWarmBackfill() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.warmBackfillInFlight = false
+}
+
+func (p *K8sWorkerPool) finishPerImageWarmBackfill(image string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.perImageWarmBackfillInFlight != nil {
+		delete(p.perImageWarmBackfillInFlight, image)
+	}
+}
+
+func (p *K8sWorkerPool) recomputeWarmTargetsLocked() {
+	p.expireWarmDemandLocked(time.Now())
+	p.minWorkers = maxInt(p.warmBaseTarget, p.warmDemandTarget)
+
+	effective := make(map[string]int, len(p.perImageWarmBaseTarget)+len(p.perImageWarmDemandTarget))
+	for image, target := range p.perImageWarmBaseTarget {
+		if image != "" && target > 0 {
+			effective[image] = target
+		}
+	}
+	for image, target := range p.perImageWarmDemandTarget {
+		if image != "" && target > effective[image] {
+			effective[image] = target
+		}
+	}
+	p.perImageWarmTarget = effective
+}
+
+func (p *K8sWorkerPool) expireWarmDemandLocked(now time.Time) {
+	if p.warmDemandTarget > 0 && !p.warmDemandUntil.IsZero() && !now.Before(p.warmDemandUntil) {
+		p.warmDemandTarget = 0
+		p.warmDemandUntil = time.Time{}
+	}
+	for image, until := range p.perImageWarmDemandUntil {
+		if !until.IsZero() && !now.Before(until) {
+			delete(p.perImageWarmDemandTarget, image)
+			delete(p.perImageWarmDemandUntil, image)
+		}
+	}
 }
 
 // triggerPerImageReplenish kicks off a background spawn for image if the
@@ -2863,12 +3053,14 @@ func (p *K8sWorkerPool) SetWarmCapacityTarget(n int) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.minWorkers = n
+	p.warmBaseTarget = n
+	p.recomputeWarmTargetsLocked()
 }
 
 func (p *K8sWorkerPool) WarmCapacityTarget() int {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.recomputeWarmTargetsLocked()
 	return p.minWorkers
 }
 
@@ -2887,13 +3079,15 @@ func (p *K8sWorkerPool) SetPerImageWarmTargets(targets map[string]int) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.perImageWarmTarget = clean
+	p.perImageWarmBaseTarget = clean
+	p.recomputeWarmTargetsLocked()
 }
 
 // PerImageWarmTargets returns a snapshot of the per-image warm floor.
 func (p *K8sWorkerPool) PerImageWarmTargets() map[string]int {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.recomputeWarmTargetsLocked()
 	out := make(map[string]int, len(p.perImageWarmTarget))
 	for k, v := range p.perImageWarmTarget {
 		out[k] = v
@@ -2903,6 +3097,12 @@ func (p *K8sWorkerPool) PerImageWarmTargets() map[string]int {
 
 func boolPtr(b bool) *bool    { return &b }
 func int64Ptr(i int64) *int64 { return &i }
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
 
 // Compile-time interface check.
 var _ WorkerPool = (*K8sWorkerPool)(nil)

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -723,9 +723,12 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	}
 	pool.workers[stale.ID] = stale
 
-	spawnCalls := 0
+	backfillStarted := make(chan struct{}, 1)
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		spawnCalls++
+		select {
+		case backfillStarted <- struct{}{}:
+		default:
+		}
 		return nil
 	}
 
@@ -754,8 +757,10 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	if _, ok := pool.Worker(stale.ID); ok {
 		t.Fatal("expected stale worker to be retired")
 	}
-	if spawnCalls != 0 {
-		t.Fatalf("did not expect warm backfill spawn, got %d calls", spawnCalls)
+	select {
+	case <-backfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected stale worker miss to trigger warm backfill")
 	}
 }
 
@@ -1163,12 +1168,10 @@ func TestK8sPoolReserveSharedWorkerRuntimeMissDoesNotUseInMemoryFallback(t *test
 	}
 }
 
-// TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRuntimeStore
-// ensures the runtime-store-less warm-pool path honors per-org image pinning.
-// Without the image filter on findReservableWarmWorkerLocked,
-// ReserveSharedWorker would return a default-image warm worker to a pinned org
-// and the subsequent activation would fail with a version-mismatch error.
-func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRuntimeStore(t *testing.T) {
+// TestK8sPoolReserveSharedWorkerPinnedImageRuntimeMissBackfillsWithoutLocalFallback
+// ensures runtime-store mode does not reserve a mismatched local warm worker
+// after a durable claim miss, but still starts pinned-image warm backfill.
+func TestK8sPoolReserveSharedWorkerPinnedImageRuntimeMissBackfillsWithoutLocalFallback(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 
 	// A warm-idle worker built from the cluster default image — a tempting
@@ -1181,9 +1184,25 @@ func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRunt
 	pool.workers[defaultWorker.ID] = defaultWorker
 
 	pinnedImage := "duckgres-worker:abc123-duckdb1.5.1"
-	spawnCalls := 0
+	backfillStarted := make(chan struct{}, 1)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawnedFunc: func(image string) *configstore.WorkerRecord {
+			select {
+			case backfillStarted <- struct{}{}:
+			default:
+			}
+			return &configstore.WorkerRecord{
+				WorkerID:          42,
+				PodName:           "duckgres-worker-test-cp-42",
+				State:             configstore.WorkerStateSpawning,
+				Image:             image,
+				OwnerCPInstanceID: pool.cpInstanceID,
+			}
+		},
+	}
+	pool.runtimeStore = store
+
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		spawnCalls++
 		return nil
 	}
 
@@ -1199,8 +1218,16 @@ func TestK8sPoolReserveSharedWorkerSkipsWarmWorkerWithMismatchedImageWithoutRunt
 	if worker != nil {
 		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-	if spawnCalls != 0 {
-		t.Fatalf("did not expect foreground or async spawn, got %d calls", spawnCalls)
+	select {
+	case <-backfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected pinned-image miss to trigger per-image warm backfill")
+	}
+	if store.perImageSpawnImage != pinnedImage {
+		t.Fatalf("per-image backfill image = %q, want %q", store.perImageSpawnImage, pinnedImage)
+	}
+	if store.spawnCalls != 0 {
+		t.Fatalf("did not expect foreground org-bound spawn, got %d calls", store.spawnCalls)
 	}
 	if defaultWorker.SharedState().Lifecycle == WorkerLifecycleReserved {
 		t.Fatalf("default-image warm worker was reserved despite image mismatch")
@@ -1565,10 +1592,24 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 	}
 	pool.workers[7] = w
 
+	backfillStarted := make(chan struct{}, 1)
 	store := &captureRuntimeWorkerStore{
 		hotIdleClaimResult: &configstore.WorkerRecord{
 			WorkerID: 7,
 			Image:    "duckgres:v1",
+		},
+		perImageSpawnedFunc: func(image string) *configstore.WorkerRecord {
+			select {
+			case backfillStarted <- struct{}{}:
+			default:
+			}
+			return &configstore.WorkerRecord{
+				WorkerID:          42,
+				PodName:           "test-cp-worker-42",
+				Image:             image,
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+			}
 		},
 	}
 	pool.runtimeStore = store
@@ -1597,14 +1638,38 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 	if store.retireIdleOrHotIdleCalledReasons[0] != RetireReasonMismatchedVersion {
 		t.Fatalf("expected reason %q, got %q", RetireReasonMismatchedVersion, store.retireIdleOrHotIdleCalledReasons[0])
 	}
-	if store.spawnCalls != 0 || store.perImageSpawnCalls != 0 {
-		t.Fatalf("did not expect foreground or async spawn, got foreground=%d per_image=%d", store.spawnCalls, store.perImageSpawnCalls)
+	select {
+	case <-backfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected mismatched image miss to trigger per-image warm backfill")
+	}
+	if store.perImageSpawnImage != "duckgres:v2" {
+		t.Fatalf("expected per-image backfill for v2, got %q", store.perImageSpawnImage)
+	}
+	if store.spawnCalls != 0 {
+		t.Fatalf("did not expect foreground org-bound spawn, got %d calls", store.spawnCalls)
 	}
 }
 
-func TestK8sPoolReserveSharedWorkerColdRuntimeBackpressuresWithoutSpawning(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerColdRuntimeBackpressuresAndTriggersNeutralWarmup(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
-	store := &captureRuntimeWorkerStore{}
+	pool.SetWarmCapacityTarget(1)
+	backfillStarted := make(chan struct{}, 1)
+	store := &captureRuntimeWorkerStore{
+		neutralSpawnedFunc: func() *configstore.WorkerRecord {
+			select {
+			case backfillStarted <- struct{}{}:
+			default:
+			}
+			return &configstore.WorkerRecord{
+				WorkerID:          31,
+				PodName:           "duckgres-worker-test-cp-31",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				Image:             pool.workerImage,
+			}
+		},
+	}
 	pool.runtimeStore = store
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error { return nil }
 
@@ -1622,8 +1687,19 @@ func TestK8sPoolReserveSharedWorkerColdRuntimeBackpressuresWithoutSpawning(t *te
 	if store.spawnCalls != 0 {
 		t.Fatalf("did not expect foreground org-bound spawn, got %d calls", store.spawnCalls)
 	}
-	if store.neutralSpawnCalls != 0 || store.perImageSpawnCalls != 0 {
-		t.Fatalf("did not expect async warm backfill, got neutral=%d per_image=%d", store.neutralSpawnCalls, store.perImageSpawnCalls)
+	select {
+	case <-backfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected runtime cold miss to trigger neutral warm backfill")
+	}
+	if store.neutralSpawnOwnerCPID != pool.cpInstanceID {
+		t.Fatalf("expected warm owner cp-instance %q, got %q", pool.cpInstanceID, store.neutralSpawnOwnerCPID)
+	}
+	if store.neutralSpawnTarget != 2 {
+		t.Fatalf("expected neutral warm target 2, got %d", store.neutralSpawnTarget)
+	}
+	if store.neutralSpawnImage != pool.workerImage {
+		t.Fatalf("expected neutral warm image %q, got %q", pool.workerImage, store.neutralSpawnImage)
 	}
 }
 
@@ -1655,6 +1731,66 @@ func TestK8sPoolReserveSharedWorkerColdBackpressuresWhenWarmupBlockedByGlobalCap
 	}
 	if store.spawnCalls != 0 || store.neutralSpawnCalls != 0 || store.perImageSpawnCalls != 0 {
 		t.Fatalf("did not expect any foreground or async spawn while at cap: spawn=%d neutral=%d per_image=%d", store.spawnCalls, store.neutralSpawnCalls, store.perImageSpawnCalls)
+	}
+}
+
+func TestK8sPoolNeutralWarmDemandCoalescesRetriesWhileBackfillInFlight(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+
+	target, shouldStart := pool.bumpNeutralWarmDemandTarget()
+	if target != 1 || !shouldStart {
+		t.Fatalf("first miss target/start = %d/%v, want 1/true", target, shouldStart)
+	}
+
+	target, shouldStart = pool.bumpNeutralWarmDemandTarget()
+	if target != 1 || shouldStart {
+		t.Fatalf("retry while in flight target/start = %d/%v, want 1/false", target, shouldStart)
+	}
+
+	pool.mu.Lock()
+	pool.warmDemandLastBump = time.Now().Add(-warmCapacityDemandBumpInterval - time.Second)
+	pool.mu.Unlock()
+
+	target, shouldStart = pool.bumpNeutralWarmDemandTarget()
+	if target != 1 || shouldStart {
+		t.Fatalf("old retry while in flight target/start = %d/%v, want 1/false", target, shouldStart)
+	}
+
+	pool.finishNeutralWarmBackfill()
+	target, shouldStart = pool.bumpNeutralWarmDemandTarget()
+	if target != 2 || !shouldStart {
+		t.Fatalf("retry after backfill target/start = %d/%v, want 2/true", target, shouldStart)
+	}
+}
+
+func TestK8sPoolPerImageWarmDemandCoalescesRetriesWhileBackfillInFlight(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	image := "duckgres:v2"
+	pool.SetPerImageWarmTargets(map[string]int{image: 1})
+
+	target, shouldStart := pool.bumpPerImageWarmDemandTarget(image)
+	if target != 2 || !shouldStart {
+		t.Fatalf("first miss target/start = %d/%v, want 2/true", target, shouldStart)
+	}
+
+	target, shouldStart = pool.bumpPerImageWarmDemandTarget(image)
+	if target != 2 || shouldStart {
+		t.Fatalf("retry while in flight target/start = %d/%v, want 2/false", target, shouldStart)
+	}
+
+	pool.mu.Lock()
+	pool.perImageWarmDemandLastBump[image] = time.Now().Add(-warmCapacityDemandBumpInterval - time.Second)
+	pool.mu.Unlock()
+
+	target, shouldStart = pool.bumpPerImageWarmDemandTarget(image)
+	if target != 2 || shouldStart {
+		t.Fatalf("old retry while in flight target/start = %d/%v, want 2/false", target, shouldStart)
+	}
+
+	pool.finishPerImageWarmBackfill(image)
+	target, shouldStart = pool.bumpPerImageWarmDemandTarget(image)
+	if target != 3 || !shouldStart {
+		t.Fatalf("retry after backfill target/start = %d/%v, want 3/true", target, shouldStart)
 	}
 }
 
@@ -1901,11 +2037,14 @@ func TestK8sPoolHealthCheckLoopReplenishesWarmCapacityAfterIdleWorkerCrash(t *te
 	}
 }
 
-func TestK8sPoolReserveSharedWorkerColdPoolBackpressuresWithoutSpawning(t *testing.T) {
+func TestK8sPoolReserveSharedWorkerColdPoolBackpressuresAndTriggersWarmup(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
-	spawnCalls := 0
+	backfillStarted := make(chan struct{}, 1)
 	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
-		spawnCalls++
+		select {
+		case backfillStarted <- struct{}{}:
+		default:
+		}
 		return nil
 	}
 
@@ -1922,8 +2061,10 @@ func TestK8sPoolReserveSharedWorkerColdPoolBackpressuresWithoutSpawning(t *testi
 	if worker != nil {
 		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
-	if spawnCalls != 0 {
-		t.Fatalf("did not expect warm backfill spawn, got %d calls", spawnCalls)
+	select {
+	case <-backfillStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected cold miss to trigger warm backfill")
 	}
 }
 

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -24,7 +24,7 @@ func (e *WarmCapacityExhaustedError) Error() string {
 	if retryAfter <= 0 {
 		retryAfter = DefaultWarmCapacityRetryAfter
 	}
-	return fmt.Sprintf("warm worker capacity exhausted; retry in about %s", retryAfter.Round(time.Second))
+	return fmt.Sprintf("warm worker capacity exhausted; additional capacity is starting, retry in about %s", retryAfter.Round(time.Second))
 }
 
 func NewWarmCapacityExhaustedError(retryAfter time.Duration) error {


### PR DESCRIPTION
## Summary
- trigger async warm backfill after warm-capacity misses, including runtime-store durable-claim misses
- layer temporary demand targets on top of chart/env warm-pool targets
- coalesce retries while a warm backfill is in flight so retry loops do not stampede pod creation or ratchet targets on every attempt

## Tests
- go test -count=1 ./controlplane
- go test -count=1 -tags kubernetes ./controlplane
- go test -count=1 ./tests/k8s -run TestIsTransientDBError