### PR TITLE
Fix query log introspection for attached DuckLake catalog

### DIFF
--- a/server/querylog.go
+++ b/server/querylog.go
@@ -505,11 +505,17 @@ func queryLogColumnExists(db *sql.DB, fullTableName, tableSchema, tableName, col
 }
 
 func queryLogColumnType(db *sql.DB, fullTableName, tableSchema, tableName, columnName string) (string, error) {
-	query := fmt.Sprintf("SELECT data_type FROM %s WHERE table_name = $1 AND column_name = $2", queryLogColumnsTable(fullTableName))
+	query := "SELECT data_type FROM information_schema.columns WHERE table_name = $1 AND column_name = $2"
 	args := []any{tableName, columnName}
+	nextParam := 3
 	if strings.TrimSpace(tableSchema) != "" {
-		query += " AND table_schema = $3"
+		query += fmt.Sprintf(" AND table_schema = $%d", nextParam)
 		args = append(args, tableSchema)
+		nextParam++
+	}
+	if catalogName := queryLogCatalogName(fullTableName); catalogName != "" {
+		query += fmt.Sprintf(" AND table_catalog = $%d", nextParam)
+		args = append(args, catalogName)
 	}
 
 	var colType string
@@ -517,12 +523,12 @@ func queryLogColumnType(db *sql.DB, fullTableName, tableSchema, tableName, colum
 	return colType, err
 }
 
-func queryLogColumnsTable(fullTableName string) string {
+func queryLogCatalogName(fullTableName string) string {
 	parts := strings.Split(fullTableName, ".")
 	if len(parts) == 3 {
-		return parts[0] + ".information_schema.columns"
+		return strings.TrimSpace(parts[0])
 	}
-	return "information_schema.columns"
+	return ""
 }
 
 func escapeSQLStringLiteral(s string) string {

--- a/server/querylog_test.go
+++ b/server/querylog_test.go
@@ -419,6 +419,33 @@ func TestEnsureQueryLogTableCreatesResourceUsageColumns(t *testing.T) {
 	}
 }
 
+func TestEnsureQueryLogTableWithAttachedCatalog(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("ATTACH ':memory:' AS ducklake"); err != nil {
+		t.Fatalf("attach ducklake catalog: %v", err)
+	}
+	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS ducklake.system"); err != nil {
+		t.Fatalf("create attached schema: %v", err)
+	}
+
+	if err := ensureQueryLogTable(db, "system", "query_log", "ducklake.system.query_log"); err != nil {
+		t.Fatalf("ensureQueryLogTable: %v", err)
+	}
+
+	got, err := queryLogColumnType(db, "ducklake.system.query_log", "system", "query_log", "cpu_time_s")
+	if err != nil {
+		t.Fatalf("queryLogColumnType(cpu_time_s): %v", err)
+	}
+	if got != "DOUBLE" {
+		t.Fatalf("expected cpu_time_s type DOUBLE, got %s", got)
+	}
+}
+
 func TestQueryLoggerFlushBatchPersistsOrgID(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix query_log column introspection for attached DuckLake catalogs by querying unqualified information_schema.columns and filtering table_catalog
- add a regression test for the writer target shape ducklake.system.query_log

## Diagnosis
The dev endpoint accepts both qualified and unqualified information_schema queries through Duckgres compatibility handling, but the query-log writer opens DuckDB directly. Direct DuckDB fails on ducklake.information_schema.columns for an attached catalog, which blocked ensureQueryLogTable before it could create system.query_log.

## Test plan
- go test ./server -run 'TestEnsureQueryLogTableWithAttachedCatalog|TestEnsureQueryLogTableCreatesResourceUsageColumns|TestUbigintToBigintMigrationViaDrop|TestQueryLogDuckLakeEntryWriter' -count=1\n- go test ./server -count=1\n- just lint