### PR TITLE
provisioning: control plane owns the per-org s3bucket name

### DIFF
--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -215,6 +215,7 @@ func main() {
 		InternalSecretFallbacks:    resolved.InternalSecretFallbacks,
 		SNIRoutingMode:             resolved.SNIRoutingMode,
 		ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
+		DucklingBucketSuffix:       resolved.DucklingBucketSuffix,
 		DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
 		K8s: controlplane.K8sConfig{
 			WorkerImage:                  resolved.K8sWorkerImage,

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -131,6 +131,7 @@ type Resolved struct {
 	UserSecretKey                   string
 	SNIRoutingMode                  string
 	ManagedHostnameSuffixes         []string
+	DucklingBucketSuffix            string
 	DuckLakeDefaultSpecVersion      string
 }
 
@@ -215,6 +216,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var userSecretKey string
 	var sniRoutingMode string
 	var managedHostnameSuffixes []string
+	var ducklingBucketSuffix string
 
 	if fileCfg != nil {
 		if fileCfg.Host != "" {
@@ -787,6 +789,13 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_MANAGED_HOSTNAME_SUFFIXES"); v != "" {
 		managedHostnameSuffixes = splitAndTrim(v, ",")
 	}
+	// Env-only (set by the duckgres Helm chart per environment). The env suffix
+	// the control plane uses to name a type=s3bucket Duckling's per-org bucket:
+	// posthog-duckling-<compact-org>-<suffix>. Must equal crossplane-config's
+	// envSuffix. Empty ⇒ CP does not name buckets (composition derives).
+	if v := getenv("DUCKGRES_DUCKLING_BUCKET_SUFFIX"); v != "" {
+		ducklingBucketSuffix = v
+	}
 	if v := getenv("DUCKGRES_WORKER_BACKEND"); v != "" {
 		workerBackend = v
 	}
@@ -1242,6 +1251,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		UserSecretKey:                   userSecretKey,
 		SNIRoutingMode:                  sniRoutingMode,
 		ManagedHostnameSuffixes:         managedHostnameSuffixes,
+		DucklingBucketSuffix:            ducklingBucketSuffix,
 		DuckLakeDefaultSpecVersion:      cfg.DuckLake.SpecVersion,
 	}
 }

--- a/controlplane/configstore/bucketname.go
+++ b/controlplane/configstore/bucketname.go
@@ -1,0 +1,44 @@
+package configstore
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// canonicalUUIDRe matches a lowercase canonical UUID (8-4-4-4-12). Only these
+// get hyphen-compacted for the bucket suffix — see DucklingBucketName.
+var canonicalUUIDRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// DucklingBucketName returns the per-org S3 bucket name for a type=s3bucket
+// Duckling, mirroring the Crossplane composition's naming (charts
+// crossplane-config, PR #12206):
+//
+//	posthog-duckling-<suffix>-<envSuffix>
+//
+// where <suffix> is the lowercased duckling name (= lowercased org ID, the same
+// value the composition sees as $name) with hyphens stripped ONLY when it is a
+// canonical UUID. The strip exists because an S3 bucket name is capped at 63
+// chars and "posthog-duckling-<36-char-hyphenated-uuid>-mw-prod-us" is 64;
+// dropping the four hyphens (UUID 36 → 32) brings it to 60. Non-UUID names
+// (e.g. "ben") are left untouched so existing buckets stay byte-stable.
+//
+// This is the control plane's single source of truth for the name: it is
+// written onto the Duckling CR's spec.dataStore.bucketName and returned to API
+// callers, so nothing downstream re-derives it. The composition consumes the
+// name verbatim when present (it only falls back to deriving the same string
+// for ducklings provisioned before the CP started supplying it).
+//
+// Returns "" when envSuffix is empty — i.e. the deployment hasn't configured
+// DUCKGRES_DUCKLING_BUCKET_SUFFIX, so the CP does not name buckets and the
+// composition keeps deriving (legacy behavior).
+func DucklingBucketName(orgID, envSuffix string) string {
+	if envSuffix == "" {
+		return ""
+	}
+	suffix := strings.ToLower(orgID)
+	if canonicalUUIDRe.MatchString(suffix) {
+		suffix = strings.ReplaceAll(suffix, "-", "")
+	}
+	return fmt.Sprintf("posthog-duckling-%s-%s", suffix, envSuffix)
+}

--- a/controlplane/configstore/bucketname_test.go
+++ b/controlplane/configstore/bucketname_test.go
@@ -1,0 +1,61 @@
+package configstore
+
+import "testing"
+
+func TestDucklingBucketName(t *testing.T) {
+	cases := []struct {
+		name      string
+		orgID     string
+		envSuffix string
+		want      string
+	}{
+		{
+			name:      "canonical UUID is hyphen-compacted to fit the 63-char S3 cap",
+			orgID:     "0194d640-5db4-0000-6cde-48d6114c0f99",
+			envSuffix: "mw-prod-us",
+			want:      "posthog-duckling-0194d6405db400006cde48d6114c0f99-mw-prod-us",
+		},
+		{
+			name:      "uppercase UUID is lowercased then compacted",
+			orgID:     "0194D640-5DB4-0000-6CDE-48D6114C0F99",
+			envSuffix: "mw-prod-us",
+			want:      "posthog-duckling-0194d6405db400006cde48d6114c0f99-mw-prod-us",
+		},
+		{
+			name:      "non-UUID name keeps its hyphens (existing buckets stay stable)",
+			orgID:     "ben",
+			envSuffix: "mw-prod-us",
+			want:      "posthog-duckling-ben-mw-prod-us",
+		},
+		{
+			name:      "non-UUID name with a hyphen is NOT compacted",
+			orgID:     "perf-runner",
+			envSuffix: "mw-dev",
+			want:      "posthog-duckling-perf-runner-mw-dev",
+		},
+		{
+			name:      "empty suffix disables CP naming",
+			orgID:     "0194d640-5db4-0000-6cde-48d6114c0f99",
+			envSuffix: "",
+			want:      "",
+		},
+		{
+			name:      "63-char cap: the compacted prod-us name fits",
+			orgID:     "0194d640-5db4-0000-6cde-48d6114c0f99",
+			envSuffix: "mw-prod-us",
+			// 60 chars — guard that we stayed under the S3 limit.
+			want: "posthog-duckling-0194d6405db400006cde48d6114c0f99-mw-prod-us",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DucklingBucketName(tc.orgID, tc.envSuffix)
+			if got != tc.want {
+				t.Fatalf("DucklingBucketName(%q, %q) = %q, want %q", tc.orgID, tc.envSuffix, got, tc.want)
+			}
+			if got != "" && len(got) > 63 {
+				t.Fatalf("bucket name %q is %d chars, exceeds the S3 63-char limit", got, len(got))
+			}
+		})
+	}
+}

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -104,6 +104,16 @@ type ControlPlaneConfig struct {
 	// resolves to the same org as the managed hostname.
 	ManagedHostnameSuffixes []string
 
+	// DucklingBucketSuffix is the env suffix the control plane uses to name a
+	// type=s3bucket Duckling's per-org S3 bucket
+	// (posthog-duckling-<compact-org>-<suffix>). It MUST equal the
+	// crossplane-config chart's envSuffix for this environment so the name the
+	// CP writes onto the Duckling CR's spec.dataStore.bucketName is exactly what
+	// the composition provisions. Empty ⇒ the CP does not name buckets and the
+	// composition derives the name (legacy behavior). See
+	// configstore.DucklingBucketName.
+	DucklingBucketSuffix string
+
 	// DuckLakeDefaultSpecVersion is the global default DuckLake spec version
 	// used for migration checks when an org doesn't specify an override.
 	DuckLakeDefaultSpecVersion string

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -386,6 +386,10 @@ func SetupMultiTenant(
 	if err != nil {
 		slog.Warn("Provisioning controller unavailable.", "error", err)
 	} else {
+		// Env suffix for CP-owned s3bucket naming: drives the backfill of
+		// spec.dataStore.bucketName onto existing ready ducklings. Empty leaves
+		// it disabled (composition keeps deriving).
+		provCtrl.WithBucketSuffix(cfg.DucklingBucketSuffix)
 		// Opt-in: enable the per-org Lakekeeper provisioning branch. Off by
 		// default so existing deploys are unaffected. Best-effort — if the
 		// K8s client can't be built we log and leave the controller running
@@ -436,7 +440,7 @@ func SetupMultiTenant(
 	// Authenticated API
 	api := engine.Group("/api/v1", admin.APIAuthMiddleware(adminTokens))
 	admin.RegisterAPI(api, store, adpt)
-	provisioning.RegisterAPI(api, provisioning.NewGormStore(store))
+	provisioning.RegisterAPI(api, provisioning.NewGormStore(store), cfg.DucklingBucketSuffix)
 
 	// Dashboard
 	admin.RegisterDashboard(engine, adminTokens)

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -43,6 +43,13 @@ type Controller struct {
 	// Lakekeeper path), reconcileLakekeeper is skipped silently.
 	lakekeeperProvisioner *LakekeeperProvisioner
 	lakekeeperInputs      LakekeeperInputsResolver
+
+	// bucketSuffix is the env suffix for CP-owned s3bucket naming
+	// (DUCKGRES_DUCKLING_BUCKET_SUFFIX, e.g. "mw-prod-us"). When set, the
+	// controller backfills spec.dataStore.bucketName onto ready s3bucket
+	// ducklings that predate CP-owned naming. Empty ⇒ backfill is a no-op and
+	// the composition keeps deriving the name.
+	bucketSuffix string
 }
 
 // LakekeeperInputsResolver is the function shape the controller uses to
@@ -99,6 +106,15 @@ func (c *Controller) WithLakekeeperProvisioner(p *LakekeeperProvisioner, inputs 
 	}
 	c.lakekeeperProvisioner = p
 	c.lakekeeperInputs = inputs
+	return c
+}
+
+// WithBucketSuffix sets the env suffix used to compute and backfill the
+// CP-owned per-org s3bucket name onto existing ready ducklings. Empty leaves
+// backfill disabled (composition keeps deriving). Returns the controller for
+// chaining.
+func (c *Controller) WithBucketSuffix(suffix string) *Controller {
+	c.bucketSuffix = suffix
 	return c
 }
 
@@ -406,10 +422,71 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 		}
 	}
 
+	// Backfill the CP-owned s3bucket name onto ducklings provisioned before the
+	// control plane started supplying it (spec.dataStore carries only
+	// {type: s3bucket}). The name computed here is exactly what the composition
+	// has been deriving into status, so the patch moves it from a derived output
+	// into a durable input without changing the actual bucket. No-op once set.
+	c.reconcileBucketName(ctx, w, log)
+
 	// Lakekeeper reconcile is independent of the Duckling state machine —
 	// provisioning a Lakekeeper for an org doesn't depend on, and doesn't
 	// block, the warehouse top-level state.
 	c.reconcileLakekeeper(ctx, w)
+}
+
+// reconcileBucketName backfills spec.dataStore.bucketName (and the config-store
+// row) with the control-plane-owned per-org bucket name for ready s3bucket
+// ducklings. Idempotent and self-limiting: a no-op when no suffix is
+// configured, when the data store isn't s3bucket, or once the CR already
+// carries the (matching) name. Never overwrites a CR that already has a
+// DIFFERENT explicit name — that would be an operator-set override we must not
+// stomp.
+func (c *Controller) reconcileBucketName(ctx context.Context, w *configstore.ManagedWarehouse, log *slog.Logger) {
+	if c.bucketSuffix == "" {
+		return
+	}
+	// Empty Kind is the historical default for the s3bucket path; "external"
+	// carries its own bucket name and must be left alone.
+	if w.DataStore.Kind != "" && w.DataStore.Kind != "s3bucket" {
+		return
+	}
+	desired := configstore.DucklingBucketName(w.OrgID, c.bucketSuffix)
+	if desired == "" {
+		return
+	}
+
+	current, err := c.duckling.GetDataStoreBucketName(ctx, w.OrgID)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		log.Warn("Failed to read Duckling CR dataStore.bucketName for backfill.", "error", err)
+		return
+	}
+	if current != "" && current != desired {
+		log.Warn("Duckling CR dataStore.bucketName differs from the computed name; leaving it.",
+			"cr", current, "computed", desired)
+		return
+	}
+
+	if current == "" {
+		log.Info("Backfilling CP-owned bucket name onto Duckling CR.", "bucket", desired)
+		if err := c.duckling.SetDataStoreBucketName(ctx, w.OrgID, desired); err != nil {
+			log.Warn("Failed to patch Duckling CR dataStore.bucketName.", "error", err)
+			return
+		}
+	}
+
+	// Mirror the authoritative name onto the config-store row so the provision
+	// response and warehouse status surface it without re-deriving.
+	if w.DataStore.BucketName != desired {
+		if err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateReady, map[string]interface{}{
+			"data_store_bucket_name": desired,
+		}); err != nil {
+			log.Warn("Failed to persist dataStore bucket name to config store.", "error", err)
+		}
+	}
 }
 
 // reconcileLakekeeper provisions a per-org Lakekeeper instance when the

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -231,6 +231,14 @@ func (d *DucklingClient) Create(ctx context.Context, orgID string, opts CreateOp
 		dataStore = map[string]interface{}{"type": "external", "external": external}
 	case "", "s3bucket":
 		dataStore = map[string]interface{}{"type": "s3bucket"}
+		// When the control plane supplies the bucket name (CP-owned naming),
+		// pin it on the CR so the composition provisions exactly that bucket
+		// instead of deriving one. Empty ⇒ omit the field and let the
+		// composition derive (legacy ducklings + deployments without
+		// DUCKGRES_DUCKLING_BUCKET_SUFFIX).
+		if opts.DataStoreBucket != "" {
+			dataStore["bucketName"] = opts.DataStoreBucket
+		}
 	default:
 		return fmt.Errorf("create duckling CR %q: unsupported data store type %q", name, opts.DataStoreType)
 	}
@@ -416,6 +424,59 @@ func (d *DucklingClient) SetIcebergEnabled(ctx context.Context, orgID string, en
 	)
 	if err != nil {
 		return fmt.Errorf("patch duckling CR %q iceberg: %w", name, err)
+	}
+	return nil
+}
+
+// GetDataStoreBucketName reads spec.dataStore.bucketName from the Duckling CR.
+// Empty (missing block / missing key) means the CR predates CP-owned naming
+// and the composition is still deriving the name — the signal the backfill in
+// reconcileReady uses to decide whether to patch.
+func (d *DucklingClient) GetDataStoreBucketName(ctx context.Context, orgID string) (string, error) {
+	cr, name, err := d.getCR(ctx, orgID)
+	if err != nil {
+		return "", fmt.Errorf("get duckling CR %q: %w", name, err)
+	}
+	spec, ok := cr.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	ds, ok := spec["dataStore"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	bucket, _ := ds["bucketName"].(string)
+	return bucket, nil
+}
+
+// SetDataStoreBucketName patches spec.dataStore.bucketName on the Duckling CR.
+// JSON merge patch (RFC 7396) so it's idempotent and only touches dataStore —
+// the type field and any sibling under spec are left untouched. Used to backfill
+// the CP-owned name onto ducklings created before this field existed (their
+// spec.dataStore carries only {type: s3bucket}); the name supplied here is the
+// same string the composition was already deriving into status, so the patch
+// causes no bucket churn — it just moves the name from a derived output into a
+// durable input so the composition stops deriving.
+func (d *DucklingClient) SetDataStoreBucketName(ctx context.Context, orgID, bucket string) error {
+	_, name, err := d.getCR(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("resolve duckling CR for %q: %w", orgID, err)
+	}
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dataStore": map[string]interface{}{
+				"bucketName": bucket,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal dataStore bucket patch for %q: %w", name, err)
+	}
+	_, err = d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patch duckling CR %q dataStore bucketName: %w", name, err)
 	}
 	return nil
 }

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -57,8 +57,11 @@ type Store interface {
 }
 
 // RegisterAPI registers provisioning endpoints on the given router group.
-func RegisterAPI(r *gin.RouterGroup, store Store) {
-	h := &handler{store: store}
+// bucketSuffix is the env suffix used to compute the control-plane-owned
+// per-org s3bucket name at provision time (empty ⇒ the CP doesn't name buckets
+// and the composition derives).
+func RegisterAPI(r *gin.RouterGroup, store Store, bucketSuffix string) {
+	h := &handler{store: store, bucketSuffix: bucketSuffix}
 	r.POST("/orgs/:id/provision", h.provisionWarehouse)
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
 	r.GET("/orgs/:id/warehouse/status", h.getWarehouseStatus)
@@ -68,6 +71,10 @@ func RegisterAPI(r *gin.RouterGroup, store Store) {
 
 type handler struct {
 	store Store
+	// bucketSuffix is the env suffix (e.g. "mw-prod-us") used to compute the
+	// CP-owned s3bucket name; empty disables CP naming. See
+	// configstore.DucklingBucketName.
+	bucketSuffix string
 }
 
 // warehouseStatusResponse is the public-facing view of warehouse state.
@@ -83,6 +90,10 @@ type warehouseStatusResponse struct {
 	ReadyAt            *time.Time                                    `json:"ready_at,omitempty"`
 	FailedAt           *time.Time                                    `json:"failed_at,omitempty"`
 	Connection         *connectionDetails                            `json:"connection,omitempty"`
+	// Bucket is the authoritative per-org S3 bucket name the CP provisioned.
+	// Empty for external data stores or ducklings provisioned before CP-owned
+	// naming whose row hasn't been backfilled yet.
+	Bucket string `json:"bucket,omitempty"`
 }
 
 // connectionDetails is returned in status (without password) and in provision/reset-password (with password).
@@ -214,6 +225,17 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
+	// Control-plane-owned bucket naming: for a fresh per-org bucket (s3bucket
+	// with no caller-supplied name) compute the name here, once, and pin it on
+	// the warehouse. It flows to the Duckling CR's spec.dataStore.bucketName
+	// (so the composition provisions exactly this bucket instead of deriving
+	// one) and back to the caller in the response below — so nothing downstream
+	// re-derives the name. No-op when bucketSuffix is unset (the composition
+	// derives, legacy behavior) or when the caller passed an explicit name.
+	if ds.Kind == "s3bucket" && ds.BucketName == "" {
+		ds.BucketName = configstore.DucklingBucketName(orgID, h.bucketSuffix)
+	}
+
 	warehouse := &configstore.ManagedWarehouse{
 		DataStore: ds,
 		DuckLake:  configstore.ManagedWarehouseDuckLake{Enabled: ducklakeEnabled},
@@ -301,12 +323,19 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, gin.H{
+	resp := gin.H{
 		"status":   "provisioning started",
 		"org":      orgID,
 		"username": "root",
 		"password": plainPassword,
-	})
+	}
+	// Return the authoritative bucket name synchronously with the password, so
+	// callers persist the name the CP provisioned instead of re-deriving it.
+	// Empty (CP naming disabled, or external data store) is omitted.
+	if warehouse.DataStore.BucketName != "" {
+		resp["bucket"] = warehouse.DataStore.BucketName
+	}
+	c.JSON(http.StatusAccepted, resp)
 }
 
 func (h *handler) deprovisionWarehouse(c *gin.Context) {
@@ -358,6 +387,7 @@ func (h *handler) getWarehouseStatus(c *gin.Context) {
 		SecretsState:       warehouse.SecretsState,
 		ReadyAt:            warehouse.ReadyAt,
 		FailedAt:           warehouse.FailedAt,
+		Bucket:             warehouse.DataStore.BucketName,
 	}
 
 	if warehouse.State == configstore.ManagedWarehouseStateReady {

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -167,9 +167,13 @@ func (s *fakeStore) SetWarehouseDeleting(orgID string, expectedState configstore
 }
 
 func newTestRouter(store Store) *gin.Engine {
+	return newTestRouterWithBucketSuffix(store, "")
+}
+
+func newTestRouterWithBucketSuffix(store Store, bucketSuffix string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	RegisterAPI(r.Group("/api/v1"), store)
+	RegisterAPI(r.Group("/api/v1"), store, bucketSuffix)
 	return r
 }
 
@@ -641,6 +645,78 @@ func TestProvisionDuckLakeExternal(t *testing.T) {
 	}
 	if !w.DuckLake.Enabled || w.Iceberg.Enabled {
 		t.Errorf("ducklake-only+external: want ducklake on, iceberg off; got ducklake=%v iceberg=%v", w.DuckLake.Enabled, w.Iceberg.Enabled)
+	}
+}
+
+// When a bucket suffix is configured, a fresh per-org s3bucket gets the
+// CP-owned name pinned on the warehouse (→ Duckling CR spec.dataStore.bucketName)
+// and returned in the provision response, so callers persist it instead of
+// re-deriving. UUID org IDs are hyphen-compacted to fit the S3 63-char cap.
+func TestProvisionComputesS3BucketName(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouterWithBucketSuffix(store, "mw-prod-us")
+
+	org := "0194d640-5db4-0000-6cde-48d6114c0f99"
+	wantBucket := "posthog-duckling-0194d6405db400006cde48d6114c0f99-mw-prod-us"
+	body := []byte(`{
+		"database_name": "db",
+		"metadata_store": {"type": "cnpg-shard"},
+		"data_store": {"type": "s3bucket"},
+		"ducklake": {"enabled": true}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/"+org+"/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	w := store.warehouses[org]
+	if w == nil {
+		t.Fatal("expected warehouse to be created")
+		return
+	}
+	if w.DataStore.BucketName != wantBucket {
+		t.Errorf("warehouse DataStore.BucketName = %q, want %q", w.DataStore.BucketName, wantBucket)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["bucket"] != wantBucket {
+		t.Errorf("response bucket = %v, want %q", resp["bucket"], wantBucket)
+	}
+}
+
+// Without a configured suffix the CP doesn't name buckets — the warehouse keeps
+// an empty bucket name and the composition derives it (legacy behavior).
+func TestProvisionNoBucketSuffixLeavesNameEmpty(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store) // empty suffix
+
+	body := []byte(`{
+		"database_name": "db",
+		"metadata_store": {"type": "cnpg-shard"},
+		"data_store": {"type": "s3bucket"},
+		"ducklake": {"enabled": true}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/someorg/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if w := store.warehouses["someorg"]; w == nil || w.DataStore.BucketName != "" {
+		t.Errorf("want empty DataStore.BucketName, got %+v", w)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if _, ok := resp["bucket"]; ok {
+		t.Errorf("response should omit bucket when CP naming is disabled, got %v", resp["bucket"])
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -344,6 +344,7 @@ func main() {
 			UserSecretKey:              resolved.UserSecretKey,
 			SNIRoutingMode:             resolved.SNIRoutingMode,
 			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
+			DucklingBucketSuffix:       resolved.DucklingBucketSuffix,
 			DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
 			K8s: controlplane.K8sConfig{
 				WorkerImage:                  resolved.K8sWorkerImage,


### PR DESCRIPTION
## What

Second of three coordinated PRs (charts #12348 → **this** → posthog). Makes the duckgres control plane the **single owner** of a `type=s3bucket` Duckling's per-org bucket name, and returns it to callers synchronously at provision time.

Today the name is derived independently in three places — the Crossplane composition, the posthog Dagster backfill, and the posthog provisioning API. They've drifted: charts #12206 compacts canonical UUIDs and uses the `mw-` env suffix, but the posthog twin still emits the old hyphenated `…-prod-us` name → freshly-provisioned ducklings resolve a bucket that doesn't exist, and backfills fail.

## Changes

- **`configstore.DucklingBucketName(orgID, suffix)`** — computes the name in Go, mirroring the composition (PR #12206): `posthog-duckling-<suffix>-<env>`, hyphens stripped **only** for canonical UUIDs (S3 63-char cap). Unit-tested incl. the 63-char guard.
- **Config `DUCKGRES_DUCKLING_BUCKET_SUFFIX`** (env-only; the duckgres Helm chart in #12348 sets it to `mw-prod-us` / `mw-dev` to match crossplane-config's `envSuffix`). Empty ⇒ CP doesn't name buckets, composition keeps deriving (no behavior change).
- **Provision handler** — computes the name for a fresh s3bucket, pins it on the warehouse (→ Duckling CR `spec.dataStore.bucketName` via the existing `Create` path) and returns it in the `/provision` response alongside the password. `/warehouse/status` surfaces it too.
- **Provisioner controller** — backfills `spec.dataStore.bucketName` (and the config-store row) onto **existing ready** s3bucket ducklings whose CR predates CP-owned naming, riding the loop that already revisits ready ducklings. The name written equals what the composition was already deriving into `status`, so the patch moves it from a derived output into a durable input **with no bucket churn**. Never overwrites a CR that already carries a different explicit name.
- **k8s client** — emits `spec.dataStore.bucketName` for s3bucket when supplied; adds `Get`/`SetDataStoreBucketName` for the backfill patch (JSON merge patch, same pattern as `SetPgBouncerEnabled`/`SetIcebergEnabled`).

## How the backfill works (not Crossplane)

The Crossplane composition only reads `spec` / writes `status` — it can't backfill `spec`. The **duckgres CP's own reconcile controller** owns the CR spec (it `Create`s and `Patch`es Duckling CRs) and visits every ready warehouse each tick. So `reconcileReady` patches `spec.dataStore.bucketName` when empty; Crossplane then re-runs the composition with the populated spec and lands on the same name.

## Test plan

- [x] `configstore` — `TestDucklingBucketName` (UUID compaction, non-UUID stability, empty-suffix disable, 63-char cap).
- [x] `provisioning` — `TestProvisionComputesS3BucketName` (name pinned on warehouse + returned in response) and `TestProvisionNoBucketSuffixLeavesNameEmpty` (disabled path).
- [x] `go build ./...` and `go build -tags kubernetes ./...`; `go vet`; `go test ./controlplane/... ./configresolve/...` green under both default and `-tags kubernetes`.
- [ ] Deploy to mw-dev (charts #12348 merged first so the env var + composition consume-path are live); provision a new duckling, confirm `spec.dataStore.bucketName` set, `status.dataStore.bucketName` echoes it, `/provision` returns `bucket`, and an existing ready duckling gets backfilled.

## Depends on / pairs with

- PostHog/charts#12348 (composition consumes `spec.dataStore.bucketName` + `DUCKGRES_DUCKLING_BUCKET_SUFFIX` env wiring) — should be live before this rolls.
- Follow-up posthog PR: persist the returned `bucket` from the provision response, demote `derive_duckling_bucket` to a dead fallback.
- Final charts PR (after all specs backfilled): delete the composition's derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)