### PR TITLE
[codex] Fence worker health cleanup by lease

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -953,9 +953,13 @@ func (cs *ConfigStore) ExpireDrainingControlPlaneInstances(before time.Time) (in
 
 // UpsertWorkerRecord inserts or updates a runtime worker row.
 func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
+	protectedStates := []WorkerState{WorkerStateDraining, WorkerStateRetired, WorkerStateLost}
 	if err := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "worker_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at"}),
+		Where: clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: `"worker_records"."state" NOT IN ?`, Vars: []any{protectedStates}},
+		}},
 	}).Create(record).Error; err != nil {
 		return fmt.Errorf("upsert worker record: %w", err)
 	}
@@ -1325,6 +1329,32 @@ func (cs *ConfigStore) RetireIdleOrHotIdleWorker(workerID int, reason string) (b
 	return result.RowsAffected > 0, nil
 }
 
+// MarkWorkerLostIfCurrentLease atomically marks a worker lost only when the
+// caller still owns the same lease observed by its local health checker. A
+// false return means another CP or lifecycle path has already moved the row.
+func (cs *ConfigStore) MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error) {
+	lostEligibleStates := []WorkerState{
+		WorkerStateSpawning,
+		WorkerStateIdle,
+		WorkerStateReserved,
+		WorkerStateActivating,
+		WorkerStateHot,
+		WorkerStateHotIdle,
+	}
+	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
+		Where("worker_id = ? AND owner_cp_instance_id = ? AND owner_epoch = ? AND state IN ?",
+			workerID, ownerCPInstanceID, expectedOwnerEpoch, lostEligibleStates).
+		Updates(map[string]any{
+			"state":         WorkerStateLost,
+			"retire_reason": reason,
+			"updated_at":    time.Now(),
+		})
+	if result.Error != nil {
+		return false, fmt.Errorf("mark worker %d lost: %w", workerID, result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
 // MarkWorkerDraining atomically transitions a worker into the draining state
 // if and only if it is still owned by the caller and not already terminal. It
 // returns true when the transition happened.
@@ -1396,8 +1426,11 @@ func (cs *ConfigStore) TakeOverWorker(workerID int, ownerCPInstanceID, orgID str
 		if current.OwnerEpoch != expectedOwnerEpoch {
 			return ErrWorkerOwnerEpochMismatch
 		}
+		if current.State != WorkerStateHot {
+			return nil
+		}
 		now := time.Now()
-		if err := tx.Table(cs.runtimeTable(current.TableName())).
+		result := tx.Table(cs.runtimeTable(current.TableName())).
 			Where("worker_id = ?", current.WorkerID).
 			Updates(map[string]any{
 				"state":                WorkerStateReserved,
@@ -1405,8 +1438,12 @@ func (cs *ConfigStore) TakeOverWorker(workerID int, ownerCPInstanceID, orgID str
 				"owner_cp_instance_id": ownerCPInstanceID,
 				"owner_epoch":          gorm.Expr("owner_epoch + 1"),
 				"updated_at":           now,
-			}).Error; err != nil {
-			return err
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
 		}
 		if err := tx.Table(cs.runtimeTable(current.TableName())).
 			First(&current, "worker_id = ?", current.WorkerID).Error; err != nil {

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2032,7 +2032,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 	defer ticker.Stop()
 
 	var mu sync.Mutex
-	failures := make(map[int]int)
+	failures := make(map[workerLeaseSnapshot]int)
 
 	for {
 		select {
@@ -2044,16 +2044,23 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 				p.mu.RUnlock()
 				return
 			}
-			workers := make([]*ManagedWorker, 0, len(p.workers))
+			type healthCheckTarget struct {
+				worker *ManagedWorker
+				lease  workerLeaseSnapshot
+			}
+			targets := make([]healthCheckTarget, 0, len(p.workers))
 			for _, w := range p.workers {
-				workers = append(workers, w)
+				targets = append(targets, healthCheckTarget{
+					worker: w,
+					lease:  p.workerLeaseSnapshot(w),
+				})
 			}
 			p.mu.RUnlock()
 
 			var wg sync.WaitGroup
-			for _, w := range workers {
+			for _, target := range targets {
 				wg.Add(1)
-				go func(w *ManagedWorker) {
+				go func(w *ManagedWorker, lease workerLeaseSnapshot) {
 					defer wg.Done()
 
 					select {
@@ -2062,25 +2069,49 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 					case <-w.done:
 						// Pod terminated (detected by informer)
 						mu.Lock()
-						delete(failures, w.ID)
+						delete(failures, lease)
 						mu.Unlock()
 
+						lostDisposition, err := p.markWorkerLostForHealthLease(lease)
+						if err != nil {
+							slog.Error("K8s worker terminated but lease validation failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							return
+						}
+						if lostDisposition == workerLostLeaseRetry {
+							slog.Warn("K8s worker terminated while runtime lease is newer for this CP; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
+							return
+						}
+						if lostDisposition == workerLostLeaseStale {
+							p.mu.Lock()
+							removedWorker, workerCount := p.dropLocalWorkerIfSameLeaseLocked(lease)
+							p.mu.Unlock()
+							if removedWorker == nil {
+								return
+							}
+							observeControlPlaneWorkers(workerCount)
+							slog.Warn("K8s worker terminated under stale lease; dropping local worker without pod delete.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
+							if removedWorker.client != nil {
+								_ = removedWorker.client.Close()
+							}
+							return
+						}
+
 						p.mu.Lock()
-						removedWorker, workerCount, replacementID, shouldReplenish := p.removeWorkerLocked(w.ID)
+						removedWorker, workerCount, replacementID, shouldReplenish := p.removeWorkerAfterLostLeaseLocked(lease)
 						p.mu.Unlock()
 						if removedWorker == nil {
 							return
 						}
 						observeControlPlaneWorkers(workerCount)
-						slog.Warn("K8s worker crashed.", "id", w.ID)
+						slog.Warn("K8s worker crashed.", "id", lease.workerID)
 						if onCrash != nil {
-							onCrash(w.ID)
+							onCrash(lease.workerID)
 						}
-						if w.client != nil {
-							_ = w.client.Close()
+						if removedWorker.client != nil {
+							_ = removedWorker.client.Close()
 						}
 						// Delete the failed pod from K8s
-						podName := p.podNameForWorker(w.ID)
+						podName := p.workerPodName(removedWorker)
 						delCtx, delCancel := context.WithTimeout(context.Background(), 10*time.Second)
 						_ = p.clientset.CoreV1().Pods(p.namespace).Delete(delCtx, podName, metav1.DeleteOptions{
 							GracePeriodSeconds: int64Ptr(0),
@@ -2096,42 +2127,68 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 						func() {
 							defer recoverWorkerPanic(&healthErr)
 							hctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-							hcResult, healthErr = doHealthCheckWithMetadata(hctx, w.client, p.healthCheckPayloadForWorker(w))
+							hcResult, healthErr = doHealthCheckWithMetadata(hctx, w.client, p.healthCheckPayloadForLease(lease))
 							cancel()
 						}()
 
 						if healthErr != nil {
 							mu.Lock()
-							failures[w.ID]++
-							count := failures[w.ID]
+							failures[lease]++
+							count := failures[lease]
 							mu.Unlock()
 
-							slog.Warn("K8s worker health check failed.", "id", w.ID, "error", healthErr, "consecutive_failures", count)
+							slog.Warn("K8s worker health check failed.", "id", lease.workerID, "error", healthErr, "consecutive_failures", count)
 
 							if count >= maxConsecutiveHealthFailures {
+								lostDisposition, err := p.markWorkerLostForHealthLease(lease)
+								if err != nil {
+									slog.Error("K8s worker unresponsive but lease validation failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count, "error", err)
+									return
+								}
+
+								if lostDisposition == workerLostLeaseRetry {
+									slog.Warn("K8s worker unresponsive while runtime lease is newer for this CP; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
+									return
+								}
+
 								mu.Lock()
-								delete(failures, w.ID)
+								delete(failures, lease)
 								mu.Unlock()
 
+								if lostDisposition == workerLostLeaseStale {
+									p.mu.Lock()
+									removedWorker, workerCount := p.dropLocalWorkerIfSameLeaseLocked(lease)
+									p.mu.Unlock()
+									if removedWorker == nil {
+										return
+									}
+									observeControlPlaneWorkers(workerCount)
+									slog.Warn("K8s worker unresponsive under stale lease; dropping local worker without crash notification or pod delete.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
+									if removedWorker.client != nil {
+										_ = removedWorker.client.Close()
+									}
+									return
+								}
+
 								p.mu.Lock()
-								removedWorker, workerCount, replacementID, shouldReplenish := p.removeWorkerLocked(w.ID)
+								removedWorker, workerCount, replacementID, shouldReplenish := p.removeWorkerAfterLostLeaseLocked(lease)
 								p.mu.Unlock()
 								if removedWorker == nil {
 									return
 								}
 								observeControlPlaneWorkers(workerCount)
 
-								slog.Error("K8s worker unresponsive, deleting pod.", "id", w.ID, "consecutive_failures", count)
+								slog.Error("K8s worker unresponsive, deleting pod.", "id", lease.workerID, "consecutive_failures", count)
 								if onCrash != nil {
-									onCrash(w.ID)
+									onCrash(lease.workerID)
 								}
 								// Delete the pod to force cleanup
-								podName := p.podNameForWorker(w.ID)
+								podName := p.workerPodName(removedWorker)
 								_ = p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 									GracePeriodSeconds: int64Ptr(10),
 								})
-								if w.client != nil {
-									_ = w.client.Close()
+								if removedWorker.client != nil {
+									_ = removedWorker.client.Close()
 								}
 								if shouldReplenish {
 									p.spawnWarmWorkerBackground(replacementID, p.workerImage)
@@ -2139,18 +2196,18 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 							}
 						} else {
 							mu.Lock()
-							delete(failures, w.ID)
+							delete(failures, lease)
 							mu.Unlock()
 
 							// Forward progress data to the control plane.
 							if onProgress != nil && hcResult != nil {
 								if sp := hcResult.toSessionProgress(); len(sp) > 0 {
-									onProgress(w.ID, sp)
+									onProgress(lease.workerID, sp)
 								}
 							}
 						}
 					}
-				}(w)
+				}(target.worker, target.lease)
 			}
 			wg.Wait()
 		}
@@ -2546,7 +2603,28 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 	for id, w := range p.workers {
 		select {
 		case <-w.done:
-			removedWorker, _, replacementID, shouldReplenish := p.removeWorkerLocked(id)
+			var removedWorker *ManagedWorker
+			var replacementID int
+			var shouldReplenish bool
+			deletePod := true
+			if p.runtimeStore != nil {
+				lease := p.workerLeaseSnapshot(w)
+				lostDisposition, err := p.markWorkerLostForHealthLease(lease)
+				if err != nil {
+					slog.Warn("Clean dead worker: lease validation failed; leaving cleanup to retry.",
+						"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+					continue
+				}
+				switch lostDisposition {
+				case workerLostLeaseStale:
+					deletePod = false
+					removedWorker, _ = p.dropLocalWorkerIfSameLeaseLocked(lease)
+				case workerLostLeaseCurrent, workerLostLeaseAlreadyLost, workerLostLeaseRetry:
+					continue
+				}
+			} else {
+				removedWorker, _, replacementID, shouldReplenish = p.removeWorkerLocked(id)
+			}
 			if removedWorker == nil {
 				continue
 			}
@@ -2554,8 +2632,11 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 			if shouldReplenish {
 				spawnIDs = append(spawnIDs, replacementID)
 			}
-			if w.client != nil {
-				go func(c *flightsql.Client) { _ = c.Close() }(w.client)
+			if removedWorker.client != nil {
+				go func(c *flightsql.Client) { _ = c.Close() }(removedWorker.client)
+			}
+			if !deletePod {
+				continue
 			}
 			// Delete the failed pod from K8s to avoid accumulating terminated pods
 			go func(worker *ManagedWorker) {
@@ -2565,7 +2646,7 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 				_ = p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 					GracePeriodSeconds: int64Ptr(0),
 				})
-			}(w)
+			}(removedWorker)
 		default:
 		}
 	}
@@ -2634,6 +2715,104 @@ func (p *K8sWorkerPool) removeWorkerLocked(id int) (*ManagedWorker, int, int, bo
 	replacementID := p.allocateBackgroundSpawnIDLocked()
 	p.spawning++
 	return w, workerCount, replacementID, true
+}
+
+type workerLeaseSnapshot struct {
+	workerID          int
+	ownerCPInstanceID string
+	ownerEpoch        int64
+}
+
+func (p *K8sWorkerPool) workerLeaseSnapshot(w *ManagedWorker) workerLeaseSnapshot {
+	ownerCPInstanceID := w.OwnerCPInstanceID()
+	if ownerCPInstanceID == "" {
+		ownerCPInstanceID = p.cpInstanceID
+	}
+	return workerLeaseSnapshot{
+		workerID:          w.ID,
+		ownerCPInstanceID: ownerCPInstanceID,
+		ownerEpoch:        w.OwnerEpoch(),
+	}
+}
+
+func (p *K8sWorkerPool) workerMatchesLease(w *ManagedWorker, lease workerLeaseSnapshot) bool {
+	return w != nil && p.workerLeaseSnapshot(w) == lease
+}
+
+type workerLostLeaseDisposition int
+
+const (
+	workerLostLeaseCurrent workerLostLeaseDisposition = iota
+	workerLostLeaseStale
+	workerLostLeaseRetry
+	workerLostLeaseAlreadyLost
+)
+
+func (p *K8sWorkerPool) markWorkerLostForHealthLease(lease workerLeaseSnapshot) (workerLostLeaseDisposition, error) {
+	if p.runtimeStore == nil {
+		return workerLostLeaseCurrent, nil
+	}
+	if lease.ownerCPInstanceID != p.cpInstanceID {
+		return workerLostLeaseStale, nil
+	}
+	currentLease, err := p.markWorkerLostIfCurrentLease(lease)
+	if err != nil {
+		return workerLostLeaseRetry, err
+	}
+	if currentLease {
+		return workerLostLeaseCurrent, nil
+	}
+
+	record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
+	if err != nil {
+		return workerLostLeaseRetry, err
+	}
+	if record == nil || record.OwnerCPInstanceID != p.cpInstanceID {
+		return workerLostLeaseStale, nil
+	}
+	if record.OwnerEpoch != lease.ownerEpoch {
+		return workerLostLeaseRetry, nil
+	}
+	if record.State == configstore.WorkerStateLost && record.RetireReason == RetireReasonCrash {
+		return workerLostLeaseAlreadyLost, nil
+	}
+	return workerLostLeaseStale, nil
+}
+
+func (p *K8sWorkerPool) markWorkerLostIfCurrentLease(lease workerLeaseSnapshot) (bool, error) {
+	if p.runtimeStore == nil {
+		return true, nil
+	}
+	if lease.ownerCPInstanceID != p.cpInstanceID {
+		return false, nil
+	}
+	return p.runtimeStore.MarkWorkerLostIfCurrentLease(lease.workerID, p.cpInstanceID, lease.ownerEpoch, RetireReasonCrash)
+}
+
+func (p *K8sWorkerPool) removeWorkerAfterLostLeaseLocked(lease workerLeaseSnapshot) (*ManagedWorker, int, int, bool) {
+	current, ok := p.workers[lease.workerID]
+	if !ok || !p.workerMatchesLease(current, lease) {
+		return nil, len(p.workers), 0, false
+	}
+	p.markWorkerRetiredInMemoryLocked(current, RetireReasonCrash)
+	delete(p.workers, current.ID)
+	workerCount := len(p.workers)
+	if !p.shouldReplenishWarmCapacityLocked() {
+		return current, workerCount, 0, false
+	}
+	replacementID := p.allocateBackgroundSpawnIDLocked()
+	p.spawning++
+	return current, workerCount, replacementID, true
+}
+
+func (p *K8sWorkerPool) dropLocalWorkerIfSameLeaseLocked(lease workerLeaseSnapshot) (*ManagedWorker, int) {
+	current, ok := p.workers[lease.workerID]
+	if !ok || !p.workerMatchesLease(current, lease) {
+		return nil, len(p.workers)
+	}
+	delete(p.workers, current.ID)
+	observeWarmPoolLifecycleGauges(p.workers)
+	return current, len(p.workers)
 }
 
 func (p *K8sWorkerPool) isGenericSessionSchedulableWorkerLocked(w *ManagedWorker) bool {
@@ -2827,11 +3006,15 @@ func (p *K8sWorkerPool) workerRecordFor(id int, worker *ManagedWorker, ownerEpoc
 }
 
 func (p *K8sWorkerPool) healthCheckPayloadForWorker(worker *ManagedWorker) server.WorkerHealthCheckPayload {
+	return p.healthCheckPayloadForLease(p.workerLeaseSnapshot(worker))
+}
+
+func (p *K8sWorkerPool) healthCheckPayloadForLease(lease workerLeaseSnapshot) server.WorkerHealthCheckPayload {
 	payload := server.WorkerHealthCheckPayload{
 		WorkerControlMetadata: server.WorkerControlMetadata{
-			WorkerID:     worker.ID,
-			OwnerEpoch:   worker.OwnerEpoch(),
-			CPInstanceID: worker.OwnerCPInstanceID(),
+			WorkerID:     lease.workerID,
+			OwnerEpoch:   lease.ownerEpoch,
+			CPInstanceID: lease.ownerCPInstanceID,
 		},
 	}
 	return payload

--- a/controlplane/k8s_pool_race_test.go
+++ b/controlplane/k8s_pool_race_test.go
@@ -1,0 +1,48 @@
+//go:build kubernetes && race
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestK8sPoolHealthCheckLoopSnapshotsLeaseUnderPoolLock(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	pool.runtimeStore = &captureRuntimeWorkerStore{
+		markLostErr: errors.New("retry lease validation"),
+	}
+
+	worker := &ManagedWorker{ID: 88, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	pool.workers[worker.ID] = worker
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.HealthCheckLoop(ctx, time.Nanosecond, nil, nil)
+	}()
+
+	deadline := time.After(50 * time.Millisecond)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			return
+		default:
+		}
+
+		pool.mu.Lock()
+		worker.SetOwnerEpoch(worker.OwnerEpoch() + 1)
+		if worker.OwnerCPInstanceID() == pool.cpInstanceID {
+			worker.SetOwnerCPInstanceID("other-cp:boot-b")
+		} else {
+			worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+		}
+		pool.mu.Unlock()
+	}
+}

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -90,6 +90,13 @@ type captureRuntimeWorkerStore struct {
 	retireOrphanCalledIDs            []int
 	retireOrphanCalledReasons        []string
 	retireOrphanErr                  error
+	markLostCalls                    int
+	markLostCalledIDs                []int
+	markLostCalledCPs                []string
+	markLostCalledEpochs             []int64
+	markLostCalledReasons            []string
+	markLostMisses                   map[int]bool
+	markLostErr                      error
 	preloadedRecords                 map[int]*configstore.WorkerRecord
 	getRecordErrIDs                  map[int]error
 	markDrainingCalls                int
@@ -333,6 +340,48 @@ func (s *captureRuntimeWorkerStore) RetireOrphanWorker(workerID int, reason stri
 	return true, nil
 }
 
+func lostEligibleState(state configstore.WorkerState) bool {
+	switch state {
+	case configstore.WorkerStateSpawning,
+		configstore.WorkerStateIdle,
+		configstore.WorkerStateReserved,
+		configstore.WorkerStateActivating,
+		configstore.WorkerStateHot,
+		configstore.WorkerStateHotIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *captureRuntimeWorkerStore) MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.markLostCalls++
+	s.markLostCalledIDs = append(s.markLostCalledIDs, workerID)
+	s.markLostCalledCPs = append(s.markLostCalledCPs, ownerCPInstanceID)
+	s.markLostCalledEpochs = append(s.markLostCalledEpochs, expectedOwnerEpoch)
+	s.markLostCalledReasons = append(s.markLostCalledReasons, reason)
+	if s.markLostErr != nil {
+		return false, s.markLostErr
+	}
+	if s.markLostMisses[workerID] {
+		return false, nil
+	}
+	rec := s.preloadedRecords[workerID]
+	if rec == nil {
+		return false, nil
+	}
+	if rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || !lostEligibleState(rec.State) {
+		return false, nil
+	}
+	rec.State = configstore.WorkerStateLost
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
+	s.recordEvent(fmt.Sprintf("lost:%d", workerID))
+	return true, nil
+}
+
 func (s *captureRuntimeWorkerStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -363,6 +412,31 @@ func (s *captureRuntimeWorkerStore) RetireDrainingWorker(workerID int, reason st
 		return false, nil
 	}
 	return true, nil
+}
+
+func podDeleteActionCount(cs *fake.Clientset) int {
+	count := 0
+	for _, action := range cs.Actions() {
+		if action.Matches("delete", "pods") {
+			count++
+		}
+	}
+	return count
+}
+
+func podDeleteActionNames(cs *fake.Clientset) []string {
+	var names []string
+	for _, action := range cs.Actions() {
+		if !action.Matches("delete", "pods") {
+			continue
+		}
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			continue
+		}
+		names = append(names, deleteAction.GetName())
+	}
+	return names
 }
 
 func newTestK8sPool(t *testing.T, maxWorkers int) (*K8sWorkerPool, *fake.Clientset) {
@@ -2145,6 +2219,511 @@ func TestK8sPoolHealthCheckLoopReplenishesWarmCapacityAfterIdleWorkerCrash(t *te
 	case <-replacementSpawned:
 	case <-time.After(time.Second):
 		t.Fatal("expected idle worker crash to trigger warm-pool replenishment")
+	}
+}
+
+func TestK8sPoolHealthCheckLoopDropsStaleLeaseWithoutDeletingPod(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			7: {
+				WorkerID:          7,
+				PodName:           "test-cp-worker-7",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: "other-cp:boot",
+				OwnerEpoch:        12,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 7, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(3)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-7", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.7"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+
+	deadline := time.After(time.Second)
+	for {
+		if _, ok := pool.Worker(worker.ID); !ok {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected stale local worker to be dropped")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	select {
+	case workerID := <-crashed:
+		t.Fatalf("stale lease must not notify sessions as crashed, got worker %d", workerID)
+	default:
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("stale lease must not delete pod, got %d delete actions", got)
+	}
+	store.mu.Lock()
+	markLostCalls := store.markLostCalls
+	markLostCalledIDs := append([]int(nil), store.markLostCalledIDs...)
+	markLostCalledCPs := append([]string(nil), store.markLostCalledCPs...)
+	markLostCalledEpochs := append([]int64(nil), store.markLostCalledEpochs...)
+	markLostCalledReasons := append([]string(nil), store.markLostCalledReasons...)
+	recordState := store.preloadedRecords[worker.ID].State
+	store.mu.Unlock()
+	if markLostCalls != 1 {
+		t.Fatalf("expected 1 lease-fenced lost CAS, got %d", markLostCalls)
+	}
+	if markLostCalledIDs[0] != worker.ID || markLostCalledCPs[0] != pool.cpInstanceID || markLostCalledEpochs[0] != 3 || markLostCalledReasons[0] != RetireReasonCrash {
+		t.Fatalf("unexpected lost CAS args: ids=%v cps=%v epochs=%v reasons=%v", markLostCalledIDs, markLostCalledCPs, markLostCalledEpochs, markLostCalledReasons)
+	}
+	if recordState != configstore.WorkerStateHot {
+		t.Fatalf("stale lease must not mutate worker record, got state %q", recordState)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("stale lease must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolHealthCheckLoopRetriesSameOwnerNewerRuntimeEpoch(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			10: {
+				WorkerID:          10,
+				PodName:           "test-cp-worker-10",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        12,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 10, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(3)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-10", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.10"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+
+	deadline := time.After(time.Second)
+	for {
+		store.mu.Lock()
+		markLostCalls := store.markLostCalls
+		store.mu.Unlock()
+		if markLostCalls > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected health loop to attempt lease-fenced lost CAS")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	if _, ok := pool.Worker(worker.ID); !ok {
+		t.Fatal("same-owner newer runtime epoch must not drop the local worker")
+	}
+	select {
+	case workerID := <-crashed:
+		t.Fatalf("same-owner newer runtime epoch must not notify sessions as crashed, got worker %d", workerID)
+	default:
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("same-owner newer runtime epoch must not delete pod, got %d delete actions", got)
+	}
+	store.mu.Lock()
+	recordState := store.preloadedRecords[worker.ID].State
+	store.mu.Unlock()
+	if recordState != configstore.WorkerStateHot {
+		t.Fatalf("same-owner newer runtime epoch must not mutate worker record, got state %q", recordState)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("same-owner newer runtime epoch must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			13: {
+				WorkerID:          13,
+				PodName:           "test-cp-worker-13",
+				State:             configstore.WorkerStateLost,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+				RetireReason:      RetireReasonCrash,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 13, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-13", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.13"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+
+	select {
+	case workerID := <-crashed:
+		if workerID != worker.ID {
+			t.Fatalf("expected crash notification for worker %d, got %d", worker.ID, workerID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected already-lost current lease to complete crash notification")
+	}
+	if _, ok := pool.Worker(worker.ID); ok {
+		t.Fatal("expected already-lost current lease to remove local worker")
+	}
+	if got := podDeleteActionNames(cs); len(got) != 1 || got[0] != "test-cp-worker-13" {
+		t.Fatalf("expected already-lost current lease to delete pod, got %v", got)
+	}
+}
+
+func TestK8sPoolHealthCheckLoopCurrentLeaseDeletesPodAndNotifiesCrash(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			8: {
+				WorkerID:          8,
+				PodName:           "adopted-worker-8",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 8, podName: "adopted-worker-8", done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "adopted-worker-8", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.8"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+
+	select {
+	case workerID := <-crashed:
+		if workerID != worker.ID {
+			t.Fatalf("expected crash notification for worker %d, got %d", worker.ID, workerID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected current lease health-check failure to notify crash")
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		if got := podDeleteActionCount(cs); got > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected current lease health-check failure to delete pod")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if got := podDeleteActionNames(cs); len(got) != 1 || got[0] != "adopted-worker-8" {
+		t.Fatalf("expected health-check failure to delete adopted pod, got %v", got)
+	}
+
+	store.mu.Lock()
+	markLostCalls := store.markLostCalls
+	markLostCalledIDs := append([]int(nil), store.markLostCalledIDs...)
+	markLostCalledCPs := append([]string(nil), store.markLostCalledCPs...)
+	markLostCalledEpochs := append([]int64(nil), store.markLostCalledEpochs...)
+	markLostCalledReasons := append([]string(nil), store.markLostCalledReasons...)
+	recordState := store.preloadedRecords[worker.ID].State
+	recordReason := store.preloadedRecords[worker.ID].RetireReason
+	store.mu.Unlock()
+	if markLostCalls != 1 {
+		t.Fatalf("expected 1 lease-fenced lost CAS, got %d", markLostCalls)
+	}
+	if markLostCalledIDs[0] != worker.ID || markLostCalledCPs[0] != pool.cpInstanceID || markLostCalledEpochs[0] != 4 || markLostCalledReasons[0] != RetireReasonCrash {
+		t.Fatalf("unexpected lost CAS args: ids=%v cps=%v epochs=%v reasons=%v", markLostCalledIDs, markLostCalledCPs, markLostCalledEpochs, markLostCalledReasons)
+	}
+	if recordState != configstore.WorkerStateLost || recordReason != RetireReasonCrash {
+		t.Fatalf("current lease should be marked lost/crash, got state=%q reason=%q", recordState, recordReason)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("current lease path must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolMarkWorkerLostIfCurrentLeaseAllowsUnstampedLocalWorker(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			9: {
+				WorkerID:          9,
+				PodName:           "test-cp-worker-9",
+				State:             configstore.WorkerStateIdle,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        0,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	worker := &ManagedWorker{ID: 9, done: make(chan struct{})}
+	currentLease, err := pool.markWorkerLostIfCurrentLease(pool.workerLeaseSnapshot(worker))
+	if err != nil {
+		t.Fatalf("mark lost: %v", err)
+	}
+	if !currentLease {
+		t.Fatal("unstamped local worker should use the pool owner for the lease CAS")
+	}
+	if got := store.preloadedRecords[worker.ID].State; got != configstore.WorkerStateLost {
+		t.Fatalf("expected worker record marked lost, got %q", got)
+	}
+}
+
+func TestK8sPoolRemoveWorkerAfterLostLeaseRejectsNewerLocalEpoch(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	worker := &ManagedWorker{ID: 11, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(3)
+	lease := pool.workerLeaseSnapshot(worker)
+
+	worker.SetOwnerEpoch(4)
+	pool.workers[worker.ID] = worker
+
+	removed, _, _, _ := pool.removeWorkerAfterLostLeaseLocked(lease)
+	if removed != nil {
+		t.Fatalf("expected old lease snapshot not to remove newer local worker")
+	}
+	if _, ok := pool.workers[worker.ID]; !ok {
+		t.Fatal("newer local worker must remain in the pool")
+	}
+}
+
+func TestK8sPoolCleanDeadWorkersDropsStaleRuntimeLeaseWithoutDeletingPod(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			12: {
+				WorkerID:          12,
+				PodName:           "test-cp-worker-12",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: "other-cp:boot",
+				OwnerEpoch:        9,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	done := make(chan struct{})
+	close(done)
+	worker := &ManagedWorker{ID: 12, done: done}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(3)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-12", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.12"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	pool.cleanDeadWorkersLocked()
+
+	if _, ok := pool.workers[worker.ID]; ok {
+		t.Fatal("expected stale closed worker to be dropped locally")
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("stale clean-dead lease must not delete pod, got %d delete actions", got)
+	}
+	if state := store.preloadedRecords[worker.ID].State; state != configstore.WorkerStateHot {
+		t.Fatalf("stale clean-dead lease must not mutate record, got state %q", state)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("stale clean-dead lease must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolCleanDeadWorkersLeavesSameOwnerNewerRuntimeEpoch(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			15: {
+				WorkerID:          15,
+				PodName:           "test-cp-worker-15",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        9,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	done := make(chan struct{})
+	close(done)
+	worker := &ManagedWorker{ID: 15, done: done}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(3)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-15", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.15"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	pool.cleanDeadWorkersLocked()
+
+	if _, ok := pool.workers[worker.ID]; !ok {
+		t.Fatal("cleanDeadWorkersLocked must not drop same-owner newer runtime epoch")
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("same-owner newer runtime epoch clean-dead path must not delete pod, got %d delete actions", got)
+	}
+	if state := store.preloadedRecords[worker.ID].State; state != configstore.WorkerStateHot {
+		t.Fatalf("same-owner newer runtime epoch clean-dead path must not mutate record, got state %q", state)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("same-owner newer runtime epoch clean-dead path must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolCleanDeadWorkersLeavesCurrentRuntimeLeaseForHealthLoop(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			16: {
+				WorkerID:          16,
+				PodName:           "test-cp-worker-16",
+				State:             configstore.WorkerStateHot,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	done := make(chan struct{})
+	close(done)
+	worker := &ManagedWorker{ID: 16, done: done}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-16", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.16"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	pool.cleanDeadWorkersLocked()
+
+	if _, ok := pool.workers[worker.ID]; !ok {
+		t.Fatal("cleanDeadWorkersLocked must leave current runtime lease for HealthCheckLoop crash notification")
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("current runtime lease clean-dead path must not delete pod, got %d delete actions", got)
+	}
+	store.mu.Lock()
+	recordState := store.preloadedRecords[worker.ID].State
+	recordReason := store.preloadedRecords[worker.ID].RetireReason
+	store.mu.Unlock()
+	if recordState != configstore.WorkerStateLost || recordReason != RetireReasonCrash {
+		t.Fatalf("cleanDeadWorkersLocked should fence current runtime lease as lost/crash, got state=%q reason=%q", recordState, recordReason)
+	}
+	if records := store.snapshot(); len(records) != 0 {
+		t.Fatalf("current runtime lease clean-dead path must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolCleanDeadWorkersLeavesSameLeaseAlreadyLostForHealthLoop(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			14: {
+				WorkerID:          14,
+				PodName:           "test-cp-worker-14",
+				State:             configstore.WorkerStateLost,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+				RetireReason:      RetireReasonCrash,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	done := make(chan struct{})
+	close(done)
+	worker := &ManagedWorker{ID: 14, done: done}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-14", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.14"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	pool.cleanDeadWorkersLocked()
+
+	if _, ok := pool.workers[worker.ID]; !ok {
+		t.Fatal("cleanDeadWorkersLocked must not consume an already-lost same-lease worker before HealthCheckLoop can notify crash")
+	}
+	if got := podDeleteActionCount(cs); got != 0 {
+		t.Fatalf("already-lost same-lease clean-dead path must not delete pod, got %d delete actions", got)
 	}
 }
 

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -126,6 +126,7 @@ type RuntimeWorkerStore interface {
 	RetireIdleWorker(workerID int, reason string) (bool, error)
 	RetireIdleOrHotIdleWorker(workerID int, reason string) (bool, error)
 	RetireOrphanWorker(workerID int, reason string) (bool, error)
+	MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
 	MarkWorkerDraining(workerID int, ownerCPInstanceID string) (bool, error)
 	RetireDrainingWorker(workerID int, reason string) (bool, error)
 }

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -1965,6 +1965,141 @@ func TestGetFlightSessionRecordReturnsNilWhenMissing(t *testing.T) {
 	}
 }
 
+func TestMarkWorkerLostIfCurrentLeasePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 12, 0, 0, 0, time.UTC)
+
+	liveStates := []configstore.WorkerState{
+		configstore.WorkerStateSpawning,
+		configstore.WorkerStateIdle,
+		configstore.WorkerStateReserved,
+		configstore.WorkerStateActivating,
+		configstore.WorkerStateHot,
+		configstore.WorkerStateHotIdle,
+	}
+	for i, state := range liveStates {
+		t.Run(string(state), func(t *testing.T) {
+			workerID := 3100 + i
+			upsertMarkLostWorker(t, store, workerID, state, "cp-me:boot-a", 4, "", now)
+
+			updated, err := store.MarkWorkerLostIfCurrentLease(workerID, "cp-me:boot-a", 4, "crash")
+			if err != nil {
+				t.Fatalf("MarkWorkerLostIfCurrentLease(%s): %v", state, err)
+			}
+			if !updated {
+				t.Fatalf("expected current %s lease to mark worker lost", state)
+			}
+			assertWorkerStateAndReason(t, store, workerID, configstore.WorkerStateLost, "crash")
+		})
+	}
+
+	upsertMarkLostWorker(t, store, 3200, configstore.WorkerStateHot, "cp-other:boot-b", 9, "", now)
+	updated, err := store.MarkWorkerLostIfCurrentLease(3200, "cp-me:boot-a", 9, "crash")
+	if err != nil {
+		t.Fatalf("MarkWorkerLostIfCurrentLease owner mismatch: %v", err)
+	}
+	if updated {
+		t.Fatal("expected owner mismatch to return false")
+	}
+	assertWorkerStateAndReason(t, store, 3200, configstore.WorkerStateHot, "")
+
+	upsertMarkLostWorker(t, store, 3201, configstore.WorkerStateHot, "cp-me:boot-a", 4, "", now)
+	updated, err = store.MarkWorkerLostIfCurrentLease(3201, "cp-me:boot-a", 3, "crash")
+	if err != nil {
+		t.Fatalf("MarkWorkerLostIfCurrentLease epoch mismatch: %v", err)
+	}
+	if updated {
+		t.Fatal("expected epoch mismatch to return false")
+	}
+	assertWorkerStateAndReason(t, store, 3201, configstore.WorkerStateHot, "")
+
+	noOpStates := []configstore.WorkerState{
+		configstore.WorkerStateDraining,
+		configstore.WorkerStateRetired,
+		configstore.WorkerStateLost,
+	}
+	for i, state := range noOpStates {
+		t.Run("noop_"+string(state), func(t *testing.T) {
+			workerID := 3300 + i
+			upsertMarkLostWorker(t, store, workerID, state, "cp-me:boot-a", 4, "original", now)
+
+			updated, err := store.MarkWorkerLostIfCurrentLease(workerID, "cp-me:boot-a", 4, "crash")
+			if err != nil {
+				t.Fatalf("MarkWorkerLostIfCurrentLease(%s): %v", state, err)
+			}
+			if updated {
+				t.Fatalf("expected %s worker to remain owned by its current lifecycle path", state)
+			}
+			assertWorkerStateAndReason(t, store, workerID, state, "original")
+		})
+	}
+}
+
+func TestUpsertWorkerRecordDoesNotResurrectTerminalWorkerPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 12, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		state configstore.WorkerState
+	}{
+		{"draining", configstore.WorkerStateDraining},
+		{"lost", configstore.WorkerStateLost},
+		{"retired", configstore.WorkerStateRetired},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			workerID := 3400 + i
+			upsertMarkLostWorker(t, store, workerID, tc.state, "cp-me:boot-a", 4, "original", now)
+
+			if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+				WorkerID:          workerID,
+				PodName:           fmt.Sprintf("duckgres-worker-%d", workerID),
+				State:             configstore.WorkerStateHot,
+				OrgID:             "acme",
+				OwnerCPInstanceID: "cp-me:boot-a",
+				OwnerEpoch:        5,
+				RetireReason:      "",
+				LastHeartbeatAt:   now.Add(time.Minute),
+			}); err != nil {
+				t.Fatalf("UpsertWorkerRecord(%d): %v", workerID, err)
+			}
+
+			assertWorkerStateAndReason(t, store, workerID, tc.state, "original")
+		})
+	}
+}
+
+func upsertMarkLostWorker(t *testing.T, store *configstore.ConfigStore, workerID int, state configstore.WorkerState, ownerCPInstanceID string, ownerEpoch int64, retireReason string, lastHeartbeatAt time.Time) {
+	t.Helper()
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          workerID,
+		PodName:           fmt.Sprintf("duckgres-worker-%d", workerID),
+		State:             state,
+		OrgID:             "acme",
+		OwnerCPInstanceID: ownerCPInstanceID,
+		OwnerEpoch:        ownerEpoch,
+		RetireReason:      retireReason,
+		LastHeartbeatAt:   lastHeartbeatAt,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(%d): %v", workerID, err)
+	}
+}
+
+func assertWorkerStateAndReason(t *testing.T, store *configstore.ConfigStore, workerID int, wantState configstore.WorkerState, wantReason string) {
+	t.Helper()
+	record, err := store.GetWorkerRecord(workerID)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord(%d): %v", workerID, err)
+	}
+	if record == nil {
+		t.Fatalf("expected worker %d to exist", workerID)
+	}
+	if record.State != wantState || record.RetireReason != wantReason {
+		t.Fatalf("worker %d = state %q reason %q, want state %q reason %q", workerID, record.State, record.RetireReason, wantState, wantReason)
+	}
+}
+
 func TestTakeOverWorkerPostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.March, 27, 17, 0, 0, 0, time.UTC)
@@ -2008,6 +2143,35 @@ func TestTakeOverWorkerPostgres(t *testing.T) {
 	}
 	if missed != nil {
 		t.Fatalf("expected stale takeover attempt to fail, got %#v", missed)
+	}
+}
+
+func TestTakeOverWorkerSkipsNonReclaimableStatesPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 12, 45, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		state configstore.WorkerState
+	}{
+		{"draining", configstore.WorkerStateDraining},
+		{"retired", configstore.WorkerStateRetired},
+		{"lost", configstore.WorkerStateLost},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			workerID := 3500 + i
+			upsertMarkLostWorker(t, store, workerID, tc.state, "cp-old:boot-a", 5, "original", now)
+
+			claimed, err := store.TakeOverWorker(workerID, "cp-new:boot-b", "analytics", 5)
+			if err != nil {
+				t.Fatalf("TakeOverWorker(%s): %v", tc.state, err)
+			}
+			if claimed != nil {
+				t.Fatalf("expected %s worker not to be claimed, got %#v", tc.state, claimed)
+			}
+			assertWorkerStateAndReason(t, store, workerID, tc.state, "original")
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR tightens worker ownership handling for K8s health checks and runtime-store worker rows.

- Adds a lease-fenced `MarkWorkerLostIfCurrentLease` path so health checks only mark/delete workers they still own.
- Classifies health-check lease outcomes so stale leases are dropped locally, same-CP epoch drift retries, and already-lost same-lease workers still complete crash notification.
- Keeps `cleanDeadWorkersLocked` from consuming current runtime-store leases before `HealthCheckLoop` can call `onCrash`.
- Prevents generic worker upserts from resurrecting `draining`, `lost`, or `retired` rows.
- Makes takeover skip non-hot rows, covering draining and terminal states.

## Root Cause

K8s worker ownership was split between the local `K8sWorkerPool.workers` map and global runtime-store rows. Health cleanup paths could act on local workers without proving the runtime-store lease still belonged to the same control-plane epoch, and generic upserts/takeover paths could move lifecycle rows after they were already fenced for shutdown or terminal cleanup.

## Validation

- `just test-controlplane-k8s`
- `just test-configstore-integration`
- `just test-controlplane`
- `go test -race -tags kubernetes ./controlplane -run TestK8sPoolHealthCheckLoopSnapshotsLeaseUnderPoolLock -count=1`
- `git diff --check`
- `just lint`

Final focused subagent review passes for K8s and configstore reported no findings.