### PR TITLE
fix(controlplane): default passthrough sessions into the tenant catalog

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1126,9 +1126,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		}
 	}()
 
-	// Passthrough users skip pg_catalog initialization and DuckLake catalog
-	// detection — they bypass the PG compatibility layer entirely, so the
-	// metadata setup that drives logical catalog mapping is unused for them.
+	// Passthrough users skip pg_catalog initialization and logical-catalog
+	// mapping — they bypass the PG compatibility layer entirely. They still
+	// need a default catalog, though: without one the worker session stays in
+	// DuckDB's empty in-memory catalog, so current_database() reports "memory"
+	// and unqualified DDL/DML never reaches the warehouse (see the passthrough
+	// branch below).
 	var duckLakeAttached bool
 	if !passthroughUser {
 		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
@@ -1170,6 +1173,31 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 				slog.Warn("Failed to apply client connect-time search_path; using default.", "user", username, "org", orgID, "search_path", clientSearchPath, "error", err)
 			}
 		}
+	} else {
+		// Passthrough: no pg_catalog views and no logical-catalog rewriting, but
+		// the session must still land in the tenant's catalog instead of the
+		// empty in-memory one. Standalone passthrough does this via
+		// server.setDuckLakeDefault/setIcebergDefault; the remote-worker path
+		// has to issue the equivalent explicitly here.
+		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
+		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
+		if err != nil {
+			initCancel()
+			slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
+			_ = writer.Flush()
+			return
+		}
+		if cmd := passthroughSessionDefaultCatalogCommand(defaultCatalog, duckLakeAttached); cmd != "" {
+			if _, err := executor.ExecContext(initCtx, cmd); err != nil {
+				initCancel()
+				slog.Error("Failed to apply passthrough session default catalog.", "user", username, "org", orgID, "command", cmd, "error", err, "worker", workerID, "worker_pod", workerPod)
+				_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply default catalog")
+				_ = writer.Flush()
+				return
+			}
+		}
+		initCancel()
 	}
 
 	// Register the TCP connection so OnWorkerCrash can close it to unblock
@@ -1183,7 +1211,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			server.SetConnectionIcebergConfig(cc, icebergCfg)
 		}
 	}
-	server.SetLogicalCatalogMapping(cc, duckLakeAttached)
+	// Logical-catalog mapping (current_database masking + USE/qualified-name
+	// rewriting) is a non-passthrough feature; passthrough sessions talk raw
+	// DuckDB against the physical catalog name, so keep it disabled for them
+	// even though duckLakeAttached is now populated on the passthrough path.
+	server.SetLogicalCatalogMapping(cc, duckLakeAttached && !passthroughUser)
 	server.SetPassthrough(cc, passthroughUser)
 	if orgID != "" {
 		observeOrgPgSessionAccepted(orgID, passthroughUser)

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1180,13 +1180,20 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		// server.setDuckLakeDefault/setIcebergDefault; the remote-worker path
 		// has to issue the equivalent explicitly here.
 		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
-		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
+		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, physicalDuckLakeCatalog)
 		if err != nil {
 			initCancel()
 			slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
 			_ = writer.Flush()
 			return
+		}
+		// Passthrough doesn't apply a client-supplied search_path (the
+		// non-passthrough best-effort path does). Surface it rather than
+		// dropping it silently — passthrough clients can issue SET search_path
+		// themselves once connected.
+		if clientSearchPath != "" {
+			slog.Warn("Ignoring client connect-time search_path for passthrough session.", "user", username, "org", orgID, "search_path", clientSearchPath, "remote_addr", remoteAddr)
 		}
 		if cmd := passthroughSessionDefaultCatalogCommand(defaultCatalog, duckLakeAttached); cmd != "" {
 			if _, err := executor.ExecContext(initCtx, cmd); err != nil {

--- a/controlplane/session_search_path.go
+++ b/controlplane/session_search_path.go
@@ -25,6 +25,24 @@ func effectiveSessionDefaultCommand(clientSearchPath, defaultCatalog string) (st
 	}
 }
 
+// passthroughSessionDefaultCatalogCommand returns the connect-time command that
+// points a passthrough session at the tenant's catalog. Passthrough users skip
+// InitSessionDatabaseMetadata (whose defer issues `USE ducklake` for the
+// standard path), so without this the session stays in DuckDB's empty in-memory
+// catalog — current_database() reports "memory" and unqualified DDL/DML never
+// reaches the warehouse. Mirrors server.setIcebergDefault / setDuckLakeDefault
+// used by the standalone passthrough path.
+func passthroughSessionDefaultCatalogCommand(defaultCatalog string, duckLakeAttached bool) string {
+	switch {
+	case defaultCatalog == iceberg.CatalogName:
+		return fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
+	case duckLakeAttached:
+		return "USE ducklake"
+	default:
+		return ""
+	}
+}
+
 func ensureMemoryMainInSearchPath(searchPath string) string {
 	if strings.Contains(strings.ToLower(searchPath), "memory.main") {
 		return searchPath

--- a/controlplane/session_search_path.go
+++ b/controlplane/session_search_path.go
@@ -14,6 +14,12 @@ const (
 	sessionDefaultSourceConfiguredCatalog sessionSearchPathSource = "configured_catalog"
 )
 
+// physicalDuckLakeCatalog is the name the per-tenant DuckLake catalog is
+// attached as on the worker (the `ATTACH ... AS ducklake` performed during
+// activation; matches server.physicalDuckLakeCatalog). Keep this and the
+// HasAttachedCatalog probe in control.go in sync.
+const physicalDuckLakeCatalog = "ducklake"
+
 func effectiveSessionDefaultCommand(clientSearchPath, defaultCatalog string) (string, sessionSearchPathSource) {
 	switch {
 	case clientSearchPath != "":
@@ -37,7 +43,7 @@ func passthroughSessionDefaultCatalogCommand(defaultCatalog string, duckLakeAtta
 	case defaultCatalog == iceberg.CatalogName:
 		return fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
 	case duckLakeAttached:
-		return "USE ducklake"
+		return "USE " + physicalDuckLakeCatalog
 	default:
 		return ""
 	}

--- a/controlplane/session_search_path_test.go
+++ b/controlplane/session_search_path_test.go
@@ -31,3 +31,24 @@ func TestEffectiveSessionDefaultCommandReturnsEmptyWhenUnset(t *testing.T) {
 		t.Fatalf("source = %q, want empty", source)
 	}
 }
+
+func TestPassthroughSessionDefaultCatalogCommand(t *testing.T) {
+	tests := []struct {
+		name             string
+		defaultCatalog   string
+		duckLakeAttached bool
+		want             string
+	}{
+		{name: "ducklake attached defaults to ducklake", defaultCatalog: "", duckLakeAttached: true, want: "USE ducklake"},
+		{name: "iceberg-default user prefers iceberg over ducklake", defaultCatalog: "iceberg", duckLakeAttached: true, want: "USE iceberg.public"},
+		{name: "iceberg-default user with no ducklake", defaultCatalog: "iceberg", duckLakeAttached: false, want: "USE iceberg.public"},
+		{name: "no ducklake and no configured catalog leaves session as-is", defaultCatalog: "", duckLakeAttached: false, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := passthroughSessionDefaultCatalogCommand(tt.defaultCatalog, tt.duckLakeAttached); got != tt.want {
+				t.Fatalf("command = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Portola runs sqlmesh against the MTCP through a **passthrough** user. Their job fails with `Catalog "portola" does not exist`, and more subtly, passthrough sessions land in the wrong catalog entirely.

Verified live against prod-us (`entirely-chief-wildcat.dw.us.postwh.com`, user `duckgres-duckdb`):

```
6/6 fresh passthrough connections:  current_database() = memory
ducklake.core.membership_events  → 7,170,968 rows   ✅ (data is here)
```

On the remote-worker path, passthrough sessions skip the entire session-init block (`controlplane/control.go`, gated `if !passthroughUser`), so the worker's DuckDB connection is left in DuckDB's default **empty in-memory `memory` catalog**. Consequences:

- `current_database()` returns `memory` — so sqlmesh's default-catalog auto-detection (which probes `current_catalog`) resolves to the wrong, ephemeral catalog.
- Unqualified DDL/DML executes against `memory` and **never reaches the tenant's DuckLake warehouse**.

Standalone passthrough doesn't have this problem — `server.CreatePassthroughDBConnection` calls `setDuckLakeDefault` (`USE ducklake`) / `setIcebergDefault`. The remote-worker path simply had no equivalent.

## Fix

Add a passthrough branch to the session-init block that detects the attached `ducklake` catalog and issues the matching `USE`, preferring an iceberg-default user's configured catalog (mirrors the standalone behavior):

```go
passthroughSessionDefaultCatalogCommand(defaultCatalog, duckLakeAttached):
  defaultCatalog == "iceberg"  -> USE iceberg.public
  duckLakeAttached             -> USE ducklake
  otherwise                    -> "" (leave session as-is)
```

After this, a passthrough session reliably reports `current_database() = ducklake` and lands in the tenant warehouse.

### Deliberately *not* in scope

This does **not** enable logical-catalog mapping for passthrough. Those sessions still talk raw DuckDB against the **physical** catalog name (`ducklake`); `SetLogicalCatalogMapping` stays disabled for them (guarded with `&& !passthroughUser`). Making the logical org name (e.g. `portola`) resolve for passthrough would require re-introducing transpiler/rewrite behavior, which defeats the purpose of passthrough and can't reliably handle the DuckDB-native SQL these users send. The customer-side counterpart to this fix is to reference the real catalog name `ducklake` in their sqlmesh project (duckdb dialect), while keeping the PG connection database as their org name for routing.

## Testing

- `go build -tags kubernetes ./controlplane/...`
- `go vet -tags kubernetes ./controlplane/`
- `go test -tags kubernetes ./controlplane/` (incl. new `TestPassthroughSessionDefaultCatalogCommand`)

### Verify post-deploy
Connect to MTCP as a passthrough user and confirm `SELECT current_database()` returns the tenant catalog (`ducklake`) on a fresh session, and that an unqualified `CREATE TABLE` lands in the warehouse rather than `memory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)