### PR TITLE
ci: per-PR e2e harness against the real mw-dev EKS cluster

### DIFF
--- a/.github/workflows/_image-build.yml
+++ b/.github/workflows/_image-build.yml
@@ -1,0 +1,103 @@
+# Reusable single-image build. Factored out of the per-image CD workflows so
+# the PR e2e flow (.github/workflows/e2e-mw-dev.yml) can build the SAME images
+# the CD pipeline builds, but arm64-only and tagged per-PR, without
+# duplicating the buildx + ECR-login + cache wiring.
+#
+# Caller passes the Dockerfile, image name, tag, platform, and the DuckDB
+# build-args (worker only). Pushes to ECR (and optionally GHCR). The CD
+# workflows can migrate onto this later; for now they keep their own matrix
+# blocks and only the e2e flow consumes this — keeps the prod image pipeline
+# untouched while the harness lands.
+name: _image-build
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: "Path to the Dockerfile to build."
+        required: true
+        type: string
+      image-name:
+        description: "ECR/GHCR repository name, e.g. duckgres-worker."
+        required: true
+        type: string
+      tag:
+        description: "Image tag to push, e.g. pr-123-<sha>-arm64."
+        required: true
+        type: string
+      platform:
+        description: "Build platform. PR e2e uses linux/arm64 (mw-dev is arm64)."
+        required: false
+        default: linux/arm64
+        type: string
+      build-args:
+        description: "Multiline docker build-args (worker needs the DuckDB pins)."
+        required: false
+        default: ""
+        type: string
+      cache-scope:
+        description: "GHA cache scope key — keep distinct per (image,platform)."
+        required: true
+        type: string
+    secrets:
+      ecr-role:
+        description: "IAM role ARN for ECR push (OIDC)."
+        required: true
+    outputs:
+      image:
+        description: "Fully-qualified image ref that was pushed."
+        value: ${{ jobs.build.outputs.image }}
+
+env:
+  ECR_REGISTRY: 795637471508.dkr.ecr.us-east-1.amazonaws.com
+
+jobs:
+  build:
+    # arm64 runner so linux/arm64 builds run natively (no QEMU). mw-dev worker
+    # nodes are arm64, so the e2e flow only ever needs arm64.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      image: ${{ steps.ref.outputs.image }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Compute image ref
+        id: ref
+        # Pass inputs via env (not inline ${{ }} in run) to avoid shell
+        # injection — semgrep run-shell-injection.
+        env:
+          IMAGE_NAME: ${{ inputs.image-name }}
+          TAG: ${{ inputs.tag }}
+        run: echo "image=${ECR_REGISTRY}/${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          role-to-assume: ${{ secrets.ecr-role }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platform }}
+          push: true
+          tags: ${{ steps.ref.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+            COMMIT=${{ github.sha }}
+            BUILD_TAGS=kubernetes
+            ${{ inputs.build-args }}
+          cache-from: type=gha,scope=${{ inputs.cache-scope }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
       # AWS_* credentials are populated by configure-aws-credentials below
       # via OIDC; the three iceberg-specific values are bucket coordinates
       # provisioned in mw-dev.
-      DUCKGRES_K8S_ICEBERG_TABLE_BUCKET_ARN: arn:aws:s3tables:us-east-1:373313242555:bucket/posthog-duckgres-iceberg-test-mw-dev
+      DUCKGRES_K8S_ICEBERG_TABLE_BUCKET_ARN: arn:aws:s3tables:us-east-1:${{ secrets.MW_DEV_ACCOUNT_ID }}:bucket/posthog-duckgres-iceberg-test-mw-dev
       DUCKGRES_K8S_ICEBERG_REGION: us-east-1
       DUCKGRES_K8S_ICEBERG_DATA_BUCKET: posthog-duckgres-iceberg-test-data-mw-dev
 
@@ -328,7 +328,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v4.0.2
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::373313242555:role/github-duckgres-iceberg-ci-testing-role
+          role-to-assume: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/github-duckgres-iceberg-ci-testing-role
           role-duration-seconds: 3600
       - name: Run Kubernetes integration tests
         run: just test-k8s-integration

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -1,0 +1,159 @@
+# Per-PR end-to-end test against the real posthog-mw-dev EKS cluster.
+#
+# Replaces what kind (tests/k8s/) cannot exercise: real Cilium network
+# policies, real Crossplane Duckling provisioning, real cnpg-shard + external
+# RDS metadata stores, and the real per-org Lakekeeper operator — the layers
+# where this quarter's bugs actually lived (Cilium egress, lakekeeper
+# encryption-key drift, cnpg role drift, RBAC delete gaps).
+#
+# Flow:
+#   1. build arm64-only worker + control-plane images, tagged pr-<N>-<sha>,
+#      pushed to ECR (mw-dev is arm64, so one arch is enough for a PR).
+#   2. join the org tailnet via OIDC/WIF → reach the private mw-dev EKS API.
+#   3. stand up an isolated namespace duckgres-ci-pr-<N>: a throwaway
+#      config-store Postgres + a control-plane Deployment running the PR image,
+#      spawning worker pods in the same namespace.
+#   4. run the e2e harness as a Job INSIDE the namespace, talking to the CP
+#      ClusterIP service (no public DNS / NLB needed). Covers cnpg + ext
+#      (aurora is being retired — out of scope).
+#   5. always tear the namespace down (and deprovision the ci-pr ducklings so
+#      no S3 / cnpg role / lakekeeper CR leaks on shared infra).
+#
+# SECURITY — who can run this:
+#   Same model as the AWS/OIDC job in ci.yml: the gate is the repo setting
+#   "Require approval for outside collaborators". Members' PRs run
+#   automatically; fork PRs from outside collaborators get NO secrets and don't
+#   run until a maintainer clicks approve-and-run, so they can't reach the
+#   cluster or assume the IAM role unapproved. (No per-workflow guard job /
+#   required-reviewer Environment — that would either block external PRs even
+#   after approval, or force an approval click on every maintainer push.)
+#
+# Required repo configuration (one-time, see tests/e2e-mw-dev/README.md):
+#   vars:    TS_WIF_CLIENT_ID_MW_DEV, TS_WIF_AUDIENCE_MW_DEV
+#   secrets: AWS_ECR_PUBLISH_IAM_ROLE (already exists, used by CD),
+#            MW_DEV_ACCOUNT_ID (mw-dev AWS account id; ARNs built from it)
+#   IAM:     github-duckgres-e2e role in the mw-dev account (posthog-cloud-infra)
+#            — stripped down, NOT the account-admin terraform-infra role.
+#   Repo setting: "Require approval for all outside collaborators".
+name: e2e-mw-dev
+
+on:
+  pull_request:
+    branches: [main]
+    # Scope: only run when something that could change runtime behavior moves.
+    # (Docs-only PRs shouldn't spin up a cluster namespace.)
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Dockerfile*"
+      - "tests/e2e-mw-dev/**"
+      - ".github/workflows/e2e-mw-dev.yml"
+      - ".github/workflows/_image-build.yml"
+  workflow_dispatch:
+
+# One in-flight run per PR; a new push cancels the old run (and its namespace
+# is GC'd by the always() teardown of the cancelled run + the janitor).
+concurrency:
+  group: e2e-mw-dev-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  # mw-dev runs ONE all-in-one `duckgres` image for both roles: the control
+  # plane is `--mode control-plane` on it, and DUCKGRES_K8S_WORKER_IMAGE points
+  # at the same image (workers run `--mode duckdb-service`). So the e2e flow
+  # builds that single image — not the separate worker/controlplane CD images —
+  # to match what actually ships to mw-dev.
+  build:
+    uses: ./.github/workflows/_image-build.yml
+    with:
+      dockerfile: Dockerfile
+      image-name: duckgres
+      tag: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-arm64
+      platform: linux/arm64
+      cache-scope: e2e-duckgres-arm64
+      # Default DuckDB row (1.5.3) — mirrors the default:true matrix entry in
+      # container-image-worker-cd.yml. Keep in lock-step on a version bump.
+      build-args: |
+        DUCKDB_EXTENSION_VERSION=1.5.3
+        HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
+        DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
+        DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
+        POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
+    secrets:
+      ecr-role: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+
+  e2e:
+    needs: [build]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 40
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      NAMESPACE: duckgres-ci-pr-${{ github.event.pull_request.number }}
+      # Single all-in-one image for both CP and workers (mw-dev parity).
+      WORKER_IMAGE: ${{ needs.build.outputs.image }}
+      CONTROLPLANE_IMAGE: ${{ needs.build.outputs.image }}
+      KUBE_CONTEXT: posthog-mw-dev
+      CLUSTER_NAME: posthog-mw-dev
+      EKS_CLUSTER_NAME: posthog-mw-dev
+      AWS_REGION: us-east-1
+      # The per-PR CP assumes the SAME EKS Pod Identity role as the real mw-dev
+      # control plane, so STS-brokered S3 activation works with no cred
+      # injection. Built from the account-id secret (no account id committed) +
+      # the non-sensitive role name.
+      CP_POD_IDENTITY_ROLE: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/duckgres-control-plane-dev
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          # Dedicated, stripped-down e2e role (NOT the account-admin
+          # terraform-infra role): eks:DescribeCluster + Pod Identity
+          # association calls + iam:PassRole on the CP role, plus an EKS access
+          # entry for the kubectl it needs. Defined in posthog-cloud-infra
+          # (mw-dev account). Account id comes from a repo secret so no AWS
+          # account id is committed; the role name is not sensitive.
+          role-to-assume: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/github-duckgres-e2e
+          aws-region: us-east-1
+
+      # Private EKS API — join the org tailnet so kubectl can reach it. OIDC/WIF,
+      # no static key. Mirrors PostHog/hogland deploy.yml. The subnet router
+      # advertises the mw-dev VPC incl. the private API endpoint.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ vars.TS_WIF_CLIENT_ID_MW_DEV }}
+          audience: ${{ vars.TS_WIF_AUDIENCE_MW_DEV }}
+          tags: tag:github-runner
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+
+      - name: Update kubeconfig
+        # --alias so the context is named posthog-mw-dev (matches KUBE_CONTEXT /
+        # run.sh's explicit --context). Without it the context defaults to the
+        # full cluster ARN and `kubectl --context posthog-mw-dev` fails with
+        # "context does not exist".
+        run: aws eks update-kubeconfig --name "$CLUSTER_NAME" --region us-east-1 --alias "$KUBE_CONTEXT"
+
+      - name: Deploy isolated namespace
+        run: bash tests/e2e-mw-dev/run.sh deploy
+
+      - name: Run e2e harness (in-cluster Job)
+        run: bash tests/e2e-mw-dev/run.sh test
+
+      - name: Collect diagnostics
+        if: always()
+        run: bash tests/e2e-mw-dev/run.sh diagnostics
+
+      # Always tear down — deprovision the ci-pr ducklings (so no S3 / cnpg
+      # role+db / lakekeeper CR leaks on shared infra) then delete the
+      # namespace. Runs even on cancel/failure.
+      - name: Teardown
+        if: always()
+        run: bash tests/e2e-mw-dev/run.sh teardown

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -1,0 +1,137 @@
+# mw-dev per-PR e2e harness
+
+Replaces what `tests/k8s/` (kind) cannot exercise — real Cilium network
+policies, real Crossplane Duckling provisioning, real cnpg-shard + external
+RDS metadata stores, and the real per-org Lakekeeper operator. Those are the
+layers where this quarter's production bugs lived.
+
+## Flow (`.github/workflows/e2e-mw-dev.yml`)
+
+1. **Build** the arm64-only all-in-one `duckgres` image (`_image-build.yml`),
+   tagged `pr-<N>-<sha>-arm64`, pushed to ECR. mw-dev runs ONE image for both
+   the control plane (`--mode control-plane`) and the workers
+   (`DUCKGRES_K8S_WORKER_IMAGE` = same image), so the PR builds just that.
+   One arch suffices (mw-dev is arm64); merge-to-main keeps the full
+   multi-arch + worker/CP-split matrices in the existing CD workflows.
+2. **Tailscale** join via OIDC/WIF → reach the private mw-dev EKS API.
+3. **Deploy** an isolated `duckgres-ci-pr-<N>` namespace: throwaway
+   config-store Postgres + a control-plane Deployment on the PR image, spawning
+   worker pods in the same namespace.
+4. **Test** via an in-cluster Job hitting the CP ClusterIP service. Covers
+   **cnpg + ext** (aurora out of scope).
+5. **Teardown** always: deprovision the ci-pr ducklings (clean shared-infra
+   footprint) then delete the namespace.
+
+## Isolation model
+
+Dedicated CP + throwaway config-store **per PR**, provisioning **real**
+ducklings (org IDs `ci-pr-<N>-cnpg`, `ci-pr-<N>-ext`) through the **shared**
+Crossplane / cnpg-shards / external RDS / Lakekeeper operator. Everything
+PR-specific lives in the namespace and is deleted; the shared-infra footprint
+is removed by deprovisioning the ducklings first.
+
+## One-time repo configuration
+
+| kind | name | purpose |
+|---|---|---|
+| var | `TS_WIF_CLIENT_ID_MW_DEV` | Tailscale OAuth WIF client (mirror of hogland's) |
+| var | `TS_WIF_AUDIENCE_MW_DEV` | Tailscale WIF audience |
+| secret | `MW_DEV_ACCOUNT_ID` | mw-dev AWS account id (kept out of committed code; ARNs are built from it) |
+| secret | `AWS_ECR_PUBLISH_IAM_ROLE` | ECR push (already exists; used by CD) |
+| (role) | `github-duckgres-e2e` | dedicated stripped role in the mw-dev account (posthog-cloud-infra) — `eks:DescribeCluster` + Pod Identity association calls + `iam:PassRole`/`iam:GetRole` on the CP role + an EKS access entry for kubectl. The workflow assumes `arn:aws:iam::<MW_DEV_ACCOUNT_ID>:role/github-duckgres-e2e`. |
+| repo setting | "Require approval for all outside collaborators" | the access gate (see below) |
+
+The Tailscale tailnet ACL must allow `tag:github-runner` to reach the mw-dev
+VPC subnet router (same pattern hogland set up for its dev cluster).
+
+## Access control — "external people cannot run this"
+
+Same model as the AWS/OIDC job in `ci.yml`: the gate is the repo setting
+**"Require approval for all outside collaborators"**. Members' PRs run
+automatically; fork PRs from outside collaborators get no secrets and don't run
+until a maintainer clicks *approve-and-run*, so they can't reach the cluster or
+assume the IAM role unapproved.
+
+No per-workflow guard job or required-reviewer Environment: a guard on
+`author_association` would block external PRs *even after a maintainer approves*
+(the opposite of the intent), and a required-reviewer Environment would force an
+approval click on every maintainer push. The repo setting gives exactly
+"members auto, outsiders need approval".
+
+## Validated locally against mw-dev (dry-run with the shipped `duckgres` image)
+
+Running `run.sh` from a laptop on the VPN (kubectl `--context posthog-mw-dev`)
+got through, in order — each was a real fix:
+1. ✅ deploy — namespace, throwaway config-store, CP, cross-ns RBAC all apply.
+2. ✅ worker boot — needed `data_dir: /data` in the worker ConfigMap (the CP
+   factory mounts an emptyDir at `/data`; default `./data` → `mkdir
+   data/extensions: permission denied` and the worker exits 1).
+3. ✅ CP secret reconciler — needed `list`/`watch` on secrets in the Role.
+4. ✅ SNI routing — the CP rejects non-SNI connections
+   (`this server requires connecting via <org-id>.<managed-suffix>`). Fixed by
+   `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES=.ci.duckgres.local` +
+   `DUCKGRES_SNI_ROUTING_MODE=passthrough`, and connecting with libpq
+   `host=<org>.<suffix>` (SNI) + `hostaddr=<CP ClusterIP>` (TCP).
+5. ✅ catalog selection — `dbname` must be `ducklake` or `iceberg`, not the org
+   (PR #651: *database = catalog selection*). harness.sh now does this.
+
+6. ✅ **activation (cnpg DuckLake + Iceberg)** — the blocker was NOT a metadata
+   SecretRef; the duckling-status path reads the metadata password straight
+   from the CR. It failed at **S3 STS brokering** because the isolated CP had no
+   AWS identity. Fixed by binding the per-PR `duckgres` SA to the **same EKS Pod
+   Identity role the real mw-dev control plane uses**
+   (`duckgres-control-plane-dev`), via `aws eks create-pod-identity-association`
+   in `run.sh` deploy (deleted in teardown). With it, the CP brokers per-duckling
+   S3 creds exactly like prod: validated the warehouse reaches `ready`, the pod
+   gets the EKS creds endpoint, and a psql session authenticates + attaches the
+   DuckLake catalog. (Full CREATE/INSERT/SELECT reconfirm was interrupted by a
+   VPN drop; the activation path itself is proven.)
+
+The CP pod-identity role is `role/duckgres-control-plane-dev` in the mw-dev
+account; the workflow builds the ARN from `secrets.MW_DEV_ACCOUNT_ID` (no account
+id committed).
+
+## Other open items
+
+- **`github-duckgres-e2e` role (posthog-cloud-infra).** AWS policy:
+  `eks:DescribeCluster`, `eks:{Create,List,Delete,Describe}PodIdentityAssociation`
+  on the cluster + its associations, and `iam:PassRole` on
+  `duckgres-control-plane-dev`. Trust: `repo:PostHog/duckgres:*`. Plus an EKS
+  **access entry** binding the role to k8s RBAC that can create namespaces, the
+  cross-namespace bindings, and the in-namespace resources (the kubectl the
+  harness runs). Scope as tightly as the cluster admins allow — deliberately
+  NOT the account-admin `github-terraform-infra-role`.
+- **Don't hammer auth.** The CP rate-limiter bans the source IP after a few
+  failed auths (~15 min). The harness uses the provision-time password and
+  settles one config-poll interval before connecting — keep it that way; a
+  reset-password + tight retry loop will trip the ban.
+- **Teardown is async-incomplete.** `run.sh teardown` deprovisions and waits on
+  warehouse `state=deleted` (= Duckling CR deleted), but the downstream
+  Crossplane DROP of the cnpg role+db lags behind that — observed a stranded
+  `lakekeeper_ci_pr_<N>_cnpg` role after teardown returned. Either wait on the
+  cnpg role/db actually being gone, or rely on the janitor below. (The
+  composition `managementPolicies: ["*"]` from charts#11522 does drop them;
+  it's just not synchronous with the CR delete.)
+- **Shared-infra contention.** Concurrent PRs provision real ducklings against
+  the same cnpg-shards / RDS / lakekeeper-operator. Org-ID prefix keeps them
+  distinct; watch quay.io / cnpg pooler / RDS limits under parallelism.
+- **Deep coverage stubbed.** Durability (worker-pod kill), concurrency, and
+  network-policy assertions are `SKIP (TODO)` — activation (#6) is cleared, so
+  these are the next layer to flesh out.
+- **Janitor.** Periodic sweep of stale `duckgres-ci-pr-*` namespaces + their
+  ci-pr-labelled cross-ns bindings + orphaned ducklings/cnpg roles, to back up
+  the always() teardown for runs that die hard. Not yet added.
+
+## Local dry-run
+
+Needs VPN to the private mw-dev API and `AWS_PROFILE=mw-dev` for the `aws eks`
+pod-identity calls. Both images point at the same all-in-one ref.
+
+```sh
+IMG=<ecr>/duckgres:<tag>
+AWS_PROFILE=mw-dev \
+NAMESPACE=duckgres-ci-pr-0 PR_NUMBER=0 KUBE_CONTEXT=posthog-mw-dev \
+  WORKER_IMAGE=$IMG CONTROLPLANE_IMAGE=$IMG \
+  CP_POD_IDENTITY_ROLE=arn:aws:iam::<mw-dev-account-id>:role/duckgres-control-plane-dev \
+  bash tests/e2e-mw-dev/run.sh deploy
+```

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# In-cluster e2e harness. Runs as a Job in the per-PR namespace, talking to the
+# control-plane ClusterIP service. Provisions cnpg + ext ducklings (aurora is
+# being retired — out of scope), then exercises DuckLake + Iceberg read/write,
+# the create→delete→recreate lifecycle, and (TODO) durability/concurrency/netpol.
+#
+# Exit non-zero on any failure → the Job fails → the workflow step fails.
+#
+# Env (from run.sh): NAMESPACE, PR_NUMBER, INTERNAL_SECRET, CP_API, CP_PG_HOST
+set -eu
+
+apk add --no-cache curl jq postgresql-client >/dev/null 2>&1 || true
+
+API="${CP_API:?}"
+PGHOST="${CP_PG_HOST:?}"
+SECRET="${INTERNAL_SECRET:?}"
+H="X-Duckgres-Internal-Secret: $SECRET"
+CNPG="ci-pr-${PR_NUMBER}-cnpg"
+EXT="ci-pr-${PR_NUMBER}-ext"
+
+# duckling-example RDS — the shared external metadata store (same one the
+# manual validation used). Endpoint is stable in mw-dev.
+EXT_RDS_ENDPOINT="duckling-example-managed-warehouse-dev-us-east-1.c8jy2c68kipq.us-east-1.rds.amazonaws.com"
+EXT_RDS_SECRET="duckling-example-managed-warehouse-dev-us-east-1-rds-password"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+# stderr, NOT stdout: log() is called inside functions whose stdout is captured
+# in $(...) and piped to jq (e.g. provision | jq -r .password). A log line on
+# stdout would land in that capture and make jq choke ("Invalid numeric literal").
+log()  { echo ">>> $*" >&2; }
+
+api_post() { curl -fsS -X POST -H "$H" "$API/api/v1/orgs/$1/$2"; }
+api_get()  { curl -fsS -H "$H" "$API/api/v1/orgs/$1/$2"; }
+state_of() { api_get "$1" warehouse/status 2>/dev/null | jq -r '.state // "missing"'; }
+
+provision() { # org metadata_json
+  log "provision $1"
+  curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' -d "$2" \
+    "$API/api/v1/orgs/$1/provision"
+}
+
+wait_state() { # org target timeout_s
+  org="$1"; want="$2"; deadline=$(( $(date +%s) + ${3:-600} ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    s="$(state_of "$org")"
+    [ "$s" = "$want" ] && { log "$org -> $s"; return 0; }
+    [ "$s" = "failed" ] && fail "$org entered failed state"
+    sleep 10
+  done
+  fail "$org did not reach $want within ${3}s (last=$(state_of "$org"))"
+}
+
+# Org routing is by TLS SNI hostname <org>.<managed-suffix>; the dbname selects
+# the CATALOG (`ducklake` or `iceberg`), not the org (PR #651). The control
+# plane rejects connections without a managed SNI host. We use libpq's
+# host (→ SNI + TLS name) / hostaddr (→ TCP target) split: SNI carries the org
+# hostname while the TCP connection still lands on the CP ClusterIP. The suffix
+# (.ci.duckgres.local) is CI-internal and never resolves in DNS — hostaddr is
+# what actually connects.
+SNI_SUFFIX=".ci.duckgres.local"
+CP_IP=""
+resolve_cp_ip() {
+  # ClusterIP of the CP service, for hostaddr. getent works from the alpine Job.
+  CP_IP="$(getent hosts "$PGHOST" | awk '{print $1}' | head -1)"
+  [ -n "$CP_IP" ] || fail "could not resolve $PGHOST"
+}
+
+pg() { # org password dbname(catalog) sql
+  PGPASSWORD="$2" psql \
+    "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=$3" \
+    -v ON_ERROR_STOP=1 -tAc "$4"
+}
+
+# Connect preflight: a warm worker isn't always available the instant a
+# warehouse goes ready (shared_warm_target=0, so the first connection for an
+# org cold-spawns a worker; a second org can find the pool momentarily
+# exhausted). The CP returns a transient "no warm Duckgres worker is currently
+# available; retry in ~45s" / "still provisioning" / "failed to initialize
+# session". Retry `SELECT 1` through those, bounded, BEFORE the R/W. Auth
+# failures are NOT in this set, so this never feeds the rate limiter.
+wait_worker() { # org password catalog
+  attempt=0
+  while [ "$attempt" -lt 10 ]; do
+    if out="$(PGPASSWORD="$2" psql \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=$3" \
+        -v ON_ERROR_STOP=1 -tAc 'SELECT 1' 2>&1)" && [ "$out" = "1" ]; then
+      return 0
+    fi
+    log "worker not ready for $1/$3 ($(printf %s "$out" | tr -d '\n' | tail -c 80)); retry…"
+    sleep 15
+    attempt=$((attempt + 1))
+  done
+  fail "no warm worker for $1/$3 after retries"
+}
+
+rw_ducklake() { # org password
+  log "DuckLake R/W on $1"
+  t="e2e_dl_$(echo "$1" | tr -c 'a-z0-9' _)"
+  pg "$1" "$2" ducklake "DROP TABLE IF EXISTS $t; CREATE TABLE $t(id INT, label VARCHAR);
+            INSERT INTO $t VALUES (1,'one'),(2,'two'),(3,'three');"
+  n="$(pg "$1" "$2" ducklake "SELECT COUNT(*) FROM $t;")"
+  [ "$n" = "3" ] || fail "$1 DuckLake rowcount=$n want 3"
+  pg "$1" "$2" ducklake "DROP TABLE $t;"
+}
+
+rw_iceberg() { # org password
+  log "Iceberg R/W on $1"
+  t="e2e_ice_$(echo "$1" | tr -c 'a-z0-9' _)"
+  pg "$1" "$2" iceberg "DROP TABLE IF EXISTS iceberg.public.$t;
+            CREATE TABLE iceberg.public.$t(id INT, label VARCHAR);
+            INSERT INTO iceberg.public.$t VALUES (10,'ten'),(20,'twenty');"
+  n="$(pg "$1" "$2" iceberg "SELECT COUNT(*) FROM iceberg.public.$t;")"
+  [ "$n" = "2" ] || fail "$1 Iceberg rowcount=$n want 2"
+  pg "$1" "$2" iceberg "DROP TABLE iceberg.public.$t;"
+}
+
+# ---- cnpg duckling: cnpg-shard metadata + DuckLake + Iceberg --------------
+CNPG_BODY='{"database_name":"'"$CNPG"'","metadata_store":{"type":"cnpg-shard"},
+  "data_store":{"type":"s3bucket"},"ducklake":{"enabled":true},
+  "iceberg":{"enabled":true,"namespace":"main"}}'
+
+# ---- ext duckling: external RDS metadata + DuckLake + Iceberg -------------
+EXT_BODY='{"database_name":"'"$EXT"'",
+  "metadata_store":{"type":"external","external":{
+    "endpoint":"'"$EXT_RDS_ENDPOINT"'","password_aws_secret":"'"$EXT_RDS_SECRET"'",
+    "user":"ducklingexample","database":"ducklingexample"}},
+  "data_store":{"type":"external","bucket_name":"posthog-duckling-example-managed-warehouse-dev","region":"us-east-1"},
+  "ducklake":{"enabled":true},"iceberg":{"enabled":true,"namespace":"main"}}'
+
+main() {
+  resolve_cp_ip
+  # Use the password returned at provision time — do NOT call reset-password and
+  # then retry-connect in a tight loop: the CP rate-limiter bans the source IP
+  # after a handful of failed auths, and a fresh password isn't live until the
+  # next config-store poll. Provision returns the live password directly.
+  cnpg_pw="$(provision "$CNPG" "$CNPG_BODY" | jq -r .password)"
+  ext_pw="$(provision "$EXT" "$EXT_BODY" | jq -r .password)"
+  wait_state "$CNPG" ready 600
+  wait_state "$EXT" ready 600
+
+  # Settle: let the CP's config-store poll pick up the provisioned org/users
+  # before the first connection, so we don't burn failed-auth attempts against
+  # the rate limiter while the auth cache catches up.
+  log "settling ${CONFIG_POLL_SETTLE:-40}s for CP auth cache…"
+  sleep "${CONFIG_POLL_SETTLE:-40}"
+
+  # 1. DuckLake + Iceberg read/write, both metadata backends. wait_worker
+  #    preflights each org so a transient empty worker pool doesn't fail the run.
+  wait_worker "$CNPG" "$cnpg_pw" ducklake
+  rw_ducklake "$CNPG" "$cnpg_pw"; rw_iceberg "$CNPG" "$cnpg_pw"
+  wait_worker "$EXT" "$ext_pw" ducklake
+  rw_ducklake "$EXT"  "$ext_pw";  rw_iceberg "$EXT"  "$ext_pw"
+
+  # 2. Lifecycle: deprovision cnpg → confirm deleted. Proves the teardown path
+  #    (warehouse delete + Duckling CR delete) works end to end.
+  #
+  #    NOTE: same-orgID *recreate* (the regression net for the stranded-state
+  #    bugs in #649/#650/#11518/#11522) is intentionally NOT done here. A
+  #    deprovision marks the warehouse deleted as soon as the Duckling CR delete
+  #    is issued, but the CR's finalizers + the downstream async drop of the
+  #    cnpg role/db keep running afterwards. Re-provisioning the same orgID
+  #    immediately races a still-terminating Duckling CR and stalls in
+  #    "no usable Duckling CR". Until teardown is synchronous (the documented
+  #    async-teardown follow-up) the recreate-same-orgID check belongs in a
+  #    slower, dedicated test, not the per-PR smoke.
+  log "lifecycle: deprovision $CNPG"
+  api_post "$CNPG" deprovision >/dev/null
+  wait_state "$CNPG" deleted 600
+
+  # 3. TODO durability: kill the active worker pod mid-session, reconnect, read
+  #    back DuckLake data from object storage. Needs `kubectl delete pod
+  #    -l app=duckgres-worker` (the Job SA has pod-delete in-ns) + a reconnect
+  #    loop. Stubbed until the connect/routing model below is confirmed green.
+  log "SKIP durability (TODO)"
+
+  # 4. TODO concurrency: N writers INSERT under DuckLake conflict-retry. Port
+  #    from tests/k8s/ducklake_test.go::TestK8sDuckLakeConcurrentWriters.
+  log "SKIP concurrency (TODO)"
+
+  # 5. TODO network policy: assert worker egress reaches the cnpg pooler +
+  #    lakekeeper:8181 and cross-tenant is denied. The Cilium policies are
+  #    cluster-wide and snap on via the duckgres/active-org label — verify the
+  #    label is stamped and a denied destination times out.
+  log "SKIP netpol (TODO)"
+
+  log "PASS: cnpg + ext DuckLake/Iceberg R/W + cnpg deprovision"
+}
+
+main "$@"

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -1,0 +1,239 @@
+# Per-PR isolated duckgres stack for the mw-dev e2e harness. Rendered by
+# run.sh via envsubst with: NAMESPACE, PR_NUMBER, CONTROLPLANE_IMAGE,
+# WORKER_IMAGE, INTERNAL_SECRET.
+#
+# Isolation model (decided with the design): a DEDICATED control plane +
+# throwaway config-store per PR, provisioning REAL ducklings (PR-prefixed org
+# IDs) through the SHARED Crossplane / cnpg-shards / external RDS / Lakekeeper
+# operator. The shared infra is what kind can't model and where the bugs live.
+# Everything PR-specific lives in ${NAMESPACE} and is deleted on teardown; the
+# shared-infra footprint (ducklings, lakekeeper CRs, cnpg roles, S3) is removed
+# by deprovisioning the ci-pr ducklings before the namespace goes.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: e2e-mw-dev
+    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
+---
+# Throwaway config-store. Ephemeral (emptyDir) — the control plane AutoMigrates
+# the schema on boot and the provisioning API creates every row, so no seed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duckgres-config-store
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: duckgres-config-store }
+  template:
+    metadata:
+      labels: { app: duckgres-config-store }
+    spec:
+      containers:
+        - name: postgres
+          image: public.ecr.aws/docker/library/postgres:16-alpine
+          env:
+            - { name: POSTGRES_USER, value: duckgres }
+            - { name: POSTGRES_PASSWORD, value: duckgres }
+            - { name: POSTGRES_DB, value: duckgres }
+            - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
+          ports: [{ containerPort: 5432 }]
+          volumeMounts: [{ name: data, mountPath: /var/lib/postgresql/data }]
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "duckgres"] }
+            periodSeconds: 3
+      volumes: [{ name: data, emptyDir: {} }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: duckgres-config-store
+  namespace: ${NAMESPACE}
+spec:
+  selector: { app: duckgres-config-store }
+  ports: [{ port: 5432, targetPort: 5432 }]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: duckgres-tokens
+  namespace: ${NAMESPACE}
+stringData:
+  internal-secret: "${INTERNAL_SECRET}"
+---
+# Worker mTLS bearer token (the CP mints per-worker secrets at runtime; this is
+# the shared seed the chart references via DUCKGRES_K8S_WORKER_SECRET).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: duckgres-worker-token
+  namespace: ${NAMESPACE}
+stringData:
+  token: "${INTERNAL_SECRET}"
+---
+# Worker config. data_dir MUST be /data — the control plane's worker pod
+# factory mounts an emptyDir there; without this the worker defaults to ./data
+# (=/app/data, not writable for the non-root user) and dies at boot with
+# "mkdir data/extensions: permission denied". Mirrors the prod duckgres-config.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: duckgres-config
+  namespace: ${NAMESPACE}
+data:
+  duckgres.yaml: |
+    data_dir: "/data"
+    extensions:
+      - ducklake
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: duckgres
+  namespace: ${NAMESPACE}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: duckgres-worker
+  namespace: ${NAMESPACE}
+automountServiceAccountToken: false
+---
+# In-namespace CP permissions: spawn/patch worker pods, manage per-worker
+# secrets, read the worker configmap, hold the janitor lease. Mirrors the
+# chart's duckgres-control-plane Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: duckgres-control-plane
+  namespace: ${NAMESPACE}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    # list/watch needed by the CP's stranded-secret reconciler (the prod chart
+    # Role grants them implicitly via the shared duckgres namespace; spelled
+    # out here for the isolated CI namespace).
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: duckgres-control-plane
+  namespace: ${NAMESPACE}
+subjects:
+  - { kind: ServiceAccount, name: duckgres, namespace: ${NAMESPACE} }
+roleRef:
+  { kind: Role, name: duckgres-control-plane, apiGroup: rbac.authorization.k8s.io }
+---
+# Cross-namespace duckling provisioning. Reuses the cluster-scoped
+# `duckgres-duckling-reader` ClusterRole already installed by the duckgres
+# chart (verbs get/list/watch/create/delete/patch on ducklings.k8s.posthog.com).
+# Per-PR binding so the namespace SA can drive real duckling provisioning;
+# deleted on teardown with the namespace label sweep.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: duckgres-ci-pr-${PR_NUMBER}-duckling-reader
+  labels:
+    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
+subjects:
+  - { kind: ServiceAccount, name: duckgres, namespace: ${NAMESPACE} }
+roleRef:
+  { kind: ClusterRole, name: duckgres-duckling-reader, apiGroup: rbac.authorization.k8s.io }
+---
+# Cross-namespace Lakekeeper provisioning. Reuses the `duckgres-lakekeeper-provisioner`
+# Role in the shared `lakekeeper` namespace (the one PR #11518 fixed to include
+# delete). Per-PR RoleBinding; deleted on teardown.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: duckgres-ci-pr-${PR_NUMBER}
+  namespace: lakekeeper
+  labels:
+    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
+subjects:
+  - { kind: ServiceAccount, name: duckgres, namespace: ${NAMESPACE} }
+roleRef:
+  { kind: Role, name: duckgres-lakekeeper-provisioner, apiGroup: rbac.authorization.k8s.io }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duckgres-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: duckgres-control-plane }
+  template:
+    metadata:
+      labels: { app: duckgres-control-plane }
+    spec:
+      serviceAccountName: duckgres
+      containers:
+        - name: controlplane
+          image: ${CONTROLPLANE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args: ["--mode", "control-plane", "--worker-backend", "remote", "--flight-port", "8815"]
+          env:
+            - name: DUCKGRES_CONFIG_STORE
+              value: "postgres://duckgres:duckgres@duckgres-config-store.${NAMESPACE}.svc:5432/duckgres?sslmode=disable"
+            - { name: DUCKGRES_K8S_WORKER_IMAGE, value: "${WORKER_IMAGE}" }
+            - { name: DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY, value: "IfNotPresent" }
+            # Spawn workers in THIS namespace so teardown is a single ns delete.
+            - { name: DUCKGRES_K8S_WORKER_NAMESPACE, value: "${NAMESPACE}" }
+            - { name: DUCKGRES_K8S_WORKER_SECRET, value: "duckgres-worker-token" }
+            - { name: DUCKGRES_K8S_WORKER_CONFIGMAP, value: "duckgres-config" }
+            - { name: DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT, value: "duckgres-worker" }
+            - { name: DUCKGRES_K8S_SHARED_WARM_TARGET, value: "0" }
+            - name: DUCKGRES_INTERNAL_SECRET
+              valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
+            - { name: DUCKGRES_AWS_REGION, value: "us-east-1" }
+            # Land workers on the dedicated worker nodepool (mw-dev arm64).
+            - { name: DUCKGRES_K8S_WORKER_NODE_SELECTOR, value: '{"posthog.com/nodepool":"duckgres-workers"}' }
+            - { name: DUCKGRES_K8S_WORKER_TOLERATION_KEY, value: "posthog.com/nodepool" }
+            - { name: DUCKGRES_K8S_WORKER_TOLERATION_VALUE, value: "duckgres-workers" }
+            # Provision real per-org Lakekeeper instances (iceberg path).
+            - { name: DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED, value: "true" }
+            # Org identity is resolved from the TLS SNI hostname
+            # <org-id>.<managed-suffix> (the server rejects connections without
+            # it). The harness connects with libpq host=<org>.<suffix> (→ SNI)
+            # + hostaddr=<CP ClusterIP> (→ TCP target), and dbname selects the
+            # catalog. Suffix is CI-internal; it never needs to resolve in DNS.
+            - { name: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES, value: ".ci.duckgres.local" }
+            - { name: DUCKGRES_SNI_ROUTING_MODE, value: "passthrough" }
+          ports:
+            - { name: pg, containerPort: 5432 }
+            - { name: api, containerPort: 8080 }
+            - { name: flight, containerPort: 8815 }
+          readinessProbe:
+            httpGet: { path: /health, port: api }
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "500m", memory: "512Mi" }
+            limits: { cpu: "1", memory: "1Gi" }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: duckgres-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  selector: { app: duckgres-control-plane }
+  ports:
+    - { name: pg, port: 5432, targetPort: pg }
+    - { name: api, port: 8080, targetPort: api }

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Orchestrate the per-PR mw-dev e2e stack from the CI runner (kubectl reaches
+# the private API via Tailscale). Subcommands: deploy | test | diagnostics |
+# teardown. All kubectl calls pin --context explicitly — never rely on the
+# current-context default.
+#
+# Required env (set by .github/workflows/e2e-mw-dev.yml):
+#   NAMESPACE, PR_NUMBER, WORKER_IMAGE, CONTROLPLANE_IMAGE, KUBE_CONTEXT,
+#   CP_POD_IDENTITY_ROLE (the duckgres-control-plane-dev role ARN — the per-PR
+#   CP assumes the SAME EKS Pod Identity as the real mw-dev control plane, so
+#   the real STS-brokered S3 activation path works without any cred injection),
+#   EKS_CLUSTER_NAME, AWS_REGION.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CTX="${KUBE_CONTEXT:?}"
+NS="${NAMESPACE:?}"
+KUBECTL=(kubectl --context "$CTX")
+EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-posthog-mw-dev}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+SA_NAME="duckgres"
+
+# Internal secret for the per-PR control plane. Random per run; never reused.
+# Stamped into the rendered manifests and handed to the in-cluster harness.
+internal_secret_file="/tmp/duckgres-ci-internal-secret"
+
+render() {
+  : "${WORKER_IMAGE:?}" "${CONTROLPLANE_IMAGE:?}" "${PR_NUMBER:?}"
+  [ -f "$internal_secret_file" ] || openssl rand -hex 16 > "$internal_secret_file"
+  INTERNAL_SECRET="$(cat "$internal_secret_file")" \
+  NAMESPACE="$NS" PR_NUMBER="$PR_NUMBER" \
+  WORKER_IMAGE="$WORKER_IMAGE" CONTROLPLANE_IMAGE="$CONTROLPLANE_IMAGE" \
+    envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET' \
+    < "$HERE/manifests.tmpl.yaml"
+}
+
+# Bind this namespace's `duckgres` SA to the same IAM role the real mw-dev
+# control plane uses (EKS Pod Identity). With it, the CP brokers per-duckling
+# S3 STS creds exactly like prod and activation completes — without it, DuckLake/
+# Iceberg activation fails at AssumeRole. Idempotent: if an association for this
+# (ns, sa) already exists, leave it. Requires the runner's AWS role to hold
+# eks:{Create,List,Delete}PodIdentityAssociation + iam:PassRole on the CP role.
+ensure_pod_identity() {
+  : "${CP_POD_IDENTITY_ROLE:?CP_POD_IDENTITY_ROLE (CP IAM role ARN) is required}"
+  # Always (re)create a FRESH association: a stale one left by an
+  # interrupted/cancelled prior run can be present but not honored by the
+  # pod-identity agent for newly-admitted pods, leaving the CP without creds.
+  # Delete any existing, then create.
+  delete_pod_identity
+  aws eks create-pod-identity-association --region "$AWS_REGION" \
+    --cluster-name "$EKS_CLUSTER_NAME" --namespace "$NS" \
+    --service-account "$SA_NAME" --role-arn "$CP_POD_IDENTITY_ROLE" >/dev/null
+  echo "Created Pod Identity association $NS/$SA_NAME -> $CP_POD_IDENTITY_ROLE"
+}
+
+delete_pod_identity() {
+  local ids id
+  ids="$(aws eks list-pod-identity-associations --region "$AWS_REGION" \
+    --cluster-name "$EKS_CLUSTER_NAME" --namespace "$NS" \
+    --query "associations[].associationId" --output text 2>/dev/null || true)"
+  for id in $ids; do
+    [ "$id" = "None" ] && continue
+    aws eks delete-pod-identity-association --region "$AWS_REGION" \
+      --cluster-name "$EKS_CLUSTER_NAME" --association-id "$id" >/dev/null 2>&1 || true
+    echo "Deleted Pod Identity association $id"
+  done
+}
+
+# The EKS Pod Identity agent injects credentials at pod ADMISSION and never
+# retries for the life of the pod. A pod admitted before the agent has cached
+# the freshly-created association gets no creds, and STS AssumeRole then fails
+# with "no EC2 IMDS role found". So restart the CP and VERIFY the new pod
+# actually carries AWS_CONTAINER_CREDENTIALS_FULL_URI; retry the restart until
+# it does (the association propagates within a few seconds-to-a-minute).
+restart_cp_with_identity() {
+  local attempt uri pod
+  # Give the just-created association a head start before the first restart so
+  # the pod-identity agent has likely cached it by admission time.
+  sleep 15
+  for attempt in $(seq 1 10); do
+    "${KUBECTL[@]}" -n "$NS" rollout restart deploy/duckgres-control-plane >/dev/null
+    "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-control-plane --timeout=180s
+    pod="$("${KUBECTL[@]}" -n "$NS" get pod -l app=duckgres-control-plane -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+    uri="$("${KUBECTL[@]}" -n "$NS" exec "$pod" -- sh -c 'printf %s "$AWS_CONTAINER_CREDENTIALS_FULL_URI"' 2>/dev/null || true)"
+    if [ -n "$uri" ]; then
+      echo "CP pod $pod has Pod Identity creds (attempt $attempt)."
+      return 0
+    fi
+    echo "CP pod $pod has no Pod Identity creds yet (attempt $attempt); waiting for association to propagate…"
+    sleep 20
+  done
+  echo "CP never received Pod Identity credentials — STS activation will fail." >&2
+  return 1
+}
+
+# The cnpg lakekeeper_<org> role+db are owned by the Crossplane composition and
+# dropped when the Duckling CR deletes — but that cascade is async and can lag,
+# leaving a stranded role from a prior run (incl. a cancelled one with no
+# teardown). On the next run the same org id re-provisions against the stranded
+# role whose password has drifted, the Lakekeeper migrate Job hits SASL auth
+# failure, and the warehouse never goes ready. So drop it directly on the
+# active shard, idempotently, BOTH before provisioning (clean slate, so a rerun
+# never inherits stranded state) and at teardown (deterministic clean exit).
+# Scoped to this PR's unique org ids, so it can't touch another PR's tenant.
+drop_cnpg_role() { # org-id
+  local ident
+  # Mirror the composition's PG identifier: lakekeeper_<lower, [^a-z0-9_]→_>.
+  ident="lakekeeper_$(printf %s "$1" | tr 'A-Z-' 'a-z_' | tr -cd 'a-z0-9_')"
+  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
+    psql -U postgres -c "DROP DATABASE IF EXISTS ${ident} WITH (FORCE);" >/dev/null 2>&1 || true
+  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
+    psql -U postgres -c "DROP ROLE IF EXISTS ${ident};" >/dev/null 2>&1 || true
+}
+
+cmd_deploy() {
+  # Clean slate for the cnpg org before anything provisions (see drop_cnpg_role).
+  drop_cnpg_role "ci-pr-${PR_NUMBER}-cnpg"
+
+  echo "::group::Apply manifests ($NS)"
+  render | "${KUBECTL[@]}" apply -f -
+  echo "::endgroup::"
+
+  "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-config-store --timeout=120s
+
+  # Create the Pod Identity association first, then restart the CP until its
+  # pod actually carries the injected credentials.
+  ensure_pod_identity
+  restart_cp_with_identity
+}
+
+cmd_test() {
+  # Ship harness.sh into the namespace as a ConfigMap and run it as a Job that
+  # talks to the control-plane ClusterIP service. The Job SA is `duckgres`,
+  # which can delete worker pods in-namespace (durability test).
+  "${KUBECTL[@]}" -n "$NS" create configmap duckgres-harness \
+    --from-file=harness.sh="$HERE/harness.sh" \
+    --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -
+
+  INTERNAL_SECRET="$(cat "$internal_secret_file")"
+  "${KUBECTL[@]}" -n "$NS" delete job duckgres-harness --ignore-not-found
+  cat <<YAML | "${KUBECTL[@]}" apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: duckgres-harness
+  namespace: $NS
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: duckgres
+      restartPolicy: Never
+      containers:
+        - name: harness
+          image: public.ecr.aws/docker/library/postgres:16-alpine
+          command: ["/bin/sh", "/harness/harness.sh"]
+          env:
+            - { name: NAMESPACE, value: "$NS" }
+            - { name: PR_NUMBER, value: "$PR_NUMBER" }
+            - { name: INTERNAL_SECRET, value: "$INTERNAL_SECRET" }
+            - { name: CP_API, value: "http://duckgres-control-plane.$NS.svc:8080" }
+            - { name: CP_PG_HOST, value: "duckgres-control-plane.$NS.svc" }
+          volumeMounts: [{ name: h, mountPath: /harness }]
+      volumes: [{ name: h, configMap: { name: duckgres-harness } }]
+YAML
+
+  echo "Streaming harness logs…"
+  # Wait for the pod then follow logs; surface the Job's final status as our exit.
+  "${KUBECTL[@]}" -n "$NS" wait --for=condition=ready pod -l job-name=duckgres-harness --timeout=120s || true
+  "${KUBECTL[@]}" -n "$NS" logs -f job/duckgres-harness || true
+
+  # Decide pass/fail by polling BOTH terminal conditions. `wait
+  # --for=condition=complete` alone hangs the full timeout when the Job
+  # FAILED (the condition it waits for never becomes true), which is what
+  # made a one-second harness failure stall the step for 20 minutes.
+  deadline=$(( $(date +%s) + 1200 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ "$("${KUBECTL[@]}" -n "$NS" get job duckgres-harness -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)" = "True" ]; then
+      echo "harness Job complete."; return 0
+    fi
+    if [ "$("${KUBECTL[@]}" -n "$NS" get job duckgres-harness -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)" = "True" ]; then
+      echo "harness Job failed." >&2; return 1
+    fi
+    sleep 5
+  done
+  echo "harness Job did not reach a terminal state in time." >&2
+  return 1
+}
+
+cmd_diagnostics() {
+  echo "::group::namespace state"
+  "${KUBECTL[@]}" -n "$NS" get pods,svc,job -o wide || true
+  echo "::endgroup::"
+  echo "::group::control-plane logs (tail)"
+  "${KUBECTL[@]}" -n "$NS" logs deploy/duckgres-control-plane --tail=200 || true
+  echo "::endgroup::"
+  echo "::group::worker pods"
+  "${KUBECTL[@]}" -n "$NS" get pods -l app=duckgres-worker -o wide || true
+  echo "::endgroup::"
+}
+
+cmd_teardown() {
+  # Deprovision the ci-pr ducklings FIRST so shared-infra resources (S3 bucket,
+  # cnpg role+db, lakekeeper CR/secret/SA) are cleaned up by the control plane
+  # before we delete it. Best-effort — the namespace delete + janitor are the
+  # backstop. Uses the CP admin API via a short-lived port-forward.
+  if "${KUBECTL[@]}" -n "$NS" get deploy/duckgres-control-plane >/dev/null 2>&1; then
+    secret="$(cat "$internal_secret_file" 2>/dev/null || true)"
+    if [ -n "$secret" ]; then
+      "${KUBECTL[@]}" -n "$NS" port-forward svc/duckgres-control-plane 18080:8080 >/dev/null 2>&1 &
+      pf=$!; sleep 4
+      for org in "ci-pr-${PR_NUMBER}-cnpg" "ci-pr-${PR_NUMBER}-ext"; do
+        curl -fsS -X POST -H "X-Duckgres-Internal-Secret: $secret" \
+          "http://localhost:18080/api/v1/orgs/$org/deprovision" >/dev/null 2>&1 || true
+      done
+      # Give the provisioner a moment to drive the duckling deletes.
+      for _ in $(seq 1 30); do
+        gone=1
+        for org in "ci-pr-${PR_NUMBER}-cnpg" "ci-pr-${PR_NUMBER}-ext"; do
+          st="$(curl -fsS -H "X-Duckgres-Internal-Secret: $secret" \
+            "http://localhost:18080/api/v1/orgs/$org/warehouse/status" 2>/dev/null \
+            | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')"
+          [ "$st" = "deleted" ] || [ -z "$st" ] || gone=0
+        done
+        [ "$gone" = 1 ] && break
+        sleep 10
+      done
+      kill "$pf" 2>/dev/null || true
+    fi
+  fi
+
+  # Wait for the Duckling CRs to FULLY delete — not just the warehouse row.
+  # A warehouse flips to "deleted" the moment the CR delete is issued, but the
+  # CR's finalizers keep running (incl the downstream provider-sql DROP of the
+  # cnpg lakekeeper_<org> role+db). If we return before that finishes, a later
+  # run that reuses the same org id (rerun, or a force-pushed PR) provisions
+  # against a stranded cnpg role whose password has drifted -> the Lakekeeper
+  # migrate Job hits SASL auth failure and the warehouse never goes ready.
+  # `wait --for=delete` blocks until the CR (and its cascade) is gone.
+  for org in "ci-pr-${PR_NUMBER}-cnpg" "ci-pr-${PR_NUMBER}-ext"; do
+    "${KUBECTL[@]}" -n ducklings wait --for=delete "duckling/$org" --timeout=300s 2>/dev/null || true
+  done
+
+  # Deterministically drop the cnpg role+db in case the composition's async
+  # cascade lagged the CR delete above (see drop_cnpg_role). Idempotent.
+  drop_cnpg_role "ci-pr-${PR_NUMBER}-cnpg"
+
+  # Drop the Pod Identity association (it's an EKS resource, not in the ns).
+  delete_pod_identity
+
+  # Cross-namespace bindings carry the ci-pr label — sweep them, then the ns.
+  "${KUBECTL[@]}" delete clusterrolebinding -l "duckgres.posthog.com/ci-pr=${PR_NUMBER}" --ignore-not-found
+  "${KUBECTL[@]}" -n lakekeeper delete rolebinding -l "duckgres.posthog.com/ci-pr=${PR_NUMBER}" --ignore-not-found
+  "${KUBECTL[@]}" delete namespace "$NS" --ignore-not-found --wait=false
+}
+
+case "${1:?usage: run.sh deploy|test|diagnostics|teardown}" in
+  deploy) cmd_deploy ;;
+  test) cmd_test ;;
+  diagnostics) cmd_diagnostics ;;
+  teardown) cmd_teardown ;;
+  *) echo "unknown: $1" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## What

Adds a per-PR end-to-end test that runs against the **real posthog-mw-dev EKS cluster**, covering the layers `tests/k8s/` (kind) cannot: real Cilium network policies, real Crossplane Duckling provisioning, real cnpg-shard + external-RDS metadata stores, and the real per-org Lakekeeper operator — where this quarter's production bugs actually lived.

## Flow (`.github/workflows/e2e-mw-dev.yml`)

1. **Build** the arm64-only all-in-one `duckgres` image (`_image-build.yml`), tagged `pr-<N>-<sha>-arm64`, pushed to ECR. mw-dev runs one image for both the control plane and the workers, so the PR builds just that one arch (mw-dev is arm64); merge-to-main keeps the full multi-arch matrix.
2. **Tailscale** join via OIDC/WIF → reach the private mw-dev EKS API (mirrors PostHog/hogland).
3. **Deploy** an isolated `duckgres-ci-pr-<N>` namespace: a throwaway config-store Postgres + a control-plane Deployment on the PR image, spawning worker pods in the same namespace.
4. **Test** via an in-cluster Job hitting the CP ClusterIP service. Provisions **cnpg + ext** ducklings (aurora is being retired — out of scope), then exercises DuckLake + Iceberg read/write on both metadata backends and the cnpg deprovision lifecycle.
5. **Teardown** always: deprovision the ci-pr ducklings (no S3 / cnpg role+db / lakekeeper CR leak on shared infra), drop the cnpg role/db deterministically, remove the Pod Identity association + cross-ns bindings, delete the namespace. A rerun self-cleans the prior run's state.

## Isolation model

Dedicated CP + throwaway config-store **per PR**, provisioning **real** ducklings (org IDs `ci-pr-<N>-cnpg`, `ci-pr-<N>-ext`) through the **shared** Crossplane / cnpg-shards / external-RDS / Lakekeeper operator. Everything PR-specific lives in the namespace and is deleted; the shared-infra footprint is removed by deprovisioning the ducklings first. The per-PR CP assumes the **same EKS Pod Identity role as the real mw-dev control plane** (`duckgres-control-plane-dev`), so STS-brokered S3 activation works exactly like prod.

## Access control

Same model as the AWS/OIDC job in `ci.yml`: the gate is the repo setting **"Require approval for outside collaborators"**. Members' PRs run automatically; fork PRs from outside collaborators get no secrets and don't run until a maintainer approves — so they can't reach the cluster or assume the IAM role unapproved. No per-workflow guard job or required-reviewer Environment (either would block external PRs even after approval, or force an approval click on every maintainer push).

## Required repo configuration (one-time)

| kind | name | purpose |
|---|---|---|
| var | `TS_WIF_CLIENT_ID_MW_DEV` | Tailscale OAuth WIF client |
| var | `TS_WIF_AUDIENCE_MW_DEV` | Tailscale WIF audience |
| secret | `MW_DEV_ACCOUNT_ID` | mw-dev AWS account id (kept out of committed code; ARNs built from it) |
| secret | `AWS_ECR_PUBLISH_IAM_ROLE` | ECR push (already exists) |
| role | `github-duckgres-e2e` | dedicated stripped-down role in the mw-dev account (posthog-cloud-infra) — NOT the account-admin terraform-infra role |
| repo setting | "Require approval for all outside collaborators" | the access gate |

Companion changes (merged): posthog-cloud-infra #8465 + #8469 (the `github-duckgres-e2e` role + EKS access entry), charts #11675 (the `duckgres-e2e-ci` RBAC).

## No account id committed

mw-dev AWS account id comes from the `MW_DEV_ACCOUNT_ID` secret; all ARNs (e2e role, CP pod-identity role) are built from it. The same change is applied to `ci.yml`'s iceberg-test ARNs.

## Validated

Green on the real mw-dev cluster end to end: build ✅, deploy ✅, worker boot ✅, SNI routing ✅, catalog selection ✅, STS-brokered cnpg + ext activation ✅, DuckLake + Iceberg R/W ✅, cnpg deprovision ✅, clean teardown (rerun-safe) ✅.

## Open follow-ups (non-blocking)

- Durability (worker-pod kill), concurrency, and network-policy assertions are `SKIP (TODO)` — activation is cleared, so these are the next layer.
- Same-orgID recreate needs synchronous teardown (the async Crossplane DROP lags the CR delete).
- A janitor to sweep stale `duckgres-ci-pr-*` namespaces for runs that die hard.

See `tests/e2e-mw-dev/README.md` for the full writeup.