### PR TITLE
Remove temporary configstore out-of-order migration bridge

### DIFF
--- a/controlplane/configstore/migrations.go
+++ b/controlplane/configstore/migrations.go
@@ -38,10 +38,6 @@ func runConfigStoreMigrations(db *gorm.DB) error {
 		migrationFS,
 		goose.WithSessionLocker(locker),
 		goose.WithSlog(slog.Default()),
-		// Compatibility bridge for the 000018/000019 ordering bug shipped on
-		// 2026-07-08. Remove this once every environment has recorded 000018 so
-		// future out-of-order configstore migrations fail at startup again.
-		goose.WithAllowOutofOrder(true),
 	)
 	if err != nil {
 		return fmt.Errorf("configstore migration provider: %w", err)


### PR DESCRIPTION
## Summary
- remove the temporary Goose out-of-order migration bridge added in #919

## Merge gate
Do not merge until #919 has run in the target environment and `goose_db_version` records migration `18`.

## Tests
Not run. This is the prepared revert for #919's temporary recovery bridge.
