### PR TITLE
feat(provisioner): pass sts-role-arn for Lakekeeper STS credential vending

### DIFF
--- a/controlplane/lakekeeper_inputs.go
+++ b/controlplane/lakekeeper_inputs.go
@@ -135,6 +135,11 @@ func lakekeeperInputsFromDuckling(
 			Region:    status.DataStore.S3Region,
 			Flavor:    "aws",
 			// Prod: Lakekeeper uses its pod IRSA identity (no static creds).
+			// RoleARN is the per-org duckling role Lakekeeper assumes to vend
+			// scoped S3 creds (sts-role-arn). It's the same role the Lakekeeper
+			// pod runs as via Pod Identity, self-assumed (the role trusts its
+			// own ARN). Sourced from the Duckling CR status.
+			RoleARN: status.IAMRoleARN,
 		},
 		// Allowall + NetworkPolicy deployment shape — no OIDC audiences yet.
 		KubernetesAuthAudiences: nil,

--- a/controlplane/lakekeeper_inputs_test.go
+++ b/controlplane/lakekeeper_inputs_test.go
@@ -69,6 +69,9 @@ func TestResolverFromDucklingCR(t *testing.T) {
 	if in.S3.StaticAccessKeyID != "" || in.S3.StaticAccessKeySecret != "" {
 		t.Errorf("prod S3 must use pod IRSA, not static creds: %+v", in.S3)
 	}
+	if in.S3.RoleARN != "arn:aws:iam::123:role/duckling-acme" {
+		t.Errorf("S3.RoleARN = %q, want the duckling role from CR status (for STS vending)", in.S3.RoleARN)
+	}
 	if len(in.KubernetesAuthAudiences) != 0 {
 		t.Errorf("expected allowall mode (no audiences), got %v", in.KubernetesAuthAudiences)
 	}

--- a/controlplane/provisioner/lakekeeper_client.go
+++ b/controlplane/provisioner/lakekeeper_client.go
@@ -106,6 +106,12 @@ type WarehouseStorageProfile struct {
 	Flavor               string `json:"flavor"`                  // "s3-compat" for MinIO, "aws" for AWS
 	STSEnabled           bool   `json:"sts-enabled"`
 	RemoteSigningEnabled bool   `json:"remote-signing-enabled"`
+	// STSRoleARN is the IAM role Lakekeeper assumes to mint vended (scoped,
+	// short-lived) S3 credentials for clients. Lakekeeper requires it for the
+	// AWS flavor when sts-enabled. Empty for s3-compat (MinIO). We set it to
+	// the per-org duckling role, which the Lakekeeper pod already runs as via
+	// EKS Pod Identity — so it assumes itself (the role trusts its own ARN).
+	STSRoleARN string `json:"sts-role-arn,omitempty"`
 }
 
 // WarehouseStorageCredential supports access-key creds (dev/MinIO) and

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -101,6 +101,12 @@ type S3StorageConfig struct {
 	// in the operator config).
 	StaticAccessKeyID     string
 	StaticAccessKeySecret string
+
+	// RoleARN is the IAM role Lakekeeper assumes to vend scoped S3 credentials
+	// to clients (sts-role-arn). Required for the AWS flavor when STS is on;
+	// the per-org duckling role (Lakekeeper's own Pod Identity, self-assumed).
+	// Empty for s3-compat (MinIO), where STS vending doesn't need a role.
+	RoleARN string
 }
 
 // LakekeeperProvisionerOption tunes the provisioner.
@@ -240,6 +246,10 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 			Flavor:               in.S3.Flavor,
 			STSEnabled:           true,
 			RemoteSigningEnabled: false,
+			// AWS requires a role to assume for STS credential vending. The
+			// per-org duckling role (which the pod runs as) self-assumes.
+			// s3-compat (MinIO) leaves this empty.
+			STSRoleARN: in.S3.RoleARN,
 		},
 		StorageCredential: storageCredFor(in.S3),
 	}


### PR DESCRIPTION
## What

Fixes the last blocker found lighting up the first org (`ben`). The Lakekeeper warehouse-create fails:

```
Either `sts-role-arn` or `assume-role-arn` is required for Storage Profiles
with AWS flavor if STS is enabled.
```

The provisioner sets `sts-enabled: true` on an AWS profile but passed no role ARN. Since the worker's ATTACH hardcodes `ACCESS_DELEGATION_MODE 'vended_credentials'`, Lakekeeper **must** vend — so a role to assume is required, not optional.

## Fix

Use the **per-org `duckling-<org>` role** as the `sts-role-arn`:
- it already has S3 access to the org's bucket, and
- it's the Lakekeeper pod's own identity (EKS Pod Identity), so it **self-assumes** to mint scoped vended creds.

Changes:
- `WarehouseStorageProfile`: new `sts-role-arn` field
- `S3StorageConfig`: new `RoleARN`
- resolver: populate `RoleARN` from the Duckling CR `status.iamRoleArn`
- `EnsureForOrg`: set it on the warehouse storage profile

Empty for s3-compat (MinIO), which doesn't require it. Build + `-tags kubernetes` provisioner tests green.

## Paired change

Requires **charts PR (composition self-assume trust policy)** — the `duckling-<org>` role must trust its own ARN so the pod can `AssumeRole` it. Both must land for STS vending to work. Needs a CP rebuild to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)