### PR TITLE
Add warm capacity observability

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -382,6 +382,14 @@ type WarmCapacityMissAggregate struct {
 	Count  int64                 `json:"count"`
 }
 
+// WarmCapacityWorkerStats is the grouped warm-worker state used for
+// warm-capacity observability.
+type WarmCapacityWorkerStats struct {
+	Scope           string `json:"scope"`
+	ReadyWorkers    int64  `json:"ready_workers"`
+	SpawningWorkers int64  `json:"spawning_workers"`
+}
+
 // WorkerRecord is the durable runtime coordination record for one worker pod.
 type WorkerRecord struct {
 	WorkerID            int         `gorm:"primaryKey" json:"worker_id"`

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -853,6 +853,30 @@ func (cs *ConfigStore) PruneWarmCapacityMissBuckets(before time.Time) (int64, er
 	return result.RowsAffected, nil
 }
 
+// ListWarmCapacityWorkerStats returns grouped cluster-wide warm-worker state
+// for image-scoped warm-capacity observability.
+func (cs *ConfigStore) ListWarmCapacityWorkerStats() ([]WarmCapacityWorkerStats, error) {
+	var out []WarmCapacityWorkerStats
+	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Select(
+			"('image:' || image) AS scope, "+
+				"COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0)::bigint AS ready_workers, "+
+				"COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0)::bigint AS spawning_workers",
+			WorkerStateIdle,
+			WorkerStateSpawning,
+		).
+		Where("org_id = ''").
+		Where("image <> ''").
+		Where("state IN ?", []WorkerState{WorkerStateIdle, WorkerStateSpawning}).
+		Group("image").
+		Order("scope ASC").
+		Scan(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("list warm capacity worker stats: %w", err)
+	}
+	return out, nil
+}
+
 // UpsertControlPlaneInstance inserts or updates a runtime control-plane instance row.
 func (cs *ConfigStore) UpsertControlPlaneInstance(instance *ControlPlaneInstance) error {
 	if err := cs.db.Table(cs.runtimeTable(instance.TableName())).Clauses(clause.OnConflict{

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1473,13 +1473,6 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 
 func (p *K8sWorkerPool) recordWarmCapacityMiss(assignment *WorkerAssignment, reason configstore.WorkerClaimMissReason) {
 	policy := warmCapacityMissPolicyForReason(reason)
-	if !policy.recordDynamicDemand {
-		return
-	}
-	if p.runtimeStore == nil {
-		return
-	}
-
 	image := ""
 	if assignment != nil {
 		image = strings.TrimSpace(assignment.Image)
@@ -1492,6 +1485,13 @@ func (p *K8sWorkerPool) recordWarmCapacityMiss(assignment *WorkerAssignment, rea
 	}
 
 	scope := "image:" + image
+	observeWarmCapacityMiss(scope, policy.reason)
+	if !policy.recordDynamicDemand {
+		return
+	}
+	if p.runtimeStore == nil {
+		return
+	}
 	if err := p.runtimeStore.RecordWarmCapacityMiss(scope, policy.reason, time.Now()); err != nil {
 		slog.Warn("Failed to record warm capacity miss.", "scope", scope, "reason", policy.reason, "error", err)
 	}
@@ -1969,6 +1969,7 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 			p.maxWorkers,
 		)
 		if err != nil {
+			observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), "error", len(slots))
 			for _, s := range slots {
 				p.retireClaimedWorker(s, RetireReasonCrash)
 			}
@@ -2010,7 +2011,13 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 		}(i, slot)
 	}
 	wg.Wait()
-	return stderrors.Join(errs...)
+	err := stderrors.Join(errs...)
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), result, len(slots))
+	return err
 }
 
 // HealthCheckLoop periodically checks worker health.

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2012,11 +2012,17 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 	}
 	wg.Wait()
 	err := stderrors.Join(errs...)
-	result := "success"
-	if err != nil {
-		result = "error"
+	successes := 0
+	failures := 0
+	for _, spawnErr := range errs {
+		if spawnErr != nil {
+			failures++
+		} else {
+			successes++
+		}
 	}
-	observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), result, len(slots))
+	observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), "success", successes)
+	observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), "error", failures)
 	return err
 }
 

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -995,6 +995,45 @@ func TestK8sPoolSpawnMinWorkersForImageSpawnsOnlyTheDeficit(t *testing.T) {
 	}
 }
 
+func TestK8sPoolSpawnMinWorkersForImageCountsMixedSpawnResults(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	image := "duckgres:metrics-mixed"
+	scope := warmCapacityImageScope(image)
+	warmCapacityReconcileSpawnsCounter.DeleteLabelValues(scope, "success")
+	warmCapacityReconcileSpawnsCounter.DeleteLabelValues(scope, "error")
+
+	nextID := 100
+	store := &captureRuntimeWorkerStore{
+		perImageSpawnedFunc: func(image string) *configstore.WorkerRecord {
+			nextID++
+			return &configstore.WorkerRecord{
+				WorkerID:          nextID,
+				PodName:           fmt.Sprintf("duckgres-worker-test-cp-%d", nextID),
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				Image:             image,
+			}
+		},
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		if id == 102 {
+			return errors.New("spawn failed")
+		}
+		return nil
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), image, 2); err == nil {
+		t.Fatal("expected mixed spawn batch to return an error")
+	}
+	if got := counterLabelValues(warmCapacityReconcileSpawnsCounter, scope, "success"); got != 1 {
+		t.Fatalf("expected one successful reconcile spawn, got %v", got)
+	}
+	if got := counterLabelValues(warmCapacityReconcileSpawnsCounter, scope, "error"); got != 1 {
+		t.Fatalf("expected one failed reconcile spawn, got %v", got)
+	}
+}
+
 func TestK8sPoolSpawnMinWorkersForImageNoOpWhenIdleCountAtTarget(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	store := &captureRuntimeWorkerStore{}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -249,13 +250,17 @@ func SetupMultiTenant(
 	janitor.retireLocalWorker = func(workerID int, reason string) bool {
 		return router.sharedPool.retireWorkerWithReason(workerID, reason)
 	}
+	lastWarmCapacityTargets := map[string]int{}
+	var lastWarmCapacityRecentMisses []configstore.WarmCapacityMissAggregate
+	var lastWarmCapacityWorkerStats []configstore.WarmCapacityWorkerStats
+	lastWarmCapacityGlobalCapBlocked := false
 	janitor.reconcileWarmCapacity = func() {
 		snap := store.Snapshot()
 		if snap == nil {
 			return
 		}
 		baseTargets := router.computeBaseWarmCapacityTargets(snap)
-		targets, err := computeEffectiveWarmCapacityTargets(
+		targetSnapshot, err := computeEffectiveWarmCapacityTargetSnapshot(
 			baseTargets,
 			store,
 			cfg.K8s,
@@ -264,6 +269,25 @@ func SetupMultiTenant(
 		if err != nil {
 			slog.Warn("Janitor failed to read dynamic warm-capacity demand; reconciling base warm targets only.", "error", err)
 		}
+		observeWarmCapacityRecentMisses(targetSnapshot.RecentMisses, lastWarmCapacityRecentMisses)
+		lastWarmCapacityRecentMisses = cloneWarmCapacityMissAggregates(targetSnapshot.RecentMisses)
+		observeWarmCapacityTargets(targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets, cfg.K8s.MaxWorkers, lastWarmCapacityTargets)
+		if stats, statsErr := listWarmCapacityWorkerStats(store); statsErr != nil {
+			slog.Warn("Janitor failed to read warm-capacity worker stats.", "error", statsErr)
+		} else {
+			observeWarmCapacityWorkerStats(stats, lastWarmCapacityWorkerStats)
+			lastWarmCapacityWorkerStats = cloneWarmCapacityWorkerStats(stats)
+		}
+		logWarmCapacityTargetChanges(lastWarmCapacityTargets, targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets)
+		lastWarmCapacityTargets = cloneWarmCapacityTargets(targetSnapshot.EffectiveTargets)
+
+		globalCapBlocked := warmCapacityGlobalCapBlocksDemand(targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets, targetSnapshot.RecentMisses, cfg.K8s.MaxWorkers)
+		if globalCapBlocked && !lastWarmCapacityGlobalCapBlocked {
+			slog.Info("Global worker cap prevents dynamic warm capacity.", "max_workers", cfg.K8s.MaxWorkers, "base_target_total", sumIntMap(targetSnapshot.BaseTargets), "effective_target_total", sumIntMap(targetSnapshot.EffectiveTargets))
+		}
+		lastWarmCapacityGlobalCapBlocked = globalCapBlocked
+
+		targets := targetSnapshot.EffectiveTargets
 		router.sharedPool.SetPerImageWarmTargets(targets)
 		reconcileWarmCapacityImageTargets(router.sharedPool, targets)
 	}
@@ -405,13 +429,32 @@ type warmCapacityMissAggregateLister interface {
 	ListWarmCapacityMissesSince(since time.Time, reasons ...configstore.WorkerClaimMissReason) ([]configstore.WarmCapacityMissAggregate, error)
 }
 
+type warmCapacityWorkerStatsLister interface {
+	ListWarmCapacityWorkerStats() ([]configstore.WarmCapacityWorkerStats, error)
+}
+
+type warmCapacityTargetSnapshot struct {
+	BaseTargets      map[string]int
+	EffectiveTargets map[string]int
+	RecentMisses     []configstore.WarmCapacityMissAggregate
+}
+
 func computeEffectiveWarmCapacityTargets(baseTargets map[string]int, lister warmCapacityMissAggregateLister, cfg K8sConfig, now time.Time) (map[string]int, error) {
+	snap, err := computeEffectiveWarmCapacityTargetSnapshot(baseTargets, lister, cfg, now)
+	return snap.EffectiveTargets, err
+}
+
+func computeEffectiveWarmCapacityTargetSnapshot(baseTargets map[string]int, lister warmCapacityMissAggregateLister, cfg K8sConfig, now time.Time) (warmCapacityTargetSnapshot, error) {
+	snap := warmCapacityTargetSnapshot{
+		BaseTargets:      sanitizeWarmCapacityTargets(baseTargets),
+		EffectiveTargets: sanitizeWarmCapacityTargets(baseTargets),
+	}
 	dynamicCfg := dynamicWarmCapacityConfigFromK8s(cfg)
 	if !dynamicCfg.Enabled {
-		return sanitizeWarmCapacityTargets(baseTargets), nil
+		return snap, nil
 	}
 	if lister == nil {
-		return sanitizeWarmCapacityTargets(baseTargets), nil
+		return snap, nil
 	}
 	window := cfg.WarmCapacityMissWindow
 	if window <= 0 {
@@ -422,9 +465,92 @@ func computeEffectiveWarmCapacityTargets(baseTargets map[string]int, lister warm
 	}
 	aggregates, err := lister.ListWarmCapacityMissesSince(now.Add(-window), configstore.WorkerClaimMissReasonNoIdle)
 	if err != nil {
-		return sanitizeWarmCapacityTargets(baseTargets), err
+		return snap, err
 	}
-	return computeDynamicWarmCapacityTargets(baseTargets, aggregates, dynamicCfg), nil
+	snap.RecentMisses = aggregates
+	snap.EffectiveTargets = computeDynamicWarmCapacityTargets(snap.BaseTargets, aggregates, dynamicCfg)
+	return snap, nil
+}
+
+func listWarmCapacityWorkerStats(lister warmCapacityWorkerStatsLister) ([]configstore.WarmCapacityWorkerStats, error) {
+	if lister == nil {
+		return nil, nil
+	}
+	return lister.ListWarmCapacityWorkerStats()
+}
+
+func logWarmCapacityTargetChanges(previous, baseTargets, effectiveTargets map[string]int) {
+	for _, image := range warmCapacityTargetScopes(previous, baseTargets, effectiveTargets) {
+		effective := positiveMapValue(effectiveTargets, image)
+		if positiveMapValue(previous, image) == effective {
+			continue
+		}
+		base := positiveMapValue(baseTargets, image)
+		demand := effective - base
+		if demand < 0 {
+			demand = 0
+		}
+		slog.Info("Warm capacity target changed.",
+			"scope", warmCapacityImageScope(image),
+			"base_target", base,
+			"demand_target", demand,
+			"effective_target", effective,
+		)
+	}
+}
+
+func cloneWarmCapacityTargets(targets map[string]int) map[string]int {
+	out := make(map[string]int, len(targets))
+	for image, target := range targets {
+		if strings.TrimSpace(image) == "" || target <= 0 {
+			continue
+		}
+		out[image] = target
+	}
+	return out
+}
+
+func cloneWarmCapacityMissAggregates(aggregates []configstore.WarmCapacityMissAggregate) []configstore.WarmCapacityMissAggregate {
+	if len(aggregates) == 0 {
+		return nil
+	}
+	out := make([]configstore.WarmCapacityMissAggregate, len(aggregates))
+	copy(out, aggregates)
+	return out
+}
+
+func cloneWarmCapacityWorkerStats(stats []configstore.WarmCapacityWorkerStats) []configstore.WarmCapacityWorkerStats {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make([]configstore.WarmCapacityWorkerStats, len(stats))
+	copy(out, stats)
+	return out
+}
+
+func warmCapacityGlobalCapBlocksDemand(baseTargets, effectiveTargets map[string]int, aggregates []configstore.WarmCapacityMissAggregate, maxWorkers int) bool {
+	if maxWorkers <= 0 || len(aggregates) == 0 {
+		return false
+	}
+	if sumIntMap(baseTargets) < maxWorkers {
+		return false
+	}
+	for _, aggregate := range aggregates {
+		if aggregate.Count <= 0 {
+			continue
+		}
+		if !warmCapacityMissPolicyForReason(aggregate.Reason).recordDynamicDemand {
+			continue
+		}
+		image, ok := strings.CutPrefix(strings.TrimSpace(aggregate.Scope), "image:")
+		if !ok || strings.TrimSpace(image) == "" {
+			continue
+		}
+		if positiveMapValue(effectiveTargets, image) <= positiveMapValue(baseTargets, image) {
+			return true
+		}
+	}
+	return false
 }
 
 func reconcileWarmCapacityImageTargets(pool *K8sWorkerPool, targets map[string]int) {

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -281,7 +281,7 @@ func SetupMultiTenant(
 		logWarmCapacityTargetChanges(lastWarmCapacityTargets, targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets)
 		lastWarmCapacityTargets = cloneWarmCapacityTargets(targetSnapshot.EffectiveTargets)
 
-		globalCapBlocked := warmCapacityGlobalCapBlocksDemand(targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets, targetSnapshot.RecentMisses, cfg.K8s.MaxWorkers)
+		globalCapBlocked := warmCapacityGlobalCapBlocksDemand(targetSnapshot.BaseTargets, targetSnapshot.EffectiveTargets, targetSnapshot.RecentMisses, cfg.K8s)
 		if globalCapBlocked && !lastWarmCapacityGlobalCapBlocked {
 			slog.Info("Global worker cap prevents dynamic warm capacity.", "max_workers", cfg.K8s.MaxWorkers, "base_target_total", sumIntMap(targetSnapshot.BaseTargets), "effective_target_total", sumIntMap(targetSnapshot.EffectiveTargets))
 		}
@@ -528,29 +528,21 @@ func cloneWarmCapacityWorkerStats(stats []configstore.WarmCapacityWorkerStats) [
 	return out
 }
 
-func warmCapacityGlobalCapBlocksDemand(baseTargets, effectiveTargets map[string]int, aggregates []configstore.WarmCapacityMissAggregate, maxWorkers int) bool {
-	if maxWorkers <= 0 || len(aggregates) == 0 {
+func warmCapacityGlobalCapBlocksDemand(baseTargets, effectiveTargets map[string]int, aggregates []configstore.WarmCapacityMissAggregate, cfg K8sConfig) bool {
+	if cfg.MaxWorkers <= 0 || len(aggregates) == 0 {
 		return false
 	}
-	if sumIntMap(baseTargets) < maxWorkers {
+	effectiveTotal := sumIntMap(effectiveTargets)
+	if effectiveTotal < cfg.MaxWorkers {
 		return false
 	}
-	for _, aggregate := range aggregates {
-		if aggregate.Count <= 0 {
-			continue
-		}
-		if !warmCapacityMissPolicyForReason(aggregate.Reason).recordDynamicDemand {
-			continue
-		}
-		image, ok := strings.CutPrefix(strings.TrimSpace(aggregate.Scope), "image:")
-		if !ok || strings.TrimSpace(image) == "" {
-			continue
-		}
-		if positiveMapValue(effectiveTargets, image) <= positiveMapValue(baseTargets, image) {
-			return true
-		}
+	dynamicCfg := dynamicWarmCapacityConfigFromK8s(cfg)
+	if !dynamicCfg.Enabled {
+		return false
 	}
-	return false
+	dynamicCfg.MaxWorkers = 0
+	uncappedTargets := computeDynamicWarmCapacityTargets(baseTargets, aggregates, dynamicCfg)
+	return sumIntMap(uncappedTargets) > effectiveTotal
 }
 
 func reconcileWarmCapacityImageTargets(pool *K8sWorkerPool, targets map[string]int) {

--- a/controlplane/multitenant_warm_capacity_test.go
+++ b/controlplane/multitenant_warm_capacity_test.go
@@ -123,6 +123,41 @@ func TestComputeEffectiveWarmCapacityTargetsFallsBackToBaseOnReadError(t *testin
 	}
 }
 
+func TestWarmCapacityGlobalCapBlocksDemandDetectsPartialHeadroom(t *testing.T) {
+	base := map[string]int{"posthog/duckgres:default": 2}
+	aggregates := []configstore.WarmCapacityMissAggregate{
+		warmCapacityMissAggregate("image:posthog/duckgres:default", configstore.WorkerClaimMissReasonNoIdle, 32),
+	}
+	cfg := K8sConfig{
+		DynamicWarmCapacityEnabled:  true,
+		WarmCapacityMissesPerWorker: 8,
+		MaxWorkers:                  3,
+	}
+	effective := computeDynamicWarmCapacityTargets(base, aggregates, dynamicWarmCapacityConfigFromK8s(cfg))
+
+	if !warmCapacityGlobalCapBlocksDemand(base, effective, aggregates, cfg) {
+		t.Fatal("expected global cap block when one free slot cannot satisfy all dynamic demand")
+	}
+}
+
+func TestWarmCapacityGlobalCapBlocksDemandIgnoresDynamicCeiling(t *testing.T) {
+	base := map[string]int{"posthog/duckgres:default": 2}
+	aggregates := []configstore.WarmCapacityMissAggregate{
+		warmCapacityMissAggregate("image:posthog/duckgres:default", configstore.WorkerClaimMissReasonNoIdle, 32),
+	}
+	cfg := K8sConfig{
+		DynamicWarmCapacityEnabled:      true,
+		WarmCapacityMissesPerWorker:     8,
+		WarmCapacityDynamicTotalCeiling: 1,
+		MaxWorkers:                      10,
+	}
+	effective := computeDynamicWarmCapacityTargets(base, aggregates, dynamicWarmCapacityConfigFromK8s(cfg))
+
+	if warmCapacityGlobalCapBlocksDemand(base, effective, aggregates, cfg) {
+		t.Fatal("did not expect global cap block when only the dynamic total ceiling limits demand")
+	}
+}
+
 func TestReconcileWarmCapacityImageTargetsSpawnsPerImageTargets(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 0)
 	store := &captureRuntimeWorkerStore{}

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightclient"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var ErrTooManyConnections = errors.New("too many connections")
@@ -176,13 +177,20 @@ func (sm *SessionManager) CreateSession(ctx context.Context, username, searchPat
 	if err != nil {
 		var capacityErr *WarmCapacityExhaustedError
 		if errors.As(err, &capacityErr) {
+			missReason := capacityErr.missReason()
 			observeControlPlaneWorkerAcquireFailure("warm_capacity_exhausted")
+			observeControlPlaneWorkerAcquireFailure("warm_capacity_" + string(missReason))
+			acquireSpan.SetAttributes(
+				attribute.String("warm_capacity.reason", string(missReason)),
+				attribute.Int("warm_capacity.retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter)),
+			)
 			slog.Warn("Worker acquisition failed.",
 				"pid", pid,
 				"user", username,
 				"duration", time.Since(acquireStart),
-				"reason", "warm_capacity_exhausted",
+				"reason", missReason,
 				"retry_after", capacityErr.RetryAfter,
+				"retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter),
 				"error", err,
 			)
 		}

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -173,7 +173,6 @@ func (sm *SessionManager) CreateSession(ctx context.Context, username, searchPat
 	ctx, acquireSpan := server.Tracer().Start(ctx, "duckgres.worker_acquire")
 	slog.Debug("Acquiring worker for session.", "pid", pid, "user", username)
 	worker, err := sm.pool.AcquireWorker(ctx)
-	acquireSpan.End()
 	if err != nil {
 		var capacityErr *WarmCapacityExhaustedError
 		if errors.As(err, &capacityErr) {
@@ -194,8 +193,10 @@ func (sm *SessionManager) CreateSession(ctx context.Context, username, searchPat
 				"error", err,
 			)
 		}
+		acquireSpan.End()
 		return 0, nil, fmt.Errorf("acquire worker: %w", err)
 	}
+	acquireSpan.End()
 	slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
 
 	pid, exec, err := sm.createSessionOnWorker(ctx, username, searchPath, pid, memoryLimit, threads, worker, "postgres", true)

--- a/controlplane/warm_capacity_metrics.go
+++ b/controlplane/warm_capacity_metrics.go
@@ -1,0 +1,186 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var warmCapacityMissesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_warm_capacity_misses_total",
+	Help: "Total foreground warm-capacity misses, partitioned by image scope and reason.",
+}, []string{"scope", "reason"})
+
+var warmCapacityRecentMissesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_recent_misses",
+	Help: "Recent warm-capacity misses read by dynamic target reconciliation, partitioned by scope and reason.",
+}, []string{"scope", "reason"})
+
+var warmCapacityBaseTargetGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_base_target",
+	Help: "Configured/base warm-capacity target by scope.",
+}, []string{"scope"})
+
+var warmCapacityDemandTargetGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_demand_target",
+	Help: "Dynamic warm-capacity target added above the base target by scope.",
+}, []string{"scope"})
+
+var warmCapacityEffectiveTargetGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_effective_target",
+	Help: "Effective warm-capacity target after applying dynamic demand and caps by scope.",
+}, []string{"scope"})
+
+var warmCapacityReadyWorkersGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_ready_workers",
+	Help: "Cluster-wide ready neutral warm workers by scope.",
+}, []string{"scope"})
+
+var warmCapacitySpawningWorkersGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_spawning_workers",
+	Help: "Cluster-wide spawning neutral warm workers by scope.",
+}, []string{"scope"})
+
+var warmCapacityHeadroomGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_warm_capacity_headroom",
+	Help: "Remaining global warm-capacity target headroom by scope; -1 means unbounded.",
+}, []string{"scope"})
+
+var warmCapacityReconcileSpawnsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_warm_capacity_reconcile_spawns_total",
+	Help: "Warm-capacity worker spawn slots accepted by reconciliation, partitioned by scope and result.",
+}, []string{"scope", "result"})
+
+func observeWarmCapacityMiss(scope string, reason configstore.WorkerClaimMissReason) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return
+	}
+	policy := warmCapacityMissPolicyForReason(reason)
+	warmCapacityMissesCounter.WithLabelValues(scope, string(policy.reason)).Inc()
+}
+
+func observeWarmCapacityRecentMisses(aggregates []configstore.WarmCapacityMissAggregate, previous ...[]configstore.WarmCapacityMissAggregate) {
+	for _, prev := range previous {
+		for _, aggregate := range prev {
+			scope := strings.TrimSpace(aggregate.Scope)
+			if scope == "" {
+				continue
+			}
+			policy := warmCapacityMissPolicyForReason(aggregate.Reason)
+			warmCapacityRecentMissesGauge.WithLabelValues(scope, string(policy.reason)).Set(0)
+		}
+	}
+	for _, aggregate := range aggregates {
+		scope := strings.TrimSpace(aggregate.Scope)
+		if scope == "" || aggregate.Count < 0 {
+			continue
+		}
+		policy := warmCapacityMissPolicyForReason(aggregate.Reason)
+		warmCapacityRecentMissesGauge.WithLabelValues(scope, string(policy.reason)).Set(float64(aggregate.Count))
+	}
+}
+
+func observeWarmCapacityTargets(baseTargets, effectiveTargets map[string]int, maxWorkers int, previousTargets ...map[string]int) {
+	scopeMaps := []map[string]int{baseTargets, effectiveTargets}
+	scopeMaps = append(scopeMaps, previousTargets...)
+	scopes := warmCapacityTargetScopes(scopeMaps...)
+	for _, image := range scopes {
+		scope := warmCapacityImageScope(image)
+		base := positiveMapValue(baseTargets, image)
+		effective := positiveMapValue(effectiveTargets, image)
+		demand := effective - base
+		if demand < 0 {
+			demand = 0
+		}
+		warmCapacityBaseTargetGauge.WithLabelValues(scope).Set(float64(base))
+		warmCapacityDemandTargetGauge.WithLabelValues(scope).Set(float64(demand))
+		warmCapacityEffectiveTargetGauge.WithLabelValues(scope).Set(float64(effective))
+	}
+
+	headroom := -1.0
+	if maxWorkers > 0 {
+		headroom = float64(maxWorkers - sumIntMap(effectiveTargets))
+		if headroom < 0 {
+			headroom = 0
+		}
+	}
+	warmCapacityHeadroomGauge.WithLabelValues("global").Set(headroom)
+}
+
+func observeWarmCapacityWorkerStats(stats []configstore.WarmCapacityWorkerStats, previous ...[]configstore.WarmCapacityWorkerStats) {
+	for _, prev := range previous {
+		for _, stat := range prev {
+			scope := strings.TrimSpace(stat.Scope)
+			if scope == "" {
+				continue
+			}
+			warmCapacityReadyWorkersGauge.WithLabelValues(scope).Set(0)
+			warmCapacitySpawningWorkersGauge.WithLabelValues(scope).Set(0)
+		}
+	}
+	for _, stat := range stats {
+		scope := strings.TrimSpace(stat.Scope)
+		if scope == "" {
+			continue
+		}
+		warmCapacityReadyWorkersGauge.WithLabelValues(scope).Set(float64(nonNegativeInt64(stat.ReadyWorkers)))
+		warmCapacitySpawningWorkersGauge.WithLabelValues(scope).Set(float64(nonNegativeInt64(stat.SpawningWorkers)))
+	}
+}
+
+func observeWarmCapacityReconcileSpawns(scope, result string, count int) {
+	scope = strings.TrimSpace(scope)
+	result = strings.TrimSpace(result)
+	if scope == "" || result == "" || count <= 0 {
+		return
+	}
+	warmCapacityReconcileSpawnsCounter.WithLabelValues(scope, result).Add(float64(count))
+}
+
+func warmCapacityImageScope(image string) string {
+	image = strings.TrimSpace(image)
+	if image == "" {
+		return ""
+	}
+	return "image:" + image
+}
+
+func warmCapacityTargetScopes(maps ...map[string]int) []string {
+	seen := make(map[string]struct{})
+	for _, values := range maps {
+		for image, value := range values {
+			image = strings.TrimSpace(image)
+			if image == "" || value <= 0 {
+				continue
+			}
+			seen[image] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for image := range seen {
+		out = append(out, image)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func positiveMapValue(values map[string]int, key string) int {
+	value := values[key]
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func nonNegativeInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/controlplane/warm_pool_metrics_test.go
+++ b/controlplane/warm_pool_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
@@ -267,6 +268,53 @@ func TestReapStuckActivatingWorkers_RecentlyReservedNotReaped(t *testing.T) {
 	}
 }
 
+func TestObserveWarmCapacityMetrics(t *testing.T) {
+	image := "duckgres:metrics-test"
+	scope := "image:" + image
+	warmCapacityMissesCounter.DeleteLabelValues(scope, string(configstore.WorkerClaimMissReasonGlobalCap))
+	warmCapacityReconcileSpawnsCounter.DeleteLabelValues(scope, "success")
+
+	observeWarmCapacityMiss(scope, configstore.WorkerClaimMissReasonGlobalCap)
+	if got := counterLabelValues(warmCapacityMissesCounter, scope, string(configstore.WorkerClaimMissReasonGlobalCap)); got != 1 {
+		t.Fatalf("expected one global-cap warm capacity miss, got %v", got)
+	}
+
+	observeWarmCapacityRecentMisses([]configstore.WarmCapacityMissAggregate{
+		{Scope: scope, Reason: configstore.WorkerClaimMissReasonNoIdle, Count: 4},
+	})
+	assertGaugeVecValue(t, warmCapacityRecentMissesGauge, 4, scope, string(configstore.WorkerClaimMissReasonNoIdle))
+	observeWarmCapacityRecentMisses(nil, []configstore.WarmCapacityMissAggregate{
+		{Scope: scope, Reason: configstore.WorkerClaimMissReasonNoIdle, Count: 4},
+	})
+	assertGaugeVecValue(t, warmCapacityRecentMissesGauge, 0, scope, string(configstore.WorkerClaimMissReasonNoIdle))
+
+	observeWarmCapacityTargets(
+		map[string]int{image: 2},
+		map[string]int{image: 5},
+		10,
+	)
+	assertGaugeVecValue(t, warmCapacityBaseTargetGauge, 2, scope)
+	assertGaugeVecValue(t, warmCapacityDemandTargetGauge, 3, scope)
+	assertGaugeVecValue(t, warmCapacityEffectiveTargetGauge, 5, scope)
+	assertGaugeVecValue(t, warmCapacityHeadroomGauge, 5, "global")
+
+	observeWarmCapacityWorkerStats([]configstore.WarmCapacityWorkerStats{
+		{Scope: scope, ReadyWorkers: 2, SpawningWorkers: 1},
+	})
+	assertGaugeVecValue(t, warmCapacityReadyWorkersGauge, 2, scope)
+	assertGaugeVecValue(t, warmCapacitySpawningWorkersGauge, 1, scope)
+	observeWarmCapacityWorkerStats(nil, []configstore.WarmCapacityWorkerStats{
+		{Scope: scope, ReadyWorkers: 2, SpawningWorkers: 1},
+	})
+	assertGaugeVecValue(t, warmCapacityReadyWorkersGauge, 0, scope)
+	assertGaugeVecValue(t, warmCapacitySpawningWorkersGauge, 0, scope)
+
+	observeWarmCapacityReconcileSpawns(scope, "success", 3)
+	if got := counterLabelValues(warmCapacityReconcileSpawnsCounter, scope, "success"); got != 3 {
+		t.Fatalf("expected three warm capacity reconcile spawns, got %v", got)
+	}
+}
+
 // --- Helpers ---
 
 func makeTestWorker(lifecycle WorkerLifecycleState, assignment *WorkerAssignment) *ManagedWorker {
@@ -290,8 +338,12 @@ func assertGaugeValue(t *testing.T, gauge prometheus.Gauge, expected float64) {
 }
 
 func counterLabelValue(cv *prometheus.CounterVec, label string) float64 {
+	return counterLabelValues(cv, label)
+}
+
+func counterLabelValues(cv *prometheus.CounterVec, labels ...string) float64 {
 	m := &dto.Metric{}
-	counter, err := cv.GetMetricWithLabelValues(label)
+	counter, err := cv.GetMetricWithLabelValues(labels...)
 	if err != nil {
 		return 0
 	}
@@ -299,4 +351,19 @@ func counterLabelValue(cv *prometheus.CounterVec, label string) float64 {
 		return 0
 	}
 	return m.GetCounter().GetValue()
+}
+
+func assertGaugeVecValue(t *testing.T, gv *prometheus.GaugeVec, expected float64, labels ...string) {
+	t.Helper()
+	gauge, err := gv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("failed to read gauge labels %v: %v", labels, err)
+	}
+	m := &dto.Metric{}
+	if err := gauge.Write(m); err != nil {
+		t.Fatalf("failed to write gauge labels %v: %v", labels, err)
+	}
+	if got := m.GetGauge().GetValue(); got != expected {
+		t.Fatalf("expected gauge labels %v value %v, got %v", labels, expected, got)
+	}
 }

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -241,6 +241,75 @@ func TestPruneWarmCapacityMissBucketsPostgres(t *testing.T) {
 	assertWarmCapacityMissBucketCount(t, store, "image:duckgres:default", configstore.WorkerClaimMissReasonNoIdle, newBucketStart, 1)
 }
 
+func TestListWarmCapacityWorkerStatsPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.March, 26, 14, 30, 0, 0, time.UTC)
+	records := []configstore.WorkerRecord{
+		{
+			WorkerID:          1001,
+			PodName:           "duckgres-worker-test-cp-1001",
+			Image:             "duckgres:default",
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: "cp-a",
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          1002,
+			PodName:           "duckgres-worker-test-cp-1002",
+			Image:             "duckgres:default",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: "cp-a",
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          1003,
+			PodName:           "duckgres-worker-test-cp-1003",
+			Image:             "duckgres:pinned",
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: "cp-b",
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          1004,
+			PodName:           "duckgres-worker-test-cp-1004",
+			Image:             "duckgres:default",
+			State:             configstore.WorkerStateHot,
+			OrgID:             "analytics",
+			OwnerCPInstanceID: "cp-a",
+			LastHeartbeatAt:   now,
+		},
+		{
+			WorkerID:          1005,
+			PodName:           "duckgres-worker-test-cp-1005",
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: "cp-a",
+			LastHeartbeatAt:   now,
+		},
+	}
+	for _, record := range records {
+		if err := store.UpsertWorkerRecord(&record); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", record.WorkerID, err)
+		}
+	}
+
+	stats, err := store.ListWarmCapacityWorkerStats()
+	if err != nil {
+		t.Fatalf("ListWarmCapacityWorkerStats: %v", err)
+	}
+
+	got := map[string][2]int64{}
+	for _, stat := range stats {
+		got[stat.Scope] = [2]int64{stat.ReadyWorkers, stat.SpawningWorkers}
+	}
+	want := map[string][2]int64{
+		"image:duckgres:default": {1, 1},
+		"image:duckgres:pinned":  {1, 0},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected warm worker stats %v, got %v", want, got)
+	}
+}
+
 func warmCapacityMissAggregateCounts(aggregates []configstore.WarmCapacityMissAggregate) map[string]int64 {
 	out := make(map[string]int64, len(aggregates))
 	for _, aggregate := range aggregates {


### PR DESCRIPTION
## Summary

- add Kubernetes warm-capacity metrics for foreground misses, recent demand, base/dynamic/effective targets, ready/spawning warm workers, global headroom, and reconciliation spawn outcomes
- wire dynamic warm-capacity target and worker-state metrics into the janitor path without adding foreground configstore reads
- add reason-aware capacity reject metric labels plus OpenTelemetry/log attributes for miss reason and retry hint
- add configstore aggregation for cluster-wide ready/spawning neutral warm workers by image scope
- update the dynamic warm-capacity plan with the PR E observability scope

## Tests

- `go test ./controlplane`
- `go test ./controlplane/configstore`
- `go test -tags kubernetes ./controlplane`
- `go test -tags kubernetes ./controlplane ./cmd/duckgres-controlplane`
- `go test -run 'TestListWarmCapacityWorkerStatsPostgres|TestRecordWarmCapacityMissAggregatesByBucketScopeAndReasonPostgres|TestListWarmCapacityMissesSinceAggregatesByScopeAndReasonPostgres' ./tests/configstore`
- `golangci-lint run`
