### PR TITLE
fix(lakekeeper): drop STS credential vending; duckling uses its own S3 creds

### DIFF
--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -247,14 +247,18 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 			KeyPrefix:            in.S3.KeyPrefix,
 			Endpoint:             in.S3.Endpoint,
 			Region:               in.S3.Region,
-			PathStyleAccess:      in.S3.Flavor == "s3-compat",
-			Flavor:               in.S3.Flavor,
-			STSEnabled:           true,
+			PathStyleAccess: in.S3.Flavor == "s3-compat",
+			Flavor:          in.S3.Flavor,
+			// STS credential vending is OFF: Lakekeeper would assume a role
+			// and hand DuckDB short-lived creds, but its downscoping session
+			// policy overflows AWS's packed-policy limit (PackedPolicyTooLarge),
+			// and it's unnecessary — the duckling worker already holds STS creds
+			// for this bucket (brokered by the control plane for DuckLake, same
+			// per-org role). The worker attaches the catalog with its own S3
+			// secret and Lakekeeper serves metadata only (using its pod identity
+			// for catalog-metadata IO via allowDirectSystemCredentials).
+			STSEnabled:           false,
 			RemoteSigningEnabled: false,
-			// AWS requires a role to assume for STS credential vending. The
-			// per-org duckling role (which the pod runs as) self-assumes.
-			// s3-compat (MinIO) leaves this empty.
-			STSRoleARN: in.S3.RoleARN,
 		},
 		StorageCredential: storageCredFor(in.S3),
 	}
@@ -285,7 +289,10 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 		"iceberg_lakekeeper_client_credentials_namespace": p.k8s.namespace,
 		"iceberg_lakekeeper_client_credentials_name":      secretName,
 		"iceberg_lakekeeper_client_credentials_key":       SecretKeyOAuth2ClientSecret,
-		"iceberg_state": configstore.ManagedWarehouseStateReady,
+		// Persist the S3 region so the worker's iceberg S3 secret (built from
+		// the duckling's brokered creds) targets the right region for data IO.
+		"iceberg_region": in.S3.Region,
+		"iceberg_state":  configstore.ManagedWarehouseStateReady,
 	}
 	_ = creds // creds are written into the Secret; the row only references them
 	if err := p.store.UpdateIcebergConfig(w.OrgID, updates); err != nil {

--- a/server/iceberg/dispatch_test.go
+++ b/server/iceberg/dispatch_test.go
@@ -35,7 +35,7 @@ func TestDispatcher_BackendSelection(t *testing.T) {
 				LakekeeperEndpoint:  "http://lk/catalog",
 				LakekeeperWarehouse: "org-x",
 			},
-			wantSQL: "ACCESS_DELEGATION_MODE 'vended_credentials'",
+			wantSQL: "AUTHORIZATION_TYPE 'none'",
 		},
 		{
 			name: "empty Backend defaults to lakekeeper even with stale TableBucket",
@@ -45,7 +45,7 @@ func TestDispatcher_BackendSelection(t *testing.T) {
 				LakekeeperEndpoint:  "http://lk/catalog",
 				LakekeeperWarehouse: "org-x",
 			},
-			wantSQL: "ACCESS_DELEGATION_MODE 'vended_credentials'",
+			wantSQL: "AUTHORIZATION_TYPE 'none'",
 		},
 	}
 	for _, tc := range cases {

--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -100,9 +100,15 @@ func BuildLakekeeperSecretStmt(cfg Config) string {
 }
 
 // BuildLakekeeperAttachStmt builds the ATTACH statement for the Iceberg
-// REST catalog vended by Lakekeeper. ACCESS_DELEGATION_MODE 'vended_credentials'
-// tells DuckDB to ask Lakekeeper for short-lived STS creds for the
-// underlying S3 storage rather than signing requests itself.
+// REST catalog served by Lakekeeper.
+//
+// We deliberately do NOT use ACCESS_DELEGATION_MODE 'vended_credentials':
+// Lakekeeper's STS vending overflows AWS's packed-policy limit
+// (PackedPolicyTooLarge), and it's unnecessary — the worker already holds S3
+// creds for the warehouse bucket via the iceberg_sigv4 secret (built from the
+// duckling's brokered STS creds, same per-org role/bucket; see
+// attachLakekeeperCatalog). DuckDB uses that secret to read/write table data;
+// Lakekeeper serves only catalog metadata.
 //
 // When OAUTH2_SERVER_URI is empty (allowall mode), AUTHORIZATION_TYPE 'none'
 // is set instead of SECRET. When OAuth2 is configured, SECRET references
@@ -110,14 +116,14 @@ func BuildLakekeeperSecretStmt(cfg Config) string {
 func BuildLakekeeperAttachStmt(cfg Config) string {
 	if cfg.LakekeeperOAuth2ServerURI == "" {
 		return fmt.Sprintf(
-			"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', ACCESS_DELEGATION_MODE 'vended_credentials', AUTHORIZATION_TYPE 'none')",
+			"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', AUTHORIZATION_TYPE 'none')",
 			escapeSQLStringLiteral(cfg.LakekeeperWarehouse),
 			CatalogName,
 			escapeSQLStringLiteral(cfg.LakekeeperEndpoint),
 		)
 	}
 	return fmt.Sprintf(
-		"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', SECRET %s, ACCESS_DELEGATION_MODE 'vended_credentials')",
+		"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', SECRET %s)",
 		escapeSQLStringLiteral(cfg.LakekeeperWarehouse),
 		CatalogName,
 		escapeSQLStringLiteral(cfg.LakekeeperEndpoint),

--- a/server/iceberg/migration_test.go
+++ b/server/iceberg/migration_test.go
@@ -84,7 +84,7 @@ func TestBuildLakekeeperAttachStmt_Allowall(t *testing.T) {
 		LakekeeperEndpoint:  "http://lakekeeper-acme.lakekeeper.svc:8181/catalog",
 		LakekeeperWarehouse: "org-acme",
 	})
-	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', ACCESS_DELEGATION_MODE 'vended_credentials', AUTHORIZATION_TYPE 'none')"
+	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', AUTHORIZATION_TYPE 'none')"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt (allowall) mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -96,7 +96,7 @@ func TestBuildLakekeeperAttachStmt_OAuth2(t *testing.T) {
 		LakekeeperWarehouse:       "org-acme",
 		LakekeeperOAuth2ServerURI: "http://oidc/token",
 	})
-	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', SECRET iceberg_oauth, ACCESS_DELEGATION_MODE 'vended_credentials')"
+	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', SECRET iceberg_oauth)"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt (oauth2) mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -107,7 +107,7 @@ func TestBuildLakekeeperAttachStmt_EscapesQuotes(t *testing.T) {
 		LakekeeperEndpoint:  "http://h/cat?x='y'",
 		LakekeeperWarehouse: "wh'name",
 	})
-	want := "ATTACH 'wh''name' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://h/cat?x=''y''', ACCESS_DELEGATION_MODE 'vended_credentials', AUTHORIZATION_TYPE 'none')"
+	want := "ATTACH 'wh''name' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://h/cat?x=''y''', AUTHORIZATION_TYPE 'none')"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt did not escape quotes:\n got: %s\nwant: %s", got, want)
 	}

--- a/server/iceberg_refresh_test.go
+++ b/server/iceberg_refresh_test.go
@@ -61,14 +61,11 @@ func TestRefreshIcebergSecretNoOpWhenDisabled(t *testing.T) {
 
 // TestRefreshIcebergSecretRejectsEmptyCredentials guards the invariant
 // that "credentials are required when iceberg is enabled" applies to
-// refresh too, not just initial attach — for the S3 Tables backend.
-// A silent fallback here would either re-introduce credential_chain (the
-// bug fixed by PR #562) or emit an empty-cred config secret that fails
-// opaquely at attach time.
-//
-// Backend is explicit because empty Backend resolves to "lakekeeper",
-// which legitimately returns nil from RefreshIcebergSecret (Lakekeeper
-// vends its own STS via ACCESS_DELEGATION_MODE; there's nothing to rotate).
+// refresh too, not just initial attach. A silent fallback here would either
+// re-introduce credential_chain (the bug fixed by PR #562) or emit an
+// empty-cred config secret that fails opaquely at attach time. Applies to
+// BOTH backends: Lakekeeper no longer vends (PackedPolicyTooLarge), so the
+// worker rotates its own iceberg_sigv4 S3 secret for Lakekeeper too.
 func TestRefreshIcebergSecretRejectsEmptyCredentials(t *testing.T) {
 	err := RefreshIcebergSecret(nil, IcebergConfig{
 		Enabled:     true,
@@ -83,18 +80,22 @@ func TestRefreshIcebergSecretRejectsEmptyCredentials(t *testing.T) {
 	}
 }
 
-// TestRefreshIcebergSecretLakekeeperNoOp covers the new branch: a
-// Lakekeeper-backed config has no S3 credentials in the payload (because
-// Lakekeeper vends them itself), and RefreshIcebergSecret should return
-// nil rather than complain about missing credentials.
-func TestRefreshIcebergSecretLakekeeperNoOp(t *testing.T) {
+// TestRefreshIcebergSecretLakekeeperRequiresCreds: Lakekeeper no longer vends
+// credentials (its STS session policy overflowed AWS's packed-policy limit),
+// so the worker reads/writes S3 data with its own brokered creds and must
+// rotate that secret on the STS schedule — same as S3 Tables. An empty-cred
+// refresh is therefore an error, not a no-op.
+func TestRefreshIcebergSecretLakekeeperRequiresCreds(t *testing.T) {
 	err := RefreshIcebergSecret(nil, IcebergConfig{
 		Enabled:             true,
 		Backend:             iceberg.BackendLakekeeper,
 		LakekeeperEndpoint:  "http://lk/catalog",
 		LakekeeperWarehouse: "org-x",
 	}, nil, "", "", "")
-	if err != nil {
-		t.Fatalf("Lakekeeper backend refresh should be a no-op, got error: %v", err)
+	if err == nil {
+		t.Fatal("expected error: Lakekeeper refresh now needs the worker's S3 creds")
+	}
+	if !strings.Contains(err.Error(), "no AWS credentials") {
+		t.Fatalf("error message should name the missing-credentials cause, got: %v", err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1616,7 +1616,7 @@ func AttachIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID
 	}
 	switch ic.ResolvedBackend() {
 	case iceberg.BackendLakekeeper:
-		return attachLakekeeperCatalog(db, ic, sem)
+		return attachLakekeeperCatalog(db, ic, sem, keyID, secret, sessionToken)
 	case iceberg.BackendS3Tables:
 		return attachS3TablesIcebergCatalog(db, ic, sem, keyID, secret, sessionToken)
 	default:
@@ -1684,7 +1684,7 @@ func attachS3TablesIcebergCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{
 // attachLakekeeperCatalog attaches the per-tenant Lakekeeper REST catalog.
 // Skipped (returns nil) when LakekeeperEndpoint is empty — the provisioner
 // hasn't run yet for this org and the next activation will retry.
-func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}) error {
+func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID, secret, sessionToken string) error {
 	if ic.LakekeeperEndpoint == "" || ic.LakekeeperWarehouse == "" {
 		// Provisioner hasn't populated the row yet. Don't fail the
 		// activation; subsequent activations after provisioning will
@@ -1711,9 +1711,19 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}) er
 		return fmt.Errorf("load iceberg extension: %w", err)
 	}
 
-	// CREATE SECRET only when OAuth2 is configured (PR3). PR1 deploys
-	// Lakekeeper in allowall + NetworkPolicy mode, where the ATTACH uses
-	// AUTHORIZATION_TYPE 'none' and no SECRET.
+	// S3 data secret: Lakekeeper does NOT vend credentials (PackedPolicyTooLarge),
+	// so DuckDB needs its own creds to read/write the warehouse's S3 data. Reuse
+	// the duckling's brokered STS creds (same per-org role + bucket as DuckLake)
+	// to build the iceberg_sigv4 secret. Refreshed on STS expiry by
+	// RefreshIcebergSecret. Skipped if creds absent (e.g. local/dev).
+	if keyID != "" && secret != "" {
+		if _, err := db.Exec(iceberg.BuildIcebergSecretStmt(ic, keyID, secret, sessionToken)); err != nil {
+			return fmt.Errorf("create Lakekeeper S3 data secret: %w", err)
+		}
+	}
+
+	// Catalog auth secret: only when OAuth2 is configured. In allowall mode
+	// the ATTACH uses AUTHORIZATION_TYPE 'none' and no catalog secret.
 	if stmt := iceberg.BuildLakekeeperSecretStmt(ic); stmt != "" {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("create Lakekeeper iceberg secret: %w", err)
@@ -2064,15 +2074,10 @@ func RefreshIcebergSecret(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID
 	if !ic.Enabled {
 		return nil
 	}
-	// Lakekeeper backend: Lakekeeper itself vends short-lived STS creds to
-	// DuckDB at table-load time via ACCESS_DELEGATION_MODE 'vended_credentials'.
-	// The OAuth2 client_secret in iceberg_oauth is a long-lived config, not
-	// an STS-minted blob — nothing to rotate on the worker's STS schedule.
-	// Returning nil here keeps Lakekeeper orgs from spuriously failing the
-	// hourly credential-refresh cycle.
-	if ic.ResolvedBackend() == iceberg.BackendLakekeeper {
-		return nil
-	}
+	// Both backends now use the worker's own brokered STS creds for S3 data
+	// (the iceberg_sigv4 secret) — Lakekeeper no longer vends — so both need
+	// the secret rotated on the worker's STS schedule. BuildIcebergSecretStmt
+	// produces the same iceberg_sigv4 secret regardless of backend.
 	if keyID == "" || secretKey == "" {
 		return fmt.Errorf("iceberg refresh: no AWS credentials in activation payload — control plane STS broker did not populate DuckLake S3 credentials")
 	}


### PR DESCRIPTION
## The problem

Lakekeeper warehouse-create fails with **`PackedPolicyTooLarge`** — when Lakekeeper assumes the role to vend scoped credentials, its session policy + session tags overflow AWS's ~2KB packed-token limit (~135% over, and *worse* for real orgs whose UUID bucket names are longer than the `ben` test org). There's no documented Lakekeeper config to shrink it.

## The fix — stop vending, reuse what already works

Vending was unnecessary: the duckling worker **already holds STS creds for the warehouse bucket** (brokered by the control plane for DuckLake — same per-org role/bucket), which is exactly how the **legacy S3-Tables Iceberg backend** reads data. Mirror that for Lakekeeper:

- **Provisioner**: warehouse storage profile `sts-enabled=false` — stops vending *and* the create-time test-assume that triggers `PackedPolicyTooLarge`. Lakekeeper still uses its pod identity (`allowDirectSystemCredentials`) for its own catalog-metadata S3 IO. Also persist `iceberg_region`.
- **Worker**: `attachLakekeeperCatalog` builds the `iceberg_sigv4` S3 secret from the duckling's brokered creds (same call `attachS3TablesIcebergCatalog` uses), and the ATTACH drops `ACCESS_DELEGATION_MODE 'vended_credentials'`. DuckDB reads/writes table data with that secret; Lakekeeper serves metadata only. `RefreshIcebergSecret` rotates it on STS expiry (no longer a Lakekeeper no-op).

## Bonus

This makes the whole self-assume IAM chain (trust/identity/boundary — #11210, #11214, #8208, #8210) **unnecessary**. Harmless to leave; can be cleaned up later.

## Testing

Full `./server/...` + `-tags kubernetes ./controlplane/...` suites green; lint clean. Test expectations updated (ATTACH no longer contains `vended_credentials`; Lakekeeper refresh now requires creds like S3-Tables).

Needs a CP rebuild. After deploy, `ben`'s warehouse-create should succeed and a duckling should ATTACH + read/write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)