### PR TITLE
Fix targeted Iceberg metadata loading

### DIFF
--- a/docs/runbooks/lakekeeper-iceberg-catalog.md
+++ b/docs/runbooks/lakekeeper-iceberg-catalog.md
@@ -136,6 +136,12 @@ schema, so raw `information_schema.columns` may expose placeholder
 Lakekeeper REST catalog to load current table schemas with bounded
 concurrency before returning `information_schema.columns` results.
 
+For simple PostgreSQL client metadata predicates such as
+`table_schema = 'x' AND table_name = 'y'`, Duckgres targets the preload to the
+requested table. For broad metadata scans, stale Lakekeeper `404` table entries
+are skipped because DuckDB's Iceberg `information_schema.tables` may
+temporarily expose dropped tables from a worker/session-local catalog view.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Action |

--- a/server/icebergmeta/icebergmeta.go
+++ b/server/icebergmeta/icebergmeta.go
@@ -24,6 +24,11 @@ type Config struct {
 	LakekeeperOAuth2ServerURI string
 }
 
+type tableFilter struct {
+	Schema string
+	Name   string
+}
+
 type sourceColumn struct {
 	Name     string
 	Type     string
@@ -44,7 +49,8 @@ func LoadColumns(ctx context.Context, executor sqlcore.QueryExecutor, query stri
 		return nil
 	}
 
-	tables, err := listCandidateTables(ctx, executor)
+	filter := extractTableFilter(query)
+	tables, err := listCandidateTables(ctx, executor, filter)
 	if err != nil {
 		return err
 	}
@@ -56,7 +62,8 @@ func LoadColumns(ctx context.Context, executor sqlcore.QueryExecutor, query stri
 	if err != nil {
 		return err
 	}
-	columns, err := source.LoadColumns(ctx, cfg.LakekeeperWarehouse, tables)
+	strictMissing := filter.Schema != "" || filter.Name != ""
+	columns, err := source.LoadColumns(ctx, cfg.LakekeeperWarehouse, tables, strictMissing)
 	if err != nil {
 		return err
 	}
@@ -70,14 +77,54 @@ func firstConfig(configs []Config) Config {
 	return configs[0]
 }
 
-func listCandidateTables(ctx context.Context, executor sqlcore.QueryExecutor) ([]tableRef, error) {
+func extractTableFilter(query string) tableFilter {
+	lower := strings.ToLower(query)
+	return tableFilter{
+		Schema: extractSingleQuotedPredicate(query, lower, "table_schema"),
+		Name:   extractSingleQuotedPredicate(query, lower, "table_name"),
+	}
+}
+
+func extractSingleQuotedPredicate(query, lowerQuery, column string) string {
+	markers := []string{
+		column + " = '",
+		column + "='",
+		"c." + column + " = '",
+		"c." + column + "='",
+	}
+	for _, marker := range markers {
+		idx := strings.Index(lowerQuery, marker)
+		if idx < 0 {
+			continue
+		}
+		start := idx + len(marker)
+		end := strings.Index(query[start:], "'")
+		if end < 0 {
+			return ""
+		}
+		value := query[start : start+end]
+		if strings.Contains(value, "%") {
+			return ""
+		}
+		return value
+	}
+	return ""
+}
+
+func listCandidateTables(ctx context.Context, executor sqlcore.QueryExecutor, filter tableFilter) ([]tableRef, error) {
 	query := `
 		SELECT table_schema, table_name
 		FROM information_schema.tables
 		WHERE table_catalog = 'iceberg'
 		AND table_type = 'BASE TABLE'
-		ORDER BY table_schema, table_name
 	`
+	if filter.Schema != "" {
+		query += "\n\t\tAND table_schema = " + quoteSQLString(filter.Schema)
+	}
+	if filter.Name != "" {
+		query += "\n\t\tAND table_name = " + quoteSQLString(filter.Name)
+	}
+	query += "\n\t\tORDER BY table_schema, table_name"
 
 	rows, err := executor.QueryContext(ctx, query)
 	if err != nil {

--- a/server/icebergmeta/icebergmeta_test.go
+++ b/server/icebergmeta/icebergmeta_test.go
@@ -107,8 +107,8 @@ func TestLoadColumnsUsesLakekeeperREST(t *testing.T) {
 	if got := strings.Join(exec.queries, "\n"); strings.Contains(got, "DESCRIBE SELECT") {
 		t.Fatalf("REST metadata path should not describe Iceberg tables, queries:\n%s", got)
 	}
-	if got := strings.Join(exec.queries, "\n"); strings.Contains(got, "table_schema IN") || strings.Contains(got, "table_name IN") {
-		t.Fatalf("metadata loading should not parse user query predicates into table filters, queries:\n%s", got)
+	if got := strings.Join(exec.queries, "\n"); !strings.Contains(got, "table_schema = 'billing_public'") {
+		t.Fatalf("metadata loading should filter simple table_schema predicates, queries:\n%s", got)
 	}
 	if got := strings.Join(exec.queries, "\n"); strings.Contains(got, "NOT EXISTS") {
 		t.Fatalf("metadata loading should refresh tables explicitly instead of relying on hidden session cache, queries:\n%s", got)
@@ -144,6 +144,67 @@ func TestLoadColumnsUsesLakekeeperREST(t *testing.T) {
 	}
 }
 
+func TestLoadColumnsFiltersCandidatesFromSimpleCompatPredicates(t *testing.T) {
+	var loadedPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/config":
+			_, _ = w.Write([]byte(`{"defaults":{"prefix":"warehouse-id"}}`))
+		case "/v1/warehouse-id/namespaces/stripe_test/tables/product":
+			loadedPaths = append(loadedPaths, r.URL.Path)
+			_, _ = w.Write([]byte(`{
+				"metadata": {
+					"current-schema-id": 1,
+					"schemas": [
+						{
+							"schema-id": 1,
+							"type": "struct",
+							"fields": [
+								{"id": 1, "name": "id", "type": "string", "required": true}
+							]
+						}
+					]
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected REST path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	exec := &scriptedExecutor{
+		rows: []sqlcore.RowSet{
+			&rowSet{cols: []string{"table_schema", "table_name"}, rows: [][]any{
+				{"stripe_test", "product"},
+			}},
+		},
+	}
+
+	err := LoadColumns(context.Background(), exec, `
+		SELECT c.column_name, c.data_type
+		FROM memory.main.information_schema_columns_compat c
+		WHERE c.table_schema = 'stripe_test'
+		AND c.table_name = 'product'
+	`, Config{
+		LakekeeperEndpoint:  srv.URL,
+		LakekeeperWarehouse: "org-acme",
+	})
+	if err != nil {
+		t.Fatalf("LoadColumns: %v", err)
+	}
+
+	listQuery := strings.Join(exec.queries, "\n")
+	if !strings.Contains(listQuery, "table_schema = 'stripe_test'") {
+		t.Fatalf("candidate query did not filter table_schema:\n%s", listQuery)
+	}
+	if !strings.Contains(listQuery, "table_name = 'product'") {
+		t.Fatalf("candidate query did not filter table_name:\n%s", listQuery)
+	}
+	if got, want := len(loadedPaths), 1; got != want {
+		t.Fatalf("REST table loads = %d, want %d", got, want)
+	}
+}
+
 func TestLoadColumnsReturnsLakekeeperRESTUnavailableError(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
@@ -166,6 +227,101 @@ func TestLoadColumnsReturnsLakekeeperRESTUnavailableError(t *testing.T) {
 	}
 	if got := strings.Join(exec.queries, "\n"); strings.Contains(got, "DESCRIBE SELECT") {
 		t.Fatalf("REST-only metadata path should not describe Iceberg tables, queries:\n%s", got)
+	}
+}
+
+func TestLoadColumnsSkipsMissingTablesDuringBroadRefresh(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/config":
+			_, _ = w.Write([]byte(`{"defaults":{"prefix":"warehouse-id"}}`))
+		case "/v1/warehouse-id/namespaces/live/tables/product":
+			_, _ = w.Write([]byte(`{
+				"metadata": {
+					"current-schema-id": 1,
+					"schemas": [
+						{
+							"schema-id": 1,
+							"type": "struct",
+							"fields": [
+								{"id": 1, "name": "id", "type": "string", "required": true}
+							]
+						}
+					]
+				}
+			}`))
+		case "/v1/warehouse-id/namespaces/stale/tables/dropped":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected REST path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	exec := &scriptedExecutor{
+		rows: []sqlcore.RowSet{
+			&rowSet{cols: []string{"table_schema", "table_name"}, rows: [][]any{
+				{"live", "product"},
+				{"stale", "dropped"},
+			}},
+		},
+	}
+
+	err := LoadColumns(context.Background(), exec, `
+		SELECT c.column_name, c.data_type
+		FROM memory.main.information_schema_columns_compat c
+	`, Config{
+		LakekeeperEndpoint:  srv.URL,
+		LakekeeperWarehouse: "org-acme",
+	})
+	if err != nil {
+		t.Fatalf("LoadColumns should skip stale broad-refresh 404s: %v", err)
+	}
+
+	insert := strings.Join(exec.execs, "\n")
+	if !strings.Contains(insert, "'live'") || !strings.Contains(insert, "'product'") {
+		t.Fatalf("live table metadata was not inserted:\n%s", insert)
+	}
+	if strings.Contains(insert, "'stale'") || strings.Contains(insert, "'dropped'") {
+		t.Fatalf("stale missing table metadata should not be inserted:\n%s", insert)
+	}
+}
+
+func TestLoadColumnsFailsMissingRequestedTable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/config":
+			_, _ = w.Write([]byte(`{"defaults":{"prefix":"warehouse-id"}}`))
+		case "/v1/warehouse-id/namespaces/stripe_test/tables/product":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected REST path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	exec := &scriptedExecutor{
+		rows: []sqlcore.RowSet{
+			&rowSet{cols: []string{"table_schema", "table_name"}, rows: [][]any{
+				{"stripe_test", "product"},
+			}},
+		},
+	}
+
+	err := LoadColumns(context.Background(), exec, `
+		SELECT c.column_name, c.data_type
+		FROM memory.main.information_schema_columns_compat c
+		WHERE c.table_schema = 'stripe_test'
+		AND c.table_name = 'product'
+	`, Config{
+		LakekeeperEndpoint:  srv.URL,
+		LakekeeperWarehouse: "org-acme",
+	})
+	if err == nil {
+		t.Fatal("expected missing requested table to fail")
+	}
+	if !errors.Is(err, errRESTCatalogTableNotFound) {
+		t.Fatalf("error = %v, want errRESTCatalogTableNotFound", err)
 	}
 }
 
@@ -261,7 +417,7 @@ func TestRestCatalogMetadataSourceLimitsConcurrency(t *testing.T) {
 		tables[i] = tableRef{Schema: "billing_public", Name: fmt.Sprintf("t_%02d", i)}
 	}
 
-	cols, err := restCatalogMetadataSource{endpoint: srv.URL}.LoadColumns(context.Background(), "org-acme", tables)
+	cols, err := restCatalogMetadataSource{endpoint: srv.URL}.LoadColumns(context.Background(), "org-acme", tables, true)
 	if err != nil {
 		t.Fatalf("LoadColumns: %v", err)
 	}

--- a/server/icebergmeta/rest_catalog.go
+++ b/server/icebergmeta/rest_catalog.go
@@ -18,6 +18,7 @@ import (
 const restCatalogConcurrency = 8
 
 var errRESTCatalogUnavailable = errors.New("lakekeeper REST catalog metadata unavailable")
+var errRESTCatalogTableNotFound = fmt.Errorf("%w: table not found", errRESTCatalogUnavailable)
 
 type restCatalogMetadataSource struct {
 	endpoint string
@@ -62,7 +63,7 @@ func (c Config) restMetadataSource() (restCatalogMetadataSource, error) {
 	}, nil
 }
 
-func (s restCatalogMetadataSource) LoadColumns(ctx context.Context, warehouse string, tables []tableRef) (map[tableRef][]sourceColumn, error) {
+func (s restCatalogMetadataSource) LoadColumns(ctx context.Context, warehouse string, tables []tableRef, strictMissing bool) (map[tableRef][]sourceColumn, error) {
 	if len(tables) == 0 {
 		return nil, nil
 	}
@@ -81,6 +82,9 @@ func (s restCatalogMetadataSource) LoadColumns(ctx context.Context, warehouse st
 		g.Go(func() error {
 			cols, err := s.loadTableColumns(ctx, prefix, table)
 			if err != nil {
+				if !strictMissing && errors.Is(err, errRESTCatalogTableNotFound) {
+					return nil
+				}
 				return err
 			}
 			mu.Lock()
@@ -158,7 +162,10 @@ func (s restCatalogMetadataSource) getJSON(ctx context.Context, requestURL strin
 	if err != nil {
 		return fmt.Errorf("%w: read GET %s response: %v", errRESTCatalogUnavailable, requestURL, err)
 	}
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: GET %s returned HTTP %d", errRESTCatalogTableNotFound, requestURL, resp.StatusCode)
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("%w: GET %s returned HTTP %d", errRESTCatalogUnavailable, requestURL, resp.StatusCode)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {


### PR DESCRIPTION
## Summary
- Target Lakekeeper column metadata preloads to simple information_schema.columns table_schema/table_name predicates.
- Skip stale Lakekeeper 404 table metadata only during broad metadata refreshes, while preserving hard failures for requested missing tables.
- Add regression tests and document the Iceberg information_schema behavior in the Lakekeeper runbook.

## Test plan
- go test ./server/icebergmeta ./server -run 'Iceberg|InformationSchemaColumnsCompat|Metadata' -count=1
- git diff --check

## Notes
- just lint could not run locally because golangci-lint is not installed in this environment.