### PR TITLE
fix(provisioner): correct GORM column name for lakekeeper oauth2_server_uri

### DIFF
--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -279,13 +279,20 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	if len(in.KubernetesAuthAudiences) > 0 {
 		oauth2URI = lakekeeperbroker.DefaultOAuth2ServerURI
 	}
+	// NOTE: these are raw DB column names — GORM's Updates(map) uses keys
+	// verbatim, bypassing struct field→column mapping. They MUST match the
+	// columns AutoMigrate generated from ManagedWarehouseIceberg. GORM
+	// snake-cases the field LakekeeperOAuth2ServerURI to "o_auth2_server_uri"
+	// (it splits the OAuth2 acronym), so the column is
+	// iceberg_lakekeeper_o_auth2_server_uri — NOT ...oauth2.... A mismatch
+	// here fails the persist with "column does not exist" (SQLSTATE 42703).
 	updates := map[string]interface{}{
 		"iceberg_enabled":                                 true,
 		"iceberg_backend":                                 configstore.IcebergBackendLakekeeper,
 		"iceberg_lakekeeper_endpoint":                     baseURL + "/catalog",
 		"iceberg_lakekeeper_warehouse":                    wh.Name,
 		"iceberg_lakekeeper_client_id":                    oauthClientID(w.OrgID),
-		"iceberg_lakekeeper_oauth2_server_uri":            oauth2URI,
+		"iceberg_lakekeeper_o_auth2_server_uri":           oauth2URI,
 		"iceberg_lakekeeper_client_credentials_namespace": p.k8s.namespace,
 		"iceberg_lakekeeper_client_credentials_name":      secretName,
 		"iceberg_lakekeeper_client_credentials_key":       SecretKeyOAuth2ClientSecret,


### PR DESCRIPTION
## What

With the no-vending fix (#594) deployed, **warehouse-create now succeeds** — but persisting the result fails against the real config-store DB:

```
persist lakekeeper config: ERROR: column "iceberg_lakekeeper_oauth2_server_uri"
of relation "duckgres_managed_warehouses" does not exist (SQLSTATE 42703)
```

## Root cause

`UpdateIcebergConfig` does `db.Model(&ManagedWarehouse{}).Updates(map)` — GORM uses the map keys as **raw column names**, bypassing struct field→column mapping. GORM's `AutoMigrate` snake-cases the field `LakekeeperOAuth2ServerURI` by **splitting the `OAuth2` acronym**, producing the column `iceberg_lakekeeper_o_auth2_server_uri`. Verified live in the managed-warehouse-dev config store:

```
iceberg_lakekeeper_o_auth2_server_uri   <- actual column
iceberg_lakekeeper_oauth2_server_uri    <- what the provisioner wrote (wrong)
```

All other `iceberg_lakekeeper_*` columns match; only this one. It wasn't caught because configstore tests use a **fake store** (no real GORM schema).

## Fix

Align the map key to the real column name (`..._o_auth2_server_uri`) + a comment so it doesn't read as a typo. The worker reads via GORM's struct mapping (already correct), so this only affects the provisioner's raw-column write.

## Follow-ups (not this PR)

- A real-DB (sqlite/dockertest) configstore test that AutoMigrates + exercises `UpdateIcebergConfig` would catch this class of mismatch.
- Consider an explicit `gorm:"column:..."` tag for a cleaner column name (would require a rename migration off the existing column).

Needs a CP rebuild. After deploy, `ben`'s persist should succeed → `LakekeeperEndpoint` populates → `iceberg_state` ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)