### PR TITLE
test(compat): cursor happy-path coverage + tx-end deadlock & extended MOVE fixes

### DIFF
--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -164,8 +164,8 @@ why.
 | Error / notice + recovery (in & out of txn) | ✅ | `protocol_test.go::TestProtocolErrors`, `edge_cases_test.go::TestErrorRecovery` | |
 | Empty / comment-only queries | ✅ | `edge_cases_test.go::TestEmptyQuery`, `::TestPgxPing` | |
 | Multi-statement simple query | ✅ | `protocol_test.go::TestProtocolMultipleStatements`, `edge_cases_test.go::TestMultiStatementBehavior` | |
-| **Cursors: DECLARE / FETCH / MOVE** | ⚠️ | server `conn_querylog_feedback_test.go::TestHandleFetchCursorLogsMissingCursorError` (error path only) | **Gap.** Implemented in `server/conn_cursor.go` (FETCH is forward-only); no differential DECLARE→FETCH happy-path test |
-| Cursor CLOSE | 🟡 | `conn_test.go` (CLOSE detection) | |
+| **Cursors: DECLARE / FETCH / MOVE** | ✅ | `cursor_test.go::TestCursorSimpleQuery` + `::TestCursorPostgresParity` (differential), `::TestCursorExtendedQuery` (pgx, extended protocol); server `conn_querylog_feedback_test.go::TestHandleFetchCursorLogsMissingCursorError` (error path) | Emulated in `server/conn_cursor.go`. Forward-only: backward fetch → `0A000` (PostgreSQL uses `55000` for non-SCROLL cursors, same message). Re-DECLARE of an open cursor replaces it (PostgreSQL raises `42P03`). Cursors close at transaction end, before COMMIT/ROLLBACK executes (also a liveness requirement: an open cursor rowset pins the session's single DuckDB connection — `server/conn_cursor_test.go::TestCloseCursorsAtTxEnd`) |
+| Cursor CLOSE | ✅ | `cursor_test.go::TestCursorSimpleQuery/lifecycle_fetch_close` + parity, `::TestCursorExtendedQuery/declare_fetch_close`; server `conn_test.go` (CLOSE detection) | FETCH after CLOSE → clean `34000` missing-cursor error |
 | Auth: cleartext password | ✅ | server `worker_auth_test.go`; integration via connection params | |
 | Auth: MD5 | ❌ | — | Current startup path requests cleartext password auth over TLS |
 | Auth: SCRAM-SHA-256 | ❌ | — | not tested |
@@ -251,27 +251,21 @@ must route them to native DuckDB execution rather than the PG transpiler.
 
 Sorted by what's worth acting on first.
 
-1. **⚠️ Cursors (DECLARE/FETCH/MOVE) — implemented but no happy-path test.** The only
-   coverage is the missing-cursor *error* path
-   (`conn_querylog_feedback_test.go::TestHandleFetchCursorLogsMissingCursorError`).
-   This is live, client-reachable code (`server/conn_cursor.go`) with no differential
-   assertion. **Highest-priority gap.**
-
-2. **🟡 Stale `skipIfKnown` skips.** Differential RETURNING
+1. **🟡 Stale `skipIfKnown` skips.** Differential RETURNING
    (`TestDML{Insert,Update,Delete}Returning`) and `COPY TO STDOUT`
    (`TestCopyToStdout`) are skipped in `tests/integration/` though the behavior is
    covered at unit/client level. Re-enable or document why they must stay skipped.
 
-3. **🟡 Transpiler-only, no differential assertion:** generated columns, `SELECT FOR
+2. **🟡 Transpiler-only, no differential assertion:** generated columns, `SELECT FOR
    UPDATE/SHARE` (stripped). Add differential cases if these matter to clients.
 
-4. **❌ Unsupported or untested but plausibly reachable — undefined behavior today:** MD5/SCRAM auth,
+3. **❌ Unsupported or untested but plausibly reachable — undefined behavior today:** MD5/SCRAM auth,
    enum/domain/composite/xml types, advisory locks, `LOCK TABLE`,
    GRANT/REVOKE/roles, `information_schema.{key_column_usage,table_constraints,
    referential_constraints}` (ORM FK discovery), `TABLESAMPLE`. Asserting these
    (even as "errors cleanly") would pin the compatibility boundary.
 
-5. **⛔ Out of scope by design (correctly skipped):** SAVEPOINT, MERGE,
+4. **⛔ Out of scope by design (correctly skipped):** SAVEPOINT, MERGE,
    sequences/SERIAL, materialized views, partitioning/inheritance,
    triggers/PL-pgSQL/rules/LISTEN-NOTIFY, RLS, and the network/geometric/range/
    text-search/money types. These are DuckDB or OLTP limitations.

--- a/server/conn.go
+++ b/server/conn.go
@@ -88,6 +88,7 @@ type preparedStmt struct {
 	cursorName        string   // Cursor name
 	cursorQuery       string   // Transpiled inner SELECT (for DECLARE)
 	fetchCount        int64    // FETCH row count
+	cursorIsMove      bool     // FETCH is a MOVE: advance position without returning rows
 	warnings          []string // Transpiler warnings to surface as NoticeResponse at Execute
 }
 
@@ -1314,6 +1315,10 @@ func (c *clientConn) handleQuery(body []byte) error {
 			_ = c.writer.Flush()
 			return nil
 		}
+
+		// Open cursors pin the session's single DuckDB connection — release
+		// them before a transaction-end statement needs it.
+		c.closeCursorsAtTxEnd(cmdType)
 
 		ctx, cleanup := c.queryContext()
 		defer cleanup()

--- a/server/conn_cursor.go
+++ b/server/conn_cursor.go
@@ -103,6 +103,21 @@ func (c *clientConn) closeAllCursors() {
 	}
 }
 
+// closeCursorsAtTxEnd closes all open cursors before a COMMIT/ROLLBACK
+// statement executes. PostgreSQL destroys non-holdable cursors at transaction
+// end; doing it BEFORE the statement runs (rather than after, in
+// updateTxStatus) is required for liveness, not just compatibility: the
+// session's DuckDB pool is capped at one connection (openBaseDB), so a
+// partially-read cursor's open rowset holds the only connection and the
+// COMMIT/ROLLBACK would block on it forever. updateTxStatus keeps its
+// post-exec close as a backstop for paths that don't call this hook.
+func (c *clientConn) closeCursorsAtTxEnd(cmdType string) {
+	if cmdType != "COMMIT" && cmdType != "ROLLBACK" {
+		return
+	}
+	c.closeAllCursors()
+}
+
 // getCursorSchema opens the cursor if needed to retrieve column metadata,
 // then returns the schema information. Used by handleDescribe for FETCH statements.
 func (c *clientConn) getCursorSchema(cursorName string) ([]string, []ColumnTyper, error) {
@@ -446,6 +461,24 @@ func (c *clientConn) handleFetchCursorExtended(p *portal) {
 	}
 
 	howMany := p.stmt.fetchCount
+
+	// MOVE: advance position without returning rows (mirrors the
+	// simple-protocol path in handleFetchCursor).
+	if p.stmt.cursorIsMove {
+		moveCount := int64(0)
+		for moveCount < howMany && cursor.rows.Next() {
+			// Read the row to advance position, but don't send it
+			values := make([]interface{}, len(cursor.cols))
+			valuePtrs := make([]interface{}, len(cursor.cols))
+			for i := range values {
+				valuePtrs[i] = &values[i]
+			}
+			_ = cursor.rows.Scan(valuePtrs...)
+			moveCount++
+		}
+		_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("MOVE %d", moveCount))
+		return
+	}
 
 	// Send RowDescription if Describe wasn't already called
 	if !p.described && len(cursor.cols) > 0 {

--- a/server/conn_cursor_test.go
+++ b/server/conn_cursor_test.go
@@ -1,0 +1,38 @@
+package server
+
+import "testing"
+
+// closeCursorsAtTxEnd must release open cursors BEFORE a COMMIT/ROLLBACK
+// executes: an open cursor rowset holds the session's only DuckDB connection
+// (openBaseDB caps the pool at 1), so the transaction-end statement would
+// otherwise block forever on the connection the cursor holds. The end-to-end
+// regression for the deadlock is tests/integration/cursor_test.go
+// (cursorBackwardFlow rolls back with a partially-read cursor open).
+func TestCloseCursorsAtTxEnd(t *testing.T) {
+	for _, tc := range []struct {
+		cmdType string
+		closed  bool
+	}{
+		{"COMMIT", true},
+		{"ROLLBACK", true},
+		{"BEGIN", false},
+		{"SELECT", false},
+		{"FETCH", false},
+		{"INSERT", false},
+	} {
+		released := false
+		c := &clientConn{cursors: map[string]*cursorState{
+			"cur_pending": {query: "SELECT 1"},
+			"cur_open":    {query: "SELECT 2", cleanup: func() { released = true }},
+		}}
+
+		c.closeCursorsAtTxEnd(tc.cmdType)
+
+		if gotClosed := len(c.cursors) == 0; gotClosed != tc.closed {
+			t.Errorf("closeCursorsAtTxEnd(%q): cursors closed = %v, want %v", tc.cmdType, gotClosed, tc.closed)
+		}
+		if released != tc.closed {
+			t.Errorf("closeCursorsAtTxEnd(%q): cursor query context released = %v, want %v", tc.cmdType, released, tc.closed)
+		}
+	}
+}

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -94,6 +94,7 @@ func (c *clientConn) handleParse(body []byte) {
 				cursorOp:       cursorOpFetch,
 				cursorName:     s.FetchStmt.Portalname,
 				fetchCount:     s.FetchStmt.HowMany,
+				cursorIsMove:   s.FetchStmt.Ismove,
 			}
 			_ = wire.WriteParseComplete(c.writer)
 			return
@@ -248,6 +249,11 @@ func (c *clientConn) handleDescribe(body []byte) {
 			_ = wire.WriteNoData(c.writer)
 			return
 		case cursorOpFetch:
+			// MOVE advances the cursor without returning rows — NoData.
+			if ps.cursorIsMove {
+				_ = wire.WriteNoData(c.writer)
+				return
+			}
 			// FETCH returns rows — look up cursor to get schema
 			cols, colTypes, err := c.getCursorSchema(ps.cursorName)
 			if err != nil || len(cols) == 0 {
@@ -367,6 +373,11 @@ func (c *clientConn) handleDescribe(body []byte) {
 			_ = wire.WriteNoData(c.writer)
 			return
 		case cursorOpFetch:
+			// MOVE advances the cursor without returning rows — NoData.
+			if p.stmt.cursorIsMove {
+				_ = wire.WriteNoData(c.writer)
+				return
+			}
 			cols, colTypes, err := c.getCursorSchema(p.stmt.cursorName)
 			if err != nil || len(cols) == 0 {
 				_ = wire.WriteNoData(c.writer)
@@ -617,6 +628,10 @@ func (c *clientConn) handleExecute(body []byte) {
 			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
 			return
 		}
+
+		// Open cursors pin the session's single DuckDB connection — release
+		// them before a transaction-end statement needs it.
+		c.closeCursorsAtTxEnd(cmdType)
 
 		// Non-result-returning query: use Exec with converted query
 		runExec := func() (ExecResult, error) {

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -28,6 +28,10 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 			return nil
 		}
 
+		// Open cursors pin the session's single DuckDB connection — release
+		// them before a transaction-end statement needs it.
+		c.closeCursorsAtTxEnd(cmdType)
+
 		ctx, cleanup := c.queryContext()
 		defer cleanup()
 
@@ -649,6 +653,10 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
 			return false, nil
 		}
+
+		// Open cursors pin the session's single DuckDB connection — release
+		// them before a transaction-end statement needs it.
+		c.closeCursorsAtTxEnd(cmdType)
 
 		ctx, cleanup := c.queryContext()
 		defer cleanup()

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -51,6 +51,12 @@ client-go:
   harness Job image is `postgres:18-alpine` (pipeline meta-commands are
   psql 18+). The same wire lane also asserts that a pgwire CancelRequest leaves
   the same session immediately reusable.
+- **server-side cursors** — DECLARE → `FETCH n` → `MOVE n` (advances without
+  returning rows) → `FETCH ALL` (remaining rows only) → CLOSE, with exact value
+  assertions on a live worker; then ROLLBACK while a second cursor is still
+  partially read must return promptly and leave the session usable (an open
+  cursor rowset pins the worker session's single DuckDB connection — the
+  pre-fix behavior deadlocked the session at transaction end).
 - **cold-burst absorption** — there is no warm pool, so a burst of cold sessions
   spawns workers on demand; if it outruns the org/global cap the surplus gets a
   graceful client-visible hint (`no Duckgres worker … retry in about 45 seconds`

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -470,6 +470,49 @@ EOF
   pg "$1" "$2" ducklake "DROP TABLE $t;"
 }
 
+# Server-side cursor emulation (server/conn_cursor.go) on a live worker:
+# DECLARE → FETCH n → MOVE n (advances WITHOUT returning rows) → FETCH ALL
+# (remaining rows only) → CLOSE, with exact value assertions. The second
+# cursor is deliberately left PARTIALLY READ when ROLLBACK runs: an open
+# cursor rowset pins the worker session's single DuckDB connection, and
+# transaction end must release it BEFORE the COMMIT/ROLLBACK statement needs
+# the connection — the pre-fix behavior deadlocked the session forever
+# (closeCursorsAtTxEnd; regression also in tests/integration/cursor_test.go).
+# The trailing SELECT 1 proves the same session is alive after the rollback.
+# Each -c is its own simple-Query message on ONE connection (cursors are
+# session state). `timeout` turns a deadlock regression into a crisp fail
+# instead of hanging the Job to its deadline.
+server_side_cursors() { # org password
+  log "server-side cursors (DECLARE/FETCH/MOVE/CLOSE + tx-end liveness) on $1"
+  a=0
+  while :; do
+    out="$(PGPASSWORD="$2" timeout 120 psql \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
+        -v ON_ERROR_STOP=1 -tA \
+        -c 'BEGIN' \
+        -c 'DECLARE e2e_cur CURSOR FOR SELECT * FROM generate_series(1,10) ORDER BY 1' \
+        -c 'FETCH 3 FROM e2e_cur' \
+        -c 'MOVE 2 FROM e2e_cur' \
+        -c 'FETCH ALL FROM e2e_cur' \
+        -c 'CLOSE e2e_cur' \
+        -c 'DECLARE e2e_cur2 CURSOR FOR SELECT * FROM generate_series(1,10) ORDER BY 1' \
+        -c 'FETCH 2 FROM e2e_cur2' \
+        -c 'ROLLBACK' \
+        -c 'SELECT 1' 2>&1)" && break
+    case "$out" in
+      *"capacity exhausted"*|*"no Duckgres worker"*|\
+      *"still provisioning"*|*"failed to initialize session"*|\
+      *"timed out waiting for an available worker"*|*"failed to start"*|*"spawn sized worker"*|\
+      *"failed to detect attached catalogs"*)
+        [ "$a" -lt 12 ] || fail "$1 cursors: backpressure never cleared ($(printf %s "$out" | tr '\n' ' ' | tail -c 120))"
+        sleep 10; a=$((a + 1)); continue ;;
+      *) fail "$1 cursors: lifecycle failed or hung ($(printf %s "$out" | tr '\n' ' ' | tail -c 300))" ;;
+    esac
+  done
+  want="$(printf 'BEGIN\nDECLARE CURSOR\n1\n2\n3\nMOVE 2\n6\n7\n8\n9\n10\nCLOSE CURSOR\nDECLARE CURSOR\n1\n2\nROLLBACK\n1')"
+  [ "$out" = "$want" ] || fail "$1 cursors: got '$(printf %s "$out" | tr '\n' ' ')', want '$(printf %s "$want" | tr '\n' ' ')'"
+}
+
 # Black-box regression for async cancel cleanup: libpq's cancel path sends a
 # PostgreSQL CancelRequest while keeping the same connection open. The next
 # query runs immediately on that same session; if the control plane reuses the
@@ -1289,6 +1332,7 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   persistent_user_secret "$CNPG" "$cnpg_pw"   # after rw_ducklake (org worker hot)
   persistent_user_secret_isolation "$CNPG" "$cnpg_pw"
   pipeline_error_recovery "$CNPG" "$cnpg_pw"  # after rw_ducklake (table writes proven)
+  server_side_cursors    "$CNPG" "$cnpg_pw"
   cancel_then_reuse_same_session "$CNPG" "$cnpg_pw"
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
   iceberg_cold_first_connect "$CNPG" "$cnpg_pw"  # cold first session must not fail the metadata-init bind

--- a/tests/integration/cursor_test.go
+++ b/tests/integration/cursor_test.go
@@ -1,0 +1,356 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Cursor happy-path coverage (docs/postgres-compatibility.md §6 Wire Protocol).
+//
+// Server-side cursors are emulated in server/conn_cursor.go with two distinct
+// entry points:
+//   - Simple query protocol (lib/pq sends parameter-less statements this way):
+//     handleDeclareCursor / handleFetchCursor / handleCloseCursor.
+//   - Extended query protocol (pgx.Conn.Query always goes through
+//     Parse/Bind/Describe/Execute): the cursorOp* detection in
+//     conn_extended_query.go plus handle*CursorExtended.
+//
+// The shared flows also run against the comparison PostgreSQL 16 instance in
+// TestCursorPostgresParity so the expected row sets and error shapes stay
+// honest. Flows run inside a transaction block because real PostgreSQL
+// requires one for cursor use (Duckgres accepts cursors outside transactions
+// too, which the extended-protocol tests exercise).
+
+// cursorRow is one (id, name) row from the users fixture.
+type cursorRow struct {
+	id   int
+	name string
+}
+
+// cursorUsers returns the users fixture rows (fixtures/data.sql) with
+// firstID <= id <= lastID, ordered by id.
+func cursorUsers(firstID, lastID int) []cursorRow {
+	all := []cursorRow{
+		{1, "Alice"}, {2, "Bob"}, {3, "Charlie"}, {4, "Diana"}, {5, "Eve"},
+		{6, "Frank"}, {7, "Grace"}, {8, "Henry"}, {9, "Ivy"}, {10, "Jack"},
+	}
+	var out []cursorRow
+	for _, u := range all {
+		if u.id >= firstID && u.id <= lastID {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+func assertCursorRows(t *testing.T, label string, got, want []cursorRow) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d rows %v, want %d rows %v", label, len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s: row %d = %+v, want %+v", label, i, got[i], want[i])
+		}
+	}
+}
+
+// fetchCursorRows runs a FETCH/MOVE statement on the transaction's connection
+// (lib/pq sends it via the simple query protocol) and collects any rows it
+// returned. Statements that return no result set yield an empty slice.
+func fetchCursorRows(t *testing.T, tx *sql.Tx, stmt string) []cursorRow {
+	t.Helper()
+	rows, err := tx.Query(stmt)
+	if err != nil {
+		t.Fatalf("%s: %v", stmt, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []cursorRow
+	for rows.Next() {
+		var r cursorRow
+		if err := rows.Scan(&r.id, &r.name); err != nil {
+			t.Fatalf("%s: scan: %v", stmt, err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("%s: rows: %v", stmt, err)
+	}
+	return out
+}
+
+func mustExecTx(t *testing.T, tx *sql.Tx, stmt string) {
+	t.Helper()
+	if _, err := tx.Exec(stmt); err != nil {
+		t.Fatalf("%s: %v", stmt, err)
+	}
+}
+
+func beginCursorTx(t *testing.T, db *sql.DB) *sql.Tx {
+	t.Helper()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("BEGIN: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	return tx
+}
+
+// cursorLifecycleFlow covers DECLARE → FETCH n → FETCH n (position advances) →
+// FETCH ALL (drains the rest) → FETCH on exhausted cursor (zero rows) →
+// CLOSE → FETCH after CLOSE (clean missing-cursor error).
+func cursorLifecycleFlow(t *testing.T, db *sql.DB) {
+	tx := beginCursorTx(t, db)
+
+	mustExecTx(t, tx, "DECLARE cur_lifecycle CURSOR FOR SELECT id, name FROM users ORDER BY id")
+
+	assertCursorRows(t, "FETCH 3", fetchCursorRows(t, tx, "FETCH 3 FROM cur_lifecycle"), cursorUsers(1, 3))
+	assertCursorRows(t, "FETCH 3 (resumes)", fetchCursorRows(t, tx, "FETCH 3 FROM cur_lifecycle"), cursorUsers(4, 6))
+	assertCursorRows(t, "FETCH ALL", fetchCursorRows(t, tx, "FETCH ALL FROM cur_lifecycle"), cursorUsers(7, 10))
+	// An exhausted cursor returns zero rows, not an error.
+	assertCursorRows(t, "FETCH 3 (exhausted)", fetchCursorRows(t, tx, "FETCH 3 FROM cur_lifecycle"), nil)
+
+	mustExecTx(t, tx, "CLOSE cur_lifecycle")
+
+	rows, err := tx.Query("FETCH 3 FROM cur_lifecycle")
+	if err == nil {
+		_ = rows.Close()
+		t.Fatal("FETCH after CLOSE succeeded, want missing-cursor error")
+	}
+	if !strings.Contains(err.Error(), `cursor "cur_lifecycle" does not exist`) {
+		t.Errorf("FETCH after CLOSE: error = %q, want it to mention the missing cursor", err)
+	}
+}
+
+// cursorMoveFlow covers MOVE n advancing the position without returning rows.
+func cursorMoveFlow(t *testing.T, db *sql.DB) {
+	tx := beginCursorTx(t, db)
+
+	mustExecTx(t, tx, "DECLARE cur_move CURSOR FOR SELECT id, name FROM users ORDER BY id")
+
+	moved := fetchCursorRows(t, tx, "MOVE 4 FROM cur_move")
+	if len(moved) != 0 {
+		t.Errorf("MOVE 4 returned %d rows %v, want none", len(moved), moved)
+	}
+	assertCursorRows(t, "FETCH ALL after MOVE", fetchCursorRows(t, tx, "FETCH ALL FROM cur_move"), cursorUsers(5, 10))
+
+	mustExecTx(t, tx, "CLOSE cur_move")
+}
+
+// cursorBackwardFlow covers the forward-only restriction: backward fetch
+// fails with a clean error. NO SCROLL pins real PostgreSQL to the same
+// forward-only behavior Duckgres always has (without it, PostgreSQL can
+// satisfy backward fetches from materialized plans like sorts).
+func cursorBackwardFlow(t *testing.T, db *sql.DB) {
+	tx := beginCursorTx(t, db)
+
+	mustExecTx(t, tx, "DECLARE cur_backward NO SCROLL CURSOR FOR SELECT id, name FROM users ORDER BY id")
+	assertCursorRows(t, "FETCH 2", fetchCursorRows(t, tx, "FETCH 2 FROM cur_backward"), cursorUsers(1, 2))
+
+	rows, err := tx.Query("FETCH BACKWARD 1 FROM cur_backward")
+	if err == nil {
+		_ = rows.Close()
+		t.Fatal("FETCH BACKWARD succeeded, want forward-only error")
+	}
+	if !strings.Contains(err.Error(), "cursor can only scan forward") {
+		t.Errorf("FETCH BACKWARD: error = %q, want forward-only error", err)
+	}
+}
+
+// cursorMissingFlow covers FETCH/CLOSE on a cursor that was never declared.
+// Each statement gets its own transaction because the error aborts the
+// transaction on real PostgreSQL.
+func cursorMissingFlow(t *testing.T, db *sql.DB) {
+	tx := beginCursorTx(t, db)
+	rows, err := tx.Query("FETCH 1 FROM cur_never_declared")
+	if err == nil {
+		_ = rows.Close()
+		t.Fatal("FETCH from undeclared cursor succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), `cursor "cur_never_declared" does not exist`) {
+		t.Errorf("FETCH from undeclared cursor: error = %q", err)
+	}
+	_ = tx.Rollback()
+
+	tx2 := beginCursorTx(t, db)
+	if _, err := tx2.Exec("CLOSE cur_never_declared"); err == nil {
+		t.Fatal("CLOSE of undeclared cursor succeeded, want error")
+	} else if !strings.Contains(err.Error(), `cursor "cur_never_declared" does not exist`) {
+		t.Errorf("CLOSE of undeclared cursor: error = %q", err)
+	}
+}
+
+// TestCursorSimpleQuery exercises the simple-query-protocol cursor path
+// against Duckgres.
+func TestCursorSimpleQuery(t *testing.T) {
+	db := testHarness.DuckgresDB
+
+	t.Run("lifecycle_fetch_close", func(t *testing.T) { cursorLifecycleFlow(t, db) })
+	t.Run("move_advances_position", func(t *testing.T) { cursorMoveFlow(t, db) })
+	t.Run("backward_fetch_rejected", func(t *testing.T) { cursorBackwardFlow(t, db) })
+	t.Run("missing_cursor_errors", func(t *testing.T) { cursorMissingFlow(t, db) })
+
+	t.Run("redeclare_replaces_cursor", func(t *testing.T) {
+		tx := beginCursorTx(t, db)
+
+		mustExecTx(t, tx, "DECLARE cur_redeclare CURSOR FOR SELECT id, name FROM users ORDER BY id")
+		assertCursorRows(t, "FETCH 2", fetchCursorRows(t, tx, "FETCH 2 FROM cur_redeclare"), cursorUsers(1, 2))
+
+		// Re-DECLARE with the same name replaces the cursor: the next FETCH
+		// reads the new query from the start. Deliberate divergence: real
+		// PostgreSQL raises 42P03 duplicate_cursor here.
+		mustExecTx(t, tx, "DECLARE cur_redeclare CURSOR FOR SELECT id, name FROM users WHERE id >= 9 ORDER BY id")
+		assertCursorRows(t, "FETCH ALL after re-DECLARE", fetchCursorRows(t, tx, "FETCH ALL FROM cur_redeclare"), cursorUsers(9, 10))
+
+		mustExecTx(t, tx, "CLOSE cur_redeclare")
+	})
+}
+
+// TestCursorPostgresParity runs the shared cursor flows against the
+// comparison PostgreSQL 16 instance, keeping the expectations in the flows
+// differential. redeclare_replaces_cursor is deliberately absent: PostgreSQL
+// raises 42P03 duplicate_cursor where Duckgres replaces the cursor.
+func TestCursorPostgresParity(t *testing.T) {
+	if skipPostgresCompare || testHarness.PostgresDB == nil {
+		t.Skip("PostgreSQL comparison not available")
+	}
+	db := testHarness.PostgresDB
+
+	t.Run("lifecycle_fetch_close", func(t *testing.T) { cursorLifecycleFlow(t, db) })
+	t.Run("move_advances_position", func(t *testing.T) { cursorMoveFlow(t, db) })
+	t.Run("backward_fetch_rejected", func(t *testing.T) { cursorBackwardFlow(t, db) })
+	t.Run("missing_cursor_errors", func(t *testing.T) { cursorMissingFlow(t, db) })
+}
+
+// pgxCursorRows issues stmt via the extended query protocol and returns the
+// rows, command tag, and error. pgx.Conn.Query always goes through
+// Parse/Bind/Describe/Execute; Exec with no arguments would silently
+// downgrade to the simple protocol, which is why it is not used here.
+func pgxCursorRows(ctx context.Context, conn *pgx.Conn, stmt string) ([]cursorRow, pgconn.CommandTag, error) {
+	rows, err := conn.Query(ctx, stmt)
+	if err != nil {
+		return nil, pgconn.CommandTag{}, err
+	}
+	defer rows.Close()
+	var out []cursorRow
+	for rows.Next() {
+		var r cursorRow
+		if err := rows.Scan(&r.id, &r.name); err != nil {
+			return out, pgconn.CommandTag{}, err
+		}
+		out = append(out, r)
+	}
+	rows.Close()
+	return out, rows.CommandTag(), rows.Err()
+}
+
+// TestCursorExtendedQuery exercises the extended-query-protocol cursor path
+// (cursorOpDeclare/cursorOpFetch/cursorOpClose) with pgx.
+func TestCursorExtendedQuery(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("declare_fetch_close", func(t *testing.T) {
+		conn := pgxConnect(t)
+		defer func() { _ = conn.Close(ctx) }()
+
+		_, tag, err := pgxCursorRows(ctx, conn, "DECLARE cur_ext CURSOR FOR SELECT id, name FROM users ORDER BY id")
+		if err != nil {
+			t.Fatalf("DECLARE: %v", err)
+		}
+		if tag.String() != "DECLARE CURSOR" {
+			t.Errorf("DECLARE tag = %q, want %q", tag, "DECLARE CURSOR")
+		}
+
+		got, tag, err := pgxCursorRows(ctx, conn, "FETCH 4 FROM cur_ext")
+		if err != nil {
+			t.Fatalf("FETCH 4: %v", err)
+		}
+		assertCursorRows(t, "FETCH 4", got, cursorUsers(1, 4))
+		if tag.String() != "FETCH 4" {
+			t.Errorf("FETCH 4 tag = %q, want %q", tag, "FETCH 4")
+		}
+
+		got, tag, err = pgxCursorRows(ctx, conn, "FETCH ALL FROM cur_ext")
+		if err != nil {
+			t.Fatalf("FETCH ALL: %v", err)
+		}
+		assertCursorRows(t, "FETCH ALL", got, cursorUsers(5, 10))
+		if tag.String() != "FETCH 6" {
+			t.Errorf("FETCH ALL tag = %q, want %q", tag, "FETCH 6")
+		}
+
+		_, tag, err = pgxCursorRows(ctx, conn, "CLOSE cur_ext")
+		if err != nil {
+			t.Fatalf("CLOSE: %v", err)
+		}
+		if tag.String() != "CLOSE CURSOR" {
+			t.Errorf("CLOSE tag = %q, want %q", tag, "CLOSE CURSOR")
+		}
+
+		// FETCH after CLOSE: clean SQLSTATE 34000 missing-cursor error.
+		_, _, err = pgxCursorRows(ctx, conn, "FETCH 4 FROM cur_ext")
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) {
+			t.Fatalf("FETCH after CLOSE: error = %v, want *pgconn.PgError", err)
+		}
+		if pgErr.Code != "34000" || !strings.Contains(pgErr.Message, `cursor "cur_ext" does not exist`) {
+			t.Errorf("FETCH after CLOSE: code=%s message=%q, want 34000 missing-cursor", pgErr.Code, pgErr.Message)
+		}
+	})
+
+	t.Run("move_advances_position", func(t *testing.T) {
+		conn := pgxConnect(t)
+		defer func() { _ = conn.Close(ctx) }()
+
+		_, _, err := pgxCursorRows(ctx, conn, "DECLARE cur_ext_move CURSOR FOR SELECT id, name FROM users ORDER BY id")
+		if err != nil {
+			t.Fatalf("DECLARE: %v", err)
+		}
+
+		moved, tag, err := pgxCursorRows(ctx, conn, "MOVE 4 FROM cur_ext_move")
+		if err != nil {
+			t.Fatalf("MOVE 4: %v", err)
+		}
+		if len(moved) != 0 {
+			t.Errorf("MOVE 4 returned %d rows %v, want none", len(moved), moved)
+		}
+		if tag.String() != "MOVE 4" {
+			t.Errorf("MOVE 4 tag = %q, want %q", tag, "MOVE 4")
+		}
+
+		got, _, err := pgxCursorRows(ctx, conn, "FETCH ALL FROM cur_ext_move")
+		if err != nil {
+			t.Fatalf("FETCH ALL: %v", err)
+		}
+		assertCursorRows(t, "FETCH ALL after MOVE", got, cursorUsers(5, 10))
+
+		if _, _, err := pgxCursorRows(ctx, conn, "CLOSE cur_ext_move"); err != nil {
+			t.Fatalf("CLOSE: %v", err)
+		}
+	})
+
+	t.Run("backward_fetch_rejected", func(t *testing.T) {
+		conn := pgxConnect(t)
+		defer func() { _ = conn.Close(ctx) }()
+
+		_, _, err := pgxCursorRows(ctx, conn, "DECLARE cur_ext_back NO SCROLL CURSOR FOR SELECT id, name FROM users ORDER BY id")
+		if err != nil {
+			t.Fatalf("DECLARE: %v", err)
+		}
+
+		_, _, err = pgxCursorRows(ctx, conn, "FETCH BACKWARD 1 FROM cur_ext_back")
+		if err == nil {
+			t.Fatal("FETCH BACKWARD succeeded, want forward-only error")
+		}
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "0A000" || !strings.Contains(pgErr.Message, "cursor can only scan forward") {
+			t.Errorf("FETCH BACKWARD: error = %v, want 0A000 forward-only error", err)
+		}
+	})
+}


### PR DESCRIPTION
## Why

`docs/postgres-compatibility.md` flagged cursors (DECLARE/FETCH/MOVE) as its **highest-priority gap**: live, client-reachable code in `server/conn_cursor.go` whose only coverage was a missing-cursor error-path unit test. This PR adds the happy-path coverage — and the new tests immediately caught two real bugs, both fixed here minimally (TDD: red observed for each before the fix).

## Tests added

**`tests/integration/cursor_test.go`**
- **Simple query protocol** (lib/pq sends parameter-less statements this way): lifecycle (`DECLARE` → `FETCH 3` → `FETCH 3` resumes → `FETCH ALL` drains → exhausted fetch returns 0 rows → `CLOSE` → fetch-after-close is a clean `34000`), `MOVE n` advances without returning rows, backward fetch rejected with `cursor can only scan forward`, missing-cursor `FETCH`/`CLOSE` errors, re-`DECLARE` replaces the open cursor.
- **Differential parity**: the same flows run against the comparison PostgreSQL 16 container (`TestCursorPostgresParity`), so the expected row sets and error shapes are pinned to real PostgreSQL. The backward-fetch cursor is declared `NO SCROLL` so PostgreSQL matches Duckgres's always-forward-only behavior. Redeclare is excluded there: PostgreSQL raises `42P03 duplicate_cursor` where Duckgres deliberately replaces.
- **Extended query protocol** with pgx (`TestCursorExtendedQuery`): declare/fetch/close with command tags, MOVE, backward rejection, fetch-after-close as `*pgconn.PgError` `34000`. Driven via `pgx.Conn.Query` because pgx `Exec` with zero args silently downgrades to the simple protocol.

**`tests/e2e-mw-dev/harness.sh`** — new `server_side_cursors` check in the cnpg lane: exact-value DECLARE/FETCH/MOVE/CLOSE lifecycle through the control plane on a live worker, plus the deadlock regression below (`ROLLBACK` with a partially-read cursor must return promptly and leave the session usable; `timeout 120` turns a regression into a crisp fail). Validated the exact psql sequence + expected output against a locally running server.

**`server/conn_cursor_test.go`** — unit test for the new tx-end hook.

## Fix 1: transaction end deadlocked the session while a cursor was partially read

Caught by the backward-fetch flow's rollback: the run hung for 10 minutes and died on Go's test timeout. The session's DuckDB pool is deliberately capped at **one** connection (`openBaseDB`, the session isolation boundary); a partially-read cursor's open rowset holds it; and `updateTxStatus` only closed cursors **after** COMMIT/ROLLBACK executed — which blocked forever waiting for that very connection. Any client that fetches part of a cursor and then ends the transaction (e.g. psycopg2 named-cursor usage that doesn't drain) wedged its session permanently.

`closeCursorsAtTxEnd` now releases cursors **before** the transaction-end statement executes, in all four exec paths (simple, simple-batch, passthrough, extended). This is also PostgreSQL semantics — non-holdable cursors are destroyed at transaction end. `updateTxStatus` keeps its post-exec close as a backstop.

## Fix 2: extended-protocol MOVE executed as a plain FETCH

`Parse` dropped `FetchStmt.Ismove`, so via pgx/JDBC a `MOVE 4 FROM cur` streamed 4 rows back with a `FETCH 4` tag (observed red: `MOVE 4 returned 4 rows … tag = "FETCH 4"`), and Describe returned a RowDescription for a statement that returns no rows. `preparedStmt` now carries `cursorIsMove`; Describe answers `NoData` and Execute consumes rows without sending them, completing with `MOVE n` — mirroring the simple-protocol path, which already handled this.

## Docs

`docs/postgres-compatibility.md`: cursor rows flipped to ✅ with the new test citations (including the deliberate redeclare divergence and the `0A000`-vs-`55000` backward-fetch SQLSTATE note); the "highest-priority gap" summary entry is removed.

## Verification

- `go test ./tests/integration/ -run 'TestCursor'` — 12/12 subtests green (red observed first for both bugs).
- Full `./tests/integration/` suite green except `TestCatalogPsqlCommands/psql_dn`, which fails identically on clean `origin/main` in this environment (local DuckLake-metadata schema pollution, unrelated).
- `go test ./server/...` green; `just lint` — 0 issues; `bash -n harness.sh` clean.
- The e2e harness check runs per-PR via the `e2e-mw-dev.yml` workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)