### PR TITLE
[codex] Add warm capacity miss reason plumbing

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -347,6 +347,18 @@ const (
 	WorkerStateLost       WorkerState = "lost"
 )
 
+// WorkerClaimMissReason classifies why a runtime-store worker claim did not
+// return a worker. The empty reason is reserved for successful claims.
+type WorkerClaimMissReason string
+
+const (
+	WorkerClaimMissReasonNone         WorkerClaimMissReason = ""
+	WorkerClaimMissReasonNoIdle       WorkerClaimMissReason = "no_idle"
+	WorkerClaimMissReasonOrgCap       WorkerClaimMissReason = "org_cap"
+	WorkerClaimMissReasonGlobalCap    WorkerClaimMissReason = "global_cap"
+	WorkerClaimMissReasonShuttingDown WorkerClaimMissReason = "shutting_down"
+)
+
 // WorkerRecord is the durable runtime coordination record for one worker pod.
 type WorkerRecord struct {
 	WorkerID            int         `gorm:"primaryKey" json:"worker_id"`

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -895,8 +895,9 @@ func (cs *ConfigStore) GetWorkerRecord(workerID int) (*WorkerRecord, error) {
 // The selected row is locked with SKIP LOCKED and transitioned to reserved while
 // incrementing owner_epoch. When maxOrgWorkers is set, org claims are serialized
 // under the same advisory lock used for spawn-slot allocation.
-func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*WorkerRecord, error) {
+func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*WorkerRecord, WorkerClaimMissReason, error) {
 	var claimed *WorkerRecord
+	missReason := WorkerClaimMissReasonNone
 	err := cs.db.Transaction(func(tx *gorm.DB) error {
 		if orgID != "" {
 			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", advisoryLockKey("duckgres:org:"+orgID)).Error; err != nil {
@@ -909,6 +910,7 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, m
 				return err
 			}
 			if count >= int64(maxOrgWorkers) {
+				missReason = WorkerClaimMissReasonOrgCap
 				return nil
 			}
 		}
@@ -925,6 +927,7 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, m
 		err := query.Order("worker_id ASC").Take(&current).Error
 		if err != nil {
 			if err == gorm.ErrRecordNotFound {
+				missReason = WorkerClaimMissReasonNoIdle
 				return nil
 			}
 			return err
@@ -951,16 +954,17 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, m
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("claim idle worker: %w", err)
+		return nil, WorkerClaimMissReasonNone, fmt.Errorf("claim idle worker: %w", err)
 	}
-	return claimed, nil
+	return claimed, missReason, nil
 }
 
 // ClaimHotIdleWorker atomically claims one hot-idle worker row that was
 // previously activated for the given org. The selected row is locked with
 // SKIP LOCKED and transitioned to reserved while incrementing owner_epoch.
-func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*WorkerRecord, error) {
+func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*WorkerRecord, WorkerClaimMissReason, error) {
 	var claimed *WorkerRecord
+	missReason := WorkerClaimMissReasonNone
 	err := cs.db.Transaction(func(tx *gorm.DB) error {
 		var current WorkerRecord
 		err := tx.Table(cs.runtimeTable(current.TableName())).
@@ -970,6 +974,7 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*Wor
 			Take(&current).Error
 		if err != nil {
 			if err == gorm.ErrRecordNotFound {
+				missReason = WorkerClaimMissReasonNoIdle
 				return nil
 			}
 			return err
@@ -995,9 +1000,9 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*Wor
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("claim hot-idle worker: %w", err)
+		return nil, WorkerClaimMissReasonNone, fmt.Errorf("claim hot-idle worker: %w", err)
 	}
-	return claimed, nil
+	return claimed, missReason, nil
 }
 
 // ListExpiredHotIdleWorkers returns hot-idle workers whose updated_at timestamp

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -678,6 +678,9 @@ func sessionCreationErrorResponse(err error) (code string, message string) {
 	var capacityErr *WarmCapacityExhaustedError
 	switch {
 	case errors.As(err, &capacityErr):
+		if capacityErr.missReason() == configstore.WorkerClaimMissReasonOrgCap {
+			return "53300", "Duckgres worker capacity for this organization is currently exhausted; retry later"
+		}
 		retryAfter := capacityErr.RetryAfter
 		if retryAfter <= 0 {
 			retryAfter = DefaultWarmCapacityRetryAfter

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightclient"
 )
@@ -89,6 +90,17 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 			t.Fatalf("code = %q, want 53300", code)
 		}
 		want := "no warm Duckgres worker is currently available; retry in about 45 seconds"
+		if message != want {
+			t.Fatalf("message = %q, want %q", message, want)
+		}
+	})
+
+	t.Run("org capacity exhausted", func(t *testing.T) {
+		code, message := sessionCreationErrorResponse(NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, 45*time.Second))
+		if code != "53300" {
+			t.Fatalf("code = %q, want 53300", code)
+		}
+		want := "Duckgres worker capacity for this organization is currently exhausted; retry later"
 		if message != want {
 			t.Fatalf("message = %q, want %q", message, want)
 		}

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1342,7 +1342,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			// Try reclaiming a hot-idle worker for the same org first (fast path:
 			// DuckLake is already attached, only needs epoch bump).
 			if assignment.OrgID != "" {
-				hotClaimed, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID)
+				hotClaimed, _, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID)
 				if err != nil {
 					return nil, err
 				}
@@ -1369,7 +1369,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				}
 			}
 
-			claimed, err := p.runtimeStore.ClaimIdleWorker(p.cpInstanceID, assignment.OrgID, assignment.Image, assignment.MaxWorkers)
+			claimed, missReason, err := p.runtimeStore.ClaimIdleWorker(p.cpInstanceID, assignment.OrgID, assignment.Image, assignment.MaxWorkers)
 			if err != nil {
 				return nil, err
 			}
@@ -1388,7 +1388,7 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				continue
 			}
 
-			return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
+			return nil, NewWarmCapacityExhaustedErrorForReason(missReason, DefaultWarmCapacityRetryAfter)
 		}
 
 		p.mu.Lock()

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -27,6 +27,7 @@ type captureRuntimeWorkerStore struct {
 	records                          []configstore.WorkerRecord
 	claimed                          *configstore.WorkerRecord
 	claimErr                         error
+	claimMissReason                  configstore.WorkerClaimMissReason
 	claimCalls                       int
 	claimOwnerCPID                   string
 	claimOrgID                       string
@@ -61,6 +62,7 @@ type captureRuntimeWorkerStore struct {
 	perImageSpawnTarget              int
 	perImageSpawnMaxGlobal           int
 	hotIdleClaimResult               *configstore.WorkerRecord
+	hotIdleClaimMissReason           configstore.WorkerClaimMissReason
 	hotIdleClaimCPID                 string
 	hotIdleClaimOrgID                string
 	takenOver                        *configstore.WorkerRecord
@@ -120,7 +122,7 @@ func (s *captureRuntimeWorkerStore) snapshot() []configstore.WorkerRecord {
 	return out
 }
 
-func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.claimCalls++
@@ -129,25 +131,25 @@ func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID, im
 	s.claimImage = image
 	s.claimMaxOrgWorkers = maxOrgWorkers
 	if s.claimErr != nil {
-		return nil, s.claimErr
+		return nil, configstore.WorkerClaimMissReasonNone, s.claimErr
 	}
 	if s.claimed == nil {
-		return nil, nil
+		return nil, s.claimMissReason, nil
 	}
 	claimed := *s.claimed
-	return &claimed, nil
+	return &claimed, configstore.WorkerClaimMissReasonNone, nil
 }
 
-func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.hotIdleClaimCPID = ownerCPInstanceID
 	s.hotIdleClaimOrgID = orgID
 	if s.hotIdleClaimResult != nil {
 		r := *s.hotIdleClaimResult
-		return &r, nil
+		return &r, configstore.WorkerClaimMissReasonNone, nil
 	}
-	return nil, nil
+	return nil, s.hotIdleClaimMissReason, nil
 }
 
 func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
@@ -1135,6 +1137,9 @@ func TestK8sPoolReserveSharedWorkerRuntimeMissDoesNotUseInMemoryFallback(t *test
 	if !errors.As(err, &capacityErr) {
 		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
+	if capacityErr.Reason != configstore.WorkerClaimMissReasonNoIdle {
+		t.Fatalf("expected no-idle miss reason, got %q", capacityErr.Reason)
+	}
 	if worker != nil {
 		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
@@ -1408,6 +1413,33 @@ func TestK8sPoolReserveSharedWorkerBackpressuresWhenRuntimeClaimReturnsNil(t *te
 	}
 	if healthChecks != 0 {
 		t.Fatalf("did not expect liveness check for unclaimed local worker, got %d checks", healthChecks)
+	}
+}
+
+func TestK8sPoolReserveSharedWorkerPropagatesRuntimeClaimMissReason(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		claimMissReason: configstore.WorkerClaimMissReasonOrgCap,
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error { return nil }
+
+	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+		OrgID:      "analytics",
+		MaxWorkers: 1,
+	})
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
+	}
+	if capacityErr.Reason != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap miss reason, got %q", capacityErr.Reason)
+	}
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
+	}
+	if store.spawnCalls != 0 || store.neutralSpawnCalls != 0 || store.perImageSpawnCalls != 0 {
+		t.Fatalf("did not expect foreground or async spawn, got spawn=%d neutral=%d per_image=%d", store.spawnCalls, store.neutralSpawnCalls, store.perImageSpawnCalls)
 	}
 }
 

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -17,6 +17,8 @@ const DefaultWarmCapacityRetryAfter = 45 * time.Second
 type WarmCapacityExhaustedError struct {
 	// RetryAfter is the client-facing retry hint for protocol-specific error responses.
 	RetryAfter time.Duration
+	// Reason classifies why the warm-capacity claim missed.
+	Reason configstore.WorkerClaimMissReason
 }
 
 func (e *WarmCapacityExhaustedError) Error() string {
@@ -24,14 +26,31 @@ func (e *WarmCapacityExhaustedError) Error() string {
 	if retryAfter <= 0 {
 		retryAfter = DefaultWarmCapacityRetryAfter
 	}
+	if e.missReason() == configstore.WorkerClaimMissReasonOrgCap {
+		return "warm worker capacity exhausted for organization"
+	}
 	return fmt.Sprintf("warm worker capacity exhausted; retry in about %s", retryAfter.Round(time.Second))
 }
 
+func (e *WarmCapacityExhaustedError) missReason() configstore.WorkerClaimMissReason {
+	if e.Reason == configstore.WorkerClaimMissReasonNone {
+		return configstore.WorkerClaimMissReasonNoIdle
+	}
+	return e.Reason
+}
+
 func NewWarmCapacityExhaustedError(retryAfter time.Duration) error {
+	return NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonNoIdle, retryAfter)
+}
+
+func NewWarmCapacityExhaustedErrorForReason(reason configstore.WorkerClaimMissReason, retryAfter time.Duration) error {
 	if retryAfter <= 0 {
 		retryAfter = DefaultWarmCapacityRetryAfter
 	}
-	return &WarmCapacityExhaustedError{RetryAfter: retryAfter}
+	if reason == configstore.WorkerClaimMissReasonNone {
+		reason = configstore.WorkerClaimMissReasonNoIdle
+	}
+	return &WarmCapacityExhaustedError{RetryAfter: retryAfter, Reason: reason}
 }
 
 // WorkerPool abstracts the lifecycle and scheduling of Flight SQL workers.
@@ -100,8 +119,8 @@ type K8sWorkerPoolConfig struct {
 
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
-	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, error)
-	ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, error)
+	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
+	ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
 	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, podNamePrefix, image string, perImageTarget, maxGlobalWorkers int) (*configstore.WorkerRecord, error)

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -126,13 +126,16 @@ func TestClaimIdleWorkerPostgres(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord: %v", err)
 	}
 
-	claimed, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 0)
+	claimed, missReason, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 0)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed == nil {
 		t.Fatal("expected idle worker claim to succeed")
 		return
+	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected no miss reason on successful claim, got %q", missReason)
 	}
 	if claimed.WorkerID != 7 {
 		t.Fatalf("expected worker id 7, got %d", claimed.WorkerID)
@@ -164,12 +167,15 @@ func TestClaimIdleWorkerPostgres(t *testing.T) {
 func TestClaimIdleWorkerReturnsNilWhenNoIdleWorkerExists(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 
-	claimed, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 0)
+	claimed, missReason, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 0)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed != nil {
 		t.Fatalf("expected no claim, got %#v", claimed)
+	}
+	if missReason != configstore.WorkerClaimMissReasonNoIdle {
+		t.Fatalf("expected no-idle miss reason, got %q", missReason)
 	}
 }
 
@@ -199,12 +205,15 @@ func TestClaimIdleWorkerRespectsOrgCapPostgres(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(hot): %v", err)
 	}
 
-	claimed, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 1)
+	claimed, missReason, err := store.ClaimIdleWorker("cp-new:boot-b", "analytics", "", 1)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed != nil {
 		t.Fatalf("expected org cap to block claim, got %#v", claimed)
+	}
+	if missReason != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap miss reason, got %q", missReason)
 	}
 
 	persisted, err := store.GetWorkerRecord(7)
@@ -240,30 +249,170 @@ func TestClaimIdleWorkerRespectsImageAffinity(t *testing.T) {
 	}
 
 	// Try claiming v2
-	claimed, err := store.ClaimIdleWorker("cp-1", "org-1", "duckgres:v2", 0)
+	claimed, missReason, err := store.ClaimIdleWorker("cp-1", "org-1", "duckgres:v2", 0)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed == nil || claimed.WorkerID != 8 {
 		t.Fatalf("expected to claim worker 8 (v2), got %#v", claimed)
 	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected no miss reason on successful image claim, got %q", missReason)
+	}
 
 	// Try claiming v3 (none exist)
-	claimed, err = store.ClaimIdleWorker("cp-1", "org-1", "duckgres:v3", 0)
+	claimed, missReason, err = store.ClaimIdleWorker("cp-1", "org-1", "duckgres:v3", 0)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed != nil {
 		t.Fatalf("expected no claim for v3, got %#v", claimed)
 	}
+	if missReason != configstore.WorkerClaimMissReasonNoIdle {
+		t.Fatalf("expected no-idle miss reason for unmatched image, got %q", missReason)
+	}
 
 	// Neutral claim (no image filter) - should get v1 (lowest ID)
-	claimed, err = store.ClaimIdleWorker("cp-1", "org-1", "", 0)
+	claimed, missReason, err = store.ClaimIdleWorker("cp-1", "org-1", "", 0)
 	if err != nil {
 		t.Fatalf("ClaimIdleWorker: %v", err)
 	}
 	if claimed == nil || claimed.WorkerID != 7 {
 		t.Fatalf("expected to claim worker 7 (neutral), got %#v", claimed)
+	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected no miss reason on successful neutral claim, got %q", missReason)
+	}
+}
+
+func TestClaimHotIdleWorkerPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	now := time.Date(2026, time.March, 26, 14, 0, 0, 0, time.UTC)
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          9,
+		PodName:           "duckgres-worker-hot-idle",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		Image:             "duckgres:v2",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        5,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          10,
+		PodName:           "duckgres-worker-hot-idle-later",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		Image:             "duckgres:v2",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        3,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(second): %v", err)
+	}
+
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics")
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("expected hot-idle worker claim to succeed")
+		return
+	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected no miss reason on successful hot-idle claim, got %q", missReason)
+	}
+	if claimed.WorkerID != 9 {
+		t.Fatalf("expected worker id 9, got %d", claimed.WorkerID)
+	}
+	if claimed.State != configstore.WorkerStateReserved {
+		t.Fatalf("expected reserved state, got %q", claimed.State)
+	}
+	if claimed.OwnerCPInstanceID != "cp-new:boot-b" {
+		t.Fatalf("expected owner cp-instance cp-new:boot-b, got %q", claimed.OwnerCPInstanceID)
+	}
+	if claimed.OwnerEpoch != 6 {
+		t.Fatalf("expected owner epoch 6, got %d", claimed.OwnerEpoch)
+	}
+	if claimed.OrgID != "analytics" {
+		t.Fatalf("expected org analytics, got %q", claimed.OrgID)
+	}
+	if claimed.Image != "duckgres:v2" {
+		t.Fatalf("expected image to be preserved, got %q", claimed.Image)
+	}
+
+	unclaimed, err := store.GetWorkerRecord(10)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord(unclaimed): %v", err)
+	}
+	if unclaimed.State != configstore.WorkerStateHotIdle {
+		t.Fatalf("expected later hot-idle worker to remain hot_idle, got %q", unclaimed.State)
+	}
+}
+
+func TestClaimHotIdleWorkerReturnsNoIdleWhenNoHotIdleWorkerExists(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	now := time.Date(2026, time.March, 26, 14, 15, 0, 0, time.UTC)
+	for _, record := range []configstore.WorkerRecord{
+		{
+			WorkerID:          11,
+			PodName:           "duckgres-worker-other-org-hot-idle",
+			State:             configstore.WorkerStateHotIdle,
+			OrgID:             "billing",
+			OwnerCPInstanceID: "cp-old:boot-a",
+			OwnerEpoch:        2,
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          12,
+			PodName:           "duckgres-worker-requested-org-idle",
+			State:             configstore.WorkerStateIdle,
+			OrgID:             "analytics",
+			OwnerCPInstanceID: "cp-old:boot-a",
+			OwnerEpoch:        2,
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          13,
+			PodName:           "duckgres-worker-requested-org-hot",
+			State:             configstore.WorkerStateHot,
+			OrgID:             "analytics",
+			OwnerCPInstanceID: "cp-old:boot-a",
+			OwnerEpoch:        2,
+			LastHeartbeatAt:   now,
+		},
+	} {
+		if err := store.UpsertWorkerRecord(&record); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", record.WorkerID, err)
+		}
+	}
+
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics")
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("expected no claim, got %#v", claimed)
+	}
+	if missReason != configstore.WorkerClaimMissReasonNoIdle {
+		t.Fatalf("expected no-idle miss reason, got %q", missReason)
+	}
+
+	for _, workerID := range []int{11, 12, 13} {
+		persisted, err := store.GetWorkerRecord(workerID)
+		if err != nil {
+			t.Fatalf("GetWorkerRecord(%d): %v", workerID, err)
+		}
+		if persisted.OwnerCPInstanceID != "cp-old:boot-a" {
+			t.Fatalf("expected worker %d owner to remain unchanged, got %q", workerID, persisted.OwnerCPInstanceID)
+		}
+		if persisted.OwnerEpoch != 2 {
+			t.Fatalf("expected worker %d owner epoch to remain 2, got %d", workerID, persisted.OwnerEpoch)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add typed worker-claim miss reasons for configstore runtime claims
- propagate org-cap/no-idle warm-capacity misses through K8s shared worker reservation and SQL error mapping
- add Postgres-backed claim reason coverage, including hot-idle claims

## Validation
- `just test-controlplane`
- `just test-controlplane-k8s`
- `just test-configstore-integration`
- `just lint`