### PR TITLE
perf(docker): drop the useless CGO dep-prewarm line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,6 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
-# CGO dep-prewarm. Compiles the two heavy C/C++ dependencies — duckdb-go
-# (links libduckdb) and pg_query_go (links libpg_query) — into the Go build
-# cache in a layer keyed ONLY on go.mod/go.sum. On a source-only PR (the
-# common case) this layer is a GHA layer-cache hit, so the multi-minute
-# libduckdb/libpg_query compile is skipped and the final `go build` below
-# only recompiles changed first-party packages. Without it, `COPY . .`
-# busts the build layer on every source edit and the CGO deps recompile
-# from scratch each run (~3-5 min). `|| true` so a transient resolve error
-# doesn't fail the build — worst case the final build recompiles.
-RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
-
 # Bundled DuckDB extensions. Downloaded BEFORE `COPY . .` so this layer
 # depends only on the extension version args, not on source — a source-only
 # PR keeps the GHA layer-cache hit and skips the 5 downloads entirely. (They

--- a/Dockerfile.controlplane
+++ b/Dockerfile.controlplane
@@ -20,13 +20,6 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
-# CGO dep-prewarm. The CP image doesn't link libduckdb, but it still links
-# libpg_query via pg_query_go (the transpiler). Compile it into the Go build
-# cache in a layer keyed only on go.mod/go.sum so a source-only PR skips the
-# libpg_query compile and the final `go build` recompiles only changed
-# first-party code. See the longer note in the top-level Dockerfile.
-RUN CGO_ENABLED=1 go build github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
-
 COPY . .
 
 ARG VERSION=dev

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -24,18 +24,16 @@ ARG DUCKDB_GO_VERSION=
 ARG DUCKDB_BINDINGS_VERSION=
 ARG TARGETARCH
 
-# Copy ONLY the module files first, apply the per-build DuckDB pin, then
-# download + CGO-prewarm — all in layers keyed solely on go.mod/go.sum + the
-# pin args. On a source-only PR these cache-hit, so the multi-minute
-# libduckdb/libpg_query compile is skipped and the final `go build` below
-# recompiles only changed first-party code.
+# Copy ONLY the module files first and apply the per-build DuckDB pin, so the
+# module download + extension fetch below sit in layers keyed solely on
+# go.mod/go.sum + the pin args. On a source-only PR these cache-hit and the
+# final `go build` recompiles only changed first-party code.
 #
 # IMPORTANT: do NOT run `go mod tidy` here. With only go.mod/go.sum present
 # (no .go files), tidy prunes EVERY require directive — it sees zero imports —
-# leaving an empty go.mod and breaking both the prewarm below and the build.
-# `go get pkg@ver` explicitly records the require regardless of imports, so it
-# pins correctly without source. tidy runs after COPY . ., once the real
-# imports are visible.
+# leaving an empty go.mod that breaks the build. `go get pkg@ver` explicitly
+# records the require regardless of imports, so it pins correctly without
+# source. tidy runs after COPY . ., once the real imports are visible.
 COPY go.mod go.sum ./
 
 RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
@@ -47,11 +45,6 @@ RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
     fi
 
 RUN go mod download
-
-# CGO dep-prewarm — see top-level Dockerfile. Compiles libduckdb-linked
-# duckdb-go + libpg_query-linked pg_query_go into the build cache, keyed on
-# the pinned go.mod/go.sum.
-RUN CGO_ENABLED=1 go build github.com/duckdb/duckdb-go/v2 github.com/pganalyze/pg_query_go/v6 2>/dev/null || true
 
 # Bundled DuckDB extensions. Downloaded BEFORE `COPY . .` so this layer
 # depends only on the extension/pin args, not on source — a source-only PR
@@ -121,9 +114,8 @@ COPY . .
 # DuckDB version regardless of the matrix row (the real bug the bindings-pin
 # verify below guards against). Re-apply the pin now that the source — and
 # thus the real import set — is present, so `go mod tidy` keeps every needed
-# require instead of pruning it. The module cache + CGO build cache warmed by
-# the pre-COPY layers stay valid: same versions, so `go get` is a fast
-# metadata no-op and the prewarmed objects are reused.
+# require instead of pruning it. The module cache from the pre-COPY layers
+# stays valid: same versions, so `go get` is a fast metadata no-op.
 RUN if [ -n "$DUCKDB_GO_VERSION" ] && [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
       go get "github.com/duckdb/duckdb-go/v2@${DUCKDB_GO_VERSION}" \
       && go get "github.com/duckdb/duckdb-go-bindings@${DUCKDB_BINDINGS_VERSION}" \


### PR DESCRIPTION
## Why

The CGO dep-prewarm added in #654 was premised on a multi-minute CGO
**compile** of duckdb-go. That premise was wrong: `duckdb-go-bindings`
ships **prebuilt static libs** (`libduckdb_*.a`, `libparquet_extension.a`
… ~1.7GB in the module cache) — there is no DuckDB C++ compile to cache.
The other prewarmed dep, `pg_query_go`, cold-compiles in **~4s**. So the
prewarm layer saved single-digit seconds while adding a confusing extra
step.

Measured on warm main builds after #654:

| image | before | after #654 (warm) |
|---|---|---|
| main | 288s | 264s |
| controlplane | 241s | 229s |

That ~10% came from the **layer reordering** (module + extension
downloads moved ahead of `COPY . .`, so they cache on source-only PRs),
**not** from the prewarm. The dominant remaining cost is the final CGO
**link** of the prebuilt static libs (~68s in the warm build's `#18`),
which caching can't touch — it changes with every source edit.

## What

Remove the prewarm `RUN` from all three Dockerfiles. Keep:
- the download reordering (the actual win),
- the worker pin-without-tidy fix from #655.

## Real lever (separate PR)
Build only `linux/arm64` in **PR** CI (mw-dev is 29 arm64 / 2 amd64),
halving the worker matrix — that targets the link floor the prewarm
couldn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)