### PR TITLE
feat(worker-pool): one query session per worker in k8s/remote mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,64 @@ DML with RETURNING is rejected at extended-query Describe time with SQLSTATE `0A
 - LIMIT 0 does NOT prevent CTE side effects — Postgres CTEs are optimization fences, so writable CTEs execute even with LIMIT 0.
 - DuckDB does not currently support MERGE. If it adds MERGE RETURNING, add `MERGE` to the prefix check in `isDMLReturning`.
 
+## Worker Session Model (k8s / remote backend) — LOAD-BEARING CONTRACT
+
+In the **control-plane remote/k8s backend** a worker pod serves **exactly one
+client query session at a time**. This is deliberate: `workerDuckDBLimits`
+(`controlplane/control.go`) gives the single session ~75% of the *whole pod's*
+RAM + all CPU cores — it does NOT divide by session count. Two sessions on one
+pod would each believe they own 75% → ~150% overcommit → nondeterministic OOM /
+a heavy query killed by a co-resident one. Do not break the following:
+
+- **One session per worker is enforced, not emergent.** The CP spawns remote
+  worker pods with `DUCKGRES_DUCKDB_MAX_SESSIONS=1` (`k8s_pool.go::spawnWorker`).
+  A 2nd concurrent `CreateSession` on a worker is rejected, not silently
+  overcommitted. Internal control/maintenance work uses the worker's side
+  connections (`controlDB`/`warmupDB`), which are NOT counted sessions — so
+  cap=1 does not starve them. Do not raise this to >1 for k8s workers, and do not
+  route internal work through `CreateSession`.
+- **`OrgReservedPool` (remote/multitenant) must never co-assign.** It reuses only
+  idle (`activeSessions==0`, Hot, org-owned) workers via
+  `findIdleAssignedWorkerLocked`, or claims/spawns a fresh one. There is NO
+  least-loaded "share onto a busy worker" path (that exists only in the
+  single-tenant flat `K8sWorkerPool.AcquireWorker`, which is not used in remote
+  mode). Do NOT add one, and do not resurrect a `leastLoaded*` helper here.
+- **At org max workers + all busy → fail fast with the clear org-cap message**
+  (`WorkerClaimMissReasonOrgCap`, see `warm_capacity_policy.go`). Never
+  busy-wait at cap.
+- **Under cap + all busy → hold for a spawn** up to `warmAcquireTimeout` (bounded
+  by the client ctx). This applies to default/exclusive requests too, not just
+  colocated.
+- **FIFO anti-snatch:** the slow acquisition path is serialized per org by
+  `orgAcquireGate` (`org_acquire_gate.go`) so a worker the CP scaled up for an
+  earlier waiter cannot be snatched by a later connection. Keep the gate
+  cancel-safe (a queued waiter whose ctx is cancelled must be skipped, not
+  deadlock the gate).
+- **Destroy-before-reuse ordering:** `SessionManager.DestroySession`
+  (`session_mgr.go`) MUST await the worker-side `DestroySession` RPC *before*
+  `ReleaseWorker`, so a reused (hot-idle) worker's prior session is gone before
+  the next one is assigned (otherwise cap=1 spuriously rejects the reuse).
+
+Touching any of: `controlplane/org_reserved_pool.go`, `org_acquire_gate.go`,
+`k8s_pool.go::spawnWorker`/`AcquireWorker`, `control.go::workerDuckDBLimits`, or
+`duckdbservice` session counting → update the unit tests
+(`org_reserved_pool_test.go`, `org_acquire_gate_test.go`,
+`duckdbservice/service_test.go`) AND the `one_session_per_worker` assertion in
+`tests/e2e-mw-dev/harness.sh`.
+
+## Worker Drain Protocol (graceful shutdown, #690)
+
+Remote worker pods drain on SIGTERM (pod deletion): they reject new work, keep
+in-flight work alive, then exit; the CP marks them `Draining` (not crashed) and
+retires them cleanly. Drain readiness is tracked by a refcount (`activeWork` in
+`duckdbservice/service.go`) of "drain tokens" — one taken per unit of in-flight
+work (query, txn, metadata stream, COPY, activation), released when it finishes.
+Invariants: take exactly one token when work starts and release exactly one when
+it ends on **every** path (a leak hangs drain to the shutdown timeout, an early
+release lets shutdown kill live work); `reapIdle` releases tokens stranded by a
+`GetFlightInfo` whose `DoGet` never arrived. `terminationGracePeriodSeconds=3600`
+(`k8s_pool.go`) must stay above `workerShutdownDrainTime` (55m).
+
 ## TODO Reference
 
 See `TODO.md` for the full feature roadmap and known issues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,15 @@ a heavy query killed by a co-resident one. Do not break the following:
   (`session_mgr.go`) MUST await the worker-side `DestroySession` RPC *before*
   `ReleaseWorker`, so a reused (hot-idle) worker's prior session is gone before
   the next one is assigned (otherwise cap=1 spuriously rejects the reuse).
+- **Cap-drift is recovered, not fatal:** if a worker still rejects a CP-scheduled
+  session at its cap (CP↔worker accounting drift — should never happen),
+  `SessionManager.CreateSessionWithProtocol` does NOT fail the client: it logs
+  loudly (ERROR), bumps `duckgres_control_plane_worker_session_cap_drift_total`,
+  retires (recycles) the inconsistent worker, and re-acquires a fresh one
+  (bounded by `maxWorkerSessionCapDriftRetries`). Detection is
+  `isWorkerSessionCapError` (matches the worker's "max sessions reached"
+  message). A nonzero drift metric means the scheduling invariant is broken —
+  fix the root cause, don't just lean on the retry.
 
 Touching any of: `controlplane/org_reserved_pool.go`, `org_acquire_gate.go`,
 `k8s_pool.go::spawnWorker`/`AcquireWorker`, `control.go::workerDuckDBLimits`, or

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -113,7 +113,7 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 		{
 			name:    "org capacity exhausted",
 			reason:  configstore.WorkerClaimMissReasonOrgCap,
-			message: "Duckgres worker capacity for this organization is currently exhausted; retry later",
+			message: "your organization has reached its maximum number of concurrent Duckgres workers and they are all busy; retry once a query finishes",
 		},
 		{
 			name:    "global capacity exhausted",

--- a/controlplane/flight_ingress_metrics.go
+++ b/controlplane/flight_ingress_metrics.go
@@ -88,6 +88,20 @@ func observeControlPlaneWorkerAcquireFailure(reason string) {
 	controlPlaneWorkerAcquireFailuresCounter.WithLabelValues(reason).Inc()
 }
 
+// controlPlaneWorkerSessionCapDriftCounter counts times a worker rejected a
+// control-plane-scheduled CreateSession because it already held its max session
+// — a CP↔worker accounting drift that must never happen under the
+// one-session-per-worker contract. Should sit at 0; a sustained nonzero rate
+// means scheduling is double-assigning workers (alert on it).
+var controlPlaneWorkerSessionCapDriftCounter = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_control_plane_worker_session_cap_drift_total",
+	Help: "Times a worker rejected a CP-scheduled CreateSession at its session cap (CP↔worker accounting drift; recovered by recycling the worker and retrying).",
+})
+
+func observeWorkerSessionCapDrift() {
+	controlPlaneWorkerSessionCapDriftCounter.Inc()
+}
+
 func observeFlightSessionsReaped(trigger string, count int) {
 	if count <= 0 {
 		return

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -775,6 +775,20 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 							Name:  "DUCKGRES_KEY",
 							Value: workerRPCMountDir + "/" + workerRPCKeyKey,
 						},
+						{
+							// One client query session per worker pod: the pod's full
+							// resources (workerDuckDBLimits gives the session ~75% of pod
+							// RAM + all cores) belong to a single query, so queries never
+							// contend and a heavy query can't be OOM'd by a co-resident
+							// one. The CP scheduler (OrgReservedPool) already never
+							// co-assigns; this is the hard worker-side guarantee — a 2nd
+							// CreateSession is rejected rather than silently overcommitting.
+							// Internal control/maintenance work runs on the worker's side
+							// connections (controlDB/warmupDB), which are NOT counted
+							// sessions, so this does not starve them.
+							Name:  "DUCKGRES_DUCKDB_MAX_SESSIONS",
+							Value: "1",
+						},
 					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: boolPtr(false),

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -3793,6 +3793,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	foundSharedWarmWorkerEnv := false
 	foundTLSCertEnv := false
 	foundTLSKeyEnv := false
+	foundMaxSessionsEnv := false
 	for _, env := range c.Env {
 		if env.Name == "DUCKGRES_DUCKDB_TOKEN" && env.ValueFrom != nil &&
 			env.ValueFrom.SecretKeyRef != nil &&
@@ -3808,6 +3809,9 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 		if env.Name == "DUCKGRES_KEY" && env.Value == "/etc/duckgres/worker-rpc/tls.key" {
 			foundTLSKeyEnv = true
 		}
+		if env.Name == "DUCKGRES_DUCKDB_MAX_SESSIONS" && env.Value == "1" {
+			foundMaxSessionsEnv = true
+		}
 	}
 	if !foundEnv {
 		t.Fatal("bearer token env var not found or incorrect")
@@ -3817,6 +3821,9 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	}
 	if !foundTLSCertEnv || !foundTLSKeyEnv {
 		t.Fatal("expected worker RPC TLS env vars to be present")
+	}
+	if !foundMaxSessionsEnv {
+		t.Fatal("expected DUCKGRES_DUCKDB_MAX_SESSIONS=1 (one query session per worker)")
 	}
 
 	if len(pod.Spec.Volumes) == 0 {

--- a/controlplane/org_acquire_gate.go
+++ b/controlplane/org_acquire_gate.go
@@ -1,0 +1,78 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"sync"
+)
+
+// orgAcquireGate is a cancellable FIFO turnstile. It serializes the slow
+// worker-acquisition path (no idle worker → claim/spawn) for one org so that a
+// newly-spawned or freed worker is handed to the EARLIEST waiting connection,
+// and a later-arriving connection cannot snatch it. Plain sync.Mutex is
+// unsuitable: it is not strictly FIFO and a goroutine blocked in Lock() cannot
+// abort when its request context is cancelled (client disconnect / deadline).
+//
+// Holders must call release() exactly once (defer) after acquire() returns nil.
+type orgAcquireGate struct {
+	mu    sync.Mutex
+	held  bool
+	queue []*gateWaiter
+}
+
+type gateWaiter struct {
+	ready    chan struct{} // closed when the gate is granted to this waiter
+	canceled bool          // set under mu when the waiter abandoned before grant
+}
+
+func newOrgAcquireGate() *orgAcquireGate { return &orgAcquireGate{} }
+
+// acquire blocks until this caller owns the gate (FIFO) or ctx is done. On a nil
+// return the caller owns the gate and MUST call release().
+func (g *orgAcquireGate) acquire(ctx context.Context) error {
+	g.mu.Lock()
+	if !g.held {
+		g.held = true
+		g.mu.Unlock()
+		return nil
+	}
+	w := &gateWaiter{ready: make(chan struct{})}
+	g.queue = append(g.queue, w)
+	g.mu.Unlock()
+
+	select {
+	case <-w.ready:
+		return nil
+	case <-ctx.Done():
+		g.mu.Lock()
+		select {
+		case <-w.ready:
+			// Granted concurrently with cancellation: we now own the gate, so we
+			// must pass it on rather than leak it.
+			g.mu.Unlock()
+			g.release()
+		default:
+			w.canceled = true
+			g.mu.Unlock()
+		}
+		return ctx.Err()
+	}
+}
+
+// release hands the gate to the next live waiter (FIFO), or marks it free.
+func (g *orgAcquireGate) release() {
+	g.mu.Lock()
+	for len(g.queue) > 0 {
+		w := g.queue[0]
+		g.queue = g.queue[1:]
+		if w.canceled {
+			continue // waiter gave up; skip it
+		}
+		close(w.ready) // grant; held stays true (ownership transfers)
+		g.mu.Unlock()
+		return
+	}
+	g.held = false
+	g.mu.Unlock()
+}

--- a/controlplane/org_acquire_gate_test.go
+++ b/controlplane/org_acquire_gate_test.go
@@ -1,0 +1,98 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The gate must grant ownership to one holder at a time and release to waiters
+// in FIFO arrival order — this is what stops a later connection from snatching a
+// worker a longer-waiting one is owed.
+func TestOrgAcquireGateFIFOOrder(t *testing.T) {
+	g := newOrgAcquireGate()
+
+	// First acquire wins immediately.
+	if err := g.acquire(context.Background()); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	const n = 5
+	entered := make([]int, 0, n)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	starts := make([]chan struct{}, n)
+
+	for i := 0; i < n; i++ {
+		starts[i] = make(chan struct{})
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-starts[idx] // queue in deterministic order
+			if err := g.acquire(context.Background()); err != nil {
+				t.Errorf("waiter %d acquire: %v", idx, err)
+				return
+			}
+			mu.Lock()
+			entered = append(entered, idx)
+			mu.Unlock()
+			g.release()
+		}(i)
+	}
+
+	// Release each waiter onto the queue one at a time so arrival order is 0..n-1.
+	for i := 0; i < n; i++ {
+		close(starts[i])
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	g.release() // hand the gate to the FIFO queue head
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if entered[i] != i {
+			t.Fatalf("gate granted out of FIFO order: got %v want [0 1 2 3 4]", entered)
+		}
+	}
+}
+
+// A waiter whose context is cancelled while queued must not deadlock the gate:
+// release() skips it and grants to the next live waiter.
+func TestOrgAcquireGateCancelledWaiterIsSkipped(t *testing.T) {
+	g := newOrgAcquireGate()
+	if err := g.acquire(context.Background()); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// Waiter A queues, then cancels.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	aDone := make(chan error, 1)
+	go func() { aDone <- g.acquire(ctxA) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// Waiter B queues behind A.
+	bGot := make(chan struct{}, 1)
+	go func() {
+		if err := g.acquire(context.Background()); err == nil {
+			bGot <- struct{}{}
+		}
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	cancelA()
+	if err := <-aDone; err == nil {
+		t.Fatal("expected cancelled waiter A to return an error")
+	}
+
+	// Hand off the gate: A is cancelled, so B must get it.
+	g.release()
+	select {
+	case <-bGot:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter B did not acquire the gate after A cancelled (gate leaked)")
+	}
+	g.release()
+}

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -39,6 +39,10 @@ type OrgReservedPool struct {
 	// 0 = unbounded on that axis. Only colocated workers count against these.
 	maxColocatedCPU      int
 	maxColocatedMemBytes uint64
+	// gate serializes the slow acquisition path (no idle worker → claim/spawn) in
+	// FIFO arrival order, so the next worker to become available goes to the
+	// earliest waiting connection and a later one cannot snatch it.
+	gate *orgAcquireGate
 }
 
 func NewOrgReservedPool(shared *K8sWorkerPool, orgID string, maxWorkers int, image string, stsBroker *STSBroker, maxColocatedCPU int, maxColocatedMemBytes uint64) *OrgReservedPool {
@@ -50,6 +54,7 @@ func NewOrgReservedPool(shared *K8sWorkerPool, orgID string, maxWorkers int, ima
 		stsBroker:            stsBroker,
 		maxColocatedCPU:      maxColocatedCPU,
 		maxColocatedMemBytes: maxColocatedMemBytes,
+		gate:                 newOrgAcquireGate(),
 	}
 	pool.activateReservedWorker = pool.activateReservedWorkerDefault
 	return pool
@@ -77,10 +82,30 @@ func (p *OrgReservedPool) assignedColocatedResourcesLocked() (cpu int, memBytes 
 }
 
 func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProfile) (*ManagedWorker, error) {
-	// Server-side patience: block up to warmAcquireTimeout for the warm pool to
-	// replenish before surfacing a "no warm worker" miss to the client. Always
-	// bounded by the request ctx, so a client with a short deadline still fails
-	// fast. 0 = legacy fail-fast.
+	// Fast path: reuse an already-assigned, idle (Hot) worker of the requested
+	// shape. Such a worker is already this org's and free, so reusing it
+	// concurrently is safe and needs no FIFO ordering — it is not a freshly
+	// spawned/neutral worker that a queued waiter is owed (those are claimed only
+	// via the gated slow path below).
+	if w := p.tryReuseIdleAssigned(profile); w != nil {
+		return w, nil
+	}
+
+	// Slow path: no idle worker — we must claim a warm worker or wait for one to
+	// spawn. Serialize per org in FIFO arrival order so the next worker to become
+	// available is handed to the EARLIEST waiting connection; a later-arriving
+	// connection cannot snatch a worker the control plane scaled up for someone
+	// already waiting. Bounded by the request ctx.
+	//
+	// NOTE: while one waiter holds the gate and waits for its spawn, queued
+	// waiters do not yet trigger their own spawn, so a large cold burst ramps
+	// roughly sequentially. Correctness (anti-snatch + clear cap errors) is the
+	// priority here; parallelizing the cold-burst ramp is a perf follow-up.
+	if err := p.gate.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer p.gate.release()
+
 	warmDeadline := time.Now().Add(p.shared.warmAcquireTimeout)
 	// Throttle warm-miss recording across the wait's repeated polls.
 	var lastWarmMissAt time.Time
@@ -91,114 +116,133 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 		default:
 		}
 
+		// A worker may have freed while we waited for our FIFO turn.
+		if w := p.tryReuseIdleAssigned(profile); w != nil {
+			return w, nil
+		}
+
 		p.shared.mu.Lock()
 		if p.shared.shuttingDown {
 			p.shared.mu.Unlock()
 			return nil, fmt.Errorf("pool is shutting down")
 		}
-
-		p.shared.cleanDeadWorkersLocked()
-
-		if idle := p.findIdleAssignedWorkerLocked(profile); idle != nil {
-			idle.activeSessions++
-			if idle.activeSessions > idle.peakSessions {
-				idle.peakSessions = idle.activeSessions
-			}
-			p.shared.mu.Unlock()
-			return idle, nil
-		}
-
-		// The count cap bounds only exclusive workers (each pins a dedicated
-		// node). A colocated request bin-packs and is intentionally unbounded:
-		// never refuse it because the exclusive budget is full.
-		isColocated := profile != nil && profile.Colocate
-		assignedCount := p.assignedWorkerCountLocked()
-		if p.maxWorkers == 0 || isColocated || assignedCount < p.maxWorkers {
-			// Resource-aware quota for colocated workers: a new colocated worker
-			// must not push the org over its colocated CPU/memory budget. Reusing
-			// an idle worker (handled above) adds nothing, so this gates only the
-			// spawn of a new one.
-			if profile != nil && profile.Colocate && (p.maxColocatedCPU > 0 || p.maxColocatedMemBytes > 0) {
-				curCPU, curMem := p.assignedColocatedResourcesLocked()
-				reqCPU, reqMem := parseK8sCPU(profile.CPU), parseK8sMemory(profile.Memory)
-				if (p.maxColocatedCPU > 0 && curCPU+reqCPU > p.maxColocatedCPU) ||
-					(p.maxColocatedMemBytes > 0 && curMem+reqMem > p.maxColocatedMemBytes) {
-					p.shared.mu.Unlock()
-					observeOrgColocatedQuotaRejection(p.orgID)
-					return nil, ErrOrgResourceQuotaExceeded
-				}
-			}
-			maxWorkers := p.maxWorkers
-			image := p.image
-			p.shared.mu.Unlock()
-
-			// While waiting (below) we poll every WarmAcquireRetryInterval, but
-			// record the warm miss (demand + metric) at most once per
-			// WarmMissRecordInterval so one waiting connection doesn't inflate the
-			// demand signal / miss counter.
-			recordMiss := lastWarmMissAt.IsZero() || time.Since(lastWarmMissAt) >= WarmMissRecordInterval
-
-			worker, err := p.shared.ReserveSharedWorker(ctx, &WorkerAssignment{
-				OrgID:                  p.orgID,
-				MaxWorkers:             maxWorkers,
-				Image:                  image,
-				Profile:                profile,
-				MaxColocatedCPU:        p.maxColocatedCPU,
-				MaxColocatedMemBytes:   p.maxColocatedMemBytes,
-				SuppressWarmMissRecord: !recordMiss,
-			})
-			if err != nil {
-				if recordMiss {
-					lastWarmMissAt = time.Now()
-				}
-				// Server-side patience: a transient no-idle miss on a colocated
-				// request resolves once the warm pool replenishes (a colocated
-				// shape may first need a cold node, minutes). Wait and retry until
-				// warmAcquireTimeout elapses rather than failing immediately;
-				// bounded by ctx. Restricted to colocated requests — a default /
-				// exclusive miss replenishes quickly and the client retries, so we
-				// don't block interactive/default traffic (e.g. data imports) for
-				// minutes.
-				if p.shared.warmAcquireTimeout > 0 && isColocated && isRetryableWarmMiss(err) && time.Now().Before(warmDeadline) {
-					timer := time.NewTimer(WarmAcquireRetryInterval)
-					select {
-					case <-ctx.Done():
-						timer.Stop()
-						return nil, ctx.Err()
-					case <-timer.C:
-					}
-					continue
-				}
-				return nil, err
-			}
-
-			if err := p.activateWorkerForOrg(ctx, worker); err != nil {
-				slog.Warn("Worker activation failed.", "worker", worker.ID, "org", p.orgID, "error", err)
-				observeActivationFailure(worker.image)
-				p.shared.retireWorkerWithReason(worker.ID, RetireReasonActivationFailure, LifecycleOriginActivationFailure)
-				return nil, err
-			}
-
-			p.shared.mu.Lock()
-			if owned := p.workerBelongsToOrgLocked(worker); owned {
-				worker.activeSessions++
-				if worker.activeSessions > worker.peakSessions {
-					worker.peakSessions = worker.activeSessions
-				}
+		// Resource-aware quota for colocated workers: a new colocated worker must
+		// not push the org over its colocated CPU/memory budget. (The count cap is
+		// enforced authoritatively, cross-CP, inside ReserveSharedWorker's claim,
+		// which exempts colocated workers; the CPU/mem budget is enforced here.)
+		if profile != nil && profile.Colocate && (p.maxColocatedCPU > 0 || p.maxColocatedMemBytes > 0) {
+			curCPU, curMem := p.assignedColocatedResourcesLocked()
+			reqCPU, reqMem := parseK8sCPU(profile.CPU), parseK8sMemory(profile.Memory)
+			if (p.maxColocatedCPU > 0 && curCPU+reqCPU > p.maxColocatedCPU) ||
+				(p.maxColocatedMemBytes > 0 && curMem+reqMem > p.maxColocatedMemBytes) {
 				p.shared.mu.Unlock()
-				return worker, nil
+				observeOrgColocatedQuotaRejection(p.orgID)
+				return nil, ErrOrgResourceQuotaExceeded
 			}
-			p.shared.mu.Unlock()
-			continue
+		}
+		maxWorkers := p.maxWorkers
+		image := p.image
+		p.shared.mu.Unlock()
+
+		// While waiting (below) we poll every WarmAcquireRetryInterval, but record
+		// the warm miss (demand + metric) at most once per WarmMissRecordInterval
+		// so one waiting connection doesn't inflate the demand signal / miss counter.
+		recordMiss := lastWarmMissAt.IsZero() || time.Since(lastWarmMissAt) >= WarmMissRecordInterval
+
+		worker, err := p.shared.ReserveSharedWorker(ctx, &WorkerAssignment{
+			OrgID:                  p.orgID,
+			MaxWorkers:             maxWorkers,
+			Image:                  image,
+			Profile:                profile,
+			MaxColocatedCPU:        p.maxColocatedCPU,
+			MaxColocatedMemBytes:   p.maxColocatedMemBytes,
+			SuppressWarmMissRecord: !recordMiss,
+		})
+		if err != nil {
+			if recordMiss {
+				lastWarmMissAt = time.Now()
+			}
+			// An org/global-cap or shutdown miss will NOT resolve by waiting —
+			// surface it immediately with its clear, reason-specific message.
+			if !isRetryableWarmMiss(err) {
+				return nil, err
+			}
+			// A retryable "no idle warm worker" miss: distinguish two cases.
+			//   - At the org's max concurrent (exclusive) workers and all busy →
+			//     waiting cannot help (no new worker will spawn); fail fast with the
+			//     clear org-cap message so the client knows it hit its own limit.
+			//     This also makes the contract hold without a runtime store, whose
+			//     in-memory claim cannot itself classify the miss as org-cap.
+			//   - Under the cap → a worker is (being) spawned, so hold up to
+			//     warmAcquireTimeout for it rather than bouncing the client. Applies
+			//     to default/exclusive requests too, not just colocated.
+			isColocated := profile != nil && profile.Colocate
+			if !isColocated && p.atOrgWorkerCap() {
+				return nil, NewWarmCapacityExhaustedErrorForReason(
+					configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
+			}
+			if p.shared.warmAcquireTimeout > 0 && time.Now().Before(warmDeadline) {
+				timer := time.NewTimer(WarmAcquireRetryInterval)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, ctx.Err()
+				case <-timer.C:
+				}
+				continue
+			}
+			return nil, err
 		}
 
-		p.shared.mu.Unlock()
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(100 * time.Millisecond):
+		if err := p.activateWorkerForOrg(ctx, worker); err != nil {
+			slog.Warn("Worker activation failed.", "worker", worker.ID, "org", p.orgID, "error", err)
+			observeActivationFailure(worker.image)
+			p.shared.retireWorkerWithReason(worker.ID, RetireReasonActivationFailure, LifecycleOriginActivationFailure)
+			return nil, err
 		}
+
+		p.shared.mu.Lock()
+		if owned := p.workerBelongsToOrgLocked(worker); owned {
+			worker.activeSessions++
+			if worker.activeSessions > worker.peakSessions {
+				worker.peakSessions = worker.activeSessions
+			}
+			p.shared.mu.Unlock()
+			return worker, nil
+		}
+		p.shared.mu.Unlock()
+		// Worker is no longer ours (raced with retirement/reclaim); try again.
 	}
+}
+
+// atOrgWorkerCap reports whether the org has reached its maximum concurrent
+// exclusive workers (count cap). Hot-idle and colocated workers are excluded
+// (they don't consume the count budget), so a true result means every counted
+// worker is actively assigned — a new exclusive worker cannot be added.
+func (p *OrgReservedPool) atOrgWorkerCap() bool {
+	p.shared.mu.Lock()
+	defer p.shared.mu.Unlock()
+	return p.maxWorkers > 0 && p.assignedWorkerCountLocked() >= p.maxWorkers
+}
+
+// tryReuseIdleAssigned returns an already-assigned, idle (Hot) worker of the
+// requested shape with its session count bumped, or nil if none is available.
+func (p *OrgReservedPool) tryReuseIdleAssigned(profile *WorkerProfile) *ManagedWorker {
+	p.shared.mu.Lock()
+	defer p.shared.mu.Unlock()
+	if p.shared.shuttingDown {
+		return nil
+	}
+	p.shared.cleanDeadWorkersLocked()
+	idle := p.findIdleAssignedWorkerLocked(profile)
+	if idle == nil {
+		return nil
+	}
+	idle.activeSessions++
+	if idle.activeSessions > idle.peakSessions {
+		idle.peakSessions = idle.activeSessions
+	}
+	return idle
 }
 
 func (p *OrgReservedPool) ReleaseWorker(id int) {
@@ -287,24 +331,6 @@ func (p *OrgReservedPool) findIdleAssignedWorkerLocked(profile *WorkerProfile) *
 		}
 	}
 	return nil
-}
-
-func (p *OrgReservedPool) leastLoadedAssignedWorkerLocked() *ManagedWorker {
-	var best *ManagedWorker
-	for _, w := range p.shared.workers {
-		select {
-		case <-w.done:
-			continue
-		default:
-		}
-		if !p.workerReadyForSchedulingLocked(w) {
-			continue
-		}
-		if best == nil || w.activeSessions < best.activeSessions {
-			best = w
-		}
-	}
-	return best
 }
 
 func (p *OrgReservedPool) assignedWorkerCountLocked() int {

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -4,6 +4,7 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -322,7 +323,10 @@ func TestIsRetryableWarmMiss(t *testing.T) {
 	}
 }
 
-func TestOrgReservedPoolAcquireWaitsWhenSharedWarmWorkerBusyAtCapacity(t *testing.T) {
+// At the org's max concurrent workers with all of them busy, AcquireWorker must
+// fail FAST with the clear org-cap message — not busy-wait until the client's
+// deadline, and not reuse the busy worker (one session per worker).
+func TestOrgReservedPoolAcquireFailsClearlyAtOrgCap(t *testing.T) {
 	shared, _ := newTestK8sPool(t, 5)
 	worker := &ManagedWorker{ID: 3, activeSessions: 1, done: make(chan struct{})}
 	if err := worker.SetSharedState(SharedWorkerState{
@@ -337,19 +341,24 @@ func TestOrgReservedPoolAcquireWaitsWhenSharedWarmWorkerBusyAtCapacity(t *testin
 
 	pool := NewOrgReservedPool(shared, "analytics", 1, shared.workerImage, nil, 0, 0)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	// Generous deadline: the call must return promptly on its own, well before this.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	start := time.Now()
 	got, err := pool.AcquireWorker(ctx, nil)
 	if err == nil {
-		t.Fatalf("expected AcquireWorker to wait instead of reusing busy worker, got worker %d", got.ID)
-		return
+		t.Fatalf("expected AcquireWorker to fail at org cap, got worker %d", got.ID)
 	}
 	if got != nil {
-		t.Fatalf("expected no worker on timeout, got %v", got)
+		t.Fatalf("expected no worker at org cap, got %v", got)
 	}
-	if err != context.DeadlineExceeded {
-		t.Fatalf("expected context deadline exceeded, got %v", err)
+	var capErr *WarmCapacityExhaustedError
+	if !errors.As(err, &capErr) || capErr.missReason() != configstore.WorkerClaimMissReasonOrgCap {
+		t.Fatalf("expected org-cap WarmCapacityExhaustedError, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected fast failure at org cap, took %s", elapsed)
 	}
 	if worker.activeSessions != 1 {
 		t.Fatalf("expected busy worker session count to stay at 1, got %d", worker.activeSessions)

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -262,42 +263,90 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 	observeControlPlaneWorkerQueueDepthDelta(1)
 	defer observeControlPlaneWorkerQueueDepthDelta(-1)
 
-	acquireStart := time.Now()
-	ctx, acquireSpan := server.Tracer().Start(ctx, "duckgres.worker_acquire")
-	slog.Debug("Acquiring worker for session.", "pid", pid, "user", username)
-	worker, err := sm.pool.AcquireWorker(ctx, profile)
-	if err != nil {
-		var capacityErr *WarmCapacityExhaustedError
-		if errors.As(err, &capacityErr) {
-			missReason := capacityErr.missReason()
-			observeControlPlaneWorkerAcquireFailure("warm_capacity_exhausted")
-			observeControlPlaneWorkerAcquireFailure("warm_capacity_" + string(missReason))
-			acquireSpan.SetAttributes(
-				attribute.String("warm_capacity.reason", string(missReason)),
-				attribute.Int("warm_capacity.retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter)),
-			)
-			slog.Warn("Worker acquisition failed.",
-				"pid", pid,
-				"user", username,
-				"duration", time.Since(acquireStart),
-				"reason", missReason,
-				"retry_after", capacityErr.RetryAfter,
-				"retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter),
-				"error", err,
-			)
+	// Acquire a worker and create the session on it. Normally one pass. If the
+	// worker rejects our session because it already holds its max session — a
+	// CP↔worker accounting drift that must never happen under one-session-per-
+	// worker — we do NOT fail the client for our own broken logic: recycle the
+	// inconsistent worker and try a fresh one (bounded), logging loudly so the
+	// drift is visible. ctx is the budget; each attempt also re-checks it.
+	var lastCapDriftErr error
+	for attempt := 1; attempt <= maxWorkerSessionCapDriftRetries+1; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return 0, nil, err
+		}
+
+		acquireStart := time.Now()
+		actx, acquireSpan := server.Tracer().Start(ctx, "duckgres.worker_acquire")
+		slog.Debug("Acquiring worker for session.", "pid", pid, "user", username, "attempt", attempt)
+		worker, err := sm.pool.AcquireWorker(actx, profile)
+		if err != nil {
+			var capacityErr *WarmCapacityExhaustedError
+			if errors.As(err, &capacityErr) {
+				missReason := capacityErr.missReason()
+				observeControlPlaneWorkerAcquireFailure("warm_capacity_exhausted")
+				observeControlPlaneWorkerAcquireFailure("warm_capacity_" + string(missReason))
+				acquireSpan.SetAttributes(
+					attribute.String("warm_capacity.reason", string(missReason)),
+					attribute.Int("warm_capacity.retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter)),
+				)
+				slog.Warn("Worker acquisition failed.",
+					"pid", pid,
+					"user", username,
+					"duration", time.Since(acquireStart),
+					"reason", missReason,
+					"retry_after", capacityErr.RetryAfter,
+					"retry_after_seconds", warmCapacityRetrySeconds(capacityErr.RetryAfter),
+					"error", err,
+				)
+			}
+			acquireSpan.End()
+			return 0, nil, fmt.Errorf("acquire worker: %w", err)
 		}
 		acquireSpan.End()
-		return 0, nil, fmt.Errorf("acquire worker: %w", err)
-	}
-	acquireSpan.End()
-	slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
+		slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
 
-	pid, exec, err := sm.createSessionOnWorker(ctx, username, pid, memoryLimit, threads, worker, protocol, true, lease)
-	if err != nil {
-		return 0, nil, err
+		newPID, exec, err := sm.createSessionOnWorker(actx, username, pid, memoryLimit, threads, worker, protocol, true, lease)
+		if err == nil {
+			success = true
+			return newPID, exec, nil
+		}
+		if !isWorkerSessionCapError(err) {
+			return 0, nil, err
+		}
+
+		// One-session-per-worker invariant violated: the CP scheduled this worker
+		// believing it idle, but the worker still holds a session. Recycle it
+		// (graceful drain via retire) so it leaves the schedulable pool, and retry
+		// with a fresh worker. Loud ERROR + metric so we can find and fix the drift.
+		lastCapDriftErr = err
+		observeWorkerSessionCapDrift()
+		slog.Error("Worker rejected a CP-scheduled session at its session cap — one-session-per-worker accounting drift; recycling worker and re-acquiring.",
+			"pid", pid,
+			"user", username,
+			"worker", worker.ID,
+			"attempt", attempt,
+			"error", err,
+		)
+		sm.pool.RetireWorker(worker.ID)
 	}
-	success = true
-	return pid, exec, nil
+
+	// Exhausted retries — every fresh worker drifted, which means scheduling is
+	// systemically broken. Surface a clear error rather than spinning.
+	return 0, nil, fmt.Errorf("create session: worker session-cap drift persisted across %d attempts: %w", maxWorkerSessionCapDriftRetries+1, lastCapDriftErr)
+}
+
+// maxWorkerSessionCapDriftRetries bounds how many EXTRA fresh workers we try when
+// a worker rejects a CP-scheduled session at its cap (one-session-per-worker
+// accounting drift). Total attempts = this + 1. Small: a single drift is a rare
+// race that a fresh worker fixes; persistent drift is a bug to surface, not spin on.
+const maxWorkerSessionCapDriftRetries = 2
+
+// isWorkerSessionCapError reports whether err is a worker's rejection of a new
+// session because it already holds its configured maximum (MaxSessions). The
+// worker maps this to gRPC ResourceExhausted with the duckdbservice message
+// "max sessions reached (N)", which propagates through the wrapped error chain.
+func isWorkerSessionCapError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "max sessions reached")
 }
 
 func (sm *SessionManager) resolveSessionLimits(memoryLimit string, threads int) (string, int) {

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -5,6 +5,7 @@ package controlplane
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -79,6 +80,30 @@ func TestCreateSessionObservesWarmCapacityExhaustion(t *testing.T) {
 	}
 	if got := metric.GetCounter().GetValue(); got != 1 {
 		t.Fatalf("expected one warm capacity acquisition failure, got %v", got)
+	}
+}
+
+func TestIsWorkerSessionCapError(t *testing.T) {
+	// The worker maps a MaxSessions rejection to a gRPC ResourceExhausted error
+	// whose message contains "max sessions reached"; the CP wraps it twice on the
+	// way up. The classifier must see through that wrapping and ignore unrelated
+	// errors (otherwise the cap-drift recycle/retry would fire on the wrong thing).
+	capLike := fmt.Errorf("create session on worker 7: %w",
+		fmt.Errorf("create session recv: %w",
+			errors.New("rpc error: code = ResourceExhausted desc = create session: max sessions reached (1)")))
+	if !isWorkerSessionCapError(capLike) {
+		t.Fatalf("expected wrapped 'max sessions reached' error to be classified as a session-cap error")
+	}
+
+	for _, e := range []error{
+		nil,
+		errors.New("create session on worker 7: connection refused"),
+		NewWarmCapacityExhaustedError(time.Second),
+		context.DeadlineExceeded,
+	} {
+		if isWorkerSessionCapError(e) {
+			t.Fatalf("did not expect %v to be classified as a session-cap error", e)
+		}
 	}
 }
 

--- a/controlplane/warm_capacity_policy.go
+++ b/controlplane/warm_capacity_policy.go
@@ -62,7 +62,7 @@ func (p warmCapacityMissPolicy) sqlMessage(retryAfter time.Duration) string {
 	case warmCapacityMessageNoIdle:
 		return fmt.Sprintf("no warm Duckgres worker is currently available; retry in about %d seconds", warmCapacityRetrySeconds(retryAfter))
 	case warmCapacityMessageOrgCap:
-		return "Duckgres worker capacity for this organization is currently exhausted; retry later"
+		return "your organization has reached its maximum number of concurrent Duckgres workers and they are all busy; retry once a query finishes"
 	case warmCapacityMessageGlobalCap:
 		return "Duckgres worker capacity is currently exhausted; retry later"
 	case warmCapacityMessageShuttingDown:

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -4,11 +4,34 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	_ "github.com/duckdb/duckdb-go/v2"
 )
+
+// With MaxSessions=1 (how the control plane spawns remote worker pods), a worker
+// serves exactly one client query session — a second concurrent CreateSession is
+// rejected rather than silently overcommitting the pod's resources. Internal
+// control/maintenance connections (controlDB/warmupDB) are not counted sessions
+// and are unaffected.
+func TestCreateSessionRejectsSecondSessionWhenMaxIsOne(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		maxSessions: 1,
+	}
+	pool.sessions["existing"] = &Session{ID: "existing"}
+
+	_, err := pool.CreateSession("u", "", 0)
+	if err == nil {
+		t.Fatal("expected second CreateSession to be rejected at MaxSessions=1")
+	}
+	if !strings.Contains(err.Error(), "max sessions reached") {
+		t.Fatalf("expected 'max sessions reached' error, got %v", err)
+	}
+}
 
 type exitPanic struct {
 	code int

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -55,7 +55,14 @@ client-go:
   a worker restart; concurrent writers (fork conflict-retry, the test that was
   flaking on main); graceful drain (a worker SIGTERM'd mid-query drains — the
   in-flight query completes correctly while the pod is Terminating — then retires
-  cleanly; regression net for the worker drain protocol, #690).
+  cleanly; regression net for the worker drain protocol, #690); one session per
+  worker (two concurrent queries for one org land on two distinct worker pods,
+  never sharing a pod's DuckDB — workers run DUCKGRES_DUCKDB_MAX_SESSIONS=1 so a
+  query owns the whole pod's resources). The org-at-max-workers clear error and
+  the under-cap hold-for-spawn / FIFO anti-snatch paths are covered by unit tests
+  (controlplane/org_reserved_pool_test.go, org_acquire_gate_test.go) — exercising
+  them in-Job would need a dedicated max_workers=1 org and deterministic cold-spawn
+  timing the shared cluster can't guarantee.
 - **isolation** — two tenants (cnpg vs ext) see distinct catalogs; a
   cross-tenant read is denied.
 - **lifecycle** — deprovision → `warehouse=deleted` → the Crossplane Duckling

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -19,7 +19,8 @@
 #                  POD_NAME/NODE_NAME env, and NO ambient SA-token mount.
 #   resilience   : worker-pod kill → crash recovery; DuckLake durability across a
 #                  worker restart; concurrent writers (fork conflict-retry);
-#                  graceful drain (in-flight query survives a worker SIGTERM, #690).
+#                  graceful drain (in-flight query survives a worker SIGTERM, #690);
+#                  one session per worker (concurrent queries land on distinct pods).
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
 #   lifecycle    : deprovision → warehouse deleted → Duckling CR fully gone
 #                  (finalizer cascade that drops the cnpg role+db completed).
@@ -394,6 +395,51 @@ graceful_drain() { # org password
   basic_query "$1" "$2"
 }
 
+# One session per worker: two concurrent queries for the same org must land on
+# two DISTINCT worker pods, never share a single pod's DuckDB. The control plane
+# spawns remote workers with DUCKGRES_DUCKDB_MAX_SESSIONS=1, so each query owns a
+# whole pod's resources and a heavy query can't be starved by a co-resident one.
+# Regression net: if a worker were ever shared (pre-change least-loaded sharing),
+# the org would peak at a single active-org-labeled pod for both queries.
+# Assumes the worker nodepool is already warm (prior resilience steps spawned
+# pods), so the second pod schedules within the queries' runtime.
+one_session_per_worker() { # org password
+  log "one session per worker: concurrent queries land on distinct pods on $1"
+  o1="$(mktemp)"; o2="$(mktemp)"; r1="$(mktemp)"; r2="$(mktemp)"
+  # Deterministic, multi-second query (range() is lazy; the modulo filter forces
+  # real per-row work). Expected = count of even i in [0, 8e9) = 4e9.
+  q="SELECT count(*) FROM range(8000000000) t(i) WHERE i % 2 = 0;"
+  ( if pg_try "$1" "$2" ducklake "$q" >"$o1" 2>&1; then echo 0 >"$r1"; else echo 1 >"$r1"; fi ) &
+  p1=$!
+  ( if pg_try "$1" "$2" ducklake "$q" >"$o2" 2>&1; then echo 0 >"$r2"; else echo 1 >"$r2"; fi ) &
+  p2=$!
+
+  # While both queries run, the org must reach >=2 worker pods — one per session.
+  # MaxSessions=1 forces the second query onto its own pod (it cannot join the
+  # first's busy pod), so co-residence is impossible.
+  peak=0 a=0
+  while [ "$a" -lt 180 ]; do
+    kill -0 "$p1" 2>/dev/null || break
+    kill -0 "$p2" 2>/dev/null || break
+    c="$(k get pods -l "duckgres/active-org=$1" --no-headers 2>/dev/null | grep -c . || true)"
+    [ "$c" -gt "$peak" ] && peak="$c"
+    [ "$peak" -ge 2 ] && break
+    sleep 1; a=$((a + 1))
+  done
+
+  wait "$p1" 2>/dev/null || true
+  wait "$p2" 2>/dev/null || true
+  { [ "$(cat "$r1")" = 0 ] && [ "$(cat "$r2")" = 0 ]; } \
+    || fail "one_session_per_worker: a concurrent query errored ($(tr -d '\n' <"$o1" | tail -c 120) | $(tr -d '\n' <"$o2" | tail -c 120))"
+  n1="$(tr -dc '0-9' <"$o1")"; n2="$(tr -dc '0-9' <"$o2")"
+  { [ "$n1" = "4000000000" ] && [ "$n2" = "4000000000" ]; } \
+    || fail "one_session_per_worker: wrong results n1=$n1 n2=$n2 want 4000000000"
+  [ "$peak" -ge 2 ] \
+    || fail "one_session_per_worker: org peaked at $peak worker pod(s) for 2 concurrent queries — sessions shared a worker"
+  rm -f "$o1" "$o2" "$r1" "$r2"
+  log "one session per worker: OK (peak $peak pods for $1)"
+}
+
 # Data committed to DuckLake survives a worker restart (parquet in object store +
 # metadata snapshot in Postgres are the source of truth).
 # Ported from TestK8sDuckLakeDurabilityAcrossWorkerRestart.
@@ -522,6 +568,7 @@ main() {
   durability_across_restart "$CNPG" "$cnpg_pw"
   crash_recovery         "$CNPG" "$cnpg_pw"
   graceful_drain         "$CNPG" "$cnpg_pw"
+  one_session_per_worker "$CNPG" "$cnpg_pw"
 
   # ---- ext backend (activation + R/W on the external-RDS metadata path) ----
   wait_worker "$EXT" "$ext_pw" ducklake
@@ -542,7 +589,7 @@ main() {
   # end-to-end would need a warm target >0 in the per-PR CP (see README).
   log "SKIP shared-warm-activation + version-reaper (CP runs warm-target=0; see README)"
 
-  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Guarantee **deterministic per-query resources** in the control-plane **remote (k8s)** backend: a worker pod serves **exactly one client query session at a time**, so each query owns the pod's full resources and a heavy query can never be starved or OOM'd by a co-resident one.

Why this matters: `workerDuckDBLimits` already gives a single session ~75% of the *whole pod's* RAM + all cores (it does not divide by session count). Two sessions on one pod → ~150% overcommit → nondeterministic OOM. Today that's avoided only *emergently* (`OrgReservedPool` never co-assigns) with nothing enforcing it — this PR makes it a hard, guaranteed contract.

**Scope: remote/k8s (`OrgReservedPool`) only.** Standalone and process backends are unchanged.

## Changes

- **Enforce 1 session/worker:** spawn remote pods with `DUCKGRES_DUCKDB_MAX_SESSIONS=1`. A 2nd concurrent `CreateSession` is rejected, not silently overcommitted. Internal control/maintenance work uses the worker's `controlDB`/`warmupDB` side connections (not counted sessions), so cap=1 doesn't starve it. Removed the dead `leastLoadedAssignedWorkerLocked` so sharing can't be re-wired into the org path.
- **At org max workers + all busy → fail fast** with a clear message ("your organization has reached its maximum number of concurrent Duckgres workers and they are all busy…") instead of busy-waiting to the client deadline. Works without a runtime store via an in-process cap check.
- **Under cap + all busy → hold** up to `warmAcquireTimeout` for a worker to spawn (bounded by ctx) — now for default/exclusive too, not only colocated.
- **Anti-snatch:** the slow acquire path is serialized per org by a cancel-safe FIFO turnstile (`orgAcquireGate`), so a worker the CP scaled up for an earlier waiter can't be snatched by a later connection. The fast idle-reuse path stays ungated (it only reuses already-org-owned Hot workers; neutral warm workers are claimed only through the gate).
- **Destroy-before-reuse** ordering already held (`session_mgr` awaits the worker `DestroySession` RPC before `ReleaseWorker`); documented as load-bearing for cap=1.

## Tests

- `duckdbservice`: 2nd session rejected at `MaxSessions=1`.
- `controlplane`: org-cap fast-fail; FIFO gate ordering + cancelled-waiter skip (race-clean); pod spec carries `DUCKGRES_DUCKDB_MAX_SESSIONS=1`.
- e2e `harness.sh`: `one_session_per_worker` — two concurrent queries for one org land on two distinct worker pods with correct results (regression net for sharing). The org-cap error and under-cap-hold/FIFO paths are unit-covered (a dedicated `max_workers=1` org + deterministic cold-spawn timing isn't reliably reproducible in-Job — noted in the README).

## Docs

`CLAUDE.md` gains a **"Worker Session Model"** load-bearing-contract section (+ a drain-protocol summary) so future changes don't reintroduce session sharing or break the cap / hold / anti-snatch / destroy-before-reuse guarantees.

## Verification

- `go build ./... && go build -tags kubernetes ./...`
- `go test -tags kubernetes ./controlplane/` and `go test ./duckdbservice/` pass; gate tests pass under `-race`.
- The remaining `tests/{configstore,controlplane,integration}` failures locally are environmental (need docker/Postgres) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)