### PR TITLE
fix: return 08P01 for malformed Bind message fields instead of panicking (#720)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -5456,6 +5456,10 @@ func (c *clientConn) handleBind(body []byte) {
 		c.sendError("ERROR", "08P01", "invalid Bind message")
 		return
 	}
+	if numParamFormats < 0 {
+		c.sendError("ERROR", "08P01", "invalid parameter format count in Bind message")
+		return
+	}
 	paramFormats := make([]int16, numParamFormats)
 	for i := int16(0); i < numParamFormats; i++ {
 		if err := binary.Read(reader, binary.BigEndian, &paramFormats[i]); err != nil {
@@ -5470,6 +5474,10 @@ func (c *clientConn) handleBind(body []byte) {
 		c.sendError("ERROR", "08P01", "invalid Bind message")
 		return
 	}
+	if numParams < 0 {
+		c.sendError("ERROR", "08P01", "invalid parameter count in Bind message")
+		return
+	}
 	paramValues := make([][]byte, numParams)
 	for i := int16(0); i < numParams; i++ {
 		var length int32
@@ -5479,6 +5487,10 @@ func (c *clientConn) handleBind(body []byte) {
 		}
 		if length == -1 {
 			paramValues[i] = nil // NULL
+		} else if length < 0 {
+			// Only -1 (NULL) is a valid negative length.
+			c.sendError("ERROR", "08P01", "invalid parameter length in Bind message")
+			return
 		} else {
 			// The length field is client-controlled; bound the allocation by
 			// the remaining bytes of the already-framed Bind message body — a
@@ -5500,6 +5512,10 @@ func (c *clientConn) handleBind(body []byte) {
 	var numResultFormats int16
 	if err := binary.Read(reader, binary.BigEndian, &numResultFormats); err != nil {
 		c.sendError("ERROR", "08P01", "invalid Bind message")
+		return
+	}
+	if numResultFormats < 0 {
+		c.sendError("ERROR", "08P01", "invalid result format count in Bind message")
 		return
 	}
 	resultFormats := make([]int16, numResultFormats)

--- a/server/conn_bind_test.go
+++ b/server/conn_bind_test.go
@@ -24,6 +24,20 @@ func buildBindBody(portal, stmt string, declaredLen int32, data []byte) []byte {
 	return buf.Bytes()
 }
 
+// bindMessageBody builds a Bind message body (without the type byte and
+// length prefix) for portal/statement names with raw trailing fields.
+func bindMessageBody(portal, stmt string, fields ...any) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(portal)
+	buf.WriteByte(0)
+	buf.WriteString(stmt)
+	buf.WriteByte(0)
+	for _, f := range fields {
+		_ = binary.Write(&buf, binary.BigEndian, f)
+	}
+	return buf.Bytes()
+}
+
 func newBindTestConn(out *bytes.Buffer) *clientConn {
 	return &clientConn{
 		writer: bufio.NewWriter(out),
@@ -65,6 +79,48 @@ func TestHandleBindRejectsOversizedParamLength(t *testing.T) {
 	}
 }
 
+// Regression test for #720: malformed counts/lengths in a Bind message used
+// to reach make() unvalidated and panic with "makeslice: len out of range"
+// (recovered per-connection). They must instead produce a clean 08P01
+// protocol_violation error.
+func TestHandleBindMalformedFieldsReturnProtocolViolation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "negative param format count",
+			body: bindMessageBody("p1", "s1", int16(-1)),
+		},
+		{
+			name: "negative param count",
+			body: bindMessageBody("p1", "s1", int16(0), int16(-1)),
+		},
+		{
+			name: "negative non-NULL param value length",
+			body: bindMessageBody("p1", "s1", int16(0), int16(1), int32(-2)),
+		},
+		{
+			name: "negative result format count",
+			body: bindMessageBody("p1", "s1", int16(0), int16(0), int16(-1)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			c := newBindTestConn(&out)
+
+			c.handleBind(tc.body) // must not panic
+
+			if !bytes.Contains(out.Bytes(), []byte("08P01")) {
+				t.Fatalf("expected 08P01 ErrorResponse, got output: %q", out.Bytes())
+			}
+			if _, ok := c.portals["p1"]; ok {
+				t.Fatal("portal must not be created from a malformed Bind message")
+			}
+		})
+	}
+}
+
 func TestHandleBindAcceptsValidParam(t *testing.T) {
 	var out bytes.Buffer
 	c := newBindTestConn(&out)
@@ -81,5 +137,25 @@ func TestHandleBindAcceptsValidParam(t *testing.T) {
 	}
 	if len(p.paramValues) != 1 || string(p.paramValues[0]) != "abc" {
 		t.Fatalf("unexpected param values: %v", p.paramValues)
+	}
+}
+
+// Sanity-check the happy path still binds: one NULL param (length -1),
+// default format codes everywhere.
+func TestHandleBindValidMessageStillBinds(t *testing.T) {
+	var out bytes.Buffer
+	c := newBindTestConn(&out)
+
+	c.handleBind(bindMessageBody("p1", "s1", int16(0), int16(1), int32(-1), int16(0)))
+
+	if bytes.Contains(out.Bytes(), []byte("08P01")) {
+		t.Fatalf("unexpected protocol error for valid Bind message: %q", out.Bytes())
+	}
+	p, ok := c.portals["p1"]
+	if !ok {
+		t.Fatal("expected portal to be created")
+	}
+	if len(p.paramValues) != 1 || p.paramValues[0] != nil {
+		t.Fatalf("expected one NULL param value, got %v", p.paramValues)
 	}
 }

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -120,6 +120,13 @@ normal `go test ./...` lane.
   GetFlightInfo-to-DoGet handoffs, and abandoned-continuation cleanup are covered
   by `duckdbservice` unit tests. The harness still asserts the cluster invariant
   this protects: one active session owns one worker.
+- **Malformed Bind message validation (#720)** — negative count/length fields
+  in a Bind message must return a clean `08P01` instead of panicking. Every
+  real client (psql, lib/pq, ...) only emits well-formed Bind messages, so
+  triggering this needs a raw pgwire client that completes TLS + SCRAM auth
+  and then sends crafted bytes — tooling the alpine Job image (psql/curl/jq)
+  doesn't have. Covered by `server/conn_bind_test.go` unit tests
+  feeding malformed payloads directly to `handleBind`.
 
 ## Isolation model
 


### PR DESCRIPTION
## Problem

`handleBind` (`server/conn.go`) read several count/length fields off the wire and passed them straight to `make()` with no range validation:

- `numParamFormats`, `numParams`, `numResultFormats` (`int16`) had no `>= 0` check — a client sending `0xFFFF` (= -1) panicked with `makeslice: len out of range`
- the per-param value length (`int32`) only special-cased `-1` (NULL); any other negative value (`-2`, ...) fell through to `make([]byte, length)` and panicked

The panics were `recover()`-contained per-connection (standalone) or killed only the offending client's child worker (process isolation), so impact was low — but real PostgreSQL returns a clean `08P01` protocol_violation here, and explicit validation is a stronger control than panic-recovery.

## Fix

Validate each count is `>= 0` and each value length is either `-1` (NULL) or `>= 0`; on violation send an `08P01` ErrorResponse with a field-specific message and return without creating the portal.

Deliberately scoped to negative/malformed-field validation only — upper-bound allocation caps in the same function are the separate parallel #717, so the two diffs compose. **Note:** this PR is developed in parallel with #717 (same function) and #718 (same file) and may need a trivial rebase against whichever lands first.

## Tests

- `server/conn_bind_test.go`: `TestHandleBindMalformedFieldsReturnProtocolViolation` feeds crafted malformed Bind payloads (negative param format count, negative param count, negative non-NULL value length `-2`, negative result format count) and asserts a clean `08P01` with no panic and no portal created. **Verified the test panics on `main`** (`makeslice: len out of range`) and passes with the fix.
- `TestHandleBindValidMessageStillBinds` sanity-checks the happy path (NULL param, default formats) still binds.
- `go build ./...`, `go test ./server/`, `go vet ./server/`, `gofmt -l` all clean.

## e2e harness decision

No in-Job `harness.sh` assertion: every real client (psql, lib/pq, ...) only emits well-formed Bind messages, so triggering this requires a raw pgwire client that completes TLS + SCRAM auth and then sends crafted bytes — tooling the Job image (postgres:16-alpine + psql/curl/jq) doesn't have. Documented explicitly in `tests/e2e-mw-dev/README.md` under "Deliberately not covered here", per the CLAUDE.md contract; coverage lives in the unit tests above, which exercise `handleBind` directly.

Fixes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)