### PR TITLE
docs(design): billing pull API (buckets by org/team/cpu/mem)

### DIFF
--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -33,9 +33,12 @@ Internally, one row per unique key, values accumulated:
   same bucket and fractional sizes keep full precision.
 - **Values:** `cpu_seconds` (vCPU-seconds), `memory_seconds` (GiB-seconds) —
   summed over every connection that falls in that key + minute.
-- `team_id` (config-store **org → team** lookup) and `query_source` (the worker's
-  role: standard query vs endpoints) are resolved at connection time — both need to
-  be threaded onto the connection.
+- `team_id` is the org's **default team** for now — a fixed value per org (from the
+  config-store org→team default), reported so the shape is right, but **no per-team
+  attribution logic** yet. A "team" is really a schema and one connection can span
+  several, so true per-team split is future work; today every bucket carries the
+  org's default team. `query_source` (the worker's role: standard query vs
+  endpoints) is resolved at connection time and threaded onto the connection.
 - Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
   accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
@@ -149,9 +152,9 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - **Extend:** the bucket table gains `team_id`, `query_source`, `cpu`, `mem_gib`
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
   the HTTP API (aggregate-on-read into one row per key + watermark ack) + safety GC.
-- **Add:** config-store `org → team` lookup and the connection's `query_source`
-  (standard vs endpoints) — both threaded onto the connection; a bearer secret for
-  the API.
+- **Add:** the org's default `team_id` (fixed per org — no per-team logic yet) and
+  the connection's `query_source` (standard vs endpoints) threaded onto the
+  connection; a bearer secret for the API.
 
 ## Defaults / house-keeping
 

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -2,27 +2,29 @@
 
 Status: **DRAFT**. Supersedes the reporting hop of
 [`billing-compute-seconds-plan.md`](./billing-compute-seconds-plan.md): billing
-now **pulls** buckets from duckgres instead of duckgres pushing capture events to
+now **pulls** usage from duckgres instead of duckgres pushing capture events to
 PostHog ingestion. The per-connection metering is unchanged — only how the data
 leaves duckgres changes.
 
 ## Overview
 
 duckgres meters compute usage into 60-second **buckets** in its config store. The
-billing service periodically **pulls** closed buckets over a small HTTP API,
-processes them, and **acks**; duckgres deletes acked buckets. A safety GC caps how
-long anything can linger. Direction is posthog → mw (billing initiates), which the
-existing duckgres control-plane ingress already supports.
+billing service periodically **pulls** the usage accumulated since its last ack,
+processes it, and **acks a watermark**; duckgres advances a cursor and deletes
+everything up to it. A safety GC caps how long anything can linger. Direction is
+posthog → mw (billing initiates), which the existing duckgres control-plane
+ingress already supports.
 
 ```
-duckgres:  connection ends → meter → accumulate into config-store buckets
-billing:   GET /buckets  → process → POST /buckets/ack  → duckgres deletes
-safety:    GC hard-deletes anything older than 30 days (logged)
+duckgres:  connection ends → meter → accumulate into 60s config-store buckets
+billing:   GET /usage  → process → POST /ack {watermark}
+                                     → duckgres advances cursor + deletes ≤ watermark
+safety:    GC hard-deletes buckets older than 30 days (logged)
 ```
 
 ## Buckets
 
-One row per unique key, values accumulated:
+Internally, one row per unique key, values accumulated:
 
 - **Key:** `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
   where `bucket_start = floor(connection_end / 60s)`.
@@ -33,59 +35,72 @@ One row per unique key, values accumulated:
 - Worker size (`cpu_millicores`, `mem_mib`) is part of the key, so different
   worker sizes accumulate — and bill — separately.
 
+**60-second resolution is kept internally.** The pull API aggregates on read (see
+below), so billing never has to chase individual minutes — but the fine buckets
+still exist as the source of truth.
+
 A bucket is **closed** (eligible to serve) once `now ≥ bucket_start + 60s + grace`
 (grace ≈ 30s). This guarantees every in-flight contribution for that minute has
-already landed before billing can read it.
+landed before billing can read it.
 
 ## API
 
 Control-plane HTTP, over the existing posthog → mw duckgres ingress.
 Auth: `Authorization: Bearer <internal secret>`.
 
-### `GET /api/billing/buckets?limit=N`
+### `GET /api/billing/usage`
 
-Returns up to `N` **closed, not-yet-acked** buckets, oldest first:
-
-```json
-[
-  {
-    "id": "9f2c…",
-    "org_id": "org_abc",
-    "team_id": "12345",
-    "cpu_millicores": 8000,
-    "mem_mib": 16384,
-    "bucket_start": "2026-07-01T12:34:00Z",
-    "cpu_seconds": 80,
-    "memory_seconds": 160
-  }
-]
-```
-
-Billing keeps calling until it gets an empty list.
-
-### `POST /api/billing/buckets/ack`
+Returns compute usage **aggregated since the last ack**, one row per
+`(org_id, team_id, cpu_millicores, mem_mib)`:
 
 ```json
-{ "ids": ["9f2c…", "7a10…"] }
+{
+  "watermark": "2026-07-01T12:40:00Z",
+  "usage": [
+    {
+      "org_id": "org_abc",
+      "team_id": "12345",
+      "cpu_millicores": 8000,
+      "mem_mib": 16384,
+      "cpu_seconds": 4800,
+      "memory_seconds": 9600
+    }
+  ]
+}
 ```
 
-duckgres deletes those buckets. **Idempotent** — unknown or already-deleted ids
-are ignored, so a retried ack is always safe.
+- Sums all **closed** buckets in `(last_acked, watermark]`, where
+  `watermark` = the latest closed minute (`now − grace`).
+- **One row per key regardless of elapsed time.** A pull returns everything since
+  the last ack aggregated, so the response size is bounded by the number of active
+  keys — **not** by how long billing was away. A week of downtime returns the same
+  row count, just larger sums. Billing can never fall behind chasing 60s buckets.
+
+### `POST /api/billing/ack`
+
+```json
+{ "watermark": "2026-07-01T12:40:00Z" }
+```
+
+- duckgres advances its cursor to `watermark` and **deletes all buckets ≤
+  watermark**. Idempotent — a watermark at or below the current cursor is a no-op,
+  so a retried ack is always safe. Pass back the exact `watermark` from the `GET`
+  response.
 
 ## No data loss
 
-- A bucket is deleted **only after an explicit ack**. The flow is
-  read → process → ack.
-- If billing crashes after processing but before acking, it simply **re-pulls the
-  same buckets** on the next cycle. Delivery is **at-least-once**; billing dedups
-  by the natural key `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
-  (each key is emitted once).
-- Only **closed** buckets are served, so a bucket is never handed over while it is
+- Buckets are deleted **only** when an ack advances the cursor past them.
+- Each `GET` returns the **complete** usage since the last ack. If billing crashes
+  after processing but before acking, the next `GET` returns the same window
+  (extended up to a later `now`) — safe to reprocess, because billing finalizes
+  only on **ack**: the ack is the commit boundary. Delivery is effectively
+  at-least-once with the watermark as the idempotency edge.
+- Only **closed** buckets are aggregated, so a minute is never served while it is
   still accumulating.
 
 ## No infinite accumulation
 
-- Acked buckets are deleted immediately.
+- Ack deletes everything `≤ watermark` immediately.
 - **Safety GC:** hard-delete any bucket older than **30 days** regardless of ack,
   logging the dropped count. This bounds table size even if billing stops pulling
   entirely. (A nonzero GC-drop count = billing isn't keeping up — alert on it.)
@@ -93,27 +108,28 @@ are ignored, so a retried ack is always safe.
 ## Reliability
 
 - Metering and the client **query path are untouched** and never blocked by the
-  API: serving is reads, ack and GC are deletes — all on the config store, off the
-  query hot path.
-- **Any control-plane replica** can serve `GET`/`ack` (state is the shared config
-  store); ack-delete is idempotent, so concurrent pulls / multiple replicas are
-  safe.
+  API: `GET` is a read (aggregate), `ack` and GC are deletes — all on the config
+  store, off the query hot path.
+- The cursor is a single config-store row. **Any control-plane replica** can serve
+  `GET`/`ack`; ack is idempotent, so concurrent pulls / multiple replicas are safe.
 
 ## What changes vs the push design
 
 - **Remove:** leader drain → `capture()` to PostHog ingestion, and the
   `DUCKGRES_BILLING_INGEST_URL` / `_TOKEN` config.
-- **Keep:** per-connection metering → config-store buckets.
+- **Keep:** per-connection metering → config-store 60s buckets.
 - **Extend:** the bucket table gains `team_id`, `cpu_millicores`, `mem_mib` in the
-  key (new migration); add the HTTP API + safety GC.
+  key (new migration); add a single `last_acked` cursor row; add the HTTP API
+  (aggregate-on-read + watermark ack) + safety GC.
 - **Add:** config-store `org → team` lookup (thread `team_id` onto the connection);
   a bearer secret for the API.
 
 ## Defaults / house-keeping
 
-- `limit` default ~1000; `id` is a stable per-bucket identifier used for ack.
-- Bucket width 60s, grace 30s (unchanged from the push design).
+- Bucket width 60s, grace 30s.
 - Endpoint paths above are indicative — adjust to the control-plane API's house
   style.
-- Values are exposed as vCPU-seconds / GiB-seconds; internally accumulated in
-  exact millicore-/MiB-seconds so no precision is lost for fractional worker sizes.
+- Values are exposed as vCPU-seconds / GiB-seconds; internally accumulated in exact
+  millicore-/MiB-seconds so no precision is lost for fractional worker sizes.
+- Single billing consumer assumed → one server-side `last_acked` cursor. (If a
+  second independent consumer is ever needed, give each its own named cursor.)

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -61,6 +61,7 @@ same units as the values:
   "watermark": "2026-07-01T12:40:00Z",
   "usage": [
     {
+    compute_type: "endpoints",
       "org_id": "org_abc",
       "team_id": "12345",
       "cpu": 8,

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -26,24 +26,29 @@ safety:    GC hard-deletes buckets older than 30 days (logged)
 
 Internally, one row per unique key, values accumulated:
 
-- **Key:** `(org_id, team_id, cpu, mem_gib, bucket_start)` where `cpu` is vCPU and
-  `mem_gib` is GiB, `bucket_start = floor(connection_end / 60s)`. Worker size is
-  stored as **exact decimals** (SQL `NUMERIC`, not IEEE floats), so equal sizes
-  always group into the same bucket and fractional sizes keep full precision.
+- **Key:** `(org_id, team_id, query_source, cpu, mem_gib, bucket_start)` where
+  `query_source` is `standard` | `endpoints`, `cpu` is vCPU, `mem_gib` is GiB, and
+  `bucket_start = floor(connection_end / 60s)`. Worker size is stored as **exact
+  decimals** (SQL `NUMERIC`, not IEEE floats), so equal sizes always group into the
+  same bucket and fractional sizes keep full precision.
 - **Values:** `cpu_seconds` (vCPU-seconds), `memory_seconds` (GiB-seconds) —
   summed over every connection that falls in that key + minute.
-- `team_id` is looked up from the config store (**org → team mapping**) at
-  connection time.
+- `team_id` (config-store **org → team** lookup) and `query_source` (the worker's
+  role: standard query vs endpoints) are resolved at connection time — both need to
+  be threaded onto the connection.
 - Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
   accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
-**60-second resolution is kept internally.** The pull API aggregates on read (see
-below), so billing never has to chase individual minutes — but the fine buckets
-still exist as the source of truth.
+**60-second resolution is preserved end to end** — the API serves these minute
+buckets directly (one row per closed minute per key). The watermark ack (below)
+lets billing pull all pending minutes at once, so minute granularity doesn't mean
+chasing buckets.
 
 A bucket is **closed** (eligible to serve) once `now ≥ bucket_start + 60s + grace`
-(grace ≈ 30s). This guarantees every in-flight contribution for that minute has
-landed before billing can read it.
+(grace ≈ 30s). `grace` must exceed the in-process→config-store flush interval so
+that, across **every** replica and **every** org, all contributions for that
+minute have landed before it is served — a minute that is still being written is
+never inside the watermark window (see [No data loss](#no-data-loss)).
 
 ## API
 
@@ -52,22 +57,23 @@ Auth: `Authorization: Bearer <internal secret>`.
 
 ### `GET /api/billing/usage`
 
-Returns compute usage **aggregated since the last ack**, one row per worker size
-per `(org_id, team_id)`. Size is reported as `cpu` (vCPU) and `mem_gib` (GiB) —
-same units as the values:
+Returns every **closed 60s bucket since the last ack** — one row per
+`(org_id, team_id, query_source, cpu, mem_gib, bucket_start)`. Size is reported as
+`cpu` (vCPU) and `mem_gib` (GiB) — same units as the values:
 
 ```json
 {
   "watermark": "2026-07-01T12:40:00Z",
   "usage": [
     {
-      "compute_type": "endpoints" | "standard",
+      "bucket_start": "2026-07-01T12:34:00Z",
+      "query_source": "endpoints" | "standard",
       "org_id": "org_abc",
       "team_id": "12345",
       "cpu": 8,
       "mem_gib": 16,
-      "cpu_seconds": 4800,
-      "memory_seconds": 9600
+      "cpu_seconds": 480,
+      "memory_seconds": 960
     }
   ]
 }
@@ -76,12 +82,13 @@ same units as the values:
 (`cpu`/`mem_gib` are exact decimals — e.g. `1.5`, `0.5` — for fractional worker
 sizes; stored as `NUMERIC` so grouping is exact.)
 
-- Sums all **closed** buckets in `(last_acked, watermark]`, where
-  `watermark` = the latest closed minute (`now − grace`).
-- **One row per key regardless of elapsed time.** A pull returns everything since
-  the last ack aggregated, so the response size is bounded by the number of active
-  keys — **not** by how long billing was away. A week of downtime returns the same
-  row count, just larger sums. Billing can never fall behind chasing 60s buckets.
+- Returns every closed bucket in `(last_acked, watermark]`, where `watermark` =
+  the latest closed minute (`now − grace`). Kept at minute granularity.
+- **Catch up in one pull.** A single `GET` returns **all** pending minutes since
+  the last ack (not one bucket per request), and one `ack` advances past all of
+  them — so billing never chases 60s buckets and can't fall behind. Response size
+  is bounded by active-keys × minutes-since-ack; pull on a sane cadence and it
+  stays small.
 
 ### `POST /api/billing/ack`
 
@@ -104,6 +111,12 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   at-least-once with the watermark as the idempotency edge.
 - Only **closed** buckets are aggregated, so a minute is never served while it is
   still accumulating.
+- **Cross-org completeness (no TOCTOU on the delete):** the `watermark` is always a
+  fully-closed minute (`≤ now − grace`), and `grace` exceeds the flush interval — so
+  by the time a minute is served (and later deleted on ack), every replica's buckets
+  for **every** org in that minute have already landed. A partially-inserted current
+  minute is never in the window, so an ack can't delete buckets that were never
+  served.
 
 ## No infinite accumulation
 
@@ -125,11 +138,12 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - **Remove:** leader drain → `capture()` to PostHog ingestion, and the
   `DUCKGRES_BILLING_INGEST_URL` / `_TOKEN` config.
 - **Keep:** per-connection metering → config-store 60s buckets.
-- **Extend:** the bucket table gains `team_id`, `cpu`, `mem_gib` (`NUMERIC`) in the
-  key (new migration); add a single `last_acked` cursor row; add the HTTP API
-  (aggregate-on-read + watermark ack) + safety GC.
-- **Add:** config-store `org → team` lookup (thread `team_id` onto the connection);
-  a bearer secret for the API.
+- **Extend:** the bucket table gains `team_id`, `query_source`, `cpu`, `mem_gib`
+  (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
+  the HTTP API (serve closed minute buckets + watermark ack) + safety GC.
+- **Add:** config-store `org → team` lookup and the connection's `query_source`
+  (standard vs endpoints) — both threaded onto the connection; a bearer secret for
+  the API.
 
 ## Defaults / house-keeping
 

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -10,15 +10,15 @@ leaves duckgres changes.
 
 duckgres meters compute usage into 60-second **buckets** in its config store. The
 billing service periodically **pulls** the usage accumulated since its last ack,
-processes it, and **acks a watermark**; duckgres advances a cursor and deletes
-everything up to it. A safety GC caps how long anything can linger. Direction is
+processes it, and **acks the high watermark**; duckgres advances a cursor and
+deletes everything up to it. A safety GC caps how long anything can linger. Direction is
 posthog → mw (billing initiates), which the existing duckgres control-plane
 ingress already supports.
 
 ```
 duckgres:  connection ends → meter → accumulate into 60s config-store buckets
-billing:   GET /usage  → process → POST /ack {watermark}
-                                     → duckgres advances cursor + deletes ≤ watermark
+billing:   GET /usage  → process → POST /ack {watermark_high}
+                                     → duckgres advances cursor + deletes ≤ watermark_high
 safety:    GC hard-deletes buckets older than 30 days (logged)
 ```
 
@@ -63,7 +63,8 @@ Returns every **closed 60s bucket since the last ack** — one row per
 
 ```json
 {
-  "watermark": "2026-07-01T12:40:00Z",
+  "watermark_low":  "2026-07-01T12:30:00Z",
+  "watermark_high": "2026-07-01T12:40:00Z",
   "usage": [
     {
       "bucket_start": "2026-07-01T12:34:00Z",
@@ -82,8 +83,16 @@ Returns every **closed 60s bucket since the last ack** — one row per
 (`cpu`/`mem_gib` are exact decimals — e.g. `1.5`, `0.5` — for fractional worker
 sizes; stored as `NUMERIC` so grouping is exact.)
 
-- Returns every closed bucket in `(last_acked, watermark]`, where `watermark` =
-  the latest closed minute (`now − grace`). Kept at minute granularity.
+- Returns every closed bucket in the window `(watermark_low, watermark_high]`,
+  kept at minute granularity, where:
+  - `watermark_low` = duckgres's current cursor (= the last value billing acked) —
+    the window start.
+  - `watermark_high` = the latest closed minute (`now − grace`) — what billing acks.
+- **Consistency check:** billing should assert `watermark_low` == its own recorded
+  last-acked value before applying. A mismatch means something desynced (a lost/
+  half-applied ack; HTTP and Postgres aren't one transaction) → a potential hole →
+  alert/reconcile instead of silently under-billing. It's a cross-check, not a
+  correctness fix (delete-on-ack already prevents loss); it makes a *bug* visible.
 - **Catch up in one pull.** A single `GET` returns **all** pending minutes since
   the last ack (not one bucket per request), and one `ack` advances past all of
   them — so billing never chases 60s buckets and can't fall behind. Response size
@@ -93,13 +102,13 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 ### `POST /api/billing/ack`
 
 ```json
-{ "watermark": "2026-07-01T12:40:00Z" }
+{ "watermark_high": "2026-07-01T12:40:00Z" }
 ```
 
-- duckgres advances its cursor to `watermark` and **deletes all buckets ≤
-  watermark**. Idempotent — a watermark at or below the current cursor is a no-op,
-  so a retried ack is always safe. Pass back the exact `watermark` from the `GET`
-  response.
+- duckgres advances its cursor to `watermark_high` and **deletes all buckets ≤
+  watermark_high**. Idempotent — a value at or below the current cursor is a no-op,
+  so a retried ack is always safe. Pass back the exact `watermark_high` from the
+  `GET` response (it becomes the next pull's `watermark_low`).
 
 ## No data loss
 
@@ -108,10 +117,10 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   after processing but before acking, the next `GET` returns the same window
   (extended up to a later `now`) — safe to reprocess, because billing finalizes
   only on **ack**: the ack is the commit boundary. Delivery is effectively
-  at-least-once with the watermark as the idempotency edge.
+  at-least-once with `watermark_high` as the idempotency edge.
 - Only **closed** buckets are aggregated, so a minute is never served while it is
   still accumulating.
-- **Cross-org completeness (no TOCTOU on the delete):** the `watermark` is always a
+- **Cross-org completeness (no TOCTOU on the delete):** `watermark_high` is always a
   fully-closed minute (`≤ now − grace`), and `grace` exceeds the flush interval — so
   by the time a minute is served (and later deleted on ack), every replica's buckets
   for **every** org in that minute have already landed. A partially-inserted current
@@ -120,7 +129,7 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 
 ## No infinite accumulation
 
-- Ack deletes everything `≤ watermark` immediately.
+- Ack deletes everything `≤ watermark_high` immediately.
 - **Safety GC:** hard-delete any bucket older than **30 days** regardless of ack,
   logging the dropped count. This bounds table size even if billing stops pulling
   entirely. (A nonzero GC-drop count = billing isn't keeping up — alert on it.)

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -1,0 +1,119 @@
+# Managed-warehouse compute billing — pull API
+
+Status: **DRAFT**. Supersedes the reporting hop of
+[`billing-compute-seconds-plan.md`](./billing-compute-seconds-plan.md): billing
+now **pulls** buckets from duckgres instead of duckgres pushing capture events to
+PostHog ingestion. The per-connection metering is unchanged — only how the data
+leaves duckgres changes.
+
+## Overview
+
+duckgres meters compute usage into 60-second **buckets** in its config store. The
+billing service periodically **pulls** closed buckets over a small HTTP API,
+processes them, and **acks**; duckgres deletes acked buckets. A safety GC caps how
+long anything can linger. Direction is posthog → mw (billing initiates), which the
+existing duckgres control-plane ingress already supports.
+
+```
+duckgres:  connection ends → meter → accumulate into config-store buckets
+billing:   GET /buckets  → process → POST /buckets/ack  → duckgres deletes
+safety:    GC hard-deletes anything older than 30 days (logged)
+```
+
+## Buckets
+
+One row per unique key, values accumulated:
+
+- **Key:** `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
+  where `bucket_start = floor(connection_end / 60s)`.
+- **Values:** `cpu_seconds` (vCPU-seconds), `memory_seconds` (GiB-seconds) —
+  summed over every connection that falls in that key + minute.
+- `team_id` is looked up from the config store (**org → team mapping**) at
+  connection time.
+- Worker size (`cpu_millicores`, `mem_mib`) is part of the key, so different
+  worker sizes accumulate — and bill — separately.
+
+A bucket is **closed** (eligible to serve) once `now ≥ bucket_start + 60s + grace`
+(grace ≈ 30s). This guarantees every in-flight contribution for that minute has
+already landed before billing can read it.
+
+## API
+
+Control-plane HTTP, over the existing posthog → mw duckgres ingress.
+Auth: `Authorization: Bearer <internal secret>`.
+
+### `GET /api/billing/buckets?limit=N`
+
+Returns up to `N` **closed, not-yet-acked** buckets, oldest first:
+
+```json
+[
+  {
+    "id": "9f2c…",
+    "org_id": "org_abc",
+    "team_id": "12345",
+    "cpu_millicores": 8000,
+    "mem_mib": 16384,
+    "bucket_start": "2026-07-01T12:34:00Z",
+    "cpu_seconds": 80,
+    "memory_seconds": 160
+  }
+]
+```
+
+Billing keeps calling until it gets an empty list.
+
+### `POST /api/billing/buckets/ack`
+
+```json
+{ "ids": ["9f2c…", "7a10…"] }
+```
+
+duckgres deletes those buckets. **Idempotent** — unknown or already-deleted ids
+are ignored, so a retried ack is always safe.
+
+## No data loss
+
+- A bucket is deleted **only after an explicit ack**. The flow is
+  read → process → ack.
+- If billing crashes after processing but before acking, it simply **re-pulls the
+  same buckets** on the next cycle. Delivery is **at-least-once**; billing dedups
+  by the natural key `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
+  (each key is emitted once).
+- Only **closed** buckets are served, so a bucket is never handed over while it is
+  still accumulating.
+
+## No infinite accumulation
+
+- Acked buckets are deleted immediately.
+- **Safety GC:** hard-delete any bucket older than **30 days** regardless of ack,
+  logging the dropped count. This bounds table size even if billing stops pulling
+  entirely. (A nonzero GC-drop count = billing isn't keeping up — alert on it.)
+
+## Reliability
+
+- Metering and the client **query path are untouched** and never blocked by the
+  API: serving is reads, ack and GC are deletes — all on the config store, off the
+  query hot path.
+- **Any control-plane replica** can serve `GET`/`ack` (state is the shared config
+  store); ack-delete is idempotent, so concurrent pulls / multiple replicas are
+  safe.
+
+## What changes vs the push design
+
+- **Remove:** leader drain → `capture()` to PostHog ingestion, and the
+  `DUCKGRES_BILLING_INGEST_URL` / `_TOKEN` config.
+- **Keep:** per-connection metering → config-store buckets.
+- **Extend:** the bucket table gains `team_id`, `cpu_millicores`, `mem_mib` in the
+  key (new migration); add the HTTP API + safety GC.
+- **Add:** config-store `org → team` lookup (thread `team_id` onto the connection);
+  a bearer secret for the API.
+
+## Defaults / house-keeping
+
+- `limit` default ~1000; `id` is a stable per-bucket identifier used for ack.
+- Bucket width 60s, grace 30s (unchanged from the push design).
+- Endpoint paths above are indicative — adjust to the control-plane API's house
+  style.
+- Values are exposed as vCPU-seconds / GiB-seconds; internally accumulated in
+  exact millicore-/MiB-seconds so no precision is lost for fractional worker sizes.

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -62,7 +62,6 @@ same units as the values:
   "usage": [
     {
       "compute_type": "endpoints" | "standard",
-    compute_type: "endpoints",
       "org_id": "org_abc",
       "team_id": "12345",
       "cpu": 8,

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -62,10 +62,12 @@ Auth: `Authorization: Bearer <internal secret>`.
 
 ### `GET /api/billing/usage`
 
-Returns compute usage **aggregated since the last ack — one row per key**
-`(org_id, team_id, query_source, cpu, mem_gib)`, summing every closed bucket in the
-window. Size is reported as `cpu` (vCPU) and `mem_gib` (GiB) — same units as the
-values:
+Returns compute usage **aggregated since the last ack — one row per key per day**
+`(org_id, team_id, query_source, cpu, mem_gib, date)`, summing every closed bucket
+in the window. `date` is the **UTC** calendar day, so each row belongs to exactly
+one billing day (a window that straddles midnight yields two rows per key — one
+per day; a same-day window yields one). Size is reported as `cpu` (vCPU) and
+`mem_gib` (GiB) — same units as the values:
 
 ```json
 {
@@ -73,6 +75,7 @@ values:
   "watermark_high": "2026-07-01T12:40:00Z",
   "usage": [
     {
+      "date": "2026-07-01",
       "query_source": "endpoints" | "standard",
       "org_id": "org_abc",
       "team_id": "12345",
@@ -89,7 +92,8 @@ values:
 sizes; stored as `NUMERIC` so grouping is exact.)
 
 - Sums every closed bucket in the window `(watermark_low, watermark_high]` into one
-  row per key, where:
+  row per key **per UTC day** (so cross-midnight windows split into per-day rows),
+  where:
   - `watermark_low` = duckgres's current cursor (= the last value billing acked) —
     the window start.
   - `watermark_high` = the latest closed minute (`now − grace`) — what billing acks.
@@ -99,9 +103,10 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   alert/reconcile instead of silently under-billing. It's a cross-check, not a
   correctness fix (delete-on-ack already prevents loss); it makes a *bug* visible.
 - **Can't fall behind.** Everything since the last ack is aggregated into one row
-  per key, so the response size is bounded by the **number of active keys** —
-  independent of how long billing was away. A week of downtime returns the same row
-  count, just larger sums. One `ack` advances past all of it.
+  per key per day, so the response size is bounded by **active keys × days in the
+  window** — independent of how *busy* billing-downtime was. A week of downtime
+  returns ~7 rows per key (one per day), not thousands of minute-buckets. One `ack`
+  advances past all of it.
 
 ### `POST /api/billing/ack`
 
@@ -153,7 +158,8 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - **Keep:** per-connection metering → config-store 60s buckets.
 - **Extend:** the bucket table gains `team_id`, `query_source`, `cpu`, `mem_gib`
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
-  the HTTP API (aggregate-on-read into one row per key + watermark ack) + safety GC.
+  the HTTP API (aggregate-on-read into one row per key per UTC day + watermark ack)
+  + safety GC.
 - **Add:** a `default_team_id` column on the org (used as the bucket `team_id` —
   fixed per org, no per-team logic yet); a `duckgres.query_source` session GUC
   (`standard` | `endpoints`, default `standard`) read by the meter; a bearer secret

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -61,6 +61,7 @@ same units as the values:
   "watermark": "2026-07-01T12:40:00Z",
   "usage": [
     {
+      "compute_type": "endpoints" | "standard",
     compute_type: "endpoints",
       "org_id": "org_abc",
       "team_id": "12345",

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -37,8 +37,10 @@ Internally, one row per unique key, values accumulated:
   config-store org→team default), reported so the shape is right, but **no per-team
   attribution logic** yet. A "team" is really a schema and one connection can span
   several, so true per-team split is future work; today every bucket carries the
-  org's default team. `query_source` (the worker's role: standard query vs
-  endpoints) is resolved at connection time and threaded onto the connection.
+  org's default team. `query_source` (`standard` | `endpoints`) is set by a session
+  GUC (`duckgres.query_source`), defaulting to `standard` when unset; the meter
+  reads it per connection. (If it's changed mid-connection the per-connection meter
+  uses a single value — same future refinement as team.)
 - Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
   accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
@@ -153,8 +155,9 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
   the HTTP API (aggregate-on-read into one row per key + watermark ack) + safety GC.
 - **Add:** a `default_team_id` column on the org (used as the bucket `team_id` —
-  fixed per org, no per-team logic yet) and the connection's `query_source`
-  (standard vs endpoints) threaded onto the connection; a bearer secret for the API.
+  fixed per org, no per-team logic yet); a `duckgres.query_source` session GUC
+  (`standard` | `endpoints`, default `standard`) read by the meter; a bearer secret
+  for the API.
 
 ## Defaults / house-keeping
 

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -39,10 +39,10 @@ Internally, one row per unique key, values accumulated:
 - Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
   accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
-**60-second resolution is preserved end to end** — the API serves these minute
-buckets directly (one row per closed minute per key). The watermark ack (below)
-lets billing pull all pending minutes at once, so minute granularity doesn't mean
-chasing buckets.
+**60-second resolution is kept internally** (source of truth), but the API
+**aggregates on read**: a `GET` sums all closed buckets in the window into **one
+row per key** (below). The fine buckets stay internally; billing gets one
+compacted row per key per pull.
 
 A bucket is **closed** (eligible to serve) once `now ≥ bucket_start + 60s + grace`
 (grace ≈ 30s). `grace` must exceed the in-process→config-store flush interval so
@@ -57,9 +57,10 @@ Auth: `Authorization: Bearer <internal secret>`.
 
 ### `GET /api/billing/usage`
 
-Returns every **closed 60s bucket since the last ack** — one row per
-`(org_id, team_id, query_source, cpu, mem_gib, bucket_start)`. Size is reported as
-`cpu` (vCPU) and `mem_gib` (GiB) — same units as the values:
+Returns compute usage **aggregated since the last ack — one row per key**
+`(org_id, team_id, query_source, cpu, mem_gib)`, summing every closed bucket in the
+window. Size is reported as `cpu` (vCPU) and `mem_gib` (GiB) — same units as the
+values:
 
 ```json
 {
@@ -67,14 +68,13 @@ Returns every **closed 60s bucket since the last ack** — one row per
   "watermark_high": "2026-07-01T12:40:00Z",
   "usage": [
     {
-      "bucket_start": "2026-07-01T12:34:00Z",
       "query_source": "endpoints" | "standard",
       "org_id": "org_abc",
       "team_id": "12345",
       "cpu": 8,
       "mem_gib": 16,
-      "cpu_seconds": 480,
-      "memory_seconds": 960
+      "cpu_seconds": 4800,
+      "memory_seconds": 9600
     }
   ]
 }
@@ -83,8 +83,8 @@ Returns every **closed 60s bucket since the last ack** — one row per
 (`cpu`/`mem_gib` are exact decimals — e.g. `1.5`, `0.5` — for fractional worker
 sizes; stored as `NUMERIC` so grouping is exact.)
 
-- Returns every closed bucket in the window `(watermark_low, watermark_high]`,
-  kept at minute granularity, where:
+- Sums every closed bucket in the window `(watermark_low, watermark_high]` into one
+  row per key, where:
   - `watermark_low` = duckgres's current cursor (= the last value billing acked) —
     the window start.
   - `watermark_high` = the latest closed minute (`now − grace`) — what billing acks.
@@ -93,11 +93,10 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   half-applied ack; HTTP and Postgres aren't one transaction) → a potential hole →
   alert/reconcile instead of silently under-billing. It's a cross-check, not a
   correctness fix (delete-on-ack already prevents loss); it makes a *bug* visible.
-- **Catch up in one pull.** A single `GET` returns **all** pending minutes since
-  the last ack (not one bucket per request), and one `ack` advances past all of
-  them — so billing never chases 60s buckets and can't fall behind. Response size
-  is bounded by active-keys × minutes-since-ack; pull on a sane cadence and it
-  stays small.
+- **Can't fall behind.** Everything since the last ack is aggregated into one row
+  per key, so the response size is bounded by the **number of active keys** —
+  independent of how long billing was away. A week of downtime returns the same row
+  count, just larger sums. One `ack` advances past all of it.
 
 ### `POST /api/billing/ack`
 
@@ -149,7 +148,7 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - **Keep:** per-connection metering → config-store 60s buckets.
 - **Extend:** the bucket table gains `team_id`, `query_source`, `cpu`, `mem_gib`
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
-  the HTTP API (serve closed minute buckets + watermark ack) + safety GC.
+  the HTTP API (aggregate-on-read into one row per key + watermark ack) + safety GC.
 - **Add:** config-store `org → team` lookup and the connection's `query_source`
   (standard vs endpoints) — both threaded onto the connection; a bearer secret for
   the API.

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -27,13 +27,15 @@ safety:    GC hard-deletes buckets older than 30 days (logged)
 Internally, one row per unique key, values accumulated:
 
 - **Key:** `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
-  where `bucket_start = floor(connection_end / 60s)`.
+  where `bucket_start = floor(connection_end / 60s)`. Worker size is stored as
+  **exact integers** (millicores, MiB) in the key — never a float — so equal sizes
+  always group into the same bucket (float keys risk `16.0 ≠ 16.0` splits).
 - **Values:** `cpu_seconds` (vCPU-seconds), `memory_seconds` (GiB-seconds) —
   summed over every connection that falls in that key + minute.
 - `team_id` is looked up from the config store (**org → team mapping**) at
   connection time.
-- Worker size (`cpu_millicores`, `mem_mib`) is part of the key, so different
-  worker sizes accumulate — and bill — separately.
+- Worker size is part of the key, so different worker sizes accumulate — and bill —
+  separately. It is **reported** in GiB/vCPU (see the API) to match the value units.
 
 **60-second resolution is kept internally.** The pull API aggregates on read (see
 below), so billing never has to chase individual minutes — but the fine buckets
@@ -50,8 +52,9 @@ Auth: `Authorization: Bearer <internal secret>`.
 
 ### `GET /api/billing/usage`
 
-Returns compute usage **aggregated since the last ack**, one row per
-`(org_id, team_id, cpu_millicores, mem_mib)`:
+Returns compute usage **aggregated since the last ack**, one row per worker size
+per `(org_id, team_id)`. Size is reported as `cpu` (vCPU) and `mem_gib` (GiB) —
+same units as the values:
 
 ```json
 {
@@ -60,14 +63,17 @@ Returns compute usage **aggregated since the last ack**, one row per
     {
       "org_id": "org_abc",
       "team_id": "12345",
-      "cpu_millicores": 8000,
-      "mem_mib": 16384,
+      "cpu": 8,
+      "mem_gib": 16,
       "cpu_seconds": 4800,
       "memory_seconds": 9600
     }
   ]
 }
 ```
+
+(`cpu`/`mem_gib` are decimals — e.g. `1.5`, `0.5` — for fractional worker sizes;
+the grouping key behind them is exact integer millicores/MiB.)
 
 - Sums all **closed** buckets in `(last_acked, watermark]`, where
   `watermark` = the latest closed minute (`now − grace`).
@@ -129,7 +135,8 @@ Returns compute usage **aggregated since the last ack**, one row per
 - Bucket width 60s, grace 30s.
 - Endpoint paths above are indicative — adjust to the control-plane API's house
   style.
-- Values are exposed as vCPU-seconds / GiB-seconds; internally accumulated in exact
+- Values exposed as vCPU-seconds / GiB-seconds; worker size reported as vCPU /
+  GiB (decimals) to match. Internally accumulated + keyed in exact
   millicore-/MiB-seconds so no precision is lost for fractional worker sizes.
 - Single billing consumer assumed → one server-side `last_acked` cursor. (If a
   second independent consumer is ever needed, give each its own named cursor.)

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -26,16 +26,16 @@ safety:    GC hard-deletes buckets older than 30 days (logged)
 
 Internally, one row per unique key, values accumulated:
 
-- **Key:** `(org_id, team_id, cpu_millicores, mem_mib, bucket_start)`
-  where `bucket_start = floor(connection_end / 60s)`. Worker size is stored as
-  **exact integers** (millicores, MiB) in the key — never a float — so equal sizes
-  always group into the same bucket (float keys risk `16.0 ≠ 16.0` splits).
+- **Key:** `(org_id, team_id, cpu, mem_gib, bucket_start)` where `cpu` is vCPU and
+  `mem_gib` is GiB, `bucket_start = floor(connection_end / 60s)`. Worker size is
+  stored as **exact decimals** (SQL `NUMERIC`, not IEEE floats), so equal sizes
+  always group into the same bucket and fractional sizes keep full precision.
 - **Values:** `cpu_seconds` (vCPU-seconds), `memory_seconds` (GiB-seconds) —
   summed over every connection that falls in that key + minute.
 - `team_id` is looked up from the config store (**org → team mapping**) at
   connection time.
-- Worker size is part of the key, so different worker sizes accumulate — and bill —
-  separately. It is **reported** in GiB/vCPU (see the API) to match the value units.
+- Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
+  accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
 **60-second resolution is kept internally.** The pull API aggregates on read (see
 below), so billing never has to chase individual minutes — but the fine buckets
@@ -72,8 +72,8 @@ same units as the values:
 }
 ```
 
-(`cpu`/`mem_gib` are decimals — e.g. `1.5`, `0.5` — for fractional worker sizes;
-the grouping key behind them is exact integer millicores/MiB.)
+(`cpu`/`mem_gib` are exact decimals — e.g. `1.5`, `0.5` — for fractional worker
+sizes; stored as `NUMERIC` so grouping is exact.)
 
 - Sums all **closed** buckets in `(last_acked, watermark]`, where
   `watermark` = the latest closed minute (`now − grace`).
@@ -124,7 +124,7 @@ the grouping key behind them is exact integer millicores/MiB.)
 - **Remove:** leader drain → `capture()` to PostHog ingestion, and the
   `DUCKGRES_BILLING_INGEST_URL` / `_TOKEN` config.
 - **Keep:** per-connection metering → config-store 60s buckets.
-- **Extend:** the bucket table gains `team_id`, `cpu_millicores`, `mem_mib` in the
+- **Extend:** the bucket table gains `team_id`, `cpu`, `mem_gib` (`NUMERIC`) in the
   key (new migration); add a single `last_acked` cursor row; add the HTTP API
   (aggregate-on-read + watermark ack) + safety GC.
 - **Add:** config-store `org → team` lookup (thread `team_id` onto the connection);
@@ -135,8 +135,8 @@ the grouping key behind them is exact integer millicores/MiB.)
 - Bucket width 60s, grace 30s.
 - Endpoint paths above are indicative — adjust to the control-plane API's house
   style.
-- Values exposed as vCPU-seconds / GiB-seconds; worker size reported as vCPU /
-  GiB (decimals) to match. Internally accumulated + keyed in exact
-  millicore-/MiB-seconds so no precision is lost for fractional worker sizes.
+- Values exposed as vCPU-seconds / GiB-seconds; worker size as vCPU / GiB. All
+  stored as exact decimals (`NUMERIC`), so fractional worker sizes keep full
+  precision with no float-equality issues.
 - Single billing consumer assumed → one server-side `last_acked` cursor. (If a
   second independent consumer is ever needed, give each its own named cursor.)

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -152,9 +152,9 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - **Extend:** the bucket table gains `team_id`, `query_source`, `cpu`, `mem_gib`
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
   the HTTP API (aggregate-on-read into one row per key + watermark ack) + safety GC.
-- **Add:** the org's default `team_id` (fixed per org — no per-team logic yet) and
-  the connection's `query_source` (standard vs endpoints) threaded onto the
-  connection; a bearer secret for the API.
+- **Add:** a `default_team_id` column on the org (used as the bucket `team_id` —
+  fixed per org, no per-team logic yet) and the connection's `query_source`
+  (standard vs endpoints) threaded onto the connection; a bearer secret for the API.
 
 ## Defaults / house-keeping
 


### PR DESCRIPTION
## What

Draft spec (`docs/design/billing-pull-api.md`) for the **pull-based** billing integration the billing team wants: billing pulls compute-usage buckets from a small duckgres HTTP API instead of duckgres pushing capture events.

## Decisions baked in

- **Buckets keyed by** `(org_id, team_id, cpu_millicores, mem_mib, bucket_start[60s])`; values `cpu_seconds` (vCPU-s) + `memory_seconds` (GiB-s).
- **API:** `GET /api/billing/buckets?limit=N` (closed, un-acked, oldest first) + `POST /api/billing/buckets/ack {ids}` (idempotent delete). Bearer auth over the existing posthog→mw ingress.
- **No data loss:** delete only on explicit ack; at-least-once + billing dedups by natural key; only closed buckets served.
- **No infinite accumulation:** ack deletes immediately; **30-day safety GC** (logged) bounds the table.
- **team_id:** config-store org→team lookup at connect (needs plumbing).
- **Replaces** the capture push (removes ingest URL/token + drain-to-PostHog); keeps per-connection metering.

Draft for review — implementation follows once the shape is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)