### PR TITLE
admin: persist duckling_name through the warehouse upsert

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -399,6 +399,7 @@ func managedWarehouseUpsertColumns() []string {
 		// DB column name. Mismatching this against the actual column makes
 		// the ON CONFLICT … DO UPDATE clause throw 42703.
 		"duck_lake_version",
+		"duckling_name",
 		"warehouse_database_endpoint",
 		"warehouse_database_port",
 		"metadata_store_kind",

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -106,10 +106,11 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 
 	createdAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 	original := &configstore.ManagedWarehouse{
-		OrgID:     "analytics",
-		State:     configstore.ManagedWarehouseStatePending,
-		CreatedAt: createdAt,
-		UpdatedAt: createdAt,
+		OrgID:        "analytics",
+		DucklingName: "analytics",
+		State:        configstore.ManagedWarehouseStatePending,
+		CreatedAt:    createdAt,
+		UpdatedAt:    createdAt,
 		WarehouseDatabase: configstore.ManagedWarehouseDatabase{
 			Endpoint: "analytics-wh.cluster.example",
 		},
@@ -124,8 +125,11 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 
 	replacementCreatedAt := time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC)
 	stored, ok, err := apiStore.UpsertManagedWarehouse("analytics", &configstore.ManagedWarehouse{
-		CreatedAt:     replacementCreatedAt,
-		UpdatedAt:     replacementCreatedAt,
+		CreatedAt: replacementCreatedAt,
+		UpdatedAt: replacementCreatedAt,
+		// Changed vs the seeded row: the ON CONFLICT assignment-column list
+		// must carry duckling_name or this change is silently dropped.
+		DucklingName:  "analytics-renamed",
 		State:         configstore.ManagedWarehouseStateReady,
 		StatusMessage: "ready",
 		WarehouseDatabase: configstore.ManagedWarehouseDatabase{
@@ -151,6 +155,9 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 	}
 	if stored.MetadataStore.DatabaseName != "ducklake_metadata" {
 		t.Fatalf("expected updated metadata db name, got %q", stored.MetadataStore.DatabaseName)
+	}
+	if stored.DucklingName != "analytics-renamed" {
+		t.Fatalf("expected updated duckling_name analytics-renamed, got %q", stored.DucklingName)
 	}
 }
 

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -331,12 +331,21 @@ function WarehousePanel({
       setMsg({ kind: "err", text: "Duckling name is required." });
       return;
     }
+    // Send only fields that actually changed: the PUT is a merge-patch and
+    // the audit log records the body's keys as "changed", so carrying
+    // untouched fields would log phantom changes.
+    const body: Partial<ManagedWarehouse> = {};
+    if (image !== (data?.image ?? "")) body.image = image;
+    if (version !== (data?.ducklake_version ?? "")) body.ducklake_version = version;
+    if (ducklingNameInput !== (data?.duckling_name || ducklingName(orgId))) {
+      body.duckling_name = ducklingNameInput;
+    }
+    if (Object.keys(body).length === 0) {
+      setMsg({ kind: "ok", text: "No changes." });
+      return;
+    }
     try {
-      await update.mutateAsync({
-        image,
-        ducklake_version: version,
-        duckling_name: ducklingNameInput,
-      });
+      await update.mutateAsync(body);
       setMsg({ kind: "ok", text: "Saved." });
     } catch (e) {
       setMsg({ kind: "err", text: e instanceof Error ? e.message : "Save failed" });


### PR DESCRIPTION
Editing `duckling_name` in the admin UI silently reverted: the value passed strict-decode and the non-empty guard, merged onto the locked row — and then `PUT /orgs/:id/warehouse`'s `ON CONFLICT … DO UPDATE` dropped it, because the fixed assignment-column list (`managedWarehouseUpsertColumns()`) never gained `duckling_name` in #858. The handler returns the reloaded row, so the UI faithfully showed the unchanged stored value.

## Changes
- **Fix**: add `duckling_name` to the upsert assignment-column list (both `UpsertManagedWarehouse` and `MutateManagedWarehouse` share it).
- **Regression test**: the Postgres upsert test now changes `DucklingName` and asserts it persists — this fails without the fix (the in-memory fake can't catch it; only the real ON CONFLICT path does).
- **Audit accuracy**: the warehouse editor sent all three pinning fields on every save, so the audit detail (`changed: <body keys>`) always named `image, ducklake_version, duckling_name` even when one field was touched. The editor now sends only dirty fields, and a no-op save short-circuits client-side.

## Verification
- `go build -tags kubernetes ./...`, `go vet`, `gofmt` — clean.
- `npm run build` (tsc + vite) — clean.
- The Postgres-backed test runs in CI (needs the docker container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)