### PR TITLE
fix(iceberg/flight): DROP SCHEMA CASCADE + inline ? placeholders on the Flight path

### DIFF
--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -714,13 +714,100 @@ func (c *bearerCreds) RequireTransportSecurity() bool {
 // Safety: args come from PostgreSQL wire protocol typed parameter binding,
 // not raw user strings. The caller (handleBind) decodes typed values from
 // the binary protocol, so the values are trusted internal data.
+// interpolateArgs inlines query arguments into the SQL string. The Flight
+// executor sends ad-hoc statements without separate bind parameters, so any
+// placeholder left in the query reaches the worker unbound and fails to prepare
+// ("incorrect argument count for command"). It supports both placeholder styles
+// the rest of the stack emits:
+//   - `$N` PostgreSQL positional placeholders (selects args[N-1]); and
+//   - `?` positional placeholders (each consumes the next arg in order), which
+//     the transpiler produces for prepared statements (convertPlaceholders) and
+//     a few internal queries.
+//
+// Placeholders inside single-quoted string literals, double-quoted identifiers,
+// and `--` / `/* */` comments are left untouched. Unmatched placeholders (no
+// corresponding arg) are passed through unchanged.
 func interpolateArgs(query string, args []any) string {
-	for i := len(args); i >= 1; i-- {
-		placeholder := fmt.Sprintf("$%d", i)
-		replacement := formatArgValue(args[i-1])
-		query = strings.ReplaceAll(query, placeholder, replacement)
+	if len(args) == 0 {
+		return query
 	}
-	return query
+
+	var b strings.Builder
+	b.Grow(len(query) + 16*len(args))
+	nextPositional := 0
+
+	for i := 0; i < len(query); {
+		ch := query[i]
+		switch {
+		case ch == '\'' || ch == '"':
+			// String literal ('...') or quoted identifier ("..."); copy verbatim,
+			// honoring doubled-quote escapes.
+			end := scanQuoted(query, i, ch)
+			b.WriteString(query[i:end])
+			i = end
+		case ch == '-' && i+1 < len(query) && query[i+1] == '-':
+			end := indexOrEnd(query, i+2, "\n")
+			b.WriteString(query[i:end])
+			i = end
+		case ch == '/' && i+1 < len(query) && query[i+1] == '*':
+			end := blockCommentEnd(query, i+2)
+			b.WriteString(query[i:end])
+			i = end
+		case ch == '?':
+			if nextPositional < len(args) {
+				b.WriteString(formatArgValue(args[nextPositional]))
+				nextPositional++
+			} else {
+				b.WriteByte(ch)
+			}
+			i++
+		case ch == '$' && i+1 < len(query) && query[i+1] >= '1' && query[i+1] <= '9':
+			j := i + 1
+			for j < len(query) && query[j] >= '0' && query[j] <= '9' {
+				j++
+			}
+			if n, err := strconv.Atoi(query[i+1 : j]); err == nil && n >= 1 && n <= len(args) {
+				b.WriteString(formatArgValue(args[n-1]))
+			} else {
+				b.WriteString(query[i:j])
+			}
+			i = j
+		default:
+			b.WriteByte(ch)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// scanQuoted returns the index just past a quoted region starting at start
+// (query[start] == quote), treating a doubled quote ('' or "") as an escape.
+func scanQuoted(query string, start int, quote byte) int {
+	for i := start + 1; i < len(query); i++ {
+		if query[i] != quote {
+			continue
+		}
+		if i+1 < len(query) && query[i+1] == quote {
+			i++ // skip the doubled (escaped) quote
+			continue
+		}
+		return i + 1
+	}
+	return len(query)
+}
+
+func indexOrEnd(query string, start int, sub string) int {
+	if idx := strings.Index(query[start:], sub); idx >= 0 {
+		return start + idx + len(sub)
+	}
+	return len(query)
+}
+
+func blockCommentEnd(query string, start int) int {
+	if idx := strings.Index(query[start:], "*/"); idx >= 0 {
+		return start + idx + 2
+	}
+	return len(query)
 }
 
 func formatArgValue(v any) string {

--- a/server/flightclient/interpolate_args_test.go
+++ b/server/flightclient/interpolate_args_test.go
@@ -1,0 +1,99 @@
+package flightclient
+
+import "testing"
+
+func TestInterpolateArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		args  []any
+		want  string
+	}{
+		{
+			name:  "no args returns query unchanged",
+			query: "SELECT 1 WHERE x = ?",
+			args:  nil,
+			want:  "SELECT 1 WHERE x = ?",
+		},
+		{
+			name:  "single ? positional",
+			query: "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
+			args:  []any{"fivetran_testing_schema_abc"},
+			want:  "SELECT table_name FROM information_schema.tables WHERE table_schema = 'fivetran_testing_schema_abc'",
+		},
+		{
+			name:  "multiple ? consumed in order",
+			query: "SELECT * FROM t WHERE a = ? AND b = ? AND c = ?",
+			args:  []any{1, "two", true},
+			want:  "SELECT * FROM t WHERE a = 1 AND b = 'two' AND c = TRUE",
+		},
+		{
+			name:  "$N positional",
+			query: "SELECT * FROM t WHERE a = $1 AND b = $2",
+			args:  []any{int64(7), "x"},
+			want:  "SELECT * FROM t WHERE a = 7 AND b = 'x'",
+		},
+		{
+			name:  "$N multi-digit and reuse",
+			query: "SELECT $10, $1",
+			args:  []any{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			want:  "SELECT 'j', 'a'",
+		},
+		{
+			name:  "? inside single-quoted literal is not replaced",
+			query: "SELECT 'is this ?' WHERE x = ?",
+			args:  []any{5},
+			want:  "SELECT 'is this ?' WHERE x = 5",
+		},
+		{
+			name:  "? inside double-quoted identifier is not replaced",
+			query: `SELECT "weird?col" FROM t WHERE x = ?`,
+			args:  []any{5},
+			want:  `SELECT "weird?col" FROM t WHERE x = 5`,
+		},
+		{
+			name:  "? inside line comment is not replaced",
+			query: "SELECT 1 -- a ? here\nWHERE x = ?",
+			args:  []any{9},
+			want:  "SELECT 1 -- a ? here\nWHERE x = 9",
+		},
+		{
+			name:  "? inside block comment is not replaced",
+			query: "SELECT 1 /* ? ignored */ WHERE x = ?",
+			args:  []any{9},
+			want:  "SELECT 1 /* ? ignored */ WHERE x = 9",
+		},
+		{
+			name:  "string arg with single quote is escaped",
+			query: "WHERE s = ?",
+			args:  []any{"o'brien"},
+			want:  "WHERE s = 'o''brien'",
+		},
+		{
+			name:  "doubled-quote escape inside literal preserved",
+			query: "SELECT 'a''?b' WHERE x = ?",
+			args:  []any{1},
+			want:  "SELECT 'a''?b' WHERE x = 1",
+		},
+		{
+			name:  "unmatched ? (too few args) passes through",
+			query: "WHERE a = ? AND b = ?",
+			args:  []any{1},
+			want:  "WHERE a = 1 AND b = ?",
+		},
+		{
+			name:  "nil arg becomes NULL",
+			query: "WHERE a = ?",
+			args:  []any{nil},
+			want:  "WHERE a = NULL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := interpolateArgs(tt.query, tt.args); got != tt.want {
+				t.Fatalf("interpolateArgs(%q, %v)\n  = %q\n want %q", tt.query, tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/iceberg_drop_schema.go
+++ b/server/iceberg_drop_schema.go
@@ -126,13 +126,18 @@ func (c *clientConn) dropIcebergSchemaCascade(ctx context.Context, query string)
 		return nil, fmt.Errorf("DROP SCHEMA CASCADE fallback only supports iceberg catalog, got %q", catalog)
 	}
 
-	rows, err := c.executor.QueryContext(ctx, `
+	// Inline the schema as an escaped string literal rather than a `?` bind
+	// param: the Flight executor (control plane → worker) applies args by
+	// string-inlining $N placeholders only, and sends no bind params, so a `?`
+	// reaches the worker unbound and fails ("incorrect argument count: have 0
+	// want 1"). Inlining works on both the Flight and standalone executors.
+	rows, err := c.executor.QueryContext(ctx, fmt.Sprintf(`
 		SELECT table_name
 		FROM information_schema.tables
 		WHERE table_catalog = 'iceberg'
-		AND table_schema = ?
+		AND table_schema = '%s'
 		ORDER BY table_name
-	`, target.Schema)
+	`, escapeSQLStringLiteral(target.Schema)))
 	if err != nil {
 		return nil, fmt.Errorf("list iceberg schema tables: %w", err)
 	}

--- a/server/iceberg_drop_schema_test.go
+++ b/server/iceberg_drop_schema_test.go
@@ -145,6 +145,56 @@ func TestDropIcebergSchemaCascadeRejectsNonIcebergSearchPath(t *testing.T) {
 	}
 }
 
+// The list-tables query must inline the schema as an escaped string literal,
+// not a `?` bind param: the Flight executor inlines only $N placeholders and
+// sends no bind params, so a `?` reaches the worker unbound ("incorrect argument
+// count: have 0 want 1"). Regression test for that Flight-path failure.
+func TestDropIcebergSchemaCascadeInlinesSchemaLiteralNoBindParam(t *testing.T) {
+	exec := &icebergDropSchemaCascadeExecutor{
+		tableNames: []string{"person"},
+	}
+	c := &clientConn{executor: exec}
+
+	if _, err := c.dropIcebergSchemaCascade(context.Background(), `DROP SCHEMA IF EXISTS iceberg.fivetran_testing_schema_abc CASCADE`); err != nil {
+		t.Fatalf("dropIcebergSchemaCascade returned error: %v", err)
+	}
+
+	var listQuery string
+	for _, q := range exec.queryQueries {
+		if strings.Contains(q, "information_schema.tables") {
+			listQuery = q
+		}
+	}
+	if listQuery == "" {
+		t.Fatal("list-tables query was not issued")
+	}
+	if strings.Contains(listQuery, "?") {
+		t.Fatalf("list-tables query must not use a `?` bind param (breaks on Flight):\n%s", listQuery)
+	}
+	if !strings.Contains(listQuery, "table_schema = 'fivetran_testing_schema_abc'") {
+		t.Fatalf("list-tables query must inline the escaped schema literal:\n%s", listQuery)
+	}
+}
+
+// A schema name containing a single quote must be escaped (doubled) when inlined.
+func TestDropIcebergSchemaCascadeEscapesSchemaLiteral(t *testing.T) {
+	exec := &icebergDropSchemaCascadeExecutor{}
+	c := &clientConn{executor: exec}
+
+	if _, err := c.dropIcebergSchemaCascade(context.Background(), `DROP SCHEMA IF EXISTS "iceberg"."o'brien" CASCADE`); err != nil {
+		t.Fatalf("dropIcebergSchemaCascade returned error: %v", err)
+	}
+	var listQuery string
+	for _, q := range exec.queryQueries {
+		if strings.Contains(q, "information_schema.tables") {
+			listQuery = q
+		}
+	}
+	if !strings.Contains(listQuery, "table_schema = 'o''brien'") {
+		t.Fatalf("schema literal must be single-quote-escaped:\n%s", listQuery)
+	}
+}
+
 func TestQuoteIdentifier(t *testing.T) {
 	if got := sqlcore.QuoteIdentifier(`a"b`); got != `"a""b"` {
 		t.Fatalf("QuoteIdentifier = %q", got)
@@ -153,12 +203,17 @@ func TestQuoteIdentifier(t *testing.T) {
 
 type icebergDropSchemaCascadeExecutor struct {
 	noopProfiling
-	searchPath  string
-	execQueries []string
-	tableNames  []string
+	searchPath   string
+	execQueries  []string
+	queryQueries []string
+	tableNames   []string
 }
 
-func (e *icebergDropSchemaCascadeExecutor) QueryContext(_ context.Context, query string, _ ...any) (RowSet, error) {
+func (e *icebergDropSchemaCascadeExecutor) QueryContext(_ context.Context, query string, args ...any) (RowSet, error) {
+	e.queryQueries = append(e.queryQueries, query)
+	// The Flight executor sends no bind params (it inlines $N), so callers must
+	// not rely on `?`/args here — mirror that by ignoring args entirely.
+	_ = args
 	if strings.Contains(query, "duckdb_settings()") {
 		return &icebergDropSchemaCascadeRows{values: []string{e.searchPath}}, nil
 	}


### PR DESCRIPTION
## What

Two related fixes for the control-plane → worker (**Flight**) path. Follow-up to #661.

### 1. Root-cause hardening: the Flight executor now inlines `?` placeholders

The Flight executor sends ad-hoc statements with args **inlined into the SQL string** (no separate bind params), but `interpolateArgs` only substituted `$N`. Any `?` left in the query reached the worker unbound and failed to prepare:

```
flight execute: rpc error: code = InvalidArgument desc = failed to prepare query:
incorrect argument count for command: have 0 want 1
```

This is broader than DROP SCHEMA CASCADE: **prepared statements with parameters** are transpiled with `convertPlaceholders` (`$N`→`?`) and executed via `c.executor` with args, so parameterized extended-protocol queries on the multitenant/worker path hit the same failure. The standalone `database/sql` executor binds `?` natively, which is why it only failed on the Flight path.

`interpolateArgs` is rewritten as a SQL-aware single pass that inlines both `?` (positional) and `$N` placeholders, **skipping any inside string literals, quoted identifiers, and `--` / `/* */` comments**. Unit tests cover positional `?`, `$N` (incl. multi-digit), literal/identifier/comment skipping, single-quote escaping, and unmatched placeholders.

### 2. DROP SCHEMA CASCADE fallback: inline the schema literal

The fallback's list-tables query used a `?` bind param (the original Fivetran failure). It now inlines the schema as an escaped string literal (`escapeSQLStringLiteral`) — Flight-safe and defensive for an internal query, independent of the executor's placeholder handling. Regression tests assert no `?` and a correctly-escaped literal.

## Verification

- Deterministically reproduced the mechanism: `interpolateArgs` left `?` intact and dropped the arg (only `$N` was inlined) → worker prepares 1 param with 0 args.
- `go build ./...` + `-tags kubernetes` — clean
- `flightclient` / `server` / `controlplane` suites green (incl. new `interpolateArgs` + DROP SCHEMA CASCADE regression tests)
- Live Lakekeeper: `DROP SCHEMA … CASCADE` on a schema containing a table drops the member tables then the schema end-to-end.

## Why it slipped through

The DROP SCHEMA CASCADE fallback was written with `database/sql` idioms (typed scan, `?` params) and only ever exercised on the standalone executor — so it hit two Flight-path bugs in a row (the `*interface{}` scan in #661, and this `?` param). The executor-level fix removes the `?` footgun for all callers; the mocks now mirror the real Flight RowSet/param contract so regressions fail in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)