### PR TITLE
admin/models-explorer: sorting, default sort, tooltips, orgs cross-model links

### DIFF
--- a/controlplane/admin/static/models.html
+++ b/controlplane/admin/static/models.html
@@ -169,6 +169,11 @@
       font-size: 10px; letter-spacing: .12em; text-transform: uppercase;
       padding: 9px 12px; border-bottom: 1px solid var(--line-bright);
     }
+    table.tbl thead th.sortable { cursor: pointer; user-select: none; }
+    table.tbl thead th.sortable:hover { color: var(--text); }
+    table.tbl thead th .sortind { color: var(--worker); margin-left: 5px; font-size: 9px; }
+    table.tbl thead th .tipmark { color: var(--cp); margin-left: 4px; font-size: 10px; cursor: help; }
+    table.tbl thead th.hastip { text-decoration: underline dotted var(--line-bright); text-underline-offset: 3px; }
     table.tbl tbody td {
       padding: 7px 12px; border-bottom: 1px solid var(--line);
       white-space: nowrap; max-width: 320px; overflow: hidden; text-overflow: ellipsis;
@@ -297,7 +302,15 @@
 
   <script>
   "use strict";
-  const state = { models: [], key: null, listing: null, filter: "", selected: -1 };
+  const state = { models: [], key: null, listing: null, filter: "", selected: -1, sortCol: null, sortDir: 1 };
+
+  // Per-model column tooltips (shown on the header, native title=). Keep text
+  // free of double quotes. Angle-bracket placeholders render literally.
+  const COLUMN_TOOLTIPS = {
+    orgs: {
+      hostname_alias: "Optional public hostname label for SNI routing. Empty/NULL: the org is reached at <database_name>.<managed-suffix> (or its org name if DNS-safe). Set: reachable at <hostname_alias>.<managed-suffix> while clients still connect with dbname=<database_name>. Must be a single DNS label (alphanumeric + hyphens, no leading/trailing hyphen).",
+    },
+  };
 
   function esc(s) {
     const d = document.createElement("div");
@@ -375,18 +388,54 @@
     return rows.filter(r => JSON.stringify(r).toLowerCase().includes(f));
   }
 
+  // cmpScalar compares two non-empty cell values: numbers numerically, booleans
+  // false<true, objects/arrays by their JSON, everything else as numeric-aware
+  // strings (so "9" < "10" and "worker-2" < "worker-10").
+  function cmpScalar(a, b) {
+    if (typeof a === "boolean" || typeof b === "boolean") return (a === b) ? 0 : (a ? 1 : -1);
+    if (typeof a === "number" && typeof b === "number") return a - b;
+    const sa = (a !== null && typeof a === "object") ? JSON.stringify(a) : String(a);
+    const sb = (b !== null && typeof b === "object") ? JSON.stringify(b) : String(b);
+    return sa.localeCompare(sb, undefined, { numeric: true, sensitivity: "base" });
+  }
+
+  // sortRows returns a sorted copy by the active column. Empty/null values
+  // always sink to the bottom regardless of direction; the click toggles
+  // asc/desc over the remaining values.
+  function sortRows(rows) {
+    if (!state.sortCol) return rows;
+    const c = state.sortCol, d = state.sortDir;
+    return rows.slice().sort((x, y) => {
+      const a = x[c], b = y[c];
+      const ea = a === null || a === undefined || a === "";
+      const eb = b === null || b === undefined || b === "";
+      if (ea && eb) return 0;
+      if (ea) return 1;
+      if (eb) return -1;
+      return d * cmpScalar(a, b);
+    });
+  }
+
   function renderTable() {
     const scroll = document.getElementById("table-scroll");
     const lst = state.listing;
     if (!lst) { scroll.innerHTML = '<div class="empty">Select a model from the sidebar.</div>'; return; }
     const cols = lst.columns || [];
-    const rows = filteredRows();
+    const rows = sortRows(filteredRows());
     if (!rows.length) {
       scroll.innerHTML = '<div class="empty">' + (lst.count === 0 ? "No rows in this table." : "No rows match the filter.") + "</div>";
       return;
     }
     let html = '<table class="tbl"><thead><tr>';
-    for (const c of cols) html += "<th>" + esc(c) + "</th>";
+    const tips = COLUMN_TOOLTIPS[state.key] || {};
+    for (const c of cols) {
+      const ind = state.sortCol === c ? (state.sortDir === 1 ? "▲" : "▼") : "";
+      const tip = tips[c];
+      const titleAttr = tip ? ' title="' + esc(tip) + '"' : "";
+      const cls = tip ? "sortable hastip" : "sortable";
+      const info = tip ? '<span class="tipmark">ⓘ</span>' : "";
+      html += '<th class="' + cls + '" data-col="' + esc(c) + '"' + titleAttr + ">" + esc(c) + info + '<span class="sortind">' + ind + "</span></th>";
+    }
     html += "</tr></thead><tbody>";
     rows.forEach((r, i) => {
       html += '<tr data-idx="' + i + '">';
@@ -395,6 +444,13 @@
     });
     html += "</tbody></table>";
     scroll.innerHTML = html;
+    scroll.querySelectorAll("thead th.sortable").forEach(th => th.addEventListener("click", () => {
+      const c = th.dataset.col;
+      // Same column → flip direction; new column → start ascending.
+      if (state.sortCol === c) state.sortDir = -state.sortDir;
+      else { state.sortCol = c; state.sortDir = 1; }
+      renderTable();
+    }));
     scroll.querySelectorAll("tbody tr").forEach(tr => tr.addEventListener("click", () => showDetail(parseInt(tr.dataset.idx, 10), rows)));
   }
 
@@ -444,6 +500,8 @@
   async function selectModel(key) {
     state.key = key;
     state.filter = "";
+    state.sortCol = null;
+    state.sortDir = 1;
     document.getElementById("search").value = "";
     closeDetail();
     renderSidebar();
@@ -455,6 +513,10 @@
     try {
       const lst = await api("/api/v1/models/" + encodeURIComponent(key));
       state.listing = lst;
+      // Default sort: first column ascending, so the table opens in a defined,
+      // visible order (▲ on column 0) rather than raw DB order.
+      state.sortCol = (lst.columns && lst.columns[0]) || null;
+      state.sortDir = 1;
       document.getElementById("model-table").textContent = lst.table || "";
       document.getElementById("model-count").textContent =
         lst.count + " row" + (lst.count === 1 ? "" : "s") + (lst.truncated ? " (showing first " + lst.rows.length + ")" : "");

--- a/controlplane/admin/static/models.html
+++ b/controlplane/admin/static/models.html
@@ -184,6 +184,8 @@
     table.tbl tbody tr.sel { background: rgba(56,225,255,.12); }
     .muted { color: var(--dim); }
     .nestref { color: var(--cp); }
+    a.celllink { color: var(--worker); text-decoration: none; border-bottom: 1px dotted var(--worker); cursor: pointer; }
+    a.celllink:hover { color: var(--text); border-bottom-color: var(--text); }
     .pill {
       font-size: 10px; letter-spacing: .06em; text-transform: uppercase;
       border-radius: 4px; padding: 1px 7px; border: 1px solid var(--line-bright);
@@ -309,8 +311,43 @@
   const COLUMN_TOOLTIPS = {
     orgs: {
       hostname_alias: "Optional public hostname label for SNI routing. Empty/NULL: the org is reached at <database_name>.<managed-suffix> (or its org name if DNS-safe). Set: reachable at <hostname_alias>.<managed-suffix> while clients still connect with dbname=<database_name>. Must be a single DNS label (alphanumeric + hyphens, no leading/trailing hyphen).",
+      users: "Number of users in this org. Click to open Org Users filtered to this org.",
+      warehouse: "The org's managed warehouse (1:1, keyed by org name). Click to open it in Managed Warehouses.",
     },
   };
+
+  // Per-org aux data computed client-side: the live /models/orgs listing does
+  // not preload users/warehouse, so we fetch those two models once and group by
+  // org_id to render a live user count + warehouse-presence link in the orgs
+  // table. Cached until the next orgs load.
+  const orgAux = { userCounts: {}, hasWarehouse: {} };
+  async function loadOrgAux() {
+    try {
+      const [users, whs] = await Promise.all([
+        api("/api/v1/models/org-users"),
+        api("/api/v1/models/managed-warehouses"),
+      ]);
+      const uc = {}, hw = {};
+      for (const u of (users.rows || [])) { if (u.org_id) uc[u.org_id] = (uc[u.org_id] || 0) + 1; }
+      for (const w of (whs.rows || [])) { if (w.org_id) hw[w.org_id] = true; }
+      orgAux.userCounts = uc;
+      orgAux.hasWarehouse = hw;
+    } catch (e) { /* on failure leave maps empty; cells still render as links */ }
+  }
+
+  // cellHTML renders one table cell, special-casing the orgs cross-model links
+  // (users count → Org Users, warehouse → Managed Warehouses), else renderCell.
+  function cellHTML(model, col, row) {
+    if (model === "orgs" && col === "users") {
+      const n = orgAux.userCounts[row.name] || 0;
+      return '<a class="celllink" data-nav="org-users" data-filter="' + esc(row.name) + '">' + n + " user" + (n === 1 ? "" : "s") + "</a>";
+    }
+    if (model === "orgs" && col === "warehouse") {
+      if (!orgAux.hasWarehouse[row.name]) return '<span class="muted">—</span>';
+      return '<a class="celllink" data-nav="managed-warehouses" data-filter="' + esc(row.name) + '">warehouse →</a>';
+    }
+    return renderCell(col, row[col]);
+  }
 
   function esc(s) {
     const d = document.createElement("div");
@@ -439,11 +476,18 @@
     html += "</tr></thead><tbody>";
     rows.forEach((r, i) => {
       html += '<tr data-idx="' + i + '">';
-      for (const c of cols) html += "<td>" + renderCell(c, r[c]) + "</td>";
+      for (const c of cols) html += "<td>" + cellHTML(state.key, c, r) + "</td>";
       html += "</tr>";
     });
     html += "</tbody></table>";
     scroll.innerHTML = html;
+    // Cross-model link cells: navigate to the related model filtered to the org,
+    // and stop the row-detail click from also firing.
+    scroll.querySelectorAll("a.celllink").forEach(a => a.addEventListener("click", e => {
+      e.stopPropagation();
+      e.preventDefault();
+      selectModel(a.dataset.nav, a.dataset.filter);
+    }));
     scroll.querySelectorAll("thead th.sortable").forEach(th => th.addEventListener("click", () => {
       const c = th.dataset.col;
       // Same column → flip direction; new column → start ascending.
@@ -497,12 +541,12 @@
     document.querySelectorAll("#table-scroll tbody tr.sel").forEach(tr => tr.classList.remove("sel"));
   }
 
-  async function selectModel(key) {
+  async function selectModel(key, filterText) {
     state.key = key;
-    state.filter = "";
+    state.filter = filterText || "";
     state.sortCol = null;
     state.sortDir = 1;
-    document.getElementById("search").value = "";
+    document.getElementById("search").value = state.filter;
     closeDetail();
     renderSidebar();
     const m = state.models.find(x => x.key === key) || {};
@@ -513,6 +557,8 @@
     try {
       const lst = await api("/api/v1/models/" + encodeURIComponent(key));
       state.listing = lst;
+      // Orgs table needs per-org user counts + warehouse presence (client-side).
+      if (key === "orgs") await loadOrgAux();
       // Default sort: first column ascending, so the table opens in a defined,
       // visible order (▲ on column 0) rather than raw DB order.
       state.sortCol = (lst.columns && lst.columns[0]) || null;


### PR DESCRIPTION
UX follow-ups to the models explorer (#821). Pure frontend (`static/models.html`); embedded via `//go:embed`, ships on the next CP image build.

- **Column sorting** — click a header to sort ascending (▲), again to flip (▼). Numeric-aware; booleans + nested object/array cells sort by JSON; empty/null sink to the bottom.
- **Default sort** — opens (and on every model switch) sorted by the first column ascending, instead of raw DB order.
- **Column tooltips** — `COLUMN_TOOLTIPS[model][column]` rendered as native `title=` (violet ⓘ + dotted underline). Seeded for `orgs.hostname_alias` (SNI fallback), `orgs.users`, `orgs.warehouse`.
- **Orgs cross-model links** — the `users` cell shows a live per-org user count → clicks into Org Users filtered to that org; the `warehouse` cell links to that org's Managed Warehouses row (warehouse PK = org name), or `—` when none. Counts/presence computed client-side (fetch `org-users` + `managed-warehouses`, group by `org_id`) since `/models/orgs` doesn't preload them; link clicks call `selectModel(model, filter)` and don't trigger the row-detail handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)