### PR TITLE
admin/ui: editable default_team_id on the org page

### DIFF
--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -39,6 +39,7 @@ interface FormState {
   default_worker_ttl: string;
   default_worker_min_hot_idle: string;
   hostname_alias: string;
+  default_team_id: string;
 }
 
 function orgToForm(o: {
@@ -49,6 +50,7 @@ function orgToForm(o: {
   default_worker_ttl: string;
   default_worker_min_hot_idle: number;
   hostname_alias: string | null;
+  default_team_id: string | null;
 }): FormState {
   return {
     max_workers: String(o.max_workers),
@@ -58,6 +60,7 @@ function orgToForm(o: {
     default_worker_ttl: o.default_worker_ttl,
     default_worker_min_hot_idle: String(o.default_worker_min_hot_idle),
     hostname_alias: o.hostname_alias ?? "",
+    default_team_id: o.default_team_id ?? "",
   };
 }
 
@@ -108,6 +111,7 @@ export function OrgDetail() {
       default_worker_ttl: form.default_worker_ttl,
       default_worker_min_hot_idle: Number(form.default_worker_min_hot_idle) || 0,
       hostname_alias: form.hostname_alias === "" ? "" : form.hostname_alias,
+      default_team_id: form.default_team_id === "" ? "" : form.default_team_id,
     };
     try {
       await update.mutateAsync(body);
@@ -195,6 +199,13 @@ export function OrgDetail() {
                   value={form.hostname_alias}
                   placeholder="single DNS label, e.g. acme"
                   onChange={(e) => set("hostname_alias", e.target.value)}
+                />
+              </Field>
+              <Field label="Default team id (empty clears)">
+                <Input
+                  value={form.default_team_id}
+                  placeholder="PostHog team id, e.g. 12345"
+                  onChange={(e) => set("default_team_id", e.target.value)}
                 />
               </Field>
 

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -52,6 +52,14 @@ export function Orgs() {
         },
       },
       {
+        accessorKey: "default_team_id",
+        header: "Default team",
+        cell: ({ getValue }) => {
+          const v = getValue() as string | null;
+          return v ? <span className="font-mono text-xs">{v}</span> : <span className="text-muted-foreground">—</span>;
+        },
+      },
+      {
         accessorKey: "max_workers",
         header: "Max workers",
         cell: ({ getValue }) => {

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -44,6 +44,7 @@ export interface Org {
   name: string;
   database_name: string;
   hostname_alias: string | null;
+  default_team_id: string | null;
   max_workers: number;
   max_vcpus: number;
   default_worker_cpu: string;
@@ -65,6 +66,7 @@ export interface OrgUpdate {
   default_worker_ttl?: string;
   default_worker_min_hot_idle?: number;
   hostname_alias?: string | null;
+  default_team_id?: string | null;
 }
 
 // ---- Users (confirmed) ----


### PR DESCRIPTION
## What

Makes `default_team_id` editable in the **admin web UI** (previously only the JSON API supported it). Mirrors the existing `hostname_alias` field.

- `OrgDetail.tsx` — a **Default team id** input (empty clears; same `*string` semantics as hostname_alias), wired to the existing `PUT /orgs/:id`.
- `Orgs.tsx` — a **Default team** column in the orgs table.
- `types/api.ts` — `default_team_id` on `Org` + `OrgUpdate`.

## Depends on

#867 (backend `default_team_id` on the org + `GET`/`PUT` support). The UI calls the API that PR adds — merge #867 first (or together).

## Checks

`tsc -b --noEmit` (typecheck) and `eslint` on the changed files pass. `ui/dist` is gitignored (built in CI), so only source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)