### PR TITLE
[codex] Add cache-proxy CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,22 @@ jobs:
       - name: Run unit tests
         run: just test-unit
 
+  cache-proxy-tests:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up just
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run cache-proxy tests
+        run: just test-cache-proxy
+
   integration-tests:
     needs: unit-tests
     runs-on: ubuntu-24.04-arm

--- a/justfile
+++ b/justfile
@@ -262,6 +262,11 @@ test:
 test-unit:
     go test -v -p 1 . ./configresolve/... ./duckdbservice/... ./server/... ./transpiler/... ./internal/...
 
+# Run cache-proxy tests
+[group('test')]
+test-cache-proxy:
+    go test -v ./cmd/cache-proxy/...
+
 # Run integration tests
 [group('test')]
 test-integration:
@@ -355,7 +360,7 @@ lint:
 
 # Run what CI runs locally (excluding kind-backed K8s integration)
 [group('test')]
-ci: lint test-unit test-integration test-controlplane test-configstore-integration test-controlplane-k8s
+ci: lint test-unit test-cache-proxy test-integration test-controlplane test-configstore-integration test-controlplane-k8s
 
 # === Metrics ===
 


### PR DESCRIPTION
## Summary
- add a dedicated `just test-cache-proxy` recipe for `./cmd/cache-proxy/...`
- add a separate `cache-proxy-tests` GitHub Actions job that runs the new recipe on PRs
- include `test-cache-proxy` in local `just ci` so local CI matches the workflow coverage

## Validation
- red step: `just test-cache-proxy` failed before the recipe existed
- red step: `rg -n "cache-proxy-tests|test-cache-proxy" .github/workflows/ci.yml justfile` returned no matches before the change
- `just test-cache-proxy`
- `just lint`
- `git diff --check`