### PR TITLE
Fix Trino catalog creation: use fs.native-s3.enabled (Trino 476)

### DIFF
--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -955,11 +955,14 @@ func (p *TrinoProvisioner) reconcileCatalogs(ctx context.Context, orgs []configs
 // credentials are embedded here — just the endpoint, the warehouse
 // name, and the per-org S3 IAM role.
 //
-// Property names follow Trino's current file-system / Iceberg-REST
-// surface (matching the working maintenance chart at
-// charts/charts/trino/files/trino_maintenance.py):
+// Property names MUST stay in sync with the working maintenance chart at
+// charts/charts/trino/files/trino_maintenance.py — this set drifted from it
+// once (fs.s3.enabled vs fs.native-s3.enabled), which Trino 476 rejects at
+// CREATE CATALOG ("Configuration property 'fs.s3.enabled' was not used"):
 //
-//	fs.s3.enabled=true              enable the unified S3 file system
+//	fs.native-s3.enabled=true       enable Trino's native S3 file system
+//	                                (required since Trino 458; the legacy
+//	                                Hadoop fs.s3.* surface is rejected by 476)
 //	s3.region=<region>              forwarded to the AWS SDK
 //	s3.iam-role=<arn>               per-org duckling-<orgid> role
 //
@@ -974,7 +977,7 @@ func (p *TrinoProvisioner) buildCatalogProperties(orgID string, ic *configstore.
 		"iceberg.catalog.type":           "rest",
 		"iceberg.rest-catalog.uri":       ic.LakekeeperEndpoint,
 		"iceberg.rest-catalog.warehouse": ic.LakekeeperWarehouse,
-		"fs.s3.enabled":                  "true",
+		"fs.native-s3.enabled":           "true",
 	}
 	if p.iamAccountID != "" {
 		props["s3.iam-role"] = fmt.Sprintf("arn:aws:iam::%s:role/duckling-%s", p.iamAccountID, orgID)

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -462,8 +462,8 @@ func TestReconcile_CreatesCatalogProjectsSecretAndConfigMap(t *testing.T) {
 	if !strings.Contains(props["s3.iam-role"], "duckling-42") {
 		t.Errorf("expected duckling-42 role ARN under s3.iam-role, got %q", props["s3.iam-role"])
 	}
-	if props["fs.s3.enabled"] != "true" {
-		t.Errorf("expected fs.s3.enabled=true, got %q", props["fs.s3.enabled"])
+	if props["fs.native-s3.enabled"] != "true" {
+		t.Errorf("expected fs.native-s3.enabled=true, got %q", props["fs.native-s3.enabled"])
 	}
 	// Old property names must NOT be emitted — they're silently ignored
 	// or rejected by current Trino.


### PR DESCRIPTION
## What

`buildCatalogProperties` emitted `fs.s3.enabled=true` in each per-org Iceberg catalog. Trino 476 rejects it at `CREATE CATALOG`:

```
create catalog org_<org>_iceberg: trino: GENERIC_INTERNAL_ERROR:
  1) Configuration property 'fs.s3.enabled' was not used
  2) Configuration property 's3.iam-role'  was not used
  3) Configuration property 's3.region'    was not used
```

Trino removed the legacy Hadoop S3 filesystem; since **Trino 458** the native S3 filesystem must be enabled per-catalog with **`fs.native-s3.enabled=true`**. The unrecognized toggle cascades `s3.region` + `s3.iam-role` into "unused," so every per-org catalog fails to create.

## Root cause — drift

The prop set drifted from the proven-working maintenance script (`charts/trino/files/trino_maintenance.py`) that the doc comment *claims* to mirror — the script uses `fs.native-s3.enabled` + `s3.region` + `s3.iam-role`; the Go code had `fs.s3.enabled`. This restores the match (one property name). The other two props were already correct and only failed because the native filesystem never turned on.

Latent until now: no org could be Trino-enabled until the numeric-org-id validator was removed (#672), so `CREATE CATALOG` had never executed end-to-end against the real coordinator.

## Found live

Enabling the first real Trino org (`ben-cnpg-ice`) in mw-dev: the projections (resource-groups, auth files) succeed, then the reconcile loops on this `CREATE CATALOG` error every ~10s.

## Changes
- `buildCatalogProperties`: `fs.s3.enabled` → `fs.native-s3.enabled`.
- Corrected the doc comment + the unit test (it asserted the wrong property name).

## Test
- `go build` / `go test -tags kubernetes ./controlplane/provisioner` — pass.
- **Live validation on deploy:** the provisioner is already retrying the failed reconcile every ~10s, so once this image rolls out the catalog `org_ben_cnpg_ice_iceberg` is created with no re-enable.

## Follow-up (not in this PR)
The Trino *coordinator* catalog-creation path has **no e2e harness coverage** — the harness is PG-wire-scoped and never reaches the coordinator, which is why this slipped through (unit tests assert the static property string; nothing asserts Trino *accepts* it). A regression assertion (enable Trino → assert the catalog exists *on the coordinator*) is a new harness capability worth its own PR. Asserting only the resource-groups projection would **not** catch this — projections succeed before the failing `CREATE CATALOG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
