### PR TITLE
Fence worker lifecycle cleanup transitions

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -27,6 +27,10 @@ type OrgUserKey struct {
 
 var ErrWorkerOwnerEpochMismatch = errors.New("worker owner epoch mismatch")
 
+// ErrWorkerRecordUpsertFenceMiss indicates an UpsertWorkerRecord conflict was
+// rejected by the monotonic owner/terminal-state fence and did not persist.
+var ErrWorkerRecordUpsertFenceMiss = errors.New("worker record upsert fence miss")
+
 // Snapshot holds a point-in-time copy of all config data for fast lookups.
 type Snapshot struct {
 	Orgs               map[string]*OrgConfig
@@ -954,14 +958,19 @@ func (cs *ConfigStore) ExpireDrainingControlPlaneInstances(before time.Time) (in
 // UpsertWorkerRecord inserts or updates a runtime worker row.
 func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
 	protectedStates := []WorkerState{WorkerStateDraining, WorkerStateRetired, WorkerStateLost}
-	if err := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
+	result := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "worker_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at"}),
 		Where: clause.Where{Exprs: []clause.Expression{
 			clause.Expr{SQL: `"worker_records"."state" NOT IN ?`, Vars: []any{protectedStates}},
+			clause.Expr{SQL: `(excluded."owner_epoch" > "worker_records"."owner_epoch" OR (excluded."owner_epoch" = "worker_records"."owner_epoch" AND excluded."owner_cp_instance_id" = "worker_records"."owner_cp_instance_id"))`},
 		}},
-	}).Create(record).Error; err != nil {
-		return fmt.Errorf("upsert worker record: %w", err)
+	}).Create(record)
+	if result.Error != nil {
+		return fmt.Errorf("upsert worker record: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%w: worker_id=%d owner=%q epoch=%d state=%q", ErrWorkerRecordUpsertFenceMiss, record.WorkerID, record.OwnerCPInstanceID, record.OwnerEpoch, record.State)
 	}
 	return nil
 }
@@ -1087,10 +1096,29 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, m
 // ClaimHotIdleWorker atomically claims one hot-idle worker row that was
 // previously activated for the given org. The selected row is locked with
 // SKIP LOCKED and transitioned to reserved while incrementing owner_epoch.
-func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*WorkerRecord, WorkerClaimMissReason, error) {
+// When maxOrgWorkers is set, the org cap is checked under the same advisory
+// lock as neutral idle claims, excluding hot-idle rows from the count so a
+// cached worker can be reclaimed as the org's only active slot.
+func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*WorkerRecord, WorkerClaimMissReason, error) {
 	var claimed *WorkerRecord
 	missReason := WorkerClaimMissReasonNone
 	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		if orgID != "" {
+			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", advisoryLockKey("duckgres:org:"+orgID)).Error; err != nil {
+				return err
+			}
+		}
+		if maxOrgWorkers > 0 && orgID != "" {
+			count, err := cs.countActiveWorkers(tx, "org_id = ? AND state <> ?", orgID, WorkerStateHotIdle)
+			if err != nil {
+				return err
+			}
+			if count >= int64(maxOrgWorkers) {
+				missReason = WorkerClaimMissReasonOrgCap
+				return nil
+			}
+		}
+
 		var current WorkerRecord
 		err := tx.Table(cs.runtimeTable(current.TableName())).
 			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
@@ -1143,38 +1171,55 @@ func (cs *ConfigStore) ListExpiredHotIdleWorkers(before time.Time) ([]WorkerReco
 	return workers, nil
 }
 
-// RetireHotIdleWorker atomically transitions a worker from hot_idle to retired.
-// Returns true if the transition happened, false if the worker was no longer hot_idle
-// (e.g. it was reclaimed by another CP pod between the list query and this call).
-func (cs *ConfigStore) RetireHotIdleWorker(workerID int) (bool, error) {
-	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND state = ?", workerID, WorkerStateHotIdle).
-		Updates(map[string]any{
-			"state":         WorkerStateRetired,
-			"retire_reason": "hot_idle_ttl_expired",
-			"updated_at":    time.Now(),
-		})
+// MarkWorkerTerminalIfCurrent moves an observed active worker row to a terminal
+// state only if the durable row still matches that observation. It is the shared
+// CAS for list-then-cleanup paths where a worker id alone is not enough to prove
+// the listed worker was not reclaimed by another CP.
+func (cs *ConfigStore) MarkWorkerTerminalIfCurrent(record *WorkerRecord, targetState WorkerState, reason string) (bool, error) {
+	if record == nil {
+		return false, nil
+	}
+	if targetState != WorkerStateRetired && targetState != WorkerStateLost {
+		return false, fmt.Errorf("worker %d unsupported terminal state %q", record.WorkerID, targetState)
+	}
+
+	eligibleStates := workerTerminalEligibleStates(targetState)
+	query := cs.db.Table(cs.runtimeTable(record.TableName())).
+		Where("worker_id = ? AND state = ? AND owner_epoch = ?", record.WorkerID, record.State, record.OwnerEpoch).
+		Where("(owner_cp_instance_id = ? OR (? = '' AND owner_cp_instance_id IS NULL))", record.OwnerCPInstanceID, record.OwnerCPInstanceID).
+		Where("state IN ?", eligibleStates)
+	if !record.UpdatedAt.IsZero() {
+		query = query.Where("updated_at <= ?", record.UpdatedAt)
+	}
+
+	result := query.Updates(map[string]any{
+		"state":         targetState,
+		"retire_reason": reason,
+		"updated_at":    time.Now(),
+	})
 	if result.Error != nil {
-		return false, fmt.Errorf("retire hot-idle worker %d: %w", workerID, result.Error)
+		return false, fmt.Errorf("mark worker %d terminal: %w", record.WorkerID, result.Error)
 	}
 	return result.RowsAffected > 0, nil
+}
+
+// RetireHotIdleWorker atomically transitions the observed hot-idle row to
+// retired. Returns false if the row no longer matches the listed snapshot.
+func (cs *ConfigStore) RetireHotIdleWorker(record *WorkerRecord) (bool, error) {
+	if record == nil || record.State != WorkerStateHotIdle {
+		return false, nil
+	}
+	return cs.MarkWorkerTerminalIfCurrent(record, WorkerStateRetired, "hot_idle_ttl_expired")
 }
 
 // RetireIdleWorker atomically transitions a worker from idle to retired.
 // Returns true if the transition happened, false if the worker was no longer
 // idle (e.g. claimed by another CP between the list query and this call).
-func (cs *ConfigStore) RetireIdleWorker(workerID int, reason string) (bool, error) {
-	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND state = ?", workerID, WorkerStateIdle).
-		Updates(map[string]any{
-			"state":         WorkerStateRetired,
-			"retire_reason": reason,
-			"updated_at":    time.Now(),
-		})
-	if result.Error != nil {
-		return false, fmt.Errorf("retire idle worker %d: %w", workerID, result.Error)
+func (cs *ConfigStore) RetireIdleWorker(record *WorkerRecord, reason string) (bool, error) {
+	if record == nil || record.State != WorkerStateIdle {
+		return false, nil
 	}
-	return result.RowsAffected > 0, nil
+	return cs.MarkWorkerTerminalIfCurrent(record, WorkerStateRetired, reason)
 }
 
 // RetireOrphanWorker is the orphan-cleanup counterpart to
@@ -1186,27 +1231,37 @@ func (cs *ConfigStore) RetireIdleWorker(workerID int, reason string) (bool, erro
 // it (the owner CP is expired or absent) — so we can short-circuit the
 // state-machine guards and just terminate the row.
 //
-// Returns true if a row transitioned, false if the row was already
-// terminal (`retired` / `lost`) or no row matches the given worker_id.
-func (cs *ConfigStore) RetireOrphanWorker(workerID int, reason string) (bool, error) {
-	cleanupStates := []WorkerState{
-		WorkerStateSpawning,
-		WorkerStateIdle,
-		WorkerStateReserved,
-		WorkerStateActivating,
-		WorkerStateHot,
-		WorkerStateHotIdle,
-		WorkerStateDraining,
+// Returns true if a row transitioned, false if the observed row was already
+// terminal (`retired` / `lost`) or has changed since it was listed.
+func (cs *ConfigStore) RetireOrphanWorker(record *WorkerRecord, reason string) (bool, error) {
+	if record == nil {
+		return false, nil
 	}
-	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND state IN ?", workerID, cleanupStates).
-		Updates(map[string]any{
-			"state":         WorkerStateRetired,
-			"retire_reason": reason,
-			"updated_at":    time.Now(),
-		})
+
+	workerTable := cs.runtimeTable(record.TableName())
+	cpTable := cs.runtimeTable((&ControlPlaneInstance{}).TableName())
+	query := cs.db.Table(workerTable).
+		Where("worker_id = ? AND state = ? AND owner_epoch = ?", record.WorkerID, record.State, record.OwnerEpoch).
+		Where("(owner_cp_instance_id = ? OR (? = '' AND owner_cp_instance_id IS NULL))", record.OwnerCPInstanceID, record.OwnerCPInstanceID).
+		Where("state IN ?", workerTerminalEligibleStates(WorkerStateRetired))
+	if !record.UpdatedAt.IsZero() {
+		query = query.Where("updated_at <= ?", record.UpdatedAt)
+	}
+	if record.OwnerCPInstanceID != "" {
+		query = query.Where(
+			"NOT EXISTS (SELECT 1 FROM "+cpTable+" AS cp WHERE cp.id = ? AND cp.state <> ?)",
+			record.OwnerCPInstanceID,
+			ControlPlaneInstanceStateExpired,
+		)
+	}
+
+	result := query.Updates(map[string]any{
+		"state":         WorkerStateRetired,
+		"retire_reason": reason,
+		"updated_at":    time.Now(),
+	})
 	if result.Error != nil {
-		return false, fmt.Errorf("retire orphan worker %d: %w", workerID, result.Error)
+		return false, fmt.Errorf("retire orphan worker %d: %w", record.WorkerID, result.Error)
 	}
 	return result.RowsAffected > 0, nil
 }
@@ -1315,18 +1370,14 @@ func (cs *ConfigStore) MarkCredentialsRefreshed(workerID int, ownerCPInstanceID 
 // RetireIdleOrHotIdleWorker atomically transitions a worker from idle or hot_idle
 // to retired. Returns true if the transition happened, false if the worker was
 // in some other state (e.g. claimed/activating/hot).
-func (cs *ConfigStore) RetireIdleOrHotIdleWorker(workerID int, reason string) (bool, error) {
-	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND state IN ?", workerID, []WorkerState{WorkerStateIdle, WorkerStateHotIdle}).
-		Updates(map[string]any{
-			"state":         WorkerStateRetired,
-			"retire_reason": reason,
-			"updated_at":    time.Now(),
-		})
-	if result.Error != nil {
-		return false, fmt.Errorf("retire idle/hot_idle worker %d: %w", workerID, result.Error)
+func (cs *ConfigStore) RetireIdleOrHotIdleWorker(record *WorkerRecord, reason string) (bool, error) {
+	if record == nil {
+		return false, nil
 	}
-	return result.RowsAffected > 0, nil
+	if record.State != WorkerStateIdle && record.State != WorkerStateHotIdle {
+		return false, nil
+	}
+	return cs.MarkWorkerTerminalIfCurrent(record, WorkerStateRetired, reason)
 }
 
 // MarkWorkerLostIfCurrentLease atomically marks a worker lost only when the
@@ -1369,7 +1420,7 @@ func (cs *ConfigStore) MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanc
 //
 // The ownerCPInstanceID guard prevents a stale CP from moving a worker that
 // has already been taken over by a successor.
-func (cs *ConfigStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string) (bool, error) {
+func (cs *ConfigStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (bool, error) {
 	drainableStates := []WorkerState{
 		WorkerStateSpawning,
 		WorkerStateIdle,
@@ -1379,7 +1430,7 @@ func (cs *ConfigStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string
 		WorkerStateHotIdle,
 	}
 	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND owner_cp_instance_id = ? AND state IN ?", workerID, ownerCPInstanceID, drainableStates).
+		Where("worker_id = ? AND owner_cp_instance_id = ? AND owner_epoch = ? AND state IN ?", workerID, ownerCPInstanceID, expectedOwnerEpoch, drainableStates).
 		Updates(map[string]any{
 			"state":      WorkerStateDraining,
 			"updated_at": time.Now(),
@@ -1393,9 +1444,9 @@ func (cs *ConfigStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string
 // RetireDrainingWorker atomically transitions a draining worker to retired.
 // Returns true if the transition happened, false if the worker was no longer
 // in draining (e.g. already retired by an orphan sweep after a CP restart).
-func (cs *ConfigStore) RetireDrainingWorker(workerID int, reason string) (bool, error) {
+func (cs *ConfigStore) RetireDrainingWorker(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error) {
 	result := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("worker_id = ? AND state = ?", workerID, WorkerStateDraining).
+		Where("worker_id = ? AND owner_cp_instance_id = ? AND owner_epoch = ? AND state = ?", workerID, ownerCPInstanceID, expectedOwnerEpoch, WorkerStateDraining).
 		Updates(map[string]any{
 			"state":         WorkerStateRetired,
 			"retire_reason": reason,
@@ -1784,16 +1835,7 @@ func (cs *ConfigStore) ExpireFlightSessionRecords(before time.Time) (int64, erro
 
 func (cs *ConfigStore) countActiveWorkers(tx *gorm.DB, where ...any) (int64, error) {
 	var count int64
-	activeStates := []WorkerState{
-		WorkerStateSpawning,
-		WorkerStateIdle,
-		WorkerStateReserved,
-		WorkerStateActivating,
-		WorkerStateHot,
-		WorkerStateHotIdle,
-		WorkerStateDraining,
-	}
-	query := tx.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).Where("state IN ?", activeStates)
+	query := tx.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).Where("state IN ?", workerActiveStates())
 	if len(where) > 0 {
 		if clauseStr, ok := where[0].(string); ok {
 			query = query.Where(clauseStr, where[1:]...)
@@ -1803,6 +1845,36 @@ func (cs *ConfigStore) countActiveWorkers(tx *gorm.DB, where ...any) (int64, err
 		return 0, err
 	}
 	return count, nil
+}
+
+func workerActiveStates() []WorkerState {
+	return []WorkerState{
+		WorkerStateSpawning,
+		WorkerStateIdle,
+		WorkerStateReserved,
+		WorkerStateActivating,
+		WorkerStateHot,
+		WorkerStateHotIdle,
+		WorkerStateDraining,
+	}
+}
+
+func workerLostEligibleStates() []WorkerState {
+	return []WorkerState{
+		WorkerStateSpawning,
+		WorkerStateIdle,
+		WorkerStateReserved,
+		WorkerStateActivating,
+		WorkerStateHot,
+		WorkerStateHotIdle,
+	}
+}
+
+func workerTerminalEligibleStates(targetState WorkerState) []WorkerState {
+	if targetState == WorkerStateLost {
+		return workerLostEligibleStates()
+	}
+	return workerActiveStates()
 }
 
 func (cs *ConfigStore) countNeutralWarmWorkers(tx *gorm.DB) (int64, error) {

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1859,6 +1859,12 @@ func workerActiveStates() []WorkerState {
 	}
 }
 
+// workerLostEligibleStates lists the worker states from which a worker may be
+// moved to `lost`. `draining` is intentionally excluded: a draining row is
+// already mid-shutdown under an owning CP's CAS chain, and the right terminal
+// for it is `retired` via RetireDrainingWorker (or the orphan sweep if its CP
+// died). Calling MarkWorkerTerminalIfCurrent with target=lost on a draining
+// snapshot is therefore a silent no-op by design.
 func workerLostEligibleStates() []WorkerState {
 	return []WorkerState{
 		WorkerStateSpawning,

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -21,7 +21,7 @@ type controlPlaneExpiryStore interface {
 	ListStuckWorkers(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerRecord, error)
 	ExpireFlightSessionRecords(before time.Time) (int64, error)
 	ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error)
-	RetireHotIdleWorker(workerID int) (bool, error)
+	RetireHotIdleWorker(record *configstore.WorkerRecord) (bool, error)
 }
 
 type warmCapacityMissBucketPruner interface {
@@ -42,6 +42,7 @@ type ControlPlaneJanitor struct {
 	retireWorker                  func(record configstore.WorkerRecord, reason string)
 	retireOrphanWorker            func(record configstore.WorkerRecord, reason string) // orphan-cleanup variant: handles any active state, skips local-pool bookkeeping
 	retireLocalWorker             func(workerID int, reason string) bool               // retires from in-memory pool + pod, returns false if not local
+	deleteRetiredWorker           func(record configstore.WorkerRecord, reason string) // post-CAS cleanup: only remove local state / delete pod
 	reconcileWarmCapacity         func()
 	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
@@ -148,13 +149,17 @@ func (j *ControlPlaneJanitor) runOnce() {
 			// Atomically transition from hot_idle to retired in the DB.
 			// If the worker was concurrently reclaimed (no longer hot_idle),
 			// the conditional update returns false and we skip retirement.
-			retired, err := j.store.RetireHotIdleWorker(record.WorkerID)
+			retired, err := j.store.RetireHotIdleWorker(&record)
 			if err != nil {
 				slog.Warn("Janitor failed to retire hot-idle worker.", "worker_id", record.WorkerID, "error", err)
 				continue
 			}
 			if !retired {
 				continue // Worker was reclaimed concurrently
+			}
+			if j.deleteRetiredWorker != nil {
+				j.deleteRetiredWorker(record, "hot_idle_ttl_expired")
+				continue
 			}
 			// Try local retire first (removes from in-memory pool + deletes pod).
 			// Falls back to remote retire if the worker isn't in our local pool.

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -23,8 +23,8 @@ type captureControlPlaneExpiryStore struct {
 	stuckWorkers           []configstore.WorkerRecord
 	expiredSessionsBefore  []time.Time
 	expiredHotIdleWorkers  []configstore.WorkerRecord
+	retireHotIdleCurrent   map[int]*configstore.WorkerRecord
 	retireHotIdleRecords   []configstore.WorkerRecord
-	retireHotIdleMisses    map[int]bool
 	pruneMissBucketsBefore []time.Time
 	prunedMissBucketCount  int64
 	pruneMissBucketErr     error
@@ -95,10 +95,24 @@ func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(record *configstore
 	if record == nil || record.State != configstore.WorkerStateHotIdle {
 		return false, nil
 	}
-	if s.retireHotIdleMisses[record.WorkerID] {
+	current := s.retireHotIdleCurrent[record.WorkerID]
+	if current == nil || !janitorObservedWorkerRecordMatchesCurrent(record, current) || current.State != configstore.WorkerStateHotIdle {
 		return false, nil
 	}
+	current.State = configstore.WorkerStateRetired
+	current.RetireReason = "hot_idle_ttl_expired"
+	current.UpdatedAt = time.Now()
 	return true, nil
+}
+
+func janitorObservedWorkerRecordMatchesCurrent(observed, current *configstore.WorkerRecord) bool {
+	if observed == nil || current == nil {
+		return false
+	}
+	return current.State == observed.State &&
+		current.OwnerCPInstanceID == observed.OwnerCPInstanceID &&
+		current.OwnerEpoch == observed.OwnerEpoch &&
+		(observed.UpdatedAt.IsZero() || !current.UpdatedAt.After(observed.UpdatedAt))
 }
 
 func (s *captureControlPlaneExpiryStore) PruneWarmCapacityMissBuckets(before time.Time) (int64, error) {
@@ -255,12 +269,20 @@ func TestControlPlaneJanitorRunReconcilesWarmCapacity(t *testing.T) {
 }
 
 func TestControlPlaneJanitorDeletesHotIdlePodAfterStoreRetire(t *testing.T) {
-	store := &captureControlPlaneExpiryStore{
-		expiredHotIdleWorkers: []configstore.WorkerRecord{
-			{WorkerID: 11, PodName: "duckgres-worker-11", State: configstore.WorkerStateHotIdle},
-		},
-	}
 	now := time.Date(2026, time.May, 22, 14, 0, 0, 0, time.UTC)
+	listed := configstore.WorkerRecord{
+		WorkerID:          11,
+		PodName:           "duckgres-worker-11",
+		State:             configstore.WorkerStateHotIdle,
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		UpdatedAt:         now.Add(-2 * time.Minute),
+	}
+	current := listed
+	store := &captureControlPlaneExpiryStore{
+		expiredHotIdleWorkers: []configstore.WorkerRecord{listed},
+		retireHotIdleCurrent:  map[int]*configstore.WorkerRecord{11: &current},
+	}
 	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
 	janitor.now = func() time.Time { return now }
 	janitor.hotIdleTTL = time.Minute
@@ -295,13 +317,21 @@ func TestControlPlaneJanitorDeletesHotIdlePodAfterStoreRetire(t *testing.T) {
 }
 
 func TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterStoreMiss(t *testing.T) {
-	store := &captureControlPlaneExpiryStore{
-		expiredHotIdleWorkers: []configstore.WorkerRecord{
-			{WorkerID: 12, PodName: "duckgres-worker-12", State: configstore.WorkerStateHotIdle},
-		},
-		retireHotIdleMisses: map[int]bool{12: true},
-	}
 	now := time.Date(2026, time.May, 22, 14, 5, 0, 0, time.UTC)
+	listed := configstore.WorkerRecord{
+		WorkerID:          12,
+		PodName:           "duckgres-worker-12",
+		State:             configstore.WorkerStateHotIdle,
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		UpdatedAt:         now.Add(-2 * time.Minute),
+	}
+	current := listed
+	current.UpdatedAt = listed.UpdatedAt.Add(time.Second)
+	store := &captureControlPlaneExpiryStore{
+		expiredHotIdleWorkers: []configstore.WorkerRecord{listed},
+		retireHotIdleCurrent:  map[int]*configstore.WorkerRecord{12: &current},
+	}
 	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
 	janitor.now = func() time.Time { return now }
 	janitor.hotIdleTTL = time.Minute

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -22,6 +22,9 @@ type captureControlPlaneExpiryStore struct {
 	stuckActivatingBefore  []time.Time
 	stuckWorkers           []configstore.WorkerRecord
 	expiredSessionsBefore  []time.Time
+	expiredHotIdleWorkers  []configstore.WorkerRecord
+	retireHotIdleRecords   []configstore.WorkerRecord
+	retireHotIdleMisses    map[int]bool
 	pruneMissBucketsBefore []time.Time
 	prunedMissBucketCount  int64
 	pruneMissBucketErr     error
@@ -78,12 +81,23 @@ func (s *captureControlPlaneExpiryStore) ExpireFlightSessionRecords(before time.
 func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return nil, nil
+	out := make([]configstore.WorkerRecord, len(s.expiredHotIdleWorkers))
+	copy(out, s.expiredHotIdleWorkers)
+	return out, nil
 }
 
-func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(workerID int) (bool, error) {
+func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(record *configstore.WorkerRecord) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if record != nil {
+		s.retireHotIdleRecords = append(s.retireHotIdleRecords, *record)
+	}
+	if record == nil || record.State != configstore.WorkerStateHotIdle {
+		return false, nil
+	}
+	if s.retireHotIdleMisses[record.WorkerID] {
+		return false, nil
+	}
 	return true, nil
 }
 
@@ -237,6 +251,73 @@ func TestControlPlaneJanitorRunReconcilesWarmCapacity(t *testing.T) {
 	defer mu.Unlock()
 	if calls != 1 {
 		t.Fatalf("expected janitor to reconcile warm capacity exactly once, got %d", calls)
+	}
+}
+
+func TestControlPlaneJanitorDeletesHotIdlePodAfterStoreRetire(t *testing.T) {
+	store := &captureControlPlaneExpiryStore{
+		expiredHotIdleWorkers: []configstore.WorkerRecord{
+			{WorkerID: 11, PodName: "duckgres-worker-11", State: configstore.WorkerStateHotIdle},
+		},
+	}
+	now := time.Date(2026, time.May, 22, 14, 0, 0, 0, time.UTC)
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.now = func() time.Time { return now }
+	janitor.hotIdleTTL = time.Minute
+
+	var mu sync.Mutex
+	var deleted []struct {
+		id     int
+		reason string
+	}
+	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
+		mu.Lock()
+		defer mu.Unlock()
+		deleted = append(deleted, struct {
+			id     int
+			reason string
+		}{id: record.WorkerID, reason: reason})
+	}
+	janitor.retireWorker = func(record configstore.WorkerRecord, reason string) {
+		t.Fatalf("hot-idle post-CAS cleanup must not call the CAS-owning retireWorker callback: worker=%d reason=%s", record.WorkerID, reason)
+	}
+
+	janitor.runOnce()
+
+	if len(store.retireHotIdleRecords) != 1 || store.retireHotIdleRecords[0].WorkerID != 11 {
+		t.Fatalf("expected one RetireHotIdleWorker call for worker 11, got %#v", store.retireHotIdleRecords)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 1 || deleted[0].id != 11 || deleted[0].reason != "hot_idle_ttl_expired" {
+		t.Fatalf("expected post-CAS delete for hot-idle worker 11, got %#v", deleted)
+	}
+}
+
+func TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterStoreMiss(t *testing.T) {
+	store := &captureControlPlaneExpiryStore{
+		expiredHotIdleWorkers: []configstore.WorkerRecord{
+			{WorkerID: 12, PodName: "duckgres-worker-12", State: configstore.WorkerStateHotIdle},
+		},
+		retireHotIdleMisses: map[int]bool{12: true},
+	}
+	now := time.Date(2026, time.May, 22, 14, 5, 0, 0, time.UTC)
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.now = func() time.Time { return now }
+	janitor.hotIdleTTL = time.Minute
+
+	var deleted []int
+	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
+		deleted = append(deleted, record.WorkerID)
+	}
+
+	janitor.runOnce()
+
+	if len(store.retireHotIdleRecords) != 1 || store.retireHotIdleRecords[0].WorkerID != 12 {
+		t.Fatalf("expected one RetireHotIdleWorker call for worker 12, got %#v", store.retireHotIdleRecords)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("expected no pod delete after hot-idle CAS miss, got %#v", deleted)
 	}
 }
 

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1738,10 +1738,19 @@ func (p *K8sWorkerPool) retireCurrentRuntimeWorker(claimed *configstore.WorkerRe
 	}
 	current := claimed
 	if p.runtimeStore != nil {
-		if refreshed, err := p.runtimeStore.GetWorkerRecord(claimed.WorkerID); err != nil {
+		refreshed, err := p.runtimeStore.GetWorkerRecord(claimed.WorkerID)
+		switch {
+		case err != nil:
 			slog.Warn("Failed to refresh worker runtime row before retirement.",
 				"worker_id", claimed.WorkerID, "reason", reason, "error", err)
-		} else if refreshed != nil {
+		case refreshed == nil:
+			// Row was hard-deleted or never existed — no CAS target. The
+			// downstream CAS would miss anyway; skip the wasted round-trip
+			// and the pod delete (no row to authorize cleanup against).
+			slog.Debug("Worker runtime row missing before retirement; skipping cleanup.",
+				"worker_id", claimed.WorkerID, "reason", reason)
+			return
+		default:
 			if refreshed.OwnerCPInstanceID != claimed.OwnerCPInstanceID || refreshed.OwnerEpoch != claimed.OwnerEpoch {
 				slog.Debug("Worker ownership changed before retirement; skipping cleanup.",
 					"worker_id", claimed.WorkerID, "reason", reason)
@@ -3041,6 +3050,14 @@ func (p *K8sWorkerPool) persistWorkerRecord(record *configstore.WorkerRecord) {
 		return
 	}
 	if err := p.runtimeStore.UpsertWorkerRecord(record); err != nil {
+		// Fence misses are expected when a peer CP has already advanced the
+		// worker's lease (terminal state, newer owner_epoch, or different
+		// owner at the same epoch). They prove the fence is doing its job —
+		// log at Debug so they don't masquerade as persistence failures.
+		if stderrors.Is(err, configstore.ErrWorkerRecordUpsertFenceMiss) {
+			slog.Debug("Worker runtime upsert fenced by newer lease.", "worker_id", record.WorkerID, "state", record.State, "error", err)
+			return
+		}
 		slog.Warn("Persisting worker runtime record failed.", "worker_id", record.WorkerID, "state", record.State, "error", err)
 	}
 }

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -305,7 +305,10 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 			continue
 		}
 
-		retired, err := p.runtimeStore.RetireIdleOrHotIdleWorker(workerID, RetireReasonMismatchedVersion)
+		if record == nil {
+			continue
+		}
+		retired, err := p.runtimeStore.RetireIdleOrHotIdleWorker(record, RetireReasonMismatchedVersion)
 		if err != nil {
 			slog.Warn("Version-aware reaper failed to retire idle row.", "worker_id", workerID, "error", err)
 			continue
@@ -1356,9 +1359,13 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 			// Try reclaiming a hot-idle worker for the same org first (fast path:
 			// DuckLake is already attached, only needs epoch bump).
 			if assignment.OrgID != "" {
-				hotClaimed, _, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID)
+				hotClaimed, hotMissReason, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID, assignment.MaxWorkers)
 				if err != nil {
 					return nil, err
+				}
+				if hotClaimed == nil && hotMissReason != configstore.WorkerClaimMissReasonNone && hotMissReason != configstore.WorkerClaimMissReasonNoIdle {
+					p.recordWarmCapacityMiss(assignment, hotMissReason)
+					return nil, NewWarmCapacityExhaustedErrorForReason(hotMissReason, DefaultWarmCapacityRetryAfter)
 				}
 				if hotClaimed != nil {
 					// Check if image matches (hot-idle reclamation is strict on version)
@@ -1725,24 +1732,85 @@ func (p *K8sWorkerPool) connectWorkerWithHealthCheck(ctx context.Context, podNam
 	return client, nil
 }
 
-func (p *K8sWorkerPool) retireClaimedWorker(claimed *configstore.WorkerRecord, reason string) {
+func (p *K8sWorkerPool) retireCurrentRuntimeWorker(claimed *configstore.WorkerRecord, reason string) {
+	if claimed == nil {
+		return
+	}
+	current := claimed
 	if p.runtimeStore != nil {
-		// Mark retired in DB immediately so the next capacity check doesn't
-		// count this slot.
-		_, _ = p.runtimeStore.RetireIdleOrHotIdleWorker(claimed.WorkerID, reason)
+		if refreshed, err := p.runtimeStore.GetWorkerRecord(claimed.WorkerID); err != nil {
+			slog.Warn("Failed to refresh worker runtime row before retirement.",
+				"worker_id", claimed.WorkerID, "reason", reason, "error", err)
+		} else if refreshed != nil {
+			if refreshed.OwnerCPInstanceID != claimed.OwnerCPInstanceID || refreshed.OwnerEpoch != claimed.OwnerEpoch {
+				slog.Debug("Worker ownership changed before retirement; skipping cleanup.",
+					"worker_id", claimed.WorkerID, "reason", reason)
+				return
+			}
+			current = refreshed
+		}
+	}
+	p.retireClaimedWorker(current, reason)
+}
+
+func (p *K8sWorkerPool) retireClaimedWorker(claimed *configstore.WorkerRecord, reason string) {
+	if claimed == nil {
+		return
+	}
+	terminalState := configstore.WorkerStateRetired
+	if reason == RetireReasonCrash {
+		terminalState = configstore.WorkerStateLost
+	}
+	if p.runtimeStore != nil {
+		updated, err := p.runtimeStore.MarkWorkerTerminalIfCurrent(claimed, terminalState, reason)
+		if err != nil {
+			slog.Warn("Failed to retire claimed worker.",
+				"worker_id", claimed.WorkerID, "reason", reason, "error", err)
+			return
+		}
+		if !updated {
+			slog.Debug("Claimed worker changed before retirement; skipping pod delete.",
+				"worker_id", claimed.WorkerID, "reason", reason)
+			return
+		}
+	}
+
+	p.deleteRetiredRuntimeWorker(claimed, reason)
+}
+
+// deleteRetiredRuntimeWorker performs the post-CAS cleanup for a worker whose
+// runtime-store row is already terminal. It intentionally avoids another DB
+// transition so janitor paths can retire once, then reliably remove local state
+// and delete the pod.
+func (p *K8sWorkerPool) deleteRetiredRuntimeWorker(record *configstore.WorkerRecord, reason string) {
+	if record == nil {
+		return
 	}
 
 	worker := &ManagedWorker{
-		ID:      claimed.WorkerID,
-		podName: claimed.PodName,
+		ID:      record.WorkerID,
+		podName: record.PodName,
 		done:    make(chan struct{}),
 	}
-	worker.SetOwnerCPInstanceID(claimed.OwnerCPInstanceID)
-	worker.SetOwnerEpoch(claimed.OwnerEpoch)
+	worker.SetOwnerCPInstanceID(record.OwnerCPInstanceID)
+	worker.SetOwnerEpoch(record.OwnerEpoch)
+
+	removedLocal := false
+	workerCount := 0
 	p.mu.Lock()
-	p.markWorkerRetiredLocked(worker, reason)
+	if local, ok := p.workers[record.WorkerID]; ok {
+		worker = local
+		p.markWorkerRetiredInMemoryLocked(worker, reason)
+		delete(p.workers, record.WorkerID)
+		workerCount = len(p.workers)
+		removedLocal = true
+	}
 	p.mu.Unlock()
-	go p.retireWorkerPod(worker.ID, worker)
+	if removedLocal {
+		observeControlPlaneWorkers(workerCount)
+	}
+
+	go p.retireWorkerPod(record.WorkerID, worker)
 }
 
 // retireOrphanWorker retires a worker the orphan janitor has identified
@@ -1756,9 +1824,15 @@ func (p *K8sWorkerPool) retireOrphanWorker(record *configstore.WorkerRecord, rea
 	if p.runtimeStore == nil || record == nil {
 		return
 	}
-	if _, err := p.runtimeStore.RetireOrphanWorker(record.WorkerID, reason); err != nil {
+	retired, err := p.runtimeStore.RetireOrphanWorker(record, reason)
+	if err != nil {
 		slog.Warn("Failed to retire orphan worker.",
 			"worker_id", record.WorkerID, "reason", reason, "error", err)
+		return
+	}
+	if !retired {
+		slog.Debug("Orphan worker changed before retirement; skipping pod delete.",
+			"worker_id", record.WorkerID, "reason", reason)
 		return
 	}
 	worker := &ManagedWorker{
@@ -1812,7 +1886,7 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 				// Retire already-claimed slots so they don't strand
 				// as durable spawning rows with no pod behind them.
 				for _, s := range slots {
-					p.retireClaimedWorker(s, RetireReasonCrash)
+					p.retireCurrentRuntimeWorker(s, RetireReasonCrash)
 				}
 				return err
 			}
@@ -1847,7 +1921,7 @@ func (p *K8sWorkerPool) SpawnMinWorkers(count int) error {
 				p.mu.Unlock()
 
 				if err != nil {
-					p.retireClaimedWorker(slot, RetireReasonCrash)
+					p.retireCurrentRuntimeWorker(slot, RetireReasonCrash)
 					errs[i] = err
 				}
 			}(i, slot)
@@ -1977,7 +2051,7 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 		if err != nil {
 			observeWarmCapacityReconcileSpawns(warmCapacityImageScope(image), "error", len(slots))
 			for _, s := range slots {
-				p.retireClaimedWorker(s, RetireReasonCrash)
+				p.retireCurrentRuntimeWorker(s, RetireReasonCrash)
 			}
 			return err
 		}
@@ -2011,7 +2085,7 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 			p.mu.Unlock()
 
 			if err != nil {
-				p.retireClaimedWorker(slot, RetireReasonCrash)
+				p.retireCurrentRuntimeWorker(slot, RetireReasonCrash)
 				errs[i] = err
 			}
 		}(i, slot)
@@ -2287,7 +2361,7 @@ func (p *K8sWorkerPool) ShutdownAll() {
 		// Step 1: CAS to draining. Skip the worker on CAS miss or error —
 		// there's no safe way to proceed if we don't own the row.
 		if p.runtimeStore != nil {
-			transitioned, err := p.runtimeStore.MarkWorkerDraining(w.ID, p.cpInstanceID)
+			transitioned, err := p.runtimeStore.MarkWorkerDraining(w.ID, p.cpInstanceID, w.OwnerEpoch())
 			if err != nil {
 				slog.Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
 					"worker_id", w.ID, "error", err)
@@ -2319,7 +2393,7 @@ func (p *K8sWorkerPool) ShutdownAll() {
 		// shutdown) the row stays in draining and the orphan sweep handles
 		// it once this CP's heartbeat expires.
 		if p.runtimeStore != nil {
-			if _, err := p.runtimeStore.RetireDrainingWorker(w.ID, RetireReasonShutdown); err != nil {
+			if _, err := p.runtimeStore.RetireDrainingWorker(w.ID, p.cpInstanceID, w.OwnerEpoch(), RetireReasonShutdown); err != nil {
 				slog.Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile.",
 					"worker_id", w.ID, "error", err)
 				continue

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -329,14 +329,13 @@ func (s *captureRuntimeWorkerStore) RetireIdleWorker(record *configstore.WorkerR
 	if record.State != configstore.WorkerStateIdle {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
-		if !observedWorkerRecordMatchesCurrent(record, rec) {
-			return false, nil
-		}
-		rec.State = configstore.WorkerStateRetired
-		rec.RetireReason = reason
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[record.WorkerID]
+	if rec == nil || !observedWorkerRecordMatchesCurrent(record, rec) {
+		return false, nil
 	}
+	rec.State = configstore.WorkerStateRetired
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
 	return true, nil
 }
 
@@ -358,14 +357,13 @@ func (s *captureRuntimeWorkerStore) RetireIdleOrHotIdleWorker(record *configstor
 	if record.State != configstore.WorkerStateIdle && record.State != configstore.WorkerStateHotIdle {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
-		if !observedWorkerRecordMatchesCurrent(record, rec) {
-			return false, nil
-		}
-		rec.State = configstore.WorkerStateRetired
-		rec.RetireReason = reason
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[record.WorkerID]
+	if rec == nil || !observedWorkerRecordMatchesCurrent(record, rec) {
+		return false, nil
 	}
+	rec.State = configstore.WorkerStateRetired
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
 	return true, nil
 }
 
@@ -384,14 +382,13 @@ func (s *captureRuntimeWorkerStore) RetireOrphanWorker(record *configstore.Worke
 	if !terminalEligibleState(configstore.WorkerStateRetired, record.State) {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
-		if !observedWorkerRecordMatchesCurrent(record, rec) {
-			return false, nil
-		}
-		rec.State = configstore.WorkerStateRetired
-		rec.RetireReason = reason
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[record.WorkerID]
+	if rec == nil || !observedWorkerRecordMatchesCurrent(record, rec) {
+		return false, nil
 	}
+	rec.State = configstore.WorkerStateRetired
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
 	return true, nil
 }
 
@@ -411,18 +408,15 @@ func (s *captureRuntimeWorkerStore) MarkWorkerTerminalIfCurrent(record *configst
 	if s.markTerminalMisses[record.WorkerID] {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
-		if rec.State != record.State ||
-			rec.OwnerCPInstanceID != record.OwnerCPInstanceID ||
-			rec.OwnerEpoch != record.OwnerEpoch ||
-			(!record.UpdatedAt.IsZero() && rec.UpdatedAt.After(record.UpdatedAt)) ||
-			!terminalEligibleState(targetState, rec.State) {
-			return false, nil
-		}
-		rec.State = targetState
-		rec.RetireReason = reason
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[record.WorkerID]
+	if rec == nil ||
+		!observedWorkerRecordMatchesCurrent(record, rec) ||
+		!terminalEligibleState(targetState, rec.State) {
+		return false, nil
 	}
+	rec.State = targetState
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
 	return true, nil
 }
 
@@ -527,13 +521,12 @@ func (s *captureRuntimeWorkerStore) MarkWorkerDraining(workerID int, ownerCPInst
 	if s.markDrainingMisses[workerID] {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[workerID]; rec != nil {
-		if rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || !drainingEligibleState(rec.State) {
-			return false, nil
-		}
-		rec.State = configstore.WorkerStateDraining
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[workerID]
+	if rec == nil || rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || !drainingEligibleState(rec.State) {
+		return false, nil
 	}
+	rec.State = configstore.WorkerStateDraining
+	rec.UpdatedAt = time.Now()
 	s.recordEvent(fmt.Sprintf("draining:%d", workerID))
 	return true, nil
 }
@@ -552,14 +545,13 @@ func (s *captureRuntimeWorkerStore) RetireDrainingWorker(workerID int, ownerCPIn
 	if s.retireDrainingMisses[workerID] {
 		return false, nil
 	}
-	if rec := s.preloadedRecords[workerID]; rec != nil {
-		if rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || rec.State != configstore.WorkerStateDraining {
-			return false, nil
-		}
-		rec.State = configstore.WorkerStateRetired
-		rec.RetireReason = reason
-		rec.UpdatedAt = time.Now()
+	rec := s.preloadedRecords[workerID]
+	if rec == nil || rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || rec.State != configstore.WorkerStateDraining {
+		return false, nil
 	}
+	rec.State = configstore.WorkerStateRetired
+	rec.RetireReason = reason
+	rec.UpdatedAt = time.Now()
 	s.recordEvent(fmt.Sprintf("retired:%d", workerID))
 	return true, nil
 }
@@ -2252,6 +2244,16 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 			Image:             "duckgres:v1",
 			OwnerCPInstanceID: pool.cpInstanceID,
 			OwnerEpoch:        2,
+		},
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			7: {
+				WorkerID:          7,
+				PodName:           w.podName,
+				State:             configstore.WorkerStateReserved,
+				Image:             "duckgres:v1",
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        2,
+			},
 		},
 	}
 	pool.runtimeStore = store

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -68,6 +68,7 @@ type captureRuntimeWorkerStore struct {
 	hotIdleClaimMissReason           configstore.WorkerClaimMissReason
 	hotIdleClaimCPID                 string
 	hotIdleClaimOrgID                string
+	hotIdleClaimMaxOrgWorkers        int
 	recordMissCalls                  int
 	recordMissScopes                 []string
 	recordMissReasons                []configstore.WorkerClaimMissReason
@@ -92,6 +93,12 @@ type captureRuntimeWorkerStore struct {
 	retireOrphanCalledIDs            []int
 	retireOrphanCalledReasons        []string
 	retireOrphanErr                  error
+	markTerminalCalls                int
+	markTerminalCalledIDs            []int
+	markTerminalStates               []configstore.WorkerState
+	markTerminalReasons              []string
+	markTerminalErr                  error
+	markTerminalMisses               map[int]bool
 	markLostCalls                    int
 	markLostCalledIDs                []int
 	markLostCalledCPs                []string
@@ -104,10 +111,13 @@ type captureRuntimeWorkerStore struct {
 	markDrainingCalls                int
 	markDrainingCalledIDs            []int
 	markDrainingCalledCPs            []string
+	markDrainingCalledEpochs         []int64
 	markDrainingMisses               map[int]bool
 	markDrainingErr                  error
 	retireDrainingCalls              int
 	retireDrainingCalledIDs          []int
+	retireDrainingCalledCPs          []string
+	retireDrainingCalledEpochs       []int64
 	retireDrainingReasons            []string
 	retireDrainingMisses             map[int]bool
 	retireDrainingErr                error
@@ -155,11 +165,12 @@ func (s *captureRuntimeWorkerStore) ClaimIdleWorker(ownerCPInstanceID, orgID, im
 	return &claimed, configstore.WorkerClaimMissReasonNone, nil
 }
 
-func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error) {
+func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.hotIdleClaimCPID = ownerCPInstanceID
 	s.hotIdleClaimOrgID = orgID
+	s.hotIdleClaimMaxOrgWorkers = maxOrgWorkers
 	if s.hotIdleClaimResult != nil {
 		r := *s.hotIdleClaimResult
 		return &r, configstore.WorkerClaimMissReasonNone, nil
@@ -300,49 +311,168 @@ func (s *captureRuntimeWorkerStore) TakeOverWorker(workerID int, ownerCPInstance
 	return &record, nil
 }
 
-func (s *captureRuntimeWorkerStore) RetireIdleWorker(workerID int, reason string) (bool, error) {
+func (s *captureRuntimeWorkerStore) RetireIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if record == nil {
+		return false, nil
+	}
 	s.retireIdleCalls++
-	s.retireIdleCalledIDs = append(s.retireIdleCalledIDs, workerID)
+	s.retireIdleCalledIDs = append(s.retireIdleCalledIDs, record.WorkerID)
 	s.retireIdleCalledReasons = append(s.retireIdleCalledReasons, reason)
 	if s.retireIdleErr != nil {
 		return false, s.retireIdleErr
 	}
-	if s.retireIdleMisses[workerID] {
+	if s.retireIdleMisses[record.WorkerID] {
 		return false, nil
+	}
+	if record.State != configstore.WorkerStateIdle {
+		return false, nil
+	}
+	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
+		if !observedWorkerRecordMatchesCurrent(record, rec) {
+			return false, nil
+		}
+		rec.State = configstore.WorkerStateRetired
+		rec.RetireReason = reason
+		rec.UpdatedAt = time.Now()
 	}
 	return true, nil
 }
 
-func (s *captureRuntimeWorkerStore) RetireIdleOrHotIdleWorker(workerID int, reason string) (bool, error) {
+func (s *captureRuntimeWorkerStore) RetireIdleOrHotIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if record == nil {
+		return false, nil
+	}
 	s.retireIdleOrHotIdleCalls++
-	s.retireIdleOrHotIdleCalledIDs = append(s.retireIdleOrHotIdleCalledIDs, workerID)
+	s.retireIdleOrHotIdleCalledIDs = append(s.retireIdleOrHotIdleCalledIDs, record.WorkerID)
 	s.retireIdleOrHotIdleCalledReasons = append(s.retireIdleOrHotIdleCalledReasons, reason)
 	if s.retireIdleOrHotIdleErr != nil {
 		return false, s.retireIdleOrHotIdleErr
 	}
-	if s.retireIdleOrHotIdleMisses[workerID] {
+	if s.retireIdleOrHotIdleMisses[record.WorkerID] {
 		return false, nil
+	}
+	if record.State != configstore.WorkerStateIdle && record.State != configstore.WorkerStateHotIdle {
+		return false, nil
+	}
+	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
+		if !observedWorkerRecordMatchesCurrent(record, rec) {
+			return false, nil
+		}
+		rec.State = configstore.WorkerStateRetired
+		rec.RetireReason = reason
+		rec.UpdatedAt = time.Now()
 	}
 	return true, nil
 }
 
-func (s *captureRuntimeWorkerStore) RetireOrphanWorker(workerID int, reason string) (bool, error) {
+func (s *captureRuntimeWorkerStore) RetireOrphanWorker(record *configstore.WorkerRecord, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if record == nil {
+		return false, nil
+	}
 	s.retireOrphanCalls++
-	s.retireOrphanCalledIDs = append(s.retireOrphanCalledIDs, workerID)
+	s.retireOrphanCalledIDs = append(s.retireOrphanCalledIDs, record.WorkerID)
 	s.retireOrphanCalledReasons = append(s.retireOrphanCalledReasons, reason)
 	if s.retireOrphanErr != nil {
 		return false, s.retireOrphanErr
+	}
+	if !terminalEligibleState(configstore.WorkerStateRetired, record.State) {
+		return false, nil
+	}
+	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
+		if !observedWorkerRecordMatchesCurrent(record, rec) {
+			return false, nil
+		}
+		rec.State = configstore.WorkerStateRetired
+		rec.RetireReason = reason
+		rec.UpdatedAt = time.Now()
+	}
+	return true, nil
+}
+
+func (s *captureRuntimeWorkerStore) MarkWorkerTerminalIfCurrent(record *configstore.WorkerRecord, targetState configstore.WorkerState, reason string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if record == nil {
+		return false, nil
+	}
+	s.markTerminalCalls++
+	s.markTerminalCalledIDs = append(s.markTerminalCalledIDs, record.WorkerID)
+	s.markTerminalStates = append(s.markTerminalStates, targetState)
+	s.markTerminalReasons = append(s.markTerminalReasons, reason)
+	if s.markTerminalErr != nil {
+		return false, s.markTerminalErr
+	}
+	if s.markTerminalMisses[record.WorkerID] {
+		return false, nil
+	}
+	if rec := s.preloadedRecords[record.WorkerID]; rec != nil {
+		if rec.State != record.State ||
+			rec.OwnerCPInstanceID != record.OwnerCPInstanceID ||
+			rec.OwnerEpoch != record.OwnerEpoch ||
+			(!record.UpdatedAt.IsZero() && rec.UpdatedAt.After(record.UpdatedAt)) ||
+			!terminalEligibleState(targetState, rec.State) {
+			return false, nil
+		}
+		rec.State = targetState
+		rec.RetireReason = reason
+		rec.UpdatedAt = time.Now()
 	}
 	return true, nil
 }
 
 func lostEligibleState(state configstore.WorkerState) bool {
+	switch state {
+	case configstore.WorkerStateSpawning,
+		configstore.WorkerStateIdle,
+		configstore.WorkerStateReserved,
+		configstore.WorkerStateActivating,
+		configstore.WorkerStateHot,
+		configstore.WorkerStateHotIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalEligibleState(targetState configstore.WorkerState, currentState configstore.WorkerState) bool {
+	switch targetState {
+	case configstore.WorkerStateLost:
+		return lostEligibleState(currentState)
+	case configstore.WorkerStateRetired:
+		switch currentState {
+		case configstore.WorkerStateSpawning,
+			configstore.WorkerStateIdle,
+			configstore.WorkerStateReserved,
+			configstore.WorkerStateActivating,
+			configstore.WorkerStateHot,
+			configstore.WorkerStateHotIdle,
+			configstore.WorkerStateDraining:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func observedWorkerRecordMatchesCurrent(observed, current *configstore.WorkerRecord) bool {
+	if observed == nil || current == nil {
+		return false
+	}
+	return current.State == observed.State &&
+		current.OwnerCPInstanceID == observed.OwnerCPInstanceID &&
+		current.OwnerEpoch == observed.OwnerEpoch &&
+		(observed.UpdatedAt.IsZero() || !current.UpdatedAt.After(observed.UpdatedAt))
+}
+
+func drainingEligibleState(state configstore.WorkerState) bool {
 	switch state {
 	case configstore.WorkerStateSpawning,
 		configstore.WorkerStateIdle,
@@ -384,35 +514,53 @@ func (s *captureRuntimeWorkerStore) MarkWorkerLostIfCurrentLease(workerID int, o
 	return true, nil
 }
 
-func (s *captureRuntimeWorkerStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string) (bool, error) {
+func (s *captureRuntimeWorkerStore) MarkWorkerDraining(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.markDrainingCalls++
 	s.markDrainingCalledIDs = append(s.markDrainingCalledIDs, workerID)
 	s.markDrainingCalledCPs = append(s.markDrainingCalledCPs, ownerCPInstanceID)
-	s.recordEvent(fmt.Sprintf("draining:%d", workerID))
+	s.markDrainingCalledEpochs = append(s.markDrainingCalledEpochs, expectedOwnerEpoch)
 	if s.markDrainingErr != nil {
 		return false, s.markDrainingErr
 	}
 	if s.markDrainingMisses[workerID] {
 		return false, nil
 	}
+	if rec := s.preloadedRecords[workerID]; rec != nil {
+		if rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || !drainingEligibleState(rec.State) {
+			return false, nil
+		}
+		rec.State = configstore.WorkerStateDraining
+		rec.UpdatedAt = time.Now()
+	}
+	s.recordEvent(fmt.Sprintf("draining:%d", workerID))
 	return true, nil
 }
 
-func (s *captureRuntimeWorkerStore) RetireDrainingWorker(workerID int, reason string) (bool, error) {
+func (s *captureRuntimeWorkerStore) RetireDrainingWorker(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.retireDrainingCalls++
 	s.retireDrainingCalledIDs = append(s.retireDrainingCalledIDs, workerID)
+	s.retireDrainingCalledCPs = append(s.retireDrainingCalledCPs, ownerCPInstanceID)
+	s.retireDrainingCalledEpochs = append(s.retireDrainingCalledEpochs, expectedOwnerEpoch)
 	s.retireDrainingReasons = append(s.retireDrainingReasons, reason)
-	s.recordEvent(fmt.Sprintf("retired:%d", workerID))
 	if s.retireDrainingErr != nil {
 		return false, s.retireDrainingErr
 	}
 	if s.retireDrainingMisses[workerID] {
 		return false, nil
 	}
+	if rec := s.preloadedRecords[workerID]; rec != nil {
+		if rec.OwnerCPInstanceID != ownerCPInstanceID || rec.OwnerEpoch != expectedOwnerEpoch || rec.State != configstore.WorkerStateDraining {
+			return false, nil
+		}
+		rec.State = configstore.WorkerStateRetired
+		rec.RetireReason = reason
+		rec.UpdatedAt = time.Now()
+	}
+	s.recordEvent(fmt.Sprintf("retired:%d", workerID))
 	return true, nil
 }
 
@@ -439,6 +587,20 @@ func podDeleteActionNames(cs *fake.Clientset) []string {
 		names = append(names, deleteAction.GetName())
 	}
 	return names
+}
+
+func waitForPodDeleteAction(t *testing.T, cs *fake.Clientset, name string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		for _, deletedName := range podDeleteActionNames(cs) {
+			if deletedName == name {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected pod delete action for %q, got %v", name, podDeleteActionNames(cs))
 }
 
 func secretDeleteActionCount(cs *fake.Clientset) int {
@@ -1884,8 +2046,41 @@ func TestK8sPoolReserveSharedWorkerPassesOrgCapToRuntimeClaim(t *testing.T) {
 	if store.claimMaxOrgWorkers != 3 {
 		t.Fatalf("expected claim max org workers 3, got %d", store.claimMaxOrgWorkers)
 	}
+	if store.hotIdleClaimMaxOrgWorkers != 3 {
+		t.Fatalf("expected hot-idle claim max org workers 3, got %d", store.hotIdleClaimMaxOrgWorkers)
+	}
 	if idle.SharedState().Assignment != nil {
 		t.Fatalf("local idle worker should not have been reserved, got assignment %#v", idle.SharedState().Assignment)
+	}
+}
+
+func TestK8sPoolReserveSharedWorkerReturnsOrgCapFromHotIdleClaim(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		hotIdleClaimMissReason: configstore.WorkerClaimMissReasonOrgCap,
+	}
+	pool.runtimeStore = store
+
+	worker, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+		OrgID:      "analytics",
+		MaxWorkers: 1,
+		Image:      "duckgres:v2",
+	})
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
+	}
+	if capacityErr.Reason != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap miss reason, got %q", capacityErr.Reason)
+	}
+	if worker != nil {
+		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
+	}
+	if store.claimCalls != 0 {
+		t.Fatalf("expected hot-idle org cap to skip neutral idle claim, got %d idle claims", store.claimCalls)
+	}
+	if store.recordMissCalls != 0 {
+		t.Fatalf("expected no recorded miss for org-cap, got %d", store.recordMissCalls)
 	}
 }
 
@@ -2026,10 +2221,12 @@ func TestK8sPoolClaimSpecificWorkerRetiresUnhealthyWorker(t *testing.T) {
 }
 
 func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
-	pool, _ := newTestK8sPool(t, 5)
+	pool, cs := newTestK8sPool(t, 5)
 
 	// Setup a hot-idle worker with "v1" image
-	w := &ManagedWorker{ID: 7, done: make(chan struct{})}
+	w := &ManagedWorker{ID: 7, podName: "duckgres-worker-test-cp-7", done: make(chan struct{})}
+	w.SetOwnerCPInstanceID(pool.cpInstanceID)
+	w.SetOwnerEpoch(1)
 	if err := w.SetSharedState(SharedWorkerState{
 		Lifecycle:  WorkerLifecycleHot,
 		Assignment: &WorkerAssignment{OrgID: "analytics", Image: "duckgres:v1"},
@@ -2037,11 +2234,24 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 		t.Fatalf("SetSharedState: %v", err)
 	}
 	pool.workers[7] = w
+	if _, err := cs.CoreV1().Pods(pool.namespace).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      w.podName,
+			Namespace: pool.namespace,
+			Labels:    map[string]string{"app": "duckgres-worker", "duckgres/worker-id": "7"},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
 
 	store := &captureRuntimeWorkerStore{
 		hotIdleClaimResult: &configstore.WorkerRecord{
-			WorkerID: 7,
-			Image:    "duckgres:v1",
+			WorkerID:          7,
+			PodName:           w.podName,
+			State:             configstore.WorkerStateReserved,
+			Image:             "duckgres:v1",
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        2,
 		},
 	}
 	pool.runtimeStore = store
@@ -2063,13 +2273,20 @@ func TestK8sPoolHotIdleMismatchedImageCorrectlyHandled(t *testing.T) {
 		t.Fatalf("expected no worker on capacity miss, got %d", got.ID)
 	}
 
-	// Verify v1 worker was retired
-	if store.retireIdleOrHotIdleCalls != 1 || store.retireIdleOrHotIdleCalledIDs[0] != 7 {
-		t.Fatalf("expected mismatched hot-idle worker 7 to be retired, got calls=%d ids=%v", store.retireIdleOrHotIdleCalls, store.retireIdleOrHotIdleCalledIDs)
+	// Verify v1 worker was retired through the observed-row terminal CAS.
+	if store.markTerminalCalls != 1 || store.markTerminalCalledIDs[0] != 7 {
+		t.Fatalf("expected mismatched hot-idle worker 7 to be retired, got calls=%d ids=%v", store.markTerminalCalls, store.markTerminalCalledIDs)
 	}
-	if store.retireIdleOrHotIdleCalledReasons[0] != RetireReasonMismatchedVersion {
-		t.Fatalf("expected reason %q, got %q", RetireReasonMismatchedVersion, store.retireIdleOrHotIdleCalledReasons[0])
+	if store.markTerminalStates[0] != configstore.WorkerStateRetired {
+		t.Fatalf("expected terminal state retired, got %q", store.markTerminalStates[0])
 	}
+	if store.markTerminalReasons[0] != RetireReasonMismatchedVersion {
+		t.Fatalf("expected reason %q, got %q", RetireReasonMismatchedVersion, store.markTerminalReasons[0])
+	}
+	if _, ok := pool.Worker(7); ok {
+		t.Fatal("expected retired mismatched hot-idle worker to be removed from the local pool")
+	}
+	waitForPodDeleteAction(t, cs, w.podName)
 	if store.spawnCalls != 0 || store.perImageSpawnCalls != 0 {
 		t.Fatalf("did not expect foreground or async spawn, got foreground=%d per_image=%d", store.spawnCalls, store.perImageSpawnCalls)
 	}
@@ -2213,6 +2430,144 @@ func TestK8sPoolSpawnMinWorkersUsesRuntimeSlots(t *testing.T) {
 	}
 	if !spawnedIDs[51] || !spawnedIDs[52] {
 		t.Fatalf("expected worker ids 51 and 52 to be spawned, got %v", spawnedIDs)
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersRetiresRefreshedSlotOnSpawnFailure(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	slotTime := time.Date(2026, time.May, 22, 14, 20, 0, 0, time.UTC)
+	store := &captureRuntimeWorkerStore{
+		neutralSpawned: &configstore.WorkerRecord{
+			WorkerID:          61,
+			PodName:           "duckgres-worker-test-cp-61",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        0,
+			UpdatedAt:         slotTime,
+		},
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			61: {
+				WorkerID:          61,
+				PodName:           "duckgres-worker-test-cp-61",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        0,
+				UpdatedAt:         slotTime,
+			},
+		},
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		store.mu.Lock()
+		store.preloadedRecords[id].UpdatedAt = slotTime.Add(time.Second)
+		store.mu.Unlock()
+		return errors.New("spawn failed after publishing runtime row")
+	}
+
+	if err := pool.SpawnMinWorkers(1); err == nil {
+		t.Fatal("expected SpawnMinWorkers to return the spawn error")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.markTerminalCalls != 1 || store.markTerminalCalledIDs[0] != 61 {
+		t.Fatalf("expected one terminal CAS for worker 61, got calls=%d ids=%v", store.markTerminalCalls, store.markTerminalCalledIDs)
+	}
+	rec := store.preloadedRecords[61]
+	if rec.State != configstore.WorkerStateLost || rec.RetireReason != RetireReasonCrash {
+		t.Fatalf("expected refreshed failed slot to be marked lost/crash, got state=%q reason=%q", rec.State, rec.RetireReason)
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersSkipsRefreshedSlotAfterOwnershipChange(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	slotTime := time.Date(2026, time.May, 22, 14, 22, 0, 0, time.UTC)
+	store := &captureRuntimeWorkerStore{
+		neutralSpawned: &configstore.WorkerRecord{
+			WorkerID:          63,
+			PodName:           "duckgres-worker-test-cp-63",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        0,
+			UpdatedAt:         slotTime,
+		},
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			63: {
+				WorkerID:          63,
+				PodName:           "duckgres-worker-test-cp-63",
+				State:             configstore.WorkerStateReserved,
+				OwnerCPInstanceID: "cp-other:boot-a",
+				OwnerEpoch:        1,
+				UpdatedAt:         slotTime.Add(time.Second),
+			},
+		},
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		return errors.New("spawn failed after ownership changed")
+	}
+
+	if err := pool.SpawnMinWorkers(1); err == nil {
+		t.Fatal("expected SpawnMinWorkers to return the spawn error")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.markTerminalCalls != 0 {
+		t.Fatalf("expected no terminal CAS after ownership changed, got calls=%d ids=%v", store.markTerminalCalls, store.markTerminalCalledIDs)
+	}
+	rec := store.preloadedRecords[63]
+	if rec.State != configstore.WorkerStateReserved || rec.OwnerCPInstanceID != "cp-other:boot-a" || rec.OwnerEpoch != 1 {
+		t.Fatalf("expected changed-owner row to survive, got state=%q owner=%q epoch=%d", rec.State, rec.OwnerCPInstanceID, rec.OwnerEpoch)
+	}
+}
+
+func TestK8sPoolSpawnMinWorkersForImageRetiresRefreshedSlotOnSpawnFailure(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	image := "duckgres:spawn-fail"
+	slotTime := time.Date(2026, time.May, 22, 14, 25, 0, 0, time.UTC)
+	store := &captureRuntimeWorkerStore{
+		perImageSpawned: &configstore.WorkerRecord{
+			WorkerID:          62,
+			PodName:           "duckgres-worker-test-cp-62",
+			State:             configstore.WorkerStateSpawning,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        0,
+			Image:             image,
+			UpdatedAt:         slotTime,
+		},
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			62: {
+				WorkerID:          62,
+				PodName:           "duckgres-worker-test-cp-62",
+				State:             configstore.WorkerStateSpawning,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        0,
+				Image:             image,
+				UpdatedAt:         slotTime,
+			},
+		},
+	}
+	pool.runtimeStore = store
+	pool.spawnWarmWorkerFunc = func(ctx context.Context, id int) error {
+		store.mu.Lock()
+		store.preloadedRecords[id].UpdatedAt = slotTime.Add(time.Second)
+		store.mu.Unlock()
+		return errors.New("image spawn failed after publishing runtime row")
+	}
+
+	if err := pool.SpawnMinWorkersForImage(context.Background(), image, 1); err == nil {
+		t.Fatal("expected SpawnMinWorkersForImage to return the spawn error")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.markTerminalCalls != 1 || store.markTerminalCalledIDs[0] != 62 {
+		t.Fatalf("expected one terminal CAS for worker 62, got calls=%d ids=%v", store.markTerminalCalls, store.markTerminalCalledIDs)
+	}
+	rec := store.preloadedRecords[62]
+	if rec.State != configstore.WorkerStateLost || rec.RetireReason != RetireReasonCrash {
+		t.Fatalf("expected refreshed failed image slot to be marked lost/crash, got state=%q reason=%q", rec.State, rec.RetireReason)
 	}
 }
 
@@ -3511,7 +3866,15 @@ func createMismatchWorkerPodWithImage(t *testing.T, cs *fake.Clientset, name, co
 }
 
 func TestRetireOneMismatchedVersionWorker_RetiresOlderVersionIdleWorker(t *testing.T) {
-	store := &captureRuntimeWorkerStore{}
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			7: {
+				WorkerID: 7,
+				PodName:  "duckgres-oldhash-worker-7",
+				State:    configstore.WorkerStateIdle,
+			},
+		},
+	}
 	pool, cs := mismatchVersionTestPool(t, "duckgres-newhash-aaaaa", store)
 	createMismatchWorkerPod(t, cs, "duckgres-oldhash-worker-7", "duckgres-oldhash-zzzzz", "7")
 
@@ -3533,7 +3896,15 @@ func TestRetireOneMismatchedVersionWorker_RetiresOlderVersionIdleWorker(t *testi
 func TestRetireOneMismatchedVersionWorker_RetiresHotIdleWorker(t *testing.T) {
 	// hot-idle workers have handled a session but are currently idle. They
 	// are safe to reap during a rolling update.
-	store := &captureRuntimeWorkerStore{}
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			9: {
+				WorkerID: 9,
+				PodName:  "duckgres-old-worker-9",
+				State:    configstore.WorkerStateHotIdle,
+			},
+		},
+	}
 	pool, cs := mismatchVersionTestPool(t, "duckgres-new-aaaaa", store)
 	createMismatchWorkerPod(t, cs, "duckgres-old-worker-9", "duckgres-old-zzzzz", "9")
 
@@ -3606,7 +3977,13 @@ func TestRetireOneMismatchedVersionWorker_LeavesSameVersionWorkersAlone(t *testi
 }
 
 func TestRetireOneMismatchedVersionWorker_RetiresOnePerCall(t *testing.T) {
-	store := &captureRuntimeWorkerStore{}
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			10: {WorkerID: 10, PodName: "duckgres-old-worker-10", State: configstore.WorkerStateIdle},
+			11: {WorkerID: 11, PodName: "duckgres-old-worker-11", State: configstore.WorkerStateIdle},
+			12: {WorkerID: 12, PodName: "duckgres-old-worker-12", State: configstore.WorkerStateIdle},
+		},
+	}
 	pool, cs := mismatchVersionTestPool(t, "duckgres-new-aaaaa", store)
 	createMismatchWorkerPod(t, cs, "duckgres-old-worker-10", "duckgres-old-xxxxx", "10")
 	createMismatchWorkerPod(t, cs, "duckgres-old-worker-11", "duckgres-old-yyyyy", "11")
@@ -3632,7 +4009,10 @@ func TestRetireOneMismatchedVersionWorker_SkipsWhenNotIdle(t *testing.T) {
 	// reserved, etc.). The reaper must skip those pods and leave
 	// them running — it will try again on the next tick.
 	store := &captureRuntimeWorkerStore{
-		retireIdleOrHotIdleMisses: map[int]bool{5: true},
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			5: {WorkerID: 5, PodName: "duckgres-old-worker-5", State: configstore.WorkerStateReserved},
+			6: {WorkerID: 6, PodName: "duckgres-old-worker-6", State: configstore.WorkerStateIdle},
+		},
 	}
 	pool, cs := mismatchVersionTestPool(t, "duckgres-new-aaaaa", store)
 	createMismatchWorkerPod(t, cs, "duckgres-old-worker-5", "duckgres-old-zzzzz", "5")
@@ -3925,7 +4305,22 @@ func addShutdownWorker(t *testing.T, p *K8sWorkerPool, cs *fake.Clientset, id in
 		podName: fmt.Sprintf("worker-%d", id),
 		done:    make(chan struct{}),
 	}
+	w.SetOwnerCPInstanceID(p.cpInstanceID)
 	p.workers[id] = w
+	if store, ok := p.runtimeStore.(*captureRuntimeWorkerStore); ok {
+		store.mu.Lock()
+		if store.preloadedRecords == nil {
+			store.preloadedRecords = make(map[int]*configstore.WorkerRecord)
+		}
+		store.preloadedRecords[id] = &configstore.WorkerRecord{
+			WorkerID:          id,
+			PodName:           w.podName,
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: p.cpInstanceID,
+			OwnerEpoch:        w.OwnerEpoch(),
+		}
+		store.mu.Unlock()
+	}
 	_, err := cs.CoreV1().Pods(p.namespace).Create(context.Background(), &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      w.podName,
@@ -4022,6 +4417,35 @@ func TestShutdownAll_SkipsWorkerWhenMarkDrainingCASMisses(t *testing.T) {
 	}
 	if podExists(t, cs, "worker-100") {
 		t.Fatal("expected worker-100 pod to be deleted")
+	}
+}
+
+func TestShutdownAll_SkipsWorkerWhenStoredEpochDiffers(t *testing.T) {
+	store := &captureRuntimeWorkerStore{}
+	pool, cs := shutdownTestPool(t, store)
+	addShutdownWorker(t, pool, cs, 55)
+
+	store.mu.Lock()
+	store.preloadedRecords = map[int]*configstore.WorkerRecord{
+		55: {
+			WorkerID:          55,
+			PodName:           "worker-55",
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        99,
+		},
+	}
+	store.mu.Unlock()
+
+	pool.ShutdownAll()
+
+	if !podExists(t, cs, "worker-55") {
+		t.Fatal("expected pod worker-55 to survive when stored owner epoch does not match")
+	}
+	for _, id := range store.retireDrainingCalledIDs {
+		if id == 55 {
+			t.Fatal("expected no RetireDrainingWorker call after owner epoch CAS miss")
+		}
 	}
 }
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -250,6 +250,9 @@ func SetupMultiTenant(
 	janitor.retireLocalWorker = func(workerID int, reason string) bool {
 		return router.sharedPool.retireWorkerWithReason(workerID, reason)
 	}
+	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
+		router.sharedPool.deleteRetiredRuntimeWorker(&record, reason)
+	}
 	lastWarmCapacityTargets := map[string]int{}
 	var lastWarmCapacityRecentMisses []configstore.WarmCapacityMissAggregate
 	var lastWarmCapacityWorkerStats []configstore.WarmCapacityWorkerStats

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -116,19 +116,20 @@ type K8sWorkerPoolConfig struct {
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
 	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
-	ClaimHotIdleWorker(ownerCPInstanceID, orgID string) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
+	ClaimHotIdleWorker(ownerCPInstanceID, orgID string, maxOrgWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
 	RecordWarmCapacityMiss(scope string, reason configstore.WorkerClaimMissReason, now time.Time) error
 	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePrefix, image string, targetWarmWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, podNamePrefix, image string, perImageTarget, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
-	RetireIdleWorker(workerID int, reason string) (bool, error)
-	RetireIdleOrHotIdleWorker(workerID int, reason string) (bool, error)
-	RetireOrphanWorker(workerID int, reason string) (bool, error)
+	RetireIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error)
+	RetireIdleOrHotIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error)
+	RetireOrphanWorker(record *configstore.WorkerRecord, reason string) (bool, error)
+	MarkWorkerTerminalIfCurrent(record *configstore.WorkerRecord, targetState configstore.WorkerState, reason string) (bool, error)
 	MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
-	MarkWorkerDraining(workerID int, ownerCPInstanceID string) (bool, error)
-	RetireDrainingWorker(workerID int, reason string) (bool, error)
+	MarkWorkerDraining(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (bool, error)
+	RetireDrainingWorker(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
 }
 
 // K8sPoolFactory creates a K8sWorkerPool. Registered at init time by the

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -647,7 +647,7 @@ func TestClaimHotIdleWorkerPostgres(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(second): %v", err)
 	}
 
-	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics")
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 0)
 	if err != nil {
 		t.Fatalf("ClaimHotIdleWorker: %v", err)
 	}
@@ -724,7 +724,7 @@ func TestClaimHotIdleWorkerReturnsNoIdleWhenNoHotIdleWorkerExists(t *testing.T) 
 		}
 	}
 
-	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics")
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 0)
 	if err != nil {
 		t.Fatalf("ClaimHotIdleWorker: %v", err)
 	}
@@ -746,6 +746,137 @@ func TestClaimHotIdleWorkerReturnsNoIdleWhenNoHotIdleWorkerExists(t *testing.T) 
 		if persisted.OwnerEpoch != 2 {
 			t.Fatalf("expected worker %d owner epoch to remain 2, got %d", workerID, persisted.OwnerEpoch)
 		}
+	}
+}
+
+func TestClaimHotIdleWorkerRespectsOrgCapPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	now := time.Date(2026, time.March, 26, 14, 20, 0, 0, time.UTC)
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          14,
+		PodName:           "duckgres-worker-active-org-slot",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-active:boot-a",
+		OwnerEpoch:        4,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(active): %v", err)
+	}
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          15,
+		PodName:           "duckgres-worker-hot-idle-over-cap",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(hot-idle): %v", err)
+	}
+
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 1)
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("expected org cap to block hot-idle claim, got %#v", claimed)
+	}
+	if missReason != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap miss reason, got %q", missReason)
+	}
+
+	persisted, err := store.GetWorkerRecord(15)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHotIdle {
+		t.Fatalf("expected hot-idle worker to remain hot_idle, got %q", persisted.State)
+	}
+	if persisted.OwnerCPInstanceID != "cp-old:boot-a" || persisted.OwnerEpoch != 2 {
+		t.Fatalf("expected hot-idle owner to remain cp-old epoch 2, got owner=%q epoch=%d", persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestClaimHotIdleWorkerAllowsOnlyHotIdleAtCapPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	now := time.Date(2026, time.March, 26, 14, 25, 0, 0, time.UTC)
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          16,
+		PodName:           "duckgres-worker-only-hot-idle",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord: %v", err)
+	}
+
+	claimed, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 1)
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("expected sole hot-idle worker to be reclaimable at org cap")
+		return
+	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected no miss reason, got %q", missReason)
+	}
+	if claimed.WorkerID != 16 || claimed.State != configstore.WorkerStateReserved {
+		t.Fatalf("expected worker 16 to be reserved, got %#v", claimed)
+	}
+}
+
+func TestClaimHotIdleWorkerSerializesOrgCapPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	now := time.Date(2026, time.March, 26, 14, 30, 0, 0, time.UTC)
+	for _, workerID := range []int{17, 18} {
+		if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			WorkerID:          workerID,
+			PodName:           fmt.Sprintf("duckgres-worker-hot-idle-%d", workerID),
+			State:             configstore.WorkerStateHotIdle,
+			OrgID:             "analytics",
+			OwnerCPInstanceID: "cp-old:boot-a",
+			OwnerEpoch:        2,
+			LastHeartbeatAt:   now,
+		}); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", workerID, err)
+		}
+	}
+
+	first, missReason, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 1)
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker(first): %v", err)
+	}
+	if first == nil || first.WorkerID != 17 {
+		t.Fatalf("expected first claim to reserve worker 17, got %#v", first)
+	}
+	if missReason != configstore.WorkerClaimMissReasonNone {
+		t.Fatalf("expected first claim to have no miss reason, got %q", missReason)
+	}
+
+	second, missReason, err := store.ClaimHotIdleWorker("cp-other:boot-c", "analytics", 1)
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker(second): %v", err)
+	}
+	if second != nil {
+		t.Fatalf("expected org cap to block second hot-idle claim, got %#v", second)
+	}
+	if missReason != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap miss reason on second claim, got %q", missReason)
+	}
+
+	persisted, err := store.GetWorkerRecord(18)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord(18): %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHotIdle {
+		t.Fatalf("expected second hot-idle worker to remain hot_idle, got %q", persisted.State)
 	}
 }
 
@@ -1261,6 +1392,45 @@ func TestListOrphanedWorkersIncludesOwnerlessIdleWorkers(t *testing.T) {
 	}
 }
 
+func TestRetireOrphanWorkerHandlesNullOwnerPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 14, 5, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          101,
+		PodName:           "duckgres-worker-101",
+		State:             configstore.WorkerStateIdle,
+		OrgID:             "",
+		OwnerCPInstanceID: "",
+		OwnerEpoch:        0,
+		LastHeartbeatAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(ownerless idle): %v", err)
+	}
+	if err := store.DB().Table(store.RuntimeSchema()+".worker_records").
+		Where("worker_id = ?", 101).
+		Update("owner_cp_instance_id", nil).Error; err != nil {
+		t.Fatalf("set owner_cp_instance_id null: %v", err)
+	}
+
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	if err != nil {
+		t.Fatalf("ListOrphanedWorkers: %v", err)
+	}
+	if len(orphaned) != 1 || orphaned[0].WorkerID != 101 || orphaned[0].OwnerCPInstanceID != "" {
+		t.Fatalf("expected null-owner worker 101 to be listed with empty owner, got %#v", orphaned)
+	}
+
+	retired, err := store.RetireOrphanWorker(&orphaned[0], "orphaned")
+	if err != nil {
+		t.Fatalf("RetireOrphanWorker(null owner): %v", err)
+	}
+	if !retired {
+		t.Fatal("expected null-owner orphan snapshot to retire")
+	}
+	assertWorkerStateAndReason(t, store, 101, configstore.WorkerStateRetired, "orphaned")
+}
+
 // TestListOrphanedWorkersIncludesDanglingOwnerWorkers covers the
 // "owner_cp_instance_id is set but no matching cp_instances row exists"
 // case — the CP row was hard-deleted (or somehow skipped insertion) but
@@ -1356,7 +1526,12 @@ func TestRetireOrphanWorkerHandlesAllActiveStates(t *testing.T) {
 				t.Fatalf("UpsertWorkerRecord(%s): %v", tc.state, err)
 			}
 
-			retired, err := store.RetireOrphanWorker(workerID, "test_orphan_cleanup")
+			observed, err := store.GetWorkerRecord(workerID)
+			if err != nil {
+				t.Fatalf("GetWorkerRecord(%s): %v", tc.state, err)
+			}
+
+			retired, err := store.RetireOrphanWorker(observed, "test_orphan_cleanup")
 			if err != nil {
 				t.Fatalf("RetireOrphanWorker(%s): %v", tc.state, err)
 			}
@@ -1365,7 +1540,7 @@ func TestRetireOrphanWorkerHandlesAllActiveStates(t *testing.T) {
 			}
 
 			// Verify final DB state via a follow-up no-op call (returns false).
-			retiredAgain, err := store.RetireOrphanWorker(workerID, "test_orphan_cleanup")
+			retiredAgain, err := store.RetireOrphanWorker(observed, "test_orphan_cleanup")
 			if err != nil {
 				t.Fatalf("RetireOrphanWorker(%s) follow-up: %v", tc.state, err)
 			}
@@ -1404,7 +1579,12 @@ func TestRetireOrphanWorkerNoOpOnTerminalStates(t *testing.T) {
 				t.Fatalf("UpsertWorkerRecord(%s): %v", tc.state, err)
 			}
 
-			retired, err := store.RetireOrphanWorker(workerID, "should_be_ignored")
+			observed, err := store.GetWorkerRecord(workerID)
+			if err != nil {
+				t.Fatalf("GetWorkerRecord(%s): %v", tc.state, err)
+			}
+
+			retired, err := store.RetireOrphanWorker(observed, "should_be_ignored")
 			if err != nil {
 				t.Fatalf("RetireOrphanWorker(%s): %v", tc.state, err)
 			}
@@ -2052,7 +2232,7 @@ func TestUpsertWorkerRecordDoesNotResurrectTerminalWorkerPostgres(t *testing.T) 
 			workerID := 3400 + i
 			upsertMarkLostWorker(t, store, workerID, tc.state, "cp-me:boot-a", 4, "original", now)
 
-			if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
 				WorkerID:          workerID,
 				PodName:           fmt.Sprintf("duckgres-worker-%d", workerID),
 				State:             configstore.WorkerStateHot,
@@ -2061,13 +2241,304 @@ func TestUpsertWorkerRecordDoesNotResurrectTerminalWorkerPostgres(t *testing.T) 
 				OwnerEpoch:        5,
 				RetireReason:      "",
 				LastHeartbeatAt:   now.Add(time.Minute),
-			}); err != nil {
-				t.Fatalf("UpsertWorkerRecord(%d): %v", workerID, err)
+			})
+			if !errors.Is(err, configstore.ErrWorkerRecordUpsertFenceMiss) {
+				t.Fatalf("expected fenced terminal upsert for worker %d, got %v", workerID, err)
 			}
 
 			assertWorkerStateAndReason(t, store, workerID, tc.state, "original")
 		})
 	}
+}
+
+func TestUpsertWorkerRecordDoesNotOverwriteNewerLeasePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3600,
+		PodName:           "duckgres-worker-3600",
+		State:             configstore.WorkerStateReserved,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-new:boot-b",
+		OwnerEpoch:        10,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(current): %v", err)
+	}
+
+	err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3600,
+		PodName:           "duckgres-worker-3600",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        9,
+		LastHeartbeatAt:   now.Add(time.Minute),
+	})
+	if !errors.Is(err, configstore.ErrWorkerRecordUpsertFenceMiss) {
+		t.Fatalf("expected stale upsert fence miss, got %v", err)
+	}
+
+	persisted, err := store.GetWorkerRecord(3600)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateReserved ||
+		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
+		persisted.OwnerEpoch != 10 {
+		t.Fatalf("stale upsert overwrote newer lease: state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireOrphanWorkerRejectsRevivedOwnerControlPlanePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 10, 0, 0, time.UTC)
+
+	if err := store.UpsertControlPlaneInstance(&configstore.ControlPlaneInstance{
+		ID:              "cp-revived:boot-a",
+		PodName:         "duckgres-old",
+		PodUID:          "pod-old",
+		BootID:          "boot-a",
+		State:           configstore.ControlPlaneInstanceStateExpired,
+		StartedAt:       now.Add(-2 * time.Hour),
+		LastHeartbeatAt: now.Add(-time.Hour),
+		ExpiredAt:       ptrTime(now.Add(-time.Hour)),
+	}); err != nil {
+		t.Fatalf("UpsertControlPlaneInstance(expired): %v", err)
+	}
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3604,
+		PodName:           "duckgres-worker-3604",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-revived:boot-a",
+		OwnerEpoch:        3,
+		LastHeartbeatAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(orphan candidate): %v", err)
+	}
+
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	if err != nil {
+		t.Fatalf("ListOrphanedWorkers: %v", err)
+	}
+	if len(orphaned) != 1 || orphaned[0].WorkerID != 3604 {
+		t.Fatalf("expected worker 3604 orphan snapshot, got %#v", orphaned)
+	}
+
+	if err := store.UpsertControlPlaneInstance(&configstore.ControlPlaneInstance{
+		ID:              "cp-revived:boot-a",
+		PodName:         "duckgres-new",
+		PodUID:          "pod-new",
+		BootID:          "boot-a",
+		State:           configstore.ControlPlaneInstanceStateActive,
+		StartedAt:       now.Add(-2 * time.Hour),
+		LastHeartbeatAt: now,
+		ExpiredAt:       nil,
+	}); err != nil {
+		t.Fatalf("UpsertControlPlaneInstance(revived): %v", err)
+	}
+
+	retired, err := store.RetireOrphanWorker(&orphaned[0], "orphaned")
+	if err != nil {
+		t.Fatalf("RetireOrphanWorker(revived CP): %v", err)
+	}
+	if retired {
+		t.Fatal("expected revived owner CP to fence orphan retirement")
+	}
+
+	persisted, err := store.GetWorkerRecord(3604)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHot || persisted.OwnerCPInstanceID != "cp-revived:boot-a" || persisted.OwnerEpoch != 3 {
+		t.Fatalf("expected revived CP's worker to survive, got state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireOrphanWorkerRejectsStaleListSnapshotAfterTakeoverPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 15, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3601,
+		PodName:           "duckgres-worker-3601",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        5,
+		LastHeartbeatAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(orphan candidate): %v", err)
+	}
+
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	if err != nil {
+		t.Fatalf("ListOrphanedWorkers: %v", err)
+	}
+	if len(orphaned) != 1 || orphaned[0].WorkerID != 3601 {
+		t.Fatalf("expected worker 3601 orphan snapshot, got %#v", orphaned)
+	}
+
+	taken, err := store.TakeOverWorker(3601, "cp-new:boot-b", "analytics", 5)
+	if err != nil {
+		t.Fatalf("TakeOverWorker: %v", err)
+	}
+	if taken == nil {
+		t.Fatal("expected takeover to succeed")
+	}
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3601,
+		PodName:           "duckgres-worker-3601",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-new:boot-b",
+		OwnerEpoch:        taken.OwnerEpoch,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(new owner hot): %v", err)
+	}
+
+	retired, err := store.RetireOrphanWorker(&orphaned[0], "orphaned")
+	if err != nil {
+		t.Fatalf("RetireOrphanWorker(stale snapshot): %v", err)
+	}
+	if retired {
+		t.Fatal("expected stale orphan snapshot not to retire a newer lease")
+	}
+
+	persisted, err := store.GetWorkerRecord(3601)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHot ||
+		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
+		persisted.OwnerEpoch != 6 {
+		t.Fatalf("expected newer hot lease to survive, got state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireHotIdleWorkerRejectsStaleListSnapshotAfterReclaimPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 30, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3602,
+		PodName:           "duckgres-worker-3602",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		LastHeartbeatAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(hot-idle): %v", err)
+	}
+
+	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
+	}
+	if len(expired) != 1 || expired[0].WorkerID != 3602 {
+		t.Fatalf("expected worker 3602 hot-idle snapshot, got %#v", expired)
+	}
+
+	claimed, _, err := store.ClaimHotIdleWorker("cp-new:boot-b", "analytics", 0)
+	if err != nil {
+		t.Fatalf("ClaimHotIdleWorker: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("expected hot-idle reclaim to succeed")
+	}
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3602,
+		PodName:           "duckgres-worker-3602",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-new:boot-b",
+		OwnerEpoch:        claimed.OwnerEpoch,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(released hot-idle): %v", err)
+	}
+
+	retired, err := store.RetireHotIdleWorker(&expired[0])
+	if err != nil {
+		t.Fatalf("RetireHotIdleWorker(stale snapshot): %v", err)
+	}
+	if retired {
+		t.Fatal("expected stale hot-idle snapshot not to retire a reclaimed worker")
+	}
+
+	persisted, err := store.GetWorkerRecord(3602)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHotIdle ||
+		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
+		persisted.OwnerEpoch != 3 {
+		t.Fatalf("expected reclaimed hot-idle lease to survive, got state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireHotIdleWorkerNoOpOnNonHotIdleSnapshotPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 40, 0, 0, time.UTC)
+
+	upsertMarkLostWorker(t, store, 3604, configstore.WorkerStateHot, "cp-me:boot-a", 4, "", now)
+	observed, err := store.GetWorkerRecord(3604)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+
+	retired, err := store.RetireHotIdleWorker(observed)
+	if err != nil {
+		t.Fatalf("RetireHotIdleWorker(non-hot-idle): %v", err)
+	}
+	if retired {
+		t.Fatal("expected non-hot-idle snapshot not to retire through RetireHotIdleWorker")
+	}
+	assertWorkerStateAndReason(t, store, 3604, configstore.WorkerStateHot, "")
+}
+
+func TestMarkWorkerDrainingRejectsStaleSameCPLeasePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 45, 0, 0, time.UTC)
+
+	upsertMarkLostWorker(t, store, 3603, configstore.WorkerStateHot, "cp-me:boot-a", 4, "", now)
+	upsertMarkLostWorker(t, store, 3603, configstore.WorkerStateHot, "cp-me:boot-a", 5, "", now.Add(time.Minute))
+
+	draining, err := store.MarkWorkerDraining(3603, "cp-me:boot-a", 4)
+	if err != nil {
+		t.Fatalf("MarkWorkerDraining(stale epoch): %v", err)
+	}
+	if draining {
+		t.Fatal("expected stale same-CP epoch not to mark worker draining")
+	}
+
+	persisted, err := store.GetWorkerRecord(3603)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHot || persisted.OwnerEpoch != 5 {
+		t.Fatalf("expected newer hot lease to survive, got state=%q epoch=%d", persisted.State, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireDrainingWorkerRejectsStaleSameCPLeasePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 50, 0, 0, time.UTC)
+
+	upsertMarkLostWorker(t, store, 3605, configstore.WorkerStateDraining, "cp-me:boot-a", 5, "", now)
+
+	retired, err := store.RetireDrainingWorker(3605, "cp-me:boot-a", 4, "shutdown")
+	if err != nil {
+		t.Fatalf("RetireDrainingWorker(stale epoch): %v", err)
+	}
+	if retired {
+		t.Fatal("expected stale same-CP epoch not to retire draining worker")
+	}
+	assertWorkerStateAndReason(t, store, 3605, configstore.WorkerStateDraining, "")
 }
 
 func upsertMarkLostWorker(t *testing.T, store *configstore.ConfigStore, workerID int, state configstore.WorkerState, ownerCPInstanceID string, ownerEpoch int64, retireReason string, lastHeartbeatAt time.Time) {

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -2255,18 +2255,22 @@ func TestUpsertWorkerRecordDoesNotOverwriteNewerLeasePostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.May, 22, 13, 0, 0, 0, time.UTC)
 
-	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
-		WorkerID:          3600,
-		PodName:           "duckgres-worker-3600",
-		State:             configstore.WorkerStateReserved,
-		OrgID:             "analytics",
-		OwnerCPInstanceID: "cp-new:boot-b",
-		OwnerEpoch:        10,
-		LastHeartbeatAt:   now,
-	}); err != nil {
-		t.Fatalf("UpsertWorkerRecord(current): %v", err)
+	insertCurrent := func(workerID int) {
+		t.Helper()
+		if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			WorkerID:          workerID,
+			PodName:           fmt.Sprintf("duckgres-worker-%d", workerID),
+			State:             configstore.WorkerStateReserved,
+			OrgID:             "analytics",
+			OwnerCPInstanceID: "cp-new:boot-b",
+			OwnerEpoch:        10,
+			LastHeartbeatAt:   now,
+		}); err != nil {
+			t.Fatalf("UpsertWorkerRecord(current %d): %v", workerID, err)
+		}
 	}
 
+	insertCurrent(3600)
 	err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
 		WorkerID:          3600,
 		PodName:           "duckgres-worker-3600",
@@ -2288,6 +2292,30 @@ func TestUpsertWorkerRecordDoesNotOverwriteNewerLeasePostgres(t *testing.T) {
 		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
 		persisted.OwnerEpoch != 10 {
 		t.Fatalf("stale upsert overwrote newer lease: state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+
+	insertCurrent(3606)
+	err = store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3606,
+		PodName:           "duckgres-worker-3606",
+		State:             configstore.WorkerStateHot,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        10,
+		LastHeartbeatAt:   now.Add(time.Minute),
+	})
+	if !errors.Is(err, configstore.ErrWorkerRecordUpsertFenceMiss) {
+		t.Fatalf("expected equal-epoch different-owner upsert fence miss, got %v", err)
+	}
+
+	persisted, err = store.GetWorkerRecord(3606)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord(equal epoch): %v", err)
+	}
+	if persisted.State != configstore.WorkerStateReserved ||
+		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
+		persisted.OwnerEpoch != 10 {
+		t.Fatalf("equal-epoch different-owner upsert overwrote lease: state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
 	}
 }
 
@@ -2478,6 +2506,56 @@ func TestRetireHotIdleWorkerRejectsStaleListSnapshotAfterReclaimPostgres(t *test
 		persisted.OwnerCPInstanceID != "cp-new:boot-b" ||
 		persisted.OwnerEpoch != 3 {
 		t.Fatalf("expected reclaimed hot-idle lease to survive, got state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
+	}
+}
+
+func TestRetireHotIdleWorkerRejectsStaleListSnapshotAfterTouchPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.May, 22, 13, 35, 0, 0, time.UTC)
+
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          3607,
+		PodName:           "duckgres-worker-3607",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		OwnerCPInstanceID: "cp-old:boot-a",
+		OwnerEpoch:        2,
+		LastHeartbeatAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(hot-idle): %v", err)
+	}
+
+	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
+	}
+	if len(expired) != 1 || expired[0].WorkerID != 3607 {
+		t.Fatalf("expected worker 3607 hot-idle snapshot, got %#v", expired)
+	}
+
+	advancedUpdatedAt := expired[0].UpdatedAt.Add(time.Second)
+	if err := store.DB().Table(store.RuntimeSchema()+".worker_records").
+		Where("worker_id = ?", 3607).
+		Update("updated_at", advancedUpdatedAt).Error; err != nil {
+		t.Fatalf("advance worker updated_at: %v", err)
+	}
+
+	retired, err := store.RetireHotIdleWorker(&expired[0])
+	if err != nil {
+		t.Fatalf("RetireHotIdleWorker(stale updated_at): %v", err)
+	}
+	if retired {
+		t.Fatal("expected stale hot-idle snapshot not to retire after same-owner touch")
+	}
+
+	persisted, err := store.GetWorkerRecord(3607)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if persisted.State != configstore.WorkerStateHotIdle ||
+		persisted.OwnerCPInstanceID != "cp-old:boot-a" ||
+		persisted.OwnerEpoch != 2 {
+		t.Fatalf("expected touched hot-idle lease to survive, got state=%q owner=%q epoch=%d", persisted.State, persisted.OwnerCPInstanceID, persisted.OwnerEpoch)
 	}
 }
 


### PR DESCRIPTION
Summary:
- add owner/epoch/snapshot fences to worker lifecycle cleanup transitions
- prevent stale janitor/reaper/shutdown paths from deleting pods after CAS misses
- enforce hot-idle org-cap checks and add regression coverage for stale snapshots and cleanup handoff

Testing:
- just test-configstore-integration
- just test-controlplane
- just test-controlplane-k8s
- just lint