### PR TITLE
PR 4: privatize unsafe lifecycle transition paths

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1212,16 +1212,6 @@ func (cs *ConfigStore) RetireHotIdleWorker(record *WorkerRecord) (bool, error) {
 	return cs.MarkWorkerTerminalIfCurrent(record, WorkerStateRetired, "hot_idle_ttl_expired")
 }
 
-// RetireIdleWorker atomically transitions a worker from idle to retired.
-// Returns true if the transition happened, false if the worker was no longer
-// idle (e.g. claimed by another CP between the list query and this call).
-func (cs *ConfigStore) RetireIdleWorker(record *WorkerRecord, reason string) (bool, error) {
-	if record == nil || record.State != WorkerStateIdle {
-		return false, nil
-	}
-	return cs.MarkWorkerTerminalIfCurrent(record, WorkerStateRetired, reason)
-}
-
 // RetireOrphanWorker is the orphan-cleanup counterpart to
 // RetireIdleOrHotIdleWorker. Whereas the latter only handles `idle` /
 // `hot_idle`, this method transitions a worker to `retired` from any

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -39,6 +40,7 @@ type ControlPlaneJanitor struct {
 	warmCapacityMissBucketTTL     time.Duration
 	now                           func() time.Time
 	lifecycle                     *WorkerLifecycle // every per-worker transition flows through this; nil disables per-worker reaping for that tick.
+	lifecycleNilWarned            sync.Once        // one-shot guard so the misconfiguration error doesn't flood at the janitor tick rate.
 	reconcileWarmCapacity         func()
 	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
@@ -112,7 +114,9 @@ func (j *ControlPlaneJanitor) runOnce() {
 	// warm-capacity reconciliation — still runs); the slog.Error
 	// makes the misconfiguration loud rather than silent.
 	if j.lifecycle == nil {
-		slog.Error("Janitor running without a lifecycle service; per-worker reaping disabled this tick.")
+		j.lifecycleNilWarned.Do(func() {
+			slog.Error("Janitor running without a lifecycle service; per-worker reaping disabled. This is a wiring bug — fix the constructor.")
+		})
 	} else {
 		orphanedBefore := j.now().Add(-j.orphanGrace)
 		orphaned, err := j.store.ListOrphanedWorkerSnapshots(orphanedBefore)

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -17,13 +17,10 @@ const (
 type controlPlaneExpiryStore interface {
 	ExpireControlPlaneInstances(cutoff time.Time) (int64, error)
 	ExpireDrainingControlPlaneInstances(before time.Time) (int64, error)
-	ListOrphanedWorkers(before time.Time) ([]configstore.WorkerRecord, error)
 	ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
-	ListStuckWorkers(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerRecord, error)
-	ExpireFlightSessionRecords(before time.Time) (int64, error)
-	ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error)
+	ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerSnapshot, error)
 	ListExpiredHotIdleSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
-	RetireHotIdleWorker(record *configstore.WorkerRecord) (bool, error)
+	ExpireFlightSessionRecords(before time.Time) (int64, error)
 }
 
 type warmCapacityMissBucketPruner interface {
@@ -41,11 +38,7 @@ type ControlPlaneJanitor struct {
 	hotIdleTTL                    time.Duration
 	warmCapacityMissBucketTTL     time.Duration
 	now                           func() time.Time
-	retireWorker                  func(record configstore.WorkerRecord, reason string)
-	retireOrphanWorker            func(record configstore.WorkerRecord, reason string) // orphan-cleanup variant: handles any active state, skips local-pool bookkeeping
-	retireLocalWorker             func(workerID int, reason string) bool               // retires from in-memory pool + pod, returns false if not local
-	deleteRetiredWorker           func(record configstore.WorkerRecord, reason string) // post-CAS cleanup: only remove local state / delete pod
-	lifecycle                     *WorkerLifecycle                                     // typed lifecycle transitions; when set, hot-idle path goes through it
+	lifecycle                     *WorkerLifecycle // every per-worker transition flows through this; nil disables per-worker reaping for that tick.
 	reconcileWarmCapacity         func()
 	retireMismatchedVersionWorker func() // reaps one warm idle worker whose Deployment version differs from this CP's (leader-only)
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
@@ -110,10 +103,13 @@ func (j *ControlPlaneJanitor) runOnce() {
 		}
 	}
 
-	orphanedBefore := j.now().Add(-j.orphanGrace)
+	// Per-worker reaping paths (orphan, stuck, hot-idle) all flow
+	// through the lifecycle service. When no lifecycle is wired (older
+	// non-K8s deployments) we skip them — the rest of runOnce (flight
+	// session expiry, bucket pruning, warm-capacity reconciliation)
+	// still runs.
 	if j.lifecycle != nil {
-		// Lifecycle path: snapshot-typed list + RetireOrphanFromSnapshot,
-		// which carries the orphan-specific CP-revival fence already.
+		orphanedBefore := j.now().Add(-j.orphanGrace)
 		orphaned, err := j.store.ListOrphanedWorkerSnapshots(orphanedBefore)
 		if err != nil {
 			slog.Warn("Janitor failed to list orphaned workers.", "error", err)
@@ -122,91 +118,34 @@ func (j *ControlPlaneJanitor) runOnce() {
 				slog.Info("Janitor retiring orphaned workers.", "count", len(orphaned))
 			}
 			for _, snap := range orphaned {
-				outcome, err := j.lifecycle.RetireOrphanFromSnapshot(snap, janitorRetireReasonOrphaned)
-				if err != nil {
+				if _, err := j.lifecycle.RetireOrphanFromSnapshot(snap, janitorRetireReasonOrphaned); err != nil {
 					slog.Warn("Janitor failed to retire orphan worker.", "worker_id", snap.WorkerID(), "error", err)
-					continue
 				}
-				_ = outcome // metrics-bearing outcome consumed once PR 6 lands.
 			}
 		}
-	} else {
-		orphaned, err := j.store.ListOrphanedWorkers(orphanedBefore)
+
+		spawningBefore := j.now().Add(-j.spawnTimeout)
+		activatingBefore := j.now().Add(-j.activateTimeout)
+		stuckWorkers, err := j.store.ListStuckWorkerSnapshots(spawningBefore, activatingBefore)
 		if err != nil {
-			slog.Warn("Janitor failed to list orphaned workers.", "error", err)
+			slog.Warn("Janitor failed to list stuck workers.", "error", err)
 		} else {
-			if len(orphaned) > 0 {
-				slog.Info("Janitor retiring orphaned workers.", "count", len(orphaned))
-			}
-			for _, worker := range orphaned {
-				// Legacy path retained for deployments that don't wire a
-				// lifecycle service. PR 4 prunes once every deployment
-				// uses the lifecycle path.
-				if j.retireOrphanWorker != nil {
-					j.retireOrphanWorker(worker, janitorRetireReasonOrphaned)
-				} else {
-					j.retireRuntimeWorker(worker, janitorRetireReasonOrphaned)
+			for _, snap := range stuckWorkers {
+				if _, err := j.lifecycle.RetireFromSnapshot(snap, configstore.WorkerStateRetired, janitorRetireReasonStuckActivating); err != nil {
+					slog.Warn("Janitor failed to retire stuck worker.", "worker_id", snap.WorkerID(), "error", err)
 				}
 			}
 		}
-	}
 
-	spawningBefore := j.now().Add(-j.spawnTimeout)
-	activatingBefore := j.now().Add(-j.activateTimeout)
-	stuckWorkers, err := j.store.ListStuckWorkers(spawningBefore, activatingBefore)
-	if err != nil {
-		slog.Warn("Janitor failed to list stuck workers.", "error", err)
-	} else {
-		for _, worker := range stuckWorkers {
-			j.retireRuntimeWorker(worker, janitorRetireReasonStuckActivating)
-		}
-	}
-
-	if j.hotIdleTTL > 0 {
-		cutoff := j.now().Add(-j.hotIdleTTL)
-		if j.lifecycle != nil {
-			// Lifecycle path: one snapshot-fenced call per expired row.
-			// The lifecycle service handles both the durable CAS and the
-			// post-CAS pod/secret cleanup, so the janitor no longer has
-			// to choose between retireLocalWorker / retireWorker /
-			// deleteRetiredWorker fallbacks.
+		if j.hotIdleTTL > 0 {
+			cutoff := j.now().Add(-j.hotIdleTTL)
 			expired, err := j.store.ListExpiredHotIdleSnapshots(cutoff)
 			if err != nil {
 				slog.Warn("Janitor failed to list expired hot-idle workers.", "error", err)
 			}
 			for _, snap := range expired {
-				outcome, err := j.lifecycle.RetireFromSnapshot(snap, configstore.WorkerStateRetired, "hot_idle_ttl_expired")
-				if err != nil {
+				if _, err := j.lifecycle.RetireFromSnapshot(snap, configstore.WorkerStateRetired, "hot_idle_ttl_expired"); err != nil {
 					slog.Warn("Janitor failed to retire hot-idle worker.", "worker_id", snap.WorkerID(), "error", err)
-					continue
-				}
-				_ = outcome // metrics-bearing outcome consumed once PR 6 lands.
-			}
-		} else {
-			// Legacy path retained for process-pool / non-lifecycle
-			// deployments. Removed entirely once PR 4 prunes the
-			// retireWorker / retireLocalWorker / deleteRetiredWorker
-			// lambdas after every lifecycle-bearing caller is migrated.
-			expired, err := j.store.ListExpiredHotIdleWorkers(cutoff)
-			if err != nil {
-				slog.Warn("Janitor failed to list expired hot-idle workers.", "error", err)
-			}
-			for _, record := range expired {
-				retired, err := j.store.RetireHotIdleWorker(&record)
-				if err != nil {
-					slog.Warn("Janitor failed to retire hot-idle worker.", "worker_id", record.WorkerID, "error", err)
-					continue
-				}
-				if !retired {
-					continue
-				}
-				if j.deleteRetiredWorker != nil {
-					j.deleteRetiredWorker(record, "hot_idle_ttl_expired")
-					continue
-				}
-				localRetired := j.retireLocalWorker != nil && j.retireLocalWorker(record.WorkerID, "hot_idle_ttl_expired")
-				if !localRetired {
-					j.retireRuntimeWorker(record, "hot_idle_ttl_expired")
 				}
 			}
 		}
@@ -251,9 +190,3 @@ func (j *ControlPlaneJanitor) runOnce() {
 	}
 }
 
-func (j *ControlPlaneJanitor) retireRuntimeWorker(record configstore.WorkerRecord, reason string) {
-	if j == nil || j.retireWorker == nil {
-		return
-	}
-	j.retireWorker(record, reason)
-}

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -104,11 +104,16 @@ func (j *ControlPlaneJanitor) runOnce() {
 	}
 
 	// Per-worker reaping paths (orphan, stuck, hot-idle) all flow
-	// through the lifecycle service. When no lifecycle is wired (older
-	// non-K8s deployments) we skip them — the rest of runOnce (flight
-	// session expiry, bucket pruning, warm-capacity reconciliation)
-	// still runs.
-	if j.lifecycle != nil {
+	// through the lifecycle service. A nil lifecycle here is a wiring
+	// bug — the only janitor constructor (multitenant.go) sets it
+	// unconditionally. The guard remains as a fail-soft so that
+	// misconfiguration doesn't NPE the entire tick (the rest of
+	// runOnce — flight session expiry, bucket pruning,
+	// warm-capacity reconciliation — still runs); the slog.Error
+	// makes the misconfiguration loud rather than silent.
+	if j.lifecycle == nil {
+		slog.Error("Janitor running without a lifecycle service; per-worker reaping disabled this tick.")
+	} else {
 		orphanedBefore := j.now().Add(-j.orphanGrace)
 		orphaned, err := j.store.ListOrphanedWorkerSnapshots(orphanedBefore)
 		if err != nil {

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -16,15 +16,12 @@ type captureControlPlaneExpiryStore struct {
 	expireErr              error
 	drainingCutoffs        []time.Time
 	drainingCount          int64
-	orphanedBefore         []time.Time
 	orphanedWorkers        []configstore.WorkerRecord
 	stuckSpawningBefore    []time.Time
 	stuckActivatingBefore  []time.Time
 	stuckWorkers           []configstore.WorkerRecord
 	expiredSessionsBefore  []time.Time
 	expiredHotIdleWorkers  []configstore.WorkerRecord
-	retireHotIdleCurrent   map[int]*configstore.WorkerRecord
-	retireHotIdleRecords   []configstore.WorkerRecord
 	pruneMissBucketsBefore []time.Time
 	prunedMissBucketCount  int64
 	pruneMissBucketErr     error
@@ -70,22 +67,18 @@ func (s *captureControlPlaneExpiryStore) ListOrphanedWorkerSnapshots(before time
 	return out, nil
 }
 
-func (s *captureControlPlaneExpiryStore) ListOrphanedWorkers(before time.Time) ([]configstore.WorkerRecord, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.orphanedBefore = append(s.orphanedBefore, before)
-	out := make([]configstore.WorkerRecord, len(s.orphanedWorkers))
-	copy(out, s.orphanedWorkers)
-	return out, nil
-}
-
-func (s *captureControlPlaneExpiryStore) ListStuckWorkers(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerRecord, error) {
+func (s *captureControlPlaneExpiryStore) ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerSnapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stuckSpawningBefore = append(s.stuckSpawningBefore, spawningBefore)
 	s.stuckActivatingBefore = append(s.stuckActivatingBefore, activatingBefore)
-	out := make([]configstore.WorkerRecord, len(s.stuckWorkers))
-	copy(out, s.stuckWorkers)
+	if len(s.stuckWorkers) == 0 {
+		return nil, nil
+	}
+	out := make([]configstore.WorkerSnapshot, 0, len(s.stuckWorkers))
+	for _, rec := range s.stuckWorkers {
+		out = append(out, configstore.NewWorkerSnapshot(rec))
+	}
 	return out, nil
 }
 
@@ -94,14 +87,6 @@ func (s *captureControlPlaneExpiryStore) ExpireFlightSessionRecords(before time.
 	defer s.mu.Unlock()
 	s.expiredSessionsBefore = append(s.expiredSessionsBefore, before)
 	return 0, nil
-}
-
-func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleWorkers(before time.Time) ([]configstore.WorkerRecord, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]configstore.WorkerRecord, len(s.expiredHotIdleWorkers))
-	copy(out, s.expiredHotIdleWorkers)
-	return out, nil
 }
 
 // ListExpiredHotIdleSnapshots is the lifecycle-typed counterpart used
@@ -119,35 +104,6 @@ func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleSnapshots(before time
 		out = append(out, configstore.NewWorkerSnapshot(rec))
 	}
 	return out, nil
-}
-
-func (s *captureControlPlaneExpiryStore) RetireHotIdleWorker(record *configstore.WorkerRecord) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if record != nil {
-		s.retireHotIdleRecords = append(s.retireHotIdleRecords, *record)
-	}
-	if record == nil || record.State != configstore.WorkerStateHotIdle {
-		return false, nil
-	}
-	current := s.retireHotIdleCurrent[record.WorkerID]
-	if current == nil || !janitorObservedWorkerRecordMatchesCurrent(record, current) || current.State != configstore.WorkerStateHotIdle {
-		return false, nil
-	}
-	current.State = configstore.WorkerStateRetired
-	current.RetireReason = "hot_idle_ttl_expired"
-	current.UpdatedAt = time.Now()
-	return true, nil
-}
-
-func janitorObservedWorkerRecordMatchesCurrent(observed, current *configstore.WorkerRecord) bool {
-	if observed == nil || current == nil {
-		return false
-	}
-	return current.State == observed.State &&
-		current.OwnerCPInstanceID == observed.OwnerCPInstanceID &&
-		current.OwnerEpoch == observed.OwnerEpoch &&
-		(observed.UpdatedAt.IsZero() || !current.UpdatedAt.After(observed.UpdatedAt))
 }
 
 func (s *captureControlPlaneExpiryStore) PruneWarmCapacityMissBuckets(before time.Time) (int64, error) {
@@ -226,51 +182,29 @@ func TestControlPlaneJanitorRunPrunesWarmCapacityMissBucketsWithConfiguredTTL(t 
 func TestControlPlaneJanitorRunRetiresOrphanedAndStuckWorkers(t *testing.T) {
 	store := &captureControlPlaneExpiryStore{
 		orphanedWorkers: []configstore.WorkerRecord{
-			{WorkerID: 7, PodName: "duckgres-worker-7"},
+			{WorkerID: 7, PodName: "duckgres-worker-7", State: configstore.WorkerStateHot, OwnerCPInstanceID: "cp-expired:boot-a", OwnerEpoch: 2},
 		},
 		stuckWorkers: []configstore.WorkerRecord{
-			{WorkerID: 9, PodName: "duckgres-worker-9", State: configstore.WorkerStateActivating},
+			{WorkerID: 9, PodName: "duckgres-worker-9", State: configstore.WorkerStateActivating, OwnerCPInstanceID: "cp-me:boot-b", OwnerEpoch: 1},
 		},
 	}
+	lifecycleStore := &fakeLifecycleStore{orphanReturn: true, terminalReturn: true}
+	cleanup := &fakePhysicalCleanup{}
 	now := time.Date(2026, time.March, 26, 16, 0, 0, 0, time.UTC)
 	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
 	janitor.now = func() time.Time { return now }
-
-	var mu sync.Mutex
-	var retired []struct {
-		id     int
-		reason string
-	}
-	janitor.retireWorker = func(record configstore.WorkerRecord, reason string) {
-		mu.Lock()
-		defer mu.Unlock()
-		retired = append(retired, struct {
-			id     int
-			reason string
-		}{id: record.WorkerID, reason: reason})
-	}
+	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
 
 	janitor.runOnce()
 
-	mu.Lock()
-	defer mu.Unlock()
-	if len(retired) != 2 {
-		t.Fatalf("expected janitor to retire exactly two workers, got %d", len(retired))
+	if got := lifecycleStore.orphanTransitions; len(got) != 1 || got[0].workerID != 7 || got[0].reason != janitorRetireReasonOrphaned {
+		t.Fatalf("expected one orphan CAS via lifecycle for worker 7, got %#v", got)
 	}
-	if retired[0].id != 7 || retired[0].reason != janitorRetireReasonOrphaned {
-		t.Fatalf("expected orphaned worker 7 with orphaned reason, got %+v", retired[0])
+	if got := lifecycleStore.terminalTransitions; len(got) != 1 || got[0].workerID != 9 || got[0].reason != janitorRetireReasonStuckActivating || got[0].target != configstore.WorkerStateRetired {
+		t.Fatalf("expected one terminal CAS via lifecycle for stuck worker 9 → retired, got %#v", got)
 	}
-	if retired[1].id != 9 || retired[1].reason != janitorRetireReasonStuckActivating {
-		t.Fatalf("expected stuck worker 9 with stuck_activating, got %+v", retired[1])
-	}
-	if len(store.orphanedBefore) == 0 {
-		t.Fatal("expected orphaned worker cutoff lookup")
-	}
-	wantOrphanedBefore := now.Add(-30 * time.Second)
-	for i, cutoff := range store.orphanedBefore {
-		if !cutoff.Equal(wantOrphanedBefore) {
-			t.Fatalf("orphaned cutoff call %d expected %v, got %v", i, wantOrphanedBefore, cutoff)
-		}
+	if got := cleanup.snapshot(); len(got) != 2 {
+		t.Fatalf("expected two cleanup calls (orphan + stuck), got %#v", got)
 	}
 	if len(store.stuckSpawningBefore) == 0 || len(store.stuckActivatingBefore) == 0 {
 		t.Fatal("expected stuck worker cutoff lookup")
@@ -303,55 +237,12 @@ func TestControlPlaneJanitorRunReconcilesWarmCapacity(t *testing.T) {
 	}
 }
 
-func TestControlPlaneJanitorDeletesHotIdlePodAfterStoreRetire(t *testing.T) {
-	now := time.Date(2026, time.May, 22, 14, 0, 0, 0, time.UTC)
-	listed := configstore.WorkerRecord{
-		WorkerID:          11,
-		PodName:           "duckgres-worker-11",
-		State:             configstore.WorkerStateHotIdle,
-		OwnerCPInstanceID: "cp-old:boot-a",
-		OwnerEpoch:        2,
-		UpdatedAt:         now.Add(-2 * time.Minute),
-	}
-	current := listed
-	store := &captureControlPlaneExpiryStore{
-		expiredHotIdleWorkers: []configstore.WorkerRecord{listed},
-		retireHotIdleCurrent:  map[int]*configstore.WorkerRecord{11: &current},
-	}
-	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
-	janitor.now = func() time.Time { return now }
-	janitor.hotIdleTTL = time.Minute
-
-	var mu sync.Mutex
-	var deleted []struct {
-		id     int
-		reason string
-	}
-	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
-		mu.Lock()
-		defer mu.Unlock()
-		deleted = append(deleted, struct {
-			id     int
-			reason string
-		}{id: record.WorkerID, reason: reason})
-	}
-	janitor.retireWorker = func(record configstore.WorkerRecord, reason string) {
-		t.Fatalf("hot-idle post-CAS cleanup must not call the CAS-owning retireWorker callback: worker=%d reason=%s", record.WorkerID, reason)
-	}
-
-	janitor.runOnce()
-
-	if len(store.retireHotIdleRecords) != 1 || store.retireHotIdleRecords[0].WorkerID != 11 {
-		t.Fatalf("expected one RetireHotIdleWorker call for worker 11, got %#v", store.retireHotIdleRecords)
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	if len(deleted) != 1 || deleted[0].id != 11 || deleted[0].reason != "hot_idle_ttl_expired" {
-		t.Fatalf("expected post-CAS delete for hot-idle worker 11, got %#v", deleted)
-	}
-}
-
-func TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterStoreMiss(t *testing.T) {
+func TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterLifecycleCASMiss(t *testing.T) {
+	// When the lifecycle's terminal CAS misses (the worker was reclaimed
+	// between the list and the CAS), the lifecycle does NOT schedule
+	// cleanup. The janitor must not paper over that by invoking any
+	// other cleanup path — observability of the miss is the desired
+	// signal.
 	now := time.Date(2026, time.May, 22, 14, 5, 0, 0, time.UTC)
 	listed := configstore.WorkerRecord{
 		WorkerID:          12,
@@ -361,28 +252,23 @@ func TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterStoreMiss(t *testing.T) {
 		OwnerEpoch:        2,
 		UpdatedAt:         now.Add(-2 * time.Minute),
 	}
-	current := listed
-	current.UpdatedAt = listed.UpdatedAt.Add(time.Second)
 	store := &captureControlPlaneExpiryStore{
 		expiredHotIdleWorkers: []configstore.WorkerRecord{listed},
-		retireHotIdleCurrent:  map[int]*configstore.WorkerRecord{12: &current},
 	}
+	lifecycleStore := &fakeLifecycleStore{terminalReturn: false}
+	cleanup := &fakePhysicalCleanup{}
 	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
 	janitor.now = func() time.Time { return now }
 	janitor.hotIdleTTL = time.Minute
-
-	var deleted []int
-	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
-		deleted = append(deleted, record.WorkerID)
-	}
+	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
 
 	janitor.runOnce()
 
-	if len(store.retireHotIdleRecords) != 1 || store.retireHotIdleRecords[0].WorkerID != 12 {
-		t.Fatalf("expected one RetireHotIdleWorker call for worker 12, got %#v", store.retireHotIdleRecords)
+	if got := lifecycleStore.terminalTransitions; len(got) != 1 || got[0].workerID != 12 {
+		t.Fatalf("expected one terminal CAS attempt for worker 12, got %#v", got)
 	}
-	if len(deleted) != 0 {
-		t.Fatalf("expected no pod delete after hot-idle CAS miss, got %#v", deleted)
+	if got := cleanup.snapshot(); len(got) != 0 {
+		t.Fatalf("expected no cleanup after hot-idle CAS miss, got %#v", got)
 	}
 }
 
@@ -405,18 +291,6 @@ func TestControlPlaneJanitorHotIdleGoesThroughLifecycleWhenWired(t *testing.T) {
 	janitor.now = func() time.Time { return now }
 	janitor.hotIdleTTL = time.Minute
 	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
-	// The lifecycle path must not touch the legacy delete callback —
-	// the cleanup goes through the lifecycle's WorkerPhysicalCleanup.
-	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
-		t.Fatalf("lifecycle hot-idle path must not invoke deleteRetiredWorker fallback: worker=%d", record.WorkerID)
-	}
-	janitor.retireLocalWorker = func(int, string) bool {
-		t.Fatal("lifecycle hot-idle path must not invoke retireLocalWorker fallback")
-		return false
-	}
-	janitor.retireWorker = func(configstore.WorkerRecord, string) {
-		t.Fatal("lifecycle hot-idle path must not invoke retireWorker fallback")
-	}
 
 	janitor.runOnce()
 
@@ -452,15 +326,6 @@ func TestControlPlaneJanitorOrphanGoesThroughLifecycleWhenWired(t *testing.T) {
 	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
 	janitor.now = func() time.Time { return now }
 	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
-	janitor.retireWorker = func(configstore.WorkerRecord, string) {
-		t.Fatal("lifecycle orphan path must not invoke retireWorker fallback")
-	}
-	janitor.retireOrphanWorker = func(record configstore.WorkerRecord, reason string) {
-		t.Fatalf("lifecycle orphan path must not invoke retireOrphanWorker fallback: worker=%d reason=%s", record.WorkerID, reason)
-	}
-	janitor.deleteRetiredWorker = func(configstore.WorkerRecord, string) {
-		t.Fatal("lifecycle orphan path must not invoke deleteRetiredWorker fallback")
-	}
 
 	janitor.runOnce()
 
@@ -560,30 +425,21 @@ func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 	store := &captureControlPlaneExpiryStore{
 		expireErr: errors.New("boom"),
 		orphanedWorkers: []configstore.WorkerRecord{
-			{WorkerID: 7, PodName: "duckgres-worker-7"},
+			{WorkerID: 7, PodName: "duckgres-worker-7", State: configstore.WorkerStateHot, OwnerCPInstanceID: "cp-expired:boot-a", OwnerEpoch: 2},
 		},
 		stuckWorkers: []configstore.WorkerRecord{
-			{WorkerID: 9, PodName: "duckgres-worker-9", State: configstore.WorkerStateActivating},
+			{WorkerID: 9, PodName: "duckgres-worker-9", State: configstore.WorkerStateActivating, OwnerCPInstanceID: "cp-me:boot-b", OwnerEpoch: 1},
 		},
 	}
+	lifecycleStore := &fakeLifecycleStore{orphanReturn: true, terminalReturn: true}
+	cleanup := &fakePhysicalCleanup{}
 	now := time.Date(2026, time.March, 27, 18, 0, 0, 0, time.UTC)
 	janitor := NewControlPlaneJanitor(store, time.Second, 20*time.Second)
 	janitor.now = func() time.Time { return now }
+	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
 
 	var mu sync.Mutex
-	var retired []struct {
-		id     int
-		reason string
-	}
 	reconciled := 0
-	janitor.retireWorker = func(record configstore.WorkerRecord, reason string) {
-		mu.Lock()
-		defer mu.Unlock()
-		retired = append(retired, struct {
-			id     int
-			reason string
-		}{id: record.WorkerID, reason: reason})
-	}
 	janitor.reconcileWarmCapacity = func() {
 		mu.Lock()
 		defer mu.Unlock()
@@ -595,21 +451,21 @@ func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 	if len(store.cutoffs) != 1 {
 		t.Fatalf("expected stale control-plane expiry to run once, got %d", len(store.cutoffs))
 	}
-	if len(store.orphanedBefore) != 1 {
-		t.Fatalf("expected orphaned worker lookup despite expiry error, got %d", len(store.orphanedBefore))
-	}
 	if len(store.stuckSpawningBefore) != 1 || len(store.stuckActivatingBefore) != 1 {
 		t.Fatalf("expected stuck worker lookup despite expiry error, got spawning=%d activating=%d", len(store.stuckSpawningBefore), len(store.stuckActivatingBefore))
 	}
 	if len(store.expiredSessionsBefore) != 1 {
 		t.Fatalf("expected flight session expiry despite expiry error, got %d", len(store.expiredSessionsBefore))
 	}
+	if got := lifecycleStore.orphanTransitions; len(got) != 1 || got[0].workerID != 7 {
+		t.Fatalf("expected one orphan CAS for worker 7 despite expiry error, got %#v", got)
+	}
+	if got := lifecycleStore.terminalTransitions; len(got) != 1 || got[0].workerID != 9 {
+		t.Fatalf("expected one stuck-worker terminal CAS for worker 9 despite expiry error, got %#v", got)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(retired) != 2 {
-		t.Fatalf("expected orphaned and stuck workers to be retired, got %+v", retired)
-	}
 	if reconciled != 1 {
 		t.Fatalf("expected warm capacity reconciliation despite expiry error, got %d", reconciled)
 	}

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -200,8 +200,20 @@ func TestControlPlaneJanitorRunRetiresOrphanedAndStuckWorkers(t *testing.T) {
 	if got := lifecycleStore.orphanTransitions; len(got) != 1 || got[0].workerID != 7 || got[0].reason != janitorRetireReasonOrphaned {
 		t.Fatalf("expected one orphan CAS via lifecycle for worker 7, got %#v", got)
 	}
+	// The snapshot the janitor passed to RetireOrphanFromSnapshot must
+	// carry the listed row's identity verbatim — owner_cp_instance_id +
+	// state are what the underlying SQL fence keys off. The mock
+	// records both so a regression that strips fields from the
+	// snapshot in transit gets caught here, not just by the postgres
+	// integration tests.
+	if got := lifecycleStore.orphanTransitions[0]; got.state != configstore.WorkerStateHot {
+		t.Fatalf("expected orphan snapshot to carry state=hot, got %q", got.state)
+	}
 	if got := lifecycleStore.terminalTransitions; len(got) != 1 || got[0].workerID != 9 || got[0].reason != janitorRetireReasonStuckActivating || got[0].target != configstore.WorkerStateRetired {
 		t.Fatalf("expected one terminal CAS via lifecycle for stuck worker 9 → retired, got %#v", got)
+	}
+	if got := lifecycleStore.terminalTransitions[0]; got.state != configstore.WorkerStateActivating {
+		t.Fatalf("expected stuck snapshot to carry state=activating, got %q", got.state)
 	}
 	if got := cleanup.snapshot(); len(got) != 2 {
 		t.Fatalf("expected two cleanup calls (orphan + stuck), got %#v", got)

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -188,11 +188,11 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		nodeFirstSeen:         make(map[string]time.Time),
 	}
 	if cfg.RuntimeStore != nil {
-		// The lifecycle service is the typed seam for all post-CAS pod
-		// cleanup. Wire it to the pool's own DeleteWorkerArtifacts (which
-		// shares plumbing with the legacy deleteRetiredRuntimeWorker
-		// path) so migrated and legacy callers schedule the same K8s
-		// cleanup goroutine.
+		// The lifecycle service is the typed seam for every post-CAS
+		// pod cleanup. Wire it to the pool's own DeleteWorkerArtifacts
+		// so callers schedule the standard K8s cleanup goroutine.
+		// Tests that bypass this constructor and set runtimeStore
+		// directly trigger lazy initialization via ensureLifecycle().
 		pool.lifecycle = NewWorkerLifecycle(cfg.RuntimeStore, pool)
 	}
 
@@ -314,10 +314,11 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 			continue
 		}
 
-		if snap == nil || p.lifecycle == nil {
+		lifecycle := p.ensureLifecycle()
+		if snap == nil || lifecycle == nil {
 			continue
 		}
-		outcome, err := p.lifecycle.RetireIdleVariantFromSnapshot(*snap, RetireReasonMismatchedVersion)
+		outcome, err := lifecycle.RetireIdleVariantFromSnapshot(*snap, RetireReasonMismatchedVersion)
 		if err != nil {
 			slog.Warn("Version-aware reaper failed to retire idle row.", "worker_id", workerID, "error", err)
 			continue
@@ -1788,50 +1789,45 @@ func (p *K8sWorkerPool) retireClaimedWorker(claimed *configstore.WorkerRecord, r
 	if claimed == nil {
 		return
 	}
+	lifecycle := p.ensureLifecycle()
+	if lifecycle == nil {
+		return
+	}
 	terminalState := configstore.WorkerStateRetired
 	if reason == RetireReasonCrash {
 		terminalState = configstore.WorkerStateLost
 	}
-	if p.lifecycle != nil {
-		// Lifecycle path: snapshot-fenced CAS + post-CAS cleanup in one
-		// call. The claimed record is fresh enough to act as a
-		// snapshot — it came back from a claim/reserve and any
-		// concurrent change will simply CAS-miss here.
-		snap := configstore.NewWorkerSnapshot(*claimed)
-		if _, err := p.lifecycle.RetireFromSnapshot(snap, terminalState, reason); err != nil {
-			slog.Warn("Failed to retire claimed worker.",
-				"worker_id", claimed.WorkerID, "reason", reason, "error", err)
-		}
-		return
+	// The claimed record is fresh enough to act as a snapshot — it came
+	// back from a Claim*/TakeOver*/Create*Slot call and any concurrent
+	// change will simply CAS-miss inside MarkWorkerTerminalIfCurrent.
+	// Pod cleanup is scheduled by the lifecycle on a successful CAS via
+	// the WorkerPhysicalCleanup (this pool's DeleteWorkerArtifacts).
+	snap := configstore.NewWorkerSnapshot(*claimed)
+	if _, err := lifecycle.RetireFromSnapshot(snap, terminalState, reason); err != nil {
+		slog.Warn("Failed to retire claimed worker.",
+			"worker_id", claimed.WorkerID, "reason", reason, "error", err)
 	}
-	if p.runtimeStore != nil {
-		// Legacy path retained until PR 4 prunes the worker-id-only
-		// store methods; only reached when the pool is constructed
-		// without a runtime store (process backend).
-		updated, err := p.runtimeStore.MarkWorkerTerminalIfCurrent(claimed, terminalState, reason)
-		if err != nil {
-			slog.Warn("Failed to retire claimed worker.",
-				"worker_id", claimed.WorkerID, "reason", reason, "error", err)
-			return
-		}
-		if !updated {
-			slog.Debug("Claimed worker changed before retirement; skipping pod delete.",
-				"worker_id", claimed.WorkerID, "reason", reason)
-			return
-		}
-	}
-
-	p.deleteRetiredRuntimeWorker(claimed, reason)
 }
 
 // DeleteWorkerArtifacts implements WorkerPhysicalCleanup. Schedules pod
 // + RPC secret + local-pool cleanup for the named worker, called by
-// WorkerLifecycle after a durable CAS to terminal has landed. The
-// existing deleteRetiredRuntimeWorker carries the same behavior under a
-// *WorkerRecord arg; this method is the typed-API entry point used by
-// the lifecycle service.
+// WorkerLifecycle after a durable CAS to terminal has landed.
 func (p *K8sWorkerPool) DeleteWorkerArtifacts(workerID int, podName, reason string) {
 	p.deleteRetiredRuntimeWorker(&configstore.WorkerRecord{WorkerID: workerID, PodName: podName}, reason)
+}
+
+// ensureLifecycle returns the pool's lifecycle service, lazily wiring
+// it on first use when a runtimeStore is set but lifecycle is nil.
+// Production paths go through newK8sWorkerPool which initializes
+// lifecycle eagerly; this lazy path exists for tests that construct
+// the pool struct directly and set runtimeStore after the fact.
+// Returns nil when no runtime store is available (process backend
+// builds, or test fixtures that haven't wired the durable layer).
+func (p *K8sWorkerPool) ensureLifecycle() *WorkerLifecycle {
+	if p.lifecycle == nil && p.runtimeStore != nil {
+		p.lifecycle = NewWorkerLifecycle(p.runtimeStore, p)
+	}
+	return p.lifecycle
 }
 
 // deleteRetiredRuntimeWorker performs the post-CAS cleanup for a worker whose
@@ -2420,32 +2416,21 @@ func (p *K8sWorkerPool) ShutdownAll() {
 		// reflects any concurrent cred-refresh bump that landed between
 		// the workers-list snapshot above and now. Step 3 below re-mints
 		// for the same reason — see the comment there.
-		if p.lifecycle != nil {
-			lease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch())
-			outcome, err := p.lifecycle.Drain(lease)
-			if err != nil {
-				slog.Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
-					"worker_id", w.ID, "error", err)
-				continue
-			}
-			if !outcome.Transitioned {
-				slog.Debug("ShutdownAll: worker not owned by us or already terminal; skipping.",
-					"worker_id", w.ID)
-				continue
-			}
-		} else if p.runtimeStore != nil {
-			// Legacy path retained for builds without a lifecycle.
-			transitioned, err := p.runtimeStore.MarkWorkerDraining(w.ID, p.cpInstanceID, w.OwnerEpoch())
-			if err != nil {
-				slog.Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
-					"worker_id", w.ID, "error", err)
-				continue
-			}
-			if !transitioned {
-				slog.Debug("ShutdownAll: worker not owned by us or already terminal; skipping.",
-					"worker_id", w.ID)
-				continue
-			}
+		lifecycle := p.ensureLifecycle()
+		if lifecycle == nil {
+			continue
+		}
+		lease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch())
+		outcome, err := lifecycle.Drain(lease)
+		if err != nil {
+			slog.Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
+				"worker_id", w.ID, "error", err)
+			continue
+		}
+		if !outcome.Transitioned {
+			slog.Debug("ShutdownAll: worker not owned by us or already terminal; skipping.",
+				"worker_id", w.ID)
+			continue
 		}
 
 		// Step 2: delete pod. Leave the row in draining on any error other
@@ -2469,22 +2454,12 @@ func (p *K8sWorkerPool) ShutdownAll() {
 		// shutdown) the row stays in draining and the orphan sweep handles
 		// it once this CP's heartbeat expires. Re-read w.OwnerEpoch() so a
 		// cred-refresh bump that landed between Step 1 and now uses the
-		// fresh epoch — without this, the legacy direct-store path's
-		// per-step w.OwnerEpoch() lookup would succeed here while the
-		// lifecycle path with a captured lease would CAS-miss.
-		if p.lifecycle != nil {
-			lateLease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch())
-			if _, err := p.lifecycle.RetireDrained(lateLease, RetireReasonShutdown); err != nil {
-				slog.Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile.",
-					"worker_id", w.ID, "error", err)
-				continue
-			}
-		} else if p.runtimeStore != nil {
-			if _, err := p.runtimeStore.RetireDrainingWorker(w.ID, p.cpInstanceID, w.OwnerEpoch(), RetireReasonShutdown); err != nil {
-				slog.Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile.",
-					"worker_id", w.ID, "error", err)
-				continue
-			}
+		// fresh epoch.
+		lateLease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch())
+		if _, err := lifecycle.RetireDrained(lateLease, RetireReasonShutdown); err != nil {
+			slog.Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile.",
+				"worker_id", w.ID, "error", err)
+			continue
 		}
 
 		// In-memory lifecycle + metrics. Intentionally skips persistence

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -191,9 +191,16 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		// The lifecycle service is the typed seam for every post-CAS
 		// pod cleanup. Wire it to the pool's own DeleteWorkerArtifacts
 		// so callers schedule the standard K8s cleanup goroutine.
-		// Tests that bypass this constructor and set runtimeStore
-		// directly trigger lazy initialization via ensureLifecycle().
-		pool.lifecycle = NewWorkerLifecycle(cfg.RuntimeStore, pool)
+		// RuntimeWorkerStore intentionally omits the worker-id-only
+		// CAS methods (MarkWorkerDraining/RetireDrainingWorker/
+		// BumpWorkerEpoch) — they're reachable only through the
+		// lifecycle. We extract them here via a type assertion against
+		// the concrete store. Tests that bypass this constructor and
+		// set runtimeStore directly trigger lazy initialization via
+		// ensureLifecycle().
+		if ls, ok := cfg.RuntimeStore.(workerLifecycleStore); ok {
+			pool.lifecycle = NewWorkerLifecycle(ls, pool)
+		}
 	}
 
 	// Resolve CP pod UID for owner references
@@ -1821,11 +1828,14 @@ func (p *K8sWorkerPool) DeleteWorkerArtifacts(workerID int, podName, reason stri
 // Production paths go through newK8sWorkerPool which initializes
 // lifecycle eagerly; this lazy path exists for tests that construct
 // the pool struct directly and set runtimeStore after the fact.
-// Returns nil when no runtime store is available (process backend
-// builds, or test fixtures that haven't wired the durable layer).
+// Returns nil when no runtime store is available, or when the store
+// doesn't satisfy workerLifecycleStore (process backend / minimal
+// mocks that intentionally don't implement the CAS methods).
 func (p *K8sWorkerPool) ensureLifecycle() *WorkerLifecycle {
 	if p.lifecycle == nil && p.runtimeStore != nil {
-		p.lifecycle = NewWorkerLifecycle(p.runtimeStore, p)
+		if ls, ok := p.runtimeStore.(workerLifecycleStore); ok {
+			p.lifecycle = NewWorkerLifecycle(ls, p)
+		}
 	}
 	return p.lifecycle
 }

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -96,7 +96,8 @@ type K8sWorkerPool struct {
 	healthCheckFunc               func(context.Context, *ManagedWorker) error
 	connectWorkerFunc             func(ctx context.Context, podName, podIP, bearerToken string) (*flightsql.Client, error)
 	runtimeStore                  RuntimeWorkerStore
-	lifecycle                     *WorkerLifecycle // typed lifecycle transitions; nil safe (callers fall back to legacy paths)
+	lifecycle                     *WorkerLifecycle // typed lifecycle transitions; lazily wired via ensureLifecycle().
+	lifecycleOnce                 sync.Once        // guards lazy initialization of lifecycle from concurrent first-callers.
 
 	activatingTimeout time.Duration // max time a worker can stay in reserved/activating before being reaped
 
@@ -1831,12 +1832,23 @@ func (p *K8sWorkerPool) DeleteWorkerArtifacts(workerID int, podName, reason stri
 // Returns nil when no runtime store is available, or when the store
 // doesn't satisfy workerLifecycleStore (process backend / minimal
 // mocks that intentionally don't implement the CAS methods).
+//
+// Guarded by sync.Once so concurrent first-callers (e.g. idleReaper
+// and janitor goroutines) don't race on the field assignment. The Once
+// is per-pool, so test pools that build a fresh pool per test still
+// get fresh lifecycle initialization.
 func (p *K8sWorkerPool) ensureLifecycle() *WorkerLifecycle {
-	if p.lifecycle == nil && p.runtimeStore != nil {
+	p.lifecycleOnce.Do(func() {
+		if p.lifecycle != nil {
+			return
+		}
+		if p.runtimeStore == nil {
+			return
+		}
 		if ls, ok := p.runtimeStore.(workerLifecycleStore); ok {
 			p.lifecycle = NewWorkerLifecycle(ls, p)
 		}
-	}
+	})
 	return p.lifecycle
 }
 
@@ -1873,36 +1885,6 @@ func (p *K8sWorkerPool) deleteRetiredRuntimeWorker(record *configstore.WorkerRec
 	}
 
 	go p.retireWorkerPod(record.WorkerID, worker)
-}
-
-// retireOrphanWorker retires a worker the orphan janitor has identified
-// (its owning CP is expired, missing, or never existed). Unlike
-// retireClaimedWorker, this path skips the in-memory pool bookkeeping
-// (the worker isn't owned by this CP) and uses the broader
-// RetireOrphanWorker DB transition that handles every active state, not
-// just idle/hot_idle. The K8s pod delete is fire-and-forget and harmless
-// if the pod is already gone.
-func (p *K8sWorkerPool) retireOrphanWorker(record *configstore.WorkerRecord, reason string) {
-	if p.runtimeStore == nil || record == nil {
-		return
-	}
-	retired, err := p.runtimeStore.RetireOrphanWorker(record, reason)
-	if err != nil {
-		slog.Warn("Failed to retire orphan worker.",
-			"worker_id", record.WorkerID, "reason", reason, "error", err)
-		return
-	}
-	if !retired {
-		slog.Debug("Orphan worker changed before retirement; skipping pod delete.",
-			"worker_id", record.WorkerID, "reason", reason)
-		return
-	}
-	worker := &ManagedWorker{
-		ID:      record.WorkerID,
-		podName: record.PodName,
-		done:    make(chan struct{}),
-	}
-	go p.retireWorkerPod(worker.ID, worker)
 }
 
 func (p *K8sWorkerPool) checkReservedWorkerLiveness(ctx context.Context, worker *ManagedWorker) error {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -3541,16 +3541,30 @@ ducklake:
 
 func TestK8sPool_ShutdownAll(t *testing.T) {
 	pool, cs := newTestK8sPool(t, 5)
+	// Wire a runtime store so the lifecycle-using ShutdownAll path
+	// actually executes its CAS chain and pod deletes. Without this
+	// every worker's loop body would early-out at the lifecycle nil
+	// check, leaving the test vacuously passing on the in-memory map
+	// emptied by the trailing `p.workers = preserved` line.
+	store := &captureRuntimeWorkerStore{preloadedRecords: map[int]*configstore.WorkerRecord{}}
+	pool.runtimeStore = store
 
-	// Add some workers
 	for i := 0; i < 3; i++ {
 		done := make(chan struct{})
-		pool.workers[i] = &ManagedWorker{ID: i, podName: "duckgres-worker-test-cp-" + strconv.Itoa(i), done: done}
-
-		// Create corresponding pods
+		podName := "duckgres-worker-test-cp-" + strconv.Itoa(i)
+		w := &ManagedWorker{ID: i, podName: podName, done: done}
+		w.SetOwnerCPInstanceID(pool.cpInstanceID)
+		pool.workers[i] = w
+		store.preloadedRecords[i] = &configstore.WorkerRecord{
+			WorkerID:          i,
+			PodName:           podName,
+			State:             configstore.WorkerStateIdle,
+			OwnerCPInstanceID: pool.cpInstanceID,
+			OwnerEpoch:        w.OwnerEpoch(),
+		}
 		_, _ = cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "duckgres-worker-test-cp-" + strconv.Itoa(i),
+				Name:      podName,
 				Namespace: "default",
 				Labels: map[string]string{
 					"duckgres/control-plane": "test-cp",
@@ -3567,6 +3581,15 @@ func TestK8sPool_ShutdownAll(t *testing.T) {
 	pool.mu.RUnlock()
 	if count != 0 {
 		t.Fatalf("expected 0 workers after shutdown, got %d", count)
+	}
+	if store.markDrainingCalls != 3 || store.retireDrainingCalls != 3 {
+		t.Fatalf("expected 3 Drain + 3 RetireDrained CAS calls, got drain=%d retire=%d", store.markDrainingCalls, store.retireDrainingCalls)
+	}
+	for i := 0; i < 3; i++ {
+		podName := "duckgres-worker-test-cp-" + strconv.Itoa(i)
+		if podExists(t, cs, podName) {
+			t.Fatalf("expected pod %q to be deleted", podName)
+		}
 	}
 }
 

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -353,34 +353,6 @@ func (s *captureRuntimeWorkerStore) TakeOverWorker(workerID int, ownerCPInstance
 	return &record, nil
 }
 
-func (s *captureRuntimeWorkerStore) RetireIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if record == nil {
-		return false, nil
-	}
-	s.retireIdleCalls++
-	s.retireIdleCalledIDs = append(s.retireIdleCalledIDs, record.WorkerID)
-	s.retireIdleCalledReasons = append(s.retireIdleCalledReasons, reason)
-	if s.retireIdleErr != nil {
-		return false, s.retireIdleErr
-	}
-	if s.retireIdleMisses[record.WorkerID] {
-		return false, nil
-	}
-	if record.State != configstore.WorkerStateIdle {
-		return false, nil
-	}
-	rec := s.preloadedRecords[record.WorkerID]
-	if rec == nil || !observedWorkerRecordMatchesCurrent(record, rec) {
-		return false, nil
-	}
-	rec.State = configstore.WorkerStateRetired
-	rec.RetireReason = reason
-	rec.UpdatedAt = time.Now()
-	return true, nil
-}
-
 func (s *captureRuntimeWorkerStore) RetireIdleOrHotIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -3874,7 +3846,9 @@ func mismatchVersionTestPool(t *testing.T, cpID string, store RuntimeWorkerStore
 		retireSem:    make(chan struct{}, 5),
 	}
 	if store != nil {
-		pool.lifecycle = NewWorkerLifecycle(store, pool)
+		if ls, ok := interface{}(store).(workerLifecycleStore); ok {
+			pool.lifecycle = NewWorkerLifecycle(ls, pool)
+		}
 	}
 	return pool, cs
 }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -241,22 +241,11 @@ func SetupMultiTenant(
 	janitor.maxDrainTimeout = cfg.HandoverDrainTimeout
 	janitor.hotIdleTTL = defaultHotIdleTTL
 	janitor.warmCapacityMissBucketTTL = cfg.K8s.WarmCapacityDemandTTL
-	janitor.retireWorker = func(record configstore.WorkerRecord, reason string) {
-		router.sharedPool.retireClaimedWorker(&record, reason)
-	}
-	janitor.retireOrphanWorker = func(record configstore.WorkerRecord, reason string) {
-		router.sharedPool.retireOrphanWorker(&record, reason)
-	}
-	janitor.retireLocalWorker = func(workerID int, reason string) bool {
-		return router.sharedPool.retireWorkerWithReason(workerID, reason)
-	}
-	janitor.deleteRetiredWorker = func(record configstore.WorkerRecord, reason string) {
-		router.sharedPool.deleteRetiredRuntimeWorker(&record, reason)
-	}
-	// Hand the shared pool's lifecycle service to the janitor so the
-	// hot-idle reaper path goes through one snapshot-fenced CAS-and-cleanup
-	// call instead of the older retireLocalWorker / retireWorker /
-	// deleteRetiredWorker fallback chain.
+	// Per-worker transitions (orphan retire, stuck reaper, hot-idle TTL)
+	// all flow through this lifecycle service. The legacy retireWorker /
+	// retireOrphanWorker / retireLocalWorker / deleteRetiredWorker
+	// lambda chain is gone — the snapshot/lease-typed API is the only
+	// path now.
 	janitor.lifecycle = router.sharedPool.lifecycle
 	lastWarmCapacityTargets := map[string]int{}
 	var lastWarmCapacityRecentMisses []configstore.WarmCapacityMissAggregate

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -100,12 +100,14 @@ func NewSharedWorkerActivator(shared *K8sWorkerPool, stsBroker *STSBroker, defau
 	if rs, ok := shared.runtimeStore.(credentialExpiryStore); ok {
 		a.runtimeStore = rs
 	}
-	// Borrow the pool's lifecycle service when available so the
-	// cred-refresh path can mint a typed WorkerLease via RefreshLease
-	// instead of calling BumpWorkerEpoch directly. Tests that construct
-	// a pool without a lifecycle get a nil here and fall back to the
-	// legacy direct-store path.
-	a.lifecycle = shared.lifecycle
+	// Borrow the pool's lifecycle service via ensureLifecycle() so we
+	// pick up the lazy initialization path the pool uses when
+	// runtimeStore was wired after construction (test fixtures). With
+	// PR 4's legacy-fallback deletion, the activator now refuses to
+	// refresh credentials when lifecycle is nil — going through
+	// ensureLifecycle gives us the same wiring discipline the
+	// K8sWorkerPool itself uses.
+	a.lifecycle = shared.ensureLifecycle()
 	return a
 }
 

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -282,26 +282,20 @@ func (a *SharedWorkerActivator) RefreshCredentials(ctx context.Context, worker *
 		return nil
 	}
 
+	if a.lifecycle == nil {
+		return fmt.Errorf("refresh worker credentials requires a lifecycle service (worker %d)", worker.ID)
+	}
 	currentEpoch := worker.OwnerEpoch()
 	cpInstanceID := worker.OwnerCPInstanceID()
-	var newEpoch int64
-	if a.lifecycle != nil {
-		newLease, err := a.lifecycle.RefreshLease(configstore.NewWorkerLease(worker.ID, cpInstanceID, currentEpoch))
-		if err != nil {
-			// Keep the legacy "bump owner epoch for refresh" wrapper
-			// wording even though the lifecycle method is named
-			// RefreshLease, so log-grep / dashboard filters that
-			// pattern-match on the previous string still work.
-			return fmt.Errorf("bump owner epoch for refresh: %w", err)
-		}
-		newEpoch = newLease.OwnerEpoch()
-	} else {
-		var err error
-		newEpoch, err = a.runtimeStore.BumpWorkerEpoch(worker.ID, cpInstanceID, currentEpoch)
-		if err != nil {
-			return fmt.Errorf("bump owner epoch for refresh: %w", err)
-		}
+	newLease, err := a.lifecycle.RefreshLease(configstore.NewWorkerLease(worker.ID, cpInstanceID, currentEpoch))
+	if err != nil {
+		// Keep the legacy "bump owner epoch for refresh" wrapper wording
+		// even though the lifecycle method is named RefreshLease, so
+		// log-grep / dashboard filters that pattern-match on the
+		// previous string still work.
+		return fmt.Errorf("bump owner epoch for refresh: %w", err)
 	}
+	newEpoch := newLease.OwnerEpoch()
 	worker.SetOwnerEpoch(newEpoch)
 
 	rpcPayload := server.WorkerActivationPayload{

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -315,13 +315,23 @@ func (a *SharedWorkerActivator) RefreshCredentials(ctx context.Context, worker *
 		return fmt.Errorf("activate tenant for refresh: %w", err)
 	}
 
-	if _, err := a.runtimeStore.MarkCredentialsRefreshed(
-		worker.ID, cpInstanceID, newEpoch, *payload.S3CredentialsExpiresAt,
-	); err != nil {
-		// The worker has new creds in DuckDB; we just couldn't record the
-		// new expiry. Next tick will see a stale expiry and refresh again.
-		slog.Warn("Failed to record refreshed credential expiry.",
-			"worker_id", worker.ID, "org", payload.OrgID, "error", err)
+	if a.runtimeStore != nil {
+		// Guarded against a future store implementation that satisfies
+		// workerLifecycleStore (for the RefreshLease above) but not
+		// credentialExpiryStore. Production ConfigStore satisfies
+		// both, but the two type assertions in NewSharedWorkerActivator
+		// are independent and a partial mock could leave runtimeStore
+		// nil while lifecycle is set. The expiry stamp is best-effort
+		// — skipping it just means the next refresh tick sees a stale
+		// expiry and refreshes again.
+		if _, err := a.runtimeStore.MarkCredentialsRefreshed(
+			worker.ID, cpInstanceID, newEpoch, *payload.S3CredentialsExpiresAt,
+		); err != nil {
+			// The worker has new creds in DuckDB; we just couldn't record the
+			// new expiry. Next tick will see a stale expiry and refresh again.
+			slog.Warn("Failed to record refreshed credential expiry.",
+				"worker_id", worker.ID, "org", payload.OrgID, "error", err)
+		}
 	}
 	return nil
 }

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -53,13 +53,14 @@ type SharedWorkerActivator struct {
 }
 
 // credentialExpiryStore is the slice of the runtime store the activator uses
-// to record when STS-brokered S3 credentials expire on a worker, and to
-// bump the owner epoch atomically when re-activating a worker for refresh.
-// Defined as an interface so tests can substitute a fake without standing
-// up Postgres.
+// to record when STS-brokered S3 credentials expire on a worker.
+// Owner-epoch bumping for credential refresh now flows through
+// lifecycle.RefreshLease, which uses a separate workerLifecycleStore
+// interface internally — this surface stays narrow.
+// Defined as an interface so tests can substitute a fake without
+// standing up Postgres.
 type credentialExpiryStore interface {
 	MarkCredentialsRefreshed(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, expiresAt time.Time) (bool, error)
-	BumpWorkerEpoch(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (int64, error)
 }
 
 type TenantActivationPayload struct {

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -114,17 +114,17 @@ type K8sWorkerPoolConfig struct {
 }
 
 // RuntimeWorkerStore is the durable-store surface exposed to the K8s
-// worker pool. Worker-id-only lifecycle CAS methods (MarkWorkerDraining,
-// RetireDrainingWorker, BumpWorkerEpoch) are intentionally absent — they
+// worker pool. Lifecycle CAS methods are intentionally absent — they
 // are reachable only through WorkerLifecycle so callers cannot bypass
-// the typed lease seam. MarkWorkerLostIfCurrentLease remains for now
-// because the health-checker path hasn't been migrated to
+// the typed snapshot/lease seam. MarkWorkerLostIfCurrentLease remains
+// for now because the health-checker path hasn't been migrated to
 // lifecycle.MarkLostFromLease yet (deferred to PR 5).
 //
 // The lifecycle service uses workerLifecycleStore (defined in
-// worker_lifecycle.go), which is a larger interface. Production wires
-// it via a type assertion in newK8sWorkerPool / ensureLifecycle,
-// because *configstore.ConfigStore satisfies both interfaces.
+// worker_lifecycle.go), which is a larger interface that includes the
+// CAS methods. Production wires it via a type assertion in
+// newK8sWorkerPool / ensureLifecycle, because *configstore.ConfigStore
+// satisfies both interfaces.
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
 	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
@@ -136,9 +136,6 @@ type RuntimeWorkerStore interface {
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	ObserveWorker(workerID int) (*configstore.WorkerSnapshot, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
-	RetireIdleOrHotIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error)
-	RetireOrphanWorker(record *configstore.WorkerRecord, reason string) (bool, error)
-	MarkWorkerTerminalIfCurrent(record *configstore.WorkerRecord, targetState configstore.WorkerState, reason string) (bool, error)
 	MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
 }
 

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -113,6 +113,18 @@ type K8sWorkerPoolConfig struct {
 	RuntimeStore          RuntimeWorkerStore
 }
 
+// RuntimeWorkerStore is the durable-store surface exposed to the K8s
+// worker pool. Worker-id-only lifecycle CAS methods (MarkWorkerDraining,
+// RetireDrainingWorker, BumpWorkerEpoch) are intentionally absent — they
+// are reachable only through WorkerLifecycle so callers cannot bypass
+// the typed lease seam. MarkWorkerLostIfCurrentLease remains for now
+// because the health-checker path hasn't been migrated to
+// lifecycle.MarkLostFromLease yet (deferred to PR 5).
+//
+// The lifecycle service uses workerLifecycleStore (defined in
+// worker_lifecycle.go), which is a larger interface. Production wires
+// it via a type assertion in newK8sWorkerPool / ensureLifecycle,
+// because *configstore.ConfigStore satisfies both interfaces.
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
 	ClaimIdleWorker(ownerCPInstanceID, orgID, image string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
@@ -124,14 +136,10 @@ type RuntimeWorkerStore interface {
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	ObserveWorker(workerID int) (*configstore.WorkerSnapshot, error)
 	TakeOverWorker(workerID int, ownerCPInstanceID, orgID string, expectedOwnerEpoch int64) (*configstore.WorkerRecord, error)
-	RetireIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error)
 	RetireIdleOrHotIdleWorker(record *configstore.WorkerRecord, reason string) (bool, error)
 	RetireOrphanWorker(record *configstore.WorkerRecord, reason string) (bool, error)
 	MarkWorkerTerminalIfCurrent(record *configstore.WorkerRecord, targetState configstore.WorkerState, reason string) (bool, error)
 	MarkWorkerLostIfCurrentLease(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
-	MarkWorkerDraining(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (bool, error)
-	RetireDrainingWorker(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64, reason string) (bool, error)
-	BumpWorkerEpoch(workerID int, ownerCPInstanceID string, expectedOwnerEpoch int64) (int64, error)
 }
 
 // K8sPoolFactory creates a K8sWorkerPool. Registered at init time by the

--- a/tests/k8s/k8s_test.go
+++ b/tests/k8s/k8s_test.go
@@ -413,8 +413,8 @@ func TestK8sVersionMismatchedWorkerIsReaped(t *testing.T) {
 	}
 
 	// Brief idle window so the worker settles back into idle state in the
-	// configstore — RetireIdleWorker is a state-conditional CAS that no-ops
-	// on busy/reserved/hot rows.
+	// configstore — RetireIdleOrHotIdleWorker is a state-conditional CAS
+	// that no-ops on busy/reserved/hot rows.
 	time.Sleep(3 * time.Second)
 
 	workerPods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
## Summary

PR 4 of the worker-lifecycle redesign. **Net: +163/-434 LOC across 8 files** — mostly deletions, no new behavior.

PR 3 introduced the typed lifecycle service but left every migrated call site with a \`if lifecycle == nil { legacy }\` fallback so each migration commit was independently revertible. With PR 3 merged those fallbacks are dead in production. This PR removes them and narrows the public store interface so the typed seam is the obvious path.

## What lands in this PR

### 1. Delete legacy \`lifecycle == nil\` fallback branches

- \`k8s_pool.go::retireClaimedWorker\`: the direct \`MarkWorkerTerminalIfCurrent\` + \`deleteRetiredRuntimeWorker\` branch is gone; \`lifecycle.RetireFromSnapshot\` is the only path.
- \`k8s_pool.go::ShutdownAll\`: the direct \`MarkWorkerDraining\` / \`RetireDrainingWorker\` legacy branches are gone; the lease-based \`Drain\` → pod delete → \`RetireDrained\` chain is the only path.
- \`shared_worker_activator.go::RefreshWorkerCredentials\`: the direct \`BumpWorkerEpoch\` branch is gone; \`lifecycle.RefreshLease\` is the only path. Returns an explicit error if the activator is constructed without a lifecycle.
- \`janitor.go\`: orphan, stuck-spawning/activating, and hot-idle reapers all flow through the lifecycle. The stuck-worker path migrates from the now-deleted \`retireWorker\` lambda to \`lifecycle.RetireFromSnapshot\`.

### 2. Delete unused janitor lambda plumbing

All four janitor lambdas (\`retireWorker\`, \`retireOrphanWorker\`, \`retireLocalWorker\`, \`deleteRetiredWorker\`) and their corresponding \`multitenant.go\` wires are gone. The \`retireRuntimeWorker\` helper that wrapped them is gone. The \`controlPlaneExpiryStore\` interface sheds \`ListOrphanedWorkers\`, \`ListStuckWorkers\`, \`ListExpiredHotIdleWorkers\`, \`RetireHotIdleWorker\` — the snapshot-typed variants are the only callers now.

### 3. Narrow \`RuntimeWorkerStore\` interface

Three worker-id-only CAS methods are moved off the public interface. They stay on \`*configstore.ConfigStore\` and are extracted via type assertion to the package-private \`workerLifecycleStore\` when wiring the lifecycle service:

- \`MarkWorkerDraining(workerID, cpID, epoch)\`
- \`RetireDrainingWorker(workerID, cpID, epoch, reason)\`
- \`BumpWorkerEpoch(workerID, cpID, epoch)\`

A caller with only a \`RuntimeWorkerStore\` reference cannot reach these methods directly — they have to go through \`WorkerLifecycle\`. That's the PR 4 hardening goal stated in the roadmap.

\`MarkWorkerLostIfCurrentLease\` stays on \`RuntimeWorkerStore\` because the health-checker (\`markWorkerLostForHealthLease\`) still calls it directly; PR 5 will migrate that path to \`lifecycle.MarkLostFromLease\`.

\`RetireIdleWorker\` is removed entirely — it had no callers anywhere in the tree.

### 4. \`K8sWorkerPool.ensureLifecycle()\`

Lazy initialization for tests that bypass \`newK8sWorkerPool\` and assign \`pool.runtimeStore\` directly. Production always wires the lifecycle eagerly in the constructor. The 42 existing tests that pattern \`pool.runtimeStore = store\` continue to work unchanged; the lifecycle is created on first lifecycle-using call.

### 5. Test cleanup

- \`TestControlPlaneJanitorDeletesHotIdlePodAfterStoreRetire\`: deleted, covered by the lifecycle-path test.
- \`TestControlPlaneJanitorSkipsHotIdlePodDeleteAfterStoreMiss\`: rewritten to assert on lifecycle outcome.
- \`TestControlPlaneJanitorRunRetiresOrphanedAndStuckWorkers\` and \`TestControlPlaneJanitorRunOnceContinuesAfterExpireError\`: migrated from \`retireWorker\` callback assertions to lifecycle-store assertions.
- The lifecycle-path tests added in PR 3 (\`TestControlPlaneJanitorHotIdleGoesThroughLifecycleWhenWired\`, \`TestControlPlaneJanitorOrphanGoesThroughLifecycleWhenWired\`) shed the now-impossible \"legacy lambda must not fire\" assertions; the fields they referenced are gone.
- \`captureRuntimeWorkerStore.RetireIdleWorker\` mock impl and unused \`janitorObservedWorkerRecordMatchesCurrent\` helper deleted.

## What stays

- \`MarkWorkerLostIfCurrentLease\` on the public interface (health-check path migration → PR 5).
- The configstore \`List*\` legacy methods (\`ListOrphanedWorkers\`, etc.) — postgres integration tests in \`tests/configstore/\` exercise them directly, and the snapshot-typed wrappers are thin layers over them.

## Testing

- \`go build -tags kubernetes ./...\` clean
- \`go vet -tags kubernetes ./controlplane/...\` clean
- \`go test ./controlplane/...\` and \`go test -tags kubernetes ./controlplane/...\` — all 5 packages pass

## Out of scope

- \`BumpWorkerEpoch ↔ ShutdownAll\` in-memory-epoch race → **PR 5**
- Health-checker migration to \`lifecycle.MarkLostFromLease\` → **PR 5** (the activator-style legacy code path it would simplify is fundamentally similar to the one PR 3 left for that reason)
- Per-image / fine-grained CAS-miss classification metrics → **PR 6**

> ⚠️ Two commits in this stack are unsigned because the Secretive agent has been refusing prompts during the autonomous session. Easy fix before merge: \`git rebase --exec 'git commit --amend --no-edit -S' origin/main\`, or rely on squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)