### PR TITLE
Fix reshard source-DB drop using empty database name

### DIFF
--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -570,6 +570,12 @@ func (o *opRun) recordSource(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	// Mirror the persisted fields onto the in-memory op so every later reader
+	// (cleanup logging, the report, the ext→cnpg rollback) sees them too. For
+	// cnpg sources the admin handler leaves these empty at create time.
+	o.op.SourceEndpoint = ms.Endpoint
+	o.op.SourceUser = ms.User
+	o.op.SourceDatabase = ms.Database
 	o.logf("info", "recorded source metadata store: %s", o.source.Redacted())
 	return nil
 }
@@ -778,8 +784,15 @@ func (o *opRun) cleanupSource(ctx context.Context) error {
 		o.logf("info", "external source left untouched (never deleted)")
 		return nil
 	}
-	o.logf("info", "dropping source database %s on %s (WITH FORCE)", o.op.SourceDatabase, o.op.FromShard)
-	if err := o.r.copier.DropDatabase(ctx, o.source, o.op.SourceDatabase); err != nil {
+	// o.source is the copy-path source of truth (recorded from the duckling
+	// status pre-flip); o.op.SourceDatabase mirrors it since recordSource.
+	// Never issue a zero-length identifier: skip loudly instead.
+	if o.source.Database == "" {
+		o.logf("error", "source database name is empty (recordSource did not run?) — skipping DROP DATABASE; the old catalog database on %s must be dropped manually", o.op.FromShard)
+		return nil
+	}
+	o.logf("info", "dropping source database %s on %s (WITH FORCE)", o.source.Database, o.op.FromShard)
+	if err := o.r.copier.DropDatabase(ctx, o.source, o.source.Database); err != nil {
 		// Loud but non-fatal: the copy is verified and live; a leftover
 		// source DB is cruft plus a weaker fence, not data loss.
 		o.logf("error", "DROP DATABASE on the source failed — old catalog database still exists on %s and must be dropped manually: %v", o.op.FromShard, err)

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -416,6 +416,20 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 			t.Fatalf("copy read from %q, want the recorded shard-001 source", call.source.Host)
 		}
 	}
+	// Regression (#observed in prod): the source drop must name the database
+	// recorded from the duckling status. The op row's SourceDatabase is unset
+	// for cnpg sources (the admin handler only fills it for external), so a
+	// runner reading only op.SourceDatabase issued `DROP DATABASE ""`.
+	for _, call := range copier.calls {
+		if call.kind == "dropdb" {
+			if call.dbName != "mdstore_org" {
+				t.Fatalf("dropdb database = %q, want %q (the recorded source database)", call.dbName, "mdstore_org")
+			}
+			if !strings.HasPrefix(call.target.Host, "shard-001-pooler") {
+				t.Fatalf("dropdb ran against %q, want the recorded shard-001 source", call.target.Host)
+			}
+		}
+	}
 	// Compaction paused (false) then restored to explicit true.
 	dkinds := duckling.callKinds()
 	if fmt.Sprint(dkinds) != fmt.Sprint([]string{"compaction", "cnpg", "compaction"}) {


### PR DESCRIPTION
## Bug (observed on a real cnpg→cnpg reshard)

The cleanup step of an otherwise-successful cnpg→cnpg reshard failed like this (note the double space — the database name is empty):

```
dropping source database  on shard-A (WITH FORCE)
DROP DATABASE on the source failed — old catalog database still exists on shard-A and must be dropped manually: drop database : ERROR: zero-length delimited identifier at or near """" (SQLSTATE 42601)
```

The copy and cutover were fine (cleanup is deliberately non-fatal but loud), but the old catalog database was left orphaned on the source shard.

## Root cause

- The admin handler fills `op.SourceEndpoint/SourceUser/SourceDatabase` at create time **only for external sources** (`controlplane/admin/reshard.go`); for a cnpg source they stay `""`.
- `recordSource` (runner) reads the real source info from the duckling CR status and persists it to the op **row** via `o.fields(...)` — but never updated the in-memory `o.op`.
- `cleanupSource` passed `o.op.SourceDatabase` (still `""`) to `DropDatabase` → `DROP DATABASE ""` → SQLSTATE 42601. The `o.source` endpoint struct built in `recordSource` carried the correct database all along (the copy used it successfully).

## Fix

- `recordSource` now mirrors the persisted `source_endpoint`/`source_user`/`source_database` onto the in-memory `o.op`, keeping every later reader (cleanup logging, the end-of-op report, the ext→cnpg rollback spec) consistent.
- `cleanupSource` drops `o.source.Database` — the copy-path source of truth — and, belt-and-suspenders, logs an ERROR and skips the drop if the name is ever empty instead of issuing a zero-length identifier.

## Test

Regression assertion in `TestReshardHappyPathCnpgToCnpg` (`controlplane/provisioner/reshard_runner_test.go`): the fake copier's `dropdb` call must name the database recorded from the duckling status. The test op's `SourceDatabase` is unset exactly like production, so pre-fix it fails with:

```
dropdb database = "", want "mdstore_org" (the recorded source database)
```

and passes after the fix. `go build -tags kubernetes ./...` and `go test -tags kubernetes ./controlplane/provisioner ./controlplane/admin -run TestReshard -count=1` are green.

Note on e2e: per the resharding contract in `CLAUDE.md`, the cnpg→cnpg positive path (the only path that reaches `cleanupSource`) is unit-only until the second mw-dev shard lands, so the regression lives in the runner unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)