### PR TITLE
fix(provisioner): enable allowDirectSystemCredentials on Lakekeeper CR

### DIFF
--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -322,6 +322,15 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 					"listenPort":           int64(8181),
 					"enableDefaultProject": true,
 					"baseURI":              spec.BaseURI,
+					// Let Lakekeeper use the pod's ambient (EKS Pod Identity)
+					// credentials for S3 — needed so it can assume the
+					// warehouse's sts-role-arn to vend. Lakekeeper defaults this
+					// OFF; the operator only emits the enabling env when the
+					// object is present, so we set it explicitly (a nil parent
+					// wouldn't pick up the CRD's default=true).
+					"storageSystemCredentials": map[string]interface{}{
+						"allowDirectSystemCredentials": true,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## What

Next blocker after the `sts-role-arn` fix (#589) landed. The warehouse-create now fails with:

```
Credentials misconfigured: System identity credentials are disabled in this Lakekeeper deployment.
```

We send the `aws-system-identity` storage credential — so Lakekeeper uses its pod's EKS Pod Identity creds to assume the warehouse's `sts-role-arn` and vend. But Lakekeeper defaults that **off**, and the operator only emits the enabling env (`LAKEKEEPER__...ALLOW_DIRECT_SYSTEM_CREDENTIALS`) when `spec.server.storageSystemCredentials` is present. Our CR omitted the object entirely, so the CRD's `default=true` on the nested field never applied (nil parent).

## Fix

Set `spec.server.storageSystemCredentials.allowDirectSystemCredentials = true` in `EnsureCR`. The Lakekeeper pod already has its Pod Identity creds (`AWS_CONTAINER_CREDENTIALS_FULL_URI` set); this just lets Lakekeeper use them.

Build + `-tags kubernetes` provisioner tests green. Needs a CP rebuild to take effect.

## Context

This is the next layer down in the live `ben` smoke test on managed-warehouse-dev. The chain is otherwise fully working: CR bootstrap, operator, PodIdentityAssociation (SYNCED), self-assume trust policy (#11210), `sts-role-arn` (#589) — this is the storage-credential toggle that lets the vend actually execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)