### PR TITLE
admin: populate per-org worker count (fix always-empty load bars)

### DIFF
--- a/controlplane/admin/live_aggregate.go
+++ b/controlplane/admin/live_aggregate.go
@@ -59,11 +59,11 @@ func dedupeBy[T any, K comparable](items []T, key func(T) K) []T {
 }
 
 // mergeOrgStats folds each peer's ClusterStatus into the local per-org stats:
-// active_sessions is summed across CPs (each reports its own slice). Workers is
-// also summed for forward-compatibility, but the adapter currently leaves it 0
-// (per-org worker counts aren't surfaced), so it's effectively a no-op today.
-// max_workers is config-store-backed (identical on every CP) so the max is
-// taken. Org identity is the name; order follows first-seen.
+// active_sessions and workers are both summed across CPs (each reports only the
+// sessions / workers it owns — a worker is owned by exactly one CP, so the sum
+// is the cluster-wide per-org count). max_workers is config-store-backed
+// (identical on every CP) so the max is taken. Org identity is the name; order
+// follows first-seen.
 func mergeOrgStats(local []OrgStatus, bodies [][]byte) []OrgStatus {
 	byName := map[string]*OrgStatus{}
 	var order []string

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -70,11 +70,18 @@ func (a *orgRouterAdapter) AllOrgStats() []admin.OrgStatus {
 	stats := make([]admin.OrgStatus, 0, len(stacks))
 	for name, stack := range stacks {
 		sessionCount := stack.Sessions.SessionCount()
-		stats = append(stats, admin.OrgStatus{
+		st := admin.OrgStatus{
 			Name:           name,
 			ActiveSessions: sessionCount,
 			MaxWorkers:     stack.Config.MaxWorkers,
-		})
+		}
+		// Workers this CP has assigned to the org (cap-counting; excludes
+		// hot-idle). Per-CP local view — the admin /status fan-out sums it
+		// across replicas (mergeOrgStats) for a cluster-wide per-org count.
+		if rp, ok := stack.Pool.(*OrgReservedPool); ok {
+			st.Workers = rp.WorkerCount()
+		}
+		stats = append(stats, st)
 		// Emit per-org Prometheus metrics
 		observeOrgSessionsActive(name, sessionCount)
 	}

--- a/controlplane/org_reserved_pool.go
+++ b/controlplane/org_reserved_pool.go
@@ -274,6 +274,17 @@ func (p *OrgReservedPool) atOrgWorkerCap() bool {
 	return p.maxWorkers > 0 && p.assignedWorkerCountLocked() >= p.maxWorkers
 }
 
+// WorkerCount returns the number of workers this CP currently has assigned to
+// the org that count against MaxWorkers (hot-idle workers are excluded — they're
+// parked for reclaim and don't consume the cap budget, same as atOrgWorkerCap).
+// This is the per-CP local view; the admin layer sums it across replicas (a
+// worker is owned by exactly one CP) for the Overview per-org load bar.
+func (p *OrgReservedPool) WorkerCount() int {
+	p.shared.mu.Lock()
+	defer p.shared.mu.Unlock()
+	return p.assignedWorkerCountLocked()
+}
+
 // tryReuseIdleAssigned returns an already-assigned, idle (Hot) worker of the
 // requested shape with its session count bumped, or nil if none is available.
 func (p *OrgReservedPool) tryReuseIdleAssigned(profile *WorkerProfile) *ManagedWorker {

--- a/controlplane/org_reserved_pool_test.go
+++ b/controlplane/org_reserved_pool_test.go
@@ -95,6 +95,44 @@ func TestOrgReservedPoolAcquireSkipsOtherOrgsWorkers(t *testing.T) {
 	}
 }
 
+// TestOrgReservedPoolWorkerCount covers the per-org worker count surfaced to
+// the admin Overview load bars: it counts this org's cap-counting (Hot)
+// workers, excludes hot-idle (parked, not against cap), and ignores workers
+// assigned to a different org sharing the pool.
+func TestOrgReservedPoolWorkerCount(t *testing.T) {
+	shared, _ := newTestK8sPool(t, 10)
+
+	mk := func(id int, org string, lc WorkerLifecycleState) {
+		w := &ManagedWorker{ID: id, activeSessions: 1, done: make(chan struct{})}
+		w.SetOwnerCPInstanceID(shared.cpInstanceID)
+		w.SetOwnerEpoch(1)
+		if err := w.SetSharedState(SharedWorkerState{
+			Lifecycle:  lc,
+			Assignment: &WorkerAssignment{OrgID: org},
+		}); err != nil {
+			t.Fatalf("SetSharedState(%d): %v", id, err)
+		}
+		shared.workers[id] = w
+	}
+	// Two Hot workers for analytics (counted), one analytics hot-idle (excluded),
+	// one Hot worker for another org (excluded).
+	mk(1, "analytics", WorkerLifecycleHot)
+	mk(2, "analytics", WorkerLifecycleHot)
+	mk(3, "analytics", WorkerLifecycleHotIdle)
+	mk(4, "other", WorkerLifecycleHot)
+
+	pool := NewOrgReservedPool(shared, "analytics", 5, shared.workerImage, nil)
+	if got := pool.WorkerCount(); got != 2 {
+		t.Fatalf("WorkerCount() = %d, want 2 (two Hot analytics workers; hot-idle + other-org excluded)", got)
+	}
+
+	// Empty org → 0, never negative.
+	empty := NewOrgReservedPool(shared, "nobody", 5, shared.workerImage, nil)
+	if got := empty.WorkerCount(); got != 0 {
+		t.Fatalf("WorkerCount() for org with no workers = %d, want 0", got)
+	}
+}
+
 func TestOrgReservedPoolReleaseWorkerTransitionsToHotIdleOnLastSession(t *testing.T) {
 	shared, _ := newTestK8sPool(t, 5)
 	worker := &ManagedWorker{ID: 9, activeSessions: 1, done: make(chan struct{})}

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1404,6 +1404,35 @@ admin_console_api() {
     || fail "/metrics/panels missing 'query_rate'"
 }
 
+# ---- admin: /status reports per-org worker counts --------------------------
+# OrgStatus.Workers (the Overview per-org load bars + total_workers) was an
+# always-0 dead field; it's now populated from each CP's OrgReservedPool
+# (cap-counting assigned workers, summed across replicas by the /status
+# fan-out). With a query in flight the org's worker is Hot, so /status must
+# report workers>=1 for that org and a nonzero cluster total_workers.
+admin_per_org_workers() { # org password
+  org="$1"; pw="$2"
+  log "admin: /status per-org worker count is populated on $org"
+  q="SELECT count(*) FROM range(2718281828) t(i) WHERE i % 2 = 0;"
+  out="$(mktemp)"
+  ( pg_try "$org" "$pw" ducklake "$q" >"$out" 2>&1 || true ) &
+  bg=$!
+  cleanup_pow() { kill "$bg" 2>/dev/null || true; wait "$bg" 2>/dev/null || true; rm -f "$out"; }
+
+  ok="" a=0
+  while [ "$a" -lt 60 ]; do
+    kill -0 "$bg" 2>/dev/null || break
+    w="$(curl -fsS -H "$H" "$API/api/v1/status" \
+      | jq -r --arg o "$org" '(.orgs[]? | select(.name==$o) | .workers) // 0')"
+    tot="$(curl -fsS -H "$H" "$API/api/v1/status" | jq -r '.total_workers // 0')"
+    if [ "${w:-0}" -ge 1 ] && [ "${tot:-0}" -ge 1 ]; then ok=1; break; fi
+    sleep 2; a=$((a + 1))
+  done
+  cleanup_pow
+  [ -n "$ok" ] || fail "admin_per_org_workers: /status never reported workers>=1 for $org (per-org worker count not populated)"
+  log "admin: /status per-org worker count OK (workers>=1, total_workers>=1) on $org"
+}
+
 # ---- admin RBAC: SSO viewer is read-only -----------------------------------
 # A forged ALB OIDC header (no internal secret) for an @posthog.com email that
 # is NOT in the operators table resolves to the viewer role (fail-closed
@@ -1727,6 +1756,9 @@ main() {
 
   # ---- admin impersonation round-trip + audit (cnpg stack is warm now) ----
   admin_impersonation_audited "$CNPG"
+
+  # ---- admin /status per-org worker count is populated (not the old 0) ----
+  admin_per_org_workers "$CNPG" "$cnpg_pw"
 
   # ---- connection-duration observability (any org; lanes already churned
   #      many connect/disconnects, so the disconnect log is warm) ----

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1410,6 +1410,9 @@ admin_console_api() {
 # (cap-counting assigned workers, summed across replicas by the /status
 # fan-out). With a query in flight the org's worker is Hot, so /status must
 # report workers>=1 for that org and a nonzero cluster total_workers.
+# PRECONDITION: the caller passes an org whose lane is already warm (e.g. CNPG
+# after join_lanes), so the query lands on a Hot worker within the 120s budget
+# rather than waiting on a multi-minute cold pod spawn — see the call site.
 admin_per_org_workers() { # org password
   org="$1"; pw="$2"
   log "admin: /status per-org worker count is populated on $org"


### PR DESCRIPTION
## The bug

`OrgStatus.Workers` is declared in the admin API but **never populated** — `AllOrgStats` only set `Name`/`ActiveSessions`/`MaxWorkers`. So:
- the Overview **per-org load bars** always rendered empty (`0/∞ wk`, 0% fill), and
- `ClusterStatus.total_workers` was always 0 (the same dead field that made the Workers card derive a bogus idle count before #839).

## Fix

Populate it from each org's `OrgReservedPool`:
- New `OrgReservedPool.WorkerCount()` returns the org's **cap-counting** assigned workers (`Hot`; hot-idle excluded — same rule as `atOrgWorkerCap`).
- `AllOrgStats` sets `OrgStatus.Workers` from it via a type assertion (remote/k8s mode → `*OrgReservedPool`).

It's a **per-CP local** count — a worker is owned by exactly one CP — and the `/status` fan-out (`mergeOrgStats`) already **sums** `Workers` across replicas, so the cluster-wide per-org total comes out right, consistent with how `active_sessions` is merged. `total_workers` becomes the real cluster total as a bonus.

## Tests

- **`TestOrgReservedPoolWorkerCount`**: counts the org's Hot workers, excludes hot-idle and other-org workers sharing the pool, and returns 0 for an org with none.
- **`harness.sh admin_per_org_workers`**: with a query in flight, `/status` reports `workers>=1` for that org and `total_workers>=1` (proves the field is live end-to-end, not 0).

Completes the per-org follow-up noted in #839 / #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUq2EVxvKQFq3YEDNLF5HP