### PR TITLE
Add storage billing metric: managed_warehouse_storage_gib_seconds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,11 +447,13 @@ side of that doc still applies). Scope is **only** the remote/k8s backend
 (per-org worker pod with a known `WorkerProfile` size). Pipeline:
 
 ```
-conn end → in-proc counter keyed (org, default team, query_source, worker size)
-        │  flusher (~15s) UPSERT-increment → config-store buffer (cross-CP sum)
-        ▼  duckgres_org_compute_usage (+ duckgres_compute_billing_cursor)
-billing: GET /api/v1/billing/usage (aggregated per key per UTC day, watermarks)
-       → POST /api/v1/billing/ack {watermark_high} → cursor advance + delete ≤ it
+compute: conn end → in-proc counter keyed (org, default team, query_source, worker size)
+              │  flusher (~15s) UPSERT-increment → config-store buffer (cross-CP sum)
+              ▼  duckgres_org_compute_usage (+ duckgres_compute_billing_cursor)
+storage: leader sampler (~30m) → org's DuckLake metadata Postgres
+              SUM(data+delete file sizes) × interval → duckgres_org_storage_usage
+billing: GET /api/v1/billing/usage (usage + storage arrays, per key per UTC day, watermarks)
+       → POST /api/v1/billing/ack {watermark_high} → cursor advance + delete ≤ it (BOTH tables)
 safety:  leader-only GC hard-deletes buckets older than 30 days (WARN, alertable)
 ```
 
@@ -502,11 +504,29 @@ touching this path:
 - **Graceful shutdown does a final flush** after connections drain to their
   natural end (`shutdown`/`drainAndShutdown`), so a departing CP pod lands its
   last interval before exit.
-- Touching the meter/flush/API/GC, the worker-size or query-source plumbing, or
-  the bucket key → update `controlplane/compute_meter_test.go`,
-  `compute_billing_api_test.go`, `compute_size_test.go`, the migration assertion
-  in `tests/configstore/migrations_postgres_test.go`, and the
-  `compute_usage_pull_api` assertion in `tests/e2e-mw-dev/harness.sh`.
+- **Storage metric** (`managed_warehouse_storage_gib_seconds`,
+  `storage_meter.go`): a LEADER-ONLY sampler (double writers would
+  double-bill — the UPSERT is additive) visits each Ready warehouse's DuckLake
+  metadata Postgres every 30m (env-only `DUCKGRES_STORAGE_SAMPLE_INTERVAL`;
+  e2e uses 60s) and credits exactly `tracked_bytes × interval` byte-seconds —
+  no elapsed-time tracking, a missed sample under-bills one interval. The SUM
+  is over `ducklake_data_file` + `ducklake_delete_file` with NO snapshot
+  filter (never `ducklake_table_info()`/`ducklake_table_stats` — current-
+  snapshot-only / approximate). byte-seconds are NUMERIC (BIGINT overflows);
+  served as exact-decimal GiB-seconds (÷2³⁰ terminates;
+  `byteSecondsToGiBSeconds` big-int math). Connection resolution reuses the
+  cross-org activator (`MetadataPostgresURL`: duckling pgbouncer → sslmode
+  disable, direct RDS → require). Drift gauges:
+  `duckgres_org_storage_pending_delete_files` (alert on sustained nonzero) +
+  `duckgres_org_storage_tracked_bytes`.
+- Touching the meter/flush/API/GC, the worker-size or query-source plumbing,
+  the storage sampler, or the bucket keys → update
+  `controlplane/compute_meter_test.go`, `compute_billing_api_test.go`,
+  `compute_size_test.go`, `storage_meter_test.go`,
+  `configstore/storage_usage_test.go`, the migration assertion in
+  `tests/configstore/migrations_postgres_test.go`, and the
+  `compute_usage_pull_api` assertion (compute + storage) in
+  `tests/e2e-mw-dev/harness.sh`.
 
 ## TODO Reference
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Run with config file:
 | `DUCKGRES_QUERY_LOG_ENABLED` | Enable per-query logging | `true` |
 | `DUCKGRES_QUERY_LOG_FLUSH_INTERVAL` | Query-log flush interval for native Postgres writes | `5s` |
 | `DUCKGRES_QUERY_LOG_BATCH_SIZE` | Query-log batch size for native Postgres inserts | `1000` |
+| `DUCKGRES_STORAGE_SAMPLE_INTERVAL` | Storage-billing sampling cadence (Go duration): how often the leader CP reads each warehouse's tracked DuckLake footprint and credits byte-seconds. Env-only. | `30m` |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events** | - |
 | `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |

--- a/controlplane/compute_billing_api.go
+++ b/controlplane/compute_billing_api.go
@@ -10,8 +10,11 @@ import (
 )
 
 // billingUsageStore is the config-store surface the billing pull API needs.
+// Compute and storage share one watermark window and one ack (AckComputeUsage
+// deletes both families).
 type billingUsageStore interface {
 	AggregateComputeUsage(low, high time.Time) ([]configstore.ComputeUsageRow, error)
+	AggregateStorageUsage(low, high time.Time) ([]configstore.StorageUsageRow, error)
 	ComputeBillingCursor() (time.Time, bool, error)
 	AckComputeUsage(watermarkHigh time.Time) (int64, error)
 }
@@ -42,9 +45,9 @@ func (h *billingAPIHandler) latestClosedBucket() time.Time {
 	return h.now().UTC().Add(-computeBucketWidth - computeBucketGrace).Truncate(computeBucketWidth)
 }
 
-// getUsage returns usage aggregated since the last ack — one row per key
-// (org, team, query_source, worker size) per UTC day — plus the watermark
-// window. watermark_low is the server cursor (what billing last acked;
+// getUsage returns usage aggregated since the last ack — compute: one row per
+// key (org, team, query_source, worker size) per UTC day; storage: one row
+// per (org, team) per UTC day — plus the shared watermark window. watermark_low is the server cursor (what billing last acked;
 // billing should cross-check it against its own record), watermark_high is
 // what billing acks after processing.
 func (h *billingAPIHandler) getUsage(c *gin.Context) {
@@ -64,6 +67,7 @@ func (h *billingAPIHandler) getUsage(c *gin.Context) {
 			"watermark_low":  low.Format(time.RFC3339),
 			"watermark_high": low.Format(time.RFC3339),
 			"usage":          []configstore.ComputeUsageRow{},
+			"storage":        []configstore.StorageUsageRow{},
 		})
 		return
 	}
@@ -76,10 +80,19 @@ func (h *billingAPIHandler) getUsage(c *gin.Context) {
 	if rows == nil {
 		rows = []configstore.ComputeUsageRow{}
 	}
+	storageRows, err := h.store.AggregateStorageUsage(low, high)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "aggregate storage usage: " + err.Error()})
+		return
+	}
+	if storageRows == nil {
+		storageRows = []configstore.StorageUsageRow{}
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"watermark_low":  low.Format(time.RFC3339),
 		"watermark_high": high.Format(time.RFC3339),
 		"usage":          rows,
+		"storage":        storageRows,
 	})
 }
 
@@ -88,7 +101,7 @@ type billingAckRequest struct {
 }
 
 // postAck advances the cursor to watermark_high and deletes every buffered
-// bucket at or below it. Idempotent: re-acking an already-acked (or older)
+// bucket at or below it, across BOTH metric families (compute + storage). Idempotent: re-acking an already-acked (or older)
 // watermark is a no-op. The watermark must be a closed bucket boundary the
 // server could have served — acking into the still-accumulating present is
 // rejected so an ack can never delete buckets that were never returned.

--- a/controlplane/compute_billing_api_test.go
+++ b/controlplane/compute_billing_api_test.go
@@ -18,17 +18,20 @@ import (
 
 // fakeBillingStore implements billingUsageStore + computeGCStore in memory.
 type fakeBillingStore struct {
-	mu       sync.Mutex
-	cursor   time.Time
-	hasAck   bool
-	rows     []configstore.ComputeUsageRow
-	aggLow   time.Time
-	aggHigh  time.Time
-	ackedTo  time.Time
-	deleted  int64
-	gcCutoff time.Time
-	gcDrop   int64
-	failWith error
+	mu          sync.Mutex
+	cursor      time.Time
+	hasAck      bool
+	rows        []configstore.ComputeUsageRow
+	storageRows []configstore.StorageUsageRow
+	aggLow      time.Time
+	aggHigh     time.Time
+	stAggLow    time.Time
+	stAggHigh   time.Time
+	ackedTo     time.Time
+	deleted     int64
+	gcCutoff    time.Time
+	gcDrop      int64
+	failWith    error
 }
 
 func (f *fakeBillingStore) AggregateComputeUsage(low, high time.Time) ([]configstore.ComputeUsageRow, error) {
@@ -39,6 +42,16 @@ func (f *fakeBillingStore) AggregateComputeUsage(low, high time.Time) ([]configs
 	}
 	f.aggLow, f.aggHigh = low, high
 	return f.rows, nil
+}
+
+func (f *fakeBillingStore) AggregateStorageUsage(low, high time.Time) ([]configstore.StorageUsageRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failWith != nil {
+		return nil, f.failWith
+	}
+	f.stAggLow, f.stAggHigh = low, high
+	return f.storageRows, nil
 }
 
 func (f *fakeBillingStore) ComputeBillingCursor() (time.Time, bool, error) {
@@ -116,6 +129,7 @@ type usageResponse struct {
 	WatermarkLow  time.Time                     `json:"watermark_low"`
 	WatermarkHigh time.Time                     `json:"watermark_high"`
 	Usage         []configstore.ComputeUsageRow `json:"usage"`
+	Storage       []configstore.StorageUsageRow `json:"storage"`
 }
 
 func TestBillingUsageWindowAndRows(t *testing.T) {
@@ -126,6 +140,9 @@ func TestBillingUsageWindowAndRows(t *testing.T) {
 		rows: []configstore.ComputeUsageRow{{
 			Date: "2026-07-01", OrgID: "org_abc", TeamID: 12345, QuerySource: "standard",
 			CPU: "8", MemGiB: "16", CPUSeconds: 4800, MemorySeconds: 9600,
+		}},
+		storageRows: []configstore.StorageUsageRow{{
+			Date: "2026-07-01", OrgID: "org_abc", TeamID: 12345, GiBSeconds: "18000000.5",
 		}},
 	}
 	router := newBillingTestRouter(store, now)
@@ -158,6 +175,17 @@ func TestBillingUsageWindowAndRows(t *testing.T) {
 	// The exact-decimal sizes must serialize as unquoted JSON numbers.
 	if !bytes.Contains(rec.Body.Bytes(), []byte(`"cpu":8`)) || !bytes.Contains(rec.Body.Bytes(), []byte(`"mem_gib":16`)) {
 		t.Fatalf("cpu/mem_gib not serialized as JSON numbers: %s", rec.Body.String())
+	}
+	// Storage rides the same window: same aggregate bounds, rows served, and
+	// gib_seconds as an unquoted JSON number.
+	if !store.stAggLow.Equal(cursor) || !store.stAggHigh.Equal(wantHigh) {
+		t.Fatalf("storage aggregate window = (%v, %v], want (%v, %v]", store.stAggLow, store.stAggHigh, cursor, wantHigh)
+	}
+	if len(resp.Storage) != 1 || resp.Storage[0].OrgID != "org_abc" || resp.Storage[0].TeamID != 12345 {
+		t.Fatalf("storage = %+v", resp.Storage)
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"gib_seconds":18000000.5`)) {
+		t.Fatalf("gib_seconds not serialized as a JSON number: %s", rec.Body.String())
 	}
 }
 
@@ -198,11 +226,11 @@ func TestBillingUsageEmptyWindowWhenCursorCurrent(t *testing.T) {
 	if !resp.WatermarkHigh.Equal(resp.WatermarkLow) || !resp.WatermarkLow.Equal(cursor) {
 		t.Fatalf("want empty window at cursor, got (%v, %v]", resp.WatermarkLow, resp.WatermarkHigh)
 	}
-	if len(resp.Usage) != 0 {
-		t.Fatalf("usage = %+v, want empty", resp.Usage)
+	if len(resp.Usage) != 0 || len(resp.Storage) != 0 {
+		t.Fatalf("usage/storage = %+v / %+v, want empty", resp.Usage, resp.Storage)
 	}
-	if !store.aggLow.IsZero() || !store.aggHigh.IsZero() {
-		t.Fatal("aggregate must not run for an empty window")
+	if !store.aggLow.IsZero() || !store.aggHigh.IsZero() || !store.stAggLow.IsZero() {
+		t.Fatal("aggregates must not run for an empty window")
 	}
 }
 

--- a/controlplane/configstore/compute_usage.go
+++ b/controlplane/configstore/compute_usage.go
@@ -146,9 +146,11 @@ func (cs *ConfigStore) ComputeBillingCursor() (cursor time.Time, ok bool, err er
 
 // AckComputeUsage commits billing's watermark: it advances the cursor to
 // watermarkHigh (monotonically — an older value never moves it backwards) and
-// deletes every buffered bucket at or below it, atomically. Idempotent: a
-// retried ack at or below the current cursor deletes nothing and leaves the
-// cursor unchanged. Returns the number of buffer rows deleted.
+// deletes every buffered bucket at or below it — BOTH metric families
+// (compute and storage share the one cursor and ack) — atomically.
+// Idempotent: a retried ack at or below the current cursor deletes nothing
+// and leaves the cursor unchanged. Returns the number of buffer rows deleted
+// across both tables.
 func (cs *ConfigStore) AckComputeUsage(watermarkHigh time.Time) (int64, error) {
 	high := watermarkHigh.UTC()
 	var deleted int64
@@ -166,6 +168,11 @@ DO UPDATE SET last_acked = GREATEST(duckgres_compute_billing_cursor.last_acked, 
 			return fmt.Errorf("delete acked compute buckets: %w", res.Error)
 		}
 		deleted = res.RowsAffected
+		res = tx.Exec(`DELETE FROM duckgres_org_storage_usage WHERE bucket_start <= ?`, high)
+		if res.Error != nil {
+			return fmt.Errorf("delete acked storage buckets: %w", res.Error)
+		}
+		deleted += res.RowsAffected
 		return nil
 	})
 	return deleted, err

--- a/controlplane/configstore/migrations/000019_add_storage_usage.sql
+++ b/controlplane/configstore/migrations/000019_add_storage_usage.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- Storage-usage buffer for managed-warehouse billing (pull model, storage
+-- metric — see docs/design/billing-pull-api.md "Storage metric"). A
+-- leader-only sampler reads each org's DuckLake metadata Postgres every ~30min
+-- and credits tracked_bytes × interval_seconds byte-seconds into the
+-- sample-minute's bucket. NUMERIC because byte-seconds overflow BIGINT for
+-- large warehouses (100 TB × a day ≈ 8.6e18). Served aggregated per key per
+-- UTC day by GET /billing/usage (as exact-decimal GiB-seconds), deleted by the
+-- same ack watermark as compute usage, swept by the same 30-day safety GC.
+CREATE TABLE IF NOT EXISTS duckgres_org_storage_usage (
+    org_id       TEXT        NOT NULL,
+    team_id      BIGINT      NOT NULL DEFAULT 0,
+    bucket_start TIMESTAMPTZ NOT NULL,
+    byte_seconds NUMERIC     NOT NULL,
+    PRIMARY KEY (org_id, team_id, bucket_start)
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS duckgres_org_storage_usage;

--- a/controlplane/configstore/storage_usage.go
+++ b/controlplane/configstore/storage_usage.go
@@ -1,0 +1,118 @@
+package configstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// StorageUsageRow is one aggregated storage row served by the billing pull
+// API: the sum of every closed bucket for one (org, team) on one UTC day,
+// exposed as exact-decimal GiB-seconds (byte-seconds / 2^30 — a finite
+// decimal). See docs/design/billing-pull-api.md "Storage metric".
+type StorageUsageRow struct {
+	Date       string      `json:"date"`
+	OrgID      string      `json:"org_id"`
+	TeamID     int64       `json:"team_id"`
+	GiBSeconds json.Number `json:"gib_seconds"`
+}
+
+// UpsertStorageSample credits one sampler observation — tracked_bytes ×
+// interval_seconds byte-seconds — into the (org, team, bucket) row. Additive
+// UPSERT so retried/overlapping writers sum rather than clobber. Best-effort
+// by contract: the sampler logs and skips on error, never fails anything.
+func (cs *ConfigStore) UpsertStorageSample(orgID string, teamID int64, bucketStart time.Time, byteSeconds int64) error {
+	if byteSeconds <= 0 {
+		return nil
+	}
+	const stmt = `
+INSERT INTO duckgres_org_storage_usage (org_id, team_id, bucket_start, byte_seconds)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (org_id, team_id, bucket_start)
+DO UPDATE SET byte_seconds = duckgres_org_storage_usage.byte_seconds + EXCLUDED.byte_seconds`
+	if err := cs.db.Exec(stmt, orgID, teamID, bucketStart.UTC(), byteSeconds).Error; err != nil {
+		return fmt.Errorf("upsert storage sample (org=%s bucket=%s): %w", orgID, bucketStart, err)
+	}
+	return nil
+}
+
+// AggregateStorageUsage sums every buffered storage bucket in the half-open
+// window (low, high] into one row per (org, team) per UTC day — the storage
+// half of the billing pull response, over the same watermark window as
+// compute. byte-seconds are summed in Postgres (NUMERIC, exact) and converted
+// to GiB-seconds in Go with integer math so no precision is lost.
+func (cs *ConfigStore) AggregateStorageUsage(low, high time.Time) ([]StorageUsageRow, error) {
+	const q = `
+SELECT to_char((bucket_start AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS date,
+       org_id, team_id, SUM(byte_seconds)::text
+FROM duckgres_org_storage_usage
+WHERE bucket_start > ? AND bucket_start <= ?
+GROUP BY 1, org_id, team_id
+ORDER BY 1, org_id, team_id`
+
+	rows, err := cs.db.Raw(q, low.UTC(), high.UTC()).Rows()
+	if err != nil {
+		return nil, fmt.Errorf("aggregate storage usage: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []StorageUsageRow
+	for rows.Next() {
+		var r StorageUsageRow
+		var byteSeconds string
+		if err := rows.Scan(&r.Date, &r.OrgID, &r.TeamID, &byteSeconds); err != nil {
+			return nil, fmt.Errorf("scan storage usage row: %w", err)
+		}
+		gib, err := byteSecondsToGiBSeconds(byteSeconds)
+		if err != nil {
+			return nil, fmt.Errorf("convert storage usage row (org=%s date=%s): %w", r.OrgID, r.Date, err)
+		}
+		r.GiBSeconds = gib
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// byteSecondsToGiBSeconds divides an integer byte-seconds decimal string by
+// 2^30, exactly. 1/2^30 = 5^30/10^30, so the result always terminates within
+// 30 fractional digits — computed with big.Int (values exceed float64 AND
+// int64 range for large warehouses), then trailing zeros trimmed.
+func byteSecondsToGiBSeconds(byteSeconds string) (json.Number, error) {
+	v, ok := new(big.Int).SetString(strings.TrimSpace(byteSeconds), 10)
+	if !ok {
+		return "", fmt.Errorf("non-integer byte_seconds %q", byteSeconds)
+	}
+	neg := v.Sign() < 0
+	if neg {
+		v.Neg(v) // defensive; the sampler never writes negatives
+	}
+	five30 := new(big.Int).Exp(big.NewInt(5), big.NewInt(30), nil)
+	v.Mul(v, five30) // v / 2^30 == v·5^30 / 10^30
+	digits := v.String()
+	if len(digits) <= 30 {
+		digits = strings.Repeat("0", 30-len(digits)+1) + digits
+	}
+	intPart := digits[:len(digits)-30]
+	frac := strings.TrimRight(digits[len(digits)-30:], "0")
+	out := intPart
+	if frac != "" {
+		out += "." + frac
+	}
+	if neg {
+		out = "-" + out
+	}
+	return json.Number(out), nil
+}
+
+// GCStorageUsage hard-deletes buffered storage buckets older than the cutoff
+// regardless of ack — same safety net as GCComputeUsage. Returns the number
+// of rows dropped.
+func (cs *ConfigStore) GCStorageUsage(olderThan time.Time) (int64, error) {
+	res := cs.db.Exec(`DELETE FROM duckgres_org_storage_usage WHERE bucket_start < ?`, olderThan.UTC())
+	if res.Error != nil {
+		return 0, fmt.Errorf("gc storage usage: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}

--- a/controlplane/configstore/storage_usage_test.go
+++ b/controlplane/configstore/storage_usage_test.go
@@ -1,0 +1,36 @@
+package configstore
+
+import "testing"
+
+func TestByteSecondsToGiBSeconds(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// 1 GiB-second exactly.
+		{"1073741824", "1"},
+		// 10 GiB × 1800s.
+		{"19327352832000", "18000"},
+		// Half a GiB-second — finite decimal (power-of-two denominator).
+		{"536870912", "0.5"},
+		// One byte-second: 1/2^30 needs the full 30 fractional digits.
+		{"1", "0.000000000931322574615478515625"},
+		// Zero.
+		{"0", "0"},
+		// ~100 TiB warehouse × 1 day — exceeds float64's exact-integer range
+		// and brushes int64's edge; must stay exact through big-int math.
+		{"9503903632588800000", "8851200000"},
+	}
+	for _, tt := range tests {
+		got, err := byteSecondsToGiBSeconds(tt.in)
+		if err != nil {
+			t.Fatalf("byteSecondsToGiBSeconds(%s): %v", tt.in, err)
+		}
+		if string(got) != tt.want {
+			t.Fatalf("byteSecondsToGiBSeconds(%s) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+	if _, err := byteSecondsToGiBSeconds("not-a-number"); err == nil {
+		t.Fatal("expected error for non-integer input")
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -597,6 +597,34 @@ func SetupMultiTenant(
 	}
 	slog.Info("Managed-warehouse compute-usage metering enabled (pull API).")
 
+	// Storage-billing sampler (leader-only, so exactly one CP credits each
+	// interval): every ~30min it reads each Ready warehouse's tracked DuckLake
+	// footprint straight from the org's metadata Postgres (via the same
+	// cross-org resolution the credential refresher uses) and credits
+	// bytes × interval into the storage buffer; billing pulls it alongside
+	// compute. Best-effort — a failed sample under-bills one interval, never
+	// affects anything user-facing.
+	storageSamplerLoop := newStorageSampler(store, storageSampleIntervalFromEnv(),
+		func() []storageOrg {
+			snap := store.Snapshot()
+			if snap == nil {
+				return nil
+			}
+			var orgs []storageOrg
+			for _, org := range snap.Orgs {
+				if org.Warehouse != nil && org.Warehouse.State == configstore.ManagedWarehouseStateReady {
+					orgs = append(orgs, storageOrg{OrgID: org.Name, TeamID: org.DefaultTeamID})
+				}
+			}
+			return orgs
+		},
+		refreshActivator.MetadataPostgresURL,
+	)
+	if janitorLeader != nil {
+		janitorLeader.AttachLeaderLoop(storageSamplerLoop.Run)
+	}
+	slog.Info("Managed-warehouse storage-usage sampling enabled.", "interval", storageSamplerLoop.interval.String())
+
 	return store, adpt, apiServer, runtimeTracker, janitorLeader, meter, nil
 }
 

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -673,4 +674,72 @@ func orgName(org *configstore.OrgConfig) string {
 		return ""
 	}
 	return org.Name
+}
+
+// MetadataPostgresURL resolves a standard postgres:// URL for an org's
+// DuckLake metadata Postgres, for CP-side read-only queries (the storage
+// sampler — see storage_meter.go). Mirrors the resolution the worker
+// activation uses: prefer the Duckling CR (pgbouncer endpoint when present,
+// else the direct metadata endpoint), fall back to the config-store warehouse
+// shape. sslmode follows provisioner.ProbeMetadataStore's rules: "disable"
+// through the duckling's pgbouncer (plaintext worker↔pooler; the pooler
+// carries TLS to RDS), "require" against a direct RDS endpoint, "prefer" for
+// config-store warehouses (matches the DuckDB ATTACH default there).
+// Returns an error when the org has no DuckLake-enabled warehouse.
+func (a *SharedWorkerActivator) MetadataPostgresURL(ctx context.Context, orgID string) (string, error) {
+	if a.resolveDucklingStatus != nil {
+		status, err := a.resolveDucklingStatus(ctx, orgID)
+		if err == nil {
+			ducklakeEnabled := status.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard
+			if status.DuckLakeEnabled != nil {
+				ducklakeEnabled = *status.DuckLakeEnabled
+			}
+			if !ducklakeEnabled {
+				return "", fmt.Errorf("org %q has DuckLake disabled", orgID)
+			}
+			if status.MetadataStore.Password == "" {
+				return "", fmt.Errorf("duckling CR %q has no metadata store password", orgID)
+			}
+			host, port, viaPgBouncer, err := ducklingMetadataStoreAddress(status, orgID)
+			if err != nil {
+				return "", err
+			}
+			sslMode := "require"
+			if viaPgBouncer {
+				sslMode = "disable"
+			}
+			return metadataPostgresURL(host, port, status.MetadataStore.User, status.MetadataStore.Password, status.MetadataStore.Database, sslMode), nil
+		}
+		slog.Debug("Duckling CR metadata resolution failed, falling back to config store.", "org", orgID, "error", err)
+	}
+
+	org, err := a.lookupOrgConfig(orgID)
+	if err != nil {
+		return "", err
+	}
+	if org.Warehouse == nil {
+		return "", fmt.Errorf("org %q has no managed warehouse", orgID)
+	}
+	password, err := a.readSecretValue(ctx, org.Warehouse.MetadataStoreCredentials)
+	if err != nil {
+		return "", fmt.Errorf("metadata store credentials for org %q: %w", orgID, err)
+	}
+	ms := org.Warehouse.MetadataStore
+	return metadataPostgresURL(ms.Endpoint, ms.Port, ms.Username, password, ms.DatabaseName, "prefer"), nil
+}
+
+// metadataPostgresURL builds a postgres:// URL for database/sql ("pgx") from
+// the same fields the DuckDB ATTACH DSN uses. url.URL handles credential
+// escaping.
+func metadataPostgresURL(host string, port int, username, password, database, sslMode string) string {
+	if port == 0 {
+		port = 5432
+	}
+	return (&url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(username, password),
+		Host:     net.JoinHostPort(host, strconv.Itoa(port)),
+		Path:     "/" + database,
+		RawQuery: "sslmode=" + sslMode + "&connect_timeout=5",
+	}).String()
 }

--- a/controlplane/storage_meter.go
+++ b/controlplane/storage_meter.go
@@ -1,0 +1,195 @@
+package controlplane
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+const (
+	// defaultStorageSampleInterval is how often the leader samples each org's
+	// tracked DuckLake storage footprint. Each successful sample credits
+	// exactly one interval of byte-seconds — no elapsed-time tracking, so a
+	// missed sample under-bills one interval (best-effort, like compute).
+	// Env-only override DUCKGRES_STORAGE_SAMPLE_INTERVAL (e2e uses seconds).
+	defaultStorageSampleInterval = 30 * time.Minute
+
+	// storageSampleQueryTimeout bounds one org's metadata-Postgres visit
+	// (connect + the two-table SUM).
+	storageSampleQueryTimeout = 15 * time.Second
+)
+
+// storageSampleQuery reads the org's tracked S3 footprint from its DuckLake
+// metadata Postgres. Sums data + delete files with NO snapshot filter
+// (time-travel-retained files stay billable until snapshot expiry), plus the
+// pending-delete count — files between expire_snapshots and
+// cleanup_old_files whose size row is already gone (the drift gauge).
+// ducklake_table_info()/ducklake_table_stats are deliberately NOT used: the
+// former filters to the current snapshot, the latter is approximate. See
+// docs/design/billing-pull-api.md "Storage metric".
+const storageSampleQuery = `
+SELECT COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_data_file), 0)
+     + COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_delete_file), 0),
+       (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion)`
+
+var storageTrackedBytesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_org_storage_tracked_bytes",
+	Help: "Tracked DuckLake S3 footprint per org (bytes), from the last storage-billing sample.",
+}, []string{"org"})
+
+var storagePendingDeleteFilesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_org_storage_pending_delete_files",
+	Help: "Files scheduled for deletion but not yet cleaned per org — bytes on S3 invisible to the storage meter. Sustained nonzero = cleanup lagging (drift).",
+}, []string{"org"})
+
+var storageSampleErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_storage_sample_errors_total",
+	Help: "Storage-billing samples skipped due to an error (org unreachable, query failed). Each miss under-bills one interval.",
+}, []string{"org"})
+
+// storageOrg is one samplable org: a Ready DuckLake warehouse and its default
+// team (the storage bucket key's team_id; 0 = no default team).
+type storageOrg struct {
+	OrgID  string
+	TeamID int64
+}
+
+// storageUsageStore is the config-store surface the sampler needs.
+type storageUsageStore interface {
+	UpsertStorageSample(orgID string, teamID int64, bucketStart time.Time, byteSeconds int64) error
+}
+
+// storageSampler is the leader-only loop converting each org's storage level
+// into billable byte-seconds. Strictly best-effort: any per-org failure is
+// logged, counted and skipped — it never fails anything user-facing.
+type storageSampler struct {
+	store    storageUsageStore
+	interval time.Duration
+	// listOrgs returns the orgs to sample (Ready DuckLake warehouses) with
+	// their default team ids, from the config snapshot.
+	listOrgs func() []storageOrg
+	// resolveDSN maps an org to its metadata-Postgres URL
+	// (SharedWorkerActivator.MetadataPostgresURL on the k8s backend).
+	resolveDSN func(ctx context.Context, orgID string) (string, error)
+	// queryFootprint visits one org's metadata Postgres; swappable in tests.
+	queryFootprint func(ctx context.Context, dsn string) (trackedBytes, pendingDeleteFiles int64, err error)
+	now            func() time.Time
+}
+
+func newStorageSampler(store storageUsageStore, interval time.Duration, listOrgs func() []storageOrg, resolveDSN func(ctx context.Context, orgID string) (string, error)) *storageSampler {
+	if interval <= 0 {
+		interval = defaultStorageSampleInterval
+	}
+	return &storageSampler{
+		store:          store,
+		interval:       interval,
+		listOrgs:       listOrgs,
+		resolveDSN:     resolveDSN,
+		queryFootprint: queryStorageFootprint,
+		now:            time.Now,
+	}
+}
+
+// Run samples every interval until ctx is cancelled. Leader-only: the caller
+// attaches it under the janitor leader lease so exactly one CP pod credits
+// each interval (a double writer would double-bill — the UPSERT is additive).
+func (s *storageSampler) Run(ctx context.Context) {
+	if s == nil || s.store == nil || s.listOrgs == nil || s.resolveDSN == nil {
+		return
+	}
+	s.sampleAll(ctx)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sampleAll(ctx)
+		}
+	}
+}
+
+func (s *storageSampler) sampleAll(ctx context.Context) {
+	orgs := s.listOrgs()
+	var sampled, failed int
+	for _, org := range orgs {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := s.sampleOrg(ctx, org); err != nil {
+			slog.Warn("Storage-billing sample failed; interval under-billed for this org.", "org", org.OrgID, "error", err)
+			storageSampleErrorsCounter.WithLabelValues(org.OrgID).Inc()
+			failed++
+			continue
+		}
+		sampled++
+	}
+	if sampled > 0 || failed > 0 {
+		slog.Info("Storage-billing sample pass complete.", "sampled", sampled, "failed", failed)
+	}
+}
+
+func (s *storageSampler) sampleOrg(ctx context.Context, org storageOrg) error {
+	orgCtx, cancel := context.WithTimeout(ctx, storageSampleQueryTimeout)
+	defer cancel()
+
+	dsn, err := s.resolveDSN(orgCtx, org.OrgID)
+	if err != nil {
+		return err
+	}
+	trackedBytes, pendingDelete, err := s.queryFootprint(orgCtx, dsn)
+	if err != nil {
+		return err
+	}
+	storageTrackedBytesGauge.WithLabelValues(org.OrgID).Set(float64(trackedBytes))
+	storagePendingDeleteFilesGauge.WithLabelValues(org.OrgID).Set(float64(pendingDelete))
+
+	// Credit exactly one interval: bytes × interval-seconds into the
+	// sample-minute's bucket (same 60s bucket_start convention as compute, so
+	// the shared closed-bucket/watermark rules apply unchanged).
+	byteSeconds := trackedBytes * int64(s.interval/time.Second)
+	bucket := s.now().UTC().Truncate(computeBucketWidth)
+	return s.store.UpsertStorageSample(org.OrgID, org.TeamID, bucket, byteSeconds)
+}
+
+// queryStorageFootprint opens the org's metadata Postgres and runs the
+// two-table SUM. One short-lived connection per visit — at a 30min cadence a
+// pool per org would be pure overhead.
+func queryStorageFootprint(ctx context.Context, dsn string) (trackedBytes, pendingDeleteFiles int64, err error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	if err := db.QueryRowContext(ctx, storageSampleQuery).Scan(&trackedBytes, &pendingDeleteFiles); err != nil {
+		return 0, 0, err
+	}
+	return trackedBytes, pendingDeleteFiles, nil
+}
+
+// storageSampleIntervalFromEnv reads the env-only sampling-interval override
+// (DUCKGRES_STORAGE_SAMPLE_INTERVAL, a Go duration — the e2e harness deploys
+// with a short one so the round-trip is assertable in-Job). Unset or invalid
+// → the 30min default.
+func storageSampleIntervalFromEnv() time.Duration {
+	v := os.Getenv("DUCKGRES_STORAGE_SAMPLE_INTERVAL")
+	if v == "" {
+		return defaultStorageSampleInterval
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		slog.Warn("Invalid DUCKGRES_STORAGE_SAMPLE_INTERVAL; using default.", "value", v, "default", defaultStorageSampleInterval.String())
+		return defaultStorageSampleInterval
+	}
+	return d
+}

--- a/controlplane/storage_meter_test.go
+++ b/controlplane/storage_meter_test.go
@@ -1,0 +1,148 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeStorageStore struct {
+	mu      sync.Mutex
+	samples []storageSampleRecord
+	err     error
+}
+
+type storageSampleRecord struct {
+	orgID       string
+	teamID      int64
+	bucketStart time.Time
+	byteSeconds int64
+}
+
+func (f *fakeStorageStore) UpsertStorageSample(orgID string, teamID int64, bucketStart time.Time, byteSeconds int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.samples = append(f.samples, storageSampleRecord{orgID, teamID, bucketStart, byteSeconds})
+	return nil
+}
+
+func newTestStorageSampler(store storageUsageStore, orgs []storageOrg, footprint func(ctx context.Context, dsn string) (int64, int64, error)) *storageSampler {
+	s := newStorageSampler(store, 30*time.Minute,
+		func() []storageOrg { return orgs },
+		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
+	)
+	s.queryFootprint = footprint
+	s.now = func() time.Time { return time.Date(2026, 7, 8, 12, 0, 47, 0, time.UTC) }
+	return s
+}
+
+func TestStorageSamplerCreditsOneIntervalPerOrg(t *testing.T) {
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "orgA", TeamID: 42}, {OrgID: "orgB", TeamID: 0}},
+		func(_ context.Context, dsn string) (int64, int64, error) {
+			if dsn == "postgres://meta/orgA" {
+				return 10 * 1024 * 1024 * 1024, 0, nil // 10 GiB
+			}
+			return 512, 3, nil
+		})
+
+	s.sampleAll(context.Background())
+
+	if len(store.samples) != 2 {
+		t.Fatalf("samples = %d, want 2", len(store.samples))
+	}
+	wantBucket := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC) // sample minute, floored
+	a := store.samples[0]
+	if a.orgID != "orgA" || a.teamID != 42 || !a.bucketStart.Equal(wantBucket) {
+		t.Fatalf("orgA sample = %+v", a)
+	}
+	// 10 GiB × 1800s.
+	if want := int64(10*1024*1024*1024) * 1800; a.byteSeconds != want {
+		t.Fatalf("orgA byteSeconds = %d, want %d (bytes × interval)", a.byteSeconds, want)
+	}
+	if b := store.samples[1]; b.orgID != "orgB" || b.teamID != 0 || b.byteSeconds != 512*1800 {
+		t.Fatalf("orgB sample = %+v", b)
+	}
+}
+
+func TestStorageSamplerSkipsFailingOrg(t *testing.T) {
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "broken", TeamID: 1}, {OrgID: "healthy", TeamID: 2}},
+		func(_ context.Context, dsn string) (int64, int64, error) {
+			if dsn == "postgres://meta/broken" {
+				return 0, 0, errors.New("connection refused")
+			}
+			return 1024 * 1024 * 1024, 0, nil
+		})
+
+	s.sampleAll(context.Background())
+
+	// The broken org is skipped (under-billed), the healthy one still lands.
+	if len(store.samples) != 1 || store.samples[0].orgID != "healthy" {
+		t.Fatalf("samples = %+v, want exactly the healthy org", store.samples)
+	}
+}
+
+func TestStorageSamplerStoreErrorIsBestEffort(t *testing.T) {
+	store := &fakeStorageStore{err: errors.New("db down")}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "orgA", TeamID: 42}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 1, 0, nil })
+	// Must not panic; the interval is dropped.
+	s.sampleAll(context.Background())
+}
+
+func TestStorageSamplerRunStopsOnCancel(t *testing.T) {
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "orgA", TeamID: 42}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 2048, 0, nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	// The first pass runs immediately.
+	deadline := time.After(2 * time.Second)
+	for {
+		store.mu.Lock()
+		n := len(store.samples)
+		store.mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("first sample pass never ran")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sampler did not stop on cancel")
+	}
+}
+
+func TestStorageSampleIntervalFromEnv(t *testing.T) {
+	t.Setenv("DUCKGRES_STORAGE_SAMPLE_INTERVAL", "")
+	if got := storageSampleIntervalFromEnv(); got != defaultStorageSampleInterval {
+		t.Fatalf("unset = %v, want default", got)
+	}
+	t.Setenv("DUCKGRES_STORAGE_SAMPLE_INTERVAL", "60s")
+	if got := storageSampleIntervalFromEnv(); got != time.Minute {
+		t.Fatalf("60s = %v, want 1m", got)
+	}
+	t.Setenv("DUCKGRES_STORAGE_SAMPLE_INTERVAL", "banana")
+	if got := storageSampleIntervalFromEnv(); got != defaultStorageSampleInterval {
+		t.Fatalf("invalid = %v, want default", got)
+	}
+}

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -168,6 +168,69 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   (`standard` | `endpoints`, default `standard`) read by the meter; a bearer secret
   for the API.
 
+## Storage metric
+
+Third raw metric: **`managed_warehouse_storage_gib_seconds`** — bytes stored ×
+seconds, the integral of the warehouse's tracked S3 footprint. Billing divides
+externally (÷3600 = GiB-hours, ÷2,592,000 = GiB-months), exactly as it already
+sums `cpu_seconds` / `memory_seconds`.
+
+**Source of truth:** the org's DuckLake metadata Postgres — DuckLake records
+`file_size_bytes` for every Parquet file it writes, so the tracked footprint is
+one SQL query, zero S3 calls:
+
+```sql
+SELECT COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_data_file), 0)
+     + COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_delete_file), 0),
+       (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion);
+```
+
+(No snapshot filter — time-travel-retained files stay billable until snapshot
+expiry, which is correct. `ducklake_table_info()` / `ducklake_table_stats` are
+NOT used: the former filters to the current snapshot, the latter is
+approximate.)
+
+**Sampling contract (level → flow):** a leader-only sampler visits every org
+with a Ready DuckLake warehouse every **30 minutes** (env-only override
+`DUCKGRES_STORAGE_SAMPLE_INTERVAL`, used by e2e). Each successful sample
+credits exactly `tracked_bytes × interval_seconds` byte-seconds into the
+sample-minute's bucket, keyed `(org_id, team_id, bucket_start)` — no
+query_source or worker size (compute dimensions). No elapsed-time tracking: a
+missed sample (org unreachable, leader failover) under-bills one interval and
+is deliberately best-effort, like compute. Values accumulate as NUMERIC
+byte-seconds; the API serves exact-decimal GiB-seconds (÷2³⁰ is a finite
+decimal).
+
+**API shape:** the same `GET /usage` response gains a `storage` array over the
+same watermark window; the same `ack` deletes both metric families ≤
+`watermark_high` atomically, and the 30-day safety GC covers both:
+
+```json
+{
+  "watermark_low":  "…",
+  "watermark_high": "…",
+  "usage":   [ { …compute rows as above… } ],
+  "storage": [
+    {
+      "date": "2026-07-08",
+      "org_id": "org_abc",
+      "team_id": 12345,
+      "gib_seconds": 18000000.5
+    }
+  ]
+}
+```
+
+**Known drift vs true bucket bytes** (tracked footprint ≠ `aws s3 ls`):
+orphans from crashed writes, incomplete multipart uploads (need a bucket
+lifecycle `AbortIncompleteMultipartUpload` rule — composition change), and
+files between `expire_snapshots` and `cleanup_old_files` whose size row is
+already gone. The sampler exports
+`duckgres_org_storage_pending_delete_files` as the drift gauge (alert on
+sustained nonzero) plus `duckgres_org_storage_tracked_bytes` for
+observability; a periodic S3-Inventory reconcile is an ops runbook item, not
+part of the meter.
+
 ## Defaults / house-keeping
 
 - Bucket width 60s, grace 30s.
@@ -176,5 +239,7 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 - Values exposed as vCPU-seconds / GiB-seconds; worker size as vCPU / GiB. All
   stored as exact decimals (`NUMERIC`), so fractional worker sizes keep full
   precision with no float-equality issues.
-- Single billing consumer assumed → one server-side `last_acked` cursor. (If a
-  second independent consumer is ever needed, give each its own named cursor.)
+- Single billing consumer assumed → one server-side `last_acked` cursor shared
+  by both metric families. (If a second independent consumer is ever needed,
+  give each its own named cursor.)
+- Storage sampling every 30 minutes; each sample credits exactly one interval.

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -35,7 +35,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 15)
 	requireGooseMigrationRecorded(t, db, 16)
 	requireGooseMigrationRecorded(t, db, 17)
-	requireGooseLatestVersion(t, db, 17)
+	requireGooseMigrationRecorded(t, db, 19)
+	requireGooseLatestVersion(t, db, 19)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000016 added the worker spawn log that feeds dynamic headroom
@@ -62,6 +63,12 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireColumnPresent(t, db, "duckgres_org_compute_usage", "mem_gib")
 	requireTablePresent(t, db, "duckgres_compute_billing_cursor")
 	requireTableAbsent(t, db, "duckgres_org_compute_drain_state")
+
+	// Migration 000019 added the storage-usage buffer (byte-seconds per
+	// (org, team, bucket); NUMERIC — byte-seconds overflow BIGINT).
+	requireTablePresent(t, db, "duckgres_org_storage_usage")
+	requireColumnType(t, db, "duckgres_org_storage_usage", "team_id", "bigint")
+	requireColumnType(t, db, "duckgres_org_storage_usage", "byte_seconds", "numeric")
 
 	// Migration 000008 added the explicit Duckling CR name column on
 	// managed warehouses, backfilled from lower(org_id).
@@ -135,7 +142,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 				org_id TEXT PRIMARY KEY,
 				last_drained_bucket TIMESTAMPTZ NOT NULL
 			);
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 19);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -166,7 +173,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 15)
 	requireGooseMigrationRecorded(t, upgradedDB, 16)
 	requireGooseMigrationRecorded(t, upgradedDB, 17)
-	requireGooseLatestVersion(t, upgradedDB, 17)
+	requireGooseMigrationRecorded(t, upgradedDB, 19)
+	requireGooseLatestVersion(t, upgradedDB, 19)
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")

--- a/tests/e2e-mw-dev/harness.sh
+++ b/tests/e2e-mw-dev/harness.sh
@@ -464,7 +464,9 @@ connection_duration_logged() { # org password
 # GUC set to endpoints) must surface as separate usage rows carrying the org's
 # provisioned default_team_id and a positive worker size, then an ack of the
 # served watermark_high must 200 and the next GET's watermark_low must equal it
-# (cursor advanced, acked buckets deleted). A bucket closes ~90s after the
+# (cursor advanced, acked buckets deleted). The storage family is asserted in
+# the same round-trip: the leader's sampler (60s here) must serve a storage row
+# with gib_seconds > 0 for the org, and the shared ack must advance past it. A bucket closes ~90s after the
 # connection ends (60s width + 30s grace) plus ≤15s flush, so the poll allows
 # ~4 minutes. This e2e stack has its own config store, so acking here cannot
 # eat production usage.
@@ -512,6 +514,35 @@ compute_usage_pull_api() { # org password
     -d "{\"watermark_high\":\"$future\"}" "$API/api/v1/billing/ack")"
   [ "$code" = "400" ] || fail "compute-usage: future ack -> HTTP $code want 400: $(cat /tmp/ack_future)"
   log "compute-usage OK: ack advanced cursor (deleted=$deleted), idempotent re-ack, future ack rejected"
+
+  # ---- storage metric (same pipeline, second family) ----
+  # The leader samples each Ready warehouse's tracked DuckLake footprint every
+  # 60s here (DUCKGRES_STORAGE_SAMPLE_INTERVAL in manifests.tmpl.yaml; 30m in
+  # prod) and credits bytes×interval byte-seconds. The org has real Parquet
+  # data by now (the lane's earlier writes), so a storage row with
+  # gib_seconds > 0 and the provisioned team id must appear once a sampled
+  # minute closes (sample 60s + close 90s → poll ~4min covers cold start).
+  a=0
+  while [ "$a" -lt 30 ]; do
+    body="$(curl -fsS -H "$H" "$API/api/v1/billing/usage")" || body=""
+    if [ -n "$body" ] && echo "$body" | jq -e --arg o "$org" --argjson t "$CNPG_DEFAULT_TEAM_ID" '
+        .storage | map(select(.org_id==$o and .team_id==$t and .gib_seconds>0)) | length >= 1' >/dev/null 2>&1; then
+      break
+    fi
+    sleep 10; a=$((a + 1))
+  done
+  [ "$a" -lt 30 ] || fail "storage-usage: no storage row for $org (team=$CNPG_DEFAULT_TEAM_ID, gib_seconds>0) in GET /billing/usage: $(echo "$body" | head -c 600)"
+  gib="$(echo "$body" | jq -r --arg o "$org" '[.storage[] | select(.org_id==$o)][0].gib_seconds')"
+  wh2="$(echo "$body" | jq -r '.watermark_high')"
+  log "storage-usage OK: $org gib_seconds=$gib served"
+
+  # The shared ack must clear storage buckets too: ack the served watermark,
+  # then the next GET's storage array must not contain rows ≤ it for this org
+  # (watermark_low advanced past them; new samples land in newer buckets).
+  curl -fsS -X POST -H "$H" -H 'Content-Type: application/json'     -d "{\"watermark_high\":\"$wh2\"}" "$API/api/v1/billing/ack" >/dev/null     || fail "storage-usage: ack POST failed"
+  low3="$(curl -fsS -H "$H" "$API/api/v1/billing/usage" | jq -r '.watermark_low')"
+  [ "$low3" = "$wh2" ] || fail "storage-usage: after ack, watermark_low='$low3' want '$wh2'"
+  log "storage-usage OK: shared ack advanced the cursor past storage buckets"
 }
 
 # jsonb || must keep Postgres concatenation semantics through the full CP
@@ -2637,7 +2668,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"

--- a/tests/e2e-mw-dev/manifests.tmpl.yaml
+++ b/tests/e2e-mw-dev/manifests.tmpl.yaml
@@ -241,6 +241,10 @@ spec:
             # The harness sized_worker assertion connects with these and verifies the
             # spawned pod carries the requested CPU+memory.
             - { name: DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE, value: "true" }
+            # Storage-billing sampler: production cadence is 30m, far beyond the
+            # Job's patience — sample every 60s so compute_usage_pull_api can
+            # assert the storage rows in-Job.
+            - { name: DUCKGRES_STORAGE_SAMPLE_INTERVAL, value: "60s" }
             # Pool-default worker shape for connections that send no sizing GUCs.
             # Workers are never BestEffort (no pod anti-affinity anymore — resource
             # requests are the only node-overcommit guard); without this the binary


### PR DESCRIPTION
Second metric family on the pull-billing pipeline (#893): each warehouse's **tracked DuckLake S3 footprint, integrated over time** — served as exact-decimal **GiB-seconds** so billing can charge GiB-months alongside compute. Spec: [`billing-pull-api.md` → Storage metric](https://github.com/PostHog/duckgres/blob/ben/billing-storage-metric/docs/design/billing-pull-api.md#storage-metric).

## How it works

- **Source of truth = DuckLake metadata Postgres** (no S3 calls): DuckLake records `file_size_bytes` for every Parquet file it writes, so the footprint is one SQL query — `SUM` over `ducklake_data_file` + `ducklake_delete_file`, **no snapshot filter** (time-travel-retained files stay billable until snapshot expiry). `ducklake_table_info()` / `ducklake_table_stats` are deliberately not used (current-snapshot-only / approximate).
- **Level → flow**: a **leader-only** sampler visits each Ready warehouse every 30 min (env-only `DUCKGRES_STORAGE_SAMPLE_INTERVAL`; the e2e deploys 60s) and credits exactly `tracked_bytes × interval` byte-seconds into the sample-minute's bucket. No elapsed-time tracking — a missed sample under-bills one interval, best-effort like compute. Leader-only because the UPSERT is additive; a second writer would double-bill.
- **Connection resolution** reuses the cross-org activator: new `MetadataPostgresURL` prefers the duckling's pgbouncer (`sslmode=disable`, the pooler carries TLS to RDS) over the direct endpoint (`require`), config-store fallback (`prefer`) — same rules as `provisioner.ProbeMetadataStore`.
- **Migration 000019**: `duckgres_org_storage_usage(org_id, team_id BIGINT, bucket_start, byte_seconds NUMERIC)` — NUMERIC because ~100 TiB × a day overflows BIGINT. (000018 is skipped — an in-flight branch claims it; goose handles gaps.)
- **API**: `GET /billing/usage` gains a `storage` array — one row per `(org, team)` per UTC day, `gib_seconds` as an exact JSON number (big-int ÷2³⁰, which terminates) — over the **same watermark window**; the **same ack** deletes both families in one transaction; the 30-day GC covers both. Billing: GiB-months = `SUM(gib_seconds) / 2,592,000`.
- **Drift observability**: `duckgres_org_storage_pending_delete_files` (files between `expire_snapshots` and `cleanup_old_files` — bytes on S3 the meter can't see; alert on sustained nonzero), `duckgres_org_storage_tracked_bytes`, `duckgres_storage_sample_errors_total`.

## Tests

- `storage_meter_test.go`: credit math (bytes × interval into the floored minute), per-org error-skip, best-effort store failure, run/cancel, env-knob parsing.
- `configstore/storage_usage_test.go`: exact byte-seconds → GiB-seconds conversion incl. a beyond-float64 vector and the full 30-digit 1-byte-second case.
- `compute_billing_api_test.go`: storage rides the same window (bounds asserted), serializes as JSON numbers, empty-window short-circuit covers both arrays.
- `migrations_postgres_test.go`: v19 recorded/latest, table + column types — verified against a real local Postgres, including the v8-replay path across the 17→19 gap.
- e2e `harness.sh`: `compute_usage_pull_api` now also polls `GET /billing/usage` for a storage row with `gib_seconds > 0` carrying the org's provisioned `default_team_id` (real Parquet data from the lane's earlier writes, real metadata Postgres), and asserts the shared ack advances the cursor past storage buckets.

## Out of scope (tracked in the spec's drift list)

Bucket lifecycle `AbortIncompleteMultipartUpload` rule (crossplane-config change), snapshot-expiry/cleanup cadence review, monthly S3-Inventory reconcile (ops runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)