### PR TITLE
fix(iceberg): USE iceberg rewrite was disabled in prod by a wrong gate

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1644,12 +1644,17 @@ func (c *clientConn) rewriteDirectQuery(query string) string {
 		// Checked before the iceberg arm so that a customer whose logical DB is
 		// (improbably) named "iceberg" still reaches their DuckLake warehouse.
 		target2part = physicalDuckLakeCatalog + ".main"
-	case c.server.cfg.Iceberg.Enabled && strings.EqualFold(unquoted, iceberg.CatalogName):
+	case strings.EqualFold(unquoted, iceberg.CatalogName):
 		// `USE iceberg` -> the guaranteed default schema. DuckDB can't `USE`
 		// a bare REST catalog (it targets <catalog>.main, which it shadows),
 		// so we land on iceberg.<DefaultSchema> (ensured by attachLakekeeperCatalog).
-		// Gated on Iceberg.Enabled so non-iceberg sessions pass `USE iceberg`
-		// through unchanged.
+		//
+		// NOT gated on cfg.Iceberg.Enabled: rewriteDirectQuery runs on the
+		// control-plane proxy conn (server = the CP, not the per-org worker),
+		// where cfg.Iceberg.Enabled is always false — gating there silently
+		// disabled the rewrite for every tenant. If the tenant doesn't have
+		// iceberg attached, `USE iceberg.public` simply errors at the worker,
+		// same as a bare `USE iceberg` would.
 		target2part = iceberg.CatalogName + "." + iceberg.DefaultSchema
 	default:
 		return query

--- a/server/direct_query_rewrite_test.go
+++ b/server/direct_query_rewrite_test.go
@@ -90,9 +90,11 @@ func TestRewriteDirectQuery(t *testing.T) {
 	}
 }
 
-// When iceberg is NOT enabled for the session, `USE iceberg` must pass through
-// unchanged (no rewrite to a schema that isn't attached).
-func TestRewriteDirectQueryUseIcebergPassthroughWhenDisabled(t *testing.T) {
+// `USE iceberg` is rewritten regardless of cfg.Iceberg.Enabled, because the
+// rewrite runs on the control-plane proxy conn where cfg.Iceberg.Enabled is
+// always false (the per-org flag lives on the worker). Gating on it there
+// silently disabled the rewrite for every tenant.
+func TestRewriteDirectQueryUseIcebergRewrittenEvenWhenCfgDisabled(t *testing.T) {
 	c := &clientConn{
 		server: &Server{cfg: Config{
 			DuckLake: DuckLakeConfig{MetadataStore: "postgres:host=127.0.0.1 dbname=ducklake"},
@@ -101,7 +103,7 @@ func TestRewriteDirectQueryUseIcebergPassthroughWhenDisabled(t *testing.T) {
 		database:              "test",
 		logicalCatalogMapping: true,
 	}
-	if got, want := c.rewriteDirectQuery("USE iceberg"), "USE iceberg"; got != want {
+	if got, want := c.rewriteDirectQuery("USE iceberg"), "USE iceberg.public"; got != want {
 		t.Fatalf("rewriteDirectQuery(USE iceberg) = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

A follow-up fix to #603. During review I gated the `USE iceberg` rewrite on `c.server.cfg.Iceberg.Enabled` — but that **disabled the feature for every tenant in prod**.

`rewriteDirectQuery` runs on the **control-plane proxy connection** (`NewClientConn` is built with `cp.srv`, the control plane's `Server`), where `cfg.Iceberg.Enabled` is always `false` — the per-org iceberg flag lives on the *worker*, not the CP. So the gate suppressed the rewrite unconditionally.

**Verified live:** with #603 deployed to prod, `USE iceberg` still failed with `Catalog Error: No catalog + schema named "iceberg" found` (the native error — proof the rewrite never fired).

## Fix

Remove the `cfg.Iceberg.Enabled` gate. The collision concern it was paired with (a customer whose logical DB is literally named `iceberg`) is already handled by **arm ordering** — the `ducklake` / `c.database` arm is checked before the `iceberg` arm. If a tenant doesn't have iceberg attached, the rewritten `USE iceberg.public` errors at the worker, exactly as a bare `USE iceberg` would.

Updated the unit test to assert the rewrite fires regardless of the CP-side `cfg.Iceberg.Enabled`.

## Note

This needs to merge **and** be promoted to prod (duckgres is approval-gated) before `USE iceberg` works for the prod org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)