### PR TITLE
refactor: dedup AcquireWorker session-claim bookkeeping (#722 phase 3)

### DIFF
--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -42,10 +42,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*M
 		// 1. Try to claim an idle worker
 		idle := p.findIdleWorkerLocked()
 		if idle != nil {
-			idle.activeSessions++
-			if idle.activeSessions > idle.peakSessions {
-				idle.peakSessions = idle.activeSessions
-			}
+			idle.claimSessionLocked()
 			p.mu.Unlock()
 			slog.Debug("Reusing idle worker.", "worker", idle.ID, "active_sessions", idle.activeSessions)
 			return idle, nil
@@ -60,10 +57,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*M
 			// and spawn a new worker in the background if below capacity.
 			w := p.leastLoadedWorkerLocked()
 			if w != nil {
-				w.activeSessions++
-				if w.activeSessions > w.peakSessions {
-					w.peakSessions = w.activeSessions
-				}
+				w.claimSessionLocked()
 				if canSpawn {
 					id := p.allocateBackgroundSpawnIDLocked()
 					p.spawning++
@@ -102,10 +96,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*M
 				return nil, fmt.Errorf("worker %d not found after spawn", id)
 			}
 			p.mu.Lock()
-			w.activeSessions++
-			if w.activeSessions > w.peakSessions {
-				w.peakSessions = w.activeSessions
-			}
+			w.claimSessionLocked()
 			p.mu.Unlock()
 			return w, nil
 		}

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -141,6 +141,20 @@ func (w *ManagedWorker) PodName() string {
 	return w.podName
 }
 
+// claimSessionLocked records one newly-assigned session on the worker: it
+// increments the active session count and advances the peak-sessions
+// high-water mark. The caller must hold the owning pool's lock (this is the
+// shared session-claim bookkeeping used identically by both
+// FlightWorkerPool.AcquireWorker and K8sWorkerPool.AcquireWorker after a
+// worker is selected). It does not make any scheduling decision — callers
+// remain responsible for choosing which worker to claim.
+func (w *ManagedWorker) claimSessionLocked() {
+	w.activeSessions++
+	if w.activeSessions > w.peakSessions {
+		w.peakSessions = w.activeSessions
+	}
+}
+
 // preboundSocket is a Unix socket pre-bound at startup while the socket
 // directory is verified writable. This avoids EROFS errors that can occur
 // later under systemd's ProtectSystem=strict when the RuntimeDirectory
@@ -682,10 +696,7 @@ func (p *FlightWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) 
 	// 1. Try to claim an idle worker before spawning a new one.
 	idle := p.findIdleWorkerLocked()
 	if idle != nil {
-		idle.activeSessions++
-		if idle.activeSessions > idle.peakSessions {
-			idle.peakSessions = idle.activeSessions
-		}
+		idle.claimSessionLocked()
 		p.mu.Unlock()
 		return idle, nil
 	}
@@ -714,10 +725,7 @@ func (p *FlightWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) 
 		}
 
 		p.mu.Lock()
-		w.activeSessions++
-		if w.activeSessions > w.peakSessions {
-			w.peakSessions = w.activeSessions
-		}
+		w.claimSessionLocked()
 		p.mu.Unlock()
 		return w, nil
 	}
@@ -725,10 +733,7 @@ func (p *FlightWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) 
 	// 3. At capacity — assign to the least-loaded live worker.
 	w := p.leastLoadedWorkerLocked()
 	if w != nil {
-		w.activeSessions++
-		if w.activeSessions > w.peakSessions {
-			w.peakSessions = w.activeSessions
-		}
+		w.claimSessionLocked()
 		p.mu.Unlock()
 		return w, nil
 	}
@@ -764,10 +769,7 @@ func (p *FlightWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) 
 	}
 
 	p.mu.Lock()
-	w.activeSessions++
-	if w.activeSessions > w.peakSessions {
-		w.peakSessions = w.activeSessions
-	}
+	w.claimSessionLocked()
 	p.mu.Unlock()
 	return w, nil
 }

--- a/controlplane/worker_mgr_test.go
+++ b/controlplane/worker_mgr_test.go
@@ -96,3 +96,42 @@ func TestManagedWorkerOwnerEpochAccessorsRaceFree(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestManagedWorkerClaimSessionLocked pins the shared session-claim
+// bookkeeping used identically by FlightWorkerPool.AcquireWorker and
+// K8sWorkerPool.AcquireWorker after a worker is selected: each claim
+// increments activeSessions and advances the peakSessions high-water
+// mark, but peakSessions never regresses when sessions are later
+// released. This is a pure no-op for scheduling; it only updates the
+// worker's own counters (the caller holds the pool lock).
+func TestManagedWorkerClaimSessionLocked(t *testing.T) {
+	w := &ManagedWorker{}
+
+	w.claimSessionLocked()
+	if w.activeSessions != 1 || w.peakSessions != 1 {
+		t.Fatalf("after first claim: active=%d peak=%d, want 1/1", w.activeSessions, w.peakSessions)
+	}
+
+	w.claimSessionLocked()
+	if w.activeSessions != 2 || w.peakSessions != 2 {
+		t.Fatalf("after second claim: active=%d peak=%d, want 2/2", w.activeSessions, w.peakSessions)
+	}
+
+	// Simulate a release: peak must hold even though active drops.
+	w.activeSessions--
+	if w.activeSessions != 1 || w.peakSessions != 2 {
+		t.Fatalf("after release: active=%d peak=%d, want 1/2", w.activeSessions, w.peakSessions)
+	}
+
+	// Re-claiming below the prior peak must not regress peak.
+	w.claimSessionLocked()
+	if w.activeSessions != 2 || w.peakSessions != 2 {
+		t.Fatalf("after re-claim: active=%d peak=%d, want 2/2", w.activeSessions, w.peakSessions)
+	}
+
+	// A claim that exceeds the prior peak advances it.
+	w.claimSessionLocked()
+	if w.activeSessions != 3 || w.peakSessions != 3 {
+		t.Fatalf("after exceeding peak: active=%d peak=%d, want 3/3", w.activeSessions, w.peakSessions)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of #722 — the final code phase. **Conservative de-dup only.**

Both `AcquireWorker` implementations — `FlightWorkerPool.AcquireWorker` (process backend, local Flight workers over unix sockets, `worker_mgr.go`) and `K8sWorkerPool.AcquireWorker` (flat single-tenant k8s pool, `k8s_pool_acquire.go`) — repeated the *exact same* post-selection bookkeeping snippet at every claim site:

```go
w.activeSessions++
if w.activeSessions > w.peakSessions {
    w.peakSessions = w.activeSessions
}
```

That snippet appeared 4 times in `worker_mgr.go` and 3 times in `k8s_pool_acquire.go`, verbatim. This PR extracts it into a small behavior-identical method:

```go
func (w *ManagedWorker) claimSessionLocked()
```

(`ManagedWorker` lives in `worker_mgr.go`, which has no build tag, so the helper is available to both the process and `-tags kubernetes` builds.)

## What this intentionally does NOT do

- **No merge of the two `AcquireWorker` methods.** Control flow and scheduling decisions in both are unchanged — only the inlined increment+peak bookkeeping became a method call. The helper makes no scheduling decision; callers still choose which worker to claim and still hold the pool lock.
- **`OrgReservedPool` (`org_reserved_pool.go`) is untouched.** The remote/multitenant path keeps its own bookkeeping inline; per the load-bearing contract it must never co-assign and must have no least-loaded path. Nothing new is routed through it.
- **Hard invariants preserved:** one-session-per-worker (`DUCKGRES_DUCKDB_MAX_SESSIONS=1`), fail-fast-at-org-cap, and destroy-before-reuse ordering are all unchanged — this PR does not touch those code paths.

## Tests

- Added `TestManagedWorkerClaimSessionLocked` (`worker_mgr_test.go`) pinning the helper: each claim increments `activeSessions` and advances `peakSessions`, and `peakSessions` never regresses on release / re-claim below the prior peak.
- Existing unit tests pass **unchanged** (behavior-preserving extraction). The `one_session_per_worker` e2e assertion in `tests/e2e-mw-dev/harness.sh` already covers the affected k8s-pool path and still exercises it as-is — no new e2e assertion is added for a behavior-preserving extraction.

## Verification (all run locally)

| check | result |
|---|---|
| `go build ./...` | pass |
| `go build -tags kubernetes ./...` | pass |
| `go vet ./controlplane/...` | pass |
| `go vet -tags kubernetes ./controlplane/...` | pass |
| `go test ./controlplane/...` | pass |
| `go test -tags kubernetes ./controlplane/...` | `controlplane`, `configstore`, `provisioner`, `provisioning` pass; `controlplane/admin` had 2 pre-existing infra-dependent failures (`TestUpsertManagedWarehousePreservesCreatedAt`, `TestMutateManagedWarehouseSerializesConcurrentWriters` — both need a local test Postgres on `127.0.0.1:35432` and pass in isolation; unrelated to this change, which does not touch `controlplane/admin`) |
| `gofmt -l` on changed files | clean |

Partially addresses #722 (phase 3 of 4). After this PR, only the doc-cleanup phase remains (handled by a sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
