### PR TITLE
fix test impact workflow PR comment permissions

### DIFF
--- a/.github/workflows/test-impact-plan-comment.yml
+++ b/.github/workflows/test-impact-plan-comment.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: test-impact-plan-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Summary

The throwaway probe PR proved that `test-impact-plan` generates the expected summary, but the follow-up `test-impact-plan-comment` workflow failed when creating the sticky PR comment with GitHub API 403.

This keeps the two-workflow setup on `pull_request` + `workflow_run`, but grants the comment workflow `pull-requests: write` so the default GitHub token can create/update the PR comment.

## Validation

- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/test-impact-plan-comment.yml"); puts "ok"'`
- `just lint`