### PR TITLE
admin ui: Overview Workers card shows real fleet + idle-hot leak signal

### DIFF
--- a/controlplane/admin/ui/src/pages/Overview.tsx
+++ b/controlplane/admin/ui/src/pages/Overview.tsx
@@ -62,7 +62,15 @@ export function Overview() {
     return { rateSeries: pts, errorPct: total > 0 ? (error / total) * 100 : 0 };
   }, [qTotal.data]);
 
-  const totalWorkers = status.data?.total_workers ?? totalFleet;
+  // The real worker count is the fleet (cluster-wide, from the config store).
+  // status.total_workers is only the SESSION-HOLDING workers the serving CP
+  // happens to see (0 when idle) — using it as the headline undercounts the
+  // fleet, and `?? totalFleet` never fell back because 0 is not nullish.
+  const busyWorkers = status.data?.total_workers ?? 0;
+  const hotCount = stateCounts["hot"] ?? 0;
+  // Idle hot workers: `hot` in the fleet but not holding a session. A large,
+  // persistent value is the leak signal (workers stuck hot, never reaped).
+  const idleHot = Math.max(0, hotCount - busyWorkers);
 
   return (
     <>
@@ -70,7 +78,13 @@ export function Overview() {
       <PageBody>
         <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6">
           <StatCard label="Organizations" value={fmtInt(status.data?.total_orgs)} icon={<Building2 className="h-4 w-4" />} />
-          <StatCard label="Workers" value={fmtInt(totalWorkers)} icon={<Server className="h-4 w-4" />} />
+          <StatCard
+            label="Workers"
+            value={fleet.isSuccess ? fmtInt(totalFleet) : "—"}
+            hint={fleet.isSuccess ? `${fmtInt(hotCount)} hot · ${fmtInt(idleHot)} idle` : undefined}
+            accent={idleHot >= 20 ? "warning" : "default"}
+            icon={<Server className="h-4 w-4" />}
+          />
           <StatCard label="Sessions" value={fmtInt(status.data?.total_sessions)} icon={<Users className="h-4 w-4" />} />
           <StatCard
             label="Queue depth"
@@ -115,6 +129,13 @@ export function Overview() {
                   Fleet detail unavailable (GET /api/v1/workers/fleet). Showing totals only.
                 </p>
               )}
+              {fleet.isSuccess && idleHot >= 20 ? (
+                <p className="mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+                  ⚠ {fmtInt(idleHot)} <span className="font-medium">hot</span> workers are not holding a
+                  session — possible idle/leaked workers reserving vCPU &amp; memory. Check the Workers page
+                  for the fleet breakdown and owner.
+                </p>
+              ) : null}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## What

The Overview **Workers** card showed **0** while the lifecycle breakdown right next to it showed **132 hot** — a confusing contradiction (reported during prod review).

Root cause: the card read `status.total_workers`, which is only the **session-holding** workers the serving CP sees (0 when idle), and the `?? totalFleet` fallback never fired because `0` isn't nullish.

## Fix

- The **Workers** card now shows the real cluster **fleet total** (`GET /api/v1/workers/fleet`, config-store-backed, cluster-wide) with a `N hot · M idle` hint.
- Adds the **idle-hot leak signal**: `idle-hot = hot workers − session-holding workers`. The card turns amber and a callout appears when it's high (≥20), pointing at the Workers page.

This is exactly the signal that would have made the **132 stuck-`hot` worker leak** (~2,385 vCPU) obvious at a glance instead of needing a kubectl investigation.

Companion to the reaper fix **PostHog/duckgres#832** that actually reclaims those workers.

## Notes
- Frontend-only; `dist/` is the gitignored build artifact (rebuilt by CI/Docker). `npm run typecheck` + `npm run build` pass.
- The per-CP **flashing** of the live session/query counts (a separate issue — those endpoints report only the serving CP's in-memory view) is tracked separately and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)