### PR TITLE
feat(worker-pool): warm-pool teardown — foreground-spawn on demand (hot-idle + hot-active only)

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -1671,15 +1671,15 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 				continue
 			}
 
-			// A sized request (non-default profile) is NOT served by the neutral
-			// warm pool — warm replenishment spawns default/neutral workers that
-			// never match a concrete size. So when no same-size hot-idle/idle worker
-			// exists, foreground-spawn a worker of the requested size and reserve it
-			// for the org, instead of returning backpressure that would never clear.
-			// Only on a transient no-idle miss; an org/global cap is respected.
+			// A sized request foreground-spawns a worker of the requested size here
+			// (the warm pool only ever spawns default/neutral shapes, which can't
+			// satisfy a concrete size). A DEFAULT request returns the no-idle miss;
+			// the no-warm-pool foreground spawn for default requests is driven one
+			// layer up in OrgReservedPool.AcquireWorker, which keeps this method's
+			// contract (and its tests) unchanged. Org/global cap is respected.
 			if assignment.Profile != nil &&
 				(missReason == configstore.WorkerClaimMissReasonNone || missReason == configstore.WorkerClaimMissReasonNoIdle) {
-				worker, spawnErr := p.spawnReservedSizedWorker(ctx, assignment)
+				worker, spawnErr := p.foregroundSpawnReservedWorker(ctx, assignment)
 				if spawnErr != nil {
 					return nil, spawnErr
 				}
@@ -1754,10 +1754,12 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 
 		p.mu.Unlock()
 
-		// Sized request with no matching warm worker: foreground-spawn one of the
-		// requested size (see the runtime-store branch above for rationale).
+		// The production warm-pool teardown lives in the runtime-store branch above
+		// (it foreground-spawns for every request). This runtime-store-less branch
+		// is non-production (tests / standalone k8s); only a sized request
+		// foreground-spawns here, a default request still surfaces a no-idle miss.
 		if assignment.Profile != nil {
-			worker, spawnErr := p.spawnReservedSizedWorker(ctx, assignment)
+			worker, spawnErr := p.foregroundSpawnReservedWorker(ctx, assignment)
 			if spawnErr != nil {
 				return nil, spawnErr
 			}
@@ -1802,18 +1804,23 @@ func (p *K8sWorkerPool) recordWarmCapacityMiss(assignment *WorkerAssignment, rea
 	}
 }
 
-// spawnReservedSizedWorker foreground-spawns a worker of the assignment's
-// requested size and reserves it for the org, returning it in Reserved state
-// (the caller activates it, same as a claimed warm worker). Used when a sized
-// request finds no same-size idle/hot-idle worker — the neutral warm pool can't
-// satisfy a concrete size, so we spawn one directly instead of failing. The pod
-// is sized from the profile (workerResourcesForProfile); the reserved record
-// round-trips the profile + TTL.
-func (p *K8sWorkerPool) spawnReservedSizedWorker(ctx context.Context, assignment *WorkerAssignment) (*ManagedWorker, error) {
-	if assignment == nil || assignment.Profile == nil {
-		return nil, fmt.Errorf("spawnReservedSizedWorker requires a sized assignment")
+// spawnReservedWorker foreground-spawns a worker for the org and reserves it,
+// returning it in Reserved state (the caller activates it, same as a claimed
+// worker). This is the only spawn path now that the warm pool is gone: a request
+// either reuses a hot-idle worker (claim) or spawns one here. The pod is sized
+// from the request profile, or the pool-global default for a default (nil
+// profile) request (workerResourcesForProfile); the reserved record round-trips
+// the profile + TTL.
+func (p *K8sWorkerPool) foregroundSpawnReservedWorker(ctx context.Context, assignment *WorkerAssignment) (*ManagedWorker, error) {
+	if assignment == nil {
+		return nil, fmt.Errorf("spawnReservedWorker requires an assignment")
 	}
-	profile := *assignment.Profile
+	// A default (nil profile) request spawns a default-sized worker: the zero
+	// profile makes workerResourcesForProfile fall back to the pool-global request.
+	var profile WorkerProfile
+	if assignment.Profile != nil {
+		profile = *assignment.Profile
+	}
 
 	p.mu.Lock()
 	if p.shuttingDown {

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -106,8 +106,8 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 	}
 	defer p.gate.release()
 
-	warmDeadline := time.Now().Add(p.shared.warmAcquireTimeout)
-	// Throttle warm-miss recording across the wait's repeated polls.
+	// Throttle warm-miss recording (the miss is still recorded for demand metrics
+	// even though we now foreground-spawn rather than wait for a replenish).
 	var lastWarmMissAt time.Time
 	for {
 		select {
@@ -181,17 +181,24 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 				return nil, NewWarmCapacityExhaustedErrorForReason(
 					configstore.WorkerClaimMissReasonOrgCap, DefaultWarmCapacityRetryAfter)
 			}
-			if p.shared.warmAcquireTimeout > 0 && time.Now().Before(warmDeadline) {
-				timer := time.NewTimer(WarmAcquireRetryInterval)
-				select {
-				case <-ctx.Done():
-					timer.Stop()
-					return nil, ctx.Err()
-				case <-timer.C:
-				}
-				continue
+			// No warm pool: foreground-spawn a worker for this request instead of
+			// waiting for a warm replenish that will never come. A sized request
+			// already foreground-spawned inside ReserveSharedWorker (so it returned a
+			// worker, not this miss); this path covers default requests. The spawn
+			// re-checks the org/global cap (CreateSpawningWorkerSlot) and reserves the
+			// worker, which then activates below.
+			worker, err = p.shared.foregroundSpawnReservedWorker(ctx, &WorkerAssignment{
+				OrgID:                p.orgID,
+				MaxWorkers:           maxWorkers,
+				Image:                image,
+				Profile:              profile,
+				MaxColocatedCPU:      p.maxColocatedCPU,
+				MaxColocatedMemBytes: p.maxColocatedMemBytes,
+			})
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+			// worker is now a freshly reserved worker; fall through to activation.
 		}
 
 		if err := p.activateWorkerForOrg(ctx, worker); err != nil {


### PR DESCRIPTION
The behavioral half of the warm-pool teardown from `docs/design/worker-ttl-pool.md`: a request either **reuses a hot-idle worker** or **foreground-spawns one** — no background warm replenishment, no neutral/idle pre-spawned workers. Workers are only **hot-active** or **hot-idle**.

## Change
- `foregroundSpawnReservedWorker` (generalized from the sized-only spawn): spawns a worker of the request's size, or the **pool-global default** for a default (nil-profile) request, and reserves it for the org. Enforces the per-org/global cap via `CreateSpawningWorkerSlot`.
- `ReserveSharedWorker` keeps foreground-spawning **sized** requests inline (a concrete size can't be served by the default-shaped warm pool); its contract for **default** requests (return a no-idle miss) is **unchanged**, so its tests are untouched.
- `OrgReservedPool.AcquireWorker`: on a retryable no-idle miss it now **foreground-spawns** for the org instead of waiting for a warm replenish that will never come (default requests; sized ones already spawned in `ReserveSharedWorker`). Org cap still surfaced as a clear error; the FIFO anti-snatch gate still serializes per-org acquisition.

## Deploy
Set `DUCKGRES_K8S_SHARED_WARM_TARGET=0` (and dynamic warm capacity off) so no neutral workers are pre-spawned. The remaining warm machinery (reconciler, `ClaimIdleWorker` neutral path, per-image targets, `SharedWarmTarget`) is now **inert** and gets deleted as dead code in a **follow-up** PR — kept this PR to the behavior change so it's bisectable and the contract tests stay green.

## Tests
- All `controlplane` tests pass (incl. the 6 `ReserveSharedWorker` contract tests, untouched).
- The per-PR e2e harness runs `SHARED_WARM_TARGET=0`, so its default-traffic `basic_query` now exercises this foreground-spawn path directly.

## Verify on mw-dev
Set `SHARED_WARM_TARGET=0`; confirm a **default** connection (no GUC) foreground-spawns + reuses a default-sized worker, a **sized** connection still works, and **no neutral** (org-less, empty-profile) workers appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)