### PR TITLE
feat(observe): instrument DuckLake metadata DB performance

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -85,6 +85,13 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	cfg.DuckLake = payload.DuckLake
 	cfg.Iceberg = payload.Iceberg
 	overrideS3EndpointForCacheProxy(&cfg.DuckLake)
+	// Tag postgres_scanner libpq connections with an application_name that
+	// includes the org so Aurora's pg_stat_activity / Performance Insights
+	// can attribute metadata-DB load back to a duckgres tenant. Skipped if
+	// the payload already carries one (control-plane override path).
+	if cfg.DuckLake.ApplicationName == "" {
+		cfg.DuckLake.ApplicationName = "duckgres/" + payload.OrgID
+	}
 
 	<-p.warmupDone
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -23,6 +25,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightclient"
+	"github.com/posthog/duckgres/server/observe"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -145,6 +148,7 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 	}
 	pool.activateTenantFunc = pool.activateTenant
 	go pool.reapLoop()
+	go pool.metadataMetricsLoop()
 
 	return &DuckDBService{
 		cfg:  cfg,
@@ -187,8 +191,9 @@ func (p *SessionPool) Warmup() error {
 }
 
 const (
-	txnIdleTimeout = 10 * time.Minute
-	reapInterval   = 1 * time.Minute
+	txnIdleTimeout          = 10 * time.Minute
+	reapInterval            = 1 * time.Minute
+	metadataMetricsInterval = 30 * time.Second
 )
 
 func (p *SessionPool) reapLoop() {
@@ -222,6 +227,112 @@ func (p *SessionPool) reapLoop() {
 		case <-p.stopCh:
 			return
 		}
+	}
+}
+
+// metadataMetricsLoop periodically scrapes observability signals about the
+// DuckLake metadata Postgres from the worker's DuckDB instance and emits them
+// as Prometheus gauges. Scrapes only run once the worker has been activated
+// (so an org is known and metadata is attached). Ticks are best-effort: any
+// query failure is logged once and the next tick retries — we never want this
+// loop to hold any locks or block user queries.
+func (p *SessionPool) metadataMetricsLoop() {
+	ticker := time.NewTicker(metadataMetricsInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.scrapeMetadataMetrics()
+		case <-p.stopCh:
+			return
+		}
+	}
+}
+
+func (p *SessionPool) scrapeMetadataMetrics() {
+	act := p.currentActivation()
+	if act == nil || act.db == nil {
+		return
+	}
+	orgID := act.payload.OrgID
+
+	// Prefer controlDB (side connection sharing the same DuckDB instance with
+	// its own pool) so a long-running user query on the main DB does not
+	// queue our scrape. Falls back to the activation DB only when controlDB
+	// has not been wired (test paths).
+	p.mu.RLock()
+	scrapeDB := p.controlDB
+	p.mu.RUnlock()
+	if scrapeDB == nil {
+		scrapeDB = act.db
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if v, ok := scrapeMetadataPoolMax(ctx, scrapeDB); ok {
+		observe.MetadataPoolMaxConnections.WithLabelValues(orgID).Set(v)
+	}
+
+	scrapeMetadataConnectionsByState(ctx, scrapeDB, orgID)
+}
+
+// scrapeMetadataPoolMax reads DuckDB's pg_pool_max_connections setting via
+// duckdb_settings(). A value of 0 means the in-process pool is disabled (we
+// set this when ViaPgBouncer is true) — still useful to emit as a gauge.
+func scrapeMetadataPoolMax(ctx context.Context, db *sql.DB) (float64, bool) {
+	var raw string
+	err := db.QueryRowContext(ctx,
+		"SELECT value FROM duckdb_settings() WHERE name = 'pg_pool_max_connections'").Scan(&raw)
+	if err != nil {
+		// Setting may be unavailable until postgres_scanner is loaded; skip
+		// silently rather than spamming logs every 30s.
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// scrapeMetadataConnectionsByState issues a single pg_stat_activity query
+// against the ATTACHed DuckLake metadata DB via postgres_query() and emits a
+// gauge per Postgres connection state. Connections are filtered by the
+// application_name we injected at attach time so we report only duckgres'
+// own connections, not whatever else is sharing the metadata Postgres.
+//
+// We deliberately do not log on failure: if postgres_query is unavailable
+// (extension load order, version skew) or the metadata user lacks
+// pg_stat_activity visibility, the gauge simply stops updating, and the
+// per-org missing-data signal in Grafana is more useful than a recurring
+// warn on every worker.
+func scrapeMetadataConnectionsByState(ctx context.Context, db *sql.DB, orgID string) {
+	const q = `SELECT state, n FROM postgres_query(
+		'__ducklake_metadata_ducklake',
+		'SELECT COALESCE(state, ''unknown'') AS state, count(*) AS n FROM pg_stat_activity WHERE application_name LIKE ''duckgres/%'' GROUP BY state'
+	)`
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	seen := map[string]float64{}
+	for rows.Next() {
+		var state string
+		var n int64
+		if err := rows.Scan(&state, &n); err != nil {
+			return
+		}
+		seen[state] = float64(n)
+	}
+	if err := rows.Err(); err != nil {
+		return
+	}
+	for state, n := range seen {
+		observe.MetadataConnectionsByState.WithLabelValues(orgID, state).Set(n)
 	}
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -184,6 +184,12 @@ type clientConn struct {
 	queryStart      atomic.Value // stores time.Time — when current query started (lock-free)
 	workerID        int          // control plane worker ID, -1 for standalone
 	workerPod       string       // K8s pod name of the worker, empty for standalone or in-process workers
+
+	// lastProfilingSummary holds the rollup from the most recent
+	// EnrichSpanWithProfiling call on this connection. Consumed by the very
+	// next logQuery and then cleared. Per-connection state is safe because
+	// each connection processes queries serially on a single goroutine.
+	lastProfilingSummary observe.QueryProfilingSummary
 }
 
 // newTranspiler creates a transpiler configured for this connection.
@@ -1442,7 +1448,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 
 		execResult, err := runExec()
-		observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -1673,7 +1679,7 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			},
 		)
 	}
-	observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+	c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 	execSpan.End()
 	if err != nil {
 		queryFinalErr = err
@@ -5647,7 +5653,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		execStart := time.Now()
 		execCtx, execSpan := observe.Tracer().Start(queryCtx, "duckgres.execute")
 		result, err := runExec()
-		observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 		execSpan.End()
 		if err != nil {
 			if c.txStatus == txStatusIdle && isDuckLakeTransactionConflict(err) {
@@ -5715,7 +5721,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			runQuery,
 		)
 	}
-	observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+	c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 	execSpan.End()
 	if err != nil {
 		queryFinalErr = err

--- a/server/ducklake/config.go
+++ b/server/ducklake/config.go
@@ -92,4 +92,13 @@ type Config struct {
 	// See duckdb/ducklake#1031: behind a network pooler, client-side pooling
 	// is redundant and prevents the pooler from reclaiming idle connections.
 	ViaPgBouncer bool `json:"via_pgbouncer,omitempty" yaml:"-"`
+
+	// ApplicationName tags the libpq connections that postgres_scanner opens
+	// against the metadata Postgres. Appears in pg_stat_activity.application_name
+	// on the Aurora/RDS side, so Performance Insights and pg_stat_activity
+	// can attribute connections and queries back to a specific duckgres
+	// org/worker. Recommended format: "duckgres/<org-id>". Ignored for
+	// non-"postgres:" metadata stores. If empty, no application_name is
+	// injected (libpq picks its own default, usually "psql").
+	ApplicationName string `json:"application_name,omitempty" yaml:"-"`
 }

--- a/server/ducklake/migration.go
+++ b/server/ducklake/migration.go
@@ -598,10 +598,43 @@ func injectPostgresKeepalive(metadataStore string) string {
 	return metadataStore + " keepalives=1 keepalives_idle=60 keepalives_interval=10 keepalives_count=5"
 }
 
+// injectPostgresApplicationName adds an application_name= libpq parameter to
+// a postgres metadata store connection string so the metadata DB can attribute
+// connections via pg_stat_activity / Performance Insights. Only modifies
+// strings with the "postgres:" prefix; leaves user-set application_name alone.
+//
+// libpq applies a 64-byte ceiling to application_name and silently truncates.
+// We pre-trim to 63 bytes here (plus the leading space + key) so the value we
+// log/store on the Aurora side matches what we sent. A "duckgres/<uuid>" or
+// "duckgres/<slug>/<worker-id>" form is the intended shape.
+func injectPostgresApplicationName(metadataStore, name string) string {
+	if name == "" {
+		return metadataStore
+	}
+	if !strings.HasPrefix(metadataStore, "postgres:") {
+		return metadataStore
+	}
+	connPart := metadataStore[len("postgres:"):]
+	if strings.Contains(connPart, "application_name") {
+		return metadataStore
+	}
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	// libpq accepts application_name as a bareword for ASCII alnum/dash/slash;
+	// quote the value defensively so any chars outside that set still parse.
+	return metadataStore + " application_name='" + strings.ReplaceAll(name, "'", "''") + "'"
+}
+
 // BuildAttachStmt builds the ATTACH statement for DuckLake.
 // If migrate is true, adds AUTOMATIC_MIGRATION TRUE to the options.
 func BuildAttachStmt(dlCfg Config, migrate bool) string {
-	connStr := escapeSQLStringLiteral(injectPostgresKeepalive(dlCfg.MetadataStore))
+	connStr := escapeSQLStringLiteral(
+		injectPostgresApplicationName(
+			injectPostgresKeepalive(dlCfg.MetadataStore),
+			dlCfg.ApplicationName,
+		),
+	)
 	dataPath := dlCfg.ObjectStore
 	if dataPath == "" {
 		dataPath = dlCfg.DataPath

--- a/server/ducklake/migration_test.go
+++ b/server/ducklake/migration_test.go
@@ -57,6 +57,61 @@ func TestInjectPostgresKeepalive(t *testing.T) {
 // keepalive suffix appended by injectPostgresKeepalive to postgres connection strings.
 const keepaliveSuffix = " keepalives=1 keepalives_idle=60 keepalives_interval=10 keepalives_count=5"
 
+func TestInjectPostgresApplicationName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		appNm string
+		want  string
+	}{
+		{
+			name:  "adds application_name to postgres connection",
+			input: "postgres:host=localhost dbname=dl",
+			appNm: "duckgres/acme",
+			want:  "postgres:host=localhost dbname=dl application_name='duckgres/acme'",
+		},
+		{
+			name:  "skips when name is empty",
+			input: "postgres:host=localhost dbname=dl",
+			appNm: "",
+			want:  "postgres:host=localhost dbname=dl",
+		},
+		{
+			name:  "skips if application_name already set",
+			input: "postgres:host=localhost dbname=dl application_name=custom",
+			appNm: "duckgres/acme",
+			want:  "postgres:host=localhost dbname=dl application_name=custom",
+		},
+		{
+			name:  "skips non-postgres metadata stores",
+			input: "sqlite:/tmp/test.db",
+			appNm: "duckgres/acme",
+			want:  "sqlite:/tmp/test.db",
+		},
+		{
+			name:  "escapes single quotes",
+			input: "postgres:host=localhost dbname=dl",
+			appNm: "duckgres/it's",
+			want:  "postgres:host=localhost dbname=dl application_name='duckgres/it''s'",
+		},
+		{
+			name:  "truncates to 63 bytes (libpq application_name ceiling)",
+			input: "postgres:host=localhost dbname=dl",
+			appNm: strings.Repeat("a", 80),
+			want:  "postgres:host=localhost dbname=dl application_name='" + strings.Repeat("a", 63) + "'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectPostgresApplicationName(tt.input, tt.appNm)
+			if got != tt.want {
+				t.Errorf("injectPostgresApplicationName(%q, %q) =\n  %s\nwant:\n  %s", tt.input, tt.appNm, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildAttachStmt(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -151,6 +206,15 @@ func TestBuildAttachStmt(t *testing.T) {
 			},
 			migrate: false,
 			want:    "ATTACH 'ducklake:postgres:host=localhost dbname=dl" + keepaliveSuffix + "' AS ducklake",
+		},
+		{
+			name: "with application_name tags libpq connection",
+			dlCfg: Config{
+				MetadataStore:   "postgres:host=localhost dbname=dl",
+				ApplicationName: "duckgres/acme",
+			},
+			migrate: false,
+			want:    "ATTACH 'ducklake:postgres:host=localhost dbname=dl" + keepaliveSuffix + " application_name=''duckgres/acme''' AS ducklake",
 		},
 	}
 

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -42,3 +42,35 @@ var ScanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOp
 	Help:    "Scan throughput: estimated wall-clock rows scanned per second. High values (>1e10) indicate buffer pool/cache hits.",
 	Buckets: []float64{1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 1e10, 1e11, 1e12},
 }, []string{"org"})
+
+// PostgresScanSecondsHistogram observes thread-time spent in postgres_scan
+// operators per query. This is the DuckDB-side view of time spent in the
+// DuckLake metadata DB roundtrips — distinguishable from time spent on S3
+// data reads (which dominate ScanWallSecondsHistogram). A regression here
+// is the first signal of metadata-DB pressure (slow Aurora, conn-pool
+// starvation, pgbouncer queueing).
+var PostgresScanSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_postgres_scan_seconds",
+	Help:    "Time spent in postgres_scan operators per query (DuckLake metadata DB roundtrips).",
+	Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
+}, []string{"org"})
+
+// MetadataPoolMaxConnections is the configured ceiling for the
+// postgres_scanner connection pool that backs DuckLake metadata access.
+// Pulled from DuckDB's pg_pool_max_connections setting periodically; emitted
+// per-org so we can correlate pool size with conflict-rate / latency.
+var MetadataPoolMaxConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_ducklake_metadata_pool_max_connections",
+	Help: "Configured postgres_scanner pool ceiling for DuckLake metadata (pg_pool_max_connections).",
+}, []string{"org"})
+
+// MetadataConnectionsByState is the live count of metadata DB connections
+// from pg_stat_activity on the DuckLake metadata DB, grouped by Postgres
+// connection state (active, idle, idle in transaction, etc.). Scraped via
+// postgres_query against the ATTACHed metadata catalog every metadata
+// metrics tick. Only populated when the metadata DB tags duckgres
+// connections via application_name (see ducklake.Config.ApplicationName).
+var MetadataConnectionsByState = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_ducklake_metadata_connections",
+	Help: "DuckLake metadata DB connection count by state, scraped from pg_stat_activity (filtered by application_name).",
+}, []string{"org", "state"})

--- a/server/observe/tracing.go
+++ b/server/observe/tracing.go
@@ -87,34 +87,66 @@ func isScanOperator(name string) bool {
 	return strings.HasSuffix(upper, "_SCAN") || strings.Contains(upper, "SCAN")
 }
 
+// isPostgresScanOperator returns true for postgres_scanner operators —
+// roundtrips into the DuckLake metadata Postgres. DuckDB emits these as
+// POSTGRES_SCAN / POSTGRES_SCAN_PUSHDOWN under the postgres_scanner
+// extension; both are caught by the POSTGRES_ prefix. Tracked separately
+// from S3/parquet scans so we can attribute metadata-DB latency.
+func isPostgresScanOperator(name string) bool {
+	return strings.HasPrefix(strings.ToUpper(name), "POSTGRES_")
+}
+
 // collectOperatorTimings walks the operator tree and sums timings by category.
-func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64, computeTime float64) {
+// pgScanTime/pgScanRows are a strict subset of scanTime/scanRows: postgres_scan
+// counts as a scan operator AND is broken out separately so we can attribute
+// metadata-DB roundtrip time without losing total scan accounting.
+func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64, computeTime float64, pgScanTime, pgScanRows float64) {
 	for _, op := range ops {
 		if isScanOperator(op.OperatorName) {
 			scanTime += op.OperatorTiming
 			scanRows += float64(op.OperatorRowsScanned)
+			if isPostgresScanOperator(op.OperatorName) {
+				pgScanTime += op.OperatorTiming
+				pgScanRows += float64(op.OperatorRowsScanned)
+			}
 		} else {
 			computeTime += op.OperatorTiming
 		}
-		childScan, childScanRows, childCompute := collectOperatorTimings(op.Children)
+		childScan, childScanRows, childCompute, childPgScan, childPgScanRows := collectOperatorTimings(op.Children)
 		scanTime += childScan
 		scanRows += childScanRows
 		computeTime += childCompute
+		pgScanTime += childPgScan
+		pgScanRows += childPgScanRows
 	}
 	return
+}
+
+// QueryProfilingSummary is the per-query profiling rollup that
+// EnrichSpanWithProfiling computes from DuckDB's profiling JSON. Callers
+// (e.g. query_log) use it to persist a few high-signal fields without
+// re-parsing the JSON.
+type QueryProfilingSummary struct {
+	// PostgresScanSeconds is the thread-time spent inside postgres_scan
+	// operators — DuckLake metadata DB roundtrips. Zero means either no
+	// metadata access on this query, or no profiling output.
+	PostgresScanSeconds float64
 }
 
 // EnrichSpanWithProfiling creates child spans from DuckDB profiling output
 // showing where execution time was spent: planning, scanning (I/O), and compute.
 // Also emits Prometheus metrics for baseline measurement.
-func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor sqlcore.QueryExecutor, orgID string) {
+//
+// Returns a per-query rollup so callers (e.g. query log) can persist key
+// metrics without re-parsing the profiling JSON.
+func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor sqlcore.QueryExecutor, orgID string) QueryProfilingSummary {
 	output := executor.LastProfilingOutput()
 	if output == "" {
-		return
+		return QueryProfilingSummary{}
 	}
 	m, ok := parseProfilingOutput(output)
 	if !ok {
-		return
+		return QueryProfilingSummary{}
 	}
 
 	span.SetAttributes(
@@ -127,7 +159,7 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 	)
 
 	planningDur := m.Planner + m.PlannerBinding + m.CumulativeOptimizerTiming + m.PhysicalPlanner
-	scanTime, scanRows, computeTime := collectOperatorTimings(m.Children)
+	scanTime, scanRows, computeTime, pgScanTime, pgScanRows := collectOperatorTimings(m.Children)
 
 	cursor := execStart
 
@@ -153,6 +185,7 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 
 	S3BytesReadTotal.WithLabelValues(orgID).Add(float64(m.TotalBytesRead))
 	ScanWallSecondsHistogram.WithLabelValues(orgID).Observe(scanWall)
+	PostgresScanSecondsHistogram.WithLabelValues(orgID).Observe(pgScanTime)
 	scanRowsWallEstimate := scanRows
 	if m.CPUTime > 0 && m.Latency > 0 {
 		if p := m.CPUTime / m.Latency; p > 1 {
@@ -177,6 +210,8 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 			attribute.Float64("duckdb.scan_thread_s", scanTime),
 			attribute.Float64("duckdb.scan_rows_wall", scanRowsWall),
 			attribute.Float64("duckdb.scan_rows_cumulative", scanRows),
+			attribute.Float64("duckdb.postgres_scan_thread_s", pgScanTime),
+			attribute.Float64("duckdb.postgres_scan_rows_cumulative", pgScanRows),
 			attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 		)
 		cursor = cursor.Add(time.Duration(scanWall * float64(time.Second)))
@@ -192,6 +227,8 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		cursor = cursor.Add(time.Duration(computeWall * float64(time.Second)))
 		compSpan.End(trace.WithTimestamp(cursor))
 	}
+
+	return QueryProfilingSummary{PostgresScanSeconds: pgScanTime}
 }
 
 // TraceIDFromContext returns the hex trace ID from the span context, or "".

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -42,6 +42,12 @@ type QueryLogEntry struct {
 	Protocol        string // "simple" or "extended"
 	TraceID         string // OTEL trace ID (empty when tracing is off)
 	SpanID          string // OTEL span ID (empty when tracing is off)
+	// PostgresScanMs is the thread-time spent in postgres_scan operators
+	// during this query — DuckLake metadata DB roundtrips. Zero when DuckDB
+	// returned no profiling output (cancelled / errored before exec /
+	// profiling disabled). Lets us answer "which query shape pounds the
+	// metadata DB?" against `system.query_log` without re-parsing profiling.
+	PostgresScanMs int64
 }
 
 // QueryLogger batches query log entries and writes them to a DuckLake table.
@@ -225,18 +231,18 @@ func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
 	}
 	sb.WriteString("INSERT INTO ")
 	sb.WriteString(table)
-	sb.WriteString(" (event_time, query_duration_ms, type, query, transpiled_query, query_kind, normalized_query_hash, result_rows, written_rows, exception_code, exception, user_name, org_id, current_database, client_address, client_port, application_name, pid, worker_id, is_transpiled, protocol, trace_id, span_id) VALUES ")
+	sb.WriteString(" (event_time, query_duration_ms, type, query, transpiled_query, query_kind, normalized_query_hash, result_rows, written_rows, exception_code, exception, user_name, org_id, current_database, client_address, client_port, application_name, pid, worker_id, is_transpiled, protocol, trace_id, span_id, postgres_scan_ms) VALUES ")
 
-	const colsPerRow = 23
+	const colsPerRow = 24
 	args := make([]any, 0, len(batch)*colsPerRow)
 	for i, e := range batch {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
 		base := i * colsPerRow
-		fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+		fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
 			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10,
-			base+11, base+12, base+13, base+14, base+15, base+16, base+17, base+18, base+19, base+20, base+21, base+22, base+23)
+			base+11, base+12, base+13, base+14, base+15, base+16, base+17, base+18, base+19, base+20, base+21, base+22, base+23, base+24)
 
 		args = append(args,
 			e.EventTime,
@@ -262,6 +268,7 @@ func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
 			e.Protocol,
 			e.TraceID,
 			e.SpanID,
+			e.PostgresScanMs,
 		)
 	}
 
@@ -331,6 +338,18 @@ func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName strin
 		}
 	}
 
+	// Backfill postgres_scan_ms column on tables created before metadata-DB
+	// observability landed. New tables already get it from CREATE TABLE.
+	hasPgScan, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, "postgres_scan_ms")
+	if err != nil {
+		return fmt.Errorf("inspect postgres_scan_ms column: %w", err)
+	}
+	if !hasPgScan {
+		if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN postgres_scan_ms BIGINT"); err != nil {
+			return fmt.Errorf("add postgres_scan_ms column: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -358,7 +377,8 @@ func queryLogCreateTableSQL(fullTableName string) string {
 		is_transpiled       BOOLEAN,
 		protocol            VARCHAR,
 		trace_id            VARCHAR,
-		span_id             VARCHAR
+		span_id             VARCHAR,
+		postgres_scan_ms    BIGINT
 	)`, fullTableName)
 }
 
@@ -499,6 +519,13 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 		}
 	}
 
+	// Consume the profiling rollup left behind by the most recent
+	// EnrichSpanWithProfiling on this connection and reset it so a later
+	// logQuery without a fresh exec (e.g. parse-failure path) doesn't
+	// reuse stale timings from a previous query.
+	pgScanMs := int64(c.lastProfilingSummary.PostgresScanSeconds * 1000)
+	c.lastProfilingSummary = observe.QueryProfilingSummary{}
+
 	ql.Log(QueryLogEntry{
 		EventTime:       start,
 		QueryDurationMs: time.Since(start).Milliseconds(),
@@ -523,6 +550,7 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 		Protocol:        protocol,
 		TraceID:         observe.TraceIDFromContext(c.ctx),
 		SpanID:          observe.SpanIDFromContext(c.ctx),
+		PostgresScanMs:  pgScanMs,
 	})
 }
 

--- a/server/querylog_test.go
+++ b/server/querylog_test.go
@@ -400,7 +400,8 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 		is_transpiled BOOLEAN,
 		protocol VARCHAR,
 		trace_id VARCHAR,
-		span_id VARCHAR
+		span_id VARCHAR,
+		postgres_scan_ms BIGINT
 	)`)
 	if err != nil {
 		t.Fatalf("create table: %v", err)
@@ -424,6 +425,7 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 		PID:             99,
 		WorkerID:        7,
 		Protocol:        "simple",
+		PostgresScanMs:  123,
 	}})
 
 	var got string
@@ -433,6 +435,14 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 	}
 	if got != "analytics" {
 		t.Fatalf("expected org_id analytics, got %q", got)
+	}
+
+	var pgScanMs int64
+	if err := db.QueryRow("SELECT postgres_scan_ms FROM query_log").Scan(&pgScanMs); err != nil {
+		t.Fatalf("query postgres_scan_ms: %v", err)
+	}
+	if pgScanMs != 123 {
+		t.Fatalf("expected postgres_scan_ms 123, got %d", pgScanMs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the metadata-DB visibility gaps surfaced in the recent audit: today a slow Aurora is indistinguishable from a slow S3 read, postgres_scanner pool state is invisible, individual metadata roundtrips aren't traced, and Aurora can't attribute connections back to a duckgres tenant. This PR fixes all four.

- **`duckgres_postgres_scan_seconds{org}`** histogram + `duckdb.postgres_scan_thread_s` span attribute — postgres_scan operator time is now broken out from generic scan time in the DuckDB profiling tree. Metadata DB latency becomes a first-class signal, separable from S3.
- **libpq `application_name=duckgres/<org-id>`** injected into the ATTACH connection string via `ducklake.Config.ApplicationName`. Every postgres_scanner connection now shows up in Aurora `pg_stat_activity` / Performance Insights attributed to a specific tenant.
- **Metadata-metrics scrape loop** on the worker (30s tick) emits `duckgres_ducklake_metadata_pool_max_connections{org}` and `duckgres_ducklake_metadata_connections{org,state}` (the latter via `postgres_query` against `pg_stat_activity` filtered by our `application_name`). Uses `controlDB` so it never queues behind user queries; silent on any failure (missing-data signal in Grafana beats per-30s warn spam).
- **`system.query_log.postgres_scan_ms`** new column, backfilled on existing tables. Answer "which query shape hammers the metadata DB?" directly from `query_log` without re-parsing the profiling JSON.

Rationale for this work specifically now: the next planned step is to pack 100s–1000s of tenant DuckLake catalogs onto a smaller pool of Postgres clusters (vs Aurora-per-org). That tenancy redesign needs the metadata-DB load dimension to be observable per-tenant before we commit to it.

## Test plan

- [x] `go test ./server/ducklake/ ./server/ ./duckdbservice/ ./controlplane/` passes
- [x] `go vet ./...` clean
- [x] New unit tests: `TestInjectPostgresApplicationName` (6 cases) + `TestBuildAttachStmt/with_application_name_tags_libpq_connection`
- [x] Updated `TestQueryLoggerFlushBatchPersistsOrgID` to assert `postgres_scan_ms` round-trips
- [x] `TestEnsureQueryLogTableAddsOrgIDToExistingTable` still passes (validates the migration path that adds `postgres_scan_ms` to legacy tables)
- [ ] Smoke-check in dev: confirm Aurora Performance Insights groups connections by `duckgres/<org>` and the new Prometheus series have data
- [ ] (deferred) Verify `postgres_query` works against Aurora through postgres_scanner in our DuckDB build — if the gauge stays at 0 in dev, fall back to a duckdb_settings-only scrape