### PR TITLE
Add admin dashboard hotdog favicon

### DIFF
--- a/controlplane/admin/ui/index.html
+++ b/controlplane/admin/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
+    <link rel="icon" type="image/png" href="/src/assets/hotdog.png" />
     <title>Duckgres Admin</title>
   </head>
   <body>

--- a/controlplane/admin/ui/src/indexHtml.test.ts
+++ b/controlplane/admin/ui/src/indexHtml.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("index.html", () => {
+  it("uses the hotdog image as the admin dashboard favicon", () => {
+    const html = readFileSync(resolve(__dirname, "../index.html"), "utf8");
+    const document = new DOMParser().parseFromString(html, "text/html");
+
+    const icon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+
+    expect(icon?.getAttribute("type")).toBe("image/png");
+    expect(icon?.getAttribute("href")).toBe("/src/assets/hotdog.png");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the existing admin UI hotdog PNG as the dashboard favicon by linking it from `index.html`.

Also adds a Vitest guard that reads `index.html` and verifies the favicon link continues to point at the hotdog PNG. The production Vite build emits this as the hashed asset `hotdog-D0v6W5C8.png`.

## Validation

- `just ui-test` passed
- `just lint` was attempted, but the local run is blocked by a toolchain mismatch: `golangci-lint` panics because it was built with Go 1.25 while one loaded file requires Go 1.26

## Impact

The admin dashboard browser tab now uses the hotdog image as its favicon. No API or backend behavior changes.