### PR TITLE
controlplane: make backend pids process-global (fix conns-map collision)

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -64,6 +64,22 @@ var globalNextPID = func() *atomic.Int32 {
 	return v
 }()
 
+// reservePID returns the next backend pid from counter, skipping 0. Backend pids
+// are int32; after ~2.1B connections in one process the counter wraps and passes
+// through 0, which the session-create path treats as "unset" (re-allocating and
+// shipping a stale pid to the client → broken cancel for that one connection).
+// Skipping 0 closes that wrap-time edge with a single extra Add. Negative values
+// after wrap are still unique within the CP's conns map and are left as-is
+// (reaching them needs a further ~2.1B connections, and a CP restarts on every
+// deploy long before either bound).
+func reservePID(counter *atomic.Int32) int32 {
+	p := counter.Add(1)
+	if p == 0 {
+		p = counter.Add(1)
+	}
+	return p
+}
+
 // SessionManager tracks all active sessions and their worker assignments.
 type SessionManager struct {
 	mu         sync.RWMutex
@@ -168,7 +184,7 @@ func (sm *SessionManager) SetRequestedVCPUsResolver(fn func(profile *WorkerProfi
 
 // ReservePID generates a new unique PID for a session.
 func (sm *SessionManager) ReservePID() int32 {
-	return globalNextPID.Add(1)
+	return reservePID(globalNextPID)
 }
 
 func (sm *SessionManager) acquireSlot(ctx context.Context) error {
@@ -573,7 +589,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	executor.SetControlMetadata(worker.ID, worker.OwnerCPInstanceID(), worker.OwnerEpoch())
 
 	if pid == 0 {
-		pid = globalNextPID.Add(1)
+		pid = reservePID(globalNextPID)
 	}
 
 	session := &ManagedSession{

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -49,6 +49,21 @@ type ManagedSession struct {
 	queryProgress atomic.Value // stores *SessionProgress (or nil)
 }
 
+// globalNextPID hands out backend PIDs that are unique across the WHOLE control
+// plane process, not per-org. SessionManagers are per-org, but every client
+// connection registers into the ONE server.conns map keyed by pid, so per-org
+// pids (each manager starting at 1000) collided: two orgs' connections at the
+// same pid value would shadow each other in that map, corrupting
+// pg_stat_activity, cancel-by-pid routing, and any pid-keyed lookup. A single
+// process-global counter makes pids unique within the CP and eliminates the
+// collision. (Cross-CP pids can still coincide, but each CP has its own conns
+// map; cross-CP addressing uses the cluster-unique worker id.)
+var globalNextPID = func() *atomic.Int32 {
+	v := new(atomic.Int32)
+	v.Store(1000) // start above typical OS PIDs
+	return v
+}()
+
 // SessionManager tracks all active sessions and their worker assignments.
 type SessionManager struct {
 	mu         sync.RWMutex
@@ -60,8 +75,6 @@ type SessionManager struct {
 	// log carries the manager's org identity (multi-tenant: one manager per
 	// org stack) so every session/worker lifecycle line is org-filterable.
 	log *slog.Logger
-
-	nextPID atomic.Int32
 
 	maxConnections int
 	activeSlots    int
@@ -111,7 +124,6 @@ func NewOrgSessionManager(pool WorkerPool, rebalancer *MemoryRebalancer, orgID s
 		lifecycle:  newSessionLifecycle(),
 		log:        log,
 	}
-	sm.nextPID.Store(1000) // Start PIDs above typical OS PIDs
 	return sm
 }
 
@@ -156,7 +168,7 @@ func (sm *SessionManager) SetRequestedVCPUsResolver(fn func(profile *WorkerProfi
 
 // ReservePID generates a new unique PID for a session.
 func (sm *SessionManager) ReservePID() int32 {
-	return sm.nextPID.Add(1)
+	return globalNextPID.Add(1)
 }
 
 func (sm *SessionManager) acquireSlot(ctx context.Context) error {
@@ -561,7 +573,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	executor.SetControlMetadata(worker.ID, worker.OwnerCPInstanceID(), worker.OwnerEpoch())
 
 	if pid == 0 {
-		pid = sm.nextPID.Add(1)
+		pid = globalNextPID.Add(1)
 	}
 
 	session := &ManagedSession{

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -131,6 +131,25 @@ func TestReservePIDGloballyUniqueAcrossManagers(t *testing.T) {
 	}
 }
 
+// TestReservePIDSkipsZeroAtWrap covers the int32-wrap edge: when the counter
+// passes through 0 (only after ~2.1B connections), reservePID must skip it so a
+// real pid never looks "unset". Uses a LOCAL counter so it doesn't perturb the
+// process-global one other tests share.
+func TestReservePIDSkipsZeroAtWrap(t *testing.T) {
+	var c atomic.Int32
+	c.Store(-1) // next Add(1) lands exactly on 0
+	if p := reservePID(&c); p == 0 {
+		t.Fatalf("reservePID returned 0 at the wrap point; must skip it")
+	}
+	// Normal range: monotonic, never 0.
+	c.Store(1000)
+	for i := 0; i < 5; i++ {
+		if p := reservePID(&c); p == 0 {
+			t.Fatalf("reservePID returned 0 in the normal range")
+		}
+	}
+}
+
 func TestOnWorkerCrash_MarksExecutorsDead(t *testing.T) {
 	pool := &FlightWorkerPool{
 		workers: make(map[int]*ManagedWorker),

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -107,6 +107,30 @@ func TestIsWorkerSessionCapError(t *testing.T) {
 	}
 }
 
+// TestReservePIDGloballyUniqueAcrossManagers is the regression for the conns-map
+// collision: backend pids must be unique across the whole CP process, not
+// per-org. Two managers (two org stacks) reserving pids must never hand out the
+// same value — otherwise their connections shadow each other in the single
+// server.conns map (keyed by pid), corrupting pg_stat_activity / cancel.
+func TestReservePIDGloballyUniqueAcrossManagers(t *testing.T) {
+	smA := NewSessionManager(&FlightWorkerPool{workers: make(map[int]*ManagedWorker)}, nil)
+	smB := NewSessionManager(&FlightWorkerPool{workers: make(map[int]*ManagedWorker)}, nil)
+
+	seen := make(map[int32]string)
+	for i := 0; i < 100; i++ {
+		for who, sm := range map[string]*SessionManager{"A": smA, "B": smB} {
+			pid := sm.ReservePID()
+			if prev, dup := seen[pid]; dup {
+				t.Fatalf("pid %d handed out twice (manager %s then %s) — per-org collision regressed", pid, prev, who)
+			}
+			seen[pid] = who
+			if pid <= 1000 {
+				t.Fatalf("pid %d is not above the 1000 floor", pid)
+			}
+		}
+	}
+}
+
 func TestOnWorkerCrash_MarksExecutorsDead(t *testing.T) {
 	pool := &FlightWorkerPool{
 		workers: make(map[int]*ManagedWorker),

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1464,11 +1464,18 @@ admin_rbac_viewer() { # org
 # connection metadata + live progress. Backed by GET /api/v1/queries/:pid, which
 # joins server.ConnDetailByPID (the already-redacted currentQuery, scoped to the
 # replica that owns the connection) with the session manager's cached progress.
-# Asserts: a real running query is findable via /queries, /queries/:pid returns
-# 200 with the SQL round-tripped + matching identity, and an unknown pid 404s
-# (not a 500). The redaction guarantee itself is unit-tested
+# Asserts: a real running query is findable via /queries, /queries/by-worker/:wid
+# returns 200 with the SQL round-tripped + matching identity, and an unknown
+# worker 404s (not a 500). The redaction guarantee itself is unit-tested
 # (server/conn_detail_test.go, controlplane/admin/live_test.go) — this proves
 # the wiring against a real worker pod.
+#
+# NOTE: backend pids are process-global within a CP (controlplane/session_mgr.go
+# globalNextPID), which removed the per-org pid collision that shadowed conns in
+# the server.conns map (pg_stat_activity / cancel). That can't be asserted
+# in-Job here: forcing a collision needs a FRESH CP with two orgs opening their
+# first connection at the same pid count, which a warm cluster can't reproduce.
+# The deterministic gate is TestReservePIDGloballyUniqueAcrossManagers.
 admin_query_detail() { # org password
   org="$1"; pw="$2"
   log "admin live: per-query detail round-trip on $org"


### PR DESCRIPTION
## The root cause

Surfaced by the #838 live-query-detail review. Backend pids were allocated **per-org** — every `SessionManager`'s `nextPID` started at 1000 (`controlplane/session_mgr.go`) — but every client connection registers into the **one** `server.conns` map keyed by pid. So two orgs' connections at the same pid value collided in that map:

- the later registrant **shadowed** the earlier, which then vanished from `pg_stat_activity` and every pid-keyed lookup;
- either connection closing (`delete(s.conns, pid)`) removed the **other** org's entry;
- cancel-by-pid (`KillSession` scans stacks for the first matching pid) could tear down the **wrong** org's session.

#838 worked around the read side by addressing detail via the cluster-unique worker id (`/queries/by-worker/:wid`), but the underlying map collision remained for `pg_stat_activity` and cancel.

## The fix

Replace the per-manager counter with a single **process-global** atomic (`globalNextPID`, starts at 1000). Pids are now unique within a CP, so the conns map can't collide — `pg_stat_activity`, cancel-by-pid, and any pid-keyed lookup are correct again.

Cross-CP pids can still coincide, but each CP has its own conns map, and cross-CP addressing already uses the cluster-unique worker id. PG clients don't assume pid ranges, so global pids are transparent to them.

## Tests

- **`TestReservePIDGloballyUniqueAcrossManagers`**: two managers (two org stacks) reserving pids never hand out the same value.
- This is the **deterministic gate** — a real collision can't be forced in the warm e2e cluster (it needs a fresh CP with two orgs opening their first connection at the same pid count), which is noted in `harness.sh`.

Closes the follow-up flagged in #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUq2EVxvKQFq3YEDNLF5HP