### PR TITLE
fix(worker-sizing): persist profile columns on UpsertWorkerRecord conflict (real root cause of no-reuse)

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1122,8 +1122,13 @@ func (cs *ConfigStore) ExpireDrainingControlPlaneInstances(before time.Time) (in
 func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
 	protectedStates := []WorkerState{WorkerStateDraining, WorkerStateRetired, WorkerStateLost}
 	result := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "worker_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at"}),
+		Columns: []clause.Column{{Name: "worker_id"}},
+		// profile_cpu/memory/colocate + ttl_minutes are in the update set so a
+		// sized worker's shape (set after CreateSpawningWorkerSlot inserts the row
+		// with an empty profile) actually persists. Without them the ON CONFLICT
+		// update silently dropped the profile, so a sized worker's hot-idle row
+		// stayed empty and ClaimHotIdleWorker could never match it (no reuse).
+		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at", "profile_cpu", "profile_memory", "profile_colocate", "ttl_minutes"}),
 		Where: clause.Where{Exprs: []clause.Expression{
 			clause.Expr{SQL: `"worker_records"."state" NOT IN ?`, Vars: []any{protectedStates}},
 			clause.Expr{SQL: `(excluded."owner_epoch" > "worker_records"."owner_epoch" OR (excluded."owner_epoch" = "worker_records"."owner_epoch" AND excluded."owner_cp_instance_id" = "worker_records"."owner_cp_instance_id"))`},

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1839,15 +1839,6 @@ func (p *K8sWorkerPool) spawnReservedSizedWorker(ctx context.Context, assignment
 			return nil, NewWarmCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
 		}
 		id = slot.WorkerID
-		// Stamp the requested size + TTL onto the slot row immediately, so any
-		// adoption/reconciliation that reconstructs the worker from the DB before
-		// it is reserved already carries the profile (CreateSpawningWorkerSlot
-		// creates the row with an empty profile).
-		slot.ProfileCPU = profile.CPU
-		slot.ProfileMemory = profile.Memory
-		slot.ProfileColocate = profile.Colocate
-		slot.TTLMinutes = int(profile.TTL.Minutes())
-		_ = p.persistWorkerRecord(slot)
 	} else {
 		p.mu.Lock()
 		id = p.allocateWorkerIDLocked()

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -862,6 +862,58 @@ func TestListExpiredHotIdleWorkersPerWorkerTTL(t *testing.T) {
 	}
 }
 
+// Regression: UpsertWorkerRecord must update the profile (cpu/mem/colocate) and
+// ttl_minutes columns on conflict. CreateSpawningWorkerSlot inserts a sized
+// worker's row with an empty profile, and the reserve/hot-idle persists set it
+// via upsert — if the ON CONFLICT update omits these columns, a sized worker's
+// hot-idle row stays empty and ClaimHotIdleWorker can never match it (no reuse).
+func TestUpsertWorkerRecordPersistsProfileOnConflict(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Now()
+
+	// Row created with an empty profile (as CreateSpawningWorkerSlot does).
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          7001,
+		PodName:           "duckgres-worker-7001",
+		State:             configstore.WorkerStateSpawning,
+		OrgID:             "analytics",
+		Image:             "duckgres:v2",
+		OwnerCPInstanceID: "cp:boot",
+		OwnerEpoch:        1,
+		LastHeartbeatAt:   now,
+	}); err != nil {
+		t.Fatalf("insert empty-profile row: %v", err)
+	}
+
+	// Later persist (reserve / hot-idle) sets the concrete size + ttl.
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID:          7001,
+		PodName:           "duckgres-worker-7001",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		Image:             "duckgres:v2",
+		OwnerCPInstanceID: "cp:boot",
+		OwnerEpoch:        1,
+		LastHeartbeatAt:   now,
+		ProfileCPU:        "4",
+		ProfileMemory:     "8Gi",
+		TTLMinutes:        15,
+	}); err != nil {
+		t.Fatalf("upsert profile on conflict: %v", err)
+	}
+
+	got, err := store.GetWorkerRecord(7001)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if got.ProfileCPU != "4" || got.ProfileMemory != "8Gi" || got.TTLMinutes != 15 {
+		t.Fatalf("profile not persisted on conflict: cpu=%q mem=%q ttl=%d", got.ProfileCPU, got.ProfileMemory, got.TTLMinutes)
+	}
+	if got.State != configstore.WorkerStateHotIdle {
+		t.Fatalf("state = %q, want hot_idle", got.State)
+	}
+}
+
 func TestClaimHotIdleWorkerReturnsNoIdleWhenNoHotIdleWorkerExists(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 


### PR DESCRIPTION
## The actual root cause (chased on mw-dev)
"Sized workers never reuse" survived #698 (id collision) and #699 (re-adoption). Querying the config store directly showed sized workers' `hot_idle` rows had **empty `profile_cpu`/`profile_memory` and `ttl_minutes=0`** — so `ClaimHotIdleWorker` (exact profile match) could never match them.

`UpsertWorkerRecord`'s `ON CONFLICT DO UPDATE` column set **omitted the profile + ttl columns**. A sized worker's row is INSERTed empty by `CreateSpawningWorkerSlot`, and every later persist (reserve, hot-idle) is an upsert → the profile was silently dropped on every write. The #695/#699 persists were correct but no-op'd by this.

## Fix
Add `profile_cpu`, `profile_memory`, `profile_colocate`, `ttl_minutes` to the upsert's `DoUpdates`. A sized worker's shape + ttl now persist through Reserved → Hot → HotIdle, so a same-size request **reuses** the hot-idle worker and per-worker TTL governs reaping.

## Cleanup per review
- **Reverted** the redundant slot-stamp I added in #699 — it was an upsert that this same bug dropped; the reserve persist already sets the profile once the columns are in the update set.
- **Kept** the #699 `adoptClaimedWorker` profile-restore — still needed so a re-adopted worker doesn't upsert an empty profile back over the row.

## Test
`TestUpsertWorkerRecordPersistsProfileOnConflict` (Postgres / CI): insert an empty-profile row, upsert a concrete size+ttl, assert they persist on conflict. Directly guards the root cause.

`go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; configstore test pkg compiles (runs against Postgres in CI); gofmt clean.

## Verify on mw-dev
After deploy (gate on): 2nd same-size request reuses the worker (no churn); the `hot_idle` row carries `profile_cpu`/`profile_memory`/`ttl_minutes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)