### PR TITLE
fix(provisioner): bump Lakekeeper catalog to v0.12.2 (operator compatibility)

### DIFF
--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -216,7 +216,7 @@ func (c *LakekeeperK8sClient) EnsureServiceAccount(ctx context.Context, orgID st
 // EnsureDatabase.
 type LakekeeperCRSpec struct {
 	OrgID      string
-	Image      string // e.g. quay.io/lakekeeper/catalog:v0.11.6
+	Image      string // e.g. quay.io/lakekeeper/catalog:v0.12.2
 	Replicas   int32
 	PGHost     string
 	PGPort     int32

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -127,7 +127,7 @@ func TestEnsureCR_SetsServiceAccountNameWhenProvided(t *testing.T) {
 	ctx := context.Background()
 	base := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.12.2",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",
@@ -155,7 +155,7 @@ func TestEnsureCR_OmitsServiceAccountNameWhenEmpty(t *testing.T) {
 	ctx := context.Background()
 	spec := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.12.2",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",
@@ -188,7 +188,7 @@ func TestEnsureCR_CreateAndShape(t *testing.T) {
 	ctx := context.Background()
 	spec := LakekeeperCRSpec{
 		OrgID:      "acme",
-		Image:      "quay.io/lakekeeper/catalog:v0.11.6",
+		Image:      "quay.io/lakekeeper/catalog:v0.12.2",
 		PGHost:     "acme-pg.local",
 		PGDatabase: "lakekeeper_acme",
 		SecretName: "lakekeeper-acme",

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -126,8 +126,13 @@ func WithClientFactory(f ClientFactory) LakekeeperProvisionerOption {
 // DefaultLakekeeperImage is the pinned image we deploy by default.
 // Bumps to this constant should be paired with a Lakekeeper-operator
 // version compatibility check. The published tags carry a "v" prefix
-// (quay.io/lakekeeper/catalog:v0.11.6) — without it the pull 404s.
-const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:v0.11.6"
+// (quay.io/lakekeeper/catalog:v0.12.2) — without it the pull 404s.
+//
+// MUST be v0.12.x or later: the operator (lakekeeper_controller.go) emits the
+// v0.12.x config scheme (LAKEKEEPER__STORAGE_CREDENTIAL_BACKEND__AWS__*).
+// v0.11.x ignores those env vars, so e.g. system-identity credential vending
+// silently stays disabled ("System identity credentials are disabled").
+const DefaultLakekeeperImage = "quay.io/lakekeeper/catalog:v0.12.2"
 
 // NewLakekeeperProvisioner builds a provisioner. The WarehouseStore is the
 // same interface the existing controller uses for persistence.


### PR DESCRIPTION
## Root cause

The persistent `System identity credentials are disabled` error is a **version mismatch**, not a config bug.

- The **operator** (`lakekeeper_controller.go`: *"Compatible with Lakekeeper v0.12.x and later"*) emits the **v0.12.x** config scheme: `LAKEKEEPER__STORAGE_CREDENTIAL_BACKEND__AWS__ALLOW_DIRECT_SYSTEM_CREDENTIALS`, `…__ENABLED`, etc.
- We pinned the **catalog to `v0.11.6`**, which doesn't read those env vars.

So everything upstream was correct — confirmed live in `managed-warehouse-dev`:
- the `ben` CR carried the right `storageSystemCredentials.aws.{allowDirectSystemCredentials:true, …}` (#591),
- the operator set the env vars on the v0.11.6 pod,
- …but v0.11.6 ignored them and kept system-identity vending disabled → warehouse-create 400.

## Fix

Bump `DefaultLakekeeperImage` → `quay.io/lakekeeper/catalog:v0.12.2` (latest published v0.12.x), matching the operator. Test fixtures updated. Build + `-tags kubernetes` provisioner tests green; needs a CP rebuild.

## Note

This explains the whole system-creds saga (#590/#591 were necessary but not sufficient — the catalog couldn't read the config they set). With v0.12.2, the operator's env vars are honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)