### PR TITLE
fix(transpiler): correct interval-typmod and pg_catalog type casts in deparser output

### DIFF
--- a/server/cast_compat_test.go
+++ b/server/cast_compat_test.go
@@ -14,7 +14,7 @@ func TestDuckDBAcceptsTranspiledCasts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	queries := []string{
 		`SELECT (current_timestamp + CAST('2' || ' day' AS "interval"))`,

--- a/server/cast_compat_test.go
+++ b/server/cast_compat_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// TestDuckDBAcceptsTranspiledCasts confirms the exact SQL forms emitted by the
+// transpiler's fixupAST cast fixes execute against real DuckDB.
+func TestDuckDBAcceptsTranspiledCasts(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	queries := []string{
+		`SELECT (current_timestamp + CAST('2' || ' day' AS "interval"))`,
+		`SELECT CAST(5 || ' day' AS "interval")`,
+		`SELECT CAST('{}' AS "json")`,
+		`SELECT json_extract(CAST('{"x":1}' AS "json"), 'x')`,
+	}
+	for _, q := range queries {
+		var out interface{}
+		if err := db.QueryRow(q).Scan(&out); err != nil {
+			t.Fatalf("DuckDB rejected transpiled form %q: %v", q, err)
+		}
+	}
+}

--- a/transpiler/cast_fixup_test.go
+++ b/transpiler/cast_fixup_test.go
@@ -1,0 +1,41 @@
+package transpiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIntervalTypmodCast verifies that a field-qualified interval cast
+// ('2'::interval day) is rewritten to a DuckDB-executable form rather than the
+// deparser's '2'::"interval"(8), which DuckDB cannot convert.
+func TestIntervalTypmodCast(t *testing.T) {
+	tp := New(DefaultConfig())
+	res, err := tp.TranspileAll(`SELECT 1 WHERE ts <= (current_timestamp + '2'::interval day)`)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if strings.Contains(res.SQL, `"interval"(`) {
+		t.Fatalf("interval typmod not rewritten: %s", res.SQL)
+	}
+	if !strings.Contains(res.SQL, "interval") || !strings.Contains(res.SQL, "day") {
+		t.Fatalf("expected interval/day in output: %s", res.SQL)
+	}
+	t.Logf("interval out: %s", res.SQL)
+}
+
+// TestPgCatalogJsonStrip verifies the deparser's pg_catalog.json canonicalization
+// is stripped even when the type-mapping flag would not otherwise fire.
+func TestPgCatalogJsonStrip(t *testing.T) {
+	// A query parsed for some unrelated reason but NOT classified as needing
+	// type mapping. The "->" forces FlagOperators (so it parses+deparses) while
+	// a bare ::json cast does not set FlagTypeMapping.
+	tp := New(DefaultConfig())
+	res, err := tp.Transpile(`SELECT (e.properties->'x')::json AS j FROM t e`)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if strings.Contains(res.SQL, "pg_catalog.json") || strings.Contains(strings.ToLower(res.SQL), "pg_catalog") {
+		t.Fatalf("pg_catalog not stripped: %s", res.SQL)
+	}
+	t.Logf("json out: %s", res.SQL)
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -703,6 +703,115 @@ func fixupAST(tree *pg_query.ParseResult) {
 			idx.IndexStmt.AccessMethod = ""
 		}
 	}
+
+	// Deparser-output compatibility fixes for type casts. These must run
+	// unconditionally (independent of which transforms the classifier selected)
+	// because they correct the SQL the pg_query deparser produces, not the
+	// user's input:
+	//
+	//   - The deparser canonicalizes built-in types as pg_catalog.<type>
+	//     (e.g. x::json -> x::pg_catalog.json), which DuckDB rejects.
+	//   - It renders a field-qualified interval cast ('2'::interval day) as
+	//     '2'::"interval"(8), which DuckDB cannot convert (no unit in the value).
+	//
+	// The flag-gated TypeMappingTransform strips pg_catalog too, but only when
+	// the classifier decided a query needs type mapping; a query that is parsed
+	// for some other transform but not flagged for type mapping would otherwise
+	// emit pg_catalog.<type>. Doing it here closes that gap.
+	transform.WalkFunc(tree, func(node *pg_query.Node) bool {
+		switch n := node.Node.(type) {
+		case *pg_query.Node_TypeCast:
+			if tc := n.TypeCast; tc != nil && tc.TypeName != nil {
+				if rewriteIntervalTypmodCast(tc) {
+					return true
+				}
+				stripPgCatalogFromTypeName(tc.TypeName)
+			}
+		case *pg_query.Node_ColumnDef:
+			if cd := n.ColumnDef; cd != nil && cd.TypeName != nil {
+				stripPgCatalogFromTypeName(cd.TypeName)
+			}
+		}
+		return true
+	})
+}
+
+// intervalTypmodUnit maps PostgreSQL interval typmod range masks (INTERVAL_MASK
+// of a single field) to the DuckDB unit keyword. These are the bitmask values
+// the parser stores for `interval <field>`: MONTH=1<<1, YEAR=1<<2, DAY=1<<3,
+// HOUR=1<<10, MINUTE=1<<11, SECOND=1<<12. Combined ranges (e.g. DAY TO HOUR)
+// are intentionally omitted — they are rare and have no clean DuckDB cast form.
+var intervalTypmodUnit = map[int32]string{
+	2:    "month",
+	4:    "year",
+	8:    "day",
+	1024: "hour",
+	2048: "minute",
+	4096: "second",
+}
+
+// rewriteIntervalTypmodCast rewrites a field-qualified interval cast such as
+// '2'::interval day into (2 || ' day')::interval, which DuckDB accepts. DuckDB
+// cannot infer a unit from a bare value cast to INTERVAL; a unit-bearing string
+// works, and concatenation handles both string and numeric operands. A bare
+// interval cast (no typmod) is not re-qualified to pg_catalog.interval by the
+// deparser, so the output survives deparsing. Returns true if it rewrote the cast.
+func rewriteIntervalTypmodCast(tc *pg_query.TypeCast) bool {
+	tn := tc.TypeName
+	if tn == nil || len(tn.Names) == 0 || tc.Arg == nil {
+		return false
+	}
+	last := tn.Names[len(tn.Names)-1].GetString_()
+	if last == nil || strings.ToLower(last.Sval) != "interval" {
+		return false
+	}
+	if len(tn.Typmods) != 1 {
+		return false
+	}
+	ac := tn.Typmods[0].GetAConst()
+	if ac == nil {
+		return false
+	}
+	iv := ac.GetIval()
+	if iv == nil {
+		return false
+	}
+	unit, ok := intervalTypmodUnit[iv.Ival]
+	if !ok {
+		return false
+	}
+
+	tc.Arg = &pg_query.Node{Node: &pg_query.Node_AExpr{AExpr: &pg_query.A_Expr{
+		Kind:  pg_query.A_Expr_Kind_AEXPR_OP,
+		Name:  []*pg_query.Node{{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: "||"}}}},
+		Lexpr: tc.Arg,
+		Rexpr: &pg_query.Node{Node: &pg_query.Node_AConst{AConst: &pg_query.A_Const{
+			Val: &pg_query.A_Const_Sval{Sval: &pg_query.String{Sval: " " + unit}},
+		}}},
+	}}}
+	tn.Names = []*pg_query.Node{{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: "interval"}}}}
+	tn.Typmods = nil
+	return true
+}
+
+// stripPgCatalogFromTypeName removes a leading pg_catalog qualifier from a type
+// name so the deparser emits e.g. json instead of pg_catalog.json (which DuckDB
+// rejects). Interval is deliberately left qualified: stripping pg_catalog from
+// interval regresses the deparser to '<n>'::"interval"(<mask>). Field-qualified
+// intervals are handled by rewriteIntervalTypmodCast before this runs.
+func stripPgCatalogFromTypeName(tn *pg_query.TypeName) {
+	if tn == nil || len(tn.Names) < 2 {
+		return
+	}
+	first := tn.Names[0].GetString_()
+	if first == nil || strings.ToLower(first.Sval) != "pg_catalog" {
+		return
+	}
+	last := tn.Names[len(tn.Names)-1].GetString_()
+	if last != nil && strings.ToLower(last.Sval) == "interval" {
+		return
+	}
+	tn.Names = tn.Names[1:]
 }
 
 // ConvertAlterTableToAlterView transforms an ALTER TABLE RENAME statement


### PR DESCRIPTION
## Problem

Two PostgreSQL-client queries failed when executed against DuckDB via duckgres:

```
ERROR:  Conversion Error: Could not convert string '2' to INTERVAL
  ... e."timestamp" <= (current_timestamp + '2'::"interval"(8)) ...
```
```
ERROR:  Parser Error: syntax error at or near "json"
  ... json_transform(e.properties::pg_catalog.json, '{ ...
```

Both stem from SQL the `pg_query` **deparser** emits (not the user's input), combined with the existing `pg_catalog` strip being **flag-gated** so it didn't always run.

## Root cause

- `'2'::interval day` parses as `pg_catalog.interval` carrying a typmod (`8` = the DAY field mask). `TypeMappingTransform` strips the `pg_catalog` prefix, which destroys the deparser's special interval rendering — it falls back to `'2'::"interval"(8)`, and DuckDB can't infer a unit from the bare value. The un-stripped form `'2'::interval day` *also* fails in DuckDB, so the cast had to be rewritten, not merely preserved.
- The deparser canonicalizes any `::json` to `::pg_catalog.json` (verified: even `SELECT x::json` deparses to `x::pg_catalog.json`). DuckDB rejects the `pg_catalog.` qualifier. The strip that fixes it only runs when `Classify` sets `FlagTypeMapping`, so a query parsed+deparsed for an unrelated transform emits the broken form.

## Fix

Both fixes move into `fixupAST`, which runs **unconditionally** before deparse — the correct place, since they fix deparser *output*, not user input:

- **`rewriteIntervalTypmodCast`** — rewrites `<expr>::interval <unit>` → `(<expr> || ' <unit>')::interval`. The concat form handles both string and numeric operands, and a bare `interval` cast is *not* re-qualified by the deparser (unlike `json`), so it survives. Covers the six single-field units (year/month/day/hour/minute/second).
- **`stripPgCatalogFromTypeName`** — strips the `pg_catalog` prefix from all cast/column-def type names (skipping `interval`, handled above), closing the flag-gating gap for `json` and any other re-qualified built-in.

## Verification

- Reproduced both bugs against the real transpiler and isolated each root cause.
- Confirmed against **real DuckDB** that the exact emitted forms execute: `CAST('2' || ' day' AS "interval")`, `CAST(5 || ' day' AS "interval")`, `CAST('{}' AS "json")`.
- Added regression tests: `transpiler/cast_fixup_test.go`, `server/cast_compat_test.go`.
- Full transpiler suite + `go build ./...` pass; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)