### PR TITLE
docs: refresh stale conn.go / k8s_pool.go pointers after the splits (#722 phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ In topologies 2 and 3, the control plane also exposes an Arrow Flight SQL ingres
 
 - **main.go / config_resolution.go**: CLI flags; effective config resolution (CLI > env > YAML > defaults), including env-only K8s knobs.
 - **server/** — PG wire protocol server and DuckDB execution
-  - Wire protocol & connections: `server.go`, `conn.go`, `protocol.go`, `exports.go`
+  - Wire protocol & connections: `server.go`, `conn.go`, `conn_errors.go`, `conn_query_exec.go`, `conn_results.go`, `conn_copy.go`, `conn_extended_query.go`, `conn_pg_stat_activity.go`, `conn_cursor.go`, `protocol.go`, `exports.go`
   - Execution: `executor.go`, `flight_executor.go`, `chsql.go`, `transient.go`
   - Catalog & types: `catalog.go`, `types.go`, `session_database_metadata.go`
   - Auth, TLS, rate limiting: `auth_policy.go`, `ratelimit.go`, `certs.go`, `acme.go`
@@ -45,7 +45,7 @@ In topologies 2 and 3, the control plane also exposes an Arrow Flight SQL ingres
   - Core: `control.go`, `session_mgr.go`, `worker_mgr.go`, `worker_pool.go` (process/k8s abstraction), `validation.go`, `sdnotify.go`
   - Flight SQL ingress adapter: `flight_ingress.go`
   - Runtime loops: `janitor.go`, `leader_loop.go`, `memory_rebalancer.go`, `runtime_tracker.go`
-  - K8s / multitenant under build tag `kubernetes` (including: `multitenant.go`, `k8s_pool.go`, `k8s_factory.go`, `org_router.go`, `org_reserved_pool.go`, `sts_broker.go`, `shared_worker_activator.go`, `worker_rpc_security.go`, `janitor_leader_k8s.go`)
+  - K8s / multitenant under build tag `kubernetes` (including: `multitenant.go`, `k8s_pool.go`, `k8s_pool_acquire.go`, `k8s_pool_spawn.go`, `k8s_pool_lifecycle.go`, `k8s_pool_reconcile.go`, `k8s_pool_helpers.go`, `k8s_factory.go`, `org_router.go`, `org_reserved_pool.go`, `sts_broker.go`, `shared_worker_activator.go`, `worker_rpc_security.go`, `janitor_leader_k8s.go`)
   - Subpackages: `admin/` (HTTP admin API, `kubernetes` tag), `provisioner/` (k8s controller, `kubernetes` tag), `provisioning/` (HTTP API), `configstore/` (Postgres-backed config)
 - **duckdbservice/** — DuckDB Arrow Flight SQL service
   - Core: `service.go`, `flight_handler.go`, `arrow_helpers.go`, `auth.go`, `config.go`

--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@
 - [x] Some PostgreSQL drivers may fail with unsupported OIDs — unknown types fall back to `OidText` ([types.go](server/types.go))
 - [x] `\d` commands in psql don't work (need system catalog) - fixed
 - [x] Transaction isolation may differ from PostgreSQL behavior — documented in [README](README.md#transaction-isolation)
-- [x] Large result sets may cause memory issues (no streaming) — results are streamed row-by-row via `rows.Next()` + server-side cursor emulation ([conn.go](server/conn.go))
+- [x] Large result sets may cause memory issues (no streaming) — results are streamed row-by-row via `rows.Next()` + server-side cursor emulation ([conn_cursor.go](server/conn_cursor.go))
 
 ## Contributing
 

--- a/cmd/duckgres-worker/main.go
+++ b/cmd/duckgres-worker/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	// --mode is accepted but must be "duckdb-service". The K8s control
 	// plane spawns workers with `--mode duckdb-service` hardcoded
-	// (controlplane/k8s_pool.go), and the all-in-one duckgres binary
+	// (controlplane/k8s_pool_spawn.go), and the all-in-one duckgres binary
 	// uses --mode to route between standalone/control-plane/duckdb-service.
 	// This binary is duckdb-service by definition; we accept the flag so
 	// existing CP pod specs don't crash flag.Parse with "flag provided but

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -412,7 +412,7 @@ func TestHealthCheckFailsAfterCPRollingRestart(t *testing.T) {
 	// CP-new starts fresh after rolling update. It discovers the worker via
 	// K8s informer but hasn't re-activated it. Its in-memory epoch for this
 	// worker is 0 (default). This is exactly what the health check loop at
-	// k8s_pool.go:2270-2278 sends.
+	// k8s_pool_lifecycle.go health check loop sends.
 	err := pool.validateControlMetadata(server.WorkerControlMetadata{
 		WorkerID:     42,
 		OwnerEpoch:   0,

--- a/server/duckdb_appender.go
+++ b/server/duckdb_appender.go
@@ -16,7 +16,7 @@ import (
 // The signature lives in the server package (rather than in duckdbservice)
 // because the COPY codepath in clientConn dispatches through it; the
 // duckdbservice package registers the actual implementation at init time
-// via RegisterDuckDBAppender, which keeps server/conn.go itself free of any
+// via RegisterDuckDBAppender, which keeps server/conn_copy.go itself free of any
 // duckdb-go imports.
 //
 // parts is the result of splitQualifiedName(tableName) — a 1, 2, or 3

--- a/server/flightclient/flight_executor_arrow_test.go
+++ b/server/flightclient/flight_executor_arrow_test.go
@@ -79,7 +79,7 @@ func TestArrowTypeToDuckDB_ListOfStruct(t *testing.T) {
 // extracted from Arrow arrays. STRUCT and MAP currently fall through to
 // the string fallback (ValueStr).
 //
-// Expected return types (matching what conn.go formatValue consumes):
+// Expected return types (matching what conn_results.go formatValue consumes):
 //   STRUCT → map[string]interface{}
 //   MAP    → arrowmap.OrderedMapValue (keys preserve original Arrow types and insertion order)
 

--- a/server/format_ordered_map_test.go
+++ b/server/format_ordered_map_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // formatOrderedMapValue tests. Live here in package server because the
-// function under test calls formatValue (defined in conn.go) which switches
+// function under test calls formatValue (defined in conn_results.go) which switches
 // on the duckdb-go driver's value types — it can't move to a duckdb-free
 // subpackage.
 

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -565,7 +565,7 @@ func TestClaimHotIdleWorkerSerializesOrgCapPostgres(t *testing.T) {
 }
 
 func TestGetWorkerRecordReturnsNilNilForMissingRow(t *testing.T) {
-	// cleanupOrphanedWorkerPods in k8s_pool.go treats (nil, nil) as "no DB
+	// cleanupOrphanedWorkerPods in k8s_pool_reconcile.go treats (nil, nil) as "no DB
 	// row — this pod is fully orphaned and safe to delete" and a non-nil
 	// error as "skip this tick and retry." If GetWorkerRecord wrapped
 	// gorm.ErrRecordNotFound as an error, the missing-row branch of the

--- a/transpiler/transform/ddl.go
+++ b/transpiler/transform/ddl.go
@@ -582,7 +582,7 @@ func (t *DDLTransform) warnDroppedAlterCommand(result *Result, cmd *pg_query.Alt
 }
 
 // warnDropColumn records a WARNING that DROP COLUMN may make existing data
-// unreadable on the Iceberg catalog (see the runtime guard in server/conn.go).
+// unreadable on the Iceberg catalog (see the runtime guard in server/conn_errors.go).
 func (t *DDLTransform) warnDropColumn(result *Result) {
 	if !t.policy.WarnOnStrippedConstraints || result == nil {
 		return

--- a/transpiler/transform/errors.go
+++ b/transpiler/transform/errors.go
@@ -1,7 +1,7 @@
 package transform
 
 // CodedError is a transform-detected error that carries an explicit PostgreSQL
-// SQLSTATE. conn.go reads the code via the SQLState() method when sending the
+// SQLSTATE. conn_errors.go reads the code via the SQLState() method when sending the
 // error to the client; errors without a code default to 42704.
 type CodedError struct {
 	Code    string


### PR DESCRIPTION
## What

Final phase of #722 (closes out the god-file split). After PRs #728/#732 split `server/conn.go` and #733 split `controlplane/k8s_pool.go` into cohesive same-package `*_*.go` files, several doc/comment pointers still named the old monolith files. This PR updates the **stale** ones to name the file the code now lives in.

This is **docs/comments only — zero code/behavior change.**

## Changes (each factually verified by grepping for the named symbol)

| Pointer | Moved to | Verified symbol |
|---|---|---|
| CLAUDE.md "Wire protocol & connections" list | enumerates new `conn_*.go` | file list |
| CLAUDE.md K8s component list | enumerates new `k8s_pool_*.go` | file list |
| `server/duckdb_appender.go` (`conn.go` free of duckdb-go imports) | `conn_copy.go` | COPY appender dispatch; confirmed `conn_copy.go` has **no** direct duckdb-go imports — property still holds |
| `TODO.md` cursor emulation | `conn_cursor.go` | `openCursor` / "server-side cursor emulation" |
| `transpiler/transform/ddl.go` runtime guard | `conn_errors.go` | DROP COLUMN "unreadable" friendly error |
| `transpiler/transform/errors.go` SQLState() reader | `conn_errors.go` | `SQLState()` (no longer in `conn.go`) |
| `server/format_ordered_map_test.go` + `flightclient/flight_executor_arrow_test.go` | `conn_results.go` | `formatValue` |
| `cmd/duckgres-worker/main.go` `--mode` hardcode | `k8s_pool_spawn.go` | spawn / `--mode duckdb-service` |
| `duckdbservice/activation_test.go` health-check loop | `k8s_pool_lifecycle.go` | control-metadata send loop |
| `tests/configstore/runtime_store_postgres_test.go` | `k8s_pool_reconcile.go` | `cleanupOrphanedWorkerPods` |

## Deliberately left unchanged (still correct)

- DML RETURNING section's `isDMLReturning ... in server/conn.go` — verified `isDMLReturning` stayed in `conn.go`.
- `transpiler.go` / `create_or_replace.go` references to `conn.go` forwarding the SQL / `FallbackToNative` / `IsIgnoredSet` / `IsNoOp` — that dispatch (conn.go:1200/1226/1235) and `validateWithDuckDB` still live in `conn.go`.
- CLAUDE.md LOAD-BEARING CONTRACT prose (`k8s_pool.go::spawnWorker`/`AcquireWorker`, drain `terminationGracePeriodSeconds`) — left verbatim per the scope of this cleanup (only factual file enumerations were touched).

## Verification

- `go build ./...` — pass
- `go build -tags kubernetes ./controlplane/... ./cmd/... ./duckdbservice/...` — pass (comment edits in k8s-tagged files still compile)
- `gofmt`: my edits introduce no formatting changes; the two files `gofmt -l` flags (`cmd/duckgres-worker/main.go`, `server/flightclient/flight_executor_arrow_test.go`) are **pre-existing** on `origin/main` (confirmed by stashing my diff) — not touched by this PR beyond a single-word comment swap.
- `git grep` after: every remaining `conn.go` / `k8s_pool.go` reference points at code that genuinely still lives in those files.

No test or harness change: this is docs/comments only with zero runtime/cluster behavior change, so there is nothing for `tests/e2e-mw-dev/harness.sh` to assert.

Fixes #722 (final phase — closes out the god-file split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)