### PR TITLE
fix(controlplane): reap hot-idle workers on a refresh-immune idle clock

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -468,8 +468,20 @@ type WorkerRecord struct {
 	// rows from before this column existed — both are treated as "due now"
 	// by the scheduler so they get refreshed eagerly.
 	S3CredentialsExpiresAt *time.Time `gorm:"index" json:"s3_credentials_expires_at,omitempty"`
-	CreatedAt              time.Time  `json:"created_at"`
-	UpdatedAt              time.Time  `json:"updated_at"`
+	// HotIdleSince is when the worker most recently entered the hot_idle state.
+	// The hot-idle TTL reaper measures idle age from this column instead of
+	// updated_at, because updated_at is legitimately bumped by lease and
+	// credential-refresh writes (BumpWorkerEpoch, MarkCredentialsRefreshed) that
+	// do not change a worker's idleness — keying the reap clock off it let a
+	// periodically-refreshed hot-idle worker reset its own TTL forever and never
+	// get retired. Stamped only on the transition into hot_idle and preserved
+	// across same-state upserts/refreshes. NULL on non-hot-idle rows and on
+	// legacy rows predating this column; the reaper falls back to updated_at when
+	// NULL so legacy hot-idle rows still expire. AutoMigrate adds this column; no
+	// migration file.
+	HotIdleSince *time.Time `gorm:"index" json:"hot_idle_since,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
 
 func (WorkerRecord) TableName() string { return "worker_records" }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -815,6 +815,17 @@ func (cs *ConfigStore) ExpireDrainingControlPlaneInstances(before time.Time) (in
 
 // UpsertWorkerRecord inserts or updates a runtime worker row.
 func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
+	// Stamp hot_idle_since when a row first enters hot_idle so the reaper has a
+	// stable idle clock that lease/credential-refresh writes can't reset (see
+	// WorkerRecord.HotIdleSince). Done at the store layer so every caller that
+	// transitions a worker to hot_idle gets it regardless of how it built the
+	// record. The ON CONFLICT expression below preserves the existing value when
+	// the row was already hot_idle, so this fresh stamp only takes effect on a
+	// genuine transition into hot_idle.
+	if record.State == WorkerStateHotIdle && record.HotIdleSince == nil {
+		now := time.Now()
+		record.HotIdleSince = &now
+	}
 	protectedStates := []WorkerState{WorkerStateDraining, WorkerStateRetired, WorkerStateLost}
 	result := cs.db.Table(cs.runtimeTable(record.TableName())).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "worker_id"}},
@@ -823,7 +834,19 @@ func (cs *ConfigStore) UpsertWorkerRecord(record *WorkerRecord) error {
 		// with an empty profile) actually persists. Without them the ON CONFLICT
 		// update silently dropped the profile, so a sized worker's hot-idle row
 		// stayed empty and ClaimHotIdleWorker could never match it (no reuse).
-		DoUpdates: clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at", "profile_cpu", "profile_memory", "ttl_minutes"}),
+		//
+		// hot_idle_since is set conditionally: take the incoming value only on a
+		// transition INTO hot_idle from another state; preserve the existing
+		// value when the row was already hot_idle so a same-state re-upsert does
+		// not reset the idle clock.
+		DoUpdates: append(
+			clause.AssignmentColumns([]string{"pod_name", "image", "state", "org_id", "owner_cp_instance_id", "owner_epoch", "activation_started_at", "last_heartbeat_at", "retire_reason", "s3_credentials_expires_at", "updated_at", "profile_cpu", "profile_memory", "ttl_minutes"}),
+			clause.Assignments(map[string]any{
+				"hot_idle_since": gorm.Expr(
+					`CASE WHEN excluded."state" = ? AND "worker_records"."state" <> ? THEN excluded."hot_idle_since" ELSE "worker_records"."hot_idle_since" END`,
+					WorkerStateHotIdle, WorkerStateHotIdle),
+			})...,
+		),
 		Where: clause.Where{Exprs: []clause.Expression{
 			clause.Expr{SQL: `"worker_records"."state" NOT IN ?`, Vars: []any{protectedStates}},
 			clause.Expr{SQL: `(excluded."owner_epoch" > "worker_records"."owner_epoch" OR (excluded."owner_epoch" = "worker_records"."owner_epoch" AND excluded."owner_cp_instance_id" = "worker_records"."owner_cp_instance_id"))`},
@@ -946,13 +969,14 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID, image string
 	return claimed, missReason, nil
 }
 
-// ListExpiredHotIdleWorkers returns hot-idle workers whose updated_at timestamp
-// is at or before the given cutoff time.
 // ListExpiredHotIdleWorkers returns hot-idle workers whose per-worker TTL has
-// elapsed since they last became idle (updated_at, bumped on the hot->hot_idle
-// transition at session end, so the TTL resets on each query). A worker's
-// ttl_seconds governs it; 0 falls back to defaultTTL (default/legacy and
-// unassigned rows).
+// elapsed since they last became idle. Idle age is measured from hot_idle_since
+// (stamped on the hot->hot_idle transition), NOT updated_at: updated_at is
+// bumped by lease and credential-refresh writes that don't change idleness, so
+// keying off it let a periodically-refreshed worker reset its own TTL forever.
+// Legacy rows with a NULL hot_idle_since fall back to updated_at so they still
+// expire. A worker's ttl_minutes governs it; 0 falls back to defaultTTL
+// (default/legacy and unassigned rows).
 func (cs *ConfigStore) ListExpiredHotIdleWorkers(now time.Time, defaultTTL time.Duration) ([]WorkerRecord, error) {
 	defMins := int64(defaultTTL.Minutes())
 	if defMins < 0 {
@@ -960,7 +984,7 @@ func (cs *ConfigStore) ListExpiredHotIdleWorkers(now time.Time, defaultTTL time.
 	}
 	var workers []WorkerRecord
 	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("state = ? AND updated_at + (CASE WHEN COALESCE(ttl_minutes, 0) > 0 THEN ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
+		Where("state = ? AND COALESCE(hot_idle_since, updated_at) + (CASE WHEN COALESCE(ttl_minutes, 0) > 0 THEN ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
 			WorkerStateHotIdle, defMins, now).
 		Find(&workers).Error
 	if err != nil {

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -2453,6 +2453,133 @@ func TestTakeOverWorkerSkipsNonReclaimableStatesPostgres(t *testing.T) {
 	}
 }
 
+// Regression: the hot-idle reaper must measure idle age from hot_idle_since, not
+// updated_at. Lease and credential-refresh writes (BumpWorkerEpoch,
+// MarkCredentialsRefreshed) bump updated_at without changing idleness; keying the
+// reap clock off updated_at let a periodically-refreshed hot-idle worker reset its
+// own TTL forever and never get retired.
+func TestListExpiredHotIdleWorkersUsesHotIdleSinceNotUpdatedAt(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	base := time.Now()
+	tbl := store.RuntimeSchema() + ".worker_records"
+
+	mk := func(id int) {
+		if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			WorkerID:          id,
+			PodName:           fmt.Sprintf("duckgres-worker-his-%d", id),
+			State:             configstore.WorkerStateHotIdle,
+			OrgID:             "analytics",
+			Image:             "duckgres:v2",
+			OwnerCPInstanceID: "cp:boot",
+			OwnerEpoch:        1,
+			LastHeartbeatAt:   base,
+			TTLMinutes:        5,
+		}); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", id, err)
+		}
+	}
+	setTimestamps := func(id int, hotIdleSince, updatedAt time.Time) {
+		if err := store.DB().Exec(
+			fmt.Sprintf(`UPDATE %s SET hot_idle_since = ?, updated_at = ? WHERE worker_id = ?`, tbl),
+			hotIdleSince, updatedAt, id,
+		).Error; err != nil {
+			t.Fatalf("set worker %d timestamps: %v", id, err)
+		}
+	}
+
+	// Worker 1 became idle long ago (base) but a credential refresh bumped its
+	// updated_at recently (base+29m). It must still expire on its hot_idle_since.
+	mk(1)
+	setTimestamps(1, base, base.Add(29*time.Minute))
+	// Worker 2 genuinely became idle recently (base+29m); it must NOT expire,
+	// proving the reaper consults hot_idle_since rather than returning everything.
+	mk(2)
+	setTimestamps(2, base.Add(29*time.Minute), base.Add(29*time.Minute))
+
+	expired, err := store.ListExpiredHotIdleWorkers(base.Add(30*time.Minute), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
+	}
+	got := map[int]bool{}
+	for _, w := range expired {
+		got[w.WorkerID] = true
+	}
+	if !got[1] {
+		t.Error("worker idle since base (ttl 5m) must expire despite a recent updated_at bump")
+	}
+	if got[2] {
+		t.Error("worker that became idle only 1m before the cutoff must not expire")
+	}
+}
+
+// hot_idle_since is stamped on entry into hot_idle and preserved across same-state
+// re-upserts (so a re-write of an already-hot-idle row cannot reset the reap
+// clock), but is re-stamped when a worker leaves and re-enters hot_idle.
+func TestUpsertWorkerRecordStampsAndPreservesHotIdleSince(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	tbl := store.RuntimeSchema() + ".worker_records"
+	rec := configstore.WorkerRecord{
+		WorkerID:          1,
+		PodName:           "duckgres-worker-his",
+		State:             configstore.WorkerStateHotIdle,
+		OrgID:             "analytics",
+		Image:             "duckgres:v2",
+		OwnerCPInstanceID: "cp:boot",
+		OwnerEpoch:        1,
+		LastHeartbeatAt:   time.Now(),
+	}
+	upsert := func() {
+		t.Helper()
+		rec.HotIdleSince = nil // caller does not carry it; the store stamps on entry
+		if err := store.UpsertWorkerRecord(&rec); err != nil {
+			t.Fatalf("UpsertWorkerRecord(epoch %d, state %s): %v", rec.OwnerEpoch, rec.State, err)
+		}
+	}
+
+	upsert()
+	first, err := store.GetWorkerRecord(1)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if first.HotIdleSince == nil {
+		t.Fatal("hot_idle_since must be stamped on entry into hot_idle")
+	}
+
+	// Backdate to a known past value so the re-stamp comparison is deterministic.
+	past := time.Now().Add(-time.Hour).UTC().Truncate(time.Microsecond)
+	if err := store.DB().Exec(
+		fmt.Sprintf(`UPDATE %s SET hot_idle_since = ? WHERE worker_id = ?`, tbl), past, 1,
+	).Error; err != nil {
+		t.Fatalf("backdate hot_idle_since: %v", err)
+	}
+
+	// Same-state re-upsert must preserve the existing hot_idle_since.
+	rec.OwnerEpoch = 2
+	upsert()
+	preserved, err := store.GetWorkerRecord(1)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if preserved.HotIdleSince == nil || !preserved.HotIdleSince.Equal(past) {
+		t.Errorf("hot_idle_since must be preserved across same-state upsert: got %v, want %v", preserved.HotIdleSince, past)
+	}
+
+	// Leaving hot_idle and re-entering must re-stamp to a fresh time.
+	rec.State = configstore.WorkerStateHot
+	rec.OwnerEpoch = 3
+	upsert()
+	rec.State = configstore.WorkerStateHotIdle
+	rec.OwnerEpoch = 4
+	upsert()
+	reentered, err := store.GetWorkerRecord(1)
+	if err != nil {
+		t.Fatalf("GetWorkerRecord: %v", err)
+	}
+	if reentered.HotIdleSince == nil || !reentered.HotIdleSince.After(past) {
+		t.Errorf("hot_idle_since must be re-stamped on re-entry into hot_idle: got %v, want after %v", reentered.HotIdleSince, past)
+	}
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }


### PR DESCRIPTION
## Problem

Hot-idle workers accumulate and are never retired. Each holds its full CPU/memory reservation, so once the worker nodepool fills, new worker spawns can't schedule and connections that need a fresh worker hang.

## Root cause

The hot-idle TTL reaper (`ListExpiredHotIdleWorkers`) measured idle age from `worker_records.updated_at`:

```sql
WHERE state = 'hot_idle' AND updated_at + ttl * interval '1 minute' <= now
```

But `updated_at` is also bumped by writes that have nothing to do with idleness:

- `BumpWorkerEpoch` (lease refresh) — `Updates({owner_epoch+1, updated_at: now()})`
- `MarkCredentialsRefreshed` (STS cred refresh) — `Updates({s3_credentials_expires_at, updated_at: now()})`

The credential-refresh scheduler runs on a short interval and **includes `hot_idle` workers**. Since STS creds are refreshed more frequently than the hot-idle TTL window, every refresh pushed `updated_at` forward and the reaper's `updated_at + ttl <= now` condition was never satisfied. A periodically-refreshed hot-idle worker reset its own TTL forever.

Observed in production: the `janitor_hot_idle_ttl` retirement transition had fired only a handful of times over a multi-day window while dozens of `hot_idle` workers sat un-reaped, each reserving its full worker shape.

## Fix

Two columns were doing one job. Split them:

- Add `worker_records.hot_idle_since`, stamped **only** on the transition into `hot_idle` and **preserved** across same-state upserts/refreshes (conditional `ON CONFLICT` assignment).
- Key the reaper off `COALESCE(hot_idle_since, updated_at)`.

Lease/credential refreshes bump `updated_at` but never `hot_idle_since`, so the reap clock is immune to them. Legacy rows (NULL `hot_idle_since`) fall back to `updated_at`, preserving prior behaviour so they still expire. The column is additive — added via the existing runtime-table `AutoMigrate`, no migration file.

## Testing

`go test ./tests/configstore/` (Postgres-backed):

- `TestListExpiredHotIdleWorkersUsesHotIdleSinceNotUpdatedAt` — a worker whose `updated_at` was bumped recently (simulating a credential refresh) still expires on its `hot_idle_since`; a genuinely recently-idle worker does not. Fails against the old `updated_at` predicate.
- `TestUpsertWorkerRecordStampsAndPreservesHotIdleSince` — `hot_idle_since` is stamped on entry, preserved across same-state re-upserts, and re-stamped on re-entry into `hot_idle`.
- Existing `TestListExpiredHotIdleWorkersPerWorkerTTL` and the rest of the package still pass (no behaviour regression).

`just lint` clean.
