### PR TITLE
feat(worker-sizing): foreground-spawn a sized worker when none fits

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1671,6 +1671,21 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				continue
 			}
 
+			// A sized request (non-default profile) is NOT served by the neutral
+			// warm pool — warm replenishment spawns default/neutral workers that
+			// never match a concrete size. So when no same-size hot-idle/idle worker
+			// exists, foreground-spawn a worker of the requested size and reserve it
+			// for the org, instead of returning backpressure that would never clear.
+			// Only on a transient no-idle miss; an org/global cap is respected.
+			if assignment.Profile != nil &&
+				(missReason == configstore.WorkerClaimMissReasonNone || missReason == configstore.WorkerClaimMissReasonNoIdle) {
+				worker, spawnErr := p.spawnReservedSizedWorker(ctx, assignment)
+				if spawnErr != nil {
+					return nil, spawnErr
+				}
+				return worker, nil
+			}
+
 			p.recordWarmCapacityMiss(assignment, missReason)
 			return nil, NewWarmCapacityExhaustedErrorForReason(missReason, DefaultWarmCapacityRetryAfter)
 		}
@@ -1739,6 +1754,16 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 
 		p.mu.Unlock()
 
+		// Sized request with no matching warm worker: foreground-spawn one of the
+		// requested size (see the runtime-store branch above for rationale).
+		if assignment.Profile != nil {
+			worker, spawnErr := p.spawnReservedSizedWorker(ctx, assignment)
+			if spawnErr != nil {
+				return nil, spawnErr
+			}
+			return worker, nil
+		}
+
 		p.recordWarmCapacityMiss(assignment, configstore.WorkerClaimMissReasonNoIdle)
 		return nil, NewWarmCapacityExhaustedError(DefaultWarmCapacityRetryAfter)
 	}
@@ -1775,6 +1800,85 @@ func (p *K8sWorkerPool) recordWarmCapacityMiss(assignment *WorkerAssignment, rea
 	if err := p.runtimeStore.RecordWarmCapacityMiss(scope, policy.reason, time.Now()); err != nil {
 		slog.Warn("Failed to record warm capacity miss.", "image", image, "reason", policy.reason, "error", err)
 	}
+}
+
+// spawnReservedSizedWorker foreground-spawns a worker of the assignment's
+// requested size and reserves it for the org, returning it in Reserved state
+// (the caller activates it, same as a claimed warm worker). Used when a sized
+// request finds no same-size idle/hot-idle worker — the neutral warm pool can't
+// satisfy a concrete size, so we spawn one directly instead of failing. The pod
+// is sized from the profile (workerResourcesForProfile); the reserved record
+// round-trips the profile + TTL.
+func (p *K8sWorkerPool) spawnReservedSizedWorker(ctx context.Context, assignment *WorkerAssignment) (*ManagedWorker, error) {
+	if assignment == nil || assignment.Profile == nil {
+		return nil, fmt.Errorf("spawnReservedSizedWorker requires a sized assignment")
+	}
+	profile := *assignment.Profile
+
+	p.mu.Lock()
+	if p.shuttingDown {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("pool is shutting down")
+	}
+	// Respect the org's worker cap before spawning (in-process count; the DB-side
+	// cap on the claim path is cross-CP, this bounds the foreground sized-spawn).
+	if assignment.MaxWorkers > 0 {
+		n := 0
+		for _, w := range p.workers {
+			select {
+			case <-w.done:
+				continue
+			default:
+			}
+			st := w.SharedState()
+			if st.Assignment != nil && st.Assignment.OrgID == assignment.OrgID && st.NormalizedLifecycle() != WorkerLifecycleRetired {
+				n++
+			}
+		}
+		if n >= assignment.MaxWorkers {
+			p.mu.Unlock()
+			return nil, NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
+		}
+	}
+	id := p.allocateBackgroundSpawnIDLocked()
+	p.spawning++
+	p.mu.Unlock()
+
+	err := p.spawnWorker(ctx, id, assignment.Image, profile, false)
+	p.mu.Lock()
+	p.spawning--
+	p.mu.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("spawn sized worker: %w", err)
+	}
+
+	p.mu.Lock()
+	w, ok := p.workers[id]
+	if !ok {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("sized worker %d missing after spawn", id)
+	}
+	// spawnWorker does not stamp the profile on the in-memory worker; do it here
+	// so reuse-matching and the reserved record carry the size + TTL.
+	w.profile = profile
+	nextState, err := w.SharedState().Transition(WorkerLifecycleReserved, assignment)
+	if err != nil {
+		p.mu.Unlock()
+		p.retireWorkerWithReason(id, RetireReasonCrash, LifecycleOriginReserveFailure)
+		return nil, err
+	}
+	if err := w.SetSharedState(nextState); err != nil {
+		p.mu.Unlock()
+		p.retireWorkerWithReason(id, RetireReasonCrash, LifecycleOriginReserveFailure)
+		return nil, err
+	}
+	w.SetOwnerCPInstanceID(p.cpInstanceID)
+	w.IncrementOwnerEpoch()
+	w.reservedAt = time.Now()
+	reservedRecord := p.workerRecordFor(id, w, w.OwnerEpoch(), configstore.WorkerStateReserved, "", nil)
+	p.mu.Unlock()
+	_ = p.persistWorkerRecord(reservedRecord)
+	return w, nil
 }
 
 func (p *K8sWorkerPool) reserveClaimedWorker(ctx context.Context, claimed *configstore.WorkerRecord, assignment *WorkerAssignment) (*ManagedWorker, error) {


### PR DESCRIPTION
Makes client worker sizing **functional**. Until now a sized request (a concrete `worker_cpu`/`worker_memory`/`worker_ttl` profile, gate on) that found no same-size idle worker hung on `no warm Duckgres worker is currently available` — the neutral warm pool only spawns default/neutral workers whose profile key never matches a concrete size.

## Change
When `ReserveSharedWorker` finds no same-size hot-idle/idle worker for a **sized** assignment (transient no-idle miss; org/global cap respected), `spawnReservedSizedWorker` foreground-spawns a worker of the requested size and reserves it for the org (Reserved state — the caller activates it like a claimed warm worker). The pod is sized from the profile (`workerResourcesForProfile`); the reserved record round-trips cpu/mem + `ttl_minutes`. Wired in both the runtime-store and in-memory branches. An in-process org-worker-count guard keeps the foreground spawn within the org's `MaxWorkers`.

Same-size reuse already works via the exact-match `ClaimHotIdleWorker`, so a sized request now either **reuses a same-size hot-idle worker** or **spawns a fresh sized one**.

## Deferred (follow-up)
**≥-fit reuse** — reuse a *larger* idle worker for a smaller request. Needs numeric quantity comparison in the claim SQL; it's a pure optimization on top of same-size reuse + sized spawn.

## Verification
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; gofmt clean.
- **Needs mw-dev verification with the client-sizing gate enabled** (`DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE=true` + clamp envs): connect with `-c duckgres.worker_cpu=2 -c duckgres.worker_memory=4Gi` and confirm the spawned worker pod has 2 CPU / 4Gi requests. The per-PR e2e runs the gate **off**, so it confirms no regression to default traffic but does not exercise sized spawn.
- Default (no-GUC / gate-off) traffic is unchanged — `resolveWorkerProfile` returns the nil default profile, so the warm pool path is untouched (the #693 regression stays fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)