### PR TITLE
Reshard copy: skip catalogued NOT NULL constraints (PG 18 sources)

### DIFF
--- a/controlplane/provisioner/catalog_copy.go
+++ b/controlplane/provisioner/catalog_copy.go
@@ -391,6 +391,11 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 
 // applyConstraints replays the source table's constraints (PK, unique, check,
 // FK) via pg_get_constraintdef, sorted so PKs/uniques come before FKs.
+// NOT NULL constraints (contype 'n' — catalogued rows on PG 18+ sources) are
+// skipped: the CREATE TABLE already carried NOT NULL from pg_attribute, and
+// their constraintdef renders as "NOT NULL <col>", whose ADD CONSTRAINT form
+// only parses on PG 18+ — an older target (external RDS) rejects it with a
+// syntax error at "NOT".
 func applyConstraints(ctx context.Context, srcTx pgx.Tx, dst *pgx.Conn, table string) error {
 	// contype is the internal "char" type (OID 18), which pgx cannot scan in
 	// binary format into a string — cast it.
@@ -421,6 +426,9 @@ ORDER BY conname`, table)
 	// Foreign keys last (they may reference other tables' PKs).
 	sort.SliceStable(cons, func(i, j int) bool { return cons[i].typ != "f" && cons[j].typ == "f" })
 	for _, c := range cons {
+		if !shouldReplayConstraint(c.typ) {
+			continue
+		}
 		stmt := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s %s", quoteIdent(table), quoteIdent(c.name), c.def)
 		if _, err := dst.Exec(ctx, stmt); err != nil {
 			return fmt.Errorf("apply constraint %s on %s: %w", c.name, table, err)
@@ -457,4 +465,12 @@ ORDER BY i.indexname`, table)
 
 func quoteIdent(s string) string {
 	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// shouldReplayConstraint reports whether a pg_constraint row of the given
+// contype is replayed on the target. 'n' (catalogued NOT NULL, PG 18+) is
+// redundant with the column-level NOT NULL the CREATE TABLE already applied
+// and its ADD CONSTRAINT syntax doesn't parse on older targets.
+func shouldReplayConstraint(contype string) bool {
+	return contype != "n"
 }

--- a/controlplane/provisioner/catalog_copy_test.go
+++ b/controlplane/provisioner/catalog_copy_test.go
@@ -1,0 +1,22 @@
+//go:build kubernetes
+
+package provisioner
+
+import "testing"
+
+// TestShouldReplayConstraint pins the PG-18 NOT NULL skip: catalogued
+// not-null constraints (contype 'n') must never be replayed — the CREATE
+// TABLE already carries column-level NOT NULL, and the ADD CONSTRAINT form
+// is PG-18-only syntax that an older external-RDS target rejects
+// ("syntax error at or near \"NOT\"", observed in a real cnpg→ext reshard).
+func TestShouldReplayConstraint(t *testing.T) {
+	replayed := map[string]bool{
+		"p": true, "u": true, "f": true, "c": true, "x": true,
+		"n": false,
+	}
+	for contype, want := range replayed {
+		if got := shouldReplayConstraint(contype); got != want {
+			t.Errorf("shouldReplayConstraint(%q) = %t, want %t", contype, got, want)
+		}
+	}
+}


### PR DESCRIPTION
A real cnpg→external reshard on mw-dev failed at the constraint replay:

```
apply constraint ducklake_data_file_data_file_id_not_null on ducklake_data_file: ERROR: syntax error at or near "NOT" (SQLSTATE 42601)
```

(The rollback worked as designed — org back on the shard, unblocked.)

**Cause:** the cnpg shards run PG 18, which catalogues NOT NULL as `pg_constraint` rows (`contype 'n'`, new in 18). `pg_get_constraintdef` renders them as `NOT NULL <col>`, and the `ALTER TABLE … ADD CONSTRAINT … NOT NULL <col>` form only parses on PG 18+ — the older external-RDS target rejects it. They're also fully redundant: the copier's `CREATE TABLE` already applies column-level `NOT NULL` from `pg_attribute.attnotnull`.

**Fix:** skip `contype 'n'` in the replay (`shouldReplayConstraint`), with a unit test pinning the replayed set (p/u/f/c/x yes, n no).

**Why e2e missed it:** the ext→cnpg positive path copies **from** an older-PG RDS (no 'n' rows exist there); the PG-18-source direction (cnpg→ext) is unit-only per the resharding contract — the harness has no RDS password, which the start API requires ephemerally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)