### PR TITLE
fix(usersecrets): redact secret DDL anywhere in a multi-statement query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,13 @@ Invariants for anyone touching this path:
   false "DROP succeeded" is fatal for a credential revocation.
 - **Never log/store secret statement text.** `usersecrets.RedactForLog` guards
   logQueryStarted/Finished/Error, the query log, spans, and pg_stat_activity
-  (`currentQuery`); keep new logging of query text behind it.
+  (`currentQuery`); keep new logging of query text behind it. Engine **error
+  messages echo the offending SQL** (DuckDB emits `LINE 1: ... SECRET '...'`),
+  so a failed CREATE SECRET leaks the credential via the `error` attribute /
+  query-log `Exception` even when the query attribute is redacted —
+  `usersecrets.RedactErrorForLog(query, errMsg)` guards those error sinks
+  (logQueryError/logQueryFinished, `logQuery`); keep new error logging behind it
+  too, and pass the original (un-redacted) query so it can classify.
 - Touching the interception, wipe/replay, or payload shape → update
   `server/conn_user_secrets_test.go`, `duckdbservice/user_secrets_test.go`,
   and the `persistent_user_secret`(+`_isolation`) assertions in

--- a/server/conn.go
+++ b/server/conn.go
@@ -419,15 +419,16 @@ func (c *clientConn) logQueryStarted(query string) {
 // "started" and a "finished" line, and can look at the separate error
 // line for severity context.
 func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64, err error) {
-	query = usersecrets.RedactForLog(query)
 	attrs := []any{
-		"query", query,
+		"query", usersecrets.RedactForLog(query),
 		"duration_ms", time.Since(start).Milliseconds(),
 		"rows", rows,
 		"trace_id", observe.TraceIDFromContext(c.ctx),
 	}
 	if err != nil {
-		attrs = append(attrs, "error", err.Error())
+		// Engine errors echo the offending SQL, so a failed CREATE SECRET
+		// leaks the credential here unless the error is redacted too.
+		attrs = append(attrs, "error", usersecrets.RedactErrorForLog(query, err.Error()))
 	}
 	c.logger().Info("Query finished.", attrs...)
 }
@@ -439,8 +440,13 @@ func (c *clientConn) logQueryFinished(query string, start time.Time, rows int64,
 // (worker crash, IO failure, internal panic, infra unreachable), not
 // "user typo'd a column name."
 func (c *clientConn) logQueryError(query string, err error) {
-	query = usersecrets.RedactForLog(query)
-	attrs := []any{"query", query, "error", err}
+	// Engine errors echo the offending SQL, so a failed CREATE SECRET leaks the
+	// credential via the error attribute unless it is redacted too. Classify
+	// against the original query before it is replaced with the redacted form.
+	attrs := []any{
+		"query", usersecrets.RedactForLog(query),
+		"error", usersecrets.RedactErrorForLog(query, err.Error()),
+	}
 	if isDuckLakeTransactionConflict(err) {
 		c.logger().Warn("DuckLake transaction conflict.", attrs...)
 		return

--- a/server/flightsqlingress/ingress.go
+++ b/server/flightsqlingress/ingress.go
@@ -331,8 +331,7 @@ func (h *ControlPlaneFlightSQLHandler) checkUserSecretDDL(query string) error {
 	if !h.rejectPersistentSecretDDL {
 		return nil
 	}
-	st := usersecrets.Classify(query)
-	if st.Kind != usersecrets.KindNone && st.Persistent {
+	if usersecrets.ContainsPersistentSecretDDL(query) {
 		return status.Error(codes.InvalidArgument,
 			"persistent secrets are managed via the PostgreSQL protocol on this deployment; CREATE/DROP PERSISTENT SECRET is not supported over Flight SQL (a secret created here would not survive the session)")
 	}

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -496,7 +496,10 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	}
 
 	// CREATE SECRET option lists carry credential material; never persist
-	// them to the query log.
+	// them to the query log. The engine's error text echoes the offending SQL,
+	// so a failed CREATE SECRET leaks the credential via Exception unless the
+	// error is redacted too — classify against the original query first.
+	errMsg = usersecrets.RedactErrorForLog(query, errMsg)
 	query = usersecrets.RedactForLog(query)
 	transpiledQuery = usersecrets.RedactForLog(transpiledQuery)
 

--- a/server/usersecrets/classify.go
+++ b/server/usersecrets/classify.go
@@ -89,6 +89,27 @@ func Classify(query string) Statement {
 	return st
 }
 
+// ContainsPersistentSecretDDL reports whether any top-level statement in query
+// is CREATE/DROP PERSISTENT SECRET. Unlike Classify (which inspects only the
+// statement head), this scans every top-level statement, so a persistent-secret
+// DDL hidden behind a leading statement ("SELECT 1; CREATE PERSISTENT SECRET
+// ...") is still caught. Used to reject persistent-secret DDL on the Flight SQL
+// ingress, where it would execute but never persist.
+func ContainsPersistentSecretDDL(query string) bool {
+	if st, _, ok := parseSecretDDLHead(query); ok && st.Persistent {
+		return true
+	}
+	if !hasTrailingStatement(query) {
+		return false
+	}
+	for _, seg := range splitTopLevel(query) {
+		if st, _, ok := parseSecretDDLHead(seg); ok && st.Persistent {
+			return true
+		}
+	}
+	return false
+}
+
 // parseSecretDDLHead parses the statement head (through the optional secret
 // name) and returns the classification plus the byte offset just past the
 // head. The fast path for non-secret statements is two short case-folded
@@ -232,6 +253,58 @@ func hasTrailingStatement(query string) bool {
 		}
 	}
 	return false
+}
+
+// splitTopLevel splits query on top-level semicolons (outside string literals,
+// quoted identifiers, and comments), using the same scanning rules as
+// hasTrailingStatement so it stays in sync with the rest of this package. The
+// returned segments do NOT include the separating semicolons; a trailing empty
+// segment (query ending in ';') is omitted.
+func splitTopLevel(query string) []string {
+	var segments []string
+	start := 0
+	i := 0
+	for i < len(query) {
+		c := query[i]
+		switch {
+		case c == '\'':
+			i = skipQuoted(query, i, '\'')
+		case c == '"':
+			i = skipQuoted(query, i, '"')
+		case c == '-' && strings.HasPrefix(query[i:], "--"):
+			idx := strings.IndexByte(query[i:], '\n')
+			if idx < 0 {
+				i = len(query)
+			} else {
+				i += idx + 1
+			}
+		case c == '/' && strings.HasPrefix(query[i:], "/*"):
+			depth := 1
+			i += 2
+			for i < len(query) && depth > 0 {
+				switch {
+				case strings.HasPrefix(query[i:], "/*"):
+					depth++
+					i += 2
+				case strings.HasPrefix(query[i:], "*/"):
+					depth--
+					i += 2
+				default:
+					i++
+				}
+			}
+		case c == ';':
+			segments = append(segments, query[start:i])
+			i++
+			start = i
+		default:
+			i++
+		}
+	}
+	if start < len(query) {
+		segments = append(segments, query[start:])
+	}
+	return segments
 }
 
 // skipQuoted returns the index just past a quoted region starting at start

--- a/server/usersecrets/redact.go
+++ b/server/usersecrets/redact.go
@@ -38,13 +38,58 @@ func RedactForLog(query string) string {
 	// handled it (and DROP / non-secret pass through unchanged). Only when
 	// there are multiple top-level statements must we scan for secret DDL
 	// hiding behind a leading statement.
+	if queryHasCreateSecret(query) {
+		return redactedPlaceholder
+	}
+	return query
+}
+
+// redactedErrorPlaceholder replaces an error message that may echo the text of
+// a CREATE SECRET statement. Engines surface parser/binder/execution errors
+// with the offending SQL inlined (DuckDB emits e.g. `LINE 1: ... SECRET
+// 'literal'`), so an error raised by secret DDL can carry the credential even
+// though the query attribute itself was already redacted by RedactForLog.
+// Logging that error verbatim leaks the secret on every failed CREATE SECRET.
+const redactedErrorPlaceholder = "(error redacted: statement carries secret DDL)"
+
+// RedactErrorForLog returns an error message safe to log/store alongside query.
+// When query carries CREATE SECRET DDL anywhere (head or a later top-level
+// statement), the engine's error text may echo the secret literal, so the whole
+// message is replaced with a fixed placeholder. Over-redaction only costs
+// diagnostic detail, never credential exposure; errors from non-secret queries
+// (and empty errors) pass through unchanged.
+//
+// Callers MUST pass the original, un-redacted query — classification needs the
+// real statement text. Pair this with RedactForLog at every query log site that
+// also emits an error: RedactForLog scrubs the query attribute, RedactErrorForLog
+// scrubs the error attribute.
+func RedactErrorForLog(query, errMsg string) string {
+	if errMsg == "" {
+		return errMsg
+	}
+	if queryHasCreateSecret(query) {
+		return redactedErrorPlaceholder
+	}
+	return errMsg
+}
+
+// queryHasCreateSecret reports whether query contains a CREATE SECRET at its
+// head or in any top-level statement. It shares the tokenizer with RedactForLog
+// (parseSecretDDLHead / splitTopLevel) so the query and error redactors can
+// never drift apart. DROP SECRET (which carries only a name) is not a match.
+func queryHasCreateSecret(query string) bool {
+	if st, _, ok := parseSecretDDLHead(query); ok && st.Kind == KindCreate {
+		return true
+	}
+	// A single top-level statement whose head is not CREATE SECRET cannot hide
+	// secret DDL; only multi-statement strings need the per-segment scan.
 	if !hasTrailingStatement(query) {
-		return query
+		return false
 	}
 	for _, seg := range splitTopLevel(query) {
 		if st, _, ok := parseSecretDDLHead(seg); ok && st.Kind == KindCreate {
-			return redactedPlaceholder
+			return true
 		}
 	}
-	return query
+	return false
 }

--- a/server/usersecrets/redact.go
+++ b/server/usersecrets/redact.go
@@ -2,22 +2,49 @@ package usersecrets
 
 import "strings"
 
+// redactedPlaceholder replaces a whole query whose credential material cannot
+// be safely located and stripped in place (a CREATE SECRET that is not the
+// statement head of the string).
+const redactedPlaceholder = "(…redacted)"
+
 // RedactForLog returns a version of query safe to write to logs, traces,
-// query logs, and pg_stat_activity. For CREATE SECRET statements (any
-// persistence, including multi-statement strings whose head is secret DDL)
-// everything after the statement head is dropped — the option list carries
-// credential material, and on a multi-statement string the trailing
-// statements are dropped along with it. DROP variants carry only a name and
-// pass through unchanged, as does every non-secret statement.
+// query logs, and pg_stat_activity. CREATE SECRET option lists carry
+// credential material and must never reach a log sink.
+//
+// The fast path: when the statement head is a CREATE SECRET, everything after
+// the head is dropped (the option list and, for a multi-statement string, the
+// trailing statements). DROP variants carry only a name and pass through, as
+// does every non-secret single statement.
+//
+// The hardened path guards against secret DDL that is NOT the statement head,
+// e.g. "SELECT 1; CREATE PERSISTENT SECRET foo (...)" or
+// "BEGIN; CREATE SECRET ...". Such a string does not classify at its head, so
+// the head-only check would leak it verbatim. We therefore split on top-level
+// semicolons and, if ANY segment classifies as a CREATE SECRET, replace the
+// entire query with a fixed placeholder. Over-redaction is harmless here —
+// false positives only cost log fidelity, never credential exposure.
 //
 // This is driven by the same tokenizer as Classify, so the redactor can never
 // be out of sync with the interceptor: any whitespace/comment arrangement
 // Classify accepts is redacted, and the non-matching fast path is two short
 // case-folded keyword comparisons with no allocation.
 func RedactForLog(query string) string {
-	st, headEnd, ok := parseSecretDDLHead(query)
-	if !ok || st.Kind != KindCreate {
+	if st, headEnd, ok := parseSecretDDLHead(query); ok && st.Kind == KindCreate {
+		return strings.TrimSpace(query[:headEnd]) + " " + redactedPlaceholder
+	}
+
+	// Head is not a CREATE SECRET. If the query is a single top-level
+	// statement, there is nothing more to check — the fast path already
+	// handled it (and DROP / non-secret pass through unchanged). Only when
+	// there are multiple top-level statements must we scan for secret DDL
+	// hiding behind a leading statement.
+	if !hasTrailingStatement(query) {
 		return query
 	}
-	return strings.TrimSpace(query[:headEnd]) + " (…redacted)"
+	for _, seg := range splitTopLevel(query) {
+		if st, _, ok := parseSecretDDLHead(seg); ok && st.Kind == KindCreate {
+			return redactedPlaceholder
+		}
+	}
+	return query
 }

--- a/server/usersecrets/redact_test.go
+++ b/server/usersecrets/redact_test.go
@@ -1,0 +1,148 @@
+package usersecrets
+
+import (
+	"strings"
+	"testing"
+)
+
+// secretLiteral is a recognizable credential token; tests assert it never
+// survives redaction.
+const secretLiteral = "AKIAreallyrealkey1234"
+
+func TestRedactForLogNonLeadingSecretDDL(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		// want is the exact redacted output when set; leave empty to only
+		// assert the secret literal is gone.
+		want string
+		// passthrough asserts the query is returned unchanged.
+		passthrough bool
+	}{
+		{
+			name:  "single create persistent secret head",
+			query: "CREATE PERSISTENT SECRET foo (TYPE s3, KEY_ID '" + secretLiteral + "', SECRET 'x')",
+			want:  "CREATE PERSISTENT SECRET foo " + redactedPlaceholder,
+		},
+		{
+			name:  "single create secret unnamed",
+			query: "CREATE SECRET (TYPE s3, KEY_ID '" + secretLiteral + "')",
+			want:  "CREATE SECRET " + redactedPlaceholder,
+		},
+		{
+			name:        "plain select passes through",
+			query:       "SELECT 1",
+			passthrough: true,
+		},
+		{
+			name:        "multi-statement non-secret passes through",
+			query:       "SELECT 1; SELECT 2",
+			passthrough: true,
+		},
+		{
+			name:        "drop secret passes through",
+			query:       "DROP PERSISTENT SECRET foo",
+			passthrough: true,
+		},
+		{
+			name:  "leading select then create secret",
+			query: "SELECT 1; CREATE SECRET foo (TYPE s3, KEY_ID '" + secretLiteral + "')",
+			want:  redactedPlaceholder,
+		},
+		{
+			name:  "leading select then create persistent secret",
+			query: "SELECT 1; CREATE PERSISTENT SECRET foo (TYPE s3, SECRET '" + secretLiteral + "')",
+			want:  redactedPlaceholder,
+		},
+		{
+			name:  "begin then create persistent secret",
+			query: "BEGIN; CREATE PERSISTENT SECRET foo (TYPE s3, SECRET '" + secretLiteral + "')",
+			want:  redactedPlaceholder,
+		},
+		{
+			name:  "create secret not at end of batch",
+			query: "SELECT 1; CREATE SECRET foo (TYPE s3, SECRET '" + secretLiteral + "'); SELECT 2",
+			want:  redactedPlaceholder,
+		},
+		{
+			name: "semicolon inside string literal does not split",
+			// A non-secret query whose string literal contains a semicolon
+			// followed by text that looks like secret DDL must NOT trigger a
+			// false split that would still be safe — but more importantly it
+			// must not be mis-tokenized. It's a single statement, passes through.
+			query:       "SELECT 'a; CREATE SECRET evil (SECRET ''" + secretLiteral + "'')'",
+			passthrough: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactForLog(tt.query)
+			if tt.passthrough {
+				if got != tt.query {
+					t.Fatalf("expected passthrough, got %q", got)
+				}
+				return
+			}
+			if tt.want != "" && got != tt.want {
+				t.Fatalf("RedactForLog(%q) = %q, want %q", tt.query, got, tt.want)
+			}
+			if strings.Contains(got, secretLiteral) {
+				t.Fatalf("secret literal leaked in redacted output: %q", got)
+			}
+		})
+	}
+}
+
+func TestContainsPersistentSecretDDL(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"CREATE PERSISTENT SECRET foo (TYPE s3)", true},
+		{"DROP PERSISTENT SECRET foo", true},
+		{"SELECT 1; CREATE PERSISTENT SECRET foo (TYPE s3)", true},
+		{"BEGIN; CREATE PERSISTENT SECRET foo (TYPE s3); COMMIT", true},
+		{"SELECT 1; DROP PERSISTENT SECRET foo", true},
+		// Plain / temporary secrets are session-scoped, not persistent.
+		{"CREATE SECRET foo (TYPE s3)", false},
+		{"CREATE TEMPORARY SECRET foo (TYPE s3)", false},
+		{"SELECT 1; CREATE TEMPORARY SECRET foo (TYPE s3)", false},
+		{"SELECT 1; SELECT 2", false},
+		{"SELECT 'CREATE PERSISTENT SECRET' FROM t", false},
+	}
+	for _, tt := range tests {
+		if got := ContainsPersistentSecretDDL(tt.query); got != tt.want {
+			t.Errorf("ContainsPersistentSecretDDL(%q) = %v, want %v", tt.query, got, tt.want)
+		}
+	}
+}
+
+func TestSplitTopLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"single", "SELECT 1", []string{"SELECT 1"}},
+		{"two", "SELECT 1; SELECT 2", []string{"SELECT 1", " SELECT 2"}},
+		{"trailing semicolon", "SELECT 1;", []string{"SELECT 1"}},
+		{"semicolon in string", "SELECT 'a;b'", []string{"SELECT 'a;b'"}},
+		{"semicolon in quoted ident", `SELECT "a;b"`, []string{`SELECT "a;b"`}},
+		{"semicolon in line comment", "SELECT 1 -- a;b\n; SELECT 2", []string{"SELECT 1 -- a;b\n", " SELECT 2"}},
+		{"semicolon in block comment", "SELECT 1 /* a;b */; SELECT 2", []string{"SELECT 1 /* a;b */", " SELECT 2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitTopLevel(tt.query)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitTopLevel(%q) = %#v, want %#v", tt.query, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("splitTopLevel(%q)[%d] = %q, want %q", tt.query, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/server/usersecrets/redact_test.go
+++ b/server/usersecrets/redact_test.go
@@ -94,6 +94,67 @@ func TestRedactForLogNonLeadingSecretDDL(t *testing.T) {
 	}
 }
 
+func TestRedactErrorForLog(t *testing.T) {
+	// A DuckDB-style error that echoes the offending SQL verbatim, including
+	// the credential literal — the exact leak this guards.
+	secretErr := "Parser Error: syntax error at or near \"BOGUS\"\n" +
+		"LINE 1: ... (TYPE s3, KEY_ID 'AKIABAD', SECRET '" + secretLiteral + "' BOGUS)"
+
+	tests := []struct {
+		name   string
+		query  string
+		errMsg string
+		// want is the exact output; if empty, only assert the literal is gone.
+		want string
+	}{
+		{
+			name:   "empty error passes through",
+			query:  "CREATE SECRET foo (TYPE s3, SECRET '" + secretLiteral + "')",
+			errMsg: "",
+			want:   "",
+		},
+		{
+			name:   "non-secret query keeps its error verbatim",
+			query:  "SELECT * FROM missing",
+			errMsg: "Catalog Error: Table with name missing does not exist",
+			want:   "Catalog Error: Table with name missing does not exist",
+		},
+		{
+			name:   "secret-head query redacts error echoing the literal",
+			query:  "CREATE SECRET foo (TYPE s3, KEY_ID 'AKIABAD', SECRET '" + secretLiteral + "' BOGUS)",
+			errMsg: secretErr,
+			want:   redactedErrorPlaceholder,
+		},
+		{
+			name:   "non-leading secret DDL redacts error",
+			query:  "SELECT 1; CREATE PERSISTENT SECRET foo (TYPE s3, SECRET '" + secretLiteral + "')",
+			errMsg: secretErr,
+			want:   redactedErrorPlaceholder,
+		},
+		{
+			name:   "drop secret error passes through (no credential material)",
+			query:  "DROP PERSISTENT SECRET foo",
+			errMsg: "Invalid Input Error: secret foo not found",
+			want:   "Invalid Input Error: secret foo not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactErrorForLog(tt.query, tt.errMsg)
+			if tt.want != "" && got != tt.want {
+				t.Fatalf("RedactErrorForLog(%q, %q) = %q, want %q", tt.query, tt.errMsg, got, tt.want)
+			}
+			if tt.want == "" && got != "" {
+				t.Fatalf("RedactErrorForLog(%q, \"\") = %q, want empty", tt.query, got)
+			}
+			if strings.Contains(got, secretLiteral) {
+				t.Fatalf("secret literal leaked in redacted error: %q", got)
+			}
+		})
+	}
+}
+
 func TestContainsPersistentSecretDDL(t *testing.T) {
 	tests := []struct {
 		query string


### PR DESCRIPTION
## Vulnerability (MEDIUM, secret exposure)

`usersecrets.RedactForLog` is the sole guard that strips credential material from query text before it reaches logs, OpenTelemetry spans (`db.statement`), the persisted query log, and `pg_stat_activity.query`. It only classified the **statement head**. A client could prefix any leading statement so the head no longer classifies as secret DDL, and `RedactForLog` then returned the query **unchanged**, leaking secret literals.

Example that leaked verbatim:
```
SELECT 1; CREATE PERSISTENT SECRET foo (TYPE s3, KEY_ID 'AKIA...', SECRET 'realKey')
```

The capture sites (`server/conn.go`, `server/querylog.go`, `server/conn_extended_query.go`) all run **before** the statement is parsed/executed, so the credential was logged even when the batch was later rejected. This violates the CLAUDE.md invariant "Never log/store secret statement text".

## Fix

`RedactForLog` now splits the query on **top-level** semicolons using the existing literal/identifier/comment-aware tokenization (new `splitTopLevel`, sharing the exact scanning rules of `hasTrailingStatement` — not a naive `strings.Split(";")`). If **any** top-level segment classifies as `CREATE SECRET`, the entire query is replaced with the existing redaction placeholder. The single-statement fast path is unchanged. Over-redaction is intentional — false positives only cost log fidelity, never credential exposure.

Also fixed (same root cause): the Flight SQL ingress `RejectPersistentSecretDDL` check had the same head-only blind spot. It now uses a new `usersecrets.ContainsPersistentSecretDDL` helper that scans every top-level statement, so a non-leading `CREATE/DROP PERSISTENT SECRET` in a batch is rejected.

## Tests

Added `server/usersecrets/redact_test.go`:
- `SELECT 1; CREATE SECRET ...`, `SELECT 1; CREATE PERSISTENT SECRET ... (SECRET 'x')`, `BEGIN; CREATE PERSISTENT SECRET ...` — assert the secret literal does **not** appear in the redacted output.
- Plain `SELECT 1` and multi-statement non-secret batches pass through unchanged; existing single-statement redaction preserved (existing `TestRedactForLog` still passes).
- Semicolon-inside-string-literal does not mis-split.
- `ContainsPersistentSecretDDL` and `splitTopLevel` coverage.

`go build ./server/usersecrets/... ./server/flightsqlingress/...` and `go test ./server/usersecrets/ ./server/flightsqlingress/ -count=1` all pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*