### PR TITLE
fix(worker-pool): per-image warm floor from SharedWarmTarget (0 = no warm pool)

### DIFF
--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -429,15 +429,20 @@ func (tr *OrgRouter) computeBaseWarmCapacityTargets(snap *configstore.Snapshot) 
 	)
 }
 
-// computePerImageWarmTargets returns "keep at least 1 warm worker for each
-// distinct image" — covering the cluster default plus every pinned
-// Warehouse.Image used by an org that currently has an active stack. Orgs
-// without a live stack (e.g. warehouse not yet ready) are skipped so we don't
-// pre-warm pods for images nobody can route to yet.
+// computePerImageWarmTargets returns "keep at least SharedWarmTarget warm workers
+// for each distinct image" — covering the cluster default plus every pinned
+// Warehouse.Image used by an org that currently has an active stack. With the
+// warm pool torn down (SharedWarmTarget=0) it returns no floors, so no neutral
+// workers are pre-spawned; requests foreground-spawn on demand instead. Orgs
+// without a live stack (e.g. warehouse not yet ready) are skipped.
 func (tr *OrgRouter) computePerImageWarmTargets(snap *configstore.Snapshot) map[string]int {
 	targets := make(map[string]int)
+	floor := tr.globalCfg.K8s.SharedWarmTarget
+	if floor <= 0 {
+		return targets // warm pool disabled — no per-image floor
+	}
 	if defaultImage := strings.TrimSpace(tr.baseCfg.WorkerImage); defaultImage != "" {
-		targets[defaultImage] = 1
+		targets[defaultImage] = floor
 	}
 	tr.mu.RLock()
 	defer tr.mu.RUnlock()
@@ -450,7 +455,7 @@ func (tr *OrgRouter) computePerImageWarmTargets(snap *configstore.Snapshot) map[
 		if image == "" {
 			continue
 		}
-		targets[image] = 1
+		targets[image] = floor
 	}
 	return targets
 }

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -465,7 +465,7 @@ func TestOrgRouterReconcileWarmCapacityFloorsOnePerActiveImage(t *testing.T) {
 		baseCfg: K8sWorkerPoolConfig{
 			WorkerImage: "posthog/duckgres:default",
 		},
-		globalCfg: ControlPlaneConfig{},
+		globalCfg: ControlPlaneConfig{K8s: K8sConfig{SharedWarmTarget: 1}},
 		orgs: map[string]*OrgStack{
 			"analytics": {Config: &configstore.OrgConfig{Name: "analytics"}},
 			"billing":   {Config: &configstore.OrgConfig{Name: "billing"}},
@@ -545,10 +545,36 @@ func TestOrgRouterReconcileWarmCapacityTreatsSharedWarmTargetAsDefaultImageBase(
 	got := sharedPool.PerImageWarmTargets()
 	want := map[string]int{
 		"posthog/duckgres:default": 4,
-		"posthog/duckgres:v1.5.1":  1,
+		"posthog/duckgres:v1.5.1":  4,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected per-image targets %v, got %v", want, got)
+	}
+}
+
+// Warm-pool teardown: SharedWarmTarget=0 means no per-image warm floor, so no
+// neutral workers are pre-spawned (requests foreground-spawn on demand instead).
+func TestOrgRouterReconcileWarmCapacityZeroTargetDisablesWarmPool(t *testing.T) {
+	sharedPool, _ := newTestK8sPool(t, 10)
+	tr := &OrgRouter{
+		sharedPool: sharedPool,
+		baseCfg:    K8sWorkerPoolConfig{WorkerImage: "posthog/duckgres:default"},
+		globalCfg:  ControlPlaneConfig{K8s: K8sConfig{SharedWarmTarget: 0}},
+		orgs: map[string]*OrgStack{
+			"analytics": {Config: &configstore.OrgConfig{Name: "analytics"}},
+		},
+	}
+	snap := &configstore.Snapshot{
+		Orgs: map[string]*configstore.OrgConfig{
+			"analytics": {
+				Name:      "analytics",
+				Warehouse: &configstore.ManagedWarehouseConfig{Image: "posthog/duckgres:v1.5.1"},
+			},
+		},
+	}
+	tr.reconcileWarmCapacity(snap)
+	if got := sharedPool.PerImageWarmTargets(); len(got) != 0 {
+		t.Fatalf("expected no per-image warm targets with SharedWarmTarget=0, got %v", got)
 	}
 }
 
@@ -558,7 +584,7 @@ func TestOrgRouterReconcileWarmCapacitySkipsEmptyClusterDefault(t *testing.T) {
 	tr := &OrgRouter{
 		sharedPool: sharedPool,
 		baseCfg:    K8sWorkerPoolConfig{}, // WorkerImage unset
-		globalCfg:  ControlPlaneConfig{},
+		globalCfg:  ControlPlaneConfig{K8s: K8sConfig{SharedWarmTarget: 1}},
 		orgs: map[string]*OrgStack{
 			"analytics": {Config: &configstore.OrgConfig{Name: "analytics"}},
 		},


### PR DESCRIPTION
## Found verifying #703 on mw-dev
Deployed #703 with `DUCKGRES_K8S_SHARED_WARM_TARGET=0` — but the reconciler **still spawned a neutral worker** (`Warm capacity target changed. base_target=1 effective_target=1`).

Root cause: `computePerImageWarmTargets` **hardcoded a floor of `1`** warm worker per image, independent of `SharedWarmTarget`. So the warm pool could never be fully turned off, and `SHARED_WARM_TARGET=0` didn't actually mean "no warm pool".

## Fix
The per-image floor is now `SharedWarmTarget`, uniform across the cluster-default image + every active org's pinned image. `SharedWarmTarget <= 0` returns **no floors** → no neutral workers pre-spawned → requests foreground-spawn on demand (the #703 path). This completes the teardown: `SHARED_WARM_TARGET=0` = no warm pool.

(Side effect: with `SharedWarmTarget=N>0`, every active image now gets `N` warm workers instead of the old special-case "default gets N, others get 1" — simpler + consistent.)

## Tests
- Updated the per-image-floor tests for the `SharedWarmTarget`-driven floor.
- New `TestOrgRouterReconcileWarmCapacityZeroTargetDisablesWarmPool`: target 0 → no floors.
- All `controlplane` tests pass; gofmt clean.

## Verify on mw-dev
With `SHARED_WARM_TARGET=0` + this image: after a default connection, no `Warm capacity target changed` with a nonzero base, and no org-less (neutral) workers spawn — only on-demand hot-active/hot-idle workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)