### PR TITLE
test: add full suite scenario DAG

### DIFF
--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -4,7 +4,7 @@
 
 The scenario runner executes end-to-end managed-warehouse flows against a configured dev environment. The first smoke scenario provisions a warehouse, waits for readiness, runs `SELECT 1` over PGWire with managed-hostname SNI, then deprovisions and verifies cleanup.
 
-The frozen metadata, perf, and dbt scenarios provision the same fresh dev warehouse shape, create read-only views over frozen persons/events parquet supplied by `DUCKGRES_SCENARIO_FROZEN_S3_URI`, run their workload, then deprovision.
+The default full workload uses one `full-suite.yaml` scenario: it provisions a fresh dev warehouse, creates read-only views over frozen persons/events parquet supplied by `DUCKGRES_SCENARIO_FROZEN_S3_URI`, runs metadata exploration, perf queries, and dbt models, then deprovisions. The standalone frozen metadata, perf, and dbt scenarios remain available for focused debugging.
 
 ## Required Environment
 
@@ -37,7 +37,7 @@ Frozen dataset scenarios additionally require:
 export DUCKGRES_SCENARIO_FROZEN_S3_URI="s3://<dev-managed-bucket>/frozen_v1/"
 ```
 
-Frozen perf scenarios additionally require the Flight SQL address because the perf catalog exercises both PGWire and Flight:
+The full suite and targeted perf scenarios additionally require the Flight SQL address because the perf catalog exercises both PGWire and Flight:
 
 ```bash
 export DUCKGRES_SCENARIO_FLIGHT_ADDR="<flight-sql-address>"
@@ -63,7 +63,13 @@ Run the dev smoke:
 just scenario-smoke
 ```
 
-Run frozen metadata exploration:
+Run the composed full suite:
+
+```bash
+just scenario scenario=tests/mw-dev/scenario/scenarios/full-suite.yaml
+```
+
+Run targeted frozen metadata exploration:
 
 ```bash
 just scenario-frozen-metadata
@@ -89,7 +95,17 @@ just scenario scenario=tests/mw-dev/scenario/scenarios/provision_smoke.yaml
 
 Artifacts are written under `artifacts/scenario/<run_id>/`.
 
-The frozen metadata scenario uses:
+The default full-suite scenario uses:
+
+- `tests/mw-dev/scenario/scenarios/full-suite.yaml`
+- `tests/mw-dev/scenario/sql/setup_frozen_views.sql`
+- `tests/mw-dev/scenario/sql/metadata_catalog.yaml`
+- `tests/perf/queries/ducklake_frozen.yaml`
+- `tests/mw-dev/scenario/dbt/posthog_frozen_project/`
+
+It runs serially in topological order: `provision` → `wait_ready` → `setup_frozen_views`, then `metadata_exploration`, `perf_queries`, and `dbt_models`. Each workload branch depends only on setup, so a failure in one branch does not suppress the others; `deprovision` always runs after the branches.
+
+The targeted frozen metadata scenario uses:
 
 - `tests/mw-dev/scenario/scenarios/posthog_frozen_metadata.yaml`
 - `tests/mw-dev/scenario/sql/setup_frozen_views.sql`

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -22,7 +22,7 @@ AWS_REGION="${AWS_REGION:-us-east-1}"
 SA_NAME="duckgres"
 FROZEN_S3_URI="${DUCKGRES_SCENARIO_FROZEN_S3_URI:-s3://posthog-duckgres-scenario-frozen-data-mw-dev/frozen_v1/}"
 SCENARIO_JOB_WATCH_TIMEOUT_SECONDS="${SCENARIO_JOB_WATCH_TIMEOUT_SECONDS:-16200}"
-SCENARIO_FULL_FILES="${SCENARIO_FULL_FILES:-tests/mw-dev/scenario/scenarios/provision_rejection.yaml tests/mw-dev/scenario/scenarios/provision_smoke.yaml tests/mw-dev/scenario/scenarios/posthog_frozen_metadata.yaml tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml tests/mw-dev/scenario/scenarios/posthog_frozen_dbt.yaml}"
+SCENARIO_FULL_FILES="${SCENARIO_FULL_FILES:-tests/mw-dev/scenario/scenarios/provision_rejection.yaml tests/mw-dev/scenario/scenarios/provision_smoke.yaml tests/mw-dev/scenario/scenarios/full-suite.yaml}"
 
 # Internal secret for the per-PR control plane. Random per run; never reused.
 # Stamped into the rendered manifests and handed to the in-cluster harness.

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -123,7 +123,6 @@ func TestScenarioFullRunsScenarioJobsAgainstIsolatedStack(t *testing.T) {
 
 	cmd := runSHCommand(t, fakes.binDir, "test-scenario-full",
 		"SCENARIO_RUNNER_IMAGE=example.invalid/duckgres:scenario",
-		"SCENARIO_FULL_FILES=tests/mw-dev/scenario/scenarios/provision_smoke.yaml tests/mw-dev/scenario/scenarios/posthog_frozen_metadata.yaml",
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -134,8 +133,9 @@ func TestScenarioFullRunsScenarioJobsAgainstIsolatedStack(t *testing.T) {
 	for _, want := range []string{
 		"kubectl --context test-context -n duckgres-ci-pr-123 get svc duckgres-control-plane -o jsonpath={.spec.clusterIP}",
 		"kubectl --context test-context -n duckgres-ci-pr-123 apply -f -",
+		"kubectl --context test-context -n duckgres-ci-pr-123 logs -f job/duckgres-scenario-provision-rejection-",
 		"kubectl --context test-context -n duckgres-ci-pr-123 logs -f job/duckgres-scenario-provision-smoke-",
-		"kubectl --context test-context -n duckgres-ci-pr-123 logs -f job/duckgres-scenario-posthog-frozen-metadata-",
+		"kubectl --context test-context -n duckgres-ci-pr-123 logs -f job/duckgres-scenario-full-suite-",
 	} {
 		if !strings.Contains(calls, want) {
 			t.Fatalf("scenario full missing expected call %q; calls:\n%s", want, calls)

--- a/tests/mw-dev/scenario/core/runner.go
+++ b/tests/mw-dev/scenario/core/runner.go
@@ -97,17 +97,13 @@ func (r *Runner) Run(ctx context.Context) (RunSummary, error) {
 	}
 
 	statusByStep := make(map[string]StepStatus, len(r.cfg.Scenario.Steps))
-	normalStepsBlocked := false
 	var runErrs []error
 	for _, step := range r.cfg.Scenario.Steps {
-		result := r.runStep(ctx, runID, step, statusByStep, normalStepsBlocked)
+		result := r.runStep(ctx, runID, step, statusByStep)
 		r.results = append(r.results, result)
 		statusByStep[step.ID] = result.Status
 		if result.Err != nil {
 			runErrs = append(runErrs, result.Err)
-		}
-		if !step.AlwaysRun && !isSuccessfulStepStatus(result.Status) {
-			normalStepsBlocked = true
 		}
 		switch result.Status {
 		case StepStatusOK, StepStatusSuccessAfterRetry:
@@ -142,11 +138,8 @@ func (r *Runner) Results() []StepResult {
 	return out
 }
 
-func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByStep map[string]StepStatus, normalStepsBlocked bool) StepResult {
+func (r *Runner) runStep(ctx context.Context, runID string, step Step, statusByStep map[string]StepStatus) StepResult {
 	if !step.AlwaysRun {
-		if normalStepsBlocked {
-			return r.skippedResult(runID, step, "prior_step_failed", "a prior non-cleanup step did not complete successfully", nil)
-		}
 		if err := ctx.Err(); err != nil {
 			return r.skippedResult(runID, step, "context_canceled", "scenario context is canceled", err)
 		}

--- a/tests/mw-dev/scenario/core/runner_test.go
+++ b/tests/mw-dev/scenario/core/runner_test.go
@@ -9,19 +9,27 @@ import (
 
 type contextKey string
 
-func TestRunnerRunsAlwaysRunStepAfterFailureAndSkipsDependents(t *testing.T) {
+func TestRunnerRunsIndependentDAGBranchesAfterSiblingFailure(t *testing.T) {
 	scenario, err := ParseScenario([]byte(`
-name: failure-cleanup
+name: independent-dag-branches
 steps:
   - id: provision
     type: fake
-  - id: query
+  - id: setup
     type: fake
-  - id: downstream
+    depends_on: [provision]
+  - id: metadata
     type: fake
+    depends_on: [setup]
+  - id: perf
+    type: fake
+    depends_on: [setup]
+  - id: dbt
+    type: fake
+    depends_on: [setup]
   - id: deprovision
     type: fake
-    depends_on: [query]
+    depends_on: [metadata, perf, dbt]
     always_run: true
 `))
 	if err != nil {
@@ -34,8 +42,8 @@ steps:
 		Scenario: scenario,
 		Executor: StepExecutorFunc(func(_ context.Context, step Step) error {
 			executed = append(executed, step.ID)
-			if step.ID == "query" {
-				return errors.New("query failed")
+			if step.ID == "metadata" {
+				return errors.New("metadata failed")
 			}
 			return nil
 		}),
@@ -46,36 +54,49 @@ steps:
 	if err == nil {
 		t.Fatal("expected runner to return failure")
 	}
-	wantExecuted := []string{"provision", "query", "deprovision"}
+	wantExecuted := []string{"provision", "setup", "metadata", "perf", "dbt", "deprovision"}
 	if !equalStrings(executed, wantExecuted) {
 		t.Fatalf("executed steps = %#v, want %#v", executed, wantExecuted)
 	}
-	if summary.TotalSteps != 4 || summary.SucceededSteps != 2 || summary.FailedSteps != 1 || summary.SkippedSteps != 1 {
+	if summary.TotalSteps != 6 || summary.SucceededSteps != 5 || summary.FailedSteps != 1 || summary.SkippedSteps != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
 	results := runner.Results()
-	if len(results) != 4 {
-		t.Fatalf("expected 4 step results, got %d", len(results))
+	if len(results) != 6 {
+		t.Fatalf("expected 6 step results, got %d", len(results))
 	}
-	if results[2].StepID != "downstream" || results[2].Status != StepStatusSkipped {
-		t.Fatalf("expected downstream to be skipped, got %+v", results[2])
+	for _, result := range results[3:5] {
+		if result.Status != StepStatusOK {
+			t.Fatalf("independent branch %s should run successfully, got %+v", result.StepID, result)
+		}
 	}
-	if results[3].StepID != "deprovision" || results[3].Status != StepStatusOK {
-		t.Fatalf("expected deprovision to run successfully, got %+v", results[3])
+	if results[5].StepID != "deprovision" || results[5].Status != StepStatusOK {
+		t.Fatalf("expected deprovision to run successfully, got %+v", results[5])
 	}
 }
 
-func TestRunnerDoesNotLetAlwaysRunCleanupUnblockLaterNormalSteps(t *testing.T) {
+func TestRunnerSkipsDAGDependentsAfterDependencyFailureAndRunsCleanup(t *testing.T) {
 	scenario, err := ParseScenario([]byte(`
-name: cleanup-does-not-unblock
+name: dependency-failure-cleanup
 steps:
-  - id: query
+  - id: provision
     type: fake
-  - id: cleanup
+  - id: setup
     type: fake
+    depends_on: [provision]
+  - id: metadata
+    type: fake
+    depends_on: [setup]
+  - id: perf
+    type: fake
+    depends_on: [setup]
+  - id: dbt
+    type: fake
+    depends_on: [setup]
+  - id: deprovision
+    type: fake
+    depends_on: [metadata, perf, dbt]
     always_run: true
-  - id: after_cleanup
-    type: fake
 `))
 	if err != nil {
 		t.Fatalf("ParseScenario returned error: %v", err)
@@ -87,8 +108,8 @@ steps:
 		Scenario: scenario,
 		Executor: StepExecutorFunc(func(_ context.Context, step Step) error {
 			executed = append(executed, step.ID)
-			if step.ID == "query" {
-				return errors.New("query failed")
+			if step.ID == "setup" {
+				return errors.New("setup failed")
 			}
 			return nil
 		}),
@@ -99,15 +120,20 @@ steps:
 	if err == nil {
 		t.Fatal("expected runner to return failure")
 	}
-	if want := []string{"query", "cleanup"}; !equalStrings(executed, want) {
+	if want := []string{"provision", "setup", "deprovision"}; !equalStrings(executed, want) {
 		t.Fatalf("executed steps = %#v, want %#v", executed, want)
 	}
-	if summary.FailedSteps != 1 || summary.SkippedSteps != 1 {
+	if summary.FailedSteps != 1 || summary.SkippedSteps != 3 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
 	results := runner.Results()
-	if results[2].StepID != "after_cleanup" || results[2].Status != StepStatusSkipped {
-		t.Fatalf("expected after_cleanup to be skipped, got %+v", results[2])
+	for _, result := range results[2:5] {
+		if result.Status != StepStatusSkipped || result.ErrorClass != "dependency_failed" {
+			t.Fatalf("dependent step %s should be skipped for its failed dependency, got %+v", result.StepID, result)
+		}
+	}
+	if result := results[5]; result.StepID != "deprovision" || result.Status != StepStatusOK {
+		t.Fatalf("expected deprovision to run successfully, got %+v", result)
 	}
 }
 

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -161,6 +161,7 @@ func TestFrozenSuccessScenariosUseValidProvisioningSlugs(t *testing.T) {
 		"posthog_frozen_metadata.yaml",
 		"posthog_frozen_perf.yaml",
 		"posthog_frozen_dbt.yaml",
+		"full-suite.yaml",
 	} {
 		t.Run(scenarioFile, func(t *testing.T) {
 			t.Setenv("DUCKGRES_SCENARIO_FLIGHT_ADDR", "grpc://flight.example:8815")
@@ -198,6 +199,63 @@ func TestFrozenSuccessScenariosUseValidProvisioningSlugs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFullSuiteScenarioComposesWorkloadsAsDAG(t *testing.T) {
+	t.Setenv("DUCKGRES_SCENARIO_FROZEN_S3_URI", "s3://example-frozen/frozen_v1/")
+	t.Setenv("DUCKGRES_SCENARIO_FLIGHT_ADDR", "flight.dev.example:443")
+
+	scenario, _, err := loadScenarioForRun(filepath.Join("scenarios", "full-suite.yaml"))
+	if err != nil {
+		t.Fatalf("load full suite scenario: %v", err)
+	}
+	resolved, err := resolveRunTemplates(scenario, "scenario-full-suite-20260102t030405z")
+	if err != nil {
+		t.Fatalf("resolve templates: %v", err)
+	}
+
+	steps := make(map[string]core.Step, len(resolved.Steps))
+	for _, step := range resolved.Steps {
+		if !dispatchSupports(step.Type) {
+			t.Fatalf("step %s has unsupported type %q", step.ID, step.Type)
+		}
+		if containsTemplate(step.With) {
+			t.Fatalf("step %s still contains unresolved template values: %#v", step.ID, step.With)
+		}
+		steps[step.ID] = step
+	}
+
+	for _, stepID := range []string{"setup_frozen_views", "metadata_exploration", "perf_queries", "dbt_models"} {
+		step, ok := steps[stepID]
+		if !ok {
+			t.Fatalf("missing %s step", stepID)
+		}
+		for _, key := range []string{"file", "catalog_file", "project_dir"} {
+			path, ok := step.With[key].(string)
+			if !ok {
+				continue
+			}
+			if !filepath.IsAbs(path) {
+				t.Fatalf("step %s %s = %q, want absolute path", step.ID, key, path)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("step %s %s %q should exist: %v", step.ID, key, path, err)
+			}
+		}
+	}
+
+	for _, stepID := range []string{"metadata_exploration", "perf_queries", "dbt_models"} {
+		if got := steps[stepID].DependsOn; len(got) != 1 || got[0] != "setup_frozen_views" {
+			t.Fatalf("step %s dependencies = %#v, want [setup_frozen_views]", stepID, got)
+		}
+	}
+	deprovision := steps["deprovision"]
+	if !deprovision.AlwaysRun {
+		t.Fatal("deprovision should always run")
+	}
+	if got := deprovision.DependsOn; len(got) != 3 || got[0] != "metadata_exploration" || got[1] != "perf_queries" || got[2] != "dbt_models" {
+		t.Fatalf("deprovision dependencies = %#v, want all frozen workload branches", got)
 	}
 }
 

--- a/tests/mw-dev/scenario/scenarios/full-suite.yaml
+++ b/tests/mw-dev/scenario/scenarios/full-suite.yaml
@@ -1,0 +1,82 @@
+name: full-suite
+run_id_prefix: scenario-full-suite
+required_env:
+  - DUCKGRES_SCENARIO_FROZEN_S3_URI
+  - DUCKGRES_SCENARIO_FLIGHT_ADDR
+steps:
+  - id: provision
+    type: provision_warehouse
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      request:
+        database_name: scenario_full_suite_${run_id_token}
+        default_team_id: 1
+        metadata_store:
+          type: cnpg-shard
+        ducklake:
+          enabled: true
+        data_store:
+          type: s3bucket
+
+  - id: wait_ready
+    type: wait_warehouse_ready
+    depends_on: [provision]
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      timeout: 15m
+      poll_interval: 10s
+
+  - id: setup_frozen_views
+    type: sql
+    depends_on: [wait_ready]
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      catalog: ducklake
+      file: ../sql/setup_frozen_views.sql
+      max_attempts: 12
+      retry_interval: 10s
+
+  - id: metadata_exploration
+    type: sql_catalog
+    depends_on: [setup_frozen_views]
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      catalog: ducklake
+      file: ../sql/metadata_catalog.yaml
+      max_attempts: 3
+      retry_interval: 5s
+
+  - id: perf_queries
+    type: perf_queries
+    depends_on: [setup_frozen_views]
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      catalog: ducklake
+      catalog_file: ../../../perf/queries/ducklake_frozen.yaml
+      run_id: ${run_id}
+      dataset_version: posthog-file-views-v1
+      flight_addr: ${env:DUCKGRES_SCENARIO_FLIGHT_ADDR}
+      fail_on_query_errors: false
+
+  - id: dbt_models
+    type: dbt_run
+    depends_on: [setup_frozen_views]
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      catalog: ducklake
+      schema: dbt_frozen
+      project_dir: ../dbt/posthog_frozen_project
+      commands: [debug, run, test, docs_generate]
+      retry:
+        enabled: true
+        max_attempts: 2
+
+  - id: deprovision
+    type: deprovision_warehouse
+    depends_on: [metadata_exploration, perf_queries, dbt_models]
+    always_run: true
+    with:
+      org_id: scenario-full-suite-${run_id_token}
+      verify_deleted: true
+      cleanup_timeout: 15m
+      poll_interval: 10s


### PR DESCRIPTION
## Summary
- compose frozen metadata, perf, and dbt workloads into `full-suite.yaml`, with shared provisioning and setup
- let independent DAG branches continue after a sibling failure while retaining dependency skips and always-run cleanup
- make the mw-dev full scenario group run rejection, smoke, and the full suite by default

## Validation
- `go test -count=1 ./tests/mw-dev/scenario/... ./tests/mw-dev`
- `just lint`

## Follow-up
`scenario-dev` is still blocked by the Go PGWire SQL driver not supporting the required libpq `hostaddr`/SNI dialing behavior. Artifact-copy error suppression remains a separate follow-up.