### PR TITLE
configstore: spare reclaimable Flight sessions in the hot-idle TTL reaper

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1009,21 +1009,42 @@ func (cs *ConfigStore) ClaimHotIdleWorker(ownerCPInstanceID, orgID, image string
 // keying off it let a periodically-refreshed worker reset its own TTL forever.
 // Legacy rows with a NULL hot_idle_since fall back to updated_at so they still
 // expire. A worker's ttl_minutes governs it; 0 falls back to defaultTTL
-// (default/legacy and unassigned rows).
+// (default/legacy and unassigned rows). Workers still backing a reclaimable
+// Flight session are spared (see reclaimableFlightSessionGuard).
 func (cs *ConfigStore) ListExpiredHotIdleWorkers(now time.Time, defaultTTL time.Duration) ([]WorkerRecord, error) {
 	defMins := int64(defaultTTL.Minutes())
 	if defMins < 0 {
 		defMins = 0
 	}
 	var workers []WorkerRecord
-	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("state = ? AND COALESCE(hot_idle_since, updated_at) + (CASE WHEN COALESCE(ttl_minutes, 0) > 0 THEN ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
+	clause, args := cs.reclaimableFlightSessionGuard()
+	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())+" AS w").
+		Where("w.state = ? AND COALESCE(w.hot_idle_since, w.updated_at) + (CASE WHEN COALESCE(w.ttl_minutes, 0) > 0 THEN w.ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
 			WorkerStateHotIdle, defMins, now).
+		Where(clause, args...).
 		Find(&workers).Error
 	if err != nil {
 		return nil, fmt.Errorf("list expired hot-idle workers: %w", err)
 	}
 	return workers, nil
+}
+
+// reclaimableFlightSessionGuard returns a correlated NOT-EXISTS clause (and its
+// args) that spares a worker row (aliased `w`) which still backs a reclaimable
+// Flight session (Active or Reconnecting). It mirrors the same exclusion in
+// ListOrphanedWorkers so the hot-idle TTL reaper does not retire a worker whose
+// customer is mid-reconnect by session token — a retire there would kill the
+// in-flight query at the moment they reconnect. Bounded by
+// ExpireFlightSessionRecords: once the session record is moved to a terminal
+// state, the worker is no longer protected.
+func (cs *ConfigStore) reclaimableFlightSessionGuard() (string, []any) {
+	flightTable := cs.runtimeTable((&FlightSessionRecord{}).TableName())
+	reclaimableSessionStates := []FlightSessionState{
+		FlightSessionStateActive,
+		FlightSessionStateReconnecting,
+	}
+	return "NOT EXISTS (SELECT 1 FROM " + flightTable + " AS f " +
+		"WHERE f.worker_id = w.worker_id AND f.state IN ?)", []any{reclaimableSessionStates}
 }
 
 // ListExpiredHotIdleWorkersForCP is the owner-scoped variant of
@@ -1039,9 +1060,11 @@ func (cs *ConfigStore) ListExpiredHotIdleWorkersForCP(ownerCPInstanceID string, 
 		defMins = 0
 	}
 	var workers []WorkerRecord
-	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Where("state = ? AND owner_cp_instance_id = ? AND COALESCE(hot_idle_since, updated_at) + (CASE WHEN COALESCE(ttl_minutes, 0) > 0 THEN ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
+	clause, args := cs.reclaimableFlightSessionGuard()
+	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())+" AS w").
+		Where("w.state = ? AND w.owner_cp_instance_id = ? AND COALESCE(w.hot_idle_since, w.updated_at) + (CASE WHEN COALESCE(w.ttl_minutes, 0) > 0 THEN w.ttl_minutes ELSE ? END) * interval '1 minute' <= ?",
 			WorkerStateHotIdle, ownerCPInstanceID, defMins, now).
+		Where(clause, args...).
 		Find(&workers).Error
 	if err != nil {
 		return nil, fmt.Errorf("list expired hot-idle workers for cp: %w", err)

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -381,6 +381,86 @@ func TestListExpiredHotIdleWorkersPerWorkerTTL(t *testing.T) {
 	}
 }
 
+// Regression: the hot-idle TTL reaper must NOT retire a hot-idle worker that
+// still backs a reclaimable (Active/Reconnecting) Flight session — the customer
+// is mid-reconnect by session token, and retiring the worker would kill their
+// in-flight query on reconnect. This mirrors the long-standing exclusion in
+// ListOrphanedWorkers. A worker with only a terminal (closed) Flight record, or
+// none at all, is still reaped once its TTL elapses.
+func TestListExpiredHotIdleWorkersSparesReclaimableFlightSessions(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	base := time.Now()
+	mkWorker := func(id int) {
+		if err := store.UpsertWorkerRecord(&configstore.WorkerRecord{
+			WorkerID:          id,
+			PodName:           fmt.Sprintf("duckgres-worker-flt-%d", id),
+			State:             configstore.WorkerStateHotIdle,
+			OrgID:             "analytics",
+			Image:             "duckgres:v2",
+			OwnerCPInstanceID: "cp:boot",
+			OwnerEpoch:        1,
+			LastHeartbeatAt:   base,
+			TTLMinutes:        5, // all well past TTL at base+30m
+		}); err != nil {
+			t.Fatalf("UpsertWorkerRecord(%d): %v", id, err)
+		}
+	}
+	mkSession := func(token string, workerID int, state configstore.FlightSessionState) {
+		if err := store.UpsertFlightSessionRecord(&configstore.FlightSessionRecord{
+			SessionToken: token,
+			Username:     "postgres",
+			OrgID:        "analytics",
+			WorkerID:     workerID,
+			OwnerEpoch:   1,
+			State:        state,
+			ExpiresAt:    base.Add(time.Hour),
+			LastSeenAt:   base,
+		}); err != nil {
+			t.Fatalf("UpsertFlightSessionRecord(%s): %v", token, err)
+		}
+	}
+
+	mkWorker(1) // no flight session         → reaped
+	mkWorker(2) // active flight session      → spared
+	mkWorker(3) // reconnecting flight session → spared
+	mkWorker(4) // closed flight session only → reaped
+	mkSession("tok-active", 2, configstore.FlightSessionStateActive)
+	mkSession("tok-reconnecting", 3, configstore.FlightSessionStateReconnecting)
+	mkSession("tok-closed", 4, configstore.FlightSessionStateClosed)
+
+	assertSpared := func(name string, expired []configstore.WorkerRecord) {
+		got := map[int]bool{}
+		for _, w := range expired {
+			got[w.WorkerID] = true
+		}
+		if !got[1] {
+			t.Errorf("%s: worker 1 (no flight session) should be reaped", name)
+		}
+		if got[2] {
+			t.Errorf("%s: worker 2 (active flight session) must be spared", name)
+		}
+		if got[3] {
+			t.Errorf("%s: worker 3 (reconnecting flight session) must be spared", name)
+		}
+		if !got[4] {
+			t.Errorf("%s: worker 4 (closed flight session only) should be reaped", name)
+		}
+	}
+
+	expired, err := store.ListExpiredHotIdleWorkers(base.Add(30*time.Minute), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkers: %v", err)
+	}
+	assertSpared("global", expired)
+
+	// The per-CP fallback reaper variant must spare them too.
+	expiredCP, err := store.ListExpiredHotIdleWorkersForCP("cp:boot", base.Add(30*time.Minute), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ListExpiredHotIdleWorkersForCP: %v", err)
+	}
+	assertSpared("per-cp", expiredCP)
+}
+
 // Regression: UpsertWorkerRecord must update the profile (cpu/mem/colocate) and
 // ttl_minutes columns on conflict. CreateSpawningWorkerSlot inserts a sized
 // worker's row with an empty profile, and the reserve/hot-idle persists set it

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -811,6 +811,19 @@ hot_idle_retired() { # org password catalog cpu memory
 # (TestK8sPoolReleaseIdleHotWorkers*/ParkIdleHotWorker*), and the reaper
 # destination (hot_idle -> pod delete within TTL) by hot_idle_retired above.
 
+# NOTE — the hot-idle TTL reaper now spares hot-idle workers that still back a
+# reclaimable (Active/Reconnecting) Flight session, mirroring the long-standing
+# exclusion in ListOrphanedWorkers (so a TTL reap can't kill a customer's query
+# at the moment they reconnect by session token). That sparing is a NEGATIVE
+# assertion over a multi-minute TTL window on a worker holding a live durable
+# Flight session — not deterministic to set up in-Job — so it is gated by the
+# real-Postgres regression test
+# TestListExpiredHotIdleWorkersSparesReclaimableFlightSessions
+# (tests/configstore/runtime_store_postgres_test.go), which asserts both the
+# global and per-CP reaper variants spare Active/Reconnecting sessions and still
+# reap workers with no session (or only a closed one). hot_idle_retired above
+# covers the positive (no Flight session -> reaped within TTL).
+
 # ---- org default worker profile --------------------------------------------
 # Operators can give a tenant a server-side default worker shape + hot-idle TTL
 # (config-store columns default_worker_cpu/memory/ttl, set via the admin API).


### PR DESCRIPTION
## What

The hot-idle TTL reaper (`ListExpiredHotIdleWorkers` / `...ForCP`, consumed by the leader janitor and the per-CP fallback reaper) now spares any `hot_idle` worker that still backs a reclaimable (`Active`/`Reconnecting`) Flight session — matching the long-standing `NOT EXISTS(flight_session_records ...)` exclusion in `ListOrphanedWorkers`.

## Why

The two worker-reclamation paths had asymmetric sparing semantics:
- `ListOrphanedWorkers` **excludes** workers with an Active/Reconnecting Flight session (a retire there would kill a customer's query at the moment they reconnect by session token).
- The hot-idle TTL reaper had **no** such check — it filtered purely on `state=hot_idle` + TTL.

So a `hot_idle` worker whose customer is mid-reconnect could be retired out from under the in-flight query. This surfaced during review of #835 (drain-time idle-Hot release). #835 itself can't trip the gap — it parks only `activeSessions==0` workers, which by construction have no in-memory Flight session — but the asymmetry is a latent footgun for any future caller, so this closes it.

## How

A shared `reclaimableFlightSessionGuard()` helper returns the correlated `NOT EXISTS` clause + args; both reaper queries now alias the worker table `w` and apply it. Bounded by `ExpireFlightSessionRecords` — once the session record goes terminal, the worker is no longer protected.

## Tests

- `TestListExpiredHotIdleWorkersSparesReclaimableFlightSessions` (real-Postgres): asserts **both** the global and per-CP reaper variants spare Active + Reconnecting sessions, and still reap workers with no session or only a `closed` one. Passes against the containerized Postgres.
- Harness note (`tests/e2e-mw-dev/harness.sh`) documents why the sparing — a negative assertion over a multi-minute TTL window on a worker holding a live durable Flight session — is gated by the unit test rather than exercised in-Job; the existing `hot_idle_retired` covers the positive (no session → reaped).

Independent of #835 (separate path); can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)