### PR TITLE
feat(cache-proxy): emit standalone OTLP traces

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -14,6 +14,26 @@ available, and forwards cache misses to origin object storage.
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` | empty | OTLP/HTTP trace endpoint. Unset → tracing is a no-op. |
+| `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
+
+## Tracing
+
+When a trace endpoint is set the proxy exports OpenTelemetry spans under
+`service.name=duckgres-cache-proxy`. Each cacheable request is its own root span
+(`cache.get`, with `cache.origin_fetch` / `cache.peer_fetch` children); `CONNECT`
+tunnels emit `cache.connect` and non-cached methods emit `cache.forward`.
+
+These are **standalone traces** — DuckDB `httpfs` sends no `traceparent`, so they
+are deliberately **not** stitched into the duckgres query trace. Correlate to a
+query by hand on the shared attributes: `client.address` (the worker pod IP, →
+org/session via Kubernetes), the S3 object (`server.address` + `url.path` +
+`duckgres.s3.range`), span timestamp, and `cache.source` (`hit`/`peer`/`miss`).
+`org_id` is intentionally absent — the proxy has no per-request tenant identity.
+
+> The cache proxy is not deployed in the `tests/e2e-mw-dev` environment
+> (`DUCKGRES_CACHE_ENABLED` is off there), so this behavior is gated by the unit
+> test `cmd/cache-proxy/tracing_test.go`, not an e2e harness assertion.
 
 Origin `GET` misses are retried up to 4 total attempts for transient failures:
 HTTP `408`, `429`, `500`, `502`, `503`, `504`, request timeouts, and common

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -86,6 +86,11 @@ func main() {
 
 	slog.Info("Cache-proxy build info.", "version", version, "commit", commit, "built", date)
 
+	// OTLP tracing (no-op unless an OTEL/DUCKGRES trace endpoint is set).
+	// Emits standalone cache-proxy traces; flushed on shutdown.
+	shutdownTracing := initTracing()
+	defer shutdownTracing()
+
 	cacheDir := envOrDefault("CACHE_DIR", "/cache")
 	maxPercent, _ := strconv.Atoi(envOrDefault("CACHE_MAX_PERCENT", "80"))
 	listenAddr := envOrDefault("LISTEN_ADDR", ":8080")

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -12,7 +12,27 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// requestSpanAttrs returns the attributes common to every proxied request,
+// chosen to be the cross-reference anchors for correlating a cache-proxy trace
+// back to a duckgres query trace by hand: the worker pod IP (client.address),
+// the S3 object (server.address + url.path + range), and the HTTP method.
+// org_id is deliberately absent — the proxy has no per-request tenant identity;
+// map client.address → org via Kubernetes when correlating.
+func requestSpanAttrs(r *http.Request) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("http.request.method", r.Method),
+		attribute.String("server.address", r.URL.Host),
+		attribute.String("url.path", r.URL.Path),
+		attribute.String("duckgres.s3.range", r.Header.Get("Range")),
+		attribute.String("client.address", r.RemoteAddr),
+	}
+}
 
 // CacheProxy is a forward HTTP proxy that caches responses on local NVMe.
 // DuckDB httpfs sends each S3 request as a signed plain-HTTP request to the
@@ -140,8 +160,14 @@ func (p *CacheProxy) shouldCache(r *http.Request) bool {
 func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	connectStart := time.Now()
 	target := r.Host
+	_, span := proxyTracer.Start(r.Context(), "cache.connect", trace.WithAttributes(
+		attribute.String("server.address", target),
+		attribute.String("client.address", r.RemoteAddr),
+	))
 	upstream, err := net.DialTimeout("tcp", target, 10*time.Second)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
 		slog.Warn("Forward-proxy CONNECT dial failed.", "target", target, "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -149,6 +175,8 @@ func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		_ = upstream.Close()
+		span.SetStatus(codes.Error, "hijacking not supported")
+		span.End()
 		slog.Error("Forward-proxy CONNECT hijack unsupported.", "target", target)
 		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
 		return
@@ -156,6 +184,8 @@ func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	client, _, err := hijacker.Hijack()
 	if err != nil {
 		_ = upstream.Close()
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
 		slog.Warn("Forward-proxy CONNECT hijack failed.", "target", target, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -163,6 +193,8 @@ func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		_ = upstream.Close()
 		_ = client.Close()
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
 		slog.Warn("Forward-proxy CONNECT 200 write failed.", "target", target, "error", err)
 		return
 	}
@@ -194,6 +226,11 @@ func (p *CacheProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		<-upstreamDone
 		<-clientDone
+		span.SetAttributes(
+			attribute.Int64("duckgres.connect.sent_bytes", sentToUpstream),
+			attribute.Int64("duckgres.connect.recv_bytes", recvFromUpstream),
+		)
+		span.End()
 		slog.Info("Forward-proxy CONNECT closed.",
 			"target", target,
 			"sent_bytes", sentToUpstream,
@@ -247,17 +284,32 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	rangeHeader := r.Header.Get("Range")
 	cacheKey := CacheKey(r.URL.String(), rangeHeader)
 
+	// Root span for this cacheable GET. DuckDB httpfs sends no traceparent, so
+	// this starts a fresh trace (service.name=duckgres-cache-proxy). Thread its
+	// context into r so the origin/peer fetch spans nest underneath.
+	ctx, span := proxyTracer.Start(r.Context(), "cache.get", trace.WithAttributes(requestSpanAttrs(r)...))
+	defer span.End()
+	span.SetAttributes(attribute.String("duckgres.cache.key", cacheKey))
+	r = r.WithContext(ctx)
+
 	if reader, size, ok := p.store.Open(cacheKey); ok {
 		cacheBytesServed.WithLabelValues("local").Add(float64(size))
+		span.SetAttributes(
+			attribute.String("duckgres.cache.source", "hit"),
+			attribute.Bool("duckgres.cache.hit", true),
+			attribute.Int64("duckgres.bytes", size),
+		)
 		slog.Info("Served.", "source", "hit", "url", r.URL.String(), "range", rangeHeader, "bytes", size)
 		p.serveStream(w, reader, size, rangeHeader, "")
 		_ = reader.Close()
 		return
 	}
 	cacheMissesTotal.Inc()
+	span.SetAttributes(attribute.Bool("duckgres.cache.hit", false))
 
 	res, err := p.fetchDedup(cacheKey, r, rangeHeader)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		// An origin that responded with a non-2xx (e.g. S3 returning a 400 with
 		// <Code>ExpiredToken</Code> in an XML envelope) is forwarded back to
 		// DuckDB verbatim — same status code, same body, same headers minus
@@ -266,6 +318,7 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 		// raw S3 error body it knows how to parse.
 		var oe *originStatusError
 		if errors.As(err, &oe) {
+			span.SetAttributes(attribute.Int("http.response.status_code", oe.status))
 			slog.Warn("Origin returned non-2xx; forwarding verbatim.",
 				"url", r.URL.String(), "range", rangeHeader, "status", oe.status, "body_preview", previewBody(oe.body))
 			oe.writeTo(w)
@@ -291,6 +344,10 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer func() { _ = reader.Close() }()
+	span.SetAttributes(
+		attribute.String("duckgres.cache.source", res.source),
+		attribute.Int64("duckgres.bytes", size),
+	)
 	slog.Info("Served.", "source", res.source, "url", r.URL.String(), "range", rangeHeader, "bytes", size)
 	p.serveStream(w, reader, size, rangeHeader, res.contentType)
 }
@@ -301,9 +358,16 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader string) (fetchResult, error) {
 	return p.flights.Do(cacheKey, func() (fetchResult, error) {
 		if p.peers != nil {
-			if _, n, ok := p.peers.FetchFromPeers(cacheKey, func(body io.Reader) (int64, error) {
+			_, peerSpan := proxyTracer.Start(r.Context(), "cache.peer_fetch")
+			_, n, ok := p.peers.FetchFromPeers(cacheKey, func(body io.Reader) (int64, error) {
 				return p.store.PutStream(cacheKey, body)
-			}); ok {
+			})
+			peerSpan.SetAttributes(attribute.Bool("duckgres.cache.peer_hit", ok))
+			if ok {
+				peerSpan.SetAttributes(attribute.Int64("duckgres.bytes", n))
+			}
+			peerSpan.End()
+			if ok {
 				cacheBytesServed.WithLabelValues("peer").Add(float64(n))
 				return fetchResult{size: n, source: "peer"}, nil
 			}
@@ -325,6 +389,9 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 // large range reads. A non-2xx response is NOT cached — its (capped) error body
 // is captured and returned as an originStatusError for verbatim forwarding.
 func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, string, error) {
+	_, originSpan := proxyTracer.Start(r.Context(), "cache.origin_fetch")
+	defer originSpan.End()
+
 	attempts := p.originRetryMaxAttempts
 	if attempts < 1 {
 		attempts = 1
@@ -333,11 +400,18 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
 		size, contentType, err := p.fetchOriginOnce(cacheKey, r)
+		originSpan.SetAttributes(attribute.Int("duckgres.origin.attempts", attempt))
 		if err == nil {
+			originSpan.SetAttributes(attribute.Int64("duckgres.bytes", size))
 			return size, contentType, nil
 		}
 		lastErr = err
+		var oe *originStatusError
+		if errors.As(err, &oe) {
+			originSpan.SetAttributes(attribute.Int("http.response.status_code", oe.status))
+		}
 		if attempt == attempts || r.Context().Err() != nil || !isRetriableOriginFetchError(err) {
+			originSpan.SetStatus(codes.Error, err.Error())
 			return 0, "", err
 		}
 
@@ -358,6 +432,9 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 				backoff = p.originRetryMaxBackoff
 			}
 		}
+	}
+	if lastErr != nil {
+		originSpan.SetStatus(codes.Error, lastErr.Error())
 	}
 	return 0, "", lastErr
 }
@@ -557,8 +634,13 @@ func (p *CacheProxy) serveStream(w http.ResponseWriter, r io.Reader, size int64,
 // S3 rejected it. The fix is to mirror ContentLength + TransferEncoding +
 // Trailer from the inbound request so the proxy is wire-shape-transparent.
 func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
+	ctx, span := proxyTracer.Start(r.Context(), "cache.forward", trace.WithAttributes(requestSpanAttrs(r)...))
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		slog.Warn("Forward-proxy request build failed.",
 			"method", r.Method, "url", r.URL.String(), "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -581,12 +663,14 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := p.client.Do(req)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		slog.Warn("Forward-proxy origin transport failed.",
 			"method", r.Method, "url", r.URL.String(), "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
+	span.SetAttributes(attribute.Int("http.response.status_code", resp.StatusCode))
 
 	for k, vv := range resp.Header {
 		if hopByHop[strings.ToLower(k)] {
@@ -605,12 +689,14 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		w.WriteHeader(resp.StatusCode)
 		n, _ := io.Copy(w, resp.Body)
+		span.SetAttributes(attribute.Int64("duckgres.bytes", n))
 		slog.Info("Forward-proxy served.",
 			"method", r.Method, "url", r.URL.String(),
 			"status", resp.StatusCode, "bytes", n)
 		return
 	}
 
+	span.SetStatus(codes.Error, fmt.Sprintf("origin %d", resp.StatusCode))
 	body, _ := io.ReadAll(resp.Body)
 	slog.Warn("Forward-proxy origin returned non-2xx.",
 		"method", r.Method, "url", r.URL.String(),

--- a/cmd/cache-proxy/tracing.go
+++ b/cmd/cache-proxy/tracing.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// proxyTracer is the package-level tracer for cache-proxy spans. Until
+// initTracing installs a real TracerProvider it resolves to the global no-op,
+// so span calls are zero-cost when tracing is disabled.
+var proxyTracer = otel.Tracer("duckgres/cache-proxy")
+
+// initTracing configures an OTLP trace exporter when
+// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (or DUCKGRES_TRACE_ENDPOINT) is set,
+// mirroring internal/cliboot.InitTracing. We replicate it here rather than
+// import cliboot because cliboot transitively pulls in the DuckDB CGO runtime
+// (via posthog/duckgres/server), which this standalone proxy must not link.
+//
+// Cache-proxy spans are emitted as their own root traces (DuckDB httpfs sends
+// no traceparent), tagged with service.name=duckgres-cache-proxy so they're
+// distinguishable from query traces in Tempo. They are NOT stitched into the
+// query trace — cross-reference by time + s3 path + client.address (worker pod
+// IP) + node. Returns a shutdown func that flushes the batch processor.
+func initTracing() func() {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	if endpoint == "" {
+		endpoint = os.Getenv("DUCKGRES_TRACE_ENDPOINT")
+	}
+	if endpoint == "" {
+		return func() {}
+	}
+
+	ctx := context.Background()
+
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithInsecure(),
+	}
+	// VictoriaTraces uses /insert/opentelemetry/v1/traces instead of the
+	// default /v1/traces. Allow overriding via OTEL_EXPORTER_OTLP_TRACES_PATH,
+	// matching the main duckgres binary.
+	if path := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PATH"); path != "" {
+		opts = append(opts, otlptracehttp.WithURLPath(path))
+	}
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create trace exporter: %v\n", err)
+		return func() {}
+	}
+
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("duckgres-cache-proxy"),
+	)
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	proxyTracer = tp.Tracer("duckgres/cache-proxy")
+
+	fmt.Fprintf(os.Stderr, "OTEL tracing enabled, exporting to %s\n", endpoint)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = tp.Shutdown(ctx)
+		})
+	}
+}

--- a/cmd/cache-proxy/tracing_test.go
+++ b/cmd/cache-proxy/tracing_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// withSpanRecorder installs an in-memory span recorder as proxyTracer for the
+// test and returns it. Restores the previous tracer on cleanup. This is how we
+// assert cache-proxy emits its standalone traces — the cache proxy is not
+// deployed in the e2e-mw-dev environment (DUCKGRES_CACHE_ENABLED is off there),
+// so a Tempo round-trip assertion isn't possible in-Job; this unit test is the
+// gate for the tracing behavior instead.
+func withSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := proxyTracer
+	proxyTracer = tp.Tracer("duckgres/cache-proxy")
+	t.Cleanup(func() { proxyTracer = prev })
+	return sr
+}
+
+// findSpan returns the first recorded span with the given name, or fails.
+func findSpan(t *testing.T, sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range sr.Ended() {
+		if s.Name() == name {
+			return s
+		}
+	}
+	t.Fatalf("no span named %q (got %v)", name, spanNames(sr))
+	return nil
+}
+
+func spanNames(sr *tracetest.SpanRecorder) []string {
+	var names []string
+	for _, s := range sr.Ended() {
+		names = append(names, s.Name())
+	}
+	return names
+}
+
+func attrValue(s sdktrace.ReadOnlySpan, key string) (attribute.Value, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+func mustAttr(t *testing.T, s sdktrace.ReadOnlySpan, key string) attribute.Value {
+	t.Helper()
+	v, ok := attrValue(s, key)
+	if !ok {
+		t.Fatalf("span %q missing attribute %q", s.Name(), key)
+	}
+	return v
+}
+
+// TestTracingMissThenHit asserts the proxy emits a cache.get root span on a
+// cacheable GET, a nested cache.origin_fetch child on a miss (same trace, child
+// of the get span), and that source/hit attributes flip miss→hit on the
+// second request.
+func TestTracingMissThenHit(t *testing.T) {
+	sr := withSpanRecorder(t)
+	proxy := newTestProxy(t)
+
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("payload-bytes"))
+	})
+
+	// First request: cache miss → origin fetch.
+	rec := doForwardProxyRequest(proxy, http.MethodGet, originURL+"/obj", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("miss: status = %d", rec.Code)
+	}
+
+	getSpan := findSpan(t, sr, "cache.get")
+	if v := mustAttr(t, getSpan, "duckgres.cache.source"); v.AsString() != "miss" {
+		t.Errorf("miss: duckgres.cache.source = %q, want miss", v.AsString())
+	}
+	if v := mustAttr(t, getSpan, "duckgres.cache.hit"); v.AsBool() {
+		t.Errorf("miss: duckgres.cache.hit = true, want false")
+	}
+	// client.address is the cross-reference anchor back to the worker pod.
+	if _, ok := attrValue(getSpan, "client.address"); !ok {
+		t.Errorf("miss: cache.get span missing client.address")
+	}
+
+	originSpan := findSpan(t, sr, "cache.origin_fetch")
+	if originSpan.Parent().SpanID() != getSpan.SpanContext().SpanID() {
+		t.Errorf("cache.origin_fetch parent = %v, want cache.get span %v",
+			originSpan.Parent().SpanID(), getSpan.SpanContext().SpanID())
+	}
+	if originSpan.SpanContext().TraceID() != getSpan.SpanContext().TraceID() {
+		t.Errorf("cache.origin_fetch trace id differs from cache.get — not nested")
+	}
+
+	// Second request (same key): served from local cache → hit, no new fetch.
+	sr2 := withSpanRecorder(t)
+	rec = doForwardProxyRequest(proxy, http.MethodGet, originURL+"/obj", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("hit: status = %d", rec.Code)
+	}
+	hitSpan := findSpan(t, sr2, "cache.get")
+	if v := mustAttr(t, hitSpan, "duckgres.cache.source"); v.AsString() != "hit" {
+		t.Errorf("hit: duckgres.cache.source = %q, want hit", v.AsString())
+	}
+	if v := mustAttr(t, hitSpan, "duckgres.cache.hit"); !v.AsBool() {
+		t.Errorf("hit: duckgres.cache.hit = false, want true")
+	}
+	for _, s := range sr2.Ended() {
+		if s.Name() == "cache.origin_fetch" {
+			t.Errorf("hit: unexpected cache.origin_fetch span (should serve from cache)")
+		}
+	}
+}
+
+// TestTracingForwardUncached asserts non-GET (uncached) requests get a
+// cache.forward span carrying the response status.
+func TestTracingForwardUncached(t *testing.T) {
+	sr := withSpanRecorder(t)
+	proxy := newTestProxy(t)
+
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	rec := doForwardProxyRequest(proxy, http.MethodHead, originURL+"/obj", nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("forward: status = %d", rec.Code)
+	}
+
+	fwd := findSpan(t, sr, "cache.forward")
+	if v := mustAttr(t, fwd, "http.response.status_code"); v.AsInt64() != int64(http.StatusNoContent) {
+		t.Errorf("forward: status_code attr = %d, want %d", v.AsInt64(), http.StatusNoContent)
+	}
+	if v := mustAttr(t, fwd, "http.request.method"); v.AsString() != http.MethodHead {
+		t.Errorf("forward: method attr = %q, want HEAD", v.AsString())
+	}
+}


### PR DESCRIPTION
## What

Adds OpenTelemetry tracing to the `cache-proxy` so its S3 fetches are visible in Tempo.

When a trace endpoint is configured, the proxy exports spans under `service.name=duckgres-cache-proxy`:

- `cache.get` (cacheable GET) with `cache.origin_fetch` / `cache.peer_fetch` children
- `cache.connect` (CONNECT tunnels)
- `cache.forward` (non-cached methods)

## Why these are *standalone* traces (not stitched into the query trace)

DuckDB `httpfs` (C++) builds the S3 requests and sends **no `traceparent`**, so the proxy has nothing to extract. True single-trace stitching would require one of:

- per-request `traceparent` header injection through the httpfs path — only achievable at *session* granularity (via the secret), not per-query, so all queries in a session would collapse into one trace; or
- an out-of-band worker→proxy side-channel, keyed by source IP, relying on the one-session-per-worker / serial-query invariant of the remote backend.

Neither is in scope here. Instead each span carries the **cross-reference anchors** for manual correlation against a query trace:

- `client.address` — worker pod IP (→ org/session via Kubernetes)
- the S3 object — `server.address` + `url.path` + `duckgres.s3.range`
- span timestamp
- `duckgres.cache.source` (`hit`/`peer`/`miss`), `duckgres.cache.hit`, `duckgres.bytes`, `http.response.status_code`

`org_id` is intentionally absent — the proxy has no per-request tenant identity.

## Notes

- **Tracing init is replicated locally** (`cmd/cache-proxy/tracing.go`) rather than imported from `internal/cliboot`, which transitively pulls in the DuckDB CGO runtime (via `posthog/duckgres/server`) that this standalone binary must not link. Same env vars as the main binary (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_PATH`); no-op when unset.
- **Volume:** one DuckLake query issues many ranged GETs → many root traces. Init is AlwaysSample; add a sampler env knob if Tempo ingest becomes a concern.
- **Prod env wiring is out of this repo** — no manifest here deploys the proxy. The DaemonSet (mw infra repo) must set the trace endpoint for spans to flow.

## Testing

- `cmd/cache-proxy/tracing_test.go` — in-memory span recorder asserts miss→hit, child-span nesting under `cache.get`, and `cache.forward` status.
- The cache proxy is **not deployed** in `tests/e2e-mw-dev` (`DUCKGRES_CACHE_ENABLED` is off there), so this behavior is gated by the unit test rather than an e2e harness assertion — documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)