### PR TITLE
fix(warm-pool): warm-spawn deadline must outlast pod-ready (exclusive pool refill after restart)

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -37,6 +37,21 @@ import (
 
 const defaultActivatingTimeout = 2 * time.Minute
 
+// workerPodReadyTimeout bounds how long a spawn waits for a worker pod to become
+// Ready. A cold spawn may need Karpenter to provision a fresh node (a single-
+// tenant exclusive 46/360 worker gets a dedicated large instance), so this is
+// generous.
+const workerPodReadyTimeout = 5 * time.Minute
+
+// warmSpawnReconcileTimeout bounds a warm-pool replenish/reconcile spawn. It MUST
+// exceed workerPodReadyTimeout: a warm spawn does the same waitForPodReady, so a
+// shorter deadline cancels every cold spawn before its node can provision. The
+// old 30s value meant the warm reconcile could never refill an exclusive worker
+// that needed a fresh node — after a CP restart the default/exclusive pool would
+// sit empty, churning "context deadline exceeded", while only colocated (small,
+// fast, bin-packed) shapes refilled. See TestWarmSpawnTimeoutExceedsPodReady.
+const warmSpawnReconcileTimeout = 6 * time.Minute
+
 var errStaleRuntimeWorkerClaim = stderrors.New("stale runtime worker claim")
 
 // K8sWorkerPool manages worker pods in Kubernetes.
@@ -925,7 +940,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	}
 
 	// Wait for pod to get an IP via informer (no polling).
-	ready, err := p.waitForPodReady(ctx, podName, 5*time.Minute)
+	ready, err := p.waitForPodReady(ctx, podName, workerPodReadyTimeout)
 	if err != nil {
 		_ = p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 			GracePeriodSeconds: int64Ptr(0),
@@ -2216,7 +2231,7 @@ func (p *K8sWorkerPool) triggerPerImageReplenish(image string) {
 		return
 	}
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), warmSpawnReconcileTimeout)
 		defer cancel()
 		if err := p.SpawnMinWorkersForImage(ctx, image, target); err != nil {
 			slog.Warn("Per-image warm replenish failed.", "image", image, "error", err)
@@ -2454,7 +2469,7 @@ func (p *K8sWorkerPool) triggerColocatedWarmReplenish(profile WorkerProfile) {
 		return
 	}
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), warmSpawnReconcileTimeout)
 		defer cancel()
 		if err := p.SpawnMinColocatedWorkers(ctx, profile, target); err != nil {
 			slog.Warn("Colocated warm replenish failed.", "cpu", profile.CPU, "memory", profile.Memory, "error", err)

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1045,6 +1045,20 @@ func TestK8sPool_SpawnWorker_ColocatedSkipsCacheProxyEnv(t *testing.T) {
 	}
 }
 
+// A warm-pool reconcile spawn does the same waitForPodReady as any spawn, so its
+// context deadline must outlast workerPodReadyTimeout — otherwise a cold spawn
+// (fresh Karpenter node, e.g. an exclusive 46/360 worker on a dedicated large
+// instance) is cancelled before its node can provision. When that happened the
+// default/exclusive warm pool sat empty after a CP restart, churning
+// "context deadline exceeded", while only the small/fast colocated shapes refilled.
+func TestWarmSpawnTimeoutExceedsPodReady(t *testing.T) {
+	if warmSpawnReconcileTimeout <= workerPodReadyTimeout {
+		t.Fatalf("warmSpawnReconcileTimeout (%s) must exceed workerPodReadyTimeout (%s); "+
+			"a shorter warm deadline cancels cold spawns before their node provisions",
+			warmSpawnReconcileTimeout, workerPodReadyTimeout)
+	}
+}
+
 func TestK8sPool_WorkerLookup(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -299,7 +299,7 @@ func SetupMultiTenant(
 		// 4/16 and 8/48) bursts into a ready pod. Coupled to the master gate so we
 		// don't pre-warm colocated pods that no client can route to.
 		if cfg.K8s.AllowClientWorkerProfile && len(cfg.K8s.ColocatedWarmShapes) > 0 {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), warmSpawnReconcileTimeout)
 			router.sharedPool.reconcileColocatedWarm(ctx)
 			cancel()
 		}
@@ -636,7 +636,7 @@ func reconcileWarmCapacityImageTargets(pool *K8sWorkerPool, targets map[string]i
 		wg.Add(1)
 		go func(image string, count int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), warmSpawnReconcileTimeout)
 			defer cancel()
 			if err := pool.SpawnMinWorkersForImage(ctx, image, count); err != nil {
 				slog.Warn("Janitor failed to reconcile image warm capacity.", "image", image, "target", count, "error", err)


### PR DESCRIPTION
## Problem (found on mw-prod-us)

After the CP was promoted to #670, the **default/exclusive shared-warm pool sat stuck at ~1 of 6** workers, churning `context deadline exceeded`, while the colocated 8/48 + 4/16 pools refilled fine. Customer **query** connections use the default profile (and profile matching is strict — a default request can't borrow a colocated worker), so they had no warm worker and would cold-start or stall.

## Root cause

Every warm-pool replenish/reconcile spawn ran with a **30s** context deadline, but a spawn's `waitForPodReady` is **5 min** — sized for Karpenter to provision a fresh node. An exclusive 46/360 worker needs its own large instance (`r6gd.16xlarge`, ~2-3 min). So the 30s ctx cancelled the spawn **every time** before the node could come up. The periodic janitor reconcile (`reconcileWarmCapacityImageTargets`) is what maintains the default pool at `SHARED_WARM_TARGET`, and it hit this 30s deadline → the default pool could never refill after a restart. Small, fast, bin-packed colocated shapes fit inside 30s, so they recovered — masking the bug.

Four sites all used `30 * time.Second`:
- `k8s_pool.go` `triggerPerImageReplenish` + `triggerColocatedWarmReplenish` (fire-and-forget)
- `multitenant.go` janitor `reconcileColocatedWarm` + `reconcileWarmCapacityImageTargets` (periodic)

## Fix

Two named constants:
- `workerPodReadyTimeout = 5m` (the existing pod-ready wait, now named + used at the spawn site)
- `warmSpawnReconcileTimeout = 6m` — **must exceed** the pod-ready wait; used at all four warm-spawn sites.

`TestWarmSpawnTimeoutExceedsPodReady` guards the invariant.

### Note on janitor blocking
The janitor reconcile is synchronous (`wg.Wait`). This change does **not** make blocking worse — it makes it better: the old 30s blocked the janitor *every tick forever* (perpetual deficit + churn, pool never filled); the new 6m blocks **once** for the duration of a cold fill, after which the pool is at target and the reconcile returns instantly. In-flight spawns are counted at the DB layer (`CreateNeutralWarmWorkerSlotForImage`), so no double-spawn across ticks.

## Test
Full `controlplane` suite green under `-tags kubernetes`; new invariant test passes.

## Rollout
New CP image → prod promote → CP restart. With this fix, that restart's warm pools (incl. the exclusive default pool) actually refill to target instead of stalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)