### PR TITLE
feat(controlplane): decouple metadata backend, DuckLake, and Iceberg

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -159,6 +159,21 @@ type ManagedWarehouseWorkerIdentity struct {
 	IAMRoleARN         string `gorm:"size:512" json:"iam_role_arn"`
 }
 
+// ManagedWarehouseDuckLake captures whether the org's DuckLake catalog is
+// enabled. Decoupled from the metadata-store type and from Iceberg: a duckling
+// may run DuckLake, Iceberg, or both, on any metadata backend (cnpg / external
+// / aurora). The DuckLake catalog lives in the metadata Postgres — the
+// per-tenant database for cnpg-shard, or the metadata database for
+// external/aurora.
+//
+// For ducklings created before this field existed the column is absent/false;
+// the worker activator does NOT key off it directly — it reads the Duckling
+// CR's spec.ducklake.enabled (present/absent) so legacy ducklings keep their
+// implied behavior (external/aurora ⇒ DuckLake, cnpg ⇒ none).
+type ManagedWarehouseDuckLake struct {
+	Enabled bool `json:"enabled"`
+}
+
 // ManagedWarehouseIceberg captures per-org Iceberg catalog config. Two
 // backends are supported, selected by Backend:
 //
@@ -321,6 +336,7 @@ type ManagedWarehouse struct {
 	DataStore         ManagedWarehouseDataStore      `gorm:"embedded;embeddedPrefix:data_store_" json:"data_store"`
 	PgBouncer         ManagedWarehousePgBouncer      `gorm:"embedded;embeddedPrefix:pgbouncer_" json:"pgbouncer"`
 	S3                ManagedWarehouseS3             `gorm:"embedded;embeddedPrefix:s3_" json:"s3"`
+	DuckLake          ManagedWarehouseDuckLake       `gorm:"embedded;embeddedPrefix:ducklake_" json:"ducklake"`
 	Iceberg           ManagedWarehouseIceberg        `gorm:"embedded;embeddedPrefix:iceberg_" json:"iceberg"`
 	WorkerIdentity    ManagedWarehouseWorkerIdentity `gorm:"embedded;embeddedPrefix:worker_identity_" json:"worker_identity"`
 

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -226,6 +226,7 @@ func (c *Controller) reconcilePending(ctx context.Context, w *configstore.Manage
 		DataStoreRegion:           w.DataStore.Region,
 		IcebergEnabled:            w.Iceberg.Enabled,
 		IcebergNamespace:          w.Iceberg.Namespace,
+		DuckLakeEnabled:           w.DuckLake.Enabled,
 	}); err != nil {
 		log.Error("Failed to create Duckling CR.", "error", err)
 		_ = c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStatePending, map[string]interface{}{

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -1011,26 +1011,60 @@ func TestReconcilePendingCreatesCnpgShardCR(t *testing.T) {
 	if !ok || iceberg["enabled"] != true {
 		t.Errorf("expected iceberg.enabled=true on cnpg-shard CR, got %v", spec["iceberg"])
 	}
+	// DuckLake is emitted explicitly (false here — iceberg-only cnpg).
+	ducklake, ok := spec["ducklake"].(map[string]interface{})
+	if !ok || ducklake["enabled"] != false {
+		t.Errorf("expected ducklake.enabled=false on iceberg-only cnpg-shard CR, got %v", spec["ducklake"])
+	}
 	if fs.warehouses["org-cnpg"].State != configstore.ManagedWarehouseStateProvisioning {
 		t.Fatalf("expected provisioning state, got %q", fs.warehouses["org-cnpg"].State)
 	}
 }
 
-// TestDucklingCreateCnpgShardRequiresIceberg verifies the Create guard: a
-// cnpg-shard CR is rejected when iceberg isn't enabled, because the XRD
-// admission rule would reject it and the tenant would have no usable catalog.
-func TestDucklingCreateCnpgShardRequiresIceberg(t *testing.T) {
+// TestReconcilePendingCreatesDuckLakeOnlyCnpgCR verifies the decoupled combo:
+// cnpg-shard with DuckLake on and Iceberg off → ducklake.enabled=true, no
+// iceberg block.
+func TestReconcilePendingCreatesDuckLakeOnlyCnpgCR(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-dlcnpg"] = &configstore.ManagedWarehouse{
+		OrgID:         "org-dlcnpg",
+		State:         configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{Kind: configstore.MetadataStoreKindCnpgShard},
+		DuckLake:      configstore.ManagedWarehouseDuckLake{Enabled: true},
+	}
+	ctx := context.Background()
+	NewControllerWithClient(fs, dc, time.Second).reconcile(ctx)
+
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("org-dlcnpg"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected CR to exist: %v", err)
+	}
+	spec := cr.Object["spec"].(map[string]interface{})
+	if dl, ok := spec["ducklake"].(map[string]interface{}); !ok || dl["enabled"] != true {
+		t.Errorf("expected ducklake.enabled=true, got %v", spec["ducklake"])
+	}
+	if _, present := spec["iceberg"]; present {
+		t.Errorf("ducklake-only cnpg CR must not carry an iceberg block, got %v", spec["iceberg"])
+	}
+}
+
+// TestDucklingCreateCnpgShardRequiresCatalog verifies the Create guard: a
+// cnpg-shard CR with neither DuckLake nor Iceberg has nothing to attach and is
+// rejected.
+func TestDucklingCreateCnpgShardRequiresCatalog(t *testing.T) {
 	dc, fakeK8s := newFakeDucklingClient()
 	ctx := context.Background()
 
-	err := dc.Create(ctx, "no-iceberg", CreateOptions{
+	err := dc.Create(ctx, "no-catalog", CreateOptions{
 		MetadataStoreType: configstore.MetadataStoreKindCnpgShard,
 		IcebergEnabled:    false,
+		DuckLakeEnabled:   false,
 	})
 	if err == nil {
-		t.Fatal("expected error creating cnpg-shard CR without iceberg")
+		t.Fatal("expected error creating cnpg-shard CR with no catalog enabled")
 	}
-	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("no-iceberg"), metav1.GetOptions{}); getErr == nil {
+	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, ducklingName("no-catalog"), metav1.GetOptions{}); getErr == nil {
 		t.Error("CR should not have been created when validation failed")
 	}
 }
@@ -1301,5 +1335,31 @@ func TestDucklingGetFallsBackToLegacyName(t *testing.T) {
 	}
 	if _, getErr := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, legacy, metav1.GetOptions{}); getErr == nil {
 		t.Error("legacy CR should have been deleted via the fallback")
+	}
+}
+
+// TestParseDucklingStatusDuckLakeEnabled locks in the present/absent contract
+// for spec.ducklake.enabled: nil (legacy CR) lets the activator apply the
+// type-based default; an explicit true/false is authoritative.
+func TestParseDucklingStatusDuckLakeEnabled(t *testing.T) {
+	mk := func(spec map[string]interface{}) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "k8s.posthog.com/v1alpha1",
+			"kind":       "Duckling",
+			"spec":       spec,
+			"status":     map[string]interface{}{},
+		}}
+	}
+	ds, _ := parseDucklingStatus(mk(map[string]interface{}{}))
+	if ds.DuckLakeEnabled != nil {
+		t.Errorf("absent ducklake block → nil, got %v", *ds.DuckLakeEnabled)
+	}
+	ds, _ = parseDucklingStatus(mk(map[string]interface{}{"ducklake": map[string]interface{}{"enabled": true}}))
+	if ds.DuckLakeEnabled == nil || !*ds.DuckLakeEnabled {
+		t.Errorf("ducklake.enabled=true → *true, got %v", ds.DuckLakeEnabled)
+	}
+	ds, _ = parseDucklingStatus(mk(map[string]interface{}{"ducklake": map[string]interface{}{"enabled": false}}))
+	if ds.DuckLakeEnabled == nil || *ds.DuckLakeEnabled {
+		t.Errorf("ducklake.enabled=false → *false, got %v", ds.DuckLakeEnabled)
 	}
 }

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -57,6 +57,12 @@ type DucklingStatus struct {
 	IAMRoleARN         string
 	ReadyCondition     bool
 	SyncedFalseMessage string
+
+	// DuckLakeEnabled is spec.ducklake.enabled, read present/absent: nil when
+	// the CR predates the decoupled ducklake field (the worker activator then
+	// falls back to the legacy type-based default — DuckLake on for
+	// external/aurora, off for cnpg-shard). Non-nil for decoupled ducklings.
+	DuckLakeEnabled *bool
 }
 
 // DucklingClient wraps a Kubernetes dynamic client for Duckling CR operations.
@@ -157,6 +163,11 @@ type CreateOptions struct {
 	// IcebergNamespace is the Iceberg namespace within the tenant's catalog.
 	// Empty falls back to the XRD default ("main").
 	IcebergNamespace string
+
+	// DuckLakeEnabled toggles spec.ducklake.enabled. Independent of Iceberg and
+	// of the metadata-store type; at least one of DuckLakeEnabled/IcebergEnabled
+	// must be true (Create rejects a CR with neither).
+	DuckLakeEnabled bool
 }
 
 // Create creates a Duckling CR for the given org.
@@ -166,15 +177,14 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 	var metadataStore map[string]interface{}
 	switch opts.MetadataStoreType {
 	case configstore.MetadataStoreKindCnpgShard:
-		// The cnpg-shard metadata store backs the per-tenant Lakekeeper
-		// Iceberg catalog on the shared CloudNativePG shard. It carries no
+		// The cnpg-shard metadata store is the per-tenant Postgres on the shared
+		// CloudNativePG shard, provisioned via provider-sql. It carries no
 		// per-claim config — the composition reads the active shard from chart
-		// values and provisions a lakekeeper_<org> role + database via
-		// provider-sql. The XRD admission rule requires iceberg.enabled=true
-		// for this type, so refuse to emit a CR that would be rejected (and
-		// that would have no usable catalog).
-		if !opts.IcebergEnabled {
-			return fmt.Errorf("create duckling CR %q: metadata store type %q requires iceberg enabled", name, configstore.MetadataStoreKindCnpgShard)
+		// values. It hosts the DuckLake catalog and/or the Lakekeeper PG
+		// depending on the catalog flags; a CR with neither catalog has nothing
+		// to attach, so refuse it.
+		if !opts.IcebergEnabled && !opts.DuckLakeEnabled {
+			return fmt.Errorf("create duckling CR %q: metadata store type %q requires at least one of ducklake or iceberg enabled", name, configstore.MetadataStoreKindCnpgShard)
 		}
 		// No aurora block and no pgbouncer block: cnpg-shard tenants reach
 		// Postgres through the shard's own session-mode Pooler, not a
@@ -247,6 +257,11 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 	spec := map[string]interface{}{
 		"metadataStore": metadataStore,
 		"dataStore":     dataStore,
+		// DuckLake is set explicitly (true or false) so the catalog choice is
+		// unambiguous on the CR — the worker activator reads spec.ducklake.enabled
+		// and only falls back to the legacy type-based default when the field is
+		// absent (i.e. for ducklings created before decoupling).
+		"ducklake": map[string]interface{}{"enabled": opts.DuckLakeEnabled},
 	}
 	if opts.IcebergEnabled {
 		iceberg := map[string]interface{}{"enabled": true}
@@ -424,14 +439,39 @@ func (d *DucklingClient) SetIcebergEnabled(ctx context.Context, orgID string, en
 	return nil
 }
 
+// readSpecDuckLakeEnabled returns spec.ducklake.enabled as *bool — nil when the
+// ducklake block (or its enabled key) is absent, so callers can distinguish a
+// legacy CR (apply the type-based default) from an explicit true/false.
+func readSpecDuckLakeEnabled(cr *unstructured.Unstructured) *bool {
+	spec, ok := cr.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	dl, ok := spec["ducklake"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	v, ok := dl["enabled"].(bool)
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
 func parseDucklingStatus(cr *unstructured.Unstructured) (*DucklingStatus, error) {
+	// spec.ducklake.enabled lives in .spec (not .status) — read it first so it's
+	// captured even before the composition writes any status. Present/absent is
+	// significant: absent (legacy CR) leaves DuckLakeEnabled nil.
+	duckLakeEnabled := readSpecDuckLakeEnabled(cr)
+
 	status, ok := cr.Object["status"].(map[string]interface{})
 	if !ok {
-		return &DucklingStatus{}, nil
+		return &DucklingStatus{DuckLakeEnabled: duckLakeEnabled}, nil
 	}
 
 	ds := &DucklingStatus{
-		IAMRoleARN: getNestedString(status, "iamRoleArn"),
+		IAMRoleARN:      getNestedString(status, "iamRoleArn"),
+		DuckLakeEnabled: duckLakeEnabled,
 	}
 
 	// Parse status.metadataStore

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -121,6 +121,7 @@ type provisionRequest struct {
 	DatabaseName  string                 `json:"database_name"`
 	MetadataStore *provisionMetadataReq  `json:"metadata_store,omitempty"`
 	DataStore     *provisionDataStoreReq `json:"data_store,omitempty"`
+	DuckLake      *provisionDuckLakeReq  `json:"ducklake,omitempty"`
 	Iceberg       *provisionIcebergReq   `json:"iceberg,omitempty"`
 
 	// Trino is the opt-in flag for the customer-facing Trino cluster.
@@ -136,6 +137,23 @@ type provisionMetadataReq struct {
 	// External is required when Type == "external": a pre-existing Postgres
 	// referenced by host + an AWS Secrets Manager secret for the password.
 	External *provisionExternalReq `json:"external,omitempty"`
+	// Aurora is required when Type == "aurora": serverless v2 sizing for the
+	// per-org Aurora cluster the composition provisions.
+	Aurora *provisionAuroraReq `json:"aurora,omitempty"`
+}
+
+// provisionAuroraReq is the serverless-v2 ACU sizing for an aurora metadata
+// store. MaxACU must be > 0; MinACU defaults to 0 (scale-to-zero).
+type provisionAuroraReq struct {
+	MinACU float64 `json:"min_acu"`
+	MaxACU float64 `json:"max_acu"`
+}
+
+// provisionDuckLakeReq toggles the DuckLake catalog. Independent of Iceberg and
+// of the metadata-store type: enable DuckLake, Iceberg, or both. At least one
+// catalog must be enabled.
+type provisionDuckLakeReq struct {
+	Enabled bool `json:"enabled"`
 }
 
 // provisionExternalReq describes a pre-existing (external) Postgres metadata
@@ -242,41 +260,51 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	// The control plane provisions three duckling shapes:
-	//   - iceberg+cnpg     metadata_store.type=cnpg-shard          (iceberg implied)
-	//   - iceberg+external  metadata_store.type=external + iceberg.enabled
-	//   - ducklake+external metadata_store.type=external           (iceberg omitted)
-	//
-	// "aurora" is no longer provisionable (the control plane never stands up a
-	// new Aurora cluster). Validation is strict: each shape's required fields
-	// must be present, or the request is rejected before any write.
-	warehouse := &configstore.ManagedWarehouse{}
-	switch req.MetadataStore.Type {
-	case configstore.MetadataStoreKindCnpgShard:
-		// cnpg-shard takes no per-claim config: the composition picks the active
-		// shard from chart values and provisions a fresh per-org bucket. Per the
-		// Duckling XRD it must always have Iceberg enabled (Lakekeeper backend),
-		// so enable it here rather than making the caller pass it redundantly.
-		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindCnpgShard
+	// Catalogs are decoupled from the metadata backend: a duckling can run
+	// DuckLake, Iceberg, or both, on any of the three metadata stores. At least
+	// one catalog must be enabled (a warehouse with neither has nothing to
+	// attach).
+	ducklakeEnabled := req.DuckLake != nil && req.DuckLake.Enabled
+	icebergEnabled := req.Iceberg != nil && req.Iceberg.Enabled
+	if !ducklakeEnabled && !icebergEnabled {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one of ducklake.enabled or iceberg.enabled must be true"})
+		return
+	}
+
+	ds, derr := resolveDataStore(req.DataStore)
+	if derr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": derr.Error()})
+		return
+	}
+
+	warehouse := &configstore.ManagedWarehouse{
+		DataStore: ds,
+		DuckLake:  configstore.ManagedWarehouseDuckLake{Enabled: ducklakeEnabled},
+	}
+	if icebergEnabled {
 		warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
 			Enabled:   true,
 			Backend:   configstore.IcebergBackendLakekeeper,
 			Namespace: icebergNamespace(req.Iceberg),
 		}
+	}
+
+	// Metadata backend (the Postgres that hosts the DuckLake catalog and/or the
+	// Lakekeeper PG). Provisioning shape differs per type; the catalog choice
+	// above is orthogonal.
+	switch req.MetadataStore.Type {
+	case configstore.MetadataStoreKindCnpgShard:
+		// No per-claim config — the composition picks the active shard from
+		// chart values and provisions the per-tenant role+database there.
+		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindCnpgShard
 
 	case configstore.MetadataStoreKindExternal:
 		// A pre-existing Postgres. Endpoint (RDS host) + the AWS Secrets Manager
 		// secret name for the password are required; user/database default to
-		// "postgres". Iceberg is optional: enabled → iceberg+external, omitted →
-		// ducklake+external.
+		// "postgres" at the XRD.
 		ext := req.MetadataStore.External
 		if ext == nil || ext.Endpoint == "" || ext.PasswordAWSSecret == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'external' requires metadata_store.external.endpoint and metadata_store.external.password_aws_secret"})
-			return
-		}
-		ds, derr := resolveDataStore(req.DataStore)
-		if derr != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": derr.Error()})
 			return
 		}
 		warehouse.MetadataStore = configstore.ManagedWarehouseMetadataStore{
@@ -286,20 +314,20 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 			DatabaseName:      ext.Database,
 			PasswordAWSSecret: ext.PasswordAWSSecret,
 		}
-		warehouse.DataStore = ds
-		if req.Iceberg != nil && req.Iceberg.Enabled {
-			warehouse.Iceberg = configstore.ManagedWarehouseIceberg{
-				Enabled:   true,
-				Backend:   configstore.IcebergBackendLakekeeper,
-				Namespace: icebergNamespace(req.Iceberg),
-			}
-		}
 
 	case configstore.MetadataStoreKindAurora:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "DuckLake on a fresh Aurora cluster (metadata_store.type 'aurora') is no longer provisionable; use 'cnpg-shard' or 'external'"})
-		return
+		// A per-org Aurora serverless-v2 cluster the composition provisions.
+		a := req.MetadataStore.Aurora
+		if a == nil || a.MaxACU <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'aurora' requires metadata_store.aurora.max_acu > 0"})
+			return
+		}
+		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindAurora
+		warehouse.AuroraMinACU = a.MinACU
+		warehouse.AuroraMaxACU = a.MaxACU
+
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q or %q (got %q)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, req.MetadataStore.Type)})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q, %q, or %q (got %q)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, configstore.MetadataStoreKindAurora, req.MetadataStore.Type)})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -206,29 +206,44 @@ func newTestRouter(store Store) *gin.Engine {
 // provisionable — even with a valid sizing block — now that cnpg-shard is the
 // only creatable backend. Existing DuckLake deployments are unaffected; this
 // only gates new creation.
-func TestProvisionRejectsAurora(t *testing.T) {
+func TestProvisionAuroraDuckLake(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
 
 	body := []byte(`{
 		"database_name": "analytics-db",
-		"metadata_store": {
-			"type": "aurora",
-			"aurora": {"min_acu": 0.5, "max_acu": 2}
-		}
+		"metadata_store": {"type": "aurora", "aurora": {"min_acu": 0.5, "max_acu": 2}},
+		"ducklake": {"enabled": true}
 	}`)
-
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	if _, ok := store.warehouses["analytics"]; ok {
-		t.Error("warehouse must not be created for a DuckLake (aurora) metadata store")
+	w := store.warehouses["analytics"]
+	if w == nil || w.MetadataStore.Kind != configstore.MetadataStoreKindAurora {
+		t.Fatalf("expected aurora warehouse, got %+v", w)
+	}
+	if w.AuroraMaxACU != 2 || !w.DuckLake.Enabled || w.Iceberg.Enabled {
+		t.Errorf("expected aurora max_acu=2, ducklake on, iceberg off; got max=%v ducklake=%v iceberg=%v", w.AuroraMaxACU, w.DuckLake.Enabled, w.Iceberg.Enabled)
+	}
+}
+
+func TestProvisionAuroraRequiresSizing(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	// aurora with a catalog but no max_acu → 400.
+	body := []byte(`{"database_name":"a-db","metadata_store":{"type":"aurora"},"ducklake":{"enabled":true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/aco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -236,7 +251,7 @@ func TestProvisionAutoCreatesOrg(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/new-org/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -277,7 +292,7 @@ func TestProvisionRejectsExistingNonTerminal(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "test-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -298,7 +313,7 @@ func TestProvisionAllowsRetryAfterFailure(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -322,7 +337,7 @@ func TestProvisionAllowsRetryAfterDeleted(t *testing.T) {
 	}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -469,7 +484,7 @@ func TestProvisionEnablesTrinoWhenRequested(t *testing.T) {
 	// cnpg-shard warehouse, which is the prerequisite for Trino.
 	body := []byte(`{
 		"database_name": "team-42-db",
-		"metadata_store": {"type": "cnpg-shard"},
+		"metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true},
 		"trino": {"enabled": true, "tier": "free"}
 	}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/42/provision", bytes.NewReader(body))
@@ -496,7 +511,7 @@ func TestProvisionTransactionRollsBackOnUserFailure(t *testing.T) {
 	store.setProvisionUserFailHook(errors.New("simulated DB write failure"))
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "team-7-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "team-7-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/7/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -542,7 +557,7 @@ func TestProvisionRejectsTrinoWithNonNumericOrgID(t *testing.T) {
 
 	body := []byte(`{
 		"database_name": "analytics-db",
-		"metadata_store": {"type": "cnpg-shard"},
+		"metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true},
 		"trino": {"enabled": true}
 	}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
@@ -560,7 +575,7 @@ func TestProvisionWithoutTrinoLeavesTrinoRowUnset(t *testing.T) {
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
 
-	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "analytics-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -681,7 +696,7 @@ func TestProvisionCnpgShard(t *testing.T) {
 	router := newTestRouter(store)
 
 	// No aurora block — cnpg-shard takes no sizing and auto-enables iceberg.
-	body := []byte(`{"database_name": "shardco-db", "metadata_store": {"type": "cnpg-shard"}}`)
+	body := []byte(`{"database_name": "shardco-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/shardco/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -746,20 +761,65 @@ func TestProvisionIcebergExternal(t *testing.T) {
 	if !w.Iceberg.Enabled || w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
 		t.Errorf("expected iceberg enabled with lakekeeper backend, got %+v", w.Iceberg)
 	}
+	// Decoupled: iceberg without a ducklake flag is iceberg-ONLY (no implicit DuckLake).
+	if w.DuckLake.Enabled {
+		t.Errorf("iceberg+external without a ducklake flag must NOT enable DuckLake; got ducklake=%v", w.DuckLake.Enabled)
+	}
+}
+
+// TestProvisionRejectsNoCatalog verifies the ≥1-catalog gate: a duckling with
+// neither ducklake nor iceberg is rejected.
+func TestProvisionRejectsNoCatalog(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	body := []byte(`{"database_name":"nc-db","metadata_store":{"type":"cnpg-shard"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/ncco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if _, ok := store.warehouses["ncco"]; ok {
+		t.Error("warehouse must not be created with no catalog enabled")
+	}
+}
+
+// TestProvisionCnpgDuckLakeAndIceberg verifies the fully-decoupled combo:
+// cnpg-shard with both catalogs.
+func TestProvisionCnpgDuckLakeAndIceberg(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	body := []byte(`{"database_name":"both-db","metadata_store":{"type":"cnpg-shard"},"ducklake":{"enabled":true},"iceberg":{"enabled":true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/bothco/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+	w := store.warehouses["bothco"]
+	if w == nil || w.MetadataStore.Kind != configstore.MetadataStoreKindCnpgShard {
+		t.Fatalf("expected cnpg-shard warehouse, got %+v", w)
+	}
+	if !w.DuckLake.Enabled || !w.Iceberg.Enabled {
+		t.Errorf("expected both ducklake and iceberg enabled; got ducklake=%v iceberg=%v", w.DuckLake.Enabled, w.Iceberg.Enabled)
+	}
 }
 
 func TestProvisionDuckLakeExternal(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
 
-	// No iceberg block → DuckLake-on-external (iceberg disabled).
+	// ducklake on, no iceberg → DuckLake-only on external.
 	body := []byte(`{
 		"database_name": "extdl-db",
 		"metadata_store": {"type": "external", "external": {
 			"endpoint": "rds.example.us-east-1.rds.amazonaws.com",
 			"password_aws_secret": "duckling-example-rds-password"
 		}},
-		"data_store": {"type": "external", "bucket_name": "posthog-duckling-example", "region": "us-east-1"}
+		"data_store": {"type": "external", "bucket_name": "posthog-duckling-example", "region": "us-east-1"},
+		"ducklake": {"enabled": true}
 	}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/extdl/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -776,16 +836,16 @@ func TestProvisionDuckLakeExternal(t *testing.T) {
 	if w.MetadataStore.Kind != configstore.MetadataStoreKindExternal {
 		t.Errorf("metadata store kind = %q, want external", w.MetadataStore.Kind)
 	}
-	if w.Iceberg.Enabled {
-		t.Errorf("ducklake+external must NOT enable iceberg, got %+v", w.Iceberg)
+	if !w.DuckLake.Enabled || w.Iceberg.Enabled {
+		t.Errorf("ducklake-only+external: want ducklake on, iceberg off; got ducklake=%v iceberg=%v", w.DuckLake.Enabled, w.Iceberg.Enabled)
 	}
 }
 
 func TestProvisionExternalRequiresEndpointAndSecret(t *testing.T) {
 	for name, body := range map[string]string{
-		"missing external block": `{"database_name":"e-db","metadata_store":{"type":"external"}}`,
-		"missing endpoint":       `{"database_name":"e-db","metadata_store":{"type":"external","external":{"password_aws_secret":"s"}}}`,
-		"missing secret":         `{"database_name":"e-db","metadata_store":{"type":"external","external":{"endpoint":"h"}}}`,
+		"missing external block": `{"database_name":"e-db","ducklake":{"enabled":true},"metadata_store":{"type":"external"}}`,
+		"missing endpoint":       `{"database_name":"e-db","ducklake":{"enabled":true},"metadata_store":{"type":"external","external":{"password_aws_secret":"s"}}}`,
+		"missing secret":         `{"database_name":"e-db","ducklake":{"enabled":true},"metadata_store":{"type":"external","external":{"endpoint":"h"}}}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			store := newFakeStore()
@@ -808,7 +868,7 @@ func TestProvisionExternalDataStoreRequiresBucket(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
 	// data_store.type=external without bucket_name → 400.
-	body := []byte(`{"database_name":"e-db","metadata_store":{"type":"external","external":{"endpoint":"h","password_aws_secret":"s"}},"data_store":{"type":"external"}}`)
+	body := []byte(`{"database_name":"e-db","ducklake":{"enabled":true},"metadata_store":{"type":"external","external":{"endpoint":"h","password_aws_secret":"s"}},"data_store":{"type":"external"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/eco/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -838,7 +898,7 @@ func TestProvisionRejectsInvalidOrgID(t *testing.T) {
 		t.Run(bad, func(t *testing.T) {
 			store := newFakeStore()
 			router := newTestRouter(store)
-			body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"}}`)
+			body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"},"iceberg":{"enabled":true}}`)
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/"+bad+"/provision", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
@@ -856,7 +916,7 @@ func TestProvisionRejectsInvalidOrgID(t *testing.T) {
 func TestProvisionAcceptsHyphenatedOrgID(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)
-	body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"}}`)
+	body := []byte(`{"database_name":"d","metadata_store":{"type":"cnpg-shard"},"iceberg":{"enabled":true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/ben-iceberg-cnpg/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -430,14 +430,20 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 		S3URLStyle:  "vhost",
 	}
 
-	// cnpg-shard tenants are iceberg-only: their metadata store is the
-	// Lakekeeper Postgres backend (not a DuckLake catalog), and the worker has
-	// no egress to reach it. Leave MetadataStore empty so the worker attaches
-	// Iceberg only (server.ActivateDBConnection takes its iceberg-only branch).
-	// External/aurora tenants keep DuckLake — they get the metadata DSN below.
-	if status.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard {
+	// DuckLake is attached iff this tenant has it enabled. The CR's
+	// spec.ducklake.enabled is authoritative (decoupled ducklings); legacy CRs
+	// that predate the field fall back to the historical coupling — DuckLake on
+	// for external/aurora, off for cnpg-shard. When on, the catalog lives in the
+	// metadata Postgres (the per-tenant lakekeeper_<org> DB on cnpg, or the
+	// metadata DB on external/aurora); when off the worker attaches Iceberg only
+	// (server.ActivateDBConnection takes its iceberg-only branch).
+	ducklakeEnabled := status.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard
+	if status.DuckLakeEnabled != nil {
+		ducklakeEnabled = *status.DuckLakeEnabled
+	}
+	if ducklakeEnabled {
 		if status.MetadataStore.Password == "" {
-			return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no metadata store password", orgID)
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has DuckLake enabled but no metadata store password", orgID)
 		}
 		host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, orgID)
 		if err != nil {


### PR DESCRIPTION
## Summary

Make a duckling's three axes independent (the model you asked for):

```
metadata: cnpg-shard | external | aurora
ducklake: true/false
iceberg:  true/false        (at least one catalog required)
```

Previously the catalog was implied by the metadata type — `cnpg ⇒ iceberg-only`, `external/aurora ⇒ DuckLake (+ optional iceberg)`, `aurora` rejected. Now all 9 catalog×metadata combinations are expressible.

## Changes (duckgres)

- **provisioning API**: `ducklake.enabled` is a first-class flag alongside `iceberg.enabled`, both independent of `metadata_store.type`. **Re-enables `aurora`** (requires `aurora.max_acu > 0`). Rejects a request with neither catalog. `external` still requires `endpoint` + `password_aws_secret`.
- **configstore**: new `ManagedWarehouseDuckLake{Enabled}` (embedded `ducklake_`).
- **`DucklingClient.Create` / `CreateOptions`**: emit `spec.ducklake.enabled` explicitly; the cnpg guard now requires **≥1 catalog** (was: iceberg required).
- **activation**: the worker attaches DuckLake iff the tenant has it enabled. `spec.ducklake.enabled` is authoritative; **legacy CRs without the field fall back to the historical coupling** (DuckLake on for external/aurora, off for cnpg) — so existing prod ducklings (portola, posthog, ben, perfprodus) are unaffected. Reuses #633's iceberg-only `ActivateDBConnection` path.

## Charts dependency (separate PR)

For **`cnpg + ducklake`**, the catalog lives in the per-tenant `lakekeeper_<org>` DB on the shard (it doubles as the DuckLake catalog). That combo also needs the **worker→cnpg-pooler egress re-added** in the crossplane-config composition, plus the XRD changes (independent `ducklake.enabled`, drop the `cnpg ⇒ iceberg` rule, allow `aurora`). Until that charts PR lands, cnpg is effectively iceberg-only at runtime (no egress to attach DuckLake) — which matches today's behavior, so this PR is safe to merge first.

## Test plan

`go test -tags kubernetes ./controlplane/... ./server/` — green; `tests/k8s` compiles.

New/updated: API (aurora+ducklake, cnpg both-catalogs, iceberg-only+external, ducklake-only+external, no-catalog rejection, aurora-requires-sizing); Create (ducklake emission, ducklake-only cnpg, ≥1-catalog guard); `parseDucklingStatus` (spec.ducklake.enabled present/absent). Existing external/aurora activation tests unchanged (legacy default preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)