### PR TITLE
fix(flightclient): stop doubling backslashes in interpolated string args

### DIFF
--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -983,8 +983,11 @@ func formatArgValue(v any) string {
 	}
 	switch val := v.(type) {
 	case string:
-		escaped := strings.ReplaceAll(val, `\`, `\\`)
-		escaped = strings.ReplaceAll(escaped, "'", "''")
+		// DuckDB standard '...' literals (like standard-conforming PostgreSQL)
+		// treat backslash as a literal character — only the single quote needs
+		// doubling. Doubling backslashes here corrupts the value: '\\' is the
+		// two-character string \\, not an escape for \.
+		escaped := strings.ReplaceAll(val, "'", "''")
 		return "'" + escaped + "'"
 	case []byte:
 		return `'\x` + hex.EncodeToString(val) + `'::BLOB`
@@ -1012,9 +1015,9 @@ func formatArgValue(v any) string {
 	case float64:
 		return fmt.Sprintf("%g", val)
 	default:
-		// Treat unknown types as strings to avoid injection via Stringer
+		// Treat unknown types as strings to avoid injection via Stringer.
+		// Same literal semantics as the string case: quote-double only.
 		s := fmt.Sprintf("%v", val)
-		s = strings.ReplaceAll(s, `\`, `\\`)
 		s = strings.ReplaceAll(s, "'", "''")
 		return "'" + s + "'"
 	}

--- a/server/flightclient/interpolate_backslash_test.go
+++ b/server/flightclient/interpolate_backslash_test.go
@@ -1,0 +1,46 @@
+package flightclient
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// Audit H5 regression test.
+//
+// formatArgValue doubles backslashes (`\` → `\\`) before wrapping the value
+// in a single-quoted literal. DuckDB standard `'...'` literals — like
+// standard-conforming PostgreSQL — treat backslash as a literal character,
+// so `'a\\b'` is the four-character string `a\\b`, not `a\b`. Every bound
+// string parameter containing a backslash (Windows paths, regexes, JSON with
+// escapes) that flows through the Flight executor's interpolation is
+// therefore silently stored/compared with doubled backslashes.
+//
+// The round-trip below executes the interpolated literal against a real
+// DuckDB so the test encodes the engine's actual semantics, not an
+// assumption about them.
+func TestFormatArgValueBackslashRoundTrip(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	for _, in := range []string{
+		`C:\Users\alice`,
+		`a\b`,
+		`a\\b`,
+		`regex \d+ with 'quote'`,
+		`trailing backslash \`,
+	} {
+		query := interpolateArgs("SELECT ?", []any{in})
+		var out string
+		if err := db.QueryRow(query).Scan(&out); err != nil {
+			t.Fatalf("round-trip query %q: %v", query, err)
+		}
+		if out != in {
+			t.Errorf("bound string corrupted through interpolation:\n  in:    %q\n  query: %s\n  out:   %q", in, query, out)
+		}
+	}
+}

--- a/server/flightclient/interpolate_backslash_test.go
+++ b/server/flightclient/interpolate_backslash_test.go
@@ -25,7 +25,7 @@ func TestFormatArgValueBackslashRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	for _, in := range []string{
 		`C:\Users\alice`,


### PR DESCRIPTION
## Problem (audit finding H5)

`formatArgValue` escaped backslashes C-style (`\` → `\\`) before wrapping bound string parameters in single-quoted literals. DuckDB standard `'...'` literals — like standard-conforming PostgreSQL — treat backslash as a **literal** character: `'a\\b'` is the four-character string `a\\b`, not an escape for `a\b`.

Result: every bound string containing a backslash (Windows paths, regexes, JSON with escapes) that flowed through the Flight executor's parameter interpolation on the process/remote worker backends was silently stored/compared with **doubled backslashes**. The same bug existed in the `default:` Stringer branch. The existing `interpolate_args_test.go` had no backslash case.

## Fix

Quote-double only (`'` → `''`) in both the `string` and `default` branches. The `[]byte` branch (`'\x…'::BLOB`) is untouched — blob casts do interpret `\x` escapes, so it was already correct.

## Test

`TestFormatArgValueBackslashRoundTrip` round-trips interpolated literals (`C:\Users\alice`, `a\b`, `a\\b`, regex + embedded quote, trailing backslash) through a **real DuckDB instance** via `SELECT ?`, so the assertion encodes the engine's actual literal semantics rather than an assumption about them. Red on main (`in: "a\b"` → `out: "a\\b"`), green with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)