### PR TITLE
fix(server): bound catalog-attachment steps with per-step deadlines so hung attaches fail fast

### DIFF
--- a/server/attach_timeout.go
+++ b/server/attach_timeout.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Per-step deadlines for catalog attachment (AttachDuckLake, AttachDeltaCatalog,
+// attachLakekeeperCatalog) and secret refresh (RefreshS3Secret,
+// RefreshIcebergSecret).
+//
+// Why these exist: every step in those functions is a plain CGO db.Exec /
+// db.QueryRow with no deadline. A hung network dependency inside DuckDB
+// (unreachable Lakekeeper REST endpoint, an S3 connect that blackholes, the
+// IMDS probe documented in attachLakekeeperCatalog, a wedged metadata
+// Postgres) therefore eats the control plane's entire activate-tenant
+// deadline (~60s) with zero Go-level logging — and, far worse, the activation
+// holds a drain token (beginDrainWork in duckdbservice/flight_handler.go), so
+// a retired worker pod with a hung attach stays Draining for up to
+// workerShutdownDrainTime (55m), pinning a warm EC2 node. Per-step deadlines
+// turn that into a fast, attributable failure.
+const (
+	// attachStepTimeout bounds the fast attachment steps: extension
+	// INSTALL/LOAD, CREATE SECRET, catalog presence checks, SET statements,
+	// and the default-schema CREATE. These are local or single-round-trip
+	// operations that complete in milliseconds when healthy; 30s is already
+	// generous slack for a cold extension INSTALL from the CDN.
+	attachStepTimeout = 30 * time.Second
+	// attachStatementTimeout bounds the ATTACH statements themselves (DuckLake,
+	// Delta, Lakekeeper Iceberg) and the Delta post-attach probe. Deliberately
+	// loose: a DuckLake ATTACH against a busy metadata Postgres can
+	// legitimately take tens of seconds (catalog snapshot read over many
+	// metadata rows), so do NOT tighten this without production latency data.
+	attachStatementTimeout = 60 * time.Second
+	// attachMigrateStatementTimeout bounds a DuckLake ATTACH that performs an
+	// automatic spec migration (AUTOMATIC_MIGRATION TRUE). Migration rewrites
+	// metadata tables inside the metadata Postgres and can legitimately run
+	// for minutes on a large catalog, so it gets a far looser wall than a
+	// normal ATTACH — the point is still "bounded", not "tight".
+	attachMigrateStatementTimeout = 15 * time.Minute
+)
+
+// attachInterruptGrace is how long past the ctx deadline we keep waiting for
+// the driver's duckdb_interrupt to actually unblock the CGO call before
+// abandoning the goroutine. The duckdb-go driver re-asserts the interrupt
+// every 500ms after cancellation, but DuckDB only observes the flag at query
+// execution checkpoints — a statement blocked in extension network I/O (TCP
+// connect inside httpfs, Lakekeeper REST, IMDS probe) may never see it.
+// Variable (not const) so tests can shrink it.
+var attachInterruptGrace = 5 * time.Second
+
+// attachStepExecer runs catalog-attachment statements against db with a hard
+// per-statement deadline. Each statement runs under a context deadline (the
+// duckdb-go driver propagates cancellation by repeatedly calling
+// duckdb_interrupt, which stops a query that reaches an execution checkpoint)
+// plus a watchdog wall: if the CGO call still hasn't returned
+// attachInterruptGrace after the deadline — i.e. it is stuck in
+// non-interruptible blocking I/O — the goroutine is abandoned, an error is
+// returned to the caller immediately, and the statement is tracked so
+// releaseSem only returns the attach semaphore slot once the underlying call
+// has actually finished (releasing it earlier would let a second attach race
+// the hung one on the same database).
+//
+// One execer instance covers one sem-held attach region; create it before
+// acquiring the semaphore and `defer ae.releaseSem(sem)` in place of the bare
+// `defer func() { <-sem }()`.
+type attachStepExecer struct {
+	db *sql.DB
+
+	mu        sync.Mutex
+	abandoned []abandonedAttachStmt
+}
+
+type abandonedAttachStmt struct {
+	query string
+	done  <-chan struct{} // closed when the underlying CGO call finally returns
+}
+
+func newAttachStepExecer(db *sql.DB) *attachStepExecer {
+	return &attachStepExecer{db: db}
+}
+
+// Exec runs query with the default attachStepTimeout. It satisfies
+// duckLakeSQLExecer so the execer can be passed straight into
+// applyDuckLakePreAttachSettingsWith / configureDuckLakeMetadataPool /
+// loadExtensionsWith.
+func (a *attachStepExecer) Exec(query string, args ...any) (sql.Result, error) {
+	return a.execTimeout(attachStepTimeout, query, args...)
+}
+
+// execTimeout runs query with an explicit deadline (use
+// attachStatementTimeout for ATTACH statements).
+func (a *attachStepExecer) execTimeout(timeout time.Duration, query string, args ...any) (sql.Result, error) {
+	var res sql.Result
+	err := a.run(timeout, query, func(ctx context.Context) error {
+		r, err := a.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		res = r
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// queryRowScan runs a single-row query with the default attachStepTimeout and
+// scans the result into dest. On timeout dest is NOT written; callers must
+// treat a non-nil error as "value unknown" (all current callers do).
+func (a *attachStepExecer) queryRowScan(query string, dest ...any) error {
+	return a.run(attachStepTimeout, query, func(ctx context.Context) error {
+		return a.db.QueryRowContext(ctx, query).Scan(dest...)
+	})
+}
+
+// run executes fn (one DuckDB statement) under a timeout. See the
+// attachStepExecer doc comment for the two-layer deadline semantics.
+func (a *attachStepExecer) run(timeout time.Duration, query string, fn func(ctx context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(done)
+		// Cancel only when fn returns: after the deadline fires the driver
+		// keeps re-asserting duckdb_interrupt until the call completes, which
+		// is exactly what we want for a statement that unblocks late.
+		defer cancel()
+		errCh <- fn(ctx)
+	}()
+
+	wall := time.NewTimer(timeout + attachInterruptGrace)
+	defer wall.Stop()
+	select {
+	case err := <-errCh:
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("catalog attachment step timed out after %s (interrupted): %w", timeout, err)
+		}
+		return err
+	case <-wall.C:
+		a.mu.Lock()
+		a.abandoned = append(a.abandoned, abandonedAttachStmt{query: summarizeAttachStmt(query), done: done})
+		a.mu.Unlock()
+		slog.Error("Catalog attachment step exceeded its deadline and did not respond to interrupt; abandoning the call. "+
+			"The statement may still be executing on its DuckDB connection (likely blocked in non-interruptible network I/O); "+
+			"the attach semaphore will not be released until it returns.",
+			"timeout", timeout, "grace", attachInterruptGrace, "query", summarizeAttachStmt(query))
+		go func(q string, started time.Time) {
+			<-done
+			slog.Warn("Abandoned catalog attachment statement finally returned.",
+				"query", q, "overrun", time.Since(started))
+		}(summarizeAttachStmt(query), time.Now())
+		return fmt.Errorf("catalog attachment step timed out after %s and did not respond to interrupt (statement may still be executing): %s",
+			timeout, summarizeAttachStmt(query))
+	}
+}
+
+// releaseSem returns the attach semaphore slot acquired by the caller. If any
+// statement was abandoned past its deadline, the release is handed to a
+// goroutine that waits for the underlying CGO call(s) to actually finish
+// first — the semaphore exists to serialize attach work on the database, and
+// a hung ATTACH still owns its connection until it returns. If the call never
+// returns, the slot is intentionally never released: subsequent attaches fail
+// fast on their existing 30s "waiting for attachment lock" timeout instead of
+// racing a wedged connection.
+//
+// No-op when sem is nil (callers that run without the semaphore).
+func (a *attachStepExecer) releaseSem(sem chan struct{}) {
+	if sem == nil {
+		return
+	}
+	a.mu.Lock()
+	abandoned := a.abandoned
+	a.abandoned = nil
+	a.mu.Unlock()
+	if len(abandoned) == 0 {
+		<-sem
+		return
+	}
+	go func() {
+		for _, st := range abandoned {
+			<-st.done
+		}
+		slog.Warn("Abandoned catalog attachment statement(s) finished; releasing attach semaphore.",
+			"count", len(abandoned))
+		<-sem
+	}()
+}
+
+// attachSQLRunner abstracts the statement runner shared by createS3SecretWith
+// so catalog-attachment paths run under per-step deadlines (attachStepExecer)
+// while standalone callers (checkpoint, querylog) keep plain *sql.DB behavior.
+type attachSQLRunner interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	queryRowScan(query string, dest ...any) error
+}
+
+// plainAttachRunner adapts *sql.DB to attachSQLRunner with no deadlines
+// (legacy behavior for non-attach callers).
+type plainAttachRunner struct{ db *sql.DB }
+
+func (p plainAttachRunner) Exec(query string, args ...any) (sql.Result, error) {
+	return p.db.Exec(query, args...)
+}
+
+func (p plainAttachRunner) queryRowScan(query string, dest ...any) error {
+	return p.db.QueryRow(query).Scan(dest...)
+}
+
+// summarizeAttachStmt truncates a statement for log/error output. Attach and
+// secret statements can embed credentials further in, but everything before
+// the first newline/paren is a safe, identifying prefix.
+func summarizeAttachStmt(query string) string {
+	const maxLen = 80
+	query = strings.TrimSpace(query)
+	if i := strings.IndexAny(query, "(\n"); i > 0 && i < maxLen {
+		return strings.TrimSpace(query[:i]) + "..."
+	}
+	if len(query) > maxLen {
+		return query[:maxLen] + "..."
+	}
+	return query
+}

--- a/server/attach_timeout_test.go
+++ b/server/attach_timeout_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openAttachTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestAttachStepExecerFastStatement verifies the happy path: statements that
+// finish within the deadline behave exactly like plain Exec/QueryRow.
+func TestAttachStepExecerFastStatement(t *testing.T) {
+	db := openAttachTestDB(t)
+	ae := newAttachStepExecer(db)
+
+	if _, err := ae.Exec("CREATE TABLE t (i INTEGER)"); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if _, err := ae.execTimeout(attachStatementTimeout, "INSERT INTO t VALUES (41), (1)"); err != nil {
+		t.Fatalf("execTimeout: %v", err)
+	}
+	var sum int
+	if err := ae.queryRowScan("SELECT sum(i) FROM t", &sum); err != nil {
+		t.Fatalf("queryRowScan: %v", err)
+	}
+	if sum != 42 {
+		t.Fatalf("sum = %d, want 42", sum)
+	}
+
+	// No statements were abandoned, so releaseSem must release synchronously.
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{}
+	ae.releaseSem(sem)
+	select {
+	case sem <- struct{}{}:
+	default:
+		t.Fatal("releaseSem did not release the semaphore synchronously")
+	}
+}
+
+// TestAttachStepExecerInterruptsLongQuery proves the deadline actually stops a
+// long-running DuckDB statement: the duckdb-go driver propagates ctx
+// cancellation by repeatedly calling duckdb_interrupt, which a query observes
+// at execution checkpoints. The cross product below would run for minutes;
+// with a sub-second deadline the call must fail fast — and because the
+// statement responded to the interrupt (returned before the watchdog wall),
+// the semaphore is released synchronously.
+func TestAttachStepExecerInterruptsLongQuery(t *testing.T) {
+	db := openAttachTestDB(t)
+	ae := newAttachStepExecer(db)
+
+	start := time.Now()
+	_, err := ae.execTimeout(300*time.Millisecond,
+		"SELECT count(*) FROM range(100000) t1(i) CROSS JOIN range(100000) t2(j) WHERE (i*j) % 7 = 3")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error %q does not mention the timeout", err)
+	}
+	// Must return well before the query's natural runtime. The watchdog wall
+	// is at timeout+attachInterruptGrace (5.3s); the interrupt path should be
+	// far quicker, but allow the full wall plus slack for CI scheduling.
+	if elapsed > 300*time.Millisecond+attachInterruptGrace+5*time.Second {
+		t.Fatalf("timeout took %s, statement was not bounded", elapsed)
+	}
+
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{}
+	ae.releaseSem(sem)
+	// If the interrupt worked (no abandoned statements) the release is
+	// synchronous; if the statement had to be abandoned, the release happens
+	// once the underlying call returns. Either way it must free up shortly.
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case sem <- struct{}{}:
+			return
+		case <-deadline:
+			t.Fatal("semaphore not released after long-query timeout")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// TestAttachStepExecerWatchdogAbandonsHungCall covers the non-interruptible
+// case (a CGO call blocked in extension network I/O never observes
+// duckdb_interrupt): the watchdog must return an error at timeout+grace,
+// and releaseSem must hold the semaphore until the underlying call actually
+// finishes — releasing earlier would let a second attach race the hung one.
+func TestAttachStepExecerWatchdogAbandonsHungCall(t *testing.T) {
+	origGrace := attachInterruptGrace
+	attachInterruptGrace = 100 * time.Millisecond
+	defer func() { attachInterruptGrace = origGrace }()
+
+	hung := make(chan struct{})
+	ae := newAttachStepExecer(nil) // db unused: run() takes fn directly
+
+	start := time.Now()
+	err := ae.run(50*time.Millisecond, "ATTACH 'fake://hung' AS hung", func(ctx context.Context) error {
+		<-hung // ignores ctx, like a blocked TCP connect inside an extension
+		return nil
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected watchdog timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not respond to interrupt") {
+		t.Fatalf("error %q does not identify the abandoned call", err)
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("watchdog fired after %s, before timeout+grace", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("watchdog took %s, not bounded", elapsed)
+	}
+
+	// The hung statement is still "running": releaseSem must NOT free the
+	// slot yet.
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{}
+	ae.releaseSem(sem)
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case sem <- struct{}{}:
+		t.Fatal("semaphore released while the abandoned statement was still running")
+	default:
+	}
+
+	// Once the underlying call finishes, the slot must be released.
+	close(hung)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case sem <- struct{}{}:
+			return
+		case <-deadline:
+			t.Fatal("semaphore not released after abandoned statement finished")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestAttachStepExecerReleaseSemNil verifies the nil-semaphore no-op used by
+// callers that run without the DuckLake semaphore.
+func TestAttachStepExecerReleaseSemNil(t *testing.T) {
+	ae := newAttachStepExecer(nil)
+	ae.releaseSem(nil) // must not panic or block
+}
+
+// TestSummarizeAttachStmt verifies log/error output never includes secret
+// material embedded in CREATE SECRET statements.
+func TestSummarizeAttachStmt(t *testing.T) {
+	secretStmt := `
+		CREATE OR REPLACE SECRET ducklake_s3 (
+			TYPE s3,
+			PROVIDER config,
+			KEY_ID 'AKIAEXAMPLEKEY',
+			SECRET 'supersecretvalue'
+		)`
+	got := summarizeAttachStmt(secretStmt)
+	if strings.Contains(got, "AKIAEXAMPLEKEY") || strings.Contains(got, "supersecretvalue") {
+		t.Fatalf("summary leaks credentials: %q", got)
+	}
+	if !strings.Contains(got, "CREATE OR REPLACE SECRET ducklake_s3") {
+		t.Fatalf("summary lost the identifying prefix: %q", got)
+	}
+
+	if got := summarizeAttachStmt("SET ducklake_max_retry_count = 100"); got != "SET ducklake_max_retry_count = 100" {
+		t.Fatalf("short statement mangled: %q", got)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1307,6 +1307,14 @@ func parseExtensionName(ext string) (name, installCmd string) {
 //
 // NOTE: Extension names come from trusted server config, not user input.
 func LoadExtensions(db *sql.DB, extensions []string) error {
+	return loadExtensionsWith(db, extensions)
+}
+
+// loadExtensionsWith is LoadExtensions over a duckLakeSQLExecer so the
+// catalog-attachment paths can run INSTALL/LOAD under per-step deadlines via
+// attachStepExecer (a hung extension LOAD is one of the documented activation
+// stalls — see shouldInstallExtension).
+func loadExtensionsWith(db duckLakeSQLExecer, extensions []string) error {
 	if len(extensions) == 0 {
 		return nil
 	}
@@ -1495,16 +1503,22 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// "database with name '__ducklake_metadata_ducklake' already exists".
 	// Use a 30-second timeout to prevent connections from hanging indefinitely
 	// if attachment is slow (e.g., network latency to metadata store).
+	//
+	// Every statement below runs through ae so a hung network dependency
+	// (metadata Postgres, S3) fails fast at a per-step deadline instead of
+	// silently eating the activate-tenant budget; releaseSem keeps the sem
+	// held until any abandoned statement actually finishes.
+	ae := newAttachStepExecer(db)
 	select {
 	case sem <- struct{}{}:
-		defer func() { <-sem }()
+		defer ae.releaseSem(sem)
 	case <-time.After(30 * time.Second):
 		return fmt.Errorf("timeout waiting for DuckLake attachment lock")
 	}
 
 	// Check if DuckLake catalog is already attached
 	var count int
-	err := db.QueryRow("SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'ducklake'").Scan(&count)
+	err := ae.queryRowScan("SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'ducklake'", &count)
 	if err == nil && count > 0 {
 		// Already attached
 		return nil
@@ -1522,7 +1536,7 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 			dlCfg.S3Profile != ""
 
 		if needsSecret {
-			if err := createS3Secret(db, dlCfg); err != nil {
+			if err := createS3SecretWith(ae, dlCfg); err != nil {
 				return fmt.Errorf("failed to create S3 secret: %w", err)
 			}
 		}
@@ -1553,7 +1567,7 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 		// resolveS3SecretTransport now does whenever HTTPProxy is set —
 		// see buildConfigSecret / buildCredentialChainSecret /
 		// buildAWSSdkSecret.
-		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL http_proxy = '%s'", dlCfg.HTTPProxy)); err != nil {
+		if _, err := ae.Exec(fmt.Sprintf("SET GLOBAL http_proxy = '%s'", dlCfg.HTTPProxy)); err != nil {
 			slog.Warn("Failed to set httpfs proxy config.", "stmt", "SET GLOBAL http_proxy", "error", err)
 		}
 		slog.Info("Routed httpfs traffic through forward HTTP proxy.", "proxy", dlCfg.HTTPProxy)
@@ -1573,7 +1587,9 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 
 	// Build the ATTACH statement.
 	// See: https://ducklake.select/docs/stable/duckdb/usage/connecting
-	if err := applyDuckLakePreAttachSettings(db, dlCfg); err != nil {
+	if err := applyDuckLakePreAttachSettingsWith(ae, func() error {
+		return loadExtensionsWith(ae, []string{"postgres_scanner"})
+	}, dlCfg); err != nil {
 		return err
 	}
 	migrate := dlCfg.Migrate || ducklake.MigrationNeeded(dlCfg.MetadataStore)
@@ -1598,9 +1614,18 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 		slog.Info("Attaching DuckLake catalog.", "metadata", redactConnectionString(dlCfg.MetadataStore))
 	}
 
+	// A migrating ATTACH rewrites metadata tables in the metadata store and
+	// can legitimately run for minutes on a large catalog; give it a far
+	// looser deadline than a normal ATTACH so per-step timeouts never break
+	// a spec migration mid-flight.
+	attachTimeout := attachStatementTimeout
+	if migrate {
+		attachTimeout = attachMigrateStatementTimeout
+	}
+
 	_, attachSpan := observe.Tracer().Start(context.Background(), "duckgres.ducklake_attach")
 	if err := retryOnTransientAttach(func() error {
-		_, err := db.Exec(attachStmt)
+		_, err := ae.execTimeout(attachTimeout, attachStmt)
 		return err
 	}); err != nil {
 		attachSpan.End()
@@ -1614,7 +1639,7 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// DuckLake uses optimistic concurrency - when multiple connections commit
 	// simultaneously, they may conflict on snapshot IDs. Default of 10 is too low
 	// for tools like Fivetran that open many concurrent connections.
-	if _, err := db.Exec("SET ducklake_max_retry_count = 100"); err != nil {
+	if _, err := ae.Exec("SET ducklake_max_retry_count = 100"); err != nil {
 		slog.Warn("Failed to set ducklake_max_retry_count.", "error", err)
 		// Don't fail - this is not critical, DuckLake will use its default
 	}
@@ -1632,7 +1657,7 @@ func AttachDuckLake(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}, dataDir
 	// SET GLOBAL only affects pools created after it runs, so would be a no-op here.
 	// See: https://github.com/duckdb/ducklake/issues/1031 and
 	// https://github.com/duckdb/duckdb-postgres/pull/430
-	configureDuckLakeMetadataPool(db)
+	configureDuckLakeMetadataPool(ae)
 
 	// Ensure performance indexes exist on the DuckLake metadata tables.
 	// Run in a goroutine so it doesn't block the DuckLake semaphore or
@@ -1659,32 +1684,35 @@ func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) err
 		return nil
 	}
 
+	// Per-step deadlines: Delta attach + probe hit S3 directly, so a
+	// blackholed object store fails fast instead of hanging activation.
+	ae := newAttachStepExecer(db)
 	select {
 	case sem <- struct{}{}:
-		defer func() { <-sem }()
+		defer ae.releaseSem(sem)
 	case <-time.After(30 * time.Second):
 		return fmt.Errorf("timeout waiting for Delta catalog attachment lock")
 	}
 
 	var count int
-	err := db.QueryRow("SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'delta'").Scan(&count)
+	err := ae.queryRowScan("SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'delta'", &count)
 	if err == nil && count > 0 {
 		return nil
 	}
 
-	if err := LoadExtensions(db, []string{"delta"}); err != nil {
+	if err := loadExtensionsWith(ae, []string{"delta"}); err != nil {
 		return fmt.Errorf("load delta extension: %w", err)
 	}
 
 	if deltaCatalogNeedsS3Secret(catalogPath, dlCfg) {
-		if err := createS3Secret(db, dlCfg); err != nil {
+		if err := createS3SecretWith(ae, dlCfg); err != nil {
 			return fmt.Errorf("failed to create S3 secret: %w", err)
 		}
 	}
 
 	attachStmt := ducklake.BuildDeltaAttachStmt(dlCfg)
 	slog.Info("Attaching Delta catalog.", "path", catalogPath)
-	if _, err := db.Exec(attachStmt); err != nil {
+	if _, err := ae.execTimeout(attachStatementTimeout, attachStmt); err != nil {
 		// Delta is enabled by default. A fresh DuckLake tenant won't have any
 		// Delta data at the sibling delta/ prefix yet, so DeltaKernel returns
 		// "No files in log segment". That's expected — the catalog will start
@@ -1703,9 +1731,9 @@ func AttachDeltaCatalog(db *sql.DB, dlCfg DuckLakeConfig, sem chan struct{}) err
 	// Delta tries to read a missing _delta_log/. Probe immediately and detach
 	// if there's no Delta data here yet, so the catalog only sticks around
 	// once it's actually queryable.
-	if _, err := db.Exec("SHOW TABLES FROM delta"); err != nil {
+	if _, err := ae.execTimeout(attachStatementTimeout, "SHOW TABLES FROM delta"); err != nil {
 		if isDeltaCatalogEmptyError(err) {
-			if _, derr := db.Exec("DETACH delta"); derr != nil {
+			if _, derr := ae.Exec("DETACH delta"); derr != nil {
 				slog.Warn("Failed to detach empty Delta catalog after attach probe.", "error", derr)
 			}
 			slog.Info("Detached Delta catalog: no Delta data at path yet.", "path", catalogPath)
@@ -1751,9 +1779,15 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 		return nil
 	}
 
+	// Per-step deadlines: a stalled Lakekeeper REST endpoint or the IMDS
+	// probe described below fails fast at the step boundary instead of
+	// silently eating the control plane's activate-tenant deadline (and the
+	// activation's drain token, which would pin a retiring worker pod for the
+	// full drain window).
+	ae := newAttachStepExecer(db)
 	select {
 	case sem <- struct{}{}:
-		defer func() { <-sem }()
+		defer ae.releaseSem(sem)
 	case <-time.After(30 * time.Second):
 		return fmt.Errorf("timeout waiting for Iceberg catalog attachment lock")
 	}
@@ -1771,9 +1805,10 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 
 	istep("count-catalogs")
 	var count int
-	err := db.QueryRow(
-		"SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = '" + iceberg.CatalogName + "'",
-	).Scan(&count)
+	err := ae.queryRowScan(
+		"SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = '"+iceberg.CatalogName+"'",
+		&count,
+	)
 	if err == nil && count > 0 {
 		return nil
 	}
@@ -1796,7 +1831,7 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 	// discovery and returns in milliseconds (matches the ~120ms observed in
 	// the "both" path on the same image).
 	istep("load-httpfs-extension")
-	if err := LoadExtensions(db, []string{"httpfs"}); err != nil {
+	if err := loadExtensionsWith(ae, []string{"httpfs"}); err != nil {
 		return fmt.Errorf("load httpfs extension: %w", err)
 	}
 
@@ -1807,13 +1842,13 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 	// RefreshIcebergSecret. Skipped if creds absent (e.g. local/dev).
 	if keyID != "" && secret != "" {
 		istep("create-s3-data-secret")
-		if _, err := db.Exec(iceberg.BuildIcebergSecretStmt(ic, keyID, secret, sessionToken)); err != nil {
+		if _, err := ae.Exec(iceberg.BuildIcebergSecretStmt(ic, keyID, secret, sessionToken)); err != nil {
 			return fmt.Errorf("create Lakekeeper S3 data secret: %w", err)
 		}
 	}
 
 	istep("load-iceberg-extension")
-	if err := LoadExtensions(db, []string{"iceberg"}); err != nil {
+	if err := loadExtensionsWith(ae, []string{"iceberg"}); err != nil {
 		return fmt.Errorf("load iceberg extension: %w", err)
 	}
 
@@ -1821,7 +1856,7 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 	// the ATTACH uses AUTHORIZATION_TYPE 'none' and no catalog secret.
 	if stmt := iceberg.BuildLakekeeperSecretStmt(ic); stmt != "" {
 		istep("create-catalog-auth-secret")
-		if _, err := db.Exec(stmt); err != nil {
+		if _, err := ae.Exec(stmt); err != nil {
 			return fmt.Errorf("create Lakekeeper iceberg secret: %w", err)
 		}
 	}
@@ -1833,7 +1868,7 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 		"endpoint", ic.LakekeeperEndpoint,
 		"warehouse", ic.LakekeeperWarehouse,
 		"oauth2", ic.LakekeeperOAuth2ServerURI != "")
-	if _, err := db.Exec(attachStmt); err != nil {
+	if _, err := ae.execTimeout(attachStatementTimeout, attachStmt); err != nil {
 		if isIcebergCatalogEmptyError(err) {
 			slog.Info("Skipping Iceberg catalog attach: Lakekeeper warehouse has no namespaces yet.", "warehouse", ic.LakekeeperWarehouse)
 			return nil
@@ -1851,7 +1886,7 @@ func attachLakekeeperCatalog(db *sql.DB, ic IcebergConfig, sem chan struct{}, ke
 	// attached catalog without it still works via explicit schema references,
 	// so a transient failure here must not fail activation.
 	istep("create-default-schema")
-	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + iceberg.CatalogName + "." + iceberg.DefaultSchema); err != nil {
+	if _, err := ae.Exec("CREATE SCHEMA IF NOT EXISTS " + iceberg.CatalogName + "." + iceberg.DefaultSchema); err != nil {
 		slog.Warn("Failed to ensure default Iceberg schema; catalog attached without it.",
 			"schema", iceberg.DefaultSchema, "warehouse", ic.LakekeeperWarehouse, "error", err)
 	}
@@ -2092,9 +2127,16 @@ func setIcebergDefault(db *sql.DB) error {
 // Note: Caller must hold duckLakeSem to avoid race conditions.
 // See: https://duckdb.org/docs/stable/core_extensions/httpfs/s3api
 func createS3Secret(db *sql.DB, dlCfg DuckLakeConfig) error {
+	return createS3SecretWith(plainAttachRunner{db: db}, dlCfg)
+}
+
+// createS3SecretWith is createS3Secret over an attachSQLRunner so the
+// catalog-attachment paths can run the secret check + CREATE SECRET under
+// per-step deadlines via attachStepExecer.
+func createS3SecretWith(db attachSQLRunner, dlCfg DuckLakeConfig) error {
 	// Check if secret already exists to avoid unnecessary creation
 	var count int
-	err := db.QueryRow("SELECT COUNT(*) FROM duckdb_secrets() WHERE name = 'ducklake_s3'").Scan(&count)
+	err := db.queryRowScan("SELECT COUNT(*) FROM duckdb_secrets() WHERE name = 'ducklake_s3'", &count)
 	if err == nil && count > 0 {
 		return nil // Secret already exists
 	}
@@ -2107,8 +2149,12 @@ func createS3Secret(db *sql.DB, dlCfg DuckLakeConfig) error {
 	switch provider {
 	case "aws_sdk":
 		// Use Go AWS SDK to fetch credentials (supports EKS Pod Identity, IRSA, etc.)
+		// Bounded so a hung credential source (e.g. a blackholed IMDS/Pod
+		// Identity endpoint) fails fast instead of stalling the attach.
+		sdkCtx, sdkCancel := context.WithTimeout(context.Background(), attachStepTimeout)
+		defer sdkCancel()
 		var err error
-		secretStmt, err = buildAWSSdkSecret(context.Background(), dlCfg)
+		secretStmt, err = buildAWSSdkSecret(sdkCtx, dlCfg)
 		if err != nil {
 			return fmt.Errorf("aws_sdk credential fetch failed: %w", err)
 		}
@@ -2138,17 +2184,20 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 	if dlCfg.ObjectStore == "" {
 		return nil
 	}
+	ae := newAttachStepExecer(db)
 	if duckLakeSem != nil {
 		duckLakeSem <- struct{}{}
-		defer func() { <-duckLakeSem }()
+		defer ae.releaseSem(duckLakeSem)
 	}
 
 	provider := S3ProviderForConfig(dlCfg)
 	var secretStmt string
 	switch provider {
 	case "aws_sdk":
+		sdkCtx, sdkCancel := context.WithTimeout(context.Background(), attachStepTimeout)
+		defer sdkCancel()
 		var err error
-		secretStmt, err = buildAWSSdkSecret(context.Background(), dlCfg)
+		secretStmt, err = buildAWSSdkSecret(sdkCtx, dlCfg)
 		if err != nil {
 			return fmt.Errorf("refresh aws_sdk S3 secret: %w", err)
 		}
@@ -2161,10 +2210,10 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 	// If the previous session left the connection in DuckDB's "Current
 	// transaction is aborted" state, the exec will always fail. Issue a
 	// ROLLBACK to recover, matching the pattern in StartCredentialRefresh.
-	if _, err := db.Exec(secretStmt); err != nil {
+	if _, err := ae.Exec(secretStmt); err != nil {
 		if isTransactionAborted(err) {
-			_, _ = db.Exec("ROLLBACK")
-			if _, retryErr := db.Exec(secretStmt); retryErr != nil {
+			_, _ = ae.Exec("ROLLBACK")
+			if _, retryErr := ae.Exec(secretStmt); retryErr != nil {
 				return fmt.Errorf("refresh S3 secret after rollback: %w", retryErr)
 			}
 		} else {
@@ -2205,16 +2254,17 @@ func RefreshIcebergSecret(db *sql.DB, ic IcebergConfig, sem chan struct{}, keyID
 	if keyID == "" || secretKey == "" {
 		return fmt.Errorf("iceberg refresh: no AWS credentials in activation payload — control plane STS broker did not populate DuckLake S3 credentials")
 	}
+	ae := newAttachStepExecer(db)
 	if sem != nil {
 		sem <- struct{}{}
-		defer func() { <-sem }()
+		defer ae.releaseSem(sem)
 	}
 
 	secretStmt := iceberg.BuildIcebergSecretStmt(ic, keyID, secretKey, sessionToken)
-	if _, err := db.Exec(secretStmt); err != nil {
+	if _, err := ae.Exec(secretStmt); err != nil {
 		if isTransactionAborted(err) {
-			_, _ = db.Exec("ROLLBACK")
-			if _, retryErr := db.Exec(secretStmt); retryErr != nil {
+			_, _ = ae.Exec("ROLLBACK")
+			if _, retryErr := ae.Exec(secretStmt); retryErr != nil {
 				return fmt.Errorf("refresh iceberg secret after rollback: %w", retryErr)
 			}
 		} else {


### PR DESCRIPTION
## Problem

Worker activation runs `AttachDuckLake`, `AttachDeltaCatalog`, `attachLakekeeperCatalog`, `RefreshS3Secret`, and `RefreshIcebergSecret` via plain `db.Exec`/`db.QueryRow` with **no timeout**. When a network dependency inside DuckDB hangs — unreachable Lakekeeper REST endpoint, a blackholed S3 connect, the IMDS probe documented at `attachLakekeeperCatalog`, a wedged metadata Postgres — two bad things happen:

1. **Silent 60s burn, customer-facing**: the hung CGO call eats the control plane's entire activate-tenant deadline (~60s) with zero Go-level logging. The client sees a bootstrap stall and then an opaque deadline error with nothing attributing which step hung.
2. **Drain-token pinning, cost-facing**: the activation holds a drain token (`beginDrainWork` in `duckdbservice/flight_handler.go::doActivateTenant`). A retiring worker pod whose attach is hung stays `Draining` for up to `workerShutdownDrainTime` (55m), pinning a warm EC2 node the whole time.

## Fix

New `attachStepExecer` (`server/attach_timeout.go`); every statement in the five functions above now runs under a per-step deadline:

| const | value | covers |
|---|---|---|
| `attachStepTimeout` | 30s | extension INSTALL/LOAD, CREATE SECRET, presence checks, SET, default-schema CREATE, Go-side AWS SDK credential fetch |
| `attachStatementTimeout` | 60s | the ATTACH statements + Delta post-attach probe (deliberately loose: DuckLake ATTACH on a busy metadata Postgres can take tens of seconds) |
| `attachMigrateStatementTimeout` | 15m | DuckLake ATTACH with `AUTOMATIC_MIGRATION TRUE` (rewrites metadata tables, legitimately minutes) |

### Does the driver actually interrupt CGO?

Partially — verified in `duckdb-go/v2@v2.10503.0` source (`context.go::runWithCtxInterrupt`): `ExecContext`/`QueryContext` spawn an interrupter goroutine that re-asserts `duckdb_interrupt` every 500ms after ctx cancellation. That **does** stop any statement that reaches a query-execution checkpoint (empirically confirmed by `TestAttachStepExecerInterruptsLongQuery`: a minutes-long cross join returns in <1s under a 300ms deadline against a real DuckDB). But `ExecContext` still blocks until the CGO call returns, and a statement stuck in non-interruptible extension network I/O (TCP connect in httpfs / Lakekeeper REST / IMDS) never observes the flag.

So the helper layers both: ctx deadline (driver interrupt, the common case) **plus a watchdog wall** at deadline+5s grace. On wall expiry the caller gets an immediate error naming the statement, an ERROR log is emitted, and the goroutine is abandoned — and crucially the **duckLakeSem is not leaked**: `releaseSem` holds the slot until the abandoned call actually returns (a second attach must never race a wedged connection). If it never returns, later attaches fail fast on the pre-existing 30s "waiting for attachment lock" timeout instead of hanging.

### Semantics preserved

- Fail-soft paths: Delta/Iceberg empty-catalog handling (`isDeltaCatalogEmptyError`, `isIcebergCatalogEmptyError`), best-effort default-schema CREATE, warn-only SET statements.
- `istep` step instrumentation in `attachLakekeeperCatalog` (timeout errors now also name the step's statement).
- Sem acquisition with its existing 30s timeout; blocking acquire in the refreshers.
- Transaction-aborted ROLLBACK retry in `RefreshS3Secret`/`RefreshIcebergSecret`; `retryOnTransientAttach` loop (a timeout is not classified transient, so it fails fast rather than retrying for minutes).
- Non-attach callers of `createS3Secret`/`LoadExtensions`/`applyDuckLakePreAttachSettings` (checkpoint, querylog, exports) keep unbounded behavior via the plain `*sql.DB` adapters.

## Testing

- `go test ./server/...` green (CGO, real DuckDB). New tests:
  - `TestAttachStepExecerInterruptsLongQuery` — real long-running DuckDB statement is actually stopped at the deadline.
  - `TestAttachStepExecerWatchdogAbandonsHungCall` — non-interruptible call: error at timeout+grace, sem held until the call finishes, released after.
  - `TestAttachStepExecerFastStatement`, `TestSummarizeAttachStmt` (no credential leakage in logs/errors), nil-sem no-op.
- `go vet ./...` (incl. `-tags kubernetes`) clean; `gofmt -l` clean for changed files (the repo-wide `gofmt -l` noise is pre-existing go1.25/go1.26 formatter drift on untouched files).
- `go test ./...`: all packages green except `tests/integration`, which fails identically on pristine `main` on this machine (stale local MinIO 403 on fixture load — environmental, unrelated).

## e2e-mw-dev note (per CLAUDE.md escape hatch)

This change touches `server.AttachDeltaCatalog` / `AttachIcebergCatalog` / `attachDuckLake*` / `Refresh*Secret`, which the harness's DuckLake round-trip and iceberg activation assertions already exercise — the happy path is behavior-identical (deadlines only bite on hangs) so those load-bearing checks continue to cover it. The *new* behavior (a hung Lakekeeper/S3/metadata dependency failing fast) **cannot be asserted in-Job**: it would require injecting a network hang into a real worker pod's egress (blackholing Lakekeeper/S3/IMDS mid-activation), which the harness Job has no mechanism for. No harness changes in this PR for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)