### PR TITLE
fix(wire): prevent slice-bounds panic on unterminated startup parameter

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -778,6 +778,17 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	server.IncrementOpenConnections()
 	defer server.DecrementOpenConnections()
 
+	// Defense-in-depth: a panic in the pre-auth parsing path (e.g. a malformed
+	// startup packet) must degrade to a single dropped connection, never crash
+	// the shared multitenant control-plane process. Mirrors the standalone
+	// server's connection-handler recover. Won't catch C++ fatal signals.
+	defer func() {
+		if r := recover(); r != nil {
+			clog.Error("Recovered from panic in control-plane connection handler.", "panic", r)
+			_ = conn.Close()
+		}
+	}()
+
 	releaseRateLimit, msg := server.BeginRateLimitedAuthAttempt(cp.rateLimiter, remoteAddr)
 	if msg != "" {
 		clog.Warn("Connection rejected.", "reason", msg)

--- a/server/wire/protocol.go
+++ b/server/wire/protocol.go
@@ -134,7 +134,11 @@ func ReadStartupMessage(r io.Reader) (map[string]string, error) {
 		for valEnd < len(data) && data[valEnd] != 0 {
 			valEnd++
 		}
-		if valEnd > len(data) {
+		// An unterminated value (no trailing NUL) means a malformed/truncated
+		// packet. Break instead of re-slicing past the end: with valEnd ==
+		// len(data), data[valEnd+1:] would be data[len(data)+1:] and panic
+		// with "slice bounds out of range". Mirrors the key-scan guard above.
+		if valEnd >= len(data) {
 			break
 		}
 		value := string(data[:valEnd])

--- a/server/wire/protocol_test.go
+++ b/server/wire/protocol_test.go
@@ -104,6 +104,29 @@ func TestReadStartupMessageMaxLengthAccepted(t *testing.T) {
 	}
 }
 
+// Regression test: a startup parameter whose final value lacks a trailing NUL
+// must NOT panic. The value-scan guard used `valEnd > len(data)`, so an
+// unterminated final value left valEnd == len(data), fell through to
+// data[valEnd+1:] == data[len(data)+1:], and panicked with "slice bounds out
+// of range". This is parsed PRE-AUTH on attacker-controlled bytes, so a panic
+// crashes the whole shared control-plane process. The fix (`valEnd >=`) breaks
+// out, returning the parameters parsed so far without error.
+func TestReadStartupMessageUnterminatedValue(t *testing.T) {
+	// v3.0 protocol version (196608 = 0x00030000) + "user\0X" with no trailing NUL.
+	body := append([]byte{0x00, 0x03, 0x00, 0x00}, []byte("user\x00X")...)
+	msg := buildRawStartup(int32(len(body)+4), body)
+
+	// Must not panic.
+	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("ReadStartupMessage on unterminated value: %v", err)
+	}
+	// The truncated final pair is dropped (break before assignment).
+	if _, ok := params["user"]; ok {
+		t.Fatalf("expected truncated final pair to be dropped, got: %v", params)
+	}
+}
+
 func TestReadMessageValid(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteMessage(&buf, MsgQuery, []byte("SELECT 1\x00")); err != nil {


### PR DESCRIPTION
## The vulnerability

`server/wire/protocol.go::ReadStartupMessage` parses the PostgreSQL startup packet's null-terminated key/value pairs **pre-authentication**, on attacker-controlled bytes.

The key-scan guard correctly uses `if keyEnd >= len(data) { break }`, but the value-scan guard had an off-by-one:

```go
if valEnd > len(data) {   // should be >=
    break
}
```

When the final parameter value lacks a trailing NUL, the inner scan loop exits with `valEnd == len(data)`. The `>` guard does **not** break, so execution falls through to:

```go
data = data[valEnd+1:]   // == data[len(data)+1:]
```

which panics with `slice bounds out of range`.

Because this runs pre-auth and the control-plane per-connection goroutine (`controlplane/control.go::handleConnection`) had **no `recover()`**, a single crafted startup packet panicked and aborted the **entire shared multitenant control-plane process** — a remote, unauthenticated DoS.

## The fix

1. **Primary (one char):** change the value guard to `if valEnd >= len(data) { break }`, matching the key-scan guard. An unterminated final value is a malformed/truncated packet, so we break and return the parameters parsed so far — we do not re-slice past the end.

2. **Defense-in-depth:** wrap the control-plane per-connection handler in a `defer func(){ recover() ... }()` that logs (slog) and closes the connection, mirroring the standalone server's existing handler recover (`server/server.go`). Any future parser panic now degrades to a single dropped connection instead of a whole-process crash.

## Tests

Added `TestReadStartupMessageUnterminatedValue` in `server/wire/protocol_test.go`: it feeds a v3.0 startup body (`\x00\x03\x00\x00` + `user\x00X`, no trailing NUL) and asserts `ReadStartupMessage` returns without panicking. Verified it **panics at `protocol.go:141` before the fix** and passes after. Full `go test ./server/wire/ -count=1` passes; `go build ./controlplane/` and `go vet ./controlplane/` are clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*