### PR TITLE
admin/audit: human-readable action labels + change details

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -519,6 +521,9 @@ func (h *apiHandler) createOrg(c *gin.Context) {
 	if org.HostnameAlias != nil && *org.HostnameAlias == "" {
 		org.HostnameAlias = nil
 	}
+	// POST /orgs has no :id param, so the audit org column is blank — record the
+	// created org's name here instead.
+	setAuditDetail(c, "created org "+org.Name)
 	if err := h.store.CreateOrg(&org); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 		return
@@ -590,6 +595,27 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
+
+	// Audit detail: which fields changed and their old → new values, so the
+	// console shows "max_workers 4 → 10" instead of a bare "org.update". These
+	// are all non-sensitive config columns (no credentials among them).
+	var changes []string
+	addChange := func(key string, old, next any) {
+		if _, ok := fields[key]; ok && old != next {
+			changes = append(changes, fmt.Sprintf("%s %v → %v", key, old, next))
+		}
+	}
+	addChange("max_workers", existing.MaxWorkers, merged.MaxWorkers)
+	addChange("max_vcpus", existing.MaxVCPUs, merged.MaxVCPUs)
+	addChange("default_worker_cpu", orgStr(existing.DefaultWorkerCPU), orgStr(merged.DefaultWorkerCPU))
+	addChange("default_worker_memory", orgStr(existing.DefaultWorkerMemory), orgStr(merged.DefaultWorkerMemory))
+	addChange("default_worker_ttl", orgStr(existing.DefaultWorkerTTL), orgStr(merged.DefaultWorkerTTL))
+	addChange("default_worker_min_hot_idle", existing.DefaultWorkerMinHotIdle, merged.DefaultWorkerMinHotIdle)
+	addChange("hostname_alias", orgStrPtr(existing.HostnameAlias), orgStrPtr(merged.HostnameAlias))
+	if len(changes) > 0 {
+		setAuditDetail(c, strings.Join(changes, ", "))
+	}
+
 	org, ok, err := h.store.UpdateOrg(name, merged)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -614,6 +640,40 @@ func (h *apiHandler) deleteOrg(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"deleted": name})
+}
+
+// topLevelJSONKeys returns the sorted top-level object keys of a JSON body, or
+// nil if it isn't a JSON object. Used to audit WHICH warehouse sections a PUT
+// touched without recording their (possibly secret) values.
+func topLevelJSONKeys(body []byte) []string {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// orgStr renders an org config string value for audit detail, showing "" as a
+// readable "(unset)" so a cleared field is unambiguous.
+func orgStr(s string) string {
+	if s == "" {
+		return "(unset)"
+	}
+	return s
+}
+
+// orgStrPtr renders an optional org config string (nil == unset) for audit
+// detail.
+func orgStrPtr(s *string) string {
+	if s == nil {
+		return "(unset)"
+	}
+	return orgStr(*s)
 }
 
 func validateOrgMutationPayload(org *configstore.Org) error {
@@ -739,6 +799,14 @@ func (h *apiHandler) putManagedWarehouse(c *gin.Context) {
 		return
 	}
 
+	// Audit detail: the top-level warehouse sections touched by this PUT (field
+	// NAMES only — the values can carry credentials/secret refs, so we never put
+	// them in the audit log). Gives "changed: metadata_store, s3" instead of a
+	// bare "warehouse.update".
+	if changed := topLevelJSONKeys(body); len(changed) > 0 {
+		setAuditDetail(c, "changed: "+strings.Join(changed, ", "))
+	}
+
 	// MutateManagedWarehouse locks the row inside a transaction, runs the
 	// closure, and commits — closing the race where two concurrent PUTs would
 	// otherwise Get + modify different snapshots and silently clobber each
@@ -834,6 +902,16 @@ func (h *apiHandler) patchTenantPinning(c *gin.Context) {
 			return
 		}
 	}
+
+	// Audit detail: image / ducklake_version are safe (non-secret) pins.
+	var pins []string
+	if req.Image != nil {
+		pins = append(pins, "image="+orgStr(*req.Image))
+	}
+	if req.DuckLakeVersion != nil {
+		pins = append(pins, "ducklake_version="+orgStr(*req.DuckLakeVersion))
+	}
+	setAuditDetail(c, strings.Join(pins, ", "))
 
 	stored, ok, err := h.store.MutateManagedWarehouse(orgID, func(w *configstore.ManagedWarehouse) error {
 		if req.Image != nil {
@@ -938,6 +1016,9 @@ func (h *apiHandler) createUser(c *gin.Context) {
 		DefaultCatalog: raw.DefaultCatalog,
 		MaxVCPUs:       raw.MaxVCPUs,
 	}
+	// The audit row's org/target columns come from URL params, but this route is
+	// the top-level POST /users with no params — record who was created here.
+	setAuditDetail(c, "created user "+raw.Username+" in org "+raw.OrgID)
 	if err := h.store.CreateUser(&user); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 		return
@@ -1007,6 +1088,25 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "max_vcpus must be >= 0"})
 		return
 	}
+	// Audit detail: which fields the update touched. The password is NEVER
+	// logged — only that it was reset.
+	var changes []string
+	if _, ok := fields["password"]; ok && raw.Password != "" {
+		changes = append(changes, "password reset")
+	}
+	if raw.Passthrough != nil {
+		changes = append(changes, fmt.Sprintf("passthrough=%v", *raw.Passthrough))
+	}
+	if raw.DefaultCatalog != nil {
+		changes = append(changes, "default_catalog="+orgStr(*raw.DefaultCatalog))
+	}
+	if maxVCPUs != nil {
+		changes = append(changes, fmt.Sprintf("max_vcpus=%d", *maxVCPUs))
+	}
+	if len(changes) > 0 {
+		setAuditDetail(c, strings.Join(changes, ", "))
+	}
+
 	user, ok, err := h.store.UpdateUser(orgID, username, passwordHash, raw.Passthrough, raw.DefaultCatalog, maxVCPUs)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/controlplane/admin/audit.go
+++ b/controlplane/admin/audit.go
@@ -28,8 +28,12 @@ type AdminAuditEntry struct {
 	Org         string    `gorm:"index" json:"org"`
 	TargetUser  string    `json:"target_user"`
 	SQLRedacted string    `json:"sql_redacted"`
-	Status      int       `json:"status"`
-	RemoteAddr  string    `json:"remote_addr"`
+	// Detail is optional, non-sensitive human context for the action (e.g.
+	// "role viewer → admin" for an operator change). Set by a handler via
+	// ctxAuditDetailKey; NEVER put credentials or raw secret DDL here.
+	Detail     string `json:"detail"`
+	Status     int    `json:"status"`
+	RemoteAddr string `json:"remote_addr"`
 }
 
 // TableName pins the audit table name in the config-store database.
@@ -120,6 +124,9 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 			Path:       c.Request.URL.Path,
 			Org:        c.Param("id"),
 			TargetUser: targetUser,
+			// Optional human context a handler recorded (e.g. which org fields
+			// changed). Empty for handlers that don't set it.
+			Detail:     c.GetString(ctxAuditDetailKey),
 			Status:     c.Writer.Status(),
 			RemoteAddr: c.ClientIP(),
 		}
@@ -132,11 +139,27 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 
 const ctxAuditHandledKey = "duckgres_audit_handled"
 
+// ctxAuditDetailKey holds an optional, non-sensitive human summary of a
+// mutation that a handler recorded (e.g. "role viewer → admin"). AuditMiddleware
+// copies it into AdminAuditEntry.Detail. NEVER put credentials or raw secret DDL
+// through it — the audit log stores it verbatim and the console shows it.
+const ctxAuditDetailKey = "duckgres_audit_detail"
+
+// setAuditDetail records a human-readable detail string for the current request
+// so AuditMiddleware includes it in the audit row. No-op for the empty string.
+func setAuditDetail(c *gin.Context, detail string) {
+	if detail != "" {
+		c.Set(ctxAuditDetailKey, detail)
+	}
+}
+
 // auditActionFor derives a resource-specific audit Action ("<resource>.<verb>")
 // from the request method and path. It tolerates both the resolved path
 // (c.Request.URL.Path, e.g. "/api/v1/orgs/acme/users/bob") and the route
 // template (c.FullPath()), and an optional "/api/v1" version prefix. Unknown
-// shapes fall back to the generic "config.<verb>".
+// shapes fall back to the generic "config.<verb>". The codes here are the source
+// of truth for the console's human labels (see ui/src/lib/audit.ts) — keep the
+// two in sync.
 func auditActionFor(method, path string) string {
 	verb := actionVerb(method)
 	segs := strings.FieldsFunc(path, func(r rune) bool { return r == '/' })
@@ -147,33 +170,53 @@ func auditActionFor(method, path string) string {
 	if len(segs) == 0 {
 		return "config." + verb
 	}
+	last := segs[len(segs)-1]
 	switch segs[0] {
 	case "operators":
 		return "operators." + verb
-	case "orgs":
-		// Sub-resources under an org get their own action; the org row itself
-		// (and anything else) is generic config.
-		for _, s := range segs[1:] {
-			switch s {
-			case "warehouse":
-				return "warehouse." + verb
-			case "users":
-				// A trailing action segment names the user action explicitly so
-				// the kill switch shows up as user.kill/disable/enable rather than
-				// a generic user.create in the audit log.
-				switch segs[len(segs)-1] {
-				case "kill":
-					return "user.kill"
-				case "disable":
-					return "user.disable"
-				case "enable":
-					return "user.enable"
-				}
-				return "user." + verb
-			}
+	case "users":
+		// Top-level user create (POST /users) — not nested under an org.
+		return "user." + verb
+	case "sessions":
+		// /sessions/:pid/cancel and /sessions/by-worker/:wid/cancel.
+		if last == "cancel" {
+			return "session.cancel"
 		}
+		return "session." + verb
+	case "orgs":
+		// Sub-resources under an org each get their own action; the org row
+		// itself is "org.<verb>". Order matters: the more specific
+		// sub-resources (secret, the user lifecycle verbs) must win over the
+		// generic "users"/"warehouse" segments they nest under.
+		switch {
+		case last == "kill" || last == "disable" || last == "enable":
+			// User kill switch: /orgs/:id/users/:username/{kill,disable,enable}.
+			return "user." + last
+		case hasSeg(segs, "secrets"):
+			// /orgs/:id/users/:username/secrets/:name.
+			return "secret." + verb
+		case hasSeg(segs, "warehouse"):
+			// PUT /warehouse and PATCH /warehouse/pinning both map here.
+			return "warehouse." + verb
+		case hasSeg(segs, "impersonate"):
+			// Impersonation records its own richer row; this is a fallback.
+			return "impersonate." + verb
+		case hasSeg(segs, "users"):
+			return "user." + verb
+		}
+		return "org." + verb
 	}
 	return "config." + verb
+}
+
+// hasSeg reports whether segs contains s.
+func hasSeg(segs []string, s string) bool {
+	for _, seg := range segs {
+		if seg == s {
+			return true
+		}
+	}
+	return false
 }
 
 func actionVerb(method string) string {

--- a/controlplane/admin/audit_test.go
+++ b/controlplane/admin/audit_test.go
@@ -28,9 +28,13 @@ func TestAuditActionFor(t *testing.T) {
 		{"org user enable", http.MethodPost, "/api/v1/orgs/acme/users/bob/enable", "user.enable"},
 		{"warehouse put", http.MethodPut, "/api/v1/orgs/acme/warehouse", "warehouse.update"},
 		{"warehouse pinning patch", http.MethodPatch, "/api/v1/orgs/acme/warehouse/pinning", "warehouse.update"},
-		{"org create", http.MethodPost, "/api/v1/orgs", "config.create"},
-		{"org update", http.MethodPut, "/api/v1/orgs/acme", "config.update"},
-		{"top-level users create", http.MethodPost, "/api/v1/users", "config.create"},
+		{"org create", http.MethodPost, "/api/v1/orgs", "org.create"},
+		{"org update", http.MethodPut, "/api/v1/orgs/acme", "org.update"},
+		{"org delete", http.MethodDelete, "/api/v1/orgs/acme", "org.delete"},
+		{"top-level users create", http.MethodPost, "/api/v1/users", "user.create"},
+		{"user secret delete", http.MethodDelete, "/api/v1/orgs/acme/users/bob/secrets/mysecret", "secret.delete"},
+		{"session cancel", http.MethodPost, "/api/v1/sessions/1234/cancel", "session.cancel"},
+		{"session cancel by worker", http.MethodPost, "/api/v1/sessions/by-worker/w-1/cancel", "session.cancel"},
 		{"unknown resource", http.MethodPost, "/api/v1/something", "config.create"},
 	}
 	for _, tc := range cases {

--- a/controlplane/admin/operators_api.go
+++ b/controlplane/admin/operators_api.go
@@ -64,28 +64,41 @@ func (h *operatorsHandler) upsertOperator(c *gin.Context) {
 		return
 	}
 
+	// existing is the operator's current role ("" if brand-new); we read it up
+	// front so we can (a) enforce the last-admin guard and (b) record a
+	// human-readable "role X → admin" audit detail.
+	existing, err := h.store.OperatorRole(email)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
 	// Last-admin guard: refuse to demote the final remaining admin to viewer.
 	// This is a pre-check + write, not a single atomic statement — acceptable
 	// for this tiny, low-traffic, internal-only table where a racing second
 	// admin-demotion is implausible and the worst case (zero admins) is still
 	// recoverable via the break-glass internal-secret path.
-	if role == string(RoleViewer) {
-		existing, err := h.store.OperatorRole(email)
+	if role == string(RoleViewer) && existing == string(RoleAdmin) {
+		admins, err := h.store.CountAdmins()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		if existing == string(RoleAdmin) {
-			admins, err := h.store.CountAdmins()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-			if admins <= 1 {
-				c.JSON(http.StatusConflict, gin.H{"error": "cannot demote the last remaining admin"})
-				return
-			}
+		if admins <= 1 {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot demote the last remaining admin"})
+			return
 		}
+	}
+
+	// Audit detail: "granted admin role" for a new operator, "role viewer →
+	// admin" for a role change, or a plain confirmation for an idempotent set.
+	switch {
+	case existing == "":
+		setAuditDetail(c, "granted "+role+" role (new operator)")
+	case existing != role:
+		setAuditDetail(c, "role "+existing+" → "+role)
+	default:
+		setAuditDetail(c, "role unchanged ("+role+")")
 	}
 
 	addedBy := ""
@@ -127,6 +140,9 @@ func (h *operatorsHandler) deleteOperator(c *gin.Context) {
 			c.JSON(http.StatusConflict, gin.H{"error": "cannot remove the last remaining admin"})
 			return
 		}
+	}
+	if role != "" {
+		setAuditDetail(c, "removed "+role+" operator")
 	}
 
 	deleted, err := h.store.DeleteOperator(email)

--- a/controlplane/admin/ui/src/lib/audit.test.ts
+++ b/controlplane/admin/ui/src/lib/audit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { actionLabel, auditSummary } from "./audit";
+import type { AuditEntry } from "@/types/api";
+
+function entry(over: Partial<AuditEntry>): AuditEntry {
+  return {
+    id: 1,
+    ts: "2026-06-30T16:46:37Z",
+    actor: "benjamin.k@posthog.com",
+    role: "admin",
+    source: "sso",
+    action: "",
+    method: "POST",
+    path: "/api/v1/operators",
+    status: 200,
+    ...over,
+  };
+}
+
+describe("actionLabel", () => {
+  it("maps known action codes to plain English", () => {
+    expect(actionLabel("operators.create")).toBe("Set operator role");
+    expect(actionLabel("operators.delete")).toBe("Removed operator");
+    expect(actionLabel("org.update")).toBe("Updated org config");
+    expect(actionLabel("warehouse.update")).toBe("Updated warehouse config");
+    expect(actionLabel("user.kill")).toBe("Killed user sessions");
+    expect(actionLabel("user.disable")).toBe("Disabled user");
+    expect(actionLabel("secret.delete")).toBe("Deleted user secret");
+    expect(actionLabel("session.cancel")).toBe("Cancelled session");
+    expect(actionLabel("impersonate.query")).toBe("Ran impersonated query");
+  });
+
+  it("degrades gracefully for the generic config bucket and unknown codes", () => {
+    expect(actionLabel("config.update")).toBe("Config updated");
+    expect(actionLabel("widget.frobnicate")).toBe("Frobnicate widget");
+    expect(actionLabel("")).toBe("—");
+  });
+});
+
+describe("auditSummary", () => {
+  it("appends the target user when present", () => {
+    expect(auditSummary(entry({ action: "operators.create", target_user: "bob@posthog.com" }))).toBe(
+      "Set operator role bob@posthog.com",
+    );
+  });
+
+  it("falls back to the bare label when there is no target", () => {
+    expect(auditSummary(entry({ action: "org.create", target_user: "" }))).toBe("Created org");
+  });
+});

--- a/controlplane/admin/ui/src/lib/audit.ts
+++ b/controlplane/admin/ui/src/lib/audit.ts
@@ -1,0 +1,79 @@
+// Human-readable rendering of admin audit rows.
+//
+// The backend records a terse "<resource>.<verb>" action code (see
+// admin/audit.go::auditActionFor) plus method/path/target/detail. Operators
+// shouldn't have to reverse-engineer "config.create POST /operators" — this maps
+// each known action code to a plain-English label and composes it with the
+// target/detail into one sentence.
+//
+// Keep ACTION_LABELS in sync with the codes emitted by auditActionFor.
+import type { AuditEntry } from "@/types/api";
+
+// A friendly label per action code. The verb is phrased as a completed action
+// ("Created org") so the row reads as a log of what happened.
+const ACTION_LABELS: Record<string, string> = {
+  "org.create": "Created org",
+  "org.update": "Updated org config",
+  "org.delete": "Deleted org",
+
+  "warehouse.create": "Created warehouse config",
+  "warehouse.update": "Updated warehouse config",
+  "warehouse.delete": "Deleted warehouse config",
+
+  "user.create": "Created user",
+  "user.update": "Updated user",
+  "user.delete": "Deleted user",
+  "user.kill": "Killed user sessions",
+  "user.disable": "Disabled user",
+  "user.enable": "Enabled user",
+
+  "secret.create": "Created user secret",
+  "secret.delete": "Deleted user secret",
+
+  "operators.create": "Set operator role",
+  "operators.update": "Set operator role",
+  "operators.delete": "Removed operator",
+
+  "session.cancel": "Cancelled session",
+
+  "impersonate.query": "Ran impersonated query",
+};
+
+// Fallback labels for the generic config.<verb> bucket and any unmapped verb.
+const VERB_LABELS: Record<string, string> = {
+  create: "Created",
+  update: "Updated",
+  delete: "Deleted",
+  other: "Changed",
+};
+
+// actionLabel returns the friendly label for an action code, degrading
+// gracefully: a known "config.update" → "Config change", an unknown
+// "widget.frobnicate" → "Frobnicate widget", and a bare code → the code itself.
+export function actionLabel(action: string): string {
+  if (!action) return "—";
+  const known = ACTION_LABELS[action];
+  if (known) return known;
+  const [resource, verb] = action.split(".");
+  if (resource === "config") return `Config ${VERB_LABELS[verb] ? VERB_LABELS[verb].toLowerCase() : verb ?? ""}`.trim();
+  const v = VERB_LABELS[verb] ?? (verb ? verb.charAt(0).toUpperCase() + verb.slice(1) : "");
+  return `${v} ${resource}`.trim();
+}
+
+// auditSubject returns the "who/what this acted on" phrase — the target user or
+// org — used to complete the sentence. Returns "" when neither is set (the
+// action label alone is enough).
+export function auditSubject(e: AuditEntry): string {
+  if (e.target_user) return e.target_user;
+  if (e.org) return e.org;
+  return "";
+}
+
+// auditSummary composes the full human sentence: "<label> <subject>". The org
+// and detail render in their own cells, so this stays short — e.g.
+// "Set operator role bob@posthog.com".
+export function auditSummary(e: AuditEntry): string {
+  const label = actionLabel(e.action);
+  const subject = e.target_user ?? "";
+  return subject ? `${label} ${subject}` : label;
+}

--- a/controlplane/admin/ui/src/pages/Audit.tsx
+++ b/controlplane/admin/ui/src/pages/Audit.tsx
@@ -10,6 +10,7 @@ import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
 import { useIdentity } from "@/components/IdentityProvider";
 import { useAudit } from "@/hooks/useApi";
 import { fmtTime } from "@/lib/format";
+import { auditSummary } from "@/lib/audit";
 import type { AuditEntry } from "@/types/api";
 
 function statusVariant(s: number): "success" | "warning" | "destructive" | "muted" {
@@ -58,9 +59,37 @@ export function Audit() {
         ),
       },
       {
-        accessorKey: "action",
+        id: "action",
         header: "Action",
-        cell: ({ getValue }) => <span className="text-xs">{String(getValue() ?? "")}</span>,
+        // The accessor feeds sort + the free-text search box, so it carries both
+        // the human summary AND the raw code/path — an operator can search
+        // "operator" or "operators.create" or "/operators" and still match.
+        accessorFn: (r) => `${auditSummary(r)} ${r.action} ${r.path}`,
+        cell: ({ row }) => {
+          const e = row.original;
+          return (
+            <div className="flex flex-col gap-0.5">
+              <span className="text-xs font-medium">{auditSummary(e)}</span>
+              <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground" title={e.path}>
+                {e.action}
+              </span>
+            </div>
+          );
+        },
+      },
+      {
+        accessorKey: "detail",
+        header: "Detail",
+        cell: ({ getValue }) => {
+          const v = getValue() as string | undefined;
+          return v ? (
+            <span className="block max-w-xs whitespace-normal break-words text-xs" title={v}>
+              {v}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          );
+        },
       },
       {
         accessorKey: "method",
@@ -68,21 +97,8 @@ export function Audit() {
         cell: ({ getValue }) => <Badge variant={methodVariant(String(getValue() ?? ""))}>{String(getValue() ?? "")}</Badge>,
       },
       {
-        accessorKey: "path",
-        header: "Path",
-        cell: ({ getValue }) => <span className="font-mono text-xs text-muted-foreground">{String(getValue() ?? "")}</span>,
-      },
-      {
         accessorKey: "org",
         header: "Org",
-        cell: ({ getValue }) => {
-          const v = getValue() as string | undefined;
-          return v ? <span className="font-mono text-xs">{v}</span> : <span className="text-muted-foreground">—</span>;
-        },
-      },
-      {
-        accessorKey: "target_user",
-        header: "Target",
         cell: ({ getValue }) => {
           const v = getValue() as string | undefined;
           return v ? <span className="font-mono text-xs">{v}</span> : <span className="text-muted-foreground">—</span>;
@@ -145,7 +161,7 @@ export function Audit() {
       <PageBody>
         <Card className="overflow-hidden">
           {audit.isLoading ? (
-            <TableSkeleton cols={9} />
+            <TableSkeleton cols={8} />
           ) : audit.isError ? (
             <ErrorState error={audit.error} onRetry={() => audit.refetch()} />
           ) : (

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -413,6 +413,9 @@ export interface AuditEntry {
   org?: string;
   target_user?: string;
   sql_redacted?: string;
+  // Optional non-sensitive human context recorded by the handler, e.g.
+  // "role viewer → admin" or "max_workers 4 → 10".
+  detail?: string;
   status: number;
   remote_addr?: string;
 }

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -957,6 +957,16 @@ org_default_profile() { # org password catalog
   after="$(count_org_workers_of_cpu "$org" "$cpu")"
   [ "$after" -le "$before" ] || fail "org default: cleared default still spawns $cpu-cpu workers ($before -> $after)"
   log "org default OK: cleared; plain connection back on the deployment default shape"
+
+  # Audit readability: the org PUTs above must land a resource-specific
+  # "org.update" row (not a generic "config.update") carrying a human "which
+  # fields changed" detail. The clear-PUT above always flips default_worker_*
+  # from the just-set 2/8Gi/10m to unset, so a detail mentioning the field is
+  # deterministic. Guards audit.go::auditActionFor + api.go::updateOrg detail.
+  curl -fsS -H "$H" "$API/api/v1/audit?org=$org" \
+    | jq -e --arg o "$org" '.entries | map(select(.action=="org.update" and .org==$o and (.detail | test("default_worker")))) | length >= 1' >/dev/null \
+    || fail "org default: no org.update audit row with a field-change detail for $org"
+  log "org default OK: audit shows org.update with field-change detail on $org"
 }
 
 # ---- user persistent secrets ------------------------------------------------


### PR DESCRIPTION
## Problem

The admin console audit log showed terse `<resource>.<verb>` codes plus a method/path, and many mutations collapsed into a generic `config.*` that hid what actually happened — e.g. changing an operator's role read as `config.create  POST  /api/v1/operators`.

## Changes

**Backend (`controlplane/admin`)**
- Rework `auditActionFor` to emit resource-specific codes for every mutating route: `org.*`, `user.*` (incl. top-level `POST /users`), `warehouse.*`, `secret.delete`, `session.cancel`, `operators.*` — no more misfiled `config.*` or a secret-delete recorded as `user.delete`.
- Add a non-sensitive `AdminAuditEntry.Detail` column (AutoMigrated) plumbed via `ctxAuditDetailKey`. Handlers record a human summary:
  - operators: `role viewer → admin` / `granted admin role (new operator)`
  - org update: per-field `max_workers 4 → 10, default_worker_cpu (unset) → 2`
  - warehouse PUT: changed section **names** only (values may hold credentials)
  - warehouse pinning: `image=…, ducklake_version=1.0`
  - user create/update: `created user bob in org acme`, `password reset, max_vcpus=4`
- **Security:** `Detail` never carries credentials or secret DDL; passwords logged only as `password reset`; warehouse PUT logs field names, not values.

**Frontend (`controlplane/admin/ui`)**
- New `lib/audit.ts` (`actionLabel` + `auditSummary`) maps codes to plain English, degrading gracefully for legacy `config.*` / unknown codes.
- `Audit.tsx`: Action cell renders the human sentence (e.g. *"Set operator role bob@…"*) with the raw code/path as muted subtext; new **Detail** column; dropped redundant Path/Target columns. Free-text search still matches summary, raw code, and path.

## Action → label reference

| Code | Label |
|---|---|
| `operators.create` | Set operator role |
| `operators.delete` | Removed operator |
| `org.create/update/delete` | Created / Updated / Deleted org |
| `warehouse.update` | Updated warehouse config |
| `user.create/update/delete` | Created / Updated / Deleted user |
| `user.kill/disable/enable` | Killed / Disabled / Enabled user |
| `secret.delete` | Deleted user secret |
| `session.cancel` | Cancelled session |
| `impersonate.query` | Ran impersonated query |

Legacy rows (pre-deploy) keep their stored codes; the frontend relabels them, and `detail` is populated only for rows written after the updated control plane runs.

## Tests
- `audit_test.go` covers the new codes (`org.*`, `user.create`, `secret.delete`, `session.cancel`).
- New `ui/src/lib/audit.test.ts` for the label mapping.
- e2e `harness.sh` `org_default_profile` now asserts an `org.update` audit row with a field-change detail.
- `go build`/`vet`/`tsc -b`/`vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)