### PR TITLE
fix(e2e): pin CP + config-store pods against Karpenter consolidation mid-run

### DIFF
--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -44,6 +44,11 @@ spec:
   template:
     metadata:
       labels: { app: duckgres-config-store }
+      annotations:
+        # Same consolidation pinning as the control plane below: a mid-run
+        # config-store reschedule forces the CP through a pod restart + PVC
+        # reattach pause the harness has no retry budget for.
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       containers:
         - name: postgres
@@ -196,6 +201,14 @@ spec:
   template:
     metadata:
       labels: { app: duckgres-control-plane }
+      annotations:
+        # The harness asserts against this single-replica CP for ~10 minutes.
+        # Worker churn from the cold-burst / sized-worker assertions empties
+        # nodes mid-run, and a Karpenter consolidation sweep that disrupts the
+        # CP's node kills the run at whatever assertion happens to be next
+        # (observed as "control plane is draining" / connection-refused at the
+        # sized-reuse step). Pin the pod for the run's lifetime.
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: duckgres
       containers:


### PR DESCRIPTION
Two clean runs of #738 died at the `sized worker reuse` assertion with "control plane is draining" / connection-refused; the run diagnostics show the CP pod **11s old, ContainerCreating** at failure time — the CP was evicted mid-harness and the harness has no retry budget for that.

Mechanism: the cold-burst (#741) and sized-worker (#709) assertions spawn and retire enough workers to empty nodes mid-run; a Karpenter consolidation sweep that disrupts the CP's node kills whichever assertion runs next. It reproduces at a quasi-deterministic phase of the harness (right after the burst workers retire).

Fix: `karpenter.sh/do-not-disrupt: "true"` on the e2e CP and config-store pod templates — pinned only for the per-PR run's lifetime; teardown deletes the namespace regardless. (Prod CPs are already protected differently — charts#11718.)

This PR's own e2e run is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)