### PR TITLE
server: classify native-fallback catalog errors with Postgres SQLSTATEs

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1261,8 +1261,16 @@ func (c *clientConn) handleQuery(body []byte) (retErr error) {
 	// Handle fallback to native DuckDB: PostgreSQL parsing failed, try DuckDB directly
 	if result.FallbackToNative {
 		if err := c.validateWithDuckDB(query); err != nil {
-			// Neither PostgreSQL nor DuckDB can parse this query
-			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
+			// validateWithDuckDB runs `EXPLAIN <query>` on DuckDB, which fails for
+			// BOTH a genuinely-unparseable query AND a parseable query that hits a
+			// real catalog/binder error (e.g. `DESCRIBE x.y.z` against a missing
+			// schema — DESCRIBE isn't valid PostgreSQL so it always lands here).
+			// Don't blanket these as 42601: classifyErrorCode unwraps the DuckDB
+			// prefix and yields the right SQLSTATE (a true Parser Error still maps
+			// to 42601, but "Catalog Error: schema … does not exist" maps to 3F000
+			// / 42P01), so postgres-protocol clients see the same error class real
+			// Postgres would and can branch on it (UndefinedTable/InvalidSchemaName).
+			c.sendError("ERROR", classifyErrorCode(err), unwrapFlightError(err.Error()))
 			_ = c.writeReadyForQuery(c.txStatus)
 			_ = c.flushWriter()
 			return nil

--- a/server/conn_errors.go
+++ b/server/conn_errors.go
@@ -163,9 +163,23 @@ func friendlyExecError(err error) string {
 func unwrapFlightError(msg string) string {
 	// gRPC puts the real message after the final "desc = ".
 	if idx := strings.LastIndex(msg, "desc = "); idx != -1 {
-		return strings.TrimSpace(msg[idx+len("desc = "):])
+		msg = msg[idx+len("desc = "):]
 	}
-	return strings.TrimSpace(msg)
+	msg = strings.TrimSpace(msg)
+	// The worker's Flight SQL ingress wraps the raw DuckDB error one more time
+	// with "failed to execute query: " / "failed to execute update: " (see
+	// server/flightsqlingress/ingress.go). That sits between "desc = " and the
+	// DuckDB exception prefix, so without stripping it the HasPrefix("Catalog
+	// Error:" …) classifiers below all miss and the error falls through to
+	// XX000. Strip any one such worker prefix so classification sees the bare
+	// DuckDB message.
+	for _, p := range []string{"failed to execute update: ", "failed to execute query: "} {
+		if strings.HasPrefix(msg, p) {
+			msg = strings.TrimSpace(msg[len(p):])
+			break
+		}
+	}
+	return msg
 }
 
 // catalogErrorCode narrows a "Catalog Error: …" message to a specific SQLSTATE

--- a/server/conn_errors_catalog_test.go
+++ b/server/conn_errors_catalog_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+// A native-fallback query that fails validation (e.g. `DESCRIBE x.y.z` against a
+// missing schema/table — DESCRIBE is not valid PostgreSQL so it always takes the
+// fallback-to-native path) used to be reported to the client as 42601
+// (syntax_error). That mislabels a runtime catalog miss as a parse failure and
+// breaks postgres-protocol clients that branch on the error class: a Dagster
+// backfill probing `DESCRIBE ducklake.posthog.events` on a fresh, empty catalog
+// caught only UndefinedTable (42P01) / InvalidSchemaName (3F000) and so never
+// took its "table absent → CREATE SCHEMA + CREATE TABLE" path.
+//
+// The fix routes the validateWithDuckDB error through classifyErrorCode (the same
+// classifier the execution path already uses), so the SQLSTATE matches what real
+// Postgres returns. These cases lock that mapping in for both the raw DuckDB
+// message and the Flight-wrapped form the control plane actually sees.
+func TestCatalogMissDescribeClassifiesLikePostgres(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "missing schema, flight-wrapped (the production DESCRIBE failure)",
+			err: errors.New("flight execute update: rpc error: code = InvalidArgument desc = failed to execute update: " +
+				`Catalog Error: Table with name "posthog.events" does not exist because schema "posthog" does not exist.`),
+			want: "3F000", // invalid_schema_name — schema clause wins, matching Postgres
+		},
+		{
+			name: "missing schema, raw",
+			err:  errors.New(`Catalog Error: schema "posthog" does not exist`),
+			want: "3F000",
+		},
+		{
+			name: "missing table on an existing schema",
+			err:  errors.New(`Catalog Error: Table with name "events" does not exist!`),
+			want: "42P01", // undefined_table
+		},
+		{
+			name: "genuine parser error still classifies as syntax_error",
+			err:  errors.New(`Parser Error: syntax error at or near "DEScRIBE"`),
+			want: "42601",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyErrorCode(tc.err); got != tc.want {
+				t.Errorf("classifyErrorCode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -594,7 +594,12 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 
 	if result.FallbackToNative {
 		if err := c.validateWithDuckDB(query); err != nil {
-			c.sendError("ERROR", "42601", fmt.Sprintf("syntax error: %v", err))
+			// Not necessarily a syntax error: a parseable native query (e.g.
+			// `DESCRIBE x.y.z`) can fail validation with a real catalog/binder
+			// error. classifyErrorCode keeps true Parser Errors at 42601 but maps
+			// "Catalog Error: schema … does not exist" to 3F000 / 42P01 so clients
+			// see the Postgres-equivalent class. See the matching site in conn.go.
+			c.sendError("ERROR", classifyErrorCode(err), unwrapFlightError(err.Error()))
 			return true, nil
 		}
 		c.logger().Debug("Fallback to native DuckDB.", "query", query)


### PR DESCRIPTION
## What

A query that isn't valid PostgreSQL but is valid DuckDB (e.g. `DESCRIBE x.y.z`) takes the fallback-to-native path, where `validateWithDuckDB` runs `EXPLAIN <query>` to check it. That `EXPLAIN` fails for **both** a genuinely unparseable query **and** a parseable one that hits a real catalog/binder error — and both call sites blanket-labelled the failure **`42601` (syntax_error)**.

So `DESCRIBE ducklake.posthog.events` against a fresh, empty catalog (no `posthog` schema yet) came back to the client as `SyntaxError` instead of the schema-missing class real Postgres returns (`3F000` invalid_schema_name).

## Why it matters

This broke the Dagster duckling events backfill. Its `table_exists()` probe runs `DESCRIBE ducklake.posthog.events` and only catches `UndefinedTable` (42P01) / `InvalidSchemaName` (3F000) as "table absent → create it":

```python
try:
    conn.execute(f"DESCRIBE {catalog}.{schema}.{table}")
    return True
except (psycopg.errors.UndefinedTable, psycopg.errors.InvalidSchemaName):
    return False
```

With the miss surfacing as `42601` → `psycopg.errors.SyntaxError`, the `except` missed, the exception propagated, and the backfill died **before** ever running `CREATE SCHEMA` / `CREATE TABLE` — so every fresh duckling could never be seeded. Production error:

> psycopg.errors.SyntaxError: syntax error: flight execute update: rpc error: code = InvalidArgument desc = failed to execute update: Catalog Error: Table with name "posthog.events" does not exist because schema "posthog" does not exist.

## Fix

1. **Both `FallbackToNative` sites** (`conn.go`, `conn_query_exec.go`) now route the `validateWithDuckDB` error through `classifyErrorCode` instead of hardcoding `42601`. A true `Parser Error:` still maps to `42601`; `Catalog Error: schema … does not exist` maps to `3F000`, a missing table to `42P01` — matching Postgres, which is exactly what `classifyErrorCode`/`catalogErrorCode` were built to do.

2. **`unwrapFlightError`** now also strips the worker's inner `failed to execute update: ` / `failed to execute query: ` prefix (added in `flightsqlingress/ingress.go`) that sits between the gRPC `desc = ` marker and the DuckDB exception prefix. Without this the `HasPrefix("Catalog Error:", …)` classifiers never matched the real production message and it fell through to `XX000` — so even after fix #1 the flight-wrapped form would have stayed misclassified. (Found by the test below failing on exactly that case.)

## Postgres alignment

| condition | real Postgres | duckgres before | duckgres after |
|---|---|---|---|
| schema does not exist | `3F000` | `42601` | `3F000` ✅ |
| table does not exist | `42P01` | `42601` | `42P01` ✅ |
| genuine parse error | `42601` | `42601` | `42601` ✅ |

## Test

`server/conn_errors_catalog_test.go` — locks in the mapping for the raw DuckDB message, the **flight-wrapped production form** (the exact string above), a missing-table case, and a genuine parser error (must stay `42601`). Full `./server/...` suite green.

## Rollout

No DAG change needed. Once the worker returns `3F000`, psycopg raises `InvalidSchemaName`, `table_exists()` returns False, and the backfill seeds the catalog as designed. After this merges + the worker image deploys, the three new mw-prod-us ducklings' backfills can be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)