### PR TITLE
controlplane: release idle Hot workers to hot_idle at CP drain start

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -251,6 +251,10 @@ type OrgRouterInterface interface {
 	IcebergConfigForOrg(orgID string) (server.IcebergConfig, bool)
 	IsMigratingForOrg(orgID string) bool
 	ShutdownAll()
+	// ReleaseIdleHotWorkers parks idle (zero-session) Hot workers into hot_idle
+	// at drain start so the TTL reaper reclaims them instead of letting them
+	// linger for the whole drain wait. Returns the number parked.
+	ReleaseIdleHotWorkers() int
 }
 
 // RunControlPlane is the entry point for the control plane process.
@@ -1575,6 +1579,15 @@ func (cp *ControlPlane) drainAndShutdown(timeout time.Duration) {
 	cp.stopAcceptingPGConnections()
 	if cp.flight != nil {
 		cp.flight.BeginDrain()
+	}
+	// Park idle (zero-session) Hot workers into hot_idle NOW, at drain start, so
+	// the hot-idle TTL reaper (or a peer-CP takeover) reclaims them during the
+	// drain wait below. Without this they linger for the entire — possibly
+	// unbounded — wait, because ShutdownAll (which cleans idle workers) runs only
+	// AFTER waitForDrain returns. No new sessions can land on them: PG accept is
+	// already closed and Flight is draining. Busy workers are untouched.
+	if cp.orgRouter != nil {
+		cp.orgRouter.ReleaseIdleHotWorkers()
 	}
 	if timeout > 0 {
 		slog.Info("Waiting for planned shutdown drain.", "timeout", timeout)

--- a/controlplane/flight_ingress_test.go
+++ b/controlplane/flight_ingress_test.go
@@ -25,6 +25,7 @@ func (r *reconnectTestOrgRouter) IcebergConfigForOrg(_ string) (server.IcebergCo
 
 func (r *reconnectTestOrgRouter) IsMigratingForOrg(_ string) bool { return false }
 func (r *reconnectTestOrgRouter) ShutdownAll()                    {}
+func (r *reconnectTestOrgRouter) ReleaseIdleHotWorkers() int      { return 0 }
 
 // recordingOrgRouter records the orgIDs StackForOrg is asked for. It returns no
 // live stack, so CreateSession returns right after recording the routing org.
@@ -44,6 +45,7 @@ func (r *recordingOrgRouter) IcebergConfigForOrg(_ string) (server.IcebergConfig
 }
 func (r *recordingOrgRouter) IsMigratingForOrg(_ string) bool { return false }
 func (r *recordingOrgRouter) ShutdownAll()                    {}
+func (r *recordingOrgRouter) ReleaseIdleHotWorkers() int      { return 0 }
 
 type testFlightOrgKey struct{}
 

--- a/controlplane/k8s_pool_lifecycle.go
+++ b/controlplane/k8s_pool_lifecycle.go
@@ -160,6 +160,16 @@ func (p *K8sWorkerPool) TransitionToHotIdleIfNoSessions(id int) bool {
 	if w.SharedState().NormalizedLifecycle() != WorkerLifecycleHot {
 		return false
 	}
+	return p.commitHotIdleLocked(id, w)
+}
+
+// commitHotIdleLocked performs the durable-first Hot → hot_idle transition for a
+// worker the caller has already verified is Hot with activeSessions == 0.
+// Caller holds p.mu. Extracted so both the session-release path
+// (TransitionToHotIdleIfNoSessions) and the no-decrement sweep
+// (parkIdleHotWorker / ReleaseIdleHotWorkers) share one correct
+// implementation.
+func (p *K8sWorkerPool) commitHotIdleLocked(id int, w *ManagedWorker) bool {
 	nextState, err := w.SharedState().Transition(WorkerLifecycleHotIdle, nil)
 	if err != nil {
 		return false
@@ -173,8 +183,7 @@ func (p *K8sWorkerPool) TransitionToHotIdleIfNoSessions(id int) bool {
 	// state=hot_idle) AND the TTL reaper (same filter) until this CP restarts,
 	// stranding an idle pod forever. Leaving it Hot keeps it reusable by its org
 	// (findIdleAssignedWorkerLocked reuses Hot, activeSessions==0 workers) and a
-	// later release/retire retries the park; the session decrement above already
-	// happened, so the worker is honestly idle, just not yet durably parked.
+	// later release/retire retries the park.
 	hotIdleRecord := p.workerRecordFor(id, w, w.OwnerEpoch(), configstore.WorkerStateHotIdle, "", nil)
 	if err := p.persistWorkerRecord(hotIdleRecord); err != nil {
 		observeHotIdlePersistFailure(w.image)
@@ -189,6 +198,58 @@ func (p *K8sWorkerPool) TransitionToHotIdleIfNoSessions(id int) bool {
 	}
 	w.lastUsed = time.Now()
 	return true
+}
+
+// parkIdleHotWorker parks a Hot, zero-session worker into hot_idle WITHOUT
+// decrementing the session count (unlike TransitionToHotIdleIfNoSessions, which
+// is a session-release callback). It re-checks state + activeSessions under the
+// lock, so it is safe against a worker becoming busy between selection and park.
+// Returns true if it parked the worker.
+func (p *K8sWorkerPool) parkIdleHotWorker(id int) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	w, ok := p.workers[id]
+	if !ok || w.activeSessions != 0 {
+		return false
+	}
+	if w.SharedState().NormalizedLifecycle() != WorkerLifecycleHot {
+		return false
+	}
+	return p.commitHotIdleLocked(id, w)
+}
+
+// ReleaseIdleHotWorkers parks every Hot worker this CP owns that currently holds
+// NO session into hot_idle, so the hot-idle TTL reaper (or a peer-CP takeover)
+// reclaims it through the existing fenced path. A Hot/0-session worker is a
+// worker whose Hot → hot_idle park was missed (e.g. an earlier persist failure
+// that never got retried because the worker received no further session); left
+// alone it is invisible to the TTL reaper and pins its pod's vCPU/memory.
+//
+// Called when this CP enters drain (drainAndShutdown): otherwise such workers
+// linger for the entire — possibly unbounded — drain wall, because ShutdownAll
+// (which would clean them) runs only AFTER waitForDrain returns. Selection is a
+// lock-held snapshot; each park re-validates under the lock, so a worker that
+// became busy in between is skipped. Returns the number parked.
+func (p *K8sWorkerPool) ReleaseIdleHotWorkers(origin LifecycleOrigin) int {
+	p.mu.Lock()
+	var ids []int
+	for id, w := range p.workers {
+		if w.activeSessions == 0 && w.SharedState().NormalizedLifecycle() == WorkerLifecycleHot {
+			ids = append(ids, id)
+		}
+	}
+	p.mu.Unlock()
+
+	parked := 0
+	for _, id := range ids {
+		if p.parkIdleHotWorker(id) {
+			parked++
+		}
+	}
+	if parked > 0 {
+		slog.Info("Parked idle hot workers into hot_idle on drain.", "count", parked, "origin", origin)
+	}
+	return parked
 }
 
 func (p *K8sWorkerPool) retireClaimedWorker(claimed *configstore.WorkerRecord, reason string, origin LifecycleOrigin) (configstore.TransitionOutcome, error) {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -1018,6 +1018,80 @@ func TestK8sPoolTransitionToHotIdlePersistFailureStaysHot(t *testing.T) {
 	}
 }
 
+// ReleaseIdleHotWorkers parks Hot/0-session workers into hot_idle (so the
+// hot-idle TTL reaper can reclaim them) and leaves busy Hot workers untouched.
+// This is the drain-time release that prevents idle Hot workers from pinning
+// vCPU for the whole (possibly unbounded) drain wall.
+func TestK8sPoolReleaseIdleHotWorkersParksIdleSkipsBusy(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+
+	mkHot := func(id int, sessions int) *ManagedWorker {
+		w := &ManagedWorker{ID: id, activeSessions: sessions, done: make(chan struct{})}
+		if err := w.SetSharedState(SharedWorkerState{
+			Lifecycle:  WorkerLifecycleHot,
+			Assignment: &WorkerAssignment{OrgID: "analytics"},
+		}); err != nil {
+			t.Fatalf("SetSharedState(%d): %v", id, err)
+		}
+		pool.workers[id] = w
+		return w
+	}
+
+	idle := mkHot(1, 0)
+	busy := mkHot(2, 1)
+	// A worker already in hot_idle must not be re-parked or counted.
+	alreadyIdle := &ManagedWorker{ID: 3, activeSessions: 0, done: make(chan struct{})}
+	if err := alreadyIdle.SetSharedState(SharedWorkerState{
+		Lifecycle:  WorkerLifecycleHotIdle,
+		Assignment: &WorkerAssignment{OrgID: "analytics"},
+	}); err != nil {
+		t.Fatalf("SetSharedState(3): %v", err)
+	}
+	pool.workers[3] = alreadyIdle
+
+	parked := pool.ReleaseIdleHotWorkers(LifecycleOriginDrainReleaseIdle)
+	if parked != 1 {
+		t.Fatalf("expected exactly 1 worker parked, got %d", parked)
+	}
+	if got := idle.SharedState().NormalizedLifecycle(); got != WorkerLifecycleHotIdle {
+		t.Fatalf("idle Hot worker should be parked to hot_idle, got %q", got)
+	}
+	if got := busy.SharedState().NormalizedLifecycle(); got != WorkerLifecycleHot {
+		t.Fatalf("busy worker must stay Hot, got %q", got)
+	}
+	if busy.activeSessions != 1 {
+		t.Fatalf("busy worker session count must be untouched, got %d", busy.activeSessions)
+	}
+	if got := alreadyIdle.SharedState().NormalizedLifecycle(); got != WorkerLifecycleHotIdle {
+		t.Fatalf("already-idle worker should remain hot_idle, got %q", got)
+	}
+}
+
+// parkIdleHotWorker must NOT decrement the session count (unlike the
+// session-release callback TransitionToHotIdleIfNoSessions): it is a sweep over
+// already-idle workers, so a worker that has any session must be left alone.
+func TestK8sPoolParkIdleHotWorkerNoDecrement(t *testing.T) {
+	pool, _ := newTestK8sPool(t, 5)
+	worker := &ManagedWorker{ID: 7, activeSessions: 1, done: make(chan struct{})}
+	if err := worker.SetSharedState(SharedWorkerState{
+		Lifecycle:  WorkerLifecycleHot,
+		Assignment: &WorkerAssignment{OrgID: "analytics"},
+	}); err != nil {
+		t.Fatalf("SetSharedState: %v", err)
+	}
+	pool.workers[worker.ID] = worker
+
+	if pool.parkIdleHotWorker(worker.ID) {
+		t.Fatal("parkIdleHotWorker must not park a worker with an active session")
+	}
+	if worker.activeSessions != 1 {
+		t.Fatalf("parkIdleHotWorker must not decrement sessions, got %d", worker.activeSessions)
+	}
+	if got := worker.SharedState().NormalizedLifecycle(); got != WorkerLifecycleHot {
+		t.Fatalf("busy worker must stay Hot, got %q", got)
+	}
+}
+
 // Regression for fix #4: when the durable Hot persist fails during activation,
 // ActivateReservedWorker must return an error and NOT advance the worker to Hot
 // (leaving a durable=activating / in-memory=Hot split the stuck reaper could

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -61,6 +61,10 @@ func (a *orgRouterAdapter) ShutdownAll() {
 	a.router.ShutdownAll()
 }
 
+func (a *orgRouterAdapter) ReleaseIdleHotWorkers() int {
+	return a.router.ReleaseIdleHotWorkers()
+}
+
 func (a *orgRouterAdapter) AllOrgStats() []admin.OrgStatus {
 	stacks := a.router.AllStacks()
 	stats := make([]admin.OrgStatus, 0, len(stacks))

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -380,6 +380,17 @@ func (tr *OrgRouter) ShutdownAll() {
 	}
 }
 
+// ReleaseIdleHotWorkers parks this CP's idle (zero-session) Hot workers into
+// hot_idle so the TTL reaper can reclaim them, instead of letting them linger
+// for the whole (possibly unbounded) drain wait. All workers live in the shared
+// pool; per-org reserved pools are slices of it. Returns the number parked.
+func (tr *OrgRouter) ReleaseIdleHotWorkers() int {
+	if tr.sharedPool == nil {
+		return 0
+	}
+	return tr.sharedPool.ReleaseIdleHotWorkers(LifecycleOriginDrainReleaseIdle)
+}
+
 func (tr *OrgRouter) onSharedWorkerCrash(workerID int) {
 	stack, orgID, ok := tr.stackForWorker(workerID)
 	if !ok {

--- a/controlplane/org_router_test_helpers_test.go
+++ b/controlplane/org_router_test_helpers_test.go
@@ -19,3 +19,4 @@ func (m *mockOrgRouter) IcebergConfigForOrg(_ string) (server.IcebergConfig, boo
 
 func (m *mockOrgRouter) IsMigratingForOrg(_ string) bool { return false }
 func (m *mockOrgRouter) ShutdownAll()                    {}
+func (m *mockOrgRouter) ReleaseIdleHotWorkers() int     { return 0 }

--- a/controlplane/worker_lifecycle_metrics.go
+++ b/controlplane/worker_lifecycle_metrics.go
@@ -49,6 +49,12 @@ const (
 	LifecycleOriginJanitorStuckActivating  LifecycleOrigin = "janitor_stuck_activating"
 	LifecycleOriginMismatchedVersionReaper LifecycleOrigin = "mismatched_version_reaper"
 	LifecycleOriginShutdownAll             LifecycleOrigin = "shutdown_all"
+	// LifecycleOriginDrainReleaseIdle marks the hot -> hot_idle park performed
+	// by OrgRouter.ReleaseIdleHotWorkers at CP drain start: idle (zero-session)
+	// Hot workers are released so the unfenced hot-idle TTL reaper reclaims them
+	// during the drain wait instead of pinning vCPU until the CP is declared
+	// expired. A nonzero rate here during a rollout is the leak fix working.
+	LifecycleOriginDrainReleaseIdle LifecycleOrigin = "drain_release_idle"
 	LifecycleOriginHealthCheckCrash        LifecycleOrigin = "health_check_crash"
 	LifecycleOriginWorkerDrain             LifecycleOrigin = "worker_drain"
 	LifecycleOriginSpawnFailure            LifecycleOrigin = "spawn_failure"

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -797,6 +797,20 @@ hot_idle_retired() { # org password catalog cpu memory
   fail "hot-idle retire: cpu=$cpu worker still present after ~4m (TTL=1m) — hot-idle reaper not retiring idle workers (the idle-leak regression)"
 }
 
+# NOTE — drain-time idle-Hot release (OrgRouter.ReleaseIdleHotWorkers, the #832
+# redesign): when a CP enters drain it now parks its idle (zero-session) Hot
+# workers into hot_idle at drain START, so the unfenced hot-idle TTL reaper
+# reclaims them during the (possibly unbounded) drain wait instead of leaving
+# them pinned until the CP is declared expired and the owner-expired-fenced
+# orphan reaper picks them up. This closes the stuck-Hot/0-session leak that
+# accumulated across CP rollout generations. It is NOT asserted directly in-Job:
+# doing so would require draining the live CP pod (whole-Job blast radius across
+# every org lane below) AND fault-injecting a stuck Hot/0-session worker, neither
+# deterministic here. The two ends ARE covered: the sweep selection (park idle
+# Hot, skip busy, no session decrement) by k8s_pool_test.go
+# (TestK8sPoolReleaseIdleHotWorkers*/ParkIdleHotWorker*), and the reaper
+# destination (hot_idle -> pod delete within TTL) by hot_idle_retired above.
+
 # ---- org default worker profile --------------------------------------------
 # Operators can give a tenant a server-side default worker shape + hot-idle TTL
 # (config-store columns default_worker_cpu/memory/ttl, set via the admin API).


### PR DESCRIPTION
## What

When a control-plane replica enters drain (SIGTERM → pod replacement during a rollout), it now parks its **idle (zero-session) Hot workers** into `hot_idle` at drain **start**, so the unfenced hot-idle TTL reaper reclaims them during the drain wait.

## Why

A draining CP previously held idle Hot workers in the `hot` state for the entire — possibly **unbounded** — drain wait, because `ShutdownAll` (which cleans idle workers) only runs *after* `waitForDrain` returns. A `Hot`/0-session worker is:

- **invisible to the hot-idle TTL reaper** (it filters `state=hot_idle`), and
- only reclaimable via the **orphan reaper**, which fences on the owner CP being *expired*.

So across CP rollout generations these workers accumulated as a **stuck-Hot vCPU leak** (the high-vCPU incident we root-caused: ~132 stuck `hot`/0-session pods for one org, falling through both cleanup paths).

## How (approach A — fix at the source)

Move the worker into the **unfenced** reclaim path at drain start instead of waiting for the owner CP to be declared expired:

- `K8sWorkerPool.ReleaseIdleHotWorkers` + `parkIdleHotWorker` — parks Hot/0-session workers **without** decrementing the session count (unlike the session-release callback `TransitionToHotIdleIfNoSessions`); extracted `commitHotIdleLocked` so both share one durable-first transition.
- Wired through `OrgRouter` / `OrgRouterInterface` / `orgRouterAdapter`, invoked from `drainAndShutdown` right after `flight.BeginDrain()`.
- Busy workers untouched; selection re-validates under the pool lock (a worker that became busy in between is skipped). No new sessions can land — PG accept is already closed and Flight is draining. Sessions that finish *during* drain park via the normal session-end path.
- New `LifecycleOriginDrainReleaseIdle` for log/metric observability — a nonzero rate during a rollout is the fix working.

## Tests

- Unit (`k8s_pool_test.go`): park idle Hot → hot_idle, skip busy, no session decrement.
- Harness note (`tests/e2e-mw-dev/harness.sh`) documents why the drain-time sweep itself is **not** asserted in-Job (would need draining the live CP pod = whole-Job blast radius + fault-injecting a stuck Hot/0-session worker, neither deterministic). Both ends are covered: the sweep selection by the unit tests, the reaper destination (`hot_idle` → pod delete within TTL) by the existing `hot_idle_retired` assertion.

## Supersedes #832

#832 tried to fix this on the **reaper** side and was found broken in review: its safety premise (a draining CP keeps `last_heartbeat_at` fresh on active workers) is false — `last_heartbeat_at` is only written on state transitions, not health-check success — and `RetireOrphanWorker` only retires when the owner CP is `expired`, never `draining`, so the new condition was also inert. This PR fixes it at the source instead. #832 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)