### PR TITLE
fix(duckdbservice): size the Main conn pool to the worker's session admission

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -105,6 +105,7 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 				p.mu.Unlock()
 				return fmt.Errorf("create activation-ready runtime: %w", err)
 			}
+			p.sizeMainForSessions(pair)
 			p.fallbackDB = pair.Main
 			p.activePair = pair
 			p.controlDB = pair.Control

--- a/duckdbservice/coassigned_sessions_test.go
+++ b/duckdbservice/coassigned_sessions_test.go
@@ -1,0 +1,81 @@
+package duckdbservice
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server"
+)
+
+// Audit H3 regression test.
+//
+// On the process backend, FlightWorkerPool.AcquireWorker co-assigns sessions:
+// at pool capacity it hands the connection to the least-loaded LIVE worker,
+// so a worker legitimately receives a second concurrent CreateSession
+// (process workers run with the default unlimited max-sessions). Every
+// session pins a dedicated *sql.Conn from the worker's shared main DB for its
+// whole lifetime, and OpenDuckDBPair caps that DB at MaxOpenConns=1 — so
+// without resizing, the second CreateSession can never get a connection while
+// the first session is alive: it blocks for the full 30s pool timeout, fails
+// with the conn-pool-timeout error, the control plane classifies the worker
+// as WEDGED (isWorkerConnPoolTimeoutError) and retires it — killing the
+// co-resident in-flight first session.
+//
+// The invariant: a worker must be able to serve as many concurrent sessions
+// as it admits. The pool resizes the pair's Main connection capacity to the
+// session cap (sizeMainForSessions); this test drives two concurrent
+// sessions through the production pair-creation path and requires the second
+// to become usable promptly.
+func TestSecondAdmittedConcurrentSessionIsNotStarvedByPinnedConn(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		maxSessions: 0, // process-backend default: unlimited admission
+		createDBPair: func(server.Config, chan struct{}, string, time.Time, string) (*DuckDBPair, error) {
+			db, err := sql.Open("duckdb", "")
+			if err != nil {
+				return nil, err
+			}
+			// Mirror OpenDuckDBPair's production setting for the
+			// client-query DB; the pool is responsible for resizing it to
+			// its session admission.
+			db.SetMaxOpenConns(1)
+			db.SetMaxIdleConns(1)
+			return PairFromMain(db), nil
+		},
+	}
+	close(pool.warmupDone) // warmup skipped; CreateSession takes the fallback pair path
+
+	first, _, err := pool.CreateSession("alice", "", 0, nil)
+	if err != nil {
+		t.Fatalf("first CreateSession: %v", err)
+	}
+	defer func() { _ = pool.DestroySession(first.ID) }()
+
+	type result struct {
+		session *Session
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, _, err := pool.CreateSession("bob", "", 0, nil)
+		done <- result{s, err}
+	}()
+
+	// The second session was admitted (no session-cap rejection), so it must
+	// become usable promptly — not sit starved behind the first session's
+	// pinned conn until the 30s pool timeout fires and the CP retires the
+	// whole worker as wedged.
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("second admitted concurrent session failed: %v", r.err)
+		}
+		_ = pool.DestroySession(r.session.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second admitted concurrent session starved behind the first session's pinned conn (MaxOpenConns=1): it will hit the 30s conn-pool timeout, which the control plane treats as a wedged worker and retires — killing the first session's in-flight query")
+	}
+}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -533,6 +533,24 @@ func wipePersistedSecrets(cfg server.Config) {
 	}
 }
 
+// sizeMainForSessions matches the Main DB's connection capacity to the
+// worker's session admission. Every admitted session pins one *sql.Conn for
+// its whole lifetime (CreateSession), so a Main pool smaller than the session
+// cap starves the (cap+1)th concurrent session for the full conn-acquire
+// timeout — which the control plane classifies as a WEDGED worker
+// (isWorkerConnPoolTimeoutError) and answers by retiring the worker, killing
+// its co-resident live sessions. The process backend co-assigns sessions at
+// pool capacity (least-loaded worker) with the default unlimited admission,
+// so its Main pool must be unlimited too; maxSessions==0 maps to
+// database/sql's 0 == unlimited. The k8s shape (maxSessions==1) keeps the
+// single-conn isolation OpenDuckDBPair sets up.
+func (p *SessionPool) sizeMainForSessions(pair *DuckDBPair) {
+	if pair == nil || pair.Main == nil || p.maxSessions == 1 {
+		return
+	}
+	pair.Main.SetMaxOpenConns(p.maxSessions)
+}
+
 // Warmup performs one-time initialization of the shared DuckDB instance.
 // This loads extensions and attaches catalogs so that subsequent session
 // creations are nearly instantaneous.
@@ -571,6 +589,7 @@ func (p *SessionPool) Warmup() error {
 	if err != nil {
 		return fmt.Errorf("warmup failed after %v: %w", time.Since(start), err)
 	}
+	p.sizeMainForSessions(pair)
 
 	p.mu.Lock()
 	p.warmupDB = pair.Main
@@ -1008,6 +1027,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 				p.fallbackErr = err
 				return
 			}
+			p.sizeMainForSessions(pair)
 			p.fallbackDB = pair.Main
 			p.activePair = pair
 			p.controlDB = pair.Control


### PR DESCRIPTION
## Problem (audit finding H3)

Three facts interact badly on the **process backend**:

1. `FlightWorkerPool.AcquireWorker` deliberately co-assigns at pool capacity: "assign to the least-loaded live worker". Process workers run with the default **unlimited** session admission (no `DUCKGRES_DUCKDB_MAX_SESSIONS` set).
2. Every admitted session pins one dedicated `*sql.Conn` from the worker's shared Main DB for its whole lifetime (`CreateSession`).
3. `OpenDuckDBPair` caps Main at `MaxOpenConns(1)`.

So the second concurrent session co-assigned onto a worker could never obtain a connection while the first was alive: it blocked for the full 30s conn-acquire timeout and failed with "failed to obtain connection from pool". The control plane classifies exactly that error as a **wedged worker** (`isWorkerConnPoolTimeoutError`) and retires the worker — killing the co-resident in-flight first session. With up to 3 retries (`maxWorkerSessionCapDriftRetries`) the recycle could cascade across more busy workers.

The k8s/remote backend is unaffected (cap=1, no co-assignment) — this is a process-backend interaction.

## Fix

Resize the pair's Main connection capacity to the pool's session admission (`sizeMainForSessions`) at the three places a pair becomes the pool's session-serving DB (warmup, CreateSession fallback, activation fallback):

- `maxSessions == 0` (unlimited admission, process-backend default) → `SetMaxOpenConns(0)` = unlimited. Multiple connections to the same DuckDB instance are the driver's supported shape; memory/thread budgeting across co-resident sessions is already the rebalancer's job on this backend.
- `maxSessions == 1` (the k8s worker shape) → untouched; keeps the single-conn isolation `OpenDuckDBPair` documents.
- `maxSessions == N` → `SetMaxOpenConns(N)`.

Alternative considered: stop co-assigning on the process backend (cap=1 there too). That changes the backend's documented capacity model (queueing instead of sharing at `--process-max-workers`) — a behavioral decision better made deliberately; this fix removes the wedge-misclassification harm without changing scheduling.

## Test

`TestSecondAdmittedConcurrentSessionIsNotStarvedByPinnedConn` drives two concurrent sessions through the production pair-creation path (stub pair mirrors `OpenDuckDBPair`'s `MaxOpenConns(1)`) and requires the second admitted session to become usable within 5s. Red without the fix (starves toward the 30s wedge timeout), green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)