### PR TITLE
fix(billing): storage sampler over-bills on leadership churn; gzip usage responses

### DIFF
--- a/controlplane/compute_billing_api.go
+++ b/controlplane/compute_billing_api.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	gingzip "github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -34,7 +35,11 @@ type billingAPIHandler struct {
 // authenticates with the internal secret, which resolves to admin).
 func registerBillingAPI(r gin.IRouter, store billingUsageStore, requireAdmin gin.HandlerFunc) {
 	h := &billingAPIHandler{store: store, now: time.Now}
-	r.GET("/billing/usage", requireAdmin, h.getUsage)
+	// gzip on the usage read: rows scale with total adoption (one per
+	// storage-holding org per day, several per compute-active org) and the
+	// repetitive JSON compresses well. Negotiated per request — clients that
+	// don't send Accept-Encoding: gzip get plain JSON.
+	r.GET("/billing/usage", requireAdmin, gingzip.Gzip(gingzip.DefaultCompression), h.getUsage)
 	r.POST("/billing/ack", requireAdmin, h.postAck)
 }
 

--- a/controlplane/compute_billing_api_test.go
+++ b/controlplane/compute_billing_api_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -323,5 +324,65 @@ func TestComputeUsageGCRunsAndStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("gc loop did not stop on cancel")
+	}
+}
+
+func newRegisteredBillingRouter(store *fakeBillingStore) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	allow := func(c *gin.Context) { c.Next() }
+	registerBillingAPI(r.Group("/api/v1"), store, allow)
+	return r
+}
+
+func TestBillingUsageGzipsWhenAccepted(t *testing.T) {
+	// Usage responses scale with total adoption (one row per storage-holding
+	// org per day) and the JSON compresses well — serve gzip to any client that
+	// accepts it. Not optional: the billing poller always accepts.
+	router := newRegisteredBillingRouter(&fakeBillingStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/billing/usage", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	gz, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(gz).Decode(&body); err != nil {
+		t.Fatalf("decode gzipped body: %v", err)
+	}
+	for _, key := range []string{"watermark_low", "watermark_high", "usage", "storage"} {
+		if _, ok := body[key]; !ok {
+			t.Fatalf("gzipped body missing %q", key)
+		}
+	}
+}
+
+func TestBillingUsagePlainWhenGzipNotAccepted(t *testing.T) {
+	router := newRegisteredBillingRouter(&fakeBillingStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/billing/usage", nil)
+	req.Header.Del("Accept-Encoding")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got == "gzip" {
+		t.Fatal("plain client got gzip")
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
 	}
 }

--- a/controlplane/storage_meter.go
+++ b/controlplane/storage_meter.go
@@ -100,11 +100,17 @@ func newStorageSampler(store storageUsageStore, interval time.Duration, listOrgs
 // Run samples every interval until ctx is cancelled. Leader-only: the caller
 // attaches it under the janitor leader lease so exactly one CP pod credits
 // each interval (a double writer would double-bill — the UPSERT is additive).
+//
+// Deliberately NO sample on entry: Run re-enters on every leadership
+// acquisition, and each successful sample credits a full interval regardless
+// of elapsed time — sampling immediately would credit an extra interval per
+// leader change (deploys, lease flaps), i.e. systematic over-billing. Waiting
+// one full interval for the first tick keeps failover in the documented
+// direction: a leadership change under-bills at most one interval.
 func (s *storageSampler) Run(ctx context.Context) {
 	if s == nil || s.store == nil || s.listOrgs == nil || s.resolveDSN == nil {
 		return
 	}
-	s.sampleAll(ctx)
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {

--- a/controlplane/storage_meter_test.go
+++ b/controlplane/storage_meter_test.go
@@ -101,28 +101,19 @@ func TestStorageSamplerStoreErrorIsBestEffort(t *testing.T) {
 
 func TestStorageSamplerRunStopsOnCancel(t *testing.T) {
 	store := &fakeStorageStore{}
-	s := newTestStorageSampler(store,
-		[]storageOrg{{OrgID: "orgA", TeamID: 42}},
-		func(_ context.Context, _ string) (int64, int64, error) { return 2048, 0, nil })
+	// Short interval: the first pass fires after one tick (never on entry —
+	// see TestStorageSamplerLeadershipChurnNeverOverCredits).
+	s := newStorageSampler(store, 20*time.Millisecond,
+		func() []storageOrg { return []storageOrg{{OrgID: "orgA", TeamID: 42}} },
+		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
+	)
+	s.queryFootprint = func(_ context.Context, _ string) (int64, int64, error) { return 2048, 0, nil }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { s.Run(ctx); close(done) }()
-	// The first pass runs immediately.
-	deadline := time.After(2 * time.Second)
-	for {
-		store.mu.Lock()
-		n := len(store.samples)
-		store.mu.Unlock()
-		if n >= 1 {
-			break
-		}
-		select {
-		case <-deadline:
-			t.Fatal("first sample pass never ran")
-		default:
-			time.Sleep(5 * time.Millisecond)
-		}
+	if got := waitForSamples(store, 1, 2*time.Second); got < 1 {
+		t.Fatal("ticker sample pass never ran")
 	}
 	cancel()
 	select {
@@ -144,5 +135,64 @@ func TestStorageSampleIntervalFromEnv(t *testing.T) {
 	t.Setenv("DUCKGRES_STORAGE_SAMPLE_INTERVAL", "banana")
 	if got := storageSampleIntervalFromEnv(); got != defaultStorageSampleInterval {
 		t.Fatalf("invalid = %v, want default", got)
+	}
+}
+
+// waitForSamples polls until the store holds at least n samples or the
+// deadline passes; returns the count seen last.
+func waitForSamples(store *fakeStorageStore, n int, deadline time.Duration) int {
+	stop := time.After(deadline)
+	for {
+		store.mu.Lock()
+		got := len(store.samples)
+		store.mu.Unlock()
+		if got >= n {
+			return got
+		}
+		select {
+		case <-stop:
+			return got
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestStorageSamplerLeadershipChurnNeverOverCredits(t *testing.T) {
+	// Every leadership acquisition re-enters Run (leader_loop.go). Each
+	// successful sample credits a FULL interval of byte-seconds regardless of
+	// elapsed wall time, so sampling on acquisition over-bills: leader A
+	// samples, loses the lease seconds later (deploy, lease flap), leader B
+	// samples again -> two full intervals credited for seconds of real time.
+	// The documented contract is the opposite direction ("a missed sample
+	// (org unreachable, leader failover) under-bills one interval").
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "orgA", TeamID: 42}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 1024, 0, nil })
+
+	churns := 2
+	for i := 0; i < churns; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() { s.Run(ctx); close(done) }()
+		// Give an eager implementation ample time to (wrongly) sample; the
+		// 30-minute ticker cannot fire in this window either way.
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("sampler did not stop on cancel")
+		}
+	}
+
+	store.mu.Lock()
+	credited := len(store.samples)
+	store.mu.Unlock()
+	// Seconds of wall time may never credit more than one interval, however
+	// many times leadership changes hands.
+	if credited > 1 {
+		t.Fatalf("leadership churn credited %d full intervals for ~0.3s of wall time (over-billing); want <= 1", credited)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cloudflare/tableflip v1.2.3
 	github.com/duckdb/duckdb-go-bindings v0.10503.0
 	github.com/duckdb/duckdb-go/v2 v2.10503.0
+	github.com/gin-contrib/gzip v1.2.6
 	github.com/gin-gonic/gin v1.12.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
 github.com/gabriel-vasile/mimetype v1.4.12/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gin-contrib/gzip v1.2.6 h1:OtN8DplD5DNZCSLAnQ5HxRkD2qZ5VU+JhOrcfJrcRvg=
+github.com/gin-contrib/gzip v1.2.6/go.mod h1:BQy8/+JApnRjAVUplSGZiVtD2k8GmIE2e9rYu/hLzzU=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=


### PR DESCRIPTION
Two fixes to the billing pull pipeline, found while building the PostHog-side consumer.

**1. Storage sampler over-bills on leadership churn.** `Run` samples on entry, and every sample credits a full interval regardless of elapsed time — so each leadership acquisition (deploy, lease flap) mints an extra interval for *every* org. At one deploy/day that's ~2% over-billing fleet-wide, and it's the opposite direction from the documented contract ("a missed sample (org unreachable, leader failover) under-bills one interval").

Fix: no sample on entry, so the first credit lands one full tick into tenure. Churn now under-bills ≤1 interval, matching the doc. Worth naming explicitly: after a CP restart, storage isn't credited for the first interval.

`TestStorageSamplerLeadershipChurnNeverOverCredits` fails on main (2 intervals credited for ~0.3s of wall time) and passes with the fix. `TestStorageSamplerRunStopsOnCancel` is updated because it asserted the entry sample.

**2. gzip on `GET /billing/usage`.** Usage rows scale with total adoption (one per storage-holding org per day), and the repetitive JSON compresses well. Negotiated per request; clients that don't accept gzip are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hSheSykRTkTsD9rz1pvfv