### PR TITLE
feat(controlplane): per-org default worker profile (server-side sizing for tenants that can't send GUCs)

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var errWarehousePayloadNotAllowed = errors.New("warehouse payload must be updated via /orgs/:id/warehouse")
@@ -188,6 +189,12 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 		"memory_budget":   updates.MemoryBudget,
 		"idle_timeout_s":  updates.IdleTimeoutS,
 		"max_connections": updates.MaxConnections,
+		// Org default worker profile: written unconditionally so an explicit
+		// empty string CLEARS the default (the handler's presence-merge keeps
+		// omitted fields at their stored values before this runs).
+		"default_worker_cpu":    updates.DefaultWorkerCPU,
+		"default_worker_memory": updates.DefaultWorkerMemory,
+		"default_worker_ttl":    updates.DefaultWorkerTTL,
 	}
 	// Only update resource fields when explicitly provided to avoid clearing
 	// previously-set values when the caller omits them from the JSON payload.
@@ -658,6 +665,17 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["worker_memory_request"]; ok {
 		merged.WorkerMemoryRequest = updates.WorkerMemoryRequest
 	}
+	// Org default worker profile: present-in-payload wins, including an
+	// explicit "" which clears the default.
+	if _, ok := fields["default_worker_cpu"]; ok {
+		merged.DefaultWorkerCPU = updates.DefaultWorkerCPU
+	}
+	if _, ok := fields["default_worker_memory"]; ok {
+		merged.DefaultWorkerMemory = updates.DefaultWorkerMemory
+	}
+	if _, ok := fields["default_worker_ttl"]; ok {
+		merged.DefaultWorkerTTL = updates.DefaultWorkerTTL
+	}
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
@@ -697,6 +715,42 @@ func validateOrgMutationPayload(org *configstore.Org) error {
 	if org.HostnameAlias != nil {
 		if err := validateHostnameAlias(*org.HostnameAlias); err != nil {
 			return err
+		}
+	}
+	if err := validateOrgDefaultWorkerProfile(org); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateOrgDefaultWorkerProfile rejects garbage default-worker-profile
+// values at the API boundary so they can never enter the config store (the
+// control plane tolerates bad rows by ignoring them, but a 400 here surfaces
+// the typo to the operator instead of a silently-ignored default). Empty
+// strings are allowed: they mean "unset" on create / "clear" on update.
+func validateOrgDefaultWorkerProfile(org *configstore.Org) error {
+	for _, f := range []struct{ name, raw string }{
+		{"default_worker_cpu", org.DefaultWorkerCPU},
+		{"default_worker_memory", org.DefaultWorkerMemory},
+	} {
+		if f.raw == "" {
+			continue
+		}
+		q, err := resource.ParseQuantity(f.raw)
+		if err != nil {
+			return fmt.Errorf("%s: invalid quantity %q", f.name, f.raw)
+		}
+		if q.Sign() <= 0 {
+			return fmt.Errorf("%s: quantity %q must be positive", f.name, f.raw)
+		}
+	}
+	if raw := org.DefaultWorkerTTL; raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("default_worker_ttl: invalid duration %q (use a Go duration like \"30m\")", raw)
+		}
+		if d < 0 {
+			return fmt.Errorf("default_worker_ttl: duration %q must be >= 0", raw)
 		}
 	}
 	return nil

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -67,6 +67,11 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 	org.MemoryBudget = updates.MemoryBudget
 	org.IdleTimeoutS = updates.IdleTimeoutS
 	org.MaxConnections = updates.MaxConnections
+	// Mirrors gormAPIStore: written unconditionally so "" clears (the handler
+	// presence-merge already preserved omitted fields).
+	org.DefaultWorkerCPU = updates.DefaultWorkerCPU
+	org.DefaultWorkerMemory = updates.DefaultWorkerMemory
+	org.DefaultWorkerTTL = updates.DefaultWorkerTTL
 	if updates.WorkerCPURequest != "" {
 		org.WorkerCPURequest = updates.WorkerCPURequest
 	}
@@ -1480,5 +1485,156 @@ func TestUpdateOrgMaxConnections(t *testing.T) {
 	}
 	if store.orgs["analytics"].IdleTimeoutS != 30 {
 		t.Fatalf("expected idle_timeout_s to be preserved, got %d", store.orgs["analytics"].IdleTimeoutS)
+	}
+}
+
+// --- Org default worker profile (default_worker_cpu/memory/ttl) ---
+
+func TestUpdateOrgSetsDefaultWorkerProfile(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme", DatabaseName: "acme"}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"default_worker_cpu":"2","default_worker_memory":"8Gi","default_worker_ttl":"10m"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultWorkerCPU != "2" || stored.DefaultWorkerMemory != "8Gi" || stored.DefaultWorkerTTL != "10m" {
+		t.Fatalf("stored default profile = %q/%q/%q, want 2/8Gi/10m",
+			stored.DefaultWorkerCPU, stored.DefaultWorkerMemory, stored.DefaultWorkerTTL)
+	}
+	// The fields must round-trip in the response JSON so operators can read
+	// back what they set (GET uses the same model serialization).
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["default_worker_cpu"] != "2" || resp["default_worker_memory"] != "8Gi" || resp["default_worker_ttl"] != "10m" {
+		t.Fatalf("response JSON missing default worker profile fields: %s", rec.Body.String())
+	}
+}
+
+func TestUpdateOrgClearsDefaultWorkerProfileWithEmptyStrings(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{
+		Name: "acme", DatabaseName: "acme",
+		DefaultWorkerCPU: "2", DefaultWorkerMemory: "8Gi", DefaultWorkerTTL: "10m",
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"default_worker_cpu":"","default_worker_memory":"","default_worker_ttl":""}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultWorkerCPU != "" || stored.DefaultWorkerMemory != "" || stored.DefaultWorkerTTL != "" {
+		t.Fatalf("default profile not cleared: %q/%q/%q",
+			stored.DefaultWorkerCPU, stored.DefaultWorkerMemory, stored.DefaultWorkerTTL)
+	}
+}
+
+func TestUpdateOrgOmittingDefaultWorkerProfilePreservesIt(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{
+		Name: "acme", DatabaseName: "acme",
+		DefaultWorkerCPU: "2", DefaultWorkerMemory: "8Gi", DefaultWorkerTTL: "10m",
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"max_workers":4}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultWorkerCPU != "2" || stored.DefaultWorkerMemory != "8Gi" || stored.DefaultWorkerTTL != "10m" {
+		t.Fatalf("default profile not preserved: %q/%q/%q",
+			stored.DefaultWorkerCPU, stored.DefaultWorkerMemory, stored.DefaultWorkerTTL)
+	}
+}
+
+func TestUpdateOrgRejectsInvalidDefaultWorkerProfile(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"garbage cpu quantity", `{"default_worker_cpu":"lots"}`},
+		{"zero cpu", `{"default_worker_cpu":"0"}`},
+		{"negative memory", `{"default_worker_memory":"-8Gi"}`},
+		{"garbage memory quantity", `{"default_worker_memory":"big"}`},
+		{"garbage ttl duration", `{"default_worker_ttl":"whenever"}`},
+		{"negative ttl", `{"default_worker_ttl":"-5m"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAPIStore()
+			store.orgs["acme"] = &configstore.Org{Name: "acme", DatabaseName: "acme", DefaultWorkerCPU: "2"}
+			router := newTestAPIRouter(store)
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if store.orgs["acme"].DefaultWorkerCPU != "2" {
+				t.Fatal("invalid payload must not mutate the stored org")
+			}
+		})
+	}
+}
+
+func TestCreateOrgAcceptsDefaultWorkerProfile(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"name":"acme","database_name":"acme","default_worker_cpu":"2","default_worker_memory":"8Gi","default_worker_ttl":"75m"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultWorkerCPU != "2" || stored.DefaultWorkerMemory != "8Gi" || stored.DefaultWorkerTTL != "75m" {
+		t.Fatalf("stored default profile = %q/%q/%q, want 2/8Gi/75m",
+			stored.DefaultWorkerCPU, stored.DefaultWorkerMemory, stored.DefaultWorkerTTL)
+	}
+}
+
+func TestCreateOrgRejectsInvalidDefaultWorkerTTL(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"name":"acme","database_name":"acme","default_worker_ttl":"10 minutes"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if _, ok := store.orgs["acme"]; ok {
+		t.Fatal("org should NOT have been created")
 	}
 }

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -10,19 +10,30 @@ import "time"
 // alias", multiple orgs can share the NULL state, but any non-NULL alias must
 // be unique across orgs (Postgres ignores NULL in UNIQUE).
 type Org struct {
-	Name                string                 `gorm:"primaryKey;size:255" json:"name"`
-	DatabaseName        string                 `gorm:"size:255;uniqueIndex" json:"database_name"`
-	HostnameAlias       *string                `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
-	MaxWorkers          int                    `gorm:"default:0" json:"max_workers"`
-	MaxConnections      int                    `gorm:"default:0" json:"max_connections"`
-	MemoryBudget        string                 `gorm:"size:32" json:"memory_budget"`
-	IdleTimeoutS        int                    `gorm:"default:0" json:"idle_timeout_s"`
-	WorkerCPURequest    string                 `gorm:"size:32" json:"worker_cpu_request"`
-	WorkerMemoryRequest string                 `gorm:"size:32" json:"worker_memory_request"`
-	Users               []OrgUser              `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
-	Warehouse           *ManagedWarehouse      `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
-	CreatedAt           time.Time              `json:"created_at"`
-	UpdatedAt           time.Time              `json:"updated_at"`
+	Name                string  `gorm:"primaryKey;size:255" json:"name"`
+	DatabaseName        string  `gorm:"size:255;uniqueIndex" json:"database_name"`
+	HostnameAlias       *string `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
+	MaxWorkers          int     `gorm:"default:0" json:"max_workers"`
+	MaxConnections      int     `gorm:"default:0" json:"max_connections"`
+	MemoryBudget        string  `gorm:"size:32" json:"memory_budget"`
+	IdleTimeoutS        int     `gorm:"default:0" json:"idle_timeout_s"`
+	WorkerCPURequest    string  `gorm:"size:32" json:"worker_cpu_request"`
+	WorkerMemoryRequest string  `gorm:"size:32" json:"worker_memory_request"`
+	// DefaultWorkerCPU/Memory/TTL are the org's operator-set default worker
+	// profile: the pod shape (k8s resource quantities, e.g. "2"/"8Gi") and
+	// hot-idle TTL (Go duration string, e.g. "75m" — stored as a string for
+	// human editability) applied to connections that don't size themselves via
+	// the duckgres.worker_* startup options. Distinct from WorkerCPURequest/
+	// WorkerMemoryRequest above, which mutate the GLOBAL pool default (a known
+	// last-org-wins footgun). Empty = unset. AutoMigrate adds these columns;
+	// no migration file.
+	DefaultWorkerCPU    string            `gorm:"size:32" json:"default_worker_cpu"`
+	DefaultWorkerMemory string            `gorm:"size:32" json:"default_worker_memory"`
+	DefaultWorkerTTL    string            `gorm:"size:32" json:"default_worker_ttl"`
+	Users               []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
+	Warehouse           *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
+	CreatedAt           time.Time         `json:"created_at"`
+	UpdatedAt           time.Time         `json:"updated_at"`
 }
 
 func (Org) TableName() string { return "duckgres_orgs" }
@@ -531,6 +542,9 @@ type OrgConfig struct {
 	IdleTimeoutS        int
 	WorkerCPURequest    string
 	WorkerMemoryRequest string
+	DefaultWorkerCPU    string            // org default worker profile: pod cpu quantity ("" = unset)
+	DefaultWorkerMemory string            // org default worker profile: pod memory quantity ("" = unset)
+	DefaultWorkerTTL    string            // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
 	Users               map[string]string // username -> password
 	Warehouse           *ManagedWarehouseConfig
 }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -260,6 +260,9 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 			IdleTimeoutS:        o.IdleTimeoutS,
 			WorkerCPURequest:    o.WorkerCPURequest,
 			WorkerMemoryRequest: o.WorkerMemoryRequest,
+			DefaultWorkerCPU:    o.DefaultWorkerCPU,
+			DefaultWorkerMemory: o.DefaultWorkerMemory,
+			DefaultWorkerTTL:    o.DefaultWorkerTTL,
 			Users:               make(map[string]string),
 			Warehouse:           copyManagedWarehouseConfig(o.Warehouse),
 		}
@@ -469,6 +472,25 @@ func (cs *ConfigStore) OrgWarehouseStatus(orgID string) (string, bool) {
 	return string(oc.Warehouse.State), true
 }
 
+// OrgDefaultWorkerProfile returns the org's operator-set default worker
+// profile from the current snapshot: cpu/memory as k8s resource-quantity
+// strings and ttl as a Go duration string. Empty strings mean "not set"
+// (including unknown orgs and a not-yet-loaded snapshot). Values are stored
+// as entered by the operator; validation/normalization happens at resolution
+// time in the control plane (a bad row must never break connections).
+func (cs *ConfigStore) OrgDefaultWorkerProfile(orgID string) (cpu, memory, ttl string) {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.snapshot == nil {
+		return "", "", ""
+	}
+	oc, ok := cs.snapshot.Orgs[orgID]
+	if !ok {
+		return "", "", ""
+	}
+	return oc.DefaultWorkerCPU, oc.DefaultWorkerMemory, oc.DefaultWorkerTTL
+}
+
 // ValidateOrgUser checks username/password scoped to a specific org.
 func (cs *ConfigStore) ValidateOrgUser(orgID, username, password string) bool {
 	cs.mu.RLock()
@@ -653,7 +675,6 @@ func (cs *ConfigStore) GetManagedWarehouseIceberg(orgID string) (*ManagedWarehou
 	return &ic, nil
 }
 
-
 // migrateDeltaCatalogDefaultEnabled is a one-shot backfill that flips existing
 // rows where delta_catalog_enabled was stored as false (the old default) to
 // true. New rows get true automatically via the gorm:"default:true" column
@@ -765,6 +786,7 @@ func (cs *ConfigStore) RuntimeSchema() string {
 func (cs *ConfigStore) runtimeTable(base string) string {
 	return cs.runtimeSchema + "." + base
 }
+
 // ListWorkerLifecycleStats returns grouped cluster-wide active worker lifecycle
 // state by image and tenant binding for Prometheus observability.
 func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error) {
@@ -926,6 +948,7 @@ func (cs *ConfigStore) GetWorkerRecord(workerID int) (*WorkerRecord, error) {
 	}
 	return &record, nil
 }
+
 // ClaimHotIdleWorker atomically claims one hot-idle worker row that was
 // previously activated for the given org. The selected row is locked with
 // SKIP LOCKED and transitioned to reserved while incrementing owner_epoch.
@@ -1408,6 +1431,7 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 	}
 	return created, nil
 }
+
 // ListOrphanedWorkers returns workers in active states that no live CP
 // is responsible for any longer. Three independent failure modes are
 // covered, joined by OR:

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -461,3 +461,43 @@ func TestTableNames(t *testing.T) {
 		}
 	}
 }
+
+func TestOrgDefaultWorkerProfile(t *testing.T) {
+	cs := &ConfigStore{
+		snapshot: &Snapshot{
+			Orgs: map[string]*OrgConfig{
+				"unset": {Name: "unset"},
+				"full": {
+					Name:                "full",
+					DefaultWorkerCPU:    "2",
+					DefaultWorkerMemory: "8Gi",
+					DefaultWorkerTTL:    "75m",
+				},
+				"partial": {Name: "partial", DefaultWorkerTTL: "10m"},
+			},
+		},
+	}
+
+	tests := []struct {
+		orgID                     string
+		wantCPU, wantMem, wantTTL string
+	}{
+		{"unknown", "", "", ""},
+		{"unset", "", "", ""},
+		{"full", "2", "8Gi", "75m"},
+		{"partial", "", "", "10m"},
+	}
+	for _, tt := range tests {
+		cpu, mem, ttl := cs.OrgDefaultWorkerProfile(tt.orgID)
+		if cpu != tt.wantCPU || mem != tt.wantMem || ttl != tt.wantTTL {
+			t.Errorf("OrgDefaultWorkerProfile(%q) = (%q,%q,%q); want (%q,%q,%q)",
+				tt.orgID, cpu, mem, ttl, tt.wantCPU, tt.wantMem, tt.wantTTL)
+		}
+	}
+
+	// Nil snapshot (store not yet loaded) must read as "not set", not panic.
+	empty := &ConfigStore{}
+	if cpu, mem, ttl := empty.OrgDefaultWorkerProfile("full"); cpu != "" || mem != "" || ttl != "" {
+		t.Errorf("nil-snapshot OrgDefaultWorkerProfile = (%q,%q,%q); want all empty", cpu, mem, ttl)
+	}
+}

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -208,6 +208,12 @@ type ConfigStoreInterface interface {
 	// warehouse row (legacy single-tenant orgs); otherwise it is the lifecycle
 	// string (pending/provisioning/ready/failed/deleting/deleted).
 	OrgWarehouseStatus(orgID string) (state string, orgExists bool)
+	// OrgDefaultWorkerProfile returns the org's operator-set default worker
+	// profile (config-store columns default_worker_cpu/memory/ttl): cpu and
+	// memory as k8s resource-quantity strings, ttl as a Go duration string.
+	// Empty strings mean "not set" (including unknown orgs). Raw stored
+	// values — validation happens in resolveWorkerProfile.
+	OrgDefaultWorkerProfile(orgID string) (cpu, memory, ttl string)
 	UpsertFlightSessionRecord(record *configstore.FlightSessionRecord) error
 	GetFlightSessionRecord(sessionToken string) (*configstore.FlightSessionRecord, error)
 	TouchFlightSessionRecord(sessionToken string, lastSeenAt time.Time) error
@@ -1003,10 +1009,17 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	slog.Info("User authenticated.", "user", username, "remote_addr", remoteAddr)
 
 	// Resolve the requested worker shape from the connection-string startup
-	// options (duckgres.worker_cpu / worker_memory / worker_ttl).
-	// nil => the default exclusive profile. Gated off by default, so this is a
-	// no-op unless the deployment opts in. A rejected profile fails the connect.
-	workerProfile, profileWarns, profileErr := cp.resolveWorkerProfile(startupOptions)
+	// options (duckgres.worker_cpu / worker_memory / worker_ttl), layered on
+	// top of the org's operator-set default profile (multi-tenant only).
+	// nil => the default exclusive profile. Client sizing is gated off by
+	// default; org defaults apply regardless of that gate (they are operator
+	// config, not client input). A rejected client profile fails the connect.
+	var orgProfileDefaults orgWorkerProfileDefaults
+	if cp.configStore != nil && orgID != "" {
+		c, m, t := cp.configStore.OrgDefaultWorkerProfile(orgID)
+		orgProfileDefaults = orgWorkerProfileDefaults{CPU: c, Memory: m, TTL: t}
+	}
+	workerProfile, profileWarns, orgProfileApplied, profileErr := cp.resolveWorkerProfile(startupOptions, orgProfileDefaults)
 	if profileErr != nil {
 		slog.Warn("Rejected worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr, "error", profileErr)
 		_ = server.WriteErrorResponse(writer, "FATAL", "22023", profileErr.Error())
@@ -1015,6 +1028,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	}
 	for _, w := range profileWarns {
 		slog.Warn("Adjusted worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr, "detail", w)
+	}
+	if orgProfileApplied && workerProfile != nil {
+		// Once per connection so support can see which shape a tenant got.
+		slog.Info("Applied org default worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr,
+			"cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
 	}
 
 	// Resolve the session manager and rebalancer for this connection.

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -162,6 +162,11 @@ func (f *fakeConfigStore) OrgWarehouseStatus(string) (string, bool) {
 	// SNI tests don't exercise the warehouse-status connection-error path.
 	return "", false
 }
+func (f *fakeConfigStore) OrgDefaultWorkerProfile(string) (string, string, string) {
+	// SNI tests don't exercise worker-profile resolution; "not set" keeps the
+	// default (nil) profile semantics.
+	return "", "", ""
+}
 func (f *fakeConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
 	panic("UpsertFlightSessionRecord should not be called from SNI tests")
 }

--- a/controlplane/worker_profile.go
+++ b/controlplane/worker_profile.go
@@ -24,44 +24,110 @@ const (
 	defaultWorkerTTL    = 20 * time.Minute
 )
 
-// resolveWorkerProfile turns the client's worker_cpu / worker_memory / worker_ttl
-// startup options into a *WorkerProfile (a worker size + hot-idle TTL), or nil.
+// orgWorkerProfileDefaults carries an org's operator-set default worker
+// profile (config store columns default_worker_cpu/memory/ttl) into profile
+// resolution. All fields are raw strings as stored; empty = unset. CPU/Memory
+// are k8s resource quantities, TTL is a Go duration string (e.g. "75m").
+type orgWorkerProfileDefaults struct {
+	CPU    string
+	Memory string
+	TTL    string
+}
+
+// resolveWorkerProfile turns the client's worker_cpu / worker_memory /
+// worker_ttl startup options plus the org's operator-set default worker
+// profile into a *WorkerProfile (a worker size + hot-idle TTL), or nil.
 //
-//   - (nil, nil, nil)  => the DEFAULT profile: gate off, or no sizing GUC set.
-//     nil is the sentinel for the default worker shape; its size comes from the
-//     pool-global WorkerCPURequest/MemoryRequest (else BestEffort), and it reuses
-//     a hot-idle default-shape worker for the org (MatchKey "|").
-//   - (profile, warns, nil) => the client explicitly requested a size/ttl. cpu/mem
-//     default to the pool-global request (else built-in 8/16Gi) for any field the
-//     client omitted, clamped to [min,max]; ttl to [0,WorkerMaxTTL], default 20m.
-//   - (nil, nil, err) => an unparseable/negative value (rejects the connection).
+// Precedence, per field (cpu, memory, ttl independently):
+//  1. client GUC — only when AllowClientWorkerProfile is on; validated and
+//     clamped to WorkerProfileMin/Max + WorkerMaxTTL exactly as before.
+//  2. org default — applies REGARDLESS of AllowClientWorkerProfile: that gate
+//     is about trusting client-supplied startup options, while org defaults
+//     are operator config set via the authenticated admin API. They are
+//     validated/normalized but NOT clamped to WorkerProfileMin/Max (TTL is
+//     still bounded by WorkerMaxTTL). A field that fails validation is
+//     ignored with a warning — a bad config-store row must not break
+//     connections.
+//  3. pool-global WorkerCPURequest/MemoryRequest (else built-in 8/16Gi); TTL
+//     defaults to 20m.
+//
+// Returns:
+//   - (nil, warns, false, nil)  => the DEFAULT profile: no client sizing and no
+//     (valid) org default. nil is the sentinel for the default worker shape;
+//     its size comes from the pool-global WorkerCPURequest/MemoryRequest (else
+//     BestEffort), and it reuses a hot-idle default-shape worker for the org
+//     (MatchKey "|").
+//   - (profile, warns, orgApplied, nil) => a concrete shape was requested.
+//     orgApplied reports whether any org-default field shaped the result (i.e.
+//     was set, valid, and not overridden by a client GUC) so the session-setup
+//     path can log which tenants run on an org default.
+//   - (nil, nil, false, err) => an unparseable/negative client value (rejects
+//     the connection). Org-default values never produce an error.
 //
 // A no-sizing request returns nil (the default shape) rather than a concrete
 // profile, so default traffic and a hot-idle default-shape worker share the same
 // MatchKey ("|") and reuse each other. A sized request spawns/reuses a worker of
 // its exact cpu/memory shape on demand (see docs/design/worker-ttl-pool.md).
-func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerProfile, []string, error) {
+func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string, org orgWorkerProfileDefaults) (*WorkerProfile, []string, bool, error) {
 	k := cp.cfg.K8s
-	if !k.AllowClientWorkerProfile {
-		return nil, nil, nil
-	}
 
-	rawCPU := strings.TrimSpace(opts[gucWorkerCPU])
-	rawMem := strings.TrimSpace(opts[gucWorkerMemory])
-	rawTTL := strings.TrimSpace(opts[gucWorkerTTL])
-	if rawCPU == "" && rawMem == "" && rawTTL == "" {
-		return nil, nil, nil // no client sizing -> default (nil) profile
-	}
-
-	cpu := firstNonEmpty(strings.TrimSpace(k.WorkerCPURequest), defaultWorkerCPU)
-	mem := firstNonEmpty(strings.TrimSpace(k.WorkerMemoryRequest), defaultWorkerMemory)
-	ttl := defaultWorkerTTL
-
+	// Validate/normalize the org defaults first so they can act as the base
+	// layer underneath any client GUCs. Invalid fields warn and fall back as
+	// if unset.
 	var warns []string
+	orgCPU, orgMem := "", ""
+	var orgTTL time.Duration
+	orgTTLSet := false
+	if raw := strings.TrimSpace(org.CPU); raw != "" {
+		if v, _, err := sizeField("org default_worker_cpu", raw, "", ""); err != nil {
+			warns = append(warns, fmt.Sprintf("ignoring invalid org default worker cpu: %v", err))
+		} else {
+			orgCPU = v
+		}
+	}
+	if raw := strings.TrimSpace(org.Memory); raw != "" {
+		if v, _, err := sizeField("org default_worker_memory", raw, "", ""); err != nil {
+			warns = append(warns, fmt.Sprintf("ignoring invalid org default worker memory: %v", err))
+		} else {
+			orgMem = v
+		}
+	}
+	if raw := strings.TrimSpace(org.TTL); raw != "" {
+		if v, warn, err := ttlField("org default_worker_ttl", raw, k.WorkerMaxTTL); err != nil {
+			warns = append(warns, fmt.Sprintf("ignoring invalid org default worker ttl: %v", err))
+		} else {
+			orgTTL, orgTTLSet = v, true
+			if warn != "" {
+				warns = append(warns, warn)
+			}
+		}
+	}
+
+	// Client startup options are only read when the deployment opts in; with
+	// the gate off even garbage GUC values are ignored, never an error.
+	rawCPU, rawMem, rawTTL := "", "", ""
+	if k.AllowClientWorkerProfile {
+		rawCPU = strings.TrimSpace(opts[gucWorkerCPU])
+		rawMem = strings.TrimSpace(opts[gucWorkerMemory])
+		rawTTL = strings.TrimSpace(opts[gucWorkerTTL])
+	}
+
+	if rawCPU == "" && rawMem == "" && rawTTL == "" && orgCPU == "" && orgMem == "" && !orgTTLSet {
+		return nil, warns, false, nil // no sizing anywhere -> default (nil) profile
+	}
+
+	// Base layer per field: org default, else pool-global request, else built-in.
+	cpu := firstNonEmpty(orgCPU, firstNonEmpty(strings.TrimSpace(k.WorkerCPURequest), defaultWorkerCPU))
+	mem := firstNonEmpty(orgMem, firstNonEmpty(strings.TrimSpace(k.WorkerMemoryRequest), defaultWorkerMemory))
+	ttl := defaultWorkerTTL
+	if orgTTLSet {
+		ttl = orgTTL
+	}
+
 	if rawCPU != "" {
 		v, warn, err := sizeField(gucWorkerCPU, rawCPU, k.WorkerProfileMinCPU, k.WorkerProfileMaxCPU)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		cpu = v
 		if warn != "" {
@@ -71,7 +137,7 @@ func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerPro
 	if rawMem != "" {
 		v, warn, err := sizeField(gucWorkerMemory, rawMem, k.WorkerProfileMinMemory, k.WorkerProfileMaxMemory)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		mem = v
 		if warn != "" {
@@ -79,9 +145,9 @@ func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerPro
 		}
 	}
 	if rawTTL != "" {
-		v, warn, err := ttlField(rawTTL, k.WorkerMaxTTL)
+		v, warn, err := ttlField(gucWorkerTTL, rawTTL, k.WorkerMaxTTL)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		ttl = v
 		if warn != "" {
@@ -89,17 +155,21 @@ func (cp *ControlPlane) resolveWorkerProfile(opts map[string]string) (*WorkerPro
 		}
 	}
 
+	// An org default "applied" when a valid org field survived into the result
+	// (i.e. the client did not override that same field).
+	orgApplied := (orgCPU != "" && rawCPU == "") || (orgMem != "" && rawMem == "") || (orgTTLSet && rawTTL == "")
+
 	// Normalize the sizes so reuse-matching is canonical ("16Gi" == "16384Mi").
 	cpuN, _, err := sizeField(gucWorkerCPU, cpu, "", "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid default worker cpu: %w", err)
+		return nil, nil, false, fmt.Errorf("invalid default worker cpu: %w", err)
 	}
 	memN, _, err := sizeField(gucWorkerMemory, mem, "", "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid default worker memory: %w", err)
+		return nil, nil, false, fmt.Errorf("invalid default worker memory: %w", err)
 	}
 
-	return &WorkerProfile{CPU: cpuN, Memory: memN, TTL: ttl}, warns, nil
+	return &WorkerProfile{CPU: cpuN, Memory: memN, TTL: ttl}, warns, orgApplied, nil
 }
 
 // sizeField normalizes a client-supplied size and, when min/max are set, bounds
@@ -135,16 +205,16 @@ func sizeField(name, raw, min, max string) (normalized, warn string, err error) 
 
 // ttlField parses a worker TTL (Go duration) and clamps it to [0,maxTTL] when
 // maxTTL > 0. ttl=0 means "retire as soon as the last query finishes".
-func ttlField(raw string, maxTTL time.Duration) (time.Duration, string, error) {
+func ttlField(name, raw string, maxTTL time.Duration) (time.Duration, string, error) {
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		return 0, "", fmt.Errorf("%s: invalid duration %q", gucWorkerTTL, raw)
+		return 0, "", fmt.Errorf("%s: invalid duration %q", name, raw)
 	}
 	if d < 0 {
-		return 0, "", fmt.Errorf("%s: duration %q must be >= 0", gucWorkerTTL, raw)
+		return 0, "", fmt.Errorf("%s: duration %q must be >= 0", name, raw)
 	}
 	if maxTTL > 0 && d > maxTTL {
-		return maxTTL, fmt.Sprintf("%s %q clamped to %q", gucWorkerTTL, raw, maxTTL.String()), nil
+		return maxTTL, fmt.Sprintf("%s %q clamped to %q", name, raw, maxTTL.String()), nil
 	}
 	return d, "", nil
 }

--- a/controlplane/worker_profile_test.go
+++ b/controlplane/worker_profile_test.go
@@ -1,9 +1,14 @@
 package controlplane
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
+
+// noOrgDefaults is the zero org default profile — single-tenant deployments
+// and orgs with no default_worker_* columns set.
+var noOrgDefaults = orgWorkerProfileDefaults{}
 
 // newSizingTestCP builds a ControlPlane whose K8s config enables client worker
 // sizing with a prod-shaped clamp policy and explicit defaults.
@@ -25,7 +30,7 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 	tests := []struct {
 		name     string
 		opts     map[string]string
-		wantNil  bool // expect the default (nil) profile — matches the neutral warm pool
+		wantNil  bool   // expect the default (nil) profile — matches the neutral warm pool
 		wantKey  string // CPU|Memory (only when !wantNil)
 		wantTTL  time.Duration
 		wantErr  bool
@@ -47,7 +52,10 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, warns, err := cp.resolveWorkerProfile(tt.opts)
+			got, warns, orgApplied, err := cp.resolveWorkerProfile(tt.opts, noOrgDefaults)
+			if orgApplied {
+				t.Fatal("orgApplied must be false without org defaults")
+			}
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got profile=%v", got)
@@ -87,7 +95,7 @@ func TestResolveWorkerProfileSizing(t *testing.T) {
 func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
 	cp := newSizingTestCP()
 	cp.cfg.K8s.AllowClientWorkerProfile = false
-	got, warns, err := cp.resolveWorkerProfile(map[string]string{gucWorkerCPU: "garbage", gucWorkerTTL: "nope"})
+	got, warns, orgApplied, err := cp.resolveWorkerProfile(map[string]string{gucWorkerCPU: "garbage", gucWorkerTTL: "nope"}, noOrgDefaults)
 	if err != nil {
 		t.Fatalf("gate off must never error, got %v", err)
 	}
@@ -97,6 +105,9 @@ func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
 	if got != nil {
 		t.Fatalf("gate off must return the default (nil) profile, got %s", got.MatchKey())
 	}
+	if orgApplied {
+		t.Fatal("orgApplied must be false without org defaults")
+	}
 }
 
 // A no-sizing request must return the nil default sentinel so it matches the
@@ -104,7 +115,7 @@ func TestResolveWorkerProfileSizing_GateOff(t *testing.T) {
 // broke worker acquisition on a warm-pool-enabled deploy).
 func TestResolveWorkerProfileSizing_NoSizingIsNil(t *testing.T) {
 	cp := newSizingTestCP()
-	got, _, err := cp.resolveWorkerProfile(map[string]string{})
+	got, _, _, err := cp.resolveWorkerProfile(map[string]string{}, noOrgDefaults)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,11 +128,206 @@ func TestResolveWorkerProfileSizing_NoSizingIsNil(t *testing.T) {
 // 8/16Gi/20m applies for the omitted fields.
 func TestResolveWorkerProfileSizing_BuiltinDefaults(t *testing.T) {
 	cp := &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{AllowClientWorkerProfile: true}}}
-	got, _, err := cp.resolveWorkerProfile(map[string]string{gucWorkerTTL: "1m"})
+	got, _, _, err := cp.resolveWorkerProfile(map[string]string{gucWorkerTTL: "1m"}, noOrgDefaults)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got == nil || got.CPU != defaultWorkerCPU || got.Memory != defaultWorkerMemory || got.TTL != time.Minute {
 		t.Fatalf("built-in defaults = %v, want %s/%s/1m", got, defaultWorkerCPU, defaultWorkerMemory)
+	}
+}
+
+// Org default worker profile (operator-set via the admin API): when the client
+// sends no sizing GUCs, the org default produces a concrete profile; partially
+// set org defaults fall back per-field to the pool-global/built-in defaults;
+// client GUCs override per-field; an org default never errors.
+func TestResolveWorkerProfileOrgDefaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           map[string]string
+		org            orgWorkerProfileDefaults
+		wantNil        bool
+		wantKey        string
+		wantTTL        time.Duration
+		wantOrgApplied bool
+		wantWarn       string // substring expected in a warning, "" = no warnings expected
+	}{
+		{
+			name:           "org default all three fields",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{CPU: "2", Memory: "8Gi", TTL: "10m"},
+			wantKey:        "2|8Gi",
+			wantTTL:        10 * time.Minute,
+			wantOrgApplied: true,
+		},
+		{
+			name:           "org cpu only -> mem/ttl fall back to pool-global/built-in",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{CPU: "2"},
+			wantKey:        "2|16Gi",
+			wantTTL:        defaultWorkerTTL,
+			wantOrgApplied: true,
+		},
+		{
+			name:           "org ttl only -> size falls back to pool-global",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{TTL: "45m"},
+			wantKey:        "8|16Gi",
+			wantTTL:        45 * time.Minute,
+			wantOrgApplied: true,
+		},
+		{
+			name:           "org default normalized (4000m -> 4)",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{CPU: "4000m", Memory: "8192Mi"},
+			wantKey:        "4|8Gi",
+			wantTTL:        defaultWorkerTTL,
+			wantOrgApplied: true,
+		},
+		{
+			name: "org default NOT clamped to WorkerProfileMax (operator config)",
+			opts: map[string]string{},
+			// Above the client clamp band (max cpu 16 / max mem 64Gi).
+			org:            orgWorkerProfileDefaults{CPU: "46", Memory: "360Gi"},
+			wantKey:        "46|360Gi",
+			wantTTL:        defaultWorkerTTL,
+			wantOrgApplied: true,
+		},
+		{
+			name:           "org ttl clamped by WorkerMaxTTL",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{TTL: "24h"},
+			wantKey:        "8|16Gi",
+			wantTTL:        time.Hour, // WorkerMaxTTL in newSizingTestCP
+			wantOrgApplied: true,
+			wantWarn:       "clamped",
+		},
+		{
+			name:           "client cpu overrides org cpu; org mem+ttl survive",
+			opts:           map[string]string{gucWorkerCPU: "4"},
+			org:            orgWorkerProfileDefaults{CPU: "2", Memory: "8Gi", TTL: "10m"},
+			wantKey:        "4|8Gi",
+			wantTTL:        10 * time.Minute,
+			wantOrgApplied: true,
+		},
+		{
+			name:           "client sets all -> org default fully overridden",
+			opts:           map[string]string{gucWorkerCPU: "4", gucWorkerMemory: "32Gi", gucWorkerTTL: "5m"},
+			org:            orgWorkerProfileDefaults{CPU: "2", Memory: "8Gi", TTL: "10m"},
+			wantKey:        "4|32Gi",
+			wantTTL:        5 * time.Minute,
+			wantOrgApplied: false,
+		},
+		{
+			name:           "invalid org cpu ignored with warning -> nil profile",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{CPU: "lots"},
+			wantNil:        true,
+			wantOrgApplied: false,
+			wantWarn:       "org default worker cpu",
+		},
+		{
+			name:           "negative org ttl ignored with warning -> nil profile",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{TTL: "-5m"},
+			wantNil:        true,
+			wantOrgApplied: false,
+			wantWarn:       "org default worker ttl",
+		},
+		{
+			name:           "invalid org mem ignored, valid org cpu still applies",
+			opts:           map[string]string{},
+			org:            orgWorkerProfileDefaults{CPU: "2", Memory: "garbage"},
+			wantKey:        "2|16Gi",
+			wantTTL:        defaultWorkerTTL,
+			wantOrgApplied: true,
+			wantWarn:       "org default worker memory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := newSizingTestCP()
+			got, warns, orgApplied, err := cp.resolveWorkerProfile(tt.opts, tt.org)
+			if err != nil {
+				t.Fatalf("org defaults must never error the connection, got %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil (default) profile, got %s", got.MatchKey())
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("expected concrete profile %q, got nil", tt.wantKey)
+				}
+				if got.MatchKey() != tt.wantKey {
+					t.Fatalf("MatchKey = %q, want %q", got.MatchKey(), tt.wantKey)
+				}
+				if got.TTL != tt.wantTTL {
+					t.Fatalf("TTL = %s, want %s", got.TTL, tt.wantTTL)
+				}
+			}
+			if orgApplied != tt.wantOrgApplied {
+				t.Fatalf("orgApplied = %v, want %v", orgApplied, tt.wantOrgApplied)
+			}
+			if tt.wantWarn == "" {
+				if len(warns) != 0 {
+					t.Fatalf("unexpected warnings: %v", warns)
+				}
+			} else {
+				found := false
+				for _, w := range warns {
+					if strings.Contains(w, tt.wantWarn) {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("warnings %v missing %q", warns, tt.wantWarn)
+				}
+			}
+		})
+	}
+}
+
+// Org defaults apply even when AllowClientWorkerProfile is off: the gate is
+// about trusting client startup options, not operator config. Client GUCs are
+// still ignored (even garbage ones), so the org default is the whole profile.
+func TestResolveWorkerProfileOrgDefaults_GateOff(t *testing.T) {
+	cp := newSizingTestCP()
+	cp.cfg.K8s.AllowClientWorkerProfile = false
+	got, warns, orgApplied, err := cp.resolveWorkerProfile(
+		map[string]string{gucWorkerCPU: "4", gucWorkerTTL: "garbage"},
+		orgWorkerProfileDefaults{CPU: "2", Memory: "8Gi", TTL: "10m"},
+	)
+	if err != nil {
+		t.Fatalf("gate off must never error, got %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("unexpected warnings: %v", warns)
+	}
+	if got == nil {
+		t.Fatal("org default must apply with the client gate off, got nil profile")
+	}
+	if got.MatchKey() != "2|8Gi" || got.TTL != 10*time.Minute {
+		t.Fatalf("profile = %s/%s, want 2|8Gi/10m (client GUCs must be ignored)", got.MatchKey(), got.TTL)
+	}
+	if !orgApplied {
+		t.Fatal("orgApplied must be true when the org default shaped the profile")
+	}
+}
+
+// An org default with no pool-global request configured falls back to the
+// built-in 8/16Gi for unset size fields (mirrors the client path).
+func TestResolveWorkerProfileOrgDefaults_BuiltinFallback(t *testing.T) {
+	cp := &ControlPlane{cfg: ControlPlaneConfig{K8s: K8sConfig{}}}
+	got, _, orgApplied, err := cp.resolveWorkerProfile(map[string]string{}, orgWorkerProfileDefaults{TTL: "30m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.CPU != defaultWorkerCPU || got.Memory != defaultWorkerMemory || got.TTL != 30*time.Minute {
+		t.Fatalf("profile = %v, want %s/%s/30m", got, defaultWorkerCPU, defaultWorkerMemory)
+	}
+	if !orgApplied {
+		t.Fatal("orgApplied must be true")
 	}
 }

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -66,6 +66,18 @@ client-go:
   can't satisfy the second from the first's hot-idle pool. There is no warm pool,
   so the only workers are the ones a request sizes + spawns on demand.
   Clamp enforcement itself is unit-covered (`controlplane/worker_profile_test.go`).
+- **org default worker profile** — an operator-set per-org default worker shape
+  + hot-idle TTL (config-store columns `default_worker_cpu`/`memory`/`ttl`, set
+  via the admin API `PUT /orgs/:id`) must size a **plain** connection — one that
+  sends no `duckgres.worker_*` startup options at all (the external-customer
+  case). The harness sets `2/8Gi/10m` on the ext org, asserts the admin API
+  round-trips the fields and 400s garbage values, then connects without
+  `PGOPTIONS` and asserts the worker pod carries the org default on requests
+  **and** limits; finally it clears the default (explicit empty strings) and
+  asserts a fresh plain connection no longer produces org-default-shaped pods.
+  Per-field client-GUC-over-org-default precedence and the
+  AllowClientWorkerProfile-independence of org defaults are unit-covered
+  (`controlplane/worker_profile_test.go`).
 - **extension forks** — the bundled `ducklake`/`httpfs` extensions are the
   PostHog forks, not upstream (ported from the `*IsBundledFork` tests).
 - **worker pods** — labels (`app`, `duckgres/control-plane`,

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -21,6 +21,11 @@
 #                  spawns a worker pod carrying the requested CPU+memory, and a
 #                  same-shape reconnect reuses that hot-idle worker (no respawn)
 #                  — asserted on cnpg for BOTH the ducklake and iceberg catalogs.
+#   org default  : an operator-set org default worker profile (admin PUT
+#                  /orgs/:id default_worker_cpu/memory/ttl) sizes a PLAIN
+#                  connection's worker pod (no client GUCs); garbage values are
+#                  rejected with 400 at the API boundary; clearing the default
+#                  restores the deployment default shape — asserted on ext.
 #   ext forks    : the bundled ducklake/httpfs extensions are the PostHog forks,
 #                  not upstream (detects an accidental upstream swap in the image).
 #   worker pods  : labels, securityContext (non-root, no priv-esc), Downward-API
@@ -519,6 +524,82 @@ reuse_sized_worker() { # org password catalog cpu memory ttl
   log "sized worker reuse OK: 1 pod of cpu=$cpu (reused, no respawn)"
 }
 
+# ---- org default worker profile --------------------------------------------
+# Operators can give a tenant a server-side default worker shape + hot-idle TTL
+# (config-store columns default_worker_cpu/memory/ttl, set via the admin API).
+# External customers send plain connection strings — no duckgres.worker_* GUCs —
+# so the org default is the only way to size them. Assert end-to-end:
+#   1. PUT /orgs/:id with the three fields persists and round-trips on GET;
+#      garbage values are rejected with 400 (they must never enter the store).
+#   2. After the CP's config-store poll, a connection with NO sizing options
+#      gets a worker pod whose requests AND limits equal the org default.
+#   3. Clearing the default (explicit empty strings) restores the deployment
+#      default shape: a fresh plain connection must NOT produce another
+#      org-default-shaped pod (a default/nil profile can never exact-match the
+#      sized shape, so reuse/spawn goes back to default-profile workers).
+# Uses a shape (2/8Gi) no other test on this org uses, so the newest worker pod
+# after the connect is unambiguously ours (same technique as sized_worker; the
+# ext org runs no client-sized assertions).
+put_org() { # org json -> prints http code; body in /tmp/put_org_out
+  curl -s -o /tmp/put_org_out -w '%{http_code}' -X PUT -H "$H" \
+    -H 'Content-Type: application/json' -d "$2" "$API/api/v1/orgs/$1"
+}
+get_org_default_profile() { # org -> prints "cpu|mem|ttl" ("||" when unset)
+  curl -fsS -H "$H" "$API/api/v1/orgs/$1" \
+    | jq -r '"\(.default_worker_cpu)|\(.default_worker_memory)|\(.default_worker_ttl)"'
+}
+org_default_profile() { # org password catalog
+  org="$1"; pw="$2"; cat="$3"; cpu=2; mem=8Gi; ttl=10m
+  log "org default worker profile on $org/$cat: cpu=$cpu memory=$mem ttl=$ttl"
+
+  code="$(put_org "$org" "{\"default_worker_cpu\":\"$cpu\",\"default_worker_memory\":\"$mem\",\"default_worker_ttl\":\"$ttl\"}")"
+  [ "$code" = "200" ] || fail "org default: PUT /orgs/$org -> HTTP $code: $(cat /tmp/put_org_out)"
+  got="$(get_org_default_profile "$org")"
+  [ "$got" = "$cpu|$mem|$ttl" ] || fail "org default: GET round-trip '$got' want '$cpu|$mem|$ttl'"
+
+  # Garbage must be rejected at the API boundary, never stored.
+  code="$(put_org "$org" '{"default_worker_ttl":"whenever"}')"
+  [ "$code" = "400" ] || fail "org default: invalid ttl accepted (HTTP $code, want 400)"
+  code="$(put_org "$org" '{"default_worker_cpu":"-2"}')"
+  [ "$code" = "400" ] || fail "org default: negative cpu accepted (HTTP $code, want 400)"
+  got="$(get_org_default_profile "$org")"
+  [ "$got" = "$cpu|$mem|$ttl" ] || fail "org default: rejected PUT mutated the org: '$got'"
+
+  # Wait out the CP's config-store poll so its snapshot carries the default.
+  sleep "${CONFIG_POLL_SETTLE:-40}"
+
+  # PLAIN connection: no PGOPTIONS / duckgres.* startup options at all.
+  pg "$org" "$pw" "$cat" 'SELECT 1' >/dev/null
+  pod="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$org" \
+        --sort-by=.metadata.creationTimestamp \
+        -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null)"
+  [ -n "$pod" ] || fail "org default: no worker pod for $org"
+  rcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.cpu}")"
+  rmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.memory}")"
+  lcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.limits.cpu}")"
+  lmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.limits.memory}")"
+  [ "$rcpu" = "$cpu" ] || fail "org default: $pod requests.cpu='$rcpu' want '$cpu' (org default not applied to a plain connection)"
+  [ "$rmem" = "$mem" ] || fail "org default: $pod requests.memory='$rmem' want '$mem'"
+  [ "$lcpu" = "$cpu" ] || fail "org default: $pod limits.cpu='$lcpu' want '$cpu'"
+  [ "$lmem" = "$mem" ] || fail "org default: $pod limits.memory='$lmem' want '$mem'"
+  log "org default OK: plain connection got $pod cpu=$rcpu mem=$rmem"
+
+  # Clear and assert a fresh plain connection is back on the deployment default
+  # shape: the count of org-default-shaped pods must not grow (a nil/default
+  # profile can never exact-match the 2-CPU shape, so a regrow means the org
+  # default is still being applied).
+  code="$(put_org "$org" '{"default_worker_cpu":"","default_worker_memory":"","default_worker_ttl":""}')"
+  [ "$code" = "200" ] || fail "org default: clear PUT -> HTTP $code: $(cat /tmp/put_org_out)"
+  got="$(get_org_default_profile "$org")"
+  [ "$got" = "||" ] || fail "org default: not cleared on GET: '$got'"
+  sleep "${CONFIG_POLL_SETTLE:-40}"
+  before="$(count_org_workers_of_cpu "$org" "$cpu")"
+  pg "$org" "$pw" "$cat" 'SELECT 1' >/dev/null
+  after="$(count_org_workers_of_cpu "$org" "$cpu")"
+  [ "$after" -le "$before" ] || fail "org default: cleared default still spawns $cpu-cpu workers ($before -> $after)"
+  log "org default OK: cleared; plain connection back on the deployment default shape"
+}
+
 # ---- resilience -----------------------------------------------------------
 # Worker pod killed mid-life → CP refills and a fresh query succeeds.
 # Ported from TestK8sWorkerCrashRecovery.
@@ -879,6 +960,10 @@ main() {
   rw_ducklake  "$EXT" "$ext_pw"
   rw_iceberg   "$EXT" "$ext_pw"
 
+  # ---- org default worker profile (server-side sizing, no client GUCs) ----
+  # On ext (no client-sized assertions there, so the 2-CPU shape is unique).
+  org_default_profile "$EXT" "$ext_pw" ducklake
+
   # ---- cross-tenant isolation (cnpg vs ext) ----
   tenant_isolation "$CNPG" "$cnpg_pw" "$EXT" "$ext_pw"
 
@@ -889,7 +974,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"


### PR DESCRIPTION
## Motivation

Worker pods are sized per session via client startup options (`duckgres.worker_cpu` / `worker_memory` / `worker_ttl`, gated by `AllowClientWorkerProfile`). A connection with no sizing GUCs gets the nil DEFAULT profile → the pool-global exclusive shape (46cpu/360Gi on prod) with the janitor-fallback hot-idle TTL (5m). External customers send plain connection strings — we cannot ask every customer to add GUCs (the sqlmesh tenant's hourly jobs stalled on cold bootstrap precisely because every connection paid the default-shape cold-spawn). Operators need a server-side, per-org way to set a tenant's default worker shape + hot-idle TTL.

This adds three additive org columns — `default_worker_cpu`, `default_worker_memory`, `default_worker_ttl` (Go duration string, stored as text for human editability) — settable via the authenticated admin API, and threads them into worker-profile resolution at session setup.

## Precedence (per field — cpu, memory, ttl independently)

| Layer | When | Clamps |
|---|---|---|
| 1. client GUC | `AllowClientWorkerProfile` on and the GUC set | `WorkerProfileMin/Max*` + `WorkerMaxTTL` (unchanged) |
| 2. org default | field set on the org row, valid | none for size; TTL bounded by `WorkerMaxTTL` |
| 3. pool-global `WorkerCPURequest`/`MemoryRequest` | configured | — |
| 4. built-in | always | `8` / `16Gi` / `20m` |

The org default is the *base layer under* client GUCs: a client that sets only `worker_cpu` still gets the org's default memory + TTL for the omitted fields. With no client sizing and no org default, behavior is exactly as today (nil profile, MatchKey `"|"`, pool-global shape — warm-pool reuse semantics untouched). Single-tenant / non-k8s paths are unaffected (no config store → no org defaults).

## Why org defaults bypass the client clamps

`WorkerProfileMin/Max*` exist to bound *client-supplied* input. Org defaults are operator config set through the authenticated admin API — clamping them would prevent giving a tenant a shape larger than the client ceiling (the whole point for heavy tenants). They are still validated/normalized (positive, parseable k8s quantities; TTL ≥ 0 and bounded by `WorkerMaxTTL`), at two layers:

- **admin API boundary**: garbage values → 400, so they can never enter the store;
- **resolution time**: an invalid stored field is ignored with a warning and falls back as if unset — a bad config-store row must never break connections.

Org defaults also apply regardless of `AllowClientWorkerProfile`: that gate is about trusting client startup options, not operator config (client GUCs stay ignored when the gate is off).

## Known issue this supersedes (not touched)

The org-level `worker_cpu_request`/`worker_memory_request` columns are NOT this feature: `org_router.go::createOrgStack` feeds them into `sharedPool.SetWorkerResources`, mutating the **global** pool default — last org wins. That footgun is currently unused in prod (all org rows have them empty) and is left as-is; for per-tenant sizing purposes this feature supersedes it.

## Observability

When an org default shapes a session's profile, the CP logs once per connection at Info: `Applied org default worker profile.` with org, user, and the resolved cpu/memory/ttl — so support can see which shape a tenant got.

## Tests

- `controlplane/worker_profile_test.go` — org default only (all three / subsets / normalization); per-field client-over-org merge (client cpu + org memory+ttl); client-sets-all → org fully overridden; org defaults NOT clamped to `WorkerProfileMax` (46/360Gi passes through); org TTL clamped by `WorkerMaxTTL`; invalid org field → warning + per-field fallback (nil profile when nothing else set, never an error); `AllowClientWorkerProfile=false` still applies org defaults while ignoring (even garbage) client GUCs; built-in fallback with no pool-global request.
- `controlplane/admin/api_test.go` — PUT sets / explicit-empty clears / omitted preserves the three fields; response JSON round-trips them; invalid quantity/duration → 400 (update and create); create accepts the fields.
- `controlplane/configstore/store_test.go` — `OrgDefaultWorkerProfile` snapshot accessor (unknown org, unset, full, partial, nil snapshot).
- `go test ./...`, `go test -tags kubernetes ./controlplane/...`, `go vet (-tags kubernetes) ./controlplane/...` clean; touched files `gofmt`-clean (this also formats the pre-existing unformatted `Org`/`K8sConfig` structs in files this PR touches). Note: `go test -tags kubernetes ./controlplane/ -race` has pre-existing failures in `k8s_pool` lifecycle tests on origin/main (verified via stash) — unrelated to this change and owned by the #741 work area.

## e2e harness (`tests/e2e-mw-dev`)

New `org_default_profile` assertion (on the ext org, where no client-sized shapes exist, so the `2/8Gi` shape is unambiguous — same newest-pod technique as the #709 `sized_worker` checks):

1. admin `PUT /orgs/:id` sets `default_worker_cpu=2 / memory=8Gi / ttl=10m`; GET round-trips; garbage ttl and negative cpu → 400 and don't mutate the row;
2. after the config-store poll settle, a **plain** psql connection (no `PGOPTIONS`) gets a worker pod whose requests **and** limits equal the org default;
3. clearing the default (explicit empty strings) round-trips, and a fresh plain connection no longer produces org-default-shaped pods (count of 2-CPU pods must not grow — a nil/default profile can never exact-match the sized shape).

README coverage list updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
