### PR TITLE
Drop stale query-log events without DuckLake targets

### DIFF
--- a/querylog_writer_mode_kubernetes.go
+++ b/querylog_writer_mode_kubernetes.go
@@ -50,6 +50,8 @@ type configStoreQueryLogDuckLakeConfigResolver struct {
 	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error)
 }
 
+const queryLogWriterEmptyMetadataSecretRefError = "metadata store credentials: secret ref requires name and key"
+
 func (r *configStoreQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfig(ctx context.Context, orgID string) (server.QueryLogDuckLakeResolvedConfig, error) {
 	snap := r.store.Snapshot()
 	if snap == nil {
@@ -57,7 +59,7 @@ func (r *configStoreQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfi
 	}
 	org, ok := snap.Orgs[orgID]
 	if !ok || org == nil {
-		return server.QueryLogDuckLakeResolvedConfig{}, fmt.Errorf("querylog: org %q not found in config snapshot", orgID)
+		return server.QueryLogDuckLakeResolvedConfig{}, fmt.Errorf("%w: org %q not found in config snapshot", server.ErrQueryLogNoDuckLakeTarget, orgID)
 	}
 	payload, err := controlplane.BuildTenantActivationPayloadWithResolver(
 		ctx,
@@ -69,6 +71,9 @@ func (r *configStoreQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfi
 		r.resolveDucklingStatus,
 	)
 	if err != nil {
+		if queryLogWriterActivationErrorIsNoDuckLakeTarget(err) {
+			return server.QueryLogDuckLakeResolvedConfig{}, fmt.Errorf("%w: %v", server.ErrQueryLogNoDuckLakeTarget, err)
+		}
 		return server.QueryLogDuckLakeResolvedConfig{}, err
 	}
 	cfg := r.base
@@ -79,6 +84,13 @@ func (r *configStoreQueryLogDuckLakeConfigResolver) ResolveQueryLogDuckLakeConfi
 		Config:               cfg,
 		CredentialsExpiresAt: payload.S3CredentialsExpiresAt,
 	}, nil
+}
+
+func queryLogWriterActivationErrorIsNoDuckLakeTarget(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), queryLogWriterEmptyMetadataSecretRefError)
 }
 
 func runQueryLogWriter(ctx context.Context, cfg server.Config, resolved configresolve.Resolved) error {

--- a/querylog_writer_mode_kubernetes_test.go
+++ b/querylog_writer_mode_kubernetes_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/posthog/duckgres/configresolve"
@@ -41,5 +42,37 @@ func TestRunQueryLogWriterBootstrapsBundledExtensions(t *testing.T) {
 	}
 	if gotDataDir != cfg.DataDir {
 		t.Fatalf("bootstrap data dir = %q, want %q", gotDataDir, cfg.DataDir)
+	}
+}
+
+func TestQueryLogWriterActivationErrorIsNoDuckLakeTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "empty metadata secret ref",
+			err:  fmt.Errorf("metadata store credentials: %w", errors.New("secret ref requires name and key")),
+			want: true,
+		},
+		{
+			name: "sts failure remains retryable",
+			err:  errors.New("STS AssumeRole for org \"org-a\": throttled"),
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := queryLogWriterActivationErrorIsNoDuckLakeTarget(tt.err); got != tt.want {
+				t.Fatalf("queryLogWriterActivationErrorIsNoDuckLakeTarget(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- treat query-log events for orgs missing from the config snapshot as no-target events
- classify deterministic empty metadata secret-ref activation errors as no-target events
- keep transient activation failures, such as STS failures, retryable

## Why
After #880 reached dev, the writer could load DuckLake, but it was stuck on an old Kafka event for a stale org whose Duckling CR no longer exists and whose config-store fallback has no metadata secret ref. Because the resolver returned a retryable error, the consumer never committed that event and could not reach newer events.

This maps that stale/no-target class to `ErrQueryLogNoDuckLakeTarget`, which the existing Kafka writer already drops and commits.

## Tests
- `go test -tags kubernetes . -run "TestQueryLogWriterActivationErrorIsNoDuckLakeTarget|TestRunQueryLogWriterBootstrapsBundledExtensions" -count=1`
- `go test ./server -run "TestQueryLogKafka|TestQueryLogDuckLakeEntryWriter|TestQueryLogDuckLakeDBDSNAllowsUnsignedExtensions" -count=1`
- `just lint`
