### PR TITLE
e2e: fix ready-wait flake — 600s too tight for shared-shard credential propagation

### DIFF
--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -81,6 +81,32 @@ EXT="ci-pr-${PR_NUMBER}-ext"
 RES1="ci-pr-${PR_NUMBER}-res1"
 RES2="ci-pr-${PR_NUMBER}-res2"
 
+# How long each org may take to reach warehouse state=ready (wait_state below).
+# All four orgs are cnpg-shard/DuckLake ducklings, and "ready" is a PROVISIONING
+# gate, not a worker-spawn one: the CP provisioner only flips ready after the
+# Crossplane Duckling is Ready (bucket + shard role/DB + IAM + secrets), the
+# per-org Lakekeeper catalog has bootstrapped, AND an end-to-end SELECT 1 probe
+# against the metadata store actually connects (controller.go reconcileProvisioning).
+#
+# 600s was too tight for that last probe. All four ducklings share ONE cnpg
+# shard cluster (shard-001-pooler), and after Crossplane reports the role/DB
+# Available there is a credential-propagation tail before the freshly-set role
+# password is accepted at the pooler — the probe fails "SASL authentication
+# failed (SQLSTATE 08P01)" and the org correctly stays in `provisioning` while
+# the reconcile loop retries every 10s. Observed on a single org (e.g. res1)
+# while its three siblings went ready inside 600s: the probe kept failing SASL
+# for ~9 min, right up to the old 600s deadline, then the harness gave up
+# (last=provisioning) even though the CP had NOT failed it — the CP's own
+# provisioning hard-timeout is 30 min (controller.go), so we were failing the
+# run well inside the window the system considers still-healthy.
+#
+# Give the shared-shard propagation transient room to self-heal while staying
+# safely under the CP's 30-min terminal timeout. Env-overridable if the cluster
+# drifts. This is a legitimately-slow provision, not a hang — a real stuck
+# warehouse still trips `failed` (wait_state) or the 30-min CP timeout long
+# before this budget.
+READY_TIMEOUT="${READY_TIMEOUT:-1200}"
+
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
 # (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.4, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry).
@@ -2247,10 +2273,10 @@ main() {
   for v in "$cnpg_pw" "$ext_pw" "$res1_pw" "$res2_pw"; do
     case "$v" in ""|null) fail "a provision call returned no password" ;; esac
   done
-  run_lane ready_cnpg wait_state "$CNPG" ready 600
-  run_lane ready_ext  wait_state "$EXT"  ready 600
-  run_lane ready_res1 wait_state "$RES1" ready 600
-  run_lane ready_res2 wait_state "$RES2" ready 600
+  run_lane ready_cnpg wait_state "$CNPG" ready "$READY_TIMEOUT"
+  run_lane ready_ext  wait_state "$EXT"  ready "$READY_TIMEOUT"
+  run_lane ready_res1 wait_state "$RES1" ready "$READY_TIMEOUT"
+  run_lane ready_res2 wait_state "$RES2" ready "$READY_TIMEOUT"
   join_lanes ready_cnpg ready_ext ready_res1 ready_res2
 
   # Settle: let the CP's config-store poll pick up the provisioned orgs/users

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -286,7 +286,17 @@ YAML
   # --for=condition=complete` alone hangs the full timeout when the Job
   # FAILED (the condition it waits for never becomes true), which is what
   # made a one-second harness failure stall the step for 20 minutes.
-  deadline=$(( $(date +%s) + 1200 ))
+  #
+  # This watch window must exceed the harness's total wall time: the ready-wait
+  # (harness.sh READY_TIMEOUT, up to 1200s while a cnpg-shard org's metadata
+  # probe waits out the shared-shard credential-propagation transient) PLUS the
+  # assertion lanes that run after. 1200s used to be the whole budget, which
+  # meant a slow provision left no room for the lanes and this loop returned a
+  # false "did not reach a terminal state" even though the harness would pass.
+  # The Job has no activeDeadlineSeconds, so this loop is the only cap; size it
+  # generously above READY_TIMEOUT and stay under the CP's 30-min provisioning
+  # hard-timeout. Env-overridable to keep it in lockstep with READY_TIMEOUT.
+  deadline=$(( $(date +%s) + ${HARNESS_WATCH_TIMEOUT:-1800} ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     if [ "$("${KUBECTL[@]}" -n "$NS" get job duckgres-harness -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)" = "True" ]; then
       echo "harness Job complete."; return 0


### PR DESCRIPTION
## The flake

The per-PR e2e job (`tests/e2e-mw-dev/`, in-cluster Job against mw-dev) intermittently fails during the readiness wait, e.g.:

```
[ready_res2] FAIL: ci-pr-<n>-res2 did not reach ready within 600s (last=provisioning)
FAIL: lane ready_res2 rc=1
```

It has hit unrelated PRs (their own changes had nothing to do with provisioning). A "res" warehouse doesn't reach `ready` within the hard-coded 600s wait; `last=provisioning` means it was still provisioning when the wait expired.

## Root cause (not what it looks like)

It is **not** slow node/image/Karpenter provisioning. Warehouse `ready` is a **provisioning** gate, not a worker-spawn gate — worker pods spawn lazily on first client connection, *after* the harness sees `ready`. Reaching `ready` requires the Crossplane Duckling to be Ready (bucket + shard role/DB + IAM + secrets), the per-org Lakekeeper catalog to bootstrap, and finally an **end-to-end `SELECT 1` probe** against the metadata store to actually connect (`controlplane/provisioner/controller.go` `reconcileProvisioning`).

All four e2e orgs (`cnpg`, `ext`, `res1`, `res2`) are cnpg-shard/DuckLake ducklings that share **one** cnpg shard cluster (a single shard pooler). CP logs from a failing run show, for exactly one org, the probe failing:

```
Infrastructure provisioned but end-to-end probe still failing — staying in provisioning.
error="SELECT 1: ... failed SASL auth: FATAL: SASL authentication failed (SQLSTATE 08P01)"
```

repeated ~56 times over **~9 minutes** — a credential-propagation tail where the freshly-set shard role password isn't yet accepted at the shared pooler. Its three sibling orgs went ready inside 600s; this one didn't. The org **correctly** stayed in `provisioning` and the CP kept retrying every 10s. The CP's own provisioning hard-timeout is **30 minutes** — so the harness's tighter 600s budget was failing the run well inside the window the system itself considers healthy. This is a legitimately slow (but self-healing) provision, not a hang.

## The fix

- Raise the ready-wait to a named, env-overridable `READY_TIMEOUT` (1200s) applied to all four ready lanes — the transient isn't res-specific in mechanism (any of the three cnpg-shard orgs can draw the slow shard-credential tail; it just happened to land on a res org). Stays comfortably under the CP's 30-min terminal timeout.
- Raise `run.sh`'s harness-Job watch window in lockstep (`HARNESS_WATCH_TIMEOUT`, 1800s). That watch loop was `1200s` and is the only cap on total harness wall time (the Job has no `activeDeadlineSeconds`); a slow provision consuming the ready budget would otherwise leave no room for the assertion lanes and return a false "did not reach a terminal state".

Both are heavily commented at the change site explaining exactly why 600s wasn't enough. A genuinely stuck warehouse still trips `failed` (via `wait_state`) or the CP's 30-min timeout long before these budgets.

`bash -n` clean on both scripts. No behavior change to any assertion — only the provisioning-wait headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)