### PR TITLE
fix(controlplane): claim the session on Flight reconnect so the worker isn't co-assigned

### DIFF
--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -489,6 +489,19 @@ func (p *OrgReservedPool) ReconnectFlightWorker(ctx context.Context, workerID in
 	if err != nil {
 		return nil, err
 	}
+
+	// Pre-claim the reconnected session while the worker is still Reserved,
+	// exactly like executeAcquire: a reconnected Flight session is a live
+	// session like any other. Without the claim the worker becomes Hot with
+	// activeSessions==0 — findIdleAssignedWorkerLocked then co-assigns the
+	// org's next connection onto it, the worker-side MaxSessions=1 cap
+	// rejects that, and the cap-drift recovery retires the worker out from
+	// under the live reconnected query (ShutdownAll's active-session
+	// preservation also wouldn't protect it).
+	p.shared.mu.Lock()
+	worker.claimSessionLocked()
+	p.shared.mu.Unlock()
+
 	if err := p.activateWorkerForOrg(ctx, worker); err != nil {
 		p.shared.retireWorkerWithReason(worker.ID, RetireReasonActivationFailure, LifecycleOriginActivationFailure)
 		return nil, err

--- a/controlplane/org_reserved_pool_reconnect_test.go
+++ b/controlplane/org_reserved_pool_reconnect_test.go
@@ -1,0 +1,86 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// Audit H2 regression test.
+//
+// Every acquisition path pre-claims the session on the pool-side worker
+// accounting (claimSessionLocked / activeSessions++) before handing the
+// worker out — that counter is what keeps a busy worker out of
+// findIdleAssignedWorkerLocked, and what makes ShutdownAll preserve workers
+// with live sessions. The Flight reconnect path (ReconnectFlightWorker →
+// claimSpecificWorker → reserveClaimedWorker) must do the same: a reconnected
+// Flight session is a live session like any other.
+//
+// Without the claim, the reconnected worker looks idle (activeSessions==0),
+// so the org's next connection is co-assigned onto it; the worker-side
+// MaxSessions=1 cap rejects that, and the cap-drift recovery then RETIRES the
+// worker — killing the live reconnected query.
+func TestReconnectFlightWorkerClaimsSession(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 5)
+	const workerID = 3
+
+	// A Flight session that disconnected with a reconnect token released its
+	// worker (ReleaseWorker → TransitionToHotIdleIfNoSessions), so the worker
+	// the reconnect claims back is hot-idle in this CP's memory.
+	worker := &ManagedWorker{ID: workerID, image: shared.workerImage, done: make(chan struct{})}
+	if err := worker.SetSharedState(SharedWorkerState{
+		Lifecycle: WorkerLifecycleHotIdle,
+		Assignment: &WorkerAssignment{
+			OrgID: "analytics",
+		},
+	}); err != nil {
+		t.Fatalf("SetSharedState(worker): %v", err)
+	}
+	shared.workers[workerID] = worker
+
+	store := &captureRuntimeWorkerStore{
+		takenOver: &configstore.WorkerRecord{
+			WorkerID:          workerID,
+			PodName:           "duckgres-worker-3",
+			Image:             shared.workerImage,
+			State:             configstore.WorkerStateHotIdle,
+			OwnerCPInstanceID: shared.cpInstanceID,
+			OwnerEpoch:        2,
+		},
+	}
+	shared.runtimeStore = store
+	shared.healthCheckFunc = func(ctx context.Context, w *ManagedWorker) error {
+		return nil
+	}
+
+	pool := NewOrgReservedPool(shared, "analytics", 2, shared.workerImage, nil)
+	pool.activateReservedWorker = func(ctx context.Context, w *ManagedWorker) error {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := pool.ReconnectFlightWorker(ctx, workerID, 1)
+	if err != nil {
+		t.Fatalf("ReconnectFlightWorker: %v", err)
+	}
+	if got.ID != workerID {
+		t.Fatalf("expected worker %d, got %d", workerID, got.ID)
+	}
+
+	shared.mu.Lock()
+	sessions := got.activeSessions
+	idle := pool.findIdleAssignedWorkerLocked(nil)
+	shared.mu.Unlock()
+
+	if sessions != 1 {
+		t.Fatalf("reconnected Flight session holds no pool-side session claim (activeSessions=%d, want 1) — the worker looks idle while serving a live query and will be co-assigned, then retired by cap-drift recovery", sessions)
+	}
+	if idle != nil {
+		t.Fatalf("worker %d serving a reconnected Flight session is offered for idle reuse — a concurrent same-org connection would be co-assigned onto it", idle.ID)
+	}
+}

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -439,6 +439,10 @@ func (sm *SessionManager) ReconnectFlightSession(ctx context.Context, username s
 	}
 	pid, exec, err := sm.createSessionOnWorker(ctx, username, 0, "", 0, worker, "flight", false, lease)
 	if err != nil {
+		// ReconnectFlightWorker pre-claimed the session on the worker; undo
+		// the claim so the worker parks hot-idle instead of looking busy
+		// forever with no session on it.
+		sm.pool.ReleaseWorker(worker.ID)
 		return 0, nil, err
 	}
 	success = true


### PR DESCRIPTION
## Problem (audit finding H2)

Every acquisition path pre-claims the session on the pool-side worker accounting (`claimSessionLocked` / `activeSessions++`) before the worker becomes visible as Hot — per the anti-snatch contract, "the session is pre-claimed before the worker becomes Hot". The Flight reconnect path (`SessionManager.ReconnectFlightSession` → `OrgReservedPool.ReconnectFlightWorker` → `claimSpecificWorker` → `reserveClaimedWorker`) never claimed.

So for the entire life of a reconnected Flight session the worker was Hot with `activeSessions==0`, with two consequences:

1. **Co-assign → kill the live query.** `findIdleAssignedWorkerLocked` (`activeSessions == 0 && ready`) offers the worker to the org's next connection. The worker-side `MaxSessions=1` cap rejects that second session, which trips the cap-drift recovery — and that path **retires** the "drifted" worker, killing the live reconnected query it was hosting.
2. **Shutdown deletes the pod under the query.** `ShutdownAll`'s active-session preservation keys off `activeSessions > 0`, so a CP shutdown/rollout deleted the reconnected session's pod.

## Fix

- `ReconnectFlightWorker` pre-claims the session right after the config-store takeover, while the worker is still Reserved — mirroring `executeAcquire`'s pre-claim, so the worker is never observable as Hot+idle while owned by the reconnecting waiter.
- If the subsequent `CreateSession` on the worker fails, `ReconnectFlightSession` now releases the claim (`ReleaseWorker`) so the worker parks hot-idle instead of looking busy forever with no session on it.

## Test

`TestReconnectFlightWorkerClaimsSession` models the real reconnect shape (worker hot-idle in CP memory after `ReleaseWorker`, takeover via the runtime store) and asserts both that the reconnected worker holds a session claim (`activeSessions == 1`) and that `findIdleAssignedWorkerLocked` no longer offers it for reuse. Fails on main with `activeSessions=0`.

## Worker session model contract note

This touches `controlplane/org_reserved_pool.go`, so per CLAUDE.md the `one_session_per_worker` harness assertion is in scope: the existing assertion exercises the acquire path and still passes; a reconnect-specific in-Job assertion needs a Flight SQL client driving disconnect/reconnect from inside the harness Job, which the harness does not currently have — flagging instead of silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)