### PR TITLE
feat(controlplane): wire Lakekeeper provisioner into control plane (PR5)

### DIFF
--- a/controlplane/lakekeeper_inputs.go
+++ b/controlplane/lakekeeper_inputs.go
@@ -1,0 +1,201 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+)
+
+// Environment variables that drive the Lakekeeper provisioner. The toggle is
+// off by default so existing deployments are unaffected until an operator
+// explicitly opts in.
+const (
+	envLakekeeperEnabled = "DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED"
+
+	// Dev/orbstack fallback inputs, used only when an org has no
+	// Crossplane-provisioned Duckling CR to read infrastructure from
+	// (local MinIO + a plain Postgres). In prod these come from the CR.
+	envLakekeeperAdminDSN   = "DUCKGRES_LAKEKEEPER_ADMIN_DSN"
+	envLakekeeperPGHost     = "DUCKGRES_LAKEKEEPER_PG_HOST"
+	envLakekeeperPGPort     = "DUCKGRES_LAKEKEEPER_PG_PORT"
+	envLakekeeperPGSSLMode  = "DUCKGRES_LAKEKEEPER_PG_SSLMODE"
+	envLakekeeperS3Bucket   = "DUCKGRES_LAKEKEEPER_S3_BUCKET"
+	envLakekeeperS3Region   = "DUCKGRES_LAKEKEEPER_S3_REGION"
+	envLakekeeperS3Endpoint = "DUCKGRES_LAKEKEEPER_S3_ENDPOINT"
+	envLakekeeperS3Flavor   = "DUCKGRES_LAKEKEEPER_S3_FLAVOR"
+	envLakekeeperS3KeyID    = "DUCKGRES_LAKEKEEPER_S3_ACCESS_KEY_ID"
+	envLakekeeperS3Secret   = "DUCKGRES_LAKEKEEPER_S3_SECRET_ACCESS_KEY"
+)
+
+// lakekeeperProvisionerEnabled reports whether the control plane should wire
+// the Lakekeeper provisioner branch into the provisioning controller.
+func lakekeeperProvisionerEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envLakekeeperEnabled)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// newLakekeeperInputsResolver builds the per-org ProvisioningInputs resolver
+// the provisioning controller calls before EnsureForOrg.
+//
+// Two sources, in priority order:
+//
+//  1. The Crossplane-provisioned Duckling CR (prod). The CR's metadata-store
+//     master credentials double as the admin connection that can CREATE the
+//     lakekeeper_<orgid> database/role, and its data-store bucket is the S3
+//     warehouse Lakekeeper hands out. The Lakekeeper pod uses its own IRSA
+//     identity for S3 (no static creds), so we leave them empty.
+//
+//  2. Environment-configured fallback (dev/orbstack with MinIO). Used when no
+//     Duckling CR resolver is available, or the CR has no usable
+//     metadata-store/data-store yet.
+//
+// KubernetesAuthAudiences is always empty here: this wires the allowall +
+// NetworkPolicy deployment shape. Enabling OIDC SA-token auth is a separate,
+// flag-day change (see ProvisioningInputs.KubernetesAuthAudiences).
+func newLakekeeperInputsResolver(
+	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error),
+) provisioner.LakekeeperInputsResolver {
+	return func(ctx context.Context, w *configstore.ManagedWarehouse) (provisioner.ProvisioningInputs, error) {
+		if resolveDucklingStatus != nil {
+			in, ok, err := lakekeeperInputsFromDuckling(ctx, resolveDucklingStatus, w.OrgID)
+			if err != nil {
+				// CR exists but is malformed/incomplete — fall through to the
+				// env fallback rather than hard-failing, mirroring how
+				// BuildActivationRequest degrades to the config-store path.
+				if env, ok := lakekeeperInputsFromEnv(); ok {
+					return env, nil
+				}
+				return provisioner.ProvisioningInputs{}, fmt.Errorf("resolve lakekeeper inputs for org %q from duckling CR: %w", w.OrgID, err)
+			}
+			if ok {
+				return in, nil
+			}
+		}
+		if env, ok := lakekeeperInputsFromEnv(); ok {
+			return env, nil
+		}
+		return provisioner.ProvisioningInputs{}, fmt.Errorf("no lakekeeper provisioning inputs for org %q: no usable Duckling CR and %s/%s/%s not set",
+			w.OrgID, envLakekeeperAdminDSN, envLakekeeperS3Bucket, envLakekeeperS3Region)
+	}
+}
+
+// lakekeeperInputsFromDuckling derives inputs from the Duckling CR status.
+// Returns ok=false (no error) when the resolver simply has no CR for the org,
+// so the caller can fall back to env config without logging it as a failure.
+func lakekeeperInputsFromDuckling(
+	ctx context.Context,
+	resolve func(context.Context, string) (*provisioner.DucklingStatus, error),
+	orgID string,
+) (provisioner.ProvisioningInputs, bool, error) {
+	status, err := resolve(ctx, orgID)
+	if err != nil {
+		return provisioner.ProvisioningInputs{}, false, nil
+	}
+	if status == nil || status.MetadataStore.Endpoint == "" {
+		return provisioner.ProvisioningInputs{}, false, nil
+	}
+	if status.MetadataStore.Password == "" || status.MetadataStore.User == "" || status.MetadataStore.Database == "" {
+		return provisioner.ProvisioningInputs{}, false, fmt.Errorf("duckling CR for org %q has incomplete metadata-store credentials", orgID)
+	}
+	if status.DataStore.BucketName == "" || status.DataStore.S3Region == "" {
+		return provisioner.ProvisioningInputs{}, false, fmt.Errorf("duckling CR for org %q has no data-store bucket/region", orgID)
+	}
+
+	// Admin DDL (CREATE DATABASE/ROLE) goes to the direct Aurora endpoint, not
+	// the PgBouncer pooler — transaction pooling breaks CREATE DATABASE and the
+	// session-level statements EnsureRole runs. We connect to the existing
+	// metadata-store database; CREATE DATABASE can be issued from any database.
+	adminDSN := buildAdminURLDSN(
+		status.MetadataStore.Endpoint, 5432,
+		status.MetadataStore.User, status.MetadataStore.Password,
+		status.MetadataStore.Database, "require",
+	)
+
+	return provisioner.ProvisioningInputs{
+		AdminDSN: adminDSN,
+		// The Lakekeeper pod also connects to the direct endpoint: it runs its
+		// own migrations and connection pool, which a transaction pooler would
+		// break.
+		PGHost:    status.MetadataStore.Endpoint,
+		PGPort:    5432,
+		PGSSLMode: "require",
+		S3: provisioner.S3StorageConfig{
+			Bucket: status.DataStore.BucketName,
+			// Keep the catalog's data under a stable prefix so it never
+			// collides with DuckLake's own layout in the shared bucket.
+			KeyPrefix: "lakekeeper",
+			Region:    status.DataStore.S3Region,
+			Flavor:    "aws",
+			// Prod: Lakekeeper uses its pod IRSA identity (no static creds).
+		},
+		// Allowall + NetworkPolicy deployment shape — no OIDC audiences yet.
+		KubernetesAuthAudiences: nil,
+	}, true, nil
+}
+
+// lakekeeperInputsFromEnv builds inputs from environment variables for
+// dev/orbstack (MinIO). Returns ok=false when the minimum set isn't present.
+func lakekeeperInputsFromEnv() (provisioner.ProvisioningInputs, bool) {
+	adminDSN := strings.TrimSpace(os.Getenv(envLakekeeperAdminDSN))
+	bucket := strings.TrimSpace(os.Getenv(envLakekeeperS3Bucket))
+	region := strings.TrimSpace(os.Getenv(envLakekeeperS3Region))
+	if adminDSN == "" || bucket == "" || region == "" {
+		return provisioner.ProvisioningInputs{}, false
+	}
+
+	pgHost := strings.TrimSpace(os.Getenv(envLakekeeperPGHost))
+	pgPort := int32(0)
+	if v := strings.TrimSpace(os.Getenv(envLakekeeperPGPort)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			pgPort = int32(n)
+		}
+	}
+	sslMode := strings.TrimSpace(os.Getenv(envLakekeeperPGSSLMode))
+	if sslMode == "" {
+		sslMode = "require"
+	}
+	flavor := strings.TrimSpace(os.Getenv(envLakekeeperS3Flavor))
+	if flavor == "" {
+		flavor = "aws"
+	}
+
+	return provisioner.ProvisioningInputs{
+		AdminDSN:  adminDSN,
+		PGHost:    pgHost,
+		PGPort:    pgPort,
+		PGSSLMode: sslMode,
+		S3: provisioner.S3StorageConfig{
+			Bucket:                bucket,
+			Region:                region,
+			Endpoint:              strings.TrimSpace(os.Getenv(envLakekeeperS3Endpoint)),
+			Flavor:                flavor,
+			StaticAccessKeyID:     strings.TrimSpace(os.Getenv(envLakekeeperS3KeyID)),
+			StaticAccessKeySecret: strings.TrimSpace(os.Getenv(envLakekeeperS3Secret)),
+		},
+		KubernetesAuthAudiences: nil,
+	}, true
+}
+
+// buildAdminURLDSN renders a pgx-compatible URL-style DSN. URL form is what
+// the provisioner's reDSN rewrites when it scopes a connection to a specific
+// database, so we emit that form here.
+func buildAdminURLDSN(host string, port int, user, password, dbName, sslMode string) string {
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   "/" + dbName,
+	}
+	q := u.Query()
+	q.Set("sslmode", sslMode)
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/controlplane/lakekeeper_inputs_test.go
+++ b/controlplane/lakekeeper_inputs_test.go
@@ -1,0 +1,164 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+)
+
+func ducklingStatusWithWarehouse() *provisioner.DucklingStatus {
+	s := &provisioner.DucklingStatus{}
+	s.MetadataStore.Endpoint = "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com"
+	s.MetadataStore.PgBouncerEndpoint = "pgb-acme.svc:6432"
+	s.MetadataStore.User = "ducklingacme"
+	s.MetadataStore.Password = "s3cr3t"
+	s.MetadataStore.Database = "ducklingacme"
+	s.DataStore.BucketName = "posthog-duckling-acme"
+	s.DataStore.S3Region = "us-east-1"
+	s.IAMRoleARN = "arn:aws:iam::123:role/duckling-acme"
+	return s
+}
+
+func TestResolverFromDucklingCR(t *testing.T) {
+	// No env fallback configured, so this must come purely from the CR.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		return ducklingStatusWithWarehouse(), nil
+	}
+	r := newLakekeeperInputsResolver(resolve)
+
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "acme"})
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+
+	// Admin DSN must target the DIRECT endpoint (not the PgBouncer pooler),
+	// be URL-form, carry the master creds, and request sslmode=require.
+	u, perr := url.Parse(in.AdminDSN)
+	if perr != nil {
+		t.Fatalf("admin DSN not a URL: %q (%v)", in.AdminDSN, perr)
+	}
+	if u.Hostname() != "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com" {
+		t.Errorf("admin DSN host = %q, want direct RDS endpoint (not pgbouncer)", u.Hostname())
+	}
+	if strings.Contains(in.AdminDSN, "pgb-acme") || strings.Contains(in.AdminDSN, "6432") {
+		t.Errorf("admin DSN must not use the PgBouncer pooler: %q", in.AdminDSN)
+	}
+	if pw, _ := u.User.Password(); pw != "s3cr3t" || u.User.Username() != "ducklingacme" {
+		t.Errorf("admin DSN creds wrong: %q", u.Redacted())
+	}
+	if got := u.Query().Get("sslmode"); got != "require" {
+		t.Errorf("sslmode = %q, want require", got)
+	}
+
+	if in.PGHost != "duckling-acme.cluster-xyz.us-east-1.rds.amazonaws.com" || in.PGPort != 5432 {
+		t.Errorf("PGHost/PGPort = %q/%d, want direct endpoint:5432", in.PGHost, in.PGPort)
+	}
+	if in.PGSSLMode != "require" {
+		t.Errorf("PGSSLMode = %q, want require", in.PGSSLMode)
+	}
+	if in.S3.Bucket != "posthog-duckling-acme" || in.S3.Region != "us-east-1" || in.S3.Flavor != "aws" {
+		t.Errorf("S3 = %+v, want bucket/region/aws from CR", in.S3)
+	}
+	if in.S3.StaticAccessKeyID != "" || in.S3.StaticAccessKeySecret != "" {
+		t.Errorf("prod S3 must use pod IRSA, not static creds: %+v", in.S3)
+	}
+	if len(in.KubernetesAuthAudiences) != 0 {
+		t.Errorf("expected allowall mode (no audiences), got %v", in.KubernetesAuthAudiences)
+	}
+}
+
+func TestResolverFromEnvFallback(t *testing.T) {
+	t.Setenv(envLakekeeperAdminDSN, "postgres://admin:pw@127.0.0.1:5432/postgres?sslmode=disable")
+	t.Setenv(envLakekeeperPGHost, "127.0.0.1")
+	t.Setenv(envLakekeeperPGPort, "5432")
+	t.Setenv(envLakekeeperPGSSLMode, "disable")
+	t.Setenv(envLakekeeperS3Bucket, "warehouse")
+	t.Setenv(envLakekeeperS3Region, "us-east-1")
+	t.Setenv(envLakekeeperS3Endpoint, "http://minio.minio.svc:9000")
+	t.Setenv(envLakekeeperS3Flavor, "s3-compat")
+	t.Setenv(envLakekeeperS3KeyID, "minioadmin")
+	t.Setenv(envLakekeeperS3Secret, "minioadmin")
+
+	// nil resolver → straight to env fallback.
+	r := newLakekeeperInputsResolver(nil)
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "dev"})
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if in.AdminDSN == "" || in.PGHost != "127.0.0.1" || in.PGPort != 5432 {
+		t.Errorf("env inputs wrong: %+v", in)
+	}
+	if in.PGSSLMode != "disable" {
+		t.Errorf("PGSSLMode = %q, want disable", in.PGSSLMode)
+	}
+	if in.S3.Endpoint != "http://minio.minio.svc:9000" || in.S3.Flavor != "s3-compat" {
+		t.Errorf("S3 = %+v, want MinIO endpoint + s3-compat", in.S3)
+	}
+	if in.S3.StaticAccessKeyID != "minioadmin" || in.S3.StaticAccessKeySecret != "minioadmin" {
+		t.Errorf("S3 static creds not propagated: %+v", in.S3)
+	}
+}
+
+func TestResolverDucklingErrorFallsBackToEnv(t *testing.T) {
+	t.Setenv(envLakekeeperAdminDSN, "postgres://admin:pw@127.0.0.1:5432/postgres?sslmode=disable")
+	t.Setenv(envLakekeeperS3Bucket, "warehouse")
+	t.Setenv(envLakekeeperS3Region, "us-east-1")
+
+	// CR resolver errors (e.g. no Duckling for this org) → env fallback used.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		return nil, errors.New("duckling not found")
+	}
+	r := newLakekeeperInputsResolver(resolve)
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "dev"})
+	if err != nil {
+		t.Fatalf("expected env fallback, got error: %v", err)
+	}
+	if in.S3.Bucket != "warehouse" {
+		t.Errorf("expected env inputs, got %+v", in)
+	}
+}
+
+func TestResolverIncompleteCRWithoutEnvErrors(t *testing.T) {
+	// CR present but missing bucket, and no env configured → hard error.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		s := &provisioner.DucklingStatus{}
+		s.MetadataStore.Endpoint = "host"
+		s.MetadataStore.User = "u"
+		s.MetadataStore.Password = "p"
+		s.MetadataStore.Database = "d"
+		// DataStore left empty.
+		return s, nil
+	}
+	r := newLakekeeperInputsResolver(resolve)
+	if _, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "acme"}); err == nil {
+		t.Fatal("expected error for incomplete CR with no env fallback")
+	}
+}
+
+func TestResolverNoSourcesErrors(t *testing.T) {
+	r := newLakekeeperInputsResolver(nil)
+	if _, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "x"}); err == nil {
+		t.Fatal("expected error when neither CR nor env provide inputs")
+	}
+}
+
+func TestLakekeeperProvisionerEnabledToggle(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"", false}, {"true", true}, {"1", true}, {"yes", true}, {"TRUE", true}, {"false", false}, {"0", false},
+	} {
+		t.Setenv(envLakekeeperEnabled, tc.val)
+		if got := lakekeeperProvisionerEnabled(); got != tc.want {
+			t.Errorf("enabled(%q) = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -347,6 +347,19 @@ func SetupMultiTenant(
 	if err != nil {
 		slog.Warn("Provisioning controller unavailable.", "error", err)
 	} else {
+		// Opt-in: enable the per-org Lakekeeper provisioning branch. Off by
+		// default so existing deploys are unaffected. Best-effort — if the
+		// K8s client can't be built we log and leave the controller running
+		// without the Lakekeeper branch (S3-Tables warehouses still work).
+		if lakekeeperProvisionerEnabled() {
+			if k8sClient, lkErr := provisioner.NewLakekeeperK8sClient(); lkErr != nil {
+				slog.Warn("Lakekeeper provisioner enabled but K8s client unavailable; skipping.", "error", lkErr)
+			} else {
+				lkProv := provisioner.NewLakekeeperProvisioner(store, k8sClient)
+				provCtrl.WithLakekeeperProvisioner(lkProv, newLakekeeperInputsResolver(resolveDucklingStatus))
+				slog.Info("Lakekeeper provisioner enabled (allowall + NetworkPolicy mode).")
+			}
+		}
 		go provCtrl.Run(context.Background())
 	}
 


### PR DESCRIPTION
## What & why

The provisioning controller gained `WithLakekeeperProvisioner` in PR3, but **nothing ever called it** — so `reconcileLakekeeper` was inert in every deployment. This PR wires it into the multitenant control plane, making per-org Lakekeeper provisioning actually run.

Lands the **allowall + NetworkPolicy** deployment shape (empty `KubernetesAuthAudiences`). OIDC SA-token auth (PR4's broker) remains a separate flag-day change.

> Stacked on PR4 (#580, merged into `lakekeeper-pr3-provisioning-trigger`). Base will retarget to `main` once PR3 (#579) merges.

## Changes

- **`controlplane/lakekeeper_inputs.go`** — `newLakekeeperInputsResolver`, resolving per-org `ProvisioningInputs` from two sources:
  1. **Crossplane Duckling CR status** (prod) — the same source `shared_worker_activator.go` already reads. Metadata-store master creds → admin DSN (CREATE DATABASE/ROLE); data-store bucket → S3 warehouse. Admin DDL **and** the Lakekeeper pod target the **direct Aurora endpoint, never PgBouncer** (transaction pooling breaks `CREATE DATABASE` and Lakekeeper's own migrations). S3 uses the pod's IRSA identity (no static creds).
  2. **Env fallback** (dev/orbstack + MinIO) when no usable Duckling CR is present.
- **`controlplane/multitenant.go`** — wires `WithLakekeeperProvisioner` after `NewController`, gated behind `DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED` (off by default; best-effort if the K8s client can't be built). S3-Tables warehouses are unaffected.

## Testing

- `go build -tags kubernetes ./controlplane/...` clean; default build clean.
- New resolver unit tests: CR path, env fallback, CR-error→env fallback, incomplete-CR error, no-source error, enable toggle. All green with `-tags kubernetes`.
- Lint clean.

## Deploy notes

- Off by default. To enable on dev: set `DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED=true` plus the `DUCKGRES_LAKEKEEPER_*` env fallbacks (admin DSN, S3 bucket/region/endpoint, MinIO creds).
- Still pending before a first prod org: prod operator AppSet/values (charts) and confirming the operator sets an IRSA-annotated ServiceAccount on the Lakekeeper pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)