### PR TITLE
fix(provisioner): preserve hyphens in derived resource names (drop lossy de-hyphenation)

### DIFF
--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -1257,3 +1257,49 @@ func TestDucklingCreateExternalDataStoreRequiresBucket(t *testing.T) {
 		t.Fatal("expected error: external dataStore without a bucket name")
 	}
 }
+
+// TestDucklingGetFallsBackToLegacyName verifies the backward-compat path: a CR
+// created before ducklingName preserved hyphens (i.e. named with hyphens
+// stripped) is still found when looked up by its hyphenated org ID. Without
+// this, switching ducklingName to keep hyphens would orphan existing prod
+// ducklings whose org IDs contain hyphens (e.g. UUID-named tenants).
+func TestDucklingGetFallsBackToLegacyName(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	ctx := context.Background()
+
+	org := "018d351a-9ff7-0000-eaff-4628875ad045"
+	legacy := legacyDucklingName(org) // "018d351a9ff70000eaff4628875ad045"
+	if ducklingName(org) == legacy {
+		t.Fatal("test premise: hyphenated org id must differ from its legacy de-hyphenated name")
+	}
+
+	// Seed a CR under the legacy (de-hyphenated) name, as the old code would have.
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata":   map[string]interface{}{"name": legacy, "namespace": ducklingNamespace},
+		"status":     map[string]interface{}{"iamRoleArn": "arn:aws:iam::123:role/duckling-" + legacy},
+	}}
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed legacy CR: %v", err)
+	}
+
+	st, err := dc.Get(ctx, org)
+	if err != nil {
+		t.Fatalf("Get must fall back to the legacy de-hyphenated name, got: %v", err)
+	}
+	if st.IAMRoleARN == "" {
+		t.Error("expected to parse the legacy CR's status")
+	}
+
+	// And iceberg/pgbouncer reads + delete must resolve it too.
+	if _, err := dc.GetIcebergEnabled(ctx, org); err != nil {
+		t.Errorf("GetIcebergEnabled fallback: %v", err)
+	}
+	if err := dc.Delete(ctx, org); err != nil {
+		t.Errorf("Delete fallback: %v", err)
+	}
+	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, legacy, metav1.GetOptions{}); getErr == nil {
+		t.Error("legacy CR should have been deleted via the fallback")
+	}
+}

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -80,11 +82,43 @@ func NewDucklingClientWithDynamic(client dynamic.Interface) *DucklingClient {
 	return &DucklingClient{client: client}
 }
 
-// ducklingName converts an org ID to a valid K8s/AWS resource name by stripping
-// hyphens. This keeps names under the 63-char limit for RDS cluster identifiers
-// when the org ID is a full UUID.
+// ducklingName is the k8s/AWS resource name derived from an org ID, used for
+// the Duckling CR, the IAM role (duckling-<name>), the S3 bucket, the
+// Lakekeeper CR/SA/Secret, etc. Org IDs are validated as DNS-1123 labels at
+// provision time (lowercase alphanumerics + hyphens), so this only lowercases:
+// hyphens are preserved, keeping in-cluster names human-readable and injective
+// with the org ID.
+//
+// (It used to strip hyphens to keep per-org Aurora RDS cluster identifiers
+// short, but the control plane no longer provisions per-org Aurora clusters,
+// and stripping was lossy — "a-b" and "ab" collided.)
 func ducklingName(orgID string) string {
-	return strings.ReplaceAll(orgID, "-", "")
+	return strings.ToLower(orgID)
+}
+
+// pgIdentSanitizeRe matches characters not allowed in an unquoted Postgres
+// identifier fragment.
+var pgIdentSanitizeRe = regexp.MustCompile(`[^a-z0-9_]`)
+
+// pgIdentSuffix sanitizes an org ID into a valid unquoted Postgres identifier
+// fragment: lowercase, with every non-[a-z0-9_] character (notably hyphens)
+// mapped to '_'. Postgres identifiers can't contain hyphens unquoted, so PG
+// object names can't preserve them the way k8s names do. This mirrors the
+// Crossplane composition's $pgIdent transform for cnpg-shard, so the external
+// (provisioner-created) and cnpg-shard (composition-created) Lakekeeper
+// databases follow the same convention. Injective for org IDs restricted to
+// [a-z0-9-], which the provision-time validation guarantees.
+func pgIdentSuffix(orgID string) string {
+	return pgIdentSanitizeRe.ReplaceAllString(strings.ToLower(orgID), "_")
+}
+
+// legacyDucklingName is the pre-hyphen-preservation transform (hyphens
+// stripped). Retained ONLY so lookups can still find Duckling CRs created
+// before ducklingName started preserving hyphens — e.g. a CR named
+// "018d351a9ff70000eaff4628875ad045" for org "018d351a-9ff7-0000-eaff-...".
+// New CRs are always created under ducklingName (hyphen-preserving).
+func legacyDucklingName(orgID string) string {
+	return strings.ReplaceAll(strings.ToLower(orgID), "-", "")
 }
 
 // CreateOptions carries per-org knobs that shape the generated Duckling CR.
@@ -240,22 +274,44 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 	return nil
 }
 
-// Get fetches the Duckling CR and parses its status.
-func (d *DucklingClient) Get(ctx context.Context, orgID string) (*DucklingStatus, error) {
+// getCR fetches the org's Duckling CR, trying the current hyphen-preserving
+// name first and falling back to the legacy de-hyphenated name for CRs created
+// before ducklingName preserved hyphens. Returns the CR and the name it was
+// found under (callers that mutate need the actual name). When neither exists,
+// returns the current-name NotFound error so callers see the new scheme.
+func (d *DucklingClient) getCR(ctx context.Context, orgID string) (*unstructured.Unstructured, string, error) {
 	name := ducklingName(orgID)
 	cr, err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return cr, name, nil
+	}
+	if legacy := legacyDucklingName(orgID); legacy != name && apierrors.IsNotFound(err) {
+		if lcr, lerr := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, legacy, metav1.GetOptions{}); lerr == nil {
+			return lcr, legacy, nil
+		}
+	}
+	return nil, name, err
+}
+
+// Get fetches the Duckling CR and parses its status.
+func (d *DucklingClient) Get(ctx context.Context, orgID string) (*DucklingStatus, error) {
+	cr, name, err := d.getCR(ctx, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("get duckling CR %q: %w", name, err)
 	}
 	return parseDucklingStatus(cr)
 }
 
-// Delete removes the Duckling CR for the given org.
+// Delete removes the Duckling CR for the given org. Resolves the legacy name so
+// pre-rename CRs are still deletable.
 func (d *DucklingClient) Delete(ctx context.Context, orgID string) error {
-	name := ducklingName(orgID)
-	err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("delete duckling CR %q: %w", name, err)
+	_, name, err := d.getCR(ctx, orgID)
+	if apierrors.IsNotFound(err) {
+		// Already gone — nothing to delete. (reconcileDeleting treats this as success.)
+		return err
+	}
+	if derr := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Delete(ctx, name, metav1.DeleteOptions{}); derr != nil {
+		return fmt.Errorf("delete duckling CR %q: %w", name, derr)
 	}
 	return nil
 }
@@ -265,8 +321,7 @@ func (d *DucklingClient) Delete(ctx context.Context, orgID string) error {
 // carried a pgbouncer section) are reported as false — same as an explicit
 // opt-out — so the caller just needs to compare against the desired value.
 func (d *DucklingClient) GetPgBouncerEnabled(ctx context.Context, orgID string) (bool, error) {
-	name := ducklingName(orgID)
-	cr, err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, name, metav1.GetOptions{})
+	cr, name, err := d.getCR(ctx, orgID)
 	if err != nil {
 		return false, fmt.Errorf("get duckling CR %q: %w", name, err)
 	}
@@ -291,7 +346,10 @@ func (d *DucklingClient) GetPgBouncerEnabled(ctx context.Context, orgID string) 
 // call is idempotent and only touches the pgbouncer block — sibling fields
 // under metadataStore (aurora, type) are left untouched.
 func (d *DucklingClient) SetPgBouncerEnabled(ctx context.Context, orgID string, enabled bool) error {
-	name := ducklingName(orgID)
+	_, name, err := d.getCR(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("resolve duckling CR for %q: %w", orgID, err)
+	}
 	patch, err := json.Marshal(map[string]interface{}{
 		"spec": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
@@ -318,8 +376,7 @@ func (d *DucklingClient) SetPgBouncerEnabled(ctx context.Context, orgID string, 
 // reported as false — same as an explicit opt-out — so the caller can just
 // compare against the desired value.
 func (d *DucklingClient) GetIcebergEnabled(ctx context.Context, orgID string) (bool, error) {
-	name := ducklingName(orgID)
-	cr, err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, name, metav1.GetOptions{})
+	cr, name, err := d.getCR(ctx, orgID)
 	if err != nil {
 		return false, fmt.Errorf("get duckling CR %q: %w", name, err)
 	}
@@ -344,7 +401,10 @@ func (d *DucklingClient) GetIcebergEnabled(ctx context.Context, orgID string) (b
 // this method intentionally only patches enabled — namespace changes have
 // to go through warehouse re-creation.
 func (d *DucklingClient) SetIcebergEnabled(ctx context.Context, orgID string, enabled bool) error {
-	name := ducklingName(orgID)
+	_, name, err := d.getCR(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("resolve duckling CR for %q: %w", orgID, err)
+	}
 	patch, err := json.Marshal(map[string]interface{}{
 		"spec": map[string]interface{}{
 			"iceberg": map[string]interface{}{

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -73,33 +73,20 @@ func NewLakekeeperK8sClientWithClients(dc dynamic.Interface, kc kubernetes.Inter
 	return &LakekeeperK8sClient{dynamic: dc, kubernetes: kc, namespace: namespace}
 }
 
-// LakekeeperResourceName derives the K8s resource name (CR + Secret) for an
-// org. Matches the ducklingName transform — strips hyphens so UUID-style
-// org IDs land under the 63-char K8s name limit.
+// LakekeeperResourceName derives the K8s resource name (CR + Secret + SA) for
+// an org. Uses ducklingName so it preserves hyphens, matching the Duckling CR
+// and the rest of the in-cluster resources.
 func LakekeeperResourceName(orgID string) string {
-	return "lakekeeper-" + lakekeeperResourceSuffix(orgID)
-}
-
-func lakekeeperResourceSuffix(orgID string) string {
-	// Inline to avoid coupling to ducklingName which lives in another file
-	// under the same build tag.
-	out := make([]byte, 0, len(orgID))
-	for i := 0; i < len(orgID); i++ {
-		if orgID[i] == '-' {
-			continue
-		}
-		out = append(out, orgID[i])
-	}
-	return string(out)
+	return "lakekeeper-" + ducklingName(orgID)
 }
 
 // LakekeeperSecretData is the strongly-typed contents of the per-org Secret
 // that the CR's *SecretRef fields point at. All values are required.
 type LakekeeperSecretData struct {
-	DBUser              string
-	DBPassword          string
-	EncryptionKey       string // 32-byte key used by Lakekeeper for at-rest secret encryption
-	OAuth2ClientSecret  string // client_secret minted for the duckling
+	DBUser             string
+	DBPassword         string
+	EncryptionKey      string // 32-byte key used by Lakekeeper for at-rest secret encryption
+	OAuth2ClientSecret string // client_secret minted for the duckling
 }
 
 // SecretKey* are the keys inside the Secret. Stable contract with the CR.

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -31,10 +31,11 @@ func newFakeLakekeeperClient() (*LakekeeperK8sClient, *dynamicfake.FakeDynamicCl
 }
 
 func TestLakekeeperResourceName(t *testing.T) {
+	// k8s resource names preserve hyphens (only lowercasing is applied).
 	cases := map[string]string{
-		"acme":                 "lakekeeper-acme",
-		"019e417b-18c4-7a41":   "lakekeeper-019e417b18c47a41",
-		"00000000-0000-0000-0000-000000000000": "lakekeeper-00000000000000000000000000000000",
+		"acme":                                 "lakekeeper-acme",
+		"019e417b-18c4-7a41":                   "lakekeeper-019e417b-18c4-7a41",
+		"00000000-0000-0000-0000-000000000000": "lakekeeper-00000000-0000-0000-0000-000000000000",
 	}
 	for in, want := range cases {
 		if got := LakekeeperResourceName(in); got != want {
@@ -336,15 +337,15 @@ func TestEnsureSecret_RejectsUnsafeOrgID(t *testing.T) {
 
 func TestIsValidOrgIDLabel(t *testing.T) {
 	cases := map[string]bool{
-		"acme":                                    true,
-		"019e417b-18c4-7a41-bfec-e9ae3a02deb8":    true, // UUID
-		"a":                                       true,
-		"a.b_c-d":                                 true,
-		"":                                        false,
-		"-leading":                                false,
-		"trailing-":                               false,
-		".":                                       false,
-		"has space":                               false,
+		"acme":                                 true,
+		"019e417b-18c4-7a41-bfec-e9ae3a02deb8": true, // UUID
+		"a":                                    true,
+		"a.b_c-d":                              true,
+		"":                                     false,
+		"-leading":                             false,
+		"trailing-":                            false,
+		".":                                    false,
+		"has space":                            false,
 		// 64 chars (over the 63 limit)
 		"a234567890123456789012345678901234567890123456789012345678901234": false,
 	}

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -441,16 +441,22 @@ func storageCredFor(s3 S3StorageConfig) WarehouseStorageCredential {
 	}
 }
 
+// lakekeeperDBName is the Postgres database (and role) name for the org's
+// Lakekeeper backend. It's a Postgres identifier, so hyphens are sanitized to
+// underscores via pgIdentSuffix — matching the cnpg-shard composition's
+// $pgIdent so the external and cnpg-shard paths agree.
 func lakekeeperDBName(orgID string) string {
-	return "lakekeeper_" + lakekeeperResourceSuffix(orgID)
+	return "lakekeeper_" + pgIdentSuffix(orgID)
 }
 
+// lakekeeperWarehouseName and oauthClientID are free-form strings (the Iceberg
+// REST warehouse name and the OAuth2 client_id), so they preserve hyphens.
 func lakekeeperWarehouseName(orgID string) string {
-	return "org-" + lakekeeperResourceSuffix(orgID)
+	return "org-" + ducklingName(orgID)
 }
 
 func oauthClientID(orgID string) string {
-	return "duckling-" + lakekeeperResourceSuffix(orgID)
+	return "duckling-" + ducklingName(orgID)
 }
 
 func mustRandomHex(byteLen int) string {

--- a/controlplane/provisioner/naming_test.go
+++ b/controlplane/provisioner/naming_test.go
@@ -1,0 +1,58 @@
+//go:build kubernetes
+
+package provisioner
+
+import "testing"
+
+// TestDucklingNamePreservesHyphens locks in the post-fix behavior: k8s/AWS
+// resource names keep hyphens (only lowercasing is applied), and the transform
+// is injective — the regression being the old de-hyphenation where "a-b" and
+// "ab" both collapsed to "ab".
+func TestDucklingNamePreservesHyphens(t *testing.T) {
+	for in, want := range map[string]string{
+		"ben-iceberg-cnpg":                     "ben-iceberg-cnpg",
+		"Ben-Iceberg":                          "ben-iceberg",
+		"team123":                              "team123",
+		"f47ac10b-58cc-4372-a567-0e02b2c3d479": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+	} {
+		if got := ducklingName(in); got != want {
+			t.Errorf("ducklingName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if ducklingName("a-b") == ducklingName("ab") {
+		t.Error("ducklingName must not collide \"a-b\" with \"ab\" (the old de-hyphenation bug)")
+	}
+}
+
+// TestPgIdentSuffixSanitizes verifies the Postgres-identifier transform maps
+// hyphens to underscores (PG identifiers can't be unquoted-hyphenated) and
+// stays injective for [a-z0-9-] inputs.
+func TestPgIdentSuffixSanitizes(t *testing.T) {
+	for in, want := range map[string]string{
+		"ben-iceberg-cnpg": "ben_iceberg_cnpg",
+		"team123":          "team123",
+		"ABC-1":            "abc_1",
+	} {
+		if got := pgIdentSuffix(in); got != want {
+			t.Errorf("pgIdentSuffix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestLakekeeperNamesForHyphenatedOrg verifies the Lakekeeper-derived names:
+// k8s/string names keep hyphens; the PG database uses underscores.
+func TestLakekeeperNamesForHyphenatedOrg(t *testing.T) {
+	const org = "ben-iceberg-external"
+	if got := LakekeeperResourceName(org); got != "lakekeeper-ben-iceberg-external" {
+		t.Errorf("LakekeeperResourceName = %q", got)
+	}
+	if got := lakekeeperDBName(org); got != "lakekeeper_ben_iceberg_external" {
+		t.Errorf("lakekeeperDBName = %q", got)
+	}
+	if got := lakekeeperWarehouseName(org); got != "org-ben-iceberg-external" {
+		t.Errorf("lakekeeperWarehouseName = %q", got)
+	}
+	if got := oauthClientID(org); got != "duckling-ben-iceberg-external" {
+		t.Errorf("oauthClientID = %q", got)
+	}
+}

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -40,6 +40,18 @@ func isUniqueViolation(err error) bool {
 // /trino enable endpoint and the optional trino block on /provision).
 var trinoOrgIDPattern = regexp.MustCompile(`^[0-9]+$`)
 
+// ducklingOrgIDPattern constrains org IDs that get a provisioned warehouse to a
+// single DNS-1123 label (lowercase alphanumerics + hyphens, start/end
+// alphanumeric). This is the shape every derived name needs:
+//   - the SNI prefix <org>.<managed-suffix> is a single DNS label already;
+//   - the Duckling CR / IAM role / S3 bucket / Lakekeeper CR names use the org
+//     ID verbatim (lowercased), so it must be a valid k8s/AWS name;
+//   - the Postgres identifier maps any non-[a-z0-9_] char to '_', which is only
+//     injective when the source charset excludes everything but hyphens.
+//
+// Validating here keeps the org ID → resource-name mappings collision-free.
+var ducklingOrgIDPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
 // Store defines the config store operations needed by the provisioning API.
 type Store interface {
 	GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error)
@@ -212,6 +224,11 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 	var req provisionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !ducklingOrgIDPattern.MatchString(orgID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "org id must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting and ending alphanumeric) so the derived resource names are valid and collision-free"})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -832,3 +832,36 @@ func TestProvisionRejectsUnsupportedMetadataStore(t *testing.T) {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }
+
+func TestProvisionRejectsInvalidOrgID(t *testing.T) {
+	for _, bad := range []string{"ben.iceberg", "Ben-Iceberg", "ben_iceberg", "-bad", "bad-"} {
+		t.Run(bad, func(t *testing.T) {
+			store := newFakeStore()
+			router := newTestRouter(store)
+			body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"}}`)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/"+bad+"/provision", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("orgID %q: status = %d, want 400: %s", bad, rec.Code, rec.Body.String())
+			}
+			if _, ok := store.warehouses[bad]; ok {
+				t.Errorf("warehouse must not be created for invalid org id %q", bad)
+			}
+		})
+	}
+}
+
+func TestProvisionAcceptsHyphenatedOrgID(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/ben-iceberg-cnpg/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("hyphenated org id should be accepted, got %d: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

`ducklingName` stripped **all** hyphens from the org ID to derive the Duckling CR name (and, through it, the IAM role, S3 bucket, Lakekeeper CR/SA/Secret, etc.). So org `ben-iceberg-cnpg` became `benicebergcnpg` in-cluster. That transform was for the old per-org Aurora RDS model (gone) and is **lossy**:
- `a-b` and `ab` both collapse to `ab` (non-injective → collision);
- it's hard to read in-cluster.

This makes the derived names **preserve hyphens** and adds the backward-compat needed so it's safe against existing prod ducklings.

## Changes

- **`ducklingName`** now only lowercases — hyphens preserved. The CR / IAM role / S3 bucket / Lakekeeper CR/SA/Secret names stay human-readable and injective with the org ID.
- **Postgres identifiers** can't be unquoted-hyphenated, so the Lakekeeper db/role name uses a new `pgIdentSuffix` (`[^a-z0-9_]` → `_`), matching the cnpg-shard composition's `$pgIdent` so the external (provisioner-created) and cnpg-shard (composition-created) paths agree.
- Removed `lakekeeperResourceSuffix` (the second hyphen-stripper); `LakekeeperResourceName` / `lakekeeperWarehouseName` / `oauthClientID` preserve hyphens.
- The provisioning API validates org IDs as **DNS-1123 labels** (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`) — already required for the SNI prefix — making the name→resource-name mappings collision-free.

No charts change: the composition derives everything from the (now-hyphenated) CR name and already sanitizes the PG identifier itself.

## Backward compatibility (prod has hyphenated-org-ID ducklings)

Prod currently has e.g. `018d351a9ff70000eaff4628875ad045` and `4dc8564dbd8210652f4097f7c50f67cf` — de-hyphenated UUIDs. **Without compat, switching `ducklingName` to keep hyphens would orphan these**: the controller would look the CR up by the hyphenated org ID, not find the existing de-hyphenated CR, and try to recreate it.

So `DucklingClient` lookups (`Get` / `Delete` / `Get`+`Set` PgBouncer/Iceberg) now resolve the CR via a `getCR` helper that **tries the current hyphen-preserving name first and falls back to the legacy de-hyphenated name**. Existing CRs are found and reconciled normally; new CRs are always created under the hyphen-preserving name. Existing Lakekeeper resources are unaffected — provisioned orgs skip `reconcileLakekeeper` (endpoint already set), and the worker reads the stored `SecretRef`/endpoint rather than recomputing the name.

## Test plan

`go test -tags kubernetes ./controlplane/ ./controlplane/provisioner/ ./controlplane/provisioning/ ./controlplane/configstore/` — all green.

New/updated: `ducklingName` preserves hyphens + injective; `pgIdentSuffix` sanitizes; Lakekeeper names for a hyphenated org; `Get`/`Delete`/`GetIcebergEnabled` fall back to a legacy de-hyphenated CR; API rejects non-DNS-1123 org IDs and accepts hyphenated ones; `TestLakekeeperResourceName` updated to the hyphen-preserving expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)