### PR TITLE
fix(sessionmeta): survive cold Iceberg catalog settling at session init

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1213,9 +1213,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		// the bind with `Schema with name "" not found` until the instance settles.
 		// Best-effort: if the prime errors, the real failure (if any) surfaces from
 		// InitSessionDatabaseMetadata with its full context.
-		if prime := icebergCatalogPrimeCommand(effectiveCatalog); prime != "" {
+		if icebergAttached {
 			primeCtx, primeCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
-			if _, err := executor.ExecContext(primeCtx, prime); err != nil {
+			if err := sessionmeta.PrimeIcebergCatalog(primeCtx, executor, physicalIcebergCatalog); err != nil {
 				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "user", username, "org", orgID, "error", err, "worker", workerID, "worker_pod", workerPod)
 			}
 			primeCancel()

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1207,6 +1207,19 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// worker session stays in DuckDB's empty in-memory catalog (see the
 	// passthrough branch below).
 	if !passthroughUser {
+		// Prime the Iceberg REST catalog's schema list on this session connection
+		// before the compat-view bind below enumerates every attached catalog.
+		// Without this, the first session on a freshly-spawned (cold) worker fails
+		// the bind with `Schema with name "" not found` until the instance settles.
+		// Best-effort: if the prime errors, the real failure (if any) surfaces from
+		// InitSessionDatabaseMetadata with its full context.
+		if prime := icebergCatalogPrimeCommand(effectiveCatalog); prime != "" {
+			primeCtx, primeCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
+			if _, err := executor.ExecContext(primeCtx, prime); err != nil {
+				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "user", username, "org", orgID, "error", err, "worker", workerID, "worker_pod", workerPod)
+			}
+			primeCancel()
+		}
 		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
 		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, effectiveCatalog); err != nil {
 			initCancel()

--- a/controlplane/session_search_path.go
+++ b/controlplane/session_search_path.go
@@ -62,31 +62,6 @@ func effectiveSessionDefaultCommand(clientSearchPath, effectiveCatalog string) (
 	}
 }
 
-// icebergCatalogPrimeCommand returns a command to run on the session connection
-// BEFORE InitSessionDatabaseMetadata binds the pg_catalog compat views, or "" if
-// the session's catalog needs no priming (DuckLake has no REST catalog).
-//
-// On the first session of a freshly-spawned worker the Iceberg REST catalog is
-// attached but its schema list has not yet been materialized on the new session
-// connection. InitSessionDatabaseMetadata binds compat views that enumerate
-// EVERY attached catalog (via information_schema / duckdb_* functions); an
-// Iceberg catalog whose schemas aren't loaded yet surfaces a schema with an
-// empty name, so the bind fails with `Catalog Error: Schema with name "" not
-// found` and the connection is rejected. A reconnect succeeds only because the
-// instance has since settled — exactly the cold-start flakiness we must avoid
-// now that there is no warm pool to absorb the first session per worker.
-//
-// Issuing `USE iceberg.<schema>` first forces a synchronous, targeted schema
-// resolve (the same call worker activation already makes successfully on a cold
-// worker), priming the catalog so the subsequent enumeration is clean. It is a
-// no-op on a session that has already touched Iceberg.
-func icebergCatalogPrimeCommand(effectiveCatalog string) string {
-	if effectiveCatalog == iceberg.CatalogName {
-		return fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
-	}
-	return ""
-}
-
 // passthroughSessionDefaultCatalogCommand returns the connect-time command that
 // points a passthrough session at the catalog it selected (effectiveCatalog).
 // Passthrough users skip InitSessionDatabaseMetadata (whose defer issues the

--- a/controlplane/session_search_path.go
+++ b/controlplane/session_search_path.go
@@ -62,6 +62,31 @@ func effectiveSessionDefaultCommand(clientSearchPath, effectiveCatalog string) (
 	}
 }
 
+// icebergCatalogPrimeCommand returns a command to run on the session connection
+// BEFORE InitSessionDatabaseMetadata binds the pg_catalog compat views, or "" if
+// the session's catalog needs no priming (DuckLake has no REST catalog).
+//
+// On the first session of a freshly-spawned worker the Iceberg REST catalog is
+// attached but its schema list has not yet been materialized on the new session
+// connection. InitSessionDatabaseMetadata binds compat views that enumerate
+// EVERY attached catalog (via information_schema / duckdb_* functions); an
+// Iceberg catalog whose schemas aren't loaded yet surfaces a schema with an
+// empty name, so the bind fails with `Catalog Error: Schema with name "" not
+// found` and the connection is rejected. A reconnect succeeds only because the
+// instance has since settled — exactly the cold-start flakiness we must avoid
+// now that there is no warm pool to absorb the first session per worker.
+//
+// Issuing `USE iceberg.<schema>` first forces a synchronous, targeted schema
+// resolve (the same call worker activation already makes successfully on a cold
+// worker), priming the catalog so the subsequent enumeration is clean. It is a
+// no-op on a session that has already touched Iceberg.
+func icebergCatalogPrimeCommand(effectiveCatalog string) string {
+	if effectiveCatalog == iceberg.CatalogName {
+		return fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
+	}
+	return ""
+}
+
 // passthroughSessionDefaultCatalogCommand returns the connect-time command that
 // points a passthrough session at the catalog it selected (effectiveCatalog).
 // Passthrough users skip InitSessionDatabaseMetadata (whose defer issues the

--- a/controlplane/session_search_path_test.go
+++ b/controlplane/session_search_path_test.go
@@ -98,19 +98,3 @@ func TestResolveEffectiveCatalog(t *testing.T) {
 	}
 }
 
-func TestIcebergCatalogPrimeCommand(t *testing.T) {
-	// Iceberg sessions get a synchronous `USE iceberg.<schema>` prime before the
-	// compat-view bind so a cold worker's first session doesn't fail on an
-	// unmaterialized REST catalog ("Schema with name \"\" not found").
-	if got := icebergCatalogPrimeCommand("iceberg"); got != "USE iceberg.public" {
-		t.Fatalf("iceberg prime = %q, want %q", got, "USE iceberg.public")
-	}
-	// DuckLake has no REST catalog, so no prime.
-	if got := icebergCatalogPrimeCommand("ducklake"); got != "" {
-		t.Fatalf("ducklake prime = %q, want empty", got)
-	}
-	// Unknown/empty catalog → no prime.
-	if got := icebergCatalogPrimeCommand(""); got != "" {
-		t.Fatalf("empty prime = %q, want empty", got)
-	}
-}

--- a/controlplane/session_search_path_test.go
+++ b/controlplane/session_search_path_test.go
@@ -97,3 +97,20 @@ func TestResolveEffectiveCatalog(t *testing.T) {
 		})
 	}
 }
+
+func TestIcebergCatalogPrimeCommand(t *testing.T) {
+	// Iceberg sessions get a synchronous `USE iceberg.<schema>` prime before the
+	// compat-view bind so a cold worker's first session doesn't fail on an
+	// unmaterialized REST catalog ("Schema with name \"\" not found").
+	if got := icebergCatalogPrimeCommand("iceberg"); got != "USE iceberg.public" {
+		t.Fatalf("iceberg prime = %q, want %q", got, "USE iceberg.public")
+	}
+	// DuckLake has no REST catalog, so no prime.
+	if got := icebergCatalogPrimeCommand("ducklake"); got != "" {
+		t.Fatalf("ducklake prime = %q, want empty", got)
+	}
+	// Unknown/empty catalog → no prime.
+	if got := icebergCatalogPrimeCommand(""); got != "" {
+		t.Fatalf("empty prime = %q, want empty", got)
+	}
+}

--- a/server/conn.go
+++ b/server/conn.go
@@ -799,6 +799,18 @@ func (c *clientConn) serve() error {
 		case icebergAttached:
 			catalog = iceberg.CatalogName
 		}
+		// Prime the Iceberg REST catalog's schema list on this connection before the
+		// compat-view bind in InitSessionDatabaseMetadata enumerates every attached
+		// catalog. On the first session of a cold backing instance an unmaterialized
+		// Iceberg catalog otherwise surfaces a schema with an empty name, failing the
+		// bind with `Schema with name "" not found`. Best-effort: a real failure
+		// still surfaces from InitSessionDatabaseMetadata below.
+		if catalog == iceberg.CatalogName {
+			primeStmt := fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
+			if _, err := c.executor.ExecContext(initCtx, primeStmt); err != nil {
+				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "error", err)
+			}
+		}
 		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, catalog); err != nil {
 			initCancel()
 			c.sendError("FATAL", "XX000", fmt.Sprintf("failed to initialize session database metadata: %v", err))

--- a/server/conn.go
+++ b/server/conn.go
@@ -805,9 +805,8 @@ func (c *clientConn) serve() error {
 		// Iceberg catalog otherwise surfaces a schema with an empty name, failing the
 		// bind with `Schema with name "" not found`. Best-effort: a real failure
 		// still surfaces from InitSessionDatabaseMetadata below.
-		if catalog == iceberg.CatalogName {
-			primeStmt := fmt.Sprintf("USE %s.%s", iceberg.CatalogName, iceberg.DefaultSchema)
-			if _, err := c.executor.ExecContext(initCtx, primeStmt); err != nil {
+		if icebergAttached {
+			if err := sessionmeta.PrimeIcebergCatalog(initCtx, c.executor, iceberg.CatalogName); err != nil {
 				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "error", err)
 			}
 		}

--- a/server/sessionmeta/sessionmeta.go
+++ b/server/sessionmeta/sessionmeta.go
@@ -15,10 +15,48 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/posthog/duckgres/server/icebergmeta"
 	"github.com/posthog/duckgres/server/sqlcore"
 )
+
+// PrimeIcebergCatalog forces the attached Iceberg REST catalog's schema list to
+// materialize on this session's DuckDB instance BEFORE the pg_catalog compat
+// views are bound. On the first session of a freshly-spawned (cold) worker the
+// catalog is attached but its schema list hasn't been loaded yet; the bind's
+// catalog enumeration then surfaces a schema with an empty name and fails with
+// `Catalog Error: Schema with name "" not found`. This probe runs that same
+// enumeration as a harmless SELECT, retrying until it succeeds (the failed
+// enumeration itself completes the load), bounded by ctx. Best-effort: callers
+// log a failure and proceed — the load-bearing error still comes from
+// InitSessionDatabaseMetadata with full context.
+func PrimeIcebergCatalog(ctx context.Context, executor sqlcore.QueryExecutor, catalog string) error {
+	if executor == nil {
+		return fmt.Errorf("session executor is required")
+	}
+	probe := fmt.Sprintf(
+		"SELECT count(*) FROM duckdb_schemas() WHERE database_name = %s",
+		quoteSQLStringLiteral(catalog),
+	)
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("prime %s catalog: %w (last probe error: %v)", catalog, ctx.Err(), lastErr)
+			case <-time.After(catalogSettleRetryDelay):
+			}
+		}
+		rows, err := executor.QueryContext(ctx, probe)
+		if err == nil {
+			_ = rows.Close()
+			return nil
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("prime %s catalog: %w", catalog, lastErr)
+}
 
 // InitSessionDatabaseMetadata installs session-local overrides for metadata
 // surfaces (current_database, pg_database, information_schema views) so they
@@ -63,10 +101,41 @@ func InitSessionDatabaseMetadata(ctx context.Context, executor sqlcore.QueryExec
 	}()
 
 	if _, err := executor.ExecContext(ctx, buildSessionMetadataSQL(catalog)); err != nil {
-		return fmt.Errorf("apply session metadata override: %w", err)
+		if !isCatalogSettlingError(err) {
+			return fmt.Errorf("apply session metadata override: %w", err)
+		}
+		// First session on a cold worker: an attached Iceberg REST catalog whose
+		// schema list isn't materialized on this DuckDB instance yet surfaces a
+		// schema with an empty name during the bind's catalog enumeration. The
+		// failed enumeration itself completes the load (observed: a second attempt
+		// on the same instance always succeeds), so retry the batch once.
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("apply session metadata override: %w", ctx.Err())
+		case <-time.After(catalogSettleRetryDelay):
+		}
+		if _, err := executor.ExecContext(ctx, buildSessionMetadataSQL(catalog)); err != nil {
+			return fmt.Errorf("apply session metadata override (after catalog-settle retry): %w", err)
+		}
 	}
 
 	return nil
+}
+
+// catalogSettleRetryDelay is the pause before retrying the metadata batch when
+// the first attempt failed on an unsettled (cold) attached catalog.
+const catalogSettleRetryDelay = 300 * time.Millisecond
+
+// isCatalogSettlingError reports whether err matches the bind failure produced
+// by enumerating an attached-but-not-yet-materialized Iceberg REST catalog on a
+// cold DuckDB instance (`Catalog Error: Schema with name "" not found`). Scoped
+// to the empty-name schema lookup so genuine missing-schema errors still fail
+// the session immediately.
+func isCatalogSettlingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), `Schema with name "" not found`)
 }
 
 func HasAttachedCatalog(ctx context.Context, executor sqlcore.QueryExecutor, catalog string) (bool, error) {

--- a/server/sessionmeta/sessionmeta_test.go
+++ b/server/sessionmeta/sessionmeta_test.go
@@ -237,3 +237,89 @@ func TestInformationSchemaColumnsCompatSuppressesNativeIcebergDuplicatesExplicit
 		t.Fatalf("columns compat SQL should not rely on hidden source_priority ranking in:\n%s", got)
 	}
 }
+
+func TestIsCatalogSettlingError(t *testing.T) {
+	if !isCatalogSettlingError(errors.New(`flight execute update: rpc error: code = InvalidArgument desc = failed to execute update: Catalog Error: Schema with name "" not found`)) {
+		t.Fatal("cold-catalog empty-name schema error not recognized as settling")
+	}
+	// A genuine missing schema must NOT be retried.
+	if isCatalogSettlingError(errors.New(`Catalog Error: Schema with name "analytics" not found`)) {
+		t.Fatal("named-schema error misclassified as settling")
+	}
+	if isCatalogSettlingError(nil) {
+		t.Fatal("nil misclassified")
+	}
+}
+
+// settleExecutor fails the metadata batch with the cold-catalog signature N
+// times, then succeeds — modeling an Iceberg REST catalog that materializes
+// after the first failed enumeration.
+type settleExecutor struct {
+	countingExecutor
+	batchFailures int
+}
+
+func (e *settleExecutor) ExecContext(ctx context.Context, query string, args ...any) (sqlcore.ExecResult, error) {
+	if strings.Contains(query, "pg_database") && e.batchFailures > 0 {
+		e.batchFailures--
+		e.execCalls++
+		return nil, errors.New(`failed to execute update: Catalog Error: Schema with name "" not found`)
+	}
+	return e.countingExecutor.ExecContext(ctx, query, args...)
+}
+
+func TestInitSessionDatabaseMetadataRetriesOnceOnSettlingCatalog(t *testing.T) {
+	e := &settleExecutor{batchFailures: 1}
+	e.queryRows = &singleIntRow{v: 0} // ducklake-attachment probe -> not attached
+	if err := InitSessionDatabaseMetadata(context.Background(), e, "iceberg"); err != nil {
+		t.Fatalf("init with one settling failure should succeed via retry, got %v", err)
+	}
+}
+
+func TestInitSessionDatabaseMetadataDoesNotRetryTwice(t *testing.T) {
+	e := &settleExecutor{batchFailures: 2}
+	e.queryRows = &singleIntRow{v: 0}
+	err := InitSessionDatabaseMetadata(context.Background(), e, "iceberg")
+	if err == nil {
+		t.Fatal("init with two settling failures must fail (single retry only)")
+	}
+	if !strings.Contains(err.Error(), "after catalog-settle retry") {
+		t.Fatalf("error should mark the exhausted retry, got %v", err)
+	}
+}
+
+// primeExecutor fails the schema-enumeration probe N times then succeeds.
+type primeExecutor struct {
+	countingExecutor
+	probeFailures int
+	probeCalls    int
+}
+
+func (e *primeExecutor) QueryContext(ctx context.Context, query string, args ...any) (sqlcore.RowSet, error) {
+	e.probeCalls++
+	if e.probeFailures > 0 {
+		e.probeFailures--
+		return nil, errors.New(`Catalog Error: Schema with name "" not found`)
+	}
+	return &singleIntRow{v: 1}, nil
+}
+
+func TestPrimeIcebergCatalogRetriesUntilEnumerationSucceeds(t *testing.T) {
+	e := &primeExecutor{probeFailures: 2}
+	if err := PrimeIcebergCatalog(context.Background(), e, "iceberg"); err != nil {
+		t.Fatalf("prime should succeed after settling, got %v", err)
+	}
+	if e.probeCalls != 3 {
+		t.Fatalf("probe calls = %d, want 3 (2 failures + 1 success)", e.probeCalls)
+	}
+}
+
+func TestPrimeIcebergCatalogGivesUpAfterBoundedAttempts(t *testing.T) {
+	e := &primeExecutor{probeFailures: 99}
+	if err := PrimeIcebergCatalog(context.Background(), e, "iceberg"); err == nil {
+		t.Fatal("prime must give up after bounded attempts")
+	}
+	if e.probeCalls != 5 {
+		t.Fatalf("probe calls = %d, want 5", e.probeCalls)
+	}
+}

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -16,7 +16,10 @@
 #                  jsonb || keeps Postgres concat semantics through
 #                  transpilation (#716), and a pipelined extended-query error
 #                  discards queued messages until Sync (#718).
-#   activation   : DuckLake + Iceberg catalogs attach and read/write.
+#   activation   : DuckLake + Iceberg catalogs attach and read/write. The FIRST
+#                  session on a cold Iceberg worker must not fail the pg_catalog
+#                  compat-view bind (the CP primes the REST catalog's schema list
+#                  first); asserted on cnpg + ext.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
 #                  same-shape reconnect reuses that hot-idle worker (no respawn)
@@ -412,6 +415,59 @@ rw_iceberg() { # org password
   n="$(pg "$1" "$2" iceberg "SELECT COUNT(*) FROM iceberg.public.$t;")"
   [ "$n" = "2" ] || fail "$1 Iceberg rowcount=$n want 2"
   pg "$1" "$2" iceberg "DROP TABLE iceberg.public.$t;"
+}
+
+# Regression for the Iceberg cold-start session-init bug: the FIRST session on a
+# freshly-spawned (cold) worker must not fail the pg_catalog compat-view bind.
+# Before the fix, InitSessionDatabaseMetadata enumerated every attached catalog
+# before anything had materialized the Iceberg REST catalog's schema list on the
+# new session connection, so the bind hit `Catalog Error: Schema with name ""
+# not found` and the connection was rejected with `failed to initialize session
+# database metadata`; only a reconnect (instance since settled) masked it. With
+# the warm pool gone, every org's first connect lands the literal first session
+# on its worker, so this fired in practice. The CP now primes the catalog
+# (`USE iceberg.<schema>`) before the bind. This forces a cold worker and asserts
+# the first connect succeeds: cold-spawn backpressure is still tolerated, but the
+# metadata-init bind error fails the test immediately instead of being retried
+# away (which is exactly how a live reconnect would mask it).
+iceberg_cold_first_connect() { # org password
+  log "iceberg cold first-connect (metadata-init regression) on $1"
+  # Force cold: delete every worker for the org and wait until none remain, so
+  # the next connect cold-spawns a brand-new worker whose first session is the
+  # client's — the precise condition that triggered the bug.
+  for p in $(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" -o name 2>/dev/null); do
+    k delete "$p" --grace-period=0 --force >/dev/null 2>&1 || true
+  done
+  i=0
+  while [ "$i" -lt 45 ]; do
+    n="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" --no-headers 2>/dev/null | grep -c . || true)"
+    [ "$n" = "0" ] && break
+    sleep 2; i=$((i + 1))
+  done
+  # First connect. Tolerate cold-spawn backpressure (worker still booting), but
+  # treat the session-metadata-init bind failure as a hard regression — do NOT
+  # retry it, or the bug would be masked exactly as a live reconnect masks it.
+  # The metadata-init clause is listed first so it wins over the broader
+  # "failed to initialize session" transient it is a prefix-superset of.
+  a=0 out=""
+  while [ "$a" -lt 12 ]; do
+    if out="$(PGPASSWORD="$2" psql \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=iceberg" \
+        -v ON_ERROR_STOP=1 -tAc "SELECT 1" 2>&1)"; then
+      [ "$out" = "1" ] || fail "iceberg_cold_first_connect: $1 returned '$out' want 1"
+      return
+    fi
+    case "$out" in
+      *"failed to initialize session database metadata"*|*'Schema with name "" not found'*)
+        fail "iceberg_cold_first_connect: cold first session hit the metadata-init bind bug on $1 (prime regressed): $out" ;;
+      *"capacity exhausted"*|*"no Duckgres worker"*|*"still provisioning"*|\
+      *"failed to initialize session"*|*"timed out waiting for an available worker"*|\
+      *"failed to start"*|*"spawn sized worker"*|*"failed to detect attached catalogs"*)
+        sleep 10; a=$((a + 1)); continue ;;
+      *) fail "iceberg_cold_first_connect: unexpected error on $1: $out" ;;
+    esac
+  done
+  fail "iceberg_cold_first_connect: exhausted retries waiting for a cold worker on $1"
 }
 
 # ---- worker pod assertions (via the K8s API) ------------------------------
@@ -927,6 +983,7 @@ main() {
   rw_ducklake            "$CNPG" "$cnpg_pw"
   pipeline_error_recovery "$CNPG" "$cnpg_pw"  # after rw_ducklake (table writes proven)
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
+  iceberg_cold_first_connect "$CNPG" "$cnpg_pw"  # cold first session must not fail the metadata-init bind
   rw_iceberg             "$CNPG" "$cnpg_pw"
   assert_worker_pod
   concurrent_connections "$CNPG" "$cnpg_pw"
@@ -958,6 +1015,7 @@ main() {
   wait_worker "$EXT" "$ext_pw" ducklake
   basic_query  "$EXT" "$ext_pw"
   rw_ducklake  "$EXT" "$ext_pw"
+  iceberg_cold_first_connect "$EXT" "$ext_pw"  # cold first session must not fail the metadata-init bind (ext backend)
   rw_iceberg   "$EXT" "$ext_pw"
 
   # ---- org default worker profile (server-side sizing, no client GUCs) ----
@@ -974,7 +1032,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + isolation + lifecycle-teardown, on cnpg & ext"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + isolation + lifecycle-teardown, on cnpg & ext"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -425,8 +425,9 @@ rw_iceberg() { # org password
 # not found` and the connection was rejected with `failed to initialize session
 # database metadata`; only a reconnect (instance since settled) masked it. With
 # the warm pool gone, every org's first connect lands the literal first session
-# on its worker, so this fired in practice. The CP now primes the catalog
-# (`USE iceberg.<schema>`) before the bind. This forces a cold worker and asserts
+# on its worker, so this fired in practice. The CP now primes the catalog with a
+# retried schema-enumeration probe before the bind, and the bind itself retries
+# once on the settle signature. This forces a cold worker and asserts
 # the first connect succeeds: cold-spawn backpressure is still tolerated, but the
 # metadata-init bind error fails the test immediately instead of being retried
 # away (which is exactly how a live reconnect would mask it).


### PR DESCRIPTION
## What

The first session on a freshly-spawned (cold) worker for an Iceberg org was rejected with `FATAL: failed to initialize session database metadata` (underlying `Catalog Error: Schema with name "" not found`). A reconnect always worked, so it looked transient — but it was deterministic on a cold worker. Exposed (not caused) by the warm-pool removal (#710): the warm pool meant a client never got the literal first session on a worker.

## Why

`InitSessionDatabaseMetadata` binds pg_catalog compat views whose bind enumerates **every** attached catalog. On the first session of a cold worker the Iceberg REST catalog is attached but its schema list isn't materialized on that DuckDB instance yet, so the enumeration surfaces a schema with an empty name and the bind fails.

A first-round fix (`USE iceberg.public` before the bind) was **proven insufficient by the e2e run**: CP logs show the USE succeeded yet the bind still failed — USE resolves one schema entry, it does not materialize the full schema list. Empirically, a failed enumeration itself completes the load: the second attempt on the same instance always succeeds.

## Fix

Two narrow layers, both scoped to the cold-catalog signature:

- **`sessionmeta.PrimeIcebergCatalog`** — runs the actual failing operation (a `duckdb_schemas()` enumeration scoped to the iceberg catalog) as a harmless SELECT, retried up to 5× / 300ms, ctx-bounded. Wired in the control-plane and standalone paths whenever Iceberg is attached (DuckLake-default sessions on dual-catalog workers bind the same views).
- **One bind retry** inside `InitSessionDatabaseMetadata` when the batch fails with exactly `Schema with name "" not found`. Genuine missing-schema errors still fail immediately.

## Testing

- **unit** (`sessionmeta`): settle-signature matcher (named-schema errors NOT retried), single bind retry + refusal to retry twice, probe bounded retry.
- **e2e** (`harness.sh`): `iceberg_cold_first_connect` on **cnpg + ext** — force-deletes the org's workers, then asserts the *first* connect succeeds; the metadata-init bind error fails the test immediately instead of being retried away. This assertion caught the insufficiency of round 1 — it is the real-cluster verification of this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)