### PR TITLE
config store: add optional default_team_id on org

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -199,6 +199,15 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 			fields["hostname_alias"] = *updates.HostnameAlias
 		}
 	}
+	// DefaultTeamID is *string with the same semantics: nil = preserve, "" =
+	// clear (NULL), "x" = set. Nullable/optional — NULL is always valid.
+	if updates.DefaultTeamID != nil {
+		if *updates.DefaultTeamID == "" {
+			fields["default_team_id"] = nil
+		} else {
+			fields["default_team_id"] = *updates.DefaultTeamID
+		}
+	}
 	result := s.db().Model(&configstore.Org{}).Where("name = ?", name).Updates(fields)
 	if result.Error != nil {
 		return nil, false, result.Error
@@ -596,6 +605,9 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
+	if _, ok := fields["default_team_id"]; ok {
+		merged.DefaultTeamID = updates.DefaultTeamID
+	}
 
 	// Audit detail: which fields changed and their old → new values, so the
 	// console shows "max_workers 4 → 10" instead of a bare "org.update". These
@@ -613,6 +625,7 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	addChange("default_worker_ttl", orgStr(existing.DefaultWorkerTTL), orgStr(merged.DefaultWorkerTTL))
 	addChange("default_worker_min_hot_idle", existing.DefaultWorkerMinHotIdle, merged.DefaultWorkerMinHotIdle)
 	addChange("hostname_alias", orgStrPtr(existing.HostnameAlias), orgStrPtr(merged.HostnameAlias))
+	addChange("default_team_id", orgStrPtr(existing.DefaultTeamID), orgStrPtr(merged.DefaultTeamID))
 	if len(changes) > 0 {
 		setAuditDetail(c, strings.Join(changes, ", "))
 	}

--- a/controlplane/configstore/migrations/000013_add_org_default_team_id.sql
+++ b/controlplane/configstore/migrations/000013_add_org_default_team_id.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+-- default_team_id links an org to its default PostHog team (a team id, stored
+-- as a string). It is a prerequisite for pull-based compute billing: usage
+-- buckets are keyed by team_id = the org's default team. NULLABLE and optional
+-- everywhere for now — existing orgs are backfilled separately and a follow-up
+-- makes it required. NULL is valid; no default; callers must tolerate empty.
+ALTER TABLE duckgres_orgs ADD COLUMN IF NOT EXISTS default_team_id VARCHAR(255);
+
+-- +goose Down
+
+ALTER TABLE duckgres_orgs DROP COLUMN IF EXISTS default_team_id;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -21,14 +21,21 @@ type Org struct {
 	// human editability) applied to connections that don't size themselves via
 	// the duckgres.worker_* startup options. Empty = unset. Versioned SQL
 	// migrations add these columns.
-	DefaultWorkerCPU        string            `gorm:"size:32" json:"default_worker_cpu"`
-	DefaultWorkerMemory     string            `gorm:"size:32" json:"default_worker_memory"`
-	DefaultWorkerTTL        string            `gorm:"size:32" json:"default_worker_ttl"`
-	DefaultWorkerMinHotIdle int               `gorm:"default:0" json:"default_worker_min_hot_idle"`
-	Users                   []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
-	Warehouse               *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
-	CreatedAt               time.Time         `json:"created_at"`
-	UpdatedAt               time.Time         `json:"updated_at"`
+	DefaultWorkerCPU        string `gorm:"size:32" json:"default_worker_cpu"`
+	DefaultWorkerMemory     string `gorm:"size:32" json:"default_worker_memory"`
+	DefaultWorkerTTL        string `gorm:"size:32" json:"default_worker_ttl"`
+	DefaultWorkerMinHotIdle int    `gorm:"default:0" json:"default_worker_min_hot_idle"`
+	// DefaultTeamID links the org to its default PostHog team (a team id, kept
+	// as a string). It is a prerequisite for pull-based compute billing —
+	// usage buckets are keyed by team_id = the org's default team. NULLABLE /
+	// optional everywhere: NULL means "unset" (existing orgs are backfilled
+	// separately, a follow-up makes it required). *string so the column is a
+	// nullable VARCHAR; callers must tolerate an empty/absent value.
+	DefaultTeamID *string           `gorm:"size:255" json:"default_team_id,omitempty"`
+	Users         []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
+	Warehouse     *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 func (Org) TableName() string { return "duckgres_orgs" }
@@ -540,6 +547,7 @@ type OrgConfig struct {
 	DefaultWorkerMemory     string            // org default worker profile: pod memory quantity ("" = unset)
 	DefaultWorkerTTL        string            // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
 	DefaultWorkerMinHotIdle int               // minimum default-profile hot-idle workers to retain for this org
+	DefaultTeamID           string            // org's default PostHog team id ("" = unset); prereq for pull-based compute billing
 	Users                   map[string]string // username -> password
 	Warehouse               *ManagedWarehouseConfig
 }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -202,6 +202,10 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 		if o.HostnameAlias != nil {
 			alias = *o.HostnameAlias
 		}
+		defaultTeamID := ""
+		if o.DefaultTeamID != nil {
+			defaultTeamID = *o.DefaultTeamID
+		}
 		oc := &OrgConfig{
 			Name:                    o.Name,
 			DatabaseName:            o.DatabaseName,
@@ -212,6 +216,7 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 			DefaultWorkerMemory:     o.DefaultWorkerMemory,
 			DefaultWorkerTTL:        o.DefaultWorkerTTL,
 			DefaultWorkerMinHotIdle: o.DefaultWorkerMinHotIdle,
+			DefaultTeamID:           defaultTeamID,
 			Users:                   make(map[string]string),
 			Warehouse:               copyManagedWarehouseConfig(o.Warehouse),
 		}
@@ -489,6 +494,24 @@ func (cs *ConfigStore) OrgDefaultWorkerMinHotIdle(orgID string) int {
 		return 0
 	}
 	return oc.DefaultWorkerMinHotIdle
+}
+
+// OrgDefaultTeamID returns the org's default PostHog team id from the current
+// snapshot, or "" when unset (including unknown orgs and a not-yet-loaded
+// snapshot). NULLABLE/optional: an empty return is a valid, non-error state —
+// callers must tolerate it and MUST NOT fail a connection or activation on it.
+// Prerequisite for pull-based compute billing (usage keyed by team id).
+func (cs *ConfigStore) OrgDefaultTeamID(orgID string) string {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.snapshot == nil {
+		return ""
+	}
+	oc, ok := cs.snapshot.Orgs[orgID]
+	if !ok {
+		return ""
+	}
+	return oc.DefaultTeamID
 }
 
 // ValidateOrgUser checks username/password scoped to a specific org.

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -135,7 +135,11 @@ type connectionDetails struct {
 }
 
 type provisionRequest struct {
-	DatabaseName  string                 `json:"database_name"`
+	DatabaseName string `json:"database_name"`
+	// DefaultTeamID optionally links the org to its default PostHog team id.
+	// Optional and non-breaking: absent/empty ⇒ the org's default_team_id is
+	// left NULL (no error). Prerequisite for pull-based compute billing.
+	DefaultTeamID string                 `json:"default_team_id,omitempty"`
 	MetadataStore *provisionMetadataReq  `json:"metadata_store,omitempty"`
 	DataStore     *provisionDataStoreReq `json:"data_store,omitempty"`
 	DuckLake      *provisionDuckLakeReq  `json:"ducklake,omitempty"`
@@ -335,10 +339,11 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 	// sub-step rolls the others back so the caller's retry sees the same
 	// starting state (no half-provisioned row blocking re-creation).
 	if err := h.store.Provision(ProvisionRequest{
-		OrgID:        orgID,
-		DatabaseName: req.DatabaseName,
-		Warehouse:    warehouse,
-		RootUserHash: hash,
+		OrgID:         orgID,
+		DatabaseName:  req.DatabaseName,
+		DefaultTeamID: req.DefaultTeamID,
+		Warehouse:     warehouse,
+		RootUserHash:  hash,
 	}); err != nil {
 		// The warehouse-already-exists conflict is the only error
 		// shape that maps to 409. Everything else (DB write failure,

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -112,6 +112,12 @@ func (s *fakeStore) Provision(req ProvisionRequest) error {
 	if _, ok := s.orgs[req.OrgID]; !ok {
 		s.orgs[req.OrgID] = &configstore.Org{Name: req.OrgID, DatabaseName: req.DatabaseName}
 	}
+	// default_team_id is optional/non-breaking: set it only when supplied,
+	// mirroring createPendingWarehouseTx (empty ⇒ leave NULL, never wipe).
+	if req.DefaultTeamID != "" {
+		teamID := req.DefaultTeamID
+		s.orgs[req.OrgID].DefaultTeamID = &teamID
+	}
 	clone := *req.Warehouse
 	clone.OrgID = req.OrgID
 	clone.State = configstore.ManagedWarehouseStatePending
@@ -220,6 +226,57 @@ func TestProvisionAutoCreatesOrg(t *testing.T) {
 	}
 	if store.warehouses["new-org"] == nil {
 		t.Fatal("expected warehouse to be created")
+	}
+}
+
+// TestProvisionPersistsDefaultTeamID checks the optional default_team_id in the
+// provision body is threaded through to the org record.
+func TestProvisionPersistsDefaultTeamID(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "team-db", "default_team_id": "12345", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/team-org/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	org, ok := store.orgs["team-org"]
+	if !ok {
+		t.Fatal("expected org to be auto-created")
+	}
+	if org.DefaultTeamID == nil {
+		t.Fatal("expected default_team_id to be set, got nil")
+	}
+	if *org.DefaultTeamID != "12345" {
+		t.Fatalf("default_team_id = %q, want %q", *org.DefaultTeamID, "12345")
+	}
+}
+
+// TestProvisionWithoutDefaultTeamIDLeavesNull checks default_team_id is optional:
+// an absent field leaves the org's default_team_id NULL with no error.
+func TestProvisionWithoutDefaultTeamIDLeavesNull(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "noteam-db", "metadata_store": {"type": "cnpg-shard"}, "iceberg": {"enabled": true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/noteam-org/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	org, ok := store.orgs["noteam-org"]
+	if !ok {
+		t.Fatal("expected org to be auto-created")
+	}
+	if org.DefaultTeamID != nil {
+		t.Fatalf("expected default_team_id to be nil (NULL), got %q", *org.DefaultTeamID)
 	}
 }
 

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -29,7 +29,11 @@ var ErrWarehouseNonTerminal = errors.New("warehouse already exists in non-termin
 type ProvisionRequest struct {
 	OrgID        string
 	DatabaseName string
-	Warehouse    *configstore.ManagedWarehouse
+	// DefaultTeamID optionally links the org to its default PostHog team id.
+	// Optional/non-breaking: empty ⇒ the org's default_team_id is left NULL
+	// (unset), never an error. Prerequisite for pull-based compute billing.
+	DefaultTeamID string
+	Warehouse     *configstore.ManagedWarehouse
 	// RootUserHash is the bcrypt hash of the freshly-generated root
 	// password. Plaintext stays in the handler (returned to the
 	// caller); only the hash is persisted, same as before.
@@ -72,7 +76,8 @@ func (s *gormStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWareh
 
 func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error {
 	return s.cs.DB().Transaction(func(tx *gorm.DB) error {
-		return createPendingWarehouseTx(tx, orgID, databaseName, warehouse)
+		// No default_team_id on this standalone path — leave the column as-is.
+		return createPendingWarehouseTx(tx, orgID, databaseName, "", warehouse)
 	})
 }
 
@@ -85,15 +90,29 @@ func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 // Returns a sentinel-comparable error string ("warehouse already
 // exists in non-terminal state") so HTTP handlers can map to 409
 // without an extra error type.
-func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error {
+func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName, defaultTeamID string, warehouse *configstore.ManagedWarehouse) error {
 	// Auto-create org if it doesn't exist (PostHog calls provision, duckgres creates everything)
 	org := configstore.Org{Name: orgID, DatabaseName: databaseName}
+	if defaultTeamID != "" {
+		// Set default_team_id on create. Optional/non-breaking: an empty value
+		// leaves the column NULL (unset), and re-provisioning without it does
+		// NOT wipe an existing value (see the explicit update below).
+		org.DefaultTeamID = &defaultTeamID
+	}
 	if err := tx.Where("name = ?", orgID).FirstOrCreate(&org).Error; err != nil {
 		return err
 	}
 	// Update database name if org already existed with a different one
 	if org.DatabaseName != databaseName {
 		if err := tx.Model(&org).Update("database_name", databaseName).Error; err != nil {
+			return err
+		}
+	}
+	// If a default_team_id was supplied, persist it even when the org already
+	// existed (FirstOrCreate only sets fields on insert). Only ever set, never
+	// cleared here, so an omitted value is a no-op rather than a wipe.
+	if defaultTeamID != "" {
+		if err := tx.Model(&org).Update("default_team_id", defaultTeamID).Error; err != nil {
 			return err
 		}
 	}
@@ -161,7 +180,7 @@ func (s *gormStore) Provision(req ProvisionRequest) error {
 	}
 	return s.cs.DB().Transaction(func(tx *gorm.DB) error {
 		// 1. Warehouse + Org (extracted helper).
-		if err := createPendingWarehouseTx(tx, req.OrgID, req.DatabaseName, req.Warehouse); err != nil {
+		if err := createPendingWarehouseTx(tx, req.OrgID, req.DatabaseName, req.DefaultTeamID, req.Warehouse); err != nil {
 			return err
 		}
 

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -30,8 +30,12 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 10)
 	requireGooseMigrationRecorded(t, db, 11)
 	requireGooseMigrationRecorded(t, db, 12)
-	requireGooseLatestVersion(t, db, 12)
+	requireGooseMigrationRecorded(t, db, 13)
+	requireGooseLatestVersion(t, db, 13)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
+
+	// Migration 000013 added the nullable per-org default_team_id column.
+	requireColumnPresent(t, db, "duckgres_orgs", "default_team_id")
 
 	// Migration 000007 added the compute-usage billing buffer + drain state.
 	requireTablePresent(t, db, "duckgres_org_compute_usage")
@@ -84,13 +88,15 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			ALTER TABLE duckgres_org_users DROP COLUMN disabled;
 			ALTER TABLE duckgres_orgs ADD COLUMN IF NOT EXISTS max_connections BIGINT DEFAULT 0;
 			ALTER TABLE duckgres_managed_warehouses ALTER COLUMN duckling_name DROP NOT NULL;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12);
+			ALTER TABLE duckgres_orgs DROP COLUMN default_team_id;
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
 	requireColumnAbsent(t, baselineDB, "duckgres_orgs", "max_vcpus")
 	requireColumnAbsent(t, baselineDB, "duckgres_org_users", "max_vcpus")
 	requireColumnAbsent(t, baselineDB, "duckgres_org_users", "disabled")
+	requireColumnAbsent(t, baselineDB, "duckgres_orgs", "default_team_id")
 	requireColumnPresent(t, baselineDB, "duckgres_orgs", "max_connections")
 	requireGooseLatestVersion(t, baselineDB, 8)
 
@@ -107,10 +113,12 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 10)
 	requireGooseMigrationRecorded(t, upgradedDB, 11)
 	requireGooseMigrationRecorded(t, upgradedDB, 12)
-	requireGooseLatestVersion(t, upgradedDB, 12)
+	requireGooseMigrationRecorded(t, upgradedDB, 13)
+	requireGooseLatestVersion(t, upgradedDB, 13)
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "disabled", "false")
+	requireColumnPresent(t, upgradedDB, "duckgres_orgs", "default_team_id")
 	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "max_connections")
 }
 

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -969,6 +969,50 @@ org_default_profile() { # org password catalog
   log "org default OK: audit shows org.update with field-change detail on $org"
 }
 
+# ---- org default_team_id (optional, non-breaking) ---------------------------
+# default_team_id links an org to its default PostHog team id (a nullable string
+# config-store column, prereq for pull-based compute billing where usage buckets
+# are keyed by team_id). It is OPTIONAL everywhere: NULL is a valid state.
+# Asserts both halves of the contract on real orgs against the real config store:
+#   1. Set path: the CNPG org was provisioned WITH default_team_id in its body
+#      (see CNPG_BODY); GET /orgs/:id must round-trip exactly that value.
+#   2. Unset path: the EXT org was provisioned WITHOUT it; GET /orgs/:id must
+#      report null (not an error, not a stray value) — proving NULL is tolerated.
+#   3. Mutate path: PUT /orgs/:id can set and clear it (""=NULL) on the EXT org,
+#      round-tripping on GET, so the admin edit path is covered too.
+# get_org_default_team_id prints the raw JSON value ("null" when NULL) so the
+# assertions can distinguish an unset column from an empty string.
+get_org_default_team_id() { # org -> prints default_team_id (jq raw; "null" when unset)
+  curl -fsS -H "$H" "$API/api/v1/orgs/$1" | jq -r '.default_team_id'
+}
+default_team_id_optional() { # cnpg_org ext_org
+  cnpg_org="$1"; ext_org="$2"
+  log "default_team_id: set-at-provision round-trip on $cnpg_org, NULL-tolerated on $ext_org"
+
+  # 1. Set path: CNPG org provisioned WITH default_team_id must read it back.
+  got="$(get_org_default_team_id "$cnpg_org")"
+  [ "$got" = "$CNPG_DEFAULT_TEAM_ID" ] \
+    || fail "default_team_id: GET /orgs/$cnpg_org = '$got' want '$CNPG_DEFAULT_TEAM_ID' (provision default_team_id did not persist)"
+  log "default_team_id OK: $cnpg_org round-tripped '$got' from provision"
+
+  # 2. Unset path: EXT org provisioned WITHOUT it must read back null (no error).
+  got="$(get_org_default_team_id "$ext_org")"
+  [ "$got" = "null" ] \
+    || fail "default_team_id: GET /orgs/$ext_org = '$got' want 'null' (unset must be NULL, not an error/value)"
+  log "default_team_id OK: $ext_org reports NULL (optional/non-breaking honored)"
+
+  # 3. Mutate path: PUT can set then clear ("" -> NULL) on the ext org.
+  code="$(put_org "$ext_org" '{"default_team_id":"424242"}')"
+  [ "$code" = "200" ] || fail "default_team_id: PUT set -> HTTP $code: $(cat /tmp/put_org_out)"
+  got="$(get_org_default_team_id "$ext_org")"
+  [ "$got" = "424242" ] || fail "default_team_id: after PUT set, GET = '$got' want '424242'"
+  code="$(put_org "$ext_org" '{"default_team_id":""}')"
+  [ "$code" = "200" ] || fail "default_team_id: PUT clear -> HTTP $code: $(cat /tmp/put_org_out)"
+  got="$(get_org_default_team_id "$ext_org")"
+  [ "$got" = "null" ] || fail "default_team_id: after PUT clear, GET = '$got' want 'null' (empty must clear to NULL)"
+  log "default_team_id OK: PUT set/clear round-trips on $ext_org (NULL restored)"
+}
+
 # ---- user persistent secrets ------------------------------------------------
 # CREATE PERSISTENT SECRET must survive across sessions: worker pods are
 # ephemeral, so the CP intercepts the statement, stores it encrypted in the
@@ -1961,7 +2005,13 @@ lifecycle_teardown_cnpg() { # org
 }
 
 # ---- cnpg duckling: cnpg-shard metadata + DuckLake ------------------------
+# Carries an optional default_team_id at provision time (prereq for pull-based
+# compute billing: usage buckets keyed by team_id = the org's default team). The
+# EXT org below deliberately omits it, so default_team_id_optional asserts both
+# the set path (round-trips) and the unset path (NULL, no error).
+CNPG_DEFAULT_TEAM_ID='90210'
 CNPG_BODY='{"database_name":"'"$CNPG"'","metadata_store":{"type":"cnpg-shard"},
+  "default_team_id":"'"$CNPG_DEFAULT_TEAM_ID"'",
   "data_store":{"type":"s3bucket"},"ducklake":{"enabled":true}}'
 
 # ---- ext duckling: external RDS metadata + DuckLake -----------------------
@@ -2210,6 +2260,10 @@ lane_ext() { # external-RDS metadata backend + org default profile
   # Org default profile on ext: no client-sized assertions run on this org, so
   # the 2-CPU shape is unambiguously the org default's.
   org_default_profile "$EXT" "$ext_pw" ducklake
+  # default_team_id contract: CNPG provisioned WITH one (round-trips), EXT
+  # WITHOUT one (NULL, no error) + PUT set/clear on EXT. Runs here because both
+  # orgs are provisioned by now; it only touches the admin API, no worker/DB.
+  default_team_id_optional "$CNPG" "$EXT"
 }
 
 main() {


### PR DESCRIPTION
## What

Adds a **nullable, optional** `default_team_id` on the org in the config store, wired through provisioning + admin and readable per-org. Prerequisite for pull-based compute billing (buckets keyed by team_id = the org default team). No metering/billing logic here — just the field + plumbing.

## Non-mandatory by design

NULL is valid everywhere; nothing fails when it is absent. Existing orgs get backfilled separately, and a **follow-up PR makes it required** once backfilled.

## Changes

- **Migration `000013_add_org_default_team_id.sql`** — `duckgres_orgs.default_team_id VARCHAR(255)` nullable (latest was 000012).
- **`configstore/models.go`** — `Org.DefaultTeamID *string`, `OrgConfig.DefaultTeamID string`.
- **`configstore/store.go`** — snapshot load + accessor `OrgDefaultTeamID(orgID) string` (empty for unknown/unset).
- **`provisioning/`** — provision body accepts optional `default_team_id` (set-only, never wiped on re-provision; absent → NULL).
- **`admin/`** — `GET/PUT /orgs/:id` expose + set/clear it (same `*string` semantics as `hostname_alias`, with audit entry).
- **Tests** — provisioning unit tests (with → read back; without → NULL); migration test bumped 12→13; `harness.sh` `default_team_id_optional` assertion (cnpg + ext, set/clear, NULL-tolerated).

## Checks

`go build` (both tags), `go vet`, `go test` (touched pkgs) pass; golangci-lint (v2.11.4) **0 issues**. Postgres/EKS-backed tests run in CI/e2e, not the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)