### PR TITLE
admin/nodes: count real worker pods (not all app pods) + restore CPU/Gi totals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,8 +395,12 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   draining-duration on nodes (deletion-timestamp or client-tracked first-seen)
   and terminating-duration on pods, each pod's running image, unscheduled tray,
   and a synthesized event ticker. Its header carries only the filters; the
-  nodes/workers/placeholders/pending counters are lifted into the shared admin
-  **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts` →
+  counters — nodes · CP · **workers · CPU · Gi** · placeholders · pending — are
+  lifted into the shared admin **Topbar**. "workers" counts only real duckgres
+  worker pods (label `app=duckgres-worker`, stamped in `k8s_pool_spawn.go`), NOT
+  every app pod — so the number matches the worker chips in the view and the CP's
+  own worker accounting; CPU/Gi are those workers' summed requests. Wiring is a
+  small external store (`ui/src/lib/clusterCounts.ts` →
   `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
   pushes `null` on unmount so they only show on this page). The view has no
   separate live indicator — the Topbar's "Connected" dot (admin-API reachability)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,11 +394,13 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   placeholder/system-pod classification, Karpenter empty-node reclaim countdown,
   draining-duration on nodes (deletion-timestamp or client-tracked first-seen)
   and terminating-duration on pods, each pod's running image, unscheduled tray,
-  and a synthesized event ticker. Its header carries only the filters + live
-  indicator; the nodes/workers/placeholders/pending counters are lifted into the
-  shared admin **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts`
-  → `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
-  pushes `null` on unmount so they only show on this page). It's imperative DOM (mounted
+  and a synthesized event ticker. Its header carries only the filters; the
+  nodes/workers/placeholders/pending counters are lifted into the shared admin
+  **Topbar** via a small external store (`ui/src/lib/clusterCounts.ts` →
+  `Topbar.tsx` `useSyncExternalStore`; the view pushes counts each repaint and
+  pushes `null` on unmount so they only show on this page). The view has no
+  separate live indicator — the Topbar's "Connected" dot (admin-API reachability)
+  is the single green pulsing live signal. It's imperative DOM (mounted
   by the React page into a `.peeper` root, scoped CSS + `pn-`-prefixed keyframes)
   and does NOT use native K8s watch — the browser can't reach the API, so it
   POLLS four **read-only** projected endpoints (`server/`-free; `cluster.go`):

--- a/controlplane/admin/ui/src/components/Topbar.tsx
+++ b/controlplane/admin/ui/src/components/Topbar.tsx
@@ -66,18 +66,25 @@ export function Topbar() {
           }
         >
           <Circle
-            className={cn("h-2.5 w-2.5", reachable ? "fill-success text-success" : "fill-destructive text-destructive")}
+            className={cn(
+              "h-2.5 w-2.5",
+              // Connected is the live pulse now (moved off the Nodes view's old
+              // in-view "LIVE" indicator): green, pulsing, with a soft glow.
+              reachable
+                ? "fill-success text-success animate-pulse [filter:drop-shadow(0_0_5px_currentColor)]"
+                : "fill-destructive text-destructive",
+            )}
           />
           <span className="text-xs text-muted-foreground">{reachable ? "Connected" : "Unreachable"}</span>
         </div>
 
         {(cpCount !== null || counts) && (
           <div className="flex items-center gap-2.5 border-l border-border pl-3">
+            {counts && <Stat n={counts.nodes} label="nodes" />}
+            {counts && cpCount !== null && <Dot />}
             {cpCount !== null && <Stat n={cpCount} label="CP" detail="live control-plane replicas (cp_instances)" />}
             {counts && (
               <>
-                {cpCount !== null && <Dot />}
-                <Stat n={counts.nodes} label="nodes" />
                 <Dot />
                 <Stat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
                 <Dot />

--- a/controlplane/admin/ui/src/components/Topbar.tsx
+++ b/controlplane/admin/ui/src/components/Topbar.tsx
@@ -86,9 +86,13 @@ export function Topbar() {
             {counts && (
               <>
                 <Dot />
-                <Stat n={counts.workers} label="workers" detail={counts.workerReq || undefined} />
+                <Stat n={counts.workers} label="workers" detail={counts.workerDetail || "no worker pods running"} />
                 <Dot />
-                <Stat n={counts.placeholders} label="placeholders" detail={counts.placeholderReq || undefined} muted />
+                <Stat n={counts.cpuCores} label="CPU" detail={counts.workerDetail || undefined} muted />
+                <Dot />
+                <Stat n={counts.memGi} label="Gi" detail={counts.workerDetail || undefined} muted />
+                <Dot />
+                <Stat n={counts.placeholders} label="placeholders" detail={counts.placeholderDetail || undefined} muted />
                 <Dot />
                 <Stat n={counts.pending} label="pending" muted />
               </>

--- a/controlplane/admin/ui/src/lib/clusterCounts.ts
+++ b/controlplane/admin/ui/src/lib/clusterCounts.ts
@@ -8,11 +8,16 @@
 
 export interface ClusterCounts {
   nodes: number;
-  workers: number; // non-placeholder, non-succeeded pods (the view calls these "workers")
+  // Real duckgres worker pods only (label app=duckgres-worker) — NOT every app
+  // pod. This is the number that lines up with the worker chips in the view and
+  // with the control plane's worker accounting.
+  workers: number;
+  cpuCores: number; // sum of worker-pod CPU requests, in cores
+  memGi: number; // sum of worker-pod memory requests, in GiB
   placeholders: number;
   pending: number;
-  workerReq: string; // "12 CPU · 34 Gi" totals, "" when zero — shown as a tooltip
-  placeholderReq: string;
+  workerDetail: string; // "12 CPU · 34 Gi across N pods", "" when none — tooltip
+  placeholderDetail: string;
 }
 
 let current: ClusterCounts | null = null;

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.css
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.css
@@ -88,11 +88,6 @@
 .peeper .menu input { accent-color: var(--worker); cursor: pointer; }
 .peeper .menu .sep { border-top: 1px solid var(--line); margin: 5px 0; }
 
-.peeper #conn { display: flex; align-items: center; gap: 8px; font-size: 11px; letter-spacing: .15em; align-self: center; }
-.peeper #conn .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--bad); transition: background .3s; }
-.peeper #conn.live .dot { background: var(--duckgres); box-shadow: 0 0 10px var(--duckgres); animation: pn-blink 2.4s infinite; }
-.peeper #conn.live span { color: var(--duckgres); }
-.peeper #conn span { color: var(--bad); }
 @keyframes pn-blink { 50% { opacity: .55; } }
 
 /* ── main ───────────────────────────────────────── */

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
@@ -54,7 +54,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
         </select>
       </div>
     </div>
-    <div id="conn"><div class="dot"></div><span>CONNECTING</span></div>
   </div>
 
   <div class="main">
@@ -87,7 +86,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   const nodes = new Map<string, any>();
   const pods = new Map<string, any>();
   let dirty = false;
-  const pollOk = { nodes: false, pods: false };
 
   // ── k8s quantity parsing ───────────────────────────────
   function parseCpu(q: string): number {
@@ -192,13 +190,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     btn.classList.toggle("active", poolSel !== "all");
   }
 
-  // ── connection indicator ───────────────────────────────
-  function setConn(): void {
-    const ok = pollOk.nodes && pollOk.pods;
-    $("#conn").classList.toggle("live", ok);
-    $("#conn span").textContent = ok ? "LIVE" : "RECONNECTING";
-  }
-
   // ── snapshot polling: fetch a projected list, diff vs the store to emit
   //    ADDED/DELETED for the ticker, and replace the store. The FIRST poll of
   //    each stream seeds silently (matches the original watch, whose initial
@@ -207,7 +198,6 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     path: string,
     store: Map<string, any>,
     onEvent: (type: string, o: any) => void,
-    connKey: "nodes" | "pods" | null,
     intervalMs: number,
   ): void {
     let firstLoad = true;
@@ -236,10 +226,7 @@ export function mountPeepernetes(root: HTMLElement): () => void {
         }
         firstLoad = false;
         dirty = true;
-        if (connKey) { pollOk[connKey] = true; setConn(); }
-      } catch {
-        if (connKey) { pollOk[connKey] = false; setConn(); }
-      } finally {
+      } catch { /* transient fetch error — retry on the next tick */ } finally {
         const i = controllers.indexOf(ctrl);
         if (i >= 0) controllers.splice(i, 1);
       }
@@ -819,9 +806,9 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   $("#pool-menu").addEventListener("change", poolMenuFn);
 
   // ── start the polling streams ──────────────────────────
-  startPoll(`${API}/nodes`, nodes, onNodeEvent, "nodes", 2000);
-  startPoll(`${API}/pods`, pods, onPodEvent, "pods", 2000);
-  startPoll(`${API}/events`, evStore, onK8sEvent, null, 4000);
+  startPoll(`${API}/nodes`, nodes, onNodeEvent, 2000);
+  startPoll(`${API}/pods`, pods, onPodEvent, 2000);
+  startPoll(`${API}/events`, evStore, onK8sEvent, 4000);
 
   // ── cleanup ────────────────────────────────────────────
   return () => {

--- a/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
+++ b/controlplane/admin/ui/src/pages/nodes/peepernetes.ts
@@ -154,6 +154,12 @@ export function mountPeepernetes(root: HTMLElement): () => void {
   function nodePool(node: any): string {
     return (node.metadata.labels || {})["karpenter.sh/nodepool"] || "static";
   }
+  // A real duckgres worker pod (spawned per session), by the label the control
+  // plane stamps at spawn (k8s_pool_spawn.go). This is what the "workers" counter
+  // means — NOT every app pod (the control-plane's own pods are not workers).
+  function isWorker(pod: any): boolean {
+    return (pod.metadata.labels || {})["app"] === "duckgres-worker";
+  }
   const POOL_ORDER = (p: string) =>
     p === "duckgres-workers" ? 0 : p === "duckgres-cp" ? 1 : p === "static" ? 9 : 5;
 
@@ -522,8 +528,8 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     const byNode = new Map<string, [any, string][]>();
     const flatPods: [any, string][] = [];
     const unsched: [any, string][] = [];
-    let nPods = 0, nHead = 0, nPend = 0;
-    let pCpu = 0, pMem = 0, hCpu = 0, hMem = 0;
+    let nWorkers = 0, nHead = 0, nPend = 0;
+    let wCpu = 0, wMem = 0, hCpu = 0, hMem = 0;
     for (const p of pods.values()) {
       const k = classify(p);
       if (ns && p.metadata.namespace !== ns) continue;
@@ -533,9 +539,10 @@ export function mountPeepernetes(root: HTMLElement): () => void {
         if (k === "headroom") {
           nHead++;
           const r = podReq(p); hCpu += r.cpu; hMem += r.mem;
-        } else {
-          nPods++;
-          const r = podReq(p); pCpu += r.cpu; pMem += r.mem;
+        } else if (isWorker(p)) {
+          // Only real duckgres worker pods count toward "workers" + its CPU/MEM.
+          nWorkers++;
+          const r = podReq(p); wCpu += r.cpu; wMem += r.mem;
         }
       }
       if (counted && p.status?.phase === "Pending") nPend++;
@@ -552,12 +559,13 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     for (const l of byNode.values()) sortPods(l);
     sortPods(unsched);
 
-    // Header counters now live in the shared admin Topbar; build the CPU/MEM
-    // total strings here and push everything (incl. the node count below) via
-    // setClusterCounts once nNodes is known.
-    const pct = (a: number, b: number) => b ? Math.round(a / b * 100) + "%" : "–";
-    const workerReq = nPods ? `${fmtCpu(pCpu)} · ${fmtMem(pMem)}` : "";
-    const placeholderReq = nHead ? `${fmtCpu(hCpu)} · ${fmtMem(hMem)} · ${pct(hCpu, pCpu)}/${pct(hMem, pMem)} of workers` : "";
+    // Header counters live in the shared admin Topbar; build the CPU/MEM totals
+    // (of the real worker pods) here and push everything (incl. the node count
+    // below) via setClusterCounts once nNodes is known.
+    const cpuCores = Math.round(wCpu / 100) / 10; // millicores → cores, 1 decimal
+    const memGi = Math.round(wMem / 2 ** 30 * 10) / 10;
+    const workerDetail = nWorkers ? `${fmtCpu(wCpu)} · ${fmtMem(wMem)} across ${nWorkers} worker${nWorkers === 1 ? "" : "s"}` : "";
+    const placeholderDetail = nHead ? `${fmtCpu(hCpu)} · ${fmtMem(hMem)}` : "";
 
     $("#tray").classList.toggle("show", unsched.length > 0);
     $("#tray-count").textContent = unsched.length ? unsched.length + " pod(s) waiting for a node" : "";
@@ -583,10 +591,10 @@ export function mountPeepernetes(root: HTMLElement): () => void {
     for (const l of pools.values()) for (const n of l) if (!goneUids.has(n.metadata.uid)) nNodes++;
     // Only publish to the Topbar when a value actually changed (avoids a Topbar
     // re-render on every poll tick when the numbers are unchanged).
-    const countsKey = [nNodes, nPods, nHead, nPend, workerReq, placeholderReq].join("|");
+    const countsKey = [nNodes, nWorkers, cpuCores, memGi, nHead, nPend].join("|");
     if (countsKey !== lastCountsKey) {
       lastCountsKey = countsKey;
-      setClusterCounts({ nodes: nNodes, workers: nPods, placeholders: nHead, pending: nPend, workerReq, placeholderReq });
+      setClusterCounts({ nodes: nNodes, workers: nWorkers, cpuCores, memGi, placeholders: nHead, pending: nPend, workerDetail, placeholderDetail });
     }
     const poolNames = [...pools.keys()].sort((a, b) => (POOL_ORDER(a) - POOL_ORDER(b)) || a.localeCompare(b));
 


### PR DESCRIPTION
## The 4-vs-none bug
The node-overview "workers" counter counted **every** non-system, non-placeholder app pod on the visible nodepools — which includes the control plane's OWN pods (3× control-plane + query-log-writer ≈ "4"). So the header showed "4 workers" while **zero** real worker pods were running. That's the mismatch.

## How workers are counted
- `/status.total_workers` (Overview page) = the CP's per-org `OrgReservedPool.WorkerCount()` — worker slots *assigned* to orgs (excludes hot-idle).
- The node overview shows real k8s pods. Real worker pods are `duckgres-worker-*`, stamped with label **`app=duckgres-worker`** at spawn (`k8s_pool_spawn.go`).

## Fix
- "workers" now counts only pods with `app=duckgres-worker` — matching the worker chips in the view and the CP's worker accounting. (Idle cluster → 0, instead of counting control-plane pods.)
- **Restore CPU / Gi totals** (of those worker pods' requests) as visible stats in the Topbar row — they'd been demoted to a tooltip. Row is now: `nodes · CP · workers · CPU · Gi · placeholders · pending`.

Debugged live on mw-dev-admin: confirmed worker pods carry `app=duckgres-worker`, and the duckgres nodepools (`duckgres-cp`, `duckgres-workers`) are visible by default; with the cluster idle there are genuinely 0 worker pods.

Frontend-only; UI typecheck / lint / vitest / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)