### PR TITLE
admin: models explorer dashboard UI + local dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ tmp/
 # Built Go binaries (build artifacts, never commit)
 /duckgres-controlplane
 /duckgres-worker
+/devserver

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ In topologies 2 and 3, the control plane also exposes an Arrow Flight SQL ingres
   - Flight SQL ingress adapter: `flight_ingress.go`
   - Runtime loops: `janitor.go`, `leader_loop.go`, `memory_rebalancer.go`, `runtime_tracker.go`
   - K8s / multitenant under build tag `kubernetes` (including: `multitenant.go`, `k8s_pool.go`, `k8s_pool_acquire.go`, `k8s_pool_spawn.go`, `k8s_pool_lifecycle.go`, `k8s_pool_reconcile.go`, `k8s_pool_helpers.go`, `k8s_factory.go`, `org_router.go`, `org_reserved_pool.go`, `sts_broker.go`, `shared_worker_activator.go`, `worker_rpc_security.go`, `janitor_leader_k8s.go`)
-  - Subpackages: `admin/` (HTTP admin API, `kubernetes` tag), `provisioner/` (k8s controller, `kubernetes` tag), `provisioning/` (HTTP API), `configstore/` (Postgres-backed config)
+  - Subpackages: `admin/` (HTTP admin API + dashboard, `kubernetes` tag; includes the models explorer UI `static/models.html` + `models_api.go`, and `devserver/` for local UI dev against a port-forwarded CP — see `admin/README.md`), `provisioner/` (k8s controller, `kubernetes` tag), `provisioning/` (HTTP API), `configstore/` (Postgres-backed config)
 - **duckdbservice/** — DuckDB Arrow Flight SQL service
   - Core: `service.go`, `flight_handler.go`, `arrow_helpers.go`, `auth.go`, `config.go`
   - Lifecycle, caching, profiling, metrics: `activation.go`, `transient.go`, `cache_proxy.go`, `profiling.go`, `progress.go`, `metrics.go`

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -1,0 +1,74 @@
+# Control-plane admin dashboard
+
+The control plane (multi-tenant / `kubernetes` build tag) serves a small admin
+dashboard on `:8080`. It is gated behind the internal secret — there is no
+public exposure; reach it via `kubectl port-forward`.
+
+## Pages
+
+| Route | Page | Purpose |
+|-------|------|---------|
+| `/`, `/models` | `static/models.html` | **Models explorer** — the primary surface. Sidebar of every config-store model grouped Tenants / Config / Runtime, a table of the selected model's rows, and a click-through detail panel. Nested warehouse sub-configs render as expandable sections. |
+| `/orgs` | `static/orgs.html` | Org list + create/delete. |
+| `/workers` | `static/workers.html` | Live worker/duckling status. |
+| `/sessions` | `static/sessions.html` | Active sessions. |
+| `/settings` | `static/settings.html` | Singleton config editing. |
+| `POST /login` | `static/login.html` | Token login (sets the `duckgres_admin_token` cookie). |
+
+The pages are plain HTML + vanilla JS served via `//go:embed static/*` and
+`html/template`. The models explorer and login page follow the dark "mission
+control" design language (Chakra Petch + IBM Plex Mono, cyan/amber accents).
+Because the templates are parsed with `html/template`, **do not write `{{` in
+their inline JS** — only `login.html` uses template directives (`{{.Next}}` /
+`{{.Error}}`).
+
+## Auth
+
+- Service-to-service: `X-Duckgres-Internal-Secret` header.
+- Dashboard UI: the `POST /login` form mints an `HttpOnly` cookie.
+- The internal secret plus rotation fallbacks are accepted (see `TokenSet`).
+- `?token=` URL auth is deliberately rejected (#721).
+
+## Models explorer API (read-only)
+
+Backed by `models_api.go`. The registry in `modelDescriptors()` is the single
+source of truth — add a config-store model there and it appears in the sidebar,
+listing, and column derivation.
+
+- `GET /api/v1/models` → `{ "models": [ { key, label, group, count } ] }` — sidebar with live row counts.
+- `GET /api/v1/models/:model` → `{ key, label, group, table, columns, count, truncated, rows }` — one model's rows.
+
+Rows are scanned into the typed model and marshaled via its `json` tags, so
+columns tagged `json:"-"` (`OrgUser.Password`, `OrgUserSecret.Ciphertext`,
+`DuckLakeConfig.S3SecretKey`, the singleton IDs) are dropped from the response —
+**never swap the typed scan for a raw `map` scan**, that would leak them.
+Runtime-schema tables (`worker_records`, `cp_instances`, …) are schema-qualified
+with `ConfigStore.RuntimeSchema()`. Listings are capped at `modelsRowLimit`
+(`truncated: true` when hit).
+
+Covered by `models_api_test.go` (redaction + real query path) and the
+`models_explorer_api` assertion in `tests/e2e-mw-dev/harness.sh`.
+
+## Local UI development (no redeploy)
+
+Iterate on the UI against a *deployed* control plane without rebuilding the
+image. A tiny dev proxy (`devserver/`) serves `static/` off disk and proxies
+`/api`, `/login`, `/health` to the port-forwarded CP, injecting the internal
+secret server-side. The browser sees one origin → no CORS, and the secret never
+reaches page JS. The embedded UI uses relative `/api/v1` paths, so the same HTML
+runs byte-for-byte embedded or under the dev proxy.
+
+```sh
+# 1. port-forward the deployed control plane's admin API (own terminal):
+just ui-port-forward                       # defaults: posthog-mw-dev / duckgres / duckgres-control-plane
+#   or: kubectl --context <ctx> -n <ns> port-forward deploy/<cp> 8080:8080
+
+# 2. serve the UI locally, pointed at the port-forward:
+DUCKGRES_INTERNAL_SECRET=<cp-secret> just ui-dev
+#   → http://127.0.0.1:5173
+
+# 3. edit controlplane/admin/static/*.html and refresh the browser. No rebuild.
+```
+
+Once the markup is right, it is already what `//go:embed` bakes into the CP — no
+separate build step.

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -72,6 +72,10 @@ type OrgStackInfo interface {
 // RegisterAPI registers all admin REST endpoints on the given router group.
 func RegisterAPI(r *gin.RouterGroup, store *configstore.ConfigStore, info OrgStackInfo) {
 	registerAPIWithStore(r, newGormAPIStore(store), info)
+	// Generic read-only models explorer (sidebar + table + detail UI). Reads
+	// the concrete store directly because it needs the runtime schema name and
+	// raw DB for tables the typed apiStore interface doesn't surface.
+	registerModelsAPI(r, store)
 }
 
 func registerAPIWithStore(r *gin.RouterGroup, store apiStore, info OrgStackInfo) {

--- a/controlplane/admin/dashboard.go
+++ b/controlplane/admin/dashboard.go
@@ -85,7 +85,11 @@ func APIAuthMiddleware(tokens TokenSet) gin.HandlerFunc {
 
 // RegisterDashboard serves the admin dashboard on the Gin engine.
 func RegisterDashboard(r *gin.Engine, tokens TokenSet) {
-	r.GET("/", dashboardPageHandler("index.html", tokens))
+	// The models explorer is the primary dashboard surface: a sidebar of every
+	// config-store model, a table of its rows, and a detail view per row. "/"
+	// and "/models" both land here. The legacy per-entity pages stay reachable.
+	r.GET("/", dashboardPageHandler("models.html", tokens))
+	r.GET("/models", dashboardPageHandler("models.html", tokens))
 	r.GET("/orgs", dashboardPageHandler("orgs.html", tokens))
 	r.GET("/workers", dashboardPageHandler("workers.html", tokens))
 	r.GET("/sessions", dashboardPageHandler("sessions.html", tokens))

--- a/controlplane/admin/devserver/main.go
+++ b/controlplane/admin/devserver/main.go
@@ -1,0 +1,123 @@
+// Command devserver serves the admin dashboard's static assets off disk and
+// reverse-proxies the API to a port-forwarded control plane, so the UI can be
+// iterated on locally without rebuilding/redeploying the control-plane image.
+//
+// It mirrors the embedded serving contract exactly: the browser talks to a
+// single origin (this server), static files are served from ./static, and any
+// /api/, /login, or /health request is proxied to the target CP with the
+// internal-secret header injected server-side. Because it's same-origin from
+// the browser's point of view there is no CORS to configure and the secret
+// never reaches the page's JavaScript — the UI uses relative /api/v1 paths and
+// works byte-for-byte the same whether embedded or served here.
+//
+// Usage:
+//
+//	# 1. port-forward the control plane's admin API (separate terminal):
+//	kubectl --context posthog-mw-dev -n <ns> port-forward deploy/duckgres-control-plane 8080:8080
+//
+//	# 2. run the dev server pointing at it:
+//	DUCKGRES_INTERNAL_SECRET=<secret> go run ./controlplane/admin/devserver
+//	# then open http://127.0.0.1:5173
+//
+// Edit controlplane/admin/static/*.html and just refresh the browser — no
+// rebuild. Once happy, the same files are what //go:embed bakes into the CP.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	listen := flag.String("listen", "127.0.0.1:5173", "address to serve the UI on")
+	target := flag.String("target", "http://127.0.0.1:8080", "base URL of the port-forwarded control plane admin API")
+	staticDir := flag.String("static", defaultStaticDir(), "directory of static UI assets to serve off disk")
+	secret := flag.String("secret", os.Getenv("DUCKGRES_INTERNAL_SECRET"), "internal secret injected as X-Duckgres-Internal-Secret on proxied requests (defaults to $DUCKGRES_INTERNAL_SECRET)")
+	flag.Parse()
+
+	if *secret == "" {
+		log.Println("WARNING: no internal secret set — proxied API requests will be rejected with 401. Set --secret or $DUCKGRES_INTERNAL_SECRET.")
+	}
+
+	targetURL, err := url.Parse(*target)
+	if err != nil {
+		log.Fatalf("invalid --target %q: %v", *target, err)
+	}
+
+	absStatic, err := filepath.Abs(*staticDir)
+	if err != nil {
+		log.Fatalf("resolve --static %q: %v", *staticDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(absStatic, "models.html")); err != nil {
+		log.Fatalf("static dir %q has no models.html (run from repo root, or pass --static): %v", absStatic, err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	baseDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		baseDirector(req)
+		req.Host = targetURL.Host
+		// Inject the service-to-service secret server-side; never trust or
+		// forward a browser cookie/credential through the dev proxy.
+		req.Header.Del("Cookie")
+		if *secret != "" {
+			req.Header.Set("X-Duckgres-Internal-Secret", *secret)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if isProxiedPath(r.URL.Path) {
+			proxy.ServeHTTP(w, r)
+			return
+		}
+		serveStatic(w, r, absStatic)
+	})
+
+	log.Printf("duckgres admin UI dev server: http://%s  →  proxying /api,/login,/health to %s", *listen, targetURL)
+	log.Printf("serving static assets from %s (edit + refresh, no rebuild)", absStatic)
+	if err := http.ListenAndServe(*listen, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// isProxiedPath reports whether a request should be forwarded to the control
+// plane rather than served from the local static dir.
+func isProxiedPath(p string) bool {
+	return strings.HasPrefix(p, "/api/") || p == "/login" || p == "/health"
+}
+
+// serveStatic serves UI assets, routing "/" and "/models" to the models
+// explorer page (matching the CP's RegisterDashboard route table).
+func serveStatic(w http.ResponseWriter, r *http.Request, dir string) {
+	name := strings.TrimPrefix(r.URL.Path, "/")
+	switch name {
+	case "", "models":
+		name = "models.html"
+	case "orgs", "workers", "sessions", "settings":
+		name = name + ".html"
+	}
+	// Constrain to the static dir; reject path traversal.
+	clean := filepath.Clean(filepath.Join(dir, name))
+	if !strings.HasPrefix(clean, dir+string(os.PathSeparator)) && clean != dir {
+		http.NotFound(w, r)
+		return
+	}
+	if info, err := os.Stat(clean); err != nil || info.IsDir() {
+		http.ServeFile(w, r, filepath.Join(dir, "models.html"))
+		return
+	}
+	http.ServeFile(w, r, clean)
+}
+
+// defaultStaticDir resolves the static dir relative to the repo layout so the
+// server can be run from the repo root with no flags.
+func defaultStaticDir() string {
+	return filepath.Join("controlplane", "admin", "static")
+}

--- a/controlplane/admin/devserver/main.go
+++ b/controlplane/admin/devserver/main.go
@@ -93,27 +93,35 @@ func isProxiedPath(p string) bool {
 	return strings.HasPrefix(p, "/api/") || p == "/login" || p == "/health"
 }
 
-// serveStatic serves UI assets, routing "/" and "/models" to the models
-// explorer page (matching the CP's RegisterDashboard route table).
+// dashboardPages maps a request path (route or bare filename) to the static
+// asset that serves it. The values are literals, so the filename handed to
+// http.ServeFile never derives from the request — no path traversal is possible
+// regardless of what the client sends. Routes mirror the CP's
+// RegisterDashboard table; "/" and "/models" both land on the models explorer.
+var dashboardPages = map[string]string{
+	"":              "models.html",
+	"models":        "models.html",
+	"orgs":          "orgs.html",
+	"workers":       "workers.html",
+	"sessions":      "sessions.html",
+	"settings":      "settings.html",
+	"login":         "login.html",
+	"models.html":   "models.html",
+	"orgs.html":     "orgs.html",
+	"workers.html":  "workers.html",
+	"sessions.html": "sessions.html",
+	"settings.html": "settings.html",
+	"login.html":    "login.html",
+}
+
+// serveStatic serves the dashboard's static assets. Any unrecognized path falls
+// back to the models explorer (single-page-style entry).
 func serveStatic(w http.ResponseWriter, r *http.Request, dir string) {
-	name := strings.TrimPrefix(r.URL.Path, "/")
-	switch name {
-	case "", "models":
-		name = "models.html"
-	case "orgs", "workers", "sessions", "settings":
-		name = name + ".html"
+	file, ok := dashboardPages[strings.TrimPrefix(r.URL.Path, "/")]
+	if !ok {
+		file = "models.html"
 	}
-	// Constrain to the static dir; reject path traversal.
-	clean := filepath.Clean(filepath.Join(dir, name))
-	if !strings.HasPrefix(clean, dir+string(os.PathSeparator)) && clean != dir {
-		http.NotFound(w, r)
-		return
-	}
-	if info, err := os.Stat(clean); err != nil || info.IsDir() {
-		http.ServeFile(w, r, filepath.Join(dir, "models.html"))
-		return
-	}
-	http.ServeFile(w, r, clean)
+	http.ServeFile(w, r, filepath.Join(dir, file))
 }
 
 // defaultStaticDir resolves the static dir relative to the repo layout so the

--- a/controlplane/admin/models_api.go
+++ b/controlplane/admin/models_api.go
@@ -1,0 +1,241 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// modelsRowLimit caps how many rows a single model listing returns. The
+// config-schema tables are tiny, but runtime tables (worker_records,
+// org_connection_queue) can grow; this keeps a stray listing from streaming an
+// unbounded result into the browser. A listing at the cap sets `truncated`.
+const modelsRowLimit = 2000
+
+// modelGroup buckets descriptors into the UI sidebar sections.
+type modelGroup string
+
+const (
+	modelGroupTenants modelGroup = "Tenants"
+	modelGroupConfig  modelGroup = "Config"
+	modelGroupRuntime modelGroup = "Runtime"
+)
+
+// modelDescriptor describes one browsable config-store table for the generic
+// models explorer. The descriptors are the single source of truth the sidebar,
+// the listing endpoint, and the column derivation all read from — adding a new
+// config-store model is one entry here.
+type modelDescriptor struct {
+	// Key is the URL slug and stable identifier (e.g. "orgs").
+	Key string
+	// Label is the human-facing sidebar name.
+	Label string
+	// Group is the sidebar section this model lives under.
+	Group modelGroup
+	// Table is the bare table name (the model's TableName()). Runtime models
+	// are schema-qualified at query time with the CP runtime schema.
+	Table string
+	// Runtime marks a table that lives in the control-plane runtime schema
+	// (cp_instances, worker_records, …) rather than the snapshot-backed config
+	// schema, so reads must be schema-qualified.
+	Runtime bool
+	// newSlice returns a pointer to a fresh, empty typed slice to scan into.
+	// Scanning into the typed model (not a map[string]any) means the struct's
+	// json tags apply on marshal, so json:"-" fields — OrgUser.Password,
+	// OrgUserSecret.Ciphertext, DuckLakeConfig.S3SecretKey, the singleton IDs —
+	// are dropped from the API response for free. Never swap this for a raw
+	// map scan: that would leak those columns.
+	newSlice func() any
+	// elem is the element type behind newSlice, used to derive column order.
+	elem reflect.Type
+}
+
+// modelDescriptors returns the ordered registry of browsable models. Order is
+// the sidebar order. Every persisted configstore model that an operator might
+// want to inspect belongs here; if you add a model in configstore/models.go,
+// add it here too (and assert it in models_api_test.go).
+func modelDescriptors() []modelDescriptor {
+	mk := func(key, label string, group modelGroup, runtime bool, sample any) modelDescriptor {
+		// table name from the model's TableName() via the gorm Tabler contract.
+		table := ""
+		if t, ok := sample.(interface{ TableName() string }); ok {
+			table = t.TableName()
+		}
+		elem := reflect.TypeOf(sample)
+		return modelDescriptor{
+			Key:     key,
+			Label:   label,
+			Group:   group,
+			Table:   table,
+			Runtime: runtime,
+			elem:    elem,
+			newSlice: func() any {
+				return reflect.New(reflect.SliceOf(elem)).Interface()
+			},
+		}
+	}
+	return []modelDescriptor{
+		mk("orgs", "Orgs", modelGroupTenants, false, configstore.Org{}),
+		mk("org-users", "Org Users", modelGroupTenants, false, configstore.OrgUser{}),
+		mk("org-user-secrets", "Org User Secrets", modelGroupTenants, false, configstore.OrgUserSecret{}),
+		mk("managed-warehouses", "Managed Warehouses", modelGroupTenants, false, configstore.ManagedWarehouse{}),
+
+		mk("global-config", "Global Config", modelGroupConfig, false, configstore.GlobalConfig{}),
+		mk("ducklake-config", "DuckLake Config", modelGroupConfig, false, configstore.DuckLakeConfig{}),
+		mk("ratelimit-config", "Rate Limit Config", modelGroupConfig, false, configstore.RateLimitConfig{}),
+		mk("querylog-config", "Query Log Config", modelGroupConfig, false, configstore.QueryLogConfig{}),
+
+		mk("cp-instances", "Control Plane Instances", modelGroupRuntime, true, configstore.ControlPlaneInstance{}),
+		mk("worker-records", "Worker Records", modelGroupRuntime, true, configstore.WorkerRecord{}),
+		mk("flight-session-records", "Flight Session Records", modelGroupRuntime, true, configstore.FlightSessionRecord{}),
+		mk("org-connection-queue", "Org Connection Queue", modelGroupRuntime, true, configstore.OrgConnectionQueueEntry{}),
+		mk("org-connection-leases", "Org Connection Leases", modelGroupRuntime, true, configstore.OrgConnectionLease{}),
+	}
+}
+
+type modelsHandler struct {
+	store *configstore.ConfigStore
+}
+
+// registerModelsAPI registers the read-only generic models explorer used by the
+// admin dashboard's models browser.
+func registerModelsAPI(r *gin.RouterGroup, store *configstore.ConfigStore) {
+	h := &modelsHandler{store: store}
+	r.GET("/models", h.listModels)
+	r.GET("/models/:model", h.getModel)
+}
+
+// qualifiedTable returns the table name to read for a descriptor, schema-
+// qualifying runtime tables with the CP runtime schema.
+func (h *modelsHandler) qualifiedTable(d modelDescriptor) string {
+	if d.Runtime {
+		return h.store.RuntimeSchema() + "." + d.Table
+	}
+	return d.Table
+}
+
+// modelSummary is a sidebar entry: identity plus a live row count.
+type modelSummary struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+	Group string `json:"group"`
+	Count int64  `json:"count"`
+}
+
+func (h *modelsHandler) listModels(c *gin.Context) {
+	db := h.store.DB()
+	descriptors := modelDescriptors()
+	out := make([]modelSummary, 0, len(descriptors))
+	for _, d := range descriptors {
+		var count int64
+		// A count failure on one table must not blank the whole sidebar; report
+		// -1 so the UI can show "?" while the rest of the list still renders.
+		if err := db.Table(h.qualifiedTable(d)).Count(&count).Error; err != nil {
+			count = -1
+		}
+		out = append(out, modelSummary{
+			Key:   d.Key,
+			Label: d.Label,
+			Group: string(d.Group),
+			Count: count,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"models": out})
+}
+
+// modelListing is the response for one model's rows.
+type modelListing struct {
+	Key       string   `json:"key"`
+	Label     string   `json:"label"`
+	Group     string   `json:"group"`
+	Table     string   `json:"table"`
+	Columns   []string `json:"columns"`
+	Count     int64    `json:"count"`
+	Truncated bool     `json:"truncated"`
+	Rows      any      `json:"rows"`
+}
+
+func (h *modelsHandler) getModel(c *gin.Context) {
+	key := c.Param("model")
+	var desc *modelDescriptor
+	for _, d := range modelDescriptors() {
+		if d.Key == key {
+			d := d
+			desc = &d
+			break
+		}
+	}
+	if desc == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "unknown model: " + key})
+		return
+	}
+
+	db := h.store.DB()
+	table := h.qualifiedTable(*desc)
+
+	var total int64
+	if err := db.Table(table).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	rows := desc.newSlice()
+	// Limit + 1 detects truncation without a second query.
+	if err := db.Table(table).Limit(modelsRowLimit + 1).Find(rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	truncated := false
+	rv := reflect.ValueOf(rows).Elem()
+	if rv.Len() > modelsRowLimit {
+		truncated = true
+		rv.Set(rv.Slice(0, modelsRowLimit))
+	}
+
+	c.JSON(http.StatusOK, modelListing{
+		Key:       desc.Key,
+		Label:     desc.Label,
+		Group:     string(desc.Group),
+		Table:     table,
+		Columns:   jsonFieldOrder(desc.elem),
+		Count:     total,
+		Truncated: truncated,
+		Rows:      rows,
+	})
+}
+
+// jsonFieldOrder returns the ordered top-level JSON keys for a struct type,
+// skipping fields tagged json:"-". Embedded warehouse sub-structs are named
+// fields (json:"s3", …) so they surface as a single nested-object column, which
+// is what the detail view renders. This gives the table stable column headers
+// even for an empty result set (the common case for runtime tables).
+func jsonFieldOrder(t reflect.Type) []string {
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil
+	}
+	cols := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported
+		}
+		tag := f.Tag.Get("json")
+		name := f.Name
+		if tag != "" {
+			parts := strings.Split(tag, ",")
+			if parts[0] == "-" {
+				continue
+			}
+			if parts[0] != "" {
+				name = parts[0]
+			}
+		}
+		cols = append(cols, name)
+	}
+	return cols
+}

--- a/controlplane/admin/models_api_test.go
+++ b/controlplane/admin/models_api_test.go
@@ -1,0 +1,155 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// TestModelDescriptorsRedaction is the no-DB guard for the load-bearing
+// security invariant of the models explorer: secret-bearing columns must never
+// appear as browsable columns. Because the listing scans into the typed model
+// and marshals via json tags, a field tagged json:"-" is dropped — this test
+// pins that the sensitive fields stay tagged and that the column derivation
+// (jsonFieldOrder) honors it. If someone retags Password/Ciphertext/S3SecretKey
+// to be serialized, this fails before the secret can leak through the UI.
+func TestModelDescriptorsRedaction(t *testing.T) {
+	descs := modelDescriptors()
+
+	// Registry must cover exactly the persisted models we expect.
+	wantKeys := map[string]bool{
+		"orgs": true, "org-users": true, "org-user-secrets": true, "managed-warehouses": true,
+		"global-config": true, "ducklake-config": true, "ratelimit-config": true, "querylog-config": true,
+		"cp-instances": true, "worker-records": true, "flight-session-records": true,
+		"org-connection-queue": true, "org-connection-leases": true,
+	}
+	seen := map[string]bool{}
+	for _, d := range descs {
+		if seen[d.Key] {
+			t.Fatalf("duplicate descriptor key %q", d.Key)
+		}
+		seen[d.Key] = true
+		if d.Table == "" {
+			t.Errorf("descriptor %q has empty Table (missing TableName?)", d.Key)
+		}
+		if d.newSlice == nil || d.elem == nil {
+			t.Errorf("descriptor %q missing newSlice/elem", d.Key)
+		}
+	}
+	for k := range wantKeys {
+		if !seen[k] {
+			t.Errorf("registry missing expected model %q", k)
+		}
+	}
+	for k := range seen {
+		if !wantKeys[k] {
+			t.Errorf("registry has unexpected model %q (update test if intentional)", k)
+		}
+	}
+
+	// Sensitive columns must not be derivable for the UI.
+	mustHide := map[string][]string{
+		"org-users":        {"password"},
+		"org-user-secrets": {"ciphertext"},
+		"ducklake-config":  {"s3_secret_key", "s3secretkey"},
+		"global-config":    {"id"},
+	}
+	for _, d := range descs {
+		cols := jsonFieldOrder(d.elem)
+		lower := map[string]bool{}
+		for _, c := range cols {
+			lower[strings.ToLower(c)] = true
+		}
+		for _, bad := range mustHide[d.Key] {
+			if lower[strings.ToLower(bad)] {
+				t.Errorf("model %q exposes column %q — must be json:\"-\"", d.Key, bad)
+			}
+		}
+	}
+}
+
+// TestModelsAPIPostgres exercises the real query path against the config store:
+// sidebar counts, a config-schema listing, a runtime-schema listing (schema
+// qualification), and the end-to-end redaction guarantee — a seeded password
+// hash must never appear in the API response bytes.
+func TestModelsAPIPostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+
+	const secretHash = "$2a$10$DEADBEEFdeadbeefDEADBEEFdeadbeefDEADBEEFdeadbeefDEADBE"
+	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acme_db"}).Error; err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := store.DB().Create(&configstore.OrgUser{OrgID: "acme", Username: "reader", Password: secretHash}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerModelsAPI(r.Group("/api/v1"), store)
+
+	get := func(path string) (*httptest.ResponseRecorder, map[string]json.RawMessage) {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		var body map[string]json.RawMessage
+		if rec.Code == http.StatusOK {
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode %s: %v (%s)", path, err, rec.Body.String())
+			}
+		}
+		return rec, body
+	}
+
+	// Sidebar listing.
+	rec, body := get("/api/v1/models")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /models = %d", rec.Code)
+	}
+	var summaries []modelSummary
+	if err := json.Unmarshal(body["models"], &summaries); err != nil {
+		t.Fatalf("decode summaries: %v", err)
+	}
+	gotOrgUsers := false
+	for _, s := range summaries {
+		if s.Key == "org-users" {
+			gotOrgUsers = true
+			if s.Count != 1 {
+				t.Errorf("org-users count = %d, want 1", s.Count)
+			}
+		}
+	}
+	if !gotOrgUsers {
+		t.Fatalf("sidebar missing org-users")
+	}
+
+	// Config-schema listing must not leak the password hash.
+	rec, _ = get("/api/v1/models/org-users")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /models/org-users = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secretHash) {
+		t.Fatalf("org-users listing leaked password hash:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "reader") {
+		t.Fatalf("org-users listing missing seeded user")
+	}
+
+	// Runtime-schema listing (schema qualification) must succeed even when empty.
+	rec, _ = get("/api/v1/models/worker-records")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /models/worker-records = %d (runtime schema qualification broken)", rec.Code)
+	}
+
+	// Unknown model → 404.
+	rec, _ = get("/api/v1/models/nope")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("GET /models/nope = %d, want 404", rec.Code)
+	}
+}

--- a/controlplane/admin/static/login.html
+++ b/controlplane/admin/static/login.html
@@ -3,33 +3,72 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Duckgres - Admin Login</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title>Duckgres — Admin Login</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        --bg: #07090d; --panel2: #11161d; --line: #1d2630; --line-bright: #2c3a48;
+        --text: #c9d6e2; --dim: #5a6b7c; --worker: #38e1ff; --bad: #ff4d5e;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        background: var(--bg); color: var(--text);
+        font-family: "IBM Plex Mono", monospace; font-size: 13px;
+        display: flex; align-items: center; justify-content: center; padding: 24px;
+      }
+      body::before {
+        content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+        background:
+          radial-gradient(ellipse at 50% -10%, rgba(56,225,255,.05), transparent 60%),
+          repeating-linear-gradient(0deg, transparent 0 39px, rgba(56,225,255,.025) 39px 40px),
+          repeating-linear-gradient(90deg, transparent 0 39px, rgba(56,225,255,.025) 39px 40px);
+      }
+      main {
+        position: relative; z-index: 1; width: 100%; max-width: 380px;
+        background: linear-gradient(180deg, var(--panel2), #0d1117);
+        border: 1px solid var(--line-bright); border-radius: 6px;
+        padding: 30px 30px 34px; box-shadow: 0 8px 40px rgba(0,0,0,.55);
+      }
+      .brand { font-family: "Chakra Petch", sans-serif; font-weight: 700;
+        font-size: 22px; letter-spacing: .14em; color: var(--worker);
+        text-shadow: 0 0 18px rgba(56,225,255,.35); }
+      .sub { font-size: 9.5px; letter-spacing: .3em; text-transform: uppercase; color: var(--dim); margin: 4px 0 22px; }
+      label { display: block; font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--dim); margin-bottom: 8px; }
+      input[type=password] {
+        width: 100%; background: #0d1117; border: 1px solid var(--line-bright); border-radius: 4px;
+        color: var(--text); font-family: inherit; font-size: 13px; padding: 9px 11px;
+      }
+      input[type=password]:focus { outline: none; border-color: var(--worker); }
+      button {
+        width: 100%; margin-top: 18px; cursor: pointer;
+        background: var(--worker); color: #07090d; border: none; border-radius: 4px;
+        font-family: "Chakra Petch", sans-serif; font-weight: 600;
+        font-size: 13px; letter-spacing: .14em; text-transform: uppercase; padding: 10px;
+      }
+      button:hover { box-shadow: 0 0 18px rgba(56,225,255,.4); }
+      .err {
+        margin-bottom: 16px; border: 1px solid rgba(255,77,94,.4); background: rgba(255,77,94,.1);
+        color: var(--bad); border-radius: 4px; padding: 9px 12px; font-size: 12px;
+      }
+    </style>
 </head>
-<body class="bg-gray-900 text-gray-100 min-h-screen flex items-center justify-center px-6">
-    <main class="w-full max-w-md bg-gray-800 border border-gray-700 rounded-xl p-8 shadow-2xl">
-        <div class="mb-6">
-            <h1 class="text-2xl font-bold text-yellow-400">Duckgres Admin</h1>
-            <p class="text-gray-400 mt-2">Enter the admin token printed in the control-plane logs.</p>
-        </div>
+<body>
+    <main>
+        <div class="brand">DUCKGRES</div>
+        <div class="sub">Control Plane Admin</div>
 
         {{if .Error}}
-        <div class="mb-4 rounded border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-            {{.Error}}
-        </div>
+        <div class="err">{{.Error}}</div>
         {{end}}
 
-        <form method="post" action="/login" class="space-y-4">
+        <form method="post" action="/login">
             <input type="hidden" name="next" value="{{.Next}}">
-            <div>
-                <label for="token" class="block text-sm font-medium text-gray-300 mb-2">Admin Token</label>
-                <input id="token" name="token" type="password" autocomplete="off" required
-                       class="w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-gray-100 focus:border-yellow-400 focus:outline-none">
-            </div>
-            <button type="submit"
-                    class="w-full rounded bg-yellow-500 px-4 py-2 font-medium text-gray-900 hover:bg-yellow-400">
-                Sign In
-            </button>
+            <label for="token">Admin Token</label>
+            <input id="token" name="token" type="password" autocomplete="off" required autofocus>
+            <button type="submit">Sign In</button>
         </form>
     </main>
 </body>

--- a/controlplane/admin/static/models.html
+++ b/controlplane/admin/static/models.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Duckgres — Control Plane</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #07090d;
+      --panel: #0d1117;
+      --panel2: #11161d;
+      --line: #1d2630;
+      --line-bright: #2c3a48;
+      --text: #c9d6e2;
+      --dim: #5a6b7c;
+      --worker: #38e1ff;
+      --headroom: #ffb224;
+      --cp: #c08bff;
+      --duckgres: #4ade80;
+      --system: #46525e;
+      --other: #7e8da0;
+      --bad: #ff4d5e;
+      --pend: #ffd166;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Mono", monospace;
+      font-size: 13px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
+      background:
+        radial-gradient(ellipse at 50% -10%, rgba(56,225,255,.05), transparent 60%),
+        repeating-linear-gradient(0deg, transparent 0 39px, rgba(56,225,255,.025) 39px 40px),
+        repeating-linear-gradient(90deg, transparent 0 39px, rgba(56,225,255,.025) 39px 40px);
+    }
+    header, #layout { position: relative; z-index: 1; }
+
+    /* Header */
+    header {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 22px;
+      padding: 14px 22px 12px;
+      border-bottom: 1px solid var(--line);
+      background: linear-gradient(180deg, #0c1118, #090d12);
+    }
+    .brand { display: flex; flex-direction: column; line-height: 1.1; }
+    .brand .t {
+      font-family: "Chakra Petch", sans-serif;
+      font-weight: 700;
+      font-size: 18px;
+      letter-spacing: .14em;
+      color: var(--worker);
+      text-shadow: 0 0 18px rgba(56,225,255,.35);
+    }
+    .brand .s {
+      font-size: 9.5px;
+      letter-spacing: .3em;
+      color: var(--dim);
+      text-transform: uppercase;
+      margin-top: 2px;
+    }
+    .spacer { flex: 1; }
+    .nav { display: flex; gap: 14px; }
+    .nav a {
+      color: var(--dim);
+      text-decoration: none;
+      font-size: 11px;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      padding-bottom: 2px;
+      border-bottom: 1px solid transparent;
+    }
+    .nav a:hover { color: var(--text); }
+    .nav a.active { color: var(--worker); border-bottom-color: var(--worker); }
+    #conn {
+      display: flex; align-items: center; gap: 7px;
+      font-size: 10.5px; letter-spacing: .18em; text-transform: uppercase; color: var(--dim);
+    }
+    #conn .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--system); }
+    #conn.live .dot { background: var(--duckgres); box-shadow: 0 0 10px var(--duckgres); }
+    #conn.err .dot { background: var(--bad); box-shadow: 0 0 10px var(--bad); }
+
+    /* Layout */
+    #layout { flex: 1; display: flex; overflow: hidden; }
+
+    /* Sidebar */
+    #sidebar {
+      width: 264px; flex: none; overflow-y: auto;
+      border-right: 1px solid var(--line);
+      background: var(--panel);
+      padding: 14px 0 24px;
+    }
+    .grp {
+      font-family: "Chakra Petch", sans-serif;
+      font-size: 10px; letter-spacing: .22em; text-transform: uppercase;
+      color: var(--dim);
+      padding: 16px 18px 7px;
+      position: relative;
+    }
+    .grp::after {
+      content: ""; position: absolute; left: 18px; right: 18px; bottom: 2px; height: 1px;
+      background: linear-gradient(90deg, var(--line-bright), transparent);
+    }
+    .mitem {
+      display: flex; align-items: center; gap: 8px;
+      padding: 7px 18px;
+      cursor: pointer;
+      border-left: 2px solid transparent;
+      color: var(--text);
+    }
+    .mitem:hover { background: var(--panel2); }
+    .mitem.active { border-left-color: var(--worker); background: rgba(56,225,255,.07); color: var(--worker); }
+    .mitem .lbl { flex: 1; font-size: 12.5px; }
+    .mitem .count {
+      font-variant-numeric: tabular-nums;
+      font-size: 10.5px; color: var(--dim);
+      background: var(--panel2); border: 1px solid var(--line);
+      border-radius: 4px; padding: 1px 7px; min-width: 26px; text-align: center;
+    }
+    .mitem.active .count { color: var(--worker); border-color: var(--line-bright); }
+
+    /* Main */
+    #main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+    #toolbar {
+      flex: none; display: flex; align-items: center; gap: 14px;
+      padding: 12px 22px; border-bottom: 1px solid var(--line);
+    }
+    #toolbar .title {
+      font-family: "Chakra Petch", sans-serif; font-weight: 600;
+      font-size: 15px; letter-spacing: .08em; color: var(--text);
+    }
+    #toolbar .tbl-name { font-size: 10.5px; color: var(--dim); letter-spacing: .1em; }
+    #toolbar .rowcount { font-size: 10.5px; color: var(--dim); letter-spacing: .18em; text-transform: uppercase; }
+    input.search {
+      background: var(--panel2); border: 1px solid var(--line-bright); border-radius: 4px;
+      color: var(--text); font-family: inherit; font-size: 12px; padding: 5px 10px; width: 230px;
+    }
+    input.search:focus { outline: none; border-color: var(--worker); }
+    button.btn {
+      background: var(--panel2); border: 1px solid var(--line-bright); border-radius: 4px;
+      color: var(--text); font-family: inherit; font-size: 11px; letter-spacing: .1em;
+      text-transform: uppercase; padding: 5px 12px; cursor: pointer;
+    }
+    button.btn:hover { border-color: var(--worker); color: var(--worker); }
+
+    #table-scroll { flex: 1; overflow: auto; }
+    table.tbl { border-collapse: collapse; width: 100%; font-size: 12px; }
+    table.tbl thead th {
+      position: sticky; top: 0; z-index: 1;
+      text-align: left; white-space: nowrap;
+      background: var(--panel);
+      color: var(--dim); font-weight: 500;
+      font-size: 10px; letter-spacing: .12em; text-transform: uppercase;
+      padding: 9px 12px; border-bottom: 1px solid var(--line-bright);
+    }
+    table.tbl tbody td {
+      padding: 7px 12px; border-bottom: 1px solid var(--line);
+      white-space: nowrap; max-width: 320px; overflow: hidden; text-overflow: ellipsis;
+      font-variant-numeric: tabular-nums;
+    }
+    table.tbl tbody tr { cursor: pointer; }
+    table.tbl tbody tr:hover { background: rgba(56,225,255,.06); }
+    table.tbl tbody tr.sel { background: rgba(56,225,255,.12); }
+    .muted { color: var(--dim); }
+    .nestref { color: var(--cp); }
+    .pill {
+      font-size: 10px; letter-spacing: .06em; text-transform: uppercase;
+      border-radius: 4px; padding: 1px 7px; border: 1px solid var(--line-bright);
+    }
+    .pill.ok { color: var(--duckgres); border-color: rgba(74,222,128,.4); }
+    .pill.warn { color: var(--headroom); border-color: rgba(255,178,36,.4); }
+    .pill.bad { color: var(--bad); border-color: rgba(255,77,94,.4); }
+    .pill.dim { color: var(--dim); }
+    .pill.bool-t { color: var(--duckgres); border-color: rgba(74,222,128,.4); }
+    .pill.bool-f { color: var(--dim); }
+
+    /* Detail */
+    #detail {
+      width: 440px; flex: none; overflow-y: auto;
+      border-left: 1px solid var(--line); background: var(--panel);
+      padding: 0 0 30px;
+    }
+    #detail.hidden { display: none; }
+    .dhead {
+      position: sticky; top: 0; z-index: 1;
+      display: flex; align-items: center; gap: 10px;
+      padding: 13px 18px; background: var(--panel);
+      border-bottom: 1px solid var(--line-bright);
+    }
+    .dhead .dt {
+      flex: 1; font-family: "Chakra Petch", sans-serif; font-weight: 600;
+      font-size: 13px; letter-spacing: .1em; color: var(--worker);
+    }
+    .dhead .x { cursor: pointer; color: var(--dim); font-size: 16px; padding: 0 4px; }
+    .dhead .x:hover { color: var(--bad); }
+    .drow {
+      display: grid; grid-template-columns: 168px 1fr; gap: 10px;
+      padding: 6px 18px; border-bottom: 1px solid var(--line);
+      align-items: start;
+    }
+    .drow .k { color: var(--dim); font-size: 11px; letter-spacing: .04em; word-break: break-word; }
+    .drow .v { color: var(--text); font-size: 12px; word-break: break-word; white-space: pre-wrap; }
+    details.dsec { border-bottom: 1px solid var(--line); }
+    details.dsec > summary {
+      list-style: none; cursor: pointer; user-select: none;
+      padding: 8px 18px; color: var(--cp);
+      font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+      display: flex; align-items: center; gap: 8px;
+    }
+    details.dsec > summary::-webkit-details-marker { display: none; }
+    details.dsec > summary::before { content: "▸"; color: var(--dim); }
+    details.dsec[open] > summary::before { content: "▾"; }
+    details.dsec > summary:hover { color: var(--worker); }
+    details.dsec .dbody { background: rgba(0,0,0,.18); }
+    details.dsec .drow { padding-left: 30px; }
+
+    .empty { padding: 40px 22px; color: var(--dim); font-size: 12px; letter-spacing: .04em; }
+    .loading { padding: 24px 22px; color: var(--dim); }
+
+    /* Session-expired overlay */
+    #gate {
+      position: fixed; inset: 0; z-index: 10;
+      background: rgba(7,9,13,.92);
+      display: none; align-items: center; justify-content: center;
+    }
+    #gate.show { display: flex; }
+    #gate .box {
+      background: var(--panel2); border: 1px solid var(--bad); border-radius: 6px;
+      padding: 26px 30px; text-align: center; max-width: 360px;
+    }
+    #gate .box h2 { font-family: "Chakra Petch", sans-serif; color: var(--bad); margin: 0 0 8px; letter-spacing: .1em; }
+    #gate .box p { color: var(--dim); margin: 0 0 16px; }
+    #gate a { color: var(--worker); text-decoration: none; border-bottom: 1px solid var(--worker); }
+
+    /* Scrollbars */
+    *::-webkit-scrollbar { width: 10px; height: 10px; }
+    *::-webkit-scrollbar-thumb { background: var(--line-bright); border-radius: 5px; }
+    *::-webkit-scrollbar-track { background: transparent; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <span class="t">DUCKGRES</span>
+      <span class="s">Control Plane</span>
+    </div>
+    <div class="spacer"></div>
+    <nav class="nav">
+      <a href="/models" class="active">Models</a>
+      <a href="/orgs">Orgs</a>
+      <a href="/workers">Ducklings</a>
+      <a href="/sessions">Sessions</a>
+      <a href="/settings">Settings</a>
+    </nav>
+    <div id="conn"><span class="dot"></span><span id="conn-label">connecting</span></div>
+  </header>
+
+  <div id="layout">
+    <aside id="sidebar"><div class="loading">Loading models…</div></aside>
+    <main id="main">
+      <div id="toolbar">
+        <span class="title" id="model-title">—</span>
+        <span class="tbl-name" id="model-table"></span>
+        <div class="spacer" style="flex:1"></div>
+        <span class="rowcount" id="model-count"></span>
+        <input class="search" id="search" type="text" placeholder="filter rows…" autocomplete="off">
+        <button class="btn" id="refresh">Refresh</button>
+      </div>
+      <div id="table-scroll"><div class="empty">Select a model from the sidebar.</div></div>
+    </main>
+    <aside id="detail" class="hidden"></aside>
+  </div>
+
+  <div id="gate">
+    <div class="box">
+      <h2>Session Expired</h2>
+      <p>The admin token is no longer valid.</p>
+      <a href="/">Reload to sign in</a>
+    </div>
+  </div>
+
+  <script>
+  "use strict";
+  const state = { models: [], key: null, listing: null, filter: "", selected: -1 };
+
+  function esc(s) {
+    const d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+  function setConn(cls, label) {
+    const el = document.getElementById("conn");
+    el.className = cls;
+    document.getElementById("conn-label").textContent = label;
+  }
+
+  async function api(path) {
+    const res = await fetch(path, { headers: { "Accept": "application/json" } });
+    if (res.status === 401) {
+      document.getElementById("gate").classList.add("show");
+      throw new Error("unauthorized");
+    }
+    if (!res.ok) {
+      let msg = "HTTP " + res.status;
+      try { const j = await res.json(); if (j && j.error) msg = j.error; } catch (e) {}
+      throw new Error(msg);
+    }
+    return res.json();
+  }
+
+  const STATE_COL = /(^|_)(state|status)$/;
+  function isStateCol(col) { return STATE_COL.test(col); }
+  function statePillClass(v) {
+    const s = String(v).toLowerCase();
+    if (["ready", "active", "hot", "idle"].includes(s)) return "ok";
+    if (["failed", "lost", "expired", "retired", "bad"].includes(s)) return "bad";
+    if (["pending", "provisioning", "draining", "reserved", "activating", "spawning", "hot_idle", "reconnecting", "deleting"].includes(s)) return "warn";
+    return "dim";
+  }
+
+  // renderCell — compact, table-cell value. Objects/arrays collapse to a hint;
+  // full structure lives in the detail panel.
+  function renderCell(col, v) {
+    if (v === null || v === undefined || v === "") return '<span class="muted">—</span>';
+    if (typeof v === "boolean") return '<span class="pill ' + (v ? "bool-t" : "bool-f") + '">' + (v ? "true" : "false") + "</span>";
+    if (Array.isArray(v)) return '<span class="nestref">[' + v.length + "]</span>";
+    if (typeof v === "object") {
+      const n = Object.keys(v).length;
+      return '<span class="nestref">{' + n + " field" + (n === 1 ? "" : "s") + "}</span>";
+    }
+    if (isStateCol(col)) return '<span class="pill ' + statePillClass(v) + '">' + esc(v) + "</span>";
+    return esc(v);
+  }
+
+  function renderSidebar() {
+    const order = ["Tenants", "Config", "Runtime"];
+    const byGroup = {};
+    for (const m of state.models) (byGroup[m.group] = byGroup[m.group] || []).push(m);
+    const groups = order.filter(g => byGroup[g]).concat(Object.keys(byGroup).filter(g => !order.includes(g)));
+    let html = "";
+    for (const g of groups) {
+      html += '<div class="grp">' + esc(g) + "</div>";
+      for (const m of byGroup[g]) {
+        const cnt = m.count < 0 ? "?" : m.count;
+        html += '<div class="mitem' + (m.key === state.key ? " active" : "") + '" data-key="' + esc(m.key) + '">' +
+                '<span class="lbl">' + esc(m.label) + "</span>" +
+                '<span class="count">' + cnt + "</span></div>";
+      }
+    }
+    const sb = document.getElementById("sidebar");
+    sb.innerHTML = html;
+    sb.querySelectorAll(".mitem").forEach(el => el.addEventListener("click", () => selectModel(el.dataset.key)));
+  }
+
+  function filteredRows() {
+    const rows = (state.listing && state.listing.rows) || [];
+    if (!state.filter) return rows;
+    const f = state.filter.toLowerCase();
+    return rows.filter(r => JSON.stringify(r).toLowerCase().includes(f));
+  }
+
+  function renderTable() {
+    const scroll = document.getElementById("table-scroll");
+    const lst = state.listing;
+    if (!lst) { scroll.innerHTML = '<div class="empty">Select a model from the sidebar.</div>'; return; }
+    const cols = lst.columns || [];
+    const rows = filteredRows();
+    if (!rows.length) {
+      scroll.innerHTML = '<div class="empty">' + (lst.count === 0 ? "No rows in this table." : "No rows match the filter.") + "</div>";
+      return;
+    }
+    let html = '<table class="tbl"><thead><tr>';
+    for (const c of cols) html += "<th>" + esc(c) + "</th>";
+    html += "</tr></thead><tbody>";
+    rows.forEach((r, i) => {
+      html += '<tr data-idx="' + i + '">';
+      for (const c of cols) html += "<td>" + renderCell(c, r[c]) + "</td>";
+      html += "</tr>";
+    });
+    html += "</tbody></table>";
+    scroll.innerHTML = html;
+    scroll.querySelectorAll("tbody tr").forEach(tr => tr.addEventListener("click", () => showDetail(parseInt(tr.dataset.idx, 10), rows)));
+  }
+
+  // detailRows — recursively render an object into key/value rows; nested
+  // objects (e.g. managed-warehouse sub-configs) become expandable sections.
+  function detailRows(obj) {
+    let html = "";
+    for (const k of Object.keys(obj)) {
+      const v = obj[k];
+      if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+        const open = Object.values(v).some(x => x !== null && x !== "" && x !== false && !(typeof x === "object" && Object.keys(x).length === 0));
+        html += '<details class="dsec"' + (open ? " open" : "") + "><summary>" + esc(k) + "</summary><div class=\"dbody\">" + detailRows(v) + "</div></details>";
+      } else {
+        html += '<div class="drow"><div class="k">' + esc(k) + '</div><div class="v">' + detailValue(k, v) + "</div></div>";
+      }
+    }
+    return html;
+  }
+  function detailValue(k, v) {
+    if (v === null || v === undefined || v === "") return '<span class="muted">—</span>';
+    if (typeof v === "boolean") return '<span class="pill ' + (v ? "bool-t" : "bool-f") + '">' + (v ? "true" : "false") + "</span>";
+    if (Array.isArray(v)) {
+      if (!v.length) return '<span class="muted">[]</span>';
+      return v.map(x => (x !== null && typeof x === "object") ? "<pre style=\"margin:0\">" + esc(JSON.stringify(x, null, 2)) + "</pre>" : esc(x)).join("<br>");
+    }
+    if (isStateCol(k)) return '<span class="pill ' + statePillClass(v) + '">' + esc(v) + "</span>";
+    return esc(v);
+  }
+
+  function showDetail(idx, rows) {
+    state.selected = idx;
+    const row = rows[idx];
+    const panel = document.getElementById("detail");
+    panel.classList.remove("hidden");
+    panel.innerHTML = '<div class="dhead"><span class="dt">' + esc(state.listing.label) +
+      '</span><span class="x" id="dclose">✕</span></div>' + detailRows(row);
+    document.getElementById("dclose").addEventListener("click", closeDetail);
+    document.querySelectorAll("#table-scroll tbody tr").forEach(tr =>
+      tr.classList.toggle("sel", parseInt(tr.dataset.idx, 10) === idx));
+  }
+  function closeDetail() {
+    document.getElementById("detail").classList.add("hidden");
+    state.selected = -1;
+    document.querySelectorAll("#table-scroll tbody tr.sel").forEach(tr => tr.classList.remove("sel"));
+  }
+
+  async function selectModel(key) {
+    state.key = key;
+    state.filter = "";
+    document.getElementById("search").value = "";
+    closeDetail();
+    renderSidebar();
+    const m = state.models.find(x => x.key === key) || {};
+    document.getElementById("model-title").textContent = m.label || key;
+    document.getElementById("model-table").textContent = "";
+    document.getElementById("model-count").textContent = "";
+    document.getElementById("table-scroll").innerHTML = '<div class="loading">Loading…</div>';
+    try {
+      const lst = await api("/api/v1/models/" + encodeURIComponent(key));
+      state.listing = lst;
+      document.getElementById("model-table").textContent = lst.table || "";
+      document.getElementById("model-count").textContent =
+        lst.count + " row" + (lst.count === 1 ? "" : "s") + (lst.truncated ? " (showing first " + lst.rows.length + ")" : "");
+      renderTable();
+    } catch (e) {
+      if (e.message !== "unauthorized")
+        document.getElementById("table-scroll").innerHTML = '<div class="empty">Error: ' + esc(e.message) + "</div>";
+    }
+  }
+
+  async function loadModels() {
+    try {
+      const data = await api("/api/v1/models");
+      state.models = data.models || [];
+      setConn("live", "connected");
+      renderSidebar();
+      if (state.models.length) selectModel(state.key || state.models[0].key);
+    } catch (e) {
+      if (e.message !== "unauthorized") {
+        setConn("err", "error");
+        document.getElementById("sidebar").innerHTML = '<div class="empty">Error: ' + esc(e.message) + "</div>";
+      }
+    }
+  }
+
+  document.getElementById("search").addEventListener("input", e => { state.filter = e.target.value.trim(); renderTable(); });
+  document.getElementById("refresh").addEventListener("click", () => { loadModels(); if (state.key) selectModel(state.key); });
+
+  loadModels();
+  </script>
+</body>
+</html>

--- a/justfile
+++ b/justfile
@@ -46,6 +46,18 @@ run-control-plane: build
 build-k8s-image tag="duckgres:test":
     docker build --build-arg BUILD_TAGS=kubernetes -t {{tag}} .
 
+# Port-forward a deployed control plane's admin API to localhost:8080 (run in its own terminal)
+[group('dev')]
+ui-port-forward context="posthog-mw-dev" namespace="duckgres" deploy="duckgres-control-plane":
+    kubectl --context {{context}} -n {{namespace}} port-forward deploy/{{deploy}} 8080:8080
+
+# Serve the admin UI locally, proxying /api to the port-forwarded control plane.
+# Run `just ui-port-forward` first; set DUCKGRES_INTERNAL_SECRET to the CP secret.
+# Edit controlplane/admin/static/*.html and refresh the browser — no rebuild/redeploy.
+[group('dev')]
+ui-dev target="http://127.0.0.1:8080" listen="127.0.0.1:5173":
+    go run ./controlplane/admin/devserver --target {{target}} --listen {{listen}}
+
 # Recreate the local kind cluster used by the portable K8s integration flow
 [group('dev')]
 kind-cluster-reset:

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -52,6 +52,10 @@
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
 #   admin auth   : the dashboard rejects ?token= query-param auth (#721); only
 #                  the internal-secret header / POST login form authenticate.
+#   models api   : the dashboard models explorer lists every config-store model
+#                  with row counts (GET /api/v1/models) and one model's rows +
+#                  columns (GET /api/v1/models/:model), redacting secret-bearing
+#                  columns (org_users.password must never appear in the UI).
 #   lifecycle    : deprovision → warehouse deleted → Duckling CR fully gone
 #                  (finalizer cascade that drops the cnpg role+db completed).
 #                  Same-id re-provision is covered across runs by run.sh, not
@@ -1307,6 +1311,47 @@ internal_secret_fallback_auth() {
   [ "$code" = "401" ] || fail "GET /api/v1/orgs with garbage secret returned $code, want 401 (accept-list must stay closed)"
 }
 
+# ---- admin models explorer API ---------------------------------------------
+# The dashboard's generic models explorer (sidebar + table + detail UI) is
+# backed by GET /api/v1/models (sidebar: every config-store model + a live row
+# count) and GET /api/v1/models/:model (one model's rows + derived columns).
+# This asserts the surface is wired and — load-bearing — that the listing never
+# leaks secret-bearing columns: org_users carry a bcrypt password hash in the
+# DB, but Password is json:"-", so it must NOT appear in the API response. A
+# regression here (someone retagging Password) would surface a credential hash
+# in the operator UI.
+models_explorer_api() {
+  log "admin models explorer API (sidebar + listing + redaction)"
+  # Sidebar: must enumerate the known models across all three groups.
+  idx="$(curl -fsS -H "$H" "$API/api/v1/models")"
+  for key in orgs org-users managed-warehouses global-config worker-records org-connection-leases; do
+    echo "$idx" | jq -e --arg k "$key" '.models[] | select(.key == $k)' >/dev/null \
+      || fail "models index missing model '$key'"
+  done
+  # The seeded cnpg org must show up with a >=1 count on the orgs model.
+  orgcount="$(echo "$idx" | jq -r '.models[] | select(.key=="orgs") | .count')"
+  [ "$orgcount" -ge 1 ] 2>/dev/null || fail "orgs model count '$orgcount' < 1 (expected seeded orgs)"
+
+  # org-users listing: present users, derive columns, and NEVER a password.
+  users="$(curl -fsS -H "$H" "$API/api/v1/models/org-users")"
+  echo "$users" | jq -e '.columns | index("username")' >/dev/null \
+    || fail "org-users listing missing 'username' column"
+  if echo "$users" | jq -e '.columns | index("password")' >/dev/null 2>&1; then
+    fail "org-users listing exposes a 'password' column (must be redacted)"
+  fi
+  if echo "$users" | jq -e '[.rows[] | has("password")] | any' >/dev/null 2>&1; then
+    fail "org-users row carries a password field (credential hash leak via UI)"
+  fi
+  # A runtime-schema model must list (schema qualification works), returning
+  # columns even when the table is empty.
+  curl -fsS -H "$H" "$API/api/v1/models/worker-records" \
+    | jq -e '.columns | index("worker_id")' >/dev/null \
+    || fail "worker-records listing missing 'worker_id' column (runtime schema qualification broken)"
+  # Unknown model → 404.
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "$H" "$API/api/v1/models/not-a-model")"
+  [ "$code" = "404" ] || fail "GET /api/v1/models/not-a-model returned $code, want 404"
+}
+
 # ---- tenant isolation -----------------------------------------------------
 # Two tenants (cnpg + ext) back onto distinct DuckLake metadata stores, so a
 # table created by one is invisible to the other. Ported (logical half) from
@@ -1556,6 +1601,11 @@ main() {
   log "settling ${CONFIG_POLL_SETTLE:-12}s for CP auth cache…"
   sleep "${CONFIG_POLL_SETTLE:-12}"
 
+  # Admin models explorer: orgs + their users now exist in the config store, so
+  # the sidebar counts are non-trivial and the org-users redaction check bites
+  # against a real bcrypt-hash-bearing row.
+  models_explorer_api
+
   # Join the kubectl background download started at script load — first k use
   # is inside the lanes, so the fetch overlapped the whole provisioning phase.
   bootstrap_kubectl
@@ -1579,7 +1629,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"


### PR DESCRIPTION
## What

Adds a generic, read-only **models explorer** to the control-plane admin dashboard, and a local dev workflow for iterating on the UI without redeploying.

- **Sidebar** of every config-store model, grouped **Tenants / Config / Runtime** (13 persisted models across the config + runtime schemas), each with a live row count.
- **Table** of the selected model's rows with derived columns.
- **Detail panel** on row click — nested managed-warehouse sub-configs (`s3`, `iceberg`, `metadata_store`, the `SecretRef`s, …) render as **expandable sections**.
- `/` and `/models` now serve this as the primary dashboard surface; the legacy per-entity pages stay reachable.

## Backend (`controlplane/admin/models_api.go`, `kubernetes` tag)

- `GET /api/v1/models` → sidebar entries + counts.
- `GET /api/v1/models/:model` → rows, columns, count, truncation flag.
- `modelDescriptors()` is the single source of truth — add a model there and it appears in the sidebar, listing, and column derivation.
- **Redaction is structural**: rows are scanned into the typed model and marshaled via `json` tags, so columns tagged `json:"-"` (`OrgUser.Password`, `OrgUserSecret.Ciphertext`, `DuckLakeConfig.S3SecretKey`, the singleton IDs) are dropped. Runtime-schema tables are schema-qualified via `RuntimeSchema()`; listings capped at `modelsRowLimit`.

## UI (`static/models.html`, restyled `static/login.html`)

Mission-control design language (Chakra Petch + IBM Plex Mono, dark HUD, cyan/amber accents). Uses relative `/api/v1` paths + cookie auth, with a session-expired gate on 401.

## Local UI dev without redeploy (`controlplane/admin/devserver/`)

A stdlib dev proxy serves `static/` off disk and proxies `/api,/login,/health` to a port-forwarded control plane, injecting the internal secret server-side. Same-origin from the browser → no CORS, secret never reaches page JS, and the embedded UI runs byte-for-byte the same under the proxy.

```sh
just ui-port-forward                              # kubectl port-forward 8080
DUCKGRES_INTERNAL_SECRET=<secret> just ui-dev     # http://127.0.0.1:5173 — edit static/ + refresh
```

> Note: the `/api/v1/models` backend is new, so a CP running this branch must be live for the explorer to load data (local stack via `just run-multitenant-kind`, or a dev-cluster deploy). Once deployed, UI edits are refresh-only.

## Auth

Unchanged — the existing internal-secret token (header / login cookie) gates the whole `/api/v1` group and the dashboard pages. Token login is enough "for now" as requested; can be hardened later.

## Tests

- `models_api_test.go`: no-DB guard pinning the registry + the redaction invariant (sensitive columns must stay `json:"-"`), plus a Postgres-backed test exercising the real query path including "password hash never appears in the response bytes".
- `tests/e2e-mw-dev/harness.sh::models_explorer_api`: live-cluster assertion — sidebar enumeration, counts, runtime-schema listing, 404 on unknown model, and the load-bearing check that `org_users` listings never expose a password column/field.

## Docs

`controlplane/admin/README.md` (pages, API, redaction invariant, local dev loop) + the `CLAUDE.md` admin bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)