### PR TITLE
configstore: allocate worker IDs from a global sequence (fix cross-org pkey collision)

### DIFF
--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -682,6 +682,49 @@ func autoMigrateRuntimeTables(db *gorm.DB, runtimeSchema string) error {
 			return err
 		}
 	}
+
+	if err := ensureWorkerIDSequence(db, runtimeSchema); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureWorkerIDSequence creates the global worker-id sequence that
+// CreateSpawningWorkerSlot allocates from. It replaces the old
+// SELECT MAX(worker_id)+1 allocation, which was only serialized by a PER-ORG
+// advisory lock while worker_id is a GLOBAL primary key: two concurrent spawns
+// for DIFFERENT orgs (or with an empty org) read the same MAX and inserted the
+// same id, colliding on worker_records_pkey (SQLSTATE 23505). nextval() is
+// globally atomic, so it removes that race entirely.
+//
+// The sequence is seeded ONCE, just above the highest existing worker_id, and
+// deliberately NOT re-seeded on later startups: a re-seed could race a
+// concurrent nextval on a peer CP and move the sequence backward, reintroducing
+// the very collision it replaces. CREATE SEQUENCE IF NOT EXISTS makes a
+// concurrent first-startup create a no-op for the loser. Sequences are
+// non-transactional, so a rolled-back CreateSpawningWorkerSlot leaves an unused
+// id — gaps are fine; only uniqueness matters.
+func ensureWorkerIDSequence(db *gorm.DB, runtimeSchema string) error {
+	qs := `"` + quoteIdentifier(runtimeSchema) + `"`
+	seq := qs + `.worker_records_id_seq`
+
+	var exists bool
+	if err := db.Raw(`SELECT to_regclass(?) IS NOT NULL`, runtimeSchema+".worker_records_id_seq").Scan(&exists).Error; err != nil {
+		return fmt.Errorf("probe worker id sequence: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	var start int64
+	if err := db.Raw(`SELECT COALESCE(MAX(worker_id), 0) + 1 FROM ` + qs + `.worker_records`).Scan(&start).Error; err != nil {
+		return fmt.Errorf("seed worker id sequence: %w", err)
+	}
+	// START WITH is an integer literal (no user input); IF NOT EXISTS handles a
+	// concurrent peer creating it first (its START WITH wins, ours no-ops).
+	if err := db.Exec(fmt.Sprintf("CREATE SEQUENCE IF NOT EXISTS %s AS BIGINT START WITH %d", seq, start)).Error; err != nil {
+		return fmt.Errorf("create worker id sequence: %w", err)
+	}
 	return nil
 }
 
@@ -1373,8 +1416,13 @@ func (cs *ConfigStore) CreateSpawningWorkerSlot(ownerCPInstanceID, orgID, image 
 			}
 		}
 
+		// Allocate the worker_id from the global sequence (nextval is atomic
+		// across orgs and CPs). The old SELECT MAX(worker_id)+1 was only
+		// serialized by the per-org advisory lock above, so two concurrent
+		// spawns for different orgs picked the same id and collided on
+		// worker_records_pkey. See ensureWorkerIDSequence.
 		var workerID int64
-		if err := tx.Raw("SELECT COALESCE(MAX(worker_id), 0) + 1 FROM " + cs.runtimeTable((&WorkerRecord{}).TableName())).Scan(&workerID).Error; err != nil {
+		if err := tx.Raw("SELECT nextval(?::regclass)", cs.runtimeTable("worker_records_id_seq")).Scan(&workerID).Error; err != nil {
 			return err
 		}
 		now := time.Now()

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -855,6 +856,62 @@ func TestCreateSpawningWorkerSlotPostgres(t *testing.T) {
 	}
 	if persisted.State != configstore.WorkerStateSpawning {
 		t.Fatalf("expected persisted spawning state, got %q", persisted.State)
+	}
+}
+
+// Regression: concurrent CreateSpawningWorkerSlot calls for DIFFERENT orgs must
+// never allocate the same worker_id. The old SELECT MAX(worker_id)+1 allocation
+// was serialized only by a per-org advisory lock, so cross-org concurrency read
+// the same MAX and collided on worker_records_pkey (SQLSTATE 23505) — the flake
+// that was failing the e2e res1/res2 lanes. nextval() off the global sequence
+// makes allocation atomic across orgs.
+func TestCreateSpawningWorkerSlotConcurrentCrossOrgUniqueIDs(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	const n = 24
+	var wg sync.WaitGroup
+	ids := make([]int, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximize contention
+			// A distinct org per goroutine → distinct per-org advisory locks →
+			// the allocation step runs concurrently (the colliding scenario).
+			slot, err := store.CreateSpawningWorkerSlot(
+				"cp:boot", fmt.Sprintf("org-%d", i), "duckgres:test", "", "", 1,
+				"duckgres-worker-test", 0 /* uncapped */)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if slot == nil {
+				errs[i] = fmt.Errorf("goroutine %d: nil slot without cap", i)
+				return
+			}
+			ids[i] = slot.WorkerID
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	seen := map[int]int{} // worker_id -> goroutine that got it
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: CreateSpawningWorkerSlot errored (pre-fix: pkey collision): %v", i, errs[i])
+		}
+		if ids[i] <= 0 {
+			t.Fatalf("goroutine %d: non-positive worker id %d", i, ids[i])
+		}
+		if prev, dup := seen[ids[i]]; dup {
+			t.Fatalf("worker_id %d allocated to both goroutine %d and %d — collision not prevented", ids[i], prev, i)
+		}
+		seen[ids[i]] = i
+	}
+	if len(seen) != n {
+		t.Fatalf("expected %d distinct worker ids, got %d", n, len(seen))
 	}
 }
 

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1441,7 +1441,18 @@ res_body() { # org
 # The assertions are grouped into per-org LANES that run concurrently: all
 # worker churn (kills, drains, cold spawns, TTL reaps) is org-scoped, so lanes
 # for different orgs cannot interfere — and the wall-clock becomes the slowest
-# lane instead of the sum. Each lane runs in a background subshell with its
+# lane instead of the sum.
+#
+# This cross-org concurrency is ALSO the regression gate for the global
+# worker-id allocation fix (CreateSpawningWorkerSlot via nextval off a shared
+# sequence; see configstore.ensureWorkerIDSequence). The lanes below spawn
+# worker pods for DIFFERENT orgs at the same time against the SAME config store
+# — exactly the scenario where the old SELECT MAX(worker_id)+1 allocation (only
+# serialized by a per-org advisory lock) handed two orgs the same worker_id and
+# failed the spawn with worker_records_pkey (SQLSTATE 23505). A green multi-lane
+# run is the in-Job proof the collision is gone; the deterministic unit repro is
+# TestCreateSpawningWorkerSlotConcurrentCrossOrgUniqueIDs
+# (tests/configstore/runtime_store_postgres_test.go). Each lane runs in a background subshell with its
 # output captured to a file; the parent prints a heartbeat while lanes run and
 # replays each lane's log (prefixed) when it finishes. A lane's failure
 # (missing/nonzero rc file) fails the harness after all lanes settle, so one


### PR DESCRIPTION
## What

`CreateSpawningWorkerSlot` now allocates `worker_id` from a dedicated global Postgres **sequence** (`nextval`) instead of `SELECT MAX(worker_id)+1`.

## Why — this is the recurring e2e flake

`CreateSpawningWorkerSlot` computed the next id as `MAX(worker_id)+1` inside a transaction guarded **only** by a **per-org** advisory lock (`pg_advisory_xact_lock(duckgres:org:<orgID>)`). But `worker_id` is a **global** primary key, so two spawns racing for **different** orgs (or an empty org) took different/no locks, both read the same `MAX`, and both inserted the same id:

```
create spawning worker slot: ERROR: duplicate key value violates unique
constraint "worker_records_pkey" (SQLSTATE 23505)
```

That's the intermittent failure we kept hitting on the concurrent `res1`/`res2` org lanes (`one_session_per_worker`, cold-burst spawns) on **#834** and **#836** — and a latent rollout race in prod any time two CPs/orgs spawn at the same instant.

## How

- **`nextval` off a global sequence** is atomic across all orgs and CP replicas → no two spawns can ever pick the same id. The per-org advisory lock stays for its real purpose (making the org-cap count-then-insert atomic).
- Sequence is created in `autoMigrateRuntimeTables` via `ensureWorkerIDSequence`, **seeded once** just above the current `MAX(worker_id)` (so it never collides with existing rows) and **never re-seeded** — a re-seed could race a concurrent `nextval` on a peer CP and move the sequence backward, reintroducing the collision. `CREATE SEQUENCE IF NOT EXISTS` makes a concurrent first-startup create a no-op for the loser.
- Sequences are non-transactional, so a rolled-back slot creation just leaves a gap. Uniqueness, not gaplessness, is the requirement.

## Tests

- **`TestCreateSpawningWorkerSlotConcurrentCrossOrgUniqueIDs`** (real-Postgres): 24 concurrent cross-org spawns must all get distinct ids. I verified it **FAILS on the pre-fix `MAX+1` allocation** with the exact `worker_records_pkey (SQLSTATE 23505)` error, and passes with the sequence — a real regression gate.
- Harness note: the existing concurrent multi-org lanes (`res1`/`res2`/`cnpg` spawning for different orgs against one config store) **are** the in-Job regression gate; this is the scenario that was colliding.

Should clear the `e2e` flake on the spawn-heavy lanes for everyone. Independent of #835/#836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)