### PR TITLE
[codex] Add scenario runner core

### DIFF
--- a/tests/scenario/core/artifacts.go
+++ b/tests/scenario/core/artifacts.go
@@ -33,6 +33,7 @@ type StepResult struct {
 	FinishedAt   time.Time     `json:"finished_at"`
 	Duration     time.Duration `json:"duration_ns"`
 	Attempts     int           `json:"attempts"`
+	Err          error         `json:"-"`
 }
 
 var stepResultsHeader = []string{
@@ -50,11 +51,8 @@ var stepResultsHeader = []string{
 }
 
 func WriteArtifacts(dir string, summary RunSummary, results []StepResult) error {
-	if dir == "" {
-		return fmt.Errorf("artifact output dir is required")
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create artifact dir %s: %w", dir, err)
+	if err := PrepareArtifactDir(dir); err != nil {
+		return err
 	}
 	if err := writeSummary(filepath.Join(dir, "scenario_summary.json"), summary); err != nil {
 		return err
@@ -64,6 +62,16 @@ func WriteArtifacts(dir string, summary RunSummary, results []StepResult) error 
 	}
 	if err := writeEvents(filepath.Join(dir, "events.jsonl"), results); err != nil {
 		return err
+	}
+	return nil
+}
+
+func PrepareArtifactDir(dir string) error {
+	if dir == "" {
+		return fmt.Errorf("artifact output dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create artifact dir %s: %w", dir, err)
 	}
 	return nil
 }

--- a/tests/scenario/core/artifacts.go
+++ b/tests/scenario/core/artifacts.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+type RunSummary struct {
+	RunID          string    `json:"run_id"`
+	ScenarioName   string    `json:"scenario_name"`
+	StartedAt      time.Time `json:"started_at"`
+	FinishedAt     time.Time `json:"finished_at"`
+	TotalSteps     int       `json:"total_steps"`
+	SucceededSteps int       `json:"succeeded_steps"`
+	FailedSteps    int       `json:"failed_steps"`
+	SkippedSteps   int       `json:"skipped_steps"`
+}
+
+type StepResult struct {
+	RunID        string        `json:"run_id"`
+	ScenarioName string        `json:"scenario_name"`
+	StepID       string        `json:"step_id"`
+	StepType     string        `json:"step_type"`
+	Status       StepStatus    `json:"status"`
+	ErrorClass   string        `json:"error_class,omitempty"`
+	Error        string        `json:"error,omitempty"`
+	StartedAt    time.Time     `json:"started_at"`
+	FinishedAt   time.Time     `json:"finished_at"`
+	Duration     time.Duration `json:"duration_ns"`
+	Attempts     int           `json:"attempts"`
+}
+
+var stepResultsHeader = []string{
+	"run_id",
+	"scenario_name",
+	"step_id",
+	"step_type",
+	"status",
+	"error_class",
+	"error",
+	"started_at",
+	"finished_at",
+	"duration_ms",
+	"attempts",
+}
+
+func WriteArtifacts(dir string, summary RunSummary, results []StepResult) error {
+	if dir == "" {
+		return fmt.Errorf("artifact output dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create artifact dir %s: %w", dir, err)
+	}
+	if err := writeSummary(filepath.Join(dir, "scenario_summary.json"), summary); err != nil {
+		return err
+	}
+	if err := writeStepResults(filepath.Join(dir, "step_results.csv"), results); err != nil {
+		return err
+	}
+	if err := writeEvents(filepath.Join(dir, "events.jsonl"), results); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeSummary(path string, summary RunSummary) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create scenario summary: %w", err)
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(summary); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("encode scenario summary: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close scenario summary: %w", err)
+	}
+	return nil
+}
+
+func writeStepResults(path string, results []StepResult) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create step results csv: %w", err)
+	}
+	w := csv.NewWriter(f)
+	if err := w.Write(stepResultsHeader); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write step results header: %w", err)
+	}
+	for _, result := range results {
+		if err := w.Write(stepResultRecord(result)); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write step result row: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("flush step results csv: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close step results csv: %w", err)
+	}
+	return nil
+}
+
+func stepResultRecord(result StepResult) []string {
+	return []string{
+		result.RunID,
+		result.ScenarioName,
+		result.StepID,
+		result.StepType,
+		string(result.Status),
+		result.ErrorClass,
+		result.Error,
+		result.StartedAt.UTC().Format(time.RFC3339Nano),
+		result.FinishedAt.UTC().Format(time.RFC3339Nano),
+		strconv.FormatFloat(float64(result.Duration)/float64(time.Millisecond), 'f', 6, 64),
+		strconv.Itoa(result.Attempts),
+	}
+}
+
+func writeEvents(path string, results []StepResult) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create events jsonl: %w", err)
+	}
+	enc := json.NewEncoder(f)
+	for _, result := range results {
+		if err := enc.Encode(result); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("encode event: %w", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close events jsonl: %w", err)
+	}
+	return nil
+}

--- a/tests/scenario/core/artifacts_test.go
+++ b/tests/scenario/core/artifacts_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerWritesArtifacts(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: artifact-smoke
+steps:
+  - id: provision
+    type: fake
+  - id: query
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	outputDir := t.TempDir()
+	runner := NewRunner(RunnerConfig{
+		RunID:      "artifact-run",
+		Scenario:   scenario,
+		OutputDir:  outputDir,
+		Executor:   StepExecutorFunc(func(context.Context, Step) error { return nil }),
+		Now:        fixedClock(time.Unix(1700000000, 0).UTC()),
+		WriteFiles: true,
+	})
+	if _, err := runner.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	for _, name := range []string{"scenario_summary.json", "step_results.csv", "events.jsonl"} {
+		if _, err := os.Stat(filepath.Join(outputDir, name)); err != nil {
+			t.Fatalf("expected artifact %s: %v", name, err)
+		}
+	}
+
+	csvBody, err := os.ReadFile(filepath.Join(outputDir, "step_results.csv"))
+	if err != nil {
+		t.Fatalf("read step_results.csv: %v", err)
+	}
+	if !strings.Contains(string(csvBody), "run_id,scenario_name,step_id,step_type,status,error_class,error,started_at,finished_at,duration_ms,attempts") {
+		t.Fatalf("step_results.csv missing expected header:\n%s", string(csvBody))
+	}
+	if !strings.Contains(string(csvBody), "artifact-run,artifact-smoke,query,fake,ok") {
+		t.Fatalf("step_results.csv missing query result:\n%s", string(csvBody))
+	}
+
+	summaryBody, err := os.ReadFile(filepath.Join(outputDir, "scenario_summary.json"))
+	if err != nil {
+		t.Fatalf("read scenario_summary.json: %v", err)
+	}
+	if !strings.Contains(string(summaryBody), `"run_id": "artifact-run"`) {
+		t.Fatalf("summary missing run_id:\n%s", string(summaryBody))
+	}
+
+	eventsBody, err := os.ReadFile(filepath.Join(outputDir, "events.jsonl"))
+	if err != nil {
+		t.Fatalf("read events.jsonl: %v", err)
+	}
+	if lines := strings.Count(strings.TrimSpace(string(eventsBody)), "\n") + 1; lines != 2 {
+		t.Fatalf("expected 2 event lines, got %d:\n%s", lines, string(eventsBody))
+	}
+}

--- a/tests/scenario/core/artifacts_test.go
+++ b/tests/scenario/core/artifacts_test.go
@@ -1,10 +1,13 @@
 package core
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -45,26 +48,119 @@ steps:
 	if err != nil {
 		t.Fatalf("read step_results.csv: %v", err)
 	}
-	if !strings.Contains(string(csvBody), "run_id,scenario_name,step_id,step_type,status,error_class,error,started_at,finished_at,duration_ms,attempts") {
-		t.Fatalf("step_results.csv missing expected header:\n%s", string(csvBody))
+	records, err := csv.NewReader(bytes.NewReader(csvBody)).ReadAll()
+	if err != nil {
+		t.Fatalf("parse step_results.csv: %v", err)
 	}
-	if !strings.Contains(string(csvBody), "artifact-run,artifact-smoke,query,fake,ok") {
-		t.Fatalf("step_results.csv missing query result:\n%s", string(csvBody))
+	if len(records) != 3 {
+		t.Fatalf("expected header plus 2 rows, got %d records: %#v", len(records), records)
+	}
+	if !equalStrings(records[0], stepResultsHeader) {
+		t.Fatalf("step_results.csv header = %#v, want %#v", records[0], stepResultsHeader)
+	}
+	if got := records[2][:5]; !equalStrings(got, []string{"artifact-run", "artifact-smoke", "query", "fake", "ok"}) {
+		t.Fatalf("query result prefix = %#v", got)
 	}
 
 	summaryBody, err := os.ReadFile(filepath.Join(outputDir, "scenario_summary.json"))
 	if err != nil {
 		t.Fatalf("read scenario_summary.json: %v", err)
 	}
-	if !strings.Contains(string(summaryBody), `"run_id": "artifact-run"`) {
-		t.Fatalf("summary missing run_id:\n%s", string(summaryBody))
+	var summary RunSummary
+	if err := json.Unmarshal(summaryBody, &summary); err != nil {
+		t.Fatalf("decode scenario_summary.json: %v", err)
+	}
+	if summary.RunID != "artifact-run" || summary.TotalSteps != 2 || summary.SucceededSteps != 2 {
+		t.Fatalf("unexpected summary: %+v", summary)
 	}
 
 	eventsBody, err := os.ReadFile(filepath.Join(outputDir, "events.jsonl"))
 	if err != nil {
 		t.Fatalf("read events.jsonl: %v", err)
 	}
-	if lines := strings.Count(strings.TrimSpace(string(eventsBody)), "\n") + 1; lines != 2 {
-		t.Fatalf("expected 2 event lines, got %d:\n%s", lines, string(eventsBody))
+	scanner := bufio.NewScanner(bytes.NewReader(eventsBody))
+	var events []StepResult
+	for scanner.Scan() {
+		var event StepResult
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode event JSON: %v", err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan events.jsonl: %v", err)
+	}
+	if len(events) != 2 || events[1].StepID != "query" || events[1].Status != StepStatusOK {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}
+
+func TestRunnerValidatesArtifactOutputBeforeExecutingSteps(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: artifact-preflight
+steps:
+  - id: provision
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	executed := false
+	runner := NewRunner(RunnerConfig{
+		RunID:      "artifact-preflight",
+		Scenario:   scenario,
+		WriteFiles: true,
+		Executor: StepExecutorFunc(func(context.Context, Step) error {
+			executed = true
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0).UTC()),
+	})
+
+	_, err = runner.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected missing output dir to fail")
+	}
+	if executed {
+		t.Fatal("executor ran before artifact output validation")
+	}
+}
+
+func TestRunnerRejectsRegularFileArtifactOutputBeforeExecutingSteps(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: artifact-preflight-file
+steps:
+  - id: provision
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(outputPath, []byte("file"), 0o644); err != nil {
+		t.Fatalf("write output file: %v", err)
+	}
+
+	executed := false
+	runner := NewRunner(RunnerConfig{
+		RunID:      "artifact-preflight-file",
+		Scenario:   scenario,
+		OutputDir:  outputPath,
+		WriteFiles: true,
+		Executor: StepExecutorFunc(func(context.Context, Step) error {
+			executed = true
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0).UTC()),
+	})
+
+	_, err = runner.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected regular-file output path to fail")
+	}
+	if executed {
+		t.Fatal("executor ran before artifact output validation")
 	}
 }

--- a/tests/scenario/core/catalog.go
+++ b/tests/scenario/core/catalog.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -46,7 +47,9 @@ func LoadScenario(path string) (Scenario, error) {
 
 func ParseScenario(raw []byte) (Scenario, error) {
 	var parsed rawScenario
-	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&parsed); err != nil {
 		return Scenario{}, fmt.Errorf("parse scenario: %w", err)
 	}
 	return normalizeScenario(parsed)

--- a/tests/scenario/core/catalog.go
+++ b/tests/scenario/core/catalog.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Scenario struct {
+	Name        string `yaml:"name" json:"name"`
+	RunIDPrefix string `yaml:"run_id_prefix" json:"run_id_prefix,omitempty"`
+	Steps       []Step `yaml:"steps" json:"steps"`
+}
+
+type Step struct {
+	ID        string         `yaml:"id" json:"id"`
+	Type      string         `yaml:"type" json:"type"`
+	DependsOn []string       `yaml:"depends_on" json:"depends_on,omitempty"`
+	AlwaysRun bool           `yaml:"always_run" json:"always_run,omitempty"`
+	With      map[string]any `yaml:"with" json:"with,omitempty"`
+}
+
+type rawScenario struct {
+	Name        string    `yaml:"name"`
+	RunIDPrefix string    `yaml:"run_id_prefix"`
+	Steps       []rawStep `yaml:"steps"`
+}
+
+type rawStep struct {
+	ID        string         `yaml:"id"`
+	Type      string         `yaml:"type"`
+	DependsOn *[]string      `yaml:"depends_on"`
+	AlwaysRun bool           `yaml:"always_run"`
+	With      map[string]any `yaml:"with"`
+}
+
+func LoadScenario(path string) (Scenario, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Scenario{}, fmt.Errorf("read scenario %s: %w", path, err)
+	}
+	return ParseScenario(b)
+}
+
+func ParseScenario(raw []byte) (Scenario, error) {
+	var parsed rawScenario
+	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		return Scenario{}, fmt.Errorf("parse scenario: %w", err)
+	}
+	return normalizeScenario(parsed)
+}
+
+func normalizeScenario(raw rawScenario) (Scenario, error) {
+	scenario := Scenario{
+		Name:        strings.TrimSpace(raw.Name),
+		RunIDPrefix: strings.TrimSpace(raw.RunIDPrefix),
+		Steps:       make([]Step, 0, len(raw.Steps)),
+	}
+	if scenario.Name == "" {
+		return Scenario{}, fmt.Errorf("scenario name is required")
+	}
+	if len(raw.Steps) == 0 {
+		return Scenario{}, fmt.Errorf("scenario steps must include at least one step")
+	}
+
+	seen := make(map[string]struct{}, len(raw.Steps))
+	var previousID string
+	for i, rawStep := range raw.Steps {
+		step := Step{
+			ID:        strings.TrimSpace(rawStep.ID),
+			Type:      strings.TrimSpace(rawStep.Type),
+			AlwaysRun: rawStep.AlwaysRun,
+			With:      rawStep.With,
+		}
+		if step.ID == "" {
+			return Scenario{}, fmt.Errorf("step %d id is required", i)
+		}
+		if step.Type == "" {
+			return Scenario{}, fmt.Errorf("step %s type is required", step.ID)
+		}
+		if _, ok := seen[step.ID]; ok {
+			return Scenario{}, fmt.Errorf("duplicate step id %q", step.ID)
+		}
+
+		switch {
+		case rawStep.DependsOn != nil:
+			step.DependsOn = append([]string(nil), (*rawStep.DependsOn)...)
+		case previousID != "":
+			step.DependsOn = []string{previousID}
+		}
+		for depIdx, dep := range step.DependsOn {
+			dep = strings.TrimSpace(dep)
+			if dep == "" {
+				return Scenario{}, fmt.Errorf("step %s dependency %d is empty", step.ID, depIdx)
+			}
+			if _, ok := seen[dep]; !ok {
+				return Scenario{}, fmt.Errorf("step %s has unknown dependency %q", step.ID, dep)
+			}
+			step.DependsOn[depIdx] = dep
+		}
+
+		seen[step.ID] = struct{}{}
+		previousID = step.ID
+		scenario.Steps = append(scenario.Steps, step)
+	}
+	return scenario, nil
+}

--- a/tests/scenario/core/catalog_test.go
+++ b/tests/scenario/core/catalog_test.go
@@ -105,3 +105,60 @@ steps:
 		t.Fatalf("expected unknown dependency error, got %v", err)
 	}
 }
+
+func TestParseScenarioRejectsUnknownFields(t *testing.T) {
+	for name, raw := range map[string][]byte{
+		"top-level": []byte(`
+name: bad
+stepz: []
+`),
+		"step": []byte(`
+name: bad
+steps:
+  - id: cleanup
+    type: fake
+    alwaysrun: true
+`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseScenario(raw)
+			if err == nil {
+				t.Fatal("expected unknown YAML field to fail")
+			}
+		})
+	}
+}
+
+func TestParseScenarioRejectsUnknownStepFieldWithFieldName(t *testing.T) {
+	_, err := ParseScenario([]byte(`
+name: bad
+steps:
+  - id: cleanup
+    type: fake
+    alwaysrun: true
+`))
+	if err == nil || !strings.Contains(err.Error(), "alwaysrun") {
+		t.Fatalf("expected unknown field name in error, got %v", err)
+	}
+}
+
+func TestParseScenarioAllowsOpenWithMap(t *testing.T) {
+	raw := []byte(`
+name: with-map
+steps:
+  - id: query
+    type: fake
+    with:
+      sql: SELECT 1
+      nested:
+        arbitrary_key: ok
+`)
+
+	scenario, err := ParseScenario(raw)
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+	if scenario.Steps[0].With["sql"] != "SELECT 1" {
+		t.Fatalf("unexpected with map: %#v", scenario.Steps[0].With)
+	}
+}

--- a/tests/scenario/core/catalog_test.go
+++ b/tests/scenario/core/catalog_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseScenarioDefaultsLinearDependencies(t *testing.T) {
+	raw := []byte(`
+name: provision-smoke
+run_id_prefix: scenario-smoke
+steps:
+  - id: provision
+    type: fake
+  - id: query
+    type: fake
+  - id: deprovision
+    type: fake
+    always_run: true
+`)
+
+	scenario, err := ParseScenario(raw)
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+	if scenario.Name != "provision-smoke" {
+		t.Fatalf("scenario name = %q, want provision-smoke", scenario.Name)
+	}
+	if len(scenario.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(scenario.Steps))
+	}
+	if len(scenario.Steps[0].DependsOn) != 0 {
+		t.Fatalf("first step should have no default dependency, got %#v", scenario.Steps[0].DependsOn)
+	}
+	if got := scenario.Steps[1].DependsOn; len(got) != 1 || got[0] != "provision" {
+		t.Fatalf("second step dependencies = %#v, want [provision]", got)
+	}
+	if got := scenario.Steps[2].DependsOn; len(got) != 1 || got[0] != "query" {
+		t.Fatalf("third step dependencies = %#v, want [query]", got)
+	}
+	if !scenario.Steps[2].AlwaysRun {
+		t.Fatal("expected deprovision to be marked always_run")
+	}
+}
+
+func TestParseScenarioHonorsExplicitDependencies(t *testing.T) {
+	raw := []byte(`
+name: fanout
+steps:
+  - id: provision
+    type: fake
+  - id: setup
+    type: fake
+    depends_on: [provision]
+  - id: metadata
+    type: fake
+    depends_on: [setup]
+  - id: perf
+    type: fake
+    depends_on: [setup]
+`)
+
+	scenario, err := ParseScenario(raw)
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+	if got := scenario.Steps[3].DependsOn; len(got) != 1 || got[0] != "setup" {
+		t.Fatalf("perf dependencies = %#v, want [setup]", got)
+	}
+}
+
+func TestParseScenarioRejectsDuplicateStepIDs(t *testing.T) {
+	raw := []byte(`
+name: bad
+steps:
+  - id: provision
+    type: fake
+  - id: provision
+    type: fake
+`)
+
+	_, err := ParseScenario(raw)
+	if err == nil {
+		t.Fatal("expected duplicate step id to fail")
+	}
+	if !strings.Contains(err.Error(), "duplicate step id") {
+		t.Fatalf("expected duplicate step id error, got %v", err)
+	}
+}
+
+func TestParseScenarioRejectsMissingDependency(t *testing.T) {
+	raw := []byte(`
+name: bad
+steps:
+  - id: query
+    type: fake
+    depends_on: [provision]
+`)
+
+	_, err := ParseScenario(raw)
+	if err == nil {
+		t.Fatal("expected missing dependency to fail")
+	}
+	if !strings.Contains(err.Error(), "unknown dependency") {
+		t.Fatalf("expected unknown dependency error, got %v", err)
+	}
+}

--- a/tests/scenario/core/runner.go
+++ b/tests/scenario/core/runner.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -30,7 +31,11 @@ type RunnerConfig struct {
 	Executor   StepExecutor
 	OutputDir  string
 	WriteFiles bool
-	Now        func() time.Time
+	// CleanupTimeout bounds always_run steps. These steps use a context whose
+	// cancellation is detached from the main scenario context so cleanup can run
+	// after the scenario times out.
+	CleanupTimeout time.Duration
+	Now            func() time.Time
 }
 
 type Runner struct {
@@ -62,13 +67,27 @@ func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
 	if r.cfg.Executor == nil {
 		return summary, fmt.Errorf("scenario runner executor is required")
 	}
+	r.results = r.results[:0]
+	if r.cfg.WriteFiles {
+		if err := PrepareArtifactDir(r.cfg.OutputDir); err != nil {
+			summary.FinishedAt = r.cfg.Now()
+			return summary, err
+		}
+	}
 
 	statusByStep := make(map[string]StepStatus, len(r.cfg.Scenario.Steps))
-	r.results = r.results[:0]
+	normalStepsBlocked := false
+	var runErrs []error
 	for _, step := range r.cfg.Scenario.Steps {
-		result := r.runStep(ctx, runID, step, statusByStep)
+		result := r.runStep(ctx, runID, step, statusByStep, normalStepsBlocked)
 		r.results = append(r.results, result)
 		statusByStep[step.ID] = result.Status
+		if result.Err != nil {
+			runErrs = append(runErrs, result.Err)
+		}
+		if !step.AlwaysRun && result.Status != StepStatusOK {
+			normalStepsBlocked = true
+		}
 		switch result.Status {
 		case StepStatusOK:
 			summary.SucceededSteps++
@@ -86,7 +105,7 @@ func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
 		}
 	}
 	if summary.FailedSteps > 0 || summary.SkippedSteps > 0 {
-		return summary, fmt.Errorf("scenario %s failed: %d failed, %d skipped", summary.ScenarioName, summary.FailedSteps, summary.SkippedSteps)
+		return summary, scenarioRunError(summary, runErrs)
 	}
 	return summary, nil
 }
@@ -97,26 +116,23 @@ func (r *Runner) Results() []StepResult {
 	return out
 }
 
-func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByStep map[string]StepStatus) StepResult {
+func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByStep map[string]StepStatus, normalStepsBlocked bool) StepResult {
 	if !step.AlwaysRun {
+		if normalStepsBlocked {
+			return r.skippedResult(runID, step, "prior_step_failed", "a prior non-cleanup step did not complete successfully", nil)
+		}
+		if err := ctx.Err(); err != nil {
+			return r.skippedResult(runID, step, "context_canceled", "scenario context is canceled", err)
+		}
 		if dep, ok := firstUnsuccessfulDependency(step, statusByStep); ok {
-			now := r.cfg.Now()
-			return StepResult{
-				RunID:        runID,
-				ScenarioName: r.cfg.Scenario.Name,
-				StepID:       step.ID,
-				StepType:     step.Type,
-				Status:       StepStatusSkipped,
-				ErrorClass:   "dependency_failed",
-				Error:        fmt.Sprintf("dependency %s did not complete successfully", dep),
-				StartedAt:    now,
-				FinishedAt:   now,
-			}
+			return r.skippedResult(runID, step, "dependency_failed", fmt.Sprintf("dependency %s did not complete successfully", dep), nil)
 		}
 	}
 
 	startedAt := r.cfg.Now()
-	err := r.cfg.Executor.ExecuteStep(ctx, step)
+	stepCtx, cancel := r.contextForStep(ctx, step)
+	defer cancel()
+	err := r.cfg.Executor.ExecuteStep(stepCtx, step)
 	finishedAt := r.cfg.Now()
 	result := StepResult{
 		RunID:        runID,
@@ -133,8 +149,36 @@ func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByS
 		result.Status = StepStatusFailed
 		result.ErrorClass = "execution_error"
 		result.Error = err.Error()
+		result.Err = err
 	}
 	return result
+}
+
+func (r *Runner) skippedResult(runID string, step Step, errorClass, message string, err error) StepResult {
+	now := r.cfg.Now()
+	return StepResult{
+		RunID:        runID,
+		ScenarioName: r.cfg.Scenario.Name,
+		StepID:       step.ID,
+		StepType:     step.Type,
+		Status:       StepStatusSkipped,
+		ErrorClass:   errorClass,
+		Error:        message,
+		StartedAt:    now,
+		FinishedAt:   now,
+		Err:          err,
+	}
+}
+
+func (r *Runner) contextForStep(ctx context.Context, step Step) (context.Context, context.CancelFunc) {
+	if !step.AlwaysRun {
+		return ctx, func() {}
+	}
+	base := context.WithoutCancel(ctx)
+	if r.cfg.CleanupTimeout <= 0 {
+		return base, func() {}
+	}
+	return context.WithTimeout(base, r.cfg.CleanupTimeout)
 }
 
 func firstUnsuccessfulDependency(step Step, statusByStep map[string]StepStatus) (string, bool) {
@@ -152,4 +196,12 @@ func defaultRunID(s Scenario, startedAt time.Time) string {
 		prefix = "scenario"
 	}
 	return fmt.Sprintf("%s-%s", prefix, startedAt.UTC().Format("20060102T150405Z"))
+}
+
+func scenarioRunError(summary RunSummary, causes []error) error {
+	aggregate := fmt.Errorf("scenario %s failed: %d failed, %d skipped", summary.ScenarioName, summary.FailedSteps, summary.SkippedSteps)
+	if len(causes) == 0 {
+		return aggregate
+	}
+	return errors.Join(append([]error{aggregate}, causes...)...)
 }

--- a/tests/scenario/core/runner.go
+++ b/tests/scenario/core/runner.go
@@ -1,0 +1,155 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type StepStatus string
+
+const (
+	StepStatusOK      StepStatus = "ok"
+	StepStatusFailed  StepStatus = "failed"
+	StepStatusSkipped StepStatus = "skipped"
+)
+
+type StepExecutor interface {
+	ExecuteStep(context.Context, Step) error
+}
+
+type StepExecutorFunc func(context.Context, Step) error
+
+func (f StepExecutorFunc) ExecuteStep(ctx context.Context, step Step) error {
+	return f(ctx, step)
+}
+
+type RunnerConfig struct {
+	RunID      string
+	Scenario   Scenario
+	Executor   StepExecutor
+	OutputDir  string
+	WriteFiles bool
+	Now        func() time.Time
+}
+
+type Runner struct {
+	cfg     RunnerConfig
+	results []StepResult
+}
+
+func NewRunner(cfg RunnerConfig) *Runner {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Runner{cfg: cfg}
+}
+
+func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
+	startedAt := r.cfg.Now()
+	runID := r.cfg.RunID
+	if runID == "" {
+		runID = defaultRunID(r.cfg.Scenario, startedAt)
+	}
+	summary := RunSummary{
+		RunID:        runID,
+		ScenarioName: r.cfg.Scenario.Name,
+		StartedAt:    startedAt,
+		FinishedAt:   startedAt,
+		TotalSteps:   len(r.cfg.Scenario.Steps),
+	}
+
+	if r.cfg.Executor == nil {
+		return summary, fmt.Errorf("scenario runner executor is required")
+	}
+
+	statusByStep := make(map[string]StepStatus, len(r.cfg.Scenario.Steps))
+	r.results = r.results[:0]
+	for _, step := range r.cfg.Scenario.Steps {
+		result := r.runStep(ctx, runID, step, statusByStep)
+		r.results = append(r.results, result)
+		statusByStep[step.ID] = result.Status
+		switch result.Status {
+		case StepStatusOK:
+			summary.SucceededSteps++
+		case StepStatusFailed:
+			summary.FailedSteps++
+		case StepStatusSkipped:
+			summary.SkippedSteps++
+		}
+	}
+	summary.FinishedAt = r.cfg.Now()
+
+	if r.cfg.WriteFiles {
+		if err := WriteArtifacts(r.cfg.OutputDir, summary, r.results); err != nil {
+			return summary, err
+		}
+	}
+	if summary.FailedSteps > 0 || summary.SkippedSteps > 0 {
+		return summary, fmt.Errorf("scenario %s failed: %d failed, %d skipped", summary.ScenarioName, summary.FailedSteps, summary.SkippedSteps)
+	}
+	return summary, nil
+}
+
+func (r *Runner) Results() []StepResult {
+	out := make([]StepResult, len(r.results))
+	copy(out, r.results)
+	return out
+}
+
+func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByStep map[string]StepStatus) StepResult {
+	if !step.AlwaysRun {
+		if dep, ok := firstUnsuccessfulDependency(step, statusByStep); ok {
+			now := r.cfg.Now()
+			return StepResult{
+				RunID:        runID,
+				ScenarioName: r.cfg.Scenario.Name,
+				StepID:       step.ID,
+				StepType:     step.Type,
+				Status:       StepStatusSkipped,
+				ErrorClass:   "dependency_failed",
+				Error:        fmt.Sprintf("dependency %s did not complete successfully", dep),
+				StartedAt:    now,
+				FinishedAt:   now,
+			}
+		}
+	}
+
+	startedAt := r.cfg.Now()
+	err := r.cfg.Executor.ExecuteStep(ctx, step)
+	finishedAt := r.cfg.Now()
+	result := StepResult{
+		RunID:        runID,
+		ScenarioName: r.cfg.Scenario.Name,
+		StepID:       step.ID,
+		StepType:     step.Type,
+		Status:       StepStatusOK,
+		StartedAt:    startedAt,
+		FinishedAt:   finishedAt,
+		Duration:     finishedAt.Sub(startedAt),
+		Attempts:     1,
+	}
+	if err != nil {
+		result.Status = StepStatusFailed
+		result.ErrorClass = "execution_error"
+		result.Error = err.Error()
+	}
+	return result
+}
+
+func firstUnsuccessfulDependency(step Step, statusByStep map[string]StepStatus) (string, bool) {
+	for _, dep := range step.DependsOn {
+		if statusByStep[dep] != StepStatusOK {
+			return dep, true
+		}
+	}
+	return "", false
+}
+
+func defaultRunID(s Scenario, startedAt time.Time) string {
+	prefix := s.RunIDPrefix
+	if prefix == "" {
+		prefix = "scenario"
+	}
+	return fmt.Sprintf("%s-%s", prefix, startedAt.UTC().Format("20060102T150405Z"))
+}

--- a/tests/scenario/core/runner_test.go
+++ b/tests/scenario/core/runner_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+type contextKey string
+
 func TestRunnerRunsAlwaysRunStepAfterFailureAndSkipsDependents(t *testing.T) {
 	scenario, err := ParseScenario([]byte(`
 name: failure-cleanup
@@ -60,6 +62,130 @@ steps:
 	}
 	if results[3].StepID != "deprovision" || results[3].Status != StepStatusOK {
 		t.Fatalf("expected deprovision to run successfully, got %+v", results[3])
+	}
+}
+
+func TestRunnerDoesNotLetAlwaysRunCleanupUnblockLaterNormalSteps(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: cleanup-does-not-unblock
+steps:
+  - id: query
+    type: fake
+  - id: cleanup
+    type: fake
+    always_run: true
+  - id: after_cleanup
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	var executed []string
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-cleanup",
+		Scenario: scenario,
+		Executor: StepExecutorFunc(func(_ context.Context, step Step) error {
+			executed = append(executed, step.ID)
+			if step.ID == "query" {
+				return errors.New("query failed")
+			}
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	summary, err := runner.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected runner to return failure")
+	}
+	if want := []string{"query", "cleanup"}; !equalStrings(executed, want) {
+		t.Fatalf("executed steps = %#v, want %#v", executed, want)
+	}
+	if summary.FailedSteps != 1 || summary.SkippedSteps != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	results := runner.Results()
+	if results[2].StepID != "after_cleanup" || results[2].Status != StepStatusSkipped {
+		t.Fatalf("expected after_cleanup to be skipped, got %+v", results[2])
+	}
+}
+
+func TestRunnerUsesUncancelledContextForAlwaysRunCleanup(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: cancelled-cleanup
+steps:
+  - id: query
+    type: fake
+  - id: deprovision
+    type: fake
+    always_run: true
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	baseCtx := context.WithValue(context.Background(), contextKey("trace"), "scenario-trace")
+	ctx, cancel := context.WithCancel(baseCtx)
+	var cleanupContextErr error
+	var cleanupContextValue any
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-cancelled",
+		Scenario: scenario,
+		Executor: StepExecutorFunc(func(stepCtx context.Context, step Step) error {
+			switch step.ID {
+			case "query":
+				cancel()
+				return context.Canceled
+			case "deprovision":
+				cleanupContextErr = stepCtx.Err()
+				cleanupContextValue = stepCtx.Value(contextKey("trace"))
+			}
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	_, err = runner.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runner error = %v, want context.Canceled", err)
+	}
+	if cleanupContextErr != nil {
+		t.Fatalf("cleanup context err = %v, want nil", cleanupContextErr)
+	}
+	if cleanupContextValue != "scenario-trace" {
+		t.Fatalf("cleanup context value = %v, want scenario-trace", cleanupContextValue)
+	}
+	results := runner.Results()
+	if results[1].StepID != "deprovision" || results[1].Status != StepStatusOK {
+		t.Fatalf("expected deprovision to run successfully, got %+v", results[1])
+	}
+}
+
+func TestRunnerPreservesExecutorError(t *testing.T) {
+	sentinel := errors.New("sentinel failure")
+	scenario, err := ParseScenario([]byte(`
+name: sentinel
+steps:
+  - id: query
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-sentinel",
+		Scenario: scenario,
+		Executor: StepExecutorFunc(func(context.Context, Step) error {
+			return sentinel
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	_, err = runner.Run(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runner error = %v, want sentinel failure", err)
 	}
 }
 

--- a/tests/scenario/core/runner_test.go
+++ b/tests/scenario/core/runner_test.go
@@ -1,0 +1,114 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunnerRunsAlwaysRunStepAfterFailureAndSkipsDependents(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: failure-cleanup
+steps:
+  - id: provision
+    type: fake
+  - id: query
+    type: fake
+  - id: downstream
+    type: fake
+  - id: deprovision
+    type: fake
+    depends_on: [query]
+    always_run: true
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	var executed []string
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-1",
+		Scenario: scenario,
+		Executor: StepExecutorFunc(func(_ context.Context, step Step) error {
+			executed = append(executed, step.ID)
+			if step.ID == "query" {
+				return errors.New("query failed")
+			}
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	summary, err := runner.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected runner to return failure")
+	}
+	wantExecuted := []string{"provision", "query", "deprovision"}
+	if !equalStrings(executed, wantExecuted) {
+		t.Fatalf("executed steps = %#v, want %#v", executed, wantExecuted)
+	}
+	if summary.TotalSteps != 4 || summary.SucceededSteps != 2 || summary.FailedSteps != 1 || summary.SkippedSteps != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	results := runner.Results()
+	if len(results) != 4 {
+		t.Fatalf("expected 4 step results, got %d", len(results))
+	}
+	if results[2].StepID != "downstream" || results[2].Status != StepStatusSkipped {
+		t.Fatalf("expected downstream to be skipped, got %+v", results[2])
+	}
+	if results[3].StepID != "deprovision" || results[3].Status != StepStatusOK {
+		t.Fatalf("expected deprovision to run successfully, got %+v", results[3])
+	}
+}
+
+func TestRunnerReturnsSuccessForAllSuccessfulSteps(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: success
+steps:
+  - id: provision
+    type: fake
+  - id: query
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-2",
+		Scenario: scenario,
+		Executor: StepExecutorFunc(func(context.Context, Step) error {
+			return nil
+		}),
+		Now: fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	summary, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if summary.RunID != "run-2" {
+		t.Fatalf("summary run id = %q, want run-2", summary.RunID)
+	}
+	if summary.TotalSteps != 2 || summary.SucceededSteps != 2 || summary.FailedSteps != 0 || summary.SkippedSteps != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func fixedClock(ts time.Time) func() time.Time {
+	return func() time.Time { return ts }
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/scenario/scenarios/provision_smoke.yaml
+++ b/tests/scenario/scenarios/provision_smoke.yaml
@@ -1,0 +1,10 @@
+name: provision-smoke
+run_id_prefix: scenario-smoke
+steps:
+  - id: provision
+    type: fake
+  - id: select_one
+    type: fake
+  - id: deprovision
+    type: fake
+    always_run: true


### PR DESCRIPTION
## Summary

Adds the first slice of the Duckgres Scenario Runner under `tests/scenario/core`:

- scenario YAML parsing and validation
- default linear dependencies with explicit `depends_on` support
- `always_run` cleanup semantics
- skipped dependent step recording
- scenario artifacts: `scenario_summary.json`, `step_results.csv`, and `events.jsonl`
- a fake `provision_smoke.yaml` fixture for the PR 1 runner contract

## Why

This establishes the pure-Go scenario runner core before adding real dev provisioning, PGWire connections, perf adapters, or dbt execution. The package has no network or dev-environment dependency, so the behavior is covered with local unit tests first.

## Validation

- `go test ./tests/scenario/...`
- `just lint`