### PR TITLE
Report stable physical catalog for DuckLake-backed sessions (single- and multi-tenant)

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -984,9 +984,13 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		passthroughUser = resolution.Passthrough
 		defaultCatalog = resolution.DefaultCatalog
 		// From here on, `database` reflects the effective routing database.
-		// This is what gets passed to the worker as the logical database
-		// (drives the `current_database()` macro and pg_database view) so
-		// observability surfaces the actual routing decision.
+		// It is passed to the worker as the logical database name (the
+		// logical-catalog transform rewrites <database>.schema.table ->
+		// ducklake.schema.table). Note: for DuckLake-backed sessions the
+		// client-visible current_database()/pg_database report the stable
+		// physical catalog "ducklake" (see sessionmeta.ReportedDatabaseName),
+		// not this routing name; org identity for observability comes from
+		// orgID, which is logged separately.
 		database = effectiveDatabase
 	} else {
 		// Single-tenant: static users map
@@ -1135,21 +1139,31 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	var duckLakeAttached bool
 	if !passthroughUser {
 		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
-		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, database); err != nil {
+		// Detect DuckLake attachment first so we can report a stable catalog
+		// name. DuckLake-backed sessions report the physical catalog name
+		// ("ducklake") as current_database() regardless of tenancy, so
+		// catalog-keyed tools (e.g. SQLMesh) see a consistent name across
+		// single-/multi-tenant and across a single->multi migration; the
+		// connection dbname still works as an alias via the logical-catalog
+		// transform. Non-DuckLake sessions (e.g. iceberg-only) keep reporting
+		// their own dbname.
+		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, physicalDuckLakeCatalog)
+		if err != nil {
+			initCancel()
+			slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
+			_ = writer.Flush()
+			return
+		}
+		reportedDatabase := sessionmeta.ReportedDatabaseName(database, defaultCatalog, duckLakeAttached)
+		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, reportedDatabase); err != nil {
 			initCancel()
 			slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
 			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
 			_ = writer.Flush()
 			return
 		}
-		duckLakeAttached, err = sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
 		initCancel()
-		if err != nil {
-			slog.Error("Failed to detect ducklake catalog attachment.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
-			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect ducklake catalog attachment")
-			_ = writer.Flush()
-			return
-		}
 
 		// Apply the effective connect-time session default AFTER metadata init.
 		// It must run here, not on the worker at session create: (1)

--- a/server/conn.go
+++ b/server/conn.go
@@ -201,7 +201,7 @@ func (c *clientConn) newTranspiler(convertPlaceholders bool) *transpiler.Transpi
 	return transpiler.New(transpiler.Config{
 		DuckLakeMode:        c.server.cfg.DuckLake.MetadataStore != "" || c.server.cfg.AlwaysDuckLake,
 		LogicalDatabaseName: c.database,
-		PhysicalCatalogName: "ducklake",
+		PhysicalCatalogName: physicalDuckLakeCatalog,
 		ConvertPlaceholders: convertPlaceholders,
 	})
 }
@@ -994,17 +994,25 @@ func (c *clientConn) serve() error {
 			initTimeout = DefaultSessionInitTimeout
 		}
 		initCtx, initCancel := context.WithTimeout(context.Background(), initTimeout)
-		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, c.database); err != nil {
+		// Detect DuckLake attachment first so we can report a stable catalog
+		// name. When DuckLake-backed, report the physical catalog name
+		// ("ducklake") as current_database() rather than the connection dbname
+		// (see sessionmeta.ReportedDatabaseName); the dbname still works as an
+		// alias via the logical-catalog transform.
+		duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, c.executor, physicalDuckLakeCatalog)
+		if err != nil {
+			initCancel()
+			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to detect ducklake catalog attachment: %v", err))
+			return err
+		}
+		// Standalone has no per-user configured default catalog, so pass "".
+		reportedDatabase := sessionmeta.ReportedDatabaseName(c.database, "", duckLakeAttached)
+		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, reportedDatabase); err != nil {
 			initCancel()
 			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to initialize session database metadata: %v", err))
 			return err
 		}
-		duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, c.executor, "ducklake")
 		initCancel()
-		if err != nil {
-			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to detect ducklake catalog attachment: %v", err))
-			return err
-		}
 		c.logicalCatalogMapping = duckLakeAttached
 	}
 
@@ -1711,7 +1719,7 @@ func (c *clientConn) queryWithArgsWithMetadata(ctx context.Context, query string
 }
 
 // physicalDuckLakeCatalog is the physical catalog name DuckLake is attached as.
-const physicalDuckLakeCatalog = "ducklake"
+const physicalDuckLakeCatalog = sessionmeta.PhysicalDuckLakeCatalog
 
 // executeSelectQuery runs a result-returning query against DuckDB and streams results to the client.
 // Sends RowDescription, DataRow messages, CommandComplete, and ReadyForQuery.

--- a/server/sessionmeta/sessionmeta.go
+++ b/server/sessionmeta/sessionmeta.go
@@ -59,6 +59,45 @@ func InitSessionDatabaseMetadata(ctx context.Context, executor sqlcore.QueryExec
 	return nil
 }
 
+// PhysicalDuckLakeCatalog is the physical catalog name DuckLake is attached as
+// on a worker. It is the stable, deployment-independent name that the
+// logical-catalog transform rewrites client references to.
+const PhysicalDuckLakeCatalog = "ducklake"
+
+// ReportedDatabaseName returns the client-visible catalog name to install as
+// current_database()/pg_database for a session, in precedence order:
+//
+//  1. A configured default catalog (e.g. "iceberg") wins. Such a session's
+//     connect-time search_path/USE is pointed at that catalog, so it is the
+//     catalog its queries resolve against and therefore what catalog-keyed
+//     tools must see as current_database().
+//
+//  2. Otherwise, a DuckLake-backed session reports the stable physical catalog
+//     name ("ducklake") rather than the per-connection startup dbname,
+//     regardless of tenancy. The startup dbname still works as an alias: the
+//     logical-catalog transform rewrites <dbname>.schema.table ->
+//     ducklake.schema.table and the USE rewriter maps USE "<dbname>" ->
+//     ducklake.main, while ducklake.* references resolve directly. Reporting a
+//     stable name keeps tools that key on the catalog — notably SQLMesh, which
+//     fully-qualifies every model as catalog.schema.object and persists that in
+//     its state — from treating a changed connection dbname as a brand-new
+//     warehouse (which would trigger a full rebuild). Because the name is the
+//     same across single- and multi-tenant deployments, an org graduating from
+//     a single-tenant duckling to a multi-tenant worker pod keeps the same
+//     catalog identity and does not churn.
+//
+//  3. Otherwise (no default catalog and no DuckLake attached — e.g. plain
+//     DuckDB), report the connection dbname unchanged.
+func ReportedDatabaseName(startupDatabase, defaultCatalog string, duckLakeBacked bool) string {
+	if defaultCatalog != "" {
+		return defaultCatalog
+	}
+	if duckLakeBacked {
+		return PhysicalDuckLakeCatalog
+	}
+	return startupDatabase
+}
+
 func HasAttachedCatalog(ctx context.Context, executor sqlcore.QueryExecutor, catalog string) (bool, error) {
 	query := fmt.Sprintf(
 		"SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = %s",

--- a/server/sessionmeta/sessionmeta_test.go
+++ b/server/sessionmeta/sessionmeta_test.go
@@ -153,3 +153,64 @@ func TestInformationSchemaColumnsCompatLoadedIcebergColumnsKeepIcebergCatalog(t 
 		t.Fatalf("loaded Iceberg columns should not use current_database() as table_catalog in:\n%s", got)
 	}
 }
+
+func TestReportedDatabaseName(t *testing.T) {
+	tests := []struct {
+		name           string
+		startup        string
+		defaultCatalog string
+		duckLakeBacked bool
+		want           string
+	}{
+		{
+			name:           "ducklake-backed reports stable physical catalog",
+			startup:        "portola",
+			duckLakeBacked: true,
+			want:           PhysicalDuckLakeCatalog,
+		},
+		{
+			name:           "ducklake-backed with ducklake dbname is unchanged",
+			startup:        "ducklake",
+			duckLakeBacked: true,
+			want:           PhysicalDuckLakeCatalog,
+		},
+		{
+			// A multi-tenant org reports the same stable name as the same org
+			// would on a single-tenant duckling, so a single->multi migration
+			// keeps the catalog identity and does not churn catalog-keyed tools.
+			name:           "multi-tenant ducklake org reports the same stable catalog",
+			startup:        "acme",
+			duckLakeBacked: true,
+			want:           PhysicalDuckLakeCatalog,
+		},
+		{
+			// A configured default catalog wins over DuckLake: the session's
+			// search_path/USE points at iceberg, so current_database() must too.
+			name:           "iceberg default catalog wins over ducklake",
+			startup:        "acme",
+			defaultCatalog: "iceberg",
+			duckLakeBacked: true,
+			want:           "iceberg",
+		},
+		{
+			name:           "iceberg default catalog without ducklake reports iceberg",
+			startup:        "acme",
+			defaultCatalog: "iceberg",
+			duckLakeBacked: false,
+			want:           "iceberg",
+		},
+		{
+			name:           "non-ducklake, no default catalog keeps connection dbname",
+			startup:        "analytics",
+			duckLakeBacked: false,
+			want:           "analytics",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ReportedDatabaseName(tc.startup, tc.defaultCatalog, tc.duckLakeBacked); got != tc.want {
+				t.Fatalf("ReportedDatabaseName(%q, %q, %v) = %q, want %q", tc.startup, tc.defaultCatalog, tc.duckLakeBacked, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/integration/logical_catalog_mapping_test.go
+++ b/tests/integration/logical_catalog_mapping_test.go
@@ -17,20 +17,24 @@ func TestPgwireLogicalCatalogMapping(t *testing.T) {
 		_, _ = db.Exec("DROP TABLE IF EXISTS ducklake.main.logical_catalog_mapping_test")
 	})
 
+	// DuckLake-backed sessions report the stable physical catalog name
+	// ("ducklake") as current_database()/pg_database, regardless of the
+	// connection dbname ("test"). The connection dbname still works as a
+	// write alias (exercised below).
 	var currentDB string
 	if err := db.QueryRow("SELECT current_database()").Scan(&currentDB); err != nil {
 		t.Fatalf("query current_database(): %v", err)
 	}
-	if currentDB != "test" {
-		t.Fatalf("expected current_database() = %q, got %q", "test", currentDB)
+	if currentDB != "ducklake" {
+		t.Fatalf("expected current_database() = %q, got %q", "ducklake", currentDB)
 	}
 
 	var datname string
 	if err := db.QueryRow("SELECT datname FROM pg_database WHERE datname = current_database()").Scan(&datname); err != nil {
 		t.Fatalf("query pg_database/current_database: %v", err)
 	}
-	if datname != "test" {
-		t.Fatalf("expected pg_database row %q, got %q", "test", datname)
+	if datname != "ducklake" {
+		t.Fatalf("expected pg_database row %q, got %q", "ducklake", datname)
 	}
 
 	mustExec(t, db, "CREATE TABLE test.public.logical_catalog_mapping_test (id INTEGER)")
@@ -52,8 +56,8 @@ func TestPgwireLogicalCatalogMapping(t *testing.T) {
 	`).Scan(&tableCatalog); err != nil {
 		t.Fatalf("query information_schema.tables: %v", err)
 	}
-	if tableCatalog != "test" {
-		t.Fatalf("expected information_schema.tables.table_catalog = %q, got %q", "test", tableCatalog)
+	if tableCatalog != "ducklake" {
+		t.Fatalf("expected information_schema.tables.table_catalog = %q, got %q", "ducklake", tableCatalog)
 	}
 
 	var schemaCatalog string
@@ -66,7 +70,7 @@ func TestPgwireLogicalCatalogMapping(t *testing.T) {
 	`).Scan(&schemaCatalog); err != nil {
 		t.Fatalf("query information_schema.schemata: %v", err)
 	}
-	if schemaCatalog != "test" {
-		t.Fatalf("expected information_schema.schemata.catalog_name = %q, got %q", "test", schemaCatalog)
+	if schemaCatalog != "ducklake" {
+		t.Fatalf("expected information_schema.schemata.catalog_name = %q, got %q", "ducklake", schemaCatalog)
 	}
 }

--- a/tests/integration/logical_database_catalog_mapping_test.go
+++ b/tests/integration/logical_database_catalog_mapping_test.go
@@ -44,21 +44,25 @@ func TestPgwireLogicalDatabaseCatalogMapping(t *testing.T) {
 		_, _ = db.Exec(fmt.Sprintf(`DROP SCHEMA IF EXISTS ducklake.%s CASCADE`, logicalSchema))
 	})
 
-	t.Run("metadata reports logical database", func(t *testing.T) {
+	// DuckLake-backed sessions report the stable physical catalog name
+	// ("ducklake") via current_database()/pg_database/information_schema,
+	// regardless of the connection dbname ("duckgres"). The connection dbname
+	// still works as a write alias (exercised in the subtests below).
+	t.Run("metadata reports stable physical catalog", func(t *testing.T) {
 		var currentDB string
 		if err := db.QueryRow("SELECT current_database()").Scan(&currentDB); err != nil {
 			t.Fatalf("query current_database(): %v", err)
 		}
-		if currentDB != "duckgres" {
-			t.Fatalf("current_database() = %q, want %q", currentDB, "duckgres")
+		if currentDB != "ducklake" {
+			t.Fatalf("current_database() = %q, want %q", currentDB, "ducklake")
 		}
 
 		var datname string
 		if err := db.QueryRow("SELECT datname FROM pg_catalog.pg_database WHERE datname = current_database()").Scan(&datname); err != nil {
 			t.Fatalf("query pg_database/current_database: %v", err)
 		}
-		if datname != "duckgres" {
-			t.Fatalf("pg_database datname = %q, want %q", datname, "duckgres")
+		if datname != "ducklake" {
+			t.Fatalf("pg_database datname = %q, want %q", datname, "ducklake")
 		}
 
 		if _, err := db.Exec(fmt.Sprintf(`CREATE TABLE duckgres.public.%s (id INTEGER)`, metadataProbeTable)); err != nil {
@@ -72,8 +76,8 @@ func TestPgwireLogicalDatabaseCatalogMapping(t *testing.T) {
 		)).Scan(&tableCatalog); err != nil {
 			t.Fatalf("query information_schema.tables: %v", err)
 		}
-		if tableCatalog != "duckgres" {
-			t.Fatalf("information_schema.tables table_catalog = %q, want %q", tableCatalog, "duckgres")
+		if tableCatalog != "ducklake" {
+			t.Fatalf("information_schema.tables table_catalog = %q, want %q", tableCatalog, "ducklake")
 		}
 
 		var columnCatalog string
@@ -83,16 +87,16 @@ func TestPgwireLogicalDatabaseCatalogMapping(t *testing.T) {
 		)).Scan(&columnCatalog); err != nil {
 			t.Fatalf("query information_schema.columns: %v", err)
 		}
-		if columnCatalog != "duckgres" {
-			t.Fatalf("information_schema.columns table_catalog = %q, want %q", columnCatalog, "duckgres")
+		if columnCatalog != "ducklake" {
+			t.Fatalf("information_schema.columns table_catalog = %q, want %q", columnCatalog, "ducklake")
 		}
 
 		var schemaCatalog string
 		if err := db.QueryRow("SELECT catalog_name FROM information_schema.schemata WHERE schema_name = 'public' LIMIT 1").Scan(&schemaCatalog); err != nil {
 			t.Fatalf("query information_schema.schemata: %v", err)
 		}
-		if schemaCatalog != "duckgres" {
-			t.Fatalf("information_schema.schemata catalog_name = %q, want %q", schemaCatalog, "duckgres")
+		if schemaCatalog != "ducklake" {
+			t.Fatalf("information_schema.schemata catalog_name = %q, want %q", schemaCatalog, "ducklake")
 		}
 	})
 

--- a/tests/integration/logical_database_catalog_test.go
+++ b/tests/integration/logical_database_catalog_test.go
@@ -45,29 +45,33 @@ func TestLogicalDatabaseCatalogMetadata(t *testing.T) {
 	mustExec(t, db, "CREATE SCHEMA IF NOT EXISTS bill")
 	mustExec(t, db, "CREATE OR REPLACE VIEW bill.logical_catalog_view AS SELECT 1 AS id")
 
-	t.Run("current_database_reports_logical_name", func(t *testing.T) {
+	// DuckLake-backed sessions report the stable physical catalog name
+	// ("ducklake"), not the connection dbname ("duckgres_catalog"). The
+	// connection dbname still resolves as a write alias (see
+	// TestLogicalDatabaseCatalogQualifiedNames).
+	t.Run("current_database_reports_physical_catalog", func(t *testing.T) {
 		var current string
 		if err := db.QueryRow("SELECT current_database()").Scan(&current); err != nil {
 			t.Fatalf("SELECT current_database(): %v", err)
 		}
-		if current != "duckgres_catalog" {
-			t.Fatalf("current_database() = %q, want %q", current, "duckgres_catalog")
+		if current != "ducklake" {
+			t.Fatalf("current_database() = %q, want %q", current, "ducklake")
 		}
 	})
 
-	t.Run("pg_database_reports_logical_name", func(t *testing.T) {
+	t.Run("pg_database_reports_physical_catalog", func(t *testing.T) {
 		var datname string
 		if err := db.QueryRow(
 			"SELECT datname FROM pg_catalog.pg_database WHERE datname = current_database()",
 		).Scan(&datname); err != nil {
 			t.Fatalf("pg_database lookup: %v", err)
 		}
-		if datname != "duckgres_catalog" {
-			t.Fatalf("datname = %q, want %q", datname, "duckgres_catalog")
+		if datname != "ducklake" {
+			t.Fatalf("datname = %q, want %q", datname, "ducklake")
 		}
 	})
 
-	t.Run("information_schema_catalog_columns_report_logical_name", func(t *testing.T) {
+	t.Run("information_schema_catalog_columns_report_physical_catalog", func(t *testing.T) {
 		checks := []struct {
 			name  string
 			query string
@@ -112,8 +116,8 @@ func TestLogicalDatabaseCatalogMetadata(t *testing.T) {
 				if err := db.QueryRow(tc.query).Scan(&catalog); err != nil {
 					t.Fatalf("%s query: %v", tc.name, err)
 				}
-				if catalog != "duckgres_catalog" {
-					t.Fatalf("%s catalog = %q, want %q", tc.name, catalog, "duckgres_catalog")
+				if catalog != "ducklake" {
+					t.Fatalf("%s catalog = %q, want %q", tc.name, catalog, "ducklake")
 				}
 			})
 		}
@@ -133,7 +137,7 @@ func TestLogicalDatabaseCatalogMetadata(t *testing.T) {
 		}
 	})
 
-	t.Run("show_databases_reports_only_logical_name", func(t *testing.T) {
+	t.Run("show_databases_reports_physical_catalog", func(t *testing.T) {
 		rows, err := db.Query("SHOW DATABASES")
 		if err != nil {
 			t.Fatalf("SHOW DATABASES: %v", err)
@@ -156,8 +160,8 @@ func TestLogicalDatabaseCatalogMetadata(t *testing.T) {
 			t.Fatalf("iterate SHOW DATABASES rows: %v", err)
 		}
 
-		if len(got) != 1 || got[0] != "duckgres_catalog" {
-			t.Fatalf("SHOW DATABASES = %v, want [duckgres_catalog]", got)
+		if len(got) != 1 || got[0] != "ducklake" {
+			t.Fatalf("SHOW DATABASES = %v, want [ducklake]", got)
 		}
 	})
 }

--- a/tests/k8s/sni_test.go
+++ b/tests/k8s/sni_test.go
@@ -28,6 +28,10 @@ const (
 	sniSeedUser         = "postgres"
 	sniSeedPassword     = "postgres"
 	sniBogusPrefix      = "ignored-by-test"
+	// sniReportedCatalog is what current_database() returns for the
+	// DuckLake-backed 'local' org: the stable physical catalog name, not the
+	// per-connection routing dbname (see sessionmeta.ReportedDatabaseName).
+	sniReportedCatalog = "ducklake"
 )
 
 // connectWithSNI dials the control plane via port-forward, sets the TLS SNI
@@ -83,9 +87,12 @@ func TestSNI_MatchedHostnameUsesDatabaseParam(t *testing.T) {
 	if err := conn.QueryRow(ctx, "SELECT current_database()").Scan(&current); err != nil {
 		t.Fatalf("SELECT current_database(): %v", err)
 	}
-	if current != sniSeedDatabaseName {
-		t.Fatalf("explicit database should be the routing database; got %q, want %q",
-			current, sniSeedDatabaseName)
+	// The 'local' org is DuckLake-backed, so current_database() reports the
+	// stable physical catalog ("ducklake"), not the routing dbname. SNI
+	// routing correctness is established by the successful connect above.
+	if current != sniReportedCatalog {
+		t.Fatalf("DuckLake-backed session should report the physical catalog; got %q, want %q",
+			current, sniReportedCatalog)
 	}
 }
 
@@ -112,9 +119,9 @@ func TestSNI_MatchedHostnameUsesSNIWhenDatabaseParamEmpty(t *testing.T) {
 	if err := conn.QueryRow(ctx, "SELECT current_database()").Scan(&current); err != nil {
 		t.Fatalf("SELECT current_database(): %v", err)
 	}
-	if current != sniSeedDatabaseName {
-		t.Fatalf("resolved SNI org database should be the routing database; got %q, want %q",
-			current, sniSeedDatabaseName)
+	if current != sniReportedCatalog {
+		t.Fatalf("DuckLake-backed session should report the physical catalog; got %q, want %q",
+			current, sniReportedCatalog)
 	}
 }
 
@@ -175,8 +182,8 @@ func TestSNI_LegacyHostnameFallsThroughInPassthrough(t *testing.T) {
 	if err := conn.QueryRow(ctx, "SELECT current_database()").Scan(&current); err != nil {
 		t.Fatalf("SELECT current_database(): %v", err)
 	}
-	if current != sniSeedDatabaseName {
-		t.Fatalf("legacy fallback should land us in the param-named database; got %q, want %q",
-			current, sniSeedDatabaseName)
+	if current != sniReportedCatalog {
+		t.Fatalf("DuckLake-backed session should report the physical catalog; got %q, want %q",
+			current, sniReportedCatalog)
 	}
 }

--- a/transpiler/transform/logicalcatalog.go
+++ b/transpiler/transform/logicalcatalog.go
@@ -61,15 +61,27 @@ func (t *LogicalCatalogTransform) Transform(tree *pg_query.ParseResult, _ *Resul
 }
 
 func (t *LogicalCatalogTransform) rewriteRangeVar(rv *pg_query.RangeVar) bool {
-	if rv == nil || rv.Catalogname == "" || !strings.EqualFold(rv.Catalogname, t.LogicalDatabaseName) {
+	if rv == nil || rv.Catalogname == "" {
 		return false
 	}
 
-	rv.Catalogname = t.PhysicalCatalogName
-	if strings.EqualFold(rv.Schemaname, "public") {
+	switch {
+	case strings.EqualFold(rv.Catalogname, t.LogicalDatabaseName):
+		// Logical catalog name -> physical catalog, mapping the PG-compat
+		// "public" schema to DuckLake's real "main".
+		rv.Catalogname = t.PhysicalCatalogName
+		if strings.EqualFold(rv.Schemaname, "public") {
+			rv.Schemaname = "main"
+		}
+		return true
+	case t.PhysicalCatalogName != "" && strings.EqualFold(rv.Catalogname, t.PhysicalCatalogName) && strings.EqualFold(rv.Schemaname, "public"):
+		// Client referenced the physical catalog directly (common now that
+		// current_database() reports the physical name): its "public" schema
+		// is the compat alias for DuckLake's "main", same as the logical case.
 		rv.Schemaname = "main"
+		return true
 	}
-	return true
+	return false
 }
 
 func (t *LogicalCatalogTransform) rewriteDropObjects(objects []*pg_query.Node) bool {

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -598,6 +598,14 @@ func TestTranspile_LogicalDatabaseCatalogMapping(t *testing.T) {
 			expected: "SELECT * FROM ducklake.main.users",
 		},
 		{
+			// Clients now read current_database() == "ducklake" and may qualify
+			// as ducklake.public.*; map the compat "public" schema to "main".
+			name:     "physical ducklake public schema maps to main",
+			input:    "SELECT * FROM ducklake.public.users",
+			contains: "ducklake.main.users",
+			excludes: "ducklake.public.users",
+		},
+		{
 			name:     "unrelated external catalog preserved",
 			input:    "SELECT * FROM postgres.public.users",
 			expected: "SELECT * FROM postgres.public.users",


### PR DESCRIPTION
## Problem

A serverless / single-tenant duckling failed its nightly SQLMesh run with `Catalog "portola" does not exist`, and SQLMesh also wanted to rebuild the entire warehouse. Root cause:

- The client-visible catalog name (`current_database()` / `pg_database`) is installed from the **connection's startup dbname** (`InitSessionDatabaseMetadata`).
- That dbname changed `ducklake` → `portola`.
- SQLMesh fully-qualifies every model as `catalog.schema.object` and **persists the catalog in state**, so a changed default catalog reads as a brand-new warehouse → full rebuild of ~140 models. Mid-transition you also get `Catalog X does not exist` when a reference under the *other* name isn't translated.

## Fix

Install `current_database()`/`pg_database` from a stable catalog name (`sessionmeta.ReportedDatabaseName`), in precedence order:
1. a configured **default catalog** (e.g. `iceberg`) — that session's `search_path`/`USE` points there, so it's what `current_database()` must report;
2. else, a **DuckLake-backed** session → the physical catalog **`ducklake`** (gated on the actual runtime DuckLake attachment);
3. else, the **connection dbname** unchanged (plain DuckDB / no default).

The connection dbname still works as an **alias** for DuckLake sessions (logical-catalog transform rewrites `<dbname>.schema.table` → `ducklake.schema.table`, `USE "<dbname>"` → `ducklake.main`, and `ducklake.*` resolves directly) — so both names resolve and a half-migrated SQLMesh state can't strand on `Catalog X does not exist`.

Reporting `ducklake` for **single- and multi-tenant** DuckLake sessions makes the catalog identity consistent across deployments, so an org graduating from a single-tenant duckling to a multi-tenant worker pod keeps the same catalog name and does not churn SQLMesh. iceberg-default sessions report `iceberg`.

This **intentionally changes** the client-visible behavior of the logical-catalog feature for DuckLake sessions: `current_database()`/`pg_database`/`information_schema`/`SHOW DATABASES` now report the stable catalog (`ducklake`, or `iceberg` for iceberg-default users) instead of the connection/logical dbname. Org identity for observability remains via `orgID` (logged separately). The feature tests asserting the old contract are updated (alias-execution assertions kept; only metadata-reporting expectations flip):
- `tests/integration/logical_catalog_mapping_test.go`, `logical_database_catalog_mapping_test.go`, `logical_database_catalog_test.go`
- `tests/k8s/sni_test.go`

**Second commit** (`public→main` for direct physical-catalog refs): now that clients read `current_database()=ducklake` and may emit `ducklake.public.<table>`, the `LogicalCatalogTransform` maps `public`→`main` for the physical catalog too (it previously only did so for the logical name; `PublicSchemaTransform` leaves 3-part names alone). Gated on `PhysicalCatalogName`, so `postgres.public.*` etc. are untouched.

### Scope / consistency
Gating on runtime attachment leaves **non-DuckLake** sessions (e.g. iceberg-only orgs with no `ducklake` attached) reporting their own dbname. Covers both entry points: control-plane handler + standalone `serve()`. The change is **control-plane behavior only** — the worker just executes the macro SQL the control plane sends.

## Verified live on portola (single-tenant duckling)
Deployed `4d6fed5` (currently-running base) + this fix via a **graceful control-plane reload** (`systemctl reload` → SIGUSR1/tableflip), worker left untouched:
- `dbname=portola` → `SELECT current_database()`: **`portola` → `ducklake`** ✅
- `dbname=ducklake` → `ducklake` (unchanged) ✅
- `dbname=portola` → `SHOW DATABASES` → `ducklake` ✅
- **Zero disruption** to in-flight Fivetran/SQLMesh imports (24+ real queries completed across the reload; worker pid unchanged).

## Deployment notes
- Behavior change is **control-plane only**; the worker binary is unaffected, so it can roll out via a **control-plane reload without restarting workers** (that's how it was validated on portola).
- Rollback: restore the previous binary and `systemctl reload duckgres`.

## Tests
- `TestReportedDatabaseName`: DuckLake → `ducklake` (single- and multi-tenant); iceberg default → `iceberg` (incl. wins-over-ducklake); non-DuckLake → connection dbname.
- `TestTranspile_LogicalDatabaseCatalogMapping/physical_ducklake_public_schema_maps_to_main` for the `public→main` fix.
- Updated logical-catalog integration + k8s SNI tests to the new contract.
- `go build`/`go vet`; transpiler, server, sessionmeta suites pass.

## Test plan
- [x] `go test ./server/sessionmeta/... ./transpiler/...`
- [x] `go test ./server/ -run 'Logical|DirectQueryRewrite|SessionDatabase|InitSession'`
- [x] `go build ./...`, `go vet`
- [x] CI: integration-tests + k8s-integration-tests green
- [x] On the affected duckling: connect `database=portola` → `current_database()` = `ducklake`; `SHOW DATABASES` = `ducklake` (verified live, see above)

## Out of scope
- Why the connection now needs `database=portola` (this PR makes the catalog name stable regardless).
- The JSON `->`/`->>` *Conversion Error: Failed to cast value to numerical* errors from the same run — separate issue (DuckDB JSON-path, likely 1.5.3 fallout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)