### PR TITLE
fix(iceberg): scan into *interface{} in DROP SCHEMA CASCADE fallback

### DIFF
--- a/server/iceberg_drop_schema.go
+++ b/server/iceberg_drop_schema.go
@@ -140,8 +140,8 @@ func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string)
 
 	var tables []string
 	for rows.Next() {
-		var table string
-		if err := rows.Scan(&table); err != nil {
+		table, err := scanStringColumn(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan iceberg schema table: %w", err)
 		}
 		tables = append(tables, table)
@@ -181,12 +181,33 @@ func (c *clientConn) currentSearchPathCatalog(ctx context.Context) (string, erro
 	if !rows.Next() {
 		return "", rows.Err()
 	}
-	var searchPath string
-	if err := rows.Scan(&searchPath); err != nil {
+	searchPath, err := scanStringColumn(rows)
+	if err != nil {
 		return "", fmt.Errorf("scan search_path: %w", err)
 	}
 	if err := rows.Err(); err != nil {
 		return "", err
 	}
 	return sqlcore.CatalogFromSearchPath(searchPath), nil
+}
+
+// scanStringColumn reads a single text column from a Duckgres RowSet. The
+// Flight executor's Scan contract requires an *interface{} destination (Arrow
+// values come back as interface{}, not typed pointers), so a plain *string
+// scan fails at runtime with "destination 0 must be *interface{}".
+func scanStringColumn(rows RowSet) (string, error) {
+	var raw interface{}
+	if err := rows.Scan(&raw); err != nil {
+		return "", err
+	}
+	switch v := raw.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	default:
+		return fmt.Sprintf("%v", v), nil
+	}
 }

--- a/server/iceberg_drop_schema_test.go
+++ b/server/iceberg_drop_schema_test.go
@@ -207,7 +207,14 @@ func (r *icebergDropSchemaCascadeRows) Next() bool {
 	return true
 }
 func (r *icebergDropSchemaCascadeRows) Scan(dest ...any) error {
-	*(dest[0].(*string)) = r.values[r.idx-1]
+	// Mirror the real (Flight) RowSet contract: destinations must be *interface{}.
+	// Scanning into a typed pointer (e.g. *string) must fail, so this guards the
+	// production code against regressing to a typed scan.
+	ptr, ok := dest[0].(*interface{})
+	if !ok {
+		return errors.New("scan: destination 0 must be *interface{}")
+	}
+	*ptr = r.values[r.idx-1]
 	return nil
 }
 func (r *icebergDropSchemaCascadeRows) Close() error { return nil }


### PR DESCRIPTION
## What

Follow-up to #659. The Iceberg `DROP SCHEMA … CASCADE` compatibility fallback scanned the `search_path` setting and the member-table names into `*string`. That works on the standalone `database/sql` executor but **fails on the Flight executor** (control plane → worker), whose `Scan` contract requires `*interface{}`:

```
iceberg DROP SCHEMA CASCADE fallback failed: scan search_path: scan: destination 0 must be *interface{}
```

Surfaced by the Fivetran capability test (`DROP SCHEMA IF EXISTS fivetran_testing_schema_… CASCADE`), which runs through the multitenant control plane.

## Fix

- Scan single-column results into `interface{}` and coerce to `string` via a `scanStringColumn` helper, at both scan sites (search_path + member tables).
- The test mock previously required `*string` — the **inverse** of the real Flight RowSet — which is why this slipped through. It now mirrors the real `*interface{}` contract, so a regression to a typed scan fails the test.

## Testing

- `go build ./...` + `-tags kubernetes` — clean
- `server` suite green (incl. the DROP SCHEMA CASCADE fallback tests)
- Verified end-to-end against a live local Lakekeeper: `DROP SCHEMA … CASCADE` on a schema containing a table drops the member tables then the schema successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)