### PR TITLE
[codex] Remove Lakekeeper from PR e2e

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -1,10 +1,10 @@
 # Per-PR end-to-end test against the real posthog-mw-dev EKS cluster.
 #
 # Replaces what kind (tests/k8s/) cannot exercise: real Cilium network
-# policies, real Crossplane Duckling provisioning, real cnpg-shard + external
-# RDS metadata stores, and the real per-org Lakekeeper operator — the layers
-# where this quarter's bugs actually lived (Cilium egress, lakekeeper
-# encryption-key drift, cnpg role drift, RBAC delete gaps).
+# policies, real Crossplane Duckling provisioning, and real cnpg-shard +
+# external RDS metadata stores — the production-like layers where this
+# quarter's bugs actually lived (Cilium egress, cnpg role drift, RBAC delete
+# gaps).
 #
 # Flow:
 #   1. build arm64-only worker + control-plane images, tagged pr-<N>-<sha>,
@@ -17,7 +17,7 @@
 #      ClusterIP service (no public DNS / NLB needed). Covers the cnpg-shard
 #      and external metadata backends.
 #   5. always tear the namespace down (and deprovision the ci-pr ducklings so
-#      no S3 / cnpg role / lakekeeper CR leaks on shared infra).
+#      no S3 / cnpg role leaks on shared infra).
 #
 # SECURITY — who can run this:
 #   Same model as the AWS/OIDC job in ci.yml: the gate is the repo setting
@@ -201,8 +201,8 @@ jobs:
         uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
       - name: Update kubeconfig
         run: aws eks update-kubeconfig --name "$CLUSTER_NAME" --region us-east-1 --alias "$KUBE_CONTEXT"
-      # Deprovision the ci-pr ducklings (so no S3 / cnpg role+db / lakekeeper CR
-      # leaks on shared infra) then delete the namespace.
+      # Deprovision the ci-pr ducklings (so no S3 / cnpg role+db leaks on
+      # shared infra) then delete the namespace.
       - name: Teardown
         run: bash tests/e2e-mw-dev/run.sh teardown
 

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -1,9 +1,9 @@
 # mw-dev per-PR e2e harness
 
 Replaces what `tests/k8s/` (kind) cannot exercise — real Cilium network
-policies, real Crossplane Duckling provisioning, real cnpg-shard + external
-RDS metadata stores, and the real per-org Lakekeeper operator. Those are the
-layers where this quarter's production bugs lived.
+policies, real Crossplane Duckling provisioning, and real cnpg-shard +
+external RDS metadata stores. Those are the layers where this quarter's
+production bugs lived.
 
 ## Flow (`.github/workflows/e2e-mw-dev.yml`)
 
@@ -63,7 +63,7 @@ client-go:
   / `timed out waiting for an available worker`) rather than a hang/500/drop, and
   the pool must then serve a retrying connection. The harness logs whether
   backpressure was observed **and** handles it (queries retry through it).
-- **activation** — DuckLake **and** Iceberg catalogs attach and read/write.
+- **activation** — DuckLake catalogs attach and read/write on cnpg and ext.
 - **worker sizing** (TTL-pool model, `docs/design/worker-ttl-pool.md`) — a
   client-sized connection (`duckgres.worker_cpu`/`worker_memory`/`worker_ttl`
   startup options, sent via `PGOPTIONS`; CP runs `allowClientWorkerProfile=true`
@@ -71,10 +71,8 @@ client-go:
   requested CPU+memory on **both** requests and limits — proving the shape flows
   control-plane → k8s pod spec, not BestEffort. A same-shape reconnect **reuses**
   that hot-idle worker (no respawn — the count of that-shape pods stays 1).
-  Asserted on cnpg for **both** the ducklake and iceberg catalogs, with a
-  distinct shape per catalog (2/4Gi vs 1/2Gi) so the catalog-agnostic worker
-  can't satisfy the second from the first's hot-idle pool. There is no warm pool,
-  so the only workers are the ones a request sizes + spawns on demand.
+  Asserted on cnpg for the ducklake catalog. There is no warm pool, so the only
+  workers are the ones a request sizes + spawns on demand.
   Clamp enforcement itself is unit-covered (`controlplane/worker_profile_test.go`).
 - **org default worker profile** — an operator-set per-org default worker shape
   + hot-idle TTL (config-store columns `default_worker_cpu`/`memory`/`ttl`, set
@@ -140,8 +138,8 @@ normal `go test ./...` lane.
   `tests/integration/credential_rotation_pin_test.go` (stock httpfs dies /
   patched httpfs survives rotation + revocation mid-scan); the harness's
   `assert_fork_extensions` pins that workers actually run the patched build
-  (`EXPECT_HTTPFS_SHA`), and every DuckLake/Iceberg assertion here exercises
-  the patched request paths against real S3.
+  (`EXPECT_HTTPFS_SHA`), and every DuckLake assertion here exercises the patched
+  request paths against real S3.
 - **Version-mismatch worker reaper** — needs a mid-run image bump, so it stays
   covered by `controlplane/` unit tests rather than in-Job.
 - **Physical object-store-prefix isolation** — the Go suite listed the MinIO
@@ -149,9 +147,9 @@ normal `go test ./...` lane.
   S3 the Job holds no list creds, so isolation is asserted **logically** (the
   cross-tenant read is denied) rather than by enumerating S3 objects.
 - **Cilium egress allow/deny probing** — asserting a worker reaches the cnpg
-  pooler + `lakekeeper:8181` but not a denied destination needs a stable
-  exec-into-worker probe; deferred (high flake risk). The policies themselves
-  are asserted statically in `tests/manifests/`.
+  pooler but not a denied destination needs a stable exec-into-worker probe;
+  deferred (high flake risk). The policies themselves are asserted statically
+  in `tests/manifests/`.
 - **Oversized Bind-parameter rejection (#717)** — rejecting a Bind message whose
   declared parameter length exceeds the remaining message body requires crafting
   a malformed wire-protocol packet on a raw socket (through TLS + auth); libpq
@@ -220,7 +218,7 @@ normal `go test ./...` lane.
 Dedicated CP + throwaway config-store **per PR**, provisioning **real**
 ducklings (org IDs `ci-pr-<N>-cnpg`, `ci-pr-<N>-ext`, plus the
 ducklake-only resilience-lane orgs `ci-pr-<N>-res1`/`-res2`) through the **shared**
-Crossplane / cnpg-shards / external RDS / Lakekeeper operator. The config-store
+Crossplane / cnpg-shards / external RDS infra. The config-store
 uses a namespace-scoped PVC so a pod recreation during the harness does not
 erase provisioned org rows. Everything PR-specific lives in the namespace and
 is deleted; the shared-infra footprint is removed by deprovisioning the
@@ -228,7 +226,7 @@ ducklings first.
 
 Each deploy first reaps any existing resources for the same PR number (namespace,
 Duckling CRs, pod identity association, cross-namespace bindings, and cnpg role)
-so a rerun never applies over stale Lakekeeper services or network policies.
+so a rerun never applies over stale services or network policies.
 
 ## One-time repo configuration
 
@@ -272,10 +270,10 @@ got through, in order — each was a real fix:
    `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES=.ci.duckgres.local` +
    `DUCKGRES_SNI_ROUTING_MODE=passthrough`, and connecting with libpq
    `host=<org>.<suffix>` (SNI) + `hostaddr=<CP ClusterIP>` (TCP).
-5. ✅ catalog selection — `dbname` must be `ducklake` or `iceberg`, not the org
+5. ✅ catalog selection — `dbname` must be `ducklake`, not the org
    (PR #651: *database = catalog selection*). harness.sh now does this.
 
-6. ✅ **activation (cnpg DuckLake + Iceberg)** — the blocker was NOT a metadata
+6. ✅ **activation (cnpg DuckLake)** — the blocker was NOT a metadata
    SecretRef; the duckling-status path reads the metadata password straight
    from the CR. It failed at **S3 STS brokering** because the isolated CP had no
    AWS identity. Fixed by binding the per-PR `duckgres` SA to the **same EKS Pod
@@ -313,7 +311,7 @@ id committed).
   `managementPolicies: ["*"]` from charts#11522 does the drop; the `--for=delete`
   wait is what makes it synchronous from our side.)
 - **Shared-infra contention.** Concurrent PRs provision real ducklings against
-  the same cnpg-shards / RDS / lakekeeper-operator. Org-ID prefix keeps them
+  the same cnpg-shards / RDS infra. Org-ID prefix keeps them
   distinct; watch quay.io / cnpg pooler / RDS limits under parallelism.
 - **e2e-cleanup** is wired: the `e2e-mw-dev.yml` `schedule` trigger runs
   `run.sh e2e-cleanup` every 6h, reaping `duckgres-ci-pr-*` namespaces older than

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -6,8 +6,8 @@
 # This is the SUCCESSOR to the kind-based tests/k8s/ Go suite: every behavior
 # that suite asserted against a fake kind cluster is re-asserted here against the
 # REAL posthog-mw-dev cluster (real Cilium, real Crossplane ducklings, real
-# cnpg-shard + external-RDS metadata, real per-org Lakekeeper). Covers the two
-# real metadata backends cnpg + ext (aurora is retired — out of scope).
+# cnpg-shard + external-RDS metadata). Covers the two real metadata backends
+# cnpg + ext (aurora is retired — out of scope).
 #
 # STRUCTURE: assertions run in four PARALLEL per-org lanes (see main() and the
 # lane_* functions) — cnpg (wire/catalog/concurrency/sizing), res1 (worker-kill
@@ -26,14 +26,11 @@
 #                  transpilation (#716), and a pipelined extended-query error
 #                  discards queued messages until Sync (#718). A same pgwire
 #                  session remains usable immediately after CancelRequest.
-#   activation   : DuckLake + Iceberg catalogs attach and read/write. The FIRST
-#                  session on a cold Iceberg worker must not fail the pg_catalog
-#                  compat-view bind (the CP primes the REST catalog's schema list
-#                  first); asserted on cnpg + ext.
+#   activation   : DuckLake catalogs attach and read/write on cnpg + ext.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
 #                  same-shape reconnect reuses that hot-idle worker (no respawn)
-#                  — asserted on cnpg for BOTH the ducklake and iceberg catalogs.
+#                  — asserted on cnpg for the ducklake catalog.
 #   org default  : an operator-set org default worker profile (admin PUT
 #                  /orgs/:id default_worker_cpu/memory/ttl) sizes a PLAIN
 #                  connection's worker pod (no client GUCs); garbage values are
@@ -169,7 +166,7 @@ wait_state() { # org target timeout_s
 }
 
 # Org routing is by TLS SNI hostname <org>.<managed-suffix>; the dbname selects
-# the CATALOG (`ducklake` or `iceberg`), not the org (PR #651). The control
+# the DuckLake catalog, not the org (PR #651). The control
 # plane rejects connections without a managed SNI host. We use libpq's
 # host (→ SNI + TLS name) / hostaddr (→ TCP target) split: SNI carries the org
 # hostname while the TCP connection still lands on the CP ClusterIP. The suffix
@@ -184,8 +181,8 @@ resolve_cp_ip() {
 
 # On-demand spawn backpressure ("…retry in about 45 seconds" / "timed out waiting
 # for an available worker") is a FEATURE, not an error: there is no warm pool, so
-# ANY new-session acquisition — a fresh catalog (ducklake→iceberg), a burst, or
-# the first connect after the pool churned (worker kills / idle timeout) — can
+# ANY new-session acquisition — a burst, or the first connect after the pool
+# churned (worker kills / idle timeout) — can
 # transiently get it while the CP spawns a worker (or while a freshly-spawned pod
 # is still pulling/booting). It is a FATAL at session create, BEFORE any SQL runs,
 # so retrying the whole command is safe (no half-applied INSERT). So every harness
@@ -644,73 +641,6 @@ httpfs_retry_budget() { # org password
   assert_compat "$1" "$2" ducklake "SELECT (value::BIGINT = 10)::text  FROM duckdb_settings() WHERE name='http_retries'"       "true" "http_retries"
   assert_compat "$1" "$2" ducklake "SELECT (value::BIGINT = 500)::text FROM duckdb_settings() WHERE name='http_retry_wait_ms'" "true" "http_retry_wait_ms"
   assert_compat "$1" "$2" ducklake "SELECT (value::DOUBLE = 2.0)::text FROM duckdb_settings() WHERE name='http_retry_backoff'" "true" "http_retry_backoff"
-}
-
-rw_iceberg() { # org password
-  log "Iceberg R/W on $1"
-  c="$(pg "$1" "$2" iceberg "SELECT COUNT(*) FROM duckdb_databases() WHERE database_name='iceberg'")"
-  [ "$c" = "1" ] || fail "$1 iceberg catalog not attached (duckdb_databases count=$c)"
-  t="e2e_ice_$(echo "$1" | tr -c 'a-z0-9' _)"
-  pg "$1" "$2" iceberg "DROP TABLE IF EXISTS iceberg.public.$t;
-            CREATE TABLE iceberg.public.$t(id INT, label VARCHAR);
-            INSERT INTO iceberg.public.$t VALUES (10,'ten'),(20,'twenty');"
-  n="$(pg "$1" "$2" iceberg "SELECT COUNT(*) FROM iceberg.public.$t;")"
-  [ "$n" = "2" ] || fail "$1 Iceberg rowcount=$n want 2"
-  pg "$1" "$2" iceberg "DROP TABLE iceberg.public.$t;"
-}
-
-# Regression for the Iceberg cold-start session-init bug: the FIRST session on a
-# freshly-spawned (cold) worker must not fail the pg_catalog compat-view bind.
-# Before the fix, InitSessionDatabaseMetadata enumerated every attached catalog
-# before anything had materialized the Iceberg REST catalog's schema list on the
-# new session connection, so the bind hit `Catalog Error: Schema with name ""
-# not found` and the connection was rejected with `failed to initialize session
-# database metadata`; only a reconnect (instance since settled) masked it. With
-# the warm pool gone, every org's first connect lands the literal first session
-# on its worker, so this fired in practice. The CP now primes the catalog with a
-# retried schema-enumeration probe before the bind, and the bind itself retries
-# once on the settle signature. This forces a cold worker and asserts
-# the first connect succeeds: cold-spawn backpressure is still tolerated, but the
-# metadata-init bind error fails the test immediately instead of being retried
-# away (which is exactly how a live reconnect would mask it).
-iceberg_cold_first_connect() { # org password
-  log "iceberg cold first-connect (metadata-init regression) on $1"
-  # Force cold: delete every worker for the org and wait until none remain, so
-  # the next connect cold-spawns a brand-new worker whose first session is the
-  # client's — the precise condition that triggered the bug.
-  for p in $(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" -o name 2>/dev/null); do
-    k delete "$p" --grace-period=0 --force >/dev/null 2>&1 || true
-  done
-  i=0
-  while [ "$i" -lt 45 ]; do
-    n="$(k get pods -l "app=duckgres-worker,duckgres/active-org=$1" --no-headers 2>/dev/null | grep -c . || true)"
-    [ "$n" = "0" ] && break
-    sleep 2; i=$((i + 1))
-  done
-  # First connect. Tolerate cold-spawn backpressure (worker still booting), but
-  # treat the session-metadata-init bind failure as a hard regression — do NOT
-  # retry it, or the bug would be masked exactly as a live reconnect masks it.
-  # The metadata-init clause is listed first so it wins over the broader
-  # "failed to initialize session" transient it is a prefix-superset of.
-  a=0 out=""
-  while [ "$a" -lt 12 ]; do
-    if out="$(PGPASSWORD="$2" psql \
-        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=iceberg" \
-        -v ON_ERROR_STOP=1 -tAc "SELECT 1" 2>&1)"; then
-      [ "$out" = "1" ] || fail "iceberg_cold_first_connect: $1 returned '$out' want 1"
-      return
-    fi
-    case "$out" in
-      *"failed to initialize session database metadata"*|*'Schema with name "" not found'*)
-        fail "iceberg_cold_first_connect: cold first session hit the metadata-init bind bug on $1 (prime regressed): $out" ;;
-      *"capacity exhausted"*|*"no Duckgres worker"*|*"still provisioning"*|\
-      *"failed to initialize session"*|*"timed out waiting for an available worker"*|\
-      *"failed to start"*|*"spawn sized worker"*|*"failed to detect attached catalogs"*)
-        sleep 10; a=$((a + 1)); continue ;;
-      *) fail "iceberg_cold_first_connect: unexpected error on $1: $out" ;;
-    esac
-  done
-  fail "iceberg_cold_first_connect: exhausted retries waiting for a cold worker on $1"
 }
 
 # ---- worker pod assertions (via the K8s API) ------------------------------
@@ -1373,7 +1303,7 @@ tenant_isolation() { # orgA pwA orgB pwB
 # ---- lifecycle: deprovision → warehouse deleted → Duckling CR fully gone ----
 # Proves the teardown path works end to end: warehouse marked deleted, the
 # Crossplane Duckling CR removed, and its finalizer cascade (which drops the
-# cnpg lakekeeper_<org> role+db) completed.
+# cnpg metadata role+db) completed.
 #
 # NOTE: same-org-id *re-provision* in the SAME run is intentionally NOT done
 # here. It is the regression net for the stranded-cnpg-role bugs
@@ -1382,11 +1312,11 @@ tenant_isolation() { # orgA pwA orgB pwB
 # the cnpg-shards Postgres, which only `run.sh` (on the runner, with
 # cnpg-shards exec rights) can do — the in-cluster Job SA cannot and must not.
 # Re-provisioning the same id while the async cnpg cascade is still in flight
-# races a drifted-password role → Lakekeeper SASL failure → the warehouse never
-# goes ready. So the same-id regression is covered ACROSS runs instead: every
-# run's `run.sh deploy` drops the cnpg role for a clean slate, and `run.sh
-# teardown` waits the CR `--for=delete` before returning. (This is the same
-# reasoning the original harness used to drop the in-Job recreate.)
+# can race stranded metadata state and leave the warehouse stuck. So the
+# same-id regression is covered ACROSS runs instead: every run's `run.sh
+# deploy` drops the cnpg role for a clean slate, and `run.sh teardown` waits the
+# CR `--for=delete` before returning. (This is the same reasoning the original
+# harness used to drop the in-Job recreate.)
 lifecycle_teardown_cnpg() { # org
   log "lifecycle: deprovision $1 + assert Duckling CR fully deleted"
   api_post "$1" deprovision >/dev/null
@@ -1396,22 +1326,21 @@ lifecycle_teardown_cnpg() { # org
   fi
 }
 
-# ---- cnpg duckling: cnpg-shard metadata + DuckLake + Iceberg --------------
+# ---- cnpg duckling: cnpg-shard metadata + DuckLake ------------------------
 CNPG_BODY='{"database_name":"'"$CNPG"'","metadata_store":{"type":"cnpg-shard"},
-  "data_store":{"type":"s3bucket"},"ducklake":{"enabled":true},
-  "iceberg":{"enabled":true,"namespace":"main"}}'
+  "data_store":{"type":"s3bucket"},"ducklake":{"enabled":true}}'
 
-# ---- ext duckling: external RDS metadata + DuckLake + Iceberg -------------
+# ---- ext duckling: external RDS metadata + DuckLake -----------------------
 EXT_BODY='{"database_name":"'"$EXT"'",
   "metadata_store":{"type":"external","external":{
     "endpoint":"'"$EXT_RDS_ENDPOINT"'","password_aws_secret":"'"$EXT_RDS_SECRET"'",
     "user":"ducklingexample","database":"ducklingexample"}},
   "data_store":{"type":"external","bucket_name":"posthog-duckling-example-managed-warehouse-dev","region":"us-east-1"},
-  "ducklake":{"enabled":true},"iceberg":{"enabled":true,"namespace":"main"}}'
+  "ducklake":{"enabled":true}}'
 
 # ---- resilience ducklings: cnpg-shard metadata + DuckLake only -------------
-# No iceberg (no per-org Lakekeeper) — these orgs exist purely to host the
-# worker-churn-heavy resilience lanes, so keep their provision footprint small.
+# DuckLake-only: these orgs exist purely to host the worker-churn-heavy
+# resilience lanes, so keep their provision footprint small.
 res_body() { # org
   printf '{"database_name":"%s","metadata_store":{"type":"cnpg-shard"},"data_store":{"type":"s3bucket"},"ducklake":{"enabled":true}}' "$1"
 }
@@ -1472,18 +1401,12 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   server_side_cursors    "$CNPG" "$cnpg_pw"
   cancel_then_reuse_same_session "$CNPG" "$cnpg_pw"
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
-  iceberg_cold_first_connect "$CNPG" "$cnpg_pw"  # cold first session must not fail the metadata-init bind
-  rw_iceberg             "$CNPG" "$cnpg_pw"
-  assert_worker_pod      "$CNPG"   # newest org pod = the default-shape iceberg worker above
+  assert_worker_pod      "$CNPG"   # newest org pod = a DuckLake worker above
   concurrent_connections "$CNPG" "$cnpg_pw"
   concurrent_writers     "$CNPG" "$cnpg_pw"
-  # Worker sizing, both catalogs. Distinct shapes per catalog (2/4Gi vs 1/2Gi)
-  # so the iceberg sized request can't reuse the ducklake hot-idle 2-CPU worker
-  # — each catalog gets a verified fresh sized spawn + a same-shape reuse.
+  # Worker sizing on DuckLake: verified fresh sized spawn + same-shape reuse.
   sized_worker        "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
   reuse_sized_worker  "$CNPG" "$cnpg_pw" ducklake 2 4Gi 15m
-  sized_worker        "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
-  reuse_sized_worker  "$CNPG" "$cnpg_pw" iceberg  1 2Gi 15m
   # Idle worker reclamation: a 3-CPU worker with a 1m TTL must be reaped after it
   # goes idle (catches the hot-idle-reaper-dark / persist-swallow idle leak).
   hot_idle_retired    "$CNPG" "$cnpg_pw" ducklake 3 6Gi
@@ -1545,8 +1468,6 @@ lane_ext() { # external-RDS metadata backend + org default profile
   rw_ducklake  "$EXT" "$ext_pw"
   httpfs_retry_budget "$EXT" "$ext_pw"      # S3-503 retry budget per worker, ext-metadata backend too
   persistent_user_secret "$EXT" "$ext_pw"   # secret replay on the ext-metadata org too
-  iceberg_cold_first_connect "$EXT" "$ext_pw"  # cold first session must not fail the metadata-init bind (ext backend)
-  rw_iceberg   "$EXT" "$ext_pw"
   # Org default profile on ext: no client-sized assertions run on this org, so
   # the 2-CPU shape is unambiguously the org default's.
   org_default_profile "$EXT" "$ext_pw" ducklake
@@ -1629,7 +1550,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake/Iceberg) + iceberg-cold-first-connect + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake+Iceberg) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -4,11 +4,11 @@
 #
 # Isolation model (decided with the design): a DEDICATED control plane +
 # throwaway config-store per PR, provisioning REAL ducklings (PR-prefixed org
-# IDs) through the SHARED Crossplane / cnpg-shards / external RDS / Lakekeeper
-# operator. The shared infra is what kind can't model and where the bugs live.
+# IDs) through the SHARED Crossplane / cnpg-shards / external RDS infra. The
+# shared infra is what kind can't model and where the bugs live.
 # Everything PR-specific lives in ${NAMESPACE} and is deleted on teardown; the
-# shared-infra footprint (ducklings, lakekeeper CRs, cnpg roles, S3) is removed
-# by deprovisioning the ci-pr ducklings before the namespace goes.
+# shared-infra footprint (ducklings, cnpg roles, S3) is removed by
+# deprovisioning the ci-pr ducklings before the namespace goes.
 ---
 apiVersion: v1
 kind: Namespace
@@ -179,21 +179,6 @@ subjects:
 roleRef:
   { kind: ClusterRole, name: duckgres-duckling-reader, apiGroup: rbac.authorization.k8s.io }
 ---
-# Cross-namespace Lakekeeper provisioning. Reuses the `duckgres-lakekeeper-provisioner`
-# Role in the shared `lakekeeper` namespace (the one PR #11518 fixed to include
-# delete). Per-PR RoleBinding; deleted on teardown.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: duckgres-ci-pr-${PR_NUMBER}
-  namespace: lakekeeper
-  labels:
-    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
-subjects:
-  - { kind: ServiceAccount, name: duckgres, namespace: ${NAMESPACE} }
-roleRef:
-  { kind: Role, name: duckgres-lakekeeper-provisioner, apiGroup: rbac.authorization.k8s.io }
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -314,8 +299,10 @@ spec:
             # worker image is arm64-only and the default pool is mixed-arch, so
             # pin the arch (no toleration needed — the default pool is untainted).
             - { name: DUCKGRES_K8S_WORKER_NODE_SELECTOR, value: '{"kubernetes.io/arch":"arm64"}' }
-            # Provision real per-org Lakekeeper instances (iceberg path).
-            - { name: DUCKGRES_LAKEKEEPER_PROVISIONER_ENABLED, value: "true" }
+            # Lakekeeper/Iceberg provisioning is intentionally not wired into
+            # the PR e2e stack; the product direction moved back to DuckLake.
+            # The harness still provisions real cnpg-shard and external
+            # metadata-store orgs.
             # Org identity is resolved from the TLS SNI hostname
             # <org-id>.<managed-suffix> (the server rejects connections without
             # it). The harness connects with libpq host=<org>.<suffix> (→ SNI)

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -49,9 +49,9 @@ render() {
 
 # Bind this namespace's `duckgres` SA to the same IAM role the real mw-dev
 # control plane uses (EKS Pod Identity). With it, the CP brokers per-duckling
-# S3 STS creds exactly like prod and activation completes — without it, DuckLake/
-# Iceberg activation fails at AssumeRole. Idempotent: if an association for this
-# (ns, sa) already exists, leave it. Requires the runner's AWS role to hold
+# S3 STS creds exactly like prod and activation completes — without it,
+# DuckLake activation fails at AssumeRole. Idempotent: if an association for
+# this (ns, sa) already exists, leave it. Requires the runner's AWS role to hold
 # eks:{Create,List,Delete}PodIdentityAssociation + iam:PassRole on the CP role.
 ensure_pod_identity() {
   : "${CP_POD_IDENTITY_ROLE:?CP_POD_IDENTITY_ROLE (CP IAM role ARN) is required}"
@@ -106,15 +106,14 @@ restart_cp_with_identity() {
   return 1
 }
 
-# The cnpg lakekeeper_<org> role+db are owned by the Crossplane composition and
+# The cnpg-shard metadata role+db are owned by the Crossplane composition and
 # dropped when the Duckling CR deletes — but that cascade is async and can lag,
-# leaving a stranded role from a prior run (incl. a cancelled one with no
-# teardown). On the next run the same org id re-provisions against the stranded
-# role whose password has drifted, the Lakekeeper migrate Job hits SASL auth
-# failure, and the warehouse never goes ready. So drop it directly on the
-# active shard, idempotently, BOTH before provisioning (clean slate, so a rerun
-# never inherits stranded state) and at teardown (deterministic clean exit).
-# Scoped to this PR's unique org ids, so it can't touch another PR's tenant.
+# leaving stranded state from a prior run (incl. a cancelled one with no
+# teardown). The composition's live identifier still uses the historical
+# lakekeeper_<org> prefix, so drop that role+db directly on the active shard,
+# idempotently, BOTH before provisioning (clean slate, so a rerun never
+# inherits stranded state) and at teardown (deterministic clean exit). Scoped
+# to this PR's unique org ids, so it can't touch another PR's tenant.
 drop_cnpg_role() { # org-id
   local ident
   # Mirror the composition's PG identifier: lakekeeper_<lower, [^a-z0-9_]→_>.
@@ -132,8 +131,8 @@ ci_orgs() { # pr-number
   local pr="$1"
   echo "ci-pr-${pr}-cnpg ci-pr-${pr}-ext ci-pr-${pr}-res1 ci-pr-${pr}-res2"
 }
-# The cnpg-shard-backed orgs (everything except ext) — these own a
-# lakekeeper_<org> role+db on the shard that drop_cnpg_role must clean.
+# The cnpg-shard-backed orgs (everything except ext) own a metadata role+db on
+# the shard that drop_cnpg_role must clean.
 ci_cnpg_orgs() { # pr-number
   local pr="$1"
   echo "ci-pr-${pr}-cnpg ci-pr-${pr}-res1 ci-pr-${pr}-res2"
@@ -156,12 +155,15 @@ wait_ci_ducklings_deleted() { # pr-number timeout
 delete_ci_bindings() { # pr-number
   local pr="$1"
   "${KUBECTL[@]}" delete clusterrolebinding -l "duckgres.posthog.com/ci-pr=${pr}" --ignore-not-found
+  # Historical cleanup: older e2e runs created per-PR Lakekeeper RoleBindings.
+  # Keep sweeping them by label so stale resources disappear after the workflow
+  # stops creating new ones.
   "${KUBECTL[@]}" -n lakekeeper delete rolebinding -l "duckgres.posthog.com/ci-pr=${pr}" --ignore-not-found
 }
 
 reset_pr_stack() {
   # A cancelled or failed run can leave a namespace, config-store rows, and
-  # shared Duckling/Lakekeeper resources for this PR. Start from a clean slate
+  # shared Duckling resources for this PR. Start from a clean slate
   # so apply never reuses stale network policies, services, or tenant state.
   delete_ci_ducklings "$PR_NUMBER"
   wait_ci_ducklings_deleted "$PR_NUMBER" 300s
@@ -277,7 +279,7 @@ cmd_diagnostics() {
 
 cmd_teardown() {
   # Deprovision the ci-pr ducklings FIRST so shared-infra resources (S3 bucket,
-  # cnpg role+db, lakekeeper CR/secret/SA) are cleaned up by the control plane
+  # cnpg role+db) are cleaned up by the control plane
   # before we delete it. Best-effort — the namespace delete + e2e-cleanup are the
   # backstop. Uses the CP admin API via a short-lived port-forward.
   if "${KUBECTL[@]}" -n "$NS" get deploy/duckgres-control-plane >/dev/null 2>&1; then
@@ -316,10 +318,9 @@ cmd_teardown() {
   # Wait for the Duckling CRs to FULLY delete — not just the warehouse row.
   # A warehouse flips to "deleted" the moment the CR delete is issued, but the
   # CR's finalizers keep running (incl the downstream provider-sql DROP of the
-  # cnpg lakekeeper_<org> role+db). If we return before that finishes, a later
-  # run that reuses the same org id (rerun, or a force-pushed PR) provisions
-  # against a stranded cnpg role whose password has drifted -> the Lakekeeper
-  # migrate Job hits SASL auth failure and the warehouse never goes ready.
+  # cnpg metadata role+db). If we return before that finishes, a later run that
+  # reuses the same org id (rerun, or a force-pushed PR) can provision against
+  # stranded cnpg state and never reach ready.
   # `wait --for=delete` blocks until the CR (and its cascade) is gone.
   delete_ci_ducklings "$PR_NUMBER"
   wait_ci_ducklings_deleted "$PR_NUMBER" 300s


### PR DESCRIPTION
## Summary

- Remove Lakekeeper/Iceberg provisioning from the PR e2e stack.
- Keep CNPG and external metadata provisioning coverage on the DuckLake path.
- Remove Iceberg-only harness assertions and update e2e docs/comments to match the active product direction.
- Keep historical cleanup for stale Lakekeeper RoleBindings and existing CNPG metadata role naming.

## Why

PR e2e was still blocking on the retired Lakekeeper/Iceberg path. Since we are moving away from Iceberg, this keeps the useful CNPG provisioning signal while removing stale Lakekeeper warehouse creation from the blocking PR workflow.

## Validation

- `bash -n tests/e2e-mw-dev/run.sh`
- `sh -n tests/e2e-mw-dev/harness.sh`
- Targeted scan for removed e2e Iceberg/Lakekeeper toggles and helper calls
- Rendered manifest parsed offline as 14 YAML docs
- `git diff --check`
- `just lint`