### PR TITLE
fix(secrets): worker persistent-secret hygiene + DROP passthrough

### DIFF
--- a/duckdbservice/duckdb_pair.go
+++ b/duckdbservice/duckdb_pair.go
@@ -88,6 +88,14 @@ func (*nonClosingConnector) Close() error { return nil }
 // path as openBaseDB (threads, memory_limit, extensions, profiling, cache
 // settings); the Control DB is intentionally minimal.
 func OpenDuckDBPair(cfg server.Config, username string) (*DuckDBPair, error) {
+	// This is the worker-process DB factory (standalone uses server.openBaseDB),
+	// so it's the single place to opt every worker out of DuckDB's persistent
+	// secret storage. Worker secrets are always re-created in-memory at
+	// activation; a persisted copy on the worker's DataDir is never durable
+	// across a recycle and only invites "secret occurs in multiple storage
+	// backends" ambiguity. ConfigureMainDB (below) applies the setting.
+	cfg.DisablePersistentSecrets = true
+
 	dsn, err := server.DuckDBDSN(cfg, username)
 	if err != nil {
 		return nil, err

--- a/duckdbservice/duckdb_pair.go
+++ b/duckdbservice/duckdb_pair.go
@@ -89,12 +89,14 @@ func (*nonClosingConnector) Close() error { return nil }
 // settings); the Control DB is intentionally minimal.
 func OpenDuckDBPair(cfg server.Config, username string) (*DuckDBPair, error) {
 	// This is the worker-process DB factory (standalone uses server.openBaseDB),
-	// so it's the single place to opt every worker out of DuckDB's persistent
-	// secret storage. Worker secrets are always re-created in-memory at
-	// activation; a persisted copy on the worker's DataDir is never durable
-	// across a recycle and only invites "secret occurs in multiple storage
-	// backends" ambiguity. ConfigureMainDB (below) applies the setting.
-	cfg.DisablePersistentSecrets = true
+	// so it's the single place to pin every worker's persistent-secret directory
+	// under DataDir. That makes the location deterministic and wipeable on
+	// recycle, and stops stale secrets in DuckDB's $HOME default from loading and
+	// colliding with the in-memory secrets re-created at activation.
+	// ConfigureMainDB (below) applies the setting. (We do NOT disable persistent
+	// secrets outright: that breaks the DuckLake ATTACH path, which needs the
+	// local_file secret storage registered.)
+	cfg.PinSecretDirectory = true
 
 	dsn, err := server.DuckDBDSN(cfg, username)
 	if err != nil {

--- a/duckdbservice/secret_recycle_test.go
+++ b/duckdbservice/secret_recycle_test.go
@@ -1,0 +1,106 @@
+package duckdbservice
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/posthog/duckgres/server"
+)
+
+// TestWipePersistedSecretsOnRecycle is the unit-level guard for the
+// worker-recycle behavior that Warmup relies on: a CREATE PERSISTENT SECRET
+// left on disk by a prior worker incarnation must not survive into the next
+// one. We do it here rather than in tests/k8s because the meaningful boundary
+// is a *process restart over a surviving DataDir* (container restart within a
+// pod, or a persistent volume / warm node). A tests/k8s pod-kill would be
+// vacuous: worker DataDir is an EmptyDir, so pod replacement already yields a
+// fresh empty /data and the test would pass even with the wipe removed.
+//
+// The test is explicitly non-vacuous: the middle phase asserts the persistent
+// secret *does* survive a plain reopen (the original bug), and only the final
+// phase — after wipePersistedSecrets — asserts it is gone (the fix).
+func TestWipePersistedSecretsOnRecycle(t *testing.T) {
+	cfg := server.Config{DataDir: t.TempDir()}
+	secretDir := server.SecretDirectory(cfg)
+	if secretDir == "" {
+		t.Fatal("SecretDirectory returned empty for a non-empty DataDir")
+	}
+
+	const secretName = "test_recycle_secret"
+
+	// open applies the same secret_directory pinning the production worker uses
+	// (server.ConfigureMainDB) and returns the DB. Caller closes it.
+	open := func() *sql.DB {
+		t.Helper()
+		db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
+		if err != nil {
+			t.Fatalf("open duckdb: %v", err)
+		}
+		if err := server.ConfigureMainDB(db, cfg, "tester"); err != nil {
+			_ = db.Close()
+			t.Fatalf("ConfigureMainDB: %v", err)
+		}
+		return db
+	}
+
+	persistentSecretCount := func(db *sql.DB) int {
+		t.Helper()
+		var n int
+		if err := db.QueryRow(
+			"SELECT count(*) FROM duckdb_secrets() WHERE name = ? AND persistent",
+			secretName,
+		).Scan(&n); err != nil {
+			t.Fatalf("query duckdb_secrets: %v", err)
+		}
+		return n
+	}
+
+	// Phase 1: create a persistent secret. It should land on disk under the
+	// pinned secret_directory.
+	db := open()
+	if _, err := db.Exec(
+		"CREATE PERSISTENT SECRET " + secretName + " (TYPE s3, KEY_ID 'a', SECRET 'b')",
+	); err != nil {
+		t.Fatalf("create persistent secret: %v", err)
+	}
+	if got := persistentSecretCount(db); got != 1 {
+		t.Fatalf("after create: persistent secret count = %d, want 1", got)
+	}
+	_ = db.Close()
+
+	entries, err := os.ReadDir(secretDir)
+	if err != nil {
+		t.Fatalf("read secret_directory: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("secret_directory %s is empty; persistent secret was not written to disk", secretDir)
+	}
+
+	// Phase 2 (non-vacuous control): reopen WITHOUT recycling. The persistent
+	// secret must reload from disk — this is exactly the state that, combined
+	// with the in-memory secret re-created at activation, produces the
+	// "secret occurs in multiple storage backends" ambiguity in production.
+	db = open()
+	if got := persistentSecretCount(db); got != 1 {
+		t.Fatalf("after plain reopen: persistent secret count = %d, want 1 "+
+			"(test is vacuous if the secret didn't survive a reopen)", got)
+	}
+	_ = db.Close()
+
+	// Phase 3: recycle. This is the exact call Warmup makes on worker startup.
+	wipePersistedSecrets(cfg)
+	if _, err := os.Stat(secretDir); !os.IsNotExist(err) {
+		t.Fatalf("secret_directory still exists after wipe (stat err = %v)", err)
+	}
+
+	// Phase 4: reopen after recycle. The persistent secret must be gone.
+	db = open()
+	if got := persistentSecretCount(db); got != 0 {
+		t.Fatalf("after recycle: persistent secret count = %d, want 0 "+
+			"(wipePersistedSecrets did not prevent resurrection)", got)
+	}
+	_ = db.Close()
+}

--- a/duckdbservice/secret_recycle_test.go
+++ b/duckdbservice/secret_recycle_test.go
@@ -33,10 +33,10 @@ func TestWipePersistedSecretsOnRecycle(t *testing.T) {
 	const secretName = "test_recycle_secret"
 
 	// open returns a DB pinned at the same secret_directory the worker uses.
-	// We pin it directly here rather than via ConfigureMainDB because this test
-	// exercises the wipe mechanism in isolation, and it needs persistent secrets
-	// *enabled* to create one to wipe — whereas the production worker config
-	// (DisablePersistentSecrets) both pins and disables. Caller closes the DB.
+	// We pin it directly here rather than via ConfigureMainDB(PinSecretDirectory)
+	// because this test exercises the wipe mechanism in isolation; pinning the
+	// directory is all that's needed to land a persistent secret where the wipe
+	// will look for it. Caller closes the DB.
 	open := func() *sql.DB {
 		t.Helper()
 		db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")

--- a/duckdbservice/secret_recycle_test.go
+++ b/duckdbservice/secret_recycle_test.go
@@ -86,7 +86,7 @@ func TestWipePersistedSecretsOnRecycle(t *testing.T) {
 	// Also plant a file in the legacy default location (<DataDir>/.duckdb/
 	// stored_secrets) — where a worker whose HOME is its DataDir accumulated
 	// secrets before we pinned secret_directory. The recycle must clear this too.
-	legacyDir := filepath.Join(cfg.DataDir, ".duckdb", "stored_secrets")
+	legacyDir := server.LegacySecretDirectory(cfg)
 	if err := os.MkdirAll(legacyDir, 0o750); err != nil {
 		t.Fatalf("mkdir legacy secret dir: %v", err)
 	}

--- a/duckdbservice/secret_recycle_test.go
+++ b/duckdbservice/secret_recycle_test.go
@@ -3,6 +3,7 @@ package duckdbservice
 import (
 	"database/sql"
 	"os"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
@@ -79,6 +80,18 @@ func TestWipePersistedSecretsOnRecycle(t *testing.T) {
 		t.Fatalf("secret_directory %s is empty; persistent secret was not written to disk", secretDir)
 	}
 
+	// Also plant a file in the legacy default location (<DataDir>/.duckdb/
+	// stored_secrets) — where a worker whose HOME is its DataDir accumulated
+	// secrets before we pinned secret_directory. The recycle must clear this too.
+	legacyDir := filepath.Join(cfg.DataDir, ".duckdb", "stored_secrets")
+	if err := os.MkdirAll(legacyDir, 0o750); err != nil {
+		t.Fatalf("mkdir legacy secret dir: %v", err)
+	}
+	legacyFile := filepath.Join(legacyDir, "old_secret.duckdb_secret")
+	if err := os.WriteFile(legacyFile, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write legacy secret file: %v", err)
+	}
+
 	// Phase 2 (non-vacuous control): reopen WITHOUT recycling. The persistent
 	// secret must reload from disk — this is exactly the state that, combined
 	// with the in-memory secret re-created at activation, produces the
@@ -94,6 +107,9 @@ func TestWipePersistedSecretsOnRecycle(t *testing.T) {
 	wipePersistedSecrets(cfg)
 	if _, err := os.Stat(secretDir); !os.IsNotExist(err) {
 		t.Fatalf("secret_directory still exists after wipe (stat err = %v)", err)
+	}
+	if _, err := os.Stat(legacyFile); !os.IsNotExist(err) {
+		t.Fatalf("legacy secret file still exists after wipe (stat err = %v)", err)
 	}
 
 	// Phase 4: reopen after recycle. The persistent secret must be gone.

--- a/duckdbservice/secret_recycle_test.go
+++ b/duckdbservice/secret_recycle_test.go
@@ -32,17 +32,20 @@ func TestWipePersistedSecretsOnRecycle(t *testing.T) {
 
 	const secretName = "test_recycle_secret"
 
-	// open applies the same secret_directory pinning the production worker uses
-	// (server.ConfigureMainDB) and returns the DB. Caller closes it.
+	// open returns a DB pinned at the same secret_directory the worker uses.
+	// We pin it directly here rather than via ConfigureMainDB because this test
+	// exercises the wipe mechanism in isolation, and it needs persistent secrets
+	// *enabled* to create one to wipe — whereas the production worker config
+	// (DisablePersistentSecrets) both pins and disables. Caller closes the DB.
 	open := func() *sql.DB {
 		t.Helper()
 		db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
 		if err != nil {
 			t.Fatalf("open duckdb: %v", err)
 		}
-		if err := server.ConfigureMainDB(db, cfg, "tester"); err != nil {
+		if _, err := db.Exec("SET secret_directory = '" + secretDir + "'"); err != nil {
 			_ = db.Close()
-			t.Fatalf("ConfigureMainDB: %v", err)
+			t.Fatalf("set secret_directory: %v", err)
 		}
 		return db
 	}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -156,6 +156,23 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 	}
 }
 
+// wipePersistedSecrets removes DuckDB's persistent-secret directory for this
+// config (server.SecretDirectory, pinned under DataDir). Called on worker
+// startup so persisted secrets never survive a recycle. Best-effort: a failure
+// is logged, not fatal — a stale secret is a correctness annoyance, not a
+// reason to refuse to start. No-op when no DataDir is configured.
+func wipePersistedSecrets(cfg server.Config) {
+	secretDir := server.SecretDirectory(cfg)
+	if secretDir == "" {
+		return
+	}
+	if err := os.RemoveAll(secretDir); err != nil {
+		slog.Warn("Failed to wipe persisted secret directory on worker startup.", "secret_directory", secretDir, "error", err)
+		return
+	}
+	slog.Info("Wiped persisted secret directory on worker startup.", "secret_directory", secretDir)
+}
+
 // Warmup performs one-time initialization of the shared DuckDB instance.
 // This loads extensions and attaches catalogs so that subsequent session
 // creations are nearly instantaneous.
@@ -169,18 +186,17 @@ func (p *SessionPool) Warmup() error {
 	// Recycle hook: a worker process starting up is the boundary between one
 	// tenant runtime and the next on this disk (a serverless/shared-warm worker
 	// is single-org-bound for its whole life, so process start == recycle).
-	// Nuke any persisted secrets left on disk before DuckDB's SecretManager
+	// Wipe any persisted secrets left on disk before DuckDB's SecretManager
 	// reads them, so a CREATE PERSISTENT SECRET from a prior incarnation can't
 	// resurface and collide with the in-memory secret re-created at activation,
-	// and can't leak across tenants. secret_directory is pinned under DataDir by
-	// server.ConfigureMainDB; we wipe that same path here.
-	if secretDir := server.SecretDirectory(p.cfg); secretDir != "" {
-		if err := os.RemoveAll(secretDir); err != nil {
-			slog.Warn("Failed to wipe persisted secret directory on worker startup.", "secret_directory", secretDir, "error", err)
-		} else {
-			slog.Info("Wiped persisted secret directory on worker startup.", "secret_directory", secretDir)
-		}
-	}
+	// and can't leak across tenants.
+	//
+	// This matters whenever DataDir survives across worker processes: a
+	// container restart within the same pod (EmptyDir survives that — it's only
+	// destroyed on pod deletion), or any persistent-volume / warm-node setup. On
+	// a fresh pod with a fresh EmptyDir the directory is already empty and this
+	// is a no-op.
+	wipePersistedSecrets(p.cfg)
 
 	start := time.Now()
 	slog.Info("Pre-warming worker DuckDB instance...")

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,7 +176,7 @@ func wipePersistedSecrets(cfg server.Config) {
 	}
 	dirs := []string{
 		server.SecretDirectory(cfg),
-		filepath.Join(cfg.DataDir, ".duckdb", "stored_secrets"),
+		server.LegacySecretDirectory(cfg),
 	}
 	for _, dir := range dirs {
 		if dir == "" {

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -156,21 +157,38 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 	}
 }
 
-// wipePersistedSecrets removes DuckDB's persistent-secret directory for this
-// config (server.SecretDirectory, pinned under DataDir). Called on worker
-// startup so persisted secrets never survive a recycle. Best-effort: a failure
-// is logged, not fatal — a stale secret is a correctness annoyance, not a
-// reason to refuse to start. No-op when no DataDir is configured.
+// wipePersistedSecrets removes DuckDB's persistent-secret directories for this
+// config. Called on worker startup so persisted secrets never survive a
+// recycle. Best-effort: a failure is logged, not fatal — a stale secret is a
+// correctness annoyance, not a reason to refuse to start. No-op when no DataDir
+// is configured.
+//
+// We wipe two locations:
+//   - the pinned secret_directory (server.SecretDirectory), where new secrets
+//     would land under the current config, and
+//   - the legacy DuckDB default <DataDir>/.duckdb/stored_secrets, which is where
+//     secrets accumulated before we pinned the directory (a worker whose
+//     HOME is its DataDir resolves DuckDB's default there). Without this, the
+//     historical files that caused the original ambiguity would linger on a
+//     persistent DataDir forever.
 func wipePersistedSecrets(cfg server.Config) {
-	secretDir := server.SecretDirectory(cfg)
-	if secretDir == "" {
+	if cfg.DataDir == "" {
 		return
 	}
-	if err := os.RemoveAll(secretDir); err != nil {
-		slog.Warn("Failed to wipe persisted secret directory on worker startup.", "secret_directory", secretDir, "error", err)
-		return
+	dirs := []string{
+		server.SecretDirectory(cfg),
+		filepath.Join(cfg.DataDir, ".duckdb", "stored_secrets"),
 	}
-	slog.Info("Wiped persisted secret directory on worker startup.", "secret_directory", secretDir)
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			slog.Warn("Failed to wipe persisted secret directory on worker startup.", "secret_directory", dir, "error", err)
+			continue
+		}
+		slog.Info("Wiped persisted secret directory on worker startup.", "secret_directory", dir)
+	}
 }
 
 // Warmup performs one-time initialization of the shared DuckDB instance.

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -166,6 +166,22 @@ func (p *SessionPool) Warmup() error {
 		return nil
 	}
 
+	// Recycle hook: a worker process starting up is the boundary between one
+	// tenant runtime and the next on this disk (a serverless/shared-warm worker
+	// is single-org-bound for its whole life, so process start == recycle).
+	// Nuke any persisted secrets left on disk before DuckDB's SecretManager
+	// reads them, so a CREATE PERSISTENT SECRET from a prior incarnation can't
+	// resurface and collide with the in-memory secret re-created at activation,
+	// and can't leak across tenants. secret_directory is pinned under DataDir by
+	// server.ConfigureMainDB; we wipe that same path here.
+	if secretDir := server.SecretDirectory(p.cfg); secretDir != "" {
+		if err := os.RemoveAll(secretDir); err != nil {
+			slog.Warn("Failed to wipe persisted secret directory on worker startup.", "secret_directory", secretDir, "error", err)
+		} else {
+			slog.Info("Wiped persisted secret directory on worker startup.", "secret_directory", secretDir)
+		}
+	}
+
 	start := time.Now()
 	slog.Info("Pre-warming worker DuckDB instance...")
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -879,10 +879,13 @@ func isDuckDBUtilityCommand(query string) bool {
 		"DROP SECRET",
 		// DuckDB's own disambiguation hint for a secret that exists in more
 		// than one storage backend is "DROP <PERSISTENT|TEMPORARY> SECRET ...".
-		// Those variants don't start with "DROP SECRET", so without these
-		// explicit prefixes they fall through to the PG transpiler and die with
-		// `syntax error at or near "PERSISTENT"` — i.e. the exact command DuckDB
-		// tells the user to run is unrunnable. Pass them straight through.
+		// Those variants don't start with "DROP SECRET" (the next token is
+		// PERSISTENT/TEMPORARY), so without these explicit prefixes they fall
+		// through to the PG transpiler and die with `syntax error at or near
+		// "PERSISTENT"` — i.e. the exact command DuckDB tells the user to run is
+		// unrunnable. Pass them straight through. (List order is irrelevant:
+		// matching is by string prefix, and "DROP SECRET" is not a prefix of
+		// "DROP PERSISTENT SECRET", so the two never collide.)
 		"DROP PERSISTENT SECRET",
 		"DROP TEMPORARY SECRET",
 		"CREATE PERSISTENT SECRET",

--- a/server/conn.go
+++ b/server/conn.go
@@ -877,6 +877,14 @@ func isDuckDBUtilityCommand(query string) bool {
 		"UNLOAD",
 		"CREATE SECRET",
 		"DROP SECRET",
+		// DuckDB's own disambiguation hint for a secret that exists in more
+		// than one storage backend is "DROP <PERSISTENT|TEMPORARY> SECRET ...".
+		// Those variants don't start with "DROP SECRET", so without these
+		// explicit prefixes they fall through to the PG transpiler and die with
+		// `syntax error at or near "PERSISTENT"` — i.e. the exact command DuckDB
+		// tells the user to run is unrunnable. Pass them straight through.
+		"DROP PERSISTENT SECRET",
+		"DROP TEMPORARY SECRET",
 		"CREATE PERSISTENT SECRET",
 		"CREATE TEMPORARY SECRET",
 		"CREATE OR REPLACE SECRET",

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -21,6 +21,43 @@ import (
 	"github.com/posthog/duckgres/server/wire"
 )
 
+func TestIsDuckDBUtilityCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		// Secret DDL must bypass the PG transpiler — DuckDB-only syntax.
+		{"create secret", `CREATE SECRET foo (TYPE s3)`, true},
+		{"create or replace secret", `CREATE OR REPLACE SECRET foo (TYPE s3)`, true},
+		{"drop secret", `DROP SECRET foo`, true},
+		{"drop secret if exists", `DROP SECRET IF EXISTS foo`, true},
+		// Regression: DuckDB's own ambiguity hint is "DROP <PERSISTENT|TEMPORARY>
+		// SECRET ...". These don't start with "DROP SECRET", so before the fix
+		// they fell through to pg_query and failed with a syntax error on the
+		// PERSISTENT/TEMPORARY keyword.
+		{"drop persistent secret", `DROP PERSISTENT SECRET foo`, true},
+		{"drop persistent secret if exists quoted", `DROP PERSISTENT SECRET IF EXISTS "portola_warehouse_prod_s3"`, true},
+		{"drop temporary secret", `DROP TEMPORARY SECRET foo`, true},
+		{"drop temporary secret if exists", `DROP TEMPORARY SECRET IF EXISTS foo`, true},
+		{"case insensitive", `drop persistent secret foo`, true},
+		{"leading comment", "-- cleanup\nDROP PERSISTENT SECRET foo", true},
+		// Not utility commands — must still go through the transpiler.
+		{"select", `SELECT * FROM duckdb_secrets()`, false},
+		{"drop table", `DROP TABLE foo`, false},
+		// Guard the word-boundary check: a name that merely starts with the
+		// keyword text must not be mistaken for the command.
+		{"drop secretive table", `DROP TABLE secretive`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDuckDBUtilityCommand(tt.query); got != tt.want {
+				t.Errorf("isDuckDBUtilityCommand(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsEmptyQuery(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/persistent_secrets_test.go
+++ b/server/persistent_secrets_test.go
@@ -56,11 +56,17 @@ func TestDisablePersistentSecrets(t *testing.T) {
 		t.Errorf("seeded persistent secret was loaded (count=%d); allow_persistent_secrets=false should prevent it", loaded)
 	}
 
-	// (a) CREATE PERSISTENT SECRET must be rejected.
-	if _, err := db.Exec("CREATE PERSISTENT SECRET nope (TYPE s3, KEY_ID 'a', SECRET 'b')"); err == nil {
-		t.Error("CREATE PERSISTENT SECRET succeeded; expected it to be rejected when persistent secrets are disabled")
-	} else if !strings.Contains(strings.ToLower(err.Error()), "persistent secrets are disabled") {
-		t.Errorf("CREATE PERSISTENT SECRET rejected, but not for the expected reason: %v", err)
+	// (a) CREATE PERSISTENT SECRET must be rejected — including the OR REPLACE
+	// variant, which is what most callers actually write.
+	for _, stmt := range []string{
+		"CREATE PERSISTENT SECRET nope (TYPE s3, KEY_ID 'a', SECRET 'b')",
+		"CREATE OR REPLACE PERSISTENT SECRET nope2 (TYPE s3, KEY_ID 'a', SECRET 'b')",
+	} {
+		if _, err := db.Exec(stmt); err == nil {
+			t.Errorf("%q succeeded; expected rejection when persistent secrets are disabled", stmt)
+		} else if !strings.Contains(strings.ToLower(err.Error()), "persistent secrets are disabled") {
+			t.Errorf("%q rejected, but not for the expected reason: %v", stmt, err)
+		}
 	}
 
 	// A temporary (in-memory) secret — the kind workers actually use — must
@@ -78,5 +84,13 @@ func TestSecretDirectory(t *testing.T) {
 	want := filepath.Join("/data", "secrets")
 	if got := SecretDirectory(Config{DataDir: "/data"}); got != want {
 		t.Errorf("SecretDirectory(/data) = %q, want %q", got, want)
+	}
+
+	if got := LegacySecretDirectory(Config{}); got != "" {
+		t.Errorf("LegacySecretDirectory with empty DataDir = %q, want \"\"", got)
+	}
+	wantLegacy := filepath.Join("/data", ".duckdb", "stored_secrets")
+	if got := LegacySecretDirectory(Config{DataDir: "/data"}); got != wantLegacy {
+		t.Errorf("LegacySecretDirectory(/data) = %q, want %q", got, wantLegacy)
 	}
 }

--- a/server/persistent_secrets_test.go
+++ b/server/persistent_secrets_test.go
@@ -41,7 +41,7 @@ func TestDisablePersistentSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	cfg := Config{DataDir: dir, DisablePersistentSecrets: true}
 	if err := ConfigureMainDB(db, cfg, "worker"); err != nil {
 		t.Fatalf("ConfigureMainDB: %v", err)

--- a/server/persistent_secrets_test.go
+++ b/server/persistent_secrets_test.go
@@ -2,77 +2,91 @@ package server
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
-// TestDisablePersistentSecrets is the regression guard for the worker-side
-// structural fix: with Config.DisablePersistentSecrets set (as
-// duckdbservice.OpenDuckDBPair does for every worker), ConfigureMainDB must
+// TestPinSecretDirectory is the regression guard for the worker-side fix: with
+// Config.PinSecretDirectory set (as duckdbservice.OpenDuckDBPair does for every
+// worker), ConfigureMainDB redirects DuckDB's persistent-secret storage to
+// <DataDir>/secrets. That means:
 //
-//	(a) prevent CREATE PERSISTENT SECRET from succeeding, and
-//	(b) not load any pre-existing on-disk persistent secret,
+//	(a) a CREATE PERSISTENT SECRET lands under <DataDir>/secrets (deterministic,
+//	    wipeable), and
+//	(b) a stale secret sitting in DuckDB's $HOME default is no longer loaded, so
+//	    it can't collide with the in-memory secret re-created at activation.
 //
-// which together make the "secret occurs in multiple storage backends"
-// ambiguity impossible on workers.
-func TestDisablePersistentSecrets(t *testing.T) {
+// We deliberately do NOT disable persistent secrets (that breaks DuckLake's
+// ATTACH, which needs the local_file secret storage registered), so persistent
+// secrets still work — they're just relocated and wiped on recycle.
+func TestPinSecretDirectory(t *testing.T) {
 	dir := t.TempDir()
 	secretDir := SecretDirectory(Config{DataDir: dir})
 
-	// Seed a persistent secret on disk using a normal (persistent-enabled)
-	// connection, so we have a real file to prove (b) against.
-	seed, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
-	if err != nil {
-		t.Fatalf("open seed duckdb: %v", err)
-	}
-	if _, err := seed.Exec("SET secret_directory = '" + secretDir + "'"); err != nil {
-		t.Fatalf("seed set secret_directory: %v", err)
-	}
-	if _, err := seed.Exec("CREATE PERSISTENT SECRET seeded (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
-		t.Fatalf("seed create persistent secret: %v", err)
-	}
-	_ = seed.Close()
-
-	// Now open a worker-style connection: DisablePersistentSecrets = true.
 	db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
 	}
 	defer func() { _ = db.Close() }()
-	cfg := Config{DataDir: dir, DisablePersistentSecrets: true}
+
+	cfg := Config{DataDir: dir, PinSecretDirectory: true}
 	if err := ConfigureMainDB(db, cfg, "worker"); err != nil {
 		t.Fatalf("ConfigureMainDB: %v", err)
 	}
 
-	// (b) the seeded persistent secret must not have been loaded.
+	// (a) a persistent secret must still be creatable and must land under the
+	// pinned directory.
+	if _, err := db.Exec("CREATE PERSISTENT SECRET pinned (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
+		t.Fatalf("create persistent secret: %v", err)
+	}
+	entries, err := os.ReadDir(secretDir)
+	if err != nil {
+		t.Fatalf("read pinned secret_directory %s: %v", secretDir, err)
+	}
+	if len(entries) == 0 {
+		t.Errorf("persistent secret did not land under pinned secret_directory %s", secretDir)
+	}
+}
+
+// TestPinSecretDirectoryIgnoresLegacyDefault proves point (b): a secret written
+// to DuckDB's old $HOME-style default location is not loaded once the directory
+// is pinned elsewhere.
+func TestPinSecretDirectoryIgnoresLegacyDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a persistent secret into the *legacy* location.
+	legacy := LegacySecretDirectory(Config{DataDir: dir})
+	seed, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
+	if err != nil {
+		t.Fatalf("open seed duckdb: %v", err)
+	}
+	if _, err := seed.Exec("SET secret_directory = '" + legacy + "'"); err != nil {
+		t.Fatalf("seed set secret_directory: %v", err)
+	}
+	if _, err := seed.Exec("CREATE PERSISTENT SECRET stale (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
+		t.Fatalf("seed create persistent secret: %v", err)
+	}
+	_ = seed.Close()
+
+	// A worker-style connection pins to <DataDir>/secrets, not the legacy path.
+	db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := ConfigureMainDB(db, Config{DataDir: dir, PinSecretDirectory: true}, "worker"); err != nil {
+		t.Fatalf("ConfigureMainDB: %v", err)
+	}
+
 	var loaded int
-	if err := db.QueryRow("SELECT count(*) FROM duckdb_secrets() WHERE name = 'seeded'").Scan(&loaded); err != nil {
+	if err := db.QueryRow("SELECT count(*) FROM duckdb_secrets() WHERE name = 'stale'").Scan(&loaded); err != nil {
 		t.Fatalf("query duckdb_secrets: %v", err)
 	}
 	if loaded != 0 {
-		t.Errorf("seeded persistent secret was loaded (count=%d); allow_persistent_secrets=false should prevent it", loaded)
-	}
-
-	// (a) CREATE PERSISTENT SECRET must be rejected — including the OR REPLACE
-	// variant, which is what most callers actually write.
-	for _, stmt := range []string{
-		"CREATE PERSISTENT SECRET nope (TYPE s3, KEY_ID 'a', SECRET 'b')",
-		"CREATE OR REPLACE PERSISTENT SECRET nope2 (TYPE s3, KEY_ID 'a', SECRET 'b')",
-	} {
-		if _, err := db.Exec(stmt); err == nil {
-			t.Errorf("%q succeeded; expected rejection when persistent secrets are disabled", stmt)
-		} else if !strings.Contains(strings.ToLower(err.Error()), "persistent secrets are disabled") {
-			t.Errorf("%q rejected, but not for the expected reason: %v", stmt, err)
-		}
-	}
-
-	// A temporary (in-memory) secret — the kind workers actually use — must
-	// still work, so the disable doesn't break activation.
-	if _, err := db.Exec("CREATE OR REPLACE SECRET inmem (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
-		t.Errorf("in-memory CREATE OR REPLACE SECRET failed: %v", err)
+		t.Errorf("stale secret in the legacy location was loaded (count=%d); pinning should redirect away from it", loaded)
 	}
 }
 

--- a/server/persistent_secrets_test.go
+++ b/server/persistent_secrets_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// TestDisablePersistentSecrets is the regression guard for the worker-side
+// structural fix: with Config.DisablePersistentSecrets set (as
+// duckdbservice.OpenDuckDBPair does for every worker), ConfigureMainDB must
+//
+//	(a) prevent CREATE PERSISTENT SECRET from succeeding, and
+//	(b) not load any pre-existing on-disk persistent secret,
+//
+// which together make the "secret occurs in multiple storage backends"
+// ambiguity impossible on workers.
+func TestDisablePersistentSecrets(t *testing.T) {
+	dir := t.TempDir()
+	secretDir := SecretDirectory(Config{DataDir: dir})
+
+	// Seed a persistent secret on disk using a normal (persistent-enabled)
+	// connection, so we have a real file to prove (b) against.
+	seed, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
+	if err != nil {
+		t.Fatalf("open seed duckdb: %v", err)
+	}
+	if _, err := seed.Exec("SET secret_directory = '" + secretDir + "'"); err != nil {
+		t.Fatalf("seed set secret_directory: %v", err)
+	}
+	if _, err := seed.Exec("CREATE PERSISTENT SECRET seeded (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
+		t.Fatalf("seed create persistent secret: %v", err)
+	}
+	_ = seed.Close()
+
+	// Now open a worker-style connection: DisablePersistentSecrets = true.
+	db, err := sql.Open("duckdb", ":memory:?allow_unsigned_extensions=true")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	cfg := Config{DataDir: dir, DisablePersistentSecrets: true}
+	if err := ConfigureMainDB(db, cfg, "worker"); err != nil {
+		t.Fatalf("ConfigureMainDB: %v", err)
+	}
+
+	// (b) the seeded persistent secret must not have been loaded.
+	var loaded int
+	if err := db.QueryRow("SELECT count(*) FROM duckdb_secrets() WHERE name = 'seeded'").Scan(&loaded); err != nil {
+		t.Fatalf("query duckdb_secrets: %v", err)
+	}
+	if loaded != 0 {
+		t.Errorf("seeded persistent secret was loaded (count=%d); allow_persistent_secrets=false should prevent it", loaded)
+	}
+
+	// (a) CREATE PERSISTENT SECRET must be rejected.
+	if _, err := db.Exec("CREATE PERSISTENT SECRET nope (TYPE s3, KEY_ID 'a', SECRET 'b')"); err == nil {
+		t.Error("CREATE PERSISTENT SECRET succeeded; expected it to be rejected when persistent secrets are disabled")
+	} else if !strings.Contains(strings.ToLower(err.Error()), "persistent secrets are disabled") {
+		t.Errorf("CREATE PERSISTENT SECRET rejected, but not for the expected reason: %v", err)
+	}
+
+	// A temporary (in-memory) secret — the kind workers actually use — must
+	// still work, so the disable doesn't break activation.
+	if _, err := db.Exec("CREATE OR REPLACE SECRET inmem (TYPE s3, KEY_ID 'a', SECRET 'b')"); err != nil {
+		t.Errorf("in-memory CREATE OR REPLACE SECRET failed: %v", err)
+	}
+}
+
+// TestSecretDirectory documents the path derivation the wipe and pinning rely on.
+func TestSecretDirectory(t *testing.T) {
+	if got := SecretDirectory(Config{}); got != "" {
+		t.Errorf("SecretDirectory with empty DataDir = %q, want \"\"", got)
+	}
+	want := filepath.Join("/data", "secrets")
+	if got := SecretDirectory(Config{DataDir: "/data"}); got != want {
+		t.Errorf("SecretDirectory(/data) = %q, want %q", got, want)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -912,29 +912,35 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 		return fmt.Errorf("failed to configure extension_directory: %w", err)
 	}
 
-	// Pin persistent secrets to a known, per-worker location under DataDir
-	// instead of DuckDB's default ($HOME/.duckdb/stored_secrets). secret_directory
-	// is a global DuckDB setting, so applying it on the main connection covers
-	// the shared SecretManager (main + control). This both makes the persisted
-	// state predictable and lets the worker wipe it on recycle. As a side
-	// benefit, redirecting the directory means any pre-existing stale secrets in
-	// the old default path stop being loaded, so they can no longer collide with
-	// the in-memory secrets re-created at activation.
-	if secretDir := SecretDirectory(cfg); secretDir != "" {
-		if _, err := db.Exec(fmt.Sprintf("SET secret_directory = '%s'", secretDir)); err != nil {
-			slog.Warn("Failed to set DuckDB secret_directory.", "secret_directory", secretDir, "error", err)
-		} else {
-			slog.Debug("Set DuckDB secret_directory.", "secret_directory", secretDir)
-		}
-	}
-
-	// On workers, turn off persistent secret storage entirely. This must run
-	// before the SecretManager's first use (it does — ConfigureMainDB is applied
-	// right after open, before any ATTACH or CREATE SECRET). It both prevents
-	// CREATE PERSISTENT SECRET (which would write a landmine to DataDir) and
-	// stops any pre-existing on-disk secret from being loaded, so it can never
-	// collide with the in-memory secret re-created at activation.
+	// Worker secret hardening — gated to workers (DisablePersistentSecrets, set
+	// by duckdbservice.OpenDuckDBPair). Standalone is intentionally left alone:
+	// it keeps DuckDB's default secret store ($HOME/.duckdb/stored_secrets) and
+	// its ability to use persistent secrets, so an upgrade doesn't silently
+	// relocate an existing standalone user's secrets.
+	//
+	// Both SETs must run before the SecretManager's first use — they do, since
+	// ConfigureMainDB is applied right after open, before any ATTACH or CREATE
+	// SECRET. secret_directory and allow_persistent_secrets are global DuckDB
+	// settings, so applying them on the main connection covers the shared
+	// SecretManager (main + control).
 	if cfg.DisablePersistentSecrets {
+		// Pin persistent secrets to a known, per-worker location under DataDir
+		// instead of DuckDB's $HOME default: deterministic and wipeable on
+		// recycle. (Largely belt-and-suspenders given the disable below, but it
+		// keeps the location predictable if persistent secrets are ever
+		// re-enabled.)
+		if secretDir := SecretDirectory(cfg); secretDir != "" {
+			if _, err := db.Exec(fmt.Sprintf("SET secret_directory = '%s'", secretDir)); err != nil {
+				slog.Warn("Failed to set DuckDB secret_directory.", "secret_directory", secretDir, "error", err)
+			} else {
+				slog.Debug("Set DuckDB secret_directory.", "secret_directory", secretDir)
+			}
+		}
+
+		// Turn off persistent secret storage entirely. This both prevents
+		// CREATE PERSISTENT SECRET (which would write a landmine to DataDir) and
+		// stops any pre-existing on-disk secret from being loaded, so it can
+		// never collide with the in-memory secret re-created at activation.
 		if _, err := db.Exec("SET allow_persistent_secrets = false"); err != nil {
 			slog.Warn("Failed to disable DuckDB persistent secrets.", "error", err)
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -266,15 +266,21 @@ type Config struct {
 	// while TLS, authentication, and query execution happen in child processes.
 	ProcessIsolation bool
 
-	// DisablePersistentSecrets turns off DuckDB's persistent secret storage
-	// (allow_persistent_secrets=false): existing on-disk secrets are not loaded
-	// at startup and CREATE PERSISTENT SECRET is rejected. Set for worker
-	// processes (see duckdbservice.OpenDuckDBPair), where secrets are always
-	// re-created in-memory at activation and a persisted copy on the worker's
-	// DataDir is never durable across recycles — only a latent source of
-	// "secret occurs in multiple storage backends" ambiguity. Left false for
-	// standalone, which may legitimately rely on persistent secrets.
-	DisablePersistentSecrets bool
+	// PinSecretDirectory pins DuckDB's persistent-secret directory under DataDir
+	// (<DataDir>/secrets) instead of DuckDB's $HOME default. Set for worker
+	// processes (see duckdbservice.OpenDuckDBPair): it makes the persisted-secret
+	// location deterministic and wipeable on recycle, and — by redirecting away
+	// from the $HOME default — stops stale secrets in the old location from being
+	// loaded and colliding with the in-memory secrets re-created at activation.
+	// Left false for standalone, so upgrading doesn't relocate an existing
+	// standalone user's persistent secrets.
+	//
+	// Note: we deliberately do NOT also set allow_persistent_secrets=false.
+	// Disabling persistent secrets unregisters DuckDB's local_file secret
+	// storage backend, which the DuckLake ATTACH path depends on ("Unknown
+	// secret storage found: 'local_file'") — so the directory pinning plus the
+	// recycle wipe is how workers stay clean.
+	PinSecretDirectory bool
 
 	// MemoryLimit is the DuckDB memory_limit per session (e.g., "4GB").
 	// If empty, auto-detected from system memory.
@@ -924,39 +930,25 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 		return fmt.Errorf("failed to configure extension_directory: %w", err)
 	}
 
-	// Worker secret hardening — gated to workers (DisablePersistentSecrets, set
-	// by duckdbservice.OpenDuckDBPair). Standalone is intentionally left alone:
-	// it keeps DuckDB's default secret store ($HOME/.duckdb/stored_secrets) and
-	// its ability to use persistent secrets, so an upgrade doesn't silently
-	// relocate an existing standalone user's secrets.
+	// Pin the persistent-secret directory under DataDir on workers
+	// (PinSecretDirectory, set by duckdbservice.OpenDuckDBPair). secret_directory
+	// is a global DuckDB setting, and this must run before the SecretManager's
+	// first use — it does, since ConfigureMainDB is applied right after open,
+	// before any ATTACH or CREATE SECRET. Standalone is left at DuckDB's $HOME
+	// default so an upgrade doesn't relocate an existing user's secrets.
 	//
-	// Both SETs must run before the SecretManager's first use — they do, since
-	// ConfigureMainDB is applied right after open, before any ATTACH or CREATE
-	// SECRET. secret_directory and allow_persistent_secrets are global DuckDB
-	// settings, so applying them on the main connection covers the shared
-	// SecretManager (main + control).
-	if cfg.DisablePersistentSecrets {
-		// Pin persistent secrets to a known, per-worker location under DataDir
-		// instead of DuckDB's $HOME default: deterministic and wipeable on
-		// recycle. (Largely belt-and-suspenders given the disable below, but it
-		// keeps the location predictable if persistent secrets are ever
-		// re-enabled.)
+	// We intentionally do NOT disable persistent secrets here
+	// (allow_persistent_secrets=false): that unregisters DuckDB's local_file
+	// secret storage, which the DuckLake ATTACH path requires. Pinning +
+	// the recycle wipe (see duckdbservice.wipePersistedSecrets) is what keeps
+	// workers from accumulating stale persisted secrets.
+	if cfg.PinSecretDirectory {
 		if secretDir := SecretDirectory(cfg); secretDir != "" {
 			if _, err := db.Exec(fmt.Sprintf("SET secret_directory = '%s'", secretDir)); err != nil {
 				slog.Warn("Failed to set DuckDB secret_directory.", "secret_directory", secretDir, "error", err)
 			} else {
 				slog.Debug("Set DuckDB secret_directory.", "secret_directory", secretDir)
 			}
-		}
-
-		// Turn off persistent secret storage entirely. This both prevents
-		// CREATE PERSISTENT SECRET (which would write a landmine to DataDir) and
-		// stops any pre-existing on-disk secret from being loaded, so it can
-		// never collide with the in-memory secret re-created at activation.
-		if _, err := db.Exec("SET allow_persistent_secrets = false"); err != nil {
-			slog.Warn("Failed to disable DuckDB persistent secrets.", "error", err)
-		} else {
-			slog.Debug("Disabled DuckDB persistent secrets.")
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -266,6 +266,16 @@ type Config struct {
 	// while TLS, authentication, and query execution happen in child processes.
 	ProcessIsolation bool
 
+	// DisablePersistentSecrets turns off DuckDB's persistent secret storage
+	// (allow_persistent_secrets=false): existing on-disk secrets are not loaded
+	// at startup and CREATE PERSISTENT SECRET is rejected. Set for worker
+	// processes (see duckdbservice.OpenDuckDBPair), where secrets are always
+	// re-created in-memory at activation and a persisted copy on the worker's
+	// DataDir is never durable across recycles — only a latent source of
+	// "secret occurs in multiple storage backends" ambiguity. Left false for
+	// standalone, which may legitimately rely on persistent secrets.
+	DisablePersistentSecrets bool
+
 	// MemoryLimit is the DuckDB memory_limit per session (e.g., "4GB").
 	// If empty, auto-detected from system memory.
 	MemoryLimit string
@@ -915,6 +925,20 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 			slog.Warn("Failed to set DuckDB secret_directory.", "secret_directory", secretDir, "error", err)
 		} else {
 			slog.Debug("Set DuckDB secret_directory.", "secret_directory", secretDir)
+		}
+	}
+
+	// On workers, turn off persistent secret storage entirely. This must run
+	// before the SecretManager's first use (it does — ConfigureMainDB is applied
+	// right after open, before any ATTACH or CREATE SECRET). It both prevents
+	// CREATE PERSISTENT SECRET (which would write a landmine to DataDir) and
+	// stops any pre-existing on-disk secret from being loaded, so it can never
+	// collide with the in-memory secret re-created at activation.
+	if cfg.DisablePersistentSecrets {
+		if _, err := db.Exec("SET allow_persistent_secrets = false"); err != nil {
+			slog.Warn("Failed to disable DuckDB persistent secrets.", "error", err)
+		} else {
+			slog.Debug("Disabled DuckDB persistent secrets.")
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -843,6 +843,24 @@ func DuckDBDSN(cfg Config, username string) (string, error) {
 	return dsn, nil
 }
 
+// SecretDirectory returns the directory DuckDB should use for persistent
+// secrets for this instance, or "" to leave DuckDB's default in place.
+//
+// DuckDB defaults persistent secrets to $HOME/.duckdb/stored_secrets,
+// independent of the database file. On a worker that means a CREATE PERSISTENT
+// SECRET lands in whatever $HOME the process happens to have and survives
+// across restarts on any non-ephemeral disk — long after the in-memory secret
+// of the same name (recreated each activation) gets re-added, which is exactly
+// what produces DuckDB's "secret occurs in multiple storage backends"
+// ambiguity errors. Pinning it under DataDir makes the location deterministic
+// and, crucially, wipeable on worker recycle (see duckdbservice.Warmup).
+func SecretDirectory(cfg Config) string {
+	if cfg.DataDir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.DataDir, "secrets")
+}
+
 // ConfigureMainDB applies the per-instance DuckDB settings (threads, memory,
 // temp dir, extensions, profiling) that the client-query DB needs. Shared
 // between openBaseDB (single-DB path) and OpenDuckDBPair (shared-connector
@@ -882,6 +900,22 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 
 	if err := setExtensionDirectory(db, cfg.DataDir); err != nil {
 		return fmt.Errorf("failed to configure extension_directory: %w", err)
+	}
+
+	// Pin persistent secrets to a known, per-worker location under DataDir
+	// instead of DuckDB's default ($HOME/.duckdb/stored_secrets). secret_directory
+	// is a global DuckDB setting, so applying it on the main connection covers
+	// the shared SecretManager (main + control). This both makes the persisted
+	// state predictable and lets the worker wipe it on recycle. As a side
+	// benefit, redirecting the directory means any pre-existing stale secrets in
+	// the old default path stop being loaded, so they can no longer collide with
+	// the in-memory secrets re-created at activation.
+	if secretDir := SecretDirectory(cfg); secretDir != "" {
+		if _, err := db.Exec(fmt.Sprintf("SET secret_directory = '%s'", secretDir)); err != nil {
+			slog.Warn("Failed to set DuckDB secret_directory.", "secret_directory", secretDir, "error", err)
+		} else {
+			slog.Debug("Set DuckDB secret_directory.", "secret_directory", secretDir)
+		}
 	}
 
 	// Load configured extensions

--- a/server/server.go
+++ b/server/server.go
@@ -871,6 +871,18 @@ func SecretDirectory(cfg Config) string {
 	return filepath.Join(cfg.DataDir, "secrets")
 }
 
+// LegacySecretDirectory returns DuckDB's pre-pinning default persistent-secret
+// location for a worker whose HOME is its DataDir (<DataDir>/.duckdb/stored_secrets).
+// This is where secrets accumulated before SecretDirectory pinning existed, and
+// the only reason it's a named helper is so the recycle wipe and this derivation
+// stay colocated and can't drift apart. Returns "" when DataDir is unset.
+func LegacySecretDirectory(cfg Config) string {
+	if cfg.DataDir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.DataDir, ".duckdb", "stored_secrets")
+}
+
 // ConfigureMainDB applies the per-instance DuckDB settings (threads, memory,
 // temp dir, extensions, profiling) that the client-query DB needs. Shared
 // between openBaseDB (single-DB path) and OpenDuckDBPair (shared-connector


### PR DESCRIPTION
## Problem

A user hit DuckDB errors that persisted for **weeks**:

```
Invalid Configuration Error: Ambiguity detected for secret name 'customer_db',
  secret occurs in multiple storage backends.
Invalid Input Error: Ambiguity found for secret name 'customer_warehouse_prod_s3',
  secret occurs in multiple storages: [local_file,memory]
```

**Root cause.** They ran `CREATE PERSISTENT SECRET ...` once, days/weeks ago. A bare `CREATE OR REPLACE SECRET` defaults to a *temporary* (memory) secret, and `OR REPLACE` only replaces *within the same storage backend* — so the persistent copy was never touched. It was written under the worker's DataDir (`/data/.duckdb/stored_secrets`, since the worker's `HOME` is `/data`), which survives across worker incarnations on a persistent/long-lived `/data`. Every activation re-creates the same-named in-memory secret, so the name ends up in **both** `local_file` and `memory` → every reference and every `DROP` is ambiguous.

Two compounding bugs made cleanup impossible:

1. The fix DuckDB suggests — `DROP <PERSISTENT|TEMPORARY> SECRET ...` — was *unrunnable*: those forms don't start with `"DROP SECRET"`, so they fell through to the PG transpiler and died with `syntax error at or near "PERSISTENT"`.
2. `DROP SECRET ... FROM local_file` is unreliable too: once the file is gone but the secret is still in DuckDB's startup-loaded registry, DuckDB throws `IO Error: Failed to remove secret file ...` (reproduced against real DuckDB).

## Changes

1. **Passthrough fix** (`server/conn.go`) — add `DROP PERSISTENT SECRET` / `DROP TEMPORARY SECRET` (+ `IF EXISTS`) to the DuckDB utility-command allowlist so they reach DuckDB instead of the PG parser.

2. **Pin the secret directory on workers** (`server/server.go` + `duckdbservice/duckdb_pair.go`) — new `Config.PinSecretDirectory`, applied in `ConfigureMainDB` as `SET secret_directory = '<DataDir>/secrets'`, set for every worker via `OpenDuckDBPair` (the worker-only DB factory; standalone uses `openBaseDB` and is untouched). Redirecting away from DuckDB's `$HOME` default means **stale secrets in the old location are no longer loaded**, so they can't collide with the in-memory secret re-created at activation — and the location is now deterministic and wipeable.

3. **Wipe persisted secrets on worker recycle** (`duckdbservice/service.go`) — `Warmup` wipes both `<DataDir>/secrets` (pinned) and the legacy `<DataDir>/.duckdb/stored_secrets` on worker startup (== recycle; a shared-warm worker is single-org-bound for life). Physically clears the historical files that caused the incident so they don't linger on a persistent DataDir.

### Why not `allow_persistent_secrets = false`

An earlier revision disabled persistent secrets outright. **CI caught that it breaks the DuckLake `ATTACH` path** (`controlplane-tests` + `k8s-integration-tests`): disabling unregisters DuckDB's `local_file` secret storage backend, which DuckLake depends on (`Unknown secret storage found: 'local_file'`). Reverted. Pinning leaves `local_file` registered (just relocated), so DuckLake is unaffected, while the redirect + recycle wipe still keep workers clean.

## Tests

- `server/conn_test.go::TestIsDuckDBUtilityCommand` — DROP variants, quoting, comments, case, word-boundary guards.
- `server/persistent_secrets_test.go` — `TestPinSecretDirectory` (a persistent secret still works and lands under the pinned dir); `TestPinSecretDirectoryIgnoresLegacyDefault` (a secret in the legacy location is not loaded once pinned away); `TestSecretDirectory` / `LegacySecretDirectory` derivation.
- `duckdbservice/secret_recycle_test.go::TestWipePersistedSecretsOnRecycle` — full recycle contract against real DuckDB, non-vacuous control phase (secret survives a plain reopen), asserts both pinned and legacy dirs are wiped.
- Full `go test ./server/` + `./duckdbservice/`, `go vet`, and `just lint` (CI-pinned golangci-lint) clean on touched files.

### Why no tests/k8s unit-test for the wipe

Worker `DataDir` (`/data`) is an `EmptyDir` (controlplane/k8s_pool.go:827), destroyed on pod deletion — a pod-kill test would pass even with the wipe removed. The boundary the wipe guards is a process restart over a *surviving* DataDir (container restart, persistent volume, warm node), modeled directly by the unit test. (Note: the real DuckLake activation path is still covered by the existing `controlplane`/`k8s` integration suites, which is what caught the `allow_persistent_secrets` regression.)

## Behavior changes to note

- **Standalone is unchanged** — pinning is gated behind `PinSecretDirectory`, which only workers set. Standalone keeps DuckDB's `$HOME` default and full persistent-secret behavior, so upgrading doesn't relocate existing secrets.
- **Workers**: persistent secrets still work, but live under `<DataDir>/secrets` and are wiped on recycle. `CREATE/`OR REPLACE` (in-memory) secrets — what duckgres and the user's scripts use — are unaffected.

## Immediate user remediation (pre-merge)

The DROP loop won't recover from the partially-deleted state. Clear the files and recycle the worker:

```
kubectl exec <worker-pod> -n duckgres -- rm -rf /data/.duckdb/stored_secrets
# then restart/recycle that worker
```

If `/data` is a persistent volume, deleting the pod alone won't help. After this ships, a worker recycle does this automatically. The user can also drop the `DROP ... FROM local_file` loop from their setup script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)