### PR TITLE
Stream A: configstore + provisioning API + Trino provisioner sub-component

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -200,9 +200,8 @@ const (
 // v1 is intentionally minimal — Enabled gates the projection, Tier picks
 // resource-group limits. Per-user identity within an org is post-v1.
 //
-// FK'd by OrgID like the other sibling rows; see
-// docs at /Users/gwyang/projects/plans/duckgres-trino-shared-cluster-plan.md
-// for the design.
+// FK'd by OrgID like the other sibling rows; consumed by the Trino
+// provisioner sub-component in controlplane/provisioner/trino_provisioner.go.
 type ManagedWarehouseTrino struct {
 	OrgID string `gorm:"primaryKey;size:255" json:"org_id"`
 

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -190,6 +190,51 @@ const (
 	IcebergBackendS3Tables   = "s3_tables"
 )
 
+// ManagedWarehouseTrino captures per-org opt-in for the customer-facing Trino
+// cluster. Trino access is granted at the org level: when Enabled is true, the
+// provisioner extension (controlplane/provisioner/trino_provisioner.go)
+// projects the org's `root` OrgUser bcrypt hash into the Trino file
+// password authenticator, creates a per-org Iceberg catalog via the Trino
+// REST API, and rebuilds the OPA bundle + resource-groups config.
+//
+// v1 is intentionally minimal — Enabled gates the projection, Tier picks
+// resource-group limits. Per-user identity within an org is post-v1.
+//
+// FK'd by OrgID like the other sibling rows; see
+// docs at /Users/gwyang/projects/plans/duckgres-trino-shared-cluster-plan.md
+// for the design.
+type ManagedWarehouseTrino struct {
+	OrgID string `gorm:"primaryKey;size:255" json:"org_id"`
+
+	// Enabled gates inclusion in every projection the Trino provisioner owns
+	// (password file, group file, OPA bundle catalog map, resource-groups
+	// config, REST CREATE CATALOG). Defaults to false so existing
+	// configstore rows never start projecting after a schema migration.
+	Enabled bool `gorm:"not null;default:false" json:"enabled"`
+
+	// Tier picks the resource-group limits applied to the org. Empty string
+	// is treated as the default tier by the resource-groups generator.
+	// Kept as a free-form string for now; refining into an enum is
+	// post-v1 work once tier shape stabilizes.
+	Tier string `gorm:"size:64" json:"tier"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (ManagedWarehouseTrino) TableName() string { return "duckgres_managed_warehouse_trino" }
+
+// TrinoEnabledOrg is the join shape returned by ListTrinoEnabledOrgs: org +
+// root-user bcrypt hash. The provisioner needs both at once — the password
+// file projection keys org_<team_id> by the password hash — so a single
+// query avoids an N+1 read pattern as the Trino-enabled org count grows.
+type TrinoEnabledOrg struct {
+	OrgID            string
+	DatabaseName     string
+	Tier             string
+	RootPasswordHash string // bcrypt hash from OrgUser row where Username = "root"
+}
+
 // ResolvedBackend returns Backend with the empty-string default applied.
 // Callers should prefer this over reading Backend directly so that rows
 // migrated from earlier schemas (no Backend column) behave correctly.

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -19,10 +19,11 @@ type Org struct {
 	IdleTimeoutS        int               `gorm:"default:0" json:"idle_timeout_s"`
 	WorkerCPURequest    string            `gorm:"size:32" json:"worker_cpu_request"`
 	WorkerMemoryRequest string            `gorm:"size:32" json:"worker_memory_request"`
-	Users               []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
-	Warehouse           *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
-	CreatedAt           time.Time         `json:"created_at"`
-	UpdatedAt           time.Time         `json:"updated_at"`
+	Users               []OrgUser              `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
+	Warehouse           *ManagedWarehouse      `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
+	Trino               *ManagedWarehouseTrino `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"trino,omitempty"`
+	CreatedAt           time.Time              `json:"created_at"`
+	UpdatedAt           time.Time              `json:"updated_at"`
 }
 
 func (Org) TableName() string { return "duckgres_orgs" }
@@ -217,6 +218,30 @@ type ManagedWarehouseTrino struct {
 	// post-v1 work once tier shape stabilizes.
 	Tier string `gorm:"size:64" json:"tier"`
 
+	// State / StatusMessage / ReadyAt / FailedAt mirror the
+	// ManagedWarehouse lifecycle fields so operators can see what the
+	// Trino reconcile loop is doing. The Trino reconcile is a single
+	// batched output per tick (catalog + auth + resource-groups +
+	// bundle); these fields summarize the most recent tick's outcome.
+	//
+	// State transitions:
+	//   - pending (default after EnableTrino, before first reconcile)
+	//   - provisioning (a reconcile tick is mid-flight or a previous
+	//     tick partially failed and is retrying)
+	//   - ready (the most recent tick succeeded across all four steps)
+	//   - failed (the most recent tick errored — StatusMessage carries
+	//     the per-step detail; ready_at is preserved, failed_at is set)
+	//
+	// On the next successful reconcile after a failed state, the row
+	// flips back to ready and failed_at is cleared. We don't model the
+	// plan's per-step sub-states (CatalogCreating, ProjectionReady,
+	// etc.) — for v1 the four-state summary plus StatusMessage detail
+	// is sufficient observability without growing the model.
+	State         ManagedWarehouseProvisioningState `gorm:"size:32" json:"state"`
+	StatusMessage string                            `gorm:"size:1024" json:"status_message"`
+	ReadyAt       *time.Time                        `json:"ready_at,omitempty"`
+	FailedAt      *time.Time                        `json:"failed_at,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -227,11 +252,18 @@ func (ManagedWarehouseTrino) TableName() string { return "duckgres_managed_wareh
 // root-user bcrypt hash. The provisioner needs both at once — the password
 // file projection keys org_<team_id> by the password hash — so a single
 // query avoids an N+1 read pattern as the Trino-enabled org count grows.
+//
+// State is the row's CURRENT operational state at the time of the read,
+// so the reconcile loop can decide whether each per-tick write is a
+// transition (set ReadyAt / FailedAt) or a no-op preservation
+// (matches the surrounding ManagedWarehouse pattern in controller.go,
+// which only stamps ready_at on the first transition into ready).
 type TrinoEnabledOrg struct {
 	OrgID            string
 	DatabaseName     string
 	Tier             string
-	RootPasswordHash string // bcrypt hash from OrgUser row where Username = "root"
+	RootPasswordHash string                            // bcrypt hash from OrgUser row where Username = "root"
+	State            ManagedWarehouseProvisioningState // current state at read time
 }
 
 // ResolvedBackend returns Backend with the empty-string default applied.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -641,7 +641,12 @@ func (cs *ConfigStore) EnableTrino(orgID string, settings TrinoSettings) error {
 		OrgID:   orgID,
 		Enabled: true,
 		Tier:    settings.Tier,
+		State:   ManagedWarehouseStatePending,
 	}
+	// On conflict update Enabled+Tier+UpdatedAt only. Do NOT touch
+	// State / StatusMessage / ReadyAt / FailedAt — those are owned by
+	// the reconcile loop. A re-enable on an already-Ready row stays
+	// Ready; the reconcile loop's next tick will refresh status.
 	if err := cs.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "org_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"enabled", "tier", "updated_at"}),
@@ -651,11 +656,87 @@ func (cs *ConfigStore) EnableTrino(orgID string, settings TrinoSettings) error {
 	return nil
 }
 
-// DisableTrino marks the org as no longer Trino-enabled. The row is kept
-// (rather than deleted) so the provisioner can observe the transition and
-// clean up the catalog + password file entry on its next reconcile tick.
-// Returns nil if no row exists — disabling something that was never enabled
-// is a no-op, not an error.
+// TrinoStateUpdate is the small set of columns the reconcile loop
+// writes through UpdateTrinoState. The State + StatusMessage are
+// always set; the timestamp pointers are optional ("nil" == don't
+// touch). Callers that want to clear an existing timestamp can pass a
+// pointer to a zero time.Time, but in practice the next state
+// transition just overwrites.
+type TrinoStateUpdate struct {
+	State         ManagedWarehouseProvisioningState
+	StatusMessage string
+	ReadyAt       *time.Time
+	FailedAt      *time.Time
+}
+
+// UpdateTrinoState writes the reconcile loop's per-tick outcome onto
+// an org's Trino row. Predicates on enabled=true: if DisableTrino
+// raced ahead during the reconcile tick, the row is no longer enabled
+// and any state write is a stale leftover that would mis-represent
+// the org's operational status. Returning nil on RowsAffected==0
+// keeps that race silent (the next reconcile tick won't see the
+// disabled org and won't try again).
+//
+// No CAS on state — the provisioning controller runs single-threaded
+// per pod, so the only race is between reconcile and DisableTrino.
+//
+// StatusMessage is truncated to the column width (1024 chars) so a
+// long joined-error message can't trip a Postgres "value too long"
+// error and silently fail the state record.
+func (cs *ConfigStore) UpdateTrinoState(orgID string, upd TrinoStateUpdate) error {
+	if orgID == "" {
+		return errors.New("UpdateTrinoState: orgID is required")
+	}
+	msg := upd.StatusMessage
+	if len(msg) > 1024 {
+		// Leave a trailing marker so anyone reading the row knows it
+		// was clipped; the full error went to the slog stream.
+		msg = msg[:1021] + "..."
+	}
+	updates := map[string]interface{}{
+		"state":          upd.State,
+		"status_message": msg,
+		"updated_at":     time.Now().UTC(),
+	}
+	// Pointer fields participate only when explicitly set. nil means
+	// "leave the column alone"; a non-nil zero time.Time clears it.
+	if upd.ReadyAt != nil {
+		updates["ready_at"] = upd.ReadyAt
+	}
+	if upd.FailedAt != nil {
+		// Distinguish "clear" (zero value pointer) from "set to a
+		// specific timestamp" by passing nil into the SQL UPDATE when
+		// the pointer points at a zero time.
+		if upd.FailedAt.IsZero() {
+			updates["failed_at"] = nil
+		} else {
+			updates["failed_at"] = upd.FailedAt
+		}
+	}
+	result := cs.db.Model(&ManagedWarehouseTrino{}).
+		Where("org_id = ? AND enabled = ?", orgID, true).
+		Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update trino state for %q: %w", orgID, result.Error)
+	}
+	return nil
+}
+
+// DisableTrino marks the org as no longer Trino-enabled. The row is
+// kept (rather than deleted) so the provisioner can observe the
+// transition and clean up the catalog + password file entry on its
+// next reconcile tick. Returns nil if no row exists — disabling
+// something that was never enabled is a no-op, not an error.
+//
+// State is reset to Pending alongside the enabled flip so operators
+// see the lifecycle restart: the previous Ready/Failed status no
+// longer reflects current reality (the catalog is being torn down).
+// status_message + failed_at are cleared since they belong to the
+// previous enabled lifecycle. The reconcile loop will not advance
+// state for disabled orgs (UpdateTrinoState predicates on enabled),
+// so state stays at Pending until either:
+//   - EnableTrino re-activates the org, OR
+//   - the row is deleted (e.g. via the FK CASCADE when the Org row goes).
 func (cs *ConfigStore) DisableTrino(orgID string) error {
 	if orgID == "" {
 		return errors.New("DisableTrino: orgID is required")
@@ -663,8 +744,11 @@ func (cs *ConfigStore) DisableTrino(orgID string) error {
 	result := cs.db.Model(&ManagedWarehouseTrino{}).
 		Where("org_id = ?", orgID).
 		Updates(map[string]interface{}{
-			"enabled":    false,
-			"updated_at": time.Now().UTC(),
+			"enabled":        false,
+			"state":          ManagedWarehouseStatePending,
+			"status_message": "",
+			"failed_at":      nil,
+			"updated_at":     time.Now().UTC(),
 		})
 	if result.Error != nil {
 		return fmt.Errorf("disable trino for %q: %w", orgID, result.Error)
@@ -690,7 +774,8 @@ func (cs *ConfigStore) ListTrinoEnabledOrgs() ([]TrinoEnabledOrg, error) {
 		Select(`t.org_id AS org_id,
 		         COALESCE(o.database_name, '') AS database_name,
 		         t.tier AS tier,
-		         u.password AS root_password_hash`).
+		         u.password AS root_password_hash,
+		         t.state AS state`).
 		Joins(`INNER JOIN duckgres_org_users AS u
 		        ON u.org_id = t.org_id AND u.username = 'root'`).
 		Joins(`LEFT JOIN duckgres_orgs AS o ON o.name = t.org_id`).

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -703,6 +703,25 @@ func (cs *ConfigStore) ListTrinoEnabledOrgs() ([]TrinoEnabledOrg, error) {
 	return out, nil
 }
 
+// GetManagedWarehouseIceberg reads the embedded Iceberg config for an
+// org. Returns (nil, nil) when the org has no warehouse row so callers
+// can distinguish "never provisioned" from a DB error. Used by the
+// Trino provisioner to read LakekeeperEndpoint + LakekeeperWarehouse
+// when building catalog properties — Trino-enabled orgs without an
+// Iceberg row are skipped at the call site (Iceberg isn't ready yet).
+func (cs *ConfigStore) GetManagedWarehouseIceberg(orgID string) (*ManagedWarehouseIceberg, error) {
+	var warehouse ManagedWarehouse
+	err := cs.db.First(&warehouse, "org_id = ?", orgID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get iceberg config for %q: %w", orgID, err)
+	}
+	ic := warehouse.Iceberg
+	return &ic, nil
+}
+
 // GetManagedWarehouseTrino reads the Trino row for an org. Returns
 // (nil, nil) when no row exists so callers can distinguish "never
 // configured" from a DB error.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -95,6 +95,7 @@ func NewConfigStore(connStr string, pollInterval time.Duration) (*ConfigStore, e
 	if err := db.AutoMigrate(
 		&Org{},
 		&ManagedWarehouse{},
+		&ManagedWarehouseTrino{},
 		&OrgUser{},
 		&GlobalConfig{},
 		&DuckLakeConfig{},
@@ -617,6 +618,104 @@ func (cs *ConfigStore) UpdateWarehouseState(orgID string, expectedState ManagedW
 		return fmt.Errorf("warehouse %q expected state %q: %w", orgID, expectedState, ErrWarehouseStateMismatch)
 	}
 	return nil
+}
+
+// TrinoSettings carries the per-org Trino options EnableTrino persists. New
+// fields can be added without changing call sites — the zero value matches
+// the existing default (no tier, enabled).
+type TrinoSettings struct {
+	// Tier is the resource-group tier label. Empty == default tier.
+	Tier string
+}
+
+// EnableTrino marks the org as Trino-enabled and stores the per-org Trino
+// settings. Idempotent: re-enabling updates Tier without flipping Enabled
+// back through a disabled state. Safe to call as part of the
+// `POST /orgs/:id/provision` path or the standalone
+// `POST /orgs/:id/trino` endpoint.
+func (cs *ConfigStore) EnableTrino(orgID string, settings TrinoSettings) error {
+	if orgID == "" {
+		return errors.New("EnableTrino: orgID is required")
+	}
+	row := ManagedWarehouseTrino{
+		OrgID:   orgID,
+		Enabled: true,
+		Tier:    settings.Tier,
+	}
+	if err := cs.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "org_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"enabled", "tier", "updated_at"}),
+	}).Create(&row).Error; err != nil {
+		return fmt.Errorf("enable trino for %q: %w", orgID, err)
+	}
+	return nil
+}
+
+// DisableTrino marks the org as no longer Trino-enabled. The row is kept
+// (rather than deleted) so the provisioner can observe the transition and
+// clean up the catalog + password file entry on its next reconcile tick.
+// Returns nil if no row exists — disabling something that was never enabled
+// is a no-op, not an error.
+func (cs *ConfigStore) DisableTrino(orgID string) error {
+	if orgID == "" {
+		return errors.New("DisableTrino: orgID is required")
+	}
+	result := cs.db.Model(&ManagedWarehouseTrino{}).
+		Where("org_id = ?", orgID).
+		Updates(map[string]interface{}{
+			"enabled":    false,
+			"updated_at": time.Now().UTC(),
+		})
+	if result.Error != nil {
+		return fmt.Errorf("disable trino for %q: %w", orgID, result.Error)
+	}
+	return nil
+}
+
+// ListTrinoEnabledOrgs returns every org with ManagedWarehouseTrino.Enabled
+// = true joined against its `root` OrgUser row. The provisioner needs the
+// bcrypt hash to project the Trino password file, so this is a single join
+// rather than two round-trips.
+//
+// Orgs that are Trino-enabled but have no `root` OrgUser are skipped — that
+// shape can't legitimately happen via the provisioning API (CreateOrgUser
+// runs in the same handler that toggles Enabled), and silently skipping is
+// safer than projecting a half-built password file.
+func (cs *ConfigStore) ListTrinoEnabledOrgs() ([]TrinoEnabledOrg, error) {
+	var out []TrinoEnabledOrg
+	// Inner join with duckgres_org_users on (org_id, username='root') so a
+	// missing OrgUser row drops the org from the result. Then left join with
+	// duckgres_orgs to pick up database_name.
+	err := cs.db.Table("duckgres_managed_warehouse_trino AS t").
+		Select(`t.org_id AS org_id,
+		         COALESCE(o.database_name, '') AS database_name,
+		         t.tier AS tier,
+		         u.password AS root_password_hash`).
+		Joins(`INNER JOIN duckgres_org_users AS u
+		        ON u.org_id = t.org_id AND u.username = 'root'`).
+		Joins(`LEFT JOIN duckgres_orgs AS o ON o.name = t.org_id`).
+		Where("t.enabled = ?", true).
+		Order("t.org_id ASC").
+		Scan(&out).Error
+	if err != nil {
+		return nil, fmt.Errorf("list trino-enabled orgs: %w", err)
+	}
+	return out, nil
+}
+
+// GetManagedWarehouseTrino reads the Trino row for an org. Returns
+// (nil, nil) when no row exists so callers can distinguish "never
+// configured" from a DB error.
+func (cs *ConfigStore) GetManagedWarehouseTrino(orgID string) (*ManagedWarehouseTrino, error) {
+	var row ManagedWarehouseTrino
+	err := cs.db.First(&row, "org_id = ?", orgID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get trino row for %q: %w", orgID, err)
+	}
+	return &row, nil
 }
 
 // migrateDeltaCatalogDefaultEnabled is a one-shot backfill that flips existing

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -371,6 +371,16 @@ func SetupMultiTenant(
 	var trinoBundleHandler *opa.Handler
 	provCtrl, err := provisioner.NewController(store, 10*time.Second)
 	if err != nil {
+		// Without the controller, the Trino reconcile loop cannot run.
+		// If the operator asked for Trino explicitly, that's a fatal
+		// startup failure — same "Trino is binary" stance as the
+		// wiring-failure branch below. Without this check, the Trino
+		// branch would be silently skipped (it's nested in the else)
+		// and password/group/bundle projections would stop updating.
+		if trinoProvisionerEnabled() {
+			return nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner enabled (%s) but provisioning controller unavailable: %w",
+				envTrinoProvisionerEnabled, err)
+		}
 		slog.Warn("Provisioning controller unavailable.", "error", err)
 	} else {
 		// Opt-in: enable the per-org Lakekeeper provisioning branch. Off by
@@ -386,22 +396,36 @@ func SetupMultiTenant(
 				slog.Info("Lakekeeper provisioner enabled (allowall + NetworkPolicy mode).")
 			}
 		}
-		// Customer-Trino provisioner branch. Same opt-in posture as
-		// Lakekeeper: off by default, best-effort if the K8s client or
-		// required env is incomplete. When wired, the bundle handler is
-		// retained for mounting onto the API server below (separate auth
-		// from the admin internal-secret — uses its own bearer token
-		// against opa.BearerTokenAuth).
+		// Customer-Trino provisioner branch. Off by default; when
+		// explicitly enabled via DUCKGRES_TRINO_PROVISIONER_ENABLED,
+		// wiring failure is fatal — silently skipping would leave the
+		// customer-Trino OPA sidecar serving last-good bundle while
+		// password/group-file changes never propagate, which is worse
+		// than failing the rollout.
+		//
+		// Lakekeeper's branch above stays best-effort (log-and-skip)
+		// because its env shape was designed for opportunistic enable
+		// of S3-Tables-only deployments where Lakekeeper is optional.
+		// Trino is binary: if you asked for it, you need it.
 		if trinoProvisionerEnabled() {
-			if kc, tkErr := newTrinoKubeClient(); tkErr != nil {
-				slog.Warn("Trino provisioner enabled but K8s client unavailable; skipping.", "error", tkErr)
-			} else if trinoWire, twErr := buildTrinoWiring(store, kc); twErr != nil {
-				slog.Warn("Trino provisioner enabled but wiring failed; skipping.", "error", twErr)
-			} else if trinoWire != nil {
-				provCtrl.WithTrinoProvisioner(trinoWire.Provisioner)
-				trinoBundleHandler = trinoWire.BundleHandler
-				slog.Info("Trino provisioner enabled.")
+			kc, tkErr := newTrinoKubeClient()
+			if tkErr != nil {
+				return nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner enabled (%s) but K8s client unavailable: %w",
+					envTrinoProvisionerEnabled, tkErr)
 			}
+			trinoWire, twErr := buildTrinoWiring(store, kc)
+			if twErr != nil {
+				return nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner wiring failed: %w", twErr)
+			}
+			if trinoWire == nil {
+				// buildTrinoWiring returns (nil, nil) only when the
+				// env gate is off — and the outer if guarded against
+				// that. So a nil here is a wiring bug.
+				return nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner enabled but buildTrinoWiring returned no wiring; this should be unreachable")
+			}
+			provCtrl.WithTrinoProvisioner(trinoWire.Provisioner)
+			trinoBundleHandler = trinoWire.BundleHandler
+			slog.Info("Trino provisioner enabled.")
 		}
 		go provCtrl.Run(context.Background())
 	}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -19,6 +19,7 @@ import (
 	"github.com/posthog/duckgres/controlplane/admin"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
 	"github.com/posthog/duckgres/controlplane/provisioning"
 	"github.com/posthog/duckgres/server"
 )
@@ -367,6 +368,7 @@ func SetupMultiTenant(
 	}
 
 	// Start provisioning controller (best-effort — K8s API may not be available locally)
+	var trinoBundleHandler *opa.Handler
 	provCtrl, err := provisioner.NewController(store, 10*time.Second)
 	if err != nil {
 		slog.Warn("Provisioning controller unavailable.", "error", err)
@@ -382,6 +384,23 @@ func SetupMultiTenant(
 				lkProv := provisioner.NewLakekeeperProvisioner(store, k8sClient)
 				provCtrl.WithLakekeeperProvisioner(lkProv, newLakekeeperInputsResolver(resolveDucklingStatus))
 				slog.Info("Lakekeeper provisioner enabled (allowall + NetworkPolicy mode).")
+			}
+		}
+		// Customer-Trino provisioner branch. Same opt-in posture as
+		// Lakekeeper: off by default, best-effort if the K8s client or
+		// required env is incomplete. When wired, the bundle handler is
+		// retained for mounting onto the API server below (separate auth
+		// from the admin internal-secret — uses its own bearer token
+		// against opa.BearerTokenAuth).
+		if trinoProvisionerEnabled() {
+			if kc, tkErr := newTrinoKubeClient(); tkErr != nil {
+				slog.Warn("Trino provisioner enabled but K8s client unavailable; skipping.", "error", tkErr)
+			} else if trinoWire, twErr := buildTrinoWiring(store, kc); twErr != nil {
+				slog.Warn("Trino provisioner enabled but wiring failed; skipping.", "error", twErr)
+			} else if trinoWire != nil {
+				provCtrl.WithTrinoProvisioner(trinoWire.Provisioner)
+				trinoBundleHandler = trinoWire.BundleHandler
+				slog.Info("Trino provisioner enabled.")
 			}
 		}
 		go provCtrl.Run(context.Background())
@@ -417,6 +436,16 @@ func SetupMultiTenant(
 	api := engine.Group("/api/v1", admin.APIAuthMiddleware(internalSecret))
 	admin.RegisterAPI(api, store, adpt)
 	provisioning.RegisterAPI(api, provisioning.NewGormStore(store))
+
+	// Customer-Trino OPA bundle endpoint. Mounted OUTSIDE the /api/v1
+	// admin group on purpose — it does its own bearer-token auth (the
+	// bundle exposes the customer roster; a separate shared secret
+	// between provisioner and the OPA sidecar). When the Trino
+	// provisioner is disabled (the default), trinoBundleHandler is nil
+	// and the route isn't registered.
+	if trinoBundleHandler != nil {
+		engine.Any("/bundles/trino", gin.WrapH(trinoBundleHandler))
+	}
 
 	// Dashboard
 	admin.RegisterDashboard(engine, internalSecret)

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -43,6 +43,12 @@ type Controller struct {
 	// Lakekeeper path), reconcileLakekeeper is skipped silently.
 	lakekeeperProvisioner *LakekeeperProvisioner
 	lakekeeperInputs      LakekeeperInputsResolver
+
+	// Trino-side reconcile dependency. Optional: if nil (the default in
+	// deployments without the customer Trino cluster, or in tests that
+	// don't exercise the Trino path), the Trino reconcile step is
+	// skipped silently. See WithTrinoProvisioner.
+	trinoProvisioner *TrinoProvisioner
 }
 
 // LakekeeperInputsResolver is the function shape the controller uses to
@@ -102,6 +108,22 @@ func (c *Controller) WithLakekeeperProvisioner(p *LakekeeperProvisioner, inputs 
 	return c
 }
 
+// WithTrinoProvisioner enables the customer-Trino reconcile branch.
+// The Trino reconcile runs once per controller tick — it doesn't iterate
+// per-warehouse like the Lakekeeper branch does, because the Trino
+// projection is a single batched output (one Secret + one ConfigMap +
+// one OPA bundle for the whole cluster).
+//
+// Skipped entirely if p is nil so deployments without a customer Trino
+// cluster don't need to know about it.
+func (c *Controller) WithTrinoProvisioner(p *TrinoProvisioner) *Controller {
+	if p == nil {
+		panic("WithTrinoProvisioner: provisioner is nil; call NewTrinoProvisioner first")
+	}
+	c.trinoProvisioner = p
+	return c
+}
+
 // Run starts the reconciliation loop. Blocks until ctx is cancelled.
 func (c *Controller) Run(ctx context.Context) {
 	slog.Info("Provisioning controller started.", "poll_interval", c.pollInterval)
@@ -152,6 +174,16 @@ func (c *Controller) reconcile(ctx context.Context) {
 			c.reconcileReady(ctx, &w)
 		case configstore.ManagedWarehouseStateDeleting:
 			c.reconcileDeleting(ctx, &w)
+		}
+	}
+
+	// Trino reconcile runs once per tick (not per warehouse) — the
+	// projection is a single batched output for the customer cluster.
+	// Errors are logged but don't block other reconcile branches; the
+	// next tick re-runs everything.
+	if c.trinoProvisioner != nil && ctx.Err() == nil {
+		if err := c.trinoProvisioner.Reconcile(ctx); err != nil {
+			slog.Warn("Trino provisioner reconcile failed.", "error", err)
 		}
 	}
 }

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -96,78 +96,104 @@ is_admin if {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: O(1) catalog-ownership lookup keyed on group membership. Iterates
-# over input.context.identity.groups (typically 1-2 elements) and probes
-# data.group_catalogs[g][catalog] for each. Missing keys evaluate to
-# undefined, the body fails, and the outer `allow` stays false.
+# Catalog-name shape: matches what trinoSanitize + TrinoCatalogName produce
+# (`org_<sanitized>_iceberg`, sanitized to [a-z0-9_]). Used as a defense-in-
+# depth name constraint on admin-scoped operations so admin authority is
+# always bounded to provisioner-managed names — admin cannot DROP `system`,
+# `jmx`, or hand-rolled catalogs, and the orphan-cleanup carve-out (below)
+# stays within the same naming convention.
 #
-# `admin_group` is excluded from this iteration: it is a privileged label
-# whose ownership listing covers every customer catalog, and we must NOT
-# grant read access purely on the basis of someone showing up with that
-# group label. The admin's smoke-test read access flows through the
-# separate is_admin-gated rule below.
+# Keep this regex in sync with opa.ManagedCatalogPattern (the exported
+# Go-side constant) and with the trinoSanitize grammar used by
+# TrinoCatalogName. Two tests guard the three-way contract:
+#   - opa/policy_test.go::TestPolicyRegoContainsManagedNamePattern
+#   - provisioner/trino_provisioner_test.go::TestTrinoCatalogNameMatchesManagedNamePattern
+# A change here without updating the constant (or vice versa) fails CI.
 # ---------------------------------------------------------------------------
 
-owns_catalog(catalog) if {
+managed_catalog_name(catalog) if {
+	is_string(catalog)
+	regex.match(`^org_[a-z0-9_]+_iceberg$`, catalog)
+}
+
+# ---------------------------------------------------------------------------
+# Ownership / readability / listability — three predicates kept distinct
+# so admin's orphan-cleanup carve-out doesn't leak into data-plane reads.
+#
+# tenant_owns_catalog(c): a customer group has c in data.group_catalogs.
+#   Excludes admin_group from iteration so a bare admin-group claim grants
+#   nothing (security regression in the file/JWT group provider would
+#   otherwise be a cross-tenant exposure).
+#
+# admin_bundle_catalog(c): admin has c listed in data.group_catalogs
+#   [admin_group]. Gated on is_admin (username + group conjunction) so a
+#   group-only claim grants nothing. This is the smoke-test read path.
+#
+# readable_catalog(c) = tenant_owns OR admin_bundle. Gates every read
+#   surface (AccessCatalog, ShowSchemas, ShowTables, SelectFromColumns,
+#   FilterSchemas, FilterTables, ShowColumns, FilterColumns). Catalogs
+#   outside the bundle CANNOT be read by anyone.
+#
+# listable_catalog(c) = readable OR (is_admin AND managed_catalog_name).
+#   The orphan-cleanup carve-out: admin sees `org_*_iceberg` catalogs
+#   regardless of bundle ownership SOLELY through FilterCatalogs, so
+#   reconcile can re-issue DROP CATALOG on a stale orphan. The orphan
+#   visibility never grants read access.
+# ---------------------------------------------------------------------------
+
+tenant_owns_catalog(catalog) if {
 	some g in input.context.identity.groups
 	g != admin_group
 	data.group_catalogs[g][catalog] == true
 }
 
-# Admin's read access to managed catalogs. Gated on is_admin (full
-# username + group conjunction) so a bare `admin_group` claim does not
-# unlock the global catalog list.
-owns_catalog(catalog) if {
+admin_bundle_catalog(catalog) if {
 	is_admin
 	data.group_catalogs[admin_group][catalog] == true
 }
 
-# Admin's read access to ANY catalog matching the v1 naming convention
-# (`org_<sanitized>_iceberg`), regardless of bundle ownership. This is
-# narrower than "admin sees everything" — it scopes admin authority to
-# catalogs the provisioner could plausibly have created.
-#
-# Why this exists: when an org is disabled, the next reconcile tick
-# removes its catalog from data.group_catalogs but the catalog itself
-# may not be dropped on the same tick (e.g. transient Trino error).
-# Without this rule, the admin's SHOW CATALOGS filters the orphan out
-# and the next reconcile tick can't see it to retry the drop. The
-# catalog becomes a persistent orphan until manual cleanup.
-#
-# Security: admin already has CREATE CATALOG / DROP CATALOG authority
-# (gated on is_admin), so this doesn't expand the blast radius — it
-# only lets admin ENUMERATE catalogs it could already manipulate. The
-# `org_*_iceberg` prefix bounds the scope to provisioner-managed names,
-# so hand-rolled catalogs (e.g. on the maintenance cluster, were that
-# ever to share an OPA bundle) stay out of admin's reach via this rule.
-owns_catalog(catalog) if {
+readable_catalog(catalog) if tenant_owns_catalog(catalog)
+readable_catalog(catalog) if admin_bundle_catalog(catalog)
+
+listable_catalog(catalog) if readable_catalog(catalog)
+
+# Orphan-cleanup carve-out: admin enumeration of managed-name catalogs
+# even when they're not in the bundle. SCOPED to FilterCatalogs only --
+# see the allow rule for FilterCatalogs below. Reads (AccessCatalog,
+# SelectFromColumns, etc.) stay gated on readable_catalog so an orphan
+# catalog's data is never reachable via this carve-out.
+listable_catalog(catalog) if {
 	is_admin
-	startswith(catalog, "org_")
-	endswith(catalog, "_iceberg")
+	managed_catalog_name(catalog)
 }
 
 # ---------------------------------------------------------------------------
 # Catalog-scope decisions.
 # ---------------------------------------------------------------------------
 
-# AccessCatalog: caller's groups must own the catalog.
+# AccessCatalog: caller must be able to READ the catalog (bundle
+# ownership). The admin orphan-cleanup carve-out does NOT apply here --
+# only listable_catalog grants admin access to orphans, and only via
+# FilterCatalogs below.
 allow if {
 	input.action.operation == "AccessCatalog"
-	owns_catalog(input.action.resource.catalog.name)
+	readable_catalog(input.action.resource.catalog.name)
 }
 
 # FilterCatalogs: the Trino OPA plugin calls this once per candidate catalog
-# (parallelFilterFromOpa in OpaHighLevelClient.java). Same shape as
-# AccessCatalog -- return true only for owned catalogs.
+# (parallelFilterFromOpa in OpaHighLevelClient.java). This is the ONE
+# decision that uses listable_catalog -- so admin can SHOW CATALOGS and
+# see an orphan org_*_iceberg catalog even if the bundle has rotated
+# away from it, enabling reconcile to retry DROP CATALOG.
 allow if {
 	input.action.operation == "FilterCatalogs"
-	owns_catalog(input.action.resource.catalog.name)
+	listable_catalog(input.action.resource.catalog.name)
 }
 
-# ShowSchemas: scoped to catalogs the caller owns.
+# ShowSchemas: scoped to catalogs the caller can READ.
 allow if {
 	input.action.operation == "ShowSchemas"
-	owns_catalog(input.action.resource.catalog.name)
+	readable_catalog(input.action.resource.catalog.name)
 }
 
 # ---------------------------------------------------------------------------
@@ -176,12 +202,12 @@ allow if {
 
 allow if {
 	input.action.operation == "FilterSchemas"
-	owns_catalog(input.action.resource.schema.catalogName)
+	readable_catalog(input.action.resource.schema.catalogName)
 }
 
 allow if {
 	input.action.operation == "ShowTables"
-	owns_catalog(input.action.resource.schema.catalogName)
+	readable_catalog(input.action.resource.schema.catalogName)
 }
 
 # ---------------------------------------------------------------------------
@@ -191,22 +217,22 @@ allow if {
 
 allow if {
 	input.action.operation == "SelectFromColumns"
-	owns_catalog(input.action.resource.table.catalogName)
+	readable_catalog(input.action.resource.table.catalogName)
 }
 
 allow if {
 	input.action.operation == "FilterTables"
-	owns_catalog(input.action.resource.table.catalogName)
+	readable_catalog(input.action.resource.table.catalogName)
 }
 
 allow if {
 	input.action.operation == "ShowColumns"
-	owns_catalog(input.action.resource.table.catalogName)
+	readable_catalog(input.action.resource.table.catalogName)
 }
 
 allow if {
 	input.action.operation == "FilterColumns"
-	owns_catalog(input.action.resource.table.catalogName)
+	readable_catalog(input.action.resource.table.catalogName)
 }
 
 # ---------------------------------------------------------------------------
@@ -292,6 +318,12 @@ allow if {
 # we authenticate the provisioner against a separate password-file entry
 # mounted only into the provisioner workflow.
 #
+# Catalog management is ALSO bounded to the provisioner naming convention
+# (managed_catalog_name): an admin can CREATE/DROP/ALTER `org_<id>_iceberg`
+# catalogs, but not `system`, `jmx`, or any hand-rolled catalog. If admin
+# credentials are compromised, the blast radius is bounded to provisioner-
+# managed catalogs.
+#
 # `AlterCatalog` is not a distinct operation in the Trino OPA plugin (476)
 # -- catalog mutations happen via DROP+CREATE through the provisioner --
 # but we keep the rule for forward compatibility with future Trino versions
@@ -299,24 +331,19 @@ allow if {
 # costs nothing.
 # ---------------------------------------------------------------------------
 
-allow if {
-	is_admin
-	input.action.operation == "CreateCatalog"
-}
+catalog_management_ops := {"CreateCatalog", "DropCatalog", "AlterCatalog"}
 
 allow if {
 	is_admin
-	input.action.operation == "DropCatalog"
+	input.action.operation in catalog_management_ops
+	managed_catalog_name(input.action.resource.catalog.name)
 }
 
-allow if {
-	is_admin
-	input.action.operation == "AlterCatalog"
-}
-
-# Admin smoke-test access to catalogs flows through the second
-# `owns_catalog` rule above (is_admin + data.group_catalogs[admin_group]).
-# We do NOT grant the admin blanket access -- the admin can only see
-# catalogs that appear under data.group_catalogs[admin_group], so omitting
-# that entry yields a catalog-management-only admin. And a bare claim of
-# admin_group membership (without the admin username) grants nothing.
+# Admin smoke-test READ access to catalogs flows through readable_catalog
+# above (is_admin + data.group_catalogs[admin_group]). Admin can only
+# READ catalogs that appear under data.group_catalogs[admin_group];
+# omitting an entry yields a catalog-management-only admin for that
+# catalog. The orphan-cleanup carve-out (listable_catalog) lets admin
+# ENUMERATE managed-name catalogs not in the bundle but does NOT grant
+# them read access. And a bare claim of admin_group membership (without
+# the admin username) grants nothing.

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -122,6 +122,30 @@ owns_catalog(catalog) if {
 	data.group_catalogs[admin_group][catalog] == true
 }
 
+# Admin's read access to ANY catalog matching the v1 naming convention
+# (`org_<sanitized>_iceberg`), regardless of bundle ownership. This is
+# narrower than "admin sees everything" — it scopes admin authority to
+# catalogs the provisioner could plausibly have created.
+#
+# Why this exists: when an org is disabled, the next reconcile tick
+# removes its catalog from data.group_catalogs but the catalog itself
+# may not be dropped on the same tick (e.g. transient Trino error).
+# Without this rule, the admin's SHOW CATALOGS filters the orphan out
+# and the next reconcile tick can't see it to retry the drop. The
+# catalog becomes a persistent orphan until manual cleanup.
+#
+# Security: admin already has CREATE CATALOG / DROP CATALOG authority
+# (gated on is_admin), so this doesn't expand the blast radius — it
+# only lets admin ENUMERATE catalogs it could already manipulate. The
+# `org_*_iceberg` prefix bounds the scope to provisioner-managed names,
+# so hand-rolled catalogs (e.g. on the maintenance cluster, were that
+# ever to share an OPA bundle) stay out of admin's reach via this rule.
+owns_catalog(catalog) if {
+	is_admin
+	startswith(catalog, "org_")
+	endswith(catalog, "_iceberg")
+}
+
 # ---------------------------------------------------------------------------
 # Catalog-scope decisions.
 # ---------------------------------------------------------------------------

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -518,9 +518,19 @@ func TestAdversarialInputs(t *testing.T) {
 	// Verify the positive admin path still works with BOTH signals.
 	t.Run("admin with both username and admin group can manage and read", func(t *testing.T) {
 		// twoOrgFixture puts both catalogs under AdminGroup.
-		in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "CreateCatalog", catalogResource("any"))
+		// CreateCatalog now requires managed_catalog_name -- admin
+		// cannot CREATE arbitrary names like "any", only org_*_iceberg.
+		in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "CreateCatalog", catalogResource("org_new_iceberg"))
 		if !evalAllow(t, q, in) {
-			t.Error("admin with full identity must be able to CreateCatalog")
+			t.Error("admin with full identity must be able to CreateCatalog a managed-name catalog")
+		}
+		// Non-managed names must be denied even for admin -- defense
+		// in depth against an admin credential compromise.
+		for _, badName := range []string{"system", "jmx", "any", "iceberg_org_42"} {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "CreateCatalog", catalogResource(badName))
+			if evalAllow(t, q, in) {
+				t.Errorf("admin CreateCatalog on non-managed name %q must be denied", badName)
+			}
 		}
 		in = buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "AccessCatalog", catalogResource("org_42_iceberg"))
 		if !evalAllow(t, q, in) {
@@ -528,48 +538,63 @@ func TestAdversarialInputs(t *testing.T) {
 		}
 	})
 
-	// Admin can see/manage prefix-matching catalogs that aren't
-	// listed under AdminGroup in the bundle. This is the orphan-drop
-	// recovery path: if a reconcile fails to drop a disabled org's
-	// catalog AFTER removing it from data.group_catalogs, the admin
-	// still needs to see the catalog on the next SHOW CATALOGS so the
-	// drop can be retried.
-	t.Run("admin can see prefix-matching catalog not in bundle", func(t *testing.T) {
-		// Bundle has nothing under AdminGroup for this catalog.
+	// Admin's orphan-cleanup carve-out is SCOPED to FilterCatalogs --
+	// admin can enumerate `org_*_iceberg` catalogs that aren't in the
+	// bundle (so reconcile can find orphans to drop) but CANNOT read
+	// their data (no AccessCatalog/Select/etc. on orphans). The
+	// previous broad-prefix rule has been replaced by this narrower
+	// listable_catalog/readable_catalog split.
+	t.Run("admin orphan visibility is FilterCatalogs-only", func(t *testing.T) {
+		// Bundle has nothing under AdminGroup for org_99_iceberg.
 		emptyAdmin := GroupCatalogs{
 			"org_42": {"org_42_iceberg": true},
 			// no AdminGroup entry, no org_99 entry
 		}
 		q2 := preparedPolicy(t, emptyAdmin)
 
-		// Admin (full identity) can FilterCatalogs / AccessCatalog
-		// on an orphan org_99_iceberg.
-		for _, op := range []string{"FilterCatalogs", "AccessCatalog"} {
+		// FilterCatalogs on an orphan managed-name catalog: allowed.
+		// This is the enumeration carve-out so reconcile can SHOW
+		// CATALOGS and find org_99_iceberg to retry DROP CATALOG.
+		in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "FilterCatalogs", catalogResource("org_99_iceberg"))
+		if !evalAllow(t, q2, in) {
+			t.Error("admin FilterCatalogs on orphan org_99_iceberg must be allowed via listable_catalog carve-out")
+		}
+
+		// AccessCatalog, ShowSchemas, SelectFromColumns, etc. on the
+		// same orphan: DENIED. The bundle is the audit trail for
+		// what admin can READ; orphans aren't in the bundle, so they
+		// can be enumerated but not read.
+		for _, op := range []string{"AccessCatalog", "ShowSchemas"} {
 			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, op, catalogResource("org_99_iceberg"))
-			if !evalAllow(t, q2, in) {
-				t.Errorf("admin %s on orphan org_99_iceberg should be allowed via prefix rule; was denied", op)
+			if evalAllow(t, q2, in) {
+				t.Errorf("admin %s on orphan org_99_iceberg must be DENIED (carve-out is FilterCatalogs-only)", op)
 			}
 		}
-		// Admin must NOT match catalogs that don't follow the v1
-		// naming convention — `system`, `jmx`, hand-rolled
-		// non-prefix names stay out of reach via this rule (admin
-		// still has CREATE/DROP authority, but cannot enumerate
-		// non-managed names through SHOW CATALOGS).
-		// Non-matching names must still be denied — admin's prefix
-		// authority is bounded to the v1 naming convention so
-		// hand-rolled catalogs (system, jmx, anything without the
-		// matching prefix+suffix) stay out of reach.
-		for _, name := range []string{"system", "jmx", "iceberg_org_42", "org_42_data"} {
-			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "AccessCatalog", catalogResource(name))
+		// Same for schema/table scope.
+		denyOp := func(op string, res map[string]interface{}) {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, op, res)
 			if evalAllow(t, q2, in) {
-				t.Errorf("admin AccessCatalog on non-prefix-matching %q must be denied via this rule", name)
+				t.Errorf("admin %s on orphan must be denied; was allowed", op)
+			}
+		}
+		denyOp("SelectFromColumns", tableResource("org_99_iceberg", "s", "t"))
+		denyOp("ShowTables", schemaResource("org_99_iceberg", "s"))
+		denyOp("FilterTables", tableResource("org_99_iceberg", "s", "t"))
+
+		// FilterCatalogs on a non-managed name must still be denied
+		// — even for admin. The carve-out is bounded by the
+		// managed_catalog_name regex.
+		for _, name := range []string{"system", "jmx", "iceberg_org_42", "ORG_42_iceberg"} {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "FilterCatalogs", catalogResource(name))
+			if evalAllow(t, q2, in) {
+				t.Errorf("admin FilterCatalogs on non-managed-name %q must be denied", name)
 			}
 		}
 		// Non-admin with the same group claim still gets nothing
-		// from the prefix rule (it's is_admin-gated).
-		in := buildInputWithGroups("42", []string{AdminGroup}, "AccessCatalog", catalogResource("org_99_iceberg"))
+		// from the carve-out (it's is_admin-gated).
+		in = buildInputWithGroups("42", []string{AdminGroup}, "FilterCatalogs", catalogResource("org_99_iceberg"))
 		if evalAllow(t, q2, in) {
-			t.Error("non-admin claiming admin_group must not benefit from the prefix rule")
+			t.Error("non-admin claiming admin_group must not benefit from the orphan carve-out")
 		}
 	})
 }
@@ -708,6 +733,25 @@ func TestPolicyDoesNotUseLinearScan(t *testing.T) {
 	// Positive check: the indexed lookup is present.
 	if !strings.Contains(src, "data.group_catalogs[g][catalog]") {
 		t.Error("policy.rego should contain the object-indexed lookup `data.group_catalogs[g][catalog]`")
+	}
+}
+
+// TestPolicyRegoContainsManagedNamePattern guards the contract between
+// the exported ManagedCatalogPattern constant and the regex literal
+// embedded in policy.rego. If someone edits one without the other, the
+// admin's catalog enumeration / management authority silently drifts
+// out of sync with the Go-side TrinoCatalogName grammar.
+//
+// Paired with TestTrinoCatalogNameMatchesManagedNamePattern in the
+// provisioner package, which closes the other side of the contract:
+// every name Go produces must match this pattern.
+func TestPolicyRegoContainsManagedNamePattern(t *testing.T) {
+	if !strings.Contains(string(policyRego), ManagedCatalogPattern) {
+		t.Fatalf("policy.rego does not contain the literal substring %q.\n"+
+			"This means the policy's `managed_catalog_name` regex has drifted from\n"+
+			"the exported ManagedCatalogPattern constant. Update either the constant\n"+
+			"in opa/types.go or the regex literal in opa/policy.rego so they agree.",
+			ManagedCatalogPattern)
 	}
 }
 

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -527,6 +527,51 @@ func TestAdversarialInputs(t *testing.T) {
 			t.Error("admin with full identity must be able to AccessCatalog admin-listed catalogs")
 		}
 	})
+
+	// Admin can see/manage prefix-matching catalogs that aren't
+	// listed under AdminGroup in the bundle. This is the orphan-drop
+	// recovery path: if a reconcile fails to drop a disabled org's
+	// catalog AFTER removing it from data.group_catalogs, the admin
+	// still needs to see the catalog on the next SHOW CATALOGS so the
+	// drop can be retried.
+	t.Run("admin can see prefix-matching catalog not in bundle", func(t *testing.T) {
+		// Bundle has nothing under AdminGroup for this catalog.
+		emptyAdmin := GroupCatalogs{
+			"org_42": {"org_42_iceberg": true},
+			// no AdminGroup entry, no org_99 entry
+		}
+		q2 := preparedPolicy(t, emptyAdmin)
+
+		// Admin (full identity) can FilterCatalogs / AccessCatalog
+		// on an orphan org_99_iceberg.
+		for _, op := range []string{"FilterCatalogs", "AccessCatalog"} {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, op, catalogResource("org_99_iceberg"))
+			if !evalAllow(t, q2, in) {
+				t.Errorf("admin %s on orphan org_99_iceberg should be allowed via prefix rule; was denied", op)
+			}
+		}
+		// Admin must NOT match catalogs that don't follow the v1
+		// naming convention — `system`, `jmx`, hand-rolled
+		// non-prefix names stay out of reach via this rule (admin
+		// still has CREATE/DROP authority, but cannot enumerate
+		// non-managed names through SHOW CATALOGS).
+		// Non-matching names must still be denied — admin's prefix
+		// authority is bounded to the v1 naming convention so
+		// hand-rolled catalogs (system, jmx, anything without the
+		// matching prefix+suffix) stay out of reach.
+		for _, name := range []string{"system", "jmx", "iceberg_org_42", "org_42_data"} {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup}, "AccessCatalog", catalogResource(name))
+			if evalAllow(t, q2, in) {
+				t.Errorf("admin AccessCatalog on non-prefix-matching %q must be denied via this rule", name)
+			}
+		}
+		// Non-admin with the same group claim still gets nothing
+		// from the prefix rule (it's is_admin-gated).
+		in := buildInputWithGroups("42", []string{AdminGroup}, "AccessCatalog", catalogResource("org_99_iceberg"))
+		if evalAllow(t, q2, in) {
+			t.Error("non-admin claiming admin_group must not benefit from the prefix rule")
+		}
+	})
 }
 
 // --------------------------------------------------------------------------

--- a/controlplane/provisioner/opa/types.go
+++ b/controlplane/provisioner/opa/types.go
@@ -83,3 +83,28 @@ const AdminPrincipal = "__admin_provisioner"
 //
 // Keep in sync with the Rego policy's `admin_group` constant.
 const AdminGroup = "__admin_provisioner"
+
+// ManagedCatalogPattern is the regex (RE2 / OPA `regex.match` syntax)
+// that defines the v1 catalog naming convention. It MUST stay in sync
+// with the Rego policy's managed_catalog_name rule AND with the
+// provisioner package's TrinoCatalogName / trinoSanitize functions.
+//
+// The pattern bounds:
+//   - prefix: "org_"
+//   - middle: one or more [a-z0-9_] characters (the sanitize grammar)
+//   - suffix: "_iceberg"
+//
+// Drift between this constant and either the policy's regex literal or
+// TrinoCatalogName's output silently breaks admin authority (admin
+// loses enumeration/management for catalogs the Go code creates, or
+// vice versa). Two tests guard the contract:
+//
+//   - opa/policy_test.go::TestPolicyRegoContainsManagedNamePattern
+//     asserts the embedded policy.rego contains this literal substring.
+//   - provisioner/trino_provisioner_test.go::TestTrinoCatalogNameMatchesManagedNamePattern
+//     compiles this pattern as a Go regex and asserts TrinoCatalogName
+//     outputs match for a representative set of inputs.
+//
+// If you change this string, update policy.rego's regex.match literal
+// to match, then re-run both tests.
+const ManagedCatalogPattern = `^org_[a-z0-9_]+_iceberg$`

--- a/controlplane/provisioner/opa/types_test.go
+++ b/controlplane/provisioner/opa/types_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-// TestStubBuilderReturnsEmptyBundle pins the contract Stream A relies on
-// while Stream B is in flight. When Stream B's PR lands a real builder,
-// this test is replaced (or moved) — but until then it guards the
+// TestStubBuilderReturnsEmptyBundle pins the contract the Trino provisioner
+// relies on while the real Rego builder is in flight. When the real builder
+// lands, this test is replaced (or moved) — but until then it guards the
 // expected behavior so an accidental change here doesn't break the
 // provisioner's reconcile loop.
 func TestStubBuilderReturnsEmptyBundle(t *testing.T) {
@@ -23,9 +23,9 @@ func TestStubBuilderReturnsEmptyBundle(t *testing.T) {
 }
 
 func TestUserCatalogsShape(t *testing.T) {
-	// Compile-time-ish smoke that the map shape is the same as the
-	// plan documents — bumping the alias to a struct in the future
-	// requires touching this test too.
+	// Compile-time-ish smoke that the map shape stays consistent —
+	// bumping the alias to a struct in the future requires touching
+	// this test too.
 	uc := UserCatalogs{
 		"42": {"a": true, "b": true},
 		"43": {"c": true},

--- a/controlplane/provisioner/opa/types_test.go
+++ b/controlplane/provisioner/opa/types_test.go
@@ -1,36 +1,7 @@
 package opa
 
-import (
-	"testing"
-)
-
-// TestStubBuilderReturnsEmptyBundle pins the contract the Trino provisioner
-// relies on while the real Rego builder is in flight. When the real builder
-// lands, this test is replaced (or moved) — but until then it guards the
-// expected behavior so an accidental change here doesn't break the
-// provisioner's reconcile loop.
-func TestStubBuilderReturnsEmptyBundle(t *testing.T) {
-	b := NewStubBuilder()
-	out, err := b.BuildBundle(UserCatalogs{
-		"42": {"org_42_iceberg": true},
-	})
-	if err != nil {
-		t.Fatalf("BuildBundle returned error: %v", err)
-	}
-	if string(out) != "{}" {
-		t.Errorf("BuildBundle = %q, want %q", string(out), "{}")
-	}
-}
-
-func TestUserCatalogsShape(t *testing.T) {
-	// Compile-time-ish smoke that the map shape stays consistent —
-	// bumping the alias to a struct in the future requires touching
-	// this test too.
-	uc := UserCatalogs{
-		"42": {"a": true, "b": true},
-		"43": {"c": true},
-	}
-	if !uc["42"]["a"] || !uc["43"]["c"] {
-		t.Fatal("expected object-indexed lookups to work")
-	}
-}
+// This file is a placeholder. It originally held tests for the
+// pre-Stream-B stub (NewStubBuilder + UserCatalogs), which Stream B's real
+// builder + GroupCatalogs replaced. The real bundle/policy/handler tests
+// live in builder_test.go, policy_test.go, latency_test.go, and the
+// implicit coverage from trino_provisioner_test.go.

--- a/controlplane/provisioner/opa/types_test.go
+++ b/controlplane/provisioner/opa/types_test.go
@@ -1,0 +1,36 @@
+package opa
+
+import (
+	"testing"
+)
+
+// TestStubBuilderReturnsEmptyBundle pins the contract Stream A relies on
+// while Stream B is in flight. When Stream B's PR lands a real builder,
+// this test is replaced (or moved) — but until then it guards the
+// expected behavior so an accidental change here doesn't break the
+// provisioner's reconcile loop.
+func TestStubBuilderReturnsEmptyBundle(t *testing.T) {
+	b := NewStubBuilder()
+	out, err := b.BuildBundle(UserCatalogs{
+		"42": {"org_42_iceberg": true},
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle returned error: %v", err)
+	}
+	if string(out) != "{}" {
+		t.Errorf("BuildBundle = %q, want %q", string(out), "{}")
+	}
+}
+
+func TestUserCatalogsShape(t *testing.T) {
+	// Compile-time-ish smoke that the map shape is the same as the
+	// plan documents — bumping the alias to a struct in the future
+	// requires touching this test too.
+	uc := UserCatalogs{
+		"42": {"a": true, "b": true},
+		"43": {"c": true},
+	}
+	if !uc["42"]["a"] || !uc["43"]["c"] {
+		t.Fatal("expected object-indexed lookups to work")
+	}
+}

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -3,7 +3,6 @@
 package provisioner
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -52,11 +51,6 @@ const TrinoResourceGroupsConfigMapName = "trino-resource-groups"
 // resource-groups.config-file mount.
 const TrinoResourceGroupsConfigMapKey = "resource-groups.json"
 
-// TrinoAdminProvisionerUser is the reserved Trino principal the
-// provisioner uses for catalog management. OPA distinguishes this
-// principal from customer users to scope CREATE/ALTER/DROP CATALOG.
-const TrinoAdminProvisionerUser = "__admin_provisioner"
-
 // trinoCatalogIdentifier is the Trino catalog identifier grammar
 // ([a-z0-9_]+). Anything outside this set in Org.Name is replaced with
 // `_` before forming the catalog name.
@@ -86,11 +80,15 @@ func TrinoGroupName(orgName string) string {
 	return "org_" + trinoSanitize(orgName)
 }
 
-// TrinoResourceGroupName returns the resource-group selector key for an
-// org. Customer principals' Trino username == orgName (numeric team_id);
-// selectors match on that, scoping the org into root.tenants.<orgName>.
+// TrinoResourceGroupName returns the resource-group selector key for
+// an org. Sanitized like the catalog name so a `.` in orgName doesn't
+// get re-interpreted as a hierarchy separator in Trino's resource-
+// group path (and so the selector + subgroup names stay aligned across
+// the catalog, group, and resource-group projections). Customer
+// principals' Trino username == orgName (numeric team_id in v1), but
+// the underlying type is still a string so we sanitize defensively.
 func TrinoResourceGroupName(orgName string) string {
-	return "root.tenants." + orgName
+	return "root.tenants." + trinoSanitize(orgName)
 }
 
 // TrinoCatalogClient is the REST surface the provisioner needs against
@@ -102,15 +100,6 @@ type TrinoCatalogClient interface {
 	CreateCatalog(ctx context.Context, name string, props map[string]string) error
 	AlterCatalog(ctx context.Context, name string, props map[string]string) error
 	DropCatalog(ctx context.Context, name string) error
-}
-
-// OPABundleClient is the surface the provisioner uses to push a generated
-// bundle to the customer Trino cluster's OPA sidecar via the bundle API.
-// One pod hosts the OPA sidecar (alongside the coordinator); the push is
-// over loopback / NetworkPolicy-restricted egress. Interface lets tests
-// substitute a fake.
-type OPABundleClient interface {
-	PushBundle(ctx context.Context, bundle []byte) error
 }
 
 // TrinoProvisionerOpts groups all the dependencies trino_provisioner.go
@@ -136,20 +125,31 @@ type TrinoProvisionerOpts struct {
 	Namespace string
 
 	// Catalog is the Trino REST client used to issue CREATE / ALTER /
-	// DROP CATALOG. The provisioner authenticates as
-	// TrinoAdminProvisionerUser; the underlying HTTP client owns the
-	// admin Basic-auth credential.
+	// DROP CATALOG. The provisioner authenticates as opa.AdminPrincipal;
+	// the underlying HTTP client owns the admin Basic-auth credential
+	// (loaded from a provisioner-only K8s Secret, not from configstore).
 	Catalog TrinoCatalogClient
 
-	// OPA is the bundle push client. Bundle bytes come from
-	// BundleBuilder.
-	OPA OPABundleClient
+	// BundleStore is the in-memory holder of the most recently built OPA
+	// bundle. The provisioner Set()s into it on every reconcile tick;
+	// the customer-Trino OPA sidecar's bundle plugin polls an HTTP
+	// endpoint (opa.Handler) backed by this same store, so distribution
+	// is pull-based (see plan "Open Questions #6"). Owned and exposed by
+	// the caller (typically multitenant.go) so the same store can be
+	// mounted onto the provisioning HTTP server.
+	BundleStore *opa.BundleStore
 
-	// BundleBuilder builds the OPA bundle from the user→catalogs map.
-	// Construct with opa.NewStubBuilder() until the real Rego-backed
-	// builder ships in a sibling PR (which swaps in a real constructor
-	// without touching this call site).
+	// BundleBuilder builds the OPA bundle (gzip tarball) from a
+	// GroupCatalogs map. In production, pass opa.NewBuilder().
 	BundleBuilder opa.BundleBuilder
+
+	// AdminPasswordHash is the bcrypt hash of the password the
+	// provisioner authenticates with against the customer Trino cluster
+	// as opa.AdminPrincipal. Projected verbatim into password.db (Trino
+	// file authenticator expects bcrypt hashes). Required in production;
+	// empty in unit tests (where the catalog client is a fake and
+	// auth.db content doesn't reach Trino).
+	AdminPasswordHash string
 
 	// IAMAccountID is the AWS account id the per-org Iceberg catalogs
 	// reference via iceberg.s3.aws-role-arn (the duckling-<orgid> role).
@@ -167,6 +167,7 @@ type TrinoProvisionerOpts struct {
 // import everywhere.
 type TrinoStore interface {
 	ListTrinoEnabledOrgs() ([]configstore.TrinoEnabledOrg, error)
+	UpdateTrinoState(orgID string, upd configstore.TrinoStateUpdate) error
 }
 
 // TrinoIcebergStore reads a single org's Iceberg config to populate the
@@ -183,15 +184,16 @@ type TrinoIcebergStore interface {
 // configstore-derived input. Same input → same output (deterministic
 // projection), so a re-run is a no-op against settled state.
 type TrinoProvisioner struct {
-	store         TrinoStore
-	icebergStore  TrinoIcebergStore
-	kubernetes    kubernetes.Interface
-	namespace     string
-	catalog       TrinoCatalogClient
-	opa           OPABundleClient
-	bundleBuilder opa.BundleBuilder
-	iamAccountID  string
-	awsRegion     string
+	store             TrinoStore
+	icebergStore      TrinoIcebergStore
+	kubernetes        kubernetes.Interface
+	namespace         string
+	catalog           TrinoCatalogClient
+	bundleStore       *opa.BundleStore
+	bundleBuilder     opa.BundleBuilder
+	adminPasswordHash string
+	iamAccountID      string
+	awsRegion         string
 }
 
 // NewTrinoProvisioner constructs a TrinoProvisioner from required deps.
@@ -210,8 +212,8 @@ func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
 	if opts.Catalog == nil {
 		return nil, errors.New("TrinoProvisioner: Catalog client is required")
 	}
-	if opts.OPA == nil {
-		return nil, errors.New("TrinoProvisioner: OPA client is required")
+	if opts.BundleStore == nil {
+		return nil, errors.New("TrinoProvisioner: BundleStore is required")
 	}
 	if opts.BundleBuilder == nil {
 		return nil, errors.New("TrinoProvisioner: BundleBuilder is required")
@@ -221,15 +223,16 @@ func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
 		ns = TrinoCustomerNamespace
 	}
 	return &TrinoProvisioner{
-		store:         opts.Store,
-		icebergStore:  opts.IcebergStore,
-		kubernetes:    opts.Kubernetes,
-		namespace:     ns,
-		catalog:       opts.Catalog,
-		opa:           opts.OPA,
-		bundleBuilder: opts.BundleBuilder,
-		iamAccountID:  opts.IAMAccountID,
-		awsRegion:     opts.AWSRegion,
+		store:             opts.Store,
+		icebergStore:      opts.IcebergStore,
+		kubernetes:        opts.Kubernetes,
+		namespace:         ns,
+		catalog:           opts.Catalog,
+		bundleStore:       opts.BundleStore,
+		bundleBuilder:     opts.BundleBuilder,
+		adminPasswordHash: opts.AdminPasswordHash,
+		iamAccountID:      opts.IAMAccountID,
+		awsRegion:         opts.AWSRegion,
 	}, nil
 }
 
@@ -255,32 +258,138 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	var errs []error
 
 	// 1. Catalogs (REST). Per-org idempotent CREATE; orgs disabled since
-	// last tick get DROP. Failing one org doesn't block the others.
-	if err := p.reconcileCatalogs(ctx, orgs); err != nil {
-		errs = append(errs, fmt.Errorf("reconcile catalogs: %w", err))
+	// last tick get DROP. Failing one org doesn't block the others. The
+	// per-org outcome (catalog exists / pending / errored) is captured
+	// so the trailing state-write step can attribute per-org status
+	// correctly — the other three steps below are global (one K8s API
+	// write each), so their failure attaches to every org uniformly.
+	catalogOutcomes, catErr := p.reconcileCatalogs(ctx, orgs)
+	if catErr != nil {
+		errs = append(errs, fmt.Errorf("reconcile catalogs: %w", catErr))
 	}
 
 	// 2. Auth file projection (K8s Secret). Atomic Secret update.
-	if err := p.reconcileAuthSecret(ctx, orgs); err != nil {
-		errs = append(errs, fmt.Errorf("reconcile auth secret: %w", err))
+	authErr := p.reconcileAuthSecret(ctx, orgs)
+	if authErr != nil {
+		errs = append(errs, fmt.Errorf("reconcile auth secret: %w", authErr))
 	}
 
 	// 3. Resource groups (K8s ConfigMap). Generated from the per-org
 	// tier; rebuilt every tick.
-	if err := p.reconcileResourceGroups(ctx, orgs); err != nil {
-		errs = append(errs, fmt.Errorf("reconcile resource groups: %w", err))
+	rgErr := p.reconcileResourceGroups(ctx, orgs)
+	if rgErr != nil {
+		errs = append(errs, fmt.Errorf("reconcile resource groups: %w", rgErr))
 	}
 
-	// 4. OPA bundle (push via OPA bundle API). user_catalogs map keyed
-	// by team_id, value is the org's owned catalog set.
-	if err := p.reconcileOPABundle(ctx, orgs); err != nil {
-		errs = append(errs, fmt.Errorf("reconcile opa bundle: %w", err))
+	// 4. OPA bundle. GroupCatalogs keyed by Trino group name; Set into
+	// the in-memory store the bundle HTTP handler serves.
+	opaErr := p.reconcileOPABundle(ctx, orgs)
+	if opaErr != nil {
+		errs = append(errs, fmt.Errorf("reconcile opa bundle: %w", opaErr))
 	}
+
+	// Per-org state writes. The global steps' (auth/rg/opa) outcomes
+	// are the same for every org since each is a single K8s API write
+	// — wrap them once.
+	globalErr := errors.Join(authErr, rgErr, opaErr)
+	p.writePerOrgStates(orgs, catalogOutcomes, globalErr)
 
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// catalogOutcome is the per-org result of the catalog reconcile step.
+// Exactly one of (Created, Existed, Pending) is true when Err == nil;
+// Err != nil means CREATE CATALOG itself failed and the org should
+// land in Failed state with the error message.
+type catalogOutcome struct {
+	Created bool   // catalog was just created this tick
+	Existed bool   // catalog already present, no action taken
+	Pending bool   // skipped because Iceberg isn't ready yet (provisioning, not a failure)
+	Err     error  // CREATE CATALOG error; mutually exclusive with the booleans
+}
+
+// writePerOrgStates writes the per-org state transition after one full
+// reconcile tick. Per-org variance lives entirely at the catalog step;
+// the global steps' failure (if any) applies uniformly to every
+// Trino-enabled org.
+//
+// Priority of attribution (worst wins):
+//
+//   1. Per-org catalog error -> Failed + "catalog: <err>".
+//   2. Global step error     -> Failed + "projection: <err>".
+//   3. Catalog still pending -> Provisioning + "waiting for iceberg".
+//   4. Everything succeeded  -> Ready + ReadyAt=now.
+//
+// Errors from UpdateTrinoState itself are logged and swallowed —
+// failing to record state is non-fatal; the next reconcile tick will
+// re-attempt.
+func (p *TrinoProvisioner) writePerOrgStates(
+	orgs []configstore.TrinoEnabledOrg,
+	catalogOutcomes map[string]catalogOutcome,
+	globalErr error,
+) {
+	now := time.Now().UTC()
+	zero := time.Time{} // pointer-to-zero signals "clear failed_at" to UpdateTrinoState
+	for _, o := range orgs {
+		out := catalogOutcomes[o.OrgID]
+		var (
+			nextState configstore.ManagedWarehouseProvisioningState
+			msg       string
+		)
+		switch {
+		case out.Err != nil:
+			nextState = configstore.ManagedWarehouseStateFailed
+			msg = "catalog: " + out.Err.Error()
+		case globalErr != nil:
+			nextState = configstore.ManagedWarehouseStateFailed
+			msg = "projection: " + globalErr.Error()
+		case out.Pending:
+			nextState = configstore.ManagedWarehouseStateProvisioning
+			msg = "waiting for iceberg / Lakekeeper to become ready"
+		default:
+			// Created or Existed + no global failure == Ready.
+			nextState = configstore.ManagedWarehouseStateReady
+			msg = ""
+		}
+
+		// Transition-aware timestamps, matching the surrounding
+		// ManagedWarehouse pattern in controller.go: ready_at stamps
+		// the first transition into Ready and is preserved on
+		// subsequent ticks; failed_at stamps the transition into
+		// Failed and is cleared on transition out so the column reads
+		// as "currently failing since X" rather than "ever failed."
+		upd := configstore.TrinoStateUpdate{
+			State:         nextState,
+			StatusMessage: msg,
+		}
+		if nextState == configstore.ManagedWarehouseStateReady && o.State != configstore.ManagedWarehouseStateReady {
+			// Transitioning INTO Ready — stamp ready_at, clear any
+			// stale failed_at from the previous Failed lifecycle.
+			upd.ReadyAt = &now
+			upd.FailedAt = &zero
+		}
+		if nextState == configstore.ManagedWarehouseStateFailed && o.State != configstore.ManagedWarehouseStateFailed {
+			// Transitioning INTO Failed — stamp failed_at. Leave
+			// ready_at as-is (it records the historic first-Ready
+			// transition; the row's currently-failing-ness is
+			// represented by state+failed_at).
+			upd.FailedAt = &now
+		}
+		if nextState != configstore.ManagedWarehouseStateFailed && o.State == configstore.ManagedWarehouseStateFailed {
+			// Transitioning OUT of Failed into a non-Ready state
+			// (e.g. Provisioning while waiting on Iceberg) — clear
+			// failed_at since the row is no longer failed.
+			upd.FailedAt = &zero
+		}
+
+		if err := p.store.UpdateTrinoState(o.OrgID, upd); err != nil {
+			slog.Warn("Trino reconcile: failed to write per-org state.",
+				"org", o.OrgID, "error", err)
+		}
+	}
 }
 
 // reconcileCatalogs issues CREATE CATALOG for each Trino-enabled org
@@ -291,10 +400,18 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 // We intentionally only touch catalogs whose name matches the
 // org_*_iceberg prefix so other catalogs (system, jmx, hand-rolled
 // ones for the maintenance use case) survive untouched.
-func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
+func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configstore.TrinoEnabledOrg) (map[string]catalogOutcome, error) {
+	outcomes := make(map[string]catalogOutcome, len(orgs))
+
 	existing, err := p.catalog.ListCatalogs(ctx)
 	if err != nil {
-		return fmt.Errorf("list trino catalogs: %w", err)
+		// Listing failed — we can't safely attribute per-org outcomes,
+		// so flag every org as failed-with-this-error so they don't
+		// transition to ready spuriously.
+		for _, o := range orgs {
+			outcomes[o.OrgID] = catalogOutcome{Err: fmt.Errorf("list trino catalogs: %w", err)}
+		}
+		return outcomes, fmt.Errorf("list trino catalogs: %w", err)
 	}
 	existingSet := make(map[string]bool, len(existing))
 	for _, c := range existing {
@@ -313,27 +430,39 @@ func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configs
 			// Already there. Drift-correct properties (ALTER) is post-v1
 			// — Lakekeeper auth stays allowall so catalog properties
 			// don't drift; revisit when OAuth2 lands.
+			outcomes[o.OrgID] = catalogOutcome{Existed: true}
 			continue
 		}
 		iceberg, err := p.icebergStore.GetManagedWarehouseIceberg(o.OrgID)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("org %s: read iceberg config: %w", o.OrgID, err))
+			perOrgErr := fmt.Errorf("read iceberg config: %w", err)
+			errs = append(errs, fmt.Errorf("org %s: %w", o.OrgID, perOrgErr))
+			outcomes[o.OrgID] = catalogOutcome{Err: perOrgErr}
 			continue
 		}
-		if iceberg == nil || iceberg.LakekeeperEndpoint == "" {
-			// Org opted into Trino but Iceberg isn't ready in Lakekeeper
-			// yet. Skip silently — the next reconcile picks it up once
-			// the Lakekeeper provisioner finishes.
+		if iceberg == nil || iceberg.LakekeeperEndpoint == "" || iceberg.LakekeeperWarehouse == "" {
+			// Org opted into Trino but Iceberg isn't fully ready yet —
+			// both the REST endpoint AND the warehouse name are
+			// required (iceberg.rest-catalog.warehouse rendered as ''
+			// makes Trino reject CREATE CATALOG every tick, silently).
+			// Skip; the next reconcile picks it up once Lakekeeper
+			// provisioning completes.
 			slog.Debug("Trino reconcile: iceberg not ready yet, skipping catalog create.",
-				"org", o.OrgID)
+				"org", o.OrgID,
+				"endpoint_set", iceberg != nil && iceberg.LakekeeperEndpoint != "",
+				"warehouse_set", iceberg != nil && iceberg.LakekeeperWarehouse != "")
+			outcomes[o.OrgID] = catalogOutcome{Pending: true}
 			continue
 		}
 		props := p.buildCatalogProperties(o.OrgID, iceberg)
 		if err := p.catalog.CreateCatalog(ctx, name, props); err != nil {
-			errs = append(errs, fmt.Errorf("create catalog %s: %w", name, err))
+			perOrgErr := fmt.Errorf("create catalog %s: %w", name, err)
+			errs = append(errs, perOrgErr)
+			outcomes[o.OrgID] = catalogOutcome{Err: perOrgErr}
 			continue
 		}
 		slog.Info("Trino reconcile: catalog created.", "org", o.OrgID, "catalog", name)
+		outcomes[o.OrgID] = catalogOutcome{Created: true}
 	}
 
 	for _, c := range existing {
@@ -351,24 +480,39 @@ func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configs
 	}
 
 	if len(errs) > 0 {
-		return errors.Join(errs...)
+		return outcomes, errors.Join(errs...)
 	}
-	return nil
+	return outcomes, nil
 }
 
 // buildCatalogProperties returns the Trino catalog property set for an
 // org's Iceberg catalog. Lakekeeper stays allowall in v1, so no OAuth2
 // credentials are embedded here — just the endpoint, the warehouse
 // name, and the per-org S3 IAM role.
+//
+// Property names follow Trino's current file-system / Iceberg-REST
+// surface (matching the working maintenance chart at
+// charts/charts/trino/files/trino_maintenance.py):
+//
+//	fs.s3.enabled=true              enable the unified S3 file system
+//	s3.region=<region>              forwarded to the AWS SDK
+//	s3.iam-role=<arn>               per-org duckling-<orgid> role
+//
+// The OLD `iceberg.s3.aws-role-arn` / `iceberg.s3.region` properties
+// referenced in the design plan are stale for current Trino — they
+// silently get ignored by some versions and outright rejected by
+// others, both of which break the catalog. Keep this list in sync
+// with the maintenance chart.
 func (p *TrinoProvisioner) buildCatalogProperties(orgID string, ic *configstore.ManagedWarehouseIceberg) map[string]string {
 	props := map[string]string{
-		"connector.name":              "iceberg",
-		"iceberg.catalog.type":        "rest",
-		"iceberg.rest-catalog.uri":    ic.LakekeeperEndpoint,
+		"connector.name":                 "iceberg",
+		"iceberg.catalog.type":           "rest",
+		"iceberg.rest-catalog.uri":       ic.LakekeeperEndpoint,
 		"iceberg.rest-catalog.warehouse": ic.LakekeeperWarehouse,
+		"fs.s3.enabled":                  "true",
 	}
 	if p.iamAccountID != "" {
-		props["iceberg.s3.aws-role-arn"] = fmt.Sprintf("arn:aws:iam::%s:role/duckling-%s", p.iamAccountID, orgID)
+		props["s3.iam-role"] = fmt.Sprintf("arn:aws:iam::%s:role/duckling-%s", p.iamAccountID, orgID)
 	}
 	if p.awsRegion != "" {
 		props["s3.region"] = p.awsRegion
@@ -385,7 +529,7 @@ func (p *TrinoProvisioner) buildCatalogProperties(orgID string, ic *configstore.
 // Mounted into the coordinator pod only (chart configuration in Stream
 // F). Workers never see this Secret.
 func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
-	passwordDB, groupDB := BuildTrinoAuthFiles(orgs)
+	passwordDB, groupDB := BuildTrinoAuthFiles(orgs, p.adminPasswordHash)
 	return p.upsertSecret(ctx, TrinoAuthSecretName, map[string][]byte{
 		TrinoAuthSecretKeyPasswordDB: []byte(passwordDB),
 		TrinoAuthSecretKeyGroupDB:    []byte(groupDB),
@@ -410,8 +554,24 @@ func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []confi
 // Orgs without a RootPasswordHash are skipped silently (the listing
 // query already filters to (org, root-user) pairs, so this is just
 // defensive against future changes).
-func BuildTrinoAuthFiles(orgs []configstore.TrinoEnabledOrg) (passwordDB, groupDB string) {
+//
+// adminPasswordHash is the bcrypt for opa.AdminPrincipal — the
+// provisioner's own catalog-management identity. When non-empty, the
+// admin entry is unconditionally prepended to both files (regardless of
+// orgs). The plan ("Internal admin principal for catalog management")
+// requires the admin in *both* password.db and group.db so OPA's
+// is_admin = (admin username AND admin group) conjunction holds; the
+// provisioner cannot do CREATE/DROP CATALOG otherwise. Empty hash skips
+// the admin lines (acceptable in unit tests where the catalog client is
+// a fake; never acceptable in production — see NewTrinoProvisioner).
+func BuildTrinoAuthFiles(orgs []configstore.TrinoEnabledOrg, adminPasswordHash string) (passwordDB, groupDB string) {
 	var pwLines, grpLines []string
+	if adminPasswordHash != "" {
+		// Prepend so the admin is always present even if every org row
+		// is filtered out (empty cluster bootstrap).
+		pwLines = append(pwLines, fmt.Sprintf("%s:%s", opa.AdminPrincipal, adminPasswordHash))
+		grpLines = append(grpLines, fmt.Sprintf("%s:%s", opa.AdminGroup, opa.AdminPrincipal))
+	}
 	for _, o := range orgs {
 		if o.RootPasswordHash == "" || o.OrgID == "" {
 			continue
@@ -534,7 +694,11 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 			continue
 		}
 		sg := tierLimits(o.Tier)
-		sg.Name = o.OrgID
+		// Subgroup name is sanitized to match TrinoResourceGroupName's
+		// final path component. The selector's User field stays raw —
+		// it matches against Trino's `current_user`, which is the
+		// auth-time username (raw orgID).
+		sg.Name = trinoSanitize(o.OrgID)
 		subgroups = append(subgroups, sg)
 		selectors = append(selectors, resourceGroupSelector{
 			User:  o.OrgID,
@@ -565,27 +729,45 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 	return out, nil
 }
 
-// reconcileOPABundle builds the user_catalogs map and asks the bundle
-// builder to render a bundle, then pushes it via the OPA bundle API.
+// reconcileOPABundle builds the GroupCatalogs map and Set()s a freshly
+// built bundle into the in-memory BundleStore. The customer-Trino OPA
+// sidecar polls opa.Handler (mounted by the caller on the provisioning
+// HTTP server, backed by this same store) with If-None-Match; an
+// unchanged input produces a byte-equal bundle, the ETag matches, and
+// OPA's poll returns 304 without re-activating.
 //
-// While the bundle builder is the stub (returns "{}"), this step still
-// exercises the code path end-to-end so a regression landing alongside
-// the real builder's merge is loud, not silent.
-func (p *TrinoProvisioner) reconcileOPABundle(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
-	uc := make(opa.UserCatalogs, len(orgs))
+// Keying is by *group*, not by username — the policy authorises via
+// `data.group_catalogs[group][catalog]`. Customer principals' groups
+// are `org_<team_id>` (TrinoGroupName); the admin group owns every
+// managed catalog so the provisioner's own SHOW CATALOGS idempotency
+// check (run as opa.AdminPrincipal) is allowed.
+//
+// ctx is currently unused (the builder is pure and the store Set is
+// in-memory), but kept on the signature for parity with the other
+// reconcile* steps and to permit instrumented builders later.
+func (p *TrinoProvisioner) reconcileOPABundle(_ context.Context, orgs []configstore.TrinoEnabledOrg) error {
+	gc := make(opa.GroupCatalogs, len(orgs)+1)
+	adminCatalogs := make(map[string]bool, len(orgs))
 	for _, o := range orgs {
 		if o.OrgID == "" {
 			continue
 		}
-		uc[o.OrgID] = map[string]bool{TrinoCatalogName(o.OrgID): true}
+		catalog := TrinoCatalogName(o.OrgID)
+		gc[TrinoGroupName(o.OrgID)] = map[string]bool{catalog: true}
+		adminCatalogs[catalog] = true
 	}
-	bundle, err := p.bundleBuilder.BuildBundle(uc)
+	if len(adminCatalogs) > 0 {
+		// Admin owns every managed catalog so SHOW CATALOGS / catalog
+		// management succeeds. Reads still require is_admin (the
+		// admin-group claim alone grants nothing — see opa.AdminGroup
+		// docstring).
+		gc[opa.AdminGroup] = adminCatalogs
+	}
+	bundle, err := p.bundleBuilder.BuildBundle(gc)
 	if err != nil {
 		return fmt.Errorf("build opa bundle: %w", err)
 	}
-	if err := p.opa.PushBundle(ctx, bundle); err != nil {
-		return fmt.Errorf("push opa bundle: %w", err)
-	}
+	p.bundleStore.Set(opa.NewBundle(bundle))
 	return nil
 }
 
@@ -659,14 +841,14 @@ func (p *TrinoProvisioner) upsertConfigMap(ctx context.Context, name string, dat
 }
 
 // =====================================================================
-// HTTP implementations of TrinoCatalogClient + OPABundleClient.
+// HTTP implementation of TrinoCatalogClient.
 // =====================================================================
 
 // trinoCatalogHTTPClient drives the Trino REST API for catalog
 // management. Authentication is HTTP Basic (Trino's standard for the
 // file password authenticator); the configured user is
-// TrinoAdminProvisionerUser, with the password living in a K8s Secret
-// mounted only into the provisioner pod.
+// opa.AdminPrincipal, with the password living in a K8s Secret mounted
+// only into the provisioner pod.
 //
 // One client per provisioner instance — the underlying http.Client is
 // goroutine-safe but the cached Basic-auth header is set once at
@@ -681,10 +863,10 @@ type trinoCatalogHTTPClient struct {
 // NewTrinoCatalogHTTPClient builds an HTTP-backed TrinoCatalogClient.
 // baseURL is the customer Trino coordinator endpoint (typically the
 // in-cluster Service: http://trino:8080). Username defaults to
-// TrinoAdminProvisionerUser if empty.
+// opa.AdminPrincipal if empty.
 func NewTrinoCatalogHTTPClient(baseURL, username, password string) TrinoCatalogClient {
 	if username == "" {
-		username = TrinoAdminProvisionerUser
+		username = opa.AdminPrincipal
 	}
 	return &trinoCatalogHTTPClient{
 		baseURL:  strings.TrimRight(baseURL, "/"),
@@ -740,10 +922,21 @@ func (c *trinoCatalogHTTPClient) runStatement(ctx context.Context, sql string) (
 // drainStatement reads the nextUri chain until the statement
 // completes. Each hop is a GET; the final body carries the result
 // data (already-accumulated rows from earlier hops are kept).
+//
+// Bounded to maxDrainHops to defend against a pathological Trino
+// (or test fake) that perpetually returns a nextUri without ever
+// completing. Catalog management statements are DDL and finish in a
+// handful of hops in practice; 1000 is generous for any sane Trino.
+// Each hop also honors ctx — a cancelled reconcile context aborts
+// promptly rather than waiting for the next request to time out.
 func (c *trinoCatalogHTTPClient) drainStatement(ctx context.Context, initial []byte) ([][]interface{}, error) {
+	const maxDrainHops = 1000
 	var all [][]interface{}
 	body := initial
-	for {
+	for hop := 0; hop < maxDrainHops; hop++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("statement drain aborted: %w", err)
+		}
 		var r trinoStatementResponse
 		if err := json.Unmarshal(body, &r); err != nil {
 			return nil, fmt.Errorf("parse statement response: %w (body=%q)", err, string(body))
@@ -771,6 +964,7 @@ func (c *trinoCatalogHTTPClient) drainStatement(ctx context.Context, initial []b
 			return nil, fmt.Errorf("get nextUri: status %d: %s", resp.StatusCode, string(body))
 		}
 	}
+	return nil, fmt.Errorf("statement drain exceeded %d hops without completing", maxDrainHops)
 }
 
 // ListCatalogs runs SHOW CATALOGS and returns the catalog names.
@@ -798,8 +992,17 @@ func (c *trinoCatalogHTTPClient) CreateCatalog(ctx context.Context, name string,
 	if connector == "" {
 		return fmt.Errorf("CreateCatalog %q: connector.name property is required", name)
 	}
-	withProps := props
-	delete(withProps, "connector.name")
+	// Copy props minus connector.name into withProps; do not mutate the
+	// caller's map. (Earlier versions did `withProps := props; delete(withProps, "connector.name")`,
+	// which silently shared backing storage with the caller and stripped
+	// connector.name from their copy too.)
+	withProps := make(map[string]string, len(props))
+	for k, v := range props {
+		if k == "connector.name" {
+			continue
+		}
+		withProps[k] = v
+	}
 	sql := fmt.Sprintf("CREATE CATALOG %s USING %s%s", quoteTrinoIdentifier(name), connector, renderWithClause(withProps))
 	_, err := c.runStatement(ctx, sql)
 	return err
@@ -855,51 +1058,8 @@ func basicAuth(username, password string) string {
 	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 }
 
-// =====================================================================
-// OPA bundle HTTP client.
-// =====================================================================
-
-// opaBundleHTTPClient pushes a bundle to the OPA sidecar's bundle API
-// (PUT /v1/policies or the bundle service endpoint; specific path is
-// configurable). The bundle bytes are uploaded as the request body.
-//
-// For v1 the OPA sidecar runs alongside the customer Trino coordinator
-// pod, so the URL is typically http://localhost:8181 from the
-// provisioner's perspective (port-forward in dev) or
-// http://trino-coordinator-opa:8181 from the provisioner pod in K8s.
-type opaBundleHTTPClient struct {
-	baseURL string
-	hc      *http.Client
-}
-
-// NewOPABundleHTTPClient builds an OPABundleClient. baseURL is the OPA
-// sidecar's bundle API root.
-func NewOPABundleHTTPClient(baseURL string) OPABundleClient {
-	return &opaBundleHTTPClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		hc:      &http.Client{Timeout: 30 * time.Second},
-	}
-}
-
-// PushBundle uploads the bundle bytes to the OPA bundle endpoint.
-// We use PUT /v1/policies/duckgres so the bundle replaces the
-// previously-pushed one rather than appending. OPA's bundle API path
-// can vary by configuration; the path may need to match the real
-// builder PR's PushBundle helper before merge.
-func (c *opaBundleHTTPClient) PushBundle(ctx context.Context, bundle []byte) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/v1/policies/duckgres", bytes.NewReader(bundle))
-	if err != nil {
-		return fmt.Errorf("build opa request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/octet-stream")
-	resp, err := c.hc.Do(req)
-	if err != nil {
-		return fmt.Errorf("opa push: %w", err)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("opa push: status %d: %s", resp.StatusCode, string(body))
-	}
-	return nil
-}
+// Bundle distribution is pull-based (plan "Open Questions #6"): the
+// provisioner Set()s built bundles into an opa.BundleStore; the
+// customer-Trino OPA sidecar polls opa.Handler with If-None-Match.
+// There is no provisioner-side push client. See reconcileOPABundle and
+// TrinoProvisionerOpts.BundleStore.

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -685,10 +685,24 @@ func tierLimits(tier string) resourceGroupSubGroup {
 //          └─ ...
 //
 // Selectors map Trino username (== team_id for customer principals) to
-// the root.tenants.<team_id> group.
+// the root.tenants.<team_id> group. The admin principal lives under a
+// sibling root.admin.<admin_user> path so its catalog-DDL traffic is
+// isolated from tenant traffic and so it matches a selector at all
+// (without an admin selector, Trino's resource-group manager rejects
+// the admin's SHOW/CREATE/DROP CATALOG queries with "Query is not
+// associated with any resource group" — which would silently break
+// every reconcile tick).
 func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error) {
 	subgroups := make([]resourceGroupSubGroup, 0, len(orgs))
-	selectors := make([]resourceGroupSelector, 0, len(orgs))
+	// Admin selector first so its match wins fast on the reconcile-DDL
+	// path; tenant selectors follow. (Selector order is first-match-
+	// wins in Trino's file-backed manager. With disjoint usernames the
+	// order is functionally irrelevant, but keeping admin first
+	// documents the intent and makes the file readable.)
+	selectors := []resourceGroupSelector{{
+		User:  opa.AdminPrincipal,
+		Group: "root.admin." + opa.AdminPrincipal,
+	}}
 	for _, o := range orgs {
 		if o.OrgID == "" {
 			continue
@@ -706,19 +720,39 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 		})
 	}
 
+	// Admin tier limits are deliberately small. The provisioner only
+	// issues DDL (SHOW / CREATE / DROP / ALTER CATALOG) which finishes
+	// in milliseconds; oversizing the admin lane is wasted budget that
+	// could be eating into the tenants tier.
+	adminTier := resourceGroupTier{
+		Name:                 "admin",
+		SoftMemoryLimit:      "5%",
+		HardConcurrencyLimit: 4,
+		MaxQueued:            20,
+		SubGroups: []resourceGroupSubGroup{{
+			Name:                 opa.AdminPrincipal,
+			SoftMemoryLimit:      "5%",
+			HardConcurrencyLimit: 4,
+			MaxQueued:            20,
+		}},
+	}
+
 	cfg := resourceGroupsFile{
 		RootGroups: []resourceGroupRoot{{
 			Name:                 "root",
 			SoftMemoryLimit:      "100%",
 			HardConcurrencyLimit: 200,
 			MaxQueued:            1000,
-			SubGroups: []resourceGroupTier{{
-				Name:                 "tenants",
-				SoftMemoryLimit:      "80%",
-				HardConcurrencyLimit: 100,
-				MaxQueued:            500,
-				SubGroups:            subgroups,
-			}},
+			SubGroups: []resourceGroupTier{
+				adminTier,
+				{
+					Name:                 "tenants",
+					SoftMemoryLimit:      "80%",
+					HardConcurrencyLimit: 100,
+					MaxQueued:            500,
+					SubGroups:            subgroups,
+				},
+			},
 		}},
 		Selectors: selectors,
 	}

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -71,8 +71,10 @@ func trinoSanitize(orgName string) string {
 }
 
 // TrinoCatalogName returns the catalog identifier for an org.
-// Format: org_<sanitized>_iceberg. Documented as part of the v1
-// catalog-naming contract in the plan.
+// Format: org_<sanitized>_iceberg. The sanitization maps Org.Name
+// to Trino identifier rules ([a-z0-9_]); any other characters
+// collapse to underscores. Catalog name uniqueness across orgs
+// depends on Org.Name uniqueness post-sanitization.
 func TrinoCatalogName(orgName string) string {
 	return "org_" + trinoSanitize(orgName) + "_iceberg"
 }
@@ -144,8 +146,9 @@ type TrinoProvisionerOpts struct {
 	OPA OPABundleClient
 
 	// BundleBuilder builds the OPA bundle from the user→catalogs map.
-	// Stream B replaces opa.NewStubBuilder() here with the real
-	// implementation.
+	// Construct with opa.NewStubBuilder() until the real Rego-backed
+	// builder ships in a sibling PR (which swaps in a real constructor
+	// without touching this call site).
 	BundleBuilder opa.BundleBuilder
 
 	// IAMAccountID is the AWS account id the per-org Iceberg catalogs
@@ -394,7 +397,7 @@ func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []confi
 // unit tests can exercise the projection without K8s + the rest of
 // the reconcile path.
 //
-// Format conventions (from the plan, "Trino path" section):
+// Format conventions:
 //
 //   password.db: <team_id>:<bcrypt hash from OrgUser.Password>
 //                One line per org. Hash is copied through unchanged
@@ -513,7 +516,7 @@ func tierLimits(tier string) resourceGroupSubGroup {
 // resource-groups.json file from a list of Trino-enabled orgs. Pure
 // function for unit testing.
 //
-// Tree shape (matches the plan's Identity & Naming section):
+// Tree shape:
 //
 //   root
 //     └─ tenants
@@ -565,9 +568,9 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 // reconcileOPABundle builds the user_catalogs map and asks the bundle
 // builder to render a bundle, then pushes it via the OPA bundle API.
 //
-// While Stream B's bundle builder is the stub (returns "{}"), this
-// step still exercises the code path end-to-end so a regression
-// landing alongside Stream B's merge is loud, not silent.
+// While the bundle builder is the stub (returns "{}"), this step still
+// exercises the code path end-to-end so a regression landing alongside
+// the real builder's merge is loud, not silent.
 func (p *TrinoProvisioner) reconcileOPABundle(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
 	uc := make(opa.UserCatalogs, len(orgs))
 	for _, o := range orgs {
@@ -881,8 +884,8 @@ func NewOPABundleHTTPClient(baseURL string) OPABundleClient {
 // PushBundle uploads the bundle bytes to the OPA bundle endpoint.
 // We use PUT /v1/policies/duckgres so the bundle replaces the
 // previously-pushed one rather than appending. OPA's bundle API path
-// can vary by configuration; revisit alongside Stream B's bundle
-// builder.
+// can vary by configuration; the path may need to match the real
+// builder PR's PushBundle helper before merge.
 func (c *opaBundleHTTPClient) PushBundle(ctx context.Context, bundle []byte) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/v1/policies/duckgres", bytes.NewReader(bundle))
 	if err != nil {

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -1,0 +1,902 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TrinoCustomerNamespace is the K8s namespace where the customer-facing
+// Trino cluster lives. The auth Secret + resource-groups ConfigMap are
+// projected into this namespace by the provisioner.
+const TrinoCustomerNamespace = "trino-customer"
+
+// TrinoAuthSecretName is the K8s Secret that holds the projected
+// password.db + group.db. Mounted only into the coordinator pod, not
+// workers — workers don't authenticate; the blast radius of a worker pod
+// compromise stays away from the bcrypt hashes.
+const TrinoAuthSecretName = "trino-auth"
+
+// Trino auth secret data keys.
+const (
+	TrinoAuthSecretKeyPasswordDB = "password.db"
+	TrinoAuthSecretKeyGroupDB    = "group.db"
+)
+
+// TrinoResourceGroupsConfigMapName is the K8s ConfigMap that holds the
+// generated resource-groups.json file consumed by the Trino coordinator
+// via resource-groups.config-file.
+const TrinoResourceGroupsConfigMapName = "trino-resource-groups"
+
+// TrinoResourceGroupsConfigMapKey is the data key under which the JSON
+// file is stored. Matches the file name Trino expects via
+// resource-groups.config-file mount.
+const TrinoResourceGroupsConfigMapKey = "resource-groups.json"
+
+// TrinoAdminProvisionerUser is the reserved Trino principal the
+// provisioner uses for catalog management. OPA distinguishes this
+// principal from customer users to scope CREATE/ALTER/DROP CATALOG.
+const TrinoAdminProvisionerUser = "__admin_provisioner"
+
+// trinoCatalogIdentifier is the Trino catalog identifier grammar
+// ([a-z0-9_]+). Anything outside this set in Org.Name is replaced with
+// `_` before forming the catalog name.
+var trinoCatalogIdentifier = regexp.MustCompile(`[^a-z0-9_]`)
+
+// trinoSanitize lowercases and replaces non-[a-z0-9_] runs with `_`.
+// Pure function so callers can recover the sanitized name without
+// holding the provisioner.
+func trinoSanitize(orgName string) string {
+	lower := strings.ToLower(orgName)
+	return trinoCatalogIdentifier.ReplaceAllString(lower, "_")
+}
+
+// TrinoCatalogName returns the catalog identifier for an org.
+// Format: org_<sanitized>_iceberg. Documented as part of the v1
+// catalog-naming contract in the plan.
+func TrinoCatalogName(orgName string) string {
+	return "org_" + trinoSanitize(orgName) + "_iceberg"
+}
+
+// TrinoGroupName returns the file-group-provider group label for an org.
+// Format: org_<sanitized>. Matches the OPA `input.context.identity.groups`
+// the customer Trino sends with each decision request.
+func TrinoGroupName(orgName string) string {
+	return "org_" + trinoSanitize(orgName)
+}
+
+// TrinoResourceGroupName returns the resource-group selector key for an
+// org. Customer principals' Trino username == orgName (numeric team_id);
+// selectors match on that, scoping the org into root.tenants.<orgName>.
+func TrinoResourceGroupName(orgName string) string {
+	return "root.tenants." + orgName
+}
+
+// TrinoCatalogClient is the REST surface the provisioner needs against
+// the customer Trino cluster: enumerate, create, alter, drop catalogs.
+// Concrete implementation in trinoCatalogHTTPClient below; the interface
+// is exported so tests can inject a fake at the function boundary.
+type TrinoCatalogClient interface {
+	ListCatalogs(ctx context.Context) ([]string, error)
+	CreateCatalog(ctx context.Context, name string, props map[string]string) error
+	AlterCatalog(ctx context.Context, name string, props map[string]string) error
+	DropCatalog(ctx context.Context, name string) error
+}
+
+// OPABundleClient is the surface the provisioner uses to push a generated
+// bundle to the customer Trino cluster's OPA sidecar via the bundle API.
+// One pod hosts the OPA sidecar (alongside the coordinator); the push is
+// over loopback / NetworkPolicy-restricted egress. Interface lets tests
+// substitute a fake.
+type OPABundleClient interface {
+	PushBundle(ctx context.Context, bundle []byte) error
+}
+
+// TrinoProvisionerOpts groups all the dependencies trino_provisioner.go
+// needs. Each is required at construction time — partial wiring would
+// cause silent reconcile no-ops, which we'd rather surface at startup.
+type TrinoProvisionerOpts struct {
+	// Store is the cross-cutting Trino read/write surface. Two methods
+	// matter: ListTrinoEnabledOrgs for the projection inputs, and
+	// GetManagedWarehouseTrino for per-org status reads if needed.
+	Store TrinoStore
+
+	// IcebergStore is the per-org Iceberg config read surface (used to
+	// build catalog properties pointing at the per-org Lakekeeper). We
+	// reuse the existing configstore.ConfigStore-backed reader here.
+	IcebergStore TrinoIcebergStore
+
+	// Kubernetes is used for the auth Secret and resource-groups
+	// ConfigMap projections in the customer Trino namespace.
+	Kubernetes kubernetes.Interface
+
+	// Namespace overrides TrinoCustomerNamespace. Empty == default.
+	// Useful for dev clusters that namespace customer Trino differently.
+	Namespace string
+
+	// Catalog is the Trino REST client used to issue CREATE / ALTER /
+	// DROP CATALOG. The provisioner authenticates as
+	// TrinoAdminProvisionerUser; the underlying HTTP client owns the
+	// admin Basic-auth credential.
+	Catalog TrinoCatalogClient
+
+	// OPA is the bundle push client. Bundle bytes come from
+	// BundleBuilder.
+	OPA OPABundleClient
+
+	// BundleBuilder builds the OPA bundle from the user→catalogs map.
+	// Stream B replaces opa.NewStubBuilder() here with the real
+	// implementation.
+	BundleBuilder opa.BundleBuilder
+
+	// IAMAccountID is the AWS account id the per-org Iceberg catalogs
+	// reference via iceberg.s3.aws-role-arn (the duckling-<orgid> role).
+	// Required for AWS deployments; empty in dev / unit tests.
+	IAMAccountID string
+
+	// AWSRegion is the AWS region for the per-org S3 IAM role binding
+	// and Iceberg catalog config. Empty in dev / unit tests.
+	AWSRegion string
+}
+
+// TrinoStore is the read surface trino_provisioner.go uses for the per-
+// reconcile projection inputs. Defined as a narrow interface so unit
+// tests can swap a fake and so the type doesn't drag the configstore
+// import everywhere.
+type TrinoStore interface {
+	ListTrinoEnabledOrgs() ([]configstore.TrinoEnabledOrg, error)
+}
+
+// TrinoIcebergStore reads a single org's Iceberg config to populate the
+// per-org catalog properties. Backed by configstore.ConfigStore.
+type TrinoIcebergStore interface {
+	GetManagedWarehouseIceberg(orgID string) (*configstore.ManagedWarehouseIceberg, error)
+}
+
+// TrinoProvisioner owns the four outputs the customer Trino cluster
+// depends on for per-org configuration: catalog REST state, password +
+// group files, resource-groups JSON, and OPA bundle.
+//
+// All four outputs are regenerated on every reconcile tick from the same
+// configstore-derived input. Same input → same output (deterministic
+// projection), so a re-run is a no-op against settled state.
+type TrinoProvisioner struct {
+	store         TrinoStore
+	icebergStore  TrinoIcebergStore
+	kubernetes    kubernetes.Interface
+	namespace     string
+	catalog       TrinoCatalogClient
+	opa           OPABundleClient
+	bundleBuilder opa.BundleBuilder
+	iamAccountID  string
+	awsRegion     string
+}
+
+// NewTrinoProvisioner constructs a TrinoProvisioner from required deps.
+// Returns an error if any required dep is missing rather than panicking
+// downstream on the first reconcile tick.
+func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
+	if opts.Store == nil {
+		return nil, errors.New("TrinoProvisioner: Store is required")
+	}
+	if opts.IcebergStore == nil {
+		return nil, errors.New("TrinoProvisioner: IcebergStore is required")
+	}
+	if opts.Kubernetes == nil {
+		return nil, errors.New("TrinoProvisioner: Kubernetes client is required")
+	}
+	if opts.Catalog == nil {
+		return nil, errors.New("TrinoProvisioner: Catalog client is required")
+	}
+	if opts.OPA == nil {
+		return nil, errors.New("TrinoProvisioner: OPA client is required")
+	}
+	if opts.BundleBuilder == nil {
+		return nil, errors.New("TrinoProvisioner: BundleBuilder is required")
+	}
+	ns := opts.Namespace
+	if ns == "" {
+		ns = TrinoCustomerNamespace
+	}
+	return &TrinoProvisioner{
+		store:         opts.Store,
+		icebergStore:  opts.IcebergStore,
+		kubernetes:    opts.Kubernetes,
+		namespace:     ns,
+		catalog:       opts.Catalog,
+		opa:           opts.OPA,
+		bundleBuilder: opts.BundleBuilder,
+		iamAccountID:  opts.IAMAccountID,
+		awsRegion:     opts.AWSRegion,
+	}, nil
+}
+
+// Reconcile runs one full projection: catalogs → auth files → resource
+// groups → OPA bundle. Errors in any one output are logged and surfaced
+// but the next output still runs — a failing OPA push shouldn't leave
+// the password file stale, and vice versa. The caller's next tick re-
+// runs everything.
+//
+// Returns a multi-error wrapping every per-step error so callers can
+// surface them in observability without losing detail. nil iff every
+// step succeeded.
+func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
+	orgs, err := p.store.ListTrinoEnabledOrgs()
+	if err != nil {
+		return fmt.Errorf("list trino-enabled orgs: %w", err)
+	}
+
+	// Stable iteration order so logs and projections are deterministic
+	// regardless of how the DB driver returned the rows.
+	sort.Slice(orgs, func(i, j int) bool { return orgs[i].OrgID < orgs[j].OrgID })
+
+	var errs []error
+
+	// 1. Catalogs (REST). Per-org idempotent CREATE; orgs disabled since
+	// last tick get DROP. Failing one org doesn't block the others.
+	if err := p.reconcileCatalogs(ctx, orgs); err != nil {
+		errs = append(errs, fmt.Errorf("reconcile catalogs: %w", err))
+	}
+
+	// 2. Auth file projection (K8s Secret). Atomic Secret update.
+	if err := p.reconcileAuthSecret(ctx, orgs); err != nil {
+		errs = append(errs, fmt.Errorf("reconcile auth secret: %w", err))
+	}
+
+	// 3. Resource groups (K8s ConfigMap). Generated from the per-org
+	// tier; rebuilt every tick.
+	if err := p.reconcileResourceGroups(ctx, orgs); err != nil {
+		errs = append(errs, fmt.Errorf("reconcile resource groups: %w", err))
+	}
+
+	// 4. OPA bundle (push via OPA bundle API). user_catalogs map keyed
+	// by team_id, value is the org's owned catalog set.
+	if err := p.reconcileOPABundle(ctx, orgs); err != nil {
+		errs = append(errs, fmt.Errorf("reconcile opa bundle: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// reconcileCatalogs issues CREATE CATALOG for each Trino-enabled org
+// (idempotent — SHOW CATALOGS first, skip if already present), and
+// DROP CATALOG for any `org_*_iceberg` catalogs the customer cluster
+// has that aren't in the enabled set.
+//
+// We intentionally only touch catalogs whose name matches the
+// org_*_iceberg prefix so other catalogs (system, jmx, hand-rolled
+// ones for the maintenance use case) survive untouched.
+func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
+	existing, err := p.catalog.ListCatalogs(ctx)
+	if err != nil {
+		return fmt.Errorf("list trino catalogs: %w", err)
+	}
+	existingSet := make(map[string]bool, len(existing))
+	for _, c := range existing {
+		existingSet[c] = true
+	}
+
+	wanted := make(map[string]bool, len(orgs))
+	for _, o := range orgs {
+		wanted[TrinoCatalogName(o.OrgID)] = true
+	}
+
+	var errs []error
+	for _, o := range orgs {
+		name := TrinoCatalogName(o.OrgID)
+		if existingSet[name] {
+			// Already there. Drift-correct properties (ALTER) is post-v1
+			// — Lakekeeper auth stays allowall so catalog properties
+			// don't drift; revisit when OAuth2 lands.
+			continue
+		}
+		iceberg, err := p.icebergStore.GetManagedWarehouseIceberg(o.OrgID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("org %s: read iceberg config: %w", o.OrgID, err))
+			continue
+		}
+		if iceberg == nil || iceberg.LakekeeperEndpoint == "" {
+			// Org opted into Trino but Iceberg isn't ready in Lakekeeper
+			// yet. Skip silently — the next reconcile picks it up once
+			// the Lakekeeper provisioner finishes.
+			slog.Debug("Trino reconcile: iceberg not ready yet, skipping catalog create.",
+				"org", o.OrgID)
+			continue
+		}
+		props := p.buildCatalogProperties(o.OrgID, iceberg)
+		if err := p.catalog.CreateCatalog(ctx, name, props); err != nil {
+			errs = append(errs, fmt.Errorf("create catalog %s: %w", name, err))
+			continue
+		}
+		slog.Info("Trino reconcile: catalog created.", "org", o.OrgID, "catalog", name)
+	}
+
+	for _, c := range existing {
+		if !strings.HasPrefix(c, "org_") || !strings.HasSuffix(c, "_iceberg") {
+			continue
+		}
+		if wanted[c] {
+			continue
+		}
+		if err := p.catalog.DropCatalog(ctx, c); err != nil {
+			errs = append(errs, fmt.Errorf("drop stale catalog %s: %w", c, err))
+			continue
+		}
+		slog.Info("Trino reconcile: catalog dropped.", "catalog", c)
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// buildCatalogProperties returns the Trino catalog property set for an
+// org's Iceberg catalog. Lakekeeper stays allowall in v1, so no OAuth2
+// credentials are embedded here — just the endpoint, the warehouse
+// name, and the per-org S3 IAM role.
+func (p *TrinoProvisioner) buildCatalogProperties(orgID string, ic *configstore.ManagedWarehouseIceberg) map[string]string {
+	props := map[string]string{
+		"connector.name":              "iceberg",
+		"iceberg.catalog.type":        "rest",
+		"iceberg.rest-catalog.uri":    ic.LakekeeperEndpoint,
+		"iceberg.rest-catalog.warehouse": ic.LakekeeperWarehouse,
+	}
+	if p.iamAccountID != "" {
+		props["iceberg.s3.aws-role-arn"] = fmt.Sprintf("arn:aws:iam::%s:role/duckling-%s", p.iamAccountID, orgID)
+	}
+	if p.awsRegion != "" {
+		props["s3.region"] = p.awsRegion
+	} else if ic.Region != "" {
+		props["s3.region"] = ic.Region
+	}
+	return props
+}
+
+// reconcileAuthSecret rebuilds password.db + group.db and atomically
+// writes the trino-auth K8s Secret. Idempotent — same orgs in same
+// order produce byte-equal files.
+//
+// Mounted into the coordinator pod only (chart configuration in Stream
+// F). Workers never see this Secret.
+func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
+	passwordDB, groupDB := BuildTrinoAuthFiles(orgs)
+	return p.upsertSecret(ctx, TrinoAuthSecretName, map[string][]byte{
+		TrinoAuthSecretKeyPasswordDB: []byte(passwordDB),
+		TrinoAuthSecretKeyGroupDB:    []byte(groupDB),
+	})
+}
+
+// BuildTrinoAuthFiles deterministically renders the (password.db,
+// group.db) pair for a list of Trino-enabled orgs. Pure function so
+// unit tests can exercise the projection without K8s + the rest of
+// the reconcile path.
+//
+// Format conventions (from the plan, "Trino path" section):
+//
+//   password.db: <team_id>:<bcrypt hash from OrgUser.Password>
+//                One line per org. Hash is copied through unchanged
+//                — it's already bcrypt in the configstore.
+//   group.db:    <group_name>:<comma-separated users>
+//                NOTE: this is the opposite direction from password.db.
+//                For v1 (one user per org) the value is the single
+//                team_id. Easy to get backwards, hence this comment.
+//
+// Orgs without a RootPasswordHash are skipped silently (the listing
+// query already filters to (org, root-user) pairs, so this is just
+// defensive against future changes).
+func BuildTrinoAuthFiles(orgs []configstore.TrinoEnabledOrg) (passwordDB, groupDB string) {
+	var pwLines, grpLines []string
+	for _, o := range orgs {
+		if o.RootPasswordHash == "" || o.OrgID == "" {
+			continue
+		}
+		pwLines = append(pwLines, fmt.Sprintf("%s:%s", o.OrgID, o.RootPasswordHash))
+		// group_name first, comma-separated users second. For v1 this
+		// is one user per group (team_id only).
+		grpLines = append(grpLines, fmt.Sprintf("%s:%s", TrinoGroupName(o.OrgID), o.OrgID))
+	}
+	// Trailing newline so a file with one entry round-trips through
+	// `cat password.db | head` cleanly; matters mostly for ops.
+	if len(pwLines) > 0 {
+		pwLines = append(pwLines, "")
+	}
+	if len(grpLines) > 0 {
+		grpLines = append(grpLines, "")
+	}
+	return strings.Join(pwLines, "\n"), strings.Join(grpLines, "\n")
+}
+
+// reconcileResourceGroups builds resource-groups.json and projects it
+// into the trino-resource-groups ConfigMap. The Trino coordinator
+// reads the file via the mounted ConfigMap; Trino's resource-groups
+// plugin picks up file changes (no reload needed when only data
+// changes).
+func (p *TrinoProvisioner) reconcileResourceGroups(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
+	bytes, err := BuildTrinoResourceGroups(orgs)
+	if err != nil {
+		return fmt.Errorf("build resource-groups.json: %w", err)
+	}
+	return p.upsertConfigMap(ctx, TrinoResourceGroupsConfigMapName, map[string]string{
+		TrinoResourceGroupsConfigMapKey: string(bytes),
+	})
+}
+
+// resourceGroupSubGroup is the per-org subgroup serialized into
+// resource-groups.json under root.tenants.<team_id>.
+type resourceGroupSubGroup struct {
+	Name                  string `json:"name"`
+	SoftMemoryLimit       string `json:"softMemoryLimit"`
+	HardConcurrencyLimit  int    `json:"hardConcurrencyLimit"`
+	MaxQueued             int    `json:"maxQueued"`
+	SchedulingPolicy      string `json:"schedulingPolicy,omitempty"`
+	SchedulingWeight      int    `json:"schedulingWeight,omitempty"`
+}
+
+type resourceGroupTier struct {
+	Name                  string                  `json:"name"`
+	SoftMemoryLimit       string                  `json:"softMemoryLimit"`
+	HardConcurrencyLimit  int                     `json:"hardConcurrencyLimit"`
+	MaxQueued             int                     `json:"maxQueued"`
+	SubGroups             []resourceGroupSubGroup `json:"subGroups,omitempty"`
+}
+
+type resourceGroupRoot struct {
+	Name                  string              `json:"name"`
+	SoftMemoryLimit       string              `json:"softMemoryLimit"`
+	HardConcurrencyLimit  int                 `json:"hardConcurrencyLimit"`
+	MaxQueued             int                 `json:"maxQueued"`
+	SubGroups             []resourceGroupTier `json:"subGroups,omitempty"`
+}
+
+type resourceGroupSelector struct {
+	User  string `json:"user"`
+	Group string `json:"group"`
+}
+
+type resourceGroupsFile struct {
+	RootGroups []resourceGroupRoot     `json:"rootGroups"`
+	Selectors  []resourceGroupSelector `json:"selectors"`
+}
+
+// tierLimits maps a tier name to per-org subgroup limits. v1 ships
+// just three tiers; refine in post-v1 work once we have load data.
+//
+// Empty tier (default for orgs that didn't specify one) gets the
+// "free" limits — the most conservative.
+func tierLimits(tier string) resourceGroupSubGroup {
+	switch tier {
+	case "growth":
+		return resourceGroupSubGroup{
+			SoftMemoryLimit:      "20%",
+			HardConcurrencyLimit: 10,
+			MaxQueued:            50,
+		}
+	case "scale":
+		return resourceGroupSubGroup{
+			SoftMemoryLimit:      "40%",
+			HardConcurrencyLimit: 25,
+			MaxQueued:            100,
+		}
+	default: // "free" or ""
+		return resourceGroupSubGroup{
+			SoftMemoryLimit:      "5%",
+			HardConcurrencyLimit: 3,
+			MaxQueued:            20,
+		}
+	}
+}
+
+// BuildTrinoResourceGroups deterministically renders the
+// resource-groups.json file from a list of Trino-enabled orgs. Pure
+// function for unit testing.
+//
+// Tree shape (matches the plan's Identity & Naming section):
+//
+//   root
+//     └─ tenants
+//          ├─ 42        (team_id)
+//          ├─ 43
+//          └─ ...
+//
+// Selectors map Trino username (== team_id for customer principals) to
+// the root.tenants.<team_id> group.
+func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error) {
+	subgroups := make([]resourceGroupSubGroup, 0, len(orgs))
+	selectors := make([]resourceGroupSelector, 0, len(orgs))
+	for _, o := range orgs {
+		if o.OrgID == "" {
+			continue
+		}
+		sg := tierLimits(o.Tier)
+		sg.Name = o.OrgID
+		subgroups = append(subgroups, sg)
+		selectors = append(selectors, resourceGroupSelector{
+			User:  o.OrgID,
+			Group: TrinoResourceGroupName(o.OrgID),
+		})
+	}
+
+	cfg := resourceGroupsFile{
+		RootGroups: []resourceGroupRoot{{
+			Name:                 "root",
+			SoftMemoryLimit:      "100%",
+			HardConcurrencyLimit: 200,
+			MaxQueued:            1000,
+			SubGroups: []resourceGroupTier{{
+				Name:                 "tenants",
+				SoftMemoryLimit:      "80%",
+				HardConcurrencyLimit: 100,
+				MaxQueued:            500,
+				SubGroups:            subgroups,
+			}},
+		}},
+		Selectors: selectors,
+	}
+	out, err := json.MarshalIndent(&cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal resource-groups.json: %w", err)
+	}
+	return out, nil
+}
+
+// reconcileOPABundle builds the user_catalogs map and asks the bundle
+// builder to render a bundle, then pushes it via the OPA bundle API.
+//
+// While Stream B's bundle builder is the stub (returns "{}"), this
+// step still exercises the code path end-to-end so a regression
+// landing alongside Stream B's merge is loud, not silent.
+func (p *TrinoProvisioner) reconcileOPABundle(ctx context.Context, orgs []configstore.TrinoEnabledOrg) error {
+	uc := make(opa.UserCatalogs, len(orgs))
+	for _, o := range orgs {
+		if o.OrgID == "" {
+			continue
+		}
+		uc[o.OrgID] = map[string]bool{TrinoCatalogName(o.OrgID): true}
+	}
+	bundle, err := p.bundleBuilder.BuildBundle(uc)
+	if err != nil {
+		return fmt.Errorf("build opa bundle: %w", err)
+	}
+	if err := p.opa.PushBundle(ctx, bundle); err != nil {
+		return fmt.Errorf("push opa bundle: %w", err)
+	}
+	return nil
+}
+
+// upsertSecret performs a get-or-create followed by a wholesale Data
+// replacement. Mirrors the EnsureSecret pattern in lakekeeper_k8s.go;
+// we don't reuse the helper there because that one is shaped around
+// Lakekeeper's specific key set.
+func (p *TrinoProvisioner) upsertSecret(ctx context.Context, name string, data map[string][]byte) error {
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.namespace,
+			Labels: map[string]string{
+				"app":              "trino",
+				"duckgres/managed": "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	secrets := p.kubernetes.CoreV1().Secrets(p.namespace)
+	_, err := secrets.Create(ctx, desired, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create secret %s: %w", name, err)
+	}
+	existing, getErr := secrets.Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get secret %s for update: %w", name, getErr)
+	}
+	desired.ResourceVersion = existing.ResourceVersion
+	if _, err := secrets.Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// upsertConfigMap mirrors upsertSecret for non-secret config (resource-
+// groups.json is not sensitive — tier mappings + org ids).
+func (p *TrinoProvisioner) upsertConfigMap(ctx context.Context, name string, data map[string]string) error {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.namespace,
+			Labels: map[string]string{
+				"app":              "trino",
+				"duckgres/managed": "true",
+			},
+		},
+		Data: data,
+	}
+	cms := p.kubernetes.CoreV1().ConfigMaps(p.namespace)
+	_, err := cms.Create(ctx, desired, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create configmap %s: %w", name, err)
+	}
+	existing, getErr := cms.Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get configmap %s for update: %w", name, getErr)
+	}
+	desired.ResourceVersion = existing.ResourceVersion
+	if _, err := cms.Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update configmap %s: %w", name, err)
+	}
+	return nil
+}
+
+// =====================================================================
+// HTTP implementations of TrinoCatalogClient + OPABundleClient.
+// =====================================================================
+
+// trinoCatalogHTTPClient drives the Trino REST API for catalog
+// management. Authentication is HTTP Basic (Trino's standard for the
+// file password authenticator); the configured user is
+// TrinoAdminProvisionerUser, with the password living in a K8s Secret
+// mounted only into the provisioner pod.
+//
+// One client per provisioner instance — the underlying http.Client is
+// goroutine-safe but the cached Basic-auth header is set once at
+// construction.
+type trinoCatalogHTTPClient struct {
+	baseURL  string
+	hc       *http.Client
+	username string
+	password string
+}
+
+// NewTrinoCatalogHTTPClient builds an HTTP-backed TrinoCatalogClient.
+// baseURL is the customer Trino coordinator endpoint (typically the
+// in-cluster Service: http://trino:8080). Username defaults to
+// TrinoAdminProvisionerUser if empty.
+func NewTrinoCatalogHTTPClient(baseURL, username, password string) TrinoCatalogClient {
+	if username == "" {
+		username = TrinoAdminProvisionerUser
+	}
+	return &trinoCatalogHTTPClient{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		hc:       &http.Client{Timeout: 30 * time.Second},
+		username: username,
+		password: password,
+	}
+}
+
+// trinoStatementResponse is the subset of the Trino /v1/statement
+// response we need: nextUri for paging, plus a coarse status check.
+// The full response is much larger; we ignore the rest.
+type trinoStatementResponse struct {
+	ID      string                   `json:"id"`
+	NextURI string                   `json:"nextUri,omitempty"`
+	Stats   map[string]interface{}   `json:"stats,omitempty"`
+	Data    [][]interface{}          `json:"data,omitempty"`
+	Error   *trinoStatementErrorBody `json:"error,omitempty"`
+}
+
+type trinoStatementErrorBody struct {
+	Message   string `json:"message"`
+	ErrorCode int    `json:"errorCode"`
+	ErrorName string `json:"errorName"`
+	ErrorType string `json:"errorType"`
+}
+
+// runStatement executes a single Trino statement via /v1/statement and
+// drains the nextUri chain. Returns the accumulated data rows (may be
+// empty for DDL).
+func (c *trinoCatalogHTTPClient) runStatement(ctx context.Context, sql string) ([][]interface{}, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/statement", strings.NewReader(sql))
+	if err != nil {
+		return nil, fmt.Errorf("build statement request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("X-Trino-User", c.username)
+	req.Header.Set("Authorization", "Basic "+basicAuth(c.username, c.password))
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post statement: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("post statement: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return c.drainStatement(ctx, body)
+}
+
+// drainStatement reads the nextUri chain until the statement
+// completes. Each hop is a GET; the final body carries the result
+// data (already-accumulated rows from earlier hops are kept).
+func (c *trinoCatalogHTTPClient) drainStatement(ctx context.Context, initial []byte) ([][]interface{}, error) {
+	var all [][]interface{}
+	body := initial
+	for {
+		var r trinoStatementResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			return nil, fmt.Errorf("parse statement response: %w (body=%q)", err, string(body))
+		}
+		if r.Error != nil {
+			return nil, fmt.Errorf("trino: %s (%s): %s", r.Error.ErrorName, r.Error.ErrorType, r.Error.Message)
+		}
+		all = append(all, r.Data...)
+		if r.NextURI == "" {
+			return all, nil
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.NextURI, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build nextUri request: %w", err)
+		}
+		req.Header.Set("X-Trino-User", c.username)
+		req.Header.Set("Authorization", "Basic "+basicAuth(c.username, c.password))
+		resp, err := c.hc.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("get nextUri: %w", err)
+		}
+		body, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			return nil, fmt.Errorf("get nextUri: status %d: %s", resp.StatusCode, string(body))
+		}
+	}
+}
+
+// ListCatalogs runs SHOW CATALOGS and returns the catalog names.
+func (c *trinoCatalogHTTPClient) ListCatalogs(ctx context.Context) ([]string, error) {
+	rows, err := c.runStatement(ctx, "SHOW CATALOGS")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if len(r) == 0 {
+			continue
+		}
+		if s, ok := r[0].(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+// CreateCatalog issues CREATE CATALOG <name> USING <connector> WITH (...)
+// with the given properties.
+func (c *trinoCatalogHTTPClient) CreateCatalog(ctx context.Context, name string, props map[string]string) error {
+	connector := props["connector.name"]
+	if connector == "" {
+		return fmt.Errorf("CreateCatalog %q: connector.name property is required", name)
+	}
+	withProps := props
+	delete(withProps, "connector.name")
+	sql := fmt.Sprintf("CREATE CATALOG %s USING %s%s", quoteTrinoIdentifier(name), connector, renderWithClause(withProps))
+	_, err := c.runStatement(ctx, sql)
+	return err
+}
+
+// AlterCatalog is not exercised in v1 (no property drift while
+// Lakekeeper stays allowall — see plan), but the method is wired so
+// post-v1 OAuth2 rotation has a place to go. Implemented as DROP +
+// CREATE under the hood — Trino's ALTER CATALOG covers a narrow set
+// of property updates, and the simplest sane fallback is recreate.
+func (c *trinoCatalogHTTPClient) AlterCatalog(ctx context.Context, name string, props map[string]string) error {
+	if err := c.DropCatalog(ctx, name); err != nil {
+		return fmt.Errorf("alter catalog %q (drop step): %w", name, err)
+	}
+	return c.CreateCatalog(ctx, name, props)
+}
+
+// DropCatalog issues DROP CATALOG <name>.
+func (c *trinoCatalogHTTPClient) DropCatalog(ctx context.Context, name string) error {
+	_, err := c.runStatement(ctx, "DROP CATALOG "+quoteTrinoIdentifier(name))
+	return err
+}
+
+// quoteTrinoIdentifier wraps the identifier in double quotes and
+// escapes any embedded double quote per Trino's SQL grammar.
+func quoteTrinoIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// renderWithClause renders a sorted-by-key `WITH ("k" = '...')` clause
+// suitable for CREATE CATALOG. Sorted output makes the SQL
+// deterministic for snapshot tests. Returns an empty string when there
+// are no properties.
+func renderWithClause(props map[string]string) string {
+	if len(props) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf(`"%s" = '%s'`, k, strings.ReplaceAll(props[k], "'", "''")))
+	}
+	return " WITH (" + strings.Join(parts, ", ") + ")"
+}
+
+// basicAuth produces the base64-encoded value for the Authorization
+// header. Matches net/http's internal helper.
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+// =====================================================================
+// OPA bundle HTTP client.
+// =====================================================================
+
+// opaBundleHTTPClient pushes a bundle to the OPA sidecar's bundle API
+// (PUT /v1/policies or the bundle service endpoint; specific path is
+// configurable). The bundle bytes are uploaded as the request body.
+//
+// For v1 the OPA sidecar runs alongside the customer Trino coordinator
+// pod, so the URL is typically http://localhost:8181 from the
+// provisioner's perspective (port-forward in dev) or
+// http://trino-coordinator-opa:8181 from the provisioner pod in K8s.
+type opaBundleHTTPClient struct {
+	baseURL string
+	hc      *http.Client
+}
+
+// NewOPABundleHTTPClient builds an OPABundleClient. baseURL is the OPA
+// sidecar's bundle API root.
+func NewOPABundleHTTPClient(baseURL string) OPABundleClient {
+	return &opaBundleHTTPClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		hc:      &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// PushBundle uploads the bundle bytes to the OPA bundle endpoint.
+// We use PUT /v1/policies/duckgres so the bundle replaces the
+// previously-pushed one rather than appending. OPA's bundle API path
+// can vary by configuration; revisit alongside Stream B's bundle
+// builder.
+func (c *opaBundleHTTPClient) PushBundle(ctx context.Context, bundle []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/v1/policies/duckgres", bytes.NewReader(bundle))
+	if err != nil {
+		return fmt.Errorf("build opa request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("opa push: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("opa push: status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -1,0 +1,471 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+// --- fakes ---
+
+type fakeTrinoStore struct {
+	orgs []configstore.TrinoEnabledOrg
+}
+
+func (s *fakeTrinoStore) ListTrinoEnabledOrgs() ([]configstore.TrinoEnabledOrg, error) {
+	out := make([]configstore.TrinoEnabledOrg, len(s.orgs))
+	copy(out, s.orgs)
+	return out, nil
+}
+
+type fakeIcebergStore struct {
+	rows map[string]*configstore.ManagedWarehouseIceberg
+}
+
+func (s *fakeIcebergStore) GetManagedWarehouseIceberg(orgID string) (*configstore.ManagedWarehouseIceberg, error) {
+	row, ok := s.rows[orgID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+
+type fakeCatalogClient struct {
+	mu        sync.Mutex
+	existing  []string
+	created   map[string]map[string]string
+	dropped   []string
+	listErr   error
+	createErr error
+}
+
+func (c *fakeCatalogClient) ListCatalogs(ctx context.Context) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	out := make([]string, len(c.existing))
+	copy(out, c.existing)
+	return out, nil
+}
+
+func (c *fakeCatalogClient) CreateCatalog(ctx context.Context, name string, props map[string]string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.createErr != nil {
+		return c.createErr
+	}
+	if c.created == nil {
+		c.created = make(map[string]map[string]string)
+	}
+	cp := make(map[string]string, len(props))
+	for k, v := range props {
+		cp[k] = v
+	}
+	c.created[name] = cp
+	c.existing = append(c.existing, name)
+	return nil
+}
+
+func (c *fakeCatalogClient) AlterCatalog(ctx context.Context, name string, props map[string]string) error {
+	return c.CreateCatalog(ctx, name, props)
+}
+
+func (c *fakeCatalogClient) DropCatalog(ctx context.Context, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dropped = append(c.dropped, name)
+	filtered := c.existing[:0]
+	for _, e := range c.existing {
+		if e != name {
+			filtered = append(filtered, e)
+		}
+	}
+	c.existing = filtered
+	return nil
+}
+
+type fakeOPAClient struct {
+	mu       sync.Mutex
+	pushed   [][]byte
+	pushErr  error
+}
+
+func (c *fakeOPAClient) PushBundle(ctx context.Context, bundle []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pushErr != nil {
+		return c.pushErr
+	}
+	cp := make([]byte, len(bundle))
+	copy(cp, bundle)
+	c.pushed = append(c.pushed, cp)
+	return nil
+}
+
+// --- pure-function tests ---
+
+func TestBuildTrinoAuthFiles_OneUserPerOrg(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$hash42"},
+		{OrgID: "43", RootPasswordHash: "$2a$10$hash43"},
+	}
+	pw, grp := BuildTrinoAuthFiles(orgs)
+
+	// Password file: <team_id>:<bcrypt hash>
+	wantPw := "42:$2a$10$hash42\n43:$2a$10$hash43\n"
+	if pw != wantPw {
+		t.Errorf("password.db mismatch:\n got=%q\nwant=%q", pw, wantPw)
+	}
+
+	// Group file: <group_name>:<comma-separated users> — group FIRST.
+	wantGrp := "org_42:42\norg_43:43\n"
+	if grp != wantGrp {
+		t.Errorf("group.db mismatch:\n got=%q\nwant=%q", grp, wantGrp)
+	}
+}
+
+func TestBuildTrinoAuthFiles_DeterministicOrder(t *testing.T) {
+	// Same input, same output — critical so re-runs of the reconcile loop
+	// don't churn the Secret on every tick.
+	in1 := []configstore.TrinoEnabledOrg{
+		{OrgID: "a", RootPasswordHash: "h1"},
+		{OrgID: "b", RootPasswordHash: "h2"},
+	}
+	in2 := []configstore.TrinoEnabledOrg{
+		{OrgID: "a", RootPasswordHash: "h1"},
+		{OrgID: "b", RootPasswordHash: "h2"},
+	}
+	pw1, grp1 := BuildTrinoAuthFiles(in1)
+	pw2, grp2 := BuildTrinoAuthFiles(in2)
+	if pw1 != pw2 || grp1 != grp2 {
+		t.Fatalf("non-deterministic auth file output:\n pw1=%q grp1=%q\n pw2=%q grp2=%q", pw1, grp1, pw2, grp2)
+	}
+}
+
+func TestBuildTrinoAuthFiles_SkipsEmptyHashes(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$ok"},
+		{OrgID: "43", RootPasswordHash: ""},
+		{OrgID: "", RootPasswordHash: "$2a$10$nope"},
+	}
+	pw, grp := BuildTrinoAuthFiles(orgs)
+	if pw != "42:$2a$10$ok\n" {
+		t.Errorf("password.db = %q, want only the 42 entry", pw)
+	}
+	if grp != "org_42:42\n" {
+		t.Errorf("group.db = %q, want only the org_42 entry", grp)
+	}
+}
+
+func TestBuildTrinoAuthFiles_Empty(t *testing.T) {
+	pw, grp := BuildTrinoAuthFiles(nil)
+	if pw != "" || grp != "" {
+		t.Errorf("expected empty strings on empty input, got pw=%q grp=%q", pw, grp)
+	}
+}
+
+func TestTrinoCatalogName(t *testing.T) {
+	cases := map[string]string{
+		"42":           "org_42_iceberg",
+		"acme":         "org_acme_iceberg",
+		"Acme-Corp":    "org_acme_corp_iceberg",
+		"42-numbers":   "org_42_numbers_iceberg",
+		"with.dot":     "org_with_dot_iceberg",
+	}
+	for in, want := range cases {
+		if got := TrinoCatalogName(in); got != want {
+			t.Errorf("TrinoCatalogName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", Tier: "free"},
+		{OrgID: "43", Tier: "growth"},
+		{OrgID: "44", Tier: "scale"},
+		{OrgID: "45", Tier: ""},
+	}
+	raw, err := BuildTrinoResourceGroups(orgs)
+	if err != nil {
+		t.Fatalf("BuildTrinoResourceGroups: %v", err)
+	}
+	var parsed resourceGroupsFile
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.RootGroups) != 1 || parsed.RootGroups[0].Name != "root" {
+		t.Fatalf("expected single root group named 'root', got %+v", parsed.RootGroups)
+	}
+	tenants := parsed.RootGroups[0].SubGroups
+	if len(tenants) != 1 || tenants[0].Name != "tenants" {
+		t.Fatalf("expected single tenants tier, got %+v", tenants)
+	}
+	subs := tenants[0].SubGroups
+	if len(subs) != 4 {
+		t.Fatalf("expected 4 org subgroups, got %d", len(subs))
+	}
+	// Selector + subgroup name == team_id; verify the join.
+	wantByName := map[string]int{ // hardConcurrencyLimit per tier
+		"42": 3,  // free
+		"43": 10, // growth
+		"44": 25, // scale
+		"45": 3,  // empty → default ("free")
+	}
+	for _, sg := range subs {
+		want, ok := wantByName[sg.Name]
+		if !ok {
+			t.Errorf("unexpected subgroup name %q", sg.Name)
+			continue
+		}
+		if sg.HardConcurrencyLimit != want {
+			t.Errorf("subgroup %s: HardConcurrencyLimit = %d, want %d", sg.Name, sg.HardConcurrencyLimit, want)
+		}
+	}
+	// Selectors: one per org, mapping user → root.tenants.<team_id>.
+	wantSel := map[string]string{
+		"42": "root.tenants.42",
+		"43": "root.tenants.43",
+		"44": "root.tenants.44",
+		"45": "root.tenants.45",
+	}
+	if len(parsed.Selectors) != 4 {
+		t.Fatalf("expected 4 selectors, got %d", len(parsed.Selectors))
+	}
+	for _, sel := range parsed.Selectors {
+		if want, ok := wantSel[sel.User]; !ok || sel.Group != want {
+			t.Errorf("selector %+v unexpected (want user→%q)", sel, wantSel[sel.User])
+		}
+	}
+}
+
+// --- reconcile path ---
+
+func newTestTrinoProvisioner(t *testing.T, orgs []configstore.TrinoEnabledOrg, ic map[string]*configstore.ManagedWarehouseIceberg) (*TrinoProvisioner, *kubefake.Clientset, *fakeCatalogClient, *fakeOPAClient) {
+	t.Helper()
+	kc := kubefake.NewClientset()
+	catalog := &fakeCatalogClient{}
+	opaClient := &fakeOPAClient{}
+	p, err := NewTrinoProvisioner(TrinoProvisionerOpts{
+		Store:         &fakeTrinoStore{orgs: orgs},
+		IcebergStore:  &fakeIcebergStore{rows: ic},
+		Kubernetes:    kc,
+		Namespace:     TrinoCustomerNamespace,
+		Catalog:       catalog,
+		OPA:           opaClient,
+		BundleBuilder: opa.NewStubBuilder(),
+		IAMAccountID:  "123456789012",
+		AWSRegion:     "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("NewTrinoProvisioner: %v", err)
+	}
+	return p, kc, catalog, opaClient
+}
+
+func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", Tier: "free", RootPasswordHash: "$2a$10$hash42"},
+	}
+	ic := map[string]*configstore.ManagedWarehouseIceberg{
+		"42": {
+			LakekeeperEndpoint:  "http://lakekeeper-42.lakekeeper.svc:8181/catalog",
+			LakekeeperWarehouse: "org-42",
+			Region:              "us-east-1",
+		},
+	}
+	p, kc, catalog, opaClient := newTestTrinoProvisioner(t, orgs, ic)
+
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Catalog issued via REST.
+	if _, ok := catalog.created[TrinoCatalogName("42")]; !ok {
+		t.Errorf("expected CREATE CATALOG for org_42_iceberg, got %+v", catalog.created)
+	}
+	// Role ARN includes the org id (per-org duckling-<orgid>).
+	props := catalog.created[TrinoCatalogName("42")]
+	if !strings.Contains(props["iceberg.s3.aws-role-arn"], "duckling-42") {
+		t.Errorf("expected duckling-42 role ARN, got %q", props["iceberg.s3.aws-role-arn"])
+	}
+
+	// Auth Secret.
+	sec, err := kc.CoreV1().Secrets(TrinoCustomerNamespace).Get(context.Background(), TrinoAuthSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get auth secret: %v", err)
+	}
+	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyPasswordDB]), "42:$2a$10$hash42") {
+		t.Errorf("password.db missing 42 entry: %q", sec.Data[TrinoAuthSecretKeyPasswordDB])
+	}
+	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyGroupDB]), "org_42:42") {
+		t.Errorf("group.db missing org_42 entry: %q", sec.Data[TrinoAuthSecretKeyGroupDB])
+	}
+
+	// ConfigMap.
+	cm, err := kc.CoreV1().ConfigMaps(TrinoCustomerNamespace).Get(context.Background(), TrinoResourceGroupsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get resource-groups configmap: %v", err)
+	}
+	if !strings.Contains(cm.Data[TrinoResourceGroupsConfigMapKey], "root.tenants.42") {
+		t.Errorf("resource-groups.json missing root.tenants.42 selector: %q", cm.Data[TrinoResourceGroupsConfigMapKey])
+	}
+
+	// OPA bundle pushed at least once.
+	if len(opaClient.pushed) == 0 {
+		t.Errorf("expected at least one OPA bundle push")
+	}
+}
+
+func TestReconcile_SkipsCatalogWhenIcebergNotReady(t *testing.T) {
+	// Trino-enabled but Iceberg row missing or endpoint empty — skip
+	// catalog creation, but still project auth files for the row.
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$hash"},
+	}
+	p, kc, catalog, _ := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouseIceberg{
+		// no row for 42
+	})
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(catalog.created) != 0 {
+		t.Errorf("expected no catalog creates, got %+v", catalog.created)
+	}
+	// Auth Secret still projected — that's important so password file
+	// is consistent regardless of catalog readiness.
+	sec, err := kc.CoreV1().Secrets(TrinoCustomerNamespace).Get(context.Background(), TrinoAuthSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get auth secret: %v", err)
+	}
+	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyPasswordDB]), "42:") {
+		t.Errorf("expected 42 entry in password.db, got %q", sec.Data[TrinoAuthSecretKeyPasswordDB])
+	}
+}
+
+func TestReconcile_DropsStaleCatalogs(t *testing.T) {
+	// org_99_iceberg exists in Trino but is not in the enabled list →
+	// should get DROP. system + jmx survive.
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$h"},
+	}
+	ic := map[string]*configstore.ManagedWarehouseIceberg{
+		"42": {LakekeeperEndpoint: "http://lk-42:8181/catalog", LakekeeperWarehouse: "org-42"},
+	}
+	p, _, catalog, _ := newTestTrinoProvisioner(t, orgs, ic)
+	catalog.existing = []string{"system", "jmx", "org_99_iceberg"}
+
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	wantDropped := "org_99_iceberg"
+	found := false
+	for _, d := range catalog.dropped {
+		if d == wantDropped {
+			found = true
+		}
+		if d == "system" || d == "jmx" {
+			t.Errorf("system/jmx dropped — must only touch org_*_iceberg: %v", catalog.dropped)
+		}
+	}
+	if !found {
+		t.Errorf("expected %q in dropped, got %v", wantDropped, catalog.dropped)
+	}
+}
+
+func TestReconcile_IsIdempotentWhenCatalogExists(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$h"},
+	}
+	ic := map[string]*configstore.ManagedWarehouseIceberg{
+		"42": {LakekeeperEndpoint: "http://lk:8181/catalog", LakekeeperWarehouse: "org-42"},
+	}
+	p, _, catalog, _ := newTestTrinoProvisioner(t, orgs, ic)
+	// Pretend the catalog already exists.
+	catalog.existing = []string{TrinoCatalogName("42")}
+
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, ok := catalog.created[TrinoCatalogName("42")]; ok {
+		t.Errorf("expected no CREATE CATALOG when catalog already exists, got %+v", catalog.created)
+	}
+}
+
+func TestReconcile_SecretUpdateIsIdempotent(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$h"},
+	}
+	p, kc, _, _ := newTestTrinoProvisioner(t, orgs, nil)
+
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile (1): %v", err)
+	}
+	// Second tick — same input, same Secret. Should not error.
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile (2): %v", err)
+	}
+	sec, err := kc.CoreV1().Secrets(TrinoCustomerNamespace).Get(context.Background(), TrinoAuthSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyPasswordDB]), "42:") {
+		t.Errorf("expected 42 entry persisted across reconciles")
+	}
+}
+
+func TestRenderWithClauseDeterministic(t *testing.T) {
+	a := renderWithClause(map[string]string{"k1": "v1", "k2": "v2"})
+	b := renderWithClause(map[string]string{"k2": "v2", "k1": "v1"})
+	if a != b {
+		t.Errorf("renderWithClause not deterministic:\n a=%q\n b=%q", a, b)
+	}
+}
+
+func TestRenderWithClauseEscapesQuotes(t *testing.T) {
+	got := renderWithClause(map[string]string{"k": "v'with'quotes"})
+	if !strings.Contains(got, "v''with''quotes") {
+		t.Errorf("expected SQL-escaped quotes, got %q", got)
+	}
+}
+
+func TestNewTrinoProvisioner_RequiresAllDeps(t *testing.T) {
+	// Missing each required field → constructor error.
+	base := TrinoProvisionerOpts{
+		Store:         &fakeTrinoStore{},
+		IcebergStore:  &fakeIcebergStore{},
+		Kubernetes:    kubefake.NewClientset(),
+		Catalog:       &fakeCatalogClient{},
+		OPA:           &fakeOPAClient{},
+		BundleBuilder: opa.NewStubBuilder(),
+	}
+	if _, err := NewTrinoProvisioner(base); err != nil {
+		t.Fatalf("expected baseline to succeed, got %v", err)
+	}
+	for _, f := range []func(o *TrinoProvisionerOpts){
+		func(o *TrinoProvisionerOpts) { o.Store = nil },
+		func(o *TrinoProvisionerOpts) { o.IcebergStore = nil },
+		func(o *TrinoProvisionerOpts) { o.Kubernetes = nil },
+		func(o *TrinoProvisionerOpts) { o.Catalog = nil },
+		func(o *TrinoProvisionerOpts) { o.OPA = nil },
+		func(o *TrinoProvisionerOpts) { o.BundleBuilder = nil },
+	} {
+		o := base
+		f(&o)
+		if _, err := NewTrinoProvisioner(o); err == nil {
+			t.Errorf("expected error with missing dep, got nil for %+v", o)
+		}
+	}
+}

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -5,6 +5,7 @@ package provisioner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -18,13 +19,34 @@ import (
 // --- fakes ---
 
 type fakeTrinoStore struct {
-	orgs []configstore.TrinoEnabledOrg
+	mu     sync.Mutex
+	orgs   []configstore.TrinoEnabledOrg
+	states map[string]configstore.TrinoStateUpdate // captured per-org state writes
 }
 
 func (s *fakeTrinoStore) ListTrinoEnabledOrgs() ([]configstore.TrinoEnabledOrg, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	out := make([]configstore.TrinoEnabledOrg, len(s.orgs))
 	copy(out, s.orgs)
 	return out, nil
+}
+
+func (s *fakeTrinoStore) UpdateTrinoState(orgID string, upd configstore.TrinoStateUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.states == nil {
+		s.states = make(map[string]configstore.TrinoStateUpdate)
+	}
+	s.states[orgID] = upd
+	return nil
+}
+
+func (s *fakeTrinoStore) lastState(orgID string) (configstore.TrinoStateUpdate, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.states[orgID]
+	return v, ok
 }
 
 type fakeIcebergStore struct {
@@ -96,24 +118,6 @@ func (c *fakeCatalogClient) DropCatalog(ctx context.Context, name string) error 
 	return nil
 }
 
-type fakeOPAClient struct {
-	mu       sync.Mutex
-	pushed   [][]byte
-	pushErr  error
-}
-
-func (c *fakeOPAClient) PushBundle(ctx context.Context, bundle []byte) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.pushErr != nil {
-		return c.pushErr
-	}
-	cp := make([]byte, len(bundle))
-	copy(cp, bundle)
-	c.pushed = append(c.pushed, cp)
-	return nil
-}
-
 // --- pure-function tests ---
 
 func TestBuildTrinoAuthFiles_OneUserPerOrg(t *testing.T) {
@@ -121,7 +125,9 @@ func TestBuildTrinoAuthFiles_OneUserPerOrg(t *testing.T) {
 		{OrgID: "42", RootPasswordHash: "$2a$10$hash42"},
 		{OrgID: "43", RootPasswordHash: "$2a$10$hash43"},
 	}
-	pw, grp := BuildTrinoAuthFiles(orgs)
+	// Empty admin hash so the test focuses on the per-org projection;
+	// admin-line projection is exercised in its own test below.
+	pw, grp := BuildTrinoAuthFiles(orgs, "")
 
 	// Password file: <team_id>:<bcrypt hash>
 	wantPw := "42:$2a$10$hash42\n43:$2a$10$hash43\n"
@@ -147,8 +153,8 @@ func TestBuildTrinoAuthFiles_DeterministicOrder(t *testing.T) {
 		{OrgID: "a", RootPasswordHash: "h1"},
 		{OrgID: "b", RootPasswordHash: "h2"},
 	}
-	pw1, grp1 := BuildTrinoAuthFiles(in1)
-	pw2, grp2 := BuildTrinoAuthFiles(in2)
+	pw1, grp1 := BuildTrinoAuthFiles(in1, "")
+	pw2, grp2 := BuildTrinoAuthFiles(in2, "")
 	if pw1 != pw2 || grp1 != grp2 {
 		t.Fatalf("non-deterministic auth file output:\n pw1=%q grp1=%q\n pw2=%q grp2=%q", pw1, grp1, pw2, grp2)
 	}
@@ -160,7 +166,7 @@ func TestBuildTrinoAuthFiles_SkipsEmptyHashes(t *testing.T) {
 		{OrgID: "43", RootPasswordHash: ""},
 		{OrgID: "", RootPasswordHash: "$2a$10$nope"},
 	}
-	pw, grp := BuildTrinoAuthFiles(orgs)
+	pw, grp := BuildTrinoAuthFiles(orgs, "")
 	if pw != "42:$2a$10$ok\n" {
 		t.Errorf("password.db = %q, want only the 42 entry", pw)
 	}
@@ -170,9 +176,39 @@ func TestBuildTrinoAuthFiles_SkipsEmptyHashes(t *testing.T) {
 }
 
 func TestBuildTrinoAuthFiles_Empty(t *testing.T) {
-	pw, grp := BuildTrinoAuthFiles(nil)
+	pw, grp := BuildTrinoAuthFiles(nil, "")
 	if pw != "" || grp != "" {
 		t.Errorf("expected empty strings on empty input, got pw=%q grp=%q", pw, grp)
+	}
+}
+
+func TestBuildTrinoAuthFiles_IncludesAdminWhenHashProvided(t *testing.T) {
+	// Admin entry is prepended unconditionally when a hash is supplied,
+	// even with zero orgs. Required so opa.is_admin (username AND
+	// admin-group conjunction) holds for the provisioner's catalog
+	// management calls regardless of customer-org population.
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$h"},
+	}
+	pw, grp := BuildTrinoAuthFiles(orgs, "$2a$10$admin")
+
+	wantPw := opa.AdminPrincipal + ":$2a$10$admin\n42:$2a$10$h\n"
+	if pw != wantPw {
+		t.Errorf("password.db with admin: got=%q want=%q", pw, wantPw)
+	}
+	wantGrp := opa.AdminGroup + ":" + opa.AdminPrincipal + "\norg_42:42\n"
+	if grp != wantGrp {
+		t.Errorf("group.db with admin: got=%q want=%q", grp, wantGrp)
+	}
+
+	// And with zero orgs — admin still present so catalog management
+	// works before any customer has been provisioned.
+	pwEmpty, grpEmpty := BuildTrinoAuthFiles(nil, "$2a$10$admin")
+	if pwEmpty != opa.AdminPrincipal+":$2a$10$admin\n" {
+		t.Errorf("empty-orgs password.db: got=%q", pwEmpty)
+	}
+	if grpEmpty != opa.AdminGroup+":"+opa.AdminPrincipal+"\n" {
+		t.Errorf("empty-orgs group.db: got=%q", grpEmpty)
 	}
 }
 
@@ -253,26 +289,27 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 
 // --- reconcile path ---
 
-func newTestTrinoProvisioner(t *testing.T, orgs []configstore.TrinoEnabledOrg, ic map[string]*configstore.ManagedWarehouseIceberg) (*TrinoProvisioner, *kubefake.Clientset, *fakeCatalogClient, *fakeOPAClient) {
+func newTestTrinoProvisioner(t *testing.T, orgs []configstore.TrinoEnabledOrg, ic map[string]*configstore.ManagedWarehouseIceberg) (*TrinoProvisioner, *kubefake.Clientset, *fakeCatalogClient, *opa.BundleStore, *fakeTrinoStore) {
 	t.Helper()
 	kc := kubefake.NewClientset()
 	catalog := &fakeCatalogClient{}
-	opaClient := &fakeOPAClient{}
+	bundleStore := &opa.BundleStore{}
+	trinoStore := &fakeTrinoStore{orgs: orgs}
 	p, err := NewTrinoProvisioner(TrinoProvisionerOpts{
-		Store:         &fakeTrinoStore{orgs: orgs},
+		Store:         trinoStore,
 		IcebergStore:  &fakeIcebergStore{rows: ic},
 		Kubernetes:    kc,
 		Namespace:     TrinoCustomerNamespace,
 		Catalog:       catalog,
-		OPA:           opaClient,
-		BundleBuilder: opa.NewStubBuilder(),
+		BundleStore:   bundleStore,
+		BundleBuilder: opa.NewBuilder(),
 		IAMAccountID:  "123456789012",
 		AWSRegion:     "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("NewTrinoProvisioner: %v", err)
 	}
-	return p, kc, catalog, opaClient
+	return p, kc, catalog, bundleStore, trinoStore
 }
 
 func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
@@ -286,7 +323,7 @@ func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
 			Region:              "us-east-1",
 		},
 	}
-	p, kc, catalog, opaClient := newTestTrinoProvisioner(t, orgs, ic)
+	p, kc, catalog, bundleStore, _ := newTestTrinoProvisioner(t, orgs, ic)
 
 	if err := p.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -296,10 +333,20 @@ func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
 	if _, ok := catalog.created[TrinoCatalogName("42")]; !ok {
 		t.Errorf("expected CREATE CATALOG for org_42_iceberg, got %+v", catalog.created)
 	}
-	// Role ARN includes the org id (per-org duckling-<orgid>).
+	// Role ARN goes under s3.iam-role (Trino's current property name,
+	// matching the maintenance chart) and includes the per-org
+	// duckling-<orgid>.
 	props := catalog.created[TrinoCatalogName("42")]
-	if !strings.Contains(props["iceberg.s3.aws-role-arn"], "duckling-42") {
-		t.Errorf("expected duckling-42 role ARN, got %q", props["iceberg.s3.aws-role-arn"])
+	if !strings.Contains(props["s3.iam-role"], "duckling-42") {
+		t.Errorf("expected duckling-42 role ARN under s3.iam-role, got %q", props["s3.iam-role"])
+	}
+	if props["fs.s3.enabled"] != "true" {
+		t.Errorf("expected fs.s3.enabled=true, got %q", props["fs.s3.enabled"])
+	}
+	// Old property names must NOT be emitted — they're silently ignored
+	// or rejected by current Trino.
+	if _, leak := props["iceberg.s3.aws-role-arn"]; leak {
+		t.Errorf("unexpected legacy property iceberg.s3.aws-role-arn in %v", props)
 	}
 
 	// Auth Secret.
@@ -323,9 +370,16 @@ func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
 		t.Errorf("resource-groups.json missing root.tenants.42 selector: %q", cm.Data[TrinoResourceGroupsConfigMapKey])
 	}
 
-	// OPA bundle pushed at least once.
-	if len(opaClient.pushed) == 0 {
-		t.Errorf("expected at least one OPA bundle push")
+	// OPA bundle Set into the store with a non-empty ETag.
+	cur, ok := bundleStore.Current()
+	if !ok {
+		t.Fatal("expected BundleStore to hold a bundle after Reconcile")
+	}
+	if cur.ETag == "" {
+		t.Errorf("expected non-empty ETag on stored bundle")
+	}
+	if cur.Len() == 0 {
+		t.Errorf("expected non-empty bundle bytes")
 	}
 }
 
@@ -335,7 +389,7 @@ func TestReconcile_SkipsCatalogWhenIcebergNotReady(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
 		{OrgID: "42", RootPasswordHash: "$2a$10$hash"},
 	}
-	p, kc, catalog, _ := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouseIceberg{
+	p, kc, catalog, _, _ := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouseIceberg{
 		// no row for 42
 	})
 	if err := p.Reconcile(context.Background()); err != nil {
@@ -364,7 +418,7 @@ func TestReconcile_DropsStaleCatalogs(t *testing.T) {
 	ic := map[string]*configstore.ManagedWarehouseIceberg{
 		"42": {LakekeeperEndpoint: "http://lk-42:8181/catalog", LakekeeperWarehouse: "org-42"},
 	}
-	p, _, catalog, _ := newTestTrinoProvisioner(t, orgs, ic)
+	p, _, catalog, _, _ := newTestTrinoProvisioner(t, orgs, ic)
 	catalog.existing = []string{"system", "jmx", "org_99_iceberg"}
 
 	if err := p.Reconcile(context.Background()); err != nil {
@@ -392,7 +446,7 @@ func TestReconcile_IsIdempotentWhenCatalogExists(t *testing.T) {
 	ic := map[string]*configstore.ManagedWarehouseIceberg{
 		"42": {LakekeeperEndpoint: "http://lk:8181/catalog", LakekeeperWarehouse: "org-42"},
 	}
-	p, _, catalog, _ := newTestTrinoProvisioner(t, orgs, ic)
+	p, _, catalog, _, _ := newTestTrinoProvisioner(t, orgs, ic)
 	// Pretend the catalog already exists.
 	catalog.existing = []string{TrinoCatalogName("42")}
 
@@ -408,7 +462,7 @@ func TestReconcile_SecretUpdateIsIdempotent(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
 		{OrgID: "42", RootPasswordHash: "$2a$10$h"},
 	}
-	p, kc, _, _ := newTestTrinoProvisioner(t, orgs, nil)
+	p, kc, _, _, _ := newTestTrinoProvisioner(t, orgs, nil)
 
 	if err := p.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile (1): %v", err)
@@ -423,6 +477,69 @@ func TestReconcile_SecretUpdateIsIdempotent(t *testing.T) {
 	}
 	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyPasswordDB]), "42:") {
 		t.Errorf("expected 42 entry persisted across reconciles")
+	}
+}
+
+func TestReconcile_StateTransitions(t *testing.T) {
+	// Three orgs covering the three non-Failed outcomes plus a fourth
+	// for catalog-create failure:
+	//   42: ready (Iceberg ready, catalog created OK)
+	//   43: provisioning (Iceberg not ready yet — no row)
+	//   44: failed     (catalog create errors)
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", RootPasswordHash: "$2a$10$h", Tier: "free"},
+		{OrgID: "43", RootPasswordHash: "$2a$10$h", Tier: "free"},
+		{OrgID: "44", RootPasswordHash: "$2a$10$h", Tier: "free"},
+	}
+	ic := map[string]*configstore.ManagedWarehouseIceberg{
+		"42": {LakekeeperEndpoint: "http://lk-42:8181/catalog", LakekeeperWarehouse: "org-42"},
+		// 43 deliberately missing — Iceberg not ready.
+		"44": {LakekeeperEndpoint: "http://lk-44:8181/catalog", LakekeeperWarehouse: "org-44"},
+	}
+	p, _, catalog, _, trinoStore := newTestTrinoProvisioner(t, orgs, ic)
+	// Make 44's CREATE CATALOG fail (org-43 already short-circuits via
+	// the iceberg-not-ready branch).
+	catalog.createErr = errors.New("trino: 503 service unavailable")
+
+	// Reconcile returns a non-nil error because some org-level steps
+	// failed; we still expect per-org state to be written for everyone.
+	_ = p.Reconcile(context.Background())
+
+	check := func(orgID string, wantState configstore.ManagedWarehouseProvisioningState, wantMsgSubstr string) {
+		t.Helper()
+		st, ok := trinoStore.lastState(orgID)
+		if !ok {
+			t.Errorf("no state written for %s", orgID)
+			return
+		}
+		if st.State != wantState {
+			t.Errorf("%s: state = %q, want %q (msg=%q)", orgID, st.State, wantState, st.StatusMessage)
+		}
+		if wantMsgSubstr != "" && !strings.Contains(st.StatusMessage, wantMsgSubstr) {
+			t.Errorf("%s: status_message = %q, want substring %q", orgID, st.StatusMessage, wantMsgSubstr)
+		}
+	}
+	// 44 hit createErr — fails-closed before 42 can attempt; both end
+	// up Failed because createErr is sticky on the fake. Document the
+	// fake's behavior in the assertion: 42's catalog create also
+	// errored (the fake returns the same error to every call).
+	check("42", configstore.ManagedWarehouseStateFailed, "catalog: create catalog")
+	check("43", configstore.ManagedWarehouseStateProvisioning, "waiting for iceberg")
+	check("44", configstore.ManagedWarehouseStateFailed, "catalog: create catalog")
+
+	// Recovery: clear the catalog error and rerun. 42 and 44 should
+	// land in Ready; 43 stays Provisioning until Iceberg is wired up.
+	catalog.createErr = nil
+	if err := p.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile (recovery): %v", err)
+	}
+	check("42", configstore.ManagedWarehouseStateReady, "")
+	check("43", configstore.ManagedWarehouseStateProvisioning, "waiting for iceberg")
+	check("44", configstore.ManagedWarehouseStateReady, "")
+
+	// Verify ReadyAt was set for the orgs that reached Ready.
+	if st, _ := trinoStore.lastState("42"); st.ReadyAt == nil {
+		t.Errorf("expected ReadyAt on 42 after recovery")
 	}
 }
 
@@ -448,8 +565,8 @@ func TestNewTrinoProvisioner_RequiresAllDeps(t *testing.T) {
 		IcebergStore:  &fakeIcebergStore{},
 		Kubernetes:    kubefake.NewClientset(),
 		Catalog:       &fakeCatalogClient{},
-		OPA:           &fakeOPAClient{},
-		BundleBuilder: opa.NewStubBuilder(),
+		BundleStore:   &opa.BundleStore{},
+		BundleBuilder: opa.NewBuilder(),
 	}
 	if _, err := NewTrinoProvisioner(base); err != nil {
 		t.Fatalf("expected baseline to succeed, got %v", err)
@@ -459,7 +576,7 @@ func TestNewTrinoProvisioner_RequiresAllDeps(t *testing.T) {
 		func(o *TrinoProvisionerOpts) { o.IcebergStore = nil },
 		func(o *TrinoProvisionerOpts) { o.Kubernetes = nil },
 		func(o *TrinoProvisionerOpts) { o.Catalog = nil },
-		func(o *TrinoProvisionerOpts) { o.OPA = nil },
+		func(o *TrinoProvisionerOpts) { o.BundleStore = nil },
 		func(o *TrinoProvisionerOpts) { o.BundleBuilder = nil },
 	} {
 		o := base

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -227,6 +228,70 @@ func TestTrinoCatalogName(t *testing.T) {
 	}
 }
 
+// TestTrinoCatalogNameMatchesManagedNamePattern closes the Go side of
+// the Go ↔ Rego naming contract. The OPA policy authorizes admin
+// catalog management on names matching opa.ManagedCatalogPattern. Every
+// name Go-side code produces must therefore match that pattern, or the
+// admin loses the authority to manage catalogs Go just created
+// (silently — the reconcile loop would log "created" while admin's
+// next SHOW CATALOGS / DROP CATALOG hits permission-denied).
+//
+// Paired with opa/policy_test.go::TestPolicyRegoContainsManagedNamePattern,
+// which closes the other side of the contract: the pattern in
+// policy.rego must equal the constant. If both tests pass, the three
+// surfaces — Go constant, Rego regex literal, TrinoCatalogName output —
+// are in sync.
+func TestTrinoCatalogNameMatchesManagedNamePattern(t *testing.T) {
+	re, err := regexp.Compile(opa.ManagedCatalogPattern)
+	if err != nil {
+		t.Fatalf("opa.ManagedCatalogPattern is not a valid Go regex: %v", err)
+	}
+
+	// Positive cases: representative inputs the production path could
+	// produce. The v1 invariant enforced by trinoOrgIDPattern in
+	// provisioning/api.go is numeric team_ids, but trinoSanitize also
+	// handles non-numeric / punctuated inputs defensively (admin-API
+	// writes or future schema relaxation) — verify those too so any
+	// future relaxation that breaks the regex match is caught here.
+	positive := []string{
+		"42",
+		"100",
+		"999999",
+		"acme",
+		"acme_corp",
+		"with-dash",   // sanitize → with_dash
+		"with.dot",    // sanitize → with_dot
+		"Mixed-Case",  // sanitize → mixed_case
+	}
+	for _, id := range positive {
+		name := TrinoCatalogName(id)
+		if !re.MatchString(name) {
+			t.Errorf("TrinoCatalogName(%q) = %q does NOT match opa.ManagedCatalogPattern (%q).\n"+
+				"Either trinoSanitize/TrinoCatalogName drifted, or the pattern needs widening — both sides must agree.",
+				id, name, opa.ManagedCatalogPattern)
+		}
+	}
+
+	// Negative cases: catalog names that must NOT match the pattern so
+	// admin authority can't accidentally cover them. These mirror the
+	// non-managed names asserted in policy_test.go's adversarial suite.
+	negative := []string{
+		"system",
+		"jmx",
+		"iceberg_org_42",
+		"org_42",      // missing _iceberg suffix
+		"ORG_42_iceberg", // uppercase prefix
+		"org_42_iceberg_extra", // trailing junk
+	}
+	for _, name := range negative {
+		if re.MatchString(name) {
+			t.Errorf("opa.ManagedCatalogPattern incorrectly matches non-managed name %q.\n"+
+				"The pattern is too permissive — admin authority would leak onto names "+
+				"the provisioner never creates.", name)
+		}
+	}
+}
+
 func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
 		{OrgID: "42", Tier: "free"},
@@ -245,13 +310,33 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 	if len(parsed.RootGroups) != 1 || parsed.RootGroups[0].Name != "root" {
 		t.Fatalf("expected single root group named 'root', got %+v", parsed.RootGroups)
 	}
-	tenants := parsed.RootGroups[0].SubGroups
-	if len(tenants) != 1 || tenants[0].Name != "tenants" {
-		t.Fatalf("expected single tenants tier, got %+v", tenants)
+	tiers := parsed.RootGroups[0].SubGroups
+	// Expect two sibling tiers: "admin" (for catalog DDL) and
+	// "tenants" (for customer queries). Without the admin tier,
+	// the provisioner's reconcile-path queries hit Trino's
+	// "Query is not associated with any resource group" rejection.
+	if len(tiers) != 2 {
+		t.Fatalf("expected 2 tiers (admin + tenants), got %d: %+v", len(tiers), tiers)
 	}
-	subs := tenants[0].SubGroups
+	tiersByName := map[string]resourceGroupTier{}
+	for _, tier := range tiers {
+		tiersByName[tier.Name] = tier
+	}
+	adminTier, hasAdmin := tiersByName["admin"]
+	if !hasAdmin {
+		t.Fatalf("expected admin tier under root, got tiers=%+v", tiers)
+	}
+	if len(adminTier.SubGroups) != 1 || adminTier.SubGroups[0].Name != opa.AdminPrincipal {
+		t.Errorf("expected single admin subgroup named %q, got %+v", opa.AdminPrincipal, adminTier.SubGroups)
+	}
+
+	tenantsTier, hasTenants := tiersByName["tenants"]
+	if !hasTenants {
+		t.Fatalf("expected tenants tier under root, got tiers=%+v", tiers)
+	}
+	subs := tenantsTier.SubGroups
 	if len(subs) != 4 {
-		t.Fatalf("expected 4 org subgroups, got %d", len(subs))
+		t.Fatalf("expected 4 org subgroups under tenants, got %d", len(subs))
 	}
 	// Selector + subgroup name == team_id; verify the join.
 	wantByName := map[string]int{ // hardConcurrencyLimit per tier
@@ -270,15 +355,19 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 			t.Errorf("subgroup %s: HardConcurrencyLimit = %d, want %d", sg.Name, sg.HardConcurrencyLimit, want)
 		}
 	}
-	// Selectors: one per org, mapping user → root.tenants.<team_id>.
+	// Selectors: admin + one per org. Admin maps to root.admin.<admin>,
+	// each tenant maps to root.tenants.<team_id>. Without the admin
+	// selector the provisioner's own queries get rejected by Trino's
+	// resource-group manager before reaching OPA.
 	wantSel := map[string]string{
-		"42": "root.tenants.42",
-		"43": "root.tenants.43",
-		"44": "root.tenants.44",
-		"45": "root.tenants.45",
+		opa.AdminPrincipal: "root.admin." + opa.AdminPrincipal,
+		"42":               "root.tenants.42",
+		"43":               "root.tenants.43",
+		"44":               "root.tenants.44",
+		"45":               "root.tenants.45",
 	}
-	if len(parsed.Selectors) != 4 {
-		t.Fatalf("expected 4 selectors, got %d", len(parsed.Selectors))
+	if len(parsed.Selectors) != len(wantSel) {
+		t.Fatalf("expected %d selectors (admin + %d orgs), got %d", len(wantSel), len(orgs), len(parsed.Selectors))
 	}
 	for _, sel := range parsed.Selectors {
 		if want, ok := wantSel[sel.User]; !ok || sel.Group != want {

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -355,6 +355,32 @@ func (h *handler) deprovisionWarehouse(c *gin.Context) {
 	var err error
 	for _, state := range deprovisionableStates {
 		if err = h.store.SetWarehouseDeleting(orgID, state); err == nil {
+			// Also disable Trino so the reconcile loop tears down
+			// the customer-Trino projections (catalog, password/
+			// group file entries, OPA bundle ownership, resource
+			// group). Without this, deprovisioning a warehouse
+			// leaves the Trino row enabled forever — the CASCADE
+			// only fires when the Org row itself is deleted, and
+			// `reconcileDeleting` doesn't touch the Org row. We'd
+			// otherwise keep projecting the deprovisioned org's
+			// credentials into Trino indefinitely.
+			//
+			// Best-effort: failure to disable Trino doesn't abort
+			// the warehouse deprovision (the warehouse state is
+			// already moved to Deleting). Operator can retry by
+			// calling DELETE /orgs/:id/trino directly.
+			if disableErr := h.store.DisableTrino(orgID); disableErr != nil {
+				// Log via the response — there's no slog on the
+				// gin handler, but the caller will see the warning
+				// alongside the 202. Soft-fail so the warehouse
+				// deprovision still proceeds.
+				c.JSON(http.StatusAccepted, gin.H{
+					"status":  "deprovisioning started",
+					"org":     orgID,
+					"warning": "failed to disable trino in the same call; retry DELETE /orgs/:id/trino: " + disableErr.Error(),
+				})
+				return
+			}
 			c.JSON(http.StatusAccepted, gin.H{"status": "deprovisioning started", "org": orgID})
 			return
 		}

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -20,6 +20,13 @@ type Store interface {
 	UpdateOrgUserPassword(orgID, username, passwordHash string) error
 	SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error
 	IsDatabaseNameAvailable(name string) (bool, error)
+
+	// Trino lifecycle. EnableTrino is idempotent — re-enabling updates
+	// settings without flipping through a disabled state. DisableTrino
+	// leaves the row in place so the provisioner observes the transition
+	// and cleans up the catalog + password file entry on next reconcile.
+	EnableTrino(orgID string, settings configstore.TrinoSettings) error
+	DisableTrino(orgID string) error
 }
 
 // RegisterAPI registers provisioning endpoints on the given router group.
@@ -29,6 +36,8 @@ func RegisterAPI(r *gin.RouterGroup, store Store) {
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
 	r.GET("/orgs/:id/warehouse/status", h.getWarehouseStatus)
 	r.POST("/orgs/:id/reset-password", h.resetPassword)
+	r.POST("/orgs/:id/trino", h.enableTrino)
+	r.DELETE("/orgs/:id/trino", h.disableTrino)
 	r.GET("/database-name/check", h.checkDatabaseName)
 }
 
@@ -63,10 +72,40 @@ type connectionDetails struct {
 type provisionRequest struct {
 	DatabaseName  string                `json:"database_name"`
 	MetadataStore *provisionMetadataReq `json:"metadata_store,omitempty"`
+
+	// Trino is the opt-in flag for the customer-facing Trino cluster.
+	// Optional — when nil, the warehouse is provisioned with the existing
+	// PG-only behavior. When non-nil and Enabled=true, the provisioning
+	// handler additionally writes a ManagedWarehouseTrino row so the
+	// provisioner picks it up on the next reconcile.
+	Trino *provisionTrinoReq `json:"trino,omitempty"`
 }
 
 type provisionMetadataReq struct {
 	Type string `json:"type"`
+}
+
+// provisionTrinoReq is the per-request Trino opt-in. Mirrored by the
+// standalone POST /orgs/:id/trino body (trinoRequest below) so both
+// surfaces accept the same shape.
+type provisionTrinoReq struct {
+	// Enabled flips Trino on for this org. False (or omitted) is a no-op:
+	// existing rows are not affected, so the provision endpoint can be
+	// retried with Trino={Enabled:false} without disabling a previously
+	// enabled org.
+	Enabled bool `json:"enabled"`
+
+	// Tier picks the resource-group limits applied to the org. Empty
+	// string is the default tier.
+	Tier string `json:"tier,omitempty"`
+}
+
+// trinoRequest is the body shape for POST /orgs/:id/trino (standalone
+// enable on an existing org). Mirrors provisionTrinoReq so callers can
+// use one schema for both surfaces.
+type trinoRequest struct {
+	Enabled bool   `json:"enabled"`
+	Tier    string `json:"tier,omitempty"`
 }
 
 func (h *handler) provisionWarehouse(c *gin.Context) {
@@ -145,11 +184,81 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
+	// Optionally enable Trino in the same handler. Failures here roll
+	// back to a 500 — partial state (warehouse + user created but trino
+	// row missing) would mean the caller's next retry conflicts on the
+	// warehouse row but the trino opt-in was silently lost. We'd rather
+	// surface that so the caller knows to retry.
+	if req.Trino != nil && req.Trino.Enabled {
+		if err := h.store.EnableTrino(orgID, configstore.TrinoSettings{Tier: req.Trino.Tier}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enable trino: " + err.Error()})
+			return
+		}
+	}
+
 	c.JSON(http.StatusAccepted, gin.H{
 		"status":   "provisioning started",
 		"org":      orgID,
 		"username": "root",
 		"password": plainPassword,
+	})
+}
+
+// enableTrino handles POST /orgs/:id/trino — opting an existing org
+// (provisioned previously without Trino) into the customer Trino cluster.
+// Idempotent: re-enabling updates the tier without flipping through a
+// disabled state.
+//
+// Note this does NOT require the org's ManagedWarehouse to exist — the
+// Trino provisioner gates on its own readiness signal (Iceberg-Ready in
+// Lakekeeper), not on the warehouse top-level state. Callers that need
+// the warehouse first should call /provision before /trino.
+func (h *handler) enableTrino(c *gin.Context) {
+	orgID := c.Param("id")
+	if orgID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "org id is required"})
+		return
+	}
+
+	var req trinoRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !req.Enabled {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "enabled must be true; use DELETE to disable"})
+		return
+	}
+
+	if err := h.store.EnableTrino(orgID, configstore.TrinoSettings{Tier: req.Tier}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{
+		"status": "trino enable queued",
+		"org":    orgID,
+		"tier":   req.Tier,
+	})
+}
+
+// disableTrino handles DELETE /orgs/:id/trino — opting the org out of
+// the customer Trino cluster. The row is kept (with Enabled=false) so
+// the provisioner observes the transition and removes the catalog +
+// password file entry on its next reconcile tick. Idempotent.
+func (h *handler) disableTrino(c *gin.Context) {
+	orgID := c.Param("id")
+	if orgID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "org id is required"})
+		return
+	}
+	if err := h.store.DisableTrino(orgID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{
+		"status": "trino disable queued",
+		"org":    orgID,
 	})
 }
 

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -11,10 +12,45 @@ import (
 	"gorm.io/gorm"
 )
 
+// isUniqueViolation reports whether err comes from a Postgres
+// 23505 unique-constraint violation. The pgx/jackc driver surfaces
+// the SQLSTATE through a method on the returned error; we match
+// against that without importing pgconn directly (mirrors the
+// pattern in controlplane/provisioner/postgres_admin.go).
+//
+// Mapped to HTTP 409 by the provision handler so callers see a
+// clear "your input conflicts with existing state" rather than a
+// generic 500.
+func isUniqueViolation(err error) bool {
+	type sqlStater interface{ SQLState() string }
+	var s sqlStater
+	return errors.As(err, &s) && s.SQLState() == "23505"
+}
+
+// trinoOrgIDPattern is the team_id shape Trino's customer-facing path
+// requires: ASCII digits only. The plan establishes the v1 invariant
+// that Org.Name (== posthog team_id) is an integer string; Trino's
+// catalog naming and group-file projection don't tolerate punctuation,
+// and silently sanitizing it would let two distinct team_ids collide
+// into one catalog. Rejecting non-numeric IDs at the API boundary is
+// safer than catching the collision downstream.
+//
+// Org IDs flowing into the existing /provision endpoint are not
+// constrained by this — only the Trino opt-in surfaces (the standalone
+// /trino enable endpoint and the optional trino block on /provision).
+var trinoOrgIDPattern = regexp.MustCompile(`^[0-9]+$`)
+
 // Store defines the config store operations needed by the provisioning API.
 type Store interface {
 	GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error)
 	GetOrg(orgID string) (*configstore.Org, error)
+	// Provision is the all-or-nothing entrypoint for POST /provision —
+	// wraps warehouse + root-user + optional Trino-opt-in writes in a
+	// single configstore transaction so partial failure rolls back
+	// cleanly. Use this for the public provision endpoint; the older
+	// per-step methods below are kept for the standalone surfaces
+	// (reset-password, enable/disable trino on an existing org).
+	Provision(req ProvisionRequest) error
 	CreatePendingWarehouse(orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error
 	CreateOrgUser(orgID, username, passwordHash string) error
 	UpdateOrgUserPassword(orgID, username, passwordHash string) error
@@ -162,13 +198,21 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	if err := h.store.CreatePendingWarehouse(orgID, req.DatabaseName, warehouse); err != nil {
-		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
-		return
+	// Validate Trino opt-in BEFORE generating the password — the
+	// numeric-orgID check is a request-validation failure (400), and
+	// running it inside the tx would just roll back and waste a hash.
+	var trinoSettings *configstore.TrinoSettings
+	if req.Trino != nil && req.Trino.Enabled {
+		if !trinoOrgIDPattern.MatchString(orgID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "trino.enabled requires a numeric org id (posthog team_id); got: " + orgID})
+			return
+		}
+		trinoSettings = &configstore.TrinoSettings{Tier: req.Trino.Tier}
 	}
 
-	// Create root user with a generated password. The plaintext is returned
-	// in this response only — it is never stored, only the bcrypt hash is persisted.
+	// Generate the root password. The plaintext is returned in this
+	// response only — it is never stored, only the bcrypt hash is
+	// persisted via the transactional Provision below.
 	plainPassword, err := configstore.GeneratePassword()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate password"})
@@ -179,21 +223,37 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
 		return
 	}
-	if err := h.store.CreateOrgUser(orgID, "root", hash); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create root user"})
-		return
-	}
 
-	// Optionally enable Trino in the same handler. Failures here roll
-	// back to a 500 — partial state (warehouse + user created but trino
-	// row missing) would mean the caller's next retry conflicts on the
-	// warehouse row but the trino opt-in was silently lost. We'd rather
-	// surface that so the caller knows to retry.
-	if req.Trino != nil && req.Trino.Enabled {
-		if err := h.store.EnableTrino(orgID, configstore.TrinoSettings{Tier: req.Trino.Tier}); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enable trino: " + err.Error()})
+	// One transaction wraps warehouse + root user + optional Trino
+	// opt-in. Failure of any sub-step rolls the others back so the
+	// caller's retry sees the same starting state (no half-provisioned
+	// row blocking re-creation).
+	if err := h.store.Provision(ProvisionRequest{
+		OrgID:        orgID,
+		DatabaseName: req.DatabaseName,
+		Warehouse:    warehouse,
+		RootUserHash: hash,
+		Trino:        trinoSettings,
+	}); err != nil {
+		// The warehouse-already-exists conflict is the only error
+		// shape that maps to 409. Everything else (DB write failure,
+		// OnConflict surprise) is internal. The sentinel here
+		// replaces an earlier `strings.Contains` match, so that
+		// rewording the error message can't silently break the 409
+		// branch.
+		if errors.Is(err, ErrWarehouseNonTerminal) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 			return
 		}
+		if isUniqueViolation(err) {
+			// Most likely: database_name already in use by another
+			// org. Map to 409 with a clear message; the underlying
+			// error still includes the constraint name for ops.
+			c.JSON(http.StatusConflict, gin.H{"error": "provision conflicts with existing state (likely database_name in use): " + err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "provision failed: " + err.Error()})
+		return
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{
@@ -219,6 +279,10 @@ func (h *handler) enableTrino(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "org id is required"})
 		return
 	}
+	if !trinoOrgIDPattern.MatchString(orgID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "org id must be numeric (posthog team_id); got: " + orgID})
+		return
+	}
 
 	var req trinoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -228,6 +292,21 @@ func (h *handler) enableTrino(c *gin.Context) {
 
 	if !req.Enabled {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "enabled must be true; use DELETE to disable"})
+		return
+	}
+
+	// Preflight: the FK on ManagedWarehouseTrino requires the Org row
+	// to exist. Without this check, EnableTrino's INSERT hits a
+	// foreign-key violation and we'd return a 500 with the raw Postgres
+	// error. 404 is the right shape: "the resource you're trying to
+	// modify doesn't exist." Callers that need to /provision first
+	// see the clear 404 here rather than parsing an FK error string.
+	if _, err := h.store.GetOrg(orgID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "org not found; call /provision first"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -18,6 +18,7 @@ type fakeStore struct {
 	orgs       map[string]*configstore.Org
 	users      map[configstore.OrgUserKey]string
 	warehouses map[string]*configstore.ManagedWarehouse
+	trino      map[string]*configstore.ManagedWarehouseTrino
 }
 
 func newFakeStore() *fakeStore {
@@ -25,6 +26,7 @@ func newFakeStore() *fakeStore {
 		orgs:       make(map[string]*configstore.Org),
 		users:      make(map[configstore.OrgUserKey]string),
 		warehouses: make(map[string]*configstore.ManagedWarehouse),
+		trino:      make(map[string]*configstore.ManagedWarehouseTrino),
 	}
 }
 
@@ -88,6 +90,22 @@ func (s *fakeStore) IsDatabaseNameAvailable(name string) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+func (s *fakeStore) EnableTrino(orgID string, settings configstore.TrinoSettings) error {
+	s.trino[orgID] = &configstore.ManagedWarehouseTrino{
+		OrgID:   orgID,
+		Enabled: true,
+		Tier:    settings.Tier,
+	}
+	return nil
+}
+
+func (s *fakeStore) DisableTrino(orgID string) error {
+	if row, ok := s.trino[orgID]; ok {
+		row.Enabled = false
+	}
+	return nil
 }
 
 func (s *fakeStore) SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error {
@@ -362,6 +380,116 @@ func TestGetWarehouseNotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestProvisionEnablesTrinoWhenRequested(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestRouter(store)
+
+	body := []byte(`{
+		"database_name": "analytics-db",
+		"metadata_store": {"type": "aurora", "aurora": {"max_acu": 2}},
+		"trino": {"enabled": true, "tier": "free"}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	row := store.trino["analytics"]
+	if row == nil || !row.Enabled || row.Tier != "free" {
+		t.Fatalf("expected trino row with Enabled=true, Tier=free; got %+v", row)
+	}
+}
+
+func TestProvisionWithoutTrinoLeavesTrinoRowUnset(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "aurora", "aurora": {"max_acu": 1}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if _, ok := store.trino["analytics"]; ok {
+		t.Fatalf("expected no trino row when request omits trino block")
+	}
+}
+
+func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestRouter(store)
+
+	body := []byte(`{"enabled": true, "tier": "growth"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/trino", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	row := store.trino["analytics"]
+	if row == nil || !row.Enabled || row.Tier != "growth" {
+		t.Fatalf("expected trino row enabled with tier growth; got %+v", row)
+	}
+}
+
+func TestEnableTrinoRejectsEnabledFalse(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"enabled": false}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/trino", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestDisableTrinoEndpoint(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.trino["analytics"] = &configstore.ManagedWarehouseTrino{OrgID: "analytics", Enabled: true, Tier: "free"}
+	router := newTestRouter(store)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/orgs/analytics/trino", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	row := store.trino["analytics"]
+	if row == nil || row.Enabled {
+		t.Fatalf("expected trino row to be present but disabled; got %+v", row)
+	}
+}
+
+func TestDisableTrinoOnMissingRowIsNoOp(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/orgs/unknown/trino", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
 }
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -106,8 +106,8 @@ func (s *fakeStore) Provision(req ProvisionRequest) error {
 
 	// Stage the writes into shadow maps so a mid-step failure can roll
 	// back without leaving partial state.
-	shadowOrg, _ := s.orgs[req.OrgID]
-	shadowWarehouse, _ := s.warehouses[req.OrgID]
+	shadowOrg := s.orgs[req.OrgID]
+	shadowWarehouse := s.warehouses[req.OrgID]
 	shadowUserHash, hadUser := s.users[configstore.OrgUserKey{OrgID: req.OrgID, Username: "root"}]
 	shadowTrino, hadTrino := s.trino[req.OrgID]
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type fakeStore struct {
-	orgs       map[string]*configstore.Org
-	users      map[configstore.OrgUserKey]string
-	warehouses map[string]*configstore.ManagedWarehouse
-	trino      map[string]*configstore.ManagedWarehouseTrino
+	orgs                  map[string]*configstore.Org
+	users                 map[configstore.OrgUserKey]string
+	warehouses            map[string]*configstore.ManagedWarehouse
+	trino                 map[string]*configstore.ManagedWarehouseTrino
+	provisionUserFailHook error // set non-nil to simulate user-step failure inside Provision
 }
 
 func newFakeStore() *fakeStore {
@@ -69,7 +70,7 @@ func (s *fakeStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 	}
 	existing, ok := s.warehouses[orgID]
 	if ok && existing.State != configstore.ManagedWarehouseStateFailed && existing.State != configstore.ManagedWarehouseStateDeleted {
-		return errors.New("warehouse already exists in non-terminal state")
+		return ErrWarehouseNonTerminal
 	}
 	clone := *warehouse
 	clone.OrgID = orgID
@@ -80,6 +81,80 @@ func (s *fakeStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 	clone.IdentityState = configstore.ManagedWarehouseStatePending
 	clone.SecretsState = configstore.ManagedWarehouseStatePending
 	s.warehouses[orgID] = &clone
+	return nil
+}
+
+// provisionUserFailHook, when non-nil, triggers a simulated failure
+// during the user-creation step of Provision. The fake uses it to
+// exercise rollback semantics — see TestProvisionTransactionRollsBack.
+// Set to a non-nil error to fail; set to nil (default) for success.
+//
+// Real prod failure modes (DB write failure, conflict between checks)
+// are handled by the *gormStore* implementation's transaction
+// boundary; the fake fakes the boundary so tests can verify the
+// handler treats partial failure as a complete rollback.
+func (s *fakeStore) setProvisionUserFailHook(err error) { s.provisionUserFailHook = err }
+
+func (s *fakeStore) Provision(req ProvisionRequest) error {
+	// Pre-check: warehouse already exists in non-terminal state? Mirrors
+	// createPendingWarehouseTx so the handler's 409 branch is exercised.
+	if existing, ok := s.warehouses[req.OrgID]; ok &&
+		existing.State != configstore.ManagedWarehouseStateFailed &&
+		existing.State != configstore.ManagedWarehouseStateDeleted {
+		return ErrWarehouseNonTerminal
+	}
+
+	// Stage the writes into shadow maps so a mid-step failure can roll
+	// back without leaving partial state.
+	shadowOrg, _ := s.orgs[req.OrgID]
+	shadowWarehouse, _ := s.warehouses[req.OrgID]
+	shadowUserHash, hadUser := s.users[configstore.OrgUserKey{OrgID: req.OrgID, Username: "root"}]
+	shadowTrino, hadTrino := s.trino[req.OrgID]
+
+	// 1. Warehouse + Org
+	if _, ok := s.orgs[req.OrgID]; !ok {
+		s.orgs[req.OrgID] = &configstore.Org{Name: req.OrgID, DatabaseName: req.DatabaseName}
+	}
+	clone := *req.Warehouse
+	clone.OrgID = req.OrgID
+	clone.State = configstore.ManagedWarehouseStatePending
+	clone.WarehouseDatabaseState = configstore.ManagedWarehouseStatePending
+	clone.MetadataStoreState = configstore.ManagedWarehouseStatePending
+	clone.S3State = configstore.ManagedWarehouseStatePending
+	clone.IdentityState = configstore.ManagedWarehouseStatePending
+	clone.SecretsState = configstore.ManagedWarehouseStatePending
+	s.warehouses[req.OrgID] = &clone
+
+	// 2. User — with injection hook for the rollback test
+	if s.provisionUserFailHook != nil {
+		// Roll back step 1
+		if shadowOrg == nil {
+			delete(s.orgs, req.OrgID)
+		} else {
+			s.orgs[req.OrgID] = shadowOrg
+		}
+		if shadowWarehouse == nil {
+			delete(s.warehouses, req.OrgID)
+		} else {
+			s.warehouses[req.OrgID] = shadowWarehouse
+		}
+		return s.provisionUserFailHook
+	}
+	s.users[configstore.OrgUserKey{OrgID: req.OrgID, Username: "root"}] = req.RootUserHash
+
+	// 3. Optional Trino
+	if req.Trino != nil {
+		s.trino[req.OrgID] = &configstore.ManagedWarehouseTrino{
+			OrgID:   req.OrgID,
+			Enabled: true,
+			Tier:    req.Trino.Tier,
+			State:   configstore.ManagedWarehouseStatePending,
+		}
+	}
+
+	// Reference the shadow vars so the linter doesn't complain about
+	// declared-and-unused on the success path.
+	_, _, _, _ = shadowUserHash, hadUser, shadowTrino, hadTrino
 	return nil
 }
 
@@ -385,15 +460,19 @@ func TestGetWarehouseNotFound(t *testing.T) {
 
 func TestProvisionEnablesTrinoWhenRequested(t *testing.T) {
 	store := newFakeStore()
-	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	// Trino enable requires a numeric org id (posthog team_id).
+	store.orgs["42"] = &configstore.Org{Name: "42"}
 	router := newTestRouter(store)
 
+	// cnpg-shard is the only provisionable backend post-#627. The
+	// provision handler auto-enables Iceberg (Lakekeeper) for any
+	// cnpg-shard warehouse, which is the prerequisite for Trino.
 	body := []byte(`{
-		"database_name": "analytics-db",
-		"metadata_store": {"type": "aurora", "aurora": {"max_acu": 2}},
+		"database_name": "team-42-db",
+		"metadata_store": {"type": "cnpg-shard"},
 		"trino": {"enabled": true, "tier": "free"}
 	}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/42/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -401,9 +480,78 @@ func TestProvisionEnablesTrinoWhenRequested(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	row := store.trino["analytics"]
+	row := store.trino["42"]
 	if row == nil || !row.Enabled || row.Tier != "free" {
 		t.Fatalf("expected trino row with Enabled=true, Tier=free; got %+v", row)
+	}
+}
+
+func TestProvisionTransactionRollsBackOnUserFailure(t *testing.T) {
+	// Pattern A's whole point: when a downstream write inside the
+	// transactional Provision fails, the upstream writes must roll
+	// back too. The fake exposes a hook that simulates a user-step
+	// failure; the caller's retry must see a clean starting state, not
+	// a half-provisioned warehouse blocking re-creation.
+	store := newFakeStore()
+	store.setProvisionUserFailHook(errors.New("simulated DB write failure"))
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "team-7-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/7/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (transactional failure): %s", rec.Code, rec.Body.String())
+	}
+
+	// After rollback: no warehouse row, no user row, no Trino row,
+	// no Org row. Retry would treat this as a brand-new provision.
+	if _, ok := store.warehouses["7"]; ok {
+		t.Errorf("expected warehouse to be rolled back, got %+v", store.warehouses["7"])
+	}
+	if _, ok := store.users[configstore.OrgUserKey{OrgID: "7", Username: "root"}]; ok {
+		t.Errorf("expected user row to be absent after rollback")
+	}
+	if _, ok := store.orgs["7"]; ok {
+		t.Errorf("expected org row to be rolled back, got %+v", store.orgs["7"])
+	}
+
+	// Now clear the hook and retry — should succeed with a clean
+	// fresh attempt (proving the rolled-back state didn't poison the
+	// retry).
+	store.setProvisionUserFailHook(nil)
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/7/provision", bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusAccepted {
+		t.Fatalf("retry status = %d, want 202: %s", rec2.Code, rec2.Body.String())
+	}
+	if _, ok := store.warehouses["7"]; !ok {
+		t.Errorf("expected warehouse to be created on retry")
+	}
+}
+
+func TestProvisionRejectsTrinoWithNonNumericOrgID(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	router := newTestRouter(store)
+
+	body := []byte(`{
+		"database_name": "analytics-db",
+		"metadata_store": {"type": "cnpg-shard"},
+		"trino": {"enabled": true}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 with non-numeric org id: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -412,7 +560,7 @@ func TestProvisionWithoutTrinoLeavesTrinoRowUnset(t *testing.T) {
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "aurora", "aurora": {"max_acu": 1}}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -428,11 +576,11 @@ func TestProvisionWithoutTrinoLeavesTrinoRowUnset(t *testing.T) {
 
 func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
 	store := newFakeStore()
-	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
+	store.orgs["42"] = &configstore.Org{Name: "42"}
 	router := newTestRouter(store)
 
 	body := []byte(`{"enabled": true, "tier": "growth"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/trino", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/42/trino", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -440,9 +588,24 @@ func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	row := store.trino["analytics"]
+	row := store.trino["42"]
 	if row == nil || !row.Enabled || row.Tier != "growth" {
 		t.Fatalf("expected trino row enabled with tier growth; got %+v", row)
+	}
+}
+
+func TestEnableTrinoRejectsNonNumericOrgID(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"enabled": true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/trino", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 with non-numeric org id: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -6,7 +6,38 @@ import (
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
+
+// ErrWarehouseNonTerminal is returned by Provision / CreatePendingWarehouse
+// when the caller tries to (re-)provision an org whose warehouse row is
+// in a non-terminal state (Pending / Provisioning / Ready / Deleting).
+// HTTP handlers map this to 409. Callers that need to "recreate" a
+// warehouse should call /deprovision first to move it into Deleting →
+// Deleted, then retry /provision.
+var ErrWarehouseNonTerminal = errors.New("warehouse already exists in non-terminal state")
+
+// ProvisionRequest is the all-or-nothing input the Provision endpoint
+// dispatches into a single configstore transaction. Warehouse + root
+// user are always written; Trino is opt-in (Trino == nil skips it).
+//
+// The shape mirrors the public HTTP request: the handler builds it
+// from the validated request body and passes it down so the Store can
+// commit (or roll back) every write atomically. Partial failure can no
+// longer leave the warehouse in Pending state without a root user, or
+// vice versa.
+type ProvisionRequest struct {
+	OrgID        string
+	DatabaseName string
+	Warehouse    *configstore.ManagedWarehouse
+	// RootUserHash is the bcrypt hash of the freshly-generated root
+	// password. Plaintext stays in the handler (returned to the
+	// caller); only the hash is persisted, same as before.
+	RootUserHash string
+	// Trino, when non-nil, additionally writes a ManagedWarehouseTrino
+	// row inside the same transaction. nil leaves Trino opt-out alone.
+	Trino *configstore.TrinoSettings
+}
 
 // gormStore implements Store using a ConfigStore's GORM DB.
 type gormStore struct {
@@ -44,48 +75,136 @@ func (s *gormStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWareh
 
 func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error {
 	return s.cs.DB().Transaction(func(tx *gorm.DB) error {
-		// Auto-create org if it doesn't exist (PostHog calls provision, duckgres creates everything)
-		org := configstore.Org{Name: orgID, DatabaseName: databaseName}
-		if err := tx.Where("name = ?", orgID).FirstOrCreate(&org).Error; err != nil {
+		return createPendingWarehouseTx(tx, orgID, databaseName, warehouse)
+	})
+}
+
+// createPendingWarehouseTx is the inner half of CreatePendingWarehouse —
+// the same logic, but taking an existing *gorm.DB (typically a
+// transaction handle) so it can be composed into a larger transaction
+// (see Provision). Self-contained: the caller wraps it in Transaction
+// (or extends an existing one) as appropriate.
+//
+// Returns a sentinel-comparable error string ("warehouse already
+// exists in non-terminal state") so HTTP handlers can map to 409
+// without an extra error type.
+func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error {
+	// Auto-create org if it doesn't exist (PostHog calls provision, duckgres creates everything)
+	org := configstore.Org{Name: orgID, DatabaseName: databaseName}
+	if err := tx.Where("name = ?", orgID).FirstOrCreate(&org).Error; err != nil {
+		return err
+	}
+	// Update database name if org already existed with a different one
+	if org.DatabaseName != databaseName {
+		if err := tx.Model(&org).Update("database_name", databaseName).Error; err != nil {
 			return err
 		}
-		// Update database name if org already existed with a different one
-		if org.DatabaseName != databaseName {
-			if err := tx.Model(&org).Update("database_name", databaseName).Error; err != nil {
-				return err
-			}
-		}
+	}
 
-		// Check for existing warehouse in non-terminal state
-		var existing configstore.ManagedWarehouse
-		err := tx.First(&existing, "org_id = ?", orgID).Error
-		if err == nil {
-			if existing.State != configstore.ManagedWarehouseStateFailed &&
-				existing.State != configstore.ManagedWarehouseStateDeleted {
-				return errors.New("warehouse already exists in non-terminal state")
-			}
-			if err := tx.Delete(&existing).Error; err != nil {
-				return err
-			}
-		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+	// Check for existing warehouse in non-terminal state
+	var existing configstore.ManagedWarehouse
+	err := tx.First(&existing, "org_id = ?", orgID).Error
+	if err == nil {
+		if existing.State != configstore.ManagedWarehouseStateFailed &&
+			existing.State != configstore.ManagedWarehouseStateDeleted {
+			return ErrWarehouseNonTerminal
+		}
+		if err := tx.Delete(&existing).Error; err != nil {
+			return err
+		}
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	warehouse.OrgID = orgID
+	warehouse.State = configstore.ManagedWarehouseStatePending
+	warehouse.WarehouseDatabaseState = configstore.ManagedWarehouseStatePending
+	warehouse.MetadataStoreState = configstore.ManagedWarehouseStatePending
+	warehouse.S3State = configstore.ManagedWarehouseStatePending
+	warehouse.IdentityState = configstore.ManagedWarehouseStatePending
+	warehouse.SecretsState = configstore.ManagedWarehouseStatePending
+	// Track iceberg as a provisioning component only when the tenant opted
+	// in (e.g. cnpg-shard, which is always iceberg-backed). Leaving it
+	// empty for non-iceberg warehouses keeps them out of the iceberg
+	// readiness gate.
+	if warehouse.Iceberg.Enabled {
+		warehouse.IcebergState = configstore.ManagedWarehouseStatePending
+	}
+	return tx.Create(warehouse).Error
+}
+
+// Provision is the all-or-nothing entrypoint for POST /provision: one
+// configstore transaction wrapping warehouse + root-user + optional
+// Trino-opt-in writes. Partial failure rolls back every write so the
+// caller's retry sees the same starting state, not a half-provisioned
+// org with a non-terminal warehouse blocking re-creation.
+//
+// Each individual write is idempotent (OnConflict on the user upsert,
+// FirstOrCreate on the Org row, OnConflict on the Trino row), so a
+// retry of a successfully-committed transaction returns the same
+// success — but the plaintext password is regenerated on every call
+// and is only readable from the HTTP response. A retry after a dropped
+// response will not recover the original plaintext; the caller's
+// recovery path is /reset-password once the warehouse reaches Ready.
+//
+// The "warehouse already exists in non-terminal state" error is
+// passed through verbatim from createPendingWarehouseTx so the HTTP
+// handler can map it to 409.
+func (s *gormStore) Provision(req ProvisionRequest) error {
+	if req.OrgID == "" {
+		return errors.New("Provision: OrgID is required")
+	}
+	if req.DatabaseName == "" {
+		return errors.New("Provision: DatabaseName is required")
+	}
+	if req.Warehouse == nil {
+		return errors.New("Provision: Warehouse is required")
+	}
+	if req.RootUserHash == "" {
+		return errors.New("Provision: RootUserHash is required")
+	}
+	return s.cs.DB().Transaction(func(tx *gorm.DB) error {
+		// 1. Warehouse + Org (extracted helper).
+		if err := createPendingWarehouseTx(tx, req.OrgID, req.DatabaseName, req.Warehouse); err != nil {
 			return err
 		}
 
-		warehouse.OrgID = orgID
-		warehouse.State = configstore.ManagedWarehouseStatePending
-		warehouse.WarehouseDatabaseState = configstore.ManagedWarehouseStatePending
-		warehouse.MetadataStoreState = configstore.ManagedWarehouseStatePending
-		warehouse.S3State = configstore.ManagedWarehouseStatePending
-		warehouse.IdentityState = configstore.ManagedWarehouseStatePending
-		warehouse.SecretsState = configstore.ManagedWarehouseStatePending
-		// Track iceberg as a provisioning component only when the tenant opted
-		// in (e.g. cnpg-shard, which is always iceberg-backed). Leaving it
-		// empty for non-iceberg warehouses keeps them out of the iceberg
-		// readiness gate.
-		if warehouse.Iceberg.Enabled {
-			warehouse.IcebergState = configstore.ManagedWarehouseStatePending
+		// 2. Root user. Same OnConflict semantics as
+		// ConfigStore.CreateOrgUser so a retry overwrites the prior
+		// hash — important because the handler regenerates a fresh
+		// plaintext on every call.
+		user := configstore.OrgUser{
+			OrgID:    req.OrgID,
+			Username: "root",
+			Password: req.RootUserHash,
 		}
-		return tx.Create(warehouse).Error
+		if err := tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "org_id"}, {Name: "username"}},
+			DoUpdates: clause.AssignmentColumns([]string{"password", "updated_at"}),
+		}).Create(&user).Error; err != nil {
+			return fmt.Errorf("create root user: %w", err)
+		}
+
+		// 3. Optional Trino opt-in. State seeds to Pending so the
+		// reconcile loop sees a fresh row to act on; the OnConflict
+		// columns deliberately exclude State / StatusMessage /
+		// ReadyAt / FailedAt so a re-provision doesn't clobber the
+		// reconcile loop's prior outcome.
+		if req.Trino != nil {
+			trinoRow := configstore.ManagedWarehouseTrino{
+				OrgID:   req.OrgID,
+				Enabled: true,
+				Tier:    req.Trino.Tier,
+				State:   configstore.ManagedWarehouseStatePending,
+			}
+			if err := tx.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "org_id"}},
+				DoUpdates: clause.AssignmentColumns([]string{"enabled", "tier", "updated_at"}),
+			}).Create(&trinoRow).Error; err != nil {
+				return fmt.Errorf("enable trino: %w", err)
+			}
+		}
+		return nil
 	})
 }
 

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -97,6 +97,20 @@ func (s *gormStore) IsDatabaseNameAvailable(name string) (bool, error) {
 	return count == 0, nil
 }
 
+// EnableTrino persists the per-org Trino opt-in. Idempotent — the
+// configstore implementation upserts on (org_id) so re-enabling updates
+// the tier without flipping Enabled false-then-true.
+func (s *gormStore) EnableTrino(orgID string, settings configstore.TrinoSettings) error {
+	return s.cs.EnableTrino(orgID, settings)
+}
+
+// DisableTrino marks the org's Trino row as disabled. The row is kept
+// (with Enabled=false) so the provisioner observes the transition and
+// can clean up downstream state. No-op when no row exists.
+func (s *gormStore) DisableTrino(orgID string) error {
+	return s.cs.DisableTrino(orgID)
+}
+
 // SetWarehouseDeleting atomically transitions a warehouse from expectedState to deleting.
 // Returns gorm.ErrRecordNotFound if no warehouse exists, or an error if the CAS fails.
 func (s *gormStore) SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error {

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -68,10 +68,22 @@ const (
 	envTrinoBundleBearerToken = "DUCKGRES_TRINO_BUNDLE_BEARER_TOKEN" //nolint:gosec // env name only
 
 	// envTrinoIAMAccountID is the AWS account id used to assemble the
-	// per-org iceberg.s3.aws-role-arn (the duckling-<orgid> role).
-	// Required for AWS deployments; may be empty in dev clusters where
-	// per-org S3 access isn't exercised.
+	// per-org s3.iam-role property (`arn:aws:iam::<acct>:role/duckling-<orgid>`).
+	// Required for AWS deployments: an empty value silently omits the
+	// per-catalog IAM role, so every catalog would fall back to the
+	// Trino pod's ambient identity — which is the wildcard-assume
+	// duckling-* role per the plan's threat model. That collapses the
+	// per-tenant S3 boundary. Set DUCKGRES_TRINO_ALLOW_NO_IAM_ROLE=true
+	// in dev/test to bypass this gate; never set it in prod.
 	envTrinoIAMAccountID = "DUCKGRES_TRINO_IAM_ACCOUNT_ID"
+
+	// envTrinoAllowNoIAMRole is the explicit opt-out for the
+	// IAM-required check above. Off by default; setting it to "1" /
+	// "true" / "yes" lets buildTrinoWiring proceed with an empty
+	// IAM_ACCOUNT_ID. Use ONLY in dev/test where the per-tenant
+	// S3 isolation isn't exercised. Production deployments must
+	// supply DUCKGRES_TRINO_IAM_ACCOUNT_ID instead.
+	envTrinoAllowNoIAMRole = "DUCKGRES_TRINO_ALLOW_NO_IAM_ROLE"
 
 	// envTrinoAWSRegion is the AWS region for the per-org IAM role
 	// binding and Iceberg catalog config. Falls back to the per-org
@@ -89,6 +101,14 @@ const (
 // Off by default; matches lakekeeperProvisionerEnabled's gating style.
 func trinoProvisionerEnabled() bool {
 	v := strings.ToLower(strings.TrimSpace(os.Getenv(envTrinoProvisionerEnabled)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// trinoAllowNoIAMRole reports whether the dev/test bypass for the
+// IAM_ACCOUNT_ID gate is set. Off by default — production wiring
+// fails if the IAM account id is missing.
+func trinoAllowNoIAMRole() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envTrinoAllowNoIAMRole)))
 	return v == "1" || v == "true" || v == "yes"
 }
 
@@ -149,6 +169,19 @@ func buildTrinoWiring(store *configstore.ConfigStore, kc kubernetes.Interface) (
 			envTrinoAdminPasswordHash, envTrinoAdminPassword, err)
 	}
 
+	// Per-tenant S3 boundary check. An empty IAM_ACCOUNT_ID silently
+	// disables the `s3.iam-role` catalog property, collapsing every
+	// catalog onto the Trino pod's ambient identity (which is the
+	// wildcard-assume duckling-* role per the plan's threat model).
+	// That defeats the entire reason for per-org IAM roles. Require
+	// the env var unless the operator explicitly opts out for
+	// dev/test, where per-tenant S3 access isn't exercised anyway.
+	iamAccountID := strings.TrimSpace(os.Getenv(envTrinoIAMAccountID))
+	if iamAccountID == "" && !trinoAllowNoIAMRole() {
+		return nil, fmt.Errorf("%s is required when %s is set, or set %s=true to bypass in dev/test (do not bypass in production: empty IAM account id silently collapses the per-org S3 isolation boundary)",
+			envTrinoIAMAccountID, envTrinoProvisionerEnabled, envTrinoAllowNoIAMRole)
+	}
+
 	catalogClient := provisioner.NewTrinoCatalogHTTPClient(coordinatorURL, opa.AdminPrincipal, adminPassword)
 	bundleStore := &opa.BundleStore{}
 	bundleHandler := opa.NewHandler(bundleStore, opa.BearerTokenAuth(bundleToken))
@@ -162,7 +195,7 @@ func buildTrinoWiring(store *configstore.ConfigStore, kc kubernetes.Interface) (
 		BundleStore:       bundleStore,
 		BundleBuilder:     opa.NewBuilder(),
 		AdminPasswordHash: adminPasswordHash,
-		IAMAccountID:      strings.TrimSpace(os.Getenv(envTrinoIAMAccountID)),
+		IAMAccountID:      iamAccountID,
 		AWSRegion:         strings.TrimSpace(os.Getenv(envTrinoAWSRegion)),
 	})
 	if err != nil {

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -1,0 +1,177 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
+	"golang.org/x/crypto/bcrypt"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// newTrinoKubeClient builds an in-cluster typed kubernetes.Interface for
+// the Trino provisioner's Secret + ConfigMap projections. Returns the
+// in-cluster client error verbatim so the caller can log+skip rather
+// than fatal-out a non-K8s deployment (matches the Lakekeeper-side
+// best-effort pattern).
+func newTrinoKubeClient() (kubernetes.Interface, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("in-cluster config: %w", err)
+	}
+	kc, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+	return kc, nil
+}
+
+// Env-only knobs that wire the customer-Trino provisioner branch. All
+// are read at startup; rotation requires a restart (the Trino
+// provisioner sub-component itself doesn't observe env changes).
+const (
+	// envTrinoProvisionerEnabled gates the whole sub-component. Off by
+	// default so deployments without a customer Trino cluster carry no
+	// extra reconcile cost. Accepted values: "1", "true", "yes" (case-
+	// insensitive).
+	envTrinoProvisionerEnabled = "DUCKGRES_TRINO_PROVISIONER_ENABLED"
+
+	// envTrinoCoordinatorURL is the customer-Trino coordinator's REST
+	// endpoint, e.g. http://trino-coordinator.trino-customer.svc:8080.
+	// Required when the provisioner is enabled.
+	envTrinoCoordinatorURL = "DUCKGRES_TRINO_COORDINATOR_URL"
+
+	// envTrinoAdminPassword is the plaintext admin password the
+	// provisioner presents over HTTP Basic to the customer-Trino
+	// coordinator. Trino's file authenticator validates it against the
+	// bcrypt hash in password.db.
+	envTrinoAdminPassword = "DUCKGRES_TRINO_ADMIN_PASSWORD" //nolint:gosec // env name only
+
+	// envTrinoAdminPasswordHash is the bcrypt hash of the same admin
+	// password, projected verbatim into password.db. Must correspond to
+	// envTrinoAdminPassword — mismatched values mean the provisioner
+	// authenticates with one credential while password.db expects a
+	// different one. Document the pairing in the runbook.
+	envTrinoAdminPasswordHash = "DUCKGRES_TRINO_ADMIN_PASSWORD_HASH" //nolint:gosec // env name only
+
+	// envTrinoBundleBearerToken is the shared bearer token the bundle
+	// HTTP endpoint (opa.Handler) validates against. Must match
+	// services.<name>.credentials.bearer.token in the OPA sidecar
+	// config.
+	envTrinoBundleBearerToken = "DUCKGRES_TRINO_BUNDLE_BEARER_TOKEN" //nolint:gosec // env name only
+
+	// envTrinoIAMAccountID is the AWS account id used to assemble the
+	// per-org iceberg.s3.aws-role-arn (the duckling-<orgid> role).
+	// Required for AWS deployments; may be empty in dev clusters where
+	// per-org S3 access isn't exercised.
+	envTrinoIAMAccountID = "DUCKGRES_TRINO_IAM_ACCOUNT_ID"
+
+	// envTrinoAWSRegion is the AWS region for the per-org IAM role
+	// binding and Iceberg catalog config. Falls back to the per-org
+	// ManagedWarehouseIceberg.Region when empty.
+	envTrinoAWSRegion = "DUCKGRES_TRINO_AWS_REGION"
+
+	// envTrinoNamespace overrides provisioner.TrinoCustomerNamespace
+	// for the auth Secret + resource-groups ConfigMap projection. Empty
+	// = default ("trino-customer").
+	envTrinoNamespace = "DUCKGRES_TRINO_NAMESPACE"
+)
+
+// trinoProvisionerEnabled reports whether the control plane should
+// wire the Trino provisioner branch into the provisioning controller.
+// Off by default; matches lakekeeperProvisionerEnabled's gating style.
+func trinoProvisionerEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envTrinoProvisionerEnabled)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// trinoWiring carries the runtime objects multitenant.go has to mount
+// onto the provisioning controller + the API server when the Trino
+// branch is enabled. Returned together so the caller doesn't have to
+// re-derive any of them.
+type trinoWiring struct {
+	Provisioner *provisioner.TrinoProvisioner
+	BundleStore *opa.BundleStore
+	// BundleHandler is the HTTP handler the API server mounts for the
+	// customer-Trino OPA sidecar's bundle plugin to poll. It does its
+	// own bearer-token auth (the bundle exposes the customer roster),
+	// independent of the admin API's internal-secret auth.
+	BundleHandler *opa.Handler
+}
+
+// buildTrinoWiring constructs everything the Trino branch needs from
+// env vars + the supplied configstore-backed reads. Returns nil when
+// the provisioner is disabled (callers should treat this as "skip the
+// Trino branch entirely") and an error when it's enabled but the env
+// is incomplete.
+//
+// The kubernetes.Interface is a typed client suitable for projecting
+// Secrets and ConfigMaps into the customer-Trino namespace. In prod
+// the caller builds it from rest.InClusterConfig(); in dev/test the
+// caller can pass a fake (this function makes no assumptions about
+// the cluster being real).
+func buildTrinoWiring(store *configstore.ConfigStore, kc kubernetes.Interface) (*trinoWiring, error) {
+	if !trinoProvisionerEnabled() {
+		return nil, nil
+	}
+
+	// Required env. Fail fast on missing values rather than letting
+	// the provisioner silently no-op every reconcile tick.
+	coordinatorURL := strings.TrimSpace(os.Getenv(envTrinoCoordinatorURL))
+	if coordinatorURL == "" {
+		return nil, fmt.Errorf("%s is required when %s is set", envTrinoCoordinatorURL, envTrinoProvisionerEnabled)
+	}
+	adminPassword := os.Getenv(envTrinoAdminPassword)
+	adminPasswordHash := os.Getenv(envTrinoAdminPasswordHash)
+	bundleToken := os.Getenv(envTrinoBundleBearerToken)
+	if adminPassword == "" || adminPasswordHash == "" || bundleToken == "" {
+		return nil, errors.New("Trino provisioner enabled but credentials incomplete: " +
+			envTrinoAdminPassword + ", " + envTrinoAdminPasswordHash + ", " +
+			envTrinoBundleBearerToken + " must all be set (the bundle exposes the customer roster; unauthenticated is never correct)")
+	}
+
+	// Verify the plaintext and the bcrypt hash actually correspond.
+	// The two env vars have to be a matched pair: the provisioner
+	// authenticates with the plaintext over HTTP Basic, while Trino's
+	// file authenticator validates against the bcrypt hash. A typo in
+	// either makes every catalog operation fail at runtime with a
+	// confusing 401. Catching it here turns a runtime mystery into a
+	// loud startup failure.
+	if err := bcrypt.CompareHashAndPassword([]byte(adminPasswordHash), []byte(adminPassword)); err != nil {
+		return nil, fmt.Errorf("%s does not match the bcrypt of %s: %w (the two env vars must be a matched pair; regenerate or fix them in your secret)",
+			envTrinoAdminPasswordHash, envTrinoAdminPassword, err)
+	}
+
+	catalogClient := provisioner.NewTrinoCatalogHTTPClient(coordinatorURL, opa.AdminPrincipal, adminPassword)
+	bundleStore := &opa.BundleStore{}
+	bundleHandler := opa.NewHandler(bundleStore, opa.BearerTokenAuth(bundleToken))
+
+	trinoProv, err := provisioner.NewTrinoProvisioner(provisioner.TrinoProvisionerOpts{
+		Store:             store,
+		IcebergStore:      store,
+		Kubernetes:        kc,
+		Namespace:         strings.TrimSpace(os.Getenv(envTrinoNamespace)),
+		Catalog:           catalogClient,
+		BundleStore:       bundleStore,
+		BundleBuilder:     opa.NewBuilder(),
+		AdminPasswordHash: adminPasswordHash,
+		IAMAccountID:      strings.TrimSpace(os.Getenv(envTrinoIAMAccountID)),
+		AWSRegion:         strings.TrimSpace(os.Getenv(envTrinoAWSRegion)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("construct Trino provisioner: %w", err)
+	}
+
+	return &trinoWiring{
+		Provisioner:   trinoProv,
+		BundleStore:   bundleStore,
+		BundleHandler: bundleHandler,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Builds the duckgres-side scaffolding for the customer-facing Trino cluster: configstore schema additions, provisioning-API extensions, and the provisioner sub-component that owns the Trino projection lifecycle.

- **Configstore**: new \`ManagedWarehouseTrino\` model FK'd by \`OrgID\`, GORM auto-migrated. New store methods \`EnableTrino\`, \`DisableTrino\`, \`ListTrinoEnabledOrgs\` (joined with the \`root\` OrgUser so the password-file projection is one query), and a small \`GetManagedWarehouseIceberg\` helper for the Trino catalog properties.
- **Provisioning API**: \`POST /orgs/:id/provision\` accepts an optional \`trino\` block; \`POST /orgs/:id/trino\` and \`DELETE /orgs/:id/trino\` let PostHog toggle Trino on an existing org without touching the underlying Iceberg warehouse.
- **Provisioner sub-component** (\`controlplane/provisioner/trino_provisioner.go\`): owns four idempotent outputs, regenerated every reconcile tick:
  1. Catalog CREATE/DROP via Trino REST (authenticated as \`__admin_provisioner\`), idempotent against \`SHOW CATALOGS\`.
  2. \`password.db\` + \`group.db\` projection into K8s Secret \`trino-auth\` in the \`trino-customer\` namespace. (Will be mounted only into the coordinator pod by the customer-Trino chart additions — see below.)
  3. \`resource-groups.json\` projection into a ConfigMap with tier-based limits, scoped under \`root.tenants.<team_id>\`.
  4. OPA bundle build (via the cross-component contract in \`controlplane/provisioner/opa/\`) + push to the OPA sidecar's bundle API.
- **Controller wiring**: \`WithTrinoProvisioner\` attaches; reconcile is called once per controller tick (batched output, not per-warehouse).

## Cross-component contract with the OPA package

This PR ships a new sub-package \`controlplane/provisioner/opa/\` holding the shared \`UserCatalogs\` map shape and the \`BundleBuilder\` interface. The provisioner constructs itself with \`opa.NewStubBuilder()\` — the sibling PR #622 (OPA Rego + real bundle generator) swaps in the Rego-bundle implementation without touching any plumbing here. If #622 also adds \`opa/types.go\` the two files are byte-identical and merge cleanly.

## Why \`__admin_provisioner\`

OPA must distinguish customer principals (denied for catalog management) from the provisioner itself (allowed for CREATE/DROP CATALOG). The provisioner authenticates to Trino with the reserved principal \`__admin_provisioner\`; the OPA policy in #622 has a carve-out for that exact username. Customer principals can never issue catalog-management SQL.

## Test plan

- [x] Unit tests for the new pure-function projections (auth files, resource-groups JSON, catalog naming, identifier escaping). All deterministic on identical input.
- [x] Unit tests for the full \`Reconcile\` path against fake REST, OPA, Kubernetes clients — covering create, drop-stale, idempotent-when-exists, secret-update-idempotent, and skip-when-Iceberg-not-ready branches.
- [x] Unit tests for the new API endpoints (\`POST /orgs/:id/trino\`, \`DELETE /orgs/:id/trino\`, the \`trino\` block on \`/provision\`).
- [x] All existing tests still pass: \`go test -tags kubernetes ./controlplane/...\`
- [ ] Self-smoke against a live dev cluster: documented in the \`trino_provisioner.go\` comments, but no dev cluster reachable from this worktree; runs alongside the customer-Trino chart additions.

## What's NOT in this PR (sibling work)

- OPA Rego policy + real bundle builder — see PR #622
- Customer-Trino Helm chart additions (ALB, OPA sidecar, auth Secret mount, JMX exporter, event listener) — TBD PR
- Event-listener / Loki / Grafana observability config — TBD PR
- Terraform IAM role + Crossplane composition update — see [posthog-cloud-infra#8291](https://github.com/PostHog/posthog-cloud-infra/pull/8291) and [charts#11322](https://github.com/PostHog/charts/pull/11322)