### PR TITLE
perf(controlplane): parallelize cold-burst worker ramp + detach spawn/activate lifetime from the requester

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,14 +186,24 @@ a heavy query killed by a co-resident one. Do not break the following:
   mode). Do NOT add one, and do not resurrect a `leastLoaded*` helper here.
 - **At org max workers + all busy → fail fast with the clear org-cap message**
   (`WorkerClaimMissReasonOrgCap`, see `capacity_policy.go`). Never busy-wait at cap.
-- **Under cap → spawn a worker on demand** (`spawnReservedWorker`, bounded by the
-  client ctx). There is no warm pool to wait on; the cap is re-checked
-  authoritatively cross-CP in `CreateSpawningWorkerSlot`.
-- **FIFO anti-snatch:** the slow acquisition path is serialized per org by
-  `orgAcquireGate` (`org_acquire_gate.go`) so a worker the CP scaled up for an
-  earlier waiter cannot be snatched by a later connection. Keep the gate
-  cancel-safe (a queued waiter whose ctx is cancelled must be skipped, not
-  deadlock the gate).
+- **Under cap → spawn a worker on demand** (`spawnReservedWorkerForSlot`). There
+  is no warm pool to wait on; the cap is re-checked authoritatively cross-CP in
+  `CreateSpawningWorkerSlot`. The spawn+activate runs DETACHED from the request
+  ctx (`context.WithoutCancel` + `workerSpawnActivateTimeout`): the requester
+  waits for the result or its own ctx, but a requester that gives up must NOT
+  kill the in-flight pod (doomed-spawn thrash). An abandoned spawn that succeeds
+  is parked hot-idle (`ReleaseWorker`/`TransitionToHotIdleIfNoSessions`, record
+  persisted) for the org's next connection; one that fails is retired. Nothing
+  may leak in Reserved/Activating.
+- **FIFO anti-snatch:** the slow acquisition path's DECISION section (idle-reuse
+  re-check → hot-idle claim → spawning-slot creation; `acquireDecision` in
+  `org_reserved_pool.go`) is serialized per org by `orgAcquireGate`
+  (`org_acquire_gate.go`) so a worker the CP scaled up for an earlier waiter
+  cannot be snatched by a later connection. The multi-minute spawn+activate runs
+  OUTSIDE the gate — each waiter is 1:1 bound to the claim/slot it owns and the
+  session is pre-claimed before the worker becomes Hot, so a cold burst ramps N
+  spawns in parallel without breaking anti-snatch. Keep the gate cancel-safe (a
+  queued waiter whose ctx is cancelled must be skipped, not deadlock the gate).
 - **Destroy-before-reuse ordering:** `SessionManager.DestroySession`
   (`session_mgr.go`) MUST await the worker-side `DestroySession` RPC *before*
   `ReleaseWorker`, so a reused (hot-idle) worker's prior session is gone before
@@ -212,8 +222,8 @@ Touching any of: `controlplane/org_reserved_pool.go`, `org_acquire_gate.go`,
 `k8s_pool.go::spawnWorker`/`AcquireWorker`, `control.go::workerDuckDBLimits`, or
 `duckdbservice` session counting → update the unit tests
 (`org_reserved_pool_test.go`, `org_acquire_gate_test.go`,
-`duckdbservice/service_test.go`) AND the `one_session_per_worker` assertion in
-`tests/e2e-mw-dev/harness.sh`.
+`duckdbservice/service_test.go`) AND the `one_session_per_worker` +
+`cold_burst_parallel_spawns` assertions in `tests/e2e-mw-dev/harness.sh`.
 
 ## Worker Drain Protocol (graceful shutdown, #690)
 

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -30,6 +30,17 @@ const defaultActivatingTimeout = 2 * time.Minute
 // generous.
 const workerPodReadyTimeout = 5 * time.Minute
 
+// workerSpawnActivateTimeout bounds the DETACHED background spawn+activate run
+// for an org cold acquisition (OrgReservedPool.AcquireWorker slow path). The
+// spawn and activation deliberately do NOT run on the requester's ctx: if node
+// provisioning reliably exceeds the client's worker-queue budget, cancelling
+// the wait would delete the in-flight pod and every retry would spawn-wait-
+// delete a fresh one without ever converging (doomed-spawn thrash). Budget =
+// pod-ready wait (workerPodReadyTimeout, may include a Karpenter node
+// provision) + gRPC connect (up to 90s) + tenant activation (ATTACH against
+// cloud storage, defaultActivatingTimeout-scale).
+const workerSpawnActivateTimeout = workerPodReadyTimeout + 3*time.Minute
+
 const workerTerminationGracePeriodSeconds int64 = 3600
 
 var errStaleRuntimeWorkerClaim = stderrors.New("stale runtime worker claim")

--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -219,11 +219,10 @@ func (p *K8sWorkerPool) ActivateReservedWorker(ctx context.Context, worker *Mana
 }
 
 // ReserveSharedWorker reserves a neutral warm worker for later tenant activation.
+// Composition of the gateable decision (reserveSharedWorkerDecision) and the slow
+// completion (completeSharedWorkerReservation); OrgReservedPool calls the two
+// halves separately so the per-org FIFO gate covers only the decision.
 func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *WorkerAssignment) (*ManagedWorker, error) {
-	if err := validateWorkerAssignment(assignment); err != nil {
-		return nil, err
-	}
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -231,72 +230,129 @@ func (p *K8sWorkerPool) ReserveSharedWorker(ctx context.Context, assignment *Wor
 		default:
 		}
 
-		if p.runtimeStore != nil {
-			// Try reclaiming a hot-idle worker for the same org first (fast path:
-			// DuckLake is already attached, only needs epoch bump).
-			if assignment.OrgID != "" {
-				hotProfileCPU, hotProfileMem := assignment.Profile.Parts()
-				hotClaimed, hotMissReason, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID, hotProfileCPU, hotProfileMem, assignment.MaxWorkers)
-				if err != nil {
-					return nil, err
-				}
-				if hotClaimed == nil && hotMissReason != configstore.WorkerClaimMissReasonNone && hotMissReason != configstore.WorkerClaimMissReasonNoIdle {
-					return nil, NewWorkerCapacityExhaustedErrorForReason(hotMissReason, DefaultWorkerSpawnRetryAfter)
-				}
-				if hotClaimed != nil {
-					// ClaimHotIdleWorker already filters by profile, so a reclaimed
-					// hot-idle worker always matches the requested shape. It is NOT
-					// filtered by image, so still retire on a version mismatch (e.g.
-					// after an image bump) rather than serve a stale-version worker.
-					if assignment.Image != "" && hotClaimed.Image != assignment.Image {
-						slog.Info("Hot-idle worker image mismatch, retiring mismatched worker.", "worker_id", hotClaimed.WorkerID, "expected", assignment.Image, "got", hotClaimed.Image)
-						p.retireClaimedWorker(hotClaimed, RetireReasonMismatchedVersion, LifecycleOriginReserveImageMismatch)
-						// Fall through to neutral idle claim or capacity backpressure.
-					} else {
-						worker, reserveErr := p.reserveClaimedWorker(ctx, hotClaimed, assignment)
-						if reserveErr == nil {
-							worker.hotIdleReclaimed = true
-							return worker, nil
-						}
-						if stderrors.Is(reserveErr, errStaleRuntimeWorkerClaim) {
-							slog.Warn("Hot-idle worker claim was stale, retrying.", "worker_id", hotClaimed.WorkerID, "error", reserveErr)
-							continue
-						}
-						slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", hotClaimed.WorkerID, "error", reserveErr)
-						p.retireClaimedWorker(hotClaimed, RetireReasonCrash, LifecycleOriginReserveFailure)
-						// Fall through to neutral idle claim.
-					}
-				}
-			}
-
-			// No reusable hot-idle worker for this org — spawn one on demand,
-			// sized from the request profile (or the pool-global default for a
-			// default request). spawnReservedWorker enforces the per-org + global
-			// caps via CreateSpawningWorkerSlot and returns the cap error at the
-			// ceiling.
-			worker, spawnErr := p.spawnReservedWorker(ctx, assignment)
-			if spawnErr != nil {
-				return nil, spawnErr
-			}
-			return worker, nil
+		claim, err := p.reserveSharedWorkerDecision(assignment)
+		if err != nil {
+			return nil, err
 		}
-
-		// Runtime-store-less mode (unit tests / standalone k8s): no durable pool,
-		// just spawn a worker on demand.
-		p.mu.Lock()
-		if p.shuttingDown {
-			p.mu.Unlock()
-			return nil, fmt.Errorf("pool is shutting down")
+		worker, retry, err := p.completeSharedWorkerReservation(ctx, claim, assignment)
+		if retry {
+			continue
 		}
-		p.cleanDeadWorkersLocked()
-		p.mu.Unlock()
-
-		worker, spawnErr := p.spawnReservedWorker(ctx, assignment)
-		if spawnErr != nil {
-			return nil, spawnErr
+		if err != nil {
+			return nil, err
 		}
 		return worker, nil
 	}
+}
+
+// sharedWorkerClaim is the outcome of the short reservation decision: either a
+// hot-idle worker claimed in the runtime store (hotClaimed != nil) or a freshly
+// created spawning slot id (hotClaimed == nil). Either way the claim/slot is
+// already bound to the caller in the durable store (or locally allocated in
+// runtime-store-less mode), so the caller may finish the multi-minute
+// completion without holding any per-org serialization.
+type sharedWorkerClaim struct {
+	hotClaimed *configstore.WorkerRecord
+	slotID     int
+}
+
+// reserveSharedWorkerDecision is the short, DB-only half of ReserveSharedWorker:
+// claim a hot-idle worker for the org (fast path: DuckLake is already attached,
+// only needs an epoch bump) or create a spawning worker slot.
+// CreateSpawningWorkerSlot re-checks the per-org and global caps transactionally
+// cross-CP (authoritative) and yields the reason-specific cap error at the
+// ceiling. No pod I/O happens here — OrgReservedPool holds its FIFO acquire gate
+// across exactly this call.
+func (p *K8sWorkerPool) reserveSharedWorkerDecision(assignment *WorkerAssignment) (*sharedWorkerClaim, error) {
+	if err := validateWorkerAssignment(assignment); err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	if p.shuttingDown {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("pool is shutting down")
+	}
+	p.cleanDeadWorkersLocked()
+	maxGlobal := p.maxWorkers
+	p.mu.Unlock()
+
+	if p.runtimeStore != nil && assignment.OrgID != "" {
+		hotProfileCPU, hotProfileMem := assignment.Profile.Parts()
+		hotClaimed, hotMissReason, err := p.runtimeStore.ClaimHotIdleWorker(p.cpInstanceID, assignment.OrgID, hotProfileCPU, hotProfileMem, assignment.MaxWorkers)
+		if err != nil {
+			return nil, err
+		}
+		if hotClaimed == nil && hotMissReason != configstore.WorkerClaimMissReasonNone && hotMissReason != configstore.WorkerClaimMissReasonNoIdle {
+			return nil, NewWorkerCapacityExhaustedErrorForReason(hotMissReason, DefaultWorkerSpawnRetryAfter)
+		}
+		if hotClaimed != nil {
+			// ClaimHotIdleWorker already filters by profile, so a reclaimed
+			// hot-idle worker always matches the requested shape. It is NOT
+			// filtered by image, so still retire on a version mismatch (e.g.
+			// after an image bump) rather than serve a stale-version worker.
+			if assignment.Image != "" && hotClaimed.Image != assignment.Image {
+				slog.Info("Hot-idle worker image mismatch, retiring mismatched worker.", "worker_id", hotClaimed.WorkerID, "expected", assignment.Image, "got", hotClaimed.Image)
+				p.retireClaimedWorker(hotClaimed, RetireReasonMismatchedVersion, LifecycleOriginReserveImageMismatch)
+				// Fall through to the spawning-slot decision or capacity backpressure.
+			} else {
+				return &sharedWorkerClaim{hotClaimed: hotClaimed}, nil
+			}
+		}
+	}
+
+	// No reusable hot-idle worker for this org — spawn one on demand, sized from
+	// the request profile (or the pool-global default for a default request).
+	// Allocate a real, unique worker id. In the runtime-store path this MUST come
+	// from the DB via CreateSpawningWorkerSlot (which also enforces the per-org and
+	// global worker caps cross-CP and returns a nil slot when capped) — the
+	// background id allocator returns a placeholder 0 that collides across spawns.
+	if p.runtimeStore != nil {
+		slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
+			p.cpInstanceID, assignment.OrgID, assignment.Image, 0,
+			p.workerPodNamePrefix(), assignment.MaxWorkers, maxGlobal)
+		if err != nil {
+			return nil, err
+		}
+		if slot == nil {
+			return nil, NewWorkerCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWorkerSpawnRetryAfter)
+		}
+		return &sharedWorkerClaim{slotID: slot.WorkerID}, nil
+	}
+
+	// Runtime-store-less mode (unit tests / standalone k8s): no durable pool,
+	// just allocate a local id and spawn a worker on demand.
+	p.mu.Lock()
+	id := p.allocateWorkerIDLocked()
+	p.mu.Unlock()
+	return &sharedWorkerClaim{slotID: id}, nil
+}
+
+// completeSharedWorkerReservation is the slow half of ReserveSharedWorker:
+// adopt/health-check a claimed hot-idle worker, or spawn the slot's pod and
+// reserve it. Runs without any per-org serialization — the claim/slot already
+// belongs to this caller. retry=true means the claim went stale or the hot-idle
+// worker was unusable (and has been retired); the caller should re-run the
+// decision (which will typically create a spawning slot).
+func (p *K8sWorkerPool) completeSharedWorkerReservation(ctx context.Context, claim *sharedWorkerClaim, assignment *WorkerAssignment) (worker *ManagedWorker, retry bool, err error) {
+	if claim.hotClaimed != nil {
+		worker, reserveErr := p.reserveClaimedWorker(ctx, claim.hotClaimed, assignment)
+		if reserveErr == nil {
+			worker.hotIdleReclaimed = true
+			return worker, false, nil
+		}
+		if stderrors.Is(reserveErr, errStaleRuntimeWorkerClaim) {
+			slog.Warn("Hot-idle worker claim was stale, retrying.", "worker_id", claim.hotClaimed.WorkerID, "error", reserveErr)
+			return nil, true, reserveErr
+		}
+		slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", claim.hotClaimed.WorkerID, "error", reserveErr)
+		p.retireClaimedWorker(claim.hotClaimed, RetireReasonCrash, LifecycleOriginReserveFailure)
+		// Pre-split ReserveSharedWorker fell through to a fresh spawn here; the
+		// retry re-runs the decision, which lands on the spawning-slot path.
+		return nil, true, reserveErr
+	}
+	worker, err = p.spawnReservedWorkerForSlot(ctx, claim.slotID, assignment)
+	return worker, false, err
 }
 
 func (p *K8sWorkerPool) reserveClaimedWorker(ctx context.Context, claimed *configstore.WorkerRecord, assignment *WorkerAssignment) (*ManagedWorker, error) {

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -551,16 +551,18 @@ func (p *K8sWorkerPool) spawnWorkerBackground(id int, image string) {
 	}
 }
 
-// spawnReservedWorker foreground-spawns a worker for the org and reserves it,
-// returning it in Reserved state (the caller activates it, same as a claimed
+// spawnReservedWorkerForSlot foreground-spawns the pod for an already-allocated
+// spawning slot (see reserveSharedWorkerDecision, which created the slot and
+// enforced the per-org + global caps via CreateSpawningWorkerSlot) and reserves
+// it, returning it in Reserved state (the caller activates it, same as a claimed
 // worker). This is the only spawn path now that the warm pool is gone: a request
 // either reuses a hot-idle worker (claim) or spawns one here. The pod is sized
 // from the request profile, or the pool-global default for a default (nil
 // profile) request (workerResourcesForProfile); the reserved record round-trips
 // the profile + TTL.
-func (p *K8sWorkerPool) spawnReservedWorker(ctx context.Context, assignment *WorkerAssignment) (*ManagedWorker, error) {
+func (p *K8sWorkerPool) spawnReservedWorkerForSlot(ctx context.Context, id int, assignment *WorkerAssignment) (*ManagedWorker, error) {
 	if assignment == nil {
-		return nil, fmt.Errorf("spawnReservedWorker requires an assignment")
+		return nil, fmt.Errorf("spawnReservedWorkerForSlot requires an assignment")
 	}
 	// A default (nil profile) request spawns a default-sized worker: the zero
 	// profile makes workerResourcesForProfile fall back to the pool-global request.
@@ -572,34 +574,10 @@ func (p *K8sWorkerPool) spawnReservedWorker(ctx context.Context, assignment *Wor
 	p.mu.Lock()
 	if p.shuttingDown {
 		p.mu.Unlock()
+		// The slot row (if any) stays in spawning state; the janitor's
+		// stale-spawning sweep reconciles it, same as a failed spawn below.
 		return nil, fmt.Errorf("pool is shutting down")
 	}
-	maxGlobal := p.maxWorkers
-	p.mu.Unlock()
-
-	// Allocate a real, unique worker id. In the runtime-store path this MUST come
-	// from the DB via CreateSpawningWorkerSlot (which also enforces the per-org and
-	// global worker caps cross-CP and returns a nil slot when capped) — the
-	// background id allocator returns a placeholder 0 that collides across spawns.
-	var id int
-	if p.runtimeStore != nil {
-		slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
-			p.cpInstanceID, assignment.OrgID, assignment.Image, 0,
-			p.workerPodNamePrefix(), assignment.MaxWorkers, maxGlobal)
-		if err != nil {
-			return nil, err
-		}
-		if slot == nil {
-			return nil, NewWorkerCapacityExhaustedErrorForReason(configstore.WorkerClaimMissReasonOrgCap, DefaultWorkerSpawnRetryAfter)
-		}
-		id = slot.WorkerID
-	} else {
-		p.mu.Lock()
-		id = p.allocateWorkerIDLocked()
-		p.mu.Unlock()
-	}
-
-	p.mu.Lock()
 	p.spawning++
 	p.mu.Unlock()
 	err := p.spawnWorker(ctx, id, assignment.Image, profile, false)

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1617,8 +1617,18 @@ func TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost(t *testing.T) {
 	if _, ok := pool.Worker(worker.ID); ok {
 		t.Fatal("expected already-lost current lease to remove local worker")
 	}
-	if got := podDeleteActionNames(cs); len(got) != 1 || got[0] != "test-cp-worker-13" {
-		t.Fatalf("expected already-lost current lease to delete pod, got %v", got)
+	// The pod delete runs on a background goroutine after the crash
+	// notification; poll for it (pre-existing flake under -race).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got := podDeleteActionNames(cs)
+		if len(got) == 1 && got[0] == "test-cp-worker-13" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected already-lost current lease to delete pod, got %v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -2809,21 +2819,35 @@ func TestK8sPoolRetireWorkerUsesTrackedPodName(t *testing.T) {
 	}
 	pool.workers[worker.ID] = worker
 
+	// The pod delete happens on retireWorkerWithReason's background goroutine, so
+	// the captured name must be read under a lock (pre-existing -race flake).
+	var mu sync.Mutex
 	var deletedPodName string
 	cs.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		deleteAction, ok := action.(k8stesting.DeleteAction)
 		if !ok {
 			return false, nil, nil
 		}
+		mu.Lock()
 		deletedPodName = deleteAction.GetName()
+		mu.Unlock()
 		return false, nil, nil
 	})
 
 	pool.RetireWorker(worker.ID)
-	time.Sleep(100 * time.Millisecond)
 
-	if deletedPodName != "duckgres-worker-other-cp-11" {
-		t.Fatalf("expected retire to delete tracked pod name duckgres-worker-other-cp-11, got %q", deletedPodName)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		got := deletedPodName
+		mu.Unlock()
+		if got == "duckgres-worker-other-cp-11" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected retire to delete tracked pod name duckgres-worker-other-cp-11, got %q", got)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -230,9 +230,16 @@ func (p *OrgReservedPool) executeAcquire(ctx context.Context, claim *sharedWorke
 
 	p.shared.mu.Lock()
 	owned := p.workerBelongsToOrgLocked(worker)
+	if !owned {
+		// Worker is no longer ours (raced with retirement/reclaim). Undo the
+		// pre-claim before re-deciding: if this CP still tracks the worker, a
+		// stranded activeSessions=1 would make findIdleAssignedWorkerLocked and
+		// TransitionToHotIdleIfNoSessions skip it forever (fail-safe direction,
+		// but the worker leaks until a TTL reaper retires it).
+		worker.activeSessions--
+	}
 	p.shared.mu.Unlock()
 	if !owned {
-		// Worker is no longer ours (raced with retirement/reclaim); re-decide.
 		return orgAcquireOutcome{retry: true}
 	}
 	return orgAcquireOutcome{worker: worker}

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -21,9 +21,12 @@ type OrgReservedPool struct {
 	image                  string
 	stsBroker              *STSBroker
 	activateReservedWorker func(context.Context, *ManagedWorker) error
-	// gate serializes the slow acquisition path (no idle worker → claim/spawn) in
+	// gate serializes the slow path's short DECISION section (re-check idle
+	// reuse → hot-idle claim → spawning-slot creation; see acquireDecision) in
 	// FIFO arrival order, so the next worker to become available goes to the
-	// earliest waiting connection and a later one cannot snatch it.
+	// earliest waiting connection and a later one cannot snatch it. The
+	// multi-minute spawn+activate runs OUTSIDE the gate, 1:1 bound to the
+	// waiter that owns the claim, so a cold burst ramps spawns in parallel.
 	gate *orgAcquireGate
 }
 
@@ -50,21 +53,7 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 		return w, nil
 	}
 
-	// Slow path: no idle worker — we must claim a warm worker or wait for one to
-	// spawn. Serialize per org in FIFO arrival order so the next worker to become
-	// available is handed to the EARLIEST waiting connection; a later-arriving
-	// connection cannot snatch a worker the control plane scaled up for someone
-	// already waiting. Bounded by the request ctx.
-	//
-	// NOTE: while one waiter holds the gate and waits for its spawn, queued
-	// waiters do not yet trigger their own spawn, so a large cold burst ramps
-	// roughly sequentially. Correctness (anti-snatch + clear cap errors) is the
-	// priority here; parallelizing the cold-burst ramp is a perf follow-up.
-	if err := p.gate.acquire(ctx); err != nil {
-		return nil, err
-	}
-	defer p.gate.release()
-
+	// Slow path: no idle worker — claim a hot-idle worker or spawn one on demand.
 	for {
 		select {
 		case <-ctx.Done():
@@ -72,60 +61,181 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 		default:
 		}
 
-		// A worker may have freed while we waited for our FIFO turn.
-		if w := p.tryReuseIdleAssigned(profile); w != nil {
-			return w, nil
-		}
-
-		p.shared.mu.Lock()
-		if p.shared.shuttingDown {
-			p.shared.mu.Unlock()
-			return nil, fmt.Errorf("pool is shutting down")
-		}
-		maxWorkers := p.maxWorkers
-		image := p.image
-		p.shared.mu.Unlock()
-
-		// At the org's max concurrent workers with all busy → fail fast with the
-		// clear org-cap message; waiting cannot help (no new worker will spawn).
-		if p.atOrgWorkerCap() {
-			return nil, NewWorkerCapacityExhaustedErrorForReason(
-				configstore.WorkerClaimMissReasonOrgCap, DefaultWorkerSpawnRetryAfter)
-		}
-
-		// Under cap: reuse a hot-idle worker for this org, or spawn one on demand.
-		// ReserveSharedWorker re-checks the org/global cap authoritatively
-		// (CreateSpawningWorkerSlot, cross-CP) and returns the reason-specific cap
-		// error; an org/global-cap or shutdown error won't resolve by waiting.
-		worker, err := p.shared.ReserveSharedWorker(ctx, &WorkerAssignment{
-			OrgID:      p.orgID,
-			MaxWorkers: maxWorkers,
-			Image:      image,
-			Profile:    profile,
-		})
+		claim, assignment, worker, err := p.acquireDecision(ctx, profile)
 		if err != nil {
 			return nil, err
 		}
-
-		if err := p.activateWorkerForOrg(ctx, worker); err != nil {
-			slog.Warn("Worker activation failed.", "worker", worker.ID, "org", p.orgID, "error", err)
-			observeActivationFailure(worker.image)
-			p.shared.retireWorkerWithReason(worker.ID, RetireReasonActivationFailure, LifecycleOriginActivationFailure)
-			return nil, err
+		if worker != nil {
+			return worker, nil // reused an idle worker that freed while queued
 		}
 
-		p.shared.mu.Lock()
-		if owned := p.workerBelongsToOrgLocked(worker); owned {
-			worker.activeSessions++
-			if worker.activeSessions > worker.peakSessions {
-				worker.peakSessions = worker.activeSessions
-			}
-			p.shared.mu.Unlock()
-			return worker, nil
+		// Execute the multi-minute spawn/adopt + activate OUTSIDE the gate (so a
+		// cold burst of N waiters ramps N spawns in parallel instead of
+		// sequentially) and DETACHED from the request ctx (so a requester that
+		// gives up doesn't kill an in-flight pod spawn).
+		out := p.completeAcquireBoundToRequester(ctx, claim, assignment)
+		if out.retry {
+			// Stale hot-idle claim or the worker stopped being ours mid-flight
+			// (raced with retirement/reclaim); re-run the gated decision.
+			continue
 		}
-		p.shared.mu.Unlock()
-		// Worker is no longer ours (raced with retirement/reclaim); try again.
+		if out.err != nil {
+			return nil, out.err
+		}
+		return out.worker, nil
 	}
+}
+
+// acquireDecision is the short, gate-held decision section of the slow path:
+// re-check idle reuse, then claim a hot-idle worker or create a spawning slot
+// (reserveSharedWorkerDecision). Returns exactly one of: an idle worker reused
+// while queued, or the claim this waiter now owns.
+//
+// The gate serializes per org in FIFO arrival order, but is held ONLY across
+// this decision — not across the multi-minute spawn+activate. The anti-snatch
+// invariant ("a worker the CP scaled up for an earlier waiter cannot be
+// snatched by a later connection") is preserved without holding the gate
+// longer: each slow-path waiter leaves the gate 1:1 bound to the specific
+// hot-idle claim or spawning slot it owns (the durable claim/slot row is
+// already assigned to it), and the spawned worker's session is pre-claimed
+// before it ever becomes visible as Hot (executeAcquire), so no later
+// connection can grab it. Freed/parked workers re-enter circulation only via
+// the idle-reuse re-check and the hot-idle claim inside this gated section,
+// which queued waiters reach in FIFO order — the earliest waiter still gets
+// the next available worker.
+func (p *OrgReservedPool) acquireDecision(ctx context.Context, profile *WorkerProfile) (*sharedWorkerClaim, *WorkerAssignment, *ManagedWorker, error) {
+	if err := p.gate.acquire(ctx); err != nil {
+		return nil, nil, nil, err
+	}
+	defer p.gate.release()
+
+	// A worker may have freed while we waited for our FIFO turn.
+	if w := p.tryReuseIdleAssigned(profile); w != nil {
+		return nil, nil, w, nil
+	}
+
+	p.shared.mu.Lock()
+	if p.shared.shuttingDown {
+		p.shared.mu.Unlock()
+		return nil, nil, nil, fmt.Errorf("pool is shutting down")
+	}
+	maxWorkers := p.maxWorkers
+	image := p.image
+	p.shared.mu.Unlock()
+
+	// At the org's max concurrent workers with all busy → fail fast with the
+	// clear org-cap message; waiting cannot help (no new worker will spawn).
+	// This in-memory pre-check is the fast-fail; the authoritative cross-CP cap
+	// re-check happens transactionally in CreateSpawningWorkerSlot below.
+	if p.atOrgWorkerCap() {
+		return nil, nil, nil, NewWorkerCapacityExhaustedErrorForReason(
+			configstore.WorkerClaimMissReasonOrgCap, DefaultWorkerSpawnRetryAfter)
+	}
+
+	// Under cap: claim a hot-idle worker for this org, or create a spawning
+	// slot. reserveSharedWorkerDecision re-checks the org/global cap
+	// authoritatively (CreateSpawningWorkerSlot, cross-CP) and returns the
+	// reason-specific cap error; an org/global-cap or shutdown error won't
+	// resolve by waiting.
+	assignment := &WorkerAssignment{
+		OrgID:      p.orgID,
+		MaxWorkers: maxWorkers,
+		Image:      image,
+		Profile:    profile,
+	}
+	claim, err := p.shared.reserveSharedWorkerDecision(assignment)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return claim, assignment, nil, nil
+}
+
+// orgAcquireOutcome is the result of executing a slow-path claim. Exactly one
+// of worker / retry / err is meaningful: a Hot worker with this waiter's
+// session claimed, a request to re-run the gated decision, or a terminal error.
+type orgAcquireOutcome struct {
+	worker *ManagedWorker
+	retry  bool
+	err    error
+}
+
+// completeAcquireBoundToRequester runs the slow spawn/adopt + activation for
+// the claim this waiter owns. The work runs under a context DETACHED from the
+// request (context.WithoutCancel keeps trace/log values) with its own deadline
+// (workerSpawnActivateTimeout): a requester that gives up must not kill an
+// in-flight pod spawn — if node provisioning reliably exceeds the client's
+// budget, a requester-scoped spawn would be deleted on every timeout and the
+// org would never converge on a ready worker. The requester waits for the
+// result or its own ctx, whichever comes first. If the requester abandons:
+//   - eventual success → the worker (Hot, session pre-claimed by executeAcquire)
+//     is parked for the org via ReleaseWorker → TransitionToHotIdleIfNoSessions,
+//     persisting its hot_idle record, so the org's next connection reclaims it
+//     through the normal hot-idle claim path;
+//   - eventual failure → executeAcquire's failure paths have already retired it
+//     (spawn failure / activation failure), so nothing leaks in
+//     Reserved/Activating state.
+func (p *OrgReservedPool) completeAcquireBoundToRequester(ctx context.Context, claim *sharedWorkerClaim, assignment *WorkerAssignment) orgAcquireOutcome {
+	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workerSpawnActivateTimeout)
+	resultCh := make(chan orgAcquireOutcome, 1)
+	go func() {
+		defer cancel()
+		resultCh <- p.executeAcquire(bgCtx, claim, assignment)
+	}()
+
+	select {
+	case out := <-resultCh:
+		return out
+	case <-ctx.Done():
+		// Abandoned: let the spawn/activate finish in the background, then park
+		// the worker for org reuse (failure paths have already retired it).
+		go func() {
+			out := <-resultCh
+			if out.worker == nil {
+				return
+			}
+			slog.Info("Requester abandoned worker spawn/activate; parking worker hot-idle for org reuse.",
+				"worker", out.worker.ID, "org", p.orgID)
+			p.ReleaseWorker(out.worker.ID)
+		}()
+		return orgAcquireOutcome{err: ctx.Err()}
+	}
+}
+
+// executeAcquire completes the reservation (pod spawn or hot-idle adoption)
+// and activates the worker for the org. On success the returned worker is Hot
+// with this waiter's session already claimed: the session is pre-claimed while
+// the worker is still Reserved, before it ever becomes visible as Hot, so a
+// concurrently-arriving connection's idle-reuse fast path can never grab the
+// worker out from under the waiter that spawned it (the 1:1 waiter↔worker
+// binding behind the anti-snatch invariant).
+func (p *OrgReservedPool) executeAcquire(ctx context.Context, claim *sharedWorkerClaim, assignment *WorkerAssignment) orgAcquireOutcome {
+	worker, retry, err := p.shared.completeSharedWorkerReservation(ctx, claim, assignment)
+	if retry {
+		return orgAcquireOutcome{retry: true}
+	}
+	if err != nil {
+		return orgAcquireOutcome{err: err}
+	}
+
+	p.shared.mu.Lock()
+	worker.claimSessionLocked()
+	p.shared.mu.Unlock()
+
+	if err := p.activateWorkerForOrg(ctx, worker); err != nil {
+		slog.Warn("Worker activation failed.", "worker", worker.ID, "org", p.orgID, "error", err)
+		observeActivationFailure(worker.image)
+		p.shared.retireWorkerWithReason(worker.ID, RetireReasonActivationFailure, LifecycleOriginActivationFailure)
+		return orgAcquireOutcome{err: err}
+	}
+
+	p.shared.mu.Lock()
+	owned := p.workerBelongsToOrgLocked(worker)
+	p.shared.mu.Unlock()
+	if !owned {
+		// Worker is no longer ours (raced with retirement/reclaim); re-decide.
+		return orgAcquireOutcome{retry: true}
+	}
+	return orgAcquireOutcome{worker: worker}
 }
 
 // atOrgWorkerCap reports whether the org has reached its maximum concurrent

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -5,6 +5,8 @@ package controlplane
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -244,6 +246,7 @@ func TestOrgReservedPoolAcquireUnboundedWhenMaxWorkersZero(t *testing.T) {
 		t.Fatalf("expected at least %d assigned workers, got %d", target, got)
 	}
 }
+
 // At the org's max concurrent workers with all of them busy, AcquireWorker must
 // fail FAST with the clear org-cap message — not busy-wait until the client's
 // deadline, and not reuse the busy worker (one session per worker).
@@ -283,5 +286,297 @@ func TestOrgReservedPoolAcquireFailsClearlyAtOrgCap(t *testing.T) {
 	}
 	if worker.activeSessions != 1 {
 		t.Fatalf("expected busy worker session count to stay at 1, got %d", worker.activeSessions)
+	}
+}
+
+// A requester that gives up (ctx cancelled) mid-spawn must NOT doom the spawn:
+// the spawn+activate continues on its detached context, the finished worker is
+// parked hot-idle (with its hot_idle record persisted), and a subsequent
+// AcquireWorker for the org reclaims it through the hot-idle claim path without
+// spawning a second pod. Regression net for the doomed-spawn thrash where every
+// retry deleted the in-flight pod and re-spawned from scratch.
+func TestOrgReservedPoolAbandonedSpawnParksHotIdleAndIsReclaimed(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 5)
+	const workerID = 21
+	store := &captureRuntimeWorkerStore{
+		spawned: &configstore.WorkerRecord{WorkerID: workerID},
+	}
+	shared.runtimeStore = store
+	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
+		return nil
+	}
+
+	spawnStarted := make(chan struct{})
+	releaseSpawn := make(chan struct{})
+	var spawnPodCalls atomic.Int32
+	shared.spawnWorkerFunc = func(ctx context.Context, id int, image string, profile WorkerProfile) error {
+		if spawnPodCalls.Add(1) == 1 {
+			close(spawnStarted)
+		}
+		// Simulate a slow pod spawn (e.g. Karpenter provisioning a node) that
+		// outlives the requester. The detached spawn ctx must stay live after the
+		// requester cancels.
+		select {
+		case <-releaseSpawn:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		shared.mu.Lock()
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
+		shared.mu.Unlock()
+		return nil
+	}
+
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
+	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
+		return nil
+	}
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	defer cancelReq()
+	acquireErr := make(chan error, 1)
+	go func() {
+		_, err := pool.AcquireWorker(reqCtx, nil)
+		acquireErr <- err
+	}()
+
+	select {
+	case <-spawnStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("spawn never started")
+	}
+
+	// Requester gives up mid-spawn.
+	cancelReq()
+	select {
+	case err := <-acquireErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled for the abandoning requester, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AcquireWorker did not return after requester cancellation")
+	}
+
+	// Let the detached spawn finish; the abandoned worker must be parked
+	// hot-idle with no sessions, not left Reserved/Activating or retired.
+	close(releaseSpawn)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		shared.mu.RLock()
+		w, ok := shared.workers[workerID]
+		var lifecycle WorkerLifecycleState
+		sessions := -1
+		if ok {
+			lifecycle = w.SharedState().NormalizedLifecycle()
+			sessions = w.activeSessions
+		}
+		shared.mu.RUnlock()
+		if ok && lifecycle == WorkerLifecycleHotIdle && sessions == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("abandoned spawn was not parked hot-idle (exists=%v lifecycle=%q sessions=%d)", ok, lifecycle, sessions)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The hot_idle record must be persisted (same as ReleaseWorker /
+	// TransitionToHotIdleIfNoSessions) so peers/janitor see the parked worker.
+	foundHotIdleRecord := false
+	for _, rec := range store.snapshot() {
+		if rec.WorkerID == workerID && rec.State == configstore.WorkerStateHotIdle {
+			foundHotIdleRecord = true
+		}
+	}
+	if !foundHotIdleRecord {
+		t.Fatal("expected a persisted hot_idle worker record for the parked worker")
+	}
+
+	// The org's next connection reclaims the parked worker via the hot-idle
+	// claim — no second pod spawn.
+	store.mu.Lock()
+	store.hotIdleClaimResult = &configstore.WorkerRecord{
+		WorkerID:          workerID,
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		Image:             shared.workerImage,
+		OwnerCPInstanceID: shared.cpInstanceID,
+		OwnerEpoch:        2,
+	}
+	store.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	worker, err := pool.AcquireWorker(ctx, nil)
+	if err != nil {
+		t.Fatalf("AcquireWorker (reclaim): %v", err)
+	}
+	if worker.ID != workerID {
+		t.Fatalf("expected to reclaim parked worker %d, got %d", workerID, worker.ID)
+	}
+	if got := spawnPodCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 pod spawn (reclaim must not respawn), got %d", got)
+	}
+	if worker.activeSessions != 1 {
+		t.Fatalf("expected reclaimed worker to carry the new session, got %d", worker.activeSessions)
+	}
+	if got := worker.SharedState().NormalizedLifecycle(); got != WorkerLifecycleHot {
+		t.Fatalf("expected reclaimed worker to be hot, got %q", got)
+	}
+}
+
+// A cold burst of N waiters under the org cap must ramp N spawns IN PARALLEL:
+// the per-org FIFO gate covers only the short claim/slot decision, not the
+// multi-minute spawn+activate. Each spawn blocks on a barrier that opens only
+// once all N spawns have started — with the old gate-held-across-spawn behavior
+// this deadlocks (waiter k can't start its spawn until k-1 finished) and the
+// test times out.
+func TestOrgReservedPoolColdBurstSpawnsInParallel(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 0)
+	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
+		return nil
+	}
+
+	const n = 3
+	var mu sync.Mutex
+	started := 0
+	allStarted := make(chan struct{})
+	shared.spawnWorkerFunc = func(ctx context.Context, id int, image string, profile WorkerProfile) error {
+		mu.Lock()
+		started++
+		if started == n {
+			close(allStarted)
+		}
+		mu.Unlock()
+		select {
+		case <-allStarted: // barrier: requires n CONCURRENT spawns
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		shared.mu.Lock()
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
+		shared.mu.Unlock()
+		return nil
+	}
+
+	pool := NewOrgReservedPool(shared, "analytics", n, shared.workerImage, nil)
+	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		worker *ManagedWorker
+		err    error
+	}
+	results := make(chan result, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			w, err := pool.AcquireWorker(ctx, nil)
+			results <- result{worker: w, err: err}
+		}()
+	}
+
+	seen := make(map[int]struct{}, n)
+	for i := 0; i < n; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Fatalf("cold-burst AcquireWorker failed (spawns serialized?): %v", r.err)
+			}
+			if _, dup := seen[r.worker.ID]; dup {
+				t.Fatalf("two cold-burst waiters got the same worker %d", r.worker.ID)
+			}
+			seen[r.worker.ID] = struct{}{}
+		case <-time.After(10 * time.Second):
+			t.Fatal("cold-burst waiters did not all complete — spawns did not run in parallel")
+		}
+	}
+}
+
+// If the requester abandons mid-spawn and the detached activation then FAILS,
+// the worker must be retired exactly like the synchronous activation-failure
+// path — nothing may leak in Reserved/Activating state.
+func TestOrgReservedPoolAbandonedSpawnActivationFailureRetiresWorker(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 5)
+	shared.healthCheckFunc = func(ctx context.Context, worker *ManagedWorker) error {
+		return nil
+	}
+
+	spawnStarted := make(chan struct{})
+	releaseSpawn := make(chan struct{})
+	var spawnedID atomic.Int32
+	shared.spawnWorkerFunc = func(ctx context.Context, id int, image string, profile WorkerProfile) error {
+		spawnedID.Store(int32(id))
+		close(spawnStarted)
+		select {
+		case <-releaseSpawn:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		shared.mu.Lock()
+		shared.workers[id] = &ManagedWorker{ID: id, image: shared.workerImage, done: make(chan struct{})}
+		shared.mu.Unlock()
+		return nil
+	}
+
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
+	activationAttempted := make(chan struct{})
+	pool.activateReservedWorker = func(ctx context.Context, worker *ManagedWorker) error {
+		close(activationAttempted)
+		return errors.New("tenant activation exploded")
+	}
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	defer cancelReq()
+	acquireErr := make(chan error, 1)
+	go func() {
+		_, err := pool.AcquireWorker(reqCtx, nil)
+		acquireErr <- err
+	}()
+
+	select {
+	case <-spawnStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("spawn never started")
+	}
+	cancelReq()
+	select {
+	case err := <-acquireErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AcquireWorker did not return after requester cancellation")
+	}
+
+	close(releaseSpawn)
+	select {
+	case <-activationAttempted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("detached activation never ran after the requester abandoned")
+	}
+
+	// The failed worker must be retired (removed from the pool), not parked and
+	// not left Reserved/Activating.
+	id := int(spawnedID.Load())
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		shared.mu.RLock()
+		w, ok := shared.workers[id]
+		var lifecycle WorkerLifecycleState
+		if ok {
+			lifecycle = w.SharedState().NormalizedLifecycle()
+		}
+		shared.mu.RUnlock()
+		if !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("activation-failed abandoned worker %d leaked in lifecycle %q", id, lifecycle)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -28,7 +28,9 @@
 #   resilience   : worker-pod kill → crash recovery; DuckLake durability across a
 #                  worker restart; concurrent writers (fork conflict-retry);
 #                  graceful drain (in-flight query survives a worker SIGTERM, #690);
-#                  one session per worker (concurrent queries land on distinct pods).
+#                  one session per worker (concurrent queries land on distinct pods);
+#                  parallel cold-burst ramp (3 cold connections spawn 3 pods
+#                  concurrently — the acquire gate covers only the claim decision).
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
 #   admin auth   : the dashboard rejects ?token= query-param auth (#721); only
 #                  the internal-secret header / POST login form authenticate.
@@ -626,6 +628,78 @@ one_session_per_worker() { # org password
   log "one session per worker: OK (peak $peak pods for $1)"
 }
 
+# Parallel cold-burst spawn ramp (regression net for the doomed-spawn /
+# serialized-cold-burst fix): with NO reusable workers for the org, 3 concurrent
+# connections must (a) ALL be served, on 3 DISTINCT worker pods, and (b) get
+# their pods spawned in PARALLEL. The per-org FIFO acquire gate is held only
+# across the short claim/slot decision, so the 3 pod creates land within seconds
+# of each other; the old gate-held-across-spawn behavior created pod k only
+# after pod k-1's full spawn+activate finished (tens of seconds each), so the
+# creationTimestamp spread of the burst's first 3 pods is the discriminator.
+cold_burst_parallel_spawns() { # org password
+  log "parallel cold-burst spawn ramp on $1"
+  # Start truly cold: drain every worker currently serving the org so each of
+  # the 3 connections below needs its own fresh pod spawn (no hot-idle reuse).
+  k delete pods -l "app=duckgres-worker,duckgres/active-org=$1" --wait=false >/dev/null 2>&1 || true
+  k wait --for=delete pods -l "app=duckgres-worker,duckgres/active-org=$1" --timeout=300s >/dev/null 2>&1 || true
+
+  cb1="$(mktemp)"; cb2="$(mktemp)"; cb3="$(mktemp)"
+  cbr1="$(mktemp)"; cbr2="$(mktemp)"; cbr3="$(mktemp)"
+  # Multi-second query (same shape as one_session_per_worker) so each session
+  # holds its worker while the others activate. Expected = 4e9.
+  cq="SELECT count(*) FROM range(8000000000) t(i) WHERE i % 2 = 0;"
+  ( if pg_try "$1" "$2" ducklake "$cq" >"$cb1" 2>&1; then echo 0 >"$cbr1"; else echo 1 >"$cbr1"; fi ) &
+  cp1=$!
+  ( if pg_try "$1" "$2" ducklake "$cq" >"$cb2" 2>&1; then echo 0 >"$cbr2"; else echo 1 >"$cbr2"; fi ) &
+  cp2=$!
+  ( if pg_try "$1" "$2" ducklake "$cq" >"$cb3" 2>&1; then echo 0 >"$cbr3"; else echo 1 >"$cbr3"; fi ) &
+  cp3=$!
+
+  # While the queries run, the org must reach 3 simultaneous worker pods —
+  # one per cold connection (one session per worker; no sharing).
+  cpeak=0 ca=0
+  while [ "$ca" -lt 300 ]; do
+    kill -0 "$cp1" 2>/dev/null || break
+    kill -0 "$cp2" 2>/dev/null || break
+    kill -0 "$cp3" 2>/dev/null || break
+    cc="$(k get pods -l "duckgres/active-org=$1" --no-headers 2>/dev/null | grep -c . || true)"
+    [ "$cc" -gt "$cpeak" ] && cpeak="$cc"
+    [ "$cpeak" -ge 3 ] && break
+    sleep 1; ca=$((ca + 1))
+  done
+
+  wait "$cp1" 2>/dev/null || true
+  wait "$cp2" 2>/dev/null || true
+  wait "$cp3" 2>/dev/null || true
+  { [ "$(cat "$cbr1")" = 0 ] && [ "$(cat "$cbr2")" = 0 ] && [ "$(cat "$cbr3")" = 0 ]; } \
+    || fail "cold_burst_parallel_spawns: a cold-burst connection failed ($(tr -d '\n' <"$cb1" | tail -c 100) | $(tr -d '\n' <"$cb2" | tail -c 100) | $(tr -d '\n' <"$cb3" | tail -c 100))"
+  for f in "$cb1" "$cb2" "$cb3"; do
+    cn="$(tr -dc '0-9' <"$f")"
+    [ "$cn" = "4000000000" ] || fail "cold_burst_parallel_spawns: wrong result $cn want 4000000000"
+  done
+  [ "$cpeak" -ge 3 ] \
+    || fail "cold_burst_parallel_spawns: org peaked at $cpeak worker pod(s) for 3 concurrent cold connections — burst did not land on distinct workers"
+
+  # Parallelism: the burst's first 3 pods must have been CREATED within a
+  # narrow window. ISO-8601 creationTimestamps sort lexicographically; take the
+  # 3 earliest (pg_try retries could add a later 4th) and bound first→third.
+  # A serialized ramp separates each create by a full pod spawn+activate
+  # (>=~20-60s each on a warm node, minutes on a cold one), far above 30s.
+  cts="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" \
+        -o jsonpath='{.items[*].metadata.creationTimestamp}' 2>/dev/null \
+        | tr ' ' '\n' | grep . | sort | head -3)"
+  [ "$(echo "$cts" | grep -c .)" = "3" ] \
+    || fail "cold_burst_parallel_spawns: expected >=3 org worker pods after the burst, got: $cts"
+  cfirst="$(echo "$cts" | head -1)"; cthird="$(echo "$cts" | tail -1)"
+  ce1="$(date -u -D "%Y-%m-%dT%H:%M:%SZ" -d "$cfirst" +%s 2>/dev/null || date -u -d "$cfirst" +%s)"
+  ce3="$(date -u -D "%Y-%m-%dT%H:%M:%SZ" -d "$cthird" +%s 2>/dev/null || date -u -d "$cthird" +%s)"
+  cspread=$((ce3 - ce1))
+  [ "$cspread" -le 30 ] \
+    || fail "cold_burst_parallel_spawns: pod creation spread ${cspread}s (first=$cfirst third=$cthird) — spawns ramped sequentially, not in parallel"
+  rm -f "$cb1" "$cb2" "$cb3" "$cbr1" "$cbr2" "$cbr3"
+  log "parallel cold-burst spawn ramp: OK (peak $cpeak pods, creation spread ${cspread}s)"
+}
+
 # Data committed to DuckLake survives a worker restart (parquet in object store +
 # metadata snapshot in Postgres are the source of truth).
 # Ported from TestK8sDuckLakeDurabilityAcrossWorkerRestart.
@@ -795,6 +869,10 @@ main() {
   sized_worker        "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
   reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
 
+  # ---- parallel cold-burst ramp (after sizing: drains ALL org workers first,
+  # so it must not run before the hot-idle reuse assertions above) ----
+  cold_burst_parallel_spawns "$CNPG" "$cnpg_pw"
+
   # ---- ext backend (activation + R/W on the external-RDS metadata path) ----
   wait_worker "$EXT" "$ext_pw" ducklake
   basic_query  "$EXT" "$ext_pw"
@@ -811,7 +889,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Motivation

A customer's sqlmesh hourly jobs stalled 30+ minutes on MTCP worker bootstrap. Two structural defects in the cold-acquire path:

1. **Doomed-spawn thrash** — `spawnReservedWorker` → `spawnWorker` waited for pod-ready on the **requester's ctx** (the client's workerQueueTimeout, 5m in prod). When the wait died, the in-flight pod was **deleted**. If node provisioning reliably exceeds the client budget, every retry spawns a new pod, waits, deletes it — the org never converges on a ready worker and burns node churn.

2. **Serialized cold burst** — `OrgReservedPool.AcquireWorker`'s slow path held the per-org FIFO `orgAcquireGate` across the **entire** spawn+activate (minutes). N concurrent cold connections for one org ramped sequentially: waiter k waited behind k−1 full spawns and timed out. (The code comment at the gate documented this as a known perf follow-up.)

## Design

**Detached spawn lifetime.** The spawn (pod create → pod-ready → reserve) and tenant activation now run under `context.WithoutCancel(requestCtx)` (keeps trace/log values) with their own deadline, the new `workerSpawnActivateTimeout = workerPodReadyTimeout + 3m` (pod-ready incl. Karpenter node provision + 90s gRPC connect + activation). The requester waits for the spawn/activate result **or** its own ctx, whichever first:

- Requester abandons + spawn/activate eventually **succeeds** → the worker is parked for the org via `ReleaseWorker` → `TransitionToHotIdleIfNoSessions` (hot_idle record persisted), so the org's next connection reclaims it through the existing hot-idle claim path instead of respawning.
- Requester abandons + it eventually **fails** → retired exactly as the synchronous failure path (`retireWorkerWithReason` with the activation-failure/spawn-failure reasons, `observeActivationFailure` where applicable). No worker can leak in Reserved/Activating.

**Gate held only for the decision section.** `ReserveSharedWorker` is split into `reserveSharedWorkerDecision` (DB-only: hot-idle claim attempt → `CreateSpawningWorkerSlot`) and `completeSharedWorkerReservation` (pod I/O); `spawnReservedWorker` becomes `spawnReservedWorkerForSlot`. `OrgReservedPool.acquireDecision` holds the gate across exactly: idle-reuse re-check → `ClaimHotIdleWorker` → `CreateSpawningWorkerSlot`. Once a waiter owns a slot/claim, the gate is released and the multi-minute spawn+activate runs outside it — so a cold burst of N waiters ramps N spawns in parallel.

**Why anti-snatch still holds.** Each slow-path waiter leaves the gate 1:1 bound to the specific worker it claimed/spawned (the durable claim/slot row is already assigned to it), and the new worker's session is **pre-claimed while still Reserved** — before it ever becomes visible as Hot — so a concurrently-arriving connection's idle-reuse fast path can never grab the worker out from under the waiter that spawned it (this also closes a pre-existing tiny window between activation and session claim). Freed/parked workers re-enter circulation only via the idle-reuse re-check and hot-idle claim **inside** the gated decision section, granted in FIFO arrival order — the earliest waiter still gets the next available worker. The gate itself (`org_acquire_gate.go`) is unchanged, including cancel-safety.

**Unchanged invariants (CLAUDE.md contract):** one session per worker (no least-loaded sharing path added), destroy-before-reuse ordering in `session_mgr.go`, cap-drift recovery in `CreateSessionWithProtocol`, hot-idle claim attempted before spawning, at-cap fail-fast with `WorkerClaimMissReasonOrgCap` (in-memory `atOrgWorkerCap` pre-check kept as fast-fail; `CreateSpawningWorkerSlot` remains the authoritative cross-CP cap check), spawn-failure metrics and persisted lifecycle records on every path (a parked worker persists its `WorkerStateHotIdle` record via `TransitionToHotIdleIfNoSessions`).

## Tests

`controlplane/org_reserved_pool_test.go` (all verified to FAIL against the old implementation where applicable):

- `TestOrgReservedPoolAbandonedSpawnParksHotIdleAndIsReclaimed` — requester cancels mid-spawn → spawn completes detached → worker ends HotIdle/0-sessions with a persisted hot_idle record → next `AcquireWorker` reclaims it via hot-idle claim with **no second pod spawn**. (Fails on main: the old code cancels the spawn and the worker never exists.)
- `TestOrgReservedPoolColdBurstSpawnsInParallel` — 3 waiters, spawn seam blocks on a barrier requiring 3 **concurrent** spawns; all succeed on distinct workers. (Fails on main: serialized ramp deadlocks the barrier.)
- `TestOrgReservedPoolAbandonedSpawnActivationFailureRetiresWorker` — abandoned requester + detached activation failure → worker retired, nothing leaks in Reserved/Activating.
- `TestOrgReservedPoolAcquireFailsClearlyAtOrgCap` — pre-existing at-cap fail-fast, unchanged and still green.

`org_acquire_gate_test.go` untouched and green (gate semantics unchanged). Full `go test -tags kubernetes ./controlplane/... -race`, `go vet -tags kubernetes ./controlplane/...`, gofmt clean on touched files. Also fixed two **pre-existing** `-race` flakes in `k8s_pool_test.go` (`TestK8sPoolRetireWorkerUsesTrackedPodName`, `TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost`) that asserted async pod deletes without synchronization — both reproduce on origin/main and blocked the required race run.

## Harness (tests/e2e-mw-dev)

- Confirmed `one_session_per_worker` still exercises the changed path (2 concurrent queries → 2 distinct pods through the new decision/complete acquire flow); assertion unchanged.
- New `cold_burst_parallel_spawns` (cnpg, after the sized-worker reuse asserts since it drains the org's workers first): deletes all of the org's worker pods, opens 3 concurrent connections running multi-second queries, and asserts (a) all 3 succeed with correct results, (b) the org peaks at ≥3 simultaneous worker pods (distinct workers), and (c) the burst's first 3 pods' creationTimestamps cluster within 30s — a serialized ramp separates each create by a full spawn+activate, so the spread is the parallel-vs-sequential discriminator.

CLAUDE.md's worker-session-model contract bullets updated to describe the gate-over-decision-only + detached-spawn behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
