### PR TITLE
feat(provisioner): connect to the customer Trino coordinator over HTTPS

### DIFF
--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1398,21 +1399,48 @@ type trinoCatalogHTTPClient struct {
 }
 
 // NewTrinoCatalogHTTPClient builds an HTTP-backed TrinoCatalogClient.
-// baseURL is the customer Trino coordinator endpoint (typically the
-// in-cluster Service: http://trino-coordinator.trino-customer.svc:8080).
+// baseURL is the customer Trino coordinator endpoint. Prefer HTTPS: Trino
+// only accepts password (Basic) authentication over a secure channel — over
+// plain HTTP it routes to the insecure (passwordless) authenticator and
+// rejects a Basic password outright ("Password not allowed for insecure
+// authentication"). A plain-http baseURL therefore cannot authenticate the
+// admin principal for catalog DDL.
+//
+// tlsServerName, when non-empty, is the name the coordinator's TLS certificate
+// is verified against, overriding the baseURL host for verification (Go's
+// crypto/tls ServerName). cert-manager issues the coordinator cert for the
+// EXTERNAL hostname (e.g. trino.dw.dev.postwh.com), which doesn't match the
+// in-cluster Service address the provisioner dials; this keeps FULL cert
+// verification (chain + the overridden name) instead of disabling it. Empty =
+// standard verification against the baseURL host (correct when baseURL already
+// uses the cert hostname). Ignored for http URLs.
 //
 // Credentials are typically empty here and populated by the first
 // Reconcile via SetCredentials (after ensureClusterSecrets bootstraps
 // the admin password). Production callers MAY pre-supply credentials
 // for the rare case where the bootstrap is known upfront (e.g. tests);
 // the username defaults to opa.AdminPrincipal if empty.
-func NewTrinoCatalogHTTPClient(baseURL, username, password string) TrinoCatalogClient {
+func NewTrinoCatalogHTTPClient(baseURL, username, password, tlsServerName string) TrinoCatalogClient {
 	if username == "" {
 		username = opa.AdminPrincipal
 	}
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if tlsServerName != "" {
+		// Clone the default transport to keep its proxy/dial/keepalive
+		// defaults, then pin the TLS verification name. This is NOT
+		// InsecureSkipVerify — the cert chain is still validated, just against
+		// tlsServerName rather than the dialed host. Applies to every request
+		// the client makes, including the /v1/statement nextUri follow-ups.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			ServerName: tlsServerName,
+			MinVersion: tls.VersionTLS12,
+		}
+		hc.Transport = transport
+	}
 	return &trinoCatalogHTTPClient{
 		baseURL:  strings.TrimRight(baseURL, "/"),
-		hc:       &http.Client{Timeout: 30 * time.Second},
+		hc:       hc,
 		username: username,
 		password: password,
 	}

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -65,6 +65,17 @@ const (
 	// enabled.
 	envTrinoCoordinatorURL = "DUCKGRES_TRINO_COORDINATOR_URL"
 
+	// envTrinoCoordinatorServerName is the TLS server name (the coordinator
+	// cert's CN/SAN, e.g. trino.dw.dev.postwh.com) to verify against when
+	// DUCKGRES_TRINO_COORDINATOR_URL is https. The provisioner dials the
+	// in-cluster Service address, but cert-manager issues the coordinator cert
+	// for the external hostname, which doesn't match; setting this keeps full
+	// TLS verification (chain + this name) without InsecureSkipVerify. Empty =
+	// verify against the URL host (correct if the URL already uses the cert
+	// hostname). Ignored for http URLs. Trino rejects password auth over plain
+	// http, so https is effectively required for the provisioner to authenticate.
+	envTrinoCoordinatorServerName = "DUCKGRES_TRINO_COORDINATOR_SERVER_NAME"
+
 	// envTrinoIAMAccountID is the AWS account id used to assemble the
 	// per-org s3.iam-role property (`arn:aws:iam::<acct>:role/duckling-<orgid>`).
 	// Required for AWS deployments: an empty value silently omits the
@@ -173,8 +184,11 @@ func buildTrinoWiring(store *configstore.ConfigStore, kc kubernetes.Interface) (
 
 	// Catalog client with empty credentials — Bootstrap (below) calls
 	// SetCredentials with the bootstrapped admin pair before the
-	// provisioner issues any catalog REST call.
-	catalogClient := provisioner.NewTrinoCatalogHTTPClient(coordinatorURL, opa.AdminPrincipal, "")
+	// provisioner issues any catalog REST call. coordinatorServerName pins TLS
+	// verification to the coordinator cert's hostname when the URL is https but
+	// dials the in-cluster Service address (see envTrinoCoordinatorServerName).
+	coordinatorServerName := strings.TrimSpace(os.Getenv(envTrinoCoordinatorServerName))
+	catalogClient := provisioner.NewTrinoCatalogHTTPClient(coordinatorURL, opa.AdminPrincipal, "", coordinatorServerName)
 
 	bundleStore := &opa.BundleStore{}
 


### PR DESCRIPTION
## Summary

The customer-Trino **provisioner** reconciles per-org catalogs by calling the coordinator REST API as `__admin_provisioner` with HTTP Basic auth. It was pointed at **plain http** (`http://trino-customer…:8080`) — but **Trino rejects a password over an insecure channel**: plain-http requests route to the *passwordless insecure authenticator*, which returns `Password not allowed for insecure authentication`. So every reconcile **401'd** and no per-org catalogs were ever created (confirmed live on mw-dev).

`allow-insecure-over-http` does **not** fix this — it only enables passwordless `X-Trino-User`, not a Basic password. Password auth requires a secure channel.

## Change

`NewTrinoCatalogHTTPClient` now takes `tlsServerName`. When set, the client uses a cloned default `Transport` with `TLSClientConfig.ServerName = tlsServerName`, so the provisioner **dials the in-cluster Service address over HTTPS but verifies the coordinator's cert against its external hostname** (cert-manager issues it for `trino.dw.<env>.postwh.com`, which doesn't match the in-cluster Service name). This keeps **full certificate verification** — not `InsecureSkipVerify` — and applies to the `/v1/statement` nextUri follow-ups. Wired via `DUCKGRES_TRINO_COORDINATOR_SERVER_NAME`.

## ⚠️ Merge ordering

**Merge this PR first.** It builds the new control-plane image. The paired charts PR flips `coordinatorUrl` to `https` and opens the NetworkPolicy to `:8443`; if that lands before this image deploys, the *old* binary's plain `http.Client` can't do the ServerName override and would fail TLS hostname verification.

Paired PR: **PostHog/charts** — *feat(trino): move the duckgres provisioner to HTTPS*.

## Verification
`go build` / `go vet` / `go test ./controlplane/provisioner/` green with `-tags kubernetes`. Diagnosis + approach validated against Trino 476 `AuthenticationFilter`/`InsecureAuthenticator` and dual-model (codex) review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
