### PR TITLE
controlplane: remove global k8s worker cap; org max_workers=0 = unbounded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Key CLI flags for control-plane mode:
 - `--ducklake-delta-catalog-enabled` / `--ducklake-delta-catalog-path`
 - Remote backend (requires `--config-store`; `-tags kubernetes` for K8s pool):
   - Config store: `--config-store`, `--config-poll-interval`, `--internal-secret`
-  - K8s pool: `--k8s-worker-image`, `--k8s-worker-namespace`, `--k8s-control-plane-id`, `--k8s-worker-port`, `--k8s-worker-secret`, `--k8s-worker-configmap`, `--k8s-worker-image-pull-policy`, `--k8s-worker-service-account`, `--k8s-max-workers`
+  - K8s pool: `--k8s-worker-image`, `--k8s-worker-namespace`, `--k8s-control-plane-id`, `--k8s-worker-port`, `--k8s-worker-secret`, `--k8s-worker-configmap`, `--k8s-worker-image-pull-policy`, `--k8s-worker-service-account` (no global worker cap — per-org `Org.MaxWorkers`, 0=unbounded, is the only cap)
   - AWS / STS: `--aws-region`
   - Pod scheduling knobs (CPU/memory requests, node selector, tolerations) are env-only — see `config_resolution.go`.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ Run with config file:
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_SNI_ROUTING_MODE` | Multi-tenant managed-hostname routing: `off`, `passthrough`, or `enforce`. Postgres uses the requested dbname first; managed SNI must resolve to the same org, and SNI supplies the database only when dbname is empty. | `off` |
 | `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES` | Comma-separated managed hostname suffixes such as `.dw.us.postwh.com` | - |
-| `DUCKGRES_K8S_MAX_WORKERS` | Global cap for shared K8s workers (`0` means Duckgres does not impose a cap) | `0` |
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` | Attach a Delta Lake catalog/table during worker boot/activation | `false` |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH` | Delta Lake catalog/table path; defaults to sibling `delta/` prefix at the DuckLake object-store root when enabled | Derived |
@@ -381,7 +380,6 @@ Options:
   -sni-routing-mode string Hostname routing: off, passthrough, or enforce
   -managed-hostname-suffixes string
                           Comma-separated managed tenant hostname suffixes
-  -k8s-max-workers int    Max K8s workers in the shared pool, 0=unbounded
 ```
 
 ## DuckDB Extensions

--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -228,7 +228,6 @@ func main() {
 			WorkerConfigMap:              resolved.K8sWorkerConfigMap,
 			ImagePullPolicy:              resolved.K8sWorkerImagePullPolicy,
 			ServiceAccount:               resolved.K8sWorkerServiceAccount,
-			MaxWorkers:                   resolved.K8sMaxWorkers,
 			WorkerCPURequest:             resolved.K8sWorkerCPURequest,
 			WorkerMemoryRequest:          resolved.K8sWorkerMemoryRequest,
 			WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,
@@ -245,7 +244,7 @@ func main() {
 			WorkerProfileMinMemory:       resolved.K8sWorkerProfileMinMemory,
 			WorkerProfileMaxMemory:       resolved.K8sWorkerProfileMaxMemory,
 			WorkerMaxTTL:                 resolved.K8sWorkerMaxTTL,
-			WorkerDefaultTTL:                   resolved.K8sWorkerDefaultTTL,
+			WorkerDefaultTTL:             resolved.K8sWorkerDefaultTTL,
 			AWSRegion:                    resolved.AWSRegion,
 		},
 	}

--- a/configloader/file_config.go
+++ b/configloader/file_config.go
@@ -64,7 +64,6 @@ type K8sFileConfig struct {
 	WorkerConfigMap       string `yaml:"worker_configmap"`
 	WorkerImagePullPolicy string `yaml:"worker_image_pull_policy"`
 	WorkerServiceAccount  string `yaml:"worker_service_account"`
-	MaxWorkers            int    `yaml:"max_workers"`
 }
 
 type QueryLogFileConfig struct {

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -73,7 +73,6 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 	k8sWorkerConfigMap := fs.String("k8s-worker-configmap", "", "ConfigMap name for worker duckgres.yaml (env: DUCKGRES_K8S_WORKER_CONFIGMAP)")
 	k8sWorkerImagePullPolicy := fs.String("k8s-worker-image-pull-policy", "", "Image pull policy for K8s worker pods: Always, IfNotPresent, Never (env: DUCKGRES_K8S_WORKER_IMAGE_PULL_POLICY)")
 	k8sWorkerServiceAccount := fs.String("k8s-worker-service-account", "", "Neutral ServiceAccount name for K8s worker pods (default: duckgres-worker) (env: DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT)")
-	k8sMaxWorkers := fs.Int("k8s-max-workers", 0, "Max K8s workers in the shared pool, 0=unbounded (env: DUCKGRES_K8S_MAX_WORKERS)")
 	awsRegion := fs.String("aws-region", "", "AWS region for STS client (env: DUCKGRES_AWS_REGION)")
 	queryLog := fs.Bool("query-log", true, "Enable/disable DuckLake query log (use --query-log=false to disable; env: DUCKGRES_QUERY_LOG_ENABLED)")
 
@@ -133,7 +132,6 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 		cli.K8sWorkerConfigMap = *k8sWorkerConfigMap
 		cli.K8sWorkerImagePullPolicy = *k8sWorkerImagePullPolicy
 		cli.K8sWorkerServiceAccount = *k8sWorkerServiceAccount
-		cli.K8sMaxWorkers = *k8sMaxWorkers
 		cli.AWSRegion = *awsRegion
 		cli.QueryLog = *queryLog
 		return cli

--- a/configresolve/cliflags_test.go
+++ b/configresolve/cliflags_test.go
@@ -46,7 +46,6 @@ func fieldNameToFlagName(name string) string {
 		{"K8sWorkerImage", "k8s-worker-image"},
 		{"K8sWorkerSecret", "k8s-worker-secret"},
 		{"K8sWorkerPort", "k8s-worker-port"},
-		{"K8sMaxWorkers", "k8s-max-workers"},
 		{"ACMEDNSProvider", "acme-dns-provider"},
 		{"ACMEDNSZoneID", "acme-dns-zone-id"},
 		{"ACMECacheDir", "acme-cache-dir"},

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -78,7 +78,6 @@ type CLIInputs struct {
 	K8sWorkerConfigMap          string
 	K8sWorkerImagePullPolicy    string
 	K8sWorkerServiceAccount     string
-	K8sMaxWorkers               int
 	K8sWorkerCPURequest         string
 	K8sWorkerMemoryRequest      string
 	K8sWorkerNodeSelector       string
@@ -106,7 +105,6 @@ type Resolved struct {
 	K8sWorkerConfigMap              string
 	K8sWorkerImagePullPolicy        string
 	K8sWorkerServiceAccount         string
-	K8sMaxWorkers                   int
 	K8sWorkerCPURequest             string
 	K8sWorkerMemoryRequest          string
 	K8sWorkerNodeSelector           string
@@ -212,7 +210,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var k8sWorkerPort int
 	var k8sWorkerSecret, k8sWorkerConfigMap, k8sWorkerImagePullPolicy string
 	k8sWorkerServiceAccount := controlplane.DefaultK8sWorkerServiceAccount
-	var k8sMaxWorkers int
 	var k8sWorkerCPURequest, k8sWorkerMemoryRequest string
 	var k8sWorkerNodeSelector, k8sWorkerTolerationKey, k8sWorkerTolerationValue string
 	var awsRegion string
@@ -518,9 +515,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		}
 		if fileCfg.K8s.WorkerServiceAccount != "" {
 			k8sWorkerServiceAccount = fileCfg.K8s.WorkerServiceAccount
-		}
-		if fileCfg.K8s.MaxWorkers != 0 {
-			k8sMaxWorkers = fileCfg.K8s.MaxWorkers
 		}
 		if fileCfg.DuckLake.DefaultSpecVersion != "" {
 			cfg.DuckLake.SpecVersion = fileCfg.DuckLake.DefaultSpecVersion
@@ -848,13 +842,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	}
 	if v := getenv("DUCKGRES_K8S_WORKER_SERVICE_ACCOUNT"); v != "" {
 		k8sWorkerServiceAccount = v
-	}
-	if v := getenv("DUCKGRES_K8S_MAX_WORKERS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			k8sMaxWorkers = n
-		} else {
-			warn("Invalid DUCKGRES_K8S_MAX_WORKERS: " + err.Error())
-		}
 	}
 	if v := getenv("DUCKGRES_K8S_WORKER_CPU_REQUEST"); v != "" {
 		k8sWorkerCPURequest = v
@@ -1185,9 +1172,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if cli.Set["k8s-worker-service-account"] {
 		k8sWorkerServiceAccount = cli.K8sWorkerServiceAccount
 	}
-	if cli.Set["k8s-max-workers"] {
-		k8sMaxWorkers = cli.K8sMaxWorkers
-	}
 	if cli.Set["aws-region"] {
 		awsRegion = cli.AWSRegion
 	}
@@ -1276,7 +1260,6 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		K8sWorkerConfigMap:              k8sWorkerConfigMap,
 		K8sWorkerImagePullPolicy:        k8sWorkerImagePullPolicy,
 		K8sWorkerServiceAccount:         k8sWorkerServiceAccount,
-		K8sMaxWorkers:                   k8sMaxWorkers,
 		K8sWorkerCPURequest:             k8sWorkerCPURequest,
 		K8sWorkerMemoryRequest:          k8sWorkerMemoryRequest,
 		K8sWorkerNodeSelector:           k8sWorkerNodeSelector,

--- a/controlplane/capacity_policy.go
+++ b/controlplane/capacity_policy.go
@@ -12,7 +12,6 @@ type capacityClientMessageKind int
 const (
 	capacityMessageNoIdle capacityClientMessageKind = iota
 	capacityMessageOrgCap
-	capacityMessageGlobalCap
 	capacityMessageShuttingDown
 	capacityMessageGeneric
 )
@@ -31,8 +30,6 @@ func capacityMissPolicyForReason(reason configstore.WorkerClaimMissReason) capac
 		}
 	case configstore.WorkerClaimMissReasonOrgCap:
 		return capacityMissPolicy{reason: reason, messageKind: capacityMessageOrgCap}
-	case configstore.WorkerClaimMissReasonGlobalCap:
-		return capacityMissPolicy{reason: reason, messageKind: capacityMessageGlobalCap}
 	case configstore.WorkerClaimMissReasonShuttingDown:
 		return capacityMissPolicy{reason: reason, messageKind: capacityMessageShuttingDown}
 	default:
@@ -46,8 +43,6 @@ func (p capacityMissPolicy) errorString(retryAfter time.Duration) string {
 		return fmt.Sprintf("worker capacity exhausted; retry in about %s", normalizedCapacityRetryAfter(retryAfter).Round(time.Second))
 	case capacityMessageOrgCap:
 		return "worker capacity exhausted for organization"
-	case capacityMessageGlobalCap:
-		return "worker capacity exhausted by global pool limit"
 	case capacityMessageShuttingDown:
 		return "worker capacity unavailable while control plane is shutting down"
 	default:
@@ -61,8 +56,6 @@ func (p capacityMissPolicy) sqlMessage(retryAfter time.Duration) string {
 		return fmt.Sprintf("no Duckgres worker is currently available; one is being spawned, retry in about %d seconds", capacityRetrySeconds(retryAfter))
 	case capacityMessageOrgCap:
 		return "your organization has reached its maximum number of concurrent Duckgres workers and they are all busy; retry once a query finishes"
-	case capacityMessageGlobalCap:
-		return "Duckgres worker capacity is currently exhausted; retry later"
 	case capacityMessageShuttingDown:
 		return "Duckgres control plane is shutting down; retry later"
 	default:

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -421,7 +421,6 @@ const (
 	WorkerClaimMissReasonNone         WorkerClaimMissReason = ""
 	WorkerClaimMissReasonNoIdle       WorkerClaimMissReason = "no_idle"
 	WorkerClaimMissReasonOrgCap       WorkerClaimMissReason = "org_cap"
-	WorkerClaimMissReasonGlobalCap    WorkerClaimMissReason = "global_cap"
 	WorkerClaimMissReasonShuttingDown WorkerClaimMissReason = "shutting_down"
 )
 

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1356,9 +1356,11 @@ func (cs *ConfigStore) TakeOverWorker(workerID int, ownerCPInstanceID, orgID str
 	return claimed, nil
 }
 
-// CreateSpawningWorkerSlot creates a durable spawning worker row under advisory-lock
-// protected org/global capacity checks. A nil result means capacity blocked the spawn.
-func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*WorkerRecord, error) {
+// CreateSpawningWorkerSlot creates a durable spawning worker row under an
+// advisory-lock-protected per-org capacity check. A nil result means the org
+// cap blocked the spawn. There is no global/cluster cap: maxOrgWorkers == 0
+// means the org is unbounded (cluster autoscaler is the only ceiling).
+func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers int) (*WorkerRecord, error) {
 	if strings.TrimSpace(podNamePrefix) == "" {
 		return nil, fmt.Errorf("pod name prefix is required")
 	}
@@ -1370,9 +1372,6 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 				return err
 			}
 		}
-		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", advisoryLockKey("duckgres:global-worker-capacity")).Error; err != nil {
-			return err
-		}
 
 		if maxOrgWorkers > 0 && orgID != "" {
 			count, err := cs.countOrgAdmittingWorkers(tx, orgID, image, profileCPU, profileMemory)
@@ -1380,16 +1379,6 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 				return err
 			}
 			if count >= int64(maxOrgWorkers) {
-				return nil
-			}
-		}
-
-		if maxGlobalWorkers > 0 {
-			count, err := cs.countActiveWorkers(tx)
-			if err != nil {
-				return err
-			}
-			if count >= int64(maxGlobalWorkers) {
 				return nil
 			}
 		}

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -134,7 +134,6 @@ type K8sConfig struct {
 	WorkerConfigMap         string // ConfigMap name for duckgres.yaml
 	ImagePullPolicy         string // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
 	ServiceAccount          string // ServiceAccount name for worker pods (default: "duckgres-worker")
-	MaxWorkers              int    // Global cap for the shared K8s worker pool (0 = unbounded; cluster autoscaler is the natural ceiling)
 	WorkerCPURequest        string // CPU request for worker pods (e.g., "500m")
 	WorkerMemoryRequest     string // Memory request for worker pods (e.g., "1Gi")
 	WorkerNodeSelector      string // JSON map for worker pod nodeSelector (e.g., '{"posthog.com/nodepool":"workers"}')
@@ -418,8 +417,6 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	if processMaxWorkers == 0 {
 		processMaxWorkers = tempRebalancer.DefaultMaxWorkers()
 	}
-	// K8s max_workers: 0 = unbounded (no cap derived from CP memory).
-	k8sMaxWorkers := cfg.K8s.MaxWorkers
 
 	rebalancer := NewMemoryRebalancer(memBudget, 0, nil, cfg.MemoryRebalance)
 
@@ -428,8 +425,11 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 			"process_max_workers", processMaxWorkers,
 			"memory_budget", formatBytes(memBudget))
 	}
-	if isK8s && k8sMaxWorkers == 0 {
-		slog.Info("k8s.max_workers unset; worker pool is unbounded — cluster autoscaler (e.g. Karpenter) is the ceiling.")
+	if isK8s {
+		// K8s worker pools have no global/cluster cap. Per-org caps
+		// (Org.MaxWorkers, 0 = unbounded) plus the cluster autoscaler
+		// (e.g. Karpenter) are the only ceilings.
+		slog.Info("K8s worker pool has no global cap; per-org Org.MaxWorkers (0=unbounded) + cluster autoscaler are the ceilings.")
 	}
 
 	processMinWorkers := cfg.Process.MinWorkers
@@ -476,7 +476,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 
 	// Multi-tenant mode: config store + per-org pools (K8s remote backend only)
 	if cfg.WorkerBackend == "remote" {
-		store, adapter, apiServer, runtimeTracker, janitorLeader, err := SetupMultiTenant(cfg, srv, memBudget, k8sMaxWorkers, cp.healthReady)
+		store, adapter, apiServer, runtimeTracker, janitorLeader, err := SetupMultiTenant(cfg, srv, memBudget, cp.healthReady)
 		if err != nil {
 			slog.Error("Failed to set up multi-tenant config store.", "error", err)
 			os.Exit(1)
@@ -652,7 +652,6 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		"worker_backend", cfg.WorkerBackend,
 		"process_min_workers", processMinWorkers,
 		"process_max_workers", processMaxWorkers,
-		"k8s_max_workers", k8sMaxWorkers,
 		"worker_queue_timeout", cfg.WorkerQueueTimeout,
 		"session_init_timeout", cfg.SessionInitTimeout,
 		"memory_budget", formatBytes(rebalancer.memoryBudget),

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -116,11 +116,6 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 			message: "your organization has reached its maximum number of concurrent Duckgres workers and they are all busy; retry once a query finishes",
 		},
 		{
-			name:    "global capacity exhausted",
-			reason:  configstore.WorkerClaimMissReasonGlobalCap,
-			message: "Duckgres worker capacity is currently exhausted; retry later",
-		},
-		{
 			name:    "control plane shutting down",
 			reason:  configstore.WorkerClaimMissReasonShuttingDown,
 			message: "Duckgres control plane is shutting down; retry later",
@@ -157,7 +152,6 @@ func TestCapacityMissPolicyForKnownReasons(t *testing.T) {
 		{name: "none defaults to no_idle", reason: configstore.WorkerClaimMissReasonNone, policyReason: configstore.WorkerClaimMissReasonNoIdle},
 		{name: "no_idle", reason: configstore.WorkerClaimMissReasonNoIdle, policyReason: configstore.WorkerClaimMissReasonNoIdle},
 		{name: "org_cap", reason: configstore.WorkerClaimMissReasonOrgCap, policyReason: configstore.WorkerClaimMissReasonOrgCap},
-		{name: "global_cap", reason: configstore.WorkerClaimMissReasonGlobalCap, policyReason: configstore.WorkerClaimMissReasonGlobalCap},
 		{name: "shutting_down", reason: configstore.WorkerClaimMissReasonShuttingDown, policyReason: configstore.WorkerClaimMissReasonShuttingDown},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -172,8 +172,9 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 	spawnConcurrency := 50
 	retireConcurrency := 5
 	pool := &K8sWorkerPool{
-		workers:                 make(map[int]*ManagedWorker),
-		maxWorkers:              cfg.MaxWorkers,
+		workers: make(map[int]*ManagedWorker),
+		// maxWorkers defaults to 0 (unbounded); there is no global cluster cap.
+		// Per-org caps are applied by OrgReservedPool, not the shared pool.
 		idleTimeout:             cfg.IdleTimeout,
 		shutdownCh:              make(chan struct{}),
 		stopInform:              make(chan struct{}),

--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -369,7 +369,6 @@ func (p *K8sWorkerPool) reserveSharedWorkerDecision(assignment *WorkerAssignment
 		return nil, fmt.Errorf("pool is shutting down")
 	}
 	p.cleanDeadWorkersLocked()
-	maxGlobal := p.maxWorkers
 	p.mu.Unlock()
 
 	if p.runtimeStore != nil && assignment.OrgID != "" {
@@ -389,14 +388,14 @@ func (p *K8sWorkerPool) reserveSharedWorkerDecision(assignment *WorkerAssignment
 	// No reusable hot-idle worker for this org — spawn one on demand, sized from
 	// the request profile (or the pool-global default for a default request).
 	// Allocate a real, unique worker id. In the runtime-store path this MUST come
-	// from the DB via CreateSpawningWorkerSlot (which also enforces the per-org and
-	// global worker caps cross-CP and returns a nil slot when capped) — the
-	// background id allocator returns a placeholder 0 that collides across spawns.
+	// from the DB via CreateSpawningWorkerSlot (which enforces the per-org worker
+	// cap cross-CP and returns a nil slot when capped) — the background id
+	// allocator returns a placeholder 0 that collides across spawns.
 	if p.runtimeStore != nil {
 		spawnProfileCPU, spawnProfileMem := assignment.Profile.Parts()
 		slot, err := p.runtimeStore.CreateSpawningWorkerSlot(
 			p.cpInstanceID, assignment.OrgID, assignment.Image, spawnProfileCPU, spawnProfileMem, 0,
-			p.workerPodNamePrefix(), assignment.MaxWorkers, maxGlobal)
+			p.workerPodNamePrefix(), assignment.MaxWorkers)
 		if err != nil {
 			return nil, err
 		}

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -107,7 +107,6 @@ type captureRuntimeWorkerStore struct {
 	spawnOwnerEpoch                  int64
 	spawnPodNamePrefix               string
 	spawnMaxOrgWorkers               int
-	spawnMaxGlobalWorks              int
 	hotIdleClaimResult               *configstore.WorkerRecord
 	hotIdleClaimMissReason           configstore.WorkerClaimMissReason
 	hotIdleClaimCPID                 string
@@ -212,7 +211,7 @@ func (s *captureRuntimeWorkerStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID,
 	}
 	return nil, s.hotIdleClaimMissReason, nil
 }
-func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error) {
+func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers int) (*configstore.WorkerRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.spawnCalls++
@@ -224,7 +223,6 @@ func (s *captureRuntimeWorkerStore) CreateSpawningWorkerSlot(ownerCPInstanceID, 
 	s.spawnOwnerEpoch = ownerEpoch
 	s.spawnPodNamePrefix = podNamePrefix
 	s.spawnMaxOrgWorkers = maxOrgWorkers
-	s.spawnMaxGlobalWorks = maxGlobalWorkers
 	if s.spawnErr != nil {
 		return nil, s.spawnErr
 	}
@@ -1382,30 +1380,6 @@ func TestK8sPoolReserveSharedWorkerReturnsOrgCapFromHotIdleClaim(t *testing.T) {
 	}
 	if store.recordMissCalls != 0 {
 		t.Fatalf("expected no recorded miss for org-cap, got %d", store.recordMissCalls)
-	}
-}
-
-func TestK8sPoolReserveSharedWorkerDecisionDoesNotReplaceIncompatibleHotIdleOnGlobalCapMiss(t *testing.T) {
-	pool, _ := newTestK8sPool(t, 1)
-	store := &captureRuntimeWorkerStore{
-		hotIdleClaimMissReason: configstore.WorkerClaimMissReasonNoIdle,
-	}
-	pool.runtimeStore = store
-
-	claim, err := pool.reserveSharedWorkerDecision(&WorkerAssignment{
-		OrgID:      "analytics",
-		MaxWorkers: 1,
-		Image:      "duckgres:new",
-	})
-	var capacityErr *WorkerCapacityExhaustedError
-	if !errors.As(err, &capacityErr) {
-		t.Fatalf("expected capacity error, got claim=%#v err=%v", claim, err)
-	}
-	if claim != nil {
-		t.Fatalf("expected no claim on capacity miss, got %#v", claim)
-	}
-	if store.spawnCalls != 1 {
-		t.Fatalf("expected direct spawn attempt to enforce global cap, got %d spawn calls", store.spawnCalls)
 	}
 }
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -130,7 +130,6 @@ func SetupMultiTenant(
 	cfg ControlPlaneConfig,
 	srv *server.Server,
 	memBudget uint64,
-	maxWorkers int,
 	isHealthy func() bool,
 ) (ConfigStoreInterface, OrgRouterInterface, *http.Server, *ControlPlaneRuntimeTracker, *JanitorLeaderManager, error) {
 	pollInterval := cfg.ConfigPollInterval
@@ -188,7 +187,6 @@ func SetupMultiTenant(
 		WorkerPort:                   cfg.K8s.WorkerPort,
 		SecretName:                   cfg.K8s.WorkerSecret,
 		ConfigMap:                    cfg.K8s.WorkerConfigMap,
-		MaxWorkers:                   maxWorkers,
 		IdleTimeout:                  cfg.WorkerIdleTimeout,
 		ConfigPath:                   cfg.ConfigPath,
 		ImagePullPolicy:              cfg.K8s.ImagePullPolicy,

--- a/controlplane/multitenant_stub.go
+++ b/controlplane/multitenant_stub.go
@@ -14,7 +14,6 @@ func SetupMultiTenant(
 	cfg ControlPlaneConfig,
 	srv *server.Server,
 	memBudget uint64,
-	maxWorkers int,
 	isHealthy func() bool,
 ) (ConfigStoreInterface, OrgRouterInterface, *http.Server, *ControlPlaneRuntimeTracker, *JanitorLeaderManager, error) {
 	return nil, nil, nil, nil, nil, fmt.Errorf("multi-tenant mode requires -tags kubernetes build")

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -99,10 +99,9 @@ func NewOrgRouter(store *configstore.ConfigStore, baseCfg K8sWorkerPoolConfig, g
 func (tr *OrgRouter) createOrgStack(tc *configstore.OrgConfig) (*OrgStack, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Per-org worker cap. 0 = unbounded (the cluster autoscaler / node capacity
+	// is the only ceiling). There is no global/cluster-default fallback.
 	maxWorkers := tc.MaxWorkers
-	if maxWorkers == 0 {
-		maxWorkers = tr.baseCfg.MaxWorkers
-	}
 
 	// Apply per-org worker resource overrides to the shared pool.
 	if tc.WorkerCPURequest != "" || tc.WorkerMemoryRequest != "" {
@@ -328,11 +327,8 @@ func (tr *OrgRouter) HandleConfigChange(old, new *configstore.Snapshot) {
 			if limitsChanged {
 				slog.Info("Org config changed.", "org", name,
 					"old_max_workers", oldTC.MaxWorkers, "new_max_workers", newTC.MaxWorkers)
-				maxWorkers := newTC.MaxWorkers
-				if maxWorkers == 0 {
-					maxWorkers = tr.baseCfg.MaxWorkers
-				}
-				stack.Pool.SetMaxWorkers(maxWorkers)
+				// 0 = unbounded; no global/cluster-default fallback.
+				stack.Pool.SetMaxWorkers(newTC.MaxWorkers)
 			}
 			if floorChanged {
 				slog.Info("Org default hot-idle floor changed.", "org", name,

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -160,7 +160,7 @@ func TestOrgRouterHandleConfigChangeRefreshesRuntimeOnlyUpdates(t *testing.T) {
 				Pool:   pool,
 			},
 		},
-		baseCfg:   K8sWorkerPoolConfig{MaxWorkers: 2},
+		baseCfg:   K8sWorkerPoolConfig{},
 		globalCfg: ControlPlaneConfig{},
 	}
 
@@ -198,7 +198,7 @@ func TestOrgRouterHandleConfigChangeRefreshesOrgWorkerImage(t *testing.T) {
 				Pool:   pool,
 			},
 		},
-		baseCfg: K8sWorkerPoolConfig{MaxWorkers: 2, WorkerImage: "posthog/duckgres:v1.0.0"},
+		baseCfg: K8sWorkerPoolConfig{WorkerImage: "posthog/duckgres:v1.0.0"},
 	}
 
 	tr.HandleConfigChange(
@@ -224,7 +224,7 @@ func TestOrgRouterHandleConfigChangeRefreshesDefaultWorkerMinHotIdle(t *testing.
 				Pool:   pool,
 			},
 		},
-		baseCfg: K8sWorkerPoolConfig{MaxWorkers: 2},
+		baseCfg: K8sWorkerPoolConfig{},
 	}
 
 	tr.HandleConfigChange(
@@ -340,7 +340,7 @@ func TestOrgRouterCreateOrgStackActivatesUsingLatestSnapshotThroughSharedWorkerA
 	tr := &OrgRouter{
 		orgs:        make(map[string]*OrgStack),
 		configStore: store,
-		baseCfg:     K8sWorkerPoolConfig{MaxWorkers: 2},
+		baseCfg:     K8sWorkerPoolConfig{},
 		sharedPool:  sharedPool,
 		globalCfg:   ControlPlaneConfig{},
 	}

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -98,7 +98,6 @@ type K8sWorkerPoolConfig struct {
 	WorkerPort                   int
 	SecretName                   string // Base name for per-worker K8s Secrets containing RPC bearer token and TLS material
 	ConfigMap                    string // ConfigMap name for duckgres.yaml
-	MaxWorkers                   int
 	IdleTimeout                  time.Duration
 	ConfigPath                   string                                       // Path inside worker pod where config is mounted
 	ImagePullPolicy              string                                       // Image pull policy for worker pods (e.g., "Never", "IfNotPresent", "Always")
@@ -132,7 +131,7 @@ type K8sWorkerPoolConfig struct {
 type RuntimeWorkerStore interface {
 	UpsertWorkerRecord(record *configstore.WorkerRecord) error
 	ClaimHotIdleWorker(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, maxOrgWorkers int) (*configstore.WorkerRecord, configstore.WorkerClaimMissReason, error)
-	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers, maxGlobalWorkers int) (*configstore.WorkerRecord, error)
+	CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image string, profileCPU, profileMemory string, ownerEpoch int64, podNamePrefix string, maxOrgWorkers int) (*configstore.WorkerRecord, error)
 	CountHotIdleWorkers(orgID, image, profileCPU, profileMemory string) (int, error)
 	GetWorkerRecord(workerID int) (*configstore.WorkerRecord, error)
 	ObserveWorker(workerID int) (*configstore.WorkerSnapshot, error)

--- a/docs/runbooks/replenish-capacity.md
+++ b/docs/runbooks/replenish-capacity.md
@@ -21,14 +21,14 @@ controller** (`reconcileHeadroom`, a janitor hook): it keeps a constant
 `DUCKGRES_K8S_HEADROOM_NODES` node-sized low-priority placeholder ("pause") pods
 (or, in the legacy mode, `DUCKGRES_K8S_HEADROOM_PERCENT` of worker demand) ready;
 a real worker spawn preempts a placeholder and schedules immediately. So "low capacity" now means one of: spawns
-are failing, the cluster can't schedule pods, headroom is exhausted, or an org /
-the global pool has hit its worker cap.
+are failing, the cluster can't schedule pods, headroom is exhausted, or an org
+has hit its per-org worker cap (`Org.MaxWorkers`; 0 = unbounded). There is no
+global/cluster worker cap — the node pool / autoscaler is the only shared ceiling.
 
 ## Metrics to watch
 
 | Metric | What it means |
 |--------|---------------|
-| `sum(duckgres_worker_lifecycle_count{state="hot"})` near `--k8s-max-workers` | Global pool at its cap; sessions get `worker capacity exhausted by global pool limit` |
 | `sum(duckgres_worker_lifecycle_count{state="spawning"})` sustained > 0 | Spawns are slow/stuck (image pull, Pending pods, cold nodes) |
 | `sum by (reason)(rate(duckgres_worker_spawn_failures_total[5m]))` | Pod spawn errors by stage |
 | `duckgres_control_plane_worker_acquire_seconds` (if present) | Session acquire latency |
@@ -81,13 +81,13 @@ unassigned anymore); production capacity lives in `binding="org_bound"`.
      ready. Placeholders use a PriorityClass ranked **below** the worker
      PriorityClass so workers always win.
 
-4. **Check the caps.** If you hit `worker capacity exhausted for organization` or
-   `...by global pool limit`, the request is at a real cap, not a scheduling
-   problem:
-   - Global: raise `--k8s-max-workers` (env `DUCKGRES_K8S_MAX_WORKERS`) if the pool
-     is legitimately undersized; otherwise scale the worker node pool.
-   - Per-org: the org reached its configured max concurrent workers and all are
-     busy — expected backpressure; the client should retry as queries finish.
+4. **Check the cap.** If you hit `worker capacity exhausted for organization`,
+   the request is at a real cap, not a scheduling problem:
+   - Per-org: the org reached its configured max concurrent workers
+     (`Org.MaxWorkers`) and all are busy — expected backpressure; the client
+     should retry as queries finish. Raise the org's `max_workers` (or set it to
+     0 = unbounded) if it is legitimately undersized; otherwise scale the worker
+     node pool. There is no global worker cap to raise.
 
 5. **Verify recovery.** New sessions stop getting capacity errors;
    `duckgres_worker_lifecycle_count{state="spawning"}` settles back toward 0.

--- a/main.go
+++ b/main.go
@@ -137,7 +137,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_CONFIG_POLL_INTERVAL  Config store poll interval (default: 30s)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_INTERNAL_SECRET    Shared secret for API authentication\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_INTERNAL_SECRET_FALLBACKS  Comma-separated previous internal secrets still accepted during rotation\n")
-		fmt.Fprintf(os.Stderr, "  DUCKGRES_K8S_MAX_WORKERS    Max K8s workers in the shared pool (0=unbounded)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_AWS_REGION         AWS region for STS client\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_LOG_LEVEL          Log level: debug, info, warn, error (default: info)\n")
 		fmt.Fprintf(os.Stderr, "\nPrecedence: CLI flags > environment variables > config file > defaults\n")
@@ -368,7 +367,6 @@ func main() {
 				WorkerConfigMap:              resolved.K8sWorkerConfigMap,
 				ImagePullPolicy:              resolved.K8sWorkerImagePullPolicy,
 				ServiceAccount:               resolved.K8sWorkerServiceAccount,
-				MaxWorkers:                   resolved.K8sMaxWorkers,
 				WorkerCPURequest:             resolved.K8sWorkerCPURequest,
 				WorkerMemoryRequest:          resolved.K8sWorkerMemoryRequest,
 				WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,

--- a/main_test.go
+++ b/main_test.go
@@ -530,9 +530,6 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 			MaxWorkers:         10,
 			RetireOnSessionEnd: &retireTrue,
 		},
-		K8s: K8sFileConfig{
-			MaxWorkers: 12,
-		},
 	}
 	resolved := configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{}, envFromMap(nil), nil)
 	if resolved.Server.MemoryBudget != "24GB" {
@@ -547,9 +544,6 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	if !resolved.ProcessRetireOnSessionEnd {
 		t.Fatal("expected process.retire_on_session_end from file")
 	}
-	if resolved.K8sMaxWorkers != 12 {
-		t.Fatalf("expected k8s.max_workers from file, got %d", resolved.K8sMaxWorkers)
-	}
 
 	// Env overrides file
 	env := map[string]string{
@@ -557,7 +551,6 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 		"DUCKGRES_PROCESS_MIN_WORKERS":           "4",
 		"DUCKGRES_PROCESS_MAX_WORKERS":           "20",
 		"DUCKGRES_PROCESS_RETIRE_ON_SESSION_END": "false",
-		"DUCKGRES_K8S_MAX_WORKERS":               "24",
 	}
 	resolved = configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{}, envFromMap(env), nil)
 	if resolved.Server.MemoryBudget != "32GB" {
@@ -572,18 +565,14 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	if resolved.ProcessRetireOnSessionEnd {
 		t.Fatal("expected process.retire_on_session_end from env")
 	}
-	if resolved.K8sMaxWorkers != 24 {
-		t.Fatalf("expected k8s.max_workers from env, got %d", resolved.K8sMaxWorkers)
-	}
 
 	// CLI overrides env
 	resolved = configresolve.ResolveEffective(fileCfg, configresolve.CLIInputs{
-		Set:                       map[string]bool{"memory-budget": true, "process-min-workers": true, "process-max-workers": true, "process-retire-on-session-end": true, "k8s-max-workers": true},
+		Set:                       map[string]bool{"memory-budget": true, "process-min-workers": true, "process-max-workers": true, "process-retire-on-session-end": true},
 		MemoryBudget:              "48GB",
 		ProcessMinWorkers:         8,
 		ProcessMaxWorkers:         50,
 		ProcessRetireOnSessionEnd: true,
-		K8sMaxWorkers:             64,
 	}, envFromMap(env), nil)
 	if resolved.Server.MemoryBudget != "48GB" {
 		t.Fatalf("expected memory_budget from CLI, got %q", resolved.Server.MemoryBudget)
@@ -596,9 +585,6 @@ func TestResolveEffectiveConfigMemoryBudgetAndWorkers(t *testing.T) {
 	}
 	if !resolved.ProcessRetireOnSessionEnd {
 		t.Fatal("expected process.retire_on_session_end from CLI")
-	}
-	if resolved.K8sMaxWorkers != 64 {
-		t.Fatalf("expected k8s.max_workers from CLI, got %d", resolved.K8sMaxWorkers)
 	}
 }
 func TestResolveEffectiveConfigInvalidMemoryBudget(t *testing.T) {
@@ -632,7 +618,6 @@ func TestResolveEffectiveConfigInvalidWorkerEnvVars(t *testing.T) {
 		"DUCKGRES_PROCESS_MIN_WORKERS":           "not-a-number",
 		"DUCKGRES_PROCESS_MAX_WORKERS":           "also-bad",
 		"DUCKGRES_PROCESS_RETIRE_ON_SESSION_END": "definitely-not-bool",
-		"DUCKGRES_K8S_MAX_WORKERS":               "still-bad",
 	}
 
 	var warns []string
@@ -646,9 +631,6 @@ func TestResolveEffectiveConfigInvalidWorkerEnvVars(t *testing.T) {
 	if resolved.ProcessMaxWorkers != 0 {
 		t.Fatalf("expected default process.max_workers, got %d", resolved.ProcessMaxWorkers)
 	}
-	if resolved.K8sMaxWorkers != 0 {
-		t.Fatalf("expected default k8s.max_workers, got %d", resolved.K8sMaxWorkers)
-	}
 	if resolved.ProcessRetireOnSessionEnd {
 		t.Fatal("expected default process.retire_on_session_end")
 	}
@@ -657,7 +639,6 @@ func TestResolveEffectiveConfigInvalidWorkerEnvVars(t *testing.T) {
 		"Invalid DUCKGRES_PROCESS_MIN_WORKERS",
 		"Invalid DUCKGRES_PROCESS_MAX_WORKERS",
 		"Invalid DUCKGRES_PROCESS_RETIRE_ON_SESSION_END",
-		"Invalid DUCKGRES_K8S_MAX_WORKERS",
 	}
 	for _, w := range wantWarnings {
 		found := false

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -835,7 +835,7 @@ func TestExpireDrainingControlPlaneInstancesPostgres(t *testing.T) {
 func TestCreateSpawningWorkerSlotPostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 
-	slot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:test", "", "", 1, "duckgres-worker-test-cp", 3, 5)
+	slot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:test", "", "", 1, "duckgres-worker-test-cp", 3)
 	if err != nil {
 		t.Fatalf("CreateSpawningWorkerSlot: %v", err)
 	}
@@ -874,7 +874,7 @@ func TestCreateSpawningWorkerSlotPostgres(t *testing.T) {
 	}
 }
 
-func TestCreateSpawningWorkerSlotRespectsOrgAndGlobalCaps(t *testing.T) {
+func TestCreateSpawningWorkerSlotRespectsOrgCap(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	now := time.Date(2026, time.March, 27, 13, 0, 0, 0, time.UTC)
 
@@ -890,20 +890,12 @@ func TestCreateSpawningWorkerSlotRespectsOrgAndGlobalCaps(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(existing): %v", err)
 	}
 
-	orgLimited, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:test", "", "", 1, "duckgres-worker-test-cp", 1, 5)
+	orgLimited, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:test", "", "", 1, "duckgres-worker-test-cp", 1)
 	if err != nil {
 		t.Fatalf("CreateSpawningWorkerSlot(org cap): %v", err)
 	}
 	if orgLimited != nil {
 		t.Fatalf("expected org cap to block spawning, got %#v", orgLimited)
-	}
-
-	globalLimited, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "sales", "duckgres:test", "", "", 1, "duckgres-worker-test-cp", 2, 1)
-	if err != nil {
-		t.Fatalf("CreateSpawningWorkerSlot(global cap): %v", err)
-	}
-	if globalLimited != nil {
-		t.Fatalf("expected global cap to block spawning, got %#v", globalLimited)
 	}
 }
 
@@ -924,7 +916,7 @@ func TestCreateSpawningWorkerSlotIgnoresIncompatibleHotIdleForOrgCapPostgres(t *
 		t.Fatalf("UpsertWorkerRecord(old hot-idle): %v", err)
 	}
 
-	slot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:new", "", "", 1, "duckgres-worker-test-cp", 1, 5)
+	slot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "analytics", "duckgres:new", "", "", 1, "duckgres-worker-test-cp", 1)
 	if err != nil {
 		t.Fatalf("CreateSpawningWorkerSlot: %v", err)
 	}
@@ -947,38 +939,12 @@ func TestCreateSpawningWorkerSlotIgnoresIncompatibleHotIdleForOrgCapPostgres(t *
 		t.Fatalf("UpsertWorkerRecord(sized hot-idle): %v", err)
 	}
 
-	profileSlot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "marketing", "duckgres:new", "", "", 1, "duckgres-worker-test-cp", 1, 5)
+	profileSlot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "marketing", "duckgres:new", "", "", 1, "duckgres-worker-test-cp", 1)
 	if err != nil {
 		t.Fatalf("CreateSpawningWorkerSlot(profile): %v", err)
 	}
 	if profileSlot == nil {
 		t.Fatal("expected wrong-profile hot-idle worker not to block org-cap spawn")
-	}
-}
-
-func TestCreateSpawningWorkerSlotCountsIncompatibleHotIdleForGlobalCapPostgres(t *testing.T) {
-	store := newIsolatedConfigStore(t)
-	now := time.Date(2026, time.June, 11, 13, 5, 0, 0, time.UTC)
-
-	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
-		WorkerID:          23,
-		PodName:           "duckgres-worker-old-global-hot-idle",
-		State:             configstore.WorkerStateHotIdle,
-		OrgID:             "analytics",
-		Image:             "duckgres:old",
-		OwnerCPInstanceID: "cp-old:boot-a",
-		OwnerEpoch:        2,
-		LastHeartbeatAt:   now,
-	}); err != nil {
-		t.Fatalf("UpsertWorkerRecord(old hot-idle): %v", err)
-	}
-
-	slot, err := store.CreateSpawningWorkerSlot("cp-new:boot-b", "sales", "duckgres:new", "", "", 1, "duckgres-worker-test-cp", 5, 1)
-	if err != nil {
-		t.Fatalf("CreateSpawningWorkerSlot: %v", err)
-	}
-	if slot != nil {
-		t.Fatalf("expected incompatible hot-idle worker to block global-cap spawn, got %#v", slot)
 	}
 }
 

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -279,7 +279,6 @@ spec:
             #   cert-manager / a Trino cluster in the per-PR namespace; the CP
             #   serves its self-signed cert and Trino is not under e2e.
             - { name: DUCKGRES_WORKER_QUEUE_TIMEOUT, value: "5m" }
-            - { name: DUCKGRES_K8S_MAX_WORKERS, value: "50" }
             # Fast config-store poll for CI only (default 30s). The harness has
             # three waits bounded by this interval — the post-provision auth-cache
             # settle and two org-default-profile propagation waits — which drop


### PR DESCRIPTION
The control plane no longer has a global/cluster-wide worker-pool ceiling. The only worker caps are now **per-org** (`Org.MaxWorkers`) and the cluster autoscaler / nodepool. An org with `max_workers=0` is genuinely **unbounded** — matching the `0`=unlimited semantics already used by `max_connections` — instead of silently inheriting the global cap.

## Behavior
- `org_router` no longer falls back to the global cap when an org leaves `max_workers` at 0; the value passes straight through. The per-org pool (`OrgReservedPool`) and the SQL claim layer already treat `0` as unbounded.
- `CreateSpawningWorkerSlot` drops its `maxGlobalWorkers` parameter, the `duckgres:global-worker-capacity` advisory lock, and the cluster-wide active-count check. Only the per-org advisory lock + per-org cap remain.

## Removed config
`--k8s-max-workers` flag, `DUCKGRES_K8S_MAX_WORKERS` env, `k8s.max_workers` YAML, `K8sConfig.MaxWorkers`, `K8sWorkerPoolConfig.MaxWorkers`, the `SetupMultiTenant` `maxWorkers` param (+ the `!kubernetes` stub), and the dead `WorkerClaimMissReasonGlobalCap` + capacity-policy global-cap branches (the global-cap miss was already mislabeled as the org-cap message, so no user-facing change).

The generic per-pool `maxWorkers` field on `K8sWorkerPool` stays (satisfies `WorkerPool.SetMaxWorkers`; `OrgReservedPool` applies the per-org cap) and defaults to `0` = unbounded.

**Not touched:** PROCESS backend max-workers (`--process-max-workers`, RAM-derived default) — sizes the single-host process pool, unrelated to the k8s cluster cap.

## ⚠️ Operational note
Removing the global cap drops the cluster-wide pod backstop. An org left at `max_workers=0` can now spawn worker pods without a duckgres-imposed ceiling — the Karpenter nodepool / autoscaler is the only shared limit. Existing orgs default to `0`; they were previously implicitly capped by the global `2000` (prod-us). If any org needs a hard ceiling, set its `max_workers` explicitly.

## Charts
Paired removal of the env wiring + prod-us `maxWorkers: "2000"`: PostHog/charts#12605.

## Tests / docs
Dropped the global-cap-specific tests (rewrote the org+global cap test to org-cap-only; deleted the two global-cap-only tests), removed `K8sMaxWorkers` from config-resolution tests, updated README / CLAUDE.md / replenish-capacity runbook / e2e manifest.

Verified: `go build ./...`, `go build -tags kubernetes ./controlplane/... ./cmd/...`, all test binaries compile (both tag sets), capacity/claim/config unit tests pass. Postgres/e2e tests run in CI.

> No new e2e assertion: "unbounded" can't be meaningfully asserted in-Job (needs unbounded resources); per-org cap behavior is unchanged and still covered by `one_session_per_worker` + the org-cap unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)