### PR TITLE
fix(s3): survive STS token expiry — freshness floor + httpfs fork credential refresh proof

### DIFF
--- a/controlplane/credential_refresh_scheduler.go
+++ b/controlplane/credential_refresh_scheduler.go
@@ -10,6 +10,22 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
+// credentialRefreshLookahead is how far ahead of a worker's recorded
+// credential expiry the scheduler refreshes it. Half the STS session
+// duration: a worker due for refresh gets picked up well before its current
+// session token actually goes stale, with a full half-life of slack to retry
+// transient STS / RPC failures on subsequent ticks.
+const credentialRefreshLookahead = stsSessionDuration / 2
+
+// Compile-time guard: the broker's cache safety margin (the freshness floor
+// on every minted/served credential) must be strictly greater than the
+// scheduler's lookahead. If it weren't, a refresh push could stamp an expiry
+// that is already inside the lookahead window, leaving the worker perpetually
+// "due" and re-pushing identical cached creds every tick (5s churn) until
+// the margin finally forces a fresh mint. The expression overflows uint64 at
+// compile time when the invariant is violated.
+const _ = uint64(stsCacheSafetyMargin - credentialRefreshLookahead - 1)
+
 // credentialRefreshScheduleStore is the slice of the runtime store the
 // scheduler depends on. Defined narrowly so unit tests can fake it without
 // pulling in the full store.

--- a/controlplane/credential_refresh_scheduler.go
+++ b/controlplane/credential_refresh_scheduler.go
@@ -10,21 +10,11 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
-// credentialRefreshLookahead is how far ahead of a worker's recorded
-// credential expiry the scheduler refreshes it. Half the STS session
-// duration: a worker due for refresh gets picked up well before its current
-// session token actually goes stale, with a full half-life of slack to retry
-// transient STS / RPC failures on subsequent ticks.
-const credentialRefreshLookahead = stsSessionDuration / 2
-
-// Compile-time guard: the broker's cache safety margin (the freshness floor
-// on every minted/served credential) must be strictly greater than the
-// scheduler's lookahead. If it weren't, a refresh push could stamp an expiry
-// that is already inside the lookahead window, leaving the worker perpetually
-// "due" and re-pushing identical cached creds every tick (5s churn) until
-// the margin finally forces a fresh mint. The expression overflows uint64 at
-// compile time when the invariant is violated.
-const _ = uint64(stsCacheSafetyMargin - credentialRefreshLookahead - 1)
+// credentialRefreshLookahead and the broker's cache safety margin now live in
+// sts_broker.go alongside stsSessionDuration: all three derive from the
+// env-overridable session duration (DUCKGRES_STS_SESSION_DURATION), and the
+// former compile-time guard (margin strictly greater than lookahead) holds by
+// construction — stsCacheSafetyMargin = credentialRefreshLookahead + 5m.
 
 // credentialRefreshScheduleStore is the slice of the runtime store the
 // scheduler depends on. Defined narrowly so unit tests can fake it without

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -360,12 +360,6 @@ func SetupMultiTenant(
 		refreshActivator.resolveDucklingStatus = resolveDucklingStatus
 	}
 
-	// Half the configured STS session duration: a worker due for refresh
-	// gets picked up well before its current session token actually goes
-	// stale, with a full half-life of slack to retry transient STS / RPC
-	// failures on subsequent ticks.
-	const credentialRefreshLookahead = stsSessionDuration / 2
-
 	// Per-CP scheduler — runs on every CP regardless of leader status, since
 	// each CP refreshes only the workers it owns (filtered by cpInstanceID in
 	// the SQL). Running this on the janitor leader only would leave workers

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -371,9 +371,11 @@ func (a *SharedWorkerActivator) BuildActivationRequest(ctx context.Context, org 
 		}
 	}
 	if a.resolveDucklingStatus == nil || err != nil {
-		// Config-store warehouses use static creds (no STS), so expiresAt
-		// stays nil and the credential refresh scheduler skips them.
-		dl, err = a.buildDuckLakeConfigFromConfigStore(ctx, org.Warehouse)
+		// Static-cred config-store warehouses (secret-ref S3 credentials)
+		// return a nil expiresAt and the credential refresh scheduler skips
+		// them; the "aws" provider path brokers STS creds and returns their
+		// expiration so the scheduler keeps those workers fresh.
+		dl, expiresAt, err = a.buildDuckLakeConfigFromConfigStore(ctx, org.Warehouse)
 	}
 	if err != nil {
 		return TenantActivationPayload{}, err
@@ -505,10 +507,10 @@ func ducklingMetadataStoreAddress(status *provisioner.DucklingStatus, orgID stri
 
 // buildDuckLakeConfigFromConfigStore reads infrastructure details from the config store
 // and K8s Secrets. Used for non-Crossplane warehouses (manual seed, MinIO, etc.).
-func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.Context, warehouse *configstore.ManagedWarehouseConfig) (server.DuckLakeConfig, error) {
+func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.Context, warehouse *configstore.ManagedWarehouseConfig) (server.DuckLakeConfig, *time.Time, error) {
 	metadataPassword, err := a.readSecretValue(ctx, warehouse.MetadataStoreCredentials)
 	if err != nil {
-		return server.DuckLakeConfig{}, fmt.Errorf("metadata store credentials: %w", err)
+		return server.DuckLakeConfig{}, nil, fmt.Errorf("metadata store credentials: %w", err)
 	}
 
 	dl := server.DuckLakeConfig{
@@ -532,7 +534,7 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.C
 	case warehouse.S3Credentials.Name != "":
 		accessKey, secretKey, sessionToken, err := a.readS3Credentials(ctx, warehouse.S3Credentials)
 		if err != nil {
-			return server.DuckLakeConfig{}, fmt.Errorf("s3 credentials: %w", err)
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("s3 credentials: %w", err)
 		}
 		dl.S3Provider = "config"
 		dl.S3AccessKey = accessKey
@@ -548,22 +550,29 @@ func (a *SharedWorkerActivator) buildDuckLakeConfigFromConfigStore(ctx context.C
 	case strings.EqualFold(warehouse.S3.Provider, "aws"):
 		roleARN := warehouse.WorkerIdentity.IAMRoleARN
 		if roleARN == "" {
-			return server.DuckLakeConfig{}, fmt.Errorf("managed warehouse %q requires worker_identity.iam_role_arn for worker activation", warehouse.OrgID)
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("managed warehouse %q requires worker_identity.iam_role_arn for worker activation", warehouse.OrgID)
 		}
 		if a.stsBroker == nil {
-			return server.DuckLakeConfig{}, fmt.Errorf("STS broker is required for worker activation for org %q", warehouse.OrgID)
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("STS broker is required for worker activation for org %q", warehouse.OrgID)
 		}
 		creds, err := a.stsBroker.AssumeRole(ctx, roleARN)
 		if err != nil {
-			return server.DuckLakeConfig{}, fmt.Errorf("STS AssumeRole for org %q: %w", warehouse.OrgID, err)
+			return server.DuckLakeConfig{}, nil, fmt.Errorf("STS AssumeRole for org %q: %w", warehouse.OrgID, err)
 		}
 		dl.S3Provider = "config"
 		dl.S3AccessKey = creds.AccessKeyID
 		dl.S3SecretKey = creds.SecretAccessKey
 		dl.S3SessionToken = creds.SessionToken
+		// STS-vended creds expire: surface the expiration so the
+		// credential-refresh scheduler keeps this worker's secret fresh.
+		// Without it the worker record's expiry stays NULL, the scheduler
+		// never lists the worker as due, and any session outliving the
+		// 1h token dies with ExpiredToken.
+		expiresAt := creds.Expiration
+		return dl, &expiresAt, nil
 	}
 
-	return dl, nil
+	return dl, nil, nil
 }
 
 func BuildTenantActivationPayload(ctx context.Context, clientset kubernetes.Interface, defaultNamespace string, org *configstore.OrgConfig, stsBroker *STSBroker) (TenantActivationPayload, error) {

--- a/controlplane/shared_worker_activator_credentials_test.go
+++ b/controlplane/shared_worker_activator_credentials_test.go
@@ -1,0 +1,148 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// testWarehouseConfig returns a minimal config-store warehouse whose metadata
+// credentials resolve against the fake clientset's "metadata-creds" secret.
+func testWarehouseConfig() *configstore.ManagedWarehouseConfig {
+	return &configstore.ManagedWarehouseConfig{
+		OrgID: "org-test",
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Endpoint:     "pg.test.local",
+			Port:         5432,
+			DatabaseName: "ducklake",
+			Username:     "duck",
+		},
+		MetadataStoreCredentials: configstore.SecretRef{
+			Namespace: "duckgres",
+			Name:      "metadata-creds",
+			Key:       "password",
+		},
+		S3: configstore.ManagedWarehouseS3{
+			Region: "us-east-1",
+			Bucket: "test-bucket",
+		},
+	}
+}
+
+func testMetadataSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "metadata-creds", Namespace: "duckgres"},
+		Data:       map[string][]byte{"password": []byte("hunter2")},
+	}
+}
+
+// The "aws" provider path brokers STS credentials, and those expire: the
+// returned expiration is what the credential-refresh scheduler keys on to
+// keep the worker's DuckDB secret fresh. A nil expiry here means the
+// scheduler never refreshes the worker and any session outliving the STS
+// token dies with ExpiredToken mid-query.
+func TestBuildDuckLakeConfigFromConfigStoreAWSProviderReturnsExpiry(t *testing.T) {
+	expiration := time.Date(2026, 6, 11, 13, 0, 0, 0, time.UTC)
+	broker := newSTSBroker(func(ctx context.Context, roleARN string) (*AssumedCredentials, error) {
+		return &AssumedCredentials{
+			AccessKeyID:     "ASIATEST",
+			SecretAccessKey: "secret",
+			SessionToken:    "token",
+			Expiration:      expiration,
+		}, nil
+	})
+	a := &SharedWorkerActivator{
+		clientset:        fake.NewSimpleClientset(testMetadataSecret()),
+		defaultNamespace: "duckgres",
+		stsBroker:        broker,
+	}
+	warehouse := testWarehouseConfig()
+	warehouse.S3.Provider = "aws"
+	warehouse.WorkerIdentity = configstore.ManagedWarehouseWorkerIdentity{
+		IAMRoleARN: "arn:aws:iam::123:role/duckling-test",
+	}
+
+	dl, expiresAt, err := a.buildDuckLakeConfigFromConfigStore(context.Background(), warehouse)
+	if err != nil {
+		t.Fatalf("buildDuckLakeConfigFromConfigStore: %v", err)
+	}
+	if dl.S3AccessKey != "ASIATEST" || dl.S3SessionToken != "token" {
+		t.Errorf("expected STS-brokered creds on config, got access_key=%q session_token=%q", dl.S3AccessKey, dl.S3SessionToken)
+	}
+	if expiresAt == nil {
+		t.Fatal("expected non-nil credential expiry for STS-brokered aws provider; nil disables the credential-refresh scheduler for this worker")
+	}
+	if !expiresAt.Equal(expiration) {
+		t.Errorf("expiresAt = %v, want %v", *expiresAt, expiration)
+	}
+}
+
+// Static secret-ref credentials have no known expiration — the scheduler
+// must skip them, so the path must return a nil expiry.
+func TestBuildDuckLakeConfigFromConfigStoreStaticCredsNilExpiry(t *testing.T) {
+	s3Secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "s3-creds", Namespace: "duckgres"},
+		Data: map[string][]byte{
+			"credentials": []byte(`{"access_key_id":"AKIATEST","secret_access_key":"secret"}`),
+		},
+	}
+	a := &SharedWorkerActivator{
+		clientset:        fake.NewSimpleClientset(testMetadataSecret(), s3Secret),
+		defaultNamespace: "duckgres",
+	}
+	warehouse := testWarehouseConfig()
+	warehouse.S3Credentials = configstore.SecretRef{
+		Namespace: "duckgres",
+		Name:      "s3-creds",
+		Key:       "credentials",
+	}
+
+	dl, expiresAt, err := a.buildDuckLakeConfigFromConfigStore(context.Background(), warehouse)
+	if err != nil {
+		t.Fatalf("buildDuckLakeConfigFromConfigStore: %v", err)
+	}
+	if dl.S3AccessKey != "AKIATEST" {
+		t.Errorf("expected static creds, got access_key=%q", dl.S3AccessKey)
+	}
+	if expiresAt != nil {
+		t.Errorf("static creds must return nil expiry (scheduler skip), got %v", *expiresAt)
+	}
+}
+
+// Pin the capture-point freshness floor: any credentials the broker hands
+// out (cached or fresh) must retain more validity than the refresh
+// scheduler's lookahead. If served creds could be closer to expiry than the
+// lookahead, a refresh push would stamp an expiry already inside the "due"
+// window and the scheduler would re-push identical creds every tick; worse,
+// a statement starting on those creds would have less runway than the
+// scheduler is designed to guarantee.
+func TestSTSBrokerServedCredsAlwaysOutliveSchedulerLookahead(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)}
+	b := newTestBroker(clock, func(ctx context.Context, roleARN string) (*AssumedCredentials, error) {
+		return &AssumedCredentials{
+			AccessKeyID: "AKID",
+			Expiration:  clock.Now().Add(stsSessionDuration),
+		}, nil
+	})
+
+	// Sweep a full session duration in 1-minute steps; at every point the
+	// served creds must outlive the scheduler lookahead.
+	for i := 0; i <= int(stsSessionDuration/time.Minute); i++ {
+		creds, err := b.AssumeRole(context.Background(), "arn:aws:iam::123:role/org-a")
+		if err != nil {
+			t.Fatalf("AssumeRole at +%dm: %v", i, err)
+		}
+		if remaining := creds.Expiration.Sub(clock.Now()); remaining <= credentialRefreshLookahead {
+			t.Fatalf("at +%dm served creds have %v remaining, must exceed scheduler lookahead %v",
+				i, remaining, credentialRefreshLookahead)
+		}
+		clock.Advance(time.Minute)
+	}
+}

--- a/controlplane/sts_broker.go
+++ b/controlplane/sts_broker.go
@@ -5,6 +5,9 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,34 +18,88 @@ import (
 )
 
 const (
-	stsSessionDuration = 1 * time.Hour
-	stsSessionName     = "duckgres-cp"
+	stsSessionName = "duckgres-cp"
 
-	// stsCacheSafetyMargin is how long before the credentials' true expiration
-	// we stop serving them from cache and mint a fresh session instead.
-	//
-	// This is the freshness floor for every credential capture point: all
-	// AssumeRole callers bake the result into a worker's DuckDB secret, and a
-	// DuckDB statement captures those credentials when it starts executing —
-	// a later CREATE OR REPLACE SECRET (the credential-refresh scheduler's
-	// push) does not re-credential an already-running statement. A statement
-	// that begins on near-expiry cached creds therefore fails with
-	// ExpiredToken once it outruns them, no matter how diligently the secret
-	// is rotated underneath it. The margin is what guarantees every
-	// statement starts with at least this much runway.
-	//
-	// It must also stay strictly greater than credentialRefreshLookahead
-	// (compile-time guard in credential_refresh_scheduler.go): a refresh push
-	// that stamps an expiry already inside the scheduler's lookahead window
-	// leaves the worker perpetually "due", re-pushing identical cached creds
-	// every tick until the margin finally forces a fresh mint.
-	stsCacheSafetyMargin = 35 * time.Minute
+	// defaultSTSSessionDuration is the AssumeRole DurationSeconds used unless
+	// overridden by the env-only DUCKGRES_STS_SESSION_DURATION knob.
+	defaultSTSSessionDuration = 1 * time.Hour
+
+	// minSTSSessionDuration is AWS's hard AssumeRole minimum (900s). The env
+	// knob is clamped up to this so a typo can't make AssumeRole reject every
+	// activation.
+	minSTSSessionDuration = 15 * time.Minute
 
 	// stsAssumeRoleTimeout bounds the underlying AWS AssumeRole call. The call
 	// is detached from the triggering caller's context (other callers may be
 	// waiting on its result via singleflight), so it needs its own deadline.
 	stsAssumeRoleTimeout = 1 * time.Minute
 )
+
+// stsSessionDuration is the STS AssumeRole session duration. Env-overridable
+// (DUCKGRES_STS_SESSION_DURATION, e.g. "900s" / "15m" / "1h", min-clamped to
+// AWS's 900s AssumeRole floor) so a soak test can shorten tokens enough to
+// exercise real in-statement expiry — with the production 1h tokens, proving
+// "a statement outlives its STS token" needs a >25min query even with the
+// refresh scheduler running.
+var stsSessionDuration = resolveSTSSessionDuration(os.Getenv("DUCKGRES_STS_SESSION_DURATION"))
+
+// credentialRefreshLookahead is how far ahead of a worker's recorded
+// credential expiry the scheduler refreshes it. Half the STS session
+// duration: a worker due for refresh gets picked up well before its current
+// session token actually goes stale, with a full half-life of slack to retry
+// transient STS / RPC failures on subsequent ticks.
+var credentialRefreshLookahead = stsSessionDuration / 2
+
+// stsCacheSafetyMargin is how long before the credentials' true expiration
+// we stop serving them from cache and mint a fresh session instead.
+//
+// This is the freshness floor for every credential capture point: all
+// AssumeRole callers bake the result into a worker's DuckDB secret, and a
+// DuckDB statement captures those credentials when it starts executing — a
+// later CREATE OR REPLACE SECRET (the credential-refresh scheduler's push)
+// does not re-credential an already-running statement (DuckDB resolves
+// secrets through the statement's MVCC snapshot). There is NO mid-statement
+// recovery path for scan workloads: httpfs' refresh-on-403 hook only runs at
+// file open AND only when the open performs a network request, but DuckLake,
+// Iceberg, and S3-glob scans all pre-populate file size/etag/last-modified
+// so opens skip the HEAD entirely and the first auth failure surfaces on a
+// range GET, which is not retried (verified against httpfs v1.5.3 /
+// ducklake / duckdb-iceberg sources; pinned by
+// TestInFlightScanDiesOnCredentialRotation in tests/integration). A
+// statement therefore lives or dies on its starting runway: this margin is
+// the ONLY guarantee, giving every statement at least lookahead+5m of token
+// validity at start. Statements longer than that can still die with
+// ExpiredToken.
+//
+// Defined as lookahead + 5m so it stays strictly greater than
+// credentialRefreshLookahead by construction (at the default 1h session:
+// 30m + 5m = 35m, the historical floor). If the margin were <= the
+// lookahead, a refresh push could stamp an expiry already inside the
+// scheduler's lookahead window, leaving the worker perpetually "due" and
+// re-pushing identical cached creds every tick until the margin finally
+// forces a fresh mint.
+var stsCacheSafetyMargin = credentialRefreshLookahead + 5*time.Minute
+
+// resolveSTSSessionDuration parses the env override, falling back to the
+// default on empty/garbage and clamping to AWS's AssumeRole minimum.
+func resolveSTSSessionDuration(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultSTSSessionDuration
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn("Invalid DUCKGRES_STS_SESSION_DURATION; using default.",
+			"value", raw, "default", defaultSTSSessionDuration, "error", err)
+		return defaultSTSSessionDuration
+	}
+	if d < minSTSSessionDuration {
+		slog.Warn("DUCKGRES_STS_SESSION_DURATION below AWS AssumeRole minimum; clamping.",
+			"value", d, "minimum", minSTSSessionDuration)
+		return minSTSSessionDuration
+	}
+	return d
+}
 
 // assumeRoleFunc mints fresh credentials for a role ARN. It is a field on
 // STSBroker so tests can substitute a fake without an AWS client.

--- a/controlplane/sts_broker.go
+++ b/controlplane/sts_broker.go
@@ -58,17 +58,28 @@ var credentialRefreshLookahead = stsSessionDuration / 2
 // DuckDB statement captures those credentials when it starts executing — a
 // later CREATE OR REPLACE SECRET (the credential-refresh scheduler's push)
 // does not re-credential an already-running statement (DuckDB resolves
-// secrets through the statement's MVCC snapshot). There is NO mid-statement
-// recovery path for scan workloads: httpfs' refresh-on-403 hook only runs at
-// file open AND only when the open performs a network request, but DuckLake,
-// Iceberg, and S3-glob scans all pre-populate file size/etag/last-modified
-// so opens skip the HEAD entirely and the first auth failure surfaces on a
-// range GET, which is not retried (verified against httpfs v1.5.3 /
-// ducklake / duckdb-iceberg sources; pinned by
+// secrets through the statement's MVCC snapshot). Stock httpfs has NO
+// mid-statement recovery path for scan workloads: its refresh-on-403 hook
+// only runs at file open AND only when the open performs a network request,
+// but DuckLake, Iceberg, and S3-glob scans all pre-populate file
+// size/etag/last-modified so opens skip the HEAD entirely and the first auth
+// failure surfaces on a range GET, which is not retried (verified against
+// httpfs v1.5.3 / ducklake / duckdb-iceberg sources; pinned by
 // TestInFlightScanDiesOnCredentialRotation in tests/integration). A
-// statement therefore lives or dies on its starting runway: this margin is
-// the ONLY guarantee, giving every statement at least lookahead+5m of token
-// validity at start. Statements longer than that can still die with
+// statement on stock httpfs therefore lives or dies on its starting runway:
+// this margin guarantees every statement at least lookahead+5m of token
+// validity at start; statements longer than that can still die with
+// ExpiredToken.
+//
+// The PostHog httpfs fork (PostHog/duckdb-httpfs, branch
+// cred-refresh-read-path) FIXES this: on an auth failure in any S3 request
+// path it re-resolves the latest committed secret — picking up this
+// scheduler's rotation pushes — and retries (proven by
+// TestInFlightScanSurvivesRotationWithPatchedHTTPFS in tests/integration).
+// Once a fork release with that patch is pinned via HTTPFS_EXTENSION_TAG in
+// Dockerfile.worker, this margin becomes defense-in-depth (a statement's
+// first credentials still want a healthy runway so recovery stays rare)
+// rather than the only thing standing between a long statement and
 // ExpiredToken.
 //
 // Defined as lookahead + 5m so it stays strictly greater than

--- a/controlplane/sts_broker.go
+++ b/controlplane/sts_broker.go
@@ -29,6 +29,18 @@ const (
 	// activation.
 	minSTSSessionDuration = 15 * time.Minute
 
+	// maxSTSSessionDuration is the effective AssumeRole ceiling in our
+	// deployment: the CP's own credentials come from EKS Pod Identity (a role
+	// session), so the per-org AssumeRole is role chaining, which STS
+	// hard-caps at 1h — and every duckling-* role's MaxSessionDuration is
+	// 3600s anyway. A DurationSeconds above that is not silently truncated:
+	// STS REJECTS the AssumeRole call, which would break activation for every
+	// org. The env knob is clamped down to this for the same reason it is
+	// clamped up to the minimum. Raising it for real requires de-chaining the
+	// assume AND raising MaxSessionDuration on every duckling role (12h
+	// absolute AWS max).
+	maxSTSSessionDuration = 1 * time.Hour
+
 	// stsAssumeRoleTimeout bounds the underlying AWS AssumeRole call. The call
 	// is detached from the triggering caller's context (other callers may be
 	// waiting on its result via singleflight), so it needs its own deadline.
@@ -36,11 +48,13 @@ const (
 )
 
 // stsSessionDuration is the STS AssumeRole session duration. Env-overridable
-// (DUCKGRES_STS_SESSION_DURATION, e.g. "900s" / "15m" / "1h", min-clamped to
-// AWS's 900s AssumeRole floor) so a soak test can shorten tokens enough to
-// exercise real in-statement expiry — with the production 1h tokens, proving
-// "a statement outlives its STS token" needs a >25min query even with the
-// refresh scheduler running.
+// (DUCKGRES_STS_SESSION_DURATION, e.g. "900s" / "15m" / "1h", clamped to
+// [minSTSSessionDuration, maxSTSSessionDuration]) so a soak test can shorten
+// tokens enough to exercise real in-statement expiry — with the production 1h
+// tokens, proving "a statement outlives its STS token" needs a >25min query
+// even with the refresh scheduler running. Only shortening is supported:
+// values above 1h would make AssumeRole itself fail (see
+// maxSTSSessionDuration).
 var stsSessionDuration = resolveSTSSessionDuration(os.Getenv("DUCKGRES_STS_SESSION_DURATION"))
 
 // credentialRefreshLookahead is how far ahead of a worker's recorded
@@ -108,6 +122,12 @@ func resolveSTSSessionDuration(raw string) time.Duration {
 		slog.Warn("DUCKGRES_STS_SESSION_DURATION below AWS AssumeRole minimum; clamping.",
 			"value", d, "minimum", minSTSSessionDuration)
 		return minSTSSessionDuration
+	}
+	if d > maxSTSSessionDuration {
+		slog.Warn("DUCKGRES_STS_SESSION_DURATION above the role-chaining AssumeRole ceiling; clamping. "+
+			"A larger DurationSeconds would make STS reject every per-org AssumeRole and break activation.",
+			"value", d, "maximum", maxSTSSessionDuration)
+		return maxSTSSessionDuration
 	}
 	return d
 }

--- a/controlplane/sts_broker.go
+++ b/controlplane/sts_broker.go
@@ -19,10 +19,24 @@ const (
 	stsSessionName     = "duckgres-cp"
 
 	// stsCacheSafetyMargin is how long before the credentials' true expiration
-	// we stop serving them from cache and mint a fresh session instead. It must
-	// leave enough room for a worker activation that receives cached creds to
-	// complete its DuckLake/Iceberg attach before the creds lapse.
-	stsCacheSafetyMargin = 10 * time.Minute
+	// we stop serving them from cache and mint a fresh session instead.
+	//
+	// This is the freshness floor for every credential capture point: all
+	// AssumeRole callers bake the result into a worker's DuckDB secret, and a
+	// DuckDB statement captures those credentials when it starts executing —
+	// a later CREATE OR REPLACE SECRET (the credential-refresh scheduler's
+	// push) does not re-credential an already-running statement. A statement
+	// that begins on near-expiry cached creds therefore fails with
+	// ExpiredToken once it outruns them, no matter how diligently the secret
+	// is rotated underneath it. The margin is what guarantees every
+	// statement starts with at least this much runway.
+	//
+	// It must also stay strictly greater than credentialRefreshLookahead
+	// (compile-time guard in credential_refresh_scheduler.go): a refresh push
+	// that stamps an expiry already inside the scheduler's lookahead window
+	// leaves the worker perpetually "due", re-pushing identical cached creds
+	// every tick until the margin finally forces a fresh mint.
+	stsCacheSafetyMargin = 35 * time.Minute
 
 	// stsAssumeRoleTimeout bounds the underlying AWS AssumeRole call. The call
 	// is detached from the triggering caller's context (other callers may be

--- a/controlplane/sts_broker_test.go
+++ b/controlplane/sts_broker_test.go
@@ -54,8 +54,9 @@ func TestSTSBrokerCacheHitWithinValidity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first AssumeRole: %v", err)
 	}
-	// Well within validity: 1h creds, 10m margin → cached until +50m.
-	clock.Advance(49 * time.Minute)
+	// Well within validity: 1h creds with the safety margin → cached until
+	// expiration minus the margin; stop one minute short of that boundary.
+	clock.Advance(stsSessionDuration - stsCacheSafetyMargin - time.Minute)
 	second, err := b.AssumeRole(context.Background(), "arn:aws:iam::123:role/org-a")
 	if err != nil {
 		t.Fatalf("second AssumeRole: %v", err)
@@ -116,8 +117,8 @@ func TestSTSBrokerRefreshesAfterExpiryMargin(t *testing.T) {
 	if _, err := b.AssumeRole(context.Background(), "arn:aws:iam::123:role/org-a"); err != nil {
 		t.Fatalf("first AssumeRole: %v", err)
 	}
-	// 1h creds with a 10m safety margin: at +50m the cached creds are no
-	// longer served even though they have not truly expired yet.
+	// 1h creds with the safety margin: once inside the margin the cached
+	// creds are no longer served even though they have not truly expired yet.
 	clock.Advance(stsSessionDuration - stsCacheSafetyMargin)
 	refreshed, err := b.AssumeRole(context.Background(), "arn:aws:iam::123:role/org-a")
 	if err != nil {

--- a/controlplane/sts_broker_test.go
+++ b/controlplane/sts_broker_test.go
@@ -275,6 +275,11 @@ func TestResolveSTSSessionDuration(t *testing.T) {
 		// Below AWS's AssumeRole minimum → clamped up, never rejected.
 		{"5m", minSTSSessionDuration},
 		{"1s", minSTSSessionDuration},
+		// Above the role-chaining ceiling → clamped down: STS would REJECT an
+		// AssumeRole with DurationSeconds > 3600 under role chaining (and every
+		// duckling role has MaxSessionDuration=3600), breaking all activations.
+		{"2h", maxSTSSessionDuration},
+		{"24h", maxSTSSessionDuration},
 	}
 	for _, c := range cases {
 		if got := resolveSTSSessionDuration(c.raw); got != c.want {

--- a/controlplane/sts_broker_test.go
+++ b/controlplane/sts_broker_test.go
@@ -258,3 +258,42 @@ func TestSTSBrokerWaiterRespectsContextCancellation(t *testing.T) {
 		t.Fatalf("leader AssumeRole failed: %v", err)
 	}
 }
+
+// DUCKGRES_STS_SESSION_DURATION is env-only and exists to let a soak test
+// shorten tokens to AWS's 900s AssumeRole floor (proving real in-statement
+// expiry needs a token shorter than the harness budget allows at 1h).
+func TestResolveSTSSessionDuration(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", defaultSTSSessionDuration},
+		{"garbage", defaultSTSSessionDuration},
+		{"30m", 30 * time.Minute},
+		{"900s", 15 * time.Minute},
+		{"1h", time.Hour},
+		// Below AWS's AssumeRole minimum → clamped up, never rejected.
+		{"5m", minSTSSessionDuration},
+		{"1s", minSTSSessionDuration},
+	}
+	for _, c := range cases {
+		if got := resolveSTSSessionDuration(c.raw); got != c.want {
+			t.Errorf("resolveSTSSessionDuration(%q) = %v, want %v", c.raw, got, c.want)
+		}
+	}
+}
+
+// The former compile-time guard, now a unit invariant: the broker's cache
+// safety margin must stay strictly greater than the scheduler's lookahead or
+// a refresh push stamps an expiry already inside the "due" window and the
+// scheduler re-pushes identical cached creds every tick.
+func TestSTSCacheSafetyMarginExceedsLookahead(t *testing.T) {
+	if stsCacheSafetyMargin <= credentialRefreshLookahead {
+		t.Fatalf("stsCacheSafetyMargin (%v) must exceed credentialRefreshLookahead (%v)",
+			stsCacheSafetyMargin, credentialRefreshLookahead)
+	}
+	// And the historical 35m floor holds at the default session duration.
+	if stsSessionDuration == defaultSTSSessionDuration && stsCacheSafetyMargin != 35*time.Minute {
+		t.Fatalf("default-session safety margin = %v, want the historical 35m floor", stsCacheSafetyMargin)
+	}
+}

--- a/server/s3_secret_test.go
+++ b/server/s3_secret_test.go
@@ -100,6 +100,30 @@ func TestBuildConfigSecretEmitsHTTPWhenProxySet(t *testing.T) {
 	}
 }
 
+// Regression for the env-inheritance hazard: a PROVIDER config secret that
+// omits SESSION_TOKEN silently inherits a host AWS_SESSION_TOKEN env var
+// (httpfs copies it into the global s3_session_token setting at load, and
+// secret lookup falls back to settings for keys the secret omits) and signs
+// with a mismatched (key, token) pair. buildConfigSecret must always pin the
+// token explicitly — empty means "no token".
+func TestBuildConfigSecretAlwaysEmitsSessionToken(t *testing.T) {
+	noToken := buildConfigSecret(DuckLakeConfig{
+		S3AccessKey: "AKIA",
+		S3SecretKey: "sk",
+	})
+	if !strings.Contains(noToken, "SESSION_TOKEN ''") {
+		t.Errorf("config secret without a token must pin SESSION_TOKEN '':\n%s", noToken)
+	}
+	withToken := buildConfigSecret(DuckLakeConfig{
+		S3AccessKey:    "ASIA",
+		S3SecretKey:    "sk",
+		S3SessionToken: "tok",
+	})
+	if !strings.Contains(withToken, "SESSION_TOKEN 'tok'") {
+		t.Errorf("config secret must carry the explicit token:\n%s", withToken)
+	}
+}
+
 // TestBuildCredentialChainSecretEmitsHTTPWhenProxySet covers the
 // credential-chain branch, which previously only emitted USE_SSL /
 // URL_STYLE when an explicit endpoint was configured. With HTTPProxy set,

--- a/server/server.go
+++ b/server/server.go
@@ -2343,9 +2343,14 @@ func buildConfigSecret(dlCfg DuckLakeConfig) string {
 		secret += fmt.Sprintf(",\n\t\t\tENDPOINT '%s'", dlCfg.S3Endpoint)
 	}
 
-	if dlCfg.S3SessionToken != "" {
-		secret += fmt.Sprintf(",\n\t\t\tSESSION_TOKEN '%s'", dlCfg.S3SessionToken)
-	}
+	// SESSION_TOKEN is ALWAYS emitted, even when empty: httpfs copies a host
+	// AWS_SESSION_TOKEN env var into the global s3_session_token setting at
+	// extension load (AWSEnvironmentCredentialsProvider::SetAll), and a secret
+	// that omits the key falls back to that setting at request-signing time
+	// (S3KeyValueReader::TryGetSecretKeyOrSetting) — signing with a mismatched
+	// (key, token) pair. An explicit empty token pins "no token". (Verified
+	// against httpfs v1.5.3 source.)
+	secret += fmt.Sprintf(",\n\t\t\tSESSION_TOKEN '%s'", dlCfg.S3SessionToken)
 
 	secret += "\n\t\t)"
 	return secret

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -162,6 +162,24 @@ normal `go test ./...` lane.
   and then sends crafted bytes — tooling the alpine Job image (psql/curl/jq)
   doesn't have. Covered by `server/conn_bind_test.go` unit tests
   feeding malformed payloads directly to `handleBind`.
+- **STS credential freshness floor** (`stsCacheSafetyMargin` /
+  `credentialRefreshLookahead`, `controlplane/sts_broker.go`) — the guarantee
+  is temporal: every statement starts with ≥35min of STS token validity (at
+  the default 1h session), and the refresh scheduler re-pushes worker secrets
+  30min ahead of expiry. Asserting it in-Job would mean holding a query open
+  across a real token-expiry boundary: even time-compressed via the env-only
+  `DUCKGRES_STS_SESSION_DURATION` knob, AWS's 900s AssumeRole floor puts the
+  shortest meaningful wait far past the Job budget, and the shared cluster
+  gives no deterministic control over when the scheduler tick lands. Covered
+  by `controlplane/sts_broker_test.go` +
+  `shared_worker_activator_credentials_test.go` (cache margin, lookahead
+  invariant, expiry surfacing on both activation paths) and — load-bearing —
+  the integration pin `tests/integration/credential_rotation_pin_test.go`,
+  which proves against a real MinIO that an in-flight scan does NOT survive
+  credential rotation (DuckDB resolves secrets through the statement's MVCC
+  snapshot, and scan-workload file opens skip the HEAD that could trigger
+  httpfs' refresh-on-403), i.e. the floor is the *only* protection and a
+  statement longer than its starting runway still dies with ExpiredToken.
 
 ## Isolation model
 

--- a/tests/integration/credential_rotation_pin_test.go
+++ b/tests/integration/credential_rotation_pin_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -12,8 +13,215 @@ import (
 	"github.com/posthog/duckgres/server"
 )
 
-// TestInFlightScanDiesOnCredentialRotation PINS a DuckDB limitation that the
-// control plane's STS freshness floor (stsCacheSafetyMargin in
+// rotationScenario drives the shared credential-rotation experiment:
+//
+// A compute-heavy glob scan over many parquet files starts with user-A
+// credentials; mid-statement the secret is rotated to user B via
+// server.RefreshS3Secret (exactly what the credential-refresh scheduler
+// pushes to workers) and user A is then DISABLED in MinIO (simulating STS
+// token expiry). Whether the in-flight statement survives depends on the
+// httpfs build — see the two tests below.
+type rotationScenario struct {
+	// loadHTTPFS installs/loads httpfs on a fresh DB handle. Distinguishes
+	// the stock extension (INSTALL httpfs from the default repo) from a
+	// locally-built patched one (LOAD '/path/httpfs.duckdb_extension').
+	loadHTTPFS func(t *testing.T, db *sql.DB)
+	// dsn for sql.Open("duckdb", ...) — the patched build is unsigned and
+	// needs allow_unsigned_extensions.
+	dsn string
+}
+
+type rotationResult struct {
+	cnt       int64
+	err       error
+	duration  time.Duration
+	rotatedAt time.Duration
+}
+
+const (
+	rotationMinioAddr      = "localhost:39000"
+	rotationMinioContainer = "duckgres-test-minio"
+	rotationBucket         = "rotation-pin"
+	rotationUserA          = "rotuser-a"
+	rotationUserB          = "rotuser-b"
+	rotationPassword       = "rotating-pass-12345"
+	rotationNumFiles       = 48
+	rotationRowsPerFile    = 40000
+)
+
+func runRotationScenario(t *testing.T, sc rotationScenario) rotationResult {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("credential rotation test skipped in -short mode")
+	}
+
+	if conn, err := net.DialTimeout("tcp", rotationMinioAddr, 2*time.Second); err != nil {
+		t.Skipf("MinIO not reachable on %s (run docker compose in tests/integration): %v", rotationMinioAddr, err)
+	} else {
+		_ = conn.Close()
+	}
+
+	mc := func(args ...string) (string, error) {
+		out, err := exec.Command("docker", append([]string{"exec", rotationMinioContainer, "mc"}, args...)...).CombinedOutput()
+		return string(out), err
+	}
+	if out, err := mc("ready", "local"); err != nil {
+		t.Skipf("mc not available in MinIO container (%v): %s", err, out)
+	}
+	// The image's built-in `local` alias is anonymous (enough for the compose
+	// healthcheck, not for admin ops) — register an authenticated alias.
+	if out, err := mc("alias", "set", "localadmin", "http://localhost:9000", "minioadmin", "minioadmin"); err != nil {
+		t.Skipf("could not configure authenticated mc alias (%v): %s", err, out)
+	}
+
+	// --- MinIO fixtures: private bucket + two users with readwrite policy ---
+	if out, err := mc("mb", "localadmin/"+rotationBucket, "--ignore-existing"); err != nil {
+		t.Fatalf("create bucket: %v: %s", err, out)
+	}
+	for _, u := range []string{rotationUserA, rotationUserB} {
+		_, _ = mc("admin", "user", "rm", "localadmin", u) // idempotent re-runs
+		if out, err := mc("admin", "user", "add", "localadmin", u, rotationPassword); err != nil {
+			t.Fatalf("add user %s: %v: %s", u, err, out)
+		}
+		if out, err := mc("admin", "policy", "attach", "localadmin", "readwrite", "--user", u); err != nil &&
+			!strings.Contains(out, "already") {
+			t.Fatalf("attach policy to %s: %v: %s", u, err, out)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = mc("admin", "user", "enable", "localadmin", rotationUserA)
+		_, _ = mc("admin", "user", "rm", "localadmin", rotationUserA)
+		_, _ = mc("admin", "user", "rm", "localadmin", rotationUserB)
+		_, _ = mc("rb", "--force", "localadmin/"+rotationBucket)
+	})
+
+	// --- Seed parquet data with admin credentials (separate DuckDB) ---
+	{
+		seedDB, err := sql.Open("duckdb", sc.dsn)
+		if err != nil {
+			t.Fatalf("open seed duckdb: %v", err)
+		}
+		defer func() { _ = seedDB.Close() }()
+		sc.loadHTTPFS(t, seedDB)
+		if _, err := seedDB.Exec(fmt.Sprintf(`CREATE SECRET seed (
+			TYPE s3, PROVIDER config,
+			KEY_ID 'minioadmin', SECRET 'minioadmin', SESSION_TOKEN '',
+			ENDPOINT '%s', USE_SSL false, URL_STYLE 'path', REGION 'us-east-1')`, rotationMinioAddr)); err != nil {
+			t.Fatalf("create seed secret: %v", err)
+		}
+		for i := 0; i < rotationNumFiles; i++ {
+			if _, err := seedDB.Exec(fmt.Sprintf(
+				`COPY (SELECT md5(range::VARCHAR) AS s, range AS val FROM range(%d)) TO 's3://%s/data/part_%d.parquet'`,
+				rotationRowsPerFile, rotationBucket, i)); err != nil {
+				t.Fatalf("seed part_%d: %v", i, err)
+			}
+		}
+	}
+
+	// --- System under test: production-shape PROVIDER config secret ---
+	dlCfg := server.DuckLakeConfig{
+		ObjectStore:    fmt.Sprintf("s3://%s/", rotationBucket),
+		S3Provider:     "config",
+		S3Endpoint:     rotationMinioAddr,
+		S3Region:       "us-east-1",
+		S3URLStyle:     "path",
+		S3UseSSL:       false,
+		S3AccessKey:    rotationUserA,
+		S3SecretKey:    rotationPassword,
+		S3SessionToken: "", // MinIO users have no session token; explicit empty is the contract
+	}
+
+	db, err := sql.Open("duckdb", sc.dsn)
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(4) // conn = pinned query conn; refresh uses a side conn (mirrors worker controlDB)
+
+	sc.loadHTTPFS(t, db)
+	// SET threads is session-scoped; pin one connection for the scan so the
+	// setting and the long statement share a connection, and file opens are
+	// spread across the whole scan (sequential reads).
+	conn, err := db.Conn(t.Context())
+	if err != nil {
+		t.Fatalf("pin query conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(t.Context(), "SET threads = 1"); err != nil {
+		t.Fatalf("set threads: %v", err)
+	}
+
+	// Initial secret exactly as a worker activation creates it.
+	if err := server.RefreshS3Secret(db, dlCfg, nil); err != nil {
+		t.Fatalf("create initial secret: %v", err)
+	}
+
+	// MD5-chain scan: compute-heavy enough that the statement is still
+	// running when we rotate at T+4s, sequentially opening ~1 file at a time.
+	scanQuery := fmt.Sprintf(
+		`SELECT count(*), max(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(s))))))))))))))))))))) FROM read_parquet('s3://%s/data/*.parquet')`,
+		rotationBucket)
+
+	done := make(chan rotationResult, 1)
+	started := time.Now()
+	go func() {
+		var r rotationResult
+		var maxOut string
+		r.err = conn.QueryRowContext(t.Context(), scanQuery).Scan(&r.cnt, &maxOut)
+		r.duration = time.Since(started)
+		done <- r
+	}()
+
+	// T+4s: rotate to user B exactly the way the credential-refresh
+	// scheduler's push lands on a worker (CREATE OR REPLACE SECRET on a side
+	// connection), then kill user A — simulating the old STS token expiring
+	// right after a rotation that any reasonable design would hope protects
+	// the running statement.
+	time.Sleep(4 * time.Second)
+	rotated := dlCfg
+	rotated.S3AccessKey = rotationUserB
+	if err := server.RefreshS3Secret(db, rotated, nil); err != nil {
+		t.Fatalf("rotate secret: %v", err)
+	}
+	if out, err := mc("admin", "user", "disable", "localadmin", rotationUserA); err != nil {
+		t.Fatalf("disable %s: %v: %s", rotationUserA, err, out)
+	}
+	rotatedAt := time.Since(started)
+
+	r := <-done
+	r.rotatedAt = rotatedAt
+	if r.err == nil && r.duration <= rotatedAt {
+		t.Fatalf("scan finished in %v, before the rotation at %v — the test proved nothing, increase data size",
+			r.duration, rotatedAt)
+	}
+
+	// The other half of the contract — and what the credential-refresh
+	// scheduler actually guarantees: a FRESH statement on the same session
+	// (user A still disabled) works off the rotated secret.
+	var n int64
+	if err := conn.QueryRowContext(t.Context(), fmt.Sprintf(
+		`SELECT count(*) FROM read_parquet('s3://%s/data/part_0.parquet')`, rotationBucket)).Scan(&n); err != nil {
+		t.Fatalf("post-rotation fresh statement failed — secret rotation is broken for NEW statements too: %v", err)
+	}
+	if want := int64(rotationRowsPerFile); n != want {
+		t.Fatalf("post-rotation fresh statement returned %d rows, want %d", n, want)
+	}
+	return r
+}
+
+// loadStockHTTPFS installs the stock httpfs extension from the default
+// extension repository (needs network; skips when unavailable).
+func loadStockHTTPFS(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, stmt := range []string{"INSTALL httpfs", "LOAD httpfs"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("httpfs unavailable (network/sandbox): %v", err)
+		}
+	}
+}
+
+// TestInFlightScanDiesOnCredentialRotation PINS a stock-DuckDB limitation that
+// the control plane's STS freshness floor (stsCacheSafetyMargin in
 // controlplane/sts_broker.go) is designed around:
 //
 //	An in-flight scan does NOT pick up rotated S3 credentials, even when the
@@ -36,192 +244,23 @@ import (
 //     therefore surfaces on a range GET inside the read path, which has no
 //     refresh handling — the statement dies.
 //
-// The scenario: a compute-heavy scan over many parquet files starts with
-// user-A credentials; mid-statement the secret is rotated to user B via
-// server.RefreshS3Secret (exactly what the credential-refresh scheduler
-// pushes to workers) and user A is then DISABLED in MinIO (simulating STS
-// token expiry). The in-flight statement is EXPECTED TO FAIL with an auth
-// error on the next file it touches, while a fresh statement afterwards
-// succeeds on the rotated secret.
-//
-// IF THIS TEST EVER FAILS WITH "in-flight statement SURVIVED": a DuckDB /
-// httpfs upgrade added mid-statement credential recovery (e.g. refresh-on-403
-// in the read path). That is good news — revisit the freshness floor and the
-// "long statements die at token expiry" caveats in controlplane/sts_broker.go,
-// which would then be over-conservative.
+// The PostHog httpfs fork (PostHog/duckdb-httpfs, cred-refresh patch) FIXES
+// this in the read path — that build is covered by
+// TestInFlightScanSurvivesRotationWithPatchedHTTPFS below. This pin stays on
+// the stock extension so we notice when upstream DuckDB gains the same
+// recovery (at which point the fork patch and the freshness-floor caveats in
+// controlplane/sts_broker.go can both be revisited).
 //
 // Requires the integration docker compose stack (MinIO with admin `mc` in the
 // container); skips otherwise.
 func TestInFlightScanDiesOnCredentialRotation(t *testing.T) {
-	if testing.Short() {
-		t.Skip("credential rotation pin test skipped in -short mode")
-	}
-	const (
-		minioAddr      = "localhost:39000"
-		minioContainer = "duckgres-test-minio"
-		bucket         = "rotation-pin"
-		userA          = "rotuser-a"
-		userB          = "rotuser-b"
-		password       = "rotating-pass-12345"
-	)
-
-	if conn, err := net.DialTimeout("tcp", minioAddr, 2*time.Second); err != nil {
-		t.Skipf("MinIO not reachable on %s (run docker compose in tests/integration): %v", minioAddr, err)
-	} else {
-		_ = conn.Close()
-	}
-
-	mc := func(args ...string) (string, error) {
-		out, err := exec.Command("docker", append([]string{"exec", minioContainer, "mc"}, args...)...).CombinedOutput()
-		return string(out), err
-	}
-	if out, err := mc("ready", "local"); err != nil {
-		t.Skipf("mc not available in MinIO container (%v): %s", err, out)
-	}
-	// The image's built-in `local` alias is anonymous (enough for the compose
-	// healthcheck, not for admin ops) — register an authenticated alias.
-	if out, err := mc("alias", "set", "localadmin", "http://localhost:9000", "minioadmin", "minioadmin"); err != nil {
-		t.Skipf("could not configure authenticated mc alias (%v): %s", err, out)
-	}
-
-	// --- MinIO fixtures: private bucket + two users with readwrite policy ---
-	if out, err := mc("mb", "localadmin/"+bucket, "--ignore-existing"); err != nil {
-		t.Fatalf("create bucket: %v: %s", err, out)
-	}
-	for _, u := range []string{userA, userB} {
-		_, _ = mc("admin", "user", "rm", "localadmin", u) // idempotent re-runs
-		if out, err := mc("admin", "user", "add", "localadmin", u, password); err != nil {
-			t.Fatalf("add user %s: %v: %s", u, err, out)
-		}
-		if out, err := mc("admin", "policy", "attach", "localadmin", "readwrite", "--user", u); err != nil &&
-			!strings.Contains(out, "already") {
-			t.Fatalf("attach policy to %s: %v: %s", u, err, out)
-		}
-	}
-	t.Cleanup(func() {
-		_, _ = mc("admin", "user", "enable", "localadmin", userA)
-		_, _ = mc("admin", "user", "rm", "localadmin", userA)
-		_, _ = mc("admin", "user", "rm", "localadmin", userB)
-		_, _ = mc("rb", "--force", "localadmin/"+bucket)
-	})
-
-	// --- Seed parquet data with admin credentials (separate DuckDB) ---
-	const numFiles = 48
-	{
-		seedDB, err := sql.Open("duckdb", "")
-		if err != nil {
-			t.Fatalf("open seed duckdb: %v", err)
-		}
-		defer func() { _ = seedDB.Close() }()
-		for _, stmt := range []string{"INSTALL httpfs", "LOAD httpfs"} {
-			if _, err := seedDB.Exec(stmt); err != nil {
-				t.Skipf("httpfs unavailable (network/sandbox): %v", err)
-			}
-		}
-		if _, err := seedDB.Exec(fmt.Sprintf(`CREATE SECRET seed (
-			TYPE s3, PROVIDER config,
-			KEY_ID 'minioadmin', SECRET 'minioadmin', SESSION_TOKEN '',
-			ENDPOINT '%s', USE_SSL false, URL_STYLE 'path', REGION 'us-east-1')`, minioAddr)); err != nil {
-			t.Fatalf("create seed secret: %v", err)
-		}
-		for i := 0; i < numFiles; i++ {
-			if _, err := seedDB.Exec(fmt.Sprintf(
-				`COPY (SELECT md5(range::VARCHAR) AS s, range AS val FROM range(40000)) TO 's3://%s/data/part_%d.parquet'`,
-				bucket, i)); err != nil {
-				t.Fatalf("seed part_%d: %v", i, err)
-			}
-		}
-	}
-
-	// --- System under test: production-shape PROVIDER config secret ---
-	dlCfg := server.DuckLakeConfig{
-		ObjectStore:    fmt.Sprintf("s3://%s/", bucket),
-		S3Provider:     "config",
-		S3Endpoint:     minioAddr,
-		S3Region:       "us-east-1",
-		S3URLStyle:     "path",
-		S3UseSSL:       false,
-		S3AccessKey:    userA,
-		S3SecretKey:    password,
-		S3SessionToken: "", // MinIO users have no session token; explicit empty is the contract
-	}
-
-	db, err := sql.Open("duckdb", "")
-	if err != nil {
-		t.Fatalf("open duckdb: %v", err)
-	}
-	defer func() { _ = db.Close() }()
-	db.SetMaxOpenConns(4) // conn = pinned query conn; refresh uses a side conn (mirrors worker controlDB)
-
-	for _, stmt := range []string{"INSTALL httpfs", "LOAD httpfs"} {
-		if _, err := db.Exec(stmt); err != nil {
-			t.Skipf("httpfs unavailable (network/sandbox): %v", err)
-		}
-	}
-	// SET threads is session-scoped; pin one connection for the scan so the
-	// setting and the long statement share a connection, and file opens are
-	// spread across the whole scan (sequential reads).
-	conn, err := db.Conn(t.Context())
-	if err != nil {
-		t.Fatalf("pin query conn: %v", err)
-	}
-	defer func() { _ = conn.Close() }()
-	if _, err := conn.ExecContext(t.Context(), "SET threads = 1"); err != nil {
-		t.Fatalf("set threads: %v", err)
-	}
-
-	// Initial secret exactly as a worker activation creates it.
-	if err := server.RefreshS3Secret(db, dlCfg, nil); err != nil {
-		t.Fatalf("create initial secret: %v", err)
-	}
-
-	// MD5-chain scan: compute-heavy enough that the statement is still
-	// running when we rotate at T+4s, sequentially opening ~1 file at a time.
-	scanQuery := fmt.Sprintf(
-		`SELECT count(*), max(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(s))))))))))))))))))))) FROM read_parquet('s3://%s/data/*.parquet')`,
-		bucket)
-
-	type result struct {
-		cnt      int64
-		max      string
-		err      error
-		duration time.Duration
-	}
-	done := make(chan result, 1)
-	started := time.Now()
-	go func() {
-		var r result
-		r.err = conn.QueryRowContext(t.Context(), scanQuery).Scan(&r.cnt, &r.max)
-		r.duration = time.Since(started)
-		done <- r
-	}()
-
-	// T+4s: rotate to user B exactly the way the credential-refresh
-	// scheduler's push lands on a worker (CREATE OR REPLACE SECRET on a side
-	// connection), then kill user A — simulating the old STS token expiring
-	// right after a rotation that any reasonable design would hope protects
-	// the running statement.
-	time.Sleep(4 * time.Second)
-	rotated := dlCfg
-	rotated.S3AccessKey = userB
-	if err := server.RefreshS3Secret(db, rotated, nil); err != nil {
-		t.Fatalf("rotate secret: %v", err)
-	}
-	if out, err := mc("admin", "user", "disable", "localadmin", userA); err != nil {
-		t.Fatalf("disable %s: %v: %s", userA, err, out)
-	}
-	rotatedAt := time.Since(started)
-
-	r := <-done
+	r := runRotationScenario(t, rotationScenario{loadHTTPFS: loadStockHTTPFS})
 	if r.err == nil {
-		if r.duration <= rotatedAt {
-			t.Fatalf("scan finished in %v, before the rotation at %v — the test proved nothing, increase data size",
-				r.duration, rotatedAt)
-		}
 		t.Fatalf("in-flight statement SURVIVED credential rotation (%d rows in %v, rotated at %v). "+
-			"DuckDB/httpfs gained mid-statement credential recovery — revisit the STS freshness floor "+
-			"(stsCacheSafetyMargin in controlplane/sts_broker.go) and its capture-at-statement-start caveats.",
-			r.cnt, r.duration, rotatedAt)
+			"Stock DuckDB/httpfs gained mid-statement credential recovery — revisit the STS freshness floor "+
+			"(stsCacheSafetyMargin in controlplane/sts_broker.go), its capture-at-statement-start caveats, "+
+			"and whether the PostHog httpfs fork's cred-refresh patch is still needed.",
+			r.cnt, r.duration, r.rotatedAt)
 	}
 	errText := r.err.Error()
 	if !strings.Contains(errText, "403") && !strings.Contains(strings.ToLower(errText), "forbidden") &&
@@ -229,17 +268,53 @@ func TestInFlightScanDiesOnCredentialRotation(t *testing.T) {
 		t.Fatalf("in-flight statement failed, but not with the expected auth error: %v", r.err)
 	}
 	t.Logf("pinned: in-flight statement died on rotation as expected after %v (rotated at %v): %v",
-		r.duration, rotatedAt, r.err)
+		r.duration, r.rotatedAt, r.err)
+}
 
-	// The other half of the contract — and what the credential-refresh
-	// scheduler actually guarantees: a FRESH statement on the same session
-	// (user A still disabled) works off the rotated secret.
-	var n int64
-	if err := conn.QueryRowContext(t.Context(), fmt.Sprintf(
-		`SELECT count(*) FROM read_parquet('s3://%s/data/part_0.parquet')`, bucket)).Scan(&n); err != nil {
-		t.Fatalf("post-rotation fresh statement failed — secret rotation is broken for NEW statements too: %v", err)
+// TestInFlightScanSurvivesRotationWithPatchedHTTPFS asserts the PostHog httpfs
+// fork's mid-statement credential refresh: on an auth failure (400/403) in any
+// S3 request path, the patched extension re-resolves the LATEST COMMITTED
+// secret (bypassing the statement's MVCC snapshot) and retries once with the
+// refreshed credentials. Combined with the control plane's credential-refresh
+// scheduler — which keeps committing fresh STS credentials via CREATE OR
+// REPLACE SECRET on a side connection — this removes the statement-length
+// ceiling that the STS freshness floor (stsCacheSafetyMargin) could otherwise
+// only push to ~35-60min: the in-flight scan survives rotation + revocation of
+// the credentials it started with.
+//
+// Runs only when DUCKGRES_TEST_PATCHED_HTTPFS points at a locally-built
+// extension binary (see PostHog/duckdb-httpfs branch cred-refresh-read-path):
+//
+//	DUCKGRES_TEST_PATCHED_HTTPFS=/path/to/httpfs.duckdb_extension \
+//	  go test ./tests/integration/ -run SurvivesRotationWithPatchedHTTPFS -v
+//
+// Once a fork release with the patch is pinned in Dockerfile.worker
+// (HTTPFS_EXTENSION_TAG), the e2e harness exercises the same behavior against
+// real STS tokens; this test is the fast local proof.
+func TestInFlightScanSurvivesRotationWithPatchedHTTPFS(t *testing.T) {
+	extPath := os.Getenv("DUCKGRES_TEST_PATCHED_HTTPFS")
+	if extPath == "" {
+		t.Skip("DUCKGRES_TEST_PATCHED_HTTPFS not set (path to patched httpfs.duckdb_extension)")
 	}
-	if want := int64(40000); n != want {
-		t.Fatalf("post-rotation fresh statement returned %d rows, want %d", n, want)
+	if _, err := os.Stat(extPath); err != nil {
+		t.Fatalf("DUCKGRES_TEST_PATCHED_HTTPFS=%s not readable: %v", extPath, err)
 	}
+	r := runRotationScenario(t, rotationScenario{
+		dsn: "?allow_unsigned_extensions=true",
+		loadHTTPFS: func(t *testing.T, db *sql.DB) {
+			t.Helper()
+			if _, err := db.Exec(fmt.Sprintf("LOAD '%s'", extPath)); err != nil {
+				t.Fatalf("load patched httpfs from %s: %v", extPath, err)
+			}
+		},
+	})
+	if r.err != nil {
+		t.Fatalf("in-flight statement DIED on rotation despite the patched httpfs (rotated at %v): %v",
+			r.rotatedAt, r.err)
+	}
+	if want := int64(rotationNumFiles * rotationRowsPerFile); r.cnt != want {
+		t.Fatalf("survived scan returned %d rows, want %d — retry must not lose or duplicate data", r.cnt, want)
+	}
+	t.Logf("patched httpfs: in-flight scan survived rotation (%d rows in %v, rotated at %v)",
+		r.cnt, r.duration, r.rotatedAt)
 }

--- a/tests/integration/credential_rotation_pin_test.go
+++ b/tests/integration/credential_rotation_pin_test.go
@@ -1,0 +1,245 @@
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/server"
+)
+
+// TestInFlightScanDiesOnCredentialRotation PINS a DuckDB limitation that the
+// control plane's STS freshness floor (stsCacheSafetyMargin in
+// controlplane/sts_broker.go) is designed around:
+//
+//	An in-flight scan does NOT pick up rotated S3 credentials, even when the
+//	secret is CREATE OR REPLACE'd with fresh credentials before the old ones
+//	are revoked. A statement lives or dies on the credentials it captured at
+//	statement start.
+//
+// Two independent DuckDB v1.5.3 behaviors combine to make this true:
+//
+//  1. Statements resolve secrets through their MVCC snapshot of the secret
+//     catalog — a CREATE OR REPLACE SECRET committed by another connection
+//     mid-statement is never visible to the in-flight statement.
+//  2. httpfs' refresh-on-403 escape hatch (TryRefreshS3Secret) only runs in
+//     S3FileHandle::Initialize, and only when the open performs a network
+//     request. Glob scans never do: the S3 glob (ListObjectsV2) pre-populates
+//     file_size/etag/last_modified in extended_info, which marks the handle
+//     initialized and skips the HEAD entirely (httpfs httpfs.cpp,
+//     HTTPFileHandle ctor). DuckLake and Iceberg file lists deliberately do
+//     the same with dummy etag/last_modified. The first auth failure
+//     therefore surfaces on a range GET inside the read path, which has no
+//     refresh handling — the statement dies.
+//
+// The scenario: a compute-heavy scan over many parquet files starts with
+// user-A credentials; mid-statement the secret is rotated to user B via
+// server.RefreshS3Secret (exactly what the credential-refresh scheduler
+// pushes to workers) and user A is then DISABLED in MinIO (simulating STS
+// token expiry). The in-flight statement is EXPECTED TO FAIL with an auth
+// error on the next file it touches, while a fresh statement afterwards
+// succeeds on the rotated secret.
+//
+// IF THIS TEST EVER FAILS WITH "in-flight statement SURVIVED": a DuckDB /
+// httpfs upgrade added mid-statement credential recovery (e.g. refresh-on-403
+// in the read path). That is good news — revisit the freshness floor and the
+// "long statements die at token expiry" caveats in controlplane/sts_broker.go,
+// which would then be over-conservative.
+//
+// Requires the integration docker compose stack (MinIO with admin `mc` in the
+// container); skips otherwise.
+func TestInFlightScanDiesOnCredentialRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("credential rotation pin test skipped in -short mode")
+	}
+	const (
+		minioAddr      = "localhost:39000"
+		minioContainer = "duckgres-test-minio"
+		bucket         = "rotation-pin"
+		userA          = "rotuser-a"
+		userB          = "rotuser-b"
+		password       = "rotating-pass-12345"
+	)
+
+	if conn, err := net.DialTimeout("tcp", minioAddr, 2*time.Second); err != nil {
+		t.Skipf("MinIO not reachable on %s (run docker compose in tests/integration): %v", minioAddr, err)
+	} else {
+		_ = conn.Close()
+	}
+
+	mc := func(args ...string) (string, error) {
+		out, err := exec.Command("docker", append([]string{"exec", minioContainer, "mc"}, args...)...).CombinedOutput()
+		return string(out), err
+	}
+	if out, err := mc("ready", "local"); err != nil {
+		t.Skipf("mc not available in MinIO container (%v): %s", err, out)
+	}
+	// The image's built-in `local` alias is anonymous (enough for the compose
+	// healthcheck, not for admin ops) — register an authenticated alias.
+	if out, err := mc("alias", "set", "localadmin", "http://localhost:9000", "minioadmin", "minioadmin"); err != nil {
+		t.Skipf("could not configure authenticated mc alias (%v): %s", err, out)
+	}
+
+	// --- MinIO fixtures: private bucket + two users with readwrite policy ---
+	if out, err := mc("mb", "localadmin/"+bucket, "--ignore-existing"); err != nil {
+		t.Fatalf("create bucket: %v: %s", err, out)
+	}
+	for _, u := range []string{userA, userB} {
+		_, _ = mc("admin", "user", "rm", "localadmin", u) // idempotent re-runs
+		if out, err := mc("admin", "user", "add", "localadmin", u, password); err != nil {
+			t.Fatalf("add user %s: %v: %s", u, err, out)
+		}
+		if out, err := mc("admin", "policy", "attach", "localadmin", "readwrite", "--user", u); err != nil &&
+			!strings.Contains(out, "already") {
+			t.Fatalf("attach policy to %s: %v: %s", u, err, out)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = mc("admin", "user", "enable", "localadmin", userA)
+		_, _ = mc("admin", "user", "rm", "localadmin", userA)
+		_, _ = mc("admin", "user", "rm", "localadmin", userB)
+		_, _ = mc("rb", "--force", "localadmin/"+bucket)
+	})
+
+	// --- Seed parquet data with admin credentials (separate DuckDB) ---
+	const numFiles = 48
+	{
+		seedDB, err := sql.Open("duckdb", "")
+		if err != nil {
+			t.Fatalf("open seed duckdb: %v", err)
+		}
+		defer func() { _ = seedDB.Close() }()
+		for _, stmt := range []string{"INSTALL httpfs", "LOAD httpfs"} {
+			if _, err := seedDB.Exec(stmt); err != nil {
+				t.Skipf("httpfs unavailable (network/sandbox): %v", err)
+			}
+		}
+		if _, err := seedDB.Exec(fmt.Sprintf(`CREATE SECRET seed (
+			TYPE s3, PROVIDER config,
+			KEY_ID 'minioadmin', SECRET 'minioadmin', SESSION_TOKEN '',
+			ENDPOINT '%s', USE_SSL false, URL_STYLE 'path', REGION 'us-east-1')`, minioAddr)); err != nil {
+			t.Fatalf("create seed secret: %v", err)
+		}
+		for i := 0; i < numFiles; i++ {
+			if _, err := seedDB.Exec(fmt.Sprintf(
+				`COPY (SELECT md5(range::VARCHAR) AS s, range AS val FROM range(40000)) TO 's3://%s/data/part_%d.parquet'`,
+				bucket, i)); err != nil {
+				t.Fatalf("seed part_%d: %v", i, err)
+			}
+		}
+	}
+
+	// --- System under test: production-shape PROVIDER config secret ---
+	dlCfg := server.DuckLakeConfig{
+		ObjectStore:    fmt.Sprintf("s3://%s/", bucket),
+		S3Provider:     "config",
+		S3Endpoint:     minioAddr,
+		S3Region:       "us-east-1",
+		S3URLStyle:     "path",
+		S3UseSSL:       false,
+		S3AccessKey:    userA,
+		S3SecretKey:    password,
+		S3SessionToken: "", // MinIO users have no session token; explicit empty is the contract
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(4) // conn = pinned query conn; refresh uses a side conn (mirrors worker controlDB)
+
+	for _, stmt := range []string{"INSTALL httpfs", "LOAD httpfs"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("httpfs unavailable (network/sandbox): %v", err)
+		}
+	}
+	// SET threads is session-scoped; pin one connection for the scan so the
+	// setting and the long statement share a connection, and file opens are
+	// spread across the whole scan (sequential reads).
+	conn, err := db.Conn(t.Context())
+	if err != nil {
+		t.Fatalf("pin query conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(t.Context(), "SET threads = 1"); err != nil {
+		t.Fatalf("set threads: %v", err)
+	}
+
+	// Initial secret exactly as a worker activation creates it.
+	if err := server.RefreshS3Secret(db, dlCfg, nil); err != nil {
+		t.Fatalf("create initial secret: %v", err)
+	}
+
+	// MD5-chain scan: compute-heavy enough that the statement is still
+	// running when we rotate at T+4s, sequentially opening ~1 file at a time.
+	scanQuery := fmt.Sprintf(
+		`SELECT count(*), max(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(s))))))))))))))))))))) FROM read_parquet('s3://%s/data/*.parquet')`,
+		bucket)
+
+	type result struct {
+		cnt      int64
+		max      string
+		err      error
+		duration time.Duration
+	}
+	done := make(chan result, 1)
+	started := time.Now()
+	go func() {
+		var r result
+		r.err = conn.QueryRowContext(t.Context(), scanQuery).Scan(&r.cnt, &r.max)
+		r.duration = time.Since(started)
+		done <- r
+	}()
+
+	// T+4s: rotate to user B exactly the way the credential-refresh
+	// scheduler's push lands on a worker (CREATE OR REPLACE SECRET on a side
+	// connection), then kill user A — simulating the old STS token expiring
+	// right after a rotation that any reasonable design would hope protects
+	// the running statement.
+	time.Sleep(4 * time.Second)
+	rotated := dlCfg
+	rotated.S3AccessKey = userB
+	if err := server.RefreshS3Secret(db, rotated, nil); err != nil {
+		t.Fatalf("rotate secret: %v", err)
+	}
+	if out, err := mc("admin", "user", "disable", "localadmin", userA); err != nil {
+		t.Fatalf("disable %s: %v: %s", userA, err, out)
+	}
+	rotatedAt := time.Since(started)
+
+	r := <-done
+	if r.err == nil {
+		if r.duration <= rotatedAt {
+			t.Fatalf("scan finished in %v, before the rotation at %v — the test proved nothing, increase data size",
+				r.duration, rotatedAt)
+		}
+		t.Fatalf("in-flight statement SURVIVED credential rotation (%d rows in %v, rotated at %v). "+
+			"DuckDB/httpfs gained mid-statement credential recovery — revisit the STS freshness floor "+
+			"(stsCacheSafetyMargin in controlplane/sts_broker.go) and its capture-at-statement-start caveats.",
+			r.cnt, r.duration, rotatedAt)
+	}
+	errText := r.err.Error()
+	if !strings.Contains(errText, "403") && !strings.Contains(strings.ToLower(errText), "forbidden") &&
+		!strings.Contains(errText, "InvalidAccessKeyId") {
+		t.Fatalf("in-flight statement failed, but not with the expected auth error: %v", r.err)
+	}
+	t.Logf("pinned: in-flight statement died on rotation as expected after %v (rotated at %v): %v",
+		r.duration, rotatedAt, r.err)
+
+	// The other half of the contract — and what the credential-refresh
+	// scheduler actually guarantees: a FRESH statement on the same session
+	// (user A still disabled) works off the rotated secret.
+	var n int64
+	if err := conn.QueryRowContext(t.Context(), fmt.Sprintf(
+		`SELECT count(*) FROM read_parquet('s3://%s/data/part_0.parquet')`, bucket)).Scan(&n); err != nil {
+		t.Fatalf("post-rotation fresh statement failed — secret rotation is broken for NEW statements too: %v", err)
+	}
+	if want := int64(40000); n != want {
+		t.Fatalf("post-rotation fresh statement returned %d rows, want %d", n, want)
+	}
+}


### PR DESCRIPTION
## Problem

Long-running statements against per-org DuckLake S3 die with `ExpiredToken` (e.g. Dagster `duckling_events_backfill` → `delete_events_partition_data`). Root cause chain:

1. Per-org credentials are 1h STS AssumeRole tokens (hard cap: role chaining via EKS Pod Identity limits `DurationSeconds` to 3600s; all `duckling-*` roles have `MaxSessionDuration=3600` — 24h tokens are not possible).
2. The broker served cached creds until expiry−10min, so a statement could *start* with as little as ~10min of runway.
3. A DuckDB statement captures credentials at statement start (secrets resolve through its MVCC snapshot); the credential-refresh scheduler's mid-session `CREATE OR REPLACE SECRET` pushes never reach an in-flight statement, and stock httpfs has **no** mid-statement recovery for scan workloads (the refresh-on-403 hook only fires at file open with a network request — DuckLake/Iceberg/glob pre-populate size/etag/mtime so opens skip the HEAD; range GETs are not retried).

## What this PR ships

- **26fede7** — raise the STS freshness floor: serve-from-cache margin 10min → lookahead+5min (35min at the default 1h session), so every statement starts with ≥35min of token validity. Adds an invariant guard (margin > scheduler lookahead, else workers go perpetually "due" and re-push identical creds every 5s — observed as ~700 log lines/15min churn in prod). Fixes a latent bug where the config-store aws path returned nil expiry, so the scheduler never refreshed those workers.
- **b791f9e** — pin the stock-DuckDB limitation with an integration test (`TestInFlightScanDiesOnCredentialRotation` vs real MinIO rotation+revocation); env-only `DUCKGRES_STS_SESSION_DURATION` knob (≥900s AWS floor) so soak tests can exercise real expiry; config secrets now always emit `SESSION_TOKEN` (an omitted key let a host `AWS_SESSION_TOKEN` env var leak into request signing).
- **03d83ab** — prove the fix: the PostHog httpfs fork patch ([PostHog/duckdb-httpfs `cred-refresh-read-path`](https://github.com/PostHog/duckdb-httpfs/tree/cred-refresh-read-path), released as `v1.5.3-cred-refresh`) re-resolves the **latest committed** secret on any 400/403 in all six S3 request paths and retries once — picking up the refresh scheduler's rotation pushes mid-statement. New `TestInFlightScanSurvivesRotationWithPatchedHTTPFS` (gated on `DUCKGRES_TEST_PATCHED_HTTPFS=<path>`): the same in-flight glob scan that deterministically dies on stock httpfs survives rotation + revocation of its starting credentials with an exact row count (1,920,000 rows; rotated+revoked at T+4s, completed T+25s).

## Net effect

- Today (stock extension deployed): every statement gets ≥35min of starting runway; statements past ~35–60min can still die.
- After bumping `HTTPFS_EXTENSION_TAG` to `v1.5.3-cred-refresh` (follow-up PR once the fork release artifacts are published): the statement-length ceiling is gone — the scheduler rotates every ≤30min and in-flight statements pick the new creds up on the first auth failure. The freshness floor remains as defense-in-depth.

## Testing

- `go test ./controlplane/ -tags kubernetes`, `go test ./server/` — green
- `tests/integration`: stock pin test passes (dies as pinned); patched survival test passes against the locally-built fork extension (macOS arm64)
- `golangci-lint run` — 0 issues
- e2e-mw-dev: real in-statement STS expiry needs a >15min statement (900s AssumeRole floor) and exceeds the Job budget — documented in `tests/e2e-mw-dev/README.md`; the MinIO rotation tests are the deterministic stand-in, and the tag-bump PR will ride the full harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)