### PR TITLE
controlplane: default a 60s connection idle timeout (free idle workers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Key CLI flags for control-plane mode:
 - `--process-min-workers N` / `--process-max-workers N`
 - `--process-retire-on-session-end`
 - `--worker-queue-timeout DURATION` / `--worker-idle-timeout DURATION`
+- `--idle-timeout DURATION` — connection idle timeout: a client connection with no traffic for this long is closed and its worker released to hot-idle (in control-plane mode an idle connection otherwise pins a worker forever). **Control-plane default is `60s`** (`server.DefaultControlPlaneIdleTimeout`; standalone defaults to `24h`); a negative value disables it. `server.New` applies the standalone default, so the control plane sets it explicitly before `InitMinimalServer` (which skips that defaulting).
 - `--memory-budget SIZE` (default 75% RAM) / `--memory-rebalance`
 - `--socket-dir /path` (process backend)
 - `--handover-drain-timeout DURATION` (default `24h` process; **remote default is `0` = unbounded** — the CP waits for active sessions for as long as it takes and the pod's k8s `terminationGracePeriodSeconds` is the only hard wall. cloudflare/tableflip FD passing applies to process/standalone single-host upgrades, not k8s pod replacement.)

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -34,7 +34,7 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 	keyFile := fs.String("key", "", "TLS private key file (env: DUCKGRES_KEY)")
 	filePersistence := fs.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
 	processIsolation := fs.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
-	idleTimeout := fs.String("idle-timeout", "", "Connection idle timeout (e.g., '30m', '1h', '-1' to disable) (env: DUCKGRES_IDLE_TIMEOUT)")
+	idleTimeout := fs.String("idle-timeout", "", "Connection idle timeout: close a connection idle (no traffic) this long, freeing its worker (e.g., '30m', '1h', '-1s' to disable). Default 24h standalone, 60s control-plane where idle connections pin a worker (env: DUCKGRES_IDLE_TIMEOUT)")
 	sessionInitTimeout := fs.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
 	memoryLimit := fs.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
 	threads := fs.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -477,6 +477,15 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		cfg.AlwaysDuckLake = true
 	}
 
+	// Default the connection idle timeout to a short value: in control-plane
+	// mode an idle client connection pins a worker (a scarce k8s pod / local
+	// process), so a connection idle this long is closed and its worker released
+	// to hot-idle. InitMinimalServer does NOT run server.New's defaulting, so set
+	// it here. --idle-timeout overrides (negative disables). Standalone keeps the
+	// 24h default applied in server.New.
+	cfg.Config.IdleTimeout = server.NormalizeIdleTimeout(cfg.Config.IdleTimeout, server.DefaultControlPlaneIdleTimeout)
+	slog.Info("Control-plane connection idle timeout.", "timeout", cfg.Config.IdleTimeout)
+
 	// Create a minimal server for cancel request routing
 	srv := &server.Server{}
 	server.InitMinimalServer(srv, cfg.Config, nil)

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -483,8 +483,8 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	// to hot-idle. InitMinimalServer does NOT run server.New's defaulting, so set
 	// it here. --idle-timeout overrides (negative disables). Standalone keeps the
 	// 24h default applied in server.New.
-	cfg.Config.IdleTimeout = server.NormalizeIdleTimeout(cfg.Config.IdleTimeout, server.DefaultControlPlaneIdleTimeout)
-	slog.Info("Control-plane connection idle timeout.", "timeout", cfg.Config.IdleTimeout)
+	cfg.IdleTimeout = server.NormalizeIdleTimeout(cfg.IdleTimeout, server.DefaultControlPlaneIdleTimeout)
+	slog.Info("Control-plane connection idle timeout.", "timeout", cfg.IdleTimeout)
 
 	// Create a minimal server for cancel request routing
 	srv := &server.Server{}

--- a/server/conn.go
+++ b/server/conn.go
@@ -1080,12 +1080,22 @@ func (c *clientConn) sendInitialParams() {
 	}
 }
 
+// armIdleReadDeadline re-arms the connection's read deadline to the configured
+// idle timeout ahead of a client read. Loops that read MANY client messages
+// within one logical operation (COPY FROM STDIN streaming its CopyData) must
+// call this before EACH read, so the timeout measures inter-message idle rather
+// than the operation's total duration — an actively-streaming COPY never times
+// out, a stalled/abandoned one is reaped after the idle timeout. No-op when the
+// idle timeout is disabled (IdleTimeout <= 0), matching the message loop.
+func (c *clientConn) armIdleReadDeadline() {
+	if c.server.cfg.IdleTimeout > 0 {
+		_ = c.conn.SetReadDeadline(time.Now().Add(c.server.cfg.IdleTimeout))
+	}
+}
+
 func (c *clientConn) messageLoop() error {
 	for {
-		// Set read deadline if idle timeout is configured
-		if c.server.cfg.IdleTimeout > 0 {
-			_ = c.conn.SetReadDeadline(time.Now().Add(c.server.cfg.IdleTimeout))
-		}
+		c.armIdleReadDeadline()
 
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {

--- a/server/conn_copy.go
+++ b/server/conn_copy.go
@@ -632,6 +632,7 @@ func (c *clientConn) handleCopyIn(query, upperQuery string) error {
 	dataReceiveStart := time.Now()
 
 	for {
+		c.armIdleReadDeadline() // per-message: don't kill an actively-streaming COPY
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {
 			c.logger().Error("COPY FROM STDIN error reading message.", "error", err)
@@ -845,6 +846,7 @@ func (r *copyDataWireReader) Read(p []byte) (int, error) {
 			}
 			return 0, io.EOF
 		}
+		r.c.armIdleReadDeadline() // per-message: don't kill an actively-streaming COPY
 		msgType, body, err := wire.ReadMessage(r.c.reader)
 		if err != nil {
 			r.done = true
@@ -900,6 +902,7 @@ func (c *clientConn) handleCopyInCSVWithBlob(query string, opts *CopyFromOptions
 	// Buffer all CopyData messages into memory (we need to parse CSV, not stream to file)
 	var buf bytes.Buffer
 	for {
+		c.armIdleReadDeadline() // per-message: don't kill an actively-streaming COPY
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {
 			return err
@@ -1034,6 +1037,7 @@ func (c *clientConn) handleCopyInBinary(query string, opts *CopyFromOptions, col
 	// Collect all CopyData messages into a buffer
 	var buf bytes.Buffer
 	for {
+		c.armIdleReadDeadline() // per-message: don't kill an actively-streaming COPY
 		msgType, body, err := wire.ReadMessage(c.reader)
 		if err != nil {
 			c.logger().Error("COPY FROM STDIN binary: error reading message.", "error", err)

--- a/server/conn_idle_test.go
+++ b/server/conn_idle_test.go
@@ -15,8 +15,8 @@ import (
 // worker back to hot-idle.
 func TestMessageLoopIdleTimeoutClosesConnection(t *testing.T) {
 	clientSide, serverSide := net.Pipe()
-	defer clientSide.Close()
-	defer serverSide.Close()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
 
 	s := &Server{}
 	InitMinimalServer(s, Config{IdleTimeout: 50 * time.Millisecond}, nil)

--- a/server/conn_idle_test.go
+++ b/server/conn_idle_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestMessageLoopIdleTimeoutClosesConnection proves the mechanism the
+// control-plane idle default relies on: with IdleTimeout configured, a
+// connection that sends nothing hits the read deadline and the message loop
+// returns nil (a clean close), which in the CP triggers DestroySession →
+// worker back to hot-idle.
+func TestMessageLoopIdleTimeoutClosesConnection(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	s := &Server{}
+	InitMinimalServer(s, Config{IdleTimeout: 50 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cc := &clientConn{
+		server: s,
+		conn:   serverSide,
+		reader: bufio.NewReader(serverSide),
+		writer: bufio.NewWriter(serverSide),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cc.messageLoop() }()
+
+	// The client never sends a message → the server idle-times-out and the loop
+	// returns nil (clean close), NOT an error.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on idle close, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("messageLoop did not return on idle timeout")
+	}
+}

--- a/server/exports.go
+++ b/server/exports.go
@@ -79,6 +79,29 @@ func NewClientConn(s *Server, conn net.Conn, reader *bufio.Reader, writer *bufio
 	}
 }
 
+// DefaultControlPlaneIdleTimeout is the connection idle timeout the control
+// plane applies when none is configured. In remote/process control-plane mode
+// an idle client connection pins a worker (a scarce k8s pod or local process),
+// so an idle connection is closed after this long — its message loop hits the
+// read deadline, returns, and the worker is released back to the hot-idle pool.
+// Operators override it with --idle-timeout (a negative value disables it).
+const DefaultControlPlaneIdleTimeout = 60 * time.Second
+
+// NormalizeIdleTimeout resolves a configured connection idle timeout: zero means
+// "unset" → use zeroDefault; a negative value means "explicitly disabled" → 0
+// (no timeout); a positive value is used as-is. Shared by standalone (24h
+// default) and the control plane (DefaultControlPlaneIdleTimeout).
+func NormalizeIdleTimeout(configured, zeroDefault time.Duration) time.Duration {
+	switch {
+	case configured == 0:
+		return zeroDefault
+	case configured < 0:
+		return 0
+	default:
+		return configured
+	}
+}
+
 // ConnDetail is a redacted snapshot of one live client connection, for the
 // admin live-query detail view. Query is the ALREADY-redacted current/last
 // query (usersecrets.RedactForLog, same as pg_stat_activity) — callers must

--- a/server/server.go
+++ b/server/server.go
@@ -416,13 +416,11 @@ func New(cfg Config) (*Server, error) {
 		cfg.ShutdownTimeout = 30 * time.Second
 	}
 
-	// Use default idle timeout if not specified (24 hours)
-	// Negative value means explicitly disabled (set to 0)
-	if cfg.IdleTimeout == 0 {
-		cfg.IdleTimeout = 24 * time.Hour
-	} else if cfg.IdleTimeout < 0 {
-		cfg.IdleTimeout = 0
-	}
+	// Standalone defaults to a 24h connection idle timeout (an idle in-process
+	// connection costs little). The control plane overrides this with a much
+	// shorter default (see NormalizeIdleTimeout) because there an idle
+	// connection pins a scarce worker.
+	cfg.IdleTimeout = NormalizeIdleTimeout(cfg.IdleTimeout, 24*time.Hour)
 	if cfg.SessionInitTimeout == 0 {
 		cfg.SessionInitTimeout = DefaultSessionInitTimeout
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,6 +13,25 @@ import (
 	"time"
 )
 
+func TestNormalizeIdleTimeout(t *testing.T) {
+	const def = 60 * time.Second
+	cases := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{"unset uses default", 0, def},
+		{"negative disables", -1, 0},
+		{"explicit positive passes through", 90 * time.Second, 90 * time.Second},
+		{"any negative disables", -5 * time.Minute, 0},
+	}
+	for _, tc := range cases {
+		if got := NormalizeIdleTimeout(tc.configured, def); got != tc.want {
+			t.Errorf("%s: NormalizeIdleTimeout(%v, %v) = %v, want %v", tc.name, tc.configured, def, got, tc.want)
+		}
+	}
+}
+
 type mockRefreshExecer struct {
 	mu            sync.Mutex
 	secretCalls   int

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1438,6 +1438,58 @@ admin_per_org_workers() { # org password
   log "admin: /status per-org worker count OK (workers>=1, total_workers>=1) on $org"
 }
 
+# ---- connection idle timeout: idle conn reaped, worker freed ----------------
+# An idle client connection pins a worker (one session per worker), so the
+# control plane defaults to a short connection idle timeout (server.Default
+# ControlPlaneIdleTimeout, 60s): a connection with no traffic for that long is
+# closed by the message loop's read deadline, DestroySession runs, and the
+# worker returns to hot-idle. We hold a connection idle-in-transaction PAST the
+# timeout and assert its session disappears from /queries while our client is
+# still connected (so the reap is the CP's, not our client exiting). The unit
+# tests (TestNormalizeIdleTimeout + TestMessageLoopIdleTimeoutClosesConnection)
+# are the deterministic gate for the mechanism; this proves the real default
+# fires end-to-end in-cluster.
+conn_idle_timeout_reaps_session() { # org password
+  org="$1"; pw="$2"
+  log "conn idle timeout: idle connection is reaped + worker freed on $org"
+  rootwids() {
+    curl -fsS -H "$H" "$API/api/v1/queries" \
+      | jq -r --arg o "$org" '[.queries[]? | select(.org==$o and .user=="root") | .worker_id] | sort | join(" ")'
+  }
+  before="$(rootwids)"
+  # Hold a connection idle-in-transaction for 150s (well past the 60s timeout):
+  # send BEGIN, then keep stdin open so psql waits and issues no further query.
+  ( printf 'BEGIN;\n'; sleep 150 ) | PGPASSWORD="$pw" psql \
+      "sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
+      -v ON_ERROR_STOP=1 -qtA >/dev/null 2>&1 &
+  bg=$!
+  cleanup_ir() { kill "$bg" 2>/dev/null || true; wait "$bg" 2>/dev/null || true; }
+  # The NEW root worker_id (not present before) is our idle connection's.
+  wid="" a=0
+  while [ "$a" -lt 30 ]; do
+    kill -0 "$bg" 2>/dev/null || break
+    for w in $(rootwids); do
+      case " $before " in *" $w "*) : ;; *) wid="$w"; break ;; esac
+    done
+    [ -n "$wid" ] && break
+    sleep 2; a=$((a + 1))
+  done
+  [ -n "$wid" ] || { cleanup_ir; fail "conn_idle_timeout: idle session never appeared for $org"; }
+  log "conn idle timeout: idle session on worker $wid — waiting for the CP to reap it"
+  # Must vanish from /queries within ~90s (60s timeout + grace), while our client
+  # is STILL alive (kill -0) so the disappearance is the CP reaping, not us.
+  gone="" a=0
+  while [ "$a" -lt 30 ]; do
+    kill -0 "$bg" 2>/dev/null || { cleanup_ir; fail "conn_idle_timeout: our client exited before reap — inconclusive"; }
+    present="$(curl -fsS -H "$H" "$API/api/v1/queries" | jq -r --argjson w "$wid" 'any(.queries[]?; .worker_id==$w)')"
+    [ "$present" = "false" ] && { gone=1; break; }
+    sleep 3; a=$((a + 1))
+  done
+  cleanup_ir
+  [ -n "$gone" ] || fail "conn_idle_timeout: idle session on worker $wid was NOT reaped within ~90s (idle timeout not enforced)"
+  log "conn idle timeout: idle session reaped, worker $wid freed on $org"
+}
+
 # ---- admin RBAC: SSO viewer is read-only -----------------------------------
 # A forged ALB OIDC header (no internal secret) for an @posthog.com email that
 # is NOT in the operators table resolves to the viewer role (fail-closed
@@ -1973,6 +2025,9 @@ main() {
 
   # ---- admin /status per-org worker count is populated (not the old 0) ----
   admin_per_org_workers "$CNPG" "$cnpg_pw"
+
+  # ---- connection idle timeout: idle conn reaped, worker freed ----
+  conn_idle_timeout_reaps_session "$CNPG" "$cnpg_pw"
 
   # ---- per-user kill switch + disable/enable block (cnpg stack is warm) ----
   user_kill_switch   "$CNPG" "$cnpg_pw"

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1490,6 +1490,52 @@ conn_idle_timeout_reaps_session() { # org password
   log "conn idle timeout: idle session reaped, worker $wid freed on $org"
 }
 
+# ---- COPY FROM STDIN: active in Live + survives the idle timeout ------------
+# An actively-streaming COPY reads many CopyData messages; each in-loop read
+# re-arms the read deadline (server/conn_copy.go armIdleReadDeadline), so a COPY
+# that streams for LONGER than the idle timeout but never stalls must NOT be
+# reaped mid-stream (the regression the 60s default would otherwise cause for
+# the COPY-heavy data-import users). It must also be categorized as an ACTIVE
+# query in /queries (elapsed_ms>0), not an idle session, while it streams.
+copy_active_and_survives_idle() { # org password
+  org="$1"; pw="$2"
+  log "COPY FROM STDIN: active in Live + survives idle timeout on $org"
+  out="$(mktemp)"
+  conn="sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake"
+  # 6 chunks of 60 rows with 11s gaps → ~66s total stream, each gap < the 60s
+  # timeout. ON_ERROR_STOP makes a mid-stream reap fail the run (no 360 count).
+  ( printf 'DROP TABLE IF EXISTS e2e_idle_copy;\n'
+    printf 'CREATE TABLE e2e_idle_copy(v TEXT);\n'
+    printf '\\copy e2e_idle_copy(v) FROM STDIN\n'
+    for i in $(seq 1 6); do
+      for j in $(seq 1 60); do printf 'row-%d-%d\n' "$i" "$j"; done
+      sleep 11
+    done
+    printf '\\.\n'
+    printf 'SELECT count(*) FROM e2e_idle_copy;\n'
+    printf 'DROP TABLE e2e_idle_copy;\n'
+  ) | PGPASSWORD="$pw" psql "$conn" -v ON_ERROR_STOP=1 -qtA >"$out" 2>&1 &
+  bg=$!
+  cleanup_copy() { kill "$bg" 2>/dev/null || true; wait "$bg" 2>/dev/null || true; rm -f "$out"; }
+  # While it streams, /queries must show it as an ACTIVE query (elapsed_ms>0),
+  # not an idle session.
+  active="" a=0
+  while [ "$a" -lt 20 ]; do
+    kill -0 "$bg" 2>/dev/null || break
+    e="$(curl -fsS -H "$H" "$API/api/v1/queries" \
+      | jq -r --arg o "$org" 'first(.queries[]? | select(.org==$o and .user=="root" and (.elapsed_ms>0))) | .elapsed_ms // empty')"
+    [ -n "$e" ] && { active=1; break; }
+    sleep 3; a=$((a + 1))
+  done
+  [ -n "$active" ] || { cleanup_copy; fail "copy_active: streaming COPY not categorized active (elapsed_ms>0) in /queries on $org"; }
+  # It must finish successfully with all 360 rows (NOT reaped mid-stream).
+  wait "$bg"; rc=$?
+  { [ "$rc" -eq 0 ] && grep -qx "360" "$out"; } \
+    || { rm -f "$out"; fail "copy_active: streaming COPY (~66s) did not succeed with 360 rows (rc=$rc): $(tr '\n' ' ' <"$out" | tail -c 300)"; }
+  rm -f "$out"
+  log "COPY FROM STDIN: active in Live + survived idle timeout (360 rows) on $org"
+}
+
 # ---- admin RBAC: SSO viewer is read-only -----------------------------------
 # A forged ALB OIDC header (no internal secret) for an @posthog.com email that
 # is NOT in the operators table resolves to the viewer role (fail-closed
@@ -2028,6 +2074,9 @@ main() {
 
   # ---- connection idle timeout: idle conn reaped, worker freed ----
   conn_idle_timeout_reaps_session "$CNPG" "$cnpg_pw"
+
+  # ---- COPY FROM STDIN survives the idle timeout + shows active ----
+  copy_active_and_survives_idle "$CNPG" "$cnpg_pw"
 
   # ---- per-user kill switch + disable/enable block (cnpg stack is warm) ----
   user_kill_switch   "$CNPG" "$cnpg_pw"


### PR DESCRIPTION
## Why

In control-plane mode **one connection pins one worker** (a scarce k8s pod / local process). A connection that connects and then issues no queries — or sits `idle in transaction` — holds its worker "hot" **forever**. That's the worker accumulation we've been fighting: the Live view shows sessions backend-started 3+ hours ago, `idle` / `(no active statement)`, pinning workers that do nothing.

## The gap

The idle-timeout **mechanism already exists** — the message loop sets a read deadline from `cfg.IdleTimeout`, closes the connection when it fires, and the handler's `defer DestroySession` releases the worker back to **hot-idle**. But:

- `server.New()` applies the default (24h);
- the control plane builds its server via `InitMinimalServer`, which **skips** `New()`'s defaulting;
- so `IdleTimeout` was `0` = **disabled**, and CP connections were never idle-reaped.

## The fix

- `server.NormalizeIdleTimeout(configured, zeroDefault)` — shared resolution (`0` → default, negative → disabled, positive → as-is). `server.New` uses it with the 24h standalone default.
- `server.DefaultControlPlaneIdleTimeout = 60s`; the control plane applies it before `InitMinimalServer`. `--idle-timeout` overrides; a negative value disables.

A connection idle for 60s is now closed → `DestroySession` → **worker returns to hot-idle** (not retired), available for reuse. Standalone is unchanged (24h).

## Tests

- **`TestNormalizeIdleTimeout`** — the resolution table.
- **`TestMessageLoopIdleTimeoutClosesConnection`** — an idle connection (via `net.Pipe`) hits the read deadline and the loop returns a clean close. These two are the deterministic gate.
- **`harness.sh conn_idle_timeout_reaps_session`** — holds a real connection `idle in transaction` past the timeout and asserts its session **vanishes from `/queries` while the client is still connected** (so the reap is the CP's, not the client exiting), end-to-end on the mw-dev cluster.

Note: the semantic is "no client traffic for the timeout" (read-deadline based), which for a worker-pinning idle/idle-in-transaction connection is exactly query-inactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUq2EVxvKQFq3YEDNLF5HP