### PR TITLE
feat(controlplane): provision external ducklings (iceberg+external, ducklake+external) via API

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -10,15 +10,15 @@ import "time"
 // alias", multiple orgs can share the NULL state, but any non-NULL alias must
 // be unique across orgs (Postgres ignores NULL in UNIQUE).
 type Org struct {
-	Name                string            `gorm:"primaryKey;size:255" json:"name"`
-	DatabaseName        string            `gorm:"size:255;uniqueIndex" json:"database_name"`
-	HostnameAlias       *string           `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
-	MaxWorkers          int               `gorm:"default:0" json:"max_workers"`
-	MaxConnections      int               `gorm:"default:0" json:"max_connections"`
-	MemoryBudget        string            `gorm:"size:32" json:"memory_budget"`
-	IdleTimeoutS        int               `gorm:"default:0" json:"idle_timeout_s"`
-	WorkerCPURequest    string            `gorm:"size:32" json:"worker_cpu_request"`
-	WorkerMemoryRequest string            `gorm:"size:32" json:"worker_memory_request"`
+	Name                string                 `gorm:"primaryKey;size:255" json:"name"`
+	DatabaseName        string                 `gorm:"size:255;uniqueIndex" json:"database_name"`
+	HostnameAlias       *string                `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
+	MaxWorkers          int                    `gorm:"default:0" json:"max_workers"`
+	MaxConnections      int                    `gorm:"default:0" json:"max_connections"`
+	MemoryBudget        string                 `gorm:"size:32" json:"memory_budget"`
+	IdleTimeoutS        int                    `gorm:"default:0" json:"idle_timeout_s"`
+	WorkerCPURequest    string                 `gorm:"size:32" json:"worker_cpu_request"`
+	WorkerMemoryRequest string                 `gorm:"size:32" json:"worker_memory_request"`
 	Users               []OrgUser              `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
 	Warehouse           *ManagedWarehouse      `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
 	Trino               *ManagedWarehouseTrino `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"trino,omitempty"`
@@ -77,14 +77,22 @@ type ManagedWarehouseDatabase struct {
 }
 
 // Metadata-store kinds, stored verbatim in ManagedWarehouseMetadataStore.Kind
-// and mirrored onto the Duckling CR's spec.metadataStore.type. These are the
-// only backends the control plane creates: "external" is deliberately absent
-// (external metadata stores are applied out-of-band, never provisioned here),
-// and "cnpg-shard" backs the per-tenant Lakekeeper Iceberg catalog on the
-// shared CloudNativePG shard (always paired with iceberg.enabled=true).
+// and mirrored onto the Duckling CR's spec.metadataStore.type. The control
+// plane provisions two of these:
+//
+//   - "cnpg-shard": the per-tenant Lakekeeper Iceberg catalog Postgres backend
+//     on the shared CloudNativePG shard (always paired with iceberg.enabled).
+//   - "external": a pre-existing Postgres (e.g. RDS), referenced by endpoint +
+//     an AWS Secrets Manager secret for the password. Backs either a DuckLake
+//     catalog (iceberg disabled) or the Lakekeeper catalog (iceberg enabled).
+//
+// "aurora" is no longer provisionable (the control plane never stands up a new
+// Aurora cluster); the constant is retained so DucklingClient.Create can still
+// reconcile pre-existing aurora ducklings.
 const (
 	MetadataStoreKindAurora    = "aurora"
 	MetadataStoreKindCnpgShard = "cnpg-shard"
+	MetadataStoreKindExternal  = "external"
 )
 
 // ManagedWarehouseMetadataStore stores org-scoped DuckLake metadata DB info.
@@ -96,6 +104,29 @@ type ManagedWarehouseMetadataStore struct {
 	Port         int    `json:"port"`
 	DatabaseName string `gorm:"size:255" json:"database_name"`
 	Username     string `gorm:"size:255" json:"username"`
+
+	// PasswordAWSSecret is the AWS Secrets Manager secret NAME that holds the
+	// metadata DB password. Only meaningful when Kind == "external": it's
+	// passed through to the Duckling CR's spec.metadataStore.external.
+	// passwordAwsSecret, where the composition resolves it (via ESO) into the
+	// status password the worker activator reads. Empty for aurora/cnpg-shard
+	// (those mint their own credentials).
+	PasswordAWSSecret string `gorm:"size:255" json:"password_aws_secret,omitempty"`
+}
+
+// ManagedWarehouseDataStore captures the org's object-store provisioning
+// intent — the shape the Duckling CR's spec.dataStore takes. Distinct from
+// ManagedWarehouseS3 (the resolved, activation-time object-store config):
+// this records what to ask the composition for.
+//
+//   - Kind "s3bucket" (default): the composition provisions a fresh per-org
+//     bucket. BucketName/Region are ignored.
+//   - Kind "external": reuse an existing bucket (BucketName required); the
+//     composition provisions no bucket.
+type ManagedWarehouseDataStore struct {
+	Kind       string `gorm:"size:32" json:"kind"`
+	BucketName string `gorm:"size:255" json:"bucket_name,omitempty"`
+	Region     string `gorm:"size:64" json:"region,omitempty"`
 }
 
 // ManagedWarehousePgBouncer captures per-org opt-in state for the per-Duckling
@@ -287,6 +318,7 @@ type ManagedWarehouse struct {
 
 	WarehouseDatabase ManagedWarehouseDatabase       `gorm:"embedded;embeddedPrefix:warehouse_database_" json:"warehouse_database"`
 	MetadataStore     ManagedWarehouseMetadataStore  `gorm:"embedded;embeddedPrefix:metadata_store_" json:"metadata_store"`
+	DataStore         ManagedWarehouseDataStore      `gorm:"embedded;embeddedPrefix:data_store_" json:"data_store"`
 	PgBouncer         ManagedWarehousePgBouncer      `gorm:"embedded;embeddedPrefix:pgbouncer_" json:"pgbouncer"`
 	S3                ManagedWarehouseS3             `gorm:"embedded;embeddedPrefix:s3_" json:"s3"`
 	Iceberg           ManagedWarehouseIceberg        `gorm:"embedded;embeddedPrefix:iceberg_" json:"iceberg"`

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -213,12 +213,19 @@ func (c *Controller) reconcilePending(ctx context.Context, w *configstore.Manage
 		"pgbouncer_enabled", w.PgBouncer.Enabled,
 		"iceberg_enabled", w.Iceberg.Enabled)
 	if err := c.duckling.Create(ctx, w.OrgID, CreateOptions{
-		MetadataStoreType: w.MetadataStore.Kind,
-		MinACU:            w.AuroraMinACU,
-		MaxACU:            w.AuroraMaxACU,
-		PgBouncerEnabled:  w.PgBouncer.Enabled,
-		IcebergEnabled:    w.Iceberg.Enabled,
-		IcebergNamespace:  w.Iceberg.Namespace,
+		MetadataStoreType:         w.MetadataStore.Kind,
+		MinACU:                    w.AuroraMinACU,
+		MaxACU:                    w.AuroraMaxACU,
+		PgBouncerEnabled:          w.PgBouncer.Enabled,
+		ExternalEndpoint:          w.MetadataStore.Endpoint,
+		ExternalPasswordAWSSecret: w.MetadataStore.PasswordAWSSecret,
+		ExternalUser:              w.MetadataStore.Username,
+		ExternalDatabase:          w.MetadataStore.DatabaseName,
+		DataStoreType:             w.DataStore.Kind,
+		DataStoreBucket:           w.DataStore.BucketName,
+		DataStoreRegion:           w.DataStore.Region,
+		IcebergEnabled:            w.Iceberg.Enabled,
+		IcebergNamespace:          w.Iceberg.Namespace,
 	}); err != nil {
 		log.Error("Failed to create Duckling CR.", "error", err)
 		_ = c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStatePending, map[string]interface{}{

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -1127,3 +1127,133 @@ func TestReconcileProvisioningCnpgShardGatedOnIceberg(t *testing.T) {
 		t.Fatalf("expected ready state after iceberg ready, got %q", fs.warehouses["org-cs"].State)
 	}
 }
+
+// --- external metadata store (iceberg+external and ducklake+external) ---
+
+// TestReconcilePendingCreatesIcebergExternalCR verifies a warehouse with an
+// external metadata store + iceberg produces a Duckling CR with
+// metadataStore.type=external (carrying endpoint/passwordAwsSecret/user/
+// database), an external dataStore reusing the named bucket, and iceberg on.
+func TestReconcilePendingCreatesIcebergExternalCR(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-ext"] = &configstore.ManagedWarehouse{
+		OrgID: "org-ext",
+		State: configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:              configstore.MetadataStoreKindExternal,
+			Endpoint:          "rds.example.us-east-1.rds.amazonaws.com",
+			Username:          "postgres",
+			DatabaseName:      "postgres",
+			PasswordAWSSecret: "duckling-example-rds-password",
+		},
+		DataStore: configstore.ManagedWarehouseDataStore{
+			Kind:       "external",
+			BucketName: "posthog-duckling-example",
+			Region:     "us-east-1",
+		},
+		Iceberg: configstore.ManagedWarehouseIceberg{
+			Enabled: true,
+			Backend: configstore.IcebergBackendLakekeeper,
+		},
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctx := context.Background()
+	ctrl.reconcile(ctx)
+
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("org-ext"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected CR to exist: %v", err)
+	}
+	spec := cr.Object["spec"].(map[string]interface{})
+	ms := spec["metadataStore"].(map[string]interface{})
+	if ms["type"] != configstore.MetadataStoreKindExternal {
+		t.Fatalf("metadataStore.type = %v, want external", ms["type"])
+	}
+	ext, ok := ms["external"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadataStore.external block, got %v", ms)
+	}
+	if ext["endpoint"] != "rds.example.us-east-1.rds.amazonaws.com" || ext["passwordAwsSecret"] != "duckling-example-rds-password" {
+		t.Errorf("external endpoint/secret wrong: %v", ext)
+	}
+	if ext["user"] != "postgres" || ext["database"] != "postgres" {
+		t.Errorf("external user/database wrong: %v", ext)
+	}
+	ds := spec["dataStore"].(map[string]interface{})
+	if ds["type"] != "external" {
+		t.Fatalf("dataStore.type = %v, want external", ds["type"])
+	}
+	dsExt, ok := ds["external"].(map[string]interface{})
+	if !ok || dsExt["bucketName"] != "posthog-duckling-example" || dsExt["region"] != "us-east-1" {
+		t.Errorf("dataStore.external wrong: %v", ds["external"])
+	}
+	iceberg, ok := spec["iceberg"].(map[string]interface{})
+	if !ok || iceberg["enabled"] != true {
+		t.Errorf("expected iceberg.enabled=true, got %v", spec["iceberg"])
+	}
+}
+
+// TestReconcilePendingCreatesDuckLakeExternalCR verifies external metadata
+// WITHOUT iceberg yields a CR with no iceberg block (DuckLake-on-external).
+func TestReconcilePendingCreatesDuckLakeExternalCR(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-dl"] = &configstore.ManagedWarehouse{
+		OrgID: "org-dl",
+		State: configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:              configstore.MetadataStoreKindExternal,
+			Endpoint:          "rds.example.us-east-1.rds.amazonaws.com",
+			PasswordAWSSecret: "duckling-example-rds-password",
+		},
+		DataStore: configstore.ManagedWarehouseDataStore{
+			Kind: "external", BucketName: "posthog-duckling-example", Region: "us-east-1",
+		},
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctx := context.Background()
+	ctrl.reconcile(ctx)
+
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("org-dl"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected CR to exist: %v", err)
+	}
+	spec := cr.Object["spec"].(map[string]interface{})
+	if spec["metadataStore"].(map[string]interface{})["type"] != configstore.MetadataStoreKindExternal {
+		t.Fatalf("metadataStore.type wrong: %v", spec["metadataStore"])
+	}
+	if _, present := spec["iceberg"]; present {
+		t.Errorf("ducklake+external CR must not carry an iceberg block, got %v", spec["iceberg"])
+	}
+}
+
+// TestDucklingCreateExternalRequiresFields verifies the Create guard: an
+// external CR is rejected without endpoint + passwordAwsSecret.
+func TestDucklingCreateExternalRequiresFields(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	ctx := context.Background()
+	if err := dc.Create(ctx, "ext-bad", CreateOptions{MetadataStoreType: configstore.MetadataStoreKindExternal}); err == nil {
+		t.Fatal("expected error creating external CR without endpoint/passwordAwsSecret")
+	}
+	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("ext-bad"), metav1.GetOptions{}); getErr == nil {
+		t.Error("CR should not have been created when external validation failed")
+	}
+}
+
+// TestDucklingCreateExternalDataStoreRequiresBucket verifies the dataStore
+// guard: an external dataStore needs a bucket name.
+func TestDucklingCreateExternalDataStoreRequiresBucket(t *testing.T) {
+	dc, _ := newFakeDucklingClient()
+	err := dc.Create(context.Background(), "ext-nobucket", CreateOptions{
+		MetadataStoreType:         configstore.MetadataStoreKindExternal,
+		ExternalEndpoint:          "h",
+		ExternalPasswordAWSSecret: "s",
+		DataStoreType:             "external",
+	})
+	if err == nil {
+		t.Fatal("expected error: external dataStore without a bucket name")
+	}
+}

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -91,13 +91,30 @@ func ducklingName(orgID string) string {
 type CreateOptions struct {
 	// MetadataStoreType selects the Duckling's metadata-store backend. Empty
 	// is treated as configstore.MetadataStoreKindAurora (the historical
-	// default). The only other accepted value is
-	// configstore.MetadataStoreKindCnpgShard; any other value (notably
-	// "external") is rejected by Create.
+	// default, retained only for reconciling pre-existing aurora ducklings).
+	// The control plane creates cnpg-shard and external; any other value is
+	// rejected by Create.
 	MetadataStoreType string
 	MinACU            float64
 	MaxACU            float64
 	PgBouncerEnabled  bool
+
+	// External metadata store (MetadataStoreType == "external"). Endpoint and
+	// ExternalPasswordAWSSecret are required for that type; User/Database
+	// default to "postgres" at the XRD level when empty.
+	ExternalEndpoint          string
+	ExternalPasswordAWSSecret string
+	ExternalUser              string
+	ExternalDatabase          string
+
+	// DataStoreType selects spec.dataStore.type. Empty defaults to "s3bucket"
+	// (the composition provisions a fresh per-org bucket). "external" reuses an
+	// existing bucket — DataStoreBucket is then required, DataStoreRegion
+	// optional (XRD/composition default applies when empty).
+	DataStoreType   string
+	DataStoreBucket string
+	DataStoreRegion string
+
 	// IcebergEnabled toggles spec.iceberg.enabled on the Duckling CR. The
 	// composition only provisions a per-tenant S3 Tables bucket when this
 	// is true; flipping it post-create is handled by the controller's
@@ -129,6 +146,34 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 		// Postgres through the shard's own session-mode Pooler, not a
 		// per-Duckling PgBouncer.
 		metadataStore = map[string]interface{}{"type": configstore.MetadataStoreKindCnpgShard}
+	case configstore.MetadataStoreKindExternal:
+		// A pre-existing Postgres (e.g. RDS), referenced by endpoint + an AWS
+		// Secrets Manager secret name for the password (resolved by the
+		// composition via ESO). Backs a DuckLake catalog (iceberg disabled) or
+		// the Lakekeeper catalog (iceberg enabled). User/Database are omitted
+		// when empty so the XRD defaults ("postgres") apply.
+		if opts.ExternalEndpoint == "" || opts.ExternalPasswordAWSSecret == "" {
+			return fmt.Errorf("create duckling CR %q: metadata store type %q requires endpoint and passwordAwsSecret", name, configstore.MetadataStoreKindExternal)
+		}
+		external := map[string]interface{}{
+			"endpoint":          opts.ExternalEndpoint,
+			"passwordAwsSecret": opts.ExternalPasswordAWSSecret,
+		}
+		if opts.ExternalUser != "" {
+			external["user"] = opts.ExternalUser
+		}
+		if opts.ExternalDatabase != "" {
+			external["database"] = opts.ExternalDatabase
+		}
+		metadataStore = map[string]interface{}{
+			"type":     configstore.MetadataStoreKindExternal,
+			"external": external,
+		}
+		if opts.PgBouncerEnabled {
+			metadataStore["pgbouncer"] = map[string]interface{}{
+				"enabled": true,
+			}
+		}
 	case "", configstore.MetadataStoreKindAurora:
 		metadataStore = map[string]interface{}{
 			"type": configstore.MetadataStoreKindAurora,
@@ -144,14 +189,30 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 		}
 	default:
 		return fmt.Errorf("create duckling CR %q: unsupported metadata store type %q (control plane creates only %q or %q)",
-			name, opts.MetadataStoreType, configstore.MetadataStoreKindAurora, configstore.MetadataStoreKindCnpgShard)
+			name, opts.MetadataStoreType, configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal)
+	}
+
+	var dataStore map[string]interface{}
+	switch opts.DataStoreType {
+	case "external":
+		// Reuse an existing bucket (the composition provisions none).
+		if opts.DataStoreBucket == "" {
+			return fmt.Errorf("create duckling CR %q: dataStore type %q requires a bucket name", name, "external")
+		}
+		external := map[string]interface{}{"bucketName": opts.DataStoreBucket}
+		if opts.DataStoreRegion != "" {
+			external["region"] = opts.DataStoreRegion
+		}
+		dataStore = map[string]interface{}{"type": "external", "external": external}
+	case "", "s3bucket":
+		dataStore = map[string]interface{}{"type": "s3bucket"}
+	default:
+		return fmt.Errorf("create duckling CR %q: unsupported data store type %q", name, opts.DataStoreType)
 	}
 
 	spec := map[string]interface{}{
 		"metadataStore": metadataStore,
-		"dataStore": map[string]interface{}{
-			"type": "s3bucket",
-		},
+		"dataStore":     dataStore,
 	}
 	if opts.IcebergEnabled {
 		iceberg := map[string]interface{}{"enabled": true}

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -106,8 +106,10 @@ type connectionDetails struct {
 }
 
 type provisionRequest struct {
-	DatabaseName  string                `json:"database_name"`
-	MetadataStore *provisionMetadataReq `json:"metadata_store,omitempty"`
+	DatabaseName  string                 `json:"database_name"`
+	MetadataStore *provisionMetadataReq  `json:"metadata_store,omitempty"`
+	DataStore     *provisionDataStoreReq `json:"data_store,omitempty"`
+	Iceberg       *provisionIcebergReq   `json:"iceberg,omitempty"`
 
 	// Trino is the opt-in flag for the customer-facing Trino cluster.
 	// Optional — when nil, the warehouse is provisioned with the existing
@@ -119,6 +121,37 @@ type provisionRequest struct {
 
 type provisionMetadataReq struct {
 	Type string `json:"type"`
+	// External is required when Type == "external": a pre-existing Postgres
+	// referenced by host + an AWS Secrets Manager secret for the password.
+	External *provisionExternalReq `json:"external,omitempty"`
+}
+
+// provisionExternalReq describes a pre-existing (external) Postgres metadata
+// store. Endpoint (RDS host) and PasswordAWSSecret (the AWS Secrets Manager
+// secret NAME holding the password) are required; User/Database default to
+// "postgres" when omitted.
+type provisionExternalReq struct {
+	Endpoint          string `json:"endpoint"`
+	PasswordAWSSecret string `json:"password_aws_secret"`
+	User              string `json:"user,omitempty"`
+	Database          string `json:"database,omitempty"`
+}
+
+// provisionDataStoreReq selects the object store. Type "s3bucket" (or omitted)
+// provisions a fresh per-org bucket; "external" reuses an existing bucket and
+// then requires BucketName. Region is optional (composition default applies).
+type provisionDataStoreReq struct {
+	Type       string `json:"type"`
+	BucketName string `json:"bucket_name,omitempty"`
+	Region     string `json:"region,omitempty"`
+}
+
+// provisionIcebergReq toggles the per-tenant Lakekeeper Iceberg catalog. For
+// external metadata stores it's optional (enabled → iceberg+external, omitted
+// → ducklake+external); for cnpg-shard it's implied and always enabled.
+type provisionIcebergReq struct {
+	Enabled   bool   `json:"enabled"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // provisionTrinoReq is the per-request Trino opt-in. Mirrored by the
@@ -144,6 +177,35 @@ type trinoRequest struct {
 	Tier    string `json:"tier,omitempty"`
 }
 
+// icebergNamespace returns the requested Iceberg namespace, or "" to let the
+// XRD default ("main") apply.
+func icebergNamespace(req *provisionIcebergReq) string {
+	if req == nil {
+		return ""
+	}
+	return req.Namespace
+}
+
+// resolveDataStore validates and normalizes the data-store request into the
+// stored intent. Nil or "s3bucket" provisions a fresh per-org bucket;
+// "external" reuses an existing bucket and requires a bucket name.
+func resolveDataStore(req *provisionDataStoreReq) (configstore.ManagedWarehouseDataStore, error) {
+	if req == nil || req.Type == "" || req.Type == "s3bucket" {
+		return configstore.ManagedWarehouseDataStore{Kind: "s3bucket"}, nil
+	}
+	if req.Type == "external" {
+		if req.BucketName == "" {
+			return configstore.ManagedWarehouseDataStore{}, errors.New("data_store.type 'external' requires data_store.bucket_name")
+		}
+		return configstore.ManagedWarehouseDataStore{
+			Kind:       "external",
+			BucketName: req.BucketName,
+			Region:     req.Region,
+		}, nil
+	}
+	return configstore.ManagedWarehouseDataStore{}, fmt.Errorf("data_store.type must be \"s3bucket\" or \"external\" (got %q)", req.Type)
+}
+
 func (h *handler) provisionWarehouse(c *gin.Context) {
 	orgID := c.Param("id")
 
@@ -163,38 +225,64 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	// The control plane provisions exactly one metadata-store backend for new
-	// warehouses: cnpg-shard (the per-tenant Lakekeeper Iceberg catalog on the
-	// shared CloudNativePG shard). DuckLake (aurora) and external are no longer
-	// provisionable.
+	// The control plane provisions three duckling shapes:
+	//   - iceberg+cnpg     metadata_store.type=cnpg-shard          (iceberg implied)
+	//   - iceberg+external  metadata_store.type=external + iceberg.enabled
+	//   - ducklake+external metadata_store.type=external           (iceberg omitted)
 	//
-	// This gate is on *creation* only. Existing DuckLake and external ducklings
-	// keep running untouched: the worker activator still reads their Duckling
-	// CR / config-store metadata and attaches DuckLake, the controller still
-	// reconciles their existing CRs (reconcilePending skips Create when the CR
-	// already exists, and DucklingClient.Create still understands aurora), and
-	// admin read/mutate/deprovision are unaffected.
+	// "aurora" is no longer provisionable (the control plane never stands up a
+	// new Aurora cluster). Validation is strict: each shape's required fields
+	// must be present, or the request is rejected before any write.
 	warehouse := &configstore.ManagedWarehouse{}
 	switch req.MetadataStore.Type {
 	case configstore.MetadataStoreKindCnpgShard:
-		// cnpg-shard takes no aurora sizing and, per the Duckling XRD, must
-		// always have Iceberg enabled — so enable it here (Lakekeeper backend)
-		// rather than making the caller pass it redundantly. The composition
-		// picks the active shard from chart values; there is no per-claim
-		// placement knob.
+		// cnpg-shard takes no per-claim config: the composition picks the active
+		// shard from chart values and provisions a fresh per-org bucket. Per the
+		// Duckling XRD it must always have Iceberg enabled (Lakekeeper backend),
+		// so enable it here rather than making the caller pass it redundantly.
 		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindCnpgShard
 		warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
-			Enabled: true,
-			Backend: configstore.IcebergBackendLakekeeper,
+			Enabled:   true,
+			Backend:   configstore.IcebergBackendLakekeeper,
+			Namespace: icebergNamespace(req.Iceberg),
 		}
+
+	case configstore.MetadataStoreKindExternal:
+		// A pre-existing Postgres. Endpoint (RDS host) + the AWS Secrets Manager
+		// secret name for the password are required; user/database default to
+		// "postgres". Iceberg is optional: enabled → iceberg+external, omitted →
+		// ducklake+external.
+		ext := req.MetadataStore.External
+		if ext == nil || ext.Endpoint == "" || ext.PasswordAWSSecret == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'external' requires metadata_store.external.endpoint and metadata_store.external.password_aws_secret"})
+			return
+		}
+		ds, derr := resolveDataStore(req.DataStore)
+		if derr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": derr.Error()})
+			return
+		}
+		warehouse.MetadataStore = configstore.ManagedWarehouseMetadataStore{
+			Kind:              configstore.MetadataStoreKindExternal,
+			Endpoint:          ext.Endpoint,
+			Username:          ext.User,
+			DatabaseName:      ext.Database,
+			PasswordAWSSecret: ext.PasswordAWSSecret,
+		}
+		warehouse.DataStore = ds
+		if req.Iceberg != nil && req.Iceberg.Enabled {
+			warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
+				Enabled:   true,
+				Backend:   configstore.IcebergBackendLakekeeper,
+				Namespace: icebergNamespace(req.Iceberg),
+			}
+		}
+
 	case configstore.MetadataStoreKindAurora:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "DuckLake (metadata_store.type 'aurora') is no longer provisionable; only 'cnpg-shard' is. Existing DuckLake deployments are unaffected."})
-		return
-	case "external":
-		c.JSON(http.StatusBadRequest, gin.H{"error": "external metadata stores are not provisionable via the control plane; existing external deployments are unaffected"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "DuckLake on a fresh Aurora cluster (metadata_store.type 'aurora') is no longer provisionable; use 'cnpg-shard' or 'external'"})
 		return
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q (got %q); 'aurora'/DuckLake and 'external' are no longer provisionable", configstore.MetadataStoreKindCnpgShard, req.MetadataStore.Type)})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q or %q (got %q)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, req.MetadataStore.Type)})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -705,21 +705,116 @@ func TestProvisionCnpgShard(t *testing.T) {
 	}
 }
 
-func TestProvisionRejectsExternalMetadataStore(t *testing.T) {
+func TestProvisionIcebergExternal(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "ext-db", "metadata_store": {"type": "external"}}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/extco/provision", bytes.NewReader(body))
+	body := []byte(`{
+		"database_name": "extice-db",
+		"metadata_store": {"type": "external", "external": {
+			"endpoint": "rds.example.us-east-1.rds.amazonaws.com",
+			"password_aws_secret": "duckling-example-rds-password",
+			"user": "postgres", "database": "postgres"
+		}},
+		"data_store": {"type": "external", "bucket_name": "posthog-duckling-example", "region": "us-east-1"},
+		"iceberg": {"enabled": true}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/extice/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	if _, ok := store.warehouses["extco"]; ok {
-		t.Error("warehouse must not be created for an external metadata store")
+	w := store.warehouses["extice"]
+	if w == nil {
+		t.Fatal("expected warehouse to be created")
+	}
+	if w.MetadataStore.Kind != configstore.MetadataStoreKindExternal {
+		t.Errorf("metadata store kind = %q, want external", w.MetadataStore.Kind)
+	}
+	if w.MetadataStore.Endpoint != "rds.example.us-east-1.rds.amazonaws.com" || w.MetadataStore.PasswordAWSSecret != "duckling-example-rds-password" {
+		t.Errorf("external creds not persisted: %+v", w.MetadataStore)
+	}
+	if w.MetadataStore.Username != "postgres" || w.MetadataStore.DatabaseName != "postgres" {
+		t.Errorf("user/database not persisted: %+v", w.MetadataStore)
+	}
+	if w.DataStore.Kind != "external" || w.DataStore.BucketName != "posthog-duckling-example" || w.DataStore.Region != "us-east-1" {
+		t.Errorf("data store not persisted: %+v", w.DataStore)
+	}
+	if !w.Iceberg.Enabled || w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
+		t.Errorf("expected iceberg enabled with lakekeeper backend, got %+v", w.Iceberg)
+	}
+}
+
+func TestProvisionDuckLakeExternal(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	// No iceberg block → DuckLake-on-external (iceberg disabled).
+	body := []byte(`{
+		"database_name": "extdl-db",
+		"metadata_store": {"type": "external", "external": {
+			"endpoint": "rds.example.us-east-1.rds.amazonaws.com",
+			"password_aws_secret": "duckling-example-rds-password"
+		}},
+		"data_store": {"type": "external", "bucket_name": "posthog-duckling-example", "region": "us-east-1"}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/extdl/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	w := store.warehouses["extdl"]
+	if w == nil {
+		t.Fatal("expected warehouse to be created")
+	}
+	if w.MetadataStore.Kind != configstore.MetadataStoreKindExternal {
+		t.Errorf("metadata store kind = %q, want external", w.MetadataStore.Kind)
+	}
+	if w.Iceberg.Enabled {
+		t.Errorf("ducklake+external must NOT enable iceberg, got %+v", w.Iceberg)
+	}
+}
+
+func TestProvisionExternalRequiresEndpointAndSecret(t *testing.T) {
+	for name, body := range map[string]string{
+		"missing external block": `{"database_name":"e-db","metadata_store":{"type":"external"}}`,
+		"missing endpoint":       `{"database_name":"e-db","metadata_store":{"type":"external","external":{"password_aws_secret":"s"}}}`,
+		"missing secret":         `{"database_name":"e-db","metadata_store":{"type":"external","external":{"endpoint":"h"}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := newFakeStore()
+			router := newTestRouter(store)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/eco/provision", bytes.NewReader([]byte(body)))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+			if _, ok := store.warehouses["eco"]; ok {
+				t.Error("warehouse must not be created when required external fields are missing")
+			}
+		})
+	}
+}
+
+func TestProvisionExternalDataStoreRequiresBucket(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	// data_store.type=external without bucket_name → 400.
+	body := []byte(`{"database_name":"e-db","metadata_store":{"type":"external","external":{"endpoint":"h","password_aws_secret":"s"}},"data_store":{"type":"external"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/eco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

After #627 the control plane could only create **iceberg+cnpg** (`cnpg-shard`) ducklings. This adds the two **external-metadata** shapes so all three currently-supported topologies are provisionable through `POST /api/v1/orgs/:id/provision`:

| Option | Request | CR shape |
|---|---|---|
| iceberg+cnpg | `metadata_store.type=cnpg-shard` | cnpg-shard, iceberg implied (#627) |
| iceberg+external | `metadata_store.type=external` + `iceberg.enabled=true` | external metadata, iceberg on |
| ducklake+external | `metadata_store.type=external` (no iceberg) | external metadata, no iceberg |

`aurora` stays rejected — the control plane never stands up a fresh Aurora cluster.

## Required-field validation (strict, up-front)

- **external** requires `metadata_store.external.endpoint` (RDS host) **and** `metadata_store.external.password_aws_secret` (the **AWS Secrets Manager secret name** holding the password — resolved by the composition via ESO). `user`/`database` default to `postgres`.
- **data_store** is optional. `type=external` reuses an existing bucket and then requires `bucket_name` (`region` optional). Omitted / `s3bucket` provisions a fresh per-org bucket. (cnpg-shard always uses s3bucket.)
- **iceberg** is optional for external (`enabled` → iceberg+external, omitted → ducklake+external) and implied-on for cnpg-shard.

Example (iceberg+external on the shared example RDS + bucket):
```json
{
  "database_name": "ben-iceberg-external",
  "metadata_store": {"type": "external", "external": {
    "endpoint": "duckling-example-...rds.amazonaws.com",
    "password_aws_secret": "duckling-example-...-rds-password"
  }},
  "data_store": {"type": "external", "bucket_name": "posthog-duckling-example-...", "region": "us-east-1"},
  "iceberg": {"enabled": true}
}
```

## Wiring

- **configstore**: add `MetadataStoreKindExternal`; persist the external password AWS secret name (`ManagedWarehouseMetadataStore.PasswordAWSSecret`) and the data-store provisioning intent (new `ManagedWarehouseDataStore` embed: `kind`/`bucket_name`/`region`) so `reconcilePending` can rebuild the CR after a controller restart. **These columns are provisioning-only** — the worker activator and the `tests/k8s` activation seed don't read them, so no seed change is needed.
- **`DucklingClient.Create` / `CreateOptions`**: emit `spec.metadataStore.external` and a conditional `spec.dataStore` (`s3bucket` | `external`), with the same required-field guards as the API.
- **controller.reconcilePending**: threads the new warehouse fields into `CreateOptions`.

The XRD/composition already support external metadata + external dataStore + iceberg, so no charts change is needed here.

## Test plan

`go test -tags kubernetes ./controlplane/ ./controlplane/provisioner/ ./controlplane/provisioning/ ./controlplane/configstore/` — all green.

New tests:
- API: `TestProvisionIcebergExternal`, `TestProvisionDuckLakeExternal` (assert persisted metadata/datastore/iceberg), `TestProvisionExternalRequiresEndpointAndSecret` (table: missing block/endpoint/secret → 400), `TestProvisionExternalDataStoreRequiresBucket`.
- Provisioner: `TestReconcilePendingCreatesIcebergExternalCR`, `TestReconcilePendingCreatesDuckLakeExternalCR`, `TestDucklingCreateExternalRequiresFields`, `TestDucklingCreateExternalDataStoreRequiresBucket`.

## Note

This is the **creation** path. The deferred iceberg-only activation work still applies: an `iceberg+external` org currently also attaches DuckLake against its external RDS (DuckLake + Iceberg), and `iceberg+cnpg` attaches DuckLake against the Lakekeeper PG — making new ducklings truly iceberg-only is the separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)