### PR TITLE
[codex] Validate provisioning resource names

### DIFF
--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -28,17 +28,44 @@ func isUniqueViolation(err error) bool {
 	return errors.As(err, &s) && s.SQLState() == "23505"
 }
 
-// ducklingOrgIDPattern constrains org IDs that get a provisioned warehouse to a
-// single DNS-1123 label (lowercase alphanumerics + hyphens, start/end
-// alphanumeric). This is the shape every derived name needs:
-//   - the SNI prefix <org>.<managed-suffix> is a single DNS label already;
-//   - the Duckling CR / IAM role / S3 bucket / Lakekeeper CR names use the org
-//     ID verbatim (lowercased), so it must be a valid k8s/AWS name;
-//   - the Postgres identifier maps any non-[a-z0-9_] char to '_', which is only
-//     injective when the source charset excludes everything but hyphens.
-//
-// Validating here keeps the org ID → resource-name mappings collision-free.
+const (
+	// maxDucklingSlugOrgIDLength is the public Duckgres provisioning contract
+	// for non-UUID org IDs. It is intentionally stricter than most individual
+	// downstream limits: with the current managed-warehouse suffix "mw-prod-us",
+	// the S3 bucket name is:
+	//
+	//   posthog-duckling-<slug>-mw-prod-us
+	//
+	// S3 caps bucket names at 63 chars, leaving 35 chars for <slug>. That cap
+	// also leaves enough room for the other request-driven names derived from
+	// org ID today (Duckling/Lakekeeper k8s names, IAM roles, PgBouncer names,
+	// and Postgres identifiers). Canonical UUID org IDs are allowed separately
+	// because configstore.DucklingBucketName compacts them from 36 to 32 chars
+	// before building the S3 bucket name. If the managed bucket suffix grows
+	// beyond "mw-prod-us", lower this cap or validate the suffix at startup.
+	maxDucklingSlugOrgIDLength = 35
+)
+
+// ducklingOrgIDPattern constrains provisionable org IDs to a single DNS-1123
+// label (lowercase alphanumerics + hyphens, start/end alphanumeric). This keeps
+// SNI labels valid and makes the Postgres hyphen-to-underscore mapping
+// collision-free for names Duckgres derives from org ID.
 var ducklingOrgIDPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// canonicalDucklingUUIDPattern matches the UUID-shaped org IDs PostHog sends.
+// These are longer than maxDucklingSlugOrgIDLength but safe because Duckgres
+// compacts UUID hyphens only for S3 bucket naming.
+var canonicalDucklingUUIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func validateDucklingOrgID(orgID string) error {
+	if !ducklingOrgIDPattern.MatchString(orgID) {
+		return errors.New("org id must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting and ending alphanumeric) so the derived resource names are valid and collision-free")
+	}
+	if !canonicalDucklingUUIDPattern.MatchString(orgID) && len(orgID) > maxDucklingSlugOrgIDLength {
+		return fmt.Errorf("org id must be a canonical UUID or a slug of at most %d characters", maxDucklingSlugOrgIDLength)
+	}
+	return nil
+}
 
 // Store defines the config store operations needed by the provisioning API.
 type Store interface {
@@ -194,8 +221,8 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	if !ducklingOrgIDPattern.MatchString(orgID) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "org id must be a DNS-1123 label (lowercase alphanumerics and hyphens, starting and ending alphanumeric) so the derived resource names are valid and collision-free"})
+	if err := validateDucklingOrgID(orgID); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -787,6 +788,32 @@ func TestProvisionRejectsInvalidOrgID(t *testing.T) {
 				t.Errorf("warehouse must not be created for invalid org id %q", bad)
 			}
 		})
+	}
+}
+
+func TestProvisionRejectsOverlongSlugOrgID(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+	org := strings.Repeat("a", 36)
+	body := []byte(`{
+		"database_name":"d",
+		"metadata_store":{"type":"external","external":{"endpoint":"h","password_aws_secret":"s"}},
+		"data_store":{"type":"external","bucket_name":"posthog-duckling-example"},
+		"ducklake":{"enabled":true}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/"+org+"/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "canonical UUID or a slug") {
+		t.Fatalf("error = %s, want org id slug length error", rec.Body.String())
+	}
+	if _, ok := store.warehouses[org]; ok {
+		t.Error("warehouse must not be created for overlong slug org id")
 	}
 }
 


### PR DESCRIPTION
## What changed

Adds a small Duckgres-side org ID contract at the provisioning API boundary:

- org IDs must be lowercase DNS-label-shaped values
- org IDs must be either a canonical lowercase UUID, or a non-UUID slug of at most 35 characters

Canonical UUID org IDs remain accepted because Duckgres already compacts UUID hyphens for bucket naming.

## Why

Provisioning derives several downstream names from `org_id`. The tightest current request-driven limit is the managed data bucket name:

```text
posthog-duckling-<slug>-mw-prod-us
```

S3 bucket names are capped at 63 characters, leaving 35 characters for a non-UUID slug. That slug cap also leaves room for the current Kubernetes, IAM, PgBouncer, Lakekeeper, and Postgres names Duckgres derives from the same value.

This keeps the API simple: validate the Duckgres org ID shape once, and explain which downstream constraints define that contract, instead of duplicating every downstream name derivation in the handler.

## Notes

This does not tighten `database_name`: it is a client-visible logical database/catalog name and existing tests use non-DNS values.

If the managed bucket suffix grows beyond `mw-prod-us`, we should lower the slug cap or validate the configured suffix at startup.

## Tests

- `go test ./controlplane/provisioning`
- `go test ./controlplane/...`
