### PR TITLE
fix: skip extended-query messages until Sync after a protocol error (#718)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -170,6 +170,8 @@ type clientConn struct {
 	stmts                  map[string]*preparedStmt // prepared statements by name
 	portals                map[string]*portal       // portals by name
 	txStatus               byte                     // current transaction status ('I', 'T', or 'E')
+	ignoreTillSync         bool                     // discard extended-query messages until Sync after an error; see runExtendedQueryMessage
+	errorResponsesSent     uint64                   // ErrorResponses sent via sendError; observed by runExtendedQueryMessage
 	passthrough            bool                     // true for passthrough users (skip transpiler + pg_catalog)
 	cursors                map[string]*cursorState  // server-side cursor emulation
 	catalogUseRewrite      bool                     // true when bare `USE ducklake`/`USE iceberg` should expand to the reliable two-part target
@@ -1337,6 +1339,10 @@ func (c *clientConn) messageLoop() error {
 
 		switch msgType {
 		case wire.MsgQuery:
+			// A simple Query resets extended-protocol state: it is processed
+			// (not discarded by skip-until-Sync) — its trailing ReadyForQuery
+			// resynchronizes the client.
+			c.ignoreTillSync = false
 			if err := c.handleQuery(body); err != nil {
 				if isConnectionBroken(err) {
 					slog.Info("Client connection lost during query.", "user", c.username, "error", err)
@@ -1347,22 +1353,24 @@ func (c *clientConn) messageLoop() error {
 
 		case wire.MsgParse:
 			// Extended query protocol - Parse
-			c.handleParse(body)
+			c.runExtendedQueryMessage(c.handleParse, body)
 
 		case wire.MsgBind:
 			// Extended query protocol - Bind
-			c.handleBind(body)
+			c.runExtendedQueryMessage(c.handleBind, body)
 
 		case wire.MsgDescribe:
 			// Extended query protocol - Describe
-			c.handleDescribe(body)
+			c.runExtendedQueryMessage(c.handleDescribe, body)
 
 		case wire.MsgExecute:
 			// Extended query protocol - Execute
-			c.handleExecute(body)
+			c.runExtendedQueryMessage(c.handleExecute, body)
 
 		case wire.MsgSync:
-			// Extended query protocol - Sync
+			// Extended query protocol - Sync: ends any skip-until-Sync error
+			// recovery, then reports readiness.
+			c.ignoreTillSync = false
 			if err := wire.WriteReadyForQuery(c.writer, c.txStatus); err != nil {
 				return err
 			}
@@ -1370,10 +1378,14 @@ func (c *clientConn) messageLoop() error {
 
 		case wire.MsgClose:
 			// Extended query protocol - Close
-			c.handleClose(body)
+			c.runExtendedQueryMessage(c.handleClose, body)
 
 		case wire.MsgFlush:
-			_ = c.writer.Flush()
+			// Discarded during skip-until-Sync error recovery, like real
+			// PostgreSQL (the ErrorResponse was already flushed by sendError).
+			if !c.ignoreTillSync {
+				_ = c.writer.Flush()
+			}
 
 		case wire.MsgTerminate:
 			return nil
@@ -1381,6 +1393,30 @@ func (c *clientConn) messageLoop() error {
 		default:
 			slog.Warn("Unknown message type.", "type", string(msgType))
 		}
+	}
+}
+
+// runExtendedQueryMessage dispatches an extended-query protocol message
+// (Parse/Bind/Describe/Execute/Close), implementing the protocol's error
+// recovery rule: after an error while processing any extended-query message
+// the server must discard subsequent extended-protocol messages until Sync
+// arrives. Without this, pipelined clients (libpq pipeline mode, pgx
+// SendBatch, JDBC batch) execute queued messages against broken state and
+// desync their response accounting.
+//
+// An error is detected by observing sendError — the single ErrorResponse
+// funnel for an established connection — so deep failure paths inside Execute
+// arm the skip too. The trigger is deliberately the error event itself, NOT
+// txStatus == txStatusError: an aborted transaction must still accept the
+// Parse/Bind/Execute of a ROLLBACK sent after Sync.
+func (c *clientConn) runExtendedQueryMessage(handler func([]byte), body []byte) {
+	if c.ignoreTillSync {
+		return
+	}
+	before := c.errorResponsesSent
+	handler(body)
+	if c.errorResponsesSent != before {
+		c.ignoreTillSync = true
 	}
 }
 
@@ -5216,6 +5252,7 @@ func (c *clientConn) sendError(severity, code, message string) {
 		queryErrorsCounter.WithLabelValues(c.orgID).Inc()
 	}
 	slog.Debug("Sending error to client.", "user", c.username, "severity", severity, "code", code, "message", message)
+	c.errorResponsesSent++
 	_ = wire.WriteErrorResponse(c.writer, severity, code, message)
 	_ = c.writer.Flush()
 }

--- a/server/conn_skip_until_sync_test.go
+++ b/server/conn_skip_until_sync_test.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/server/wire"
+)
+
+// These tests cover the extended-query protocol's skip-until-Sync error
+// recovery (issue #718): after an error while processing any extended-query
+// message, the server must discard subsequent extended-protocol messages
+// until Sync arrives, then respond ReadyForQuery. Without it, pipelined
+// clients (libpq pipeline mode, pgx SendBatch, JDBC batch) execute queued
+// messages against broken state and desync their response accounting.
+
+// badParseSQL fails Parse deterministically: the pg_catalog reference forces
+// the transpiler through pg_query (no Tier-0 direct passthrough), which
+// cannot parse "SELEC", so handleParse falls back to DuckDB validation —
+// whose EXPLAIN probe the test executor rejects.
+const badParseSQL = "SELEC oid FROM pg_catalog.pg_class"
+
+// pipelineRecordingExecutor fails all Query paths and EXPLAIN probes (so a
+// Parse of unparseable SQL that falls back to DuckDB validation errors
+// deterministically) and records every other Exec so tests can assert which
+// statements actually executed.
+type pipelineRecordingExecutor struct {
+	noopProfiling
+	execCalls []string
+}
+
+func (e *pipelineRecordingExecutor) exec(query string) (ExecResult, error) {
+	query = strings.TrimSpace(query)
+	if strings.HasPrefix(strings.ToUpper(query), "EXPLAIN") {
+		// validateWithDuckDB probe for SQL pg_query couldn't parse.
+		return nil, errors.New("Parser Error: syntax error at or near \"SELEC\"")
+	}
+	e.execCalls = append(e.execCalls, query)
+	return &fakeExecResult{}, nil
+}
+
+func (e *pipelineRecordingExecutor) QueryContext(context.Context, string, ...any) (RowSet, error) {
+	return nil, errors.New("Parser Error: syntax error at or near \"SELEC\"")
+}
+
+func (e *pipelineRecordingExecutor) ExecContext(_ context.Context, query string, _ ...any) (ExecResult, error) {
+	return e.exec(query)
+}
+
+func (e *pipelineRecordingExecutor) Query(string, ...any) (RowSet, error) {
+	return nil, errors.New("Parser Error: syntax error at or near \"SELEC\"")
+}
+
+func (e *pipelineRecordingExecutor) Exec(query string, _ ...any) (ExecResult, error) {
+	return e.exec(query)
+}
+
+func (e *pipelineRecordingExecutor) ConnContext(context.Context) (RawConn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *pipelineRecordingExecutor) PingContext(context.Context) error { return nil }
+
+func (e *pipelineRecordingExecutor) Close() error { return nil }
+
+// pgFrame builds a framed wire-protocol message: type byte + int32 length
+// (including itself) + body.
+func pgFrame(msgType byte, body []byte) []byte {
+	frame := make([]byte, 0, 5+len(body))
+	frame = append(frame, msgType)
+	frame = binary.BigEndian.AppendUint32(frame, uint32(4+len(body)))
+	return append(frame, body...)
+}
+
+func parseFrame(stmtName, query string) []byte {
+	var body bytes.Buffer
+	body.WriteString(stmtName)
+	body.WriteByte(0)
+	body.WriteString(query)
+	body.WriteByte(0)
+	_ = binary.Write(&body, binary.BigEndian, int16(0)) // no parameter types
+	return pgFrame(wire.MsgParse, body.Bytes())
+}
+
+func bindFrame(portalName, stmtName string) []byte {
+	var body bytes.Buffer
+	body.WriteString(portalName)
+	body.WriteByte(0)
+	body.WriteString(stmtName)
+	body.WriteByte(0)
+	_ = binary.Write(&body, binary.BigEndian, int16(0)) // no param format codes
+	_ = binary.Write(&body, binary.BigEndian, int16(0)) // no param values
+	_ = binary.Write(&body, binary.BigEndian, int16(0)) // no result format codes
+	return pgFrame(wire.MsgBind, body.Bytes())
+}
+
+func describePortalFrame(portalName string) []byte {
+	var body bytes.Buffer
+	body.WriteByte('P')
+	body.WriteString(portalName)
+	body.WriteByte(0)
+	return pgFrame(wire.MsgDescribe, body.Bytes())
+}
+
+func executeFrame(portalName string) []byte {
+	var body bytes.Buffer
+	body.WriteString(portalName)
+	body.WriteByte(0)
+	_ = binary.Write(&body, binary.BigEndian, int32(0)) // no row limit
+	return pgFrame(wire.MsgExecute, body.Bytes())
+}
+
+func queryFrame(query string) []byte {
+	return pgFrame(wire.MsgQuery, append([]byte(query), 0))
+}
+
+type wireFrame struct {
+	msgType byte
+	body    []byte
+}
+
+// scanWireFrames splits the server's output buffer into framed messages.
+func scanWireFrames(t *testing.T, buf []byte) []wireFrame {
+	t.Helper()
+	var frames []wireFrame
+	for i := 0; i < len(buf); {
+		if i+5 > len(buf) {
+			t.Fatalf("truncated frame header at offset %d (%d bytes total)", i, len(buf))
+		}
+		length := int(binary.BigEndian.Uint32(buf[i+1 : i+5]))
+		if length < 4 || i+1+length > len(buf) {
+			t.Fatalf("malformed frame at offset %d: type=%c length=%d", i, buf[i], length)
+		}
+		frames = append(frames, wireFrame{msgType: buf[i], body: buf[i+5 : i+1+length]})
+		i += 1 + length
+	}
+	return frames
+}
+
+func frameTypes(frames []wireFrame) string {
+	var b strings.Builder
+	for _, f := range frames {
+		b.WriteByte(f.msgType)
+	}
+	return b.String()
+}
+
+// runPipeline feeds a pipelined client byte stream (terminated with a
+// Terminate frame) through messageLoop and returns the parsed output frames.
+func runPipeline(t *testing.T, c *clientConn, out *bytes.Buffer, frames ...[]byte) []wireFrame {
+	t.Helper()
+	stream := bytes.Join(frames, nil)
+	stream = append(stream, pgFrame(wire.MsgTerminate, nil)...)
+	c.reader = bufio.NewReader(bytes.NewReader(stream))
+	if err := c.messageLoop(); err != nil {
+		t.Fatalf("messageLoop returned error: %v", err)
+	}
+	_ = c.writer.Flush()
+	return scanWireFrames(t, out.Bytes())
+}
+
+func newPipelineConn(t *testing.T, executor QueryExecutor) (*clientConn, *bytes.Buffer) {
+	t.Helper()
+	clientSide, serverSide := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientSide.Close()
+		_ = serverSide.Close()
+	})
+
+	var out bytes.Buffer
+	c := &clientConn{
+		server:   &Server{activeQueries: make(map[BackendKey]context.CancelFunc)},
+		conn:     clientSide,
+		writer:   bufio.NewWriter(&out),
+		ctx:      context.Background(),
+		cancel:   func() {},
+		txStatus: txStatusIdle,
+		executor: executor,
+		stmts:    make(map[string]*preparedStmt),
+		portals:  make(map[string]*portal),
+	}
+	return c, &out
+}
+
+// TestExtendedQueryErrorDiscardsPipelineUntilSync is the regression test for
+// issue #718: after a failed Parse, the queued Bind/Describe/Execute of a
+// previously prepared (valid) statement must be discarded — not executed —
+// until Sync, which responds ReadyForQuery and resumes normal processing.
+func TestExtendedQueryErrorDiscardsPipelineUntilSync(t *testing.T) {
+	executor := &pipelineRecordingExecutor{}
+	c, out := newPipelineConn(t, executor)
+
+	frames := runPipeline(t, c, out,
+		// Prepare a valid statement, complete the round trip.
+		parseFrame("s_del", "DELETE FROM t WHERE id = 1"),
+		pgFrame(wire.MsgSync, nil),
+		// Pipelined batch: Parse fails, the rest must be discarded.
+		parseFrame("s_bad", badParseSQL),
+		bindFrame("p", "s_del"),
+		describePortalFrame("p"),
+		executeFrame("p"),
+		pgFrame(wire.MsgSync, nil),
+		// After Sync, the same Bind/Execute must work normally again.
+		bindFrame("p", "s_del"),
+		executeFrame("p"),
+		pgFrame(wire.MsgSync, nil),
+	)
+
+	// ParseComplete, ReadyForQuery; exactly one ErrorResponse then
+	// ReadyForQuery (no BindComplete/CommandComplete for the discarded
+	// messages); BindComplete, CommandComplete, ReadyForQuery.
+	if got, want := frameTypes(frames), "1ZEZ2CZ"; got != want {
+		t.Fatalf("frame sequence = %q, want %q", got, want)
+	}
+	if code, ok := errorResponseField(out.Bytes(), 'C'); !ok || code != "42601" {
+		t.Fatalf("ErrorResponse SQLSTATE = %q (ok=%v), want 42601", code, ok)
+	}
+
+	// The DELETE behind the discarded Execute must have run exactly once —
+	// for the post-Sync Execute, not the discarded one.
+	var deletes []string
+	for _, call := range executor.execCalls {
+		if strings.HasPrefix(strings.ToUpper(call), "DELETE") {
+			deletes = append(deletes, call)
+		}
+	}
+	if len(deletes) != 1 {
+		t.Fatalf("DELETE executed %d times (%v), want exactly once (the post-Sync Execute)", len(deletes), executor.execCalls)
+	}
+}
+
+// TestAbortedTransactionStillAllowsExtendedRollback pins the recovery
+// trigger: it is the error event during extended-query processing, NOT
+// txStatus == 'E'. A connection whose transaction is aborted must still
+// accept Parse/Bind/Execute of ROLLBACK (real PostgreSQL accepts these in an
+// aborted transaction; gating on txStatus would wedge clients).
+func TestAbortedTransactionStillAllowsExtendedRollback(t *testing.T) {
+	executor := &pipelineRecordingExecutor{}
+	c, out := newPipelineConn(t, executor)
+	c.txStatus = txStatusError
+
+	frames := runPipeline(t, c, out,
+		parseFrame("", "ROLLBACK"),
+		bindFrame("", ""),
+		executeFrame(""),
+		pgFrame(wire.MsgSync, nil),
+	)
+
+	if got, want := frameTypes(frames), "12CZ"; got != want {
+		t.Fatalf("frame sequence = %q, want %q", got, want)
+	}
+	if tag := string(bytes.TrimRight(frames[2].body, "\x00")); tag != "ROLLBACK" {
+		t.Fatalf("CommandComplete tag = %q, want ROLLBACK", tag)
+	}
+	if status := frames[3].body[0]; status != txStatusIdle {
+		t.Fatalf("ReadyForQuery status = %c, want %c", status, txStatusIdle)
+	}
+	if got := executor.execCalls; len(got) != 1 || got[0] != "ROLLBACK" {
+		t.Fatalf("Exec calls = %v, want [ROLLBACK]", got)
+	}
+}
+
+// TestSimpleQueryResetsSkipUntilSync: per the audit on #718, a simple Query
+// message is processed (not discarded) during error recovery — it resets
+// extended-protocol state and its trailing ReadyForQuery resynchronizes the
+// client, so subsequent extended-query messages execute normally.
+func TestSimpleQueryResetsSkipUntilSync(t *testing.T) {
+	executor := &pipelineRecordingExecutor{}
+	c, out := newPipelineConn(t, executor)
+
+	frames := runPipeline(t, c, out,
+		parseFrame("s_bad", badParseSQL), // error arms skip-until-Sync
+		queryFrame(""),                   // simple Query: EmptyQueryResponse + ReadyForQuery
+		parseFrame("s_del", "DELETE FROM t WHERE id = 1"),
+		bindFrame("p", "s_del"),
+		executeFrame("p"),
+		pgFrame(wire.MsgSync, nil),
+	)
+
+	// ErrorResponse; EmptyQueryResponse + ReadyForQuery from the simple
+	// Query; then the extended-query batch runs normally.
+	if got, want := frameTypes(frames), "EIZ12CZ"; got != want {
+		t.Fatalf("frame sequence = %q, want %q", got, want)
+	}
+	if len(executor.execCalls) != 1 || !strings.HasPrefix(strings.ToUpper(executor.execCalls[0]), "DELETE") {
+		t.Fatalf("Exec calls = %v, want exactly the DELETE", executor.execCalls)
+	}
+}

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -41,6 +41,12 @@ client-go:
   post-TLS startup-message length (negative / ~2GiB / truncated, injected via
   `openssl s_client -starttls postgres`) gets a clean connection close — the CP
   pod must not restart and must keep serving (regression for #715).
+- **pipeline error recovery** (#718) — a pipelined extended-query batch (psql
+  18 `\startpipeline`) whose first statement errors must have its queued
+  statements **discarded until Sync** (the queued INSERT must not execute);
+  the statement after `\syncpipeline` must execute normally. This is why the
+  harness Job image is `postgres:18-alpine` (pipeline meta-commands are
+  psql 18+).
 - **cold-burst absorption** — there is no warm pool, so a burst of cold sessions
   spawns workers on demand; if it outruns the org/global cap the surplus gets a
   graceful client-visible hint (`no Duckgres worker … retry in about 45 seconds`

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -14,7 +14,8 @@
 #                  crash, #715), and a cold burst is absorbed (workers spawn on
 #                  demand; any surplus gets a graceful retry hint) then served.
 #                  jsonb || keeps Postgres concat semantics through
-#                  transpilation (#716).
+#                  transpilation (#716), and a pipelined extended-query error
+#                  discards queued messages until Sync (#718).
 #   activation   : DuckLake + Iceberg catalogs attach and read/write.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
@@ -319,6 +320,51 @@ concurrent_connections() { # org password
     [ -f "${ok}.$i" ] || fail "concurrent connection $1 #$i did not return $i"
     i=$((i + 1))
   done
+}
+
+# Extended-query skip-until-Sync error recovery (#718): after an error while
+# processing any extended-query message, the server must DISCARD subsequent
+# pipelined extended-protocol messages until Sync arrives, then recover.
+# Pipelining clients (libpq pipeline mode, pgx SendBatch, JDBC batch) rely on
+# this; without it a queued statement executes against broken state and the
+# client's response accounting desyncs. Uses psql 18's pipeline meta-commands
+# (\startpipeline / \syncpipeline / \endpipeline) — the reason the harness Job
+# image in run.sh is postgres:18-alpine. Regression test for issue #718.
+pipeline_error_recovery() { # org password
+  log "pipeline skip-until-Sync error recovery on $1"
+  t="e2e_pipe_$(echo "$1" | tr -c 'a-z0-9' _)"
+  pg "$1" "$2" ducklake "DROP TABLE IF EXISTS $t; CREATE TABLE $t(id INT);"
+  # One pipelined batch: statement 1 errors; the INSERT of id=1 is queued
+  # BEFORE the Sync so the server must discard it; the INSERT of id=2 comes
+  # after \syncpipeline so it must execute. No ON_ERROR_STOP — the error is
+  # the point — and psql's exit code is ignored (a desynced libpq may bail);
+  # the SERVER-side outcome is asserted from a fresh session below. The
+  # transient session-create FATALs are retried like _pg_exec: they fire
+  # before any SQL runs, so re-running the whole batch is safe.
+  a=0
+  while [ "$a" -lt 12 ]; do
+    out="$(PGPASSWORD="$2" psql \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" 2>&1 <<EOF || true
+\startpipeline
+SELEC deliberately_broken \bind \g
+INSERT INTO $t VALUES (1) \bind \g
+\syncpipeline
+INSERT INTO $t VALUES (2) \bind \g
+\endpipeline
+EOF
+)"
+    case "$out" in
+      *"capacity exhausted"*|*"no Duckgres worker"*|\
+      *"still provisioning"*|*"failed to initialize session"*|\
+      *"timed out waiting for an available worker"*|*"failed to start"*|*"spawn sized worker"*|\
+      *"failed to detect attached catalogs"*)
+        sleep 10; a=$((a + 1)); continue ;;
+    esac
+    break
+  done
+  got="$(pg "$1" "$2" ducklake "SELECT id FROM $t ORDER BY id;")"
+  [ "$got" = "2" ] || fail "$1 pipeline recovery: table has '$got', want only '2' (a pipelined statement queued behind an error executed, or post-Sync work was lost; psql said: $(printf %s "$out" | tr '\n' ' ' | tail -c 200))"
+  pg "$1" "$2" ducklake "DROP TABLE $t;"
 }
 
 # ---- bundled extension forks ----------------------------------------------
@@ -724,6 +770,7 @@ main() {
   jsonb_concat_semantics "$CNPG" "$cnpg_pw"
   cold_burst_absorption  "$CNPG" "$cnpg_pw"   # before more workers exist
   rw_ducklake            "$CNPG" "$cnpg_pw"
+  pipeline_error_recovery "$CNPG" "$cnpg_pw"  # after rw_ducklake (table writes proven)
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
   rw_iceberg             "$CNPG" "$cnpg_pw"
   assert_worker_pod
@@ -764,7 +811,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -185,7 +185,11 @@ spec:
       restartPolicy: Never
       containers:
         - name: harness
-          image: public.ecr.aws/docker/library/postgres:16-alpine
+          # postgres:18-alpine: psql 18 ships the pipeline meta-commands
+          # (\startpipeline/\syncpipeline/\endpipeline) that the harness's
+          # pipeline_error_recovery check (#718) drives the extended-query
+          # protocol with. Earlier psql cannot pipeline.
+          image: public.ecr.aws/docker/library/postgres:18-alpine
           command: ["/bin/sh", "/harness/harness.sh"]
           env:
             - { name: NAMESPACE, value: "$NS" }


### PR DESCRIPTION
## Problem

Per the PostgreSQL wire protocol, after an error while processing any extended-query message the server must **discard subsequent extended-protocol messages until a Sync arrives**, then respond `ReadyForQuery`. `messageLoop` (`server/conn.go`) dispatched Parse/Bind/Describe/Execute/Close unconditionally and `Sync` only wrote `ReadyForQuery` — there was no skip-until-Sync mechanism at all.

Non-pipelined clients (one Sync per statement) were unaffected, but pipelining/batch clients (libpq pipeline mode, pgx `SendBatch`, JDBC batch) desynced: after a mid-pipeline error, later queued statements **still executed** against broken state, and extra responses arrived before `ReadyForQuery`, breaking the client's message accounting.

## Fix

- `messageLoop` routes Parse/Bind/Describe/Execute/Close through a new `runExtendedQueryMessage`, which arms an `ignoreTillSync` flag when the handler sent an `ErrorResponse` and discards extended-protocol messages while it is armed. Errors are detected by observing `sendError` — the single ErrorResponse funnel for an established connection — so deep failure paths inside Execute arm the skip too.
- `Sync` clears the flag, then writes `ReadyForQuery` as before. `Flush` is discarded while skipping (like real PostgreSQL).
- **The trigger is deliberately the error event itself, NOT `txStatus == 'E'`** (per the issue's correction): an aborted transaction still accepts the Parse/Bind/Execute of a `ROLLBACK` sent after Sync. A simple Query message is processed (not discarded) and resets the recovery state, per the protocol note that simple Query resets extended-protocol state.

## Tests

- **Unit** (`server/conn_skip_until_sync_test.go`) — drives `messageLoop` with real pipelined wire bytes and asserts the exact response frame sequence:
  - `TestExtendedQueryErrorDiscardsPipelineUntilSync` (regression): after a failed Parse, the queued Bind/Describe/Execute of a previously prepared **valid** statement is discarded (frame sequence exactly `1ZEZ2CZ`; the DELETE never reaches the executor pre-Sync) and the same Bind/Execute works normally after Sync. Verified to fail without the fix (sequence `1ZE2nCZ2CZ`, DELETE executed twice).
  - `TestAbortedTransactionStillAllowsExtendedRollback`: `txStatus='E'` + extended-protocol ROLLBACK completes (`12CZ`, tag `ROLLBACK`, RFQ status `I`) — pins that recovery is not gated on txStatus.
  - `TestSimpleQueryResetsSkipUntilSync`: a simple Query during recovery is processed and resets the skip state.
- **Real pipelining client (manual)** — pgx v5 `SendBatch` (`QueryExecModeExec`) against a local standalone server: on `main` the queued INSERT executes and errors desync (`portal "" does not exist` attributed to the wrong statements); with the fix the INSERT is discarded and the connection recovers cleanly.
- `go build ./...`, `go vet ./server/...`, `go test ./server/` all pass; `gofmt` clean on changed files.

## e2e harness

Added `pipeline_error_recovery` to `tests/e2e-mw-dev/harness.sh`: a psql 18 `\startpipeline` batch whose first statement errors must have its queued INSERT **discarded until Sync**, while the INSERT after `\syncpipeline` executes (asserted from a fresh session on the cnpg duckling; protocol-layer behavior is metadata-backend-independent). This required bumping the harness Job image `postgres:16-alpine` → `postgres:18-alpine` in `run.sh` — psql's pipeline meta-commands (`\startpipeline`/`\syncpipeline`/`\endpipeline`) are psql 18+ and there is no other pipelining-capable client in the Job image. README updated.

## Notes

Developed in parallel with #717 and #720, which also touch `server/conn.go` — merge order may require a trivial rebase.

Fixes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)