### PR TITLE
admin/ui: unify header status into one stat row + honest reachability label

### DIFF
--- a/controlplane/admin/ui/src/components/Topbar.tsx
+++ b/controlplane/admin/ui/src/components/Topbar.tsx
@@ -6,20 +6,11 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { getClusterCounts, subscribeClusterCounts } from "@/lib/clusterCounts";
 
-function HealthDot({ ok, label, detail }: { ok: boolean; label: string; detail?: string }) {
-  return (
-    <div className="flex items-center gap-1.5" title={detail}>
-      <Circle
-        className={cn("h-2.5 w-2.5", ok ? "fill-success text-success" : "fill-destructive text-destructive")}
-      />
-      <span className="text-xs text-muted-foreground">{label}</span>
-    </div>
-  );
-}
-
-// One node/worker/placeholder/pending counter, shown only on the Nodes view
-// (the peepernetes view pushes live counts into the clusterCounts store).
-function CountStat({ n, label, detail, muted }: { n: number; label: string; detail?: string; muted?: boolean }) {
+// One counter in the unified header stat row: a value + a small label, styled
+// identically for every metric (CP replicas, nodes, workers, …) so they read as
+// one design instead of a mix of health pills and counters. `muted` dims a zero
+// value for metrics where 0 is the boring/expected state (placeholders/pending).
+function Stat({ n, label, detail, muted }: { n: number; label: string; detail?: string; muted?: boolean }) {
   return (
     <div className="flex items-baseline gap-1" title={detail}>
       <span className={cn("font-mono text-sm tabular-nums", muted && n === 0 ? "text-muted-foreground" : "text-foreground")}>
@@ -30,17 +21,16 @@ function CountStat({ n, label, detail, muted }: { n: number; label: string; deta
   );
 }
 
-function ClusterCounters() {
-  const counts = useSyncExternalStore(subscribeClusterCounts, getClusterCounts);
-  if (!counts) return null;
-  return (
-    <div className="flex items-center gap-4 border-l border-border pl-4">
-      <CountStat n={counts.nodes} label="nodes" />
-      <CountStat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
-      <CountStat n={counts.placeholders} label="placeholders" detail={counts.placeholderReq || undefined} muted />
-      <CountStat n={counts.pending} label="pending" muted />
-    </div>
-  );
+// Middot divider between stats.
+function Dot() {
+  return <span className="text-xs text-muted-foreground/40">·</span>;
+}
+
+// Count of live CP replicas: prefer rows explicitly marked "active", falling
+// back to the total row count if none carry a state (older cp_instances rows).
+function activeOrTotal(rows: { state?: string }[]): number {
+  const active = rows.filter((r) => (r.state ?? "").toLowerCase() === "active").length;
+  return active || rows.length;
 }
 
 export function Topbar() {
@@ -49,27 +39,55 @@ export function Topbar() {
   // cp-instances is a runtime model in the config-store explorer; active rows
   // = live control-plane replicas. Tolerant of the endpoint being absent.
   const cps = useModel("cp-instances");
+  // Live node/worker/placeholder/pending counts, pushed by the Nodes view while
+  // it's mounted (null elsewhere).
+  const counts = useSyncExternalStore(subscribeClusterCounts, getClusterCounts);
 
   const cpRows = (cps.data?.rows ?? []) as { state?: string }[];
-  const activeCPs = cpRows.filter((r) => (r.state ?? "").toLowerCase() === "active").length;
-  const clusterOk = status.isSuccess && !status.isError;
+  const cpCount = cps.isSuccess ? activeOrTotal(cpRows) : null;
+  // "Reachable" reflects only that the admin API answered GET /status — it is NOT
+  // a real cluster-health signal (the query even tolerates a 404 as success). So
+  // the dot means "the admin API is responding", nothing more; the tooltip spells
+  // out the totals it returned.
+  const reachable = status.isSuccess && !status.isError;
+  const orgs = status.data?.total_orgs ?? 0;
+  const workers = status.data?.total_workers ?? 0;
+  const sessions = status.data?.total_sessions ?? 0;
 
   return (
     <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card/40 px-5">
-      <div className="flex items-center gap-5">
-        <HealthDot
-          ok={clusterOk}
-          label={clusterOk ? "Cluster healthy" : "Cluster unreachable"}
-          detail={`${status.data?.total_orgs ?? 0} orgs · ${status.data?.total_workers ?? 0} workers`}
-        />
-        {cps.isSuccess && (
-          <HealthDot
-            ok={activeCPs > 0}
-            label={`${activeCPs || cpRows.length} CP replica${(activeCPs || cpRows.length) === 1 ? "" : "s"}`}
-            detail="control-plane instances (cp_instances)"
+      <div className="flex items-center gap-3">
+        <div
+          className="flex items-center gap-1.5"
+          title={
+            reachable
+              ? `admin API reachable — ${orgs} orgs · ${workers} workers · ${sessions} sessions`
+              : "admin API not reachable (GET /status failed)"
+          }
+        >
+          <Circle
+            className={cn("h-2.5 w-2.5", reachable ? "fill-success text-success" : "fill-destructive text-destructive")}
           />
+          <span className="text-xs text-muted-foreground">{reachable ? "Connected" : "Unreachable"}</span>
+        </div>
+
+        {(cpCount !== null || counts) && (
+          <div className="flex items-center gap-2.5 border-l border-border pl-3">
+            {cpCount !== null && <Stat n={cpCount} label="CP" detail="live control-plane replicas (cp_instances)" />}
+            {counts && (
+              <>
+                {cpCount !== null && <Dot />}
+                <Stat n={counts.nodes} label="nodes" />
+                <Dot />
+                <Stat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
+                <Dot />
+                <Stat n={counts.placeholders} label="placeholders" detail={counts.placeholderReq || undefined} muted />
+                <Dot />
+                <Stat n={counts.pending} label="pending" muted />
+              </>
+            )}
+          </div>
         )}
-        <ClusterCounters />
       </div>
 
       <div className="flex items-center gap-3">


### PR DESCRIPTION
Two things, both Topbar-only.

## 1. One unified design
The header mixed "health pills" (Cluster healthy, N CP replicas) with the separate node/worker/placeholder/pending counters — three different treatments. Merged into a single strip: one reachability dot, then a consistent `N CP · N nodes · N workers · N placeholders · N pending` row (same `Stat` component + middot dividers). CP replicas always show; the node metrics appear only while the Nodes view is mounted (pushed via `clusterCounts`).

## 2. "Cluster healthy" was misleading
It only ever meant **the admin API answered `GET /status`** — `clusterOk = status.isSuccess`, and the query is even `tolerate404`'d, so a 404 counts as "healthy". It reflects nothing about actual cluster health, just admin-API reachability. Relabeled to **Connected / Unreachable**, with a tooltip that spells out what it actually reflects (orgs · workers · sessions the API returned).

Frontend-only; UI typecheck / lint / vitest / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)