### PR TITLE
e2e: harden COPY-survives-idle-timeout flake (too-tight 60s margin)

### DIFF
--- a/server/conn_idle_test.go
+++ b/server/conn_idle_test.go
@@ -3,9 +3,12 @@ package server
 import (
 	"bufio"
 	"context"
+	"io"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/posthog/duckgres/server/wire"
 )
 
 // TestMessageLoopIdleTimeoutClosesConnection proves the mechanism the
@@ -44,5 +47,71 @@ func TestMessageLoopIdleTimeoutClosesConnection(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("messageLoop did not return on idle timeout")
+	}
+}
+
+// TestCopyStreamReArmsIdleDeadline proves the COPY-FROM-STDIN forwarding reader
+// (copyDataWireReader) re-arms the connection idle read deadline on EVERY
+// CopyData message, so a COPY that keeps putting bytes on the wire for LONGER
+// than the idle timeout — while never stalling longer than it between messages
+// — is NOT reaped mid-stream. This is the exact product guarantee the e2e
+// "COPY survives idle timeout" assertion exercises end-to-end.
+//
+// The connection starts with a deadline already armed (as it is when a COPY is
+// dispatched). If the reader failed to re-arm per message, that initial
+// deadline would fire partway through the >timeout stream and the read would
+// error — so deleting the per-message armIdleReadDeadline() makes this test
+// fail, which is what gives it teeth.
+func TestCopyStreamReArmsIdleDeadline(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	s := &Server{}
+	InitMinimalServer(s, Config{IdleTimeout: 250 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cc := &clientConn{
+		server: s,
+		conn:   serverSide,
+		reader: bufio.NewReader(serverSide),
+		writer: bufio.NewWriter(serverSide),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	// Simulate the deadline that is already armed when the COPY is dispatched.
+	cc.armIdleReadDeadline()
+
+	const msgs = 40
+	const payload = "row-data\n"
+	// Stream 40 CopyData messages 10ms apart (well under the 250ms timeout) then
+	// CopyDone: ~400ms total, comfortably PAST the idle timeout, but every gap is
+	// ~25x under it — so only correct per-message re-arming keeps the read alive.
+	go func() {
+		for i := 0; i < msgs; i++ {
+			time.Sleep(10 * time.Millisecond)
+			if err := wire.WriteCopyData(clientSide, []byte(payload)); err != nil {
+				return
+			}
+		}
+		_ = wire.WriteCopyDone(clientSide)
+	}()
+
+	r := &copyDataWireReader{c: cc}
+	total := 0
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		total += n
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("COPY stream reader errored mid-stream (idle re-arm broken?): %v", err)
+		}
+	}
+	if want := msgs * len(payload); total != want {
+		t.Fatalf("streamed %d bytes, want %d", total, want)
 	}
 }

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1497,43 +1497,78 @@ conn_idle_timeout_reaps_session() { # org password
 # reaped mid-stream (the regression the 60s default would otherwise cause for
 # the COPY-heavy data-import users). It must also be categorized as an ACTIVE
 # query in /queries (elapsed_ms>0), not an idle session, while it streams.
+#
+# Pacing (flake hardening): stream 15 chunks of 24 rows (=360) with 5s gaps →
+# ~75s total, comfortably ABOVE the 60s idle timeout (so a broken re-arm is still
+# caught — the stream out-lives the timeout), while every inter-chunk gap is only
+# 5s: ~12x under the 60s deadline. The previous 11s gap / ~66s total sat right on
+# the 60s boundary, so a single stretched gap — CI scheduling jitter, or the
+# just-reaped org's connection cold-spawning a worker whose first-chunk read /
+# DoPut forward stalled — pushed one armed read past 60s and tripped the deadline
+# (observed on ~5 runs/24h as duration_ms≈60001 "read csv stream: … i/o timeout").
+# 5s gaps restore the margin while keeping the assertion honest. The product-side
+# re-arm logic is correct; this is purely a too-tight harness margin.
 copy_active_and_survives_idle() { # org password
   org="$1"; pw="$2"
   log "COPY FROM STDIN: active in Live + survives idle timeout on $org"
-  out="$(mktemp)"
   conn="sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake"
-  # 6 chunks of 60 rows with 11s gaps → ~66s total stream, each gap < the 60s
-  # timeout. ON_ERROR_STOP makes a mid-stream reap fail the run (no 360 count).
-  ( printf 'DROP TABLE IF EXISTS e2e_idle_copy;\n'
-    printf 'CREATE TABLE e2e_idle_copy(v TEXT);\n'
-    printf '\\copy e2e_idle_copy(v) FROM STDIN\n'
-    for i in $(seq 1 6); do
-      for j in $(seq 1 60); do printf 'row-%d-%d\n' "$i" "$j"; done
-      sleep 11
+  # This test runs right after the idle-timeout test frees the org's worker, so a
+  # bare COPY connection would cold-spawn a worker inside the stream's critical
+  # path. Force activation up front so the streamed data never races a cold start.
+  wait_worker "$org" "$pw" ducklake
+  # A one-off environmental blip (a >60s CP→worker forward stall, a connection
+  # reset) can trip the client read deadline even though the COPY itself never
+  # idled — that is NOT the behavior under test, so retry the streaming attempt a
+  # bounded number of times on ONLY that transient signature. A genuine re-arm
+  # regression fails EVERY attempt (the stream always out-lives 60s), so this
+  # cannot mask it; a non-transient failure aborts immediately.
+  attempt=0 last=""
+  while [ "$attempt" -lt 2 ]; do
+    attempt=$((attempt + 1))
+    out="$(mktemp)"
+    ( printf 'DROP TABLE IF EXISTS e2e_idle_copy;\n'
+      printf 'CREATE TABLE e2e_idle_copy(v TEXT);\n'
+      printf '\\copy e2e_idle_copy(v) FROM STDIN\n'
+      for i in $(seq 1 15); do
+        for j in $(seq 1 24); do printf 'row-%d-%d\n' "$i" "$j"; done
+        sleep 5
+      done
+      printf '\\.\n'
+      printf 'SELECT count(*) FROM e2e_idle_copy;\n'
+      printf 'DROP TABLE e2e_idle_copy;\n'
+    ) | PGPASSWORD="$pw" psql "$conn" -v ON_ERROR_STOP=1 -qtA >"$out" 2>&1 &
+    bg=$!
+    # While it streams, /queries must show it as an ACTIVE query (elapsed_ms>0),
+    # not an idle session. Poll until seen active or the client exits (bounded).
+    active="" a=0
+    while [ "$a" -lt 30 ]; do
+      kill -0 "$bg" 2>/dev/null || break
+      e="$(curl -fsS -H "$H" "$API/api/v1/queries" \
+        | jq -r --arg o "$org" 'first(.queries[]? | select(.org==$o and .user=="root" and (.elapsed_ms>0))) | .elapsed_ms // empty')"
+      [ -n "$e" ] && { active=1; break; }
+      sleep 3; a=$((a + 1))
     done
-    printf '\\.\n'
-    printf 'SELECT count(*) FROM e2e_idle_copy;\n'
-    printf 'DROP TABLE e2e_idle_copy;\n'
-  ) | PGPASSWORD="$pw" psql "$conn" -v ON_ERROR_STOP=1 -qtA >"$out" 2>&1 &
-  bg=$!
-  cleanup_copy() { kill "$bg" 2>/dev/null || true; wait "$bg" 2>/dev/null || true; rm -f "$out"; }
-  # While it streams, /queries must show it as an ACTIVE query (elapsed_ms>0),
-  # not an idle session.
-  active="" a=0
-  while [ "$a" -lt 20 ]; do
-    kill -0 "$bg" 2>/dev/null || break
-    e="$(curl -fsS -H "$H" "$API/api/v1/queries" \
-      | jq -r --arg o "$org" 'first(.queries[]? | select(.org==$o and .user=="root" and (.elapsed_ms>0))) | .elapsed_ms // empty')"
-    [ -n "$e" ] && { active=1; break; }
-    sleep 3; a=$((a + 1))
+    # It must finish successfully with all 360 rows (NOT reaped mid-stream).
+    wait "$bg"; rc=$?
+    ok=""; { [ "$rc" -eq 0 ] && grep -qx "360" "$out"; } && ok=1
+    body="$(tr '\n' ' ' <"$out" | tail -c 300)"; rm -f "$out"
+    if [ -n "$ok" ]; then
+      # Streamed the full ~75s past the idle timeout: now the active-categorization
+      # assertion is the real remaining signal.
+      [ -n "$active" ] || fail "copy_active: streaming COPY not categorized active (elapsed_ms>0) in /queries on $org"
+      log "COPY FROM STDIN: active in Live + survived idle timeout (360 rows) on $org"
+      return 0
+    fi
+    last="$body"
+    case "$body" in
+      *"i/o timeout"*|*"read csv stream"*|*"connection reset"*|*"broken pipe"*|*"EOF"*|*"server closed the connection"*)
+        log "copy_active: transient stream blip on $org (attempt $attempt/2), retrying: $body"
+        continue ;;
+      *)
+        fail "copy_active: streaming COPY (~75s) did not succeed with 360 rows (rc=$rc): $body" ;;
+    esac
   done
-  [ -n "$active" ] || { cleanup_copy; fail "copy_active: streaming COPY not categorized active (elapsed_ms>0) in /queries on $org"; }
-  # It must finish successfully with all 360 rows (NOT reaped mid-stream).
-  wait "$bg"; rc=$?
-  { [ "$rc" -eq 0 ] && grep -qx "360" "$out"; } \
-    || { rm -f "$out"; fail "copy_active: streaming COPY (~66s) did not succeed with 360 rows (rc=$rc): $(tr '\n' ' ' <"$out" | tail -c 300)"; }
-  rm -f "$out"
-  log "COPY FROM STDIN: active in Live + survived idle timeout (360 rows) on $org"
+  fail "copy_active: streaming COPY (~75s) failed all $attempt attempts with transient stream errors — likely a real re-arm/reaper regression (last: $last)"
 }
 
 # ---- admin RBAC: SSO viewer is read-only -----------------------------------

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -1493,21 +1493,29 @@ conn_idle_timeout_reaps_session() { # org password
 # ---- COPY FROM STDIN: active in Live + survives the idle timeout ------------
 # An actively-streaming COPY reads many CopyData messages; each in-loop read
 # re-arms the read deadline (server/conn_copy.go armIdleReadDeadline), so a COPY
-# that streams for LONGER than the idle timeout but never stalls must NOT be
-# reaped mid-stream (the regression the 60s default would otherwise cause for
-# the COPY-heavy data-import users). It must also be categorized as an ACTIVE
-# query in /queries (elapsed_ms>0), not an idle session, while it streams.
+# that keeps putting bytes ON THE WIRE for LONGER than the idle timeout — while
+# never stalling longer than it between messages — must NOT be reaped mid-stream
+# (the regression the 60s default would otherwise cause for COPY-heavy data
+# imports). It must also be categorized as an ACTIVE query in /queries
+# (elapsed_ms>0), not an idle session, while it streams. The server-side re-arm
+# is unit-tested by TestCopyStreamReArmsIdleDeadline (server/conn_idle_test.go);
+# this asserts the same guarantee end-to-end against a real worker.
 #
-# Pacing (flake hardening): stream 15 chunks of 24 rows (=360) with 5s gaps →
-# ~75s total, comfortably ABOVE the 60s idle timeout (so a broken re-arm is still
-# caught — the stream out-lives the timeout), while every inter-chunk gap is only
-# 5s: ~12x under the 60s deadline. The previous 11s gap / ~66s total sat right on
-# the 60s boundary, so a single stretched gap — CI scheduling jitter, or the
-# just-reaped org's connection cold-spawning a worker whose first-chunk read /
-# DoPut forward stalled — pushed one armed read past 60s and tripped the deadline
-# (observed on ~5 runs/24h as duration_ms≈60001 "read csv stream: … i/o timeout").
-# 5s gaps restore the margin while keeping the assertion honest. The product-side
-# re-arm logic is correct; this is purely a too-tight harness margin.
+# ROOT CAUSE of the earlier flake (do NOT regress this): the old version streamed
+# tiny rows (~12 bytes) with sleeps between them. libpq buffers CopyData in its
+# ~8KB client-side output buffer and only flushes when that buffer fills — so a
+# trickle of small rows was NEVER put on the wire until PQputCopyEnd (the closing
+# "\."), which for a ~75s producer lands well past the 60s idle timeout. The
+# server therefore saw a genuinely IDLE connection (zero bytes for 60s) and
+# correctly reaped it — the observed failure was duration_ms≈60001 on the FIRST
+# read with rows=0 (i.e. nothing ever arrived), NOT a re-arm bug. The producer's
+# sleeps paced the SHELL, not the wire.
+#
+# FIX: send fat chunks (~32KB each, well over libpq's flush threshold) so every
+# 5s interval forces a real flush and the server actually receives a burst of
+# CopyData to re-arm on. 14 chunks × 5s ≈ 70s of genuine wire activity — past the
+# 60s idle timeout (a broken re-arm would still be caught), with each gap ~12x
+# under the deadline. Each row carries a 2000-char pad so ~16 rows = ~32KB/chunk.
 copy_active_and_survives_idle() { # org password
   org="$1"; pw="$2"
   log "COPY FROM STDIN: active in Live + survives idle timeout on $org"
@@ -1516,12 +1524,15 @@ copy_active_and_survives_idle() { # org password
   # bare COPY connection would cold-spawn a worker inside the stream's critical
   # path. Force activation up front so the streamed data never races a cold start.
   wait_worker "$org" "$pw" ducklake
-  # A one-off environmental blip (a >60s CP→worker forward stall, a connection
+  # 2000-char pad → each row line is ~2KB, so a 16-row chunk is ~32KB: bigger than
+  # libpq's ~8KB output buffer, which forces a flush to the wire each interval.
+  pad="$(printf '%02000d' 0)"
+  # A one-off environmental blip (a real CP→worker forward stall, a connection
   # reset) can trip the client read deadline even though the COPY itself never
   # idled — that is NOT the behavior under test, so retry the streaming attempt a
   # bounded number of times on ONLY that transient signature. A genuine re-arm
-  # regression fails EVERY attempt (the stream always out-lives 60s), so this
-  # cannot mask it; a non-transient failure aborts immediately.
+  # regression fails EVERY attempt (the stream always out-lives 60s of real wire
+  # activity), so this cannot mask it; a non-transient failure aborts immediately.
   attempt=0 last=""
   while [ "$attempt" -lt 2 ]; do
     attempt=$((attempt + 1))
@@ -1529,8 +1540,8 @@ copy_active_and_survives_idle() { # org password
     ( printf 'DROP TABLE IF EXISTS e2e_idle_copy;\n'
       printf 'CREATE TABLE e2e_idle_copy(v TEXT);\n'
       printf '\\copy e2e_idle_copy(v) FROM STDIN\n'
-      for i in $(seq 1 15); do
-        for j in $(seq 1 24); do printf 'row-%d-%d\n' "$i" "$j"; done
+      for i in $(seq 1 14); do
+        for j in $(seq 1 16); do printf 'r%d_%d_%s\n' "$i" "$j" "$pad"; done
         sleep 5
       done
       printf '\\.\n'
@@ -1548,15 +1559,18 @@ copy_active_and_survives_idle() { # org password
       [ -n "$e" ] && { active=1; break; }
       sleep 3; a=$((a + 1))
     done
-    # It must finish successfully with all 360 rows (NOT reaped mid-stream).
-    wait "$bg"; rc=$?
-    ok=""; { [ "$rc" -eq 0 ] && grep -qx "360" "$out"; } && ok=1
+    # It must finish successfully with all 224 rows (NOT reaped mid-stream).
+    # NB: `wait; rc=$?` must NOT be a bare statement — under `set -e` a non-zero
+    # psql exit would abort the whole harness at `wait` (the "HARNESS EXIT rc=3,
+    # no FAIL line" seen before) before the retry/branch logic below could run.
+    if wait "$bg"; then rc=0; else rc=$?; fi
+    ok=""; { [ "$rc" -eq 0 ] && grep -qx "224" "$out"; } && ok=1
     body="$(tr '\n' ' ' <"$out" | tail -c 300)"; rm -f "$out"
     if [ -n "$ok" ]; then
-      # Streamed the full ~75s past the idle timeout: now the active-categorization
-      # assertion is the real remaining signal.
+      # Streamed ~70s of real wire traffic past the idle timeout without being
+      # reaped: now the active-categorization assertion is the remaining signal.
       [ -n "$active" ] || fail "copy_active: streaming COPY not categorized active (elapsed_ms>0) in /queries on $org"
-      log "COPY FROM STDIN: active in Live + survived idle timeout (360 rows) on $org"
+      log "COPY FROM STDIN: active in Live + survived idle timeout (224 rows) on $org"
       return 0
     fi
     last="$body"
@@ -1565,10 +1579,10 @@ copy_active_and_survives_idle() { # org password
         log "copy_active: transient stream blip on $org (attempt $attempt/2), retrying: $body"
         continue ;;
       *)
-        fail "copy_active: streaming COPY (~75s) did not succeed with 360 rows (rc=$rc): $body" ;;
+        fail "copy_active: streaming COPY (~70s) did not succeed with 224 rows (rc=$rc): $body" ;;
     esac
   done
-  fail "copy_active: streaming COPY (~75s) failed all $attempt attempts with transient stream errors — likely a real re-arm/reaper regression (last: $last)"
+  fail "copy_active: streaming COPY (~70s) failed all $attempt attempts with transient stream errors — likely a real re-arm/reaper regression (last: $last)"
 }
 
 # ---- admin RBAC: SSO viewer is read-only -----------------------------------


### PR DESCRIPTION
## Summary

Hardens the `COPY FROM STDIN: active in Live + survives idle timeout` e2e assertion, which was the dominant flake across the last 24h of `e2e-mw-dev.yml` runs (~5 failures). **Harness + test only — no product code changed.**

## Corrected root cause (client-side libpq buffering — NOT a re-arm bug)

Every failure had the identical signature: the COPY errored at **`duration_ms=60001` on the FIRST message read with `rows=0`**. That is decisive: if the server had received *any* CopyData and re-armed, the deadline would fire 60s after the *last* message (duration ≫ 60s). Exactly-60001-from-start means **the server received zero bytes for 60s** and correctly reaped a genuinely-idle connection.

Why did zero bytes arrive when the client was "connected" for ~75s? The harness streamed tiny rows (~12 bytes) with `sleep`s between them. **libpq buffers CopyData in its ~8KB client-side output buffer and only flushes when it fills**, so a trickle of small rows was never put on the wire until `PQputCopyEnd` (the closing `\.`), which for a ~75s producer lands well past the 60s idle timeout. The producer's sleeps paced the *shell*, not the *wire*. So the connection genuinely *was* idle from the server's point of view.

The server-side re-arm (`server/conn_copy.go` `armIdleReadDeadline`, `now+IdleTimeout` per CopyData) is **correct** — it just never received data to re-arm on.

## Fix

| Change | Why |
| --- | --- |
| Stream **fat chunks (~32KB each)** — 14 chunks × 16 rows, each row padded to ~2KB — with 5s gaps | Each chunk far exceeds libpq's ~8KB flush threshold, so every 5s interval forces a real flush and the server actually receives CopyData bursts to re-arm on. ~70s of **genuine wire activity** past the 60s idle timeout (a broken re-arm would still be caught), each gap ~12x under the deadline. |
| **`set -e` / `wait` fix**: `if wait "$bg"; then rc=0; else rc=$?; fi` | The prior `wait "$bg"; rc=$?` aborts the whole harness under `set -e` on a non-zero psql exit (the "HARNESS EXIT rc=3, no FAIL line" symptom) *before* the retry/branch logic could run. |
| `wait_worker` before the timed stream | Keeps a cold worker spawn out of the stream's critical path (this test runs right after the idle-timeout test frees the worker). |
| Bounded retry (2 attempts) on ONLY the transient `i/o timeout` / `connection reset` / `broken pipe` signature | A one-off CP→worker forward stall is not the behavior under test. A genuine re-arm regression fails **every** attempt (the stream always out-lives 60s of real wire traffic), so it can't be masked. |

The 224-row exact-match check, the "shown ACTIVE in `/queries`" check, and `ON_ERROR_STOP=1` are all preserved.

## New unit test (proves the product is correct)

`TestCopyStreamReArmsIdleDeadline` (`server/conn_idle_test.go`): drives `copyDataWireReader` over a `net.Pipe` with a 250ms idle timeout, streaming CopyData every 10ms for ~400ms (past the timeout). It passes with the per-message re-arm and — verified locally — **fails with `i/o timeout` when `armIdleReadDeadline()` is removed**, so it guards the real guarantee deterministically and fast.

## Other 24h failures — NOT hardened (deliberately)

- **`/cluster/nodes empty or missing projected node fields`** (branch `admin-node-overview`) — a real failure of that branch's own in-flight feature, not a flake, out of scope.
- **`ready_res1 did not reach ready within 600s (last=provisioning)`** (one occurrence) — real duckling cold-provisioning latency; the 600s budget is already generous. Reported, not papered over.

## Validation

`bash -n` passes on `harness.sh` and `run.sh`; `go vet ./server/` clean; `go test ./server/ -run 'Idle|Copy'` passes. The e2e path can't be run locally; correctness rests on the wire-buffering analysis above plus the deterministic unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)