### PR TITLE
fix(cache-proxy): stream S3 bodies through disk to stop OOM kills

### DIFF
--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -28,6 +28,11 @@ func IsValidCacheKey(key string) bool {
 	return validCacheKey.MatchString(key)
 }
 
+// tmpSubdir holds in-progress streamed writes. It lives under the cache dir so
+// the temp file and its final destination share a filesystem and os.Rename is
+// atomic. Entries here are never servable and are excluded from scan/accounting.
+const tmpSubdir = ".tmp"
+
 var (
 	cacheHitsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "cache_proxy_hits_total",
@@ -88,6 +93,14 @@ func NewDiskCache(dir string, maxPercent int) (*DiskCache, error) {
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
 
+	// Recreate the temp dir from scratch so any half-written streams left by a
+	// crash don't linger and leak disk.
+	tmpDir := filepath.Join(dir, tmpSubdir)
+	_ = os.RemoveAll(tmpDir)
+	if err := os.MkdirAll(tmpDir, 0750); err != nil {
+		return nil, fmt.Errorf("create cache temp dir: %w", err)
+	}
+
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(dir, &stat); err != nil {
 		return nil, fmt.Errorf("statfs %s: %w", dir, err)
@@ -126,6 +139,11 @@ func (c *DiskCache) scanExisting() {
 
 	for _, e := range entries {
 		if e.IsDir() {
+			continue
+		}
+		// Only count real cache entries — the .tmp dir's contents and any
+		// stray non-key files must not enter the LRU accounting.
+		if !IsValidCacheKey(e.Name()) {
 			continue
 		}
 		info, err := e.Info()
@@ -203,8 +221,75 @@ func (c *DiskCache) Put(key string, data []byte) error {
 	return nil
 }
 
-// Open returns a reader for the cached data. Caller must close it.
+// PutStream stores data from r under key without buffering the whole body in
+// memory. It writes to a temp file and atomically renames it into place, so a
+// truncated or failed copy never becomes a servable entry. Returns the number
+// of bytes stored. This is the streaming counterpart to Put and is what keeps
+// the proxy's memory flat under a flood of concurrent large range reads.
+func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
+	if !IsValidCacheKey(key) {
+		return 0, fmt.Errorf("invalid cache key")
+	}
+
+	tmp, err := os.CreateTemp(filepath.Join(c.dir, tmpSubdir), key+"-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	size, copyErr := io.Copy(tmp, r)
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return 0, copyErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return 0, closeErr
+	}
+
+	// Now that the actual size is known, drop any prior accounting for this key
+	// (the rename below overwrites it) and evict to make room.
+	c.mu.Lock()
+	c.dropLocked(key)
+	for c.currentSize+size > c.maxBytes && len(c.order) > 0 {
+		c.evictOldest()
+	}
+	c.mu.Unlock()
+
+	path := filepath.Join(c.dir, key)
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return 0, fmt.Errorf("commit cache entry: %w", err)
+	}
+
+	c.mu.Lock()
+	c.order = append(c.order, cacheEntry{
+		key:        key,
+		size:       size,
+		lastAccess: time.Now(),
+	})
+	c.currentSize += size
+	cacheSizeBytes.Set(float64(c.currentSize))
+	c.mu.Unlock()
+
+	return size, nil
+}
+
+// Open returns a reader for the cached data and counts a cache hit. Caller must
+// close the reader.
 func (c *DiskCache) Open(key string) (io.ReadCloser, int64, bool) {
+	f, size, ok := c.openFile(key)
+	if !ok {
+		return nil, 0, false
+	}
+	cacheHitsTotal.Inc()
+	return f, size, true
+}
+
+// openFile opens a cached entry WITHOUT recording a hit. Used to serve a body
+// that was just fetched on a miss — that path already counted a miss, so
+// counting it as a hit too would double-count.
+func (c *DiskCache) openFile(key string) (io.ReadCloser, int64, bool) {
 	if !IsValidCacheKey(key) {
 		return nil, 0, false
 	}
@@ -223,7 +308,6 @@ func (c *DiskCache) Open(key string) (io.ReadCloser, int64, bool) {
 	c.touchLocked(key)
 	c.mu.Unlock()
 
-	cacheHitsTotal.Inc()
 	return f, info.Size(), true
 }
 
@@ -235,6 +319,19 @@ func (c *DiskCache) touchLocked(key string) {
 			entry := c.order[i]
 			c.order = append(c.order[:i], c.order[i+1:]...)
 			c.order = append(c.order, entry)
+			return
+		}
+	}
+}
+
+// dropLocked removes any accounting for key (used when an overwrite is about to
+// replace the file under it) so currentSize doesn't double-count. No-op if the
+// key isn't tracked. Caller holds c.mu.
+func (c *DiskCache) dropLocked(key string) {
+	for i := range c.order {
+		if c.order[i].key == key {
+			c.currentSize -= c.order[i].size
+			c.order = append(c.order[:i], c.order[i+1:]...)
 			return
 		}
 	}

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -263,6 +263,12 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	}
 
 	c.mu.Lock()
+	// dropLocked again before appending: in production singleFlight serializes
+	// writes per key so the earlier drop is enough, but guarding here keeps the
+	// "one entry per key" invariant (and currentSize) correct even if some
+	// future caller writes the same key concurrently — a duplicate entry would
+	// otherwise permanently inflate currentSize.
+	c.dropLocked(key)
 	c.order = append(c.order, cacheEntry{
 		key:        key,
 		size:       size,

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -1,10 +1,44 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
+
+// counterValue reads a Prometheus counter's current value without pulling in the
+// testutil package (and its extra module deps). Used to assert the Open-vs-
+// openFile hit-count split.
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// errAfterReader yields n bytes then returns a non-EOF error, simulating an
+// origin/peer connection dropping mid-body.
+type errAfterReader struct {
+	data []byte
+	pos  int
+}
+
+func (e *errAfterReader) Read(p []byte) (int, error) {
+	if e.pos >= len(e.data) {
+		return 0, errors.New("connection reset mid-stream")
+	}
+	n := copy(p, e.data[e.pos:])
+	e.pos += n
+	return n, nil
+}
 
 func TestIsValidCacheKey(t *testing.T) {
 	cases := []struct {
@@ -153,5 +187,167 @@ func TestDiskCacheEviction(t *testing.T) {
 	// The most recent must still be present.
 	if !c.Has(keys[2]) {
 		t.Error("newest entry should still be cached")
+	}
+}
+
+// tmpDirEntries counts the files left behind in the cache's .tmp subdir, so
+// tests can assert PutStream never leaks a temp file.
+func tmpDirEntries(t *testing.T, c *DiskCache) int {
+	t.Helper()
+	entries, err := readDirNames(c.dir + "/" + tmpSubdir)
+	if err != nil {
+		t.Fatalf("read tmp dir: %v", err)
+	}
+	return len(entries)
+}
+
+func readDirNames(dir string) ([]string, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Readdirnames(-1)
+}
+
+func TestPutStreamRoundTrip(t *testing.T) {
+	c := newTestCache(t)
+	key := strings.Repeat("a", 64)
+	data := []byte("streamed-parquet-bytes")
+
+	n, err := c.PutStream(key, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("PutStream: %v", err)
+	}
+	if n != int64(len(data)) {
+		t.Errorf("PutStream returned %d, want %d", n, len(data))
+	}
+	if !c.Has(key) {
+		t.Fatal("Has should be true after PutStream")
+	}
+	r, size, ok := c.Open(key)
+	if !ok {
+		t.Fatal("Open should find the streamed entry")
+	}
+	defer func() { _ = r.Close() }()
+	got, _ := io.ReadAll(r)
+	if string(got) != string(data) {
+		t.Errorf("streamed data = %q, want %q", got, data)
+	}
+	if size != int64(len(data)) {
+		t.Errorf("Open size = %d, want %d", size, len(data))
+	}
+	if left := tmpDirEntries(t, c); left != 0 {
+		t.Errorf("temp dir has %d leftover files, want 0", left)
+	}
+}
+
+// TestPutStreamErrorMidStream verifies that a reader failing mid-body leaves no
+// servable entry, no LRU accounting, and no temp-file leak.
+func TestPutStreamErrorMidStream(t *testing.T) {
+	c := newTestCache(t)
+	key := strings.Repeat("b", 64)
+
+	_, err := c.PutStream(key, &errAfterReader{data: make([]byte, 32)})
+	if err == nil {
+		t.Fatal("PutStream should return the mid-stream error")
+	}
+	if c.Has(key) {
+		t.Error("a failed stream must not produce a servable entry")
+	}
+	if c.currentSize != 0 {
+		t.Errorf("currentSize = %d after failed stream, want 0", c.currentSize)
+	}
+	if len(c.order) != 0 {
+		t.Errorf("order has %d entries after failed stream, want 0", len(c.order))
+	}
+	if left := tmpDirEntries(t, c); left != 0 {
+		t.Errorf("temp dir has %d leftover files after failed stream, want 0", left)
+	}
+}
+
+// TestPutStreamOverwrite verifies that re-streaming a key replaces it without
+// double-counting currentSize or leaving a duplicate LRU entry (finding #2).
+func TestPutStreamOverwrite(t *testing.T) {
+	c := newTestCache(t)
+	key := strings.Repeat("c", 64)
+
+	if _, err := c.PutStream(key, bytes.NewReader(make([]byte, 100))); err != nil {
+		t.Fatalf("first PutStream: %v", err)
+	}
+	if _, err := c.PutStream(key, bytes.NewReader(make([]byte, 40))); err != nil {
+		t.Fatalf("second PutStream: %v", err)
+	}
+
+	if c.currentSize != 40 {
+		t.Errorf("currentSize = %d after overwrite, want 40 (not 140)", c.currentSize)
+	}
+	count := 0
+	for _, e := range c.order {
+		if e.key == key {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("key appears %d times in order, want exactly 1", count)
+	}
+	r, size, ok := c.Open(key)
+	if !ok || size != 40 {
+		t.Fatalf("Open after overwrite: ok=%v size=%d, want ok size=40", ok, size)
+	}
+	_ = r.Close()
+}
+
+// TestPutStreamOversizedObject documents that an object larger than maxBytes is
+// stored anyway (the eviction loop drains the cache but stops when empty), so a
+// single huge range is never silently dropped.
+func TestPutStreamOversizedObject(t *testing.T) {
+	c := newTestCache(t)
+	c.maxBytes = 100
+	// Seed a smaller entry that should get evicted to make room.
+	if _, err := c.PutStream(strings.Repeat("1", 64), bytes.NewReader(make([]byte, 50))); err != nil {
+		t.Fatalf("seed PutStream: %v", err)
+	}
+
+	big := strings.Repeat("2", 64)
+	if _, err := c.PutStream(big, bytes.NewReader(make([]byte, 250))); err != nil {
+		t.Fatalf("oversized PutStream: %v", err)
+	}
+	if !c.Has(big) {
+		t.Error("oversized object should still be stored, not dropped")
+	}
+	// The seed entry was evicted to (try to) make room.
+	if c.Has(strings.Repeat("1", 64)) {
+		t.Error("seed entry should have been evicted by the oversized put")
+	}
+}
+
+// TestOpenCountsHitOpenFileDoesNot locks in the metric split: serving a hit via
+// Open records a cache hit; serving a freshly-fetched miss via openFile does
+// not (otherwise misses would be double-counted as hits).
+func TestOpenCountsHitOpenFileDoesNot(t *testing.T) {
+	c := newTestCache(t)
+	key := strings.Repeat("d", 64)
+	if _, err := c.PutStream(key, bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatalf("PutStream: %v", err)
+	}
+
+	before := counterValue(t, cacheHitsTotal)
+	r, _, ok := c.openFile(key)
+	if !ok {
+		t.Fatal("openFile should find the entry")
+	}
+	_ = r.Close()
+	if mid := counterValue(t, cacheHitsTotal); mid != before {
+		t.Errorf("openFile changed hit counter by %v, want 0", mid-before)
+	}
+
+	r, _, ok = c.Open(key)
+	if !ok {
+		t.Fatal("Open should find the entry")
+	}
+	_ = r.Close()
+	if after := counterValue(t, cacheHitsTotal); after != before+1 {
+		t.Errorf("Open changed hit counter by %v, want 1", after-before)
 	}
 }

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -25,27 +25,44 @@ var (
 	})
 )
 
+// Peer timeouts. The /cache/has probe is a tiny HEAD-like check, so it gets a
+// short budget; the /cache/get body transfer can move many MB of a Parquet
+// range over the VPC, so it gets a much larger one. They are deliberately
+// separate: sharing one 2s budget (as the original code did) meant a slow
+// has-race ate into the body-transfer time and large peer ranges timed out
+// mid-stream, silently downgrading the hit to a full S3 fetch.
+const (
+	peerHasTimeout = 1 * time.Second
+	peerGetTimeout = 30 * time.Second
+)
+
 // PeerManager discovers and communicates with cache proxy peers
 // via a Kubernetes headless Service.
 type PeerManager struct {
-	serviceName string
-	peerPort    string // port for peer API (e.g. ":8081")
-	client      *http.Client
+	serviceName  string
+	peerPort     string // port for peer API (e.g. ":8081")
+	client       *http.Client // /cache/has probes (short timeout)
+	streamClient *http.Client // /cache/get body transfers (long timeout)
 
 	mu    sync.RWMutex
 	peers []string // peer addresses (ip:port)
 }
 
 func NewPeerManager(serviceName, peerPort string) *PeerManager {
+	transport := &http.Transport{
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     30 * time.Second,
+	}
 	return &PeerManager{
 		serviceName: serviceName,
 		peerPort:    peerPort,
 		client: &http.Client{
-			Timeout: 2 * time.Second,
-			Transport: &http.Transport{
-				MaxIdleConnsPerHost: 10,
-				IdleConnTimeout:     30 * time.Second,
-			},
+			Timeout:   peerHasTimeout,
+			Transport: transport,
+		},
+		streamClient: &http.Client{
+			Timeout:   peerGetTimeout,
+			Transport: transport,
 		},
 	}
 }
@@ -123,16 +140,17 @@ func (pm *PeerManager) FetchFromPeers(cacheKey string, sink func(io.Reader) (int
 
 	peerFetchesTotal.Inc()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
 	// Phase 1: ask every peer "do you have this?" in parallel (cheap, no body)
-	// and take the first that says yes.
+	// and take the first that says yes. Its own short context bounds the probe
+	// so a slow/dead peer can't eat into the body-transfer budget below.
+	hasCtx, hasCancel := context.WithTimeout(context.Background(), peerHasTimeout)
+	defer hasCancel()
+
 	holderCh := make(chan string, len(peers))
 	for _, addr := range peers {
 		go func(addr string) {
 			hasURL := fmt.Sprintf("http://%s/cache/has?key=%s", addr, cacheKey)
-			req, err := http.NewRequestWithContext(ctx, "GET", hasURL, nil)
+			req, err := http.NewRequestWithContext(hasCtx, "GET", hasURL, nil)
 			if err != nil {
 				holderCh <- ""
 				return
@@ -161,15 +179,22 @@ func (pm *PeerManager) FetchFromPeers(cacheKey string, sink func(io.Reader) (int
 	if holder == "" {
 		return "", 0, false
 	}
+	// Probes for the losing peers are no longer needed — release them so they
+	// don't hold connections open for the rest of the has-timeout window.
+	hasCancel()
 
-	// Phase 2: stream the body from the chosen holder straight into sink. Only
+	// Phase 2: stream the body from the chosen holder straight into sink, with
+	// its own generous budget (a multi-MB Parquet range can take a while). Only
 	// the winner is fetched, so we never pull a body we won't use.
+	getCtx, getCancel := context.WithTimeout(context.Background(), peerGetTimeout)
+	defer getCancel()
+
 	getURL := fmt.Sprintf("http://%s/cache/get?key=%s", holder, cacheKey)
-	req, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
+	req, err := http.NewRequestWithContext(getCtx, "GET", getURL, nil)
 	if err != nil {
 		return "", 0, false
 	}
-	resp, err := pm.client.Do(req)
+	resp, err := pm.streamClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		if resp != nil {
 			_ = resp.Body.Close()

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -106,89 +106,84 @@ func (pm *PeerManager) resolve() {
 	}
 }
 
-// FetchFromPeers asks all peers in parallel if they have the given cache key.
-// Returns the data from the first peer that has it, or false if none do.
-func (pm *PeerManager) FetchFromPeers(cacheKey string) ([]byte, string, bool) {
+// FetchFromPeers locates a peer holding cacheKey and streams its body into
+// sink, returning the serving peer's address and the number of bytes streamed.
+// ok is false if no peer has the key (or the chosen peer's body couldn't be
+// streamed). The body is never buffered here — sink (typically DiskCache.PutStream)
+// consumes it as it arrives, so a peer hit costs only sink's copy buffer.
+func (pm *PeerManager) FetchFromPeers(cacheKey string, sink func(io.Reader) (int64, error)) (string, int64, bool) {
 	pm.mu.RLock()
 	peers := make([]string, len(pm.peers))
 	copy(peers, pm.peers)
 	pm.mu.RUnlock()
 
 	if len(peers) == 0 {
-		return nil, "", false
+		return "", 0, false
 	}
 
 	peerFetchesTotal.Inc()
 
-	type result struct {
-		data []byte
-		addr string
-		ok   bool
-	}
-
-	// Ask all peers in parallel
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	results := make(chan result, len(peers))
-
+	// Phase 1: ask every peer "do you have this?" in parallel (cheap, no body)
+	// and take the first that says yes.
+	holderCh := make(chan string, len(peers))
 	for _, addr := range peers {
 		go func(addr string) {
-			// First check if peer has the key (cheap HEAD-like check)
 			hasURL := fmt.Sprintf("http://%s/cache/has?key=%s", addr, cacheKey)
 			req, err := http.NewRequestWithContext(ctx, "GET", hasURL, nil)
 			if err != nil {
-				results <- result{ok: false}
+				holderCh <- ""
 				return
 			}
 			resp, err := pm.client.Do(req)
-			if err != nil || resp.StatusCode != http.StatusOK {
-				if resp != nil {
-					_ = resp.Body.Close()
-				}
-				results <- result{ok: false}
+			if err != nil {
+				holderCh <- ""
 				return
 			}
 			_ = resp.Body.Close()
-
-			// Peer has it — fetch the data
-			getURL := fmt.Sprintf("http://%s/cache/get?key=%s", addr, cacheKey)
-			req2, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
-			if err != nil {
-				results <- result{ok: false}
-				return
+			if resp.StatusCode == http.StatusOK {
+				holderCh <- addr
+			} else {
+				holderCh <- ""
 			}
-			resp2, err := pm.client.Do(req2)
-			if err != nil || resp2.StatusCode != http.StatusOK {
-				if resp2 != nil {
-					_ = resp2.Body.Close()
-				}
-				results <- result{ok: false}
-				return
-			}
-			defer func() { _ = resp2.Body.Close() }()
-
-			data, err := io.ReadAll(resp2.Body)
-			if err != nil {
-				results <- result{ok: false}
-				return
-			}
-
-			results <- result{data: data, addr: addr, ok: true}
 		}(addr)
 	}
 
-	// Return first successful result
+	var holder string
 	for range peers {
-		r := <-results
-		if r.ok {
-			peerHitsTotal.Inc()
-			cancel() // cancel remaining peer requests
-			return r.data, r.addr, true
+		if a := <-holderCh; a != "" {
+			holder = a
+			break
 		}
 	}
+	if holder == "" {
+		return "", 0, false
+	}
 
-	return nil, "", false
+	// Phase 2: stream the body from the chosen holder straight into sink. Only
+	// the winner is fetched, so we never pull a body we won't use.
+	getURL := fmt.Sprintf("http://%s/cache/get?key=%s", holder, cacheKey)
+	req, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
+	if err != nil {
+		return "", 0, false
+	}
+	resp, err := pm.client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		return "", 0, false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	n, err := sink(resp.Body)
+	if err != nil {
+		return "", 0, false
+	}
+	peerHitsTotal.Inc()
+	return holder, n, true
 }
 
 func getLocalIPs() []string {

--- a/cmd/cache-proxy/peers_test.go
+++ b/cmd/cache-proxy/peers_test.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+// collectSink returns a sink that streams the peer body into buf, mirroring how
+// DiskCache.PutStream consumes it in production (without touching disk).
+func collectSink(buf *bytes.Buffer) func(io.Reader) (int64, error) {
+	return func(r io.Reader) (int64, error) {
+		return io.Copy(buf, r)
+	}
+}
 
 // newPeerServer returns an httptest server exposing /cache/has and /cache/get
 // for the supplied key and data. hasCallback/getCallback increment counters.
@@ -57,12 +67,16 @@ func TestFetchFromPeersHit(t *testing.T) {
 	addr := newPeerServer(t, key, data, &hasCalls, &getCalls)
 	pm := peerManagerWith([]string{addr})
 
-	got, from, ok := pm.FetchFromPeers(key)
+	var buf bytes.Buffer
+	from, n, ok := pm.FetchFromPeers(key, collectSink(&buf))
 	if !ok {
 		t.Fatal("expected peer hit")
 	}
-	if string(got) != string(data) {
-		t.Errorf("peer data = %q, want %q", got, data)
+	if buf.String() != string(data) {
+		t.Errorf("peer data = %q, want %q", buf.String(), data)
+	}
+	if n != int64(len(data)) {
+		t.Errorf("streamed bytes = %d, want %d", n, len(data))
 	}
 	if from != addr {
 		t.Errorf("peer addr = %q, want %q", from, addr)
@@ -84,9 +98,10 @@ func TestFetchFromPeersMissFromAll(t *testing.T) {
 	addr := newPeerServer(t, other, []byte("not-ours"), &hasCalls, &getCalls)
 	pm := peerManagerWith([]string{addr})
 
-	got, _, ok := pm.FetchFromPeers(key)
+	var buf bytes.Buffer
+	_, _, ok := pm.FetchFromPeers(key, collectSink(&buf))
 	if ok {
-		t.Fatalf("expected miss, got %q", got)
+		t.Fatalf("expected miss, got %q", buf.String())
 	}
 	if atomic.LoadInt32(&hasCalls) != 1 {
 		t.Errorf("peer /cache/has calls = %d, want 1", hasCalls)
@@ -108,12 +123,13 @@ func TestFetchFromPeersReturnsFirstHit(t *testing.T) {
 	addr2 := newPeerServer(t, key, data, &has2, &get2)
 	pm := peerManagerWith([]string{addr1, addr2})
 
-	got, _, ok := pm.FetchFromPeers(key)
+	var buf bytes.Buffer
+	_, _, ok := pm.FetchFromPeers(key, collectSink(&buf))
 	if !ok {
 		t.Fatal("expected peer hit from one of two peers")
 	}
-	if string(got) != string(data) {
-		t.Errorf("peer data = %q, want %q", got, data)
+	if buf.String() != string(data) {
+		t.Errorf("peer data = %q, want %q", buf.String(), data)
 	}
 	// At least one peer must have been asked; both may have responded.
 	totalHas := atomic.LoadInt32(&has1) + atomic.LoadInt32(&has2)
@@ -124,7 +140,8 @@ func TestFetchFromPeersReturnsFirstHit(t *testing.T) {
 
 func TestFetchFromPeersEmptyPeerList(t *testing.T) {
 	pm := peerManagerWith(nil)
-	if _, _, ok := pm.FetchFromPeers(strings.Repeat("a", 64)); ok {
+	var buf bytes.Buffer
+	if _, _, ok := pm.FetchFromPeers(strings.Repeat("a", 64), collectSink(&buf)); ok {
 		t.Error("expected miss when no peers are known")
 	}
 }

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -30,6 +30,16 @@ type CacheProxy struct {
 	cacheHostSuffixes []string
 }
 
+// fetchResult describes a body that fetchDedup has materialized onto local
+// disk under its cache key. It deliberately carries no body bytes — the data
+// lives on NVMe and is served by streaming straight from the file, so a flood
+// of concurrent fetches no longer pins one buffer per request in memory.
+type fetchResult struct {
+	size        int64
+	contentType string // origin Content-Type ("" for peer fetches and hits)
+	source      string // "peer" or "miss"
+}
+
 type singleFlight struct {
 	mu sync.Mutex
 	m  map[string]*call
@@ -37,11 +47,11 @@ type singleFlight struct {
 
 type call struct {
 	wg  sync.WaitGroup
-	val []byte
+	res fetchResult
 	err error
 }
 
-func (sf *singleFlight) Do(key string, fn func() ([]byte, error)) ([]byte, error) {
+func (sf *singleFlight) Do(key string, fn func() (fetchResult, error)) (fetchResult, error) {
 	sf.mu.Lock()
 	if sf.m == nil {
 		sf.m = make(map[string]*call)
@@ -49,21 +59,21 @@ func (sf *singleFlight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 	if c, ok := sf.m[key]; ok {
 		sf.mu.Unlock()
 		c.wg.Wait()
-		return c.val, c.err
+		return c.res, c.err
 	}
 	c := &call{}
 	c.wg.Add(1)
 	sf.m[key] = c
 	sf.mu.Unlock()
 
-	c.val, c.err = fn()
+	c.res, c.err = fn()
 	c.wg.Done()
 
 	sf.mu.Lock()
 	delete(sf.m, key)
 	sf.mu.Unlock()
 
-	return c.val, c.err
+	return c.res, c.err
 }
 
 func NewCacheProxy(store *DiskCache, peers *PeerManager, cacheHostSuffixes []string) *CacheProxy {
@@ -220,15 +230,16 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	rangeHeader := r.Header.Get("Range")
 	cacheKey := CacheKey(r.URL.String(), rangeHeader)
 
-	if data, ok := p.store.Get(cacheKey); ok {
-		cacheBytesServed.WithLabelValues("local").Add(float64(len(data)))
-		slog.Info("Served.", "source", "hit", "url", r.URL.String(), "range", rangeHeader, "bytes", len(data))
-		p.serveBody(w, data, rangeHeader, "")
+	if reader, size, ok := p.store.Open(cacheKey); ok {
+		cacheBytesServed.WithLabelValues("local").Add(float64(size))
+		slog.Info("Served.", "source", "hit", "url", r.URL.String(), "range", rangeHeader, "bytes", size)
+		p.serveStream(w, reader, size, rangeHeader, "")
+		_ = reader.Close()
 		return
 	}
 	cacheMissesTotal.Inc()
 
-	data, contentType, source, err := p.fetchDedup(cacheKey, r, rangeHeader)
+	res, err := p.fetchDedup(cacheKey, r, rangeHeader)
 	if err != nil {
 		// An origin that responded with a non-2xx (e.g. S3 returning a 400 with
 		// <Code>ExpiredToken</Code> in an XML envelope) is forwarded back to
@@ -251,49 +262,58 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := p.store.Put(cacheKey, data); err != nil {
-		slog.Warn("Failed to cache.", "key", cacheKey[:16], "error", err)
+	// fetchDedup already committed the body to disk under cacheKey. Serve it by
+	// streaming from the file (openFile, not Open — the miss was already counted,
+	// so this must not also register a hit).
+	reader, size, ok := p.store.openFile(cacheKey)
+	if !ok {
+		// The entry was evicted in the narrow window between commit and serve.
+		// 502 so httpfs retries rather than receiving a truncated body.
+		slog.Warn("Cached entry vanished before serve.", "url", r.URL.String(), "range", rangeHeader)
+		http.Error(w, "cache entry vanished", http.StatusBadGateway)
+		return
 	}
-	slog.Info("Served.", "source", source, "url", r.URL.String(), "range", rangeHeader, "bytes", len(data))
-	p.serveBody(w, data, rangeHeader, contentType)
+	defer func() { _ = reader.Close() }()
+	slog.Info("Served.", "source", res.source, "url", r.URL.String(), "range", rangeHeader, "bytes", size)
+	p.serveStream(w, reader, size, rangeHeader, res.contentType)
 }
 
-// fetchDedup tries peers then origin, deduplicating concurrent fetches.
-// contentType is reported only for origin fetches (peers strip it).
-// source is "peer" or "miss" depending on where the data came from.
-func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader string) ([]byte, string, string, error) {
-	var contentType, source string
-	data, err := p.flights.Do(cacheKey, func() ([]byte, error) {
+// fetchDedup tries peers then origin, deduplicating concurrent fetches. On
+// success the body has been committed to local disk under cacheKey; the caller
+// serves it by streaming from the file. Nothing here holds the body in memory.
+func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader string) (fetchResult, error) {
+	return p.flights.Do(cacheKey, func() (fetchResult, error) {
 		if p.peers != nil {
-			if peerData, peerAddr, ok := p.peers.FetchFromPeers(cacheKey); ok {
-				cacheBytesServed.WithLabelValues("peer").Add(float64(len(peerData)))
-				source = "peer"
-				_ = peerAddr
-				return peerData, nil
+			if _, n, ok := p.peers.FetchFromPeers(cacheKey, func(body io.Reader) (int64, error) {
+				return p.store.PutStream(cacheKey, body)
+			}); ok {
+				cacheBytesServed.WithLabelValues("peer").Add(float64(n))
+				return fetchResult{size: n, source: "peer"}, nil
 			}
 		}
-		data, ct, err := p.fetchOrigin(r)
+		size, ct, err := p.fetchOrigin(cacheKey, r)
 		if err != nil {
-			return nil, err
+			return fetchResult{}, err
 		}
-		contentType = ct
-		cacheBytesServed.WithLabelValues("s3").Add(float64(len(data)))
-		source = "miss"
-		return data, nil
+		cacheBytesServed.WithLabelValues("s3").Add(float64(size))
+		return fetchResult{size: size, contentType: ct, source: "miss"}, nil
 	})
-	return data, contentType, source, err
 }
 
 // fetchOrigin forwards the request verbatim (headers, Host, signature) to the
-// real origin and returns the body. The SigV4 signature remains valid because
-// the URL and Host header are unchanged.
-func (p *CacheProxy) fetchOrigin(r *http.Request) ([]byte, string, error) {
+// real origin and streams a successful body straight to the on-disk cache,
+// returning the stored size and Content-Type. The SigV4 signature remains valid
+// because the URL and Host header are unchanged. Streaming to disk (rather than
+// io.ReadAll into a []byte) is what keeps proxy memory flat under concurrent
+// large range reads. A non-2xx response is NOT cached — its (capped) error body
+// is captured and returned as an originStatusError for verbatim forwarding.
+func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, string, error) {
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, r.Method, r.URL.String(), nil)
 	if err != nil {
-		return nil, "", err
+		return 0, "", err
 	}
 	for k, vv := range r.Header {
 		if hopByHop[strings.ToLower(k)] {
@@ -307,7 +327,7 @@ func (p *CacheProxy) fetchOrigin(r *http.Request) ([]byte, string, error) {
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return nil, "", err
+		return 0, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -316,18 +336,18 @@ func (p *CacheProxy) fetchOrigin(r *http.Request) ([]byte, string, error) {
 		// typically <1 KiB; the cap is just a guard against a misbehaving
 		// origin streaming forever. The 60s context above also protects us.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, originErrorBodyCap))
-		return nil, "", &originStatusError{
+		return 0, "", &originStatusError{
 			status:  resp.StatusCode,
 			headers: resp.Header.Clone(),
 			body:    body,
 		}
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	size, err := p.store.PutStream(cacheKey, resp.Body)
 	if err != nil {
-		return nil, "", err
+		return 0, "", err
 	}
-	return data, resp.Header.Get("Content-Type"), nil
+	return size, resp.Header.Get("Content-Type"), nil
 }
 
 // originErrorBodyCap is the maximum number of bytes we'll buffer from a
@@ -377,18 +397,21 @@ func previewBody(body []byte) string {
 	return string(body[:max]) + "...(truncated)"
 }
 
-// serveBody writes cached data back to the client, reconstructing 206 Partial
-// Content semantics when the original request had a Range header.
-func (p *CacheProxy) serveBody(w http.ResponseWriter, data []byte, rangeHeader, contentType string) {
+// serveStream copies a cached body from r back to the client, reconstructing
+// 206 Partial Content semantics when the original request had a Range header.
+// size is the on-disk length (known up front), so Content-Length and the
+// Content-Range total are set before any body bytes flow — same response shape
+// the old buffered serveBody produced, without holding the body in memory.
+func (p *CacheProxy) serveStream(w http.ResponseWriter, r io.Reader, size int64, rangeHeader, contentType string) {
 	if contentType != "" {
 		w.Header().Set("Content-Type", contentType)
 	}
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
 	if rangeHeader != "" {
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %s/%d", strings.TrimPrefix(rangeHeader, "bytes="), len(data)))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %s/%d", strings.TrimPrefix(rangeHeader, "bytes="), size))
 		w.WriteHeader(http.StatusPartialContent)
 	}
-	_, _ = w.Write(data)
+	_, _ = io.Copy(w, r)
 }
 
 // forwardUncached forwards a request to the origin without caching. Used for

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -327,21 +327,21 @@ func TestHandlePeerRejectsInvalidKey(t *testing.T) {
 func TestSingleFlightDedups(t *testing.T) {
 	var sf singleFlight
 	var calls int32
-	fn := func() ([]byte, error) {
+	fn := func() (fetchResult, error) {
 		atomic.AddInt32(&calls, 1)
-		return []byte("payload"), nil
+		return fetchResult{size: 7, source: "miss"}, nil
 	}
 
 	// Sequential calls with the same key should still invoke fn each time
 	// (singleflight only coalesces concurrent in-flight callers). We verify
 	// that the return values are correct rather than count.
 	got1, err := sf.Do("k", fn)
-	if err != nil || string(got1) != "payload" {
-		t.Fatalf("sf.Do: got=%q err=%v", got1, err)
+	if err != nil || got1.size != 7 {
+		t.Fatalf("sf.Do: got=%+v err=%v", got1, err)
 	}
 	got2, err := sf.Do("k", fn)
-	if err != nil || string(got2) != "payload" {
-		t.Fatalf("sf.Do repeat: got=%q err=%v", got2, err)
+	if err != nil || got2.size != 7 {
+		t.Fatalf("sf.Do repeat: got=%+v err=%v", got2, err)
 	}
 	if atomic.LoadInt32(&calls) != 2 {
 		t.Errorf("sequential calls invoked fn %d times, want 2", calls)


### PR DESCRIPTION
## Problem

The per-node `duckgres-cache-proxy` was **OOMKilled** (exit 137) under heavy backfill load. On **2026-06-03 ~05:29Z** a customer events backfill flooded one node's proxy with hundreds of concurrent S3 range-read *misses*; the pod (`gct4x`) crash-looped 4× and a second pod (`wv46g`) OOM'd again at 14:20Z. Every in-flight request buffered its **full body in a `[]byte`**, so `Σ(range sizes of all in-flight misses)` blew past the 512Mi limit.

This is the memory-side analogue of #11609 (charts), which removed the CPU limit to stop throttling-induced S3 connect failures. The CPU fix is working; this addresses the separate memory failure mode it didn't touch.

## Fix

Every S3 path now streams through the on-disk NVMe cache, so per-request memory is just a copy buffer (~32KB) regardless of object size or concurrency.

| Path | Before | After |
|------|--------|-------|
| **miss** (`fetchOrigin`) | `io.ReadAll(resp.Body)` → full body in RAM | `DiskCache.PutStream`: copy body → `.tmp/` file → **atomic rename** into place |
| **hit** (`HandleProxy`) | `os.ReadFile` → full body in RAM | `Open` + `io.Copy` straight from the file |
| **peer** (`FetchFromPeers`) | `io.ReadAll(peer body)` | stream the chosen holder's body into `PutStream`; has-check is now a parallel race that fetches only the winner |

- `singleFlight` carries a small `fetchResult{size, contentType, source}` instead of body bytes, so coalesced waiters no longer pin a shared buffer.
- Atomic temp→rename means a truncated/failed copy never becomes a servable entry. Non-2xx responses are still captured and forwarded **verbatim** and never cached.
- Miss-serve uses a non-metric `openFile` so it isn't double-counted as a cache hit.
- Temp files live in a `.tmp` subdir (same-FS rename, wiped on startup, excluded from LRU scan/accounting).

**Response shape is byte-for-byte preserved**: 206 + `Content-Range` + `Content-Length`, verbatim error forwarding, and no-cache-on-error all unchanged.

## Testing

- `go build`, `go vet`, and `go test ./cmd/cache-proxy/` all pass.
- `go test -race` passes on all changed paths. (One pre-existing race in `TestHandleConnectLogsOpenAndClose` — the test reads the shared slog buffer before the detached CONNECT close-log goroutine finishes — is unrelated to this change and also fails on `main`.)
- Unit tests for the changed internal contracts (`singleFlight`, `FetchFromPeers`) updated to the streaming signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)