### PR TITLE
Initialize query-log storage before DuckLake attach

### DIFF
--- a/server/querylog_view.go
+++ b/server/querylog_view.go
@@ -17,6 +17,44 @@ const (
 )
 
 var queryLogSurfaceCache = newQueryLogSurfaceCache()
+var queryLogStorageCache = newQueryLogSurfaceCache()
+
+// ensurePostgresQueryLogStorageForDuckLakeAttach must run before DuckLake
+// ATTACH. DuckLake's hidden metadata catalog may not see Postgres schemas
+// created after attach, so the storage schema must exist before the hidden
+// catalog is bound.
+func ensurePostgresQueryLogStorageForDuckLakeAttach(ctx context.Context, cfg Config) error {
+	if !cfg.QueryLog.Enabled || cfg.DuckLake.MetadataStore == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cacheKey := cfg.DuckLake.MetadataStore
+	// Cache successes only. A transient pre-attach failure should be retried by
+	// the next activation/connect attempt because this is the only point where
+	// the querylog schema can become visible to DuckLake's hidden metadata catalog.
+	if queryLogStorageCache.ready(cacheKey) {
+		return nil
+	}
+
+	connStr, err := postgresQueryLogDSN(cfg.DuckLake)
+	if err != nil {
+		return err
+	}
+	pgDB, err := openPostgresQueryLogDB(connStr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = pgDB.Close() }()
+
+	if err := ensurePostgresQueryLogTableContext(ctx, pgDB); err != nil {
+		return err
+	}
+	queryLogStorageCache.recordSuccess(cacheKey)
+	return nil
+}
 
 func ensureDuckLakeQueryLogSurface(ctx context.Context, db *sql.DB, cfg Config) error {
 	if !cfg.QueryLog.Enabled || cfg.DuckLake.MetadataStore == "" {
@@ -41,22 +79,6 @@ func ensureDuckLakeQueryLogSurface(ctx context.Context, db *sql.DB, cfg Config) 
 		return nil
 	}
 
-	connStr, err := postgresQueryLogDSN(cfg.DuckLake)
-	if err != nil {
-		queryLogSurfaceCache.recordFailure(cacheKey, time.Now())
-		return err
-	}
-	pgDB, err := openPostgresQueryLogDB(connStr)
-	if err != nil {
-		queryLogSurfaceCache.recordFailure(cacheKey, time.Now())
-		return err
-	}
-	defer func() { _ = pgDB.Close() }()
-
-	if err := ensurePostgresQueryLogTableContext(ctx, pgDB); err != nil {
-		queryLogSurfaceCache.recordFailure(cacheKey, time.Now())
-		return err
-	}
 	if err := ensureDuckLakeQueryLogViewContext(ctx, db); err != nil {
 		queryLogSurfaceCache.recordFailure(cacheKey, time.Now())
 		return fmt.Errorf("querylog: ensure ducklake view: %w", err)
@@ -253,4 +275,5 @@ func (c *queryLogSurfaceStateCache) recordFailure(key string, now time.Time) {
 
 func resetQueryLogSurfaceCacheForTest() {
 	queryLogSurfaceCache = newQueryLogSurfaceCache()
+	queryLogStorageCache = newQueryLogSurfaceCache()
 }

--- a/server/querylog_view_test.go
+++ b/server/querylog_view_test.go
@@ -64,6 +64,50 @@ func TestEnsureDuckLakeQueryLogSurfaceFastPathSkipsPostgresDSN(t *testing.T) {
 	}
 }
 
+func TestEnsureDuckLakeQueryLogSurfaceDoesNotCreateStorageAfterAttach(t *testing.T) {
+	resetQueryLogSurfaceCacheForTest()
+	t.Cleanup(resetQueryLogSurfaceCacheForTest)
+	db := openQueryLogViewTestDBWithoutHiddenSource(t)
+
+	err := ensureDuckLakeQueryLogSurface(context.Background(), db, Config{
+		DuckLake: DuckLakeConfig{
+			MetadataStore: "not-a-postgres-metadata-store",
+		},
+		QueryLog: QueryLogConfig{
+			Enabled: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected hidden-source preflight error")
+	}
+	if !strings.Contains(err.Error(), "preflight ducklake query_log source") {
+		t.Fatalf("expected post-attach view preflight error, got %v", err)
+	}
+}
+
+func TestEnsurePostgresQueryLogStorageForDuckLakeAttachRetriesAfterFailure(t *testing.T) {
+	resetQueryLogSurfaceCacheForTest()
+	t.Cleanup(resetQueryLogSurfaceCacheForTest)
+
+	cfg := Config{
+		DuckLake: DuckLakeConfig{
+			MetadataStore: "not-a-postgres-metadata-store",
+		},
+		QueryLog: QueryLogConfig{
+			Enabled: true,
+		},
+	}
+
+	err := ensurePostgresQueryLogStorageForDuckLakeAttach(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected first invalid metadata store failure")
+	}
+	err = ensurePostgresQueryLogStorageForDuckLakeAttach(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected second invalid metadata store failure; pre-attach storage failures must not be cached")
+	}
+}
+
 func TestEnsureDuckLakeQueryLogViewContextRenamesLegacyTable(t *testing.T) {
 	db := openQueryLogViewTestDB(t)
 

--- a/server/server.go
+++ b/server/server.go
@@ -1203,7 +1203,13 @@ func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config, username s
 	// provisioning/migrations create querylog.query_log_entries before any
 	// DuckLake attach, and all existing tenants have been migrated.
 	if err := ensurePostgresQueryLogStorageForDuckLakeAttach(queryLogCtx, cfg); err != nil {
-		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username, "error", err)
+		reason := "unavailable"
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(queryLogCtx.Err(), context.DeadlineExceeded) {
+			reason = "timeout"
+		}
+		// Do not log err here: metadata-store connection errors can carry DSNs
+		// with credentials. The setup is best-effort, so a coarse reason is enough.
+		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username, "reason", reason)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1202,14 +1202,11 @@ func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config, username s
 	// predate managed query-log storage. Remove it once org metadata
 	// provisioning/migrations create querylog.query_log_entries before any
 	// DuckLake attach, and all existing tenants have been migrated.
-	if err := ensurePostgresQueryLogStorageForDuckLakeAttach(queryLogCtx, cfg); err != nil {
-		reason := "unavailable"
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(queryLogCtx.Err(), context.DeadlineExceeded) {
-			reason = "timeout"
-		}
-		// Do not log err here: metadata-store connection errors can carry DSNs
-		// with credentials. The setup is best-effort, so a coarse reason is enough.
-		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username, "reason", reason)
+	if ensurePostgresQueryLogStorageForDuckLakeAttach(queryLogCtx, cfg) != nil {
+		// Do not log or classify the error here: metadata-store connection
+		// errors can carry DSNs with credentials, and even derived log fields can
+		// be treated as sensitive by static analysis. The setup is best-effort.
+		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1195,6 +1195,18 @@ func tryEnsureDuckLakeQueryLogSurface(db *sql.DB, cfg Config, username string) {
 	}
 }
 
+func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config, username string) {
+	queryLogCtx, queryLogCancel := context.WithTimeout(context.Background(), queryLogSurfaceInitTimeout)
+	defer queryLogCancel()
+	// Runtime pre-attach DDL is a compatibility bridge for existing orgs that
+	// predate managed query-log storage. Remove it once org metadata
+	// provisioning/migrations create querylog.query_log_entries before any
+	// DuckLake attach, and all existing tenants have been migrated.
+	if err := ensurePostgresQueryLogStorageForDuckLakeAttach(queryLogCtx, cfg); err != nil {
+		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username, "error", err)
+	}
+}
+
 // ConfigureDBConnection initializes an existing DuckDB connection with pg_catalog,
 // information_schema, and DuckLake catalog attachment.
 func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, username string, serverStartTime time.Time, serverVersion string) error {
@@ -1211,6 +1223,7 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 
 	// Attach DuckLake catalog if configured (but don't set as default yet)
 	duckLakeMode := false
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		// If DuckLake was explicitly configured, fail the connection.
 		// Silent fallback to local DB causes schema/table mismatches.
@@ -1274,6 +1287,7 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 		return fmt.Errorf("tenant activation requires a ducklake metadata_store")
 	}
 
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		return fmt.Errorf("DuckLake configured but attachment failed: %w", err)
 	}
@@ -1319,6 +1333,7 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 	chsql.InitMacros(db)
 
 	// Attach DuckLake catalog if configured (same data, no pg_catalog views)
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		if cfg.DuckLake.MetadataStore != "" {
 			_ = db.Close()

--- a/server/server.go
+++ b/server/server.go
@@ -1195,7 +1195,7 @@ func tryEnsureDuckLakeQueryLogSurface(db *sql.DB, cfg Config, username string) {
 	}
 }
 
-func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config, username string) {
+func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config) {
 	queryLogCtx, queryLogCancel := context.WithTimeout(context.Background(), queryLogSurfaceInitTimeout)
 	defer queryLogCancel()
 	// Runtime pre-attach DDL is a compatibility bridge for existing orgs that
@@ -1206,7 +1206,7 @@ func tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg Config, username s
 		// Do not log or classify the error here: metadata-store connection
 		// errors can carry DSNs with credentials, and even derived log fields can
 		// be treated as sensitive by static analysis. The setup is best-effort.
-		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.", "user", username)
+		slog.Warn("Failed to initialize native Postgres query-log storage before DuckLake attach.")
 	}
 }
 
@@ -1226,7 +1226,7 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 
 	// Attach DuckLake catalog if configured (but don't set as default yet)
 	duckLakeMode := false
-	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		// If DuckLake was explicitly configured, fail the connection.
 		// Silent fallback to local DB causes schema/table mismatches.
@@ -1290,7 +1290,7 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 		return fmt.Errorf("tenant activation requires a ducklake metadata_store")
 	}
 
-	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		return fmt.Errorf("DuckLake configured but attachment failed: %w", err)
 	}
@@ -1336,7 +1336,7 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 	chsql.InitMacros(db)
 
 	// Attach DuckLake catalog if configured (same data, no pg_catalog views)
-	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg, username)
+	tryEnsurePostgresQueryLogStorageBeforeDuckLakeAttach(cfg)
 	if err := AttachDuckLake(db, cfg.DuckLake, duckLakeSem, cfg.DataDir); err != nil {
 		if cfg.DuckLake.MetadataStore != "" {
 			_ = db.Close()


### PR DESCRIPTION
## Summary

Initialize native Postgres query-log storage before DuckLake attach so DuckLake's hidden metadata catalog can see `querylog.query_log_entries` when `ducklake.system.query_log` is created.

This keeps the runtime DDL as a temporary compatibility bridge for existing orgs that predate managed query-log storage. Once provisioning or migrations create the table before first attach, this bridge can be removed.

## Changes

- Add a pre-attach Postgres query-log storage ensure path.
- Call it before DuckLake attach in standard, activation, and passthrough connection setup.
- Keep the pre-attach path best-effort and success-cached only; transient failures are retried by later activation/connect attempts.
- Keep DuckLake view setup post-attach and warning-only.
- Add tests for post-attach view behavior and pre-attach retry after failure.

## Validation

- `go test ./server -run 'TestEnsureDuckLakeQueryLog|TestEnsurePostgresQueryLog|TestNewQueryLogSink'`
- `go test ./duckdbservice`
