### PR TITLE
fix: stop accepting the admin secret via ?token= URL query (#721)

### DIFF
--- a/controlplane/admin/dashboard.go
+++ b/controlplane/admin/dashboard.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"html/template"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -50,7 +51,7 @@ func dashboardPageHandler(templateName, adminToken string) gin.HandlerFunc {
 		// logs. Authenticate via the POST /login form or the
 		// X-Duckgres-Internal-Secret header instead.
 		if !validAdminToken(requestAdminToken(c), adminToken) {
-			renderLoginPage(c, c.Request.URL.RequestURI(), "")
+			renderLoginPage(c, loginNextURI(c.Request.URL), "")
 			return
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
@@ -112,6 +113,21 @@ func setAdminTokenCookie(c *gin.Context, token string) {
 	// plain-HTTP on a network-policy-restricted port reached via port-forward.
 	c.SetSameSite(http.SameSiteStrictMode)
 	c.SetCookie(adminTokenCookieName, token, 7*24*60*60, "/", "", false, true)
+}
+
+// loginNextURI returns the request URI to round-trip through the login form's
+// hidden "next" field, with any ?token= query key (the pre-#721 URL auth flow,
+// e.g. a stale bookmark) stripped — the login page must never embed the secret
+// or redirect it back into the URL bar / browser history.
+func loginNextURI(u *url.URL) string {
+	q := u.Query()
+	if _, ok := q["token"]; !ok {
+		return u.RequestURI()
+	}
+	q.Del("token")
+	cloned := *u
+	cloned.RawQuery = q.Encode()
+	return cloned.RequestURI()
 }
 
 func normalizeNextPath(next string) string {

--- a/controlplane/admin/dashboard.go
+++ b/controlplane/admin/dashboard.go
@@ -7,7 +7,6 @@ import (
 	"embed"
 	"html/template"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -46,10 +45,10 @@ func RegisterDashboard(r *gin.Engine, adminToken string) {
 
 func dashboardPageHandler(templateName, adminToken string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if redirectPath, ok := maybeSetAdminCookieFromQuery(c, adminToken); ok {
-			c.Redirect(http.StatusSeeOther, redirectPath)
-			return
-		}
+		// The admin token is deliberately NOT accepted via URL query parameters:
+		// URL-borne secrets persist in browser history and any future proxy/access
+		// logs. Authenticate via the POST /login form or the
+		// X-Duckgres-Internal-Secret header instead.
 		if !validAdminToken(requestAdminToken(c), adminToken) {
 			renderLoginPage(c, c.Request.URL.RequestURI(), "")
 			return
@@ -109,35 +108,10 @@ func validAdminToken(got, want string) bool {
 }
 
 func setAdminTokenCookie(c *gin.Context, token string) {
-	c.SetSameSite(http.SameSiteLaxMode)
+	// HttpOnly + SameSite=Strict; not Secure because the dashboard is served
+	// plain-HTTP on a network-policy-restricted port reached via port-forward.
+	c.SetSameSite(http.SameSiteStrictMode)
 	c.SetCookie(adminTokenCookieName, token, 7*24*60*60, "/", "", false, true)
-}
-
-func maybeSetAdminCookieFromQuery(c *gin.Context, adminToken string) (string, bool) {
-	token := c.Query("token")
-	if token == "" || !validAdminToken(token, adminToken) {
-		return "", false
-	}
-	setAdminTokenCookie(c, token)
-	q := cloneWithoutToken(c.Request.URL.Query())
-	redirectPath := c.Request.URL.Path
-	if encoded := q.Encode(); encoded != "" {
-		redirectPath += "?" + encoded
-	}
-	return redirectPath, true
-}
-
-func cloneWithoutToken(values url.Values) url.Values {
-	cloned := url.Values{}
-	for k, v := range values {
-		if k == "token" {
-			continue
-		}
-		copied := make([]string, len(v))
-		copy(copied, v)
-		cloned[k] = copied
-	}
-	return cloned
 }
 
 func normalizeNextPath(next string) string {

--- a/controlplane/admin/dashboard_test.go
+++ b/controlplane/admin/dashboard_test.go
@@ -68,6 +68,12 @@ func TestDashboardRejectsTokenQueryParam(t *testing.T) {
 		if got := rec.Header().Get("Location"); got != "" {
 			t.Errorf("GET %s redirected to %q, want no redirect", path, got)
 		}
+		// The login page must not echo the secret back (e.g. inside the
+		// hidden "next" field) — that would re-embed it in the page and
+		// redirect it back into the URL bar after login.
+		if strings.Contains(rec.Body.String(), "secret") {
+			t.Errorf("GET %s login page echoes the token", path)
+		}
 	}
 }
 

--- a/controlplane/admin/dashboard_test.go
+++ b/controlplane/admin/dashboard_test.go
@@ -45,6 +45,55 @@ func TestAPIMiddlewareAcceptsCookie(t *testing.T) {
 	}
 }
 
+// Regression test for #721: the admin token must never be accepted via a URL
+// query parameter — URL-borne secrets persist in browser history and proxy
+// access logs. A request carrying the correct token in ?token= must get the
+// login page (401), with no Set-Cookie and no redirect.
+func TestDashboardRejectsTokenQueryParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterDashboard(r, "secret")
+
+	for _, path := range []string{"/?token=secret", "/workers?token=secret&foo=bar"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("GET %s status = %d, want %d", path, rec.Code, http.StatusUnauthorized)
+		}
+		if got := rec.Header().Get("Set-Cookie"); got != "" {
+			t.Errorf("GET %s set a cookie: %q, want none", path, got)
+		}
+		if got := rec.Header().Get("Location"); got != "" {
+			t.Errorf("GET %s redirected to %q, want no redirect", path, got)
+		}
+	}
+}
+
+func TestLoginCookieIsHttpOnlyStrict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterDashboard(r, "secret")
+
+	form := url.Values{"token": {"secret"}, "next": {"/"}}
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != adminTokenCookieName {
+		t.Fatalf("cookies = %v, want exactly one %q cookie", cookies, adminTokenCookieName)
+	}
+	if !cookies[0].HttpOnly {
+		t.Error("cookie is not HttpOnly")
+	}
+	if cookies[0].SameSite != http.SameSiteStrictMode {
+		t.Errorf("cookie SameSite = %v, want %v", cookies[0].SameSite, http.SameSiteStrictMode)
+	}
+}
+
 func TestDashboardRequiresLoginThenSetsCookie(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -27,6 +27,8 @@
 #                  graceful drain (in-flight query survives a worker SIGTERM, #690);
 #                  one session per worker (concurrent queries land on distinct pods).
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
+#   admin auth   : the dashboard rejects ?token= query-param auth (#721); only
+#                  the internal-secret header / POST login form authenticate.
 #   lifecycle    : deprovision → warehouse deleted → Duckling CR fully gone
 #                  (finalizer cascade that drops the cnpg role+db completed).
 #                  Same-id re-provision is covered across runs by run.sh, not
@@ -597,6 +599,25 @@ concurrent_writers() { # org password
   pg "$1" "$2" ducklake "DROP TABLE $t;"
 }
 
+# ---- admin dashboard auth (#721) -------------------------------------------
+# Regression for #721: the admin dashboard must NOT accept the internal secret
+# via a ?token= URL query parameter (URL-borne secrets persist in browser
+# history and any future proxy access logs). A request carrying the correct
+# token in the query string gets the login page (401) with no auth cookie and
+# no redirect; the X-Duckgres-Internal-Secret header path still authenticates.
+admin_dashboard_no_query_token() {
+  log "admin dashboard rejects ?token= query auth"
+  hdrs=/tmp/admin_qt_hdrs
+  code="$(curl -s -o /dev/null -D "$hdrs" -w '%{http_code}' "$API/?token=$SECRET")"
+  [ "$code" = "401" ] || fail "GET /?token=<secret> returned $code, want 401 (query-param auth must be rejected)"
+  if grep -qi '^set-cookie:' "$hdrs"; then
+    fail "GET /?token=<secret> set a cookie — query-param auth is back"
+  fi
+  # Sanity: the header path (what this harness uses everywhere) still works.
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "$H" "$API/")"
+  [ "$code" = "200" ] || fail "GET / with internal-secret header returned $code, want 200"
+}
+
 # ---- tenant isolation -----------------------------------------------------
 # Two tenants (cnpg + ext) back onto distinct DuckLake metadata stores, so a
 # table created by one is invisible to the other. Ported (logical half) from
@@ -657,6 +678,9 @@ EXT_BODY='{"database_name":"'"$EXT"'",
 main() {
   bootstrap_kubectl
   resolve_cp_ip
+
+  # No org dependency — assert the admin surface auth contract up front.
+  admin_dashboard_no_query_token
 
   # Use the password returned at provision time — do NOT call reset-password and
   # then retry-connect in a tight loop: the CP rate-limiter bans the source IP
@@ -719,7 +743,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: wire + malformed-startup-resilience + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

The control-plane admin dashboard accepted the admin bearer token — the long-lived `internalSecret` — via a `?token=` URL query parameter (`maybeSetAdminCookieFromQuery` in `controlplane/admin/dashboard.go`, wired into every dashboard page handler), converting it into the auth cookie and redirecting.

Honest framing of the existing mitigations (this is a P3 hardening, not an active leak): the handler validated and immediately `303`-redirected to the token-stripped URL, the gin engine has no request logger, and `k8s/networkpolicy.yaml` restricts the admin port to same-namespace pods. The residual gap is that the secret persists in the **operator's browser history**, and any proxy/access logging placed in front of the port in the future would capture it.

## Fix

- Remove the `?token=` query-parameter auth path entirely (`maybeSetAdminCookieFromQuery` + `cloneWithoutToken` deleted). The dashboard already has a POST `/login` form that sets the same cookie, so the operator workflow stays one step: open the page, paste the token. Service-to-service callers keep using the `X-Duckgres-Internal-Secret` header.
- Strip any stale `?token=` query key from the login form's hidden `next` field (`loginNextURI`): a pre-fix bookmark like `/workers?token=<secret>` must not have the login page echo the secret or redirect it back into the URL bar after login.
- Tighten the auth cookie from `SameSite=Lax` to `SameSite=Strict` (it was already `HttpOnly`). It deliberately stays non-`Secure`: the dashboard is served plain-HTTP on a NetworkPolicy-restricted port reached via `kubectl port-forward`, and Safari rejects `Secure` cookies over `http://localhost`.

No references to the `?token=` flow exist in docs, scripts, runbooks, or the charts repo — the query path was convenience-only and is safe to remove.

## Tests

- `TestDashboardRejectsTokenQueryParam` (regression, would have caught the bug): a request carrying the **correct** token in `?token=` gets the 401 login page with no `Set-Cookie`, no redirect, and no echo of the token in the page body.
- `TestLoginCookieIsHttpOnlyStrict`: the login-issued cookie is `HttpOnly` + `SameSite=Strict`.
- Existing `TestDashboardRequiresLoginThenSetsCookie` / API-middleware tests still pass.
- `go build` (with and without `-tags kubernetes`), `go vet`, `gofmt` clean. (The two `api_postgres_test.go` container tests fail locally without Docker — pre-existing on `main`, unrelated.)

## e2e-mw-dev harness

Added `admin_dashboard_no_query_token` to `tests/e2e-mw-dev/harness.sh`: against the real control plane, `GET /?token=<secret>` must return 401 with no `Set-Cookie`, and the `X-Duckgres-Internal-Secret` header path must still return 200. Runs up front in `main()` (no org dependency).

Fixes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)