### PR TITLE
fix(headroom): GenerateName for placeholder pods (was colliding on one name)

### DIFF
--- a/controlplane/headroom.go
+++ b/controlplane/headroom.go
@@ -156,11 +156,13 @@ func (p *K8sWorkerPool) listPlaceholderPods(ctx context.Context) ([]string, erro
 }
 
 func (p *K8sWorkerPool) createPlaceholderPod(ctx context.Context, cpu, mem resource.Quantity) error {
-	name := fmt.Sprintf("%s-%s-%d", headroomPodLabel, p.cpID, p.allocateBackgroundSpawnID())
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: p.namespace,
+			// GenerateName lets the API server assign a unique suffix per pod —
+			// the controller creates N placeholders per reconcile and does not
+			// track ids, so a fixed/derived name would collide ("already exists").
+			GenerateName: fmt.Sprintf("%s-%s-", headroomPodLabel, p.cpID),
+			Namespace:    p.namespace,
 			Labels: map[string]string{
 				"app":                    headroomPodLabel,
 				"duckgres/control-plane": p.cpID,
@@ -205,14 +207,6 @@ func (p *K8sWorkerPool) createPlaceholderPod(ctx context.Context, cpu, mem resou
 	}
 	_, err := p.clientset.CoreV1().Pods(p.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	return err
-}
-
-// allocateBackgroundSpawnID returns a process-unique id (shares the worker id
-// space; only used to make placeholder pod names unique).
-func (p *K8sWorkerPool) allocateBackgroundSpawnID() int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.allocateBackgroundSpawnIDLocked()
 }
 
 func nodeIsReady(n *corev1.Node) bool {


### PR DESCRIPTION
## Found testing headroom on mw-dev
Enabled headroom (`HEADROOM_PERCENT=5`, placeholder 1cpu/2Gi). The controller created **one** placeholder pod, then logged `Headroom: failed to create placeholder pod. error="pods \"duckgres-headroom-...-0\" already exists"` on every janitor tick.

## Root cause
`createPlaceholderPod` named pods with `allocateBackgroundSpawnID()`, which returns a fixed placeholder **`0`** when a runtime store is configured (production). So every placeholder got the **same name** and all but the first failed. (Same id-placeholder pitfall as the sized-spawn path #698.)

## Fix
Use `ObjectMeta.GenerateName` so the API server assigns a unique suffix per pod. The controller already lists/deletes placeholders by the `app=duckgres-headroom` label, so it never needed to allocate or track ids. Removes the now-unused `allocateBackgroundSpawnID` helper.

## Verification
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/ -run Headroom` pass; gofmt clean.
- On mw-dev (after deploy): the controller creates the full target set of placeholders (Running, `priorityClass=duckgres-headroom`, on the worker nodepool). The unit test covers the count math; the create path is k8s-API and verified on-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)