### PR TITLE
fix(controlplane): janitor stuck-spawning cutoff must cover the detached spawn budget

### DIFF
--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -52,12 +52,23 @@ func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeo
 		expiryTimeout = 20 * time.Second
 	}
 	return &ControlPlaneJanitor{
-		store:           store,
-		interval:        interval,
-		expiryTimeout:   expiryTimeout,
-		orphanGrace:     30 * time.Second,
-		spawnTimeout:    2 * time.Minute,
-		activateTimeout: 2 * time.Minute,
+		store:         store,
+		interval:      interval,
+		expiryTimeout: expiryTimeout,
+		orphanGrace:   30 * time.Second,
+		// The stuck-worker cutoffs must exceed the detached spawn+activate
+		// budget (workerSpawnActivateTimeout, 8m: pod-ready incl. Karpenter
+		// node provisioning + gRPC connect + activation). A spawning row's
+		// updated_at is not touched between CreateSpawningWorkerSlot and the
+		// Reserved transition, and ListStuckWorkers does not exclude rows
+		// whose owner CP is alive — so a cutoff below the budget makes the
+		// janitor leader delete legitimately in-flight pods mid-spawn
+		// (doomed-spawn thrash on every cold-node spawn slower than the
+		// cutoff). Reserved/Activating rows get their updated_at bumped at
+		// each lifecycle transition, so activateTimeout only needs to cover
+		// the connect+activate tail, with slack for clock/poll skew.
+		spawnTimeout:    10 * time.Minute,
+		activateTimeout: 5 * time.Minute,
 		maxDrainTimeout: 15 * time.Minute,
 		now:             time.Now,
 	}

--- a/controlplane/janitor_spawn_budget_test.go
+++ b/controlplane/janitor_spawn_budget_test.go
@@ -1,0 +1,60 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"testing"
+	"time"
+)
+
+// Audit H1 regression test.
+//
+// The detached spawn+activate path budgets workerSpawnActivateTimeout
+// (pod-ready wait of workerPodReadyTimeout — which may include Karpenter
+// provisioning a fresh node — plus gRPC connect and activation). During that
+// whole window the worker's config-store row sits in state=spawning with an
+// untouched updated_at: nothing heartbeats it until the Reserved record is
+// persisted after pod-ready + connect succeed (spawnReservedWorkerForSlot).
+//
+// The janitor's stuck-spawning sweep retires any spawning row older than its
+// spawnTimeout cutoff, and ListStuckWorkers does NOT exclude rows whose owner
+// CP is alive. So if the cutoff is shorter than the spawn budget, the janitor
+// leader deletes legitimately in-flight pods mid-spawn (cold-node spawns are
+// exactly the slow ones), recreating the doomed-spawn thrash the detached
+// spawn design exists to prevent.
+//
+// This test pins the relation: the janitor must not consider a spawning row
+// stuck while the detached spawn budget for it has not yet expired. If the
+// fix instead heartbeats the spawning row or makes ListStuckWorkers exclude
+// live-owner rows, relax this assertion accordingly — but only together with
+// a test of that mechanism.
+func TestJanitorStuckSpawningCutoffCoversDetachedSpawnBudget(t *testing.T) {
+	store := &captureControlPlaneExpiryStore{}
+	now := time.Date(2026, time.June, 12, 12, 0, 0, 0, time.UTC)
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.now = func() time.Time { return now }
+	janitor.lifecycle = NewWorkerLifecycle(&fakeLifecycleStore{}, &fakePhysicalCleanup{})
+
+	janitor.runOnce()
+
+	if len(store.stuckSpawningBefore) == 0 {
+		t.Fatal("janitor did not run the stuck-spawning sweep")
+	}
+	cutoff := store.stuckSpawningBefore[0]
+	tolerated := now.Sub(cutoff)
+	if tolerated < workerSpawnActivateTimeout {
+		t.Fatalf("janitor retires spawning workers after %s, but a legitimate detached spawn may take up to %s (workerSpawnActivateTimeout: pod-ready incl. node provisioning + connect + activate) — in-flight cold spawns get their pods deleted mid-spawn",
+			tolerated, workerSpawnActivateTimeout)
+	}
+
+	// Reserved/Activating rows have their updated_at bumped at each lifecycle
+	// transition, so the activating cutoff only needs to cover the
+	// connect+activate tail of the spawn budget.
+	if len(store.stuckActivatingBefore) == 0 {
+		t.Fatal("janitor did not run the stuck-activating sweep")
+	}
+	activateTail := workerSpawnActivateTimeout - workerPodReadyTimeout
+	if got := now.Sub(store.stuckActivatingBefore[0]); got < activateTail {
+		t.Fatalf("janitor retires reserved/activating workers after %s, but the connect+activate tail of a legitimate spawn may take up to %s", got, activateTail)
+	}
+}


### PR DESCRIPTION
## Problem (audit finding H1)

The janitor's stuck-worker sweep retires any config-store row in `state=spawning` older than its `spawnTimeout` cutoff — which defaulted to **2 minutes**. But a legitimate detached spawn budgets up to **8 minutes** (`workerSpawnActivateTimeout` = `workerPodReadyTimeout` 5m — explicitly sized for Karpenter provisioning a fresh node — plus 3m for gRPC connect + activation).

Two facts make the 2m cutoff destructive rather than conservative:

- The spawning row's `updated_at` is never touched between `CreateSpawningWorkerSlot` and the Reserved transition (nothing heartbeats it during the pod-ready wait).
- `ListStuckWorkers` does **not** exclude rows whose owner CP is alive (`cp.id IS NULL OR cp.state <> expired` includes live owners).

So on every cold-node spawn slower than 2 minutes, the janitor leader CAS'd the row to retired and deleted the pod mid-spawn — the requester gets "pod failed or was deleted", retries, and the cycle repeats: exactly the doomed-spawn thrash the detached-spawn design exists to prevent.

## Fix

- `spawnTimeout`: 2m → **10m** (spawn budget 8m + slack).
- `activateTimeout`: 2m → **5m**. Reserved/Activating rows get `updated_at` bumped at each lifecycle transition, so this cutoff only needs to cover the connect+activate tail (up to 3m of the budget) + slack — but 2m was below even that tail.

Alternative fixes considered (heartbeating the spawning row; excluding live-owner rows in `ListStuckWorkers`) are more invasive and can be layered later; the cutoff raise removes the active harm now. Genuinely stuck rows (owner CP crashed mid-spawn) are still reaped — 8 minutes later than before, which only delays cleanup of an already-dead pod slot.

## Test

`TestJanitorStuckSpawningCutoffCoversDetachedSpawnBudget` runs the janitor sweep against the capture store and asserts the cutoffs it actually passes to the stuck-worker listing cover `workerSpawnActivateTimeout` (and the activate tail respectively), so the janitor and the spawn budget can no longer drift apart silently. The test fails on main as written ("janitor retires spawning workers after 2m0s, but a legitimate detached spawn may take up to 8m0s").

## e2e-mw-dev note

This cannot be asserted deterministically in-Job: it would require forcing a >2-minute cold-node spawn (Karpenter provisioning) and observing the janitor leader's behavior mid-spawn, which is timing-dependent cluster state the harness cannot control. The unit test pins the budget relation instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)