### PR TITLE
admin/ui: never let table cells wrap and grow rows

### DIFF
--- a/controlplane/admin/ui/src/components/ui/table.tsx
+++ b/controlplane/admin/ui/src/components/ui/table.tsx
@@ -40,7 +40,7 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
     <th
       ref={ref}
       className={cn(
-        "h-9 px-3 text-left align-middle text-xs font-medium uppercase tracking-wide text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        "h-9 whitespace-nowrap px-3 text-left align-middle text-xs font-medium uppercase tracking-wide text-muted-foreground [&:has([role=checkbox])]:pr-0",
         className,
       )}
       {...props}
@@ -51,7 +51,11 @@ TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
   ({ className, ...props }, ref) => (
-    <td ref={ref} className={cn("px-3 py-2 align-middle", className)} {...props} />
+    // whitespace-nowrap: cell content (UUIDs, hostnames, timestamps) must never
+    // wrap and grow the row — the Table wrapper is overflow-auto, so wide
+    // content horizontal-scrolls instead. Override per-cell via className when
+    // a column genuinely needs to wrap.
+    <td ref={ref} className={cn("whitespace-nowrap px-3 py-2 align-middle", className)} {...props} />
   ),
 );
 TableCell.displayName = "TableCell";


### PR DESCRIPTION
Org rows (and potentially any table) grew tall when long values like UUIDs line-wrapped inside a cell.

Fix at the single chokepoint: `whitespace-nowrap` on the base `TableCell`/`TableHead` primitives in `ui/table.tsx`. Every table in the admin UI (DataTable-backed and raw) renders through these, so no cell can ever wrap and inflate row height again. The `Table` wrapper is already `overflow-auto`, so oversized content degrades to horizontal scroll instead of taller rows. A column that genuinely needs wrapping can still opt back in via `className`.

Frontend-only, one file. Verified with `npm run build` and eyeballed against prod data via the dev proxy (Orgs UUIDs back to one line, dense rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)