### PR TITLE
test(e2e-mw-dev): assert client worker sizing + same-shape reuse

### DIFF
--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -46,6 +46,19 @@ client-go:
   succeeds. The harness asserts the hint when observed **and** handles it (the
   concurrency tests retry through it).
 - **activation** — DuckLake **and** Iceberg catalogs attach and read/write.
+- **worker sizing** (TTL-pool model, `docs/design/worker-ttl-pool.md`) — a
+  client-sized connection (`duckgres.worker_cpu`/`worker_memory`/`worker_ttl`
+  startup options, sent via `PGOPTIONS`; CP runs `allowClientWorkerProfile=true`
+  with clamps) spawns a worker pod whose `duckdb-worker` container carries the
+  requested CPU+memory on **both** requests and limits — proving the shape flows
+  control-plane → k8s pod spec, not BestEffort. A same-shape reconnect **reuses**
+  that hot-idle worker (no respawn — the count of that-shape pods stays 1).
+  Asserted on cnpg for **both** the ducklake and iceberg catalogs, with a
+  distinct shape per catalog (2/4Gi vs 3/6Gi) so the catalog-agnostic worker
+  can't satisfy the second from the first's hot-idle pool. The per-PR CP also
+  runs `DUCKGRES_K8S_DYNAMIC_WARM_CAPACITY_ENABLED=false`, so the only workers
+  are the ones a request sizes + spawns (no neutral warm-miss-driven workers).
+  Clamp enforcement itself is unit-covered (`controlplane/worker_profile_test.go`).
 - **extension forks** — the bundled `ducklake`/`httpfs` extensions are the
   PostHog forks, not upstream (ported from the `*IsBundledFork` tests).
 - **worker pods** — labels (`app`, `duckgres/control-plane`,

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -54,7 +54,7 @@ client-go:
   control-plane → k8s pod spec, not BestEffort. A same-shape reconnect **reuses**
   that hot-idle worker (no respawn — the count of that-shape pods stays 1).
   Asserted on cnpg for **both** the ducklake and iceberg catalogs, with a
-  distinct shape per catalog (2/4Gi vs 3/6Gi) so the catalog-agnostic worker
+  distinct shape per catalog (2/4Gi vs 1/2Gi) so the catalog-agnostic worker
   can't satisfy the second from the first's hot-idle pool. The per-PR CP also
   runs `DUCKGRES_K8S_DYNAMIC_WARM_CAPACITY_ENABLED=false`, so the only workers
   are the ones a request sizes + spawns (no neutral warm-miss-driven workers).

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -134,7 +134,12 @@ _pg_exec() { # org password dbname sql  -> prints output; rc 0 ok / 1 real error
     fi
     case "$out" in
       *"capacity exhausted"*|*"no warm Duckgres worker"*|*"no warm worker"*|\
-      *"still provisioning"*|*"failed to initialize session"*)
+      *"still provisioning"*|*"failed to initialize session"*|\
+      *"timed out waiting for an available worker"*|*"failed to start"*|*"spawn sized worker"*)
+        # The last three cover an on-demand cold spawn that needed a fresh node
+        # (sized worker too big for the warm node): the first connect can hit the
+        # spawn ceiling while the pod is still pulling/booting; by the retry it is
+        # hot-idle and the reconnect reuses it. Same transient class as a cold pool.
         sleep 10; a=$((a + 1)); continue ;;
       *) printf %s "$out" >&2; return 1 ;;
     esac
@@ -163,7 +168,8 @@ pg_try() { # org password dbname sql
     fi
     case "$out" in
       *"capacity exhausted"*|*"no warm Duckgres worker"*|*"no warm worker"*|\
-      *"still provisioning"*|*"failed to initialize session"*)
+      *"still provisioning"*|*"failed to initialize session"*|\
+      *"timed out waiting for an available worker"*|*"failed to start"*|*"spawn sized worker"*)
         sleep 10; a=$((a + 1)); continue ;;
       *) printf %s "$out"; return 1 ;;
     esac
@@ -641,14 +647,18 @@ main() {
   one_session_per_worker "$CNPG" "$cnpg_pw"
 
   # ---- worker sizing (TTL-pool model) on cnpg, both catalogs ----
-  # Distinct shapes per catalog (2/4Gi vs 3/6Gi) so the iceberg sized request
+  # Distinct shapes per catalog (2/4Gi vs 1/2Gi) so the iceberg sized request
   # can't reuse the ducklake org's hot-idle 2-CPU worker (workers are
   # catalog-agnostic; only the profile shape gates reuse) — each catalog gets a
-  # verified fresh sized spawn, then a verified same-shape reuse.
+  # verified fresh sized spawn, then a verified same-shape reuse. Both shapes are
+  # small enough to bin-pack onto an already-warm worker node (2+1 CPU), so the
+  # iceberg spawn doesn't force a cold node scale-up that would outrun the CP's
+  # spawn ceiling (the on-demand cold-spawn case is tolerated by _pg_exec's retry
+  # set regardless, but keeping it warm makes the assertion fast + deterministic).
   sized_worker        "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
   reuse_sized_worker  "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
-  sized_worker        "$CNPG" "$cnpg_pw" iceberg  3 6Gi 15m
-  reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  3 6Gi 15m
+  sized_worker        "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
+  reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
 
   # ---- ext backend (activation + R/W on the external-RDS metadata path) ----
   wait_worker "$EXT" "$ext_pw" ducklake

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -13,6 +13,10 @@
 #                  and a cold-pool burst gets the graceful warm-pool backpressure
 #                  hint ("retry in ~45s") then recovers.
 #   activation   : DuckLake + Iceberg catalogs attach and read/write.
+#   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
+#                  spawns a worker pod carrying the requested CPU+memory, and a
+#                  same-shape reconnect reuses that hot-idle worker (no respawn)
+#                  — asserted on cnpg for BOTH the ducklake and iceberg catalogs.
 #   ext forks    : the bundled ducklake/httpfs extensions are the PostHog forks,
 #                  not upstream (detects an accidental upstream swap in the image).
 #   worker pods  : labels, securityContext (non-root, no priv-esc), Downward-API
@@ -332,6 +336,71 @@ assert_worker_pod() {
   fi
 }
 
+# ---- worker sizing (TTL-pool model) ---------------------------------------
+# The TTL-pool model (docs/design/worker-ttl-pool.md) lets a client pick the
+# worker shape + TTL via the duckgres.worker_cpu/worker_memory/worker_ttl
+# startup options (gated by allowClientWorkerProfile, clamped by the CP). Assert
+# end-to-end that a sized connection spawns a worker pod whose duckdb-worker
+# container carries the requested CPU+memory on BOTH requests and limits — i.e.
+# the shape flows control-plane → k8s pod spec, not BestEffort. A distinct shape
+# (no other test, and no other catalog of this org, uses it) guarantees a fresh
+# spawn: the implemented reuse path is EXACT-profile-match only, so it can't hand
+# back a default or other-shape hot-idle worker — the newest worker pod for the
+# org is unambiguously ours. The connection's dbname forces that catalog's
+# activation at session-create, so this also exercises sizing × catalog together.
+WORKER_C='{.spec.containers[?(@.name=="duckdb-worker")]'
+sized_worker() { # org password catalog cpu memory ttl
+  org="$1"; pw="$2"; cat="$3"; cpu="$4"; mem="$5"; ttl="$6"
+  log "sized worker spawn on $org/$cat: cpu=$cpu memory=$mem ttl=$ttl"
+  # PGOPTIONS (scoped to this subshell) carries the startup options; libpq sends
+  # them in the StartupMessage exactly like search_path. Run a real query so the
+  # CP actually spawns + activates the sized worker.
+  ( export PGOPTIONS="-c duckgres.worker_cpu=$cpu -c duckgres.worker_memory=$mem -c duckgres.worker_ttl=$ttl"
+    _pg_exec "$org" "$pw" "$cat" 'SELECT 1' ) >/dev/null \
+    || fail "sized worker query failed on $org/$cat"
+  pod="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$org" \
+        --sort-by=.metadata.creationTimestamp \
+        -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null)"
+  [ -n "$pod" ] || fail "sized worker: no worker pod for $org"
+  rcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.cpu}")"
+  rmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.memory}")"
+  lcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.limits.cpu}")"
+  lmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.limits.memory}")"
+  [ "$rcpu" = "$cpu" ] || fail "sized worker $pod requests.cpu='$rcpu' want '$cpu' (sizing not applied — BestEffort?)"
+  [ "$rmem" = "$mem" ] || fail "sized worker $pod requests.memory='$rmem' want '$mem'"
+  [ "$lcpu" = "$cpu" ] || fail "sized worker $pod limits.cpu='$lcpu' want '$cpu'"
+  [ "$lmem" = "$mem" ] || fail "sized worker $pod limits.memory='$lmem' want '$mem'"
+  log "sized worker OK: $pod requests/limits cpu=$rcpu mem=$rmem"
+}
+
+# Same-shape reconnect must REUSE the hot-idle sized worker, not spawn a second.
+# After sized_worker leaves exactly one hot-idle worker of this shape for the
+# org, an identical sized connection re-uses it (Destroy-before-reuse makes the
+# prior session gone before the next is assigned), so the count of worker pods
+# of that CPU stays 1 — a respawn would make it 2. A non-trivial TTL keeps the
+# first alive across this check.
+count_org_workers_of_cpu() { # org cpu  -> prints count
+  n=0
+  for p in $(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" \
+        -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    c="$(k get pod "$p" -o jsonpath="${WORKER_C}.resources.requests.cpu}" 2>/dev/null)"
+    [ "$c" = "$2" ] && n=$((n + 1))
+  done
+  echo "$n"
+}
+reuse_sized_worker() { # org password catalog cpu memory ttl
+  org="$1"; pw="$2"; cat="$3"; cpu="$4"; mem="$5"; ttl="$6"
+  log "sized worker reuse on $org/$cat (same shape must not respawn)"
+  # Let the prior sized session fully release to hot-idle before re-acquiring.
+  sleep 5
+  ( export PGOPTIONS="-c duckgres.worker_cpu=$cpu -c duckgres.worker_memory=$mem -c duckgres.worker_ttl=$ttl"
+    _pg_exec "$org" "$pw" "$cat" 'SELECT 1' ) >/dev/null \
+    || fail "sized worker reuse query failed on $org/$cat"
+  n="$(count_org_workers_of_cpu "$org" "$cpu")"
+  [ "$n" = "1" ] || fail "sized worker reuse: org $org has $n pods of cpu=$cpu, want 1 (same-shape request respawned instead of reusing the hot-idle worker)"
+  log "sized worker reuse OK: 1 pod of cpu=$cpu (reused, no respawn)"
+}
+
 # ---- resilience -----------------------------------------------------------
 # Worker pod killed mid-life → CP refills and a fresh query succeeds.
 # Ported from TestK8sWorkerCrashRecovery.
@@ -571,6 +640,16 @@ main() {
   graceful_drain         "$CNPG" "$cnpg_pw"
   one_session_per_worker "$CNPG" "$cnpg_pw"
 
+  # ---- worker sizing (TTL-pool model) on cnpg, both catalogs ----
+  # Distinct shapes per catalog (2/4Gi vs 3/6Gi) so the iceberg sized request
+  # can't reuse the ducklake org's hot-idle 2-CPU worker (workers are
+  # catalog-agnostic; only the profile shape gates reuse) — each catalog gets a
+  # verified fresh sized spawn, then a verified same-shape reuse.
+  sized_worker        "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
+  reuse_sized_worker  "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
+  sized_worker        "$CNPG" "$cnpg_pw" iceberg  3 6Gi 15m
+  reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  3 6Gi 15m
+
   # ---- ext backend (activation + R/W on the external-RDS metadata path) ----
   wait_worker "$EXT" "$ext_pw" ducklake
   basic_query  "$EXT" "$ext_pw"
@@ -590,7 +669,7 @@ main() {
   # end-to-end would need a warm target >0 in the per-PR CP (see README).
   log "SKIP shared-warm-activation + version-reaper (CP runs warm-target=0; see README)"
 
-  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: wire + warm-pool-backpressure + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -214,6 +214,22 @@ spec:
             - { name: DUCKGRES_K8S_WORKER_CONFIGMAP, value: "duckgres-config" }
             - { name: DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT, value: "duckgres-worker" }
             - { name: DUCKGRES_K8S_SHARED_WARM_TARGET, value: "0" }
+            # Worker-TTL-pool model (docs/design/worker-ttl-pool.md): no warm pool.
+            # With shared-warm-target=0 the configstore-driven dynamic warm-capacity
+            # spawner would still add neutral (org="") workers from warm-miss history,
+            # defeating the on-demand model — disable it so the only workers are the
+            # ones a client request sizes + spawns.
+            - { name: DUCKGRES_K8S_DYNAMIC_WARM_CAPACITY_ENABLED, value: "false" }
+            # Honor client-supplied worker shape/TTL startup options
+            # (duckgres.worker_cpu/worker_memory/worker_ttl), clamped to a sane band.
+            # The harness sized_worker assertion connects with these and verifies the
+            # spawned pod carries the requested CPU+memory.
+            - { name: DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE, value: "true" }
+            - { name: DUCKGRES_K8S_WORKER_PROFILE_MIN_CPU, value: "1" }
+            - { name: DUCKGRES_K8S_WORKER_PROFILE_MAX_CPU, value: "8" }
+            - { name: DUCKGRES_K8S_WORKER_PROFILE_MIN_MEMORY, value: "2Gi" }
+            - { name: DUCKGRES_K8S_WORKER_PROFILE_MAX_MEMORY, value: "16Gi" }
+            - { name: DUCKGRES_K8S_WORKER_MAX_TTL, value: "24h" }
             - name: DUCKGRES_INTERNAL_SECRET
               valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
             - { name: DUCKGRES_AWS_REGION, value: "us-east-1" }


### PR DESCRIPTION
## Why

The worker-TTL-pool model (`docs/design/worker-ttl-pool.md`) lets a client pick the worker shape + TTL via `duckgres.worker_cpu` / `worker_memory` / `worker_ttl` startup options. Nothing in the e2e harness exercised it — and the per-PR CP didn't even enable the feature. Getting solid e2e coverage here first makes the upcoming warm-machinery dead-code removal safe.

## What

**Harness (`harness.sh`)**
- `sized_worker` — connect with the sizing options (via `PGOPTIONS`), then assert the spawned worker pod's `duckdb-worker` container carries the requested **CPU + memory on both requests and limits** (proving the shape flows control-plane → k8s pod spec, not BestEffort). A distinct shape per catalog guarantees a fresh spawn (reuse is exact-profile-match only), so the newest worker pod is unambiguously ours.
- `reuse_sized_worker` — a same-shape reconnect must **reuse** the hot-idle worker: the count of that-shape pods for the org stays 1 (a respawn would make it 2).
- Both run on **cnpg** for the **ducklake** (2 CPU / 4Gi) and **iceberg** (3 CPU / 6Gi) catalogs. Distinct shapes so the catalog-agnostic worker can't satisfy the iceberg request from the ducklake org's hot-idle pool — each catalog gets a verified fresh sized spawn + a verified reuse.

**Per-PR CP config (`manifests.tmpl.yaml`)**
- Enable `DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE` with min/max CPU+memory and max-TTL clamps so the options are honored (and clamped) in CI.
- `DUCKGRES_K8S_DYNAMIC_WARM_CAPACITY_ENABLED=false` — with `shared-warm-target=0` the configstore-driven dynamic warm-capacity spawner would otherwise add neutral (`org=""`) workers from warm-miss history, defeating the on-demand model. Matches the live mw-dev deployment (PostHog/charts#11846).

README updated with the new sizing coverage; clamp enforcement itself stays unit-covered (`controlplane/worker_profile_test.go`).

## Test

Local `sh -n harness.sh` passes. The real assertion is the per-PR `e2e-mw-dev` Job against the live mw-dev cluster — watching this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)