### PR TITLE
[codex] add query log resource usage fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ Duckgres exposes Prometheus metrics on `:9090/metrics`. The metrics port is curr
 - `scripts/perf_nightly.sh` - Nightly wrapper with lock/timeout guards and optional artifact publisher
 - `metrics-compose.yml` - Starts Prometheus and Grafana locally for metrics (Prometheus at http://localhost:9091, Grafana at http://localhost:3000)
 
+### Query Log
+
+When DuckLake is configured, Duckgres writes a durable per-query history to
+`ducklake.system.query_log` by default. The query log records SQL user
+(`user_name`), org, query text, duration, row counts, errors, trace/span IDs,
+and profiling-derived resource usage. `cpu_time_s` is DuckDB cumulative
+CPU/thread time in seconds, and `peak_buffer_memory_bytes` is DuckDB's
+`system_peak_buffer_memory` in bytes, not process RSS.
+
+```sql
+SELECT event_time, user_name, org_id, query_duration_ms, cpu_time_s,
+       peak_buffer_memory_bytes, postgres_scan_ms, query
+FROM ducklake.system.query_log
+ORDER BY cpu_time_s DESC, peak_buffer_memory_bytes DESC
+LIMIT 20;
+```
+
 ## Runbooks
 
 - [Worker Upgrades & Canaries](docs/runbooks/worker-upgrades.md): Process for upgrading DuckDB/DuckLake versions, canarying builds for a subset of tenants, and global version management.

--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -203,6 +203,7 @@ why.
 | pg_roles | ✅ | `catalog_test.go::TestCatalogPgRoles` | single hardcoded superuser |
 | pg_settings | ✅ | `catalog_test.go::TestCatalogPgSettings` | |
 | pg_stat_activity | ✅ | `pg_stat_activity_test.go::TestPgStatActivity`/`::TestPgStatActivityFromSecondConnection`/`::TestPgStatActivityExtendedQuery`/`::TestPgStatActivityStubView` | intercepted at query time for live data |
+| system.query_log | ✅ | `querylog_test.go` | DuckLake-backed durable query history with `user_name`, timing, errors, trace IDs, `cpu_time_s`, `peak_buffer_memory_bytes`, and `postgres_scan_ms` |
 | information_schema (tables/columns/views/schemata) | ✅ | `catalog_test.go::TestCatalogInformationSchema{Tables,Columns,Views,Schemata}` | |
 | information_schema key_column_usage / table_constraints / referential_constraints | ❌ | — | Missing; used by ORMs for FK introspection |
 | System functions (format_type, pg_get_userbyid, pg_table_is_visible, has_*_privilege, pg_encoding_to_char, size fns, quote_*) | ✅ | `catalog_test.go::TestCatalogSystemFunctions`, `::TestFormatTypeTimePrecision`; server `pg_compat_macros_test.go` | many return permissive/stub values |

--- a/server/observe/tracing.go
+++ b/server/observe/tracing.go
@@ -127,6 +127,12 @@ func collectOperatorTimings(ops []profilingOperator) (scanTime, scanRows float64
 // (e.g. query_log) use it to persist a few high-signal fields without
 // re-parsing the JSON.
 type QueryProfilingSummary struct {
+	// CPUTimeSeconds is DuckDB's cumulative query CPU/thread time in seconds.
+	// Zero means either no profiling output, or DuckDB reported no CPU time.
+	CPUTimeSeconds float64
+	// PeakBufferMemoryBytes is DuckDB's system_peak_buffer_memory value.
+	// It is DuckDB buffer memory, not process RSS or cgroup memory.
+	PeakBufferMemoryBytes int64
 	// PostgresScanSeconds is the thread-time spent inside postgres_scan
 	// operators — DuckLake metadata DB roundtrips. Zero means either no
 	// metadata access on this query, or no profiling output.
@@ -151,6 +157,7 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 
 	span.SetAttributes(
 		attribute.Float64("duckdb.latency_s", m.Latency),
+		attribute.Float64("duckdb.cpu_time_s", m.CPUTime),
 		attribute.Int64("duckdb.rows_returned", int64(m.RowsReturned)),
 		attribute.Int64("duckdb.result_set_size", int64(m.ResultSetSize)),
 		attribute.Int64("duckdb.total_memory_allocated", int64(m.TotalMemoryAllocated)),
@@ -228,7 +235,11 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		compSpan.End(trace.WithTimestamp(cursor))
 	}
 
-	return QueryProfilingSummary{PostgresScanSeconds: pgScanTime}
+	return QueryProfilingSummary{
+		CPUTimeSeconds:        m.CPUTime,
+		PeakBufferMemoryBytes: int64(m.PeakBufferMemory),
+		PostgresScanSeconds:   pgScanTime,
+	}
 }
 
 // TraceIDFromContext returns the hex trace ID from the span context, or "".

--- a/server/profiling_test.go
+++ b/server/profiling_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/posthog/duckgres/server/observe"
+	"github.com/posthog/duckgres/server/sqlcore"
 )
 
 func TestProfilingOutputToFile(t *testing.T) {
@@ -152,6 +154,66 @@ func TestProfilingCoverageAllCoversNonSelect(t *testing.T) {
 			t.Errorf("expected positive latency, got %f", m.Latency)
 		}
 	})
+}
+
+type profilingOutputExecutor struct {
+	output string
+}
+
+func (e profilingOutputExecutor) QueryContext(context.Context, string, ...any) (sqlcore.RowSet, error) {
+	return nil, nil
+}
+
+func (e profilingOutputExecutor) ExecContext(context.Context, string, ...any) (sqlcore.ExecResult, error) {
+	return nil, nil
+}
+
+func (e profilingOutputExecutor) Query(string, ...any) (sqlcore.RowSet, error) {
+	return nil, nil
+}
+
+func (e profilingOutputExecutor) Exec(string, ...any) (sqlcore.ExecResult, error) {
+	return nil, nil
+}
+
+func (e profilingOutputExecutor) ConnContext(context.Context) (sqlcore.RawConn, error) {
+	return nil, nil
+}
+
+func (e profilingOutputExecutor) PingContext(context.Context) error {
+	return nil
+}
+
+func (e profilingOutputExecutor) Close() error {
+	return nil
+}
+
+func (e profilingOutputExecutor) LastProfilingOutput() string {
+	return e.output
+}
+
+func TestEnrichSpanWithProfilingSummaryIncludesResourceUsage(t *testing.T) {
+	ctx := context.Background()
+	ctx, span := observe.Tracer().Start(ctx, "test")
+	defer span.End()
+
+	summary := observe.EnrichSpanWithProfiling(ctx, span, time.Now(), profilingOutputExecutor{output: `{
+		"latency": 2.5,
+		"cpu_time": 4.25,
+		"rows_returned": 3,
+		"result_set_size": 128,
+		"total_memory_allocated": 1024,
+		"system_peak_buffer_memory": 2048,
+		"total_bytes_read": 4096,
+		"children": []
+	}`}, "org-a")
+
+	if summary.CPUTimeSeconds != 4.25 {
+		t.Fatalf("expected CPUTimeSeconds 4.25, got %f", summary.CPUTimeSeconds)
+	}
+	if summary.PeakBufferMemoryBytes != 2048 {
+		t.Fatalf("expected PeakBufferMemoryBytes 2048, got %d", summary.PeakBufferMemoryBytes)
+	}
 }
 
 // TestProfilingSettingsArePerConnection reproduces the cluster-mode bug:

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -49,6 +49,12 @@ type QueryLogEntry struct {
 	// profiling disabled). Lets us answer "which query shape pounds the
 	// metadata DB?" against `system.query_log` without re-parsing profiling.
 	PostgresScanMs int64
+	// CPUTimeSeconds is DuckDB's cumulative query CPU/thread time in seconds.
+	// Zero when DuckDB returned no profiling output.
+	CPUTimeSeconds float64
+	// PeakBufferMemoryBytes is DuckDB's system_peak_buffer_memory value in
+	// bytes. This is DuckDB buffer memory, not process RSS.
+	PeakBufferMemoryBytes int64
 }
 
 // QueryLogger batches query log entries and writes them to a DuckLake table.
@@ -232,18 +238,18 @@ func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
 	}
 	sb.WriteString("INSERT INTO ")
 	sb.WriteString(table)
-	sb.WriteString(" (event_time, query_duration_ms, type, query, transpiled_query, query_kind, normalized_query_hash, result_rows, written_rows, exception_code, exception, user_name, org_id, current_database, client_address, client_port, application_name, pid, worker_id, is_transpiled, protocol, trace_id, span_id, postgres_scan_ms) VALUES ")
+	sb.WriteString(" (event_time, query_duration_ms, type, query, transpiled_query, query_kind, normalized_query_hash, result_rows, written_rows, exception_code, exception, user_name, org_id, current_database, client_address, client_port, application_name, pid, worker_id, is_transpiled, protocol, trace_id, span_id, postgres_scan_ms, cpu_time_s, peak_buffer_memory_bytes) VALUES ")
 
-	const colsPerRow = 24
+	const colsPerRow = 26
 	args := make([]any, 0, len(batch)*colsPerRow)
 	for i, e := range batch {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
 		base := i * colsPerRow
-		fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+		fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
 			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10,
-			base+11, base+12, base+13, base+14, base+15, base+16, base+17, base+18, base+19, base+20, base+21, base+22, base+23, base+24)
+			base+11, base+12, base+13, base+14, base+15, base+16, base+17, base+18, base+19, base+20, base+21, base+22, base+23, base+24, base+25, base+26)
 
 		args = append(args,
 			e.EventTime,
@@ -270,6 +276,8 @@ func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
 			e.TraceID,
 			e.SpanID,
 			e.PostgresScanMs,
+			e.CPUTimeSeconds,
+			e.PeakBufferMemoryBytes,
 		)
 	}
 
@@ -339,15 +347,27 @@ func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName strin
 		}
 	}
 
-	// Backfill postgres_scan_ms column on tables created before metadata-DB
-	// observability landed. New tables already get it from CREATE TABLE.
-	hasPgScan, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, "postgres_scan_ms")
-	if err != nil {
-		return fmt.Errorf("inspect postgres_scan_ms column: %w", err)
-	}
-	if !hasPgScan {
-		if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN postgres_scan_ms BIGINT"); err != nil {
-			return fmt.Errorf("add postgres_scan_ms column: %w", err)
+	// Backfill profiling-derived columns on tables created before these
+	// observability fields landed. New tables already get them from CREATE TABLE.
+	for _, col := range []struct {
+		name string
+		typ  string
+	}{
+		{name: "postgres_scan_ms", typ: "BIGINT"},
+		{name: "cpu_time_s", typ: "DOUBLE"},
+		{name: "peak_buffer_memory_bytes", typ: "BIGINT"},
+	} {
+		hasCol, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, col.name)
+		if err != nil {
+			return fmt.Errorf("inspect %s column: %w", col.name, err)
+		}
+		if !hasCol {
+			if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN " + col.name + " " + col.typ + " DEFAULT 0"); err != nil {
+				return fmt.Errorf("add %s column: %w", col.name, err)
+			}
+		}
+		if _, err := db.Exec("UPDATE " + fullTableName + " SET " + col.name + " = 0 WHERE " + col.name + " IS NULL"); err != nil {
+			return fmt.Errorf("backfill %s column: %w", col.name, err)
 		}
 	}
 
@@ -379,7 +399,9 @@ func queryLogCreateTableSQL(fullTableName string) string {
 		protocol            VARCHAR,
 		trace_id            VARCHAR,
 		span_id             VARCHAR,
-		postgres_scan_ms    BIGINT
+		postgres_scan_ms    BIGINT DEFAULT 0,
+		cpu_time_s          DOUBLE DEFAULT 0,
+		peak_buffer_memory_bytes BIGINT DEFAULT 0
 	)`, fullTableName)
 }
 
@@ -491,6 +513,8 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	if ql == nil {
 		return
 	}
+	profilingSummary := c.lastProfilingSummary
+	c.lastProfilingSummary = observe.QueryProfilingSummary{}
 	if isQueryLogSelfReferential(query) {
 		return
 	}
@@ -532,34 +556,35 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	// EnrichSpanWithProfiling on this connection and reset it so a later
 	// logQuery without a fresh exec (e.g. parse-failure path) doesn't
 	// reuse stale timings from a previous query.
-	pgScanMs := int64(c.lastProfilingSummary.PostgresScanSeconds * 1000)
-	c.lastProfilingSummary = observe.QueryProfilingSummary{}
+	pgScanMs := int64(profilingSummary.PostgresScanSeconds * 1000)
 
 	ql.Log(QueryLogEntry{
-		EventTime:       start,
-		QueryDurationMs: time.Since(start).Milliseconds(),
-		Type:            entryType,
-		Query:           query,
-		TranspiledQuery: transpiled,
-		QueryKind:       classifyQuery(cmdType),
-		NormalizedHash:  normalizeQueryHash(query),
-		ResultRows:      resultRows,
-		WrittenRows:     writtenRows,
-		ExceptionCode:   errCode,
-		Exception:       errMsg,
-		UserName:        c.username,
-		OrgID:           c.orgID,
-		CurrentDatabase: c.database,
-		ClientAddress:   clientAddr,
-		ClientPort:      clientPort,
-		ApplicationName: c.applicationName,
-		PID:             c.pid,
-		WorkerID:        c.workerID,
-		IsTranspiled:    transpiled != nil,
-		Protocol:        protocol,
-		TraceID:         observe.TraceIDFromContext(c.ctx),
-		SpanID:          observe.SpanIDFromContext(c.ctx),
-		PostgresScanMs:  pgScanMs,
+		EventTime:             start,
+		QueryDurationMs:       time.Since(start).Milliseconds(),
+		Type:                  entryType,
+		Query:                 query,
+		TranspiledQuery:       transpiled,
+		QueryKind:             classifyQuery(cmdType),
+		NormalizedHash:        normalizeQueryHash(query),
+		ResultRows:            resultRows,
+		WrittenRows:           writtenRows,
+		ExceptionCode:         errCode,
+		Exception:             errMsg,
+		UserName:              c.username,
+		OrgID:                 c.orgID,
+		CurrentDatabase:       c.database,
+		ClientAddress:         clientAddr,
+		ClientPort:            clientPort,
+		ApplicationName:       c.applicationName,
+		PID:                   c.pid,
+		WorkerID:              c.workerID,
+		IsTranspiled:          transpiled != nil,
+		Protocol:              protocol,
+		TraceID:               observe.TraceIDFromContext(c.ctx),
+		SpanID:                observe.SpanIDFromContext(c.ctx),
+		PostgresScanMs:        pgScanMs,
+		CPUTimeSeconds:        profilingSummary.CPUTimeSeconds,
+		PeakBufferMemoryBytes: profilingSummary.PeakBufferMemoryBytes,
 	})
 }
 

--- a/server/querylog_test.go
+++ b/server/querylog_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"testing"
 	"time"
+
+	"github.com/posthog/duckgres/server/observe"
 )
 
 func TestClassifyQuery(t *testing.T) {
@@ -370,6 +372,53 @@ func TestEscapeSQLStringLiteral(t *testing.T) {
 	}
 }
 
+func TestEnsureQueryLogTableCreatesResourceUsageColumns(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := ensureQueryLogTable(db, "", "query_log", "query_log"); err != nil {
+		t.Fatalf("ensureQueryLogTable: %v", err)
+	}
+
+	tests := []struct {
+		column string
+		want   string
+	}{
+		{column: "cpu_time_s", want: "DOUBLE"},
+		{column: "peak_buffer_memory_bytes", want: "BIGINT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.column, func(t *testing.T) {
+			got, err := queryLogColumnType(db, "query_log", "", "query_log", tt.column)
+			if err != nil {
+				t.Fatalf("queryLogColumnType(%s): %v", tt.column, err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %s type %s, got %s", tt.column, tt.want, got)
+			}
+		})
+	}
+
+	if _, err := db.Exec(`INSERT INTO query_log (event_time, query_duration_ms, type, query, user_name)
+		VALUES (?, ?, ?, ?, ?)`, time.Unix(1700000000, 0).UTC(), int64(1), "QueryFinish", "SELECT 1", "alice"); err != nil {
+		t.Fatalf("insert without resource usage columns: %v", err)
+	}
+	var cpuTimeS sql.NullFloat64
+	var peakBufferMemoryBytes sql.NullInt64
+	if err := db.QueryRow("SELECT cpu_time_s, peak_buffer_memory_bytes FROM query_log").Scan(&cpuTimeS, &peakBufferMemoryBytes); err != nil {
+		t.Fatalf("query default resource usage columns: %v", err)
+	}
+	if !cpuTimeS.Valid || cpuTimeS.Float64 != 0 {
+		t.Fatalf("expected cpu_time_s default 0, got valid=%t value=%f", cpuTimeS.Valid, cpuTimeS.Float64)
+	}
+	if !peakBufferMemoryBytes.Valid || peakBufferMemoryBytes.Int64 != 0 {
+		t.Fatalf("expected peak_buffer_memory_bytes default 0, got valid=%t value=%d", peakBufferMemoryBytes.Valid, peakBufferMemoryBytes.Int64)
+	}
+}
+
 func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {
@@ -401,7 +450,9 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 		protocol VARCHAR,
 		trace_id VARCHAR,
 		span_id VARCHAR,
-		postgres_scan_ms BIGINT
+		postgres_scan_ms BIGINT,
+		cpu_time_s DOUBLE,
+		peak_buffer_memory_bytes BIGINT
 	)`)
 	if err != nil {
 		t.Fatalf("create table: %v", err)
@@ -409,27 +460,29 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 
 	ql := &QueryLogger{db: db}
 	ql.flushBatch([]QueryLogEntry{{
-		EventTime:       time.Unix(1700000000, 0).UTC(),
-		QueryDurationMs: 42,
-		Type:            "QueryFinish",
-		Query:           "SELECT 1",
-		QueryKind:       "Select",
-		NormalizedHash:  17,
-		ResultRows:      1,
-		UserName:        "alice",
-		OrgID:           "analytics",
-		CurrentDatabase: "analytics_db",
-		ClientAddress:   "127.0.0.1",
-		ClientPort:      5432,
-		ApplicationName: "psql",
-		PID:             99,
-		WorkerID:        7,
-		Protocol:        "simple",
-		PostgresScanMs:  123,
+		EventTime:             time.Unix(1700000000, 0).UTC(),
+		QueryDurationMs:       42,
+		Type:                  "QueryFinish",
+		Query:                 "SELECT 1",
+		QueryKind:             "Select",
+		NormalizedHash:        17,
+		ResultRows:            1,
+		UserName:              "alice",
+		OrgID:                 "analytics",
+		CurrentDatabase:       "analytics_db",
+		ClientAddress:         "127.0.0.1",
+		ClientPort:            5432,
+		ApplicationName:       "psql",
+		PID:                   99,
+		WorkerID:              7,
+		Protocol:              "simple",
+		PostgresScanMs:        123,
+		CPUTimeSeconds:        4.25,
+		PeakBufferMemoryBytes: 2048,
 	}})
 
 	var got string
-	err = db.QueryRow("SELECT org_id FROM query_log").Scan(&got)
+	err = db.QueryRow("SELECT org_id FROM query_log WHERE query = 'SELECT 1'").Scan(&got)
 	if err != nil {
 		t.Fatalf("query org_id: %v", err)
 	}
@@ -443,6 +496,18 @@ func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 	}
 	if pgScanMs != 123 {
 		t.Fatalf("expected postgres_scan_ms 123, got %d", pgScanMs)
+	}
+
+	var cpuTimeS float64
+	var peakBufferMemoryBytes int64
+	if err := db.QueryRow("SELECT cpu_time_s, peak_buffer_memory_bytes FROM query_log").Scan(&cpuTimeS, &peakBufferMemoryBytes); err != nil {
+		t.Fatalf("query resource usage columns: %v", err)
+	}
+	if cpuTimeS != 4.25 {
+		t.Fatalf("expected cpu_time_s 4.25, got %f", cpuTimeS)
+	}
+	if peakBufferMemoryBytes != 2048 {
+		t.Fatalf("expected peak_buffer_memory_bytes 2048, got %d", peakBufferMemoryBytes)
 	}
 }
 
@@ -480,37 +545,122 @@ func TestEnsureQueryLogTableAddsOrgIDToExistingTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create table: %v", err)
 	}
+	if _, err := db.Exec(`INSERT INTO query_log (event_time, query_duration_ms, type, query, user_name)
+		VALUES (?, ?, ?, ?, ?)`, time.Unix(1699999999, 0).UTC(), int64(1), "QueryFinish", "SELECT old", "bob"); err != nil {
+		t.Fatalf("insert existing row before migration: %v", err)
+	}
 
 	if err := ensureQueryLogTable(db, "", "query_log", "query_log"); err != nil {
 		t.Fatalf("ensureQueryLogTable: %v", err)
 	}
+	for _, col := range []string{"org_id", "postgres_scan_ms", "cpu_time_s", "peak_buffer_memory_bytes"} {
+		exists, err := queryLogColumnExists(db, "query_log", "", "query_log", col)
+		if err != nil {
+			t.Fatalf("inspect %s: %v", col, err)
+		}
+		if !exists {
+			t.Fatalf("expected %s column to be added", col)
+		}
+	}
+	var existingCPU sql.NullFloat64
+	var existingPeak sql.NullInt64
+	if err := db.QueryRow("SELECT cpu_time_s, peak_buffer_memory_bytes FROM query_log WHERE query = 'SELECT old'").Scan(&existingCPU, &existingPeak); err != nil {
+		t.Fatalf("query migrated existing row resource usage: %v", err)
+	}
+	if !existingCPU.Valid || existingCPU.Float64 != 0 {
+		t.Fatalf("expected migrated existing cpu_time_s 0, got valid=%t value=%f", existingCPU.Valid, existingCPU.Float64)
+	}
+	if !existingPeak.Valid || existingPeak.Int64 != 0 {
+		t.Fatalf("expected migrated existing peak_buffer_memory_bytes 0, got valid=%t value=%d", existingPeak.Valid, existingPeak.Int64)
+	}
+	if _, err := db.Exec(`INSERT INTO query_log (event_time, query_duration_ms, type, query, user_name)
+		VALUES (?, ?, ?, ?, ?)`, time.Unix(1700000001, 0).UTC(), int64(1), "QueryFinish", "SELECT legacy insert", "carol"); err != nil {
+		t.Fatalf("insert old-style row after migration: %v", err)
+	}
+	var defaultCPU sql.NullFloat64
+	var defaultPeak sql.NullInt64
+	if err := db.QueryRow("SELECT cpu_time_s, peak_buffer_memory_bytes FROM query_log WHERE query = 'SELECT legacy insert'").Scan(&defaultCPU, &defaultPeak); err != nil {
+		t.Fatalf("query old-style insert resource usage: %v", err)
+	}
+	if !defaultCPU.Valid || defaultCPU.Float64 != 0 {
+		t.Fatalf("expected old-style insert cpu_time_s default 0, got valid=%t value=%f", defaultCPU.Valid, defaultCPU.Float64)
+	}
+	if !defaultPeak.Valid || defaultPeak.Int64 != 0 {
+		t.Fatalf("expected old-style insert peak_buffer_memory_bytes default 0, got valid=%t value=%d", defaultPeak.Valid, defaultPeak.Int64)
+	}
 
 	ql := &QueryLogger{db: db}
 	ql.flushBatch([]QueryLogEntry{{
-		EventTime:       time.Unix(1700000000, 0).UTC(),
-		QueryDurationMs: 42,
-		Type:            "QueryFinish",
-		Query:           "SELECT 1",
-		QueryKind:       "Select",
-		NormalizedHash:  17,
-		ResultRows:      1,
-		UserName:        "alice",
-		OrgID:           "analytics",
-		CurrentDatabase: "analytics_db",
-		ClientAddress:   "127.0.0.1",
-		ClientPort:      5432,
-		ApplicationName: "psql",
-		PID:             99,
-		WorkerID:        7,
-		Protocol:        "simple",
+		EventTime:             time.Unix(1700000000, 0).UTC(),
+		QueryDurationMs:       42,
+		Type:                  "QueryFinish",
+		Query:                 "SELECT 1",
+		QueryKind:             "Select",
+		NormalizedHash:        17,
+		ResultRows:            1,
+		UserName:              "alice",
+		OrgID:                 "analytics",
+		CurrentDatabase:       "analytics_db",
+		ClientAddress:         "127.0.0.1",
+		ClientPort:            5432,
+		ApplicationName:       "psql",
+		PID:                   99,
+		WorkerID:              7,
+		Protocol:              "simple",
+		CPUTimeSeconds:        1.5,
+		PeakBufferMemoryBytes: 4096,
 	}})
 
 	var got string
-	err = db.QueryRow("SELECT org_id FROM query_log").Scan(&got)
+	err = db.QueryRow("SELECT org_id FROM query_log WHERE query = 'SELECT 1'").Scan(&got)
 	if err != nil {
 		t.Fatalf("query org_id: %v", err)
 	}
 	if got != "analytics" {
 		t.Fatalf("expected org_id analytics, got %q", got)
+	}
+
+	var cpuTimeS float64
+	var peakBufferMemoryBytes int64
+	if err := db.QueryRow("SELECT cpu_time_s, peak_buffer_memory_bytes FROM query_log WHERE query = 'SELECT 1'").Scan(&cpuTimeS, &peakBufferMemoryBytes); err != nil {
+		t.Fatalf("query backfilled resource usage columns: %v", err)
+	}
+	if cpuTimeS != 1.5 {
+		t.Fatalf("expected cpu_time_s 1.5, got %f", cpuTimeS)
+	}
+	if peakBufferMemoryBytes != 4096 {
+		t.Fatalf("expected peak_buffer_memory_bytes 4096, got %d", peakBufferMemoryBytes)
+	}
+}
+
+func TestLogQueryCopiesProfilingSummaryToQueryLogEntry(t *testing.T) {
+	c, ql, cleanup := newFeedbackClientConn(t)
+	defer cleanup()
+
+	c.lastProfilingSummary = observe.QueryProfilingSummary{
+		CPUTimeSeconds:        2.75,
+		PeakBufferMemoryBytes: 8192,
+		PostgresScanSeconds:   0.456,
+	}
+
+	c.logQuery(time.Unix(1700000000, 0).UTC(), "SELECT 1", "", "SELECT", 1, 0, "", "", "simple")
+
+	select {
+	case entry := <-ql.ch:
+		if entry.CPUTimeSeconds != 2.75 {
+			t.Fatalf("expected CPUTimeSeconds 2.75, got %f", entry.CPUTimeSeconds)
+		}
+		if entry.PeakBufferMemoryBytes != 8192 {
+			t.Fatalf("expected PeakBufferMemoryBytes 8192, got %d", entry.PeakBufferMemoryBytes)
+		}
+		if entry.PostgresScanMs != 456 {
+			t.Fatalf("expected PostgresScanMs 456, got %d", entry.PostgresScanMs)
+		}
+	default:
+		t.Fatal("expected query log entry")
+	}
+
+	if c.lastProfilingSummary != (observe.QueryProfilingSummary{}) {
+		t.Fatalf("expected profiling summary to be reset, got %#v", c.lastProfilingSummary)
 	}
 }


### PR DESCRIPTION
## Summary
- add `cpu_time_s` and `peak_buffer_memory_bytes` to `system.query_log`
- populate both fields from the existing DuckDB profiling summary path alongside `postgres_scan_ms`
- add query-log defaults/backfill so unavailable profiling stores `0`, not `NULL`
- emit `duckdb.cpu_time_s` on execute spans and document the new query-log fields

## Scope
This intentionally follows the existing `postgres_scan_ms` convention. It does not expand profiling coverage for COPY, simple-batch, or other paths that were not already reliably covered by the existing profiling summary flow.

## Validation
- `go test ./server -run 'TestEnsureQueryLogTable(CreatesResourceUsageColumns|AddsOrgIDToExistingTable)|Test(QueryLoggerFlushBatchPersistsOrgID|LogQueryCopiesProfilingSummaryToQueryLogEntry|EnrichSpanWithProfilingSummaryIncludesResourceUsage)'`
- `go test ./server`
- `go test ./server/observe ./server/flightclient`
- `just test-unit`
- `just lint`
- `git diff --check`
