### PR TITLE
admin/live: flag sessions with no in-flight query (State column)

### DIFF
--- a/controlplane/admin/live.go
+++ b/controlplane/admin/live.go
@@ -27,12 +27,17 @@ type QueryStatus struct {
 	// owning CP from the connection's query-start, so it survives the cross-CP
 	// /queries merge unchanged. The Live view shows query-elapsed when a query is
 	// in flight and falls back to session age otherwise.
-	StartedAt  time.Time `json:"started_at,omitempty"`
-	ElapsedMS  int64     `json:"elapsed_ms"`
-	Percentage float64   `json:"percentage"`
-	Rows       uint64    `json:"rows"`
-	TotalRows  uint64    `json:"total_rows"`
-	Stalled    bool      `json:"stalled"`
+	StartedAt time.Time `json:"started_at,omitempty"`
+	ElapsedMS int64     `json:"elapsed_ms"`
+	// State is the pg_stat_activity-style connection state: "active" when a query
+	// is in flight, else "idle" / "idle in transaction" / "idle in transaction
+	// (aborted)". A non-active session holds a worker but has no in-flight query —
+	// surfaced in the Live view so idle sessions are visible at a glance.
+	State      string  `json:"state"`
+	Percentage float64 `json:"percentage"`
+	Rows       uint64  `json:"rows"`
+	TotalRows  uint64  `json:"total_rows"`
+	Stalled    bool    `json:"stalled"`
 }
 
 // QueryDetail is the expanded, single-session view behind a running query: the

--- a/controlplane/admin/ui/src/lib/session.test.ts
+++ b/controlplane/admin/ui/src/lib/session.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { idleInTransaction, isIdleSession, sessionStateLabel } from "./session";
+
+describe("isIdleSession", () => {
+  it("flags idle states (no in-flight query)", () => {
+    expect(isIdleSession("idle")).toBe(true);
+    expect(isIdleSession("idle in transaction")).toBe(true);
+    expect(isIdleSession("idle in transaction (aborted)")).toBe(true);
+    expect(isIdleSession("IDLE")).toBe(true); // case-insensitive
+  });
+
+  it("does NOT flag active or unknown states", () => {
+    expect(isIdleSession("active")).toBe(false);
+    expect(isIdleSession("active (stuck)")).toBe(false);
+    expect(isIdleSession("")).toBe(false); // unknown → not a false positive
+    expect(isIdleSession(undefined)).toBe(false);
+  });
+});
+
+describe("idleInTransaction", () => {
+  it("distinguishes the open-transaction variant", () => {
+    expect(idleInTransaction("idle in transaction")).toBe(true);
+    expect(idleInTransaction("idle in transaction (aborted)")).toBe(true);
+    expect(idleInTransaction("idle")).toBe(false);
+    expect(idleInTransaction("active")).toBe(false);
+    expect(idleInTransaction(undefined)).toBe(false);
+  });
+});
+
+describe("sessionStateLabel", () => {
+  it("returns the state, or 'unknown' for empty", () => {
+    expect(sessionStateLabel("idle in transaction")).toBe("idle in transaction");
+    expect(sessionStateLabel("")).toBe("unknown");
+    expect(sessionStateLabel(undefined)).toBe("unknown");
+  });
+});

--- a/controlplane/admin/ui/src/lib/session.ts
+++ b/controlplane/admin/ui/src/lib/session.ts
@@ -1,0 +1,25 @@
+// Pure, testable helpers for live-session state. A session that holds a worker
+// but has no in-flight query ("idle"/"idle in transaction") is a smell when
+// it persists — surfaced in the Live view. Keep this logic here, not in JSX.
+
+// isIdleSession reports whether a session has NO in-flight query, i.e. its
+// pg_stat_activity-style state is idle / idle in transaction / aborted. An
+// "active" session (or an unknown/empty state) is NOT flagged — we only mark a
+// session idle when the backend explicitly says so, to avoid false positives
+// during the brief window before state is first reported.
+export function isIdleSession(state: string | undefined): boolean {
+  return (state ?? "").toLowerCase().startsWith("idle");
+}
+
+// idleInTransaction is the worse idle variant: the session holds an OPEN
+// transaction (and its worker) while running nothing. Worth distinguishing in
+// the UI from a plain idle connection.
+export function idleInTransaction(state: string | undefined): boolean {
+  return (state ?? "").toLowerCase().startsWith("idle in transaction");
+}
+
+// sessionStateLabel is the short human label for a session state, for tooltips.
+export function sessionStateLabel(state: string | undefined): string {
+  const s = (state ?? "").trim();
+  return s === "" ? "unknown" : s;
+}

--- a/controlplane/admin/ui/src/pages/Live.tsx
+++ b/controlplane/admin/ui/src/pages/Live.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Activity, Ban, RefreshCw, Zap } from "lucide-react";
+import { Activity, Ban, CircleSlash, RefreshCw, Zap } from "lucide-react";
 import { PageBody, PageHeader } from "@/components/AppShell";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { useCancelSession, useKillUserSessions, useQueries, useSessions } from "@/hooks/useApi";
 import { fmtAge, fmtDurationMs, fmtInt, fmtTime } from "@/lib/format";
+import { idleInTransaction, isIdleSession, sessionStateLabel } from "@/lib/session";
 import { QueryDetailDialog } from "@/components/QueryDetailDialog";
 
 export function Live() {
@@ -140,6 +141,7 @@ export function Live() {
                     <TableHead>Started</TableHead>
                     <TableHead>Worker</TableHead>
                     <TableHead>Protocol</TableHead>
+                    <TableHead>State</TableHead>
                     <TableHead>Duration</TableHead>
                     <TableHead className="w-56">Progress</TableHead>
                     <TableHead className="text-right">Action</TableHead>
@@ -171,6 +173,23 @@ export function Live() {
                         <TableCell className="font-mono text-xs">#{q.worker_id}</TableCell>
                         <TableCell>
                           <Badge variant="outline">{q.protocol || "pg"}</Badge>
+                        </TableCell>
+                        <TableCell>
+                          {isIdleSession(q.state) ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span
+                                  className={idleInTransaction(q.state) ? "text-warning" : "text-muted-foreground"}
+                                  aria-label={`no in-flight query — ${sessionStateLabel(q.state)}`}
+                                >
+                                  <CircleSlash className="h-4 w-4" />
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>No in-flight query — {sessionStateLabel(q.state)}</TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <span className="text-muted-foreground/30">·</span>
+                          )}
                         </TableCell>
                         <TableCell className="font-mono text-xs tabular-nums">{fmtDurationMs(q.elapsed_ms)}</TableCell>
                         <TableCell>

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -300,6 +300,7 @@ export interface RunningQuery {
   stalled: boolean;
   started_at?: string; // RFC3339 session start (session age); may be absent/zero
   elapsed_ms: number; // how long the current statement has been running (0 = idle)
+  state: string; // "active" | "idle" | "idle in transaction" | "idle in transaction (aborted)"
 }
 
 // GET /api/v1/queries/by-worker/:wid → expanded detail for one in-flight query,

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -30,13 +30,13 @@ var _ admin.LiveInfo = (*clusterInfoProvider)(nil)
 // progress, attributed to org + user.
 func (p *clusterInfoProvider) RunningQueries() []admin.QueryStatus {
 	stacks := p.router.AllStacks()
-	// Running-query duration comes from the owning connection's query-start.
-	// Key it by cluster-unique worker id, not pid: pids are allocated per-org
-	// (every stack starts at 1000), so a pid-keyed lookup can read the wrong
-	// org's connection. Snapshot once per poll.
-	var queryStarts map[int]time.Time
+	// Per-connection live state (active/idle + query-start) comes from the owning
+	// connection. Key it by cluster-unique worker id, not pid: pids are allocated
+	// per-org (every stack starts at 1000), so a pid-keyed lookup can read the
+	// wrong org's connection. Snapshot once per poll.
+	var conns map[int]server.ConnLiveSummary
 	if p.srv != nil {
-		queryStarts = p.srv.QueryStartsByWorkerID()
+		conns = p.srv.ConnSummariesByWorkerID()
 	}
 	var out []admin.QueryStatus
 	for org, stack := range stacks {
@@ -55,8 +55,11 @@ func (p *clusterInfoProvider) RunningQueries() []admin.QueryStatus {
 				q.TotalRows = prog.TotalRows
 				q.Stalled = prog.Stalled
 			}
-			if qs, ok := queryStarts[s.WorkerID]; ok {
-				q.ElapsedMS = time.Since(qs).Milliseconds()
+			if cs, ok := conns[s.WorkerID]; ok {
+				q.State = cs.State
+				if !cs.QueryStart.IsZero() {
+					q.ElapsedMS = time.Since(cs.QueryStart).Milliseconds()
+				}
 			}
 			out = append(out, q)
 		}

--- a/docs/design/admin-ui.md
+++ b/docs/design/admin-ui.md
@@ -112,7 +112,9 @@ for live views), TanStack Table (dense sortable tables), Recharts (trends). Page
 4. **Live** — running queries / sessions / connections, sliced + filterable by org & user,
    with progress bars (SessionProgress), a running-query **Duration** column
    (`QueryStatus.ElapsedMS`, computed on the owning CP from the connection's query-start),
-   and a cancel affordance. Opening a running-query row fetches
+   a **State** column (`QueryStatus.State`, the pg_stat_activity-style state) that flags
+   sessions holding a worker with **no in-flight query** — `idle` / `idle in transaction` —
+   a smell when persistent, and a cancel affordance. Opening a running-query row fetches
    `GET /api/v1/queries/by-worker/:wid` on demand — addressed by the **cluster-unique worker
    id**, not pid, because the CP allocates backend pids per-org (every stack starts at 1000)
    so two orgs can share a pid. The detail dialog shows the redacted SQL text

--- a/server/conn_detail_test.go
+++ b/server/conn_detail_test.go
@@ -8,6 +8,50 @@ import (
 	"github.com/posthog/duckgres/server/usersecrets"
 )
 
+// TestConnSummariesByWorkerID covers the live-list state snapshot: an active
+// session reports "active" + a query-start; an idle-in-transaction session
+// reports the idle state + zero query-start; worker-less conns are omitted.
+func TestConnSummariesByWorkerID(t *testing.T) {
+	s := &Server{conns: map[int32]*clientConn{}}
+
+	active := &clientConn{pid: 1, workerID: 100}
+	active.currentQuery.Store("SELECT 1")
+	active.queryStart.Store(time.Now())
+	s.conns[1] = active
+
+	idleTx := &clientConn{pid: 2, workerID: 200, txStatus: txStatusTransaction}
+	idleTx.currentQuery.Store("")
+	s.conns[2] = idleTx
+
+	// Worker-less conn (standalone / transient) must be omitted.
+	noWorker := &clientConn{pid: 3, workerID: -1}
+	noWorker.currentQuery.Store("")
+	s.conns[3] = noWorker
+
+	sums := s.ConnSummariesByWorkerID()
+	if len(sums) != 2 {
+		t.Fatalf("expected 2 worker-bound summaries, got %d", len(sums))
+	}
+	if sums[100].State != "active" || sums[100].QueryStart.IsZero() {
+		t.Fatalf("worker 100 should be active with a query-start, got %+v", sums[100])
+	}
+	if sums[200].State != "idle in transaction" {
+		t.Fatalf("worker 200 should be 'idle in transaction', got %q", sums[200].State)
+	}
+	if !sums[200].QueryStart.IsZero() {
+		t.Fatalf("idle session should have zero query-start, got %v", sums[200].QueryStart)
+	}
+	if _, ok := sums[-1]; ok {
+		t.Fatal("worker-less conn must be omitted")
+	}
+
+	// Nil server is safe.
+	var ns *Server
+	if ns.ConnSummariesByWorkerID() != nil {
+		t.Fatal("nil server should return nil")
+	}
+}
+
 // TestConnDetailByPID covers the admin live-query detail snapshot: registry
 // lookup, the (load-bearing) redaction guarantee, and state derivation.
 func TestConnDetailByPID(t *testing.T) {

--- a/server/conn_pg_stat_activity.go
+++ b/server/conn_pg_stat_activity.go
@@ -227,21 +227,27 @@ func (c *clientConn) sendPgStatActivityDataRow(conn *clientConn, formatCodes []i
 // path must never surface raw SQL, or a CREATE PERSISTENT SECRET credential
 // would leak into the admin UI. The state string mirrors the pg_stat_activity
 // derivation above (active iff a query is in flight, else the txn idle state).
+// connState returns the pg_stat_activity-style state string: "active" when a
+// query is in flight, else the idle / idle-in-transaction state from the txn
+// status. An "active" session has query data; anything else is idle (no
+// in-flight query) — the smell the Live view flags.
+func (c *clientConn) connState() string {
+	if q, _ := c.currentQuery.Load().(string); q != "" {
+		return "active"
+	}
+	switch c.txStatus {
+	case txStatusTransaction:
+		return "idle in transaction"
+	case txStatusError:
+		return "idle in transaction (aborted)"
+	default:
+		return "idle"
+	}
+}
+
 func (c *clientConn) connDetail() ConnDetail {
 	q, _ := c.currentQuery.Load().(string)
-	var state string
-	if q != "" {
-		state = "active"
-	} else {
-		switch c.txStatus {
-		case txStatusTransaction:
-			state = "idle in transaction"
-		case txStatusError:
-			state = "idle in transaction (aborted)"
-		default:
-			state = "idle"
-		}
-	}
+	state := c.connState()
 	d := ConnDetail{
 		PID:             c.pid,
 		OrgID:           c.orgID,

--- a/server/exports.go
+++ b/server/exports.go
@@ -138,25 +138,35 @@ func (s *Server) ConnDetailByWorkerID(workerID int) (ConnDetail, bool) {
 	return ConnDetail{}, false
 }
 
-// QueryStartsByWorkerID returns the current-statement start time of every live
-// connection that has a query in flight, keyed by cluster-unique worker id. Used
-// to attach running-query duration to the live list in one pass (no per-session
-// lookup, and keyed on worker id rather than the collision-prone per-org pid).
-// Idle connections (no query) are omitted.
-func (s *Server) QueryStartsByWorkerID() map[int]time.Time {
+// ConnLiveSummary is the per-connection live state the admin Live list needs:
+// the pg_stat_activity-style State and the current-query start. State is
+// "active" when a query is in flight; anything else means no in-flight query.
+type ConnLiveSummary struct {
+	State      string    // active | idle | idle in transaction | idle in transaction (aborted)
+	QueryStart time.Time // zero when no query is in flight
+}
+
+// ConnSummariesByWorkerID returns a one-pass snapshot of every live connection
+// keyed by cluster-unique worker id: its state and current-query start. Used to
+// attach running-query duration AND the active/idle state to the live list in a
+// single lock acquisition (keyed on worker id, not the collision-prone per-org
+// pid). Connections with no worker (standalone / transient) are omitted.
+func (s *Server) ConnSummariesByWorkerID() map[int]ConnLiveSummary {
 	if s == nil {
 		return nil
 	}
 	s.connsMu.RLock()
 	defer s.connsMu.RUnlock()
-	out := make(map[int]time.Time, len(s.conns))
+	out := make(map[int]ConnLiveSummary, len(s.conns))
 	for _, c := range s.conns {
 		if c.workerID < 0 {
 			continue
 		}
+		sum := ConnLiveSummary{State: c.connState()}
 		if qs, ok := c.queryStart.Load().(time.Time); ok && !qs.IsZero() {
-			out[c.workerID] = qs
+			sum.QueryStart = qs
 		}
+		out[c.workerID] = sum
 	}
 	return out
 }

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1476,6 +1476,36 @@ admin_rbac_viewer() { # org
 # in-Job here: forcing a collision needs a FRESH CP with two orgs opening their
 # first connection at the same pid count, which a warm cluster can't reproduce.
 # The deterministic gate is TestReservePIDGloballyUniqueAcrossManagers.
+
+# ---- admin live: idle (no in-flight query) sessions are flagged ------------
+# QueryStatus.State surfaces the pg_stat_activity-style connection state in
+# /queries, so the Live view can flag sessions that hold a worker but run no
+# query (idle / idle in transaction) — a smell when persistent. We hold a
+# connection idle-in-transaction (send BEGIN, then keep stdin open so psql
+# waits) and assert /queries reports an idle* state for that session.
+admin_idle_session_flagged() { # org password
+  org="$1"; pw="$2"
+  log "admin live: idle-in-transaction session is flagged (no in-flight query) on $org"
+  ( printf 'BEGIN;\n'; sleep 30 ) | PGPASSWORD="$pw" psql \
+      "sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
+      -v ON_ERROR_STOP=1 -qtA >/dev/null 2>&1 &
+  bg=$!
+  cleanup_idle() { kill "$bg" 2>/dev/null || true; wait "$bg" 2>/dev/null || true; }
+  found="" a=0
+  while [ "$a" -lt 20 ]; do
+    kill -0 "$bg" 2>/dev/null || break
+    found="$(curl -fsS -H "$H" "$API/api/v1/queries" \
+      | jq -r --arg o "$org" 'first(.queries[]? | select(.org==$o and ((.state // "")|test("idle";"i"))) | .state) // empty')"
+    [ -n "$found" ] && break
+    sleep 2; a=$((a + 1))
+  done
+  cleanup_idle
+  case "$found" in
+    idle*) log "admin live: idle session flagged OK (state='$found') on $org" ;;
+    *) fail "admin_idle_session_flagged: /queries never reported an idle* state for an idle-in-transaction session on $org (got '$found')" ;;
+  esac
+}
+
 admin_query_detail() { # org password
   org="$1"; pw="$2"
   log "admin live: per-query detail round-trip on $org"
@@ -1970,6 +2000,9 @@ main() {
 
   # ---- admin live-query detail view (phase 1) — cnpg stack is warm now ----
   admin_query_detail "$CNPG" "$cnpg_pw"
+
+  # ---- admin live: idle-in-transaction session is flagged (state column) ----
+  admin_idle_session_flagged "$CNPG" "$cnpg_pw"
 
   # ---- admin /status per-org worker count is populated (not the old 0) ----
   admin_per_org_workers "$CNPG" "$cnpg_pw"


### PR DESCRIPTION
## Why

Active sessions that hold a worker but run **no query** (`idle` / `idle in transaction`) are a smell — exactly the pattern behind the recent prod runaway: a client BEGINs a transaction and sits idle, pinning a worker. The Live view couldn't show this; the screenshot that prompted this had to be opened in the detail dialog to see "idle in transaction / (no active statement)".

## What

A **State** column in the Live running-queries table that flags idle sessions at a glance.

- **server**: `ConnSummariesByWorkerID` returns each live connection's pg_stat_activity-style **state** + query-start in one pass, keyed by the cluster-unique worker id. Replaces the narrower `QueryStartsByWorkerID`; `connState()` is factored out of `connDetail()` so the list and the detail dialog agree.
- **admin**: `QueryStatus.State` carries the state through `/queries` (and survives the cross-CP merge); `RunningQueries` populates it.
- **ui**: idle / idle-in-transaction sessions show an amber `⊘` icon with a tooltip of the exact state; active sessions show nothing. The classification is pure, tested logic in `lib/session.ts` (`isIdleSession` / `idleInTransaction` / `sessionStateLabel`) — unknown/empty state is deliberately **not** flagged (no false positives during the first-poll window).

## Tests

- `server` `TestConnSummariesByWorkerID` — active vs idle-in-transaction vs worker-less.
- `lib/session.test.ts` — idle/active/unknown classification (vitest).
- `harness.sh` `admin_idle_session_flagged` — holds a real connection **idle in transaction** (sends `BEGIN`, keeps stdin open) and asserts `/queries` reports an `idle*` state for it.

Backend, UI typecheck/test/build/lint, and harness syntax all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUq2EVxvKQFq3YEDNLF5HP