### PR TITLE
Clean up remaining warm pool and neutral worker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,14 +668,14 @@ See [`k8s/README.md`](k8s/README.md) for the full architecture, configuration re
 
 On the multi-tenant path, the config store now keeps per-team managed-warehouse metadata in addition to team/user auth and limits. That team-scoped contract is intended to become the source of truth for the tenant warehouse DB, the tenant DuckLake metadata store (which may live on shared Aurora or a dedicated RDS instance), object-store settings, worker identity, secret references, and provisioning state. The older config-store `DuckLakeConfig` singleton remains only as a legacy cluster-wide setting and should not be treated as authoritative for multi-tenant runtime wiring.
 
-The shared K8s pool keeps workers neutral at startup, reserves them per org, activates tenant runtime over the control-plane RPC channel, and keeps idle activated workers briefly available for same-org hot-idle reuse before janitor retirement.
+The shared K8s pool spawns workers on-demand, reserves them per org, activates tenant runtime over the control-plane RPC channel, and keeps idle activated workers briefly available for same-org hot-idle reuse before janitor retirement.
 
 Managed-warehouse contract notes:
 
 - At most one managed-warehouse row exists per team. The row may be absent before first provisioning or after cleanup, but there is never more than one active warehouse contract for a team.
 - The admin API exposes that contract at `GET /api/v1/teams/:name/warehouse` and `PUT /api/v1/teams/:name/warehouse`. Team list/get responses also include a nested `warehouse` object when present.
 - User rows support an optional `default_catalog` field on `POST /api/v1/users` and `PUT /api/v1/orgs/:id/users/:username`. The default is empty, which preserves the standard DuckLake-first session behavior. Set `default_catalog` to `iceberg` for users whose sessions should resolve schema-qualified names and compatibility metadata through the Iceberg catalog by default; a client-supplied startup `search_path` still takes precedence.
-- The typed sections are `warehouse_database`, `metadata_store`, `s3`, `worker_identity`, and structured secret refs for `warehouse_database_credentials`, `metadata_store_credentials`, `s3_credentials`, and `runtime_config`. In shared warm mode, every non-empty secret ref must store an explicit `namespace`, and it must match `worker_identity.namespace`.
+- The typed sections are `warehouse_database`, `metadata_store`, `s3`, `worker_identity`, and structured secret refs for `warehouse_database_credentials`, `metadata_store_credentials`, `s3_credentials`, and `runtime_config`. In shared worker mode, every non-empty secret ref must store an explicit `namespace`, and it must match `worker_identity.namespace`.
 - Secret references only are stored in the config store. Secret material remains outside the database.
 - The provisioning fields are stored directly on the warehouse row as overall `state` / `status_message`, per-resource `*_state` / `*_status_message`, plus `ready_at` and `failed_at`.
 - Those state fields are open strings. Canonical values are `pending`, `provisioning`, `ready`, `failed`, `deleting`, and `deleted`, but callers may persist other values while workflows evolve.

--- a/configresolve/resolve_k8s_test.go
+++ b/configresolve/resolve_k8s_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestResolveEffectiveDefaultsK8sWorkerServiceAccountToNeutralWorker(t *testing.T) {
+func TestResolveEffectiveDefaultsK8sWorkerServiceAccountToDefaultWorker(t *testing.T) {
 	resolved := ResolveEffective(nil, CLIInputs{}, nil, nil)
 
 	if resolved.K8sWorkerServiceAccount != "duckgres-worker" {

--- a/controlplane/configstore/lifecycle_types.go
+++ b/controlplane/configstore/lifecycle_types.go
@@ -53,7 +53,7 @@ func (s WorkerSnapshot) PodName() string { return s.record.PodName }
 func (s WorkerSnapshot) Image() string { return s.record.Image }
 
 // OrgID returns the org id the worker was assigned to at observation time.
-// Empty for neutral warm workers.
+// Empty for unassigned workers.
 func (s WorkerSnapshot) OrgID() string { return s.record.OrgID }
 
 // OwnerCPInstanceID returns the control-plane id that owned the worker at

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -439,7 +439,7 @@ type WorkerRecord struct {
 	// TTLMinutes is how long this worker stays hot-idle after its last query
 	// before the janitor retires it (client-selected duckgres.worker_ttl, rounded
 	// down to whole minutes). 0 = use the deployment's global hot-idle TTL
-	// (default/warm/neutral workers and legacy rows). AutoMigrate adds this
+	// (default/legacy workers and legacy rows). AutoMigrate adds this
 	// column; no migration file.
 	TTLMinutes          int         `gorm:"default:0" json:"ttl_minutes"`
 	State               WorkerState `gorm:"size:32;not null;index" json:"state"`
@@ -454,7 +454,7 @@ type WorkerRecord struct {
 	// will expire. Stamped when the control plane mints creds (initial
 	// activation, takeover, scheduled refresh) and consulted by the
 	// credential refresh scheduler to pick workers nearing expiry. NULL on
-	// workers that haven't had creds issued yet (warm pool) and on legacy
+	// workers that haven't had creds issued yet and on legacy
 	// rows from before this column existed — both are treated as "due now"
 	// by the scheduler so they get refreshed eagerly.
 	S3CredentialsExpiresAt *time.Time `gorm:"index" json:"s3_credentials_expires_at,omitempty"`

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -791,7 +791,7 @@ func (cs *ConfigStore) runtimeTable(base string) string {
 // state by image and tenant binding for Prometheus observability.
 func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error) {
 	// "neutral" (empty org_id) is legacy — every worker is org-bound from spawn
-	// now (no warm pool); the branch only matches pre-existing/legacy rows.
+	// now; the branch only matches pre-existing/legacy rows or single-tenant mode.
 	const bindingExpr = "CASE WHEN NULLIF(org_id, '') IS NULL THEN 'neutral' ELSE 'org_bound' END"
 	var out []WorkerLifecycleStats
 	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
@@ -953,7 +953,7 @@ func (cs *ConfigStore) GetWorkerRecord(workerID int) (*WorkerRecord, error) {
 // previously activated for the given org. The selected row is locked with
 // SKIP LOCKED and transitioned to reserved while incrementing owner_epoch.
 // When maxOrgWorkers is set, the org cap is checked under the same advisory
-// lock as neutral idle claims, excluding hot-idle rows from the count so a
+// lock as on-demand claims, excluding hot-idle rows from the count so a
 // cached worker can be reclaimed as the org's only active slot.
 func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, profileCPU, profileMemory string, maxOrgWorkers int) (*WorkerRecord, WorkerClaimMissReason, error) {
 	var claimed *WorkerRecord
@@ -1024,8 +1024,8 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID string, profi
 // ListExpiredHotIdleWorkers returns hot-idle workers whose per-worker TTL has
 // elapsed since they last became idle (updated_at, bumped on the hot->hot_idle
 // transition at session end, so the TTL resets on each query). A worker's
-// ttl_seconds governs it; 0 falls back to defaultTTL (default/warm/neutral and
-// legacy rows).
+// ttl_seconds governs it; 0 falls back to defaultTTL (default/legacy and
+// unassigned rows).
 func (cs *ConfigStore) ListExpiredHotIdleWorkers(now time.Time, defaultTTL time.Duration) ([]WorkerRecord, error) {
 	defMins := int64(defaultTTL.Minutes())
 	if defMins < 0 {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -110,7 +110,7 @@ type K8sConfig struct {
 	WorkerSecret            string // Base name for per-worker K8s Secrets containing RPC bearer token and TLS material
 	WorkerConfigMap         string // ConfigMap name for duckgres.yaml
 	ImagePullPolicy         string // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
-	ServiceAccount          string // Neutral ServiceAccount name for worker pods (default: "duckgres-worker")
+	ServiceAccount          string // ServiceAccount name for worker pods (default: "duckgres-worker")
 	MaxWorkers              int    // Global cap for the shared K8s worker pool (0 = unbounded; cluster autoscaler is the natural ceiling)
 	WorkerCPURequest        string // CPU request for worker pods (e.g., "500m")
 	WorkerMemoryRequest     string // Memory request for worker pods (e.g., "1Gi")
@@ -145,7 +145,7 @@ type K8sConfig struct {
 	// default-profile worker — sized profiles carry their own duckgres.worker_ttl)
 	// retains its org assignment before the janitor retires it. 0 = the built-in
 	// default (defaultHotIdleTTL, 5m). Raise this above a tenant's job cadence
-	// (e.g. 70m for hourly jobs) so scheduled workloads reclaim warm workers
+	// (e.g. 70m for hourly jobs) so scheduled workloads reuse hot-idle workers
 	// instead of cold-spawning every run — at the cost of idle worker nodes.
 	HotIdleTTL time.Duration
 }

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -435,11 +435,11 @@ func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
 
 	var mu sync.Mutex
-	reconciled := 0
+	lifecycleObserved := 0
 	janitor.observeWorkerLifecycle = func() {
 		mu.Lock()
 		defer mu.Unlock()
-		reconciled++
+		lifecycleObserved++
 	}
 
 	janitor.runOnce()
@@ -462,7 +462,7 @@ func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if reconciled != 1 {
-		t.Fatalf("expected warm capacity reconciliation despite expiry error, got %d", reconciled)
+	if lifecycleObserved != 1 {
+		t.Fatalf("expected worker lifecycle observation despite expiry error, got %d", lifecycleObserved)
 	}
 }

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -96,7 +96,7 @@ type K8sWorkerPool struct {
 
 	// nodeFirstSeen tracks the first time this CP observed a worker on each
 	// node. Used to prefer reaping workers on the newest-seen nodes and
-	// claiming idle workers on the oldest-seen nodes, so warm parquet pages
+	// claiming idle workers on the oldest-seen nodes, so cached parquet pages
 	// on the local NVMe cache-proxy stay useful for longer. Per-CP state;
 	// CPs don't coordinate this (see idleReaper/findIdleWorker).
 	nodeFirstSeen map[string]time.Time

--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -218,7 +218,7 @@ func (p *K8sWorkerPool) ActivateReservedWorker(ctx context.Context, worker *Mana
 	return nil
 }
 
-// ReserveSharedWorker reserves a neutral warm worker for later tenant activation.
+// ReserveSharedWorker claims a hot-idle worker or spawns one on demand.
 // Composition of the gateable decision (reserveSharedWorkerDecision) and the slow
 // completion (completeSharedWorkerReservation); OrgReservedPool calls the two
 // halves separately so the per-org FIFO gate covers only the decision.
@@ -508,7 +508,7 @@ func (p *K8sWorkerPool) adoptClaimedWorker(ctx context.Context, claimed *configs
 	// already bumped the epoch in the DB. The health check requires exact epoch
 	// match, so neither the old epoch (worker has N, we'd send N+1) nor the new
 	// CP instance ID will pass. ActivateTenant validates the epoch properly
-	// (accepts > current). For fresh neutral workers (epoch 0), use the normal
+	// (accepts > current). For freshly spawned workers (epoch 0), use the normal
 	// health-checked path.
 	var client *flightsql.Client
 	if claimed.OwnerEpoch > 1 {
@@ -637,7 +637,7 @@ func validateReservedWorkerHealth(result *healthCheckResult) error {
 	return nil
 }
 
-// SpawnMinWorkers is a no-op for the K8s pool: there is no warm pool to
+// SpawnMinWorkers is a no-op for the K8s pool: workers are created on demand.
 // pre-spawn. Workers are created on demand per request (ReserveSharedWorker)
 // and reused while hot-idle until their TTL. Present only to satisfy the
 // WorkerPool interface (the process backend uses it for --process-min-workers).
@@ -702,7 +702,7 @@ func (p *K8sWorkerPool) findIdleWorkerLocked() *ManagedWorker {
 			continue
 		default:
 		}
-		if !p.isWarmIdleWorkerLocked(w) {
+		if !p.isIdleWorkerLocked(w) {
 			continue
 		}
 		seen := p.nodeSeenAtLocked(w.nodeName, now)
@@ -749,6 +749,6 @@ func (p *K8sWorkerPool) isGenericSessionSchedulableWorkerLocked(w *ManagedWorker
 	return w.SharedState().NormalizedLifecycle() == WorkerLifecycleIdle
 }
 
-func (p *K8sWorkerPool) isWarmIdleWorkerLocked(w *ManagedWorker) bool {
+func (p *K8sWorkerPool) isIdleWorkerLocked(w *ManagedWorker) bool {
 	return w.activeSessions == 0 && p.isGenericSessionSchedulableWorkerLocked(w)
 }

--- a/controlplane/k8s_pool_helpers.go
+++ b/controlplane/k8s_pool_helpers.go
@@ -76,11 +76,11 @@ func (p *K8sWorkerPool) workerRecordFor(id int, worker *ManagedWorker, ownerEpoc
 	}
 	if worker == nil {
 		// OwnerCPInstanceID is already this CP's id from the struct literal
-		// above. Stamping warm/idle workers with the creating CP keeps
+		// above. Stamping idle workers with the creating CP keeps
 		// last_heartbeat_at fresh via the CP heartbeat — without it, the
 		// orphan reconciler matches case (2) (NULLIF(owner_cp_instance_id,
 		// '') IS NULL AND last_heartbeat_at <= before) the moment the row
-		// crosses orphanGrace, so warm workers get reaped on a ~30s loop.
+		// crosses orphanGrace, so idle workers get reaped on a ~30s loop.
 		return record
 	}
 	record.PodName = p.workerPodName(worker)

--- a/controlplane/k8s_pool_lifecycle.go
+++ b/controlplane/k8s_pool_lifecycle.go
@@ -697,14 +697,14 @@ func (p *K8sWorkerPool) reapIdleWorkers() {
 	now := time.Now()
 	idleCount := 0
 	for _, w := range p.workers {
-		if p.isWarmIdleWorkerLocked(w) {
+		if p.isIdleWorkerLocked(w) {
 			idleCount++
 		}
 	}
 
 	// Build the list of reap-eligible workers and sort by the first time
 	// this CP saw their node — newest node first. We prefer evicting workers
-	// on nodes we only just started using so older nodes keep their warm
+	// on nodes we only just started using so older nodes keep their cached
 	// NVMe parquet cache for longer. Workers with no known nodeName sort as
 	// "new" (they're reaped first) to avoid stalling on stale state.
 	type candidate struct {
@@ -714,7 +714,7 @@ func (p *K8sWorkerPool) reapIdleWorkers() {
 	}
 	var candidates []candidate
 	for id, w := range p.workers {
-		if p.isWarmIdleWorkerLocked(w) && !w.lastUsed.IsZero() && now.Sub(w.lastUsed) > p.idleTimeout {
+		if p.isIdleWorkerLocked(w) && !w.lastUsed.IsZero() && now.Sub(w.lastUsed) > p.idleTimeout {
 			candidates = append(candidates, candidate{id: id, w: w, seenAt: p.nodeSeenAtLocked(w.nodeName, now)})
 		}
 	}

--- a/controlplane/k8s_pool_reconcile.go
+++ b/controlplane/k8s_pool_reconcile.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// RetireOneMismatchedVersionWorker scans all shared warm-worker pods in the
+// RetireOneMismatchedVersionWorker scans all shared worker pods in the
 // namespace for one whose duckgres/control-plane label identifies a different
 // Deployment ReplicaSet (pod-template-hash) than this CP, atomically marks
 // its idle runtime-store row retired, and deletes the pod.
@@ -77,7 +77,7 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 		}
 
 		// Resolve the target version for this specific pod.
-		// For neutral workers, the target is the global binary version.
+		// For unassigned workers, the target is the global binary version.
 		// For assigned workers, the target is the tenant's configured image.
 		var isMismatched bool
 		podOrgID := pod.Labels["duckgres/org"]

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1166,7 +1166,7 @@ func TestK8sPoolReserveSharedWorkerReturnsOrgCapFromHotIdleClaim(t *testing.T) {
 	})
 	var capacityErr *WorkerCapacityExhaustedError
 	if !errors.As(err, &capacityErr) {
-		t.Fatalf("expected warm capacity exhaustion, got worker=%#v err=%v", worker, err)
+		t.Fatalf("expected worker capacity exhaustion, got worker=%#v err=%v", worker, err)
 	}
 	if capacityErr.Reason != configstore.WorkerClaimMissReasonOrgCap {
 		t.Fatalf("expected org-cap miss reason, got %q", capacityErr.Reason)
@@ -1175,7 +1175,7 @@ func TestK8sPoolReserveSharedWorkerReturnsOrgCapFromHotIdleClaim(t *testing.T) {
 		t.Fatalf("expected no worker on capacity miss, got %d", worker.ID)
 	}
 	if store.claimCalls != 0 {
-		t.Fatalf("expected hot-idle org cap to skip neutral idle claim, got %d idle claims", store.claimCalls)
+		t.Fatalf("expected hot-idle org cap to prevent on-demand spawn, got %d idle claims", store.claimCalls)
 	}
 	if store.recordMissCalls != 0 {
 		t.Fatalf("expected no recorded miss for org-cap, got %d", store.recordMissCalls)
@@ -1345,18 +1345,18 @@ func TestK8sPoolActivateReservedWorkerPersistsActivatingThenHotWorkerRecord(t *t
 }
 
 // TestK8sPoolWorkerRecordForIdleStampsOwnerCPInstanceID guards against the
-// warm-pool churn loop. workerRecordFor used to clear OwnerCPInstanceID
-// whenever state==Idle, which left every freshly-spawned warm worker
+// idle worker churn loop. workerRecordFor used to clear OwnerCPInstanceID
+// whenever state==Idle, which left every freshly-spawned idle worker
 // matching ListOrphanedWorkers case (2) (NULLIF(owner_cp_instance_id, ”) IS
 // NULL AND last_heartbeat_at <= before) the moment it crossed the orphan
-// grace. The janitor then retired it, the warm pool replenished, and the
-// loop repeated indefinitely. Stamping warm workers with the creating CP's
+// grace. The janitor then retired it, the idle worker replenished, and the
+// loop repeated indefinitely. Stamping idle workers with the creating CP's
 // id makes case (1) handle them via the existing CP heartbeat instead.
 func TestK8sPoolWorkerRecordForIdleStampsOwnerCPInstanceID(t *testing.T) {
 	pool, _ := newTestK8sPool(t, 5)
 
 	// worker == nil branch: spawn path before the in-memory ManagedWorker
-	// exists. Used by the warm-slot creation flow.
+	// exists. Used by the idle worker creation flow.
 	rec := pool.workerRecordFor(11, nil, 0, configstore.WorkerStateIdle, "", nil)
 	if rec.OwnerCPInstanceID != pool.cpInstanceID {
 		t.Fatalf("worker==nil idle: expected OwnerCPInstanceID %q, got %q", pool.cpInstanceID, rec.OwnerCPInstanceID)
@@ -2596,17 +2596,17 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 		t.Fatalf("expected owner-epoch label 0, got %s", pod.Labels["duckgres/owner-epoch"])
 	}
 	if _, ok := pod.Labels["duckgres/org"]; ok {
-		t.Fatalf("expected shared warm worker startup to stay org-neutral, got labels %#v", pod.Labels)
+		t.Fatalf("expected shared worker startup to stay org-neutral, got labels %#v", pod.Labels)
 	}
 
 	if len(pod.OwnerReferences) != 0 {
 		t.Fatalf("expected no owner references, got %d", len(pod.OwnerReferences))
 	}
 	if pod.Spec.ServiceAccountName != "duckgres-worker" {
-		t.Fatalf("expected neutral worker service account duckgres-worker, got %q", pod.Spec.ServiceAccountName)
+		t.Fatalf("expected shared worker service account duckgres-worker, got %q", pod.Spec.ServiceAccountName)
 	}
 	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
-		t.Fatal("expected automountServiceAccountToken=false for shared warm worker pods")
+		t.Fatal("expected automountServiceAccountToken=false for shared worker pods")
 	}
 	if pod.Spec.TerminationGracePeriodSeconds == nil || *pod.Spec.TerminationGracePeriodSeconds != workerTerminationGracePeriodSeconds {
 		t.Fatalf("expected terminationGracePeriodSeconds=%d, got %v", workerTerminationGracePeriodSeconds, pod.Spec.TerminationGracePeriodSeconds)
@@ -2652,7 +2652,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 		t.Fatal("bearer token env var not found or incorrect")
 	}
 	if !foundSharedWarmWorkerEnv {
-		t.Fatal("expected shared warm worker startup env to be present")
+		t.Fatal("expected shared worker startup env to be present")
 	}
 	if !foundTLSCertEnv || !foundTLSKeyEnv {
 		t.Fatal("expected worker RPC TLS env vars to be present")
@@ -4022,7 +4022,7 @@ func TestShutdownAll_TreatsPodNotFoundAsDeleteSuccess(t *testing.T) {
 // query sessions land on cache-warm nodes and Karpenter can consolidate the
 // newest nodes first.
 
-// addIdleWorker inserts a ready warm-idle worker on nodeName with a matching
+// addIdleWorker inserts a ready idle worker on nodeName with a matching
 // nodeFirstSeen entry. idleFor controls how far in the past lastUsed is —
 // must exceed idleTimeout for the reaper to consider it.
 func addIdleWorker(t *testing.T, p *K8sWorkerPool, id int, nodeName string, nodeSeenAt time.Time, idleFor time.Duration) {

--- a/controlplane/org_activation_test.go
+++ b/controlplane/org_activation_test.go
@@ -342,7 +342,7 @@ func TestSharedWorkerActivatorDucklingCRRequiresSTSBroker(t *testing.T) {
 
 	_, err := activator.BuildActivationRequest(context.Background(), org, &WorkerAssignment{OrgID: "test-org"})
 	if err == nil {
-		t.Fatal("expected shared warm activation to fail without an STS broker")
+		t.Fatal("expected worker activation to fail without an STS broker")
 		return
 	}
 }

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -11,7 +11,7 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
-// OrgReservedPool presents one org's reserved slice of a shared K8s warm pool.
+// OrgReservedPool presents one org's reserved slice of a shared K8s pool.
 // It preserves the existing WorkerPool contract for SessionManager while ensuring
 // workers are reserved to a single org for their lifetime and retired after use.
 type OrgReservedPool struct {
@@ -55,7 +55,7 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 	// Fast path: reuse an already-assigned, idle (Hot) worker of the requested
 	// shape. Such a worker is already this org's and free, so reusing it
 	// concurrently is safe and needs no FIFO ordering — it is not a freshly
-	// spawned/neutral worker that a queued waiter is owed (those are claimed only
+	// spawned worker that a queued waiter is owed (those are claimed only
 	// via the gated slow path below).
 	if w := p.tryReuseIdleAssigned(profile); w != nil {
 		return w, nil

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -58,7 +58,7 @@ func (p *acquireErrorPool) SetMaxWorkers(n int) {}
 
 func (p *acquireErrorPool) ShutdownAll() {}
 
-func TestCreateSessionObservesWarmCapacityExhaustion(t *testing.T) {
+func TestCreateSessionObservesWorkerCapacityExhaustion(t *testing.T) {
 	controlPlaneWorkerAcquireFailuresCounter.Reset()
 	sm := NewSessionManager(&acquireErrorPool{
 		err: NewWorkerCapacityExhaustedError(30 * time.Second),
@@ -67,19 +67,19 @@ func TestCreateSessionObservesWarmCapacityExhaustion(t *testing.T) {
 	_, _, err := sm.CreateSession(context.Background(), "root", 1001, "", 0, nil)
 	var capacityErr *WorkerCapacityExhaustedError
 	if !errors.As(err, &capacityErr) {
-		t.Fatalf("expected warm capacity error, got %v", err)
+		t.Fatalf("expected worker capacity error, got %v", err)
 	}
 
 	counter, counterErr := controlPlaneWorkerAcquireFailuresCounter.GetMetricWithLabelValues("worker_capacity_exhausted")
 	if counterErr != nil {
-		t.Fatalf("failed to read warm capacity counter: %v", counterErr)
+		t.Fatalf("failed to read worker capacity counter: %v", counterErr)
 	}
 	metric := &dto.Metric{}
 	if err := counter.Write(metric); err != nil {
-		t.Fatalf("failed to write warm capacity counter: %v", err)
+		t.Fatalf("failed to write worker capacity counter: %v", err)
 	}
 	if got := metric.GetCounter().GetValue(); got != 1 {
-		t.Fatalf("expected one warm capacity acquisition failure, got %v", got)
+		t.Fatalf("expected one worker capacity acquisition failure, got %v", got)
 	}
 }
 

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -460,10 +460,10 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromDuckling(ctx context.Cont
 
 	// Broker S3 credentials via STS AssumeRole
 	if status.IAMRoleARN == "" {
-		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no IAM role ARN for shared warm activation", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("duckling CR %q has no IAM role ARN for worker activation", orgID)
 	}
 	if a.stsBroker == nil {
-		return server.DuckLakeConfig{}, nil, fmt.Errorf("STS broker is required for shared warm activation for org %q", orgID)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("STS broker is required for worker activation for org %q", orgID)
 	}
 	creds, err := a.stsBroker.AssumeRole(ctx, status.IAMRoleARN)
 	if err != nil {
@@ -548,10 +548,10 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.C
 	case strings.EqualFold(warehouse.S3.Provider, "aws"):
 		roleARN := warehouse.WorkerIdentity.IAMRoleARN
 		if roleARN == "" {
-			return server.DuckLakeConfig{}, fmt.Errorf("managed warehouse %q requires worker_identity.iam_role_arn for shared warm activation", warehouse.OrgID)
+			return server.DuckLakeConfig{}, fmt.Errorf("managed warehouse %q requires worker_identity.iam_role_arn for worker activation", warehouse.OrgID)
 		}
 		if a.stsBroker == nil {
-			return server.DuckLakeConfig{}, fmt.Errorf("STS broker is required for shared warm activation for org %q", warehouse.OrgID)
+			return server.DuckLakeConfig{}, fmt.Errorf("STS broker is required for worker activation for org %q", warehouse.OrgID)
 		}
 		creds, err := a.stsBroker.AssumeRole(ctx, roleARN)
 		if err != nil {

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -28,9 +28,9 @@ import (
 type ManagedWorker struct {
 	ID             int
 	podName        string
-	nodeName       string        //nolint:unused // only set in kubernetes warm-pool; drives cache-locality-aware scheduling
-	image          string        //nolint:unused // only set in kubernetes warm-pool; carried through runtime store records
-	profile        WorkerProfile //nolint:unused // only set in kubernetes warm-pool; pod-shape this worker was spawned with (zero = default exclusive)
+	nodeName       string        //nolint:unused // only set in kubernetes remote backend; drives cache-locality-aware scheduling
+	image          string        //nolint:unused // only set in kubernetes remote backend; carried through runtime store records
+	profile        WorkerProfile //nolint:unused // only set in kubernetes remote backend; pod-shape this worker was spawned with (zero = default exclusive)
 	cmd            *exec.Cmd
 	socketPath     string
 	bearerToken    string
@@ -43,7 +43,7 @@ type ManagedWorker struct {
 	activeSessions int       // Number of sessions currently assigned to this worker
 	lastUsed       time.Time // Last time a session was destroyed on this worker
 	sharedState    SharedWorkerState
-	reservedAt     time.Time //nolint:unused // only set in kubernetes warm-pool reservation path
+	reservedAt     time.Time //nolint:unused // only set in kubernetes remote backend reservation path
 	peakSessions   int       // High-water mark of concurrent sessions (for retirement metrics)
 	// ownerEpoch is guarded by epochMu so cred-refresh's
 	// "RefreshLease then SetOwnerEpoch" sequence appears atomic to
@@ -58,13 +58,13 @@ type ManagedWorker struct {
 	cachedActivationPayload any  //nolint:unused // *TenantActivationPayload, cached in kubernetes activation path
 }
 
-// SharedState returns the additive shared warm-worker lifecycle metadata for
+// SharedState returns the additive shared worker lifecycle metadata for
 // this worker. The zero value normalizes to an idle, unassigned worker.
 func (w *ManagedWorker) SharedState() SharedWorkerState {
 	return cloneSharedWorkerState(w.sharedState)
 }
 
-// SetSharedState updates the additive shared warm-worker lifecycle metadata
+// SetSharedState updates the additive shared worker lifecycle metadata
 // without changing existing session scheduling behavior.
 func (w *ManagedWorker) SetSharedState(state SharedWorkerState) error {
 	if err := state.Validate(); err != nil {

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -102,7 +102,7 @@ type K8sWorkerPoolConfig struct {
 	IdleTimeout                  time.Duration
 	ConfigPath                   string                                       // Path inside worker pod where config is mounted
 	ImagePullPolicy              string                                       // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
-	ServiceAccount               string                                       // Neutral ServiceAccount name for worker pods (default: "duckgres-worker")
+	ServiceAccount               string                                       // ServiceAccount name for worker pods (default: "duckgres-worker")
 	WorkerCPURequest             string                                       // CPU request for worker pods (e.g., "500m"). Empty = BestEffort.
 	WorkerMemoryRequest          string                                       // Memory request for worker pods (e.g., "1Gi"). Empty = BestEffort.
 	WorkerNodeSelector           map[string]string                            // Node selector for worker pods. Nil = no selector.

--- a/controlplane/worker_state.go
+++ b/controlplane/worker_state.go
@@ -5,9 +5,8 @@ import (
 	"time"
 )
 
-// WorkerLifecycleState models the shared warm-worker lifecycle introduced for
-// late tenant binding. The current production worker pools do not act on this
-// state yet; this is scaffolding for later shared-pool work.
+// WorkerLifecycleState models the shared worker lifecycle used for late
+// tenant binding (spawn → reserve → activate → hot → hot-idle → drain/retire).
 type WorkerLifecycleState string
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 // WorkerProfile describes the pod shape a session asked for via connection-string
-// startup options (duckgres.colocate / worker_cpu / worker_memory / worker_tier).
+// startup options (duckgres.worker_cpu / worker_memory / worker_ttl).
 // It is a match dimension on WorkerAssignment, ORTHOGONAL to Image: a reserved or
-// warm worker may only be handed to a request whose profile Equal()s it.
+// hot-idle worker may only be handed to a request whose profile Equal()s it.
 //
 // The nil/zero profile is the DEFAULT profile: empty CPU/Memory (the pool-global
 // request applies). Normalizing the default to empty strings (rather than the
@@ -77,8 +76,7 @@ type WorkerAssignment struct {
 }
 
 // SharedWorkerState holds the additive lifecycle/assignment model for shared
-// warm workers. Existing worker pools can keep using their current session
-// counters until later PRs wire this state into scheduling decisions.
+// workers.
 type SharedWorkerState struct {
 	Lifecycle  WorkerLifecycleState
 	Assignment *WorkerAssignment

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -43,16 +43,16 @@ The control plane handles TLS, authentication, PostgreSQL wire protocol, and SQL
 | File | Description |
 |------|-------------|
 | `namespace.yaml` | `duckgres` namespace |
-| `rbac.yaml` | Control-plane and neutral worker ServiceAccounts, Role (pods + secrets), RoleBinding |
+| `rbac.yaml` | Control-plane and shared worker ServiceAccounts, Role (pods + secrets), RoleBinding |
 | `configmap.yaml` | Shared duckgres config (users, extensions, data dir) |
 | `secret.yaml` | Bearer token secret (auto-populated by CP if empty) |
 | `managed-warehouse-secrets.yaml` | Local secret payloads referenced by the seeded managed-warehouse contract |
 | `worker-identity.yaml` | Local worker ServiceAccount referenced by the seeded managed-warehouse contract |
 | `networkpolicy.yaml` | Restricts worker ingress to CP pods only |
-| `control-plane-multitenant-local.yaml` | Optional OrbStack-oriented shared warm-worker control-plane manifest |
+| `control-plane-multitenant-local.yaml` | Optional OrbStack-oriented shared-worker control-plane manifest |
 | `kind/config-store.overlay.yaml` | Compose overlay that attaches local dependency containers to the external Docker `kind` network |
-| `kind/config-store.seed.sql` | Kind-oriented managed-warehouse seed for the shared warm-worker flow |
-| `kind/control-plane.yaml` | Kind-first shared warm-worker control-plane manifest used by local dev and CI |
+| `kind/config-store-seed.sql` | Kind-oriented managed-warehouse seed for the shared-worker flow |
+| `kind/control-plane.yaml` | Kind-first shared-worker control-plane manifest used by local dev and CI |
 | `orbstack/dependency-ports.overlay.yaml` | Optional OrbStack overlay that publishes local DuckLake and MinIO dependency ports on the host |
 
 ## Configuration
@@ -69,13 +69,13 @@ Key flags for Kubernetes multitenant mode:
 | `--managed-hostname-suffixes` | `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES` | Comma-separated managed hostname suffixes such as `.dw.test.local` |
 | `--k8s-worker-image` | `DUCKGRES_K8S_WORKER_IMAGE` | Docker image for worker pods |
 | `--k8s-worker-image-pull-policy` | `DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY` | Image pull policy (`Never`, `IfNotPresent`, `Always`) |
-| `--k8s-worker-service-account` | `DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT` | Neutral ServiceAccount name for worker pods (`duckgres-worker` default) |
+| `--k8s-worker-service-account` | `DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT` | Shared ServiceAccount name for worker pods (`duckgres-worker` default) |
 | `--k8s-worker-secret` | `DUCKGRES_K8S_WORKER_SECRET` | K8s Secret name for bearer token |
 | `--k8s-worker-configmap` | `DUCKGRES_K8S_WORKER_CONFIGMAP` | ConfigMap name for worker config |
 
 The worker Secret setting is a base name for per-worker RPC Secrets. Each worker pod gets its own derived Secret containing its RPC bearer token and TLS material. If the derived Secret does not exist, the control plane creates it before spawning the pod.
 
-Shared warm workers should use the neutral `duckgres-worker` ServiceAccount with `automountServiceAccountToken: false`. Tenant authority must arrive only through activation-time scoped credentials.
+Shared workers should use the shared `duckgres-worker` ServiceAccount with `automountServiceAccountToken: false`. Tenant authority must arrive only through activation-time scoped credentials.
 
 For managed-hostname routing, `passthrough` logs legacy/non-managed callers while allowing them to route by requested dbname. `enforce` rejects Postgres clients whose TLS SNI does not match a configured managed suffix. In both managed modes, when SNI does match a suffix, the hostname prefix and requested Postgres database must resolve to the same org; if the client omits the startup database, the SNI prefix is used as the fallback database source. Unknown routing-mode values behave like `off`.
 
@@ -90,7 +90,7 @@ That gives the old replica time to fail readiness, stop taking new pgwire sessio
 
 ## Local Development with kind
 
-The primary shared warm-worker workflow now uses [`kind`](https://kind.sigs.k8s.io/). Prerequisites: Docker, `kubectl`, `kind`, and `just`.
+The primary shared-worker workflow now uses [`kind`](https://kind.sigs.k8s.io/). Prerequisites: Docker, `kubectl`, `kind`, and `just`.
 
 ```bash
 just run-multitenant-kind
@@ -101,7 +101,7 @@ PGPASSWORD=postgres psql "host=127.0.0.1 port=5432 user=postgres dbname=duckgres
 
 `just multitenant-port-forward-pg` forwards both pgwire on `5432` and Flight SQL on `8815`.
 
-`just run-multitenant-kind` recreates a local kind cluster, starts the config store plus the local warehouse DB, DuckLake metadata DB, and MinIO backing the seeded managed-warehouse contract, attaches those dependency containers to the Docker `kind` network, loads the locally built image into kind, and deploys the shared warm-worker control plane.
+`just run-multitenant-kind` recreates a local kind cluster, starts the config store plus the local warehouse DB, DuckLake metadata DB, and MinIO backing the seeded managed-warehouse contract, attaches those dependency containers to the Docker `kind` network, loads the locally built image into kind, and deploys the shared-worker control plane.
 
 Default login: `postgres / postgres`
 

--- a/k8s/kind/config-store-seed.sql
+++ b/k8s/kind/config-store-seed.sql
@@ -93,7 +93,7 @@ VALUES (
     'local-runtime',
     'duckgres.yaml',
     'ready',
-    'kind shared warm-worker metadata',
+    'kind shared-worker metadata',
     'ready',
     'kind warehouse db metadata seeded',
     'ready',

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -21,7 +21,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["create", "delete", "get", "list", "watch"]
-  # Validate the shared neutral worker startup config before spawn
+  # Validate the shared worker startup config before spawn
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -944,11 +944,10 @@ func TestListOrphanedAndStuckWorkersPostgres(t *testing.T) {
 }
 
 // TestListOrphanedWorkersIncludesOwnerlessIdleWorkers seeds a row that
-// reproduces the mw-dev incident: a neutral idle worker whose
+// reproduces the mw-dev incident: an unassigned idle worker whose
 // owner_cp_instance_id is the empty string. Today's INNER JOIN against
 // the cp_instances table excludes such rows, so the orphan janitor never
-// retires them, the warm-target check counts them as live capacity, and
-// no new warm workers ever spawn. The fix LEFT JOINs and adds an explicit
+// retires them. The fix LEFT JOINs and adds an explicit
 // "ownerless and stale" branch.
 func TestListOrphanedWorkersIncludesOwnerlessIdleWorkers(t *testing.T) {
 	store := newIsolatedConfigStore(t)
@@ -1297,12 +1296,12 @@ func TestListWorkersDueForCredentialRefreshSkipsReservedAndActivatingRows(t *tes
 	}
 }
 
-// TestListWorkersDueForCredentialRefreshSkipsHealthyAndNeutral:
+// TestListWorkersDueForCredentialRefreshSkipsHealthyAndUnassigned:
 //   - Healthy row (expiry comfortably in the future): not returned.
-//   - Neutral warm row (org_id=”): not returned regardless of expiry.
+//   - Unassigned row (org_id=”): not returned regardless of expiry.
 //     A pre-activation worker has no STS creds to refresh.
 //   - Terminal row (retired): not returned.
-func TestListWorkersDueForCredentialRefreshSkipsHealthyAndNeutral(t *testing.T) {
+func TestListWorkersDueForCredentialRefreshSkipsHealthyAndUnassigned(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.April, 30, 12, 0, 0, 0, time.UTC)
 	farFuture := now.Add(2 * time.Hour)
@@ -1340,7 +1339,7 @@ func TestListWorkersDueForCredentialRefreshSkipsHealthyAndNeutral(t *testing.T) 
 		t.Fatalf("ListWorkersDueForCredentialRefresh: %v", err)
 	}
 	if len(due) != 0 {
-		t.Fatalf("expected no rows returned (healthy / neutral / terminal), got %#v", due)
+		t.Fatalf("expected no rows returned (healthy / unassigned / terminal), got %#v", due)
 	}
 }
 

--- a/tests/manifests/manifests_test.go
+++ b/tests/manifests/manifests_test.go
@@ -39,7 +39,7 @@ func TestControlPlaneRBACIncludesSharedWorkerConfigMapRead(t *testing.T) {
 	}
 }
 
-func TestControlPlaneRBACDefinesNeutralWorkerServiceAccount(t *testing.T) {
+func TestControlPlaneRBACDefinesSharedWorkerServiceAccount(t *testing.T) {
 	content := readManifest(t, "k8s", "rbac.yaml")
 	for _, want := range []string{
 		"kind: ServiceAccount",
@@ -51,7 +51,7 @@ func TestControlPlaneRBACDefinesNeutralWorkerServiceAccount(t *testing.T) {
 		}
 	}
 	if strings.Contains(content, "subjects:\n  - kind: ServiceAccount\n    name: duckgres-worker") {
-		t.Fatal("expected neutral worker service account to have no RoleBinding in k8s/rbac.yaml")
+		t.Fatal("expected shared worker service account to have no RoleBinding in k8s/rbac.yaml")
 	}
 }
 


### PR DESCRIPTION
This PR cleans up remaining stale comments, metrics config, test assertions, variables, and deployment manifests referencing the old warm pool and neutral worker pool logic.