### PR TITLE
Add query log Kafka writer service

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ CPU/thread time in seconds, and `peak_buffer_memory_bytes` is DuckDB's
 The default `query_log.sink` is `ducklake`, which writes directly to
 `ducklake.system.query_log`. Set `query_log.sink: kafka` to publish JSON query
 log events to Kafka instead; the Kafka message key is `org_id`, and each
-payload includes `schema_version`, `event_id`, and `emitted_at` for downstream
-deduplication and schema handling. Kafka mode requires `brokers` and `topic`.
+payload includes `schema_version`, `event_id`, and `emitted_at`. Run
+`duckgres --mode query-log-writer` from a Kubernetes build as a separate
+DuckDB-linking process to consume those events and write them into each
+tenant's `ducklake.system.query_log`. The writer stores `event_id` and uses it
+to skip duplicates during normal single-consumer Kafka replay; it is not a
+storage-level unique constraint.
 
 ```sql
 SELECT event_time, user_name, org_id, query_duration_ms, cpu_time_s,
@@ -217,7 +221,7 @@ rate_limit:
 query_log:
   enabled: true
   # Default: ducklake. Set to kafka to publish per-query events for an
-  # external query-log writer.
+  # external query-log writer (`duckgres --mode query-log-writer`, Kubernetes build).
   sink: ducklake
   flush_interval: "5s"
   batch_size: 1000
@@ -227,6 +231,8 @@ query_log:
     topic: "duckgres_query_log"
     # Default: duckgres-query-log
     client_id: "duckgres-query-log"
+    # Default: duckgres-query-log-writer
+    group_id: "duckgres-query-log-writer"
 ```
 
 Run with config file:
@@ -269,6 +275,7 @@ Run with config file:
 | `DUCKGRES_QUERY_LOG_KAFKA_BROKERS` | Comma-separated Kafka bootstrap brokers used when `DUCKGRES_QUERY_LOG_SINK=kafka` | - |
 | `DUCKGRES_QUERY_LOG_KAFKA_TOPIC` | Kafka topic for query-log events; required for Kafka mode | - |
 | `DUCKGRES_QUERY_LOG_KAFKA_CLIENT_ID` | Kafka client ID used by the query-log producer | `duckgres-query-log` |
+| `DUCKGRES_QUERY_LOG_KAFKA_GROUP_ID` | Kafka consumer group used by `duckgres --mode query-log-writer` | `duckgres-query-log-writer` |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events** | - |
 | `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |
@@ -363,7 +370,7 @@ Options:
   -threads int             DuckDB threads per session
   -process-isolation       Enable process isolation (spawn child process per connection)
   -idle-timeout string     Connection idle timeout (e.g., '30m', '1h', '-1' to disable)
-  -mode string             Run mode: standalone (default), control-plane, or duckdb-service
+  -mode string             Run mode: standalone (default), control-plane, duckdb-service, or query-log-writer (Kubernetes build)
   -process-min-workers int Pre-warm process worker count at startup (control-plane mode, default 0)
   -process-max-workers int Max process workers, 0=auto-derived (control-plane mode)
   -process-retire-on-session-end
@@ -644,7 +651,7 @@ GROUP BY name;
 
 ## Architecture
 
-Duckgres supports three run modes: **standalone** (single process, default), **control-plane** (multi-process with worker pool), and **duckdb-service** (worker process mode used by the control plane).
+Duckgres supports four run modes: **standalone** (single process, default), **control-plane** (multi-process with worker pool), **duckdb-service** (worker process mode used by the control plane), and **query-log-writer** (Kubernetes-build service mode that drains Kafka query-log events into tenant DuckLakes).
 
 ### Standalone Mode
 

--- a/configloader/file_config.go
+++ b/configloader/file_config.go
@@ -81,6 +81,7 @@ type QueryLogKafkaFileConfig struct {
 	Brokers  []string `yaml:"brokers"`
 	Topic    string   `yaml:"topic"`
 	ClientID string   `yaml:"client_id"`
+	GroupID  string   `yaml:"group_id"`
 }
 
 type TLSConfig struct {

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -170,6 +170,7 @@ func DefaultServerConfig() server.Config {
 			DataInliningRowLimit: 1000,
 			Kafka: server.QueryLogKafkaConfig{
 				ClientID: "duckgres-query-log",
+				GroupID:  "duckgres-query-log-writer",
 			},
 		},
 	}
@@ -468,6 +469,9 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		}
 		if fileCfg.QueryLog.Kafka.ClientID != "" {
 			cfg.QueryLog.Kafka.ClientID = fileCfg.QueryLog.Kafka.ClientID
+		}
+		if fileCfg.QueryLog.Kafka.GroupID != "" {
+			cfg.QueryLog.Kafka.GroupID = fileCfg.QueryLog.Kafka.GroupID
 		}
 
 		if fileCfg.TLS.ACME.Domain != "" {
@@ -966,6 +970,9 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	}
 	if v := getenv("DUCKGRES_QUERY_LOG_KAFKA_CLIENT_ID"); v != "" {
 		cfg.QueryLog.Kafka.ClientID = v
+	}
+	if v := getenv("DUCKGRES_QUERY_LOG_KAFKA_GROUP_ID"); v != "" {
+		cfg.QueryLog.Kafka.GroupID = v
 	}
 
 	if cli.Set["host"] {

--- a/configresolve/resolve_querylog_test.go
+++ b/configresolve/resolve_querylog_test.go
@@ -1,0 +1,26 @@
+package configresolve
+
+import (
+	"testing"
+
+	"github.com/posthog/duckgres/configloader"
+)
+
+func TestResolveEffectiveQueryLogKafkaGroupID(t *testing.T) {
+	resolved := ResolveEffective(&configloader.FileConfig{
+		QueryLog: configloader.QueryLogFileConfig{
+			Kafka: configloader.QueryLogKafkaFileConfig{
+				GroupID: "yaml-group",
+			},
+		},
+	}, CLIInputs{}, func(key string) string {
+		if key == "DUCKGRES_QUERY_LOG_KAFKA_GROUP_ID" {
+			return "env-group"
+		}
+		return ""
+	}, nil)
+
+	if got := resolved.Server.QueryLog.Kafka.GroupID; got != "env-group" {
+		t.Fatalf("expected env Kafka group id to win, got %q", got)
+	}
+}

--- a/controlplane/tenant_activation_payload_with_resolver.go
+++ b/controlplane/tenant_activation_payload_with_resolver.go
@@ -1,0 +1,35 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+	"k8s.io/client-go/kubernetes"
+)
+
+// BuildTenantActivationPayloadWithResolver builds a tenant activation payload
+// when the caller already owns the Kubernetes and runtime resolver dependencies.
+func BuildTenantActivationPayloadWithResolver(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	defaultNamespace string,
+	org *configstore.OrgConfig,
+	stsBroker *STSBroker,
+	defaultSpecVersion string,
+	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error),
+) (TenantActivationPayload, error) {
+	activator := &SharedWorkerActivator{
+		clientset:             clientset,
+		defaultNamespace:      defaultNamespace,
+		defaultSpecVersion:    defaultSpecVersion,
+		stsBroker:             stsBroker,
+		resolveDucklingStatus: resolveDucklingStatus,
+	}
+	assignment := &WorkerAssignment{
+		OrgID: orgName(org),
+	}
+	return activator.BuildActivationRequest(ctx, org, assignment)
+}

--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -203,7 +203,7 @@ why.
 | pg_roles | ✅ | `catalog_test.go::TestCatalogPgRoles` | single hardcoded superuser |
 | pg_settings | ✅ | `catalog_test.go::TestCatalogPgSettings` | |
 | pg_stat_activity | ✅ | `pg_stat_activity_test.go::TestPgStatActivity`/`::TestPgStatActivityFromSecondConnection`/`::TestPgStatActivityExtendedQuery`/`::TestPgStatActivityStubView` | intercepted at query time for live data |
-| system.query_log | ✅ | `querylog_test.go` | DuckLake-backed durable query history with `user_name`, timing, errors, trace IDs, `cpu_time_s`, `peak_buffer_memory_bytes`, and `postgres_scan_ms` |
+| system.query_log | ✅ | `querylog_test.go` | DuckLake-backed durable query history with `event_id`, `user_name`, timing, errors, trace IDs, `cpu_time_s`, `peak_buffer_memory_bytes`, and `postgres_scan_ms` |
 | information_schema (tables/columns/views/schemata) | ✅ | `catalog_test.go::TestCatalogInformationSchema{Tables,Columns,Views,Schemata}` | |
 | information_schema key_column_usage / table_constraints / referential_constraints | ❌ | — | Missing; used by ORMs for FK introspection |
 | System functions (format_type, pg_get_userbyid, pg_table_is_visible, has_*_privilege, pg_encoding_to_char, size fns, quote_*) | ✅ | `catalog_test.go::TestCatalogSystemFunctions`, `::TestFormatTypeTimePrecision`; server `pg_compat_macros_test.go` | many return permissive/stub values |

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 	psql := flag.Bool("psql", false, "Launch psql connected to the local Duckgres server")
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	showHelp := flag.Bool("help", false, "Show help message")
-	mode := flag.String("mode", "standalone", "Run mode: standalone, control-plane, or duckdb-service")
+	mode := flag.String("mode", "standalone", "Run mode: standalone, control-plane, duckdb-service, or query-log-writer")
 	socketDir := flag.String("socket-dir", "/var/run/duckgres", "Unix socket directory (control-plane mode)")
 	duckdbListen := flag.String("duckdb-listen", "", "DuckDB service listen address (duckdb-service mode, env: DUCKGRES_DUCKDB_LISTEN)")
 	duckdbListenFD := flag.Int("duckdb-listen-fd", 0, "Inherit a pre-bound listener FD instead of creating a new socket (duckdb-service mode, set by control plane)")
@@ -294,6 +294,15 @@ func main() {
 			BearerToken:  token,
 			MaxSessions:  maxSessions,
 		})
+		return
+	}
+
+	// Handle query-log-writer mode. This consumes Kafka query-log events and
+	// writes them to each tenant's DuckLake-backed system.query_log table.
+	if *mode == "query-log-writer" {
+		if err := runQueryLogWriter(context.Background(), cfg, resolved); err != nil {
+			fatal("Query-log writer error: " + err.Error())
+		}
 		return
 	}
 

--- a/querylog_writer_mode_kubernetes.go
+++ b/querylog_writer_mode_kubernetes.go
@@ -1,0 +1,205 @@
+//go:build kubernetes
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/posthog/duckgres/configresolve"
+	"github.com/posthog/duckgres/controlplane"
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+	"github.com/posthog/duckgres/internal/cliboot"
+	"github.com/posthog/duckgres/server"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type staticQueryLogDuckLakeConfigResolver struct {
+	cfg server.Config
+}
+
+func (r staticQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfig(context.Context, string) (server.QueryLogDuckLakeResolvedConfig, error) {
+	if r.cfg.DuckLake.MetadataStore == "" {
+		return server.QueryLogDuckLakeResolvedConfig{}, errors.New("querylog: static DuckLake metadata store is required")
+	}
+	cfg := r.cfg
+	cfg.QueryLog.Enabled = true
+	cfg.QueryLog.Sink = server.QueryLogSinkDuckLake
+	return server.QueryLogDuckLakeResolvedConfig{Config: cfg}, nil
+}
+
+type configStoreQueryLogDuckLakeConfigResolver struct {
+	base                  server.Config
+	store                 *configstore.ConfigStore
+	clientset             kubernetes.Interface
+	namespace             string
+	stsBroker             *controlplane.STSBroker
+	defaultSpecVersion    string
+	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)
+}
+
+func (r *configStoreQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfig(ctx context.Context, orgID string) (server.QueryLogDuckLakeResolvedConfig, error) {
+	snap := r.store.Snapshot()
+	if snap == nil {
+		return server.QueryLogDuckLakeResolvedConfig{}, errors.New("querylog: config snapshot unavailable")
+	}
+	org, ok := snap.Orgs[orgID]
+	if !ok || org == nil {
+		return server.QueryLogDuckLakeResolvedConfig{}, fmt.Errorf("querylog: org %q not found in config snapshot", orgID)
+	}
+	payload, err := controlplane.BuildTenantActivationPayloadWithResolver(
+		ctx,
+		r.clientset,
+		r.namespace,
+		org,
+		r.stsBroker,
+		r.defaultSpecVersion,
+		r.resolveDucklingStatus,
+	)
+	if err != nil {
+		return server.QueryLogDuckLakeResolvedConfig{}, err
+	}
+	cfg := r.base
+	cfg.DuckLake = payload.DuckLake
+	cfg.QueryLog.Enabled = true
+	cfg.QueryLog.Sink = server.QueryLogSinkDuckLake
+	return server.QueryLogDuckLakeResolvedConfig{
+		Config:               cfg,
+		CredentialsExpiresAt: payload.S3CredentialsExpiresAt,
+	}, nil
+}
+
+func runQueryLogWriter(ctx context.Context, cfg server.Config, resolved configresolve.Resolved) error {
+	if !cfg.QueryLog.Enabled {
+		return errors.New("querylog: query log is disabled")
+	}
+
+	metricsSrv := cliboot.InitMetrics()
+	defer shutdownQueryLogWriterMetrics(metricsSrv)
+
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	consumer, err := server.NewKafkaQueryLogConsumer(cfg.QueryLog)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = consumer.Close() }()
+
+	cfgResolver, err := newQueryLogDuckLakeConfigResolver(ctx, cfg, resolved)
+	if err != nil {
+		return err
+	}
+	writerResolver, err := server.NewQueryLogDuckLakeEntryWriterResolver(cfgResolver)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = writerResolver.Close() }()
+	writerResolver.StartIdlePruner(ctx)
+
+	writer, err := server.NewQueryLogKafkaWriter(consumer, writerResolver)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Starting query-log Kafka writer.",
+		"topic", cfg.QueryLog.Kafka.Topic,
+		"brokers", len(cfg.QueryLog.Kafka.Brokers),
+		"group_id", cfg.QueryLog.Kafka.GroupID,
+	)
+	if err := writer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+func newQueryLogDuckLakeConfigResolver(ctx context.Context, cfg server.Config, resolved configresolve.Resolved) (server.QueryLogDuckLakeConfigResolver, error) {
+	if strings.TrimSpace(resolved.ConfigStoreConn) == "" {
+		return staticQueryLogDuckLakeConfigResolver{cfg: cfg}, nil
+	}
+
+	store, err := configstore.NewConfigStore(resolved.ConfigStoreConn, resolved.ConfigPollInterval)
+	if err != nil {
+		return nil, err
+	}
+	store.Start(ctx)
+	go func() {
+		<-ctx.Done()
+		sqlDB, err := store.DB().DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	}()
+
+	restCfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load in-cluster config: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	namespace, err := queryLogWriterNamespace(resolved.K8sWorkerNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var stsBroker *controlplane.STSBroker
+	if resolved.AWSRegion != "" {
+		stsBroker, err = controlplane.NewSTSBroker(ctx, resolved.AWSRegion)
+		if err != nil {
+			slog.Warn("STS broker unavailable for query-log writer; STS-backed orgs will fail until it recovers.", "error", err)
+		}
+	}
+
+	var resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)
+	ducklingClient, err := provisioner.NewDucklingClient()
+	if err != nil {
+		slog.Warn("Duckling client unavailable for query-log writer; using config store runtime only.", "error", err)
+	} else {
+		resolveDucklingStatus = func(ctx context.Context, orgID string) (*provisioner.DucklingStatus, error) {
+			return ducklingClient.Get(ctx, orgID)
+		}
+	}
+
+	return &configStoreQueryLogDuckLakeConfigResolver{
+		base:                  cfg,
+		store:                 store,
+		clientset:             clientset,
+		namespace:             namespace,
+		stsBroker:             stsBroker,
+		defaultSpecVersion:    resolved.DuckLakeDefaultSpecVersion,
+		resolveDucklingStatus: resolveDucklingStatus,
+	}, nil
+}
+
+func queryLogWriterNamespace(configured string) (string, error) {
+	if strings.TrimSpace(configured) != "" {
+		return strings.TrimSpace(configured), nil
+	}
+	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("querylog: k8s worker namespace is required when service account namespace cannot be read: %w", err)
+	}
+	return strings.TrimSpace(string(ns)), nil
+}
+
+func shutdownQueryLogWriterMetrics(srv *http.Server) {
+	if srv == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+}

--- a/querylog_writer_mode_stub.go
+++ b/querylog_writer_mode_stub.go
@@ -1,0 +1,15 @@
+//go:build !kubernetes
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/posthog/duckgres/configresolve"
+	"github.com/posthog/duckgres/server"
+)
+
+func runQueryLogWriter(context.Context, server.Config, configresolve.Resolved) error {
+	return errors.New("query-log-writer mode requires a kubernetes build")
+}

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -21,6 +21,7 @@ import (
 
 // QueryLogEntry represents a single entry in the query log.
 type QueryLogEntry struct {
+	EventID         string
 	EventTime       time.Time
 	QueryDurationMs int64
 	Type            string // "QueryFinish" or "ExceptionWhileProcessing"
@@ -113,6 +114,29 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 		return nil, nil
 	}
 
+	db, err := openQueryLogDuckLakeDB(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	ql := &QueryLogger{
+		db:    db,
+		cfg:   cfg.QueryLog,
+		table: "ducklake.system.query_log",
+		ch:    make(chan QueryLogEntry, queryLogChannelSize),
+		done:  make(chan struct{}),
+	}
+
+	go ql.flushLoop()
+	slog.Info("Query log enabled.", "flush_interval", cfg.QueryLog.FlushInterval, "batch_size", cfg.QueryLog.BatchSize)
+	return ql, nil
+}
+
+func openQueryLogDuckLakeDB(cfg Config) (*sql.DB, error) {
+	if cfg.DuckLake.MetadataStore == "" {
+		return nil, errors.New("querylog: DuckLake metadata store is required")
+	}
+
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {
 		return nil, fmt.Errorf("querylog: open duckdb: %w", err)
@@ -178,17 +202,7 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 		slog.Warn("querylog: failed to set data_inlining_row_limit, continuing without it.", "error", err)
 	}
 
-	ql := &QueryLogger{
-		db:    db,
-		cfg:   cfg.QueryLog,
-		table: "ducklake.system.query_log",
-		ch:    make(chan QueryLogEntry, queryLogChannelSize),
-		done:  make(chan struct{}),
-	}
-
-	go ql.flushLoop()
-	slog.Info("Query log enabled.", "flush_interval", cfg.QueryLog.FlushInterval, "batch_size", cfg.QueryLog.BatchSize)
-	return ql, nil
+	return db, nil
 }
 
 // Log sends an entry to the query log. Non-blocking; drops if channel is full.
@@ -283,13 +297,20 @@ func (ql *QueryLogger) flushLoop() {
 }
 
 func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
+	if err := insertQueryLogEntries(context.Background(), ql.db, ql.table, batch); err != nil {
+		slog.Error("querylog: flush failed.", "error", err, "batch_size", len(batch))
+	}
+}
+
+func insertQueryLogEntries(ctx context.Context, db *sql.DB, table string, batch []QueryLogEntry) error {
 	if len(batch) == 0 {
-		return
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	// Build multi-row INSERT with placeholders
 	var sb strings.Builder
-	table := ql.table
 	if table == "" {
 		table = "query_log"
 	}
@@ -308,38 +329,43 @@ func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
 			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10,
 			base+11, base+12, base+13, base+14, base+15, base+16, base+17, base+18, base+19, base+20, base+21, base+22, base+23, base+24, base+25, base+26)
 
-		args = append(args,
-			e.EventTime,
-			e.QueryDurationMs,
-			e.Type,
-			truncateQuery(e.Query),
-			truncateNullableQuery(e.TranspiledQuery),
-			e.QueryKind,
-			e.NormalizedHash,
-			e.ResultRows,
-			e.WrittenRows,
-			e.ExceptionCode,
-			e.Exception,
-			e.UserName,
-			e.OrgID,
-			e.CurrentDatabase,
-			e.ClientAddress,
-			e.ClientPort,
-			e.ApplicationName,
-			e.PID,
-			e.WorkerID,
-			e.IsTranspiled,
-			e.Protocol,
-			e.TraceID,
-			e.SpanID,
-			e.PostgresScanMs,
-			e.CPUTimeSeconds,
-			e.PeakBufferMemoryBytes,
-		)
+		args = append(args, queryLogEntryInsertArgs(e)...)
 	}
 
-	if _, err := ql.db.Exec(sb.String(), args...); err != nil {
-		slog.Error("querylog: flush failed.", "error", err, "batch_size", len(batch))
+	if _, err := db.ExecContext(ctx, sb.String(), args...); err != nil {
+		return fmt.Errorf("insert query_log entries: %w", err)
+	}
+	return nil
+}
+
+func queryLogEntryInsertArgs(e QueryLogEntry) []any {
+	return []any{
+		e.EventTime,
+		e.QueryDurationMs,
+		e.Type,
+		truncateQuery(e.Query),
+		truncateNullableQuery(e.TranspiledQuery),
+		e.QueryKind,
+		e.NormalizedHash,
+		e.ResultRows,
+		e.WrittenRows,
+		e.ExceptionCode,
+		e.Exception,
+		e.UserName,
+		e.OrgID,
+		e.CurrentDatabase,
+		e.ClientAddress,
+		e.ClientPort,
+		e.ApplicationName,
+		e.PID,
+		e.WorkerID,
+		e.IsTranspiled,
+		e.Protocol,
+		e.TraceID,
+		e.SpanID,
+		e.PostgresScanMs,
+		e.CPUTimeSeconds,
+		e.PeakBufferMemoryBytes,
 	}
 }
 
@@ -391,8 +417,8 @@ func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName strin
 		}
 	}
 
-	// Add trace_id and span_id columns for OTEL tracing correlation.
-	for _, col := range []string{"trace_id", "span_id"} {
+	// Add columns for OTEL tracing correlation and Kafka writer idempotency.
+	for _, col := range []string{"trace_id", "span_id", "event_id"} {
 		hasCol, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, col)
 		if err != nil {
 			return fmt.Errorf("inspect %s column: %w", col, err)
@@ -456,6 +482,7 @@ func queryLogCreateTableSQL(fullTableName string) string {
 		protocol            VARCHAR,
 		trace_id            VARCHAR,
 		span_id             VARCHAR,
+		event_id            VARCHAR,
 		postgres_scan_ms    BIGINT DEFAULT 0,
 		cpu_time_s          DOUBLE DEFAULT 0,
 		peak_buffer_memory_bytes BIGINT DEFAULT 0

--- a/server/querylog_kafka_writer.go
+++ b/server/querylog_kafka_writer.go
@@ -1,0 +1,603 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	kafka "github.com/segmentio/kafka-go"
+)
+
+const defaultQueryLogKafkaWriterGroupID = "duckgres-query-log-writer"
+const queryLogWriterCredentialExpiryMargin = 5 * time.Minute
+const defaultQueryLogWriterIdleTTL = 15 * time.Minute
+const defaultQueryLogWriterPruneInterval = time.Minute
+const defaultQueryLogWriterMaxCachedWriters = 128
+const defaultQueryLogKafkaWriterRetryDelay = time.Second
+
+// ErrQueryLogNoDuckLakeTarget means an org has no DuckLake table that can store
+// query-log events.
+var ErrQueryLogNoDuckLakeTarget = errors.New("querylog: no DuckLake metadata store for query log target")
+
+// QueryLogKafkaConsumedMessage is the minimal Kafka message shape needed by
+// the query-log writer. The concrete kafka-go reader keeps offsets internally;
+// tests use this value to prove commits happen only after durable writes.
+type QueryLogKafkaConsumedMessage struct {
+	Key   []byte
+	Value []byte
+	raw   kafka.Message
+}
+
+type QueryLogKafkaConsumer interface {
+	FetchMessage(context.Context) (QueryLogKafkaConsumedMessage, error)
+	CommitMessages(context.Context, ...QueryLogKafkaConsumedMessage) error
+	Close() error
+}
+
+type QueryLogEntryWriter interface {
+	WriteQueryLogEntries(context.Context, []QueryLogEntry) error
+	Close() error
+}
+
+type QueryLogKafkaEventWriter interface {
+	QueryLogEntryWriter
+	WriteQueryLogKafkaEvent(context.Context, QueryLogKafkaEvent) error
+}
+
+type QueryLogEntryWriterResolver interface {
+	ResolveQueryLogEntryWriter(context.Context, string) (QueryLogEntryWriter, error)
+}
+
+// QueryLogEntryWriterInvalidator lets the Kafka writer evict a cached writer
+// after a failed write, so the next retry rebuilds the DuckLake connection.
+type QueryLogEntryWriterInvalidator interface {
+	InvalidateQueryLogEntryWriter(string, QueryLogEntryWriter)
+}
+
+// QueryLogDuckLakeResolvedConfig is the per-org DuckLake runtime used by the
+// Kafka query-log writer. CredentialsExpiresAt is set for STS-backed object
+// store credentials so cached writers can be refreshed before expiry.
+type QueryLogDuckLakeResolvedConfig struct {
+	Config               Config
+	CredentialsExpiresAt *time.Time
+}
+
+// QueryLogDuckLakeConfigResolver resolves the per-org DuckLake runtime.
+// Production wires this to the config store and the same tenant activation path
+// used for workers.
+type QueryLogDuckLakeConfigResolver interface {
+	ResolveQueryLogDuckLakeConfig(context.Context, string) (QueryLogDuckLakeResolvedConfig, error)
+}
+
+type QueryLogKafkaWriter struct {
+	consumer   QueryLogKafkaConsumer
+	resolver   QueryLogEntryWriterResolver
+	retryDelay time.Duration
+}
+
+func NewQueryLogKafkaWriter(consumer QueryLogKafkaConsumer, resolver QueryLogEntryWriterResolver) (*QueryLogKafkaWriter, error) {
+	if consumer == nil {
+		return nil, errors.New("querylog: kafka consumer is nil")
+	}
+	if resolver == nil {
+		return nil, errors.New("querylog: entry writer resolver is nil")
+	}
+	return &QueryLogKafkaWriter{consumer: consumer, resolver: resolver, retryDelay: defaultQueryLogKafkaWriterRetryDelay}, nil
+}
+
+func (w *QueryLogKafkaWriter) Run(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+	for {
+		msg, err := w.fetchMessage(ctx)
+		if err != nil {
+			if isQueryLogKafkaWriterStopError(err) {
+				return err
+			}
+			w.recordRetryableError(err)
+			if err := w.waitBeforeRetry(ctx); err != nil {
+				return err
+			}
+			continue
+		}
+
+		for {
+			if err := w.processMessage(ctx, msg); err != nil {
+				if isQueryLogKafkaWriterStopError(err) {
+					return err
+				}
+				w.recordRetryableError(err)
+				if err := w.waitBeforeRetry(ctx); err != nil {
+					return err
+				}
+				continue
+			}
+			break
+		}
+	}
+}
+
+func (w *QueryLogKafkaWriter) ProcessOne(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+	msg, err := w.fetchMessage(ctx)
+	if err != nil {
+		return err
+	}
+	return w.processMessage(ctx, msg)
+}
+
+func (w *QueryLogKafkaWriter) fetchMessage(ctx context.Context) (QueryLogKafkaConsumedMessage, error) {
+	msg, err := w.consumer.FetchMessage(ctx)
+	if err != nil {
+		return QueryLogKafkaConsumedMessage{}, err
+	}
+	queryLogKafkaWriterEvents.WithLabelValues("consumed").Inc()
+	return msg, nil
+}
+
+func (w *QueryLogKafkaWriter) processMessage(ctx context.Context, msg QueryLogKafkaConsumedMessage) error {
+	var event QueryLogKafkaEvent
+	if err := json.Unmarshal(msg.Value, &event); err != nil {
+		queryLogKafkaWriterEvents.WithLabelValues("dropped").Inc()
+		return w.dropAndCommit(ctx, msg, fmt.Errorf("decode query log kafka event: %w", err))
+	}
+	if err := validateQueryLogKafkaEvent(event); err != nil {
+		queryLogKafkaWriterEvents.WithLabelValues("dropped").Inc()
+		return w.dropAndCommit(ctx, msg, err)
+	}
+
+	entryWriter, err := w.resolver.ResolveQueryLogEntryWriter(ctx, event.OrgID)
+	if err != nil {
+		if errors.Is(err, ErrQueryLogNoDuckLakeTarget) {
+			queryLogKafkaWriterEvents.WithLabelValues("dropped").Inc()
+			return w.dropAndCommit(ctx, msg, err)
+		}
+		return fmt.Errorf("resolve query log writer for org %q: %w", event.OrgID, err)
+	}
+	if eventWriter, ok := entryWriter.(QueryLogKafkaEventWriter); ok {
+		err = eventWriter.WriteQueryLogKafkaEvent(ctx, event)
+	} else {
+		err = entryWriter.WriteQueryLogEntries(ctx, []QueryLogEntry{queryLogEntryFromKafkaEvent(event)})
+	}
+	if err != nil {
+		if invalidator, ok := w.resolver.(QueryLogEntryWriterInvalidator); ok {
+			invalidator.InvalidateQueryLogEntryWriter(event.OrgID, entryWriter)
+		}
+		return fmt.Errorf("write query log event %q for org %q: %w", event.EventID, event.OrgID, err)
+	}
+	queryLogKafkaWriterEvents.WithLabelValues("inserted").Inc()
+
+	if err := w.consumer.CommitMessages(ctx, msg); err != nil {
+		return fmt.Errorf("commit query log kafka event %q: %w", event.EventID, err)
+	}
+	queryLogKafkaWriterEvents.WithLabelValues("committed").Inc()
+	return nil
+}
+
+func (w *QueryLogKafkaWriter) recordRetryableError(err error) {
+	queryLogKafkaWriterEvents.WithLabelValues("failed").Inc()
+	slog.Error("querylog: kafka writer failed to process event.", "error", err)
+	queryLogKafkaWriterEvents.WithLabelValues("retried").Inc()
+}
+
+func (w *QueryLogKafkaWriter) waitBeforeRetry(ctx context.Context) error {
+	delay := w.retryDelay
+	if delay <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isQueryLogKafkaWriterStopError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func (w *QueryLogKafkaWriter) dropAndCommit(ctx context.Context, msg QueryLogKafkaConsumedMessage, dropErr error) error {
+	if err := w.consumer.CommitMessages(ctx, msg); err != nil {
+		return fmt.Errorf("%w; commit dropped kafka message: %v", dropErr, err)
+	}
+	slog.Warn("querylog: dropped invalid kafka event.", "error", dropErr)
+	queryLogKafkaWriterEvents.WithLabelValues("committed").Inc()
+	return nil
+}
+
+func (w *QueryLogKafkaWriter) Close() error {
+	if w == nil || w.consumer == nil {
+		return nil
+	}
+	return w.consumer.Close()
+}
+
+func validateQueryLogKafkaEvent(event QueryLogKafkaEvent) error {
+	if event.SchemaVersion != queryLogKafkaSchemaVersion {
+		return fmt.Errorf("querylog: unsupported kafka event schema version %d", event.SchemaVersion)
+	}
+	if strings.TrimSpace(event.EventID) == "" {
+		return errors.New("querylog: kafka event_id is required")
+	}
+	if strings.TrimSpace(event.OrgID) == "" {
+		return errors.New("querylog: kafka org_id is required")
+	}
+	if strings.TrimSpace(event.Type) == "" {
+		return errors.New("querylog: kafka event type is required")
+	}
+	if strings.TrimSpace(event.UserName) == "" {
+		return errors.New("querylog: kafka user_name is required")
+	}
+	return nil
+}
+
+func queryLogEntryFromKafkaEvent(event QueryLogKafkaEvent) QueryLogEntry {
+	return QueryLogEntry{
+		EventID:               event.EventID,
+		EventTime:             event.EventTime,
+		QueryDurationMs:       event.QueryDurationMs,
+		Type:                  event.Type,
+		Query:                 event.Query,
+		TranspiledQuery:       event.TranspiledQuery,
+		QueryKind:             event.QueryKind,
+		NormalizedHash:        event.NormalizedHash,
+		ResultRows:            event.ResultRows,
+		WrittenRows:           event.WrittenRows,
+		ExceptionCode:         event.ExceptionCode,
+		Exception:             event.Exception,
+		UserName:              event.UserName,
+		OrgID:                 event.OrgID,
+		CurrentDatabase:       event.CurrentDatabase,
+		ClientAddress:         event.ClientAddress,
+		ClientPort:            event.ClientPort,
+		ApplicationName:       event.ApplicationName,
+		PID:                   event.PID,
+		WorkerID:              event.WorkerID,
+		IsTranspiled:          event.IsTranspiled,
+		Protocol:              event.Protocol,
+		TraceID:               event.TraceID,
+		SpanID:                event.SpanID,
+		PostgresScanMs:        event.PostgresScanMs,
+		CPUTimeSeconds:        event.CPUTimeSeconds,
+		PeakBufferMemoryBytes: event.PeakBufferMemoryBytes,
+	}
+}
+
+type QueryLogDuckLakeEntryWriter struct {
+	db    *sql.DB
+	table string
+}
+
+func NewQueryLogDuckLakeEntryWriter(cfg Config) (*QueryLogDuckLakeEntryWriter, error) {
+	db, err := openQueryLogDuckLakeDB(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &QueryLogDuckLakeEntryWriter{db: db, table: "ducklake.system.query_log"}, nil
+}
+
+func (w *QueryLogDuckLakeEntryWriter) WriteQueryLogEntries(ctx context.Context, entries []QueryLogEntry) error {
+	if w == nil || w.db == nil {
+		return errors.New("querylog: ducklake entry writer is nil")
+	}
+	return insertQueryLogEntries(ctx, w.db, w.table, entries)
+}
+
+func (w *QueryLogDuckLakeEntryWriter) WriteQueryLogKafkaEvent(ctx context.Context, event QueryLogKafkaEvent) error {
+	if w == nil || w.db == nil {
+		return errors.New("querylog: ducklake entry writer is nil")
+	}
+	entry := queryLogEntryFromKafkaEvent(event)
+	return insertQueryLogKafkaEvent(ctx, w.db, w.table, entry)
+}
+
+func (w *QueryLogDuckLakeEntryWriter) Close() error {
+	if w == nil || w.db == nil {
+		return nil
+	}
+	return w.db.Close()
+}
+
+// insertQueryLogKafkaEvent skips an event_id that is already present. This makes
+// normal single-consumer Kafka replays idempotent, but it is not a storage-level
+// unique constraint across multiple independent writer groups.
+func insertQueryLogKafkaEvent(ctx context.Context, db *sql.DB, table string, entry QueryLogEntry) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if table == "" {
+		table = "query_log"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO ")
+	sb.WriteString(table)
+	sb.WriteString(" (event_id, event_time, query_duration_ms, type, query, transpiled_query, query_kind, normalized_query_hash, result_rows, written_rows, exception_code, exception, user_name, org_id, current_database, client_address, client_port, application_name, pid, worker_id, is_transpiled, protocol, trace_id, span_id, postgres_scan_ms, cpu_time_s, peak_buffer_memory_bytes) ")
+	sb.WriteString("SELECT ")
+	for i := 1; i <= 27; i++ {
+		if i > 1 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, "$%d", i)
+	}
+	sb.WriteString(" WHERE NOT EXISTS (SELECT 1 FROM ")
+	sb.WriteString(table)
+	sb.WriteString(" WHERE event_id = $1)")
+
+	args := append([]any{entry.EventID}, queryLogEntryInsertArgs(entry)...)
+	if _, err := db.ExecContext(ctx, sb.String(), args...); err != nil {
+		return fmt.Errorf("insert query_log kafka event: %w", err)
+	}
+	return nil
+}
+
+type QueryLogDuckLakeEntryWriterResolver struct {
+	configResolver   QueryLogDuckLakeConfigResolver
+	writers          map[string]cachedQueryLogEntryWriter
+	newWriter        func(Config) (QueryLogEntryWriter, error)
+	now              func() time.Time
+	idleTTL          time.Duration
+	pruneInterval    time.Duration
+	maxCachedWriters int
+	mu               sync.Mutex
+}
+
+type cachedQueryLogEntryWriter struct {
+	writer               QueryLogEntryWriter
+	credentialsExpiresAt *time.Time
+	lastUsed             time.Time
+}
+
+func NewQueryLogDuckLakeEntryWriterResolver(configResolver QueryLogDuckLakeConfigResolver) (*QueryLogDuckLakeEntryWriterResolver, error) {
+	if configResolver == nil {
+		return nil, errors.New("querylog: ducklake config resolver is nil")
+	}
+	return &QueryLogDuckLakeEntryWriterResolver{
+		configResolver: configResolver,
+		writers:        make(map[string]cachedQueryLogEntryWriter),
+		newWriter: func(cfg Config) (QueryLogEntryWriter, error) {
+			return NewQueryLogDuckLakeEntryWriter(cfg)
+		},
+		now:              func() time.Time { return time.Now().UTC() },
+		idleTTL:          defaultQueryLogWriterIdleTTL,
+		pruneInterval:    defaultQueryLogWriterPruneInterval,
+		maxCachedWriters: defaultQueryLogWriterMaxCachedWriters,
+	}, nil
+}
+
+// StartIdlePruner closes cached DuckLake writers that have been idle beyond the
+// resolver's idle TTL, even when no new Kafka events arrive to trigger pruning.
+func (r *QueryLogDuckLakeEntryWriterResolver) StartIdlePruner(ctx context.Context) {
+	if r == nil || r.idleTTL <= 0 || r.pruneInterval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(r.pruneInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.pruneIdleWriters(r.now())
+			}
+		}
+	}()
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) ResolveQueryLogEntryWriter(ctx context.Context, orgID string) (QueryLogEntryWriter, error) {
+	orgID = strings.TrimSpace(orgID)
+	if strings.TrimSpace(orgID) == "" {
+		return nil, errors.New("querylog: org_id is required")
+	}
+	now := r.now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneIdleWritersLocked(now)
+	if cached, ok := r.writers[orgID]; ok {
+		if cached.valid(now, r.idleTTL) {
+			cached.lastUsed = now
+			r.writers[orgID] = cached
+			return cached.writer, nil
+		}
+		_ = cached.writer.Close()
+		delete(r.writers, orgID)
+	}
+	resolved, err := r.configResolver.ResolveQueryLogDuckLakeConfig(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resolved.Config.DuckLake.MetadataStore) == "" {
+		return nil, ErrQueryLogNoDuckLakeTarget
+	}
+	writer, err := r.newWriter(resolved.Config)
+	if err != nil {
+		return nil, err
+	}
+	r.writers[orgID] = cachedQueryLogEntryWriter{
+		writer:               writer,
+		credentialsExpiresAt: resolved.CredentialsExpiresAt,
+		lastUsed:             now,
+	}
+	r.evictLeastRecentlyUsedWritersLocked()
+	return writer, nil
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) InvalidateQueryLogEntryWriter(orgID string, writer QueryLogEntryWriter) {
+	if r == nil || writer == nil {
+		return
+	}
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cached, ok := r.writers[orgID]
+	if !ok || cached.writer != writer {
+		return
+	}
+	_ = cached.writer.Close()
+	delete(r.writers, orgID)
+}
+
+func (c cachedQueryLogEntryWriter) valid(now time.Time, idleTTL time.Duration) bool {
+	if c.writer == nil {
+		return false
+	}
+	if c.idleExpired(now, idleTTL) {
+		return false
+	}
+	if c.credentialsExpiresAt == nil {
+		return true
+	}
+	return now.Before(c.credentialsExpiresAt.Add(-queryLogWriterCredentialExpiryMargin))
+}
+
+func (c cachedQueryLogEntryWriter) idleExpired(now time.Time, idleTTL time.Duration) bool {
+	return idleTTL > 0 && !c.lastUsed.IsZero() && !now.Before(c.lastUsed.Add(idleTTL))
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) pruneIdleWriters(now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneIdleWritersLocked(now)
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) pruneIdleWritersLocked(now time.Time) {
+	if r.idleTTL <= 0 {
+		return
+	}
+	for orgID, cached := range r.writers {
+		if cached.idleExpired(now, r.idleTTL) {
+			_ = cached.writer.Close()
+			delete(r.writers, orgID)
+		}
+	}
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) evictLeastRecentlyUsedWritersLocked() {
+	if r.maxCachedWriters <= 0 {
+		return
+	}
+	for len(r.writers) > r.maxCachedWriters {
+		var oldestOrgID string
+		var oldestLastUsed time.Time
+		for orgID, cached := range r.writers {
+			if oldestOrgID == "" || cached.lastUsed.Before(oldestLastUsed) {
+				oldestOrgID = orgID
+				oldestLastUsed = cached.lastUsed
+			}
+		}
+		if oldestOrgID == "" {
+			return
+		}
+		_ = r.writers[oldestOrgID].writer.Close()
+		delete(r.writers, oldestOrgID)
+	}
+}
+
+func (r *QueryLogDuckLakeEntryWriterResolver) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var closeErr error
+	for orgID, cached := range r.writers {
+		if err := cached.writer.Close(); err != nil && closeErr == nil {
+			closeErr = fmt.Errorf("close query log writer for org %q: %w", orgID, err)
+		}
+		delete(r.writers, orgID)
+	}
+	return closeErr
+}
+
+type kafkaGoQueryLogConsumer struct {
+	reader *kafka.Reader
+}
+
+func NewKafkaQueryLogConsumer(cfg QueryLogConfig) (*kafkaGoQueryLogConsumer, error) {
+	if err := validateQueryLogKafkaWriterConfig(cfg); err != nil {
+		return nil, err
+	}
+	groupID := strings.TrimSpace(cfg.Kafka.GroupID)
+	if groupID == "" {
+		groupID = defaultQueryLogKafkaWriterGroupID
+	}
+	clientID := strings.TrimSpace(cfg.Kafka.ClientID)
+	if clientID == "" {
+		clientID = "duckgres-query-log"
+	}
+	return &kafkaGoQueryLogConsumer{
+		reader: kafka.NewReader(kafka.ReaderConfig{
+			Brokers:     cfg.Kafka.Brokers,
+			Topic:       cfg.Kafka.Topic,
+			GroupID:     groupID,
+			StartOffset: kafka.FirstOffset,
+			MinBytes:    1,
+			MaxBytes:    10e6,
+			MaxWait:     time.Second,
+			Dialer: &kafka.Dialer{
+				ClientID: clientID,
+			},
+		}),
+	}, nil
+}
+
+func validateQueryLogKafkaWriterConfig(cfg QueryLogConfig) error {
+	if err := validateQueryLogKafkaConfig(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *kafkaGoQueryLogConsumer) FetchMessage(ctx context.Context) (QueryLogKafkaConsumedMessage, error) {
+	if c == nil || c.reader == nil {
+		return QueryLogKafkaConsumedMessage{}, errors.New("querylog: kafka reader is nil")
+	}
+	msg, err := c.reader.FetchMessage(ctx)
+	if err != nil {
+		return QueryLogKafkaConsumedMessage{}, err
+	}
+	return QueryLogKafkaConsumedMessage{Key: msg.Key, Value: msg.Value, raw: msg}, nil
+}
+
+func (c *kafkaGoQueryLogConsumer) CommitMessages(ctx context.Context, messages ...QueryLogKafkaConsumedMessage) error {
+	if c == nil || c.reader == nil {
+		return errors.New("querylog: kafka reader is nil")
+	}
+	raw := make([]kafka.Message, 0, len(messages))
+	for _, msg := range messages {
+		raw = append(raw, msg.raw)
+	}
+	if err := c.reader.CommitMessages(ctx, raw...); err != nil {
+		return fmt.Errorf("commit kafka messages: %w", err)
+	}
+	return nil
+}
+
+func (c *kafkaGoQueryLogConsumer) Close() error {
+	if c == nil || c.reader == nil {
+		return nil
+	}
+	return c.reader.Close()
+}

--- a/server/querylog_kafka_writer_test.go
+++ b/server/querylog_kafka_writer_test.go
@@ -1,0 +1,637 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeQueryLogKafkaConsumer struct {
+	messages   []QueryLogKafkaConsumedMessage
+	commits    []QueryLogKafkaConsumedMessage
+	commitErrs []error
+	closed     bool
+}
+
+func (c *fakeQueryLogKafkaConsumer) FetchMessage(context.Context) (QueryLogKafkaConsumedMessage, error) {
+	if len(c.messages) == 0 {
+		return QueryLogKafkaConsumedMessage{}, context.Canceled
+	}
+	msg := c.messages[0]
+	c.messages = c.messages[1:]
+	return msg, nil
+}
+
+func (c *fakeQueryLogKafkaConsumer) CommitMessages(_ context.Context, messages ...QueryLogKafkaConsumedMessage) error {
+	if len(c.commitErrs) > 0 {
+		err := c.commitErrs[0]
+		c.commitErrs = c.commitErrs[1:]
+		if err != nil {
+			return err
+		}
+	}
+	c.commits = append(c.commits, messages...)
+	return nil
+}
+
+func (c *fakeQueryLogKafkaConsumer) Close() error {
+	c.closed = true
+	return nil
+}
+
+type fakeQueryLogEntryWriterResolver struct {
+	writer      *fakeQueryLogEntryWriter
+	orgs        []string
+	invalidated []struct {
+		orgID  string
+		writer QueryLogEntryWriter
+	}
+}
+
+func (r *fakeQueryLogEntryWriterResolver) ResolveQueryLogEntryWriter(_ context.Context, orgID string) (QueryLogEntryWriter, error) {
+	r.orgs = append(r.orgs, orgID)
+	return r.writer, nil
+}
+
+func (r *fakeQueryLogEntryWriterResolver) InvalidateQueryLogEntryWriter(orgID string, writer QueryLogEntryWriter) {
+	r.invalidated = append(r.invalidated, struct {
+		orgID  string
+		writer QueryLogEntryWriter
+	}{orgID: orgID, writer: writer})
+}
+
+type fakeQueryLogEntryWriter struct {
+	entries []QueryLogEntry
+	err     error
+	errs    []error
+	closed  int
+}
+
+func (w *fakeQueryLogEntryWriter) WriteQueryLogEntries(_ context.Context, entries []QueryLogEntry) error {
+	if len(w.errs) > 0 {
+		err := w.errs[0]
+		w.errs = w.errs[1:]
+		if err != nil {
+			return err
+		}
+	}
+	if w.err != nil {
+		return w.err
+	}
+	w.entries = append(w.entries, entries...)
+	return nil
+}
+
+func (w *fakeQueryLogEntryWriter) Close() error {
+	w.closed++
+	return nil
+}
+
+type fakeDuckLakeConfigResolver struct {
+	resolved QueryLogDuckLakeResolvedConfig
+	calls    int
+}
+
+func (r *fakeDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfig(context.Context, string) (QueryLogDuckLakeResolvedConfig, error) {
+	r.calls++
+	return r.resolved, nil
+}
+
+func TestQueryLogKafkaWriterWritesAndCommitsAfterSuccess(t *testing.T) {
+	event := QueryLogKafkaEvent{
+		SchemaVersion:         queryLogKafkaSchemaVersion,
+		EventID:               "evt-1",
+		EmittedAt:             time.Unix(1700000001, 0).UTC(),
+		EventTime:             time.Unix(1700000000, 0).UTC(),
+		QueryDurationMs:       42,
+		Type:                  "QueryFinish",
+		Query:                 "SELECT 1",
+		QueryKind:             "Select",
+		NormalizedHash:        99,
+		ResultRows:            1,
+		UserName:              "alice",
+		OrgID:                 "org-a",
+		CurrentDatabase:       "ducklake",
+		PostgresScanMs:        7,
+		CPUTimeSeconds:        1.25,
+		PeakBufferMemoryBytes: 2048,
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{{Value: payload}},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{}
+	writer, err := NewQueryLogKafkaWriter(consumer, &fakeQueryLogEntryWriterResolver{writer: entryWriter})
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+
+	if err := writer.ProcessOne(context.Background()); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	if len(entryWriter.entries) != 1 {
+		t.Fatalf("expected one written query log entry, got %d", len(entryWriter.entries))
+	}
+	got := entryWriter.entries[0]
+	if got.Query != "SELECT 1" || got.OrgID != "org-a" || got.UserName != "alice" {
+		t.Fatalf("unexpected written entry: %#v", got)
+	}
+	if got.CPUTimeSeconds != 1.25 || got.PeakBufferMemoryBytes != 2048 || got.PostgresScanMs != 7 {
+		t.Fatalf("resource fields did not round-trip: %#v", got)
+	}
+	if len(consumer.commits) != 1 {
+		t.Fatalf("expected one committed Kafka message, got %d", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaWriterDoesNotCommitWhenWriteFails(t *testing.T) {
+	payload, err := json.Marshal(QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-1",
+		EventTime:     time.Unix(1700000000, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 1",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{{Value: payload}},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{err: errors.New("write failed")}
+	resolver := &fakeQueryLogEntryWriterResolver{writer: entryWriter}
+	writer, err := NewQueryLogKafkaWriter(consumer, resolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+
+	if err := writer.ProcessOne(context.Background()); err == nil {
+		t.Fatal("expected ProcessOne to fail")
+	}
+	if len(consumer.commits) != 0 {
+		t.Fatalf("expected no commits after write failure, got %d", len(consumer.commits))
+	}
+	if len(resolver.invalidated) != 1 {
+		t.Fatalf("expected failed writer to be invalidated, got %d invalidations", len(resolver.invalidated))
+	}
+	if resolver.invalidated[0].orgID != "org-a" || resolver.invalidated[0].writer != entryWriter {
+		t.Fatalf("unexpected invalidation: %#v", resolver.invalidated[0])
+	}
+}
+
+func TestQueryLogKafkaWriterRunRetriesFailedMessageBeforeFetchingNext(t *testing.T) {
+	first := QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-first",
+		EventTime:     time.Unix(1700000000, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 1",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	}
+	second := QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-second",
+		EventTime:     time.Unix(1700000001, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 2",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	}
+	firstPayload, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first event: %v", err)
+	}
+	secondPayload, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{
+			{Value: firstPayload},
+			{Value: secondPayload},
+		},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{
+		errs: []error{errors.New("transient write failure"), nil, nil},
+	}
+	writer, err := NewQueryLogKafkaWriter(consumer, &fakeQueryLogEntryWriterResolver{writer: entryWriter})
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+	writer.retryDelay = 0
+
+	err = writer.Run(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run returned %v, want context.Canceled after fake consumer drains", err)
+	}
+	if len(entryWriter.entries) != 2 {
+		t.Fatalf("expected both events to be written after retry, got %d entries", len(entryWriter.entries))
+	}
+	if entryWriter.entries[0].EventID != "evt-first" || entryWriter.entries[1].EventID != "evt-second" {
+		t.Fatalf("unexpected write order: %#v", entryWriter.entries)
+	}
+	if len(consumer.commits) != 2 {
+		t.Fatalf("expected both messages to be committed after writes, got %d commits", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaWriterRunRetriesCommitFailureBeforeFetchingNext(t *testing.T) {
+	first := QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-first",
+		EventTime:     time.Unix(1700000000, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 1",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	}
+	second := QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-second",
+		EventTime:     time.Unix(1700000001, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 2",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	}
+	firstPayload, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first event: %v", err)
+	}
+	secondPayload, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{
+			{Value: firstPayload},
+			{Value: secondPayload},
+		},
+		commitErrs: []error{errors.New("transient commit failure"), nil, nil},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{}
+	writer, err := NewQueryLogKafkaWriter(consumer, &fakeQueryLogEntryWriterResolver{writer: entryWriter})
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+	writer.retryDelay = 0
+
+	err = writer.Run(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run returned %v, want context.Canceled after fake consumer drains", err)
+	}
+	if len(entryWriter.entries) != 3 {
+		t.Fatalf("expected failed commit to retry the same event before the next fetch, got %d entries", len(entryWriter.entries))
+	}
+	if entryWriter.entries[0].EventID != "evt-first" || entryWriter.entries[1].EventID != "evt-first" || entryWriter.entries[2].EventID != "evt-second" {
+		t.Fatalf("unexpected write order: %#v", entryWriter.entries)
+	}
+	if len(consumer.commits) != 2 {
+		t.Fatalf("expected two successful commits after retry, got %d commits", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaWriterCommitsDroppedInvalidEvent(t *testing.T) {
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{{Value: []byte(`{"schema_version":999}`)}},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{}
+	writer, err := NewQueryLogKafkaWriter(consumer, &fakeQueryLogEntryWriterResolver{writer: entryWriter})
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+
+	if err := writer.ProcessOne(context.Background()); err != nil {
+		t.Fatalf("expected dropped invalid event to be committed without retry, got %v", err)
+	}
+	if len(entryWriter.entries) != 0 {
+		t.Fatalf("expected invalid event not to write entries, got %d", len(entryWriter.entries))
+	}
+	if len(consumer.commits) != 1 {
+		t.Fatalf("expected invalid event to be committed after drop, got %d commits", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaWriterAllowsEmptyQueryText(t *testing.T) {
+	payload, err := json.Marshal(QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-empty-query",
+		EventTime:     time.Unix(1700000000, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{{Value: payload}},
+	}
+	entryWriter := &fakeQueryLogEntryWriter{}
+	writer, err := NewQueryLogKafkaWriter(consumer, &fakeQueryLogEntryWriterResolver{writer: entryWriter})
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+
+	if err := writer.ProcessOne(context.Background()); err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if len(entryWriter.entries) != 1 {
+		t.Fatalf("expected one written query log entry, got %d", len(entryWriter.entries))
+	}
+	if entryWriter.entries[0].Query != "" {
+		t.Fatalf("expected empty query text to round-trip, got %q", entryWriter.entries[0].Query)
+	}
+	if len(consumer.commits) != 1 {
+		t.Fatalf("expected empty-query event to commit, got %d commits", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaWriterCommitsWhenOrgHasNoDuckLakeTarget(t *testing.T) {
+	payload, err := json.Marshal(QueryLogKafkaEvent{
+		SchemaVersion: queryLogKafkaSchemaVersion,
+		EventID:       "evt-no-ducklake",
+		EventTime:     time.Unix(1700000000, 0).UTC(),
+		Type:          "QueryFinish",
+		Query:         "SELECT 1",
+		UserName:      "alice",
+		OrgID:         "org-a",
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	consumer := &fakeQueryLogKafkaConsumer{
+		messages: []QueryLogKafkaConsumedMessage{{Value: payload}},
+	}
+	configResolver := &fakeDuckLakeConfigResolver{
+		resolved: QueryLogDuckLakeResolvedConfig{Config: Config{}},
+	}
+	entryWriterResolver, err := NewQueryLogDuckLakeEntryWriterResolver(configResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogDuckLakeEntryWriterResolver: %v", err)
+	}
+	writer, err := NewQueryLogKafkaWriter(consumer, entryWriterResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogKafkaWriter: %v", err)
+	}
+
+	if err := writer.ProcessOne(context.Background()); err != nil {
+		t.Fatalf("expected missing DuckLake target to be committed without retry, got %v", err)
+	}
+	if len(consumer.commits) != 1 {
+		t.Fatalf("expected no-target event to commit, got %d commits", len(consumer.commits))
+	}
+}
+
+func TestQueryLogKafkaEventInsertIsIdempotentByEventID(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := ensureQueryLogTable(db, "", "query_log", "query_log"); err != nil {
+		t.Fatalf("ensureQueryLogTable: %v", err)
+	}
+	writer := &QueryLogDuckLakeEntryWriter{db: db, table: "query_log"}
+	event := QueryLogKafkaEvent{
+		SchemaVersion:         queryLogKafkaSchemaVersion,
+		EventID:               "evt-duplicate",
+		EventTime:             time.Unix(1700000000, 0).UTC(),
+		QueryDurationMs:       42,
+		Type:                  "QueryFinish",
+		Query:                 "SELECT 1",
+		QueryKind:             "Select",
+		UserName:              "alice",
+		OrgID:                 "org-a",
+		CPUTimeSeconds:        1.25,
+		PeakBufferMemoryBytes: 2048,
+	}
+
+	if err := writer.WriteQueryLogKafkaEvent(context.Background(), event); err != nil {
+		t.Fatalf("first WriteQueryLogKafkaEvent: %v", err)
+	}
+	if err := writer.WriteQueryLogKafkaEvent(context.Background(), event); err != nil {
+		t.Fatalf("second WriteQueryLogKafkaEvent: %v", err)
+	}
+
+	var rows int
+	if err := db.QueryRow("SELECT COUNT(*) FROM query_log").Scan(&rows); err != nil {
+		t.Fatalf("count query_log: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("expected duplicate event_id to insert one row, got %d", rows)
+	}
+	var eventID string
+	if err := db.QueryRow("SELECT event_id FROM query_log").Scan(&eventID); err != nil {
+		t.Fatalf("query event_id: %v", err)
+	}
+	if eventID != "evt-duplicate" {
+		t.Fatalf("expected event_id to persist, got %q", eventID)
+	}
+}
+
+func TestQueryLogDuckLakeEntryWriterResolverRefreshesIdleWriters(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	configResolver := &fakeDuckLakeConfigResolver{
+		resolved: QueryLogDuckLakeResolvedConfig{
+			Config: Config{DuckLake: DuckLakeConfig{MetadataStore: "postgres:metadata"}},
+		},
+	}
+	resolver, err := NewQueryLogDuckLakeEntryWriterResolver(configResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogDuckLakeEntryWriterResolver: %v", err)
+	}
+	resolver.now = func() time.Time { return now }
+	resolver.idleTTL = time.Minute
+	var created []*fakeQueryLogEntryWriter
+	resolver.newWriter = func(Config) (QueryLogEntryWriter, error) {
+		w := &fakeQueryLogEntryWriter{}
+		created = append(created, w)
+		return w, nil
+	}
+
+	first, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a")
+	if err != nil {
+		t.Fatalf("first ResolveQueryLogEntryWriter: %v", err)
+	}
+	now = now.Add(time.Minute + time.Second)
+	second, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a")
+	if err != nil {
+		t.Fatalf("second ResolveQueryLogEntryWriter: %v", err)
+	}
+
+	if first == second {
+		t.Fatal("expected idle writer to be refreshed")
+	}
+	if len(created) != 2 {
+		t.Fatalf("expected two writers to be created, got %d", len(created))
+	}
+	if created[0].closed != 1 {
+		t.Fatalf("expected idle writer to be closed on refresh, got %d closes", created[0].closed)
+	}
+}
+
+func TestQueryLogDuckLakeEntryWriterResolverEvictsLeastRecentlyUsedWriter(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	configResolver := &fakeDuckLakeConfigResolver{
+		resolved: QueryLogDuckLakeResolvedConfig{
+			Config: Config{DuckLake: DuckLakeConfig{MetadataStore: "postgres:metadata"}},
+		},
+	}
+	resolver, err := NewQueryLogDuckLakeEntryWriterResolver(configResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogDuckLakeEntryWriterResolver: %v", err)
+	}
+	resolver.now = func() time.Time { return now }
+	resolver.maxCachedWriters = 2
+	resolver.newWriter = func(Config) (QueryLogEntryWriter, error) {
+		return &fakeQueryLogEntryWriter{}, nil
+	}
+
+	writerA, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a")
+	if err != nil {
+		t.Fatalf("resolve org-a: %v", err)
+	}
+	now = now.Add(time.Second)
+	writerB, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-b")
+	if err != nil {
+		t.Fatalf("resolve org-b: %v", err)
+	}
+	now = now.Add(time.Second)
+	if _, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a"); err != nil {
+		t.Fatalf("refresh org-a recency: %v", err)
+	}
+	now = now.Add(time.Second)
+	if _, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-c"); err != nil {
+		t.Fatalf("resolve org-c: %v", err)
+	}
+
+	if _, ok := resolver.writers["org-a"]; !ok {
+		t.Fatal("expected recently used org-a writer to remain cached")
+	}
+	if _, ok := resolver.writers["org-b"]; ok {
+		t.Fatal("expected least recently used org-b writer to be evicted")
+	}
+	if _, ok := resolver.writers["org-c"]; !ok {
+		t.Fatal("expected new org-c writer to be cached")
+	}
+	if writerB.(*fakeQueryLogEntryWriter).closed != 1 {
+		t.Fatalf("expected evicted org-b writer to be closed, got %d closes", writerB.(*fakeQueryLogEntryWriter).closed)
+	}
+	if writerA.(*fakeQueryLogEntryWriter).closed != 0 {
+		t.Fatalf("expected org-a writer to remain open, got %d closes", writerA.(*fakeQueryLogEntryWriter).closed)
+	}
+}
+
+func TestQueryLogDuckLakeEntryWriterResolverPrunesIdleWritersWithoutResolve(t *testing.T) {
+	current := time.Unix(1700000000, 0).UTC()
+	var nowMu sync.Mutex
+	configResolver := &fakeDuckLakeConfigResolver{
+		resolved: QueryLogDuckLakeResolvedConfig{
+			Config: Config{DuckLake: DuckLakeConfig{MetadataStore: "postgres:metadata"}},
+		},
+	}
+	resolver, err := NewQueryLogDuckLakeEntryWriterResolver(configResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogDuckLakeEntryWriterResolver: %v", err)
+	}
+	resolver.now = func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return current
+	}
+	resolver.idleTTL = time.Millisecond
+	resolver.pruneInterval = 10 * time.Millisecond
+	var created []*fakeQueryLogEntryWriter
+	resolver.newWriter = func(Config) (QueryLogEntryWriter, error) {
+		w := &fakeQueryLogEntryWriter{}
+		created = append(created, w)
+		return w, nil
+	}
+
+	if _, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a"); err != nil {
+		t.Fatalf("ResolveQueryLogEntryWriter: %v", err)
+	}
+	nowMu.Lock()
+	current = current.Add(time.Second)
+	nowMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resolver.StartIdlePruner(ctx)
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("idle writer was not pruned")
+		case <-ticker.C:
+			resolver.mu.Lock()
+			closed := created[0].closed
+			cached := len(resolver.writers)
+			resolver.mu.Unlock()
+			if closed == 1 && cached == 0 {
+				return
+			}
+		}
+	}
+}
+
+func TestQueryLogDuckLakeEntryWriterResolverRefreshesExpiringCredentials(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	expiresAt := now.Add(time.Minute)
+	configResolver := &fakeDuckLakeConfigResolver{
+		resolved: QueryLogDuckLakeResolvedConfig{
+			Config:               Config{DuckLake: DuckLakeConfig{MetadataStore: "postgres:metadata"}},
+			CredentialsExpiresAt: &expiresAt,
+		},
+	}
+	resolver, err := NewQueryLogDuckLakeEntryWriterResolver(configResolver)
+	if err != nil {
+		t.Fatalf("NewQueryLogDuckLakeEntryWriterResolver: %v", err)
+	}
+	resolver.now = func() time.Time { return now }
+	var created []*fakeQueryLogEntryWriter
+	resolver.newWriter = func(Config) (QueryLogEntryWriter, error) {
+		w := &fakeQueryLogEntryWriter{}
+		created = append(created, w)
+		return w, nil
+	}
+
+	first, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a")
+	if err != nil {
+		t.Fatalf("first ResolveQueryLogEntryWriter: %v", err)
+	}
+	second, err := resolver.ResolveQueryLogEntryWriter(context.Background(), "org-a")
+	if err != nil {
+		t.Fatalf("second ResolveQueryLogEntryWriter: %v", err)
+	}
+
+	if first == second {
+		t.Fatal("expected expiring writer to be refreshed")
+	}
+	if len(created) != 2 {
+		t.Fatalf("expected two writers to be created, got %d", len(created))
+	}
+	if created[0].closed != 1 {
+		t.Fatalf("expected first writer to be closed on refresh, got %d closes", created[0].closed)
+	}
+	if configResolver.calls != 2 {
+		t.Fatalf("expected config resolver to be called twice, got %d", configResolver.calls)
+	}
+}

--- a/server/querylog_metrics.go
+++ b/server/querylog_metrics.go
@@ -1,0 +1,11 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var queryLogKafkaWriterEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_query_log_kafka_writer_events_total",
+	Help: "Query-log Kafka writer events by outcome.",
+}, []string{"outcome"})

--- a/server/server.go
+++ b/server/server.go
@@ -326,6 +326,7 @@ type QueryLogKafkaConfig struct {
 	Brokers  []string
 	Topic    string
 	ClientID string
+	GroupID  string
 }
 
 // fileDBEntry tracks a shared *sql.DB for file-persistence mode.


### PR DESCRIPTION
## Summary
- add a Kafka query-log writer that consumes query-log events and writes them to the DuckLake-backed system.query_log for each org
- persist event_id and use it for idempotent Kafka retry handling
- add query-log writer mode, Kafka group_id config, metrics, docs, and STS credential-expiry-aware writer caching

## Review Notes
- The writer retries a fetched Kafka message in-place until write plus commit succeeds, so a later commit cannot skip a failed event.
- Current storage writes are intentionally one event at a time with event_id replay protection; batching and scalable dedupe can be a follow-up throughput improvement.
- No e2e harness assertion is included because this PR adds the writer service binary/path but not the deployment topology; that belongs with the deployment PR.

## Tests
- go test -tags kubernetes ./controlplane -run "TestBuildTenantDuckLakeConfig|TestBuildTenantActivationPayload"
- go test ./server -run "TestQueryLogKafkaWriter|TestQueryLogKafkaEventInsert|TestQueryLogDuckLakeEntryWriterResolver"
- go test -tags kubernetes . ./controlplane
- just test-unit
- just lint
