### PR TITLE
Show readable org names in load table

### DIFF
--- a/controlplane/admin/ui/src/pages/Overview.test.tsx
+++ b/controlplane/admin/ui/src/pages/Overview.test.tsx
@@ -10,6 +10,7 @@ const hooks = vi.hoisted(() => ({
   useFleet: vi.fn(),
   useModel: vi.fn(),
   useMetricRange: vi.fn(),
+  useOrgs: vi.fn(),
 }));
 
 vi.mock("@/hooks/useApi", () => hooks);
@@ -18,11 +19,17 @@ import { Overview } from "./Overview";
 
 const ok = <T,>(data: T) => ({ data, isSuccess: true, isLoading: false, isError: false });
 
-function setup(fleet: FleetStat[], opts?: { sessions?: number; orgs?: number }) {
+function setup(fleet: FleetStat[], opts?: { sessions?: number; orgs?: number; statusOrgs?: unknown[]; orgRows?: unknown[] }) {
   hooks.useFleet.mockReturnValue(ok(fleet));
   hooks.useClusterStatus.mockReturnValue(
-    ok({ total_orgs: opts?.orgs ?? 11, total_sessions: opts?.sessions ?? 0, total_workers: 0, orgs: [] }),
+    ok({
+      total_orgs: opts?.orgs ?? 11,
+      total_sessions: opts?.sessions ?? 0,
+      total_workers: 0,
+      orgs: opts?.statusOrgs ?? [],
+    }),
   );
+  hooks.useOrgs.mockReturnValue(ok(opts?.orgRows ?? []));
   hooks.useModel.mockReturnValue(ok({ rows: [] }));
   hooks.useMetricRange.mockReturnValue(ok(undefined));
 }
@@ -66,5 +73,34 @@ describe("Overview Workers card", () => {
 
     expect(within(card("Workers")).getByText("4 hot · 25 idle")).toBeInTheDocument();
     expect(screen.getByText(/reserving vCPU/i)).toBeInTheDocument();
+  });
+});
+
+describe("Overview per-org load", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the readable org database name when org metadata is available", () => {
+    setup([], {
+      statusOrgs: [
+        {
+          name: "019740a8-ac01-0000-cad1-26dbbe0cde55",
+          workers: 7,
+          active_sessions: 3,
+          max_workers: 10,
+        },
+      ],
+      orgRows: [
+        {
+          name: "019740a8-ac01-0000-cad1-26dbbe0cde55",
+          database_name: "product_analytics",
+          hostname_alias: null,
+        },
+      ],
+    });
+
+    render(<Overview />);
+
+    expect(screen.getByText("product_analytics")).toBeInTheDocument();
+    expect(screen.getByText("019740a8-ac01-0000-cad1-26dbbe0cde55")).toBeInTheDocument();
   });
 });

--- a/controlplane/admin/ui/src/pages/Overview.tsx
+++ b/controlplane/admin/ui/src/pages/Overview.tsx
@@ -6,7 +6,7 @@ import { Sparkline } from "@/components/Sparkline";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
-import { useClusterStatus, useFleet, useMetricRange, useModel } from "@/hooks/useApi";
+import { useClusterStatus, useFleet, useMetricRange, useModel, useOrgs } from "@/hooks/useApi";
 import { fmtInt, fmtPercent, promToSeries } from "@/lib/format";
 import { isIdleLeak, orgLoadPercent, summarizeFleet, topOrgsByLoad } from "@/lib/fleet";
 import type { WorkerLifecycleState } from "@/types/api";
@@ -22,6 +22,7 @@ const LIFECYCLE: WorkerLifecycleState[] = [
 export function Overview() {
   const status = useClusterStatus();
   const fleet = useFleet();
+  const orgs = useOrgs();
   const queue = useModel("org-connection-queue");
   const cps = useModel("cp-instances");
   const qTotal = useMetricRange("query_rate", undefined, "1h");
@@ -62,6 +63,13 @@ export function Overview() {
   // (warm, reserving the pod but running no query).
   const busyWorkers = fleetSummary.busy;
   const idleWorkers = fleetSummary.idle;
+  const orgLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const org of orgs.data ?? []) {
+      labels.set(org.name, org.database_name || org.hostname_alias || org.name);
+    }
+    return labels;
+  }, [orgs.data]);
 
   return (
     <>
@@ -165,9 +173,19 @@ export function Overview() {
               <div className="space-y-1.5">
                 {topOrgsByLoad(status.data?.orgs, 12).map((o) => {
                   const pct = orgLoadPercent(o.workers, o.max_workers);
+                  const label = orgLabels.get(o.name) ?? o.name;
                   return (
                     <div key={o.name} className="flex items-center gap-3 text-sm">
-                      <span className="w-44 truncate font-mono text-xs">{o.name}</span>
+                      <span className="w-52 min-w-0">
+                        <span className="block truncate text-xs font-medium text-foreground" title={label}>
+                          {label}
+                        </span>
+                        {label !== o.name ? (
+                          <span className="block truncate font-mono text-[11px] text-muted-foreground" title={o.name}>
+                            {o.name}
+                          </span>
+                        ) : null}
+                      </span>
                       <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
                         <div className="h-full rounded-full bg-primary" style={{ width: `${pct}%` }} />
                       </div>


### PR DESCRIPTION
## Summary

Show a readable org label in the Overview page's per-org load table when org metadata is available. The table now prefers `database_name`, then `hostname_alias`, and falls back to the raw org id. When a readable label is shown, the raw org id remains visible underneath for disambiguation.

## Validation

- `just ui-test`
- `just lint`