### PR TITLE
fix(provisioner): correct Lakekeeper catalog image tag (v0.11.6)

### DIFF
--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -216,7 +216,7 @@ func (c *LakekeeperK8sClient) EnsureServiceAccount(ctx context.Context, orgID st
 // EnsureDatabase.
 type LakekeeperCRSpec struct {
 	OrgID      string
-	Image      string // e.g. quay.io/lakekeeper/catalog:0.11.6
+	Image      string // e.g. quay.io/lakekeeper/catalog:v0.11.6
 	Replicas   int32
 	PGHost     string
 	PGPort     int32

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -127,7 +127,7 @@ func TestEnsureCR_SetsServiceAccountNameWhenProvided(t *testing.T) {
 	ctx := context.Background()
 	base := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",
@@ -155,7 +155,7 @@ func TestEnsureCR_OmitsServiceAccountNameWhenEmpty(t *testing.T) {
 	ctx := context.Background()
 	spec := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",
@@ -188,7 +188,7 @@ func TestEnsureCR_CreateAndShape(t *testing.T) {
 	ctx := context.Background()
 	spec := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -119,8 +119,9 @@ func WithClientFactory(f ClientFactory) LakekeeperProvisionerOption {
 
 // DefaultLakekeeperImage is the pinned image we deploy by default.
 // Bumps to this constant should be paired with a Lakekeeper-operator
-// version compatibility check.
-const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:0.11.6"
+// version compatibility check. The published tags carry a "v" prefix
+// (quay.io/lakekeeper/catalog:v0.11.6) — without it the pull 404s.
+const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:v0.11.6"
 
 // NewLakekeeperProvisioner builds a provisioner. The WarehouseStore is the
 // same interface the existing controller uses for persistence.


### PR DESCRIPTION
## What

`DefaultLakekeeperImage` was `quay.io/lakekeeper/catalog:0.11.6`, which **404s** — the published tags carry a `v` prefix (`v0.11.6`). Verified against quay.io's tag list (`latest`, `v0.11.6`, `v0.11`, `v0`).

## How it surfaced

Lighting up the first org on `managed-warehouse-dev`: the control plane provisioned correctly (Lakekeeper CR + Secret + SA created, operator picked it up), but the migrate Job pod went `ErrImagePull`:

```
Failed to pull image "quay.io/lakekeeper/catalog:0.11.6": ... not found
```

## Fix

`DefaultLakekeeperImage` → `quay.io/lakekeeper/catalog:v0.11.6`, plus the doc comment + `EnsureCR` test fixtures updated to the realistic v-prefixed tag. Build + `-tags kubernetes` provisioner tests green.

## Rollout

Needs a control-plane image rebuild + redeploy to `managed-warehouse-dev` to take effect (the image is baked into the CP binary). The in-flight `ben` provisioning will complete on the next reconcile once the new CP is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)