### PR TITLE
perf(docker): cache CGO dep compile via go.sum-keyed prewarm layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN go mod download
 # doesn't fail the build — worst case the final build recompiles.
 RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
 
-COPY . .
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG BUILD_TAGS=""
+# Bundled DuckDB extensions. Downloaded BEFORE `COPY . .` so this layer
+# depends only on the extension version args, not on source — a source-only
+# PR keeps the GHA layer-cache hit and skips the 5 downloads entirely. (They
+# previously ran after the source COPY + build, so they re-fetched on every
+# edit.)
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
 ARG HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
@@ -30,16 +31,14 @@ ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions
 # may need the nightly repo to match what was previously published).
 ARG POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
-RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres .
 # `: ${VAR:?msg}` asserts every required input is non-empty — catches a
 # CI matrix row that forgets to pass a build-arg and would otherwise
 # silently fall back to the ARG default, producing a cross-version
-# bundle (the failure class the L77-90 binding-pin check in
-# Dockerfile.worker exists to prevent). The per-file `[ -s ... ]` size
-# check below catches the curl|gunzip failure modes — a curl -fsSL 404
-# writes nothing, gunzip on empty input exits non-zero, the && chain
-# breaks. (`set -o pipefail` would be cleaner but /bin/sh here is dash,
-# which rejects -o pipefail.)
+# bundle (the failure class the binding-pin check in Dockerfile.worker
+# exists to prevent). The per-file `[ -s ... ]` size check below catches
+# the curl|gunzip failure modes — a curl -fsSL 404 writes nothing, gunzip
+# on empty input exits non-zero, the && chain breaks. (`set -o pipefail`
+# would be cleaner but /bin/sh here is dash, which rejects -o pipefail.)
 RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && : "${HTTPFS_EXTENSION_TAG:?must be set}" \
     && : "${DUCKLAKE_EXTENSION_TAG:?must be set}" \
@@ -60,6 +59,12 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \
        done
+
+COPY . .
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TAGS=""
+RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres .
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ libc6-d
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
+
+# CGO dep-prewarm. Compiles the two heavy C/C++ dependencies — duckdb-go
+# (links libduckdb) and pg_query_go (links libpg_query) — into the Go build
+# cache in a layer keyed ONLY on go.mod/go.sum. On a source-only PR (the
+# common case) this layer is a GHA layer-cache hit, so the multi-minute
+# libduckdb/libpg_query compile is skipped and the final `go build` below
+# only recompiles changed first-party packages. Without it, `COPY . .`
+# busts the build layer on every source edit and the CGO deps recompile
+# from scratch each run (~3-5 min). `|| true` so a transient resolve error
+# doesn't fail the build — worst case the final build recompiles.
+RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
+
 COPY . .
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/Dockerfile.controlplane
+++ b/Dockerfile.controlplane
@@ -19,6 +19,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ libc6-d
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
+
+# CGO dep-prewarm. The CP image doesn't link libduckdb, but it still links
+# libpg_query via pg_query_go (the transpiler). Compile it into the Go build
+# cache in a layer keyed only on go.mod/go.sum so a source-only PR skips the
+# libpg_query compile and the final `go build` recompiles only changed
+# first-party code. See the longer note in the top-level Dockerfile.
+RUN CGO_ENABLED=1 go build github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
+
 COPY . .
 
 ARG VERSION=dev

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -13,20 +13,6 @@ FROM golang:1.25-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ libc6-dev curl gzip && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-# Copy the full source first. The earlier layout (COPY go.mod go.sum;
-# go get; COPY . .) silently broke per-DuckDB-version pinning: the second
-# COPY overlaid the host's go.mod/go.sum on top of the downgraded ones,
-# undoing the `go get`. Symptom: the duckgres-worker:<sha>-duckdb1.5.1
-# image was actually statically linked against duckdb-go-bindings@v0.10502.0
-# (DuckDB 1.5.2), with bundled 0.4 extensions sitting at /app/extensions/v1.5.1/
-# where the 1.5.2 runtime never looks. Catalog attach failed at runtime
-# with "extension requires version 1.0". COPY-then-pin avoids it.
-COPY . .
-
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG BUILD_TAGS=""
-ARG TARGETARCH
 
 # DuckDB driver pin. Default to whatever the repo's go.mod is currently
 # tracking; override via --build-arg when the matrix produces an image
@@ -36,6 +22,24 @@ ARG TARGETARCH
 # without the v2 prefix).
 ARG DUCKDB_GO_VERSION=
 ARG DUCKDB_BINDINGS_VERSION=
+ARG TARGETARCH
+
+# Copy ONLY the module files first, apply the per-build DuckDB pin, then
+# download + CGO-prewarm — all in layers keyed solely on go.mod/go.sum + the
+# pin args. On a source-only PR these cache-hit, so the multi-minute
+# libduckdb/libpg_query compile is skipped and the final `go build` below
+# recompiles only changed first-party code.
+#
+# The earlier layout copied the full source first (COPY . .; go get) to stop
+# the source COPY from overlaying the host's unpinned go.mod/go.sum back on
+# top of the downgraded ones — a real bug: the duckgres-worker:<sha>-duckdb1.5.1
+# image once shipped statically linked against duckdb-go-bindings@v0.10502.0
+# with extensions seeded under the wrong v1.5.1/ dir, failing catalog attach
+# at runtime ("extension requires version 1.0"). We keep that correctness by
+# stashing the pinned module files and restoring them after COPY . . (a local
+# copy, no network), while still getting cacheable prewarm. The verify layers
+# further down fail the build if the embedded bindings version ever drifts.
+COPY go.mod go.sum ./
 
 RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
       go get "github.com/duckdb/duckdb-go/v2@${DUCKDB_GO_VERSION}" \
@@ -44,9 +48,25 @@ RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
            go get "github.com/duckdb/duckdb-go-bindings/lib/${arch}@${DUCKDB_BINDINGS_VERSION}" 2>/dev/null || true; \
          done \
       && go mod tidy ; \
-    fi
+    fi \
+    && cp go.mod go.mod.pinned && cp go.sum go.sum.pinned
 
 RUN go mod download
+
+# CGO dep-prewarm — see top-level Dockerfile. Compiles libduckdb-linked
+# duckdb-go + libpg_query-linked pg_query_go into the build cache, keyed on
+# the pinned go.mod/go.sum.
+RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
+
+COPY . .
+
+# Restore the pinned module files clobbered by COPY . . — a local copy, no
+# `go get`, so no network and the prewarmed module/build caches stay valid.
+RUN cp go.mod.pinned go.mod && cp go.sum.pinned go.sum
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TAGS=""
 
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
 ARG HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -58,16 +58,10 @@ RUN go mod download
 # the pinned go.mod/go.sum.
 RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
 
-COPY . .
-
-# Restore the pinned module files clobbered by COPY . . — a local copy, no
-# `go get`, so no network and the prewarmed module/build caches stay valid.
-RUN cp go.mod.pinned go.mod && cp go.sum.pinned go.sum
-
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG BUILD_TAGS=""
-
+# Bundled DuckDB extensions. Downloaded BEFORE `COPY . .` so this layer
+# depends only on the extension/pin args, not on source — a source-only PR
+# keeps the GHA layer-cache hit and skips the 5 downloads. (They previously
+# ran after the source COPY + build, so they re-fetched on every edit.)
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
 ARG HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
@@ -76,28 +70,6 @@ ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions
 # may need the nightly repo to match what was previously published).
 ARG POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
-
-RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" \
-    -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    -o duckgres-worker \
-    ./cmd/duckgres-worker
-
-# Defense-in-depth: assert the binary actually links against the bindings
-# version the build args asked for. If a future Dockerfile change re-breaks
-# the pinning, this fails the build instead of shipping a silently-wrong
-# image. The DUCKDB_BINDINGS_VERSION arg encodes DuckDB minor (e.g.
-# v0.10501.0 -> DuckDB 1.5.1); the embedded module info in the binary must
-# match exactly.
-RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
-      embedded=$(go version -m ./duckgres-worker | awk '$2 == "github.com/duckdb/duckdb-go-bindings" { print $3 }') ; \
-      if [ "$embedded" != "$DUCKDB_BINDINGS_VERSION" ]; then \
-        echo "ERROR: bindings pin mismatch — wanted $DUCKDB_BINDINGS_VERSION, got $embedded" >&2 ; \
-        echo "       (full embedded module info follows)" >&2 ; \
-        go version -m ./duckgres-worker | grep duckdb >&2 ; \
-        exit 1 ; \
-      fi ; \
-      echo "Verified: duckgres-worker linked against duckdb-go-bindings@$embedded" ; \
-    fi
 
 # Cross-check that DUCKDB_EXTENSION_VERSION (which keys the bundled-extension
 # directory layout) matches the DuckDB version implied by DUCKDB_BINDINGS_VERSION.
@@ -146,6 +118,38 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \
        done
+
+COPY . .
+
+# Restore the pinned module files clobbered by COPY . . — a local copy, no
+# `go get`, so no network and the prewarmed module/build caches stay valid.
+RUN cp go.mod.pinned go.mod && cp go.sum.pinned go.sum
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TAGS=""
+
+RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" \
+    -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    -o duckgres-worker \
+    ./cmd/duckgres-worker
+
+# Defense-in-depth: assert the binary actually links against the bindings
+# version the build args asked for. If a future Dockerfile change re-breaks
+# the pinning, this fails the build instead of shipping a silently-wrong
+# image. The DUCKDB_BINDINGS_VERSION arg encodes DuckDB minor (e.g.
+# v0.10501.0 -> DuckDB 1.5.1); the embedded module info in the binary must
+# match exactly.
+RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
+      embedded=$(go version -m ./duckgres-worker | awk '$2 == "github.com/duckdb/duckdb-go-bindings" { print $3 }') ; \
+      if [ "$embedded" != "$DUCKDB_BINDINGS_VERSION" ]; then \
+        echo "ERROR: bindings pin mismatch — wanted $DUCKDB_BINDINGS_VERSION, got $embedded" >&2 ; \
+        echo "       (full embedded module info follows)" >&2 ; \
+        go version -m ./duckgres-worker | grep duckdb >&2 ; \
+        exit 1 ; \
+      fi ; \
+      echo "Verified: duckgres-worker linked against duckdb-go-bindings@$embedded" ; \
+    fi
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
## Problem

Docker image builds redo two expensive things on **every** PR that the
non-Docker CI jobs already cache:

1. **CGO dep compile** — `duckdb-go` (libduckdb) + `pg_query_go`
   (libpg_query). `actions/setup-go` caches this for the test jobs
   (keyed on `go.sum`), but the cache doesn't reach Docker, and
   `COPY . .` busts the build layer on any source edit, so the
   multi-minute C/C++ compile re-runs each time.
2. **Extension downloads** — 5 curls (httpfs, ducklake, json,
   postgres_scanner, iceberg) that ran *after* `COPY . .` + build, so
   they re-fetched on every source edit despite depending only on the
   version args.

Measured CD build times (GHA, native arm64 runners):

| image | time | matrix |
|---|---|---|
| worker | ~367s | ×4 |
| main | ~288s | ×2 |
| controlplane | ~241s | ×2 |

`--mount=type=cache` would **not** help on ephemeral GHA runners — the
GHA cache backend doesn't persist BuildKit cache mounts. Layer caching
(`cache-to: type=gha,mode=max`, already configured on all image
workflows) does, so the fix is to put every expensive step in a layer
keyed on `go.sum` / version args, ahead of the source `COPY`.

## Fix

**1. CGO dep-prewarm** after `go mod download`:

```dockerfile
RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 \
    github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
```

**2. Move extension downloads before `COPY . .`** (keyed on version args).

Net: every builder layer that costs time — module download, CGO dep
compile, extension fetch — now sits before the source `COPY` and caches
independently of first-party code. A source-only PR (the common case)
hits cache for all of them; the final `go build` recompiles only changed
packages.

### Per-file
- **Dockerfile**: prewarm duckdb-go + pg_query_go; extension download moved up.
- **Dockerfile.controlplane**: prewarm pg_query_go only (CP doesn't link libduckdb; no extensions).
- **Dockerfile.worker**: copy `go.mod`/`go.sum` first → pin → download → prewarm → extension download → `COPY` source. Per-DuckDB-version pin correctness (the old *copy-source-first* layout) preserved by stashing the pinned `go.mod`/`go.sum` and restoring after `COPY . .` (local copy, no network). Binary-dependent bindings-verify stays after the build; arg-only version cross-check moved up with the downloads.
- **cache-proxy** Dockerfile unchanged — `CGO_ENABLED=0`, no C deps, no extensions.

Expected: warm-cache source-only PRs drop CGO compile (~3-5 min) + 5 extension fetches to near-zero; first build after a `go.sum` / extension-version bump pays it once.

## Not included (deferred, separate PRs)
- PR-triggered image builds arm64-only (mw-dev is 29 arm64 / 2 amd64); keep full matrix on merge-to-main.
- Trim worker bindings download from 5 OS/arch to `$TARGETARCH` — now low-value since the pin+download layer is itself cached, and risks `go mod tidy` (which is exhaustive across GOOS/GOARCH) breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)