### PR TITLE
[codex] Fix Flight timestamp with time zone mapping

### DIFF
--- a/duckdbservice/arrowmap/arrowmap.go
+++ b/duckdbservice/arrowmap/arrowmap.go
@@ -97,9 +97,9 @@ func DuckDBTypeToArrow(dbType string) arrow.DataType {
 		return arrow.FixedWidthTypes.Date32
 
 	// Time
-	case "TIME":
+	case "TIME", "TIME WITHOUT TIME ZONE":
 		return arrow.FixedWidthTypes.Time64us
-	case "TIMETZ":
+	case "TIMETZ", "TIME WITH TIME ZONE":
 		// The Go driver converts TIMETZ to UTC (see duckdb-go getTimeTZ),
 		// discarding the original timezone offset before we see the value.
 		// Time64us preserves the UTC time-of-day correctly; the offset is
@@ -107,7 +107,7 @@ func DuckDBTypeToArrow(dbType string) arrow.DataType {
 		return arrow.FixedWidthTypes.Time64us
 
 	// Timestamps (no timezone → empty TimeZone string)
-	case "TIMESTAMP":
+	case "TIMESTAMP", "TIMESTAMP WITHOUT TIME ZONE":
 		return &arrow.TimestampType{Unit: arrow.Microsecond}
 	case "TIMESTAMP_S":
 		return &arrow.TimestampType{Unit: arrow.Second}
@@ -115,7 +115,7 @@ func DuckDBTypeToArrow(dbType string) arrow.DataType {
 		return &arrow.TimestampType{Unit: arrow.Millisecond}
 	case "TIMESTAMP_NS":
 		return &arrow.TimestampType{Unit: arrow.Nanosecond}
-	case "TIMESTAMPTZ":
+	case "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE":
 		return &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
 
 	// Interval

--- a/duckdbservice/arrowmap/arrowmap_test.go
+++ b/duckdbservice/arrowmap/arrowmap_test.go
@@ -83,15 +83,19 @@ func TestDuckDBTypeToArrow(t *testing.T) {
 
 		// Time
 		{"TIME", arrow.FixedWidthTypes.Time64us},
+		{"TIME WITHOUT TIME ZONE", arrow.FixedWidthTypes.Time64us},
 		{"TIMETZ", arrow.FixedWidthTypes.Time64us},
+		{"TIME WITH TIME ZONE", arrow.FixedWidthTypes.Time64us},
 
 		// Timestamps — plain TIMESTAMP must NOT have timezone
 		{"TIMESTAMP", &arrow.TimestampType{Unit: arrow.Microsecond}},
+		{"TIMESTAMP WITHOUT TIME ZONE", &arrow.TimestampType{Unit: arrow.Microsecond}},
 		{"TIMESTAMP_S", &arrow.TimestampType{Unit: arrow.Second}},
 		{"TIMESTAMP_MS", &arrow.TimestampType{Unit: arrow.Millisecond}},
 		{"TIMESTAMP_NS", &arrow.TimestampType{Unit: arrow.Nanosecond}},
 		// TIMESTAMPTZ must have UTC timezone
 		{"TIMESTAMPTZ", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}},
+		{"TIMESTAMP WITH TIME ZONE", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}},
 
 		// Interval
 		{"INTERVAL", arrow.FixedWidthTypes.MonthDayNanoInterval},


### PR DESCRIPTION
## Summary

Fix Flight SQL Arrow type inference for DuckDB/PostgreSQL long-form temporal type names.

Duckgres already mapped `TIMESTAMPTZ` and `TIMETZ`, but `database/sql` can return the standard names `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITHOUT TIME ZONE`, `TIME WITH TIME ZONE`, and `TIME WITHOUT TIME ZONE` from `ColumnTypes().DatabaseTypeName()`. Those long forms previously fell through to Arrow string.

## Root Cause

DuckHog uses Flight metadata/schema to bind remote scans. For `billing_public.billing_price`, Flight metadata exposed timestamp columns as `varchar` even though the runtime values are `TIMESTAMP WITH TIME ZONE`. DuckDB then used the metadata string type while reading timestamp Arrow buffers and crashed in `SetVectorString<unsigned int>` during Arrow conversion.

Reproduced before the fix with both cached/community DuckHog and local DuckHog:

- `/opt/homebrew/bin/duckdb` + cached `duckhog`: exit 139
- local `./build/release/duckdb -unsigned` + local `duckhog.duckdb_extension`: exit 138

The crashing stack was in DuckDB Arrow conversion under `ArrowTableFunction::ArrowScanFunction`.

## Changes

- Map long-form time/timestamp type names to the same Arrow types as their DuckDB shorthand aliases.
- Add mapper regression coverage for the long-form names.

## Tests

- `go test ./duckdbservice/arrowmap`
- `go test ./duckdbservice`
