### PR TITLE
Add dbt retry reporting and realistic frozen scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ duckgres_local_test.yaml
 artifacts/perf/
 /artifacts/
 
+# dbt local user identity
+.user.yml
+
 .gemini/
 gha-creds-*.json
 data-test/

--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -109,6 +109,16 @@ The frozen dbt scenario uses:
 
 dbt artifacts are written under `artifacts/scenario/<run_id>/dbt/`, including per-command stdout/stderr logs, `target/` artifacts, and dbt logs. Install `dbt-postgres` locally or set `DUCKGRES_SCENARIO_DBT_BIN` to the dbt executable to use.
 
+dbt retry is opt-in per scenario step:
+
+```yaml
+retry:
+  enabled: true
+  max_attempts: 2
+```
+
+When enabled, a failed `run`, `test`, or `docs_generate` command is retried with `dbt retry`. The scenario records the original failure and retry as separate attempts in `events.jsonl`, marks the step `success_after_retry` if recovery succeeds, and writes per-attempt logs under `artifacts/scenario/<run_id>/dbt/attempts/<command>/attempt_<n>/`. `retry.enabled` defaults to `false`; `max_attempts` counts the original command attempt.
+
 `DUCKGRES_SCENARIO_FROZEN_S3_URI` must point at a dev-owned frozen dataset prefix with `persons/` and `events/` parquet children.
 The provisioned Duckgres worker role also needs read/list access to that prefix; the runner process only supplies the URI, while the worker performs the S3 reads during `read_parquet`.
 

--- a/tests/scenario/core/artifacts.go
+++ b/tests/scenario/core/artifacts.go
@@ -13,27 +13,50 @@ import (
 type RunSummary struct {
 	RunID          string    `json:"run_id"`
 	ScenarioName   string    `json:"scenario_name"`
+	Status         RunStatus `json:"status"`
 	StartedAt      time.Time `json:"started_at"`
 	FinishedAt     time.Time `json:"finished_at"`
 	TotalSteps     int       `json:"total_steps"`
 	SucceededSteps int       `json:"succeeded_steps"`
 	FailedSteps    int       `json:"failed_steps"`
 	SkippedSteps   int       `json:"skipped_steps"`
+	RecoveredSteps int       `json:"recovered_steps"`
+	FailedAttempts int       `json:"failed_attempts"`
 }
 
 type StepResult struct {
-	RunID        string        `json:"run_id"`
-	ScenarioName string        `json:"scenario_name"`
-	StepID       string        `json:"step_id"`
-	StepType     string        `json:"step_type"`
-	Status       StepStatus    `json:"status"`
-	ErrorClass   string        `json:"error_class,omitempty"`
-	Error        string        `json:"error,omitempty"`
-	StartedAt    time.Time     `json:"started_at"`
-	FinishedAt   time.Time     `json:"finished_at"`
-	Duration     time.Duration `json:"duration_ns"`
-	Attempts     int           `json:"attempts"`
-	Err          error         `json:"-"`
+	RunID          string              `json:"run_id"`
+	ScenarioName   string              `json:"scenario_name"`
+	StepID         string              `json:"step_id"`
+	StepType       string              `json:"step_type"`
+	Status         StepStatus          `json:"status"`
+	ErrorClass     string              `json:"error_class,omitempty"`
+	Error          string              `json:"error,omitempty"`
+	StartedAt      time.Time           `json:"started_at"`
+	FinishedAt     time.Time           `json:"finished_at"`
+	Duration       time.Duration       `json:"duration_ns"`
+	Attempts       int                 `json:"attempts"`
+	FailedAttempts int                 `json:"failed_attempts"`
+	Recovered      bool                `json:"recovered"`
+	AttemptDetails []StepAttemptResult `json:"attempt_details,omitempty"`
+	Err            error               `json:"-"`
+}
+
+type StepResultMetadata struct {
+	Attempts       int
+	FailedAttempts int
+	Recovered      bool
+	AttemptDetails []StepAttemptResult
+}
+
+type StepAttemptResult struct {
+	Attempt     int    `json:"attempt"`
+	CommandName string `json:"command_name"`
+	Status      string `json:"status"`
+	ExitCode    int    `json:"exit_code,omitempty"`
+	Error       string `json:"error,omitempty"`
+	RetryOf     string `json:"retry_of,omitempty"`
+	OutputDir   string `json:"output_dir,omitempty"`
 }
 
 var stepResultsHeader = []string{
@@ -48,6 +71,8 @@ var stepResultsHeader = []string{
 	"finished_at",
 	"duration_ms",
 	"attempts",
+	"failed_attempts",
+	"recovered",
 }
 
 func WriteArtifacts(dir string, summary RunSummary, results []StepResult) error {
@@ -133,6 +158,8 @@ func stepResultRecord(result StepResult) []string {
 		result.FinishedAt.UTC().Format(time.RFC3339Nano),
 		strconv.FormatFloat(float64(result.Duration)/float64(time.Millisecond), 'f', 6, 64),
 		strconv.Itoa(result.Attempts),
+		strconv.Itoa(result.FailedAttempts),
+		strconv.FormatBool(result.Recovered),
 	}
 }
 

--- a/tests/scenario/core/runner.go
+++ b/tests/scenario/core/runner.go
@@ -11,16 +11,27 @@ import (
 type StepStatus string
 
 const (
-	StepStatusOK      StepStatus = "ok"
-	StepStatusFailed  StepStatus = "failed"
-	StepStatusSkipped StepStatus = "skipped"
+	StepStatusOK                StepStatus = "ok"
+	StepStatusSuccessAfterRetry StepStatus = "success_after_retry"
+	StepStatusFailed            StepStatus = "failed"
+	StepStatusSkipped           StepStatus = "skipped"
+
+	RunStatusSuccess            RunStatus = "success"
+	RunStatusSuccessWithRetries RunStatus = "success_with_retries"
+	RunStatusFailed             RunStatus = "failed"
 
 	errorClassExpectedErrorMissing  = "expected_error_missing"
 	errorClassExpectedErrorMismatch = "expected_error_mismatch"
 )
 
+type RunStatus string
+
 type StepExecutor interface {
 	ExecuteStep(context.Context, Step) error
+}
+
+type StepMetadataProvider interface {
+	StepResultMetadata(stepID string) (StepResultMetadata, bool)
 }
 
 type ClassifiedError interface {
@@ -68,6 +79,7 @@ func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
 	summary := RunSummary{
 		RunID:        runID,
 		ScenarioName: r.cfg.Scenario.Name,
+		Status:       RunStatusSuccess,
 		StartedAt:    startedAt,
 		FinishedAt:   startedAt,
 		TotalSteps:   len(r.cfg.Scenario.Steps),
@@ -94,19 +106,24 @@ func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
 		if result.Err != nil {
 			runErrs = append(runErrs, result.Err)
 		}
-		if !step.AlwaysRun && result.Status != StepStatusOK {
+		if !step.AlwaysRun && !isSuccessfulStepStatus(result.Status) {
 			normalStepsBlocked = true
 		}
 		switch result.Status {
-		case StepStatusOK:
+		case StepStatusOK, StepStatusSuccessAfterRetry:
 			summary.SucceededSteps++
+			if result.Status == StepStatusSuccessAfterRetry {
+				summary.RecoveredSteps++
+			}
 		case StepStatusFailed:
 			summary.FailedSteps++
 		case StepStatusSkipped:
 			summary.SkippedSteps++
 		}
+		summary.FailedAttempts += result.FailedAttempts
 	}
 	summary.FinishedAt = r.cfg.Now()
+	summary.Status = summaryStatus(summary)
 
 	if r.cfg.WriteFiles {
 		if err := WriteArtifacts(r.cfg.OutputDir, summary, r.results); err != nil {
@@ -156,6 +173,7 @@ func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByS
 	}
 	if step.ExpectError != nil {
 		r.applyExpectedError(step, err, &result)
+		r.applyStepMetadata(step.ID, &result)
 		return result
 	}
 	if err != nil {
@@ -164,7 +182,28 @@ func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByS
 		result.Error = err.Error()
 		result.Err = err
 	}
+	r.applyStepMetadata(step.ID, &result)
 	return result
+}
+
+func (r *Runner) applyStepMetadata(stepID string, result *StepResult) {
+	provider, ok := r.cfg.Executor.(StepMetadataProvider)
+	if !ok {
+		return
+	}
+	metadata, ok := provider.StepResultMetadata(stepID)
+	if !ok {
+		return
+	}
+	if metadata.Attempts > 0 {
+		result.Attempts = metadata.Attempts
+	}
+	result.FailedAttempts = metadata.FailedAttempts
+	result.Recovered = metadata.Recovered
+	result.AttemptDetails = metadata.AttemptDetails
+	if metadata.Recovered && result.Status == StepStatusOK {
+		result.Status = StepStatusSuccessAfterRetry
+	}
 }
 
 func (r *Runner) applyExpectedError(step Step, err error, result *StepResult) {
@@ -232,11 +271,25 @@ func (r *Runner) contextForStep(ctx context.Context, step Step) (context.Context
 
 func firstUnsuccessfulDependency(step Step, statusByStep map[string]StepStatus) (string, bool) {
 	for _, dep := range step.DependsOn {
-		if statusByStep[dep] != StepStatusOK {
+		if !isSuccessfulStepStatus(statusByStep[dep]) {
 			return dep, true
 		}
 	}
 	return "", false
+}
+
+func isSuccessfulStepStatus(status StepStatus) bool {
+	return status == StepStatusOK || status == StepStatusSuccessAfterRetry
+}
+
+func summaryStatus(summary RunSummary) RunStatus {
+	if summary.FailedSteps > 0 || summary.SkippedSteps > 0 {
+		return RunStatusFailed
+	}
+	if summary.RecoveredSteps > 0 || summary.FailedAttempts > 0 {
+		return RunStatusSuccessWithRetries
+	}
+	return RunStatusSuccess
 }
 
 func classifyStepError(err error) string {

--- a/tests/scenario/core/runner_test.go
+++ b/tests/scenario/core/runner_test.go
@@ -189,6 +189,143 @@ steps:
 	}
 }
 
+func TestRunnerMarksRecoveredAttemptFailuresAsSuccessfulWithRetries(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: recovered
+steps:
+  - id: dbt_models
+    type: dbt_run
+  - id: downstream
+    type: fake
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	executor := &metadataExecutor{
+		results: map[string]StepResultMetadata{
+			"dbt_models": {
+				Attempts:       2,
+				FailedAttempts: 1,
+				Recovered:      true,
+				AttemptDetails: []StepAttemptResult{{
+					Attempt:     1,
+					CommandName: "run",
+					Status:      "failed",
+					ExitCode:    2,
+					Error:       "flight EOF",
+				}, {
+					Attempt:     2,
+					CommandName: "retry",
+					Status:      "ok",
+					RetryOf:     "run",
+				}},
+			},
+		},
+	}
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-recovered",
+		Scenario: scenario,
+		Executor: executor,
+		Now:      fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	summary, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error for recovered failure: %v", err)
+	}
+	if summary.SucceededSteps != 2 || summary.RecoveredSteps != 1 || summary.FailedAttempts != 1 || summary.Status != RunStatusSuccessWithRetries {
+		t.Fatalf("summary = %+v", summary)
+	}
+	results := runner.Results()
+	if results[0].Status != StepStatusSuccessAfterRetry || !results[0].Recovered || results[0].FailedAttempts != 1 {
+		t.Fatalf("dbt result = %+v", results[0])
+	}
+	if len(results[0].AttemptDetails) != 2 || results[0].AttemptDetails[0].Status != "failed" {
+		t.Fatalf("attempt details = %+v", results[0].AttemptDetails)
+	}
+	if results[1].StepID != "downstream" || results[1].Status != StepStatusOK {
+		t.Fatalf("downstream should run after recovered step, got %+v", results[1])
+	}
+}
+
+func TestRunnerIncludesAttemptMetadataForExpectedErrors(t *testing.T) {
+	scenario, err := ParseScenario([]byte(`
+name: expected-error-attempts
+steps:
+  - id: dbt_models
+    type: dbt_run
+    expect_error:
+      error_class: dbt_execution
+      contains: ["exit code 2"]
+`))
+	if err != nil {
+		t.Fatalf("ParseScenario returned error: %v", err)
+	}
+
+	executor := &metadataExecutor{
+		errs: map[string]error{
+			"dbt_models": classifiedTestError{class: "dbt_execution", message: "dbt command run failed with exit code 2"},
+		},
+		results: map[string]StepResultMetadata{
+			"dbt_models": {
+				Attempts:       2,
+				FailedAttempts: 2,
+				AttemptDetails: []StepAttemptResult{{
+					Attempt:     1,
+					CommandName: "run",
+					Status:      "failed",
+					ExitCode:    2,
+				}, {
+					Attempt:     2,
+					CommandName: "retry",
+					Status:      "failed",
+					ExitCode:    2,
+					RetryOf:     "run",
+				}},
+			},
+		},
+	}
+	runner := NewRunner(RunnerConfig{
+		RunID:    "run-expected-error-attempts",
+		Scenario: scenario,
+		Executor: executor,
+		Now:      fixedClock(time.Unix(1700000000, 0)),
+	})
+
+	summary, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error for expected dbt failure: %v", err)
+	}
+	if summary.SucceededSteps != 1 || summary.FailedAttempts != 2 || summary.Status != RunStatusSuccessWithRetries {
+		t.Fatalf("summary = %+v", summary)
+	}
+	results := runner.Results()
+	if len(results) != 1 {
+		t.Fatalf("results = %+v", results)
+	}
+	if results[0].Status != StepStatusOK || results[0].Attempts != 2 || results[0].FailedAttempts != 2 {
+		t.Fatalf("result = %+v", results[0])
+	}
+	if len(results[0].AttemptDetails) != 2 || results[0].AttemptDetails[1].RetryOf != "run" {
+		t.Fatalf("attempt details = %+v", results[0].AttemptDetails)
+	}
+}
+
+type metadataExecutor struct {
+	errs    map[string]error
+	results map[string]StepResultMetadata
+}
+
+func (e *metadataExecutor) ExecuteStep(_ context.Context, step Step) error {
+	return e.errs[step.ID]
+}
+
+func (e *metadataExecutor) StepResultMetadata(stepID string) (StepResultMetadata, bool) {
+	result, ok := e.results[stepID]
+	return result, ok
+}
+
 func TestRunnerRecordsClassifiedExecutorError(t *testing.T) {
 	sentinel := classifiedTestError{class: "cleanup_timeout", message: "cleanup timed out"}
 	scenario, err := ParseScenario([]byte(`

--- a/tests/scenario/dbt/posthog_frozen_project/dbt_project.yml
+++ b/tests/scenario/dbt/posthog_frozen_project/dbt_project.yml
@@ -8,6 +8,10 @@ test-paths: ["tests"]
 models:
   posthog_frozen_scenario:
     staging:
-      +materialized: view
+      +materialized: table
+    intermediate:
+      +materialized: table
+    facts:
+      +materialized: table
     marts:
       +materialized: table

--- a/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_activation_funnel.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_activation_funnel.sql
@@ -1,0 +1,29 @@
+WITH person_events AS (
+    SELECT
+        person_id,
+        min(CASE WHEN event_category = 'pageview' THEN event_timestamp END) AS first_pageview_timestamp,
+        min(CASE WHEN event_category = 'feature' THEN event_timestamp END) AS first_feature_timestamp,
+        min(CASE WHEN event_category NOT IN ('pageview', 'autocapture') THEN event_timestamp END) AS first_product_event_timestamp,
+        count(*) AS total_events,
+        count(DISTINCT event_day) AS active_days
+    FROM {{ ref('stg_events') }}
+    WHERE person_id IS NOT NULL
+    GROUP BY 1
+)
+
+SELECT
+    first_seen.person_id,
+    first_seen.first_seen_timestamp,
+    person_events.first_pageview_timestamp,
+    person_events.first_feature_timestamp,
+    person_events.first_product_event_timestamp,
+    person_events.first_pageview_timestamp IS NOT NULL AS saw_pageview,
+    person_events.first_feature_timestamp IS NOT NULL AS used_feature,
+    person_events.first_product_event_timestamp IS NOT NULL AS performed_product_action,
+    person_events.first_feature_timestamp IS NOT NULL
+        OR person_events.first_product_event_timestamp IS NOT NULL AS activated,
+    person_events.total_events,
+    person_events.active_days
+FROM {{ ref('int_person_first_seen') }} AS first_seen
+LEFT JOIN person_events
+    ON first_seen.person_id = person_events.person_id

--- a/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_feature_usage_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_feature_usage_daily.sql
@@ -1,0 +1,9 @@
+SELECT
+    event_day,
+    feature_area,
+    count(*) AS users,
+    sum(events) AS events,
+    sum(pageview_events) AS pageview_events,
+    sum(feature_events) AS feature_events
+FROM {{ ref('int_person_feature_usage_daily') }}
+GROUP BY 1, 2

--- a/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_retention_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_retention_daily.sql
@@ -1,0 +1,33 @@
+WITH person_activity AS (
+    SELECT
+        person_id,
+        event_day AS activity_day,
+        events
+    FROM {{ ref('int_person_activity_daily') }}
+),
+
+retention_rows AS (
+    SELECT
+        first_seen.person_id,
+        CAST(date_trunc('day', first_seen.first_seen_timestamp) AS DATE) AS cohort_day,
+        person_activity.activity_day,
+        date_diff(
+            'day',
+            CAST(date_trunc('day', first_seen.first_seen_timestamp) AS DATE),
+            person_activity.activity_day
+        ) AS days_since_first_seen,
+        person_activity.events
+    FROM {{ ref('int_person_first_seen') }} AS first_seen
+    INNER JOIN person_activity
+        ON first_seen.person_id = person_activity.person_id
+)
+
+SELECT
+    cohort_day,
+    activity_day,
+    days_since_first_seen,
+    count(DISTINCT person_id) AS retained_persons,
+    sum(events) AS events
+FROM retention_rows
+WHERE days_since_first_seen >= 0
+GROUP BY 1, 2, 3

--- a/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_sessions.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_sessions.sql
@@ -1,0 +1,13 @@
+SELECT
+    session_id,
+    person_id,
+    min(event_timestamp) AS session_start,
+    max(event_timestamp) AS session_end,
+    CAST(date_trunc('day', min(event_timestamp)) AS DATE) AS session_day,
+    date_diff('second', min(event_timestamp), max(event_timestamp)) AS session_duration_seconds,
+    count(*) AS events,
+    sum(CASE WHEN event_category = 'pageview' THEN 1 ELSE 0 END) AS pageview_events,
+    sum(CASE WHEN event_category = 'feature' THEN 1 ELSE 0 END) AS feature_events,
+    count(DISTINCT feature_area) AS feature_areas_touched
+FROM {{ ref('int_sessionized_events') }}
+GROUP BY 1, 2

--- a/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_user_activity_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/facts/fct_user_activity_daily.sql
@@ -1,0 +1,18 @@
+SELECT
+    event_days.event_day,
+    coalesce(person_days.active_persons, 0) AS active_persons,
+    event_days.events,
+    event_days.pageview_events,
+    event_days.feature_events,
+    event_days.autocapture_events,
+    event_days.unique_event_names,
+    event_days.feature_areas_touched
+FROM {{ ref('int_event_days') }} AS event_days
+LEFT JOIN (
+    SELECT
+        event_day,
+        count(*) AS active_persons
+    FROM {{ ref('int_person_activity_daily') }}
+    GROUP BY 1
+) AS person_days
+    ON event_days.event_day = person_days.event_day

--- a/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_event_days.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_event_days.sql
@@ -1,0 +1,10 @@
+SELECT
+    event_day,
+    count(*) AS events,
+    sum(CASE WHEN event_category = 'pageview' THEN 1 ELSE 0 END) AS pageview_events,
+    sum(CASE WHEN event_category = 'feature' THEN 1 ELSE 0 END) AS feature_events,
+    sum(CASE WHEN event_category = 'autocapture' THEN 1 ELSE 0 END) AS autocapture_events,
+    count(DISTINCT event) AS unique_event_names,
+    count(DISTINCT feature_area) AS feature_areas_touched
+FROM {{ ref('stg_events') }}
+GROUP BY 1

--- a/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_activity_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_activity_daily.sql
@@ -1,0 +1,14 @@
+SELECT
+    person_id,
+    event_day,
+    count(*) AS events,
+    min(event_timestamp) AS first_event_timestamp,
+    max(event_timestamp) AS last_event_timestamp,
+    sum(CASE WHEN event_category = 'pageview' THEN 1 ELSE 0 END) AS pageview_events,
+    sum(CASE WHEN event_category = 'feature' THEN 1 ELSE 0 END) AS feature_events,
+    sum(CASE WHEN event_category = 'autocapture' THEN 1 ELSE 0 END) AS autocapture_events,
+    count(DISTINCT event) AS unique_event_names,
+    count(DISTINCT feature_area) AS feature_areas_touched
+FROM {{ ref('stg_events') }}
+WHERE person_id IS NOT NULL
+GROUP BY 1, 2

--- a/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_feature_usage_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_feature_usage_daily.sql
@@ -1,0 +1,10 @@
+SELECT
+    person_id,
+    event_day,
+    feature_area,
+    count(*) AS events,
+    sum(CASE WHEN event_category = 'pageview' THEN 1 ELSE 0 END) AS pageview_events,
+    sum(CASE WHEN event_category = 'feature' THEN 1 ELSE 0 END) AS feature_events
+FROM {{ ref('stg_events') }}
+WHERE person_id IS NOT NULL
+GROUP BY 1, 2, 3

--- a/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_first_seen.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_person_first_seen.sql
@@ -1,0 +1,29 @@
+WITH event_first_seen AS (
+    SELECT
+        person_id,
+        min(event_timestamp) AS first_event_timestamp,
+        max(event_timestamp) AS last_event_timestamp,
+        count(*) AS lifetime_events,
+        count(DISTINCT event_day) AS active_days
+    FROM {{ ref('stg_events') }}
+    WHERE person_id IS NOT NULL
+    GROUP BY 1
+),
+
+person_dataset_bounds AS (
+    SELECT
+        count(*) AS person_snapshots
+    FROM {{ ref('stg_persons') }}
+)
+
+SELECT
+    event_first_seen.person_id,
+    event_first_seen.first_event_timestamp,
+    CAST(NULL AS TIMESTAMP) AS first_person_timestamp,
+    event_first_seen.first_event_timestamp AS first_seen_timestamp,
+    event_first_seen.last_event_timestamp,
+    event_first_seen.lifetime_events,
+    event_first_seen.active_days,
+    person_dataset_bounds.person_snapshots
+FROM event_first_seen
+CROSS JOIN person_dataset_bounds

--- a/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_sessionized_events.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/intermediate/int_sessionized_events.sql
@@ -1,0 +1,52 @@
+WITH ordered_events AS (
+    SELECT
+        event_row_id,
+        person_id,
+        event,
+        event_timestamp,
+        event_day,
+        event_category,
+        feature_area,
+        lag(event_timestamp) OVER (
+            PARTITION BY person_id
+            ORDER BY event_timestamp, event_row_id
+        ) AS previous_event_timestamp
+    FROM {{ ref('stg_events') }}
+    WHERE person_id IS NOT NULL
+),
+
+session_boundaries AS (
+    SELECT
+        *,
+        CASE
+            WHEN previous_event_timestamp IS NULL THEN 1
+            WHEN date_diff('minute', previous_event_timestamp, event_timestamp) > 30 THEN 1
+            ELSE 0
+        END AS is_new_session
+    FROM ordered_events
+),
+
+numbered_sessions AS (
+    SELECT
+        *,
+        sum(is_new_session) OVER (
+            PARTITION BY person_id
+            ORDER BY event_timestamp, event_row_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS session_number
+    FROM session_boundaries
+)
+
+SELECT
+    CAST(person_id AS VARCHAR) || '-' || CAST(session_number AS VARCHAR) AS session_id,
+    session_number,
+    event_row_id,
+    person_id,
+    event,
+    event_timestamp,
+    event_day,
+    event_category,
+    feature_area,
+    previous_event_timestamp,
+    is_new_session
+FROM numbered_sessions

--- a/tests/scenario/dbt/posthog_frozen_project/models/marts/daily_event_counts.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/marts/daily_event_counts.sql
@@ -1,6 +1,0 @@
-SELECT
-    date_trunc('day', event_timestamp) AS event_day,
-    event,
-    count(*) AS events
-FROM {{ ref('stg_events') }}
-GROUP BY 1, 2

--- a/tests/scenario/dbt/posthog_frozen_project/models/marts/mart_product_kpis_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/marts/mart_product_kpis_daily.sql
@@ -1,0 +1,82 @@
+WITH days AS (
+    SELECT event_day AS metric_day FROM {{ ref('fct_user_activity_daily') }}
+    UNION
+    SELECT session_day AS metric_day FROM {{ ref('fct_sessions') }}
+    UNION
+    SELECT CAST(date_trunc('day', first_seen_timestamp) AS DATE) AS metric_day FROM {{ ref('fct_activation_funnel') }}
+    UNION
+    SELECT cohort_day AS metric_day FROM {{ ref('fct_retention_daily') }}
+    UNION
+    SELECT person_day AS metric_day FROM {{ ref('stg_persons') }}
+),
+
+session_metrics AS (
+    SELECT
+        session_day,
+        count(*) AS sessions,
+        count(DISTINCT person_id) AS session_users,
+        avg(session_duration_seconds) AS avg_session_duration_seconds
+    FROM {{ ref('fct_sessions') }}
+    GROUP BY 1
+),
+
+activation_metrics AS (
+    SELECT
+        CAST(date_trunc('day', first_seen_timestamp) AS DATE) AS first_seen_day,
+        count(*) AS first_seen_users,
+        sum(CASE WHEN saw_pageview THEN 1 ELSE 0 END) AS users_with_pageview,
+        sum(CASE WHEN used_feature THEN 1 ELSE 0 END) AS users_with_feature,
+        sum(CASE WHEN activated THEN 1 ELSE 0 END) AS activated_users
+    FROM {{ ref('fct_activation_funnel') }}
+    GROUP BY 1
+),
+
+retention_metrics AS (
+    SELECT
+        cohort_day,
+        sum(CASE WHEN days_since_first_seen = 1 THEN retained_persons ELSE 0 END) AS retained_users_d1,
+        sum(CASE WHEN days_since_first_seen = 7 THEN retained_persons ELSE 0 END) AS retained_users_d7,
+        sum(CASE WHEN days_since_first_seen = 30 THEN retained_persons ELSE 0 END) AS retained_users_d30,
+        sum(CASE WHEN days_since_first_seen > 0 THEN retained_persons ELSE 0 END) AS retained_users
+    FROM {{ ref('fct_retention_daily') }}
+    GROUP BY 1
+),
+
+person_metrics AS (
+    SELECT
+        person_day,
+        count(*) AS person_snapshots
+    FROM {{ ref('stg_persons') }}
+    GROUP BY 1
+)
+
+SELECT
+    days.metric_day,
+    coalesce(activity.active_persons, 0) AS daily_active_users,
+    coalesce(activity.events, 0) AS total_events,
+    coalesce(activity.pageview_events, 0) AS pageview_events,
+    coalesce(activity.feature_events, 0) AS feature_events,
+    coalesce(activity.autocapture_events, 0) AS autocapture_events,
+    coalesce(sessions.sessions, 0) AS sessions,
+    coalesce(sessions.session_users, 0) AS session_users,
+    coalesce(sessions.avg_session_duration_seconds, 0) AS avg_session_duration_seconds,
+    coalesce(activation.first_seen_users, 0) AS first_seen_users,
+    coalesce(activation.users_with_pageview, 0) AS users_with_pageview,
+    coalesce(activation.users_with_feature, 0) AS users_with_feature,
+    coalesce(activation.activated_users, 0) AS activated_users,
+    coalesce(retention.retained_users, 0) AS retained_users,
+    coalesce(retention.retained_users_d1, 0) AS retained_users_d1,
+    coalesce(retention.retained_users_d7, 0) AS retained_users_d7,
+    coalesce(retention.retained_users_d30, 0) AS retained_users_d30,
+    coalesce(persons.person_snapshots, 0) AS person_snapshots
+FROM days
+LEFT JOIN {{ ref('fct_user_activity_daily') }} AS activity
+    ON days.metric_day = activity.event_day
+LEFT JOIN session_metrics AS sessions
+    ON days.metric_day = sessions.session_day
+LEFT JOIN activation_metrics AS activation
+    ON days.metric_day = activation.first_seen_day
+LEFT JOIN retention_metrics AS retention
+    ON days.metric_day = retention.cohort_day
+LEFT JOIN person_metrics AS persons
+    ON days.metric_day = persons.person_day

--- a/tests/scenario/dbt/posthog_frozen_project/models/marts/person_event_rollup.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/marts/person_event_rollup.sql
@@ -1,8 +1,0 @@
-SELECT
-    person_id,
-    count(*) AS events,
-    min(event_timestamp) AS first_event_timestamp,
-    max(event_timestamp) AS last_event_timestamp
-FROM {{ ref('stg_events') }}
-WHERE person_id IS NOT NULL
-GROUP BY 1

--- a/tests/scenario/dbt/posthog_frozen_project/models/schema.yml
+++ b/tests/scenario/dbt/posthog_frozen_project/models/schema.yml
@@ -1,38 +1,210 @@
 version: 2
 
 models:
-  - name: stg_persons_daily
-    columns:
-      - name: person_day
-        tests:
-          - not_null
-      - name: persons
-        tests:
-          - not_null
-
   - name: stg_events
+    description: Normalized raw events with product analytics classifications.
     columns:
+      - name: event_row_id
+        tests:
+          - not_null
       - name: event
         tests:
           - not_null
       - name: event_timestamp
         tests:
           - not_null
+      - name: event_day
+        tests:
+          - not_null
+      - name: event_category
+        tests:
+          - not_null
+      - name: feature_area
+        tests:
+          - not_null
 
-  - name: daily_event_counts
+  - name: stg_persons
+    description: Person snapshot timestamps from the frozen persons dataset.
     columns:
+      - name: person_snapshot_id
+        tests:
+          - not_null
+      - name: person_created_at
+        tests:
+          - not_null
+      - name: person_day
+        tests:
+          - not_null
+
+  - name: int_person_first_seen
+    description: One row per event person with first-seen and lifetime activity metrics.
+    columns:
+      - name: person_id
+        tests:
+          - not_null
+          - unique
+      - name: first_event_timestamp
+        tests:
+          - not_null
+      - name: first_seen_timestamp
+        tests:
+          - not_null
+
+  - name: int_sessionized_events
+    description: Event stream annotated with 30-minute inactivity session boundaries.
+    columns:
+      - name: session_id
+        tests:
+          - not_null
+      - name: session_number
+        tests:
+          - not_null
+      - name: person_id
+        tests:
+          - not_null
+      - name: event_timestamp
+        tests:
+          - not_null
+
+  - name: int_event_days
+    description: One row per event day, materialized to avoid repeated raw event scans for daily facts.
+    columns:
+      - name: event_day
+        tests:
+          - not_null
+          - unique
+      - name: events
+        tests:
+          - not_null
+      - name: pageview_events
+        tests:
+          - not_null
+
+  - name: int_person_activity_daily
+    description: One row per active person per event day.
+    columns:
+      - name: person_id
+        tests:
+          - not_null
       - name: event_day
         tests:
           - not_null
       - name: events
         tests:
           - not_null
+      - name: feature_events
+        tests:
+          - not_null
 
-  - name: person_event_rollup
+  - name: int_person_feature_usage_daily
+    description: One row per person, day, and feature area for reusable feature usage aggregation.
     columns:
       - name: person_id
         tests:
           - not_null
+      - name: event_day
+        tests:
+          - not_null
+      - name: feature_area
+        tests:
+          - not_null
       - name: events
+        tests:
+          - not_null
+
+  - name: fct_sessions
+    description: Session-level fact table for product usage analysis.
+    columns:
+      - name: session_id
+        tests:
+          - not_null
+          - unique
+      - name: person_id
+        tests:
+          - not_null
+      - name: session_start
+        tests:
+          - not_null
+      - name: session_day
+        tests:
+          - not_null
+      - name: events
+        tests:
+          - not_null
+
+  - name: fct_user_activity_daily
+    description: Daily active user and event-volume aggregate.
+    columns:
+      - name: event_day
+        tests:
+          - not_null
+          - unique
+      - name: active_persons
+        tests:
+          - not_null
+      - name: events
+        tests:
+          - not_null
+
+  - name: fct_activation_funnel
+    description: Per-person activation funnel from first seen to pageview/product action.
+    columns:
+      - name: person_id
+        tests:
+          - not_null
+          - unique
+      - name: first_seen_timestamp
+        tests:
+          - not_null
+      - name: activated
+        tests:
+          - not_null
+
+  - name: fct_retention_daily
+    description: Cohort retention rows by cohort day and activity day.
+    columns:
+      - name: cohort_day
+        tests:
+          - not_null
+      - name: activity_day
+        tests:
+          - not_null
+      - name: days_since_first_seen
+        tests:
+          - not_null
+      - name: retained_persons
+        tests:
+          - not_null
+
+  - name: fct_feature_usage_daily
+    description: Daily feature-area usage metrics.
+    columns:
+      - name: event_day
+        tests:
+          - not_null
+      - name: feature_area
+        tests:
+          - not_null
+      - name: users
+        tests:
+          - not_null
+      - name: events
+        tests:
+          - not_null
+
+  - name: mart_product_kpis_daily
+    description: Product analytics KPI mart combining activity, sessions, activation, retention, and person snapshots.
+    columns:
+      - name: metric_day
+        tests:
+          - not_null
+          - unique
+      - name: daily_active_users
+        tests:
+          - not_null
+      - name: activated_users
+        tests:
+          - not_null
+      - name: retained_users
         tests:
           - not_null

--- a/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_events.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_events.sql
@@ -1,6 +1,30 @@
 SELECT
+    row_number() OVER () AS event_row_id,
     event,
     person_id,
-    "timestamp" AS event_timestamp
+    "timestamp" AS event_timestamp,
+    CAST(date_trunc('day', "timestamp") AS DATE) AS event_day,
+    CASE
+        WHEN event = '$pageview' THEN 'pageview'
+        WHEN event = '$autocapture' THEN 'autocapture'
+        WHEN event IN ('$identify', '$set') THEN 'identity'
+        WHEN lower(event) LIKE '%feature%'
+            OR lower(event) LIKE '%insight%'
+            OR lower(event) LIKE '%dashboard%'
+            OR lower(event) LIKE '%recording%'
+            OR lower(event) LIKE '%experiment%'
+            THEN 'feature'
+        ELSE 'other'
+    END AS event_category,
+    CASE
+        WHEN event IN ('$pageview', '$pageleave') THEN 'web'
+        WHEN lower(event) LIKE '%dashboard%' THEN 'dashboards'
+        WHEN lower(event) LIKE '%insight%' THEN 'insights'
+        WHEN lower(event) LIKE '%feature%' THEN 'feature_flags'
+        WHEN lower(event) LIKE '%recording%' THEN 'session_replay'
+        WHEN lower(event) LIKE '%experiment%' THEN 'experiments'
+        ELSE 'product'
+    END AS feature_area
 FROM {{ source('frozen_v1', 'events_file_view') }}
 WHERE "timestamp" IS NOT NULL
+    AND event IS NOT NULL

--- a/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_persons.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_persons.sql
@@ -1,0 +1,6 @@
+SELECT
+    row_number() OVER () AS person_snapshot_id,
+    _timestamp AS person_created_at,
+    CAST(date_trunc('day', _timestamp) AS DATE) AS person_day
+FROM {{ source('frozen_v1', 'persons_file_view') }}
+WHERE _timestamp IS NOT NULL

--- a/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_persons_daily.sql
+++ b/tests/scenario/dbt/posthog_frozen_project/models/staging/stg_persons_daily.sql
@@ -1,6 +1,0 @@
-SELECT
-    date_trunc('day', _timestamp) AS person_day,
-    count(*) AS persons
-FROM {{ source('frozen_v1', 'persons_file_view') }}
-WHERE _timestamp IS NOT NULL
-GROUP BY 1

--- a/tests/scenario/dbt/runner_test.go
+++ b/tests/scenario/dbt/runner_test.go
@@ -181,6 +181,97 @@ func TestExecutorStopsAfterFailedDBTCommand(t *testing.T) {
 	}
 }
 
+func TestExecutorRetriesFailedDBTCommandAndRecordsRecoveredFailure(t *testing.T) {
+	projectDir := writeDBTProject(t)
+	provisionState := provision.NewState()
+	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
+		Org:      "scenario-org",
+		Username: "root",
+		Password: "root-password",
+	})
+	runAttempts := 0
+	runner := &fakeCommandRunner{
+		onRun: func(req CommandRequest) CommandResult {
+			switch req.CommandName {
+			case "run":
+				runAttempts++
+				return CommandResult{ExitCode: 2, Stderr: "flight EOF"}
+			case "retry":
+				return CommandResult{Stdout: "retry recovered"}
+			default:
+				return CommandResult{}
+			}
+		},
+	}
+	executor := NewExecutor(ExecutorConfig{
+		ProvisionState: provisionState,
+		Connection: scenariosql.ConnectionConfig{
+			HostAddr:  "10.0.0.10",
+			SNISuffix: ".dev.example",
+			SSLMode:   "require",
+		},
+		OutputDir:     t.TempDir(),
+		CommandRunner: runner,
+	})
+
+	err := executor.ExecuteStep(context.Background(), core.Step{
+		ID:   "dbt_models",
+		Type: StepTypeDBTRun,
+		With: map[string]any{
+			"org_id":      "scenario-org",
+			"project_dir": projectDir,
+			"commands":    []any{"debug", "run", "test"},
+			"retry": map[string]any{
+				"enabled":      true,
+				"max_attempts": 2,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep returned error after retry recovered: %v", err)
+	}
+	if got := runner.commandNames(); !reflect.DeepEqual(got, []string{"debug", "run", "retry", "test"}) {
+		t.Fatalf("commands = %#v, want debug/run/retry/test", got)
+	}
+	if runAttempts != 1 {
+		t.Fatalf("dbt run attempts = %d, want 1 plus dbt retry", runAttempts)
+	}
+	retryReq := runner.requests[2]
+	if retryReq.CommandName != "retry" || !reflect.DeepEqual(retryReq.Args[:1], []string{"retry"}) {
+		t.Fatalf("retry request = %+v", retryReq)
+	}
+	if targetPath := argValue(retryReq.Args, "--target-path"); targetPath != filepath.Join(executor.OutputDir(), "dbt", "target") {
+		t.Fatalf("retry target path = %q", targetPath)
+	}
+
+	result, ok := executor.State().Result("dbt_models")
+	if !ok {
+		t.Fatal("expected dbt result to be recorded")
+	}
+	if result.CommandsRun != 4 || result.Attempts != 4 || result.FailedAttempts != 1 || !result.Recovered {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(result.AttemptResults) != 4 {
+		t.Fatalf("attempt results = %+v", result.AttemptResults)
+	}
+	if got := result.AttemptResults[1]; got.CommandName != "run" || got.Status != "failed" || got.ExitCode != 2 {
+		t.Fatalf("failed attempt = %+v", got)
+	}
+	if got := result.AttemptResults[2]; got.CommandName != "retry" || got.Status != "ok" || got.RetryOf != "run" {
+		t.Fatalf("retry attempt = %+v", got)
+	}
+
+	dbtDir := filepath.Join(executor.OutputDir(), "dbt")
+	for _, path := range []string{
+		filepath.Join(dbtDir, "attempts", "run", "attempt_1", "run.stderr.log"),
+		filepath.Join(dbtDir, "attempts", "run", "attempt_2", "retry.stdout.log"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected attempt artifact %s: %v", path, err)
+		}
+	}
+}
+
 func writeDBTProject(t *testing.T) string {
 	t.Helper()
 	projectDir := t.TempDir()

--- a/tests/scenario/dbt/steps.go
+++ b/tests/scenario/dbt/steps.go
@@ -61,9 +61,13 @@ type State struct {
 }
 
 type StepResult struct {
-	StepID      string
-	OutputDir   string
-	CommandsRun int
+	StepID         string
+	OutputDir      string
+	CommandsRun    int
+	Attempts       int
+	FailedAttempts int
+	Recovered      bool
+	AttemptResults []core.StepAttemptResult
 }
 
 type stepSpec struct {
@@ -79,11 +83,17 @@ type stepSpec struct {
 	SSLMode        string
 	ConnectTimeout int
 	Commands       []commandSpec
+	Retry          retrySpec
 }
 
 type commandSpec struct {
 	Name string
 	Args []string
+}
+
+type retrySpec struct {
+	Enabled     bool
+	MaxAttempts int
 }
 
 type defaultCommandRunner struct{}
@@ -136,6 +146,19 @@ func (s *State) Result(stepID string) (StepResult, bool) {
 	return result, ok
 }
 
+func (e *Executor) StepResultMetadata(stepID string) (core.StepResultMetadata, bool) {
+	result, ok := e.state.Result(stepID)
+	if !ok {
+		return core.StepResultMetadata{}, false
+	}
+	return core.StepResultMetadata{
+		Attempts:       result.Attempts,
+		FailedAttempts: result.FailedAttempts,
+		Recovered:      result.Recovered,
+		AttemptDetails: result.AttemptResults,
+	}, true
+}
+
 func (e *Executor) ExecuteStep(ctx context.Context, step core.Step) error {
 	if step.Type != StepTypeDBTRun {
 		return classified(ErrorClassUnsupportedStep, fmt.Errorf("unsupported dbt step type %q", step.Type))
@@ -150,39 +173,69 @@ func (e *Executor) ExecuteStep(ctx context.Context, step core.Step) error {
 	}
 
 	commandsRun := 0
+	failedAttempts := 0
+	recovered := false
+	attemptResults := []core.StepAttemptResult{}
 	for _, command := range spec.Commands {
-		args := append([]string{}, command.Args...)
-		args = append(args,
-			"--project-dir", spec.ProjectDir,
-			"--profiles-dir", spec.ProfilesDir,
-			"--log-path", filepath.Join(dbtDir, "logs"),
-		)
-		if command.Name != "debug" {
-			args = append(args, "--target-path", filepath.Join(dbtDir, "target"))
-		}
-		req := CommandRequest{
-			Binary:      spec.DBTBinary,
-			CommandName: command.Name,
-			Args:        args,
-			Env:         e.commandEnv(spec),
-			Dir:         spec.ProjectDir,
-		}
-		result := e.commandRunner.Run(ctx, req)
+		result, attempt, err := e.runCommandAttempt(ctx, spec, dbtDir, command, "", 1)
 		commandsRun++
-		if err := writeCommandLogs(dbtDir, command.Name, result, spec.Password); err != nil {
+		attemptResults = append(attemptResults, attempt)
+		if err != nil {
 			return err
 		}
 		if result.Err != nil {
-			e.state.StoreResult(StepResult{StepID: step.ID, OutputDir: dbtDir, CommandsRun: commandsRun})
+			failedAttempts++
+			e.state.StoreResult(stepResult(step.ID, dbtDir, commandsRun, failedAttempts, recovered, attemptResults))
 			return classified(ErrorClassDBT, fmt.Errorf("dbt command %s failed: %w", command.Name, result.Err))
 		}
 		if result.ExitCode != 0 {
-			e.state.StoreResult(StepResult{StepID: step.ID, OutputDir: dbtDir, CommandsRun: commandsRun})
+			failedAttempts++
+			if spec.Retry.Enabled && spec.Retry.MaxAttempts > 1 && commandSupportsRetry(command.Name) {
+				var retryResult CommandResult
+				recoveredThisCommand := false
+				for attemptNumber := 2; attemptNumber <= spec.Retry.MaxAttempts; attemptNumber++ {
+					var retryAttempt core.StepAttemptResult
+					var err error
+					retryResult, retryAttempt, err = e.runCommandAttempt(ctx, spec, dbtDir, commandSpec{Name: "retry", Args: []string{"retry"}}, command.Name, attemptNumber)
+					commandsRun++
+					attemptResults = append(attemptResults, retryAttempt)
+					if err != nil {
+						return err
+					}
+					if retryResult.Err == nil && retryResult.ExitCode == 0 {
+						recoveredThisCommand = true
+						break
+					}
+					failedAttempts++
+				}
+				if recoveredThisCommand {
+					recovered = true
+					continue
+				}
+				e.state.StoreResult(stepResult(step.ID, dbtDir, commandsRun, failedAttempts, recovered, attemptResults))
+				if retryResult.Err != nil {
+					return classified(ErrorClassDBT, fmt.Errorf("dbt command %s failed with exit code %d; retry failed: %w", command.Name, result.ExitCode, retryResult.Err))
+				}
+				return classified(ErrorClassDBT, fmt.Errorf("dbt command %s failed with exit code %d; retry failed with exit code %d", command.Name, result.ExitCode, retryResult.ExitCode))
+			}
+			e.state.StoreResult(stepResult(step.ID, dbtDir, commandsRun, failedAttempts, recovered, attemptResults))
 			return classified(ErrorClassDBT, fmt.Errorf("dbt command %s failed with exit code %d", command.Name, result.ExitCode))
 		}
 	}
-	e.state.StoreResult(StepResult{StepID: step.ID, OutputDir: dbtDir, CommandsRun: commandsRun})
+	e.state.StoreResult(stepResult(step.ID, dbtDir, commandsRun, failedAttempts, recovered, attemptResults))
 	return nil
+}
+
+func stepResult(stepID, dbtDir string, commandsRun, failedAttempts int, recovered bool, attemptResults []core.StepAttemptResult) StepResult {
+	return StepResult{
+		StepID:         stepID,
+		OutputDir:      dbtDir,
+		CommandsRun:    commandsRun,
+		Attempts:       len(attemptResults),
+		FailedAttempts: failedAttempts,
+		Recovered:      recovered,
+		AttemptResults: append([]core.StepAttemptResult{}, attemptResults...),
+	}
 }
 
 func (e *Executor) parseStep(step core.Step) (stepSpec, error) {
@@ -218,6 +271,10 @@ func (e *Executor) parseStep(step core.Step) (stepSpec, error) {
 	if err != nil {
 		return stepSpec{}, err
 	}
+	retry, err := retryFromStep(step)
+	if err != nil {
+		return stepSpec{}, err
+	}
 	return stepSpec{
 		OrgID:          orgID,
 		Username:       username,
@@ -231,6 +288,56 @@ func (e *Executor) parseStep(step core.Step) (stepSpec, error) {
 		SSLMode:        stringFromWith(step, "sslmode", "require"),
 		ConnectTimeout: intFromWith(step, "connect_timeout", e.connection.ConnectTimeout),
 		Commands:       commands,
+		Retry:          retry,
+	}, nil
+}
+
+func (e *Executor) runCommandAttempt(ctx context.Context, spec stepSpec, dbtDir string, command commandSpec, retryOf string, attemptNumber int) (CommandResult, core.StepAttemptResult, error) {
+	args := append([]string{}, command.Args...)
+	args = append(args,
+		"--project-dir", spec.ProjectDir,
+		"--profiles-dir", spec.ProfilesDir,
+		"--log-path", filepath.Join(dbtDir, "logs"),
+	)
+	if command.Name != "debug" {
+		args = append(args, "--target-path", filepath.Join(dbtDir, "target"))
+	}
+	req := CommandRequest{
+		Binary:      spec.DBTBinary,
+		CommandName: command.Name,
+		Args:        args,
+		Env:         e.commandEnv(spec),
+		Dir:         spec.ProjectDir,
+	}
+	result := e.commandRunner.Run(ctx, req)
+	if err := writeCommandLogs(dbtDir, command.Name, result, spec.Password); err != nil {
+		return result, core.StepAttemptResult{}, err
+	}
+
+	status := "ok"
+	message := ""
+	if result.Err != nil {
+		status = "failed"
+		message = result.Err.Error()
+	} else if result.ExitCode != 0 {
+		status = "failed"
+		message = fmt.Sprintf("exit code %d", result.ExitCode)
+	}
+	attemptDir := filepath.Join(dbtDir, "attempts", attemptRoot(command.Name, retryOf), fmt.Sprintf("attempt_%d", attemptNumber))
+	if err := writeCommandLogs(attemptDir, command.Name, result, spec.Password); err != nil {
+		return result, core.StepAttemptResult{}, err
+	}
+	if err := snapshotDBTArtifacts(dbtDir, attemptDir); err != nil {
+		return result, core.StepAttemptResult{}, err
+	}
+	return result, core.StepAttemptResult{
+		Attempt:     attemptNumber,
+		CommandName: command.Name,
+		Status:      status,
+		ExitCode:    result.ExitCode,
+		Error:       message,
+		RetryOf:     retryOf,
+		OutputDir:   attemptDir,
 	}, nil
 }
 
@@ -284,6 +391,32 @@ func commandsFromStep(step core.Step) ([]commandSpec, error) {
 	return commands, nil
 }
 
+func retryFromStep(step core.Step) (retrySpec, error) {
+	raw, ok := step.With["retry"]
+	if !ok {
+		return retrySpec{MaxAttempts: 1}, nil
+	}
+	values, ok := raw.(map[string]any)
+	if !ok {
+		return retrySpec{}, classified(ErrorClassConfig, fmt.Errorf("step %s with.retry must be an object", step.ID))
+	}
+	enabled := boolFromMap(values, "enabled", false)
+	maxAttempts := intFromMap(values, "max_attempts", 2)
+	if enabled && maxAttempts < 2 {
+		return retrySpec{}, classified(ErrorClassConfig, fmt.Errorf("step %s with.retry.max_attempts must be at least 2 when retry is enabled", step.ID))
+	}
+	return retrySpec{Enabled: enabled, MaxAttempts: maxAttempts}, nil
+}
+
+func commandSupportsRetry(name string) bool {
+	switch name {
+	case "run", "test", "docs_generate":
+		return true
+	default:
+		return false
+	}
+}
+
 func parseCommandName(name string) (commandSpec, error) {
 	switch name {
 	case "debug":
@@ -300,6 +433,9 @@ func parseCommandName(name string) (commandSpec, error) {
 }
 
 func writeCommandLogs(dir, commandName string, result CommandResult, secret string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return classified(ErrorClassConfig, fmt.Errorf("create dbt log dir: %w", err))
+	}
 	for suffix, body := range map[string]string{
 		"stdout": result.Stdout,
 		"stderr": result.Stderr,
@@ -308,6 +444,64 @@ func writeCommandLogs(dir, commandName string, result CommandResult, secret stri
 		redacted := redactSecret(body, secret)
 		if err := os.WriteFile(path, []byte(redacted), 0o644); err != nil {
 			return classified(ErrorClassConfig, fmt.Errorf("write dbt %s log: %w", suffix, err))
+		}
+	}
+	return nil
+}
+
+func attemptRoot(commandName, retryOf string) string {
+	if retryOf != "" {
+		return retryOf
+	}
+	return commandName
+}
+
+func snapshotDBTArtifacts(dbtDir, attemptDir string) error {
+	for _, name := range []string{"target", "logs"} {
+		src := filepath.Join(dbtDir, name)
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return classified(ErrorClassConfig, fmt.Errorf("stat dbt artifact %s: %w", name, err))
+		}
+		if err := copyDir(src, filepath.Join(attemptDir, name)); err != nil {
+			return classified(ErrorClassConfig, fmt.Errorf("snapshot dbt artifact %s: %w", name, err))
+		}
+	}
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		body, err := os.ReadFile(srcPath)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dstPath, body, info.Mode().Perm()); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -374,6 +568,44 @@ func intFromWith(step core.Step, key string, fallback int) int {
 		return int(value)
 	case string:
 		parsed, err := strconv.Atoi(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func intFromMap(values map[string]any, key string, fallback int) int {
+	raw, ok := values[key]
+	if !ok {
+		return fallback
+	}
+	switch value := raw.(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case string:
+		parsed, err := strconv.Atoi(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func boolFromMap(values map[string]any, key string, fallback bool) bool {
+	raw, ok := values[key]
+	if !ok {
+		return fallback
+	}
+	switch value := raw.(type) {
+	case bool:
+		return value
+	case string:
+		parsed, err := strconv.ParseBool(value)
 		if err == nil {
 			return parsed
 		}

--- a/tests/scenario/runner_test.go
+++ b/tests/scenario/runner_test.go
@@ -392,9 +392,140 @@ func TestFrozenDBTScenarioUsesSupportedStepsAndRelativeProject(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(projectDir, "dbt_project.yml")); err != nil {
 			t.Fatalf("dbt project should exist at %q: %v", projectDir, err)
 		}
+		retry, ok := step.With["retry"].(map[string]any)
+		if !ok {
+			t.Fatal("frozen dbt scenario should enable dbt retry metadata")
+		}
+		if enabled, _ := retry["enabled"].(bool); !enabled {
+			t.Fatalf("frozen dbt retry enabled = %#v, want true", retry["enabled"])
+		}
+		if maxAttempts := fmt.Sprint(retry["max_attempts"]); maxAttempts != "2" {
+			t.Fatalf("frozen dbt retry max_attempts = %#v, want 2", retry["max_attempts"])
+		}
 	}
 	if !foundDBT {
 		t.Fatal("expected frozen dbt scenario to include a dbt_run step")
+	}
+}
+
+func TestFrozenDBTProjectModelsRealisticProductAnalyticsWorkload(t *testing.T) {
+	projectDir := filepath.Join("dbt", "posthog_frozen_project")
+	requiredModels := map[string][]string{
+		"models/staging/stg_events.sql": {
+			"event_timestamp",
+			"person_id",
+			"event_category",
+		},
+		"models/staging/stg_persons.sql": {
+			"person_created_at",
+			"person_day",
+		},
+		"models/intermediate/int_person_first_seen.sql": {
+			"first_event_timestamp",
+			"first_person_timestamp",
+			"first_seen_timestamp",
+		},
+		"models/intermediate/int_sessionized_events.sql": {
+			"lag(event_timestamp)",
+			"session_number",
+			"session_id",
+		},
+		"models/intermediate/int_event_days.sql": {
+			"event_day",
+			"events",
+			"pageview_events",
+		},
+		"models/intermediate/int_person_activity_daily.sql": {
+			"person_id",
+			"event_day",
+			"feature_events",
+		},
+		"models/intermediate/int_person_feature_usage_daily.sql": {
+			"person_id",
+			"feature_area",
+			"events",
+		},
+		"models/facts/fct_sessions.sql": {
+			"session_start",
+			"session_duration_seconds",
+			"pageview_events",
+		},
+		"models/facts/fct_user_activity_daily.sql": {
+			"int_person_activity_daily",
+			"active_persons",
+			"pageview_events",
+			"feature_events",
+		},
+		"models/facts/fct_activation_funnel.sql": {
+			"saw_pageview",
+			"used_feature",
+			"activated",
+		},
+		"models/facts/fct_retention_daily.sql": {
+			"cohort_day",
+			"days_since_first_seen",
+			"retained_persons",
+		},
+		"models/facts/fct_feature_usage_daily.sql": {
+			"int_person_feature_usage_daily",
+			"feature_area",
+			"users",
+			"events",
+		},
+		"models/marts/mart_product_kpis_daily.sql": {
+			"daily_active_users",
+			"activated_users",
+			"retained_users",
+		},
+	}
+
+	for modelPath, requiredSnippets := range requiredModels {
+		body, err := os.ReadFile(filepath.Join(projectDir, modelPath))
+		if err != nil {
+			t.Fatalf("expected realistic dbt model %s: %v", modelPath, err)
+		}
+		sql := strings.ToLower(string(body))
+		for _, snippet := range requiredSnippets {
+			if !strings.Contains(sql, strings.ToLower(snippet)) {
+				t.Fatalf("model %s missing realistic analytics snippet %q", modelPath, snippet)
+			}
+		}
+	}
+
+	schema, err := os.ReadFile(filepath.Join(projectDir, "models", "schema.yml"))
+	if err != nil {
+		t.Fatalf("read dbt schema.yml: %v", err)
+	}
+	for _, modelName := range []string{
+		"stg_events",
+		"stg_persons",
+		"int_person_first_seen",
+		"int_sessionized_events",
+		"int_event_days",
+		"int_person_activity_daily",
+		"int_person_feature_usage_daily",
+		"fct_sessions",
+		"fct_user_activity_daily",
+		"fct_activation_funnel",
+		"fct_retention_daily",
+		"fct_feature_usage_daily",
+		"mart_product_kpis_daily",
+	} {
+		if !strings.Contains(string(schema), "name: "+modelName) {
+			t.Fatalf("schema.yml should document and test model %s", modelName)
+		}
+	}
+
+	project, err := os.ReadFile(filepath.Join(projectDir, "dbt_project.yml"))
+	if err != nil {
+		t.Fatalf("read dbt_project.yml: %v", err)
+	}
+	projectYAML := string(project)
+	if !strings.Contains(projectYAML, "staging:\n      +materialized: table") {
+		t.Fatal("frozen dbt staging models should be materialized as tables so downstream facts do not repeatedly scan raw parquet")
+	}
+	if !strings.Contains(projectYAML, "intermediate:\n      +materialized: table") {
+		t.Fatal("frozen dbt intermediate models should be materialized as tables to reuse reduced-grain aggregates")
 	}
 }
 
@@ -439,6 +570,13 @@ func (e dispatchExecutor) ExecuteStep(ctx context.Context, step core.Step) error
 	default:
 		return fmt.Errorf("unsupported scenario step type %q", step.Type)
 	}
+}
+
+func (e dispatchExecutor) StepResultMetadata(stepID string) (core.StepResultMetadata, bool) {
+	if e.dbt == nil {
+		return core.StepResultMetadata{}, false
+	}
+	return e.dbt.StepResultMetadata(stepID)
 }
 
 func dispatchSupports(stepType string) bool {

--- a/tests/scenario/scenarios/posthog_frozen_dbt.yaml
+++ b/tests/scenario/scenarios/posthog_frozen_dbt.yaml
@@ -41,6 +41,9 @@ steps:
       schema: dbt_frozen
       project_dir: ../dbt/posthog_frozen_project
       commands: [debug, run, test, docs_generate]
+      retry:
+        enabled: true
+        max_attempts: 2
 
   - id: deprovision
     type: deprovision_warehouse


### PR DESCRIPTION
## Summary
- add dbt retry attempt reporting to the scenario runner, including recovered/failed attempt counts and per-attempt artifacts
- make the frozen dbt scenario model a realistic product analytics workload over events/persons
- enable dbt retry for the frozen dbt scenario and document retry behavior

## Verification
- go test ./tests/scenario/core ./tests/scenario/dbt ./tests/scenario
- just test-scenario
- just lint
- git diff --check

## Manual scenario run
- posthog-frozen-dbt passed against dev
- scenario steps: 5/5 passed
- dbt run: 13/13 models passed
- dbt test: 56/56 tests passed
- dbt docs generate: passed
- total runtime: about 2h38m
- retry was configured but not exercised because all dbt commands passed on the first attempt