### PR TITLE
chore(httpfs): bump extension to v1.5.3-cred-refresh — mid-statement credential recovery

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -71,7 +71,13 @@ jobs:
                     - version: "1.5.3"
                       go: "v2.10503.0"
                       bindings: "v0.10503.0"
-                      httpfs: "v1.5.3-stoi-fix"
+                      # cred-refresh: mid-statement S3 credential recovery on
+                      # auth failure (PostHog/duckdb-httpfs cred-refresh-read-path;
+                      # supersedes v1.5.3-stoi-fix, which it is based on). Lets
+                      # statements outlive their starting STS token as long as
+                      # the credential-refresh scheduler keeps rotating the
+                      # ducklake_s3 secret.
+                      httpfs: "v1.5.3-cred-refresh"
                       ducklake: "v1.0-posthog.4"
                       # Stable repo hosts postgres_scanner for 1.5.3; nightly
                       # does not. See scripts/ducklake_version_matrix.sh

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -87,7 +87,7 @@ jobs:
       # container-image-worker-cd.yml. Keep in lock-step on a version bump.
       build-args: |
         DUCKDB_EXTENSION_VERSION=1.5.3
-        HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
+        HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
         DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
         POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 # edit.)
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -51,7 +51,7 @@ RUN go mod download
 # keeps the GHA layer-cache hit and skips the 5 downloads. (They previously
 # ran after the source COPY + build, so they re-fetched on every edit.)
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -124,6 +124,18 @@ normal `go test ./...` lane.
 
 ### Deliberately not covered here
 
+- **Mid-statement STS credential recovery (httpfs `v1.5.3-cred-refresh`)** —
+  the worker image bundles the PostHog httpfs fork patch that re-resolves the
+  latest committed `ducklake_s3` secret and retries on an auth failure, letting
+  a statement outlive the STS token it started with. Proving real in-statement
+  expiry in-Job needs a statement longer than the shortest AssumeRole token
+  (900s AWS floor), which blows the Job time budget. The behavior is
+  deterministically covered by the MinIO rotation tests in
+  `tests/integration/credential_rotation_pin_test.go` (stock httpfs dies /
+  patched httpfs survives rotation + revocation mid-scan); the harness's
+  `assert_fork_extensions` pins that workers actually run the patched build
+  (`EXPECT_HTTPFS_SHA`), and every DuckLake/Iceberg assertion here exercises
+  the patched request paths against real S3.
 - **Version-mismatch worker reaper** — needs a mid-run image bump, so it stays
   covered by `controlplane/` unit tests rather than in-Job.
 - **Physical object-store-prefix isolation** — the Go suite listed the MinIO
@@ -173,13 +185,14 @@ normal `go test ./...` lane.
   gives no deterministic control over when the scheduler tick lands. Covered
   by `controlplane/sts_broker_test.go` +
   `shared_worker_activator_credentials_test.go` (cache margin, lookahead
-  invariant, expiry surfacing on both activation paths) and — load-bearing —
-  the integration pin `tests/integration/credential_rotation_pin_test.go`,
-  which proves against a real MinIO that an in-flight scan does NOT survive
-  credential rotation (DuckDB resolves secrets through the statement's MVCC
-  snapshot, and scan-workload file opens skip the HEAD that could trigger
-  httpfs' refresh-on-403), i.e. the floor is the *only* protection and a
-  statement longer than its starting runway still dies with ExpiredToken.
+  invariant, expiry surfacing on both activation paths) and the integration
+  pin `tests/integration/credential_rotation_pin_test.go`, which proves
+  against a real MinIO that on STOCK httpfs an in-flight scan does NOT
+  survive credential rotation (DuckDB resolves secrets through the
+  statement's MVCC snapshot, and scan-workload file opens skip the HEAD that
+  could trigger httpfs' refresh-on-403). With the bundled
+  `v1.5.3-cred-refresh` fork build the floor is defense-in-depth rather than
+  the only protection — see the mid-statement recovery bullet above.
 
 ## Isolation model
 

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -81,10 +81,10 @@ RES2="ci-pr-${PR_NUMBER}-res2"
 
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
-# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-stoi-fix).
+# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh).
 # If the image accidentally ships upstream, the version differs and we fail.
 EXPECT_DUCKLAKE_SHA="e4ac5150"
-EXPECT_HTTPFS_SHA="c727795"
+EXPECT_HTTPFS_SHA="b1fece6"
 
 # duckling-example RDS — the shared external metadata store (same one the
 # manual validation used). Endpoint is stable in mw-dev.


### PR DESCRIPTION
## What

Bumps `HTTPFS_EXTENSION_TAG` from `v1.5.3-stoi-fix` to [`v1.5.3-cred-refresh`](https://github.com/PostHog/duckdb-httpfs/releases/tag/v1.5.3-cred-refresh) in both Dockerfiles, the worker-CD matrix default row, and the e2e workflow. The new fork build ([branch `cred-refresh-read-path`](https://github.com/PostHog/duckdb-httpfs/compare/v1.5.3-stoi-fix...cred-refresh-read-path), based on the previously deployed `v1.5.3-stoi-fix`) adds **mid-statement S3 credential recovery**: on an auth failure (400/403) in any S3 request path — range GET, full GET, HEAD, DELETE, and the multipart-upload POST/PUT — it re-resolves the **latest committed** `ducklake_s3` secret (bypassing the statement's MVCC snapshot of the secret catalog) and retries once with the refreshed credentials.

## Why

Follow-up to #778. A DuckDB statement captures its STS credentials at statement start; the credential-refresh scheduler's `CREATE OR REPLACE SECRET` pushes never reached in-flight statements, so any statement outliving its 1h token died with `ExpiredToken` (the Dagster `duckling_events_backfill` failure). #778 raised the starting-runway floor to 35min; this bump removes the ceiling entirely — the scheduler rotates every ≤30min and an in-flight statement picks the rotation up on its first auth failure. Backfill DELETEs/SELECTs can now run for hours.

Proven by `TestInFlightScanSurvivesRotationWithPatchedHTTPFS` (merged in #778): the same in-flight glob scan that deterministically dies on stock httpfs survives rotation + revocation of its starting credentials with an exact row count.

## Harness / coverage

- `assert_fork_extensions` now pins `EXPECT_HTTPFS_SHA=b1fece6` — this PR's own e2e run fails unless worker pods actually load the new build (verified the published release asset embeds `b1fece6`).
- e2e README: new "mid-statement STS credential recovery" deferral entry (real in-statement expiry needs a >900s statement — past the Job budget; the MinIO rotation tests are the deterministic stand-in), and the freshness-floor entry no longer claims the floor is the *only* protection.

## Rollout / rollback

- Prod workers run the all-in-one `duckgres` image (verified live: all 60 pods on `duckgres:21d995f`, no per-org image overrides), so the `Dockerfile` bump is the one that reaches prod via the normal deploy; `k8s_pool_reconcile` recycles idle workers onto the new image automatically.
- Rollback: revert this commit — the `v1.5.3-stoi-fix` release assets remain published; the 1.5.2 matrix row is untouched.
- Fork release note: windows is now excluded from the fork's distribution matrix (June 2026 windows-latest MSVC removed `stdext::checked_array_iterator`, which duckdb v1.5.3's vendored fmt needs — toolchain drift unrelated to our patch; we only consume linux assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)