### PR TITLE
feat(worker-pool): exempt colocated workers from the exclusive count cap

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1242,8 +1242,12 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, p
 				return err
 			}
 		}
-		if maxOrgWorkers > 0 && orgID != "" {
-			count, err := cs.countActiveWorkers(tx, "org_id = ?", orgID)
+		// The worker-count cap bounds only exclusive workers — each pins a
+		// dedicated node. Colocated workers bin-pack and are intentionally
+		// unbounded: a colocated request never counts toward the cap and is
+		// never refused because the exclusive budget is full.
+		if maxOrgWorkers > 0 && orgID != "" && !profileColocate {
+			count, err := cs.countActiveWorkers(tx, "org_id = ? AND COALESCE(profile_colocate, false) = false", orgID)
 			if err != nil {
 				return err
 			}
@@ -1270,8 +1274,10 @@ func (cs *ConfigStore) ClaimIdleWorker(ownerCPInstanceID, orgID, image string, p
 		err := query.Order("worker_id ASC").Take(&current).Error
 		if err != nil {
 			if err == gorm.ErrRecordNotFound {
-				if maxGlobalWorkers > 0 {
-					count, err := cs.countActiveWorkers(tx)
+				// Exclusive-only global cap, bypassed for colocated requests —
+				// see the org-cap note above.
+				if maxGlobalWorkers > 0 && !profileColocate {
+					count, err := cs.countActiveWorkers(tx, "COALESCE(profile_colocate, false) = false")
 					if err != nil {
 						return err
 					}
@@ -1345,8 +1351,10 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, profi
 				return err
 			}
 		}
-		if maxOrgWorkers > 0 && orgID != "" {
-			count, err := cs.countActiveWorkers(tx, "org_id = ? AND state <> ?", orgID, WorkerStateHotIdle)
+		// Exclusive-only count cap, bypassed for colocated requests — colocated
+		// workers bin-pack and are intentionally unbounded.
+		if maxOrgWorkers > 0 && orgID != "" && !profileColocate {
+			count, err := cs.countActiveWorkers(tx, "org_id = ? AND state <> ? AND COALESCE(profile_colocate, false) = false", orgID, WorkerStateHotIdle)
 			if err != nil {
 				return err
 			}
@@ -1759,8 +1767,9 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 			return err
 		}
 
+		// Exclusive-only count caps: colocated workers bin-pack and are unbounded.
 		if maxOrgWorkers > 0 && orgID != "" {
-			count, err := cs.countActiveWorkers(tx, "org_id = ?", orgID)
+			count, err := cs.countActiveWorkers(tx, "org_id = ? AND COALESCE(profile_colocate, false) = false", orgID)
 			if err != nil {
 				return err
 			}
@@ -1770,7 +1779,7 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 		}
 
 		if maxGlobalWorkers > 0 {
-			count, err := cs.countActiveWorkers(tx)
+			count, err := cs.countActiveWorkers(tx, "COALESCE(profile_colocate, false) = false")
 			if err != nil {
 				return err
 			}
@@ -1840,8 +1849,10 @@ func (cs *ConfigStore) CreateNeutralWarmWorkerSlotForImage(ownerCPInstanceID, po
 			}
 		}
 
+		// Exclusive-only global cap: colocated workers are unbounded and must
+		// not block an exclusive warm spawn.
 		if maxGlobalWorkers > 0 {
-			count, err := cs.countActiveWorkers(tx)
+			count, err := cs.countActiveWorkers(tx, "COALESCE(profile_colocate, false) = false")
 			if err != nil {
 				return err
 			}
@@ -1905,8 +1916,10 @@ func (cs *ConfigStore) CreateNeutralWarmWorkerSlot(ownerCPInstanceID, podNamePre
 			}
 		}
 
-		if maxGlobalWorkers > 0 {
-			count, err := cs.countActiveWorkers(tx)
+		// Exclusive-only global cap, bypassed for colocated warm shapes —
+		// colocated workers bin-pack and are intentionally unbounded.
+		if maxGlobalWorkers > 0 && !profileColocate {
+			count, err := cs.countActiveWorkers(tx, "COALESCE(profile_colocate, false) = false")
 			if err != nil {
 				return err
 			}

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2269,8 +2269,11 @@ func (p *K8sWorkerPool) SpawnMinWorkersForImage(ctx context.Context, image strin
 		p.mu.Unlock()
 		return nil
 	}
+	// Exclusive-only room: this spawns default-shape (exclusive) warm workers,
+	// so colocated workers must not shrink the budget — consistent with the
+	// exclusive-only DB-side global cap in CreateNeutralWarmWorkerSlotForImage.
 	if p.maxWorkers > 0 {
-		room := p.maxWorkers - p.liveWorkerCountLocked()
+		room := p.maxWorkers - p.liveExclusiveWorkerCountLocked()
 		if room <= 0 {
 			p.mu.Unlock()
 			return nil
@@ -2374,16 +2377,11 @@ func (p *K8sWorkerPool) SpawnMinColocatedWorkers(ctx context.Context, profile Wo
 		p.mu.Unlock()
 		return nil
 	}
-	if p.maxWorkers > 0 {
-		room := p.maxWorkers - p.liveWorkerCountLocked()
-		if room <= 0 {
-			p.mu.Unlock()
-			return nil
-		}
-		if missing > room {
-			missing = room
-		}
-	}
+	// No exclusive worker-count cap here: colocated workers bin-pack and are
+	// intentionally unbounded (the DB-side global cap is exclusive-only and
+	// skips colocated too). `missing` is already bounded by this shape's warm
+	// target, and CreateNeutralWarmWorkerSlot enforces that target per shape,
+	// so the spawn loop self-limits without consulting p.maxWorkers.
 	p.mu.Unlock()
 
 	var slots []*configstore.WorkerRecord
@@ -3117,6 +3115,27 @@ func (p *K8sWorkerPool) liveWorkerCountLocked() int {
 		default:
 			count++
 		}
+	}
+	return count
+}
+
+// liveExclusiveWorkerCountLocked counts only the live workers that consume the
+// exclusive worker-count budget: every non-colocated worker plus in-flight
+// background (default-shape) spawns. Colocated workers bin-pack and are
+// intentionally unbounded, so they must not be charged against the cap — this
+// mirrors the exclusive-only count used by the DB-side cap checks.
+func (p *K8sWorkerPool) liveExclusiveWorkerCountLocked() int {
+	count := p.spawning
+	for _, w := range p.workers {
+		select {
+		case <-w.done:
+			continue
+		default:
+		}
+		if w.profile.Colocate {
+			continue
+		}
+		count++
 	}
 	return count
 }

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1360,6 +1360,38 @@ func TestK8sPool_LiveWorkerCount(t *testing.T) {
 	}
 }
 
+// TestK8sPool_LiveExclusiveWorkerCount confirms the exclusive-only live count
+// excludes colocated workers (which are unbounded) while still counting
+// in-flight default-shape background spawns. This is the count the exclusive
+// worker-count cap is charged against.
+func TestK8sPool_LiveExclusiveWorkerCount(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+
+	alive := make(chan struct{})
+	dead := make(chan struct{})
+	close(dead)
+
+	excl := &ManagedWorker{ID: 1, done: alive}
+	colo := &ManagedWorker{ID: 2, done: alive}
+	colo.profile = WorkerProfile{CPU: "8", Memory: "48Gi", Colocate: true}
+	deadColo := &ManagedWorker{ID: 3, done: dead}
+	deadColo.profile = WorkerProfile{Colocate: true}
+
+	pool.workers[1] = excl
+	pool.workers[2] = colo
+	pool.workers[3] = deadColo
+	pool.spawning = 2 // in-flight default-shape (exclusive) spawns
+
+	// liveWorkerCountLocked counts everything alive + spawning: 1 excl + 1 colo + 2 spawning = 4
+	if got := pool.liveWorkerCountLocked(); got != 4 {
+		t.Fatalf("liveWorkerCountLocked: expected 4, got %d", got)
+	}
+	// Exclusive-only: 1 excl + 2 spawning, colocated excluded = 3
+	if got := pool.liveExclusiveWorkerCountLocked(); got != 3 {
+		t.Fatalf("liveExclusiveWorkerCountLocked: expected 3 (colocated excluded), got %d", got)
+	}
+}
+
 func TestK8sPoolSpawnMinWorkersTracksWarmCapacityAndSpawnsMissingWorkers(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	pool.workers[41] = &ManagedWorker{ID: 41, done: make(chan struct{})}

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -86,8 +86,12 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 			return idle, nil
 		}
 
+		// The count cap bounds only exclusive workers (each pins a dedicated
+		// node). A colocated request bin-packs and is intentionally unbounded:
+		// never refuse it because the exclusive budget is full.
+		isColocated := profile != nil && profile.Colocate
 		assignedCount := p.assignedWorkerCountLocked()
-		if p.maxWorkers == 0 || assignedCount < p.maxWorkers {
+		if p.maxWorkers == 0 || isColocated || assignedCount < p.maxWorkers {
 			// Resource-aware quota for colocated workers: a new colocated worker
 			// must not push the org over its colocated CPU/memory budget. Reusing
 			// an idle worker (handled above) adds nothing, so this gates only the
@@ -266,6 +270,11 @@ func (p *OrgReservedPool) assignedWorkerCountLocked() int {
 		// against maxWorkers so AcquireWorker can reach ReserveSharedWorker
 		// and ClaimHotIdleWorker.
 		if w.SharedState().NormalizedLifecycle() == WorkerLifecycleHotIdle {
+			continue
+		}
+		// Colocated workers are unbounded and must not consume the exclusive
+		// worker budget that maxWorkers governs.
+		if w.profile.Colocate {
 			continue
 		}
 		if p.workerBelongsToOrgLocked(w) {

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -261,6 +261,42 @@ func TestOrgReservedPoolAcquireUnboundedWhenMaxWorkersZero(t *testing.T) {
 	}
 }
 
+// TestOrgReservedPoolAssignedCountExcludesColocated confirms the exclusive
+// worker count cap (maxWorkers) does not count an org's colocated workers.
+// Colocated workers bin-pack and are intentionally unbounded, so they must
+// not consume the exclusive budget that gates default/exclusive spawns.
+func TestOrgReservedPoolAssignedCountExcludesColocated(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 5)
+
+	seed := func(id int, colocate bool) {
+		w := &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
+		w.profile = WorkerProfile{Colocate: colocate}
+		if colocate {
+			w.profile.CPU, w.profile.Memory = "8", "48Gi"
+		}
+		if err := w.SetSharedState(SharedWorkerState{
+			Lifecycle:  WorkerLifecycleHot,
+			Assignment: &WorkerAssignment{OrgID: "analytics"},
+		}); err != nil {
+			t.Fatalf("SetSharedState(%d): %v", id, err)
+		}
+		shared.workers[id] = w
+	}
+
+	seed(1, false) // one exclusive worker
+	seed(2, true)  // two colocated workers — must not count
+	seed(3, true)
+
+	pool := NewOrgReservedPool(shared, "analytics", 1, shared.workerImage, nil, 0, 0)
+
+	shared.mu.Lock()
+	got := pool.assignedWorkerCountLocked()
+	shared.mu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected exclusive-only count of 1, got %d (colocated workers must not count)", got)
+	}
+}
+
 func TestOrgReservedPoolAcquireWaitsWhenSharedWarmWorkerBusyAtCapacity(t *testing.T) {
 	shared, _ := newTestK8sPool(t, 5)
 	worker := &ManagedWorker{ID: 3, activeSessions: 1, done: make(chan struct{})}


### PR DESCRIPTION
## What

Colocated (bin-packed) workers should be **unbounded** — per-org and in aggregate. Today they're not: the worker-count cap (`DUCKGRES_K8S_MAX_WORKERS`, used as *both* the per-org and global cap) counts colocated + exclusive workers together.

## Why

While dogfooding duckling backfills on mw-prod-us, the team-2 backfill (and unrelated `posthog_data_import_2` default-shape connections) intermittently failed with:

> FATAL: Duckgres worker capacity for this organization is currently exhausted; retry later

Root cause: colocated-backfill churn briefly filled active `worker_records` slots, pushing the PostHog org to the shared count cap (50) and bouncing **all** new connections for that org — including default-shape product/data-import traffic. It was *not* the colocated CPU/memory quota.

## Change

Make the count cap (`maxOrgWorkers` / `maxGlobalWorkers`) govern **exclusive workers only**, and **bypass it entirely for colocated requests**, at every enforcement site:

- `ClaimIdleWorker` (org + global cap)
- `ClaimHotIdleWorker` (org cap)
- `CreateNeutralWarmWorkerSlot` / `…ForImage` (global cap → exclusive-only)
- `CreateSpawningWorkerSlot` (exclusive-only; dead path kept consistent)
- `OrgReservedPool.AcquireWorker` in-process count

Exclusive workers (each pins a dedicated r6gd node) keep their cap. Colocated workers are limited only by the optional summed CPU/memory quota (unset = unbounded) and Karpenter node availability.

Companion charts change sets the prod-us colocated quota to unbounded and raises the exclusive cap so it stops being a practical limit.

## Test

- New `TestOrgReservedPoolAssignedCountExcludesColocated` — colocated workers don't count toward the exclusive budget.
- `go build`/`go vet`/`go test -tags kubernetes ./controlplane/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)