### PR TITLE
admin/nodes: move counters to Topbar, restructure header, drain/terminate durations + pod image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,13 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   cluster node/pod TV — nodes grouped by karpenter nodepool (or by namespace /
   deployment), CPU/MEM request bars, pod chips colored per deployment,
   placeholder/system-pod classification, Karpenter empty-node reclaim countdown,
-  unscheduled tray, and a synthesized event ticker. It's imperative DOM (mounted
+  draining-duration on nodes (deletion-timestamp or client-tracked first-seen)
+  and terminating-duration on pods, each pod's running image, unscheduled tray,
+  and a synthesized event ticker. Its header carries only the filters + live
+  indicator; the nodes/workers/placeholders/pending counters are lifted into the
+  shared admin **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts`
+  → `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
+  pushes `null` on unmount so they only show on this page). It's imperative DOM (mounted
   by the React page into a `.peeper` root, scoped CSS + `pn-`-prefixed keyframes)
   and does NOT use native K8s watch — the browser can't reach the API, so it
   POLLS four **read-only** projected endpoints (`server/`-free; `cluster.go`):

--- a/controlplane/admin/ui/src/components/Topbar.tsx
+++ b/controlplane/admin/ui/src/components/Topbar.tsx
@@ -1,8 +1,10 @@
+import { useSyncExternalStore } from "react";
 import { Circle, ShieldCheck, Eye } from "lucide-react";
 import { useClusterStatus, useModel } from "@/hooks/useApi";
 import { useIdentity } from "@/components/IdentityProvider";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { getClusterCounts, subscribeClusterCounts } from "@/lib/clusterCounts";
 
 function HealthDot({ ok, label, detail }: { ok: boolean; label: string; detail?: string }) {
   return (
@@ -11,6 +13,32 @@ function HealthDot({ ok, label, detail }: { ok: boolean; label: string; detail?:
         className={cn("h-2.5 w-2.5", ok ? "fill-success text-success" : "fill-destructive text-destructive")}
       />
       <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+// One node/worker/placeholder/pending counter, shown only on the Nodes view
+// (the peepernetes view pushes live counts into the clusterCounts store).
+function CountStat({ n, label, detail, muted }: { n: number; label: string; detail?: string; muted?: boolean }) {
+  return (
+    <div className="flex items-baseline gap-1" title={detail}>
+      <span className={cn("font-mono text-sm tabular-nums", muted && n === 0 ? "text-muted-foreground" : "text-foreground")}>
+        {n}
+      </span>
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function ClusterCounters() {
+  const counts = useSyncExternalStore(subscribeClusterCounts, getClusterCounts);
+  if (!counts) return null;
+  return (
+    <div className="flex items-center gap-4 border-l border-border pl-4">
+      <CountStat n={counts.nodes} label="nodes" />
+      <CountStat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
+      <CountStat n={counts.placeholders} label="placeholders" detail={counts.placeholderReq || undefined} muted />
+      <CountStat n={counts.pending} label="pending" muted />
     </div>
   );
 }
@@ -41,6 +69,7 @@ export function Topbar() {
             detail="control-plane instances (cp_instances)"
           />
         )}
+        <ClusterCounters />
       </div>
 
       <div className="flex items-center gap-3">

--- a/controlplane/admin/ui/src/lib/clusterCounts.ts
+++ b/controlplane/admin/ui/src/lib/clusterCounts.ts
@@ -1,0 +1,35 @@
+// Tiny external store that bridges the imperative peepernetes "Nodes" view's
+// live cluster counters into the shared React Topbar. The Nodes page owns an
+// imperative DOM/polling module (pages/nodes/peepernetes.ts) that can't render
+// into React directly, so on each repaint it pushes the current
+// nodes/workers/placeholders/pending counts here; Topbar subscribes via
+// useSyncExternalStore and shows them next to the CP-replica health chips.
+// When the Nodes view unmounts it pushes null and the Topbar hides them.
+
+export interface ClusterCounts {
+  nodes: number;
+  workers: number; // non-placeholder, non-succeeded pods (the view calls these "workers")
+  placeholders: number;
+  pending: number;
+  workerReq: string; // "12 CPU · 34 Gi" totals, "" when zero — shown as a tooltip
+  placeholderReq: string;
+}
+
+let current: ClusterCounts | null = null;
+const subscribers = new Set<() => void>();
+
+export function setClusterCounts(next: ClusterCounts | null): void {
+  current = next;
+  for (const fn of subscribers) fn();
+}
+
+export function getClusterCounts(): ClusterCounts | null {
+  return current;
+}
+
+export function subscribeClusterCounts(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.css
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.css
@@ -48,41 +48,17 @@
 }
 
 /* ── header ─────────────────────────────────────── */
+/* Only the filters + live indicator live here now (left-aligned); the brand and
+ * the nodes/workers/placeholders/pending counters moved to the admin Topbar. */
 .peeper .hdr {
   position: relative; z-index: 2;
-  display: flex; align-items: flex-start; gap: 28px;
-  padding: 14px 22px 12px;
+  display: flex; align-items: center; gap: 20px;
+  padding: 10px 22px;
   border-bottom: 1px solid var(--line);
   background: linear-gradient(180deg, #0c1118, #090d12);
   flex: none;
 }
-.peeper .brand { display: flex; flex-direction: column; line-height: 1.05; }
-.peeper .brand .t {
-  font-family: "Chakra Petch", "IBM Plex Mono", sans-serif; font-weight: 700; font-size: 21px;
-  letter-spacing: .14em; color: #eaf6ff;
-  text-shadow: 0 0 18px rgba(56,225,255,.35);
-}
-.peeper .brand .t em { color: var(--worker); font-style: normal; }
-.peeper .brand .s { font-size: 10px; color: var(--dim); letter-spacing: .3em; margin-top: 3px; }
-.peeper .stats { display: flex; gap: 24px; margin-left: 18px; align-items: flex-start; margin-top: 2px; }
-.peeper .stat { display: flex; flex-direction: column; align-items: flex-start; min-width: 72px; }
-.peeper .stat .top { display: flex; align-items: baseline; gap: 6px; }
-.peeper .stat .n {
-  font-family: "IBM Plex Mono", monospace; font-weight: 600; font-size: 19px; line-height: 1.1;
-  font-variant-numeric: tabular-nums; transition: color .3s;
-}
-.peeper .stat .l { font-size: 9px; letter-spacing: .22em; color: var(--dim); }
-.peeper .stat .r { font-size: 9px; min-height: 11px; color: var(--dim); margin-top: 2px; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.peeper .stat.bump .n { animation: pn-bump .4s ease; }
-@keyframes pn-bump { 30% { transform: translateY(-3px) scale(1.12); } }
-.peeper #n-nodes .n   { color: #eaf6ff; }
-.peeper #n-pods .n { color: var(--worker); }
-.peeper #n-head .n    { color: var(--headroom); }
-.peeper #n-pend .n    { color: var(--pend); }
-.peeper #n-pend.zero .n { color: var(--dim); }
-
-.peeper .spacer { flex: 1; }
-.peeper .toggles { display: flex; gap: 14px; align-items: flex-end; align-self: center; flex-wrap: wrap; }
+.peeper .toggles { display: flex; gap: 14px; align-items: flex-end; flex-wrap: wrap; }
 .peeper .fctl { display: flex; flex-direction: column; gap: 3px; }
 .peeper .fctl .fl { font-size: 8.5px; letter-spacing: .18em; color: var(--dim); }
 .peeper #ns-filter, .peeper #sys-mode, .peeper #group-by {
@@ -212,6 +188,13 @@
 .peeper .pods.flat .pod:not(.dot) { flex: 0 0 150px; max-width: 150px; }
 .peeper .pod.dot { flex: 0 0 auto; }
 .peeper .pod .pm { font-size: 9px; color: var(--dim); white-space: nowrap; }
+/* running image (short name:tag); full path in the chip tooltip */
+.peeper .pod .pi {
+  font-size: 8.5px; color: color-mix(in srgb, var(--c) 55%, var(--dim));
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
+  font-variant-numeric: tabular-nums;
+}
+.peeper .pod .pi:empty { display: none; }
 .peeper .pod.fresh { animation: pn-pod-in .55s cubic-bezier(.2,1.6,.4,1); }
 @keyframes pn-pod-in { from { transform: scale(.4); opacity: 0; } 60% { transform: scale(1.08); } }
 .peeper .pod.fresh::after {
@@ -243,7 +226,7 @@
 /* collapsed daemonset/system pod: tiny dot, full info on hover */
 .peeper .pod.dot { min-width: 0; width: 12px; height: 12px; padding: 0; border-radius: 50%; align-self: center; transition: transform .15s; }
 .peeper .pod.dot::before { display: none; }
-.peeper .pod.dot .pn, .peeper .pod.dot .pm { display: none; }
+.peeper .pod.dot .pn, .peeper .pod.dot .pm, .peeper .pod.dot .pi { display: none; }
 .peeper .pod.dot:hover { transform: scale(1.7); opacity: 1; }
 
 /* unscheduled tray */

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
@@ -14,6 +14,8 @@
  * keeping it recognizably the same eases future diffing against upstream.
  */
 
+import { setClusterCounts } from "@/lib/clusterCounts";
+
 const API = "/api/v1/cluster";
 
 // mountPeepernetes builds the whole view inside `root` and starts polling.
@@ -22,19 +24,11 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   const $ = (s: string): any => root.querySelector(s);
 
   root.classList.add("peeper");
+  // Header carries only the filters + live indicator, left-aligned. The brand
+  // and the nodes/workers/placeholders/pending counters were lifted OUT of this
+  // header into the shared admin Topbar (see setClusterCounts + Topbar.tsx).
   root.innerHTML = `
   <div class="hdr">
-    <div class="brand">
-      <div class="t">PEEPER<em>NETES</em></div>
-      <div class="s">LIVE CLUSTER WATCH</div>
-    </div>
-    <div class="stats">
-      <div class="stat" id="n-nodes"><span class="top"><span class="n">–</span><span class="l">NODES</span></span><span class="r"></span></div>
-      <div class="stat" id="n-pods"><span class="top"><span class="n">–</span><span class="l">PODS</span></span><span class="r"></span></div>
-      <div class="stat" id="n-head"><span class="top"><span class="n">–</span><span class="l">PLACEHOLDERS</span></span><span class="r"></span></div>
-      <div class="stat" id="n-pend"><span class="top"><span class="n">–</span><span class="l">PENDING</span></span><span class="r"></span></div>
-    </div>
-    <div class="spacer"></div>
     <div class="toggles">
       <div class="fctl"><span class="fl">GROUP BY</span>
         <select id="group-by">
@@ -283,8 +277,35 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   }
   const emptySince = new Map<string, { ts: number; approx: boolean }>();
   try { for (const [k, v] of JSON.parse(sessionStorage.getItem("peepernetes-emptysince") || "[]")) emptySince.set(k, v); } catch { /* ignore */ }
+  // How long a node has been draining. deletionTimestamp is authoritative when a
+  // node is actually being deleted; a cordon / karpenter-disrupt taint has no
+  // server-side start time, so we record first-seen client-side (persisted so it
+  // survives a reload; `approx` when we can't know it started exactly then).
+  const drainSince = new Map<string, { ts: number; approx: boolean }>();
+  try { for (const [k, v] of JSON.parse(sessionStorage.getItem("peepernetes-drainsince") || "[]")) drainSince.set(k, v); } catch { /* ignore */ }
   let podsLoadedAt = 0;
+  let nodesLoadedAt = 0;
   function fmtLeft(ms: number): string { return ms >= 60e3 ? Math.ceil(ms / 60e3) + "m" : Math.ceil(ms / 1e3) + "s"; }
+  // Elapsed duration (floored, s/m/h/d) — for how long something has been in a state.
+  function fmtDur(ms: number): string {
+    const s = Math.max(0, ms / 1000);
+    if (s < 90) return Math.round(s) + "s";
+    if (s < 5400) return Math.round(s / 60) + "m";
+    if (s < 2 * 86400) return (s / 3600).toFixed(1) + "h";
+    return Math.round(s / 86400) + "d";
+  }
+  // Container image(s) a pod runs. Short form drops the registry/repo path and
+  // keeps the final `name:tag` (or `name@sha…`); "+N" when a pod has sidecars.
+  function shortImage(img: string): string { return (img.split("/").pop() || img); }
+  function podImages(pod: any): string[] {
+    return (pod.spec.containers || []).map((c: any) => c.image || "").filter(Boolean);
+  }
+  function imageLabel(pod: any): string {
+    const imgs = podImages(pod);
+    if (!imgs.length) return "";
+    const s = shortImage(imgs[0]);
+    return imgs.length > 1 ? `${s} +${imgs.length - 1}` : s;
+  }
 
   // ── event ticker ───────────────────────────────────────
   const evBox = $("#events");
@@ -376,15 +397,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   const poolsBox: HTMLElement = $("#pools");
   const seen = new Set<string>();
   let firstPaint = true;
-
-  function setStat(id: string, v: number): void {
-    const el = $(id), n = el.querySelector(".n");
-    if (n.textContent !== String(v)) {
-      n.textContent = v;
-      el.classList.remove("bump"); void el.offsetWidth; el.classList.add("bump");
-    }
-    el.classList.toggle("zero", v === 0);
-  }
+  let lastCountsKey = "";
 
   function nodeReady(node: any): boolean {
     return (node.status?.conditions || []).some((c: any) => c.type === "Ready" && c.status === "True");
@@ -394,7 +407,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     const el = document.createElement("div");
     el.className = "pod " + kindClass(_k);
     el.dataset.uid = pod.metadata.uid;
-    el.innerHTML = `<span class="pn"></span><span class="pm"></span>`;
+    el.innerHTML = `<span class="pn"></span><span class="pi"></span><span class="pm"></span>`;
     if (!firstPaint && !seen.has(pod.metadata.uid)) el.classList.add("fresh");
     seen.add(pod.metadata.uid);
     setTimeout(() => el.classList.remove("fresh"), 1700);
@@ -404,15 +417,25 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     const phase = pod.status?.phase || "?";
     if (k.startsWith("a:")) el.style.setProperty("--c", appColor(k.slice(2)));
     else el.style.removeProperty("--c");
+    const terminating = !!pod.metadata.deletionTimestamp;
     el.classList.toggle("dot", k === "system" && sysMode() === "dot");
-    el.classList.toggle("terminating", !!pod.metadata.deletionTimestamp);
-    el.classList.toggle("pending", phase === "Pending" && !pod.metadata.deletionTimestamp);
+    el.classList.toggle("terminating", terminating);
+    el.classList.toggle("pending", phase === "Pending" && !terminating);
     el.classList.toggle("failed", phase === "Failed");
     const { cpu, mem } = podReq(pod);
     (el.querySelector(".pn") as HTMLElement).textContent = pod.metadata.name;
-    (el.querySelector(".pm") as HTMLElement).textContent =
-      `${cpu || mem ? fmtCpu(cpu) + " · " + fmtMem(mem) : phase.toLowerCase()}${cpu || mem ? " · " + age(pod.metadata.creationTimestamp) : ""}`;
-    el.title = `${pod.metadata.namespace}/${pod.metadata.name}\nphase: ${phase}\nnode: ${pod.spec.nodeName || "—"}\nreq: ${fmtCpu(cpu)} / ${fmtMem(mem)}`;
+    // Every pod shows its running image (short name:tag; full path in the tooltip).
+    const imgs = podImages(pod);
+    (el.querySelector(".pi") as HTMLElement).textContent = imageLabel(pod);
+    // While terminating, the meta line shows how long it's been draining down
+    // (since deletionTimestamp — authoritative). Otherwise req · age as before.
+    (el.querySelector(".pm") as HTMLElement).textContent = terminating
+      ? `terminating ${fmtDur(Date.now() - Date.parse(pod.metadata.deletionTimestamp))}`
+      : `${cpu || mem ? fmtCpu(cpu) + " · " + fmtMem(mem) : phase.toLowerCase()}${cpu || mem ? " · " + age(pod.metadata.creationTimestamp) : ""}`;
+    el.title = `${pod.metadata.namespace}/${pod.metadata.name}\nphase: ${phase}` +
+      (terminating ? ` (terminating ${fmtDur(Date.now() - Date.parse(pod.metadata.deletionTimestamp))})` : "") +
+      `\nnode: ${pod.spec.nodeName || "—"}\nreq: ${fmtCpu(cpu)} / ${fmtMem(mem)}` +
+      (imgs.length ? `\nimage: ${imgs.join("\n       ")}` : "");
   }
 
   // reconcile a flex container of pod chips against a desired pod list
@@ -505,6 +528,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     const ns = nsFilter();
 
     if (pods.size && !podsLoadedAt) podsLoadedAt = Date.now();
+    if (nodes.size && !nodesLoadedAt) nodesLoadedAt = Date.now();
 
     const poolOfNode = new Map<string, string>();
     for (const n of nodes.values()) poolOfNode.set(n.metadata.name, nodePool(n));
@@ -541,13 +565,12 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     for (const l of byNode.values()) sortPods(l);
     sortPods(unsched);
 
-    setStat("#n-pods", nPods);
-    setStat("#n-head", nHead);
-    setStat("#n-pend", nPend);
-    $("#n-pods .r").textContent = nPods ? `${fmtCpu(pCpu)} · ${fmtMem(pMem)}` : "";
+    // Header counters now live in the shared admin Topbar; build the CPU/MEM
+    // total strings here and push everything (incl. the node count below) via
+    // setClusterCounts once nNodes is known.
     const pct = (a: number, b: number) => b ? Math.round(a / b * 100) + "%" : "–";
-    $("#n-head .r").textContent = nHead ? `${fmtCpu(hCpu)} · ${fmtMem(hMem)} · ${pct(hCpu, pCpu)}/${pct(hMem, pMem)}` : "";
-    $("#n-head .r").title = "placeholder requests as % of (filtered) pod requests (cpu/mem)";
+    const workerReq = nPods ? `${fmtCpu(pCpu)} · ${fmtMem(pMem)}` : "";
+    const placeholderReq = nHead ? `${fmtCpu(hCpu)} · ${fmtMem(hMem)} · ${pct(hCpu, pCpu)}/${pct(hMem, pMem)} of workers` : "";
 
     $("#tray").classList.toggle("show", unsched.length > 0);
     $("#tray-count").textContent = unsched.length ? unsched.length + " pod(s) waiting for a node" : "";
@@ -571,7 +594,13 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     }
     let nNodes = 0;
     for (const l of pools.values()) for (const n of l) if (!goneUids.has(n.metadata.uid)) nNodes++;
-    setStat("#n-nodes", nNodes);
+    // Only publish to the Topbar when a value actually changed (avoids a Topbar
+    // re-render on every poll tick when the numbers are unchanged).
+    const countsKey = [nNodes, nPods, nHead, nPend, workerReq, placeholderReq].join("|");
+    if (countsKey !== lastCountsKey) {
+      lastCountsKey = countsKey;
+      setClusterCounts({ nodes: nNodes, workers: nPods, placeholders: nHead, pending: nPend, workerReq, placeholderReq });
+    }
     const poolNames = [...pools.keys()].sort((a, b) => (POOL_ORDER(a) - POOL_ORDER(b)) || a.localeCompare(b));
 
     const gmode = $("#group-by").value;
@@ -633,6 +662,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
           card.classList.toggle("gone", isGone);
           card.classList.toggle("draining", !isGone && nodeDraining(n));
           card.classList.toggle("notready", !isGone && !nodeDraining(n) && !nodeReady(n));
+          if (isGone || !nodeDraining(n)) drainSince.delete(n.metadata.name);
           (card.querySelector(".node-name") as HTMLElement).textContent = n.metadata.name.replace(".ec2.internal", "");
           (card.querySelector(".node-meta") as HTMLElement).textContent =
             (n.metadata.labels?.["node.kubernetes.io/instance-type"] || "") +
@@ -669,9 +699,22 @@ export function mountPeepernetes(root: HTMLElement): () => void {
             expEl.classList.add("gone");
             expEl.title = "node deleted — shown briefly for context";
           } else if (nodeDraining(n)) {
-            expTxt = "DRAINING";
+            // How long it's been draining: deletionTimestamp is authoritative;
+            // otherwise fall back to when we first saw it draining (approx if it
+            // was already draining at load — real start unknown, so mark it "≥").
+            let startMs: number, approx = false;
+            if (n.metadata.deletionTimestamp) {
+              startMs = Date.parse(n.metadata.deletionTimestamp);
+              drainSince.delete(n.metadata.name);
+            } else {
+              let rec = drainSince.get(n.metadata.name);
+              if (!rec) { rec = { ts: Date.now(), approx: !!nodesLoadedAt && Date.now() - nodesLoadedAt < 3000 }; drainSince.set(n.metadata.name, rec); }
+              startMs = rec.ts; approx = rec.approx;
+            }
+            expTxt = `DRAINING ${approx ? "≥" : ""}${fmtDur(Date.now() - startMs)}`;
             expEl.classList.add("draining");
-            expEl.title = "node is cordoned / being disrupted — pods drain, then it terminates";
+            expEl.title = "node is cordoned / being disrupted — pods drain, then it terminates" +
+              (approx ? "\n(was already draining at page load — actual start may be earlier)" : "");
           } else if (!nodeReady(n)) {
             expTxt = "NOT READY";
             expEl.classList.add("bad");
@@ -722,6 +765,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     }
     firstPaint = false;
     try { sessionStorage.setItem("peepernetes-emptysince", JSON.stringify([...emptySince])); } catch { /* ignore */ }
+    try { sessionStorage.setItem("peepernetes-drainsince", JSON.stringify([...drainSince])); } catch { /* ignore */ }
   }
 
   // render loop: coalesce bursts, repaint ages every 5s
@@ -785,6 +829,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     for (const id of timers) clearInterval(id);
     for (const c of controllers) c.abort();
     document.removeEventListener("click", docClickFn);
+    setClusterCounts(null); // Topbar drops the node/worker counters when we leave
     root.classList.remove("peeper");
     root.innerHTML = "";
   };


### PR DESCRIPTION
Reworks the live **Nodes** view (peepernetes) per operator feedback. Frontend-only — the `/cluster/*` projection already carries container images, so no backend change.

## Changes
- **Removed** the peepernetes brand / "LIVE CLUSTER WATCH" block from the view header.
- **Moved counters to the shared admin Topbar**: nodes · workers (renamed from "pods") · placeholders · pending now render next to the existing "N CP replicas" chip, via a tiny external store (`lib/clusterCounts.ts` + `Topbar` `useSyncExternalStore`). The view pushes counts each repaint and `null` on unmount, so they only appear on the Nodes page. CPU/MEM totals ride along as tooltips.
- **Filters + live indicator moved left**: the view header now carries only the group-by / namespace / node-pool / system-pods filters and the live indicator, left-aligned.
- **Draining/terminating durations**: nodes show how long they've been `DRAINING` (authoritative `deletionTimestamp` when present, else client-tracked first-seen, persisted across reloads; `≥` when it was already draining at page load). Pods show how long they've been `terminating` (since `deletionTimestamp`).
- **Pod image**: every pod chip shows its running image (short `name:tag`; full path + any sidecar images in the tooltip).

## Validation
UI `typecheck` / `lint` / `vitest` / `build` all pass. No Go/backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)