### PR TITLE
fix(controlplane): de-ratchet node headroom; busy-only worker disruption protection

### DIFF
--- a/controlplane/headroom.go
+++ b/controlplane/headroom.go
@@ -19,25 +19,43 @@ const headroomPodLabel = "duckgres-headroom"
 
 // headroomPlaceholdersNeeded returns how many placeholder pods of size
 // (phCPUMillis, phMemBytes) are required to hold `percent`% of the worker
-// nodepool's allocatable (allocCPUMillis, allocMemBytes) free. It's the max of
-// the count needed to cover the CPU headroom and the count needed to cover the
-// memory headroom, so both axes are satisfied. Pure (no I/O) for testability.
-func headroomPlaceholdersNeeded(allocCPUMillis, allocMemBytes, phCPUMillis, phMemBytes int64, percent int) int {
+// nodepool's NON-PLACEHOLDER allocatable free. It's the max of the count
+// needed to cover the CPU headroom and the count needed to cover the memory
+// headroom, so both axes are satisfied. Pure (no I/O) for testability.
+//
+// The capacity held by the already-SCHEDULED placeholders is subtracted
+// from allocatable before taking the percentage. Without the subtraction the
+// target is self-referential and RATCHETS: placeholders pin nodes (a node
+// hosting one is never "Empty", so WhenEmpty consolidation can't reclaim it),
+// pinned nodes inflate allocatable, inflated allocatable raises the target,
+// which creates more placeholders — observed holding ~57% of the nodepool at
+// a configured 20%. Sizing against the non-placeholder baseline makes the
+// target track real (worker) usage: as workers finish, the target falls, the
+// reconciler deletes the excess, emptied nodes consolidate, and allocatable
+// follows it down.
+//
+// Floors at 1 while headroom is enabled: a pure percentage hits zero on an
+// idle pool, which would leave no preemptible slot at all and make the first
+// spawn after an idle period fully cold — one warm slot is the point of the
+// feature.
+func headroomPlaceholdersNeeded(allocCPUMillis, allocMemBytes, phCPUMillis, phMemBytes int64, percent, scheduledPlaceholders int) int {
 	if percent <= 0 {
 		return 0
 	}
 	if phCPUMillis <= 0 && phMemBytes <= 0 {
 		return 0
 	}
-	n := 0
+	baseCPU := allocCPUMillis - int64(scheduledPlaceholders)*phCPUMillis
+	baseMem := allocMemBytes - int64(scheduledPlaceholders)*phMemBytes
+	n := 1 // floor: always keep one preemptible slot while enabled
 	if phCPUMillis > 0 {
-		cpuTarget := allocCPUMillis * int64(percent) / 100
+		cpuTarget := baseCPU * int64(percent) / 100
 		if c := ceilDiv(cpuTarget, phCPUMillis); c > n {
 			n = c
 		}
 	}
 	if phMemBytes > 0 {
-		memTarget := allocMemBytes * int64(percent) / 100
+		memTarget := baseMem * int64(percent) / 100
 		if c := ceilDiv(memTarget, phMemBytes); c > n {
 			n = c
 		}
@@ -87,13 +105,13 @@ func (p *K8sWorkerPool) reconcileHeadroom(ctx context.Context) {
 		return
 	}
 
-	desired := headroomPlaceholdersNeeded(allocCPU, allocMem, phCPU.MilliValue(), phMem.Value(), p.headroomPercent)
-
-	existing, err := p.listPlaceholderPods(ctx)
+	existing, scheduled, err := p.listPlaceholderPods(ctx)
 	if err != nil {
 		slog.Warn("Headroom: failed to list placeholder pods.", "error", err)
 		return
 	}
+
+	desired := headroomPlaceholdersNeeded(allocCPU, allocMem, phCPU.MilliValue(), phMem.Value(), p.headroomPercent, scheduled)
 
 	switch {
 	case len(existing) < desired:
@@ -137,22 +155,31 @@ func (p *K8sWorkerPool) workerNodepoolAllocatable(ctx context.Context) (cpuMilli
 	return cpuMillis, memBytes, nil
 }
 
-func (p *K8sWorkerPool) listPlaceholderPods(ctx context.Context) ([]string, error) {
+// listPlaceholderPods returns the live placeholder pod names plus how many of
+// them are SCHEDULED (assigned to a node). Only scheduled placeholders occupy
+// node allocatable, so only they are subtracted from the sizing baseline —
+// subtracting Pending ones (created but not yet backed by a Karpenter node)
+// would shrink the baseline below reality and make the target flap down while
+// capacity is still arriving.
+func (p *K8sWorkerPool) listPlaceholderPods(ctx context.Context) (names []string, scheduled int, err error) {
 	pods, err := p.clientset.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "app=" + headroomPodLabel,
 	})
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	names := make([]string, 0, len(pods.Items))
+	names = make([]string, 0, len(pods.Items))
 	for i := range pods.Items {
 		// Skip pods already terminating.
 		if pods.Items[i].DeletionTimestamp != nil {
 			continue
 		}
 		names = append(names, pods.Items[i].Name)
+		if pods.Items[i].Spec.NodeName != "" {
+			scheduled++
+		}
 	}
-	return names, nil
+	return names, scheduled, nil
 }
 
 func (p *K8sWorkerPool) createPlaceholderPod(ctx context.Context, cpu, mem resource.Quantity) error {

--- a/controlplane/headroom_test.go
+++ b/controlplane/headroom_test.go
@@ -20,6 +20,7 @@ func TestHeadroomPlaceholdersNeeded(t *testing.T) {
 		allocCPUMillis, allocMemBytes int64
 		phCPUMillis, phMemBytes       int64
 		percent                       int
+		scheduled                     int
 		want                          int
 	}{
 		{name: "disabled (0%)", allocCPUMillis: 100000, allocMemBytes: 1000 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 0, want: 0},
@@ -32,14 +33,23 @@ func TestHeadroomPlaceholdersNeeded(t *testing.T) {
 		{name: "cpu bound", allocCPUMillis: 1000000, allocMemBytes: 100 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 20, want: 25},
 		// tiny cluster, headroom rounds up to 1 placeholder.
 		{name: "rounds up to one", allocCPUMillis: 8000, allocMemBytes: 16 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 10, want: 1},
-		// zero allocatable => none.
-		{name: "no nodes", allocCPUMillis: 0, allocMemBytes: 0, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 25, want: 0},
+		// zero allocatable: the floor still asks for one placeholder — it goes
+		// Pending and pulls the first node, so an idle pool keeps a warm slot.
+		{name: "no nodes -> floor", allocCPUMillis: 0, allocMemBytes: 0, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 25, want: 1},
 		// placeholder with no size => none (guards a misconfig).
 		{name: "no placeholder size", allocCPUMillis: 100000, allocMemBytes: 200 * gi, phCPUMillis: 0, phMemBytes: 0, percent: 25, want: 0},
+		// RATCHET REGRESSION: 10 scheduled placeholders (80c/160Gi) pin nodes
+		// that inflate allocatable to 200c/400Gi. Sizing must target the
+		// non-placeholder baseline (120c/240Gi): 15% => 18c/36Gi => 3 — NOT
+		// 15% of the inflated total (=> 4, which would never shrink).
+		{name: "scheduled placeholders excluded from baseline", allocCPUMillis: 200000, allocMemBytes: 400 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 15, scheduled: 10, want: 3},
+		// Idle pool: allocatable is ONLY placeholder-held capacity => baseline
+		// 0 => floor of one warm slot (the old formula self-sustained all 10).
+		{name: "idle pool converges to floor", allocCPUMillis: 80000, allocMemBytes: 160 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 20, scheduled: 10, want: 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := headroomPlaceholdersNeeded(tt.allocCPUMillis, tt.allocMemBytes, tt.phCPUMillis, tt.phMemBytes, tt.percent)
+			got := headroomPlaceholdersNeeded(tt.allocCPUMillis, tt.allocMemBytes, tt.phCPUMillis, tt.phMemBytes, tt.percent, tt.scheduled)
 			if got != tt.want {
 				t.Fatalf("headroomPlaceholdersNeeded = %d, want %d", got, tt.want)
 			}

--- a/controlplane/k8s_pool_disruption.go
+++ b/controlplane/k8s_pool_disruption.go
@@ -1,0 +1,70 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// doNotDisruptAnnotation is Karpenter's voluntary-disruption veto: a pod
+// carrying it blocks consolidation/drift of its node, but NOT kube-scheduler
+// preemption (so headroom placeholders are still preempted by real workers).
+const doNotDisruptAnnotation = "karpenter.sh/do-not-disrupt"
+
+// setWorkerDoNotDisrupt toggles the Karpenter do-not-disrupt annotation on a
+// worker pod. Workers are BUSY-protected only: the annotation is present from
+// pod creation (covering the expensive spawn+activate window and the first
+// session) and while a session is assigned, and removed when the worker parks
+// hot-idle — so consolidation (WhenEmptyOrUnderutilized) can reclaim nodes
+// holding only idle workers and placeholders, while a node running an active
+// query is never voluntarily disrupted. Pinning is therefore bounded by query
+// lifetime, not the up-to-24h worker TTL (which would stall drift rollouts).
+//
+// Best-effort by design: a failed PATCH must never fail the session path. The
+// failure modes are benign — a busy worker briefly without the annotation is
+// still backed by the drain protocol (#690: SIGTERM → finish in-flight work),
+// and an idle worker briefly with it just delays one consolidation pass.
+func (p *K8sWorkerPool) setWorkerDoNotDisrupt(podName string, protected bool) {
+	if p.clientset == nil || podName == "" {
+		return
+	}
+	var patch []byte
+	if protected {
+		patch = []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:"true"}}}`, doNotDisruptAnnotation))
+	} else {
+		patch = []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, doNotDisruptAnnotation))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := p.clientset.CoreV1().Pods(p.namespace).Patch(ctx, podName, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		slog.Warn("Failed to toggle worker do-not-disrupt annotation.",
+			"worker_pod", podName, "protected", protected, "error", err)
+	}
+}
+
+// markWorkerProtected flags a worker as actively serving (session assigned):
+// its node must not be voluntarily disrupted. Synchronous (one fast PATCH) so
+// the protect cannot be reordered after a subsequent release's unprotect.
+func (p *K8sWorkerPool) markWorkerProtected(w *ManagedWorker) {
+	if w == nil {
+		return
+	}
+	p.setWorkerDoNotDisrupt(p.workerPodName(w), true)
+}
+
+// markWorkerDisruptable flags a parked (hot-idle) worker as fair game for
+// Karpenter consolidation. Async: release latency doesn't matter, and the
+// worst-case race (annotation lingering briefly) only delays consolidation.
+func (p *K8sWorkerPool) markWorkerDisruptable(w *ManagedWorker) {
+	if w == nil {
+		return
+	}
+	podName := p.workerPodName(w)
+	go p.setWorkerDoNotDisrupt(podName, false)
+}

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -80,6 +80,10 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 			Name:      podName,
 			Namespace: p.namespace,
 			Labels:    podLabels,
+			// Born protected: the spawn+activate window and the first session
+			// must not be consolidation-evicted. Removed when the worker first
+			// parks hot-idle, re-added per session (see k8s_pool_disruption.go).
+			Annotations: map[string]string{doNotDisruptAnnotation: "true"},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                 corev1.RestartPolicyNever,

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -4160,3 +4160,46 @@ func TestCPReplicaSetHash(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkerDoNotDisruptLifecycle(t *testing.T) {
+	// Busy-only protection: born protected (spawn sets the annotation on the
+	// pod spec), disruptable when parked hot-idle, protected again on reuse.
+	cs := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "duckgres-worker-test-cp-7",
+			Namespace:   "default",
+			Annotations: map[string]string{doNotDisruptAnnotation: "true"},
+		},
+	})
+	pool := &K8sWorkerPool{clientset: cs, namespace: "default", cpID: "test-cp"}
+	w := &ManagedWorker{ID: 7}
+
+	annotation := func() (string, bool) {
+		pod, err := cs.CoreV1().Pods("default").Get(context.Background(), "duckgres-worker-test-cp-7", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get pod: %v", err)
+		}
+		v, ok := pod.Annotations[doNotDisruptAnnotation]
+		return v, ok
+	}
+
+	// Parked hot-idle: annotation must go away so consolidation can reclaim
+	// the node. markWorkerDisruptable patches async — poll briefly.
+	pool.markWorkerDisruptable(w)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ok := annotation(); !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("do-not-disrupt annotation not removed for hot-idle worker")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Reused for a session: protected again (synchronous).
+	pool.markWorkerProtected(w)
+	if v, ok := annotation(); !ok || v != "true" {
+		t.Fatalf("do-not-disrupt annotation = %q,%v after protect, want \"true\"", v, ok)
+	}
+}

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -50,6 +50,14 @@ func (p *OrgReservedPool) AcquireWorker(ctx context.Context, profile *WorkerProf
 	acquireStart := time.Now()
 	defer func() {
 		observeAcquireTotal(time.Since(acquireStart), acquireTotalOutcome(err))
+		if worker != nil {
+			// Session assigned: veto voluntary disruption (consolidation/drift)
+			// of the worker's node until release. Freshly spawned pods are
+			// already born with the annotation; this covers hot-idle reuse and
+			// cross-CP claims. Synchronous so it cannot reorder after a later
+			// release's removal.
+			p.shared.markWorkerProtected(worker)
+		}
 	}()
 
 	// Fast path: reuse an already-assigned, idle (Hot) worker of the requested
@@ -288,6 +296,12 @@ func (p *OrgReservedPool) tryReuseIdleAssigned(profile *WorkerProfile) *ManagedW
 
 func (p *OrgReservedPool) ReleaseWorker(id int) {
 	if p.shared.TransitionToHotIdleIfNoSessions(id) {
+		// Parked hot-idle: drop the do-not-disrupt veto so Karpenter may
+		// consolidate a node holding only idle workers/placeholders. The next
+		// acquire re-adds it before the session starts.
+		if w, ok := p.shared.Worker(id); ok {
+			p.shared.markWorkerDisruptable(w)
+		}
 		return
 	}
 	// TransitionToHotIdleIfNoSessions already decremented activeSessions.

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -113,6 +113,17 @@ only) it:
 - placeholder pods use a PriorityClass **below** the worker PriorityClass, so a
   real worker spawn preempts them and schedules immediately; the evicted
   placeholder triggers Karpenter to add a node in the background.
+- the placeholder target is sized against the **non-placeholder** allocatable
+  (floor: one placeholder while enabled). Sizing against raw allocatable is
+  self-referential and ratchets: placeholders pin nodes, pinned nodes inflate
+  allocatable, the inflated total raises the target.
+- workers carry `karpenter.sh/do-not-disrupt` **only while busy** (set at pod
+  create — covering spawn/activate and the first session — re-added per
+  session, removed when parked hot-idle). With the worker nodepool on
+  `WhenEmptyOrUnderutilized`, Karpenter can consolidate nodes holding only
+  idle workers/placeholders, while a node running a query is never voluntarily
+  disrupted; pinning is bounded by query lifetime, not the worker TTL (which
+  would stall drift rollouts).
 
 Config: `DUCKGRES_K8S_HEADROOM_PERCENT` (0 = disabled), placeholder pod size,
 the two PriorityClass names. Manifests add the PriorityClasses.

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1305,8 +1305,43 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
 }
 
+# Busy-only Karpenter disruption protection: a worker pod must carry
+# karpenter.sh/do-not-disrupt while a session runs (its node must not be
+# consolidation/drift-evicted mid-query) and must DROP it when parked hot-idle
+# (so WhenEmptyOrUnderutilized can reclaim idle nodes — without the removal the
+# headroom ratchet returns: annotated idle workers pin nodes forever).
+worker_disruption_annotation() { # org password
+  log "busy-only do-not-disrupt annotation on $1"
+  out="$(mktemp)"
+  ( pg_try "$1" "$2" ducklake "$HEAVY_Q" >"$out" 2>&1 ) &
+  qpid=$!
+  # While the query runs, the serving worker must be protected.
+  ann="" a=0
+  while [ "$a" -lt 90 ]; do
+    kill -0 "$qpid" 2>/dev/null || break
+    pod="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$1"           -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+    if [ -n "$pod" ]; then
+      ann="$(k get pod "$pod" -o jsonpath='{.metadata.annotations.karpenter\.sh/do-not-disrupt}' 2>/dev/null)"
+      [ "$ann" = "true" ] && break
+    fi
+    sleep 1; a=$((a + 1))
+  done
+  [ "$ann" = "true" ] || { kill "$qpid" 2>/dev/null || true; fail "worker_disruption_annotation: busy worker $pod not protected (annotation '$ann')"; }
+  wait "$qpid" 2>/dev/null || true
+
+  # Session ended -> worker parks hot-idle -> annotation must be removed.
+  a=0
+  while [ "$a" -lt 30 ]; do
+    ann="$(k get pod "$pod" -o jsonpath='{.metadata.annotations.karpenter\.sh/do-not-disrupt}' 2>/dev/null)"
+    [ -z "$ann" ] && { rm -f "$out"; log "busy-only do-not-disrupt OK on $pod"; return; }
+    sleep 2; a=$((a + 1))
+  done
+  fail "worker_disruption_annotation: hot-idle worker $pod still annotated after 60s (consolidation pinned)"
+}
+
 lane_res1() { # worker-kill resilience on its own org (heavy, churns workers)
   wait_worker "$RES1" "$res1_pw" ducklake
+  worker_disruption_annotation "$RES1" "$res1_pw"
   durability_across_restart "$RES1" "$res1_pw"
   crash_recovery         "$RES1" "$res1_pw"
   graceful_drain         "$RES1" "$res1_pw"
@@ -1403,7 +1438,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

Headroom placeholders held **~57%** of the prod-us worker nodepool at a configured **20%**, and never shrank. The target was `20% × raw allocatable`, which is self-referential: placeholders pin nodes (a node hosting one is never "Empty" → `WhenEmpty` can't reclaim it), pinned nodes inflate allocatable, the inflated total raises the target. No downward path exists.

## Fix (pairs with a charts-side consolidation change)

**1. Target math** — size against the **non-placeholder** allocatable. Only *scheduled* placeholders are subtracted (Pending ones hold no capacity yet; subtracting them would flap the target while Karpenter adds nodes). Target now tracks real worker usage and converges back down as workers finish. Floor of 1 placeholder while enabled — a pure percentage hits 0 on an idle pool, which would leave no warm slot at all.

**2. Busy-only `karpenter.sh/do-not-disrupt`** — worker pods carry the annotation only while they have work: born with it (covers spawn+activate+first session), re-added **synchronously** on every successful acquire, removed (async, best-effort) when parked hot-idle. With the nodepool on `WhenEmptyOrUnderutilized` (charts companion), Karpenter can consolidate nodes holding only idle workers/placeholders, while a node running a query is never voluntarily disrupted. Protection is bounded by **query lifetime**, not the up-to-24h worker TTL — so drift rollouts don't stall behind idle workers (verified semantics on Karpenter 1.9: the annotation blocks consolidation+drift, not scheduler preemption, so placeholder preemption keeps working).

Failure modes are benign by construction: a busy worker briefly unannotated is still backed by the #690 drain protocol; an idle worker briefly annotated delays one consolidation pass.

## Testing

- **unit**: ratchet-regression cases (`scheduled placeholders excluded from baseline`, `idle pool converges to floor` — the old formula self-sustained all 10 placeholders), annotation lifecycle (born protected → disruptable when parked → protected on reuse) on a fake clientset.
- **e2e** (`worker_disruption_annotation`, res1 lane): asserts the annotation is present on the serving worker while a query runs and removed once the worker parks hot-idle.

## Companion

charts: `duckgres-workers` nodepool `consolidationPolicy: WhenEmpty → WhenEmptyOrUnderutilized` (dev + prod-us) — follows in a separate PR; safe to merge in either order (annotation without policy = no-op protection; policy without annotation would be unsafe, so this PR must deploy FIRST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)