### PR TITLE
docs(claude): fix stale handover-drain-timeout default + require docs stay in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,20 @@ Configuration is resolved in `config_resolution.go` with the following precedenc
 
 Note: `--mode` is CLI-only (not loadable from YAML/env). A handful of K8s pod-scheduling knobs are env-only (no CLI flag).
 
+## Keep docs in sync with behavior
+
+When you change a behavior, default, flag, or invariant that is documented
+anywhere in the repo, **update that documentation in the same PR.** Stale docs
+are worse than no docs — they actively mislead the next reader (human or agent).
+This applies to, at least: this `CLAUDE.md`, `README.md`, `docs/`, CLI flag help
+text (`main.go` / `cliflags.go`), and any design/plan docs that pin the changed
+behavior. Concretely: if you change a default value, a flag's meaning, a drain or
+shutdown semantic, an activation/routing/teardown order, or any of the
+LOAD-BEARING CONTRACT sections below, grep for the old value/term across `*.md`
+and help strings and fix every mention. A behavior change that leaves a doc
+asserting the old behavior is incomplete, the same way a behavior change without
+a test is incomplete.
+
 ## Development
 
 The project uses [just](https://github.com/casey/just) as a command runner. Run `just` to see all available recipes for building, testing, running, metrics, and scripts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Key CLI flags for control-plane mode:
 - `--worker-queue-timeout DURATION` / `--worker-idle-timeout DURATION`
 - `--memory-budget SIZE` (default 75% RAM) / `--memory-rebalance`
 - `--socket-dir /path` (process backend)
-- `--handover-drain-timeout DURATION` (default `24h` process / `15m` remote; uses cloudflare/tableflip for FD passing)
+- `--handover-drain-timeout DURATION` (default `24h` process; **remote default is `0` = unbounded** — the CP waits for active sessions for as long as it takes and the pod's k8s `terminationGracePeriodSeconds` is the only hard wall. cloudflare/tableflip FD passing applies to process/standalone single-host upgrades, not k8s pod replacement.)
 - `--flight-port N` (Arrow Flight SQL ingress) plus `--flight-session-idle-ttl`, `--flight-session-reap-interval`, `--flight-handle-idle-ttl`, `--flight-session-token-ttl`
 - `--ducklake-delta-catalog-enabled` / `--ducklake-delta-catalog-path`
 - Remote backend (requires `--config-store`; `-tags kubernetes` for K8s pool):


### PR DESCRIPTION
## What

Two doc-only commits to `CLAUDE.md`:

1. **Fix the stale `--handover-drain-timeout` remote default.** CLAUDE.md claimed the remote default is `15m`. That default was removed (`controlplane/control.go:256-268`, worker-40761 incident): the remote default is now `0` = unbounded — the CP waits for active sessions for as long as it takes, and the pod's k8s `terminationGracePeriodSeconds` is the only hard wall. Also clarified that cloudflare/tableflip FD passing is process/standalone-only, not k8s pod replacement.
2. **Add a standing "keep docs in sync" instruction.** When a documented behavior/default/flag/invariant changes, update the docs (CLAUDE.md, README, docs/, CLI help, design docs) in the same PR — a behavior change that leaves a doc asserting the old behavior is incomplete, the same way a missing test is.

## Why

The stale `15m` claim actively misled a reader while reasoning about CP shutdown semantics. The second commit is the systemic fix so it does not recur.

## Notes

- Docs only; no code change.
- `README.md` also carries a stale `15m` mention; correcting it (and the CLI help text) is part of the acceptance criteria of #782 (the underlying unbounded-drain problem), so left there to land with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)