### PR TITLE
fix(ducklake): retry the first-attach schema-init race (concurrent first connections to a fresh warehouse)

### DIFF
--- a/duckdbservice/transient.go
+++ b/duckdbservice/transient.go
@@ -90,7 +90,15 @@ func isTransientDuckLakeError(err error) bool {
 		strings.Contains(msg, "SSL connection has been closed unexpectedly") ||
 		strings.Contains(msg, "Current transaction is aborted") ||
 		strings.Contains(msg, "no route to host") ||
-		strings.Contains(msg, "network is unreachable")
+		strings.Contains(msg, "network is unreachable") ||
+		// Concurrent first ATTACHes for a fresh org race the DuckLake
+		// metadata-store schema init: both workers CREATE the ducklake_*
+		// tables, the loser hits a Postgres catalog unique constraint
+		// (e.g. pg_type_typname_nsp_index on ducklake_metadata), and a
+		// retry succeeds because the winner's schema now exists. Guarded
+		// on "ducklake" so user-data duplicate keys are never retried.
+		(strings.Contains(msg, "duplicate key value violates unique constraint") &&
+			strings.Contains(msg, "ducklake"))
 }
 
 const (

--- a/duckdbservice/transient_test.go
+++ b/duckdbservice/transient_test.go
@@ -59,6 +59,13 @@ func TestIsTransientDuckLakeError(t *testing.T) {
 		{"auth error", errors.New("password authentication failed for user"), false},
 		{"table not found", errors.New("Table with name foo does not exist"), false},
 		{"transaction conflict is not transient", errors.New(`Transaction conflict - attempting to insert into table with index "29784"`), false},
+		// Two workers cold-activating the same fresh org race the DuckLake
+		// metadata-store schema init; the loser's ATTACH fails on a catalog
+		// unique constraint and succeeds on retry (schema now exists).
+		{"first-attach schema-init race", errors.New(`duplicate key value violates unique constraint "pg_type_typname_nsp_index" DETAIL: Key (typname, typnamespace)=(ducklake_metadata, 2200) already exists.`), true},
+		{"first-attach race on a ducklake relation", errors.New(`duplicate key value violates unique constraint "pg_class_relname_nsp_index" DETAIL: Key (relname, relnamespace)=(ducklake_snapshot, 2200) already exists.`), true},
+		// A duplicate-key on a non-ducklake object must NOT be treated as transient.
+		{"user duplicate key is not transient", errors.New(`duplicate key value violates unique constraint "users_pkey" DETAIL: Key (id)=(1) already exists.`), false},
 	}
 
 	for _, tt := range tests {

--- a/server/transient.go
+++ b/server/transient.go
@@ -26,7 +26,15 @@ func isTransientDuckLakeError(err error) bool {
 		strings.Contains(msg, "SSL connection has been closed unexpectedly") ||
 		strings.Contains(msg, "Current transaction is aborted") ||
 		strings.Contains(msg, "no route to host") ||
-		strings.Contains(msg, "network is unreachable")
+		strings.Contains(msg, "network is unreachable") ||
+		// Concurrent first ATTACHes for a fresh org race the DuckLake
+		// metadata-store schema init: both workers CREATE the ducklake_*
+		// tables, the loser hits a Postgres catalog unique constraint
+		// (e.g. pg_type_typname_nsp_index on ducklake_metadata), and a
+		// retry succeeds because the winner's schema now exists. Guarded
+		// on "ducklake" so user-data duplicate keys are never retried.
+		(strings.Contains(msg, "duplicate key value violates unique constraint") &&
+			strings.Contains(msg, "ducklake"))
 }
 
 const (

--- a/server/transient_test.go
+++ b/server/transient_test.go
@@ -33,6 +33,13 @@ func TestIsTransientDuckLakeError(t *testing.T) {
 		{"auth error", errors.New("password authentication failed for user"), false},
 		{"table not found", errors.New("Table with name foo does not exist"), false},
 		{"transaction conflict is not transient", errors.New(`Transaction conflict - attempting to insert into table with index "29784"`), false},
+		// Two workers cold-activating the same fresh org race the DuckLake
+		// metadata-store schema init; the loser's ATTACH fails on a catalog
+		// unique constraint and succeeds on retry (schema now exists).
+		{"first-attach schema-init race", errors.New(`duplicate key value violates unique constraint "pg_type_typname_nsp_index" DETAIL: Key (typname, typnamespace)=(ducklake_metadata, 2200) already exists.`), true},
+		{"first-attach race on a ducklake relation", errors.New(`duplicate key value violates unique constraint "pg_class_relname_nsp_index" DETAIL: Key (relname, relnamespace)=(ducklake_snapshot, 2200) already exists.`), true},
+		// A duplicate-key on a non-ducklake object must NOT be treated as transient.
+		{"user duplicate key is not transient", errors.New(`duplicate key value violates unique constraint "users_pkey" DETAIL: Key (id)=(1) already exists.`), false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes a real concurrency bug surfaced twice by the e2e harness: **two concurrent first connections to a fresh warehouse race the DuckLake metadata-store schema init, and the loser surfaces a raw Postgres catalog error to the client.**

```
duplicate key value violates unique constraint "pg_type_typname_nsp_index"
DETAIL: Key (typname, typnamespace)=(ducklake_metadata, 2200) already exists.
```

## Mechanism

An org's first-ever ATTACH creates the `ducklake_*` tables in the metadata store. When two workers cold-activate the same fresh org simultaneously (e.g. two first connections arriving together), both run that schema init; the loser hits a metadata-Postgres catalog unique constraint. A retry succeeds trivially — the winner's schema now exists — but nothing retried, so the client got the error.

**Sightings** (both from `one_session_per_worker`, which fires an org's first two sessions concurrently — exactly this shape):
- run 27291505631 (2026-06-09, `codex/wait-worker-close…`)
- run 27304575868 (2026-06-10, #707 rerun — one query returned correct results, the sibling died on this)

## Change

Classify the duplicate-key-during-schema-init shape as transient in **both** copies of `isTransientDuckLakeError`:
- `server/transient.go` — feeds `retryOnTransientAttach`, which wraps the ATTACH statement (activation path)
- `duckdbservice/transient.go` — feeds the worker's query-time `retryOnTransient` (where lazy init surfaces it)

Guarded on the message containing `ducklake`, so user-data duplicate keys (e.g. `users_pkey`) are never retried — covered by a negative test case. The classifiers' only consumers are these retry wrappers (3 attempts, 250ms exponential backoff).

## Testing

- TDD: new table cases in both `TestIsTransientDuckLakeError`s (exact observed error strings) watched RED, then GREEN; negative case for user duplicate keys.
- `go test ./server ./duckdbservice ./transpiler/...` green; lint 0 issues.
- e2e regression coverage is the existing `one_session_per_worker` assertion — it found this bug twice and exercises the exact concurrent-first-attach shape on both metadata backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
