### PR TITLE
chore(metadata): remove the dead aurora metadata-store backend

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -14,8 +14,8 @@
 #      config-store Postgres + a control-plane Deployment running the PR image,
 #      spawning worker pods in the same namespace.
 #   4. run the e2e harness as a Job INSIDE the namespace, talking to the CP
-#      ClusterIP service (no public DNS / NLB needed). Covers cnpg + ext
-#      (aurora is being retired — out of scope).
+#      ClusterIP service (no public DNS / NLB needed). Covers the cnpg-shard
+#      and external metadata backends.
 #   5. always tear the namespace down (and deprovision the ci-pr ducklings so
 #      no S3 / cnpg role / lakekeeper CR leaks on shared infra).
 #

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -397,8 +397,6 @@ func managedWarehouseUpsertColumns() []string {
 		// DB column name. Mismatching this against the actual column makes
 		// the ON CONFLICT … DO UPDATE clause throw 42703.
 		"duck_lake_version",
-		"aurora_min_acu",
-		"aurora_max_acu",
 		"warehouse_database_region",
 		"warehouse_database_endpoint",
 		"warehouse_database_port",

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -1233,7 +1233,7 @@ func TestPatchTenantPinningRejectsUnknownFields(t *testing.T) {
 	store.warehouses["analytics"] = &configstore.ManagedWarehouse{OrgID: "analytics"}
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"image":"x","aurora_max_acu":42}`)
+	body := []byte(`{"image":"x","not_a_real_field":42}`)
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/orgs/analytics/warehouse/pinning", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -83,15 +83,11 @@ type ManagedWarehouseDatabase struct {
 //
 //   - "cnpg-shard": the per-tenant Lakekeeper Iceberg catalog Postgres backend
 //     on the shared CloudNativePG shard (always paired with iceberg.enabled).
-//   - "external": a pre-existing Postgres (e.g. RDS), referenced by endpoint +
-//     an AWS Secrets Manager secret for the password. Backs either a DuckLake
-//     catalog (iceberg disabled) or the Lakekeeper catalog (iceberg enabled).
-//
-// "aurora" is no longer provisionable (the control plane never stands up a new
-// Aurora cluster); the constant is retained so DucklingClient.Create can still
-// reconcile pre-existing aurora ducklings.
+//   - "external": a pre-existing Postgres (e.g. RDS/Aurora), referenced by
+//     endpoint + an AWS Secrets Manager secret for the password. Backs either a
+//     DuckLake catalog (iceberg disabled) or the Lakekeeper catalog (iceberg
+//     enabled).
 const (
-	MetadataStoreKindAurora    = "aurora"
 	MetadataStoreKindCnpgShard = "cnpg-shard"
 	MetadataStoreKindExternal  = "external"
 )
@@ -110,8 +106,8 @@ type ManagedWarehouseMetadataStore struct {
 	// metadata DB password. Only meaningful when Kind == "external": it's
 	// passed through to the Duckling CR's spec.metadataStore.external.
 	// passwordAwsSecret, where the composition resolves it (via ESO) into the
-	// status password the worker activator reads. Empty for aurora/cnpg-shard
-	// (those mint their own credentials).
+	// status password the worker activator reads. Empty for cnpg-shard
+	// (which mints its own credentials).
 	PasswordAWSSecret string `gorm:"size:255" json:"password_aws_secret,omitempty"`
 }
 
@@ -162,15 +158,14 @@ type ManagedWarehouseWorkerIdentity struct {
 
 // ManagedWarehouseDuckLake captures whether the org's DuckLake catalog is
 // enabled. Decoupled from the metadata-store type and from Iceberg: a duckling
-// may run DuckLake, Iceberg, or both, on any metadata backend (cnpg / external
-// / aurora). The DuckLake catalog lives in the metadata Postgres — the
-// per-tenant database for cnpg-shard, or the metadata database for
-// external/aurora.
+// may run DuckLake, Iceberg, or both, on any metadata backend (cnpg /
+// external). The DuckLake catalog lives in the metadata Postgres — the
+// per-tenant database for cnpg-shard, or the metadata database for external.
 //
 // For ducklings created before this field existed the column is absent/false;
 // the worker activator does NOT key off it directly — it reads the Duckling
 // CR's spec.ducklake.enabled (present/absent) so legacy ducklings keep their
-// implied behavior (external/aurora ⇒ DuckLake, cnpg ⇒ none).
+// implied behavior (external ⇒ DuckLake, cnpg ⇒ none).
 type ManagedWarehouseDuckLake struct {
 	Enabled bool `json:"enabled"`
 }
@@ -333,10 +328,8 @@ func (i ManagedWarehouseIceberg) ResolvedBackend() string {
 type ManagedWarehouse struct {
 	OrgID string `gorm:"primaryKey;size:255" json:"org_id"`
 
-	Image           string  `gorm:"size:512" json:"image"`
-	DuckLakeVersion string  `gorm:"size:32" json:"ducklake_version"`
-	AuroraMinACU    float64 `json:"aurora_min_acu"`
-	AuroraMaxACU    float64 `json:"aurora_max_acu"`
+	Image           string `gorm:"size:512" json:"image"`
+	DuckLakeVersion string `gorm:"size:32" json:"ducklake_version"`
 
 	WarehouseDatabase ManagedWarehouseDatabase       `gorm:"embedded;embeddedPrefix:warehouse_database_" json:"warehouse_database"`
 	MetadataStore     ManagedWarehouseMetadataStore  `gorm:"embedded;embeddedPrefix:metadata_store_" json:"metadata_store"`
@@ -657,8 +650,6 @@ type ManagedWarehouseConfig struct {
 
 	Image           string
 	DuckLakeVersion string
-	AuroraMinACU    float64
-	AuroraMaxACU    float64
 
 	WarehouseDatabase ManagedWarehouseDatabase
 	MetadataStore     ManagedWarehouseMetadataStore
@@ -699,8 +690,6 @@ func copyManagedWarehouseConfig(warehouse *ManagedWarehouse) *ManagedWarehouseCo
 		OrgID:                          warehouse.OrgID,
 		Image:                          warehouse.Image,
 		DuckLakeVersion:                warehouse.DuckLakeVersion,
-		AuroraMinACU:                   warehouse.AuroraMinACU,
-		AuroraMaxACU:                   warehouse.AuroraMaxACU,
 		WarehouseDatabase:              warehouse.WarehouseDatabase,
 		MetadataStore:                  warehouse.MetadataStore,
 		PgBouncer:                      warehouse.PgBouncer,

--- a/controlplane/lakekeeper_inputs.go
+++ b/controlplane/lakekeeper_inputs.go
@@ -145,10 +145,10 @@ func lakekeeperInputsFromDuckling(
 		}, true, nil
 	}
 
-	// aurora/external: status carries the metadata-store master credentials,
+	// external: status carries the metadata-store master credentials,
 	// which double as the admin connection that can CREATE the
 	// lakekeeper_<orgid> database/role. Admin DDL (CREATE DATABASE/ROLE) goes
-	// to the direct Aurora endpoint, not the PgBouncer pooler — transaction
+	// to the direct RDS endpoint, not the PgBouncer pooler — transaction
 	// pooling breaks CREATE DATABASE and the session-level statements
 	// EnsureRole runs. We connect to the existing metadata-store database;
 	// CREATE DATABASE can be issued from any database.

--- a/controlplane/org_activation_test.go
+++ b/controlplane/org_activation_test.go
@@ -17,13 +17,13 @@ import (
 
 func TestDucklingMetadataStoreAddressUsesDirectEndpointByDefault(t *testing.T) {
 	status := &provisioner.DucklingStatus{}
-	status.MetadataStore.Endpoint = "direct-aurora.example.internal"
+	status.MetadataStore.Endpoint = "direct-rds.example.internal"
 
 	host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, "analytics")
 	if err != nil {
 		t.Fatalf("ducklingMetadataStoreAddress: %v", err)
 	}
-	if host != "direct-aurora.example.internal" {
+	if host != "direct-rds.example.internal" {
 		t.Fatalf("host = %q, want direct endpoint", host)
 	}
 	if port != 5432 {
@@ -36,7 +36,7 @@ func TestDucklingMetadataStoreAddressUsesDirectEndpointByDefault(t *testing.T) {
 
 func TestDucklingMetadataStoreAddressPrefersPgBouncerEndpoint(t *testing.T) {
 	status := &provisioner.DucklingStatus{}
-	status.MetadataStore.Endpoint = "direct-aurora.example.internal"
+	status.MetadataStore.Endpoint = "direct-rds.example.internal"
 	status.MetadataStore.PgBouncerEndpoint = "pooler.ducklings.svc.cluster.local:6543"
 
 	host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, "analytics")
@@ -56,7 +56,7 @@ func TestDucklingMetadataStoreAddressPrefersPgBouncerEndpoint(t *testing.T) {
 
 func TestDucklingMetadataStoreAddressRejectsInvalidPgBouncerEndpoint(t *testing.T) {
 	status := &provisioner.DucklingStatus{}
-	status.MetadataStore.Endpoint = "direct-aurora.example.internal"
+	status.MetadataStore.Endpoint = "direct-rds.example.internal"
 	status.MetadataStore.PgBouncerEndpoint = "not-a-host-port"
 
 	_, _, _, err := ducklingMetadataStoreAddress(status, "analytics")

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -214,8 +214,6 @@ func (c *Controller) reconcilePending(ctx context.Context, w *configstore.Manage
 		"iceberg_enabled", w.Iceberg.Enabled)
 	if err := c.duckling.Create(ctx, w.OrgID, CreateOptions{
 		MetadataStoreType:         w.MetadataStore.Kind,
-		MinACU:                    w.AuroraMinACU,
-		MaxACU:                    w.AuroraMaxACU,
 		PgBouncerEnabled:          w.PgBouncer.Enabled,
 		ExternalEndpoint:          w.MetadataStore.Endpoint,
 		ExternalPasswordAWSSecret: w.MetadataStore.PasswordAWSSecret,
@@ -275,7 +273,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 
 	// Check for Crossplane failure — only fail on persistent sync errors.
 	// Crossplane resources commonly flap Synced=False transiently (e.g., IAM
-	// eventual consistency, Aurora cold start delays), so we only transition
+	// eventual consistency, metadata-store endpoint DNS propagation), so we only transition
 	// to failed if 10+ minutes have passed, giving transient errors time to resolve.
 	if status.SyncedFalseMessage != "" && time.Since(startedAt) > 10*time.Minute {
 		log.Warn("Crossplane sync failure.", "message", status.SyncedFalseMessage)
@@ -317,7 +315,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 
 	// Infrastructure is ready when all components are provisioned AND the
 	// Crossplane Ready condition is True. The Ready condition ensures all
-	// composed resources (including the Aurora instance) are fully reconciled,
+	// composed resources (including the metadata store) are fully reconciled,
 	// not just that individual status fields are populated.
 	s3Ready := w.S3State == configstore.ManagedWarehouseStateReady || updates["s3_state"] == configstore.ManagedWarehouseStateReady
 	metaReady := w.MetadataStoreState == configstore.ManagedWarehouseStateReady || updates["metadata_store_state"] == configstore.ManagedWarehouseStateReady
@@ -329,7 +327,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 		updates["iceberg_state"] == configstore.ManagedWarehouseStateReady
 
 	if s3Ready && metaReady && secretsReady && identReady && icebergReady && status.ReadyCondition {
-		// End-to-end probe: AWS reports the Aurora cluster Available before
+		// End-to-end probe: AWS reports the metadata store (RDS) Available before
 		// its DNS record has propagated to in-cluster CoreDNS, and even longer
 		// before pgbouncer's resolver picks it up. Flipping to Ready on
 		// AWS-Available alone produces a 3-5 minute window where worker
@@ -339,7 +337,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 		//
 		// PgBouncer is opt-in per duckling: when enabled, workers connect
 		// through the pgbouncer Service (plaintext); when disabled they
-		// connect to the Aurora endpoint directly (TLS required). The probe
+		// connect to the RDS endpoint directly (TLS required). The probe
 		// has to match that — otherwise we'd be testing a path nobody uses.
 		probe := c.probe
 		if probe == nil {

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -183,10 +183,14 @@ func TestReconcilePendingCreatesCR(t *testing.T) {
 	dc, fakeK8s := newFakeDucklingClient()
 	fs := newFakeStore()
 	fs.warehouses["org-a"] = &configstore.ManagedWarehouse{
-		OrgID:        "org-a",
-		State:        configstore.ManagedWarehouseStatePending,
-		AuroraMinACU: 0.5,
-		AuroraMaxACU: 2,
+		OrgID: "org-a",
+		State: configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:              configstore.MetadataStoreKindExternal,
+			Endpoint:          "ext.example.internal",
+			PasswordAWSSecret: "ext-secret",
+		},
+		DuckLake: configstore.ManagedWarehouseDuckLake{Enabled: true},
 	}
 
 	ctrl := NewControllerWithClient(fs, dc, time.Second)
@@ -208,18 +212,18 @@ func TestReconcilePendingCreatesCR(t *testing.T) {
 	if !ok {
 		t.Fatal("expected metadataStore in spec")
 	}
-	if metadataStore["type"] != "aurora" {
-		t.Fatalf("expected metadataStore type aurora, got %v", metadataStore["type"])
+	if metadataStore["type"] != "external" {
+		t.Fatalf("expected metadataStore type external, got %v", metadataStore["type"])
 	}
-	aurora, ok := metadataStore["aurora"].(map[string]interface{})
+	external, ok := metadataStore["external"].(map[string]interface{})
 	if !ok {
-		t.Fatal("expected aurora in metadataStore")
+		t.Fatal("expected external in metadataStore")
 	}
-	if aurora["minACU"] != 0.5 {
-		t.Fatalf("expected minACU 0.5, got %v", aurora["minACU"])
+	if external["endpoint"] != "ext.example.internal" {
+		t.Fatalf("expected endpoint ext.example.internal, got %v", external["endpoint"])
 	}
-	if aurora["maxACU"] != 2.0 {
-		t.Fatalf("expected maxACU 2, got %v", aurora["maxACU"])
+	if external["passwordAwsSecret"] != "ext-secret" {
+		t.Fatalf("expected passwordAwsSecret ext-secret, got %v", external["passwordAwsSecret"])
 	}
 
 	// Verify state transitioned to provisioning
@@ -240,11 +244,15 @@ func TestReconcilePendingEmitsPgBouncerBlock(t *testing.T) {
 	dc, fakeK8s := newFakeDucklingClient()
 	fs := newFakeStore()
 	fs.warehouses["org-pgb"] = &configstore.ManagedWarehouse{
-		OrgID:        "org-pgb",
-		State:        configstore.ManagedWarehouseStatePending,
-		AuroraMinACU: 0.5,
-		AuroraMaxACU: 4,
-		PgBouncer:    configstore.ManagedWarehousePgBouncer{Enabled: true},
+		OrgID: "org-pgb",
+		State: configstore.ManagedWarehouseStatePending,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:              configstore.MetadataStoreKindExternal,
+			Endpoint:          "ext.example.internal",
+			PasswordAWSSecret: "ext-secret",
+		},
+		DuckLake:  configstore.ManagedWarehouseDuckLake{Enabled: true},
+		PgBouncer: configstore.ManagedWarehousePgBouncer{Enabled: true},
 	}
 
 	ctrl := NewControllerWithClient(fs, dc, time.Second)
@@ -284,10 +292,10 @@ func TestReconcileReadyPatchesCRWhenPgBouncerFlippedOn(t *testing.T) {
 		},
 		"spec": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
-				"type": "aurora",
-				"aurora": map[string]interface{}{
-					"minACU": 0.5,
-					"maxACU": 2.0,
+				"type": "external",
+				"external": map[string]interface{}{
+					"endpoint":          "ext.example.internal",
+					"passwordAwsSecret": "ext-secret",
 				},
 			},
 		},
@@ -313,11 +321,11 @@ func TestReconcileReadyPatchesCRWhenPgBouncerFlippedOn(t *testing.T) {
 		t.Fatalf("expected pgbouncer.enabled=true, got %v", pgb["enabled"])
 	}
 	// Merge-patch must not wipe sibling metadataStore fields.
-	if ms["type"] != "aurora" {
+	if ms["type"] != "external" {
 		t.Fatalf("expected metadataStore.type preserved, got %v", ms["type"])
 	}
-	if _, ok := ms["aurora"].(map[string]interface{}); !ok {
-		t.Fatalf("expected aurora block preserved, got %v", ms)
+	if _, ok := ms["external"].(map[string]interface{}); !ok {
+		t.Fatalf("expected external block preserved, got %v", ms)
 	}
 }
 
@@ -340,7 +348,7 @@ func TestReconcileReadyPatchesCRWhenPgBouncerFlippedOff(t *testing.T) {
 		},
 		"spec": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
-				"type": "aurora",
+				"type": "external",
 				"pgbouncer": map[string]interface{}{
 					"enabled": true,
 				},
@@ -385,10 +393,10 @@ func TestReconcileReadyPatchesCRWhenIcebergFlippedOn(t *testing.T) {
 		},
 		"spec": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
-				"type": "aurora",
-				"aurora": map[string]interface{}{
-					"minACU": 0.5,
-					"maxACU": 2.0,
+				"type": "external",
+				"external": map[string]interface{}{
+					"endpoint":          "ext.example.internal",
+					"passwordAwsSecret": "ext-secret",
 				},
 			},
 			"dataStore": map[string]interface{}{"type": "s3bucket"},
@@ -439,7 +447,7 @@ func TestReconcileReadyPatchesCRWhenIcebergFlippedOff(t *testing.T) {
 			"namespace": ducklingNamespace,
 		},
 		"spec": map[string]interface{}{
-			"metadataStore": map[string]interface{}{"type": "aurora"},
+			"metadataStore": map[string]interface{}{"type": "external"},
 			"dataStore":     map[string]interface{}{"type": "s3bucket"},
 			"iceberg":       map[string]interface{}{"enabled": true},
 		},
@@ -480,7 +488,7 @@ func TestReconcileReadyNoDriftDoesNotPatch(t *testing.T) {
 		},
 		"spec": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
-				"type":      "aurora",
+				"type":      "external",
 				"pgbouncer": map[string]interface{}{"enabled": true},
 			},
 		},
@@ -522,7 +530,7 @@ func TestReconcileProvisioningAllReady(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":     "aurora",
+					"type":     "external",
 					"endpoint": "org-b.cluster.us-east-1.rds.amazonaws.com",
 					"password": "supersecret123",
 					"user":     "postgres",
@@ -583,7 +591,7 @@ func TestReconcileProvisioningAllReady(t *testing.T) {
 
 // TestReconcileProvisioningProbeFailsKeepsProvisioning verifies the controller
 // stays in the Provisioning state when the metadata-store probe fails — the
-// case our load test surfaced where Aurora reports Available but its DNS
+// case our load test surfaced where the RDS reports Available but its DNS
 // hasn't propagated yet. Flipping to Ready in that window produces a flurry
 // of "Worker activation failed" errors as workers try to connect through
 // pgbouncer.
@@ -606,7 +614,7 @@ func TestReconcileProvisioningProbeFailsKeepsProvisioning(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":              "aurora",
+					"type":              "external",
 					"endpoint":          "org-probe.cluster.us-east-1.rds.amazonaws.com",
 					"pgbouncerEndpoint": "pgbouncer-duckling-org-probe.ducklings.svc.cluster.local:6543",
 					"password":          "supersecret123",
@@ -634,7 +642,7 @@ func TestReconcileProvisioningProbeFailsKeepsProvisioning(t *testing.T) {
 	ctrl := NewControllerWithClient(fs, dc, time.Second)
 	ctrl.SetProbe(func(_ context.Context, endpoint, _, _, _, sslMode string) error {
 		// PgBouncer is disabled by default (ManagedWarehousePgBouncer.Enabled
-		// zero value), so the controller should probe the direct Aurora
+		// zero value), so the controller should probe the direct RDS
 		// endpoint with sslmode=require — not the pgbouncer Service.
 		if endpoint != "org-probe.cluster.us-east-1.rds.amazonaws.com" {
 			t.Errorf("expected direct endpoint, got %q", endpoint)
@@ -674,7 +682,7 @@ func TestReconcileProvisioningProbeFailsKeepsProvisioning(t *testing.T) {
 
 // TestReconcileProvisioningProbesPgBouncerWhenEnabled asserts that warehouses
 // with pgbouncer.enabled=true have their end-to-end probe directed at the
-// pgbouncer Service (sslmode=disable), not the direct Aurora endpoint —
+// pgbouncer Service (sslmode=disable), not the direct RDS endpoint —
 // pgbouncer's resolver is the slow lookup that motivated the probe.
 func TestReconcileProvisioningProbesPgBouncerWhenEnabled(t *testing.T) {
 	dc, fakeK8s := newFakeDucklingClient()
@@ -696,7 +704,7 @@ func TestReconcileProvisioningProbesPgBouncerWhenEnabled(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":              "aurora",
+					"type":              "external",
 					"endpoint":          "org-pgb.cluster.us-east-1.rds.amazonaws.com",
 					"pgbouncerEndpoint": "pgbouncer-duckling-org-pgb.ducklings.svc.cluster.local:6543",
 					"password":          "supersecret123",
@@ -807,7 +815,7 @@ func TestParseDucklingStatusSyncedFalse(t *testing.T) {
 					map[string]interface{}{
 						"type":    "Synced",
 						"status":  "False",
-						"message": "cannot create Aurora cluster: InvalidParameterException",
+						"message": "cannot create metadata store: InvalidParameterException",
 					},
 				},
 			},
@@ -818,7 +826,7 @@ func TestParseDucklingStatusSyncedFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status.SyncedFalseMessage != "cannot create Aurora cluster: InvalidParameterException" {
+	if status.SyncedFalseMessage != "cannot create metadata store: InvalidParameterException" {
 		t.Fatalf("expected synced false message, got %q", status.SyncedFalseMessage)
 	}
 	if status.ReadyCondition {
@@ -831,7 +839,7 @@ func TestParseDucklingStatusPgBouncerEndpoint(t *testing.T) {
 		Object: map[string]interface{}{
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":              "aurora",
+					"type":              "external",
 					"endpoint":          "posthog-duckling-foo.cluster-xyz.us-east-1.rds.amazonaws.com",
 					"pgbouncerEndpoint": "pgbouncer-duckling-foo.ducklings.svc.cluster.local:6543",
 					"user":              "postgres",
@@ -850,7 +858,7 @@ func TestParseDucklingStatusPgBouncerEndpoint(t *testing.T) {
 		t.Fatalf("PgBouncerEndpoint = %q, want pooler DNS", got)
 	}
 	if got := status.MetadataStore.Endpoint; got != "posthog-duckling-foo.cluster-xyz.us-east-1.rds.amazonaws.com" {
-		t.Fatalf("Endpoint = %q, want Aurora DNS", got)
+		t.Fatalf("Endpoint = %q, want RDS DNS", got)
 	}
 }
 
@@ -904,7 +912,7 @@ func TestFakeStoreUpdateWarehouseState(t *testing.T) {
 
 // TestReconcilePendingCreatesCnpgShardCR verifies that a warehouse whose
 // metadata-store kind is cnpg-shard produces a Duckling CR with
-// metadataStore.type=cnpg-shard, no aurora/pgbouncer blocks, and the iceberg
+// metadataStore.type=cnpg-shard, no external/pgbouncer blocks, and the iceberg
 // block enabled — the shape the composition expects for a Lakekeeper-backed
 // shard tenant.
 func TestReconcilePendingCreatesCnpgShardCR(t *testing.T) {
@@ -935,8 +943,8 @@ func TestReconcilePendingCreatesCnpgShardCR(t *testing.T) {
 	if metadataStore["type"] != configstore.MetadataStoreKindCnpgShard {
 		t.Fatalf("metadataStore.type = %v, want cnpg-shard", metadataStore["type"])
 	}
-	if _, present := metadataStore["aurora"]; present {
-		t.Errorf("cnpg-shard CR must not carry an aurora block, got %v", metadataStore["aurora"])
+	if _, present := metadataStore["external"]; present {
+		t.Errorf("cnpg-shard CR must not carry an external block, got %v", metadataStore["external"])
 	}
 	if _, present := metadataStore["pgbouncer"]; present {
 		t.Errorf("cnpg-shard CR must not carry a pgbouncer block, got %v", metadataStore["pgbouncer"])

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -28,8 +28,9 @@ var ducklingGVR = schema.GroupVersionResource{
 const ducklingNamespace = "ducklings"
 
 // DucklingStatus holds the parsed status from a Duckling CR.
-// The Duckling composition provisions AWS infrastructure (Aurora, S3, IAM)
-// but not K8s workloads — those are managed by the duckgres Helm chart.
+// The Duckling composition provisions AWS infrastructure (S3, IAM) and the
+// per-tenant metadata Postgres, but not K8s workloads — those are managed by
+// the duckgres Helm chart.
 type DucklingStatus struct {
 	MetadataStore struct {
 		Type              string
@@ -59,7 +60,7 @@ type DucklingStatus struct {
 	// DuckLakeEnabled is spec.ducklake.enabled, read present/absent: nil when
 	// the CR predates the decoupled ducklake field (the worker activator then
 	// falls back to the legacy type-based default — DuckLake on for
-	// external/aurora, off for cnpg-shard). Non-nil for decoupled ducklings.
+	// external, off for cnpg-shard). Non-nil for decoupled ducklings.
 	DuckLakeEnabled *bool
 }
 
@@ -127,14 +128,10 @@ func legacyDucklingName(orgID string) string {
 
 // CreateOptions carries per-org knobs that shape the generated Duckling CR.
 type CreateOptions struct {
-	// MetadataStoreType selects the Duckling's metadata-store backend. Empty
-	// is treated as configstore.MetadataStoreKindAurora (the historical
-	// default, retained only for reconciling pre-existing aurora ducklings).
-	// The control plane creates cnpg-shard and external; any other value is
-	// rejected by Create.
+	// MetadataStoreType selects the Duckling's metadata-store backend. The
+	// control plane creates cnpg-shard and external; any other value (including
+	// empty) is rejected by Create.
 	MetadataStoreType string
-	MinACU            float64
-	MaxACU            float64
 	PgBouncerEnabled  bool
 
 	// External metadata store (MetadataStoreType == "external"). Endpoint and
@@ -154,8 +151,8 @@ type CreateOptions struct {
 	DataStoreRegion string
 
 	// IcebergEnabled toggles spec.iceberg.enabled on the Duckling CR. The
-	// composition only provisions a per-tenant S3 Tables bucket when this
-	// is true; flipping it post-create is handled by the controller's
+	// composition only provisions the per-tenant Lakekeeper Iceberg catalog
+	// when this is true; flipping it post-create is handled by the controller's
 	// Ready-state drift logic.
 	IcebergEnabled bool
 	// IcebergNamespace is the Iceberg namespace within the tenant's catalog.
@@ -184,9 +181,8 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 		if !opts.IcebergEnabled && !opts.DuckLakeEnabled {
 			return fmt.Errorf("create duckling CR %q: metadata store type %q requires at least one of ducklake or iceberg enabled", name, configstore.MetadataStoreKindCnpgShard)
 		}
-		// No aurora block and no pgbouncer block: cnpg-shard tenants reach
-		// Postgres through the shard's own session-mode Pooler, not a
-		// per-Duckling PgBouncer.
+		// No pgbouncer block: cnpg-shard tenants reach Postgres through the
+		// shard's own session-mode Pooler, not a per-Duckling PgBouncer.
 		metadataStore = map[string]interface{}{"type": configstore.MetadataStoreKindCnpgShard}
 	case configstore.MetadataStoreKindExternal:
 		// A pre-existing Postgres (e.g. RDS), referenced by endpoint + an AWS
@@ -210,19 +206,6 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 		metadataStore = map[string]interface{}{
 			"type":     configstore.MetadataStoreKindExternal,
 			"external": external,
-		}
-		if opts.PgBouncerEnabled {
-			metadataStore["pgbouncer"] = map[string]interface{}{
-				"enabled": true,
-			}
-		}
-	case "", configstore.MetadataStoreKindAurora:
-		metadataStore = map[string]interface{}{
-			"type": configstore.MetadataStoreKindAurora,
-			"aurora": map[string]interface{}{
-				"minACU": opts.MinACU,
-				"maxACU": opts.MaxACU,
-			},
 		}
 		if opts.PgBouncerEnabled {
 			metadataStore["pgbouncer"] = map[string]interface{}{
@@ -357,7 +340,7 @@ func (d *DucklingClient) GetPgBouncerEnabled(ctx context.Context, orgID string) 
 // SetPgBouncerEnabled patches spec.metadataStore.pgbouncer.enabled on the
 // Duckling CR for the given org. Uses a JSON merge patch (RFC 7396) so the
 // call is idempotent and only touches the pgbouncer block — sibling fields
-// under metadataStore (aurora, type) are left untouched.
+// under metadataStore (type, external) are left untouched.
 func (d *DucklingClient) SetPgBouncerEnabled(ctx context.Context, orgID string, enabled bool) error {
 	_, name, err := d.getCR(ctx, orgID)
 	if err != nil {

--- a/controlplane/provisioner/lakekeeper_k8s.go
+++ b/controlplane/provisioner/lakekeeper_k8s.go
@@ -199,7 +199,7 @@ func (c *LakekeeperK8sClient) EnsureServiceAccount(ctx context.Context, orgID st
 
 // LakekeeperCRSpec carries the inputs we need to render a Lakekeeper CR.
 // One CR per org. PG connection points at the org's existing managed-warehouse
-// Aurora cluster, with the lakekeeper_<orgid> database created by
+// metadata Postgres, with the lakekeeper_<orgid> database created by
 // EnsureDatabase.
 type LakekeeperCRSpec struct {
 	OrgID      string

--- a/controlplane/provisioner/lakekeeper_provisioner.go
+++ b/controlplane/provisioner/lakekeeper_provisioner.go
@@ -43,7 +43,7 @@ type ClientFactory func(baseURL string) *LakekeeperClient
 // environment that doesn't live in the warehouse row yet.
 type ProvisioningInputs struct {
 	// AdminDSN is a pgx-compatible DSN with permission to CREATE DATABASE
-	// on the org's Aurora cluster. Caller resolves this from a K8s Secret
+	// on the org's metadata Postgres. Caller resolves this from a K8s Secret
 	// managed by Crossplane.
 	AdminDSN string
 
@@ -352,12 +352,10 @@ func (p *LakekeeperProvisioner) EnsureForOrg(ctx context.Context, w *configstore
 // (PGPreProvisioned) the corresponding cleanup happens via the Crossplane
 // composition's [Delete] managementPolicy on the cnpg-tenant-role and
 // cnpg-tenant-database resources — see posthog/charts PR for the parallel
-// fix. For the aurora case the whole Aurora cluster is destroyed by
-// Crossplane on Duckling CR delete, so the DROP DATABASE here is redundant
-// but harmless (and the connection may simply refuse — tolerated below).
+// fix.
 //
 // Best-effort: PG drop failures are logged and swallowed so a transient
-// network issue or a half-deleted Aurora cluster doesn't permanently block
+// network issue or a half-deleted metadata store doesn't permanently block
 // the duckling teardown. The k8s teardown failures (which actually leave
 // resources stranded) still surface as errors to the controller's retry
 // loop.

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -124,16 +124,6 @@ type provisionMetadataReq struct {
 	// External is required when Type == "external": a pre-existing Postgres
 	// referenced by host + an AWS Secrets Manager secret for the password.
 	External *provisionExternalReq `json:"external,omitempty"`
-	// Aurora is required when Type == "aurora": serverless v2 sizing for the
-	// per-org Aurora cluster the composition provisions.
-	Aurora *provisionAuroraReq `json:"aurora,omitempty"`
-}
-
-// provisionAuroraReq is the serverless-v2 ACU sizing for an aurora metadata
-// store. MaxACU must be > 0; MinACU defaults to 0 (scale-to-zero).
-type provisionAuroraReq struct {
-	MinACU float64 `json:"min_acu"`
-	MaxACU float64 `json:"max_acu"`
 }
 
 // provisionDuckLakeReq toggles the DuckLake catalog. Independent of Iceberg and
@@ -302,19 +292,8 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 			PasswordAWSSecret: ext.PasswordAWSSecret,
 		}
 
-	case configstore.MetadataStoreKindAurora:
-		// A per-org Aurora serverless-v2 cluster the composition provisions.
-		a := req.MetadataStore.Aurora
-		if a == nil || a.MaxACU <= 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "metadata_store.type 'aurora' requires metadata_store.aurora.max_acu > 0"})
-			return
-		}
-		warehouse.MetadataStore.Kind = configstore.MetadataStoreKindAurora
-		warehouse.AuroraMinACU = a.MinACU
-		warehouse.AuroraMaxACU = a.MaxACU
-
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q, %q, or %q (got %q)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, configstore.MetadataStoreKindAurora, req.MetadataStore.Type)})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("metadata_store.type must be %q or %q (got %q)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, req.MetadataStore.Type)})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -202,18 +202,17 @@ func newTestRouter(store Store) *gin.Engine {
 	return r
 }
 
-// TestProvisionRejectsAurora locks in that DuckLake (aurora) is no longer
-// provisionable — even with a valid sizing block — now that cnpg-shard is the
-// only creatable backend. Existing DuckLake deployments are unaffected; this
-// only gates new creation.
-func TestProvisionAuroraDuckLake(t *testing.T) {
+// TestProvisionRejectsAurora locks in that the removed "aurora" metadata-store
+// backend is no longer provisionable — the only creatable backends are
+// cnpg-shard and external.
+func TestProvisionRejectsAurora(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["analytics"] = &configstore.Org{Name: "analytics"}
 	router := newTestRouter(store)
 
 	body := []byte(`{
 		"database_name": "analytics-db",
-		"metadata_store": {"type": "aurora", "aurora": {"min_acu": 0.5, "max_acu": 2}},
+		"metadata_store": {"type": "aurora"},
 		"ducklake": {"enabled": true}
 	}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/analytics/provision", bytes.NewReader(body))
@@ -221,29 +220,11 @@ func TestProvisionAuroraDuckLake(t *testing.T) {
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
-	}
-	w := store.warehouses["analytics"]
-	if w == nil || w.MetadataStore.Kind != configstore.MetadataStoreKindAurora {
-		t.Fatalf("expected aurora warehouse, got %+v", w)
-	}
-	if w.AuroraMaxACU != 2 || !w.DuckLake.Enabled || w.Iceberg.Enabled {
-		t.Errorf("expected aurora max_acu=2, ducklake on, iceberg off; got max=%v ducklake=%v iceberg=%v", w.AuroraMaxACU, w.DuckLake.Enabled, w.Iceberg.Enabled)
-	}
-}
-
-func TestProvisionAuroraRequiresSizing(t *testing.T) {
-	store := newFakeStore()
-	router := newTestRouter(store)
-	// aurora with a catalog but no max_acu → 400.
-	body := []byte(`{"database_name":"a-db","metadata_store":{"type":"aurora"},"ducklake":{"enabled":true}}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/aco/provision", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+		t.Fatalf("status = %d, want 400 (aurora removed): %s", rec.Code, rec.Body.String())
+	}
+	if store.warehouses["analytics"] != nil {
+		t.Fatal("aurora request must not create a warehouse")
 	}
 }
 
@@ -707,7 +688,7 @@ func TestProvisionCnpgShard(t *testing.T) {
 	store.orgs["shardco"] = &configstore.Org{Name: "shardco"}
 	router := newTestRouter(store)
 
-	// No aurora block — cnpg-shard takes no sizing and auto-enables iceberg.
+	// cnpg-shard takes no sizing and auto-enables iceberg.
 	body := []byte(`{"database_name": "shardco-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/shardco/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -726,9 +707,6 @@ func TestProvisionCnpgShard(t *testing.T) {
 	}
 	if !w.Iceberg.Enabled || w.Iceberg.Backend != configstore.IcebergBackendLakekeeper {
 		t.Errorf("expected iceberg enabled with lakekeeper backend, got %+v", w.Iceberg)
-	}
-	if w.AuroraMaxACU != 0 {
-		t.Errorf("cnpg-shard must not set aurora sizing, got max_acu=%f", w.AuroraMaxACU)
 	}
 }
 

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -432,9 +432,9 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 	// DuckLake is attached iff this tenant has it enabled. The CR's
 	// spec.ducklake.enabled is authoritative (decoupled ducklings); legacy CRs
 	// that predate the field fall back to the historical coupling — DuckLake on
-	// for external/aurora, off for cnpg-shard. When on, the catalog lives in the
+	// for external, off for cnpg-shard. When on, the catalog lives in the
 	// metadata Postgres (the per-tenant lakekeeper_<org> DB on cnpg, or the
-	// metadata DB on external/aurora); when off the worker attaches Iceberg only
+	// metadata DB on external); when off the worker attaches Iceberg only
 	// (server.ActivateDBConnection takes its iceberg-only branch).
 	ducklakeEnabled := status.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard
 	if status.DuckLakeEnabled != nil {
@@ -494,7 +494,7 @@ func ducklingMetadataStoreAddress(status *provisioner.DucklingStatus, orgID stri
 		return h, portNum, true, nil
 	}
 
-	// No pooler — fall back to the direct Aurora endpoint. Guard against an
+	// No pooler — fall back to the direct RDS endpoint. Guard against an
 	// empty endpoint here rather than letting a malformed DSN surface later
 	// as an opaque connect error.
 	if status.MetadataStore.Endpoint == "" {

--- a/k8s/kind/config-store.seed.sql
+++ b/k8s/kind/config-store.seed.sql
@@ -6,8 +6,6 @@ SET updated_at = NOW();
 INSERT INTO duckgres_managed_warehouses (
     org_id,
     image,
-    aurora_min_acu,
-    aurora_max_acu,
     warehouse_database_region,
     warehouse_database_endpoint,
     warehouse_database_port,
@@ -62,8 +60,6 @@ INSERT INTO duckgres_managed_warehouses (
 VALUES (
     'local',
     '',
-    0,
-    0,
     'kind-dev',
     'local-warehouse-db',
     5432,

--- a/k8s/lakekeeper-networkpolicy.yaml
+++ b/k8s/lakekeeper-networkpolicy.yaml
@@ -77,8 +77,8 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # Postgres (the org's managed-warehouse Aurora). Open to any IP since
-    # Aurora endpoints aren't necessarily in-cluster.
+    # Postgres (the org's managed-warehouse RDS/Aurora). Open to any IP since
+    # those endpoints aren't necessarily in-cluster.
     - ports:
         - port: 5432
           protocol: TCP

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -47,7 +47,7 @@ var ScanRowsPerSecondHistogram = promauto.NewHistogramVec(prometheus.HistogramOp
 // operators per query. This is the DuckDB-side view of time spent in the
 // DuckLake metadata DB roundtrips — distinguishable from time spent on S3
 // data reads (which dominate ScanWallSecondsHistogram). A regression here
-// is the first signal of metadata-DB pressure (slow Aurora, conn-pool
+// is the first signal of metadata-DB pressure (slow metadata Postgres, conn-pool
 // starvation, pgbouncer queueing).
 var PostgresScanSecondsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "duckgres_postgres_scan_seconds",

--- a/server/server.go
+++ b/server/server.go
@@ -1205,7 +1205,7 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 	// "metadata store" is the Lakekeeper Postgres backend, not a DuckLake
 	// catalog (and which the worker has no egress to reach). The control plane
 	// signals this by leaving DuckLake.MetadataStore empty while enabling
-	// Iceberg. External/aurora tenants keep DuckLake (+ optional Iceberg) and
+	// Iceberg. External tenants keep DuckLake (+ optional Iceberg) and
 	// take the branch below unchanged.
 	icebergOnly := cfg.DuckLake.MetadataStore == ""
 	if icebergOnly && !cfg.Iceberg.Enabled {

--- a/tests/configstore/testdata/tenant-isolation.seed.sql
+++ b/tests/configstore/testdata/tenant-isolation.seed.sql
@@ -9,8 +9,6 @@ SET database_name = EXCLUDED.database_name,
 INSERT INTO duckgres_managed_warehouses (
     org_id,
     image,
-    aurora_min_acu,
-    aurora_max_acu,
     warehouse_database_region,
     warehouse_database_endpoint,
     warehouse_database_port,
@@ -66,8 +64,6 @@ VALUES
 (
     'analytics',
     '',
-    0,
-    0,
     'kind-dev',
     'duckgres-local-warehouse-db',
     5432,
@@ -122,8 +118,6 @@ VALUES
 (
     'billing',
     '',
-    0,
-    0,
     'kind-dev',
     'duckgres-local-warehouse-db',
     5432,

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -18,7 +18,7 @@ layers where this quarter's production bugs lived.
    config-store Postgres + a control-plane Deployment on the PR image, spawning
    worker pods in the same namespace.
 4. **Test** via an in-cluster Job hitting the CP ClusterIP service. Covers
-   **cnpg + ext** (aurora out of scope).
+   the **cnpg + ext** metadata backends.
 5. **Teardown** always: deprovision the ci-pr ducklings (clean shared-infra
    footprint) then delete the namespace.
 


### PR DESCRIPTION
## What

Removes the **`aurora` metadata-store backend** completely — the per-org Aurora serverless-v2 cluster path the composition used to stand up. It's no longer provisionable and has **no live deployments**, so this is a full rip-out: no backward-compat shim, no retained constant (same approach as the `s3_tables` removal in #648). `cnpg-shard` and `external` remain the only metadata backends.

## Disambiguation

"Aurora" appears in two senses; only the first is removed:
- **(A) the aurora backend type** — removed (enum value, ACU config, provisioning/Create arm, status wiring).
- **(B) AWS Aurora as the RDS engine behind the kept `external` backend** — preserved (pg_stat_activity / Performance Insights observability comments, the networkpolicy egress to RDS/Aurora endpoints, the metadata-probe TLS/DNS rationale). Stale backend-prose mentioning "aurora" in kept paths was reworded to `external`/`RDS`.

## Production

- **configstore**: drop `MetadataStoreKindAurora`, `ManagedWarehouse.AuroraMin/MaxACU` (+ the Config snapshot copy), and the `aurora_min_acu/max_acu` admin upsert columns.
- **provisioning API**: drop the `aurora` request shape (`provisionAuroraReq`) + its provisioning case; the type list now rejects anything but cnpg-shard/external.
- **provisioner**: drop `CreateOptions.Min/MaxACU` + the aurora Create arm. **Behavior change**: an empty `metadata_store_kind` previously aliased to aurora — it now hits the reject `default:` (intentional; no empty-kind rows exist). cnpg-shard/external are explicit cases, unaffected.

## Tests / seeds

- Replace the two aurora provisioning tests with **one regression test asserting aurora is rejected** (400, no warehouse created).
- Rewrite the shared `controller_test` fixtures (probe / pgbouncer-drift / endpoint / Synced) from aurora → external — they exercise **backend-agnostic** logic, so only the fixture type changes (coverage preserved, not deleted).
- Drop `aurora_min_acu/max_acu` columns + values from the kind and tenant-isolation config-store seeds — the struct fields are gone, so a fresh AutoMigrate won't create the columns and the INSERTs must not reference them.

## Verification

`go build` / `go vet` (`-tags kubernetes`) clean; provisioner + provisioning unit lanes green locally. CI covers the configstore-integration lane (seeds) + the e2e-mw-dev real-cluster run (cnpg + external activation still work, lakekeeper-only iceberg).