### PR TITLE
[codex] Harden e2e cleanup gate

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -57,8 +57,10 @@ on:
   schedule:
     - cron: "0 */6 * * *"
 
-# One in-flight run per PR; a new push cancels the old run (and its namespace
-# is GC'd by the always() teardown of the cancelled run + the e2e-cleanup sweep).
+# One in-flight run per PR; a new push cancels the old run. The replacement
+# deploy starts by deleting same-PR shared resources and refuses to reuse the
+# PR-scoped names until Duckling CR deletion completes; e2e-cleanup is the
+# backstop for namespaces with no follow-up run.
 concurrency:
   group: e2e-mw-dev-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -116,6 +118,14 @@ jobs:
       CP_POD_IDENTITY_ROLE: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/duckgres-control-plane-dev
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Test e2e harness scripts
+        run: go test -count=1 ./tests/e2e-mw-dev
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1

--- a/justfile
+++ b/justfile
@@ -294,6 +294,7 @@ test:
 [group('test')]
 test-unit:
     go test -v -p 1 . ./configresolve/... ./duckdbservice/... ./server/... ./transpiler/... ./internal/... ./tests/manifests/...
+    go test -v -count=1 ./tests/e2e-mw-dev/...
 
 # Run scenario runner unit tests
 [group('test')]

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -225,8 +225,10 @@ is deleted; the shared-infra footprint is removed by deprovisioning the
 ducklings first.
 
 Each deploy first reaps any existing resources for the same PR number (namespace,
-Duckling CRs, pod identity association, cross-namespace bindings, and cnpg role)
-so a rerun never applies over stale services or network policies.
+Duckling CRs, pod identity association, cross-namespace bindings, and cnpg role).
+It fails before applying manifests if the same-PR Duckling CRs do not fully
+delete, so a rerun never reuses PR-scoped bucket/org names while Crossplane
+finalizers are still running.
 
 ## One-time repo configuration
 
@@ -303,13 +305,16 @@ id committed).
   failed auths (~15 min). The harness uses the provision-time password and
   settles one config-poll interval before connecting — keep it that way; a
   reset-password + tight retry loop will trip the ban.
-- **Teardown / recreate are now CR-synchronous.** `run.sh teardown` and the
-  in-harness same-org recreate both `kubectl wait --for=delete` on the Duckling
-  CR, whose finalizers run the Crossplane DROP of the cnpg role+db, before
-  returning / re-provisioning. `drop_cnpg_role` is still called at deploy + at
-  teardown as a belt-and-suspenders idempotent backstop. (Composition
-  `managementPolicies: ["*"]` from charts#11522 does the drop; the `--for=delete`
-  wait is what makes it synchronous from our side.)
+- **Teardown / recreate are now CR-synchronous.** `run.sh deploy`, `run.sh
+  teardown`, and the in-harness same-org recreate all `kubectl wait --for=delete`
+  on the Duckling CR, whose finalizers run the Crossplane DROP of the cnpg
+  role+db, before returning / re-provisioning. Deploy and teardown fail if the
+  same-PR CRs do not delete within the timeout; the scheduled `e2e-cleanup` sweep
+  logs a narrow stuck-CR summary but keeps going so one old namespace does not
+  block the janitor. `drop_cnpg_role` is still called at deploy + at teardown as a
+  belt-and-suspenders idempotent backstop. (Composition `managementPolicies:
+  ["*"]` from charts#11522 does the drop; the `--for=delete` wait is what makes
+  it synchronous from our side.)
 - **Shared-infra contention.** Concurrent PRs provision real ducklings against
   the same cnpg-shards / RDS infra. Org-ID prefix keeps them
   distinct; watch quay.io / cnpg pooler / RDS limits under parallelism.

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -312,7 +312,8 @@ id committed).
   same-PR CRs do not delete within the timeout; the scheduled `e2e-cleanup` sweep
   logs a narrow stuck-CR summary but keeps going so one old namespace does not
   block the janitor. `drop_cnpg_role` is still called at deploy + at teardown as a
-  belt-and-suspenders idempotent backstop. (Composition `managementPolicies:
+  belt-and-suspenders idempotent backstop; it sweeps both current `mdstore_<org>`
+  and legacy `lakekeeper_<org>` identifiers. (Composition `managementPolicies:
   ["*"]` from charts#11522 does the drop; the `--for=delete` wait is what makes
   it synchronous from our side.)
 - **Shared-infra contention.** Concurrent PRs provision real ducklings against

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -127,19 +127,22 @@ restart_cp_with_identity() {
 # The cnpg-shard metadata role+db are owned by the Crossplane composition and
 # dropped when the Duckling CR deletes — but that cascade is async and can lag,
 # leaving stranded state from a prior run (incl. a cancelled one with no
-# teardown). The composition's live identifier still uses the historical
-# lakekeeper_<org> prefix, so drop that role+db directly on the active shard,
+# teardown). New Ducklings use mdstore_<org>; legacy Ducklings can still use
+# lakekeeper_<org>. Drop both role+db names directly on the active shard,
 # idempotently, BOTH before provisioning (clean slate, so a rerun never
 # inherits stranded state) and at teardown (deterministic clean exit). Scoped
 # to this PR's unique org ids, so it can't touch another PR's tenant.
 drop_cnpg_role() { # org-id
-  local ident
-  # Mirror the composition's PG identifier: lakekeeper_<lower, [^a-z0-9_]→_>.
-  ident="lakekeeper_$(printf %s "$1" | tr 'A-Z-' 'a-z_' | tr -cd 'a-z0-9_')"
-  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
-    psql -U postgres -c "DROP DATABASE IF EXISTS ${ident} WITH (FORCE);" >/dev/null 2>&1 || true
-  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
-    psql -U postgres -c "DROP ROLE IF EXISTS ${ident};" >/dev/null 2>&1 || true
+  local suffix prefix ident
+  # Mirror the composition's PG identifier suffix: lower, [^a-z0-9_] -> _.
+  suffix="$(printf %s "$1" | tr 'A-Z-' 'a-z_' | tr -cd 'a-z0-9_')"
+  for prefix in mdstore lakekeeper; do
+    ident="${prefix}_${suffix}"
+    "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
+      psql -U postgres -c "DROP DATABASE IF EXISTS ${ident} WITH (FORCE);" >/dev/null 2>&1 || true
+    "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
+      psql -U postgres -c "DROP ROLE IF EXISTS ${ident};" >/dev/null 2>&1 || true
+  done
 }
 
 # Every duckling org a harness run provisions for a PR (harness.sh main()):

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -33,6 +33,24 @@ internal_secret_fallback_file="/tmp/duckgres-ci-internal-secret-fallback"
 # run: stored user secrets only need to outlive the run's sessions.
 user_secret_key_file="/tmp/duckgres-ci-user-secret-key"
 
+require_pr_identity() {
+  : "${PR_NUMBER:?PR_NUMBER is required}"
+  case "$PR_NUMBER" in
+    *[!0-9]*)
+      echo "PR_NUMBER must be numeric, got '$PR_NUMBER'." >&2
+      return 2
+      ;;
+  esac
+  if [ -z "$NS" ]; then
+    echo "NAMESPACE is required." >&2
+    return 2
+  fi
+  if [ "$NS" != "duckgres-ci-pr-$PR_NUMBER" ]; then
+    echo "NAMESPACE '$NS' does not match PR_NUMBER '$PR_NUMBER'." >&2
+    return 2
+  fi
+}
+
 render() {
   : "${WORKER_IMAGE:?}" "${CONTROLPLANE_IMAGE:?}" "${PR_NUMBER:?}"
   [ -f "$internal_secret_file" ] || openssl rand -hex 16 > "$internal_secret_file"
@@ -146,10 +164,29 @@ delete_ci_ducklings() { # pr-number
 }
 
 wait_ci_ducklings_deleted() { # pr-number timeout
-  local pr="$1" timeout="$2" org
+  local pr="$1" timeout="$2" org get_out deletion_timestamp finalizers conditions rest rc=0
   for org in $(ci_orgs "$pr"); do
-    "${KUBECTL[@]}" -n ducklings wait --for=delete "duckling/$org" --timeout="$timeout" 2>/dev/null || true
+    if ! "${KUBECTL[@]}" -n ducklings wait --for=delete "duckling/$org" --timeout="$timeout"; then
+      if get_out="$("${KUBECTL[@]}" -n ducklings get "duckling/$org" \
+          -o jsonpath='{.metadata.deletionTimestamp}{"|"}{.metadata.finalizers}{"|"}{range .status.conditions[*]}{.type}={.status}:{.reason}{";"}{end}' 2>&1)"; then
+        deletion_timestamp="${get_out%%|*}"
+        rest="${get_out#*|}"
+        finalizers="${rest%%|*}"
+        conditions="${rest#*|}"
+        [ -n "$deletion_timestamp" ] || deletion_timestamp="<none>"
+        [ -n "$finalizers" ] || finalizers="<none>"
+        [ -n "$conditions" ] || conditions="<none>"
+        echo "Duckling $org did not delete within $timeout; refusing to reuse same-PR resource names." >&2
+        echo "Duckling $org summary: deletionTimestamp=$deletion_timestamp finalizers=$finalizers conditions=$conditions" >&2
+        rc=1
+      elif ! printf '%s\n' "$get_out" | grep -qi 'not found'; then
+        echo "Could not verify Duckling $org was deleted after wait failed; refusing to reuse same-PR resource names." >&2
+        printf '%s\n' "$get_out" >&2
+        rc=1
+      fi
+    fi
   done
+  return "$rc"
 }
 
 delete_ci_bindings() { # pr-number
@@ -278,6 +315,8 @@ cmd_diagnostics() {
 }
 
 cmd_teardown() {
+  local duckling_delete_rc=0
+
   # Deprovision the ci-pr ducklings FIRST so shared-infra resources (S3 bucket,
   # cnpg role+db) are cleaned up by the control plane
   # before we delete it. Best-effort — the namespace delete + e2e-cleanup are the
@@ -323,7 +362,7 @@ cmd_teardown() {
   # stranded cnpg state and never reach ready.
   # `wait --for=delete` blocks until the CR (and its cascade) is gone.
   delete_ci_ducklings "$PR_NUMBER"
-  wait_ci_ducklings_deleted "$PR_NUMBER" 300s
+  wait_ci_ducklings_deleted "$PR_NUMBER" 300s || duckling_delete_rc=$?
 
   # Deterministically drop the cnpg role+db in case the composition's async
   # cascade lagged the CR delete above (see drop_cnpg_role). Idempotent.
@@ -335,6 +374,7 @@ cmd_teardown() {
   # Cross-namespace bindings carry the ci-pr label — sweep them, then the ns.
   delete_ci_bindings "$PR_NUMBER"
   "${KUBECTL[@]}" delete namespace "$NS" --ignore-not-found --wait=false
+  return "$duckling_delete_rc"
 }
 
 # Sweep stale per-PR namespaces left behind by runs that died hard (cancelled
@@ -362,7 +402,7 @@ cmd_e2e_cleanup() {
       pr="${ns#duckgres-ci-pr-}"
       echo "e2e-cleanup: reaping $ns (age ${age}h, PR $pr)"
       delete_ci_ducklings "$pr"
-      wait_ci_ducklings_deleted "$pr" 300s
+      wait_ci_ducklings_deleted "$pr" 300s || true
       for org in $(ci_cnpg_orgs "$pr"); do drop_cnpg_role "$org"; done
       NS="$ns" delete_pod_identity
       delete_ci_bindings "$pr"
@@ -371,10 +411,10 @@ cmd_e2e_cleanup() {
 }
 
 case "${1:?usage: run.sh deploy|test|diagnostics|teardown|e2e-cleanup}" in
-  deploy) : "${NAMESPACE:?}"; cmd_deploy ;;
-  test) : "${NAMESPACE:?}"; cmd_test ;;
-  diagnostics) : "${NAMESPACE:?}"; cmd_diagnostics ;;
-  teardown) : "${NAMESPACE:?}"; cmd_teardown ;;
+  deploy) : "${NAMESPACE:?}"; require_pr_identity; cmd_deploy ;;
+  test) : "${NAMESPACE:?}"; require_pr_identity; cmd_test ;;
+  diagnostics) : "${NAMESPACE:?}"; require_pr_identity; cmd_diagnostics ;;
+  teardown) : "${NAMESPACE:?}"; require_pr_identity; cmd_teardown ;;
   e2e-cleanup) cmd_e2e_cleanup ;;
   *) echo "unknown: $1" >&2; exit 2 ;;
 esac

--- a/tests/e2e-mw-dev/run_sh_test.go
+++ b/tests/e2e-mw-dev/run_sh_test.go
@@ -1,0 +1,252 @@
+package e2emwdev_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeployFailsWhenSamePRDucklingsDoNotDelete(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "deploy")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("deploy succeeded despite stuck same-PR Ducklings; output:\n%s", out)
+	}
+
+	calls := fakes.calls(t)
+	if strings.Contains(calls, "kubectl --context test-context apply -f -") {
+		t.Fatalf("deploy applied manifests after Duckling delete wait failed; calls:\n%s", calls)
+	}
+}
+
+func TestDeployFailureDoesNotDumpDucklingYAML(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "deploy")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("deploy succeeded despite stuck same-PR Ducklings; output:\n%s", out)
+	}
+
+	output := string(out)
+	for _, secret := range []string{
+		"internal-ci-bucket-name",
+		"arn:aws:iam::123456789012:role/internal-ci-role",
+		"internal-provider-config",
+	} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("deploy output leaked raw Duckling YAML value %q:\n%s", secret, output)
+		}
+	}
+	if !strings.Contains(output, "finalizers=") {
+		t.Fatalf("deploy output did not include a narrow stuck-Duckling summary:\n%s", output)
+	}
+}
+
+func TestScheduledCleanupKeepsGoingWhenDucklingsDoNotDelete(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "e2e-cleanup")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("e2e-cleanup should be best-effort when stale Ducklings do not delete: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	if !strings.Contains(calls, "kubectl --context test-context delete namespace duckgres-ci-pr-123 --ignore-not-found --wait=false") {
+		t.Fatalf("e2e-cleanup did not continue to namespace cleanup; calls:\n%s", calls)
+	}
+}
+
+func TestTeardownContinuesCleanupWhenDucklingsDoNotDelete(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "teardown")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("teardown should report stuck same-PR Ducklings; output:\n%s", out)
+	}
+
+	calls := fakes.calls(t)
+	for _, want := range []string{
+		"aws eks list-pod-identity-associations",
+		"kubectl --context test-context delete clusterrolebinding -l duckgres.posthog.com/ci-pr=123 --ignore-not-found",
+		"kubectl --context test-context delete namespace duckgres-ci-pr-123 --ignore-not-found --wait=false",
+	} {
+		if !strings.Contains(calls, want) {
+			t.Fatalf("teardown did not continue cleanup after Duckling delete wait failed; missing %q in calls:\n%s", want, calls)
+		}
+	}
+}
+
+func TestDeployRejectsMissingPRNumberBeforeCleanup(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "deploy", "PR_NUMBER=", "NAMESPACE=duckgres-ci-pr-")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("deploy succeeded without a PR number; output:\n%s", out)
+	}
+
+	calls := fakes.calls(t)
+	if strings.Contains(calls, "duckling/ci-pr--") {
+		t.Fatalf("deploy touched empty-PR Duckling names before validating PR identity; calls:\n%s", calls)
+	}
+}
+
+type runSHFakes struct {
+	binDir  string
+	logPath string
+}
+
+func newRunSHFakes(t *testing.T) runSHFakes {
+	t.Helper()
+
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bin: %v", err)
+	}
+	logPath := filepath.Join(dir, "calls.log")
+
+	writeFake(t, binDir, "kubectl", `#!/usr/bin/env bash
+printf 'kubectl %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+
+if [[ "$*" == *" apply -f -"* ]]; then
+  cat >/dev/null
+  exit 0
+fi
+if [[ "$*" == *" wait --for=delete duckling/ci-pr-123-"* ]]; then
+  exit 1
+fi
+if [[ "$*" == *" get duckling/ci-pr-123-"* && "$*" == *"-o jsonpath="* ]]; then
+  printf '2026-06-30T00:00:00Z|[finalizer.crossplane.io]|Ready=False:Deleting;'
+  exit 0
+fi
+if [[ "$*" == *" get duckling/ci-pr-123-"* ]]; then
+  cat <<'YAML'
+apiVersion: ducklings.posthog.com/v1
+kind: Duckling
+metadata:
+  name: ci-pr-123-cnpg
+  deletionTimestamp: "2026-06-30T00:00:00Z"
+  finalizers:
+    - finalizer.crossplane.io
+spec:
+  providerConfigRef:
+    name: internal-provider-config
+status:
+  dataStore:
+    bucketName: internal-ci-bucket-name
+  roleArn: arn:aws:iam::123456789012:role/internal-ci-role
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: Deleting
+YAML
+  exit 0
+fi
+if [[ "$*" == *" get ns -l app.kubernetes.io/managed-by=e2e-mw-dev "* ]]; then
+  printf 'duckgres-ci-pr-123 2026-01-01T00:00:00Z\n'
+  exit 0
+fi
+if [[ "$*" == *" get pod -l app=duckgres-control-plane "* ]]; then
+  printf 'duckgres-control-plane-test'
+  exit 0
+fi
+if [[ "$*" == *" exec duckgres-control-plane-test -- sh -c "* ]]; then
+  printf 'http://pod-identity-credentials'
+  exit 0
+fi
+
+exit 0
+`)
+
+	writeFake(t, binDir, "aws", `#!/usr/bin/env bash
+printf 'aws %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+if [[ "$*" == *" list-pod-identity-associations "* ]]; then
+  printf 'None\n'
+fi
+exit 0
+`)
+
+	writeFake(t, binDir, "openssl", `#!/usr/bin/env bash
+printf 'openssl %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+printf 'test-secret\n'
+`)
+
+	writeFake(t, binDir, "envsubst", `#!/usr/bin/env bash
+printf 'envsubst %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+cat
+`)
+
+	writeFake(t, binDir, "curl", `#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+if [[ "$*" == *"/warehouse/status"* ]]; then
+  printf '{"state":"deleted"}'
+fi
+exit 0
+`)
+
+	writeFake(t, binDir, "sleep", `#!/usr/bin/env bash
+printf 'sleep %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+`)
+
+	writeFake(t, binDir, "date", `#!/usr/bin/env bash
+printf 'date %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
+if [[ "$*" == "+%s" ]]; then
+  printf '2000000000\n'
+  exit 0
+fi
+if [[ "$*" == *"-d 2026-01-01T00:00:00Z +%s"* ]]; then
+  printf '1767225600\n'
+  exit 0
+fi
+exec /bin/date "$@"
+`)
+
+	return runSHFakes{binDir: binDir, logPath: logPath}
+}
+
+func writeFake(t *testing.T, binDir, name, body string) {
+	t.Helper()
+	path := filepath.Join(binDir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+}
+
+func runSHCommand(t *testing.T, binDir, subcommand string, extraEnv ...string) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command("bash", "run.sh", subcommand)
+	cmd.Dir = "."
+	env := append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"RUN_SH_TEST_CALLS="+filepath.Join(filepath.Dir(binDir), "calls.log"),
+		"KUBE_CONTEXT=test-context",
+		"NAMESPACE=duckgres-ci-pr-123",
+		"PR_NUMBER=123",
+		"WORKER_IMAGE=example.invalid/duckgres:test",
+		"CONTROLPLANE_IMAGE=example.invalid/duckgres:test",
+		"CP_POD_IDENTITY_ROLE=arn:aws:iam::123456789012:role/duckgres-control-plane-dev",
+		"EKS_CLUSTER_NAME=test-cluster",
+		"AWS_REGION=us-east-1",
+	)
+	env = append(env, extraEnv...)
+	cmd.Env = env
+	return cmd
+}
+
+func (f runSHFakes) calls(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(f.logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read fake calls: %v", err)
+	}
+	return string(b)
+}

--- a/tests/e2e-mw-dev/run_sh_test.go
+++ b/tests/e2e-mw-dev/run_sh_test.go
@@ -62,6 +62,28 @@ func TestScheduledCleanupKeepsGoingWhenDucklingsDoNotDelete(t *testing.T) {
 	}
 }
 
+func TestScheduledCleanupDropsCurrentAndLegacyCnpgIdentifiers(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "e2e-cleanup")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("e2e-cleanup failed: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	for _, want := range []string{
+		"DROP DATABASE IF EXISTS mdstore_ci_pr_123_cnpg WITH (FORCE);",
+		"DROP ROLE IF EXISTS mdstore_ci_pr_123_cnpg;",
+		"DROP DATABASE IF EXISTS lakekeeper_ci_pr_123_cnpg WITH (FORCE);",
+		"DROP ROLE IF EXISTS lakekeeper_ci_pr_123_cnpg;",
+	} {
+		if !strings.Contains(calls, want) {
+			t.Fatalf("cleanup did not drop expected cnpg identifier %q; calls:\n%s", want, calls)
+		}
+	}
+}
+
 func TestTeardownContinuesCleanupWhenDucklingsDoNotDelete(t *testing.T) {
 	fakes := newRunSHFakes(t)
 


### PR DESCRIPTION
## Summary

Harden the managed-warehouse e2e cleanup path so consecutive runs for the same PR cannot reuse PR-scoped Duckling names while prior Duckling CR finalizers are still running.

## Root Cause

The e2e deploy reset path deleted same-PR Duckling CRs but ignored `kubectl wait --for=delete` failures. A newly started run could therefore apply fresh manifests and reuse the same PR-scoped org/bucket names while Crossplane cleanup from the cancelled or failed run was still in progress.

## Changes

- Make deploy fail before applying manifests if same-PR Duckling CR deletion cannot be confirmed.
- Validate `PR_NUMBER` and `NAMESPACE` before touching PR-scoped resources.
- Keep scheduled cleanup best-effort so one stuck stale namespace does not block the sweep.
- Make teardown continue pod identity, binding, and namespace cleanup even if Duckling deletion times out, then return the Duckling deletion failure.
- Log only a narrow stuck-Duckling summary instead of raw Duckling YAML.
- Add e2e script regression tests and wire them into both the e2e workflow preflight and `just test-unit`.

## Validation

- `go test -count=1 ./tests/e2e-mw-dev`
- `just test-unit`
- `bash -n tests/e2e-mw-dev/run.sh`
- `git diff --check`
- `just lint`