### PR TITLE
Fix truncation of identifiers longer than 63 bytes in the transpiler

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1347,7 +1347,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 	// Each statement gets its own results, with a single ReadyForQuery at the end.
 	tree, parseErr := pg_query.Parse(query)
 	if parseErr == nil && len(tree.Stmts) > 1 {
-		return c.handleMultiStatementQuery(tree)
+		return c.handleMultiStatementQuery(query)
 	}
 
 	// Transpile PostgreSQL SQL to DuckDB-compatible SQL
@@ -1847,7 +1847,19 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 // each statement gets its own RowDescription/DataRow/CommandComplete messages,
 // with a single ReadyForQuery at the end. If any statement fails, remaining
 // statements are skipped.
-func (c *clientConn) handleMultiStatementQuery(tree *pg_query.ParseResult) error {
+func (c *clientConn) handleMultiStatementQuery(query string) error {
+	// Re-parse with long identifiers protected so that splitting the batch via
+	// Deparse below does not silently truncate names > 63 bytes (see
+	// transpiler/longident.go). executeSingleStatement transpiles each
+	// statement again, which re-applies the same protection.
+	parseSQL, longIdents := transpiler.ProtectLongIdentifiers(query)
+	tree, err := pg_query.Parse(parseSQL)
+	if err != nil {
+		c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
+		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+		_ = c.writer.Flush()
+		return nil
+	}
 	slog.Debug("Multi-statement simple query.", "user", c.username, "count", len(tree.Stmts))
 
 	for _, stmt := range tree.Stmts {
@@ -1860,6 +1872,7 @@ func (c *clientConn) handleMultiStatementQuery(tree *pg_query.ParseResult) error
 			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
 			break
 		}
+		singleSQL = transpiler.RestoreLongIdentifiers(singleSQL, longIdents)
 
 		errSent, fatalErr := c.executeSingleStatement(singleSQL)
 		if fatalErr != nil {

--- a/transpiler/longident.go
+++ b/transpiler/longident.go
@@ -1,0 +1,344 @@
+package transpiler
+
+import (
+	"strconv"
+	"strings"
+)
+
+// maxIdentifierBytes is PostgreSQL's identifier length limit (NAMEDATALEN - 1).
+//
+// libpg_query (the C parser behind pg_query.Parse) inherits PostgreSQL's
+// scanner, which silently truncates any identifier longer than this to its
+// first 63 bytes. DuckDB has no such limit, so a Parse -> Deparse round trip
+// renames e.g. a 65-character table to its 63-character prefix and the
+// subsequent lookup fails with "Table with name ... does not exist".
+//
+// We work around this by swapping over-long identifiers for short, unique
+// placeholders before parsing and restoring them after deparsing, so the
+// truncation never touches a real name.
+const maxIdentifierBytes = 63
+
+// identReplacement records one long identifier that was swapped for a short
+// placeholder before parsing, so it can be restored after deparsing.
+type identReplacement struct {
+	placeholder string // short, parse-safe stand-in (a bare lowercase identifier)
+	original    string // verbatim source token, including surrounding double quotes if quoted
+}
+
+// protectLongIdentifiers scans sql and replaces every identifier whose value
+// exceeds maxIdentifierBytes with a unique short placeholder. It returns the
+// rewritten SQL together with the replacements needed to undo the swap.
+//
+// The scan is SQL-aware: it skips string literals (single-quoted, E-strings,
+// dollar-quoted), comments, and parameter placeholders so that only genuine
+// identifiers (bare or double-quoted) are considered. Identical source tokens
+// reuse the same placeholder.
+//
+// When sql contains no over-long identifier, the input is returned unchanged
+// and the replacement slice is nil, making the common path a no-op.
+func protectLongIdentifiers(sql string) (string, []identReplacement) {
+	// An identifier can only exceed the limit if the whole string does.
+	if len(sql) <= maxIdentifierBytes {
+		return sql, nil
+	}
+
+	// Choose a placeholder prefix that does not already occur in the input so
+	// that restoration (a plain string replace) cannot collide with existing
+	// text. The trailing underscore on each placeholder (added below) keeps
+	// placeholders from being prefixes of one another (e.g. "..._1_" is not a
+	// substring of "..._10_").
+	prefix := "dglongident_"
+	for strings.Contains(sql, prefix) {
+		prefix = "_" + prefix
+	}
+
+	var b strings.Builder
+	b.Grow(len(sql))
+	var repls []identReplacement
+	seen := make(map[string]string) // original token -> placeholder
+	counter := 0
+
+	placeholderFor := func(orig string) string {
+		if ph, ok := seen[orig]; ok {
+			return ph
+		}
+		ph := prefix + strconv.Itoa(counter) + "_"
+		counter++
+		seen[orig] = ph
+		repls = append(repls, identReplacement{placeholder: ph, original: orig})
+		return ph
+	}
+
+	n := len(sql)
+	i := 0
+	for i < n {
+		ch := sql[i]
+		switch {
+		case ch == '-' && i+1 < n && sql[i+1] == '-':
+			// Line comment: skip to end of line.
+			j := i + 2
+			for j < n && sql[j] != '\n' {
+				j++
+			}
+			b.WriteString(sql[i:j])
+			i = j
+
+		case ch == '/' && i+1 < n && sql[i+1] == '*':
+			// Block comment (nestable in PostgreSQL).
+			depth := 1
+			j := i + 2
+			for j < n && depth > 0 {
+				if j+1 < n && sql[j] == '/' && sql[j+1] == '*' {
+					depth++
+					j += 2
+					continue
+				}
+				if j+1 < n && sql[j] == '*' && sql[j+1] == '/' {
+					depth--
+					j += 2
+					continue
+				}
+				j++
+			}
+			b.WriteString(sql[i:j])
+			i = j
+
+		case ch == '\'':
+			// Standard string literal ('' is an escaped quote).
+			j := consumeQuoted(sql, i, false)
+			b.WriteString(sql[i:j])
+			i = j
+
+		case ch == '$':
+			// Dollar-quoted string ($tag$...$tag$) or parameter ($1).
+			if tag, ok := dollarQuoteTag(sql, i); ok {
+				delim := "$" + tag + "$"
+				rest := sql[i+len(delim):]
+				if end := strings.Index(rest, delim); end >= 0 {
+					stop := i + len(delim) + end + len(delim)
+					b.WriteString(sql[i:stop])
+					i = stop
+				} else {
+					// Unterminated: treat the remainder as opaque.
+					b.WriteString(sql[i:])
+					i = n
+				}
+			} else {
+				b.WriteByte(ch)
+				i++
+			}
+
+		case ch == '"':
+			// Double-quoted identifier ("" is an escaped quote).
+			end, value := consumeQuotedIdent(sql, i)
+			tok := sql[i:end]
+			if len(value) > maxIdentifierBytes {
+				b.WriteString(placeholderFor(tok))
+			} else {
+				b.WriteString(tok)
+			}
+			i = end
+
+		case isIdentStart(ch):
+			j := i + 1
+			for j < n && isIdentCont(sql[j]) {
+				j++
+			}
+			tok := sql[i:j]
+			// "E'...'" / "e'...'" introduce a backslash-escaped string. Emit the
+			// introducer, then consume the following string with backslash escapes.
+			if (tok == "E" || tok == "e") && j < n && sql[j] == '\'' {
+				b.WriteString(tok)
+				end := consumeQuoted(sql, j, true)
+				b.WriteString(sql[j:end])
+				i = end
+				continue
+			}
+			if len(tok) > maxIdentifierBytes {
+				b.WriteString(placeholderFor(tok))
+			} else {
+				b.WriteString(tok)
+			}
+			i = j
+
+		default:
+			b.WriteByte(ch)
+			i++
+		}
+	}
+
+	if len(repls) == 0 {
+		return sql, nil
+	}
+	return b.String(), repls
+}
+
+// restoreLongIdentifiers reverses protectLongIdentifiers, substituting each
+// placeholder in sql back to its original token text. It is a no-op when repls
+// is empty.
+//
+// Restoration only replaces a placeholder where it stands alone as a token,
+// i.e. where it is not flanked by identifier characters. This matters because a
+// transform may derive a NEW identifier from a protected one — e.g. the
+// writable-CTE transform builds a temp table name "_cte_<placeholder>_<hex>".
+// Such a derived name embeds the placeholder inside a larger token; replacing it
+// there would splice the original (possibly quoted) text into the middle of an
+// identifier and produce invalid SQL. Leaving it as the (still unique, still
+// valid) placeholder keeps the generated name self-consistent across the
+// CREATE/SELECT/DROP statements that reference it.
+func restoreLongIdentifiers(sql string, repls []identReplacement) string {
+	if len(repls) == 0 {
+		return sql
+	}
+	for _, r := range repls {
+		sql = replaceStandaloneToken(sql, r.placeholder, r.original)
+	}
+	return sql
+}
+
+// replaceStandaloneToken replaces every occurrence of tok in s with repl, but
+// only where tok is not adjacent to an identifier-continuation byte on either
+// side (so it is a whole token rather than a substring of a larger identifier).
+// A surrounding double quote counts as a boundary, so a deparser that quotes the
+// placeholder ("tok") still matches.
+func replaceStandaloneToken(s, tok, repl string) string {
+	if tok == "" {
+		return s
+	}
+	var b strings.Builder
+	for {
+		idx := strings.Index(s, tok)
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		after := idx + len(tok)
+		beforeOK := idx == 0 || !isIdentCont(s[idx-1])
+		afterOK := after >= len(s) || !isIdentCont(s[after])
+		if beforeOK && afterOK {
+			b.WriteString(s[:idx])
+			b.WriteString(repl)
+		} else {
+			// Embedded in a larger identifier — leave it untouched.
+			b.WriteString(s[:after])
+		}
+		s = s[after:]
+	}
+	return b.String()
+}
+
+// IdentReplacement is the exported form of identReplacement, returned by
+// ProtectLongIdentifiers for callers outside this package (e.g. the server's
+// multi-statement path) that parse and deparse SQL directly.
+type IdentReplacement = identReplacement
+
+// ProtectLongIdentifiers exposes protectLongIdentifiers to other packages.
+func ProtectLongIdentifiers(sql string) (string, []IdentReplacement) {
+	return protectLongIdentifiers(sql)
+}
+
+// RestoreLongIdentifiers exposes restoreLongIdentifiers to other packages.
+func RestoreLongIdentifiers(sql string, repls []IdentReplacement) string {
+	return restoreLongIdentifiers(sql, repls)
+}
+
+// restoreLongIdentifiersAll applies restoreLongIdentifiers to each statement in
+// the slice, returning a new slice (or the input unchanged when repls is empty).
+func restoreLongIdentifiersAll(stmts []string, repls []identReplacement) []string {
+	if len(repls) == 0 || len(stmts) == 0 {
+		return stmts
+	}
+	out := make([]string, len(stmts))
+	for i, s := range stmts {
+		out[i] = restoreLongIdentifiers(s, repls)
+	}
+	return out
+}
+
+// consumeQuoted returns the index just past a single-quoted string that starts
+// at the single quote sql[start]. A pair of adjacent single quotes is an
+// embedded quote, not a terminator. When escBackslash is true (E-strings), a
+// backslash escapes the next byte.
+func consumeQuoted(sql string, start int, escBackslash bool) int {
+	n := len(sql)
+	j := start + 1
+	for j < n {
+		c := sql[j]
+		if c == '\\' && escBackslash {
+			j += 2
+			continue
+		}
+		if c == '\'' {
+			if j+1 < n && sql[j+1] == '\'' {
+				j += 2
+				continue
+			}
+			return j + 1
+		}
+		j++
+	}
+	return n // unterminated
+}
+
+// consumeQuotedIdent parses a double-quoted identifier starting at
+// sql[start] == '"'. It returns the index just past the closing quote and the
+// decoded identifier value (with "" collapsed to a single ").
+func consumeQuotedIdent(sql string, start int) (end int, value string) {
+	n := len(sql)
+	var v strings.Builder
+	j := start + 1
+	for j < n {
+		if sql[j] == '"' {
+			if j+1 < n && sql[j+1] == '"' {
+				v.WriteByte('"')
+				j += 2
+				continue
+			}
+			j++ // consume closing quote
+			break
+		}
+		v.WriteByte(sql[j])
+		j++
+	}
+	return j, v.String()
+}
+
+// dollarQuoteTag reports whether sql[start] == '$' begins a dollar-quote
+// opening delimiter ($$ or $tag$) and, if so, returns the tag (possibly empty).
+// A "$" followed by a digit (a parameter like $1) is not a dollar quote.
+func dollarQuoteTag(sql string, start int) (tag string, ok bool) {
+	n := len(sql)
+	j := start + 1
+	if j < n && sql[j] == '$' {
+		return "", true // "$$"
+	}
+	// The tag follows identifier rules but, unlike a normal identifier, it
+	// cannot contain a dollar sign - the next '$' closes the opening delimiter.
+	if j >= n || !isIdentStart(sql[j]) {
+		return "", false
+	}
+	j++
+	for j < n && isIdentCont(sql[j]) && sql[j] != '$' {
+		j++
+	}
+	if j < n && sql[j] == '$' {
+		return sql[start+1 : j], true
+	}
+	return "", false
+}
+
+// isIdentStart reports whether b can begin an SQL identifier. Bytes >= 0x80
+// (multibyte/Unicode identifier characters) are permitted.
+func isIdentStart(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		b >= 0x80
+}
+
+// isIdentCont reports whether b can continue an SQL identifier.
+func isIdentCont(b byte) bool {
+	return isIdentStart(b) ||
+		(b >= '0' && b <= '9') ||
+		b == '$'
+}

--- a/transpiler/longident_test.go
+++ b/transpiler/longident_test.go
@@ -1,0 +1,256 @@
+package transpiler
+
+import (
+	"strings"
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// longName is 65 bytes - the exact production case that triggered the bug:
+// libpg_query truncates it to 63 bytes during Parse.
+const longName = "reports__cohort_user_period_activity_calendar_monthly__4119277097"
+
+func init() {
+	if len(longName) != 65 {
+		panic("longName must be 65 bytes to exercise the 63-byte truncation")
+	}
+}
+
+// roundTrip parses and deparses sql the way the transpiler core does, with
+// long-identifier protection applied. It returns the SQL DuckDB would receive.
+func roundTrip(t *testing.T, sql string) string {
+	t.Helper()
+	protected, repls := protectLongIdentifiers(sql)
+	tree, err := pg_query.Parse(protected)
+	if err != nil {
+		t.Fatalf("parse %q: %v", protected, err)
+	}
+	out, err := pg_query.Deparse(tree)
+	if err != nil {
+		t.Fatalf("deparse: %v", err)
+	}
+	return restoreLongIdentifiers(out, repls)
+}
+
+func TestProtectPreservesLongTableName(t *testing.T) {
+	out := roundTrip(t, "INSERT INTO "+longName+" (a) VALUES (1::regtype)")
+	if !strings.Contains(out, longName) {
+		t.Fatalf("long table name was lost; got: %s", out)
+	}
+}
+
+func TestProtectVariousStatements(t *testing.T) {
+	col := "an_exceedingly_verbose_column_identifier_well_past_the_sixty_three_byte_limit"
+	if len(col) <= maxIdentifierBytes {
+		t.Fatalf("col fixture must exceed the limit")
+	}
+	cases := []string{
+		"SELECT * FROM " + longName + " WHERE id::regtype = 1",
+		"UPDATE " + longName + " SET x = 1 WHERE y::regtype = 2",
+		"DELETE FROM " + longName + " WHERE z IN (1::regtype)",
+		"SELECT " + col + " FROM " + longName,
+		"SELECT a FROM myschema." + longName + " WHERE b::regtype = 1",
+	}
+	for _, sql := range cases {
+		out := roundTrip(t, sql)
+		if !strings.Contains(out, longName) && !strings.Contains(out, col) {
+			t.Errorf("identifier lost for %q -> %q", sql, out)
+		}
+	}
+}
+
+func TestProtectQuotedLongIdentifier(t *testing.T) {
+	quoted := `"` + longName + `"`
+	out := roundTrip(t, "SELECT * FROM "+quoted+" WHERE x::regtype = 1")
+	if !strings.Contains(out, longName) {
+		t.Fatalf("quoted long identifier lost; got: %s", out)
+	}
+}
+
+func TestProtectSkipsStringLiterals(t *testing.T) {
+	// A long sequence inside a string literal must NOT be treated as an
+	// identifier (no placeholder), and must survive verbatim.
+	lit := "'" + longName + "'"
+	sql := "SELECT " + lit + "::regtype"
+	protected, repls := protectLongIdentifiers(sql)
+	if len(repls) != 0 {
+		t.Fatalf("string literal content was wrongly protected: %v", repls)
+	}
+	if protected != sql {
+		t.Fatalf("string literal SQL altered: %q", protected)
+	}
+}
+
+func TestProtectSkipsDollarQuoted(t *testing.T) {
+	sql := "SELECT $tag$" + longName + "$tag$"
+	_, repls := protectLongIdentifiers(sql)
+	if len(repls) != 0 {
+		t.Fatalf("dollar-quoted content wrongly protected: %v", repls)
+	}
+}
+
+func TestProtectSkipsComments(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1 -- " + longName + "\n",
+		"SELECT 1 /* " + longName + " */",
+	} {
+		if _, repls := protectLongIdentifiers(sql); len(repls) != 0 {
+			t.Errorf("comment content wrongly protected for %q: %v", sql, repls)
+		}
+	}
+}
+
+func TestProtectSkipsEString(t *testing.T) {
+	// Backslash-escaped quote inside an E-string must not desync the scanner.
+	sql := "SELECT E'foo\\'" + longName + "' , x"
+	if _, repls := protectLongIdentifiers(sql); len(repls) != 0 {
+		t.Errorf("E-string content wrongly protected: %v", repls)
+	}
+}
+
+func TestProtectNoOpForShortQueries(t *testing.T) {
+	sql := "SELECT * FROM short_table WHERE id = 1"
+	out, repls := protectLongIdentifiers(sql)
+	if out != sql || repls != nil {
+		t.Fatalf("short query should be untouched; got %q, %v", out, repls)
+	}
+}
+
+func TestProtectDedupesRepeatedIdentifier(t *testing.T) {
+	sql := "SELECT * FROM " + longName + " a JOIN " + longName + " b ON a.id = b.id WHERE a.x::regtype = 1"
+	protected, repls := protectLongIdentifiers(sql)
+	if len(repls) != 1 {
+		t.Fatalf("expected 1 unique replacement, got %d", len(repls))
+	}
+	// Placeholder must appear twice in the protected SQL.
+	if n := strings.Count(protected, repls[0].placeholder); n != 2 {
+		t.Fatalf("expected placeholder twice, got %d", n)
+	}
+	if out := restoreLongIdentifiers(protected, repls); strings.Count(out, longName) != 2 {
+		t.Fatalf("restore should yield two occurrences; got: %s", out)
+	}
+}
+
+func TestProtectMultipleDistinctIdentifiers(t *testing.T) {
+	a := "first_table_name_that_is_definitely_longer_than_the_postgres_limit_aaaa"
+	b := "second_table_name_that_is_definitely_longer_than_the_postgres_limit_bb"
+	sql := "SELECT * FROM " + a + " JOIN " + b + " USING (id) WHERE q::regtype = 1"
+	out := roundTrip(t, sql)
+	if !strings.Contains(out, a) || !strings.Contains(out, b) {
+		t.Fatalf("distinct long identifiers lost; got: %s", out)
+	}
+}
+
+// TestPrefixCollisionAvoided ensures the placeholder prefix is bumped when the
+// default prefix already appears in the input.
+func TestPrefixCollisionAvoided(t *testing.T) {
+	sql := "SELECT dglongident_0_ , " + longName + "::regtype"
+	protected, repls := protectLongIdentifiers(sql)
+	if len(repls) != 1 {
+		t.Fatalf("expected 1 replacement, got %d", len(repls))
+	}
+	// The chosen placeholder must not be the literal that already existed,
+	// and restoration must not corrupt the pre-existing token.
+	out := restoreLongIdentifiers(protected, repls)
+	if !strings.Contains(out, "dglongident_0_") {
+		t.Fatalf("pre-existing token corrupted: %s", out)
+	}
+	if !strings.Contains(out, longName) {
+		t.Fatalf("long identifier lost: %s", out)
+	}
+}
+
+// TestRestoreLeavesEmbeddedPlaceholder verifies boundary-aware restoration: a
+// placeholder embedded inside a larger identifier (as the writable-CTE transform
+// does when it builds "_cte_<placeholder>_<hex>") must NOT be substituted, since
+// splicing the original token there would corrupt the generated name.
+func TestRestoreLeavesEmbeddedPlaceholder(t *testing.T) {
+	_, repls := protectLongIdentifiers("SELECT * FROM " + longName)
+	if len(repls) != 1 {
+		t.Fatalf("want 1 replacement, got %d", len(repls))
+	}
+	ph := repls[0].placeholder
+	embedded := "_cte_" + ph + "_deadbeef"
+	standalone := "SELECT * FROM " + ph + " JOIN " + embedded + " USING (id)"
+	got := restoreLongIdentifiers(standalone, repls)
+	want := "SELECT * FROM " + longName + " JOIN _cte_" + ph + "_deadbeef USING (id)"
+	if got != want {
+		t.Fatalf("boundary-aware restore wrong:\n got:  %s\n want: %s", got, want)
+	}
+}
+
+// TestWritableCTELongNameProducesValidSQL exercises the full path that motivated
+// boundary-aware restoration: a writable CTE whose (quoted, special-char) name
+// exceeds 63 bytes must still deparse to valid SQL.
+func TestWritableCTELongNameProducesValidSQL(t *testing.T) {
+	cte := `"My CTE With Spaces And Punctuation!! that runs well past sixty-three bytes"`
+	sql := "WITH " + cte + " AS (DELETE FROM t RETURNING id) SELECT * FROM " + cte
+	tr := New(Config{DuckLakeMode: true})
+	res, err := tr.Transpile(sql)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Statements) == 0 {
+		t.Fatalf("expected a multi-statement rewrite; got SQL: %s", res.SQL)
+	}
+	for i, s := range res.Statements {
+		if _, perr := pg_query.Parse(s); perr != nil {
+			t.Errorf("statement %d is invalid SQL: %v\n  %s", i, perr, s)
+		}
+	}
+}
+
+// TestProtectNeverPanicsAndIsSafe feeds adversarial inputs (unterminated quotes,
+// nested comments, multibyte runs, adjacent placeholders) to make sure the
+// scanner always terminates without panicking and that, whenever the protected
+// SQL re-parses, restoration brings back the original long names.
+func TestProtectNeverPanicsAndIsSafe(t *testing.T) {
+	long := strings.Repeat("a", 80)
+	mb := strings.Repeat("é", 40) // 80 bytes, 40 runes
+	inputs := []string{
+		"",
+		"SELECT 1",
+		"SELECT * FROM " + long,
+		"SELECT '" + long + "",                     // unterminated string
+		`SELECT "` + long,                          // unterminated quoted ident
+		"SELECT $tag$" + long,                      // unterminated dollar quote
+		"SELECT /* " + long,                        // unterminated block comment
+		"SELECT E'\\'" + long,                      // E-string with trailing escape
+		"SELECT " + mb + " FROM t",                 // multibyte identifier
+		"SELECT " + long + "$" + long,              // '$' inside identifier run
+		"SELECT $$" + long + "$$, " + long,         // dollar body then real ident
+		"-- " + long + "\nSELECT " + long,          // comment then ident
+		"SELECT " + long + "," + long + "," + long, // many adjacent
+	}
+	for _, in := range inputs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic on %q: %v", in, r)
+				}
+			}()
+			protected, repls := protectLongIdentifiers(in)
+			// Restoration must always reproduce the input exactly.
+			if got := restoreLongIdentifiers(protected, repls); got != in {
+				t.Errorf("round-trip mismatch for %q:\n got %q", in, got)
+			}
+		}()
+	}
+}
+
+// TestTranspilerEndToEndLongName verifies the fix through the public Transpile
+// entry point using a query that forces Tier-1 parsing (the ::regtype cast).
+func TestTranspilerEndToEndLongName(t *testing.T) {
+	tr := New(Config{})
+	res, err := tr.Transpile("INSERT INTO " + longName + " (a) VALUES (1::regtype)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FallbackToNative {
+		t.Fatalf("unexpected fallback; SQL: %s", res.SQL)
+	}
+	if !strings.Contains(res.SQL, longName) {
+		t.Fatalf("Transpile truncated the table name; got: %s", res.SQL)
+	}
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -189,8 +189,15 @@ func (t *Transpiler) TranspileAll(sql string) (*Result, error) {
 
 // transpileWithFlags parses the SQL and applies only transforms whose flag is set.
 func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Result, error) {
+	// Protect identifiers longer than PostgreSQL's NAMEDATALEN limit from being
+	// silently truncated by libpg_query during Parse/Deparse (see longident.go).
+	// We parse the placeholdered SQL, then restore the originals on any SQL we
+	// emit from the resulting AST. Paths that return the original `sql` need no
+	// restoration since `sql` is never the placeholdered form.
+	parseSQL, longIdents := protectLongIdentifiers(sql)
+
 	// Parse the SQL into an AST
-	tree, err := pg_query.Parse(sql)
+	tree, err := pg_query.Parse(parseSQL)
 	if err != nil {
 		// PostgreSQL parsing failed - signal that we should try native DuckDB execution
 		// Count parameters using regex since we can't use the AST
@@ -232,8 +239,8 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 		if len(transformResult.Statements) > 0 {
 			return &Result{
 				SQL:               sql, // Keep original for logging
-				Statements:        transformResult.Statements,
-				CleanupStatements: transformResult.CleanupStatements,
+				Statements:        restoreLongIdentifiersAll(transformResult.Statements, longIdents),
+				CleanupStatements: restoreLongIdentifiersAll(transformResult.CleanupStatements, longIdents),
 				ParamCount:        transformResult.ParamCount,
 			}, nil
 		}
@@ -258,7 +265,7 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 
 	if transformResult.SQLOverride != "" {
 		return &Result{
-			SQL:          transformResult.SQLOverride,
+			SQL:          restoreLongIdentifiers(transformResult.SQLOverride, longIdents),
 			ParamCount:   transformResult.ParamCount,
 			IsNoOp:       transformResult.IsNoOp,
 			NoOpTag:      transformResult.NoOpTag,
@@ -271,6 +278,7 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 	if err != nil {
 		return nil, err
 	}
+	deparsed = restoreLongIdentifiers(deparsed, longIdents)
 
 	return &Result{
 		SQL:          deparsed,


### PR DESCRIPTION
## Problem

After upgrading 0.4 → 1.0, queries against tables whose names exceed **63 bytes** fail with errors like:

```
Catalog Error: Table with name reports__cohort_user_period_activity_calendar_monthly__41192770 does not exist!
Did you mean "reports__cohort_user_period_activity_calendar_monthly__4119277097"?
```

Note the requested name is exactly **63 chars** while the real table is **65** — a classic PostgreSQL `NAMEDATALEN` truncation.

## Root cause

The 0.4 → 1.0 upgrade replaced regex-based query rewriting with an **AST-based transpiler** (`fe9d446`). The transpiler parses SQL with `pg_query_go` → libpg_query, which is PostgreSQL's own C scanner and enforces `NAMEDATALEN` (63 bytes), silently truncating any longer identifier during `Parse`. DuckDB has no such limit, so a `Parse → Deparse` round trip renames the table to its 63-char prefix and the lookup fails.

This only triggers for queries that take the transpiler's full parse path (i.e. that contain a PostgreSQL-specific feature such as a `::regtype` cast, a pg function, `public.`, etc.). Plain queries bypass the parser and were unaffected — which is why it looked size/shape dependent.

## Fix

`transpiler/longident.go` swaps any identifier longer than 63 bytes for a short, unique placeholder **before** parsing, then restores the originals on the SQL emitted from the AST. The scan is SQL-aware — it skips string literals, E-strings, dollar-quoted bodies, comments, and `$N` parameters, and handles both bare and `"double-quoted"` identifiers. For normal short queries it is a no-op (early return).

Wired into:
- `transpiler/transpiler.go` `transpileWithFlags` — the core path used by every `Transpile()` caller, including the control-plane Flight path, prepared statements, and writable-CTE / SQL-override rewrites.
- `server/conn.go` `handleMultiStatementQuery` — a separate standalone-mode deparse that also truncated.

## Tests

- New `transpiler/longident_test.go` covers the production case, bare/quoted/qualified identifiers, dedup, multiple distinct names, placeholder-prefix collision avoidance, and that string/dollar/comment/E-string contents are **not** mis-protected.
- End-to-end (validated locally against a real DuckDB, not committed to keep the transpiler package driver-free): create the 65-char table → transpile a query that forces the parse path → DuckDB finds it. Fails on `main`, passes here.
- Full `transpiler/...` and `server/` suites pass; `gofmt`/`go vet` clean.

## Known residual (out of scope)

A server-side cursor whose **inner** SELECT references a >63-char table still truncates, because it deparses from a tree parsed upstream. It's a narrow edge case; can be a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)