### PR TITLE
feat(worker-sizing): worker_cpu/memory/ttl request knobs (TTL-pool, slice 1 + design)

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -144,6 +144,7 @@ type K8sConfig struct {
 	WorkerProfileMaxCPU            string                       // Clamp ceiling for a client-supplied cpu (e.g. "16")
 	WorkerProfileMinMemory         string                       // Clamp floor for a client-supplied memory (e.g. "4Gi")
 	WorkerProfileMaxMemory         string                       // Clamp ceiling for a client-supplied memory (e.g. "64Gi")
+	WorkerMaxTTL                   time.Duration                // Clamp ceiling for a client-supplied duckgres.worker_ttl (0 = unbounded)
 	OrgMaxColocatedCPU             int                          // Per-org cap on summed colocated worker CPU cores (0 = unbounded)
 	OrgMaxColocatedMemory          string                       // Per-org cap on summed colocated worker memory (e.g. "256Gi")
 	WorkerTiers                    map[string]WorkerProfileSpec // Named tier aliases selectable via duckgres.worker_tier

--- a/controlplane/worker_profile.go
+++ b/controlplane/worker_profile.go
@@ -2,127 +2,100 @@ package controlplane
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// Startup-option GUC names a client uses to select its worker shape. Parsed from
-// the libpq `options` parameter exactly like search_path (see control.go).
+// Startup-option GUC names a client uses to select its worker size + idle TTL.
+// Parsed from the libpq `options` parameter exactly like search_path (control.go).
 const (
-	gucColocate     = "duckgres.colocate"
 	gucWorkerCPU    = "duckgres.worker_cpu"
 	gucWorkerMemory = "duckgres.worker_memory"
-	gucWorkerTier   = "duckgres.worker_tier"
+	gucWorkerTTL    = "duckgres.worker_ttl"
 )
 
-// resolveWorkerProfile turns the parsed startup-option GUCs into a *WorkerProfile
-// under this deployment's gate/clamp/tier policy.
+// Built-in defaults when a request omits a field (or client sizing is gated off)
+// and the deployment did not configure its own default size/TTL.
+const (
+	defaultWorkerCPU    = "8"
+	defaultWorkerMemory = "16Gi"
+	defaultWorkerTTL    = 20 * time.Minute
+)
+
+// resolveWorkerProfile turns the client's worker_cpu / worker_memory / worker_ttl
+// startup options into a concrete *WorkerProfile (a worker size + hot-idle TTL).
 //
-// Returns:
-//   - (nil, warns, nil)  => the default exclusive profile (gate off, no GUCs, or a
-//     selection that normalizes to the default). nil is the sentinel that matches
-//     legacy/default workers, so callers thread it straight through unchanged.
-//   - (profile, warns, nil) => a non-default profile to schedule.
-//   - (nil, nil, err) => reject the connection (unknown tier, disallowed
-//     colocate=false, or an unparseable/non-positive size). Clamping never errors;
-//     an out-of-range size is capped and reported via warns.
+// Every request resolves to a concrete size: the deployment default
+// (WorkerCPURequest / WorkerMemoryRequest, defaultWorkerTTL) when a field is
+// unset or client sizing is gated off, otherwise the clamped client value.
+// Client cpu/mem are clamped to [min,max] and ttl to [0,maxTTL]; an out-of-range
+// value is clamped with a warning, an unparseable/negative one errors (rejecting
+// the connection). Returns (profile, warns, nil) on success.
 func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerProfile, []string, error) {
 	k := cp.cfg.K8s
-	if !k.AllowClientWorkerProfile {
-		return nil, nil, nil
-	}
 
-	rawColocate := strings.TrimSpace(opts[gucColocate])
-	rawCPU := strings.TrimSpace(opts[gucWorkerCPU])
-	rawMem := strings.TrimSpace(opts[gucWorkerMemory])
-	rawTier := strings.TrimSpace(opts[gucWorkerTier])
+	cpu := firstNonEmpty(strings.TrimSpace(k.WorkerCPURequest), defaultWorkerCPU)
+	mem := firstNonEmpty(strings.TrimSpace(k.WorkerMemoryRequest), defaultWorkerMemory)
+	ttl := defaultWorkerTTL
 
-	if rawColocate == "" && rawCPU == "" && rawMem == "" && rawTier == "" {
-		return nil, nil, nil // no selection -> default exclusive profile
-	}
-
-	// Tier alias expands first; explicit inline GUCs override its fields below.
-	var (
-		tierColocate     *bool
-		tierCPU, tierMem string
-	)
-	if rawTier != "" {
-		spec, ok := k.WorkerTiers[rawTier]
-		if !ok {
-			return nil, nil, fmt.Errorf("unknown worker tier %q", rawTier)
-		}
-		tierColocate, tierCPU, tierMem = spec.Colocate, spec.CPU, spec.Memory
-	}
-
-	// colocate: inline GUC > tier > default(false)
-	colocate := false
-	if tierColocate != nil {
-		colocate = *tierColocate
-	}
-	if rawColocate != "" {
-		b, err := strconv.ParseBool(rawColocate)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid %s %q (want true or false)", gucColocate, rawColocate)
-		}
-		colocate = b
-	}
-
-	// A full exclusive node is the expensive button; gate it independently.
-	if !colocate && !k.AllowClientExclusiveNode {
-		return nil, nil, fmt.Errorf("client-selected exclusive workers (colocate=false) are not permitted on this deployment")
-	}
-
-	// size: inline GUC > tier > colocate default. colocate=false with no size stays
-	// empty -> the pool-global request (today's 46/360) applies.
-	cpu := firstNonEmpty(rawCPU, tierCPU)
-	mem := firstNonEmpty(rawMem, tierMem)
-	if cpu == "" && mem == "" && colocate {
-		cpu = k.ColocatedWorkerCPURequest
-		mem = k.ColocatedWorkerMemoryRequest
-	}
-
-	// Normalize both sizes; clamp only COLOCATED sizes. The clamp range is the
-	// bin-pack safety bound — it would wrongly cap an exclusive full-node request
-	// (46/360 is well above it), and exclusive is already gated + quota'd.
 	var warns []string
-	cpu, warn, err := sizeField(gucWorkerCPU, cpu, k.WorkerProfileMinCPU, k.WorkerProfileMaxCPU, colocate)
+	if k.AllowClientWorkerProfile {
+		rawCPU := strings.TrimSpace(opts[gucWorkerCPU])
+		rawMem := strings.TrimSpace(opts[gucWorkerMemory])
+		rawTTL := strings.TrimSpace(opts[gucWorkerTTL])
+
+		if rawCPU != "" {
+			v, warn, err := sizeField(gucWorkerCPU, rawCPU, k.WorkerProfileMinCPU, k.WorkerProfileMaxCPU)
+			if err != nil {
+				return nil, nil, err
+			}
+			cpu = v
+			if warn != "" {
+				warns = append(warns, warn)
+			}
+		}
+		if rawMem != "" {
+			v, warn, err := sizeField(gucWorkerMemory, rawMem, k.WorkerProfileMinMemory, k.WorkerProfileMaxMemory)
+			if err != nil {
+				return nil, nil, err
+			}
+			mem = v
+			if warn != "" {
+				warns = append(warns, warn)
+			}
+		}
+		if rawTTL != "" {
+			v, warn, err := ttlField(rawTTL, k.WorkerMaxTTL)
+			if err != nil {
+				return nil, nil, err
+			}
+			ttl = v
+			if warn != "" {
+				warns = append(warns, warn)
+			}
+		}
+	}
+
+	// Normalize the (possibly default) sizes so reuse-matching is canonical
+	// (e.g. "16Gi" vs "16384Mi" compare equal once normalized).
+	cpuN, _, err := sizeField(gucWorkerCPU, cpu, "", "")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("invalid default worker cpu: %w", err)
 	}
-	if warn != "" {
-		warns = append(warns, warn)
-	}
-	mem, warn, err = sizeField(gucWorkerMemory, mem, k.WorkerProfileMinMemory, k.WorkerProfileMaxMemory, colocate)
+	memN, _, err := sizeField(gucWorkerMemory, mem, "", "")
 	if err != nil {
-		return nil, nil, err
-	}
-	if warn != "" {
-		warns = append(warns, warn)
+		return nil, nil, fmt.Errorf("invalid default worker memory: %w", err)
 	}
 
-	// Guaranteed-QoS safety: a colocated (bin-packed) pod must carry explicit
-	// non-empty resources, or it would schedule BestEffort and be first to OOM
-	// under bin-packing. The colocate defaults guarantee this; this guards a
-	// misconfigured deployment (colocated defaults unset).
-	if colocate && (cpu == "" || mem == "") {
-		return nil, nil, fmt.Errorf("colocated workers require both cpu and memory; set %s/%s or configure colocated defaults", gucWorkerCPU, gucWorkerMemory)
-	}
-
-	// Normalizes to the default exclusive profile -> return the nil sentinel so it
-	// matches legacy/default workers rather than forming a distinct key.
-	if cpu == "" && mem == "" && !colocate {
-		return nil, warns, nil
-	}
-
-	return &WorkerProfile{CPU: cpu, Memory: mem, Colocate: colocate}, warns, nil
+	return &WorkerProfile{CPU: cpuN, Memory: memN, TTL: ttl}, warns, nil
 }
 
-// sizeField normalizes a client-supplied size and, when clamp is set, bounds it
-// into [min,max], returning a human-readable warning if it was capped. An empty
-// raw value passes through unchanged (=> pool-global request).
-func sizeField(name, raw, min, max string, clamp bool) (normalized, warn string, err error) {
+// sizeField normalizes a client-supplied size and, when min/max are set, bounds
+// it into [min,max], returning a human-readable warning if it was capped. A
+// negative/zero or unparseable value errors.
+func sizeField(name, raw, min, max string) (normalized, warn string, err error) {
 	if raw == "" {
 		return "", "", nil
 	}
@@ -133,23 +106,37 @@ func sizeField(name, raw, min, max string, clamp bool) (normalized, warn string,
 	if q.Sign() <= 0 {
 		return "", "", fmt.Errorf("%s: quantity %q must be positive", name, raw)
 	}
-	if clamp {
-		capped := false
-		if min != "" {
-			if lo, e := resource.ParseQuantity(min); e == nil && q.Cmp(lo) < 0 {
-				q, capped = lo, true
-			}
-		}
-		if max != "" {
-			if hi, e := resource.ParseQuantity(max); e == nil && q.Cmp(hi) > 0 {
-				q, capped = hi, true
-			}
-		}
-		if capped {
-			warn = fmt.Sprintf("%s %q clamped to %q", name, raw, q.String())
+	capped := false
+	if min != "" {
+		if lo, e := resource.ParseQuantity(min); e == nil && q.Cmp(lo) < 0 {
+			q, capped = lo, true
 		}
 	}
+	if max != "" {
+		if hi, e := resource.ParseQuantity(max); e == nil && q.Cmp(hi) > 0 {
+			q, capped = hi, true
+		}
+	}
+	if capped {
+		warn = fmt.Sprintf("%s %q clamped to %q", name, raw, q.String())
+	}
 	return q.String(), warn, nil
+}
+
+// ttlField parses a worker TTL (Go duration) and clamps it to [0,maxTTL] when
+// maxTTL > 0. ttl=0 means "retire as soon as the last query finishes".
+func ttlField(raw string, maxTTL time.Duration) (time.Duration, string, error) {
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, "", fmt.Errorf("%s: invalid duration %q", gucWorkerTTL, raw)
+	}
+	if d < 0 {
+		return 0, "", fmt.Errorf("%s: duration %q must be >= 0", gucWorkerTTL, raw)
+	}
+	if maxTTL > 0 && d > maxTTL {
+		return maxTTL, fmt.Sprintf("%s %q clamped to %q", gucWorkerTTL, raw, maxTTL.String()), nil
+	}
+	return d, "", nil
 }
 
 func firstNonEmpty(a, b string) string {

--- a/controlplane/worker_profile_test.go
+++ b/controlplane/worker_profile_test.go
@@ -1,55 +1,49 @@
 package controlplane
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-// wpBoolPtr is a small helper for tier specs.
-func wpBoolPtr(b bool) *bool { return &b }
-
-// newProfileTestCP builds a ControlPlane whose K8s config enables the
-// connection-string worker-profile feature with the prod-shaped policy.
-func newProfileTestCP() *ControlPlane {
+// newSizingTestCP builds a ControlPlane whose K8s config enables client worker
+// sizing with a prod-shaped clamp policy and explicit defaults.
+func newSizingTestCP() *ControlPlane {
 	return &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{
-		AllowClientWorkerProfile:     true,
-		AllowClientExclusiveNode:     false,
-		ColocatedWorkerCPURequest:    "4",
-		ColocatedWorkerMemoryRequest: "16Gi",
-		ColocatedWorkerNodeSelector:  `{"posthog.com/nodepool":"duckgres-workers-colocated"}`,
-		WorkerProfileMinCPU:          "1",
-		WorkerProfileMaxCPU:          "16",
-		WorkerProfileMinMemory:       "4Gi",
-		WorkerProfileMaxMemory:       "64Gi",
-		WorkerTiers: map[string]WorkerProfileSpec{
-			"backfill": {CPU: "4", Memory: "16Gi", Colocate: wpBoolPtr(true)},
-			"heavy":    {Colocate: wpBoolPtr(false)},
-		},
+		AllowClientWorkerProfile: true,
+		WorkerCPURequest:         "8",
+		WorkerMemoryRequest:      "16Gi",
+		WorkerProfileMinCPU:      "1",
+		WorkerProfileMaxCPU:      "16",
+		WorkerProfileMinMemory:   "4Gi",
+		WorkerProfileMaxMemory:   "64Gi",
+		WorkerMaxTTL:             time.Hour,
 	}}}
 }
 
-func TestResolveWorkerProfile(t *testing.T) {
+func TestResolveWorkerProfileSizing(t *testing.T) {
+	cp := newSizingTestCP()
 	tests := []struct {
 		name     string
 		opts     map[string]string
-		wantNil  bool // expect the default (nil) profile
-		wantKey  string
+		wantKey  string // CPU|Memory|Colocate
+		wantTTL  time.Duration
 		wantErr  bool
 		wantWarn bool
 	}{
-		{name: "no opts -> default", opts: map[string]string{}, wantNil: true},
-		{name: "unrelated opts -> default", opts: map[string]string{"search_path": "iceberg.public"}, wantNil: true},
-		{name: "colocate true, no size -> defaults 4/16", opts: map[string]string{gucColocate: "true"}, wantKey: "4|16Gi|true"},
-		{name: "inline size colocated", opts: map[string]string{gucColocate: "true", gucWorkerCPU: "8", gucWorkerMemory: "48Gi"}, wantKey: "8|48Gi|true"},
-		{name: "tier alias backfill", opts: map[string]string{gucWorkerTier: "backfill"}, wantKey: "4|16Gi|true"},
-		{name: "unknown tier -> error", opts: map[string]string{gucWorkerTier: "nope"}, wantErr: true},
-		{name: "explicit colocate=false disallowed -> error", opts: map[string]string{gucColocate: "false"}, wantErr: true},
-		{name: "tier heavy (colocate=false) disallowed -> error", opts: map[string]string{gucWorkerTier: "heavy"}, wantErr: true},
-		{name: "invalid colocate -> error", opts: map[string]string{gucColocate: "maybe"}, wantErr: true},
-		{name: "cpu over max -> clamp+warn", opts: map[string]string{gucColocate: "true", gucWorkerCPU: "64", gucWorkerMemory: "16Gi"}, wantKey: "16|16Gi|true", wantWarn: true},
-		{name: "mem under min -> clamp+warn", opts: map[string]string{gucColocate: "true", gucWorkerCPU: "4", gucWorkerMemory: "1Gi"}, wantKey: "4|4Gi|true", wantWarn: true},
-		{name: "zero cpu -> error", opts: map[string]string{gucColocate: "true", gucWorkerCPU: "0", gucWorkerMemory: "16Gi"}, wantErr: true},
-		{name: "inline overrides tier", opts: map[string]string{gucWorkerTier: "backfill", gucWorkerCPU: "8", gucWorkerMemory: "48Gi"}, wantKey: "8|48Gi|true"},
+		{name: "no opts -> defaults", opts: map[string]string{}, wantKey: "8|16Gi|false", wantTTL: defaultWorkerTTL},
+		{name: "unrelated opts -> defaults", opts: map[string]string{"search_path": "iceberg.public"}, wantKey: "8|16Gi|false", wantTTL: defaultWorkerTTL},
+		{name: "client cpu+mem", opts: map[string]string{gucWorkerCPU: "4", gucWorkerMemory: "32Gi"}, wantKey: "4|32Gi|false", wantTTL: defaultWorkerTTL},
+		{name: "client ttl", opts: map[string]string{gucWorkerTTL: "5m"}, wantKey: "8|16Gi|false", wantTTL: 5 * time.Minute},
+		{name: "cpu over max -> clamp+warn", opts: map[string]string{gucWorkerCPU: "64"}, wantKey: "16|16Gi|false", wantTTL: defaultWorkerTTL, wantWarn: true},
+		{name: "mem under min -> clamp+warn", opts: map[string]string{gucWorkerMemory: "1Gi"}, wantKey: "8|4Gi|false", wantTTL: defaultWorkerTTL, wantWarn: true},
+		{name: "ttl over max -> clamp+warn", opts: map[string]string{gucWorkerTTL: "24h"}, wantKey: "8|16Gi|false", wantTTL: time.Hour, wantWarn: true},
+		{name: "cpu normalized", opts: map[string]string{gucWorkerCPU: "4000m"}, wantKey: "4|16Gi|false", wantTTL: defaultWorkerTTL},
+		{name: "zero cpu -> error", opts: map[string]string{gucWorkerCPU: "0"}, wantErr: true},
+		{name: "bad mem -> error", opts: map[string]string{gucWorkerMemory: "lots"}, wantErr: true},
+		{name: "bad ttl -> error", opts: map[string]string{gucWorkerTTL: "soon"}, wantErr: true},
+		{name: "negative ttl -> error", opts: map[string]string{gucWorkerTTL: "-5m"}, wantErr: true},
 	}
 
-	cp := newProfileTestCP()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, warns, err := cp.resolveWorkerProfile(tt.opts)
@@ -62,20 +56,17 @@ func TestResolveWorkerProfile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if tt.wantNil {
-				if got != nil {
-					t.Fatalf("expected nil (default) profile, got %s", got.MatchKey())
-				}
-				return
-			}
 			if got == nil {
-				t.Fatalf("expected profile %q, got nil (default)", tt.wantKey)
+				t.Fatal("expected a concrete profile, got nil")
 			}
 			if got.MatchKey() != tt.wantKey {
 				t.Fatalf("MatchKey = %q, want %q", got.MatchKey(), tt.wantKey)
 			}
+			if got.TTL != tt.wantTTL {
+				t.Fatalf("TTL = %s, want %s", got.TTL, tt.wantTTL)
+			}
 			if tt.wantWarn && len(warns) == 0 {
-				t.Fatalf("expected a clamp warning, got none")
+				t.Fatal("expected a clamp warning, got none")
 			}
 			if !tt.wantWarn && len(warns) != 0 {
 				t.Fatalf("unexpected warnings: %v", warns)
@@ -84,78 +75,31 @@ func TestResolveWorkerProfile(t *testing.T) {
 	}
 }
 
-// Gate off: every GUC is ignored and the default profile is returned.
-func TestResolveWorkerProfile_GateOff(t *testing.T) {
-	cp := newProfileTestCP()
+// Gate off: every GUC is ignored and the deployment defaults are returned (never
+// an error, even for garbage values).
+func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
+	cp := newSizingTestCP()
 	cp.cfg.K8s.AllowClientWorkerProfile = false
-	got, _, err := cp.resolveWorkerProfile(map[string]string{gucColocate: "true", gucWorkerTier: "nope"})
+	got, warns, err := cp.resolveWorkerProfile(map[string]string{gucWorkerCPU: "garbage", gucWorkerTTL: "nope"})
 	if err != nil {
 		t.Fatalf("gate off must never error, got %v", err)
 	}
-	if got != nil {
-		t.Fatalf("gate off must return the default (nil) profile, got %s", got.MatchKey())
+	if len(warns) != 0 {
+		t.Fatalf("gate off must not warn, got %v", warns)
+	}
+	if got == nil || got.MatchKey() != "8|16Gi|false" || got.TTL != defaultWorkerTTL {
+		t.Fatalf("gate off must return defaults, got %v / ttl=%v", got, got.TTL)
 	}
 }
 
-// Explicit colocate=false is honored when the deployment allows it, and a colocated
-// node selector is attached only to colocated profiles.
-func TestResolveWorkerProfile_ExclusiveAllowed(t *testing.T) {
-	cp := newProfileTestCP()
-	cp.cfg.K8s.AllowClientExclusiveNode = true
-
-	got, _, err := cp.resolveWorkerProfile(map[string]string{gucColocate: "false", gucWorkerCPU: "32", gucWorkerMemory: "256Gi"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got == nil || got.Colocate {
-		t.Fatalf("expected a non-colocated profile, got %v", got)
-	}
-	if got.MatchKey() != "32|256Gi|false" {
-		t.Fatalf("MatchKey = %q, want %q", got.MatchKey(), "32|256Gi|false")
-	}
-}
-
-// The tier alias and its inline equivalent must produce identical match keys so a
-// worker reserved one way is reusable the other way.
-func TestResolveWorkerProfile_TierEqualsInline(t *testing.T) {
-	cp := newProfileTestCP()
-	viaTier, _, err := cp.resolveWorkerProfile(map[string]string{gucWorkerTier: "backfill"})
+// With no configured default size, the built-in 8/16Gi/20m applies.
+func TestResolveWorkerProfileSizing_BuiltinDefaults(t *testing.T) {
+	cp := &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{AllowClientWorkerProfile: true}}}
+	got, _, err := cp.resolveWorkerProfile(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	viaInline, _, err := cp.resolveWorkerProfile(map[string]string{gucColocate: "true", gucWorkerCPU: "4", gucWorkerMemory: "16Gi"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !viaTier.Equal(viaInline) {
-		t.Fatalf("tier %q != inline %q", viaTier.MatchKey(), viaInline.MatchKey())
-	}
-}
-
-// Quantity normalization collapses equivalent spellings so they match.
-func TestResolveWorkerProfile_Normalization(t *testing.T) {
-	cp := newProfileTestCP()
-	a, _, err := cp.resolveWorkerProfile(map[string]string{gucColocate: "true", gucWorkerCPU: "4000m", gucWorkerMemory: "16Gi"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if a.MatchKey() != "4|16Gi|true" {
-		t.Fatalf("MatchKey = %q, want %q (4000m should normalize to 4)", a.MatchKey(), "4|16Gi|true")
-	}
-}
-
-// MatchKey/Equal must be nil-safe and treat nil as the default profile.
-func TestWorkerProfileMatchKeyNilSafe(t *testing.T) {
-	var nilProfile *WorkerProfile
-	if nilProfile.MatchKey() != "||false" {
-		t.Fatalf("nil MatchKey = %q, want %q", nilProfile.MatchKey(), "||false")
-	}
-	def := &WorkerProfile{}
-	if !nilProfile.Equal(def) || !def.Equal(nilProfile) {
-		t.Fatalf("nil profile must equal the zero/default profile")
-	}
-	colo := &WorkerProfile{CPU: "4", Memory: "16Gi", Colocate: true}
-	if nilProfile.Equal(colo) {
-		t.Fatalf("nil (default) profile must not equal a colocated profile")
+	if got.CPU != defaultWorkerCPU || got.Memory != defaultWorkerMemory || got.TTL != defaultWorkerTTL {
+		t.Fatalf("built-in defaults = %s/%s/%s, want %s/%s/%s", got.CPU, got.Memory, got.TTL, defaultWorkerCPU, defaultWorkerMemory, defaultWorkerTTL)
 	}
 }

--- a/controlplane/worker_state.go
+++ b/controlplane/worker_state.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"fmt"
 	"strconv"
+	"time"
 )
 
 // WorkerLifecycleState models the shared warm-worker lifecycle introduced for
@@ -36,9 +37,10 @@ const (
 // is DERIVED from Colocate plus the pool's config at spawn time, so the
 // reserved-spawn path can reconstruct everything it needs from the stored record.
 type WorkerProfile struct {
-	CPU      string // normalized k8s quantity (e.g. "4"); "" => pool-global request
-	Memory   string // normalized k8s quantity (e.g. "16Gi"); "" => pool-global request
-	Colocate bool   // true => bin-pack (exclusiveNode=false); false => exclusive node
+	CPU      string        // normalized k8s quantity (e.g. "8"); the worker's CPU size
+	Memory   string        // normalized k8s quantity (e.g. "16Gi"); the worker's memory size
+	Colocate bool          // deprecated: always false; bin-pack/colocate is being removed
+	TTL      time.Duration // how long the worker stays hot-idle after its last query (reset per query); not part of MatchKey
 }
 
 // MatchKey is the identity used to decide whether an existing worker can serve a

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -1,0 +1,132 @@
+# Worker TTL pool: one pool, size-on-request, TTL lifecycle, node headroom
+
+Status: in progress (branch `ben/duckgres-worker-ttl-pool`). Scope: **remote/k8s
+backend only** (`-tags kubernetes`, `OrgReservedPool` / `K8sWorkerPool`).
+Standalone and process backends are unchanged.
+
+## Goal
+
+Replace the warm-pool + worker-profile/colocate machinery with a simple,
+predictable model:
+
+- A worker pod runs **one query session at a time** (already true) and has only
+  two live states: **hot-active** (a session is running) and **hot-idle** (no
+  session, alive until its TTL expires). No warm/neutral pool, no
+  reserved/activating warm slots kept around speculatively.
+- A connection asks for a worker **size** (`cpu`, `memory`) and a **ttl**. On a
+  query:
+  - if the org already has a **hot-idle** worker with cpu **and** memory ≥ the
+    request → reuse it (smallest-fitting one);
+  - else → spawn a fresh worker of the requested size.
+- **TTL** = how long a worker stays alive after its last query finishes. Every
+  query resets the worker's TTL to its initial value. The user picks it (and pays
+  for the idle time).
+- A **headroom controller** in the control plane keeps a configurable % of
+  cluster-allocatable CPU+memory free by running low-priority placeholder
+  ("pause") pods, so a real worker spawn schedules immediately (preempting the
+  placeholders) instead of waiting on a fresh Karpenter node.
+
+Removed concepts: warm pool / neutral pool / shared-warm-target, worker
+**profiles** and **tiers**, the **colocate** flag and the colocated nodepool /
+quota / warm-shapes, per-image warm reconcilers.
+
+Out of scope (future): per-org reserved minimum capacity (e.g. "portola always
+wants 10×46cpu/360GB warm"). Hooks left where it would slot in.
+
+## Request grammar (libpq `options`, parsed like the existing GUCs)
+
+```
+options=-c duckgres.worker_cpu=8 -c duckgres.worker_memory=16Gi -c duckgres.worker_ttl=20m
+```
+
+- `duckgres.worker_cpu` — integer cores. Default **8**.
+- `duckgres.worker_memory` — k8s quantity. Default **16Gi**.
+- `duckgres.worker_ttl` — Go duration. Default **20m**.
+- Absent GUCs → defaults. Gated behind `AllowClientWorkerSizing`; sizes clamped
+  to `[min,max]` and ttl to `[0,maxTTL]` per deployment (out-of-range → clamp +
+  warn). Gate off → every request uses the defaults.
+
+`duckgres.colocate` / `worker_tier` are removed (unknown GUCs are ignored, so old
+clients that still send them degrade to defaults rather than erroring).
+
+## Worker identity / match
+
+A worker carries its size `{CPU cores, Memory bytes}` and `TTL`. Match for reuse:
+same org, lifecycle hot-idle, `worker.CPU >= req.CPU && worker.Mem >= req.Mem`.
+Pick the smallest-fitting (least CPU then least memory) to avoid pinning a big
+worker on a small query. On reuse, the worker's TTL is reset to the request's
+ttl and it transitions hot-idle → hot-active.
+
+DuckDB limits for the single session derive from the worker's **actual** size
+(75% of pod memory, all cores) — unchanged from `workerDuckDBLimits`, now keyed
+off size not profile.
+
+## Lifecycle
+
+```
+(none) --spawn(size)--> Activating --activated--> Hot(active, 1 session)
+Hot --session ends--> HotIdle (deadline = now + ttl)
+HotIdle --new query (size fits)--> Hot (deadline cleared, ttl reset on session end)
+HotIdle --deadline passed--> Retired (pod deleted, graceful drain)
+Hot/HotIdle --crash/evict--> Lost --> removed
+```
+
+The reaper (existing `idleReaper`, 1-min tick or faster) retires hot-idle workers
+whose `idleDeadline` (last-session-end + ttl) has passed. TTL is stored per
+worker (set at spawn, reset on each session end). No global `idleTimeout` knob
+governs it anymore — ttl is per worker.
+
+## Acquire path (consolidated `OrgReservedPool`)
+
+1. Reuse: smallest-fitting hot-idle org worker with size ≥ request → bump to
+   hot-active, return. (Ungated fast path; only reuses org-owned workers.)
+2. Else, under the FIFO gate (anti-snatch, kept): spawn a new worker of the
+   requested size for the org; activate; return. Bounded by ctx; clear org-cap
+   error if a per-org worker cap is hit (cap retained, now size-agnostic count).
+
+`ReserveSharedWorker` / `ClaimIdleWorker` / `ClaimHotIdleWorker` warm-claim
+machinery and the neutral-warm DB rows collapse to: "is there a reusable hot-idle
+worker for this org of sufficient size?" (in-memory + runtime-store query), else
+spawn. The runtime store keeps tracking workers (for cross-CP visibility and
+crash recovery) but the warm/neutral slot concept is gone.
+
+## Headroom controller (new)
+
+A control-plane loop (started in `SetupMultiTenant`, leader-gated) that:
+
+- reads node allocatable CPU+memory (k8s API, the worker nodepool) and current
+  worker+placeholder usage;
+- maintains low-priority **placeholder pods** so that ≥ `HeadroomPercent` of
+  cluster-allocatable CPU and memory is held by placeholders (preemptible);
+- placeholder pods use a PriorityClass **below** the worker PriorityClass, so a
+  real worker spawn preempts them and schedules immediately; the evicted
+  placeholder triggers Karpenter to add a node in the background.
+
+Config: `DUCKGRES_K8S_HEADROOM_PERCENT` (0 = disabled), placeholder pod size,
+the two PriorityClass names. Manifests add the PriorityClasses.
+
+## Config knobs (env-only K8s, per existing convention)
+
+New: `DUCKGRES_K8S_ALLOW_CLIENT_WORKER_SIZING`, `DUCKGRES_K8S_WORKER_DEFAULT_CPU`
+(8), `_DEFAULT_MEMORY` (16Gi), `_DEFAULT_TTL` (20m),
+`_WORKER_MIN_CPU`/`_MAX_CPU`/`_MIN_MEMORY`/`_MAX_MEMORY`/`_MAX_TTL`,
+`_HEADROOM_PERCENT`, `_PLACEHOLDER_*`.
+
+Removed: all `DUCKGRES_K8S_*COLOCATED*`, `*WORKER_PROFILE*`, `*WORKER_TIERS*`,
+`*ALLOW_CLIENT_WORKER_PROFILE*`, `*ALLOW_CLIENT_EXCLUSIVE_NODE*`,
+`*SHARED_WARM_TARGET*`.
+
+## Testing
+
+- Unit: GUC parse/clamp/default; smallest-fitting reuse vs spawn; TTL reset on
+  query + reap after deadline; headroom controller target math (placeholder
+  count from allocatable + percent); gate/clamp.
+- e2e `harness.sh`: a query with `worker_cpu/memory/ttl` lands on a worker of
+  that size; a second query of a smaller size reuses it; after ttl the worker is
+  reaped; one-session-per-worker still holds; placeholder pods exist at the
+  configured headroom. Verified on cnpg + ext backends.
+
+## Rollout
+
+Build arm64 control-plane + worker images, push to ECR, deploy to **mw-dev only**
+(`tests/e2e-mw-dev/run.sh`), run harness, iterate. Never prod.


### PR DESCRIPTION
First slice of the worker-pool rebuild (remote/k8s backend only). Lands the **client-facing sizing knobs + the design doc**; the deeper pool/TTL/headroom refactor follows in subsequent PRs (it's a coupled configstore-migration change — see "Follow-up").

## What's in this PR

- **Design doc** `docs/design/worker-ttl-pool.md` — the full plan: one pool, size-on-request, TTL lifecycle, node-headroom controller; warm-pool/colocate/profiles removed; per-org reserved minimum out of scope.
- **New request grammar** (libpq `options` GUCs), replacing `colocate`/`worker_tier`/profile selection:
  - `duckgres.worker_cpu`, `duckgres.worker_memory`, `duckgres.worker_ttl`.
  - Every request resolves to a **concrete** worker size + idle TTL — no more nil=default sentinel. Default **8 CPU / 16 GiB / 20 min** (deployment `WorkerCPURequest`/`WorkerMemoryRequest` else built-in).
  - cpu/mem clamped to `[min,max]`, ttl to `[0,WorkerMaxTTL]`; out-of-range clamps with a warning, garbage errors the connect. Gated by `AllowClientWorkerProfile` (gate off ⇒ defaults, never errors).
  - The `colocate` / `worker_tier` GUCs are dropped (a stale client still sending them degrades to defaults instead of erroring).
- `WorkerProfile` gains a `TTL` field (not part of `MatchKey`); `Colocate` is kept temporarily (always false) and removed alongside the rest of the colocated/warm plumbing in the follow-up.
- Rewrote `worker_profile_test.go` for the new resolver (defaults, gate-off, client cpu/mem/ttl, clamp+warn, normalization, error cases).

## Behavior after this PR

Coherent and deployable: requests get concrete sizes, reuse on **exact-size** match, spawn otherwise. Reaping still uses the existing global idle/hot-idle TTL. The *new* semantics (per-worker TTL, smallest-fitting ≥ reuse, warm-pool removal, headroom pods) are **not** in this PR.

## Follow-up (next PRs)

Per the design doc, all coupled to the configstore claim machinery:
1. Persist per-worker TTL in `worker_records`; janitor reaps per-row `hot_idle_since + ttl < now`; `ClaimHotIdleWorker` match → smallest-fitting `cpu>=req && mem>=req`; drop the neutral/warm-slot rows.
2. Merge `K8sWorkerPool` warm machinery into the per-org hot-idle-or-spawn path; delete colocate/profiles/tiers/warm-shapes/`SharedWarmTarget`.
3. Headroom controller: leader-gated CP loop maintaining low-priority placeholder pods to a configurable % of cluster allocatable; PriorityClasses in `k8s/`.
4. e2e harness assertions + mw-dev deploy/verify.

## Verification

- `go build ./... && go build -tags kubernetes ./...`
- `go test -tags kubernetes ./controlplane/` and `go test ./duckdbservice/` pass.
- No e2e harness assertion in this slice (no runtime-behavior change beyond the request-parse path; the harness assertion lands with the lifecycle/TTL slice that changes cluster behavior). Flagging per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)