### PR TITLE
fix(controlplane): headroom targets worker demand; placeholders take the default worker shape

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -234,8 +234,6 @@ func main() {
 			WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 			HeadroomPercent:              resolved.K8sHeadroomPercent,
 			PlaceholderImage:             resolved.K8sPlaceholderImage,
-			PlaceholderCPU:               resolved.K8sPlaceholderCPU,
-			PlaceholderMemory:            resolved.K8sPlaceholderMemory,
 			PlaceholderPriorityClassName: resolved.K8sPlaceholderPriorityClassName,
 			WorkerProfileMinCPU:          resolved.K8sWorkerProfileMinCPU,
 			WorkerProfileMaxCPU:          resolved.K8sWorkerProfileMaxCPU,

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -115,8 +115,6 @@ type Resolved struct {
 	K8sWorkerPriorityClassName      string
 	K8sHeadroomPercent              int
 	K8sPlaceholderImage             string
-	K8sPlaceholderCPU               string
-	K8sPlaceholderMemory            string
 	K8sPlaceholderPriorityClassName string
 	K8sWorkerProfileMinCPU          string
 	K8sWorkerProfileMaxCPU          string
@@ -199,7 +197,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var k8sWorkerMaxTTL, k8sWorkerDefaultTTL time.Duration
 	var k8sWorkerPriorityClassName string
 	var k8sHeadroomPercent int
-	var k8sPlaceholderImage, k8sPlaceholderCPU, k8sPlaceholderMemory, k8sPlaceholderPriorityClassName string
+	var k8sPlaceholderImage, k8sPlaceholderPriorityClassName string
 	var k8sWorkerImage, k8sWorkerNamespace, k8sControlPlaneID string
 	var k8sWorkerPort int
 	var k8sWorkerSecret, k8sWorkerConfigMap, k8sWorkerImagePullPolicy string
@@ -882,12 +880,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_K8S_PLACEHOLDER_IMAGE"); v != "" {
 		k8sPlaceholderImage = v
 	}
-	if v := getenv("DUCKGRES_K8S_PLACEHOLDER_CPU"); v != "" {
-		k8sPlaceholderCPU = v
-	}
-	if v := getenv("DUCKGRES_K8S_PLACEHOLDER_MEMORY"); v != "" {
-		k8sPlaceholderMemory = v
-	}
 	if v := getenv("DUCKGRES_K8S_PLACEHOLDER_PRIORITY_CLASS"); v != "" {
 		k8sPlaceholderPriorityClassName = v
 	}
@@ -1223,8 +1215,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		K8sWorkerPriorityClassName:      k8sWorkerPriorityClassName,
 		K8sHeadroomPercent:              k8sHeadroomPercent,
 		K8sPlaceholderImage:             k8sPlaceholderImage,
-		K8sPlaceholderCPU:               k8sPlaceholderCPU,
-		K8sPlaceholderMemory:            k8sPlaceholderMemory,
 		K8sPlaceholderPriorityClassName: k8sPlaceholderPriorityClassName,
 		K8sWorkerProfileMinCPU:          k8sWorkerProfileMinCPU,
 		K8sWorkerProfileMaxCPU:          k8sWorkerProfileMaxCPU,

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -133,8 +133,6 @@ type K8sConfig struct {
 	// on a fresh Karpenter node. 0 = disabled.
 	HeadroomPercent              int    // % of worker-nodepool allocatable to hold free (0 = disabled)
 	PlaceholderImage             string // Image for placeholder pods (a pause image)
-	PlaceholderCPU               string // CPU request per placeholder pod (default: worker default cpu)
-	PlaceholderMemory            string // Memory request per placeholder pod (default: worker default memory)
 	PlaceholderPriorityClassName string // PriorityClass for placeholder pods — MUST rank below WorkerPriorityClassName
 
 	// Connection-string worker sizing (duckgres.worker_cpu / worker_memory /

--- a/controlplane/headroom.go
+++ b/controlplane/headroom.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -18,44 +17,41 @@ import (
 const headroomPodLabel = "duckgres-headroom"
 
 // headroomPlaceholdersNeeded returns how many placeholder pods of size
-// (phCPUMillis, phMemBytes) are required to hold `percent`% of the worker
-// nodepool's NON-PLACEHOLDER allocatable free. It's the max of the count
-// needed to cover the CPU headroom and the count needed to cover the memory
-// headroom, so both axes are satisfied. Pure (no I/O) for testability.
+// (phCPUMillis, phMemBytes) are required to hold `percent`% of the CURRENT
+// WORKER DEMAND (workerCPUMillis/workerMemBytes — the summed resource requests
+// of live worker pods) as preemptible spare capacity. It's the max of the
+// CPU-axis and memory-axis counts, so both are satisfied. Pure (no I/O).
 //
-// The capacity held by the already-SCHEDULED placeholders is subtracted
-// from allocatable before taking the percentage. Without the subtraction the
-// target is self-referential and RATCHETS: placeholders pin nodes (a node
-// hosting one is never "Empty", so WhenEmpty consolidation can't reclaim it),
-// pinned nodes inflate allocatable, inflated allocatable raises the target,
-// which creates more placeholders — observed holding ~57% of the nodepool at
-// a configured 20%. Sizing against the non-placeholder baseline makes the
-// target track real (worker) usage: as workers finish, the target falls, the
-// reconciler deletes the excess, emptied nodes consolidate, and allocatable
-// follows it down.
+// Worker demand is the only sane baseline. Sizing against node allocatable —
+// even with the placeholders' own share subtracted — still counts the FREE
+// space on nodes as "capacity that needs headroom", which is backwards: free
+// capacity IS headroom. Observed failure mode: a single over-sized node (one
+// 192-CPU consolidation artifact) demanded 11 placeholders at 5% with ZERO
+// workers running, and those placeholders then pinned the node alive. Keyed to
+// worker demand, the target tracks load by construction: zero workers -> the
+// floor; N busy CPUs -> percent of N; node geometry drops out entirely and
+// the placeholders can never feed their own target.
 //
 // Floors at 1 while headroom is enabled: a pure percentage hits zero on an
 // idle pool, which would leave no preemptible slot at all and make the first
 // spawn after an idle period fully cold — one warm slot is the point of the
 // feature.
-func headroomPlaceholdersNeeded(allocCPUMillis, allocMemBytes, phCPUMillis, phMemBytes int64, percent, scheduledPlaceholders int) int {
+func headroomPlaceholdersNeeded(workerCPUMillis, workerMemBytes, phCPUMillis, phMemBytes int64, percent int) int {
 	if percent <= 0 {
 		return 0
 	}
 	if phCPUMillis <= 0 && phMemBytes <= 0 {
 		return 0
 	}
-	baseCPU := allocCPUMillis - int64(scheduledPlaceholders)*phCPUMillis
-	baseMem := allocMemBytes - int64(scheduledPlaceholders)*phMemBytes
 	n := 1 // floor: always keep one preemptible slot while enabled
 	if phCPUMillis > 0 {
-		cpuTarget := baseCPU * int64(percent) / 100
+		cpuTarget := workerCPUMillis * int64(percent) / 100
 		if c := ceilDiv(cpuTarget, phCPUMillis); c > n {
 			n = c
 		}
 	}
 	if phMemBytes > 0 {
-		memTarget := baseMem * int64(percent) / 100
+		memTarget := workerMemBytes * int64(percent) / 100
 		if c := ceilDiv(memTarget, phMemBytes); c > n {
 			n = c
 		}
@@ -74,44 +70,47 @@ func ceilDiv(a, b int64) int {
 }
 
 // reconcileHeadroom drives the number of placeholder pods toward the configured
-// percentage of worker-nodepool allocatable. Leader-gated (called from the
-// janitor, which runs only on the elected CP). A no-op when headroomPercent<=0.
+// percentage of CURRENT WORKER DEMAND (summed live worker pod requests).
+// Leader-gated (called from the janitor, which runs only on the elected CP).
+// A no-op when headroomPercent<=0.
 //
-// Placeholders are default-worker-sized and carry a PriorityClass BELOW the
-// worker PriorityClass, so the scheduler preempts them to fit a real worker. A
-// worker larger than one placeholder preempts AS MANY placeholders as it needs
-// (standard k8s priority preemption) — e.g. a 32-core worker evicts ~4 of the
-// 8-core placeholders. The reconcile then recreates placeholders back toward the
-// target on the next tick, which makes Karpenter add node capacity in the
+// Placeholders are sized to the pool's DEFAULT WORKER SHAPE (WorkerCPURequest/
+// WorkerMemoryRequest, else the built-in defaults) — no separate sizing knob:
+// one preempted placeholder always frees exactly one default-worker slot, in
+// every environment. They carry a PriorityClass BELOW the worker
+// PriorityClass, so the scheduler preempts them to fit a real worker; a worker
+// larger than one placeholder preempts AS MANY as it needs (standard k8s
+// priority preemption). The reconcile then recreates placeholders back toward
+// the target on the next tick, which makes Karpenter add node capacity in the
 // background. So headroom self-heals after any size of spawn.
 func (p *K8sWorkerPool) reconcileHeadroom(ctx context.Context) {
 	if p.headroomPercent <= 0 {
 		return
 	}
-	phCPU, err := resource.ParseQuantity(firstNonEmpty(p.placeholderCPU, defaultWorkerCPU))
+	phCPU, err := resource.ParseQuantity(firstNonEmpty(p.workerCPURequest, defaultWorkerCPU))
 	if err != nil {
-		slog.Warn("Headroom: invalid placeholder cpu.", "value", p.placeholderCPU, "error", err)
+		slog.Warn("Headroom: invalid default worker cpu for placeholder sizing.", "value", p.workerCPURequest, "error", err)
 		return
 	}
-	phMem, err := resource.ParseQuantity(firstNonEmpty(p.placeholderMemory, defaultWorkerMemory))
+	phMem, err := resource.ParseQuantity(firstNonEmpty(p.workerMemoryRequest, defaultWorkerMemory))
 	if err != nil {
-		slog.Warn("Headroom: invalid placeholder memory.", "value", p.placeholderMemory, "error", err)
-		return
-	}
-
-	allocCPU, allocMem, err := p.workerNodepoolAllocatable(ctx)
-	if err != nil {
-		slog.Warn("Headroom: failed to read worker nodepool allocatable.", "error", err)
+		slog.Warn("Headroom: invalid default worker memory for placeholder sizing.", "value", p.workerMemoryRequest, "error", err)
 		return
 	}
 
-	existing, scheduled, err := p.listPlaceholderPods(ctx)
+	workerCPU, workerMem, err := p.activeWorkerDemand(ctx)
+	if err != nil {
+		slog.Warn("Headroom: failed to sum worker demand.", "error", err)
+		return
+	}
+
+	existing, _, err := p.listPlaceholderPods(ctx)
 	if err != nil {
 		slog.Warn("Headroom: failed to list placeholder pods.", "error", err)
 		return
 	}
 
-	desired := headroomPlaceholdersNeeded(allocCPU, allocMem, phCPU.MilliValue(), phMem.Value(), p.headroomPercent, scheduled)
+	desired := headroomPlaceholdersNeeded(workerCPU, workerMem, phCPU.MilliValue(), phMem.Value(), p.headroomPercent)
 
 	switch {
 	case len(existing) < desired:
@@ -132,25 +131,28 @@ func (p *K8sWorkerPool) reconcileHeadroom(ctx context.Context) {
 	}
 }
 
-// workerNodepoolAllocatable sums allocatable CPU (millicores) and memory (bytes)
-// across Ready nodes matching the worker nodeSelector. An empty selector means
-// all nodes (callers should configure a selector in multi-nodepool clusters).
-func (p *K8sWorkerPool) workerNodepoolAllocatable(ctx context.Context) (cpuMillis, memBytes int64, err error) {
-	opts := metav1.ListOptions{}
-	if sel := labelSelectorString(p.workerNodeSelector); sel != "" {
-		opts.LabelSelector = sel
-	}
-	nodes, err := p.clientset.CoreV1().Nodes().List(ctx, opts)
+// activeWorkerDemand sums the resource REQUESTS of live (non-terminating)
+// worker pods in the namespace — the demand baseline the headroom percentage
+// applies to. Worker pods are never BestEffort (every one carries requests),
+// so the sum is faithful. Listing by label covers all CP replicas' workers,
+// which is what the leader-only reconcile needs.
+func (p *K8sWorkerPool) activeWorkerDemand(ctx context.Context) (cpuMillis, memBytes int64, err error) {
+	pods, err := p.clientset.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=duckgres-worker",
+	})
 	if err != nil {
 		return 0, 0, err
 	}
-	for i := range nodes.Items {
-		n := &nodes.Items[i]
-		if !nodeIsReady(n) || n.Spec.Unschedulable {
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 			continue
 		}
-		cpuMillis += n.Status.Allocatable.Cpu().MilliValue()
-		memBytes += n.Status.Allocatable.Memory().Value()
+		for c := range pod.Spec.Containers {
+			req := pod.Spec.Containers[c].Resources.Requests
+			cpuMillis += req.Cpu().MilliValue()
+			memBytes += req.Memory().Value()
+		}
 	}
 	return cpuMillis, memBytes, nil
 }
@@ -239,31 +241,4 @@ func (p *K8sWorkerPool) createPlaceholderPod(ctx context.Context, cpu, mem resou
 	}
 	_, err := p.clientset.CoreV1().Pods(p.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	return err
-}
-
-func nodeIsReady(n *corev1.Node) bool {
-	for _, c := range n.Status.Conditions {
-		if c.Type == corev1.NodeReady {
-			return c.Status == corev1.ConditionTrue
-		}
-	}
-	return false
-}
-
-// labelSelectorString renders a node selector map as a comma-joined equality
-// selector ("k1=v1,k2=v2"), deterministically ordered.
-func labelSelectorString(sel map[string]string) string {
-	if len(sel) == 0 {
-		return ""
-	}
-	keys := make([]string, 0, len(sel))
-	for k := range sel {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	parts := make([]string, 0, len(keys))
-	for _, k := range keys {
-		parts = append(parts, k+"="+sel[k])
-	}
-	return strings.Join(parts, ",")
 }

--- a/controlplane/headroom_test.go
+++ b/controlplane/headroom_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -16,55 +17,38 @@ func TestHeadroomPlaceholdersNeeded(t *testing.T) {
 		gi = 1 << 30
 	)
 	tests := []struct {
-		name                          string
-		allocCPUMillis, allocMemBytes int64
-		phCPUMillis, phMemBytes       int64
-		percent                       int
-		scheduled                     int
-		want                          int
+		name                            string
+		workerCPUMillis, workerMemBytes int64
+		phCPUMillis, phMemBytes         int64
+		percent                         int
+		want                            int
 	}{
-		{name: "disabled (0%)", allocCPUMillis: 100000, allocMemBytes: 1000 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 0, want: 0},
-		// 100 cores, 200Gi alloc; 15% => 15 cores / 30Gi headroom; placeholder 8c/16Gi.
-		// cpu: ceil(15/8)=2 ; mem: ceil(30/16)=2 => 2.
-		{name: "cpu and mem both 2", allocCPUMillis: 100000, allocMemBytes: 200 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 15, want: 2},
-		// memory-bound: 100c/2000Gi, 10% => 10c/200Gi; cpu ceil(10/8)=2, mem ceil(200/16)=13 => 13.
-		{name: "memory bound", allocCPUMillis: 100000, allocMemBytes: 2000 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 10, want: 13},
-		// cpu-bound: 1000c/100Gi, 20% => 200c/20Gi; cpu ceil(200/8)=25, mem ceil(20/16)=2 => 25.
-		{name: "cpu bound", allocCPUMillis: 1000000, allocMemBytes: 100 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 20, want: 25},
-		// tiny cluster, headroom rounds up to 1 placeholder.
-		{name: "rounds up to one", allocCPUMillis: 8000, allocMemBytes: 16 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 10, want: 1},
-		// zero allocatable: the floor still asks for one placeholder — it goes
-		// Pending and pulls the first node, so an idle pool keeps a warm slot.
-		{name: "no nodes -> floor", allocCPUMillis: 0, allocMemBytes: 0, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 25, want: 1},
+		{name: "disabled (0%)", workerCPUMillis: 100000, workerMemBytes: 1000 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 0, want: 0},
+		// 100 worker cores / 200Gi demand; 15% => 15c/30Gi headroom; placeholder
+		// 8c/16Gi. cpu ceil(15/8)=2, mem ceil(30/16)=2 => 2.
+		{name: "cpu and mem both 2", workerCPUMillis: 100000, workerMemBytes: 200 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 15, want: 2},
+		// memory-bound demand: 100c/2000Gi, 10% => 10c/200Gi; mem ceil(200/16)=13.
+		{name: "memory bound", workerCPUMillis: 100000, workerMemBytes: 2000 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 10, want: 13},
+		// cpu-bound demand: 1000c/100Gi, 20% => 200c/20Gi; cpu ceil(200/8)=25.
+		{name: "cpu bound", workerCPUMillis: 1000000, workerMemBytes: 100 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 20, want: 25},
+		// IDLE POOL: zero worker demand => the floor, regardless of how many or
+		// how large the nodes currently are. This is the ratchet regression: the
+		// old node-allocatable baseline demanded 11 placeholders at 5% off one
+		// stray 192-CPU node with ZERO workers running, and those placeholders
+		// then pinned the node alive.
+		{name: "zero demand -> floor", workerCPUMillis: 0, workerMemBytes: 0, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 25, want: 1},
+		// tiny demand rounds up to the floor.
+		{name: "rounds up to one", workerCPUMillis: 800, workerMemBytes: 2 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 10, want: 1},
 		// placeholder with no size => none (guards a misconfig).
-		{name: "no placeholder size", allocCPUMillis: 100000, allocMemBytes: 200 * gi, phCPUMillis: 0, phMemBytes: 0, percent: 25, want: 0},
-		// RATCHET REGRESSION: 10 scheduled placeholders (80c/160Gi) pin nodes
-		// that inflate allocatable to 200c/400Gi. Sizing must target the
-		// non-placeholder baseline (120c/240Gi): 15% => 18c/36Gi => 3 — NOT
-		// 15% of the inflated total (=> 4, which would never shrink).
-		{name: "scheduled placeholders excluded from baseline", allocCPUMillis: 200000, allocMemBytes: 400 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 15, scheduled: 10, want: 3},
-		// Idle pool: allocatable is ONLY placeholder-held capacity => baseline
-		// 0 => floor of one warm slot (the old formula self-sustained all 10).
-		{name: "idle pool converges to floor", allocCPUMillis: 80000, allocMemBytes: 160 * gi, phCPUMillis: 8000, phMemBytes: 16 * gi, percent: 20, scheduled: 10, want: 1},
+		{name: "no placeholder size", workerCPUMillis: 100000, workerMemBytes: 200 * gi, phCPUMillis: 0, phMemBytes: 0, percent: 25, want: 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := headroomPlaceholdersNeeded(tt.allocCPUMillis, tt.allocMemBytes, tt.phCPUMillis, tt.phMemBytes, tt.percent, tt.scheduled)
+			got := headroomPlaceholdersNeeded(tt.workerCPUMillis, tt.workerMemBytes, tt.phCPUMillis, tt.phMemBytes, tt.percent)
 			if got != tt.want {
 				t.Fatalf("headroomPlaceholdersNeeded = %d, want %d", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestLabelSelectorStringDeterministic(t *testing.T) {
-	got := labelSelectorString(map[string]string{"posthog.com/nodepool": "duckgres-workers", "kubernetes.io/arch": "arm64"})
-	want := "kubernetes.io/arch=arm64,posthog.com/nodepool=duckgres-workers"
-	if got != want {
-		t.Fatalf("labelSelectorString = %q, want %q", got, want)
-	}
-	if labelSelectorString(nil) != "" {
-		t.Fatal("nil selector must render empty")
 	}
 }
 
@@ -94,5 +78,44 @@ func TestPlaceholderPodGenerateName(t *testing.T) {
 	// under the old name stay managed across a rollout.
 	if pod.Labels["app"] != "duckgres-headroom" {
 		t.Fatalf("app label = %q, want duckgres-headroom", pod.Labels["app"])
+	}
+}
+
+func TestActiveWorkerDemand(t *testing.T) {
+	// Sums live worker pod requests; excludes terminating/terminal pods and
+	// non-worker pods (placeholders must never feed the demand baseline).
+	mk := func(name string, cpu, mem string, labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: labels},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name: "duckdb-worker",
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(cpu),
+					corev1.ResourceMemory: resource.MustParse(mem),
+				}},
+			}}},
+		}
+	}
+	worker := map[string]string{"app": "duckgres-worker"}
+	terminating := mk("w-going", "4", "8Gi", worker)
+	now := metav1.Now()
+	terminating.DeletionTimestamp = &now
+	cs := fake.NewSimpleClientset(
+		mk("w1", "2", "4Gi", worker),
+		mk("w2", "750m", "1536Mi", worker),
+		terminating,
+		mk("ph", "46", "360Gi", map[string]string{"app": "duckgres-headroom"}),
+	)
+	p := &K8sWorkerPool{clientset: cs, namespace: "default"}
+	cpu, mem, err := p.activeWorkerDemand(context.Background())
+	if err != nil {
+		t.Fatalf("activeWorkerDemand: %v", err)
+	}
+	if cpu != 2750 {
+		t.Fatalf("cpu demand = %d millicores, want 2750", cpu)
+	}
+	wantMem := int64(4)<<30 + int64(1536)<<20
+	if mem != wantMem {
+		t.Fatalf("mem demand = %d, want %d", mem, wantMem)
 	}
 }

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -80,8 +80,6 @@ type K8sWorkerPool struct {
 	// immediately (preempting placeholders) instead of waiting on a fresh node.
 	headroomPercent              int
 	placeholderImage             string
-	placeholderCPU               string
-	placeholderMemory            string
 	placeholderPriorityClassName string
 
 	orgID             string                                       // org ID for pod labels (multi-tenant mode)
@@ -191,8 +189,6 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 
 		headroomPercent:              cfg.HeadroomPercent,
 		placeholderImage:             cfg.PlaceholderImage,
-		placeholderCPU:               cfg.PlaceholderCPU,
-		placeholderMemory:            cfg.PlaceholderMemory,
 		placeholderPriorityClassName: cfg.PlaceholderPriorityClassName,
 
 		orgID:             cfg.OrgID,

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -201,8 +201,6 @@ func SetupMultiTenant(
 		WorkerPriorityClassName:      cfg.K8s.WorkerPriorityClassName,
 		HeadroomPercent:              cfg.K8s.HeadroomPercent,
 		PlaceholderImage:             cfg.K8s.PlaceholderImage,
-		PlaceholderCPU:               cfg.K8s.PlaceholderCPU,
-		PlaceholderMemory:            cfg.K8s.PlaceholderMemory,
 		PlaceholderPriorityClassName: cfg.K8s.PlaceholderPriorityClassName,
 		ResolveOrgConfig: func(orgID string) (*configstore.OrgConfig, error) {
 			snap := store.Snapshot()

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -111,8 +111,6 @@ type K8sWorkerPoolConfig struct {
 	WorkerPriorityClassName      string                                       // PriorityClass for worker pods (so they preempt overprovision pause pods). Empty = none.
 	HeadroomPercent              int                                          // Keep this % of worker-nodepool allocatable CPU+mem free via low-priority placeholder pods (0 = disabled).
 	PlaceholderImage             string                                       // Image for headroom placeholder pods (a pause image).
-	PlaceholderCPU               string                                       // CPU request per placeholder pod (e.g. "8").
-	PlaceholderMemory            string                                       // Memory request per placeholder pod (e.g. "16Gi").
 	PlaceholderPriorityClassName string                                       // PriorityClass for placeholder pods — MUST be below WorkerPriorityClassName so workers preempt them.
 	OrgID                        string                                       // Org ID for pod labels (multi-tenant mode)
 	WorkerIDGenerator            func() int                                   // Shared ID generator across orgs (nil = internal counter)

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -113,10 +113,20 @@ only) it:
 - placeholder pods use a PriorityClass **below** the worker PriorityClass, so a
   real worker spawn preempts them and schedules immediately; the evicted
   placeholder triggers Karpenter to add a node in the background.
-- the placeholder target is sized against the **non-placeholder** allocatable
-  (floor: one placeholder while enabled). Sizing against raw allocatable is
-  self-referential and ratchets: placeholders pin nodes, pinned nodes inflate
-  allocatable, the inflated total raises the target.
+- the placeholder target is sized against **current worker demand** (the
+  summed requests of live worker pods), floor one placeholder while enabled.
+  Node allocatable is the wrong baseline in any form: even with the
+  placeholders' own share subtracted it counts FREE node capacity as
+  "capacity needing headroom" (free capacity IS headroom), so one stray
+  oversized node inflates the target and the placeholders pin it alive.
+  Keyed to worker demand the target tracks load by construction and node
+  geometry drops out entirely.
+- placeholders are sized to the pool's **default worker shape**
+  (`DUCKGRES_K8S_WORKER_CPU_REQUEST`/`_MEMORY_REQUEST`, else the built-in
+  default) — there is no separate placeholder sizing knob
+  (`DUCKGRES_K8S_PLACEHOLDER_CPU`/`_MEMORY` are removed). One preempted
+  placeholder always frees exactly one default-worker slot, identically in
+  every environment.
 - workers carry `karpenter.sh/do-not-disrupt` **only while busy** (set at pod
   create — covering spawn/activate and the first session — re-added per
   session, removed when parked hot-idle). With the worker nodepool on
@@ -136,7 +146,9 @@ options), `DUCKGRES_K8S_WORKER_PROFILE_MIN_CPU`/`_MAX_CPU`/`_MIN_MEMORY`/
 `_MAX_MEMORY` (clamps), `DUCKGRES_K8S_WORKER_MAX_TTL` (clamp ceiling) and
 `DUCKGRES_K8S_WORKER_DEFAULT_TTL` (the default for requests that specify no
 ttl — see the TTL resolution chain above),
-`DUCKGRES_K8S_HEADROOM_PERCENT`, `DUCKGRES_K8S_PLACEHOLDER_*`.
+`DUCKGRES_K8S_HEADROOM_PERCENT`, `DUCKGRES_K8S_PLACEHOLDER_IMAGE`/`_PRIORITY_CLASS`
+(`_PLACEHOLDER_CPU`/`_MEMORY` are removed — placeholders take the default
+worker shape).
 
 Removed: all `DUCKGRES_K8S_*COLOCATED*`, `*WORKER_TIERS*`,
 `*ALLOW_CLIENT_EXCLUSIVE_NODE*`, `*SHARED_WARM_TARGET*`,

--- a/main.go
+++ b/main.go
@@ -362,8 +362,6 @@ func main() {
 				WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 				HeadroomPercent:              resolved.K8sHeadroomPercent,
 				PlaceholderImage:             resolved.K8sPlaceholderImage,
-				PlaceholderCPU:               resolved.K8sPlaceholderCPU,
-				PlaceholderMemory:            resolved.K8sPlaceholderMemory,
 				PlaceholderPriorityClassName: resolved.K8sPlaceholderPriorityClassName,
 				WorkerProfileMinCPU:          resolved.K8sWorkerProfileMinCPU,
 				WorkerProfileMaxCPU:          resolved.K8sWorkerProfileMaxCPU,


### PR DESCRIPTION
## Live regression this fixes

After #757 deployed to mw-dev: **11 placeholders at 5% with zero workers running**. The allocatable baseline — even minus the placeholders' own share — counts free node capacity as "capacity needing headroom", which is backwards (free capacity *is* headroom). One stray 192-CPU node demanded 11 placeholders, which then pinned it alive under `WhenEmpty`.

## Changes

1. **Target = `headroomPercent% × current worker demand`** (summed requests of live worker pods, all CP replicas). Zero workers → floor of one warm slot; N busy CPUs → percent of N. Node geometry drops out entirely — the target can't be inflated by oversized nodes and can't feed itself. (Worker pods are never BestEffort since #745, so summed requests are a faithful demand signal.)

2. **Placeholder sizing knob removed** (`DUCKGRES_K8S_PLACEHOLDER_CPU`/`_MEMORY`): placeholders take the pool's **default worker shape** (`WORKER_CPU_REQUEST`/`_MEMORY_REQUEST`, else built-ins). One preempted placeholder = exactly one default-worker slot, in every env. Prod's "one placeholder = one r6gd node" stays true as a *consequence* (46/360Gi fills the node); dev derives 2/4Gi; the per-env sizing values disappear from the charts — dev and prod configs align.

## Expected effect in mw-dev

On deploy: target drops 11 → 1 on the next 5s janitor tick (zero demand → floor), 10 placeholders deleted immediately; the stray `c8gd.48xlarge` then needs charts#11980's `Underutilized` consolidation to be reclaimed (it still hosts the floor placeholder + daemonsets — or the floor placeholder lands elsewhere and the node goes Empty).

## Testing

Unit: `zero demand → floor` (the live regression), cpu/mem-bound demand cases, `activeWorkerDemand` summing (excludes terminating pods and placeholders — they must never feed their own baseline).

## Companion / ordering

Chart-side removal of `placeholderCPU`/`placeholderMemory` rides in charts#11980 (same gate: **this image live first** — the old binary's placeholder fallback is the built-in 8/16Gi, which misfits both envs once the values are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)