### PR TITLE
Retry transient cache proxy origin fetches

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -1,0 +1,24 @@
+# cache-proxy
+
+`cache-proxy` is a forward HTTP proxy used by DuckDB `httpfs` traffic. It caches
+cacheable `GET` responses on local disk, serves matching peer cache entries when
+available, and forwards cache misses to origin object storage.
+
+## Runtime Defaults
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `CACHE_DIR` | `/cache` | Local disk cache directory. |
+| `CACHE_MAX_PERCENT` | `80` | Maximum percent of the cache filesystem to use. |
+| `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
+| `PEER_ADDR` | `:8081` | Peer cache API listener. |
+| `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
+| `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
+
+Origin `GET` misses are retried up to 4 total attempts for transient failures:
+HTTP `408`, `429`, `500`, `502`, `503`, `504`, request timeouts, and common
+transport resets. Retries start with a 100 ms backoff and cap at 1 second.
+
+Terminal origin responses such as `400`, `403`, `404`, and `416` are not retried
+and are forwarded back to DuckDB verbatim. Failed origin responses are never
+stored in the cache.

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"strings"
@@ -24,6 +25,11 @@ type CacheProxy struct {
 	client  *http.Client
 	flights singleFlight
 
+	originTimeout             time.Duration
+	originRetryMaxAttempts    int
+	originRetryInitialBackoff time.Duration
+	originRetryMaxBackoff     time.Duration
+
 	// cacheHostSuffixes are the Host substrings that identify DuckLake bucket
 	// traffic worth caching. Requests whose Host doesn't contain any of these
 	// are passed through without caching.
@@ -39,6 +45,13 @@ type fetchResult struct {
 	contentType string // origin Content-Type ("" for peer fetches and hits)
 	source      string // "peer" or "miss"
 }
+
+const (
+	defaultOriginTimeout             = 60 * time.Second
+	defaultOriginRetryMaxAttempts    = 4
+	defaultOriginRetryInitialBackoff = 100 * time.Millisecond
+	defaultOriginRetryMaxBackoff     = 1 * time.Second
+)
 
 type singleFlight struct {
 	mu sync.Mutex
@@ -78,10 +91,14 @@ func (sf *singleFlight) Do(key string, fn func() (fetchResult, error)) (fetchRes
 
 func NewCacheProxy(store *DiskCache, peers *PeerManager, cacheHostSuffixes []string) *CacheProxy {
 	return &CacheProxy{
-		store:             store,
-		peers:             peers,
-		client:            &http.Client{Timeout: 60 * time.Second},
-		cacheHostSuffixes: cacheHostSuffixes,
+		store:                     store,
+		peers:                     peers,
+		client:                    &http.Client{Timeout: defaultOriginTimeout},
+		originTimeout:             defaultOriginTimeout,
+		originRetryMaxAttempts:    defaultOriginRetryMaxAttempts,
+		originRetryInitialBackoff: defaultOriginRetryInitialBackoff,
+		originRetryMaxBackoff:     defaultOriginRetryMaxBackoff,
+		cacheHostSuffixes:         cacheHostSuffixes,
 	}
 }
 
@@ -308,7 +325,59 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 // large range reads. A non-2xx response is NOT cached — its (capped) error body
 // is captured and returned as an originStatusError for verbatim forwarding.
 func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, string, error) {
-	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	attempts := p.originRetryMaxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	backoff := p.originRetryInitialBackoff
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		size, contentType, err := p.fetchOriginOnce(cacheKey, r)
+		if err == nil {
+			return size, contentType, nil
+		}
+		lastErr = err
+		if attempt == attempts || r.Context().Err() != nil || !isRetriableOriginFetchError(err) {
+			return 0, "", err
+		}
+
+		delay := jitteredOriginRetryDelay(backoff, p.originRetryMaxBackoff)
+		slog.Warn("Origin fetch failed with retriable error, retrying.",
+			"url", r.URL.String(),
+			"range", r.Header.Get("Range"),
+			"attempt", attempt,
+			"max_attempts", attempts,
+			"backoff", delay,
+			"error", err)
+		if !sleepContext(r.Context(), delay) {
+			return 0, "", r.Context().Err()
+		}
+		if backoff > 0 {
+			backoff *= 2
+			if p.originRetryMaxBackoff > 0 && backoff > p.originRetryMaxBackoff {
+				backoff = p.originRetryMaxBackoff
+			}
+		}
+	}
+	return 0, "", lastErr
+}
+
+func jitteredOriginRetryDelay(backoff, maxBackoff time.Duration) time.Duration {
+	if backoff <= 0 {
+		return 0
+	}
+	if maxBackoff > 0 && backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	return time.Duration(float64(backoff) * (0.5 + rand.Float64()*0.5))
+}
+
+func (p *CacheProxy) fetchOriginOnce(cacheKey string, r *http.Request) (int64, string, error) {
+	timeout := p.originTimeout
+	if timeout <= 0 {
+		timeout = defaultOriginTimeout
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, r.Method, r.URL.String(), nil)
@@ -348,6 +417,55 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 		return 0, "", err
 	}
 	return size, resp.Header.Get("Content-Type"), nil
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return true
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func isRetriableOriginFetchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var oe *originStatusError
+	if errors.As(err, &oe) {
+		switch oe.status {
+		case http.StatusRequestTimeout,
+			http.StatusTooManyRequests,
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "unexpected eof") ||
+		strings.Contains(msg, "timeout")
 }
 
 // originErrorBodyCap is the maximum number of bytes we'll buffer from a

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -30,7 +30,10 @@ func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
 // newTestProxy wires a CacheProxy with no peers and a tempdir-backed store.
 func newTestProxy(t *testing.T) *CacheProxy {
 	t.Helper()
-	return NewCacheProxy(newTestCache(t), nil, nil)
+	proxy := NewCacheProxy(newTestCache(t), nil, nil)
+	proxy.originRetryInitialBackoff = 0
+	proxy.originRetryMaxBackoff = 0
+	return proxy
 }
 
 // newTestServer returns an httptest origin plus a proxy that rewrites inbound
@@ -135,10 +138,10 @@ func TestHandleProxyRejectsNonAbsoluteURL(t *testing.T) {
 	}
 }
 
-// TestHandleProxyForwardsOrigin5xxVerbatim: any non-2xx the origin returns
-// must be passed back to DuckDB unchanged. Translating a 500 into a 502
-// (the old behaviour) made DuckDB's httpfs retry transient-class errors that
-// were really terminal, and hid the real status from logs and the client.
+// TestHandleProxyForwardsOrigin5xxVerbatim: a transient 5xx that keeps failing
+// must eventually be passed back to DuckDB unchanged. Translating a 500 into a
+// 502 (the old behaviour) made DuckDB's httpfs retry transient-class errors
+// that were really terminal, and hid the real status from logs and the client.
 func TestHandleProxyForwardsOrigin5xxVerbatim(t *testing.T) {
 	proxy := newTestProxy(t)
 	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -150,6 +153,108 @@ func TestHandleProxyForwardsOrigin5xxVerbatim(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "boom") {
 		t.Errorf("body = %q, want it to contain origin body 'boom'", rec.Body.String())
+	}
+}
+
+func TestHandleProxyRetriesOrigin503ThenCachesSuccess(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	var calls int32
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("X-Amz-Request-Id", "retry-me")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`<Error><Code>SlowDown</Code></Error>`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok-after-retry"))
+	})
+
+	rec := doForwardProxyRequest(proxy, "GET", originURL+"/bucket/flaky-503.parquet", http.Header{"Range": []string{"bytes=0-13"}})
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206 after retry", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok-after-retry" {
+		t.Fatalf("body = %q, want successful retry body", got)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("origin calls = %d, want 2 (initial 503 + retry success)", calls)
+	}
+
+	rec = doForwardProxyRequest(proxy, "GET", originURL+"/bucket/flaky-503.parquet", http.Header{"Range": []string{"bytes=0-13"}})
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("cache hit status = %d, want 206", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok-after-retry" {
+		t.Fatalf("cache hit body = %q, want successful retry body", got)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("origin calls after cache hit = %d, want still 2", calls)
+	}
+}
+
+func TestHandleProxyRetriesOrigin503AndForwardsFinalFailure(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	var calls int32
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("X-Amz-Request-Id", fmt.Sprintf("attempt-%d", n))
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprintf(w, `<Error><Code>SlowDown</Code><Attempt>%d</Attempt></Error>`, n)
+	})
+
+	rec := doForwardProxyRequest(proxy, "GET", originURL+"/bucket/still-503.parquet", http.Header{"Range": []string{"bytes=0-7"}})
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want final 503 forwarded", rec.Code)
+	}
+	totalCalls := atomic.LoadInt32(&calls)
+	if totalCalls != int32(defaultOriginRetryMaxAttempts) {
+		t.Fatalf("origin calls = %d, want %d attempts before forwarding final failure", totalCalls, defaultOriginRetryMaxAttempts)
+	}
+	if rid := rec.Header().Get("X-Amz-Request-Id"); rid != fmt.Sprintf("attempt-%d", totalCalls) {
+		t.Fatalf("X-Amz-Request-Id = %q, want final attempt header", rid)
+	}
+	wantBody := fmt.Sprintf(`<Error><Code>SlowDown</Code><Attempt>%d</Attempt></Error>`, totalCalls)
+	if got := rec.Body.String(); got != wantBody {
+		t.Fatalf("body = %q, want final attempt body %q", got, wantBody)
+	}
+}
+
+func TestHandleProxyDoesNotRetryTerminalOriginStatuses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"bad-request", http.StatusBadRequest},
+		{"forbidden", http.StatusForbidden},
+		{"not-found", http.StatusNotFound},
+		{"range-not-satisfiable", http.StatusRequestedRangeNotSatisfiable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := newTestProxy(t)
+			var calls int32
+			_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&calls, 1)
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprintf(w, "status=%d", tt.status)
+			})
+
+			rec := doForwardProxyRequest(proxy, "GET", originURL+"/bucket/terminal.parquet", http.Header{"Range": []string{"bytes=0-1"}})
+			if rec.Code != tt.status {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.status)
+			}
+			if atomic.LoadInt32(&calls) != 1 {
+				t.Fatalf("origin calls = %d, want 1 for terminal status %d", calls, tt.status)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry cacheable GET origin misses on transient origin/transport failures before forwarding the final error
- keep terminal origin responses such as 400/403/404/416 verbatim and uncached
- add cache-proxy tests for 503 recovery, 503 exhaustion, and terminal no-retry behavior
- document cache-proxy runtime defaults and retry behavior

## Testing
- go test -v ./cmd/cache-proxy
- just test-unit
- just lint