### PR TITLE
feat(controlplane): rotation fallbacks for the internal API secret

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -212,6 +212,7 @@ func main() {
 		ConfigStoreConn:            resolved.ConfigStoreConn,
 		ConfigPollInterval:         resolved.ConfigPollInterval,
 		InternalSecret:             resolved.InternalSecret,
+		InternalSecretFallbacks:    resolved.InternalSecretFallbacks,
 		SNIRoutingMode:             resolved.SNIRoutingMode,
 		ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
 		DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -61,6 +61,7 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 	configStoreConn := fs.String("config-store", "", "PostgreSQL connection string for config store (env: DUCKGRES_CONFIG_STORE)")
 	configPollInterval := fs.String("config-poll-interval", "", "How often to poll config store for changes (default: 30s) (env: DUCKGRES_CONFIG_POLL_INTERVAL)")
 	internalSecret := fs.String("internal-secret", "", "Shared secret for API authentication (env: DUCKGRES_INTERNAL_SECRET)")
+	internalSecretFallbacks := fs.String("internal-secret-fallbacks", "", "Comma-separated previous internal secrets still accepted for API authentication during rotation, newest first (env: DUCKGRES_INTERNAL_SECRET_FALLBACKS)")
 	sniRoutingMode := fs.String("sni-routing-mode", "", "Hostname-based org routing: 'enforce' (default; require a managed SNI hostname that resolves to an org — the database name selects the catalog, not the org), 'passthrough' (warn on legacy hostnames), 'off' (no SNI handling; identity can no longer be resolved). Multi-tenant only. (env: DUCKGRES_SNI_ROUTING_MODE)")
 	managedHostnameSuffixes := fs.String("managed-hostname-suffixes", "", "Comma-separated DNS suffixes (each starting with '.') for managed tenant hostnames, e.g. '.dw.us.postwh.com'. (env: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES)")
 	workerBackend := fs.String("worker-backend", "", "Worker backend: process (default) or remote for config-store-backed K8s multitenant mode (env: DUCKGRES_WORKER_BACKEND)")
@@ -120,6 +121,7 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 		cli.ConfigStoreConn = *configStoreConn
 		cli.ConfigPollInterval = *configPollInterval
 		cli.InternalSecret = *internalSecret
+		cli.InternalSecretFallbacks = *internalSecretFallbacks
 		cli.SNIRoutingMode = *sniRoutingMode
 		cli.ManagedHostnameSuffixes = *managedHostnameSuffixes
 		cli.WorkerBackend = *workerBackend

--- a/configresolve/cliflags_test.go
+++ b/configresolve/cliflags_test.go
@@ -57,6 +57,7 @@ func fieldNameToFlagName(name string) string {
 		{"ManagedHostnameSuffixes", "managed-hostname-suffixes"},
 		{"ConfigStoreConn", "config-store"},
 		{"ConfigPollInterval", "config-poll-interval"},
+		{"InternalSecretFallbacks", "internal-secret-fallbacks"},
 		{"InternalSecret", "internal-secret"},
 		{"WorkerBackend", "worker-backend"},
 		{"WorkerQueueTimeout", "worker-queue-timeout"},

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -66,6 +66,7 @@ type CLIInputs struct {
 	ConfigStoreConn             string
 	ConfigPollInterval          string
 	InternalSecret              string
+	InternalSecretFallbacks     string
 	SNIRoutingMode              string
 	ManagedHostnameSuffixes     string
 	WorkerBackend               string
@@ -126,6 +127,7 @@ type Resolved struct {
 	ConfigStoreConn                 string
 	ConfigPollInterval              time.Duration
 	InternalSecret                  string
+	InternalSecretFallbacks         []string
 	UserSecretKey                   string
 	SNIRoutingMode                  string
 	ManagedHostnameSuffixes         []string
@@ -209,6 +211,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var configStoreConn string
 	var configPollInterval time.Duration
 	var internalSecret string
+	var internalSecretFallbacks []string
 	var userSecretKey string
 	var sniRoutingMode string
 	var managedHostnameSuffixes []string
@@ -770,6 +773,9 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_INTERNAL_SECRET"); v != "" {
 		internalSecret = v
 	}
+	if v := getenv("DUCKGRES_INTERNAL_SECRET_FALLBACKS"); v != "" {
+		internalSecretFallbacks = splitAndTrim(v, ",")
+	}
 	// Env-only (no CLI flag, no YAML): the AES key for user persistent
 	// secrets should only arrive via a mounted K8s Secret.
 	if v := getenv("DUCKGRES_USER_SECRET_KEY"); v != "" {
@@ -1082,6 +1088,12 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if cli.Set["internal-secret"] {
 		internalSecret = cli.InternalSecret
 	}
+	if cli.Set["internal-secret-fallbacks"] {
+		// An explicitly-set empty flag clears env-provided fallbacks
+		// (splitAndTrim("") == nil), same semantics as posthog's
+		// JWT_SIGNING_KEY_FALLBACKS.
+		internalSecretFallbacks = splitAndTrim(cli.InternalSecretFallbacks, ",")
+	}
 	if cli.Set["sni-routing-mode"] {
 		sniRoutingMode = cli.SNIRoutingMode
 	}
@@ -1226,6 +1238,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		ConfigStoreConn:                 configStoreConn,
 		ConfigPollInterval:              configPollInterval,
 		InternalSecret:                  internalSecret,
+		InternalSecretFallbacks:         internalSecretFallbacks,
 		UserSecretKey:                   userSecretKey,
 		SNIRoutingMode:                  sniRoutingMode,
 		ManagedHostnameSuffixes:         managedHostnameSuffixes,

--- a/configresolve/resolve_internal_secret_test.go
+++ b/configresolve/resolve_internal_secret_test.go
@@ -1,0 +1,65 @@
+package configresolve
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveEffectiveInternalSecretFallbacksFromEnv(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		if key == "DUCKGRES_INTERNAL_SECRET_FALLBACKS" {
+			return "old1, old2,"
+		}
+		return ""
+	}, nil)
+
+	want := []string{"old1", "old2"}
+	if !reflect.DeepEqual(resolved.InternalSecretFallbacks, want) {
+		t.Fatalf("InternalSecretFallbacks = %v, want %v (trimmed, empty entries dropped)",
+			resolved.InternalSecretFallbacks, want)
+	}
+}
+
+func TestResolveEffectiveInternalSecretFallbacksCLIBeatsEnv(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{
+		Set:                     map[string]bool{"internal-secret-fallbacks": true},
+		InternalSecretFallbacks: "cli-old",
+	}, func(key string) string {
+		if key == "DUCKGRES_INTERNAL_SECRET_FALLBACKS" {
+			return "env-old"
+		}
+		return ""
+	}, nil)
+
+	want := []string{"cli-old"}
+	if !reflect.DeepEqual(resolved.InternalSecretFallbacks, want) {
+		t.Fatalf("InternalSecretFallbacks = %v, want %v (CLI beats env)",
+			resolved.InternalSecretFallbacks, want)
+	}
+}
+
+func TestResolveEffectiveInternalSecretFallbacksExplicitEmptyCLIClearsEnv(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{
+		Set:                     map[string]bool{"internal-secret-fallbacks": true},
+		InternalSecretFallbacks: "",
+	}, func(key string) string {
+		if key == "DUCKGRES_INTERNAL_SECRET_FALLBACKS" {
+			return "env-old"
+		}
+		return ""
+	}, nil)
+
+	if len(resolved.InternalSecretFallbacks) != 0 {
+		t.Fatalf("InternalSecretFallbacks = %v, want empty (explicit empty flag clears env)",
+			resolved.InternalSecretFallbacks)
+	}
+}
+
+func TestResolveEffectiveInternalSecretFallbacksUnsetIsNil(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{}, nil, nil)
+
+	if resolved.InternalSecretFallbacks != nil {
+		t.Fatalf("InternalSecretFallbacks = %v, want nil when unset",
+			resolved.InternalSecretFallbacks)
+	}
+}

--- a/controlplane/admin/dashboard.go
+++ b/controlplane/admin/dashboard.go
@@ -3,6 +3,7 @@
 package admin
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"embed"
 	"html/template"
@@ -24,9 +25,57 @@ func init() {
 	dashboardTmpl = template.Must(template.ParseFS(staticFS, "static/*.html"))
 }
 
-func APIAuthMiddleware(adminToken string) gin.HandlerFunc {
+// TokenSet is the set of currently accepted admin bearer tokens: the primary
+// internal secret plus any still-trusted previous secrets (rotation
+// fallbacks). Mirrors posthog's SECRET_KEY + SECRET_KEY_FALLBACKS convention:
+// clients always send the primary; the server accepts any member of the set,
+// so a secret rotation is a phased roll with no auth-mismatch window.
+//
+// Tokens are stored and compared as SHA-256 digests: tokens are arbitrary
+// operator-supplied strings, and subtle.ConstantTimeCompare short-circuits on
+// a length mismatch, so comparing raw values would leak token lengths.
+// Fixed-length digests keep every comparison the same shape regardless of
+// the candidate, the provided value, or which (if any) token matches.
+type TokenSet struct {
+	digests [][sha256.Size]byte
+}
+
+// NewTokenSet builds a TokenSet from the primary secret and rotation
+// fallbacks, dropping empty strings so an unset slot can never validate.
+func NewTokenSet(primary string, fallbacks []string) TokenSet {
+	digests := make([][sha256.Size]byte, 0, 1+len(fallbacks))
+	for _, t := range append([]string{primary}, fallbacks...) {
+		if t != "" {
+			digests = append(digests, sha256.Sum256([]byte(t)))
+		}
+	}
+	return TokenSet{digests: digests}
+}
+
+// Valid reports whether got matches any accepted token. Every candidate
+// digest is compared with subtle.ConstantTimeCompare and there is no early
+// exit on a match.
+func (ts TokenSet) Valid(got string) bool {
+	if got == "" {
+		return false
+	}
+	gotSum := sha256.Sum256([]byte(got))
+	match := 0
+	for i := range ts.digests {
+		match |= subtle.ConstantTimeCompare(gotSum[:], ts.digests[i][:])
+	}
+	return match == 1
+}
+
+// Count returns the number of accepted tokens (for operability logging only —
+// never log the values themselves).
+func (ts TokenSet) Count() int {
+	return len(ts.digests)
+}
+
+func APIAuthMiddleware(tokens TokenSet) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if !validAdminToken(requestAdminToken(c), adminToken) {
+		if !tokens.Valid(requestAdminToken(c)) {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing or invalid admin token"})
 			return
 		}
@@ -35,22 +84,22 @@ func APIAuthMiddleware(adminToken string) gin.HandlerFunc {
 }
 
 // RegisterDashboard serves the admin dashboard on the Gin engine.
-func RegisterDashboard(r *gin.Engine, adminToken string) {
-	r.GET("/", dashboardPageHandler("index.html", adminToken))
-	r.GET("/orgs", dashboardPageHandler("orgs.html", adminToken))
-	r.GET("/workers", dashboardPageHandler("workers.html", adminToken))
-	r.GET("/sessions", dashboardPageHandler("sessions.html", adminToken))
-	r.GET("/settings", dashboardPageHandler("settings.html", adminToken))
-	r.POST("/login", loginHandler(adminToken))
+func RegisterDashboard(r *gin.Engine, tokens TokenSet) {
+	r.GET("/", dashboardPageHandler("index.html", tokens))
+	r.GET("/orgs", dashboardPageHandler("orgs.html", tokens))
+	r.GET("/workers", dashboardPageHandler("workers.html", tokens))
+	r.GET("/sessions", dashboardPageHandler("sessions.html", tokens))
+	r.GET("/settings", dashboardPageHandler("settings.html", tokens))
+	r.POST("/login", loginHandler(tokens))
 }
 
-func dashboardPageHandler(templateName, adminToken string) gin.HandlerFunc {
+func dashboardPageHandler(templateName string, tokens TokenSet) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// The admin token is deliberately NOT accepted via URL query parameters:
 		// URL-borne secrets persist in browser history and any future proxy/access
 		// logs. Authenticate via the POST /login form or the
 		// X-Duckgres-Internal-Secret header instead.
-		if !validAdminToken(requestAdminToken(c), adminToken) {
+		if !tokens.Valid(requestAdminToken(c)) {
 			renderLoginPage(c, loginNextURI(c.Request.URL), "")
 			return
 		}
@@ -61,14 +110,17 @@ func dashboardPageHandler(templateName, adminToken string) gin.HandlerFunc {
 	}
 }
 
-func loginHandler(adminToken string) gin.HandlerFunc {
+func loginHandler(tokens TokenSet) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		next := normalizeNextPath(c.PostForm("next"))
 		token := c.PostForm("token")
-		if !validAdminToken(token, adminToken) {
+		if !tokens.Valid(token) {
 			renderLoginPage(c, next, "Invalid admin token")
 			return
 		}
+		// The cookie stores the token the user provided. During a rotation a
+		// cookie minted from a fallback secret keeps validating until the
+		// fallback is dropped (re-login required then).
 		setAdminTokenCookie(c, token)
 		c.Redirect(http.StatusSeeOther, next)
 	}
@@ -99,13 +151,6 @@ func requestAdminToken(c *gin.Context) string {
 		return cookie
 	}
 	return ""
-}
-
-func validAdminToken(got, want string) bool {
-	if got == "" || want == "" {
-		return false
-	}
-	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
 }
 
 func setAdminTokenCookie(c *gin.Context, token string) {

--- a/controlplane/admin/dashboard_test.go
+++ b/controlplane/admin/dashboard_test.go
@@ -15,7 +15,7 @@ import (
 func TestAPIMiddlewareRejectsMissingAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.GET("/api/v1/status", APIAuthMiddleware("secret"), func(c *gin.Context) {
+	r.GET("/api/v1/status", APIAuthMiddleware(NewTokenSet("secret", nil)), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": true})
 	})
 
@@ -31,7 +31,7 @@ func TestAPIMiddlewareRejectsMissingAuth(t *testing.T) {
 func TestAPIMiddlewareAcceptsCookie(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.GET("/api/v1/status", APIAuthMiddleware("secret"), func(c *gin.Context) {
+	r.GET("/api/v1/status", APIAuthMiddleware(NewTokenSet("secret", nil)), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": true})
 	})
 
@@ -52,7 +52,7 @@ func TestAPIMiddlewareAcceptsCookie(t *testing.T) {
 func TestDashboardRejectsTokenQueryParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	RegisterDashboard(r, "secret")
+	RegisterDashboard(r, NewTokenSet("secret", nil))
 
 	for _, path := range []string{"/?token=secret", "/workers?token=secret&foo=bar"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -80,7 +80,7 @@ func TestDashboardRejectsTokenQueryParam(t *testing.T) {
 func TestLoginCookieIsHttpOnlyStrict(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	RegisterDashboard(r, "secret")
+	RegisterDashboard(r, NewTokenSet("secret", nil))
 
 	form := url.Values{"token": {"secret"}, "next": {"/"}}
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
@@ -103,7 +103,7 @@ func TestLoginCookieIsHttpOnlyStrict(t *testing.T) {
 func TestDashboardRequiresLoginThenSetsCookie(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	RegisterDashboard(r, "secret")
+	RegisterDashboard(r, NewTokenSet("secret", nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -133,5 +133,117 @@ func TestDashboardRequiresLoginThenSetsCookie(t *testing.T) {
 	}
 	if got := loginRec.Header().Get("Location"); got != "/" {
 		t.Fatalf("redirect = %q, want %q", got, "/")
+	}
+}
+
+func TestTokenSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		primary   string
+		fallbacks []string
+		got       string
+		want      bool
+	}{
+		{"primary matches", "new", []string{"old"}, "new", true},
+		{"fallback matches", "new", []string{"old"}, "old", true},
+		{"second fallback matches", "new", []string{"old1", "old2"}, "old2", true},
+		{"garbage rejected", "new", []string{"old"}, "wrong", false},
+		{"empty got rejected", "new", []string{"old"}, "", false},
+		{"no fallbacks, primary matches", "new", nil, "new", true},
+		{"no fallbacks, garbage rejected", "new", nil, "wrong", false},
+		// Empty strings must never validate: an unset slot (empty primary or
+		// an empty entry in the fallback list) is filtered, not matchable.
+		{"empty primary not matchable", "", []string{"old"}, "", false},
+		{"empty primary, fallback still works", "", []string{"old"}, "old", true},
+		{"empty fallback entry not matchable", "new", []string{""}, "", false},
+		{"zero tokens reject everything", "", nil, "anything", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := NewTokenSet(tt.primary, tt.fallbacks)
+			if got := ts.Valid(tt.got); got != tt.want {
+				t.Errorf("NewTokenSet(%q, %v).Valid(%q) = %v, want %v",
+					tt.primary, tt.fallbacks, tt.got, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenSetCount(t *testing.T) {
+	if got := NewTokenSet("new", []string{"old", ""}).Count(); got != 2 {
+		t.Errorf("Count() = %d, want 2 (empty entries filtered)", got)
+	}
+}
+
+// During a secret rotation the server accepts the previous secret(s) as
+// fallbacks while clients are flipped over to the new primary — on both the
+// service-to-service header path and the dashboard cookie path.
+func TestAPIMiddlewareAcceptsFallbackDuringRotation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/v1/status", APIAuthMiddleware(NewTokenSet("new-secret", []string{"old-secret"})), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	cases := []struct {
+		name   string
+		setup  func(req *http.Request)
+		status int
+	}{
+		{"fallback via header", func(req *http.Request) {
+			req.Header.Set("X-Duckgres-Internal-Secret", "old-secret")
+		}, http.StatusOK},
+		{"primary via header", func(req *http.Request) {
+			req.Header.Set("X-Duckgres-Internal-Secret", "new-secret")
+		}, http.StatusOK},
+		{"fallback via cookie", func(req *http.Request) {
+			req.AddCookie(&http.Cookie{Name: adminTokenCookieName, Value: "old-secret"})
+		}, http.StatusOK},
+		{"garbage via header", func(req *http.Request) {
+			req.Header.Set("X-Duckgres-Internal-Secret", "wrong")
+		}, http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+			tc.setup(req)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != tc.status {
+				t.Errorf("status = %d, want %d", rec.Code, tc.status)
+			}
+		})
+	}
+}
+
+// A dashboard login with a fallback secret must succeed and mint a working
+// cookie: a rotation must not lock out an operator holding the old value
+// until the fallback is dropped in the final phase.
+func TestLoginWithFallbackTokenWorksEndToEnd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterDashboard(r, NewTokenSet("new-secret", []string{"old-secret"}))
+
+	form := url.Values{"token": {"old-secret"}, "next": {"/"}}
+	loginReq := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginRec := httptest.NewRecorder()
+	r.ServeHTTP(loginRec, loginReq)
+
+	if loginRec.Code != http.StatusSeeOther {
+		t.Fatalf("POST /login status = %d, want %d", loginRec.Code, http.StatusSeeOther)
+	}
+	cookies := loginRec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != adminTokenCookieName {
+		t.Fatalf("cookies = %v, want exactly one %q cookie", cookies, adminTokenCookieName)
+	}
+
+	// The cookie minted from the fallback must authenticate a dashboard GET.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookies[0])
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / with fallback cookie status = %d, want %d", rec.Code, http.StatusOK)
 	}
 }

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -68,6 +68,12 @@ type ControlPlaneConfig struct {
 	// When empty, a random secret is generated and logged at startup.
 	InternalSecret string
 
+	// InternalSecretFallbacks are previous internal secrets still accepted
+	// for API authentication during a rotation (newest first). Clients always
+	// send the primary InternalSecret; the server accepts any of
+	// {primary ∪ fallbacks}. Mirrors posthog's SECRET_KEY_FALLBACKS.
+	InternalSecretFallbacks []string
+
 	// UserSecretKey is the base64-encoded 32-byte AES key for encrypting
 	// user persistent secrets in the config store (env-only:
 	// DUCKGRES_USER_SECRET_KEY). Empty disables the persistent secret

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -403,6 +403,11 @@ func SetupMultiTenant(
 		internalSecret = hex.EncodeToString(tokenBytes)
 		slog.Info("Generated internal secret; set --internal-secret or DUCKGRES_INTERNAL_SECRET explicitly to avoid rotation on restart.")
 	}
+	adminTokens := admin.NewTokenSet(internalSecret, cfg.InternalSecretFallbacks)
+	if n := len(cfg.InternalSecretFallbacks); n > 0 {
+		// Count only — never log the secret values.
+		slog.Info("Internal secret rotation fallbacks active.", "fallback_count", n)
+	}
 
 	// Set up API server (admin + provisioning + dashboard on :8080).
 	// The existing metrics server on :9090 stays running separately.
@@ -414,12 +419,12 @@ func SetupMultiTenant(
 	engine.GET("/health", newHealthHandler(isHealthy))
 
 	// Authenticated API
-	api := engine.Group("/api/v1", admin.APIAuthMiddleware(internalSecret))
+	api := engine.Group("/api/v1", admin.APIAuthMiddleware(adminTokens))
 	admin.RegisterAPI(api, store, adpt)
 	provisioning.RegisterAPI(api, provisioning.NewGormStore(store))
 
 	// Dashboard
-	admin.RegisterDashboard(engine, internalSecret)
+	admin.RegisterDashboard(engine, adminTokens)
 
 	apiServer := &http.Server{
 		Addr:    ":8080",

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_CONFIG_STORE       PostgreSQL connection string for config store (multi-tenant)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_CONFIG_POLL_INTERVAL  Config store poll interval (default: 30s)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_INTERNAL_SECRET    Shared secret for API authentication\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_INTERNAL_SECRET_FALLBACKS  Comma-separated previous internal secrets still accepted during rotation\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_K8S_MAX_WORKERS    Max K8s workers in the shared pool (0=unbounded)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_AWS_REGION         AWS region for STS client\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_LOG_LEVEL          Log level: debug, info, warn, error (default: info)\n")
@@ -339,6 +340,7 @@ func main() {
 			ConfigStoreConn:            resolved.ConfigStoreConn,
 			ConfigPollInterval:         resolved.ConfigPollInterval,
 			InternalSecret:             resolved.InternalSecret,
+			InternalSecretFallbacks:    resolved.InternalSecretFallbacks,
 			UserSecretKey:              resolved.UserSecretKey,
 			SNIRoutingMode:             resolved.SNIRoutingMode,
 			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -59,7 +59,8 @@
 #
 # Exit non-zero on any failure → the Job fails → the workflow step fails.
 #
-# Env (from run.sh): NAMESPACE, PR_NUMBER, INTERNAL_SECRET, CP_API, CP_PG_HOST
+# Env (from run.sh): NAMESPACE, PR_NUMBER, INTERNAL_SECRET,
+# INTERNAL_SECRET_FALLBACK, CP_API, CP_PG_HOST
 set -eu
 # Surface ANY exit path in the Job log: set -e can kill the script without a
 # FAIL line, and an evicted pod prints nothing — make the normal/abnormal exit
@@ -1173,6 +1174,26 @@ admin_dashboard_no_query_token() {
   [ "$code" = "200" ] || fail "GET / with internal-secret header returned $code, want 200"
 }
 
+# ---- internal secret rotation fallback --------------------------------------
+# The CP accepts {primary ∪ DUCKGRES_INTERNAL_SECRET_FALLBACKS} so a secret
+# rotation is a phased roll with no auth-mismatch window. The deployment
+# configures INTERNAL_SECRET_FALLBACK as a fallback; it must authenticate both
+# the service-to-service API path and the dashboard, and the accept-list must
+# not have opened the door to arbitrary tokens.
+internal_secret_fallback_auth() {
+  log "internal secret rotation fallback authenticates"
+  fb="${INTERNAL_SECRET_FALLBACK:?}"
+  code="$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "X-Duckgres-Internal-Secret: $fb" "$API/api/v1/orgs")"
+  [ "$code" = "200" ] || fail "GET /api/v1/orgs with fallback secret returned $code, want 200 (rotation overlap broken)"
+  code="$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "X-Duckgres-Internal-Secret: $fb" "$API/")"
+  [ "$code" = "200" ] || fail "GET / (dashboard) with fallback secret returned $code, want 200"
+  code="$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "X-Duckgres-Internal-Secret: definitely-not-a-secret" "$API/api/v1/orgs")"
+  [ "$code" = "401" ] || fail "GET /api/v1/orgs with garbage secret returned $code, want 401 (accept-list must stay closed)"
+}
+
 # ---- tenant isolation -----------------------------------------------------
 # Two tenants (cnpg + ext) back onto distinct DuckLake metadata stores, so a
 # table created by one is invisible to the other. Ported (logical half) from
@@ -1372,6 +1393,7 @@ main() {
 
   # No org dependency — assert the admin surface auth contract up front.
   admin_dashboard_no_query_token
+  internal_secret_fallback_auth
 
   mkdir -p "$LANE_DIR"
 

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -1,6 +1,6 @@
 # Per-PR isolated duckgres stack for the mw-dev e2e harness. Rendered by
 # run.sh via envsubst with: NAMESPACE, PR_NUMBER, CONTROLPLANE_IMAGE,
-# WORKER_IMAGE, INTERNAL_SECRET.
+# WORKER_IMAGE, INTERNAL_SECRET, INTERNAL_SECRET_FALLBACK, USER_SECRET_KEY.
 #
 # Isolation model (decided with the design): a DEDICATED control plane +
 # throwaway config-store per PR, provisioning REAL ducklings (PR-prefixed org
@@ -84,6 +84,9 @@ metadata:
   namespace: ${NAMESPACE}
 stringData:
   internal-secret: "${INTERNAL_SECRET}"
+  # Rotation fallback the CP must ALSO accept (mirrors the prod chart's
+  # internal-secret-fallbacks key); asserted by internal_secret_fallback_auth.
+  internal-secret-fallbacks: "${INTERNAL_SECRET_FALLBACK}"
   # AES key for the user persistent secret manager (CREATE PERSISTENT SECRET).
   user-secret-key: "${USER_SECRET_KEY}"
 ---
@@ -284,6 +287,10 @@ spec:
             - { name: DUCKGRES_CONFIG_POLL_INTERVAL, value: "5s" }
             - name: DUCKGRES_INTERNAL_SECRET
               valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
+            # Previous internal secrets still accepted during rotation; the
+            # harness asserts the fallback authenticates (and garbage doesn't).
+            - name: DUCKGRES_INTERNAL_SECRET_FALLBACKS
+              valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret-fallbacks } }
             # Enables the user persistent secret manager; the harness
             # persistent_user_secret assertion exercises it end-to-end.
             - name: DUCKGRES_USER_SECRET_KEY

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -25,6 +25,10 @@ SA_NAME="duckgres"
 # Internal secret for the per-PR control plane. Random per run; never reused.
 # Stamped into the rendered manifests and handed to the in-cluster harness.
 internal_secret_file="/tmp/duckgres-ci-internal-secret"
+# Rotation fallback secret (DUCKGRES_INTERNAL_SECRET_FALLBACKS): a second
+# random value the CP must also accept, so the harness can assert the
+# rotation-overlap path (internal_secret_fallback_auth).
+internal_secret_fallback_file="/tmp/duckgres-ci-internal-secret-fallback"
 # AES key for user persistent secrets (DUCKGRES_USER_SECRET_KEY). Random per
 # run: stored user secrets only need to outlive the run's sessions.
 user_secret_key_file="/tmp/duckgres-ci-user-secret-key"
@@ -32,12 +36,14 @@ user_secret_key_file="/tmp/duckgres-ci-user-secret-key"
 render() {
   : "${WORKER_IMAGE:?}" "${CONTROLPLANE_IMAGE:?}" "${PR_NUMBER:?}"
   [ -f "$internal_secret_file" ] || openssl rand -hex 16 > "$internal_secret_file"
+  [ -f "$internal_secret_fallback_file" ] || openssl rand -hex 16 > "$internal_secret_fallback_file"
   [ -f "$user_secret_key_file" ] || openssl rand -base64 32 > "$user_secret_key_file"
   INTERNAL_SECRET="$(cat "$internal_secret_file")" \
+  INTERNAL_SECRET_FALLBACK="$(cat "$internal_secret_fallback_file")" \
   USER_SECRET_KEY="$(cat "$user_secret_key_file")" \
   NAMESPACE="$NS" PR_NUMBER="$PR_NUMBER" \
   WORKER_IMAGE="$WORKER_IMAGE" CONTROLPLANE_IMAGE="$CONTROLPLANE_IMAGE" \
-    envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET $USER_SECRET_KEY' \
+    envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET $INTERNAL_SECRET_FALLBACK $USER_SECRET_KEY' \
     < "$HERE/manifests.tmpl.yaml"
 }
 
@@ -189,6 +195,7 @@ cmd_test() {
     --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -
 
   INTERNAL_SECRET="$(cat "$internal_secret_file")"
+  INTERNAL_SECRET_FALLBACK="$(cat "$internal_secret_fallback_file")"
   "${KUBECTL[@]}" -n "$NS" delete job duckgres-harness --ignore-not-found
   cat <<YAML | "${KUBECTL[@]}" apply -f -
 apiVersion: batch/v1
@@ -214,6 +221,7 @@ spec:
             - { name: NAMESPACE, value: "$NS" }
             - { name: PR_NUMBER, value: "$PR_NUMBER" }
             - { name: INTERNAL_SECRET, value: "$INTERNAL_SECRET" }
+            - { name: INTERNAL_SECRET_FALLBACK, value: "$INTERNAL_SECRET_FALLBACK" }
             - { name: CP_API, value: "http://duckgres-control-plane.$NS.svc:8080" }
             - { name: CP_PG_HOST, value: "duckgres-control-plane.$NS.svc" }
           # Real requests/limits: the harness shares the default nodepool with


### PR DESCRIPTION
## Summary

Makes `DUCKGRES_INTERNAL_SECRET` (the client → CP admin/provisioning API bearer token) rotation-friendly by adopting posthog's `SECRET_KEY_FALLBACKS` convention: the CP accepts a **set** of valid tokens — the primary plus `DUCKGRES_INTERNAL_SECRET_FALLBACKS` (comma-separated, newest first) — while clients keep sending only the primary. A secret rotation becomes a phased roll (add fallback → flip client → drop fallback) with **no auth-mismatch window** instead of a synchronized client+CP restart.

## Changes

- **`admin.TokenSet`** (`controlplane/admin/dashboard.go`): replaces the single-value `validAdminToken`. Tokens are stored and compared as **SHA-256 digests** with `subtle.ConstantTimeCompare` and no early exit — tokens are arbitrary operator-supplied strings and `ConstantTimeCompare` short-circuits on length mismatch, so fixed-length digests keep every comparison the same shape. Empty strings are filtered and can never validate. Header, cookie, and `/login` paths all accept the set — a dashboard cookie minted from a fallback keeps working until the fallback is dropped (final rotation phase).
- **Config plumbing**: `--internal-secret-fallbacks` / `DUCKGRES_INTERNAL_SECRET_FALLBACKS` through `configresolve` (CLI > env, no YAML — matches the primary secret; an explicitly-set empty flag clears env-provided fallbacks, same semantics as posthog's `JWT_SIGNING_KEY_FALLBACKS`).
- **Operability**: startup logs the fallback *count* only, never values.
- **Unit tests**: `TestTokenSet` matrix (incl. empty-string-never-validates), fallback via header + cookie, end-to-end login with a fallback, config resolution precedence, and the CLI-flag drift-guard entry.
- **e2e (mw-dev harness)**: the per-PR CP now deploys with a random fallback configured; new `internal_secret_fallback_auth` check asserts fallback → 200 on `/api/v1/orgs` and the dashboard, garbage → 401.

## Notes

- Worker-token (CP↔worker bearer) is explicitly **out of scope** — workers receive their token at spawn; rotating it means recycling the fleet.
- Companion charts PR (PostHog/charts#12023) syncs the fallbacks property **atomically with the primary** into one K8s Secret (a third explicit data entry on the same ExternalSecret; the upstream property is a hard schema requirement, `""` when not rotating) and extends the Stakater Reloader annotation so an ESO sync auto-rolls the CP — one rollout always sees a consistent accepted-token set.
- The step-by-step rotation procedure (per-phase AWS property values, force-sync, verification matrix) lives in private ops material, not in this repo.

## Rollback

Revert this PR. The new env var/flag is additive; with no fallbacks configured, behavior is byte-identical to the single-secret compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)