### PR TITLE
fix(server): re-armable query cancel for process-isolation child workers

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -283,9 +283,17 @@ func (c *clientConn) queryContextInner(monitor bool) (context.Context, func()) {
 	key := c.backendKey()
 	c.server.RegisterQuery(key, cancel)
 
-	// If there's an external cancel channel (child worker mode), set up a goroutine
-	// to cancel the context when the channel is closed
+	// If there's an external cancel channel (child worker mode), set up a
+	// goroutine to cancel the context when a cancel token arrives. Each
+	// SIGUSR1 sends one token (worker.go notifyQueryCancel); discard a token
+	// that arrived while no query was in flight — like Postgres, a cancel
+	// request targets only the query running when it is delivered, so a stale
+	// one must not kill the next query.
 	if c.server.externalCancelCh != nil {
+		select {
+		case <-c.server.externalCancelCh:
+		default:
+		}
 		go func() {
 			select {
 			case <-c.server.externalCancelCh:

--- a/server/conn_external_cancel_test.go
+++ b/server/conn_external_cancel_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Audit H4 regression test.
+//
+// In ProcessIsolation child-worker mode, SIGUSR1 signals query cancellation
+// via the server's externalCancelCh (wired in runChildWorker). The channel
+// used to be CLOSED on the first signal and never re-armed, while
+// queryContextInner wires EVERY new query's context to it — so after one
+// cancel request the permanently-readable channel instantly cancelled every
+// subsequent query's context and the connection could never run another
+// statement.
+//
+// The contract: a cancel signal kills the query in flight, not the
+// connection. A query started after a cancel was consumed must get a live
+// context, and a later cancel must still work (the mechanism re-arms).
+func TestExternalCancelDoesNotPoisonSubsequentQueries(t *testing.T) {
+	cancelCh := make(chan struct{}, 1)
+	srv := &Server{
+		activeQueries:    make(map[BackendKey]context.CancelFunc),
+		externalCancelCh: cancelCh,
+	}
+	c := &clientConn{server: srv}
+
+	waitDone := func(ctx context.Context, what string) {
+		t.Helper()
+		select {
+		case <-ctx.Done():
+		case <-time.After(2 * time.Second):
+			t.Fatalf("external cancel did not cancel %s", what)
+		}
+	}
+	requireLive := func(ctx context.Context, what string) {
+		t.Helper()
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s was cancelled at start: a single SIGUSR1 must target only the query in flight, not poison the connection", what)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+
+	// Query 1 is in flight when SIGUSR1 arrives.
+	ctx1, cleanup1 := c.queryContextInner(false)
+	notifyQueryCancel(cancelCh)
+	waitDone(ctx1, "the in-flight query")
+	cleanup1()
+
+	// Query 2 starts after the cancel was consumed: must get a live context.
+	ctx2, cleanup2 := c.queryContextInner(false)
+	requireLive(ctx2, "the query after a consumed cancel")
+
+	// The mechanism must re-arm: a new SIGUSR1 cancels the new in-flight query.
+	notifyQueryCancel(cancelCh)
+	waitDone(ctx2, "the second query after a fresh cancel signal")
+	cleanup2()
+
+	// A cancel delivered while NO query is in flight is stale; like Postgres,
+	// it must not kill the next query.
+	notifyQueryCancel(cancelCh)
+	ctx3, cleanup3 := c.queryContextInner(false)
+	defer cleanup3()
+	requireLive(ctx3, "the query after a stale between-queries cancel")
+}

--- a/server/worker.go
+++ b/server/worker.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 
 	"github.com/posthog/duckgres/server/wire"
-	"sync"
 	"syscall"
 	"time"
 
@@ -179,6 +178,16 @@ func authenticateChildClient(reader *bufio.Reader, writer *bufio.Writer, users m
 	return ExitSuccess
 }
 
+// notifyQueryCancel delivers one query-cancel request, coalescing bursts: if
+// a cancel is already pending (buffer full), the new one is dropped — the
+// pending token will cancel the same in-flight query.
+func notifyQueryCancel(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
 // runChildWorker handles a single client connection in a child process.
 // Returns the appropriate exit code.
 func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
@@ -190,10 +199,14 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	defer shutdownCancel()
 
-	// Create a channel to signal query cancellation (SIGUSR1)
-	// This is separate from shutdown so we can cancel queries without closing the connection
-	queryCancelCh := make(chan struct{})
-	var queryCancelOnce sync.Once
+	// Create a channel to signal query cancellation (SIGUSR1).
+	// This is separate from shutdown so we can cancel queries without closing
+	// the connection. Each SIGUSR1 delivers ONE cancel token (coalescing
+	// bursts) that the in-flight query's context goroutine consumes — the
+	// channel must never be closed: a closed channel is permanently readable,
+	// so a single cancel would instantly cancel every subsequent query on the
+	// connection (the session could never run another statement).
+	queryCancelCh := make(chan struct{}, 1)
 
 	// Handle signals in a goroutine
 	go func() {
@@ -204,10 +217,7 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 				shutdownCancel()
 			case syscall.SIGUSR1:
 				slog.Info("Received query cancel signal")
-				// Signal query cancellation (can be called multiple times safely)
-				queryCancelOnce.Do(func() {
-					close(queryCancelCh)
-				})
+				notifyQueryCancel(queryCancelCh)
 			}
 		}
 	}()


### PR DESCRIPTION
## Problem (audit finding H4)

In ProcessIsolation child-worker mode, SIGUSR1 signals query cancellation via `queryCancelCh`, which was **closed once** (`queryCancelOnce.Do(close(...))`) and never re-armed. `queryContextInner` wires **every** new query's context to that channel — and a closed channel is permanently readable. So after the first cancel request (e.g. a single psql Ctrl-C), every subsequent query on the connection was cancelled the instant it started: the session could never run another statement.

Only ProcessIsolation child mode is affected — the control plane passes a nil cancel channel.

## Fix

- `runChildWorker`: replace the one-shot close with `notifyQueryCancel` — a non-blocking, one-token-per-signal send on a buffered(1) channel, coalescing signal bursts. The in-flight query's context goroutine consumes the token; only that query dies, and the next SIGUSR1 delivers a fresh token.
- `queryContextInner`: discard a token that arrived while no query was in flight before arming the new query's cancel goroutine — matching Postgres semantics, where a cancel request targets only the query running when it is delivered (a stale cancel must not kill the next query).

No change for standalone/control-plane modes (`externalCancelCh == nil` path untouched).

## Test

`TestExternalCancelDoesNotPoisonSubsequentQueries` exercises the full lifecycle through the real `queryContextInner` + `notifyQueryCancel` producer: cancel kills the in-flight query → next query gets a live context (red on main: instant cancellation) → a fresh signal cancels the new in-flight query (re-arm works) → a stale between-queries cancel is discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)