### PR TITLE
fix(worker-profile): colocated workers skip cache-proxy integration

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -800,7 +800,13 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	// DaemonSet proxy on the same node via the node IP + fixed hostPort.
 	// Inject NODE_IP via the Downward API so the worker process can resolve
 	// the proxy address at runtime.
-	if os.Getenv("DUCKGRES_CACHE_ENABLED") == "true" {
+	//
+	// Colocated workers are exempt: they bin-pack onto the dedicated colocated
+	// nodepool, which runs no cache-proxy DaemonSet (and has no NVMe to back
+	// one). If they inherited DUCKGRES_CACHE_ENABLED they would block forever in
+	// waitForCacheProxy() waiting on a proxy that never comes up, never answer
+	// the control plane's gRPC health check, and churn. They talk to S3 directly.
+	if os.Getenv("DUCKGRES_CACHE_ENABLED") == "true" && !profile.Colocate {
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
 			corev1.EnvVar{
 				Name:  "DUCKGRES_CACHE_ENABLED",

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -956,6 +956,95 @@ func TestK8sPool_SpawnWorkerCleansUpWhenRPCSecurityReadCancelsContext(t *testing
 	}
 }
 
+// createdPodEnv returns the container env of the pod created via the fake
+// clientset under the given name. spawnWorker creates the pod before any of its
+// later steps can fail, so this is observable even when spawnWorker errors out.
+func createdPodEnv(t *testing.T, cs *fake.Clientset, podName string) []corev1.EnvVar {
+	t.Helper()
+	for _, action := range cs.Actions() {
+		if !action.Matches("create", "pods") {
+			continue
+		}
+		ca, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			continue
+		}
+		pod, ok := ca.GetObject().(*corev1.Pod)
+		if !ok || pod.Name != podName {
+			continue
+		}
+		return pod.Spec.Containers[0].Env
+	}
+	t.Fatalf("no create pods action for %q; actions=%v", podName, cs.Actions())
+	return nil
+}
+
+func envHasName(env []corev1.EnvVar, name string) bool {
+	for _, e := range env {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Colocated workers run on the bin-pack nodepool, which has no cache-proxy
+// DaemonSet. They must not inherit DUCKGRES_CACHE_ENABLED, or they block forever
+// in waitForCacheProxy() and never answer the control plane's gRPC health check.
+func TestK8sPool_SpawnWorker_ColocatedSkipsCacheProxyEnv(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+
+	cases := []struct {
+		name         string
+		profile      WorkerProfile
+		wantCacheEnv bool
+	}{
+		{"exclusive worker gets cache proxy env", WorkerProfile{}, true},
+		{"colocated worker skips cache proxy env", WorkerProfile{Colocate: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, cs := newTestK8sPool(t, 5)
+			workerID := 11
+			podName := pool.podNameForWorker(workerID)
+			secretName := pool.workerRPCSecretName(podName)
+
+			cs.Fake.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				ga, ok := action.(k8stesting.GetAction)
+				if !ok || ga.GetName() != podName {
+					return false, nil, nil
+				}
+				return true, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: pool.namespace},
+					Spec:       corev1.PodSpec{NodeName: "node-a"},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.11"},
+				}, nil
+			})
+			// Force a failure after the pod is created (we only inspect the pod spec).
+			cs.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				ga, ok := action.(k8stesting.GetAction)
+				if !ok || ga.GetName() != secretName {
+					return false, nil, nil
+				}
+				return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, secretName)
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			_ = pool.spawnWorker(ctx, workerID, "duckgres:test", tc.profile, false)
+
+			env := createdPodEnv(t, cs, podName)
+			gotCache := envHasName(env, "DUCKGRES_CACHE_ENABLED")
+			gotNodeIP := envHasName(env, "NODE_IP")
+			if gotCache != tc.wantCacheEnv || gotNodeIP != tc.wantCacheEnv {
+				t.Fatalf("profile %+v: DUCKGRES_CACHE_ENABLED=%v NODE_IP=%v, want both %v",
+					tc.profile, gotCache, gotNodeIP, tc.wantCacheEnv)
+			}
+		})
+	}
+}
+
 func TestK8sPool_WorkerLookup(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 

--- a/docs/design/connection-string-worker-profile.md
+++ b/docs/design/connection-string-worker-profile.md
@@ -66,3 +66,20 @@ An adversarial multi-agent review (36/37 findings confirmed) drove these fixes:
 - **Worker PriorityClass** so worker pods preempt the overprovision headroom pause pods (else a real worker forces a fresh node).
 - **`worker_tier` wired from env** (`DUCKGRES_K8S_WORKER_TIERS`); previously unreachable in production.
 - **Deeper client connect retry** (~5 min) to outlast a cold colocated-node provision.
+
+## Post-deploy fix: colocated workers skip the cache proxy
+
+First mw-prod-us deploy churned: every colocated worker blocked forever in
+`waitForCacheProxy()`. The cache-proxy DaemonSet is pinned to the
+`duckgres-workers` nodepool (nodeSelector + toleration) and mounts the node's
+NVMe (`hostPath: /mnt/.ephemeral`). The colocated bin-pack nodepool runs no
+cache proxy and is deliberately NVMe-free, so the proxy can't run there. Workers
+with `DUCKGRES_CACHE_ENABLED=true` waited on a health endpoint that never came
+up, never answered the control plane's gRPC health check, and were torn
+down/respawned every ~90s — which also saturated the shared client-go rate
+limiter (the 8/48 shape couldn't even read its configmap).
+
+Fix: the control plane omits `DUCKGRES_CACHE_ENABLED`/`NODE_IP` when spawning a
+colocated worker (`spawnWorker`, gated on `!profile.Colocate`). Colocated
+workers talk to S3 directly; exclusive workers keep the node-local cache. No
+worker-code change — `cacheEnabled()` already no-ops when the env is unset.


### PR DESCRIPTION
## Problem

First mw-prod-us deploy of the colocated worker pool churned continuously. Every colocated worker blocked at startup:

```
"Cache proxy integration enabled." health_url=http://<node-ip>:8082/health
"Waiting for cache proxy to be ready."   ← blocks forever
```

Root cause: the `duckgres-cache-proxy` DaemonSet is pinned to the `duckgres-workers` nodepool (nodeSelector + toleration) and mounts the node's NVMe (`hostPath: /mnt/.ephemeral`). The new `duckgres-workers-colocated` bin-pack nodepool runs **no** cache proxy and is deliberately NVMe-free, so the proxy can't run there. Colocated workers inherited `DUCKGRES_CACHE_ENABLED=true` and hung in `waitForCacheProxy()` (an infinite loop) on a proxy that never comes up:

- never answered the control plane's gRPC health check → `DeadlineExceeded`
- torn down and respawned every ~90s (worker ids climbing 56039→56234+)
- the spawn-storm **saturated the shared client-go rate limiter**, so the 8/48 Iceberg shape couldn't even `get configmap duckgres-config`

Gated off for clients (`DUCKGRES_WORKER_PROFILE_ENABLED` not set in posthog), so no customer impact — the warm reconcile was the only thing spawning these workers. No customer/exclusive spawn failures observed.

## Fix

`spawnWorker` omits `DUCKGRES_CACHE_ENABLED`/`NODE_IP` for colocated profiles (`&& !profile.Colocate`). Colocated workers talk to S3 directly; exclusive workers keep the node-local cache. No worker-code change — `cacheEnabled()` already no-ops when the env is unset.

This is the agreed direction (decouple colocated workers from the cache proxy) rather than giving colocated nodes NVMe or running a second NVMe-free proxy DaemonSet.

## Test

`TestK8sPool_SpawnWorker_ColocatedSkipsCacheProxyEnv` — with `DUCKGRES_CACHE_ENABLED=true`, asserts the exclusive profile's pod gets `DUCKGRES_CACHE_ENABLED`+`NODE_IP` and the colocated profile's pod gets neither. Full `controlplane` suite green under `-tags kubernetes`.

## Rollout

Needs a new prod image → manual Promote-to-Prod on mw-prod-us (the colocated warm config is already live, so the churn stops as soon as this image rolls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)