### PR TITLE
fix(activation): always INSTALL iceberg even when bundled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1279,6 +1279,30 @@ func LoadExtensions(db *sql.DB, extensions []string) error {
 }
 
 func shouldInstallExtension(name string) bool {
+	// The bundle-skip optimization assumes a bundled .duckdb_extension on disk
+	// is enough — LOAD finds the file via extension_directory and DuckDB treats
+	// it as installed. That holds for the PostHog-fork extensions (httpfs,
+	// ducklake) and the stable ones we ship (json, postgres_scanner): LOAD
+	// against the seeded extension_directory file just works.
+	//
+	// Iceberg behaves differently. With the bundled binary in place but no
+	// prior INSTALL, db.Exec("LOAD iceberg") blocks indefinitely (observed on
+	// a worker in mw-dev: warm-up → activation hangs past the activate-tenant
+	// deadline at the LOAD with no progress and no Go log; the bundled binary
+	// is sitting in the cache the whole time). The CDN INSTALL — which the
+	// bundle (#645) was added specifically to avoid — turns into the same
+	// silent stall the bundle was meant to fix when LOAD is left to figure
+	// things out on its own.
+	//
+	// Running INSTALL when the binary is already in extension_directory is a
+	// cheap no-op (DuckDB sees the cached file and skips the CDN download), so
+	// special-casing iceberg keeps the bundle benefit (no first-load fetch
+	// from the CDN) and unblocks LOAD. The upstream-overwrite risk that
+	// motivates skipping INSTALL for the PostHog forks doesn't apply here: we
+	// bundle the same stock iceberg build the repository would serve.
+	if name == "iceberg" {
+		return true
+	}
 	return !hasBundledExtensionBinary(name)
 }
 


### PR DESCRIPTION
## Problem

After #645 bundled the iceberg extension into the worker image, iceberg-only tenant activation still hangs past the activate-tenant deadline. The bundle is correct — `/data/extensions/v1.5.3/linux_arm64/iceberg.duckdb_extension` is in place (the bootstrap seeded it from `/app/extensions/...`) — but `db.Exec("LOAD iceberg")` blocks for the full ~60s with no progress and no DuckDB-level log, until the CP cancels and the worker is retired.

Why: `LoadExtensions` skips `INSTALL` whenever `hasBundledExtensionBinary` returns true:
```go
if shouldInstallExtension(name) { db.Exec("INSTALL " + installCmd) }
db.Exec("LOAD " + name)
```
That works for `httpfs`, `ducklake`, `json`, `postgres_scanner` — LOAD against the seeded `extension_directory` file just works. It does **not** work for iceberg: without a prior `INSTALL`, DuckDB's internal extension metadata leaves `LOAD iceberg` blocked indefinitely, even with the binary already in the cache. So the very `INSTALL` the bundle was meant to spare us turns into the same silent stall when the bundle deletes the call.

Live evidence on mw-dev (`ben-ext-ice`, build `2f2f38d` = #645):
```
step=count-catalogs       elapsed=172ns
step=load-iceberg-extension elapsed=1.5ms
… (no further activity for ~60s) …
worker shutting down
```

## Fix

Special-case `iceberg` in `shouldInstallExtension` so `INSTALL` runs even when the binary is bundled. With the file already in `extension_directory`, `INSTALL` is a cheap no-op — DuckDB sees the cached file and skips the CDN download — so the bundle benefit is preserved (no first-load fetch from the CDN) while `LOAD` now finds the extension already installed.

The upstream-overwrite risk that motivates skipping `INSTALL` for the PostHog forks (`httpfs`, `ducklake`) doesn't apply: we bundle the same stock iceberg build the DuckDB repository would serve.

## Test plan (mw-dev after deploy)

- `ben-ext-ice` activates within the deadline.
- Iceberg-only `SELECT 1` succeeds; `CREATE TABLE iceberg.public.<t> / INSERT / SELECT` round-trips.
- The "both" combos (already passing for iceberg + DuckLake) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
