### PR TITLE
Fix Iceberg information_schema metadata loading in control plane

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -196,6 +196,7 @@ type ConfigStoreInterface interface {
 // OrgRouterInterface abstracts the org router for the control plane.
 type OrgRouterInterface interface {
 	StackForOrg(orgID string) (pool WorkerPool, sessions *SessionManager, rebalancer *MemoryRebalancer, ok bool)
+	IcebergConfigForOrg(orgID string) (server.IcebergConfig, bool)
 	IsMigratingForOrg(orgID string) bool
 	SetWarmCapacityTarget(n int)
 	ShutdownAll()
@@ -1172,6 +1173,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Create real clientConn with FlightExecutor and worker assignment
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
+	if cp.orgRouter != nil && orgID != "" {
+		if icebergCfg, ok := cp.orgRouter.IcebergConfigForOrg(orgID); ok {
+			server.SetConnectionIcebergConfig(cc, icebergCfg)
+		}
+	}
 	server.SetLogicalCatalogMapping(cc, duckLakeAttached)
 	server.SetPassthrough(cc, passthroughUser)
 	if orgID != "" {

--- a/controlplane/flight_ingress_test.go
+++ b/controlplane/flight_ingress_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightsqlingress"
 )
 
@@ -16,6 +17,10 @@ type reconnectTestOrgRouter struct {
 func (r *reconnectTestOrgRouter) StackForOrg(orgID string) (WorkerPool, *SessionManager, *MemoryRebalancer, bool) {
 	r.stackByOrgCalls++
 	return nil, nil, nil, false
+}
+
+func (r *reconnectTestOrgRouter) IcebergConfigForOrg(_ string) (server.IcebergConfig, bool) {
+	return server.IcebergConfig{}, false
 }
 
 func (r *reconnectTestOrgRouter) IsMigratingForOrg(_ string) bool { return false }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -42,6 +42,10 @@ func (a *orgRouterAdapter) StackForOrg(orgID string) (WorkerPool, *SessionManage
 	return stack.Pool, stack.Sessions, stack.Rebalancer, true
 }
 
+func (a *orgRouterAdapter) IcebergConfigForOrg(orgID string) (server.IcebergConfig, bool) {
+	return a.router.IcebergConfigForOrg(orgID)
+}
+
 func (a *orgRouterAdapter) IsMigratingForOrg(orgID string) bool {
 	return a.router.IsMigrating(orgID)
 }

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/iceberg"
 )
 
 // OrgStack holds the isolated worker pool and session manager for an org.
@@ -203,6 +204,31 @@ func (tr *OrgRouter) StackForOrg(orgID string) (*OrgStack, bool) {
 	stack, ok := tr.orgs[orgID]
 	tr.mu.RUnlock()
 	return stack, ok
+}
+
+func (tr *OrgRouter) IcebergConfigForOrg(orgID string) (server.IcebergConfig, bool) {
+	tr.mu.RLock()
+	stack, ok := tr.orgs[orgID]
+	tr.mu.RUnlock()
+	if !ok || stack == nil || stack.Config == nil || stack.Config.Warehouse == nil {
+		return server.IcebergConfig{}, false
+	}
+
+	src := stack.Config.Warehouse.Iceberg
+	cfg := server.IcebergConfig{
+		Enabled:                   src.Enabled,
+		Backend:                   src.Backend,
+		Namespace:                 src.Namespace,
+		Region:                    src.Region,
+		LakekeeperEndpoint:        src.LakekeeperEndpoint,
+		LakekeeperWarehouse:       src.LakekeeperWarehouse,
+		LakekeeperClientID:        src.LakekeeperClientID,
+		LakekeeperOAuth2ServerURI: src.LakekeeperOAuth2ServerURI,
+	}
+	if cfg.ResolvedBackend() == iceberg.BackendS3Tables {
+		cfg.TableBucket = src.TableBucketArn
+	}
+	return cfg, true
 }
 
 // SetMigrating marks an org as having a DuckLake migration in progress.

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -59,6 +59,39 @@ func (l *recordingOrgRouterLease) Release(ctx context.Context) error {
 	return nil
 }
 
+func TestOrgRouterIcebergConfigForOrg(t *testing.T) {
+	router := &OrgRouter{
+		orgs: map[string]*OrgStack{
+			"org-acme": {
+				Config: &configstore.OrgConfig{
+					Name: "org-acme",
+					Warehouse: &configstore.ManagedWarehouseConfig{
+						Iceberg: configstore.ManagedWarehouseIceberg{
+							Enabled:             true,
+							Backend:             configstore.IcebergBackendLakekeeper,
+							Namespace:           "main",
+							Region:              "us-east-1",
+							LakekeeperEndpoint:  "http://lakekeeper/catalog",
+							LakekeeperWarehouse: "org-acme",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg, ok := router.IcebergConfigForOrg("org-acme")
+	if !ok {
+		t.Fatal("expected Iceberg config for org")
+	}
+	if !cfg.Enabled || cfg.LakekeeperEndpoint != "http://lakekeeper/catalog" || cfg.LakekeeperWarehouse != "org-acme" {
+		t.Fatalf("unexpected Iceberg config: %+v", cfg)
+	}
+	if cfg.Namespace != "main" || cfg.Region != "us-east-1" {
+		t.Fatalf("expected namespace and region to be preserved, got %+v", cfg)
+	}
+}
+
 func TestOrgRouterDestroyOrgStackDrainsSessionsBeforePoolShutdownAndReleasesSessionLeases(t *testing.T) {
 	events := []string{}
 	pool := &recordingOrgRouterPool{events: &events}

--- a/controlplane/org_router_test_helpers_test.go
+++ b/controlplane/org_router_test_helpers_test.go
@@ -1,5 +1,7 @@
 package controlplane
 
+import "github.com/posthog/duckgres/server"
+
 // mockOrgRouter implements OrgRouterInterface for testing.
 type mockOrgRouter struct {
 	sessions   *SessionManager
@@ -9,6 +11,10 @@ type mockOrgRouter struct {
 
 func (m *mockOrgRouter) StackForOrg(_ string) (WorkerPool, *SessionManager, *MemoryRebalancer, bool) {
 	return nil, m.sessions, m.rebalancer, m.ok
+}
+
+func (m *mockOrgRouter) IcebergConfigForOrg(_ string) (server.IcebergConfig, bool) {
+	return server.IcebergConfig{}, false
 }
 
 func (m *mockOrgRouter) IsMigratingForOrg(_ string) bool { return false }

--- a/server/catalog.go
+++ b/server/catalog.go
@@ -1225,6 +1225,11 @@ func initInformationSchema(db *sql.DB, duckLakeMode bool) error {
 			ON c.table_schema = m.table_schema
 			AND c.table_name = m.table_name
 			AND c.column_name = m.column_name
+		WHERE NOT (
+			c.table_catalog = 'iceberg'
+			AND c.column_name = '__'
+			AND UPPER(c.data_type) = 'UNKNOWN'
+		)
 	`
 	if _, err := db.Exec(fmt.Sprintf(columnsViewSQL, infoSchemaPrefix)); err != nil {
 		// If join with metadata table fails, create simpler view without it
@@ -1308,6 +1313,11 @@ func initInformationSchema(db *sql.DB, duckLakeMode bool) error {
 				NULL AS generation_expression,
 				'YES' AS is_updatable
 			FROM %s.columns
+			WHERE NOT (
+				table_catalog = 'iceberg'
+				AND column_name = '__'
+				AND UPPER(data_type) = 'UNKNOWN'
+			)
 		`
 		if _, err := db.Exec(fmt.Sprintf(columnsViewSimpleSQL, infoSchemaPrefix)); err != nil {
 			slog.Warn("Failed to create information_schema_columns_compat view.", "error", err)

--- a/server/catalog_test.go
+++ b/server/catalog_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +51,39 @@ func TestPgDatabaseView(t *testing.T) {
 		}
 		if columns[i] != expected {
 			t.Errorf("Column %d: expected %q, got %q", i, expected, columns[i])
+		}
+	}
+}
+
+func TestInitInformationSchemaColumnsCompatFiltersIcebergDummyRows(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := initInformationSchema(db, true); err != nil {
+		t.Fatalf("Failed to init information_schema: %v", err)
+	}
+
+	var viewSQL string
+	if err := db.QueryRow(`
+		SELECT sql
+		FROM duckdb_views()
+		WHERE database_name = 'memory'
+			AND schema_name = 'main'
+			AND view_name = 'information_schema_columns_compat'
+	`).Scan(&viewSQL); err != nil {
+		t.Fatalf("Failed to query compat view definition: %v", err)
+	}
+
+	for _, want := range []string{
+		"table_catalog = 'iceberg'",
+		"column_name = '__'",
+		"UNKNOWN",
+	} {
+		if !strings.Contains(viewSQL, want) {
+			t.Fatalf("columns compat view definition missing %q in:\n%s", want, viewSQL)
 		}
 	}
 }
@@ -305,7 +339,6 @@ func TestUptimeMacros(t *testing.T) {
 		}
 	}
 }
-
 
 func TestUtilityMacrosWithoutPgCatalog(t *testing.T) {
 	// Verify that initUtilityMacros works independently of initPgCatalog,

--- a/server/conn.go
+++ b/server/conn.go
@@ -156,24 +156,26 @@ const (
 )
 
 type clientConn struct {
-	server                *Server
-	conn                  net.Conn
-	reader                *bufio.Reader
-	writer                *bufio.Writer
-	username              string
-	orgID                 string
-	database              string
-	executor              QueryExecutor
-	pid                   int32
-	secretKey             int32                    // unique key for cancel requests
-	stmts                 map[string]*preparedStmt // prepared statements by name
-	portals               map[string]*portal       // portals by name
-	txStatus              byte                     // current transaction status ('I', 'T', or 'E')
-	passthrough           bool                     // true for passthrough users (skip transpiler + pg_catalog)
-	cursors               map[string]*cursorState  // server-side cursor emulation
-	logicalCatalogMapping bool                     // true when the session has an attached ducklake catalog and logical catalog masking is active
-	ctx                   context.Context          // connection context, cancelled when connection is closed
-	cancel                context.CancelFunc       // cancels the connection context
+	server                 *Server
+	conn                   net.Conn
+	reader                 *bufio.Reader
+	writer                 *bufio.Writer
+	username               string
+	orgID                  string
+	database               string
+	executor               QueryExecutor
+	pid                    int32
+	secretKey              int32                    // unique key for cancel requests
+	stmts                  map[string]*preparedStmt // prepared statements by name
+	portals                map[string]*portal       // portals by name
+	txStatus               byte                     // current transaction status ('I', 'T', or 'E')
+	passthrough            bool                     // true for passthrough users (skip transpiler + pg_catalog)
+	cursors                map[string]*cursorState  // server-side cursor emulation
+	logicalCatalogMapping  bool                     // true when the session has an attached ducklake catalog and logical catalog masking is active
+	tenantIcebergConfig    IcebergConfig
+	hasTenantIcebergConfig bool
+	ctx                    context.Context    // connection context, cancelled when connection is closed
+	cancel                 context.CancelFunc // cancels the connection context
 
 	// sharedDB is true when this connection uses a shared file-persistence DB pool.
 	// Cleanup differs: we return the pinned conn to the pool instead of closing the DB.
@@ -1669,14 +1671,25 @@ func (c *clientConn) rewriteDirectQuery(query string) string {
 }
 
 func (c *clientConn) loadIcebergColumnMetadata(ctx context.Context, query string) error {
-	if c == nil || !shouldLoadIcebergColumnMetadata(c.server.cfg.Iceberg, c.passthrough) {
+	cfg := c.effectiveIcebergConfig()
+	if c == nil || !shouldLoadIcebergColumnMetadata(cfg, c.passthrough) {
 		return nil
 	}
 	return icebergmeta.LoadColumns(ctx, c.executor, query, icebergmeta.Config{
-		LakekeeperEndpoint:        c.server.cfg.Iceberg.LakekeeperEndpoint,
-		LakekeeperWarehouse:       c.server.cfg.Iceberg.LakekeeperWarehouse,
-		LakekeeperOAuth2ServerURI: c.server.cfg.Iceberg.LakekeeperOAuth2ServerURI,
+		LakekeeperEndpoint:        cfg.LakekeeperEndpoint,
+		LakekeeperWarehouse:       cfg.LakekeeperWarehouse,
+		LakekeeperOAuth2ServerURI: cfg.LakekeeperOAuth2ServerURI,
 	})
+}
+
+func (c *clientConn) effectiveIcebergConfig() IcebergConfig {
+	if c != nil && c.hasTenantIcebergConfig {
+		return c.tenantIcebergConfig
+	}
+	if c != nil && c.server != nil {
+		return c.server.cfg.Iceberg
+	}
+	return IcebergConfig{}
 }
 
 func shouldLoadIcebergColumnMetadata(cfg IcebergConfig, passthrough bool) bool {

--- a/server/exports.go
+++ b/server/exports.go
@@ -104,13 +104,23 @@ func SetPassthrough(cc *clientConn, enabled bool) {
 	}
 }
 
+// SetConnectionIcebergConfig records the per-tenant Iceberg config for
+// control-plane proxy connections. The proxy server's global config is not
+// tenant-specific, so query-time metadata loading must use this override.
+func SetConnectionIcebergConfig(cc *clientConn, cfg IcebergConfig) {
+	if cc != nil {
+		cc.tenantIcebergConfig = cfg
+		cc.hasTenantIcebergConfig = true
+	}
+}
+
 // HasAttachedCatalog and InitSessionDatabaseMetadata moved to
 // server/sessionmeta. Re-exports kept here for the dozen call sites in
 // the control plane and elsewhere; new code should import server/sessionmeta
 // directly.
 var (
-	HasAttachedCatalog           = sessionmeta.HasAttachedCatalog
-	InitSessionDatabaseMetadata  = sessionmeta.InitSessionDatabaseMetadata
+	HasAttachedCatalog          = sessionmeta.HasAttachedCatalog
+	InitSessionDatabaseMetadata = sessionmeta.InitSessionDatabaseMetadata
 )
 
 // SendInitialParams sends the initial parameter status messages and backend key data.
@@ -143,7 +153,6 @@ func InitMinimalServer(s *Server, cfg Config, queryCancelCh <-chan struct{}) {
 // that imported it from server keep compiling. New code should use
 // server/wire directly.
 var GenerateSecretKey = wire.GenerateSecretKey
-
 
 // SetQueryLogger sets the query logger on a Server. Used by the control plane
 // to attach a query logger to the minimal server after creation.

--- a/server/iceberg_column_metadata_test.go
+++ b/server/iceberg_column_metadata_test.go
@@ -28,3 +28,26 @@ func TestShouldLoadIcebergColumnMetadataOnlyForLakekeeper(t *testing.T) {
 		t.Fatal("passthrough connections should not load Iceberg column metadata")
 	}
 }
+
+func TestLoadIcebergColumnMetadataUsesConnectionIcebergConfig(t *testing.T) {
+	cc := &clientConn{
+		server: &Server{cfg: Config{}},
+	}
+	SetConnectionIcebergConfig(cc, IcebergConfig{
+		Enabled:             true,
+		Backend:             iceberg.BackendLakekeeper,
+		LakekeeperEndpoint:  "http://lakekeeper.example/catalog",
+		LakekeeperWarehouse: "org-acme",
+	})
+
+	cfg := cc.effectiveIcebergConfig()
+	if !shouldLoadIcebergColumnMetadata(cfg, false) {
+		t.Fatalf("expected tenant Iceberg config to enable metadata loading")
+	}
+	if cfg.LakekeeperEndpoint != "http://lakekeeper.example/catalog" {
+		t.Fatalf("tenant endpoint not preserved: %q", cfg.LakekeeperEndpoint)
+	}
+	if cfg.LakekeeperWarehouse != "org-acme" {
+		t.Fatalf("tenant warehouse not preserved: %q", cfg.LakekeeperWarehouse)
+	}
+}


### PR DESCRIPTION
## Summary
- Pass per-org Iceberg config onto control-plane proxy client connections so Lakekeeper column metadata loading is not gated by the global control-plane config.
- Add an org-router resolver for tenant Iceberg config and wire it into Postgres proxy session setup.
- Filter Iceberg dummy `__ unknown` rows from the legacy information_schema columns compat view as well.

## Test plan
- `go test ./server/... ./transpiler/...`
- `go test -tags kubernetes ./controlplane`
- `go test ./controlplane ./controlplane/configstore ./controlplane/provisioning`
- `GOCACHE=/private/tmp/duckgres-gocache just test-unit` (rerun outside local socket sandbox)
- `go test -v -count=1 ./controlplane ./controlplane/configstore ./controlplane/provisioning` (rerun outside local socket sandbox)
- `PATH=/private/tmp/duckgres-gobin:$PATH GOCACHE=/private/tmp/duckgres-gocache just lint` currently fails only on unrelated untracked `process_isolation_e2e_test.go` errcheck findings.
