### PR TITLE
admin: denser tables, live query age, worker resources, duckling visibility + drift

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -31,6 +31,9 @@ type WorkerStatus struct {
 	Org            string `json:"org"`
 	ActiveSessions int    `json:"active_sessions"`
 	Status         string `json:"status"`
+	CPU            string `json:"cpu"`
+	Memory         string `json:"memory"`
+	TTLSeconds     int    `json:"ttl_seconds"`
 }
 
 // SessionStatus represents an active session for the API.

--- a/controlplane/admin/audit.go
+++ b/controlplane/admin/audit.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -16,19 +17,19 @@ import (
 // statement writes a row. SQL text is stored already-redacted by the caller —
 // never store raw secret DDL here.
 type AdminAuditEntry struct {
-	ID         uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
-	Timestamp  time.Time `gorm:"index" json:"ts"`
-	Actor      string    `gorm:"index" json:"actor"`  // SSO email or "internal-secret"
-	Role       string    `json:"role"`                // viewer/admin
-	Source     string    `json:"source"`              // sso / internal-secret
-	Action     string    `gorm:"index" json:"action"` // e.g. "config.update", "impersonate.query"
-	Method     string    `json:"method"`
-	Path       string    `json:"path"`
-	Org        string    `gorm:"index" json:"org"`
-	TargetUser string    `json:"target_user"`
-	SQLRedacted string   `json:"sql_redacted"`
-	Status     int       `json:"status"`
-	RemoteAddr string    `json:"remote_addr"`
+	ID          uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	Timestamp   time.Time `gorm:"index" json:"ts"`
+	Actor       string    `gorm:"index" json:"actor"`  // SSO email or "internal-secret"
+	Role        string    `json:"role"`                // viewer/admin
+	Source      string    `json:"source"`              // sso / internal-secret
+	Action      string    `gorm:"index" json:"action"` // e.g. "config.update", "impersonate.query"
+	Method      string    `json:"method"`
+	Path        string    `json:"path"`
+	Org         string    `gorm:"index" json:"org"`
+	TargetUser  string    `json:"target_user"`
+	SQLRedacted string    `json:"sql_redacted"`
+	Status      int       `json:"status"`
+	RemoteAddr  string    `json:"remote_addr"`
 }
 
 // TableName pins the audit table name in the config-store database.
@@ -96,15 +97,20 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 		if c.GetBool(ctxAuditHandledKey) {
 			return
 		}
+		// Operators routes key the target on :email; org user routes on :username.
+		targetUser := c.Param("username")
+		if targetUser == "" {
+			targetUser = c.Param("email")
+		}
 		id := IdentityFromContext(c)
 		entry := &AdminAuditEntry{
-			Action: "config." + actionVerb(c.Request.Method),
+			Action: auditActionFor(c.Request.Method, c.Request.URL.Path),
 			Method: c.Request.Method,
 			// Resolved path (not the route template) so "who changed which
 			// user/secret" is answerable from the log.
 			Path:       c.Request.URL.Path,
 			Org:        c.Param("id"),
-			TargetUser: c.Param("username"),
+			TargetUser: targetUser,
 			Status:     c.Writer.Status(),
 			RemoteAddr: c.ClientIP(),
 		}
@@ -116,6 +122,39 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 }
 
 const ctxAuditHandledKey = "duckgres_audit_handled"
+
+// auditActionFor derives a resource-specific audit Action ("<resource>.<verb>")
+// from the request method and path. It tolerates both the resolved path
+// (c.Request.URL.Path, e.g. "/api/v1/orgs/acme/users/bob") and the route
+// template (c.FullPath()), and an optional "/api/v1" version prefix. Unknown
+// shapes fall back to the generic "config.<verb>".
+func auditActionFor(method, path string) string {
+	verb := actionVerb(method)
+	segs := strings.FieldsFunc(path, func(r rune) bool { return r == '/' })
+	// Drop a leading API version prefix so segs[0] is the resource.
+	if len(segs) >= 2 && segs[0] == "api" && segs[1] == "v1" {
+		segs = segs[2:]
+	}
+	if len(segs) == 0 {
+		return "config." + verb
+	}
+	switch segs[0] {
+	case "operators":
+		return "operators." + verb
+	case "orgs":
+		// Sub-resources under an org get their own action; the org row itself
+		// (and anything else) is generic config.
+		for _, s := range segs[1:] {
+			switch s {
+			case "warehouse":
+				return "warehouse." + verb
+			case "users":
+				return "user." + verb
+			}
+		}
+	}
+	return "config." + verb
+}
 
 func actionVerb(method string) string {
 	switch method {

--- a/controlplane/admin/audit_test.go
+++ b/controlplane/admin/audit_test.go
@@ -1,0 +1,40 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestAuditActionFor pins the resource-specific Action derivation: operators,
+// org-warehouse, and org-user mutations each get their own prefix, and anything
+// else falls back to the generic config.<verb>. Both the resolved path (with the
+// /api/v1 version prefix) and the bare route shape must resolve identically.
+func TestAuditActionFor(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{"operator upsert", http.MethodPost, "/api/v1/operators", "operators.create"},
+		{"operator delete by email", http.MethodDelete, "/api/v1/operators/alice@example.com", "operators.delete"},
+		{"operator delete no prefix", http.MethodDelete, "/operators/:email", "operators.delete"},
+		{"org user delete", http.MethodDelete, "/api/v1/orgs/acme/users/bob", "user.delete"},
+		{"org user update", http.MethodPut, "/api/v1/orgs/acme/users/bob", "user.update"},
+		{"warehouse put", http.MethodPut, "/api/v1/orgs/acme/warehouse", "warehouse.update"},
+		{"warehouse pinning patch", http.MethodPatch, "/api/v1/orgs/acme/warehouse/pinning", "warehouse.update"},
+		{"org create", http.MethodPost, "/api/v1/orgs", "config.create"},
+		{"org update", http.MethodPut, "/api/v1/orgs/acme", "config.update"},
+		{"top-level users create", http.MethodPost, "/api/v1/users", "config.create"},
+		{"unknown resource", http.MethodPost, "/api/v1/something", "config.create"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := auditActionFor(tc.method, tc.path); got != tc.want {
+				t.Fatalf("auditActionFor(%q, %q) = %q, want %q", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/controlplane/admin/ducklings_drift.go
+++ b/controlplane/admin/ducklings_drift.go
@@ -1,0 +1,154 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// DucklingChecker is the slice of the Duckling k8s client the drift finder
+// needs. Declared here so the admin package doesn't import provisioner;
+// *provisioner.DucklingClient satisfies it.
+type DucklingChecker interface {
+	CRStatus(ctx context.Context, orgID string) (present, ready bool, err error)
+	ListCRNames(ctx context.Context) ([]string, error)
+}
+
+// driftHandler finds drift between config-store warehouses and live Duckling
+// CRs in the cluster.
+type driftHandler struct {
+	store   *configstore.ConfigStore
+	checker DucklingChecker
+}
+
+// driftEntry is one anomaly in the drift report. Only anomalies are emitted —
+// healthy warehouses are omitted.
+type driftEntry struct {
+	Org            string `json:"org"`
+	DucklingName   string `json:"duckling_name"`
+	WarehouseState string `json:"warehouse_state"`
+	CRPresent      bool   `json:"cr_present"`
+	CRReady        bool   `json:"cr_ready"`
+	Issue          string `json:"issue"`
+	Message        string `json:"message"`
+}
+
+// driftCheckTimeout bounds the whole handler: each warehouse triggers at least
+// one k8s GET plus a namespace LIST, which can be slow on a large cluster.
+const driftCheckTimeout = 15 * time.Second
+
+// RegisterDucklingsDrift wires GET /ducklings/drift. Admin-only via a
+// per-route RequireAdmin so the gate travels with the route (mirrors
+// operators_api.go). checker may be nil (Duckling client unavailable) — the
+// handler then degrades to {"available": false}.
+func RegisterDucklingsDrift(r *gin.RouterGroup, store *configstore.ConfigStore, checker DucklingChecker) {
+	h := &driftHandler{store: store, checker: checker}
+	r.GET("/ducklings/drift", RequireAdmin(), h.findDrift)
+}
+
+func (h *driftHandler) findDrift(c *gin.Context) {
+	// When the Duckling client is unavailable (out-of-cluster, RBAC, etc.)
+	// degrade gracefully rather than 500 — the UI can show "unavailable".
+	if h.checker == nil {
+		c.JSON(http.StatusOK, gin.H{"available": false, "checked": 0, "entries": []driftEntry{}})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), driftCheckTimeout)
+	defer cancel()
+
+	warehouses, err := h.store.ListWarehouses()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	entries := make([]driftEntry, 0)
+	// expected holds every CR name a warehouse legitimately maps to, so the
+	// orphan pass below doesn't flag a CR that simply uses the legacy
+	// (hyphen-stripped) name.
+	expected := make(map[string]struct{}, len(warehouses)*2)
+
+	for i := range warehouses {
+		wh := warehouses[i]
+		orgID := wh.OrgID
+		name := wh.DucklingName
+		if name == "" {
+			// Fallback for rows the backfill missed; mirrors
+			// provisioner.ducklingName (lowercased org ID).
+			name = strings.ToLower(orgID)
+		}
+		expected[name] = struct{}{}
+		// Also expect the canonical and legacy (hyphen-stripped) variants so
+		// pre-rename CRs aren't misreported as orphans.
+		expected[strings.ToLower(orgID)] = struct{}{}
+		expected[strings.ReplaceAll(strings.ToLower(orgID), "-", "")] = struct{}{}
+
+		present, ready, cerr := h.checker.CRStatus(ctx, orgID)
+		if cerr != nil {
+			entries = append(entries, driftEntry{
+				Org:            orgID,
+				DucklingName:   name,
+				WarehouseState: string(wh.State),
+				Issue:          "check_error",
+				Message:        "failed to check Duckling CR: " + cerr.Error(),
+			})
+			continue
+		}
+
+		entry := driftEntry{
+			Org:            orgID,
+			DucklingName:   name,
+			WarehouseState: string(wh.State),
+			CRPresent:      present,
+			CRReady:        ready,
+		}
+		switch {
+		case !present:
+			entry.Issue = "missing"
+			entry.Message = "warehouse exists but Duckling CR not found"
+		case present && !ready:
+			entry.Issue = "not_ready"
+			entry.Message = "Duckling CR present but not Ready"
+		case present && ready && wh.State != configstore.ManagedWarehouseStateReady:
+			entry.Issue = "state_mismatch"
+			entry.Message = fmt.Sprintf("CR healthy but warehouse state is %s", wh.State)
+		default:
+			// Healthy: CR present, ready, and warehouse state Ready. Skip.
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	// Orphan pass: any live CR not mapped by some warehouse row.
+	names, err := h.checker.ListCRNames(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	for _, crName := range names {
+		if _, ok := expected[crName]; ok {
+			continue
+		}
+		entries = append(entries, driftEntry{
+			Org:          "",
+			DucklingName: crName,
+			CRPresent:    true,
+			Issue:        "orphan",
+			Message:      "Duckling CR with no warehouse row",
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"available": true,
+		"checked":   len(warehouses),
+		"entries":   entries,
+	})
+}

--- a/controlplane/admin/live.go
+++ b/controlplane/admin/live.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,25 +13,28 @@ import (
 // QueryStatus is a currently-running query/session with its live progress,
 // sliceable by org and user.
 type QueryStatus struct {
-	Org        string  `json:"org"`
-	User       string  `json:"user"`
-	PID        int32   `json:"pid"`
-	WorkerID   int     `json:"worker_id"`
-	Protocol   string  `json:"protocol"`
-	Percentage float64 `json:"percentage"`
-	Rows       uint64  `json:"rows"`
-	TotalRows  uint64  `json:"total_rows"`
-	Stalled    bool    `json:"stalled"`
+	Org        string    `json:"org"`
+	User       string    `json:"user"`
+	PID        int32     `json:"pid"`
+	WorkerID   int       `json:"worker_id"`
+	Protocol   string    `json:"protocol"`
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	Percentage float64   `json:"percentage"`
+	Rows       uint64    `json:"rows"`
+	TotalRows  uint64    `json:"total_rows"`
+	Stalled    bool      `json:"stalled"`
 }
 
 // FleetStat is a cluster-wide worker count grouped by image/state/binding,
 // from the durable runtime store (the source of truth for hot-idle/spawning/
 // draining counts the in-memory session map cannot see).
 type FleetStat struct {
-	Image   string `json:"image"`
-	State   string `json:"state"`
-	Binding string `json:"binding"`
-	Count   int64  `json:"count"`
+	Image       string  `json:"image"`
+	State       string  `json:"state"`
+	Binding     string  `json:"binding"`
+	Count       int64   `json:"count"`
+	CPUCores    float64 `json:"cpu_cores"`
+	MemoryBytes int64   `json:"memory_bytes"`
 }
 
 // CPInstance is a live control-plane replica.

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -11,10 +11,12 @@ import {
 } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { POLL } from "@/lib/query";
+import { useIdentity } from "@/components/IdentityProvider";
 import type {
   AuditEntry,
   ClusterStatus,
   CreateUserBody,
+  DucklingDriftResponse,
   FleetStat,
   ImpersonateBody,
   ManagedWarehouse,
@@ -121,6 +123,26 @@ export function useUpdateWarehouse(id: string) {
   return useMutation({
     mutationFn: (body: Partial<ManagedWarehouse>) => api.updateWarehouse(id, body),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["orgs", id, "warehouse"] }),
+  });
+}
+
+// ---- ducklings (admin-only) ----
+
+const EMPTY_DRIFT: DucklingDriftResponse = { available: false, checked: 0, entries: [] };
+
+// GET /ducklings/drift — the endpoint 403s for viewers, so we only fire it for
+// admins. Any failure (403/404/503/network) degrades quietly to an empty,
+// unavailable report rather than surfacing an error toast.
+export function useDucklingDrift() {
+  const { isAdmin } = useIdentity();
+  return useQuery<DucklingDriftResponse>({
+    queryKey: ["ducklings", "drift"],
+    queryFn: () =>
+      tolerateStatus<DucklingDriftResponse>(EMPTY_DRIFT, 403, 404, 503)(api.getDucklingDrift()).catch(
+        () => EMPTY_DRIFT,
+      ),
+    enabled: isAdmin,
+    refetchInterval: POLL.normal,
   });
 }
 

--- a/controlplane/admin/ui/src/lib/api.ts
+++ b/controlplane/admin/ui/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ClusterStatus,
   CreateUserBody,
   CPInstance,
+  DucklingDriftResponse,
   FleetStat,
   ImpersonateBody,
   Me,
@@ -121,6 +122,9 @@ export const api = {
   getWarehouse: (id: string) => get<ManagedWarehouse>(`/orgs/${enc(id)}/warehouse`),
   updateWarehouse: (id: string, body: Partial<ManagedWarehouse>) =>
     put<ManagedWarehouse>(`/orgs/${enc(id)}/warehouse`, body),
+
+  // ducklings (admin-only)
+  getDucklingDrift: () => get<DucklingDriftResponse>("/ducklings/drift"),
 
   // users
   listUsers: () => get<OrgUser[]>("/users"),

--- a/controlplane/admin/ui/src/lib/format.ts
+++ b/controlplane/admin/ui/src/lib/format.ts
@@ -81,8 +81,39 @@ export function fmtAge(ts: string | number | Date | null | undefined): string {
   return `${days}d ${h % 24}h`;
 }
 
+// Humanize a duration in seconds, e.g. 1800 → "30m", 3600 → "1h", 5400 → "1h 30m".
+// Returns "—" for 0/unset (the backend uses 0 to mean "default").
+export function fmtDuration(seconds: number | null | undefined): string {
+  if (seconds == null || Number.isNaN(seconds) || seconds <= 0) return "—";
+  const s = Math.floor(seconds);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) {
+    const rem = m % 60;
+    return rem ? `${h}h ${rem}m` : `${h}h`;
+  }
+  const days = Math.floor(h / 24);
+  const remH = h % 24;
+  return remH ? `${days}d ${remH}h` : `${days}d`;
+}
+
 export function isZeroTime(ts: string | null | undefined): boolean {
   return !ts || ts.startsWith(ZERO_TIME);
+}
+
+// The Duckling (managed warehouse) CR name is the org ID lowercased, hyphens
+// preserved.
+export function ducklingName(orgName: string): string {
+  return orgName.toLowerCase();
+}
+
+// A Duckling is broken/unhealthy when its warehouse row exists but the overall
+// state is failed or deleted.
+export function ducklingBroken(state: string | undefined): boolean {
+  const s = (state ?? "").toLowerCase();
+  return s === "failed" || s === "deleted";
 }
 
 // A SQL statement is a "read" if it begins (ignoring leading comments/whitespace)

--- a/controlplane/admin/ui/src/pages/Live.tsx
+++ b/controlplane/admin/ui/src/pages/Live.tsx
@@ -9,8 +9,9 @@ import { ProgressBar } from "@/components/ProgressBar";
 import { AdminGate } from "@/components/AdminOnly";
 import { EmptyState } from "@/components/states";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCancelSession, useQueries, useSessions } from "@/hooks/useApi";
-import { fmtInt } from "@/lib/format";
+import { fmtAge, fmtInt, fmtTime } from "@/lib/format";
 
 export function Live() {
   const queries = useQueries();
@@ -80,6 +81,7 @@ export function Live() {
                     <TableHead>PID</TableHead>
                     <TableHead>Org</TableHead>
                     <TableHead>User</TableHead>
+                    <TableHead>Started</TableHead>
                     <TableHead>Worker</TableHead>
                     <TableHead>Protocol</TableHead>
                     <TableHead className="w-56">Progress</TableHead>
@@ -92,25 +94,38 @@ export function Live() {
                     // progress reported yet" → indeterminate animation.
                     const pct = q.percentage > 0 ? q.percentage : undefined;
                     return (
-                      <TableRow key={`${q.pid}-${q.worker_id}`}>
+                      <TableRow key={`${q.pid}-${q.worker_id}`} className="[&>td]:py-1.5">
                         <TableCell className="font-mono text-xs">{q.pid}</TableCell>
                         <TableCell className="font-mono text-xs">{q.org}</TableCell>
                         <TableCell className="font-mono text-xs">{q.user || "—"}</TableCell>
+                        <TableCell className="font-mono text-xs tabular-nums text-muted-foreground">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span>{fmtAge(q.started_at)}</span>
+                            </TooltipTrigger>
+                            <TooltipContent>{fmtTime(q.started_at)}</TooltipContent>
+                          </Tooltip>
+                        </TableCell>
                         <TableCell className="font-mono text-xs">#{q.worker_id}</TableCell>
                         <TableCell>
                           <Badge variant="outline">{q.protocol || "pg"}</Badge>
                         </TableCell>
                         <TableCell>
-                          <ProgressBar percentage={pct} stalled={q.stalled} indeterminate={pct == null} />
-                          <div className="mt-1 flex items-center justify-between text-[10px] text-muted-foreground">
-                            <span>
+                          <div className="flex items-center gap-2">
+                            <ProgressBar
+                              percentage={pct}
+                              stalled={q.stalled}
+                              indeterminate={pct == null}
+                              className="flex-1"
+                            />
+                            <span className="whitespace-nowrap text-[10px] text-muted-foreground">
                               {q.rows > 0
                                 ? `${fmtInt(q.rows)}${q.total_rows > 0 ? ` / ${fmtInt(q.total_rows)}` : ""} rows`
                                 : pct != null
                                   ? `${pct.toFixed(0)}%`
                                   : "running"}
                             </span>
-                            {q.stalled && <span className="text-warning">stalled</span>}
+                            {q.stalled && <span className="text-[10px] text-warning">stalled</span>}
                           </div>
                         </TableCell>
                         <TableCell className="text-right">
@@ -118,6 +133,7 @@ export function Live() {
                             <Button
                               variant="ghost"
                               size="sm"
+                              className="-my-1 h-6"
                               disabled={cancel.isPending}
                               onClick={() => cancel.mutate(q.pid)}
                             >
@@ -156,7 +172,7 @@ export function Live() {
                 </TableHeader>
                 <TableBody>
                   {liveSessions.map((s) => (
-                    <TableRow key={`${s.pid}-${s.worker_id}`}>
+                    <TableRow key={`${s.pid}-${s.worker_id}`} className="[&>td]:py-1.5">
                       <TableCell className="font-mono text-xs">{s.pid}</TableCell>
                       <TableCell className="font-mono text-xs">{s.org}</TableCell>
                       <TableCell className="font-mono text-xs">{s.user || "—"}</TableCell>
@@ -166,7 +182,13 @@ export function Live() {
                       </TableCell>
                       <TableCell className="text-right">
                         <AdminGate>
-                          <Button variant="ghost" size="sm" disabled={cancel.isPending} onClick={() => cancel.mutate(s.pid)}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="-my-1 h-6"
+                            disabled={cancel.isPending}
+                            onClick={() => cancel.mutate(s.pid)}
+                          >
                             <Ban className="h-4 w-4 text-destructive" /> Cancel
                           </Button>
                         </AdminGate>

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Save, Trash2, Warehouse } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Save, Trash2, Warehouse } from "lucide-react";
 import { PageBody, PageHeader } from "@/components/AppShell";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AdminGate } from "@/components/AdminOnly";
 import { JsonValue } from "@/components/JsonView";
 import { ErrorState, LoadingState } from "@/components/states";
@@ -20,7 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ApiError } from "@/lib/api";
-import { fmtTime } from "@/lib/format";
+import { ducklingBroken, ducklingName, fmtTime } from "@/lib/format";
 import {
   useDeleteOrg,
   useOrg,
@@ -296,6 +297,15 @@ function WarehousePanel({
   }, [data]);
 
   const notFound = error instanceof ApiError && error.status === 404;
+  const missing = notFound || !data;
+  const broken = !missing && ducklingBroken(data?.state);
+  const ducklingWarning = loading
+    ? null
+    : missing
+      ? "No duckling provisioned for this org"
+      : broken
+        ? `Duckling unhealthy (state: ${data?.state})`
+        : null;
 
   const save = async () => {
     setMsg(null);
@@ -316,6 +326,20 @@ function WarehousePanel({
         {data && <StateBadge state={data.state} />}
       </CardHeader>
       <CardContent className="space-y-4">
+        <div className="flex items-center justify-between rounded-md border border-border bg-background/40 px-3 py-2">
+          <div>
+            <div className="text-[10px] uppercase text-muted-foreground">Duckling</div>
+            <div className="font-mono text-xs">{data?.duckling_name || ducklingName(orgId)}</div>
+          </div>
+          {ducklingWarning && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <AlertTriangle className="h-4 w-4 text-warning" />
+              </TooltipTrigger>
+              <TooltipContent>{ducklingWarning}</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
         {loading ? (
           <LoadingState />
         ) : notFound || !data ? (

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -1,20 +1,22 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type ColumnDef } from "@tanstack/react-table";
-import { Building2, Search } from "lucide-react";
+import { AlertTriangle, Building2, Search } from "lucide-react";
 import { PageBody, PageHeader } from "@/components/AppShell";
 import { DataTable } from "@/components/DataTable";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
-import { useOrgs } from "@/hooks/useApi";
-import { fmtInt } from "@/lib/format";
-import type { Org } from "@/types/api";
+import { useDucklingDrift, useOrgs } from "@/hooks/useApi";
+import { ducklingBroken, ducklingName, fmtInt } from "@/lib/format";
+import type { DucklingDrift, DucklingDriftIssue, Org } from "@/types/api";
 
 export function Orgs() {
   const orgs = useOrgs();
+  const drift = useDucklingDrift();
   const navigate = useNavigate();
   const [filter, setFilter] = useState("");
 
@@ -64,12 +66,50 @@ export function Orgs() {
         id: "warehouse",
         header: "Warehouse",
         accessorFn: (o) => o.warehouse?.state ?? "",
-        cell: ({ row }) =>
-          row.original.warehouse ? (
-            <StateBadge state={row.original.warehouse.state} />
-          ) : (
-            <Badge variant="muted">none</Badge>
-          ),
+        cell: ({ row }) => {
+          const o = row.original;
+          if (!o.warehouse) return <Badge variant="muted">none</Badge>;
+          const broken = ducklingBroken(o.warehouse.state);
+          return (
+            <div className="flex items-center gap-1.5">
+              <StateBadge state={o.warehouse.state} />
+              {broken && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertTriangle className="h-4 w-4 text-warning" />
+                  </TooltipTrigger>
+                  <TooltipContent>Duckling unhealthy (state: {o.warehouse.state})</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          );
+        },
+      },
+      {
+        id: "duckling",
+        header: "Duckling",
+        accessorFn: (o) => (o.warehouse ? o.warehouse.duckling_name || ducklingName(o.name) : ""),
+        cell: ({ row }) => {
+          const o = row.original;
+          if (!o.warehouse) {
+            return (
+              <div className="flex items-center gap-1.5">
+                <span className="text-muted-foreground">—</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertTriangle className="h-4 w-4 text-warning" />
+                  </TooltipTrigger>
+                  <TooltipContent>No duckling provisioned for this org</TooltipContent>
+                </Tooltip>
+              </div>
+            );
+          }
+          return (
+            <span className="font-mono text-xs text-muted-foreground">
+              {o.warehouse.duckling_name || ducklingName(o.name)}
+            </span>
+          );
+        },
       },
     ],
     [],
@@ -93,9 +133,12 @@ export function Orgs() {
         }
       />
       <PageBody>
+        {drift.data?.available && drift.data.entries.length > 0 && (
+          <DriftBanner entries={drift.data.entries} onOpenOrg={(org) => navigate(`/orgs/${encodeURIComponent(org)}`)} />
+        )}
         <Card className="overflow-hidden">
           {orgs.isLoading ? (
-            <TableSkeleton cols={7} />
+            <TableSkeleton cols={8} />
           ) : orgs.isError ? (
             <ErrorState error={orgs.error} onRetry={() => orgs.refetch()} />
           ) : (
@@ -118,5 +161,70 @@ export function Orgs() {
         </Card>
       </PageBody>
     </>
+  );
+}
+
+// missing/orphan are hard breaks (a row or CR is absent) → destructive;
+// not_ready/state_mismatch are transient/soft drift → warning.
+const ISSUE_VARIANT: Record<DucklingDriftIssue, BadgeProps["variant"]> = {
+  missing: "destructive",
+  orphan: "destructive",
+  not_ready: "warning",
+  state_mismatch: "warning",
+  check_error: "destructive",
+};
+
+function DriftBanner({
+  entries,
+  onOpenOrg,
+}: {
+  entries: DucklingDrift[];
+  onOpenOrg: (org: string) => void;
+}) {
+  return (
+    <Card className="border-warning/40 bg-warning/5">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-warning">
+          <AlertTriangle className="h-4 w-4" />
+          {entries.length} duckling issue{entries.length === 1 ? "" : "s"} detected
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="max-h-64 space-y-1 overflow-y-auto">
+          {entries.map((e, i) => {
+            const hasOrg = e.org !== "";
+            return (
+              <div
+                key={`${e.org}:${e.duckling_name}:${i}`}
+                className="grid grid-cols-[8rem_1fr_7rem_7rem] items-center gap-3 rounded-md border border-border/60 bg-background/40 px-3 py-1.5"
+              >
+                {hasOrg ? (
+                  <button
+                    type="button"
+                    onClick={() => onOpenOrg(e.org)}
+                    className="truncate text-left font-mono text-xs font-medium hover:underline"
+                    title={e.org}
+                  >
+                    {e.org}
+                  </button>
+                ) : (
+                  <span className="text-xs text-muted-foreground">orphan</span>
+                )}
+                <span className="truncate font-mono text-xs text-muted-foreground" title={e.duckling_name}>
+                  {e.duckling_name || "—"}
+                </span>
+                <Badge variant={ISSUE_VARIANT[e.issue] ?? "warning"}>{e.issue}</Badge>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {e.warehouse_state || "—"}
+                </span>
+                {e.message && (
+                  <span className="col-span-4 text-xs text-muted-foreground">{e.message}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/controlplane/admin/ui/src/pages/Users.tsx
+++ b/controlplane/admin/ui/src/pages/Users.tsx
@@ -76,18 +76,24 @@ export function UsersPage() {
         header: "",
         enableSorting: false,
         cell: ({ row }) => (
-          <div className="flex justify-end gap-1">
-            <Button variant="ghost" size="icon" title="Persistent secrets" onClick={() => setSecretsFor(row.original)}>
-              <KeyRound className="h-4 w-4" />
+          <div className="-my-1 flex justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              title="Persistent secrets"
+              onClick={() => setSecretsFor(row.original)}
+            >
+              <KeyRound className="h-3.5 w-3.5" />
             </Button>
             <AdminGate>
-              <Button variant="ghost" size="icon" title="Edit" onClick={() => setEditing(row.original)}>
-                <Pencil className="h-4 w-4" />
+              <Button variant="ghost" size="icon" className="h-6 w-6" title="Edit" onClick={() => setEditing(row.original)}>
+                <Pencil className="h-3.5 w-3.5" />
               </Button>
             </AdminGate>
             <AdminGate>
-              <Button variant="ghost" size="icon" title="Delete" onClick={() => setDeleting(row.original)}>
-                <Trash2 className="h-4 w-4 text-destructive" />
+              <Button variant="ghost" size="icon" className="h-6 w-6" title="Delete" onClick={() => setDeleting(row.original)}>
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
               </Button>
             </AdminGate>
           </div>

--- a/controlplane/admin/ui/src/pages/Workers.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
 import { useFleet, useWorkers } from "@/hooks/useApi";
-import { fmtInt } from "@/lib/format";
+import { fmtBytes, fmtDuration, fmtInt } from "@/lib/format";
 import type { WorkerStatus } from "@/types/api";
 
 // Canonical lifecycle-state order for the rollup chips.
@@ -36,6 +36,8 @@ export function Workers() {
   }, [fleetRows]);
 
   const totalFleet = useMemo(() => fleetRows.reduce((n, f) => n + f.count, 0), [fleetRows]);
+  const totalCpu = useMemo(() => fleetRows.reduce((n, f) => n + (f.cpu_cores ?? 0), 0), [fleetRows]);
+  const totalMem = useMemo(() => fleetRows.reduce((n, f) => n + (f.memory_bytes ?? 0), 0), [fleetRows]);
 
   const columns = useMemo<ColumnDef<WorkerStatus, any>[]>(
     () => [
@@ -62,6 +64,34 @@ export function Workers() {
           return <span className={v > 0 ? "font-medium tabular-nums" : "tabular-nums text-muted-foreground"}>{v}</span>;
         },
       },
+      {
+        accessorKey: "cpu",
+        header: "CPU",
+        cell: ({ getValue }) => {
+          const v = getValue() as string;
+          return v ? <span className="tabular-nums">{v}</span> : <span className="text-muted-foreground">—</span>;
+        },
+      },
+      {
+        accessorKey: "memory",
+        header: "Memory",
+        cell: ({ getValue }) => {
+          const v = getValue() as string;
+          return v ? <span className="tabular-nums">{v}</span> : <span className="text-muted-foreground">—</span>;
+        },
+      },
+      {
+        accessorKey: "ttl_seconds",
+        header: "TTL",
+        cell: ({ getValue }) => {
+          const v = getValue() as number;
+          return v > 0 ? (
+            <span className="tabular-nums">{fmtDuration(v)}</span>
+          ) : (
+            <span className="text-muted-foreground">default</span>
+          );
+        },
+      },
     ],
     [],
   );
@@ -83,7 +113,11 @@ export function Workers() {
           <Card className="lg:col-span-2">
             <CardHeader className="flex-row items-center justify-between">
               <CardTitle>Fleet by state</CardTitle>
-              <Badge variant="secondary">{fmtInt(totalFleet)} total</Badge>
+              <div className="flex items-center gap-1.5">
+                <Badge variant="secondary">{fmtInt(totalFleet)} total</Badge>
+                <Badge variant="muted">{fmtInt(totalCpu)} cores</Badge>
+                <Badge variant="muted">{fmtBytes(totalMem)}</Badge>
+              </div>
             </CardHeader>
             <CardContent>
               {fleet.isError ? (
@@ -135,7 +169,7 @@ export function Workers() {
             <CardTitle>Session-holding workers</CardTitle>
           </CardHeader>
           {workers.isLoading ? (
-            <TableSkeleton cols={4} />
+            <TableSkeleton cols={7} />
           ) : workers.isError ? (
             <ErrorState error={workers.error} onRetry={() => workers.refetch()} />
           ) : (

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -115,6 +115,9 @@ export type WarehouseState =
 
 export interface ManagedWarehouse {
   org_id: string;
+  // The explicit Duckling CR name (provisioner-owned). May be "" on legacy rows
+  // that predate the field — callers fall back to ducklingName(org) in that case.
+  duckling_name: string;
   image: string;
   ducklake_version: string;
   warehouse_database: { endpoint: string; port: number };
@@ -171,6 +174,30 @@ export interface ManagedWarehouse {
   updated_at: string;
 }
 
+// ---- Duckling drift (admin-only) ----
+
+// One mismatch between a managed warehouse row and its Duckling custom resource.
+// For issue "orphan" (a CR with no warehouse row) `org` is "".
+export type DucklingDriftIssue = "missing" | "not_ready" | "state_mismatch" | "orphan" | "check_error";
+
+export interface DucklingDrift {
+  org: string;
+  duckling_name: string;
+  warehouse_state: string;
+  cr_present: boolean;
+  cr_ready: boolean;
+  issue: DucklingDriftIssue;
+  message: string;
+}
+
+// GET /api/v1/ducklings/drift → drift report (admin-only; 403s for viewers).
+// `available` is false when the check could not run.
+export interface DucklingDriftResponse {
+  available: boolean;
+  checked: number;
+  entries: DucklingDrift[];
+}
+
 // ---- Cluster status (confirmed) ----
 
 export interface OrgStatus {
@@ -195,6 +222,9 @@ export interface WorkerStatus {
   org: string;
   active_sessions: number;
   status: string; // "active" | "idle"
+  cpu: string; // e.g. "8"
+  memory: string; // e.g. "16Gi"
+  ttl_seconds: number; // 0 = default/unset
 }
 
 // GET /api/v1/sessions → SessionStatus[]. Note `user` (not `username`).
@@ -226,6 +256,8 @@ export interface FleetStat {
   state: WorkerLifecycleState;
   binding: string;
   count: number;
+  cpu_cores: number;
+  memory_bytes: number;
 }
 
 // GET /api/v1/cluster/instances → { instances: CPInstance[] }.
@@ -248,6 +280,7 @@ export interface RunningQuery {
   rows: number;
   total_rows: number;
   stalled: boolean;
+  started_at?: string; // RFC3339; may be absent/zero
 }
 
 // ---- Metrics (raw Prometheus / VictoriaMetrics) ----

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -29,11 +29,12 @@ func (p *clusterInfoProvider) RunningQueries() []admin.QueryStatus {
 	for org, stack := range stacks {
 		for _, s := range stack.Sessions.AllSessions() {
 			q := admin.QueryStatus{
-				Org:      org,
-				User:     s.Username,
-				PID:      s.PID,
-				WorkerID: s.WorkerID,
-				Protocol: s.Protocol,
+				Org:       org,
+				User:      s.Username,
+				PID:       s.PID,
+				WorkerID:  s.WorkerID,
+				Protocol:  s.Protocol,
+				StartedAt: s.StartedAt,
 			}
 			if prog := stack.Sessions.GetProgress(s.PID); prog != nil {
 				q.Percentage = prog.Percentage
@@ -58,10 +59,12 @@ func (p *clusterInfoProvider) WorkerFleet() ([]admin.FleetStat, error) {
 	out := make([]admin.FleetStat, 0, len(stats))
 	for _, s := range stats {
 		out = append(out, admin.FleetStat{
-			Image:   s.Image,
-			State:   string(s.State),
-			Binding: s.Binding,
-			Count:   s.Count,
+			Image:       s.Image,
+			State:       string(s.State),
+			Binding:     s.Binding,
+			Count:       s.Count,
+			CPUCores:    s.CPUCores,
+			MemoryBytes: s.MemoryBytes,
 		})
 	}
 	return out, nil

--- a/controlplane/configstore/migrations/000008_add_duckling_name.sql
+++ b/controlplane/configstore/migrations/000008_add_duckling_name.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- Store the k8s Duckling CR name explicitly instead of deriving it from the
+-- org ID at lookup time. Canonical name = lowercased org ID (mirrors
+-- provisioner.ducklingName). Backfill existing rows from lower(org_id) so the
+-- column is authoritative for both old and new warehouses.
+ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS duckling_name VARCHAR(255);
+
+UPDATE duckgres_managed_warehouses
+SET duckling_name = lower(org_id)
+WHERE duckling_name IS NULL OR duckling_name = '';
+
+-- +goose Down
+
+ALTER TABLE duckgres_managed_warehouses DROP COLUMN IF EXISTS duckling_name;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -282,6 +282,11 @@ type ManagedWarehouse struct {
 	Image           string `gorm:"size:512" json:"image"`
 	DuckLakeVersion string `gorm:"size:32" json:"ducklake_version"`
 
+	// DucklingName is the k8s Duckling CR name; canonical = lowercased org ID.
+	// Authoritative, not derived — stored explicitly so lookups stop guessing
+	// it from the org ID (see provisioner.ducklingName for the canonical form).
+	DucklingName string `gorm:"size:255" json:"duckling_name"`
+
 	WarehouseDatabase ManagedWarehouseDatabase       `gorm:"embedded;embeddedPrefix:warehouse_database_" json:"warehouse_database"`
 	MetadataStore     ManagedWarehouseMetadataStore  `gorm:"embedded;embeddedPrefix:metadata_store_" json:"metadata_store"`
 	DataStore         ManagedWarehouseDataStore      `gorm:"embedded;embeddedPrefix:data_store_" json:"data_store"`
@@ -380,10 +385,12 @@ const (
 // WorkerLifecycleStats is the grouped worker lifecycle state used for
 // cluster-wide worker observability.
 type WorkerLifecycleStats struct {
-	Image   string      `json:"image"`
-	State   WorkerState `json:"state"`
-	Binding string      `json:"binding"`
-	Count   int64       `json:"count"`
+	Image       string      `json:"image"`
+	State       WorkerState `json:"state"`
+	Binding     string      `json:"binding"`
+	Count       int64       `json:"count"`
+	CPUCores    float64     `json:"cpu_cores"`
+	MemoryBytes int64       `json:"memory_bytes"`
 }
 
 // WorkerRecord is the durable runtime coordination record for one worker pod.

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -17,6 +17,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // OrgUserKey is the composite key for org-scoped user lookups.
@@ -556,6 +557,16 @@ func (cs *ConfigStore) OnChange(fn func(old, new *Snapshot)) {
 
 // ListWarehousesByStates returns all warehouses with a state matching one of the given values.
 // This is a direct DB query, not snapshot-based, for use by the provisioning controller.
+// ListWarehouses returns every managed-warehouse row. Used by the admin drift
+// finder, which only consumes org_id, state, and duckling_name.
+func (cs *ConfigStore) ListWarehouses() ([]ManagedWarehouse, error) {
+	var warehouses []ManagedWarehouse
+	if err := cs.db.Find(&warehouses).Error; err != nil {
+		return nil, fmt.Errorf("list warehouses: %w", err)
+	}
+	return warehouses, nil
+}
+
 func (cs *ConfigStore) ListWarehousesByStates(states []ManagedWarehouseProvisioningState) ([]ManagedWarehouse, error) {
 	var warehouses []ManagedWarehouse
 	if err := cs.db.Where("state IN ?", states).Find(&warehouses).Error; err != nil {
@@ -747,16 +758,35 @@ func (cs *ConfigStore) runtimeTable(base string) string {
 }
 
 // ListWorkerLifecycleStats returns grouped cluster-wide active worker lifecycle
-// state by image and tenant binding for Prometheus observability.
+// state by image and tenant binding for Prometheus observability, with summed
+// cpu cores and memory bytes per group.
 func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error) {
 	// "neutral" (empty org_id) is legacy — every worker is org-bound from spawn
 	// now; the branch only matches pre-existing/legacy rows or single-tenant mode.
-	const bindingExpr = "CASE WHEN NULLIF(org_id, '') IS NULL THEN 'neutral' ELSE 'org_bound' END"
-	var out []WorkerLifecycleStats
-	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())).
-		Select("image, state, "+bindingExpr+" AS binding, COUNT(*)::bigint AS count").
-		Where("image <> ''").
-		Where("state IN ?", []WorkerState{
+	const bindingExpr = "CASE WHEN NULLIF(w.org_id, '') IS NULL THEN 'neutral' ELSE 'org_bound' END"
+	workerTable := cs.runtimeTable((&WorkerRecord{}).TableName())
+	// Org is a config table (not runtime-qualified); its default worker profile
+	// supplies the cpu/mem for workers that carry no explicit profile.
+	orgTable := (&Org{}).TableName()
+
+	// k8s quantity strings can't be summed in SQL, so pull the raw filtered rows
+	// (cpu/mem resolved to the org default when the worker carries none) and
+	// aggregate per (image,state,binding) group in Go below.
+	type workerRow struct {
+		Image   string
+		State   WorkerState
+		Binding string
+		CPU     string
+		Memory  string
+	}
+	var rows []workerRow
+	err := cs.db.Table(workerTable+" AS w").
+		Select("w.image AS image, w.state AS state, "+bindingExpr+" AS binding, "+
+			"COALESCE(NULLIF(w.profile_cpu, ''), o.default_worker_cpu, '') AS cpu, "+
+			"COALESCE(NULLIF(w.profile_memory, ''), o.default_worker_memory, '') AS memory").
+		Joins("LEFT JOIN "+orgTable+" AS o ON o.name = w.org_id").
+		Where("w.image <> ''").
+		Where("w.state IN ?", []WorkerState{
 			WorkerStateSpawning,
 			WorkerStateIdle,
 			WorkerStateReserved,
@@ -765,11 +795,42 @@ func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error
 			WorkerStateHotIdle,
 			WorkerStateDraining,
 		}).
-		Group("image, state, " + bindingExpr).
-		Order("image ASC, state ASC, binding ASC").
-		Scan(&out).Error
+		Order("w.image ASC, w.state ASC, " + bindingExpr + " ASC").
+		Scan(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("list worker lifecycle stats: %w", err)
+	}
+
+	// Aggregate count + summed cpu cores / memory bytes per group, preserving the
+	// image/state/binding ordering established by the query above.
+	type groupKey struct {
+		image   string
+		state   WorkerState
+		binding string
+	}
+	index := make(map[groupKey]int)
+	var out []WorkerLifecycleStats
+	for _, r := range rows {
+		k := groupKey{r.Image, r.State, r.Binding}
+		i, ok := index[k]
+		if !ok {
+			i = len(out)
+			index[k] = i
+			out = append(out, WorkerLifecycleStats{Image: r.Image, State: r.State, Binding: r.Binding})
+		}
+		out[i].Count++
+		// Unparseable/empty quantities (e.g. default profile with no org default)
+		// contribute 0.
+		if r.CPU != "" {
+			if q, err := resource.ParseQuantity(r.CPU); err == nil {
+				out[i].CPUCores += q.AsApproximateFloat64()
+			}
+		}
+		if r.Memory != "" {
+			if q, err := resource.ParseQuantity(r.Memory); err == nil {
+				out[i].MemoryBytes += q.Value()
+			}
+		}
 	}
 	return out, nil
 }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -95,12 +95,20 @@ func (a *orgRouterAdapter) AllWorkerStatuses() []admin.WorkerStatus {
 			if count == 0 {
 				status = "idle"
 			}
-			result = append(result, admin.WorkerStatus{
+			ws := admin.WorkerStatus{
 				ID:             wID,
 				Org:            name,
 				ActiveSessions: count,
 				Status:         status,
-			})
+			}
+			// Pod-shape (cpu/memory/ttl) of the session-holding worker; empty/zero
+			// for the default profile or a worker no longer in the pool.
+			if profile, ok := stack.Sessions.WorkerProfile(wID); ok {
+				ws.CPU = profile.CPU
+				ws.Memory = profile.Memory
+				ws.TTLSeconds = int(profile.TTL.Seconds())
+			}
+			result = append(result, ws)
 		}
 	}
 	return result
@@ -523,6 +531,16 @@ func SetupMultiTenant(
 		Audit:        auditStore,
 		Metrics:      metricsProxy,
 	})
+
+	// Live Duckling drift finder. Reuse the in-cluster Duckling client built
+	// above (dc); pass nil when it's unavailable so the endpoint degrades to
+	// {"available": false} rather than 500ing. A typed-nil *DucklingClient must
+	// not be boxed into the interface, so only assign when dc is usable.
+	var ducklingChecker admin.DucklingChecker
+	if dcErr == nil && dc != nil {
+		ducklingChecker = dc
+	}
+	admin.RegisterDucklingsDrift(api, store, ducklingChecker)
 
 	// Break-glass internal-secret login (the SPA owns "/" and app routes).
 	admin.RegisterLogin(engine, adminTokens)

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -297,6 +297,39 @@ func (d *DucklingClient) getCR(ctx context.Context, orgID string) (*unstructured
 	return nil, name, err
 }
 
+// ListCRNames returns the names of every Duckling CR in the namespace. Used by
+// the admin drift finder to detect orphan CRs (CRs with no warehouse row).
+func (d *DucklingClient) ListCRNames(ctx context.Context) ([]string, error) {
+	list, err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list duckling CRs: %w", err)
+	}
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		names = append(names, list.Items[i].GetName())
+	}
+	return names, nil
+}
+
+// CRStatus reports whether the org's Duckling CR exists and, if so, whether it
+// is Ready — without treating absence as an error. A NotFound resolves to
+// (false, false, nil) so the drift finder can classify a missing CR rather than
+// surfacing a 500. Any other error is returned as-is.
+func (d *DucklingClient) CRStatus(ctx context.Context, orgID string) (present bool, ready bool, err error) {
+	cr, _, gerr := d.getCR(ctx, orgID)
+	if gerr != nil {
+		if apierrors.IsNotFound(gerr) {
+			return false, false, nil
+		}
+		return false, false, gerr
+	}
+	status, perr := parseDucklingStatus(cr)
+	if perr != nil {
+		return true, false, perr
+	}
+	return true, status.ReadyCondition, nil
+}
+
 // Get fetches the Duckling CR and parses its status.
 func (d *DucklingClient) Get(ctx context.Context, orgID string) (*DucklingStatus, error) {
 	cr, name, err := d.getCR(ctx, orgID)

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -267,6 +268,11 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 	warehouse := &configstore.ManagedWarehouse{
 		DataStore: ds,
 		DuckLake:  configstore.ManagedWarehouseDuckLake{Enabled: ducklakeEnabled},
+		// Stamp the canonical Duckling CR name now so lookups never have to
+		// re-derive it. lower(orgID) mirrors provisioner.ducklingName (org IDs
+		// are validated DNS-1123 labels, so lowercasing is the whole transform);
+		// we inline it rather than import provisioner into this package.
+		DucklingName: strings.ToLower(orgID),
 	}
 	if icebergEnabled {
 		warehouse.Iceberg = configstore.ManagedWarehouseIceberg{

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -37,7 +37,8 @@ type ManagedSession struct {
 	PID          int32
 	Username     string // org user the session was created for (for admin slicing/attribution)
 	WorkerID     int
-	Protocol     string // "postgres" or "flight"
+	Protocol     string    // "postgres" or "flight"
+	StartedAt    time.Time // when the session was created (UTC); surfaced in the Live view
 	SessionToken string
 	Executor     *flightclient.FlightExecutor
 	connCloser   io.Closer // TCP connection, closed on worker crash to unblock the message loop
@@ -514,6 +515,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 		Username:     username,
 		WorkerID:     worker.ID,
 		Protocol:     protocol,
+		StartedAt:    time.Now().UTC(),
 		SessionToken: sessionToken,
 		Executor:     executor,
 		lease:        lease,
@@ -841,6 +843,17 @@ func (sm *SessionManager) WorkerPodNameForPID(pid int32) string {
 		return ""
 	}
 	return worker.PodName()
+}
+
+// WorkerProfile returns the pod-shape profile (cpu/memory/ttl) of a worker by
+// ID, or false if the worker is not in the pool. The zero profile is the
+// default profile (empty cpu/memory).
+func (sm *SessionManager) WorkerProfile(workerID int) (WorkerProfile, bool) {
+	w, ok := sm.pool.Worker(workerID)
+	if !ok || w == nil {
+		return WorkerProfile{}, false
+	}
+	return w.Profile(), true
 }
 
 // GetProgress returns the cached query progress for a session, or nil.

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -58,6 +58,12 @@ type ManagedWorker struct {
 	cachedActivationPayload any  //nolint:unused // *TenantActivationPayload, cached in kubernetes activation path
 }
 
+// Profile returns the pod-shape profile this worker was spawned with (zero =
+// default exclusive profile). Exposes the unexported field for the admin API.
+func (w *ManagedWorker) Profile() WorkerProfile {
+	return w.profile
+}
+
 // SharedState returns the additive shared worker lifecycle metadata for
 // this worker. The zero value normalizes to an idle, unassigned worker.
 func (w *ManagedWorker) SharedState() SharedWorkerState {

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -25,12 +25,17 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 5)
 	requireGooseMigrationRecorded(t, db, 6)
 	requireGooseMigrationRecorded(t, db, 7)
-	requireGooseLatestVersion(t, db, 7)
+	requireGooseMigrationRecorded(t, db, 8)
+	requireGooseLatestVersion(t, db, 8)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000007 added the compute-usage billing buffer + drain state.
 	requireTablePresent(t, db, "duckgres_org_compute_usage")
 	requireTablePresent(t, db, "duckgres_org_compute_drain_state")
+
+	// Migration 000008 added the explicit Duckling CR name column on
+	// managed warehouses, backfilled from lower(org_id).
+	requireColumnPresent(t, db, "duckgres_managed_warehouses", "duckling_name")
 
 	// Migration 000004 dropped the dead cluster-wide singleton config tables.
 	requireTableAbsent(t, db, "duckgres_global_config")
@@ -265,6 +270,26 @@ func requireGooseLatestVersion(t *testing.T, db *sql.DB, version int64) {
 	}
 	if !latest.Valid || latest.Int64 != version {
 		t.Fatalf("latest goose migration version = %v, want %d", latest, version)
+	}
+}
+
+func requireColumnPresent(t *testing.T, db *sql.DB, tableName, columnName string) {
+	t.Helper()
+
+	var exists bool
+	if err := db.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = $1
+			  AND column_name = $2
+		)
+	`, tableName, columnName).Scan(&exists); err != nil {
+		t.Fatalf("check column %q.%q presence: %v", tableName, columnName, err)
+	}
+	if !exists {
+		t.Fatalf("column %q.%q missing, want present", tableName, columnName)
 	}
 }
 


### PR DESCRIPTION
Admin console polish + operational visibility. All server-side data behind these views is additive (new JSON fields / one new read endpoint); no behavior change to existing flows.

## UI polish
- **Density**: Users and Live tables now match the Organizations row height (compact action buttons via `h-6` + negative margin; live query progress collapsed to a single line).

## Live
- Running queries show **start time as a relative age** ("24m") with the absolute timestamp on hover. Backed by a new `ManagedSession.StartedAt` threaded through the queries API (`started_at`).

## Workers
- Session-holding workers table gains **CPU / Memory / TTL** per worker (from the worker's `WorkerProfile`).
- **Fleet-by-state** rollup gains summed **CPU cores / memory** — computed from the durable `WorkerRecord` profile, falling back to each org's default worker shape when a row carries the default profile.

## Audit
- `AuditMiddleware` now derives a **resource-specific action** (`operators.` / `warehouse.` / `user.` / `config.`) and captures the `:email` route target. Added a unit test for the action-derivation helper. Verified every mutating route under `/api/v1` is covered by the middleware.

## Ducklings
- New explicit **`duckling_name`** column on managed warehouses (goose migration `000008`, backfilled to `lower(org_id)`, stamped on new warehouses) — removes the derive-from-org-id guesswork. Surfaced as its own **Duckling** column on Organizations and in the org detail view.
- New admin-only **`GET /ducklings/drift`** live-checks every warehouse against its actual Duckling CR in the cluster and reports drift: **missing** (no CR), **not_ready**, **state_mismatch**, **orphan** (CR with no warehouse row), plus a per-row `check_error` fallback. Rendered as a warning **banner on the Organizations page** (admin-only; viewers never fire the request).

## Build / test
- `go build -tags kubernetes ./...`, `go vet`, `gofmt` — clean.
- `npm run build` (tsc + vite) — clean.
- New `TestAuditActionFor` passes. DB-backed Postgres tests (incl. the migration parity test, version bumped 7→8) require a live Postgres container and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)