### PR TITLE
[codex] Pin httpfs write retry release

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -71,13 +71,13 @@ jobs:
                     - version: "1.5.3"
                       go: "v2.10503.0"
                       bindings: "v0.10503.0"
-                      # cred-refresh: mid-statement S3 credential recovery on
-                      # auth failure (PostHog/duckdb-httpfs cred-refresh-read-path;
-                      # supersedes v1.5.3-stoi-fix, which it is based on). Lets
-                      # statements outlive their starting STS token as long as
-                      # the credential-refresh scheduler keeps rotating the
+                      # cred-refresh-write-retry: mid-statement S3 credential
+                      # recovery on ExpiredToken read/write auth failures
+                      # (supersedes v1.5.3-cred-refresh, which it is based on).
+                      # Lets statements outlive their starting STS token as long
+                      # as the credential-refresh scheduler keeps rotating the
                       # ducklake_s3 secret.
-                      httpfs: "v1.5.3-cred-refresh"
+                      httpfs: "v1.5.3-cred-refresh-write-retry"
                       ducklake: "v1.0-posthog.4"
                       # Stable repo hosts postgres_scanner for 1.5.3; nightly
                       # does not. See scripts/ducklake_version_matrix.sh

--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -71,10 +71,13 @@ jobs:
                     - version: "1.5.3"
                       go: "v2.10503.0"
                       bindings: "v0.10503.0"
-                      # cred-refresh: mid-statement S3 credential recovery for
-                      # thrown auth failures. Temporarily pinned back here for
-                      # e2e A/B against v1.5.3-cred-refresh-write-retry.
-                      httpfs: "v1.5.3-cred-refresh"
+                      # cred-refresh-write-retry: mid-statement S3 credential
+                      # recovery on ExpiredToken read/write auth failures
+                      # (supersedes v1.5.3-cred-refresh, which it is based on).
+                      # Lets statements outlive their starting STS token as long
+                      # as the credential-refresh scheduler keeps rotating the
+                      # ducklake_s3 secret.
+                      httpfs: "v1.5.3-cred-refresh-write-retry"
                       ducklake: "v1.0-posthog.4"
                       # Stable repo hosts postgres_scanner for 1.5.3; nightly
                       # does not. See scripts/ducklake_version_matrix.sh

--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -71,13 +71,10 @@ jobs:
                     - version: "1.5.3"
                       go: "v2.10503.0"
                       bindings: "v0.10503.0"
-                      # cred-refresh-write-retry: mid-statement S3 credential
-                      # recovery on ExpiredToken read/write auth failures
-                      # (supersedes v1.5.3-cred-refresh, which it is based on).
-                      # Lets statements outlive their starting STS token as long
-                      # as the credential-refresh scheduler keeps rotating the
-                      # ducklake_s3 secret.
-                      httpfs: "v1.5.3-cred-refresh-write-retry"
+                      # cred-refresh: mid-statement S3 credential recovery for
+                      # thrown auth failures. Temporarily pinned back here for
+                      # e2e A/B against v1.5.3-cred-refresh-write-retry.
+                      httpfs: "v1.5.3-cred-refresh"
                       ducklake: "v1.0-posthog.4"
                       # Stable repo hosts postgres_scanner for 1.5.3; nightly
                       # does not. See scripts/ducklake_version_matrix.sh

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -87,7 +87,7 @@ jobs:
       # container-image-worker-cd.yml. Keep in lock-step on a version bump.
       build-args: |
         DUCKDB_EXTENSION_VERSION=1.5.3
-        HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
+        HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
         DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
         POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -87,7 +87,7 @@ jobs:
       # container-image-worker-cd.yml. Keep in lock-step on a version bump.
       build-args: |
         DUCKDB_EXTENSION_VERSION=1.5.3
-        HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
+        HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
         DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
         POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 # edit.)
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 # edit.)
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -51,7 +51,7 @@ RUN go mod download
 # keeps the GHA layer-cache hit and skips the 5 downloads. (They previously
 # ran after the source COPY + build, so they re-fetched on every edit.)
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -51,7 +51,7 @@ RUN go mod download
 # keeps the GHA layer-cache hit and skips the 5 downloads. (They previously
 # ran after the source COPY + build, so they re-fetched on every edit.)
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
-ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
+ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable

--- a/controlplane/sts_broker.go
+++ b/controlplane/sts_broker.go
@@ -85,12 +85,12 @@ var credentialRefreshLookahead = stsSessionDuration / 2
 // validity at start; statements longer than that can still die with
 // ExpiredToken.
 //
-// The PostHog httpfs fork (PostHog/duckdb-httpfs, branch
-// cred-refresh-read-path) FIXES this: on an auth failure in any S3 request
-// path it re-resolves the latest committed secret — picking up this
-// scheduler's rotation pushes — and retries (proven by
+// The PostHog httpfs fork (PostHog/duckdb-httpfs,
+// v1.5.3-cred-refresh-write-retry) FIXES this: on an ExpiredToken auth failure
+// in S3 read/write request paths it re-resolves the latest committed secret —
+// picking up this scheduler's rotation pushes — and retries (proven by
 // TestInFlightScanSurvivesRotationWithPatchedHTTPFS in tests/integration).
-// Once a fork release with that patch is pinned via HTTPFS_EXTENSION_TAG in
+// With that fork release pinned via HTTPFS_EXTENSION_TAG in
 // Dockerfile.worker, this margin becomes defense-in-depth (a statement's
 // first credentials still want a healthy runway so recovery stays rare)
 // rather than the only thing standing between a long statement and

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -130,10 +130,11 @@ normal `go test ./...` lane.
 
 ### Deliberately not covered here
 
-- **Mid-statement STS credential recovery (httpfs `v1.5.3-cred-refresh`)** —
+- **Mid-statement STS credential recovery (httpfs `v1.5.3-cred-refresh-write-retry`)** —
   the worker image bundles the PostHog httpfs fork patch that re-resolves the
-  latest committed `ducklake_s3` secret and retries on an auth failure, letting
-  a statement outlive the STS token it started with. Proving real in-statement
+  latest committed `ducklake_s3` secret and retries on ExpiredToken read/write
+  auth failures, letting a statement outlive the STS token it started with.
+  Proving real in-statement
   expiry in-Job needs a statement longer than the shortest AssumeRole token
   (900s AWS floor), which blows the Job time budget. The behavior is
   deterministically covered by the MinIO rotation tests in
@@ -197,7 +198,7 @@ normal `go test ./...` lane.
   survive credential rotation (DuckDB resolves secrets through the
   statement's MVCC snapshot, and scan-workload file opens skip the HEAD that
   could trigger httpfs' refresh-on-403). With the bundled
-  `v1.5.3-cred-refresh` fork build the floor is defense-in-depth rather than
+  `v1.5.3-cred-refresh-write-retry` fork build the floor is defense-in-depth rather than
   the only protection — see the mid-statement recovery bullet above.
 - **PostHog product-analytics events** (`internal/analytics`,
   `warehouse_provision_begin`/`_success`/`_failed`,

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -86,10 +86,10 @@ RES2="ci-pr-${PR_NUMBER}-res2"
 
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
-# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh).
+# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry).
 # If the image accidentally ships upstream, the version differs and we fail.
 EXPECT_DUCKLAKE_SHA="e4ac5150"
-EXPECT_HTTPFS_SHA="b1fece6"
+EXPECT_HTTPFS_SHA="0dac6fc"
 
 # duckling-example RDS — the shared external metadata store (same one the
 # manual validation used). Endpoint is stable in mw-dev.

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -83,10 +83,10 @@ RES2="ci-pr-${PR_NUMBER}-res2"
 
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
-# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry).
+# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh).
 # If the image accidentally ships upstream, the version differs and we fail.
 EXPECT_DUCKLAKE_SHA="e4ac5150"
-EXPECT_HTTPFS_SHA="0dac6fc"
+EXPECT_HTTPFS_SHA="b1fece6"
 
 # duckling-example RDS — the shared external metadata store (same one the
 # manual validation used). Endpoint is stable in mw-dev.

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -83,10 +83,10 @@ RES2="ci-pr-${PR_NUMBER}-res2"
 
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
-# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh).
+# (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry).
 # If the image accidentally ships upstream, the version differs and we fail.
 EXPECT_DUCKLAKE_SHA="e4ac5150"
-EXPECT_HTTPFS_SHA="b1fece6"
+EXPECT_HTTPFS_SHA="0dac6fc"
 
 # duckling-example RDS — the shared external metadata store (same one the
 # manual validation used). Endpoint is stable in mw-dev.

--- a/tests/integration/credential_rotation_pin_test.go
+++ b/tests/integration/credential_rotation_pin_test.go
@@ -47,6 +47,7 @@ const (
 	rotationPassword       = "rotating-pass-12345"
 	rotationNumFiles       = 48
 	rotationRowsPerFile    = 40000
+	rotationDelay          = 2 * time.Second
 )
 
 func runRotationScenario(t *testing.T, sc rotationScenario) rotationResult {
@@ -157,7 +158,8 @@ func runRotationScenario(t *testing.T, sc rotationScenario) rotationResult {
 	}
 
 	// MD5-chain scan: compute-heavy enough that the statement is still
-	// running when we rotate at T+4s, sequentially opening ~1 file at a time.
+	// running when we rotate at T+rotationDelay, sequentially opening ~1 file
+	// at a time.
 	scanQuery := fmt.Sprintf(
 		`SELECT count(*), max(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(md5(s))))))))))))))))))))) FROM read_parquet('s3://%s/data/*.parquet')`,
 		rotationBucket)
@@ -172,12 +174,12 @@ func runRotationScenario(t *testing.T, sc rotationScenario) rotationResult {
 		done <- r
 	}()
 
-	// T+4s: rotate to user B exactly the way the credential-refresh
+	// T+rotationDelay: rotate to user B exactly the way the credential-refresh
 	// scheduler's push lands on a worker (CREATE OR REPLACE SECRET on a side
 	// connection), then kill user A — simulating the old STS token expiring
 	// right after a rotation that any reasonable design would hope protects
 	// the running statement.
-	time.Sleep(4 * time.Second)
+	time.Sleep(rotationDelay)
 	rotated := dlCfg
 	rotated.S3AccessKey = rotationUserB
 	if err := server.RefreshS3Secret(db, rotated, nil); err != nil {
@@ -283,7 +285,7 @@ func TestInFlightScanDiesOnCredentialRotation(t *testing.T) {
 // the credentials it started with.
 //
 // Runs only when DUCKGRES_TEST_PATCHED_HTTPFS points at a locally-built
-// extension binary (see PostHog/duckdb-httpfs branch cred-refresh-read-path):
+// extension binary (see PostHog/duckdb-httpfs v1.5.3-cred-refresh-write-retry):
 //
 //	DUCKGRES_TEST_PATCHED_HTTPFS=/path/to/httpfs.duckdb_extension \
 //	  go test ./tests/integration/ -run SurvivesRotationWithPatchedHTTPFS -v


### PR DESCRIPTION
## Summary
- Pin Duckgres images and e2e build args to `PostHog/duckdb-httpfs` `v1.5.3-cred-refresh-write-retry`.
- Update the e2e fork SHA assertion and credential-refresh docs/comments for read/write `ExpiredToken` recovery.
- Make the MinIO credential-rotation canary rotate earlier so fast local runs do not finish before rotation.

## Verification
- `just lint`
- `git diff --check`
- `just test-unit`
- `just test-cache-proxy`
- `go test -v -count=1 -timeout 10m ./tests/integration -run '^TestInFlightScanDiesOnCredentialRotation$'`
- `DUCKGRES_TEST_PATCHED_HTTPFS=/Users/gwyang/projects/duckdb-httpfs/build/release/extension/httpfs/httpfs.duckdb_extension go test -v -count=1 -timeout 10m ./tests/integration -run '^TestInFlightScanSurvivesRotationWithPatchedHTTPFS$'`
- `DUCKGRES_TEST_PATCHED_HTTPFS=/Users/gwyang/projects/duckdb-httpfs/build/release/extension/httpfs/httpfs.duckdb_extension just test-integration`
- `gh run view 28391513947 --repo PostHog/duckdb-httpfs --json status,conclusion,url`
- `gh release view v1.5.3-cred-refresh-write-retry --repo PostHog/duckdb-httpfs --json body,assets,targetCommitish`
- `curl -fsSI https://github.com/PostHog/duckdb-httpfs/releases/download/v1.5.3-cred-refresh-write-retry/httpfs-linux-amd64.duckdb_extension`
- `curl -fsSI https://github.com/PostHog/duckdb-httpfs/releases/download/v1.5.3-cred-refresh-write-retry/httpfs-linux-arm64.duckdb_extension`
- `just build-k8s-image duckgres:httpfs-write-retry`
- `docker build -f Dockerfile.worker -t duckgres-worker:httpfs-write-retry --build-arg VERSION=local-httpfs-write-retry --build-arg COMMIT=local --build-arg BUILD_TAGS=kubernetes --build-arg DUCKDB_GO_VERSION=v2.10503.0 --build-arg DUCKDB_BINDINGS_VERSION=v0.10503.0 --build-arg DUCKDB_EXTENSION_VERSION=1.5.3 --build-arg HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry --build-arg DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4 --build-arg POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org .`
- `docker run --rm duckgres:httpfs-write-retry --version`
- `docker run --rm duckgres-worker:httpfs-write-retry --version`

## Manual validation

Red repro against current mw-dev image (`duckgres:4e7ead5...`, loaded `httpfs=b1fece6`):

- Isolated mw-dev stack with `DUCKGRES_STS_SESSION_DURATION=15m`.
- Streaming multipart DuckLake CTAS started at `2026-06-30 18:29:00Z`.
- Control plane refreshed worker S3 credentials while the statement was still in flight at `18:34:40Z` and `18:42:10Z`.
- The statement failed at `18:46:14Z` after `1037s` with S3 `Bad Request (HTTP code 400)` on the DuckLake parquet write path.

This reproduces the PR's target gap: current httpfs retries thrown auth failures, but not returned S3 `400 ExpiredToken` response bodies from multipart completion.

Green validation after mw-dev deployed the merged image (`duckgres:e9c684d...`, loaded `httpfs=0dac6fc`):

- Isolated mw-dev stack with `DUCKGRES_STS_SESSION_DURATION=15m`.
- Longer streaming multipart DuckLake CTAS started at `2026-06-30 21:58:48Z`.
- The worker received fresh S3 credentials immediately before statement start at `21:58:35Z`, so the credentials captured by the statement should have expired around `22:13:35Z`.
- Control plane refreshed worker S3 credentials while the statement was still in flight at `22:06:00Z`, `22:13:30Z`, `22:21:00Z`, and `22:28:30Z`.
- The statement completed successfully at `22:31:56Z` after `1988s` (`CREATE TABLE`, `649672` rows), about `18m` after the statement-start S3 credentials expired, with no S3 `Bad Request (HTTP code 400)` failure.
