### PR TITLE
Simplify worker session continuations

### DIFF
--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -123,8 +123,8 @@ func releaseQueryHandleValue(handle *QueryHandle) {
 		releaseDrains = append(releaseDrains, handle.finishOperation)
 		handle.finishOperation = nil
 	}
-	releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
-	handle.pendingDrains = nil
+	releaseDrains = appendOptionalDrainTokenFunc(releaseDrains, handle.pendingDrain)
+	handle.pendingDrain = nil
 	for _, release := range releaseDrains {
 		releaseDrainFunc(release)
 	}
@@ -142,15 +142,15 @@ func appendQueryHandleReleaseFuncs(handle *QueryHandle, drainReleases, operation
 		operationReleases = append(operationReleases, handle.finishOperation)
 		handle.finishOperation = nil
 	}
-	for _, token := range handle.pendingDrains {
-		if token.finish != nil {
-			drainReleases = append(drainReleases, token.finish)
+	if handle.pendingDrain != nil {
+		if handle.pendingDrain.finish != nil {
+			drainReleases = append(drainReleases, handle.pendingDrain.finish)
 		}
-		if token.finishOperation != nil {
-			operationReleases = append(operationReleases, token.finishOperation)
+		if handle.pendingDrain.finishOperation != nil {
+			operationReleases = append(operationReleases, handle.pendingDrain.finishOperation)
 		}
+		handle.pendingDrain = nil
 	}
-	handle.pendingDrains = nil
 	return drainReleases, operationReleases
 }
 
@@ -173,36 +173,24 @@ func popAbandonedTransactionContinuations(session *Session, txnKey string) ([]fu
 			drainReleases, operationReleases = appendQueryHandleReleaseFuncs(handle, drainReleases, operationReleases)
 			continue
 		}
-		kept := handle.pendingDrains[:0]
-		for _, token := range handle.pendingDrains {
-			if token.finishOperation == nil {
-				kept = append(kept, token)
-				continue
-			}
-			if token.finish != nil {
-				drainReleases = append(drainReleases, token.finish)
-			}
-			operationReleases = append(operationReleases, token.finishOperation)
+		if handle.pendingDrain == nil || handle.pendingDrain.finishOperation == nil {
+			continue
 		}
-		handle.pendingDrains = kept
+		if handle.pendingDrain.finish != nil {
+			drainReleases = append(drainReleases, handle.pendingDrain.finish)
+		}
+		operationReleases = append(operationReleases, handle.pendingDrain.finishOperation)
+		handle.pendingDrain = nil
 	}
-	for key, tokens := range session.metadataDrains {
-		kept := tokens[:0]
-		for _, token := range tokens {
-			if token.finishOperation == nil || token.txnID != txnKey {
-				kept = append(kept, token)
-				continue
-			}
-			if token.finish != nil {
-				drainReleases = append(drainReleases, token.finish)
-			}
-			operationReleases = append(operationReleases, token.finishOperation)
+	for key, token := range session.metadataDrains {
+		if token.finishOperation == nil || token.txnID != txnKey {
+			continue
 		}
-		if len(kept) == 0 {
-			delete(session.metadataDrains, key)
-		} else {
-			session.metadataDrains[key] = kept
+		if token.finish != nil {
+			drainReleases = append(drainReleases, token.finish)
 		}
+		operationReleases = append(operationReleases, token.finishOperation)
+		delete(session.metadataDrains, key)
 	}
 	session.mu.Unlock()
 	return drainReleases, operationReleases
@@ -256,7 +244,10 @@ func appendPreparedDrain(session *Session, handleID string, finishDrain func(), 
 			ttx.lastUsed.Store(now.UnixNano())
 		}
 	}
-	handle.pendingDrains = append(handle.pendingDrains, drainToken{finish: finishDrain, finishOperation: finishOperation, at: now})
+	if handle.pendingDrain != nil {
+		return false
+	}
+	handle.pendingDrain = &drainToken{finish: finishDrain, finishOperation: finishOperation, txnID: handle.TxnID, at: now}
 	return true
 }
 
@@ -267,12 +258,11 @@ func popPreparedDrain(session *Session, handleID string) (*QueryHandle, func(), 
 	if !ok {
 		return nil, nil, nil, false
 	}
-	if len(handle.pendingDrains) == 0 {
+	if handle.pendingDrain == nil {
 		return handle, nil, nil, true
 	}
-	token := handle.pendingDrains[0]
-	copy(handle.pendingDrains, handle.pendingDrains[1:])
-	handle.pendingDrains = handle.pendingDrains[:len(handle.pendingDrains)-1]
+	token := *handle.pendingDrain
+	handle.pendingDrain = nil
 	return handle, token.finish, token.finishOperation, true
 }
 
@@ -283,29 +273,28 @@ func appendMetadataDrain(session *Session, key string, finishDrain func(), finis
 		return false
 	}
 	if session.metadataDrains == nil {
-		session.metadataDrains = make(map[string][]drainToken)
+		session.metadataDrains = make(map[string]drainToken)
 	}
-	session.metadataDrains[key] = append(session.metadataDrains[key], drainToken{
+	if _, exists := session.metadataDrains[key]; exists {
+		return false
+	}
+	session.metadataDrains[key] = drainToken{
 		finish:          finishDrain,
 		finishOperation: finishOperation,
 		txnID:           txnID,
 		at:              time.Now(),
-	})
+	}
 	return true
 }
 
 func popMetadataDrain(session *Session, key string) (func(), func()) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	if len(session.metadataDrains[key]) == 0 {
+	token, ok := session.metadataDrains[key]
+	if !ok {
 		return nil, nil
 	}
-	token := session.metadataDrains[key][0]
-	copy(session.metadataDrains[key], session.metadataDrains[key][1:])
-	session.metadataDrains[key] = session.metadataDrains[key][:len(session.metadataDrains[key])-1]
-	if len(session.metadataDrains[key]) == 0 {
-		delete(session.metadataDrains, key)
-	}
+	delete(session.metadataDrains, key)
 	return token.finish, token.finishOperation
 }
 
@@ -1249,21 +1238,7 @@ func (h *FlightSQLHandler) DoGetPreparedStatement(ctx context.Context,
 		return nil, nil, status.Error(codes.NotFound, "prepared statement not found")
 	}
 	if finishDrain == nil {
-		var operationOK bool
-		finishOperation, operationOK = session.beginOperation()
-		if busyErr := sessionBusyStatus(operationOK); busyErr != nil {
-			return nil, nil, busyErr
-		}
-		var err error
-		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(handle.TxnID))
-		if drainErr := workerDrainingStatus(err); drainErr != nil {
-			finishOperation()
-			return nil, nil, drainErr
-		}
-		if err != nil {
-			finishOperation()
-			return nil, nil, status.Errorf(codes.Internal, "start prepared query drain tracking: %v", err)
-		}
+		return nil, nil, status.Error(codes.FailedPrecondition, "prepared statement has no pending FlightInfo")
 	}
 	if finishOperation == nil {
 		finishOperation = func() {}
@@ -1402,21 +1377,7 @@ func (h *FlightSQLHandler) DoGetDBSchemas(ctx context.Context, cmd flightsql.Get
 	}
 	finishDrain, finishOperation := popMetadataDrain(session, metadataSchemasDrainKey(cmd))
 	if finishDrain == nil {
-		var operationOK bool
-		finishOperation, operationOK = session.beginOperation()
-		if busyErr := sessionBusyStatus(operationOK); busyErr != nil {
-			return nil, nil, busyErr
-		}
-		var err error
-		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(""))
-		if drainErr := workerDrainingStatus(err); drainErr != nil {
-			finishOperation()
-			return nil, nil, drainErr
-		}
-		if err != nil {
-			finishOperation()
-			return nil, nil, status.Errorf(codes.Internal, "start schema metadata drain tracking: %v", err)
-		}
+		return nil, nil, status.Error(codes.FailedPrecondition, "schema metadata has no pending FlightInfo")
 	}
 	if finishOperation == nil {
 		finishOperation = func() {}
@@ -1566,21 +1527,7 @@ func (h *FlightSQLHandler) DoGetTables(ctx context.Context, cmd flightsql.GetTab
 	}
 	finishDrain, finishOperation := popMetadataDrain(session, metadataTablesDrainKey(cmd))
 	if finishDrain == nil {
-		var operationOK bool
-		finishOperation, operationOK = session.beginOperation()
-		if busyErr := sessionBusyStatus(operationOK); busyErr != nil {
-			return nil, nil, busyErr
-		}
-		var err error
-		finishDrain, err = h.pool.beginDrainWork(session.allowsDrainContinuation(""))
-		if drainErr := workerDrainingStatus(err); drainErr != nil {
-			finishOperation()
-			return nil, nil, drainErr
-		}
-		if err != nil {
-			finishOperation()
-			return nil, nil, status.Errorf(codes.Internal, "start table metadata drain tracking: %v", err)
-		}
+		return nil, nil, status.Error(codes.FailedPrecondition, "table metadata has no pending FlightInfo")
 	}
 	if finishOperation == nil {
 		finishOperation = func() {}

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -145,7 +145,7 @@ func TestStatementFlightInfoHoldsSessionOperationUntilDoGet(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -210,7 +210,7 @@ func TestStatementFlightInfoNonEmptyHoldsSessionOperationUntilDoGet(t *testing.T
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -717,7 +717,7 @@ func TestEndTransactionRollbackReleasesAbandonedStatementOperation(t *testing.T)
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -782,7 +782,7 @@ func TestEndTransactionRollbackReleasesAbandonedMetadataOperation(t *testing.T) 
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -852,7 +852,7 @@ func TestEndTransactionNotFoundDoesNotConsumeMetadataOperation(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -879,8 +879,8 @@ func TestEndTransactionNotFoundDoesNotConsumeMetadataOperation(t *testing.T) {
 			delete(session.txns, id)
 			delete(session.txnOwner, id)
 		}
-		for key, drains := range session.metadataDrains {
-			releaseDrains = appendDrainTokenFuncs(releaseDrains, drains)
+		for key, drain := range session.metadataDrains {
+			releaseDrains = appendDrainTokenFunc(releaseDrains, drain)
 			delete(session.metadataDrains, key)
 		}
 		session.mu.Unlock()
@@ -949,7 +949,7 @@ func TestEndTransactionBusyDoesNotDeleteLivePreparedHandle(t *testing.T) {
 				Prepared: true,
 			},
 		},
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns: map[string]*trackedTx{
 			"txn-1": {},
 		},
@@ -999,7 +999,7 @@ func TestRawSQLTransactionKeepsDrainOpenUntilCommit(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1048,7 +1048,7 @@ func TestRawSQLTransactionKeepsDrainOpenAfterFailedCommit(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1124,7 +1124,7 @@ func TestClosePreparedStatementReleasesAbandonedOperation(t *testing.T) {
 		queries: map[string]*QueryHandle{
 			"prep-1": {Query: "", Schema: arrow.NewSchema(nil, nil), Prepared: true},
 		},
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1150,6 +1150,30 @@ func TestClosePreparedStatementReleasesAbandonedOperation(t *testing.T) {
 		t.Fatal("operation gate should release after close prepared")
 	} else {
 		finish()
+	}
+}
+
+func TestDoGetPreparedStatementRequiresPendingFlightInfo(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	session := &Session{
+		ID: "session-1",
+		queries: map[string]*QueryHandle{
+			"prep-1": {Query: "", Schema: arrow.NewSchema(nil, nil), Prepared: true},
+		},
+		metadataDrains: make(map[string]drainToken),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+	}
+	pool.sessions[session.ID] = session
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", session.ID))
+	cmd := testPreparedStatementQuery{handle: []byte("prep-1")}
+
+	if _, _, err := handler.DoGetPreparedStatement(ctx, cmd); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected DoGet without GetFlightInfo handoff to fail, got %v", err)
 	}
 }
 
@@ -1258,7 +1282,7 @@ func TestDoGetStatementKeepsRawSQLTransactionDrainOpenBeforeStreamingStarts(t *t
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		sqlTxDrain:     finishDrain,
@@ -1360,7 +1384,7 @@ func TestMetadataGetFlightInfoRejectsConcurrentSessionOperation(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1411,6 +1435,38 @@ func TestMetadataGetFlightInfoRejectsConcurrentSessionOperation(t *testing.T) {
 	defer session.mu.RUnlock()
 	if len(session.metadataDrains) != 0 {
 		t.Fatalf("metadata drains were not consumed: %v", session.metadataDrains)
+	}
+}
+
+func TestMetadataDoGetRequiresPendingFlightInfo(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+	}
+	pool.sessions["session-1"] = &Session{
+		ID:             "session-1",
+		Conn:           conn,
+		queries:        make(map[string]*QueryHandle),
+		metadataDrains: make(map[string]drainToken),
+		txns:           make(map[string]*trackedTx),
+		txnOwner:       make(map[string]string),
+	}
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-duckgres-session", "session-1"))
+
+	if _, _, err := handler.DoGetDBSchemas(ctx, testGetDBSchemas{}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected metadata DoGet without GetFlightInfo handoff to fail, got %v", err)
 	}
 }
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -119,7 +119,7 @@ type Session struct {
 	mu             sync.RWMutex
 	connMu         sync.Mutex // serializes operations on Conn and session-owned transactions
 	queries        map[string]*QueryHandle
-	metadataDrains map[string][]drainToken
+	metadataDrains map[string]drainToken
 	txns           map[string]*trackedTx
 	txnOwner       map[string]string
 	closed         bool
@@ -148,16 +148,17 @@ type QueryHandle struct {
 	Query     string
 	Schema    *arrow.Schema
 	TxnID     string
-	Prepared  bool      // prepared statements live until ClosePreparedStatement; the reaper never drops them, only their stale pendingDrains
+	Prepared  bool      // prepared statements live until ClosePreparedStatement; the reaper never drops them, only a stale pendingDrain
 	createdAt time.Time // when registered; the reaper drops a stale ad-hoc handle whose DoGet never arrived (guarded by Session.mu)
 	// finishOperation is the session operation token for an ad-hoc query
 	// awaiting its DoGet.
 	finishOperation func()
 	// finishDrain is the drain token of an ad-hoc query awaiting its DoGet.
 	finishDrain func()
-	// pendingDrains are drain tokens of GetFlightInfo[Prepared] calls awaiting
-	// their DoGet (a prepared handle accumulates one per GetFlightInfo).
-	pendingDrains []drainToken
+	// pendingDrain is the drain token of a GetFlightInfoPrepared call awaiting
+	// its DoGet. The session operation gate allows at most one pending
+	// continuation per session.
+	pendingDrain *drainToken
 }
 
 // drainToken pairs a drain-release closure with the time it was registered, so
@@ -176,14 +177,6 @@ func releaseDrainFunc(release func()) {
 	}
 }
 
-// appendDrainTokenFuncs appends the release closures of tokens to dst.
-func appendDrainTokenFuncs(dst []func(), tokens []drainToken) []func() {
-	for _, t := range tokens {
-		dst = appendDrainTokenFunc(dst, t)
-	}
-	return dst
-}
-
 func appendDrainTokenFunc(dst []func(), t drainToken) []func() {
 	if t.finish != nil {
 		dst = append(dst, t.finish)
@@ -192,6 +185,13 @@ func appendDrainTokenFunc(dst []func(), t drainToken) []func() {
 		dst = append(dst, t.finishOperation)
 	}
 	return dst
+}
+
+func appendOptionalDrainTokenFunc(dst []func(), token *drainToken) []func() {
+	if token == nil {
+		return dst
+	}
+	return appendDrainTokenFunc(dst, *token)
 }
 
 func (s *Session) hasTrackedTxDrain(txnKey string) bool {
@@ -691,16 +691,11 @@ func (p *SessionPool) reapIdle(now time.Time) {
 		for id, h := range s.queries {
 			if h.Prepared {
 				// Long-lived prepared handle: never drop it, only release
-				// pendingDrains (a GetFlightInfoPreparedStatement with no DoGet) gone stale.
-				kept := h.pendingDrains[:0]
-				for _, t := range h.pendingDrains {
-					if now.Sub(t.at) > handleIdleTimeout {
-						releaseDrains = appendDrainTokenFunc(releaseDrains, t)
-						continue
-					}
-					kept = append(kept, t)
+				// pendingDrain (a GetFlightInfoPreparedStatement with no DoGet) gone stale.
+				if h.pendingDrain != nil && now.Sub(h.pendingDrain.at) > handleIdleTimeout {
+					releaseDrains = appendDrainTokenFunc(releaseDrains, *h.pendingDrain)
+					h.pendingDrain = nil
 				}
-				h.pendingDrains = kept
 				continue
 			}
 			// Ad-hoc handle awaiting its DoGetStatement; drop it and release its
@@ -714,27 +709,18 @@ func (p *SessionPool) reapIdle(now time.Time) {
 					releaseDrains = append(releaseDrains, h.finishOperation)
 					h.finishOperation = nil
 				}
-				releaseDrains = appendDrainTokenFuncs(releaseDrains, h.pendingDrains)
-				h.pendingDrains = nil
+				releaseDrains = appendOptionalDrainTokenFunc(releaseDrains, h.pendingDrain)
+				h.pendingDrain = nil
 				slog.Warn("Reaping abandoned query handle (no DoGet).", "user", s.Username, "handle", id)
 				delete(s.queries, id)
 			}
 		}
 		// Drain tokens stranded on metadata streams (GetFlightInfoSchemas/Tables
 		// with no DoGet).
-		for key, tokens := range s.metadataDrains {
-			kept := tokens[:0]
-			for _, t := range tokens {
-				if now.Sub(t.at) > handleIdleTimeout {
-					releaseDrains = appendDrainTokenFunc(releaseDrains, t)
-					continue
-				}
-				kept = append(kept, t)
-			}
-			if len(kept) == 0 {
+		for key, token := range s.metadataDrains {
+			if now.Sub(token.at) > handleIdleTimeout {
+				releaseDrains = appendDrainTokenFunc(releaseDrains, token)
 				delete(s.metadataDrains, key)
-			} else {
-				s.metadataDrains[key] = kept
 			}
 		}
 		s.mu.Unlock()
@@ -1112,7 +1098,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		Username:       username,
 		CreatedAt:      time.Now(),
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		duckdbConn:     duckConn,
@@ -1203,12 +1189,12 @@ func (p *SessionPool) DestroySession(token string) error {
 			releaseDrains = append(releaseDrains, handle.finishOperation)
 			handle.finishOperation = nil
 		}
-		releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
-		handle.pendingDrains = nil
+		releaseDrains = appendOptionalDrainTokenFunc(releaseDrains, handle.pendingDrain)
+		handle.pendingDrain = nil
 		delete(session.queries, id)
 	}
-	for key, drains := range session.metadataDrains {
-		releaseDrains = appendDrainTokenFuncs(releaseDrains, drains)
+	for key, drain := range session.metadataDrains {
+		releaseDrains = appendDrainTokenFunc(releaseDrains, drain)
 		delete(session.metadataDrains, key)
 	}
 	if session.sqlTxDrain != nil {
@@ -1427,12 +1413,12 @@ func (p *SessionPool) CloseAll() {
 				releaseDrains = append(releaseDrains, handle.finishOperation)
 				handle.finishOperation = nil
 			}
-			releaseDrains = appendDrainTokenFuncs(releaseDrains, handle.pendingDrains)
-			handle.pendingDrains = nil
+			releaseDrains = appendOptionalDrainTokenFunc(releaseDrains, handle.pendingDrain)
+			handle.pendingDrain = nil
 			delete(session.queries, id)
 		}
-		for key, drains := range session.metadataDrains {
-			releaseDrains = appendDrainTokenFuncs(releaseDrains, drains)
+		for key, drain := range session.metadataDrains {
+			releaseDrains = appendDrainTokenFunc(releaseDrains, drain)
 			delete(session.metadataDrains, key)
 		}
 		if session.sqlTxDrain != nil {

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -134,7 +134,7 @@ func TestReapAbandonedQueryHandleReleasesOperation(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 	}
 	finishOperation, ok := session.beginOperation()
@@ -172,20 +172,20 @@ func TestReapAbandonedPreparedDrainReleasesOperation(t *testing.T) {
 			"prep-1": {
 				Query:    "SELECT 1",
 				Prepared: true,
-				pendingDrains: []drainToken{{
+				pendingDrain: &drainToken{
 					finish: finishDrain,
 					at:     time.Now().Add(-handleIdleTimeout - time.Minute),
-				}},
+				},
 			},
 		},
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 	}
 	finishOperation, ok := session.beginOperation()
 	if !ok {
 		t.Fatal("expected operation to start")
 	}
-	session.queries["prep-1"].pendingDrains[0].finishOperation = finishOperation
+	session.queries["prep-1"].pendingDrain.finishOperation = finishOperation
 	pool.sessions[session.ID] = session
 
 	pool.reapIdle(time.Now())
@@ -212,18 +212,18 @@ func TestReapAbandonedMetadataDrainReleasesOperation(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 	}
 	finishOperation, ok := session.beginOperation()
 	if !ok {
 		t.Fatal("expected operation to start")
 	}
-	session.metadataDrains["schemas|x"] = []drainToken{{
+	session.metadataDrains["schemas|x"] = drainToken{
 		finish:          finishDrain,
 		finishOperation: finishOperation,
 		at:              time.Now().Add(-handleIdleTimeout - time.Minute),
-	}}
+	}
 	pool.sessions[session.ID] = session
 
 	pool.reapIdle(time.Now())
@@ -749,7 +749,7 @@ func TestReapIdleRawSQLTransactionReleasesDrainWork(t *testing.T) {
 		ID:             "session-1",
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		sqlTxDrain:     finishDrain,
@@ -789,7 +789,7 @@ func TestReapIdleRawSQLTransactionKeepsDrainWorkWhenConnWorkActive(t *testing.T)
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		sqlTxDrain:     finishDrain,
@@ -838,7 +838,7 @@ func TestReapIdleRawSQLTransactionKeepsDrainWorkWhenRollbackCannotRun(t *testing
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 		sqlTxDrain:     finishDrain,
@@ -888,7 +888,7 @@ func TestDestroySessionPreventsLateQueryHandleDrainLeak(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -922,7 +922,7 @@ func TestDestroySessionPreventsLateSQLTransactionDrainLeak(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -956,7 +956,7 @@ func TestDestroySessionPreventsLateTrackedTransactionDrainLeak(t *testing.T) {
 	session := &Session{
 		ID:             "session-1",
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1002,7 +1002,7 @@ func TestDestroySessionWaitsForActiveConnectionWorkBeforeCleanup(t *testing.T) {
 		DB:             db,
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1051,7 +1051,7 @@ func TestDestroySessionWaitsForAcceptedConnectionWorkBeforeCleanup(t *testing.T)
 		DB:             db,
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1103,7 +1103,7 @@ func TestCloseAllWaitsForActiveConnectionWorkBeforeClose(t *testing.T) {
 		DB:             db,
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1150,7 +1150,7 @@ func TestCloseAllWaitsForAcceptedConnectionWorkBeforeClose(t *testing.T) {
 		DB:             db,
 		Conn:           conn,
 		queries:        make(map[string]*QueryHandle),
-		metadataDrains: make(map[string][]drainToken),
+		metadataDrains: make(map[string]drainToken),
 		txns:           make(map[string]*trackedTx),
 		txnOwner:       make(map[string]string),
 	}
@@ -1182,7 +1182,7 @@ func TestCloseAllWaitsForAcceptedConnectionWorkBeforeClose(t *testing.T) {
 
 // A GetFlightInfo whose matching DoGet never arrives must not hold the drain
 // open forever: the reaper releases drain tokens stranded on stale ad-hoc query
-// handles, stale prepared pendingDrains, and stale metadata streams — while
+// handles, stale prepared pendingDrain, and stale metadata streams — while
 // leaving fresh handles and long-lived prepared handles intact.
 func TestReapIdleReleasesAbandonedHandleDrains(t *testing.T) {
 	pool := &SessionPool{
@@ -1209,10 +1209,10 @@ func TestReapIdleReleasesAbandonedHandleDrains(t *testing.T) {
 		queries: map[string]*QueryHandle{
 			"query-1": {Query: "SELECT 1", createdAt: stale, finishDrain: staleAdhoc},
 			"query-2": {Query: "SELECT 2", createdAt: fresh, finishDrain: freshAdhoc},
-			"prep-1":  {Query: "SELECT 3", Prepared: true, createdAt: stale, pendingDrains: []drainToken{{finish: stalePrepared, at: stale}}},
+			"prep-1":  {Query: "SELECT 3", Prepared: true, createdAt: stale, pendingDrain: &drainToken{finish: stalePrepared, at: stale}},
 		},
-		metadataDrains: map[string][]drainToken{
-			"schemas|x": {{finish: staleMeta, at: stale}},
+		metadataDrains: map[string]drainToken{
+			"schemas|x": {finish: staleMeta, at: stale},
 		},
 		txns:     make(map[string]*trackedTx),
 		txnOwner: make(map[string]string),
@@ -1241,8 +1241,8 @@ func TestReapIdleReleasesAbandonedHandleDrains(t *testing.T) {
 	if !ok {
 		t.Fatal("prepared handle prep-1 was wrongly dropped (must outlive a stale pendingDrain)")
 	}
-	if len(prep.pendingDrains) != 0 {
-		t.Errorf("stale prepared pendingDrain not released: %d remain", len(prep.pendingDrains))
+	if prep.pendingDrain != nil {
+		t.Errorf("stale prepared pendingDrain not released: still present")
 	}
 	if _, ok := sess.metadataDrains["schemas|x"]; ok {
 		t.Error("stale metadata drain was not reaped")

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -107,9 +107,10 @@ normal `go test ./...` lane.
   harness enters through pgwire, where one client connection maps to one worker
   session and operations are serialized by the control plane. Driving this
   specific defense-in-depth path end-to-end would need a bespoke concurrent
-  Flight-ingress client, so the rejection contract and abandoned-continuation
-  cleanup are covered by `duckdbservice` unit tests. The harness still asserts
-  the cluster invariant this protects: one active session owns one worker.
+  Flight-ingress client, so the rejection contract, required
+  GetFlightInfo-to-DoGet handoffs, and abandoned-continuation cleanup are covered
+  by `duckdbservice` unit tests. The harness still asserts the cluster invariant
+  this protects: one active session owns one worker.
 
 ## Isolation model
 


### PR DESCRIPTION
## Summary

This follow-up leans on the merged worker invariant that a session can have only one active user operation at a time. With that contract in place, continuation state no longer needs to model multiple same-session pending executions.

## Changes

- Collapse prepared-statement continuation state from a FIFO slice to a single pending drain token.
- Collapse metadata continuation state from per-descriptor token queues to a single token per descriptor key.
- Reject prepared/metadata `DoGet` calls that do not consume a pending `GetFlightInfo` handoff, instead of letting them start fresh work.
- Keep abandoned-continuation cleanup, drain release, reaper, `DestroySession`, and `CloseAll` paths wired for the single-token state.
- Update the e2e harness README to document why the Flight-specific handoff/concurrency contract is covered by `duckdbservice` unit tests rather than the pgwire harness.

## Verification

- `go test ./duckdbservice ./server/flightsqlingress -count=1`
- `just lint`
- `just test-unit`