### PR TITLE
Gracefully drain workers before shutdown

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -2113,11 +2113,27 @@ func (p *K8sWorkerPool) checkReservedWorkerLiveness(ctx context.Context, worker 
 			}
 			hctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
-			_, err := doHealthCheckWithMetadata(hctx, worker.client, p.healthCheckPayloadForWorker(worker))
-			return err
+			result, err := doHealthCheckWithMetadata(hctx, worker.client, p.healthCheckPayloadForWorker(worker))
+			if err != nil {
+				return err
+			}
+			return validateReservedWorkerHealth(result)
 		}
 	}
 	return check(ctx, worker)
+}
+
+func validateReservedWorkerHealth(result *healthCheckResult) error {
+	if result == nil {
+		return fmt.Errorf("worker health check returned no result")
+	}
+	if !result.Healthy {
+		return fmt.Errorf("worker health check reported unhealthy")
+	}
+	if result.Draining {
+		return fmt.Errorf("worker is draining")
+	}
+	return nil
 }
 
 // SpawnMinWorkers pre-warms the pool with count workers.
@@ -3187,21 +3203,58 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 			deletePod := true
 			if p.runtimeStore != nil {
 				lease := p.workerLeaseSnapshot(w)
-				// cleanDeadWorkersLocked sweeps for pods whose informer
-				// fired w.done — cluster-driven termination (eviction,
-				// OOM, manual delete), not our health-check decision.
-				lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginInformerCrash)
-				if err != nil {
-					slog.Warn("Clean dead worker: lease validation failed; leaving cleanup to retry.",
-						"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
-					continue
-				}
-				switch lostDisposition {
-				case workerLostLeaseStale:
+				if p.workerMatchesLease(w, lease) && w.SharedState().NormalizedLifecycle() == WorkerLifecycleDraining {
+					lc := p.ensureLifecycle()
+					if lc != nil {
+						outcome, err := lc.RetireDrained(
+							configstore.NewWorkerLease(lease.workerID, lease.ownerCPInstanceID, lease.ownerEpoch, lease.image),
+							RetireReasonNormal,
+							LifecycleOriginInformerCrash,
+						)
+						if err != nil {
+							slog.Warn("Clean dead worker: retire draining CAS failed; leaving cleanup to retry.",
+								"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							continue
+						}
+						if !outcome.Transitioned {
+							record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
+							if err != nil {
+								slog.Warn("Clean dead worker: retire draining verification failed; leaving cleanup to retry.",
+									"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+								continue
+							}
+							if record == nil || record.OwnerCPInstanceID != lease.ownerCPInstanceID ||
+								record.OwnerEpoch != lease.ownerEpoch || record.State != configstore.WorkerStateRetired {
+								continue
+							}
+						}
+					}
+					p.markWorkerRetiredInMemoryLocked(w)
+					delete(p.workers, id)
+					removedWorker = w
 					deletePod = false
-					removedWorker, _ = p.dropLocalWorkerIfSameLeaseLocked(lease)
-				case workerLostLeaseCurrent, workerLostLeaseAlreadyLost, workerLostLeaseRetry:
-					continue
+					if p.shouldReplenishWarmCapacityLocked() {
+						replacementID = p.allocateBackgroundSpawnIDLocked()
+						p.spawning++
+						shouldReplenish = true
+					}
+				} else {
+					// cleanDeadWorkersLocked sweeps for pods whose informer
+					// fired w.done — cluster-driven termination (eviction,
+					// OOM, manual delete), not our health-check decision.
+					lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginInformerCrash)
+					if err != nil {
+						slog.Warn("Clean dead worker: lease validation failed; leaving cleanup to retry.",
+							"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+						continue
+					}
+					switch lostDisposition {
+					case workerLostLeaseStale:
+						deletePod = false
+						removedWorker, _ = p.dropLocalWorkerIfSameLeaseLocked(lease)
+					case workerLostLeaseCurrent, workerLostLeaseAlreadyLost, workerLostLeaseRetry:
+						continue
+					}
 				}
 			} else {
 				removedWorker, _, replacementID, shouldReplenish = p.removeWorkerLocked(id)

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -52,6 +52,8 @@ const workerPodReadyTimeout = 5 * time.Minute
 // fast, bin-packed) shapes refilled. See TestWarmSpawnTimeoutExceedsPodReady.
 const warmSpawnReconcileTimeout = 6 * time.Minute
 
+const workerTerminationGracePeriodSeconds int64 = 3600
+
 var errStaleRuntimeWorkerClaim = stderrors.New("stale runtime worker claim")
 
 // K8sWorkerPool manages worker pods in Kubernetes.
@@ -725,11 +727,12 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:                corev1.RestartPolicyNever,
-			ServiceAccountName:           p.workerServiceAccountName(),
-			AutomountServiceAccountToken: boolPtr(false),
-			PriorityClassName:            p.workerPriorityClassName,
-			NodeSelector:                 p.nodeSelectorForProfile(profile),
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: int64Ptr(workerTerminationGracePeriodSeconds),
+			ServiceAccountName:            p.workerServiceAccountName(),
+			AutomountServiceAccountToken:  boolPtr(false),
+			PriorityClassName:             p.workerPriorityClassName,
+			NodeSelector:                  p.nodeSelectorForProfile(profile),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: boolPtr(true),
 				RunAsUser:    int64Ptr(1000),
@@ -2534,6 +2537,23 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 						delete(failures, lease)
 						mu.Unlock()
 
+						removedWorker, workerCount, replacementID, shouldReplenish, err := p.removeWorkerAfterDrainedLease(lease, LifecycleOriginWorkerDrain)
+						if err != nil {
+							slog.Error("K8s worker terminated after draining but retire CAS failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							return
+						}
+						if removedWorker != nil {
+							observeControlPlaneWorkers(workerCount)
+							slog.Info("K8s worker terminated after draining.", "id", lease.workerID)
+							if removedWorker.client != nil {
+								_ = removedWorker.client.Close()
+							}
+							if shouldReplenish {
+								p.spawnWarmWorkerBackground(replacementID, p.workerImage)
+							}
+							return
+						}
+
 						lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginInformerCrash)
 						if err != nil {
 							slog.Error("K8s worker terminated but lease validation failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
@@ -2559,7 +2579,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 						}
 
 						p.mu.Lock()
-						removedWorker, workerCount, replacementID, shouldReplenish := p.removeWorkerAfterLostLeaseLocked(lease)
+						removedWorker, workerCount, replacementID, shouldReplenish = p.removeWorkerAfterLostLeaseLocked(lease)
 						p.mu.Unlock()
 						if removedWorker == nil {
 							return
@@ -2680,6 +2700,10 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 							mu.Lock()
 							delete(failures, lease)
 							mu.Unlock()
+
+							if hcResult != nil && hcResult.Draining {
+								p.markWorkerDrainingFromHealth(lease)
+							}
 
 							// Forward progress data to the control plane.
 							if onProgress != nil && hcResult != nil {
@@ -3394,6 +3418,123 @@ func (p *K8sWorkerPool) markWorkerLostIfCurrentLease(lease workerLeaseSnapshot, 
 		return false, err
 	}
 	return outcome.Transitioned, nil
+}
+
+func (p *K8sWorkerPool) markWorkerDrainingFromHealth(lease workerLeaseSnapshot) {
+	if lease.ownerCPInstanceID != p.cpInstanceID {
+		return
+	}
+	p.mu.Lock()
+	w, ok := p.workers[lease.workerID]
+	if !ok || !p.workerMatchesLease(w, lease) {
+		p.mu.Unlock()
+		return
+	}
+	previous := w.SharedState()
+	switch previous.NormalizedLifecycle() {
+	case WorkerLifecycleDraining, WorkerLifecycleRetired:
+		p.mu.Unlock()
+		return
+	}
+	next, err := previous.Transition(WorkerLifecycleDraining, previous.Assignment)
+	if err != nil {
+		p.mu.Unlock()
+		slog.Warn("Worker reported draining but local lifecycle transition failed.",
+			"worker_id", lease.workerID, "state", previous.NormalizedLifecycle(), "error", err)
+		return
+	}
+	w.sharedState = next
+	p.mu.Unlock()
+
+	durableVerified := false
+	defer func() {
+		if durableVerified {
+			return
+		}
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		w, ok := p.workers[lease.workerID]
+		if !ok || !p.workerMatchesLease(w, lease) {
+			return
+		}
+		if w.SharedState().NormalizedLifecycle() == WorkerLifecycleDraining {
+			w.sharedState = previous
+		}
+	}()
+
+	lc := p.ensureLifecycle()
+	if lc != nil {
+		outcome, err := lc.Drain(
+			configstore.NewWorkerLease(lease.workerID, p.cpInstanceID, lease.ownerEpoch, lease.image),
+			LifecycleOriginWorkerDrain,
+		)
+		if err != nil {
+			slog.Warn("Worker reported draining but durable drain CAS failed; keeping local worker schedulable until retry.",
+				"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+			return
+		}
+		if !outcome.Transitioned {
+			record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
+			if err != nil {
+				slog.Warn("Worker reported draining but durable worker record could not be verified after CAS miss.",
+					"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+				return
+			}
+			if record == nil || record.OwnerCPInstanceID != p.cpInstanceID || record.OwnerEpoch != lease.ownerEpoch || record.State != configstore.WorkerStateDraining {
+				return
+			}
+		}
+	}
+	durableVerified = true
+}
+
+func (p *K8sWorkerPool) removeWorkerAfterDrainedLease(lease workerLeaseSnapshot, origin LifecycleOrigin) (*ManagedWorker, int, int, bool, error) {
+	p.mu.RLock()
+	w, ok := p.workers[lease.workerID]
+	if !ok || !p.workerMatchesLease(w, lease) || w.SharedState().NormalizedLifecycle() != WorkerLifecycleDraining {
+		p.mu.RUnlock()
+		return nil, 0, 0, false, nil
+	}
+	p.mu.RUnlock()
+
+	lc := p.ensureLifecycle()
+	if lc != nil {
+		outcome, err := lc.RetireDrained(
+			configstore.NewWorkerLease(lease.workerID, p.cpInstanceID, lease.ownerEpoch, lease.image),
+			RetireReasonNormal,
+			origin,
+		)
+		if err != nil {
+			return nil, 0, 0, false, err
+		}
+		if !outcome.Transitioned {
+			record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
+			if err != nil {
+				return nil, 0, 0, false, err
+			}
+			if record == nil || record.OwnerCPInstanceID != p.cpInstanceID || record.OwnerEpoch != lease.ownerEpoch || record.State != configstore.WorkerStateRetired {
+				return nil, 0, 0, false, nil
+			}
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	current, ok := p.workers[lease.workerID]
+	if !ok || !p.workerMatchesLease(current, lease) || current.SharedState().NormalizedLifecycle() != WorkerLifecycleDraining {
+		return nil, 0, 0, false, nil
+	}
+	p.markWorkerRetiredInMemoryLocked(current)
+	delete(p.workers, current.ID)
+	workerCount := len(p.workers)
+	replacementID := 0
+	shouldReplenish := false
+	if p.shouldReplenishWarmCapacityLocked() {
+		replacementID = p.allocateBackgroundSpawnIDLocked()
+		p.spawning++
+		shouldReplenish = true
+	}
+	return current, workerCount, replacementID, shouldReplenish, nil
 }
 
 func (p *K8sWorkerPool) removeWorkerAfterLostLeaseLocked(lease workerLeaseSnapshot) (*ManagedWorker, int, int, bool) {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/server"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3172,6 +3173,151 @@ func TestK8sPoolHealthCheckLoopCurrentLeaseDeletesPodAndNotifiesCrash(t *testing
 	}
 }
 
+func TestK8sPoolHealthCheckLoopMarksDrainingWorkerUnschedulable(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			8: {
+				WorkerID:          8,
+				PodName:           "test-cp-worker-8",
+				State:             configstore.WorkerStateIdle,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+			},
+		},
+	}
+	pool.runtimeStore = store
+	pool.lifecycle = NewWorkerLifecycle(store, pool)
+
+	worker := &ManagedWorker{ID: 8, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	if err := worker.SetSharedState(SharedWorkerState{Lifecycle: WorkerLifecycleIdle}); err != nil {
+		t.Fatalf("set worker state: %v", err)
+	}
+	pool.workers[worker.ID] = worker
+
+	origHealthCheck := doHealthCheckWithMetadata
+	doHealthCheckWithMetadata = func(context.Context, *flightsql.Client, server.WorkerHealthCheckPayload) (*healthCheckResult, error) {
+		return &healthCheckResult{Healthy: true, Draining: true}, nil
+	}
+	t.Cleanup(func() { doHealthCheckWithMetadata = origHealthCheck })
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+
+	deadline := time.After(time.Second)
+	for {
+		pool.mu.RLock()
+		state := worker.SharedState().NormalizedLifecycle()
+		schedulable := pool.isGenericSessionSchedulableWorkerLocked(worker)
+		pool.mu.RUnlock()
+		if state == WorkerLifecycleDraining {
+			if schedulable {
+				t.Fatal("draining worker must not remain schedulable")
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected draining health response to mark worker draining, got %q", state)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	select {
+	case workerID := <-crashed:
+		t.Fatalf("draining worker must not notify sessions as crashed, got worker %d", workerID)
+	default:
+	}
+	store.mu.Lock()
+	markLostCalls := store.markLostCalls
+	markDrainingCalls := store.markDrainingCalls
+	recordState := store.preloadedRecords[worker.ID].State
+	store.mu.Unlock()
+	if markLostCalls != 0 {
+		t.Fatalf("draining worker must not be marked lost, got %d lost calls", markLostCalls)
+	}
+	if markDrainingCalls != 1 {
+		t.Fatalf("expected one draining CAS, got %d", markDrainingCalls)
+	}
+	if recordState != configstore.WorkerStateDraining {
+		t.Fatalf("expected durable worker state draining, got %q", recordState)
+	}
+}
+
+func TestK8sPoolHealthCheckLoopRetiresDrainingWorkerAfterPodExit(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			8: {
+				WorkerID:          8,
+				PodName:           "test-cp-worker-8",
+				State:             configstore.WorkerStateDraining,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+			},
+		},
+	}
+	pool.runtimeStore = store
+	pool.lifecycle = NewWorkerLifecycle(store, pool)
+
+	worker := &ManagedWorker{ID: 8, done: make(chan struct{})}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	if err := worker.SetSharedState(SharedWorkerState{Lifecycle: WorkerLifecycleDraining}); err != nil {
+		t.Fatalf("set worker state: %v", err)
+	}
+	pool.workers[worker.ID] = worker
+
+	crashed := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pool.HealthCheckLoop(ctx, time.Millisecond, func(workerID int) {
+		crashed <- workerID
+	}, nil)
+	close(worker.done)
+
+	deadline := time.After(time.Second)
+	for {
+		pool.mu.RLock()
+		_, stillPresent := pool.workers[worker.ID]
+		pool.mu.RUnlock()
+		if !stillPresent {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected drained pod exit to remove local worker")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	select {
+	case workerID := <-crashed:
+		t.Fatalf("drained pod exit must not notify sessions as crashed, got worker %d", workerID)
+	default:
+	}
+	store.mu.Lock()
+	markLostCalls := store.markLostCalls
+	retireDrainingCalls := store.retireDrainingCalls
+	recordState := store.preloadedRecords[worker.ID].State
+	store.mu.Unlock()
+	if markLostCalls != 0 {
+		t.Fatalf("drained pod exit must not mark worker lost, got %d lost calls", markLostCalls)
+	}
+	if retireDrainingCalls != 1 {
+		t.Fatalf("expected one retire-draining CAS, got %d", retireDrainingCalls)
+	}
+	if recordState != configstore.WorkerStateRetired {
+		t.Fatalf("expected durable worker state retired, got %q", recordState)
+	}
+}
+
 func TestK8sPoolMarkWorkerLostIfCurrentLeaseAllowsUnstampedLocalWorker(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 	store := &captureRuntimeWorkerStore{
@@ -3550,6 +3696,9 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	}
 	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
 		t.Fatal("expected automountServiceAccountToken=false for shared warm worker pods")
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil || *pod.Spec.TerminationGracePeriodSeconds != workerTerminationGracePeriodSeconds {
+		t.Fatalf("expected terminationGracePeriodSeconds=%d, got %v", workerTerminationGracePeriodSeconds, pod.Spec.TerminationGracePeriodSeconds)
 	}
 
 	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.RunAsNonRoot == nil || !*pod.Spec.SecurityContext.RunAsNonRoot {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1296,6 +1296,33 @@ func TestK8sPoolReserveSharedWorkerSkipsUnhealthyIdleWorker(t *testing.T) {
 	}
 }
 
+func TestK8sPoolReserveSharedWorkerSkipsDrainingIdleWorker(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 2)
+	draining := &ManagedWorker{ID: 1, done: make(chan struct{})}
+	if err := draining.SetSharedState(SharedWorkerState{Lifecycle: WorkerLifecycleIdle}); err != nil {
+		t.Fatalf("SetSharedState(draining): %v", err)
+	}
+	pool.workers[draining.ID] = draining
+
+	pool.healthCheckFunc = func(context.Context, *ManagedWorker) error {
+		return validateReservedWorkerHealth(&healthCheckResult{Healthy: true, Draining: true})
+	}
+
+	got, err := pool.ReserveSharedWorker(context.Background(), &WorkerAssignment{
+		OrgID: "analytics",
+	})
+	var capacityErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("expected warm capacity exhaustion after draining worker, got worker=%#v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected no worker on draining reservation, got %d", got.ID)
+	}
+	if _, ok := pool.Worker(draining.ID); ok {
+		t.Fatal("expected draining worker to be retired from the pool")
+	}
+}
+
 func TestK8sPool_CleanDeadWorkers(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 
@@ -3501,6 +3528,55 @@ func TestK8sPoolCleanDeadWorkersLeavesCurrentRuntimeLeaseForHealthLoop(t *testin
 	}
 	if records := store.snapshot(); len(records) != 0 {
 		t.Fatalf("current runtime lease clean-dead path must not write unconditional worker records, got %#v", records)
+	}
+}
+
+func TestK8sPoolCleanDeadWorkersRetiresDrainingWorkerAfterPodExit(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	store := &captureRuntimeWorkerStore{
+		preloadedRecords: map[int]*configstore.WorkerRecord{
+			16: {
+				WorkerID:          16,
+				PodName:           "test-cp-worker-16",
+				State:             configstore.WorkerStateDraining,
+				OwnerCPInstanceID: pool.cpInstanceID,
+				OwnerEpoch:        4,
+			},
+		},
+	}
+	pool.runtimeStore = store
+
+	done := make(chan struct{})
+	close(done)
+	worker := &ManagedWorker{ID: 16, done: done}
+	worker.SetOwnerCPInstanceID(pool.cpInstanceID)
+	worker.SetOwnerEpoch(4)
+	if err := worker.SetSharedState(SharedWorkerState{Lifecycle: WorkerLifecycleDraining}); err != nil {
+		t.Fatalf("SetSharedState: %v", err)
+	}
+	pool.workers[worker.ID] = worker
+
+	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-16", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.16"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker pod: %v", err)
+	}
+
+	pool.cleanDeadWorkersLocked()
+
+	if _, ok := pool.workers[worker.ID]; ok {
+		t.Fatal("cleanDeadWorkersLocked should remove exited draining worker")
+	}
+	if store.retireDrainingCalls != 1 {
+		t.Fatalf("expected one retire-draining CAS, got %d", store.retireDrainingCalls)
+	}
+	store.mu.Lock()
+	recordState := store.preloadedRecords[worker.ID].State
+	recordReason := store.preloadedRecords[worker.ID].RetireReason
+	store.mu.Unlock()
+	if recordState != configstore.WorkerStateRetired || recordReason != RetireReasonNormal {
+		t.Fatalf("expected draining worker to retire normally, got state=%q reason=%q", recordState, recordReason)
 	}
 }
 

--- a/controlplane/worker_lifecycle_metrics.go
+++ b/controlplane/worker_lifecycle_metrics.go
@@ -50,6 +50,7 @@ const (
 	LifecycleOriginMismatchedVersionReaper LifecycleOrigin = "mismatched_version_reaper"
 	LifecycleOriginShutdownAll             LifecycleOrigin = "shutdown_all"
 	LifecycleOriginHealthCheckCrash        LifecycleOrigin = "health_check_crash"
+	LifecycleOriginWorkerDrain             LifecycleOrigin = "worker_drain"
 	LifecycleOriginSpawnFailure            LifecycleOrigin = "spawn_failure"
 	LifecycleOriginReserveImageMismatch    LifecycleOrigin = "reserve_image_mismatch"
 	LifecycleOriginCredRefresh             LifecycleOrigin = "cred_refresh"

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -26,25 +26,25 @@ import (
 
 // ManagedWorker represents a duckdb-service worker process.
 type ManagedWorker struct {
-	ID                      int
-	podName                 string
-	nodeName                string //nolint:unused // only set in kubernetes warm-pool; drives cache-locality-aware scheduling
-	image                   string        //nolint:unused // only set in kubernetes warm-pool; carried through runtime store records
-	profile                 WorkerProfile //nolint:unused // only set in kubernetes warm-pool; pod-shape this worker was spawned with (zero = default exclusive)
-	cmd                     *exec.Cmd
-	socketPath              string
-	bearerToken             string
-	client                  *flightsql.Client
-	parentListener          net.Listener    // CP-side listener; lifecycle managed by releaseSocket
-	prebound                *preboundSocket // non-nil if using a pre-bound socket slot
-	releaseOnce             sync.Once       // ensures releaseWorkerSocket body runs exactly once
-	done                    chan struct{}   // closed when process exits
-	exitErr                 error
-	activeSessions          int       // Number of sessions currently assigned to this worker
-	lastUsed                time.Time // Last time a session was destroyed on this worker
-	sharedState             SharedWorkerState
-	reservedAt              time.Time //nolint:unused // only set in kubernetes warm-pool reservation path
-	peakSessions            int       // High-water mark of concurrent sessions (for retirement metrics)
+	ID             int
+	podName        string
+	nodeName       string        //nolint:unused // only set in kubernetes warm-pool; drives cache-locality-aware scheduling
+	image          string        //nolint:unused // only set in kubernetes warm-pool; carried through runtime store records
+	profile        WorkerProfile //nolint:unused // only set in kubernetes warm-pool; pod-shape this worker was spawned with (zero = default exclusive)
+	cmd            *exec.Cmd
+	socketPath     string
+	bearerToken    string
+	client         *flightsql.Client
+	parentListener net.Listener    // CP-side listener; lifecycle managed by releaseSocket
+	prebound       *preboundSocket // non-nil if using a pre-bound socket slot
+	releaseOnce    sync.Once       // ensures releaseWorkerSocket body runs exactly once
+	done           chan struct{}   // closed when process exits
+	exitErr        error
+	activeSessions int       // Number of sessions currently assigned to this worker
+	lastUsed       time.Time // Last time a session was destroyed on this worker
+	sharedState    SharedWorkerState
+	reservedAt     time.Time //nolint:unused // only set in kubernetes warm-pool reservation path
+	peakSessions   int       // High-water mark of concurrent sessions (for retirement metrics)
 	// ownerEpoch is guarded by epochMu so cred-refresh's
 	// "RefreshLease then SetOwnerEpoch" sequence appears atomic to
 	// concurrent readers (notably ShutdownAll's lease minting).
@@ -551,6 +551,8 @@ type sessionProgressJSON struct {
 // healthCheckResult is the parsed health check response from a worker.
 type healthCheckResult struct {
 	Healthy         bool                            `json:"healthy"`
+	Draining        bool                            `json:"draining"`
+	ActiveQueries   int                             `json:"active_queries"`
 	SessionProgress map[string]*sessionProgressJSON `json:"session_progress"`
 }
 
@@ -579,7 +581,9 @@ func doHealthCheck(ctx context.Context, client *flightsql.Client) (*healthCheckR
 	return doHealthCheckWithMetadata(ctx, client, server.WorkerHealthCheckPayload{})
 }
 
-func doHealthCheckWithMetadata(ctx context.Context, client *flightsql.Client, payload server.WorkerHealthCheckPayload) (*healthCheckResult, error) {
+var doHealthCheckWithMetadata = doHealthCheckWithMetadataImpl
+
+func doHealthCheckWithMetadataImpl(ctx context.Context, client *flightsql.Client, payload server.WorkerHealthCheckPayload) (*healthCheckResult, error) {
 	body, _ := json.Marshal(payload)
 
 	// Use the underlying flight client for custom actions.

--- a/controlplane/worker_state.go
+++ b/controlplane/worker_state.go
@@ -117,12 +117,12 @@ func (s SharedWorkerState) Validate() error {
 			return fmt.Errorf("lifecycle %q cannot have an assignment", lifecycle)
 		}
 		return nil
-	case WorkerLifecycleReserved, WorkerLifecycleActivating, WorkerLifecycleHot, WorkerLifecycleHotIdle, WorkerLifecycleDraining:
+	case WorkerLifecycleReserved, WorkerLifecycleActivating, WorkerLifecycleHot, WorkerLifecycleHotIdle:
 		if err := validateWorkerAssignment(s.Assignment); err != nil {
 			return fmt.Errorf("lifecycle %q requires a valid assignment: %w", lifecycle, err)
 		}
 		return nil
-	case WorkerLifecycleRetired:
+	case WorkerLifecycleDraining, WorkerLifecycleRetired:
 		if s.Assignment == nil {
 			return nil
 		}
@@ -151,12 +151,20 @@ func (s SharedWorkerState) Transition(next WorkerLifecycleState, assignment *Wor
 	switch next {
 	case WorkerLifecycleIdle:
 		nextState.Assignment = nil
-	case WorkerLifecycleReserved, WorkerLifecycleActivating, WorkerLifecycleHot, WorkerLifecycleHotIdle, WorkerLifecycleDraining:
+	case WorkerLifecycleReserved, WorkerLifecycleActivating, WorkerLifecycleHot, WorkerLifecycleHotIdle:
 		resolved, err := resolveWorkerAssignment(s.Assignment, assignment)
 		if err != nil {
 			return SharedWorkerState{}, err
 		}
 		nextState.Assignment = resolved
+	case WorkerLifecycleDraining:
+		if s.Assignment != nil || assignment != nil {
+			resolved, err := resolveWorkerAssignment(s.Assignment, assignment)
+			if err != nil {
+				return SharedWorkerState{}, err
+			}
+			nextState.Assignment = resolved
+		}
 	case WorkerLifecycleRetired:
 		if assignment != nil {
 			resolved, err := resolveWorkerAssignment(s.Assignment, assignment)
@@ -180,15 +188,15 @@ func (s SharedWorkerState) Transition(next WorkerLifecycleState, assignment *Wor
 func isAllowedWorkerLifecycleTransition(current, next WorkerLifecycleState) bool {
 	switch current {
 	case WorkerLifecycleIdle:
-		return next == WorkerLifecycleReserved || next == WorkerLifecycleRetired
+		return next == WorkerLifecycleReserved || next == WorkerLifecycleDraining || next == WorkerLifecycleRetired
 	case WorkerLifecycleReserved:
-		return next == WorkerLifecycleActivating || next == WorkerLifecycleRetired
+		return next == WorkerLifecycleActivating || next == WorkerLifecycleDraining || next == WorkerLifecycleRetired
 	case WorkerLifecycleActivating:
-		return next == WorkerLifecycleHot || next == WorkerLifecycleRetired
+		return next == WorkerLifecycleHot || next == WorkerLifecycleDraining || next == WorkerLifecycleRetired
 	case WorkerLifecycleHot:
 		return next == WorkerLifecycleDraining || next == WorkerLifecycleRetired || next == WorkerLifecycleHotIdle
 	case WorkerLifecycleHotIdle:
-		return next == WorkerLifecycleReserved || next == WorkerLifecycleRetired
+		return next == WorkerLifecycleReserved || next == WorkerLifecycleDraining || next == WorkerLifecycleRetired
 	case WorkerLifecycleDraining:
 		return next == WorkerLifecycleRetired
 	case WorkerLifecycleRetired:

--- a/controlplane/worker_state_test.go
+++ b/controlplane/worker_state_test.go
@@ -70,6 +70,27 @@ func TestSharedWorkerStateTransitionRejectsMissingOrInvalidAssignment(t *testing
 	}
 }
 
+func TestSharedWorkerStateAllowsUnassignedWorkerToDrain(t *testing.T) {
+	state, err := (SharedWorkerState{}).Transition(WorkerLifecycleDraining, nil)
+	if err != nil {
+		t.Fatalf("transition idle worker to draining: %v", err)
+	}
+	if got := state.NormalizedLifecycle(); got != WorkerLifecycleDraining {
+		t.Fatalf("expected draining lifecycle, got %q", got)
+	}
+	if state.Assignment != nil {
+		t.Fatalf("expected unassigned draining worker, got %#v", state.Assignment)
+	}
+
+	state, err = state.Transition(WorkerLifecycleRetired, nil)
+	if err != nil {
+		t.Fatalf("transition unassigned draining worker to retired: %v", err)
+	}
+	if got := state.NormalizedLifecycle(); got != WorkerLifecycleRetired {
+		t.Fatalf("expected retired lifecycle, got %q", got)
+	}
+}
+
 func TestSharedWorkerStateTransitionRejectsInvalidLifecycleMoves(t *testing.T) {
 	state, err := (SharedWorkerState{}).Transition(WorkerLifecycleReserved, &WorkerAssignment{
 		OrgID: "analytics",

--- a/duckdbservice/copy_from_stdin.go
+++ b/duckdbservice/copy_from_stdin.go
@@ -136,6 +136,11 @@ func (h *FlightSQLHandler) doCopyFromStdin(
 	if mErr != nil {
 		return status.Errorf(codes.Internal, "marshal DoPutUpdateResult: %v", mErr)
 	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	if err := stream.Send(&flight.PutResult{AppMetadata: app}); err != nil {
 		return fmt.Errorf("copy-from-stdin: send PutResult: %w", err)
 	}

--- a/duckdbservice/copy_from_stdin.go
+++ b/duckdbservice/copy_from_stdin.go
@@ -48,6 +48,14 @@ func (h *FlightSQLHandler) doCopyFromStdin(
 	if err != nil {
 		return err
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return drainErr
+	}
+	if err != nil {
+		return status.Errorf(codes.Internal, "copy-from-stdin: start drain tracking: %v", err)
+	}
+	defer finishDrain()
 
 	desc := first.GetFlightDescriptor()
 	if desc == nil || len(desc.Cmd) == 0 {

--- a/duckdbservice/copy_from_stdin.go
+++ b/duckdbservice/copy_from_stdin.go
@@ -48,7 +48,7 @@ func (h *FlightSQLHandler) doCopyFromStdin(
 	if err != nil {
 		return err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(""))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return drainErr
 	}

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -39,6 +39,101 @@ func workerDrainingStatus(err error) error {
 	return nil
 }
 
+const (
+	metadataDrainSchemas = "schemas"
+	metadataDrainTables  = "tables"
+)
+
+func sendStreamChunk(ctx context.Context, ch chan<- flight.StreamChunk, chunk flight.StreamChunk) bool {
+	select {
+	case ch <- chunk:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func sendActionResult(stream flight.FlightService_DoActionServer, result *flight.Result) error {
+	select {
+	case <-stream.Context().Done():
+		return stream.Context().Err()
+	default:
+		return stream.Send(result)
+	}
+}
+
+func releaseQueryHandle(session *Session, handleID string) {
+	var releaseDrains []func()
+	session.mu.Lock()
+	handle, ok := session.queries[handleID]
+	if ok {
+		delete(session.queries, handleID)
+		if handle.finishDrain != nil {
+			releaseDrains = append(releaseDrains, handle.finishDrain)
+			handle.finishDrain = nil
+		}
+		releaseDrains = append(releaseDrains, handle.pendingDrains...)
+		handle.pendingDrains = nil
+	}
+	session.mu.Unlock()
+	for _, release := range releaseDrains {
+		if release != nil {
+			release()
+		}
+	}
+}
+
+func appendPreparedDrain(session *Session, handleID string, finishDrain func()) bool {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	handle, ok := session.queries[handleID]
+	if !ok {
+		return false
+	}
+	handle.pendingDrains = append(handle.pendingDrains, finishDrain)
+	return true
+}
+
+func popPreparedDrain(session *Session, handleID string) (*QueryHandle, func(), bool) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	handle, ok := session.queries[handleID]
+	if !ok {
+		return nil, nil, false
+	}
+	if len(handle.pendingDrains) == 0 {
+		return handle, nil, true
+	}
+	finishDrain := handle.pendingDrains[0]
+	copy(handle.pendingDrains, handle.pendingDrains[1:])
+	handle.pendingDrains = handle.pendingDrains[:len(handle.pendingDrains)-1]
+	return handle, finishDrain, true
+}
+
+func appendMetadataDrain(session *Session, key string, finishDrain func()) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.metadataDrains == nil {
+		session.metadataDrains = make(map[string][]func())
+	}
+	session.metadataDrains[key] = append(session.metadataDrains[key], finishDrain)
+}
+
+func popMetadataDrain(session *Session, key string) func() {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if len(session.metadataDrains[key]) == 0 {
+		return nil
+	}
+	finishDrain := session.metadataDrains[key][0]
+	copy(session.metadataDrains[key], session.metadataDrains[key][1:])
+	session.metadataDrains[key] = session.metadataDrains[key][:len(session.metadataDrains[key])-1]
+	if len(session.metadataDrains[key]) == 0 {
+		delete(session.metadataDrains, key)
+	}
+	return finishDrain
+}
+
 // sessionFromContext extracts the session from gRPC metadata.
 // The session token is expected in the "x-duckgres-session" header.
 func (h *FlightSQLHandler) sessionFromContext(ctx context.Context) (*Session, error) {
@@ -131,7 +226,11 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 	resp, _ := json.Marshal(map[string]string{
 		"session_token": session.ID,
 	})
-	return stream.Send(&flight.Result{Body: resp})
+	if err := sendActionResult(stream, &flight.Result{Body: resp}); err != nil {
+		_ = h.pool.DestroySession(session.ID)
+		return err
+	}
+	return nil
 }
 
 func (h *FlightSQLHandler) doActivateTenant(body []byte, stream flight.FlightService_DoActionServer) error {
@@ -159,7 +258,7 @@ func (h *FlightSQLHandler) doActivateTenant(body []byte, stream flight.FlightSer
 	}
 
 	resp, _ := json.Marshal(map[string]bool{"ok": true})
-	return stream.Send(&flight.Result{Body: resp})
+	return sendActionResult(stream, &flight.Result{Body: resp})
 }
 
 func (h *FlightSQLHandler) doDestroySession(body []byte, stream flight.FlightService_DoActionServer) error {
@@ -179,7 +278,7 @@ func (h *FlightSQLHandler) doDestroySession(body []byte, stream flight.FlightSer
 	}
 
 	resp, _ := json.Marshal(map[string]bool{"ok": true})
-	return stream.Send(&flight.Result{Body: resp})
+	return sendActionResult(stream, &flight.Result{Body: resp})
 }
 
 func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightService_DoActionServer) error {
@@ -310,7 +409,7 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 		"uptime_ns":        time.Since(h.pool.startTime).Nanoseconds(),
 		"session_progress": sessionProgress,
 	})
-	return stream.Send(&flight.Result{Body: resp})
+	return sendActionResult(stream, &flight.Result{Body: resp})
 }
 
 // Flight SQL method implementations
@@ -331,11 +430,16 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "start query drain tracking: %v", err)
 	}
+	releaseOnReturn := true
+	defer func() {
+		if releaseOnReturn {
+			finishDrain()
+		}
+	}()
 
 	// Handle empty queries (e.g., ";" from PostgreSQL client pings).
 	// Return an empty schema instead of sending to DuckDB which rejects empty queries.
 	if isEmptyFlightQuery(query) {
-		finishDrain()
 		emptySchema := arrow.NewSchema(nil, nil)
 		handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 		session.mu.Lock()
@@ -359,7 +463,6 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 
 	tx, txnKey, err := session.getOpenTxn(cmd.GetTransactionId())
 	if err != nil {
-		finishDrain()
 		return nil, err
 	}
 
@@ -401,7 +504,6 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		)
 	}
 	if err != nil {
-		finishDrain()
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare query: %v", err)
 	}
 
@@ -410,18 +512,14 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	sendProfilingMetadata(ctx, session)
 
 	handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
+	ticketBytes, err := flightsql.CreateStatementQueryTicket([]byte(handleID))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create ticket: %v", err)
+	}
 	session.mu.Lock()
 	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey, finishDrain: finishDrain}
 	session.mu.Unlock()
-
-	ticketBytes, err := flightsql.CreateStatementQueryTicket([]byte(handleID))
-	if err != nil {
-		finishDrain()
-		session.mu.Lock()
-		delete(session.queries, handleID)
-		session.mu.Unlock()
-		return nil, status.Errorf(codes.Internal, "failed to create ticket: %v", err)
-	}
+	releaseOnReturn = false
 
 	return &flight.FlightInfo{
 		Schema:           flight.SerializeSchema(schema, h.alloc),
@@ -450,7 +548,6 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 	if !ok {
 		return nil, nil, status.Error(codes.NotFound, "query handle not found")
 	}
-	finishDrain := handle.finishDrain
 
 	var tx *sql.Tx
 	if handle.TxnID != "" {
@@ -458,12 +555,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		ttx := session.txns[handle.TxnID]
 		session.mu.RUnlock()
 		if ttx == nil || ttx.tx == nil {
-			session.mu.Lock()
-			delete(session.queries, handleID)
-			session.mu.Unlock()
-			if finishDrain != nil {
-				finishDrain()
-			}
+			releaseQueryHandle(session, handleID)
 			return nil, nil, status.Error(codes.NotFound, "transaction not found")
 		}
 		ttx.lastUsed.Store(time.Now().UnixNano())
@@ -476,9 +568,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 
 	// Empty queries have no rows to fetch — return an empty stream immediately.
 	if isEmptyFlightQuery(handle.Query) {
-		if finishDrain != nil {
-			finishDrain()
-		}
+		releaseQueryHandle(session, handleID)
 		close(ch)
 		return schema, ch, nil
 	}
@@ -486,12 +576,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 	go func() {
 		defer close(ch)
 		defer func() {
-			session.mu.Lock()
-			delete(session.queries, handleID)
-			session.mu.Unlock()
-			if finishDrain != nil {
-				finishDrain()
-			}
+			releaseQueryHandle(session, handleID)
 		}()
 
 		session.progress.queryActive.Store(true)
@@ -533,7 +618,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 			)
 		}
 		if qerr != nil {
-			ch <- flight.StreamChunk{Err: qerr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: qerr})
 			return
 		}
 		defer func() {
@@ -543,13 +628,16 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		for {
 			record, recErr := RowsToRecord(h.alloc, rows, schema, 1024)
 			if recErr != nil {
-				ch <- flight.StreamChunk{Err: recErr}
+				_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: recErr})
 				return
 			}
 			if record == nil {
 				break
 			}
-			ch <- flight.StreamChunk{Data: record}
+			if !sendStreamChunk(ctx, ch, flight.StreamChunk{Data: record}) {
+				record.Release()
+				return
+			}
 		}
 	}()
 
@@ -664,16 +752,16 @@ func (h *FlightSQLHandler) BeginTransaction(ctx context.Context,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "start transaction drain tracking: %v", err)
 	}
-	defer finishDrain()
 	_ = req
 
 	tx, err := session.Conn.BeginTx(context.Background(), nil)
 	if err != nil {
+		finishDrain()
 		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
 	}
 
 	txnKey := fmt.Sprintf("txn-%d", session.handleCounter.Add(1))
-	ttx := &trackedTx{tx: tx}
+	ttx := &trackedTx{tx: tx, finishDrain: finishDrain}
 	ttx.lastUsed.Store(time.Now().UnixNano())
 
 	session.mu.Lock()
@@ -708,11 +796,12 @@ func (h *FlightSQLHandler) EndTransaction(ctx context.Context,
 	if !ok || ttx == nil || ttx.tx == nil {
 		return status.Error(codes.NotFound, "transaction not found")
 	}
-	finishDrain, err := h.pool.beginDrainWork(true)
-	if err != nil {
-		return status.Errorf(codes.Internal, "start transaction finalization drain tracking: %v", err)
-	}
-	defer finishDrain()
+	defer func() {
+		if ttx.finishDrain != nil {
+			ttx.finishDrain()
+			ttx.finishDrain = nil
+		}
+	}()
 
 	switch req.GetAction() {
 	case flightsql.EndTransactionCommit:
@@ -794,9 +883,7 @@ func (h *FlightSQLHandler) ClosePreparedStatement(ctx context.Context,
 	}
 
 	handleID := string(req.GetPreparedStatementHandle())
-	session.mu.Lock()
-	delete(session.queries, handleID)
-	session.mu.Unlock()
+	releaseQueryHandle(session, handleID)
 	return nil
 }
 
@@ -807,9 +894,19 @@ func (h *FlightSQLHandler) GetFlightInfoPreparedStatement(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
-	if h.pool.IsDraining() {
-		return nil, status.Error(codes.Unavailable, "worker is draining")
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, drainErr
 	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start prepared query drain tracking: %v", err)
+	}
+	releaseOnReturn := true
+	defer func() {
+		if releaseOnReturn {
+			finishDrain()
+		}
+	}()
 
 	handleID := string(cmd.GetPreparedStatementHandle())
 	session.mu.RLock()
@@ -818,6 +915,10 @@ func (h *FlightSQLHandler) GetFlightInfoPreparedStatement(ctx context.Context, c
 	if !ok {
 		return nil, status.Error(codes.NotFound, "prepared statement not found")
 	}
+	if !appendPreparedDrain(session, handleID, finishDrain) {
+		return nil, status.Error(codes.NotFound, "prepared statement not found")
+	}
+	releaseOnReturn = false
 
 	return &flight.FlightInfo{
 		Schema:           flight.SerializeSchema(handle.Schema, h.alloc),
@@ -837,20 +938,20 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
-	if drainErr := workerDrainingStatus(err); drainErr != nil {
-		return nil, nil, drainErr
-	}
-	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "start prepared query drain tracking: %v", err)
-	}
-
-	session.mu.RLock()
-	handle, ok := session.queries[string(cmd.GetPreparedStatementHandle())]
-	session.mu.RUnlock()
+	handleID := string(cmd.GetPreparedStatementHandle())
+	handle, finishDrain, ok := popPreparedDrain(session, handleID)
 	if !ok {
-		finishDrain()
 		return nil, nil, status.Error(codes.NotFound, "prepared statement not found")
+	}
+	if finishDrain == nil {
+		var err error
+		finishDrain, err = h.pool.beginDrainWork(false)
+		if drainErr := workerDrainingStatus(err); drainErr != nil {
+			return nil, nil, drainErr
+		}
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "start prepared query drain tracking: %v", err)
+		}
 	}
 
 	var tx *sql.Tx
@@ -890,7 +991,7 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 			rows, qerr = session.Conn.QueryContext(ctx, handle.Query)
 		}
 		if qerr != nil {
-			ch <- flight.StreamChunk{Err: qerr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: qerr})
 			return
 		}
 		defer func() {
@@ -900,13 +1001,16 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 		for {
 			record, recErr := RowsToRecord(h.alloc, rows, schema, 1024)
 			if recErr != nil {
-				ch <- flight.StreamChunk{Err: recErr}
+				_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: recErr})
 				return
 			}
 			if record == nil {
 				break
 			}
-			ch <- flight.StreamChunk{Data: record}
+			if !sendStreamChunk(ctx, ch, flight.StreamChunk{Data: record}) {
+				record.Release()
+				return
+			}
 		}
 	}()
 
@@ -916,13 +1020,18 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 func (h *FlightSQLHandler) GetFlightInfoSchemas(ctx context.Context, cmd flightsql.GetDBSchemas,
 	desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
 
-	_, err := h.sessionFromContext(ctx)
+	session, err := h.sessionFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if h.pool.IsDraining() {
-		return nil, status.Error(codes.Unavailable, "worker is draining")
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, drainErr
 	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
+	}
+	appendMetadataDrain(session, metadataDrainSchemas, finishDrain)
 
 	return &flight.FlightInfo{
 		Schema:           flight.SerializeSchema(schema_ref.DBSchemas, h.alloc),
@@ -942,12 +1051,16 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 	if err != nil {
 		return nil, nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
-	if drainErr := workerDrainingStatus(err); drainErr != nil {
-		return nil, nil, drainErr
-	}
-	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
+	finishDrain := popMetadataDrain(session, metadataDrainSchemas)
+	if finishDrain == nil {
+		var err error
+		finishDrain, err = h.pool.beginDrainWork(false)
+		if drainErr := workerDrainingStatus(err); drainErr != nil {
+			return nil, nil, drainErr
+		}
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
+		}
 	}
 
 	schema := schema_ref.DBSchemas
@@ -978,7 +1091,7 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 			rows, qerr = session.Conn.QueryContext(ctx, query, args...)
 		}
 		if qerr != nil {
-			ch <- flight.StreamChunk{Err: qerr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: qerr})
 			return
 		}
 		defer func() {
@@ -994,7 +1107,7 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 			var catalog sql.NullString
 			var schemaName sql.NullString
 			if scanErr := rows.Scan(&catalog, &schemaName); scanErr != nil {
-				ch <- flight.StreamChunk{Err: scanErr}
+				_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: scanErr})
 				return
 			}
 			if catalog.Valid {
@@ -1009,10 +1122,14 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 			}
 		}
 		if rowErr := rows.Err(); rowErr != nil {
-			ch <- flight.StreamChunk{Err: rowErr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: rowErr})
 			return
 		}
-		ch <- flight.StreamChunk{Data: builder.NewRecordBatch()}
+		record := builder.NewRecordBatch()
+		if !sendStreamChunk(ctx, ch, flight.StreamChunk{Data: record}) {
+			record.Release()
+			return
+		}
 	}()
 
 	return schema, ch, nil
@@ -1021,13 +1138,18 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 func (h *FlightSQLHandler) GetFlightInfoTables(ctx context.Context, cmd flightsql.GetTables,
 	desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
 
-	_, err := h.sessionFromContext(ctx)
+	session, err := h.sessionFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if h.pool.IsDraining() {
-		return nil, status.Error(codes.Unavailable, "worker is draining")
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, drainErr
 	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
+	}
+	appendMetadataDrain(session, metadataDrainTables, finishDrain)
 
 	schema := schema_ref.Tables
 	if cmd.GetIncludeSchema() {
@@ -1052,12 +1174,16 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 	if err != nil {
 		return nil, nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
-	if drainErr := workerDrainingStatus(err); drainErr != nil {
-		return nil, nil, drainErr
-	}
-	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
+	finishDrain := popMetadataDrain(session, metadataDrainTables)
+	if finishDrain == nil {
+		var err error
+		finishDrain, err = h.pool.beginDrainWork(false)
+		if drainErr := workerDrainingStatus(err); drainErr != nil {
+			return nil, nil, drainErr
+		}
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
+		}
 	}
 
 	schema := schema_ref.Tables
@@ -1106,7 +1232,7 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 			rows, qerr = session.Conn.QueryContext(ctx, query, args...)
 		}
 		if qerr != nil {
-			ch <- flight.StreamChunk{Err: qerr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: qerr})
 			return
 		}
 		rowsOpen := true
@@ -1131,19 +1257,19 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 		for rows.Next() {
 			var t tableInfo
 			if scanErr := rows.Scan(&t.catalog, &t.schema, &t.name, &t.tableType); scanErr != nil {
-				ch <- flight.StreamChunk{Err: scanErr}
+				_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: scanErr})
 				return
 			}
 			tables = append(tables, t)
 		}
 		if rowErr := rows.Err(); rowErr != nil {
-			ch <- flight.StreamChunk{Err: rowErr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: rowErr})
 			return
 		}
 		// Close the metadata cursor before issuing schema probe queries on the
 		// same DB/transaction.
 		if closeErr := closeRows(); closeErr != nil {
-			ch <- flight.StreamChunk{Err: closeErr}
+			_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: closeErr})
 			return
 		}
 
@@ -1173,14 +1299,18 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 				qualified := QualifyTableName(t.catalog, t.schema, t.name)
 				tableSchema, schemaErr := GetQuerySchema(ctx, session.Conn, "SELECT * FROM "+qualified, activeTx)
 				if schemaErr != nil {
-					ch <- flight.StreamChunk{Err: schemaErr}
+					_ = sendStreamChunk(ctx, ch, flight.StreamChunk{Err: schemaErr})
 					return
 				}
 				schemaBuilder.Append(flight.SerializeSchema(tableSchema, h.alloc))
 			}
 		}
 
-		ch <- flight.StreamChunk{Data: builder.NewRecordBatch()}
+		record := builder.NewRecordBatch()
+		if !sendStreamChunk(ctx, ch, flight.StreamChunk{Data: record}) {
+			record.Release()
+			return
+		}
 	}()
 
 	return schema, ch, nil

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -44,6 +44,28 @@ const (
 	metadataDrainTables  = "tables"
 )
 
+func optionalStringKey(v *string) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return *v
+}
+
+func metadataSchemasDrainKey(cmd flightsql.GetDBSchemas) string {
+	return metadataDrainSchemas + "|" +
+		optionalStringKey(cmd.GetCatalog()) + "|" +
+		optionalStringKey(cmd.GetDBSchemaFilterPattern())
+}
+
+func metadataTablesDrainKey(cmd flightsql.GetTables) string {
+	return metadataDrainTables + "|" +
+		optionalStringKey(cmd.GetCatalog()) + "|" +
+		optionalStringKey(cmd.GetDBSchemaFilterPattern()) + "|" +
+		optionalStringKey(cmd.GetTableNameFilterPattern()) + "|" +
+		strings.Join(cmd.GetTableTypes(), ",") + "|" +
+		strconv.FormatBool(cmd.GetIncludeSchema())
+}
+
 func sendStreamChunk(ctx context.Context, ch chan<- flight.StreamChunk, chunk flight.StreamChunk) bool {
 	select {
 	case ch <- chunk:
@@ -63,24 +85,42 @@ func sendActionResult(stream flight.FlightService_DoActionServer, result *flight
 }
 
 func releaseQueryHandle(session *Session, handleID string) {
-	var releaseDrains []func()
 	session.mu.Lock()
 	handle, ok := session.queries[handleID]
 	if ok {
 		delete(session.queries, handleID)
-		if handle.finishDrain != nil {
-			releaseDrains = append(releaseDrains, handle.finishDrain)
-			handle.finishDrain = nil
-		}
-		releaseDrains = append(releaseDrains, handle.pendingDrains...)
-		handle.pendingDrains = nil
 	}
 	session.mu.Unlock()
-	for _, release := range releaseDrains {
-		if release != nil {
-			release()
-		}
+	if ok {
+		releaseQueryHandleValue(handle)
 	}
+}
+
+func releaseQueryHandleValue(handle *QueryHandle) {
+	if handle == nil {
+		return
+	}
+	var releaseDrains []func()
+	if handle.finishDrain != nil {
+		releaseDrains = append(releaseDrains, handle.finishDrain)
+		handle.finishDrain = nil
+	}
+	releaseDrains = append(releaseDrains, handle.pendingDrains...)
+	handle.pendingDrains = nil
+	for _, release := range releaseDrains {
+		releaseDrainFunc(release)
+	}
+}
+
+func popQueryHandle(session *Session, handleID string) (*QueryHandle, bool) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	handle, ok := session.queries[handleID]
+	if !ok {
+		return nil, false
+	}
+	delete(session.queries, handleID)
+	return handle, true
 }
 
 func appendPreparedDrain(session *Session, handleID string, finishDrain func()) bool {
@@ -423,7 +463,15 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	}
 
 	query := cmd.GetQuery()
-	finishDrain, err := h.pool.beginDrainWork(false)
+	var tx *sql.Tx
+	var txnKey string
+	if !isEmptyFlightQuery(query) {
+		tx, txnKey, err = session.getOpenTxn(cmd.GetTransactionId())
+		if err != nil {
+			return nil, err
+		}
+	}
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(txnKey))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return nil, drainErr
 	}
@@ -459,11 +507,6 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 			TotalRecords: 0,
 			TotalBytes:   0,
 		}, nil
-	}
-
-	tx, txnKey, err := session.getOpenTxn(cmd.GetTransactionId())
-	if err != nil {
-		return nil, err
 	}
 
 	session.progress.queryActive.Store(true)
@@ -542,9 +585,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 
 	handleID := string(ticket.GetStatementHandle())
 
-	session.mu.RLock()
-	handle, ok := session.queries[handleID]
-	session.mu.RUnlock()
+	handle, ok := popQueryHandle(session, handleID)
 	if !ok {
 		return nil, nil, status.Error(codes.NotFound, "query handle not found")
 	}
@@ -555,7 +596,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		ttx := session.txns[handle.TxnID]
 		session.mu.RUnlock()
 		if ttx == nil || ttx.tx == nil {
-			releaseQueryHandle(session, handleID)
+			releaseQueryHandleValue(handle)
 			return nil, nil, status.Error(codes.NotFound, "transaction not found")
 		}
 		ttx.lastUsed.Store(time.Now().UnixNano())
@@ -568,7 +609,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 
 	// Empty queries have no rows to fetch — return an empty stream immediately.
 	if isEmptyFlightQuery(handle.Query) {
-		releaseQueryHandle(session, handleID)
+		releaseQueryHandleValue(handle)
 		close(ch)
 		return schema, ch, nil
 	}
@@ -576,7 +617,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 	go func() {
 		defer close(ch)
 		defer func() {
-			releaseQueryHandle(session, handleID)
+			releaseQueryHandleValue(handle)
 		}()
 
 		session.progress.queryActive.Store(true)
@@ -651,14 +692,6 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	if err != nil {
 		return 0, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
-	if drainErr := workerDrainingStatus(err); drainErr != nil {
-		return 0, drainErr
-	}
-	if err != nil {
-		return 0, status.Errorf(codes.Internal, "start update drain tracking: %v", err)
-	}
-	defer finishDrain()
 
 	tx, _, err := session.getOpenTxn(cmd.GetTransactionId())
 	if err != nil {
@@ -666,6 +699,19 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	}
 
 	query := cmd.GetQuery()
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(string(cmd.GetTransactionId())))
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return 0, drainErr
+	}
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "start update drain tracking: %v", err)
+	}
+	releaseOnReturn := true
+	defer func() {
+		if releaseOnReturn {
+			finishDrain()
+		}
+	}()
 
 	// Handle empty queries (e.g., ";" from PostgreSQL client pings).
 	if isEmptyFlightQuery(query) {
@@ -703,8 +749,6 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 		result, execErr = retryOnTransient(execFn)
 	}
 
-	// Track SQL-level transaction state for BEGIN/COMMIT/ROLLBACK sent as raw SQL.
-	trackSQLTransactionState(query, execErr, &session.sqlTxActive)
 	// Conflict retry for autocommit only (see GetFlightInfoStatement comment).
 	if execErr != nil && tx == nil && isDuckLakeTransactionConflict(execErr) {
 		ducklakeConflictTotal.Inc()
@@ -724,6 +768,15 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 				return execFn()
 			},
 		)
+	}
+	// Track SQL-level transaction state for BEGIN/COMMIT/ROLLBACK sent as raw SQL.
+	trackSQLTransactionState(query, execErr, &session.sqlTxActive)
+	if tx == nil && isTransactionStartStmt(query) && execErr == nil {
+		session.setSQLTransactionDrain(finishDrain)
+		releaseOnReturn = false
+	}
+	if tx == nil && isTxControl && execErr == nil {
+		session.releaseSQLTransactionDrain()
 	}
 	if execErr != nil {
 		return 0, status.Errorf(codes.InvalidArgument, "failed to execute update: %v", execErr)
@@ -827,7 +880,13 @@ func (h *FlightSQLHandler) CreatePreparedStatement(ctx context.Context,
 	if err != nil {
 		return flightsql.ActionCreatePreparedStatementResult{}, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
+
+	tx, txnKey, err := session.getOpenTxn(req.GetTransactionId())
+	if err != nil {
+		return flightsql.ActionCreatePreparedStatementResult{}, err
+	}
+
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(txnKey))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return flightsql.ActionCreatePreparedStatementResult{}, drainErr
 	}
@@ -835,11 +894,6 @@ func (h *FlightSQLHandler) CreatePreparedStatement(ctx context.Context,
 		return flightsql.ActionCreatePreparedStatementResult{}, status.Errorf(codes.Internal, "start prepare drain tracking: %v", err)
 	}
 	defer finishDrain()
-
-	tx, txnKey, err := session.getOpenTxn(req.GetTransactionId())
-	if err != nil {
-		return flightsql.ActionCreatePreparedStatementResult{}, err
-	}
 
 	query := req.GetQuery()
 
@@ -894,7 +948,15 @@ func (h *FlightSQLHandler) GetFlightInfoPreparedStatement(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
+	handleID := string(cmd.GetPreparedStatementHandle())
+	session.mu.RLock()
+	handle, ok := session.queries[handleID]
+	session.mu.RUnlock()
+	if !ok {
+		return nil, status.Error(codes.NotFound, "prepared statement not found")
+	}
+
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(handle.TxnID))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return nil, drainErr
 	}
@@ -908,13 +970,6 @@ func (h *FlightSQLHandler) GetFlightInfoPreparedStatement(ctx context.Context, c
 		}
 	}()
 
-	handleID := string(cmd.GetPreparedStatementHandle())
-	session.mu.RLock()
-	handle, ok := session.queries[handleID]
-	session.mu.RUnlock()
-	if !ok {
-		return nil, status.Error(codes.NotFound, "prepared statement not found")
-	}
 	if !appendPreparedDrain(session, handleID, finishDrain) {
 		return nil, status.Error(codes.NotFound, "prepared statement not found")
 	}
@@ -945,7 +1000,7 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 	}
 	if finishDrain == nil {
 		var err error
-		finishDrain, err = h.pool.beginDrainWork(false)
+		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(handle.TxnID))
 		if drainErr := workerDrainingStatus(err); drainErr != nil {
 			return nil, nil, drainErr
 		}
@@ -1024,14 +1079,14 @@ func (h *FlightSQLHandler) GetFlightInfoSchemas(ctx context.Context, cmd flights
 	if err != nil {
 		return nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(""))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return nil, drainErr
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
 	}
-	appendMetadataDrain(session, metadataDrainSchemas, finishDrain)
+	appendMetadataDrain(session, metadataSchemasDrainKey(cmd), finishDrain)
 
 	return &flight.FlightInfo{
 		Schema:           flight.SerializeSchema(schema_ref.DBSchemas, h.alloc),
@@ -1051,10 +1106,10 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 	if err != nil {
 		return nil, nil, err
 	}
-	finishDrain := popMetadataDrain(session, metadataDrainSchemas)
+	finishDrain := popMetadataDrain(session, metadataSchemasDrainKey(cmd))
 	if finishDrain == nil {
 		var err error
-		finishDrain, err = h.pool.beginDrainWork(false)
+		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(""))
 		if drainErr := workerDrainingStatus(err); drainErr != nil {
 			return nil, nil, drainErr
 		}
@@ -1142,14 +1197,14 @@ func (h *FlightSQLHandler) GetFlightInfoTables(ctx context.Context, cmd flightsq
 	if err != nil {
 		return nil, err
 	}
-	finishDrain, err := h.pool.beginDrainWork(false)
+	finishDrain, err := h.pool.beginDrainWork(session.allowsDrainContinuation(""))
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return nil, drainErr
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
 	}
-	appendMetadataDrain(session, metadataDrainTables, finishDrain)
+	appendMetadataDrain(session, metadataTablesDrainKey(cmd), finishDrain)
 
 	schema := schema_ref.Tables
 	if cmd.GetIncludeSchema() {
@@ -1174,10 +1229,10 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 	if err != nil {
 		return nil, nil, err
 	}
-	finishDrain := popMetadataDrain(session, metadataDrainTables)
+	finishDrain := popMetadataDrain(session, metadataTablesDrainKey(cmd))
 	if finishDrain == nil {
 		var err error
-		finishDrain, err = h.pool.beginDrainWork(false)
+		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(""))
 		if drainErr := workerDrainingStatus(err); drainErr != nil {
 			return nil, nil, drainErr
 		}

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -105,7 +105,7 @@ func releaseQueryHandleValue(handle *QueryHandle) {
 		releaseDrains = append(releaseDrains, handle.finishDrain)
 		handle.finishDrain = nil
 	}
-	releaseDrains = append(releaseDrains, handle.pendingDrains...)
+	releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
 	handle.pendingDrains = nil
 	for _, release := range releaseDrains {
 		releaseDrainFunc(release)
@@ -130,7 +130,7 @@ func appendPreparedDrain(session *Session, handleID string, finishDrain func()) 
 	if !ok {
 		return false
 	}
-	handle.pendingDrains = append(handle.pendingDrains, finishDrain)
+	handle.pendingDrains = append(handle.pendingDrains, drainToken{finish: finishDrain, at: time.Now()})
 	return true
 }
 
@@ -144,7 +144,7 @@ func popPreparedDrain(session *Session, handleID string) (*QueryHandle, func(), 
 	if len(handle.pendingDrains) == 0 {
 		return handle, nil, true
 	}
-	finishDrain := handle.pendingDrains[0]
+	finishDrain := handle.pendingDrains[0].finish
 	copy(handle.pendingDrains, handle.pendingDrains[1:])
 	handle.pendingDrains = handle.pendingDrains[:len(handle.pendingDrains)-1]
 	return handle, finishDrain, true
@@ -154,9 +154,9 @@ func appendMetadataDrain(session *Session, key string, finishDrain func()) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
 	if session.metadataDrains == nil {
-		session.metadataDrains = make(map[string][]func())
+		session.metadataDrains = make(map[string][]drainToken)
 	}
-	session.metadataDrains[key] = append(session.metadataDrains[key], finishDrain)
+	session.metadataDrains[key] = append(session.metadataDrains[key], drainToken{finish: finishDrain, at: time.Now()})
 }
 
 func popMetadataDrain(session *Session, key string) func() {
@@ -165,7 +165,7 @@ func popMetadataDrain(session *Session, key string) func() {
 	if len(session.metadataDrains[key]) == 0 {
 		return nil
 	}
-	finishDrain := session.metadataDrains[key][0]
+	finishDrain := session.metadataDrains[key][0].finish
 	copy(session.metadataDrains[key], session.metadataDrains[key][1:])
 	session.metadataDrains[key] = session.metadataDrains[key][:len(session.metadataDrains[key])-1]
 	if len(session.metadataDrains[key]) == 0 {
@@ -491,7 +491,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		emptySchema := arrow.NewSchema(nil, nil)
 		handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 		session.mu.Lock()
-		session.queries[handleID] = &QueryHandle{Query: query, Schema: emptySchema}
+		session.queries[handleID] = &QueryHandle{Query: query, Schema: emptySchema, createdAt: time.Now()}
 		session.mu.Unlock()
 
 		ticketBytes, ticketErr := flightsql.CreateStatementQueryTicket([]byte(handleID))
@@ -560,7 +560,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		return nil, status.Errorf(codes.Internal, "failed to create ticket: %v", err)
 	}
 	session.mu.Lock()
-	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey, finishDrain: finishDrain}
+	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey, finishDrain: finishDrain, createdAt: time.Now()}
 	session.mu.Unlock()
 	releaseOnReturn = false
 
@@ -902,7 +902,7 @@ func (h *FlightSQLHandler) CreatePreparedStatement(ctx context.Context,
 		emptySchema := arrow.NewSchema(nil, nil)
 		handleID := fmt.Sprintf("prep-%d", session.handleCounter.Add(1))
 		session.mu.Lock()
-		session.queries[handleID] = &QueryHandle{Query: query, Schema: emptySchema, TxnID: txnKey}
+		session.queries[handleID] = &QueryHandle{Query: query, Schema: emptySchema, TxnID: txnKey, Prepared: true, createdAt: time.Now()}
 		session.mu.Unlock()
 		return flightsql.ActionCreatePreparedStatementResult{
 			Handle:        []byte(handleID),
@@ -919,7 +919,7 @@ func (h *FlightSQLHandler) CreatePreparedStatement(ctx context.Context,
 
 	handleID := fmt.Sprintf("prep-%d", session.handleCounter.Add(1))
 	session.mu.Lock()
-	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey}
+	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey, Prepared: true, createdAt: time.Now()}
 	session.mu.Unlock()
 
 	return flightsql.ActionCreatePreparedStatementResult{

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -29,6 +30,13 @@ type FlightSQLHandler struct {
 	flightsql.BaseServer
 	pool  *SessionPool
 	alloc memory.Allocator
+}
+
+func workerDrainingStatus(err error) error {
+	if errors.Is(err, ErrWorkerDraining) {
+		return status.Error(codes.Unavailable, "worker is draining")
+	}
+	return nil
 }
 
 // sessionFromContext extracts the session from gRPC metadata.
@@ -92,6 +100,9 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 	if req.Username == "" {
 		return status.Error(codes.InvalidArgument, "username is required")
 	}
+	if h.pool.IsDraining() {
+		return status.Error(codes.Unavailable, "worker is draining")
+	}
 	if err := h.pool.validateControlMetadata(req.WorkerControlMetadata); err != nil {
 		return status.Errorf(codes.FailedPrecondition, "stale worker owner: %v", err)
 	}
@@ -110,6 +121,9 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 	}
 
 	session, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.Threads)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return drainErr
+	}
 	if err != nil {
 		return status.Errorf(codes.ResourceExhausted, "create session: %v", err)
 	}
@@ -131,6 +145,14 @@ func (h *FlightSQLHandler) doActivateTenant(body []byte, stream flight.FlightSer
 	if current := h.pool.currentActivation(); current != nil && current.payload.OrgID != payload.OrgID {
 		return status.Errorf(codes.FailedPrecondition, "activate tenant: worker already activated for org %q", current.payload.OrgID)
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return drainErr
+	}
+	if err != nil {
+		return status.Errorf(codes.Internal, "start activation drain tracking: %v", err)
+	}
+	defer finishDrain()
 
 	if err := h.pool.activateTenantFunc(payload); err != nil {
 		return status.Errorf(codes.FailedPrecondition, "activate tenant: %v", err)
@@ -282,7 +304,9 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 
 	resp, _ := json.Marshal(map[string]interface{}{
 		"healthy":          true,
+		"draining":         h.pool.IsDraining(),
 		"sessions":         h.pool.ActiveSessions(),
+		"active_queries":   h.pool.ActiveDrainWork(),
 		"uptime_ns":        time.Since(h.pool.startTime).Nanoseconds(),
 		"session_progress": sessionProgress,
 	})
@@ -300,10 +324,18 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	}
 
 	query := cmd.GetQuery()
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, drainErr
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start query drain tracking: %v", err)
+	}
 
 	// Handle empty queries (e.g., ";" from PostgreSQL client pings).
 	// Return an empty schema instead of sending to DuckDB which rejects empty queries.
 	if isEmptyFlightQuery(query) {
+		finishDrain()
 		emptySchema := arrow.NewSchema(nil, nil)
 		handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 		session.mu.Lock()
@@ -327,6 +359,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 
 	tx, txnKey, err := session.getOpenTxn(cmd.GetTransactionId())
 	if err != nil {
+		finishDrain()
 		return nil, err
 	}
 
@@ -368,6 +401,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		)
 	}
 	if err != nil {
+		finishDrain()
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare query: %v", err)
 	}
 
@@ -377,11 +411,15 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 
 	handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 	session.mu.Lock()
-	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey}
+	session.queries[handleID] = &QueryHandle{Query: query, Schema: schema, TxnID: txnKey, finishDrain: finishDrain}
 	session.mu.Unlock()
 
 	ticketBytes, err := flightsql.CreateStatementQueryTicket([]byte(handleID))
 	if err != nil {
+		finishDrain()
+		session.mu.Lock()
+		delete(session.queries, handleID)
+		session.mu.Unlock()
 		return nil, status.Errorf(codes.Internal, "failed to create ticket: %v", err)
 	}
 
@@ -412,6 +450,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 	if !ok {
 		return nil, nil, status.Error(codes.NotFound, "query handle not found")
 	}
+	finishDrain := handle.finishDrain
 
 	var tx *sql.Tx
 	if handle.TxnID != "" {
@@ -419,6 +458,12 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		ttx := session.txns[handle.TxnID]
 		session.mu.RUnlock()
 		if ttx == nil || ttx.tx == nil {
+			session.mu.Lock()
+			delete(session.queries, handleID)
+			session.mu.Unlock()
+			if finishDrain != nil {
+				finishDrain()
+			}
 			return nil, nil, status.Error(codes.NotFound, "transaction not found")
 		}
 		ttx.lastUsed.Store(time.Now().UnixNano())
@@ -431,6 +476,9 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 
 	// Empty queries have no rows to fetch — return an empty stream immediately.
 	if isEmptyFlightQuery(handle.Query) {
+		if finishDrain != nil {
+			finishDrain()
+		}
 		close(ch)
 		return schema, ch, nil
 	}
@@ -441,6 +489,9 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 			session.mu.Lock()
 			delete(session.queries, handleID)
 			session.mu.Unlock()
+			if finishDrain != nil {
+				finishDrain()
+			}
 		}()
 
 		session.progress.queryActive.Store(true)
@@ -512,6 +563,14 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	if err != nil {
 		return 0, err
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return 0, drainErr
+	}
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "start update drain tracking: %v", err)
+	}
+	defer finishDrain()
 
 	tx, _, err := session.getOpenTxn(cmd.GetTransactionId())
 	if err != nil {
@@ -598,6 +657,14 @@ func (h *FlightSQLHandler) BeginTransaction(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, drainErr
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start transaction drain tracking: %v", err)
+	}
+	defer finishDrain()
 	_ = req
 
 	tx, err := session.Conn.BeginTx(context.Background(), nil)
@@ -641,6 +708,11 @@ func (h *FlightSQLHandler) EndTransaction(ctx context.Context,
 	if !ok || ttx == nil || ttx.tx == nil {
 		return status.Error(codes.NotFound, "transaction not found")
 	}
+	finishDrain, err := h.pool.beginDrainWork(true)
+	if err != nil {
+		return status.Errorf(codes.Internal, "start transaction finalization drain tracking: %v", err)
+	}
+	defer finishDrain()
 
 	switch req.GetAction() {
 	case flightsql.EndTransactionCommit:
@@ -666,6 +738,14 @@ func (h *FlightSQLHandler) CreatePreparedStatement(ctx context.Context,
 	if err != nil {
 		return flightsql.ActionCreatePreparedStatementResult{}, err
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return flightsql.ActionCreatePreparedStatementResult{}, drainErr
+	}
+	if err != nil {
+		return flightsql.ActionCreatePreparedStatementResult{}, status.Errorf(codes.Internal, "start prepare drain tracking: %v", err)
+	}
+	defer finishDrain()
 
 	tx, txnKey, err := session.getOpenTxn(req.GetTransactionId())
 	if err != nil {
@@ -727,6 +807,9 @@ func (h *FlightSQLHandler) GetFlightInfoPreparedStatement(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
+	if h.pool.IsDraining() {
+		return nil, status.Error(codes.Unavailable, "worker is draining")
+	}
 
 	handleID := string(cmd.GetPreparedStatementHandle())
 	session.mu.RLock()
@@ -754,11 +837,19 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, nil, drainErr
+	}
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "start prepared query drain tracking: %v", err)
+	}
 
 	session.mu.RLock()
 	handle, ok := session.queries[string(cmd.GetPreparedStatementHandle())]
 	session.mu.RUnlock()
 	if !ok {
+		finishDrain()
 		return nil, nil, status.Error(codes.NotFound, "prepared statement not found")
 	}
 
@@ -768,6 +859,7 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 		ttx := session.txns[handle.TxnID]
 		session.mu.RUnlock()
 		if ttx == nil || ttx.tx == nil {
+			finishDrain()
 			return nil, nil, status.Error(codes.NotFound, "transaction not found")
 		}
 		ttx.lastUsed.Store(time.Now().UnixNano())
@@ -780,12 +872,14 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 
 	// Empty queries have no rows to fetch — return an empty stream immediately.
 	if isEmptyFlightQuery(handle.Query) {
+		finishDrain()
 		close(ch)
 		return schema, ch, nil
 	}
 
 	go func() {
 		defer close(ch)
+		defer finishDrain()
 		session.progress.queryActive.Store(true)
 		defer session.progress.queryActive.Store(false)
 		var rows *sql.Rows
@@ -826,6 +920,9 @@ func (h *FlightSQLHandler) GetFlightInfoSchemas(ctx context.Context, cmd flights
 	if err != nil {
 		return nil, err
 	}
+	if h.pool.IsDraining() {
+		return nil, status.Error(codes.Unavailable, "worker is draining")
+	}
 
 	return &flight.FlightInfo{
 		Schema:           flight.SerializeSchema(schema_ref.DBSchemas, h.alloc),
@@ -844,6 +941,13 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 	session, err := h.sessionFromContext(ctx)
 	if err != nil {
 		return nil, nil, err
+	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, nil, drainErr
+	}
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
 	}
 
 	schema := schema_ref.DBSchemas
@@ -865,6 +969,7 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 	ch := make(chan flight.StreamChunk, 1)
 	go func() {
 		defer close(ch)
+		defer finishDrain()
 		var rows *sql.Rows
 		var qerr error
 		if activeTx != nil {
@@ -920,6 +1025,9 @@ func (h *FlightSQLHandler) GetFlightInfoTables(ctx context.Context, cmd flightsq
 	if err != nil {
 		return nil, err
 	}
+	if h.pool.IsDraining() {
+		return nil, status.Error(codes.Unavailable, "worker is draining")
+	}
 
 	schema := schema_ref.Tables
 	if cmd.GetIncludeSchema() {
@@ -943,6 +1051,13 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 	session, err := h.sessionFromContext(ctx)
 	if err != nil {
 		return nil, nil, err
+	}
+	finishDrain, err := h.pool.beginDrainWork(false)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return nil, nil, drainErr
+	}
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
 	}
 
 	schema := schema_ref.Tables
@@ -982,6 +1097,7 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 	ch := make(chan flight.StreamChunk, 1)
 	go func() {
 		defer close(ch)
+		defer finishDrain()
 		var rows *sql.Rows
 		var qerr error
 		if activeTx != nil {

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/posthog/duckgres/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -18,10 +22,22 @@ import (
 // mockDoActionStream implements flight.FlightService_DoActionServer for testing.
 type mockDoActionStream struct {
 	grpc.ServerStream
+	ctx     context.Context
 	results []*flight.Result
+	sendErr error
+}
+
+func (m *mockDoActionStream) Context() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
 }
 
 func (m *mockDoActionStream) Send(r *flight.Result) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
 	m.results = append(m.results, r)
 	return nil
 }
@@ -30,6 +46,67 @@ func (m *mockDoActionStream) SetHeader(metadata.MD) error  { return nil }
 func (m *mockDoActionStream) SendHeader(metadata.MD) error { return nil }
 func (m *mockDoActionStream) SetTrailer(metadata.MD)       {}
 
+type testEndTransactionRequest struct {
+	transactionID []byte
+	action        flightsql.EndTransactionRequestType
+}
+
+func (r testEndTransactionRequest) GetTransactionId() []byte {
+	return r.transactionID
+}
+
+func (r testEndTransactionRequest) GetAction() flightsql.EndTransactionRequestType {
+	return r.action
+}
+
+type testPreparedStatementQuery struct {
+	handle []byte
+}
+
+func (q testPreparedStatementQuery) GetPreparedStatementHandle() []byte {
+	return q.handle
+}
+
+type testGetDBSchemas struct{}
+
+func (testGetDBSchemas) GetCatalog() *string {
+	return nil
+}
+
+func (testGetDBSchemas) GetDBSchemaFilterPattern() *string {
+	return nil
+}
+
+type testGetTables struct{}
+
+func (testGetTables) GetCatalog() *string {
+	return nil
+}
+
+func (testGetTables) GetDBSchemaFilterPattern() *string {
+	return nil
+}
+
+func (testGetTables) GetTableNameFilterPattern() *string {
+	return nil
+}
+
+func (testGetTables) GetTableTypes() []string {
+	return nil
+}
+
+func (testGetTables) GetIncludeSchema() bool {
+	return false
+}
+
+type testStatementQueryTicket struct {
+	handle []byte
+}
+
+func (t testStatementQueryTicket) GetStatementHandle() []byte {
+	return t.handle
+}
+
 func TestHealthCheckBlocksUntilWarmup(t *testing.T) {
 	pool := &SessionPool{
 		sessions:    make(map[string]*Session),
@@ -37,7 +114,7 @@ func TestHealthCheckBlocksUntilWarmup(t *testing.T) {
 		warmupDone:  make(chan struct{}),
 		startTime:   time.Now(),
 	}
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	// Health check in a goroutine — should block until warmup completes
@@ -90,7 +167,7 @@ func TestHealthCheckReturnsImmediatelyAfterWarmup(t *testing.T) {
 	// Warmup already completed
 	close(pool.warmupDone)
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	done := make(chan error, 1)
@@ -118,7 +195,7 @@ func TestHealthCheckReportsDraining(t *testing.T) {
 	close(pool.warmupDone)
 	pool.BeginDrain()
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	if err := handler.doHealthCheck([]byte(`{}`), stream); err != nil {
@@ -152,7 +229,7 @@ func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	// Health checks no longer validate epoch — a fresh CP with epoch 0 should
@@ -175,7 +252,7 @@ func TestCreateSessionRejectsWhileDraining(t *testing.T) {
 	close(pool.warmupDone)
 	pool.BeginDrain()
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	body, err := json.Marshal(server.WorkerCreateSessionPayload{
@@ -191,6 +268,40 @@ func TestCreateSessionRejectsWhileDraining(t *testing.T) {
 	}
 }
 
+func TestCreateSessionSendFailureDestroysSession(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		startTime:   time.Now(),
+		cfg:         server.Config{Users: map[string]string{"alice": "pass"}},
+		duckLakeSem: make(chan struct{}, 1),
+	}
+	close(pool.warmupDone)
+	pool.createDBPair = func(server.Config, chan struct{}, string, time.Time, string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		return PairFromMain(db), nil
+	}
+
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	stream := &mockDoActionStream{sendErr: errors.New("send failed")}
+
+	body, err := json.Marshal(server.WorkerCreateSessionPayload{Username: "alice"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	if err := handler.doCreateSession(body, stream); err == nil {
+		t.Fatal("expected send failure")
+	}
+	if got := len(pool.sessions); got != 0 {
+		t.Fatalf("expected failed response to destroy created session, got %d sessions", got)
+	}
+}
+
 func TestCreateSessionRequiresActivationForSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),
@@ -202,7 +313,7 @@ func TestCreateSessionRequiresActivationForSharedWarmMode(t *testing.T) {
 	}
 	close(pool.warmupDone)
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	body, err := json.Marshal(map[string]any{
@@ -237,7 +348,7 @@ func TestActivateTenantRejectsDifferentTenantAfterActivation(t *testing.T) {
 	}
 	pool.activateTenantFunc = pool.activateTenant
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	firstBody, err := json.Marshal(ActivationPayload{
@@ -299,7 +410,7 @@ func TestCreateSessionAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 		return PairFromMain(db), nil
 	}
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	stream := &mockDoActionStream{}
 
 	// Session creation with a mismatched epoch should now succeed past the
@@ -335,7 +446,7 @@ func TestSessionFromContextAcceptsMismatchedEpoch(t *testing.T) {
 	close(pool.warmupDone)
 	pool.sessions["session-1"] = &Session{ID: "session-1"}
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		"x-duckgres-session", "session-1",
 		"x-duckgres-owner-epoch", "4",
@@ -365,7 +476,7 @@ func TestSessionFromContextRejectsMismatchedControlIdentity(t *testing.T) {
 	close(pool.warmupDone)
 	pool.sessions["session-1"] = &Session{ID: "session-1"}
 
-	handler := &FlightSQLHandler{pool: pool}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		"x-duckgres-session", "session-1",
 		"x-duckgres-owner-epoch", "5",
@@ -376,5 +487,225 @@ func TestSessionFromContextRejectsMismatchedControlIdentity(t *testing.T) {
 	_, err := handler.sessionFromContext(ctx)
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("expected FailedPrecondition, got %v", err)
+	}
+}
+
+func TestEndTransactionKeepsDrainOpenForOpenTransaction(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:       "session-1",
+		Conn:     conn,
+		queries:  make(map[string]*QueryHandle),
+		txns:     make(map[string]*trackedTx),
+		txnOwner: make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	txnID, err := handler.BeginTransaction(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+
+	pool.BeginDrain()
+	shortCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if pool.WaitForDrain(shortCtx) {
+		t.Fatal("expected open transaction to keep drain active")
+	}
+
+	if err := handler.EndTransaction(ctx, testEndTransactionRequest{
+		transactionID: txnID,
+		action:        flightsql.EndTransactionRollback,
+	}); err != nil {
+		t.Fatalf("rollback during drain: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected drain to complete after transaction finalization")
+	}
+}
+
+func TestPreparedStatementDoGetContinuesAfterDrainStarts(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID: "session-1",
+		queries: map[string]*QueryHandle{
+			"prep-1": {Query: "", Schema: arrow.NewSchema(nil, nil)},
+		},
+		txns: make(map[string]*trackedTx),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+	cmd := testPreparedStatementQuery{handle: []byte("prep-1")}
+
+	if _, err := handler.GetFlightInfoPreparedStatement(ctx, cmd, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("get prepared flight info: %v", err)
+	}
+	pool.BeginDrain()
+
+	_, ch, err := handler.DoGetPreparedStatement(ctx, cmd)
+	if err != nil {
+		t.Fatalf("prepared DoGet should continue after drain starts: %v", err)
+	}
+	for range ch {
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected prepared continuation to release drain work")
+	}
+}
+
+func TestDoGetStatementEmptyQueryDeletesHandle(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID: "session-1",
+		queries: map[string]*QueryHandle{
+			"query-1": {Query: "", Schema: arrow.NewSchema(nil, nil)},
+		},
+		txns: make(map[string]*trackedTx),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	_, ch, err := handler.DoGetStatement(ctx, testStatementQueryTicket{handle: []byte("query-1")})
+	if err != nil {
+		t.Fatalf("DoGetStatement: %v", err)
+	}
+	for range ch {
+	}
+
+	session := pool.sessions["session-1"]
+	session.mu.RLock()
+	_, ok := session.queries["query-1"]
+	session.mu.RUnlock()
+	if ok {
+		t.Fatal("expected empty query handle to be deleted")
+	}
+}
+
+func TestMetadataDoGetContinuesAfterDrainStarts(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:       "session-1",
+		Conn:     conn,
+		queries:  make(map[string]*QueryHandle),
+		txns:     make(map[string]*trackedTx),
+		txnOwner: make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+	cmd := testGetDBSchemas{}
+
+	if _, err := handler.GetFlightInfoSchemas(ctx, cmd, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("get schemas flight info: %v", err)
+	}
+	pool.BeginDrain()
+
+	_, ch, err := handler.DoGetDBSchemas(ctx, cmd)
+	if err != nil {
+		t.Fatalf("metadata DoGet should continue after drain starts: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Err != nil {
+			t.Fatalf("metadata stream error: %v", chunk.Err)
+		}
+		if chunk.Data != nil {
+			chunk.Data.Release()
+		}
+	}
+}
+
+func TestTablesMetadataDoGetContinuesAfterDrainStarts(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:       "session-1",
+		Conn:     conn,
+		queries:  make(map[string]*QueryHandle),
+		txns:     make(map[string]*trackedTx),
+		txnOwner: make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+	cmd := testGetTables{}
+
+	if _, err := handler.GetFlightInfoTables(ctx, cmd, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("get tables flight info: %v", err)
+	}
+	pool.BeginDrain()
+
+	_, ch, err := handler.DoGetTables(ctx, cmd)
+	if err != nil {
+		t.Fatalf("table metadata DoGet should continue after drain starts: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Err != nil {
+			t.Fatalf("table metadata stream error: %v", chunk.Err)
+		}
+		if chunk.Data != nil {
+			chunk.Data.Release()
+		}
+	}
+}
+
+func TestSendStreamChunkReturnsOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ch := make(chan flight.StreamChunk)
+
+	if sendStreamChunk(ctx, ch, flight.StreamChunk{}) {
+		t.Fatal("expected send to fail after context cancellation")
 	}
 }

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -67,14 +67,17 @@ func (q testPreparedStatementQuery) GetPreparedStatementHandle() []byte {
 	return q.handle
 }
 
-type testGetDBSchemas struct{}
-
-func (testGetDBSchemas) GetCatalog() *string {
-	return nil
+type testGetDBSchemas struct {
+	catalog *string
+	pattern *string
 }
 
-func (testGetDBSchemas) GetDBSchemaFilterPattern() *string {
-	return nil
+func (g testGetDBSchemas) GetCatalog() *string {
+	return g.catalog
+}
+
+func (g testGetDBSchemas) GetDBSchemaFilterPattern() *string {
+	return g.pattern
 }
 
 type testGetTables struct{}
@@ -105,6 +108,19 @@ type testStatementQueryTicket struct {
 
 func (t testStatementQueryTicket) GetStatementHandle() []byte {
 	return t.handle
+}
+
+type testStatementUpdate struct {
+	query         string
+	transactionID []byte
+}
+
+func (u testStatementUpdate) GetQuery() string {
+	return u.query
+}
+
+func (u testStatementUpdate) GetTransactionId() []byte {
+	return u.transactionID
 }
 
 func TestHealthCheckBlocksUntilWarmup(t *testing.T) {
@@ -542,6 +558,106 @@ func TestEndTransactionKeepsDrainOpenForOpenTransaction(t *testing.T) {
 	}
 }
 
+func TestRawSQLTransactionKeepsDrainOpenUntilCommit(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:             "session-1",
+		Conn:           conn,
+		queries:        make(map[string]*QueryHandle),
+		metadataDrains: make(map[string][]func()),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	if _, err := handler.DoPutCommandStatementUpdate(ctx, testStatementUpdate{query: "BEGIN"}); err != nil {
+		t.Fatalf("raw BEGIN: %v", err)
+	}
+
+	pool.BeginDrain()
+	shortCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if pool.WaitForDrain(shortCtx) {
+		t.Fatal("expected raw SQL transaction to keep drain active")
+	}
+
+	if _, err := handler.DoPutCommandStatementUpdate(ctx, testStatementUpdate{query: "COMMIT"}); err != nil {
+		t.Fatalf("raw COMMIT during drain: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected raw SQL transaction drain token to release on COMMIT")
+	}
+}
+
+func TestRawSQLTransactionKeepsDrainOpenAfterFailedCommit(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:             "session-1",
+		Conn:           conn,
+		queries:        make(map[string]*QueryHandle),
+		metadataDrains: make(map[string][]func()),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	if _, err := handler.DoPutCommandStatementUpdate(ctx, testStatementUpdate{query: "BEGIN"}); err != nil {
+		t.Fatalf("raw BEGIN: %v", err)
+	}
+	pool.BeginDrain()
+
+	if _, err := handler.DoPutCommandStatementUpdate(ctx, testStatementUpdate{query: "COMMIT INVALID"}); err == nil {
+		t.Fatal("expected invalid COMMIT to fail")
+	}
+	shortCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if pool.WaitForDrain(shortCtx) {
+		t.Fatal("expected failed COMMIT to keep raw SQL transaction drain active")
+	}
+
+	if _, err := handler.DoPutCommandStatementUpdate(ctx, testStatementUpdate{query: "ROLLBACK"}); err != nil {
+		t.Fatalf("raw ROLLBACK during drain: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected raw SQL transaction drain token to release on ROLLBACK")
+	}
+}
+
 func TestPreparedStatementDoGetContinuesAfterDrainStarts(t *testing.T) {
 	pool := &SessionPool{
 		sessions:    make(map[string]*Session),
@@ -608,6 +724,50 @@ func TestDoGetStatementEmptyQueryDeletesHandle(t *testing.T) {
 	}
 }
 
+func TestDoGetStatementConsumesHandleBeforeStreaming(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:   "session-1",
+		Conn: conn,
+		queries: map[string]*QueryHandle{
+			"query-1": {Query: "SELECT 1", Schema: arrow.NewSchema([]arrow.Field{{Name: "x", Type: arrow.PrimitiveTypes.Int32}}, nil)},
+		},
+		txns: make(map[string]*trackedTx),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	_, ch, err := handler.DoGetStatement(ctx, testStatementQueryTicket{handle: []byte("query-1")})
+	if err != nil {
+		t.Fatalf("first DoGetStatement: %v", err)
+	}
+	if _, _, err := handler.DoGetStatement(ctx, testStatementQueryTicket{handle: []byte("query-1")}); status.Code(err) != codes.NotFound {
+		t.Fatalf("expected duplicate DoGetStatement to be rejected, got %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Err != nil {
+			t.Fatalf("first stream error: %v", chunk.Err)
+		}
+		if chunk.Data != nil {
+			chunk.Data.Release()
+		}
+	}
+}
+
 func TestMetadataDoGetContinuesAfterDrainStarts(t *testing.T) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
@@ -652,6 +812,73 @@ func TestMetadataDoGetContinuesAfterDrainStarts(t *testing.T) {
 			chunk.Data.Release()
 		}
 	}
+}
+
+func TestMetadataDoGetConsumesMatchingDrainToken(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:             "session-1",
+		Conn:           conn,
+		queries:        make(map[string]*QueryHandle),
+		metadataDrains: make(map[string][]func()),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+	firstPattern := "%"
+	secondPattern := "main"
+	first := testGetDBSchemas{pattern: &firstPattern}
+	second := testGetDBSchemas{pattern: &secondPattern}
+
+	if _, err := handler.GetFlightInfoSchemas(ctx, first, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("first GetFlightInfoSchemas: %v", err)
+	}
+	if _, err := handler.GetFlightInfoSchemas(ctx, second, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("second GetFlightInfoSchemas: %v", err)
+	}
+	pool.BeginDrain()
+
+	_, ch, err := handler.DoGetDBSchemas(ctx, second)
+	if err != nil {
+		t.Fatalf("second DoGetDBSchemas: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Err != nil {
+			t.Fatalf("second stream error: %v", chunk.Err)
+		}
+		if chunk.Data != nil {
+			chunk.Data.Release()
+		}
+	}
+
+	session := pool.sessions["session-1"]
+	session.mu.RLock()
+	firstPending := len(session.metadataDrains[metadataSchemasDrainKey(first)])
+	secondPending := len(session.metadataDrains[metadataSchemasDrainKey(second)])
+	session.mu.RUnlock()
+	if firstPending != 1 {
+		t.Fatalf("expected first metadata token to remain pending, got %d", firstPending)
+	}
+	if secondPending != 0 {
+		t.Fatalf("expected second metadata token to be consumed, got %d", secondPending)
+	}
+	release := popMetadataDrain(session, metadataSchemasDrainKey(first))
+	releaseDrainFunc(release)
 }
 
 func TestTablesMetadataDoGetContinuesAfterDrainStarts(t *testing.T) {

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -108,6 +108,37 @@ func TestHealthCheckReturnsImmediatelyAfterWarmup(t *testing.T) {
 	}
 }
 
+func TestHealthCheckReportsDraining(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		startTime:   time.Now(),
+	}
+	close(pool.warmupDone)
+	pool.BeginDrain()
+
+	handler := &FlightSQLHandler{pool: pool}
+	stream := &mockDoActionStream{}
+
+	if err := handler.doHealthCheck([]byte(`{}`), stream); err != nil {
+		t.Fatalf("health check returned error: %v", err)
+	}
+	if len(stream.results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(stream.results))
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(stream.results[0].Body, &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp["healthy"] != true {
+		t.Errorf("expected healthy=true, got %v", resp["healthy"])
+	}
+	if resp["draining"] != true {
+		t.Errorf("expected draining=true, got %v", resp["draining"])
+	}
+}
+
 func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:          make(map[string]*Session),
@@ -130,6 +161,33 @@ func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	err := handler.doHealthCheck([]byte(`{}`), stream)
 	if err != nil {
 		t.Fatalf("health check should succeed regardless of epoch mismatch, got %v", err)
+	}
+}
+
+func TestCreateSessionRejectsWhileDraining(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		startTime:   time.Now(),
+		cfg:         server.Config{Users: map[string]string{"alice": "pass"}},
+	}
+	close(pool.warmupDone)
+	pool.BeginDrain()
+
+	handler := &FlightSQLHandler{pool: pool}
+	stream := &mockDoActionStream{}
+
+	body, err := json.Marshal(server.WorkerCreateSessionPayload{
+		Username: "alice",
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	err = handler.doCreateSession(body, stream)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected Unavailable while draining, got %v", err)
 	}
 }
 

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -578,7 +578,7 @@ func TestRawSQLTransactionKeepsDrainOpenUntilCommit(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]func()),
+		metadataDrains: make(map[string][]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -627,7 +627,7 @@ func TestRawSQLTransactionKeepsDrainOpenAfterFailedCommit(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]func()),
+		metadataDrains: make(map[string][]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -834,7 +834,7 @@ func TestMetadataDoGetConsumesMatchingDrainToken(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]func()),
+		metadataDrains: make(map[string][]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -116,7 +116,7 @@ type Session struct {
 
 	mu             sync.RWMutex
 	queries        map[string]*QueryHandle
-	metadataDrains map[string][]func()
+	metadataDrains map[string][]drainToken
 	txns           map[string]*trackedTx
 	txnOwner       map[string]string
 	handleCounter  atomic.Uint64
@@ -137,17 +137,40 @@ type Session struct {
 
 // QueryHandle stores a prepared or ad-hoc query for later execution.
 type QueryHandle struct {
-	Query         string
-	Schema        *arrow.Schema
-	TxnID         string
-	finishDrain   func()
-	pendingDrains []func()
+	Query     string
+	Schema    *arrow.Schema
+	TxnID     string
+	Prepared  bool      // prepared statements live until ClosePreparedStatement; the reaper never drops them, only their stale pendingDrains
+	createdAt time.Time // when registered; the reaper drops a stale ad-hoc handle whose DoGet never arrived (guarded by Session.mu)
+	// finishDrain is the drain token of an ad-hoc query awaiting its DoGet.
+	finishDrain func()
+	// pendingDrains are drain tokens of GetFlightInfo[Prepared] calls awaiting
+	// their DoGet (a prepared handle accumulates one per GetFlightInfo).
+	pendingDrains []drainToken
+}
+
+// drainToken pairs a drain-release closure with the time it was registered, so
+// the reaper can release a token stranded by a GetFlightInfo whose matching
+// DoGet never arrived (client cancelled between the two RPCs, session kept).
+type drainToken struct {
+	finish func()
+	at     time.Time
 }
 
 func releaseDrainFunc(release func()) {
 	if release != nil {
 		release()
 	}
+}
+
+// appendDrainTokenFuncs appends the release closures of tokens to dst.
+func appendDrainTokenFuncs(dst []func(), tokens []drainToken) []func() {
+	for _, t := range tokens {
+		if t.finish != nil {
+			dst = append(dst, t.finish)
+		}
+	}
+	return dst
 }
 
 func (s *Session) hasTrackedTxDrain(txnKey string) bool {
@@ -307,7 +330,14 @@ func (p *SessionPool) Warmup() error {
 }
 
 const (
-	txnIdleTimeout          = 10 * time.Minute
+	txnIdleTimeout = 10 * time.Minute
+	// handleIdleTimeout bounds how long a drain token may sit stranded on a query
+	// handle / metadata stream whose matching DoGet never arrived (client
+	// cancelled between GetFlightInfo and DoGet, session kept). Without reaping,
+	// such a token holds the worker's drain open until the full
+	// workerShutdownDrainTime, then a forced shutdown kills genuinely in-flight
+	// work. The real GetFlightInfo→DoGet gap is sub-second, so this is generous.
+	handleIdleTimeout       = 10 * time.Minute
 	reapInterval            = 1 * time.Minute
 	metadataMetricsInterval = 30 * time.Second
 	workerShutdownDrainTime = 55 * time.Minute
@@ -320,14 +350,18 @@ func (p *SessionPool) reapLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			p.reapIdleTransactions(time.Now())
+			p.reapIdle(time.Now())
 		case <-p.stopCh:
 			return
 		}
 	}
 }
 
-func (p *SessionPool) reapIdleTransactions(now time.Time) {
+// reapIdle rolls back idle transactions and releases drain tokens stranded by a
+// GetFlightInfo whose matching DoGet never arrived. Both are bounded so a single
+// abandoned client RPC cannot hold the worker's drain open until the shutdown
+// timeout (and then force-kill genuinely in-flight work).
+func (p *SessionPool) reapIdle(now time.Time) {
 	p.mu.RLock()
 	sessions := make([]*Session, 0, len(p.sessions))
 	for _, s := range p.sessions {
@@ -351,6 +385,59 @@ func (p *SessionPool) reapIdleTransactions(now time.Time) {
 				}
 				delete(s.txns, id)
 				delete(s.txnOwner, id)
+			}
+		}
+		// Drain tokens stranded on query handles. An actively-streaming DoGet has
+		// already popped its handle out of this map (ad-hoc) or its pendingDrain
+		// entry (prepared), so anything still here past the TTL was abandoned
+		// mid-handshake.
+		for id, h := range s.queries {
+			if h.Prepared {
+				// Long-lived prepared handle: never drop it, only release
+				// pendingDrains (a GetFlightInfoPreparedStatement with no DoGet) gone stale.
+				kept := h.pendingDrains[:0]
+				for _, t := range h.pendingDrains {
+					if now.Sub(t.at) > handleIdleTimeout {
+						if t.finish != nil {
+							releaseDrains = append(releaseDrains, t.finish)
+						}
+						continue
+					}
+					kept = append(kept, t)
+				}
+				h.pendingDrains = kept
+				continue
+			}
+			// Ad-hoc handle awaiting its DoGetStatement; drop it and release its
+			// tokens once stale.
+			if now.Sub(h.createdAt) > handleIdleTimeout {
+				if h.finishDrain != nil {
+					releaseDrains = append(releaseDrains, h.finishDrain)
+					h.finishDrain = nil
+				}
+				releaseDrains = appendDrainTokenFuncs(releaseDrains, h.pendingDrains)
+				h.pendingDrains = nil
+				slog.Warn("Reaping abandoned query handle (no DoGet).", "user", s.Username, "handle", id)
+				delete(s.queries, id)
+			}
+		}
+		// Drain tokens stranded on metadata streams (GetFlightInfoSchemas/Tables
+		// with no DoGet).
+		for key, tokens := range s.metadataDrains {
+			kept := tokens[:0]
+			for _, t := range tokens {
+				if now.Sub(t.at) > handleIdleTimeout {
+					if t.finish != nil {
+						releaseDrains = append(releaseDrains, t.finish)
+					}
+					continue
+				}
+				kept = append(kept, t)
+			}
+			if len(kept) == 0 {
+				delete(s.metadataDrains, key)
+			} else {
+				s.metadataDrains[key] = kept
 			}
 		}
 		s.mu.Unlock()
@@ -728,7 +815,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		Username:       username,
 		CreatedAt:      time.Now(),
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]func()),
+		metadataDrains: make(map[string][]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		duckdbConn:     duckConn,
@@ -813,12 +900,12 @@ func (p *SessionPool) DestroySession(token string) error {
 			releaseDrains = append(releaseDrains, handle.finishDrain)
 			handle.finishDrain = nil
 		}
-		releaseDrains = append(releaseDrains, handle.pendingDrains...)
+		releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
 		handle.pendingDrains = nil
 		delete(session.queries, id)
 	}
 	for key, drains := range session.metadataDrains {
-		releaseDrains = append(releaseDrains, drains...)
+		releaseDrains = appendDrainTokenFuncs(releaseDrains, drains)
 		delete(session.metadataDrains, key)
 	}
 	if session.sqlTxDrain != nil {
@@ -961,10 +1048,10 @@ func (p *SessionPool) beginDrainWork(allowWhenDraining bool) (func(), error) {
 	if p.draining && !p.drainZeroOpen {
 		return nil, ErrWorkerDraining
 	}
-	if !p.drainZeroOpen {
-		p.drainZero = make(chan struct{})
-		p.drainZeroOpen = true
-	}
+	// Invariant: drainZeroOpen only goes false while draining (BeginDrain / the
+	// release closure), and draining never clears, so reaching here means the
+	// channel is open — !draining implies drainZeroOpen, and draining implies it
+	// per the guard above. No reopen needed.
 	p.activeWork++
 
 	var once sync.Once
@@ -1024,12 +1111,12 @@ func (p *SessionPool) CloseAll() {
 				releaseDrains = append(releaseDrains, handle.finishDrain)
 				handle.finishDrain = nil
 			}
-			releaseDrains = append(releaseDrains, handle.pendingDrains...)
+			releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
 			handle.pendingDrains = nil
 			delete(session.queries, id)
 		}
 		for key, drains := range session.metadataDrains {
-			releaseDrains = append(releaseDrains, drains...)
+			releaseDrains = appendDrainTokenFuncs(releaseDrains, drains)
 			delete(session.metadataDrains, key)
 		}
 		if session.sqlTxDrain != nil {

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -32,6 +33,8 @@ import (
 
 var bootstrapBundledExtensions = server.BootstrapBundledExtensions
 var exitProcess = os.Exit
+
+var ErrWorkerDraining = errors.New("worker is draining")
 
 // DuckDBService is a standalone Arrow Flight SQL service backed by DuckDB.
 type DuckDBService struct {
@@ -87,6 +90,12 @@ type SessionPool struct {
 	// DuckLake stays fresh. Defaults to server.RefreshIcebergSecret;
 	// stubbed by tests the same way refreshS3Secret is.
 	refreshIcebergSecret func(*sql.DB, server.IcebergConfig, chan struct{}, string, string, string) error
+
+	drainMu       sync.Mutex
+	draining      bool
+	activeWork    int
+	drainZero     chan struct{}
+	drainZeroOpen bool
 }
 
 type trackedTx struct {
@@ -124,9 +133,10 @@ type Session struct {
 
 // QueryHandle stores a prepared or ad-hoc query for later execution.
 type QueryHandle struct {
-	Query  string
-	Schema *arrow.Schema
-	TxnID  string
+	Query       string
+	Schema      *arrow.Schema
+	TxnID       string
+	finishDrain func()
 }
 
 // NewDuckDBService creates a new DuckDB service with the given config.
@@ -145,6 +155,8 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		activateDBConnection: server.ActivateDBConnection,
 		refreshS3Secret:      server.RefreshS3Secret,
 		refreshIcebergSecret: server.RefreshIcebergSecret,
+		drainZero:            make(chan struct{}),
+		drainZeroOpen:        true,
 	}
 	pool.activateTenantFunc = pool.activateTenant
 	go pool.reapLoop()
@@ -243,6 +255,7 @@ const (
 	txnIdleTimeout          = 10 * time.Minute
 	reapInterval            = 1 * time.Minute
 	metadataMetricsInterval = 30 * time.Second
+	workerShutdownDrainTime = 55 * time.Minute
 )
 
 func (p *SessionPool) reapLoop() {
@@ -425,6 +438,13 @@ func Run(cfg ServiceConfig) {
 
 	go func() {
 		<-sigChan
+		slog.Info("Draining DuckDB service before shutdown...")
+		svc.BeginDrain()
+		ctx, cancel := context.WithTimeout(context.Background(), workerShutdownDrainTime)
+		if !svc.WaitForDrain(ctx) {
+			slog.Warn("DuckDB service drain timed out before shutdown.", "timeout", workerShutdownDrainTime)
+		}
+		cancel()
 		slog.Info("Shutting down DuckDB service...")
 		svc.Shutdown()
 		os.Exit(0)
@@ -484,9 +504,28 @@ func (svc *DuckDBService) Shutdown() {
 	svc.pool.CloseAll()
 }
 
+func (svc *DuckDBService) BeginDrain() {
+	if svc.pool != nil {
+		svc.pool.BeginDrain()
+	}
+}
+
+func (svc *DuckDBService) WaitForDrain(ctx context.Context) bool {
+	if svc.pool == nil {
+		return true
+	}
+	return svc.pool.WaitForDrain(ctx)
+}
+
 // CreateSession creates a new DuckDB session for the given username.
 func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (*Session, error) {
 	start := time.Now()
+	finishDrain, drainErr := p.beginDrainWork(false)
+	if drainErr != nil {
+		return nil, drainErr
+	}
+	defer finishDrain()
+
 	// Reserve a slot under the lock to prevent TOCTOU race on maxSessions.
 	p.mu.Lock()
 	if p.maxSessions > 0 && len(p.sessions)+p.reserved >= p.maxSessions {
@@ -762,6 +801,83 @@ func (p *SessionPool) ActiveSessions() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.sessions)
+}
+
+func (p *SessionPool) BeginDrain() {
+	p.drainMu.Lock()
+	defer p.drainMu.Unlock()
+	p.ensureDrainChannelLocked()
+	p.draining = true
+	if p.activeWork == 0 && p.drainZeroOpen {
+		close(p.drainZero)
+		p.drainZeroOpen = false
+	}
+}
+
+func (p *SessionPool) IsDraining() bool {
+	p.drainMu.Lock()
+	defer p.drainMu.Unlock()
+	return p.draining
+}
+
+func (p *SessionPool) ActiveDrainWork() int {
+	p.drainMu.Lock()
+	defer p.drainMu.Unlock()
+	return p.activeWork
+}
+
+func (p *SessionPool) WaitForDrain(ctx context.Context) bool {
+	p.drainMu.Lock()
+	p.ensureDrainChannelLocked()
+	if p.activeWork == 0 {
+		p.drainMu.Unlock()
+		return true
+	}
+	ch := p.drainZero
+	p.drainMu.Unlock()
+
+	select {
+	case <-ch:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (p *SessionPool) beginDrainWork(allowWhenDraining bool) (func(), error) {
+	p.drainMu.Lock()
+	defer p.drainMu.Unlock()
+	p.ensureDrainChannelLocked()
+	if p.draining && !allowWhenDraining {
+		return nil, ErrWorkerDraining
+	}
+	if !p.drainZeroOpen {
+		p.drainZero = make(chan struct{})
+		p.drainZeroOpen = true
+	}
+	p.activeWork++
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.drainMu.Lock()
+			defer p.drainMu.Unlock()
+			if p.activeWork > 0 {
+				p.activeWork--
+			}
+			if p.draining && p.activeWork == 0 && p.drainZeroOpen {
+				close(p.drainZero)
+				p.drainZeroOpen = false
+			}
+		})
+	}, nil
+}
+
+func (p *SessionPool) ensureDrainChannelLocked() {
+	if p.drainZero == nil {
+		p.drainZero = make(chan struct{})
+		p.drainZeroOpen = true
+	}
 }
 
 // CloseAll closes all sessions.

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -54,6 +54,7 @@ type SessionPool struct {
 	startTime   time.Time
 	maxSessions int
 	stopCh      chan struct{}
+	stopOnce    sync.Once
 	warmupDB    *sql.DB       // Keep this open to keep shared cache alive
 	warmupDone  chan struct{} // Closed when Warmup() completes (success or failure)
 	dbInitOnce  sync.Once     // Serializes fallback CreateDBConnection when warmup fails
@@ -99,8 +100,9 @@ type SessionPool struct {
 }
 
 type trackedTx struct {
-	tx       *sql.Tx
-	lastUsed atomic.Int64 // unix nano
+	tx          *sql.Tx
+	finishDrain func()
+	lastUsed    atomic.Int64 // unix nano
 }
 
 // Session represents a single DuckDB session.
@@ -112,11 +114,12 @@ type Session struct {
 	CreatedAt time.Time
 	lastUsed  atomic.Int64 // unix nano
 
-	mu            sync.RWMutex
-	queries       map[string]*QueryHandle
-	txns          map[string]*trackedTx
-	txnOwner      map[string]string
-	handleCounter atomic.Uint64
+	mu             sync.RWMutex
+	queries        map[string]*QueryHandle
+	metadataDrains map[string][]func()
+	txns           map[string]*trackedTx
+	txnOwner       map[string]string
+	handleCounter  atomic.Uint64
 
 	// sqlTxActive tracks whether a SQL-level transaction is in progress on this
 	// session's Conn (i.e., BEGIN was sent as raw SQL without a corresponding
@@ -133,10 +136,11 @@ type Session struct {
 
 // QueryHandle stores a prepared or ad-hoc query for later execution.
 type QueryHandle struct {
-	Query       string
-	Schema      *arrow.Schema
-	TxnID       string
-	finishDrain func()
+	Query         string
+	Schema        *arrow.Schema
+	TxnID         string
+	finishDrain   func()
+	pendingDrains []func()
 }
 
 // NewDuckDBService creates a new DuckDB service with the given config.
@@ -443,6 +447,9 @@ func Run(cfg ServiceConfig) {
 		ctx, cancel := context.WithTimeout(context.Background(), workerShutdownDrainTime)
 		if !svc.WaitForDrain(ctx) {
 			slog.Warn("DuckDB service drain timed out before shutdown.", "timeout", workerShutdownDrainTime)
+			cancel()
+			svc.CloseAll()
+			os.Exit(0)
 		}
 		cancel()
 		slog.Info("Shutting down DuckDB service...")
@@ -501,7 +508,13 @@ func (svc *DuckDBService) Shutdown() {
 	if svc.flightSrv != nil {
 		svc.flightSrv.Shutdown()
 	}
-	svc.pool.CloseAll()
+	svc.CloseAll()
+}
+
+func (svc *DuckDBService) CloseAll() {
+	if svc.pool != nil {
+		svc.pool.CloseAll()
+	}
 }
 
 func (svc *DuckDBService) BeginDrain() {
@@ -645,15 +658,16 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 
 	token := generateSessionToken()
 	session := &Session{
-		ID:         token,
-		DB:         db,
-		Conn:       conn,
-		Username:   username,
-		CreatedAt:  time.Now(),
-		queries:    make(map[string]*QueryHandle),
-		txns:       make(map[string]*trackedTx),
-		txnOwner:   make(map[string]string),
-		duckdbConn: duckConn,
+		ID:             token,
+		DB:             db,
+		Conn:           conn,
+		Username:       username,
+		CreatedAt:      time.Now(),
+		queries:        make(map[string]*QueryHandle),
+		metadataDrains: make(map[string][]func()),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+		duckdbConn:     duckConn,
 	}
 	session.lastUsed.Store(time.Now().UnixNano())
 
@@ -726,14 +740,38 @@ func (p *SessionPool) DestroySession(token string) error {
 		return fmt.Errorf("session not found")
 	}
 
+	var releaseDrains []func()
+
 	// Roll back any open transactions
 	session.mu.Lock()
+	for id, handle := range session.queries {
+		if handle.finishDrain != nil {
+			releaseDrains = append(releaseDrains, handle.finishDrain)
+			handle.finishDrain = nil
+		}
+		releaseDrains = append(releaseDrains, handle.pendingDrains...)
+		handle.pendingDrains = nil
+		delete(session.queries, id)
+	}
+	for key, drains := range session.metadataDrains {
+		releaseDrains = append(releaseDrains, drains...)
+		delete(session.metadataDrains, key)
+	}
 	for id, ttx := range session.txns {
 		_ = ttx.tx.Rollback()
+		if ttx.finishDrain != nil {
+			releaseDrains = append(releaseDrains, ttx.finishDrain)
+			ttx.finishDrain = nil
+		}
 		delete(session.txns, id)
 		delete(session.txnOwner, id)
 	}
 	session.mu.Unlock()
+	for _, release := range releaseDrains {
+		if release != nil {
+			release()
+		}
+	}
 
 	if stop != nil {
 		stop()
@@ -851,6 +889,9 @@ func (p *SessionPool) beginDrainWork(allowWhenDraining bool) (func(), error) {
 	if p.draining && !allowWhenDraining {
 		return nil, ErrWorkerDraining
 	}
+	if p.draining && !p.drainZeroOpen {
+		return nil, ErrWorkerDraining
+	}
 	if !p.drainZeroOpen {
 		p.drainZero = make(chan struct{})
 		p.drainZeroOpen = true
@@ -882,7 +923,11 @@ func (p *SessionPool) ensureDrainChannelLocked() {
 
 // CloseAll closes all sessions.
 func (p *SessionPool) CloseAll() {
-	close(p.stopCh)
+	p.stopOnce.Do(func() {
+		if p.stopCh != nil {
+			close(p.stopCh)
+		}
+	})
 	p.mu.Lock()
 	sessions := make(map[string]*Session, len(p.sessions))
 	stops := make(map[string]func(), len(p.stopRefresh))
@@ -903,12 +948,36 @@ func (p *SessionPool) CloseAll() {
 	}
 
 	for _, session := range sessions {
+		var releaseDrains []func()
 		session.mu.Lock()
+		for id, handle := range session.queries {
+			if handle.finishDrain != nil {
+				releaseDrains = append(releaseDrains, handle.finishDrain)
+				handle.finishDrain = nil
+			}
+			releaseDrains = append(releaseDrains, handle.pendingDrains...)
+			handle.pendingDrains = nil
+			delete(session.queries, id)
+		}
+		for key, drains := range session.metadataDrains {
+			releaseDrains = append(releaseDrains, drains...)
+			delete(session.metadataDrains, key)
+		}
 		for id, ttx := range session.txns {
 			_ = ttx.tx.Rollback()
+			if ttx.finishDrain != nil {
+				releaseDrains = append(releaseDrains, ttx.finishDrain)
+				ttx.finishDrain = nil
+			}
 			delete(session.txns, id)
+			delete(session.txnOwner, id)
 		}
 		session.mu.Unlock()
+		for _, release := range releaseDrains {
+			if release != nil {
+				release()
+			}
+		}
 
 		if session.Conn != nil {
 			_ = session.Conn.Close()

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -129,6 +129,7 @@ type Session struct {
 	// transient error would run in autocommit mode (the transaction is dead)
 	// and mask the failure from the client.
 	sqlTxActive atomic.Bool
+	sqlTxDrain  func()
 
 	duckdbConn duckdbConnHandle // raw handle for progress polling (zero if extraction failed)
 	progress   progressState    // stall detection state
@@ -141,6 +142,56 @@ type QueryHandle struct {
 	TxnID         string
 	finishDrain   func()
 	pendingDrains []func()
+}
+
+func releaseDrainFunc(release func()) {
+	if release != nil {
+		release()
+	}
+}
+
+func (s *Session) hasTrackedTxDrain(txnKey string) bool {
+	if txnKey == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ttx := s.txns[txnKey]
+	return ttx != nil && ttx.finishDrain != nil
+}
+
+func (s *Session) hasSQLTransactionDrain() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sqlTxDrain != nil
+}
+
+func (s *Session) allowsDrainContinuation(txnKey string) bool {
+	if s.hasTrackedTxDrain(txnKey) {
+		return true
+	}
+	return s.sqlTxActive.Load() && s.hasSQLTransactionDrain()
+}
+
+func (s *Session) setSQLTransactionDrain(release func()) {
+	if release == nil {
+		return
+	}
+	var old func()
+	s.mu.Lock()
+	old = s.sqlTxDrain
+	s.sqlTxDrain = release
+	s.mu.Unlock()
+	releaseDrainFunc(old)
+}
+
+func (s *Session) releaseSQLTransactionDrain() {
+	var release func()
+	s.mu.Lock()
+	release = s.sqlTxDrain
+	s.sqlTxDrain = nil
+	s.mu.Unlock()
+	releaseDrainFunc(release)
 }
 
 // NewDuckDBService creates a new DuckDB service with the given config.
@@ -269,29 +320,42 @@ func (p *SessionPool) reapLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			p.mu.RLock()
-			sessions := make([]*Session, 0, len(p.sessions))
-			for _, s := range p.sessions {
-				sessions = append(sessions, s)
-			}
-			p.mu.RUnlock()
-
-			now := time.Now()
-			for _, s := range sessions {
-				s.mu.Lock()
-				for id, ttx := range s.txns {
-					last := time.Unix(0, ttx.lastUsed.Load())
-					if now.Sub(last) > txnIdleTimeout {
-						slog.Warn("Rolling back idle transaction.", "user", s.Username, "txn", id)
-						_ = ttx.tx.Rollback()
-						delete(s.txns, id)
-						delete(s.txnOwner, id)
-					}
-				}
-				s.mu.Unlock()
-			}
+			p.reapIdleTransactions(time.Now())
 		case <-p.stopCh:
 			return
+		}
+	}
+}
+
+func (p *SessionPool) reapIdleTransactions(now time.Time) {
+	p.mu.RLock()
+	sessions := make([]*Session, 0, len(p.sessions))
+	for _, s := range p.sessions {
+		sessions = append(sessions, s)
+	}
+	p.mu.RUnlock()
+
+	for _, s := range sessions {
+		var releaseDrains []func()
+		s.mu.Lock()
+		for id, ttx := range s.txns {
+			last := time.Unix(0, ttx.lastUsed.Load())
+			if now.Sub(last) > txnIdleTimeout {
+				slog.Warn("Rolling back idle transaction.", "user", s.Username, "txn", id)
+				if ttx.tx != nil {
+					_ = ttx.tx.Rollback()
+				}
+				if ttx.finishDrain != nil {
+					releaseDrains = append(releaseDrains, ttx.finishDrain)
+					ttx.finishDrain = nil
+				}
+				delete(s.txns, id)
+				delete(s.txnOwner, id)
+			}
+		}
+		s.mu.Unlock()
+		for _, release := range releaseDrains {
+			releaseDrainFunc(release)
 		}
 	}
 }
@@ -757,8 +821,15 @@ func (p *SessionPool) DestroySession(token string) error {
 		releaseDrains = append(releaseDrains, drains...)
 		delete(session.metadataDrains, key)
 	}
+	if session.sqlTxDrain != nil {
+		releaseDrains = append(releaseDrains, session.sqlTxDrain)
+		session.sqlTxDrain = nil
+		session.sqlTxActive.Store(false)
+	}
 	for id, ttx := range session.txns {
-		_ = ttx.tx.Rollback()
+		if ttx.tx != nil {
+			_ = ttx.tx.Rollback()
+		}
 		if ttx.finishDrain != nil {
 			releaseDrains = append(releaseDrains, ttx.finishDrain)
 			ttx.finishDrain = nil
@@ -768,9 +839,7 @@ func (p *SessionPool) DestroySession(token string) error {
 	}
 	session.mu.Unlock()
 	for _, release := range releaseDrains {
-		if release != nil {
-			release()
-		}
+		releaseDrainFunc(release)
 	}
 
 	if stop != nil {
@@ -963,8 +1032,15 @@ func (p *SessionPool) CloseAll() {
 			releaseDrains = append(releaseDrains, drains...)
 			delete(session.metadataDrains, key)
 		}
+		if session.sqlTxDrain != nil {
+			releaseDrains = append(releaseDrains, session.sqlTxDrain)
+			session.sqlTxDrain = nil
+			session.sqlTxActive.Store(false)
+		}
 		for id, ttx := range session.txns {
-			_ = ttx.tx.Rollback()
+			if ttx.tx != nil {
+				_ = ttx.tx.Rollback()
+			}
 			if ttx.finishDrain != nil {
 				releaseDrains = append(releaseDrains, ttx.finishDrain)
 				ttx.finishDrain = nil
@@ -974,9 +1050,7 @@ func (p *SessionPool) CloseAll() {
 		}
 		session.mu.Unlock()
 		for _, release := range releaseDrains {
-			if release != nil {
-				release()
-			}
+			releaseDrainFunc(release)
 		}
 
 		if session.Conn != nil {

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -340,3 +340,46 @@ func TestSessionPoolDrainWaitsForActiveWorkAndRejectsNewWork(t *testing.T) {
 		t.Fatalf("expected no active drain work, got %d", got)
 	}
 }
+
+func TestSessionPoolRejectsContinuationAfterDrainReachesZero(t *testing.T) {
+	pool := &SessionPool{}
+
+	pool.BeginDrain()
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected drain to complete with no active work")
+	}
+
+	if _, err := pool.beginDrainWork(true); !errors.Is(err, ErrWorkerDraining) {
+		t.Fatalf("expected continuation to be rejected after drain completed, got %v", err)
+	}
+}
+
+func TestDestroySessionReleasesPendingQueryDrainWork(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+
+	finishDrain, err := pool.beginDrainWork(false)
+	if err != nil {
+		t.Fatalf("begin pending query drain work: %v", err)
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:      "session-1",
+		queries: map[string]*QueryHandle{"query-1": {Query: "SELECT 1", finishDrain: finishDrain}},
+		txns:    make(map[string]*trackedTx),
+	}
+
+	pool.BeginDrain()
+	if err := pool.DestroySession("session-1"); err != nil {
+		t.Fatalf("destroy session: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected destroying the session to release pending query drain work")
+	}
+}

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -383,3 +383,31 @@ func TestDestroySessionReleasesPendingQueryDrainWork(t *testing.T) {
 		t.Fatal("expected destroying the session to release pending query drain work")
 	}
 }
+
+func TestReapIdleTransactionsReleasesDrainWork(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	finishDrain, err := pool.beginDrainWork(false)
+	if err != nil {
+		t.Fatalf("begin transaction drain work: %v", err)
+	}
+	ttx := &trackedTx{finishDrain: finishDrain}
+	ttx.lastUsed.Store(time.Now().Add(-txnIdleTimeout - time.Minute).UnixNano())
+	pool.sessions["session-1"] = &Session{
+		ID:       "session-1",
+		queries:  make(map[string]*QueryHandle),
+		txns:     map[string]*trackedTx{"txn-1": ttx},
+		txnOwner: map[string]string{"txn-1": "alice"},
+	}
+
+	pool.BeginDrain()
+	pool.reapIdleTransactions(time.Now())
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected idle transaction reaper to release transaction drain work")
+	}
+}

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	_ "github.com/duckdb/duckdb-go/v2"
 )
@@ -300,4 +301,42 @@ func TestRunExitsWhenBundledExtensionBootstrapFails(t *testing.T) {
 
 	Run(ServiceConfig{})
 	t.Fatal("expected Run to exit")
+}
+
+func TestSessionPoolDrainWaitsForActiveWorkAndRejectsNewWork(t *testing.T) {
+	pool := &SessionPool{}
+
+	finish, err := pool.beginDrainWork(false)
+	if err != nil {
+		t.Fatalf("begin tracked work: %v", err)
+	}
+	if got := pool.ActiveDrainWork(); got != 1 {
+		t.Fatalf("expected one active drain work item, got %d", got)
+	}
+
+	pool.BeginDrain()
+	if !pool.IsDraining() {
+		t.Fatal("expected pool to be draining")
+	}
+
+	if _, err := pool.beginDrainWork(false); !errors.Is(err, ErrWorkerDraining) {
+		t.Fatalf("expected new work to be rejected while draining, got %v", err)
+	}
+
+	shortCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if pool.WaitForDrain(shortCtx) {
+		t.Fatal("expected drain wait to time out while active work is still running")
+	}
+
+	finish()
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected drain wait to complete after active work finishes")
+	}
+	if got := pool.ActiveDrainWork(); got != 0 {
+		t.Fatalf("expected no active drain work, got %d", got)
+	}
 }

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -403,11 +403,80 @@ func TestReapIdleTransactionsReleasesDrainWork(t *testing.T) {
 	}
 
 	pool.BeginDrain()
-	pool.reapIdleTransactions(time.Now())
+	pool.reapIdle(time.Now())
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if !pool.WaitForDrain(waitCtx) {
 		t.Fatal("expected idle transaction reaper to release transaction drain work")
+	}
+}
+
+// A GetFlightInfo whose matching DoGet never arrives must not hold the drain
+// open forever: the reaper releases drain tokens stranded on stale ad-hoc query
+// handles, stale prepared pendingDrains, and stale metadata streams — while
+// leaving fresh handles and long-lived prepared handles intact.
+func TestReapIdleReleasesAbandonedHandleDrains(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	mustToken := func() func() {
+		f, err := pool.beginDrainWork(false)
+		if err != nil {
+			t.Fatalf("begin drain work: %v", err)
+		}
+		return f
+	}
+	stale := time.Now().Add(-handleIdleTimeout - time.Minute)
+	fresh := time.Now()
+
+	staleAdhoc := mustToken()
+	freshAdhoc := mustToken()
+	stalePrepared := mustToken()
+	staleMeta := mustToken()
+
+	sess := &Session{
+		ID: "s1",
+		queries: map[string]*QueryHandle{
+			"query-1": {Query: "SELECT 1", createdAt: stale, finishDrain: staleAdhoc},
+			"query-2": {Query: "SELECT 2", createdAt: fresh, finishDrain: freshAdhoc},
+			"prep-1":  {Query: "SELECT 3", Prepared: true, createdAt: stale, pendingDrains: []drainToken{{finish: stalePrepared, at: stale}}},
+		},
+		metadataDrains: map[string][]drainToken{
+			"schemas|x": {{finish: staleMeta, at: stale}},
+		},
+		txns:     make(map[string]*trackedTx),
+		txnOwner: make(map[string]string),
+	}
+	pool.sessions["s1"] = sess
+
+	if got := pool.ActiveDrainWork(); got != 4 {
+		t.Fatalf("activeWork=%d want 4 before reap", got)
+	}
+
+	pool.reapIdle(time.Now())
+
+	if got := pool.ActiveDrainWork(); got != 1 {
+		t.Fatalf("activeWork=%d want 1 (only the fresh ad-hoc handle should remain)", got)
+	}
+
+	sess.mu.RLock()
+	defer sess.mu.RUnlock()
+	if _, ok := sess.queries["query-1"]; ok {
+		t.Error("stale ad-hoc handle query-1 was not reaped")
+	}
+	if _, ok := sess.queries["query-2"]; !ok {
+		t.Error("fresh ad-hoc handle query-2 was wrongly reaped")
+	}
+	prep, ok := sess.queries["prep-1"]
+	if !ok {
+		t.Fatal("prepared handle prep-1 was wrongly dropped (must outlive a stale pendingDrain)")
+	}
+	if len(prep.pendingDrains) != 0 {
+		t.Errorf("stale prepared pendingDrain not released: %d remain", len(prep.pendingDrains))
+	}
+	if _, ok := sess.metadataDrains["schemas|x"]; ok {
+		t.Error("stale metadata drain was not reaped")
 	}
 }

--- a/duckdbservice/transient.go
+++ b/duckdbservice/transient.go
@@ -26,19 +26,27 @@ func isTransactionControlStmt(query string) bool {
 		strings.HasPrefix(upper, "END")
 }
 
+func isTransactionStartStmt(query string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	return strings.HasPrefix(upper, "BEGIN") ||
+		strings.HasPrefix(upper, "START")
+}
+
 func trackSQLTransactionState(query string, execErr error, sqlTxActive *atomic.Bool) {
 	upper := strings.ToUpper(strings.TrimSpace(query))
 	if len(upper) == 0 {
 		return
 	}
-	if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START") {
+	if isTransactionStartStmt(upper) {
 		if execErr == nil {
 			sqlTxActive.Store(true)
 		}
 		return
 	}
 	if isTransactionControlStmt(upper) {
-		sqlTxActive.Store(false)
+		if execErr == nil {
+			sqlTxActive.Store(false)
+		}
 	}
 }
 

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -53,7 +53,9 @@ client-go:
   SA-token mount.
 - **resilience** — worker-pod kill → crash recovery; DuckLake durability across
   a worker restart; concurrent writers (fork conflict-retry, the test that was
-  flaking on main).
+  flaking on main); graceful drain (a worker SIGTERM'd mid-query drains — the
+  in-flight query completes correctly while the pod is Terminating — then retires
+  cleanly; regression net for the worker drain protocol, #690).
 - **isolation** — two tenants (cnpg vs ext) see distinct catalogs; a
   cross-tenant read is denied.
 - **lifecycle** — deprovision → `warehouse=deleted` → the Crossplane Duckling

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -18,7 +18,8 @@
 #   worker pods  : labels, securityContext (non-root, no priv-esc), Downward-API
 #                  POD_NAME/NODE_NAME env, and NO ambient SA-token mount.
 #   resilience   : worker-pod kill → crash recovery; DuckLake durability across a
-#                  worker restart; concurrent writers (fork conflict-retry).
+#                  worker restart; concurrent writers (fork conflict-retry);
+#                  graceful drain (in-flight query survives a worker SIGTERM, #690).
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
 #   lifecycle    : deprovision → warehouse deleted → Duckling CR fully gone
 #                  (finalizer cascade that drops the cnpg role+db completed).
@@ -341,6 +342,58 @@ crash_recovery() { # org password
   basic_query "$1" "$2"
 }
 
+# Graceful drain (regression net for the worker drain protocol, #690): a worker
+# that receives SIGTERM (pod deletion) must DRAIN — finish its in-flight query
+# rather than dropping the connection — then retire cleanly. Distinct from
+# crash_recovery, which kills a worker and only asserts a *fresh* query recovers;
+# here the SAME query that was running at SIGTERM must still return correctly.
+# A passing result after a mid-flight SIGTERM is impossible without the drain
+# protocol (pre-#690 the worker shut down immediately and the query errored).
+graceful_drain() { # org password
+  log "graceful drain: in-flight query survives worker SIGTERM on $1"
+  out="$(mktemp)"; rc="$(mktemp)"
+  # range() is lazy and count over it is metadata-fast, so the modulo filter
+  # forces real per-row work; 8e9 rows reliably outlast the few seconds before
+  # the delete. Expected = count of even i in [0, 8e9) = 4e9. The `if` keeps the
+  # query's failure from tripping `set -e` inside the subshell before we record rc.
+  ( if pg_try "$1" "$2" ducklake \
+        "SELECT count(*) FROM range(8000000000) t(i) WHERE i % 2 = 0;" >"$out" 2>&1
+    then echo 0 >"$rc"; else echo 1 >"$rc"; fi ) &
+  qpid=$!
+
+  # Let the query land on and start running on the worker, then identify the pod
+  # serving it and gracefully delete it (SIGTERM → drain; the pod's
+  # terminationGracePeriodSeconds=3600 keeps it alive long enough to finish).
+  sleep 6
+  pod="$(newest_worker)"
+  [ -n "$pod" ] || { kill "$qpid" 2>/dev/null || true; fail "graceful_drain: no worker pod serving the query"; }
+  k delete pod "$pod" --wait=false >/dev/null 2>&1 || true
+
+  # Overlap proof: the pod must be Terminating (deletionTimestamp set) WHILE the
+  # query is still running — i.e. the SIGTERM landed mid-flight. Without this the
+  # test could false-pass on a query that finished before the delete.
+  ts="$(k get pod "$pod" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)"
+  [ -n "$ts" ] || { wait "$qpid" 2>/dev/null || true; fail "graceful_drain: pod $pod not Terminating after delete"; }
+  kill -0 "$qpid" 2>/dev/null \
+    || fail "graceful_drain: query finished before SIGTERM landed — raise the row count (not a mid-flight test)"
+
+  # The in-flight query must complete successfully despite the SIGTERM.
+  wait "$qpid" 2>/dev/null || true
+  [ "$(cat "$rc")" = 0 ] \
+    || fail "graceful_drain: in-flight query died on worker SIGTERM: $(tr -d '\n' <"$out" | tail -c 200)"
+  n="$(tr -dc '0-9' <"$out")"
+  [ "$n" = "4000000000" ] \
+    || fail "graceful_drain: in-flight result=$n want 4000000000 (drain corrupted the query)"
+  rm -f "$out" "$rc"
+
+  # Once drained the worker must retire cleanly — the pod exits on its own and
+  # the CP retires it (not a crash). Then re-establish a worker for later steps.
+  k wait --for=delete "pod/$pod" --timeout=300s >/dev/null 2>&1 \
+    || fail "graceful_drain: drained worker $pod did not exit/retire within 300s"
+  wait_worker "$1" "$2" ducklake
+  basic_query "$1" "$2"
+}
+
 # Data committed to DuckLake survives a worker restart (parquet in object store +
 # metadata snapshot in Postgres are the source of truth).
 # Ported from TestK8sDuckLakeDurabilityAcrossWorkerRestart.
@@ -468,6 +521,7 @@ main() {
   concurrent_writers     "$CNPG" "$cnpg_pw"
   durability_across_restart "$CNPG" "$cnpg_pw"
   crash_recovery         "$CNPG" "$cnpg_pw"
+  graceful_drain         "$CNPG" "$cnpg_pw"
 
   # ---- ext backend (activation + R/W on the external-RDS metadata path) ----
   wait_worker "$EXT" "$ext_pw" ducklake
@@ -488,7 +542,7 @@ main() {
   # end-to-end would need a warm target >0 in the per-PR CP (see README).
   log "SKIP shared-warm-activation + version-reaper (CP runs warm-target=0; see README)"
 
-  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Add worker drain mode before Flight shutdown so SIGTERM rejects new work but keeps health checks alive with `draining=true`.
- Track active and pending Flight work through ad-hoc query tickets, updates, COPY, transactions, prepared execution, metadata streams, session creation, and tenant activation.
- Teach the control plane to mark draining workers unschedulable without firing crash handling, then retire them cleanly when their pod exits.
- Set worker pod `terminationGracePeriodSeconds` to 3600 seconds.

## Verification

- `just test-unit`
- `just test-controlplane-k8s`
- `just lint` currently fails on pre-existing staticcheck SA5011 warnings in `controlplane/provisioning/api_test.go`, which is not touched by this PR.