### PR TITLE
chore(observe): drop dead pg_stat_activity scrape path

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -274,13 +274,18 @@ func (p *SessionPool) scrapeMetadataMetrics() {
 	if v, ok := scrapeMetadataPoolMax(ctx, scrapeDB); ok {
 		observe.MetadataPoolMaxConnections.WithLabelValues(orgID).Set(v)
 	}
-
-	scrapeMetadataConnectionsByState(ctx, scrapeDB, orgID)
 }
 
 // scrapeMetadataPoolMax reads DuckDB's pg_pool_max_connections setting via
 // duckdb_settings(). A value of 0 means the in-process pool is disabled (we
 // set this when ViaPgBouncer is true) — still useful to emit as a gauge.
+//
+// Aurora-side load (active/idle connections, slow queries) is observed via
+// pg_stat_activity / Performance Insights, attributed back to duckgres by
+// the application_name we tag at ATTACH time (ducklake.Config.ApplicationName).
+// We deliberately don't try to scrape pg_stat_activity from the worker via
+// postgres_query — an earlier attempt silently no-op'd in our DuckDB build
+// and Performance Insights is the better tool for that view anyway.
 func scrapeMetadataPoolMax(ctx context.Context, db *sql.DB) (float64, bool) {
 	var raw string
 	err := db.QueryRowContext(ctx,
@@ -295,45 +300,6 @@ func scrapeMetadataPoolMax(ctx context.Context, db *sql.DB) (float64, bool) {
 		return 0, false
 	}
 	return v, true
-}
-
-// scrapeMetadataConnectionsByState issues a single pg_stat_activity query
-// against the ATTACHed DuckLake metadata DB via postgres_query() and emits a
-// gauge per Postgres connection state. Connections are filtered by the
-// application_name we injected at attach time so we report only duckgres'
-// own connections, not whatever else is sharing the metadata Postgres.
-//
-// We deliberately do not log on failure: if postgres_query is unavailable
-// (extension load order, version skew) or the metadata user lacks
-// pg_stat_activity visibility, the gauge simply stops updating, and the
-// per-org missing-data signal in Grafana is more useful than a recurring
-// warn on every worker.
-func scrapeMetadataConnectionsByState(ctx context.Context, db *sql.DB, orgID string) {
-	const q = `SELECT state, n FROM postgres_query(
-		'__ducklake_metadata_ducklake',
-		'SELECT COALESCE(state, ''unknown'') AS state, count(*) AS n FROM pg_stat_activity WHERE application_name LIKE ''duckgres/%'' GROUP BY state'
-	)`
-	rows, err := db.QueryContext(ctx, q)
-	if err != nil {
-		return
-	}
-	defer func() { _ = rows.Close() }()
-
-	seen := map[string]float64{}
-	for rows.Next() {
-		var state string
-		var n int64
-		if err := rows.Scan(&state, &n); err != nil {
-			return
-		}
-		seen[state] = float64(n)
-	}
-	if err := rows.Err(); err != nil {
-		return
-	}
-	for state, n := range seen {
-		observe.MetadataConnectionsByState.WithLabelValues(orgID, state).Set(n)
-	}
 }
 
 // Run starts the DuckDB service, blocking until shutdown.

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -63,14 +63,3 @@ var MetadataPoolMaxConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "duckgres_ducklake_metadata_pool_max_connections",
 	Help: "Configured postgres_scanner pool ceiling for DuckLake metadata (pg_pool_max_connections).",
 }, []string{"org"})
-
-// MetadataConnectionsByState is the live count of metadata DB connections
-// from pg_stat_activity on the DuckLake metadata DB, grouped by Postgres
-// connection state (active, idle, idle in transaction, etc.). Scraped via
-// postgres_query against the ATTACHed metadata catalog every metadata
-// metrics tick. Only populated when the metadata DB tags duckgres
-// connections via application_name (see ducklake.Config.ApplicationName).
-var MetadataConnectionsByState = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Name: "duckgres_ducklake_metadata_connections",
-	Help: "DuckLake metadata DB connection count by state, scraped from pg_stat_activity (filtered by application_name).",
-}, []string{"org", "state"})


### PR DESCRIPTION
## Summary

Follow-up cleanup after #598. The `postgres_query()`-based `pg_stat_activity` scrape silently no-ops in our DuckDB build, leaving `duckgres_ducklake_metadata_connections` empty in dev and never reporting any data. Dead code is worse than no code here: it gives the misleading impression that "no data" means "no connections", instead of "this never worked".

Removed:
- `scrapeMetadataConnectionsByState` and its `postgres_query` call in `duckdbservice/service.go`
- `MetadataConnectionsByState` gauge in `server/observe/metrics.go`

Kept (works, confirmed wired):
- `duckgres_ducklake_metadata_pool_max_connections` gauge — scraped via `duckdb_settings()`, which is universally available.
- `duckgres_postgres_scan_seconds{org}` histogram and `duckdb.postgres_scan_thread_s` span attribute (per-query metadata DB time).
- `system.query_log.postgres_scan_ms` column — `QueryLogger` is a real, wired feature (configstore singleton in `controlplane/configstore/models.go:287`, CLI flag, admin API, plumbed through `cmd/duckgres-worker/main.go:214`); the column just sits idle in deployments where `QueryLog.Enabled=false` and lights up automatically when the feature is flipped on.
- `application_name=duckgres/<org-id>` injection — Aurora-side `pg_stat_activity` / Performance Insights are the better tool for live connection state anyway.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./duckdbservice/ ./server/observe/`