### PR TITLE
fix(provisioner): nest allowDirectSystemCredentials under storageSystemCredentials.aws

### DIFF
--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -326,10 +326,18 @@ func (c *LakekeeperK8sClient) EnsureCR(ctx context.Context, spec LakekeeperCRSpe
 					// credentials for S3 — needed so it can assume the
 					// warehouse's sts-role-arn to vend. Lakekeeper defaults this
 					// OFF; the operator only emits the enabling env when the
-					// object is present, so we set it explicitly (a nil parent
-					// wouldn't pick up the CRD's default=true).
+					// object is present, so we set it explicitly. The flags live
+					// under .aws (gated by enableAWS) — a nil parent wouldn't
+					// pick up the CRD defaults. assumeRoleRequireExternalID is
+					// false: same-account self-assume needs no external id (and
+					// requiring one would force an external-id in the
+					// storage-credential we don't send).
 					"storageSystemCredentials": map[string]interface{}{
-						"allowDirectSystemCredentials": true,
+						"enableAWS": true,
+						"aws": map[string]interface{}{
+							"allowDirectSystemCredentials": true,
+							"assumeRoleRequireExternalID":  false,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## What

Corrects #590, which set the flag at the **wrong path**. The operator CRD nests the AWS credential flags under `.aws` (gated by `enableAWS`):

```
spec.server.storageSystemCredentials.aws.allowDirectSystemCredentials
```

#590 set `spec.server.storageSystemCredentials.allowDirectSystemCredentials` (no `.aws`). The API server prunes that as an unknown field, so #590 was effectively a **no-op** — the `System identity credentials are disabled` error would have persisted after its rebuild.

## How found

Proactive audit of our warehouse storage-profile + CR server config against the operator CRD (`StorageSystemCredentialsConfig` → `AWSConfig`) and Lakekeeper's [S3-STS docs](https://docs.lakekeeper.io/docs/latest/storage/), to catch remaining required fields in one pass instead of one rebuild at a time.

## Fix

```yaml
spec.server.storageSystemCredentials:
  enableAWS: true
  aws:
    allowDirectSystemCredentials: true     # use Pod Identity creds for S3
    assumeRoleRequireExternalID: false     # same-account self-assume; no external-id needed
```

`assumeRoleRequireExternalID: false` is set explicitly to **preempt the next blocker** — we send no `external-id` in the storage-credential, so requiring one would fail the warehouse-create.

Build + `-tags kubernetes` provisioner tests green. Needs a CP rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)