### PR TITLE
fix: jsonb || silently corrupted array/scalar concatenation via json_merge_patch (#716)

### DIFF
--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -13,6 +13,8 @@
 #                  a malformed startup-message length is rejected cleanly (no CP
 #                  crash, #715), and a cold burst is absorbed (workers spawn on
 #                  demand; any surplus gets a graceful retry hint) then served.
+#                  jsonb || keeps Postgres concat semantics through
+#                  transpilation (#716).
 #   activation   : DuckLake + Iceberg catalogs attach and read/write.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
@@ -248,6 +250,24 @@ malformed_startup_resilience() { # org password
   [ "$after" = "$before" ] || fail "CP pod $cp_pod restarted on malformed startup (restarts $before -> $after)"
   v="$(pg "$1" "$2" ducklake 'SELECT 1')"
   [ "$v" = "1" ] || fail "CP stopped serving after malformed startup (got '$v')"
+}
+
+# jsonb || must keep Postgres concatenation semantics through the full CP
+# transpile → worker DuckDB execute path (regression for #716: the transpiler
+# used to rewrite it to json_merge_patch, which REPLACED arrays instead of
+# concatenating them — silently corrupting the common `col || '["x"]'::jsonb`
+# append idiom — and deleted null-valued keys instead of keeping them).
+# Backend-independent (no metadata touched), so cnpg-only is sufficient.
+jsonb_concat_semantics() { # org password
+  log "jsonb || semantics on $1"
+  v="$(pg "$1" "$2" ducklake "SELECT '[1,2]'::jsonb || '[3,4]'::jsonb")"
+  [ "$v" = '[1,2,3,4]' ] || fail "jsonb array concat returned '$v' (want [1,2,3,4])"
+  v="$(pg "$1" "$2" ducklake "SELECT '{\"a\":1}'::jsonb || '{\"a\":null}'::jsonb")"
+  [ "$v" = '{"a":null}' ] || fail "jsonb null-value merge returned '$v' (want {\"a\":null})"
+  v="$(pg "$1" "$2" ducklake "SELECT '{\"a\":1}'::jsonb || '{\"b\":2}'::jsonb")"
+  [ "$v" = '{"a":1,"b":2}' ] || fail "jsonb object merge returned '$v' (want {\"a\":1,\"b\":2})"
+  v="$(pg "$1" "$2" ducklake "SELECT '[1,2]'::jsonb || '3'::jsonb")"
+  [ "$v" = '[1,2,3]' ] || fail "jsonb array append returned '$v' (want [1,2,3])"
 }
 
 # Cold-burst absorption: there is no warm pool — workers are spawned on demand
@@ -701,6 +721,7 @@ main() {
   wait_worker "$CNPG" "$cnpg_pw" ducklake
   basic_query            "$CNPG" "$cnpg_pw"
   malformed_startup_resilience "$CNPG" "$cnpg_pw"
+  jsonb_concat_semantics "$CNPG" "$cnpg_pw"
   cold_burst_absorption  "$CNPG" "$cnpg_pw"   # before more workers exist
   rw_ducklake            "$CNPG" "$cnpg_pw"
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
@@ -743,7 +764,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -272,7 +272,21 @@ func TestFunctionsJSON(t *testing.T) {
 
 		// JSONB modification
 		{Name: "jsonb_set", Query: "SELECT jsonb_set('{\"a\": 1}'::JSONB, '{a}', '2')"},
+		// jsonb || semantics matrix (regression for #716: the old
+		// json_merge_patch rewrite replaced arrays instead of concatenating
+		// and deleted null-valued keys instead of keeping them). Each case is
+		// compared against real PostgreSQL output (jsonEqual is key-order
+		// insensitive; Postgres sorts jsonb keys, DuckDB does not).
 		{Name: "jsonb_concat", Query: "SELECT '{\"a\": 1}'::JSONB || '{\"b\": 2}'::JSONB"},
+		{Name: "jsonb_concat_null_value_kept", Query: "SELECT '{\"a\": 1}'::JSONB || '{\"a\": null}'::JSONB"},
+		{Name: "jsonb_concat_shallow_merge", Query: "SELECT '{\"a\": {\"x\": 1}}'::JSONB || '{\"a\": {\"y\": 2}}'::JSONB"},
+		{Name: "jsonb_concat_arrays", Query: "SELECT '[1, 2]'::JSONB || '[3, 4]'::JSONB"},
+		{Name: "jsonb_concat_array_append", Query: "SELECT '[1, 2]'::JSONB || '3'::JSONB"},
+		{Name: "jsonb_concat_array_prepend", Query: "SELECT '3'::JSONB || '[1, 2]'::JSONB"},
+		{Name: "jsonb_concat_scalars", Query: "SELECT '1'::JSONB || '2'::JSONB"},
+		{Name: "jsonb_concat_object_array", Query: "SELECT '{\"a\": 1}'::JSONB || '[1]'::JSONB"},
+		{Name: "jsonb_concat_json_null_element", Query: "SELECT 'null'::JSONB || '[1]'::JSONB"},
+		{Name: "jsonb_concat_sql_null", Query: "SELECT (NULL::JSONB || '[1]'::JSONB) IS NULL"},
 		{Name: "jsonb_delete_key", Query: "SELECT '{\"a\": 1, \"b\": 2}'::JSONB - 'a'"},
 
 		// Expansion functions

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -155,7 +155,6 @@ var knownFailures = map[string]string{
 	"json_typeof_number":      "DuckDB: json_typeof differs",
 	"json_array_length":       "DuckDB: json_array_length differs",
 	"jsonb_set":               "DuckDB: jsonb_set not available",
-	"jsonb_concat":            "DuckDB: jsonb concat differs",
 	"jsonb_delete_key":        "DuckDB: jsonb delete differs",
 	"json_each":               "DuckDB: json_each not available",
 	"jsonb_each":              "DuckDB: jsonb_each not available",

--- a/transpiler/transform/literals_test.go
+++ b/transpiler/transform/literals_test.go
@@ -63,21 +63,4 @@ func TestLiteralTransform_NonLiteralUnchanged(t *testing.T) {
 	}
 }
 
-func TestOperatorTransform_JSONBMerge(t *testing.T) {
-	tr := NewOperatorTransform()
-	out := deparseAfter(t, tr, `SELECT '{"a":1}'::jsonb || '{"b":2}'::jsonb`)
-	if !strings.Contains(strings.ToLower(out), "json_merge_patch") {
-		t.Errorf("expected json_merge_patch, got %q", out)
-	}
-}
-
-func TestOperatorTransform_StringConcatUnchanged(t *testing.T) {
-	tr := NewOperatorTransform()
-	out := deparseAfter(t, tr, `SELECT 'a' || 'b'`)
-	if strings.Contains(strings.ToLower(out), "json_merge_patch") {
-		t.Errorf("plain string concat should not become json_merge_patch, got %q", out)
-	}
-	if !strings.Contains(out, "||") {
-		t.Errorf("string concat || should be preserved, got %q", out)
-	}
-}
+// jsonb || rewrite coverage lives in operators_jsonb_concat_test.go.

--- a/transpiler/transform/operators.go
+++ b/transpiler/transform/operators.go
@@ -510,12 +510,16 @@ func (t *OperatorTransform) createJsonExtractFuncCall(left, right *pg_query.Node
 }
 
 // looksJSON reports whether a node is syntactically JSON: a cast to json/jsonb,
-// or a JSON-returning json* function call (including the json_extract calls this
-// transform produces from -> / ->>). Used to gate the || JSON-concat rewrite so
-// genuine string/array concatenation is left untouched. json*-named functions
-// that return text/numbers/booleans (json_extract_string, json_array_length,
-// json_type, ...) are excluded: `json_extract_string(d,'a') || 'x'` is plain
-// text concat in Postgres and must stay that way.
+// a JSON-returning json* function call (including the json_extract calls this
+// transform produces from -> / ->>), a JSON-producing conversion function
+// (to_json/to_jsonb/row_to_json/array_to_json), or a `->` A_Expr (which this
+// transform deterministically rewrites to json_extract — the || gate runs
+// before the operands' own rewrite, so the raw arrow must count). Used to gate
+// the || JSON-concat rewrite so genuine string/array concatenation is left
+// untouched. json*-named functions that return text/numbers/booleans
+// (json_extract_string, json_array_length, json_type, ...) are excluded:
+// `json_extract_string(d,'a') || 'x'` is plain text concat in Postgres and
+// must stay that way (likewise `->>`, which yields text, does not count).
 func looksJSON(node *pg_query.Node) bool {
 	if node == nil {
 		return false
@@ -534,6 +538,22 @@ func looksJSON(node *pg_query.Node) bool {
 			if strings.HasPrefix(name, "json") && !jsonFuncReturnsNonJSON(name) {
 				return true
 			}
+			// JSON-producing conversions whose names don't start with "json".
+			// FunctionTransform (which runs earlier) maps to_jsonb -> to_json,
+			// but cover the Postgres spellings too for direct/standalone use.
+			switch name {
+			case "to_json", "to_jsonb", "row_to_json", "array_to_json":
+				return true
+			}
+		}
+	}
+	// A bare `d -> 'a'` operand (no cast, not yet rewritten): the arrow always
+	// becomes json_extract, which returns JSON. Without this, `(d->'a') ||
+	// (d->'b')` would fall through to DuckDB string concat of two JSON values.
+	if ae := node.GetAExpr(); ae != nil && ae.Kind == pg_query.A_Expr_Kind_AEXPR_OP &&
+		ae.Lexpr != nil && ae.Rexpr != nil && len(ae.Name) == 1 {
+		if s := ae.Name[0].GetString_(); s != nil && s.Sval == "->" {
+			return true
 		}
 	}
 	return false
@@ -585,8 +605,21 @@ func jsonFuncReturnsNonJSON(name string) bool {
 // values, which is exactly the Postgres shallow-merge behavior (verified
 // against PostgreSQL output for all the cases above; key ORDER may differ —
 // Postgres sorts jsonb keys, DuckDB preserves left-operand order — but jsonb
-// objects are semantically unordered). Operands are cloned per use site so
-// later pipeline transforms never visit a shared node twice.
+// objects are semantically unordered; objects with DUPLICATE keys also differ,
+// but that is duckgres's global jsonb-as-JSON divergence — Postgres dedups at
+// the ::jsonb cast, DuckDB JSON does not — not something this rewrite adds).
+// Operands are cloned per use site so later pipeline transforms never visit a
+// shared node twice.
+//
+// KNOWN COSTS of the per-use-site cloning: each operand appears ~6 times in
+// the emitted CASE, so a chain of N `||` grows the transpiled SQL ~6^N (fine
+// for the realistic 1-3 operand idioms; ~1MB of SQL by 6 chained operands),
+// and a non-trivial operand (scalar subquery, volatile function) is EVALUATED
+// up to that many times — a volatile operand could even dispatch differently
+// between the json_type() probe and the use site. If this ever bites, the fix
+// is linear expansion: register a DuckDB scalar macro (e.g.
+// duckgres_jsonb_concat(l, r)) at session/worker init and emit one call per
+// ||, binding each operand exactly once.
 func (t *OperatorTransform) createJSONConcatExpr(left, right *pg_query.Node) *pg_query.Node {
 	if newLeft := t.transformExpression(left); newLeft != nil {
 		left = newLeft

--- a/transpiler/transform/operators.go
+++ b/transpiler/transform/operators.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"google.golang.org/protobuf/proto"
 )
 
 // OperatorTransform converts PostgreSQL operators to DuckDB equivalents.
@@ -290,13 +291,15 @@ func (t *OperatorTransform) transformExpression(node *pg_query.Node) *pg_query.N
 			return t.createJsonExtractFuncCall(aexpr.Lexpr, aexpr.Rexpr, false)
 		case "->>":
 			return t.createJsonExtractFuncCall(aexpr.Lexpr, aexpr.Rexpr, true)
-		// jsonb || jsonb is an object merge in Postgres, but DuckDB treats || as
-		// string concatenation, silently producing invalid JSON. Rewrite to
-		// json_merge_patch only when an operand is clearly JSON; otherwise leave
-		// || alone (string/array concat is the safe default).
+		// jsonb || jsonb is concatenation in Postgres (object merge / array
+		// concat), but DuckDB treats || as string concatenation, silently
+		// producing invalid JSON. Rewrite to a json_type()-dispatching CASE
+		// that reproduces Postgres semantics only when an operand is clearly
+		// JSON; otherwise leave || alone (string/array concat is the safe
+		// default).
 		case "||":
 			if looksJSON(aexpr.Lexpr) || looksJSON(aexpr.Rexpr) {
-				return t.createJSONMergeFuncCall(aexpr.Lexpr, aexpr.Rexpr)
+				return t.createJSONConcatExpr(aexpr.Lexpr, aexpr.Rexpr)
 			}
 		// Regex operators — only match binary ~ (both operands present).
 		// Unary ~ (bitwise NOT, e.g. ~id) has Lexpr=nil and must be left as-is;
@@ -507,9 +510,12 @@ func (t *OperatorTransform) createJsonExtractFuncCall(left, right *pg_query.Node
 }
 
 // looksJSON reports whether a node is syntactically JSON: a cast to json/jsonb,
-// or a json* function call (including the json_extract calls this transform
-// produces from -> / ->>). Used to gate the || -> json_merge_patch rewrite so
-// genuine string/array concatenation is left untouched.
+// or a JSON-returning json* function call (including the json_extract calls this
+// transform produces from -> / ->>). Used to gate the || JSON-concat rewrite so
+// genuine string/array concatenation is left untouched. json*-named functions
+// that return text/numbers/booleans (json_extract_string, json_array_length,
+// json_type, ...) are excluded: `json_extract_string(d,'a') || 'x'` is plain
+// text concat in Postgres and must stay that way.
 func looksJSON(node *pg_query.Node) bool {
 	if node == nil {
 		return false
@@ -524,7 +530,8 @@ func looksJSON(node *pg_query.Node) bool {
 	}
 	if fc := node.GetFuncCall(); fc != nil && len(fc.Funcname) > 0 {
 		if last := fc.Funcname[len(fc.Funcname)-1].GetString_(); last != nil {
-			if strings.HasPrefix(strings.ToLower(last.Sval), "json") {
+			name := strings.ToLower(last.Sval)
+			if strings.HasPrefix(name, "json") && !jsonFuncReturnsNonJSON(name) {
 				return true
 			}
 		}
@@ -532,27 +539,149 @@ func looksJSON(node *pg_query.Node) bool {
 	return false
 }
 
-// createJSONMergeFuncCall rewrites `a || b` to json_merge_patch(a, b). Note this
-// is RFC 7396 merge-patch semantics (recursive, and a null value deletes a key),
-// which matches Postgres jsonb || for the common flat-object-merge case but
-// diverges for nested objects and explicit nulls.
-func (t *OperatorTransform) createJSONMergeFuncCall(left, right *pg_query.Node) *pg_query.Node {
+// jsonFuncReturnsNonJSON reports whether a json*-named function returns a
+// non-JSON value (VARCHAR, BIGINT, BOOLEAN, ...), so its result concatenated
+// with || must keep DuckDB string-concat semantics. Covers both the PostgreSQL
+// names and the DuckDB names FunctionTransform rewrites them to (function
+// mapping runs before this transform in the pipeline).
+func jsonFuncReturnsNonJSON(name string) bool {
+	for _, suffix := range []string{"_string", "_text", "_length", "_keys", "_valid", "_exists", "_contains"} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	switch name {
+	case "json_type", "json_typeof", "jsonb_typeof":
+		return true
+	}
+	return false
+}
+
+// createJSONConcatExpr rewrites `a || b` (with a JSON-looking operand) to a
+// CASE expression reproducing Postgres jsonb || semantics in DuckDB:
+//
+//	object || object  -> shallow merge, right side wins, explicit nulls are
+//	                     KEPT (unlike json_merge_patch, which deep-merges and
+//	                     deletes null-valued keys)
+//	array  || array   -> element concatenation
+//	array  || other   -> append   (non-array side wrapped as a one-element array)
+//	other  || array   -> prepend
+//	scalar || scalar  -> two-element array
+//	NULL   || any     -> NULL (SQL NULL, not JSON null)
+//
+// Emitted shape (L/R = operands):
+//
+//	CASE
+//	  WHEN L IS NULL OR R IS NULL THEN NULL
+//	  WHEN json_type(L) = 'OBJECT' AND json_type(R) = 'OBJECT'
+//	    THEN to_json(map_concat(json_transform(L, '"MAP(VARCHAR, JSON)"'),
+//	                            json_transform(R, '"MAP(VARCHAR, JSON)"')))
+//	  ELSE to_json(list_concat(<L as JSON[]>, <R as JSON[]>))
+//	END
+//
+// where <x as JSON[]> is CASE WHEN json_type(x) = 'ARRAY' THEN
+// json_transform(x, '["JSON"]') ELSE list_value(CAST(x AS JSON)) END.
+// map_concat is last-wins on key collision and to_json inlines JSON-typed
+// values, which is exactly the Postgres shallow-merge behavior (verified
+// against PostgreSQL output for all the cases above; key ORDER may differ —
+// Postgres sorts jsonb keys, DuckDB preserves left-operand order — but jsonb
+// objects are semantically unordered). Operands are cloned per use site so
+// later pipeline transforms never visit a shared node twice.
+func (t *OperatorTransform) createJSONConcatExpr(left, right *pg_query.Node) *pg_query.Node {
 	if newLeft := t.transformExpression(left); newLeft != nil {
 		left = newLeft
 	}
 	if newRight := t.transformExpression(right); newRight != nil {
 		right = newRight
 	}
-	return &pg_query.Node{
-		Node: &pg_query.Node_FuncCall{
-			FuncCall: &pg_query.FuncCall{
-				Funcname: []*pg_query.Node{
-					{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: "json_merge_patch"}}},
-				},
-				Args: []*pg_query.Node{left, right},
-			},
-		},
+
+	asObjectMap := func(operand *pg_query.Node) *pg_query.Node {
+		return jsonFuncCall("json_transform", cloneNode(operand), strConst(`"MAP(VARCHAR, JSON)"`))
 	}
+	// CASE WHEN json_type(x) = 'ARRAY' THEN json_transform(x, '["JSON"]')
+	// ELSE list_value(CAST(x AS JSON)) END — Postgres treats every non-array
+	// operand of a non-object||object concat as a one-element array.
+	asElementList := func(operand *pg_query.Node) *pg_query.Node {
+		return &pg_query.Node{Node: &pg_query.Node_CaseExpr{CaseExpr: &pg_query.CaseExpr{
+			Args: []*pg_query.Node{{Node: &pg_query.Node_CaseWhen{CaseWhen: &pg_query.CaseWhen{
+				Expr:   jsonTypeEquals(operand, "ARRAY"),
+				Result: jsonFuncCall("json_transform", cloneNode(operand), strConst(`["JSON"]`)),
+			}}}},
+			Defresult: jsonFuncCall("list_value", castToJSON(cloneNode(operand))),
+		}}}
+	}
+
+	return &pg_query.Node{Node: &pg_query.Node_CaseExpr{CaseExpr: &pg_query.CaseExpr{
+		Args: []*pg_query.Node{
+			// WHEN L IS NULL OR R IS NULL THEN NULL — Postgres jsonb || is
+			// strict; without this guard the ELSE branch would wrap a SQL
+			// NULL operand into [null, ...].
+			{Node: &pg_query.Node_CaseWhen{CaseWhen: &pg_query.CaseWhen{
+				Expr: &pg_query.Node{Node: &pg_query.Node_BoolExpr{BoolExpr: &pg_query.BoolExpr{
+					Boolop: pg_query.BoolExprType_OR_EXPR,
+					Args:   []*pg_query.Node{isNullTest(left), isNullTest(right)},
+				}}},
+				Result: nullConstNode(0),
+			}}},
+			// WHEN both objects THEN shallow merge, right side wins.
+			{Node: &pg_query.Node_CaseWhen{CaseWhen: &pg_query.CaseWhen{
+				Expr: &pg_query.Node{Node: &pg_query.Node_BoolExpr{BoolExpr: &pg_query.BoolExpr{
+					Boolop: pg_query.BoolExprType_AND_EXPR,
+					Args:   []*pg_query.Node{jsonTypeEquals(left, "OBJECT"), jsonTypeEquals(right, "OBJECT")},
+				}}},
+				Result: jsonFuncCall("to_json", jsonFuncCall("map_concat", asObjectMap(left), asObjectMap(right))),
+			}}},
+		},
+		// ELSE array concatenation (with non-arrays wrapped as one element).
+		Defresult: jsonFuncCall("to_json", jsonFuncCall("list_concat", asElementList(left), asElementList(right))),
+	}}}
+}
+
+// jsonFuncCall builds an unqualified function-call node.
+func jsonFuncCall(name string, args ...*pg_query.Node) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_FuncCall{FuncCall: &pg_query.FuncCall{
+		Funcname: []*pg_query.Node{
+			{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: name}}},
+		},
+		Args: args,
+	}}}
+}
+
+// jsonTypeEquals builds `json_type(<operand clone>) = '<typ>'`.
+func jsonTypeEquals(operand *pg_query.Node, typ string) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_AExpr{AExpr: &pg_query.A_Expr{
+		Kind: pg_query.A_Expr_Kind_AEXPR_OP,
+		Name: []*pg_query.Node{
+			{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: "="}}},
+		},
+		Lexpr: jsonFuncCall("json_type", cloneNode(operand)),
+		Rexpr: strConst(typ),
+	}}}
+}
+
+// isNullTest builds `<operand clone> IS NULL`.
+func isNullTest(operand *pg_query.Node) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_NullTest{NullTest: &pg_query.NullTest{
+		Arg:          cloneNode(operand),
+		Nulltesttype: pg_query.NullTestType_IS_NULL,
+	}}}
+}
+
+// castToJSON builds `CAST(<operand> AS json)`.
+func castToJSON(operand *pg_query.Node) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_TypeCast{TypeCast: &pg_query.TypeCast{
+		Arg: operand,
+		TypeName: &pg_query.TypeName{
+			Names:   []*pg_query.Node{{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: "json"}}}},
+			Typemod: -1,
+		},
+	}}}
+}
+
+// cloneNode deep-copies an AST node so an operand can appear at several
+// positions in the emitted expression without sharing mutable state.
+func cloneNode(node *pg_query.Node) *pg_query.Node {
+	return proto.Clone(node).(*pg_query.Node)
 }
 
 // createRegexFuncCall creates a regexp_matches function call node

--- a/transpiler/transform/operators_jsonb_concat_test.go
+++ b/transpiler/transform/operators_jsonb_concat_test.go
@@ -113,6 +113,45 @@ func TestOperatorTransform_TextReturningJSONFuncConcatUnchanged(t *testing.T) {
 	}
 }
 
+func TestOperatorTransform_JSONBConcatToJSONFuncOperands(t *testing.T) {
+	// to_json/to_jsonb/row_to_json/array_to_json return JSON but their names
+	// don't start with "json"; without explicit looksJSON coverage
+	// `to_jsonb(a) || to_jsonb(b)` fell through to DuckDB string concat,
+	// producing invalid JSON. (FunctionTransform maps to_jsonb -> to_json
+	// earlier in the pipeline, but this transform must recognize both
+	// spellings since it also runs standalone.)
+	for _, sql := range []string{
+		`SELECT to_jsonb(a) || to_jsonb(b) FROM t`,
+		`SELECT to_json(a) || '[1]'::jsonb FROM t`,
+		`SELECT row_to_json(r) || '{"x":1}'::jsonb FROM t`,
+		`SELECT array_to_json(arr) || '[1]'::jsonb FROM t`,
+	} {
+		assertJSONConcatShape(t, sql)
+	}
+}
+
+func TestOperatorTransform_JSONBConcatBareArrowOperands(t *testing.T) {
+	// Neither side carries a cast: both operands are raw `->` A_Exprs, which
+	// this transform deterministically rewrites to json_extract (JSON-
+	// returning). The || gate runs before the operand rewrite, so the raw
+	// arrow must count as JSON-looking or this would silently become string
+	// concat of two JSON values.
+	assertJSONConcatShape(t, `SELECT (d -> 'a') || (d -> 'b') FROM t`)
+}
+
+func TestOperatorTransform_DoubleArrowConcatUnchanged(t *testing.T) {
+	// ->> yields text, so || on its bare result stays plain text concat.
+	tr := NewOperatorTransform()
+	out := deparseAfter(t, tr, `SELECT (d ->> 'a') || '-x' FROM t`)
+	low := strings.ToLower(out)
+	if strings.Contains(low, "map_concat") || strings.Contains(low, "list_concat") {
+		t.Errorf("->> result concat should stay text concat, got %q", out)
+	}
+	if !strings.Contains(out, "||") {
+		t.Errorf("|| should be preserved, got %q", out)
+	}
+}
+
 func TestOperatorTransform_JSONBConcatDeparses(t *testing.T) {
 	// The emitted CASE must survive a pg_query deparse round-trip for every
 	// shape the issue calls out; deparseAfter fails the test on error.

--- a/transpiler/transform/operators_jsonb_concat_test.go
+++ b/transpiler/transform/operators_jsonb_concat_test.go
@@ -1,0 +1,131 @@
+package transform
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for the jsonb || rewrite (issue #716). The old rewrite to
+// json_merge_patch silently corrupted non-flat-object concatenation: Postgres
+// `'[1,2]'::jsonb || '[3,4]'::jsonb` is [1,2,3,4] but json_merge_patch yields
+// [3,4] (RFC 7396 replaces non-object values), and `'{"a":1}' || '{"a":null}'`
+// is {"a":null} in Postgres but {} under merge-patch (null deletes the key).
+// The rewrite now emits a json_type()-dispatching CASE; these tests assert its
+// shape. The runtime semantics of the emitted expression are verified against
+// a live PostgreSQL by tests/integration/functions_test.go (TestFunctionsJSON,
+// jsonb_concat_* cases), which compares Duckgres output with real Postgres for
+// the full matrix: object merge, null-value kept, nested-object shallow merge,
+// array concat, array append/prepend, scalar pairing, and NULL operands.
+
+// concatShapeMarkers are the load-bearing pieces of the emitted CASE: NULL
+// guard, object||object shallow merge (map_concat, NOT json_merge_patch), and
+// the array-concat fallback with non-arrays wrapped as one-element lists.
+var concatShapeMarkers = []string{
+	"is null",
+	"json_type",
+	"map_concat",
+	`json_transform`,
+	`"map(varchar, json)"`,
+	"list_concat",
+	`["json"]`,
+	"list_value",
+}
+
+func assertJSONConcatShape(t *testing.T, sql string) {
+	t.Helper()
+	tr := NewOperatorTransform()
+	out := strings.ToLower(deparseAfter(t, tr, sql))
+	for _, marker := range concatShapeMarkers {
+		if !strings.Contains(out, marker) {
+			t.Errorf("transpiled %q missing %q: %q", sql, marker, out)
+		}
+	}
+	if strings.Contains(out, "json_merge_patch") {
+		t.Errorf("jsonb || must not use json_merge_patch (wrong for arrays/nulls), got %q", out)
+	}
+}
+
+func TestOperatorTransform_JSONBConcatObjects(t *testing.T) {
+	assertJSONConcatShape(t, `SELECT '{"a":1}'::jsonb || '{"b":2}'::jsonb`)
+}
+
+func TestOperatorTransform_JSONBConcatArrays(t *testing.T) {
+	// The regression that motivated #716: array || array must concatenate,
+	// not merge-patch (which replaces the left array wholesale).
+	assertJSONConcatShape(t, `SELECT '[1,2]'::jsonb || '[3,4]'::jsonb`)
+}
+
+func TestOperatorTransform_JSONBConcatUpdateSet(t *testing.T) {
+	// The write-path idiom that silently corrupted data: jsonb array append
+	// inside UPDATE ... SET.
+	assertJSONConcatShape(t, `UPDATE t SET col = col || '["x"]'::jsonb`)
+}
+
+func TestOperatorTransform_JSONBConcatMixedOperand(t *testing.T) {
+	// Only one operand is provably JSON; the rewrite must still fire (the
+	// other side is implicitly JSON in Postgres) and keep full semantics.
+	assertJSONConcatShape(t, `SELECT json_extract(data, '$.tags') || '["new"]'::jsonb FROM t`)
+}
+
+func TestOperatorTransform_JSONBConcatChainedArrowRewritten(t *testing.T) {
+	tr := NewOperatorTransform()
+	out := strings.ToLower(deparseAfter(t, tr, `SELECT (data -> 'tags') || '["new"]'::jsonb FROM t`))
+	// The arrow inside the left operand must still be rewritten to
+	// json_extract (the operand pre-pass), and the || must dispatch.
+	if !strings.Contains(out, "json_extract") {
+		t.Errorf("nested -> not rewritten inside || operand: %q", out)
+	}
+	if !strings.Contains(out, "map_concat") || !strings.Contains(out, "list_concat") {
+		t.Errorf("|| with JSON operand not rewritten to dispatching CASE: %q", out)
+	}
+}
+
+func TestOperatorTransform_StringConcatUnchanged(t *testing.T) {
+	tr := NewOperatorTransform()
+	out := deparseAfter(t, tr, `SELECT 'a' || 'b'`)
+	low := strings.ToLower(out)
+	if strings.Contains(low, "json_merge_patch") || strings.Contains(low, "map_concat") {
+		t.Errorf("plain string concat should not be rewritten, got %q", out)
+	}
+	if !strings.Contains(out, "||") {
+		t.Errorf("string concat || should be preserved, got %q", out)
+	}
+}
+
+func TestOperatorTransform_TextReturningJSONFuncConcatUnchanged(t *testing.T) {
+	tr := NewOperatorTransform()
+	// json_extract_string / *_text / *_length return non-JSON values, so ||
+	// on their results is plain text concat in Postgres and must stay ||.
+	for _, sql := range []string{
+		`SELECT json_extract_string(data, '$.name') || '-suffix' FROM t`,
+		`SELECT json_extract_path_text(data, 'name') || '-suffix' FROM t`,
+		`SELECT json_array_length(data) || ' items' FROM t`,
+		`SELECT json_type(data) || '!' FROM t`,
+	} {
+		out := deparseAfter(t, tr, sql)
+		low := strings.ToLower(out)
+		if strings.Contains(low, "json_merge_patch") || strings.Contains(low, "map_concat") {
+			t.Errorf("text-returning json func concat was rewritten: %q -> %q", sql, out)
+		}
+		if !strings.Contains(out, "||") {
+			t.Errorf("|| should be preserved for %q, got %q", sql, out)
+		}
+	}
+}
+
+func TestOperatorTransform_JSONBConcatDeparses(t *testing.T) {
+	// The emitted CASE must survive a pg_query deparse round-trip for every
+	// shape the issue calls out; deparseAfter fails the test on error.
+	tr := NewOperatorTransform()
+	for _, sql := range []string{
+		`SELECT '{"a":1}'::jsonb || '{"a":null}'::jsonb`,
+		`SELECT '{"a":{"x":1}}'::jsonb || '{"a":{"y":2}}'::jsonb`,
+		`SELECT '[1,2]'::jsonb || '3'::jsonb`,
+		`SELECT '3'::jsonb || '[1,2]'::jsonb`,
+		`SELECT '1'::jsonb || '2'::jsonb`,
+		`SELECT NULL::jsonb || '[1]'::jsonb`,
+		`INSERT INTO t (col) SELECT a || b::jsonb FROM s`,
+	} {
+		_ = deparseAfter(t, tr, sql)
+	}
+}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -447,6 +447,9 @@ func Classify(sql string, cfg Config) Classification {
 		// Type/conversion functions
 		"PG_TYPEOF(", "TO_CHAR(", "TO_DATE(", "TO_NUMBER(",
 		"TO_TIMESTAMP(",
+		// TO_JSON( also covers ROW_TO_JSON( / ARRAY_TO_JSON( (substring match);
+		// TO_JSONB( needs its own entry (the trailing paren breaks the overlap).
+		"TO_JSON(", "TO_JSONB(",
 		// JSON functions
 		"JSON_OBJECT_KEYS(", "JSONB_OBJECT_KEYS(",
 		// Date/time functions


### PR DESCRIPTION
## Problem

The transpiler rewrote any `||` with a JSON-looking operand to `json_merge_patch()`. That implements RFC 7396 merge-patch, which only matches Postgres `jsonb ||` for flat object||object merges without null values:

| Expression | Postgres `jsonb \|\|` | old `json_merge_patch` |
|---|---|---|
| `'[1,2]' \|\| '[3,4]'` | `[1,2,3,4]` | `[3,4]` (replaces!) |
| `'{"a":1}' \|\| '{"a":null}'` | `{"a":null}` | `{}` (deletes key) |
| `'{"a":{"x":1}}' \|\| '{"a":{"y":2}}'` | `{"a":{"y":2}}` (shallow) | deep merge |

The array case silently corrupted the common write idiom `UPDATE t SET col = col || '["x"]'::jsonb` (jsonb array append) by replacing the whole value.

## Fix

`createJSONConcatExpr` (replacing `createJSONMergeFuncCall`) emits a `json_type()`-dispatching CASE that reproduces Postgres `jsonb ||` semantics exactly:

- `object || object` → shallow merge, right side wins, explicit nulls **kept**: `to_json(map_concat(json_transform(x, '"MAP(VARCHAR, JSON)"'), ...))` — `map_concat` is last-wins on key collision and `to_json` inlines JSON-typed map values.
- everything else → array concatenation via `to_json(list_concat(...))`, with each non-array operand wrapped as a one-element list (`list_value(CAST(x AS JSON))`), exactly as Postgres treats array append/prepend and scalar pairing.
- `NULL || any` → SQL NULL (strictness guard; without it a NULL operand would be wrapped into `[null, ...]`).

Operands are cloned per use site (`proto.Clone`) so later pipeline transforms never visit a shared node twice.

The whole matrix was executed against DuckDB 1.5.3 (the exact engine version bundled by `duckdb-go v2.10503.0`) and matches Postgres output for: object merge, null-value kept, nested-object shallow merge, array concat, array append/prepend, scalar pairing, object||array, JSON-null elements, and NULL operands. The only divergence is object key order (Postgres sorts jsonb keys, DuckDB preserves insertion order), which `jsonb` does not define.

Also tightens the `looksJSON` gate: `json*`-named functions that return non-JSON values (`json_extract_string`, `*_text`, `*_length`, `json_type`, ...) no longer trigger the rewrite — `json_extract_string(d,'a') || 'x'` is plain text concat in Postgres and previously got corrupted into `json_merge_patch` too (FunctionTransform rewrites `jsonb_extract_path_text` → `json_extract_string` *before* the operator pass, so this was reachable from pure-Postgres SQL).

## Tests

- **Unit** (`transpiler/transform/operators_jsonb_concat_test.go`): regression tests that would have caught the bug — array concat, the `UPDATE ... SET col = col || ...` write path, mixed/one-sided JSON operands, chained-arrow operands, plain string concat left alone, text-returning json functions left alone, and deparse round-trips for the full matrix. Replaces the old `json_merge_patch`-asserting test.
- **Integration** (`tests/integration/functions_test.go`): `jsonb_concat_*` matrix executed on a live Duckgres and compared against **real PostgreSQL** output (the suite's `jsonEqual` is key-order-insensitive).
- **e2e harness** (`tests/e2e-mw-dev/harness.sh`): new `jsonb_concat_semantics` assertion runs the load-bearing cases (array concat, null-value merge, object merge, array append) through the real CP transpile → worker pod DuckDB execute path with exact expected outputs. Backend-independent (no metadata touched), so it runs on the cnpg org only.
- `go build ./...`, `go test . ./server/... ./transpiler/...`, `go vet`, `gofmt` all clean.

Fixes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)