### PR TITLE
fix(worker-sizing): allocate sized-spawn worker id from the DB slot, not placeholder 0

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1820,30 +1820,34 @@ func (p *K8sWorkerPool) spawnReservedSizedWorker(ctx context.Context, assignment
 		p.mu.Unlock()
 		return nil, fmt.Errorf("pool is shutting down")
 	}
-	// Respect the org's worker cap before spawning (in-process count; the DB-side
-	// cap on the claim path is cross-CP, this bounds the foreground sized-spawn).
-	if assignment.MaxWorkers > 0 {
-		n := 0
-		for _, w := range p.workers {
-			select {
-			case <-w.done:
-				continue
-			default:
-			}
-			st := w.SharedState()
-			if st.Assignment != nil && st.Assignment.OrgID == assignment.OrgID && st.NormalizedLifecycle() != WorkerLifecycleRetired {
-				n++
-			}
-		}
-		if n >= assignment.MaxWorkers {
-			p.mu.Unlock()
-			return nil, NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
-		}
-	}
-	id := p.allocateBackgroundSpawnIDLocked()
-	p.spawning++
+	maxGlobal := p.maxWorkers
 	p.mu.Unlock()
 
+	// Allocate a real, unique worker id. In the runtime-store path this MUST come
+	// from the DB via CreateSpawningWorkerSlot (which also enforces the per-org and
+	// global worker caps cross-CP and returns a nil slot when capped) — the
+	// background id allocator returns a placeholder 0 that collides across spawns.
+	var id int
+	if p.runtimeStore != nil {
+		slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
+			p.cpInstanceID, assignment.OrgID, assignment.Image, 0,
+			p.workerPodNamePrefix(), assignment.MaxWorkers, maxGlobal)
+		if err != nil {
+			return nil, err
+		}
+		if slot == nil {
+			return nil, NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
+		}
+		id = slot.WorkerID
+	} else {
+		p.mu.Lock()
+		id = p.allocateWorkerIDLocked()
+		p.mu.Unlock()
+	}
+
+	p.mu.Lock()
+	p.spawning++
+	p.mu.Unlock()
 	err := p.spawnWorker(ctx, id, assignment.Image, profile, false)
 	p.mu.Lock()
 	p.spawning--


### PR DESCRIPTION
## Found on mw-dev
Deployed #696 and tested with the client-sizing gate on. A `worker_cpu=2 worker_memory=4Gi` request **did** spawn a worker with exactly `cpu=2 mem=4Gi` for the org (✓), and the clamp worked (`worker_memory=1Gi` → `2Gi` ✓). But the CP logs showed worker **`id=0` respawned on every sized request** — different pod each time, no reuse, ttl not retained.

## Root cause
`spawnReservedSizedWorker` (#696) took the worker id from `allocateBackgroundSpawnIDLocked()`, which returns a hardcoded **placeholder `0`** when a runtime store is configured (production) — the real id is supposed to come from the DB slot. So every sized spawn collided on id 0, overwrote the in-memory worker, and forced retire+respawn instead of going hot-idle / being reused.

## Fix
Runtime-store path now allocates the id + an org-bound `Spawning` row via `CreateSpawningWorkerSlot` (which also enforces the per-org + global caps cross-CP and returns a nil slot when capped — replacing the in-process count guard). In-memory path uses `allocateWorkerIDLocked`. With a stable unique id, a sized worker goes hot-idle after its session and is reused by the next same-size request, and its `ttl_minutes` governs reaping.

## Verification
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; gofmt clean.
- **Needs re-verify on mw-dev** (gate on): a 2nd same-size sized request reuses the worker (id stable, no churn), and the worker persists ~ttl after the session ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)