### PR TITLE
admin/ui: flip nodes↔CP, drop Nodes-view LIVE indicator, pulse the Connected dot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,11 +394,13 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   placeholder/system-pod classification, Karpenter empty-node reclaim countdown,
   draining-duration on nodes (deletion-timestamp or client-tracked first-seen)
   and terminating-duration on pods, each pod's running image, unscheduled tray,
-  and a synthesized event ticker. Its header carries only the filters + live
-  indicator; the nodes/workers/placeholders/pending counters are lifted into the
-  shared admin **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts`
-  → `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
-  pushes `null` on unmount so they only show on this page). It's imperative DOM (mounted
+  and a synthesized event ticker. Its header carries only the filters; the
+  nodes/workers/placeholders/pending counters are lifted into the shared admin
+  **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts` →
+  `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
+  pushes `null` on unmount so they only show on this page). The view has no
+  separate live indicator — the Topbar's "Connected" dot (admin-API reachability)
+  is the single green pulsing live signal. It's imperative DOM (mounted
   by the React page into a `.peeper` root, scoped CSS + `pn-`-prefixed keyframes)
   and does NOT use native K8s watch — the browser can't reach the API, so it
   POLLS four **read-only** projected endpoints (`server/`-free; `cluster.go`):

--- a/controlplane/admin/ui/src/components/Topbar.tsx
+++ b/controlplane/admin/ui/src/components/Topbar.tsx
@@ -66,18 +66,25 @@ export function Topbar() {
           }
         >
           <Circle
-            className={cn("h-2.5 w-2.5", reachable ? "fill-success text-success" : "fill-destructive text-destructive")}
+            className={cn(
+              "h-2.5 w-2.5",
+              // Connected is the live pulse now (moved off the Nodes view's old
+              // in-view "LIVE" indicator): green, pulsing, with a soft glow.
+              reachable
+                ? "fill-success text-success animate-pulse [filter:drop-shadow(0_0_5px_currentColor)]"
+                : "fill-destructive text-destructive",
+            )}
           />
           <span className="text-xs text-muted-foreground">{reachable ? "Connected" : "Unreachable"}</span>
         </div>
 
         {(cpCount !== null || counts) && (
           <div className="flex items-center gap-2.5 border-l border-border pl-3">
+            {counts && <Stat n={counts.nodes} label="nodes" />}
+            {counts && cpCount !== null && <Dot />}
             {cpCount !== null && <Stat n={cpCount} label="CP" detail="live control-plane replicas (cp_instances)" />}
             {counts && (
               <>
-                {cpCount !== null && <Dot />}
-                <Stat n={counts.nodes} label="nodes" />
                 <Dot />
                 <Stat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
                 <Dot />

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.css
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.css
@@ -88,11 +88,6 @@
 .peeper .menu input { accent-color: var(--worker); cursor: pointer; }
 .peeper .menu .sep { border-top: 1px solid var(--line); margin: 5px 0; }
 
-.peeper #conn { display: flex; align-items: center; gap: 8px; font-size: 11px; letter-spacing: .15em; align-self: center; }
-.peeper #conn .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--bad); transition: background .3s; }
-.peeper #conn.live .dot { background: var(--duckgres); box-shadow: 0 0 10px var(--duckgres); animation: pn-blink 2.4s infinite; }
-.peeper #conn.live span { color: var(--duckgres); }
-.peeper #conn span { color: var(--bad); }
 @keyframes pn-blink { 50% { opacity: .55; } }
 
 /* ── main ───────────────────────────────────────── */

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
@@ -54,7 +54,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
         </select>
       </div>
     </div>
-    <div id="conn"><div class="dot"></div><span>CONNECTING</span></div>
   </div>
 
   <div class="main">
@@ -87,7 +86,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   const nodes = new Map<string, any>();
   const pods = new Map<string, any>();
   let dirty = false;
-  const pollOk = { nodes: false, pods: false };
 
   // ── k8s quantity parsing ───────────────────────────────
   function parseCpu(q: string): number {
@@ -192,13 +190,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     btn.classList.toggle("active", poolSel !== "all");
   }
 
-  // ── connection indicator ───────────────────────────────
-  function setConn(): void {
-    const ok = pollOk.nodes && pollOk.pods;
-    $("#conn").classList.toggle("live", ok);
-    $("#conn span").textContent = ok ? "LIVE" : "RECONNECTING";
-  }
-
   // ── snapshot polling: fetch a projected list, diff vs the store to emit
   //    ADDED/DELETED for the ticker, and replace the store. The FIRST poll of
   //    each stream seeds silently (matches the original watch, whose initial
@@ -207,7 +198,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     path: string,
     store: Map<string, any>,
     onEvent: (type: string, o: any) => void,
-    connKey: "nodes" | "pods" | null,
     intervalMs: number,
   ): void {
     let firstLoad = true;
@@ -236,10 +226,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
         }
         firstLoad = false;
         dirty = true;
-        if (connKey) { pollOk[connKey] = true; setConn(); }
-      } catch {
-        if (connKey) { pollOk[connKey] = false; setConn(); }
-      } finally {
+      } catch { /* transient fetch error — retry on the next tick */ } finally {
         const i = controllers.indexOf(ctrl);
         if (i >= 0) controllers.splice(i, 1);
       }
@@ -819,9 +806,9 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   $("#pool-menu").addEventListener("change", poolMenuFn);
 
   // ── start the polling streams ──────────────────────────
-  startPoll(`${API}/nodes`, nodes, onNodeEvent, "nodes", 2000);
-  startPoll(`${API}/pods`, pods, onPodEvent, "pods", 2000);
-  startPoll(`${API}/events`, evStore, onK8sEvent, null, 4000);
+  startPoll(`${API}/nodes`, nodes, onNodeEvent, 2000);
+  startPoll(`${API}/pods`, pods, onPodEvent, 2000);
+  startPoll(`${API}/events`, evStore, onK8sEvent, 4000);
 
   // ── cleanup ────────────────────────────────────────────
   return () => {


### PR DESCRIPTION
Topbar/Nodes-view polish. Frontend-only.

- **Flip nodes ↔ CP** in the header stat row: `N nodes · N CP · N workers · N placeholders · N pending` (nodes now leads).
- **Remove the Nodes view's own LIVE indicator** (and its poll-status plumbing) — it duplicated a "connected" signal.
- **The "Connected" dot is now the single live pulse**: green, `animate-pulse`, with a soft glow; red + static when unreachable.

UI typecheck / lint / vitest / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)