### PR TITLE
feat(iceberg): honor connect-time search_path to pick default catalog

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -847,6 +847,20 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	database := startupParams["database"]
 	applicationName := startupParams["application_name"]
 
+	// Honor a client-supplied connect-time search_path from the startup
+	// `options` parameter (libpq `options=-c search_path=...`, PGOPTIONS, or
+	// pgjdbc `currentSchema`), so a session can pick its default catalog at
+	// connect (e.g. iceberg.public). Sanitized here at the trust boundary;
+	// empty/invalid falls back to the worker's default search_path.
+	var clientSearchPath string
+	if raw := server.ParseStartupOptions(startupParams["options"])["search_path"]; raw != "" {
+		if sp, ok := server.SanitizeSearchPath(raw); ok {
+			clientSearchPath = sp
+		} else {
+			slog.Warn("Ignoring unsafe client search_path option.", "remote_addr", remoteAddr, "search_path", raw)
+		}
+	}
+
 	if username == "" {
 		server.RecordFailedAuthAttempt(cp.rateLimiter, remoteAddr)
 		_ = server.WriteErrorResponse(writer, "FATAL", "28000", "no user specified")
@@ -1080,7 +1094,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		cp.cfg.WorkerQueueTimeout,
 		server.BackendKey{Pid: pid, SecretKey: secretKey},
 		func(ctx context.Context) (int32, *flightclient.FlightExecutor, error) {
-			return sessions.CreateSession(ctx, username, pid, memLimit, threads)
+			return sessions.CreateSession(ctx, username, clientSearchPath, pid, memLimit, threads)
 		},
 	)
 	if err != nil {

--- a/controlplane/flight_ingress.go
+++ b/controlplane/flight_ingress.go
@@ -47,7 +47,7 @@ type flightSessionProvider struct {
 }
 
 func (p *flightSessionProvider) CreateSession(ctx context.Context, username string, pid int32, memoryLimit string, threads int) (int32, *flightclient.FlightExecutor, error) {
-	workerPID, executor, err := p.sm.CreateSession(ctx, username, pid, memoryLimit, threads)
+	workerPID, executor, err := p.sm.CreateSession(ctx, username, "", pid, memoryLimit, threads)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -88,7 +88,7 @@ func (p *orgRoutedSessionProvider) CreateSession(ctx context.Context, username s
 
 	// SessionManager.resolveSessionLimits handles rebalancer defaults,
 	// so pass memoryLimit/threads through as-is.
-	workerPID, executor, err := sessions.CreateSession(ctx, username, pid, memoryLimit, threads)
+	workerPID, executor, err := sessions.CreateSession(ctx, username, "", pid, memoryLimit, threads)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -150,7 +150,7 @@ func (sm *SessionManager) removeWaiterLocked(waiter *connectionWaiter) {
 // CreateSession acquires a worker from the configured pool, creates a session
 // on it, and rebalances memory/thread limits across all active sessions.
 // If pid is 0, a new one is generated.
-func (sm *SessionManager) CreateSession(ctx context.Context, username string, pid int32, memoryLimit string, threads int) (int32, *flightclient.FlightExecutor, error) {
+func (sm *SessionManager) CreateSession(ctx context.Context, username, searchPath string, pid int32, memoryLimit string, threads int) (int32, *flightclient.FlightExecutor, error) {
 	if err := sm.acquireSlot(ctx); err != nil {
 		return 0, nil, err
 	}
@@ -190,7 +190,7 @@ func (sm *SessionManager) CreateSession(ctx context.Context, username string, pi
 	}
 	slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
 
-	pid, exec, err := sm.createSessionOnWorker(ctx, username, pid, memoryLimit, threads, worker, "postgres", true)
+	pid, exec, err := sm.createSessionOnWorker(ctx, username, searchPath, pid, memoryLimit, threads, worker, "postgres", true)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -230,7 +230,7 @@ func (sm *SessionManager) ReconnectFlightSession(ctx context.Context, username s
 	if err != nil {
 		return 0, nil, fmt.Errorf("reconnect worker %d: %w", workerID, err)
 	}
-	pid, exec, err := sm.createSessionOnWorker(ctx, username, 0, "", 0, worker, "flight", false)
+	pid, exec, err := sm.createSessionOnWorker(ctx, username, "", 0, "", 0, worker, "flight", false)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -238,7 +238,7 @@ func (sm *SessionManager) ReconnectFlightSession(ctx context.Context, username s
 	return pid, exec, nil
 }
 
-func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username string, pid int32, memoryLimit string, threads int, worker *ManagedWorker, protocol string, retireOnFailure bool) (int32, *flightclient.FlightExecutor, error) {
+func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username, searchPath string, pid int32, memoryLimit string, threads int, worker *ManagedWorker, protocol string, retireOnFailure bool) (int32, *flightclient.FlightExecutor, error) {
 	createStart := time.Now()
 	slog.Info("Creating session on worker.",
 		"pid", pid,
@@ -250,7 +250,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 		"owner_cp_instance_id", worker.OwnerCPInstanceID(),
 		"owner_epoch", worker.OwnerEpoch(),
 	)
-	sessionToken, err := worker.CreateSession(ctx, username, memoryLimit, threads)
+	sessionToken, err := worker.CreateSession(ctx, username, memoryLimit, searchPath, threads)
 	if err != nil {
 		slog.Warn("Failed to create session on worker.",
 			"pid", pid,

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -63,7 +63,7 @@ func TestCreateSessionObservesWarmCapacityExhaustion(t *testing.T) {
 		err: NewWarmCapacityExhaustedError(30 * time.Second),
 	}, nil)
 
-	_, _, err := sm.CreateSession(context.Background(), "root", 1001, "", 0)
+	_, _, err := sm.CreateSession(context.Background(), "root", "", 1001, "", 0)
 	var capacityErr *WarmCapacityExhaustedError
 	if !errors.As(err, &capacityErr) {
 		t.Fatalf("expected warm capacity error, got %v", err)

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -1200,7 +1200,7 @@ func recoverWorkerPanic(err *error) {
 }
 
 // CreateSession creates a new session on the given worker.
-func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit string, threads int) (token string, err error) {
+func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit, searchPath string, threads int) (token string, err error) {
 	defer recoverWorkerPanic(&err)
 
 	body, _ := json.Marshal(server.WorkerCreateSessionPayload{
@@ -1211,6 +1211,7 @@ func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit
 		},
 		Username:    username,
 		MemoryLimit: memoryLimit,
+		SearchPath:  searchPath,
 		Threads:     threads,
 	})
 

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -109,7 +109,7 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 		}
 	}
 
-	session, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.Threads)
+	session, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.SearchPath, req.Threads)
 	if err != nil {
 		return status.Errorf(codes.ResourceExhausted, "create session: %v", err)
 	}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -435,8 +435,10 @@ func (svc *DuckDBService) Shutdown() {
 	svc.pool.CloseAll()
 }
 
-// CreateSession creates a new DuckDB session for the given username.
-func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (*Session, error) {
+// CreateSession creates a new DuckDB session for the given username. When
+// searchPath is non-empty it is the client's connect-time search_path
+// (sanitized control-plane side) and overrides the username-based default.
+func (p *SessionPool) CreateSession(username, memoryLimit, searchPath string, threads int) (*Session, error) {
 	start := time.Now()
 	// Reserve a slot under the lock to prevent TOCTOU race on maxSessions.
 	p.mu.Lock()
@@ -523,7 +525,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 
 	// Initialize the session connection with username-specific state if needed.
 	// Since the DB is shared, we must set session-local parameters here.
-	initSearchPath(conn, username)
+	initSearchPath(conn, username, searchPath)
 
 	// Re-apply DuckDB profiling settings on the freshly-pooled connection.
 	// ConfigureMainDB sets these once at warmup, but in cluster mode the
@@ -920,7 +922,27 @@ func dropTemporary(conn *sql.Conn, query, dropFmt string) bool {
 // format_type, etc.) remain resolvable when the default catalog is ducklake.
 // Without it, DuckDB restricts function resolution to the ducklake catalog
 // and psql commands like \dt fail.
-func initSearchPath(conn *sql.Conn, username string) {
+func initSearchPath(conn *sql.Conn, username, clientSearchPath string) {
+	// Honor a client-supplied connect-time search_path (from the startup
+	// `options` parameter, e.g. `options=-c search_path=iceberg.public`) so a
+	// session can pick its default catalog/schema at connect — the standard
+	// mechanism BI tools and JDBC (currentSchema) use. The value is sanitized
+	// control-plane side. memory.main is appended so pg_catalog macros stay
+	// resolvable. On failure (e.g. the schema doesn't exist) we fall through to
+	// the username-based default rather than leaving the session unconfigured.
+	if clientSearchPath != "" {
+		sp := clientSearchPath
+		if !strings.Contains(strings.ToLower(sp), "memory.main") {
+			sp += ",memory.main"
+		}
+		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf("SET search_path = '%s'", sp)); err == nil {
+			return
+		} else {
+			slog.Warn("Client-requested search_path rejected; using default.", "user", username, "search_path", clientSearchPath, "error", err)
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}
+
 	if _, err := conn.ExecContext(context.Background(), fmt.Sprintf("SET search_path = '%s,main,memory.main'", username)); err != nil {
 		slog.Debug("User schema not found, using default search_path.", "user", username)
 		// Clear the aborted transaction state before retrying.

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -28,7 +28,7 @@ func TestInitSearchPath(t *testing.T) {
 		defer func() { _ = conn.Close() }()
 
 		// "nonexistent_user" is not a schema — should fall back to 'main' without error
-		initSearchPath(conn, "nonexistent_user")
+		initSearchPath(conn, "nonexistent_user", "")
 
 		var searchPath string
 		if err := conn.QueryRowContext(context.Background(), "SELECT current_setting('search_path')").Scan(&searchPath); err != nil {
@@ -51,7 +51,7 @@ func TestInitSearchPath(t *testing.T) {
 			t.Fatalf("failed to create schema: %v", err)
 		}
 
-		initSearchPath(conn, "myuser")
+		initSearchPath(conn, "myuser", "")
 
 		var searchPath string
 		if err := conn.QueryRowContext(context.Background(), "SELECT current_setting('search_path')").Scan(&searchPath); err != nil {
@@ -59,6 +59,48 @@ func TestInitSearchPath(t *testing.T) {
 		}
 		if searchPath != "myuser,main,memory.main" {
 			t.Errorf("expected search_path 'myuser,main,memory.main', got %q", searchPath)
+		}
+	})
+
+	t.Run("honors client search_path and appends memory.main", func(t *testing.T) {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get connection: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, err := conn.ExecContext(context.Background(), "CREATE SCHEMA IF NOT EXISTS chosen"); err != nil {
+			t.Fatalf("failed to create schema: %v", err)
+		}
+
+		// Client picked `chosen` at connect; memory.main must be appended.
+		initSearchPath(conn, "ignored_user", "chosen")
+
+		var searchPath string
+		if err := conn.QueryRowContext(context.Background(), "SELECT current_setting('search_path')").Scan(&searchPath); err != nil {
+			t.Fatalf("failed to query search_path: %v", err)
+		}
+		if searchPath != "chosen,memory.main" {
+			t.Errorf("expected search_path 'chosen,memory.main', got %q", searchPath)
+		}
+	})
+
+	t.Run("falls back to default when client search_path is invalid", func(t *testing.T) {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("failed to get connection: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		// A schema that doesn't exist: SET fails, fall back to the username default.
+		initSearchPath(conn, "nonexistent_user", "no_such_schema")
+
+		var searchPath string
+		if err := conn.QueryRowContext(context.Background(), "SELECT current_setting('search_path')").Scan(&searchPath); err != nil {
+			t.Fatalf("failed to query search_path: %v", err)
+		}
+		if searchPath != "main,memory.main" {
+			t.Errorf("expected fallback search_path 'main,memory.main', got %q", searchPath)
 		}
 	})
 }

--- a/server/startup_options.go
+++ b/server/startup_options.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ParseStartupOptions parses the Postgres startup-message `options` parameter,
+// which carries `-c name=value` GUC settings (also accepted: `-cname=value` and
+// `--name=value`), e.g. `-c search_path=iceberg.public`. libpq's `options`
+// connection keyword, the PGOPTIONS env var, and pgjdbc's `currentSchema` all
+// arrive here. Values may contain backslash-escaped spaces. Returns a map of
+// setting name -> value (later settings win on duplicate names).
+func ParseStartupOptions(options string) map[string]string {
+	out := map[string]string{}
+	if strings.TrimSpace(options) == "" {
+		return out
+	}
+	tokens := splitStartupOptions(options)
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		var kv string
+		switch {
+		case strings.HasPrefix(tok, "-c"):
+			kv = tok[2:]
+			if kv == "" && i+1 < len(tokens) { // space-separated form: `-c name=value`
+				i++
+				kv = tokens[i]
+			}
+		case strings.HasPrefix(tok, "--"):
+			kv = tok[2:]
+		default:
+			continue
+		}
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			name := strings.TrimSpace(kv[:eq])
+			val := strings.TrimSpace(kv[eq+1:])
+			if name != "" {
+				out[name] = val
+			}
+		}
+	}
+	return out
+}
+
+// splitStartupOptions splits on unescaped whitespace, honoring Postgres'
+// backslash escaping of spaces within a value (e.g. `search_path=a,\ b`).
+func splitStartupOptions(s string) []string {
+	var tokens []string
+	var b strings.Builder
+	escaped := false
+	for _, r := range s {
+		switch {
+		case escaped:
+			b.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == ' ' || r == '\t':
+			if b.Len() > 0 {
+				tokens = append(tokens, b.String())
+				b.Reset()
+			}
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() > 0 {
+		tokens = append(tokens, b.String())
+	}
+	return tokens
+}
+
+// safeSearchPathPattern permits a comma-separated list of (optionally
+// double-quoted, optionally catalog-qualified) identifiers plus surrounding
+// whitespace. It deliberately excludes single quotes, semicolons, and
+// parentheses so the value cannot break out of the single-quoted SET statement
+// it is embedded in.
+var safeSearchPathPattern = regexp.MustCompile(`^[A-Za-z0-9_.,"\- ]+$`)
+
+// SanitizeSearchPath validates a client-supplied search_path so it can be
+// safely embedded in `SET search_path = '<value>'`. Returns (trimmed, true)
+// when the value is a plausible, injection-safe search_path; ("", false)
+// otherwise (callers should then fall back to the default search_path).
+func SanitizeSearchPath(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > 512 {
+		return "", false
+	}
+	if !safeSearchPathPattern.MatchString(s) {
+		return "", false
+	}
+	return s, true
+}

--- a/server/startup_options.go
+++ b/server/startup_options.go
@@ -76,6 +76,11 @@ func splitStartupOptions(s string) []string {
 // whitespace. It deliberately excludes single quotes, semicolons, and
 // parentheses so the value cannot break out of the single-quoted SET statement
 // it is embedded in.
+//
+// In the class `["\- ]`, `\-` is an ESCAPED LITERAL hyphen (RE2), not a range —
+// so the allowed punctuation is exactly `.` `,` `"` `-` and space. `'` and `;`
+// are NOT admitted (locked down in TestSanitizeSearchPath). Keep `\-` escaped if
+// you edit this: an unescaped `-` between class members would form a range.
 var safeSearchPathPattern = regexp.MustCompile(`^[A-Za-z0-9_.,"\- ]+$`)
 
 // SanitizeSearchPath validates a client-supplied search_path so it can be

--- a/server/startup_options_test.go
+++ b/server/startup_options_test.go
@@ -1,0 +1,55 @@
+package server
+
+import "testing"
+
+func TestParseStartupOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options string
+		key     string
+		want    string
+	}{
+		{"space-separated -c", "-c search_path=iceberg.public", "search_path", "iceberg.public"},
+		{"combined -c", "-csearch_path=iceberg.public", "search_path", "iceberg.public"},
+		{"double-dash", "--search_path=iceberg.public", "search_path", "iceberg.public"},
+		{"multiple settings", "-c search_path=iceberg.public -c work_mem=64MB", "work_mem", "64MB"},
+		{"escaped space in value", `-c search_path=iceberg.public,\ memory.main`, "search_path", "iceberg.public, memory.main"},
+		{"empty", "", "search_path", ""},
+		{"unrelated", "-c work_mem=64MB", "search_path", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseStartupOptions(tc.options)[tc.key]; got != tc.want {
+				t.Fatalf("ParseStartupOptions(%q)[%q] = %q, want %q", tc.options, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeSearchPath(t *testing.T) {
+	ok := []string{
+		"iceberg.public",
+		"iceberg.public, memory.main",
+		`"iceberg"."public"`,
+		"ducklake.main",
+		"my_schema",
+	}
+	for _, s := range ok {
+		if got, valid := SanitizeSearchPath(s); !valid || got != s {
+			t.Errorf("SanitizeSearchPath(%q) = (%q, %v), want valid passthrough", s, got, valid)
+		}
+	}
+
+	bad := []string{
+		"",
+		"iceberg.public'; DROP SCHEMA x; --",
+		"iceberg.public; SELECT 1",
+		"foo' || (SELECT 1)",
+		"a(b)",
+	}
+	for _, s := range bad {
+		if _, valid := SanitizeSearchPath(s); valid {
+			t.Errorf("SanitizeSearchPath(%q) accepted an unsafe value", s)
+		}
+	}
+}

--- a/server/startup_options_test.go
+++ b/server/startup_options_test.go
@@ -46,6 +46,14 @@ func TestSanitizeSearchPath(t *testing.T) {
 		"iceberg.public; SELECT 1",
 		"foo' || (SELECT 1)",
 		"a(b)",
+		// Standalone metacharacters: these guard that the `\-` in the allowlist
+		// is an escaped literal hyphen, NOT a range (e.g. `"`..`\`) that would
+		// silently admit ' and ; — the exact thing that would break out of the
+		// single-quoted `SET search_path = '<value>'` statement.
+		"'",
+		";",
+		`x',memory.main`,
+		`a'b`,
 	}
 	for _, s := range bad {
 		if _, valid := SanitizeSearchPath(s); valid {

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -31,6 +31,10 @@ type WorkerCreateSessionPayload struct {
 	Username    string `json:"username"`
 	MemoryLimit string `json:"memory_limit"`
 	Threads     int    `json:"threads"`
+	// SearchPath, when set, is the client's connect-time search_path (parsed
+	// from the startup `options` parameter, e.g. `-c search_path=iceberg.public`).
+	// Empty means use the worker's default. Sanitized control-plane side.
+	SearchPath string `json:"search_path,omitempty"`
 }
 
 // WorkerDestroySessionPayload is the control plane request body for


### PR DESCRIPTION
## Summary

Lets a managed-warehouse session choose its **default catalog/schema at connect time** via the standard Postgres startup `options` parameter:

```sh
# libpq / psql
psql "host=<org>.dw.us.postwh.com ... options=-c search_path=iceberg.public"
# PGOPTIONS
PGOPTIONS='-c search_path=iceberg.public' psql ...
# JDBC
jdbc:postgresql://<org>.dw.us.postwh.com/<db>?currentSchema=iceberg.public
```

This is the mechanism BI tools and JDBC drivers use — they can't run a `USE`/`SET` after connecting but can set connection parameters. Pairs with the `USE iceberg` / `USE ducklake` switching from #603.

## Before / after

- **Before:** `initSearchPath` unconditionally set `search_path = '<user>,main,memory.main'` and **discarded** the client's `options`, so a connect-time search_path was silently ignored (every session landed on DuckLake).
- **After:** the control plane parses the startup `options`, extracts + sanitizes a client `search_path`, and threads it through the session-create RPC to `initSearchPath`, which applies it (appending `memory.main` so `pg_catalog` macros keep resolving) and falls back to the username-based default when the client doesn't ask or the requested schema doesn't exist. **DuckLake stays the default** for connections that don't specify one.

## Security

The client value is sanitized at the trust boundary (`SanitizeSearchPath`) to a comma-separated list of (optionally double-quoted, optionally catalog-qualified) identifiers. Single quotes, semicolons, and parens are rejected, so it can't break out of the `SET search_path = '...'` statement it's embedded in. Invalid values are logged and ignored (fall back to default).

## Threading

`control.go` (parse `options`) → `SessionManager.CreateSession` → `createSessionOnWorker` → `ManagedWorker.CreateSession` → `WorkerCreateSessionPayload.SearchPath` → `SessionPool.CreateSession` → `initSearchPath`. Flight ingress passes `""` (no startup options on that path).

## Tests

- `ParseStartupOptions` — `-c k=v`, `-ck=v`, `--k=v`, multiple settings, escaped spaces.
- `SanitizeSearchPath` — accepts valid catalog.schema lists / quoted idents; rejects injection attempts.
- `initSearchPath` — honors a client search_path (+ appends `memory.main`); falls back to default when the requested schema doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)