### PR TITLE
fix(controlplane): raise cold-spawn worker connect budget 90s → 3m (fixes e2e worker-reap flakiness)

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -30,16 +30,35 @@ const defaultActivatingTimeout = 2 * time.Minute
 // generous.
 const workerPodReadyTimeout = 5 * time.Minute
 
+// workerSpawnConnectTimeout bounds the gRPC connect-and-health-check to a
+// freshly-spawned worker (waitForWorkerTCP). It must cover the worker's whole
+// warmup, not just a TCP dial: the worker's health handler deliberately blocks
+// on warmupDone (duckdbservice FlightSQLHandler.doHealthCheck) until extension
+// load + the DuckLake ATTACH (httpfs/S3 + metadata) complete, so the CP can't
+// route to a not-yet-attached worker. waitForPodReady returns the instant the
+// pod is Running+IP (~1.5s) — there is no readiness probe gating on warmup — so
+// this connect budget, NOT workerPodReadyTimeout, is what absorbs the attach.
+//
+// 90s was too tight: under a burst of concurrent cold spawns (e.g. the e2e
+// harness's parallel per-org lanes) the DuckLake ATTACH contends on S3/metadata
+// and routinely exceeds 90s, so the CP reaped healthy-but-still-attaching
+// workers, failing the session. 3m gives comfortable headroom over a
+// contended-but-progressing attach while staying well under the engine-side
+// attach cap (attachMigrateStatementTimeout, 15m). A genuinely dead/crashed
+// worker is detected independently by the pod informer / PodFailed path, so the
+// longer budget does not weaken crash detection.
+const workerSpawnConnectTimeout = 3 * time.Minute
+
 // workerSpawnActivateTimeout bounds the DETACHED background spawn+activate run
 // for an org cold acquisition (OrgReservedPool.AcquireWorker slow path). The
 // spawn and activation deliberately do NOT run on the requester's ctx: if node
 // provisioning reliably exceeds the client's worker-queue budget, cancelling
 // the wait would delete the in-flight pod and every retry would spawn-wait-
-// delete a fresh one without ever converging (doomed-spawn thrash). Budget =
-// pod-ready wait (workerPodReadyTimeout, may include a Karpenter node
-// provision) + gRPC connect (up to 90s) + tenant activation (ATTACH against
-// cloud storage, defaultActivatingTimeout-scale).
-const workerSpawnActivateTimeout = workerPodReadyTimeout + 3*time.Minute
+// delete a fresh one without ever converging (doomed-spawn thrash). Budget is
+// the sum of its phases — pod-ready wait (may include a Karpenter node
+// provision) + gRPC connect (covers worker warmup) + tenant activation (ATTACH
+// against cloud storage) — so the three deadlines can't drift out of sync.
+const workerSpawnActivateTimeout = workerPodReadyTimeout + workerSpawnConnectTimeout + defaultActivatingTimeout
 
 const workerTerminationGracePeriodSeconds int64 = 3600
 

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -315,7 +315,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 		observeSpawnFailure(SpawnFailureReasonSecretRead, image)
 		return fmt.Errorf("read worker RPC security: %w", err)
 	}
-	client, err := waitForWorkerTCP(addr, token, serverCertPEM, 90*time.Second)
+	client, err := waitForWorkerTCP(addr, token, serverCertPEM, workerSpawnConnectTimeout)
 	if err != nil {
 		_ = p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 			GracePeriodSeconds: int64Ptr(0),

--- a/controlplane/k8s_pool_spawn_timeout_test.go
+++ b/controlplane/k8s_pool_spawn_timeout_test.go
@@ -1,0 +1,25 @@
+//go:build kubernetes
+
+package controlplane
+
+import "testing"
+
+// The spawn-connect budget must absorb the worker's full warmup (the health
+// handler blocks on warmupDone through extension load + DuckLake ATTACH), so it
+// has to be comfortably larger than a bare TCP dial. 90s proved too tight under
+// concurrent cold spawns; guard against regressing it back.
+func TestWorkerSpawnConnectTimeoutCoversWarmup(t *testing.T) {
+	if workerSpawnConnectTimeout <= 90_000_000_000 { // 90s in ns
+		t.Errorf("workerSpawnConnectTimeout=%s must exceed the old 90s budget that reaped still-warming workers", workerSpawnConnectTimeout)
+	}
+}
+
+// The detached spawn+activate budget must dominate the sum of the phases it
+// supervises (pod-ready + connect + activate); otherwise the outer ctx can
+// expire mid-phase and thrash. Defining it as that sum keeps the three in sync.
+func TestWorkerSpawnActivateTimeoutDominatesPhases(t *testing.T) {
+	phases := workerPodReadyTimeout + workerSpawnConnectTimeout + defaultActivatingTimeout
+	if workerSpawnActivateTimeout < phases {
+		t.Errorf("workerSpawnActivateTimeout=%s must be >= pod-ready+connect+activate=%s", workerSpawnActivateTimeout, phases)
+	}
+}


### PR DESCRIPTION
## Summary

Raises the **cold-spawn worker connect budget from 90s to 3 minutes**, fixing the e2e flakiness where the control plane reaps a healthy-but-still-warming worker.

This is the root cause of the recurring `e2e` failures across PRs since ~16:40 UTC today (`acquire worker: spawn sized worker: ... timeout connecting to worker at <ip>:8816 ... DeadlineExceeded ... attempts: 37`).

## Root cause

A freshly-spawned worker's gRPC health handler **deliberately blocks until warmup completes** — `duckdbservice/flight_handler.go`: `<-h.pool.warmupDone` — so the CP won't route to a worker that hasn't loaded extensions + done the **DuckLake `ATTACH`** (httpfs/S3 + metadata). Meanwhile:

- `waitForPodReady` returns the instant the pod is `Running`+IP (~1.5s) — **there is no readiness probe gating on warmup** — so the **connect budget** (`waitForWorkerTCP`), *not* the 5-minute `workerPodReadyTimeout`, is what absorbs the entire attach.
- That budget was **90s** (a loop of ~37 attempts × 2s health RPC).

Under a burst of concurrent cold spawns — the e2e harness's **four parallel per-org lanes** (#747), on workers packed tighter after #745/#746 — the DuckLake ATTACH contends on S3/metadata and routinely exceeds 90s. Every health attempt times out, the CP reaps the worker mid-attach, the session fails, and with all four lanes hitting it the whole run fails. It's load-dependent, hence intermittent (passes in low-contention windows).

## Diagnosed live on mw-dev

- Workers reach `Running` and bind `:8816` in ~1.5s, then **hang right after `Loaded extension ducklake`** and are reaped **before** ever logging `pre-warmed successfully`.
- `duckgres_worker_acquire_phase_seconds{phase="spawn"}` never records a completion — only `gate_wait` shows requests *entering* the spawn phase (5 in-flight, 0 completing).
- Not node-freshness (failing worker shared a warm node with workers that connected), not a Cilium drop (none captured; cluster health 35/35), not any PR's code (a branch without the latest main fails identically; the worker binary never runs the changed transpiler/catalog code).

## Change

- New named constant `workerSpawnConnectTimeout = 3m`; `waitForWorkerTCP` in the cold-spawn path uses it instead of the magic `90s`. 3m gives comfortable headroom over a contended-but-progressing attach while staying well under the engine-side cap (`attachMigrateStatementTimeout`, 15m).
- The **hot-idle reuse** path keeps its 30s budget (those workers are already warm).
- Crash detection is unaffected — dead/crashed workers are caught independently by the pod informer / `PodFailed` path, not this health loop.
- `workerSpawnActivateTimeout` is now defined as the **sum of its phases** (pod-ready + connect + activate) so the three deadlines can't drift out of sync.
- Regression tests guard both invariants.

## Follow-up (not in this PR — platform/test owners)

This makes the CP tolerant of slow attach; the *underlying* slowness is the concurrent-attach contention introduced by #747/#745/#746. Worth: staggering the lanes' worker demand and/or restoring worker CPU headroom, and confirming warmup isn't doing avoidable network I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
