### PR TITLE
[codex] reconcile postgres compatibility status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,4 +280,7 @@ Invariants for anyone touching this path:
 
 ## TODO Reference
 
-See `TODO.md` for the full feature roadmap and known issues.
+`TODO.md` is a lightweight backlog for ideas that do not yet have a better
+home. It is not the PostgreSQL compatibility source of truth; use
+`docs/postgres-compatibility.md` for compatibility status, test citations, and
+known gaps.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A PostgreSQL wire protocol compatible server backed by DuckDB. Connect with any 
 
 ## Features
 
-- **PostgreSQL Wire Protocol**: Full compatibility with PostgreSQL clients
+- **PostgreSQL Wire Protocol**: Compatibility with PostgreSQL clients for analytical workloads
 - **Two-Tier Query Processing**: Transparently handles both PostgreSQL and DuckDB-specific syntax
 - **TLS Encryption**: Required TLS connections with auto-generated self-signed certificates
 - **Per-User Databases**: Each authenticated user gets their own isolated DuckDB database file
@@ -734,7 +734,7 @@ The following DuckDB features work transparently through the fallback mechanism:
 ### PostgreSQL Compatibility
 - Extended query protocol (prepared statements)
 - Binary and text result formats
-- MD5 password authentication
+- Cleartext password authentication over TLS
 - Basic `pg_catalog` system tables for client compatibility
 - `\dt`, `\d`, and other psql meta-commands
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@
 - [ ] **Dynamic User Management**: Add/remove users without restart
 
 ### Protocol Compatibility
-- [ ] **Binary Format Support**: Encode results in binary format for better performance with some clients
+- [x] **Binary Result Format Support**: Encode common result types in PostgreSQL binary format for clients that request it ([conn_results.go](server/conn_results.go), [types.go](server/types.go), [clients_test.go](tests/integration/clients/clients_test.go))
 - [x] **COPY Protocol**: Support `COPY FROM`/`COPY TO` for bulk data loading
 - [x] **Cancel Request Handling**: Properly cancel long-running queries ([protocol.go](server/protocol.go), [cancel_test.go](tests/integration/cancel_test.go))
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,82 +1,46 @@
-# TODO - Future Enhancements
+# Backlog / Ideas
 
-## High Priority
+This file is a lightweight, non-canonical backlog for project ideas that do not
+yet have a better home. It is not the PostgreSQL compatibility source of truth;
+use [docs/postgres-compatibility.md](docs/postgres-compatibility.md) for
+feature-by-feature compatibility status, test citations, and known gaps.
 
-### Security
-- [x] **TLS/SSL Support**: Add encrypted connections for production use
-- [ ] **MD5 Password Authentication**: Support PostgreSQL's MD5-based auth for better security
-- [ ] **SCRAM-SHA-256 Authentication**: Modern PostgreSQL authentication method
-- [x] **Connection Rate Limiting**: Prevent brute-force attacks
+Prefer GitHub issues for committed work. Keep this file short: remove items once
+they move to issues, docs, or implementation.
 
-### Configuration
-- [x] **Config File Support**: Load configuration from YAML/TOML file instead of hardcoding
-- [x] **Environment Variables**: Support `DUCKGRES_PORT`, `DUCKGRES_DATA_DIR`, etc.
-- [x] **Command Line Flags**: `--port`, `--data-dir`, `--config` options
-- [ ] **Dynamic User Management**: Add/remove users without restart
+## Authentication & Users
 
-### Protocol Compatibility
-- [x] **Binary Result Format Support**: Encode common result types in PostgreSQL binary format for clients that request it ([conn_results.go](server/conn_results.go), [types.go](server/types.go), [clients_test.go](tests/integration/clients/clients_test.go))
-- [x] **COPY Protocol**: Support `COPY FROM`/`COPY TO` for bulk data loading
-- [x] **Cancel Request Handling**: Properly cancel long-running queries ([protocol.go](server/protocol.go), [cancel_test.go](tests/integration/cancel_test.go))
+- Support PostgreSQL MD5 password authentication.
+- Support SCRAM-SHA-256 authentication.
+- Add dynamic user management without restart.
 
-### Compatibility
-- [x] **System Catalog Emulation**: Basic `pg_catalog` compatibility for psql
-  - [x] `\dt` (list tables) - working
-  - [x] `\l` (list databases) - working
-  - [x] `\d <table>` (describe table) - working
-- [x] **Information Schema**: Emulate PostgreSQL's `information_schema` ([information_schema.go](transpiler/transform/information_schema.go))
-- [x] **Session Variables**: Support `SET` commands (timezone, search_path, etc.) ([setshow.go](transpiler/transform/setshow.go))
-- [x] **Type OID Mapping**: Proper PostgreSQL OID mapping for all DuckDB types ([types.go](server/types.go))
+## Configuration & Operations
 
-### Features
-- [x] **Extensions**: Load DuckDB extensions on startup
+- Support hot-reloading config without restart.
+- Add admin commands such as `\duckgres status` and `\duckgres users`.
+- Add a health check endpoint for load balancers.
 
-### Operations
-- [ ] **Hot Reload**: Reload config without restart
-- [ ] **Admin Commands**: `\duckgres status`, `\duckgres users`, etc.
-- [x] **Docker Image**: Official container image ([Dockerfile](Dockerfile))
-- [x] **Graceful Shutdown**: Finish in-flight queries before shutdown
+## Observability
 
-## Medium Priority
+- Add slow query logging for queries exceeding a configurable threshold.
 
-### Performance
-- [ ] **DuckDB Per Connection**: each connection for each user is a separate duckdb instance 
-- [x] **Connection Limits**: Max connections per user and globally ([ratelimit.go](server/ratelimit.go))
+## Architecture & Storage
 
-### Monitoring
-- [x] **Prometheus Metrics**: Export query count, latency, connection stats ([metrics.go](server/flightsqlingress/metrics.go), [flight_ingress_metrics.go](controlplane/flight_ingress_metrics.go))
-- [x] **Query Logging**: Configurable query logging to file/stdout ([querylog.go](server/querylog.go))
-- [ ] **Slow Query Log**: Log queries exceeding threshold
-- [ ] **Health Check Endpoint**: HTTP endpoint for load balancer health checks
+- Review whether each connection should own a separate DuckDB instance.
+- Support read-only replicas using DuckDB `ATTACH`.
+- Support multiple named databases per user.
+- Define remaining schema support beyond the compatibility surfaces documented in
+  [docs/postgres-compatibility.md](docs/postgres-compatibility.md).
 
-## Low Priority
+## Research
 
-### Features
-- [ ] **Read Replicas**: Support read-only replicas using DuckDB's `ATTACH`
-- [ ] **Multi-Database**: Support multiple named databases per user
-- [ ] **Schema Support**: PostgreSQL schema emulation
-
-### Testing
-- [x] **Unit Tests**: Test wire protocol parsing/encoding ([protocol_test.go](server/protocol_test.go), [types_test.go](server/types_test.go), [conn_test.go](server/conn_test.go))
-- [x] **Integration Tests**: Test with various PostgreSQL clients ([tests/integration/](tests/integration/README.md))
-- [x] **Compatibility Tests**: Run PostgreSQL regression tests ([clients_test.go](tests/integration/clients/clients_test.go), [jdbc_test.go](tests/integration/jdbc_test.go))
-- [x] **Benchmark Suite**: Performance comparison with native PostgreSQL ([tests/perf/](tests/perf/README.md))
-
-## Ideas / Research
-
-- **Federation**: Query multiple DuckDB files in single query
-- **Caching Layer**: Redis/memcached for query results
-- **Query Rewriting**: Translate PostgreSQL-specific syntax to DuckDB
-- **MotherDuck Integration**: Support MotherDuck cloud backend
-- **Parquet Direct Query**: `SELECT * FROM 's3://bucket/file.parquet'`
-
-## Known Issues
-
-- [x] Some PostgreSQL drivers may fail with unsupported OIDs — unknown types fall back to `OidText` ([types.go](server/types.go))
-- [x] `\d` commands in psql don't work (need system catalog) - fixed
-- [x] Transaction isolation may differ from PostgreSQL behavior — documented in [README](README.md#transaction-isolation)
-- [x] Large result sets may cause memory issues (no streaming) — results are streamed row-by-row via `rows.Next()` + server-side cursor emulation ([conn_cursor.go](server/conn_cursor.go))
+- Federation: query multiple DuckDB files in a single query.
+- Caching layer: Redis/memcached for query results.
+- Query rewriting: translate PostgreSQL-specific syntax to DuckDB.
+- MotherDuck integration.
+- Parquet direct query: `SELECT * FROM 's3://bucket/file.parquet'`.
 
 ## Contributing
 
-Pick an item from this list and submit a PR! Issues labeled [`good first issue`](https://github.com/PostHog/duckgres/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are great starting points.
+Issues labeled [`good first issue`](https://github.com/PostHog/duckgres/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+are a good place to start.

--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -167,7 +167,7 @@ why.
 | **Cursors: DECLARE / FETCH / MOVE** | ⚠️ | server `conn_querylog_feedback_test.go::TestHandleFetchCursorLogsMissingCursorError` (error path only) | **Gap.** Implemented in `server/conn_cursor.go` (FETCH is forward-only); no differential DECLARE→FETCH happy-path test |
 | Cursor CLOSE | 🟡 | `conn_test.go` (CLOSE detection) | |
 | Auth: cleartext password | ✅ | server `worker_auth_test.go`; integration via connection params | |
-| Auth: MD5 | 🟡 | — | README claims MD5; no direct test |
+| Auth: MD5 | ❌ | — | Current startup path requests cleartext password auth over TLS |
 | Auth: SCRAM-SHA-256 | ❌ | — | not tested |
 | TLS / SSL (`sslmode=require`) | ✅ | `edge_cases_test.go::TestConnectionParameters` | |
 
@@ -265,7 +265,7 @@ Sorted by what's worth acting on first.
 3. **🟡 Transpiler-only, no differential assertion:** generated columns, `SELECT FOR
    UPDATE/SHARE` (stripped). Add differential cases if these matter to clients.
 
-4. **❌ Untested but plausibly reachable — undefined behavior today:** MD5/SCRAM auth,
+4. **❌ Unsupported or untested but plausibly reachable — undefined behavior today:** MD5/SCRAM auth,
    enum/domain/composite/xml types, advisory locks, `LOCK TABLE`,
    GRANT/REVOKE/roles, `information_schema.{key_column_usage,table_constraints,
    referential_constraints}` (ORM FK discovery), `TABLESAMPLE`. Asserting these

--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -3,7 +3,7 @@
 This is the canonical, feature-by-feature record of **what PostgreSQL functionality
 Duckgres supports and which tests prove it.** It exists so that "is feature X
 supported?" and "where's the test / where's the gap?" have one answer instead of
-being smeared across the README, `tests/integration/README.md`, and `TODO.md`.
+being smeared across the README and test docs.
 
 Duckgres speaks the PostgreSQL wire protocol but executes on **DuckDB**, an OLAP
 engine. So the compatibility target is "PostgreSQL semantics for analytical
@@ -394,5 +394,5 @@ deliberate stubs sized to satisfy client introspection, not real implementations
 
 - [README.md](../README.md) → "SQL Client Compatibility" — short user-facing summary that links here.
 - [tests/integration/README.md](../tests/integration/README.md) — test-suite architecture, category counts, and the skip-reason table.
-- [TODO.md](../TODO.md) — forward-looking compatibility/protocol gaps.
+- [TODO.md](../TODO.md) — lightweight backlog for project ideas that do not yet have a better home.
 - [scripts/client-compat/README.md](../scripts/client-compat/README.md) — real-driver compatibility harness and `queries.yaml`.


### PR DESCRIPTION
## Summary

- Soften README wording around PostgreSQL compatibility to match the scoped compatibility matrix.
- Replace the stale MD5 auth claim with the current cleartext-over-TLS behavior.
- Mark binary result format support complete in TODO with implementation/test references.
- Update the compatibility matrix so MD5 auth is marked unsupported rather than partially supported.
- Trim `TODO.md` into a lightweight non-canonical backlog and remove completed/history entries.
- Update references in `CLAUDE.md` and the compatibility matrix so `TODO.md` is no longer described as the full roadmap or compatibility source of truth.

## Validation

- `just lint`
- `git diff --check`