### PR TITLE
Backfill pinned cnpg shard into Duckling spec (spec.metadataStore.cnpgShard)

### DIFF
--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -73,6 +73,13 @@ type Controller struct {
 	// ducklings that predate CP-owned naming. Empty ⇒ backfill is a no-op and
 	// the composition keeps deriving the name.
 	bucketSuffix string
+
+	// cnpgShardFieldUnsupported latches when a cnpg-shard backfill read-back
+	// shows the API server pruned spec.metadataStore.cnpgShard — i.e. the
+	// cluster's Duckling XRD predates the field. Cluster-wide condition, so
+	// one latch disables the backfill (not per-org) until restart; the
+	// reconcile loop is single-goroutine so no locking. See reconcileCnpgShard.
+	cnpgShardFieldUnsupported bool
 }
 
 // NewController creates a provisioning controller. Returns an error if the
@@ -390,6 +397,17 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 	// has been deriving into status, so the patch moves it from a derived output
 	// into a durable input without changing the actual bucket. No-op once set.
 	c.reconcileBucketName(ctx, w, log)
+
+	// Backfill the composition-pinned cnpg shard onto the Duckling spec
+	// (spec.metadataStore.cnpgShard) for cnpg-shard ducklings provisioned
+	// before the field existed. Same derived-output → durable-input move as
+	// the bucket name: the value written is exactly the CR's own
+	// status.metadataStore.assignedShard, so the composition re-renders
+	// identically and nothing moves. Once every duckling carries it, the
+	// shard a tenant lives on is explicit, schema-validated spec — the
+	// prerequisite for shard-migration cutovers, which patch this field to a
+	// DIFFERENT shard (an explicitly operator-driven step, never done here).
+	c.reconcileCnpgShard(ctx, w, log)
 }
 
 // reconcileBucketName backfills spec.dataStore.bucketName (and the config-store
@@ -443,6 +461,59 @@ func (c *Controller) reconcileBucketName(ctx context.Context, w *configstore.Man
 		}); err != nil {
 			log.Warn("Failed to persist dataStore bucket name to config store.", "error", err)
 		}
+	}
+}
+
+// reconcileCnpgShard backfills spec.metadataStore.cnpgShard with the CR's own
+// pinned status.metadataStore.assignedShard for ready cnpg-shard ducklings
+// that don't carry the field yet. Idempotent and self-limiting: a no-op for
+// non-cnpg metadata stores, while the pin isn't stamped yet, and once the
+// spec carries ANY value — an existing (different) spec value is an
+// operator-set migration override we must never stomp.
+//
+// The read-back after the patch detects a cluster whose Duckling XRD predates
+// the field (the API server then silently prunes it): that disables the
+// backfill for the rest of this controller's lifetime — cluster-wide
+// condition, one WARN, no per-tick patch churn.
+func (c *Controller) reconcileCnpgShard(ctx context.Context, w *configstore.ManagedWarehouse, log *slog.Logger) {
+	if c.cnpgShardFieldUnsupported {
+		return
+	}
+	if w.MetadataStore.Kind != configstore.MetadataStoreKindCnpgShard {
+		return
+	}
+
+	specShard, assignedShard, err := c.duckling.GetCnpgShardState(ctx, ducklingCRName(w))
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		log.Warn("Failed to read Duckling CR cnpg shard state for backfill.", "error", err)
+		return
+	}
+	if specShard != "" {
+		// Already backfilled, or an operator-set migration override.
+		return
+	}
+	if assignedShard == "" {
+		// Composition hasn't stamped the pin yet.
+		return
+	}
+
+	log.Info("Backfilling pinned cnpg shard onto Duckling CR spec.", "shard", assignedShard)
+	if err := c.duckling.SetMetadataStoreCnpgShard(ctx, ducklingCRName(w), assignedShard); err != nil {
+		log.Warn("Failed to patch Duckling CR metadataStore.cnpgShard.", "error", err)
+		return
+	}
+	readBack, _, err := c.duckling.GetCnpgShardState(ctx, ducklingCRName(w))
+	if err != nil {
+		log.Warn("Failed to read back Duckling CR cnpg shard after backfill.", "error", err)
+		return
+	}
+	if readBack != assignedShard {
+		c.cnpgShardFieldUnsupported = true
+		log.Warn("Duckling XRD pruned spec.metadataStore.cnpgShard — the cluster's XRD predates the field; disabling the shard backfill until this control plane restarts.",
+			"wrote", assignedShard, "readBack", readBack)
 	}
 }
 

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
@@ -350,6 +351,155 @@ func TestReconcileReadyNoDriftDoesNotPatch(t *testing.T) {
 	}
 	if got.GetResourceVersion() != seededRV {
 		t.Fatalf("expected no patch when in sync, resourceVersion went %q -> %q", seededRV, got.GetResourceVersion())
+	}
+}
+
+// seedCnpgCR creates a cnpg-shard Duckling CR with the given spec override and
+// status-pinned shard (either may be empty to omit the field).
+func seedCnpgCR(t *testing.T, fakeK8s *dynamicfake.FakeDynamicClient, name, specShard, assignedShard string) {
+	t.Helper()
+	ms := map[string]interface{}{"type": "cnpg-shard"}
+	if specShard != "" {
+		ms["cnpgShard"] = specShard
+	}
+	obj := map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ducklingNamespace,
+		},
+		"spec": map[string]interface{}{
+			"metadataStore": ms,
+		},
+	}
+	if assignedShard != "" {
+		obj["status"] = map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"type":          "cnpg-shard",
+				"assignedShard": assignedShard,
+			},
+		}
+	}
+	cr := &unstructured.Unstructured{Object: obj}
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(context.Background(), cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+}
+
+func cnpgWarehouse(org string) *configstore.ManagedWarehouse {
+	return &configstore.ManagedWarehouse{
+		OrgID:         org,
+		DucklingName:  org,
+		State:         configstore.ManagedWarehouseStateReady,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{Kind: configstore.MetadataStoreKindCnpgShard},
+	}
+}
+
+func specCnpgShardOf(t *testing.T, fakeK8s *dynamicfake.FakeDynamicClient, name string) string {
+	t.Helper()
+	got, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch CR: %v", err)
+	}
+	spec, _ := got.Object["spec"].(map[string]interface{})
+	ms, _ := spec["metadataStore"].(map[string]interface{})
+	shard, _ := ms["cnpgShard"].(string)
+	return shard
+}
+
+// TestReconcileReadyBackfillsCnpgShard pins the derived-output → durable-input
+// backfill: a ready cnpg-shard duckling with no spec override gets its own
+// status-pinned assignedShard stamped into spec.metadataStore.cnpgShard, with
+// sibling fields preserved.
+func TestReconcileReadyBackfillsCnpgShard(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-bf"] = cnpgWarehouse("org-bf")
+	seedCnpgCR(t, fakeK8s, "org-bf", "", "shard-001")
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.reconcile(context.Background())
+
+	if got := specCnpgShardOf(t, fakeK8s, "org-bf"); got != "shard-001" {
+		t.Fatalf("spec.metadataStore.cnpgShard = %q, want shard-001", got)
+	}
+	got, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(context.Background(), "org-bf", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch CR: %v", err)
+	}
+	ms := got.Object["spec"].(map[string]interface{})["metadataStore"].(map[string]interface{})
+	if ms["type"] != "cnpg-shard" {
+		t.Fatalf("merge patch must preserve metadataStore.type, got %v", ms["type"])
+	}
+}
+
+// TestReconcileCnpgShardSkips pins every no-op path: an existing spec value
+// (an operator-set migration override pointing at a DIFFERENT shard) is never
+// stomped, a not-yet-stamped pin defers, and non-cnpg metadata stores are
+// ignored entirely.
+func TestReconcileCnpgShardSkips(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+
+	// Operator override present — must survive untouched.
+	fs.warehouses["org-override"] = cnpgWarehouse("org-override")
+	seedCnpgCR(t, fakeK8s, "org-override", "shard-002", "shard-001")
+
+	// Pin not stamped yet (composition still rendering) — nothing to backfill.
+	fs.warehouses["org-unpinned"] = cnpgWarehouse("org-unpinned")
+	seedCnpgCR(t, fakeK8s, "org-unpinned", "", "")
+
+	// External metadata store — no shard concept.
+	fs.warehouses["org-ext"] = &configstore.ManagedWarehouse{
+		OrgID:         "org-ext",
+		DucklingName:  "org-ext",
+		State:         configstore.ManagedWarehouseStateReady,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{Kind: configstore.MetadataStoreKindExternal},
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.reconcile(context.Background())
+
+	if got := specCnpgShardOf(t, fakeK8s, "org-override"); got != "shard-002" {
+		t.Fatalf("operator override was stomped: cnpgShard = %q, want shard-002", got)
+	}
+	if got := specCnpgShardOf(t, fakeK8s, "org-unpinned"); got != "" {
+		t.Fatalf("unpinned CR was patched: cnpgShard = %q, want empty", got)
+	}
+}
+
+// TestReconcileCnpgShardLatchesOnPrunedPatch pins the XRD-drift guard: when
+// the API server prunes the field (Duckling XRD predates it — simulated by a
+// reactor that swallows the patch), the read-back mismatch latches the
+// backfill off so it doesn't churn a patch per tick until the XRD ships.
+func TestReconcileCnpgShardLatchesOnPrunedPatch(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	fs.warehouses["org-prune"] = cnpgWarehouse("org-prune")
+	seedCnpgCR(t, fakeK8s, "org-prune", "", "shard-001")
+
+	patches := 0
+	fakeK8s.PrependReactor("patch", "ducklings", func(k8stesting.Action) (bool, runtime.Object, error) {
+		patches++
+		// Swallow the patch: return the stored object unmodified, like an API
+		// server whose XRD prunes the unknown field.
+		obj, err := fakeK8s.Tracker().Get(ducklingGVR, ducklingNamespace, "org-prune")
+		return true, obj, err
+	})
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.reconcile(context.Background())
+	if patches != 1 {
+		t.Fatalf("first tick patches = %d, want 1", patches)
+	}
+	if !ctrl.cnpgShardFieldUnsupported {
+		t.Fatal("pruned patch did not latch cnpgShardFieldUnsupported")
+	}
+
+	ctrl.reconcile(context.Background())
+	if patches != 1 {
+		t.Fatalf("latched backfill still patched: patches = %d, want 1", patches)
 	}
 }
 

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -421,6 +421,64 @@ func (d *DucklingClient) SetDataStoreBucketName(ctx context.Context, name, bucke
 	return nil
 }
 
+// GetCnpgShardState reads, in one CR read, the explicit shard override
+// (spec.metadataStore.cnpgShard) and the composition-pinned assignment
+// (status.metadataStore.assignedShard) of the named Duckling CR. An empty
+// specShard means no override is set (pre-backfill CR, or an XRD that pruned
+// the field); an empty assignedShard means the composition hasn't stamped the
+// pin yet (still provisioning) or the CR isn't cnpg-shard.
+func (d *DucklingClient) GetCnpgShardState(ctx context.Context, name string) (specShard, assignedShard string, err error) {
+	cr, gerr := d.getCR(ctx, name)
+	if gerr != nil {
+		return "", "", fmt.Errorf("get duckling CR %q: %w", name, gerr)
+	}
+	if spec, ok := cr.Object["spec"].(map[string]interface{}); ok {
+		if ms, ok := spec["metadataStore"].(map[string]interface{}); ok {
+			specShard, _ = ms["cnpgShard"].(string)
+		}
+	}
+	if status, ok := cr.Object["status"].(map[string]interface{}); ok {
+		if ms, ok := status["metadataStore"].(map[string]interface{}); ok {
+			assignedShard, _ = ms["assignedShard"].(string)
+		}
+	}
+	return specShard, assignedShard, nil
+}
+
+// SetMetadataStoreCnpgShard patches spec.metadataStore.cnpgShard on the named
+// Duckling CR. JSON merge patch (RFC 7396) so it's idempotent and only touches
+// that one field — type/external/pgbouncer siblings are left untouched.
+//
+// Setting it to the CR's own status.metadataStore.assignedShard (the backfill
+// in reconcileReady) is a pure no-op for the composition. Setting a DIFFERENT
+// shard is the cutover step of a metadata-store migration: the composition
+// re-points the per-tenant provider-sql Role/Database at the new shard's
+// ProviderConfig IN PLACE (same pgIdent, same pinned password; the old
+// shard's role/database are orphaned, not dropped) and does NOT copy any
+// catalog data — the caller is responsible for having restored the catalog
+// on the target shard first. Callers should read the value back with
+// GetCnpgShardState: an XRD that predates the field silently prunes the
+// patch, so a successful Patch alone does not mean the override applied.
+func (d *DucklingClient) SetMetadataStoreCnpgShard(ctx context.Context, name, shard string) error {
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"cnpgShard": shard,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal cnpgShard patch for %q: %w", name, err)
+	}
+	_, err = d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patch duckling CR %q metadataStore cnpgShard: %w", name, err)
+	}
+	return nil
+}
+
 // readSpecDuckLakeEnabled returns spec.ducklake.enabled as *bool — nil when the
 // ducklake block (or its enabled key) is absent, so callers can distinguish a
 // legacy CR (apply the type-based default) from an explicit true/false.

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -2129,6 +2129,43 @@ admin_ducklings_metadata() { # cnpgOrg extOrg
   log "admin ducklings metadata OK ($cnpg_d on $(echo "$out" | jq -r --arg d "$cnpg_d" '.entries[$d].cnpg_shard'))"
 }
 
+# ---- duckling shard backfill (provisioner reconcileCnpgShard) --------------
+# The CP backfills the composition-pinned shard (status.metadataStore.
+# assignedShard) of a ready cnpg-shard duckling into
+# spec.metadataStore.cnpgShard, making the tenant's shard explicit,
+# schema-validated spec — the precondition for shard-migration cutovers.
+# Provisioner tick is 10s and the warehouse has been ready for a while by the
+# time this runs, so 120s is generous.
+#
+# The spec field only exists once the cluster's Duckling XRD carries it
+# (charts PR #12918); an older XRD silently prunes the patch and the CP
+# latches its backfill off. That state is EXPECTED until that PR deploys, so
+# on timeout this probes XRD support by patching the field itself (the Job SA
+# has ducklings patch via duckgres-duckling-reader): probe pruned → loud SKIP,
+# not a failure; probe sticks → the field works and the CP failed to backfill
+# → real failure.
+duckling_shard_backfill() { # cnpgOrg
+  d="$(echo "$1" | tr 'A-Z' 'a-z')"
+  log "duckling shard backfill: spec.metadataStore.cnpgShard on duckling/$d"
+  assigned="$("$KUBECTL" -n ducklings get duckling "$d" -o jsonpath='{.status.metadataStore.assignedShard}')"
+  [ -n "$assigned" ] || fail "duckling shard backfill: duckling/$d has no status.metadataStore.assignedShard"
+  spec=""
+  for _ in $(seq 1 12); do
+    spec="$("$KUBECTL" -n ducklings get duckling "$d" -o jsonpath='{.spec.metadataStore.cnpgShard}')"
+    [ "$spec" = "$assigned" ] && { log "duckling shard backfill OK (spec.cnpgShard=$spec)"; return 0; }
+    sleep 10
+  done
+  "$KUBECTL" -n ducklings patch duckling "$d" --type merge \
+    -p "{\"spec\":{\"metadataStore\":{\"cnpgShard\":\"$assigned\"}}}" >/dev/null \
+    || fail "duckling shard backfill: probe patch failed"
+  probe="$("$KUBECTL" -n ducklings get duckling "$d" -o jsonpath='{.spec.metadataStore.cnpgShard}')"
+  if [ -z "$probe" ]; then
+    log "SKIP: duckling shard backfill — cluster XRD predates spec.metadataStore.cnpgShard (charts #12918 not deployed); the CP latches the backfill off, nothing to assert yet"
+    return 0
+  fi
+  fail "duckling shard backfill: XRD supports the field (probe stuck: $probe) but the CP never backfilled it (spec=$spec assigned=$assigned)"
+}
+
 # ---- tenant isolation -----------------------------------------------------
 # Two tenants (cnpg + ext) back onto distinct DuckLake metadata stores, so a
 # table created by one is invisible to the other. Ported (logical half) from
@@ -2550,6 +2587,9 @@ main() {
   # ---- admin ducklings metadata: live cnpg shard assignment ----------------
   admin_ducklings_metadata "$CNPG" "$EXT"
 
+  # ---- provisioner backfills pinned shard into duckling spec (cnpg) --------
+  duckling_shard_backfill "$CNPG"
+
   # ---- admin live-query detail view (phase 1) — cnpg stack is warm now ----
   admin_query_detail "$CNPG" "$cnpg_pw"
 
@@ -2597,7 +2637,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"


### PR DESCRIPTION
Companion to charts PR https://github.com/PostHog/charts/pull/12918, which adds the optional `spec.metadataStore.cnpgShard` field to the Duckling XRD (precedence: spec override > pinned `status.metadataStore.assignedShard` > `cnpg.activeShard`).

## What

Scope is deliberately just **getting the shard info into the spec** — no migration machinery, no admin surface.

The provisioner's `reconcileReady` now backfills `spec.metadataStore.cnpgShard` on ready cnpg-shard ducklings with the CR's own pinned `status.metadataStore.assignedShard` — the same derived-output → durable-input move as the existing bucket-name backfill, and a pure no-op for the composition since the written value equals the pin. Invariants:

- Never overwrites an existing spec value (that would be an operator-set migration override).
- No-op for external metadata stores and while the pin isn't stamped yet.
- **XRD-drift guard:** on a cluster whose Duckling XRD predates the field, the API server silently prunes the patch. The post-patch read-back detects this and latches the backfill off for the controller's lifetime (one WARN, no per-tick patch churn). It resumes on the next CP restart after the new XRD deploys.

Once every duckling carries the field, the shard a tenant lives on is explicit, schema-validated spec — the precondition for shard-migration cutovers, which patch this field to a *different* shard (explicitly operator-driven; never done by this backfill).

## Tests

- `controlplane/provisioner/controller_test.go`: backfill happy path (sibling spec fields preserved), never-stomp-override / unpinned / external no-op paths, and the pruned-patch latch (reactor swallows the patch → latch set → no second patch).
- e2e (`tests/e2e-mw-dev/harness.sh`): new `duckling_shard_backfill` assertion in the cnpg lane — waits for `spec.metadataStore.cnpgShard` to match the pinned shard. Until charts #12918 is deployed to mw-dev the XRD prunes the field, so the assertion probes field support with its own patch and SKIPs loudly (instead of failing); it becomes a hard assertion the moment the new XRD ships.

## Deploy order

Safe in either order (that's what the latch is for), but the backfill only takes effect after charts #12918 is deployed and the CP restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)