### PR TITLE
fix(worker-sizing): keep/reset TTL when reusing a hot-idle worker

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1925,7 +1925,14 @@ func (p *K8sWorkerPool) reserveClaimedWorker(ctx context.Context, claimed *confi
 	}
 	// Carry the worker's persisted pod-shape so the reserved record and any later
 	// reconciliation round-trip it. Default/legacy rows yield the zero profile.
-	worker.profile = WorkerProfile{CPU: claimed.ProfileCPU, Memory: claimed.ProfileMemory, Colocate: claimed.ProfileColocate}
+	// TTL resets to the new request's value on reuse (a query hitting the worker
+	// extends its life by the requested ttl); fall back to the worker's persisted
+	// ttl when the request carries none.
+	reuseTTL := time.Duration(claimed.TTLMinutes) * time.Minute
+	if assignment != nil && assignment.Profile != nil && assignment.Profile.TTL > 0 {
+		reuseTTL = assignment.Profile.TTL
+	}
+	worker.profile = WorkerProfile{CPU: claimed.ProfileCPU, Memory: claimed.ProfileMemory, Colocate: claimed.ProfileColocate, TTL: reuseTTL}
 	if worker.OwnerEpoch() > 0 && claimed.OwnerEpoch < worker.OwnerEpoch() {
 		currentEpoch := worker.OwnerEpoch()
 		p.mu.Unlock()


### PR DESCRIPTION
## Verified #700 on mw-dev
Same-size request now **reuses** the hot-idle worker (one pod for both requests) and the profile persists — config store: `11201 | hot_idle | ben-ext-both | profile_cpu=5 | profile_memory=10Gi`. ✅

But `ttl_minutes=0` (expected 20). On reuse the per-worker TTL was being dropped.

## Root cause
`reserveClaimedWorker` (the claim/reuse path) rebuilds `worker.profile` from the claimed record but **omitted TTL** — so a reused worker's `profile.TTL` reset to 0, and the next hot-idle persist wrote `ttl_minutes=0`. The worker would then be reaped at the global fallback TTL instead of its requested ttl.

## Fix
On reuse, set the worker's TTL to the **new request's** ttl (a query hitting the worker extends its life by the requested ttl — "resets on each query", per the design), falling back to the worker's persisted `ttl_minutes` when the request carries none.

## Verification
- `go build -tags kubernetes ./...` + `go test -tags kubernetes ./controlplane/` pass; gofmt clean.
- Re-verify on mw-dev: after a reuse, the `hot_idle` row carries `ttl_minutes` = the request's ttl (default 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)