### PR TITLE
observe: record per-connection lifetime (histogram + disconnect duration_ms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Duckgres exposes Prometheus metrics on `:9090/metrics`. The metrics port is curr
 | Metric | Type | Description |
 |--------|------|-------------|
 | `duckgres_connections_open` | Gauge | Number of currently open client connections |
+| `duckgres_connection_duration_seconds{org}` | Histogram | Client connection lifetime, accept→disconnect (includes `_count`, `_sum`, `_bucket`); `_sum` is exact total connection-seconds (per org) with no scrape-integral bias. The disconnect log also carries `duration_ms` |
 | `duckgres_query_total{org,outcome}` | Counter | Total number of non-empty query attempts by terminal outcome (`success`, `error`, `canceled`) |
 | `duckgres_query_duration_seconds{org}` | Histogram | Simple/extended query execution latency (includes `_count`, `_sum`, `_bucket`); use `duckgres_query_total` for attempt totals |
 | `duckgres_auth_failures_total` | Counter | Total number of authentication failures |

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1323,6 +1323,13 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Create real clientConn with FlightExecutor and worker assignment
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
+	// Record the connection's full lifetime exactly once, on every exit path
+	// (clean disconnect, message-loop error, or handshake-completion failure):
+	// bumps duckgres_connection_duration_seconds (per org) and logs duration_ms.
+	defer func() {
+		dur := server.CloseConnectionMetrics(cc)
+		clog.Info("Client disconnected.", "duration_ms", dur.Milliseconds())
+	}()
 	if cp.orgRouter != nil && orgID != "" {
 		if icebergCfg, ok := cp.orgRouter.IcebergConfigForOrg(orgID); ok {
 			server.SetConnectionIcebergConfig(cc, icebergCfg)
@@ -1351,13 +1358,12 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		return
 	}
 
-	// Run message loop
+	// Run message loop. Disconnect log + duration histogram are emitted by the
+	// deferred CloseConnectionMetrics above on every return path.
 	if err := server.RunMessageLoop(cc); err != nil {
 		clog.Error("Message loop error.", "error", err)
 		return
 	}
-
-	clog.Info("Client disconnected.")
 }
 
 // workerDuckDBLimits derives DuckDB memory_limit and threads from the worker

--- a/server/conn_duration_test.go
+++ b/server/conn_duration_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// CloseConnectionMetrics must return the elapsed connection lifetime measured
+// from backendStart so the control plane can log duration_ms. The histogram
+// side effect is covered in server/observe; here we pin the returned duration
+// (the value the disconnect log reports).
+func TestCloseConnectionMetricsReturnsLifetime(t *testing.T) {
+	cc := &clientConn{orgID: "close-metrics-org", backendStart: time.Now().Add(-250 * time.Millisecond)}
+
+	dur := CloseConnectionMetrics(cc)
+
+	if dur < 250*time.Millisecond {
+		t.Fatalf("duration = %v, want >= 250ms", dur)
+	}
+	if dur > 5*time.Second {
+		t.Fatalf("duration = %v, implausibly large (backendStart not honoured?)", dur)
+	}
+}

--- a/server/exports.go
+++ b/server/exports.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/wire"
 )
@@ -148,6 +149,17 @@ func RunMessageLoop(cc *clientConn) error {
 	cc.server.registerConn(cc)
 	defer cc.server.unregisterConn(cc.pid)
 	return cc.messageLoop()
+}
+
+// CloseConnectionMetrics records the completed connection's lifetime in the
+// duckgres_connection_duration_seconds histogram (per org) and returns the
+// elapsed duration so the caller can log it. Call exactly once per connection
+// at teardown. backendStart is always set in NewClientConn, so the duration is
+// always meaningful for control-plane connections.
+func CloseConnectionMetrics(cc *clientConn) time.Duration {
+	d := time.Since(cc.backendStart)
+	observe.ObserveConnectionDuration(cc.orgID, d.Seconds())
+	return d
 }
 
 // InitMinimalServer initializes a Server struct with minimal fields for use

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -18,6 +18,26 @@ func IncrementOpenConnections() { connectionsGauge.Inc() }
 // DecrementOpenConnections decrements the open connections gauge.
 func DecrementOpenConnections() { connectionsGauge.Dec() }
 
+// connectionDurationHistogram observes the full lifetime of a client
+// connection (accept → disconnect) in seconds, labelled by org. It complements
+// the duckgres_connections_open gauge: integrating that gauge over time
+// approximates total connection-time, but a coarse scrape interval undercounts
+// connections shorter than the scrape window. This histogram records every
+// connection's true lifetime, so `_sum` gives exact total connection-seconds
+// (per org) with no scrape bias and the buckets give the lifetime distribution.
+// Org is empty for single-tenant/standalone connections. Buckets span 1s
+// (health probes / short clients) to 24h (long-lived pooled connections).
+var connectionDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_connection_duration_seconds",
+	Help:    "Client connection lifetime in seconds (accept to disconnect)",
+	Buckets: []float64{1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 18000, 36000, 86400},
+}, []string{"org"})
+
+// ObserveConnectionDuration records one completed connection's lifetime.
+func ObserveConnectionDuration(org string, seconds float64) {
+	connectionDurationHistogram.WithLabelValues(org).Observe(seconds)
+}
+
 // S3BytesReadTotal counts bytes read from S3 by DuckDB, labeled by org.
 // Bumped from EnrichSpanWithProfiling when DuckDB reports total_bytes_read
 // in its profiling output.

--- a/server/observe/metrics_test.go
+++ b/server/observe/metrics_test.go
@@ -1,0 +1,45 @@
+package observe
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func connDurationSample(t *testing.T, org string) (count uint64, sum float64) {
+	t.Helper()
+	observer, err := connectionDurationHistogram.GetMetricWithLabelValues(org)
+	if err != nil {
+		t.Fatalf("histogram labels %q: %v", org, err)
+	}
+	m := &dto.Metric{}
+	if err := observer.(interface{ Write(*dto.Metric) error }).Write(m); err != nil {
+		t.Fatalf("histogram write labels %q: %v", org, err)
+	}
+	return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
+}
+
+// ObserveConnectionDuration must record exactly one sample per call and add the
+// observed seconds to the per-org sum — _sum is the load-bearing series for
+// exact total connection-seconds (no scrape-integral bias). Verifies org
+// labelling is honoured so per-org slicing works.
+func TestObserveConnectionDurationRecordsPerOrgSample(t *testing.T) {
+	const org = "conn-duration-test-org"
+	countBefore, sumBefore := connDurationSample(t, org)
+
+	ObserveConnectionDuration(org, 12.5)
+	ObserveConnectionDuration(org, 7.5)
+
+	countAfter, sumAfter := connDurationSample(t, org)
+	if countAfter != countBefore+2 {
+		t.Fatalf("sample count = %d, want %d", countAfter, countBefore+2)
+	}
+	if got := sumAfter - sumBefore; got != 20.0 {
+		t.Fatalf("sum delta = %v, want 20", got)
+	}
+
+	// A different org must not see those samples (label isolation).
+	if c, _ := connDurationSample(t, "conn-duration-other-org"); c != 0 {
+		t.Fatalf("unrelated org sample count = %d, want 0", c)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2747,10 +2747,20 @@ func (s *Server) handleConnectionInProcess(conn net.Conn, remoteAddr net.Addr) {
 		conn:   conn,
 	}
 
-	if err := c.serve(); err != nil {
-		slog.Error("Connection error.", "user", c.username, "remote_addr", remoteAddr, "error", err)
+	err := c.serve()
+	// backendStart is set early in serve() (after the startup message); if serve
+	// failed before that (e.g. TLS/startup error) it is zero — skip the histogram
+	// and report duration_ms=0 rather than a bogus since-epoch value.
+	var durMs int64
+	if !c.backendStart.IsZero() {
+		d := time.Since(c.backendStart)
+		durMs = d.Milliseconds()
+		observe.ObserveConnectionDuration(c.orgID, d.Seconds())
+	}
+	if err != nil {
+		slog.Error("Connection error.", "user", c.username, "remote_addr", remoteAddr, "duration_ms", durMs, "error", err)
 	} else {
-		slog.Info("Client disconnected.", "user", c.username, "remote_addr", remoteAddr)
+		slog.Info("Client disconnected.", "user", c.username, "remote_addr", remoteAddr, "duration_ms", durMs)
 	}
 }
 

--- a/server/worker.go
+++ b/server/worker.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/server/auth"
+	"github.com/posthog/duckgres/server/observe"
 )
 
 // Exit codes for child processes
@@ -369,6 +370,12 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 	// In process isolation mode each child only sees itself.
 	srv.registerConn(clientConn)
 
+	// Record the connection's full lifetime once on exit (orgID is empty in the
+	// single-host process-isolation backend; the histogram still aggregates).
+	defer func() {
+		observe.ObserveConnectionDuration(clientConn.orgID, time.Since(clientConn.backendStart).Seconds())
+	}()
+
 	// Ensure cleanup on exit
 	defer func() {
 		if clientConn.executor != nil {
@@ -404,7 +411,8 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 			slog.Error("Message loop error", "error", err)
 			return ExitError
 		}
-		slog.Info("Client disconnected cleanly", "user", username, "remote_addr", cfg.RemoteAddr)
+		slog.Info("Client disconnected cleanly", "user", username, "remote_addr", cfg.RemoteAddr,
+			"duration_ms", time.Since(clientConn.backendStart).Milliseconds())
 		return ExitSuccess
 
 	case <-shutdownCtx.Done():

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -358,6 +358,37 @@ malformed_startup_resilience() { # org password
   [ "$v" = "1" ] || fail "CP stopped serving after malformed startup (got '$v')"
 }
 
+# Connection lifetime is recorded at disconnect: the CP's per-connection teardown
+# (control.go defer -> server.CloseConnectionMetrics) bumps the per-org
+# duckgres_connection_duration_seconds histogram AND stamps duration_ms on the
+# "Client disconnected." log. The histogram is the load-bearing series (its _sum
+# gives exact total connection-seconds with no scrape-integral bias), but the
+# :9090 metrics port is NetworkPolicy-blocked from this in-cluster Job and the
+# CP image ships no HTTP client to self-scrape — so we assert the log field,
+# which is emitted by the SAME teardown call that records the histogram. A
+# positive duration_ms proves real elapsed time was measured (guards an
+# always-zero / unset-backendStart regression).
+connection_duration_logged() { # org password
+  log "connection duration_ms stamped on disconnect for $1"
+  # psql opens and closes exactly one connection per call → a fresh disconnect.
+  v="$(pg "$1" "$2" ducklake 'SELECT 1')"
+  [ "$v" = "1" ] || fail "warmup query for duration assertion returned '$v'"
+  sleep 3 # let the disconnect log flush
+  ms=""
+  for p in $(k get pods -l app=duckgres-control-plane -o jsonpath='{.items[*].metadata.name}'); do
+    # logfmt: `... msg="Client disconnected." ... duration_ms=NN`. Take the max
+    # duration_ms seen on a disconnect line in the recent window across replicas.
+    m="$(k logs "$p" --since=180s 2>/dev/null \
+          | grep 'Client disconnected.' \
+          | grep -oE 'duration_ms=[0-9]+' \
+          | grep -oE '[0-9]+' \
+          | sort -nr | head -1)"
+    if [ -n "$m" ] && { [ -z "$ms" ] || [ "$m" -gt "$ms" ]; }; then ms="$m"; fi
+  done
+  [ -n "$ms" ] || fail "no 'Client disconnected.' log carrying duration_ms in last 180s (CP not recording connection lifetime)"
+  [ "$ms" -gt 0 ] || fail "disconnect duration_ms is $ms (want > 0 — backendStart not honoured?)"
+}
+
 # jsonb || must keep Postgres concatenation semantics through the full CP
 # transpile → worker DuckDB execute path (regression for #716: the transpiler
 # used to rewrite it to json_merge_patch, which REPLACED arrays instead of
@@ -1669,6 +1700,10 @@ main() {
   # ---- admin impersonation round-trip + audit (cnpg stack is warm now) ----
   admin_impersonation_audited "$CNPG"
 
+  # ---- connection-duration observability (any org; lanes already churned
+  #      many connect/disconnects, so the disconnect log is warm) ----
+  connection_duration_logged "$CNPG" "$cnpg_pw"
+
   # ---- cross-tenant isolation (cnpg vs ext) — needs both lanes done ----
   tenant_isolation "$CNPG" "$cnpg_pw" "$EXT" "$ext_pw"
 
@@ -1681,7 +1716,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + connection-duration-logged + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"


### PR DESCRIPTION
## Why

Total connection-duration for a day was only derivable by integrating the `duckgres_connections_open` gauge (area under concurrent-connections curve). That undercounts connections shorter than the scrape interval (60s in prod) and gives no per-org breakdown — fine for a rough aggregate, not for per-connection truth or per-org billing-grade numbers.

## What

**New metric `duckgres_connection_duration_seconds{org}`** (histogram, buckets 1s→24h). Its `_sum` is exact total connection-seconds per org with no scrape-integral bias; buckets give the lifetime distribution. Exposed on `:9090/metrics` like the existing gauge.

Recorded exactly once per connection at teardown via new `server.CloseConnectionMetrics(cc)`, on **every** client-connection termination path:

| Path | Notes |
|---|---|
| Control plane (remote/prod) | `defer` at conn create → records on clean exit, message-loop error, and handshake-completion failure (the old code logged disconnect only on the clean path) |
| Standalone in-process | guards a zero `backendStart` (pre-startup failures) |
| Process-isolation worker | `defer` + clean-disconnect log |

The same teardown also stamps **`duration_ms`** on the `Client disconnected.` log.

## Usage

- Exact total connection-seconds for a day, per org: `increase(duckgres_connection_duration_seconds_sum[1d])`
- Distribution: the `_bucket` series / `histogram_quantile(...)`
- Retroactive days (before this ships) still need the gauge integral.

## Tests

- `server/observe/metrics_test.go` — sample count, `_sum` delta, per-org label isolation
- `server/conn_duration_test.go` — `CloseConnectionMetrics` returns true lifetime
- `tests/e2e-mw-dev/harness.sh::connection_duration_logged` — drives a connect/disconnect, asserts a recent `Client disconnected.` log carries a **positive** `duration_ms` (guards an always-zero / unset-`backendStart` regression). The `:9090` metrics port is NetworkPolicy-blocked from the in-cluster Job and the CP image (debian-slim) ships no HTTP client to self-scrape, so we assert the log field — emitted by the same teardown call that records the histogram. Documented inline.
- README metrics table updated.

Build (default + `-tags kubernetes`), vet, gofmt, unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)