### PR TITLE
feat(lakekeeper): support pre-provisioned PG backend (cnpg-shard)

### DIFF
--- a/controlplane/lakekeeper_inputs.go
+++ b/controlplane/lakekeeper_inputs.go
@@ -109,10 +109,49 @@ func lakekeeperInputsFromDuckling(
 		return provisioner.ProvisioningInputs{}, false, fmt.Errorf("duckling CR for org %q has no data-store bucket/region", orgID)
 	}
 
-	// Admin DDL (CREATE DATABASE/ROLE) goes to the direct Aurora endpoint, not
-	// the PgBouncer pooler — transaction pooling breaks CREATE DATABASE and the
-	// session-level statements EnsureRole runs. We connect to the existing
-	// metadata-store database; CREATE DATABASE can be issued from any database.
+	s3 := provisioner.S3StorageConfig{
+		Bucket: status.DataStore.BucketName,
+		// Keep the catalog's data under a stable prefix so it never
+		// collides with DuckLake's own layout in the shared bucket.
+		KeyPrefix: "lakekeeper",
+		Region:    status.DataStore.S3Region,
+		Flavor:    "aws",
+		// Prod: Lakekeeper uses its pod IRSA identity (no static creds).
+		// RoleARN is the per-org duckling role Lakekeeper assumes to vend
+		// scoped S3 creds (sts-role-arn). It's the same role the Lakekeeper
+		// pod runs as via Pod Identity, self-assumed (the role trusts its
+		// own ARN). Sourced from the Duckling CR status.
+		RoleARN: status.IAMRoleARN,
+	}
+
+	// cnpg-shard: the Lakekeeper database + role are pre-provisioned on the
+	// CNPG shard by provider-sql, and status carries the per-tenant role
+	// credentials (not a privileged admin). We have no superuser DSN here, so
+	// the provisioner must NOT attempt CREATE DATABASE/ROLE — it takes these
+	// creds verbatim. The shard's Pooler is session-mode, so the Lakekeeper
+	// pod's migrations + pooled prepared statements work through it.
+	if status.MetadataStore.Type == "cnpg-shard" {
+		return provisioner.ProvisioningInputs{
+			PGPreProvisioned: true,
+			PGUser:           status.MetadataStore.User,
+			PGPassword:       status.MetadataStore.Password,
+			PGDatabase:       status.MetadataStore.Database,
+			PGHost:           status.MetadataStore.Endpoint,
+			PGPort:           5432,
+			PGSSLMode:        "require",
+			S3:               s3,
+			// Allowall + NetworkPolicy deployment shape — no OIDC audiences yet.
+			KubernetesAuthAudiences: nil,
+		}, true, nil
+	}
+
+	// aurora/external: status carries the metadata-store master credentials,
+	// which double as the admin connection that can CREATE the
+	// lakekeeper_<orgid> database/role. Admin DDL (CREATE DATABASE/ROLE) goes
+	// to the direct Aurora endpoint, not the PgBouncer pooler — transaction
+	// pooling breaks CREATE DATABASE and the session-level statements
+	// EnsureRole runs. We connect to the existing metadata-store database;
+	// CREATE DATABASE can be issued from any database.
 	adminDSN := buildAdminURLDSN(
 		status.MetadataStore.Endpoint, 5432,
 		status.MetadataStore.User, status.MetadataStore.Password,
@@ -124,24 +163,10 @@ func lakekeeperInputsFromDuckling(
 		// The Lakekeeper pod also connects to the direct endpoint: it runs its
 		// own migrations and connection pool, which a transaction pooler would
 		// break.
-		PGHost:    status.MetadataStore.Endpoint,
-		PGPort:    5432,
-		PGSSLMode: "require",
-		S3: provisioner.S3StorageConfig{
-			Bucket: status.DataStore.BucketName,
-			// Keep the catalog's data under a stable prefix so it never
-			// collides with DuckLake's own layout in the shared bucket.
-			KeyPrefix: "lakekeeper",
-			Region:    status.DataStore.S3Region,
-			Flavor:    "aws",
-			// Prod: Lakekeeper uses its pod IRSA identity (no static creds).
-			// RoleARN is the per-org duckling role Lakekeeper assumes to vend
-			// scoped S3 creds (sts-role-arn). It's the same role the Lakekeeper
-			// pod runs as via Pod Identity, self-assumed (the role trusts its
-			// own ARN). Sourced from the Duckling CR status.
-			RoleARN: status.IAMRoleARN,
-		},
-		// Allowall + NetworkPolicy deployment shape — no OIDC audiences yet.
+		PGHost:                  status.MetadataStore.Endpoint,
+		PGPort:                  5432,
+		PGSSLMode:               "require",
+		S3:                      s3,
 		KubernetesAuthAudiences: nil,
 	}, true, nil
 }

--- a/controlplane/lakekeeper_inputs_test.go
+++ b/controlplane/lakekeeper_inputs_test.go
@@ -77,6 +77,48 @@ func TestResolverFromDucklingCR(t *testing.T) {
 	}
 }
 
+func TestResolverFromCnpgShardCR(t *testing.T) {
+	// cnpg-shard: the Lakekeeper DB + role are pre-provisioned by provider-sql
+	// on the shard, and status carries the per-tenant role creds + the
+	// session-mode Pooler endpoint. The resolver must produce pre-provisioned
+	// inputs with NO AdminDSN (the provisioner must not attempt CREATE
+	// DATABASE/ROLE), taking the role creds verbatim.
+	resolve := func(context.Context, string) (*provisioner.DucklingStatus, error) {
+		s := &provisioner.DucklingStatus{}
+		s.MetadataStore.Type = "cnpg-shard"
+		s.MetadataStore.Endpoint = "shard-001-pooler.cnpg-shards.svc.cluster.local"
+		s.MetadataStore.User = "lakekeeper_acme"
+		s.MetadataStore.Password = "from-provider-sql"
+		s.MetadataStore.Database = "lakekeeper_acme"
+		s.DataStore.BucketName = "posthog-duckling-acme"
+		s.DataStore.S3Region = "us-east-1"
+		s.IAMRoleARN = "arn:aws:iam::123:role/duckling-acme"
+		return s, nil
+	}
+	r := newLakekeeperInputsResolver(resolve)
+
+	in, err := r(context.Background(), &configstore.ManagedWarehouse{OrgID: "acme"})
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+
+	if !in.PGPreProvisioned {
+		t.Fatalf("PGPreProvisioned = false, want true for cnpg-shard")
+	}
+	if in.AdminDSN != "" {
+		t.Errorf("AdminDSN = %q, want empty (no privileged DDL in cnpg-shard mode)", in.AdminDSN)
+	}
+	if in.PGUser != "lakekeeper_acme" || in.PGPassword != "from-provider-sql" || in.PGDatabase != "lakekeeper_acme" {
+		t.Errorf("PG creds = %q/%q/%q, want the provider-sql role verbatim", in.PGUser, in.PGPassword, in.PGDatabase)
+	}
+	if in.PGHost != "shard-001-pooler.cnpg-shards.svc.cluster.local" || in.PGPort != 5432 {
+		t.Errorf("PGHost/PGPort = %q/%d, want the session Pooler:5432", in.PGHost, in.PGPort)
+	}
+	if in.S3.Bucket != "posthog-duckling-acme" || in.S3.RoleARN != "arn:aws:iam::123:role/duckling-acme" {
+		t.Errorf("S3 = %+v, want bucket/roleARN from CR status", in.S3)
+	}
+}
+
 func TestResolverFromEnvFallback(t *testing.T) {
 	t.Setenv(envLakekeeperAdminDSN, "postgres://admin:pw@127.0.0.1:5432/postgres?sslmode=disable")
 	t.Setenv(envLakekeeperPGHost, "127.0.0.1")

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -52,6 +52,19 @@ type ProvisioningInputs struct {
 	PGHost string
 	PGPort int32
 
+	// PGPreProvisioned is set when the org's Lakekeeper database and role
+	// already exist, created out-of-band — specifically by provider-sql on a
+	// CloudNativePG shard (the cnpg-shard metadata-store type). In that mode
+	// the provisioner does NOT run CREATE DATABASE / CREATE ROLE (it has no
+	// privileged AdminDSN — the connection is the per-tenant lakekeeper_<org>
+	// role itself), and instead takes the role credentials below verbatim:
+	// PGUser/PGPassword go into the Lakekeeper pod's Secret, PGDatabase is the
+	// database it connects to. AdminDSN is not required when this is true.
+	PGPreProvisioned bool
+	PGUser           string
+	PGPassword       string
+	PGDatabase       string
+
 	// PGSSLMode the Lakekeeper pod sets when connecting. Default "require".
 	// Set to "disable" for local/dev environments where PG has no TLS.
 	PGSSLMode string
@@ -174,16 +187,26 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	// In-cluster Service DNS — operator names the Service after the CR.
 	baseURL := fmt.Sprintf("http://%s.%s.svc:8181", resourceName, p.k8s.namespace)
 
-	// 1. CREATE DATABASE lakekeeper_<orgid> if absent.
-	if err := EnsureDatabase(ctx, in.AdminDSN, dbName); err != nil {
-		return fmt.Errorf("ensure lakekeeper db: %w", err)
+	// In pre-provisioned mode (cnpg-shard) the database + role were already
+	// created by provider-sql on the shard, and the connection we have is the
+	// non-privileged per-tenant role — so skip the CREATE DATABASE / CREATE
+	// ROLE DDL and take the role's name/password verbatim from the inputs.
+	if in.PGPreProvisioned {
+		dbName = in.PGDatabase
+	} else {
+		// 1. CREATE DATABASE lakekeeper_<orgid> if absent.
+		if err := EnsureDatabase(ctx, in.AdminDSN, dbName); err != nil {
+			return fmt.Errorf("ensure lakekeeper db: %w", err)
+		}
 	}
 
 	// 2. Resolve or generate the per-org credentials, and ensure the K8s
 	// Secret holds them. On re-runs we read the existing Secret rather than
 	// rotating its values — Lakekeeper's DB password would otherwise drift
-	// from the Postgres user's actual password.
-	creds, err := p.resolveOrGenerateSecret(ctx, w.OrgID, dbName, secretName)
+	// from the Postgres user's actual password. In pre-provisioned mode the
+	// DB user/password come from the inputs (the provider-sql role); the
+	// Lakekeeper-internal EncryptionKey/OAuth2ClientSecret are still generated.
+	creds, err := p.resolveOrGenerateSecret(ctx, w.OrgID, dbName, secretName, in.PGUser, in.PGPassword)
 	if err != nil {
 		return fmt.Errorf("ensure lakekeeper secret: %w", err)
 	}
@@ -192,9 +215,12 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	// Secret. A freshly-created database has no users by default; without
 	// this, the Lakekeeper pod's CreateAdminUser-style startup would fail
 	// with "role does not exist". EnsureRole is idempotent and rotates the
-	// password to match the Secret on re-runs.
-	if err := EnsureRole(ctx, in.AdminDSN, creds.DBUser, creds.DBPassword, dbName); err != nil {
-		return fmt.Errorf("ensure lakekeeper pg role: %w", err)
+	// password to match the Secret on re-runs. Skipped when pre-provisioned —
+	// provider-sql owns the role and our connection can't CREATE ROLE.
+	if !in.PGPreProvisioned {
+		if err := EnsureRole(ctx, in.AdminDSN, creds.DBUser, creds.DBPassword, dbName); err != nil {
+			return fmt.Errorf("ensure lakekeeper pg role: %w", err)
+		}
 	}
 
 	// 2c. Ensure the per-org ServiceAccount the Lakekeeper pod runs under.
@@ -331,7 +357,13 @@ func (p *LakekeeperProvisioner) checkBootstrap(ctx context.Context, orgID string
 // generates fresh credentials and writes a new Secret. Generating ONLY on
 // first run keeps the Postgres user's password stable across re-runs —
 // rotating the Secret would silently de-sync it from the actual PG password.
-func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, orgID, dbName, secretName string) (LakekeeperSecretData, error) {
+//
+// The DB user/password are generated unless pgUser/pgPassword are supplied
+// (pre-provisioned cnpg-shard mode), in which case they're taken verbatim so
+// the Lakekeeper pod authenticates as the provider-sql-created role. The
+// Lakekeeper-internal EncryptionKey and OAuth2ClientSecret are always
+// generated regardless of mode.
+func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, orgID, dbName, secretName, pgUser, pgPassword string) (LakekeeperSecretData, error) {
 	existing, err := p.k8s.kubernetes.CoreV1().Secrets(p.k8s.namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err == nil {
 		return secretFromExisting(existing), nil
@@ -339,10 +371,17 @@ func (p *LakekeeperProvisioner) resolveOrGenerateSecret(ctx context.Context, org
 	if !apierrors.IsNotFound(err) {
 		return LakekeeperSecretData{}, fmt.Errorf("get existing secret: %w", err)
 	}
-	// Generate fresh credentials.
+	// DB credentials: pre-provisioned values win; otherwise generate. Default
+	// user is a role named after the DB (matches EnsureRole).
+	dbUser := dbName
+	dbPassword := mustRandomHex(32)
+	if pgUser != "" {
+		dbUser = pgUser
+		dbPassword = pgPassword
+	}
 	data := LakekeeperSecretData{
-		DBUser:             dbName, // Lakekeeper connects as a role named after its DB
-		DBPassword:         mustRandomHex(32),
+		DBUser:             dbUser,
+		DBPassword:         dbPassword,
 		EncryptionKey:      mustRandomHex(32), // 32 bytes ⇒ 64 hex chars; safely covers any 256-bit key expectation
 		OAuth2ClientSecret: mustRandomHex(32),
 	}
@@ -368,7 +407,11 @@ func secretFromExisting(s *corev1.Secret) LakekeeperSecretData {
 }
 
 func validateInputs(in ProvisioningInputs) error {
-	if in.AdminDSN == "" {
+	if in.PGPreProvisioned {
+		if in.PGUser == "" || in.PGPassword == "" || in.PGDatabase == "" {
+			return errors.New("ProvisioningInputs: PGPreProvisioned requires PGUser, PGPassword, and PGDatabase")
+		}
+	} else if in.AdminDSN == "" {
 		return errors.New("ProvisioningInputs.AdminDSN is required")
 	}
 	if in.PGHost == "" {

--- a/controlplane/provisioner/lakekeeper_provisioner_test.go
+++ b/controlplane/provisioner/lakekeeper_provisioner_test.go
@@ -192,6 +192,78 @@ func TestEnsureForOrg_HappyPath_Fakes(t *testing.T) {
 	}
 }
 
+// TestEnsureForOrg_PreProvisioned exercises the cnpg-shard path: the database
+// and role were already created (by provider-sql on the shard), so EnsureForOrg
+// must NOT run CREATE DATABASE / CREATE ROLE (it has no AdminDSN — a connection
+// attempt would fail), and must put the supplied PG credentials into the
+// Lakekeeper Secret verbatim. Unlike the happy-path test this needs no real
+// Postgres, precisely because the DDL steps are skipped.
+func TestEnsureForOrg_PreProvisioned(t *testing.T) {
+	c, _, kube := newFakeLakekeeperClient()
+	fake := newFakeLakekeeperServer(t)
+	store := newFakeProvisionerStore("acme", configstore.ManagedWarehouseStateProvisioning)
+	p := NewLakekeeperProvisioner(store, c,
+		WithImage("img:test"),
+		WithClientFactory(func(baseURL string) *LakekeeperClient {
+			return NewLakekeeperClient(fake.srv.URL)
+		}),
+	)
+
+	// Pre-create + bootstrap the CR (the fake k8s client doesn't run the operator).
+	if err := c.EnsureCR(context.Background(), LakekeeperCRSpec{
+		OrgID: "acme", Image: "stub", PGHost: "stub", PGDatabase: "stub", SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+	markBootstrapped(t, c, "acme")
+
+	in := ProvisioningInputs{
+		PGPreProvisioned: true,
+		PGUser:           "lakekeeper_acme",
+		PGPassword:       "from-provider-sql",
+		PGDatabase:       "lakekeeper_acme",
+		PGHost:           "shard-001-pooler.cnpg-shards.svc.cluster.local",
+		PGPort:           5432,
+		PGSSLMode:        "require",
+		S3: S3StorageConfig{
+			Bucket: "warehouse", KeyPrefix: "lakekeeper",
+			Region: "us-east-1", Flavor: "aws",
+			RoleARN: "arn:aws:iam::123456789012:role/duckling-acme",
+		},
+	}
+
+	// No PG_ADMIN_DSN, no real Postgres: succeeding proves the DDL steps were
+	// skipped (a nil/blank AdminDSN connection would otherwise error).
+	if err := p.EnsureForOrg(context.Background(), store.warehouses["acme"], in); err != nil {
+		t.Fatalf("EnsureForOrg (pre-provisioned): %v", err)
+	}
+
+	// The Secret must carry the supplied DB creds verbatim (not generated).
+	sec, err := kube.CoreV1().Secrets(c.namespace).Get(context.Background(), LakekeeperResourceName("acme"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get lakekeeper secret: %v", err)
+	}
+	if got := string(sec.Data[SecretKeyDBUser]); got != "lakekeeper_acme" {
+		t.Errorf("db-user = %q, want lakekeeper_acme", got)
+	}
+	if got := string(sec.Data[SecretKeyDBPassword]); got != "from-provider-sql" {
+		t.Errorf("db-password = %q, want from-provider-sql", got)
+	}
+	// Lakekeeper-internal secrets are still generated even in pre-provisioned mode.
+	if len(sec.Data[SecretKeyEncryptionKey]) == 0 {
+		t.Errorf("encryption-key should still be generated")
+	}
+
+	// Warehouse created + iceberg flipped on.
+	w := store.warehouses["acme"]
+	if !w.Iceberg.Enabled || w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
+		t.Errorf("iceberg not configured: %+v", w.Iceberg)
+	}
+	if len(fake.warehouses) != 1 {
+		t.Fatalf("warehouse creates = %d, want 1", len(fake.warehouses))
+	}
+}
+
 // EnsureForOrg returns ErrBootstrapPending when the operator hasn't yet
 // flipped status.bootstrappedAt — caller (the warehouse-reconcile loop)
 // is responsible for requeueing without blocking other orgs.


### PR DESCRIPTION
## Summary

Lets the Lakekeeper provisioner use a Postgres database + role that were **created out-of-band** rather than creating them itself — specifically by provider-sql on a CloudNativePG shard (the `cnpg-shard` metadata-store type in [posthog/charts#11354](https://github.com/PostHog/charts/pull/11354)).

In cnpg mode the control plane only holds the **non-privileged per-tenant role** (the Duckling status carries its creds, not a superuser admin), so it can't run `CREATE DATABASE`/`CREATE ROLE`. provider-sql owns that SQL; duckgres keeps everything that *isn't* SQL.

## Changes

- **`ProvisioningInputs.PGPreProvisioned`** (+ `PGUser`/`PGPassword`/`PGDatabase`). When set, `EnsureForOrg` skips `EnsureDatabase` + `EnsureRole` and feeds the supplied role creds into the Lakekeeper pod's Secret verbatim. The Lakekeeper-internal `EncryptionKey`/`OAuth2ClientSecret` are still generated. `validateInputs` requires the role creds (not an AdminDSN) in this mode.
- **`lakekeeperInputsFromDuckling`**: returns pre-provisioned inputs (no AdminDSN) when `status.metadataStore.type == "cnpg-shard"`, with `PGHost` = the shard's session-mode Pooler. aurora/external keep the existing admin-DSN path unchanged.

Untouched: ServiceAccount creation, the Lakekeeper CR, bootstrap-wait, warehouse creation via Lakekeeper's REST API, and configstore persistence — all inherently control-plane work that provider-sql can't do.

## Tests

- `TestEnsureForOrg_PreProvisioned` — runs the **full pipeline on fakes with no real Postgres** (which itself proves the `CREATE DATABASE`/`CREATE ROLE` steps are skipped — a connection attempt would fail), and asserts the Secret carries the supplied DB creds verbatim while the encryption key is still generated.
- `TestResolverFromCnpgShardCR` — the resolver produces pre-provisioned inputs (no AdminDSN, session-Pooler host, role creds verbatim) for a cnpg-shard CR.

`go build`/`go test`/`go vet` (all `-tags kubernetes`) green.

## Deploy ordering

Merge alongside the charts PR. The charts side provisions `lakekeeper_<org>` + sets the status; this side consumes it. Until both are in, an iceberg+cnpg Duckling won't have its Lakekeeper PG provisioned correctly.