### PR TITLE
janitor: reclaim hot workers abandoned by a draining/dead CP

### DIFF
--- a/controlplane/configstore/lifecycle_store.go
+++ b/controlplane/configstore/lifecycle_store.go
@@ -23,8 +23,8 @@ func (cs *ConfigStore) ObserveWorker(workerID int) (*WorkerSnapshot, error) {
 // snapshot binds the observation (state, owner, epoch, updated_at) to
 // the subsequent retire CAS, so callers cannot accidentally retire a
 // row that has changed under them since the listing.
-func (cs *ConfigStore) ListOrphanedWorkerSnapshots(before time.Time) ([]WorkerSnapshot, error) {
-	records, err := cs.ListOrphanedWorkers(before)
+func (cs *ConfigStore) ListOrphanedWorkerSnapshots(before, workerStale time.Time) ([]WorkerSnapshot, error) {
+	records, err := cs.ListOrphanedWorkers(before, workerStale)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1425,6 +1425,18 @@ func (cs *ConfigStore) countOrgAdmittingWorkers(tx *gorm.DB, orgID, image, profi
 //  3. owner_cp_instance_id is set but no matching cp_instances row
 //     exists at all (hard-deleted somehow), and again the heartbeat
 //     is stale. Same shape as (2), different cause.
+//  4. The owning CP row exists and is DRAINING (or itself heartbeat-stale
+//     past `before`) AND the worker's own heartbeat has gone stale past
+//     `workerStale`. This closes the leak where a CP drains (or dies
+//     ungracefully) without being marked expired — with the remote
+//     backend's unbounded handover-drain timeout a draining CP can linger
+//     for the full pod grace period, and its idle `hot` workers (no longer
+//     health-checked, so their heartbeat goes stale) were invisible to
+//     (1)/(2)/(3). `workerStale` is a deliberately generous grace (well
+//     beyond the health-check interval) so a worker with an active session
+//     — which a draining CP keeps health-checking per the drain contract —
+//     keeps a fresh heartbeat and is never reaped here; the Flight-session
+//     guard below is a second line of defense.
 //
 // Retired/lost rows are deliberately excluded — their pods are already
 // gone (or are reconciled by K8sWorkerPool.cleanupOrphanedWorkerPods).
@@ -1443,7 +1455,7 @@ func (cs *ConfigStore) countOrgAdmittingWorkers(tx *gorm.DB, orgID, image, profi
 //
 // See TestListOrphanedWorkers* in tests/configstore for the regression
 // fixtures.
-func (cs *ConfigStore) ListOrphanedWorkers(before time.Time) ([]WorkerRecord, error) {
+func (cs *ConfigStore) ListOrphanedWorkers(before, workerStale time.Time) ([]WorkerRecord, error) {
 	var workers []WorkerRecord
 	cleanupStates := []WorkerState{
 		WorkerStateSpawning,
@@ -1471,10 +1483,15 @@ func (cs *ConfigStore) ListOrphanedWorkers(before time.Time) ([]WorkerRecord, er
 				// (2) owner string is empty/NULL and heartbeat is stale
 				"OR (NULLIF(w.owner_cp_instance_id, '') IS NULL AND w.last_heartbeat_at <= ?) "+
 				// (3) owner string is set but no matching CP row, heartbeat stale
-				"OR (cp.id IS NULL AND NULLIF(w.owner_cp_instance_id, '') IS NOT NULL AND w.last_heartbeat_at <= ?)",
+				"OR (cp.id IS NULL AND NULLIF(w.owner_cp_instance_id, '') IS NOT NULL AND w.last_heartbeat_at <= ?) "+
+				// (4) owner CP is draining (or itself heartbeat-stale) and the
+				//     worker's own heartbeat is stale past the generous grace —
+				//     a draining/dead-but-not-yet-expired owner won't manage it.
+				"OR ((cp.state = ? OR cp.last_heartbeat_at <= ?) AND w.last_heartbeat_at <= ?)",
 			ControlPlaneInstanceStateExpired, before,
 			before,
 			before,
+			ControlPlaneInstanceStateDraining, before, workerStale,
 		).
 		// Spare workers with at least one reclaimable Flight session: a
 		// retire here would kill the customer's mid-flight query at the

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -17,7 +17,7 @@ const (
 type controlPlaneExpiryStore interface {
 	ExpireControlPlaneInstances(cutoff time.Time) (int64, error)
 	ExpireDrainingControlPlaneInstances(before time.Time) (int64, error)
-	ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
+	ListOrphanedWorkerSnapshots(before, workerStale time.Time) ([]configstore.WorkerSnapshot, error)
 	ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerSnapshot, error)
 	ListExpiredHotIdleSnapshots(now time.Time, defaultTTL time.Duration) ([]configstore.WorkerSnapshot, error)
 	CountHotIdleWorkers(orgID, image, profileCPU, profileMemory string) (int, error)
@@ -29,6 +29,7 @@ type ControlPlaneJanitor struct {
 	interval                      time.Duration
 	expiryTimeout                 time.Duration
 	orphanGrace                   time.Duration
+	abandonedWorkerGrace          time.Duration
 	spawnTimeout                  time.Duration
 	activateTimeout               time.Duration
 	maxDrainTimeout               time.Duration
@@ -56,6 +57,12 @@ func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeo
 		interval:      interval,
 		expiryTimeout: expiryTimeout,
 		orphanGrace:   30 * time.Second,
+		// A worker whose heartbeat is this stale AND whose owner CP is draining
+		// or itself stale is treated as abandoned (orphan condition (4)). Kept
+		// generous — far beyond the worker health-check interval — so a worker
+		// with an active session (which a draining CP keeps health-checking per
+		// the drain contract) keeps a fresh heartbeat and is never reaped here.
+		abandonedWorkerGrace: 5 * time.Minute,
 		// The stuck-worker cutoffs must exceed the detached spawn+activate
 		// budget (workerSpawnActivateTimeout, 8m: pod-ready incl. Karpenter
 		// node provisioning + gRPC connect + activation). A spawning row's
@@ -132,7 +139,8 @@ func (j *ControlPlaneJanitor) runOnce() {
 		})
 	} else {
 		orphanedBefore := j.now().Add(-j.orphanGrace)
-		orphaned, err := j.store.ListOrphanedWorkerSnapshots(orphanedBefore)
+		abandonedBefore := j.now().Add(-j.abandonedWorkerGrace)
+		orphaned, err := j.store.ListOrphanedWorkerSnapshots(orphanedBefore, abandonedBefore)
 		if err != nil {
 			slog.Warn("Janitor failed to list orphaned workers.", "error", err)
 		} else {

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -54,7 +54,7 @@ func (s *captureControlPlaneExpiryStore) snapshot() []time.Time {
 // slice through NewWorkerSnapshot so existing fixtures that
 // populate orphanedWorkers also drive the lifecycle path when a
 // lifecycle is wired.
-func (s *captureControlPlaneExpiryStore) ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error) {
+func (s *captureControlPlaneExpiryStore) ListOrphanedWorkerSnapshots(before, workerStale time.Time) ([]configstore.WorkerSnapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.orphanedWorkers) == 0 {

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -344,9 +344,10 @@ func SetupMultiTenant(
 		lifecycle:    router.sharedPool.lifecycle,
 		cpInstanceID: cpInstanceID,
 		hotIdleTTL:   janitor.hotIdleTTL,
-		hotIdleFloor: janitor.hotIdleFloor,
-		orphanGrace:  janitor.orphanGrace, // same cutoff as the leader orphan sweep
-		interval:     time.Minute,
+		hotIdleFloor:         janitor.hotIdleFloor,
+		orphanGrace:          janitor.orphanGrace, // same cutoff as the leader orphan sweep
+		abandonedWorkerGrace: janitor.abandonedWorkerGrace,
+		interval:             time.Minute,
 	}
 	go fallbackReaper.Run(context.Background())
 

--- a/controlplane/per_cp_hot_idle_reaper.go
+++ b/controlplane/per_cp_hot_idle_reaper.go
@@ -16,7 +16,7 @@ type perCPHotIdleStore interface {
 	// longer live (expired/missing past the cutoff). Reused here so the per-CP
 	// reaper can reclaim hot-idle workers orphaned by a rollout/crash without
 	// waiting on the leader.
-	ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error)
+	ListOrphanedWorkerSnapshots(before, workerStale time.Time) ([]configstore.WorkerSnapshot, error)
 }
 
 // perCPHotIdleReaper retires THIS replica's own expired hot-idle workers on a
@@ -43,8 +43,12 @@ type perCPHotIdleReaper struct {
 	// the per-CP orphan pass (self-owned reaping still runs). Matches the leader
 	// janitor's orphanGrace so timing is identical, just leader-independent.
 	orphanGrace time.Duration
-	interval    time.Duration
-	now         func() time.Time
+	// abandonedWorkerGrace mirrors the leader janitor's: how stale a worker's
+	// own heartbeat must be (with a draining/stale owner CP) before the orphan
+	// pass reclaims it. Generous so active-session workers are never reaped.
+	abandonedWorkerGrace time.Duration
+	interval             time.Duration
+	now                  func() time.Time
 }
 
 func (r *perCPHotIdleReaper) Run(ctx context.Context) {
@@ -128,7 +132,11 @@ func (r *perCPHotIdleReaper) reapOrphanedHotIdle(now time.Time) {
 	if r.orphanGrace <= 0 {
 		return
 	}
-	orphaned, err := r.store.ListOrphanedWorkerSnapshots(now.Add(-r.orphanGrace))
+	abandonedGrace := r.abandonedWorkerGrace
+	if abandonedGrace <= 0 {
+		abandonedGrace = r.orphanGrace
+	}
+	orphaned, err := r.store.ListOrphanedWorkerSnapshots(now.Add(-r.orphanGrace), now.Add(-abandonedGrace))
 	if err != nil {
 		slog.Warn("Per-CP hot-idle reaper failed to list orphaned workers.", "error", err)
 		return

--- a/controlplane/per_cp_hot_idle_reaper_test.go
+++ b/controlplane/per_cp_hot_idle_reaper_test.go
@@ -24,7 +24,7 @@ func (s *fakePerCPHotIdleStore) CountHotIdleWorkers(orgID, image, cpu, mem strin
 	return s.counts[orgID], nil
 }
 
-func (s *fakePerCPHotIdleStore) ListOrphanedWorkerSnapshots(before time.Time) ([]configstore.WorkerSnapshot, error) {
+func (s *fakePerCPHotIdleStore) ListOrphanedWorkerSnapshots(before, workerStale time.Time) ([]configstore.WorkerSnapshot, error) {
 	return s.orphaned, nil
 }
 

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -1015,7 +1015,7 @@ func TestListOrphanedAndStuckWorkersPostgres(t *testing.T) {
 		t.Fatalf("age stuck worker: %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1055,12 +1055,85 @@ func TestListOrphanedWorkersIncludesOwnerlessIdleWorkers(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(ownerless idle): %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
 	if len(orphaned) != 1 || orphaned[0].WorkerID != 77 {
 		t.Fatalf("expected ownerless idle worker 77 to be returned as an orphan, got %#v", orphaned)
+	}
+}
+
+// TestListOrphanedWorkersReclaimsAbandonedHotWorker covers condition (4):
+// a `hot` worker whose owning CP is DRAINING (or itself heartbeat-stale) and
+// whose own heartbeat has gone stale past the abandoned grace is reclaimed,
+// even though the CP row was never marked expired. This is the prod leak where
+// the remote backend's unbounded handover-drain timeout lets a draining CP
+// linger while its idle hot workers (no longer health-checked) pile up. The
+// control rows assert the safety boundary: a hot worker with a FRESH heartbeat
+// (still being health-checked → has an active session) and a hot worker owned
+// by a healthy ACTIVE CP are both spared.
+func TestListOrphanedWorkersReclaimsAbandonedHotWorker(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	now := time.Date(2026, time.June, 30, 14, 0, 0, 0, time.UTC)
+
+	// A draining CP (rolling out) that still heartbeats — NOT expired.
+	drainingAt := now.Add(-20 * time.Minute)
+	if err := store.UpsertControlPlaneInstance(&configstore.ControlPlaneInstance{
+		ID:              "cp-draining:boot-x",
+		PodName:         "duckgres-cp-draining",
+		State:           configstore.ControlPlaneInstanceStateDraining,
+		StartedAt:       now.Add(-time.Hour),
+		LastHeartbeatAt: now,
+		DrainingAt:      ptrTime(drainingAt),
+	}); err != nil {
+		t.Fatalf("UpsertControlPlaneInstance(draining): %v", err)
+	}
+	// A healthy active CP.
+	if err := store.UpsertControlPlaneInstance(&configstore.ControlPlaneInstance{
+		ID:              "cp-active:boot-y",
+		PodName:         "duckgres-cp-active",
+		State:           configstore.ControlPlaneInstanceStateActive,
+		StartedAt:       now.Add(-time.Hour),
+		LastHeartbeatAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertControlPlaneInstance(active): %v", err)
+	}
+
+	// (A) hot worker, draining owner, STALE heartbeat → must be reclaimed.
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID: 201, PodName: "duckgres-worker-201", State: configstore.WorkerStateHot,
+		OrgID: "acme", OwnerCPInstanceID: "cp-draining:boot-x", OwnerEpoch: 1,
+		LastHeartbeatAt: now.Add(-10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(abandoned hot): %v", err)
+	}
+	// (B) hot worker, draining owner, FRESH heartbeat (still health-checked /
+	//     active session) → must be SPARED.
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID: 202, PodName: "duckgres-worker-202", State: configstore.WorkerStateHot,
+		OrgID: "acme", OwnerCPInstanceID: "cp-draining:boot-x", OwnerEpoch: 1,
+		LastHeartbeatAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(fresh hot): %v", err)
+	}
+	// (C) hot worker, ACTIVE healthy owner, stale heartbeat → must be SPARED
+	//     (a live CP is responsible for it; don't reap a healthy CP's worker).
+	if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+		WorkerID: 203, PodName: "duckgres-worker-203", State: configstore.WorkerStateHot,
+		OrgID: "acme", OwnerCPInstanceID: "cp-active:boot-y", OwnerEpoch: 1,
+		LastHeartbeatAt: now.Add(-10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("UpsertWorkerRecord(active-owned hot): %v", err)
+	}
+
+	// before = orphan/cp-staleness cutoff (30s); workerStale = abandoned grace (5m).
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-5*time.Minute))
+	if err != nil {
+		t.Fatalf("ListOrphanedWorkers: %v", err)
+	}
+	if len(orphaned) != 1 || orphaned[0].WorkerID != 201 {
+		t.Fatalf("expected only abandoned hot worker 201 reclaimed, got %#v", orphaned)
 	}
 }
 
@@ -1085,7 +1158,7 @@ func TestRetireOrphanWorkerHandlesNullOwnerPostgres(t *testing.T) {
 		t.Fatalf("set owner_cp_instance_id null: %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1124,7 +1197,7 @@ func TestListOrphanedWorkersIncludesDanglingOwnerWorkers(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(dangling owner): %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1155,7 +1228,7 @@ func TestListOrphanedWorkersExcludesFreshOwnerlessWorker(t *testing.T) {
 		t.Fatalf("UpsertWorkerRecord(fresh ownerless): %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1588,7 +1661,7 @@ func TestListOrphanedWorkersExcludesWorkersWithActiveFlightSessions(t *testing.T
 		t.Fatalf("UpsertFlightSessionRecord: %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1641,7 +1714,7 @@ func TestListOrphanedWorkersIncludesWorkersWithReconnectingFlightSessions(t *tes
 		t.Fatalf("UpsertFlightSessionRecord: %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -1696,7 +1769,7 @@ func TestListOrphanedWorkersIncludesWorkersWithExpiredFlightSessions(t *testing.
 		t.Fatalf("UpsertFlightSessionRecord: %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -2011,7 +2084,7 @@ func TestRetireOrphanWorkerRejectsRevivedOwnerControlPlanePostgres(t *testing.T)
 		t.Fatalf("UpsertWorkerRecord(orphan candidate): %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}
@@ -2063,7 +2136,7 @@ func TestRetireOrphanWorkerRejectsStaleListSnapshotAfterTakeoverPostgres(t *test
 		t.Fatalf("UpsertWorkerRecord(orphan candidate): %v", err)
 	}
 
-	orphaned, err := store.ListOrphanedWorkers(now.Add(-30 * time.Second))
+	orphaned, err := store.ListOrphanedWorkers(now.Add(-30*time.Second), now.Add(-30*time.Second))
 	if err != nil {
 		t.Fatalf("ListOrphanedWorkers: %v", err)
 	}


### PR DESCRIPTION
## What

Closes a worker-leak gap that pins idle vCPU/memory. A worker stuck in `hot` with **no session** fell through both cleanup paths:
- the **hot-idle TTL reaper** only reaps `hot_idle`;
- the **stranded-pod reconciler** only deletes `Retired`/`Lost` rows;
- `ListOrphanedWorkers` reaped `hot` workers only once their owning CP row was marked **Expired** — but with the remote backend's **unbounded handover-drain timeout**, a draining CP lingers (up to the pod grace period), so its idle hot workers (no longer health-checked → heartbeat goes stale) accumulate.

**Found live in prod-us:** 132 `hot`, 0-session workers for a single org (`4dc8564d`) reserving **~2,385 vCPU / ~25 TB**, owned across 3 CP replicaset generations — i.e. workers abandoned by CPs that rolled. (This is the residual cause of the long-standing high-vCPU problem; removing the org's size override earlier shrank new workers but never reclaimed the leaked count.)

## Fix

Adds orphan **condition (4)** to `ListOrphanedWorkers`: a worker in a cleanup state whose owner CP is **draining** (or itself heartbeat-stale past the orphan cutoff) **AND** whose own heartbeat is stale past a generous `abandonedWorkerGrace` (5m default) is reclaimed — independent of whether/when the CP row is marked Expired.

Safety guards:
- `abandonedWorkerGrace` is far beyond the worker health-check interval, so a worker **with an active session** — which a draining CP keeps health-checking per the drain contract — keeps a fresh heartbeat and is **never reaped**;
- the existing **reclaimable-Flight-session** exclusion (`NOT EXISTS active/reconnecting session`) is a second line of defense.

Threaded through `ListOrphanedWorkers(before, workerStale)`, the snapshot wrapper, the leader janitor, and the per-CP fallback reaper.

## Tests

New configstore **Postgres** test `TestListOrphanedWorkersReclaimsAbandonedHotWorker` (ran green against real PG): the abandoned hot worker is reclaimed; a **fresh-heartbeat** hot worker and a hot worker owned by a **healthy active CP** are both spared. Existing janitor / per-CP reaper unit tests pass.

**e2e:** not asserted in `tests/e2e-mw-dev` — it needs a draining-CP + stuck-hot-worker fixture the in-Job harness can't construct deterministically; the Postgres + unit tests cover the logic. (Flagging per the harness-coverage rule.)

## Ops note

The immediate prod leak was already mitigated out-of-band (124 idle hot pods for the org deleted, ~2.2k vCPU reclaimed, busy workers preserved). This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)