### PR TITLE
feat(provisioner,worker): Lakekeeper-as-Iceberg-catalog — PR4 (OIDC SA-token auth)

### DIFF
--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/posthog/duckgres/duckdbservice"
 	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/lakekeeperbroker"
 )
 
 // Each duckgres binary owns its own package-main version/commit/date because
@@ -247,6 +248,23 @@ func main() {
 	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create data directory %q: %s\n", cfg.DataDir, err)
 		os.Exit(1)
+	}
+
+	// Lakekeeper OIDC SA-token broker. Started when DUCKGRES_LAKEKEEPER_TOKEN_PATH
+	// is set (typically by the duckling pod spec, mounting a projected SA
+	// token volume at /var/run/secrets/lakekeeper/token). DuckDB's iceberg
+	// extension POSTs to OAUTH2_SERVER_URI=http://127.0.0.1:9876/token to
+	// fetch a bearer; the broker reads the projected file and hands it back.
+	// When the env var is unset, no broker is started — preserves the
+	// allowall + NetworkPolicy posture for clusters that haven't enabled
+	// OIDC on Lakekeeper yet.
+	if tokenPath := configloader.Env("DUCKGRES_LAKEKEEPER_TOKEN_PATH", ""); tokenPath != "" {
+		broker := lakekeeperbroker.New(tokenPath)
+		if err := broker.ListenAndServe(lakekeeperbroker.DefaultAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to start lakekeeper broker on %s: %s\n", lakekeeperbroker.DefaultAddr, err)
+			os.Exit(1)
+		}
+		slog.Info("Lakekeeper OIDC broker started.", "addr", lakekeeperbroker.DefaultAddr, "token_path", tokenPath)
 	}
 
 	// No initMetrics() here. In control-plane mode all worker pods would

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -189,6 +189,14 @@ type LakekeeperCRSpec struct {
 	// Defaults to "require" (the operator's default). Set to "disable" for
 	// local/dev where PG runs without TLS.
 	PGSSLMode string
+
+	// KubernetesAuthAudiences, when non-empty, enables the operator's
+	// `authentication.kubernetes` mode with the given audiences. The
+	// duckling's projected SA token must carry one of these audiences for
+	// Lakekeeper to accept it. Empty disables kubernetes auth (Lakekeeper
+	// runs in allowall mode behind NetworkPolicy — the PR1+PR2 deployment
+	// shape).
+	KubernetesAuthAudiences []string
 }
 
 // EnsureCR creates the Lakekeeper CR for the given org or patches it to match
@@ -268,6 +276,22 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 				},
 			},
 		},
+	}
+	// Optional: enable Kubernetes SA-token authentication. The operator
+	// turns this into LAKEKEEPER__K8S_AUTH_ENABLED=true +
+	// LAKEKEEPER__K8S_AUTH_AUDIENCES=<csv>, which makes Lakekeeper validate
+	// incoming bearer tokens against the K8s TokenReview API.
+	if len(spec.KubernetesAuthAudiences) > 0 {
+		audiences := make([]interface{}, 0, len(spec.KubernetesAuthAudiences))
+		for _, a := range spec.KubernetesAuthAudiences {
+			audiences = append(audiences, a)
+		}
+		cr.Object["spec"].(map[string]interface{})["authentication"] = map[string]interface{}{
+			"kubernetes": map[string]interface{}{
+				"enabled":   true,
+				"audiences": audiences,
+			},
+		}
 	}
 
 	resource := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace)

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -145,6 +145,57 @@ func TestEnsureCR_CreateAndShape(t *testing.T) {
 	}
 }
 
+func TestEnsureCR_KubernetesAuthOff_OmitsAuthenticationBlock(t *testing.T) {
+	c, dc, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+		// KubernetesAuthAudiences left empty
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+	got, _ := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	specMap := got.Object["spec"].(map[string]interface{})
+	if _, present := specMap["authentication"]; present {
+		t.Errorf("authentication block should be absent when KubernetesAuthAudiences is empty")
+	}
+}
+
+func TestEnsureCR_KubernetesAuthOn_EmitsAuthenticationBlock(t *testing.T) {
+	c, dc, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	spec := LakekeeperCRSpec{
+		OrgID: "acme", Image: "img:v1", PGHost: "h", PGDatabase: "lakekeeper_acme",
+		SecretName: "lakekeeper-acme", BaseURI: "http://x",
+		KubernetesAuthAudiences: []string{"lakekeeper", "lakekeeper-prod"},
+	}
+	if err := c.EnsureCR(ctx, spec); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+	got, _ := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{})
+	specMap := got.Object["spec"].(map[string]interface{})
+	auth, ok := specMap["authentication"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("authentication block missing or wrong type: %T", specMap["authentication"])
+	}
+	k8sAuth, ok := auth["kubernetes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("authentication.kubernetes missing")
+	}
+	if k8sAuth["enabled"] != true {
+		t.Errorf("authentication.kubernetes.enabled = %v, want true", k8sAuth["enabled"])
+	}
+	auds, ok := k8sAuth["audiences"].([]interface{})
+	if !ok || len(auds) != 2 {
+		t.Fatalf("audiences = %v, want [lakekeeper lakekeeper-prod]", k8sAuth["audiences"])
+	}
+	if auds[0] != "lakekeeper" || auds[1] != "lakekeeper-prod" {
+		t.Errorf("audiences contents = %v", auds)
+	}
+}
+
 func TestEnsureCR_IdempotentUpdate(t *testing.T) {
 	c, dc, _ := newFakeLakekeeperClient()
 	ctx := context.Background()

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/server/lakekeeperbroker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +60,16 @@ type ProvisioningInputs struct {
 	// AWS, leave Endpoint empty and Flavor "aws". For MinIO / s3-compat,
 	// set Endpoint and Flavor "s3-compat".
 	S3 S3StorageConfig
+
+	// KubernetesAuthAudiences enables the OIDC SA-token auth path on the
+	// Lakekeeper CR. The duckling's projected SA token must carry one of
+	// these audiences. Empty disables — Lakekeeper runs in allowall +
+	// NetworkPolicy mode (the PR1+PR2 deployment shape).
+	//
+	// When set, the provisioner also writes a non-empty
+	// LakekeeperOAuth2ServerURI to the warehouse row so the worker's
+	// in-process broker becomes DuckDB's OAuth2 server.
+	KubernetesAuthAudiences []string
 }
 
 // S3StorageConfig captures the bucket + credentials Lakekeeper uses.
@@ -165,15 +176,16 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		pgPort = 5432
 	}
 	if err := p.k8s.EnsureCR(ctx, LakekeeperCRSpec{
-		OrgID:      w.OrgID,
-		Image:      p.image,
-		Replicas:   1,
-		PGHost:     in.PGHost,
-		PGPort:     pgPort,
-		PGDatabase: dbName,
-		SecretName: secretName,
-		BaseURI:    baseURL,
-		PGSSLMode:  in.PGSSLMode,
+		OrgID:                   w.OrgID,
+		Image:                   p.image,
+		Replicas:                1,
+		PGHost:                  in.PGHost,
+		PGPort:                  pgPort,
+		PGDatabase:              dbName,
+		SecretName:              secretName,
+		BaseURI:                 baseURL,
+		PGSSLMode:               in.PGSSLMode,
+		KubernetesAuthAudiences: in.KubernetesAuthAudiences,
 	}); err != nil {
 		return fmt.Errorf("ensure lakekeeper cr: %w", err)
 	}
@@ -212,21 +224,24 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	}
 
 	// 6. Persist endpoint+credentials back into the warehouse row. Iceberg
-	// state flips to Ready as part of the same write. Callers that don't
-	// own the row (e.g. integration tests) pass a fake store; production
-	// uses configstore's Compare-And-Swap UpdateWarehouseState.
-	// In PR1, Lakekeeper runs in allowall mode and the OAuth2 server URI is
-	// not used at the wire layer (the duckling's CREATE SECRET sends
-	// CLIENT_ID/CLIENT_SECRET but Lakekeeper accepts unauthenticated
-	// requests from within the org's NetworkPolicy). PR3 fills in the
-	// real token endpoint when OIDC SA-token auth lands.
+	// state flips to Ready as part of the same write.
+	//
+	// OAUTH2_SERVER_URI is populated only when KubernetesAuthAudiences was
+	// passed (PR4 OIDC mode). Without it, Lakekeeper runs in allowall +
+	// NetworkPolicy mode and the worker emits an ATTACH with
+	// AUTHORIZATION_TYPE 'none' — the empty URI value signals that path
+	// downstream via server/iceberg.BuildLakekeeperAttachStmt.
+	oauth2URI := ""
+	if len(in.KubernetesAuthAudiences) > 0 {
+		oauth2URI = lakekeeperbroker.DefaultOAuth2ServerURI
+	}
 	updates := map[string]interface{}{
 		"iceberg_enabled":                                 true,
 		"iceberg_backend":                                 configstore.IcebergBackendLakekeeper,
 		"iceberg_lakekeeper_endpoint":                     baseURL + "/catalog",
 		"iceberg_lakekeeper_warehouse":                    wh.Name,
 		"iceberg_lakekeeper_client_id":                    oauthClientID(w.OrgID),
-		"iceberg_lakekeeper_oauth2_server_uri":            "", // PR3
+		"iceberg_lakekeeper_oauth2_server_uri":            oauth2URI,
 		"iceberg_lakekeeper_client_credentials_namespace": p.k8s.namespace,
 		"iceberg_lakekeeper_client_credentials_name":      secretName,
 		"iceberg_lakekeeper_client_credentials_key":       SecretKeyOAuth2ClientSecret,

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -69,6 +69,21 @@ type ProvisioningInputs struct {
 	// When set, the provisioner also writes a non-empty
 	// LakekeeperOAuth2ServerURI to the warehouse row so the worker's
 	// in-process broker becomes DuckDB's OAuth2 server.
+	//
+	// **Flag-day deploy ordering.** Once any org gets a non-empty value
+	// here, its activation payload carries LakekeeperOAuth2ServerURI=
+	// http://127.0.0.1:9876/token, which the worker's iceberg extension
+	// tries to POST to. If the duckling pod spec hasn't yet been updated
+	// to (a) mount the projected SA token at DUCKGRES_LAKEKEEPER_TOKEN_PATH
+	// and (b) expose the broker on 9876, the POST hits a closed port and
+	// the ATTACH fails. There is no path that clears the URI once written
+	// (re-running with empty audiences would leave the old value behind).
+	// Deploy order MUST be:
+	//   1. Roll out the duckling pod spec change with the projected SA
+	//      volume + env var.
+	//   2. Apply the operator chart change that flips the CR's
+	//      authentication.kubernetes.enabled (PR4 already plumbs this).
+	//   3. Only then flip KubernetesAuthAudiences in the inputs resolver.
 	KubernetesAuthAudiences []string
 }
 

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -286,6 +286,97 @@ func TestEnsureForOrg_PersistsAfterTopLevelStateMoved(t *testing.T) {
 	}
 }
 
+// TestEnsureForOrg_PersistsOAuth2URIWhenKubernetesAuthOn confirms that
+// KubernetesAuthAudiences on the inputs flows through to:
+//
+//   - the Lakekeeper CR's spec.authentication.kubernetes block
+//   - the warehouse row's LakekeeperOAuth2ServerURI (pointing at the
+//     worker's local broker on 127.0.0.1)
+//
+// This is the wire-level handshake PR4 unlocks: the worker emits an
+// OAuth2 secret + ATTACH because the URI is non-empty.
+func TestEnsureForOrg_PersistsOAuth2URIWhenKubernetesAuthOn(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("oidc-org", configstore.ManagedWarehouseStateProvisioning)
+
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "oidc-org", Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "oidc-org")
+
+	p := NewLakekeeperProvisioner(store, c,
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_oidcorg") })
+
+	err := p.EnsureForOrg(context.Background(), store.warehouses["oidc-org"], ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434, PGSSLMode: "disable",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "oidc-org", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+		KubernetesAuthAudiences: []string{"lakekeeper"},
+	})
+	if err != nil {
+		t.Fatalf("EnsureForOrg: %v", err)
+	}
+
+	w := store.warehouses["oidc-org"]
+	if w.Iceberg.LakekeeperOAuth2ServerURI == "" {
+		t.Errorf("LakekeeperOAuth2ServerURI should be populated in OIDC mode")
+	}
+	if w.Iceberg.LakekeeperOAuth2ServerURI != "http://127.0.0.1:9876/token" {
+		t.Errorf("OAUTH2_SERVER_URI = %q, want http://127.0.0.1:9876/token (worker-local broker)",
+			w.Iceberg.LakekeeperOAuth2ServerURI)
+	}
+}
+
+func TestEnsureForOrg_OAuth2URIEmptyInAllowallMode(t *testing.T) {
+	dsn := os.Getenv("PG_ADMIN_DSN")
+	if dsn == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+	c, _, _ := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("allowall-org", configstore.ManagedWarehouseStateProvisioning)
+
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "allowall-org", Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "allowall-org")
+
+	p := NewLakekeeperProvisioner(store, c,
+		WithClientFactory(func(string) *LakekeeperClient { return NewLakekeeperClient(fake.srv.URL) }),
+	)
+	t.Cleanup(func() { dropDatabase(t, dsn, "lakekeeper_allowallorg") })
+
+	// KubernetesAuthAudiences left empty → allowall mode.
+	err := p.EnsureForOrg(context.Background(), store.warehouses["allowall-org"], ProvisioningInputs{
+		AdminDSN: dsn, PGHost: "localhost", PGPort: 5434, PGSSLMode: "disable",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "allowall-org", Region: "us-east-1", Flavor: "s3-compat",
+			StaticAccessKeyID: "minioadmin", StaticAccessKeySecret: "minioadmin",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EnsureForOrg: %v", err)
+	}
+	if w := store.warehouses["allowall-org"]; w.Iceberg.LakekeeperOAuth2ServerURI != "" {
+		t.Errorf("OAUTH2_SERVER_URI = %q, want empty (allowall mode)", w.Iceberg.LakekeeperOAuth2ServerURI)
+	}
+}
+
 func TestEnsureForOrg_RejectsInvalidOrgID(t *testing.T) {
 	c, _, _ := newFakeLakekeeperClient()
 	store := newFakeProvisionerStore("bad org", configstore.ManagedWarehouseStateProvisioning)

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -337,6 +337,35 @@ func TestEnsureForOrg_PersistsOAuth2URIWhenKubernetesAuthOn(t *testing.T) {
 		t.Errorf("OAUTH2_SERVER_URI = %q, want http://127.0.0.1:9876/token (worker-local broker)",
 			w.Iceberg.LakekeeperOAuth2ServerURI)
 	}
+
+	// Cross-check that the CR's authentication.kubernetes block was set in
+	// the SAME EnsureForOrg call. Without this read-back, the DB row and
+	// the CR could drift — a future refactor that threads
+	// KubernetesAuthAudiences into ProvisioningInputs but forgets to pass
+	// it to LakekeeperCRSpec would leave Lakekeeper in allowall mode while
+	// the worker tells DuckDB to POST to the broker. Lakekeeper would
+	// then reject the token because k8s auth wasn't actually enabled.
+	cr, err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).
+		Get(context.Background(), LakekeeperResourceName("oidc-org"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR for cross-check: %v", err)
+	}
+	specMap := cr.Object["spec"].(map[string]interface{})
+	auth, ok := specMap["authentication"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.authentication missing on CR — would be allowall in prod")
+	}
+	k8sAuth, ok := auth["kubernetes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.authentication.kubernetes missing on CR")
+	}
+	if k8sAuth["enabled"] != true {
+		t.Errorf("spec.authentication.kubernetes.enabled = %v, want true", k8sAuth["enabled"])
+	}
+	auds, ok := k8sAuth["audiences"].([]interface{})
+	if !ok || len(auds) != 1 || auds[0] != "lakekeeper" {
+		t.Errorf("audiences = %v, want [lakekeeper]", k8sAuth["audiences"])
+	}
 }
 
 func TestEnsureForOrg_OAuth2URIEmptyInAllowallMode(t *testing.T) {

--- a/server/lakekeeperbroker/broker.go
+++ b/server/lakekeeperbroker/broker.go
@@ -1,0 +1,214 @@
+// Package lakekeeperbroker is a tiny in-process HTTP server that bridges
+// DuckDB's OAuth2 client_credentials expectations to a Kubernetes-projected
+// ServiceAccount token. The DuckDB iceberg extension knows how to fetch a
+// bearer token via OAuth2 (POST grant_type=client_credentials), but not how
+// to load one from disk. The broker handles the disk read and hands the
+// token back wrapped in an OAuth2 response shape that DuckDB accepts.
+//
+// Lifecycle:
+//   - The worker starts the broker at boot, before any client session can run.
+//   - kubelet refreshes the projected SA token on its own schedule (default
+//     well under 1h); each /token request re-reads the file so we always
+//     hand DuckDB the current token.
+//   - The activation payload's LakekeeperOAuth2ServerURI points at
+//     http://127.0.0.1:<broker-port>/token, so the broker is reachable only
+//     from inside the worker pod.
+//
+// Why an in-process broker rather than a sidecar:
+//   - One process to lifecycle and observe.
+//   - No extra container in the duckling pod spec.
+//   - The token file is mounted via a projected volume; the broker is the
+//     only consumer.
+package lakekeeperbroker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Broker is an HTTP server that wraps a projected SA token file as an
+// OAuth2 client_credentials response.
+type Broker struct {
+	tokenPath string
+	srv       *http.Server
+	listener  net.Listener
+
+	// expiresInSeconds is what we return in the OAuth2 response. DuckDB's
+	// iceberg extension uses this to decide when to re-fetch. A short
+	// value (default 60) keeps DuckDB in sync with kubelet's projected
+	// token rotation; a long value reduces /token QPS but risks DuckDB
+	// using a stale token after kubelet rotates.
+	expiresInSeconds int
+
+	mu      sync.Mutex
+	started bool
+}
+
+// New builds a Broker that reads its token from tokenPath. The path must
+// be readable at request time, not just at construction — the file is
+// rotated by kubelet on the projected-token TTL schedule.
+func New(tokenPath string) *Broker {
+	return &Broker{
+		tokenPath:        tokenPath,
+		expiresInSeconds: 60,
+	}
+}
+
+// WithExpiresIn overrides the expires_in (seconds) value in the OAuth2
+// response. Default 60. Lower values increase /token QPS but reduce the
+// window in which DuckDB could be holding a stale token after kubelet
+// rotation.
+func (b *Broker) WithExpiresIn(s int) *Broker {
+	b.expiresInSeconds = s
+	return b
+}
+
+// ListenAndServe starts the broker on the given loopback addr (e.g.
+// "127.0.0.1:9876"). Returns once the listener is bound; the HTTP server
+// runs in a background goroutine. Use Shutdown to stop it cleanly.
+//
+// Binding loopback-only is intentional — only the local worker process
+// should ever hit /token, and exposing the wrapped SA token to any
+// non-loopback caller would be a real credential leak.
+func (b *Broker) ListenAndServe(addr string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.started {
+		return errors.New("broker already started")
+	}
+	if !strings.HasPrefix(addr, "127.0.0.1:") && !strings.HasPrefix(addr, "[::1]:") {
+		return fmt.Errorf("broker addr %q must bind to loopback; non-loopback would leak the SA token", addr)
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("broker listen: %w", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", b.handleToken)
+	mux.HandleFunc("/health", b.handleHealth)
+	b.listener = ln
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+	b.srv = srv
+	b.started = true
+	// Capture srv in the closure rather than b.srv — Shutdown nil-clears
+	// the struct field, so a goroutine that reads b.srv directly can
+	// race with Shutdown and panic.
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			fmt.Fprintf(os.Stderr, "lakekeeper broker: serve: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+// Addr returns the bound address, useful when the caller passed a :0 port
+// and wants to know what was picked.
+func (b *Broker) Addr() string {
+	if b.listener == nil {
+		return ""
+	}
+	return b.listener.Addr().String()
+}
+
+// Shutdown stops the broker gracefully. Safe to call multiple times.
+func (b *Broker) Shutdown(ctx context.Context) error {
+	b.mu.Lock()
+	srv := b.srv
+	b.srv = nil
+	b.started = false
+	b.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
+}
+
+// tokenResponse is the JSON shape DuckDB's iceberg extension expects from
+// an OAuth2 client_credentials response.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type errorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func (b *Broker) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		b.respondError(w, http.StatusMethodNotAllowed, "invalid_request", "POST only")
+		return
+	}
+	// Read the projected SA token. The kubelet refreshes this file on its
+	// own schedule; each request gets the freshest copy.
+	raw, err := os.ReadFile(b.tokenPath)
+	if err != nil {
+		// 503 rather than 500 — file-not-yet-mounted is transient.
+		b.respondError(w, http.StatusServiceUnavailable, "server_error",
+			fmt.Sprintf("read token file: %v", err))
+		return
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		b.respondError(w, http.StatusServiceUnavailable, "server_error", "token file empty")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(tokenResponse{
+		AccessToken: token,
+		TokenType:   "Bearer",
+		ExpiresIn:   b.expiresInSeconds,
+	})
+}
+
+func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(b.tokenPath); err != nil {
+		b.respondError(w, http.StatusServiceUnavailable, "unhealthy",
+			fmt.Sprintf("token path %q: %v", b.tokenPath, err))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (b *Broker) respondError(w http.ResponseWriter, status int, code, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: code, ErrorDescription: desc})
+}
+
+// DefaultPort is the loopback port we bind to in the worker pod. Picked
+// to avoid common app ports; mirrored in the activation payload's
+// LakekeeperOAuth2ServerURI value.
+const DefaultPort = 9876
+
+// DefaultAddr is the loopback address for the broker.
+const DefaultAddr = "127.0.0.1:9876"
+
+// DefaultTokenPath is the conventional mount path for the projected SA
+// token. The duckling pod spec must mount a projected volume here with
+// audience matching Lakekeeper's authentication.kubernetes.audiences.
+const DefaultTokenPath = "/var/run/secrets/lakekeeper/token"
+
+// DefaultOAuth2ServerURI is the value written to ManagedWarehouseIceberg.
+// LakekeeperOAuth2ServerURI when the provisioner runs in OIDC mode. The
+// worker activator ships it to the worker, which uses it as DuckDB's
+// OAUTH2_SERVER_URI — the worker's own broker is what DuckDB ends up
+// POSTing to.
+const DefaultOAuth2ServerURI = "http://127.0.0.1:9876/token"

--- a/server/lakekeeperbroker/broker.go
+++ b/server/lakekeeperbroker/broker.go
@@ -66,6 +66,11 @@ func New(tokenPath string) *Broker {
 // response. Default 60. Lower values increase /token QPS but reduce the
 // window in which DuckDB could be holding a stale token after kubelet
 // rotation.
+//
+// TODO(PR5): the worker binary doesn't expose this override via env yet
+// — the duckling pod spec work that lands the projected SA volume
+// should also wire DUCKGRES_LAKEKEEPER_TOKEN_EXPIRES_IN. Until then,
+// every duckling uses the default 60s.
 func (b *Broker) WithExpiresIn(s int) *Broker {
 	b.expiresInSeconds = s
 	return b
@@ -169,7 +174,12 @@ func (b *Broker) handleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	// RFC 6749 §5.1: token responses must include both Cache-Control: no-store
+	// and Pragma: no-cache. The latter is an HTTP/1.0 remnant that won't matter
+	// on a loopback connection to DuckDB, but the broker is otherwise spec-
+	// compliant and the header is one line.
 	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	_ = json.NewEncoder(w).Encode(tokenResponse{
 		AccessToken: token,
 		TokenType:   "Bearer",

--- a/server/lakekeeperbroker/broker_test.go
+++ b/server/lakekeeperbroker/broker_test.go
@@ -57,6 +57,9 @@ func TestTokenEndpointReturnsFileContents(t *testing.T) {
 	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
 		t.Errorf("cache-control = %q, want no-store", cc)
 	}
+	if pr := resp.Header.Get("Pragma"); pr != "no-cache" {
+		t.Errorf("pragma = %q, want no-cache (RFC 6749 §5.1)", pr)
+	}
 	var tr tokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
 		t.Fatalf("decode: %v", err)

--- a/server/lakekeeperbroker/broker_test.go
+++ b/server/lakekeeperbroker/broker_test.go
@@ -1,0 +1,205 @@
+package lakekeeperbroker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTempToken(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "token")
+	if err := os.WriteFile(p, []byte(contents), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	return p
+}
+
+func startBroker(t *testing.T, tokenPath string) *Broker {
+	t.Helper()
+	b := New(tokenPath)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = b.Shutdown(ctx)
+	})
+	return b
+}
+
+func TestTokenEndpointReturnsFileContents(t *testing.T) {
+	const want = "eyJ.fake.jwt"
+	p := writeTempToken(t, want+"\n") // trailing newline gets trimmed
+	b := startBroker(t, p)
+
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", url.Values{
+		"grant_type": {"client_credentials"},
+	})
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("cache-control = %q, want no-store", cc)
+	}
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tr.AccessToken != want {
+		t.Errorf("access_token = %q, want %q", tr.AccessToken, want)
+	}
+	if tr.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", tr.TokenType)
+	}
+	if tr.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want positive", tr.ExpiresIn)
+	}
+}
+
+func TestTokenEndpointReReadsFileEachRequest(t *testing.T) {
+	// Verifies that kubelet token rotation is picked up — the broker
+	// must not cache the token contents in memory.
+	p := writeTempToken(t, "first-token")
+	b := startBroker(t, p)
+
+	get := func() string {
+		resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+		if err != nil {
+			t.Fatalf("POST /token: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var tr tokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return tr.AccessToken
+	}
+	if got := get(); got != "first-token" {
+		t.Fatalf("first = %q", got)
+	}
+	if err := os.WriteFile(p, []byte("second-token"), 0600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if got := get(); got != "second-token" {
+		t.Fatalf("second = %q, want second-token (broker should re-read on each request)", got)
+	}
+}
+
+func TestTokenEndpointGETIsRejected(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := startBroker(t, p)
+	resp, err := http.Get("http://" + b.Addr() + "/token")
+	if err != nil {
+		t.Fatalf("GET /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestTokenEndpointMissingFileReturns503(t *testing.T) {
+	b := startBroker(t, "/nonexistent/path")
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestTokenEndpointEmptyFileReturns503(t *testing.T) {
+	p := writeTempToken(t, "   \n\t ")
+	b := startBroker(t, p)
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("empty token file should 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := startBroker(t, p)
+	resp, err := http.Get("http://" + b.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHealthEndpointReports503WhenTokenMissing(t *testing.T) {
+	b := startBroker(t, "/no/such/file")
+	resp, err := http.Get("http://" + b.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestRefusesToBindNonLoopback(t *testing.T) {
+	b := New("irrelevant")
+	if err := b.ListenAndServe("0.0.0.0:0"); err == nil {
+		t.Fatal("expected error binding to non-loopback")
+	} else if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("error should mention loopback: %v", err)
+	}
+}
+
+func TestStartTwiceErrors(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := New(p)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("first ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Shutdown(context.Background()) })
+	if err := b.ListenAndServe("127.0.0.1:0"); err == nil {
+		t.Fatal("expected error on double-start")
+	}
+}
+
+func TestExpiresInOverride(t *testing.T) {
+	p := writeTempToken(t, "abc")
+	b := New(p).WithExpiresIn(300)
+	if err := b.ListenAndServe("127.0.0.1:0"); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Shutdown(context.Background()) })
+	resp, err := http.PostForm("http://"+b.Addr()+"/token", nil)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var tr tokenResponse
+	_ = json.NewDecoder(resp.Body).Decode(&tr)
+	if tr.ExpiresIn != 300 {
+		t.Errorf("expires_in = %d, want 300", tr.ExpiresIn)
+	}
+}


### PR DESCRIPTION
## Summary

Fourth and final PR in the Lakekeeper-as-Iceberg-catalog series. Adds defense-in-depth for the duckling → Lakekeeper path. Until now, isolation between orgs depended entirely on NetworkPolicy + allowall on the Lakekeeper side. PR4 turns on the operator's \`authentication.kubernetes\` mode so Lakekeeper validates the duckling's projected SA token against the K8s TokenReview API.

**Targets \`lakekeeper-pr3-provisioning-trigger\` as the base** — stacked PR; merge #574, #576, #579 first.

## The bridge problem

DuckDB's iceberg extension fetches its bearer via OAuth2 (POST client_credentials), not by reading a file. The duckling has a projected SA token at \`/var/run/secrets/lakekeeper/token\`. The bridge is a tiny in-process HTTP server that handles POST /token by reading the file and wrapping it as an OAuth2 response. Kubelet rotates the file in place; the broker re-reads on every request, so no token-rotation surgery is needed.

## What's in this PR

- **\`server/lakekeeperbroker\`** (new package) — HTTP broker, loopback-only. POST /token reads the SA token from disk + wraps it. Refuses to bind to non-loopback (exposing the wrapped SA token elsewhere would be a real leak). 10 unit tests covering happy path, file rotation pickup, GET rejection, missing/empty 503s, health endpoint, double-start protection, expires_in override, loopback enforcement.
- **\`cmd/duckgres-worker\`** — starts the broker when \`DUCKGRES_LAKEKEEPER_TOKEN_PATH\` is set. Unset → no broker, existing duckling pods unaffected.
- **\`LakekeeperCRSpec.KubernetesAuthAudiences\`** — non-empty populates \`spec.authentication.kubernetes\` on the CR (operator turns this into \`LAKEKEEPER__K8S_AUTH_*\`). Empty keeps Lakekeeper in allowall mode (PR1/2 deployment shape).
- **\`ProvisioningInputs.KubernetesAuthAudiences\`** threads through to the CR. When non-empty, \`EnsureForOrg\` also writes \`LakekeeperOAuth2ServerURI=http://127.0.0.1:9876/token\` (the worker-local broker) to the warehouse row, so the worker's ATTACH builder emits the OAuth2 secret + ATTACH form instead of \`AUTHORIZATION_TYPE 'none'\`.

## What's NOT in this PR

- **Pod spec / chart changes** adding the projected SA volume mount. That's a follow-up in PostHog/charts where the duckling pod template lives. Until that lands, the broker is dormant.
- **Changes to the controller's \`LakekeeperInputsResolver\`** to set \`KubernetesAuthAudiences\` by default. The flag lives in \`ProvisioningInputs\` and callers opt in when ready.

## Test plan

- [x] \`go test ./server/lakekeeperbroker/\` — 10 cases, all pass
- [x] \`go test -tags kubernetes ./controlplane/provisioner/\` — 4 new cases for the CR authentication block + OAUTH2_SERVER_URI persistence in both modes
- [x] Full sweep + \`golangci-lint\` clean
- [ ] CI
- [ ] (follow-up) Wire pod spec, run orbstack e2e with OIDC enabled, verify the broker → Lakekeeper round-trip end to end

## Stacked

\`\`\`
main
└── lakekeeper-pr1 (#574)
    └── lakekeeper-pr2-worker-wiring (#576)
        └── lakekeeper-pr3-provisioning-trigger (#579)
            └── lakekeeper-pr4-oidc (this PR)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)