### PR TITLE
fix(worker-sizing): no-sizing request returns nil default profile (unbreak warm-pool deploys)

### DIFF
--- a/controlplane/worker_profile.go
+++ b/controlplane/worker_profile.go
@@ -25,61 +25,75 @@ const (
 )
 
 // resolveWorkerProfile turns the client's worker_cpu / worker_memory / worker_ttl
-// startup options into a concrete *WorkerProfile (a worker size + hot-idle TTL).
+// startup options into a *WorkerProfile (a worker size + hot-idle TTL), or nil.
 //
-// Every request resolves to a concrete size: the deployment default
-// (WorkerCPURequest / WorkerMemoryRequest, defaultWorkerTTL) when a field is
-// unset or client sizing is gated off, otherwise the clamped client value.
-// Client cpu/mem are clamped to [min,max] and ttl to [0,maxTTL]; an out-of-range
-// value is clamped with a warning, an unparseable/negative one errors (rejecting
-// the connection). Returns (profile, warns, nil) on success.
+//   - (nil, nil, nil)  => the DEFAULT profile: gate off, or no sizing GUC set.
+//     nil is the sentinel that matches the neutral/default worker pool (the warm
+//     pool spawns neutral workers with no profile), so default traffic reuses
+//     warm workers exactly as before. The default worker SIZE then comes from the
+//     pool-global WorkerCPURequest/MemoryRequest, not from this profile.
+//   - (profile, warns, nil) => the client explicitly requested a size/ttl. cpu/mem
+//     default to the pool-global request (else built-in 8/16Gi) for any field the
+//     client omitted, clamped to [min,max]; ttl to [0,WorkerMaxTTL], default 20m.
+//   - (nil, nil, err) => an unparseable/negative value (rejects the connection).
+//
+// IMPORTANT: a no-sizing request MUST return nil, not a concrete-default profile.
+// Returning concrete here regresses warm-pool reuse — the concrete key (e.g.
+// "8|16Gi|false") never matches a neutral warm worker's key ("||false"), so the
+// request can neither reuse a warm worker nor be served by warm replenishment
+// (which spawns neutral workers), and fails with "no warm worker available".
+// Concrete sizing only becomes fully functional once the warm pool is removed
+// (see docs/design/worker-ttl-pool.md) — until then it is opt-in via the gate.
 func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerProfile, []string, error) {
 	k := cp.cfg.K8s
+	if !k.AllowClientWorkerProfile {
+		return nil, nil, nil
+	}
+
+	rawCPU := strings.TrimSpace(opts[gucWorkerCPU])
+	rawMem := strings.TrimSpace(opts[gucWorkerMemory])
+	rawTTL := strings.TrimSpace(opts[gucWorkerTTL])
+	if rawCPU == "" && rawMem == "" && rawTTL == "" {
+		return nil, nil, nil // no client sizing -> default (nil) profile
+	}
 
 	cpu := firstNonEmpty(strings.TrimSpace(k.WorkerCPURequest), defaultWorkerCPU)
 	mem := firstNonEmpty(strings.TrimSpace(k.WorkerMemoryRequest), defaultWorkerMemory)
 	ttl := defaultWorkerTTL
 
 	var warns []string
-	if k.AllowClientWorkerProfile {
-		rawCPU := strings.TrimSpace(opts[gucWorkerCPU])
-		rawMem := strings.TrimSpace(opts[gucWorkerMemory])
-		rawTTL := strings.TrimSpace(opts[gucWorkerTTL])
-
-		if rawCPU != "" {
-			v, warn, err := sizeField(gucWorkerCPU, rawCPU, k.WorkerProfileMinCPU, k.WorkerProfileMaxCPU)
-			if err != nil {
-				return nil, nil, err
-			}
-			cpu = v
-			if warn != "" {
-				warns = append(warns, warn)
-			}
+	if rawCPU != "" {
+		v, warn, err := sizeField(gucWorkerCPU, rawCPU, k.WorkerProfileMinCPU, k.WorkerProfileMaxCPU)
+		if err != nil {
+			return nil, nil, err
 		}
-		if rawMem != "" {
-			v, warn, err := sizeField(gucWorkerMemory, rawMem, k.WorkerProfileMinMemory, k.WorkerProfileMaxMemory)
-			if err != nil {
-				return nil, nil, err
-			}
-			mem = v
-			if warn != "" {
-				warns = append(warns, warn)
-			}
+		cpu = v
+		if warn != "" {
+			warns = append(warns, warn)
 		}
-		if rawTTL != "" {
-			v, warn, err := ttlField(rawTTL, k.WorkerMaxTTL)
-			if err != nil {
-				return nil, nil, err
-			}
-			ttl = v
-			if warn != "" {
-				warns = append(warns, warn)
-			}
+	}
+	if rawMem != "" {
+		v, warn, err := sizeField(gucWorkerMemory, rawMem, k.WorkerProfileMinMemory, k.WorkerProfileMaxMemory)
+		if err != nil {
+			return nil, nil, err
+		}
+		mem = v
+		if warn != "" {
+			warns = append(warns, warn)
+		}
+	}
+	if rawTTL != "" {
+		v, warn, err := ttlField(rawTTL, k.WorkerMaxTTL)
+		if err != nil {
+			return nil, nil, err
+		}
+		ttl = v
+		if warn != "" {
+			warns = append(warns, warn)
 		}
 	}
 
-	// Normalize the (possibly default) sizes so reuse-matching is canonical
-	// (e.g. "16Gi" vs "16384Mi" compare equal once normalized).
+	// Normalize the sizes so reuse-matching is canonical ("16Gi" == "16384Mi").
 	cpuN, _, err := sizeField(gucWorkerCPU, cpu, "", "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid default worker cpu: %w", err)

--- a/controlplane/worker_profile_test.go
+++ b/controlplane/worker_profile_test.go
@@ -25,15 +25,16 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 	tests := []struct {
 		name     string
 		opts     map[string]string
-		wantKey  string // CPU|Memory|Colocate
+		wantNil  bool // expect the default (nil) profile — matches the neutral warm pool
+		wantKey  string // CPU|Memory|Colocate (only when !wantNil)
 		wantTTL  time.Duration
 		wantErr  bool
 		wantWarn bool
 	}{
-		{name: "no opts -> defaults", opts: map[string]string{}, wantKey: "8|16Gi|false", wantTTL: defaultWorkerTTL},
-		{name: "unrelated opts -> defaults", opts: map[string]string{"search_path": "iceberg.public"}, wantKey: "8|16Gi|false", wantTTL: defaultWorkerTTL},
+		{name: "no opts -> default (nil)", opts: map[string]string{}, wantNil: true},
+		{name: "unrelated opts -> default (nil)", opts: map[string]string{"search_path": "iceberg.public"}, wantNil: true},
 		{name: "client cpu+mem", opts: map[string]string{gucWorkerCPU: "4", gucWorkerMemory: "32Gi"}, wantKey: "4|32Gi|false", wantTTL: defaultWorkerTTL},
-		{name: "client ttl", opts: map[string]string{gucWorkerTTL: "5m"}, wantKey: "8|16Gi|false", wantTTL: 5 * time.Minute},
+		{name: "client ttl only -> concrete w/ default size", opts: map[string]string{gucWorkerTTL: "5m"}, wantKey: "8|16Gi|false", wantTTL: 5 * time.Minute},
 		{name: "cpu over max -> clamp+warn", opts: map[string]string{gucWorkerCPU: "64"}, wantKey: "16|16Gi|false", wantTTL: defaultWorkerTTL, wantWarn: true},
 		{name: "mem under min -> clamp+warn", opts: map[string]string{gucWorkerMemory: "1Gi"}, wantKey: "8|4Gi|false", wantTTL: defaultWorkerTTL, wantWarn: true},
 		{name: "ttl over max -> clamp+warn", opts: map[string]string{gucWorkerTTL: "24h"}, wantKey: "8|16Gi|false", wantTTL: time.Hour, wantWarn: true},
@@ -56,8 +57,14 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil (default) profile, got %s", got.MatchKey())
+				}
+				return
+			}
 			if got == nil {
-				t.Fatal("expected a concrete profile, got nil")
+				t.Fatalf("expected concrete profile %q, got nil", tt.wantKey)
 			}
 			if got.MatchKey() != tt.wantKey {
 				t.Fatalf("MatchKey = %q, want %q", got.MatchKey(), tt.wantKey)
@@ -75,8 +82,8 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 	}
 }
 
-// Gate off: every GUC is ignored and the deployment defaults are returned (never
-// an error, even for garbage values).
+// Gate off: every GUC is ignored and the default (nil) profile is returned (never
+// an error, even for garbage values) — preserving warm-pool reuse.
 func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
 	cp := newSizingTestCP()
 	cp.cfg.K8s.AllowClientWorkerProfile = false
@@ -87,19 +94,34 @@ func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
 	if len(warns) != 0 {
 		t.Fatalf("gate off must not warn, got %v", warns)
 	}
-	if got == nil || got.MatchKey() != "8|16Gi|false" || got.TTL != defaultWorkerTTL {
-		t.Fatalf("gate off must return defaults, got %v / ttl=%v", got, got.TTL)
+	if got != nil {
+		t.Fatalf("gate off must return the default (nil) profile, got %s", got.MatchKey())
 	}
 }
 
-// With no configured default size, the built-in 8/16Gi/20m applies.
-func TestResolveWorkerProfileSizing_BuiltinDefaults(t *testing.T) {
-	cp := &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{AllowClientWorkerProfile: true}}}
+// A no-sizing request must return the nil default sentinel so it matches the
+// neutral warm pool (regression guard: returning a concrete-default profile here
+// broke worker acquisition on a warm-pool-enabled deploy).
+func TestResolveWorkerProfileSizing_NoSizingIsNil(t *testing.T) {
+	cp := newSizingTestCP()
 	got, _, err := cp.resolveWorkerProfile(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.CPU != defaultWorkerCPU || got.Memory != defaultWorkerMemory || got.TTL != defaultWorkerTTL {
-		t.Fatalf("built-in defaults = %s/%s/%s, want %s/%s/%s", got.CPU, got.Memory, got.TTL, defaultWorkerCPU, defaultWorkerMemory, defaultWorkerTTL)
+	if got != nil {
+		t.Fatalf("no-sizing request must return nil (default), got %s", got.MatchKey())
+	}
+}
+
+// When the client DOES set sizing and no default size is configured, the built-in
+// 8/16Gi/20m applies for the omitted fields.
+func TestResolveWorkerProfileSizing_BuiltinDefaults(t *testing.T) {
+	cp := &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{AllowClientWorkerProfile: true}}}
+	got, _, err := cp.resolveWorkerProfile(map[string]string{gucWorkerTTL: "1m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.CPU != defaultWorkerCPU || got.Memory != defaultWorkerMemory || got.TTL != time.Minute {
+		t.Fatalf("built-in defaults = %v, want %s/%s/1m", got, defaultWorkerCPU, defaultWorkerMemory)
 	}
 }


### PR DESCRIPTION
## Incident

After #692 deployed to mw-dev, **default connections failed**: `FATAL: no warm Duckgres worker is currently available`. Confirmed by connecting to a dev duckling — connect timed out and the warm pool churned neutral workers.

## Root cause

#692 made `resolveWorkerProfile` resolve **every** request to a concrete profile (e.g. `8|16Gi|false`), including no-GUC / gate-off traffic. On a deploy with `SHARED_WARM_TARGET>0` the warm pool spawns **neutral** workers (no profile, key `||false`). The concrete-default key never matches `||false`, so a default request can neither reuse a warm worker nor be satisfied by warm replenishment (which only spawns neutral workers) → "no warm worker available".

The per-PR e2e didn't catch it because it runs `SHARED_WARM_TARGET=0`; the standing deploy runs `>0`.

## Fix forward

`resolveWorkerProfile` returns **nil** (the default sentinel that matches the neutral warm pool) when client sizing is gated off **or** no `worker_cpu`/`worker_memory`/`worker_ttl` GUC is set — restoring exact pre-#692 default behavior. A concrete profile is returned **only** when the client explicitly opts in (gate on + a sizing GUC). The default worker size keeps coming from the pool-global `WorkerCPURequest`/`MemoryRequest`.

Concrete sizing becomes fully functional only once the warm pool is removed (the follow-up in `docs/design/worker-ttl-pool.md`); until then it's opt-in via the gate.

## Tests

- New regression guard `TestResolveWorkerProfileSizing_NoSizingIsNil` (no-sizing ⇒ nil).
- Updated sizing tests: no-GUC / gate-off ⇒ nil; concrete only on opt-in.
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass.
- e2e harness can't assert this interaction (needs warm-target>0, which the per-PR CP doesn't run — documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)