### PR TITLE
fix(duckdbservice): wipe all user secrets between sessions, not just persistent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,10 +253,14 @@ Invariants for anyone touching this path:
 
 - **Cross-user isolation is the wipe at session create, not the destroy-time
   cleanup.** DuckDB secrets are instance-global, and a hot-idle worker is
-  reused across users of an org: `wipeUserPersistentSecrets` (persistent
-  storage only — system secrets `ducklake_s3`/`iceberg_sigv4`/`iceberg_oauth`
-  are in-memory and untouched) MUST run before replay on every CreateSession
-  in shared-warm mode, and a wipe failure MUST fail the session.
+  reused across users of an org: `wipeUserSecrets` drops ALL user-created
+  secrets — persistent ones AND non-persistent (plain/TEMPORARY `CREATE
+  SECRET`) ones, which pass through to the worker and would otherwise leak to
+  the next user. It preserves only the system-managed allowlist
+  (`usersecrets.IsReservedName`: `ducklake_s3`/`iceberg_sigv4`/`iceberg_oauth`
+  + the `__default_*`/`duckgres_*` prefixes, which activation re-creates). It
+  MUST run before replay on every CreateSession in shared-warm mode, and a
+  wipe failure MUST fail the session.
 - **Execute-then-persist ordering.** Persist only statements DuckDB accepted;
   a store failure after a successful exec is an ERROR telling the user the
   secret will NOT survive the session. Replay failures at session create are

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -1062,13 +1062,15 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 		}
 	}
 
-	// Persistent user-secret hygiene + replay (shared-warm / k8s mode only).
-	// DuckDB secrets are instance-global, so a hot-idle worker reused by a
-	// different user of the same org would otherwise see the previous user's
-	// persistent secrets. Wipe first (mandatory — this is the cross-user
-	// isolation step), then replay this user's secrets from the control
-	// plane. Replay failures degrade to warnings; a wipe failure fails the
-	// session because handing user A's secrets to user B is not acceptable.
+	// User-secret hygiene + replay (shared-warm / k8s mode only). DuckDB
+	// secrets are instance-global, so a hot-idle worker reused by a different
+	// user of the same org would otherwise see the previous user's secrets —
+	// both persistent ones and non-persistent (plain/TEMPORARY CREATE SECRET)
+	// ones that pass through to the worker. Wipe ALL user secrets first
+	// (mandatory — this is the cross-user isolation step), then replay this
+	// user's secrets from the control plane. Replay failures degrade to
+	// warnings; a wipe failure fails the session because handing user A's
+	// secrets to user B is not acceptable.
 	var secretWarnings []string
 	switch {
 	case p.sharedWarmMode && p.maxSessions != 1:
@@ -1078,24 +1080,24 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 		// the point of reliance, instead of trusting a flag set two layers
 		// away: with any other cap, wiping would delete a concurrent
 		// session's secrets mid-query. Skip hygiene entirely and scream.
-		slog.Error("User persistent secret hygiene requires max_sessions=1 on shared-warm workers; skipping wipe+replay.",
+		slog.Error("User secret hygiene requires max_sessions=1 on shared-warm workers; skipping wipe+replay.",
 			"max_sessions", p.maxSessions, "user", username, "secrets", len(secretStatements))
 		if len(secretStatements) > 0 {
 			secretWarnings = []string{"persistent secrets were NOT restored: worker session cap is misconfigured (requires max_sessions=1)"}
 		}
 	case p.sharedWarmMode:
 		secretCtx, secretCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
-		wiped, wipeErr := wipeUserPersistentSecrets(secretCtx, conn)
+		wiped, wipeErr := wipeUserSecrets(secretCtx, conn)
 		if wipeErr != nil {
 			secretCancel()
 			_ = conn.Close()
 			p.mu.Lock()
 			p.reserved--
 			p.mu.Unlock()
-			return nil, nil, fmt.Errorf("wipe persistent secrets before session start: %w", wipeErr)
+			return nil, nil, fmt.Errorf("wipe user secrets before session start: %w", wipeErr)
 		}
 		if len(wiped) > 0 {
-			slog.Info("Wiped persistent secrets left by previous session.", "user", username, "count", len(wiped))
+			slog.Info("Wiped user secrets left by previous session.", "user", username, "count", len(wiped))
 		}
 		secretWarnings = replayUserSecrets(secretCtx, conn, username, secretStatements)
 		secretCancel()
@@ -1286,16 +1288,16 @@ func (p *SessionPool) DestroySession(token string) error {
 		session.connMu.Unlock()
 	}
 
-	// Best-effort persistent-secret wipe so user credentials don't sit on a
-	// hot-idle worker between sessions. The mandatory cross-user isolation
-	// wipe happens at the next CreateSession; this one just narrows the
-	// window. Only safe when this worker serves one session at a time
-	// (secrets are instance-global), which is how k8s workers are deployed
-	// (DUCKGRES_DUCKDB_MAX_SESSIONS=1).
+	// Best-effort user-secret wipe (persistent + temporary) so user
+	// credentials don't sit on a hot-idle worker between sessions. The
+	// mandatory cross-user isolation wipe happens at the next CreateSession;
+	// this one just narrows the window. Only safe when this worker serves one
+	// session at a time (secrets are instance-global), which is how k8s
+	// workers are deployed (DUCKGRES_DUCKDB_MAX_SESSIONS=1).
 	if p.sharedWarmMode && p.maxSessions == 1 && session.DB != nil {
 		wipeCtx, wipeCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
-		if _, err := wipeUserPersistentSecrets(wipeCtx, session.DB); err != nil {
-			slog.Warn("Failed to wipe persistent secrets on session destroy.", "user", session.Username, "error", err)
+		if _, err := wipeUserSecrets(wipeCtx, session.DB); err != nil {
+			slog.Warn("Failed to wipe user secrets on session destroy.", "user", session.Username, "error", err)
 		}
 		wipeCancel()
 	}

--- a/duckdbservice/user_secrets.go
+++ b/duckdbservice/user_secrets.go
@@ -20,26 +20,42 @@ type secretDBHandle interface {
 
 const userSecretOpTimeout = 15 * time.Second
 
-// wipeUserPersistentSecrets drops every persistent-storage DuckDB secret on
-// the shared per-org instance. System secrets (ducklake_s3, iceberg_sigv4,
-// iceberg_oauth) are created with plain CREATE OR REPLACE SECRET and live in
-// in-memory storage, so a persistent-only wipe never touches them — anything
-// persistent was replayed (or created) by a user session and must not leak
-// into the next session, which may belong to a different user of the org.
+// wipeUserSecrets drops every user-created DuckDB secret on the shared per-org
+// instance — both persistent ones (replayed/created by a user session) AND
+// non-persistent ones created via plain CREATE SECRET / CREATE TEMPORARY
+// SECRET, which the control plane passes through verbatim to the worker.
+//
+// DuckDB secrets are instance-global and survive connection eviction, so a
+// temporary secret created by user A of an org would otherwise linger on the
+// hot-idle worker pod and be inherited by the next user B of the same org —
+// who could then read A's private buckets or enumerate A's credentials via
+// duckdb_secrets(). That makes a persistent-only wipe a cross-user isolation
+// leak; this wipe closes it by dropping temporary secrets too.
+//
+// System-managed secrets (ducklake_s3, iceberg_sigv4, iceberg_oauth, plus the
+// reserved __default_*/duckgres_* prefixes) are preserved: activation
+// re-creates them and dropping them would break the org's own catalog wiring.
+// The allowlist is usersecrets.IsReservedName, the same set the control plane
+// forbids users from creating, so no user secret can hide behind it.
+//
 // Returns the names that were dropped.
-func wipeUserPersistentSecrets(ctx context.Context, h secretDBHandle) ([]string, error) {
-	rows, err := h.QueryContext(ctx, "SELECT name FROM duckdb_secrets() WHERE persistent")
+func wipeUserSecrets(ctx context.Context, h secretDBHandle) ([]string, error) {
+	rows, err := h.QueryContext(ctx, "SELECT name, persistent FROM duckdb_secrets()")
 	if err != nil {
-		return nil, fmt.Errorf("list persistent secrets: %w", err)
+		return nil, fmt.Errorf("list secrets: %w", err)
 	}
-	var names []string
+	type secretRow struct {
+		name       string
+		persistent bool
+	}
+	var secrets []secretRow
 	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
+		var s secretRow
+		if err := rows.Scan(&s.name, &s.persistent); err != nil {
 			_ = rows.Close()
 			return nil, err
 		}
-		names = append(names, name)
+		secrets = append(secrets, s)
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
@@ -48,11 +64,25 @@ func wipeUserPersistentSecrets(ctx context.Context, h secretDBHandle) ([]string,
 	_ = rows.Close()
 
 	var dropped []string
-	for _, name := range names {
-		if _, err := h.ExecContext(ctx, "DROP PERSISTENT SECRET IF EXISTS "+quoteSecretIdent(name)); err != nil {
-			return dropped, fmt.Errorf("drop persistent secret %q: %w", name, err)
+	for _, s := range secrets {
+		// Preserve system-managed secrets; activation re-creates these.
+		if usersecrets.IsReservedName(s.name) {
+			continue
 		}
-		dropped = append(dropped, name)
+		// DuckDB requires the storage backend in DROP when more than one
+		// backend is in play: persistent secrets live on disk, temporary ones
+		// in memory, and a plain "DROP SECRET" is ambiguous across them. Branch
+		// on the per-row persistent flag to issue the unambiguous form.
+		var drop string
+		if s.persistent {
+			drop = "DROP PERSISTENT SECRET IF EXISTS " + quoteSecretIdent(s.name)
+		} else {
+			drop = "DROP TEMPORARY SECRET IF EXISTS " + quoteSecretIdent(s.name)
+		}
+		if _, err := h.ExecContext(ctx, drop); err != nil {
+			return dropped, fmt.Errorf("drop secret %q (persistent=%t): %w", s.name, s.persistent, err)
+		}
+		dropped = append(dropped, s.name)
 	}
 	return dropped, nil
 }

--- a/duckdbservice/user_secrets_test.go
+++ b/duckdbservice/user_secrets_test.go
@@ -44,9 +44,11 @@ func secretNames(t *testing.T, db *sql.DB, where string) map[string]bool {
 	return names
 }
 
-// Wipe must drop persistent secrets (user-created) and leave in-memory
-// secrets (how the system catalog secrets are created) untouched.
-func TestWipeUserPersistentSecrets(t *testing.T) {
+// Wipe must drop ALL user-created secrets — persistent AND non-persistent
+// (plain/TEMPORARY CREATE SECRET) — while leaving the system-managed catalog
+// secrets (ducklake_s3 / iceberg_sigv4 / iceberg_oauth, plus the reserved
+// __default_*/duckgres_* prefixes) untouched.
+func TestWipeUserSecrets(t *testing.T) {
 	db := openSecretTestDB(t)
 	mustExec := func(q string) {
 		t.Helper()
@@ -54,22 +56,58 @@ func TestWipeUserPersistentSecrets(t *testing.T) {
 			t.Fatalf("exec %q: %v", q, err)
 		}
 	}
+	// System-managed secrets (created with plain CREATE OR REPLACE SECRET, so
+	// they land in in-memory/temporary storage). These must survive the wipe.
 	mustExec("CREATE OR REPLACE SECRET ducklake_s3 (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
+	mustExec("CREATE OR REPLACE SECRET iceberg_sigv4 (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
+	// User secrets: a persistent one and a temporary one. Both must be dropped.
 	mustExec("CREATE PERSISTENT SECRET user_a (TYPE s3, KEY_ID 'a', SECRET 'a')")
 	mustExec(`CREATE PERSISTENT SECRET "user_b" (TYPE gcs, KEY_ID 'b', SECRET 'b')`)
+	mustExec("CREATE TEMPORARY SECRET user_temp (TYPE s3, KEY_ID 't', SECRET 't')")
 
-	dropped, err := wipeUserPersistentSecrets(context.Background(), db)
+	dropped, err := wipeUserSecrets(context.Background(), db)
 	if err != nil {
-		t.Fatalf("wipeUserPersistentSecrets: %v", err)
+		t.Fatalf("wipeUserSecrets: %v", err)
 	}
-	if len(dropped) != 2 {
-		t.Errorf("dropped = %v, want 2 names", dropped)
+	if len(dropped) != 3 {
+		t.Errorf("dropped = %v, want 3 names (user_a, user_b, user_temp)", dropped)
 	}
-	if names := secretNames(t, db, "WHERE persistent"); len(names) != 0 {
-		t.Errorf("persistent secrets remain after wipe: %v", names)
+	remaining := secretNames(t, db, "")
+	for _, leaked := range []string{"user_a", "user_b", "user_temp"} {
+		if remaining[leaked] {
+			t.Errorf("user secret %q remains after wipe; remaining: %v", leaked, remaining)
+		}
 	}
-	if names := secretNames(t, db, ""); !names["ducklake_s3"] {
-		t.Errorf("system in-memory secret was wiped; remaining: %v", names)
+	for _, sys := range []string{"ducklake_s3", "iceberg_sigv4"} {
+		if !remaining[sys] {
+			t.Errorf("system secret %q was wiped; remaining: %v", sys, remaining)
+		}
+	}
+}
+
+// Regression for the cross-user isolation leak: a non-persistent (TEMPORARY /
+// plain) secret created by one user lingers on the instance-global DuckDB and
+// would be inherited by the next user of the same org. The wipe must remove it.
+func TestWipeUserSecretsDropsTemporary(t *testing.T) {
+	db := openSecretTestDB(t)
+	// Plain CREATE SECRET is non-persistent in DuckDB — the exact passthrough
+	// path the control plane allows for session-scoped secrets.
+	if _, err := db.Exec("CREATE SECRET leaky (TYPE s3, KEY_ID 'private', SECRET 'private')"); err != nil {
+		t.Fatalf("create temporary secret: %v", err)
+	}
+	if names := secretNames(t, db, ""); !names["leaky"] {
+		t.Fatalf("temporary secret not present before wipe; have %v", names)
+	}
+
+	dropped, err := wipeUserSecrets(context.Background(), db)
+	if err != nil {
+		t.Fatalf("wipeUserSecrets: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "leaky" {
+		t.Errorf("dropped = %v, want [leaky]", dropped)
+	}
+	if names := secretNames(t, db, ""); names["leaky"] {
+		t.Errorf("temporary secret leaked across wipe (cross-user isolation bug); remaining: %v", names)
 	}
 }
 

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -878,33 +878,45 @@ persistent_user_secret() { # org password
   log "persistent secret OK on $org (create → cross-session replay → reserved/unnamed rejected → durable drop)"
 }
 
-# Cross-user isolation within one org: user B must never see user A's
-# persistent secret. B's session typically reuses A's hot-idle worker (one org,
-# cap permitting), which is exactly the leak path: the worker wipes persistent
-# secrets at session create and replays only the connecting user's.
+# Cross-user isolation within one org: user B must never see user A's secrets,
+# whether PERSISTENT or non-persistent (plain/TEMPORARY CREATE SECRET). B's
+# session typically reuses A's hot-idle worker (one org, cap permitting), which
+# is exactly the leak path. DuckDB secrets are instance-global, so a temporary
+# secret created by A would survive on the worker and be visible to B unless the
+# session-create wipe drops non-persistent secrets too. The worker wipes ALL
+# user secrets at session create and replays only the connecting user's stored
+# (persistent) ones.
 persistent_user_secret_isolation() { # org rootpw
-  org="$1"; pw="$2"; sname="e2e_root_secret"; u2="e2esecuser"
+  org="$1"; pw="$2"; sname="e2e_root_secret"; tname="e2e_root_temp_secret"; u2="e2esecuser"
   u2pw="e2e-$(openssl rand -hex 12)"
-  log "persistent secret cross-user isolation on $org"
+  log "user secret cross-user isolation on $org (persistent + temporary)"
 
   pg "$org" "$pw" ducklake "CREATE PERSISTENT SECRET $sname (TYPE s3, KEY_ID 'AKIAE2EDUMMY', SECRET 'root-dummy', REGION 'us-east-1', SCOPE 's3://duckgres-e2e-nonexistent-root-$org')" >/dev/null
+  # A non-persistent (TEMPORARY) secret is passed through to the worker and is
+  # NOT stored/replayed. It lives only on the instance-global DuckDB — the exact
+  # state that must be wiped before another user of the org connects.
+  pg "$org" "$pw" ducklake "CREATE TEMPORARY SECRET $tname (TYPE s3, KEY_ID 'AKIAE2ETMP', SECRET 'root-temp', REGION 'us-east-1', SCOPE 's3://duckgres-e2e-nonexistent-temp-$org')" >/dev/null
 
   code="$(curl -s -o /tmp/create_user_out -w '%{http_code}' -X POST -H "$H" \
     -H 'Content-Type: application/json' \
     -d "{\"org_id\":\"$org\",\"username\":\"$u2\",\"password\":\"$u2pw\"}" \
     "$API/api/v1/users")"
-  case "$code" in 200|201) ;; *) fail "persistent secret: create user $u2 -> HTTP $code: $(cat /tmp/create_user_out)";; esac
+  case "$code" in 200|201) ;; *) fail "user secret: create user $u2 -> HTTP $code: $(cat /tmp/create_user_out)";; esac
   # New-user auth is config-snapshot-driven; wait out one poll before the
   # first login so we don't burn failed auths against the rate limiter.
   sleep "${CONFIG_POLL_SETTLE:-12}"
 
   n="$(pg "$org" "$u2pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'" "$u2")"
-  [ "$n" = "0" ] || fail "persistent secret: user $u2 sees root's secret (count=$n)"
-  # Root's stored copy must be unaffected by $u2's session-create wipe.
+  [ "$n" = "0" ] || fail "user secret: user $u2 sees root's persistent secret (count=$n)"
+  # Regression for the cross-user secret leak: $u2 must not inherit root's
+  # TEMPORARY secret left behind on the instance-global worker DuckDB.
+  n="$(pg "$org" "$u2pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$tname'" "$u2")"
+  [ "$n" = "0" ] || fail "user secret: user $u2 sees root's TEMPORARY secret — cross-user leak (count=$n)"
+  # Root's stored (persistent) copy must be unaffected by $u2's session-create wipe.
   n="$(pg "$org" "$pw" ducklake "SELECT count(*) FROM duckdb_secrets() WHERE name = '$sname'")"
-  [ "$n" = "1" ] || fail "persistent secret: root's secret lost after $u2's session (count=$n)"
+  [ "$n" = "1" ] || fail "user secret: root's persistent secret lost after $u2's session (count=$n)"
   pg "$org" "$pw" ducklake "DROP PERSISTENT SECRET $sname" >/dev/null
-  log "persistent secret isolation OK on $org ($u2 blind to root's secret; root's copy intact)"
+  log "user secret isolation OK on $org ($u2 blind to root's persistent AND temporary secrets; root's stored copy intact)"
 }
 
 # ---- resilience -----------------------------------------------------------


### PR DESCRIPTION
## The vulnerability (HIGH — tenant isolation)

The cross-user isolation wipe `wipeUserPersistentSecrets` (`duckdbservice/user_secrets.go`) only enumerated and dropped **persistent** secrets (`SELECT name FROM duckdb_secrets() WHERE persistent` + `DROP PERSISTENT SECRET`).

But clients can create **non-persistent** secrets via plain `CREATE SECRET` or `CREATE TEMPORARY SECRET`, which the control plane intentionally passes through to run verbatim on the org's worker DuckDB (`server/conn_user_secrets.go`). DuckDB secrets are **instance-global** and survive connection eviction, so a temporary secret created by user A of an org persisted on the hot-idle worker pod and was inherited by the next user B of the same org. B could then read A's private buckets or enumerate A's credentials via `duckdb_secrets()`.

The wipe runs at `CreateSession` (mandatory cross-user isolation step) and at `DestroySession` (best-effort).

## The fix

- Renamed `wipeUserPersistentSecrets` → `wipeUserSecrets` and updated all callers (`duckdbservice/service.go`, the test).
- It now enumerates **every** secret (`SELECT name, persistent FROM duckdb_secrets()`) and drops every non-allowlisted one, branching on the per-row `persistent` flag to issue the storage-correct DROP form (`DROP PERSISTENT SECRET` vs `DROP TEMPORARY SECRET` — DuckDB requires the backend to be named when more than one storage backend is in play).
- System-managed secrets are preserved via the existing `usersecrets.IsReservedName` allowlist: `ducklake_s3`, `iceberg_sigv4`, `iceberg_oauth`, plus the reserved `__default_*` / `duckgres_*` prefixes — the same set the control plane forbids users from creating, so no user secret can hide behind it. Activation re-creates these.
- Preserved semantics: a wipe failure at `CreateSession` still **fails the session**; the `DestroySession` wipe stays best-effort.
- Updated the matching CLAUDE.md invariant comment.

## Tests

- **Unit** (`duckdbservice/user_secrets_test.go`): rewrote `TestWipeUserSecrets` to assert a persistent secret, a quoted persistent secret, and a TEMPORARY secret are all dropped while `ducklake_s3` / `iceberg_sigv4` survive. Added `TestWipeUserSecretsDropsTemporary` as a focused regression on the plain `CREATE SECRET` leak. `go test ./duckdbservice/ -run Secret -count=1` passes; full `go test ./duckdbservice/` passes.
- **E2E** (`tests/e2e-mw-dev/harness.sh`): extended `persistent_user_secret_isolation` with a TEMPORARY-secret variant — user A creates a `CREATE TEMPORARY SECRET`, and user B (reusing A's hot-idle worker) must see `count = 0` for it. **This e2e harness was NOT executed locally** — the real posthog-mw-dev EKS cluster is required and cannot be run from this environment. The assertion follows the existing harness style and shell syntax checks clean (`bash -n`).

## Verification

- `go build ./duckdbservice/...` — pass
- `go vet ./duckdbservice/` — clean
- `go test ./duckdbservice/` — pass

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*