### PR TITLE
fix(activation): iceberg-only activation for cnpg-shard (no DuckLake)

### DIFF
--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -419,31 +419,38 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 	if err != nil {
 		return server.DuckLakeConfig{}, nil, fmt.Errorf("resolve duckling CR %q: %w", orgID, err)
 	}
-	if status.MetadataStore.Password == "" {
-		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no metadata store password", orgID)
-	}
 	if status.DataStore.BucketName == "" {
 		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no data store bucket", orgID)
 	}
 
-	host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, orgID)
-	if err != nil {
-		return server.DuckLakeConfig{}, nil, err
+	dl := server.DuckLakeConfig{
+		ObjectStore: fmt.Sprintf("s3://%s/", status.DataStore.BucketName),
+		S3Region:    status.DataStore.S3Region,
+		S3UseSSL:    true,
+		S3URLStyle:  "vhost",
 	}
 
-	dl := server.DuckLakeConfig{
-		MetadataStore: buildDuckLakeMetadataStoreDSN(
+	// cnpg-shard tenants are iceberg-only: their metadata store is the
+	// Lakekeeper Postgres backend (not a DuckLake catalog), and the worker has
+	// no egress to reach it. Leave MetadataStore empty so the worker attaches
+	// Iceberg only (server.ActivateDBConnection takes its iceberg-only branch).
+	// External/aurora tenants keep DuckLake — they get the metadata DSN below.
+	if status.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard {
+		if status.MetadataStore.Password == "" {
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no metadata store password", orgID)
+		}
+		host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, orgID)
+		if err != nil {
+			return server.DuckLakeConfig{}, nil, err
+		}
+		dl.MetadataStore = buildDuckLakeMetadataStoreDSN(
 			host,
 			port,
 			status.MetadataStore.User,
 			status.MetadataStore.Password,
 			status.MetadataStore.Database,
-		),
-		ViaPgBouncer: viaPgBouncer,
-		ObjectStore:  fmt.Sprintf("s3://%s/", status.DataStore.BucketName),
-		S3Region:     status.DataStore.S3Region,
-		S3UseSSL:     true,
-		S3URLStyle:   "vhost",
+		)
+		dl.ViaPgBouncer = viaPgBouncer
 	}
 
 	// Broker S3 credentials via STS AssumeRole

--- a/server/activate_iceberg_only_test.go
+++ b/server/activate_iceberg_only_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestActivateDBConnectionRequiresCatalog covers the iceberg-only activation
+// guard: with neither a DuckLake metadata store nor an enabled Iceberg catalog
+// there is nothing to attach, so activation is rejected up front (before any DB
+// work — hence the nil *sql.DB here never gets touched).
+//
+// The success branches (DuckLake-only, iceberg-only, both) attach real
+// catalogs against a live metadata store / Lakekeeper REST endpoint and are
+// exercised by the k8s integration suite + live validation, not here.
+func TestActivateDBConnectionRequiresCatalog(t *testing.T) {
+	// Config{} → DuckLake.MetadataStore == "" and Iceberg.Enabled == false.
+	err := ActivateDBConnection(nil, Config{}, nil, "tenant")
+	if err == nil {
+		t.Fatal("expected error when neither DuckLake nor Iceberg is configured")
+	}
+	if !strings.Contains(err.Error(), "ducklake metadata_store or an enabled iceberg catalog") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1114,30 +1114,49 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 // ActivateDBConnection applies tenant-specific DuckLake runtime to an already
 // initialized generic DuckDB connection used by a shared warm worker.
 func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, username string) error {
-	if cfg.DuckLake.MetadataStore == "" {
-		return fmt.Errorf("tenant activation requires ducklake metadata_store")
+	// Iceberg-only activation (no DuckLake): used by cnpg-shard tenants, whose
+	// "metadata store" is the Lakekeeper Postgres backend, not a DuckLake
+	// catalog (and which the worker has no egress to reach). The control plane
+	// signals this by leaving DuckLake.MetadataStore empty while enabling
+	// Iceberg. External/aurora tenants keep DuckLake (+ optional Iceberg) and
+	// take the branch below unchanged.
+	icebergOnly := cfg.DuckLake.MetadataStore == ""
+	if icebergOnly && !cfg.Iceberg.Enabled {
+		return fmt.Errorf("tenant activation requires a ducklake metadata_store or an enabled iceberg catalog")
 	}
 
-	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
-		return fmt.Errorf("DuckLake configured but attachment failed: %w", err)
-	}
-	if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
-		return fmt.Errorf("delta catalog configured but attachment failed: %w", err)
+	if !icebergOnly {
+		if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
+			return fmt.Errorf("DuckLake configured but attachment failed: %w", err)
+		}
+		if err := AttachDeltaCatalog(db, cfg.DuckLake, duckLakeSem); err != nil {
+			return fmt.Errorf("delta catalog configured but attachment failed: %w", err)
+		}
 	}
 	if err := AttachIcebergCatalog(db, cfg.Iceberg, duckLakeSem, cfg.DuckLake.S3AccessKey, cfg.DuckLake.S3SecretKey, cfg.DuckLake.S3SessionToken); err != nil {
 		return fmt.Errorf("iceberg catalog configured but attachment failed: %w", err)
 	}
 
-	if err := recreatePgClassForDuckLake(db); err != nil {
-		slog.Warn("Failed to recreate pg_class_full for DuckLake during activation.", "user", username, "error", err)
+	// The pg_class/pg_namespace recreation and the duckLakeMode information_schema
+	// reflect the DuckLake catalog; skip the DuckLake-specific rewrites when
+	// there's no DuckLake attached.
+	if !icebergOnly {
+		if err := recreatePgClassForDuckLake(db); err != nil {
+			slog.Warn("Failed to recreate pg_class_full for DuckLake during activation.", "user", username, "error", err)
+		}
+		if err := recreatePgNamespaceForDuckLake(db); err != nil {
+			slog.Warn("Failed to recreate pg_namespace for DuckLake during activation.", "user", username, "error", err)
+		}
 	}
-	if err := recreatePgNamespaceForDuckLake(db); err != nil {
-		slog.Warn("Failed to recreate pg_namespace for DuckLake during activation.", "user", username, "error", err)
-	}
-	if err := initInformationSchema(db, true); err != nil {
+	if err := initInformationSchema(db, !icebergOnly); err != nil {
 		slog.Warn("Failed to initialize information_schema during activation.", "user", username, "error", err)
 	}
-	if err := setDuckLakeDefault(db); err != nil {
+
+	if icebergOnly {
+		if err := setIcebergDefault(db); err != nil {
+			return fmt.Errorf("failed to set Iceberg as default: %w", err)
+		}
+	} else if err := setDuckLakeDefault(db); err != nil {
 		return fmt.Errorf("failed to set DuckLake as default: %w", err)
 	}
 
@@ -1959,6 +1978,21 @@ func setDuckLakeDefault(db *sql.DB) error {
 		return fmt.Errorf("failed to set DuckLake as default catalog: %w", err)
 	}
 	slog.Info("Set DuckLake as default catalog.")
+	return nil
+}
+
+// setIcebergDefault makes the Iceberg catalog the session default for
+// iceberg-only (cnpg-shard) tenants, so unqualified DDL/DML lands in Iceberg
+// rather than the ephemeral in-memory catalog — the analogue of
+// setDuckLakeDefault for the no-DuckLake path. Targets iceberg.<DefaultSchema>
+// (not a bare `USE iceberg`) because DuckDB shadows `main` on a REST catalog;
+// attachLakekeeperCatalog guarantees that schema exists.
+func setIcebergDefault(db *sql.DB) error {
+	stmt := fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("failed to set Iceberg as default catalog: %w", err)
+	}
+	slog.Info("Set Iceberg as default catalog.", "schema", iceberg.DefaultSchema)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

cnpg-shard tenants provision `ready` but **can't be queried**: the worker activator unconditionally builds a DuckLake metadata DSN from the Duckling status. For cnpg-shard that points at the **Lakekeeper Postgres backend** (`lakekeeper_<org>` @ `shard-001-pooler`) — not a DuckLake catalog, and a connection the worker has **no egress** to reach (cnpg tenants reach their catalog via Lakekeeper HTTP). So activation fails:

```
DuckLake migration check failed: connect to lakekeeper_<org> @ shard-001-pooler: timeout
```

This **removes DuckLake from the cnpg-shard path only**. `external`/`aurora` are untouched — they keep DuckLake (+ optional Iceberg), which is the working prod model: `external + iceberg` tenants (portola, posthog) legitimately run **both** catalogs.

## Changes

- **`buildDuckLakeConfigFromDuckling`** (control plane): when `status.MetadataStore.Type == "cnpg-shard"`, leave `DuckLakeConfig.MetadataStore` empty (no DuckLake DSN, no metadata-store address lookup) while still brokering the S3 creds + object store the Iceberg secret needs. Every other type builds the DuckLake DSN exactly as before.
- **`ActivateDBConnection`** (worker): when `DuckLake.MetadataStore` is empty, take an **iceberg-only** path — skip `AttachDuckLake`/`AttachDeltaCatalog`, the DuckLake `pg_class`/`pg_namespace` recreation, and the `duckLakeMode` `information_schema`; still `AttachIcebergCatalog`; set the Iceberg catalog (`iceberg.<DefaultSchema>`) as the session default via new `setIcebergDefault`. Errors up front if **neither** DuckLake nor Iceberg is configured.

## Scope / what's deliberately unchanged

- `external`/`aurora` + iceberg → still attach **both** DuckLake and Iceberg (matches prod).
- The control-plane transpiler stays in `DuckLakeMode` (global `AlwaysDuckLake` in remote mode). Iceberg-qualified (`iceberg.schema.table`) and unqualified queries work (unqualified resolve to the worker's iceberg default; the logical-catalog rewrite only fires on the literal db name). Mapping the *logical db name* itself to the iceberg catalog (so `ben-iceberg-cnpg.x` works) would be a separate per-org transpiler change — not needed for the validated query patterns.

## Test plan

- New `TestActivateDBConnectionRequiresCatalog` (guard: no DuckLake + no Iceberg → error).
- Existing `external`/`aurora` activation tests unchanged + passing (`controlplane`, `server` suites green).
- `tests/k8s` compiles (`go test -c`); not run (destructive TestMain).
- **Full cnpg-shard path validated live** on mw-dev (`ben-iceberg-cnpg`) — can't be unit-tested without a real Lakekeeper REST endpoint + the cnpg shard.

After deploy I'll re-run the `ben-iceberg-cnpg` round-trip (`CREATE SCHEMA iceberg.x; CREATE TABLE; INSERT; SELECT`) to confirm it activates iceberg-only and writes to S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)