### PR TITLE
feat(iceberg): switch session catalog with USE iceberg / USE ducklake

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -25,6 +25,7 @@ import (
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server/auth"
 	"github.com/posthog/duckgres/server/flightclient"
+	"github.com/posthog/duckgres/server/iceberg"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/sqlcore"
@@ -1614,28 +1615,38 @@ func (c *clientConn) rewriteDirectQuery(query string) string {
 	}
 
 	unquoted := target
-	quoteResult := false
 	if len(target) >= 2 && target[0] == '"' && target[len(target)-1] == '"' {
 		unquoted = strings.ReplaceAll(target[1:len(target)-1], `""`, `"`)
-		quoteResult = true
 	}
 
-	if !strings.EqualFold(unquoted, c.database) {
+	// Rewrite a bare catalog `USE` to a two-part `catalog.schema` target.
+	// Two-part is required for reliable switching: a bare `USE ducklake`
+	// issued while the session is in the iceberg catalog resolves `ducklake`
+	// as a schema *within* iceberg (DuckDB prefers schema-in-current-catalog
+	// for a single identifier), landing on a bogus `iceberg.ducklake`.
+	var target2part string
+	switch {
+	case strings.EqualFold(unquoted, iceberg.CatalogName):
+		// `USE iceberg` -> the guaranteed default schema. DuckDB can't `USE`
+		// a bare REST catalog (it targets <catalog>.main, which it shadows),
+		// so we land on iceberg.<DefaultSchema> (ensured by attachLakekeeperCatalog).
+		target2part = iceberg.CatalogName + "." + iceberg.DefaultSchema
+	case strings.EqualFold(unquoted, physicalDuckLakeCatalog) || strings.EqualFold(unquoted, c.database):
+		// `USE ducklake` or `USE <logical-db-name>` -> the physical ducklake.main.
+		target2part = physicalDuckLakeCatalog + ".main"
+	default:
 		return query
 	}
 
-	physicalCatalog := "ducklake"
-	replacement := physicalCatalog
-	if quoteResult {
-		replacement = `"` + strings.ReplaceAll(physicalCatalog, `"`, `""`) + `"`
-	}
-
-	rewritten := "USE " + replacement
+	rewritten := "USE " + target2part
 	if hasSemicolon {
 		rewritten += ";"
 	}
 	return rewritten
 }
+
+// physicalDuckLakeCatalog is the physical catalog name DuckLake is attached as.
+const physicalDuckLakeCatalog = "ducklake"
 
 // executeSelectQuery runs a result-returning query against DuckDB and streams results to the client.
 // Sends RowDescription, DataRow messages, CommandComplete, and ReadyForQuery.

--- a/server/conn.go
+++ b/server/conn.go
@@ -762,6 +762,19 @@ func (c *clientConn) safeCleanupDB() {
 		}
 
 		if connHealthy {
+			if c.server.cfg.Iceberg.Enabled {
+				// The iceberg catalog stays attached for the life of the session
+				// (attachLakekeeperCatalog no longer detaches empty warehouses),
+				// so release it here too — otherwise a pooled connection reused by
+				// the next activation hits the count>0 early-return in
+				// attachLakekeeperCatalog and keeps a stale catalog secret.
+				ctxIce, cancelIce := context.WithTimeout(context.Background(), cleanupTimeout)
+				_, err := c.executor.ExecContext(ctxIce, "DETACH "+iceberg.CatalogName)
+				cancelIce()
+				if err != nil {
+					slog.Warn("Failed to detach Iceberg catalog.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				}
+			}
 			if c.server.cfg.DuckLake.DeltaCatalogEnabled {
 				ctxDelta, cancelDelta := context.WithTimeout(context.Background(), cleanupTimeout)
 				_, err := c.executor.ExecContext(ctxDelta, "DETACH delta")
@@ -1626,14 +1639,18 @@ func (c *clientConn) rewriteDirectQuery(query string) string {
 	// for a single identifier), landing on a bogus `iceberg.ducklake`.
 	var target2part string
 	switch {
-	case strings.EqualFold(unquoted, iceberg.CatalogName):
+	case strings.EqualFold(unquoted, c.database) || strings.EqualFold(unquoted, physicalDuckLakeCatalog):
+		// `USE <logical-db-name>` or `USE ducklake` -> the physical ducklake.main.
+		// Checked before the iceberg arm so that a customer whose logical DB is
+		// (improbably) named "iceberg" still reaches their DuckLake warehouse.
+		target2part = physicalDuckLakeCatalog + ".main"
+	case c.server.cfg.Iceberg.Enabled && strings.EqualFold(unquoted, iceberg.CatalogName):
 		// `USE iceberg` -> the guaranteed default schema. DuckDB can't `USE`
 		// a bare REST catalog (it targets <catalog>.main, which it shadows),
 		// so we land on iceberg.<DefaultSchema> (ensured by attachLakekeeperCatalog).
+		// Gated on Iceberg.Enabled so non-iceberg sessions pass `USE iceberg`
+		// through unchanged.
 		target2part = iceberg.CatalogName + "." + iceberg.DefaultSchema
-	case strings.EqualFold(unquoted, physicalDuckLakeCatalog) || strings.EqualFold(unquoted, c.database):
-		// `USE ducklake` or `USE <logical-db-name>` -> the physical ducklake.main.
-		target2part = physicalDuckLakeCatalog + ".main"
 	default:
 		return query
 	}

--- a/server/direct_query_rewrite_test.go
+++ b/server/direct_query_rewrite_test.go
@@ -9,6 +9,7 @@ func TestRewriteDirectQuery(t *testing.T) {
 				DuckLake: DuckLakeConfig{
 					MetadataStore: "postgres:host=127.0.0.1 dbname=ducklake",
 				},
+				Iceberg: IcebergConfig{Enabled: true},
 			},
 		},
 		database:              "test",
@@ -86,6 +87,38 @@ func TestRewriteDirectQuery(t *testing.T) {
 				t.Fatalf("rewriteDirectQuery(%q) = %q, want %q", tc.query, got, tc.want)
 			}
 		})
+	}
+}
+
+// When iceberg is NOT enabled for the session, `USE iceberg` must pass through
+// unchanged (no rewrite to a schema that isn't attached).
+func TestRewriteDirectQueryUseIcebergPassthroughWhenDisabled(t *testing.T) {
+	c := &clientConn{
+		server: &Server{cfg: Config{
+			DuckLake: DuckLakeConfig{MetadataStore: "postgres:host=127.0.0.1 dbname=ducklake"},
+			Iceberg:  IcebergConfig{Enabled: false},
+		}},
+		database:              "test",
+		logicalCatalogMapping: true,
+	}
+	if got, want := c.rewriteDirectQuery("USE iceberg"), "USE iceberg"; got != want {
+		t.Fatalf("rewriteDirectQuery(USE iceberg) = %q, want %q", got, want)
+	}
+}
+
+// A customer whose logical DB name is literally "iceberg" must still reach
+// their DuckLake warehouse on `USE iceberg`, not the Iceberg REST catalog.
+func TestRewriteDirectQueryLogicalDBNamedIcebergGoesToDuckLake(t *testing.T) {
+	c := &clientConn{
+		server: &Server{cfg: Config{
+			DuckLake: DuckLakeConfig{MetadataStore: "postgres:host=127.0.0.1 dbname=ducklake"},
+			Iceberg:  IcebergConfig{Enabled: true},
+		}},
+		database:              "iceberg",
+		logicalCatalogMapping: true,
+	}
+	if got, want := c.rewriteDirectQuery("USE iceberg"), "USE ducklake.main"; got != want {
+		t.Fatalf("rewriteDirectQuery(USE iceberg) with logical db 'iceberg' = %q, want %q", got, want)
 	}
 }
 

--- a/server/direct_query_rewrite_test.go
+++ b/server/direct_query_rewrite_test.go
@@ -21,19 +21,42 @@ func TestRewriteDirectQuery(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "rewrites logical use command",
+			name:  "rewrites logical use command to two-part ducklake.main",
 			query: "USE test",
-			want:  "USE ducklake",
+			want:  "USE ducklake.main",
 		},
 		{
-			name:  "rewrites quoted logical use command",
+			name:  "rewrites quoted logical use command to two-part ducklake.main",
 			query: `USE "test"`,
-			want:  `USE "ducklake"`,
+			want:  "USE ducklake.main",
 		},
 		{
 			name:  "rewrites commented logical use command",
 			query: "/* switch */ USE test;",
-			want:  "USE ducklake;",
+			want:  "USE ducklake.main;",
+		},
+		{
+			// `USE ducklake` while currently in the iceberg catalog would
+			// otherwise resolve to a bogus iceberg.ducklake — two-part fixes it.
+			name:  "rewrites bare ducklake to two-part ducklake.main",
+			query: "USE ducklake",
+			want:  "USE ducklake.main",
+		},
+		{
+			name:  "rewrites bare iceberg to its default schema",
+			query: "USE iceberg",
+			want:  "USE iceberg.public",
+		},
+		{
+			name:  "rewrites quoted iceberg to its default schema",
+			query: `USE "iceberg";`,
+			want:  "USE iceberg.public;",
+		},
+		{
+			// already two-part — left untouched.
+			name:  "preserves two-part iceberg use",
+			query: "USE iceberg.billing",
+			want:  "USE iceberg.billing",
 		},
 		{
 			name:  "preserves physical use command",

--- a/server/iceberg/migration.go
+++ b/server/iceberg/migration.go
@@ -14,6 +14,17 @@ const DefaultRegion = "us-east-1"
 // worker) would require generalizing this.
 const CatalogName = "iceberg"
 
+// DefaultSchema is the schema the worker guarantees exists in the Iceberg
+// catalog so customers can switch to it with a bare `USE iceberg` (rewritten
+// to `USE iceberg.<DefaultSchema>` in server.rewriteDirectQuery).
+//
+// DuckLake uses `main` for this role, but we cannot: DuckDB reserves `main` as
+// a catalog's implicit local schema and shadows the REST catalog's real `main`
+// namespace, so `iceberg.main` never resolves (it's absent from
+// information_schema even when Lakekeeper has a `main` namespace). `public`
+// (the Postgres convention) is a safe, unshadowed default.
+const DefaultSchema = "public"
+
 // BuildIcebergSecretStmt builds the CREATE SECRET statement that the
 // DuckDB iceberg extension uses to sign AWS S3 Tables requests when an
 // `ATTACH ... (TYPE iceberg, ENDPOINT_TYPE 's3_tables')` is opened.

--- a/server/server.go
+++ b/server/server.go
@@ -1743,15 +1743,19 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 		}
 		return fmt.Errorf("failed to attach Lakekeeper iceberg catalog: %w", err)
 	}
-	if _, err := db.Exec("SHOW TABLES FROM " + iceberg.CatalogName); err != nil {
-		if isIcebergCatalogEmptyError(err) {
-			if _, derr := db.Exec("DETACH " + iceberg.CatalogName); derr != nil {
-				slog.Warn("Failed to detach empty Lakekeeper iceberg catalog after attach probe.", "error", derr)
-			}
-			slog.Info("Detached Lakekeeper iceberg catalog: no namespaces yet.", "warehouse", ic.LakekeeperWarehouse)
-			return nil
-		}
-		return fmt.Errorf("failed to probe Lakekeeper iceberg catalog: %w", err)
+
+	// Guarantee a default schema in the Iceberg catalog. This serves two
+	// purposes: (1) it makes a freshly-provisioned warehouse non-empty so the
+	// catalog stays attached and immediately usable, replacing the old
+	// "probe SHOW TABLES, detach if empty" behavior; and (2) it gives a bare
+	// `USE iceberg` somewhere to land — rewriteDirectQuery rewrites that to
+	// `USE iceberg.<DefaultSchema>` because DuckDB shadows `main` on a REST
+	// catalog (see iceberg.DefaultSchema). Idempotent and best-effort: an
+	// attached catalog without it still works via explicit schema references,
+	// so a transient failure here must not fail activation.
+	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + iceberg.CatalogName + "." + iceberg.DefaultSchema); err != nil {
+		slog.Warn("Failed to ensure default Iceberg schema; catalog attached without it.",
+			"schema", iceberg.DefaultSchema, "warehouse", ic.LakekeeperWarehouse, "error", err)
 	}
 	slog.Info("Attached Iceberg catalog successfully.", "backend", "lakekeeper", "warehouse", ic.LakekeeperWarehouse)
 	return nil


### PR DESCRIPTION
## Summary

Makes it easy for a customer to switch their session's default catalog between **DuckLake** (still the default) and the **Iceberg (Lakekeeper)** catalog:

```sql
USE iceberg;     -- switch to the Iceberg catalog
USE ducklake;    -- switch back (the default)
SET search_path = 'iceberg.<schema>';   -- also works (unchanged)
```

## Why it needed code (two DuckDB quirks)

1. **DuckDB shadows `main` on a REST catalog.** It reserves `main` as a catalog's implicit local schema, so the Lakekeeper catalog's real `main` namespace never appears in `information_schema` and `iceberg.main` won't resolve — which means a bare `USE iceberg` (DuckDB targets `<catalog>.main`) always failed. Fix: the worker guarantees a default **`iceberg.public`** schema on attach (`iceberg.DefaultSchema`), and `rewriteDirectQuery` rewrites bare `USE iceberg` → `USE iceberg.public`.

2. **A bare `USE ducklake` from inside iceberg mis-resolves.** DuckDB prefers schema-in-current-catalog for a single identifier, so `USE ducklake` while the session is in `iceberg` lands on a bogus `iceberg.ducklake`. Fix: the logical-DB and bare-`ducklake` rewrites now emit two-part **`USE ducklake.main`**, which switches reliably from any current catalog.

## Changes

- `server/iceberg/migration.go` — add `DefaultSchema = "public"` with the rationale.
- `server/server.go` (`attachLakekeeperCatalog`) — ensure `iceberg.public` exists on attach (idempotent, best-effort). This replaces the old "probe `SHOW TABLES`, detach if empty" step: guaranteeing a schema keeps a freshly-provisioned warehouse attached and immediately usable.
- `server/conn.go` (`rewriteDirectQuery`) — rewrite bare `USE iceberg` → `USE iceberg.public` and `USE ducklake` / `USE <logical-db>` → `USE ducklake.main`.
- `server/direct_query_rewrite_test.go` — updated/added cases.

## Verification

Unit tests cover the rewrite. Validated live on a `managed-warehouse-prod-us` org: `iceberg.public` creates and is visible cross-session; `USE iceberg.public` and `USE ducklake.main` round-trip; `SET search_path='iceberg.<schema>'` works for existing schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)