### PR TITLE
Allow unsigned DuckLake extension in query log writer

### DIFF
--- a/server/querylog.go
+++ b/server/querylog.go
@@ -137,7 +137,7 @@ func openQueryLogDuckLakeDB(cfg Config) (*sql.DB, error) {
 		return nil, errors.New("querylog: DuckLake metadata store is required")
 	}
 
-	db, err := sql.Open("duckdb", ":memory:")
+	db, err := sql.Open("duckdb", queryLogDuckLakeDBDSN())
 	if err != nil {
 		return nil, fmt.Errorf("querylog: open duckdb: %w", err)
 	}
@@ -203,6 +203,10 @@ func openQueryLogDuckLakeDB(cfg Config) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+func queryLogDuckLakeDBDSN() string {
+	return ":memory:?allow_unsigned_extensions=true"
 }
 
 // Log sends an entry to the query log. Non-blocking; drops if channel is full.

--- a/server/querylog_kafka_writer_test.go
+++ b/server/querylog_kafka_writer_test.go
@@ -439,6 +439,12 @@ func TestQueryLogKafkaWriterCommitsWhenOrgHasNoDuckLakeTarget(t *testing.T) {
 	}
 }
 
+func TestQueryLogDuckLakeDBDSNAllowsUnsignedExtensions(t *testing.T) {
+	if got, want := queryLogDuckLakeDBDSN(), ":memory:?allow_unsigned_extensions=true"; got != want {
+		t.Fatalf("queryLogDuckLakeDBDSN() = %q, want %q", got, want)
+	}
+}
+
 func TestQueryLogKafkaEventInsertIsIdempotentByEventID(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {


### PR DESCRIPTION
## Summary
- open the query-log writer's dedicated DuckDB connection with allow_unsigned_extensions=true
- add a focused regression test for the writer DSN

## Why
Dev query-log writer now has Pod Identity and starts cleanly, but it fails to process Kafka events when loading the bundled ducklake extension:

```
Extension /data/extensions/v1.5.3/linux_arm64/ducklake.duckdb_extension could not be loaded because its signature is either missing or invalid and unsigned extensions are disabled by configuration
```

Normal Duckgres sessions already use `?allow_unsigned_extensions=true`; this brings the writer path into parity.

## Tests
- `go test ./server -run 'TestQueryLogDuckLakeDBDSNAllowsUnsignedExtensions|TestQueryLogKafka|TestQueryLogDuckLakeEntryWriter' -count=1`
- `just lint`
