### PR TITLE
Allow out-of-order configstore migration recovery

### DIFF
--- a/controlplane/configstore/migrations.go
+++ b/controlplane/configstore/migrations.go
@@ -38,6 +38,10 @@ func runConfigStoreMigrations(db *gorm.DB) error {
 		migrationFS,
 		goose.WithSessionLocker(locker),
 		goose.WithSlog(slog.Default()),
+		// Compatibility bridge for the 000018/000019 ordering bug shipped on
+		// 2026-07-08. Remove this once every environment has recorded 000018 so
+		// future out-of-order configstore migrations fail at startup again.
+		goose.WithAllowOutofOrder(true),
 	)
 	if err != nil {
 		return fmt.Errorf("configstore migration provider: %w", err)


### PR DESCRIPTION
## Summary
- allow Goose to apply missing out-of-order configstore migrations during startup

## Notes
This is a compatibility bridge for the 000018/000019 ordering bug shipped on 2026-07-08. Once every environment has recorded 000018, we should remove `goose.WithAllowOutofOrder(true)` so future out-of-order configstore migrations fail again.

## Tests
Not run after narrowing the PR to the runtime hotfix only.
