### PR TITLE
fix(controlplane): recycle wedged workers on session-create pool timeout

### DIFF
--- a/controlplane/flight_ingress_metrics.go
+++ b/controlplane/flight_ingress_metrics.go
@@ -98,8 +98,21 @@ var controlPlaneWorkerSessionCapDriftCounter = promauto.NewCounter(prometheus.Co
 	Help: "Times a worker rejected a CP-scheduled CreateSession at its session cap (CP↔worker accounting drift; recovered by recycling the worker and retrying).",
 })
 
+// controlPlaneWorkerConnPoolWedgeCounter counts sessions rejected by a worker
+// whose single DB connection never returned to its pool (wedged worker). The
+// CP recycles the worker and re-acquires; a nonzero rate means worker-side
+// session cleanup is hanging — find the leak, don't lean on the recycle.
+var controlPlaneWorkerConnPoolWedgeCounter = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_control_plane_worker_conn_pool_wedge_total",
+	Help: "Sessions rejected by a wedged worker (DB connection pool timeout); the worker is recycled and the session retried on a fresh one.",
+})
+
 func observeWorkerSessionCapDrift() {
 	controlPlaneWorkerSessionCapDriftCounter.Inc()
+}
+
+func observeWorkerConnPoolWedge() {
+	controlPlaneWorkerConnPoolWedgeCounter.Inc()
 }
 
 func observeFlightSessionsReaped(trigger string, count int) {

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -331,23 +331,40 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 			success = true
 			return newPID, exec, nil
 		}
-		if !isWorkerSessionCapError(err) {
+		switch {
+		case isWorkerSessionCapError(err):
+			// One-session-per-worker invariant violated: the CP scheduled this
+			// worker believing it idle, but the worker still holds a session.
+			// Loud ERROR + metric so we can find and fix the drift.
+			observeWorkerSessionCapDrift()
+			sm.log.Error("Worker rejected a CP-scheduled session at its session cap — one-session-per-worker accounting drift; recycling worker and re-acquiring.",
+				"pid", pid,
+				"user", username,
+				"worker", worker.ID,
+				"attempt", attempt,
+				"error", err,
+			)
+		case isWorkerConnPoolTimeoutError(err):
+			// The worker's single session connection never returned to its pool
+			// (a previous session's cleanup is stuck) — the worker is WEDGED, and
+			// because it still looks hot-idle, plain client retries deterministically
+			// reuse it and fail again (observed live: 12 straight failures against
+			// one worker). Recycle it and re-acquire a fresh one.
+			observeWorkerConnPoolWedge()
+			sm.log.Error("Worker session-create timed out acquiring its DB connection — wedged worker; recycling and re-acquiring.",
+				"pid", pid,
+				"user", username,
+				"worker", worker.ID,
+				"attempt", attempt,
+				"error", err,
+			)
+		default:
 			return 0, nil, err
 		}
 
-		// One-session-per-worker invariant violated: the CP scheduled this worker
-		// believing it idle, but the worker still holds a session. Recycle it
-		// (graceful drain via retire) so it leaves the schedulable pool, and retry
-		// with a fresh worker. Loud ERROR + metric so we can find and fix the drift.
+		// Recycle (graceful drain via retire) so the worker leaves the
+		// schedulable pool, and retry with a fresh worker.
 		lastCapDriftErr = err
-		observeWorkerSessionCapDrift()
-		sm.log.Error("Worker rejected a CP-scheduled session at its session cap — one-session-per-worker accounting drift; recycling worker and re-acquiring.",
-			"pid", pid,
-			"user", username,
-			"worker", worker.ID,
-			"attempt", attempt,
-			"error", err,
-		)
 		sm.pool.RetireWorker(worker.ID)
 	}
 
@@ -368,6 +385,17 @@ const maxWorkerSessionCapDriftRetries = 2
 // "max sessions reached (N)", which propagates through the wrapped error chain.
 func isWorkerSessionCapError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "max sessions reached")
+}
+
+// isWorkerConnPoolTimeoutError reports whether err is the worker-side
+// "failed to obtain connection from pool" session-create failure
+// (duckdbservice acquires the single-session DB connection with a 30s
+// timeout; see the MaxOpenConns=1 isolation contract). A worker returning
+// this is wedged — its connection never came back from the previous
+// session's cleanup — and because it parks hot-idle afterwards, plain
+// client retries deterministically reuse it; it must be recycled instead.
+func isWorkerConnPoolTimeoutError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to obtain connection from pool")
 }
 
 func (sm *SessionManager) resolveSessionLimits(memoryLimit string, threads int) (string, int) {

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -639,3 +639,22 @@ func TestSessionManager_ConnectionLimits_WorkerCrashGrantsQueuedWaiter(t *testin
 		t.Fatal("timed out waiting for queued waiter after OnWorkerCrash")
 	}
 }
+
+func TestIsWorkerConnPoolTimeoutError(t *testing.T) {
+	// The exact wedged-worker signature observed live (e2e ci-pr-759, worker 26:
+	// 12 straight client retries deterministically reused the same hot-idle
+	// wedged worker). The CP must classify it for recycle-and-reacquire.
+	err := fmt.Errorf("create session: %w",
+		fmt.Errorf("create session on worker 26: create session recv: %w",
+			errors.New("rpc error: code = ResourceExhausted desc = create session: failed to obtain connection from pool (timeout after 30s): context deadline exceeded")))
+	if !isWorkerConnPoolTimeoutError(err) {
+		t.Fatal("wedged-worker pool-timeout error not classified for recycle")
+	}
+	// Cap errors and unrelated errors must not match.
+	if isWorkerConnPoolTimeoutError(errors.New("max sessions reached (1)")) {
+		t.Fatal("cap error misclassified as pool timeout")
+	}
+	if isWorkerConnPoolTimeoutError(nil) {
+		t.Fatal("nil misclassified")
+	}
+}


### PR DESCRIPTION
## Bug (second live sighting)

A worker whose single session DB connection never returns to its pool (previous session's cleanup stuck past the 30s acquire timeout — the `MaxOpenConns=1` isolation contract) rejects every new session with `ResourceExhausted: failed to obtain connection from pool`. But it **parks hot-idle afterwards**, so the org's retrying client deterministically reuses the *same wedged worker*: e2e `ci-pr-759` saw 12 straight retries against worker 26. Client-side retry cannot escape by construction.

## Fix

Extend the existing session-cap-drift recycle path in `SessionManager`: a pool-timeout rejection now also **retires the worker and re-acquires a fresh one**, bounded by the same retry budget (`maxWorkerSessionCapDriftRetries`). New counter `duckgres_control_plane_worker_conn_pool_wedge_total` — nonzero rate = worker-side session cleanup is hanging; that root cause still wants finding, this stops it from failing clients.

## Testing

- unit: `TestIsWorkerConnPoolTimeoutError` classifies the exact live error chain; cap/nil/unrelated don't match. Full suites green both tag sets.
- e2e: the harness's retry set already tolerates the error string (added after the first sighting) — with this fix the retry actually lands on a fresh worker. The flake that motivated this (twice in three days, both in worker-churn-heavy lanes) is the regression signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)