### PR TITLE
feat(worker-ttl): persist per-worker TTL + reap hot-idle workers per-row

### DIFF
--- a/controlplane/configstore/lifecycle_store.go
+++ b/controlplane/configstore/lifecycle_store.go
@@ -33,8 +33,8 @@ func (cs *ConfigStore) ListOrphanedWorkerSnapshots(before time.Time) ([]WorkerSn
 
 // ListExpiredHotIdleSnapshots is the snapshot-typed variant of
 // ListExpiredHotIdleWorkers used by the janitor's hot-idle TTL reaper.
-func (cs *ConfigStore) ListExpiredHotIdleSnapshots(before time.Time) ([]WorkerSnapshot, error) {
-	records, err := cs.ListExpiredHotIdleWorkers(before)
+func (cs *ConfigStore) ListExpiredHotIdleSnapshots(now time.Time, defaultTTL time.Duration) ([]WorkerSnapshot, error) {
+	records, err := cs.ListExpiredHotIdleWorkers(now, defaultTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -528,10 +528,10 @@ type WorkerLifecycleStats struct {
 
 // WorkerRecord is the durable runtime coordination record for one worker pod.
 type WorkerRecord struct {
-	WorkerID            int         `gorm:"primaryKey" json:"worker_id"`
-	PodName             string      `gorm:"size:255;not null;uniqueIndex" json:"pod_name"`
-	PodUID              string      `gorm:"size:255" json:"pod_uid"`
-	Image               string      `gorm:"size:512;index" json:"image"`
+	WorkerID int    `gorm:"primaryKey" json:"worker_id"`
+	PodName  string `gorm:"size:255;not null;uniqueIndex" json:"pod_name"`
+	PodUID   string `gorm:"size:255" json:"pod_uid"`
+	Image    string `gorm:"size:512;index" json:"image"`
 	// Worker pod-shape profile (connection-string-selected sizing). Empty
 	// CPU/Memory + Colocate=false is the default exclusive profile, so legacy
 	// rows (and warm/neutral workers) read back as the default and stay
@@ -540,7 +540,13 @@ type WorkerRecord struct {
 	ProfileCPU      string `gorm:"size:32;index:idx_worker_profile" json:"profile_cpu"`
 	ProfileMemory   string `gorm:"size:32;index:idx_worker_profile" json:"profile_memory"`
 	ProfileColocate bool   `gorm:"index:idx_worker_profile" json:"profile_colocate"`
-	State           WorkerState `gorm:"size:32;not null;index" json:"state"`
+	// TTLMinutes is how long this worker stays hot-idle after its last query
+	// before the janitor retires it (client-selected duckgres.worker_ttl, rounded
+	// down to whole minutes). 0 = use the deployment's global hot-idle TTL
+	// (default/warm/neutral workers and legacy rows). AutoMigrate adds this
+	// column; no migration file.
+	TTLMinutes          int         `gorm:"default:0" json:"ttl_minutes"`
+	State               WorkerState `gorm:"size:32;not null;index" json:"state"`
 	OrgID               string      `gorm:"size:255;index" json:"org_id"`
 	OwnerCPInstanceID   string      `gorm:"size:255;index" json:"owner_cp_instance_id"`
 	OwnerEpoch          int64       `gorm:"not null" json:"owner_epoch"`

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -867,7 +867,6 @@ func migrateDeltaCatalogDefaultEnabled(db *gorm.DB) error {
 	})
 }
 
-
 func migrateOrgUserPK(db *gorm.DB) error {
 	// Check if the PK already has 2 columns (idempotent)
 	var count int64
@@ -1360,10 +1359,20 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, profi
 
 // ListExpiredHotIdleWorkers returns hot-idle workers whose updated_at timestamp
 // is at or before the given cutoff time.
-func (cs *ConfigStore) ListExpiredHotIdleWorkers(before time.Time) ([]WorkerRecord, error) {
+// ListExpiredHotIdleWorkers returns hot-idle workers whose per-worker TTL has
+// elapsed since they last became idle (updated_at, bumped on the hot->hot_idle
+// transition at session end, so the TTL resets on each query). A worker's
+// ttl_seconds governs it; 0 falls back to defaultTTL (default/warm/neutral and
+// legacy rows).
+func (cs *ConfigStore) ListExpiredHotIdleWorkers(now time.Time, defaultTTL time.Duration) ([]WorkerRecord, error) {
+	defMins := int64(defaultTTL.Minutes())
+	if defMins < 0 {
+		defMins = 0
+	}
 	var workers []WorkerRecord
 	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("state = ? AND updated_at <= ?", WorkerStateHotIdle, before).
+		Where("state = ? AND updated_at + (CASE WHEN COALESCE(ttl_minutes, 0) > 0 THEN ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
+			WorkerStateHotIdle, defMins, now).
 		Find(&workers).Error
 	if err != nil {
 		return nil, fmt.Errorf("list expired hot-idle workers: %w", err)

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -20,7 +20,7 @@ type controlPlaneExpiryStore interface {
 	ExpireDrainingControlPlaneInstances(before time.Time) (int64, error)
 	ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
 	ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerSnapshot, error)
-	ListExpiredHotIdleSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
+	ListExpiredHotIdleSnapshots(now time.Time, defaultTTL time.Duration) ([]configstore.WorkerSnapshot, error)
 	ExpireFlightSessionRecords(before time.Time) (int64, error)
 }
 
@@ -154,8 +154,9 @@ func (j *ControlPlaneJanitor) runOnce() {
 		}
 
 		if j.hotIdleTTL > 0 {
-			cutoff := j.now().Add(-j.hotIdleTTL)
-			expired, err := j.store.ListExpiredHotIdleSnapshots(cutoff)
+			// Per-worker TTL: a worker's ttl_minutes governs its hot-idle life;
+			// hotIdleTTL is the fallback for default/warm/legacy workers (ttl=0).
+			expired, err := j.store.ListExpiredHotIdleSnapshots(j.now(), j.hotIdleTTL)
 			if err != nil {
 				slog.Warn("Janitor failed to list expired hot-idle workers.", "error", err)
 			}
@@ -209,4 +210,3 @@ func (j *ControlPlaneJanitor) runOnce() {
 		j.reconcileHeadroom()
 	}
 }
-

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -94,7 +94,7 @@ func (s *captureControlPlaneExpiryStore) ExpireFlightSessionRecords(before time.
 // by the migrated janitor hot-idle path. The mock wraps the same
 // underlying slice through NewWorkerSnapshot so existing
 // tests can opt into the lifecycle path by setting expiredHotIdleWorkers.
-func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error) {
+func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleSnapshots(now time.Time, defaultTTL time.Duration) ([]configstore.WorkerSnapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.expiredHotIdleWorkers) == 0 {

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -965,6 +965,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 		spawnRecord.ProfileCPU = profile.CPU
 		spawnRecord.ProfileMemory = profile.Memory
 		spawnRecord.ProfileColocate = profile.Colocate
+		spawnRecord.TTLMinutes = int(profile.TTL.Minutes())
 		_ = p.persistWorkerRecord(spawnRecord)
 	}
 
@@ -3921,6 +3922,7 @@ func (p *K8sWorkerPool) workerRecordFor(id int, worker *ManagedWorker, ownerEpoc
 	record.ProfileCPU = worker.profile.CPU
 	record.ProfileMemory = worker.profile.Memory
 	record.ProfileColocate = worker.profile.Colocate
+	record.TTLMinutes = int(worker.profile.TTL.Minutes())
 	if assignment := worker.SharedState().Assignment; assignment != nil {
 		record.OrgID = assignment.OrgID
 	}

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -812,6 +812,56 @@ func TestClaimHotIdleWorkerPostgres(t *testing.T) {
 	}
 }
 
+// Per-worker TTL: ListExpiredHotIdleWorkers retires a hot-idle worker once its
+// own ttl_minutes has elapsed since updated_at (last became idle); ttl=0 falls
+// back to the deployment default; non-hot-idle workers are never returned.
+func TestListExpiredHotIdleWorkersPerWorkerTTL(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	base := time.Now()
+	mk := func(id, ttlMin int, state configstore.WorkerState) {
+		if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			WorkerID:          id,
+			PodName:           fmt.Sprintf("duckgres-worker-ttl-%d", id),
+			State:             state,
+			OrgID:             "analytics",
+			Image:             "duckgres:v2",
+			OwnerCPInstanceID: "cp:boot",
+			OwnerEpoch:        1,
+			LastHeartbeatAt:   base,
+			TTLMinutes:        ttlMin,
+		}); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", id, err)
+		}
+	}
+	mk(1, 0, configstore.WorkerStateHotIdle)   // uses default TTL
+	mk(2, 5, configstore.WorkerStateHotIdle)   // short per-worker TTL
+	mk(3, 120, configstore.WorkerStateHotIdle) // long per-worker TTL
+	mk(4, 1, configstore.WorkerStateHot)       // not hot-idle: never reaped
+
+	// As of base+30m with a 10m default: ttl=0 (default 10m) and ttl=5m have
+	// elapsed; ttl=120m has not; the hot (active) worker is excluded.
+	expired, err := store.ListExpiredHotIdleWorkers(base.Add(30*time.Minute), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
+	}
+	got := map[int]bool{}
+	for _, w := range expired {
+		got[w.WorkerID] = true
+	}
+	if !got[1] {
+		t.Error("ttl=0 worker should expire via the 10m default by base+30m")
+	}
+	if !got[2] {
+		t.Error("ttl=5m worker should expire by base+30m")
+	}
+	if got[3] {
+		t.Error("ttl=120m worker should NOT expire by base+30m")
+	}
+	if got[4] {
+		t.Error("non-hot-idle (hot) worker must never be returned")
+	}
+}
+
 func TestClaimHotIdleWorkerReturnsNoIdleWhenNoHotIdleWorkerExists(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 
@@ -2589,7 +2639,7 @@ func TestRetireHotIdleWorkerRejectsStaleListSnapshotAfterReclaimPostgres(t *test
 		t.Fatalf("UpsertWorkerRecord(hot-idle): %v", err)
 	}
 
-	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour))
+	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour), time.Minute)
 	if err != nil {
 		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
 	}
@@ -2651,7 +2701,7 @@ func TestRetireHotIdleWorkerRejectsStaleListSnapshotAfterTouchPostgres(t *testin
 		t.Fatalf("UpsertWorkerRecord(hot-idle): %v", err)
 	}
 
-	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour))
+	expired, err := store.ListExpiredHotIdleWorkers(time.Now().Add(time.Hour), time.Minute)
 	if err != nil {
 		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
 	}


### PR DESCRIPTION
Foundation slice of the TTL-pool model (`docs/design/worker-ttl-pool.md`): a worker carries the client-selected `duckgres.worker_ttl` and the janitor retires it that long after its last query, instead of one global hot-idle TTL for everyone.

## Changes
- `configstore.WorkerRecord` gains **`TTLMinutes`** (additive, AutoMigrated; no migration file). `0` = use the deployment's global hot-idle TTL — so default/warm/neutral and legacy rows are unchanged.
- `ListExpiredHotIdleWorkers(now, defaultTTL)` selects hot-idle rows whose own `ttl_minutes` (falling back to `defaultTTL` when 0) has elapsed since `updated_at`. `updated_at` is bumped on the `hot→hot_idle` transition at session end, so **the TTL resets on each query** (matches the design).
- The janitor passes `(now, hotIdleTTL)`; `hotIdleTTL` is now the fallback rather than the universal cutoff.
- Spawn/transition persist `TTLMinutes` from the worker's profile (`k8s_pool.go`). A nil default profile persists `0` → fallback, so default traffic is untouched.

Minutes (not seconds) per request — clean for human-set values and expresses up to 24h fine.

## Safety
Behavior is unchanged until client sizing is enabled (sized requests are the only ones that set a non-zero ttl). This just lands the per-worker TTL in the DB and makes it govern reaping. **Sized on-demand spawn + ≥-fit reuse are the next slice** (what makes the sizing knobs functional end-to-end).

## Tests
- `TestListExpiredHotIdleWorkersPerWorkerTTL` (Postgres / CI): `ttl=0` uses the default, a short ttl expires, a long ttl does not, non-hot-idle rows never returned.
- Existing `ListExpiredHotIdleWorkers` callers updated to the new signature.
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; configstore test pkg compiles (runs against Postgres in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)