### PR TITLE
Refactor Duckgres query outcome metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Duckgres exposes Prometheus metrics on `:9090/metrics`. The metrics port is curr
 | Metric | Type | Description |
 |--------|------|-------------|
 | `duckgres_connections_open` | Gauge | Number of currently open client connections |
-| `duckgres_query_duration_seconds` | Histogram | Query execution duration (includes `_count`, `_sum`, `_bucket`) |
-| `duckgres_query_errors_total` | Counter | Total number of failed queries |
+| `duckgres_query_total{org,outcome}` | Counter | Total number of non-empty query attempts by terminal outcome (`success`, `error`, `canceled`) |
+| `duckgres_query_duration_seconds{org}` | Histogram | Simple/extended query execution latency (includes `_count`, `_sum`, `_bucket`); use `duckgres_query_total` for attempt totals |
 | `duckgres_auth_failures_total` | Counter | Total number of authentication failures |
 | `duckgres_rate_limit_rejects_total` | Counter | Total number of connections rejected due to rate limiting |
 | `duckgres_rate_limited_ips` | Gauge | Number of currently rate-limited IP addresses |

--- a/grafana/dashboards/duckgres.json
+++ b/grafana/dashboards/duckgres.json
@@ -229,7 +229,7 @@
       },
       "targets": [
         {
-          "expr": "rate(duckgres_query_duration_seconds_count[5m])",
+          "expr": "sum(rate(duckgres_query_total[5m]))",
           "legendFormat": "Queries/s",
           "refId": "A"
         }
@@ -261,7 +261,7 @@
       },
       "targets": [
         {
-          "expr": "rate(duckgres_query_errors_total[5m])",
+          "expr": "sum(rate(duckgres_query_total{outcome=\"error\"}[5m]))",
           "legendFormat": "Errors/s",
           "refId": "A"
         }

--- a/metrics-compose.yml
+++ b/metrics-compose.yml
@@ -9,8 +9,8 @@
 #
 # Available metrics:
 #   - duckgres_connections_open: current number of open connections
-#   - duckgres_query_duration_seconds: histogram of query latencies
-#   - duckgres_query_errors_total: counter of failed queries
+#   - duckgres_query_total: counter of query attempts by terminal outcome
+#   - duckgres_query_duration_seconds: histogram of query execution latencies
 #   - duckgres_perf_query_duration_seconds: per-query perf harness latency histograms
 #
 # Note: Uses port 9091 for Prometheus UI to avoid conflict with duckgres metrics on 9090.

--- a/scripts/test_metrics.sh
+++ b/scripts/test_metrics.sh
@@ -25,7 +25,9 @@ PGPASSWORD=postgres psql "host=127.0.0.1 port=$PORT user=postgres sslmode=requir
 PGPASSWORD=postgres psql "host=127.0.0.1 port=$PORT user=postgres sslmode=require" -c "SELECT 2" >/dev/null
 
 # Check metrics
-QUERY_COUNT=$(curl -s "http://localhost:$METRICS_PORT/metrics" | grep 'duckgres_query_duration_seconds_count' | awk '{print $2}')
+METRICS=$(curl -s "http://localhost:$METRICS_PORT/metrics")
+QUERY_COUNT=$(echo "$METRICS" | awk '/^duckgres_query_duration_seconds_count/ {sum += $2} END {print sum}')
+QUERY_SUCCESS_TOTAL=$(echo "$METRICS" | awk '/^duckgres_query_total\{.*outcome="success"/ {sum += $2} END {print sum}')
 
 if [ -z "$QUERY_COUNT" ]; then
     echo "FAIL: could not find 'duckgres_query_duration_seconds_count' metric in metrics output"
@@ -40,5 +42,21 @@ if [ "$QUERY_COUNT" -ge 2 ]; then
     echo "PASS: query count is $QUERY_COUNT (expected >= 2)"
 else
     echo "FAIL: query count is $QUERY_COUNT (expected >= 2)"
+    exit 1
+fi
+
+if [ -z "$QUERY_SUCCESS_TOTAL" ]; then
+    echo "FAIL: could not find 'duckgres_query_total{outcome=\"success\"}' metric in metrics output"
+    exit 1
+fi
+
+if ! [[ "$QUERY_SUCCESS_TOTAL" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: query success total '$QUERY_SUCCESS_TOTAL' is not a valid integer metric value"
+    exit 1
+fi
+if [ "$QUERY_SUCCESS_TOTAL" -ge 2 ]; then
+    echo "PASS: query success total is $QUERY_SUCCESS_TOTAL (expected >= 2)"
+else
+    echo "FAIL: query success total is $QUERY_SUCCESS_TOTAL (expected >= 2)"
     exit 1
 fi

--- a/server/conn.go
+++ b/server/conn.go
@@ -167,6 +167,8 @@ type clientConn struct {
 	txStatus               byte                     // current transaction status ('I', 'T', or 'E')
 	ignoreTillSync         bool                     // discard extended-query messages until Sync after an error; see runExtendedQueryMessage
 	errorResponsesSent     uint64                   // ErrorResponses sent via sendError; observed by runExtendedQueryMessage
+	lastErrorCode          string                   // most recent SQLSTATE sent via sendError; observed by query metrics
+	activeQueryMetrics     *queryMetricsScope       // active query attempt metrics scope for non-ErrorResponse failures
 	passthrough            bool                     // true for passthrough users (skip transpiler + pg_catalog)
 	cursors                map[string]*cursorState  // server-side cursor emulation
 	catalogUseRewrite      bool                     // true when bare `USE ducklake`/`USE iceberg` should expand to the reliable two-part target
@@ -873,10 +875,10 @@ func (c *clientConn) serve() error {
 	c.sendInitialParams()
 
 	// Send ready for query
-	if err := wire.WriteReadyForQuery(c.writer, c.txStatus); err != nil {
+	if err := c.writeReadyForQuery(c.txStatus); err != nil {
 		return err
 	}
-	if err := c.writer.Flush(); err != nil {
+	if err := c.flushWriter(); err != nil {
 		return fmt.Errorf("failed to flush writer: %w", err)
 	}
 
@@ -978,7 +980,7 @@ func (c *clientConn) handleStartup() error {
 	if err := wire.WriteAuthCleartextPassword(c.writer); err != nil {
 		return err
 	}
-	if err := c.writer.Flush(); err != nil {
+	if err := c.flushWriter(); err != nil {
 		return fmt.Errorf("failed to flush writer: %w", err)
 	}
 
@@ -1096,10 +1098,10 @@ func (c *clientConn) messageLoop() error {
 			// Extended query protocol - Sync: ends any skip-until-Sync error
 			// recovery, then reports readiness.
 			c.ignoreTillSync = false
-			if err := wire.WriteReadyForQuery(c.writer, c.txStatus); err != nil {
+			if err := c.writeReadyForQuery(c.txStatus); err != nil {
 				return err
 			}
-			_ = c.writer.Flush()
+			_ = c.flushWriter()
 
 		case wire.MsgClose:
 			// Extended query protocol - Close
@@ -1109,7 +1111,7 @@ func (c *clientConn) messageLoop() error {
 			// Discarded during skip-until-Sync error recovery, like real
 			// PostgreSQL (the ErrorResponse was already flushed by sendError).
 			if !c.ignoreTillSync {
-				_ = c.writer.Flush()
+				_ = c.flushWriter()
 			}
 
 		case wire.MsgTerminate:
@@ -1121,7 +1123,7 @@ func (c *clientConn) messageLoop() error {
 	}
 }
 
-func (c *clientConn) handleQuery(body []byte) error {
+func (c *clientConn) handleQuery(body []byte) (retErr error) {
 	query := string(bytes.TrimRight(body, "\x00"))
 	query = strings.TrimSpace(query)
 
@@ -1129,8 +1131,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 	// PostgreSQL returns EmptyQueryResponse for queries like "" or ";" or ";;;"
 	if query == "" || isEmptyQuery(query) {
 		_ = wire.WriteEmptyQueryResponse(c.writer)
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -1146,7 +1148,13 @@ func (c *clientConn) handleQuery(body []byte) error {
 	}()
 
 	start := time.Now()
-	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
+	queryMetrics := c.beginQueryMetrics(start)
+	defer func() {
+		if retErr != nil {
+			queryMetrics.markError(retErr)
+		}
+		c.finishQueryMetrics(queryMetrics)
+	}()
 
 	ctx, span := observe.Tracer().Start(c.ctx, "duckgres.query",
 		trace.WithAttributes(
@@ -1244,8 +1252,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 	if err != nil {
 		// Transform error - send error to client
 		c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -1254,8 +1262,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 		if err := c.validateWithDuckDB(query); err != nil {
 			// Neither PostgreSQL nor DuckDB can parse this query
 			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 		c.logger().Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "query", loggableQuery)
@@ -1264,8 +1272,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 	// Handle transform-detected errors (e.g., unrecognized config parameter)
 	if result.Error != nil {
 		c.sendError("ERROR", transformErrorSQLState(result.Error), result.Error.Error())
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -1278,18 +1286,18 @@ func (c *clientConn) handleQuery(body []byte) error {
 	// Handle ignored SET parameters
 	if result.IsIgnoredSet {
 		c.logger().Debug("Ignoring PostgreSQL-specific SET.", "query", query)
-		_ = wire.WriteCommandComplete(c.writer, "SET")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeCommandComplete("SET")
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
 	// Handle no-op commands (CREATE INDEX, VACUUM, etc.)
 	if result.IsNoOp {
 		c.logger().Debug("No-op command (DuckLake limitation).", "query", query)
-		_ = wire.WriteCommandComplete(c.writer, result.NoOpTag)
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeCommandComplete(result.NoOpTag)
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -1323,9 +1331,9 @@ func (c *clientConn) handleQuery(body []byte) error {
 		// while DuckDB throws an error. Match PostgreSQL behavior.
 		if cmdType == "BEGIN" && c.txStatus == txStatusTransaction {
 			c.sendNotice("WARNING", "25001", "there is already a transaction in progress")
-			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeCommandComplete("BEGIN")
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -1377,8 +1385,8 @@ func (c *clientConn) handleQuery(body []byte) error {
 				c.sendError("ERROR", errCode, errMsg)
 				c.setTxError()
 				c.logQuery(start, originalQuery, query, cmdType, 0, 0, errCode, errMsg, "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 		}
@@ -1389,10 +1397,10 @@ func (c *clientConn) handleQuery(body []byte) error {
 		}
 		c.updateTxStatus(cmdType)
 		tag := c.buildCommandTag(cmdType, execResult)
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 		c.logQuery(start, originalQuery, query, cmdType, 0, writtenRows, "", "", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 

--- a/server/conn_copy.go
+++ b/server/conn_copy.go
@@ -216,15 +216,15 @@ func (c *clientConn) handleCopy(query, upperQuery string) error {
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowsAffected))
+	_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowsAffected))
 	c.logQuery(start, query, query, "COPY", 0, rowsAffected, "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -236,8 +236,8 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		c.sendError("ERROR", "42601", "Invalid COPY TO STDOUT syntax")
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42601", "Invalid COPY TO STDOUT syntax", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -279,8 +279,8 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	defer func() { _ = rows.Close() }()
@@ -291,8 +291,8 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -309,8 +309,8 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	typeOIDs := make([]int32, len(colTypes))
@@ -330,7 +330,7 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 	if err := wire.WriteCopyOutResponse(c.writer, int16(len(cols)), true); err != nil {
 		return err
 	}
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 
 	// Send header if CSV with HEADER
 	if copyWithCSVRegex.MatchString(upperQuery) && copyWithHeaderRegex.MatchString(upperQuery) {
@@ -379,8 +379,8 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, int64(rowCount), "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -390,10 +390,10 @@ func (c *clientConn) handleCopyOut(query, upperQuery string) error {
 		return err
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 	c.logQuery(start, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -409,8 +409,8 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, 0, "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -424,7 +424,7 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 	if err := wire.WriteCopyOutResponse(c.writer, int16(len(cols)), false); err != nil {
 		return err
 	}
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 
 	// Binary COPY header (19 bytes)
 	binaryHeader := []byte{
@@ -468,8 +468,8 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			c.logQuery(start, query, query, "COPY", 0, int64(rowCount), "42000", err.Error(), "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -496,8 +496,8 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
 		c.logQuery(start, query, query, "COPY", 0, int64(rowCount), "42000", err.Error(), "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -522,10 +522,10 @@ func (c *clientConn) handleCopyOutBinary(query string, rows RowSet, cols []strin
 		return err
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 	c.logQuery(start, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -540,8 +540,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 		c.sendError("ERROR", "42601", "Invalid COPY FROM STDIN syntax")
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "42601", "Invalid COPY FROM STDIN syntax", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -565,8 +565,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 		c.sendError("ERROR", "42P01", errMsg)
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "42P01", errMsg, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	cols, _ := testRows.Columns()
@@ -596,7 +596,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	if err := wire.WriteCopyInResponse(c.writer, int16(len(cols)), true); err != nil {
 		return err
 	}
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 	c.logger().Debug("COPY FROM STDIN sent CopyInResponse, waiting for data.")
 
 	// Remote-worker (Flight) executors implement CopyFromStdinExecutor so the
@@ -618,8 +618,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 		c.sendError("ERROR", "58000", errMsg)
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "58000", errMsg, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	tmpPath := tmpFile.Name()
@@ -655,8 +655,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 				c.sendError("ERROR", "58000", errMsg)
 				c.setTxError()
 				c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "58000", errMsg, "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 			bytesWritten += int64(n)
@@ -692,8 +692,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
 				c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "22P02", errMsg, "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 
@@ -703,10 +703,10 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			loadElapsed := time.Since(loadStart)
 			c.logger().Info("COPY FROM STDIN completed.", "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
 
-			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+			_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		case wire.MsgCopyFail:
@@ -716,8 +716,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			c.sendError("ERROR", "57014", exception)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "57014", exception, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		default:
@@ -725,8 +725,8 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 			c.sendError("ERROR", "08P01", errMsg)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "08P01", errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 	}
@@ -770,16 +770,16 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 		c.sendError("ERROR", "57014", exception)
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "57014", exception, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	if r.protoErr != "" {
 		c.sendError("ERROR", "08P01", r.protoErr)
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "08P01", r.protoErr, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	if err != nil {
@@ -788,8 +788,8 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 		c.sendError("ERROR", "22P02", errMsg)
 		c.setTxError()
 		c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "22P02", errMsg, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -798,10 +798,10 @@ func (c *clientConn) handleCopyInRemoteStreaming(
 	c.logger().Info("COPY FROM STDIN completed (remote streaming).", "rows", rowCount, "bytes", r.bytesRead,
 		"total_duration", totalElapsed, "load_duration", loadElapsed)
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 	c.logQuery(copyStartTime, query, query, "COPY", 0, rowCount, "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -895,7 +895,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 	if err := wire.WriteCopyInResponse(c.writer, int16(len(cols)), true); err != nil {
 		return err
 	}
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 
 	// Buffer all CopyData messages into memory (we need to parse CSV, not stream to file)
 	var buf bytes.Buffer
@@ -930,8 +930,8 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 					c.sendError("ERROR", "22P02", errMsg)
 					c.setTxError()
 					c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "22P02", errMsg, "simple")
-					_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-					_ = c.writer.Flush()
+					_ = c.writeReadyForQuery(c.txStatus)
+					_ = c.flushWriter()
 					return nil
 				}
 			}
@@ -961,10 +961,10 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			}
 
 			if len(rows) == 0 {
-				_ = wire.WriteCommandComplete(c.writer, "COPY 0")
+				_ = c.writeCommandComplete("COPY 0")
 				c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "", "", "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 
@@ -976,8 +976,8 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
 				c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "22P02", errMsg, "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 
@@ -985,10 +985,10 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			loadElapsed := time.Since(loadStart)
 			c.logger().Info("COPY FROM STDIN (BLOB fallback) completed.", "rows", rowCount, "total_duration", totalElapsed, "load_duration", loadElapsed)
 
-			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+			_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		case wire.MsgCopyFail:
@@ -997,8 +997,8 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			c.sendError("ERROR", "57014", exception)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "57014", exception, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		default:
@@ -1006,8 +1006,8 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 			c.sendError("ERROR", "08P01", errMsg)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "08P01", errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 	}
@@ -1028,7 +1028,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 	if err := wire.WriteCopyInResponse(c.writer, int16(len(cols)), false); err != nil {
 		return err
 	}
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 	c.logger().Debug("COPY FROM STDIN binary: sent CopyInResponse.")
 
 	// Collect all CopyData messages into a buffer
@@ -1054,18 +1054,18 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 				c.sendError("ERROR", "22P02", errMsg)
 				c.setTxError()
 				c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "22P02", errMsg, "simple")
-				_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-				_ = c.writer.Flush()
+				_ = c.writeReadyForQuery(c.txStatus)
+				_ = c.flushWriter()
 				return nil
 			}
 
 			elapsed := time.Since(copyStartTime)
 			c.logger().Info("COPY FROM STDIN binary completed.", "rows", rowCount, "bytes", buf.Len(), "duration", elapsed)
 
-			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("COPY %d", rowCount))
+			_ = c.writeCommandComplete(fmt.Sprintf("COPY %d", rowCount))
 			c.logQuery(copyStartTime, query, query, "COPY", 0, int64(rowCount), "", "", "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		case wire.MsgCopyFail:
@@ -1074,8 +1074,8 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 			c.sendError("ERROR", "57014", exception)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "57014", exception, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 
 		default:
@@ -1083,8 +1083,8 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 			c.sendError("ERROR", "08P01", errMsg)
 			c.setTxError()
 			c.logQuery(copyStartTime, query, query, "COPY", 0, 0, "08P01", errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 	}

--- a/server/conn_cursor.go
+++ b/server/conn_cursor.go
@@ -172,9 +172,9 @@ func (c *clientConn) handlePgCursorsQuery(cursorName string) error {
 		rowCount = 1
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", rowCount))
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", rowCount))
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -198,7 +198,7 @@ func (c *clientConn) handlePgCursorsQueryExtended(p *portal) {
 		rowCount = 1
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", rowCount))
 }
 
 // sendPgCursorsRowDescription sends a RowDescription for a pg_cursors query result (single int4 column).
@@ -229,8 +229,8 @@ func (c *clientConn) handleDeclareCursor(query string, stmt *pg_query.DeclareCur
 	if innerSQL == "" {
 		c.sendError("ERROR", "42601", "could not deparse cursor query")
 		c.logQuery(start, query, query, "DECLARE", 0, 0, "42601", "could not deparse cursor query", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -243,8 +243,8 @@ func (c *clientConn) handleDeclareCursor(query string, stmt *pg_query.DeclareCur
 			errMsg := fmt.Sprintf("syntax error in cursor query: %v", err)
 			c.sendError("ERROR", "42601", errMsg)
 			c.logQuery(start, query, query, "DECLARE", 0, 0, "42601", errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 		transpiledSQL = result.SQL
@@ -259,10 +259,10 @@ func (c *clientConn) handleDeclareCursor(query string, stmt *pg_query.DeclareCur
 	c.cursors[stmt.Portalname] = &cursorState{query: transpiledSQL}
 	c.logger().Debug("Cursor declared.", "cursor", stmt.Portalname, "query", transpiledSQL)
 
-	_ = wire.WriteCommandComplete(c.writer, "DECLARE CURSOR")
+	_ = c.writeCommandComplete("DECLARE CURSOR")
 	c.logQuery(start, query, query, "DECLARE", 0, 0, "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -273,8 +273,8 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 	if !isFetchForwardOnly(stmt.Direction) {
 		c.sendError("ERROR", "0A000", "cursor can only scan forward")
 		c.logQuery(start, query, query, "FETCH", 0, 0, "0A000", "cursor can only scan forward", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -283,8 +283,8 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 		errMsg := fmt.Sprintf("cursor %q does not exist", stmt.Portalname)
 		c.sendError("ERROR", "34000", errMsg)
 		c.logQuery(start, query, query, "FETCH", 0, 0, "34000", errMsg, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -300,8 +300,8 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 			c.sendError("ERROR", errCode, errMsg)
 			c.setTxError()
 			c.logQuery(start, query, query, "FETCH", 0, 0, errCode, errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 	}
@@ -311,8 +311,8 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 	if howMany < 0 {
 		c.sendError("ERROR", "0A000", "cursor can only scan forward")
 		c.logQuery(start, query, query, "FETCH", 0, 0, "0A000", "cursor can only scan forward", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -329,10 +329,10 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 			_ = cursor.rows.Scan(valuePtrs...)
 			moveCount++
 		}
-		_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("MOVE %d", moveCount))
+		_ = c.writeCommandComplete(fmt.Sprintf("MOVE %d", moveCount))
 		c.logQuery(start, query, query, "FETCH", moveCount, 0, "", "", "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -354,8 +354,8 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
 			c.logQuery(start, query, query, "FETCH", 0, 0, "42000", err.Error(), "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -375,15 +375,15 @@ func (c *clientConn) handleFetchCursor(query string, stmt *pg_query.FetchStmt) e
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
 		c.logQuery(start, query, query, "FETCH", 0, 0, errCode, errMsg, "simple")
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("FETCH %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("FETCH %d", rowCount))
 	c.logQuery(start, query, query, "FETCH", rowCount, 0, "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -398,18 +398,18 @@ func (c *clientConn) handleCloseCursor(query string, stmt *pg_query.ClosePortalS
 			errMsg := fmt.Sprintf("cursor %q does not exist", stmt.Portalname)
 			c.sendError("ERROR", "34000", errMsg)
 			c.logQuery(start, query, query, "CLOSE", 0, 0, "34000", errMsg, "simple")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 		c.closeCursor(stmt.Portalname)
 	}
 
 	c.logger().Debug("Cursor closed.", "cursor", stmt.Portalname)
-	_ = wire.WriteCommandComplete(c.writer, "CLOSE CURSOR")
+	_ = c.writeCommandComplete("CLOSE CURSOR")
 	c.logQuery(start, query, query, "CLOSE", 0, 0, "", "", "simple")
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -421,7 +421,7 @@ func (c *clientConn) handleDeclareCursorExtended(p *portal) {
 	c.cursors[p.stmt.cursorName] = &cursorState{query: p.stmt.cursorQuery}
 	c.logger().Debug("Cursor declared (extended).", "cursor", p.stmt.cursorName, "query", p.stmt.cursorQuery)
 
-	_ = wire.WriteCommandComplete(c.writer, "DECLARE CURSOR")
+	_ = c.writeCommandComplete("DECLARE CURSOR")
 }
 
 // handleFetchCursorExtended handles FETCH in the Extended Query protocol.
@@ -485,7 +485,7 @@ func (c *clientConn) handleFetchCursorExtended(p *portal) {
 		return
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("FETCH %d", rowCount))
+	_ = c.writeCommandComplete(fmt.Sprintf("FETCH %d", rowCount))
 }
 
 // handleCloseCursorExtended handles CLOSE cursor in the Extended Query protocol.
@@ -501,5 +501,5 @@ func (c *clientConn) handleCloseCursorExtended(p *portal) {
 	}
 
 	c.logger().Debug("Cursor closed (extended).", "cursor", p.stmt.cursorName)
-	_ = wire.WriteCommandComplete(c.writer, "CLOSE CURSOR")
+	_ = c.writeCommandComplete("CLOSE CURSOR")
 }

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -84,7 +84,7 @@ func (c *clientConn) handleParse(body []byte) {
 
 		case *pg_query.Node_FetchStmt:
 			if !isFetchForwardOnly(s.FetchStmt.Direction) || s.FetchStmt.HowMany < 0 {
-				c.sendError("ERROR", "0A000", "cursor can only scan forward")
+				c.observeExtendedParseQueryError("0A000", "cursor can only scan forward")
 				return
 			}
 			delete(c.stmts, stmtName)
@@ -161,13 +161,13 @@ func (c *clientConn) handleParse(body []byte) {
 	tr := c.newTranspiler(true) // Enable placeholder conversion for prepared statements
 	result, err := tr.Transpile(query)
 	if err != nil {
-		c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
+		c.observeExtendedParseQueryError("42601", fmt.Sprintf("syntax error: %v", err))
 		return
 	}
 
 	// Handle transform-detected errors (e.g., unrecognized config parameter)
 	if result.Error != nil {
-		c.sendError("ERROR", transformErrorSQLState(result.Error), result.Error.Error())
+		c.observeExtendedParseQueryError(transformErrorSQLState(result.Error), result.Error.Error())
 		return
 	}
 
@@ -175,7 +175,7 @@ func (c *clientConn) handleParse(body []byte) {
 	if result.FallbackToNative {
 		if err := c.validateWithDuckDB(query); err != nil {
 			// Neither PostgreSQL nor DuckDB can parse this query
-			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
+			c.observeExtendedParseQueryError("42601", fmt.Sprintf("syntax error: %v", err))
 			return
 		}
 		c.logger().Debug("Fallback to native DuckDB: query not valid PostgreSQL but valid DuckDB.", "query", usersecrets.RedactForLog(query))
@@ -499,6 +499,17 @@ func (c *clientConn) handleExecute(body []byte) {
 		c.queryStart.Store(time.Time{})
 	}()
 
+	// Handle empty queries - PostgreSQL returns EmptyQueryResponse for these
+	trimmedQuery := strings.TrimSpace(p.stmt.query)
+	if trimmedQuery == "" || isEmptyQuery(trimmedQuery) {
+		_ = wire.WriteEmptyQueryResponse(c.writer)
+		return
+	}
+
+	start := time.Now()
+	queryMetrics := c.beginQueryMetrics(start)
+	defer c.finishQueryMetrics(queryMetrics)
+
 	// Handle cursor operations before normal execution
 	switch p.stmt.cursorOp {
 	case cursorOpDeclare:
@@ -517,16 +528,6 @@ func (c *clientConn) handleExecute(body []byte) {
 		c.handlePgStatActivityExtended(p)
 		return
 	}
-
-	// Handle empty queries - PostgreSQL returns EmptyQueryResponse for these
-	trimmedQuery := strings.TrimSpace(p.stmt.query)
-	if trimmedQuery == "" || isEmptyQuery(trimmedQuery) {
-		_ = wire.WriteEmptyQueryResponse(c.writer)
-		return
-	}
-
-	start := time.Now()
-	defer func() { queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(start).Seconds()) }()
 
 	queryCtx, span := observe.Tracer().Start(c.ctx, "duckgres.query",
 		trace.WithAttributes(
@@ -570,7 +571,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	// (determined by transpiler during Parse)
 	if p.stmt.isIgnoredSet {
 		c.logger().Debug("Ignoring PostgreSQL-specific SET.", "query", p.stmt.query)
-		_ = wire.WriteCommandComplete(c.writer, "SET")
+		_ = c.writeCommandComplete("SET")
 		return
 	}
 
@@ -578,7 +579,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	// (determined by transpiler during Parse)
 	if p.stmt.isNoOp {
 		c.logger().Debug("No-op command (DuckLake limitation).", "query", p.stmt.query)
-		_ = wire.WriteCommandComplete(c.writer, p.stmt.noOpTag)
+		_ = c.writeCommandComplete(p.stmt.noOpTag)
 		return
 	}
 
@@ -614,7 +615,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		// while DuckDB throws an error. Match PostgreSQL behavior.
 		if cmdType == "BEGIN" && c.txStatus == txStatusTransaction {
 			c.sendNotice("WARNING", "25001", "there is already a transaction in progress")
-			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
+			_ = c.writeCommandComplete("BEGIN")
 			return
 		}
 
@@ -674,7 +675,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		queryRowsAff = writtenRows
 		c.updateTxStatus(cmdType)
 		tag := c.buildCommandTag(cmdType, result)
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, writtenRows, "", "", "extended")
 		return
 	}
@@ -797,7 +798,7 @@ func (c *clientConn) handleExecute(body []byte) {
 
 	c.updateTxStatus(cmdType)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
-	_ = wire.WriteCommandComplete(c.writer, tag)
+	_ = c.writeCommandComplete(tag)
 	c.logQuery(start, originalQuery, convertedQuery, cmdType, int64(rowCount), 0, "", "", "extended")
 }
 

--- a/server/conn_pg_stat_activity.go
+++ b/server/conn_pg_stat_activity.go
@@ -90,9 +90,9 @@ func (c *clientConn) handlePgStatActivity() error {
 		}
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", len(conns)))
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", len(conns)))
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -109,7 +109,7 @@ func (c *clientConn) handlePgStatActivityExtended(p *portal) {
 		_ = c.sendPgStatActivityDataRow(conn, p.resultFormats)
 	}
 
-	_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", len(conns)))
+	_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", len(conns)))
 }
 
 // sendPgStatActivityRowDescription sends a RowDescription for pg_stat_activity.

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -22,9 +22,9 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 		// Handle nested BEGIN
 		if cmdType == "BEGIN" && c.txStatus == txStatusTransaction {
 			c.sendNotice("WARNING", "25001", "there is already a transaction in progress")
-			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeCommandComplete("BEGIN")
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -75,8 +75,8 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 			}
 			c.sendError("ERROR", errCode, errMsg)
 			c.setTxError()
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -85,9 +85,9 @@ func (c *clientConn) executeQueryDirect(query, cmdType string) error {
 		}
 		c.updateTxStatus(cmdType)
 		tag := c.buildCommandTag(cmdType, result)
-		_ = wire.WriteCommandComplete(c.writer, tag)
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeCommandComplete(tag)
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -269,8 +269,8 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return 0, errCode, errMsg, nil
 	}
 	defer func() { _ = rows.Close() }()
@@ -285,8 +285,8 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return 0, errCode, errMsg, nil
 	}
 
@@ -300,8 +300,8 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return 0, errCode, errMsg, nil
 	}
 
@@ -345,8 +345,8 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 			}
 			c.sendError("ERROR", errCode, errMsg)
 			c.setTxError()
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return 0, errCode, errMsg, nil
 		}
 
@@ -373,16 +373,16 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string) (int64, st
 		}
 		c.sendError("ERROR", errCode, errMsg)
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return 0, errCode, errMsg, nil
 	}
 
 	c.updateTxStatus(cmdType)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
-	_ = wire.WriteCommandComplete(c.writer, tag)
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeCommandComplete(tag)
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return int64(rowCount), "", "", nil
 }
 
@@ -400,8 +400,8 @@ func (c *clientConn) handleMultiStatementQuery(query string) error {
 	tree, err := pg_query.Parse(parseSQL)
 	if err != nil {
 		c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 	c.logger().Debug("Multi-statement simple query.", "count", len(tree.Stmts))
@@ -427,8 +427,8 @@ func (c *clientConn) handleMultiStatementQuery(query string) error {
 		}
 	}
 
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return nil
 }
 
@@ -465,7 +465,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			}
 			c.closeCursor(s.DeclareCursorStmt.Portalname)
 			c.cursors[s.DeclareCursorStmt.Portalname] = &cursorState{query: transpiledSQL}
-			_ = wire.WriteCommandComplete(c.writer, "DECLARE CURSOR")
+			_ = c.writeCommandComplete("DECLARE CURSOR")
 			return false, nil
 
 		case *pg_query.Node_FetchStmt:
@@ -505,7 +505,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 					_ = cursor.rows.Scan(valuePtrs...)
 					moveCount++
 				}
-				_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("MOVE %d", moveCount))
+				_ = c.writeCommandComplete(fmt.Sprintf("MOVE %d", moveCount))
 				return false, nil
 			}
 			if err := c.sendRowDescription(cursor.cols, cursor.colTypes); err != nil {
@@ -537,7 +537,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 				c.setTxError()
 				return true, nil
 			}
-			_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("FETCH %d", rowCount))
+			_ = c.writeCommandComplete(fmt.Sprintf("FETCH %d", rowCount))
 			return false, nil
 
 		case *pg_query.Node_ClosePortalStmt:
@@ -550,7 +550,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 				}
 				c.closeCursor(s.ClosePortalStmt.Portalname)
 			}
-			_ = wire.WriteCommandComplete(c.writer, "CLOSE CURSOR")
+			_ = c.writeCommandComplete("CLOSE CURSOR")
 			return false, nil
 		}
 	}
@@ -564,7 +564,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 			_ = c.sendDataRowWithFormats([]interface{}{int64(1)}, nil, []int32{23})
 			rowCount = 1
 		}
-		_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", rowCount))
+		_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", rowCount))
 		return false, nil
 	}
 
@@ -576,7 +576,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 		for _, conn := range conns {
 			_ = c.sendPgStatActivityDataRow(conn, nil)
 		}
-		_ = wire.WriteCommandComplete(c.writer, fmt.Sprintf("SELECT %d", len(conns)))
+		_ = c.writeCommandComplete(fmt.Sprintf("SELECT %d", len(conns)))
 		return false, nil
 	}
 
@@ -602,12 +602,12 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 	}
 
 	if result.IsIgnoredSet {
-		_ = wire.WriteCommandComplete(c.writer, "SET")
+		_ = c.writeCommandComplete("SET")
 		return false, nil
 	}
 
 	if result.IsNoOp {
-		_ = wire.WriteCommandComplete(c.writer, result.NoOpTag)
+		_ = c.writeCommandComplete(result.NoOpTag)
 		return false, nil
 	}
 
@@ -646,7 +646,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 	if !queryReturnsResults(executedQuery) {
 		if cmdType == "BEGIN" && c.txStatus == txStatusTransaction {
 			c.sendNotice("WARNING", "25001", "there is already a transaction in progress")
-			_ = wire.WriteCommandComplete(c.writer, "BEGIN")
+			_ = c.writeCommandComplete("BEGIN")
 			return false, nil
 		}
 
@@ -706,7 +706,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 		queryRowsAff = writtenRows
 		c.updateTxStatus(cmdType)
 		tag := c.buildCommandTag(cmdType, execResult)
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 		c.logQuery(start, query, executedQuery, cmdType, 0, writtenRows, "", "", "simple-batch")
 		return false, nil
 	}
@@ -802,7 +802,7 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 
 	c.updateTxStatus(cmdType)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
-	_ = wire.WriteCommandComplete(c.writer, tag)
+	_ = c.writeCommandComplete(tag)
 	c.logQuery(start, query, executedQuery, cmdType, int64(rowCount), 0, "", "", "simple-batch")
 	return false, nil
 }
@@ -819,8 +819,8 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 func (c *clientConn) executeMultiStatement(statements []string, cleanup []string) error {
 	if len(statements) == 0 {
 		_ = wire.WriteEmptyQueryResponse(c.writer)
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -856,8 +856,8 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 			// On error, still try to cleanup (best effort)
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 	}
@@ -885,8 +885,8 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 		defer func() { _ = rows.Close() }()
@@ -915,8 +915,8 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 			c.setTxError()
 			c.executeCleanup(cleanup)
 			c.sendError("ERROR", "42000", err.Error())
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 		if result != nil {
@@ -928,9 +928,9 @@ func (c *clientConn) executeMultiStatement(statements []string, cleanup []string
 
 		// Send completion
 		tag := c.buildCommandTag(cmdType, result)
-		_ = wire.WriteCommandComplete(c.writer, tag)
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		return c.writer.Flush()
+		_ = c.writeCommandComplete(tag)
+		_ = c.writeReadyForQuery(c.txStatus)
+		return c.flushWriter()
 	}
 }
 
@@ -1048,6 +1048,6 @@ func (c *clientConn) executeMultiStatementExtended(statements []string, cleanup 
 
 		// Send completion (no ReadyForQuery - that's done by Sync)
 		tag := c.buildCommandTag(cmdType, result)
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 	}
 }

--- a/server/conn_results.go
+++ b/server/conn_results.go
@@ -81,7 +81,7 @@ func (c *clientConn) streamRowsToClientExtended(rows RowSet, cmdType string, res
 
 	// Send completion (no ReadyForQuery - that's done by Sync)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
-	_ = wire.WriteCommandComplete(c.writer, tag)
+	_ = c.writeCommandComplete(tag)
 }
 
 // streamRowsToClient sends result rows over the wire protocol.
@@ -93,8 +93,8 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		c.logger().Error("Failed to get column info.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -103,8 +103,8 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 		c.logger().Error("Failed to get column types.", "query", query, "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
@@ -132,8 +132,8 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 			c.logger().Error("Failed to scan row.", "query", query, "error", err)
 			c.sendError("ERROR", "42000", err.Error())
 			c.setTxError()
-			_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-			_ = c.writer.Flush()
+			_ = c.writeReadyForQuery(c.txStatus)
+			_ = c.flushWriter()
 			return nil
 		}
 
@@ -151,16 +151,16 @@ func (c *clientConn) streamRowsToClient(rows RowSet, cmdType string, query strin
 			c.sendError("ERROR", "42000", err.Error())
 		}
 		c.setTxError()
-		_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-		_ = c.writer.Flush()
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
 		return nil
 	}
 
 	// Send completion
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
-	_ = wire.WriteCommandComplete(c.writer, tag)
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	return c.writer.Flush()
+	_ = c.writeCommandComplete(tag)
+	_ = c.writeReadyForQuery(c.txStatus)
+	return c.flushWriter()
 }
 
 func (c *clientConn) sendRowDescription(cols []string, colTypes []ColumnTyper) error {
@@ -217,7 +217,11 @@ func (c *clientConn) sendRowDescriptionWithFormats(cols []string, colTypes []Col
 		_ = binary.Write(&buf, binary.BigEndian, format)
 	}
 
-	return wire.WriteMessage(c.writer, wire.MsgRowDescription, buf.Bytes())
+	if err := wire.WriteMessage(c.writer, wire.MsgRowDescription, buf.Bytes()); err != nil {
+		c.markActiveQueryMetricsError(err)
+		return err
+	}
+	return nil
 }
 
 func (c *clientConn) mapTypeOIDWithColumnName(colName string, colType ColumnTyper) int32 {
@@ -297,7 +301,11 @@ func (c *clientConn) sendDataRowWithFormats(values []interface{}, formatCodes []
 		}
 	}
 
-	return wire.WriteMessage(c.writer, wire.MsgDataRow, buf.Bytes())
+	if err := wire.WriteMessage(c.writer, wire.MsgDataRow, buf.Bytes()); err != nil {
+		c.markActiveQueryMetricsError(err)
+		return err
+	}
+	return nil
 }
 
 // formatValue converts a value to its PostgreSQL text representation
@@ -497,6 +505,33 @@ func formatOrderedMapValue(m arrowmap.OrderedMapValue) string {
 	return buf.String()
 }
 
+func (c *clientConn) writeCommandComplete(tag string) error {
+	if err := wire.WriteCommandComplete(c.writer, tag); err != nil {
+		c.markActiveQueryMetricsError(err)
+		return err
+	}
+	if c.activeQueryMetrics != nil {
+		return c.flushWriter()
+	}
+	return nil
+}
+
+func (c *clientConn) writeReadyForQuery(txStatus byte) error {
+	if err := wire.WriteReadyForQuery(c.writer, txStatus); err != nil {
+		c.markActiveQueryMetricsError(err)
+		return err
+	}
+	return nil
+}
+
+func (c *clientConn) flushWriter() error {
+	if err := c.writer.Flush(); err != nil {
+		c.markActiveQueryMetricsError(err)
+		return err
+	}
+	return nil
+}
+
 func (c *clientConn) sendError(severity, code, message string) {
 	// Class 28 = "Invalid Authorization Specification" (auth failures).
 	// All current FATAL errors use class 28, so this covers both auth
@@ -505,13 +540,14 @@ func (c *clientConn) sendError(severity, code, message string) {
 	// a metric for it here.
 	if strings.HasPrefix(code, "28") {
 		auth.AuthFailuresCounter.Inc()
-	} else if severity == "ERROR" {
-		queryErrorsCounter.WithLabelValues(c.orgID).Inc()
+	}
+	if severity != "" {
+		c.lastErrorCode = code
 	}
 	c.logger().Debug("Sending error to client.", "severity", severity, "code", code, "message", message)
 	c.errorResponsesSent++
 	_ = wire.WriteErrorResponse(c.writer, severity, code, message)
-	_ = c.writer.Flush()
+	_ = c.flushWriter()
 }
 
 func (c *clientConn) sendNotice(severity, code, message string) {

--- a/server/conn_user_secrets.go
+++ b/server/conn_user_secrets.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/server/usersecrets"
-	"github.com/posthog/duckgres/server/wire"
 )
 
 // UserSecretManager persists per-user CREATE PERSISTENT SECRET statements so
@@ -195,10 +194,10 @@ func (c *clientConn) handleUserSecretDDLSimple(query string) bool {
 	if secErr != nil {
 		c.sendError("ERROR", secErr.code, secErr.msg)
 	} else {
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 	}
-	_ = wire.WriteReadyForQuery(c.writer, c.txStatus)
-	_ = c.writer.Flush()
+	_ = c.writeReadyForQuery(c.txStatus)
+	_ = c.flushWriter()
 	return true
 }
 
@@ -213,7 +212,7 @@ func (c *clientConn) handleUserSecretDDLExtended(query string) bool {
 	if secErr != nil {
 		c.sendError("ERROR", secErr.code, secErr.msg)
 	} else {
-		_ = wire.WriteCommandComplete(c.writer, tag)
+		_ = c.writeCommandComplete(tag)
 	}
 	return true
 }

--- a/server/query_metrics.go
+++ b/server/query_metrics.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type queryOutcome string
+
+const (
+	queryOutcomeSuccess  queryOutcome = "success"
+	queryOutcomeError    queryOutcome = "error"
+	queryOutcomeCanceled queryOutcome = "canceled"
+)
+
+var queryTotalCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_query_total",
+	Help: "Total number of non-empty query attempts partitioned by terminal outcome.",
+}, []string{"org", "outcome"})
+
+type queryMetricsScope struct {
+	start              time.Time
+	errorResponsesSent uint64
+	outcome            queryOutcome
+	previous           *queryMetricsScope
+}
+
+func (c *clientConn) beginQueryMetrics(start time.Time) *queryMetricsScope {
+	scope := &queryMetricsScope{
+		start:              start,
+		errorResponsesSent: c.errorResponsesSent,
+		outcome:            queryOutcomeSuccess,
+		previous:           c.activeQueryMetrics,
+	}
+	c.activeQueryMetrics = scope
+	return scope
+}
+
+func (c *clientConn) finishQueryMetrics(scope *queryMetricsScope) {
+	if c.writer != nil {
+		if err := c.flushWriter(); err != nil {
+			scope.markError(err)
+		}
+	}
+
+	queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(scope.start).Seconds())
+
+	outcome := scope.outcome
+	if outcome == queryOutcomeSuccess && c.errorResponsesSent > scope.errorResponsesSent {
+		outcome = queryOutcomeFromErrorCode(c.lastErrorCode)
+	}
+	observeQueryOutcome(c.orgID, outcome)
+
+	if c.activeQueryMetrics == scope {
+		c.activeQueryMetrics = scope.previous
+	}
+}
+
+func (s *queryMetricsScope) markError(err error) {
+	if s == nil {
+		return
+	}
+	if isQueryCancelled(err) {
+		s.outcome = queryOutcomeCanceled
+		return
+	}
+	s.outcome = queryOutcomeError
+}
+
+func (c *clientConn) markActiveQueryMetricsError(err error) {
+	if c == nil || c.activeQueryMetrics == nil {
+		return
+	}
+	c.activeQueryMetrics.markError(err)
+}
+
+func queryOutcomeFromErrorCode(code string) queryOutcome {
+	if code == "57014" {
+		return queryOutcomeCanceled
+	}
+	return queryOutcomeError
+}
+
+func observeQueryOutcome(org string, outcome queryOutcome) {
+	switch outcome {
+	case queryOutcomeSuccess, queryOutcomeError, queryOutcomeCanceled:
+	default:
+		outcome = queryOutcomeError
+	}
+
+	queryTotalCounter.WithLabelValues(org, string(outcome)).Inc()
+}
+
+func (c *clientConn) observeExtendedParseQueryError(code, message string) {
+	c.sendError("ERROR", code, message)
+	observeQueryOutcome(c.orgID, queryOutcomeError)
+}

--- a/server/query_metrics_test.go
+++ b/server/query_metrics_test.go
@@ -1,0 +1,323 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func serverCounterVecValue(t *testing.T, cv *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	counter, err := cv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("counter labels %v: %v", labels, err)
+	}
+	m := &dto.Metric{}
+	if err := counter.Write(m); err != nil {
+		t.Fatalf("counter write labels %v: %v", labels, err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func serverHistogramVecSampleCount(t *testing.T, hv *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	observer, err := hv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("histogram labels %v: %v", labels, err)
+	}
+	h, ok := observer.(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("expected prometheus.Histogram, got %T", observer)
+	}
+	m := &dto.Metric{}
+	if err := h.Write(m); err != nil {
+		t.Fatalf("histogram write labels %v: %v", labels, err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestObserveQueryOutcomeIncrementsCanonicalCounter(t *testing.T) {
+	org := "query-metrics-outcomes"
+
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled))
+
+	observeQueryOutcome(org, queryOutcomeSuccess)
+	observeQueryOutcome(org, queryOutcomeError)
+	observeQueryOutcome(org, queryOutcomeCanceled)
+
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore+1 {
+		t.Fatalf("success query total = %v, want %v", got, successBefore+1)
+	}
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+	}
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled)); got != canceledBefore+1 {
+		t.Fatalf("canceled query total = %v, want %v", got, canceledBefore+1)
+	}
+}
+
+func TestFinishQueryMetricsClassifiesCanceledOutcomeSeparately(t *testing.T) {
+	org := "query-metrics-canceled"
+	c := &clientConn{orgID: org}
+	scope := c.beginQueryMetrics(time.Now())
+
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled))
+	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
+
+	c.lastErrorCode = "57014"
+	c.errorResponsesSent = scope.errorResponsesSent + 1
+	c.finishQueryMetrics(scope)
+
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+		t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
+	}
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled)); got != canceledBefore+1 {
+		t.Fatalf("canceled query total = %v, want %v", got, canceledBefore+1)
+	}
+	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
+		t.Fatalf("duration samples = %v, want %v", got, durationBefore+1)
+	}
+}
+
+func TestFinishQueryMetricsClassifiesSuccessAndErrorOutcomes(t *testing.T) {
+	successOrg := "query-metrics-finish-success"
+	successConn := &clientConn{orgID: successOrg}
+	successScope := successConn.beginQueryMetrics(time.Now())
+	successBefore := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryOutcomeSuccess))
+	successDurationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, successOrg)
+
+	successConn.finishQueryMetrics(successScope)
+
+	if got := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryOutcomeSuccess)); got != successBefore+1 {
+		t.Fatalf("success query total = %v, want %v", got, successBefore+1)
+	}
+	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, successOrg); got != successDurationBefore+1 {
+		t.Fatalf("success duration samples = %v, want %v", got, successDurationBefore+1)
+	}
+
+	errorOrg := "query-metrics-finish-error"
+	errorConn := &clientConn{orgID: errorOrg}
+	errorScope := errorConn.beginQueryMetrics(time.Now())
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryOutcomeError))
+
+	errorConn.lastErrorCode = "42P01"
+	errorConn.errorResponsesSent = errorScope.errorResponsesSent + 1
+	errorConn.finishQueryMetrics(errorScope)
+
+	if got := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryOutcomeError)); got != errorBefore+1 {
+		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+	}
+}
+
+func TestQueryMetricsWrapSimpleAndExtendedEntryPoints(t *testing.T) {
+	t.Run("simple success", func(t *testing.T) {
+		org := "query-metrics-simple-success"
+		c, cleanup := newLifecycleClientConn(t)
+		defer cleanup()
+		c.orgID = org
+		c.executor = &lifecycleExecutor{execResult: emptyExecResult{}}
+
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+		durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
+
+		if err := c.handleQuery([]byte("UPDATE foo SET x = 1\x00")); err != nil {
+			t.Fatalf("handleQuery: %v", err)
+		}
+
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore+1 {
+			t.Fatalf("success query total = %v, want %v", got, successBefore+1)
+		}
+		if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
+			t.Fatalf("duration samples = %v, want %v", got, durationBefore+1)
+		}
+	})
+
+	t.Run("extended error", func(t *testing.T) {
+		org := "query-metrics-extended-error"
+		c, cleanup := newLifecycleClientConn(t)
+		defer cleanup()
+		c.orgID = org
+		c.executor = &lifecycleExecutor{execErr: errors.New("Catalog Error: table does not exist")}
+		c.portals["p1"] = &portal{stmt: &preparedStmt{
+			query:          "UPDATE missing SET x = 1",
+			convertedQuery: "UPDATE missing SET x = 1",
+		}}
+
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+		durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
+
+		body := append([]byte("p1"), 0)
+		body = append(body, 0, 0, 0, 0)
+		c.handleExecute(body)
+
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+		}
+		if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
+			t.Fatalf("duration samples = %v, want %v", got, durationBefore+1)
+		}
+	})
+}
+
+func TestQueryMetricsCountExtendedParseQueryErrorsWithoutDuration(t *testing.T) {
+	org := "query-metrics-extended-parse-error"
+	c, cleanup := newLifecycleClientConn(t)
+	defer cleanup()
+	c.orgID = org
+	c.executor = &pipelineRecordingExecutor{}
+
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
+
+	var body bytes.Buffer
+	body.WriteByte(0) // unnamed statement
+	body.WriteString(badParseSQL)
+	body.WriteByte(0)
+	if err := binary.Write(&body, binary.BigEndian, int16(0)); err != nil {
+		t.Fatalf("write param count: %v", err)
+	}
+
+	c.handleParse(body.Bytes())
+
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+	}
+	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore {
+		t.Fatalf("duration samples = %v, want unchanged %v", got, durationBefore)
+	}
+}
+
+func TestQueryMetricsClassifiesSimpleWireWriteFailureAsError(t *testing.T) {
+	org := "query-metrics-wire-write-error"
+	c, cleanup := newLifecycleClientConn(t)
+	defer cleanup()
+	c.orgID = org
+	c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 16)
+	c.executor = &lifecycleExecutor{
+		queryRows: &streamingRowSet{
+			cols:      []string{"c"},
+			colTypers: []ColumnTyper{stringColumnTyper{}},
+			rows:      [][]any{{"hello"}},
+		},
+	}
+
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
+
+	if err := c.handleQuery([]byte("SELECT 'hello'\x00")); err == nil {
+		t.Fatal("handleQuery returned nil error, want pgwire write failure")
+	}
+
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+		t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
+	}
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+	}
+	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
+		t.Fatalf("duration samples = %v, want %v", got, durationBefore+1)
+	}
+}
+
+func TestQueryMetricsClassifiesTerminalWireWriteFailureAsError(t *testing.T) {
+	t.Run("simple exec command complete", func(t *testing.T) {
+		org := "query-metrics-simple-terminal-write-error"
+		c, cleanup := newLifecycleClientConn(t)
+		defer cleanup()
+		c.orgID = org
+		c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 16)
+		c.executor = &lifecycleExecutor{execResult: &fakeExecResult{rowsAffected: 123456789012345678}}
+
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+
+		if err := c.handleQuery([]byte("UPDATE foo SET x = 1\x00")); err != nil {
+			t.Fatalf("handleQuery: %v", err)
+		}
+
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
+		}
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+		}
+	})
+
+	t.Run("extended exec command complete", func(t *testing.T) {
+		org := "query-metrics-extended-terminal-write-error"
+		c, cleanup := newLifecycleClientConn(t)
+		defer cleanup()
+		c.orgID = org
+		c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 16)
+		c.executor = &lifecycleExecutor{execResult: &fakeExecResult{rowsAffected: 123456789012345678}}
+		c.portals["p1"] = &portal{stmt: &preparedStmt{
+			query:          "UPDATE foo SET x = 1",
+			convertedQuery: "UPDATE foo SET x = 1",
+		}}
+
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+
+		body := append([]byte("p1"), 0)
+		body = append(body, 0, 0, 0, 0)
+		c.handleExecute(body)
+
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
+		}
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+		}
+	})
+
+	t.Run("extended exec buffered terminal flush", func(t *testing.T) {
+		org := "query-metrics-extended-buffered-terminal-write-error"
+		c, cleanup := newLifecycleClientConn(t)
+		defer cleanup()
+		c.orgID = org
+		c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 4096)
+		c.executor = &lifecycleExecutor{execResult: emptyExecResult{}}
+		c.portals["p1"] = &portal{stmt: &preparedStmt{
+			query:          "UPDATE foo SET x = 1",
+			convertedQuery: "UPDATE foo SET x = 1",
+		}}
+
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+
+		body := append([]byte("p1"), 0)
+		body = append(body, 0, 0, 0, 0)
+		c.handleExecute(body)
+
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
+		}
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
+		}
+	})
+}
+
+func TestQueryErrorsLegacyMetricRemoved(t *testing.T) {
+	observeQueryOutcome("query-metrics-no-legacy-errors", queryOutcomeError)
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, metric := range metrics {
+		if metric.GetName() == "duckgres_query_errors_total" {
+			t.Fatalf("legacy duckgres_query_errors_total metric is still registered")
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -135,11 +135,6 @@ var queryDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 18000, 36000},
 }, []string{"org"})
 
-var queryErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "duckgres_query_errors_total",
-	Help: "Total number of failed queries",
-}, []string{"org"})
-
 var queryCancellationsCounter = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "duckgres_query_cancellations_total",
 	Help: "Total number of queries cancelled via cancel request",


### PR DESCRIPTION
## Summary
- add canonical `duckgres_query_total{org,outcome}` query outcome accounting for success, error, and canceled attempts
- remove the duplicate `duckgres_query_errors_total` metric and update local metrics docs, smoke test, and local Grafana dashboard references
- route terminal pgwire writes through helpers so write failures are classified as query errors instead of successes

## Validation
- `go test ./server -count=1`
- `just test-unit`
- `just test-metrics`
- `just lint`
- `git diff --check`