### PR TITLE
Reflect real composed-resource errors in warehouse provisioning status

### DIFF
--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -271,36 +272,33 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 		return
 	}
 
-	// Track per-component readiness based on Duckling CR status fields.
-	// Infrastructure details (endpoint, password, bucket, etc.) are read directly
-	// from the Duckling CR by the worker activator at activation time — only
-	// state transitions are stored in the config store.
+	// Track per-component readiness. A component is ready only once the XR's
+	// Ready condition is True — NOT merely because its status field
+	// (bucketName, endpoint, password, iamRoleArn) is populated. The
+	// composition sets those fields as soon as it *renders* the composed
+	// resource, which happens well before that resource actually reconciles, so
+	// keying readiness on field presence alone reported a component (notably S3)
+	// green while its underlying managed resource was still failing — e.g. a
+	// bucket stuck on BucketNotEmpty. Ready is Crossplane's aggregate "all
+	// composed resources reconciled" signal, so gate on it and recompute every
+	// tick: a component that regresses is revoked, not latched on.
 	updates := map[string]interface{}{}
 
-	if status.DataStore.BucketName != "" && w.S3State != configstore.ManagedWarehouseStateReady {
-		updates["s3_state"] = configstore.ManagedWarehouseStateReady
+	setComponent := func(key string, current configstore.ManagedWarehouseProvisioningState, present bool) bool {
+		desired := configstore.ManagedWarehouseStateProvisioning
+		if present && status.ReadyCondition {
+			desired = configstore.ManagedWarehouseStateReady
+		}
+		if current != desired {
+			updates[key] = desired
+		}
+		return desired == configstore.ManagedWarehouseStateReady
 	}
 
-	if status.MetadataStore.Endpoint != "" && w.MetadataStoreState != configstore.ManagedWarehouseStateReady {
-		updates["metadata_store_state"] = configstore.ManagedWarehouseStateReady
-	}
-
-	if status.MetadataStore.Password != "" && w.SecretsState != configstore.ManagedWarehouseStateReady {
-		updates["secrets_state"] = configstore.ManagedWarehouseStateReady
-	}
-
-	if status.IAMRoleARN != "" && w.IdentityState != configstore.ManagedWarehouseStateReady {
-		updates["identity_state"] = configstore.ManagedWarehouseStateReady
-	}
-
-	// Infrastructure is ready when all components are provisioned AND the
-	// Crossplane Ready condition is True. The Ready condition ensures all
-	// composed resources (including the metadata store) are fully reconciled,
-	// not just that individual status fields are populated.
-	s3Ready := w.S3State == configstore.ManagedWarehouseStateReady || updates["s3_state"] == configstore.ManagedWarehouseStateReady
-	metaReady := w.MetadataStoreState == configstore.ManagedWarehouseStateReady || updates["metadata_store_state"] == configstore.ManagedWarehouseStateReady
-	secretsReady := w.SecretsState == configstore.ManagedWarehouseStateReady || updates["secrets_state"] == configstore.ManagedWarehouseStateReady
-	identReady := w.IdentityState == configstore.ManagedWarehouseStateReady || updates["identity_state"] == configstore.ManagedWarehouseStateReady
+	s3Ready := setComponent("s3_state", w.S3State, status.DataStore.BucketName != "")
+	metaReady := setComponent("metadata_store_state", w.MetadataStoreState, status.MetadataStore.Endpoint != "")
+	secretsReady := setComponent("secrets_state", w.SecretsState, status.MetadataStore.Password != "")
+	identReady := setComponent("identity_state", w.IdentityState, status.IAMRoleARN != "")
 
 	if s3Ready && metaReady && secretsReady && identReady && status.ReadyCondition {
 		// End-to-end probe: AWS reports the metadata store (RDS) Available before
@@ -344,6 +342,16 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 			updates["ready_at"] = now
 			log.Info("Infrastructure ready, transitioning to ready.", "pgbouncer_enabled", w.PgBouncer.Enabled)
 		}
+	} else if !status.ReadyCondition {
+		// Still provisioning and the XR is not Ready — surface *why*. Prefer the
+		// concrete provider error from a failing composed resource (e.g. the S3
+		// bucket's BucketNotEmpty) over the XR's generic "Unready resources:
+		// <name>" roll-up, so the admin UI shows the actual blocker instead of a
+		// stale message. Guarded to the not-Ready branch so it never overwrites
+		// the probe-wait / ready messages set above.
+		if msg := c.diagnoseNotReady(ctx, w, status); msg != "" && msg != w.StatusMessage {
+			updates["status_message"] = msg
+		}
 	}
 
 	if len(updates) > 0 {
@@ -358,6 +366,35 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 		}
 	}
 
+}
+
+// statusMessageMaxLen bounds the diagnostic status message so a verbose provider
+// error can't overflow the status_message column (VARCHAR(1024)).
+const statusMessageMaxLen = 1000
+
+// diagnoseNotReady builds a human-facing explanation of why a still-provisioning
+// warehouse is not Ready. It asks Kubernetes for the failing composed resources
+// and joins their provider errors (the actual blocker, e.g. a bucket's
+// BucketNotEmpty); if none report an error — or the lookup fails — it falls back
+// to the XR's own Ready-condition roll-up ("Unready resources: <name>"). Returns
+// "" when there is nothing more specific to say.
+func (c *Controller) diagnoseNotReady(ctx context.Context, w *configstore.ManagedWarehouse, status *DucklingStatus) string {
+	errs, err := c.duckling.ComposedResourceErrors(ctx, ducklingCRName(w))
+	if err == nil && len(errs) > 0 {
+		parts := make([]string, 0, len(errs))
+		for _, e := range errs {
+			parts = append(parts, fmt.Sprintf("%s %s: %s", e.Kind, e.Name, e.Message))
+		}
+		return truncate(strings.Join(parts, "; "), statusMessageMaxLen)
+	}
+	return truncate(status.ReadyFalseMessage, statusMessageMaxLen)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
 }
 
 // reconcileReady handles drift correction for Ready warehouses. The

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -907,6 +907,155 @@ func TestFakeStoreUpdateWarehouseState(t *testing.T) {
 	}
 }
 
+func TestParseDucklingStatusReadyFalseMessage(t *testing.T) {
+	// A wedged S3 bucket produces exactly this: the XR composed fine
+	// (Synced=True) but a composed resource has not reconciled, so Ready=False
+	// carries the roll-up of what is unready.
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Synced", "status": "True"},
+					map[string]interface{}{
+						"type":    "Ready",
+						"status":  "False",
+						"message": "Unready resources: s3-bucket",
+					},
+				},
+			},
+		},
+	}
+
+	status, err := parseDucklingStatus(cr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.ReadyCondition {
+		t.Fatal("expected Ready to be false")
+	}
+	if status.SyncedFalseMessage != "" {
+		t.Fatalf("expected no synced-false message, got %q", status.SyncedFalseMessage)
+	}
+	if status.ReadyFalseMessage != "Unready resources: s3-bucket" {
+		t.Fatalf("expected ready-false roll-up, got %q", status.ReadyFalseMessage)
+	}
+}
+
+func TestKindToResource(t *testing.T) {
+	// Guards the pluralization the composed-resource GVR mapping depends on —
+	// every Kind the Duckling composition composes must map to the right
+	// resource segment, or ComposedResourceErrors silently skips it.
+	cases := map[string]string{
+		"Bucket":       "buckets",
+		"BucketPolicy": "bucketpolicies",
+		"Role":         "roles",
+		"RolePolicy":   "rolepolicies",
+		"Database":     "databases",
+		"Object":       "objects",
+		"Usage":        "usages",
+	}
+	for kind, want := range cases {
+		if got := kindToResource(kind); got != want {
+			t.Errorf("kindToResource(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+// bucketGVR is the composed S3 bucket's GVR — the resource a stuck bucket lives
+// at, referenced from the Duckling XR's spec.crossplane.resourceRefs.
+var bucketGVR = schema.GroupVersionResource{
+	Group:    "s3.aws.m.upbound.io",
+	Version:  "v1beta1",
+	Resource: "buckets",
+}
+
+// newFakeDucklingClientWithComposed builds a fake dynamic client that serves
+// both Duckling CRs and composed S3 Bucket resources, so a reconcile can read a
+// failing composed resource's condition through ComposedResourceErrors.
+func newFakeDucklingClientWithComposed(objects ...runtime.Object) *DucklingClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "k8s.posthog.com", Version: "v1alpha1", Kind: "Duckling"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "s3.aws.m.upbound.io", Version: "v1beta1", Kind: "Bucket"}, &unstructured.Unstructured{})
+	listKinds := map[schema.GroupVersionResource]string{
+		ducklingGVR: "DucklingList",
+		bucketGVR:   "BucketList",
+	}
+	fake := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+	return NewDucklingClientWithDynamic(fake)
+}
+
+// TestReconcileProvisioningStuckBucketSurfacesError is the regression for the
+// false-green S3 badge: a Duckling whose bucket is wedged on BucketNotEmpty
+// reported status.dataStore.bucketName populated, so the old code latched
+// s3_state=ready. It asserts the fix on all three facets — the component is NOT
+// marked ready, a previously-ready component is revoked, and the exact provider
+// error reaches status_message.
+func TestReconcileProvisioningStuckBucketSurfacesError(t *testing.T) {
+	const bucketName = "posthog-duckling-orgstuck-mw-prod-us"
+	bucketErr := "async delete failed: failed to delete the resource: deleting S3 Bucket: " +
+		"api error BucketNotEmpty: The bucket you tried to delete is not empty"
+
+	duckling := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata":   map[string]interface{}{"name": "org-stuck", "namespace": ducklingNamespace},
+		"spec": map[string]interface{}{
+			"crossplane": map[string]interface{}{
+				"resourceRefs": []interface{}{
+					map[string]interface{}{"apiVersion": "s3.aws.m.upbound.io/v1beta1", "kind": "Bucket", "name": bucketName},
+				},
+			},
+		},
+		"status": map[string]interface{}{
+			// Populated infra fields — what fooled the old presence check.
+			"metadataStore": map[string]interface{}{"type": "external", "endpoint": "org-stuck.rds.amazonaws.com", "password": "pw", "user": "postgres", "database": "postgres"},
+			"dataStore":     map[string]interface{}{"type": "s3bucket", "bucketName": bucketName},
+			"iamRoleArn":    "arn:aws:iam::123456789012:role/duckling-org-stuck",
+			// XR composed fine but the bucket never reconciled.
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Synced", "status": "True"},
+				map[string]interface{}{"type": "Ready", "status": "False", "reason": "Creating", "message": "Unready resources: s3-bucket"},
+			},
+		},
+	}}
+	bucket := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "s3.aws.m.upbound.io/v1beta1",
+		"kind":       "Bucket",
+		"metadata":   map[string]interface{}{"name": bucketName, "namespace": ducklingNamespace},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Synced", "status": "False", "reason": "ReconcileError", "message": bucketErr},
+			},
+		},
+	}}
+
+	dc := newFakeDucklingClientWithComposed(duckling, bucket)
+	fs := newFakeStore()
+	fs.warehouses["org-stuck"] = &configstore.ManagedWarehouse{
+		OrgID:        "org-stuck",
+		DucklingName: "org-stuck",
+		State:        configstore.ManagedWarehouseStateProvisioning,
+		// Previously latched ready — must be revoked now the bucket is failing.
+		S3State:   configstore.ManagedWarehouseStateReady,
+		CreatedAt: time.Now(),
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.SetProbe(func(context.Context, string, string, string, string, string) error { return nil })
+	ctrl.reconcile(context.Background())
+
+	w := fs.warehouses["org-stuck"]
+	if w.State == configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse must not be ready while the bucket is stuck")
+	}
+	if w.S3State == configstore.ManagedWarehouseStateReady {
+		t.Fatalf("s3_state must be revoked from ready, got %q", w.S3State)
+	}
+	if !strings.Contains(w.StatusMessage, "BucketNotEmpty") {
+		t.Fatalf("status_message should surface the exact provider error, got %q", w.StatusMessage)
+	}
+}
+
 // --- cnpg-shard metadata store ---
 
 // TestReconcilePendingCreatesCnpgShardCR verifies that a warehouse whose

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -48,6 +48,12 @@ type DucklingStatus struct {
 	IAMRoleARN         string
 	ReadyCondition     bool
 	SyncedFalseMessage string
+	// ReadyFalseMessage is the Ready condition's message when Ready=False — the
+	// XR's roll-up of what is still unready (e.g. "Unready resources:
+	// s3-bucket"). Distinct from SyncedFalseMessage: the XR can be Synced=True
+	// (composed successfully) yet Ready=False (a composed resource has not
+	// reconciled), which is exactly the state a stuck S3 bucket produces.
+	ReadyFalseMessage string
 
 	// DuckLakeEnabled is spec.ducklake.enabled, read present/absent: nil when
 	// the CR predates the decoupled ducklake field (the worker activator then
@@ -309,6 +315,119 @@ func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus,
 	return parseDucklingStatus(cr)
 }
 
+// ComposedResourceError describes one composed managed resource that is not
+// healthy — Crossplane could not sync it to the provider (Synced=False) or the
+// provider reports it not ready (Ready=False) — along with that condition's
+// message. It lets the provisioner surface the *actual* failure (e.g. an S3
+// "BucketNotEmpty" delete conflict) instead of only the Duckling XR's generic
+// "Unready resources: <name>" roll-up.
+type ComposedResourceError struct {
+	Kind    string
+	Name    string
+	Message string
+}
+
+// ComposedResourceErrors returns the unhealthy composed resources of the named
+// Duckling XR: it reads spec.crossplane.resourceRefs (the composition's composed
+// resources), fetches each, and reports any whose Synced or Ready condition is
+// False, with that condition's message.
+//
+// Best-effort and diagnostic-only: a ref that can't be fetched (already gone, or
+// an unexpected GVR) is skipped rather than failing the whole call, since the
+// result only feeds the human-facing status message. protection.crossplane.io
+// Usage guards are skipped — internal dependency ordering, not tenant infra.
+func (d *DucklingClient) ComposedResourceErrors(ctx context.Context, name string) ([]ComposedResourceError, error) {
+	cr, err := d.getCR(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("get duckling CR %q: %w", name, err)
+	}
+	var out []ComposedResourceError
+	for _, ref := range nestedComposedRefs(cr) {
+		gvr, kind, refName, ok := composedRefGVR(ref)
+		if !ok || gvr.Group == "protection.crossplane.io" {
+			continue
+		}
+		obj, gerr := d.client.Resource(gvr).Namespace(ducklingNamespace).Get(ctx, refName, metav1.GetOptions{})
+		if gerr != nil {
+			continue
+		}
+		if msg, unhealthy := unhealthyConditionMessage(obj); unhealthy {
+			out = append(out, ComposedResourceError{Kind: kind, Name: refName, Message: msg})
+		}
+	}
+	return out, nil
+}
+
+// nestedComposedRefs pulls spec.crossplane.resourceRefs (the Crossplane v2
+// composed-resource references) off a Duckling XR. Missing or wrongly-typed
+// yields nil.
+func nestedComposedRefs(cr *unstructured.Unstructured) []map[string]interface{} {
+	spec, _ := cr.Object["spec"].(map[string]interface{})
+	xp, _ := spec["crossplane"].(map[string]interface{})
+	raw, _ := xp["resourceRefs"].([]interface{})
+	refs := make([]map[string]interface{}, 0, len(raw))
+	for _, r := range raw {
+		if m, ok := r.(map[string]interface{}); ok {
+			refs = append(refs, m)
+		}
+	}
+	return refs
+}
+
+// composedRefGVR turns a resourceRef ({apiVersion, kind, name}) into the GVR to
+// fetch it by. Resource is the lowercased plural of Kind — see kindToResource.
+func composedRefGVR(ref map[string]interface{}) (gvr schema.GroupVersionResource, kind, name string, ok bool) {
+	apiVersion := getNestedString(ref, "apiVersion")
+	kind = getNestedString(ref, "kind")
+	name = getNestedString(ref, "name")
+	if apiVersion == "" || kind == "" || name == "" {
+		return schema.GroupVersionResource{}, "", "", false
+	}
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return schema.GroupVersionResource{}, "", "", false
+	}
+	return gv.WithResource(kindToResource(kind)), kind, name, true
+}
+
+// kindToResource lowercases a Kind and pluralizes it to the resource segment of
+// a GVR. It implements only the rules the Duckling composition's composed kinds
+// need (…y→…ies, otherwise +s): Bucket→buckets, BucketPolicy→bucketpolicies,
+// Role→roles, RolePolicy→rolepolicies, Database→databases, Object→objects,
+// Usage→usages. None of those end in s/x/z/ch/sh, so no -es rule is needed.
+func kindToResource(kind string) string {
+	lower := strings.ToLower(kind)
+	if strings.HasSuffix(lower, "y") {
+		return lower[:len(lower)-1] + "ies"
+	}
+	return lower + "s"
+}
+
+// unhealthyConditionMessage reports whether a composed managed resource has a
+// Synced=False or Ready=False condition, returning that condition's message.
+// Synced is preferred: a provider sync error (e.g. BucketNotEmpty) is the
+// actionable cause, whereas Ready=False is often just its downstream symptom.
+func unhealthyConditionMessage(obj *unstructured.Unstructured) (string, bool) {
+	status, _ := obj.Object["status"].(map[string]interface{})
+	conditions, _ := status["conditions"].([]interface{})
+	readyMsg := ""
+	readyBad := false
+	for _, c := range conditions {
+		cm, ok := c.(map[string]interface{})
+		if !ok || getNestedString(cm, "status") != "False" {
+			continue
+		}
+		switch getNestedString(cm, "type") {
+		case "Synced":
+			return getNestedString(cm, "message"), true
+		case "Ready":
+			readyMsg = getNestedString(cm, "message")
+			readyBad = true
+		}
+	}
+	return readyMsg, readyBad
+}
+
 // Delete removes the named Duckling CR.
 func (d *DucklingClient) Delete(ctx context.Context, name string) error {
 	if derr := d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Delete(ctx, name, metav1.DeleteOptions{}); derr != nil {
@@ -544,6 +663,9 @@ func parseDucklingStatus(cr *unstructured.Unstructured) (*DucklingStatus, error)
 		switch condType {
 		case "Ready":
 			ds.ReadyCondition = condStatus == "True"
+			if condStatus == "False" {
+				ds.ReadyFalseMessage = getNestedString(condMap, "message")
+			}
 		case "Synced":
 			if condStatus == "False" {
 				ds.SyncedFalseMessage = getNestedString(condMap, "message")


### PR DESCRIPTION
## Problem

The provisioner marked each warehouse component (S3, metadata store, secrets, identity) **ready** as soon as its Duckling CR status *field* was populated — `status.dataStore.bucketName != ""`, `status.metadataStore.endpoint != ""`, etc. The composition sets those fields when it *renders* a composed resource, well before that resource actually reconciles.

Result: a Duckling whose composed S3 bucket was stuck (a delete wedged on `BucketNotEmpty` — XR `Synced=True` but `Ready=False, "Unready resources: s3-bucket"`) still showed **S3 = ready** (green) in the admin UI. And the states latched: once set ready, they were never revoked when the resource later failed. The real provider error never reached the UI.

## Fix

Three parts, all in the provisioner:

1. **Gate per-component readiness on the XR `Ready` condition** and recompute every reconcile tick — a component that regresses is revoked, not latched. `Ready` is Crossplane's aggregate "all composed resources reconciled" signal, so a populated status field alone no longer flips a badge green.
2. **Surface the actual provider error.** Walk `spec.crossplane.resourceRefs`, fetch each composed managed resource, and if it reports `Synced=False`/`Ready=False`, join those condition messages into `status_message` (e.g. the bucket's `BucketNotEmpty` text). Best-effort and diagnostic-only.
3. **Fall back** to the XR's own `Ready`-condition roll-up (`Unready resources: …`) when no composed resource reports a specific error.

The admin UI already renders the per-component badges and `status_message`, so it now reflects the true state — no frontend change.

## Tests

- `TestReconcileProvisioningStuckBucketSurfacesError` — the regression: a wedged bucket must not show S3 ready, a previously-ready component is revoked, and the exact provider error reaches `status_message`.
- `TestParseDucklingStatusReadyFalseMessage` — the `Ready=False` roll-up is captured.
- `TestKindToResource` — guards the Kind→resource pluralization the composed-resource lookup depends on.

## Notes

Scoped to status *reflection*. The separate matter of a recreate deadlocking on a non-empty bucket (deterministic bucket name + no `forceDestroy`) is handled independently.
