### PR TITLE
refactor(logging): org/worker/pod identity on every request-lifecycle log line

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -770,13 +770,17 @@ func (cp *ControlPlane) managedHostnameHint() string {
 
 func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr()
-	slog.Info("Connection accepted.", "remote_addr", remoteAddr)
+	// Connection-scoped logger: grows identity attrs as they resolve
+	// (remote_addr -> user -> org -> worker), so every line in the request
+	// lifecycle is filterable without joining log streams.
+	clog := slog.With("remote_addr", remoteAddr)
+	clog.Info("Connection accepted.")
 	server.IncrementOpenConnections()
 	defer server.DecrementOpenConnections()
 
 	releaseRateLimit, msg := server.BeginRateLimitedAuthAttempt(cp.rateLimiter, remoteAddr)
 	if msg != "" {
-		slog.Warn("Connection rejected.", "remote_addr", remoteAddr, "reason", msg)
+		clog.Warn("Connection rejected.", "reason", msg)
 		_ = conn.Close()
 		return
 	}
@@ -785,7 +789,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Set a startup read timeout to prevent goroutine leaks from clients
 	// that connect but never send data (e.g., load balancer TCP health checks).
 	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
-		slog.Error("Failed to set startup deadline.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to set startup deadline.", "error", err)
 		_ = conn.Close()
 		return
 	}
@@ -795,9 +799,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	params, err := readStartupFromRaw(conn)
 	if err != nil {
 		if err == io.EOF || errors.Is(err, io.EOF) {
-			slog.Debug("Client closed connection before sending startup message.", "remote_addr", remoteAddr)
+			clog.Debug("Client closed connection before sending startup message.")
 		} else {
-			slog.Error("Failed to read startup.", "remote_addr", remoteAddr, "error", err)
+			clog.Error("Failed to read startup.", "error", err)
 		}
 		_ = conn.Close()
 		return
@@ -813,7 +817,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Clear the startup read deadline before proceeding to TLS (which sets its own).
 	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		slog.Error("Failed to clear startup deadline.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to clear startup deadline.", "error", err)
 		_ = conn.Close()
 		return
 	}
@@ -825,14 +829,14 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			// Send a PostgreSQL error so the client sees a clear message.
 			_ = server.WriteErrorResponse(conn, "FATAL", "28000", "SSL/TLS connection required. Connect with sslmode=require or higher.")
 		}
-		slog.Warn("Connection rejected: SSL required.", "remote_addr", remoteAddr)
+		clog.Warn("Connection rejected: SSL required.")
 		_ = conn.Close()
 		return
 	}
 
 	// Send 'S' to indicate SSL support
 	if _, err := conn.Write([]byte("S")); err != nil {
-		slog.Error("Failed to send SSL response.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to send SSL response.", "error", err)
 		_ = conn.Close()
 		return
 	}
@@ -843,20 +847,20 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// TLS handshake
 	tlsConn := tls.Server(conn, cp.tlsConfig)
 	if err := tlsConn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
-		slog.Error("Failed to set TLS deadline.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to set TLS deadline.", "error", err)
 		_ = conn.Close()
 		return
 	}
 	if err := tlsConn.Handshake(); err != nil {
-		slog.Error("TLS handshake failed.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("TLS handshake failed.", "error", err)
 		_ = tlsConn.Close()
 		return
 	}
-	slog.Info("TLS connection established.", "remote_addr", remoteAddr)
+	clog.Info("TLS connection established.")
 	defer func() { _ = tlsConn.Close() }()
 
 	if err := tlsConn.SetDeadline(time.Time{}); err != nil {
-		slog.Error("Failed to clear TLS deadline.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to clear TLS deadline.", "error", err)
 		return
 	}
 
@@ -866,13 +870,14 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Read startup message (user/database)
 	startupParams, err := server.ReadStartupMessage(reader)
 	if err != nil {
-		slog.Error("Failed to read startup message.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to read startup message.", "error", err)
 		return
 	}
 
 	username := startupParams["user"]
 	database := startupParams["database"]
 	applicationName := startupParams["application_name"]
+	clog = clog.With("user", username)
 
 	// Honor a client-supplied connect-time search_path from the startup
 	// `options` parameter (libpq `options=-c search_path=...`, PGOPTIONS, or
@@ -885,7 +890,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		if sp, ok := server.SanitizeSearchPath(raw); ok {
 			clientSearchPath = sp
 		} else {
-			slog.Warn("Ignoring unsafe client search_path option.", "remote_addr", remoteAddr, "search_path", raw)
+			clog.Warn("Ignoring unsafe client search_path option.", "search_path", raw)
 		}
 	}
 
@@ -898,18 +903,18 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Request password
 	if err := server.WriteAuthCleartextPassword(writer); err != nil {
-		slog.Error("Failed to request password.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to request password.", "error", err)
 		return
 	}
 	if err := writer.Flush(); err != nil {
-		slog.Error("Failed to flush writer.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to flush writer.", "error", err)
 		return
 	}
 
 	// Read password response
 	msgType, body, err := server.ReadMessage(reader)
 	if err != nil {
-		slog.Error("Failed to read password message.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to read password message.", "error", err)
 		return
 	}
 
@@ -940,13 +945,13 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			// Identity now comes solely from the managed hostname. The legacy
 			// database→org routing is gone, so an org cannot be resolved without
 			// SNI routing enabled. Warn loudly — this is a misconfiguration.
-			slog.Warn("Postgres connection: SNI routing disabled but identity now requires a managed hostname; set sni_routing_mode=enforce.",
-				"mode", cp.cfg.SNIRoutingMode, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
+			clog.Warn("Postgres connection: SNI routing disabled but identity now requires a managed hostname; set sni_routing_mode=enforce.",
+				"mode", cp.cfg.SNIRoutingMode, "application_name", applicationName)
 		}
 		if !sniResolution.isManaged {
 			hint := cp.managedHostnameHint()
-			slog.Warn("Postgres connection rejected: SNI does not match a managed hostname.",
-				"sni", sni, "expected", hint, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
+			clog.Warn("Postgres connection rejected: SNI does not match a managed hostname.",
+				"sni", sni, "expected", hint, "application_name", applicationName)
 			_ = server.WriteErrorResponse(writer, "FATAL", "08006",
 				fmt.Sprintf("this server requires connecting via %s", hint))
 			_ = writer.Flush()
@@ -958,8 +963,8 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			observeSNIRoutingResolution("postgres", resolution.SNIAliasUsed)
 		}
 		if !resolution.SNIResolved {
-			slog.Warn("Postgres connection rejected: managed hostname does not resolve to a known organization.",
-				"sni", sni, "sni_prefix", sniResolution.sniPrefix, "remote_addr", remoteAddr, "user", username, "application_name", applicationName)
+			clog.Warn("Postgres connection rejected: managed hostname does not resolve to a known organization.",
+				"sni", sni, "sni_prefix", sniResolution.sniPrefix, "application_name", applicationName)
 			_ = server.WriteErrorResponse(writer, "FATAL", "08006",
 				fmt.Sprintf("this server requires connecting via %s", cp.managedHostnameHint()))
 			_ = writer.Flush()
@@ -968,24 +973,25 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		if !resolution.CatalogValid {
 			// The startup `database` is now a catalog selector; only
 			// "ducklake"/"iceberg"/empty are valid. No logical-name masking.
-			slog.Warn("Postgres connection rejected: requested database is not a selectable catalog.",
-				"database", database, "org", resolution.OrgID, "remote_addr", remoteAddr, "user", username)
+			clog.Warn("Postgres connection rejected: requested database is not a selectable catalog.",
+				"database", database, "org", resolution.OrgID)
 			_ = server.WriteErrorResponse(writer, "FATAL", "3D000",
 				fmt.Sprintf("database %q does not exist (connect with \"ducklake\" or \"iceberg\")", database))
 			_ = writer.Flush()
 			return
 		}
 		if !resolution.Valid {
-			slog.Warn("Authentication failed.", "user", username, "org", resolution.OrgID, "database", database, "remote_addr", remoteAddr)
+			clog.Warn("Authentication failed.", "org", resolution.OrgID, "database", database)
 			banned := server.RecordFailedAuthAttempt(cp.rateLimiter, remoteAddr)
 			if banned {
-				slog.Warn("IP banned after too many failed auth attempts.", "remote_addr", remoteAddr)
+				clog.Warn("IP banned after too many failed auth attempts.")
 			}
 			_ = server.WriteErrorResponse(writer, "FATAL", "28P01", "password authentication failed")
 			_ = writer.Flush()
 			return
 		}
 		orgID = resolution.OrgID
+		clog = clog.With("org", orgID)
 		passthroughUser = resolution.Passthrough
 		defaultCatalog = resolution.DefaultCatalog
 		requestedCatalog = resolution.EffectiveCatalog
@@ -995,10 +1001,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	} else {
 		// Single-tenant: static users map
 		if !server.ValidateUserPassword(cp.cfg.Users, username, password) {
-			slog.Warn("Authentication failed.", "user", username, "remote_addr", remoteAddr)
+			clog.Warn("Authentication failed.")
 			banned := server.RecordFailedAuthAttempt(cp.rateLimiter, remoteAddr)
 			if banned {
-				slog.Warn("IP banned after too many failed auth attempts.", "remote_addr", remoteAddr)
+				clog.Warn("IP banned after too many failed auth attempts.")
 			}
 			_ = server.WriteErrorResponse(writer, "FATAL", "28P01", "password authentication failed")
 			_ = writer.Flush()
@@ -1008,12 +1014,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Send auth OK
 	if err := server.WriteAuthOK(writer); err != nil {
-		slog.Error("Failed to send auth OK.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to send auth OK.", "error", err)
 		return
 	}
 
 	server.RecordSuccessfulAuthAttempt(cp.rateLimiter, remoteAddr)
-	slog.Info("User authenticated.", "user", username, "remote_addr", remoteAddr)
+	clog.Info("User authenticated.")
 
 	// Resolve the requested worker shape from the connection-string startup
 	// options (duckgres.worker_cpu / worker_memory / worker_ttl), layered on
@@ -1028,18 +1034,17 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	}
 	workerProfile, profileWarns, orgProfileApplied, profileErr := cp.resolveWorkerProfile(startupOptions, orgProfileDefaults)
 	if profileErr != nil {
-		slog.Warn("Rejected worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr, "error", profileErr)
+		clog.Warn("Rejected worker profile.", "error", profileErr)
 		_ = server.WriteErrorResponse(writer, "FATAL", "22023", profileErr.Error())
 		_ = writer.Flush()
 		return
 	}
 	for _, w := range profileWarns {
-		slog.Warn("Adjusted worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr, "detail", w)
+		clog.Warn("Adjusted worker profile.", "detail", w)
 	}
 	if orgProfileApplied && workerProfile != nil {
 		// Once per connection so support can see which shape a tenant got.
-		slog.Info("Applied org default worker profile.", "user", username, "org", orgID, "remote_addr", remoteAddr,
-			"cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
+		clog.Info("Applied org default worker profile.", 			"cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
 	}
 
 	// Resolve the session manager and rebalancer for this connection.
@@ -1051,7 +1056,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		// hitting a partially-migrated catalog. The client gets a clear error
 		// and can retry after the migration completes.
 		if cp.orgRouter.IsMigratingForOrg(orgID) {
-			slog.Info("Connection rejected during DuckLake migration.", "user", username, "org", orgID, "remote_addr", remoteAddr)
+			clog.Info("Connection rejected during DuckLake migration.")
 			_ = server.WriteErrorResponse(writer, "FATAL", "57P03",
 				"DuckLake catalog upgrade in progress for your organization, please retry in a few moments")
 			_ = writer.Flush()
@@ -1110,7 +1115,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	defer server.CancelClientConn(tmpCC)
 	server.SendInitialParams(tmpCC)
 	if err := writer.Flush(); err != nil {
-		slog.Error("Failed to flush initial params.", "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to flush initial params.", "error", err)
 		return
 	}
 
@@ -1138,7 +1143,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		},
 	)
 	if err != nil {
-		slog.Error("Failed to create session.", "user", username, "remote_addr", remoteAddr, "error", err)
+		clog.Error("Failed to create session.", "error", err)
 		code, message := sessionCreationErrorResponse(err)
 		_ = server.WriteErrorResponse(writer, "FATAL", code, message)
 		_ = writer.Flush()
@@ -1147,6 +1152,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Worker is now assigned — capture identity for log correlation.
 	workerID := sessions.WorkerIDForPID(pid)
 	workerPod := sessions.WorkerPodNameForPID(pid)
+	clog = clog.With("worker", workerID, "worker_pod", workerPod)
 	if orgID != "" {
 		observeOrgSessionsActive(orgID, sessions.SessionCount())
 	}
@@ -1170,7 +1176,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		probeErr = icErr
 	}
 	if probeErr != nil {
-		slog.Error("Failed to detect attached catalogs.", "user", username, "org", orgID, "remote_addr", remoteAddr, "error", probeErr, "worker", workerID, "worker_pod", workerPod)
+		clog.Error("Failed to detect attached catalogs.", "error", probeErr)
 		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect attached catalogs")
 		_ = writer.Flush()
 		return
@@ -1180,8 +1186,8 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		var ok bool
 		effectiveCatalog, ok = resolveEffectiveCatalog(requestedCatalog, defaultCatalog, duckLakeAttached, icebergAttached)
 		if !ok {
-			slog.Warn("Postgres connection rejected: requested catalog is not available for this connection.",
-				"requested", requestedCatalog, "org", orgID, "ducklake_attached", duckLakeAttached, "iceberg_attached", icebergAttached, "remote_addr", remoteAddr, "user", username)
+			clog.Warn("Postgres connection rejected: requested catalog is not available for this connection.",
+				"requested", requestedCatalog, "ducklake_attached", duckLakeAttached, "iceberg_attached", icebergAttached)
 			msg := "no catalog is available for this connection"
 			if requestedCatalog != "" {
 				msg = fmt.Sprintf("database %q does not exist", requestedCatalog)
@@ -1223,14 +1229,14 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		if icebergAttached {
 			primeCtx, primeCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
 			if err := sessionmeta.PrimeIcebergCatalog(primeCtx, executor, physicalIcebergCatalog); err != nil {
-				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "user", username, "org", orgID, "error", err, "worker", workerID, "worker_pod", workerPod)
+				clog.Warn("Failed to prime Iceberg catalog before session metadata init.", "error", err)
 			}
 			primeCancel()
 		}
 		initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
 		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, effectiveCatalog); err != nil {
 			initCancel()
-			slog.Error("Failed to initialize session database metadata.", "user", username, "org", orgID, "database", database, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+			clog.Error("Failed to initialize session database metadata.", "database", database, "error", err)
 			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
 			_ = writer.Flush()
 			return
@@ -1249,12 +1255,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			spCancel()
 			if err != nil {
 				if source == sessionDefaultSourceConfiguredCatalog {
-					slog.Error("Failed to apply session default catalog.", "user", username, "org", orgID, "catalog", effectiveCatalog, "error", err)
+					clog.Error("Failed to apply session default catalog.", "catalog", effectiveCatalog, "error", err)
 					_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply default catalog")
 					_ = writer.Flush()
 					return
 				}
-				slog.Warn("Failed to apply client connect-time search_path; using default.", "user", username, "org", orgID, "search_path", clientSearchPath, "error", err)
+				clog.Warn("Failed to apply client connect-time search_path; using default.", "search_path", clientSearchPath, "error", err)
 			}
 		}
 	} else {
@@ -1263,14 +1269,14 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		// Standalone passthrough does this via server.setDuckLakeDefault/
 		// setIcebergDefault; the remote-worker path issues the equivalent here.
 		if clientSearchPath != "" {
-			slog.Warn("Ignoring client connect-time search_path for passthrough session.", "user", username, "org", orgID, "search_path", clientSearchPath, "remote_addr", remoteAddr)
+			clog.Warn("Ignoring client connect-time search_path for passthrough session.", "search_path", clientSearchPath)
 		}
 		if cmd := passthroughSessionDefaultCatalogCommand(effectiveCatalog); cmd != "" {
 			initCtx, initCancel := context.WithTimeout(context.Background(), cp.cfg.SessionInitTimeout)
 			_, err := executor.ExecContext(initCtx, cmd)
 			initCancel()
 			if err != nil {
-				slog.Error("Failed to apply passthrough session default catalog.", "user", username, "org", orgID, "command", cmd, "error", err, "worker", workerID, "worker_pod", workerPod)
+				clog.Error("Failed to apply passthrough session default catalog.", "command", cmd, "error", err)
 				_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply default catalog")
 				_ = writer.Flush()
 				return
@@ -1304,21 +1310,21 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Send ReadyForQuery to signal that the handshake is complete
 	if err := server.WriteReadyForQuery(writer, 'I'); err != nil {
-		slog.Error("Failed to send ReadyForQuery.", "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+		clog.Error("Failed to send ReadyForQuery.", "error", err)
 		return
 	}
 	if err := writer.Flush(); err != nil {
-		slog.Error("Failed to flush writer.", "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+		clog.Error("Failed to flush writer.", "error", err)
 		return
 	}
 
 	// Run message loop
 	if err := server.RunMessageLoop(cc); err != nil {
-		slog.Error("Message loop error.", "user", username, "remote_addr", remoteAddr, "error", err, "worker", workerID, "worker_pod", workerPod)
+		clog.Error("Message loop error.", "error", err)
 		return
 	}
 
-	slog.Info("Client disconnected.", "user", username, "remote_addr", remoteAddr, "worker", workerID, "worker_pod", workerPod)
+	clog.Info("Client disconnected.")
 }
 
 // workerDuckDBLimits derives DuckDB memory_limit and threads from the worker

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -128,7 +128,7 @@ func (j *ControlPlaneJanitor) runOnce() {
 			}
 			for _, snap := range orphaned {
 				if _, err := j.lifecycle.RetireOrphanFromSnapshot(snap, janitorRetireReasonOrphaned, LifecycleOriginJanitorOrphan); err != nil {
-					slog.Warn("Janitor failed to retire orphan worker.", "worker_id", snap.WorkerID(), "error", err)
+					slog.Warn("Janitor failed to retire orphan worker.", "worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "error", err)
 				}
 			}
 		}
@@ -141,7 +141,7 @@ func (j *ControlPlaneJanitor) runOnce() {
 		} else {
 			for _, snap := range stuckWorkers {
 				if _, err := j.lifecycle.RetireFromSnapshot(snap, configstore.WorkerStateRetired, janitorRetireReasonStuckActivating, LifecycleOriginJanitorStuckActivating); err != nil {
-					slog.Warn("Janitor failed to retire stuck worker.", "worker_id", snap.WorkerID(), "error", err)
+					slog.Warn("Janitor failed to retire stuck worker.", "worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "error", err)
 				}
 			}
 		}
@@ -155,7 +155,7 @@ func (j *ControlPlaneJanitor) runOnce() {
 			}
 			for _, snap := range expired {
 				if _, err := j.lifecycle.RetireFromSnapshot(snap, configstore.WorkerStateRetired, "hot_idle_ttl_expired", LifecycleOriginJanitorHotIdleTTL); err != nil {
-					slog.Warn("Janitor failed to retire hot-idle worker.", "worker_id", snap.WorkerID(), "error", err)
+					slog.Warn("Janitor failed to retire hot-idle worker.", "worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "error", err)
 				}
 			}
 		}

--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -44,7 +44,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*M
 		if idle != nil {
 			idle.claimSessionLocked()
 			p.mu.Unlock()
-			slog.Debug("Reusing idle worker.", "worker", idle.ID, "active_sessions", idle.activeSessions)
+			slog.Debug("Reusing idle worker.", append(workerLogAttrs(idle), "active_sessions", idle.activeSessions)...)
 			return idle, nil
 		}
 
@@ -80,7 +80,7 @@ func (p *K8sWorkerPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*M
 			p.spawning++
 			p.mu.Unlock()
 
-			slog.Info("No live workers, blocking on spawn.", "worker", id)
+			p.logw(id).Info("No live workers, blocking on spawn.")
 			err := p.SpawnWorker(ctx, id, p.workerImage)
 
 			p.mu.Lock()
@@ -292,7 +292,7 @@ func (p *K8sWorkerPool) reserveSharedWorkerDecision(assignment *WorkerAssignment
 			// filtered by image, so still retire on a version mismatch (e.g.
 			// after an image bump) rather than serve a stale-version worker.
 			if assignment.Image != "" && hotClaimed.Image != assignment.Image {
-				slog.Info("Hot-idle worker image mismatch, retiring mismatched worker.", "worker_id", hotClaimed.WorkerID, "expected", assignment.Image, "got", hotClaimed.Image)
+				slog.Info("Hot-idle worker image mismatch, retiring mismatched worker.", "worker", hotClaimed.WorkerID, "worker_pod", hotClaimed.PodName, "org", assignment.OrgID, "expected", assignment.Image, "got", hotClaimed.Image)
 				p.retireClaimedWorker(hotClaimed, RetireReasonMismatchedVersion, LifecycleOriginReserveImageMismatch)
 				// Fall through to the spawning-slot decision or capacity backpressure.
 			} else {
@@ -348,10 +348,10 @@ func (p *K8sWorkerPool) completeSharedWorkerReservation(ctx context.Context, cla
 			return worker, false, nil
 		}
 		if stderrors.Is(reserveErr, errStaleRuntimeWorkerClaim) {
-			slog.Warn("Hot-idle worker claim was stale, retrying.", "worker_id", claim.hotClaimed.WorkerID, "error", reserveErr)
+			slog.Warn("Hot-idle worker claim was stale, retrying.", "worker", claim.hotClaimed.WorkerID, "worker_pod", claim.hotClaimed.PodName, "org", claim.hotClaimed.OrgID, "error", reserveErr)
 			return nil, true, reserveErr
 		}
-		slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker_id", claim.hotClaimed.WorkerID, "error", reserveErr)
+		slog.Warn("Hot-idle worker could not be reserved, retiring.", "worker", claim.hotClaimed.WorkerID, "worker_pod", claim.hotClaimed.PodName, "org", claim.hotClaimed.OrgID, "error", reserveErr)
 		p.retireClaimedWorker(claim.hotClaimed, RetireReasonCrash, LifecycleOriginReserveFailure)
 		// Pre-split ReserveSharedWorker fell through to a fresh spawn here; the
 		// retry re-runs the decision, which lands on the spawning-slot path.
@@ -438,7 +438,7 @@ func (p *K8sWorkerPool) reserveClaimedWorker(ctx context.Context, claimed *confi
 		_ = p.persistWorkerRecord(reservedRecord)
 	}
 	if err := p.checkReservedWorkerLiveness(ctx, worker); err != nil {
-		slog.Warn("Claimed worker failed liveness recheck.", "worker", worker.ID, "worker_pod", worker.PodName(), "error", err)
+		slog.Warn("Claimed worker failed liveness recheck.", append(workerLogAttrs(worker), "error", err)...)
 		p.retireWorkerWithReason(worker.ID, RetireReasonCrash, LifecycleOriginReserveFailure)
 		return nil, err
 	}

--- a/controlplane/k8s_pool_helpers.go
+++ b/controlplane/k8s_pool_helpers.go
@@ -184,3 +184,31 @@ func trimK8sPodHashSuffix(name string) string {
 	}
 	return name[:idx]
 }
+
+// workerLogAttrs returns the standard identity attrs for a worker log line:
+// worker id, pod name, and the assigned org (when tenant-bound). Every log
+// line in a worker's lifecycle should carry these so the full history of one
+// worker — or one org's workers — is filterable without joins.
+func workerLogAttrs(w *ManagedWorker) []any {
+	if w == nil {
+		return nil
+	}
+	attrs := []any{"worker", w.ID}
+	if pod := w.PodName(); pod != "" {
+		attrs = append(attrs, "worker_pod", pod)
+	}
+	if a := w.SharedState().Assignment; a != nil && a.OrgID != "" {
+		attrs = append(attrs, "org", a.OrgID)
+	}
+	return attrs
+}
+
+// logw returns a logger pre-scoped with the worker's identity attrs (see
+// workerLogAttrs), resolved by id. For workers no longer tracked locally it
+// still carries the id, so the line stays attributable.
+func (p *K8sWorkerPool) logw(id int) *slog.Logger {
+	if w, ok := p.Worker(id); ok {
+		return slog.With(workerLogAttrs(w)...)
+	}
+	return slog.With("worker", id)
+}

--- a/controlplane/k8s_pool_lifecycle.go
+++ b/controlplane/k8s_pool_lifecycle.go
@@ -120,14 +120,13 @@ func (p *K8sWorkerPool) RetireIfDrainingAndEmpty(id int, origin LifecycleOrigin)
 		lease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch(), w.image)
 		outcome, err := lifecycle.RetireDrained(lease, RetireReasonNormal, origin)
 		if err != nil {
-			slog.Warn("RetireIfDrainingAndEmpty: CAS to retired failed; orphan sweep will reconcile.",
-				"worker_id", id, "error", err)
+			p.logw(id).Warn("RetireIfDrainingAndEmpty: CAS to retired failed; orphan sweep will reconcile.",
+				"error", err)
 			p.mu.Unlock()
 			return
 		}
 		if !outcome.Transitioned {
-			slog.Debug("RetireIfDrainingAndEmpty: retire-drained CAS missed; orphan sweep will reconcile.",
-				"worker_id", id)
+			p.logw(id).Debug("RetireIfDrainingAndEmpty: retire-drained CAS missed; orphan sweep will reconcile.")
 			p.mu.Unlock()
 			return
 		}
@@ -198,8 +197,8 @@ func (p *K8sWorkerPool) retireClaimedWorker(claimed *configstore.WorkerRecord, r
 	// the WorkerPhysicalCleanup (this pool's DeleteWorkerArtifacts).
 	snap := configstore.NewWorkerSnapshot(*claimed)
 	if _, err := lifecycle.RetireFromSnapshot(snap, terminalState, reason, origin); err != nil {
-		slog.Warn("Failed to retire claimed worker.",
-			"worker_id", claimed.WorkerID, "reason", reason, "origin", origin, "error", err)
+		p.logw(claimed.WorkerID).Warn("Failed to retire claimed worker.",
+			"reason", reason, "origin", origin, "error", err)
 	}
 }
 
@@ -295,12 +294,12 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 
 						removedWorker, workerCount, err := p.removeWorkerAfterDrainedLease(lease, LifecycleOriginWorkerDrain)
 						if err != nil {
-							slog.Error("K8s worker terminated after draining but retire CAS failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							p.logw(lease.workerID).Error("K8s worker terminated after draining but retire CAS failed; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
 							return
 						}
 						if removedWorker != nil {
 							observeControlPlaneWorkers(workerCount)
-							slog.Info("K8s worker terminated after draining.", "id", lease.workerID)
+							p.logw(lease.workerID).Info("K8s worker terminated after draining.")
 							if removedWorker.client != nil {
 								_ = removedWorker.client.Close()
 							}
@@ -309,11 +308,11 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 
 						lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginInformerCrash)
 						if err != nil {
-							slog.Error("K8s worker terminated but lease validation failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							p.logw(lease.workerID).Error("K8s worker terminated but lease validation failed; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
 							return
 						}
 						if lostDisposition == workerLostLeaseRetry {
-							slog.Warn("K8s worker terminated while runtime lease is newer for this CP; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
+							p.logw(lease.workerID).Warn("K8s worker terminated while runtime lease is newer for this CP; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
 							return
 						}
 						if lostDisposition == workerLostLeaseStale {
@@ -324,7 +323,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 								return
 							}
 							observeControlPlaneWorkers(workerCount)
-							slog.Warn("K8s worker terminated under stale lease; dropping local worker without pod delete.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
+							p.logw(lease.workerID).Warn("K8s worker terminated under stale lease; dropping local worker without pod delete.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch)
 							if removedWorker.client != nil {
 								_ = removedWorker.client.Close()
 							}
@@ -338,7 +337,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 							return
 						}
 						observeControlPlaneWorkers(workerCount)
-						slog.Warn("K8s worker crashed.", "id", lease.workerID)
+						p.logw(lease.workerID).Warn("K8s worker crashed.")
 						if onCrash != nil {
 							onCrash(lease.workerID)
 						}
@@ -386,29 +385,27 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 						if healthErr != nil {
 							if p.workerLeaseLocallyDraining(lease) {
 								if p.workerLeaseDurablyDrainingOrRepair(lease) {
-									slog.Warn("K8s worker health check failed while worker is draining; waiting for pod exit.",
-										"id", lease.workerID, "error", healthErr)
+									p.logw(lease.workerID).Warn("K8s worker health check failed while worker is draining; waiting for pod exit.", "error", healthErr)
 									return
 								}
-								slog.Warn("K8s worker health check failed while worker is locally draining but durable state is not draining; treating as health failure.",
-									"id", lease.workerID, "error", healthErr)
+								p.logw(lease.workerID).Warn("K8s worker health check failed while worker is locally draining but durable state is not draining; treating as health failure.", "error", healthErr)
 							}
 							mu.Lock()
 							failures[lease]++
 							count := failures[lease]
 							mu.Unlock()
 
-							slog.Warn("K8s worker health check failed.", "id", lease.workerID, "error", healthErr, "consecutive_failures", count)
+							p.logw(lease.workerID).Warn("K8s worker health check failed.", "error", healthErr, "consecutive_failures", count)
 
 							if count >= maxConsecutiveHealthFailures {
 								lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginHealthCheckCrash)
 								if err != nil {
-									slog.Error("K8s worker unresponsive but lease validation failed; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count, "error", err)
+									p.logw(lease.workerID).Error("K8s worker unresponsive but lease validation failed; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count, "error", err)
 									return
 								}
 
 								if lostDisposition == workerLostLeaseRetry {
-									slog.Warn("K8s worker unresponsive while runtime lease is newer for this CP; leaving cleanup to retry.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
+									p.logw(lease.workerID).Warn("K8s worker unresponsive while runtime lease is newer for this CP; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
 									return
 								}
 
@@ -424,7 +421,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 										return
 									}
 									observeControlPlaneWorkers(workerCount)
-									slog.Warn("K8s worker unresponsive under stale lease; dropping local worker without crash notification or pod delete.", "id", lease.workerID, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
+									p.logw(lease.workerID).Warn("K8s worker unresponsive under stale lease; dropping local worker without crash notification or pod delete.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "consecutive_failures", count)
 									if removedWorker.client != nil {
 										_ = removedWorker.client.Close()
 									}
@@ -439,7 +436,7 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 								}
 								observeControlPlaneWorkers(workerCount)
 
-								slog.Error("K8s worker unresponsive, deleting pod.", "id", lease.workerID, "consecutive_failures", count)
+								p.logw(lease.workerID).Error("K8s worker unresponsive, deleting pod.", "consecutive_failures", count)
 								if onCrash != nil {
 									onCrash(lease.workerID)
 								}
@@ -532,13 +529,12 @@ func (p *K8sWorkerPool) ShutdownAll() {
 		// connection (the CP socket is going away) — protecting the
 		// worker doesn't help them, but it doesn't hurt either.
 		if w.activeSessions > 0 {
-			slog.Info("ShutdownAll: worker has active sessions; leaving pod alive for Flight reconnect.",
-				"id", w.ID, "worker_pod", podName, "active_sessions", w.activeSessions)
+			p.logw(w.ID).Info("ShutdownAll: worker has active sessions; leaving pod alive for Flight reconnect.", "worker_pod", podName, "active_sessions", w.activeSessions)
 			preserved[w.ID] = w
 			continue
 		}
 
-		slog.Info("Shutting down K8s worker.", "id", w.ID, "worker_pod", podName)
+		p.logw(w.ID).Info("Shutting down K8s worker.", "worker_pod", podName)
 
 		// Step 1: CAS to draining. Skip the worker on CAS miss or error —
 		// there's no safe way to proceed if we don't own the row.
@@ -565,13 +561,12 @@ func (p *K8sWorkerPool) ShutdownAll() {
 			lease := configstore.NewWorkerLease(w.ID, p.cpInstanceID, w.OwnerEpoch(), w.image)
 			outcome, err := lifecycle.Drain(lease, LifecycleOriginShutdownAll)
 			if err != nil {
-				slog.Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
-					"worker_id", w.ID, "error", err)
+				p.logw(w.ID).Warn("ShutdownAll: CAS to draining failed; orphan sweep will reconcile.",
+					"error", err)
 				return false
 			}
 			if !outcome.Transitioned {
-				slog.Debug("ShutdownAll: worker not owned by us or already terminal; skipping.",
-					"worker_id", w.ID)
+				p.logw(w.ID).Debug("ShutdownAll: worker not owned by us or already terminal; skipping.")
 				return false
 			}
 
@@ -586,8 +581,7 @@ func (p *K8sWorkerPool) ShutdownAll() {
 			if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 				GracePeriodSeconds: &gracePeriod,
 			}); err != nil && !errors.IsNotFound(err) {
-				slog.Warn("ShutdownAll: pod delete failed; worker left in draining for orphan sweep/reconciler.",
-					"id", w.ID, "worker_pod", podName, "error", err)
+				p.logw(w.ID).Warn("ShutdownAll: pod delete failed; worker left in draining for orphan sweep/reconciler.", "worker_pod", podName, "error", err)
 				if w.client != nil {
 					_ = w.client.Close()
 				}
@@ -614,11 +608,10 @@ func (p *K8sWorkerPool) ShutdownAll() {
 			retireOutcome, err := lifecycle.RetireDrained(lateLease, RetireReasonShutdown, LifecycleOriginShutdownAll)
 			switch {
 			case err != nil:
-				slog.Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile durable row.",
-					"worker_id", w.ID, "error", err)
+				p.logw(w.ID).Warn("ShutdownAll: CAS to retired failed; orphan sweep will reconcile durable row.",
+					"error", err)
 			case !retireOutcome.Transitioned:
-				slog.Debug("ShutdownAll: retire-drained CAS missed; orphan sweep will reconcile durable row.",
-					"worker_id", w.ID)
+				p.logw(w.ID).Debug("ShutdownAll: retire-drained CAS missed; orphan sweep will reconcile durable row.")
 			}
 			return true
 		}()
@@ -653,7 +646,7 @@ func (p *K8sWorkerPool) retireWorkerPod(id int, w *ManagedWorker) {
 	defer func() { <-p.retireSem }()
 
 	podName := p.workerPodName(w)
-	slog.Info("Retiring K8s worker.", "id", id, "worker_pod", podName)
+	p.logw(id).Info("Retiring K8s worker.", "worker_pod", podName)
 	if w.client != nil {
 		_ = w.client.Close()
 	}
@@ -662,10 +655,10 @@ func (p *K8sWorkerPool) retireWorkerPod(id int, w *ManagedWorker) {
 	if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, podName, metav1.DeleteOptions{
 		GracePeriodSeconds: int64Ptr(10),
 	}); err != nil {
-		slog.Warn("Failed to delete worker pod.", "id", id, "worker_pod", podName, "error", err)
+		p.logw(id).Warn("Failed to delete worker pod.", "worker_pod", podName, "error", err)
 	}
 	if err := p.deleteWorkerRPCSecret(ctx, podName); err != nil {
-		slog.Warn("Failed to delete worker RPC secret.", "id", id, "worker_pod", podName, "error", err)
+		p.logw(id).Warn("Failed to delete worker RPC secret.", "worker_pod", podName, "error", err)
 	}
 }
 
@@ -813,8 +806,7 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 					if lc != nil {
 						retired, err := p.retireLocalDrainingLease(lease, RetireReasonNormal, LifecycleOriginInformerCrash)
 						if err != nil {
-							slog.Warn("Clean dead worker: retire draining CAS failed; leaving cleanup to retry.",
-								"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+							p.logw(id).Warn("Clean dead worker: retire draining CAS failed; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
 							continue
 						}
 						if !retired {
@@ -831,8 +823,7 @@ func (p *K8sWorkerPool) cleanDeadWorkersLocked() {
 					// OOM, manual delete), not our health-check decision.
 					lostDisposition, err := p.markWorkerLostForHealthLease(lease, LifecycleOriginInformerCrash)
 					if err != nil {
-						slog.Warn("Clean dead worker: lease validation failed; leaving cleanup to retry.",
-							"id", id, "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
+						p.logw(id).Warn("Clean dead worker: lease validation failed; leaving cleanup to retry.", "owner_cp_instance_id", lease.ownerCPInstanceID, "owner_epoch", lease.ownerEpoch, "error", err)
 						continue
 					}
 					switch lostDisposition {
@@ -969,8 +960,7 @@ func (p *K8sWorkerPool) markWorkerLostIfCurrentLease(lease workerLeaseSnapshot, 
 	outcome, err := lc.MarkLostFromLease(
 		configstore.NewWorkerLease(lease.workerID, p.cpInstanceID, lease.ownerEpoch, lease.image),
 		RetireReasonCrash,
-		origin,
-	)
+		origin)
 	if err != nil {
 		return false, err
 	}
@@ -994,8 +984,8 @@ func (p *K8sWorkerPool) workerLeaseDurablyDrainingOrRepair(lease workerLeaseSnap
 	}
 	record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
 	if err != nil {
-		slog.Warn("K8s worker health check failed while worker is locally draining, but durable worker record could not be verified.",
-			"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+		p.logw(lease.workerID).Warn("K8s worker health check failed while worker is locally draining, but durable worker record could not be verified.",
+			"owner_epoch", lease.ownerEpoch, "error", err)
 		return false
 	}
 	if record == nil || record.OwnerCPInstanceID != lease.ownerCPInstanceID || record.OwnerEpoch != lease.ownerEpoch {
@@ -1007,11 +997,10 @@ func (p *K8sWorkerPool) workerLeaseDurablyDrainingOrRepair(lease workerLeaseSnap
 
 	outcome, err := lc.Drain(
 		configstore.NewWorkerLease(lease.workerID, lease.ownerCPInstanceID, lease.ownerEpoch, lease.image),
-		LifecycleOriginWorkerDrain,
-	)
+		LifecycleOriginWorkerDrain)
 	if err != nil {
-		slog.Warn("K8s worker health check failed while worker is locally draining, but durable drain repair failed.",
-			"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+		p.logw(lease.workerID).Warn("K8s worker health check failed while worker is locally draining, but durable drain repair failed.",
+			"owner_epoch", lease.ownerEpoch, "error", err)
 		return false
 	}
 	if outcome.Transitioned {
@@ -1020,8 +1009,8 @@ func (p *K8sWorkerPool) workerLeaseDurablyDrainingOrRepair(lease workerLeaseSnap
 
 	record, err = p.runtimeStore.GetWorkerRecord(lease.workerID)
 	if err != nil {
-		slog.Warn("K8s worker health check failed while worker is locally draining, but durable worker record could not be verified after repair miss.",
-			"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+		p.logw(lease.workerID).Warn("K8s worker health check failed while worker is locally draining, but durable worker record could not be verified after repair miss.",
+			"owner_epoch", lease.ownerEpoch, "error", err)
 		return false
 	}
 	return record != nil &&
@@ -1052,8 +1041,8 @@ func (p *K8sWorkerPool) markWorkerDrainingFromHealth(lease workerLeaseSnapshot) 
 		next, err := previous.Transition(WorkerLifecycleDraining, previous.Assignment)
 		if err != nil {
 			p.mu.Unlock()
-			slog.Warn("Worker reported draining but local lifecycle transition failed.",
-				"worker_id", lease.workerID, "state", previous.NormalizedLifecycle(), "error", err)
+			p.logw(lease.workerID).Warn("Worker reported draining but local lifecycle transition failed.",
+				"state", previous.NormalizedLifecycle(), "error", err)
 			return
 		}
 		w.sharedState = next
@@ -1081,8 +1070,8 @@ func (p *K8sWorkerPool) markWorkerDrainingFromHealth(lease workerLeaseSnapshot) 
 		if alreadyDraining {
 			record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
 			if err != nil {
-				slog.Warn("Worker reported draining but durable worker record could not be verified.",
-					"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+				p.logw(lease.workerID).Warn("Worker reported draining but durable worker record could not be verified.",
+					"owner_epoch", lease.ownerEpoch, "error", err)
 				return
 			}
 			if record == nil || record.OwnerCPInstanceID != p.cpInstanceID || record.OwnerEpoch != lease.ownerEpoch {
@@ -1095,18 +1084,17 @@ func (p *K8sWorkerPool) markWorkerDrainingFromHealth(lease workerLeaseSnapshot) 
 		}
 		outcome, err := lc.Drain(
 			configstore.NewWorkerLease(lease.workerID, p.cpInstanceID, lease.ownerEpoch, lease.image),
-			LifecycleOriginWorkerDrain,
-		)
+			LifecycleOriginWorkerDrain)
 		if err != nil {
-			slog.Warn("Worker reported draining but durable drain CAS failed; keeping local worker schedulable until retry.",
-				"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+			p.logw(lease.workerID).Warn("Worker reported draining but durable drain CAS failed; keeping local worker schedulable until retry.",
+				"owner_epoch", lease.ownerEpoch, "error", err)
 			return
 		}
 		if !outcome.Transitioned {
 			record, err := p.runtimeStore.GetWorkerRecord(lease.workerID)
 			if err != nil {
-				slog.Warn("Worker reported draining but durable worker record could not be verified after CAS miss.",
-					"worker_id", lease.workerID, "owner_epoch", lease.ownerEpoch, "error", err)
+				p.logw(lease.workerID).Warn("Worker reported draining but durable worker record could not be verified after CAS miss.",
+					"owner_epoch", lease.ownerEpoch, "error", err)
 				return
 			}
 			if record == nil || record.OwnerCPInstanceID != p.cpInstanceID || record.OwnerEpoch != lease.ownerEpoch || record.State != configstore.WorkerStateDraining {
@@ -1260,8 +1248,7 @@ func (p *K8sWorkerPool) markWorkerRetiredLocked(w *ManagedWorker, reason string,
 			LifecycleOpRetireLocal,
 			outcome,
 			w.image,
-			origin,
-		)
+			origin)
 		return false
 	}
 	// markWorkerRetiredInMemoryLocked returns false only when the
@@ -1284,8 +1271,7 @@ func (p *K8sWorkerPool) markWorkerRetiredLocked(w *ManagedWorker, reason string,
 		LifecycleOpRetireLocal,
 		configstore.TransitionOutcomeTransitioned,
 		w.image,
-		origin,
-	)
+		origin)
 	return true
 }
 

--- a/controlplane/k8s_pool_reconcile.go
+++ b/controlplane/k8s_pool_reconcile.go
@@ -72,7 +72,7 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 			var err error
 			snap, err = p.runtimeStore.ObserveWorker(workerID)
 			if err != nil {
-				slog.Warn("Version-aware reaper failed to observe worker.", "worker_id", workerID, "error", err)
+				slog.Warn("Version-aware reaper failed to observe worker.", "worker", workerID, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "error", err)
 			}
 		}
 
@@ -123,7 +123,7 @@ func (p *K8sWorkerPool) RetireOneMismatchedVersionWorker(ctx context.Context) bo
 		}
 		outcome, err := lifecycle.RetireIdleVariantFromSnapshot(*snap, RetireReasonMismatchedVersion, LifecycleOriginMismatchedVersionReaper)
 		if err != nil {
-			slog.Warn("Version-aware reaper failed to retire idle row.", "worker_id", workerID, "error", err)
+			slog.Warn("Version-aware reaper failed to retire idle row.", "worker", workerID, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "error", err)
 			continue
 		}
 		if !outcome.Transitioned {
@@ -215,7 +215,7 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods(ctx context.Context, minAge ti
 		}
 		rec, err := p.runtimeStore.GetWorkerRecord(workerID)
 		if err != nil {
-			slog.Warn("Stranded-pod reconciler failed to load worker record.", "worker_id", workerID, "error", err)
+			slog.Warn("Stranded-pod reconciler failed to load worker record.", "worker", workerID, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "error", err)
 			continue
 		}
 		dbState := "missing"
@@ -236,12 +236,12 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods(ctx context.Context, minAge ti
 		if err := p.clientset.CoreV1().Pods(p.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriod,
 		}); err != nil && !errors.IsNotFound(err) {
-			slog.Warn("Stranded-pod reconciler failed to delete pod.", "worker_pod", pod.Name, "worker_id", workerID, "error", err)
+			slog.Warn("Stranded-pod reconciler failed to delete pod.", "worker", workerID, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "error", err)
 			observeStrandedPodReconciled(StrandedOutcomeDeleteFailed)
 			continue
 		}
 		_ = p.deleteWorkerRPCSecret(ctx, pod.Name)
-		slog.Info("Stranded worker pod reconciled.", "worker_pod", pod.Name, "worker_id", workerID, "db_state", dbState)
+		slog.Info("Stranded worker pod reconciled.", "worker", workerID, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "db_state", dbState)
 		observeStrandedPodReconciled(outcome)
 		deleted++
 	}
@@ -400,7 +400,7 @@ func (p *K8sWorkerPool) onPodTerminated(pod *corev1.Pod) {
 	case <-w.done:
 		// Already closed
 	default:
-		slog.Warn("Worker pod terminated.", "id", id, "worker_pod", pod.Name, "phase", pod.Status.Phase)
+		slog.Warn("Worker pod terminated.", "worker", id, "worker_pod", pod.Name, "org", pod.Labels["duckgres/active-org"], "phase", pod.Status.Phase)
 		close(w.done)
 	}
 }

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -350,7 +350,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	}
 	observeControlPlaneWorkers(workerCount)
 
-	slog.Info("K8s worker spawned.", "id", id, "worker_pod", podName, "addr", addr)
+	p.logw(id).Info("K8s worker spawned.", "addr", addr)
 	return nil
 }
 
@@ -537,7 +537,7 @@ func (p *K8sWorkerPool) spawnWorkerBackground(id int, image string) {
 	p.mu.Unlock()
 
 	if err != nil {
-		slog.Warn("Background worker spawn failed.", "worker", id, "error", err)
+		p.logw(id).Warn("Background worker spawn failed.", "error", err)
 	}
 }
 

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -136,7 +136,7 @@ func (tr *OrgRouter) createOrgStack(tc *configstore.OrgConfig) (*OrgStack, error
 	// In K8s mode, DuckDB auto-detects memory from the container's cgroup limits.
 	// Pass 0/false to disable budget-based rebalancing.
 	rebalancer := NewMemoryRebalancer(0, 0, nil, false)
-	sessions := NewSessionManager(pool, rebalancer)
+	sessions := NewOrgSessionManager(pool, rebalancer, tc.Name)
 	if tr.userSecrets != nil {
 		sessions.SetUserSecretLoader(tr.userSecrets.SessionSecretLoader(tc.Name))
 	}

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -54,6 +54,9 @@ type SessionManager struct {
 	pool       WorkerPool
 	rebalancer *MemoryRebalancer
 	lifecycle  *sessionLifecycle
+	// log carries the manager's org identity (multi-tenant: one manager per
+	// org stack) so every session/worker lifecycle line is org-filterable.
+	log *slog.Logger
 
 	nextPID atomic.Int32
 
@@ -81,12 +84,23 @@ type connectionWaiter struct {
 
 // NewSessionManager creates a new session manager.
 func NewSessionManager(pool WorkerPool, rebalancer *MemoryRebalancer) *SessionManager {
+	return NewOrgSessionManager(pool, rebalancer, "")
+}
+
+// NewOrgSessionManager builds a SessionManager whose log lines all carry the
+// owning org (multi-tenant remote backend: one manager per org stack).
+func NewOrgSessionManager(pool WorkerPool, rebalancer *MemoryRebalancer, orgID string) *SessionManager {
+	log := slog.Default()
+	if orgID != "" {
+		log = log.With("org", orgID)
+	}
 	sm := &SessionManager{
 		sessions:   make(map[int32]*ManagedSession),
 		byWorker:   make(map[int][]int32),
 		pool:       pool,
 		rebalancer: rebalancer,
 		lifecycle:  newSessionLifecycle(),
+		log:        log,
 	}
 	sm.nextPID.Store(1000) // Start PIDs above typical OS PIDs
 	return sm
@@ -284,7 +298,7 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 
 		acquireStart := time.Now()
 		actx, acquireSpan := server.Tracer().Start(ctx, "duckgres.worker_acquire")
-		slog.Debug("Acquiring worker for session.", "pid", pid, "user", username, "attempt", attempt)
+		sm.log.Debug("Acquiring worker for session.", "pid", pid, "user", username, "attempt", attempt)
 		worker, err := sm.pool.AcquireWorker(actx, profile)
 		if err != nil {
 			var capacityErr *WorkerCapacityExhaustedError
@@ -296,7 +310,7 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 					attribute.String("worker_capacity.reason", string(missReason)),
 					attribute.Int("worker_capacity.retry_after_seconds", capacityRetrySeconds(capacityErr.RetryAfter)),
 				)
-				slog.Warn("Worker acquisition failed.",
+				sm.log.Warn("Worker acquisition failed.",
 					"pid", pid,
 					"user", username,
 					"duration", time.Since(acquireStart),
@@ -310,7 +324,7 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 			return 0, nil, fmt.Errorf("acquire worker: %w", err)
 		}
 		acquireSpan.End()
-		slog.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
+		sm.log.Debug("Worker acquired.", "pid", pid, "worker", worker.ID, "user", username, "duration", time.Since(acquireStart))
 
 		newPID, exec, err := sm.createSessionOnWorker(actx, username, pid, memoryLimit, threads, worker, protocol, true, lease)
 		if err == nil {
@@ -327,7 +341,7 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 		// with a fresh worker. Loud ERROR + metric so we can find and fix the drift.
 		lastCapDriftErr = err
 		observeWorkerSessionCapDrift()
-		slog.Error("Worker rejected a CP-scheduled session at its session cap — one-session-per-worker accounting drift; recycling worker and re-acquiring.",
+		sm.log.Error("Worker rejected a CP-scheduled session at its session cap — one-session-per-worker accounting drift; recycling worker and re-acquiring.",
 			"pid", pid,
 			"user", username,
 			"worker", worker.ID,
@@ -409,7 +423,7 @@ func (sm *SessionManager) beginSessionCreation(ctx context.Context) (context.Con
 
 func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username string, pid int32, memoryLimit string, threads int, worker *ManagedWorker, protocol string, retireOnFailure bool, lease connectionLease) (int32, *flightclient.FlightExecutor, error) {
 	createStart := time.Now()
-	slog.Info("Creating session on worker.",
+	sm.log.Info("Creating session on worker.",
 		"pid", pid,
 		"worker", worker.ID,
 		"user", username,
@@ -428,14 +442,14 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 		var secretErr error
 		secretStatements, secretErr = sm.userSecretLoader(ctx, username)
 		if secretErr != nil {
-			slog.Error("Failed to load user persistent secrets; session starts without them.",
+			sm.log.Error("Failed to load user persistent secrets; session starts without them.",
 				"pid", pid, "worker", worker.ID, "user", username, "error", secretErr)
 		}
 	}
 
 	sessionToken, secretWarnings, err := worker.CreateSession(ctx, username, memoryLimit, threads, secretStatements)
 	if err != nil {
-		slog.Warn("Failed to create session on worker.",
+		sm.log.Warn("Failed to create session on worker.",
 			"pid", pid,
 			"worker", worker.ID,
 			"user", username,
@@ -451,7 +465,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	}
 
 	for _, w := range secretWarnings {
-		slog.Warn("User persistent secret replay warning.",
+		sm.log.Warn("User persistent secret replay warning.",
 			"pid", pid, "worker", worker.ID, "user", username, "warning", w)
 	}
 
@@ -483,7 +497,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	workerSessionCount := len(sm.byWorker[worker.ID])
 	sm.mu.Unlock()
 
-	slog.Info("Session created on worker.",
+	sm.log.Info("Session created on worker.",
 		"pid", pid,
 		"worker", worker.ID,
 		"user", username,
@@ -507,7 +521,7 @@ func (sm *SessionManager) cleanupUnregisteredWorkerSession(worker *ManagedWorker
 		default:
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			if err := worker.DestroySession(ctx, sessionToken); err != nil {
-				slog.Warn("Failed to destroy unregistered worker session during drain.", "worker", worker.ID, "error", err)
+				sm.log.Warn("Failed to destroy unregistered worker session during drain.", "worker", worker.ID, "error", err)
 			}
 			cancel()
 		}
@@ -523,14 +537,14 @@ func (sm *SessionManager) DestroySession(pid int32) {
 	session, sessionCount, workerSessionCount, ok := sm.detachSessionLocked(pid)
 	if !ok {
 		sm.mu.Unlock()
-		slog.Warn("DestroySession called for unknown session.", "pid", pid)
+		sm.log.Warn("DestroySession called for unknown session.", "pid", pid)
 		return
 	}
 	finishCleanup := sm.lifecycle.beginCleanup()
 	sm.mu.Unlock()
 	defer finishCleanup()
 
-	slog.Info("Destroying session.",
+	sm.log.Info("Destroying session.",
 		"pid", pid,
 		"worker", session.WorkerID,
 		"protocol", session.Protocol,
@@ -563,7 +577,7 @@ func (sm *SessionManager) DestroySession(pid int32) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			workerDestroyErr = worker.DestroySession(ctx, session.SessionToken)
 			cancel()
-			slog.Info("Worker session destroy RPC completed.",
+			sm.log.Info("Worker session destroy RPC completed.",
 				"pid", pid,
 				"worker", session.WorkerID,
 				"protocol", session.Protocol,
@@ -577,7 +591,7 @@ func (sm *SessionManager) DestroySession(pid int32) {
 	sm.pool.ReleaseWorker(session.WorkerID)
 	sm.releaseSessionLease(session, "pid", pid)
 
-	slog.Info("Session destroyed.",
+	sm.log.Info("Session destroyed.",
 		"pid", pid,
 		"worker", session.WorkerID,
 		"protocol", session.Protocol,
@@ -691,7 +705,7 @@ func (sm *SessionManager) OnWorkerCrash(workerID int, errorFn func(pid int32)) {
 	}
 	sm.mu.Unlock()
 
-	slog.Warn("Worker crashed, notifying sessions.", "worker", workerID, "sessions", len(pids), "pids", pids)
+	sm.log.Warn("Worker crashed, notifying sessions.", "worker", workerID, "sessions", len(pids), "pids", pids)
 
 	for _, pid := range pids {
 		cleanupStart := time.Now()
@@ -722,7 +736,7 @@ func (sm *SessionManager) OnWorkerCrash(workerID int, errorFn func(pid int32)) {
 			_ = connCloser.Close()
 		}
 		sm.releaseSessionLease(session, "pid", pid)
-		slog.Info("Worker crash session cleanup completed.",
+		sm.log.Info("Worker crash session cleanup completed.",
 			"pid", pid,
 			"worker", workerID,
 			"session_found", ok,

--- a/controlplane/worker_lifecycle.go
+++ b/controlplane/worker_lifecycle.go
@@ -103,14 +103,14 @@ func (l *WorkerLifecycle) RetireFromSnapshot(snap configstore.WorkerSnapshot, ta
 	transitioned, err := l.store.MarkWorkerTerminalIfCurrent(&record, target, reason)
 	if err != nil {
 		slog.Warn("Lifecycle retire CAS failed.",
-			"worker_id", snap.WorkerID(), "target", target, "reason", reason, "origin", origin, "error", err)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "target", target, "reason", reason, "origin", origin, "error", err)
 		outcome := configstore.TransitionOutcome{Reason: configstore.TransitionOutcomeStoreError}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, err
 	}
 	if !transitioned {
 		slog.Debug("Lifecycle retire CAS missed; pod cleanup skipped.",
-			"worker_id", snap.WorkerID(), "target", target, "reason", reason, "origin", origin)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "target", target, "reason", reason, "origin", origin)
 		outcome := configstore.TransitionOutcome{Reason: classifySnapshotMiss(snap)}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, nil
@@ -145,7 +145,7 @@ func (l *WorkerLifecycle) RetireOrphanFromSnapshot(snap configstore.WorkerSnapsh
 	transitioned, err := l.store.RetireOrphanWorker(&record, reason)
 	if err != nil {
 		slog.Warn("Lifecycle orphan retire CAS failed.",
-			"worker_id", snap.WorkerID(), "reason", reason, "origin", origin, "error", err)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "reason", reason, "origin", origin, "error", err)
 		outcome := configstore.TransitionOutcome{Reason: configstore.TransitionOutcomeStoreError}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, err
@@ -159,7 +159,7 @@ func (l *WorkerLifecycle) RetireOrphanFromSnapshot(snap configstore.WorkerSnapsh
 		// finer dimensions.
 		miss := classifySnapshotMiss(snap)
 		slog.Debug("Lifecycle orphan retire CAS missed; pod cleanup skipped.",
-			"worker_id", snap.WorkerID(), "reason", reason, "origin", origin, "miss", miss)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "reason", reason, "origin", origin, "miss", miss)
 		outcome := configstore.TransitionOutcome{Reason: miss}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, nil
@@ -196,7 +196,7 @@ func (l *WorkerLifecycle) RetireIdleVariantFromSnapshot(snap configstore.WorkerS
 	transitioned, err := l.store.RetireIdleOrHotIdleWorker(&record, reason)
 	if err != nil {
 		slog.Warn("Lifecycle idle-variant retire CAS failed.",
-			"worker_id", snap.WorkerID(), "reason", reason, "origin", origin, "error", err)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "reason", reason, "origin", origin, "error", err)
 		outcome := configstore.TransitionOutcome{Reason: configstore.TransitionOutcomeStoreError}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, err
@@ -209,7 +209,7 @@ func (l *WorkerLifecycle) RetireIdleVariantFromSnapshot(snap configstore.WorkerS
 			miss = configstore.TransitionOutcomeFenceMissState
 		}
 		slog.Debug("Lifecycle idle-variant retire CAS missed; pod cleanup skipped.",
-			"worker_id", snap.WorkerID(), "reason", reason, "origin", origin, "miss", miss)
+			"worker", snap.WorkerID(), "worker_pod", snap.PodName(), "org", snap.OrgID(), "reason", reason, "origin", origin, "miss", miss)
 		outcome := configstore.TransitionOutcome{Reason: miss}
 		observeLifecycleTransition(op, outcome.Reason, snap.Image(), origin)
 		return outcome, nil

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/posthog/duckgres/server"
 )
@@ -156,7 +157,32 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	p.ownerEpoch = payload.OwnerEpoch
 	p.ownerCPInstanceID = payload.CPInstanceID
 	p.workerID = payload.WorkerID
+	stampWorkerLogIdentity(payload.OrgID, payload.WorkerID)
 	return nil
+}
+
+// workerLogIdentityOnce guards the one-time default-logger stamp: takeovers
+// and credential refreshes re-activate with the same identity, and stamping
+// again would duplicate the attrs on every line.
+var workerLogIdentityOnce sync.Once
+
+// stampWorkerLogIdentity attaches the worker's tenant identity to the default
+// logger, so EVERY worker log line — session create/destroy, query execution,
+// drain — carries org= and worker= alongside the pod=/node= stamps, matching
+// the control plane's per-connection identity attrs.
+func stampWorkerLogIdentity(orgID string, workerID int) {
+	workerLogIdentityOnce.Do(func() {
+		attrs := make([]any, 0, 4)
+		if orgID != "" {
+			attrs = append(attrs, "org", orgID)
+		}
+		if workerID > 0 {
+			attrs = append(attrs, "worker", workerID)
+		}
+		if len(attrs) > 0 {
+			slog.SetDefault(slog.Default().With(attrs...))
+		}
+	})
 }
 
 func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {

--- a/server/conn.go
+++ b/server/conn.go
@@ -379,13 +379,32 @@ func (c *clientConn) startDisconnectMonitor(ctx context.Context) (stop func()) {
 // Includes worker_id and worker_pod so an operator chasing a specific
 // worker incident (e.g. the one in the worker-40761 postmortem) can
 // filter to just that worker's queries without joining across logs.
+// logger returns the connection-scoped logger: every line carries the session
+// identity (user, org, worker, worker_pod) so the full request/query lifecycle
+// is filterable by org or worker without joining log streams. Built per call —
+// the identity fields settle at different times (username after auth, worker
+// after assignment), so caching would freeze a half-built identity.
+func (c *clientConn) logger() *slog.Logger {
+	attrs := make([]any, 0, 8)
+	if c.username != "" {
+		attrs = append(attrs, "user", c.username)
+	}
+	if c.orgID != "" {
+		attrs = append(attrs, "org", c.orgID)
+	}
+	if c.workerID > 0 {
+		attrs = append(attrs, "worker", c.workerID)
+	}
+	if c.workerPod != "" {
+		attrs = append(attrs, "worker_pod", c.workerPod)
+	}
+	return slog.With(attrs...)
+}
+
 func (c *clientConn) logQueryStarted(query string) {
 	query = usersecrets.RedactForLog(query)
-	slog.Info("Query started.",
-		"user", c.username,
+	c.logger().Info("Query started.",
 		"query", query,
-		"worker", c.workerID,
-		"worker_pod", c.workerPod,
 		"trace_id", observe.TraceIDFromContext(c.ctx))
 }
 
@@ -402,18 +421,15 @@ func (c *clientConn) logQueryStarted(query string) {
 func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64, err error) {
 	query = usersecrets.RedactForLog(query)
 	attrs := []any{
-		"user", c.username,
 		"query", query,
 		"duration_ms", time.Since(start).Milliseconds(),
 		"rows", rows,
-		"worker", c.workerID,
-		"worker_pod", c.workerPod,
 		"trace_id", observe.TraceIDFromContext(c.ctx),
 	}
 	if err != nil {
 		attrs = append(attrs, "error", err.Error())
 	}
-	slog.Info("Query finished.", attrs...)
+	c.logger().Info("Query finished.", attrs...)
 }
 
 // logQueryError logs a query execution failure. DuckLake-specific
@@ -424,20 +440,20 @@ func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64,
 // "user typo'd a column name."
 func (c *clientConn) logQueryError(query string, err error) {
 	query = usersecrets.RedactForLog(query)
-	attrs := []any{"user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod}
+	attrs := []any{"query", query, "error", err}
 	if isDuckLakeTransactionConflict(err) {
-		slog.Warn("DuckLake transaction conflict.", attrs...)
+		c.logger().Warn("DuckLake transaction conflict.", attrs...)
 		return
 	}
 	if isDuckLakeMetadataConnectionLost(err) {
-		slog.Warn("DuckLake metadata connection lost during transaction.", attrs...)
+		c.logger().Warn("DuckLake metadata connection lost during transaction.", attrs...)
 		return
 	}
 	if isUserQueryError(err) {
-		slog.Info("Query execution failed.", attrs...)
+		c.logger().Info("Query execution failed.", attrs...)
 		return
 	}
-	slog.Error("Query execution errored.", attrs...)
+	c.logger().Error("Query execution errored.", attrs...)
 }
 
 // safeCleanupDB safely closes the database connection, handling the case where
@@ -457,8 +473,7 @@ func (c *clientConn) safeCleanupDB() {
 	// caught by recover() — process isolation mode is needed to survive those.
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("Recovered from panic during database cleanup.",
-				"user", c.username, "panic", r)
+			c.logger().Error("Recovered from panic during database cleanup.", "panic", r)
 		}
 	}()
 
@@ -473,13 +488,12 @@ func (c *clientConn) safeCleanupDB() {
 			_, err := c.executor.ExecContext(ctx, "ROLLBACK")
 			cancel()
 			if err != nil {
-				slog.Warn("Failed to rollback transaction during cleanup.",
-					"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				c.logger().Warn("Failed to rollback transaction during cleanup.", "error", err)
 			}
 		}
 		// Close returns the pinned *sql.Conn to the pool (does not close the DB).
 		if err := c.executor.Close(); err != nil {
-			slog.Warn("Failed to return connection to pool.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("Failed to return connection to pool.", "error", err)
 		}
 		c.server.releaseFileDB(c.username)
 		return
@@ -496,14 +510,12 @@ func (c *clientConn) safeCleanupDB() {
 		// catalog that can be referenced as ducklake.information_schema.*.
 		_, err := c.executor.ExecContext(ctx, "SELECT 1 FROM duckdb_tables() WHERE database_name = 'ducklake' LIMIT 1")
 		if err != nil {
-			slog.Warn("DuckLake connection unhealthy during cleanup, skipping SQL cleanup.",
-				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("DuckLake connection unhealthy during cleanup, skipping SQL cleanup.", "error", err)
 			connHealthy = false
 		}
 	} else {
 		if err := c.executor.PingContext(ctx); err != nil {
-			slog.Warn("Database connection unhealthy during cleanup, skipping SQL cleanup.",
-				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("Database connection unhealthy during cleanup, skipping SQL cleanup.", "error", err)
 			connHealthy = false
 		}
 	}
@@ -517,8 +529,7 @@ func (c *clientConn) safeCleanupDB() {
 		_, err := c.executor.ExecContext(ctx2, "ROLLBACK")
 		cancel2()
 		if err != nil {
-			slog.Warn("Failed to rollback transaction during cleanup.",
-				"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("Failed to rollback transaction during cleanup.", "error", err)
 			if isConnectionBroken(err) {
 				connHealthy = false
 			}
@@ -534,7 +545,7 @@ func (c *clientConn) safeCleanupDB() {
 		_, err := c.executor.ExecContext(ctx3, "USE memory")
 		cancel3()
 		if err != nil {
-			slog.Warn("Failed to switch to memory.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("Failed to switch to memory.", "error", err)
 			if isConnectionBroken(err) {
 				connHealthy = false
 			}
@@ -551,7 +562,7 @@ func (c *clientConn) safeCleanupDB() {
 				_, err := c.executor.ExecContext(ctxIce, "DETACH "+iceberg.CatalogName)
 				cancelIce()
 				if err != nil {
-					slog.Warn("Failed to detach Iceberg catalog.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+					c.logger().Warn("Failed to detach Iceberg catalog.", "error", err)
 				}
 			}
 			if c.server.cfg.DuckLake.DeltaCatalogEnabled {
@@ -559,7 +570,7 @@ func (c *clientConn) safeCleanupDB() {
 				_, err := c.executor.ExecContext(ctxDelta, "DETACH delta")
 				cancelDelta()
 				if err != nil {
-					slog.Warn("Failed to detach Delta catalog.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+					c.logger().Warn("Failed to detach Delta catalog.", "error", err)
 				}
 			}
 
@@ -568,7 +579,7 @@ func (c *clientConn) safeCleanupDB() {
 				_, err := c.executor.ExecContext(ctx4, "DETACH ducklake")
 				cancel4()
 				if err != nil {
-					slog.Warn("Failed to detach DuckLake.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+					c.logger().Warn("Failed to detach DuckLake.", "error", err)
 				}
 			}
 		}
@@ -578,7 +589,7 @@ func (c *clientConn) safeCleanupDB() {
 	// If the connection is broken, this may still throw, but we've done our best
 	// to clean up the transaction state first.
 	if err := c.executor.Close(); err != nil {
-		slog.Warn("Failed to close database.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Warn("Failed to close database.", "error", err)
 	}
 }
 
@@ -720,7 +731,7 @@ func (c *clientConn) serve() error {
 	// Check if this is a passthrough user (skip transpiler + pg_catalog)
 	c.passthrough = c.server.cfg.PassthroughUsers[c.username]
 	if c.passthrough {
-		slog.Info("Passthrough mode enabled.", "user", c.username)
+		c.logger().Info("Passthrough mode enabled.")
 	}
 
 	// Create a DuckDB connection for this client session (unless pre-created by caller)
@@ -811,7 +822,7 @@ func (c *clientConn) serve() error {
 		// still surfaces from InitSessionDatabaseMetadata below.
 		if icebergAttached {
 			if err := sessionmeta.PrimeIcebergCatalog(initCtx, c.executor, iceberg.CatalogName); err != nil {
-				slog.Warn("Failed to prime Iceberg catalog before session metadata init.", "error", err)
+				c.logger().Warn("Failed to prime Iceberg catalog before session metadata init.", "error", err)
 			}
 		}
 		if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, c.executor, catalog); err != nil {
@@ -874,7 +885,7 @@ func (c *clientConn) handleStartup() error {
 
 		// Handle GSSENCRequest - decline and let client retry with SSL
 		if params["__gssenc_request"] == "true" {
-			slog.Debug("GSSENCRequest received, declining.", "remote_addr", c.conn.RemoteAddr())
+			c.logger().Debug("GSSENCRequest received, declining.", "remote_addr", c.conn.RemoteAddr())
 			if _, err := c.conn.Write([]byte("N")); err != nil {
 				return err
 			}
@@ -910,7 +921,7 @@ func (c *clientConn) handleStartup() error {
 			c.writer = bufio.NewWriter(tlsConn)
 			tlsUpgraded = true
 
-			slog.Info("TLS connection established.", "remote_addr", c.conn.RemoteAddr())
+			c.logger().Info("TLS connection established.", "remote_addr", c.conn.RemoteAddr())
 			continue
 		}
 
@@ -938,7 +949,7 @@ func (c *clientConn) handleStartup() error {
 		c.database = params["database"]
 		c.applicationName = params["application_name"]
 
-		slog.Info("Client startup.", "user", c.username, "database", c.database,
+		c.logger().Info("Client startup.", "database", c.database,
 			"application_name", c.applicationName, "remote_addr", c.conn.RemoteAddr())
 
 		if c.username == "" {
@@ -976,7 +987,7 @@ func (c *clientConn) handleStartup() error {
 		// Record failed authentication attempt
 		banned := c.server.rateLimiter.RecordFailedAuth(c.conn.RemoteAddr())
 		if banned {
-			slog.Warn("IP banned after too many failed auth attempts.", "remote_addr", c.conn.RemoteAddr())
+			c.logger().Warn("IP banned after too many failed auth attempts.", "remote_addr", c.conn.RemoteAddr())
 		}
 		c.sendError("FATAL", "28P01", "password authentication failed")
 		return fmt.Errorf("authentication failed for user %q", c.username)
@@ -990,7 +1001,7 @@ func (c *clientConn) handleStartup() error {
 		return err
 	}
 
-	slog.Info("User authenticated.", "user", c.username, "remote_addr", c.conn.RemoteAddr())
+	c.logger().Info("User authenticated.", "remote_addr", c.conn.RemoteAddr())
 	return nil
 }
 
@@ -1007,13 +1018,13 @@ func (c *clientConn) sendInitialParams() {
 
 	for name, value := range params {
 		if err := wire.WriteParameterStatus(c.writer, name, value); err != nil {
-			slog.Warn("Failed to write parameter.", "param", name, "error", err)
+			c.logger().Warn("Failed to write parameter.", "param", name, "error", err)
 		}
 	}
 
 	// Send backend key data (pid and secret key for cancel requests)
 	if err := wire.WriteBackendKeyData(c.writer, c.pid, c.secretKey); err != nil {
-		slog.Warn("Failed to write backend key data.", "error", err)
+		c.logger().Warn("Failed to write backend key data.", "error", err)
 	}
 }
 
@@ -1031,7 +1042,7 @@ func (c *clientConn) messageLoop() error {
 			}
 			// Check if this is a timeout error
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				slog.Info("Connection idle timeout, closing.", "user", c.username)
+				c.logger().Info("Connection idle timeout, closing.")
 				return nil
 			}
 			return err
@@ -1045,10 +1056,10 @@ func (c *clientConn) messageLoop() error {
 			c.ignoreTillSync = false
 			if err := c.handleQuery(body); err != nil {
 				if isConnectionBroken(err) {
-					slog.Info("Client connection lost during query.", "user", c.username, "error", err)
+					c.logger().Info("Client connection lost during query.", "error", err)
 					return nil
 				}
-				slog.Error("Query error.", "error", err)
+				c.logger().Error("Query error.", "error", err)
 			}
 
 		case wire.MsgParse:
@@ -1091,7 +1102,7 @@ func (c *clientConn) messageLoop() error {
 			return nil
 
 		default:
-			slog.Warn("Unknown message type.", "type", string(msgType))
+			c.logger().Warn("Unknown message type.", "type", string(msgType))
 		}
 	}
 }
@@ -1138,7 +1149,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 	c.ctx = ctx
 	defer func() { c.ctx = prevCtx }()
 
-	slog.Debug("Query received.", "user", c.username, "query", loggableQuery)
+	c.logger().Debug("Query received.", "query", loggableQuery)
 
 	// Check for cursor operations (DECLARE, FETCH, CLOSE) before passthrough
 	// or transpilation. DuckDB doesn't support these natively, so cursor
@@ -1233,7 +1244,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 			_ = c.writer.Flush()
 			return nil
 		}
-		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", loggableQuery)
+		c.logger().Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "query", loggableQuery)
 	}
 
 	// Handle transform-detected errors (e.g., unrecognized config parameter)
@@ -1252,7 +1263,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 
 	// Handle ignored SET parameters
 	if result.IsIgnoredSet {
-		slog.Debug("Ignoring PostgreSQL-specific SET.", "user", c.username, "query", query)
+		c.logger().Debug("Ignoring PostgreSQL-specific SET.", "query", query)
 		_ = wire.WriteCommandComplete(c.writer, "SET")
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
 		_ = c.writer.Flush()
@@ -1261,7 +1272,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 
 	// Handle no-op commands (CREATE INDEX, VACUUM, etc.)
 	if result.IsNoOp {
-		slog.Debug("No-op command (DuckLake limitation).", "user", c.username, "query", query)
+		c.logger().Debug("No-op command (DuckLake limitation).", "query", query)
 		_ = wire.WriteCommandComplete(c.writer, result.NoOpTag)
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
 		_ = c.writer.Flush()
@@ -1270,7 +1281,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 
 	// Handle multi-statement results (writable CTE rewrites)
 	if len(result.Statements) > 0 {
-		slog.Debug("Multi-statement query.", "user", c.username, "statements", len(result.Statements), "cleanup", len(result.CleanupStatements))
+		c.logger().Debug("Multi-statement query.", "statements", len(result.Statements), "cleanup", len(result.CleanupStatements))
 		return c.executeMultiStatement(result.Statements, result.CleanupStatements)
 	}
 
@@ -1280,7 +1291,7 @@ func (c *clientConn) handleQuery(body []byte) error {
 
 	// Log the transpiled query if it differs from the original
 	if query != originalQuery {
-		slog.Debug("Query transpiled.", "user", c.username, "executed", query)
+		c.logger().Debug("Query transpiled.", "executed", query)
 	}
 
 	// Determine command type for proper response

--- a/server/conn_copy.go
+++ b/server/conn_copy.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -276,7 +275,7 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 	rows, err := c.executor.Query(selectQuery)
 	if err != nil {
 		copyFinalErr = err
-		slog.Error("COPY TO query failed.", "user", c.username, "query", selectQuery, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("COPY TO query failed.", "query", selectQuery, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
@@ -288,7 +287,7 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("COPY TO failed to get columns.", "user", c.username, "query", selectQuery, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("COPY TO failed to get columns.", "query", selectQuery, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
@@ -533,7 +532,7 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 // handleCopyIn handles COPY ... FROM STDIN
 func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	copyStartTime := time.Now()
-	slog.Debug("COPY FROM STDIN starting.", "user", c.username, "query", query)
+	c.logger().Debug("COPY FROM STDIN starting.", "query", query)
 
 	// Parse COPY options using the helper function
 	opts, err := ParseCopyFromOptions(query)
@@ -548,7 +547,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 
 	tableName := opts.TableName
 	columnList := opts.ColumnList
-	slog.Debug("COPY FROM STDIN parsed.", "user", c.username, "table", tableName, "columns", columnList, "binary", opts.IsBinary)
+	c.logger().Debug("COPY FROM STDIN parsed.", "table", tableName, "columns", columnList, "binary", opts.IsBinary)
 
 	// Get column info. If a column list is specified, query only those columns
 	// in the specified order to match the binary data field order.
@@ -561,7 +560,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	}
 	testRows, err := c.executor.Query(colQuery)
 	if err != nil {
-		slog.Error("COPY FROM table check failed.", "user", c.username, "table", tableName, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("COPY FROM table check failed.", "table", tableName, "error", err)
 		errMsg := fmt.Sprintf("relation \"%s\" does not exist", tableName)
 		c.sendError("ERROR", "42P01", errMsg)
 		c.setTxError()
@@ -589,7 +588,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 		}
 	}
 	if len(blobColIndices) > 0 {
-		slog.Debug("COPY FROM STDIN: table has BLOB columns, using CSV parse fallback.", "user", c.username, "blob_columns", len(blobColIndices))
+		c.logger().Debug("COPY FROM STDIN: table has BLOB columns, using CSV parse fallback.", "blob_columns", len(blobColIndices))
 		return c.handleCopyInCSVWithBlob(query, opts, cols, colTypes, blobColIndices)
 	}
 
@@ -598,7 +597,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 		return err
 	}
 	_ = c.writer.Flush()
-	slog.Debug("COPY FROM STDIN sent CopyInResponse, waiting for data.", "user", c.username)
+	c.logger().Debug("COPY FROM STDIN sent CopyInResponse, waiting for data.")
 
 	// Remote-worker (Flight) executors implement CopyFromStdinExecutor so the
 	// CSV bytes are streamed to the worker pod via DoPut and spooled to the
@@ -614,7 +613,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	// type conversions automatically and can load millions of rows in seconds.
 	tmpFile, err := os.CreateTemp("", "duckgres-copy-*.csv")
 	if err != nil {
-		slog.Error("COPY FROM STDIN failed to create temp file.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("COPY FROM STDIN failed to create temp file.", "error", err)
 		errMsg := fmt.Sprintf("failed to create temp file: %v", err)
 		c.sendError("ERROR", "58000", errMsg)
 		c.setTxError()
@@ -635,7 +634,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	for {
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {
-			slog.Error("COPY FROM STDIN error reading message.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("COPY FROM STDIN error reading message.", "error", err)
 			_ = tmpFile.Close()
 			return err
 		}
@@ -650,7 +649,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			}
 			n, err := tmpFile.Write(body)
 			if err != nil {
-				slog.Error("COPY FROM STDIN failed to write to temp file.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				c.logger().Error("COPY FROM STDIN failed to write to temp file.", "error", err)
 				_ = tmpFile.Close()
 				errMsg := fmt.Sprintf("failed to write to temp file: %v", err)
 				c.sendError("ERROR", "58000", errMsg)
@@ -663,18 +662,18 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			bytesWritten += int64(n)
 			copyDataMessages++
 			if copyDataMessages%10000 == 0 {
-				slog.Debug("COPY FROM STDIN progress.", "user", c.username, "messages", copyDataMessages, "bytes", bytesWritten)
+				c.logger().Debug("COPY FROM STDIN progress.", "messages", copyDataMessages, "bytes", bytesWritten)
 			}
 
 		case wire.MsgCopyDone:
 			_ = tmpFile.Close()
 			dataReceiveElapsed := time.Since(dataReceiveStart)
-			slog.Debug("COPY FROM STDIN CopyDone received.", "user", c.username, "messages", copyDataMessages, "bytes", bytesWritten, "duration", dataReceiveElapsed)
+			c.logger().Debug("COPY FROM STDIN CopyDone received.", "messages", copyDataMessages, "bytes", bytesWritten, "duration", dataReceiveElapsed)
 
 			// Build DuckDB COPY FROM statement using the helper function
 			copySQL := BuildDuckDBCopyFromSQL(tableName, columnList, tmpPath, opts)
 
-			slog.Debug("COPY FROM STDIN executing native DuckDB COPY.", "user", c.username, "sql", copySQL)
+			c.logger().Debug("COPY FROM STDIN executing native DuckDB COPY.", "sql", copySQL)
 			loadStart := time.Now()
 
 			// Lifecycle log pair (PR #519): the native DuckDB COPY FROM is
@@ -688,7 +687,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			}
 			c.logQueryFinished(copySQL, loadStart, copyRowsAffected, err)
 			if err != nil {
-				slog.Error("COPY FROM STDIN DuckDB COPY failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				c.logger().Error("COPY FROM STDIN DuckDB COPY failed.", "error", err)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -702,7 +701,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 
 			totalElapsed := time.Since(copyStartTime)
 			loadElapsed := time.Since(loadStart)
-			slog.Info("COPY FROM STDIN completed.", "user", c.username, "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
+			c.logger().Info("COPY FROM STDIN completed.", "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
 
 			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
@@ -752,8 +751,7 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 	// Build the COPY SQL with the path placeholder; the worker substitutes
 	// in its own tempfile path before executing.
 	copySQL := BuildDuckDBCopyFromSQL(tableName, columnList, flightclient.CopyFromStdinPathPlaceholder, opts)
-	slog.Debug("COPY FROM STDIN streaming to remote worker.",
-		"user", c.username, "sql", copySQL, "worker", c.workerID, "worker_pod", c.workerPod)
+	c.logger().Debug("COPY FROM STDIN streaming to remote worker.", "sql", copySQL)
 
 	r := &copyDataWireReader{c: c}
 
@@ -785,8 +783,7 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 		return nil
 	}
 	if err != nil {
-		slog.Error("COPY FROM STDIN remote streaming failed.",
-			"user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("COPY FROM STDIN remote streaming failed.", "error", err)
 		errMsg := fmt.Sprintf("COPY failed: %v", err)
 		c.sendError("ERROR", "22P02", errMsg)
 		c.setTxError()
@@ -798,10 +795,8 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 
 	totalElapsed := time.Since(copyStartTime)
 	loadElapsed := time.Since(loadStart)
-	slog.Info("COPY FROM STDIN completed (remote streaming).",
-		"user", c.username, "rows", rowCount, "bytes", r.bytesRead,
-		"total_duration", totalElapsed, "load_duration", loadElapsed,
-		"worker", c.workerID, "worker_pod", c.workerPod)
+	c.logger().Info("COPY FROM STDIN completed (remote streaming).", "rows", rowCount, "bytes", r.bytesRead,
+		"total_duration", totalElapsed, "load_duration", loadElapsed)
 
 	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
 	c.logQuery(copyStartTime, query, query, "COPY", 0, rowCount, "", "", "simple")
@@ -921,7 +916,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 
 		case wire.MsgCopyDone:
 			dataReceiveElapsed := time.Since(copyStartTime)
-			slog.Debug("COPY FROM STDIN (BLOB fallback) CopyDone received.", "user", c.username, "bytes", buf.Len(), "duration", dataReceiveElapsed)
+			c.logger().Debug("COPY FROM STDIN (BLOB fallback) CopyDone received.", "bytes", buf.Len(), "duration", dataReceiveElapsed)
 
 			// Parse CSV from the buffered data
 			csvReader := csv.NewReader(&buf)
@@ -949,7 +944,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 					break // EOF or error — stop reading
 				}
 				if len(record) != len(cols) {
-					slog.Warn("COPY FROM STDIN (BLOB fallback) skipping row with wrong field count.", "expected", len(cols), "got", len(record))
+					c.logger().Warn("COPY FROM STDIN (BLOB fallback) skipping row with wrong field count.", "expected", len(cols), "got", len(record))
 					continue
 				}
 				row := make([]interface{}, len(cols))
@@ -976,7 +971,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			loadStart := time.Now()
 			rowCount, err := c.batchInsertRows(opts.TableName, opts.ColumnList, cols, rows)
 			if err != nil {
-				slog.Error("COPY FROM STDIN (BLOB fallback) INSERT failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				c.logger().Error("COPY FROM STDIN (BLOB fallback) INSERT failed.", "error", err)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -988,7 +983,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 
 			totalElapsed := time.Since(copyStartTime)
 			loadElapsed := time.Since(loadStart)
-			slog.Info("COPY FROM STDIN (BLOB fallback) completed.", "user", c.username, "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
+			c.logger().Info("COPY FROM STDIN (BLOB fallback) completed.", "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
 
 			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
@@ -1034,14 +1029,14 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 		return err
 	}
 	_ = c.writer.Flush()
-	slog.Debug("COPY FROM STDIN binary: sent CopyInResponse.", "user", c.username)
+	c.logger().Debug("COPY FROM STDIN binary: sent CopyInResponse.")
 
 	// Collect all CopyData messages into a buffer
 	var buf bytes.Buffer
 	for {
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {
-			slog.Error("COPY FROM STDIN binary: error reading message.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("COPY FROM STDIN binary: error reading message.", "error", err)
 			return err
 		}
 
@@ -1054,7 +1049,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 			data := buf.Bytes()
 			rowCount, err := c.parseBinaryCopyAndInsert(data, opts.TableName, opts.ColumnList, cols, typeOIDs)
 			if err != nil {
-				slog.Error("COPY FROM STDIN binary: parse/insert failed.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+				c.logger().Error("COPY FROM STDIN binary: parse/insert failed.", "error", err)
 				errMsg := fmt.Sprintf("COPY failed: %v", err)
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
@@ -1065,7 +1060,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 			}
 
 			elapsed := time.Since(copyStartTime)
-			slog.Info("COPY FROM STDIN binary completed.", "user", c.username, "rows", rowCount, "bytes", buf.Len(), "duration", elapsed)
+			c.logger().Info("COPY FROM STDIN binary completed.", "rows", rowCount, "bytes", buf.Len(), "duration", elapsed)
 
 			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
@@ -1258,7 +1253,7 @@ func (c *clientConn) parseBinaryCopyAndInsert(data []byte, tableName, columnList
 		if err == nil {
 			return count, nil
 		}
-		slog.Warn("Appender failed, falling back to batched INSERT.", "table", tableName, "error", err)
+		c.logger().Warn("Appender failed, falling back to batched INSERT.", "table", tableName, "error", err)
 	}
 
 	// Fallback: batched multi-row INSERT

--- a/server/conn_cursor.go
+++ b/server/conn_cursor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -258,7 +257,7 @@ func (c *clientConn) handleDeclareCursor(query string, stmt *pg_query.DeclareCur
 	c.closeCursor(stmt.Portalname)
 
 	c.cursors[stmt.Portalname] = &cursorState{query: transpiledSQL}
-	slog.Debug("Cursor declared.", "user", c.username, "cursor", stmt.Portalname, "query", transpiledSQL)
+	c.logger().Debug("Cursor declared.", "cursor", stmt.Portalname, "query", transpiledSQL)
 
 	_ = wire.WriteCommandComplete(c.writer, "DECLARE CURSOR")
 	c.logQuery(start, query, query, "DECLARE", 0, 0, "", "", "simple")
@@ -406,7 +405,7 @@ func (c *clientConn) handleCloseCursor(query string, stmt *pg_query.ClosePortalS
 		c.closeCursor(stmt.Portalname)
 	}
 
-	slog.Debug("Cursor closed.", "user", c.username, "cursor", stmt.Portalname)
+	c.logger().Debug("Cursor closed.", "cursor", stmt.Portalname)
 	_ = wire.WriteCommandComplete(c.writer, "CLOSE CURSOR")
 	c.logQuery(start, query, query, "CLOSE", 0, 0, "", "", "simple")
 	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -420,7 +419,7 @@ func (c *clientConn) handleDeclareCursorExtended(p *portal) {
 	c.closeCursor(p.stmt.cursorName)
 
 	c.cursors[p.stmt.cursorName] = &cursorState{query: p.stmt.cursorQuery}
-	slog.Debug("Cursor declared (extended).", "user", c.username, "cursor", p.stmt.cursorName, "query", p.stmt.cursorQuery)
+	c.logger().Debug("Cursor declared (extended).", "cursor", p.stmt.cursorName, "query", p.stmt.cursorQuery)
 
 	_ = wire.WriteCommandComplete(c.writer, "DECLARE CURSOR")
 }
@@ -501,6 +500,6 @@ func (c *clientConn) handleCloseCursorExtended(p *portal) {
 		c.closeCursor(p.stmt.cursorName)
 	}
 
-	slog.Debug("Cursor closed (extended).", "user", c.username, "cursor", p.stmt.cursorName)
+	c.logger().Debug("Cursor closed (extended).", "cursor", p.stmt.cursorName)
 	_ = wire.WriteCommandComplete(c.writer, "CLOSE CURSOR")
 }

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -179,7 +178,7 @@ func (c *clientConn) handleParse(body []byte) {
 			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
 			return
 		}
-		slog.Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "user", c.username, "query", usersecrets.RedactForLog(query))
+		c.logger().Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "query", usersecrets.RedactForLog(query))
 	}
 
 	// Close existing statement with same name
@@ -198,11 +197,11 @@ func (c *clientConn) handleParse(body []byte) {
 		warnings:          result.Warnings,          // Surfaced as NoticeResponse at Execute
 	}
 
-	slog.Debug("Prepared statement.", "user", c.username, "name", stmtName, "query", usersecrets.RedactForLog(query))
+	c.logger().Debug("Prepared statement.", "name", stmtName, "query", usersecrets.RedactForLog(query))
 	if len(result.Statements) > 0 {
-		slog.Debug("Prepared statement multi-statement.", "user", c.username, "name", stmtName, "statements", len(result.Statements), "cleanup", len(result.CleanupStatements))
+		c.logger().Debug("Prepared statement multi-statement.", "name", stmtName, "statements", len(result.Statements), "cleanup", len(result.CleanupStatements))
 	} else if result.SQL != query {
-		slog.Debug("Prepared statement transpiled.", "user", c.username, "name", stmtName, "transpiled", usersecrets.RedactForLog(result.SQL))
+		c.logger().Debug("Prepared statement transpiled.", "name", stmtName, "transpiled", usersecrets.RedactForLog(result.SQL))
 	}
 	_ = wire.WriteParseComplete(c.writer)
 }
@@ -228,7 +227,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 			c.sendError("ERROR", "26000", fmt.Sprintf("prepared statement %q does not exist", name))
 			return
 		}
-		slog.Debug("Describe statement.", "user", c.username, "name", name, "query", usersecrets.RedactForLog(ps.query))
+		c.logger().Debug("Describe statement.", "name", name, "query", usersecrets.RedactForLog(ps.query))
 
 		// Send parameter description based on the number of $N placeholders we found
 		// If the client didn't send explicit types, create them
@@ -271,7 +270,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 		// For queries that return results, we need to send RowDescription
 		// For other queries, send NoData
 		returnsResults := queryReturnsResults(ps.query)
-		slog.Debug("Describe statement returns results check.", "user", c.username, "name", name, "returns_results", returnsResults)
+		c.logger().Debug("Describe statement returns results check.", "name", name, "returns_results", returnsResults)
 		if !returnsResults {
 			_ = wire.WriteNoData(c.writer)
 			return
@@ -323,7 +322,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 		rows, err := c.executor.Query(describeQuery, args...)
 		if err != nil {
 			// Can't describe - send NoData
-			slog.Debug("Describe failed to get columns.", "user", c.username, "error", err)
+			c.logger().Debug("Describe failed to get columns.", "error", err)
 			_ = wire.WriteNoData(c.writer)
 			return
 		}
@@ -337,7 +336,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 			return
 		}
 
-		slog.Debug("Describe statement sending RowDescription.", "user", c.username, "columns", len(cols))
+		c.logger().Debug("Describe statement sending RowDescription.", "columns", len(cols))
 		_ = c.sendRowDescription(cols, colTypes)
 		ps.described = true
 
@@ -351,7 +350,7 @@ func (c *clientConn) handleDescribe(body []byte) {
 			if _, cursorOk := c.cursors[name]; cursorOk {
 				cols, colTypes, err := c.getCursorSchema(name)
 				if err != nil {
-					slog.Debug("Describe cursor-as-portal failed to open.", "user", c.username, "cursor", name, "error", err)
+					c.logger().Debug("Describe cursor-as-portal failed to open.", "cursor", name, "error", err)
 					_ = wire.WriteNoData(c.writer)
 					return
 				}
@@ -559,7 +558,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 
-	slog.Debug("Execute portal.", "user", c.username, "portal", portalName, "params", len(args), "query", loggableQuery)
+	c.logger().Debug("Execute portal.", "portal", portalName, "params", len(args), "query", loggableQuery)
 
 	// Surface any transpiler warnings (e.g. an unenforced constraint stripped on a
 	// lake catalog) as NoticeResponse before the command result.
@@ -570,7 +569,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	// Check if this is a PostgreSQL-specific SET command that should be ignored
 	// (determined by transpiler during Parse)
 	if p.stmt.isIgnoredSet {
-		slog.Debug("Ignoring PostgreSQL-specific SET.", "user", c.username, "query", p.stmt.query)
+		c.logger().Debug("Ignoring PostgreSQL-specific SET.", "query", p.stmt.query)
 		_ = wire.WriteCommandComplete(c.writer, "SET")
 		return
 	}
@@ -578,14 +577,14 @@ func (c *clientConn) handleExecute(body []byte) {
 	// Handle no-op commands (CREATE INDEX, VACUUM, etc.) - DuckLake doesn't support these
 	// (determined by transpiler during Parse)
 	if p.stmt.isNoOp {
-		slog.Debug("No-op command (DuckLake limitation).", "user", c.username, "query", p.stmt.query)
+		c.logger().Debug("No-op command (DuckLake limitation).", "query", p.stmt.query)
 		_ = wire.WriteCommandComplete(c.writer, p.stmt.noOpTag)
 		return
 	}
 
 	// Handle multi-statement results (e.g., writable CTE rewrites)
 	if len(p.stmt.statements) > 0 {
-		slog.Debug("Execute multi-statement.", "user", c.username, "statements", len(p.stmt.statements), "cleanup", len(p.stmt.cleanupStatements))
+		c.logger().Debug("Execute multi-statement.", "statements", len(p.stmt.statements), "cleanup", len(p.stmt.cleanupStatements))
 		c.executeMultiStatementExtended(p.stmt.statements, p.stmt.cleanupStatements, args, p.resultFormats, p.described)
 		return
 	}
@@ -724,7 +723,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	cols, err := rows.Columns()
 	if err != nil {
 		queryFinalErr = err
-		slog.Error("Columns error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("Columns error.", "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, "42000", err.Error(), "extended")
@@ -788,7 +787,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			errMsg = "canceling statement due to user request"
 			c.sendError("ERROR", errCode, errMsg)
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Row iteration error.", "error", err)
 			c.sendError("ERROR", errCode, errMsg)
 		}
 		c.setTxError()

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -405,7 +404,7 @@ func (c *clientConn) handleMultiStatementQuery(query string) error {
 		_ = c.writer.Flush()
 		return nil
 	}
-	slog.Debug("Multi-statement simple query.", "user", c.username, "count", len(tree.Stmts))
+	c.logger().Debug("Multi-statement simple query.", "count", len(tree.Stmts))
 
 	for _, stmt := range tree.Stmts {
 		// Deparse individual statement back to SQL
@@ -594,7 +593,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
 			return true, nil
 		}
-		slog.Debug("Fallback to native DuckDB.", "user", c.username, "query", query)
+		c.logger().Debug("Fallback to native DuckDB.", "query", query)
 	}
 
 	if result.Error != nil {
@@ -620,7 +619,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 
 	executedQuery := c.rewriteDirectQuery(result.SQL)
 	if executedQuery != query {
-		slog.Debug("Query transpiled.", "user", c.username, "executed", executedQuery)
+		c.logger().Debug("Query transpiled.", "executed", executedQuery)
 	}
 
 	upperQuery := strings.ToUpper(executedQuery)
@@ -842,7 +841,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 	// logQueryFinished pair (PR #519).
 	for i := 0; i < len(statements)-1; i++ {
 		stmt := statements[i]
-		slog.Debug("Multi-stmt setup.", "user", c.username, "step", i+1, "total", len(statements)-1, "stmt", stmt)
+		c.logger().Debug("Multi-stmt setup.", "step", i+1, "total", len(statements)-1, "stmt", stmt)
 		setupStart := time.Now()
 		c.logQueryStarted(stmt)
 		result, err := c.executor.Exec(stmt)
@@ -852,7 +851,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		}
 		c.logQueryFinished(stmt, setupStart, setupRows, err)
 		if err != nil {
-			slog.Error("Multi-stmt setup error.", "user", c.username, "query", stmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt setup error.", "query", stmt, "error", err)
 			c.setTxError()
 			// On error, still try to cleanup (best effort)
 			c.executeCleanup(cleanup)
@@ -867,7 +866,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 	finalStmt := statements[len(statements)-1]
 	upperFinal := strings.ToUpper(strings.TrimSpace(finalStmt))
 	cmdType := c.getCommandType(upperFinal)
-	slog.Debug("Multi-stmt final.", "user", c.username, "stmt", finalStmt, "cmd_type", cmdType)
+	c.logger().Debug("Multi-stmt final.", "stmt", finalStmt, "cmd_type", cmdType)
 
 	finalStart := time.Now()
 	var finalRowsAff int64
@@ -882,7 +881,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		rows, err := c.executor.Query(finalStmt)
 		if err != nil {
 			finalErr = err
-			slog.Error("Multi-stmt final query error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt final query error.", "query", finalStmt, "error", err)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -912,7 +911,7 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 		result, err := c.executor.Exec(finalStmt)
 		if err != nil {
 			finalErr = err
-			slog.Error("Multi-stmt final exec error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt final exec error.", "query", finalStmt, "error", err)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -939,11 +938,11 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 // This is used to clean up temp tables after a multi-statement query.
 func (c *clientConn) executeCleanup(cleanup []string) {
 	for _, stmt := range cleanup {
-		slog.Debug("Multi-stmt cleanup.", "user", c.username, "stmt", stmt)
+		c.logger().Debug("Multi-stmt cleanup.", "stmt", stmt)
 		_, err := c.executor.Exec(stmt)
 		if err != nil {
 			// Log but don't fail - cleanup is best effort
-			slog.Warn("Multi-stmt cleanup error (ignored).", "user", c.username, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Warn("Multi-stmt cleanup error (ignored).", "error", err)
 		}
 	}
 }
@@ -974,7 +973,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 	// setup work is observable per statement, not just per outer query.
 	for i := 0; i < len(statements)-1; i++ {
 		stmt := statements[i]
-		slog.Debug("Multi-stmt-ext setup.", "user", c.username, "step", i+1, "total", len(statements)-1, "stmt", stmt)
+		c.logger().Debug("Multi-stmt-ext setup.", "step", i+1, "total", len(statements)-1, "stmt", stmt)
 		setupStart := time.Now()
 		c.logQueryStarted(stmt)
 		result, err := c.executor.Exec(stmt, args...)
@@ -984,7 +983,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		}
 		c.logQueryFinished(stmt, setupStart, setupRows, err)
 		if err != nil {
-			slog.Error("Multi-stmt-ext setup error.", "user", c.username, "query", stmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt-ext setup error.", "query", stmt, "error", err)
 			c.setTxError()
 			// On error, still try to cleanup (best effort)
 			c.executeCleanup(cleanup)
@@ -997,7 +996,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 	finalStmt := statements[len(statements)-1]
 	upperFinal := strings.ToUpper(strings.TrimSpace(finalStmt))
 	cmdType := c.getCommandType(upperFinal)
-	slog.Debug("Multi-stmt-ext final.", "user", c.username, "stmt", finalStmt, "cmd_type", cmdType)
+	c.logger().Debug("Multi-stmt-ext final.", "stmt", finalStmt, "cmd_type", cmdType)
 
 	finalStart := time.Now()
 	var finalRowsAff int64
@@ -1012,7 +1011,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		rows, err := c.executor.Query(finalStmt, args...)
 		if err != nil {
 			finalErr = err
-			slog.Error("Multi-stmt-ext final query error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt-ext final query error.", "query", finalStmt, "error", err)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
@@ -1034,7 +1033,7 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 		result, err := c.executor.Exec(finalStmt, args...)
 		if err != nil {
 			finalErr = err
-			slog.Error("Multi-stmt-ext final exec error.", "user", c.username, "query", finalStmt, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Multi-stmt-ext final exec error.", "query", finalStmt, "error", err)
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())

--- a/server/conn_results.go
+++ b/server/conn_results.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -20,7 +19,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 	// Get column info
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("Failed to get column info.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		return
@@ -28,7 +27,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
-		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("Failed to get column types.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		return
@@ -57,7 +56,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 		}
 
 		if err := rows.Scan(valuePtrs...); err != nil {
-			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Failed to scan row.", "query", query, "error", err)
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			return
@@ -73,7 +72,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 		if c.isCallerCancellation(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Row iteration error.", "query", query, "error", err)
 			c.sendError("ERROR", "42000", err.Error())
 		}
 		c.setTxError()
@@ -91,7 +90,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 	// Get column info
 	cols, err := rows.Columns()
 	if err != nil {
-		slog.Error("Failed to get column info.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("Failed to get column info.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -101,7 +100,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
-		slog.Error("Failed to get column types.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+		c.logger().Error("Failed to get column types.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -130,7 +129,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		}
 
 		if err := rows.Scan(valuePtrs...); err != nil {
-			slog.Error("Failed to scan row.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Failed to scan row.", "query", query, "error", err)
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
@@ -148,7 +147,7 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		if c.isCallerCancellation(err) {
 			c.sendError("ERROR", "57014", "canceling statement due to user request")
 		} else {
-			slog.Error("Row iteration error.", "user", c.username, "query", query, "error", err, "worker", c.workerID, "worker_pod", c.workerPod)
+			c.logger().Error("Row iteration error.", "query", query, "error", err)
 			c.sendError("ERROR", "42000", err.Error())
 		}
 		c.setTxError()
@@ -509,7 +508,7 @@ func (c *clientConn) sendError(severity, code, message string) {
 	} else if severity == "ERROR" {
 		queryErrorsCounter.WithLabelValues(c.orgID).Inc()
 	}
-	slog.Debug("Sending error to client.", "user", c.username, "severity", severity, "code", code, "message", message)
+	c.logger().Debug("Sending error to client.", "severity", severity, "code", code, "message", message)
 	c.errorResponsesSent++
 	_ = wire.WriteErrorResponse(c.writer, severity, code, message)
 	_ = c.writer.Flush()

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -219,6 +219,14 @@ spec:
           imagePullPolicy: IfNotPresent
           args: ["--mode", "control-plane", "--worker-backend", "remote", "--flight-port", "8815"]
           env:
+            # Pod identity for log stamping: the shared logging handler attaches
+            # pod=/node= to every line when these are set (workers get them via
+            # the Downward API at spawn; the CP needs them too so its log lines
+            # carry the control-plane identity for cross-CP correlation).
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: NODE_NAME
+              valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
             - name: DUCKGRES_CONFIG_STORE
               value: "postgres://duckgres:duckgres@duckgres-config-store.${NAMESPACE}.svc:5432/duckgres?sslmode=disable"
             - { name: DUCKGRES_K8S_WORKER_IMAGE, value: "${WORKER_IMAGE}" }


### PR DESCRIPTION
## Problem

Lifecycle log lines were inconsistently tagged — examples: `User authenticated.` had no org, `Client disconnected.` had worker but no org, `session_mgr` had no org anywhere, the k8s pool's drain/crash/retire family had worker ids but no org, worker-side query logs had `pod=` but no org, and **CP logs carried no pod identity at all**. Following one org's request story meant joining log streams by hand.

## Now

Every line in the connection/query lifecycle carries the identity that exists at that point in the flow:

| layer | mechanism |
|---|---|
| `server/conn*` (queries, COPY, cursors, extended protocol) | `c.logger()` with user/org/worker/worker_pod — 106 sites migrated, duplicate attrs stripped; built per call because identity settles at different times |
| `control.go` connection lifecycle | connection-scoped logger growing attrs as identity resolves: remote_addr → user → org → worker |
| `session_mgr` | per-org logger (`NewOrgSessionManager`) — acquire/create/destroy/crash lines org+worker tagged |
| k8s pool (spawn/claim/retire/drain/crash/CAS/janitor/reconcilers) | `workerLogAttrs()` / `logw(id)` — worker + worker_pod + org from assignment, durable record, or pod label |
| worker (duckdbservice) | one-time default-logger stamp at activation: `org=`/`worker=` on every worker line, next to `pod=`/`node=` |
| CP pod identity | `POD_NAME`/`NODE_NAME` Downward API on the CP container (e2e manifest here; 4-line chart companion) → handler emits `pod=` on CP lines |

Result: `org=X` filters one tenant's complete story across CP and workers; `worker=N` follows one worker's life; `pod=` disambiguates CP replicas.

## Notes

- Logging-only, no behavior change. Full unit suites green both tag sets; `conn_querylog_lifecycle_test`'s worker-attr assertion now passes via the connection-scoped logger.
- Janitor mechanism names and startup/shutdown lines (no org/worker exists there) intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)