### PR TITLE
feat(controlplane): cnpg-shard (iceberg/Lakekeeper) is the only provisionable backend

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -75,6 +75,17 @@ type ManagedWarehouseDatabase struct {
 	Username     string `gorm:"size:255" json:"username"`
 }
 
+// Metadata-store kinds, stored verbatim in ManagedWarehouseMetadataStore.Kind
+// and mirrored onto the Duckling CR's spec.metadataStore.type. These are the
+// only backends the control plane creates: "external" is deliberately absent
+// (external metadata stores are applied out-of-band, never provisioned here),
+// and "cnpg-shard" backs the per-tenant Lakekeeper Iceberg catalog on the
+// shared CloudNativePG shard (always paired with iceberg.enabled=true).
+const (
+	MetadataStoreKindAurora    = "aurora"
+	MetadataStoreKindCnpgShard = "cnpg-shard"
+)
+
 // ManagedWarehouseMetadataStore stores org-scoped DuckLake metadata DB info.
 type ManagedWarehouseMetadataStore struct {
 	Kind         string `gorm:"size:64" json:"kind"`

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -181,11 +181,12 @@ func (c *Controller) reconcilePending(ctx context.Context, w *configstore.Manage
 		"pgbouncer_enabled", w.PgBouncer.Enabled,
 		"iceberg_enabled", w.Iceberg.Enabled)
 	if err := c.duckling.Create(ctx, w.OrgID, CreateOptions{
-		MinACU:           w.AuroraMinACU,
-		MaxACU:           w.AuroraMaxACU,
-		PgBouncerEnabled: w.PgBouncer.Enabled,
-		IcebergEnabled:   w.Iceberg.Enabled,
-		IcebergNamespace: w.Iceberg.Namespace,
+		MetadataStoreType: w.MetadataStore.Kind,
+		MinACU:            w.AuroraMinACU,
+		MaxACU:            w.AuroraMaxACU,
+		PgBouncerEnabled:  w.PgBouncer.Enabled,
+		IcebergEnabled:    w.Iceberg.Enabled,
+		IcebergNamespace:  w.Iceberg.Namespace,
 	}); err != nil {
 		log.Error("Failed to create Duckling CR.", "error", err)
 		_ = c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStatePending, map[string]interface{}{
@@ -336,6 +337,18 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 			log.Warn("Failed to update warehouse state.", "error", err)
 		}
 	}
+
+	// Provision the per-org Lakekeeper as part of turn-up, not only as a
+	// post-Ready late-enable. A cnpg-shard Duckling is required by the XRD to
+	// have iceberg.enabled=true, so its warehouse can never reach Ready until
+	// iceberg_state flips — and for the Lakekeeper backend that only happens
+	// once EnsureForOrg has stood the catalog up (there's no S3 Tables bucket
+	// whose ARN would otherwise trigger it). reconcileLakekeeper is idempotent,
+	// no-ops for non-Lakekeeper backends, and returns quietly until the
+	// Duckling status carries the metadata creds and the Lakekeeper CR has
+	// bootstrapped; the poll loop is the requeue. The iceberg_state=Ready it
+	// writes is picked up by the readiness check on a subsequent tick.
+	c.reconcileLakekeeper(ctx, w)
 }
 
 // reconcileReady handles drift correction for Ready warehouses. The
@@ -452,7 +465,10 @@ func applyIcebergUpdatesToWarehouse(w *configstore.ManagedWarehouse, updates map
 }
 
 // reconcileLakekeeper provisions a per-org Lakekeeper instance when the
-// warehouse selects the lakekeeper backend and isn't yet provisioned.
+// warehouse selects the lakekeeper backend and isn't yet provisioned. Called
+// from both reconcileProvisioning (initial turn-up — required for cnpg-shard,
+// which must have iceberg enabled and so can't reach Ready until the catalog
+// is up) and reconcileReady (late-enable on an already-Ready warehouse).
 // Idempotent: a warehouse with LakekeeperEndpoint already populated is a
 // no-op. ErrBootstrapPending from the underlying EnsureForOrg is logged
 // at debug and treated as "retry on the next tick" — the controller's

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -572,7 +572,7 @@ func TestReconcileProvisioningAllReady(t *testing.T) {
 	dc, fakeK8s := newFakeDucklingClient()
 	fs := newFakeStore()
 	fs.warehouses["org-b"] = &configstore.ManagedWarehouse{
-		OrgID:  "org-b",
+		OrgID:     "org-b",
 		State:     configstore.ManagedWarehouseStateProvisioning,
 		CreatedAt: time.Now(),
 	}
@@ -808,7 +808,7 @@ func TestReconcileDeletingDeletesCR(t *testing.T) {
 	fs := newFakeStore()
 	fs.warehouses["org-c"] = &configstore.ManagedWarehouse{
 		OrgID: "org-c",
-		State:    configstore.ManagedWarehouseStateDeleting,
+		State: configstore.ManagedWarehouseStateDeleting,
 	}
 	ctx := context.Background()
 
@@ -851,7 +851,7 @@ func TestReconcileDeletingRetriesOnNonNotFoundError(t *testing.T) {
 	fs := newFakeStore()
 	fs.warehouses["org-d"] = &configstore.ManagedWarehouse{
 		OrgID: "org-d",
-		State:    configstore.ManagedWarehouseStateDeleting,
+		State: configstore.ManagedWarehouseStateDeleting,
 	}
 	ctx := context.Background()
 
@@ -938,7 +938,7 @@ func TestFakeStoreUpdateWarehouseState(t *testing.T) {
 	fs := newFakeStore()
 	fs.warehouses["org-x"] = &configstore.ManagedWarehouse{
 		OrgID: "org-x",
-		State:    configstore.ManagedWarehouseStatePending,
+		State: configstore.ManagedWarehouseStatePending,
 	}
 
 	// CAS update should succeed
@@ -963,5 +963,167 @@ func TestFakeStoreUpdateWarehouseState(t *testing.T) {
 	}
 	if fs.warehouses["org-x"].State != configstore.ManagedWarehouseStateProvisioning {
 		t.Fatalf("expected state to remain provisioning, got %q", fs.warehouses["org-x"].State)
+	}
+}
+
+// --- cnpg-shard metadata store ---
+
+// TestReconcilePendingCreatesCnpgShardCR verifies that a warehouse whose
+// metadata-store kind is cnpg-shard produces a Duckling CR with
+// metadataStore.type=cnpg-shard, no aurora/pgbouncer blocks, and the iceberg
+// block enabled — the shape the composition expects for a Lakekeeper-backed
+// shard tenant.
+func TestReconcilePendingCreatesCnpgShardCR(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-cnpg"] = &configstore.ManagedWarehouse{
+		OrgID: "org-cnpg",
+		State: configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind: configstore.MetadataStoreKindCnpgShard,
+		},
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctx := context.Background()
+	ctrl.reconcile(ctx)
+
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("org-cnpg"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected CR to exist: %v", err)
+	}
+	spec := cr.Object["spec"].(map[string]interface{})
+	metadataStore := spec["metadataStore"].(map[string]interface{})
+	if metadataStore["type"] != configstore.MetadataStoreKindCnpgShard {
+		t.Fatalf("metadataStore.type = %v, want cnpg-shard", metadataStore["type"])
+	}
+	if _, present := metadataStore["aurora"]; present {
+		t.Errorf("cnpg-shard CR must not carry an aurora block, got %v", metadataStore["aurora"])
+	}
+	if _, present := metadataStore["pgbouncer"]; present {
+		t.Errorf("cnpg-shard CR must not carry a pgbouncer block, got %v", metadataStore["pgbouncer"])
+	}
+	iceberg, ok := spec["iceberg"].(map[string]interface{})
+	if !ok || iceberg["enabled"] != true {
+		t.Errorf("expected iceberg.enabled=true on cnpg-shard CR, got %v", spec["iceberg"])
+	}
+	if fs.warehouses["org-cnpg"].State != configstore.ManagedWarehouseStateProvisioning {
+		t.Fatalf("expected provisioning state, got %q", fs.warehouses["org-cnpg"].State)
+	}
+}
+
+// TestDucklingCreateCnpgShardRequiresIceberg verifies the Create guard: a
+// cnpg-shard CR is rejected when iceberg isn't enabled, because the XRD
+// admission rule would reject it and the tenant would have no usable catalog.
+func TestDucklingCreateCnpgShardRequiresIceberg(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	ctx := context.Background()
+
+	err := dc.Create(ctx, "no-iceberg", CreateOptions{
+		MetadataStoreType: configstore.MetadataStoreKindCnpgShard,
+		IcebergEnabled:    false,
+	})
+	if err == nil {
+		t.Fatal("expected error creating cnpg-shard CR without iceberg")
+	}
+	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("no-iceberg"), metav1.GetOptions{}); getErr == nil {
+		t.Error("CR should not have been created when validation failed")
+	}
+}
+
+// TestDucklingCreateRejectsUnsupportedType verifies the control plane refuses
+// to create metadata-store types it doesn't provision (notably "external").
+func TestDucklingCreateRejectsUnsupportedType(t *testing.T) {
+	dc, _ := newFakeDucklingClient()
+	if err := dc.Create(context.Background(), "ext-org", CreateOptions{MetadataStoreType: "external"}); err == nil {
+		t.Fatal("expected error creating CR with unsupported metadata store type 'external'")
+	}
+}
+
+// TestReconcileProvisioningCnpgShardGatedOnIceberg verifies a cnpg-shard
+// warehouse does not flip to Ready while iceberg_state is unset (the Lakekeeper
+// catalog isn't up yet), then reaches Ready once iceberg_state is Ready. This
+// is the gating that the reconcileProvisioning -> reconcileLakekeeper call
+// satisfies in production; here we drive iceberg_state directly since no
+// Lakekeeper provisioner is wired.
+func TestReconcileProvisioningCnpgShardGatedOnIceberg(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-cs"] = &configstore.ManagedWarehouse{
+		OrgID:     "org-cs",
+		State:     configstore.ManagedWarehouseStateProvisioning,
+		CreatedAt: time.Now(),
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind: configstore.MetadataStoreKindCnpgShard,
+		},
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "k8s.posthog.com/v1alpha1",
+			"kind":       "Duckling",
+			"metadata": map[string]interface{}{
+				"name":      ducklingName("org-cs"),
+				"namespace": ducklingNamespace,
+			},
+			"status": map[string]interface{}{
+				"metadataStore": map[string]interface{}{
+					"type":     configstore.MetadataStoreKindCnpgShard,
+					"endpoint": "shard-001-pooler.cnpg-shards.svc.cluster.local",
+					"password": "from-provider-sql",
+					"user":     "lakekeeper_org_cs",
+					"database": "lakekeeper_org_cs",
+				},
+				"dataStore": map[string]interface{}{
+					"type":       "s3bucket",
+					"bucketName": "org-cs-bucket",
+				},
+				"iamRoleArn": "arn:aws:iam::123456789012:role/duckling-org-cs",
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Ready", "status": "True"},
+					map[string]interface{}{"type": "Synced", "status": "True"},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create CR: %v", err)
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.SetProbe(func(context.Context, string, string, string, string, string) error { return nil })
+
+	// First pass: infra is ready but iceberg_state is still pending (no
+	// Lakekeeper provisioner wired), so the warehouse must stay in provisioning.
+	ctrl.reconcile(ctx)
+	w := fs.warehouses["org-cs"]
+	if w.MetadataStoreState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("expected metadata_store_state ready, got %q", w.MetadataStoreState)
+	}
+	if w.State == configstore.ManagedWarehouseStateReady {
+		t.Fatal("warehouse must not be Ready while iceberg (Lakekeeper) is unprovisioned")
+	}
+
+	// Simulate the Lakekeeper provisioner having completed.
+	if err := fs.UpdateIcebergConfig("org-cs", map[string]interface{}{
+		"iceberg_state":               configstore.ManagedWarehouseStateReady,
+		"iceberg_lakekeeper_endpoint": "http://lakekeeper-org-cs.lakekeeper.svc/catalog",
+	}); err != nil {
+		t.Fatalf("update iceberg config: %v", err)
+	}
+
+	// Second pass: now all components incl. iceberg are ready -> Ready.
+	ctrl.reconcile(ctx)
+	if fs.warehouses["org-cs"].State != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("expected ready state after iceberg ready, got %q", fs.warehouses["org-cs"].State)
 	}
 }

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/posthog/duckgres/controlplane/configstore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,9 +89,15 @@ func ducklingName(orgID string) string {
 
 // CreateOptions carries per-org knobs that shape the generated Duckling CR.
 type CreateOptions struct {
-	MinACU           float64
-	MaxACU           float64
-	PgBouncerEnabled bool
+	// MetadataStoreType selects the Duckling's metadata-store backend. Empty
+	// is treated as configstore.MetadataStoreKindAurora (the historical
+	// default). The only other accepted value is
+	// configstore.MetadataStoreKindCnpgShard; any other value (notably
+	// "external") is rejected by Create.
+	MetadataStoreType string
+	MinACU            float64
+	MaxACU            float64
+	PgBouncerEnabled  bool
 	// IcebergEnabled toggles spec.iceberg.enabled on the Duckling CR. The
 	// composition only provisions a per-tenant S3 Tables bucket when this
 	// is true; flipping it post-create is handled by the controller's
@@ -104,18 +111,42 @@ type CreateOptions struct {
 // Create creates a Duckling CR for the given org.
 func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOptions) error {
 	name := ducklingName(orgID)
-	metadataStore := map[string]interface{}{
-		"type": "aurora",
-		"aurora": map[string]interface{}{
-			"minACU": opts.MinACU,
-			"maxACU": opts.MaxACU,
-		},
-	}
-	if opts.PgBouncerEnabled {
-		metadataStore["pgbouncer"] = map[string]interface{}{
-			"enabled": true,
+
+	var metadataStore map[string]interface{}
+	switch opts.MetadataStoreType {
+	case configstore.MetadataStoreKindCnpgShard:
+		// The cnpg-shard metadata store backs the per-tenant Lakekeeper
+		// Iceberg catalog on the shared CloudNativePG shard. It carries no
+		// per-claim config — the composition reads the active shard from chart
+		// values and provisions a lakekeeper_<org> role + database via
+		// provider-sql. The XRD admission rule requires iceberg.enabled=true
+		// for this type, so refuse to emit a CR that would be rejected (and
+		// that would have no usable catalog).
+		if !opts.IcebergEnabled {
+			return fmt.Errorf("create duckling CR %q: metadata store type %q requires iceberg enabled", name, configstore.MetadataStoreKindCnpgShard)
 		}
+		// No aurora block and no pgbouncer block: cnpg-shard tenants reach
+		// Postgres through the shard's own session-mode Pooler, not a
+		// per-Duckling PgBouncer.
+		metadataStore = map[string]interface{}{"type": configstore.MetadataStoreKindCnpgShard}
+	case "", configstore.MetadataStoreKindAurora:
+		metadataStore = map[string]interface{}{
+			"type": configstore.MetadataStoreKindAurora,
+			"aurora": map[string]interface{}{
+				"minACU": opts.MinACU,
+				"maxACU": opts.MaxACU,
+			},
+		}
+		if opts.PgBouncerEnabled {
+			metadataStore["pgbouncer"] = map[string]interface{}{
+				"enabled": true,
+			}
+		}
+	default:
+		return fmt.Errorf("create duckling CR %q: unsupported metadata store type %q (control plane creates only %q or %q)",
+			name, opts.MetadataStoreType, configstore.MetadataStoreKindAurora, configstore.MetadataStoreKindCnpgShard)
 	}
+
 	spec := map[string]interface{}{
 		"metadataStore": metadataStore,
 		"dataStore": map[string]interface{}{

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -66,13 +66,7 @@ type provisionRequest struct {
 }
 
 type provisionMetadataReq struct {
-	Type   string              `json:"type"`
-	Aurora *provisionAuroraReq `json:"aurora,omitempty"`
-}
-
-type provisionAuroraReq struct {
-	MinACU float64 `json:"min_acu"`
-	MaxACU float64 `json:"max_acu"`
+	Type string `json:"type"`
 }
 
 func (h *handler) provisionWarehouse(c *gin.Context) {
@@ -94,37 +88,38 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	// The control plane only provisions two metadata-store backends. An empty
-	// type stays backwards-compatible with existing callers (aurora). External
-	// metadata stores are applied out-of-band and are explicitly not
-	// provisionable here.
+	// The control plane provisions exactly one metadata-store backend for new
+	// warehouses: cnpg-shard (the per-tenant Lakekeeper Iceberg catalog on the
+	// shared CloudNativePG shard). DuckLake (aurora) and external are no longer
+	// provisionable.
+	//
+	// This gate is on *creation* only. Existing DuckLake and external ducklings
+	// keep running untouched: the worker activator still reads their Duckling
+	// CR / config-store metadata and attaches DuckLake, the controller still
+	// reconciles their existing CRs (reconcilePending skips Create when the CR
+	// already exists, and DucklingClient.Create still understands aurora), and
+	// admin read/mutate/deprovision are unaffected.
 	warehouse := &configstore.ManagedWarehouse{}
 	switch req.MetadataStore.Type {
-	case "", configstore.MetadataStoreKindAurora:
-		if req.MetadataStore.Aurora == nil || req.MetadataStore.Aurora.MaxACU <= 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.aurora.max_acu must be greater than 0"})
-			return
-		}
-		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindAurora
-		warehouse.AuroraMinACU = req.MetadataStore.Aurora.MinACU
-		warehouse.AuroraMaxACU = req.MetadataStore.Aurora.MaxACU
 	case configstore.MetadataStoreKindCnpgShard:
-		// cnpg-shard backs the per-tenant Lakekeeper Iceberg catalog on the
-		// shared CloudNativePG shard. It takes no aurora sizing and, per the
-		// Duckling XRD, must always have Iceberg enabled — so enable it here
-		// (Lakekeeper backend) rather than making the caller pass it
-		// redundantly. The composition picks the active shard from chart
-		// values; there is no per-claim placement knob.
+		// cnpg-shard takes no aurora sizing and, per the Duckling XRD, must
+		// always have Iceberg enabled — so enable it here (Lakekeeper backend)
+		// rather than making the caller pass it redundantly. The composition
+		// picks the active shard from chart values; there is no per-claim
+		// placement knob.
 		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindCnpgShard
 		warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
 			Enabled: true,
 			Backend: configstore.IcebergBackendLakekeeper,
 		}
+	case configstore.MetadataStoreKindAurora:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "DuckLake (metadata_store.type 'aurora') is no longer provisionable; only 'cnpg-shard' is. Existing DuckLake deployments are unaffected."})
+		return
 	case "external":
-		c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'external' is not provisionable via the control plane; apply the Duckling CR out-of-band"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "external metadata stores are not provisionable via the control plane; existing external deployments are unaffected"})
 		return
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type %q is not supported (use %q or %q)", req.MetadataStore.Type, configstore.MetadataStoreKindAurora, configstore.MetadataStoreKindCnpgShard)})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q (got %q); 'aurora'/DuckLake and 'external' are no longer provisionable", configstore.MetadataStoreKindCnpgShard, req.MetadataStore.Type)})
 		return
 	}
 

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -38,16 +39,16 @@ type handler struct {
 // warehouseStatusResponse is the public-facing view of warehouse state.
 // Exposes lifecycle status and, when ready, connection details (without password).
 type warehouseStatusResponse struct {
-	OrgID              string                                       `json:"org_id"`
+	OrgID              string                                        `json:"org_id"`
 	State              configstore.ManagedWarehouseProvisioningState `json:"state"`
-	StatusMessage      string                                       `json:"status_message"`
+	StatusMessage      string                                        `json:"status_message"`
 	S3State            configstore.ManagedWarehouseProvisioningState `json:"s3_state"`
 	MetadataStoreState configstore.ManagedWarehouseProvisioningState `json:"metadata_store_state"`
 	IdentityState      configstore.ManagedWarehouseProvisioningState `json:"identity_state"`
 	SecretsState       configstore.ManagedWarehouseProvisioningState `json:"secrets_state"`
-	ReadyAt            *time.Time                                   `json:"ready_at,omitempty"`
-	FailedAt           *time.Time                                   `json:"failed_at,omitempty"`
-	Connection         *connectionDetails                           `json:"connection,omitempty"`
+	ReadyAt            *time.Time                                    `json:"ready_at,omitempty"`
+	FailedAt           *time.Time                                    `json:"failed_at,omitempty"`
+	Connection         *connectionDetails                            `json:"connection,omitempty"`
 }
 
 // connectionDetails is returned in status (without password) and in provision/reset-password (with password).
@@ -88,14 +89,43 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	if req.MetadataStore == nil || req.MetadataStore.Aurora == nil || req.MetadataStore.Aurora.MaxACU <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.aurora.max_acu must be greater than 0"})
+	if req.MetadataStore == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store is required"})
 		return
 	}
 
-	warehouse := &configstore.ManagedWarehouse{
-		AuroraMinACU: req.MetadataStore.Aurora.MinACU,
-		AuroraMaxACU: req.MetadataStore.Aurora.MaxACU,
+	// The control plane only provisions two metadata-store backends. An empty
+	// type stays backwards-compatible with existing callers (aurora). External
+	// metadata stores are applied out-of-band and are explicitly not
+	// provisionable here.
+	warehouse := &configstore.ManagedWarehouse{}
+	switch req.MetadataStore.Type {
+	case "", configstore.MetadataStoreKindAurora:
+		if req.MetadataStore.Aurora == nil || req.MetadataStore.Aurora.MaxACU <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.aurora.max_acu must be greater than 0"})
+			return
+		}
+		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindAurora
+		warehouse.AuroraMinACU = req.MetadataStore.Aurora.MinACU
+		warehouse.AuroraMaxACU = req.MetadataStore.Aurora.MaxACU
+	case configstore.MetadataStoreKindCnpgShard:
+		// cnpg-shard backs the per-tenant Lakekeeper Iceberg catalog on the
+		// shared CloudNativePG shard. It takes no aurora sizing and, per the
+		// Duckling XRD, must always have Iceberg enabled — so enable it here
+		// (Lakekeeper backend) rather than making the caller pass it
+		// redundantly. The composition picks the active shard from chart
+		// values; there is no per-claim placement knob.
+		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindCnpgShard
+		warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		}
+	case "external":
+		c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'external' is not provisionable via the control plane; apply the Duckling CR out-of-band"})
+		return
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type %q is not supported (use %q or %q)", req.MetadataStore.Type, configstore.MetadataStoreKindAurora, configstore.MetadataStoreKindCnpgShard)})
+		return
 	}
 
 	if err := h.store.CreatePendingWarehouse(orgID, req.DatabaseName, warehouse); err != nil {

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -109,7 +109,11 @@ func newTestRouter(store Store) *gin.Engine {
 	return r
 }
 
-func TestProvisionCreatesWarehouse(t *testing.T) {
+// TestProvisionRejectsAurora locks in that DuckLake (aurora) is no longer
+// provisionable — even with a valid sizing block — now that cnpg-shard is the
+// only creatable backend. Existing DuckLake deployments are unaffected; this
+// only gates new creation.
+func TestProvisionRejectsAurora(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
@@ -127,23 +131,11 @@ func TestProvisionCreatesWarehouse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
-
-	w := store.warehouses["analytics"]
-	if w == nil {
-		t.Fatal("expected warehouse to be created")
-		return
-	}
-	if w.State != configstore.ManagedWarehouseStatePending {
-		t.Fatalf("expected state pending, got %q", w.State)
-	}
-	if w.AuroraMinACU != 0.5 {
-		t.Fatalf("expected min_acu 0.5, got %f", w.AuroraMinACU)
-	}
-	if w.AuroraMaxACU != 2 {
-		t.Fatalf("expected max_acu 2, got %f", w.AuroraMaxACU)
+	if _, ok := store.warehouses["analytics"]; ok {
+		t.Error("warehouse must not be created for a DuckLake (aurora) metadata store")
 	}
 }
 
@@ -151,7 +143,7 @@ func TestProvisionAutoCreatesOrg(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "aurora", "aurora": {"max_acu": 1}}}`)
+	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/new-org/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -183,21 +175,6 @@ func TestProvisionRejectsEmptyBody(t *testing.T) {
 	}
 }
 
-func TestProvisionRejectsZeroMaxACU(t *testing.T) {
-	store := newFakeStore()
-	router := newTestRouter(store)
-
-	body := []byte(`{"metadata_store": {"type": "aurora", "aurora": {"min_acu": 0.5, "max_acu": 0}}}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
-	}
-}
-
 func TestProvisionRejectsExistingNonTerminal(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
@@ -207,7 +184,7 @@ func TestProvisionRejectsExistingNonTerminal(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "aurora", "aurora": {"max_acu": 1}}}`)
+	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -228,7 +205,7 @@ func TestProvisionAllowsRetryAfterFailure(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "aurora", "aurora": {"min_acu": 0, "max_acu": 2}}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -237,8 +214,8 @@ func TestProvisionAllowsRetryAfterFailure(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	if store.warehouses["analytics"].AuroraMaxACU != 2 {
-		t.Fatalf("expected max_acu 2, got %f", store.warehouses["analytics"].AuroraMaxACU)
+	if store.warehouses["analytics"].MetadataStore.Kind != configstore.MetadataStoreKindCnpgShard {
+		t.Fatalf("expected cnpg-shard warehouse after retry, got kind %q", store.warehouses["analytics"].MetadataStore.Kind)
 	}
 }
 
@@ -252,7 +229,7 @@ func TestProvisionAllowsRetryAfterDeleted(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "aurora", "aurora": {"min_acu": 0, "max_acu": 2}}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -406,3 +406,66 @@ func TestResetPasswordRequiresReadyWarehouse(t *testing.T) {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusConflict, rec.Body.String())
 	}
 }
+
+func TestProvisionCnpgShard(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["shardco"] = &configstore.Org{Name: "shardco"}
+	router := newTestRouter(store)
+
+	// No aurora block — cnpg-shard takes no sizing and auto-enables iceberg.
+	body := []byte(`{"database_name": "shardco-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/shardco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	w := store.warehouses["shardco"]
+	if w == nil {
+		t.Fatal("expected warehouse to be created")
+	}
+	if w.MetadataStore.Kind != configstore.MetadataStoreKindCnpgShard {
+		t.Errorf("metadata store kind = %q, want cnpg-shard", w.MetadataStore.Kind)
+	}
+	if !w.Iceberg.Enabled || w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
+		t.Errorf("expected iceberg enabled with lakekeeper backend, got %+v", w.Iceberg)
+	}
+	if w.AuroraMaxACU != 0 {
+		t.Errorf("cnpg-shard must not set aurora sizing, got max_acu=%f", w.AuroraMaxACU)
+	}
+}
+
+func TestProvisionRejectsExternalMetadataStore(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "ext-db", "metadata_store": {"type": "external"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/extco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if _, ok := store.warehouses["extco"]; ok {
+		t.Error("warehouse must not be created for an external metadata store")
+	}
+}
+
+func TestProvisionRejectsUnsupportedMetadataStore(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "x-db", "metadata_store": {"type": "neon"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/xco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -78,6 +78,13 @@ func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 		warehouse.S3State = configstore.ManagedWarehouseStatePending
 		warehouse.IdentityState = configstore.ManagedWarehouseStatePending
 		warehouse.SecretsState = configstore.ManagedWarehouseStatePending
+		// Track iceberg as a provisioning component only when the tenant opted
+		// in (e.g. cnpg-shard, which is always iceberg-backed). Leaving it
+		// empty for non-iceberg warehouses keeps them out of the iceberg
+		// readiness gate.
+		if warehouse.Iceberg.Enabled {
+			warehouse.IcebergState = configstore.ManagedWarehouseStatePending
+		}
 		return tx.Create(warehouse).Error
 	})
 }


### PR DESCRIPTION
## Summary

Make **`cnpg-shard` the single metadata-store backend the control plane creates**, and stop creating new **DuckLake (`aurora`)** and **`external`** warehouses entirely. `cnpg-shard` is the per-tenant Lakekeeper Iceberg catalog backend on the shared CloudNativePG shard.

Previously `DucklingClient.Create` hardcoded `metadataStore.type: aurora` and the provisioning API only accepted an aurora sizing block, so `cnpg-shard` couldn't be created through the normal flow at all. This PR adds it and then retires aurora/external from the create path.

## Creation vs runtime — why existing deployments are safe

The disallow is on **creation only**. Existing DuckLake and external ducklings keep running, because creation and runtime are separate code paths:

- **`CreatePendingWarehouse` is the sole entry point for new warehouses** and is reached only from `provisionWarehouse`. Gating that handler fully blocks new aurora/external warehouses.
- **Runtime is untouched:** the worker activator still reads the Duckling CR / config-store metadata of existing aurora and external ducklings and attaches DuckLake; the controller still reconciles their *existing* CRs (`reconcilePending` calls `duckling.Get` and skips `Create` when the CR already exists, and `DucklingClient.Create` keeps its aurora branch so an existing CR can be recreated after a controller restart); admin read/mutate and deprovision are unaffected.
- **k8s integration tests seed warehouses via direct SQL**, bypassing this API, so they're unaffected.

The one caller-facing change: the provisioning API now accepts only `metadata_store.type: cnpg-shard`. Any caller currently sending `aurora` (e.g. PostHog onboarding) must switch — `aurora`, `external`, empty, and unknown types all return `400` with a message noting existing deployments are unaffected.

## Changes

- **configstore**: `MetadataStoreKind{Aurora,CnpgShard}` constants (single source of truth; stored in `MetadataStore.Kind`, mirrored onto `spec.metadataStore.type`).
- **`DucklingClient.Create` / `CreateOptions`**: branch on `MetadataStoreType`. `cnpg-shard` emits `{type: cnpg-shard}` (no aurora/pgbouncer block — Postgres is reached via the shard's session-mode Pooler) and requires `iceberg.enabled=true` (XRD rule). The aurora branch is retained for reconciling *existing* warehouses. Unknown types rejected.
- **provisioning API**: only `cnpg-shard` provisionable (auto-enables Iceberg/Lakekeeper, no ACU). `aurora`/`external`/empty/unknown → `400`. The aurora sizing block is removed from the request.
- **controller**: thread `MetadataStore.Kind` into `CreateOptions`; run `reconcileLakekeeper` during `reconcileProvisioning` (not only post-Ready) so a cnpg-shard warehouse — which must have iceberg enabled — can reach `Ready` (the Lakekeeper backend has no S3 Tables ARN to trigger `iceberg_state`). Idempotent; no-ops for non-Lakekeeper backends.
- **store**: mark `IcebergState` pending at create for iceberg-enabled warehouses.

## Known follow-up (not in this PR)

`SharedWorkerActivator.buildDuckLakeConfigFromDuckling` still builds a **DuckLake** metadata DSN from the Duckling status unconditionally. For a cnpg-shard org that status points at the **Lakekeeper Postgres backend**, not a DuckLake catalog — so the activator must **skip the DuckLake attach for cnpg-shard tenants** (Iceberg-only) before these ducklings can serve queries end to end. Tracked separately.

## Test plan

`go test -tags kubernetes ./controlplane/provisioner/ ./controlplane/provisioning/ ./controlplane/configstore/` — all green.

New / updated tests:
- `TestReconcilePendingCreatesCnpgShardCR`, `TestDucklingCreateCnpgShardRequiresIceberg`, `TestDucklingCreateRejectsUnsupportedType`, `TestReconcileProvisioningCnpgShardGatedOnIceberg`
- `TestProvisionCnpgShard`, `TestProvisionRejectsAurora`, `TestProvisionRejectsExternalMetadataStore`, `TestProvisionRejectsUnsupportedMetadataStore`
- retry/conflict + auto-create-org tests switched to `cnpg-shard`; obsolete zero-ACU test removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)