### PR TITLE
[codex] Surface vCPU limits in admin UI

### DIFF
--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -34,6 +34,7 @@ import type { ManagedWarehouse, OrgUpdate } from "@/types/api";
 interface FormState {
   max_workers: string;
   max_connections: string;
+  max_vcpus: string;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -44,6 +45,7 @@ interface FormState {
 function orgToForm(o: {
   max_workers: number;
   max_connections: number;
+  max_vcpus: number;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -53,6 +55,7 @@ function orgToForm(o: {
   return {
     max_workers: String(o.max_workers),
     max_connections: String(o.max_connections),
+    max_vcpus: String(o.max_vcpus),
     default_worker_cpu: o.default_worker_cpu,
     default_worker_memory: o.default_worker_memory,
     default_worker_ttl: o.default_worker_ttl,
@@ -103,6 +106,7 @@ export function OrgDetail() {
     const body: OrgUpdate = {
       max_workers: Number(form.max_workers) || 0,
       max_connections: Number(form.max_connections) || 0,
+      max_vcpus: Number(form.max_vcpus) || 0,
       default_worker_cpu: form.default_worker_cpu,
       default_worker_memory: form.default_worker_memory,
       default_worker_ttl: form.default_worker_ttl,
@@ -158,6 +162,14 @@ export function OrgDetail() {
                     type="number"
                     value={form.max_connections}
                     onChange={(e) => set("max_connections", e.target.value)}
+                  />
+                </Field>
+                <Field label="Max vCPUs (0 = unbounded)">
+                  <Input
+                    type="number"
+                    min={0}
+                    value={form.max_vcpus}
+                    onChange={(e) => set("max_vcpus", e.target.value)}
                   />
                 </Field>
                 <Field label="Default worker CPU">

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -33,7 +33,6 @@ import type { ManagedWarehouse, OrgUpdate } from "@/types/api";
 
 interface FormState {
   max_workers: string;
-  max_connections: string;
   max_vcpus: string;
   default_worker_cpu: string;
   default_worker_memory: string;
@@ -44,7 +43,6 @@ interface FormState {
 
 function orgToForm(o: {
   max_workers: number;
-  max_connections: number;
   max_vcpus: number;
   default_worker_cpu: string;
   default_worker_memory: string;
@@ -54,7 +52,6 @@ function orgToForm(o: {
 }): FormState {
   return {
     max_workers: String(o.max_workers),
-    max_connections: String(o.max_connections),
     max_vcpus: String(o.max_vcpus),
     default_worker_cpu: o.default_worker_cpu,
     default_worker_memory: o.default_worker_memory,
@@ -105,7 +102,6 @@ export function OrgDetail() {
     setMsg(null);
     const body: OrgUpdate = {
       max_workers: Number(form.max_workers) || 0,
-      max_connections: Number(form.max_connections) || 0,
       max_vcpus: Number(form.max_vcpus) || 0,
       default_worker_cpu: form.default_worker_cpu,
       default_worker_memory: form.default_worker_memory,
@@ -156,13 +152,6 @@ export function OrgDetail() {
               <div className="grid grid-cols-2 gap-3">
                 <Field label="Max workers (0 = unbounded)">
                   <Input type="number" value={form.max_workers} onChange={(e) => set("max_workers", e.target.value)} />
-                </Field>
-                <Field label="Max connections (0 = unbounded)">
-                  <Input
-                    type="number"
-                    value={form.max_connections}
-                    onChange={(e) => set("max_connections", e.target.value)}
-                  />
                 </Field>
                 <Field label="Max vCPUs (0 = unbounded)">
                   <Input

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -49,14 +49,6 @@ export function Orgs() {
         },
       },
       {
-        accessorKey: "max_connections",
-        header: "Max conns",
-        cell: ({ getValue }) => {
-          const v = getValue() as number;
-          return <span className="tabular-nums">{v === 0 ? "∞" : fmtInt(v)}</span>;
-        },
-      },
-      {
         accessorKey: "max_vcpus",
         header: "Max vCPUs",
         cell: ({ getValue }) => {

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -57,6 +57,14 @@ export function Orgs() {
         },
       },
       {
+        accessorKey: "max_vcpus",
+        header: "Max vCPUs",
+        cell: ({ getValue }) => {
+          const v = getValue() as number;
+          return <span className="tabular-nums">{v === 0 ? "∞" : fmtInt(v)}</span>;
+        },
+      },
+      {
         id: "users",
         header: "Users",
         accessorFn: (o) => o.users?.length ?? 0,

--- a/controlplane/admin/ui/src/pages/Users.tsx
+++ b/controlplane/admin/ui/src/pages/Users.tsx
@@ -27,7 +27,7 @@ import {
   useUserSecrets,
   useUsers,
 } from "@/hooks/useApi";
-import { fmtTime } from "@/lib/format";
+import { fmtInt, fmtTime } from "@/lib/format";
 import type { OrgUser } from "@/types/api";
 
 export function UsersPage() {
@@ -64,6 +64,14 @@ export function UsersPage() {
         cell: ({ getValue }) => {
           const v = getValue() as string | undefined;
           return v ? <Badge variant="secondary">{v}</Badge> : <span className="text-muted-foreground">—</span>;
+        },
+      },
+      {
+        accessorKey: "max_vcpus",
+        header: "Max vCPUs",
+        cell: ({ getValue }) => {
+          const v = getValue() as number;
+          return <span className="tabular-nums">{v === 0 ? "∞" : fmtInt(v)}</span>;
         },
       },
       {
@@ -125,7 +133,7 @@ export function UsersPage() {
       <PageBody>
         <Card className="overflow-hidden">
           {users.isLoading ? (
-            <TableSkeleton cols={6} />
+            <TableSkeleton cols={7} />
           ) : users.isError ? (
             <ErrorState error={users.error} onRetry={() => users.refetch()} />
           ) : (
@@ -186,6 +194,7 @@ function CreateUserDialog({ onClose }: { onClose: () => void }) {
   const [password, setPassword] = useState("");
   const [passthrough, setPassthrough] = useState(false);
   const [iceberg, setIceberg] = useState(false);
+  const [maxVCPUs, setMaxVCPUs] = useState("0");
   const [err, setErr] = useState<string | null>(null);
 
   const submit = async () => {
@@ -197,6 +206,7 @@ function CreateUserDialog({ onClose }: { onClose: () => void }) {
         password,
         passthrough,
         default_catalog: iceberg ? "iceberg" : "",
+        max_vcpus: Number(maxVCPUs) || 0,
       });
       onClose();
     } catch (e) {
@@ -226,6 +236,10 @@ function CreateUserDialog({ onClose }: { onClose: () => void }) {
             <Label>Password</Label>
             <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
           </div>
+          <div className="space-y-1">
+            <Label>Max vCPUs (0 = unbounded)</Label>
+            <Input type="number" min={0} value={maxVCPUs} onChange={(e) => setMaxVCPUs(e.target.value)} />
+          </div>
           <div className="flex items-center gap-6">
             <label className="flex items-center gap-2 text-sm">
               <Switch checked={passthrough} onCheckedChange={setPassthrough} /> Passthrough
@@ -254,6 +268,7 @@ function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void 
   const [password, setPassword] = useState("");
   const [passthrough, setPassthrough] = useState(user.passthrough);
   const [iceberg, setIceberg] = useState(user.default_catalog === "iceberg");
+  const [maxVCPUs, setMaxVCPUs] = useState(String(user.max_vcpus));
   const [err, setErr] = useState<string | null>(null);
 
   const submit = async () => {
@@ -266,6 +281,7 @@ function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void 
           ...(password ? { password } : {}),
           passthrough,
           default_catalog: iceberg ? "iceberg" : "",
+          max_vcpus: Number(maxVCPUs) || 0,
         },
       });
       onClose();
@@ -289,6 +305,10 @@ function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void 
           <div className="space-y-1">
             <Label>New password</Label>
             <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="unchanged" />
+          </div>
+          <div className="space-y-1">
+            <Label>Max vCPUs (0 = unbounded)</Label>
+            <Input type="number" min={0} value={maxVCPUs} onChange={(e) => setMaxVCPUs(e.target.value)} />
           </div>
           <div className="flex items-center gap-6">
             <label className="flex items-center gap-2 text-sm">

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -46,6 +46,7 @@ export interface Org {
   hostname_alias: string | null;
   max_workers: number;
   max_connections: number;
+  max_vcpus: number;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -60,6 +61,7 @@ export interface Org {
 export interface OrgUpdate {
   max_workers?: number;
   max_connections?: number;
+  max_vcpus?: number;
   default_worker_cpu?: string;
   default_worker_memory?: string;
   default_worker_ttl?: string;
@@ -74,6 +76,7 @@ export interface OrgUser {
   username: string;
   passthrough: boolean;
   default_catalog?: string;
+  max_vcpus: number;
   created_at: string;
   updated_at: string;
 }
@@ -84,12 +87,14 @@ export interface CreateUserBody {
   org_id: string;
   passthrough?: boolean;
   default_catalog?: string;
+  max_vcpus?: number;
 }
 
 export interface UpdateUserBody {
   password?: string;
   passthrough?: boolean;
   default_catalog?: string;
+  max_vcpus?: number;
 }
 
 // GET /api/v1/orgs/:id/users/:username/secrets → { secrets: OrgUserSecret[] }.


### PR DESCRIPTION
## Summary

- Add org-level `max_vcpus` to the admin UI org list and org edit form.
- Add user-level `max_vcpus` to the users table and create/edit dialogs.
- Update admin UI API types so the UI matches the merged backend fields.

## Why

The backend now supports org and per-user vCPU admission limits. The mw-dev admin UI should let operators see and manage those limits directly instead of requiring raw API calls.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run lint` (existing unrelated warnings only)
- `go test -tags kubernetes ./controlplane/admin -run 'Test(CreateUserAcceptsMaxVCPUs|UpdateUserMaxVCPUs|UpdateOrgMaxVCPUs)' -count=1`
- `just lint`
- `git diff --check`
