### PR TITLE
admin/ui: don't let a deprovisioned warehouse block org delete

### DIFF
--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -132,10 +132,14 @@ export function OrgDetail() {
     }
   };
 
-  // Org deletion is blocked while a managed warehouse still exists: the correct
-  // flow is deprovision → provisioner tears down the duckling and removes the
-  // warehouse row → then delete. The backend 409s too; this is belt-and-suspenders.
-  const orgHasWarehouse = Boolean(org.data?.warehouse) || Boolean(warehouse.data);
+  // Org deletion is blocked while a managed warehouse is still LIVE: the
+  // correct flow is deprovision → provisioner tears down the duckling → then
+  // delete. Deprovisioning does not remove the warehouse row — it parks it in
+  // the terminal "deleted" state (infra gone), which must NOT block deletion
+  // or a fully deprovisioned org becomes undeletable. The backend applies the
+  // same state<>deleted rule and sweeps the dead row; this is belt-and-suspenders.
+  const liveWarehouse = (w?: { state?: string } | null) => Boolean(w) && w?.state !== "deleted";
+  const orgHasWarehouse = liveWarehouse(org.data?.warehouse) || liveWarehouse(warehouse.data);
 
   const closeDelete = () => {
     setConfirmDelete(false);


### PR DESCRIPTION
A fully deprovisioned org was undeletable from the UI: deprovision parks the warehouse row in the terminal `deleted` state (infra gone, row kept — `reconcileDeleting`), but the org-delete gating counted **any** warehouse row as blocking. Result: Delete button permanently disabled with the "deprovision first" tooltip, while the Deprovision button is (correctly) hidden for `deleted` — a dead end. Hit on a real deprovisioned org in prod.

Fix: only a **live** warehouse (`state !== "deleted"`) blocks deletion — matching the backend `DeleteOrg` rule, which already excludes `state=deleted` and sweeps the dead row inside the delete transaction. One expression change; the header button, dialog warning, and confirm-disable all key off it.

`npm run build` (tsc + vite) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)