### PR TITLE
fix(docker): worker build broke — go mod tidy pruned all deps pre-source

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -30,15 +30,12 @@ ARG TARGETARCH
 # libduckdb/libpg_query compile is skipped and the final `go build` below
 # recompiles only changed first-party code.
 #
-# The earlier layout copied the full source first (COPY . .; go get) to stop
-# the source COPY from overlaying the host's unpinned go.mod/go.sum back on
-# top of the downgraded ones — a real bug: the duckgres-worker:<sha>-duckdb1.5.1
-# image once shipped statically linked against duckdb-go-bindings@v0.10502.0
-# with extensions seeded under the wrong v1.5.1/ dir, failing catalog attach
-# at runtime ("extension requires version 1.0"). We keep that correctness by
-# stashing the pinned module files and restoring them after COPY . . (a local
-# copy, no network), while still getting cacheable prewarm. The verify layers
-# further down fail the build if the embedded bindings version ever drifts.
+# IMPORTANT: do NOT run `go mod tidy` here. With only go.mod/go.sum present
+# (no .go files), tidy prunes EVERY require directive — it sees zero imports —
+# leaving an empty go.mod and breaking both the prewarm below and the build.
+# `go get pkg@ver` explicitly records the require regardless of imports, so it
+# pins correctly without source. tidy runs after COPY . ., once the real
+# imports are visible.
 COPY go.mod go.sum ./
 
 RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
@@ -46,10 +43,8 @@ RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
       && go get "github.com/duckdb/duckdb-go-bindings@${DUCKDB_BINDINGS_VERSION}" \
       && for arch in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64 windows-amd64; do \
            go get "github.com/duckdb/duckdb-go-bindings/lib/${arch}@${DUCKDB_BINDINGS_VERSION}" 2>/dev/null || true; \
-         done \
-      && go mod tidy ; \
-    fi \
-    && cp go.mod go.mod.pinned && cp go.sum go.sum.pinned
+         done ; \
+    fi
 
 RUN go mod download
 
@@ -121,9 +116,22 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
 
 COPY . .
 
-# Restore the pinned module files clobbered by COPY . . — a local copy, no
-# `go get`, so no network and the prewarmed module/build caches stay valid.
-RUN cp go.mod.pinned go.mod && cp go.sum.pinned go.sum
+# COPY . . overlaid the host's (unpinned) go.mod/go.sum back on top of the
+# pinned ones — without this re-pin the build would link the repo-default
+# DuckDB version regardless of the matrix row (the real bug the bindings-pin
+# verify below guards against). Re-apply the pin now that the source — and
+# thus the real import set — is present, so `go mod tidy` keeps every needed
+# require instead of pruning it. The module cache + CGO build cache warmed by
+# the pre-COPY layers stay valid: same versions, so `go get` is a fast
+# metadata no-op and the prewarmed objects are reused.
+RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
+      go get "github.com/duckdb/duckdb-go/v2@${DUCKDB_GO_VERSION}" \
+      && go get "github.com/duckdb/duckdb-go-bindings@${DUCKDB_BINDINGS_VERSION}" \
+      && for arch in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64 windows-amd64; do \
+           go get "github.com/duckdb/duckdb-go-bindings/lib/${arch}@${DUCKDB_BINDINGS_VERSION}" 2>/dev/null || true; \
+         done \
+      && go mod tidy ; \
+    fi
 
 ARG VERSION=dev
 ARG COMMIT=unknown


### PR DESCRIPTION
**Main is currently red for the worker image** — all four
`container-image-worker-cd` matrix builds fail on `c4db37d` (the #654
merge). Forward-fix.

## Cause

#654 moved the per-DuckDB-version pin into a module-files-only stage
(`COPY go.mod go.sum`; `go get`; `go mod tidy`) ahead of `COPY . .`.
With **no `.go` files present**, `go mod tidy` sees zero imports and
prunes **every** `require` directive, emptying `go.mod`. The stashed
`go.mod.pinned` was empty too, so restoring it after `COPY . .` gave the
final build a depless go.mod:

```
duckdbservice/appender_init.go:7:2: no required module provides
  package github.com/duckdb/duckdb-go/v2
```

Main + control-plane images were unaffected — they never run `tidy`.

## Fix

- Pin with `go get pkg@ver` (records the `require` regardless of imports)
  but do **not** `tidy` in the source-less stage.
- Drop the `go.mod.pinned` stash/restore.
- Re-run the pin **+ `go mod tidy` after `COPY . .`**, once the real
  import set is visible, so tidy keeps every needed `require`.

Prewarm + module caches from the pre-COPY layers stay valid (same
versions → `go get` is a fast metadata no-op, prewarmed objects reused).

## Verified locally
```
go mod tidy  (only go.mod/go.sum)         -> duckdb-go requires: 0  (the break)
go get duckdb-go/v2@v2.10502.0 (no tidy)  -> duckdb-go requires: 1, pinned (OK)
```
Default-path worker binary builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)