### PR TITLE
[codex] add test impact plan workflow

### DIFF
--- a/.github/workflows/test-impact-plan-comment.yml
+++ b/.github/workflows/test-impact-plan-comment.yml
@@ -1,0 +1,133 @@
+name: test-impact-plan-comment
+
+on:
+  workflow_run:
+    workflows: ["test-impact-plan"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: test-impact-plan-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve pull request context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          pr_count="$(jq -r '.workflow_run.pull_requests | length' "$GITHUB_EVENT_PATH")"
+          if [ "$pr_count" != "1" ]; then
+            echo "Expected one pull request context, found $pr_count."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+          if [ -z "$pr_number" ]; then
+            echo "No pull request context found for workflow run."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_json=/tmp/test-impact-pr.json
+          gh api "repos/$REPOSITORY/pulls/$pr_number" > "$pr_json"
+          head_sha="$(jq -r '.head.sha' "$pr_json")"
+          state="$(jq -r '.state' "$pr_json")"
+          base_repo="$(jq -r '.base.repo.full_name' "$pr_json")"
+          base_ref="$(jq -r '.base.ref' "$pr_json")"
+          changed_files="$(jq -r '.changed_files' "$pr_json")"
+
+          if [ "$state" != "open" ]; then
+            echo "Skipping PR #$pr_number because it is $state."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$base_repo" != "$REPOSITORY" ] || [ "$base_ref" != "$TARGET_BRANCH" ]; then
+            echo "Skipping PR #$pr_number targeting $base_repo:$base_ref."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$head_sha" != "$RUN_HEAD_SHA" ]; then
+            echo "Skipping stale workflow run for $RUN_HEAD_SHA; current PR head is $head_sha."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "current=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "changed_files=$changed_files" >> "$GITHUB_OUTPUT"
+
+      - name: Generate test impact plan
+        if: steps.context.outputs.current == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+          CHANGED_FILES: ${{ steps.context.outputs.changed_files }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            --paginate \
+            --slurp \
+            > /tmp/test-impact-pr-files.json
+
+          python3 scripts/test_impact_plan.py \
+            --github-pr-files-json /tmp/test-impact-pr-files.json \
+            --expected-file-count "$CHANGED_FILES" \
+            --markdown-output /tmp/test-impact-plan.md \
+            --json-output /tmp/test-impact-plan.json
+
+          cat /tmp/test-impact-plan.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        if: steps.context.outputs.current == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker="<!-- test-impact-plan -->"
+          body_file=/tmp/test-impact-plan-comment.md
+          {
+            echo "$marker"
+            cat /tmp/test-impact-plan.md
+          } > "$body_file"
+
+          existing_id="$(
+            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- test-impact-plan -->"))) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$existing_id" ]; then
+            gh api "repos/$REPOSITORY/issues/comments/$existing_id" \
+              -X PATCH \
+              -F "body=@$body_file" >/dev/null
+          else
+            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+              -F "body=@$body_file" >/dev/null
+          fi

--- a/.github/workflows/test-impact-plan.yml
+++ b/.github/workflows/test-impact-plan.yml
@@ -1,0 +1,29 @@
+name: test-impact-plan
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate test impact plan
+        run: |
+          set -euo pipefail
+          python3 scripts/test_impact_plan.py \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head HEAD \
+            --markdown-output /tmp/test-impact-plan.md \
+            --json-output /tmp/test-impact-plan.json
+
+          cat /tmp/test-impact-plan.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-impact-plan.yml
+++ b/.github/workflows/test-impact-plan.yml
@@ -1,29 +1,76 @@
 name: test-impact-plan
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
   plan:
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Checkout pull request
+      # This workflow can write PR comments, so it must not checkout or execute
+      # code from the PR branch. It runs trusted base code and treats PR changes
+      # as passive API data.
+      - name: Checkout trusted base
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch pull request file data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
+            --paginate \
+            --slurp \
+            > /tmp/test-impact-pr-files.json
 
       - name: Generate test impact plan
         run: |
           set -euo pipefail
           python3 scripts/test_impact_plan.py \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD \
+            --github-pr-files-json /tmp/test-impact-pr-files.json \
             --markdown-output /tmp/test-impact-plan.md \
             --json-output /tmp/test-impact-plan.json
 
           cat /tmp/test-impact-plan.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker="<!-- test-impact-plan -->"
+          body_file=/tmp/test-impact-plan-comment.md
+          {
+            echo "$marker"
+            cat /tmp/test-impact-plan.md
+          } > "$body_file"
+
+          existing_id="$(
+            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+              --jq '.[] | select(.body | contains("<!-- test-impact-plan -->")) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$existing_id" ]; then
+            gh api "repos/$REPOSITORY/issues/comments/$existing_id" \
+              -X PATCH \
+              -F "body=@$body_file" >/dev/null
+          else
+            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+              -F "body=@$body_file" >/dev/null
+          fi

--- a/.github/workflows/test-impact-plan.yml
+++ b/.github/workflows/test-impact-plan.yml
@@ -1,76 +1,26 @@
 name: test-impact-plan
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
+
+concurrency:
+  group: test-impact-plan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  plan:
+  trigger:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     steps:
-      # This workflow can write PR comments, so it must not checkout or execute
-      # code from the PR branch. It runs trusted base code and treats PR changes
-      # as passive API data.
-      - name: Checkout trusted base
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Fetch pull request file data
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
+      - name: Record trigger
         run: |
-          set -euo pipefail
-          gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
-            --paginate \
-            --slurp \
-            > /tmp/test-impact-pr-files.json
-
-      - name: Generate test impact plan
-        run: |
-          set -euo pipefail
-          python3 scripts/test_impact_plan.py \
-            --github-pr-files-json /tmp/test-impact-pr-files.json \
-            --markdown-output /tmp/test-impact-plan.md \
-            --json-output /tmp/test-impact-plan.json
-
-          cat /tmp/test-impact-plan.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Comment on pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          marker="<!-- test-impact-plan -->"
-          body_file=/tmp/test-impact-plan-comment.md
           {
-            echo "$marker"
-            cat /tmp/test-impact-plan.md
-          } > "$body_file"
-
-          existing_id="$(
-            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
-              --jq '.[] | select(.body | contains("<!-- test-impact-plan -->")) | .id' \
-              | tail -n 1
-          )"
-
-          if [ -n "$existing_id" ]; then
-            gh api "repos/$REPOSITORY/issues/comments/$existing_id" \
-              -X PATCH \
-              -F "body=@$body_file" >/dev/null
-          else
-            gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-              -F "body=@$body_file" >/dev/null
-          fi
+            echo "## Test Impact Plan"
+            echo
+            echo "A follow-up workflow posts the sticky PR comment after this run completes."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/justfile
+++ b/justfile
@@ -288,6 +288,11 @@ test-configstore-integration:
 test-controlplane-k8s:
     go test -v -count=1 -tags kubernetes ./controlplane ./controlplane/admin ./controlplane/provisioner
 
+# Print the test impact plan for the current branch
+[group('test')]
+test-impact-plan base="origin/main" head="HEAD":
+    python3 scripts/test_impact_plan.py --base {{base}} --head {{head}}
+
 # Run Kubernetes integration tests against the default kind-backed multitenant setup
 [group('test')]
 test-k8s-integration:

--- a/scripts/test_impact_plan.py
+++ b/scripts/test_impact_plan.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a deterministic test-impact summary for a git diff.
+"""Generate a deterministic test-impact summary for a PR diff.
 
 The goal is PR review visibility, not a merge gate. The classifier is deliberately
 rule-based so reviewers can audit why a warning appeared.
@@ -71,6 +71,8 @@ class TestImpactPlan:
     workflow_jobs_removed: int = 0
     test_commands_removed: int = 0
     missing_patch_files: list[str] = field(default_factory=list)
+    expected_file_count: int | None = None
+    observed_file_count: int = 0
     warnings: list[Warning] = field(default_factory=list)
 
     @property
@@ -108,7 +110,7 @@ def is_runner_file(path: str) -> bool:
     return path == "justfile" or is_workflow_file(path)
 
 
-def parse_name_status(line: str) -> tuple[str, str] | None:
+def parse_name_status(line: str) -> tuple[str, str, str | None] | None:
     if not line.strip():
         return None
     parts = line.split("\t")
@@ -116,10 +118,10 @@ def parse_name_status(line: str) -> tuple[str, str] | None:
     if status.startswith("R") or status.startswith("C"):
         if len(parts) < 3:
             return None
-        return status[0], parts[2]
+        return status[0], parts[2], parts[1]
     if len(parts) < 2:
         return None
-    return status[0], parts[1]
+    return status[0], parts[1], None
 
 
 def add_file_delta(plan: TestImpactPlan, status: str, path: str) -> None:
@@ -152,6 +154,78 @@ def add_file_delta(plan: TestImpactPlan, status: str, path: str) -> None:
             plan.file_deltas.workflow_changed += 1
 
     if is_runner_file(path) and status != "A":
+        plan.file_deltas.runner_changed += 1
+
+
+def account_rename(
+    plan: TestImpactPlan,
+    previous_path: str,
+    path: str,
+    matcher,
+    added_attr: str,
+    changed_attr: str,
+    deleted_attr: str,
+    changed_paths: list[str] | None = None,
+    deleted_paths: list[str] | None = None,
+) -> None:
+    previous_matches = matcher(previous_path)
+    current_matches = matcher(path)
+    if not previous_matches and not current_matches:
+        return
+
+    if previous_matches and current_matches:
+        setattr(plan.file_deltas, changed_attr, getattr(plan.file_deltas, changed_attr) + 1)
+        if changed_paths is not None:
+            changed_paths.append(path)
+        return
+
+    if current_matches:
+        setattr(plan.file_deltas, added_attr, getattr(plan.file_deltas, added_attr) + 1)
+        if changed_paths is not None:
+            changed_paths.append(path)
+        return
+
+    setattr(plan.file_deltas, deleted_attr, getattr(plan.file_deltas, deleted_attr) + 1)
+    if deleted_paths is not None:
+        deleted_paths.append(previous_path)
+    if changed_paths is not None:
+        changed_paths.append(f"{previous_path} -> {path}")
+
+
+def add_rename_delta(plan: TestImpactPlan, previous_path: str, path: str) -> None:
+    account_rename(
+        plan,
+        previous_path,
+        path,
+        is_test_file,
+        "test_added",
+        "test_changed",
+        "test_deleted",
+        plan.changed_test_files,
+        plan.deleted_test_files,
+    )
+    account_rename(
+        plan,
+        previous_path,
+        path,
+        is_e2e_or_journey_file,
+        "e2e_added",
+        "e2e_changed",
+        "e2e_deleted",
+        plan.changed_e2e_files,
+    )
+    account_rename(
+        plan,
+        previous_path,
+        path,
+        is_workflow_file,
+        "workflow_added",
+        "workflow_changed",
+        "workflow_deleted",
+        plan.changed_workflow_files,
+    )
+
+    if is_runner_file(previous_path) or is_runner_file(path):
         plan.file_deltas.runner_changed += 1
 
 
@@ -208,8 +282,11 @@ def analyze_diff(name_status_lines: Iterable[str], patch_lines: Iterable[str]) -
         parsed = parse_name_status(line)
         if parsed is None:
             continue
-        status, path = parsed
-        add_file_delta(plan, status, path)
+        status, path, previous_path = parsed
+        if status == "R" and previous_path:
+            add_rename_delta(plan, previous_path, path)
+        else:
+            add_file_delta(plan, status, path)
 
     current_path = ""
     for line in patch_lines:
@@ -252,16 +329,27 @@ def github_status_to_name_status(status: str) -> str:
     }.get(status, "M")
 
 
-def analyze_github_pr_files(files_payload: object) -> TestImpactPlan:
+def analyze_github_pr_files(
+    files_payload: object,
+    expected_file_count: int | None = None,
+) -> TestImpactPlan:
     plan = TestImpactPlan()
+    plan.expected_file_count = expected_file_count
+    files = normalize_pr_files_payload(files_payload)
+    plan.observed_file_count = len(files)
 
-    for file_info in normalize_pr_files_payload(files_payload):
+    for file_info in files:
         filename = file_info.get("filename")
         if not isinstance(filename, str) or not filename:
             continue
 
-        status = github_status_to_name_status(str(file_info.get("status", "modified")))
-        add_file_delta(plan, status, filename)
+        raw_status = str(file_info.get("status", "modified"))
+        status = github_status_to_name_status(raw_status)
+        previous_filename = file_info.get("previous_filename")
+        if raw_status == "renamed" and isinstance(previous_filename, str) and previous_filename:
+            add_rename_delta(plan, previous_filename, filename)
+        else:
+            add_file_delta(plan, status, filename)
 
         patch = file_info.get("patch")
         if not isinstance(patch, str):
@@ -360,6 +448,23 @@ def add_warnings(plan: TestImpactPlan) -> None:
             )
         )
 
+    if (
+        plan.expected_file_count is not None
+        and plan.expected_file_count > plan.observed_file_count
+    ):
+        plan.warnings.append(
+            Warning(
+                title="PR file list may be incomplete",
+                severity="needs_review",
+                details=[
+                    (
+                        f"GitHub reported {plan.expected_file_count} changed file(s), "
+                        f"but {plan.observed_file_count} file record(s) were analyzed"
+                    )
+                ],
+            )
+        )
+
     if plan.changed_e2e_files and not plan.retry_lines_added:
         plan.warnings.append(
             Warning(
@@ -441,6 +546,11 @@ def main(argv: list[str] | None = None) -> int:
         "--github-pr-files-json",
         help="analyze GitHub pull request files API JSON instead of running git diff",
     )
+    parser.add_argument(
+        "--expected-file-count",
+        type=int,
+        help="warn when GitHub reports more changed files than were provided",
+    )
     parser.add_argument("--markdown-output", help="write Markdown report here")
     parser.add_argument("--json-output", help="write JSON report here")
     parser.add_argument(
@@ -452,7 +562,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.github_pr_files_json:
         with Path(args.github_pr_files_json).open() as handle:
-            plan = analyze_github_pr_files(json.load(handle))
+            plan = analyze_github_pr_files(
+                json.load(handle),
+                expected_file_count=args.expected_file_count,
+            )
     else:
         repo = Path(args.repo)
         diff_range = f"{args.base}...{args.head}"

--- a/scripts/test_impact_plan.py
+++ b/scripts/test_impact_plan.py
@@ -8,6 +8,7 @@ rule-based so reviewers can audit why a warning appeared.
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
 import re
@@ -69,6 +70,7 @@ class TestImpactPlan:
     retry_lines_added: int = 0
     workflow_jobs_removed: int = 0
     test_commands_removed: int = 0
+    missing_patch_files: list[str] = field(default_factory=list)
     warnings: list[Warning] = field(default_factory=list)
 
     @property
@@ -222,6 +224,56 @@ def analyze_diff(name_status_lines: Iterable[str], patch_lines: Iterable[str]) -
     return plan
 
 
+def normalize_pr_files_payload(payload: object) -> list[dict[str, object]]:
+    """Flatten GitHub API file payloads from a single page or gh --slurp pages."""
+    if not isinstance(payload, list):
+        raise ValueError("GitHub PR files payload must be a JSON array")
+
+    files: list[dict[str, object]] = []
+    for item in payload:
+        if isinstance(item, list):
+            files.extend(normalize_pr_files_payload(item))
+            continue
+        if not isinstance(item, dict):
+            raise ValueError("GitHub PR files payload entries must be objects")
+        files.append(item)
+    return files
+
+
+def github_status_to_name_status(status: str) -> str:
+    return {
+        "added": "A",
+        "removed": "D",
+        "modified": "M",
+        "renamed": "R",
+        "copied": "C",
+        "changed": "M",
+        "unchanged": "M",
+    }.get(status, "M")
+
+
+def analyze_github_pr_files(files_payload: object) -> TestImpactPlan:
+    plan = TestImpactPlan()
+
+    for file_info in normalize_pr_files_payload(files_payload):
+        filename = file_info.get("filename")
+        if not isinstance(filename, str) or not filename:
+            continue
+
+        status = github_status_to_name_status(str(file_info.get("status", "modified")))
+        add_file_delta(plan, status, filename)
+
+        patch = file_info.get("patch")
+        if not isinstance(patch, str):
+            plan.missing_patch_files.append(filename)
+            continue
+        for line in patch.splitlines():
+            analyze_patch_line(plan, filename, line)
+
+    add_warnings(plan)
+    return plan
+
+
 def add_warnings(plan: TestImpactPlan) -> None:
     if plan.deleted_test_files:
         plan.warnings.append(
@@ -299,6 +351,15 @@ def add_warnings(plan: TestImpactPlan) -> None:
             )
         )
 
+    if plan.missing_patch_files:
+        plan.warnings.append(
+            Warning(
+                title="Files without patch data",
+                severity="needs_review",
+                details=sorted(set(plan.missing_patch_files)),
+            )
+        )
+
     if plan.changed_e2e_files and not plan.retry_lines_added:
         plan.warnings.append(
             Warning(
@@ -309,10 +370,15 @@ def add_warnings(plan: TestImpactPlan) -> None:
         )
 
 
+def code_detail(value: str) -> str:
+    text = value.replace("\r", "\\r").replace("\n", "\\n")
+    return f"<code>{html.escape(text)}</code>"
+
+
 def bullet_list(items: Iterable[str], limit: int = 8) -> list[str]:
     values = list(items)
     visible = values[:limit]
-    bullets = [f"  - `{item}`" for item in visible]
+    bullets = [f"  - {code_detail(item)}" for item in visible]
     if len(values) > limit:
         bullets.append(f"  - ... and {len(values) - limit} more")
     return bullets
@@ -371,6 +437,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo", default=".", help="repository path")
     parser.add_argument("--base", default="origin/main", help="base ref")
     parser.add_argument("--head", default="HEAD", help="head ref")
+    parser.add_argument(
+        "--github-pr-files-json",
+        help="analyze GitHub pull request files API JSON instead of running git diff",
+    )
     parser.add_argument("--markdown-output", help="write Markdown report here")
     parser.add_argument("--json-output", help="write JSON report here")
     parser.add_argument(
@@ -380,11 +450,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    repo = Path(args.repo)
-    diff_range = f"{args.base}...{args.head}"
-    name_status = run_git(repo, ["diff", "--name-status", diff_range])
-    patch = run_git(repo, ["diff", "--unified=0", diff_range])
-    plan = analyze_diff(name_status, patch)
+    if args.github_pr_files_json:
+        with Path(args.github_pr_files_json).open() as handle:
+            plan = analyze_github_pr_files(json.load(handle))
+    else:
+        repo = Path(args.repo)
+        diff_range = f"{args.base}...{args.head}"
+        name_status = run_git(repo, ["diff", "--name-status", diff_range])
+        patch = run_git(repo, ["diff", "--unified=0", diff_range])
+        plan = analyze_diff(name_status, patch)
 
     markdown = render_markdown(plan)
     payload = json.dumps(asdict(plan), indent=2, sort_keys=True)

--- a/scripts/test_impact_plan.py
+++ b/scripts/test_impact_plan.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Generate a deterministic test-impact summary for a git diff.
+
+The goal is PR review visibility, not a merge gate. The classifier is deliberately
+rule-based so reviewers can audit why a warning appeared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+TEST_CASE_RE = re.compile(r"^\s*(func\s+Test[A-Za-z0-9_]*\s*\(|def\s+test_[A-Za-z0-9_]*\s*\()")
+ASSERTION_RE = re.compile(
+    r"(require\.|assert\.|t\.Fatalf?\(|t\.Errorf?\(|\bfail\s+\"|\|\|\s*fail\b)"
+)
+SKIP_RE = re.compile(
+    r"(t\.Skipf?\(|pytest\.mark\.skip|\.skip\(|\bSkip\s*:|knownFailures)",
+    re.IGNORECASE,
+)
+TEST_COMMAND_RE = re.compile(r"\b(go test|just test[-A-Za-z0-9_]*)\b")
+WORKFLOW_JOB_RE = re.compile(r"^\s{2}[A-Za-z0-9_-]+:\s*(#.*)?$")
+RETRY_RE = re.compile(r"\b(retry|retrying|attempt)\b", re.IGNORECASE)
+
+
+@dataclass
+class FileDeltas:
+    test_added: int = 0
+    test_changed: int = 0
+    test_deleted: int = 0
+    e2e_added: int = 0
+    e2e_changed: int = 0
+    e2e_deleted: int = 0
+    workflow_added: int = 0
+    workflow_changed: int = 0
+    workflow_deleted: int = 0
+    runner_changed: int = 0
+
+
+@dataclass
+class Warning:
+    title: str
+    severity: str
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TestImpactPlan:
+    file_deltas: FileDeltas = field(default_factory=FileDeltas)
+    changed_test_files: list[str] = field(default_factory=list)
+    deleted_test_files: list[str] = field(default_factory=list)
+    changed_e2e_files: list[str] = field(default_factory=list)
+    changed_workflow_files: list[str] = field(default_factory=list)
+    test_cases_added: int = 0
+    test_cases_removed: int = 0
+    assertions_added: int = 0
+    assertions_removed: int = 0
+    skips_added: int = 0
+    continue_on_error_added: int = 0
+    path_filters_added: int = 0
+    retry_lines_added: int = 0
+    workflow_jobs_removed: int = 0
+    test_commands_removed: int = 0
+    warnings: list[Warning] = field(default_factory=list)
+
+    @property
+    def coverage_risk(self) -> str:
+        if any(w.severity == "likely_reduced" for w in self.warnings):
+            return "likely reduced"
+        if self.warnings:
+            return "needs review"
+        return "neutral or increased"
+
+
+def is_test_file(path: str) -> bool:
+    base = os.path.basename(path)
+    return (
+        path.startswith("tests/")
+        or base.endswith("_test.go")
+        or base.endswith("_test.py")
+        or (
+            path.startswith("scripts/client-compat/")
+            and base.startswith("test_")
+            and base.endswith(".py")
+        )
+    )
+
+
+def is_e2e_or_journey_file(path: str) -> bool:
+    return path.startswith("tests/e2e-mw-dev/") or path.startswith("tests/journeys/")
+
+
+def is_workflow_file(path: str) -> bool:
+    return path.startswith(".github/workflows/")
+
+
+def is_runner_file(path: str) -> bool:
+    return path == "justfile" or is_workflow_file(path)
+
+
+def parse_name_status(line: str) -> tuple[str, str] | None:
+    if not line.strip():
+        return None
+    parts = line.split("\t")
+    status = parts[0]
+    if status.startswith("R") or status.startswith("C"):
+        if len(parts) < 3:
+            return None
+        return status[0], parts[2]
+    if len(parts) < 2:
+        return None
+    return status[0], parts[1]
+
+
+def add_file_delta(plan: TestImpactPlan, status: str, path: str) -> None:
+    if is_test_file(path):
+        plan.changed_test_files.append(path)
+        if status == "A":
+            plan.file_deltas.test_added += 1
+        elif status == "D":
+            plan.file_deltas.test_deleted += 1
+            plan.deleted_test_files.append(path)
+        else:
+            plan.file_deltas.test_changed += 1
+
+    if is_e2e_or_journey_file(path):
+        plan.changed_e2e_files.append(path)
+        if status == "A":
+            plan.file_deltas.e2e_added += 1
+        elif status == "D":
+            plan.file_deltas.e2e_deleted += 1
+        else:
+            plan.file_deltas.e2e_changed += 1
+
+    if is_workflow_file(path):
+        plan.changed_workflow_files.append(path)
+        if status == "A":
+            plan.file_deltas.workflow_added += 1
+        elif status == "D":
+            plan.file_deltas.workflow_deleted += 1
+        else:
+            plan.file_deltas.workflow_changed += 1
+
+    if is_runner_file(path) and status != "A":
+        plan.file_deltas.runner_changed += 1
+
+
+def strip_diff_marker(line: str) -> str:
+    return line[1:] if line[:1] in {"+", "-"} else line
+
+
+def analyze_patch_line(plan: TestImpactPlan, path: str, line: str) -> None:
+    if not line or line.startswith("+++") or line.startswith("---"):
+        return
+    if line[0] not in {"+", "-"}:
+        return
+
+    added = line[0] == "+"
+    content = strip_diff_marker(line)
+    if content.startswith(("+", "-")):
+        return
+
+    if TEST_CASE_RE.search(content):
+        if added:
+            plan.test_cases_added += 1
+        else:
+            plan.test_cases_removed += 1
+
+    if ASSERTION_RE.search(content):
+        if added:
+            plan.assertions_added += 1
+        else:
+            plan.assertions_removed += 1
+
+    if added and is_test_file(path) and SKIP_RE.search(content):
+        plan.skips_added += 1
+
+    if added and is_workflow_file(path) and "continue-on-error:" in content and "true" in content.lower():
+        plan.continue_on_error_added += 1
+
+    if added and is_workflow_file(path) and re.match(r"^\s*paths\s*:", content):
+        plan.path_filters_added += 1
+
+    if added and is_e2e_or_journey_file(path) and RETRY_RE.search(content):
+        plan.retry_lines_added += 1
+
+    if not added and is_workflow_file(path) and WORKFLOW_JOB_RE.match(content):
+        plan.workflow_jobs_removed += 1
+
+    if not added and path == "justfile" and TEST_COMMAND_RE.search(content):
+        plan.test_commands_removed += 1
+
+
+def analyze_diff(name_status_lines: Iterable[str], patch_lines: Iterable[str]) -> TestImpactPlan:
+    plan = TestImpactPlan()
+
+    for line in name_status_lines:
+        parsed = parse_name_status(line)
+        if parsed is None:
+            continue
+        status, path = parsed
+        add_file_delta(plan, status, path)
+
+    current_path = ""
+    for line in patch_lines:
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                current_path = parts[3][2:] if parts[3].startswith("b/") else parts[3]
+            continue
+        analyze_patch_line(plan, current_path, line)
+
+    add_warnings(plan)
+    return plan
+
+
+def add_warnings(plan: TestImpactPlan) -> None:
+    if plan.deleted_test_files:
+        plan.warnings.append(
+            Warning(
+                title="Test files deleted",
+                severity="likely_reduced",
+                details=plan.deleted_test_files,
+            )
+        )
+
+    if plan.test_cases_removed > plan.test_cases_added:
+        plan.warnings.append(
+            Warning(
+                title="Test cases removed",
+                severity="likely_reduced",
+                details=[
+                    f"{plan.test_cases_removed} removed vs {plan.test_cases_added} added"
+                ],
+            )
+        )
+
+    if plan.assertions_removed > plan.assertions_added:
+        plan.warnings.append(
+            Warning(
+                title="Assertions removed",
+                severity="needs_review",
+                details=[
+                    f"{plan.assertions_removed} removed vs {plan.assertions_added} added"
+                ],
+            )
+        )
+
+    if plan.skips_added:
+        plan.warnings.append(
+            Warning(
+                title="New skips or known failures",
+                severity="likely_reduced",
+                details=[f"{plan.skips_added} skip/allowlist line(s) added"],
+            )
+        )
+
+    ci_details = []
+    if plan.file_deltas.workflow_deleted:
+        ci_details.append(f"{plan.file_deltas.workflow_deleted} workflow file(s) deleted")
+    if plan.workflow_jobs_removed:
+        ci_details.append(f"{plan.workflow_jobs_removed} possible workflow job line(s) removed")
+    if plan.continue_on_error_added:
+        ci_details.append(f"{plan.continue_on_error_added} continue-on-error line(s) added")
+    if plan.path_filters_added:
+        ci_details.append(f"{plan.path_filters_added} workflow path filter line(s) added")
+    if ci_details:
+        plan.warnings.append(
+            Warning(
+                title="CI/test runner behavior changed",
+                severity="likely_reduced",
+                details=ci_details,
+            )
+        )
+
+    if plan.test_commands_removed:
+        plan.warnings.append(
+            Warning(
+                title="Test command removed",
+                severity="likely_reduced",
+                details=[f"{plan.test_commands_removed} test command line(s) removed from justfile"],
+            )
+        )
+
+    if plan.retry_lines_added:
+        plan.warnings.append(
+            Warning(
+                title="E2E or journey retry behavior changed",
+                severity="needs_review",
+                details=[f"{plan.retry_lines_added} retry/attempt line(s) added"],
+            )
+        )
+
+    if plan.changed_e2e_files and not plan.retry_lines_added:
+        plan.warnings.append(
+            Warning(
+                title="E2E or journey files changed",
+                severity="needs_review",
+                details=sorted(set(plan.changed_e2e_files)),
+            )
+        )
+
+
+def bullet_list(items: Iterable[str], limit: int = 8) -> list[str]:
+    values = list(items)
+    visible = values[:limit]
+    bullets = [f"  - `{item}`" for item in visible]
+    if len(values) > limit:
+        bullets.append(f"  - ... and {len(values) - limit} more")
+    return bullets
+
+
+def render_markdown(plan: TestImpactPlan) -> str:
+    lines = [
+        "## Test Impact Plan",
+        "",
+        "Deterministic summary of how this PR changes tests, CI runners, and coverage-risk signals.",
+        "",
+        "### Summary",
+        "",
+        "| Area | Added | Changed | Deleted |",
+        "|---|---:|---:|---:|",
+        f"| Test files | {plan.file_deltas.test_added} | {plan.file_deltas.test_changed} | {plan.file_deltas.test_deleted} |",
+        f"| E2E/journey files | {plan.file_deltas.e2e_added} | {plan.file_deltas.e2e_changed} | {plan.file_deltas.e2e_deleted} |",
+        f"| Workflow files | {plan.file_deltas.workflow_added} | {plan.file_deltas.workflow_changed} | {plan.file_deltas.workflow_deleted} |",
+        "",
+        "### Signals",
+        "",
+        f"- Test cases: +{plan.test_cases_added} / -{plan.test_cases_removed}",
+        f"- Assertions: +{plan.assertions_added} / -{plan.assertions_removed}",
+        f"- Skips or known failures added: {plan.skips_added}",
+        f"- Workflow `continue-on-error` added: {plan.continue_on_error_added}",
+        f"- Workflow path filters added: {plan.path_filters_added}",
+        f"- Test commands removed from `justfile`: {plan.test_commands_removed}",
+        f"- E2E/journey retry lines added: {plan.retry_lines_added}",
+        "",
+        f"**Coverage risk: {plan.coverage_risk}**",
+    ]
+
+    if plan.warnings:
+        lines.extend(["", "### Warnings", ""])
+        for warning in plan.warnings:
+            lines.append(f"- **{warning.title}** ({warning.severity.replace('_', ' ')})")
+            lines.extend(bullet_list(warning.details))
+    else:
+        lines.extend(["", "No coverage-reduction warnings detected."])
+
+    return "\n".join(lines) + "\n"
+
+
+def run_git(repo: Path, args: list[str]) -> list[str]:
+    out = subprocess.check_output(["git", "-C", str(repo), *args], text=True)
+    return out.splitlines()
+
+
+def write_text(path: str | None, content: str) -> None:
+    if path:
+        Path(path).write_text(content)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="repository path")
+    parser.add_argument("--base", default="origin/main", help="base ref")
+    parser.add_argument("--head", default="HEAD", help="head ref")
+    parser.add_argument("--markdown-output", help="write Markdown report here")
+    parser.add_argument("--json-output", help="write JSON report here")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print JSON instead of Markdown to stdout",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo)
+    diff_range = f"{args.base}...{args.head}"
+    name_status = run_git(repo, ["diff", "--name-status", diff_range])
+    patch = run_git(repo, ["diff", "--unified=0", diff_range])
+    plan = analyze_diff(name_status, patch)
+
+    markdown = render_markdown(plan)
+    payload = json.dumps(asdict(plan), indent=2, sort_keys=True)
+    write_text(args.markdown_output, markdown)
+    write_text(args.json_output, payload + "\n")
+
+    if args.json:
+        sys.stdout.write(payload + "\n")
+    else:
+        sys.stdout.write(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a deterministic test impact planner that summarizes how a PR changes test coverage signals, similar to a lightweight `tfplan` for tests.

- Adds `scripts/test_impact_plan.py` to classify test file deltas, test case/assertion deltas, added skips/known failures, workflow runner changes, path filters, `continue-on-error`, e2e retry changes, GitHub API files that lack patch data, renamed files moving into/out of test scope, and incomplete PR file-list data.
- Adds `just test-impact-plan` so developers can preview the plan for a branch.
- Adds a two-workflow comment flow that avoids `pull_request_target`:
  - `test-impact-plan` runs on `pull_request` with read-only permissions and records the trigger.
  - `test-impact-plan-comment` runs on `workflow_run`, checks out trusted default-branch code, verifies the PR context is current/open/targeting this repo, re-fetches PR metadata/files via GitHub API, runs the trusted planner, writes the job summary, and posts/updates one sticky PR comment.

## Notes

The workflow is advisory and does not block merges by itself.

The privileged comment workflow does not trust artifacts or PR-produced output. It uses `workflow_run` only as a trigger, then re-fetches PR data from GitHub and runs the planner from trusted default-branch code.

Because the `workflow_run` workflow must exist on the default branch, sticky comments will apply to future PRs after this lands.

## Validation

- Red/green acceptance check for `--github-pr-files-json`
- Red/green acceptance check for missing GitHub API patch data
- Red/green acceptance check for renamed test files moving out of test scope
- Red/green acceptance check for incomplete PR file-list warnings
- `python3 scripts/test_impact_plan.py --github-pr-files-json /tmp/duckgres-pr794-files.json --expected-file-count $(jq -r '.changed_files' /tmp/duckgres-pr794.json)`
- `python3 scripts/test_impact_plan.py --base origin/main --head HEAD`
- `PYTHONPYCACHEPREFIX=/tmp/duckgres-pycache python3 -m py_compile scripts/test_impact_plan.py`
- `ruby -e 'require "psych"; Dir[".github/workflows/test-impact-plan*.yml"].each { |p| Psych.load_file(p); puts "ok #{p}" }'`
- `git diff --cached --check`
- `just lint` in a clean temporary copy with only this branch's changes applied

Local `just lint` in the active worktree is currently blocked by an unrelated unstaged edit in `server/conn_cleanup_test.go` (`testing` import unused after a local test deletion).