### PR TITLE
feat: per-user persistent secret manager (CREATE PERSISTENT SECRET) for MTCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,15 @@ Invariants for anyone touching this path:
   a store failure after a successful exec is an ERROR telling the user the
   secret will NOT survive the session. Replay failures at session create are
   warnings, never connection refusals.
+- **No silent non-persistence.** Any path where persistent-secret DDL would
+  execute but not persist must REJECT instead: multi-statement batches and
+  parameterized statements (CP interception), and the Flight SQL ingress
+  (`flightsqlingress.Config.RejectPersistentSecretDDL`). Otherwise the secret
+  works for one session and is silently deleted by the next session's wipe.
+- **DROP's store-fallback is gated on DuckDB's not-found error only**
+  (`isSecretNotFoundError`). Any other exec failure (cancel, RPC error,
+  ambiguity, aborted txn) must surface and leave the store untouched — a
+  false "DROP succeeded" is fatal for a credential revocation.
 - **Never log/store secret statement text.** `usersecrets.RedactForLog` guards
   logQueryStarted/Finished/Error, the query log, spans, and pg_stat_activity
   (`currentQuery`); keep new logging of query text behind it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,37 @@ release lets shutdown kill live work); `reapIdle` releases tokens stranded by a
 `GetFlightInfo` whose `DoGet` never arrived. `terminationGracePeriodSeconds=3600`
 (`k8s_pool.go`) must stay above `workerShutdownDrainTime` (55m).
 
+## User Persistent Secrets (multitenant remote backend)
+
+`CREATE PERSISTENT SECRET` from a client survives across sessions and worker
+pods: the CP intercepts it (`server/conn_user_secrets.go`, classification in
+`server/usersecrets/`), executes it on the live session first (DuckDB
+validates), then stores the statement AES-GCM-encrypted in the config store
+(`duckgres_org_user_secrets`, keyed org/user/name) and replays it in the
+`CreateSession` payload on the user's future sessions
+(`duckdbservice/user_secrets.go`). Enabled by the env-only
+`DUCKGRES_USER_SECRET_KEY` (base64 32-byte AES key); unset → clear 0A000
+error. Plain/TEMPORARY `CREATE SECRET` stays session-scoped passthrough.
+Invariants for anyone touching this path:
+
+- **Cross-user isolation is the wipe at session create, not the destroy-time
+  cleanup.** DuckDB secrets are instance-global, and a hot-idle worker is
+  reused across users of an org: `wipeUserPersistentSecrets` (persistent
+  storage only — system secrets `ducklake_s3`/`iceberg_sigv4`/`iceberg_oauth`
+  are in-memory and untouched) MUST run before replay on every CreateSession
+  in shared-warm mode, and a wipe failure MUST fail the session.
+- **Execute-then-persist ordering.** Persist only statements DuckDB accepted;
+  a store failure after a successful exec is an ERROR telling the user the
+  secret will NOT survive the session. Replay failures at session create are
+  warnings, never connection refusals.
+- **Never log/store secret statement text.** `usersecrets.RedactForLog` guards
+  logQueryStarted/Finished/Error, the query log, spans, and pg_stat_activity
+  (`currentQuery`); keep new logging of query text behind it.
+- Touching the interception, wipe/replay, or payload shape → update
+  `server/conn_user_secrets_test.go`, `duckdbservice/user_secrets_test.go`,
+  and the `persistent_user_secret`(+`_isolation`) assertions in
+  `tests/e2e-mw-dev/harness.sh`.
+
 ## TODO Reference
 
 See `TODO.md` for the full feature roadmap and known issues.

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -128,6 +128,7 @@ type Resolved struct {
 	ConfigStoreConn                 string
 	ConfigPollInterval              time.Duration
 	InternalSecret                  string
+	UserSecretKey                   string
 	SNIRoutingMode                  string
 	ManagedHostnameSuffixes         []string
 	DuckLakeDefaultSpecVersion      string
@@ -210,6 +211,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var configStoreConn string
 	var configPollInterval time.Duration
 	var internalSecret string
+	var userSecretKey string
 	var sniRoutingMode string
 	var managedHostnameSuffixes []string
 
@@ -770,6 +772,11 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_INTERNAL_SECRET"); v != "" {
 		internalSecret = v
 	}
+	// Env-only (no CLI flag, no YAML): the AES key for user persistent
+	// secrets should only arrive via a mounted K8s Secret.
+	if v := getenv("DUCKGRES_USER_SECRET_KEY"); v != "" {
+		userSecretKey = v
+	}
 	if v := getenv("DUCKGRES_SNI_ROUTING_MODE"); v != "" {
 		sniRoutingMode = v
 	}
@@ -1229,6 +1236,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		ConfigStoreConn:                 configStoreConn,
 		ConfigPollInterval:              configPollInterval,
 		InternalSecret:                  internalSecret,
+		UserSecretKey:                   userSecretKey,
 		SNIRoutingMode:                  sniRoutingMode,
 		ManagedHostnameSuffixes:         managedHostnameSuffixes,
 		DuckLakeDefaultSpecVersion:      cfg.DuckLake.SpecVersion,

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -57,6 +57,25 @@ type OrgUser struct {
 
 func (OrgUser) TableName() string { return "duckgres_org_users" }
 
+// OrgUserSecret is one customer-set persistent DuckDB secret, scoped to
+// (org, user) and replayed onto the user's worker at session creation. The
+// row stores the AES-GCM-sealed CREATE SECRET statement (see
+// server/usersecrets); the config store never sees plaintext credential
+// material. Rows are written/deleted inline when the control plane intercepts
+// CREATE/DROP PERSISTENT SECRET and read directly (not via the snapshot
+// poller) at session creation, so a secret set through one CP replica is
+// immediately visible to all replicas.
+type OrgUserSecret struct {
+	OrgID      string    `gorm:"primaryKey;size:255" json:"org_id"`
+	Username   string    `gorm:"primaryKey;size:255" json:"username"`
+	SecretName string    `gorm:"primaryKey;size:255" json:"secret_name"`
+	Ciphertext []byte    `gorm:"not null" json:"-"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func (OrgUserSecret) TableName() string { return "duckgres_org_user_secrets" }
+
 // ManagedWarehouseProvisioningState is an open string used for warehouse lifecycle status.
 // The constants below are the canonical values used by current tooling, but callers may
 // persist other states while provisioning workflows evolve.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -118,6 +118,7 @@ func NewConfigStore(connStr string, pollInterval time.Duration) (*ConfigStore, e
 		&Org{},
 		&ManagedWarehouse{},
 		&OrgUser{},
+		&OrgUserSecret{},
 		&GlobalConfig{},
 		&DuckLakeConfig{},
 		&RateLimitConfig{},

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -448,6 +448,7 @@ func TestTableNames(t *testing.T) {
 	}{
 		{Org{}, "duckgres_orgs"},
 		{OrgUser{}, "duckgres_org_users"},
+		{OrgUserSecret{}, "duckgres_org_user_secrets"},
 		{ManagedWarehouse{}, "duckgres_managed_warehouses"},
 		{GlobalConfig{}, "duckgres_global_config"},
 		{DuckLakeConfig{}, "duckgres_ducklake_config"},

--- a/controlplane/configstore/user_secrets.go
+++ b/controlplane/configstore/user_secrets.go
@@ -1,0 +1,72 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrTooManyUserSecrets is returned by UpsertOrgUserSecret when creating a
+// new secret would push the user past the per-user cap.
+var ErrTooManyUserSecrets = errors.New("too many persistent secrets for user")
+
+// UpsertOrgUserSecret stores (or replaces) one sealed user secret. When
+// maxPerUser > 0, creating a NEW secret name is rejected with
+// ErrTooManyUserSecrets once the user already has maxPerUser secrets;
+// replacing an existing name is always allowed.
+func (cs *ConfigStore) UpsertOrgUserSecret(orgID, username, secretName string, ciphertext []byte, maxPerUser int) error {
+	return cs.db.Transaction(func(tx *gorm.DB) error {
+		if maxPerUser > 0 {
+			var existing int64
+			if err := tx.Model(&OrgUserSecret{}).
+				Where("org_id = ? AND username = ? AND secret_name = ?", orgID, username, secretName).
+				Count(&existing).Error; err != nil {
+				return err
+			}
+			if existing == 0 {
+				var total int64
+				if err := tx.Model(&OrgUserSecret{}).
+					Where("org_id = ? AND username = ?", orgID, username).
+					Count(&total).Error; err != nil {
+					return err
+				}
+				if total >= int64(maxPerUser) {
+					return fmt.Errorf("%w (max %d)", ErrTooManyUserSecrets, maxPerUser)
+				}
+			}
+		}
+		secret := OrgUserSecret{
+			OrgID:      orgID,
+			Username:   username,
+			SecretName: secretName,
+			Ciphertext: ciphertext,
+		}
+		return tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "org_id"}, {Name: "username"}, {Name: "secret_name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"ciphertext", "updated_at"}),
+		}).Create(&secret).Error
+	})
+}
+
+// DeleteOrgUserSecret removes one user secret, reporting whether it existed.
+// Deleting a secret that does not exist is not an error (DROP ... IF EXISTS
+// semantics live with the caller).
+func (cs *ConfigStore) DeleteOrgUserSecret(orgID, username, secretName string) (bool, error) {
+	result := cs.db.
+		Where("org_id = ? AND username = ? AND secret_name = ?", orgID, username, secretName).
+		Delete(&OrgUserSecret{})
+	return result.RowsAffected > 0, result.Error
+}
+
+// ListOrgUserSecrets returns all sealed secrets for one user, ordered by
+// creation time so replay order is deterministic.
+func (cs *ConfigStore) ListOrgUserSecrets(orgID, username string) ([]OrgUserSecret, error) {
+	var secrets []OrgUserSecret
+	err := cs.db.
+		Where("org_id = ? AND username = ?", orgID, username).
+		Order("created_at ASC").
+		Find(&secrets).Error
+	return secrets, err
+}

--- a/controlplane/configstore/user_secrets.go
+++ b/controlplane/configstore/user_secrets.go
@@ -15,8 +15,10 @@ var ErrTooManyUserSecrets = errors.New("too many persistent secrets for user")
 // UpsertOrgUserSecret stores (or replaces) one sealed user secret. When
 // maxPerUser > 0, creating a NEW secret name is rejected with
 // ErrTooManyUserSecrets once the user already has maxPerUser secrets;
-// replacing an existing name is always allowed.
-func (cs *ConfigStore) UpsertOrgUserSecret(orgID, username, secretName string, ciphertext []byte, maxPerUser int) error {
+// replacing an existing name is always allowed. With createOnly set
+// (CREATE ... IF NOT EXISTS), an existing row is left untouched instead of
+// replaced.
+func (cs *ConfigStore) UpsertOrgUserSecret(orgID, username, secretName string, ciphertext []byte, maxPerUser int, createOnly bool) error {
 	return cs.db.Transaction(func(tx *gorm.DB) error {
 		if maxPerUser > 0 {
 			var existing int64
@@ -43,10 +45,17 @@ func (cs *ConfigStore) UpsertOrgUserSecret(orgID, username, secretName string, c
 			SecretName: secretName,
 			Ciphertext: ciphertext,
 		}
-		return tx.Clauses(clause.OnConflict{
+		conflict := clause.OnConflict{
 			Columns:   []clause.Column{{Name: "org_id"}, {Name: "username"}, {Name: "secret_name"}},
 			DoUpdates: clause.AssignmentColumns([]string{"ciphertext", "updated_at"}),
-		}).Create(&secret).Error
+		}
+		if createOnly {
+			conflict = clause.OnConflict{
+				Columns:   conflict.Columns,
+				DoNothing: true,
+			}
+		}
+		return tx.Clauses(conflict).Create(&secret).Error
 	})
 }
 

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1929,6 +1929,10 @@ func (cp *ControlPlane) startFlightIngress() {
 		HandleIdleTTL:      cp.cfg.FlightHandleIdleTTL,
 		SessionTokenTTL:    cp.cfg.FlightSessionTokenTTL,
 		WorkerQueueTimeout: cp.cfg.WorkerQueueTimeout,
+		// Persistent-secret DDL is intercepted on the PG wire protocol only;
+		// over Flight it would execute, never persist, and be wiped at the
+		// next session — reject it up front instead.
+		RejectPersistentSecretDDL: cp.srv != nil && cp.srv.UserSecretManager() != nil,
 	}
 
 	var (

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -68,6 +68,13 @@ type ControlPlaneConfig struct {
 	// When empty, a random secret is generated and logged at startup.
 	InternalSecret string
 
+	// UserSecretKey is the base64-encoded 32-byte AES key for encrypting
+	// user persistent secrets in the config store (env-only:
+	// DUCKGRES_USER_SECRET_KEY). Empty disables the persistent secret
+	// manager: CREATE PERSISTENT SECRET is rejected with a clear error.
+	// Only used in multitenant remote mode.
+	UserSecretKey string
+
 	// SNIRoutingMode controls hostname-based org routing. Values:
 	//   "" or "off"   - SNI is ignored; legacy database-param routing only
 	//                   (default).

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -143,6 +143,20 @@ func SetupMultiTenant(
 		return nil, nil, nil, nil, nil, err
 	}
 
+	// Per-user persistent secret manager (CREATE PERSISTENT SECRET). With no
+	// key configured the manager still loads so DROP can clean up stale rows,
+	// but persistence is disabled with a clear client-facing error.
+	userSecrets, err := NewCPUserSecretManager(store, cfg.UserSecretKey)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	server.SetUserSecretManager(srv, userSecrets)
+	if cfg.UserSecretKey == "" {
+		slog.Info("User persistent secrets disabled (DUCKGRES_USER_SECRET_KEY not set).")
+	} else {
+		slog.Info("User persistent secrets enabled.")
+	}
+
 	namespace, err := resolveK8sNamespace(cfg.K8s.WorkerNamespace)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -224,7 +238,7 @@ func SetupMultiTenant(
 		}
 	}
 
-	router, err := NewOrgRouter(store, baseCfg, cfg, srv, stsBroker, resolveDucklingStatus)
+	router, err := NewOrgRouter(store, baseCfg, cfg, srv, stsBroker, userSecrets, resolveDucklingStatus)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -34,6 +34,7 @@ type OrgRouter struct {
 	globalCfg             ControlPlaneConfig
 	srv                   *server.Server
 	stsBroker             *STSBroker
+	userSecrets           *CPUserSecretManager
 	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)
 	nextWorkerID          atomic.Int32
 	sharedCancel          context.CancelFunc
@@ -45,7 +46,7 @@ type OrgRouter struct {
 }
 
 // NewOrgRouter creates an OrgRouter from the initial config snapshot.
-func NewOrgRouter(store *configstore.ConfigStore, baseCfg K8sWorkerPoolConfig, globalCfg ControlPlaneConfig, srv *server.Server, stsBroker *STSBroker, resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)) (*OrgRouter, error) {
+func NewOrgRouter(store *configstore.ConfigStore, baseCfg K8sWorkerPoolConfig, globalCfg ControlPlaneConfig, srv *server.Server, stsBroker *STSBroker, userSecrets *CPUserSecretManager, resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)) (*OrgRouter, error) {
 	tr := &OrgRouter{
 		orgs:                  make(map[string]*OrgStack),
 		configStore:           store,
@@ -53,6 +54,7 @@ func NewOrgRouter(store *configstore.ConfigStore, baseCfg K8sWorkerPoolConfig, g
 		globalCfg:             globalCfg,
 		srv:                   srv,
 		stsBroker:             stsBroker,
+		userSecrets:           userSecrets,
 		resolveDucklingStatus: resolveDucklingStatus,
 	}
 
@@ -135,6 +137,9 @@ func (tr *OrgRouter) createOrgStack(tc *configstore.OrgConfig) (*OrgStack, error
 	// Pass 0/false to disable budget-based rebalancing.
 	rebalancer := NewMemoryRebalancer(0, 0, nil, false)
 	sessions := NewSessionManager(pool, rebalancer)
+	if tr.userSecrets != nil {
+		sessions.SetUserSecretLoader(tr.userSecrets.SessionSecretLoader(tc.Name))
+	}
 	sessions.SetMaxConnections(tc.MaxConnections)
 	sessions.SetConnectionLimiter(NewRuntimeOrgConnectionLimiter(tr.configStore, tc.Name, tr.baseCfg.CPInstanceID, tr.globalCfg.WorkerQueueTimeout))
 	rebalancer.SetSessionLister(sessions)

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -61,6 +61,12 @@ type SessionManager struct {
 	activeSlots    int
 	waiters        []*connectionWaiter
 	limiter        connectionLimiter
+
+	// userSecretLoader returns the user's persistent CREATE SECRET statements
+	// (decrypted) to replay on a worker at session creation. nil outside the
+	// multitenant/remote backend. A loader error must not block the session:
+	// callers log and continue without secrets.
+	userSecretLoader func(ctx context.Context, username string) ([]string, error)
 }
 
 type flightReconnectPool interface {
@@ -92,6 +98,12 @@ func (sm *SessionManager) SetMaxConnections(n int) {
 	defer sm.mu.Unlock()
 	sm.maxConnections = n
 	sm.grantWaitersLocked()
+}
+
+// SetUserSecretLoader installs the per-user persistent-secret loader used at
+// session creation (multitenant/remote backend only).
+func (sm *SessionManager) SetUserSecretLoader(loader func(ctx context.Context, username string) ([]string, error)) {
+	sm.userSecretLoader = loader
 }
 
 // SetConnectionLimiter replaces the local process limiter with a cluster-wide
@@ -407,7 +419,21 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 		"owner_cp_instance_id", worker.OwnerCPInstanceID(),
 		"owner_epoch", worker.OwnerEpoch(),
 	)
-	sessionToken, err := worker.CreateSession(ctx, username, memoryLimit, threads)
+	// Load the user's persistent secrets for replay. Failure to load degrades
+	// to a session without user secrets (logged loudly) rather than a refused
+	// connection: the config store being briefly unavailable must not lock
+	// every returning user out of their warehouse.
+	var secretStatements []string
+	if sm.userSecretLoader != nil {
+		var secretErr error
+		secretStatements, secretErr = sm.userSecretLoader(ctx, username)
+		if secretErr != nil {
+			slog.Error("Failed to load user persistent secrets; session starts without them.",
+				"pid", pid, "worker", worker.ID, "user", username, "error", secretErr)
+		}
+	}
+
+	sessionToken, secretWarnings, err := worker.CreateSession(ctx, username, memoryLimit, threads, secretStatements)
 	if err != nil {
 		slog.Warn("Failed to create session on worker.",
 			"pid", pid,
@@ -422,6 +448,11 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 			sm.pool.RetireWorkerIfNoSessions(worker.ID)
 		}
 		return 0, nil, fmt.Errorf("create session on worker %d: %w", worker.ID, err)
+	}
+
+	for _, w := range secretWarnings {
+		slog.Warn("User persistent secret replay warning.",
+			"pid", pid, "worker", worker.ID, "user", username, "warning", w)
 	}
 
 	executor := flightclient.NewFlightExecutorFromClient(worker.client, sessionToken)

--- a/controlplane/user_secrets.go
+++ b/controlplane/user_secrets.go
@@ -50,8 +50,10 @@ func (m *CPUserSecretManager) Ready() error {
 	return nil
 }
 
-// PutSecret implements server.UserSecretManager.
-func (m *CPUserSecretManager) PutSecret(_ context.Context, orgID, username, secretName, statement string) error {
+// PutSecret implements server.UserSecretManager. With ifNotExists set, an
+// already-stored name is left untouched (DuckDB no-ops the live session for
+// IF NOT EXISTS, so replacing the stored statement would diverge the two).
+func (m *CPUserSecretManager) PutSecret(_ context.Context, orgID, username, secretName, statement string, ifNotExists bool) error {
 	if err := m.Ready(); err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func (m *CPUserSecretManager) PutSecret(_ context.Context, orgID, username, secr
 	if err != nil {
 		return fmt.Errorf("seal secret: %w", err)
 	}
-	if err := m.store.UpsertOrgUserSecret(orgID, username, secretName, sealed, maxUserSecretsPerUser); err != nil {
+	if err := m.store.UpsertOrgUserSecret(orgID, username, secretName, sealed, maxUserSecretsPerUser, ifNotExists); err != nil {
 		if errors.Is(err, configstore.ErrTooManyUserSecrets) {
 			return err
 		}

--- a/controlplane/user_secrets.go
+++ b/controlplane/user_secrets.go
@@ -1,0 +1,107 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/server/usersecrets"
+)
+
+// maxUserSecretsPerUser caps how many persistent secrets one (org, user) can
+// store. Generous for real use, small enough that a misbehaving client can't
+// bloat the config store.
+const maxUserSecretsPerUser = 32
+
+// CPUserSecretManager implements server.UserSecretManager on top of the
+// config store: it seals user CREATE PERSISTENT SECRET statements with
+// AES-GCM and persists them per (org, user, name) for replay at session
+// creation. With no encryption key configured, writes are disabled (Ready
+// errors, so the client gets a clear message) but deletes still work, so
+// stale rows remain removable.
+type CPUserSecretManager struct {
+	store  *configstore.ConfigStore
+	cipher *usersecrets.Cipher // nil when DUCKGRES_USER_SECRET_KEY is unset
+}
+
+// NewCPUserSecretManager builds the manager. encodedKey is the value of
+// DUCKGRES_USER_SECRET_KEY; empty disables persistence (not an error), a
+// malformed key is a startup error (fail fast on operator mistakes rather
+// than surfacing them to customers one statement at a time).
+func NewCPUserSecretManager(store *configstore.ConfigStore, encodedKey string) (*CPUserSecretManager, error) {
+	m := &CPUserSecretManager{store: store}
+	if encodedKey != "" {
+		cipher, err := usersecrets.NewCipher(encodedKey)
+		if err != nil {
+			return nil, fmt.Errorf("user secret key: %w", err)
+		}
+		m.cipher = cipher
+	}
+	return m, nil
+}
+
+// Ready implements server.UserSecretManager.
+func (m *CPUserSecretManager) Ready() error {
+	if m.cipher == nil {
+		return errors.New("the operator has not configured a secret encryption key (" + usersecrets.EnvKeyName + ")")
+	}
+	return nil
+}
+
+// PutSecret implements server.UserSecretManager.
+func (m *CPUserSecretManager) PutSecret(_ context.Context, orgID, username, secretName, statement string) error {
+	if err := m.Ready(); err != nil {
+		return err
+	}
+	sealed, err := m.cipher.Seal(orgID, username, secretName, statement)
+	if err != nil {
+		return fmt.Errorf("seal secret: %w", err)
+	}
+	if err := m.store.UpsertOrgUserSecret(orgID, username, secretName, sealed, maxUserSecretsPerUser); err != nil {
+		if errors.Is(err, configstore.ErrTooManyUserSecrets) {
+			return err
+		}
+		return fmt.Errorf("store secret: %w", err)
+	}
+	return nil
+}
+
+// DeleteSecret implements server.UserSecretManager. Works without a cipher so
+// rows written under a lost key can still be removed.
+func (m *CPUserSecretManager) DeleteSecret(_ context.Context, orgID, username, secretName string) (bool, error) {
+	return m.store.DeleteOrgUserSecret(orgID, username, secretName)
+}
+
+// LoadStatements returns the user's decrypted secret statements for replay at
+// session creation. Rows that fail to decrypt (e.g. written under a rotated
+// key) are skipped with a loud log instead of failing the whole session.
+func (m *CPUserSecretManager) LoadStatements(_ context.Context, orgID, username string) ([]string, error) {
+	if m.cipher == nil {
+		return nil, nil
+	}
+	rows, err := m.store.ListOrgUserSecrets(orgID, username)
+	if err != nil {
+		return nil, fmt.Errorf("list user secrets: %w", err)
+	}
+	statements := make([]string, 0, len(rows))
+	for _, row := range rows {
+		stmt, err := m.cipher.Open(row.OrgID, row.Username, row.SecretName, row.Ciphertext)
+		if err != nil {
+			slog.Error("User persistent secret cannot be decrypted; skipping replay (was the encryption key rotated?).",
+				"org", row.OrgID, "user", row.Username, "secret", row.SecretName, "error", err)
+			continue
+		}
+		statements = append(statements, stmt)
+	}
+	return statements, nil
+}
+
+// SessionSecretLoader binds an org onto LoadStatements in the shape
+// SessionManager.SetUserSecretLoader expects.
+func (m *CPUserSecretManager) SessionSecretLoader(orgID string) func(ctx context.Context, username string) ([]string, error) {
+	return func(ctx context.Context, username string) ([]string, error) {
+		return m.LoadStatements(ctx, orgID, username)
+	}
+}

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -1256,8 +1256,10 @@ func recoverWorkerPanic(err *error) {
 	}
 }
 
-// CreateSession creates a new session on the given worker.
-func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit string, threads int) (token string, err error) {
+// CreateSession creates a new session on the given worker. secretStatements
+// are the user's persistent secrets to replay on the worker before the
+// session serves queries; secretWarnings reports any that failed to apply.
+func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit string, threads int, secretStatements []string) (token string, secretWarnings []string, err error) {
 	defer recoverWorkerPanic(&err)
 
 	body, _ := json.Marshal(server.WorkerCreateSessionPayload{
@@ -1266,9 +1268,10 @@ func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit
 			OwnerEpoch:   w.OwnerEpoch(),
 			CPInstanceID: w.OwnerCPInstanceID(),
 		},
-		Username:    username,
-		MemoryLimit: memoryLimit,
-		Threads:     threads,
+		Username:         username,
+		MemoryLimit:      memoryLimit,
+		Threads:          threads,
+		SecretStatements: secretStatements,
 	})
 
 	stream, err := w.client.Client.DoAction(ctx, &flight.Action{
@@ -1276,22 +1279,23 @@ func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit
 		Body: body,
 	})
 	if err != nil {
-		return "", fmt.Errorf("create session: %w", err)
+		return "", nil, fmt.Errorf("create session: %w", err)
 	}
 
 	msg, err := stream.Recv()
 	if err != nil {
-		return "", fmt.Errorf("create session recv: %w", err)
+		return "", nil, fmt.Errorf("create session recv: %w", err)
 	}
 
 	var resp struct {
-		SessionToken string `json:"session_token"`
+		SessionToken   string   `json:"session_token"`
+		SecretWarnings []string `json:"secret_warnings"`
 	}
 	if err := json.Unmarshal(msg.Body, &resp); err != nil {
-		return "", fmt.Errorf("create session unmarshal: %w", err)
+		return "", nil, fmt.Errorf("create session unmarshal: %w", err)
 	}
 
-	return resp.SessionToken, nil
+	return resp.SessionToken, resp.SecretWarnings, nil
 }
 
 // ActivateTenant delivers tenant runtime to a shared warm worker before it may serve sessions.

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -1288,14 +1288,29 @@ func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit
 	}
 
 	var resp struct {
-		SessionToken   string   `json:"session_token"`
-		SecretWarnings []string `json:"secret_warnings"`
+		SessionToken string `json:"session_token"`
+		// Pointer so an old-image worker that omits the field entirely is
+		// distinguishable from a new worker reporting zero warnings.
+		SecretWarnings *[]string `json:"secret_warnings"`
 	}
 	if err := json.Unmarshal(msg.Body, &resp); err != nil {
 		return "", nil, fmt.Errorf("create session unmarshal: %w", err)
 	}
 
-	return resp.SessionToken, resp.SecretWarnings, nil
+	if resp.SecretWarnings == nil {
+		if len(secretStatements) > 0 {
+			// Per-org image pinning means a worker can run an arbitrarily old
+			// image: one that predates secret replay ignores the payload
+			// field (no replay, no create-time wipe) without erroring.
+			// Surface it as a replay warning so it is logged per-session and
+			// can't silently masquerade as "secrets restored".
+			slog.Error("Worker did not acknowledge persistent secret replay; it likely runs an image without user-secret support.",
+				"worker", w.ID, "secrets", len(secretStatements))
+			return resp.SessionToken, []string{"persistent secrets were NOT restored: the assigned worker runs an image without user-secret support"}, nil
+		}
+		return resp.SessionToken, nil, nil
+	}
+	return resp.SessionToken, *resp.SecretWarnings, nil
 }
 
 // ActivateTenant delivers tenant runtime to a shared warm worker before it may serve sessions.

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -244,6 +244,13 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 		return status.Errorf(codes.ResourceExhausted, "create session: %v", err)
 	}
 
+	// secret_warnings is always present (empty slice, never null/absent): its
+	// presence is how the control plane distinguishes a worker that processed
+	// the secret replay from an old-image worker that silently ignored the
+	// payload field.
+	if secretWarnings == nil {
+		secretWarnings = []string{}
+	}
 	resp, _ := json.Marshal(map[string]any{
 		"session_token":   session.ID,
 		"secret_warnings": secretWarnings,

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -236,7 +236,7 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 		}
 	}
 
-	session, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.Threads)
+	session, secretWarnings, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.Threads, req.SecretStatements)
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return drainErr
 	}
@@ -244,8 +244,9 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 		return status.Errorf(codes.ResourceExhausted, "create session: %v", err)
 	}
 
-	resp, _ := json.Marshal(map[string]string{
-		"session_token": session.ID,
+	resp, _ := json.Marshal(map[string]any{
+		"session_token":   session.ID,
+		"secret_warnings": secretWarnings,
 	})
 	if err := sendActionResult(stream, &flight.Result{Body: resp}); err != nil {
 		_ = h.pool.DestroySession(session.ID)

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -911,8 +911,9 @@ func (svc *DuckDBService) WaitForDrain(ctx context.Context) bool {
 
 // CreateSession creates a new DuckDB session for the given username.
 // secretStatements are the user's persistent secrets to replay (shared-warm
-// mode only); replay failures come back as client-facing warnings, not
-// errors.
+// mode only); replay failures come back as warnings — logged on the worker
+// and again by the control plane's session manager, never failing the
+// session — rather than errors.
 func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, secretStatements []string) (*Session, []string, error) {
 	start := time.Now()
 	finishDrain, drainErr := p.beginDrainWork(false)
@@ -1036,7 +1037,20 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 	// plane. Replay failures degrade to warnings; a wipe failure fails the
 	// session because handing user A's secrets to user B is not acceptable.
 	var secretWarnings []string
-	if p.sharedWarmMode {
+	switch {
+	case p.sharedWarmMode && p.maxSessions != 1:
+		// The wipe and replay below are only safe because exactly one session
+		// runs at a time (DuckDB secrets are instance-global; k8s workers are
+		// spawned with DUCKGRES_DUCKDB_MAX_SESSIONS=1). Assert that here, at
+		// the point of reliance, instead of trusting a flag set two layers
+		// away: with any other cap, wiping would delete a concurrent
+		// session's secrets mid-query. Skip hygiene entirely and scream.
+		slog.Error("User persistent secret hygiene requires max_sessions=1 on shared-warm workers; skipping wipe+replay.",
+			"max_sessions", p.maxSessions, "user", username, "secrets", len(secretStatements))
+		if len(secretStatements) > 0 {
+			secretWarnings = []string{"persistent secrets were NOT restored: worker session cap is misconfigured (requires max_sessions=1)"}
+		}
+	case p.sharedWarmMode:
 		secretCtx, secretCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
 		wiped, wipeErr := wipeUserPersistentSecrets(secretCtx, conn)
 		if wipeErr != nil {

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -910,11 +910,14 @@ func (svc *DuckDBService) WaitForDrain(ctx context.Context) bool {
 }
 
 // CreateSession creates a new DuckDB session for the given username.
-func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (*Session, error) {
+// secretStatements are the user's persistent secrets to replay (shared-warm
+// mode only); replay failures come back as client-facing warnings, not
+// errors.
+func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, secretStatements []string) (*Session, []string, error) {
 	start := time.Now()
 	finishDrain, drainErr := p.beginDrainWork(false)
 	if drainErr != nil {
-		return nil, drainErr
+		return nil, nil, drainErr
 	}
 	defer finishDrain()
 
@@ -922,7 +925,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 	p.mu.Lock()
 	if p.maxSessions > 0 && len(p.sessions)+p.reserved >= p.maxSessions {
 		p.mu.Unlock()
-		return nil, fmt.Errorf("max sessions reached (%d)", p.maxSessions)
+		return nil, nil, fmt.Errorf("max sessions reached (%d)", p.maxSessions)
 	}
 	p.reserved++
 	p.mu.Unlock()
@@ -958,7 +961,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 			p.mu.Lock()
 			p.reserved--
 			p.mu.Unlock()
-			return nil, cfgErr
+			return nil, nil, cfgErr
 		}
 
 		// Fallback: create a shared DB if warmup failed or wasn't run.
@@ -979,7 +982,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 			p.mu.Lock()
 			p.reserved--
 			p.mu.Unlock()
-			return nil, fmt.Errorf("create session db: %w", p.fallbackErr)
+			return nil, nil, fmt.Errorf("create session db: %w", p.fallbackErr)
 		}
 		db = p.fallbackDB
 		slog.Info("Using fallback DB (warmup failed).", "duration", time.Since(fallbackStart))
@@ -997,7 +1000,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		p.mu.Lock()
 		p.reserved--
 		p.mu.Unlock()
-		return nil, fmt.Errorf("failed to obtain connection from pool (timeout after 30s): %w", err)
+		return nil, nil, fmt.Errorf("failed to obtain connection from pool (timeout after 30s): %w", err)
 	}
 	slog.Debug("Acquired DB connection from pool.", "user", username, "duration", time.Since(start))
 
@@ -1023,6 +1026,32 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf("SET threads = %d", threads)); err != nil {
 			slog.Warn("Failed to set initial threads.", "user", username, "error", err)
 		}
+	}
+
+	// Persistent user-secret hygiene + replay (shared-warm / k8s mode only).
+	// DuckDB secrets are instance-global, so a hot-idle worker reused by a
+	// different user of the same org would otherwise see the previous user's
+	// persistent secrets. Wipe first (mandatory — this is the cross-user
+	// isolation step), then replay this user's secrets from the control
+	// plane. Replay failures degrade to warnings; a wipe failure fails the
+	// session because handing user A's secrets to user B is not acceptable.
+	var secretWarnings []string
+	if p.sharedWarmMode {
+		secretCtx, secretCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
+		wiped, wipeErr := wipeUserPersistentSecrets(secretCtx, conn)
+		if wipeErr != nil {
+			secretCancel()
+			_ = conn.Close()
+			p.mu.Lock()
+			p.reserved--
+			p.mu.Unlock()
+			return nil, nil, fmt.Errorf("wipe persistent secrets before session start: %w", wipeErr)
+		}
+		if len(wiped) > 0 {
+			slog.Info("Wiped persistent secrets left by previous session.", "user", username, "count", len(wiped))
+		}
+		secretWarnings = replayUserSecrets(secretCtx, conn, username, secretStatements)
+		secretCancel()
 	}
 
 	// Extract the raw DuckDB connection handle for progress polling.
@@ -1055,7 +1084,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 		p.mu.Lock()
 		p.reserved--
 		p.mu.Unlock()
-		return nil, cfgErr
+		return nil, nil, cfgErr
 	}
 
 	// In shared-warm (multi-tenant) mode the control plane drives credential
@@ -1092,7 +1121,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int) (
 	p.mu.Unlock()
 
 	slog.Debug("Created DuckDB session", "user", username, "duration", time.Since(start))
-	return session, nil
+	return session, secretWarnings, nil
 }
 
 // GetSession returns a session by token.
@@ -1209,6 +1238,21 @@ func (p *SessionPool) DestroySession(token string) error {
 			"evicted", evicted)
 		session.connMu.Unlock()
 	}
+
+	// Best-effort persistent-secret wipe so user credentials don't sit on a
+	// hot-idle worker between sessions. The mandatory cross-user isolation
+	// wipe happens at the next CreateSession; this one just narrows the
+	// window. Only safe when this worker serves one session at a time
+	// (secrets are instance-global), which is how k8s workers are deployed
+	// (DUCKGRES_DUCKDB_MAX_SESSIONS=1).
+	if p.sharedWarmMode && p.maxSessions == 1 && session.DB != nil {
+		wipeCtx, wipeCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
+		if _, err := wipeUserPersistentSecrets(wipeCtx, session.DB); err != nil {
+			slog.Warn("Failed to wipe persistent secrets on session destroy.", "user", session.Username, "error", err)
+		}
+		wipeCancel()
+	}
+
 	// Do NOT close session.DB if it is a shared DB (warmup or fallback)
 	p.mu.RLock()
 	isShared := session.DB == p.warmupDB || session.DB == p.fallbackDB

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -88,7 +88,7 @@ func TestCreateSessionRejectsSecondSessionWhenMaxIsOne(t *testing.T) {
 	}
 	pool.sessions["existing"] = &Session{ID: "existing"}
 
-	_, err := pool.CreateSession("u", "", 0)
+	_, _, err := pool.CreateSession("u", "", 0, nil)
 	if err == nil {
 		t.Fatal("expected second CreateSession to be rejected at MaxSessions=1")
 	}

--- a/duckdbservice/user_secrets.go
+++ b/duckdbservice/user_secrets.go
@@ -1,0 +1,86 @@
+package duckdbservice
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/posthog/duckgres/server/usersecrets"
+)
+
+// secretDBHandle is the subset of *sql.Conn / *sql.DB needed for secret
+// hygiene and replay.
+type secretDBHandle interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+const userSecretOpTimeout = 15 * time.Second
+
+// wipeUserPersistentSecrets drops every persistent-storage DuckDB secret on
+// the shared per-org instance. System secrets (ducklake_s3, iceberg_sigv4,
+// iceberg_oauth) are created with plain CREATE OR REPLACE SECRET and live in
+// in-memory storage, so a persistent-only wipe never touches them — anything
+// persistent was replayed (or created) by a user session and must not leak
+// into the next session, which may belong to a different user of the org.
+// Returns the names that were dropped.
+func wipeUserPersistentSecrets(ctx context.Context, h secretDBHandle) ([]string, error) {
+	rows, err := h.QueryContext(ctx, "SELECT name FROM duckdb_secrets() WHERE persistent")
+	if err != nil {
+		return nil, fmt.Errorf("list persistent secrets: %w", err)
+	}
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+
+	var dropped []string
+	for _, name := range names {
+		if _, err := h.ExecContext(ctx, "DROP PERSISTENT SECRET IF EXISTS "+quoteSecretIdent(name)); err != nil {
+			return dropped, fmt.Errorf("drop persistent secret %q: %w", name, err)
+		}
+		dropped = append(dropped, name)
+	}
+	return dropped, nil
+}
+
+// quoteSecretIdent double-quotes a DuckDB identifier, escaping embedded quotes.
+func quoteSecretIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// replayUserSecrets applies the control-plane-supplied persistent secret
+// statements to a fresh session. Failures are collected as warnings rather
+// than failing the session: a stale or broken stored secret must not lock the
+// user out of their warehouse. Statement text is never logged — only the
+// classified secret name.
+func replayUserSecrets(ctx context.Context, h secretDBHandle, username string, statements []string) []string {
+	var warnings []string
+	for _, stmt := range statements {
+		name := usersecrets.Classify(stmt).Name
+		if name == "" {
+			name = "(unknown)"
+		}
+		if _, err := h.ExecContext(ctx, stmt); err != nil {
+			slog.Warn("Failed to replay user persistent secret.",
+				"user", username, "secret", name, "error", err)
+			warnings = append(warnings, fmt.Sprintf("persistent secret %q could not be restored: %v", name, err))
+			continue
+		}
+		slog.Debug("Replayed user persistent secret.", "user", username, "secret", name)
+	}
+	return warnings
+}

--- a/duckdbservice/user_secrets_test.go
+++ b/duckdbservice/user_secrets_test.go
@@ -1,0 +1,98 @@
+package duckdbservice
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func openSecretTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// Pin persistent secrets under the test dir (must happen before the
+	// secret manager is first used).
+	dir := filepath.Join(t.TempDir(), "secrets")
+	if _, err := db.Exec("SET secret_directory = '" + dir + "'"); err != nil {
+		t.Fatalf("set secret_directory: %v", err)
+	}
+	return db
+}
+
+func secretNames(t *testing.T, db *sql.DB, where string) map[string]bool {
+	t.Helper()
+	rows, err := db.Query("SELECT name FROM duckdb_secrets() " + where)
+	if err != nil {
+		t.Fatalf("duckdb_secrets: %v", err)
+	}
+	defer rows.Close()
+	names := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		names[name] = true
+	}
+	return names
+}
+
+// Wipe must drop persistent secrets (user-created) and leave in-memory
+// secrets (how the system catalog secrets are created) untouched.
+func TestWipeUserPersistentSecrets(t *testing.T) {
+	db := openSecretTestDB(t)
+	mustExec := func(q string) {
+		t.Helper()
+		if _, err := db.Exec(q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	mustExec("CREATE OR REPLACE SECRET ducklake_s3 (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
+	mustExec("CREATE PERSISTENT SECRET user_a (TYPE s3, KEY_ID 'a', SECRET 'a')")
+	mustExec(`CREATE PERSISTENT SECRET "user_b" (TYPE gcs, KEY_ID 'b', SECRET 'b')`)
+
+	dropped, err := wipeUserPersistentSecrets(context.Background(), db)
+	if err != nil {
+		t.Fatalf("wipeUserPersistentSecrets: %v", err)
+	}
+	if len(dropped) != 2 {
+		t.Errorf("dropped = %v, want 2 names", dropped)
+	}
+	if names := secretNames(t, db, "WHERE persistent"); len(names) != 0 {
+		t.Errorf("persistent secrets remain after wipe: %v", names)
+	}
+	if names := secretNames(t, db, ""); !names["ducklake_s3"] {
+		t.Errorf("system in-memory secret was wiped; remaining: %v", names)
+	}
+}
+
+// Replay applies statements and degrades per-statement failures to warnings
+// that never include the statement text (it carries credentials).
+func TestReplayUserSecrets(t *testing.T) {
+	db := openSecretTestDB(t)
+
+	warnings := replayUserSecrets(context.Background(), db, "alice", []string{
+		"CREATE PERSISTENT SECRET good_one (TYPE s3, KEY_ID 'k', SECRET 'sensitive-value')",
+		"CREATE PERSISTENT SECRET bad_one (TYPE not_a_type)",
+	})
+
+	if names := secretNames(t, db, "WHERE persistent"); !names["good_one"] {
+		t.Errorf("good_one not replayed; have %v", names)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly 1", warnings)
+	}
+	if !strings.Contains(warnings[0], "bad_one") {
+		t.Errorf("warning %q does not name the failed secret", warnings[0])
+	}
+	if strings.Contains(warnings[0], "sensitive-value") {
+		t.Errorf("warning leaks statement text: %q", warnings[0])
+	}
+}

--- a/duckdbservice/user_secrets_test.go
+++ b/duckdbservice/user_secrets_test.go
@@ -32,7 +32,7 @@ func secretNames(t *testing.T, db *sql.DB, where string) map[string]bool {
 	if err != nil {
 		t.Fatalf("duckdb_secrets: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	names := map[string]bool{}
 	for rows.Next() {
 		var name string

--- a/main.go
+++ b/main.go
@@ -339,6 +339,7 @@ func main() {
 			ConfigStoreConn:            resolved.ConfigStoreConn,
 			ConfigPollInterval:         resolved.ConfigPollInterval,
 			InternalSecret:             resolved.InternalSecret,
+			UserSecretKey:              resolved.UserSecretKey,
 			SNIRoutingMode:             resolved.SNIRoutingMode,
 			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
 			DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,

--- a/server/conn.go
+++ b/server/conn.go
@@ -24,6 +24,7 @@ import (
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/sqlcore"
+	"github.com/posthog/duckgres/server/usersecrets"
 	"github.com/posthog/duckgres/server/wire"
 	"github.com/posthog/duckgres/transpiler"
 	"go.opentelemetry.io/otel/attribute"
@@ -379,6 +380,7 @@ func (c *clientConn) startDisconnectMonitor(ctx context.Context) (stop func()) {
 // worker incident (e.g. the one in the worker-40761 postmortem) can
 // filter to just that worker's queries without joining across logs.
 func (c *clientConn) logQueryStarted(query string) {
+	query = usersecrets.RedactForLog(query)
 	slog.Info("Query started.",
 		"user", c.username,
 		"query", query,
@@ -398,6 +400,7 @@ func (c *clientConn) logQueryStarted(query string) {
 // "started" and a "finished" line, and can look at the separate error
 // line for severity context.
 func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64, err error) {
+	query = usersecrets.RedactForLog(query)
 	attrs := []any{
 		"user", c.username,
 		"query", query,
@@ -420,6 +423,7 @@ func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64,
 // (worker crash, IO failure, internal panic, infra unreachable), not
 // "user typo'd a column name."
 func (c *clientConn) logQueryError(query string, err error) {
+	query = usersecrets.RedactForLog(query)
 	attrs := []any{"user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod}
 	if isDuckLakeTransactionConflict(err) {
 		slog.Warn("DuckLake transaction conflict.", attrs...)
@@ -1105,7 +1109,11 @@ func (c *clientConn) handleQuery(body []byte) error {
 		return nil
 	}
 
-	c.currentQuery.Store(query)
+	// Redacted form for everything observable (pg_stat_activity, spans,
+	// logs): CREATE SECRET option lists carry credential material.
+	loggableQuery := usersecrets.RedactForLog(query)
+
+	c.currentQuery.Store(loggableQuery)
 	c.queryStart.Store(time.Now())
 	defer func() {
 		c.currentQuery.Store("")
@@ -1120,7 +1128,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 			attribute.String("duckgres.protocol", "simple"),
 			attribute.String("duckgres.org_id", c.orgID),
 			attribute.String("db.user", c.username),
-			attribute.String("db.statement", observe.TruncateForSpan(query)),
+			attribute.String("db.statement", observe.TruncateForSpan(loggableQuery)),
 		),
 	)
 	defer span.End()
@@ -1130,7 +1138,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 	c.ctx = ctx
 	defer func() { c.ctx = prevCtx }()
 
-	slog.Debug("Query received.", "user", c.username, "query", query)
+	slog.Debug("Query received.", "user", c.username, "query", loggableQuery)
 
 	// Check for cursor operations (DECLARE, FETCH, CLOSE) before passthrough
 	// or transpilation. DuckDB doesn't support these natively, so cursor
@@ -1158,6 +1166,15 @@ func (c *clientConn) handleQuery(body []byte) error {
 	// Intercept pg_stat_activity queries. Return synthetic results from the connection registry.
 	if matchPgStatActivityQuery(query) {
 		return c.handlePgStatActivity()
+	}
+
+	// Intercept persistent-secret DDL (CREATE PERSISTENT SECRET / DROP
+	// SECRET) when a user secret manager is configured (multitenant remote
+	// backend), so customer secrets survive across sessions and worker pods.
+	// Must run before the passthrough branch: passthrough users get
+	// persistence too.
+	if c.handleUserSecretDDLSimple(query) {
+		return nil
 	}
 
 	// Passthrough mode: skip all transpilation, send query directly to DuckDB
@@ -1216,7 +1233,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 			_ = c.writer.Flush()
 			return nil
 		}
-		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", query)
+		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", loggableQuery)
 	}
 
 	// Handle transform-detected errors (e.g., unrecognized config parameter)

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -12,6 +12,7 @@ import (
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/posthog/duckgres/server/observe"
+	"github.com/posthog/duckgres/server/usersecrets"
 	"github.com/posthog/duckgres/server/wire"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -178,7 +179,7 @@ func (c *clientConn) handleParse(body []byte) {
 			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
 			return
 		}
-		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", query)
+		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", usersecrets.RedactForLog(query))
 	}
 
 	// Close existing statement with same name
@@ -197,11 +198,11 @@ func (c *clientConn) handleParse(body []byte) {
 		warnings:          result.Warnings,          // Surfaced as NoticeResponse at Execute
 	}
 
-	slog.Debug("Prepared statement.", "user", c.username, "name", stmtName, "query", query)
+	slog.Debug("Prepared statement.", "user", c.username, "name", stmtName, "query", usersecrets.RedactForLog(query))
 	if len(result.Statements) > 0 {
 		slog.Debug("Prepared statement multi-statement.", "user", c.username, "name", stmtName, "statements", len(result.Statements), "cleanup", len(result.CleanupStatements))
 	} else if result.SQL != query {
-		slog.Debug("Prepared statement transpiled.", "user", c.username, "name", stmtName, "transpiled", result.SQL)
+		slog.Debug("Prepared statement transpiled.", "user", c.username, "name", stmtName, "transpiled", usersecrets.RedactForLog(result.SQL))
 	}
 	_ = wire.WriteParseComplete(c.writer)
 }
@@ -488,7 +489,11 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 
-	c.currentQuery.Store(p.stmt.query)
+	// Redacted form for everything observable (pg_stat_activity, spans,
+	// logs): CREATE SECRET option lists carry credential material.
+	loggableQuery := usersecrets.RedactForLog(p.stmt.query)
+
+	c.currentQuery.Store(loggableQuery)
 	c.queryStart.Store(time.Now())
 	defer func() {
 		c.currentQuery.Store("")
@@ -529,7 +534,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			attribute.String("duckgres.protocol", "extended"),
 			attribute.String("duckgres.org_id", c.orgID),
 			attribute.String("db.user", c.username),
-			attribute.String("db.statement", observe.TruncateForSpan(p.stmt.query)),
+			attribute.String("db.statement", observe.TruncateForSpan(loggableQuery)),
 		),
 	)
 	defer span.End()
@@ -546,7 +551,15 @@ func (c *clientConn) handleExecute(body []byte) {
 	cmdType := c.getCommandType(upperQuery)
 	returnsResults := queryReturnsResults(p.stmt.query)
 
-	slog.Debug("Execute portal.", "user", c.username, "portal", portalName, "params", len(args), "query", p.stmt.query)
+	// Intercept persistent-secret DDL (multitenant remote backend): persist /
+	// delete the user's stored secret alongside the session-side DDL. Uses
+	// the original (untranspiled) text — secret DDL is DuckDB-native and
+	// always falls back unmodified. ReadyForQuery is sent by Sync.
+	if c.handleUserSecretDDLExtended(p.stmt.query) {
+		return
+	}
+
+	slog.Debug("Execute portal.", "user", c.username, "portal", portalName, "params", len(args), "query", loggableQuery)
 
 	// Surface any transpiler warnings (e.g. an unenforced constraint stripped on a
 	// lake catalog) as NoticeResponse before the command result.

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -228,7 +228,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 			c.sendError("ERROR", "26000", fmt.Sprintf("prepared statement %q does not exist", name))
 			return
 		}
-		slog.Debug("Describe statement.", "user", c.username, "name", name, "query", ps.query)
+		slog.Debug("Describe statement.", "user", c.username, "name", name, "query", usersecrets.RedactForLog(ps.query))
 
 		// Send parameter description based on the number of $N placeholders we found
 		// If the client didn't send explicit types, create them

--- a/server/conn_user_secrets.go
+++ b/server/conn_user_secrets.go
@@ -18,16 +18,26 @@ type UserSecretManager interface {
 	// Ready reports whether secrets can be persisted (e.g. the encryption
 	// key is configured). A non-nil error is shown to the client.
 	Ready() error
-	// PutSecret stores one statement, replacing any prior statement with the
-	// same name. Called only after the statement executed successfully on
-	// the live session.
-	PutSecret(ctx context.Context, orgID, username, secretName, statement string) error
+	// PutSecret stores one statement. With ifNotExists set, an already-stored
+	// name is left untouched (mirroring DuckDB's IF NOT EXISTS no-op on the
+	// live session); otherwise any prior statement with the same name is
+	// replaced. Called only after the statement executed successfully on the
+	// live session.
+	PutSecret(ctx context.Context, orgID, username, secretName, statement string, ifNotExists bool) error
 	// DeleteSecret removes one stored secret, reporting whether it existed.
 	DeleteSecret(ctx context.Context, orgID, username, secretName string) (existed bool, err error)
 }
 
 // maxUserSecretStatementLen bounds a single stored CREATE SECRET statement.
 const maxUserSecretStatementLen = 8 * 1024
+
+// isSecretNotFoundError matches DuckDB's error for dropping a secret that
+// does not exist ("Invalid Input Error: Failed to remove non-existent secret
+// with name '...'"). The DROP store-fallback is gated on exactly this error;
+// see execUserSecretDDL.
+func isSecretNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "non-existent secret")
+}
 
 // secretDDLError is a client-facing error from the secret DDL path.
 type secretDDLError struct {
@@ -48,10 +58,10 @@ type secretDDLError struct {
 //     config store for replay on the user's future sessions.
 //   - DROP [PERSISTENT] SECRET <name>: execute on the session, then delete
 //     from the store so it doesn't reappear next session. If the session-side
-//     DROP fails but the store had the secret (e.g. its replay failed because
-//     an extension is missing), the store row is still deleted and the DROP
-//     reported successful — otherwise a broken stored secret could never be
-//     removed.
+//     DROP fails with DuckDB's not-found error (and only that error) but the
+//     store had the secret — e.g. its replay failed because an extension is
+//     missing — the store row is still deleted and the DROP reported
+//     successful, otherwise a broken stored secret could never be removed.
 //
 // DuckDB secrets are not transactional, so the store write is immediate even
 // inside an explicit transaction block; a ROLLBACK does not undo it.
@@ -69,6 +79,24 @@ func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, 
 	}
 	if st.Kind == usersecrets.KindDrop && st.Name == "" {
 		return false, "", nil // let DuckDB produce its own parse error
+	}
+
+	// Persistence side effects must map 1:1 to a statement. Letting a
+	// persistent variant fall through inside a multi-statement batch would be
+	// worse than rejecting: the statement executes, never persists, and the
+	// next session's hygiene wipe silently deletes it.
+	if st.MultiStatement {
+		if st.Persistent {
+			return true, "", &secretDDLError{"0A000", "persistent secret DDL must be sent as a single statement; split it out of the multi-statement batch"}
+		}
+		return false, "", nil // plain DROP SECRET in a batch keeps passthrough behavior
+	}
+
+	// The stored statement is replayed verbatim on future sessions, so bound
+	// parameters can never be resolved again — and the executor would run
+	// them unbound here anyway. Require literals.
+	if hasParameterPlaceholders(query) {
+		return true, "", &secretDDLError{"0A000", "persistent secret statements must use literal values, not parameters ($1, ...), so they can be replayed on future sessions"}
 	}
 
 	if st.Kind == usersecrets.KindCreate {
@@ -89,14 +117,14 @@ func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, 
 	ctx, cleanup := c.queryContext()
 	defer cleanup()
 
-	// Lifecycle log pair, like the normal exec paths — but with the
-	// credential-bearing option list redacted.
-	redacted := usersecrets.RedactForLog(query)
+	// Lifecycle log pair, like the normal exec paths. logQueryStarted/
+	// Finished/Error redact secret DDL internally (see usersecrets.
+	// RedactForLog) — they own redaction, callers pass raw text.
 	queryStart := time.Now()
 	var queryFinalErr error
-	c.logQueryStarted(redacted)
+	c.logQueryStarted(query)
 	defer func() {
-		c.logQueryFinished(redacted, queryStart, 0, queryFinalErr)
+		c.logQueryFinished(query, queryStart, 0, queryFinalErr)
 	}()
 
 	upperQuery := strings.ToUpper(query)
@@ -105,10 +133,17 @@ func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, 
 	_, execErr := c.executor.ExecContext(ctx, query)
 	if execErr != nil {
 		queryFinalErr = execErr
-		if st.Kind == usersecrets.KindDrop {
+		if st.Kind == usersecrets.KindDrop && isSecretNotFoundError(execErr) {
 			// The stored secret may exist even though the session-side one
-			// doesn't (its replay failed). Deleting the row is the only way
-			// for the user to get rid of it, so prefer that over the error.
+			// doesn't (its replay failed, e.g. a missing extension). Deleting
+			// the row is the only way for the user to get rid of it, so
+			// treat the DROP as successful when the store had it. Gated on
+			// DuckDB's not-found error specifically: any other failure
+			// (cancellation, RPC error, aborted transaction, the
+			// multiple-storages ambiguity error) means the session-side
+			// secret may still exist, and reporting a successful DROP while
+			// deleting only the stored copy would hand the user a false
+			// confirmation — fatal for a credential revocation.
 			if existed, delErr := mgr.DeleteSecret(ctx, c.orgID, c.username, st.Name); delErr == nil && existed {
 				queryFinalErr = nil
 				c.updateTxStatus(cmdType)
@@ -119,7 +154,7 @@ func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, 
 		if c.isCallerCancellation(execErr) {
 			errMsg = "canceling statement due to user request"
 		} else {
-			c.logQueryError(redacted, execErr)
+			c.logQueryError(query, execErr)
 		}
 		c.setTxError()
 		return true, "", &secretDDLError{classifyErrorCode(execErr), errMsg}
@@ -131,7 +166,7 @@ func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, 
 	var storeErr error
 	switch st.Kind {
 	case usersecrets.KindCreate:
-		storeErr = mgr.PutSecret(ctx, c.orgID, c.username, st.Name, query)
+		storeErr = mgr.PutSecret(ctx, c.orgID, c.username, st.Name, query, st.IfNotExists)
 		if storeErr != nil {
 			return true, "", &secretDDLError{"58000", fmt.Sprintf(
 				"secret %q was applied to the current session but could not be persisted (it will NOT survive this session): %v; retry the statement",

--- a/server/conn_user_secrets.go
+++ b/server/conn_user_secrets.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/posthog/duckgres/server/usersecrets"
+	"github.com/posthog/duckgres/server/wire"
+)
+
+// UserSecretManager persists per-user CREATE PERSISTENT SECRET statements so
+// they survive across sessions and worker pods. Implemented by the
+// multitenant control plane (backed by the config store); nil in standalone
+// and process-worker modes, where secret DDL passes through untouched.
+type UserSecretManager interface {
+	// Ready reports whether secrets can be persisted (e.g. the encryption
+	// key is configured). A non-nil error is shown to the client.
+	Ready() error
+	// PutSecret stores one statement, replacing any prior statement with the
+	// same name. Called only after the statement executed successfully on
+	// the live session.
+	PutSecret(ctx context.Context, orgID, username, secretName, statement string) error
+	// DeleteSecret removes one stored secret, reporting whether it existed.
+	DeleteSecret(ctx context.Context, orgID, username, secretName string) (existed bool, err error)
+}
+
+// maxUserSecretStatementLen bounds a single stored CREATE SECRET statement.
+const maxUserSecretStatementLen = 8 * 1024
+
+// secretDDLError is a client-facing error from the secret DDL path.
+type secretDDLError struct {
+	code string
+	msg  string
+}
+
+// execUserSecretDDL is the shared (simple + extended protocol) handler for
+// persistent-secret DDL. It returns handled=false when the statement is not
+// secret DDL this feature owns (temporary secrets, no manager configured,
+// unclassifiable text) — the caller then proceeds down the normal execution
+// path. When handled=true the statement was executed (and the store updated);
+// tag is the CommandComplete tag, or secErr the error to send.
+//
+// Semantics:
+//   - CREATE [OR REPLACE] PERSISTENT SECRET <name>: execute on the session
+//     first (DuckDB validates), then persist the statement (encrypted) in the
+//     config store for replay on the user's future sessions.
+//   - DROP [PERSISTENT] SECRET <name>: execute on the session, then delete
+//     from the store so it doesn't reappear next session. If the session-side
+//     DROP fails but the store had the secret (e.g. its replay failed because
+//     an extension is missing), the store row is still deleted and the DROP
+//     reported successful — otherwise a broken stored secret could never be
+//     removed.
+//
+// DuckDB secrets are not transactional, so the store write is immediate even
+// inside an explicit transaction block; a ROLLBACK does not undo it.
+func (c *clientConn) execUserSecretDDL(query string) (handled bool, tag string, secErr *secretDDLError) {
+	mgr := c.server.cfg.UserSecrets
+	if mgr == nil {
+		return false, "", nil
+	}
+	st := usersecrets.Classify(query)
+	if st.Kind == usersecrets.KindNone || st.Temporary {
+		return false, "", nil
+	}
+	if st.Kind == usersecrets.KindCreate && !st.Persistent {
+		return false, "", nil // plain CREATE SECRET stays session-scoped
+	}
+	if st.Kind == usersecrets.KindDrop && st.Name == "" {
+		return false, "", nil // let DuckDB produce its own parse error
+	}
+
+	if st.Kind == usersecrets.KindCreate {
+		if err := mgr.Ready(); err != nil {
+			return true, "", &secretDDLError{"0A000", fmt.Sprintf("persistent secrets are not enabled on this deployment: %v", err)}
+		}
+		if st.Name == "" {
+			return true, "", &secretDDLError{"0A000", "persistent secrets must be named (CREATE PERSISTENT SECRET <name> (...)) so they can be managed across sessions"}
+		}
+		if usersecrets.IsReservedName(st.Name) {
+			return true, "", &secretDDLError{"42939", fmt.Sprintf("secret name %q is reserved for system use", st.Name)}
+		}
+		if len(query) > maxUserSecretStatementLen {
+			return true, "", &secretDDLError{"54000", fmt.Sprintf("CREATE SECRET statement exceeds %d bytes", maxUserSecretStatementLen)}
+		}
+	}
+
+	ctx, cleanup := c.queryContext()
+	defer cleanup()
+
+	// Lifecycle log pair, like the normal exec paths — but with the
+	// credential-bearing option list redacted.
+	redacted := usersecrets.RedactForLog(query)
+	queryStart := time.Now()
+	var queryFinalErr error
+	c.logQueryStarted(redacted)
+	defer func() {
+		c.logQueryFinished(redacted, queryStart, 0, queryFinalErr)
+	}()
+
+	upperQuery := strings.ToUpper(query)
+	cmdType := c.getCommandType(upperQuery)
+
+	_, execErr := c.executor.ExecContext(ctx, query)
+	if execErr != nil {
+		queryFinalErr = execErr
+		if st.Kind == usersecrets.KindDrop {
+			// The stored secret may exist even though the session-side one
+			// doesn't (its replay failed). Deleting the row is the only way
+			// for the user to get rid of it, so prefer that over the error.
+			if existed, delErr := mgr.DeleteSecret(ctx, c.orgID, c.username, st.Name); delErr == nil && existed {
+				queryFinalErr = nil
+				c.updateTxStatus(cmdType)
+				return true, c.buildCommandTag(cmdType, nil), nil
+			}
+		}
+		errMsg := friendlyExecError(execErr)
+		if c.isCallerCancellation(execErr) {
+			errMsg = "canceling statement due to user request"
+		} else {
+			c.logQueryError(redacted, execErr)
+		}
+		c.setTxError()
+		return true, "", &secretDDLError{classifyErrorCode(execErr), errMsg}
+	}
+
+	// Session-side DDL succeeded; now make it durable. Failures here must be
+	// surfaced as errors — the client believing a secret persisted when it
+	// didn't is the one outcome this feature exists to prevent.
+	var storeErr error
+	switch st.Kind {
+	case usersecrets.KindCreate:
+		storeErr = mgr.PutSecret(ctx, c.orgID, c.username, st.Name, query)
+		if storeErr != nil {
+			return true, "", &secretDDLError{"58000", fmt.Sprintf(
+				"secret %q was applied to the current session but could not be persisted (it will NOT survive this session): %v; retry the statement",
+				st.Name, storeErr)}
+		}
+	case usersecrets.KindDrop:
+		if _, storeErr = mgr.DeleteSecret(ctx, c.orgID, c.username, st.Name); storeErr != nil {
+			return true, "", &secretDDLError{"58000", fmt.Sprintf(
+				"secret %q was dropped from the current session but is still persisted and will reappear next session: %v; retry the statement",
+				st.Name, storeErr)}
+		}
+	}
+
+	c.updateTxStatus(cmdType)
+	return true, c.buildCommandTag(cmdType, nil), nil
+}
+
+// handleUserSecretDDLSimple intercepts persistent-secret DDL on the simple
+// query protocol. Returns true when fully handled (responses written,
+// including ReadyForQuery).
+func (c *clientConn) handleUserSecretDDLSimple(query string) bool {
+	handled, tag, secErr := c.execUserSecretDDL(query)
+	if !handled {
+		return false
+	}
+	if secErr != nil {
+		c.sendError("ERROR", secErr.code, secErr.msg)
+	} else {
+		_ = wire.WriteCommandComplete(c.writer, tag)
+	}
+	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
+	_ = c.writer.Flush()
+	return true
+}
+
+// handleUserSecretDDLExtended intercepts persistent-secret DDL at Execute
+// time on the extended query protocol (ReadyForQuery is sent by Sync).
+// Returns true when fully handled.
+func (c *clientConn) handleUserSecretDDLExtended(query string) bool {
+	handled, tag, secErr := c.execUserSecretDDL(query)
+	if !handled {
+		return false
+	}
+	if secErr != nil {
+		c.sendError("ERROR", secErr.code, secErr.msg)
+	} else {
+		_ = wire.WriteCommandComplete(c.writer, tag)
+	}
+	return true
+}

--- a/server/conn_user_secrets_test.go
+++ b/server/conn_user_secrets_test.go
@@ -9,19 +9,21 @@ import (
 
 // fakeUserSecretMgr records PutSecret/DeleteSecret calls.
 type fakeUserSecretMgr struct {
-	readyErr error
-	putErr   error
-	delErr   error
-	delExist bool
-	putCalls []string // "org/user/name"
-	putStmts []string
-	delCalls []string
+	readyErr       error
+	putErr         error
+	delErr         error
+	delExist       bool
+	putCalls       []string // "org/user/name"
+	putStmts       []string
+	putIfNotExists []bool
+	delCalls       []string
 }
 
 func (m *fakeUserSecretMgr) Ready() error { return m.readyErr }
-func (m *fakeUserSecretMgr) PutSecret(_ context.Context, orgID, username, name, stmt string) error {
+func (m *fakeUserSecretMgr) PutSecret(_ context.Context, orgID, username, name, stmt string, ifNotExists bool) error {
 	m.putCalls = append(m.putCalls, orgID+"/"+username+"/"+name)
 	m.putStmts = append(m.putStmts, stmt)
+	m.putIfNotExists = append(m.putIfNotExists, ifNotExists)
 	return m.putErr
 }
 func (m *fakeUserSecretMgr) DeleteSecret(_ context.Context, orgID, username, name string) (bool, error) {
@@ -76,6 +78,7 @@ func TestExecUserSecretDDLNotHandledCases(t *testing.T) {
 		{"drop temporary", &fakeUserSecretMgr{}, "DROP TEMPORARY SECRET s"},
 		{"non-secret statement", &fakeUserSecretMgr{}, "SELECT 1"},
 		{"unnamed drop", &fakeUserSecretMgr{}, "DROP SECRET"},
+		{"plain drop in multi-statement batch keeps passthrough", &fakeUserSecretMgr{}, "DROP SECRET s; SELECT 1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +107,14 @@ func TestExecUserSecretDDLRejections(t *testing.T) {
 		{"unnamed persistent", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET (TYPE s3)", "0A000"},
 		{"reserved name", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET ducklake_s3 (TYPE s3)", "42939"},
 		{"oversized statement", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET big (TYPE s3, SECRET '" + strings.Repeat("x", maxUserSecretStatementLen) + "')", "54000"},
+		// A persistent variant in a multi-statement batch must be rejected,
+		// not silently fall through: it would execute, never persist, and be
+		// wiped at the next session.
+		{"multi-statement create", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET s (TYPE s3); SELECT 1", "0A000"},
+		{"multi-statement drop", &fakeUserSecretMgr{}, "DROP PERSISTENT SECRET s; SELECT 1", "0A000"},
+		// Bound parameters can never be replayed; reject rather than execute
+		// unbound or persist placeholder text.
+		{"parameterized statement", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET s (TYPE s3, KEY_ID $1, SECRET $2)", "0A000"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -182,10 +193,16 @@ func TestExecUserSecretDDLDropDeletesFromStore(t *testing.T) {
 }
 
 // A stored secret whose replay failed doesn't exist on the session; DROP must
-// still be able to remove it from the store.
+// still be able to remove it from the store — but ONLY when the session-side
+// failure is DuckDB's not-found error. Any other failure must surface and
+// leave the store untouched: a false "DROP succeeded" is fatal for a
+// credential revocation.
 func TestExecUserSecretDDLDropFallsBackToStore(t *testing.T) {
+	// DuckDB's actual message for dropping a missing secret.
+	notFound := errors.New("Invalid Input Error: Failed to remove non-existent secret with name 'broken_one'")
+
 	mgr := &fakeUserSecretMgr{delExist: true}
-	exec := &lifecycleExecutor{execErr: errors.New("Invalid Input Error: secret not found")}
+	exec := &lifecycleExecutor{execErr: notFound}
 	c, cleanup := newUserSecretTestConn(t, mgr, exec)
 	defer cleanup()
 
@@ -197,12 +214,55 @@ func TestExecUserSecretDDLDropFallsBackToStore(t *testing.T) {
 		t.Errorf("tag = %q, want DROP", tag)
 	}
 
-	// But when the store has nothing either, the DuckDB error wins.
+	// When the store has nothing either, the DuckDB error wins.
 	mgr2 := &fakeUserSecretMgr{delExist: false}
 	c2, cleanup2 := newUserSecretTestConn(t, mgr2, exec)
 	defer cleanup2()
 	handled, _, secErr = c2.execUserSecretDDL("DROP PERSISTENT SECRET nope")
 	if !handled || secErr == nil {
 		t.Fatalf("handled=%v secErr=%v, want the DuckDB error surfaced", handled, secErr)
+	}
+}
+
+// Any session-side DROP failure other than not-found (cancellation, RPC
+// error, aborted transaction, the multiple-storages ambiguity error) must NOT
+// delete the stored secret and must surface the error.
+func TestExecUserSecretDDLDropOtherErrorsDoNotTouchStore(t *testing.T) {
+	for _, execErr := range []error{
+		errors.New("rpc error: code = Unavailable desc = connection reset"),
+		errors.New("Invalid Input Error: Ambiguity found for secret name 'dup', secret occurs in multiple storages"),
+		errors.New("current transaction is aborted"),
+	} {
+		mgr := &fakeUserSecretMgr{delExist: true}
+		exec := &lifecycleExecutor{execErr: execErr}
+		c, cleanup := newUserSecretTestConn(t, mgr, exec)
+		handled, _, secErr := c.execUserSecretDDL("DROP PERSISTENT SECRET my_s3")
+		if !handled || secErr == nil {
+			t.Errorf("%v: handled=%v secErr=%v, want the error surfaced", execErr, handled, secErr)
+		}
+		if len(mgr.delCalls) != 0 {
+			t.Errorf("%v: store delete was attempted on a non-not-found exec error", execErr)
+		}
+		cleanup()
+	}
+}
+
+// IF NOT EXISTS must flow through to the store so an already-stored secret is
+// not silently replaced while DuckDB no-ops the live session.
+func TestExecUserSecretDDLIfNotExistsFlag(t *testing.T) {
+	mgr := &fakeUserSecretMgr{}
+	exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	if handled, _, secErr := c.execUserSecretDDL("CREATE PERSISTENT SECRET IF NOT EXISTS foo (TYPE s3)"); !handled || secErr != nil {
+		t.Fatalf("handled=%v secErr=%v", handled, secErr)
+	}
+	if handled, _, secErr := c.execUserSecretDDL("CREATE PERSISTENT SECRET bar (TYPE s3)"); !handled || secErr != nil {
+		t.Fatalf("handled=%v secErr=%v", handled, secErr)
+	}
+	want := []bool{true, false}
+	if len(mgr.putIfNotExists) != 2 || mgr.putIfNotExists[0] != want[0] || mgr.putIfNotExists[1] != want[1] {
+		t.Errorf("putIfNotExists = %v, want %v", mgr.putIfNotExists, want)
 	}
 }

--- a/server/conn_user_secrets_test.go
+++ b/server/conn_user_secrets_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeUserSecretMgr records PutSecret/DeleteSecret calls.
+type fakeUserSecretMgr struct {
+	readyErr error
+	putErr   error
+	delErr   error
+	delExist bool
+	putCalls []string // "org/user/name"
+	putStmts []string
+	delCalls []string
+}
+
+func (m *fakeUserSecretMgr) Ready() error { return m.readyErr }
+func (m *fakeUserSecretMgr) PutSecret(_ context.Context, orgID, username, name, stmt string) error {
+	m.putCalls = append(m.putCalls, orgID+"/"+username+"/"+name)
+	m.putStmts = append(m.putStmts, stmt)
+	return m.putErr
+}
+func (m *fakeUserSecretMgr) DeleteSecret(_ context.Context, orgID, username, name string) (bool, error) {
+	m.delCalls = append(m.delCalls, orgID+"/"+username+"/"+name)
+	return m.delExist, m.delErr
+}
+
+func newUserSecretTestConn(t *testing.T, mgr UserSecretManager, exec *lifecycleExecutor) (*clientConn, func()) {
+	t.Helper()
+	c, cleanup := newLifecycleClientConn(t)
+	c.server.cfg.UserSecrets = mgr
+	c.orgID = "org1"
+	c.username = "alice"
+	c.executor = exec
+	return c, cleanup
+}
+
+func TestExecUserSecretDDLCreatePersists(t *testing.T) {
+	mgr := &fakeUserSecretMgr{}
+	exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	stmt := "CREATE PERSISTENT SECRET my_s3 (TYPE s3, KEY_ID 'k', SECRET 's')"
+	handled, tag, secErr := c.execUserSecretDDL(stmt)
+	if !handled || secErr != nil {
+		t.Fatalf("handled=%v secErr=%v, want handled with no error", handled, secErr)
+	}
+	if tag != "CREATE" {
+		t.Errorf("tag = %q, want CREATE", tag)
+	}
+	if exec.execCalls.Load() != 1 {
+		t.Errorf("executor calls = %d, want 1 (DuckDB must validate before persisting)", exec.execCalls.Load())
+	}
+	if len(mgr.putCalls) != 1 || mgr.putCalls[0] != "org1/alice/my_s3" {
+		t.Errorf("putCalls = %v, want [org1/alice/my_s3]", mgr.putCalls)
+	}
+	if mgr.putStmts[0] != stmt {
+		t.Errorf("stored statement = %q, want original text", mgr.putStmts[0])
+	}
+}
+
+func TestExecUserSecretDDLNotHandledCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		mgr   UserSecretManager
+		query string
+	}{
+		{"nil manager", nil, "CREATE PERSISTENT SECRET s (TYPE s3)"},
+		{"temporary create", &fakeUserSecretMgr{}, "CREATE TEMPORARY SECRET s (TYPE s3)"},
+		{"plain create stays session-scoped", &fakeUserSecretMgr{}, "CREATE SECRET s (TYPE s3)"},
+		{"drop temporary", &fakeUserSecretMgr{}, "DROP TEMPORARY SECRET s"},
+		{"non-secret statement", &fakeUserSecretMgr{}, "SELECT 1"},
+		{"unnamed drop", &fakeUserSecretMgr{}, "DROP SECRET"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+			c, cleanup := newUserSecretTestConn(t, tt.mgr, exec)
+			defer cleanup()
+			handled, _, _ := c.execUserSecretDDL(tt.query)
+			if handled {
+				t.Errorf("execUserSecretDDL(%q) handled=true, want passthrough", tt.query)
+			}
+			if exec.execCalls.Load() != 0 {
+				t.Errorf("executor was called for a passthrough statement")
+			}
+		})
+	}
+}
+
+func TestExecUserSecretDDLRejections(t *testing.T) {
+	tests := []struct {
+		name     string
+		mgr      *fakeUserSecretMgr
+		query    string
+		wantCode string
+	}{
+		{"not enabled", &fakeUserSecretMgr{readyErr: errors.New("no key")}, "CREATE PERSISTENT SECRET s (TYPE s3)", "0A000"},
+		{"unnamed persistent", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET (TYPE s3)", "0A000"},
+		{"reserved name", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET ducklake_s3 (TYPE s3)", "42939"},
+		{"oversized statement", &fakeUserSecretMgr{}, "CREATE PERSISTENT SECRET big (TYPE s3, SECRET '" + strings.Repeat("x", maxUserSecretStatementLen) + "')", "54000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+			c, cleanup := newUserSecretTestConn(t, tt.mgr, exec)
+			defer cleanup()
+			handled, _, secErr := c.execUserSecretDDL(tt.query)
+			if !handled || secErr == nil {
+				t.Fatalf("handled=%v secErr=%v, want handled error", handled, secErr)
+			}
+			if secErr.code != tt.wantCode {
+				t.Errorf("code = %q, want %q (msg: %s)", secErr.code, tt.wantCode, secErr.msg)
+			}
+			if exec.execCalls.Load() != 0 {
+				t.Errorf("rejected statement must not reach the executor")
+			}
+			if len(tt.mgr.putCalls) != 0 {
+				t.Errorf("rejected statement must not be persisted")
+			}
+		})
+	}
+}
+
+func TestExecUserSecretDDLExecErrorNotPersisted(t *testing.T) {
+	mgr := &fakeUserSecretMgr{}
+	exec := &lifecycleExecutor{execErr: errors.New("Invalid Input Error: bad type")}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	handled, _, secErr := c.execUserSecretDDL("CREATE PERSISTENT SECRET s (TYPE wat)")
+	if !handled || secErr == nil {
+		t.Fatalf("want handled error, got handled=%v secErr=%v", handled, secErr)
+	}
+	if len(mgr.putCalls) != 0 {
+		t.Errorf("statement that failed on DuckDB must not be persisted")
+	}
+}
+
+func TestExecUserSecretDDLPutFailureSurfaces(t *testing.T) {
+	mgr := &fakeUserSecretMgr{putErr: errors.New("config store down")}
+	exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	handled, _, secErr := c.execUserSecretDDL("CREATE PERSISTENT SECRET s (TYPE s3)")
+	if !handled || secErr == nil {
+		t.Fatalf("want handled error when persistence fails, got handled=%v secErr=%v", handled, secErr)
+	}
+	if secErr.code != "58000" {
+		t.Errorf("code = %q, want 58000", secErr.code)
+	}
+	if !strings.Contains(secErr.msg, "NOT survive") {
+		t.Errorf("message %q must warn the secret did not persist", secErr.msg)
+	}
+}
+
+func TestExecUserSecretDDLDropDeletesFromStore(t *testing.T) {
+	mgr := &fakeUserSecretMgr{delExist: true}
+	exec := &lifecycleExecutor{execResult: emptyExecResult{}}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	for _, q := range []string{"DROP PERSISTENT SECRET my_s3", "DROP SECRET IF EXISTS my_s3"} {
+		mgr.delCalls = nil
+		handled, tag, secErr := c.execUserSecretDDL(q)
+		if !handled || secErr != nil {
+			t.Fatalf("%q: handled=%v secErr=%v", q, handled, secErr)
+		}
+		if tag != "DROP" {
+			t.Errorf("%q: tag = %q, want DROP", q, tag)
+		}
+		if len(mgr.delCalls) != 1 || mgr.delCalls[0] != "org1/alice/my_s3" {
+			t.Errorf("%q: delCalls = %v, want [org1/alice/my_s3]", q, mgr.delCalls)
+		}
+	}
+}
+
+// A stored secret whose replay failed doesn't exist on the session; DROP must
+// still be able to remove it from the store.
+func TestExecUserSecretDDLDropFallsBackToStore(t *testing.T) {
+	mgr := &fakeUserSecretMgr{delExist: true}
+	exec := &lifecycleExecutor{execErr: errors.New("Invalid Input Error: secret not found")}
+	c, cleanup := newUserSecretTestConn(t, mgr, exec)
+	defer cleanup()
+
+	handled, tag, secErr := c.execUserSecretDDL("DROP PERSISTENT SECRET broken_one")
+	if !handled || secErr != nil {
+		t.Fatalf("handled=%v secErr=%v, want store-backed success", handled, secErr)
+	}
+	if tag != "DROP" {
+		t.Errorf("tag = %q, want DROP", tag)
+	}
+
+	// But when the store has nothing either, the DuckDB error wins.
+	mgr2 := &fakeUserSecretMgr{delExist: false}
+	c2, cleanup2 := newUserSecretTestConn(t, mgr2, exec)
+	defer cleanup2()
+	handled, _, secErr = c2.execUserSecretDDL("DROP PERSISTENT SECRET nope")
+	if !handled || secErr == nil {
+		t.Fatalf("handled=%v secErr=%v, want the DuckDB error surfaced", handled, secErr)
+	}
+}

--- a/server/exports.go
+++ b/server/exports.go
@@ -171,6 +171,13 @@ func SetQueryLogger(s *Server, ql *QueryLogger) {
 	s.queryLogger = ql
 }
 
+// SetUserSecretManager installs the per-user persistent secret manager on a
+// Server. Used by the multitenant control plane after the config store is up.
+// Must be called before the server starts accepting connections.
+func SetUserSecretManager(s *Server, mgr UserSecretManager) {
+	s.cfg.UserSecrets = mgr
+}
+
 // QueryLogger returns the server's query logger (may be nil).
 func (s *Server) QueryLogger() *QueryLogger {
 	return s.queryLogger

--- a/server/exports.go
+++ b/server/exports.go
@@ -178,6 +178,12 @@ func SetUserSecretManager(s *Server, mgr UserSecretManager) {
 	s.cfg.UserSecrets = mgr
 }
 
+// UserSecretManager returns the installed per-user persistent secret manager
+// (nil when the feature is not configured).
+func (s *Server) UserSecretManager() UserSecretManager {
+	return s.cfg.UserSecrets
+}
+
 // QueryLogger returns the server's query logger (may be nil).
 func (s *Server) QueryLogger() *QueryLogger {
 	return s.queryLogger

--- a/server/flightsqlingress/ingress.go
+++ b/server/flightsqlingress/ingress.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/usersecrets"
 	"github.com/posthog/duckgres/server/flightclient"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -62,6 +63,15 @@ type Config struct {
 	HandleIdleTTL      time.Duration
 	SessionTokenTTL    time.Duration
 	WorkerQueueTimeout time.Duration // applied to CreateSession calls; 0 = use request context as-is
+
+	// RejectPersistentSecretDDL rejects CREATE/DROP PERSISTENT SECRET with a
+	// clear error. Set when the deployment runs the user persistent secret
+	// manager: that manager intercepts secret DDL on the PG wire protocol
+	// only, so a persistent secret created via Flight would execute, never be
+	// stored, and then be silently deleted by the next session's hygiene wipe
+	// — rejecting up front is the honest behavior until Flight gets its own
+	// interception.
+	RejectPersistentSecretDDL bool
 }
 
 type SessionProvider interface {
@@ -224,6 +234,7 @@ func NewFlightIngressFromListener(baseListener net.Listener, tlsConfig *tls.Conf
 		return nil, err
 	}
 	handler.rateLimiter = opts.RateLimiter
+	handler.rejectPersistentSecretDDL = cfg.RejectPersistentSecretDDL
 
 	grpcOpts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(flightclient.MaxGRPCMessageSize),
@@ -305,10 +316,27 @@ func (fi *FlightIngress) Shutdown() {
 // ControlPlaneFlightSQLHandler implements Flight SQL over control-plane sessions.
 type ControlPlaneFlightSQLHandler struct {
 	flightsql.BaseServer
-	validator   CredentialValidator
-	sessions    *flightAuthSessionStore
-	rateLimiter *server.RateLimiter
-	alloc       memory.Allocator
+	validator                 CredentialValidator
+	sessions                  *flightAuthSessionStore
+	rateLimiter               *server.RateLimiter
+	alloc                     memory.Allocator
+	rejectPersistentSecretDDL bool
+}
+
+// checkUserSecretDDL rejects persistent-secret DDL when the deployment
+// manages user secrets via the PG protocol (see Config.
+// RejectPersistentSecretDDL). Plain/TEMPORARY secret DDL passes through —
+// it is genuinely session-scoped on every path.
+func (h *ControlPlaneFlightSQLHandler) checkUserSecretDDL(query string) error {
+	if !h.rejectPersistentSecretDDL {
+		return nil
+	}
+	st := usersecrets.Classify(query)
+	if st.Kind != usersecrets.KindNone && st.Persistent {
+		return status.Error(codes.InvalidArgument,
+			"persistent secrets are managed via the PostgreSQL protocol on this deployment; CREATE/DROP PERSISTENT SECRET is not supported over Flight SQL (a secret created here would not survive the session)")
+	}
+	return nil
 }
 
 func NewControlPlaneFlightSQLHandler(sessions *flightAuthSessionStore, validator CredentialValidator) (*ControlPlaneFlightSQLHandler, error) {
@@ -521,6 +549,10 @@ func (h *ControlPlaneFlightSQLHandler) GetFlightInfoStatement(ctx context.Contex
 		}, nil
 	}
 
+	if err := h.checkUserSecretDDL(query); err != nil {
+		return nil, err
+	}
+
 	schema, err := getQuerySchema(ctx, s, query)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare query: %v", err)
@@ -616,6 +648,10 @@ func (h *ControlPlaneFlightSQLHandler) DoPutCommandStatementUpdate(ctx context.C
 	query := cmd.GetQuery()
 	if server.IsEmptyQuery(query) {
 		return 0, nil
+	}
+
+	if err := h.checkUserSecretDDL(query); err != nil {
+		return 0, err
 	}
 
 	res, err := s.exec(ctx, query)
@@ -719,6 +755,10 @@ func (h *ControlPlaneFlightSQLHandler) CreatePreparedStatement(ctx context.Conte
 			Handle:        []byte(handleID),
 			DatasetSchema: emptySchema,
 		}, nil
+	}
+
+	if err := h.checkUserSecretDDL(query); err != nil {
+		return flightsql.ActionCreatePreparedStatementResult{}, err
 	}
 
 	schema, err := getQuerySchema(ctx, s, query)

--- a/server/flightsqlingress/user_secrets_test.go
+++ b/server/flightsqlingress/user_secrets_test.go
@@ -1,0 +1,42 @@
+package flightsqlingress
+
+import "testing"
+
+// Persistent-secret DDL must be rejected on the Flight ingress when the
+// deployment manages user secrets via the PG protocol: over Flight the
+// statement would execute, never persist, and be wiped at the next session.
+func TestCheckUserSecretDDL(t *testing.T) {
+	h := &ControlPlaneFlightSQLHandler{rejectPersistentSecretDDL: true}
+
+	rejected := []string{
+		"CREATE PERSISTENT SECRET s (TYPE s3, KEY_ID 'k', SECRET 'v')",
+		"CREATE OR REPLACE PERSISTENT SECRET s (TYPE s3)",
+		"DROP PERSISTENT SECRET s",
+		"CREATE PERSISTENT SECRET s (TYPE s3); SELECT 1",
+	}
+	for _, q := range rejected {
+		if err := h.checkUserSecretDDL(q); err == nil {
+			t.Errorf("checkUserSecretDDL(%q) = nil, want rejection", q)
+		}
+	}
+
+	allowed := []string{
+		"CREATE SECRET s (TYPE s3, KEY_ID 'k', SECRET 'v')", // session-scoped, fine
+		"CREATE TEMPORARY SECRET s (TYPE s3)",
+		"DROP SECRET s",
+		"SELECT 1",
+	}
+	for _, q := range allowed {
+		if err := h.checkUserSecretDDL(q); err != nil {
+			t.Errorf("checkUserSecretDDL(%q) = %v, want nil", q, err)
+		}
+	}
+
+	// Flag off (no user-secret manager on the deployment): everything passes.
+	off := &ControlPlaneFlightSQLHandler{}
+	for _, q := range rejected {
+		if err := off.checkUserSecretDDL(q); err != nil {
+			t.Errorf("flag off: checkUserSecretDDL(%q) = %v, want nil", q, err)
+		}
+	}
+}

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/observe"
+	"github.com/posthog/duckgres/server/usersecrets"
 )
 
 // QueryLogEntry represents a single entry in the query log.
@@ -493,6 +494,11 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	if isQueryLogSelfReferential(query) {
 		return
 	}
+
+	// CREATE SECRET option lists carry credential material; never persist
+	// them to the query log.
+	query = usersecrets.RedactForLog(query)
+	transpiledQuery = usersecrets.RedactForLog(transpiledQuery)
 
 	entryType := "QueryFinish"
 	if errCode != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -282,6 +282,12 @@ type Config struct {
 	// recycle wipe is how workers stay clean.
 	PinSecretDirectory bool
 
+	// UserSecrets persists per-user CREATE PERSISTENT SECRET statements
+	// across sessions and worker pods. Set by the multitenant control plane
+	// (remote backend, config-store-backed); nil everywhere else, in which
+	// case secret DDL passes through to DuckDB untouched.
+	UserSecrets UserSecretManager
+
 	// MemoryLimit is the DuckDB memory_limit per session (e.g., "4GB").
 	// If empty, auto-detected from system memory.
 	MemoryLimit string

--- a/server/usersecrets/classify.go
+++ b/server/usersecrets/classify.go
@@ -240,15 +240,12 @@ type tokenizer struct {
 func newTokenizer(s string) *tokenizer { return &tokenizer{s: s} }
 
 func (t *tokenizer) skipSpace() {
-	for {
-		rest, ok := skipCommentsAndSpace(t.s[t.i:])
-		if !ok {
-			t.i = len(t.s)
-			return
-		}
-		t.i = len(t.s) - len(rest)
+	rest, ok := skipCommentsAndSpace(t.s[t.i:])
+	if !ok {
+		t.i = len(t.s)
 		return
 	}
+	t.i = len(t.s) - len(rest)
 }
 
 // eatKeyword consumes the given keyword (case-insensitive, word-bounded).

--- a/server/usersecrets/classify.go
+++ b/server/usersecrets/classify.go
@@ -35,7 +35,18 @@ type Statement struct {
 	Persistent bool
 	// Temporary is true when the TEMPORARY keyword is present.
 	Temporary bool
-	OrReplace bool
+	// IfNotExists is true for CREATE ... IF NOT EXISTS. The persistence layer
+	// must honor it: when the secret is already stored, DuckDB no-ops on the
+	// live session, so overwriting the stored statement would silently
+	// diverge the two.
+	IfNotExists bool
+	// MultiStatement is true when the secret DDL is followed by further
+	// statements ("CREATE PERSISTENT SECRET ...; SELECT 1"). Persistence side
+	// effects must map 1:1 to a statement, so callers must not persist these —
+	// and must not let persistent variants silently fall through either,
+	// because the statement would execute, never persist, and then be wiped
+	// at the next session.
+	MultiStatement bool
 }
 
 // Reserved secret names/prefixes. These belong to duckgres itself: the
@@ -63,18 +74,32 @@ func IsReservedName(name string) bool {
 	return false
 }
 
-// Classify inspects a single SQL statement and reports whether it is DuckDB
-// secret DDL. It is deliberately conservative: anything it cannot confidently
-// parse as a single secret DDL statement classifies as KindNone, which makes
-// the caller fall back to today's plain passthrough behavior (the statement
-// still executes, it just doesn't persist). A multi-statement string is never
-// classified, since the persistence side effect must map 1:1 to a statement.
+// Classify inspects a SQL statement and reports whether it is DuckDB secret
+// DDL. It is deliberately conservative: anything it cannot confidently parse
+// as secret DDL classifies as KindNone, which makes the caller fall back to
+// today's plain passthrough behavior. Multi-statement strings classify with
+// MultiStatement set so callers can reject (not silently drop) persistent
+// variants.
 func Classify(query string) Statement {
-	rest, ok := skipCommentsAndSpace(query)
+	st, _, ok := parseSecretDDLHead(query)
 	if !ok {
 		return Statement{}
 	}
+	st.MultiStatement = hasTrailingStatement(query)
+	return st
+}
+
+// parseSecretDDLHead parses the statement head (through the optional secret
+// name) and returns the classification plus the byte offset just past the
+// head. The fast path for non-secret statements is two short case-folded
+// keyword comparisons — no allocation — so this is safe on hot paths.
+func parseSecretDDLHead(query string) (Statement, int, bool) {
+	rest, ok := skipCommentsAndSpace(query)
+	if !ok {
+		return Statement{}, 0, false
+	}
 	toks := newTokenizer(rest)
+	headStart := len(query) - len(rest)
 
 	var st Statement
 	switch {
@@ -82,14 +107,13 @@ func Classify(query string) Statement {
 		st.Kind = KindCreate
 		if toks.eatKeyword("OR") {
 			if !toks.eatKeyword("REPLACE") {
-				return Statement{}
+				return Statement{}, 0, false
 			}
-			st.OrReplace = true
 		}
 	case toks.eatKeyword("DROP"):
 		st.Kind = KindDrop
 	default:
-		return Statement{}
+		return Statement{}, 0, false
 	}
 
 	if toks.eatKeyword("PERSISTENT") {
@@ -99,19 +123,20 @@ func Classify(query string) Statement {
 	}
 
 	if !toks.eatKeyword("SECRET") {
-		return Statement{}
+		return Statement{}, 0, false
 	}
 
 	if st.Kind == KindCreate {
 		if toks.eatKeyword("IF") {
 			if !toks.eatKeyword("NOT") || !toks.eatKeyword("EXISTS") {
-				return Statement{}
+				return Statement{}, 0, false
 			}
+			st.IfNotExists = true
 		}
 	} else {
 		if toks.eatKeyword("IF") {
 			if !toks.eatKeyword("EXISTS") {
-				return Statement{}
+				return Statement{}, 0, false
 			}
 		}
 	}
@@ -122,13 +147,7 @@ func Classify(query string) Statement {
 		st.Name = strings.ToLower(name)
 	}
 
-	// A persistence side effect must correspond to exactly one statement.
-	// If anything follows a top-level semicolon, refuse to classify.
-	if hasTrailingStatement(query) {
-		return Statement{}
-	}
-
-	return st
+	return st, headStart + toks.i, true
 }
 
 // skipCommentsAndSpace removes leading whitespace, line comments (--) and

--- a/server/usersecrets/classify.go
+++ b/server/usersecrets/classify.go
@@ -1,0 +1,305 @@
+// Package usersecrets implements the building blocks of the per-user
+// persistent secret manager: classification of DuckDB secret DDL statements
+// and authenticated encryption for storing them in the config store.
+//
+// In the multi-tenant control plane, a worker pod's DuckDB secrets die with
+// the pod, so "CREATE PERSISTENT SECRET" is intercepted at the control plane,
+// stored encrypted in the Postgres config store keyed by (org, user, name),
+// and replayed onto the worker at session creation.
+package usersecrets
+
+import (
+	"strings"
+)
+
+// Kind classifies a SQL statement with respect to secret DDL.
+type Kind int
+
+const (
+	// KindNone means the statement is not secret DDL (or is one this package
+	// declines to handle, e.g. part of a multi-statement string).
+	KindNone Kind = iota
+	// KindCreate is CREATE [OR REPLACE] [PERSISTENT|TEMPORARY] SECRET.
+	KindCreate
+	// KindDrop is DROP [PERSISTENT|TEMPORARY] SECRET.
+	KindDrop
+)
+
+// Statement is the classification result for a secret DDL statement.
+type Statement struct {
+	Kind Kind
+	// Name is the secret name, lowercased (DuckDB stores secret names
+	// case-insensitively). Empty for an unnamed CREATE SECRET.
+	Name string
+	// Persistent is true when the PERSISTENT keyword is present.
+	Persistent bool
+	// Temporary is true when the TEMPORARY keyword is present.
+	Temporary bool
+	OrReplace bool
+}
+
+// Reserved secret names/prefixes. These belong to duckgres itself: the
+// system-issued catalog secrets, DuckDB's default names for unnamed secrets,
+// and a duckgres_ prefix reserved for future system use.
+var reservedNames = map[string]struct{}{
+	"ducklake_s3":   {},
+	"iceberg_sigv4": {},
+	"iceberg_oauth": {},
+}
+
+var reservedPrefixes = []string{"__default_", "duckgres_"}
+
+// IsReservedName reports whether a secret name is reserved for system use.
+func IsReservedName(name string) bool {
+	name = strings.ToLower(name)
+	if _, ok := reservedNames[name]; ok {
+		return true
+	}
+	for _, p := range reservedPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// Classify inspects a single SQL statement and reports whether it is DuckDB
+// secret DDL. It is deliberately conservative: anything it cannot confidently
+// parse as a single secret DDL statement classifies as KindNone, which makes
+// the caller fall back to today's plain passthrough behavior (the statement
+// still executes, it just doesn't persist). A multi-statement string is never
+// classified, since the persistence side effect must map 1:1 to a statement.
+func Classify(query string) Statement {
+	rest, ok := skipCommentsAndSpace(query)
+	if !ok {
+		return Statement{}
+	}
+	toks := newTokenizer(rest)
+
+	var st Statement
+	switch {
+	case toks.eatKeyword("CREATE"):
+		st.Kind = KindCreate
+		if toks.eatKeyword("OR") {
+			if !toks.eatKeyword("REPLACE") {
+				return Statement{}
+			}
+			st.OrReplace = true
+		}
+	case toks.eatKeyword("DROP"):
+		st.Kind = KindDrop
+	default:
+		return Statement{}
+	}
+
+	if toks.eatKeyword("PERSISTENT") {
+		st.Persistent = true
+	} else if toks.eatKeyword("TEMPORARY") || toks.eatKeyword("TEMP") {
+		st.Temporary = true
+	}
+
+	if !toks.eatKeyword("SECRET") {
+		return Statement{}
+	}
+
+	if st.Kind == KindCreate {
+		if toks.eatKeyword("IF") {
+			if !toks.eatKeyword("NOT") || !toks.eatKeyword("EXISTS") {
+				return Statement{}
+			}
+		}
+	} else {
+		if toks.eatKeyword("IF") {
+			if !toks.eatKeyword("EXISTS") {
+				return Statement{}
+			}
+		}
+	}
+
+	// Optional secret name. For CREATE the next token may instead be the
+	// opening paren of the option list (unnamed secret).
+	if name, ok := toks.eatIdentifier(); ok {
+		st.Name = strings.ToLower(name)
+	}
+
+	// A persistence side effect must correspond to exactly one statement.
+	// If anything follows a top-level semicolon, refuse to classify.
+	if hasTrailingStatement(query) {
+		return Statement{}
+	}
+
+	return st
+}
+
+// skipCommentsAndSpace removes leading whitespace, line comments (--) and
+// block comments (/* */, nested) from s. Returns ok=false on an unterminated
+// block comment.
+func skipCommentsAndSpace(s string) (string, bool) {
+	for {
+		s = strings.TrimLeft(s, " \t\r\n")
+		switch {
+		case strings.HasPrefix(s, "--"):
+			idx := strings.IndexByte(s, '\n')
+			if idx < 0 {
+				return "", true
+			}
+			s = s[idx+1:]
+		case strings.HasPrefix(s, "/*"):
+			depth := 1
+			i := 2
+			for i < len(s) && depth > 0 {
+				switch {
+				case strings.HasPrefix(s[i:], "/*"):
+					depth++
+					i += 2
+				case strings.HasPrefix(s[i:], "*/"):
+					depth--
+					i += 2
+				default:
+					i++
+				}
+			}
+			if depth > 0 {
+				return "", false
+			}
+			s = s[i:]
+		default:
+			return s, true
+		}
+	}
+}
+
+// hasTrailingStatement reports whether query contains a top-level semicolon
+// (outside string literals, quoted identifiers, and comments) followed by
+// anything other than whitespace/comments.
+func hasTrailingStatement(query string) bool {
+	i := 0
+	for i < len(query) {
+		c := query[i]
+		switch {
+		case c == '\'':
+			i = skipQuoted(query, i, '\'')
+		case c == '"':
+			i = skipQuoted(query, i, '"')
+		case c == '-' && strings.HasPrefix(query[i:], "--"):
+			idx := strings.IndexByte(query[i:], '\n')
+			if idx < 0 {
+				return false
+			}
+			i += idx + 1
+		case c == '/' && strings.HasPrefix(query[i:], "/*"):
+			depth := 1
+			i += 2
+			for i < len(query) && depth > 0 {
+				switch {
+				case strings.HasPrefix(query[i:], "/*"):
+					depth++
+					i += 2
+				case strings.HasPrefix(query[i:], "*/"):
+					depth--
+					i += 2
+				default:
+					i++
+				}
+			}
+		case c == ';':
+			rest, ok := skipCommentsAndSpace(query[i+1:])
+			if !ok {
+				return true
+			}
+			return strings.TrimSpace(rest) != ""
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+// skipQuoted returns the index just past a quoted region starting at start
+// (where query[start] == quote). Doubled quotes are escapes.
+func skipQuoted(query string, start int, quote byte) int {
+	i := start + 1
+	for i < len(query) {
+		if query[i] == quote {
+			if i+1 < len(query) && query[i+1] == quote {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+type tokenizer struct {
+	s string
+	i int
+}
+
+func newTokenizer(s string) *tokenizer { return &tokenizer{s: s} }
+
+func (t *tokenizer) skipSpace() {
+	for {
+		rest, ok := skipCommentsAndSpace(t.s[t.i:])
+		if !ok {
+			t.i = len(t.s)
+			return
+		}
+		t.i = len(t.s) - len(rest)
+		return
+	}
+}
+
+// eatKeyword consumes the given keyword (case-insensitive, word-bounded).
+func (t *tokenizer) eatKeyword(kw string) bool {
+	t.skipSpace()
+	if len(t.s)-t.i < len(kw) {
+		return false
+	}
+	if !strings.EqualFold(t.s[t.i:t.i+len(kw)], kw) {
+		return false
+	}
+	end := t.i + len(kw)
+	if end < len(t.s) && isIdentChar(t.s[end]) {
+		return false
+	}
+	t.i = end
+	return true
+}
+
+// eatIdentifier consumes a bare or double-quoted identifier.
+func (t *tokenizer) eatIdentifier() (string, bool) {
+	t.skipSpace()
+	if t.i >= len(t.s) {
+		return "", false
+	}
+	if t.s[t.i] == '"' {
+		end := skipQuoted(t.s, t.i, '"')
+		if end <= t.i+1 || t.s[end-1] != '"' {
+			return "", false
+		}
+		name := strings.ReplaceAll(t.s[t.i+1:end-1], `""`, `"`)
+		if name == "" {
+			return "", false
+		}
+		t.i = end
+		return name, true
+	}
+	if !isIdentStart(t.s[t.i]) {
+		return "", false
+	}
+	start := t.i
+	for t.i < len(t.s) && isIdentChar(t.s[t.i]) {
+		t.i++
+	}
+	return t.s[start:t.i], true
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentChar(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '$'
+}

--- a/server/usersecrets/classify_test.go
+++ b/server/usersecrets/classify_test.go
@@ -16,12 +16,12 @@ func TestClassify(t *testing.T) {
 		{
 			name:  "create or replace persistent",
 			query: "create or replace persistent secret My_S3 (TYPE s3)",
-			want:  Statement{Kind: KindCreate, Name: "my_s3", Persistent: true, OrReplace: true},
+			want:  Statement{Kind: KindCreate, Name: "my_s3", Persistent: true},
 		},
 		{
 			name:  "create persistent if not exists",
 			query: "CREATE PERSISTENT SECRET IF NOT EXISTS foo (TYPE s3)",
-			want:  Statement{Kind: KindCreate, Name: "foo", Persistent: true},
+			want:  Statement{Kind: KindCreate, Name: "foo", Persistent: true, IfNotExists: true},
 		},
 		{
 			name:  "create temporary",
@@ -79,9 +79,14 @@ func TestClassify(t *testing.T) {
 			want:  Statement{Kind: KindCreate, Name: "s", Persistent: true},
 		},
 		{
-			name:  "multi-statement refused",
+			name:  "multi-statement flagged",
 			query: "CREATE PERSISTENT SECRET s (TYPE s3); SELECT 1",
-			want:  Statement{},
+			want:  Statement{Kind: KindCreate, Name: "s", Persistent: true, MultiStatement: true},
+		},
+		{
+			name:  "multi-statement drop flagged",
+			query: "DROP PERSISTENT SECRET s; SELECT 1",
+			want:  Statement{Kind: KindDrop, Name: "s", Persistent: true, MultiStatement: true},
 		},
 		{
 			name:  "semicolon inside string literal ok",
@@ -146,7 +151,28 @@ func TestRedactForLog(t *testing.T) {
 		},
 		{
 			query: "-- note\nCREATE SECRET (TYPE s3, SECRET 'x')",
-			want:  "CREATE SECRET (…redacted)",
+			want:  "-- note\nCREATE SECRET (…redacted)",
+		},
+		{
+			// Redaction must track the tokenizer, not a flat prefix list:
+			// extra whitespace between keywords must still redact.
+			query: "CREATE  PERSISTENT\nSECRET s (TYPE s3, SECRET 'hunter2')",
+			want:  "CREATE  PERSISTENT\nSECRET s (…redacted)",
+		},
+		{
+			// ... and comments between keywords.
+			query: "CREATE /*c*/ PERSISTENT SECRET s (TYPE s3, SECRET 'hunter2')",
+			want:  "CREATE /*c*/ PERSISTENT SECRET s (…redacted)",
+		},
+		{
+			// Multi-statement strings with a secret-DDL head drop everything
+			// after the head (the trailing statements go with the options).
+			query: "CREATE PERSISTENT SECRET s (TYPE s3, SECRET 'x'); SELECT 1",
+			want:  "CREATE PERSISTENT SECRET s (…redacted)",
+		},
+		{
+			query: "CREATE SECRET IF NOT EXISTS foo (TYPE s3, SECRET 'x')",
+			want:  "CREATE SECRET IF NOT EXISTS foo (…redacted)",
 		},
 		{
 			query: "DROP PERSISTENT SECRET my_s3",

--- a/server/usersecrets/classify_test.go
+++ b/server/usersecrets/classify_test.go
@@ -1,0 +1,217 @@
+package usersecrets
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  Statement
+	}{
+		{
+			name:  "create persistent named",
+			query: "CREATE PERSISTENT SECRET my_s3 (TYPE s3, KEY_ID 'k', SECRET 's')",
+			want:  Statement{Kind: KindCreate, Name: "my_s3", Persistent: true},
+		},
+		{
+			name:  "create or replace persistent",
+			query: "create or replace persistent secret My_S3 (TYPE s3)",
+			want:  Statement{Kind: KindCreate, Name: "my_s3", Persistent: true, OrReplace: true},
+		},
+		{
+			name:  "create persistent if not exists",
+			query: "CREATE PERSISTENT SECRET IF NOT EXISTS foo (TYPE s3)",
+			want:  Statement{Kind: KindCreate, Name: "foo", Persistent: true},
+		},
+		{
+			name:  "create temporary",
+			query: "CREATE TEMPORARY SECRET t1 (TYPE s3)",
+			want:  Statement{Kind: KindCreate, Name: "t1", Temporary: true},
+		},
+		{
+			name:  "create plain (temp by default)",
+			query: "CREATE SECRET plain1 (TYPE s3)",
+			want:  Statement{Kind: KindCreate, Name: "plain1"},
+		},
+		{
+			name:  "create unnamed persistent",
+			query: "CREATE PERSISTENT SECRET (TYPE s3, KEY_ID 'k')",
+			want:  Statement{Kind: KindCreate, Persistent: true},
+		},
+		{
+			name:  "leading comments and whitespace",
+			query: "  -- set up creds\n/* block */ CREATE PERSISTENT SECRET c1 (TYPE gcs)",
+			want:  Statement{Kind: KindCreate, Name: "c1", Persistent: true},
+		},
+		{
+			name:  "quoted identifier",
+			query: `CREATE PERSISTENT SECRET "My""Quoted" (TYPE s3)`,
+			want:  Statement{Kind: KindCreate, Name: `my"quoted`, Persistent: true},
+		},
+		{
+			name:  "drop persistent",
+			query: "DROP PERSISTENT SECRET my_s3",
+			want:  Statement{Kind: KindDrop, Name: "my_s3", Persistent: true},
+		},
+		{
+			name:  "drop persistent if exists",
+			query: "DROP PERSISTENT SECRET IF EXISTS my_s3;",
+			want:  Statement{Kind: KindDrop, Name: "my_s3", Persistent: true},
+		},
+		{
+			name:  "drop plain",
+			query: "DROP SECRET my_s3",
+			want:  Statement{Kind: KindDrop, Name: "my_s3"},
+		},
+		{
+			name:  "drop temporary",
+			query: "DROP TEMPORARY SECRET my_s3",
+			want:  Statement{Kind: KindDrop, Name: "my_s3", Temporary: true},
+		},
+		{
+			name:  "trailing semicolon ok",
+			query: "CREATE PERSISTENT SECRET s (TYPE s3);",
+			want:  Statement{Kind: KindCreate, Name: "s", Persistent: true},
+		},
+		{
+			name:  "trailing semicolon then comment ok",
+			query: "CREATE PERSISTENT SECRET s (TYPE s3); -- done",
+			want:  Statement{Kind: KindCreate, Name: "s", Persistent: true},
+		},
+		{
+			name:  "multi-statement refused",
+			query: "CREATE PERSISTENT SECRET s (TYPE s3); SELECT 1",
+			want:  Statement{},
+		},
+		{
+			name:  "semicolon inside string literal ok",
+			query: "CREATE PERSISTENT SECRET s (TYPE s3, SECRET 'a;b')",
+			want:  Statement{Kind: KindCreate, Name: "s", Persistent: true},
+		},
+		{
+			name:  "not secret ddl",
+			query: "SELECT * FROM t",
+			want:  Statement{},
+		},
+		{
+			name:  "create table not matched",
+			query: "CREATE TABLE secret (id INT)",
+			want:  Statement{},
+		},
+		{
+			name:  "drop secretive_thing not matched",
+			query: "DROP SECRETIVE_THING x",
+			want:  Statement{},
+		},
+		{
+			name:  "create or without replace refused",
+			query: "CREATE OR SECRET s (TYPE s3)",
+			want:  Statement{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Classify(tt.query); got != tt.want {
+				t.Errorf("Classify(%q) = %+v, want %+v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsReservedName(t *testing.T) {
+	for _, name := range []string{"ducklake_s3", "ICEBERG_SIGV4", "iceberg_oauth", "__default_s3", "duckgres_internal"} {
+		if !IsReservedName(name) {
+			t.Errorf("IsReservedName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"my_s3", "customer_gcs", "ducklake"} {
+		if IsReservedName(name) {
+			t.Errorf("IsReservedName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestRedactForLog(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{
+			query: "CREATE PERSISTENT SECRET my_s3 (TYPE s3, KEY_ID 'AKIA…', SECRET 'hunter2')",
+			want:  "CREATE PERSISTENT SECRET my_s3 (…redacted)",
+		},
+		{
+			query: "create or replace secret s (TYPE s3, SECRET 'x')",
+			want:  "create or replace secret s (…redacted)",
+		},
+		{
+			query: "-- note\nCREATE SECRET (TYPE s3, SECRET 'x')",
+			want:  "CREATE SECRET (…redacted)",
+		},
+		{
+			query: "DROP PERSISTENT SECRET my_s3",
+			want:  "DROP PERSISTENT SECRET my_s3",
+		},
+		{
+			query: "SELECT 'CREATE SECRET' FROM t",
+			want:  "SELECT 'CREATE SECRET' FROM t",
+		},
+		{
+			query: "CREATE SECRETIVE_TABLE (id INT)",
+			want:  "CREATE SECRETIVE_TABLE (id INT)",
+		},
+	}
+	for _, tt := range tests {
+		if got := RedactForLog(tt.query); got != tt.want {
+			t.Errorf("RedactForLog(%q) = %q, want %q", tt.query, got, tt.want)
+		}
+	}
+}
+
+func TestCipherRoundTrip(t *testing.T) {
+	// 32 bytes of 'k', base64-encoded.
+	key := "a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s="
+	c, err := NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+
+	stmt := "CREATE PERSISTENT SECRET my_s3 (TYPE s3, KEY_ID 'k', SECRET 's')"
+	sealed, err := c.Seal("org1", "alice", "my_s3", stmt)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	got, err := c.Open("org1", "alice", "my_s3", sealed)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got != stmt {
+		t.Errorf("round trip = %q, want %q", got, stmt)
+	}
+
+	// Ciphertext is bound to its row: moving it to another row must fail.
+	if _, err := c.Open("org1", "bob", "my_s3", sealed); err == nil {
+		t.Error("Open with different username succeeded, want error")
+	}
+	if _, err := c.Open("org1", "alice", "other", sealed); err == nil {
+		t.Error("Open with different secret name succeeded, want error")
+	}
+
+	// Wrong key must fail.
+	other, err := NewCipher("eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=")
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	if _, err := other.Open("org1", "alice", "my_s3", sealed); err == nil {
+		t.Error("Open with wrong key succeeded, want error")
+	}
+}
+
+func TestNewCipherRejectsBadKeys(t *testing.T) {
+	if _, err := NewCipher("not-base64!!!"); err == nil {
+		t.Error("NewCipher with invalid base64 succeeded, want error")
+	}
+	if _, err := NewCipher("c2hvcnQ="); err == nil { // "short"
+		t.Error("NewCipher with short key succeeded, want error")
+	}
+}

--- a/server/usersecrets/crypto.go
+++ b/server/usersecrets/crypto.go
@@ -1,0 +1,89 @@
+package usersecrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// EnvKeyName is the env-only knob holding the base64-encoded 32-byte AES key
+// used to encrypt user secret statements at rest in the config store. There
+// is deliberately no CLI flag or YAML field: the key should only ever arrive
+// via a mounted K8s Secret.
+const EnvKeyName = "DUCKGRES_USER_SECRET_KEY"
+
+// ciphertextVersion prefixes every sealed payload so the format can evolve
+// (key rotation, algorithm change) without a table migration.
+const ciphertextVersion = byte(1)
+
+// Cipher seals and opens user secret statements with AES-256-GCM. The
+// (org, user, name) row key is bound in as additional authenticated data, so
+// a ciphertext copied onto another row fails to decrypt.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipher builds a Cipher from a base64-encoded (std or url, padded or raw)
+// 32-byte key.
+func NewCipher(encodedKey string) (*Cipher, error) {
+	var key []byte
+	var err error
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		key, err = enc.DecodeString(encodedKey)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s is not valid base64: %w", EnvKeyName, err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("%s must decode to 32 bytes, got %d", EnvKeyName, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+func rowAAD(orgID, username, secretName string) []byte {
+	return []byte(orgID + "\x00" + username + "\x00" + secretName)
+}
+
+// Seal encrypts a secret statement for storage on the (org, user, name) row.
+func (c *Cipher) Seal(orgID, username, secretName, statement string) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, 1+len(nonce)+len(statement)+c.aead.Overhead())
+	out = append(out, ciphertextVersion)
+	out = append(out, nonce...)
+	return c.aead.Seal(out, nonce, []byte(statement), rowAAD(orgID, username, secretName)), nil
+}
+
+// Open decrypts a stored secret statement from the (org, user, name) row.
+func (c *Cipher) Open(orgID, username, secretName string, ciphertext []byte) (string, error) {
+	if len(ciphertext) < 1+c.aead.NonceSize() {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	if ciphertext[0] != ciphertextVersion {
+		return "", fmt.Errorf("unknown ciphertext version %d", ciphertext[0])
+	}
+	nonce := ciphertext[1 : 1+c.aead.NonceSize()]
+	plain, err := c.aead.Open(nil, nonce, ciphertext[1+c.aead.NonceSize():], rowAAD(orgID, username, secretName))
+	if err != nil {
+		return "", fmt.Errorf("decrypt user secret: %w", err)
+	}
+	return string(plain), nil
+}

--- a/server/usersecrets/redact.go
+++ b/server/usersecrets/redact.go
@@ -2,53 +2,22 @@ package usersecrets
 
 import "strings"
 
-// createSecretPrefixes are the statement shapes that can carry secret
-// material (key ids, tokens, passwords) in their option list. DROP variants
-// carry only a name and need no redaction.
-var createSecretPrefixes = []string{
-	"CREATE SECRET",
-	"CREATE PERSISTENT SECRET",
-	"CREATE TEMPORARY SECRET",
-	"CREATE TEMP SECRET",
-	"CREATE OR REPLACE SECRET",
-	"CREATE OR REPLACE PERSISTENT SECRET",
-	"CREATE OR REPLACE TEMPORARY SECRET",
-	"CREATE OR REPLACE TEMP SECRET",
-}
-
 // RedactForLog returns a version of query safe to write to logs, traces,
-// query logs, and pg_stat_activity. For CREATE SECRET statements the option
-// list (which contains credential material) is dropped, keeping only the
-// statement head and secret name. All other statements pass through
-// unchanged. This is intentionally looser than Classify: any statement that
-// merely looks like CREATE ... SECRET gets redacted — a false positive costs
-// one uninformative log line, a false negative leaks a credential.
+// query logs, and pg_stat_activity. For CREATE SECRET statements (any
+// persistence, including multi-statement strings whose head is secret DDL)
+// everything after the statement head is dropped — the option list carries
+// credential material, and on a multi-statement string the trailing
+// statements are dropped along with it. DROP variants carry only a name and
+// pass through unchanged, as does every non-secret statement.
+//
+// This is driven by the same tokenizer as Classify, so the redactor can never
+// be out of sync with the interceptor: any whitespace/comment arrangement
+// Classify accepts is redacted, and the non-matching fast path is two short
+// case-folded keyword comparisons with no allocation.
 func RedactForLog(query string) string {
-	head, ok := skipCommentsAndSpace(query)
-	if !ok {
+	st, headEnd, ok := parseSecretDDLHead(query)
+	if !ok || st.Kind != KindCreate {
 		return query
 	}
-	// Only the statement head matters for matching; don't uppercase a
-	// potentially huge query just to reject it. 64 bytes comfortably covers
-	// the longest prefix plus the word-boundary byte.
-	probe := head
-	if len(probe) > 64 {
-		probe = probe[:64]
-	}
-	upper := strings.ToUpper(probe)
-	for _, prefix := range createSecretPrefixes {
-		if !strings.HasPrefix(upper, prefix) {
-			continue
-		}
-		if len(upper) > len(prefix) && isIdentChar(upper[len(prefix)]) {
-			continue // e.g. "CREATE SECRETIVE_TABLE"
-		}
-		// Keep everything up to the option list. The name (if any) sits
-		// between the prefix and the first '(' and is safe to log.
-		if idx := strings.IndexByte(head, '('); idx >= 0 {
-			return strings.TrimSpace(head[:idx]) + " (…redacted)"
-		}
-		return strings.TrimSpace(head)
-	}
-	return query
+	return strings.TrimSpace(query[:headEnd]) + " (…redacted)"
 }

--- a/server/usersecrets/redact.go
+++ b/server/usersecrets/redact.go
@@ -1,0 +1,54 @@
+package usersecrets
+
+import "strings"
+
+// createSecretPrefixes are the statement shapes that can carry secret
+// material (key ids, tokens, passwords) in their option list. DROP variants
+// carry only a name and need no redaction.
+var createSecretPrefixes = []string{
+	"CREATE SECRET",
+	"CREATE PERSISTENT SECRET",
+	"CREATE TEMPORARY SECRET",
+	"CREATE TEMP SECRET",
+	"CREATE OR REPLACE SECRET",
+	"CREATE OR REPLACE PERSISTENT SECRET",
+	"CREATE OR REPLACE TEMPORARY SECRET",
+	"CREATE OR REPLACE TEMP SECRET",
+}
+
+// RedactForLog returns a version of query safe to write to logs, traces,
+// query logs, and pg_stat_activity. For CREATE SECRET statements the option
+// list (which contains credential material) is dropped, keeping only the
+// statement head and secret name. All other statements pass through
+// unchanged. This is intentionally looser than Classify: any statement that
+// merely looks like CREATE ... SECRET gets redacted — a false positive costs
+// one uninformative log line, a false negative leaks a credential.
+func RedactForLog(query string) string {
+	head, ok := skipCommentsAndSpace(query)
+	if !ok {
+		return query
+	}
+	// Only the statement head matters for matching; don't uppercase a
+	// potentially huge query just to reject it. 64 bytes comfortably covers
+	// the longest prefix plus the word-boundary byte.
+	probe := head
+	if len(probe) > 64 {
+		probe = probe[:64]
+	}
+	upper := strings.ToUpper(probe)
+	for _, prefix := range createSecretPrefixes {
+		if !strings.HasPrefix(upper, prefix) {
+			continue
+		}
+		if len(upper) > len(prefix) && isIdentChar(upper[len(prefix)]) {
+			continue // e.g. "CREATE SECRETIVE_TABLE"
+		}
+		// Keep everything up to the option list. The name (if any) sits
+		// between the prefix and the first '(' and is safe to log.
+		if idx := strings.IndexByte(head, '('); idx >= 0 {
+			return strings.TrimSpace(head[:idx]) + " (…redacted)"
+		}
+		return strings.TrimSpace(head)
+	}
+	return query
+}

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -31,6 +31,12 @@ type WorkerCreateSessionPayload struct {
 	Username    string `json:"username"`
 	MemoryLimit string `json:"memory_limit"`
 	Threads     int    `json:"threads"`
+	// SecretStatements are the user's persistent CREATE SECRET statements
+	// (decrypted by the control plane from the config store) to replay on the
+	// worker before the session is handed to the client. Worker pods are
+	// ephemeral, so this is the only way a user secret survives across
+	// sessions. Carries credential material: never log this payload.
+	SecretStatements []string `json:"secret_statements,omitempty"`
 }
 
 // WorkerDestroySessionPayload is the control plane request body for

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -99,6 +99,13 @@ client-go:
   (controlplane/org_reserved_pool_test.go, org_acquire_gate_test.go) — exercising
   them in-Job would need a dedicated max_workers=1 org and deterministic cold-spawn
   timing the shared cluster can't guarantee.
+- **persistent user secrets** — `CREATE PERSISTENT SECRET` survives across
+  sessions on both metadata-backend orgs (the CP stores the statement encrypted
+  in the config store and replays it at session creation — worker pods are
+  ephemeral); reserved system names (`ducklake_s3`, …) and unnamed persistent
+  secrets are rejected; `DROP PERSISTENT SECRET` removes it durably; and a
+  second user of the same org never sees the first user's secret, even on a
+  reused hot-idle worker (cnpg lane).
 - **isolation** — two tenants (cnpg vs ext) see distinct catalogs; a
   cross-tenant read is denied.
 - **lifecycle** — deprovision → `warehouse=deleted` → the Crossplane Duckling

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -721,6 +721,12 @@ persistent_user_secret() { # org password
   if pg_try "$org" "$pw" ducklake "CREATE PERSISTENT SECRET (TYPE s3, KEY_ID 'x', SECRET 'y')" >/dev/null; then
     fail "persistent secret: unnamed persistent secret was accepted"
   fi
+  # Multi-statement batches must be rejected, not silently executed-but-never-
+  # persisted (the secret would work for the session, then be wiped).
+  if out="$(pg_try "$org" "$pw" ducklake "CREATE PERSISTENT SECRET batch_ms (TYPE s3, KEY_ID 'x', SECRET 'y'); SELECT 1")"; then
+    fail "persistent secret: multi-statement batch was accepted"
+  fi
+  case "$out" in *"single statement"*) ;; *) fail "persistent secret: multi-statement rejection said '$out'";; esac
 
   # DROP must remove it durably — gone on the NEXT fresh session too (the
   # config-store row is deleted, not just the live worker's copy).

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -165,11 +165,11 @@ resolve_cp_ip() {
 # query tolerates it via bounded retry. Auth failures and real SQL errors are NOT
 # retried — they surface immediately, so this never feeds the rate limiter or
 # masks a genuine failure. (The behavior is exercised in cold_burst_absorption.)
-_pg_exec() { # org password dbname sql  -> prints output; rc 0 ok / 1 real error
+_pg_exec() { # org password dbname sql [user=root]  -> prints output; rc 0 ok / 1 real error
   a=0 out=""
   while [ "$a" -lt 12 ]; do
     if out="$(PGPASSWORD="$2" psql \
-        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=$3" \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=${5:-root} dbname=$3" \
         -v ON_ERROR_STOP=1 -tAc "$4" 2>&1)"; then
       printf %s "$out"; return 0
     fi
@@ -203,11 +203,11 @@ pgc() { _pg_exec "$@"; }
 # backpressure so the test evaluates the REAL outcome, then prints the final
 # output to stdout and returns the psql rc (0 = query succeeded, 1 = SQL error)
 # for the caller to inspect — never aborts the harness itself.
-pg_try() { # org password dbname sql
+pg_try() { # org password dbname sql [user=root]
   a=0 out=""
   while [ "$a" -lt 12 ]; do
     if out="$(PGPASSWORD="$2" psql \
-        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=$3" \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=${5:-root} dbname=$3" \
         -v ON_ERROR_STOP=1 -tAc "$4" 2>&1)"; then
       printf %s "$out"; return 0
     fi
@@ -695,6 +695,70 @@ org_default_profile() { # org password catalog
   log "org default OK: cleared; plain connection back on the deployment default shape"
 }
 
+# ---- user persistent secrets ------------------------------------------------
+# CREATE PERSISTENT SECRET must survive across sessions: worker pods are
+# ephemeral, so the CP intercepts the statement, stores it encrypted in the
+# config store keyed (org, user, name), and replays it at session creation.
+# Each psql invocation below is a fresh session (often a reused hot-idle
+# worker, whose persistent secrets are wiped at session create) — a secret
+# visible on the SECOND connection proves config-store replay, not worker-disk
+# luck. The dummy secret is SCOPEd to a nonexistent bucket so its bogus creds
+# can never shadow the org's real ducklake_s3 secret for actual queries.
+persistent_user_secret() { # org password
+  org="$1"; pw="$2"; sname="e2e_user_secret"
+  log "persistent user secret on $org"
+
+  pg "$org" "$pw" ducklake "CREATE PERSISTENT SECRET $sname (TYPE s3, KEY_ID 'AKIAE2EDUMMY', SECRET 'e2e-dummy', REGION 'us-east-1', SCOPE 's3://duckgres-e2e-nonexistent-$org')" >/dev/null
+
+  n="$(pg "$org" "$pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'")"
+  [ "$n" = "1" ] || fail "persistent secret: not replayed on a fresh session (count=$n)"
+
+  # Reserved (system) names and unnamed persistent secrets must be rejected.
+  if out="$(pg_try "$org" "$pw" ducklake "CREATE PERSISTENT SECRET ducklake_s3 (TYPE s3, KEY_ID 'x', SECRET 'y')")"; then
+    fail "persistent secret: reserved name ducklake_s3 was accepted"
+  fi
+  case "$out" in *reserved*) ;; *) fail "persistent secret: reserved-name rejection said '$out'";; esac
+  if pg_try "$org" "$pw" ducklake "CREATE PERSISTENT SECRET (TYPE s3, KEY_ID 'x', SECRET 'y')" >/dev/null; then
+    fail "persistent secret: unnamed persistent secret was accepted"
+  fi
+
+  # DROP must remove it durably — gone on the NEXT fresh session too (the
+  # config-store row is deleted, not just the live worker's copy).
+  pg "$org" "$pw" ducklake "DROP PERSISTENT SECRET $sname" >/dev/null
+  n="$(pg "$org" "$pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'")"
+  [ "$n" = "0" ] || fail "persistent secret: still present on a fresh session after DROP (count=$n)"
+  log "persistent secret OK on $org (create → cross-session replay → reserved/unnamed rejected → durable drop)"
+}
+
+# Cross-user isolation within one org: user B must never see user A's
+# persistent secret. B's session typically reuses A's hot-idle worker (one org,
+# cap permitting), which is exactly the leak path: the worker wipes persistent
+# secrets at session create and replays only the connecting user's.
+persistent_user_secret_isolation() { # org rootpw
+  org="$1"; pw="$2"; sname="e2e_root_secret"; u2="e2esecuser"
+  u2pw="e2e-$(openssl rand -hex 12)"
+  log "persistent secret cross-user isolation on $org"
+
+  pg "$org" "$pw" ducklake "CREATE PERSISTENT SECRET $sname (TYPE s3, KEY_ID 'AKIAE2EDUMMY', SECRET 'root-dummy', REGION 'us-east-1', SCOPE 's3://duckgres-e2e-nonexistent-root-$org')" >/dev/null
+
+  code="$(curl -s -o /tmp/create_user_out -w '%{http_code}' -X POST -H "$H" \
+    -H 'Content-Type: application/json' \
+    -d "{\"org_id\":\"$org\",\"username\":\"$u2\",\"password\":\"$u2pw\"}" \
+    "$API/api/v1/users")"
+  case "$code" in 200|201) ;; *) fail "persistent secret: create user $u2 -> HTTP $code: $(cat /tmp/create_user_out)";; esac
+  # New-user auth is config-snapshot-driven; wait out one poll before the
+  # first login so we don't burn failed auths against the rate limiter.
+  sleep "${CONFIG_POLL_SETTLE:-40}"
+
+  n="$(pg "$org" "$u2pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'" "$u2")"
+  [ "$n" = "0" ] || fail "persistent secret: user $u2 sees root's secret (count=$n)"
+  # Root's stored copy must be unaffected by $u2's session-create wipe.
+  n="$(pg "$org" "$pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'")"
+  [ "$n" = "1" ] || fail "persistent secret: root's secret lost after $u2's session (count=$n)"
+  pg "$org" "$pw" ducklake "DROP PERSISTENT SECRET $sname" >/dev/null
+  log "persistent secret isolation OK on $org ($u2 blind to root's secret; root's copy intact)"
+}
+
 # ---- resilience -----------------------------------------------------------
 # Worker pod killed mid-life → CP refills and a fresh query succeeds.
 # Ported from TestK8sWorkerCrashRecovery.
@@ -1052,6 +1116,8 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   jsonb_concat_semantics "$CNPG" "$cnpg_pw"
   cold_burst_absorption  "$CNPG" "$cnpg_pw"   # early, while this org is mostly cold
   rw_ducklake            "$CNPG" "$cnpg_pw"
+  persistent_user_secret "$CNPG" "$cnpg_pw"   # after rw_ducklake (org worker hot)
+  persistent_user_secret_isolation "$CNPG" "$cnpg_pw"
   pipeline_error_recovery "$CNPG" "$cnpg_pw"  # after rw_ducklake (table writes proven)
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
   iceberg_cold_first_connect "$CNPG" "$cnpg_pw"  # cold first session must not fail the metadata-init bind
@@ -1086,6 +1152,7 @@ lane_ext() { # external-RDS metadata backend + org default profile
   wait_worker "$EXT" "$ext_pw" ducklake
   basic_query  "$EXT" "$ext_pw"
   rw_ducklake  "$EXT" "$ext_pw"
+  persistent_user_secret "$EXT" "$ext_pw"   # secret replay on the ext-metadata org too
   iceberg_cold_first_connect "$EXT" "$ext_pw"  # cold first session must not fail the metadata-init bind (ext backend)
   rw_iceberg   "$EXT" "$ext_pw"
   # Org default profile on ext: no client-sized assertions run on this org, so
@@ -1159,7 +1226,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -84,6 +84,8 @@ metadata:
   namespace: ${NAMESPACE}
 stringData:
   internal-secret: "${INTERNAL_SECRET}"
+  # AES key for the user persistent secret manager (CREATE PERSISTENT SECRET).
+  user-secret-key: "${USER_SECRET_KEY}"
 ---
 # Worker mTLS bearer token (the CP mints per-worker secrets at runtime; this is
 # the shared seed the chart references via DUCKGRES_K8S_WORKER_SECRET).
@@ -269,6 +271,10 @@ spec:
             - { name: DUCKGRES_K8S_MAX_WORKERS, value: "50" }
             - name: DUCKGRES_INTERNAL_SECRET
               valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
+            # Enables the user persistent secret manager; the harness
+            # persistent_user_secret assertion exercises it end-to-end.
+            - name: DUCKGRES_USER_SECRET_KEY
+              valueFrom: { secretKeyRef: { name: duckgres-tokens, key: user-secret-key } }
             - { name: DUCKGRES_AWS_REGION, value: "us-east-1" }
             # Land e2e workers on the DEFAULT (untainted) nodepool, NOT the real
             # deployment's duckgres-workers pool: per-PR worker churn must not

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -25,14 +25,19 @@ SA_NAME="duckgres"
 # Internal secret for the per-PR control plane. Random per run; never reused.
 # Stamped into the rendered manifests and handed to the in-cluster harness.
 internal_secret_file="/tmp/duckgres-ci-internal-secret"
+# AES key for user persistent secrets (DUCKGRES_USER_SECRET_KEY). Random per
+# run: stored user secrets only need to outlive the run's sessions.
+user_secret_key_file="/tmp/duckgres-ci-user-secret-key"
 
 render() {
   : "${WORKER_IMAGE:?}" "${CONTROLPLANE_IMAGE:?}" "${PR_NUMBER:?}"
   [ -f "$internal_secret_file" ] || openssl rand -hex 16 > "$internal_secret_file"
+  [ -f "$user_secret_key_file" ] || openssl rand -base64 32 > "$user_secret_key_file"
   INTERNAL_SECRET="$(cat "$internal_secret_file")" \
+  USER_SECRET_KEY="$(cat "$user_secret_key_file")" \
   NAMESPACE="$NS" PR_NUMBER="$PR_NUMBER" \
   WORKER_IMAGE="$WORKER_IMAGE" CONTROLPLANE_IMAGE="$CONTROLPLANE_IMAGE" \
-    envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET' \
+    envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET $USER_SECRET_KEY' \
     < "$HERE/manifests.tmpl.yaml"
 }
 


### PR DESCRIPTION
## Summary

A customer can now run `CREATE PERSISTENT SECRET` and have it survive across sessions and worker pods in the multitenant remote backend. Worker pods are ephemeral (pinned `secret_directory` wiped on recycle), so until now any client-issued secret died with the session.

```sql
CREATE PERSISTENT SECRET my_gcs (TYPE gcs, KEY_ID '…', SECRET '…', SCOPE 'gs://my-bucket');
-- reconnect later, different worker pod:
SELECT name FROM duckdb_secrets();   -- my_gcs is back
DROP PERSISTENT SECRET my_gcs;       -- durably gone
```

Plain / `TEMPORARY` `CREATE SECRET` stays session-scoped passthrough, unchanged.

## Design

- **Intercept at the CP** (`server/conn_user_secrets.go`, classifier in `server/usersecrets/`): both simple and extended protocols, passthrough users included. Execute on the live session first (DuckDB validates), **then** persist — a store failure after a successful exec returns an explicit "applied but will NOT survive this session" error. `DROP` deletes the store row even when the session-side drop fails, so a broken stored secret can't become unremovable.
- **Store in the config store**: new `duckgres_org_user_secrets` table keyed `(org_id, username, secret_name)`; the statement is AES-256-GCM-encrypted with the row key bound as AAD (ciphertext can't be moved between rows). Direct DB reads (not snapshot-polled), so a secret set via one CP replica is immediately live on all.
- **Replay at session creation**: the user's decrypted statements ride the existing TLS+bearer `CreateSession` worker RPC. The worker first **wipes all persistent-storage secrets** (system secrets `ducklake_s3`/`iceberg_sigv4`/`iceberg_oauth` are in-memory and untouched), then replays. The wipe is the cross-user isolation step for hot-idle worker reuse and failing it fails the session; replay failures degrade to warnings so a stale secret can't lock a user out.
- **Key management**: env-only `DUCKGRES_USER_SECRET_KEY` (base64 32-byte AES key, mounted from a K8s Secret). Unset → `CREATE PERSISTENT SECRET` fails with a clear 0A000 ("not enabled on this deployment"); malformed → CP refuses to start; `DROP` works keyless so stale rows stay removable after key loss.
- **Guardrails**: reserved system names, unnamed persistent secrets, >8KB statements, >32 secrets/user are all rejected before anything executes.
- **Log hygiene**: `usersecrets.RedactForLog` now guards `logQueryStarted/Finished/Error`, the query log, trace spans, and `pg_stat_activity` — secret DDL appears as `CREATE PERSISTENT SECRET my_s3 (…redacted)`. This also closes the pre-existing leak where a passthrough `CREATE SECRET` landed in the query log with plaintext credentials.

## Test plan

- Unit: classifier/crypto/redaction (`server/usersecrets`), CP interception semantics (`server/conn_user_secrets_test.go`), worker wipe+replay against real DuckDB (`duckdbservice/user_secrets_test.go`), configstore CRUD against the Postgres test container.
- e2e (`tests/e2e-mw-dev/harness.sh`): `persistent_user_secret` on **both** cnpg and ext lanes (create → cross-session replay → reserved/unnamed rejected → durable drop) and `persistent_user_secret_isolation` on cnpg (a second org user must not see root's secret on a reused hot-idle worker; root's stored copy survives the other user's session). `run.sh` mints a per-run key into `duckgres-tokens` and the CP env.
- `go build` / `go vet` / `go test ./...` clean on both plain and `-tags kubernetes` builds. (Two pre-existing failures unrelated to this PR: `TestCatalogPsqlCommands/psql_dn` fails identically on main; `controlplane/admin` postgres-container test needs `docker-compose` on PATH.)

## Deployment note

Real deployments need a **stable** `DUCKGRES_USER_SECRET_KEY` minted and mounted before this is live (rotating it orphans stored user secrets — they're skipped with a loud log and removable via `DROP`). Until the key ships, the feature is cleanly disabled. Chart/infra PRs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)