### PR TITLE
fix: constant-time auth check + uniform unknown-user handshake flow (#719)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1269,9 +1269,8 @@ func (c *clientConn) handleStartup() error {
 	// Password is null-terminated
 	password := string(bytes.TrimRight(body, "\x00"))
 
-	// Validate password
-	expectedPassword, ok := c.server.cfg.Users[c.username]
-	if !ok || expectedPassword != password {
+	// Validate password (constant-time; does not leak whether the user exists)
+	if !auth.ValidateUserPassword(c.server.cfg.Users, c.username, password) {
 		// Record failed authentication attempt
 		banned := c.server.rateLimiter.RecordFailedAuth(c.conn.RemoteAddr())
 		if banned {

--- a/server/worker.go
+++ b/server/worker.go
@@ -127,6 +127,58 @@ func RunChildMode() {
 	os.Exit(exitCode)
 }
 
+// authenticateChildClient runs the cleartext-password handshake for a child
+// worker connection. The password is always requested before any credential
+// check, and validation is constant-time via auth.ValidateUserPassword, so an
+// unknown user and a wrong password are indistinguishable to the client in
+// both protocol flow and error shape. Returns ExitSuccess after sending
+// AuthOK, or the exit code to terminate with on failure.
+func authenticateChildClient(reader *bufio.Reader, writer *bufio.Writer, users map[string]string, username, remoteAddr string) int {
+	// Request password
+	if err := wire.WriteAuthCleartextPassword(writer); err != nil {
+		slog.Error("Failed to request password", "error", err)
+		return ExitError
+	}
+	if err := writer.Flush(); err != nil {
+		slog.Error("Failed to flush writer", "error", err)
+		return ExitError
+	}
+
+	// Read password response
+	msgType, body, err := wire.ReadMessage(reader)
+	if err != nil {
+		slog.Error("Failed to read password message", "error", err)
+		return ExitError
+	}
+
+	if msgType != wire.MsgPassword {
+		slog.Error("Expected password message", "got", string(msgType))
+		_ = wire.WriteErrorResponse(writer, "FATAL", "28000", "expected password message")
+		_ = writer.Flush()
+		return ExitError
+	}
+
+	// Password is null-terminated
+	password := string(bytes.TrimRight(body, "\x00"))
+
+	// Validate password (constant-time; does not leak whether the user exists)
+	if !auth.ValidateUserPassword(users, username, password) {
+		slog.Warn("Authentication failed", "user", username, "remote_addr", remoteAddr)
+		auth.AuthFailuresCounter.Inc()
+		_ = wire.WriteErrorResponse(writer, "FATAL", "28P01", "password authentication failed")
+		_ = writer.Flush()
+		return ExitAuthFailure
+	}
+
+	// Send auth OK
+	if err := wire.WriteAuthOK(writer); err != nil {
+		slog.Error("Failed to send auth OK", "error", err)
+		return ExitError
+	}
+
+	return ExitSuccess
+}
+
 // runChildWorker handles a single client connection in a child process.
 // Returns the appropriate exit code.
 func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
@@ -220,54 +272,8 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 		return ExitError
 	}
 
-	// Look up expected password for this user
-	expectedPassword, ok := cfg.Users[username]
-	if !ok {
-		slog.Warn("Unknown user", "user", username, "remote_addr", cfg.RemoteAddr)
-		auth.AuthFailuresCounter.Inc()
-		_ = wire.WriteErrorResponse(writer, "FATAL", "28P01", "password authentication failed")
-		_ = writer.Flush()
-		return ExitAuthFailure
-	}
-
-	// Request password
-	if err := wire.WriteAuthCleartextPassword(writer); err != nil {
-		slog.Error("Failed to request password", "error", err)
-		return ExitError
-	}
-	if err := writer.Flush(); err != nil {
-		slog.Error("Failed to flush writer", "error", err)
-		return ExitError
-	}
-
-	// Read password response
-	msgType, body, err := wire.ReadMessage(reader)
-	if err != nil {
-		slog.Error("Failed to read password message", "error", err)
-		return ExitError
-	}
-
-	if msgType != wire.MsgPassword {
-		slog.Error("Expected password message", "got", string(msgType))
-		_ = wire.WriteErrorResponse(writer, "FATAL", "28000", "expected password message")
-		_ = writer.Flush()
-		return ExitError
-	}
-
-	// Password is null-terminated
-	password := string(bytes.TrimRight(body, "\x00"))
-	if password != expectedPassword {
-		slog.Warn("Authentication failed", "user", username, "remote_addr", cfg.RemoteAddr)
-		auth.AuthFailuresCounter.Inc()
-		_ = wire.WriteErrorResponse(writer, "FATAL", "28P01", "password authentication failed")
-		_ = writer.Flush()
-		return ExitAuthFailure
-	}
-
-	// Send auth OK
-	if err := wire.WriteAuthOK(writer); err != nil {
-		slog.Error("Failed to send auth OK", "error", err)
-		return ExitError
+	if exitCode := authenticateChildClient(reader, writer, cfg.Users, username, cfg.RemoteAddr); exitCode != ExitSuccess {
+		return exitCode
 	}
 
 	slog.Info("User authenticated", "user", username, "remote_addr", cfg.RemoteAddr)

--- a/server/worker_auth_test.go
+++ b/server/worker_auth_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/posthog/duckgres/server/wire"
+)
+
+// passwordMessage builds a client PasswordMessage ('p') for the given password.
+func passwordMessage(t *testing.T, password string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := wire.WriteMessage(&buf, wire.MsgPassword, append([]byte(password), 0)); err != nil {
+		t.Fatalf("failed to build password message: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// runChildAuth feeds clientBytes to authenticateChildClient and returns the
+// exit code plus everything the server wrote to the client.
+func runChildAuth(t *testing.T, users map[string]string, username string, clientBytes []byte) (int, []byte) {
+	t.Helper()
+	var out bytes.Buffer
+	reader := bufio.NewReader(bytes.NewReader(clientBytes))
+	writer := bufio.NewWriter(&out)
+	exitCode := authenticateChildClient(reader, writer, users, username, "test:5432")
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("failed to flush writer: %v", err)
+	}
+	return exitCode, out.Bytes()
+}
+
+func TestAuthenticateChildClientSuccess(t *testing.T) {
+	users := map[string]string{"alice": "secret"}
+
+	exitCode, out := runChildAuth(t, users, "alice", passwordMessage(t, "secret"))
+	if exitCode != ExitSuccess {
+		t.Fatalf("expected ExitSuccess, got %d", exitCode)
+	}
+
+	reader := bytes.NewReader(out)
+	msgType, _, err := wire.ReadMessage(reader)
+	if err != nil || msgType != wire.MsgAuth {
+		t.Fatalf("expected cleartext password request, got %c (err %v)", msgType, err)
+	}
+	msgType, body, err := wire.ReadMessage(reader)
+	if err != nil || msgType != wire.MsgAuth {
+		t.Fatalf("expected AuthOK, got %c (err %v)", msgType, err)
+	}
+	if !bytes.Equal(body, []byte{0, 0, 0, 0}) {
+		t.Fatalf("expected AuthOK body, got %v", body)
+	}
+}
+
+// TestAuthenticateChildClientUnknownUserIndistinguishable is a regression test
+// for the user-existence oracle: the worker used to return 28P01 for unknown
+// users before requesting a password, while known users got a password request
+// first. Both failure paths must now be byte-for-byte identical to the client.
+func TestAuthenticateChildClientUnknownUserIndistinguishable(t *testing.T) {
+	users := map[string]string{"alice": "secret"}
+
+	unknownCode, unknownOut := runChildAuth(t, users, "mallory", passwordMessage(t, "secret"))
+	wrongPwCode, wrongPwOut := runChildAuth(t, users, "alice", passwordMessage(t, "wrong"))
+
+	if unknownCode != ExitAuthFailure {
+		t.Fatalf("unknown user: expected ExitAuthFailure, got %d", unknownCode)
+	}
+	if wrongPwCode != ExitAuthFailure {
+		t.Fatalf("wrong password: expected ExitAuthFailure, got %d", wrongPwCode)
+	}
+
+	// Same message flow, same error code/message shape — no existence oracle.
+	if !bytes.Equal(unknownOut, wrongPwOut) {
+		t.Fatalf("unknown-user and wrong-password byte streams differ:\nunknown:  %q\nwrong-pw: %q", unknownOut, wrongPwOut)
+	}
+
+	// Both flows: password request first, then a generic 28P01 error.
+	reader := bytes.NewReader(unknownOut)
+	msgType, _, err := wire.ReadMessage(reader)
+	if err != nil || msgType != wire.MsgAuth {
+		t.Fatalf("expected cleartext password request before failure, got %c (err %v)", msgType, err)
+	}
+	msgType, body, err := wire.ReadMessage(reader)
+	if err != nil || msgType != 'E' {
+		t.Fatalf("expected ErrorResponse, got %c (err %v)", msgType, err)
+	}
+	if !bytes.Contains(body, []byte("28P01")) {
+		t.Fatalf("expected SQLSTATE 28P01 in error, got %q", body)
+	}
+	if !bytes.Contains(body, []byte("password authentication failed")) {
+		t.Fatalf("expected generic auth failure message, got %q", body)
+	}
+	if bytes.Contains(body, []byte("mallory")) || bytes.Contains(body, []byte("alice")) {
+		t.Fatalf("error message must not echo the username, got %q", body)
+	}
+}

--- a/server/worker_auth_test.go
+++ b/server/worker_auth_test.go
@@ -83,7 +83,7 @@ func TestAuthenticateChildClientUnknownUserIndistinguishable(t *testing.T) {
 		t.Fatalf("expected cleartext password request before failure, got %c (err %v)", msgType, err)
 	}
 	msgType, body, err := wire.ReadMessage(reader)
-	if err != nil || msgType != 'E' {
+	if err != nil || msgType != wire.MsgErrorResponse {
 		t.Fatalf("expected ErrorResponse, got %c (err %v)", msgType, err)
 	}
 	if !bytes.Contains(body, []byte("28P01")) {


### PR DESCRIPTION
## Problem

Two related auth-hardening gaps found by audit (#719):

1. **Standalone PG path** (`server/conn.go` `handleStartup`): the cleartext-password check was `expectedPassword, ok := c.server.cfg.Users[c.username]; if !ok || expectedPassword != password` — a non-constant-time string compare that also short-circuits the compare entirely for unknown users. The repo already has a constant-time, existence-hiding helper (`server/auth/policy.go::ValidateUserPassword`, sentinel password + `crypto/subtle`) used by the control-plane handshake and the Flight SQL ingress; the standalone path was simply never migrated.

2. **Process-isolation child worker** (`server/worker.go`): an unknown user received SQLSTATE `28P01` *before* the server requested a password, while a known user got a password request first. That is a user-existence oracle visible in protocol message flow — timing-independent, observable with a single connection.

## Fix

- `server/conn.go`: validate via `auth.ValidateUserPassword` (constant-time, does not leak user existence).
- `server/worker.go`: always request the password first, then validate via `auth.ValidateUserPassword`, so unknown-user and wrong-password failures are byte-for-byte identical to the client (same message flow, same generic `28P01` "password authentication failed"). The handshake is extracted into `authenticateChildClient(reader, writer, users, username, remoteAddr)` with behavior otherwise unchanged, so it is unit-testable.

No client-visible change for valid credentials; failed auths keep the same generic `28P01` error, exit codes, rate-limiter accounting, and `AuthFailuresCounter` metrics.

## Honest severity note

This is defense-in-depth, not a critical fix. The practical timing-attack risk was already mitigated: the nanosecond-scale compare is measured over TLS, and the IP-ban rate limiter (`server/auth/ratelimit.go`, invoked on this exact failure path) bans the source IP after `MaxFailedAttempts`, so the thousands of samples needed for statistical timing enumeration are not obtainable. The worker-path protocol-flow oracle was the more real of the two (single-probe, timing-independent), and is now closed.

## Tests

- New `server/worker_auth_test.go`:
  - `TestAuthenticateChildClientSuccess` — correct credentials → password request, then AuthOK, `ExitSuccess`.
  - `TestAuthenticateChildClientUnknownUserIndistinguishable` — **regression test that would have caught the bug**: asserts the unknown-user and wrong-password server byte streams are *identical* (password request first, then generic `28P01`, no username echoed), both returning `ExitAuthFailure`. On `origin/main` this fails because the unknown-user path skips the password request.
- The standalone `conn.go` path now delegates to `auth.ValidateUserPassword`, whose unknown-user/wrong-password/constant-time behavior is covered by the existing `server/auth/policy_test.go`; the failure branch in `handleStartup` is a single shared path for both cases by construction.
- `go build ./...`, `go test ./server/... ./server/auth/...` pass; `gofmt -l` clean on changed files; `go vet` clean.

## e2e-mw-dev harness decision

No in-Job assertion added, deliberately: the mw-dev cluster runs the **control-plane remote backend**, whose client PG auth path (`controlplane/control.go` multitenant resolution / `ValidateUserPassword`) is already constant-time and is **not modified** by this PR. The two surfaces changed here — standalone mode and process-isolation child workers (`server/worker.go`, the `--worker-backend process` single-host topology) — do not run in the mw-dev deployment, so the fixed behavior is unreachable from the harness Job. Additionally, the harness intentionally avoids failed-auth probes because the CP IP-bans the Job's source IP after a handful of failed auths (noted in `harness.sh`), which would flake the entire suite. Coverage lives in the new deterministic unit test of the exact wire-level byte streams instead.

Fixes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)