### PR TITLE
[codex] Fix scenario runner dev compatibility

### DIFF
--- a/tests/scenario/dbt/runner_test.go
+++ b/tests/scenario/dbt/runner_test.go
@@ -78,17 +78,24 @@ func TestExecutorRunsCommandsCapturesLogsAndCopiesTargetArtifacts(t *testing.T) 
 	if !containsAll(first.Args, "--project-dir", projectDir, "--profiles-dir", projectDir) {
 		t.Fatalf("dbt args = %#v, want project/profiles dirs", first.Args)
 	}
-	if targetPath := argValue(first.Args, "--target-path"); targetPath != filepath.Join(executor.OutputDir(), "dbt", "target") {
-		t.Fatalf("target path = %q", targetPath)
+	if targetPath := argValue(first.Args, "--target-path"); targetPath != "" {
+		t.Fatalf("debug target path = %q, want omitted because dbt debug does not support --target-path", targetPath)
 	}
 	if logPath := argValue(first.Args, "--log-path"); logPath != filepath.Join(executor.OutputDir(), "dbt", "logs") {
 		t.Fatalf("log path = %q", logPath)
 	}
+	runReq := runner.requests[1]
+	if targetPath := argValue(runReq.Args, "--target-path"); targetPath != filepath.Join(executor.OutputDir(), "dbt", "target") {
+		t.Fatalf("run target path = %q", targetPath)
+	}
 	if envValue(first.Env, "DUCKGRES_DBT_HOST") != "scenario-org.dev.example" {
 		t.Fatalf("DUCKGRES_DBT_HOST = %q", envValue(first.Env, "DUCKGRES_DBT_HOST"))
 	}
-	if envValue(first.Env, "PGHOSTADDR") != "10.0.0.10" {
-		t.Fatalf("PGHOSTADDR = %q", envValue(first.Env, "PGHOSTADDR"))
+	if envValue(first.Env, "DUCKGRES_DBT_HOSTADDR") != "" {
+		t.Fatal("expected command environment to avoid DUCKGRES_DBT_HOSTADDR because dbt-postgres expects hostaddr to be numeric")
+	}
+	if envValue(first.Env, "PGHOSTADDR") != "" {
+		t.Fatal("expected command environment to avoid PGHOSTADDR because dbt-postgres expects hostaddr to be numeric")
 	}
 	if envValue(first.Env, "DBT_ENV_SECRET_DUCKGRES_PASSWORD") != "root-password" {
 		t.Fatal("expected command environment to include provision password as a dbt secret")

--- a/tests/scenario/dbt/steps.go
+++ b/tests/scenario/dbt/steps.go
@@ -151,17 +151,21 @@ func (e *Executor) ExecuteStep(ctx context.Context, step core.Step) error {
 
 	commandsRun := 0
 	for _, command := range spec.Commands {
+		args := append([]string{}, command.Args...)
+		args = append(args,
+			"--project-dir", spec.ProjectDir,
+			"--profiles-dir", spec.ProfilesDir,
+			"--log-path", filepath.Join(dbtDir, "logs"),
+		)
+		if command.Name != "debug" {
+			args = append(args, "--target-path", filepath.Join(dbtDir, "target"))
+		}
 		req := CommandRequest{
 			Binary:      spec.DBTBinary,
 			CommandName: command.Name,
-			Args: append(append([]string{}, command.Args...),
-				"--project-dir", spec.ProjectDir,
-				"--profiles-dir", spec.ProfilesDir,
-				"--target-path", filepath.Join(dbtDir, "target"),
-				"--log-path", filepath.Join(dbtDir, "logs"),
-			),
-			Env: e.commandEnv(spec),
-			Dir: spec.ProjectDir,
+			Args:        args,
+			Env:         e.commandEnv(spec),
+			Dir:         spec.ProjectDir,
 		}
 		result := e.commandRunner.Run(ctx, req)
 		commandsRun++
@@ -241,7 +245,6 @@ func (e *Executor) commandEnv(spec stepSpec) []string {
 	}
 	return []string{
 		"DUCKGRES_DBT_HOST=" + spec.OrgID + e.connection.SNISuffix,
-		"DUCKGRES_DBT_HOSTADDR=" + e.connection.HostAddr,
 		"DUCKGRES_DBT_PORT=" + strconv.Itoa(port),
 		"DUCKGRES_DBT_USER=" + spec.Username,
 		"DBT_ENV_SECRET_DUCKGRES_PASSWORD=" + spec.Password,
@@ -249,7 +252,6 @@ func (e *Executor) commandEnv(spec stepSpec) []string {
 		"DUCKGRES_DBT_SCHEMA=" + spec.Schema,
 		"DUCKGRES_DBT_SSLMODE=" + spec.SSLMode,
 		"DUCKGRES_DBT_CONNECT_TIMEOUT=" + strconv.Itoa(connectTimeout),
-		"PGHOSTADDR=" + e.connection.HostAddr,
 	}
 }
 

--- a/tests/scenario/runner_test.go
+++ b/tests/scenario/runner_test.go
@@ -153,6 +153,7 @@ func TestProvisionSmokeScenarioUsesRunUniqueSupportedSteps(t *testing.T) {
 	if databaseName == "scenario_smoke" || !strings.Contains(databaseName, "scenario_smoke_") {
 		t.Fatalf("database_name = %q, want run-unique templated database", databaseName)
 	}
+	requireScenarioDefaultTeamID(t, request)
 }
 
 func TestFrozenSuccessScenariosUseValidProvisioningSlugs(t *testing.T) {
@@ -187,6 +188,13 @@ func TestFrozenSuccessScenariosUseValidProvisioningSlugs(t *testing.T) {
 				orgID, _ := step.With["org_id"].(string)
 				if orgID == "" || len(orgID) > 35 {
 					t.Fatalf("step %s org_id = %q, want valid provisioning slug of at most 35 chars", step.ID, orgID)
+				}
+				if step.Type == provision.StepTypeProvisionWarehouse {
+					request, ok := step.With["request"].(map[string]any)
+					if !ok {
+						t.Fatalf("provision request = %#v, want map", step.With["request"])
+					}
+					requireScenarioDefaultTeamID(t, request)
 				}
 			}
 		})
@@ -225,6 +233,11 @@ func TestProvisionRejectionScenarioUsesExpectedProvisionFailure(t *testing.T) {
 	if got := strings.Join(expected.Contains, "\n"); !strings.Contains(got, "HTTP 400") || !strings.Contains(got, "slug of at most 35 characters") {
 		t.Fatalf("expected error contains = %#v, want HTTP 400 and slug limit", expected.Contains)
 	}
+	request, ok := provisionStep.With["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("provision request = %#v, want map", provisionStep.With["request"])
+	}
+	requireScenarioDefaultTeamID(t, request)
 }
 
 func TestFrozenMetadataScenarioRequiresDatasetURI(t *testing.T) {
@@ -440,6 +453,17 @@ func dispatchSupports(stepType string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func requireScenarioDefaultTeamID(t *testing.T, request map[string]any) {
+	t.Helper()
+	defaultTeamID, ok := request["default_team_id"]
+	if !ok {
+		t.Fatal("provision request should include default_team_id")
+	}
+	if fmt.Sprint(defaultTeamID) != "1" {
+		t.Fatalf("default_team_id = %#v, want numeric 1", defaultTeamID)
 	}
 }
 

--- a/tests/scenario/scenarios/posthog_frozen_dbt.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_dbt.yaml
@@ -9,6 +9,7 @@ steps:
       org_id: scenario-frozen-dbt-${run_id_token}
       request:
         database_name: scenario_frozen_dbt_${run_id_token}
+        default_team_id: 1
         metadata_store:
           type: cnpg-shard
         ducklake:

--- a/tests/scenario/scenarios/posthog_frozen_metadata.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_metadata.yaml
@@ -9,6 +9,7 @@ steps:
       org_id: scenario-frozen-${run_id_token}
       request:
         database_name: scenario_frozen_${run_id_token}
+        default_team_id: 1
         metadata_store:
           type: cnpg-shard
         ducklake:

--- a/tests/scenario/scenarios/posthog_frozen_perf.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_perf.yaml
@@ -10,6 +10,7 @@ steps:
       org_id: scenario-frozen-perf-${run_id_token}
       request:
         database_name: scenario_frozen_perf_${run_id_token}
+        default_team_id: 1
         metadata_store:
           type: cnpg-shard
         ducklake:

--- a/tests/scenario/scenarios/provision_rejection.yaml
+++ b/tests/scenario/scenarios/provision_rejection.yaml
@@ -12,6 +12,7 @@ steps:
       org_id: scenario-reject-${run_id_compact}
       request:
         database_name: scenario_reject_${run_id_token}
+        default_team_id: 1
         metadata_store:
           type: cnpg-shard
         ducklake:

--- a/tests/scenario/scenarios/provision_smoke.yaml
+++ b/tests/scenario/scenarios/provision_smoke.yaml
@@ -7,6 +7,7 @@ steps:
       org_id: scenario-smoke-${run_id_token}
       request:
         database_name: scenario_smoke_${run_id_token}
+        default_team_id: 1
         metadata_store:
           type: cnpg-shard
         ducklake:

--- a/tests/scenario/sql/steps.go
+++ b/tests/scenario/sql/steps.go
@@ -370,6 +370,9 @@ func IsTransientStartupError(err error) bool {
 		"failed to start",
 		"spawn sized worker",
 		"failed to detect attached catalogs",
+		"eof",
+		"connection reset by peer",
+		"i/o timeout",
 	} {
 		if strings.Contains(msg, marker) {
 			return true

--- a/tests/scenario/sql/steps_test.go
+++ b/tests/scenario/sql/steps_test.go
@@ -77,6 +77,162 @@ func TestExecutorRetriesTransientStartupErrors(t *testing.T) {
 	}
 }
 
+func TestExecutorRetriesEOFStartupErrors(t *testing.T) {
+	provisionState := provision.NewState()
+	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
+		Org:      "scenario-org",
+		Username: "root",
+		Password: "root-password",
+	})
+	var attempts int
+	driver := &fakeDriver{
+		executeFunc: func(context.Context, QueryRequest) (QueryResult, error) {
+			attempts++
+			if attempts == 1 {
+				return QueryResult{}, errors.New("EOF")
+			}
+			return QueryResult{Rows: 1}, nil
+		},
+	}
+	executor := NewExecutor(ExecutorConfig{
+		ProvisionState: provisionState,
+		Connection: ConnectionConfig{
+			HostAddr:  "10.0.0.10",
+			SNISuffix: ".dev.example",
+			Port:      5432,
+			SSLMode:   "require",
+		},
+		Driver: driver,
+		Retry: RetryConfig{
+			MaxAttempts:  2,
+			RetryBackoff: time.Millisecond,
+			Sleep: func(context.Context, time.Duration) error {
+				return nil
+			},
+		},
+	})
+
+	err := executor.ExecuteStep(context.Background(), core.Step{
+		ID:   "setup_frozen_views",
+		Type: StepTypeSQL,
+		With: map[string]any{
+			"org_id":  "scenario-org",
+			"catalog": "ducklake",
+			"sql":     "CREATE VIEW frozen_v1.events_file_view AS SELECT 1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestExecutorRetriesConnectionResetStartupErrors(t *testing.T) {
+	provisionState := provision.NewState()
+	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
+		Org:      "scenario-org",
+		Username: "root",
+		Password: "root-password",
+	})
+	var attempts int
+	driver := &fakeDriver{
+		executeFunc: func(context.Context, QueryRequest) (QueryResult, error) {
+			attempts++
+			if attempts == 1 {
+				return QueryResult{}, errors.New("read tcp 127.0.0.1:5432: read: connection reset by peer")
+			}
+			return QueryResult{Rows: 1}, nil
+		},
+	}
+	executor := NewExecutor(ExecutorConfig{
+		ProvisionState: provisionState,
+		Connection: ConnectionConfig{
+			HostAddr:  "10.0.0.10",
+			SNISuffix: ".dev.example",
+			Port:      5432,
+			SSLMode:   "require",
+		},
+		Driver: driver,
+		Retry: RetryConfig{
+			MaxAttempts:  2,
+			RetryBackoff: time.Millisecond,
+			Sleep: func(context.Context, time.Duration) error {
+				return nil
+			},
+		},
+	})
+
+	err := executor.ExecuteStep(context.Background(), core.Step{
+		ID:   "setup_frozen_views",
+		Type: StepTypeSQL,
+		With: map[string]any{
+			"org_id":  "scenario-org",
+			"catalog": "ducklake",
+			"sql":     "CREATE VIEW frozen_v1.events_file_view AS SELECT 1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestExecutorRetriesIOTimeoutStartupErrors(t *testing.T) {
+	provisionState := provision.NewState()
+	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
+		Org:      "scenario-org",
+		Username: "root",
+		Password: "root-password",
+	})
+	var attempts int
+	driver := &fakeDriver{
+		executeFunc: func(context.Context, QueryRequest) (QueryResult, error) {
+			attempts++
+			if attempts == 1 {
+				return QueryResult{}, errors.New("read tcp 127.0.0.1:5432: i/o timeout")
+			}
+			return QueryResult{Rows: 1}, nil
+		},
+	}
+	executor := NewExecutor(ExecutorConfig{
+		ProvisionState: provisionState,
+		Connection: ConnectionConfig{
+			HostAddr:  "10.0.0.10",
+			SNISuffix: ".dev.example",
+			Port:      5432,
+			SSLMode:   "require",
+		},
+		Driver: driver,
+		Retry: RetryConfig{
+			MaxAttempts:  2,
+			RetryBackoff: time.Millisecond,
+			Sleep: func(context.Context, time.Duration) error {
+				return nil
+			},
+		},
+	})
+
+	err := executor.ExecuteStep(context.Background(), core.Step{
+		ID:   "setup_frozen_views",
+		Type: StepTypeSQL,
+		With: map[string]any{
+			"org_id":  "scenario-org",
+			"catalog": "ducklake",
+			"sql":     "CREATE VIEW frozen_v1.events_file_view AS SELECT 1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
 func TestExecutorDoesNotRetryNonTransientSQLErrors(t *testing.T) {
 	provisionState := provision.NewState()
 	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{


### PR DESCRIPTION
## Summary

- Add `default_team_id` to scenario provisioning requests so dev accepts new-org provision scenarios.
- Make dbt scenario execution compatible with `dbt debug` and dbt-postgres host handling.
- Retry additional transient SQL startup disconnects seen during scenario setup.

## Validation

- `go test ./tests/scenario/... -count=1`
- `just lint`
- Live dev scenario checks:
  - Provision rejection scenario passed.
  - Provision success scenario passed.
  - Frozen metadata scenario passed.
  - Frozen perf scenario completed and recorded query-level success/failure results.
  - Frozen dbt scenario now passes provisioning, setup, and `dbt debug`; `dbt run` reaches the model workload but the final aggregate exceeds the scenario timeout. Cleanup still succeeds.

## Notes

The remaining frozen dbt timeout appears to be workload/runtime capacity, not scenario runner wiring. This PR keeps that failure visible instead of weakening the scenario.
