### PR TITLE
fix: bound Bind parameter allocations by remaining message bytes (#717)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -5480,6 +5480,14 @@ func (c *clientConn) handleBind(body []byte) {
 		if length == -1 {
 			paramValues[i] = nil // NULL
 		} else {
+			// The length field is client-controlled; bound the allocation by
+			// the remaining bytes of the already-framed Bind message body — a
+			// parameter value can never legitimately exceed it. Without this
+			// check a client could reserve multi-GiB per parameter (#717).
+			if int64(length) > int64(reader.Len()) {
+				c.sendError("ERROR", "08P01", fmt.Sprintf("invalid Bind message: parameter %d length %d exceeds remaining message size %d", i+1, length, reader.Len()))
+				return
+			}
 			paramValues[i] = make([]byte, length)
 			if _, err := io.ReadFull(reader, paramValues[i]); err != nil {
 				c.sendError("ERROR", "08P01", "invalid Bind message")

--- a/server/conn_bind_test.go
+++ b/server/conn_bind_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildBindBody constructs a Bind message body (without the 'B' type byte and
+// length header): portal name, statement name, no format codes, one parameter
+// with the given declared length and actual data, no result format codes.
+func buildBindBody(portal, stmt string, declaredLen int32, data []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(portal)
+	buf.WriteByte(0)
+	buf.WriteString(stmt)
+	buf.WriteByte(0)
+	_ = binary.Write(&buf, binary.BigEndian, int16(0)) // no param format codes
+	_ = binary.Write(&buf, binary.BigEndian, int16(1)) // one parameter
+	_ = binary.Write(&buf, binary.BigEndian, declaredLen)
+	buf.Write(data)
+	_ = binary.Write(&buf, binary.BigEndian, int16(0)) // no result format codes
+	return buf.Bytes()
+}
+
+func newBindTestConn(out *bytes.Buffer) *clientConn {
+	return &clientConn{
+		writer: bufio.NewWriter(out),
+		stmts: map[string]*preparedStmt{
+			"s1": {query: "SELECT $1", convertedQuery: "SELECT $1", numParams: 1},
+		},
+		portals: map[string]*portal{},
+	}
+}
+
+// Regression test for #717: a Bind parameter length is client-controlled and
+// must be bounded by the remaining message bytes before allocating — a client
+// could otherwise reserve multi-GiB per parameter.
+func TestHandleBindRejectsOversizedParamLength(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		declaredLen int32
+		data        []byte
+	}{
+		{"max int32 with no data", 0x7FFFFFFF, nil},
+		{"slightly exceeds remaining bytes", 8, []byte("abc")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			c := newBindTestConn(&out)
+
+			c.handleBind(buildBindBody("p1", "s1", tc.declaredLen, tc.data))
+
+			if !bytes.Contains(out.Bytes(), []byte("08P01")) {
+				t.Fatalf("expected 08P01 protocol_violation error, got: %q", out.Bytes())
+			}
+			if !bytes.Contains(out.Bytes(), []byte("exceeds remaining message size")) {
+				t.Fatalf("expected oversized-length rejection before allocation, got: %q", out.Bytes())
+			}
+			if _, ok := c.portals["p1"]; ok {
+				t.Fatal("portal must not be created for a rejected Bind")
+			}
+		})
+	}
+}
+
+func TestHandleBindAcceptsValidParam(t *testing.T) {
+	var out bytes.Buffer
+	c := newBindTestConn(&out)
+
+	c.handleBind(buildBindBody("p1", "s1", 3, []byte("abc")))
+	_ = c.writer.Flush()
+
+	if out.Len() == 0 || out.Bytes()[0] != '2' {
+		t.Fatalf("expected BindComplete ('2'), got: %q", out.Bytes())
+	}
+	p, ok := c.portals["p1"]
+	if !ok {
+		t.Fatal("expected portal to be created")
+	}
+	if len(p.paramValues) != 1 || string(p.paramValues[0]) != "abc" {
+		t.Fatalf("unexpected param values: %v", p.paramValues)
+	}
+}

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -105,6 +105,12 @@ normal `go test ./...` lane.
   pooler + `lakekeeper:8181` but not a denied destination needs a stable
   exec-into-worker probe; deferred (high flake risk). The policies themselves
   are asserted statically in `tests/manifests/`.
+- **Oversized Bind-parameter rejection (#717)** — rejecting a Bind message whose
+  declared parameter length exceeds the remaining message body requires crafting
+  a malformed wire-protocol packet on a raw socket (through TLS + auth); libpq
+  clients like psql always emit well-formed lengths, and the Job image carries no
+  raw-packet tooling. Covered by the unit regression test in
+  `server/conn_bind_test.go` instead.
 - **Concurrent worker operations on one session** — the worker rejects
   overlapping same-session Flight operations with `FailedPrecondition`, but the
   harness enters through pgwire, where one client connection maps to one worker


### PR DESCRIPTION
## Bug

`server/conn.go::handleBind` read each Bind parameter value with `make([]byte, length)` where `length` is a client-controlled `int32` from the wire; only `length == -1` (NULL) was special-cased. An authenticated client could declare `length = 0x7FFFFFFF` and have the server reserve ~2 GiB per parameter (per `numParams`, per connection) — a post-auth memory-exhaustion DoS (#717). The blast radius is worst in control-plane mode, where `clientConn` runs in the shared CP process serving all tenants.

## Fix

A parameter value can never legitimately exceed the remaining bytes of the already-framed Bind message body, so the declared length is now bounded by `reader.Len()` before allocating. An oversized length is rejected with a clean `ERROR 08P01` (protocol_violation) that names the offending parameter, its declared length, and the remaining message size — no allocation happens. This is the principled bound (no arbitrary constant) and rejects garbage early.

Deliberately out of scope, per parallel work:
- negative-length (`< -1`) validation in the same loop → #720 (separate PR)
- the framing-layer `make([]byte, length-4)` cap in `server/wire/protocol.go` → #715

This PR is developed in parallel with #718 and #720, which also touch `server/conn.go`; merge order may require a trivial rebase.

## Tests

- `server/conn_bind_test.go` (new):
  - `TestHandleBindRejectsOversizedParamLength` — regression test: a Bind with declared length `0x7FFFFFFF` (and a second case just past the remaining bytes) gets `08P01` with the `exceeds remaining message size` message and creates no portal. The message assertion distinguishes the new pre-allocation rejection from the old path (which also returned `08P01`, but only after allocating).
  - `TestHandleBindAcceptsValidParam` — a well-formed Bind still completes (`BindComplete`, portal created with the param value).
- `go build ./...`, `go test ./server/`, `go vet ./server/`, `gofmt -l` all clean.

## e2e harness decision

Not feasible in-Job: triggering the rejection requires crafting a malformed Bind packet on a raw socket (through TLS + auth) — libpq clients like `psql` always emit well-formed lengths, and the harness Job image (alpine sh + psql/curl/jq/kubectl) has no raw-packet tooling. Documented in the `Deliberately not covered here` section of `tests/e2e-mw-dev/README.md`; the unit regression test covers the behavior.

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)