### PR TITLE
[codex] Remove org max_connections config

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -178,9 +178,8 @@ func (s *gormAPIStore) GetOrg(name string) (*configstore.Org, error) {
 
 func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configstore.Org, bool, error) {
 	fields := map[string]interface{}{
-		"max_workers":     updates.MaxWorkers,
-		"max_connections": updates.MaxConnections,
-		"max_vcpus":       updates.MaxVCPUs,
+		"max_workers": updates.MaxWorkers,
+		"max_vcpus":   updates.MaxVCPUs,
 		// Org default worker profile: written unconditionally so an explicit
 		// empty string CLEARS the default (the handler's presence-merge keeps
 		// omitted fields at their stored values before this runs).
@@ -570,9 +569,6 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	merged := *existing
 	if _, ok := fields["max_workers"]; ok {
 		merged.MaxWorkers = updates.MaxWorkers
-	}
-	if _, ok := fields["max_connections"]; ok {
-		merged.MaxConnections = updates.MaxConnections
 	}
 	if _, ok := fields["max_vcpus"]; ok {
 		merged.MaxVCPUs = updates.MaxVCPUs

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -64,7 +64,6 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 		return nil, false, nil
 	}
 	org.MaxWorkers = updates.MaxWorkers
-	org.MaxConnections = updates.MaxConnections
 	org.MaxVCPUs = updates.MaxVCPUs
 	// Mirrors gormAPIStore: written unconditionally so "" clears (the handler
 	// presence-merge already preserved omitted fields).
@@ -1174,6 +1173,25 @@ func TestGetOrgOmitsMinWorkers(t *testing.T) {
 	}
 }
 
+func TestGetOrgOmitsMaxConnections(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["analytics"] = &configstore.Org{
+		Name: "analytics",
+	}
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/orgs/analytics", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"max_connections"`)) {
+		t.Fatalf("expected org response to omit max_connections, got %s", rec.Body.String())
+	}
+}
+
 func TestManagedWarehouseUpsertColumnsExcludeCreatedAt(t *testing.T) {
 	columns := managedWarehouseUpsertColumns()
 
@@ -1542,35 +1560,6 @@ func TestIsValidDuckLakeSpecVersion(t *testing.T) {
 		if got := isValidDuckLakeSpecVersion(tc.v); got != tc.want {
 			t.Errorf("isValidDuckLakeSpecVersion(%q) = %v, want %v", tc.v, got, tc.want)
 		}
-	}
-}
-
-func TestUpdateOrgMaxConnections(t *testing.T) {
-	store := newFakeAPIStore()
-	store.orgs["analytics"] = &configstore.Org{
-		Name:           "analytics",
-		MaxWorkers:     2,
-		MaxConnections: 5,
-	}
-	router := newTestAPIRouter(store)
-
-	body := []byte(`{
-		"max_connections": 10
-	}`)
-
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
-	}
-	if store.orgs["analytics"].MaxConnections != 10 {
-		t.Fatalf("expected org max_connections to be updated, got %d", store.orgs["analytics"].MaxConnections)
-	}
-	if store.orgs["analytics"].MaxWorkers != 2 {
-		t.Fatalf("expected max_workers to be preserved, got %d", store.orgs["analytics"].MaxWorkers)
 	}
 }
 

--- a/controlplane/admin/static/models.html
+++ b/controlplane/admin/static/models.html
@@ -365,7 +365,6 @@
       name: "Org name. Primary key and stable tenant identifier.",
       database_name: "Database name clients connect with (dbname=). Unique across orgs.",
       max_workers: "Maximum concurrent worker pods this org may run. 0 means use the deployment default.",
-      max_connections: "Legacy org connection cap. Not used for K8s multi-tenant admission.",
       max_vcpus: "Maximum active worker pod vCPUs this org may have admitted. 0 means unlimited.",
       default_worker_cpu: "Operator-set default worker pod CPU (k8s quantity, e.g. 2). Empty means unset. Applied when a connection does not size itself via duckgres.worker_* options.",
       default_worker_memory: "Operator-set default worker pod memory (k8s quantity, e.g. 8Gi). Empty means unset.",
@@ -732,7 +731,6 @@
   // simply never in this allowlist. "int" → numeric input, else text.
   const ORG_EDIT_FIELDS = {
     max_workers: "int",
-    max_connections: "int",
     max_vcpus: "int",
     default_worker_cpu: "text",
     default_worker_memory: "text",

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -33,7 +33,6 @@ import type { ManagedWarehouse, OrgUpdate } from "@/types/api";
 
 interface FormState {
   max_workers: string;
-  max_connections: string;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -43,7 +42,6 @@ interface FormState {
 
 function orgToForm(o: {
   max_workers: number;
-  max_connections: number;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -52,7 +50,6 @@ function orgToForm(o: {
 }): FormState {
   return {
     max_workers: String(o.max_workers),
-    max_connections: String(o.max_connections),
     default_worker_cpu: o.default_worker_cpu,
     default_worker_memory: o.default_worker_memory,
     default_worker_ttl: o.default_worker_ttl,
@@ -102,7 +99,6 @@ export function OrgDetail() {
     setMsg(null);
     const body: OrgUpdate = {
       max_workers: Number(form.max_workers) || 0,
-      max_connections: Number(form.max_connections) || 0,
       default_worker_cpu: form.default_worker_cpu,
       default_worker_memory: form.default_worker_memory,
       default_worker_ttl: form.default_worker_ttl,
@@ -152,13 +148,6 @@ export function OrgDetail() {
               <div className="grid grid-cols-2 gap-3">
                 <Field label="Max workers (0 = unbounded)">
                   <Input type="number" value={form.max_workers} onChange={(e) => set("max_workers", e.target.value)} />
-                </Field>
-                <Field label="Max connections (0 = unbounded)">
-                  <Input
-                    type="number"
-                    value={form.max_connections}
-                    onChange={(e) => set("max_connections", e.target.value)}
-                  />
                 </Field>
                 <Field label="Default worker CPU">
                   <Input

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -49,14 +49,6 @@ export function Orgs() {
         },
       },
       {
-        accessorKey: "max_connections",
-        header: "Max conns",
-        cell: ({ getValue }) => {
-          const v = getValue() as number;
-          return <span className="tabular-nums">{v === 0 ? "∞" : fmtInt(v)}</span>;
-        },
-      },
-      {
         id: "users",
         header: "Users",
         accessorFn: (o) => o.users?.length ?? 0,
@@ -138,7 +130,7 @@ export function Orgs() {
         )}
         <Card className="overflow-hidden">
           {orgs.isLoading ? (
-            <TableSkeleton cols={8} />
+            <TableSkeleton cols={7} />
           ) : orgs.isError ? (
             <ErrorState error={orgs.error} onRetry={() => orgs.refetch()} />
           ) : (

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -45,7 +45,6 @@ export interface Org {
   database_name: string;
   hostname_alias: string | null;
   max_workers: number;
-  max_connections: number;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -59,7 +58,6 @@ export interface Org {
 // Editable subset of Org accepted by PUT /api/v1/orgs/:id.
 export interface OrgUpdate {
   max_workers?: number;
-  max_connections?: number;
   default_worker_cpu?: string;
   default_worker_memory?: string;
   default_worker_ttl?: string;

--- a/controlplane/configstore/migrations/000010_drop_org_max_connections.sql
+++ b/controlplane/configstore/migrations/000010_drop_org_max_connections.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- org max_connections was the old K8s multi-tenant connection-count admission
+-- knob. Admission now uses runtime-store vCPU leases via max_vcpus; standalone
+-- rate_limit.max_connections remains a separate config path outside this table.
+ALTER TABLE duckgres_orgs
+    DROP COLUMN IF EXISTS max_connections;
+
+-- +goose Down
+ALTER TABLE duckgres_orgs
+    ADD COLUMN IF NOT EXISTS max_connections BIGINT DEFAULT 0;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -10,12 +10,11 @@ import "time"
 // alias", multiple orgs can share the NULL state, but any non-NULL alias must
 // be unique across orgs (Postgres ignores NULL in UNIQUE).
 type Org struct {
-	Name           string  `gorm:"primaryKey;size:255" json:"name"`
-	DatabaseName   string  `gorm:"size:255;uniqueIndex" json:"database_name"`
-	HostnameAlias  *string `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
-	MaxWorkers     int     `gorm:"default:0" json:"max_workers"`
-	MaxConnections int     `gorm:"default:0" json:"max_connections"`
-	MaxVCPUs       int     `gorm:"column:max_vcpus;default:0" json:"max_vcpus"`
+	Name          string  `gorm:"primaryKey;size:255" json:"name"`
+	DatabaseName  string  `gorm:"size:255;uniqueIndex" json:"database_name"`
+	HostnameAlias *string `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
+	MaxWorkers    int     `gorm:"default:0" json:"max_workers"`
+	MaxVCPUs      int     `gorm:"column:max_vcpus;default:0" json:"max_vcpus"`
 	// DefaultWorkerCPU/Memory/TTL are the org's operator-set default worker
 	// profile: the pod shape (k8s resource quantities, e.g. "2"/"8Gi") and
 	// hot-idle TTL (Go duration string, e.g. "75m" — stored as a string for
@@ -532,7 +531,6 @@ type OrgConfig struct {
 	DatabaseName            string
 	HostnameAlias           string // empty when no alias is configured
 	MaxWorkers              int
-	MaxConnections          int
 	MaxVCPUs                int
 	DefaultWorkerCPU        string            // org default worker profile: pod cpu quantity ("" = unset)
 	DefaultWorkerMemory     string            // org default worker profile: pod memory quantity ("" = unset)

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -196,7 +196,6 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 			DatabaseName:            o.DatabaseName,
 			HostnameAlias:           alias,
 			MaxWorkers:              o.MaxWorkers,
-			MaxConnections:          o.MaxConnections,
 			MaxVCPUs:                o.MaxVCPUs,
 			DefaultWorkerCPU:        o.DefaultWorkerCPU,
 			DefaultWorkerMemory:     o.DefaultWorkerMemory,

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -27,7 +27,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 7)
 	requireGooseMigrationRecorded(t, db, 8)
 	requireGooseMigrationRecorded(t, db, 9)
-	requireGooseLatestVersion(t, db, 9)
+	requireGooseMigrationRecorded(t, db, 10)
+	requireGooseLatestVersion(t, db, 10)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000007 added the compute-usage billing buffer + drain state.
@@ -59,9 +60,10 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	}
 	requireColumnDefault(t, db, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, db, "duckgres_org_users", "max_vcpus", "0")
+	requireColumnAbsent(t, db, "duckgres_orgs", "max_connections")
 }
 
-func TestConfigStoreSQLMigration9AddsVCPULimitsToVersion8Schema(t *testing.T) {
+func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	_, connStr := newIsolatedConfigStoreSchema(t)
 	store, err := cpconfigStoreNew(connStr)
 	if err != nil {
@@ -75,12 +77,14 @@ func TestConfigStoreSQLMigration9AddsVCPULimitsToVersion8Schema(t *testing.T) {
 	if err := store.DB().Exec(`
 			ALTER TABLE duckgres_orgs DROP COLUMN max_vcpus;
 			ALTER TABLE duckgres_org_users DROP COLUMN max_vcpus;
-			DELETE FROM goose_db_version WHERE version_id = 9;
+			ALTER TABLE duckgres_orgs ADD COLUMN IF NOT EXISTS max_connections BIGINT DEFAULT 0;
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
 	requireColumnAbsent(t, baselineDB, "duckgres_orgs", "max_vcpus")
 	requireColumnAbsent(t, baselineDB, "duckgres_org_users", "max_vcpus")
+	requireColumnPresent(t, baselineDB, "duckgres_orgs", "max_connections")
 	requireGooseLatestVersion(t, baselineDB, 8)
 
 	upgradedStore, err := cpconfigStoreNew(connStr)
@@ -93,9 +97,11 @@ func TestConfigStoreSQLMigration9AddsVCPULimitsToVersion8Schema(t *testing.T) {
 	})
 
 	requireGooseMigrationRecorded(t, upgradedDB, 9)
-	requireGooseLatestVersion(t, upgradedDB, 9)
+	requireGooseMigrationRecorded(t, upgradedDB, 10)
+	requireGooseLatestVersion(t, upgradedDB, 10)
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")
+	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "max_connections")
 }
 
 func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
@@ -156,6 +162,7 @@ func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
 	if maxVCPUs != 0 {
 		t.Fatalf("org max_vcpus after migration = %d, want 0", maxVCPUs)
 	}
+	requireColumnAbsent(t, sqlDB, "duckgres_orgs", "max_connections")
 	requireGooseMigrationRecorded(t, sqlDB, 3)
 }
 


### PR DESCRIPTION
## Summary

- drop the legacy org-level max_connections column with migration 000010
- remove max_connections from the config-store org model, snapshot, and admin org update path
- remove the field from the static model explorer and React admin UI so the frontend no longer reads or sends it

## Why

PR #843 replaced K8s multi-tenant connection-count admission with runtime-store vCPU leases. The remaining org max_connections field is no longer part of that admission contract; standalone rate_limit.max_connections remains separate and unchanged.

## Testing

- go test -tags kubernetes ./controlplane/admin ./controlplane/configstore ./controlplane -count=1
- go test ./tests/configstore -count=1
- go test ./tests/configstore -run 'TestConfigStoreSQLMigrationsUpgradeVersion8Schema$' -count=1
- npm run typecheck
- npm run lint (existing warnings only)
- npm run build
- just lint
- git diff --check

## Follow-up

After this lands, rebase the admin UI vCPU limits PR so it can rely on the backend contract without carrying the max_connections cleanup.