### PR TITLE
feat(provisioner): Lakekeeper-as-Iceberg-catalog — PR3 (controller trigger)

### DIFF
--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/posthog/duckgres/duckdbservice"
 	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/lakekeeperbroker"
 )
 
 // Each duckgres binary owns its own package-main version/commit/date because
@@ -247,6 +248,23 @@ func main() {
 	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create data directory %q: %s\n", cfg.DataDir, err)
 		os.Exit(1)
+	}
+
+	// Lakekeeper OIDC SA-token broker. Started when DUCKGRES_LAKEKEEPER_TOKEN_PATH
+	// is set (typically by the duckling pod spec, mounting a projected SA
+	// token volume at /var/run/secrets/lakekeeper/token). DuckDB's iceberg
+	// extension POSTs to OAUTH2_SERVER_URI=http://127.0.0.1:9876/token to
+	// fetch a bearer; the broker reads the projected file and hands it back.
+	// When the env var is unset, no broker is started — preserves the
+	// allowall + NetworkPolicy posture for clusters that haven't enabled
+	// OIDC on Lakekeeper yet.
+	if tokenPath := configloader.Env("DUCKGRES_LAKEKEEPER_TOKEN_PATH", ""); tokenPath != "" {
+		broker := lakekeeperbroker.New(tokenPath)
+		if err := broker.ListenAndServe(lakekeeperbroker.DefaultAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to start lakekeeper broker on %s: %s\n", lakekeeperbroker.DefaultAddr, err)
+			os.Exit(1)
+		}
+		slog.Info("Lakekeeper OIDC broker started.", "addr", lakekeeperbroker.DefaultAddr, "token_path", tokenPath)
 	}
 
 	// No initMetrics() here. In control-plane mode all worker pods would

--- a/controlplane/lakekeeper_inputs.go
+++ b/controlplane/lakekeeper_inputs.go
@@ -1,0 +1,201 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+)
+
+// Environment variables that drive the Lakekeeper provisioner. The toggle is
+// off by default so existing deployments are unaffected until an operator
+// explicitly opts in.
+const (
+	envLakekeeperEnabled = "DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED"
+
+	// Dev/orbstack fallback inputs, used only when an org has no
+	// Crossplane-provisioned Duckling CR to read infrastructure from
+	// (local MinIO + a plain Postgres). In prod these come from the CR.
+	envLakekeeperAdminDSN   = "DUCKGRES_LAKEKEEPER_ADMIN_DSN"
+	envLakekeeperPGHost     = "DUCKGRES_LAKEKEEPER_PG_HOST"
+	envLakekeeperPGPort     = "DUCKGRES_LAKEKEEPER_PG_PORT"
+	envLakekeeperPGSSLMode  = "DUCKGRES_LAKEKEEPER_PG_SSLMODE"
+	envLakekeeperS3Bucket   = "DUCKGRES_LAKEKEEPER_S3_BUCKET"
+	envLakekeeperS3Region   = "DUCKGRES_LAKEKEEPER_S3_REGION"
+	envLakekeeperS3Endpoint = "DUCKGRES_LAKEKEEPER_S3_ENDPOINT"
+	envLakekeeperS3Flavor   = "DUCKGRES_LAKEKEEPER_S3_FLAVOR"
+	envLakekeeperS3KeyID    = "DUCKGRES_LAKEKEEPER_S3_ACCESS_KEY_ID"
+	envLakekeeperS3Secret   = "DUCKGRES_LAKEKEEPER_S3_SECRET_ACCESS_KEY"
+)
+
+// lakekeeperProvisionerEnabled reports whether the control plane should wire
+// the Lakekeeper provisioner branch into the provisioning controller.
+func lakekeeperProvisionerEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envLakekeeperEnabled)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// newLakekeeperInputsResolver builds the per-org ProvisioningInputs resolver
+// the provisioning controller calls before EnsureForOrg.
+//
+// Two sources, in priority order:
+//
+//  1. The Crossplane-provisioned Duckling CR (prod). The CR's metadata-store
+//     master credentials double as the admin connection that can CREATE the
+//     lakekeeper_<orgid> database/role, and its data-store bucket is the S3
+//     warehouse Lakekeeper hands out. The Lakekeeper pod uses its own IRSA
+//     identity for S3 (no static creds), so we leave them empty.
+//
+//  2. Environment-configured fallback (dev/orbstack with MinIO). Used when no
+//     Duckling CR resolver is available, or the CR has no usable
+//     metadata-store/data-store yet.
+//
+// KubernetesAuthAudiences is always empty here: this wires the allowall +
+// NetworkPolicy deployment shape. Enabling OIDC SA-token auth is a separate,
+// flag-day change (see ProvisioningInputs.KubernetesAuthAudiences).
+func newLakekeeperInputsResolver(
+	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error),
+) provisioner.LakekeeperInputsResolver {
+	return func(ctx context.Context, w *configstore.ManagedWarehouse) (provisioner.ProvisioningInputs, error) {
+		if resolveDucklingStatus != nil {
+			in, ok, err := lakekeeperInputsFromDuckling(ctx, resolveDucklingStatus, w.OrgID)
+			if err != nil {
+				// CR exists but is malformed/incomplete — fall through to the
+				// env fallback rather than hard-failing, mirroring how
+				// BuildActivationRequest degrades to the config-store path.
+				if env, ok := lakekeeperInputsFromEnv(); ok {
+					return env, nil
+				}
+				return provisioner.ProvisioningInputs{}, fmt.Errorf("resolve lakekeeper inputs for org %q from duckling CR: %w", w.OrgID, err)
+			}
+			if ok {
+				return in, nil
+			}
+		}
+		if env, ok := lakekeeperInputsFromEnv(); ok {
+			return env, nil
+		}
+		return provisioner.ProvisioningInputs{}, fmt.Errorf("no lakekeeper provisioning inputs for org %q: no usable Duckling CR and %s/%s/%s not set",
+			w.OrgID, envLakekeeperAdminDSN, envLakekeeperS3Bucket, envLakekeeperS3Region)
+	}
+}
+
+// lakekeeperInputsFromDuckling derives inputs from the Duckling CR status.
+// Returns ok=false (no error) when the resolver simply has no CR for the org,
+// so the caller can fall back to env config without logging it as a failure.
+func lakekeeperInputsFromDuckling(
+	ctx context.Context,
+	resolve func(context.Context, string) (*provisioner.DucklingStatus, error),
+	orgID string,
+) (provisioner.ProvisioningInputs, bool, error) {
+	status, err := resolve(ctx, orgID)
+	if err != nil {
+		return provisioner.ProvisioningInputs{}, false, nil
+	}
+	if status == nil || status.MetadataStore.Endpoint == "" {
+		return provisioner.ProvisioningInputs{}, false, nil
+	}
+	if status.MetadataStore.Password == "" || status.MetadataStore.User == "" || status.MetadataStore.Database == "" {
+		return provisioner.ProvisioningInputs{}, false, fmt.Errorf("duckling CR for org %q has incomplete metadata-store credentials", orgID)
+	}
+	if status.DataStore.BucketName == "" || status.DataStore.S3Region == "" {
+		return provisioner.ProvisioningInputs{}, false, fmt.Errorf("duckling CR for org %q has no data-store bucket/region", orgID)
+	}
+
+	// Admin DDL (CREATE DATABASE/ROLE) goes to the direct Aurora endpoint, not
+	// the PgBouncer pooler — transaction pooling breaks CREATE DATABASE and the
+	// session-level statements EnsureRole runs. We connect to the existing
+	// metadata-store database; CREATE DATABASE can be issued from any database.
+	adminDSN := buildAdminURLDSN(
+		status.MetadataStore.Endpoint, 5432,
+		status.MetadataStore.User, status.MetadataStore.Password,
+		status.MetadataStore.Database, "require",
+	)
+
+	return provisioner.ProvisioningInputs{
+		AdminDSN: adminDSN,
+		// The Lakekeeper pod also connects to the direct endpoint: it runs its
+		// own migrations and connection pool, which a transaction pooler would
+		// break.
+		PGHost:    status.MetadataStore.Endpoint,
+		PGPort:    5432,
+		PGSSLMode: "require",
+		S3: provisioner.S3StorageConfig{
+			Bucket: status.DataStore.BucketName,
+			// Keep the catalog's data under a stable prefix so it never
+			// collides with DuckLake's own layout in the shared bucket.
+			KeyPrefix: "lakekeeper",
+			Region:    status.DataStore.S3Region,
+			Flavor:    "aws",
+			// Prod: Lakekeeper uses its pod IRSA identity (no static creds).
+		},
+		// Allowall + NetworkPolicy deployment shape — no OIDC audiences yet.
+		KubernetesAuthAudiences: nil,
+	}, true, nil
+}
+
+// lakekeeperInputsFromEnv builds inputs from environment variables for
+// dev/orbstack (MinIO). Returns ok=false when the minimum set isn't present.
+func lakekeeperInputsFromEnv() (provisioner.ProvisioningInputs, bool) {
+	adminDSN := strings.TrimSpace(os.Getenv(envLakekeeperAdminDSN))
+	bucket := strings.TrimSpace(os.Getenv(envLakekeeperS3Bucket))
+	region := strings.TrimSpace(os.Getenv(envLakekeeperS3Region))
+	if adminDSN == "" || bucket == "" || region == "" {
+		return provisioner.ProvisioningInputs{}, false
+	}
+
+	pgHost := strings.TrimSpace(os.Getenv(envLakekeeperPGHost))
+	pgPort := int32(0)
+	if v := strings.TrimSpace(os.Getenv(envLakekeeperPGPort)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			pgPort = int32(n)
+		}
+	}
+	sslMode := strings.TrimSpace(os.Getenv(envLakekeeperPGSSLMode))
+	if sslMode == "" {
+		sslMode = "require"
+	}
+	flavor := strings.TrimSpace(os.Getenv(envLakekeeperS3Flavor))
+	if flavor == "" {
+		flavor = "aws"
+	}
+
+	return provisioner.ProvisioningInputs{
+		AdminDSN:  adminDSN,
+		PGHost:    pgHost,
+		PGPort:    pgPort,
+		PGSSLMode: sslMode,
+		S3: provisioner.S3StorageConfig{
+			Bucket:                bucket,
+			Region:                region,
+			Endpoint:              strings.TrimSpace(os.Getenv(envLakekeeperS3Endpoint)),
+			Flavor:                flavor,
+			StaticAccessKeyID:     strings.TrimSpace(os.Getenv(envLakekeeperS3KeyID)),
+			StaticAccessKeySecret: strings.TrimSpace(os.Getenv(envLakekeeperS3Secret)),
+		},
+		KubernetesAuthAudiences: nil,
+	}, true
+}
+
+// buildAdminURLDSN renders a pgx-compatible URL-style DSN. URL form is what
+// the provisioner's reDSN rewrites when it scopes a connection to a specific
+// database, so we emit that form here.
+func buildAdminURLDSN(host string, port int, user, password, dbName, sslMode string) string {
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   "/" + dbName,
+	}
+	q := u.Query()
+	q.Set("sslmode", sslMode)
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/controlplane/lakekeeper_inputs_test.go
+++ b/controlplane/lakekeeper_inputs_test.go
@@ -1,0 +1,164 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+)
+
+func ducklingStatusWithWarehouse() *provisioner.DucklingStatus {
+	s := &provisioner.DucklingStatus{}
+	s.MetadataStore.Endpoint = "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com"
+	s.MetadataStore.PgBouncerEndpoint = "pgb-acme.svc:6432"
+	s.MetadataStore.User = "ducklingacme"
+	s.MetadataStore.Password = "s3cr3t"
+	s.MetadataStore.Database = "ducklingacme"
+	s.DataStore.BucketName = "posthog-duckling-acme"
+	s.DataStore.S3Region = "us-east-1"
+	s.IAMRoleARN = "arn:aws:iam::123:role/duckling-acme"
+	return s
+}
+
+func TestResolverFromDucklingCR(t *testing.T) {
+	// No env fallback configured, so this must come purely from the CR.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		return ducklingStatusWithWarehouse(), nil
+	}
+	r := newLakekeeperInputsResolver(resolve)
+
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "acme"})
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+
+	// Admin DSN must target the DIRECT endpoint (not the PgBouncer pooler),
+	// be URL-form, carry the master creds, and request sslmode=require.
+	u, perr := url.Parse(in.AdminDSN)
+	if perr != nil {
+		t.Fatalf("admin DSN not a URL: %q (%v)", in.AdminDSN, perr)
+	}
+	if u.Hostname() != "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com" {
+		t.Errorf("admin DSN host = %q, want direct RDS endpoint (not pgbouncer)", u.Hostname())
+	}
+	if strings.Contains(in.AdminDSN, "pgb-acme") || strings.Contains(in.AdminDSN, "6432") {
+		t.Errorf("admin DSN must not use the PgBouncer pooler: %q", in.AdminDSN)
+	}
+	if pw, _ := u.User.Password(); pw != "s3cr3t" || u.User.Username() != "ducklingacme" {
+		t.Errorf("admin DSN creds wrong: %q", u.Redacted())
+	}
+	if got := u.Query().Get("sslmode"); got != "require" {
+		t.Errorf("sslmode = %q, want require", got)
+	}
+
+	if in.PGHost != "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com" || in.PGPort != 5432 {
+		t.Errorf("PGHost/PGPort = %q/%d, want direct endpoint:5432", in.PGHost, in.PGPort)
+	}
+	if in.PGSSLMode != "require" {
+		t.Errorf("PGSSLMode = %q, want require", in.PGSSLMode)
+	}
+	if in.S3.Bucket != "posthog-duckling-acme" || in.S3.Region != "us-east-1" || in.S3.Flavor != "aws" {
+		t.Errorf("S3 = %+v, want bucket/region/aws from CR", in.S3)
+	}
+	if in.S3.StaticAccessKeyID != "" || in.S3.StaticAccessKeySecret != "" {
+		t.Errorf("prod S3 must use pod IRSA, not static creds: %+v", in.S3)
+	}
+	if len(in.KubernetesAuthAudiences) != 0 {
+		t.Errorf("expected allowall mode (no audiences), got %v", in.KubernetesAuthAudiences)
+	}
+}
+
+func TestResolverFromEnvFallback(t *testing.T) {
+	t.Setenv(envLakekeeperAdminDSN, "postgres://admin:pw@127.0.0.1:5432/postgres?sslmode=disable")
+	t.Setenv(envLakekeeperPGHost, "127.0.0.1")
+	t.Setenv(envLakekeeperPGPort, "5432")
+	t.Setenv(envLakekeeperPGSSLMode, "disable")
+	t.Setenv(envLakekeeperS3Bucket, "warehouse")
+	t.Setenv(envLakekeeperS3Region, "us-east-1")
+	t.Setenv(envLakekeeperS3Endpoint, "http://minio.minio.svc:9000")
+	t.Setenv(envLakekeeperS3Flavor, "s3-compat")
+	t.Setenv(envLakekeeperS3KeyID, "minioadmin")
+	t.Setenv(envLakekeeperS3Secret, "minioadmin")
+
+	// nil resolver → straight to env fallback.
+	r := newLakekeeperInputsResolver(nil)
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "dev"})
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if in.AdminDSN == "" || in.PGHost != "127.0.0.1" || in.PGPort != 5432 {
+		t.Errorf("env inputs wrong: %+v", in)
+	}
+	if in.PGSSLMode != "disable" {
+		t.Errorf("PGSSLMode = %q, want disable", in.PGSSLMode)
+	}
+	if in.S3.Endpoint != "http://minio.minio.svc:9000" || in.S3.Flavor != "s3-compat" {
+		t.Errorf("S3 = %+v, want MinIO endpoint + s3-compat", in.S3)
+	}
+	if in.S3.StaticAccessKeyID != "minioadmin" || in.S3.StaticAccessKeySecret != "minioadmin" {
+		t.Errorf("S3 static creds not propagated: %+v", in.S3)
+	}
+}
+
+func TestResolverDucklingErrorFallsBackToEnv(t *testing.T) {
+	t.Setenv(envLakekeeperAdminDSN, "postgres://admin:pw@127.0.0.1:5432/postgres?sslmode=disable")
+	t.Setenv(envLakekeeperS3Bucket, "warehouse")
+	t.Setenv(envLakekeeperS3Region, "us-east-1")
+
+	// CR resolver errors (e.g. no Duckling for this org) → env fallback used.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		return nil, errors.New("duckling not found")
+	}
+	r := newLakekeeperInputsResolver(resolve)
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "dev"})
+	if err != nil {
+		t.Fatalf("expected env fallback, got error: %v", err)
+	}
+	if in.S3.Bucket != "warehouse" {
+		t.Errorf("expected env inputs, got %+v", in)
+	}
+}
+
+func TestResolverIncompleteCRWithoutEnvErrors(t *testing.T) {
+	// CR present but missing bucket, and no env configured → hard error.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		s := &provisioner.DucklingStatus{}
+		s.MetadataStore.Endpoint = "host"
+		s.MetadataStore.User = "u"
+		s.MetadataStore.Password = "p"
+		s.MetadataStore.Database = "d"
+		// DataStore left empty.
+		return s, nil
+	}
+	r := newLakekeeperInputsResolver(resolve)
+	if _, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "acme"}); err == nil {
+		t.Fatal("expected error for incomplete CR with no env fallback")
+	}
+}
+
+func TestResolverNoSourcesErrors(t *testing.T) {
+	r := newLakekeeperInputsResolver(nil)
+	if _, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "x"}); err == nil {
+		t.Fatal("expected error when neither CR nor env provide inputs")
+	}
+}
+
+func TestLakekeeperProvisionerEnabledToggle(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"", false}, {"true", true}, {"1", true}, {"yes", true}, {"TRUE", true}, {"false", false}, {"0", false},
+	} {
+		t.Setenv(envLakekeeperEnabled, tc.val)
+		if got := lakekeeperProvisionerEnabled(); got != tc.want {
+			t.Errorf("enabled(%q) = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -347,6 +347,19 @@ func SetupMultiTenant(
 	if err != nil {
 		slog.Warn("Provisioning controller unavailable.", "error", err)
 	} else {
+		// Opt-in: enable the per-org Lakekeeper provisioning branch. Off by
+		// default so existing deploys are unaffected. Best-effort — if the
+		// K8s client can't be built we log and leave the controller running
+		// without the Lakekeeper branch (S3-Tables warehouses still work).
+		if lakekeeperProvisionerEnabled() {
+			if k8sClient, lkErr := provisioner.NewLakekeeperK8sClient(); lkErr != nil {
+				slog.Warn("Lakekeeper provisioner enabled but K8s client unavailable; skipping.", "error", lkErr)
+			} else {
+				lkProv := provisioner.NewLakekeeperProvisioner(store, k8sClient)
+				provCtrl.WithLakekeeperProvisioner(lkProv, newLakekeeperInputsResolver(resolveDucklingStatus))
+				slog.Info("Lakekeeper provisioner enabled (allowall + NetworkPolicy mode).")
+			}
+		}
 		go provCtrl.Run(context.Background())
 	}
 

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -36,7 +37,24 @@ type Controller struct {
 	duckling     *DucklingClient
 	pollInterval time.Duration
 	probe        MetadataProbe
+
+	// Lakekeeper-side reconcile dependencies. All optional: if any is nil
+	// (e.g. in older deployments or unit tests that don't exercise the
+	// Lakekeeper path), reconcileLakekeeper is skipped silently.
+	lakekeeperProvisioner *LakekeeperProvisioner
+	lakekeeperInputs      LakekeeperInputsResolver
 }
+
+// LakekeeperInputsResolver is the function shape the controller uses to
+// build ProvisioningInputs for a given warehouse. Resolves things the
+// configstore doesn't carry directly: the admin Postgres DSN (from a
+// K8s Secret managed by Crossplane), the PG host the Lakekeeper pod uses
+// to reach the cluster, and the S3 storage profile.
+//
+// Defined as a function rather than a method on Controller so tests can
+// substitute a fake and so the convention for sourcing the admin DSN
+// (Crossplane-emitted Secret name pattern) lives outside this package.
+type LakekeeperInputsResolver func(ctx context.Context, w *configstore.ManagedWarehouse) (ProvisioningInputs, error)
 
 // NewController creates a provisioning controller. Returns an error if the
 // Kubernetes client cannot be initialized (e.g., not running in-cluster).
@@ -66,6 +84,16 @@ func NewControllerWithClient(store WarehouseStore, dc *DucklingClient, pollInter
 // SetProbe overrides the metadata-store probe. Used by tests.
 func (c *Controller) SetProbe(p MetadataProbe) {
 	c.probe = p
+}
+
+// WithLakekeeperProvisioner enables the Lakekeeper reconcile branch.
+// Both p and inputs must be non-nil; otherwise the controller's
+// Lakekeeper reconcile step stays inert. inputs is the function the
+// controller calls to build ProvisioningInputs for a given warehouse.
+func (c *Controller) WithLakekeeperProvisioner(p *LakekeeperProvisioner, inputs LakekeeperInputsResolver) *Controller {
+	c.lakekeeperProvisioner = p
+	c.lakekeeperInputs = inputs
+	return c
 }
 
 // Run starts the reconciliation loop. Blocks until ctx is cancelled.
@@ -377,6 +405,57 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 			}
 		}
 	}
+
+	// Lakekeeper reconcile runs after the iceberg status propagation so we
+	// have the most recent view of w.Iceberg in memory. Independent of the
+	// Duckling state machine — provisioning a Lakekeeper for an org doesn't
+	// depend on, and doesn't block, the warehouse top-level state.
+	c.reconcileLakekeeper(ctx, w)
+}
+
+// reconcileLakekeeper provisions a per-org Lakekeeper instance when the
+// warehouse selects the lakekeeper backend and isn't yet provisioned.
+// Idempotent: a warehouse with LakekeeperEndpoint already populated is a
+// no-op. ErrBootstrapPending from the underlying EnsureForOrg is logged
+// at debug and treated as "retry on the next tick" — the controller's
+// poll loop is the requeue mechanism.
+//
+// Skipped silently when the controller wasn't built with
+// WithLakekeeperProvisioner (e.g. in deployments where the operator
+// isn't installed, or in tests).
+func (c *Controller) reconcileLakekeeper(ctx context.Context, w *configstore.ManagedWarehouse) {
+	if c.lakekeeperProvisioner == nil || c.lakekeeperInputs == nil {
+		return
+	}
+	if !w.Iceberg.Enabled {
+		return
+	}
+	if w.Iceberg.ResolvedBackend() != configstore.IcebergBackendLakekeeper {
+		return
+	}
+	if w.Iceberg.LakekeeperEndpoint != "" {
+		// Already provisioned. Future drift correction (e.g. image bumps)
+		// will be handled by the operator's reconcile loop reading the CR
+		// spec on every tick; nothing to do here.
+		return
+	}
+
+	log := slog.With("org", w.OrgID, "phase", "lakekeeper")
+
+	inputs, err := c.lakekeeperInputs(ctx, w)
+	if err != nil {
+		log.Warn("Failed to resolve lakekeeper provisioning inputs.", "error", err)
+		return
+	}
+	if err := c.lakekeeperProvisioner.EnsureForOrg(ctx, w, inputs); err != nil {
+		if errors.Is(err, ErrBootstrapPending) {
+			log.Debug("Lakekeeper bootstrap still pending; next tick will retry.")
+			return
+		}
+		log.Warn("Lakekeeper provisioning failed.", "error", err)
+		return
+	}
+	log.Info("Lakekeeper provisioning completed.")
 }
 
 // addIcebergStatusUpdates copies the Duckling's reported iceberg status

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -87,10 +87,16 @@ func (c *Controller) SetProbe(p MetadataProbe) {
 }
 
 // WithLakekeeperProvisioner enables the Lakekeeper reconcile branch.
-// Both p and inputs must be non-nil; otherwise the controller's
-// Lakekeeper reconcile step stays inert. inputs is the function the
-// controller calls to build ProvisioningInputs for a given warehouse.
+// Both p and inputs must be non-nil — partial wiring would silently
+// disable the reconcile step and that's a misconfiguration we'd rather
+// surface at startup than at the first activation.
 func (c *Controller) WithLakekeeperProvisioner(p *LakekeeperProvisioner, inputs LakekeeperInputsResolver) *Controller {
+	if p == nil {
+		panic("WithLakekeeperProvisioner: provisioner is nil; call NewLakekeeperProvisioner first")
+	}
+	if inputs == nil {
+		panic("WithLakekeeperProvisioner: inputs resolver is nil")
+	}
 	c.lakekeeperProvisioner = p
 	c.lakekeeperInputs = inputs
 	return c
@@ -390,6 +396,11 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 	// would only land in the configstore if the warehouse was still in
 	// Provisioning when the composition completed — never on a re-enable.
 	if w.Iceberg.Enabled {
+		// TODO: this is the third c.duckling.Get-equivalent call in this
+		// function (after GetPgBouncerEnabled + GetIcebergEnabled). All
+		// three parse the same CR. Worth consolidating to a single fetch
+		// once another caller adds a fourth — for now the extra
+		// round-trips only hit warehouses where iceberg is enabled.
 		status, err := c.duckling.Get(ctx, w.OrgID)
 		if err != nil {
 			log.Warn("Failed to read Duckling status for iceberg propagation.", "error", err)
@@ -402,15 +413,42 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 				log.Warn("Failed to persist iceberg status to configstore.", "error", err)
 			} else {
 				log.Info("Iceberg status persisted to configstore.", "updates", updates)
+				// Mirror the persisted updates onto the in-memory w so
+				// downstream reconcile steps (notably reconcileLakekeeper)
+				// see the fresh values without a re-read round-trip.
+				applyIcebergUpdatesToWarehouse(w, updates)
 			}
 		}
 	}
 
-	// Lakekeeper reconcile runs after the iceberg status propagation so we
-	// have the most recent view of w.Iceberg in memory. Independent of the
-	// Duckling state machine — provisioning a Lakekeeper for an org doesn't
-	// depend on, and doesn't block, the warehouse top-level state.
+	// Lakekeeper reconcile is independent of the Duckling state machine —
+	// provisioning a Lakekeeper for an org doesn't depend on, and doesn't
+	// block, the warehouse top-level state.
 	c.reconcileLakekeeper(ctx, w)
+}
+
+// applyIcebergUpdatesToWarehouse mirrors the column-update map onto the
+// in-memory warehouse struct so subsequent reconcile steps in the same
+// tick see the values that were just persisted, without a second store
+// read. Mirrors the column → field mapping used by the configstore's
+// UpdateWarehouseState GORM call (which writes by column name).
+//
+// Only the iceberg_* columns reconcileReady actually writes are handled
+// here; if a future caller passes other column names through this
+// function, extend the switch alongside.
+func applyIcebergUpdatesToWarehouse(w *configstore.ManagedWarehouse, updates map[string]interface{}) {
+	for k, v := range updates {
+		switch k {
+		case "iceberg_table_bucket_arn":
+			w.Iceberg.TableBucketArn = v.(string)
+		case "iceberg_region":
+			w.Iceberg.Region = v.(string)
+		case "iceberg_namespace":
+			w.Iceberg.Namespace = v.(string)
+		case "iceberg_state":
+			w.IcebergState = v.(configstore.ManagedWarehouseProvisioningState)
+		}
+	}
 }
 
 // reconcileLakekeeper provisions a per-org Lakekeeper instance when the

--- a/controlplane/provisioner/controller_lakekeeper_test.go
+++ b/controlplane/provisioner/controller_lakekeeper_test.go
@@ -1,0 +1,158 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// fakeLakekeeperProvisioner tracks EnsureForOrg calls.
+type fakeLakekeeperProvisioner struct {
+	calls   []string
+	returns []error // popped FIFO; nil after exhausted
+}
+
+func (f *fakeLakekeeperProvisioner) next() error {
+	if len(f.returns) == 0 {
+		return nil
+	}
+	r := f.returns[0]
+	f.returns = f.returns[1:]
+	return r
+}
+
+// Synthetic wrapper for the controller test — the real provisioner needs a
+// full K8s client. The controller calls EnsureForOrg via the
+// LakekeeperProvisioner pointer; here we substitute a stub by building
+// a thin pseudo-provisioner around the fake's EnsureForOrg.
+//
+// Implemented by capturing calls inline rather than depending on the real
+// LakekeeperProvisioner — we want to test the controller's branch logic,
+// not re-test the provisioner itself.
+type stubLakekeeperProvisioner struct {
+	track *fakeLakekeeperProvisioner
+}
+
+// We replicate just enough of LakekeeperProvisioner's surface to let the
+// controller call EnsureForOrg. The controller holds a *LakekeeperProvisioner,
+// not an interface — so the test substitutes by using a builder shortcut:
+// the controller's reconcileLakekeeper method is exercised via a custom
+// constructor that injects a function rather than a real provisioner.
+//
+// To avoid that refactor pressure, we change strategy: the test exercises
+// reconcileLakekeeper by wrapping the call. We patch by replacing the
+// EnsureForOrg function via a method indirection. Cleaner: just test
+// what reconcileLakekeeper observes (no-op vs call) with provided
+// inputs/state, leaving the call-counting to follow-up code review.
+
+func TestReconcileLakekeeper_SkipsWhenProvisionerNotConfigured(t *testing.T) {
+	store := newFakeStore()
+	store.warehouses["acme"] = &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+	c := NewControllerWithClient(store, nil, 0) // no lakekeeperProvisioner
+	// Should be a silent no-op — no panic, no calls, no err.
+	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
+}
+
+func TestReconcileLakekeeper_SkipsWhenIcebergDisabled(t *testing.T) {
+	called := false
+	store := newFakeStore()
+	store.warehouses["acme"] = &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: false, // <-- gated off
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+	c := NewControllerWithClient(store, nil, 0)
+	c.lakekeeperProvisioner = &LakekeeperProvisioner{} // present but unused
+	c.lakekeeperInputs = func(_ context.Context, _ *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+		called = true
+		return ProvisioningInputs{}, nil
+	}
+	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
+	if called {
+		t.Errorf("inputs resolver should not be called when Iceberg.Enabled=false")
+	}
+}
+
+func TestReconcileLakekeeper_SkipsWhenBackendIsS3Tables(t *testing.T) {
+	called := false
+	store := newFakeStore()
+	store.warehouses["acme"] = &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendS3Tables,
+		},
+	}
+	c := NewControllerWithClient(store, nil, 0)
+	c.lakekeeperProvisioner = &LakekeeperProvisioner{}
+	c.lakekeeperInputs = func(_ context.Context, _ *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+		called = true
+		return ProvisioningInputs{}, nil
+	}
+	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
+	if called {
+		t.Errorf("inputs resolver should not be called when Backend=s3_tables")
+	}
+}
+
+func TestReconcileLakekeeper_SkipsWhenAlreadyProvisioned(t *testing.T) {
+	called := false
+	store := newFakeStore()
+	store.warehouses["acme"] = &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled:            true,
+			Backend:            configstore.IcebergBackendLakekeeper,
+			LakekeeperEndpoint: "http://lk-acme.lakekeeper.svc:8181/catalog",
+		},
+	}
+	c := NewControllerWithClient(store, nil, 0)
+	c.lakekeeperProvisioner = &LakekeeperProvisioner{}
+	c.lakekeeperInputs = func(_ context.Context, _ *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+		called = true
+		return ProvisioningInputs{}, nil
+	}
+	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
+	if called {
+		t.Errorf("inputs resolver should not be called when LakekeeperEndpoint already set")
+	}
+}
+
+func TestReconcileLakekeeper_LogsAndContinuesOnInputResolverError(t *testing.T) {
+	store := newFakeStore()
+	store.warehouses["acme"] = &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+	c := NewControllerWithClient(store, nil, 0)
+	c.lakekeeperProvisioner = &LakekeeperProvisioner{}
+	c.lakekeeperInputs = func(_ context.Context, _ *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+		return ProvisioningInputs{}, errors.New("crossplane secret not found")
+	}
+	// Should not panic; the controller logs at warn level and moves on so
+	// the poll loop retries on the next tick.
+	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
+}
+
+// Compile-time gate to keep the stub helpers from being flagged as unused
+// while the fake's full surface evolves.
+var _ = stubLakekeeperProvisioner{track: &fakeLakekeeperProvisioner{}}

--- a/controlplane/provisioner/controller_lakekeeper_test.go
+++ b/controlplane/provisioner/controller_lakekeeper_test.go
@@ -4,50 +4,17 @@ package provisioner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// fakeLakekeeperProvisioner tracks EnsureForOrg calls.
-type fakeLakekeeperProvisioner struct {
-	calls   []string
-	returns []error // popped FIFO; nil after exhausted
-}
-
-func (f *fakeLakekeeperProvisioner) next() error {
-	if len(f.returns) == 0 {
-		return nil
-	}
-	r := f.returns[0]
-	f.returns = f.returns[1:]
-	return r
-}
-
-// Synthetic wrapper for the controller test — the real provisioner needs a
-// full K8s client. The controller calls EnsureForOrg via the
-// LakekeeperProvisioner pointer; here we substitute a stub by building
-// a thin pseudo-provisioner around the fake's EnsureForOrg.
-//
-// Implemented by capturing calls inline rather than depending on the real
-// LakekeeperProvisioner — we want to test the controller's branch logic,
-// not re-test the provisioner itself.
-type stubLakekeeperProvisioner struct {
-	track *fakeLakekeeperProvisioner
-}
-
-// We replicate just enough of LakekeeperProvisioner's surface to let the
-// controller call EnsureForOrg. The controller holds a *LakekeeperProvisioner,
-// not an interface — so the test substitutes by using a builder shortcut:
-// the controller's reconcileLakekeeper method is exercised via a custom
-// constructor that injects a function rather than a real provisioner.
-//
-// To avoid that refactor pressure, we change strategy: the test exercises
-// reconcileLakekeeper by wrapping the call. We patch by replacing the
-// EnsureForOrg function via a method indirection. Cleaner: just test
-// what reconcileLakekeeper observes (no-op vs call) with provided
-// inputs/state, leaving the call-counting to follow-up code review.
 
 func TestReconcileLakekeeper_SkipsWhenProvisionerNotConfigured(t *testing.T) {
 	store := newFakeStore()
@@ -153,6 +120,138 @@ func TestReconcileLakekeeper_LogsAndContinuesOnInputResolverError(t *testing.T) 
 	c.reconcileLakekeeper(context.Background(), store.warehouses["acme"])
 }
 
-// Compile-time gate to keep the stub helpers from being flagged as unused
-// while the fake's full surface evolves.
-var _ = stubLakekeeperProvisioner{track: &fakeLakekeeperProvisioner{}}
+func TestWithLakekeeperProvisioner_PanicsOnNilProvisioner(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil provisioner")
+		}
+	}()
+	NewControllerWithClient(newFakeStore(), nil, 0).
+		WithLakekeeperProvisioner(nil, func(context.Context, *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+			return ProvisioningInputs{}, nil
+		})
+}
+
+func TestWithLakekeeperProvisioner_PanicsOnNilResolver(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil resolver")
+		}
+	}()
+	NewControllerWithClient(newFakeStore(), nil, 0).
+		WithLakekeeperProvisioner(&LakekeeperProvisioner{}, nil)
+}
+
+// TestReconcileLakekeeper_HappyPath exercises the positive case where all
+// gates pass: a real LakekeeperProvisioner (built with fakes) is invoked,
+// the inputs resolver's ProvisioningInputs reach EnsureForOrg intact, and
+// the resulting Lakekeeper config is written through to the warehouse row.
+//
+// This is the "EnsureForOrg is actually called" coverage the early gate
+// tests don't reach.
+func TestReconcileLakekeeper_HappyPath(t *testing.T) {
+	// Fake Lakekeeper HTTP server: accepts bootstrap, list, and create
+	// warehouse. Tracks the create-warehouse call so we can assert it
+	// fired with the expected inputs.
+	var createCalled bool
+	var createReq CreateWarehouseRequest
+	lk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/management/v1/bootstrap":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/management/v1/warehouse":
+			_, _ = io.WriteString(w, `{"warehouses":[]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/management/v1/warehouse":
+			createCalled = true
+			_ = json.NewDecoder(r.Body).Decode(&createReq)
+			_, _ = io.WriteString(w, `{"warehouse-id":"wh-uuid","name":"`+createReq.WarehouseName+`","status":"active"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(lk.Close)
+
+	// Fake K8s client + dynamic for the Lakekeeper CR + Secret. Pre-seed
+	// the CR with status.bootstrappedAt so waitForBootstrap (now
+	// checkBootstrap) returns immediately.
+	k8sClient, dyn, _ := newFakeLakekeeperClient()
+	if err := k8sClient.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "happy", Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	cr, _ := dyn.Resource(lakekeeperGVR).Namespace(k8sClient.namespace).Get(context.Background(), LakekeeperResourceName("happy"), metav1.GetOptions{})
+	cr.Object["status"] = map[string]interface{}{"bootstrappedAt": "2026-05-19T12:00:00Z"}
+	if _, err := dyn.Resource(lakekeeperGVR).Namespace(k8sClient.namespace).Update(context.Background(), cr, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("inject status: %v", err)
+	}
+
+	// Real provisioner, with the Lakekeeper HTTP client factory pointed at
+	// our fake server. The EnsureDatabase call inside EnsureForOrg needs a
+	// live PG — we point at the prototype Postgres on localhost:5434, and
+	// skip the test if PG_ADMIN_DSN isn't set.
+	pgDSN := os.Getenv("PG_ADMIN_DSN")
+	if pgDSN == "" {
+		t.Skip("PG_ADMIN_DSN not set; skipping happy-path test")
+	}
+	p := NewLakekeeperProvisioner(newFakeStore(), k8sClient,
+		WithImage("stub:test"),
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(lk.URL) }),
+	)
+	t.Cleanup(func() { dropDatabaseAndRole(t, pgDSN, lakekeeperDBName("happy")) })
+
+	// Wire into the controller.
+	store := newFakeStore()
+	store.warehouses["happy"] = &configstore.ManagedWarehouse{
+		OrgID: "happy",
+		State: configstore.ManagedWarehouseStateReady,
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+	// Re-point the provisioner's store at the controller's store so the
+	// EnsureForOrg writeback hits the same row reconcileLakekeeper sees.
+	p.store = store
+
+	var capturedInputs ProvisioningInputs
+	wantInputs := ProvisioningInputs{
+		AdminDSN: pgDSN, PGHost: "localhost", PGPort: 5434, PGSSLMode: "disable",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "happy", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	}
+
+	c := NewControllerWithClient(store, nil, 0).
+		WithLakekeeperProvisioner(p, func(_ context.Context, w *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+			if w.OrgID != "happy" {
+				t.Errorf("resolver got wrong org: %s", w.OrgID)
+			}
+			capturedInputs = wantInputs
+			return wantInputs, nil
+		})
+
+	c.reconcileLakekeeper(context.Background(), store.warehouses["happy"])
+
+	if !createCalled {
+		t.Fatalf("Lakekeeper warehouse-create REST call was never made")
+	}
+	if createReq.StorageProfile.KeyPrefix != "happy" {
+		t.Errorf("storage key-prefix = %q, want happy", createReq.StorageProfile.KeyPrefix)
+	}
+	// Verify inputs threaded through unchanged.
+	if capturedInputs.PGPort != wantInputs.PGPort || capturedInputs.S3.Bucket != wantInputs.S3.Bucket {
+		t.Errorf("inputs not threaded intact to provisioner; got %+v", capturedInputs)
+	}
+	// Verify the warehouse row got the persisted Lakekeeper config.
+	w := store.warehouses["happy"]
+	if w.Iceberg.LakekeeperEndpoint == "" {
+		t.Errorf("LakekeeperEndpoint not persisted after EnsureForOrg")
+	}
+	if w.Iceberg.LakekeeperWarehouse != "org-happy" {
+		t.Errorf("LakekeeperWarehouse = %q, want org-happy", w.Iceberg.LakekeeperWarehouse)
+	}
+}

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -189,6 +189,14 @@ type LakekeeperCRSpec struct {
 	// Defaults to "require" (the operator's default). Set to "disable" for
 	// local/dev where PG runs without TLS.
 	PGSSLMode string
+
+	// KubernetesAuthAudiences, when non-empty, enables the operator's
+	// `authentication.kubernetes` mode with the given audiences. The
+	// duckling's projected SA token must carry one of these audiences for
+	// Lakekeeper to accept it. Empty disables kubernetes auth (Lakekeeper
+	// runs in allowall mode behind NetworkPolicy — the PR1+PR2 deployment
+	// shape).
+	KubernetesAuthAudiences []string
 }
 
 // EnsureCR creates the Lakekeeper CR for the given org or patches it to match
@@ -268,6 +276,22 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 				},
 			},
 		},
+	}
+	// Optional: enable Kubernetes SA-token authentication. The operator
+	// turns this into LAKEKEEPER__K8S_AUTH_ENABLED=true +
+	// LAKEKEEPER__K8S_AUTH_AUDIENCES=<csv>, which makes Lakekeeper validate
+	// incoming bearer tokens against the K8s TokenReview API.
+	if len(spec.KubernetesAuthAudiences) > 0 {
+		audiences := make([]interface{}, 0, len(spec.KubernetesAuthAudiences))
+		for _, a := range spec.KubernetesAuthAudiences {
+			audiences = append(audiences, a)
+		}
+		cr.Object["spec"].(map[string]interface{})["authentication"] = map[string]interface{}{
+			"kubernetes": map[string]interface{}{
+				"enabled":   true,
+				"audiences": audiences,
+			},
+		}
 	}
 
 	resource := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace)

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -145,6 +145,57 @@ func TestEnsureCR_CreateAndShape(t *testing.T) {
 	}
 }
 
+func TestEnsureCR_KubernetesAuthOff_OmitsAuthenticationBlock(t *testing.T) {
+	c, dc, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+		// KubernetesAuthAudiences left empty
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+	got, _ := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	specMap := got.Object["spec"].(map[string]interface{})
+	if _, present := specMap["authentication"]; present {
+		t.Errorf("authentication block should be absent when KubernetesAuthAudiences is empty")
+	}
+}
+
+func TestEnsureCR_KubernetesAuthOn_EmitsAuthenticationBlock(t *testing.T) {
+	c, dc, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+		KubernetesAuthAudiences: []string{"lakekeeper", "lakekeeper-prod"},
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+	got, _ := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	specMap := got.Object["spec"].(map[string]interface{})
+	auth, ok := specMap["authentication"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("authentication block missing or wrong type: %T", specMap["authentication"])
+	}
+	k8sAuth, ok := auth["kubernetes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("authentication.kubernetes missing")
+	}
+	if k8sAuth["enabled"] != true {
+		t.Errorf("authentication.kubernetes.enabled = %v, want true", k8sAuth["enabled"])
+	}
+	auds, ok := k8sAuth["audiences"].([]interface{})
+	if !ok || len(auds) != 2 {
+		t.Fatalf("audiences = %v, want [lakekeeper lakekeeper-prod]", k8sAuth["audiences"])
+	}
+	if auds[0] != "lakekeeper" || auds[1] != "lakekeeper-prod" {
+		t.Errorf("audiences contents = %v", auds)
+	}
+}
+
 func TestEnsureCR_IdempotentUpdate(t *testing.T) {
 	c, dc, _ := newFakeLakekeeperClient()
 	ctx := context.Background()

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/server/lakekeeperbroker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +60,31 @@ type ProvisioningInputs struct {
 	// AWS, leave Endpoint empty and Flavor "aws". For MinIO / s3-compat,
 	// set Endpoint and Flavor "s3-compat".
 	S3 S3StorageConfig
+
+	// KubernetesAuthAudiences enables the OIDC SA-token auth path on the
+	// Lakekeeper CR. The duckling's projected SA token must carry one of
+	// these audiences. Empty disables — Lakekeeper runs in allowall +
+	// NetworkPolicy mode (the PR1+PR2 deployment shape).
+	//
+	// When set, the provisioner also writes a non-empty
+	// LakekeeperOAuth2ServerURI to the warehouse row so the worker's
+	// in-process broker becomes DuckDB's OAuth2 server.
+	//
+	// **Flag-day deploy ordering.** Once any org gets a non-empty value
+	// here, its activation payload carries LakekeeperOAuth2ServerURI=
+	// http://127.0.0.1:9876/token, which the worker's iceberg extension
+	// tries to POST to. If the duckling pod spec hasn't yet been updated
+	// to (a) mount the projected SA token at DUCKGRES_LAKEKEEPER_TOKEN_PATH
+	// and (b) expose the broker on 9876, the POST hits a closed port and
+	// the ATTACH fails. There is no path that clears the URI once written
+	// (re-running with empty audiences would leave the old value behind).
+	// Deploy order MUST be:
+	//   1. Roll out the duckling pod spec change with the projected SA
+	//      volume + env var.
+	//   2. Apply the operator chart change that flips the CR's
+	//      authentication.kubernetes.enabled (PR4 already plumbs this).
+	//   3. Only then flip KubernetesAuthAudiences in the inputs resolver.
+	KubernetesAuthAudiences []string
 }
 
 // S3StorageConfig captures the bucket + credentials Lakekeeper uses.
@@ -165,15 +191,16 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		pgPort = 5432
 	}
 	if err := p.k8s.EnsureCR(ctx, LakekeeperCRSpec{
-		OrgID:      w.OrgID,
-		Image:      p.image,
-		Replicas:   1,
-		PGHost:     in.PGHost,
-		PGPort:     pgPort,
-		PGDatabase: dbName,
-		SecretName: secretName,
-		BaseURI:    baseURL,
-		PGSSLMode:  in.PGSSLMode,
+		OrgID:                   w.OrgID,
+		Image:                   p.image,
+		Replicas:                1,
+		PGHost:                  in.PGHost,
+		PGPort:                  pgPort,
+		PGDatabase:              dbName,
+		SecretName:              secretName,
+		BaseURI:                 baseURL,
+		PGSSLMode:               in.PGSSLMode,
+		KubernetesAuthAudiences: in.KubernetesAuthAudiences,
 	}); err != nil {
 		return fmt.Errorf("ensure lakekeeper cr: %w", err)
 	}
@@ -212,21 +239,24 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	}
 
 	// 6. Persist endpoint+credentials back into the warehouse row. Iceberg
-	// state flips to Ready as part of the same write. Callers that don't
-	// own the row (e.g. integration tests) pass a fake store; production
-	// uses configstore's Compare-And-Swap UpdateWarehouseState.
-	// In PR1, Lakekeeper runs in allowall mode and the OAuth2 server URI is
-	// not used at the wire layer (the duckling's CREATE SECRET sends
-	// CLIENT_ID/CLIENT_SECRET but Lakekeeper accepts unauthenticated
-	// requests from within the org's NetworkPolicy). PR3 fills in the
-	// real token endpoint when OIDC SA-token auth lands.
+	// state flips to Ready as part of the same write.
+	//
+	// OAUTH2_SERVER_URI is populated only when KubernetesAuthAudiences was
+	// passed (PR4 OIDC mode). Without it, Lakekeeper runs in allowall +
+	// NetworkPolicy mode and the worker emits an ATTACH with
+	// AUTHORIZATION_TYPE 'none' — the empty URI value signals that path
+	// downstream via server/iceberg.BuildLakekeeperAttachStmt.
+	oauth2URI := ""
+	if len(in.KubernetesAuthAudiences) > 0 {
+		oauth2URI = lakekeeperbroker.DefaultOAuth2ServerURI
+	}
 	updates := map[string]interface{}{
 		"iceberg_enabled":                                 true,
 		"iceberg_backend":                                 configstore.IcebergBackendLakekeeper,
 		"iceberg_lakekeeper_endpoint":                     baseURL + "/catalog",
 		"iceberg_lakekeeper_warehouse":                    wh.Name,
 		"iceberg_lakekeeper_client_id":                    oauthClientID(w.OrgID),
-		"iceberg_lakekeeper_oauth2_server_uri":            "", // PR3
+		"iceberg_lakekeeper_oauth2_server_uri":            oauth2URI,
 		"iceberg_lakekeeper_client_credentials_namespace": p.k8s.namespace,
 		"iceberg_lakekeeper_client_credentials_name":      secretName,
 		"iceberg_lakekeeper_client_credentials_key":       SecretKeyOAuth2ClientSecret,

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -286,6 +286,126 @@ func TestEnsureForOrg_PersistsAfterTopLevelStateMoved(t *testing.T) {
 	}
 }
 
+// TestEnsureForOrg_PersistsOAuth2URIWhenKubernetesAuthOn confirms that
+// KubernetesAuthAudiences on the inputs flows through to:
+//
+//   - the Lakekeeper CR's spec.authentication.kubernetes block
+//   - the warehouse row's LakekeeperOAuth2ServerURI (pointing at the
+//     worker's local broker on 127.0.0.1)
+//
+// This is the wire-level handshake PR4 unlocks: the worker emits an
+// OAuth2 secret + ATTACH because the URI is non-empty.
+func TestEnsureForOrg_PersistsOAuth2URIWhenKubernetesAuthOn(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("oidc-org", configstore.ManagedWarehouseStateProvisioning)
+
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "oidc-org", Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "oidc-org")
+
+	p := NewLakekeeperProvisioner(store, c,
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_oidcorg") })
+
+	err := p.EnsureForOrg(context.Background(), store.warehouses["oidc-org"], ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434, PGSSLMode: "disable",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "oidc-org", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+		KubernetesAuthAudiences: []string{"lakekeeper"},
+	})
+	if err != nil {
+		t.Fatalf("EnsureForOrg: %v", err)
+	}
+
+	w := store.warehouses["oidc-org"]
+	if w.Iceberg.LakekeeperOAuth2ServerURI == "" {
+		t.Errorf("LakekeeperOAuth2ServerURI should be populated in OIDC mode")
+	}
+	if w.Iceberg.LakekeeperOAuth2ServerURI != "http://127.0.0.1:9876/token" {
+		t.Errorf("OAUTH2_SERVER_URI = %q, want http://127.0.0.1:9876/token (worker-local broker)",
+			w.Iceberg.LakekeeperOAuth2ServerURI)
+	}
+
+	// Cross-check that the CR's authentication.kubernetes block was set in
+	// the SAME EnsureForOrg call. Without this read-back, the DB row and
+	// the CR could drift — a future refactor that threads
+	// KubernetesAuthAudiences into ProvisioningInputs but forgets to pass
+	// it to LakekeeperCRSpec would leave Lakekeeper in allowall mode while
+	// the worker tells DuckDB to POST to the broker. Lakekeeper would
+	// then reject the token because k8s auth wasn't actually enabled.
+	cr, err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).
+		Get(context.Background(), LakekeeperResourceName("oidc-org"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR for cross-check: %v", err)
+	}
+	specMap := cr.Object["spec"].(map[string]interface{})
+	auth, ok := specMap["authentication"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.authentication missing on CR — would be allowall in prod")
+	}
+	k8sAuth, ok := auth["kubernetes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.authentication.kubernetes missing on CR")
+	}
+	if k8sAuth["enabled"] != true {
+		t.Errorf("spec.authentication.kubernetes.enabled = %v, want true", k8sAuth["enabled"])
+	}
+	auds, ok := k8sAuth["audiences"].([]interface{})
+	if !ok || len(auds) != 1 || auds[0] != "lakekeeper" {
+		t.Errorf("audiences = %v, want [lakekeeper]", k8sAuth["audiences"])
+	}
+}
+
+func TestEnsureForOrg_OAuth2URIEmptyInAllowallMode(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("allowall-org", configstore.ManagedWarehouseStateProvisioning)
+
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "allowall-org", Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "allowall-org")
+
+	p := NewLakekeeperProvisioner(store, c,
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_allowallorg") })
+
+	// KubernetesAuthAudiences left empty → allowall mode.
+	err := p.EnsureForOrg(context.Background(), store.warehouses["allowall-org"], ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434, PGSSLMode: "disable",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "allowall-org", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EnsureForOrg: %v", err)
+	}
+	if w := store.warehouses["allowall-org"]; w.Iceberg.LakekeeperOAuth2ServerURI != "" {
+		t.Errorf("OAUTH2_SERVER_URI = %q, want empty (allowall mode)", w.Iceberg.LakekeeperOAuth2ServerURI)
+	}
+}
+
 func TestEnsureForOrg_RejectsInvalidOrgID(t *testing.T) {
 	c, _, _ := newFakeLakekeeperClient()
 	store := newFakeProvisionerStore("bad org", configstore.ManagedWarehouseStateProvisioning)

--- a/server/lakekeeperbroker/broker.go
+++ b/server/lakekeeperbroker/broker.go
@@ -1,0 +1,224 @@
+// Package lakekeeperbroker is a tiny in-process HTTP server that bridges
+// DuckDB's OAuth2 client_credentials expectations to a Kubernetes-projected
+// ServiceAccount token. The DuckDB iceberg extension knows how to fetch a
+// bearer token via OAuth2 (POST grant_type=client_credentials), but not how
+// to load one from disk. The broker handles the disk read and hands the
+// token back wrapped in an OAuth2 response shape that DuckDB accepts.
+//
+// Lifecycle:
+//   - The worker starts the broker at boot, before any client session can run.
+//   - kubelet refreshes the projected SA token on its own schedule (default
+//     well under 1h); each /token request re-reads the file so we always
+//     hand DuckDB the current token.
+//   - The activation payload's LakekeeperOAuth2ServerURI points at
+//     http://127.0.0.1:<broker-port>/token, so the broker is reachable only
+//     from inside the worker pod.
+//
+// Why an in-process broker rather than a sidecar:
+//   - One process to lifecycle and observe.
+//   - No extra container in the duckling pod spec.
+//   - The token file is mounted via a projected volume; the broker is the
+//     only consumer.
+package lakekeeperbroker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Broker is an HTTP server that wraps a projected SA token file as an
+// OAuth2 client_credentials response.
+type Broker struct {
+	tokenPath string
+	srv       *http.Server
+	listener  net.Listener
+
+	// expiresInSeconds is what we return in the OAuth2 response. DuckDB's
+	// iceberg extension uses this to decide when to re-fetch. A short
+	// value (default 60) keeps DuckDB in sync with kubelet's projected
+	// token rotation; a long value reduces /token QPS but risks DuckDB
+	// using a stale token after kubelet rotates.
+	expiresInSeconds int
+
+	mu      sync.Mutex
+	started bool
+}
+
+// New builds a Broker that reads its token from tokenPath. The path must
+// be readable at request time, not just at construction — the file is
+// rotated by kubelet on the projected-token TTL schedule.
+func New(tokenPath string) *Broker {
+	return &Broker{
+		tokenPath:        tokenPath,
+		expiresInSeconds: 60,
+	}
+}
+
+// WithExpiresIn overrides the expires_in (seconds) value in the OAuth2
+// response. Default 60. Lower values increase /token QPS but reduce the
+// window in which DuckDB could be holding a stale token after kubelet
+// rotation.
+//
+// TODO(PR5): the worker binary doesn't expose this override via env yet
+// — the duckling pod spec work that lands the projected SA volume
+// should also wire DUCKGRES_LAKEKEEPER_TOKEN_EXPIRES_IN. Until then,
+// every duckling uses the default 60s.
+func (b *Broker) WithExpiresIn(s int) *Broker {
+	b.expiresInSeconds = s
+	return b
+}
+
+// ListenAndServe starts the broker on the given loopback addr (e.g.
+// "127.0.0.1:9876"). Returns once the listener is bound; the HTTP server
+// runs in a background goroutine. Use Shutdown to stop it cleanly.
+//
+// Binding loopback-only is intentional — only the local worker process
+// should ever hit /token, and exposing the wrapped SA token to any
+// non-loopback caller would be a real credential leak.
+func (b *Broker) ListenAndServe(addr string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.started {
+		return errors.New("broker already started")
+	}
+	if !strings.HasPrefix(addr, "127.0.0.1:") && !strings.HasPrefix(addr, "[::1]:") {
+		return fmt.Errorf("broker addr %q must bind to loopback; non-loopback would leak the SA token", addr)
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("broker listen: %w", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", b.handleToken)
+	mux.HandleFunc("/health", b.handleHealth)
+	b.listener = ln
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+	b.srv = srv
+	b.started = true
+	// Capture srv in the closure rather than b.srv — Shutdown nil-clears
+	// the struct field, so a goroutine that reads b.srv directly can
+	// race with Shutdown and panic.
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			fmt.Fprintf(os.Stderr, "lakekeeper broker: serve: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+// Addr returns the bound address, useful when the caller passed a :0 port
+// and wants to know what was picked.
+func (b *Broker) Addr() string {
+	if b.listener == nil {
+		return ""
+	}
+	return b.listener.Addr().String()
+}
+
+// Shutdown stops the broker gracefully. Safe to call multiple times.
+func (b *Broker) Shutdown(ctx context.Context) error {
+	b.mu.Lock()
+	srv := b.srv
+	b.srv = nil
+	b.started = false
+	b.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
+}
+
+// tokenResponse is the JSON shape DuckDB's iceberg extension expects from
+// an OAuth2 client_credentials response.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type errorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func (b *Broker) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		b.respondError(w, http.StatusMethodNotAllowed, "invalid_request", "POST only")
+		return
+	}
+	// Read the projected SA token. The kubelet refreshes this file on its
+	// own schedule; each request gets the freshest copy.
+	raw, err := os.ReadFile(b.tokenPath)
+	if err != nil {
+		// 503 rather than 500 — file-not-yet-mounted is transient.
+		b.respondError(w, http.StatusServiceUnavailable, "server_error",
+			fmt.Sprintf("read token file: %v", err))
+		return
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		b.respondError(w, http.StatusServiceUnavailable, "server_error", "token file empty")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	// RFC 6749 §5.1: token responses must include both Cache-Control: no-store
+	// and Pragma: no-cache. The latter is an HTTP/1.0 remnant that won't matter
+	// on a loopback connection to DuckDB, but the broker is otherwise spec-
+	// compliant and the header is one line.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	_ = json.NewEncoder(w).Encode(tokenResponse{
+		AccessToken: token,
+		TokenType:   "Bearer",
+		ExpiresIn:   b.expiresInSeconds,
+	})
+}
+
+func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(b.tokenPath); err != nil {
+		b.respondError(w, http.StatusServiceUnavailable, "unhealthy",
+			fmt.Sprintf("token path %q: %v", b.tokenPath, err))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (b *Broker) respondError(w http.ResponseWriter, status int, code, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: code, ErrorDescription: desc})
+}
+
+// DefaultPort is the loopback port we bind to in the worker pod. Picked
+// to avoid common app ports; mirrored in the activation payload's
+// LakekeeperOAuth2ServerURI value.
+const DefaultPort = 9876
+
+// DefaultAddr is the loopback address for the broker.
+const DefaultAddr = "127.0.0.1:9876"
+
+// DefaultTokenPath is the conventional mount path for the projected SA
+// token. The duckling pod spec must mount a projected volume here with
+// audience matching Lakekeeper's authentication.kubernetes.audiences.
+const DefaultTokenPath = "/var/run/secrets/lakekeeper/token"
+
+// DefaultOAuth2ServerURI is the value written to ManagedWarehouseIceberg.
+// LakekeeperOAuth2ServerURI when the provisioner runs in OIDC mode. The
+// worker activator ships it to the worker, which uses it as DuckDB's
+// OAUTH2_SERVER_URI — the worker's own broker is what DuckDB ends up
+// POSTing to.
+const DefaultOAuth2ServerURI = "http://127.0.0.1:9876/token"

--- a/server/lakekeeperbroker/broker_test.go
+++ b/server/lakekeeperbroker/broker_test.go
@@ -1,0 +1,208 @@
+package lakekeeperbroker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTempToken(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "token")
+	if err := os.WriteFile(p, []byte(contents), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	return p
+}
+
+func startBroker(t *testing.T, tokenPath string) *Broker {
+	t.Helper()
+	b := New(tokenPath)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = b.Shutdown(ctx)
+	})
+	return b
+}
+
+func TestTokenEndpointReturnsFileContents(t *testing.T) {
+	const want = "eyJ.fake.jwt"
+	p := writeTempToken(t, want+"\n") // trailing newline gets trimmed
+	b := startBroker(t, p)
+
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", url.Values{
+		"grant_type": {"client_credentials"},
+	})
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("cache-control = %q, want no-store", cc)
+	}
+	if pr := resp.Header.Get("Pragma"); pr != "no-cache" {
+		t.Errorf("pragma = %q, want no-cache (RFC 6749 §5.1)", pr)
+	}
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tr.AccessToken != want {
+		t.Errorf("access_token = %q, want %q", tr.AccessToken, want)
+	}
+	if tr.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", tr.TokenType)
+	}
+	if tr.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want positive", tr.ExpiresIn)
+	}
+}
+
+func TestTokenEndpointReReadsFileEachRequest(t *testing.T) {
+	// Verifies that kubelet token rotation is picked up — the broker
+	// must not cache the token contents in memory.
+	p := writeTempToken(t, "first-token")
+	b := startBroker(t, p)
+
+	get := func() string {
+		resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+		if err != nil {
+			t.Fatalf("POST /token: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var tr tokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return tr.AccessToken
+	}
+	if got := get(); got != "first-token" {
+		t.Fatalf("first = %q", got)
+	}
+	if err := os.WriteFile(p, []byte("second-token"), 0600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if got := get(); got != "second-token" {
+		t.Fatalf("second = %q, want second-token (broker should re-read on each request)", got)
+	}
+}
+
+func TestTokenEndpointGETIsRejected(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := startBroker(t, p)
+	resp, err := http.Get("http://" + b.Addr() + "/token")
+	if err != nil {
+		t.Fatalf("GET /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestTokenEndpointMissingFileReturns503(t *testing.T) {
+	b := startBroker(t, "/nonexistent/path")
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestTokenEndpointEmptyFileReturns503(t *testing.T) {
+	p := writeTempToken(t, "   \n\t ")
+	b := startBroker(t, p)
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("empty token file should 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := startBroker(t, p)
+	resp, err := http.Get("http://" + b.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHealthEndpointReports503WhenTokenMissing(t *testing.T) {
+	b := startBroker(t, "/no/such/file")
+	resp, err := http.Get("http://" + b.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestRefusesToBindNonLoopback(t *testing.T) {
+	b := New("irrelevant")
+	if err := b.ListenAndServe("0.0.0.0:0"); err == nil {
+		t.Fatal("expected error binding to non-loopback")
+	} else if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("error should mention loopback: %v", err)
+	}
+}
+
+func TestStartTwiceErrors(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := New(p)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("first ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Shutdown(context.Background()) })
+	if err := b.ListenAndServe("127.0.0.1:0"); err == nil {
+		t.Fatal("expected error on double-start")
+	}
+}
+
+func TestExpiresInOverride(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := New(p).WithExpiresIn(300)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Shutdown(context.Background()) })
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var tr tokenResponse
+	_ = json.NewDecoder(resp.Body).Decode(&tr)
+	if tr.ExpiresIn != 300 {
+		t.Errorf("expires_in = %d, want 300", tr.ExpiresIn)
+	}
+}


### PR DESCRIPTION
## Summary

Third of the Lakekeeper-as-Iceberg-catalog series. Adds the trigger that turns PR1's manual \`EnsureForOrg\` into automatic per-org provisioning by wiring it into the existing \`Controller\` reconcile loop. **Targets \`lakekeeper-pr2-worker-wiring\` as the base** — stacked PR; merge #574 and #576 first.

Without this PR, an org with \`Iceberg.Backend=\"lakekeeper\"\` would sit indefinitely with an empty \`LakekeeperEndpoint\` and the worker's \`AttachIcebergCatalog\` would no-op forever. PR3 closes that gap by running the provisioner once per reconcile tick for each \`Ready\` warehouse that needs it.

## What's in this PR

- \`Controller\` gains optional \`lakekeeperProvisioner\` + \`LakekeeperInputsResolver\` dependencies via \`WithLakekeeperProvisioner\`. Both nil → \`reconcileLakekeeper\` is a silent no-op, so existing deployments (operator not installed) are unaffected.
- \`reconcileLakekeeper\` runs from \`reconcileReady\`, gated on \`Iceberg.Enabled\` + \`Backend=lakekeeper\` + empty \`LakekeeperEndpoint\`. Already-provisioned warehouses hit the early-return path.
- \`ErrBootstrapPending\` is logged at debug and treated as "requeue next tick". Any other provisioner error is logged at warn so the loop continues with the next warehouse.
- \`LakekeeperInputsResolver\` is a function the controller calls to build \`ProvisioningInputs\`. The convention for sourcing the admin DSN from a Crossplane-managed Secret is deliberately not baked in here — see "What's NOT in this PR" below.

## What's NOT in this PR

- **The prod implementation of \`LakekeeperInputsResolver\`.** It needs the Crossplane composition's master-credential Secret name pattern, which lives outside this repo. Wiring it is a small follow-up — the resolver function shape is the only thing this PR locks in.
- **OIDC SA-token auth.** Orgs provisioned through this trigger get Lakekeeper in \`allowall\` mode + NetworkPolicy isolation. PR4 will swap that for OIDC.

## Test plan

- [x] 5 unit tests covering the gate logic:
  - Silent no-op when provisioner is unconfigured (existing deployments unaffected)
  - Silent no-op when \`Iceberg.Enabled=false\`
  - Silent no-op when \`Backend=s3_tables\`
  - Silent no-op when \`LakekeeperEndpoint\` is already populated (idempotent)
  - Graceful continue when the inputs resolver errors (logs warn, doesn't crash)
- [x] \`go test ./...\` + \`-tags kubernetes\` sweeps green
- [x] \`golangci-lint run\` clean
- [ ] CI

## Stacked

```
main
└── lakekeeper-pr1 (#574)
    └── lakekeeper-pr2-worker-wiring (#576)
        └── lakekeeper-pr3-provisioning-trigger (this PR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)