### PR TITLE
[codex] Fix Tableau public information_schema compat view routing

### DIFF
--- a/transpiler/transform/information_schema.go
+++ b/transpiler/transform/information_schema.go
@@ -76,6 +76,17 @@ func (t *InformationSchemaTransform) walkAndTransform(node *pg_query.Node, chang
 				*changed = true
 			}
 			// If no mapping, leave as-is (DuckDB will handle it)
+		} else if n.RangeVar != nil && n.RangeVar.Catalogname == "" && strings.EqualFold(n.RangeVar.Schemaname, "public") {
+			// Some clients cache or re-query the compat view names that duckgres
+			// exposes through metadata, often as "public"."information_schema_*_compat".
+			// Those views physically live in memory.main, so route direct references
+			// back to their real location.
+			if compatName, ok := t.compatViewName(n.RangeVar.Relname); ok {
+				n.RangeVar.Relname = compatName
+				n.RangeVar.Catalogname = "memory"
+				n.RangeVar.Schemaname = "main"
+				*changed = true
+			}
 		}
 
 	case *pg_query.Node_SelectStmt:
@@ -210,6 +221,16 @@ func (t *InformationSchemaTransform) walkAndTransform(node *pg_query.Node, chang
 			}
 		}
 	}
+}
+
+func (t *InformationSchemaTransform) compatViewName(relname string) (string, bool) {
+	relname = strings.ToLower(relname)
+	for _, compatName := range t.ViewMappings {
+		if relname == strings.ToLower(compatName) {
+			return compatName, true
+		}
+	}
+	return "", false
 }
 
 func (t *InformationSchemaTransform) walkSelectStmt(stmt *pg_query.SelectStmt, changed *bool) {

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -182,6 +182,18 @@ func TestTranspile_InformationSchema(t *testing.T) {
 			excludes: "information_schema.columns",
 		},
 		{
+			name:     "quoted public compat view from Tableau metadata cache",
+			input:    `SELECT * FROM "public"."information_schema_views_compat" WHERE 1 = 0 LIMIT 0`,
+			contains: "memory.main.information_schema_views_compat",
+			excludes: "public.information_schema_views_compat",
+		},
+		{
+			name:     "main compat-like table name is not hijacked",
+			input:    "SELECT * FROM main.information_schema_views_compat",
+			contains: "FROM main.information_schema_views_compat",
+			excludes: "memory.main.information_schema_views_compat",
+		},
+		{
 			name:     "string literal NOT rewritten",
 			input:    "SELECT 'information_schema.columns' AS name",
 			contains: "information_schema.columns",


### PR DESCRIPTION
## Summary

- route direct `public.information_schema_*_compat` references back to `memory.main`
- cover Tableau-style quoted metadata probes such as `"public"."information_schema_views_compat"`

## Why

After PR #586, Tableau can get past managed SNI auth and then issue a metadata probe against `public.information_schema_views_compat`. The compat views physically live in `memory.main`; the query was parsed/deparsed but not canonicalized, so DuckDB tried to resolve a nonexistent `public` schema.

## Validation

- go test ./transpiler -run TestTranspile_InformationSchema/quoted -count=1
- go test ./transpiler -run `TestTranspile_InformationSchema|TestTranspile_PublicSchema|TestTranspile_LogicalDatabaseCatalogMapping` -count=1
- go test ./transpiler -count=1
- go test ./server/sessionmeta -count=1
- go test ./server -run `TestSessionDatabaseMetadata|TestCatalog|TestTranspile` -count=1
- just lint
- git diff --check