### PR TITLE
Transpile CREATE OR REPLACE TABLE (fix multi-tenant logical-catalog rewrite)

### DIFF
--- a/transpiler/create_or_replace.go
+++ b/transpiler/create_or_replace.go
@@ -1,0 +1,49 @@
+package transpiler
+
+import "regexp"
+
+// createOrReplaceTableRe matches a leading
+// `CREATE OR REPLACE [TEMP|TEMPORARY|UNLOGGED] TABLE ...` after leading
+// comments/whitespace are stripped.
+//
+// PostgreSQL has no `OR REPLACE` for TABLE (only VIEW/FUNCTION/etc.), so
+// pg_query cannot parse this DuckDB-specific form. Without interception the
+// transpiler would set FallbackToNative and conn.go would forward the SQL
+// raw — skipping every transform, including the logical-catalog rewrite
+// (logical database name -> physical catalog, e.g. `portola` -> `ducklake`).
+// On a multi-tenant worker the physical catalog is `ducklake`, so the
+// un-rewritten logical name fails to bind ("Catalog \"portola\" does not
+// exist"). dbt-duckdb and SQLMesh both materialize tables with
+// `CREATE OR REPLACE TABLE ... AS ...`, so this hit real tenants.
+//
+// `(?is)`: case-insensitive, and `.` spans newlines (the AS-SELECT body is
+// usually multi-line).
+var createOrReplaceTableRe = regexp.MustCompile(`(?is)^CREATE\s+OR\s+REPLACE\s+((?:(?:TEMP|TEMPORARY|UNLOGGED)\s+)?TABLE\b.*)$`)
+
+// createPrefixRe captures the leading `CREATE ` keyword (with surrounding
+// whitespace) so OR REPLACE can be re-inserted after it.
+var createPrefixRe = regexp.MustCompile(`(?is)^(\s*CREATE\s+)(.*)$`)
+
+// stripCreateOrReplaceTable detects `CREATE OR REPLACE TABLE ...`. On a match
+// it returns the PostgreSQL-parseable `CREATE TABLE ...` form (with OR REPLACE
+// removed) and ok=true; the caller transpiles that through the normal pipeline
+// and then restores OR REPLACE via reinjectOrReplace. Returns ok=false for any
+// other statement (including the PostgreSQL-valid `CREATE OR REPLACE VIEW`).
+func stripCreateOrReplaceTable(sql string) (inner string, ok bool) {
+	m := createOrReplaceTableRe.FindStringSubmatch(stripLeadingSQL(sql))
+	if m == nil {
+		return "", false
+	}
+	return "CREATE " + m[1], true
+}
+
+// reinjectOrReplace inserts `OR REPLACE` after the leading CREATE keyword of a
+// transpiled `CREATE [TEMP] TABLE ...` statement, reversing the strip done by
+// stripCreateOrReplaceTable.
+func reinjectOrReplace(out string) string {
+	m := createPrefixRe.FindStringSubmatch(out)
+	if m == nil {
+		return out
+	}
+	return m[1] + "OR REPLACE " + m[2]
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -158,6 +158,20 @@ func (t *Transpiler) Transpile(sql string) (*Result, error) {
 		return &Result{SQL: rewritten}, nil
 	}
 
+	// CREATE OR REPLACE TABLE is DuckDB-only syntax that PostgreSQL can't
+	// parse. Strip OR REPLACE so the statement runs through the full transform
+	// pipeline (critically, the logical-catalog rewrite), then restore it.
+	// Without this the statement would FallbackToNative and be forwarded raw,
+	// reaching the worker with the un-rewritten logical catalog name.
+	if inner, ok := stripCreateOrReplaceTable(sql); ok {
+		res, err := t.Transpile(inner)
+		if err != nil {
+			return res, err
+		}
+		res.SQL = reinjectOrReplace(res.SQL)
+		return res, nil
+	}
+
 	// Tier 0: Pre-parse classification
 	cls := Classify(sql, t.config)
 	if cls.Direct {

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -301,6 +301,92 @@ func TestTranspile_LogicalCatalogMapping_DuckLakeMode(t *testing.T) {
 	}
 }
 
+func TestTranspile_CreateOrReplaceTable_LogicalCatalog(t *testing.T) {
+	// CREATE OR REPLACE TABLE is DuckDB-only syntax (PostgreSQL has no
+	// OR REPLACE for TABLE). Before the pre-parse interceptor this fell back
+	// to native and was forwarded raw, so the logical catalog name was never
+	// rewritten to the physical catalog — breaking multi-tenant dbt/SQLMesh
+	// table materializations with "Catalog \"portola\" does not exist".
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+		excludes string
+	}{
+		{
+			name:     "CTAS target and source both rewritten, OR REPLACE preserved",
+			input:    `CREATE OR REPLACE TABLE "portola"."core"."payment_events" AS SELECT * FROM "portola"."core"."raw_payments"`,
+			contains: []string{"CREATE OR REPLACE TABLE", "ducklake.core.payment_events", "ducklake.core.raw_payments"},
+			excludes: "portola",
+		},
+		{
+			name:     "public schema maps to main; OR REPLACE preserved",
+			input:    `CREATE OR REPLACE TABLE portola.public.t AS SELECT 1 AS x`,
+			contains: []string{"CREATE OR REPLACE TABLE", "ducklake.main.t"},
+			excludes: "portola",
+		},
+		{
+			name:     "multi-line AS SELECT body still rewritten",
+			input:    "CREATE OR REPLACE TABLE portola.core.t AS\nSELECT a\nFROM portola.core.src\nWHERE a > 0",
+			contains: []string{"CREATE OR REPLACE TABLE", "ducklake.core.t", "ducklake.core.src"},
+			excludes: "portola",
+		},
+		{
+			name:     "TEMP variant preserves OR REPLACE and TEMP",
+			input:    `CREATE OR REPLACE TEMP TABLE t AS SELECT * FROM portola.core.src`,
+			contains: []string{"OR REPLACE", "TEMP", "ducklake.core.src"},
+			excludes: "portola.core.src",
+		},
+		{
+			name:     "plain column-def form (no AS) rewrites target",
+			input:    `CREATE OR REPLACE TABLE portola.core.t (id INTEGER)`,
+			contains: []string{"CREATE OR REPLACE TABLE", "ducklake.core.t"},
+			excludes: "portola",
+		},
+	}
+
+	tr := New(Config{DuckLakeMode: true, LogicalDatabaseName: "portola", PhysicalCatalogName: "ducklake"})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if result.FallbackToNative {
+				t.Fatalf("Transpile(%q) fell back to native; expected transpilation. SQL=%q", tt.input, result.SQL)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(result.SQL, want) {
+					t.Errorf("Transpile(%q) = %q, should contain %q", tt.input, result.SQL, want)
+				}
+			}
+			if tt.excludes != "" && strings.Contains(result.SQL, tt.excludes) {
+				t.Errorf("Transpile(%q) = %q, should NOT contain %q", tt.input, result.SQL, tt.excludes)
+			}
+		})
+	}
+}
+
+// CREATE OR REPLACE VIEW is valid PostgreSQL and must NOT be touched by the
+// CREATE OR REPLACE TABLE interceptor.
+func TestTranspile_CreateOrReplaceView_Unaffected(t *testing.T) {
+	tr := New(Config{DuckLakeMode: true, LogicalDatabaseName: "portola", PhysicalCatalogName: "ducklake"})
+	result, err := tr.Transpile(`CREATE OR REPLACE VIEW portola.core.v AS SELECT * FROM portola.core.t`)
+	if err != nil {
+		t.Fatalf("Transpile error: %v", err)
+	}
+	if !strings.Contains(result.SQL, "CREATE OR REPLACE VIEW") {
+		t.Errorf("CREATE OR REPLACE VIEW not preserved: %q", result.SQL)
+	}
+	if !strings.Contains(result.SQL, "ducklake.core.v") || !strings.Contains(result.SQL, "ducklake.core.t") {
+		t.Errorf("view logical catalog not rewritten: %q", result.SQL)
+	}
+	if strings.Contains(result.SQL, "portola") {
+		t.Errorf("portola should have been rewritten away: %q", result.SQL)
+	}
+}
+
 func TestTranspile_PgCatalog_DuckLakeMode(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

`CREATE OR REPLACE TABLE` is DuckDB-only syntax — PostgreSQL has no `OR REPLACE` for TABLE (only VIEW/FUNCTION/…). duckgres parses incoming SQL with `pg_query` (libpg_query), which **fails to parse** it, so `Transpile` returned `FallbackToNative` and `conn.go` forwarded the statement **raw to the worker** — skipping every transform, including the **logical-catalog rewrite** that maps a session's logical database name to the physical catalog (`portola` → `ducklake`).

On a multi-tenant worker the physical catalog is `ducklake`, so the un-rewritten logical name failed to bind:

```
Binder Error: Catalog "portola" does not exist!
```

**dbt-duckdb and SQLMesh both materialize tables with `CREATE OR REPLACE TABLE … AS …`**, so every table model on a serverless duckling broke. Confirmed live against tenant Portola: `CREATE TABLE … AS SELECT …` worked (rewritten to `ducklake`), and adding `OR REPLACE` failed with the catalog error. It is **not** version-specific — `pg_query` has never parsed `OR REPLACE TABLE`.

## Fix

A pre-parse interceptor (mirroring the existing `interceptShowCreate`) in `transpiler/create_or_replace.go`:
1. detects a leading `CREATE OR REPLACE [TEMP|TEMPORARY|UNLOGGED] TABLE …`,
2. strips `OR REPLACE` → the PostgreSQL-parseable `CREATE TABLE …` form,
3. runs it through the **full** transpile pipeline (logical-catalog rewrite of target *and* source, `public`→`main`, etc.),
4. re-injects `OR REPLACE` into the deparsed output.

`CREATE OR REPLACE VIEW` is valid PostgreSQL and is intentionally left untouched.

## Tests
- `TestTranspile_CreateOrReplaceTable_LogicalCatalog` — target+source rewrite, `public`→`main`, multi-line AS-SELECT, `TEMP`, and plain column-def forms; asserts `portola` is fully rewritten away and the statement does **not** fall back to native.
- `TestTranspile_CreateOrReplaceView_Unaffected` — the PG-valid VIEW form still transpiles normally.

## Test plan
- [x] `go test ./transpiler/...`
- [x] `go build ./...`, `go vet ./transpiler/...`
- [ ] CI (unit + integration + k8s)
- Customer unblock available without deploy (point model relations at physical catalog `ducklake`, or disable `OR REPLACE` in the adapter), but this is the proper fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)