### PR TITLE
fix(flightsqlingress): never log raw Flight session token

### DIFF
--- a/internal/cliboot/logging.go
+++ b/internal/cliboot/logging.go
@@ -141,7 +141,19 @@ func (h *RedactingHandler) WithGroup(name string) slog.Handler {
 	return &RedactingHandler{Inner: h.Inner.WithGroup(name)}
 }
 
+// redactedKeys are slog attribute keys whose values are bearer credentials and
+// must never be logged in the clear, regardless of value shape. The value-based
+// RedactSecrets only scrubs password=<value> patterns, so a bare token value
+// would otherwise pass through verbatim. Defense-in-depth on top of callers that
+// should already be logging a fingerprint instead of the raw token.
+var redactedKeys = map[string]bool{
+	"token": true,
+}
+
 func redactAttr(a slog.Attr) slog.Attr {
+	if redactedKeys[strings.ToLower(a.Key)] {
+		return slog.String(a.Key, "[REDACTED]")
+	}
 	switch a.Value.Kind() {
 	case slog.KindString:
 		a.Value = slog.StringValue(server.RedactSecrets(a.Value.String()))

--- a/internal/cliboot/logging_test.go
+++ b/internal/cliboot/logging_test.go
@@ -108,6 +108,20 @@ func TestRedactingHandler(t *testing.T) {
 			notWant: "topSecret",
 			want:    "[REDACTED]",
 		},
+		{
+			name:    "token attr key is scrubbed by key, not value pattern",
+			msg:     "reconnect failed",
+			attrs:   []slog.Attr{slog.String("token", "live-bearer-credential-xyz")},
+			notWant: "live-bearer-credential-xyz",
+			want:    "[REDACTED]",
+		},
+		{
+			name:    "token_fp fingerprint attr is preserved",
+			msg:     "reconnect failed",
+			attrs:   []slog.Attr{slog.String("token_fp", "deadbeef")},
+			notWant: "[REDACTED]",
+			want:    "deadbeef",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/flightsqlingress/ingress.go
+++ b/server/flightsqlingress/ingress.go
@@ -3,6 +3,7 @@ package flightsqlingress
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"database/sql"
 	"encoding/base64"
@@ -1926,13 +1927,27 @@ func (s *flightAuthSessionStore) persistSession(session *flightClientSession, us
 	}
 }
 
+// tokenFingerprint returns a short, non-reversible fingerprint of a session
+// token for safe logging. The x-duckgres-session token is a standalone bearer
+// credential (token-only auth grants full session access), so the raw value
+// must never be logged — anyone with log read access could replay it to hijack
+// the victim's session. The fingerprint (first 8 hex chars of sha256) is enough
+// to correlate log lines for the same token without exposing it.
+func tokenFingerprint(token string) string {
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
 func (s *flightAuthSessionStore) reconnectByToken(ctx context.Context, token string) (*flightClientSession, bool) {
 	if s == nil || s.durableStore == nil || s.reconnector == nil {
 		return nil, false
 	}
 	record, err := s.durableStore.GetSession(token)
 	if err != nil {
-		slog.Warn("Loading durable Flight session record failed.", "token", token, "error", err)
+		slog.Warn("Loading durable Flight session record failed.", "token_fp", tokenFingerprint(token), "error", err)
 		return nil, false
 	}
 	if record == nil {
@@ -1947,7 +1962,7 @@ func (s *flightAuthSessionStore) reconnectByToken(ctx context.Context, token str
 	}
 	pid, executor, err := s.reconnector.ReconnectSession(ctx, *record)
 	if err != nil {
-		slog.Warn("Reconnecting durable Flight session failed.", "token", token, "error", err)
+		slog.Warn("Reconnecting durable Flight session failed.", "token_fp", tokenFingerprint(token), "error", err)
 		if errors.Is(err, ErrDurableReconnectTerminal) {
 			_ = s.durableStore.CloseSession(token, time.Now())
 		}

--- a/server/flightsqlingress/ingress_test.go
+++ b/server/flightsqlingress/ingress_test.go
@@ -1720,3 +1720,31 @@ func TestFlightAuthSessionStoreReapStaleHandleAllowsSessionReap(t *testing.T) {
 		t.Fatalf("expected session 1234 to be destroyed, got %v", destroyed)
 	}
 }
+
+// TestTokenFingerprint verifies the session-token fingerprint used for logging
+// is deterministic, non-reversible (never equal to the input), and fixed-length,
+// so raw bearer tokens never reach the logs.
+func TestTokenFingerprint(t *testing.T) {
+	const token = "live-bearer-credential-xyz"
+
+	fp := tokenFingerprint(token)
+
+	if fp == token {
+		t.Fatalf("fingerprint must not equal the raw token")
+	}
+	if len(fp) != 8 {
+		t.Fatalf("expected 8-char fingerprint, got %d (%q)", len(fp), fp)
+	}
+	if got := tokenFingerprint(token); got != fp {
+		t.Fatalf("fingerprint not deterministic: %q != %q", got, fp)
+	}
+	if other := tokenFingerprint(token + "!"); other == fp {
+		t.Fatalf("different tokens produced the same fingerprint %q", fp)
+	}
+	if strings.Contains(token, fp) {
+		t.Fatalf("fingerprint %q is a substring of the raw token", fp)
+	}
+	if empty := tokenFingerprint(""); empty != "" {
+		t.Fatalf("empty token must yield empty fingerprint, got %q", empty)
+	}
+}


### PR DESCRIPTION
## Vulnerability (HIGH — secret exposure)

The `x-duckgres-session` token is a standalone bearer credential: presenting the token alone grants full access to the victim's org-bound session (see `sessionFromContextWithTokenMetadata`). In `server/flightsqlingress/ingress.go`, `reconnectByToken` logged the **raw token in plaintext** on two reachable error paths:

- "Loading durable Flight session record failed."
- "Reconnecting durable Flight session failed."

These fire under normal ops (control-plane restart/failover, worker `OwnerEpoch` mismatch) for **live, valid** tokens. The global slog `RedactingHandler` only scrubs `password=<value>` patterns, so a `token` attribute passed through verbatim to stderr and the OTLP/log exporter. Anyone with log read access could lift the token and replay it in `x-duckgres-session` to hijack the session.

## Fix

1. Added `tokenFingerprint(token)` returning the first 8 hex chars of `sha256(token)` — non-reversible. Both log sites now log `"token_fp"` instead of the raw `"token"`. **Auth behavior is unchanged**; the token still works as a credential, only its logging changes.
2. Grepped the repo for other raw session-token / durable-record-token / bootstrap-nonce slog sites — these two were the only ones.
3. Defense-in-depth: the `cliboot` `RedactingHandler` now scrubs any slog attr whose key is `token` to `[REDACTED]` (the `token_fp` fingerprint is preserved).

## Tests

- `TestTokenFingerprint` (in `ingress_test.go`): deterministic, never equal to the input, fixed 8-char length, distinct tokens differ, empty-safe.
- Added redaction-handler cases (in `logging_test.go`): a `token` attr is scrubbed by key; a `token_fp` attr is preserved.
- `go test ./server/flightsqlingress/... ./internal/cliboot/... -count=1` passes; `go build` of both packages passes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*