### PR TITLE
[codex] Add worker-local query log batching

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -606,7 +606,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	sm.mu.Lock()
 	if sm.lifecycle.isClosed() {
 		sm.mu.Unlock()
-		sm.cleanupUnregisteredWorkerSession(worker, session.SessionToken)
+		sm.cleanupUnregisteredWorkerSession(worker, session)
 		return 0, nil, ErrSessionManagerDraining
 	}
 	sm.sessions[pid] = session
@@ -632,13 +632,16 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 	return pid, executor, nil
 }
 
-func (sm *SessionManager) cleanupUnregisteredWorkerSession(worker *ManagedWorker, sessionToken string) {
+func (sm *SessionManager) cleanupUnregisteredWorkerSession(worker *ManagedWorker, session *ManagedSession) {
+	if session.Executor != nil {
+		_ = session.Executor.Close()
+	}
 	if worker != nil {
 		select {
 		case <-worker.done:
 		default:
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := worker.DestroySession(ctx, sessionToken); err != nil {
+			if err := worker.DestroySession(ctx, session.SessionToken); err != nil {
 				sm.log.Warn("Failed to destroy unregistered worker session during drain.", "worker", worker.ID, "error", err)
 			}
 			cancel()

--- a/controlplane/session_mgr_drain_test.go
+++ b/controlplane/session_mgr_drain_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -381,10 +382,12 @@ func (l *blockingAcquireLimiter) Acquire(ctx context.Context, request connection
 }
 
 type blockingCreateSessionFlightClient struct {
-	createStarted chan struct{}
-	allowCreate   chan struct{}
-	startOnce     sync.Once
-	destroyCalls  atomic.Int32
+	createStarted   chan struct{}
+	allowCreate     chan struct{}
+	createSucceeded chan struct{}
+	startOnce       sync.Once
+	successOnce     sync.Once
+	destroyCalls    atomic.Int32
 }
 
 func (c *blockingCreateSessionFlightClient) DoAction(ctx context.Context, action *flight.Action, opts ...grpc.CallOption) (flight.FlightService_DoActionClient, error) {
@@ -482,6 +485,11 @@ func (c *blockingCreateSessionActionClient) Recv() (*flight.Result, error) {
 		return nil, c.ctx.Err()
 	}
 	c.sent = true
+	c.client.successOnce.Do(func() {
+		if c.client.createSucceeded != nil {
+			close(c.client.createSucceeded)
+		}
+	})
 	return &flight.Result{Body: []byte(`{"session_token":"session-1"}`)}, nil
 }
 
@@ -710,9 +718,11 @@ func TestDestroyAllSessions_ReleasesAllLeasesAndClearsSessions(t *testing.T) {
 }
 
 func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T) {
+	queryLogForwardersBefore := countFlightExecutorQueryLogForwarders()
 	flightClient := &blockingCreateSessionFlightClient{
-		createStarted: make(chan struct{}),
-		allowCreate:   make(chan struct{}),
+		createStarted:   make(chan struct{}),
+		allowCreate:     make(chan struct{}),
+		createSucceeded: make(chan struct{}),
 	}
 	lease := &countingConnectionLease{}
 	worker := &ManagedWorker{
@@ -723,6 +733,13 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 	pool := &blockingCreateSessionPool{worker: worker}
 	sm := NewSessionManager(pool, nil)
 	sm.SetConnectionLimiter(&blockingCreateSessionLimiter{lease: lease})
+
+	registrationLocked := false
+	defer func() {
+		if registrationLocked {
+			sm.mu.Unlock()
+		}
+	}()
 
 	createErr := make(chan error, 1)
 	go func() {
@@ -735,6 +752,14 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for CreateSession RPC to start")
 	}
+	sm.mu.Lock()
+	registrationLocked = true
+	close(flightClient.allowCreate)
+	select {
+	case <-flightClient.createSucceeded:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker CreateSession to succeed")
+	}
 
 	destroyDone := make(chan struct{})
 	go func() {
@@ -742,12 +767,13 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 		close(destroyDone)
 	}()
 	waitForSessionManagerDraining(t, sm)
-	close(flightClient.allowCreate)
+	sm.mu.Unlock()
+	registrationLocked = false
 
 	select {
 	case err := <-createErr:
-		if err == nil {
-			t.Fatal("expected in-flight CreateSession to fail once draining starts")
+		if !errors.Is(err, ErrSessionManagerDraining) {
+			t.Fatalf("CreateSessionWithProtocol error = %v, want %v", err, ErrSessionManagerDraining)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for CreateSession to return")
@@ -763,6 +789,10 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 	if got := lease.releases.Load(); got != 1 {
 		t.Fatalf("expected acquired lease to be released once, got %d", got)
 	}
+	if got := flightClient.destroyCalls.Load(); got != 1 {
+		t.Fatalf("expected worker session to be destroyed once, got %d", got)
+	}
+	waitForFlightExecutorQueryLogForwardersAtMost(t, queryLogForwardersBefore)
 }
 
 func TestDestroyAllSessionsWaitsForCreateBlockedInLimiterAcquire(t *testing.T) {
@@ -947,6 +977,24 @@ func waitForSessionManagerDraining(t *testing.T, sm *SessionManager) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("timed out waiting for session manager to start draining")
+}
+
+func waitForFlightExecutorQueryLogForwardersAtMost(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := countFlightExecutorQueryLogForwarders(); got <= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("flight executor query-log forwarder count = %d, want <= %d", countFlightExecutorQueryLogForwarders(), want)
+}
+
+func countFlightExecutorQueryLogForwarders() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "(*FlightExecutor).queryLogForwardLoop")
 }
 
 func countEvents(events []string, want string) int {

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -493,6 +493,28 @@ func (h *FlightSQLHandler) doReleaseQueryHandle(body []byte, stream flight.Fligh
 	return sendActionResult(stream, &flight.Result{Body: resp})
 }
 
+func (h *FlightSQLHandler) doLogQuery(body []byte, stream flight.FlightService_DoActionServer) error {
+	var req server.WorkerQueryLogPayload
+	if err := json.Unmarshal(body, &req); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid LogQuery request: %v", err)
+	}
+	if err := h.pool.validateControlMetadata(req.WorkerControlMetadata); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "stale worker owner: %v", err)
+	}
+	if err := h.pool.LogQueryEntries(req.Entries); err != nil {
+		if drainErr := workerDrainingStatus(err); drainErr != nil {
+			return drainErr
+		}
+		if errors.Is(err, ErrQueryLogRejected) {
+			return status.Errorf(codes.FailedPrecondition, "log query: %v", err)
+		}
+		return status.Errorf(codes.Internal, "log query: %v", err)
+	}
+
+	resp, _ := json.Marshal(map[string]bool{"ok": true})
+	return sendActionResult(stream, &flight.Result{Body: resp})
+}
+
 // Flight SQL method implementations
 
 func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd flightsql.StatementQuery,

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -501,12 +501,27 @@ func (h *FlightSQLHandler) doLogQuery(body []byte, stream flight.FlightService_D
 	if err := h.pool.validateControlMetadata(req.WorkerControlMetadata); err != nil {
 		return status.Errorf(codes.FailedPrecondition, "stale worker owner: %v", err)
 	}
-	if err := h.pool.LogQueryEntries(req.Entries); err != nil {
+	finishDrain, err := h.pool.beginDrainWork(true)
+	if drainErr := workerDrainingStatus(err); drainErr != nil {
+		return drainErr
+	}
+	if err != nil {
+		return status.Errorf(codes.Internal, "start query-log drain tracking: %v", err)
+	}
+	defer finishDrain()
+
+	if err := h.pool.LogQueryEntries(stream.Context(), req.Entries); err != nil {
 		if drainErr := workerDrainingStatus(err); drainErr != nil {
 			return drainErr
 		}
 		if errors.Is(err, ErrQueryLogRejected) {
 			return status.Errorf(codes.FailedPrecondition, "log query: %v", err)
+		}
+		if errors.Is(err, context.Canceled) {
+			return status.Errorf(codes.Canceled, "log query: %v", err)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return status.Errorf(codes.DeadlineExceeded, "log query: %v", err)
 		}
 		return status.Errorf(codes.Internal, "log query: %v", err)
 	}

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -799,6 +799,80 @@ func TestLogQueryActionRejectsClosedWorker(t *testing.T) {
 	}
 }
 
+func TestQueryLogSinkInitDoesNotBlockShutdown(t *testing.T) {
+	oldNewAttachedQueryLogger := newAttachedQueryLogger
+	started := make(chan struct{})
+	release := make(chan struct{})
+	newAttachedQueryLogger = func(ctx context.Context, db *sql.DB, cfg server.QueryLogConfig) (server.QueryLogSink, error) {
+		close(started)
+		select {
+		case <-release:
+			return &captureWorkerQueryLogSink{}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	t.Cleanup(func() {
+		newAttachedQueryLogger = oldNewAttachedQueryLogger
+	})
+
+	stopCh := make(chan struct{})
+	pool := &SessionPool{
+		stopCh:         stopCh,
+		controlDB:      &sql.DB{},
+		workerID:       17,
+		sharedWarmMode: true,
+		cfg: server.Config{
+			QueryLog: server.QueryLogConfig{Enabled: true},
+			DuckLake: server.DuckLakeConfig{
+				MetadataStore: "metadata.db",
+			},
+		},
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+			DuckLake: server.DuckLakeConfig{
+				MetadataStore: "metadata.db",
+			},
+		}},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := pool.queryLogSinkForCurrentRuntime()
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("query-log sink initialization did not start")
+	}
+
+	close(stopCh)
+	stopped := make(chan struct{})
+	go func() {
+		pool.stopQueryLogSink(context.Background())
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("stopQueryLogSink blocked behind query-log sink initialization")
+	}
+
+	close(release)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrWorkerDraining) {
+			t.Fatalf("queryLogSinkForCurrentRuntime error = %v, want ErrWorkerDraining", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("query-log sink initialization did not finish")
+	}
+}
+
 func TestCreateSessionRequiresActivationForSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:       make(map[string]*Session),

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -52,6 +52,18 @@ type testEndTransactionRequest struct {
 	action        flightsql.EndTransactionRequestType
 }
 
+type captureWorkerQueryLogSink struct {
+	entries []server.QueryLogEntry
+}
+
+func (s *captureWorkerQueryLogSink) Log(entry server.QueryLogEntry) {
+	s.entries = append(s.entries, entry)
+}
+
+func (s *captureWorkerQueryLogSink) StopContext(context.Context) error {
+	return nil
+}
+
 func (r testEndTransactionRequest) GetTransactionId() []byte {
 	return r.transactionID
 }
@@ -622,6 +634,168 @@ func TestCreateSessionSendFailureDestroysSession(t *testing.T) {
 	}
 	if got := len(pool.sessions); got != 0 {
 		t.Fatalf("expected failed response to destroy created session, got %d sessions", got)
+	}
+}
+
+func TestLogQueryActionEnqueuesEntries(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		sharedWarmMode: true,
+		workerID:       17,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries: []server.QueryLogEntry{{
+			Query:                 "SELECT 1",
+			UserName:              "alice",
+			OrgID:                 "analytics",
+			WorkerID:              17,
+			CPUTimeSeconds:        1.25,
+			PeakBufferMemoryBytes: 4096,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	stream := &mockDoActionStream{}
+	if err := handler.doLogQuery(body, stream); err != nil {
+		t.Fatalf("doLogQuery: %v", err)
+	}
+	if len(stream.results) != 1 {
+		t.Fatalf("expected one action response, got %d", len(stream.results))
+	}
+	if len(sink.entries) != 1 {
+		t.Fatalf("expected one query-log entry, got %d", len(sink.entries))
+	}
+	if got := sink.entries[0]; got.Query != "SELECT 1" || got.UserName != "alice" || got.OrgID != "analytics" {
+		t.Fatalf("unexpected entry: %#v", got)
+	}
+}
+
+func TestLogQueryActionRejectsStaleWorkerMetadata(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		sharedWarmMode: true,
+		workerID:       17,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 18},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	err = handler.doLogQuery(body, &mockDoActionStream{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("status code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected stale action not to enqueue entries, got %d", len(sink.entries))
+	}
+}
+
+func TestLogQueryActionRejectsMismatchedEntryOrg(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		sharedWarmMode: true,
+		workerID:       17,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "other-org", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	err = handler.doLogQuery(body, &mockDoActionStream{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("status code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected mismatched entry not to enqueue, got %d", len(sink.entries))
+	}
+}
+
+func TestLogQueryActionRejectsUnactivatedSharedWarmWorker(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		sharedWarmMode: true,
+		workerID:       17,
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	err = handler.doLogQuery(body, &mockDoActionStream{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("status code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected unactivated worker not to enqueue, got %d", len(sink.entries))
+	}
+}
+
+func TestLogQueryActionRejectsClosedWorker(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	stopCh := make(chan struct{})
+	close(stopCh)
+	pool := &SessionPool{
+		stopCh:         stopCh,
+		queryLogSink:   sink,
+		workerID:       17,
+		sharedWarmMode: true,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	err = handler.doLogQuery(body, &mockDoActionStream{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("status code = %v, want Unavailable (err=%v)", status.Code(err), err)
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected closed worker not to enqueue, got %d", len(sink.entries))
 	}
 }
 

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -62,6 +63,32 @@ func (s *captureWorkerQueryLogSink) Log(entry server.QueryLogEntry) {
 
 func (s *captureWorkerQueryLogSink) StopContext(context.Context) error {
 	return nil
+}
+
+type blockingWorkerQueryLogSink struct {
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+	mu        sync.Mutex
+	entries   []server.QueryLogEntry
+}
+
+func (s *blockingWorkerQueryLogSink) Log(entry server.QueryLogEntry) {
+	s.mu.Lock()
+	s.entries = append(s.entries, entry)
+	s.mu.Unlock()
+	s.startOnce.Do(func() { close(s.started) })
+	<-s.release
+}
+
+func (s *blockingWorkerQueryLogSink) StopContext(context.Context) error {
+	return nil
+}
+
+func (s *blockingWorkerQueryLogSink) entryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
 }
 
 func (r testEndTransactionRequest) GetTransactionId() []byte {
@@ -799,6 +826,218 @@ func TestLogQueryActionRejectsClosedWorker(t *testing.T) {
 	}
 }
 
+func TestLogQueryActionContinuesDuringDrainAndTracksDrainWork(t *testing.T) {
+	sink := &blockingWorkerQueryLogSink{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		workerID:       17,
+		sharedWarmMode: true,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+	finishExistingWork, err := pool.beginDrainWork(false)
+	if err != nil {
+		t.Fatalf("begin existing drain work: %v", err)
+	}
+	pool.BeginDrain()
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- handler.doLogQuery(body, &mockDoActionStream{})
+	}()
+
+	select {
+	case <-sink.started:
+	case <-time.After(time.Second):
+		t.Fatal("LogQuery did not reach query-log sink")
+	}
+	if got := pool.ActiveDrainWork(); got != 2 {
+		t.Fatalf("active drain work while LogQuery is blocked = %d, want 2", got)
+	}
+
+	finishExistingWork()
+	if got := pool.ActiveDrainWork(); got != 1 {
+		t.Fatalf("active drain work after existing work finished = %d, want 1", got)
+	}
+	shortCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if pool.WaitForDrain(shortCtx) {
+		t.Fatal("expected blocked LogQuery to keep drain active")
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("LogQuery returned before sink was released: %v", err)
+	default:
+	}
+
+	close(sink.release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("doLogQuery: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LogQuery did not finish after sink release")
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected drain to complete after LogQuery finished")
+	}
+	if got := pool.ActiveDrainWork(); got != 0 {
+		t.Fatalf("active drain work after LogQuery finished = %d, want 0", got)
+	}
+	if got := sink.entryCount(); got != 1 {
+		t.Fatalf("logged entries = %d, want 1", got)
+	}
+}
+
+func TestLogQueryActionRejectsAfterDrainCompleted(t *testing.T) {
+	sink := &captureWorkerQueryLogSink{}
+	pool := &SessionPool{
+		queryLogSink:   sink,
+		workerID:       17,
+		sharedWarmMode: true,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	pool.BeginDrain()
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !pool.WaitForDrain(waitCtx) {
+		t.Fatal("expected drain with no active work to complete")
+	}
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	err = handler.doLogQuery(body, &mockDoActionStream{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("status code = %v, want Unavailable (err=%v)", status.Code(err), err)
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected completed drain not to enqueue entries, got %d", len(sink.entries))
+	}
+}
+
+func TestLogQueryActionSinkInitUsesStreamContext(t *testing.T) {
+	oldNewAttachedQueryLogger := newAttachedQueryLogger
+	started := make(chan struct{})
+	newAttachedQueryLogger = func(ctx context.Context, db *sql.DB, cfg server.QueryLogConfig) (server.QueryLogSink, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() {
+		newAttachedQueryLogger = oldNewAttachedQueryLogger
+	})
+
+	pool := &SessionPool{
+		controlDB:      &sql.DB{},
+		workerID:       17,
+		sharedWarmMode: true,
+		cfg: server.Config{
+			QueryLog: server.QueryLogConfig{Enabled: true},
+		},
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+			DuckLake: server.DuckLakeConfig{
+				MetadataStore: "metadata.db",
+			},
+		}},
+	}
+	handler := NewFlightSQLHandler(pool)
+
+	body, err := json.Marshal(server.WorkerQueryLogPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+		Entries:               []server.QueryLogEntry{{Query: "SELECT 1", OrgID: "analytics", WorkerID: 17}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- handler.doLogQuery(body, &mockDoActionStream{ctx: streamCtx})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("query-log sink initialization did not start")
+	}
+	if got := pool.ActiveDrainWork(); got != 1 {
+		t.Fatalf("active drain work while query-log init is blocked = %d, want 1", got)
+	}
+	cancelStream()
+
+	select {
+	case err := <-done:
+		if status.Code(err) != codes.Canceled {
+			t.Fatalf("status code = %v, want Canceled (err=%v)", status.Code(err), err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LogQuery did not return after stream context cancellation")
+	}
+	if got := pool.ActiveDrainWork(); got != 0 {
+		t.Fatalf("active drain work after canceled query-log init = %d, want 0", got)
+	}
+}
+
+func TestQueryLogSinkInitWaitRespectsContext(t *testing.T) {
+	pool := &SessionPool{
+		controlDB:      &sql.DB{},
+		workerID:       17,
+		sharedWarmMode: true,
+		cfg: server.Config{
+			QueryLog: server.QueryLogConfig{Enabled: true},
+		},
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			WorkerControlMetadata: server.WorkerControlMetadata{WorkerID: 17},
+			OrgID:                 "analytics",
+			DuckLake: server.DuckLakeConfig{
+				MetadataStore: "metadata.db",
+			},
+		}},
+	}
+
+	pool.queryLogInit.Lock()
+	defer pool.queryLogInit.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := pool.queryLogSinkForCurrentRuntime(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("queryLogSinkForCurrentRuntime error = %v, want context.Canceled", err)
+	}
+}
+
 func TestQueryLogSinkInitDoesNotBlockShutdown(t *testing.T) {
 	oldNewAttachedQueryLogger := newAttachedQueryLogger
 	started := make(chan struct{})
@@ -839,7 +1078,7 @@ func TestQueryLogSinkInitDoesNotBlockShutdown(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := pool.queryLogSinkForCurrentRuntime()
+		_, err := pool.queryLogSinkForCurrentRuntime(context.Background())
 		errCh <- err
 	}()
 

--- a/duckdbservice/querylog.go
+++ b/duckdbservice/querylog.go
@@ -1,0 +1,165 @@
+package duckdbservice
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/server/observe"
+)
+
+var ErrQueryLogRejected = errors.New("query log rejected")
+
+func (p *SessionPool) LogQueryEntries(entries []server.QueryLogEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if p.queryLogClosed() {
+		observe.AddQueryLogDroppedEntries("worker_closing", len(entries))
+		return ErrWorkerDraining
+	}
+	if err := p.validateQueryLogEntryIdentities(entries); err != nil {
+		observe.AddQueryLogDroppedEntries("worker_rejected", len(entries))
+		return err
+	}
+	sink, err := p.queryLogSinkForCurrentRuntime()
+	if err != nil {
+		observe.AddQueryLogDroppedEntries("worker_sink_init_error", len(entries))
+		return err
+	}
+	if sink == nil {
+		observe.AddQueryLogDroppedEntries("worker_sink_disabled", len(entries))
+		return nil
+	}
+	for _, entry := range entries {
+		sink.Log(entry)
+	}
+	return nil
+}
+
+func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, error) {
+	if p.queryLogClosed() {
+		return nil, ErrWorkerDraining
+	}
+	p.queryLogMu.Lock()
+	if p.queryLogSink != nil {
+		sink := p.queryLogSink
+		p.queryLogMu.Unlock()
+		return sink, nil
+	}
+	p.queryLogMu.Unlock()
+
+	cfg, db, ok := p.queryLogRuntime()
+	if !ok || !cfg.QueryLog.Enabled || db == nil || cfg.DuckLake.MetadataStore == "" {
+		return nil, nil
+	}
+
+	p.queryLogMu.Lock()
+	defer p.queryLogMu.Unlock()
+	if p.queryLogClosed() {
+		return nil, ErrWorkerDraining
+	}
+	if p.queryLogSink != nil {
+		return p.queryLogSink, nil
+	}
+	ql, err := server.NewAttachedQueryLogger(db, cfg.QueryLog)
+	if err != nil {
+		return nil, fmt.Errorf("initialize worker query log: %w", err)
+	}
+	p.queryLogSink = ql
+	return p.queryLogSink, nil
+}
+
+func (p *SessionPool) validateQueryLogEntryIdentities(entries []server.QueryLogEntry) error {
+	if !p.sharedWarmMode {
+		return nil
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.activation == nil {
+		return fmt.Errorf("%w: worker is not activated", ErrQueryLogRejected)
+	}
+	orgID := p.activation.payload.OrgID
+	workerID := p.workerID
+	if workerID == 0 {
+		workerID = p.activation.payload.WorkerID
+	}
+	for _, entry := range entries {
+		if entry.OrgID != orgID {
+			return fmt.Errorf("%w: entry org_id %q does not match activated org %q", ErrQueryLogRejected, entry.OrgID, orgID)
+		}
+		if workerID > 0 && entry.WorkerID != workerID {
+			return fmt.Errorf("%w: entry worker_id %d does not match active worker %d", ErrQueryLogRejected, entry.WorkerID, workerID)
+		}
+	}
+	return nil
+}
+
+func (p *SessionPool) queryLogClosed() bool {
+	if p == nil || p.stopCh == nil {
+		return false
+	}
+	select {
+	case <-p.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *SessionPool) queryLogRuntime() (server.Config, *sql.DB, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	cfg := p.cfg
+	var db *sql.DB
+	if p.sharedWarmMode {
+		if p.activation == nil {
+			return server.Config{}, nil, false
+		}
+		cfg.DuckLake = p.activation.payload.DuckLake
+		overrideS3EndpointForCacheProxy(&cfg.DuckLake)
+		if cfg.DuckLake.ApplicationName == "" && p.activation.payload.OrgID != "" {
+			cfg.DuckLake.ApplicationName = "duckgres/" + p.activation.payload.OrgID
+		}
+		db = p.controlDB
+		if db == nil {
+			db = p.activation.db
+		}
+	} else {
+		db = p.controlDB
+	}
+	if db == nil {
+		db = p.warmupDB
+	}
+	if db == nil {
+		db = p.fallbackDB
+	}
+	return cfg, db, true
+}
+
+func (p *SessionPool) stopQueryLogSink(ctx context.Context) {
+	p.queryLogMu.Lock()
+	sink := p.queryLogSink
+	p.queryLogSink = nil
+	p.queryLogMu.Unlock()
+	if sink == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+	if err := sink.StopContext(ctx); err != nil {
+		slog.Warn("Failed to stop worker query log sink.", "error", err)
+	}
+}

--- a/duckdbservice/querylog.go
+++ b/duckdbservice/querylog.go
@@ -16,6 +16,7 @@ var ErrQueryLogRejected = errors.New("query log rejected")
 
 const (
 	queryLogSinkInitTimeout       = 30 * time.Second
+	queryLogInitLockPollInterval  = 10 * time.Millisecond
 	queryLogUnusedSinkStopTimeout = 5 * time.Second
 )
 
@@ -23,7 +24,7 @@ var newAttachedQueryLogger = func(ctx context.Context, db *sql.DB, cfg server.Qu
 	return server.NewAttachedQueryLoggerContext(ctx, db, cfg)
 }
 
-func (p *SessionPool) LogQueryEntries(entries []server.QueryLogEntry) error {
+func (p *SessionPool) LogQueryEntries(ctx context.Context, entries []server.QueryLogEntry) error {
 	if len(entries) == 0 {
 		return nil
 	}
@@ -35,7 +36,7 @@ func (p *SessionPool) LogQueryEntries(entries []server.QueryLogEntry) error {
 		observe.AddQueryLogDroppedEntries("worker_rejected", len(entries))
 		return err
 	}
-	sink, err := p.queryLogSinkForCurrentRuntime()
+	sink, err := p.queryLogSinkForCurrentRuntime(ctx)
 	if err != nil {
 		observe.AddQueryLogDroppedEntries("worker_sink_init_error", len(entries))
 		return err
@@ -50,7 +51,10 @@ func (p *SessionPool) LogQueryEntries(entries []server.QueryLogEntry) error {
 	return nil
 }
 
-func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, error) {
+func (p *SessionPool) queryLogSinkForCurrentRuntime(ctx context.Context) (server.QueryLogSink, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if p.queryLogClosed() {
 		return nil, ErrWorkerDraining
 	}
@@ -67,8 +71,11 @@ func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, erro
 		return nil, nil
 	}
 
-	p.queryLogInit.Lock()
-	defer p.queryLogInit.Unlock()
+	unlockInit, err := p.lockQueryLogInit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer unlockInit()
 
 	p.queryLogMu.Lock()
 	if p.queryLogClosed() {
@@ -82,7 +89,7 @@ func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, erro
 	}
 	p.queryLogMu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), queryLogSinkInitTimeout)
+	ctx, cancel := context.WithTimeout(ctx, queryLogSinkInitTimeout)
 	defer cancel()
 	ql, err := newAttachedQueryLogger(ctx, db, cfg.QueryLog)
 	if err != nil {
@@ -107,6 +114,25 @@ func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, erro
 	p.queryLogSink = ql
 	p.queryLogMu.Unlock()
 	return ql, nil
+}
+
+func (p *SessionPool) lockQueryLogInit(ctx context.Context) (func(), error) {
+	if p.queryLogInit.TryLock() {
+		return p.queryLogInit.Unlock, nil
+	}
+
+	ticker := time.NewTicker(queryLogInitLockPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			if p.queryLogInit.TryLock() {
+				return p.queryLogInit.Unlock, nil
+			}
+		}
+	}
 }
 
 func stopUnusedQueryLogSink(sink server.QueryLogSink) {

--- a/duckdbservice/querylog.go
+++ b/duckdbservice/querylog.go
@@ -14,6 +14,15 @@ import (
 
 var ErrQueryLogRejected = errors.New("query log rejected")
 
+const (
+	queryLogSinkInitTimeout       = 30 * time.Second
+	queryLogUnusedSinkStopTimeout = 5 * time.Second
+)
+
+var newAttachedQueryLogger = func(ctx context.Context, db *sql.DB, cfg server.QueryLogConfig) (server.QueryLogSink, error) {
+	return server.NewAttachedQueryLoggerContext(ctx, db, cfg)
+}
+
 func (p *SessionPool) LogQueryEntries(entries []server.QueryLogEntry) error {
 	if len(entries) == 0 {
 		return nil
@@ -58,20 +67,57 @@ func (p *SessionPool) queryLogSinkForCurrentRuntime() (server.QueryLogSink, erro
 		return nil, nil
 	}
 
+	p.queryLogInit.Lock()
+	defer p.queryLogInit.Unlock()
+
 	p.queryLogMu.Lock()
-	defer p.queryLogMu.Unlock()
 	if p.queryLogClosed() {
+		p.queryLogMu.Unlock()
 		return nil, ErrWorkerDraining
 	}
 	if p.queryLogSink != nil {
-		return p.queryLogSink, nil
+		sink := p.queryLogSink
+		p.queryLogMu.Unlock()
+		return sink, nil
 	}
-	ql, err := server.NewAttachedQueryLogger(db, cfg.QueryLog)
+	p.queryLogMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryLogSinkInitTimeout)
+	defer cancel()
+	ql, err := newAttachedQueryLogger(ctx, db, cfg.QueryLog)
 	if err != nil {
 		return nil, fmt.Errorf("initialize worker query log: %w", err)
 	}
+	if ql == nil {
+		return nil, nil
+	}
+
+	p.queryLogMu.Lock()
+	if p.queryLogClosed() {
+		p.queryLogMu.Unlock()
+		stopUnusedQueryLogSink(ql)
+		return nil, ErrWorkerDraining
+	}
+	if p.queryLogSink != nil {
+		sink := p.queryLogSink
+		p.queryLogMu.Unlock()
+		stopUnusedQueryLogSink(ql)
+		return sink, nil
+	}
 	p.queryLogSink = ql
-	return p.queryLogSink, nil
+	p.queryLogMu.Unlock()
+	return ql, nil
+}
+
+func stopUnusedQueryLogSink(sink server.QueryLogSink) {
+	if sink == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryLogUnusedSinkStopTimeout)
+	defer cancel()
+	if err := sink.StopContext(ctx); err != nil {
+		slog.Warn("Failed to stop unused worker query log sink.", "error", err)
+	}
 }
 
 func (p *SessionPool) validateQueryLogEntryIdentities(entries []server.QueryLogEntry) error {

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -71,7 +71,9 @@ type SessionPool struct {
 	// controlDB is activePair.Control, surfaced for direct use by control-side
 	// ops (CREATE OR REPLACE SECRET on STS rotation). Always nil before
 	// activation; nil-check before use and fall back to the main DB.
-	controlDB *sql.DB
+	controlDB    *sql.DB
+	queryLogMu   sync.Mutex
+	queryLogSink server.QueryLogSink
 
 	sharedWarmMode       bool
 	activation           *activatedTenantRuntime
@@ -1503,6 +1505,8 @@ func (p *SessionPool) CloseAll() {
 		}
 	}
 
+	p.stopQueryLogSink(context.Background())
+
 	if p.warmupDB != nil {
 		cleanupWorkerCatalogs(p.warmupDB)
 	}
@@ -1733,6 +1737,8 @@ func (s *customActionServer) DoAction(cmd *flight.Action, stream flight.FlightSe
 		return s.handler.doWaitSessionIdle(cmd.Body, stream)
 	case "ReleaseQueryHandle":
 		return s.handler.doReleaseQueryHandle(cmd.Body, stream)
+	case "LogQuery":
+		return s.handler.doLogQuery(cmd.Body, stream)
 	default:
 		// Fall through to standard flightsql action router (BeginTransaction, etc.)
 		return s.FlightServer.DoAction(cmd, stream)

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -73,6 +73,7 @@ type SessionPool struct {
 	// activation; nil-check before use and fall back to the main DB.
 	controlDB    *sql.DB
 	queryLogMu   sync.Mutex
+	queryLogInit sync.Mutex
 	queryLogSink server.QueryLogSink
 
 	sharedWarmMode       bool

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/posthog/duckgres/duckdbservice/arrowmap"
+	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sqlcore"
 	"github.com/posthog/duckgres/server/wire"
 	"google.golang.org/grpc"
@@ -38,7 +39,12 @@ const MaxGRPCMessageSize = 1 << 30 // 1GB
 const (
 	waitSessionIdleAction    = "WaitSessionIdle"
 	releaseQueryHandleAction = "ReleaseQueryHandle"
+	logQueryAction           = "LogQuery"
 	queryCloseWaitTimeout    = 30 * time.Second
+	queryLogForwardTimeout   = 5 * time.Second
+	queryLogForwardBatchSize = 100
+	queryLogForwardInterval  = 1 * time.Second
+	queryLogForwardQueueSize = 10000
 )
 
 // ErrWorkerDead is returned when the backing worker process has crashed.
@@ -65,6 +71,10 @@ type FlightExecutor struct {
 	// lastProfiling stores the most recent DuckDB profiling output received
 	// from the worker via gRPC trailing metadata.
 	lastProfiling atomic.Value // stores string
+
+	queryLogCh       chan wire.QueryLogEntry
+	queryLogDone     chan struct{}
+	queryLogStopOnce sync.Once
 }
 
 // NewFlightExecutor creates a FlightExecutor connected to the given address.
@@ -93,7 +103,7 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	return &FlightExecutor{
+	e := &FlightExecutor{
 		client:       client,
 		sessionToken: sessionToken,
 		ownerEpoch:   0,
@@ -101,7 +111,9 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 		ownsClient:   true,
 		ctx:          ctx,
 		cancel:       cancel,
-	}, nil
+	}
+	e.startQueryLogForwarder()
+	return e, nil
 }
 
 // NewFlightExecutorFromClient creates a FlightExecutor that shares an existing
@@ -109,7 +121,7 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 // This avoids creating a new gRPC connection per session.
 func NewFlightExecutorFromClient(client *flightsql.Client, sessionToken string) *FlightExecutor {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &FlightExecutor{
+	e := &FlightExecutor{
 		client:       client,
 		sessionToken: sessionToken,
 		ownerEpoch:   0,
@@ -118,6 +130,8 @@ func NewFlightExecutorFromClient(client *flightsql.Client, sessionToken string) 
 		ctx:          ctx,
 		cancel:       cancel,
 	}
+	e.startQueryLogForwarder()
+	return e
 }
 
 // MarkDead marks this executor's backing worker as dead. All subsequent RPC
@@ -325,6 +339,10 @@ func (e *FlightExecutor) mergedContext(ctx context.Context) (context.Context, co
 }
 
 func (e *FlightExecutor) Close() error {
+	if !e.stopQueryLogForwarder() && e.cancel != nil {
+		e.cancel()
+		e.waitQueryLogForwarder()
+	}
 	if e.cancel != nil {
 		e.cancel()
 	}
@@ -332,6 +350,150 @@ func (e *FlightExecutor) Close() error {
 		return e.client.Close()
 	}
 	return nil
+}
+
+// Log implements the server query-log forwarding hook without making query
+// completion wait on worker RPC or DuckLake writes.
+func (e *FlightExecutor) Log(entry wire.QueryLogEntry) {
+	if e == nil {
+		return
+	}
+	if e.dead.Load() {
+		observe.AddQueryLogDroppedEntries("forward_worker_dead", 1)
+		return
+	}
+	if e.queryLogCh == nil {
+		observe.AddQueryLogDroppedEntries("forward_unavailable", 1)
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			observe.AddQueryLogDroppedEntries("forward_closed", 1)
+		}
+	}()
+	select {
+	case e.queryLogCh <- entry:
+	default:
+		observe.AddQueryLogDroppedEntries("forward_buffer_full", 1)
+	}
+}
+
+func (e *FlightExecutor) startQueryLogForwarder() {
+	e.queryLogCh = make(chan wire.QueryLogEntry, queryLogForwardQueueSize)
+	e.queryLogDone = make(chan struct{})
+	go e.queryLogForwardLoop()
+}
+
+func (e *FlightExecutor) stopQueryLogForwarder() bool {
+	stopped := true
+	e.queryLogStopOnce.Do(func() {
+		if e.queryLogCh != nil {
+			close(e.queryLogCh)
+		}
+		stopped = e.waitQueryLogForwarder()
+	})
+	return stopped
+}
+
+func (e *FlightExecutor) waitQueryLogForwarder() bool {
+	if e.queryLogDone == nil {
+		return true
+	}
+	select {
+	case <-e.queryLogDone:
+		return true
+	case <-time.After(queryLogForwardTimeout):
+		return false
+	}
+}
+
+func (e *FlightExecutor) queryLogForwardLoop() {
+	defer close(e.queryLogDone)
+	ticker := time.NewTicker(queryLogForwardInterval)
+	defer ticker.Stop()
+
+	batch := make([]wire.QueryLogEntry, 0, queryLogForwardBatchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		e.forwardQueryLogBatch(batch)
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case entry, ok := <-e.queryLogCh:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, entry)
+			if len(batch) >= queryLogForwardBatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-e.ctx.Done():
+			observe.AddQueryLogDroppedEntries("forward_context_done", len(batch)+len(e.queryLogCh))
+			return
+		}
+	}
+}
+
+func (e *FlightExecutor) forwardQueryLogBatch(entries []wire.QueryLogEntry) (err error) {
+	if len(entries) == 0 {
+		return nil
+	}
+	if e.dead.Load() {
+		observe.AddQueryLogDroppedEntries("forward_worker_dead", len(entries))
+		return nil
+	}
+	if e.client == nil || e.client.Client == nil {
+		observe.AddQueryLogDroppedEntries("forward_unavailable", len(entries))
+		return nil
+	}
+	defer func() {
+		recoverClientPanic(&err)
+		if err != nil {
+			observe.AddQueryLogDroppedEntries("forward_error", len(entries))
+		}
+	}()
+
+	payload, err := json.Marshal(wire.WorkerQueryLogPayload{
+		WorkerControlMetadata: wire.WorkerControlMetadata{
+			WorkerID:     e.workerID,
+			OwnerEpoch:   e.ownerEpoch,
+			CPInstanceID: e.cpInstanceID,
+		},
+		Entries: entries,
+	})
+	if err != nil {
+		return err
+	}
+
+	baseCtx := context.Background()
+	if e.ctx != nil {
+		baseCtx = e.ctx
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, queryLogForwardTimeout)
+	defer cancel()
+	stream, err := e.client.Client.DoAction(
+		e.withSession(ctx),
+		&flight.Action{Type: logQueryAction, Body: payload},
+	)
+	if err != nil {
+		return err
+	}
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
 }
 
 func isTerminalSessionIdleWaitError(err error) bool {
@@ -948,7 +1110,7 @@ func interpolateArgs(query string, args []any) string {
 }
 
 // scanQuoted returns the index just past a quoted region starting at start
-// (query[start] == quote), treating a doubled quote ('' or "") as an escape.
+// (query[start] == quote), treating a doubled quote (” or "") as an escape.
 func scanQuoted(query string, start int, quote byte) int {
 	for i := start + 1; i < len(query); i++ {
 		if query[i] != quote {

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -417,7 +417,8 @@ func (e *FlightExecutor) queryLogForwardLoop() {
 		if len(batch) == 0 {
 			return
 		}
-		e.forwardQueryLogBatch(batch)
+		// forwardQueryLogBatch records dropped-entry metrics for failed batches.
+		_ = e.forwardQueryLogBatch(batch)
 		batch = batch[:0]
 	}
 

--- a/server/flightclient/flight_executor_test.go
+++ b/server/flightclient/flight_executor_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestFlightExecutorWithSessionAddsOwnerEpochHeader(t *testing.T) {
 	exec := NewFlightExecutorFromClient(nil, "session-1")
+	defer func() { _ = exec.Close() }()
 	exec.SetOwnerEpoch(7)
 	exec.SetControlMetadata(17, "cp-live:boot-a", 7)
 
@@ -61,6 +62,9 @@ type closeWaitFlightServer struct {
 	releaseActionCalled   chan struct{}
 	releaseActionOnce     sync.Once
 	releaseTicket         []byte
+	logQueryCalled        chan struct{}
+	logQueryOnce          sync.Once
+	logQueryPayload       wire.WorkerQueryLogPayload
 	waitBeforeDoGetCancel chan struct{}
 	waitBeforeOnce        sync.Once
 	closeAfterFirstBatch  bool
@@ -78,6 +82,7 @@ func newCloseWaitFlightServer() *closeWaitFlightServer {
 		doGetDone:            make(chan struct{}),
 		doActionCalled:       make(chan struct{}),
 		releaseActionCalled:  make(chan struct{}),
+		logQueryCalled:       make(chan struct{}),
 	}
 }
 
@@ -142,6 +147,14 @@ func (s *closeWaitFlightServer) DoAction(action *flight.Action, stream pb.Flight
 		}
 		s.releaseTicket = payload.Ticket
 		return stream.Send(&flight.Result{Body: []byte(`{"ok":true}`)})
+	case logQueryAction:
+		s.logQueryOnce.Do(func() {
+			close(s.logQueryCalled)
+		})
+		if err := json.Unmarshal(action.Body, &s.logQueryPayload); err != nil {
+			return err
+		}
+		return stream.Send(&flight.Result{Body: []byte(`{"ok":true}`)})
 	case waitSessionIdleAction:
 	default:
 		return s.UnimplementedFlightServiceServer.DoAction(action, stream)
@@ -195,6 +208,48 @@ func newCloseWaitExecutor(t *testing.T, srv *closeWaitFlightServer) (*FlightExec
 	exec := NewFlightExecutorFromClient(&flightsql.Client{Client: flightCli}, "session-1")
 	t.Cleanup(func() { _ = exec.Close() })
 	return exec, ctx
+}
+
+func TestFlightExecutorLogForwardsQueryLogBatch(t *testing.T) {
+	srv := newCloseWaitFlightServer()
+	exec, _ := newCloseWaitExecutor(t, srv)
+	exec.SetControlMetadata(17, "cp-live:boot-a", 7)
+
+	exec.Log(wire.QueryLogEntry{
+		Query:                 "SELECT 1",
+		UserName:              "alice",
+		OrgID:                 "analytics",
+		CPUTimeSeconds:        1.5,
+		PeakBufferMemoryBytes: 2048,
+	})
+	if err := exec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case <-srv.logQueryCalled:
+	case <-time.After(time.Second):
+		t.Fatal("LogQuery action was not sent")
+	}
+	if got := srv.logQueryPayload.WorkerID; got != 17 {
+		t.Fatalf("worker_id = %d, want 17", got)
+	}
+	if got := srv.logQueryPayload.OwnerEpoch; got != 7 {
+		t.Fatalf("owner_epoch = %d, want 7", got)
+	}
+	if got := srv.logQueryPayload.CPInstanceID; got != "cp-live:boot-a" {
+		t.Fatalf("cp_instance_id = %q, want cp-live:boot-a", got)
+	}
+	if len(srv.logQueryPayload.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(srv.logQueryPayload.Entries))
+	}
+	entry := srv.logQueryPayload.Entries[0]
+	if entry.Query != "SELECT 1" || entry.UserName != "alice" || entry.OrgID != "analytics" {
+		t.Fatalf("unexpected forwarded entry: %#v", entry)
+	}
+	if entry.CPUTimeSeconds != 1.5 || entry.PeakBufferMemoryBytes != 2048 {
+		t.Fatalf("resource fields not forwarded: %#v", entry)
+	}
 }
 
 func TestFlightRowSetCloseWaitsForWorkerDoGetCleanup(t *testing.T) {

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -1,6 +1,8 @@
 package observe
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -83,3 +85,70 @@ var MetadataPoolMaxConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "duckgres_ducklake_metadata_pool_max_connections",
 	Help: "Configured postgres_scanner pool ceiling for DuckLake metadata (pg_pool_max_connections).",
 }, []string{"org"})
+
+var queryLogBufferedEntries = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "duckgres_query_log_buffered_entries",
+	Help: "Current number of query-log entries buffered in memory before DuckLake flush.",
+})
+
+var queryLogEnqueuedEntriesTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_query_log_enqueued_entries_total",
+	Help: "Total number of query-log entries accepted into the in-memory buffer.",
+})
+
+var queryLogFlushedEntriesTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_query_log_flushed_entries_total",
+	Help: "Total number of query-log entries flushed successfully to DuckLake.",
+})
+
+var queryLogDroppedEntriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_query_log_dropped_entries_total",
+	Help: "Total number of query-log entries dropped before reaching DuckLake.",
+}, []string{"reason"})
+
+var queryLogFlushErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "duckgres_query_log_flush_errors_total",
+	Help: "Total number of failed query-log DuckLake flush attempts.",
+})
+
+var queryLogFlushDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "duckgres_query_log_flush_duration_seconds",
+	Help:    "Duration of query-log DuckLake flush attempts in seconds.",
+	Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
+})
+
+func SetQueryLogBufferedEntries(entries int) {
+	if entries < 0 {
+		entries = 0
+	}
+	queryLogBufferedEntries.Set(float64(entries))
+}
+
+func IncQueryLogEnqueuedEntries() {
+	queryLogEnqueuedEntriesTotal.Inc()
+}
+
+func AddQueryLogFlushedEntries(entries int) {
+	if entries <= 0 {
+		return
+	}
+	queryLogFlushedEntriesTotal.Add(float64(entries))
+}
+
+func AddQueryLogDroppedEntries(reason string, entries int) {
+	if entries <= 0 {
+		return
+	}
+	queryLogDroppedEntriesTotal.WithLabelValues(reason).Add(float64(entries))
+}
+
+func IncQueryLogFlushErrors() {
+	queryLogFlushErrorsTotal.Inc()
+}
+
+func ObserveQueryLogFlushDuration(duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	queryLogFlushDurationHistogram.Observe(duration.Seconds())
+}

--- a/server/observe/metrics_test.go
+++ b/server/observe/metrics_test.go
@@ -2,9 +2,47 @@ package observe
 
 import (
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
+
+func gaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := gauge.Write(m); err != nil {
+		t.Fatalf("gauge write: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+func counterValue(t *testing.T, counter prometheus.Counter) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := counter.Write(m); err != nil {
+		t.Fatalf("counter write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func counterVecValue(t *testing.T, counterVec *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	counter, err := counterVec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("counter labels %v: %v", labels, err)
+	}
+	return counterValue(t, counter)
+}
+
+func histogramSampleCount(t *testing.T, histogram prometheus.Histogram) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := histogram.Write(m); err != nil {
+		t.Fatalf("histogram write: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
 
 func connDurationSample(t *testing.T, org string) (count uint64, sum float64) {
 	t.Helper()
@@ -41,5 +79,45 @@ func TestObserveConnectionDurationRecordsPerOrgSample(t *testing.T) {
 	// A different org must not see those samples (label isolation).
 	if c, _ := connDurationSample(t, "conn-duration-other-org"); c != 0 {
 		t.Fatalf("unrelated org sample count = %d, want 0", c)
+	}
+}
+
+func TestQueryLogMetricsHelpersRecordBufferFlushAndDrops(t *testing.T) {
+	enqueuedBefore := counterValue(t, queryLogEnqueuedEntriesTotal)
+	flushedBefore := counterValue(t, queryLogFlushedEntriesTotal)
+	droppedFullBefore := counterVecValue(t, queryLogDroppedEntriesTotal, "buffer_full")
+	droppedFlushBefore := counterVecValue(t, queryLogDroppedEntriesTotal, "flush_error")
+	errorsBefore := counterValue(t, queryLogFlushErrorsTotal)
+	flushSamplesBefore := histogramSampleCount(t, queryLogFlushDurationHistogram)
+
+	SetQueryLogBufferedEntries(7)
+	if got := gaugeValue(t, queryLogBufferedEntries); got != 7 {
+		t.Fatalf("buffered entries gauge = %v, want 7", got)
+	}
+
+	IncQueryLogEnqueuedEntries()
+	AddQueryLogFlushedEntries(3)
+	AddQueryLogDroppedEntries("buffer_full", 2)
+	AddQueryLogDroppedEntries("flush_error", 4)
+	IncQueryLogFlushErrors()
+	ObserveQueryLogFlushDuration(125 * time.Millisecond)
+
+	if got := counterValue(t, queryLogEnqueuedEntriesTotal) - enqueuedBefore; got != 1 {
+		t.Fatalf("enqueued delta = %v, want 1", got)
+	}
+	if got := counterValue(t, queryLogFlushedEntriesTotal) - flushedBefore; got != 3 {
+		t.Fatalf("flushed delta = %v, want 3", got)
+	}
+	if got := counterVecValue(t, queryLogDroppedEntriesTotal, "buffer_full") - droppedFullBefore; got != 2 {
+		t.Fatalf("buffer_full dropped delta = %v, want 2", got)
+	}
+	if got := counterVecValue(t, queryLogDroppedEntriesTotal, "flush_error") - droppedFlushBefore; got != 4 {
+		t.Fatalf("flush_error dropped delta = %v, want 4", got)
+	}
+	if got := counterValue(t, queryLogFlushErrorsTotal) - errorsBefore; got != 1 {
+		t.Fatalf("flush errors delta = %v, want 1", got)
+	}
+	if got := histogramSampleCount(t, queryLogFlushDurationHistogram) - flushSamplesBefore; got != 1 {
+		t.Fatalf("flush duration sample delta = %d, want 1", got)
 	}
 }

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -129,10 +129,6 @@ func NewAttachedQueryLoggerContext(ctx context.Context, db *sql.DB, cfg QueryLog
 	return ql, nil
 }
 
-func ensureAttachedQueryLogTable(db *sql.DB, cfg QueryLogConfig) error {
-	return ensureAttachedQueryLogTableContext(context.Background(), db, cfg)
-}
-
 func ensureAttachedQueryLogTableContext(ctx context.Context, db *sql.DB, cfg QueryLogConfig) error {
 	if ctx == nil {
 		ctx = context.Background()

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -11,53 +11,21 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/usersecrets"
+	"github.com/posthog/duckgres/server/wire"
 )
 
 // QueryLogEntry represents a single entry in the query log.
-type QueryLogEntry struct {
-	EventID         string
-	EventTime       time.Time
-	QueryDurationMs int64
-	Type            string // "QueryFinish" or "ExceptionWhileProcessing"
-	Query           string
-	TranspiledQuery *string // nil if unchanged
-	QueryKind       string  // "Select","Insert","Update","Delete","DDL","Utility","Copy","Cursor"
-	NormalizedHash  int64
-	ResultRows      int64
-	WrittenRows     int64
-	ExceptionCode   string
-	Exception       string
-	UserName        string
-	OrgID           string
-	CurrentDatabase string
-	ClientAddress   string
-	ClientPort      int
-	ApplicationName string
-	PID             int32
-	WorkerID        int
-	IsTranspiled    bool
-	Protocol        string // "simple" or "extended"
-	TraceID         string // OTEL trace ID (empty when tracing is off)
-	SpanID          string // OTEL span ID (empty when tracing is off)
-	// PostgresScanMs is the thread-time spent in postgres_scan operators
-	// during this query — DuckLake metadata DB roundtrips. Zero when DuckDB
-	// returned no profiling output (cancelled / errored before exec /
-	// profiling disabled). Lets us answer "which query shape pounds the
-	// metadata DB?" against `system.query_log` without re-parsing profiling.
-	PostgresScanMs int64
-	// CPUTimeSeconds is DuckDB's cumulative query CPU/thread time in seconds.
-	// Zero when DuckDB returned no profiling output.
-	CPUTimeSeconds float64
-	// PeakBufferMemoryBytes is DuckDB's system_peak_buffer_memory value in
-	// bytes. This is DuckDB buffer memory, not process RSS.
-	PeakBufferMemoryBytes int64
-}
+//
+// The concrete shape lives in server/wire so the DuckDB-free Flight client can
+// forward entries to worker pods without importing the full server package.
+type QueryLogEntry = wire.QueryLogEntry
 
 // QueryLogger batches query log entries and writes them to a DuckLake table.
 type QueryLogger struct {
@@ -67,12 +35,20 @@ type QueryLogger struct {
 	ch       chan QueryLogEntry
 	done     chan struct{}
 	stopOnce sync.Once
+	ctx      context.Context
+	cancel   context.CancelFunc
+	buffered atomic.Int64
+	closeDB  bool
 }
 
 // QueryLogSink accepts query log entries and drains them during shutdown.
 type QueryLogSink interface {
 	Log(QueryLogEntry)
 	StopContext(context.Context) error
+}
+
+type queryLogEntrySink interface {
+	Log(QueryLogEntry)
 }
 
 const (
@@ -104,17 +80,62 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	ql := &QueryLogger{
-		db:    db,
-		cfg:   cfg.QueryLog,
-		table: "ducklake.system.query_log",
-		ch:    make(chan QueryLogEntry, queryLogChannelSize),
-		done:  make(chan struct{}),
+		db:      db,
+		cfg:     cfg.QueryLog,
+		table:   "ducklake.system.query_log",
+		ch:      make(chan QueryLogEntry, queryLogChannelSize),
+		done:    make(chan struct{}),
+		ctx:     ctx,
+		cancel:  cancel,
+		closeDB: true,
 	}
 
 	go ql.flushLoop()
 	slog.Info("Query log enabled.", "flush_interval", cfg.QueryLog.FlushInterval, "batch_size", cfg.QueryLog.BatchSize)
 	return ql, nil
+}
+
+// NewAttachedQueryLogger creates a query logger using a DuckDB handle that
+// already sees the tenant DuckLake catalog. The logger does not own db; callers
+// must close the handle after StopContext returns.
+func NewAttachedQueryLogger(db *sql.DB, cfg QueryLogConfig) (*QueryLogger, error) {
+	if !cfg.Enabled || db == nil {
+		return nil, nil
+	}
+	if err := ensureAttachedQueryLogTable(db, cfg); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ql := &QueryLogger{
+		db:     db,
+		cfg:    cfg,
+		table:  "ducklake.system.query_log",
+		ch:     make(chan QueryLogEntry, queryLogChannelSize),
+		done:   make(chan struct{}),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	go ql.flushLoop()
+	slog.Info("Query log enabled on attached DuckLake.", "flush_interval", cfg.FlushInterval, "batch_size", cfg.BatchSize)
+	return ql, nil
+}
+
+func ensureAttachedQueryLogTable(db *sql.DB, cfg QueryLogConfig) error {
+	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS ducklake.system"); err != nil {
+		return fmt.Errorf("querylog: create schema: %w", err)
+	}
+	if err := ensureQueryLogTable(db, "system", "query_log", "ducklake.system.query_log"); err != nil {
+		return fmt.Errorf("querylog: ensure table: %w", err)
+	}
+	inlineStmt := fmt.Sprintf(
+		"CALL ducklake.set_option('data_inlining_row_limit', %d, schema => 'system', table_name => 'query_log')",
+		cfg.DataInliningRowLimit)
+	if _, err := db.Exec(inlineStmt); err != nil {
+		slog.Warn("querylog: failed to set data_inlining_row_limit, continuing without it.", "error", err)
+	}
+	return nil
 }
 
 func openQueryLogDuckLakeDB(cfg Config) (*sql.DB, error) {
@@ -199,14 +220,24 @@ func (ql *QueryLogger) Log(entry QueryLogEntry) {
 	if ql == nil || ql.ch == nil {
 		return
 	}
+	ql.addBufferedEntries(1)
+	queued := false
 	defer func() {
 		if r := recover(); r != nil {
+			if !queued {
+				ql.addBufferedEntries(-1)
+				observe.AddQueryLogDroppedEntries("logger_closed", 1)
+			}
 			slog.Warn("querylog: logger stopped while writing entry; dropping entry.")
 		}
 	}()
 	select {
 	case ql.ch <- entry:
+		queued = true
+		observe.IncQueryLogEnqueuedEntries()
 	default:
+		ql.addBufferedEntries(-1)
+		observe.AddQueryLogDroppedEntries("buffer_full", 1)
 		slog.Warn("querylog: channel full, dropping entry.")
 	}
 }
@@ -216,8 +247,9 @@ func (ql *QueryLogger) Stop() {
 	_ = ql.StopContext(context.Background())
 }
 
-// StopContext drains remaining entries until ctx expires, then closes the DB to
-// unblock any in-flight flush.
+// StopContext drains remaining entries until ctx expires. If the deadline is
+// reached, it cancels in-flight DuckDB work; standalone loggers also close
+// their owned DB handle to unblock shutdown.
 func (ql *QueryLogger) StopContext(ctx context.Context) error {
 	if ql == nil {
 		return nil
@@ -235,9 +267,15 @@ func (ql *QueryLogger) StopContext(ctx context.Context) error {
 			case <-ql.done:
 			case <-ctx.Done():
 				stopErr = ctx.Err()
+				if ql.cancel != nil {
+					ql.cancel()
+				}
 			}
 		}
-		if ql.db != nil {
+		if ql.cancel != nil {
+			ql.cancel()
+		}
+		if ql.db != nil && ql.closeDB {
 			_ = ql.db.Close()
 		}
 	})
@@ -256,6 +294,7 @@ func queryLogStopContext(ctx context.Context, defaultTimeout time.Duration) (con
 
 func (ql *QueryLogger) flushLoop() {
 	defer close(ql.done)
+	defer observe.SetQueryLogBufferedEntries(0)
 
 	batch := make([]QueryLogEntry, 0, ql.cfg.BatchSize)
 	flushTicker := time.NewTicker(ql.cfg.FlushInterval)
@@ -295,10 +334,41 @@ func (ql *QueryLogger) flushLoop() {
 	}
 }
 
-func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
-	if err := insertQueryLogEntries(context.Background(), ql.db, ql.table, batch); err != nil {
-		slog.Error("querylog: flush failed.", "error", err, "batch_size", len(batch))
+func (ql *QueryLogger) addBufferedEntries(delta int64) {
+	if ql == nil {
+		return
 	}
+	buffered := ql.buffered.Add(delta)
+	if buffered < 0 {
+		ql.buffered.Store(0)
+		buffered = 0
+	}
+	observe.SetQueryLogBufferedEntries(int(buffered))
+}
+
+func (ql *QueryLogger) context() context.Context {
+	if ql == nil {
+		return context.Background()
+	}
+	ctx := ql.ctx
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func (ql *QueryLogger) flushBatch(batch []QueryLogEntry) {
+	defer ql.addBufferedEntries(-int64(len(batch)))
+	start := time.Now()
+	err := insertQueryLogEntries(ql.context(), ql.db, ql.table, batch)
+	observe.ObserveQueryLogFlushDuration(time.Since(start))
+	if err != nil {
+		observe.IncQueryLogFlushErrors()
+		observe.AddQueryLogDroppedEntries("flush_error", len(batch))
+		slog.Error("querylog: flush failed.", "error", err, "batch_size", len(batch))
+		return
+	}
+	observe.AddQueryLogFlushedEntries(len(batch))
 }
 
 func insertQueryLogEntries(ctx context.Context, db *sql.DB, table string, batch []QueryLogEntry) error {
@@ -369,7 +439,7 @@ func queryLogEntryInsertArgs(e QueryLogEntry) []any {
 }
 
 func (ql *QueryLogger) compactParquet() {
-	_, err := ql.db.Exec("CALL ducklake_flush_inlined_data('ducklake', schema_name => 'system', table_name => 'query_log')")
+	_, err := ql.db.ExecContext(ql.context(), "CALL ducklake_flush_inlined_data('ducklake', schema_name => 'system', table_name => 'query_log')")
 	if err != nil {
 		slog.Warn("querylog: compact failed.", "error", err)
 	}
@@ -599,11 +669,16 @@ func isQueryLogSelfReferential(query string) bool {
 func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType string,
 	resultRows, writtenRows int64, errCode, errMsg, protocol string) {
 
-	var ql QueryLogSink
-	if c.server.queryLogSink != nil {
+	var ql queryLogEntrySink
+	if c.server != nil && c.server.cfg.QueryLog.Enabled && c.executor != nil {
+		if sink, ok := c.executor.(queryLogEntrySink); ok {
+			ql = sink
+		}
+	}
+	if ql == nil && c.server != nil && c.server.queryLogSink != nil {
 		ql = c.server.queryLogSink
 	}
-	if ql == nil && c.server.queryLogger != nil {
+	if ql == nil && c.server != nil && c.server.queryLogger != nil {
 		ql = c.server.queryLogger
 	}
 	if ql == nil {

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -101,20 +101,27 @@ func NewQueryLogger(cfg Config) (*QueryLogger, error) {
 // already sees the tenant DuckLake catalog. The logger does not own db; callers
 // must close the handle after StopContext returns.
 func NewAttachedQueryLogger(db *sql.DB, cfg QueryLogConfig) (*QueryLogger, error) {
+	return NewAttachedQueryLoggerContext(context.Background(), db, cfg)
+}
+
+func NewAttachedQueryLoggerContext(ctx context.Context, db *sql.DB, cfg QueryLogConfig) (*QueryLogger, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !cfg.Enabled || db == nil {
 		return nil, nil
 	}
-	if err := ensureAttachedQueryLogTable(db, cfg); err != nil {
+	if err := ensureAttachedQueryLogTableContext(ctx, db, cfg); err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	loggerCtx, cancel := context.WithCancel(context.Background())
 	ql := &QueryLogger{
 		db:     db,
 		cfg:    cfg,
 		table:  "ducklake.system.query_log",
 		ch:     make(chan QueryLogEntry, queryLogChannelSize),
 		done:   make(chan struct{}),
-		ctx:    ctx,
+		ctx:    loggerCtx,
 		cancel: cancel,
 	}
 	go ql.flushLoop()
@@ -123,16 +130,23 @@ func NewAttachedQueryLogger(db *sql.DB, cfg QueryLogConfig) (*QueryLogger, error
 }
 
 func ensureAttachedQueryLogTable(db *sql.DB, cfg QueryLogConfig) error {
-	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS ducklake.system"); err != nil {
+	return ensureAttachedQueryLogTableContext(context.Background(), db, cfg)
+}
+
+func ensureAttachedQueryLogTableContext(ctx context.Context, db *sql.DB, cfg QueryLogConfig) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := db.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS ducklake.system"); err != nil {
 		return fmt.Errorf("querylog: create schema: %w", err)
 	}
-	if err := ensureQueryLogTable(db, "system", "query_log", "ducklake.system.query_log"); err != nil {
+	if err := ensureQueryLogTableContext(ctx, db, "system", "query_log", "ducklake.system.query_log"); err != nil {
 		return fmt.Errorf("querylog: ensure table: %w", err)
 	}
 	inlineStmt := fmt.Sprintf(
 		"CALL ducklake.set_option('data_inlining_row_limit', %d, schema => 'system', table_name => 'query_log')",
 		cfg.DataInliningRowLimit)
-	if _, err := db.Exec(inlineStmt); err != nil {
+	if _, err := db.ExecContext(ctx, inlineStmt); err != nil {
 		slog.Warn("querylog: failed to set data_inlining_row_limit, continuing without it.", "error", err)
 	}
 	return nil
@@ -462,26 +476,33 @@ func truncateNullableQuery(q *string) *string {
 }
 
 func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName string) error {
-	colType, err := queryLogColumnType(db, fullTableName, tableSchema, tableName, "normalized_query_hash")
+	return ensureQueryLogTableContext(context.Background(), db, tableSchema, tableName, fullTableName)
+}
+
+func ensureQueryLogTableContext(ctx context.Context, db *sql.DB, tableSchema, tableName, fullTableName string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	colType, err := queryLogColumnTypeContext(ctx, db, fullTableName, tableSchema, tableName, "normalized_query_hash")
 	if err == nil && strings.ToUpper(colType) != "BIGINT" {
 		slog.Info("querylog: dropping query_log to migrate normalized_query_hash from UBIGINT to BIGINT.")
-		if _, dropErr := db.Exec("DROP TABLE " + fullTableName); dropErr != nil {
+		if _, dropErr := db.ExecContext(ctx, "DROP TABLE "+fullTableName); dropErr != nil {
 			return fmt.Errorf("drop query_log for normalized_query_hash migration: %w", dropErr)
 		}
 	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("inspect normalized_query_hash column: %w", err)
 	}
 
-	if _, err := db.Exec(queryLogCreateTableSQL(fullTableName)); err != nil {
+	if _, err := db.ExecContext(ctx, queryLogCreateTableSQL(fullTableName)); err != nil {
 		return fmt.Errorf("create query_log table: %w", err)
 	}
 
-	hasOrgID, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, "org_id")
+	hasOrgID, err := queryLogColumnExistsContext(ctx, db, fullTableName, tableSchema, tableName, "org_id")
 	if err != nil {
 		return fmt.Errorf("inspect org_id column: %w", err)
 	}
 	if !hasOrgID {
-		if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN org_id VARCHAR"); err != nil {
+		if _, err := db.ExecContext(ctx, "ALTER TABLE "+fullTableName+" ADD COLUMN org_id VARCHAR"); err != nil {
 			return fmt.Errorf("add org_id column: %w", err)
 		}
 	}
@@ -489,12 +510,12 @@ func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName strin
 	// Add columns for OTEL tracing correlation and compatibility with tables
 	// created while distributed query-log delivery was supported.
 	for _, col := range []string{"trace_id", "span_id", "event_id"} {
-		hasCol, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, col)
+		hasCol, err := queryLogColumnExistsContext(ctx, db, fullTableName, tableSchema, tableName, col)
 		if err != nil {
 			return fmt.Errorf("inspect %s column: %w", col, err)
 		}
 		if !hasCol {
-			if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN " + col + " VARCHAR"); err != nil {
+			if _, err := db.ExecContext(ctx, "ALTER TABLE "+fullTableName+" ADD COLUMN "+col+" VARCHAR"); err != nil {
 				return fmt.Errorf("add %s column: %w", col, err)
 			}
 		}
@@ -510,16 +531,16 @@ func ensureQueryLogTable(db *sql.DB, tableSchema, tableName, fullTableName strin
 		{name: "cpu_time_s", typ: "DOUBLE"},
 		{name: "peak_buffer_memory_bytes", typ: "BIGINT"},
 	} {
-		hasCol, err := queryLogColumnExists(db, fullTableName, tableSchema, tableName, col.name)
+		hasCol, err := queryLogColumnExistsContext(ctx, db, fullTableName, tableSchema, tableName, col.name)
 		if err != nil {
 			return fmt.Errorf("inspect %s column: %w", col.name, err)
 		}
 		if !hasCol {
-			if _, err := db.Exec("ALTER TABLE " + fullTableName + " ADD COLUMN " + col.name + " " + col.typ + " DEFAULT 0"); err != nil {
+			if _, err := db.ExecContext(ctx, "ALTER TABLE "+fullTableName+" ADD COLUMN "+col.name+" "+col.typ+" DEFAULT 0"); err != nil {
 				return fmt.Errorf("add %s column: %w", col.name, err)
 			}
 		}
-		if _, err := db.Exec("UPDATE " + fullTableName + " SET " + col.name + " = 0 WHERE " + col.name + " IS NULL"); err != nil {
+		if _, err := db.ExecContext(ctx, "UPDATE "+fullTableName+" SET "+col.name+" = 0 WHERE "+col.name+" IS NULL"); err != nil {
 			return fmt.Errorf("backfill %s column: %w", col.name, err)
 		}
 	}
@@ -560,7 +581,11 @@ func queryLogCreateTableSQL(fullTableName string) string {
 }
 
 func queryLogColumnExists(db *sql.DB, fullTableName, tableSchema, tableName, columnName string) (bool, error) {
-	_, err := queryLogColumnType(db, fullTableName, tableSchema, tableName, columnName)
+	return queryLogColumnExistsContext(context.Background(), db, fullTableName, tableSchema, tableName, columnName)
+}
+
+func queryLogColumnExistsContext(ctx context.Context, db *sql.DB, fullTableName, tableSchema, tableName, columnName string) (bool, error) {
+	_, err := queryLogColumnTypeContext(ctx, db, fullTableName, tableSchema, tableName, columnName)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -571,6 +596,13 @@ func queryLogColumnExists(db *sql.DB, fullTableName, tableSchema, tableName, col
 }
 
 func queryLogColumnType(db *sql.DB, fullTableName, tableSchema, tableName, columnName string) (string, error) {
+	return queryLogColumnTypeContext(context.Background(), db, fullTableName, tableSchema, tableName, columnName)
+}
+
+func queryLogColumnTypeContext(ctx context.Context, db *sql.DB, fullTableName, tableSchema, tableName, columnName string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	query := "SELECT data_type FROM information_schema.columns WHERE table_name = $1 AND column_name = $2"
 	args := []any{tableName, columnName}
 	nextParam := 3
@@ -585,7 +617,7 @@ func queryLogColumnType(db *sql.DB, fullTableName, tableSchema, tableName, colum
 	}
 
 	var colType string
-	err := db.QueryRow(query, args...).Scan(&colType)
+	err := db.QueryRowContext(ctx, query, args...).Scan(&colType)
 	return colType, err
 }
 

--- a/server/querylog_test.go
+++ b/server/querylog_test.go
@@ -691,3 +691,34 @@ func TestLogQueryCopiesProfilingSummaryToQueryLogEntry(t *testing.T) {
 		t.Fatalf("expected profiling summary to be reset, got %#v", c.lastProfilingSummary)
 	}
 }
+
+type captureQueryLogExecutor struct {
+	feedbackExecutor
+	entries []QueryLogEntry
+}
+
+func (e *captureQueryLogExecutor) Log(entry QueryLogEntry) {
+	e.entries = append(e.entries, entry)
+}
+
+func TestLogQueryPrefersExecutorQueryLogSink(t *testing.T) {
+	c, ql, cleanup := newFeedbackClientConn(t)
+	defer cleanup()
+	exec := &captureQueryLogExecutor{}
+	c.executor = exec
+	c.server.cfg.QueryLog.Enabled = true
+
+	c.logQuery(time.Unix(1700000000, 0).UTC(), "SELECT 1", "", "SELECT", 1, 0, "", "", "simple")
+
+	if len(exec.entries) != 1 {
+		t.Fatalf("expected executor query-log sink to receive one entry, got %d", len(exec.entries))
+	}
+	if exec.entries[0].Query != "SELECT 1" {
+		t.Fatalf("unexpected forwarded query-log entry: %#v", exec.entries[0])
+	}
+	select {
+	case entry := <-ql.ch:
+		t.Fatalf("server query logger should not receive entry when executor sink is available: %#v", entry)
+	default:
+	}
+}

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -1,6 +1,8 @@
 package wire
 
 import (
+	"time"
+
 	"github.com/posthog/duckgres/server/ducklake"
 )
 
@@ -60,4 +62,43 @@ type WorkerWaitSessionIdlePayload struct {
 type WorkerReleaseQueryHandlePayload struct {
 	WorkerControlMetadata
 	Ticket []byte `json:"ticket"`
+}
+
+// QueryLogEntry represents a completed client query event that the control
+// plane asks the activated worker to persist in the tenant DuckLake.
+type QueryLogEntry struct {
+	EventID               string
+	EventTime             time.Time
+	QueryDurationMs       int64
+	Type                  string
+	Query                 string
+	TranspiledQuery       *string
+	QueryKind             string
+	NormalizedHash        int64
+	ResultRows            int64
+	WrittenRows           int64
+	ExceptionCode         string
+	Exception             string
+	UserName              string
+	OrgID                 string
+	CurrentDatabase       string
+	ClientAddress         string
+	ClientPort            int
+	ApplicationName       string
+	PID                   int32
+	WorkerID              int
+	IsTranspiled          bool
+	Protocol              string
+	TraceID               string
+	SpanID                string
+	PostgresScanMs        int64
+	CPUTimeSeconds        float64
+	PeakBufferMemoryBytes int64
+}
+
+// WorkerQueryLogPayload carries a batch of completed query-log entries to the
+// activated worker that owns the tenant DuckLake.
+type WorkerQueryLogPayload struct {
+	WorkerControlMetadata
+	Entries []QueryLogEntry `json:"entries"`
 }

--- a/server/worker_control.go
+++ b/server/worker_control.go
@@ -13,4 +13,5 @@ type (
 	WorkerHealthCheckPayload        = wire.WorkerHealthCheckPayload
 	WorkerWaitSessionIdlePayload    = wire.WorkerWaitSessionIdlePayload
 	WorkerReleaseQueryHandlePayload = wire.WorkerReleaseQueryHandlePayload
+	WorkerQueryLogPayload           = wire.WorkerQueryLogPayload
 )


### PR DESCRIPTION
## Summary

Adds the non-Kafka worker-local query-log write path for managed Duckgres:

- forwards completed query-log entries from the control-plane Flight executor to the activated worker with a bounded async queue
- persists entries through a worker-local attached DuckLake query logger that batches inserts into tenant `system.query_log`
- keeps the existing direct DuckLake logger as the standalone/single-tenant compatibility path
- adds query-log buffer, flush, drop, error, and latency metrics
- rejects stale, unactivated, closing, or mismatched worker/tenant `LogQuery` deliveries

This intentionally does not fall back from failed worker forwarding to the old direct server sink in managed mode, because that can write to the wrong tenant DuckLake. Forwarding failures are best-effort and counted with drop metrics.

## Validation

- `go test -count=1 ./server/observe ./server/flightclient ./server ./duckdbservice ./controlplane`
- review-fix-loop completed cleanly on loop 3

## Notes

Branch is based on Duckgres #900, which removed the Kafka query-log writer. `origin/main` is one unrelated scenario-runner commit ahead.
