### PR TITLE
fix(worker-sizing): preserve worker size+TTL across re-adoption (enables sized reuse)

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1839,6 +1839,15 @@ func (p *K8sWorkerPool) spawnReservedSizedWorker(ctx context.Context, assignment
 			return nil, NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
 		}
 		id = slot.WorkerID
+		// Stamp the requested size + TTL onto the slot row immediately, so any
+		// adoption/reconciliation that reconstructs the worker from the DB before
+		// it is reserved already carries the profile (CreateSpawningWorkerSlot
+		// creates the row with an empty profile).
+		slot.ProfileCPU = profile.CPU
+		slot.ProfileMemory = profile.Memory
+		slot.ProfileColocate = profile.Colocate
+		slot.TTLMinutes = int(profile.TTL.Minutes())
+		_ = p.persistWorkerRecord(slot)
 	} else {
 		p.mu.Lock()
 		id = p.allocateWorkerIDLocked()
@@ -2042,7 +2051,17 @@ func (p *K8sWorkerPool) adoptClaimedWorker(ctx context.Context, claimed *configs
 		image:       claimed.Image,
 		bearerToken: token,
 		client:      client,
-		done:        make(chan struct{}),
+		// Restore the worker's size + TTL from the persisted record so a re-adopted
+		// worker keeps its shape. Without this, re-adopting a sized worker reset its
+		// profile to the default and the next hot-idle persist dropped its
+		// cpu/mem/ttl, so a same-size request could no longer reuse it.
+		profile: WorkerProfile{
+			CPU:      claimed.ProfileCPU,
+			Memory:   claimed.ProfileMemory,
+			Colocate: claimed.ProfileColocate,
+			TTL:      time.Duration(claimed.TTLMinutes) * time.Minute,
+		},
+		done: make(chan struct{}),
 	}
 	worker.SetOwnerCPInstanceID(claimed.OwnerCPInstanceID)
 	worker.SetOwnerEpoch(claimed.OwnerEpoch)


### PR DESCRIPTION
## Found on mw-dev (after #698)
With the id-collision fix deployed, a sized request spawned a worker with a **stable** id (✓), but a **second same-size request still spawned a fresh worker** instead of reusing the hot-idle one. Queried the config store directly:

```
worker_id | state    | org_id     | profile_cpu | profile_memory | ttl_minutes
11185     | hot_idle | ben-ext-dl |             |                | 0
11186     | hot_idle | ben-ext-dl |             |                | 0
```

The hot-idle rows have **empty profile + ttl=0** — so `ClaimHotIdleWorker` (exact profile match) can't match them, and every sized request respawns.

## Root cause
`adoptClaimedWorker` reconstructs a `ManagedWorker` from the DB record but **didn't copy the profile**. When a sized worker is re-adopted during activation, its in-memory `profile` resets to the default; the subsequent hot-idle persist (`workerRecordFor` reads `worker.profile`) then writes an **empty** profile + `ttl=0`, erasing the size.

## Fix
1. `adoptClaimedWorker` restores `profile` (cpu/mem/colocate + `ttl_minutes`) from the record — a re-adopted worker keeps its shape.
2. `spawnReservedSizedWorker` stamps the size+ttl onto the DB slot row right after `CreateSpawningWorkerSlot` (which creates it empty), so the record carries the profile before any adoption can read it.

Now a sized worker keeps cpu/mem/ttl through Reserved → Hot → HotIdle, so `ClaimHotIdleWorker` matches it and a same-size request **reuses** it; `ttl_minutes` persists so per-worker TTL governs reaping.

## Verification
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; gofmt clean.
- **Re-verify on mw-dev** (gate on): 2nd same-size request reuses the worker (no churn); the `hot_idle` row carries `profile_cpu`/`profile_memory` + `ttl_minutes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)