### PR TITLE
fix(lakekeeper): set ACCESS_DELEGATION_MODE 'none' on Iceberg ATTACH

### DIFF
--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -99,16 +99,31 @@ func BuildLakekeeperSecretStmt(cfg Config) string {
 	)
 }
 
+// LakekeeperAccessDelegationNone disables Iceberg REST credential vending on
+// the ATTACH. This MUST be set explicitly: DuckDB's iceberg extension defaults
+// ACCESS_DELEGATION_MODE to 'vended_credentials', so simply *omitting* the
+// option does NOT turn vending off (the lesson from the first live write test).
+const LakekeeperAccessDelegationNone = "ACCESS_DELEGATION_MODE 'none'"
+
 // BuildLakekeeperAttachStmt builds the ATTACH statement for the Iceberg
 // REST catalog served by Lakekeeper.
 //
-// We deliberately do NOT use ACCESS_DELEGATION_MODE 'vended_credentials':
-// Lakekeeper's STS vending overflows AWS's packed-policy limit
-// (PackedPolicyTooLarge), and it's unnecessary — the worker already holds S3
-// creds for the warehouse bucket via the iceberg_sigv4 secret (built from the
-// duckling's brokered STS creds, same per-org role/bucket; see
-// attachLakekeeperCatalog). DuckDB uses that secret to read/write table data;
-// Lakekeeper serves only catalog metadata.
+// We explicitly set ACCESS_DELEGATION_MODE 'none' (NOT 'vended_credentials',
+// and crucially NOT omitted — see below). Two reasons vending is wrong here:
+//   - Lakekeeper's STS vending overflows AWS's packed-policy limit
+//     (PackedPolicyTooLarge), so vending is disabled on the warehouse anyway.
+//   - With vending disabled server-side, a delegation-requesting client still
+//     gets a per-table storage *config* (region/endpoint) back with NO
+//     credentials. DuckDB turns that into a path-scoped S3 secret with empty
+//     creds, and because its scope (the table's S3 prefix) is MORE SPECIFIC
+//     than iceberg_sigv4's (s3://), it SHADOWS our working secret — every data
+//     read/write then goes out anonymous and S3 returns 403. Verified live on
+//     `ben` in managed-warehouse-dev: omitting the option 403'd; 'none' fixed it.
+//
+// With delegation off, DuckDB falls back to the ambient iceberg_sigv4 secret,
+// which holds the duckling's own brokered S3 creds for the warehouse bucket
+// (built in attachLakekeeperCatalog from the same per-org role/bucket). DuckDB
+// uses that to read/write table data; Lakekeeper serves only catalog metadata.
 //
 // When OAUTH2_SERVER_URI is empty (allowall mode), AUTHORIZATION_TYPE 'none'
 // is set instead of SECRET. When OAuth2 is configured, SECRET references
@@ -116,18 +131,20 @@ func BuildLakekeeperSecretStmt(cfg Config) string {
 func BuildLakekeeperAttachStmt(cfg Config) string {
 	if cfg.LakekeeperOAuth2ServerURI == "" {
 		return fmt.Sprintf(
-			"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', AUTHORIZATION_TYPE 'none')",
+			"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', AUTHORIZATION_TYPE 'none', %s)",
 			escapeSQLStringLiteral(cfg.LakekeeperWarehouse),
 			CatalogName,
 			escapeSQLStringLiteral(cfg.LakekeeperEndpoint),
+			LakekeeperAccessDelegationNone,
 		)
 	}
 	return fmt.Sprintf(
-		"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', SECRET %s)",
+		"ATTACH '%s' AS %s (TYPE ICEBERG, ENDPOINT '%s', SECRET %s, %s)",
 		escapeSQLStringLiteral(cfg.LakekeeperWarehouse),
 		CatalogName,
 		escapeSQLStringLiteral(cfg.LakekeeperEndpoint),
 		LakekeeperSecretName,
+		LakekeeperAccessDelegationNone,
 	)
 }
 

--- a/server/iceberg/migration_test.go
+++ b/server/iceberg/migration_test.go
@@ -84,7 +84,7 @@ func TestBuildLakekeeperAttachStmt_Allowall(t *testing.T) {
 		LakekeeperEndpoint:  "http://lakekeeper-acme.lakekeeper.svc:8181/catalog",
 		LakekeeperWarehouse: "org-acme",
 	})
-	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', AUTHORIZATION_TYPE 'none')"
+	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', AUTHORIZATION_TYPE 'none', ACCESS_DELEGATION_MODE 'none')"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt (allowall) mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -96,7 +96,7 @@ func TestBuildLakekeeperAttachStmt_OAuth2(t *testing.T) {
 		LakekeeperWarehouse:       "org-acme",
 		LakekeeperOAuth2ServerURI: "http://oidc/token",
 	})
-	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', SECRET iceberg_oauth)"
+	want := "ATTACH 'org-acme' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://lakekeeper-acme.lakekeeper.svc:8181/catalog', SECRET iceberg_oauth, ACCESS_DELEGATION_MODE 'none')"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt (oauth2) mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -107,7 +107,7 @@ func TestBuildLakekeeperAttachStmt_EscapesQuotes(t *testing.T) {
 		LakekeeperEndpoint:  "http://h/cat?x='y'",
 		LakekeeperWarehouse: "wh'name",
 	})
-	want := "ATTACH 'wh''name' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://h/cat?x=''y''', AUTHORIZATION_TYPE 'none')"
+	want := "ATTACH 'wh''name' AS iceberg (TYPE ICEBERG, ENDPOINT 'http://h/cat?x=''y''', AUTHORIZATION_TYPE 'none', ACCESS_DELEGATION_MODE 'none')"
 	if got != want {
 		t.Fatalf("BuildLakekeeperAttachStmt did not escape quotes:\n got: %s\nwant: %s", got, want)
 	}


### PR DESCRIPTION
## Summary

The Lakekeeper Iceberg `ATTACH` **omitted** `ACCESS_DELEGATION_MODE`, on the assumption that omitting it meant "don't vend." It doesn't — DuckDB's iceberg extension **defaults** the mode to `'vended_credentials'`. So the worker still requested credential delegation on every table load.

Since warehouse-side STS vending is disabled (#594, to avoid `PackedPolicyTooLarge`), Lakekeeper responded with a per-table storage **config** (region/endpoint) carrying **no credentials**. DuckDB materialized that into a path-scoped S3 secret with empty creds, and because its scope (the table's S3 prefix) is **more specific** than `iceberg_sigv4`'s (`s3://`), it **shadowed** the duckling's real brokered-creds secret. Every data read/write then went out anonymous → S3 `403 Forbidden`.

Catalog metadata ops (CREATE SCHEMA/TABLE via the Lakekeeper REST API) worked fine — only the client-side S3 data path was broken, which is why provisioning looked green.

## Fix

Set `ACCESS_DELEGATION_MODE 'none'` explicitly on both ATTACH branches (allowall + OAuth2). DuckDB then never creates the empty shadow secret and falls back to the ambient `iceberg_sigv4` secret, which holds the duckling's own brokered S3 creds for the warehouse bucket.

## Verification (live, `ben` in managed-warehouse-dev)

- With the option **omitted** (current main): `INSERT` → `403 Forbidden` writing the parquet data file; `SELECT` returned 0 rows.
- After re-ATTACHing with `ACCESS_DELEGATION_MODE 'none'`: `CREATE SCHEMA` / `CREATE TABLE` / `INSERT` / `SELECT` round-trip through Lakekeeper to S3 — parquet data + Iceberg metadata (metadata.json, manifest/snapshot `.avro`) land in `s3://posthog-duckling-ben-mw-dev/lakekeeper/.../data/`, and rows read back correctly.

Unit tests updated to assert the delegation option on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)