### PR TITLE
fix(provisioner): tear down per-org Lakekeeper on duckling delete

### DIFF
--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -592,6 +592,21 @@ func (c *Controller) reconcileDeleting(ctx context.Context, w *configstore.Manag
 		}
 	}
 
+	// Tear down the per-org Lakekeeper instance the control plane provisioned
+	// out-of-band (CR + Secret + ServiceAccount in the lakekeeper namespace).
+	// The Crossplane Duckling composition doesn't own these, so without an
+	// explicit teardown they leak after the warehouse is gone. Idempotent and
+	// NotFound-tolerant — a clean no-op for ducklings that never enabled
+	// Iceberg. Skipped silently when the provisioner isn't wired (mirrors
+	// reconcileLakekeeper). On error we return without marking the warehouse
+	// deleted so the next reconcile pass retries.
+	if c.lakekeeperProvisioner != nil {
+		if err := c.lakekeeperProvisioner.DeleteForOrg(ctx, w.OrgID); err != nil {
+			log.Warn("Failed to tear down Lakekeeper resources, will retry.", "error", err)
+			return
+		}
+	}
+
 	if err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateDeleting, map[string]interface{}{
 		"state":          configstore.ManagedWarehouseStateDeleted,
 		"status_message": "Resources deleted",

--- a/controlplane/provisioner/controller_lakekeeper_test.go
+++ b/controlplane/provisioner/controller_lakekeeper_test.go
@@ -13,8 +13,61 @@ import (
 	"testing"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestReconcileDeleting_TearsDownLakekeeper(t *testing.T) {
+	dc, _ := newFakeDucklingClient()
+	k8sClient, dyn, kc := newFakeLakekeeperClient()
+	ctx := context.Background()
+	orgID := "tenant-x"
+
+	// Seed the per-org Lakekeeper resources EnsureForOrg would have created.
+	// The Duckling CR is intentionally left absent — reconcileDeleting tolerates
+	// NotFound on the CR delete and must still proceed to Lakekeeper teardown.
+	if err := k8sClient.EnsureSecret(ctx, orgID, LakekeeperSecretData{
+		DBUser: "u", DBPassword: "p", EncryptionKey: "k", OAuth2ClientSecret: "o",
+	}); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	if err := k8sClient.EnsureServiceAccount(ctx, orgID); err != nil {
+		t.Fatalf("seed service account: %v", err)
+	}
+	if err := k8sClient.EnsureCR(ctx, LakekeeperCRSpec{
+		OrgID: orgID, Image: "stub", PGHost: "stub", PGDatabase: "stub",
+		SecretName: "stub", BaseURI: "http://stub",
+	}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+
+	fs := newFakeStore()
+	fs.warehouses[orgID] = &configstore.ManagedWarehouse{
+		OrgID: orgID,
+		State: configstore.ManagedWarehouseStateDeleting,
+	}
+
+	p := NewLakekeeperProvisioner(fs, k8sClient)
+	c := NewControllerWithClient(fs, dc, 0).
+		WithLakekeeperProvisioner(p, func(context.Context, *configstore.ManagedWarehouse) (ProvisioningInputs, error) {
+			return ProvisioningInputs{}, nil
+		})
+
+	c.reconcileDeleting(ctx, fs.warehouses[orgID])
+
+	if _, err := dyn.Resource(lakekeeperGVR).Namespace(k8sClient.namespace).Get(ctx, LakekeeperResourceName(orgID), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Lakekeeper CR not torn down: err=%v", err)
+	}
+	if _, err := kc.CoreV1().Secrets(k8sClient.namespace).Get(ctx, LakekeeperResourceName(orgID), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Lakekeeper Secret not torn down: err=%v", err)
+	}
+	if _, err := kc.CoreV1().ServiceAccounts(k8sClient.namespace).Get(ctx, LakekeeperServiceAccountName(orgID), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Lakekeeper ServiceAccount not torn down: err=%v", err)
+	}
+	if fs.warehouses[orgID].State != configstore.ManagedWarehouseStateDeleted {
+		t.Errorf("warehouse state = %q, want deleted", fs.warehouses[orgID].State)
+	}
+}
 
 func TestReconcileLakekeeper_SkipsWhenProvisionerNotConfigured(t *testing.T) {
 	store := newFakeStore()

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -420,3 +420,49 @@ func (c *LakekeeperK8sClient) GetCR(ctx context.Context, orgID string) (*Lakekee
 	}
 	return st, nil
 }
+
+// backgroundDeletion propagates deletion to dependents (the operator-managed
+// Deployment, Service, and migration Job are owned by the CR via
+// ownerReferences). Without this, the dynamic client uses the API server's
+// per-resource default, which can orphan those children.
+var backgroundDeletion = metav1.DeletePropagationBackground
+
+// DeleteCR deletes the org's Lakekeeper CR. The operator-managed Deployment /
+// Service / migration Job carry the CR as their controller ownerReference, so
+// background-propagation deletion cascades to them. NotFound is treated as
+// success (idempotent teardown).
+func (c *LakekeeperK8sClient) DeleteCR(ctx context.Context, orgID string) error {
+	name := LakekeeperResourceName(orgID)
+	err := c.dynamic.Resource(lakekeeperGVR).Namespace(c.namespace).Delete(ctx, name, metav1.DeleteOptions{
+		PropagationPolicy: &backgroundDeletion,
+	})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete lakekeeper CR %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteSecret deletes the org's Lakekeeper Secret. The Secret has no
+// ownerReference to the CR (EnsureSecret creates it standalone), so deleting
+// the CR does not remove it — it must be torn down explicitly. NotFound is
+// treated as success.
+func (c *LakekeeperK8sClient) DeleteSecret(ctx context.Context, orgID string) error {
+	name := LakekeeperResourceName(orgID)
+	err := c.kubernetes.CoreV1().Secrets(c.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete lakekeeper secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteServiceAccount deletes the org's Lakekeeper ServiceAccount. Like the
+// Secret, it is created standalone (no ownerReference) so it must be deleted
+// explicitly. NotFound is treated as success.
+func (c *LakekeeperK8sClient) DeleteServiceAccount(ctx context.Context, orgID string) error {
+	name := LakekeeperServiceAccountName(orgID)
+	err := c.kubernetes.CoreV1().ServiceAccounts(c.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete lakekeeper service account %s: %w", name, err)
+	}
+	return nil
+}

--- a/controlplane/provisioner/lakekeeper_k8s_test.go
+++ b/controlplane/provisioner/lakekeeper_k8s_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -390,5 +391,64 @@ func TestGetCR_ParsesStatus(t *testing.T) {
 	}
 	if !st.Bootstrapped || st.ServerID != "abc-123" || st.ReadyReplicas != 2 {
 		t.Errorf("status parse mismatch: %+v", st)
+	}
+}
+
+func TestDeleteResources_RemovesProvisionedResources(t *testing.T) {
+	c, dc, kc := newFakeLakekeeperClient()
+	ctx := context.Background()
+	orgID := "acme"
+
+	// Provision the three resources DeleteForOrg is responsible for.
+	if err := c.EnsureSecret(ctx, orgID, LakekeeperSecretData{
+		DBUser: "lakekeeper_acme", DBPassword: "pw", EncryptionKey: "key", OAuth2ClientSecret: "oauth",
+	}); err != nil {
+		t.Fatalf("EnsureSecret: %v", err)
+	}
+	if err := c.EnsureServiceAccount(ctx, orgID); err != nil {
+		t.Fatalf("EnsureServiceAccount: %v", err)
+	}
+	if err := c.EnsureCR(ctx, LakekeeperCRSpec{
+		OrgID: orgID, Image: "quay.io/lakekeeper/catalog:v0.12.2",
+		PGHost: "acme-pg.local", PGDatabase: "lakekeeper_acme", SecretName: "lakekeeper-acme",
+		BaseURI: "http://lakekeeper-acme.lakekeeper.svc:8181",
+	}); err != nil {
+		t.Fatalf("EnsureCR: %v", err)
+	}
+
+	if err := c.DeleteCR(ctx, orgID); err != nil {
+		t.Fatalf("DeleteCR: %v", err)
+	}
+	if err := c.DeleteSecret(ctx, orgID); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+	if err := c.DeleteServiceAccount(ctx, orgID); err != nil {
+		t.Fatalf("DeleteServiceAccount: %v", err)
+	}
+
+	if _, err := dc.Resource(lakekeeperGVR).Namespace("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("CR still present after delete: err=%v", err)
+	}
+	if _, err := kc.CoreV1().Secrets("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Secret still present after delete: err=%v", err)
+	}
+	if _, err := kc.CoreV1().ServiceAccounts("lakekeeper").Get(ctx, "lakekeeper-acme", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("ServiceAccount still present after delete: err=%v", err)
+	}
+}
+
+func TestDeleteResources_NotFoundIsNoOp(t *testing.T) {
+	c, _, _ := newFakeLakekeeperClient()
+	ctx := context.Background()
+	// Deleting resources that were never created must be a clean no-op so the
+	// teardown path is safe for ducklings that never enabled Iceberg.
+	if err := c.DeleteCR(ctx, "never-existed"); err != nil {
+		t.Errorf("DeleteCR on missing CR: %v", err)
+	}
+	if err := c.DeleteSecret(ctx, "never-existed"); err != nil {
+		t.Errorf("DeleteSecret on missing secret: %v", err)
+	}
+	if err := c.DeleteServiceAccount(ctx, "never-existed"); err != nil {
+		t.Errorf("DeleteServiceAccount on missing SA: %v", err)
 	}
 }

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -334,6 +334,31 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 	return nil
 }
 
+// DeleteForOrg tears down the per-org Lakekeeper instance that EnsureForOrg
+// created: the CR (which cascades to the operator-managed Deployment, Service,
+// and migration Job via ownerReferences) plus the standalone Secret and
+// ServiceAccount (which don't carry an ownerReference and so must be deleted
+// explicitly). Idempotent and NotFound-tolerant, so it's a safe no-op for orgs
+// that never had Iceberg enabled.
+//
+// What it does NOT touch: the lakekeeper_<org> Postgres database/role. On
+// cnpg-shard it's provider-sql-managed and torn down with the Duckling CR; on
+// aurora the whole cluster is torn down with the Duckling CR; on an external
+// (shared) metadata store it currently persists — dropping a database on a
+// shared RDS is destructive and out of scope for this teardown.
+func (p *LakekeeperProvisioner) DeleteForOrg(ctx context.Context, orgID string) error {
+	if err := p.k8s.DeleteCR(ctx, orgID); err != nil {
+		return err
+	}
+	if err := p.k8s.DeleteSecret(ctx, orgID); err != nil {
+		return err
+	}
+	if err := p.k8s.DeleteServiceAccount(ctx, orgID); err != nil {
+		return err
+	}
+	return nil
+}
+
 // checkBootstrap reads the Lakekeeper CR status once. Returns nil when
 // bootstrappedAt is non-empty, ErrBootstrapPending otherwise. The caller —
 // typically the warehouse-reconcile loop — is responsible for requeueing on


### PR DESCRIPTION
## Problem

When a duckling is deprovisioned, `reconcileDeleting` deletes the Duckling CR and flips the warehouse row to `deleted` — but it never removes the per-org **Lakekeeper** instance that the control plane provisions out-of-band in `reconcileLakekeeper` / `EnsureForOrg`.

Those resources (the `Lakekeeper` CR, its backing `Secret`, and its `ServiceAccount`, all named `lakekeeper-<org>` in the `lakekeeper` namespace) are **not owned by the Crossplane Duckling composition**, so deleting the Duckling CR doesn't cascade to them. They leak after every deprovision. Observed in mw-dev: `lakekeeper-ben-iceberg-cnpg` / `lakekeeper-ben-iceberg-external` (and their Secrets/SAs) still Running after the ducklings were deprovisioned and their CRs gone.

## Fix

- `LakekeeperK8sClient.DeleteCR` — deletes the CR with **background propagation** so the operator-managed `Deployment` / `Service` / migration `Job` (which carry the CR as their controller `ownerReference`) cascade. NotFound-tolerant.
- `LakekeeperK8sClient.DeleteSecret` / `DeleteServiceAccount` — the Secret and SA are created standalone (no `ownerReference`), so they must be deleted explicitly. NotFound-tolerant.
- `LakekeeperProvisioner.DeleteForOrg` — chains the three.
- `reconcileDeleting` calls `DeleteForOrg`, **nil-guarded** like `reconcileLakekeeper`, and returns (to retry on the next reconcile pass) on error *before* marking the warehouse `deleted`.

Idempotent and NotFound-tolerant throughout, so it's a clean no-op for ducklings that never enabled Iceberg.

## Out of scope

Does **not** drop the `lakekeeper_<org>` Postgres database/role:
- **cnpg-shard**: provider-sql-managed, torn down with the Duckling CR.
- **aurora**: the whole cluster is torn down with the Duckling CR.
- **external** (shared RDS): the DB currently persists — dropping a database on a shared RDS is destructive and out of scope for this teardown.

## Tests

- `TestDeleteResources_RemovesProvisionedResources` / `TestDeleteResources_NotFoundIsNoOp` — k8s-client delete methods remove resources and are no-ops when absent.
- `TestReconcileDeleting_TearsDownLakekeeper` — end-to-end: seeded Lakekeeper CR+Secret+SA are all gone after `reconcileDeleting`, and the warehouse transitions to `deleted` (with the Duckling CR absent, exercising the NotFound-tolerant path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
