### PR TITLE
Fix Flight sessions defaulting outside DuckLake

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/observe"
+	"github.com/posthog/duckgres/server/sessionmeta"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -1050,7 +1051,24 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 	}
 	slog.Debug("Acquired DB connection from pool.", "user", username, "duration", time.Since(start))
 
-	// Initialize the session connection with username-specific state if needed.
+	sessionCfg, cfgErr := p.currentSessionConfig()
+	if cfgErr != nil {
+		_ = conn.Close()
+		p.mu.Lock()
+		p.reserved--
+		p.mu.Unlock()
+		return nil, nil, cfgErr
+	}
+
+	if err := initAttachedDuckLakeSessionMetadata(conn, db, sessionCfg); err != nil {
+		_ = conn.Close()
+		p.mu.Lock()
+		p.reserved--
+		p.mu.Unlock()
+		return nil, nil, err
+	}
+	// Initialize the session connection with username-specific state after any
+	// catalog setup; DuckLake metadata init restores the default search_path.
 	// Since the DB is shared, we must set session-local parameters here.
 	initSearchPath(conn, username)
 
@@ -1139,15 +1157,6 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 	}
 	session.lastUsed.Store(time.Now().UnixNano())
 
-	cfg, cfgErr := p.currentSessionConfig()
-	if cfgErr != nil {
-		_ = conn.Close()
-		p.mu.Lock()
-		p.reserved--
-		p.mu.Unlock()
-		return nil, nil, cfgErr
-	}
-
 	// In shared-warm (multi-tenant) mode the control plane drives credential
 	// refresh by re-activating the worker with a freshly-brokered STS payload
 	// before the current creds expire (see controlplane/janitor scheduler +
@@ -1168,7 +1177,7 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 	if p.sharedWarmMode {
 		stop = func() {}
 	} else {
-		stop = server.StartCredentialRefresh(conn, cfg.DuckLake, func() bool {
+		stop = server.StartCredentialRefresh(conn, sessionCfg.DuckLake, func() bool {
 			session.mu.Lock()
 			defer session.mu.Unlock()
 			return len(session.txns) > 0
@@ -1670,6 +1679,28 @@ func initSearchPath(conn *sql.Conn, username string) {
 			slog.Warn("Failed to set search_path for session.", "user", username, "error", err)
 		}
 	}
+}
+
+func initAttachedDuckLakeSessionMetadata(conn *sql.Conn, db *sql.DB, cfg server.Config) error {
+	initTimeout := cfg.SessionInitTimeout
+	if initTimeout == 0 {
+		initTimeout = server.DefaultSessionInitTimeout
+	}
+	initCtx, initCancel := context.WithTimeout(context.Background(), initTimeout)
+	defer initCancel()
+
+	executor := server.NewPinnedExecutor(conn, db)
+	duckLakeAttached, err := sessionmeta.HasAttachedCatalog(initCtx, executor, "ducklake")
+	if err != nil {
+		return fmt.Errorf("detect ducklake catalog attachment: %w", err)
+	}
+	if !duckLakeAttached {
+		return nil
+	}
+	if err := sessionmeta.InitSessionDatabaseMetadata(initCtx, executor, "ducklake"); err != nil {
+		return fmt.Errorf("initialize ducklake session metadata: %w", err)
+	}
+	return nil
 }
 
 func generateSessionToken() string {

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server"
 )
 
 func TestReapIdleRawSQLRollbackUsesBoundedContext(t *testing.T) {
@@ -208,6 +209,73 @@ func TestInitSearchPath(t *testing.T) {
 			t.Errorf("expected search_path 'myuser,main,memory.main', got %q", searchPath)
 		}
 	})
+}
+
+func TestCreateSessionDefaultsToAttachedDuckLakeCatalog(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	for _, stmt := range []string{
+		"ATTACH ':memory:' AS ducklake",
+		"CREATE SCHEMA ducklake.frozen_v1",
+		"CREATE TABLE ducklake.frozen_v1.persons_file_view (id INTEGER)",
+		"INSERT INTO ducklake.frozen_v1.persons_file_view VALUES (1)",
+		"CREATE SCHEMA ducklake.root",
+		"CREATE TABLE ducklake.root.user_scoped (id INTEGER)",
+		"INSERT INTO ducklake.root.user_scoped VALUES (1)",
+		"USE memory",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup %q: %v", stmt, err)
+		}
+	}
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		warmupDB:       db,
+		warmupDone:     make(chan struct{}),
+		cfg:            server.Config{SessionInitTimeout: time.Second},
+		maxSessions:    1,
+		sharedWarmMode: true,
+		activation:     &activatedTenantRuntime{payload: ActivationPayload{OrgID: "scenario-org"}, db: db},
+	}
+	close(pool.warmupDone)
+
+	session, _, err := pool.CreateSession("root", "", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	defer func() { _ = pool.DestroySession(session.ID) }()
+
+	var currentDB string
+	if err := session.Conn.QueryRowContext(context.Background(), "SELECT current_database()").Scan(&currentDB); err != nil {
+		t.Fatalf("current_database: %v", err)
+	}
+	if currentDB != "ducklake" {
+		t.Fatalf("current_database() = %q, want ducklake", currentDB)
+	}
+
+	var count int
+	if err := session.Conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM frozen_v1.persons_file_view").Scan(&count); err != nil {
+		t.Fatalf("unqualified frozen_v1 query should use ducklake catalog: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+
+	var userScopedCount int
+	if err := session.Conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM user_scoped").Scan(&userScopedCount); err != nil {
+		t.Fatalf("unqualified user schema query should preserve username search_path: %v", err)
+	}
+	if userScopedCount != 1 {
+		t.Fatalf("userScopedCount = %d, want 1", userScopedCount)
+	}
 }
 
 func TestCleanupSessionState(t *testing.T) {


### PR DESCRIPTION
## Summary
- initialize Flight worker sessions with DuckLake session metadata when the ducklake catalog is attached
- keep username search_path setup after catalog metadata initialization
- add regression coverage for unqualified frozen schema access and username schema resolution

## Tests
- go test ./duckdbservice -count=1
- just lint