### PR TITLE
Support Iceberg DROP SCHEMA CASCADE fallback

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1448,22 +1448,9 @@ func (c *clientConn) handleQuery(body []byte) error {
 		runExec := func() (ExecResult, error) {
 			execResult, err := c.executor.ExecContext(ctx, query)
 			if err != nil {
-				// Retry ALTER TABLE as ALTER VIEW if target is a view
-				if isAlterTableNotTableError(err) {
-					if alteredQuery, ok := transpiler.ConvertAlterTableToAlterView(query); ok {
-						return c.executor.ExecContext(ctx, alteredQuery)
-					}
-				}
-				// Retry DROP TABLE as DROP VIEW if target is a view
-				if isDropTableOnViewError(err) {
-					if alteredQuery, ok := transpiler.ConvertDropTableToDropView(query); ok {
-						return c.executor.ExecContext(ctx, alteredQuery)
-					}
-				}
-				if isIcebergDropSchemaCascadeUnsupported(err) {
-					if fallbackResult, fallbackErr := c.dropIcebergSchemaCascade(ctx, query); fallbackErr == nil {
-						return fallbackResult, nil
-					}
+				fallbackResult, handled, fallbackErr := c.execCompatibilityFallback(ctx, query, err)
+				if handled {
+					return fallbackResult, fallbackErr
 				}
 			}
 			return execResult, err

--- a/server/conn.go
+++ b/server/conn.go
@@ -1460,6 +1460,11 @@ func (c *clientConn) handleQuery(body []byte) error {
 						return c.executor.ExecContext(ctx, alteredQuery)
 					}
 				}
+				if isIcebergDropSchemaCascadeUnsupported(err) {
+					if fallbackResult, fallbackErr := c.dropIcebergSchemaCascade(ctx, query); fallbackErr == nil {
+						return fallbackResult, nil
+					}
+				}
 			}
 			return execResult, err
 		}

--- a/server/exec_fallback.go
+++ b/server/exec_fallback.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/posthog/duckgres/transpiler"
+)
+
+func (c *clientConn) execCompatibilityFallback(ctx context.Context, query string, execErr error) (ExecResult, bool, error) {
+	if isAlterTableNotTableError(execErr) {
+		if alteredQuery, ok := transpiler.ConvertAlterTableToAlterView(query); ok {
+			result, err := c.executor.ExecContext(ctx, alteredQuery)
+			return result, true, err
+		}
+	}
+
+	if isDropTableOnViewError(execErr) {
+		if alteredQuery, ok := transpiler.ConvertDropTableToDropView(query); ok {
+			result, err := c.executor.ExecContext(ctx, alteredQuery)
+			return result, true, err
+		}
+	}
+
+	if isIcebergDropSchemaCascadeUnsupported(execErr) {
+		result, err := c.dropIcebergSchemaCascade(ctx, query)
+		if err != nil {
+			return nil, true, fmt.Errorf("iceberg DROP SCHEMA CASCADE fallback failed: %w", err)
+		}
+		return result, true, nil
+	}
+
+	return nil, false, nil
+}

--- a/server/exec_fallback_test.go
+++ b/server/exec_fallback_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExecCompatibilityFallbackReturnsIcebergFallbackError(t *testing.T) {
+	execErr := errors.New("Not implemented Error: DROP SCHEMA <schema_name> CASCADE is not supported for Iceberg schemas currently")
+	c := &clientConn{executor: &failingFallbackExecutor{}}
+
+	_, handled, err := c.execCompatibilityFallback(context.Background(), "DROP SCHEMA IF EXISTS stripe CASCADE", execErr)
+	if !handled {
+		t.Fatal("expected Iceberg fallback to handle unsupported DROP SCHEMA CASCADE error")
+	}
+	if err == nil || !strings.Contains(err.Error(), "iceberg DROP SCHEMA CASCADE fallback failed") {
+		t.Fatalf("fallback error = %v, want contextual fallback failure", err)
+	}
+}
+
+type failingFallbackExecutor struct {
+	noopProfiling
+}
+
+func (e *failingFallbackExecutor) QueryContext(context.Context, string, ...any) (RowSet, error) {
+	return nil, errors.New("settings query failed")
+}
+
+func (e *failingFallbackExecutor) ExecContext(context.Context, string, ...any) (ExecResult, error) {
+	return nil, errors.New("unexpected exec")
+}
+
+func (e *failingFallbackExecutor) Query(string, ...any) (RowSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *failingFallbackExecutor) Exec(string, ...any) (ExecResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *failingFallbackExecutor) ConnContext(context.Context) (RawConn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *failingFallbackExecutor) PingContext(context.Context) error {
+	return errors.New("not implemented")
+}
+
+func (e *failingFallbackExecutor) Close() error {
+	return nil
+}

--- a/server/iceberg_drop_schema.go
+++ b/server/iceberg_drop_schema.go
@@ -1,0 +1,261 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/posthog/duckgres/server/iceberg"
+)
+
+type dropSchemaCascadeTarget struct {
+	Catalog  string
+	Schema   string
+	IfExists bool
+}
+
+func parseDropSchemaCascadeTarget(query string) (dropSchemaCascadeTarget, bool) {
+	s := strings.TrimSpace(stripLeadingComments(query))
+	s = strings.TrimSpace(strings.TrimSuffix(s, ";"))
+
+	pos, ok := consumeSQLKeyword(s, 0, "DROP")
+	if !ok {
+		return dropSchemaCascadeTarget{}, false
+	}
+	pos, ok = consumeSQLKeyword(s, pos, "SCHEMA")
+	if !ok {
+		return dropSchemaCascadeTarget{}, false
+	}
+
+	target := dropSchemaCascadeTarget{}
+	if next, ok := consumeSQLKeyword(s, pos, "IF"); ok {
+		next, ok = consumeSQLKeyword(s, next, "EXISTS")
+		if !ok {
+			return dropSchemaCascadeTarget{}, false
+		}
+		target.IfExists = true
+		pos = next
+	}
+
+	targetSQL, ok := trimTrailingSQLKeyword(s[pos:], "CASCADE")
+	if !ok {
+		return dropSchemaCascadeTarget{}, false
+	}
+	parts, ok := splitDropSchemaTarget(targetSQL)
+	if !ok || len(parts) == 0 || len(parts) > 2 {
+		return dropSchemaCascadeTarget{}, false
+	}
+	if len(parts) == 1 {
+		target.Schema = parts[0]
+	} else {
+		target.Catalog = parts[0]
+		target.Schema = parts[1]
+	}
+	if target.Schema == "" || target.Catalog == "" && len(parts) == 2 {
+		return dropSchemaCascadeTarget{}, false
+	}
+	return target, true
+}
+
+func consumeSQLKeyword(s string, pos int, keyword string) (int, bool) {
+	pos = skipSQLSpace(s, pos)
+	end := pos + len(keyword)
+	if end > len(s) || !strings.EqualFold(s[pos:end], keyword) {
+		return pos, false
+	}
+	if end < len(s) && isSQLIdentChar(s[end]) {
+		return pos, false
+	}
+	return end, true
+}
+
+func trimTrailingSQLKeyword(s string, keyword string) (string, bool) {
+	s = strings.TrimSpace(s)
+	end := len(s) - len(keyword)
+	if end < 0 || !strings.EqualFold(s[end:], keyword) {
+		return "", false
+	}
+	if end > 0 && !isSQLSpace(s[end-1]) {
+		return "", false
+	}
+	target := strings.TrimSpace(s[:end])
+	return target, target != ""
+}
+
+func splitDropSchemaTarget(s string) ([]string, bool) {
+	var parts []string
+	inQuotes := false
+	partStart := 0
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == '"' {
+			if inQuotes && i+1 < len(s) && s[i+1] == '"' {
+				i++
+				continue
+			}
+			inQuotes = !inQuotes
+			continue
+		}
+		if ch == '.' && !inQuotes {
+			part, ok := parseDropSchemaIdentifierPart(s[partStart:i])
+			if !ok {
+				return nil, false
+			}
+			parts = append(parts, part)
+			partStart = i + 1
+			continue
+		}
+	}
+	if inQuotes {
+		return nil, false
+	}
+	part, ok := parseDropSchemaIdentifierPart(s[partStart:])
+	if !ok {
+		return nil, false
+	}
+	parts = append(parts, part)
+	return parts, true
+}
+
+func parseDropSchemaIdentifierPart(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	if s[0] != '"' {
+		if strings.Contains(s, `"`) {
+			return "", false
+		}
+		return strings.ToLower(s), true
+	}
+	if len(s) < 2 || s[len(s)-1] != '"' {
+		return "", false
+	}
+	var ident strings.Builder
+	for i := 1; i < len(s)-1; i++ {
+		if s[i] == '"' {
+			if i+1 >= len(s)-1 || s[i+1] != '"' {
+				return "", false
+			}
+			ident.WriteByte('"')
+			i++
+			continue
+		}
+		ident.WriteByte(s[i])
+	}
+	return ident.String(), true
+}
+
+func skipSQLSpace(s string, pos int) int {
+	for pos < len(s) && isSQLSpace(s[pos]) {
+		pos++
+	}
+	return pos
+}
+
+func isSQLSpace(ch byte) bool {
+	switch ch {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func isSQLIdentChar(ch byte) bool {
+	return ch == '_' || ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+}
+
+func isIcebergDropSchemaCascadeUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "DROP SCHEMA <schema_name> CASCADE is not supported for Iceberg schemas currently")
+}
+
+func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string) (ExecResult, error) {
+	target, ok := parseDropSchemaCascadeTarget(query)
+	if !ok {
+		return nil, fmt.Errorf("not a DROP SCHEMA CASCADE statement")
+	}
+
+	catalog := target.Catalog
+	if catalog == "" {
+		defaultCatalog, err := c.currentSearchPathCatalog(ctx)
+		if err != nil {
+			return nil, err
+		}
+		catalog = defaultCatalog
+	}
+	if !strings.EqualFold(catalog, iceberg.CatalogName) {
+		return nil, fmt.Errorf("DROP SCHEMA CASCADE fallback only supports iceberg catalog, got %q", catalog)
+	}
+
+	rows, err := c.executor.QueryContext(ctx, `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_catalog = 'iceberg'
+		AND table_schema = ?
+		ORDER BY table_name
+	`, target.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("list iceberg schema tables: %w", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			return nil, fmt.Errorf("scan iceberg schema table: %w", err)
+		}
+		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list iceberg schema tables: %w", err)
+	}
+
+	for _, table := range tables {
+		dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s.%s",
+			quoteDuckDBIdentifier(iceberg.CatalogName),
+			quoteDuckDBIdentifier(target.Schema),
+			quoteDuckDBIdentifier(table),
+		)
+		if _, err := c.executor.ExecContext(ctx, dropTable); err != nil {
+			return nil, fmt.Errorf("drop iceberg table %s.%s: %w", target.Schema, table, err)
+		}
+	}
+
+	dropSchema := fmt.Sprintf("DROP SCHEMA IF EXISTS %s.%s",
+		quoteDuckDBIdentifier(iceberg.CatalogName),
+		quoteDuckDBIdentifier(target.Schema),
+	)
+	return c.executor.ExecContext(ctx, dropSchema)
+}
+
+func (c *clientConn) currentSearchPathCatalog(ctx context.Context) (string, error) {
+	rows, err := c.executor.QueryContext(ctx, `
+		SELECT lower(regexp_extract(regexp_replace(value, '\s+', '', 'g'), '^([A-Za-z0-9_]+)\.', 1))
+		FROM duckdb_settings()
+		WHERE name = 'search_path'
+	`)
+	if err != nil {
+		return "", fmt.Errorf("read search_path: %w", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return "", rows.Err()
+	}
+	var catalog string
+	if err := rows.Scan(&catalog); err != nil {
+		return "", fmt.Errorf("scan search_path catalog: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return catalog, nil
+}
+
+func quoteDuckDBIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/server/iceberg_drop_schema.go
+++ b/server/iceberg_drop_schema.go
@@ -136,7 +136,7 @@ func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string)
 	if err != nil {
 		return nil, fmt.Errorf("list iceberg schema tables: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var tables []string
 	for rows.Next() {
@@ -177,7 +177,7 @@ func (c *clientConn) currentSearchPathCatalog(ctx context.Context) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("read search_path: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	if !rows.Next() {
 		return "", rows.Err()
 	}

--- a/server/iceberg_drop_schema.go
+++ b/server/iceberg_drop_schema.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 
 	"github.com/posthog/duckgres/server/iceberg"
+	"github.com/posthog/duckgres/server/sqlcore"
 )
 
 type dropSchemaCascadeTarget struct {
-	Catalog  string
-	Schema   string
-	IfExists bool
+	Catalog string
+	Schema  string
 }
 
 func parseDropSchemaCascadeTarget(query string) (dropSchemaCascadeTarget, bool) {
-	s := strings.TrimSpace(stripLeadingComments(query))
+	s := strings.TrimSpace(sqlcore.StripLeadingComments(query))
 	s = strings.TrimSpace(strings.TrimSuffix(s, ";"))
 
 	pos, ok := consumeSQLKeyword(s, 0, "DROP")
@@ -33,7 +33,6 @@ func parseDropSchemaCascadeTarget(query string) (dropSchemaCascadeTarget, bool) 
 		if !ok {
 			return dropSchemaCascadeTarget{}, false
 		}
-		target.IfExists = true
 		pos = next
 	}
 
@@ -41,7 +40,7 @@ func parseDropSchemaCascadeTarget(query string) (dropSchemaCascadeTarget, bool) 
 	if !ok {
 		return dropSchemaCascadeTarget{}, false
 	}
-	parts, ok := splitDropSchemaTarget(targetSQL)
+	parts, ok := sqlcore.ParseQualifiedIdentifier(targetSQL)
 	if !ok || len(parts) == 0 || len(parts) > 2 {
 		return dropSchemaCascadeTarget{}, false
 	}
@@ -80,70 +79,6 @@ func trimTrailingSQLKeyword(s string, keyword string) (string, bool) {
 	}
 	target := strings.TrimSpace(s[:end])
 	return target, target != ""
-}
-
-func splitDropSchemaTarget(s string) ([]string, bool) {
-	var parts []string
-	inQuotes := false
-	partStart := 0
-	for i := 0; i < len(s); i++ {
-		ch := s[i]
-		if ch == '"' {
-			if inQuotes && i+1 < len(s) && s[i+1] == '"' {
-				i++
-				continue
-			}
-			inQuotes = !inQuotes
-			continue
-		}
-		if ch == '.' && !inQuotes {
-			part, ok := parseDropSchemaIdentifierPart(s[partStart:i])
-			if !ok {
-				return nil, false
-			}
-			parts = append(parts, part)
-			partStart = i + 1
-			continue
-		}
-	}
-	if inQuotes {
-		return nil, false
-	}
-	part, ok := parseDropSchemaIdentifierPart(s[partStart:])
-	if !ok {
-		return nil, false
-	}
-	parts = append(parts, part)
-	return parts, true
-}
-
-func parseDropSchemaIdentifierPart(s string) (string, bool) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", false
-	}
-	if s[0] != '"' {
-		if strings.Contains(s, `"`) {
-			return "", false
-		}
-		return strings.ToLower(s), true
-	}
-	if len(s) < 2 || s[len(s)-1] != '"' {
-		return "", false
-	}
-	var ident strings.Builder
-	for i := 1; i < len(s)-1; i++ {
-		if s[i] == '"' {
-			if i+1 >= len(s)-1 || s[i+1] != '"' {
-				return "", false
-			}
-			ident.WriteByte('"')
-			i++
-			continue
-		}
-		ident.WriteByte(s[i])
-	}
-	return ident.String(), true
 }
 
 func skipSQLSpace(s string, pos int) int {
@@ -217,9 +152,9 @@ func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string)
 
 	for _, table := range tables {
 		dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s.%s",
-			quoteDuckDBIdentifier(iceberg.CatalogName),
-			quoteDuckDBIdentifier(target.Schema),
-			quoteDuckDBIdentifier(table),
+			sqlcore.QuoteIdentifier(iceberg.CatalogName),
+			sqlcore.QuoteIdentifier(target.Schema),
+			sqlcore.QuoteIdentifier(table),
 		)
 		if _, err := c.executor.ExecContext(ctx, dropTable); err != nil {
 			return nil, fmt.Errorf("drop iceberg table %s.%s: %w", target.Schema, table, err)
@@ -227,15 +162,15 @@ func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string)
 	}
 
 	dropSchema := fmt.Sprintf("DROP SCHEMA IF EXISTS %s.%s",
-		quoteDuckDBIdentifier(iceberg.CatalogName),
-		quoteDuckDBIdentifier(target.Schema),
+		sqlcore.QuoteIdentifier(iceberg.CatalogName),
+		sqlcore.QuoteIdentifier(target.Schema),
 	)
 	return c.executor.ExecContext(ctx, dropSchema)
 }
 
 func (c *clientConn) currentSearchPathCatalog(ctx context.Context) (string, error) {
 	rows, err := c.executor.QueryContext(ctx, `
-		SELECT lower(regexp_extract(regexp_replace(value, '\s+', '', 'g'), '^([A-Za-z0-9_]+)\.', 1))
+		SELECT value
 		FROM duckdb_settings()
 		WHERE name = 'search_path'
 	`)
@@ -246,16 +181,12 @@ func (c *clientConn) currentSearchPathCatalog(ctx context.Context) (string, erro
 	if !rows.Next() {
 		return "", rows.Err()
 	}
-	var catalog string
-	if err := rows.Scan(&catalog); err != nil {
-		return "", fmt.Errorf("scan search_path catalog: %w", err)
+	var searchPath string
+	if err := rows.Scan(&searchPath); err != nil {
+		return "", fmt.Errorf("scan search_path: %w", err)
 	}
 	if err := rows.Err(); err != nil {
 		return "", err
 	}
-	return catalog, nil
-}
-
-func quoteDuckDBIdentifier(s string) string {
-	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	return sqlcore.CatalogFromSearchPath(searchPath), nil
 }

--- a/server/iceberg_drop_schema_test.go
+++ b/server/iceberg_drop_schema_test.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseDropSchemaCascadeTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		want   dropSchemaCascadeTarget
+		wantOK bool
+	}{
+		{
+			name:   "qualified iceberg schema",
+			query:  "DROP SCHEMA IF EXISTS iceberg.fivetran_testing_schema_abc CASCADE",
+			wantOK: true,
+			want: dropSchemaCascadeTarget{
+				Catalog:  "iceberg",
+				Schema:   "fivetran_testing_schema_abc",
+				IfExists: true,
+			},
+		},
+		{
+			name:   "unqualified schema",
+			query:  "DROP SCHEMA fivetran_testing_schema_abc CASCADE",
+			wantOK: true,
+			want: dropSchemaCascadeTarget{
+				Schema: "fivetran_testing_schema_abc",
+			},
+		},
+		{
+			name:   "quoted identifiers",
+			query:  `DROP SCHEMA IF EXISTS "iceberg"."MixedSchema" CASCADE`,
+			wantOK: true,
+			want: dropSchemaCascadeTarget{
+				Catalog:  "iceberg",
+				Schema:   "MixedSchema",
+				IfExists: true,
+			},
+		},
+		{
+			name:   "unquoted identifiers normalize",
+			query:  `/*Fivetran*/ DROP SCHEMA IF EXISTS ICEBERG.Fivetran_Testing_Schema_ABC CASCADE;`,
+			wantOK: true,
+			want: dropSchemaCascadeTarget{
+				Catalog:  "iceberg",
+				Schema:   "fivetran_testing_schema_abc",
+				IfExists: true,
+			},
+		},
+		{
+			name:   "not cascade",
+			query:  "DROP SCHEMA IF EXISTS iceberg.foo",
+			wantOK: false,
+		},
+		{
+			name:   "drop table ignored",
+			query:  "DROP TABLE iceberg.foo.bar CASCADE",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseDropSchemaCascadeTarget(tt.query)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("target = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsIcebergDropSchemaCascadeUnsupported(t *testing.T) {
+	err := errors.New("flight execute update: rpc error: code = InvalidArgument desc = failed to execute update: Not implemented Error: DROP SCHEMA <schema_name> CASCADE is not supported for Iceberg schemas currently")
+	if !isIcebergDropSchemaCascadeUnsupported(err) {
+		t.Fatal("expected Iceberg DROP SCHEMA CASCADE unsupported error")
+	}
+	if isIcebergDropSchemaCascadeUnsupported(errors.New(`Catalog Error: Table with name "person" already exists`)) {
+		t.Fatal("table already exists must not trigger schema cascade fallback")
+	}
+}
+
+func TestDropIcebergSchemaCascadeDropsTablesThenSchema(t *testing.T) {
+	exec := &icebergDropSchemaCascadeExecutor{
+		tableNames: []string{`plain`, `quote"table`},
+	}
+	c := &clientConn{executor: exec}
+
+	if _, err := c.dropIcebergSchemaCascade(context.Background(), `DROP SCHEMA IF EXISTS iceberg."fivetran testing" CASCADE`); err != nil {
+		t.Fatalf("dropIcebergSchemaCascade returned error: %v", err)
+	}
+
+	want := []string{
+		`DROP TABLE IF EXISTS "iceberg"."fivetran testing"."plain"`,
+		`DROP TABLE IF EXISTS "iceberg"."fivetran testing"."quote""table"`,
+		`DROP SCHEMA IF EXISTS "iceberg"."fivetran testing"`,
+	}
+	if !slices.Equal(exec.execQueries, want) {
+		t.Fatalf("exec queries = %#v, want %#v", exec.execQueries, want)
+	}
+}
+
+func TestDropIcebergSchemaCascadeUsesCurrentSearchPathForUnqualifiedSchema(t *testing.T) {
+	exec := &icebergDropSchemaCascadeExecutor{
+		defaultCatalog: "iceberg",
+		tableNames:     []string{`person`},
+	}
+	c := &clientConn{executor: exec}
+
+	if _, err := c.dropIcebergSchemaCascade(context.Background(), `DROP SCHEMA IF EXISTS stripe CASCADE`); err != nil {
+		t.Fatalf("dropIcebergSchemaCascade returned error: %v", err)
+	}
+
+	want := []string{
+		`DROP TABLE IF EXISTS "iceberg"."stripe"."person"`,
+		`DROP SCHEMA IF EXISTS "iceberg"."stripe"`,
+	}
+	if !slices.Equal(exec.execQueries, want) {
+		t.Fatalf("exec queries = %#v, want %#v", exec.execQueries, want)
+	}
+}
+
+func TestDropIcebergSchemaCascadeRejectsNonIcebergSearchPath(t *testing.T) {
+	exec := &icebergDropSchemaCascadeExecutor{
+		defaultCatalog: "ducklake",
+		tableNames:     []string{`person`},
+	}
+	c := &clientConn{executor: exec}
+
+	if _, err := c.dropIcebergSchemaCascade(context.Background(), `DROP SCHEMA IF EXISTS stripe CASCADE`); err == nil {
+		t.Fatal("expected non-Iceberg search_path catalog to be rejected")
+	}
+	if len(exec.execQueries) != 0 {
+		t.Fatalf("exec queries = %#v, want none", exec.execQueries)
+	}
+}
+
+func TestQuoteDuckDBIdentifier(t *testing.T) {
+	if got := quoteDuckDBIdentifier(`a"b`); got != `"a""b"` {
+		t.Fatalf("quoteDuckDBIdentifier = %q", got)
+	}
+}
+
+type icebergDropSchemaCascadeExecutor struct {
+	noopProfiling
+	defaultCatalog string
+	execQueries    []string
+	tableNames     []string
+}
+
+func (e *icebergDropSchemaCascadeExecutor) QueryContext(_ context.Context, query string, _ ...any) (RowSet, error) {
+	if strings.Contains(query, "duckdb_settings()") {
+		return &icebergDropSchemaCascadeRows{values: []string{e.defaultCatalog}}, nil
+	}
+	return &icebergDropSchemaCascadeRows{values: e.tableNames}, nil
+}
+
+func (e *icebergDropSchemaCascadeExecutor) ExecContext(_ context.Context, query string, _ ...any) (ExecResult, error) {
+	e.execQueries = append(e.execQueries, query)
+	return &fakeExecResult{}, nil
+}
+
+func (e *icebergDropSchemaCascadeExecutor) Query(string, ...any) (RowSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *icebergDropSchemaCascadeExecutor) Exec(string, ...any) (ExecResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *icebergDropSchemaCascadeExecutor) ConnContext(context.Context) (RawConn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *icebergDropSchemaCascadeExecutor) PingContext(context.Context) error {
+	return errors.New("not implemented")
+}
+
+func (e *icebergDropSchemaCascadeExecutor) Close() error {
+	return nil
+}
+
+type icebergDropSchemaCascadeRows struct {
+	values []string
+	idx    int
+}
+
+func (r *icebergDropSchemaCascadeRows) Columns() ([]string, error) { return []string{"value"}, nil }
+func (r *icebergDropSchemaCascadeRows) ColumnTypes() ([]ColumnTyper, error) {
+	return []ColumnTyper{describeColumnType("VARCHAR")}, nil
+}
+func (r *icebergDropSchemaCascadeRows) Next() bool {
+	if r.idx >= len(r.values) {
+		return false
+	}
+	r.idx++
+	return true
+}
+func (r *icebergDropSchemaCascadeRows) Scan(dest ...any) error {
+	*(dest[0].(*string)) = r.values[r.idx-1]
+	return nil
+}
+func (r *icebergDropSchemaCascadeRows) Close() error { return nil }
+func (r *icebergDropSchemaCascadeRows) Err() error   { return nil }

--- a/server/iceberg_drop_schema_test.go
+++ b/server/iceberg_drop_schema_test.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/posthog/duckgres/server/sqlcore"
 )
 
 func TestParseDropSchemaCascadeTarget(t *testing.T) {
@@ -20,9 +22,8 @@ func TestParseDropSchemaCascadeTarget(t *testing.T) {
 			query:  "DROP SCHEMA IF EXISTS iceberg.fivetran_testing_schema_abc CASCADE",
 			wantOK: true,
 			want: dropSchemaCascadeTarget{
-				Catalog:  "iceberg",
-				Schema:   "fivetran_testing_schema_abc",
-				IfExists: true,
+				Catalog: "iceberg",
+				Schema:  "fivetran_testing_schema_abc",
 			},
 		},
 		{
@@ -38,9 +39,8 @@ func TestParseDropSchemaCascadeTarget(t *testing.T) {
 			query:  `DROP SCHEMA IF EXISTS "iceberg"."MixedSchema" CASCADE`,
 			wantOK: true,
 			want: dropSchemaCascadeTarget{
-				Catalog:  "iceberg",
-				Schema:   "MixedSchema",
-				IfExists: true,
+				Catalog: "iceberg",
+				Schema:  "MixedSchema",
 			},
 		},
 		{
@@ -48,9 +48,8 @@ func TestParseDropSchemaCascadeTarget(t *testing.T) {
 			query:  `/*Fivetran*/ DROP SCHEMA IF EXISTS ICEBERG.Fivetran_Testing_Schema_ABC CASCADE;`,
 			wantOK: true,
 			want: dropSchemaCascadeTarget{
-				Catalog:  "iceberg",
-				Schema:   "fivetran_testing_schema_abc",
-				IfExists: true,
+				Catalog: "iceberg",
+				Schema:  "fivetran_testing_schema_abc",
 			},
 		},
 		{
@@ -113,8 +112,8 @@ func TestDropIcebergSchemaCascadeDropsTablesThenSchema(t *testing.T) {
 
 func TestDropIcebergSchemaCascadeUsesCurrentSearchPathForUnqualifiedSchema(t *testing.T) {
 	exec := &icebergDropSchemaCascadeExecutor{
-		defaultCatalog: "iceberg",
-		tableNames:     []string{`person`},
+		searchPath: `"iceberg"."public",memory.main`,
+		tableNames: []string{`person`},
 	}
 	c := &clientConn{executor: exec}
 
@@ -133,8 +132,8 @@ func TestDropIcebergSchemaCascadeUsesCurrentSearchPathForUnqualifiedSchema(t *te
 
 func TestDropIcebergSchemaCascadeRejectsNonIcebergSearchPath(t *testing.T) {
 	exec := &icebergDropSchemaCascadeExecutor{
-		defaultCatalog: "ducklake",
-		tableNames:     []string{`person`},
+		searchPath: "ducklake.main,memory.main",
+		tableNames: []string{`person`},
 	}
 	c := &clientConn{executor: exec}
 
@@ -146,22 +145,22 @@ func TestDropIcebergSchemaCascadeRejectsNonIcebergSearchPath(t *testing.T) {
 	}
 }
 
-func TestQuoteDuckDBIdentifier(t *testing.T) {
-	if got := quoteDuckDBIdentifier(`a"b`); got != `"a""b"` {
-		t.Fatalf("quoteDuckDBIdentifier = %q", got)
+func TestQuoteIdentifier(t *testing.T) {
+	if got := sqlcore.QuoteIdentifier(`a"b`); got != `"a""b"` {
+		t.Fatalf("QuoteIdentifier = %q", got)
 	}
 }
 
 type icebergDropSchemaCascadeExecutor struct {
 	noopProfiling
-	defaultCatalog string
-	execQueries    []string
-	tableNames     []string
+	searchPath  string
+	execQueries []string
+	tableNames  []string
 }
 
 func (e *icebergDropSchemaCascadeExecutor) QueryContext(_ context.Context, query string, _ ...any) (RowSet, error) {
 	if strings.Contains(query, "duckdb_settings()") {
-		return &icebergDropSchemaCascadeRows{values: []string{e.defaultCatalog}}, nil
+		return &icebergDropSchemaCascadeRows{values: []string{e.searchPath}}, nil
 	}
 	return &icebergDropSchemaCascadeRows{values: e.tableNames}, nil
 }

--- a/server/sqlcore/identifier.go
+++ b/server/sqlcore/identifier.go
@@ -1,0 +1,113 @@
+package sqlcore
+
+import "strings"
+
+// ParseQualifiedIdentifier splits a one-or-more-part SQL identifier, preserving
+// quoted identifier case and lowercasing unquoted identifiers.
+func ParseQualifiedIdentifier(ref string) ([]string, bool) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, false
+	}
+
+	var parts []string
+	inQuotes := false
+	partStart := 0
+	for i := 0; i < len(ref); i++ {
+		ch := ref[i]
+		if ch == '"' {
+			if inQuotes && i+1 < len(ref) && ref[i+1] == '"' {
+				i++
+				continue
+			}
+			inQuotes = !inQuotes
+			continue
+		}
+		if ch == '.' && !inQuotes {
+			part, ok := parseIdentifierPart(ref[partStart:i])
+			if !ok {
+				return nil, false
+			}
+			parts = append(parts, part)
+			partStart = i + 1
+		}
+	}
+	if inQuotes {
+		return nil, false
+	}
+
+	part, ok := parseIdentifierPart(ref[partStart:])
+	if !ok {
+		return nil, false
+	}
+	parts = append(parts, part)
+	return parts, true
+}
+
+// CatalogFromSearchPath returns the catalog from the first search_path entry,
+// or "" when the first entry is an unqualified schema.
+func CatalogFromSearchPath(searchPath string) string {
+	entry := firstSearchPathEntry(searchPath)
+	if entry == "" {
+		return ""
+	}
+	parts, ok := ParseQualifiedIdentifier(entry)
+	if !ok || len(parts) < 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+func QuoteIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func firstSearchPathEntry(searchPath string) string {
+	searchPath = strings.TrimSpace(searchPath)
+	inQuotes := false
+	for i := 0; i < len(searchPath); i++ {
+		ch := searchPath[i]
+		if ch == '"' {
+			if inQuotes && i+1 < len(searchPath) && searchPath[i+1] == '"' {
+				i++
+				continue
+			}
+			inQuotes = !inQuotes
+			continue
+		}
+		if ch == ',' && !inQuotes {
+			return strings.TrimSpace(searchPath[:i])
+		}
+	}
+	return searchPath
+}
+
+func parseIdentifierPart(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	if s[0] != '"' {
+		if strings.ContainsAny(s, "\" \t\n\r\f") {
+			return "", false
+		}
+		return strings.ToLower(s), true
+	}
+	if len(s) < 2 || s[len(s)-1] != '"' {
+		return "", false
+	}
+
+	var ident strings.Builder
+	for i := 1; i < len(s)-1; i++ {
+		if s[i] == '"' {
+			if i+1 >= len(s)-1 || s[i+1] != '"' {
+				return "", false
+			}
+			ident.WriteByte('"')
+			i++
+			continue
+		}
+		ident.WriteByte(s[i])
+	}
+	return ident.String(), true
+}

--- a/server/sqlcore/identifier_test.go
+++ b/server/sqlcore/identifier_test.go
@@ -1,0 +1,55 @@
+package sqlcore
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseQualifiedIdentifier(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   []string
+		wantOK bool
+	}{
+		{name: "unquoted lowercases", input: "ICEBERG.Fivetran_Testing", want: []string{"iceberg", "fivetran_testing"}, wantOK: true},
+		{name: "quoted preserves case", input: `"iceberg"."MixedSchema"`, want: []string{"iceberg", "MixedSchema"}, wantOK: true},
+		{name: "escaped quote", input: `"iceberg"."quote""schema"`, want: []string{"iceberg", `quote"schema`}, wantOK: true},
+		{name: "empty part", input: "iceberg..schema", wantOK: false},
+		{name: "unterminated quote", input: `"iceberg"."schema`, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseQualifiedIdentifier(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("parts = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCatalogFromSearchPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		searchPath string
+		want       string
+	}{
+		{name: "qualified catalog first", searchPath: "iceberg.public,memory.main", want: "iceberg"},
+		{name: "quoted qualified catalog first", searchPath: `"iceberg"."public", memory.main`, want: "iceberg"},
+		{name: "escaped comma inside quoted schema", searchPath: `"iceberg"."pub,lic", memory.main`, want: "iceberg"},
+		{name: "unqualified first entry", searchPath: "main,memory.main", want: ""},
+		{name: "empty", searchPath: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CatalogFromSearchPath(tt.searchPath); got != tt.want {
+				t.Fatalf("CatalogFromSearchPath(%q) = %q, want %q", tt.searchPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/ddl_test.go
+++ b/tests/integration/ddl_test.go
@@ -286,6 +286,11 @@ func TestDDLSchemas(t *testing.T) {
 			Query:        "DROP SCHEMA IF EXISTS ddl_schema_test",
 			DuckgresOnly: true,
 		},
+		{
+			Name:         "drop_schema_if_exists_cascade",
+			Query:        "DROP SCHEMA IF EXISTS ddl_schema_test CASCADE",
+			DuckgresOnly: true,
+		},
 	}
 	runQueryTests(t, tests)
 }


### PR DESCRIPTION
## Summary
- Adds an Iceberg-only fallback for DuckDB's unsupported `DROP SCHEMA ... CASCADE` path.
- Enumerates tables in the target Iceberg schema, drops them, then drops the schema without CASCADE.
- Keeps generic and DuckLake `DROP SCHEMA ... CASCADE` behavior intact, with focused unit coverage and DDL integration coverage.

## Test plan
- `go test ./server -count=1`
- `go test ./tests/integration -run TestDDLSchemas -count=1 -v` (passed in Duckgres-only fallback mode because Docker was unavailable locally)
- `git diff --check`

## Notes
- `just lint` could not run locally because `golangci-lint` is not installed on PATH; `go tool golangci-lint run` is also unavailable.