### PR TITLE
Let DELETE /orgs/:id succeed after a completed deprovision

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -228,15 +228,26 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 func (s *gormAPIStore) DeleteOrg(name string) (bool, error) {
 	returnRows := int64(0)
 	err := s.db().Transaction(func(tx *gorm.DB) error {
-		// Deleting an org while its managed warehouse row still exists would
-		// cascade the row away and leak the Duckling CR + infra behind it. The
-		// warehouse must be deprovisioned (which removes the row) first.
-		var warehouses int64
-		if err := tx.Model(&configstore.ManagedWarehouse{}).Where("org_id = ?", name).Count(&warehouses).Error; err != nil {
+		// Deleting an org while a managed warehouse row is in a non-terminal
+		// state would leak the Duckling CR + AWS infra behind it, so those
+		// still block deletion. But deprovisioning does NOT remove the
+		// warehouse row — the provisioner tears the infra down and leaves the
+		// row in the terminal "deleted" state (controller.go reconcileDeleting).
+		// A "deleted" row means the infra is gone, so cascade it away here and
+		// let the org (and its unique database_name) be released. Without this,
+		// a fully deprovisioned org could never be deleted and its
+		// database_name would be squatted forever.
+		var liveWarehouses int64
+		if err := tx.Model(&configstore.ManagedWarehouse{}).
+			Where("org_id = ? AND state <> ?", name, configstore.ManagedWarehouseStateDeleted).
+			Count(&liveWarehouses).Error; err != nil {
 			return err
 		}
-		if warehouses > 0 {
+		if liveWarehouses > 0 {
 			return errWarehouseStillExists
+		}
+		if err := tx.Where("org_id = ?", name).Delete(&configstore.ManagedWarehouse{}).Error; err != nil {
+			return err
 		}
 		if err := tx.Where("org_id = ?", name).Delete(&configstore.OrgUser{}).Error; err != nil {
 			return err

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -161,6 +161,55 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 	}
 }
 
+func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics_db"}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	wh := &configstore.ManagedWarehouse{OrgID: "analytics", State: configstore.ManagedWarehouseStateReady}
+	if err := store.DB().Create(wh).Error; err != nil {
+		t.Fatalf("create warehouse: %v", err)
+	}
+
+	// A non-terminal warehouse row must still block org deletion — the infra is
+	// live and deleting the org would orphan the Duckling CR.
+	if _, err := apiStore.DeleteOrg("analytics"); err != errWarehouseStillExists {
+		t.Fatalf("DeleteOrg with a ready warehouse: got %v, want errWarehouseStillExists", err)
+	}
+
+	// Simulate a completed deprovision: the provisioner leaves the row behind in
+	// the terminal "deleted" state. The org must now delete, cascading the row
+	// away so the database_name is released (no longer squatted).
+	if err := store.DB().Model(&configstore.ManagedWarehouse{}).Where("org_id = ?", "analytics").
+		Update("state", configstore.ManagedWarehouseStateDeleted).Error; err != nil {
+		t.Fatalf("mark warehouse deleted: %v", err)
+	}
+	deleted, err := apiStore.DeleteOrg("analytics")
+	if err != nil {
+		t.Fatalf("DeleteOrg after deprovision: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected org row to be deleted")
+	}
+
+	var orgs, warehouses int64
+	store.DB().Model(&configstore.Org{}).Where("name = ?", "analytics").Count(&orgs)
+	store.DB().Model(&configstore.ManagedWarehouse{}).Where("org_id = ?", "analytics").Count(&warehouses)
+	if orgs != 0 {
+		t.Fatalf("expected org row gone, found %d", orgs)
+	}
+	if warehouses != 0 {
+		t.Fatalf("expected deleted warehouse row cascaded away, found %d", warehouses)
+	}
+
+	// The database_name is now free for reuse (no unique-index squat).
+	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db"}).Error; err != nil {
+		t.Fatalf("expected database_name to be reusable after org deletion: %v", err)
+	}
+}
+
 func TestMutateManagedWarehouseSerializesConcurrentWriters(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -86,9 +86,12 @@ func (s *fakeAPIStore) DeleteOrg(name string) (bool, error) {
 	if _, ok := s.orgs[name]; !ok {
 		return false, nil
 	}
-	if _, ok := s.warehouses[name]; ok {
+	// Only a non-terminal warehouse row blocks deletion; a "deleted" row (infra
+	// torn down by the provisioner) is cascaded away so the name is released.
+	if wh, ok := s.warehouses[name]; ok && wh.State != configstore.ManagedWarehouseStateDeleted {
 		return false, errWarehouseStillExists
 	}
+	delete(s.warehouses, name)
 	delete(s.orgs, name)
 	return true, nil
 }
@@ -1150,6 +1153,29 @@ func TestDeleteOrgSucceedsAfterWarehouseRemoved(t *testing.T) {
 	}
 	if _, ok := store.orgs["analytics"]; ok {
 		t.Fatal("expected org to be deleted once the warehouse is gone")
+	}
+}
+
+func TestDeleteOrgCascadesDeletedWarehouse(t *testing.T) {
+	store := newFakeAPIStore()
+	seedOrgWithWarehouse(store, "analytics")
+	// Simulate a completed deprovision: the provisioner leaves the warehouse
+	// row behind in the terminal "deleted" state rather than removing it.
+	store.warehouses["analytics"].State = configstore.ManagedWarehouseStateDeleted
+	router := newTestAPIRouter(store)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/orgs/analytics", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if _, ok := store.orgs["analytics"]; ok {
+		t.Fatal("expected org to be deleted once its warehouse is fully deprovisioned")
+	}
+	if _, ok := store.warehouses["analytics"]; ok {
+		t.Fatal("expected the deleted warehouse row to be cascaded away")
 	}
 }
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -171,6 +171,7 @@ func (s *fakeStore) SetWarehouseDeleting(orgID string, expectedState configstore
 		return fmt.Errorf("warehouse %q not in expected state %q", orgID, expectedState)
 	}
 	w.State = configstore.ManagedWarehouseStateDeleting
+	w.StatusMessage = "Deprovisioning..."
 	return nil
 }
 
@@ -409,6 +410,11 @@ func TestDeprovisionReadyWarehouse(t *testing.T) {
 	}
 	if store.warehouses["analytics"].State != configstore.ManagedWarehouseStateDeleting {
 		t.Fatalf("expected deleting state, got %q", store.warehouses["analytics"].State)
+	}
+	// The status_message flips to a live "Deprovisioning..." so a client polling
+	// warehouse/status sees progress rather than the stale ready message.
+	if got := store.warehouses["analytics"].StatusMessage; got != "Deprovisioning..." {
+		t.Fatalf("expected status_message %q, got %q", "Deprovisioning...", got)
 	}
 }
 

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -229,9 +229,17 @@ func (s *gormStore) IsDatabaseNameAvailable(name string) (bool, error) {
 // SetWarehouseDeleting atomically transitions a warehouse from expectedState to deleting.
 // Returns gorm.ErrRecordNotFound if no warehouse exists, or an error if the CAS fails.
 func (s *gormStore) SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error {
+	// Also stamp a status_message so a client polling warehouse/status sees a
+	// live "Deprovisioning..." message during teardown — mirroring how the
+	// provisioning phases stamp status_message. Without this the message stays
+	// stale (e.g. "Infrastructure ready") until the provisioner flips it to
+	// "Resources deleted" at the very end.
 	result := s.cs.DB().Model(&configstore.ManagedWarehouse{}).
 		Where("org_id = ? AND state = ?", orgID, expectedState).
-		Update("state", configstore.ManagedWarehouseStateDeleting)
+		Updates(map[string]interface{}{
+			"state":          configstore.ManagedWarehouseStateDeleting,
+			"status_message": "Deprovisioning...",
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -116,7 +116,11 @@ client-go:
   cross-tenant read is denied.
 - **lifecycle** — deprovision → `warehouse=deleted` → the Crossplane Duckling
   CR **fully** deletes (`kubectl wait --for=delete`, asserting the finalizer
-  cascade that drops the cnpg role+db completed). Same-id **re-provision** is
+  cascade that drops the cnpg role+db completed). Then `DELETE /orgs/:id`
+  cascades the terminal `deleted` warehouse row + the org row away and the org's
+  `database_name` becomes available again (`database-name/check` flips
+  `false`→`true`) — the regression net for the name being squatted forever after
+  a completed deprovision. Same-id **re-provision** is
   *not* done in-Job: a clean slate needs DROPping a possibly-stranded cnpg role,
   which only `run.sh` (on the runner, with cnpg-shards exec) can do — so the
   stranded-cnpg-role regression (#649/#650/#11518/#11522) is covered **across

--- a/tests/e2e-mw-dev/README.md
+++ b/tests/e2e-mw-dev/README.md
@@ -116,7 +116,10 @@ client-go:
   cross-tenant read is denied.
 - **lifecycle** — deprovision → `warehouse=deleted` → the Crossplane Duckling
   CR **fully** deletes (`kubectl wait --for=delete`, asserting the finalizer
-  cascade that drops the cnpg role+db completed). Then `DELETE /orgs/:id`
+  cascade that drops the cnpg role+db completed). Right after the deprovision
+  202 the warehouse status is watchable — state `deleting` with
+  `status_message="Deprovisioning..."` — so a UI can poll `warehouse/status`
+  until `deleted`. Then `DELETE /orgs/:id`
   cascades the terminal `deleted` warehouse row + the org row away and the org's
   `database_name` becomes available again (`database-name/check` flips
   `false`→`true`) — the regression net for the name being squatted forever after

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -54,7 +54,9 @@
 #                  columns (GET /api/v1/models/:model), redacting secret-bearing
 #                  columns (org_users.password must never appear in the UI).
 #   lifecycle    : deprovision → warehouse deleted → Duckling CR fully gone
-#                  (finalizer cascade that drops the cnpg role+db completed).
+#                  (finalizer cascade that drops the cnpg role+db completed),
+#                  then DELETE /orgs/:id cascades the terminal deleted-warehouse
+#                  row + org row away and frees the database_name (no squat).
 #                  Same-id re-provision is covered across runs by run.sh, not
 #                  in-Job — see lifecycle_teardown_cnpg for why.
 #
@@ -2169,6 +2171,22 @@ lifecycle_teardown_cnpg() { # org
   if ! "$KUBECTL" -n ducklings wait --for=delete "duckling/$1" --timeout=420s >/dev/null 2>&1; then
     fail "Duckling CR $1 did not fully delete within 420s (finalizer/cnpg cascade stuck)"
   fi
+
+  # Deprovision leaves the org row + a terminal "deleted" warehouse row behind;
+  # DELETE /orgs/:id must now cascade both away and release the org's
+  # database_name. Without this the name is squatted forever (org row's unique
+  # database_name index survives, so no future org can reuse it).
+  dbname="$(curl -fsS -H "$H" "$API/api/v1/orgs/$1" | jq -r '.database_name // empty')"
+  [ -n "$dbname" ] || fail "could not read database_name for $1 before delete"
+  [ "$(curl -fsS -H "$H" "$API/api/v1/database-name/check?name=$dbname" | jq -r '.available')" = "false" ] \
+    || fail "database_name $dbname unexpectedly free while org $1 still exists"
+  curl -fsS -X DELETE -H "$H" "$API/api/v1/orgs/$1" >/dev/null \
+    || fail "DELETE /orgs/$1 failed after a completed deprovision (name would stay squatted)"
+  if api_get "$1" warehouse/status >/dev/null 2>&1; then
+    fail "warehouse row for $1 survived org deletion — deleted-state row not cascaded"
+  fi
+  [ "$(curl -fsS -H "$H" "$API/api/v1/database-name/check?name=$dbname" | jq -r '.available')" = "true" ] \
+    || fail "database_name $dbname still squatted after org deletion"
 }
 
 # ---- cnpg duckling: cnpg-shard metadata + DuckLake ------------------------
@@ -2563,7 +2581,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg) + isolation + lifecycle-teardown, on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -2167,6 +2167,22 @@ tenant_isolation() { # orgA pwA orgB pwB
 lifecycle_teardown_cnpg() { # org
   log "lifecycle: deprovision $1 + assert Duckling CR fully deleted"
   api_post "$1" deprovision >/dev/null
+  # The status endpoint is watchable throughout teardown: right after the 202
+  # the warehouse reports a deprovisioning state (deleting, or deleted if the
+  # async provisioner already finished), never still-ready — so /data-ops can
+  # poll warehouse/status until it reaches "deleted", then send the delete.
+  # While deleting, status_message reads "Deprovisioning..." (the deprovision
+  # analogue of the provisioning-phase messages) rather than a stale ready line.
+  status_json="$(api_get "$1" warehouse/status)"
+  st="$(printf '%s' "$status_json" | jq -r '.state')"
+  msg="$(printf '%s' "$status_json" | jq -r '.status_message')"
+  case "$st" in
+    deleting)
+      [ "$msg" = "Deprovisioning..." ] \
+        || fail "warehouse $1 deleting but status_message=$msg (expected 'Deprovisioning...')";;
+    deleted) ;;
+    *) fail "warehouse $1 status=$st right after deprovision (expected deleting/deleted — status not watchable)";;
+  esac
   wait_state "$1" deleted 600
   if ! "$KUBECTL" -n ducklings wait --for=delete "duckling/$1" --timeout=420s >/dev/null 2>&1; then
     fail "Duckling CR $1 did not fully delete within 420s (finalizer/cnpg cascade stuck)"

--- a/tests/e2e-mw-dev/run.sh
+++ b/tests/e2e-mw-dev/run.sh
@@ -349,9 +349,14 @@ cmd_teardown() {
       for _ in $(seq 1 30); do
         gone=1
         for org in $(ci_orgs "$PR_NUMBER"); do
+          # A 404 here means the org was fully deleted (row cascaded away, e.g.
+          # the lifecycle test's DELETE /orgs/:id) — that counts as gone. Under
+          # `set -euo pipefail` an unguarded curl -f 404 (exit 22) would abort
+          # teardown, so tolerate it and let the empty-state check below treat
+          # it as gone.
           st="$(curl -fsS -H "X-Duckgres-Internal-Secret: $secret" \
             "http://localhost:18080/api/v1/orgs/$org/warehouse/status" 2>/dev/null \
-            | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')"
+            | sed -n 's/.*"state":"\([^"]*\)".*/\1/p' || true)"
           [ "$st" = "deleted" ] || [ -z "$st" ] || gone=0
         done
         [ "$gone" = 1 ] && break


### PR DESCRIPTION
Two changes to the managed-warehouse deprovision → delete flow so `/data-ops` can fully release a warehouse name.

**1. `DELETE /orgs/:id` works after a completed deprovision.** Deprovisioning leaves the config-store row behind in the terminal `deleted` state (the provisioner tears down infra but never removes the row). `DeleteOrg` counted **all** warehouse rows — including that `deleted` one — and 409'd, so a fully deprovisioned org could never be deleted and its unique `database_name` stayed squatted forever. It now only blocks on a **non-terminal** warehouse row; a `deleted` row is cascaded away in the same transaction so the org and its name are released.

**2. Watchable "Deprovisioning..." status.** Deprovision only flipped state to `deleting` and left `status_message` stale until the very end. `SetWarehouseDeleting` now also stamps `status_message="Deprovisioning..."`, mirroring the provisioning phases — so `/data-ops` can poll `warehouse/status` and show a live status the same way it does while provisioning, then send the delete once state reaches `deleted`.

**Why:** clicking "deprovision" on `/data-ops` tore down the warehouse but the org row survived, squatting the name forever. The intended flow — deprovision, watch status until done, then delete the org — now works end to end on the duckgres side. (The `/data-ops` UI still needs a separate change to actually poll + issue the delete — that lives in the posthog repo.)

## Testing
- Config-store test: `DeleteOrg` blocks on a `ready` warehouse, succeeds once it flips to `deleted`, org + warehouse rows gone, `database_name` reusable.
- Deprovision handler test asserts `status_message` flips to `Deprovisioning...`.
- e2e `lifecycle_teardown_cnpg`: status is watchable right after the 202 (`deleting` + `Deprovisioning...`), then `DELETE /orgs/:id` succeeds and `database-name/check` flips `false`→`true`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A1M678WCV/p1783354422552539)*
