### PR TITLE
[codex] Fix e2e harness log RBAC

### DIFF
--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -378,7 +378,9 @@ connection_duration_logged() { # org password
   for p in $(k get pods -l app=duckgres-control-plane -o jsonpath='{.items[*].metadata.name}'); do
     # logfmt: `... msg="Client disconnected." ... duration_ms=NN`. Take the max
     # duration_ms seen on a disconnect line in the recent window across replicas.
-    m="$(k logs "$p" --since=180s 2>/dev/null \
+    logs="$(k logs "$p" --since=180s 2>&1)" \
+      || fail "kubectl logs failed for control-plane pod $p while checking duration_ms: $logs"
+    m="$(printf '%s\n' "$logs" \
           | grep 'Client disconnected.' \
           | grep -oE 'duration_ms=[0-9]+' \
           | grep -oE '[0-9]+' \

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -141,6 +141,9 @@ rules:
     resources: ["pods"]
     verbs: ["create", "delete", "get", "list", "watch", "patch"]
   - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources: ["secrets"]
     # list/watch needed by the CP's stranded-secret reconciler (the prod chart
     # Role grants them implicitly via the shared duckgres namespace; spelled


### PR DESCRIPTION
## Summary

- Grant the in-cluster e2e harness service account `get` on the `pods/log` subresource.
- Make `connection_duration_logged()` fail with the actual `kubectl logs` error instead of suppressing stderr and reporting a missing duration log.

## Root cause

PR #841 added a harness assertion that reads control-plane logs from inside the cluster, but the e2e Role only granted access to `pods`, not the `pods/log` subresource. The harness also redirected `kubectl logs` stderr to `/dev/null`, so an RBAC denial looked like the expected disconnect log was absent.

## Validation

- `git diff --check`
- `just lint`