### PR TITLE
Fix frozen scenario resource names

### DIFF
--- a/tests/scenario/runner_test.go
+++ b/tests/scenario/runner_test.go
@@ -155,6 +155,44 @@ func TestProvisionSmokeScenarioUsesRunUniqueSupportedSteps(t *testing.T) {
 	}
 }
 
+func TestFrozenSuccessScenariosUseValidProvisioningSlugs(t *testing.T) {
+	for _, scenarioFile := range []string{
+		"posthog_frozen_metadata.yaml",
+		"posthog_frozen_perf.yaml",
+		"posthog_frozen_dbt.yaml",
+	} {
+		t.Run(scenarioFile, func(t *testing.T) {
+			t.Setenv("DUCKGRES_SCENARIO_FLIGHT_ADDR", "grpc://flight.example:8815")
+			scenario, err := core.LoadScenario(filepath.Join("scenarios", scenarioFile))
+			if err != nil {
+				t.Fatalf("load scenario: %v", err)
+			}
+			runID := scenario.RunIDPrefix + "-20260701t135927z"
+			resolved, err := resolveRunTemplates(scenario, runID)
+			if err != nil {
+				t.Fatalf("resolve templates: %v", err)
+			}
+			for _, step := range resolved.Steps {
+				if !dispatchSupports(step.Type) {
+					t.Fatalf("step %s has unsupported type %q", step.ID, step.Type)
+				}
+				if containsTemplate(step.With) {
+					t.Fatalf("step %s still contains unresolved template values: %#v", step.ID, step.With)
+				}
+				if step.Type != provision.StepTypeProvisionWarehouse &&
+					step.Type != provision.StepTypeWaitWarehouseReady &&
+					step.Type != provision.StepTypeDeprovisionWarehouse {
+					continue
+				}
+				orgID, _ := step.With["org_id"].(string)
+				if orgID == "" || len(orgID) > 35 {
+					t.Fatalf("step %s org_id = %q, want valid provisioning slug of at most 35 chars", step.ID, orgID)
+				}
+			}
+		})
+	}
+}
+
 func TestProvisionRejectionScenarioUsesExpectedProvisionFailure(t *testing.T) {
 	scenario, err := core.LoadScenario(filepath.Join("scenarios", "provision_rejection.yaml"))
 	if err != nil {

--- a/tests/scenario/scenarios/posthog_frozen_dbt.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_dbt.yaml
@@ -6,9 +6,9 @@ steps:
   - id: provision
     type: provision_warehouse
     with:
-      org_id: scenario-frozen-dbt-${run_id_compact}
+      org_id: scenario-frozen-dbt-${run_id_token}
       request:
-        database_name: scenario_frozen_dbt_${run_id_compact}
+        database_name: scenario_frozen_dbt_${run_id_token}
         metadata_store:
           type: cnpg-shard
         ducklake:
@@ -19,14 +19,14 @@ steps:
   - id: wait_ready
     type: wait_warehouse_ready
     with:
-      org_id: scenario-frozen-dbt-${run_id_compact}
+      org_id: scenario-frozen-dbt-${run_id_token}
       timeout: 15m
       poll_interval: 10s
 
   - id: setup_frozen_views
     type: sql
     with:
-      org_id: scenario-frozen-dbt-${run_id_compact}
+      org_id: scenario-frozen-dbt-${run_id_token}
       catalog: ducklake
       file: ../sql/setup_frozen_views.sql
       max_attempts: 12
@@ -35,7 +35,7 @@ steps:
   - id: dbt_models
     type: dbt_run
     with:
-      org_id: scenario-frozen-dbt-${run_id_compact}
+      org_id: scenario-frozen-dbt-${run_id_token}
       catalog: ducklake
       schema: dbt_frozen
       project_dir: ../dbt/posthog_frozen_project
@@ -46,7 +46,7 @@ steps:
     depends_on: [dbt_models]
     always_run: true
     with:
-      org_id: scenario-frozen-dbt-${run_id_compact}
+      org_id: scenario-frozen-dbt-${run_id_token}
       verify_deleted: true
       cleanup_timeout: 15m
       poll_interval: 10s

--- a/tests/scenario/scenarios/posthog_frozen_metadata.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_metadata.yaml
@@ -6,9 +6,9 @@ steps:
   - id: provision
     type: provision_warehouse
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       request:
-        database_name: scenario_frozen_${run_id_compact}
+        database_name: scenario_frozen_${run_id_token}
         metadata_store:
           type: cnpg-shard
         ducklake:
@@ -19,14 +19,14 @@ steps:
   - id: wait_ready
     type: wait_warehouse_ready
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       timeout: 15m
       poll_interval: 10s
 
   - id: setup_frozen_views
     type: sql
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       catalog: ducklake
       file: ../sql/setup_frozen_views.sql
       max_attempts: 12
@@ -35,7 +35,7 @@ steps:
   - id: validate_dataset_manifest
     type: sql
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       catalog: ducklake
       sql: |
         SELECT dataset_version
@@ -48,7 +48,7 @@ steps:
   - id: metadata_exploration
     type: sql_catalog
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       catalog: ducklake
       file: ../sql/metadata_catalog.yaml
       max_attempts: 3
@@ -59,7 +59,7 @@ steps:
     depends_on: [metadata_exploration]
     always_run: true
     with:
-      org_id: scenario-frozen-${run_id_compact}
+      org_id: scenario-frozen-${run_id_token}
       verify_deleted: true
       cleanup_timeout: 15m
       poll_interval: 10s

--- a/tests/scenario/scenarios/posthog_frozen_perf.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_perf.yaml
@@ -7,9 +7,9 @@ steps:
   - id: provision
     type: provision_warehouse
     with:
-      org_id: scenario-frozen-perf-${run_id_compact}
+      org_id: scenario-frozen-perf-${run_id_token}
       request:
-        database_name: scenario_frozen_perf_${run_id_compact}
+        database_name: scenario_frozen_perf_${run_id_token}
         metadata_store:
           type: cnpg-shard
         ducklake:
@@ -20,14 +20,14 @@ steps:
   - id: wait_ready
     type: wait_warehouse_ready
     with:
-      org_id: scenario-frozen-perf-${run_id_compact}
+      org_id: scenario-frozen-perf-${run_id_token}
       timeout: 15m
       poll_interval: 10s
 
   - id: setup_frozen_views
     type: sql
     with:
-      org_id: scenario-frozen-perf-${run_id_compact}
+      org_id: scenario-frozen-perf-${run_id_token}
       catalog: ducklake
       file: ../sql/setup_frozen_views.sql
       max_attempts: 12
@@ -36,7 +36,7 @@ steps:
   - id: perf_queries
     type: perf_queries
     with:
-      org_id: scenario-frozen-perf-${run_id_compact}
+      org_id: scenario-frozen-perf-${run_id_token}
       catalog: ducklake
       catalog_file: ../../perf/queries/ducklake_frozen.yaml
       run_id: ${run_id}
@@ -48,7 +48,7 @@ steps:
     depends_on: [perf_queries]
     always_run: true
     with:
-      org_id: scenario-frozen-perf-${run_id_compact}
+      org_id: scenario-frozen-perf-${run_id_token}
       verify_deleted: true
       cleanup_timeout: 15m
       poll_interval: 10s


### PR DESCRIPTION
## Summary
- switch frozen success scenarios from compact run ids to short run tokens for org/database names
- add coverage that all frozen success scenarios resolve default run ids to valid provisioning slugs
- leave the explicit provision rejection scenario as the long-name failure path

## Validation
- go test ./tests/scenario
- just lint
- live dev run: just scenario-frozen-metadata with default generated run id passed after the dev S3 policy fix was applied

Live run verified the previous provisioning rejection is gone and the frozen metadata scenario can provision, read frozen S3 parquet, run metadata queries, and deprovision.