### PR TITLE
fix: jsonb || returns malformed value on remote backend — worker Arrow JSON serialization (#716 regression)

### DIFF
--- a/duckdbservice/arrowmap/arrowmap.go
+++ b/duckdbservice/arrowmap/arrowmap.go
@@ -13,6 +13,7 @@ package arrowmap
 import (
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
@@ -625,6 +626,22 @@ func appendBuiltin(builder array.Builder, val any) {
 				b.Append(s[0:8] + "-" + s[8:12] + "-" + s[12:16] + "-" + s[16:20] + "-" + s[20:32])
 			} else {
 				b.Append(string(v))
+			}
+		case []interface{}, map[string]interface{}:
+			// DuckDB JSON columns map to an Arrow String column
+			// (DuckDBTypeToArrow("JSON") == String), but the database/sql
+			// driver decodes JSON values into native Go composites (array ->
+			// []interface{}, object -> map[string]interface{}). Serialize them
+			// back to JSON text — Go's %v default below would emit "[1 2 3 4]"
+			// / "map[a:1]", which is invalid JSON and is exactly what reached
+			// remote-backend clients for `jsonb ||` and any JSON array/object
+			// column (#716). A plain VARCHAR column never decodes to a
+			// composite, so this only ever fires for JSON. Mirrors the
+			// standalone wire path's server.encodeJSON.
+			if jb, err := json.Marshal(v); err == nil {
+				b.Append(string(jb))
+			} else {
+				b.Append(fmt.Sprintf("%v", v))
 			}
 		default:
 			b.Append(fmt.Sprintf("%v", v))

--- a/duckdbservice/arrowmap/arrowmap_test.go
+++ b/duckdbservice/arrowmap/arrowmap_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
 func TestDecimalValueString(t *testing.T) {
@@ -191,8 +193,8 @@ func TestParseDecimalParams(t *testing.T) {
 		{"DECIMAL(10,5)", 10, 5},
 		{"DECIMAL(38,0)", 38, 0},
 		{"NUMERIC(5,3)", 5, 3},
-		{"DECIMAL", 18, 3},   // default fallback
-		{"DECIMAL()", 18, 3}, // empty parens
+		{"DECIMAL", 18, 3},          // default fallback
+		{"DECIMAL()", 18, 3},        // empty parens
 		{"DECIMAL(abc,def)", 18, 3}, // non-numeric
 		{"DECIMAL(18,)", 18, 3},     // missing scale
 		{"DECIMAL(,2)", 18, 3},      // missing precision
@@ -310,6 +312,38 @@ func TestParseStructFieldDef(t *testing.T) {
 			}
 			if gotType != tt.wantType {
 				t.Errorf("parseStructFieldDef(%q) type = %q, want %q", tt.input, gotType, tt.wantType)
+			}
+		})
+	}
+}
+
+// Regression for #716: DuckDB JSON columns map to an Arrow String column, and
+// the database/sql driver decodes JSON values into native Go composites
+// ([]interface{} / map[string]interface{}). AppendValue must serialize those
+// back to JSON text — before the fix it used fmt.Sprintf("%v"), so a jsonb
+// array reached remote-backend clients as "[1 2 3 4]" instead of "[1,2,3,4]".
+// VARCHAR columns never decode to a composite, so plain strings are untouched.
+func TestAppendValueJSONCompositeToString(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want string
+	}{
+		{"json array", []interface{}{int64(1), int64(2), int64(3), int64(4)}, "[1,2,3,4]"},
+		{"json object", map[string]interface{}{"a": int64(1)}, `{"a":1}`},
+		{"json null-valued key", map[string]interface{}{"a": nil}, `{"a":null}`},
+		{"nested", []interface{}{map[string]interface{}{"a": int64(1)}, int64(2)}, `[{"a":1},2]`},
+		{"plain varchar untouched", "plain text", "plain text"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := array.NewStringBuilder(memory.DefaultAllocator)
+			defer b.Release()
+			AppendValue(b, tc.val)
+			arr := b.NewStringArray()
+			defer arr.Release()
+			if got := arr.Value(0); got != tc.want {
+				t.Fatalf("AppendValue(%v) -> %q, want %q", tc.val, got, tc.want)
 			}
 		})
 	}

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -346,10 +346,10 @@ pipeline_error_recovery() { # org password
     out="$(PGPASSWORD="$2" psql \
         "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" 2>&1 <<EOF || true
 \startpipeline
-SELEC deliberately_broken \bind \g
-INSERT INTO $t VALUES (1) \bind \g
+SELEC deliberately_broken \bind \sendpipeline
+INSERT INTO $t VALUES (1) \bind \sendpipeline
 \syncpipeline
-INSERT INTO $t VALUES (2) \bind \g
+INSERT INTO $t VALUES (2) \bind \sendpipeline
 \endpipeline
 EOF
 )"

--- a/tests/integration/compare.go
+++ b/tests/integration/compare.go
@@ -330,6 +330,15 @@ func valuesEqual(pg, dg interface{}, opts CompareOptions) bool {
 	pgNorm := normalizeValue(pg)
 	dgNorm := normalizeValue(dg)
 
+	// JSON comparison MUST come before the plain string comparison below:
+	// Postgres jsonb pretty-prints ("[1, 2, 3, 4]", "{\"a\": 1}") while DuckDB
+	// JSON is compact ("[1,2,3,4]", "{\"a\":1}"). They are structurally
+	// identical valid JSON but not byte-equal, so an exact string compare would
+	// spuriously fail (e.g. the #716 jsonb_concat_* cases). Compare structurally.
+	if isJSON(pgNorm) && isJSON(dgNorm) {
+		return jsonEqual(pgNorm, dgNorm)
+	}
+
 	// String comparison
 	if pgStr, ok := pgNorm.(string); ok {
 		if dgStr, ok := dgNorm.(string); ok {
@@ -376,11 +385,6 @@ func valuesEqual(pg, dg interface{}, opts CompareOptions) bool {
 		if dgBool, ok := dgNorm.(bool); ok {
 			return pgBool == dgBool
 		}
-	}
-
-	// JSON comparison
-	if isJSON(pgNorm) && isJSON(dgNorm) {
-		return jsonEqual(pgNorm, dgNorm)
 	}
 
 	// Array/slice comparison

--- a/transpiler/transform/operators.go
+++ b/transpiler/transform/operators.go
@@ -644,7 +644,15 @@ func (t *OperatorTransform) createJSONConcatExpr(left, right *pg_query.Node) *pg
 		}}}
 	}
 
-	return &pg_query.Node{Node: &pg_query.Node_CaseExpr{CaseExpr: &pg_query.CaseExpr{
+	// The whole CASE is wrapped in an explicit CAST(... AS JSON). DuckDB's
+	// to_json()/map_concat()/list_concat() result type is not reported as JSON
+	// by every bundled DuckDB version — on some versions the wire layer then
+	// sees the column as an untyped list and renders it with Go's %v
+	// ("[1 2 3 4]") instead of routing it through the JSON re-serializer
+	// ("[1,2,3,4]"). Forcing the column to JSON pins OID 114 so server's
+	// encodeJSON path always produces valid JSON text. The cast is idempotent
+	// on versions that already type it as JSON. (#716 regression.)
+	return castToJSON(&pg_query.Node{Node: &pg_query.Node_CaseExpr{CaseExpr: &pg_query.CaseExpr{
 		Args: []*pg_query.Node{
 			// WHEN L IS NULL OR R IS NULL THEN NULL — Postgres jsonb || is
 			// strict; without this guard the ELSE branch would wrap a SQL
@@ -667,7 +675,7 @@ func (t *OperatorTransform) createJSONConcatExpr(left, right *pg_query.Node) *pg
 		},
 		// ELSE array concatenation (with non-arrays wrapped as one element).
 		Defresult: jsonFuncCall("to_json", jsonFuncCall("list_concat", asElementList(left), asElementList(right))),
-	}}}
+	}}})
 }
 
 // jsonFuncCall builds an unqualified function-call node.

--- a/transpiler/transform/operators_jsonb_concat_test.go
+++ b/transpiler/transform/operators_jsonb_concat_test.go
@@ -43,6 +43,15 @@ func assertJSONConcatShape(t *testing.T, sql string) {
 	if strings.Contains(out, "json_merge_patch") {
 		t.Errorf("jsonb || must not use json_merge_patch (wrong for arrays/nulls), got %q", out)
 	}
+	// The whole CASE must be cast to JSON. Without this, DuckDB versions that
+	// don't report the to_json()/list_concat() result type as JSON make the
+	// wire layer render the column as an untyped list ("[1 2 3 4]") instead of
+	// JSON text ("[1,2,3,4]") — the #716 runtime regression that the emitted-
+	// shape markers alone did not catch. The outer cast deparses as the
+	// trailing `END::"json"`.
+	if !strings.Contains(out, `end::"json"`) {
+		t.Errorf("jsonb || result must be cast to JSON (expected trailing `END::\"json\"`), got %q", out)
+	}
 }
 
 func TestOperatorTransform_JSONBConcatObjects(t *testing.T) {


### PR DESCRIPTION
Fixes the #716 runtime regression that merged red (#729 landed with `e2e` + `integration-tests` failing — those lanes aren't required checks). Three complementary layers, all root-caused and reproduced **in-process** (no cluster needed):

### 1. Worker Arrow JSON serialization — `duckdbservice/arrowmap` (the remote-backend bug)
The worker maps a DuckDB `JSON` column to an Arrow **String** column, but the `database/sql` driver decodes JSON values into native Go composites (`array → []interface{}`, `object → map[string]interface{}`). `AppendValue`'s String-builder path stringified those with `fmt.Sprintf("%v")`, so a jsonb array crossed Arrow Flight to the client as `"[1 2 3 4]"` instead of `"[1,2,3,4]"`. The standalone path dodged this via `server.encodeJSON` at wire-send; the worker had no equivalent. Now `AppendValue` `json.Marshal`s composites. **This fixes all jsonb array/object columns over the remote backend, not just `||`.** A VARCHAR column never decodes to a composite, so plain strings are untouched.

### 2. Transpiler `CAST(... AS JSON)` — `createJSONConcatExpr`
Pins the concat result column to `JSON` on every DuckDB version → Arrow **String** (not List), so layer 1 applies and the standalone path's `encodeJSON` runs. Idempotent where the type was already JSON.

### 3. Integration comparison — `tests/integration/compare.go`
Pre-existing bug: `valuesEqual` did an exact string compare *before* the JSON branch, so Postgres' pretty-printed `[1, 2, 3, 4]` never matched DuckDB's compact `[1,2,3,4]` even when structurally identical. Moved `isJSON`/`jsonEqual` ahead of the string compare.

### Why the original slipped through
The #716 unit tests only asserted emitted-SQL shape; the value bug lived in the worker Arrow path (remote-only) and a test-harness compare gap. Both were invisible to unit tests and the standalone path, and `e2e`/`integration-tests` aren't required for merge.

### Verification
Reproduced the worker path locally via `GetQuerySchema` + `RowsToRecord` (confirmed `[1 2 3 4]` → `[1,2,3,4]` after the fix). New regression test `arrowmap_test.go::TestAppendValueJSONCompositeToString` (composite → JSON text, varchar untouched) fails on the old `%v` path. `go build/vet/test` green across `duckdbservice`, `transpiler`, `server`. The authoritative cross-version check is the `e2e` + `integration-tests` CI lanes on this PR — **must be green before merge** (the lanes that were red on #729).

Fixes the #716 runtime regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)