### PR TITLE
refactor(controlplane): readable worker + placeholder pod names

### DIFF
--- a/controlplane/headroom.go
+++ b/controlplane/headroom.go
@@ -161,7 +161,12 @@ func (p *K8sWorkerPool) createPlaceholderPod(ctx context.Context, cpu, mem resou
 			// GenerateName lets the API server assign a unique suffix per pod —
 			// the controller creates N placeholders per reconcile and does not
 			// track ids, so a fixed/derived name would collide ("already exists").
-			GenerateName: fmt.Sprintf("%s-%s-", headroomPodLabel, p.cpID),
+			// "duckgres-placeholder-<cp-replicaset-hash>-<rand>": the RS hash
+			// identifies the owning CP build without embedding the whole CP pod
+			// name (whose own random suffix is noise). The app label stays
+			// `duckgres-headroom`, so selectors keep matching pods created
+			// under the old name across a rollout.
+			GenerateName: fmt.Sprintf("duckgres-placeholder-%s-", cpReplicaSetHash(p.cpID)),
 			Namespace:    p.namespace,
 			Labels: map[string]string{
 				"app":                    headroomPodLabel,

--- a/controlplane/headroom_test.go
+++ b/controlplane/headroom_test.go
@@ -2,7 +2,14 @@
 
 package controlplane
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
 
 func TestHeadroomPlaceholdersNeeded(t *testing.T) {
 	const (
@@ -48,5 +55,34 @@ func TestLabelSelectorStringDeterministic(t *testing.T) {
 	}
 	if labelSelectorString(nil) != "" {
 		t.Fatal("nil selector must render empty")
+	}
+}
+
+func TestPlaceholderPodGenerateName(t *testing.T) {
+	// "duckgres-placeholder-<cp-replicaset-hash>-<apiserver-rand>": the RS hash
+	// identifies the owning CP build; the CP pod's own random suffix is NOT
+	// embedded (it was pure noise in the old
+	// duckgres-headroom-<full-cp-pod-name>-<rand> shape).
+	cs := fake.NewSimpleClientset()
+	p := &K8sWorkerPool{
+		clientset: cs,
+		namespace: "default",
+		cpID:      "duckgres-5ff4d85bdb-zshgq",
+	}
+	if err := p.createPlaceholderPod(context.Background(), resource.MustParse("1"), resource.MustParse("2Gi")); err != nil {
+		t.Fatalf("createPlaceholderPod: %v", err)
+	}
+	pods, err := cs.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil || len(pods.Items) != 1 {
+		t.Fatalf("expected 1 placeholder pod, got %d (err=%v)", len(pods.Items), err)
+	}
+	pod := pods.Items[0]
+	if pod.GenerateName != "duckgres-placeholder-5ff4d85bdb-" {
+		t.Fatalf("GenerateName = %q, want duckgres-placeholder-5ff4d85bdb-", pod.GenerateName)
+	}
+	// Selector continuity: the app label keeps the legacy value so pods created
+	// under the old name stay managed across a rollout.
+	if pod.Labels["app"] != "duckgres-headroom" {
+		t.Fatalf("app label = %q, want duckgres-headroom", pod.Labels["app"])
 	}
 }

--- a/controlplane/k8s_pool_helpers.go
+++ b/controlplane/k8s_pool_helpers.go
@@ -133,12 +133,35 @@ func (p *K8sWorkerPool) workerPodName(worker *ManagedWorker) string {
 	return p.podNameForWorker(worker.ID)
 }
 
+// workerPodNamePrefix builds the worker pod name prefix:
+// "duckgres-worker[-<org>]-<cp-replicaset-hash>". A fixed "duckgres-worker"
+// head makes worker pods sort/scan together in `kubectl get pods`; the CP
+// ReplicaSet hash identifies which control-plane build spawned the worker
+// (useful mid-rollout, when the version-mismatch reaper is churning the
+// fleet). Uniqueness across CP replicas rides on worker IDs, which are
+// cluster-unique (config-store issued) — the hash is shared by all replicas
+// of one Deployment revision, exactly like the old <cp-pod-minus-suffix>
+// prefix was.
 func (p *K8sWorkerPool) workerPodNamePrefix() string {
-	base := trimK8sPodHashSuffix(p.cpID)
 	if p.orgID != "" {
-		return fmt.Sprintf("%s-worker-%s", base, p.orgID)
+		return fmt.Sprintf("duckgres-worker-%s-%s", p.orgID, cpReplicaSetHash(p.cpID))
 	}
-	return fmt.Sprintf("%s-worker", base)
+	return fmt.Sprintf("duckgres-worker-%s", cpReplicaSetHash(p.cpID))
+}
+
+// cpReplicaSetHash extracts the Deployment ReplicaSet hash segment from a CP
+// pod name ("duckgres-control-plane-6f877c7779-abcde" -> "6f877c7779"). A
+// name without a recognizable random pod-hash suffix (local runs, tests) is
+// returned whole so the prefix stays unique per CP instance.
+func cpReplicaSetHash(cpID string) string {
+	base := trimK8sPodHashSuffix(cpID)
+	if base == cpID {
+		return cpID
+	}
+	if i := strings.LastIndex(base, "-"); i > 0 {
+		return base[i+1:]
+	}
+	return base
 }
 
 // trimK8sPodHashSuffix removes the trailing 5-character random pod-hash

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1577,7 +1577,7 @@ func TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost(t *testing.T) {
 		preloadedRecords: map[int]*configstore.WorkerRecord{
 			13: {
 				WorkerID:          13,
-				PodName:           "test-cp-worker-13",
+				PodName:           "duckgres-worker-test-cp-13",
 				State:             configstore.WorkerStateLost,
 				OwnerCPInstanceID: pool.cpInstanceID,
 				OwnerEpoch:        4,
@@ -1593,7 +1593,7 @@ func TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost(t *testing.T) {
 	pool.workers[worker.ID] = worker
 
 	if _, err := cs.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-cp-worker-13", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "duckgres-worker-test-cp-13", Namespace: "default"},
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.13"},
 	}, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create worker pod: %v", err)
@@ -1622,7 +1622,7 @@ func TestK8sPoolHealthCheckLoopCompletesSameLeaseAlreadyLost(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		got := podDeleteActionNames(cs)
-		if len(got) == 1 && got[0] == "test-cp-worker-13" {
+		if len(got) == 1 && got[0] == "duckgres-worker-test-cp-13" {
 			break
 		}
 		if time.Now().After(deadline) {
@@ -2632,7 +2632,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	for _, env := range c.Env {
 		if env.Name == "DUCKGRES_DUCKDB_TOKEN" && env.ValueFrom != nil &&
 			env.ValueFrom.SecretKeyRef != nil &&
-			env.ValueFrom.SecretKeyRef.Name == "test-secret-test-cp-worker-0" {
+			env.ValueFrom.SecretKeyRef.Name == "test-secret-duckgres-worker-test-cp-0" {
 			foundEnv = true
 		}
 		if env.Name == "DUCKGRES_SHARED_WARM_WORKER" && env.Value == "true" {
@@ -2667,7 +2667,7 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	foundWorkerRPCSecret := false
 	for _, volume := range pod.Spec.Volumes {
 		if volume.Name == "worker-rpc-tls" && volume.Secret != nil &&
-			volume.Secret.SecretName == "test-secret-test-cp-worker-0" {
+			volume.Secret.SecretName == "test-secret-duckgres-worker-test-cp-0" {
 			foundWorkerRPCSecret = true
 		}
 	}
@@ -4126,5 +4126,37 @@ func TestFindIdleWorkerLockedUnknownNodeSortsLast(t *testing.T) {
 	chosen := pool.findIdleWorkerLocked()
 	if chosen == nil || chosen.ID != 1 {
 		t.Errorf("expected worker on node-old (id=1), got %+v", chosen)
+	}
+}
+
+func TestWorkerPodNaming(t *testing.T) {
+	// "duckgres-worker[-<org>]-<cp-replicaset-hash>-<id>": fixed head so worker
+	// pods scan together, RS hash identifying the spawning CP build.
+	p := &K8sWorkerPool{cpID: "duckgres-control-plane-6f877c7779-abcde"}
+	if got := p.podNameForWorker(15); got != "duckgres-worker-6f877c7779-15" {
+		t.Fatalf("pod name = %q, want duckgres-worker-6f877c7779-15", got)
+	}
+	p.orgID = "acme"
+	if got := p.podNameForWorker(7); got != "duckgres-worker-acme-6f877c7779-7" {
+		t.Fatalf("org pod name = %q, want duckgres-worker-acme-6f877c7779-7", got)
+	}
+	// A cpID without a recognizable pod-hash suffix (local/test runs) is used
+	// whole, keeping the prefix unique per CP instance.
+	p = &K8sWorkerPool{cpID: "test-cp"}
+	if got := p.podNameForWorker(3); got != "duckgres-worker-test-cp-3" {
+		t.Fatalf("hashless pod name = %q, want duckgres-worker-test-cp-3", got)
+	}
+}
+
+func TestCPReplicaSetHash(t *testing.T) {
+	for in, want := range map[string]string{
+		"duckgres-control-plane-6f877c7779-abcde": "6f877c7779",
+		"duckgres-7c6c5769bb-mdnw7":               "7c6c5769bb",
+		"test-cp":                                 "test-cp",
+		"":                                        "",
+	} {
+		if got := cpReplicaSetHash(in); got != want {
+			t.Fatalf("cpReplicaSetHash(%q) = %q, want %q", in, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## What

`kubectl get pods` in the duckgres namespace currently reads:

```
duckgres-7c6c5769bb-mdnw7                           # control plane (charts)
duckgres-7c6c5769bb-worker-15                       # worker
duckgres-headroom-duckgres-5ff4d85bdb-zshgq-dgg5b   # placeholder (embeds the CP pod's own random suffix — noise)
```

New shapes from this PR:

```
duckgres-worker-6f877c7779-15            # duckgres-worker[-<org>]-<cp-rs-hash>-<id>
duckgres-placeholder-5ff4d85bdb-dgg5b    # duckgres-placeholder-<cp-rs-hash>-<rand>
```

Fixed heads group each kind; the CP ReplicaSet hash still says which control-plane build owns the pod (useful mid-rollout while the version-mismatch reaper churns) without the CP pod's random suffix.

## Safety

- Uniqueness across CP replicas rides on cluster-unique worker IDs — exactly as before (the old prefix was equally shared by all replicas of one Deployment revision).
- Everything selects pods by **label** (`app=duckgres-worker` / `app=duckgres-headroom` / `duckgres/control-plane`), never by name; worker records persist their pod name, so old-named pods stay managed across a rollout. The headroom `app` label intentionally keeps its legacy value for selector continuity.
- The worker RPC secret name derives from the pod name dynamically at create/reconcile time — follows automatically.

## Testing

- unit: `TestWorkerPodNaming` (default/org/hashless shapes), `TestCPReplicaSetHash`, `TestPlaceholderPodGenerateName` (+ label continuity); existing spawn/lease tests updated to the new derived names.
- e2e: the harness selects worker pods purely by label, so the full suite exercises the new names end-to-end on the real cluster.

## Companion

The control-plane pod rename (`duckgres-*` → `duckgres-control-plane-*`) is a charts-side Deployment rename — separate charts PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)