### PR TITLE
Add per-user default search path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ Managed-warehouse contract notes:
 
 - At most one managed-warehouse row exists per team. The row may be absent before first provisioning or after cleanup, but there is never more than one active warehouse contract for a team.
 - The admin API exposes that contract at `GET /api/v1/teams/:name/warehouse` and `PUT /api/v1/teams/:name/warehouse`. Team list/get responses also include a nested `warehouse` object when present.
+- User rows support an optional `default_search_path` field on `POST /api/v1/users` and `PUT /api/v1/orgs/:id/users/:username`. The default is empty, which preserves the standard DuckLake-first session behavior. Set `default_search_path` to `iceberg.main,memory.main` for users whose sessions should resolve unqualified names and compatibility metadata through the Iceberg catalog by default; a client-supplied startup `search_path` still takes precedence.
 - The typed sections are `warehouse_database`, `metadata_store`, `s3`, `worker_identity`, and structured secret refs for `warehouse_database_credentials`, `metadata_store_credentials`, `s3_credentials`, and `runtime_config`. In shared warm mode, every non-empty secret ref must store an explicit `namespace`, and it must match `worker_identity.namespace`.
 - Secret references only are stored in the config store. Secret material remains outside the database.
 - The provisioning fields are stored directly on the warehouse row as overall `state` / `status_message`, per-resource `*_state` / `*_status_message`, plus `ready_at` and `failed_at`.

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/server"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -126,7 +127,7 @@ type apiStore interface {
 	ListUsers() ([]configstore.OrgUser, error)
 	CreateUser(user *configstore.OrgUser) error
 	GetUser(orgID, username string) (*configstore.OrgUser, error)
-	UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error)
+	UpdateUser(orgID, username, passwordHash string, passthrough *bool, defaultSearchPath *string) (*configstore.OrgUser, bool, error)
 	DeleteUser(orgID, username string) (bool, error)
 
 	GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error)
@@ -259,13 +260,16 @@ func (s *gormAPIStore) GetUser(orgID, username string) (*configstore.OrgUser, er
 	return &user, nil
 }
 
-func (s *gormAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error) {
+func (s *gormAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool, defaultSearchPath *string) (*configstore.OrgUser, bool, error) {
 	updates := map[string]interface{}{}
 	if passwordHash != "" {
 		updates["password"] = passwordHash
 	}
 	if passthrough != nil {
 		updates["passthrough"] = *passthrough
+	}
+	if defaultSearchPath != nil {
+		updates["default_search_path"] = *defaultSearchPath
 	}
 	if len(updates) == 0 {
 		// Nothing to change — return the current row so callers can still
@@ -925,10 +929,11 @@ func (h *apiHandler) listUsers(c *gin.Context) {
 func (h *apiHandler) createUser(c *gin.Context) {
 	// Use a raw struct because OrgUser.Password has json:"-"
 	var raw struct {
-		Username    string `json:"username"`
-		Password    string `json:"password"`
-		OrgID       string `json:"org_id"`
-		Passthrough bool   `json:"passthrough"`
+		Username          string `json:"username"`
+		Password          string `json:"password"`
+		OrgID             string `json:"org_id"`
+		Passthrough       bool   `json:"passthrough"`
+		DefaultSearchPath string `json:"default_search_path"`
 	}
 	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -942,16 +947,23 @@ func (h *apiHandler) createUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "password is required"})
 		return
 	}
+	if sp, err := validateDefaultSearchPath(raw.DefaultSearchPath); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	} else {
+		raw.DefaultSearchPath = sp
+	}
 	hash, err := configstore.HashPassword(raw.Password)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
 		return
 	}
 	user := configstore.OrgUser{
-		Username:    raw.Username,
-		Password:    hash,
-		OrgID:       raw.OrgID,
-		Passthrough: raw.Passthrough,
+		Username:          raw.Username,
+		Password:          hash,
+		OrgID:             raw.OrgID,
+		Passthrough:       raw.Passthrough,
+		DefaultSearchPath: raw.DefaultSearchPath,
 	}
 	if err := h.store.CreateUser(&user); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
@@ -977,8 +989,9 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 	// Passthrough is *bool so omitting it preserves the stored value; sending
 	// `false` explicitly clears the flag.
 	var raw struct {
-		Password    string `json:"password"`
-		Passthrough *bool  `json:"passthrough,omitempty"`
+		Password          string  `json:"password"`
+		Passthrough       *bool   `json:"passthrough,omitempty"`
+		DefaultSearchPath *string `json:"default_search_path,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -993,7 +1006,15 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 		}
 		passwordHash = hash
 	}
-	user, ok, err := h.store.UpdateUser(orgID, username, passwordHash, raw.Passthrough)
+	if raw.DefaultSearchPath != nil {
+		sp, err := validateDefaultSearchPath(*raw.DefaultSearchPath)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		raw.DefaultSearchPath = &sp
+	}
+	user, ok, err := h.store.UpdateUser(orgID, username, passwordHash, raw.Passthrough, raw.DefaultSearchPath)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -1003,6 +1024,16 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, user)
+}
+
+func validateDefaultSearchPath(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if sp, ok := server.SanitizeSearchPath(raw); ok {
+		return sp, nil
+	}
+	return "", errors.New("default_search_path contains unsafe characters or is too long")
 }
 
 func (h *apiHandler) deleteUser(c *gin.Context) {

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -122,7 +122,7 @@ func (s *fakeAPIStore) GetUser(orgID, username string) (*configstore.OrgUser, er
 	return &clone, nil
 }
 
-func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool) (*configstore.OrgUser, bool, error) {
+func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string, passthrough *bool, defaultSearchPath *string) (*configstore.OrgUser, bool, error) {
 	key := orgID + "/" + username
 	user, ok := s.users[key]
 	if !ok {
@@ -133,6 +133,9 @@ func (s *fakeAPIStore) UpdateUser(orgID, username, passwordHash string, passthro
 	}
 	if passthrough != nil {
 		user.Passthrough = *passthrough
+	}
+	if defaultSearchPath != nil {
+		user.DefaultSearchPath = *defaultSearchPath
 	}
 	clone := *user
 	return &clone, true, nil
@@ -310,6 +313,108 @@ func seedOrgWithWarehouse(store *fakeAPIStore, name string) {
 		Warehouse: copyWarehouse(warehouse),
 	}
 	store.warehouses[name] = warehouse
+}
+
+func TestCreateUserAcceptsDefaultSearchPath(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{
+		"org_id": "analytics",
+		"username": "iceberg_reader",
+		"password": "secret",
+		"default_search_path": "iceberg.main,memory.main"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	user := store.users["analytics/iceberg_reader"]
+	if user == nil {
+		t.Fatal("expected user to be created")
+	}
+	if user.DefaultSearchPath != "iceberg.main,memory.main" {
+		t.Fatalf("DefaultSearchPath = %q, want iceberg.main,memory.main", user.DefaultSearchPath)
+	}
+
+	var response configstore.OrgUser
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.DefaultSearchPath != "iceberg.main,memory.main" {
+		t.Fatalf("response DefaultSearchPath = %q, want iceberg.main,memory.main", response.DefaultSearchPath)
+	}
+}
+
+func TestCreateUserRejectsUnsafeDefaultSearchPath(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{
+		"org_id": "analytics",
+		"username": "iceberg_reader",
+		"password": "secret",
+		"default_search_path": "iceberg.main';DROP TABLE x;--"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if len(store.users) != 0 {
+		t.Fatalf("expected no users to be created, got %d", len(store.users))
+	}
+}
+
+func TestUpdateUserDefaultSearchPathPreserveSetAndClear(t *testing.T) {
+	store := newFakeAPIStore()
+	store.users["analytics/iceberg_reader"] = &configstore.OrgUser{
+		OrgID:             "analytics",
+		Username:          "iceberg_reader",
+		Password:          "hash",
+		DefaultSearchPath: "iceberg.main,memory.main",
+	}
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/iceberg_reader", bytes.NewReader([]byte(`{"passthrough":true}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("preserve status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.users["analytics/iceberg_reader"].DefaultSearchPath; got != "iceberg.main,memory.main" {
+		t.Fatalf("preserved DefaultSearchPath = %q, want iceberg.main,memory.main", got)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/iceberg_reader", bytes.NewReader([]byte(`{"default_search_path":"iceberg.billing_public,memory.main"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.users["analytics/iceberg_reader"].DefaultSearchPath; got != "iceberg.billing_public,memory.main" {
+		t.Fatalf("updated DefaultSearchPath = %q, want iceberg.billing_public,memory.main", got)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/users/iceberg_reader", bytes.NewReader([]byte(`{"default_search_path":""}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.users["analytics/iceberg_reader"].DefaultSearchPath; got != "" {
+		t.Fatalf("cleared DefaultSearchPath = %q, want empty", got)
+	}
 }
 
 func TestGetOrgIncludesWarehouse(t *testing.T) {

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -36,12 +36,13 @@ func (Org) TableName() string { return "duckgres_orgs" }
 // (org_id, username) so the same login name can be passthrough in one tenant
 // and not in another.
 type OrgUser struct {
-	OrgID       string    `gorm:"primaryKey;size:255" json:"org_id"`
-	Username    string    `gorm:"primaryKey;size:255" json:"username"`
-	Password    string    `gorm:"size:255;not null" json:"-"`
-	Passthrough bool      `gorm:"not null;default:false" json:"passthrough"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	OrgID             string    `gorm:"primaryKey;size:255" json:"org_id"`
+	Username          string    `gorm:"primaryKey;size:255" json:"username"`
+	Password          string    `gorm:"size:255;not null" json:"-"`
+	Passthrough       bool      `gorm:"not null;default:false" json:"passthrough"`
+	DefaultSearchPath string    `gorm:"size:512" json:"default_search_path,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 func (OrgUser) TableName() string { return "duckgres_org_users" }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -33,15 +33,16 @@ var ErrWorkerRecordUpsertFenceMiss = errors.New("worker record upsert fence miss
 
 // Snapshot holds a point-in-time copy of all config data for fast lookups.
 type Snapshot struct {
-	Orgs               map[string]*OrgConfig
-	DatabaseOrg        map[string]string     // database name -> org ID
-	HostnameAliasOrg   map[string]string     // hostname alias -> org ID (sparse — only orgs with non-empty alias)
-	OrgUserPassword    map[OrgUserKey]string // (orgID, username) -> bcrypt hash
-	OrgUserPassthrough map[OrgUserKey]bool   // (orgID, username) -> passthrough flag
-	Global             GlobalConfig
-	DuckLake           DuckLakeConfig
-	RateLimit          RateLimitConfig
-	QueryLog           QueryLogConfig
+	Orgs                     map[string]*OrgConfig
+	DatabaseOrg              map[string]string     // database name -> org ID
+	HostnameAliasOrg         map[string]string     // hostname alias -> org ID (sparse — only orgs with non-empty alias)
+	OrgUserPassword          map[OrgUserKey]string // (orgID, username) -> bcrypt hash
+	OrgUserPassthrough       map[OrgUserKey]bool   // (orgID, username) -> passthrough flag
+	OrgUserDefaultSearchPath map[OrgUserKey]string // (orgID, username) -> default session search_path
+	Global                   GlobalConfig
+	DuckLake                 DuckLakeConfig
+	RateLimit                RateLimitConfig
+	QueryLog                 QueryLogConfig
 }
 
 // PostgresConnectionResolution is the result of resolving and authenticating a
@@ -59,6 +60,7 @@ type PostgresConnectionResolution struct {
 	HostnameMatches     bool
 	Valid               bool
 	Passthrough         bool
+	DefaultSearchPath   string
 }
 
 // ConfigStore manages configuration stored in a PostgreSQL database.
@@ -201,15 +203,16 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 	cs.db.First(&queryLog, 1)
 
 	snap := &Snapshot{
-		Orgs:               make(map[string]*OrgConfig),
-		DatabaseOrg:        make(map[string]string),
-		HostnameAliasOrg:   make(map[string]string),
-		OrgUserPassword:    make(map[OrgUserKey]string),
-		OrgUserPassthrough: make(map[OrgUserKey]bool),
-		Global:             global,
-		DuckLake:           duckLake,
-		RateLimit:          rateLimit,
-		QueryLog:           queryLog,
+		Orgs:                     make(map[string]*OrgConfig),
+		DatabaseOrg:              make(map[string]string),
+		HostnameAliasOrg:         make(map[string]string),
+		OrgUserPassword:          make(map[OrgUserKey]string),
+		OrgUserPassthrough:       make(map[OrgUserKey]bool),
+		OrgUserDefaultSearchPath: make(map[OrgUserKey]string),
+		Global:                   global,
+		DuckLake:                 duckLake,
+		RateLimit:                rateLimit,
+		QueryLog:                 queryLog,
 	}
 
 	for _, o := range orgs {
@@ -242,6 +245,9 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 			snap.OrgUserPassword[key] = u.Password
 			if u.Passthrough {
 				snap.OrgUserPassthrough[key] = true
+			}
+			if u.DefaultSearchPath != "" {
+				snap.OrgUserDefaultSearchPath[key] = u.DefaultSearchPath
 			}
 		}
 		snap.Orgs[o.Name] = oc
@@ -403,6 +409,7 @@ func (cs *ConfigStore) ResolvePostgresConnection(startupDatabase, sniPrefix stri
 	}
 	result.Valid = true
 	result.Passthrough = cs.snapshot.OrgUserPassthrough[key]
+	result.DefaultSearchPath = cs.snapshot.OrgUserDefaultSearchPath[key]
 	return result
 }
 

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -295,6 +295,9 @@ func TestResolvePostgresConnection(t *testing.T) {
 			OrgUserPassthrough: map[OrgUserKey]bool{
 				{OrgID: "test-org-smoke-1778167994", Username: "root"}: true,
 			},
+			OrgUserDefaultSearchPath: map[OrgUserKey]string{
+				{OrgID: "billing", Username: "root"}: "iceberg.main,memory.main",
+			},
 		},
 	}
 
@@ -381,6 +384,22 @@ func TestResolvePostgresConnection(t *testing.T) {
 		)
 		if got.EffectiveDatabase != "ghostorg" || got.DatabaseExists {
 			t.Fatalf("unknown SNI fallback = (%q, exists=%v), want ghostorg missing", got.EffectiveDatabase, got.DatabaseExists)
+		}
+	})
+
+	t.Run("valid user includes configured default search path", func(t *testing.T) {
+		got := cs.ResolvePostgresConnection(
+			"billing_db",
+			"billing-alias",
+			true,
+			"root",
+			"secret",
+		)
+		if !got.Valid {
+			t.Fatalf("expected valid auth: %+v", got)
+		}
+		if got.DefaultSearchPath != "iceberg.main,memory.main" {
+			t.Fatalf("DefaultSearchPath = %q, want iceberg.main,memory.main", got.DefaultSearchPath)
 		}
 	})
 }

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -905,8 +905,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// In multi-tenant mode, the database name maps to an org.
 	// User uniqueness is scoped to the org.
 	var (
-		orgID           string
-		passthroughUser bool
+		orgID             string
+		passthroughUser   bool
+		defaultSearchPath string
 	)
 	if cp.configStore != nil {
 		// Resolve the effective database name based on SNI routing mode.
@@ -981,6 +982,16 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		}
 		orgID = resolution.OrgID
 		passthroughUser = resolution.Passthrough
+		if resolution.DefaultSearchPath != "" {
+			sp, ok := server.SanitizeSearchPath(resolution.DefaultSearchPath)
+			if !ok {
+				slog.Error("Connection rejected: configured default search_path is unsafe.", "user", username, "org", orgID, "search_path", resolution.DefaultSearchPath)
+				_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "configured default search_path is invalid")
+				_ = writer.Flush()
+				return
+			}
+			defaultSearchPath = sp
+		}
 		// From here on, `database` reflects the effective routing database.
 		// This is what gets passed to the worker as the logical database
 		// (drives the `current_database()` macro and pg_database view) so
@@ -1146,24 +1157,28 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			return
 		}
 
-		// Apply the client's connect-time search_path (from the startup `options`
-		// parameter, e.g. `options=-c search_path=iceberg.public`) AFTER metadata
-		// init. It must run here, not on the worker at session create: (1)
+		// Apply the effective connect-time search_path AFTER metadata init. It
+		// must run here, not on the worker at session create: (1)
 		// InitSessionDatabaseMetadata's defer resets search_path to the ducklake
 		// default, so an earlier value is clobbered; and (2) running metadata init
 		// while the session default points at the iceberg REST catalog fails. We
-		// append memory.main so pg_catalog macros stay resolvable; on failure
-		// (e.g. the schema doesn't exist) we log and keep the default.
-		if clientSearchPath != "" {
-			sp := clientSearchPath
-			if !strings.Contains(strings.ToLower(sp), "memory.main") {
-				sp += ",memory.main"
-			}
+		// append memory.main so pg_catalog macros stay resolvable. Client-supplied
+		// search_path keeps the previous best-effort behavior; configured per-user
+		// defaults fail closed because silently falling back would route the user
+		// to the wrong catalog.
+		if sp, source := effectiveSessionSearchPath(clientSearchPath, defaultSearchPath); sp != "" {
 			spCtx, spCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
-			if _, err := executor.ExecContext(spCtx, fmt.Sprintf("SET search_path = '%s'", sp)); err != nil {
+			_, err := executor.ExecContext(spCtx, fmt.Sprintf("SET search_path = '%s'", sp))
+			spCancel()
+			if err != nil {
+				if source == sessionSearchPathSourceConfiguredDefault {
+					slog.Error("Failed to apply configured default search_path.", "user", username, "org", orgID, "search_path", defaultSearchPath, "error", err)
+					_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply configured default search_path")
+					_ = writer.Flush()
+					return
+				}
 				slog.Warn("Failed to apply client connect-time search_path; using default.", "user", username, "org", orgID, "search_path", clientSearchPath, "error", err)
 			}
-			spCancel()
 		}
 	}
 

--- a/controlplane/session_search_path.go
+++ b/controlplane/session_search_path.go
@@ -1,0 +1,28 @@
+package controlplane
+
+import "strings"
+
+type sessionSearchPathSource string
+
+const (
+	sessionSearchPathSourceClient            sessionSearchPathSource = "client"
+	sessionSearchPathSourceConfiguredDefault sessionSearchPathSource = "configured_default"
+)
+
+func effectiveSessionSearchPath(clientSearchPath, configuredDefaultSearchPath string) (string, sessionSearchPathSource) {
+	switch {
+	case clientSearchPath != "":
+		return ensureMemoryMainInSearchPath(clientSearchPath), sessionSearchPathSourceClient
+	case configuredDefaultSearchPath != "":
+		return ensureMemoryMainInSearchPath(configuredDefaultSearchPath), sessionSearchPathSourceConfiguredDefault
+	default:
+		return "", ""
+	}
+}
+
+func ensureMemoryMainInSearchPath(searchPath string) string {
+	if strings.Contains(strings.ToLower(searchPath), "memory.main") {
+		return searchPath
+	}
+	return searchPath + ",memory.main"
+}

--- a/controlplane/session_search_path_test.go
+++ b/controlplane/session_search_path_test.go
@@ -1,0 +1,33 @@
+package controlplane
+
+import "testing"
+
+func TestEffectiveSessionSearchPathUsesClientBeforeConfiguredDefault(t *testing.T) {
+	got, source := effectiveSessionSearchPath("ducklake.main", "iceberg.main")
+	if got != "ducklake.main,memory.main" {
+		t.Fatalf("search path = %q, want ducklake.main,memory.main", got)
+	}
+	if source != sessionSearchPathSourceClient {
+		t.Fatalf("source = %q, want %q", source, sessionSearchPathSourceClient)
+	}
+}
+
+func TestEffectiveSessionSearchPathUsesConfiguredDefaultWhenClientOmitted(t *testing.T) {
+	got, source := effectiveSessionSearchPath("", "iceberg.main,memory.main")
+	if got != "iceberg.main,memory.main" {
+		t.Fatalf("search path = %q, want iceberg.main,memory.main", got)
+	}
+	if source != sessionSearchPathSourceConfiguredDefault {
+		t.Fatalf("source = %q, want %q", source, sessionSearchPathSourceConfiguredDefault)
+	}
+}
+
+func TestEffectiveSessionSearchPathReturnsEmptyWhenUnset(t *testing.T) {
+	got, source := effectiveSessionSearchPath("", "")
+	if got != "" {
+		t.Fatalf("search path = %q, want empty", got)
+	}
+	if source != "" {
+		t.Fatalf("source = %q, want empty", source)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds optional `default_search_path` to control-plane users and the admin create/update APIs.
- Carries the user default through configstore auth resolution and applies it after session metadata init when the client does not provide startup `search_path`.
- Documents `iceberg.main,memory.main` as the Iceberg-first user configuration.

## Test plan
- `go test ./controlplane/configstore ./controlplane`
- `go test -tags kubernetes ./controlplane/admin -run 'Test(CreateUserAcceptsDefaultSearchPath|CreateUserRejectsUnsafeDefaultSearchPath|UpdateUserDefaultSearchPathPreserveSetAndClear)'`
- `git diff --check`
- `just lint` could not run locally because `golangci-lint` is not installed in this shell.