### PR TITLE
Add Kafka query log sink foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ and profiling-derived resource usage. `cpu_time_s` is DuckDB cumulative
 CPU/thread time in seconds, and `peak_buffer_memory_bytes` is DuckDB's
 `system_peak_buffer_memory` in bytes, not process RSS.
 
+The default `query_log.sink` is `ducklake`, which writes directly to
+`ducklake.system.query_log`. Set `query_log.sink: kafka` to publish JSON query
+log events to Kafka instead; the Kafka message key is `org_id`, and each
+payload includes `schema_version`, `event_id`, and `emitted_at` for downstream
+deduplication and schema handling. Kafka mode requires `brokers` and `topic`.
+
 ```sql
 SELECT event_time, user_name, org_id, query_duration_ms, cpu_time_s,
        peak_buffer_memory_bytes, postgres_scan_ms, query
@@ -207,6 +213,20 @@ rate_limit:
   failed_attempt_window: "5m"
   ban_duration: "15m"
   max_connections_per_ip: 100
+
+query_log:
+  enabled: true
+  # Default: ducklake. Set to kafka to publish per-query events for an
+  # external query-log writer.
+  sink: ducklake
+  flush_interval: "5s"
+  batch_size: 1000
+  kafka:
+    brokers:
+      - "redpanda:9092"
+    topic: "duckgres_query_log"
+    # Default: duckgres-query-log
+    client_id: "duckgres-query-log"
 ```
 
 Run with config file:
@@ -244,6 +264,11 @@ Run with config file:
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` | Attach a Delta Lake catalog/table during worker boot/activation | `false` |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH` | Delta Lake catalog/table path; defaults to sibling `delta/` prefix at the DuckLake object-store root when enabled | Derived |
+| `DUCKGRES_QUERY_LOG_ENABLED` | Enable per-query logging | `true` |
+| `DUCKGRES_QUERY_LOG_SINK` | Query-log destination: `ducklake` writes `ducklake.system.query_log`; `kafka` publishes JSON events | `ducklake` |
+| `DUCKGRES_QUERY_LOG_KAFKA_BROKERS` | Comma-separated Kafka bootstrap brokers used when `DUCKGRES_QUERY_LOG_SINK=kafka` | - |
+| `DUCKGRES_QUERY_LOG_KAFKA_TOPIC` | Kafka topic for query-log events; required for Kafka mode | - |
+| `DUCKGRES_QUERY_LOG_KAFKA_CLIENT_ID` | Kafka client ID used by the query-log producer | `duckgres-query-log` |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events** | - |
 | `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |

--- a/configloader/file_config.go
+++ b/configloader/file_config.go
@@ -68,11 +68,19 @@ type K8sFileConfig struct {
 }
 
 type QueryLogFileConfig struct {
-	Enabled              *bool  `yaml:"enabled"`
-	FlushInterval        string `yaml:"flush_interval"`
-	BatchSize            int    `yaml:"batch_size"`
-	CompactInterval      string `yaml:"compact_interval"`
-	DataInliningRowLimit int    `yaml:"data_inlining_row_limit"`
+	Enabled              *bool                   `yaml:"enabled"`
+	Sink                 string                  `yaml:"sink"`
+	FlushInterval        string                  `yaml:"flush_interval"`
+	BatchSize            int                     `yaml:"batch_size"`
+	CompactInterval      string                  `yaml:"compact_interval"`
+	DataInliningRowLimit int                     `yaml:"data_inlining_row_limit"`
+	Kafka                QueryLogKafkaFileConfig `yaml:"kafka"`
+}
+
+type QueryLogKafkaFileConfig struct {
+	Brokers  []string `yaml:"brokers"`
+	Topic    string   `yaml:"topic"`
+	ClientID string   `yaml:"client_id"`
 }
 
 type TLSConfig struct {

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -122,7 +122,7 @@ type Resolved struct {
 	K8sWorkerProfileMinMemory       string
 	K8sWorkerProfileMaxMemory       string
 	K8sWorkerMaxTTL                 time.Duration
-	K8sWorkerDefaultTTL                   time.Duration
+	K8sWorkerDefaultTTL             time.Duration
 	AWSRegion                       string
 	ConfigStoreConn                 string
 	ConfigPollInterval              time.Duration
@@ -163,10 +163,14 @@ func DefaultServerConfig() server.Config {
 		},
 		QueryLog: server.QueryLogConfig{
 			Enabled:              true,
+			Sink:                 server.QueryLogSinkDuckLake,
 			FlushInterval:        5 * time.Second,
 			BatchSize:            1000,
 			CompactInterval:      10 * time.Minute,
 			DataInliningRowLimit: 1000,
+			Kafka: server.QueryLogKafkaConfig{
+				ClientID: "duckgres-query-log",
+			},
 		},
 	}
 }
@@ -433,6 +437,9 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		if fileCfg.QueryLog.Enabled != nil {
 			cfg.QueryLog.Enabled = *fileCfg.QueryLog.Enabled
 		}
+		if fileCfg.QueryLog.Sink != "" {
+			cfg.QueryLog.Sink = fileCfg.QueryLog.Sink
+		}
 		if fileCfg.QueryLog.FlushInterval != "" {
 			if d, err := time.ParseDuration(fileCfg.QueryLog.FlushInterval); err == nil {
 				cfg.QueryLog.FlushInterval = d
@@ -452,6 +459,15 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		}
 		if fileCfg.QueryLog.DataInliningRowLimit > 0 {
 			cfg.QueryLog.DataInliningRowLimit = fileCfg.QueryLog.DataInliningRowLimit
+		}
+		if len(fileCfg.QueryLog.Kafka.Brokers) > 0 {
+			cfg.QueryLog.Kafka.Brokers = append([]string(nil), fileCfg.QueryLog.Kafka.Brokers...)
+		}
+		if fileCfg.QueryLog.Kafka.Topic != "" {
+			cfg.QueryLog.Kafka.Topic = fileCfg.QueryLog.Kafka.Topic
+		}
+		if fileCfg.QueryLog.Kafka.ClientID != "" {
+			cfg.QueryLog.Kafka.ClientID = fileCfg.QueryLog.Kafka.ClientID
 		}
 
 		if fileCfg.TLS.ACME.Domain != "" {
@@ -911,6 +927,9 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 			warn("Invalid DUCKGRES_QUERY_LOG_ENABLED: " + err.Error())
 		}
 	}
+	if v := getenv("DUCKGRES_QUERY_LOG_SINK"); v != "" {
+		cfg.QueryLog.Sink = v
+	}
 	if v := getenv("DUCKGRES_QUERY_LOG_FLUSH_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			cfg.QueryLog.FlushInterval = d
@@ -938,6 +957,15 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		} else {
 			warn("Invalid DUCKGRES_QUERY_LOG_DATA_INLINING_ROW_LIMIT: " + err.Error())
 		}
+	}
+	if v := getenv("DUCKGRES_QUERY_LOG_KAFKA_BROKERS"); v != "" {
+		cfg.QueryLog.Kafka.Brokers = splitAndTrim(v, ",")
+	}
+	if v := getenv("DUCKGRES_QUERY_LOG_KAFKA_TOPIC"); v != "" {
+		cfg.QueryLog.Kafka.Topic = v
+	}
+	if v := getenv("DUCKGRES_QUERY_LOG_KAFKA_CLIENT_ID"); v != "" {
+		cfg.QueryLog.Kafka.ClientID = v
 	}
 
 	if cli.Set["host"] {
@@ -1196,6 +1224,14 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		warn("DUCKGRES_QUERY_LOG_FLUSH_INTERVAL must be > 0; using default")
 		cfg.QueryLog.FlushInterval = defaultQueryLog.FlushInterval
 	}
+	cfg.QueryLog.Sink = strings.ToLower(strings.TrimSpace(cfg.QueryLog.Sink))
+	if cfg.QueryLog.Sink == "" {
+		cfg.QueryLog.Sink = defaultQueryLog.Sink
+	}
+	if cfg.QueryLog.Sink != server.QueryLogSinkDuckLake && cfg.QueryLog.Sink != server.QueryLogSinkKafka {
+		warn("DUCKGRES_QUERY_LOG_SINK must be ducklake or kafka; using default")
+		cfg.QueryLog.Sink = defaultQueryLog.Sink
+	}
 	if cfg.QueryLog.BatchSize <= 0 {
 		warn("DUCKGRES_QUERY_LOG_BATCH_SIZE must be > 0; using default")
 		cfg.QueryLog.BatchSize = defaultQueryLog.BatchSize
@@ -1242,7 +1278,7 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		K8sWorkerProfileMinMemory:       k8sWorkerProfileMinMemory,
 		K8sWorkerProfileMaxMemory:       k8sWorkerProfileMaxMemory,
 		K8sWorkerMaxTTL:                 k8sWorkerMaxTTL,
-		K8sWorkerDefaultTTL:                   k8sWorkerDefaultTTL,
+		K8sWorkerDefaultTTL:             k8sWorkerDefaultTTL,
 		AWSRegion:                       awsRegion,
 		ConfigStoreConn:                 configStoreConn,
 		ConfigPollInterval:              configPollInterval,

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -451,10 +451,10 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	server.InitMinimalServer(srv, cfg.Config, nil)
 
 	// Initialize query logger (non-fatal on error)
-	if ql, err := server.NewQueryLogger(cfg.Config); err != nil {
+	if sink, err := server.NewQueryLogSink(cfg.Config); err != nil {
 		slog.Warn("Failed to initialize query log, continuing without it.", "error", err)
-	} else if ql != nil {
-		server.SetQueryLogger(srv, ql)
+	} else if sink != nil {
+		server.SetQueryLogSink(srv, sink)
 	}
 
 	cp := &ControlPlane{
@@ -1071,7 +1071,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	}
 	if orgProfileApplied && workerProfile != nil {
 		// Once per connection so support can see which shape a tenant got.
-		clog.Info("Applied org default worker profile.", 			"cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
+		clog.Info("Applied org default worker profile.", "cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
 	}
 
 	// Resolve the session manager and rebalancer for this connection.
@@ -1693,8 +1693,16 @@ func (cp *ControlPlane) healthReady() bool {
 }
 
 func (cp *ControlPlane) stopQueryLogger() {
-	if cp.srv != nil && cp.srv.QueryLogger() != nil {
-		cp.srv.QueryLogger().Stop()
+	if cp.srv != nil {
+		timeout := cp.cfg.ShutdownTimeout
+		if timeout <= 0 {
+			timeout = 30 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if err := cp.srv.StopQueryLogging(ctx); err != nil {
+			slog.Warn("Query log shutdown deadline exceeded.", "error", err)
+		}
 	}
 }
 

--- a/controlplane/control_test.go
+++ b/controlplane/control_test.go
@@ -3,9 +3,11 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/binary"
 	"io"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +21,35 @@ type remoteAddrConn struct {
 
 func (c remoteAddrConn) RemoteAddr() net.Addr {
 	return c.remote
+}
+
+type fakeControlPlaneQueryLogSink struct {
+	stops atomic.Int32
+}
+
+func (s *fakeControlPlaneQueryLogSink) Log(server.QueryLogEntry) {}
+
+func (s *fakeControlPlaneQueryLogSink) Stop() {
+	s.stops.Add(1)
+}
+
+func (s *fakeControlPlaneQueryLogSink) StopContext(context.Context) error {
+	s.Stop()
+	return nil
+}
+
+func TestStopQueryLoggerStopsGenericQueryLogSink(t *testing.T) {
+	srv := &server.Server{}
+	server.InitMinimalServer(srv, server.Config{}, nil)
+	sink := &fakeControlPlaneQueryLogSink{}
+	server.SetQueryLogSink(srv, sink)
+
+	cp := &ControlPlane{srv: srv}
+	cp.stopQueryLogger()
+
+	if got := sink.stops.Load(); got != 1 {
+		t.Fatalf("expected generic query log sink to stop once, got %d", got)
+	}
 }
 
 func TestReadStartupFromRaw_SSLRequest(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/duckdb/duckdb-go-bindings v0.10503.0
 	github.com/duckdb/duckdb-go/v2 v2.10503.0
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.10.9
 	github.com/pganalyze/pg_query_go/v6 v6.1.0
@@ -20,6 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
+	github.com/segmentio/kafka-go v0.4.51
 	go.opentelemetry.io/contrib/bridges/otelslog v0.15.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0
 	go.opentelemetry.io/otel v1.43.0
@@ -83,7 +85,6 @@ require (
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/segmentio/kafka-go v0.4.51 h1:JgDPPG75tC1rWIS2Me6MwcvXJ6f49UQ4HjAOef71Hno=
+github.com/segmentio/kafka-go v0.4.51/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
@@ -245,6 +247,12 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
+github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.2.0 h1:bYKF2AEwG5rqd1BumT4gAnvwU/M9nBp2pTSxeZw7Wvs=
+github.com/xdg-go/scram v1.2.0/go.mod h1:3dlrS0iBaWKYVt2ZfA4cj48umJZ+cAEbR6/SjLA88I8=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/main.go
+++ b/main.go
@@ -30,14 +30,15 @@ type FileConfig = configloader.FileConfig
 // the configloader. prefix on every line. The actual resolver now lives in
 // the configresolve package and takes *configloader.FileConfig directly.
 type (
-	ProcessFileConfig   = configloader.ProcessFileConfig
-	K8sFileConfig       = configloader.K8sFileConfig
-	QueryLogFileConfig  = configloader.QueryLogFileConfig
-	TLSConfig           = configloader.TLSConfig
-	ACMEConfig          = configloader.ACMEConfig
-	RateLimitFileConfig = configloader.RateLimitFileConfig
-	DuckLakeFileConfig  = configloader.DuckLakeFileConfig
-	IcebergFileConfig   = configloader.IcebergFileConfig
+	ProcessFileConfig       = configloader.ProcessFileConfig
+	K8sFileConfig           = configloader.K8sFileConfig
+	QueryLogFileConfig      = configloader.QueryLogFileConfig
+	QueryLogKafkaFileConfig = configloader.QueryLogKafkaFileConfig
+	TLSConfig               = configloader.TLSConfig
+	ACMEConfig              = configloader.ACMEConfig
+	RateLimitFileConfig     = configloader.RateLimitFileConfig
+	DuckLakeFileConfig      = configloader.DuckLakeFileConfig
+	IcebergFileConfig       = configloader.IcebergFileConfig
 )
 
 // loadConfigFile + env are thin wrappers around configloader for back-compat
@@ -374,7 +375,7 @@ func main() {
 				WorkerProfileMinMemory:       resolved.K8sWorkerProfileMinMemory,
 				WorkerProfileMaxMemory:       resolved.K8sWorkerProfileMaxMemory,
 				WorkerMaxTTL:                 resolved.K8sWorkerMaxTTL,
-				WorkerDefaultTTL:                   resolved.K8sWorkerDefaultTTL,
+				WorkerDefaultTTL:             resolved.K8sWorkerDefaultTTL,
 				AWSRegion:                    resolved.AWSRegion,
 			},
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -366,6 +366,40 @@ func TestResolveEffectiveConfigInvalidQueryLogEnvValues(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveConfigQueryLogKafka(t *testing.T) {
+	fileCfg := &FileConfig{
+		QueryLog: QueryLogFileConfig{
+			Sink: "ducklake",
+			Kafka: QueryLogKafkaFileConfig{
+				Brokers:  []string{"file-a:9092"},
+				Topic:    "file-topic",
+				ClientID: "file-client",
+			},
+		},
+	}
+
+	env := map[string]string{
+		"DUCKGRES_QUERY_LOG_SINK":            "kafka",
+		"DUCKGRES_QUERY_LOG_KAFKA_BROKERS":   "env-a:9092, env-b:9092",
+		"DUCKGRES_QUERY_LOG_KAFKA_TOPIC":     "env-topic",
+		"DUCKGRES_QUERY_LOG_KAFKA_CLIENT_ID": "env-client",
+	}
+
+	resolved := configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{}, envFromMap(env), nil)
+	if got, want := resolved.Server.QueryLog.Sink, "kafka"; got != want {
+		t.Fatalf("query log sink mismatch: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(resolved.Server.QueryLog.Kafka.Brokers, ","), "env-a:9092,env-b:9092"; got != want {
+		t.Fatalf("query log kafka brokers mismatch: got %q want %q", got, want)
+	}
+	if got, want := resolved.Server.QueryLog.Kafka.Topic, "env-topic"; got != want {
+		t.Fatalf("query log kafka topic mismatch: got %q want %q", got, want)
+	}
+	if got, want := resolved.Server.QueryLog.Kafka.ClientID, "env-client"; got != want {
+		t.Fatalf("query log kafka client_id mismatch: got %q want %q", got, want)
+	}
+}
+
 func TestResolveEffectiveConfigQueryLogCLIOverride(t *testing.T) {
 	fileCfg := &FileConfig{}
 

--- a/server/exports.go
+++ b/server/exports.go
@@ -169,6 +169,38 @@ var GenerateSecretKey = wire.GenerateSecretKey
 // to attach a query logger to the minimal server after creation.
 func SetQueryLogger(s *Server, ql *QueryLogger) {
 	s.queryLogger = ql
+	s.queryLogSink = ql
+}
+
+// SetQueryLogSink sets the active query-log sink on a Server.
+func SetQueryLogSink(s *Server, sink QueryLogSink) {
+	s.queryLogSink = sink
+	if ql, ok := sink.(*QueryLogger); ok {
+		s.queryLogger = ql
+	} else {
+		s.queryLogger = nil
+	}
+}
+
+// StopQueryLogging drains and stops the active query-log sink, if any.
+func (s *Server) StopQueryLogging(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	ctx, cancel := queryLogStopContext(ctx, 30*time.Second)
+	defer cancel()
+	if s.queryLogSink != nil {
+		err := s.queryLogSink.StopContext(ctx)
+		s.queryLogSink = nil
+		s.queryLogger = nil
+		return err
+	}
+	if s.queryLogger != nil {
+		err := s.queryLogger.StopContext(ctx)
+		s.queryLogger = nil
+		return err
+	}
+	return nil
 }
 
 // SetUserSecretManager installs the per-user persistent secret manager on a

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -67,10 +68,43 @@ type QueryLogger struct {
 	stopOnce sync.Once
 }
 
+// QueryLogSink accepts query log entries and drains them during shutdown.
+type QueryLogSink interface {
+	Log(QueryLogEntry)
+	StopContext(context.Context) error
+}
+
 const (
 	queryLogChannelSize = 10000
 	maxQueryLength      = 4096
+
+	QueryLogSinkDuckLake = "ducklake"
+	QueryLogSinkKafka    = "kafka"
 )
+
+// NewQueryLogSink creates the configured query-log sink. The default sink is
+// the historical DuckLake-backed system.query_log table.
+func NewQueryLogSink(cfg Config) (QueryLogSink, error) {
+	if !cfg.QueryLog.Enabled {
+		return nil, nil
+	}
+	sink := strings.TrimSpace(strings.ToLower(cfg.QueryLog.Sink))
+	if sink == "" {
+		sink = QueryLogSinkDuckLake
+	}
+	switch sink {
+	case QueryLogSinkDuckLake:
+		ql, err := NewQueryLogger(cfg)
+		if ql == nil {
+			return nil, err
+		}
+		return ql, err
+	case QueryLogSinkKafka:
+		return NewKafkaQueryLogSink(cfg.QueryLog)
+	default:
+		return nil, fmt.Errorf("querylog: unsupported sink %q", cfg.QueryLog.Sink)
+	}
+}
 
 // NewQueryLogger opens a dedicated :memory: DuckDB, attaches DuckLake,
 // creates the system.query_log table, and starts the background flush goroutine.
@@ -159,6 +193,14 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 
 // Log sends an entry to the query log. Non-blocking; drops if channel is full.
 func (ql *QueryLogger) Log(entry QueryLogEntry) {
+	if ql == nil || ql.ch == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("querylog: logger stopped while writing entry; dropping entry.")
+		}
+	}()
 	select {
 	case ql.ch <- entry:
 	default:
@@ -168,20 +210,35 @@ func (ql *QueryLogger) Log(entry QueryLogEntry) {
 
 // Stop drains remaining entries and shuts down the flush goroutine.
 func (ql *QueryLogger) Stop() {
+	_ = ql.StopContext(context.Background())
+}
+
+// StopContext drains remaining entries until ctx expires, then closes the DB to
+// unblock any in-flight flush.
+func (ql *QueryLogger) StopContext(ctx context.Context) error {
 	if ql == nil {
-		return
+		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var stopErr error
 	ql.stopOnce.Do(func() {
 		if ql.ch != nil {
 			close(ql.ch)
 		}
 		if ql.done != nil {
-			<-ql.done
+			select {
+			case <-ql.done:
+			case <-ctx.Done():
+				stopErr = ctx.Err()
+			}
 		}
 		if ql.db != nil {
 			_ = ql.db.Close()
 		}
 	})
+	return stopErr
 }
 
 func (ql *QueryLogger) flushLoop() {
@@ -509,7 +566,13 @@ func isQueryLogSelfReferential(query string) bool {
 func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType string,
 	resultRows, writtenRows int64, errCode, errMsg, protocol string) {
 
-	ql := c.server.queryLogger
+	var ql QueryLogSink
+	if c.server.queryLogSink != nil {
+		ql = c.server.queryLogSink
+	}
+	if ql == nil && c.server.queryLogger != nil {
+		ql = c.server.queryLogger
+	}
 	if ql == nil {
 		return
 	}

--- a/server/querylog_kafka.go
+++ b/server/querylog_kafka.go
@@ -1,0 +1,407 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	kafka "github.com/segmentio/kafka-go"
+)
+
+const (
+	queryLogKafkaSchemaVersion         = 1
+	defaultQueryLogKafkaPublishTimeout = 30 * time.Second
+)
+
+// QueryLogKafkaEvent is the stable JSON payload written to Kafka. It mirrors
+// system.query_log columns and adds an event envelope for distributed delivery.
+type QueryLogKafkaEvent struct {
+	SchemaVersion         int       `json:"schema_version"`
+	EventID               string    `json:"event_id"`
+	EmittedAt             time.Time `json:"emitted_at"`
+	EventTime             time.Time `json:"event_time"`
+	QueryDurationMs       int64     `json:"query_duration_ms"`
+	Type                  string    `json:"type"`
+	Query                 string    `json:"query"`
+	TranspiledQuery       *string   `json:"transpiled_query"`
+	QueryKind             string    `json:"query_kind"`
+	NormalizedHash        int64     `json:"normalized_query_hash"`
+	ResultRows            int64     `json:"result_rows"`
+	WrittenRows           int64     `json:"written_rows"`
+	ExceptionCode         string    `json:"exception_code"`
+	Exception             string    `json:"exception"`
+	UserName              string    `json:"user_name"`
+	OrgID                 string    `json:"org_id"`
+	CurrentDatabase       string    `json:"current_database"`
+	ClientAddress         string    `json:"client_address"`
+	ClientPort            int       `json:"client_port"`
+	ApplicationName       string    `json:"application_name"`
+	PID                   int32     `json:"pid"`
+	WorkerID              int       `json:"worker_id"`
+	IsTranspiled          bool      `json:"is_transpiled"`
+	Protocol              string    `json:"protocol"`
+	TraceID               string    `json:"trace_id"`
+	SpanID                string    `json:"span_id"`
+	PostgresScanMs        int64     `json:"postgres_scan_ms"`
+	CPUTimeSeconds        float64   `json:"cpu_time_s"`
+	PeakBufferMemoryBytes int64     `json:"peak_buffer_memory_bytes"`
+}
+
+type queryLogKafkaMessage struct {
+	Topic string
+	Key   []byte
+	Value []byte
+}
+
+type queryLogKafkaProducer interface {
+	WriteMessages(context.Context, ...queryLogKafkaMessage) error
+	Close() error
+}
+
+// KafkaQueryLogSink batches query-log entries and publishes them to Kafka.
+type KafkaQueryLogSink struct {
+	cfg            QueryLogConfig
+	producer       queryLogKafkaProducer
+	ch             chan QueryLogEntry
+	done           chan struct{}
+	stopOnce       sync.Once
+	stopMu         sync.RWMutex
+	stopCtx        context.Context
+	publishTimeout time.Duration
+	now            func() time.Time
+	newEventID     func() string
+}
+
+func NewKafkaQueryLogSink(cfg QueryLogConfig) (*KafkaQueryLogSink, error) {
+	producer, err := newKafkaGoQueryLogProducer(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return newKafkaQueryLogSinkForProducer(cfg, producer)
+}
+
+func newKafkaQueryLogSinkForProducer(cfg QueryLogConfig, producer queryLogKafkaProducer) (*KafkaQueryLogSink, error) {
+	if err := validateQueryLogKafkaConfig(cfg); err != nil {
+		if producer != nil {
+			_ = producer.Close()
+		}
+		return nil, err
+	}
+	if producer == nil {
+		return nil, errors.New("querylog: kafka producer is nil")
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 1000
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 5 * time.Second
+	}
+	sink := &KafkaQueryLogSink{
+		cfg:            cfg,
+		producer:       producer,
+		ch:             make(chan QueryLogEntry, queryLogChannelSize),
+		done:           make(chan struct{}),
+		publishTimeout: defaultQueryLogKafkaPublishTimeout,
+		now:            func() time.Time { return time.Now().UTC() },
+		newEventID:     func() string { return uuid.NewString() },
+	}
+	go sink.flushLoop()
+	slog.Info("Query log Kafka sink enabled.", "topic", cfg.Kafka.Topic, "brokers", len(cfg.Kafka.Brokers), "flush_interval", cfg.FlushInterval, "batch_size", cfg.BatchSize)
+	return sink, nil
+}
+
+func validateQueryLogKafkaConfig(cfg QueryLogConfig) error {
+	if len(cfg.Kafka.Brokers) == 0 {
+		return errors.New("querylog: kafka brokers are required")
+	}
+	if strings.TrimSpace(cfg.Kafka.Topic) == "" {
+		return errors.New("querylog: kafka topic is required")
+	}
+	return nil
+}
+
+func (s *KafkaQueryLogSink) Log(entry QueryLogEntry) {
+	if s == nil || s.ch == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("querylog: kafka sink stopped while writing entry; dropping entry.")
+		}
+	}()
+	select {
+	case s.ch <- entry:
+	default:
+		slog.Warn("querylog: kafka channel full, dropping entry.")
+	}
+}
+
+func (s *KafkaQueryLogSink) Stop() {
+	_ = s.StopContext(context.Background())
+}
+
+func (s *KafkaQueryLogSink) StopContext(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	ctx, cancel := queryLogStopContext(ctx, defaultQueryLogKafkaPublishTimeout)
+	defer cancel()
+
+	var stopErr error
+	s.stopOnce.Do(func() {
+		s.setStopContext(ctx)
+		if s.ch != nil {
+			close(s.ch)
+		}
+		if s.done != nil {
+			select {
+			case <-s.done:
+			case <-ctx.Done():
+				stopErr = ctx.Err()
+			}
+		}
+		if s.producer != nil {
+			if err := s.producer.Close(); err != nil {
+				slog.Warn("querylog: kafka producer close failed.", "error", err)
+				if stopErr == nil {
+					stopErr = err
+				}
+			}
+		}
+	})
+	return stopErr
+}
+
+func (s *KafkaQueryLogSink) flushLoop() {
+	defer close(s.done)
+
+	batch := make([]QueryLogEntry, 0, s.cfg.BatchSize)
+	flushTicker := time.NewTicker(s.cfg.FlushInterval)
+	defer flushTicker.Stop()
+
+	for {
+		if s.dropRemainingIfStopExpired(len(batch)) {
+			return
+		}
+		select {
+		case entry, ok := <-s.ch:
+			if !ok {
+				if len(batch) > 0 {
+					if err := s.flushBatchWithContext(s.currentStopContext(), batch); err != nil && s.stopContextDone() {
+						s.logDroppedOnStop(len(batch))
+					}
+				}
+				return
+			}
+			batch = append(batch, entry)
+			if len(batch) >= s.cfg.BatchSize {
+				if err := s.flushBatchWithContext(s.currentStopContext(), batch); err != nil && s.stopContextDone() {
+					s.logDroppedOnStop(len(batch))
+					return
+				}
+				batch = batch[:0]
+			}
+		case <-flushTicker.C:
+			if len(batch) > 0 {
+				flushCtx := s.currentStopContext()
+				if flushCtx == nil {
+					flushCtx = context.Background()
+				}
+				if err := s.flushBatchWithContext(flushCtx, batch); err != nil && s.stopContextDone() {
+					s.logDroppedOnStop(len(batch))
+					return
+				}
+				batch = batch[:0]
+			}
+		}
+	}
+}
+
+func (s *KafkaQueryLogSink) flushBatchWithContext(ctx context.Context, batch []QueryLogEntry) error {
+	messages := make([]queryLogKafkaMessage, 0, len(batch))
+	for _, entry := range batch {
+		message, err := s.kafkaMessage(entry)
+		if err != nil {
+			slog.Error("querylog: encode kafka event failed.", "error", err)
+			continue
+		}
+		messages = append(messages, message)
+	}
+	if len(messages) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	publishTimeout := s.publishTimeout
+	if publishTimeout <= 0 {
+		publishTimeout = defaultQueryLogKafkaPublishTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, publishTimeout)
+	defer cancel()
+
+	if err := s.producer.WriteMessages(ctx, messages...); err != nil {
+		slog.Error("querylog: kafka publish failed.", "error", err, "batch_size", len(messages))
+		return err
+	}
+	return nil
+}
+
+func queryLogStopContext(ctx context.Context, defaultTimeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultTimeout)
+}
+
+func (s *KafkaQueryLogSink) setStopContext(ctx context.Context) {
+	s.stopMu.Lock()
+	defer s.stopMu.Unlock()
+	s.stopCtx = ctx
+}
+
+func (s *KafkaQueryLogSink) currentStopContext() context.Context {
+	s.stopMu.RLock()
+	defer s.stopMu.RUnlock()
+	return s.stopCtx
+}
+
+func (s *KafkaQueryLogSink) stopContextDone() bool {
+	ctx := s.currentStopContext()
+	return ctx != nil && ctx.Err() != nil
+}
+
+func (s *KafkaQueryLogSink) dropRemainingIfStopExpired(batchLen int) bool {
+	ctx := s.currentStopContext()
+	if ctx == nil || ctx.Err() == nil {
+		return false
+	}
+	s.logDroppedOnStop(batchLen)
+	return true
+}
+
+func (s *KafkaQueryLogSink) logDroppedOnStop(batchLen int) {
+	dropped := batchLen
+	if s.ch != nil {
+		dropped += len(s.ch)
+	}
+	slog.Warn("querylog: kafka shutdown deadline exceeded; dropping queued entries.", "dropped", dropped)
+}
+
+func (s *KafkaQueryLogSink) kafkaMessage(entry QueryLogEntry) (queryLogKafkaMessage, error) {
+	event := newQueryLogKafkaEvent(entry, s.now(), s.newEventID())
+	value, err := json.Marshal(event)
+	if err != nil {
+		return queryLogKafkaMessage{}, err
+	}
+	return queryLogKafkaMessage{
+		Topic: s.cfg.Kafka.Topic,
+		Key:   []byte(entry.OrgID),
+		Value: value,
+	}, nil
+}
+
+func newQueryLogKafkaEvent(entry QueryLogEntry, emittedAt time.Time, eventID string) QueryLogKafkaEvent {
+	return QueryLogKafkaEvent{
+		SchemaVersion:         queryLogKafkaSchemaVersion,
+		EventID:               eventID,
+		EmittedAt:             emittedAt.UTC(),
+		EventTime:             entry.EventTime.UTC(),
+		QueryDurationMs:       entry.QueryDurationMs,
+		Type:                  entry.Type,
+		Query:                 truncateQuery(entry.Query),
+		TranspiledQuery:       truncateNullableQuery(entry.TranspiledQuery),
+		QueryKind:             entry.QueryKind,
+		NormalizedHash:        entry.NormalizedHash,
+		ResultRows:            entry.ResultRows,
+		WrittenRows:           entry.WrittenRows,
+		ExceptionCode:         entry.ExceptionCode,
+		Exception:             entry.Exception,
+		UserName:              entry.UserName,
+		OrgID:                 entry.OrgID,
+		CurrentDatabase:       entry.CurrentDatabase,
+		ClientAddress:         entry.ClientAddress,
+		ClientPort:            entry.ClientPort,
+		ApplicationName:       entry.ApplicationName,
+		PID:                   entry.PID,
+		WorkerID:              entry.WorkerID,
+		IsTranspiled:          entry.IsTranspiled,
+		Protocol:              entry.Protocol,
+		TraceID:               entry.TraceID,
+		SpanID:                entry.SpanID,
+		PostgresScanMs:        entry.PostgresScanMs,
+		CPUTimeSeconds:        entry.CPUTimeSeconds,
+		PeakBufferMemoryBytes: entry.PeakBufferMemoryBytes,
+	}
+}
+
+type kafkaGoQueryLogProducer struct {
+	writer *kafka.Writer
+}
+
+func newKafkaGoQueryLogProducer(cfg QueryLogConfig) (*kafkaGoQueryLogProducer, error) {
+	if err := validateQueryLogKafkaConfig(cfg); err != nil {
+		return nil, err
+	}
+	clientID := strings.TrimSpace(cfg.Kafka.ClientID)
+	if clientID == "" {
+		clientID = "duckgres-query-log"
+	}
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	batchTimeout := cfg.FlushInterval
+	if batchTimeout <= 0 {
+		batchTimeout = 5 * time.Second
+	}
+	return &kafkaGoQueryLogProducer{
+		writer: &kafka.Writer{
+			Addr:         kafka.TCP(cfg.Kafka.Brokers...),
+			Topic:        cfg.Kafka.Topic,
+			Balancer:     &kafka.Hash{},
+			BatchSize:    batchSize,
+			BatchTimeout: batchTimeout,
+			RequiredAcks: kafka.RequireOne,
+			Transport: &kafka.Transport{
+				ClientID: clientID,
+			},
+		},
+	}, nil
+}
+
+func (p *kafkaGoQueryLogProducer) WriteMessages(ctx context.Context, messages ...queryLogKafkaMessage) error {
+	if p == nil || p.writer == nil {
+		return errors.New("querylog: kafka writer is nil")
+	}
+	kafkaMessages := make([]kafka.Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Topic == "" {
+			return errors.New("querylog: kafka message topic is empty")
+		}
+		kafkaMessages = append(kafkaMessages, kafka.Message{
+			Key:   message.Key,
+			Value: message.Value,
+		})
+	}
+	if err := p.writer.WriteMessages(ctx, kafkaMessages...); err != nil {
+		return fmt.Errorf("write kafka messages: %w", err)
+	}
+	return nil
+}
+
+func (p *kafkaGoQueryLogProducer) Close() error {
+	if p == nil || p.writer == nil {
+		return nil
+	}
+	return p.writer.Close()
+}

--- a/server/querylog_kafka_test.go
+++ b/server/querylog_kafka_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type captureQueryLogKafkaProducer struct {
+	messages []queryLogKafkaMessage
+	closed   bool
+}
+
+func (p *captureQueryLogKafkaProducer) WriteMessages(_ context.Context, messages ...queryLogKafkaMessage) error {
+	p.messages = append(p.messages, messages...)
+	return nil
+}
+
+func (p *captureQueryLogKafkaProducer) Close() error {
+	p.closed = true
+	return nil
+}
+
+type blockingQueryLogKafkaProducer struct {
+	writeStarted chan struct{}
+	closeStarted chan struct{}
+	closeOnce    sync.Once
+	writeOnce    sync.Once
+}
+
+func (p *blockingQueryLogKafkaProducer) WriteMessages(ctx context.Context, _ ...queryLogKafkaMessage) error {
+	p.writeOnce.Do(func() {
+		close(p.writeStarted)
+	})
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (p *blockingQueryLogKafkaProducer) Close() error {
+	p.closeOnce.Do(func() {
+		close(p.closeStarted)
+	})
+	return nil
+}
+
+type captureQueryLogSink struct {
+	stops atomic.Int32
+}
+
+func (s *captureQueryLogSink) Log(QueryLogEntry) {}
+
+func (s *captureQueryLogSink) Stop() {
+	s.stops.Add(1)
+}
+
+func (s *captureQueryLogSink) StopContext(context.Context) error {
+	s.Stop()
+	return nil
+}
+
+func TestServerShutdownStopsQueryLogSink(t *testing.T) {
+	srv := &Server{}
+	sink := &captureQueryLogSink{}
+	SetQueryLogSink(srv, sink)
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	if got := sink.stops.Load(); got != 1 {
+		t.Fatalf("expected query log sink to stop once, got %d", got)
+	}
+}
+
+func TestKafkaQueryLogSinkPublishesEnvelope(t *testing.T) {
+	producer := &captureQueryLogKafkaProducer{}
+	sink, err := newKafkaQueryLogSinkForProducer(QueryLogConfig{
+		BatchSize:     10,
+		FlushInterval: time.Hour,
+		Kafka: QueryLogKafkaConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "duckgres-query-log",
+		},
+	}, producer)
+	if err != nil {
+		t.Fatalf("newKafkaQueryLogSinkForProducer: %v", err)
+	}
+	sink.now = func() time.Time { return time.Unix(1710000000, 0).UTC() }
+	sink.newEventID = func() string { return "evt-test" }
+
+	eventTime := time.Unix(1700000000, 0).UTC()
+	sink.Log(QueryLogEntry{
+		EventTime:             eventTime,
+		QueryDurationMs:       42,
+		Type:                  "QueryFinish",
+		Query:                 "SELECT 1",
+		QueryKind:             "Select",
+		NormalizedHash:        -17,
+		ResultRows:            1,
+		UserName:              "alice",
+		OrgID:                 "org-a",
+		CurrentDatabase:       "ducklake",
+		ClientAddress:         "127.0.0.1",
+		ClientPort:            54321,
+		ApplicationName:       "psql",
+		PID:                   123,
+		WorkerID:              456,
+		Protocol:              "simple",
+		TraceID:               "trace-1",
+		SpanID:                "span-1",
+		PostgresScanMs:        7,
+		CPUTimeSeconds:        1.25,
+		PeakBufferMemoryBytes: 2048,
+	})
+	sink.Stop()
+
+	if !producer.closed {
+		t.Fatal("expected producer to be closed on Stop")
+	}
+	if len(producer.messages) != 1 {
+		t.Fatalf("expected 1 Kafka message, got %d", len(producer.messages))
+	}
+	message := producer.messages[0]
+	if got, want := message.Topic, "duckgres-query-log"; got != want {
+		t.Fatalf("topic mismatch: got %q want %q", got, want)
+	}
+	if got, want := string(message.Key), "org-a"; got != want {
+		t.Fatalf("key mismatch: got %q want %q", got, want)
+	}
+
+	var event QueryLogKafkaEvent
+	if err := json.Unmarshal(message.Value, &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.SchemaVersion != 1 {
+		t.Fatalf("schema version mismatch: got %d", event.SchemaVersion)
+	}
+	if event.EventID != "evt-test" {
+		t.Fatalf("event id mismatch: got %q", event.EventID)
+	}
+	if !event.EmittedAt.Equal(time.Unix(1710000000, 0).UTC()) {
+		t.Fatalf("emitted_at mismatch: got %s", event.EmittedAt)
+	}
+	if !event.EventTime.Equal(eventTime) {
+		t.Fatalf("event_time mismatch: got %s", event.EventTime)
+	}
+	if event.OrgID != "org-a" || event.UserName != "alice" || event.Query != "SELECT 1" {
+		t.Fatalf("unexpected event identity fields: %#v", event)
+	}
+	if event.CPUTimeSeconds != 1.25 {
+		t.Fatalf("cpu_time_s mismatch: got %f", event.CPUTimeSeconds)
+	}
+	if event.PeakBufferMemoryBytes != 2048 {
+		t.Fatalf("peak_buffer_memory_bytes mismatch: got %d", event.PeakBufferMemoryBytes)
+	}
+	if event.PostgresScanMs != 7 {
+		t.Fatalf("postgres_scan_ms mismatch: got %d", event.PostgresScanMs)
+	}
+}
+
+func TestKafkaQueryLogSinkStopBoundsBlockedPublish(t *testing.T) {
+	producer := &blockingQueryLogKafkaProducer{
+		writeStarted: make(chan struct{}),
+		closeStarted: make(chan struct{}),
+	}
+	sink, err := newKafkaQueryLogSinkForProducer(QueryLogConfig{
+		BatchSize:     1,
+		FlushInterval: time.Hour,
+		Kafka: QueryLogKafkaConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "duckgres-query-log",
+		},
+	}, producer)
+	if err != nil {
+		t.Fatalf("newKafkaQueryLogSinkForProducer: %v", err)
+	}
+	sink.publishTimeout = 10 * time.Millisecond
+
+	sink.Log(QueryLogEntry{
+		EventTime: time.Unix(1700000000, 0).UTC(),
+		Type:      "QueryFinish",
+		Query:     "SELECT 1",
+		OrgID:     "org-a",
+	})
+
+	select {
+	case <-producer.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected Kafka publish to start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		sink.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected Stop to return after publish timeout")
+	}
+
+	select {
+	case <-producer.closeStarted:
+	default:
+		t.Fatal("expected producer to close")
+	}
+}
+
+func TestKafkaQueryLogSinkStopContextBoundsTotalDrain(t *testing.T) {
+	producer := &blockingQueryLogKafkaProducer{
+		writeStarted: make(chan struct{}),
+		closeStarted: make(chan struct{}),
+	}
+	sink, err := newKafkaQueryLogSinkForProducer(QueryLogConfig{
+		BatchSize:     1,
+		FlushInterval: time.Hour,
+		Kafka: QueryLogKafkaConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "duckgres-query-log",
+		},
+	}, producer)
+	if err != nil {
+		t.Fatalf("newKafkaQueryLogSinkForProducer: %v", err)
+	}
+	sink.publishTimeout = time.Second
+
+	sink.Log(QueryLogEntry{
+		EventTime: time.Unix(1700000000, 0).UTC(),
+		Type:      "QueryFinish",
+		Query:     "SELECT 1",
+		OrgID:     "org-a",
+	})
+
+	select {
+	case <-producer.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected Kafka publish to start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err = sink.StopContext(ctx)
+	if err == nil {
+		t.Fatal("expected StopContext to return deadline error")
+	}
+
+	select {
+	case <-producer.closeStarted:
+	default:
+		t.Fatal("expected producer to close after stop deadline")
+	}
+}
+
+func TestNewQueryLogSinkDefaultsToDuckLake(t *testing.T) {
+	cfg := Config{
+		QueryLog: QueryLogConfig{
+			Enabled: true,
+			Sink:    "",
+		},
+	}
+	sink, err := NewQueryLogSink(cfg)
+	if err != nil {
+		t.Fatalf("NewQueryLogSink: %v", err)
+	}
+	if sink != nil {
+		t.Fatalf("expected nil sink without DuckLake metadata store, got %T", sink)
+	}
+}
+
+func TestNewQueryLogSinkRejectsKafkaWithoutTopic(t *testing.T) {
+	_, err := NewQueryLogSink(Config{
+		QueryLog: QueryLogConfig{
+			Enabled: true,
+			Sink:    QueryLogSinkKafka,
+			Kafka: QueryLogKafkaConfig{
+				Brokers: []string{"localhost:9092"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing Kafka topic error")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -313,10 +313,19 @@ type Config struct {
 // QueryLogConfig configures the query log feature.
 type QueryLogConfig struct {
 	Enabled              bool
+	Sink                 string
 	FlushInterval        time.Duration
 	BatchSize            int
 	CompactInterval      time.Duration
 	DataInliningRowLimit int
+	Kafka                QueryLogKafkaConfig
+}
+
+// QueryLogKafkaConfig configures Kafka publishing for query log events.
+type QueryLogKafkaConfig struct {
+	Brokers  []string
+	Topic    string
+	ClientID string
 }
 
 // fileDBEntry tracks a shared *sql.DB for file-persistence mode.
@@ -361,8 +370,12 @@ type Server struct {
 	connsMu sync.RWMutex
 	conns   map[int32]*clientConn
 
-	// Query logger for DuckLake system.query_log
+	// Query logger for DuckLake system.query_log. Kept for existing control
+	// plane call sites that install or inspect the direct DuckLake logger.
 	queryLogger *QueryLogger
+	// Query-log sink used by query execution. Defaults to queryLogger for the
+	// direct DuckLake path, or a Kafka sink when configured.
+	queryLogSink QueryLogSink
 
 	// Per-user shared DB pool for file persistence mode.
 	// Each user gets one *sql.DB; PG connections share it via pinned *sql.Conn.
@@ -487,10 +500,13 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	// Initialize query logger (non-fatal on error)
-	if ql, err := NewQueryLogger(cfg); err != nil {
+	if sink, err := NewQueryLogSink(cfg); err != nil {
 		slog.Warn("Failed to initialize query log, continuing without it.", "error", err)
-	} else if ql != nil {
-		s.queryLogger = ql
+	} else if sink != nil {
+		s.queryLogSink = sink
+		if ql, ok := sink.(*QueryLogger); ok {
+			s.queryLogger = ql
+		}
 	}
 
 	// Initialize DuckLake checkpoint scheduler (non-fatal on error)
@@ -594,9 +610,15 @@ func (s *Server) Close() error {
 	}
 
 	// Stop query logger (drains remaining entries)
-	if s.queryLogger != nil {
-		s.queryLogger.Stop()
+	queryLogTimeout := s.cfg.ShutdownTimeout
+	if queryLogTimeout <= 0 {
+		queryLogTimeout = 30 * time.Second
 	}
+	queryLogCtx, queryLogCancel := context.WithTimeout(context.Background(), queryLogTimeout)
+	if err := s.StopQueryLogging(queryLogCtx); err != nil {
+		slog.Warn("Query log shutdown deadline exceeded.", "error", err)
+	}
+	queryLogCancel()
 
 	// Stop DuckLake checkpoint scheduler
 	if s.checkpointer != nil {
@@ -666,6 +688,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		if err := s.acmeDNSManager.Close(); err != nil {
 			slog.Warn("ACME DNS manager shutdown error.", "error", err)
 		}
+	}
+
+	// Stop query logger (drains remaining entries)
+	if err := s.StopQueryLogging(ctx); err != nil {
+		slog.Warn("Query log shutdown deadline exceeded.", "error", err)
 	}
 
 	// Database connections are now closed by each clientConn when it terminates


### PR DESCRIPTION
## Summary
- add a configurable query_log sink selector with the existing DuckLake table path as the default
- add a Kafka query-log sink that publishes batched JSON events keyed by org_id with schema_version, event_id, and emitted_at envelope fields
- add YAML/env config for Kafka brokers, topic, and client ID, plus README docs

## Test plan
- go test ./server ./configresolve .
- just test-unit
- just lint