### PR TITLE
fix: validate client-supplied wire message lengths to prevent pre-auth remote DoS (#715)

### DIFF
--- a/server/wire/protocol.go
+++ b/server/wire/protocol.go
@@ -9,16 +9,16 @@ import (
 // PostgreSQL message types
 const (
 	// Frontend (client) messages
-	MsgQuery       = 'Q'
-	MsgTerminate   = 'X'
-	MsgPassword    = 'p'
-	MsgParse       = 'P'
-	MsgBind        = 'B'
-	MsgDescribe    = 'D'
-	MsgExecute     = 'E'
-	MsgSync        = 'S'
-	MsgClose       = 'C'
-	MsgFlush       = 'H'
+	MsgQuery     = 'Q'
+	MsgTerminate = 'X'
+	MsgPassword  = 'p'
+	MsgParse     = 'P'
+	MsgBind      = 'B'
+	MsgDescribe  = 'D'
+	MsgExecute   = 'E'
+	MsgSync      = 'S'
+	MsgClose     = 'C'
+	MsgFlush     = 'H'
 
 	// Backend (server) messages
 	MsgAuth            = 'R'
@@ -46,9 +46,22 @@ const (
 
 // Authentication types
 const (
-	authOK              = 0
-	authCleartextPwd    = 3
-	authMD5Pwd          = 5
+	authOK           = 0
+	authCleartextPwd = 3
+	authMD5Pwd       = 5
+)
+
+// Message length bounds. Lengths are client-supplied (and read pre-auth for
+// startup messages), so they MUST be validated before allocation: a negative
+// or absurd length would otherwise panic in make() and crash the process.
+const (
+	// maxStartupMessageLength caps the startup packet. Matches PostgreSQL's
+	// MAX_STARTUP_PACKET_LENGTH and controlplane's readStartupFromRaw guard.
+	maxStartupMessageLength = 10000
+
+	// maxMessageLength caps regular protocol messages (1 GiB). Generous enough
+	// for large COPY data and bind parameters while bounding allocations.
+	maxMessageLength = 1 << 30
 )
 
 // readStartupMessage reads the initial startup message from the client
@@ -57,6 +70,12 @@ func ReadStartupMessage(r io.Reader) (map[string]string, error) {
 	var length int32
 	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
 		return nil, fmt.Errorf("failed to read startup message length: %w", err)
+	}
+
+	// Validate before allocating: minimum 8 = length field (4) + protocol
+	// version (4), which also guarantees remaining[:4] below is in range.
+	if length < 8 || length > maxStartupMessageLength {
+		return nil, fmt.Errorf("invalid startup message length: %d", length)
 	}
 
 	// Read remaining bytes
@@ -142,6 +161,11 @@ func ReadMessage(r io.Reader) (byte, []byte, error) {
 	var length int32
 	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
 		return 0, nil, fmt.Errorf("failed to read message length: %w", err)
+	}
+
+	// Validate before allocating: minimum 4 = the length field itself.
+	if length < 4 || length > maxMessageLength {
+		return 0, nil, fmt.Errorf("invalid message length: %d", length)
 	}
 
 	// Read message body

--- a/server/wire/protocol_test.go
+++ b/server/wire/protocol_test.go
@@ -1,0 +1,163 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// buildStartupMessage encodes a v3 startup packet: int32 length (includes
+// itself), int32 protocol version, then null-terminated key/value pairs.
+func buildStartupMessage(protocolVersion uint32, params map[string]string) []byte {
+	var body bytes.Buffer
+	_ = binary.Write(&body, binary.BigEndian, protocolVersion)
+	for k, v := range params {
+		body.WriteString(k)
+		body.WriteByte(0)
+		body.WriteString(v)
+		body.WriteByte(0)
+	}
+	body.WriteByte(0) // terminator
+
+	var msg bytes.Buffer
+	_ = binary.Write(&msg, binary.BigEndian, int32(body.Len()+4))
+	msg.Write(body.Bytes())
+	return msg.Bytes()
+}
+
+// buildRawStartup writes an arbitrary (possibly invalid) length header
+// followed by payload bytes.
+func buildRawStartup(length int32, payload []byte) []byte {
+	var msg bytes.Buffer
+	_ = binary.Write(&msg, binary.BigEndian, length)
+	msg.Write(payload)
+	return msg.Bytes()
+}
+
+func TestReadStartupMessageValid(t *testing.T) {
+	msg := buildStartupMessage(196608, map[string]string{ // protocol 3.0
+		"user":     "alice",
+		"database": "db1",
+	})
+	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("ReadStartupMessage: %v", err)
+	}
+	if params["user"] != "alice" || params["database"] != "db1" {
+		t.Fatalf("unexpected params: %v", params)
+	}
+}
+
+func TestReadStartupMessageSSLRequest(t *testing.T) {
+	msg := buildStartupMessage(80877103, nil)
+	// SSLRequest is exactly 8 bytes: length + request code.
+	msg = msg[:8]
+	binary.BigEndian.PutUint32(msg[:4], 8)
+	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("ReadStartupMessage: %v", err)
+	}
+	if params["__ssl_request"] != "true" {
+		t.Fatalf("expected SSL request, got: %v", params)
+	}
+}
+
+// Regression test for #715: malformed startup lengths must return an error,
+// not panic with a negative/huge makeslice or an out-of-range slice. The
+// startup message is read pre-auth, so a panic here is a remote DoS.
+func TestReadStartupMessageInvalidLength(t *testing.T) {
+	cases := []struct {
+		name   string
+		length int32
+	}{
+		{"negative", -1},
+		{"most_negative", -2147483648},
+		{"zero", 0},
+		{"below_length_field", 3},
+		{"length_only_no_version", 4}, // would slice remaining[:4] out of range
+		{"partial_version", 7},
+		{"just_over_cap", maxStartupMessageLength + 1},
+		{"absurdly_large", 2147483647}, // would allocate ~2GiB
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := buildRawStartup(tc.length, nil)
+			_, err := ReadStartupMessage(bytes.NewReader(msg))
+			if err == nil {
+				t.Fatalf("expected error for length %d, got nil", tc.length)
+			}
+			if !strings.Contains(err.Error(), "invalid startup message length") {
+				t.Fatalf("unexpected error for length %d: %v", tc.length, err)
+			}
+		})
+	}
+}
+
+func TestReadStartupMessageMaxLengthAccepted(t *testing.T) {
+	// A startup message exactly at the cap must still be readable.
+	body := make([]byte, maxStartupMessageLength-4)
+	binary.BigEndian.PutUint32(body[:4], 196608) // protocol 3.0, rest zeros
+	msg := buildRawStartup(maxStartupMessageLength, body)
+	if _, err := ReadStartupMessage(bytes.NewReader(msg)); err != nil {
+		t.Fatalf("ReadStartupMessage at max length: %v", err)
+	}
+}
+
+func TestReadMessageValid(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, MsgQuery, []byte("SELECT 1\x00")); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	msgType, body, err := ReadMessage(&buf)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msgType != MsgQuery || string(body) != "SELECT 1\x00" {
+		t.Fatalf("unexpected message: type=%c body=%q", msgType, body)
+	}
+}
+
+func TestReadMessageEmptyBody(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, MsgSync, nil); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	msgType, body, err := ReadMessage(&buf)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msgType != MsgSync || len(body) != 0 {
+		t.Fatalf("unexpected message: type=%c body=%q", msgType, body)
+	}
+}
+
+// Regression test for #715 (hardening half): malformed regular-message
+// lengths must return an error, not panic in make().
+func TestReadMessageInvalidLength(t *testing.T) {
+	cases := []struct {
+		name   string
+		length int32
+	}{
+		{"negative", -1},
+		{"most_negative", -2147483648},
+		{"zero", 0},
+		{"below_length_field", 3},
+		{"just_over_cap", maxMessageLength + 1},
+		{"absurdly_large", 2147483647},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			buf.WriteByte(MsgQuery)
+			_ = binary.Write(&buf, binary.BigEndian, tc.length)
+			_, _, err := ReadMessage(&buf)
+			if err == nil {
+				t.Fatalf("expected error for length %d, got nil", tc.length)
+			}
+			if !strings.Contains(err.Error(), "invalid message length") {
+				t.Fatalf("unexpected error for length %d: %v", tc.length, err)
+			}
+		})
+	}
+}

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -37,7 +37,10 @@ from its mounted SA token) for the pod-level checks the Go suite made via
 client-go:
 
 - **wire/query** — `SELECT 1` round-trips; 5 concurrent connections stay
-  distinct (ported from `TestK8sMultipleConcurrentConnections`).
+  distinct (ported from `TestK8sMultipleConcurrentConnections`); a malformed
+  post-TLS startup-message length (negative / ~2GiB / truncated, injected via
+  `openssl s_client -starttls postgres`) gets a clean connection close — the CP
+  pod must not restart and must keep serving (regression for #715).
 - **cold-burst absorption** — there is no warm pool, so a burst of cold sessions
   spawns workers on demand; if it outruns the org/global cap the surplus gets a
   graceful client-visible hint (`no Duckgres worker … retry in about 45 seconds`

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -10,8 +10,9 @@
 # two real metadata backends cnpg + ext (aurora is retired — out of scope):
 #
 #   wire/query   : SELECT 1 round-trips, N concurrent connections stay distinct,
-#                  and a cold burst is absorbed (workers spawn on demand; any
-#                  surplus gets a graceful retry hint) then served.
+#                  a malformed startup-message length is rejected cleanly (no CP
+#                  crash, #715), and a cold burst is absorbed (workers spawn on
+#                  demand; any surplus gets a graceful retry hint) then served.
 #   activation   : DuckLake + Iceberg catalogs attach and read/write.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
@@ -62,7 +63,7 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 # stdout would land in that capture and make jq choke ("Invalid numeric literal").
 log()  { echo ">>> $*" >&2; }
 
-apk add --no-cache curl jq postgresql-client >/dev/null 2>&1 || true
+apk add --no-cache curl jq postgresql-client openssl >/dev/null 2>&1 || true
 
 # kubectl, for the pod-level assertions the Go suite used to make via client-go.
 # The Job runs as the `duckgres` SA (pods get/list/delete/patch + pods/exec +
@@ -208,6 +209,43 @@ basic_query() { # org password
   log "basic query on $1"
   n="$(pg "$1" "$2" ducklake 'SELECT 1')"
   [ "$n" = "1" ] || fail "$1 SELECT 1 returned '$n'"
+}
+
+# Regression for #715: the CP reads the post-TLS startup message with the shared
+# wire.ReadStartupMessage, which used to make([]byte, length-4) straight from the
+# client-supplied length — a negative or absurd length panicked the (unrecovered)
+# connection goroutine and crashed the WHOLE control plane, dropping every
+# tenant's in-flight session, pre-auth. Drive malformed lengths through a real
+# TLS session and assert the CP neither restarts nor stops serving.
+# `openssl s_client -starttls postgres` performs the pre-TLS SSLRequest dance,
+# then hands us the raw post-TLS stream where the startup message goes.
+malformed_startup_resilience() { # org password
+  log "malformed startup-length resilience on $1 (#715)"
+  cp_pod="$(k get pods -l app=duckgres-control-plane -o jsonpath='{.items[0].metadata.name}')"
+  [ -n "$cp_pod" ] || fail "no control-plane pod found"
+  before="$(k get pod "$cp_pod" -o jsonpath='{.status.containerStatuses[0].restartCount}')"
+
+  # \377…: length -1 (negative makeslice); \177…: length 2^31-1 (~2GiB alloc);
+  # \000\000\000\004: length 4 (remaining[:4] out of range). Each must yield a
+  # clean connection close, never a CP panic.
+  for hdr in '\377\377\377\377' '\177\377\377\377' '\000\000\000\004'; do
+    out="$({ printf "$hdr"; sleep 2; } | openssl s_client \
+        -connect "$CP_IP:5432" -servername "$1$SNI_SUFFIX" \
+        -starttls postgres 2>&1 || true)"
+    # Vacuity guard: the TLS handshake must have completed (server cert seen),
+    # or the garbage never reached the post-TLS startup reader and this test
+    # asserted nothing.
+    case "$out" in
+      *"BEGIN CERTIFICATE"*) : ;;
+      *) fail "s_client did not complete TLS to the CP (header $hdr): $(printf %s "$out" | tr -d '\n' | tail -c 200)" ;;
+    esac
+  done
+
+  sleep 5 # let a hypothetical CP crash surface in pod status
+  after="$(k get pod "$cp_pod" -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo gone)"
+  [ "$after" = "$before" ] || fail "CP pod $cp_pod restarted on malformed startup (restarts $before -> $after)"
+  v="$(pg "$1" "$2" ducklake 'SELECT 1')"
+  [ "$v" = "1" ] || fail "CP stopped serving after malformed startup (got '$v')"
 }
 
 # Cold-burst absorption: there is no warm pool — workers are spawned on demand
@@ -638,6 +676,7 @@ main() {
   # ---- cnpg backend (full coverage incl. pod-level + resilience) ----
   wait_worker "$CNPG" "$cnpg_pw" ducklake
   basic_query            "$CNPG" "$cnpg_pw"
+  malformed_startup_resilience "$CNPG" "$cnpg_pw"
   cold_burst_absorption  "$CNPG" "$cnpg_pw"   # before more workers exist
   rw_ducklake            "$CNPG" "$cnpg_pw"
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
@@ -680,7 +719,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: wire + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: wire + malformed-startup-resilience + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem (#715, P0)

`server/wire/protocol.go` read client-supplied message lengths as `int32` and used them unvalidated:

- `ReadStartupMessage`: `make([]byte, length-4)` — `length < 4` panics with a negative `makeslice`; `length` in 4..7 panics at `remaining[:4]` (slice out of range); a huge length forces a ~2GiB allocation.
- `ReadMessage`: same unvalidated `make` (the `length > 4` guard only protected the subsequent `io.ReadFull`).

The startup message is the **first, pre-auth** bytes on a connection, and the panic is **unrecovered** on two production paths:

- `server/server.go::handleConnectionIsolated` (isolated-parent startup read)
- `controlplane/control.go::handleConnection` (post-TLS startup read at `control.go:846`)

So a single malformed packet crashed the whole process — in control-plane mode dropping **all tenants'** in-flight sessions.

## Fix

Validate the length in the shared `wire` package before allocating, mirroring the existing guard in controlplane's `readStartupFromRaw` (`length < 8 || length > 10000`):

- `ReadStartupMessage`: `8 <= length <= 10000` (`maxStartupMessageLength`, matching PostgreSQL's `MAX_STARTUP_PACKET_LENGTH`; minimum 8 also covers the `remaining[:4]` OOB case).
- `ReadMessage`: `4 <= length <= 1GiB` (`maxMessageLength` — generous for COPY data / bind parameters while bounding allocations).

A bad length now returns a proper error → clean connection close, never a panic. This fixes every caller at once (isolated parent, control plane, child worker, in-process conn loop).

I did **not** add `recover()` to the two unrecovered handlers: `handleConnectionIsolated` and the CP handler use manual (non-deferred) rate-limiter unregister/close on each return path, so a blanket recover-with-cleanup risks double-unregister accounting bugs; the validation removes the only known panic source in these readers. Happy to do that restructure as a follow-up if wanted.

Also gofmt'd `server/wire/protocol.go` (constant-block alignment was non-gofmt on main), which accounts for the whitespace-only hunks.

## Tests

- **Unit (`server/wire/protocol_test.go`, new):** regression cases on both readers — negative (`-1`, `math.MinInt32`), zero, truncated (`3`, `4`, `7`), just-over-cap and `MaxInt32` lengths all return `invalid … length` errors; plus valid startup (params parsed), SSLRequest, startup exactly at the 10000 cap, valid `ReadMessage` round-trip, and empty-body (`length == 4`) message. All pass; pre-fix, the malformed cases panic.
- `go build ./...`, `go vet ./server/wire`, `go test ./server/... ./controlplane/...` all green; `gofmt -l` clean on changed files.

## e2e harness decision

**Added** `malformed_startup_resilience` to `tests/e2e-mw-dev/harness.sh`: it drives the exact P0 path (CP post-TLS startup read) against the real control plane using `openssl s_client -starttls postgres` (which performs the pre-TLS SSLRequest dance, then hands over the raw post-TLS stream), injecting three malformed length headers (negative, `MaxInt32` ~2GiB, truncated `4`). It asserts the CP pod's restartCount is unchanged and `SELECT 1` still serves afterwards, with a vacuity guard that the TLS handshake actually completed (server cert seen) so the test can't silently pass without reaching the startup reader. Pre-fix, each header panics the CP → pod restart → assertion fails. The isolated-parent path (`server.go:2625`) is standalone-mode-only and not deployed in mw-dev, so it is covered by the wire unit tests through the same shared function.

Fixes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)