### PR TITLE
build: bundle iceberg extension in worker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,9 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${POSTGRES_SCANNER_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
-    && for f in httpfs ducklake json postgres_scanner; do \
+    && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/iceberg.duckdb_extension.gz" \
+      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/iceberg.duckdb_extension" \
+    && for f in httpfs ducklake json postgres_scanner iceberg; do \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \
        done

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -120,7 +120,9 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${POSTGRES_SCANNER_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
-    && for f in httpfs ducklake json postgres_scanner; do \
+    && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/iceberg.duckdb_extension.gz" \
+      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/iceberg.duckdb_extension" \
+    && for f in httpfs ducklake json postgres_scanner iceberg; do \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \
        done


### PR DESCRIPTION
## Problem

Iceberg-only tenant activation silently exceeds the ~60s activate-tenant deadline and fails (`DeadlineExceeded`), as observed on mw-dev (`ben-{cnpg,ext,aur}-ice`). Iceberg + DuckLake tenants are unaffected.

Pinpointed via #642's per-step instrumentation on a real worker:
```
worker pre-warmed (ducklake ext bundled, loaded in ~120ms)
step=count-catalogs   elapsed=189ns         ✓ (~1ms)
step=load-iceberg-extension elapsed=1.7ms   …
(no further step logs)
worker shutting down (60.7s after step start) — no DuckDB error
```
`LoadExtensions(["iceberg"])` blocks for the entire deadline.

## Why iceberg-only

The four DuckDB extensions duckgres relies on (`httpfs`, `ducklake`, `json`, `postgres_scanner`) are pre-seeded into the bundled extension cache by `Dockerfile` / `Dockerfile.worker`. **`iceberg` is not** — it gets `INSTALL`ed on-demand at first attach, fetching from `extensions.duckdb.org`.

- iceberg-only: `LoadExtensions("iceberg")` is the **first network extension install** of the worker process → silent cold install/download hangs past the activate deadline.
- iceberg + DuckLake: `LoadExtensions("delta")` runs first (via `AttachDeltaCatalog`), priming DuckDB's extension subsystem; the subsequent `LoadExtensions("iceberg")` finishes within the deadline (verified live with the existing "both" combos — iceberg writes succeed end-to-end).

Worker→CDN reachability is fine (`extensions.duckdb.org:443` OPEN from a born-as-worker pod) and worker→Lakekeeper is fine (#11444). The hang is *inside* DuckDB's INSTALL path.

## Fix

Bundle `iceberg` at image build time, identical to the other core-repo extensions:

```Dockerfile
curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/iceberg.duckdb_extension.gz" \
  | gunzip > "/build/duckdb-extensions/.../iceberg.duckdb_extension"
…
for f in httpfs ducklake json postgres_scanner iceberg; do …  # size check
```

Applied to both `Dockerfile` and `Dockerfile.worker`. Subsequent `LoadExtensions("iceberg")` becomes a local cache hit — same path as the other bundled extensions — for every iceberg-using tenant (Lakekeeper + S3Tables backends alike).

## Test

Once the new image is deployed to mw-dev I'll re-run `ben-ext-ice` and confirm:
- `step=load-iceberg-extension` finishes in ms instead of timing out
- Iceberg-only `SELECT 1` + `CREATE TABLE iceberg.public.<t> / INSERT / SELECT` round-trip succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
