### PR TITLE
Drop the numeric-team_id Trino org-id validator

### DIFF
--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -14,7 +14,8 @@
 #                                         Trino's file group provider (v1)
 #                                         or OIDC group claim (post-v1).
 #                                         Customer principals get
-#                                         `org_<team_id>`; the admin gets
+#                                         `org_<org>` (org = sanitized
+#                                         Org.Name); the admin gets
 #                                         the admin group. Customer access
 #                                         decisions key on this, not on the
 #                                         username -- so the bundle schema
@@ -73,7 +74,7 @@ default allow := false
 # is defense in depth: in v1 both signals come from the same K8s Secret
 # (password.db + group.db projected by the provisioner), but the
 # conjunction guards against a regression in projection logic that lets
-# a customer's team_id collide with the admin name OR be added to the
+# a customer's org name collide with the admin name OR be added to the
 # admin group. Under v2 OIDC, the username + group claim ride together
 # in a signed JWT; the conjunction still hardens the boundary should
 # any future identity flow split them.

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -67,7 +67,7 @@ func twoOrgFixture() GroupCatalogs {
 
 // groupsFor returns the Trino group memberships we model for a given user.
 // Mirrors the provisioner's projection logic: customers belong to
-// `org_<team_id>`; the admin user belongs to AdminGroup.
+// `org_<org>` (org = sanitized Org.Name); the admin user belongs to AdminGroup.
 func groupsFor(user string) []string {
 	if user == AdminPrincipal {
 		return []string{AdminGroup}

--- a/controlplane/provisioner/opa/types.go
+++ b/controlplane/provisioner/opa/types.go
@@ -18,7 +18,8 @@
 //
 // Keying choice: the policy authorizes by *group* membership, not by
 // username. Trino's file group provider (and, post-v1, OIDC group claims)
-// stamps `org_<team_id>` (and `__admin_provisioner` for the admin) into
+// stamps `org_<org>` (sanitized Org.Name; and `__admin_provisioner` for
+// the admin) into
 // every request's `identity.groups`. Keying on groups means the bundle
 // schema does not change when v2 moves from password-file auth to OIDC
 // with per-user identity within an org -- only the source of
@@ -27,9 +28,10 @@
 // per-user and require a bundle-shape migration during the OIDC rollout.
 package opa
 
-// GroupCatalogs maps a Trino group name (e.g. `org_<team_id>` for customer
-// orgs, or the admin group for the provisioner's smoke-test access) to the
-// set of catalog names that group owns.
+// GroupCatalogs maps a Trino group name (e.g. `org_<org>` for customer
+// orgs, where `org` is the sanitized Org.Name; or the admin group for
+// the provisioner's smoke-test access) to the set of catalog names that
+// group owns.
 //
 // The "set" is represented as map[string]bool with the value always true,
 // so the Rego policy can do an O(1) presence check

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -127,8 +127,8 @@ func TrinoGroupName(orgName string) string {
 // get re-interpreted as a hierarchy separator in Trino's resource-
 // group path (and so the selector + subgroup names stay aligned across
 // the catalog, group, and resource-group projections). Customer
-// principals' Trino username == orgName (numeric team_id in v1), but
-// the underlying type is still a string so we sanitize defensively.
+// principals' Trino username == orgName (a DNS-1123 label), and we
+// sanitize defensively so a non-identifier char can't reshape the path.
 func TrinoResourceGroupName(orgName string) string {
 	return "root.tenants." + trinoSanitize(orgName)
 }
@@ -1010,13 +1010,14 @@ func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []confi
 //
 // Format conventions:
 //
-//	password.db: <team_id>:<bcrypt hash from OrgUser.Password>
-//	             One line per org. Hash is copied through unchanged
-//	             — it's already bcrypt in the configstore.
+//	password.db: <org_name>:<bcrypt hash from OrgUser.Password>
+//	             One line per org (org_name is the DNS-1123 Org.Name, the
+//	             customer principal's Trino username). Hash is copied
+//	             through unchanged — it's already bcrypt in the configstore.
 //	group.db:    <group_name>:<comma-separated users>
 //	             NOTE: this is the opposite direction from password.db.
 //	             For v1 (one user per org) the value is the single
-//	             team_id. Easy to get backwards, hence this comment.
+//	             org_name. Easy to get backwards, hence this comment.
 //
 // Orgs without a RootPasswordHash are skipped silently (the listing
 // query already filters to (org, root-user) pairs, so this is just
@@ -1045,7 +1046,7 @@ func BuildTrinoAuthFiles(orgs []configstore.TrinoEnabledOrg, adminPasswordHash s
 		}
 		pwLines = append(pwLines, fmt.Sprintf("%s:%s", o.OrgID, o.RootPasswordHash))
 		// group_name first, comma-separated users second. For v1 this
-		// is one user per group (team_id only).
+		// is one user per group (the org name only).
 		grpLines = append(grpLines, fmt.Sprintf("%s:%s", TrinoGroupName(o.OrgID), o.OrgID))
 	}
 	// Trailing newline so a file with one entry round-trips through
@@ -1075,7 +1076,8 @@ func (p *TrinoProvisioner) reconcileResourceGroups(ctx context.Context, orgs []c
 }
 
 // resourceGroupSubGroup is the per-org subgroup serialized into
-// resource-groups.json under root.tenants.<team_id>.
+// resource-groups.json under root.tenants.<sanitized-org-name>
+// (trinoSanitize(Org.Name), so ben-iceberg-cnpg → ben_iceberg_cnpg).
 type resourceGroupSubGroup struct {
 	Name                 string `json:"name"`
 	SoftMemoryLimit      string `json:"softMemoryLimit"`
@@ -1147,12 +1149,15 @@ func tierLimits(tier string) resourceGroupSubGroup {
 //
 //	root
 //	  └─ tenants
-//	       ├─ 42        (team_id)
-//	       ├─ 43
+//	       ├─ acme              (org name; sanitize is a no-op)
+//	       ├─ ben_iceberg_cnpg  (= trinoSanitize("ben-iceberg-cnpg"))
 //	       └─ ...
 //
-// Selectors map Trino username (== team_id for customer principals) to
-// the root.tenants.<team_id> group. The admin principal lives under a
+// The tenant node name is trinoSanitize(org name), so a hyphenated org
+// like ben-iceberg-cnpg lands at root.tenants.ben_iceberg_cnpg. The
+// selector matches the Trino username (the raw org name, == auth-time
+// current_user) and maps it to that sanitized root.tenants.<sanitized>
+// group. The admin principal lives under a
 // sibling root.admin.<admin_user> path so its catalog-DDL traffic is
 // isolated from tenant traffic and so it matches a selector at all
 // (without an admin selector, Trino's resource-group manager rejects
@@ -1239,7 +1244,8 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 //
 // Keying is by *group*, not by username — the policy authorises via
 // `data.group_catalogs[group][catalog]`. Customer principals' groups
-// are `org_<team_id>` (TrinoGroupName); the admin group owns every
+// are `org_<sanitized-org-name>` (TrinoGroupName — trinoSanitize, so
+// ben-iceberg-cnpg → org_ben_iceberg_cnpg); the admin group owns every
 // managed catalog so the provisioner's own SHOW CATALOGS idempotency
 // check (run as opa.AdminPrincipal) is allowed.
 //

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -130,7 +130,8 @@ func TestBuildTrinoAuthFiles_OneUserPerOrg(t *testing.T) {
 	// admin-line projection is exercised in its own test below.
 	pw, grp := BuildTrinoAuthFiles(orgs, "")
 
-	// Password file: <team_id>:<bcrypt hash>
+	// Password file: <org_name>:<bcrypt hash> (numeric-shaped names used
+	// here are just compact DNS-1123 fixtures, not team_ids).
 	wantPw := "42:$2a$10$hash42\n43:$2a$10$hash43\n"
 	if pw != wantPw {
 		t.Errorf("password.db mismatch:\n got=%q\nwant=%q", pw, wantPw)
@@ -248,11 +249,12 @@ func TestTrinoCatalogNameMatchesManagedNamePattern(t *testing.T) {
 	}
 
 	// Positive cases: representative inputs the production path could
-	// produce. The v1 invariant enforced by trinoOrgIDPattern in
-	// provisioning/api.go is numeric team_ids, but trinoSanitize also
-	// handles non-numeric / punctuated inputs defensively (admin-API
-	// writes or future schema relaxation) — verify those too so any
-	// future relaxation that breaks the regex match is caught here.
+	// produce. Org names are DNS-1123 labels (validated by
+	// ducklingOrgIDPattern in provisioning/api.go), e.g. "42", "acme",
+	// "with-dash"; trinoSanitize maps non-[a-z0-9_] chars to '_'
+	// (injective over DNS-1123). It also handles odder inputs (dots,
+	// case, underscores) defensively — verify those too so any future
+	// change that breaks the regex match is caught here.
 	positive := []string{
 		"42",
 		"100",
@@ -338,7 +340,7 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 	if len(subs) != 4 {
 		t.Fatalf("expected 4 org subgroups under tenants, got %d", len(subs))
 	}
-	// Selector + subgroup name == team_id; verify the join.
+	// Selector + subgroup name == org name; verify the join.
 	wantByName := map[string]int{ // hardConcurrencyLimit per tier
 		"42": 3,  // free
 		"43": 10, // growth
@@ -356,7 +358,7 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 		}
 	}
 	// Selectors: admin + one per org. Admin maps to root.admin.<admin>,
-	// each tenant maps to root.tenants.<team_id>. Without the admin
+	// each tenant maps to root.tenants.<org_name>. Without the admin
 	// selector the provisioner's own queries get rejected by Trino's
 	// resource-group manager before reaching OPA.
 	wantSel := map[string]string{

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -27,19 +27,6 @@ func isUniqueViolation(err error) bool {
 	return errors.As(err, &s) && s.SQLState() == "23505"
 }
 
-// trinoOrgIDPattern is the team_id shape Trino's customer-facing path
-// requires: ASCII digits only. The plan establishes the v1 invariant
-// that Org.Name (== posthog team_id) is an integer string; Trino's
-// catalog naming and group-file projection don't tolerate punctuation,
-// and silently sanitizing it would let two distinct team_ids collide
-// into one catalog. Rejecting non-numeric IDs at the API boundary is
-// safer than catching the collision downstream.
-//
-// Org IDs flowing into the existing /provision endpoint are not
-// constrained by this — only the Trino opt-in surfaces (the standalone
-// /trino enable endpoint and the optional trino block on /provision).
-var trinoOrgIDPattern = regexp.MustCompile(`^[0-9]+$`)
-
 // ducklingOrgIDPattern constrains org IDs that get a provisioned warehouse to a
 // single DNS-1123 label (lowercase alphanumerics + hyphens, start/end
 // alphanumeric). This is the shape every derived name needs:
@@ -331,15 +318,12 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	// Validate Trino opt-in BEFORE generating the password — the
-	// numeric-orgID check is a request-validation failure (400), and
-	// running it inside the tx would just roll back and waste a hash.
+	// orgID was already validated as a DNS-1123 label at the top of the handler
+	// (ducklingOrgIDPattern) — that's all the Trino catalog/group naming needs,
+	// since TrinoCatalogName sanitizes it injectively (org_<sanitize(Name)>_iceberg).
+	// No extra per-Trino constraint; org names are not numeric team_ids.
 	var trinoSettings *configstore.TrinoSettings
 	if req.Trino != nil && req.Trino.Enabled {
-		if !trinoOrgIDPattern.MatchString(orgID) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "trino.enabled requires a numeric org id (posthog team_id); got: " + orgID})
-			return
-		}
 		trinoSettings = &configstore.TrinoSettings{Tier: req.Trino.Tier}
 	}
 
@@ -412,8 +396,8 @@ func (h *handler) enableTrino(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "org id is required"})
 		return
 	}
-	if !trinoOrgIDPattern.MatchString(orgID) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "org id must be numeric (posthog team_id); got: " + orgID})
+	if !ducklingOrgIDPattern.MatchString(orgID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "org id must be a DNS-1123 label (lowercase alphanumerics + hyphens); got: " + orgID})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -475,7 +475,7 @@ func TestGetWarehouseNotFound(t *testing.T) {
 
 func TestProvisionEnablesTrinoWhenRequested(t *testing.T) {
 	store := newFakeStore()
-	// Trino enable requires a numeric org id (posthog team_id).
+	// Org.Name is a DNS-1123 label; "42" is one valid (numeric) shape.
 	store.orgs["42"] = &configstore.Org{Name: "42"}
 	router := newTestRouter(store)
 
@@ -550,7 +550,11 @@ func TestProvisionTransactionRollsBackOnUserFailure(t *testing.T) {
 	}
 }
 
-func TestProvisionRejectsTrinoWithNonNumericOrgID(t *testing.T) {
+func TestProvisionEnablesTrinoWithNonNumericOrgID(t *testing.T) {
+	// Org names are DNS-1123 labels (e.g. "analytics", "ben-iceberg-cnpg"), not
+	// numeric team_ids. Trino opt-in must accept them — the catalog name is
+	// derived via injective sanitization (org_<sanitize(Name)>_iceberg), not
+	// assumed numeric.
 	store := newFakeStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
@@ -565,8 +569,11 @@ func TestProvisionRejectsTrinoWithNonNumericOrgID(t *testing.T) {
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 with non-numeric org id: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d for non-numeric org id: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if row := store.trino["analytics"]; row == nil || !row.Enabled {
+		t.Fatalf("expected trino row Enabled=true for analytics; got %+v", row)
 	}
 }
 
@@ -590,12 +597,14 @@ func TestProvisionWithoutTrinoLeavesTrinoRowUnset(t *testing.T) {
 }
 
 func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
+	// A DNS-1123-named org (the real shape, e.g. "ben-iceberg-cnpg") — not a
+	// numeric team_id — opts into Trino via the standalone endpoint.
 	store := newFakeStore()
-	store.orgs["42"] = &configstore.Org{Name: "42"}
+	store.orgs["ben-iceberg-cnpg"] = &configstore.Org{Name: "ben-iceberg-cnpg"}
 	router := newTestRouter(store)
 
 	body := []byte(`{"enabled": true, "tier": "growth"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/42/trino", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/ben-iceberg-cnpg/trino", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -603,24 +612,27 @@ func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
 	}
-	row := store.trino["42"]
+	row := store.trino["ben-iceberg-cnpg"]
 	if row == nil || !row.Enabled || row.Tier != "growth" {
 		t.Fatalf("expected trino row enabled with tier growth; got %+v", row)
 	}
 }
 
-func TestEnableTrinoRejectsNonNumericOrgID(t *testing.T) {
+func TestEnableTrinoRejectsInvalidOrgID(t *testing.T) {
+	// A non-numeric name is fine (DNS-1123); a name that is NOT a valid DNS-1123
+	// label (uppercase, underscore, punctuation) is rejected — the catalog/group
+	// sanitization's collision-freeness depends on the DNS-1123 charset.
 	store := newFakeStore()
 	router := newTestRouter(store)
 
 	body := []byte(`{"enabled": true}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/trino", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/Bad_Org/trino", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 with non-numeric org id: %s", rec.Code, rec.Body.String())
+		t.Fatalf("status = %d, want 400 for invalid (non-DNS-1123) org id: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## What

The Trino opt-in path rejected any non-numeric org id, on a false `Org.Name == posthog team_id` assumption. duckgres has no `team_id` — `Org.Name` is the primary key, a DNS-1123 label (e.g. `ben-iceberg-cnpg`), validated by `ducklingOrgIDPattern`. This removes that wrong validator and aligns the Trino opt-in with the rest of the org lifecycle.

## Why it's safe

The numeric check was redundant. The Trino catalog / group / resource-group / OPA identifiers are already derived via `trinoSanitize(Org.Name)` (lowercase, then non-`[a-z0-9_]` → `_`), which is **injective over the DNS-1123 charset** (only hyphens remap), so two distinct org names can't collide into one catalog. The DNS-1123 charset also can't inject into `password.db` / `group.db` lines or the resource-groups / OPA JSON. `/provision` validates the org id as DNS-1123 *before* the trino block, so the block can rely on it.

Reviewed twice by codex (xhigh) — both passes confirmed the removal is behaviorally safe; the only findings were comment-accuracy (raw-vs-sanitized placeholders), which are addressed.

## Changes

- Remove `trinoOrgIDPattern` (`^[0-9]+$`) and its two call sites (the `/provision` trino block + `enableTrino`).
- `enableTrino` now validates with `ducklingOrgIDPattern` — the same DNS-1123 gate `provisionWarehouse` already applies — so invalid names like `Bad_Org` still 400.
- Tests: invert the two "rejects non-numeric" assertions to "enables"; the standalone-endpoint test uses the real `ben-iceberg-cnpg` (the one shape where raw ≠ sanitized); a repurposed test still rejects non-DNS-1123 input.
- Comment-only: drop the `team_id` framing across the whole Trino path (provisioner + OPA `policy.rego` / `types.go`), and make resource-group / group placeholders show the sanitized form (`root.tenants.ben_iceberg_cnpg`, `org_ben_iceberg_cnpg`).

No behavior change beyond dropping the wrong validator. This unblocks opting a DNS-1123-named org (the real dev shape, e.g. `ben-iceberg-cnpg`) into Trino.

## Test

`go build` / `go vet` / `go test -tags kubernetes` across `controlplane/provisioner`, `controlplane/provisioner/opa`, and `controlplane/provisioning` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
