### PR TITLE
refactor(controlplane): remove exclusive-node anti-affinity; workers are never BestEffort

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -230,7 +230,6 @@ func main() {
 			WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,
 			WorkerTolerationKey:          resolved.K8sWorkerTolerationKey,
 			WorkerTolerationValue:        resolved.K8sWorkerTolerationValue,
-			WorkerExclusiveNode:          resolved.K8sWorkerExclusiveNode,
 			AllowClientWorkerProfile:     resolved.K8sAllowClientWorkerProfile,
 			WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 			HeadroomPercent:              resolved.K8sHeadroomPercent,

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -12,7 +12,7 @@ import "flag"
 //
 // A handful of CLIInputs fields (the K8s pod-scheduling knobs:
 // K8sWorkerCPURequest, K8sWorkerMemoryRequest, K8sWorkerNodeSelector,
-// K8sWorkerTolerationKey, K8sWorkerTolerationValue, K8sWorkerExclusiveNode)
+// K8sWorkerTolerationKey, K8sWorkerTolerationValue)
 // are env-only by design — see CLAUDE.md "K8s pod scheduling knobs are
 // env-only." They stay zero in the harvested CLIInputs and ResolveEffective
 // reads them directly from os.Getenv. Adding a flag for any of them is a

--- a/configresolve/cliflags_test.go
+++ b/configresolve/cliflags_test.go
@@ -16,7 +16,6 @@ var nonFlagCLIInputsFields = map[string]bool{
 	"K8sWorkerNodeSelector":    true,
 	"K8sWorkerTolerationKey":   true,
 	"K8sWorkerTolerationValue": true,
-	"K8sWorkerExclusiveNode":   true,
 }
 
 // fieldNameToFlagName converts a CLIInputs Go field name (PascalCase) into

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -83,7 +83,6 @@ type CLIInputs struct {
 	K8sWorkerNodeSelector       string
 	K8sWorkerTolerationKey      string
 	K8sWorkerTolerationValue    string
-	K8sWorkerExclusiveNode      bool
 	AWSRegion                   string
 	QueryLog                    bool
 }
@@ -112,7 +111,6 @@ type Resolved struct {
 	K8sWorkerNodeSelector           string
 	K8sWorkerTolerationKey          string
 	K8sWorkerTolerationValue        string
-	K8sWorkerExclusiveNode          bool
 	K8sAllowClientWorkerProfile     bool
 	K8sWorkerPriorityClassName      string
 	K8sHeadroomPercent              int
@@ -208,7 +206,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var k8sMaxWorkers int
 	var k8sWorkerCPURequest, k8sWorkerMemoryRequest string
 	var k8sWorkerNodeSelector, k8sWorkerTolerationKey, k8sWorkerTolerationValue string
-	var k8sWorkerExclusiveNode bool
 	var awsRegion string
 	var configStoreConn string
 	var configPollInterval time.Duration
@@ -832,11 +829,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_K8S_WORKER_TOLERATION_VALUE"); v != "" {
 		k8sWorkerTolerationValue = v
 	}
-	if v := getenv("DUCKGRES_K8S_WORKER_EXCLUSIVE_NODE"); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil {
-			k8sWorkerExclusiveNode = b
-		}
-	}
 
 	// Connection-string worker-profile config.
 	if v := getenv("DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE"); v != "" {
@@ -1220,7 +1212,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		K8sWorkerNodeSelector:           k8sWorkerNodeSelector,
 		K8sWorkerTolerationKey:          k8sWorkerTolerationKey,
 		K8sWorkerTolerationValue:        k8sWorkerTolerationValue,
-		K8sWorkerExclusiveNode:          k8sWorkerExclusiveNode,
 		K8sAllowClientWorkerProfile:     k8sAllowClientWorkerProfile,
 		K8sWorkerPriorityClassName:      k8sWorkerPriorityClassName,
 		K8sHeadroomPercent:              k8sHeadroomPercent,

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -117,7 +117,6 @@ type K8sConfig struct {
 	WorkerNodeSelector      string // JSON map for worker pod nodeSelector (e.g., '{"posthog.com/nodepool":"workers"}')
 	WorkerTolerationKey     string // Taint key for worker pod NoSchedule toleration
 	WorkerTolerationValue   string // Taint value for worker pod NoSchedule toleration
-	WorkerExclusiveNode     bool   // One worker per node via pod anti-affinity
 	WorkerPriorityClassName string // PriorityClass for worker pods, so they preempt overprovision headroom pause pods (empty = none)
 	AWSRegion               string // AWS region for STS client
 

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -73,7 +73,6 @@ type K8sWorkerPool struct {
 	workerNodeSelector      map[string]string // node selector for worker pods
 	workerTolerationKey     string            // taint key for NoSchedule toleration
 	workerTolerationValue   string            // taint value for NoSchedule toleration
-	workerExclusiveNode     bool              // one worker per node via anti-affinity
 	workerPriorityClassName string            // PriorityClass for worker pods (preempts overprovision pause pods)
 
 	// Headroom controller: keep headroomPercent% of worker-nodepool allocatable
@@ -188,7 +187,6 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		workerNodeSelector:      cfg.WorkerNodeSelector,
 		workerTolerationKey:     cfg.WorkerTolerationKey,
 		workerTolerationValue:   cfg.WorkerTolerationValue,
-		workerExclusiveNode:     cfg.WorkerExclusiveNode,
 		workerPriorityClassName: cfg.WorkerPriorityClassName,
 
 		headroomPercent:              cfg.HeadroomPercent,

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -222,20 +222,6 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 		pod.Spec.Tolerations = []corev1.Toleration{tol}
 	}
 
-	// One worker per node, on a dedicated node pool.
-	if p.workerExclusiveNode {
-		pod.Spec.Affinity = &corev1.Affinity{
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"app": "duckgres-worker"},
-					},
-					TopologyKey: "kubernetes.io/hostname",
-				}},
-			},
-		}
-	}
-
 	// Add writable data directory for DuckDB databases
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
 		Name: "data",
@@ -638,23 +624,29 @@ func (p *K8sWorkerPool) workerResources() corev1.ResourceRequirements {
 // profile always carries non-empty CPU/Memory (resolver-enforced), so it never
 // degrades to BestEffort.
 func (p *K8sWorkerPool) workerResourcesForProfile(profile WorkerProfile) corev1.ResourceRequirements {
+	// Workers must never be BestEffort: with no pod anti-affinity, resource
+	// requests are the ONLY thing keeping two workers from overcommitting a
+	// node (each worker's single session sizes itself off the whole pod —
+	// workerDuckDBLimits — so co-resident requestless workers would each
+	// believe they own the node's RAM). Fall back to the built-in default
+	// shape when neither the profile nor the pool-global request sets one.
 	cpuReq := profile.CPU
 	if cpuReq == "" {
 		cpuReq = p.workerCPURequest
+	}
+	if cpuReq == "" {
+		cpuReq = defaultWorkerCPU
 	}
 	memReq := profile.Memory
 	if memReq == "" {
 		memReq = p.workerMemoryRequest
 	}
-	requests := corev1.ResourceList{}
-	if cpuReq != "" {
-		requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
+	if memReq == "" {
+		memReq = defaultWorkerMemory
 	}
-	if memReq != "" {
-		requests[corev1.ResourceMemory] = resource.MustParse(memReq)
-	}
-	if len(requests) == 0 {
-		return corev1.ResourceRequirements{}
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(cpuReq),
+		corev1.ResourceMemory: resource.MustParse(memReq),
 	}
 	limits := make(corev1.ResourceList, len(requests))
 	for k, v := range requests {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -2940,51 +2940,61 @@ func TestWorkerResources_BothSet(t *testing.T) {
 }
 
 func TestWorkerResources_CPUOnly(t *testing.T) {
+	// Memory falls back to the built-in default: workers are never BestEffort
+	// (resource requests are the only node-overcommit guard without pod
+	// anti-affinity).
 	pool := &K8sWorkerPool{
 		workerCPURequest: "1",
 	}
 	res := pool.workerResources()
-	if _, ok := res.Requests[corev1.ResourceCPU]; !ok {
-		t.Fatal("expected CPU request")
+	cpu := res.Requests[corev1.ResourceCPU]
+	if cpu.String() != "1" {
+		t.Fatalf("expected CPU request 1, got %s", cpu.String())
 	}
-	if _, ok := res.Requests[corev1.ResourceMemory]; ok {
-		t.Fatal("expected no memory request")
+	mem := res.Requests[corev1.ResourceMemory]
+	if mem.String() != defaultWorkerMemory {
+		t.Fatalf("expected default memory request %s, got %s", defaultWorkerMemory, mem.String())
 	}
 	if _, ok := res.Limits[corev1.ResourceCPU]; !ok {
 		t.Fatal("expected CPU limit (Guaranteed QoS)")
 	}
-	if _, ok := res.Limits[corev1.ResourceMemory]; ok {
-		t.Fatal("expected no memory limit")
+	if _, ok := res.Limits[corev1.ResourceMemory]; !ok {
+		t.Fatal("expected memory limit (Guaranteed QoS)")
 	}
 }
 
 func TestWorkerResources_MemoryOnly(t *testing.T) {
+	// CPU falls back to the built-in default (never BestEffort).
 	pool := &K8sWorkerPool{
 		workerMemoryRequest: "4Gi",
 	}
 	res := pool.workerResources()
-	if _, ok := res.Requests[corev1.ResourceMemory]; !ok {
-		t.Fatal("expected memory request")
+	mem := res.Requests[corev1.ResourceMemory]
+	if mem.String() != "4Gi" {
+		t.Fatalf("expected memory request 4Gi, got %s", mem.String())
 	}
-	if _, ok := res.Requests[corev1.ResourceCPU]; ok {
-		t.Fatal("expected no CPU request")
-	}
-	if _, ok := res.Limits[corev1.ResourceMemory]; !ok {
-		t.Fatal("expected memory limit (Guaranteed QoS)")
-	}
-	if _, ok := res.Limits[corev1.ResourceCPU]; ok {
-		t.Fatal("expected no CPU limit")
+	cpu := res.Requests[corev1.ResourceCPU]
+	if cpu.String() != defaultWorkerCPU {
+		t.Fatalf("expected default CPU request %s, got %s", defaultWorkerCPU, cpu.String())
 	}
 }
 
 func TestWorkerResources_NeitherSet(t *testing.T) {
+	// No pool-global requests configured: the built-in default shape applies.
+	// Workers must never be BestEffort — without pod anti-affinity, requests
+	// are the only thing keeping two workers from overcommitting a node.
 	pool := &K8sWorkerPool{}
 	res := pool.workerResources()
-	if res.Requests != nil {
-		t.Fatal("expected empty requests (BestEffort)")
+	cpu := res.Requests[corev1.ResourceCPU]
+	if cpu.String() != defaultWorkerCPU {
+		t.Fatalf("expected default CPU request %s, got %s", defaultWorkerCPU, cpu.String())
 	}
-	if res.Limits != nil {
-		t.Fatal("expected empty limits")
+	mem := res.Requests[corev1.ResourceMemory]
+	if mem.String() != defaultWorkerMemory {
+		t.Fatalf("expected default memory request %s, got %s", defaultWorkerMemory, mem.String())
+	}
+	if len(res.Limits) != 2 {
+		t.Fatalf("expected cpu+memory limits (Guaranteed QoS), got %v", res.Limits)
 	}
 }
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -187,7 +187,6 @@ func SetupMultiTenant(
 		WorkerNodeSelector:           parseNodeSelector(cfg.K8s.WorkerNodeSelector),
 		WorkerTolerationKey:          cfg.K8s.WorkerTolerationKey,
 		WorkerTolerationValue:        cfg.K8s.WorkerTolerationValue,
-		WorkerExclusiveNode:          cfg.K8s.WorkerExclusiveNode,
 		WorkerPriorityClassName:      cfg.K8s.WorkerPriorityClassName,
 		HeadroomPercent:              cfg.K8s.HeadroomPercent,
 		PlaceholderImage:             cfg.K8s.PlaceholderImage,

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -108,7 +108,6 @@ type K8sWorkerPoolConfig struct {
 	WorkerNodeSelector           map[string]string                            // Node selector for worker pods. Nil = no selector.
 	WorkerTolerationKey          string                                       // Taint key for worker pod NoSchedule toleration. Empty = no toleration.
 	WorkerTolerationValue        string                                       // Taint value for worker pod NoSchedule toleration.
-	WorkerExclusiveNode          bool                                         // One worker per node via pod anti-affinity.
 	WorkerPriorityClassName      string                                       // PriorityClass for worker pods (so they preempt overprovision pause pods). Empty = none.
 	HeadroomPercent              int                                          // Keep this % of worker-nodepool allocatable CPU+mem free via low-priority placeholder pods (0 = disabled).
 	PlaceholderImage             string                                       // Image for headroom placeholder pods (a pause image).

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -118,7 +118,12 @@ options), `DUCKGRES_K8S_WORKER_PROFILE_MIN_CPU`/`_MAX_CPU`/`_MIN_MEMORY`/
 
 Removed: all `DUCKGRES_K8S_*COLOCATED*`, `*WORKER_TIERS*`,
 `*ALLOW_CLIENT_EXCLUSIVE_NODE*`, `*SHARED_WARM_TARGET*`,
-`*DYNAMIC_WARM_CAPACITY*`, `*WARM_CAPACITY_*`, `*WARM_ACQUIRE_TIMEOUT*`.
+`*DYNAMIC_WARM_CAPACITY*`, `*WARM_CAPACITY_*`, `*WARM_ACQUIRE_TIMEOUT*`,
+`*WORKER_EXCLUSIVE_NODE*` (the one-worker-per-node pod anti-affinity is gone;
+isolation comes from resource requests — workers are never BestEffort, falling
+back to the built-in default shape (8/16Gi) when neither the profile nor
+`DUCKGRES_K8S_WORKER_CPU_REQUEST`/`_MEMORY_REQUEST` set one, so co-scheduled
+workers cannot overcommit a node).
 
 ## Testing
 

--- a/main.go
+++ b/main.go
@@ -357,7 +357,6 @@ func main() {
 				WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,
 				WorkerTolerationKey:          resolved.K8sWorkerTolerationKey,
 				WorkerTolerationValue:        resolved.K8sWorkerTolerationValue,
-				WorkerExclusiveNode:          resolved.K8sWorkerExclusiveNode,
 				AllowClientWorkerProfile:     resolved.K8sAllowClientWorkerProfile,
 				WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 				HeadroomPercent:              resolved.K8sHeadroomPercent,

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -514,6 +514,15 @@ assert_worker_pod() {
   if echo "$mounts" | grep -q '/var/run/secrets/kubernetes.io/serviceaccount'; then
     fail "worker $pod mounts a kubernetes.io/serviceaccount token"
   fi
+
+  # Never-BestEffort: a DEFAULT-shape worker (no client sizing) must still carry
+  # the pool-default resource requests. With the exclusive-node pod anti-affinity
+  # removed, requests are the ONLY thing keeping co-scheduled workers from
+  # overcommitting a node — a BestEffort default worker is a regression.
+  dcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.cpu}")"
+  dmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.memory}")"
+  [ "$dcpu" = "750m" ] || fail "default worker $pod requests.cpu='$dcpu' want '750m' (pool default; BestEffort regression?)"
+  [ "$dmem" = "1536Mi" ] || fail "default worker $pod requests.memory='$dmem' want '1536Mi'"
 }
 
 # ---- worker sizing (TTL-pool model) ---------------------------------------

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -234,6 +234,17 @@ spec:
             # The harness sized_worker assertion connects with these and verifies the
             # spawned pod carries the requested CPU+memory.
             - { name: DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE, value: "true" }
+            # Pool-default worker shape for connections that send no sizing GUCs.
+            # Workers are never BestEffort (no pod anti-affinity anymore — resource
+            # requests are the only node-overcommit guard); without this the binary
+            # falls back to its built-in 8/16Gi default, which does not fit the
+            # mw-dev c6gd.xlarge worker nodes and would force a cold bigger node on
+            # every default spawn. Sub-1-CPU so the value collides with no sized
+            # assertion (they count org workers BY CPU: sized tests use 1 and 2)
+            # and several default workers bin-pack onto one warm node — exercising
+            # the post-anti-affinity packing behavior.
+            - { name: DUCKGRES_K8S_WORKER_CPU_REQUEST, value: "750m" }
+            - { name: DUCKGRES_K8S_WORKER_MEMORY_REQUEST, value: "1536Mi" }
             - { name: DUCKGRES_K8S_WORKER_PROFILE_MIN_CPU, value: "1" }
             - { name: DUCKGRES_K8S_WORKER_PROFILE_MAX_CPU, value: "8" }
             - { name: DUCKGRES_K8S_WORKER_PROFILE_MIN_MEMORY, value: "2Gi" }


### PR DESCRIPTION
## What

Removes `DUCKGRES_K8S_WORKER_EXCLUSIVE_NODE` and the hard one-worker-per-node pod anti-affinity it enabled (introduced in #364, predating client worker sizing). With the warm pool (#710) and the colocated bin-pack pool gone, the anti-affinity forced even a 1-CPU client-sized worker to claim a whole node. Worker placement is now governed purely by resource requests.

## Safety: workers are never BestEffort

Requests become load-bearing for isolation, so `workerResourcesForProfile` now falls back to the built-in default shape (8 CPU / 16Gi) when neither the profile nor the pool-global `DUCKGRES_K8S_WORKER_CPU_REQUEST`/`_MEMORY_REQUEST` set one. Previously a no-request deployment got BestEffort workers that only the anti-affinity kept from co-scheduling; two such workers on one node would each size their session off the whole node (`workerDuckDBLimits`) → memory overcommit. Now that cannot happen.

## Testing

- unit: `TestWorkerResources_*` assert the never-BestEffort fallback (cpu-only, memory-only, neither).
- e2e: CP manifest sets a pool-default shape (`750m/1536Mi` — sub-1-CPU so it collides with no sized assertion's CPU-keyed pod counts, and several default workers bin-pack onto one warm mw-dev node, exercising the new packing). `assert_worker_pod` now fails on a BestEffort default worker. Existing `one_session_per_worker` / `sized_worker` / `reuse_sized_worker` / cold-burst assertions all still run against the new scheduling.

## Deploy note

Chart-side removal of `workerExclusiveNode` (value + env block, all managed-warehouse envs) plus a pool-default worker shape for mw-dev rides in PostHog/charts#11921. Merge this first; the chart change is safe either way (the env var is ignored once this ships, honored harmlessly before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)