### PR TITLE
admin: show each org's live cnpg shard on the orgs overview + org detail

### DIFF
--- a/controlplane/admin/ducklings_metadata.go
+++ b/controlplane/admin/ducklings_metadata.go
@@ -1,0 +1,91 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DucklingMetadataStore mirrors provisioner.CRMetadataStore without importing
+// provisioner (same decoupling as DucklingChecker); multitenant.go adapts
+// between the two.
+type DucklingMetadataStore struct {
+	Kind     string // "cnpg-shard" | "external"
+	Endpoint string // Postgres host from the CR status
+}
+
+// DucklingMetadataLister lists the live metadata-store assignment of every
+// Duckling CR, keyed by CR name. Satisfied via an adapter over
+// *provisioner.DucklingClient.
+type DucklingMetadataLister interface {
+	CRMetadataStores(ctx context.Context) (map[string]DucklingMetadataStore, error)
+}
+
+// ducklingMetadataEntry is the per-CR wire shape. CnpgShard is the parsed
+// shard name (e.g. "shard-001") for cnpg-shard tenants, empty otherwise —
+// the console shows the shard directly instead of making operators eyeball
+// the service hostname.
+type ducklingMetadataEntry struct {
+	Kind      string `json:"kind"`
+	Endpoint  string `json:"endpoint"`
+	CnpgShard string `json:"cnpg_shard,omitempty"`
+}
+
+// ducklingMetadataTimeout bounds the single CR LIST behind the handler.
+const ducklingMetadataTimeout = 15 * time.Second
+
+// RegisterDucklingsMetadata wires GET /ducklings/metadata: the live
+// metadata-store backend of every Duckling CR (notably the current cnpg
+// shard), keyed by CR name. Read-only infra info — viewer-accessible like the
+// other GETs. lister may be nil (Duckling client unavailable) — the handler
+// then degrades to {"available": false} rather than 500ing.
+func RegisterDucklingsMetadata(r *gin.RouterGroup, lister DucklingMetadataLister) {
+	r.GET("/ducklings/metadata", func(c *gin.Context) {
+		if lister == nil {
+			c.JSON(http.StatusOK, gin.H{"available": false, "entries": map[string]ducklingMetadataEntry{}})
+			return
+		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), ducklingMetadataTimeout)
+		defer cancel()
+		stores, err := lister.CRMetadataStores(ctx)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		entries := make(map[string]ducklingMetadataEntry, len(stores))
+		for name, ms := range stores {
+			e := ducklingMetadataEntry{Kind: ms.Kind, Endpoint: ms.Endpoint}
+			if ms.Kind == "cnpg-shard" {
+				e.CnpgShard = cnpgShardFromEndpoint(ms.Endpoint)
+			}
+			entries[name] = e
+		}
+		c.JSON(http.StatusOK, gin.H{"available": true, "entries": entries})
+	})
+}
+
+// cnpgShardFromEndpoint extracts the shard name from a cnpg metadata-store
+// endpoint: the first DNS label minus the CloudNativePG service-role suffix,
+// e.g. "shard-001-pooler.cnpg-shards.svc.cluster.local" → "shard-001".
+// An unrecognized shape degrades to the bare host label — still a stable,
+// compact per-shard identifier.
+func cnpgShardFromEndpoint(endpoint string) string {
+	host := endpoint
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		host = host[:i]
+	}
+	for _, suf := range []string{"-pooler", "-rw", "-ro", "-r"} {
+		if s, ok := strings.CutSuffix(host, suf); ok && s != "" {
+			return s
+		}
+	}
+	return host
+}

--- a/controlplane/admin/ducklings_metadata_test.go
+++ b/controlplane/admin/ducklings_metadata_test.go
@@ -1,0 +1,113 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestCnpgShardFromEndpoint pins the shard-name extraction: the first DNS
+// label minus the CloudNativePG service-role suffix, degrading to the bare
+// label for unrecognized shapes.
+func TestCnpgShardFromEndpoint(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		want     string
+	}{
+		{"shard-001-pooler.cnpg-shards.svc.cluster.local", "shard-001"},
+		{"shard-042-rw.cnpg-shards.svc.cluster.local", "shard-042"},
+		{"shard-007-ro.cnpg-shards.svc", "shard-007"},
+		{"shard-003-r.cnpg-shards.svc", "shard-003"},
+		{"shard-001-pooler.cnpg-shards.svc.cluster.local:5432", "shard-001"},
+		{"shard-001", "shard-001"},
+		{"someotherhost.example.com", "someotherhost"},
+		// A host that IS just the suffix must not collapse to "".
+		{"-rw.cnpg-shards.svc", "-rw"},
+	}
+	for _, tc := range cases {
+		if got := cnpgShardFromEndpoint(tc.endpoint); got != tc.want {
+			t.Errorf("cnpgShardFromEndpoint(%q) = %q, want %q", tc.endpoint, got, tc.want)
+		}
+	}
+}
+
+type stubMetadataLister struct {
+	stores map[string]DucklingMetadataStore
+	err    error
+}
+
+func (s stubMetadataLister) CRMetadataStores(context.Context) (map[string]DucklingMetadataStore, error) {
+	return s.stores, s.err
+}
+
+func metadataRouter(lister DucklingMetadataLister) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterDucklingsMetadata(r.Group("/api/v1"), lister)
+	return r
+}
+
+// TestDucklingsMetadataHandler pins the wire shape: entries keyed by CR name,
+// cnpg-shard entries carry the parsed shard, external entries do not.
+func TestDucklingsMetadataHandler(t *testing.T) {
+	r := metadataRouter(stubMetadataLister{stores: map[string]DucklingMetadataStore{
+		"acme-cnpg": {Kind: "cnpg-shard", Endpoint: "shard-001-pooler.cnpg-shards.svc.cluster.local"},
+		"acme-ext":  {Kind: "external", Endpoint: "db.example.rds.amazonaws.com"},
+	}})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ducklings/metadata", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp struct {
+		Available bool                             `json:"available"`
+		Entries   map[string]ducklingMetadataEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Available {
+		t.Fatal("available = false, want true")
+	}
+	cnpg := resp.Entries["acme-cnpg"]
+	if cnpg.Kind != "cnpg-shard" || cnpg.CnpgShard != "shard-001" {
+		t.Fatalf("cnpg entry = %+v, want kind=cnpg-shard shard=shard-001", cnpg)
+	}
+	ext := resp.Entries["acme-ext"]
+	if ext.Kind != "external" || ext.CnpgShard != "" {
+		t.Fatalf("ext entry = %+v, want kind=external no shard", ext)
+	}
+}
+
+// TestDucklingsMetadataDegrades pins the nil-lister and error paths: nil →
+// available=false (not 500), lister error → 500.
+func TestDucklingsMetadataDegrades(t *testing.T) {
+	w := httptest.NewRecorder()
+	metadataRouter(nil).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ducklings/metadata", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("nil lister status = %d, want 200", w.Code)
+	}
+	var resp struct {
+		Available bool `json:"available"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Available {
+		t.Fatal("available = true with nil lister, want false")
+	}
+
+	w = httptest.NewRecorder()
+	metadataRouter(stubMetadataLister{err: errors.New("boom")}).
+		ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ducklings/metadata", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("error lister status = %d, want 500", w.Code)
+	}
+}

--- a/controlplane/admin/ui/src/components/ShardBadge.tsx
+++ b/controlplane/admin/ui/src/components/ShardBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { hashColor, hashColorBg } from "@/lib/colors";
+import type { DucklingMetadataEntry } from "@/types/api";
+
+// ShardBadge renders a Duckling's live metadata-store assignment: a
+// color-coded pill for the cnpg shard (same deterministic per-key palette as
+// the nodes overview, so one shard is one color everywhere), a muted
+// "external" pill for RDS-backed tenants, and "—" when unknown (CR missing /
+// endpoint not yet populated / pre-rollout backend).
+export function ShardBadge({ meta }: { meta: DucklingMetadataEntry | undefined }) {
+  if (!meta) return <span className="text-muted-foreground">—</span>;
+  const label = meta.cnpg_shard || (meta.kind === "external" ? "external" : meta.kind || "—");
+  const colored = Boolean(meta.cnpg_shard);
+  const badge = (
+    <Badge
+      variant={colored ? "outline" : "muted"}
+      className="font-mono"
+      style={colored ? { color: hashColor(label), backgroundColor: hashColorBg(label), borderColor: "transparent" } : undefined}
+    >
+      {label}
+    </Badge>
+  );
+  return meta.endpoint ? (
+    <Tooltip>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent className="font-mono text-xs">{meta.endpoint}</TooltipContent>
+    </Tooltip>
+  ) : (
+    badge
+  );
+}

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -17,6 +17,7 @@ import type {
   ClusterStatus,
   CreateUserBody,
   DucklingDriftResponse,
+  DucklingMetadataResponse,
   ErrorEntry,
   ErrorFilters,
   FleetStat,
@@ -146,6 +147,21 @@ export function useDucklingDrift() {
       ),
     enabled: isAdmin,
     refetchInterval: POLL.normal,
+  });
+}
+
+const EMPTY_DUCKLING_METADATA: DucklingMetadataResponse = { available: false, entries: {} };
+
+// Live per-Duckling metadata-store assignment (which cnpg shard each tenant is
+// on). Viewer-accessible; a pre-rollout backend without the endpoint → empty.
+export function useDucklingsMetadata() {
+  return useQuery<DucklingMetadataResponse>({
+    queryKey: ["ducklings", "metadata"],
+    queryFn: () =>
+      tolerateStatus<DucklingMetadataResponse>(EMPTY_DUCKLING_METADATA, 403, 404, 503)(
+        api.getDucklingsMetadata(),
+      ).catch(() => EMPTY_DUCKLING_METADATA),
+    refetchInterval: POLL.slow,
   });
 }
 

--- a/controlplane/admin/ui/src/lib/api.ts
+++ b/controlplane/admin/ui/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   CreateUserBody,
   CPInstance,
   DucklingDriftResponse,
+  DucklingMetadataResponse,
   ErrorEntry,
   ErrorFilters,
   FleetStat,
@@ -129,6 +130,7 @@ export const api = {
 
   // ducklings (admin-only)
   getDucklingDrift: () => get<DucklingDriftResponse>("/ducklings/drift"),
+  getDucklingsMetadata: () => get<DucklingMetadataResponse>("/ducklings/metadata"),
 
   // users
   listUsers: () => get<OrgUser[]>("/users"),

--- a/controlplane/admin/ui/src/lib/colors.test.ts
+++ b/controlplane/admin/ui/src/lib/colors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { hashColor, hashColorBg } from "./colors";
+import { ducklingEntryFor } from "./format";
+
+describe("hashColor", () => {
+  it("is deterministic and distinct per shard", () => {
+    expect(hashColor("shard-001")).toBe(hashColor("shard-001"));
+    expect(hashColor("shard-001")).not.toBe(hashColor("shard-002"));
+  });
+
+  it("skips the success-green hue band (95–150°)", () => {
+    for (const key of ["shard-001", "shard-002", "shard-042", "x", "abcdef"]) {
+      const hue = Number(/hsl\((\d+) /.exec(hashColor(key))![1]);
+      expect(hue < 95 || hue >= 150, `hue ${hue} for ${key}`).toBe(true);
+    }
+  });
+
+  it("bg variant matches the fg hue with alpha", () => {
+    expect(hashColorBg("shard-001")).toBe(hashColor("shard-001").replace(")", " / 0.15)"));
+  });
+});
+
+describe("ducklingEntryFor", () => {
+  const entries = { "acme-corp": 1, acmecorp: 2, custom: 3 };
+
+  it("prefers the stored duckling_name, then canonical, then legacy", () => {
+    expect(ducklingEntryFor(entries, "Acme-Corp", "custom")).toBe(3);
+    expect(ducklingEntryFor(entries, "Acme-Corp")).toBe(1);
+    expect(ducklingEntryFor({ acmecorp: 2 }, "Acme-Corp")).toBe(2);
+    expect(ducklingEntryFor(entries, "unknown-org")).toBeUndefined();
+    expect(ducklingEntryFor(undefined, "Acme-Corp")).toBeUndefined();
+  });
+});

--- a/controlplane/admin/ui/src/lib/colors.ts
+++ b/controlplane/admin/ui/src/lib/colors.ts
@@ -1,0 +1,28 @@
+// Deterministic per-key colors, matching the nodes-overview scheme
+// (pages/nodes/peepernetes.ts `appColor`): FNV-1a hash of the key → a hue that
+// skips the 95–150° band (avoids reading as the success-green used by status
+// badges), rendered at 75% saturation / 62% lightness. Same key → same color
+// everywhere, across pages and reloads.
+export function hashColor(key: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const t = (h >>> 0) % 265;
+  const hue = t < 75 ? 20 + t : 150 + (t - 75);
+  return `hsl(${hue} 75% 62%)`;
+}
+
+// Translucent fill for the same key, for badge backgrounds behind hashColor
+// text (mirrors the Badge variants' bg-*/15 pattern).
+export function hashColorBg(key: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const t = (h >>> 0) % 265;
+  const hue = t < 75 ? 20 + t : 150 + (t - 75);
+  return `hsl(${hue} 75% 62% / 0.15)`;
+}

--- a/controlplane/admin/ui/src/lib/format.ts
+++ b/controlplane/admin/ui/src/lib/format.ts
@@ -151,6 +151,23 @@ export function ducklingName(orgName: string): string {
   return orgName.toLowerCase();
 }
 
+// Resolve an org's entry in a Duckling-CR-name-keyed map: the stored
+// duckling_name wins, then the canonical (lowercased) org name, then the
+// legacy hyphen-stripped variant pre-rename CRs still use (mirrors the drift
+// finder's expected-name set).
+export function ducklingEntryFor<T>(
+  entries: Record<string, T> | undefined,
+  orgName: string,
+  ducklingNameOverride?: string,
+): T | undefined {
+  if (!entries) return undefined;
+  const canonical = ducklingName(orgName);
+  for (const name of [ducklingNameOverride, canonical, canonical.replaceAll("-", "")]) {
+    if (name && entries[name] !== undefined) return entries[name];
+  }
+  return undefined;
+}
+
 // A Duckling is broken/unhealthy when its warehouse row exists but the overall
 // state is failed or deleted.
 export function ducklingBroken(state: string | undefined): boolean {

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -21,9 +21,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ApiError } from "@/lib/api";
-import { ducklingBroken, ducklingName, fmtTime } from "@/lib/format";
+import { ducklingBroken, ducklingEntryFor, ducklingName, fmtTime } from "@/lib/format";
+import { ShardBadge } from "@/components/ShardBadge";
 import {
   useDeleteOrg,
+  useDucklingsMetadata,
   useOrg,
   useUpdateOrg,
   useUpdateWarehouse,
@@ -286,6 +288,7 @@ function WarehousePanel({
   error: unknown;
 }) {
   const update = useUpdateWarehouse(orgId);
+  const metadata = useDucklingsMetadata();
   const [image, setImage] = useState("");
   const [version, setVersion] = useState("");
   const [ducklingNameInput, setDucklingNameInput] = useState("");
@@ -343,6 +346,13 @@ function WarehousePanel({
           <div>
             <div className="text-[10px] uppercase text-muted-foreground">Duckling</div>
             <div className="font-mono text-xs">{data?.duckling_name || ducklingName(orgId)}</div>
+          </div>
+          {/* Live metadata-store assignment from the Duckling CR status — the
+              cnpg shard the tenant's metadata actually lives on (the config
+              store doesn't hold this; the composition assigns it). */}
+          <div className="text-right">
+            <div className="text-[10px] uppercase text-muted-foreground">Metadata shard</div>
+            <ShardBadge meta={ducklingEntryFor(metadata.data?.entries, orgId, data?.duckling_name)} />
           </div>
           {ducklingWarning && (
             <Tooltip>

--- a/controlplane/admin/ui/src/pages/Orgs.tsx
+++ b/controlplane/admin/ui/src/pages/Orgs.tsx
@@ -9,14 +9,16 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { StateBadge } from "@/components/StateBadge";
+import { ShardBadge } from "@/components/ShardBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
-import { useDucklingDrift, useOrgs } from "@/hooks/useApi";
-import { ducklingName, fmtInt } from "@/lib/format";
+import { useDucklingDrift, useDucklingsMetadata, useOrgs } from "@/hooks/useApi";
+import { ducklingEntryFor, ducklingName, fmtInt } from "@/lib/format";
 import type { DucklingDrift, Org } from "@/types/api";
 
 export function Orgs() {
   const orgs = useOrgs();
   const drift = useDucklingDrift();
+  const metadata = useDucklingsMetadata();
   const navigate = useNavigate();
   const [filter, setFilter] = useState("");
 
@@ -109,8 +111,22 @@ export function Orgs() {
           return <span className="font-mono text-xs text-muted-foreground">{name || "—"}</span>;
         },
       },
+      {
+        id: "shard",
+        header: "Shard",
+        // Live CR status (composition-assigned), not config — the shard an
+        // org's metadata actually lives on. Sorting/filtering keys off the
+        // shard name so orgs on one shard group together.
+        accessorFn: (o) =>
+          ducklingEntryFor(metadata.data?.entries, o.name, o.warehouse?.duckling_name)?.cnpg_shard ?? "",
+        cell: ({ row }) => {
+          const o = row.original;
+          if (!o.warehouse) return <span className="text-muted-foreground">—</span>;
+          return <ShardBadge meta={ducklingEntryFor(metadata.data?.entries, o.name, o.warehouse.duckling_name)} />;
+        },
+      },
     ],
-    [driftByOrg],
+    [driftByOrg, metadata.data],
   );
 
   return (
@@ -136,7 +152,7 @@ export function Orgs() {
         )}
         <Card className="overflow-hidden">
           {orgs.isLoading ? (
-            <TableSkeleton cols={8} />
+            <TableSkeleton cols={9} />
           ) : orgs.isError ? (
             <ErrorState error={orgs.error} onRetry={() => orgs.refetch()} />
           ) : (

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -216,6 +216,25 @@ export interface DucklingDriftResponse {
   entries: DucklingDrift[];
 }
 
+// ---- Duckling metadata-store assignment ----
+
+// The live metadata-store backend of one Duckling CR. `cnpg_shard` is the
+// parsed shard name (e.g. "shard-001") for cnpg-shard tenants, absent for
+// external.
+export interface DucklingMetadataEntry {
+  kind: string;
+  endpoint: string;
+  cnpg_shard?: string;
+}
+
+// GET /api/v1/ducklings/metadata → per-CR metadata-store assignment keyed by
+// CR (duckling) name. `available` is false when the Duckling client is
+// unavailable.
+export interface DucklingMetadataResponse {
+  available: boolean;
+  entries: Record<string, DucklingMetadataEntry>;
+}
+
 // ---- Cluster status (confirmed) ----
 
 export interface OrgStatus {

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -558,6 +558,15 @@ func SetupMultiTenant(
 	}
 	admin.RegisterDucklingsDrift(api, store, ducklingChecker)
 
+	// Live per-Duckling metadata-store assignment (which cnpg shard each
+	// tenant landed on) for the org overview/detail pages. Same nil-degrade
+	// contract as the drift finder.
+	var ducklingMetadata admin.DucklingMetadataLister
+	if dcErr == nil && dc != nil {
+		ducklingMetadata = ducklingMetadataAdapter{dc: dc}
+	}
+	admin.RegisterDucklingsMetadata(api, ducklingMetadata)
+
 	// Break-glass internal-secret login (the SPA owns "/" and app routes).
 	admin.RegisterLogin(engine, adminTokens)
 
@@ -597,6 +606,26 @@ func SetupMultiTenant(
 	}
 
 	return store, adpt, apiServer, runtimeTracker, janitorLeader, meter, nil
+}
+
+// ducklingMetadataAdapter converts provisioner.CRMetadataStore into the
+// admin package's DucklingMetadataStore so admin does not import provisioner
+// (same decoupling as DucklingChecker, which needs no adapter only because
+// its method signatures carry no provisioner types).
+type ducklingMetadataAdapter struct {
+	dc *provisioner.DucklingClient
+}
+
+func (a ducklingMetadataAdapter) CRMetadataStores(ctx context.Context) (map[string]admin.DucklingMetadataStore, error) {
+	stores, err := a.dc.CRMetadataStores(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]admin.DucklingMetadataStore, len(stores))
+	for name, ms := range stores {
+		out[name] = admin.DucklingMetadataStore{Kind: ms.Type, Endpoint: ms.Endpoint}
+	}
+	return out, nil
 }
 
 type workerLifecycleStatsLister interface {

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -311,6 +311,39 @@ func (d *DucklingClient) ListCRNames(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+// CRMetadataStore is the metadata-store slice of one Duckling CR's status —
+// the live (composition-assigned) backend, notably which cnpg shard a
+// cnpg-shard tenant landed on. The config store does not hold this (the
+// composition picks the active shard at provision time and only the CR status
+// carries the endpoint), so the admin console reads it from here.
+type CRMetadataStore struct {
+	Type     string // "cnpg-shard" | "external"
+	Endpoint string // Postgres host, e.g. "shard-001-pooler.cnpg-shards.svc.cluster.local"
+}
+
+// CRMetadataStores lists every Duckling CR and returns each one's
+// status.metadataStore type + endpoint, keyed by CR name. CRs whose status is
+// not yet populated (still provisioning) are skipped rather than failing the
+// whole listing.
+func (d *DucklingClient) CRMetadataStores(ctx context.Context) (map[string]CRMetadataStore, error) {
+	list, err := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list duckling CRs: %w", err)
+	}
+	out := make(map[string]CRMetadataStore, len(list.Items))
+	for i := range list.Items {
+		status, perr := parseDucklingStatus(&list.Items[i])
+		if perr != nil || status.MetadataStore.Endpoint == "" {
+			continue
+		}
+		out[list.Items[i].GetName()] = CRMetadataStore{
+			Type:     status.MetadataStore.Type,
+			Endpoint: status.MetadataStore.Endpoint,
+		}
+	}
+	return out, nil
+}
+
 // CRStatus reports whether the org's Duckling CR exists and, if so, whether it
 // is Ready — without treating absence as an error. A NotFound resolves to
 // (false, false, nil) so the drift finder can classify a missing CR rather than

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -2020,6 +2020,29 @@ admin_impersonation_audited() { # org
     || fail "impersonate: no audit row for impersonate.query root@$org"
 }
 
+# ---- admin ducklings metadata: live cnpg shard assignment ------------------
+# GET /ducklings/metadata surfaces each Duckling CR's status.metadataStore for
+# the org overview/detail pages — notably WHICH cnpg shard a cnpg tenant's
+# metadata landed on (composition-assigned; not in the config store). Asserts
+# the cnpg org's entry is kind=cnpg-shard with a parsed shard name, and the ext
+# org's entry is kind=external with no shard. Guards
+# provisioner.CRMetadataStores + admin/ducklings_metadata.go.
+admin_ducklings_metadata() { # cnpgOrg extOrg
+  cnpg_d="$(echo "$1" | tr 'A-Z' 'a-z')"; ext_d="$(echo "$2" | tr 'A-Z' 'a-z')"
+  log "admin ducklings metadata: shard assignment for $cnpg_d + $ext_d"
+  out="$(curl -fsS -H "$H" "$API/api/v1/ducklings/metadata")" \
+    || fail "ducklings metadata: request failed"
+  echo "$out" | jq -e '.available == true' >/dev/null \
+    || fail "ducklings metadata: available != true: $out"
+  echo "$out" | jq -e --arg d "$cnpg_d" \
+    '.entries[$d] | .kind == "cnpg-shard" and (.cnpg_shard | test("^shard-"))' >/dev/null \
+    || fail "ducklings metadata: no cnpg-shard entry with parsed shard for $cnpg_d: $(echo "$out" | jq -c --arg d "$cnpg_d" '.entries[$d]')"
+  echo "$out" | jq -e --arg d "$ext_d" \
+    '.entries[$d] | .kind == "external" and (has("cnpg_shard") | not)' >/dev/null \
+    || fail "ducklings metadata: ext entry wrong for $ext_d: $(echo "$out" | jq -c --arg d "$ext_d" '.entries[$d]')"
+  log "admin ducklings metadata OK ($cnpg_d on $(echo "$out" | jq -r --arg d "$cnpg_d" '.entries[$d].cnpg_shard'))"
+}
+
 # ---- tenant isolation -----------------------------------------------------
 # Two tenants (cnpg + ext) back onto distinct DuckLake metadata stores, so a
 # table created by one is invisible to the other. Ported (logical half) from
@@ -2400,6 +2423,9 @@ main() {
 
   # ---- admin impersonation round-trip + audit (cnpg stack is warm now) ----
   admin_impersonation_audited "$CNPG"
+
+  # ---- admin ducklings metadata: live cnpg shard assignment ----------------
+  admin_ducklings_metadata "$CNPG" "$EXT"
 
   # ---- admin live-query detail view (phase 1) — cnpg stack is warm now ----
   admin_query_detail "$CNPG" "$cnpg_pw"


### PR DESCRIPTION
## Problem

The cnpg shard a tenant's metadata lands on is composition-assigned and only lives in the Duckling CR's `status.metadataStore` — the config store never holds it. Answering "which shard is this org on?" meant kubectl-ing into the cluster.

## Changes

**Backend**
- `provisioner.DucklingClient.CRMetadataStores`: one LIST over Duckling CRs → each CR's `status.metadataStore` type + endpoint, keyed by CR name. CRs with unpopulated status (still provisioning) are skipped, not fatal.
- `admin/ducklings_metadata.go`: `GET /api/v1/ducklings/metadata` (viewer-accessible, read-only) returning `{kind, endpoint, cnpg_shard}` per CR. `cnpgShardFromEndpoint` parses `shard-001` out of `shard-001-pooler.cnpg-shards.svc.cluster.local` (handles `-pooler/-rw/-ro/-r` suffixes and ports; unrecognized shapes degrade to the bare host label). Same nil-degrade contract as the drift finder (`{"available": false}` when the Duckling client is unavailable).
- `multitenant.go`: `ducklingMetadataAdapter` bridges provisioner→admin types so admin keeps not importing provisioner.

**Frontend**
- New **Shard** column on the Orgs overview + a **Metadata shard** slot in the org-detail warehouse panel. Joined to the CR map by `duckling_name` → canonical → legacy hyphen-stripped name (`ducklingEntryFor`, mirroring the drift finder's expected-name set), so pre-rename CRs still resolve.
- **Color-coded shards** using the nodes-overview scheme (`lib/colors.ts`, same FNV-1a → hue formula as peepernetes `appColor`, success-green hue band skipped): one shard = one color everywhere, sortable/filterable by shard so orgs on the same shard group together. External (RDS) tenants get a muted `external` pill; the raw endpoint is in a tooltip.

## Tests
- `admin/ducklings_metadata_test.go`: handler wire shape (cnpg entry carries parsed shard, external doesn't), nil-lister degrade, lister-error 500, shard-parse table test.
- `ui/src/lib/colors.test.ts`: color determinism + hue-band skip + join-precedence for `ducklingEntryFor`.
- e2e `harness.sh`: new `admin_ducklings_metadata` assertion — cnpg org resolves to `kind=cnpg-shard` with a parsed `shard-*` name, ext org to `kind=external` with no shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)