### PR TITLE
feat(billing): skip unresolved-team (team_id 0) usage in the pull

### DIFF
--- a/controlplane/compute_billing_api.go
+++ b/controlplane/compute_billing_api.go
@@ -93,12 +93,42 @@ func (h *billingAPIHandler) getUsage(c *gin.Context) {
 	if storageRows == nil {
 		storageRows = []configstore.StorageUsageRow{}
 	}
+	// Never serve usage for an unresolved default team (team_id 0): it can't be
+	// attributed to a billable team and would collide across orgs on billing's
+	// team-keyed mirror. The meter no longer records such usage; this is the
+	// serve-side guard for any rows written before that shipped.
+	rows = resolvedComputeRows(rows)
+	storageRows = resolvedStorageRows(storageRows)
 	c.JSON(http.StatusOK, gin.H{
 		"watermark_low":  low.Format(time.RFC3339),
 		"watermark_high": high.Format(time.RFC3339),
 		"usage":          rows,
 		"storage":        storageRows,
 	})
+}
+
+// resolvedComputeRows drops compute rows with an unresolved team (team_id <= 0).
+// Returns a non-nil slice so an all-dropped result still serializes as [].
+func resolvedComputeRows(rows []configstore.ComputeUsageRow) []configstore.ComputeUsageRow {
+	out := make([]configstore.ComputeUsageRow, 0, len(rows))
+	for _, r := range rows {
+		if r.TeamID > 0 {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// resolvedStorageRows drops storage rows with an unresolved team (team_id <= 0).
+// Returns a non-nil slice so an all-dropped result still serializes as [].
+func resolvedStorageRows(rows []configstore.StorageUsageRow) []configstore.StorageUsageRow {
+	out := make([]configstore.StorageUsageRow, 0, len(rows))
+	for _, r := range rows {
+		if r.TeamID > 0 {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 type billingAckRequest struct {

--- a/controlplane/compute_billing_api_test.go
+++ b/controlplane/compute_billing_api_test.go
@@ -190,6 +190,43 @@ func TestBillingUsageWindowAndRows(t *testing.T) {
 	}
 }
 
+func TestBillingUsageExcludesUnresolvedTeam(t *testing.T) {
+	// The serve-side guard for the window before the meter-level skip shipped:
+	// any usage/storage row with an unresolved team (team_id 0) is dropped from
+	// the pull, so billing can never receive a row that would collide across
+	// orgs on its team-keyed mirror.
+	now := time.Date(2026, 7, 1, 12, 40, 47, 0, time.UTC)
+	cursor := time.Date(2026, 7, 1, 12, 30, 0, 0, time.UTC)
+	store := &fakeBillingStore{
+		cursor: cursor, hasAck: true,
+		rows: []configstore.ComputeUsageRow{
+			{Date: "2026-07-01", OrgID: "org_real", TeamID: 12345, QuerySource: "standard", CPU: "8", MemGiB: "16", CPUSeconds: 4800, MemorySeconds: 9600},
+			{Date: "2026-07-01", OrgID: "org_noteam", TeamID: 0, QuerySource: "standard", CPU: "8", MemGiB: "16", CPUSeconds: 100, MemorySeconds: 200},
+		},
+		storageRows: []configstore.StorageUsageRow{
+			{Date: "2026-07-01", OrgID: "org_real", TeamID: 12345, GiBSeconds: "18000000.5"},
+			{Date: "2026-07-01", OrgID: "org_noteam", TeamID: 0, GiBSeconds: "999"},
+		},
+	}
+	router := newBillingTestRouter(store, now)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/billing/usage", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp usageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Usage) != 1 || resp.Usage[0].OrgID != "org_real" {
+		t.Fatalf("usage = %+v, want only the resolved-team row", resp.Usage)
+	}
+	if len(resp.Storage) != 1 || resp.Storage[0].OrgID != "org_real" {
+		t.Fatalf("storage = %+v, want only the resolved-team row", resp.Storage)
+	}
+}
+
 func TestBillingUsageNeverAckedServesEverything(t *testing.T) {
 	// No cursor row yet → the window starts at the zero time (serves all
 	// buffered history).

--- a/controlplane/compute_meter.go
+++ b/controlplane/compute_meter.go
@@ -7,8 +7,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
+
+var computeUsageSkippedNoTeamCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_compute_usage_skipped_no_team_total",
+	Help: "Compute-usage records dropped because the org has no resolved default team (team_id 0). Unattributable usage that is deliberately not metered; should stay flat at zero once every billable org has a default team.",
+}, []string{"org"})
 
 // Compute-seconds billing intervals (see docs/design/billing-compute-seconds-plan.md).
 const (
@@ -152,8 +160,9 @@ type computeUsageStore interface {
 // computeMeter wires the per-org counter to a flusher. Nil-safe: a disabled
 // meter (non-remote backend) leaves this nil and every call site no-ops.
 // resolveTeam maps an org to its default PostHog team id at record time (a
-// config-snapshot read — no I/O); 0 is tolerated per the OrgDefaultTeamID
-// contract and the bucket then carries team_id 0 ("no default team").
+// config-snapshot read — no I/O). An org with no resolved default team yields
+// 0; that usage is unattributable (billing keys buckets by team, and 0 collides
+// across orgs), so Record skips it rather than emit a team_id 0 bucket.
 type computeMeter struct {
 	counter     *computeUsageCounter
 	store       computeUsageStore
@@ -172,6 +181,13 @@ func (m *computeMeter) Record(orgID, querySource string, millicores, mib int64, 
 	teamID := int64(0)
 	if m.resolveTeam != nil {
 		teamID = m.resolveTeam(orgID)
+	}
+	if teamID <= 0 {
+		// No resolved default team: usage can't be attributed to a billable
+		// team. Skip it (never emit a team_id 0 bucket) and count it so an
+		// operator can alert — post-backfill this should stay flat at zero.
+		computeUsageSkippedNoTeamCounter.WithLabelValues(orgID).Inc()
+		return
 	}
 	m.counter.Record(orgID, querySource, teamID, millicores, mib, endTime, dur)
 }

--- a/controlplane/compute_meter_test.go
+++ b/controlplane/compute_meter_test.go
@@ -175,17 +175,19 @@ func TestComputeMeterFlush(t *testing.T) {
 	}
 }
 
-func TestComputeMeterUnknownTeamTolerated(t *testing.T) {
-	// An org with no default_team_id (or a nil resolver) still meters — the
-	// bucket carries team_id 0 rather than dropping usage.
+func TestComputeMeterSkipsUnresolvedTeam(t *testing.T) {
+	// An org with no default_team_id resolves to team 0 — unattributable usage.
+	// We don't meter it: recording nothing keeps a team_id 0 bucket out of the
+	// billing pull entirely (billing keys usage by team, and 0 collides across
+	// orgs). Losing an unattributable interval is the accepted tradeoff.
 	store := &fakeFlushStore{}
 	m := newComputeMeter(store, teamResolverA)
 	m.Record("orgB", "standard", 1000, 1024, time.Now(), 2*time.Second)
-	if n := m.Flush(); n != 1 {
-		t.Fatalf("Flush rows = %d, want 1", n)
+	if n := m.Flush(); n != 0 {
+		t.Fatalf("Flush rows = %d, want 0 (unresolved-team usage must not be metered)", n)
 	}
-	if store.flushed[0].TeamID != 0 {
-		t.Fatalf("team = %d, want 0 for unknown org", store.flushed[0].TeamID)
+	if len(store.flushed) != 0 {
+		t.Fatalf("flushed = %v, want nothing for an unresolved team", store.flushed)
 	}
 }
 

--- a/controlplane/storage_meter.go
+++ b/controlplane/storage_meter.go
@@ -54,8 +54,15 @@ var storageSampleErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Storage-billing samples skipped due to an error (org unreachable, query failed). Each miss under-bills one interval.",
 }, []string{"org"})
 
+var storageSamplesSkippedNoTeamCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_storage_samples_skipped_no_team_total",
+	Help: "Storage-billing samples dropped because the org has no resolved default team (team_id 0). Unattributable storage that is deliberately not sampled; should stay flat at zero once every billable org has a default team.",
+}, []string{"org"})
+
 // storageOrg is one samplable org: a Ready DuckLake warehouse and its default
-// team (the storage bucket key's team_id; 0 = no default team).
+// team (the storage bucket key's team_id). TeamID 0 means "no default team" —
+// such an org is skipped, not sampled (unattributable storage stays out of the
+// pull; 0 collides across orgs on billing's team-keyed mirror).
 type storageOrg struct {
 	OrgID  string
 	TeamID int64
@@ -125,10 +132,18 @@ func (s *storageSampler) Run(ctx context.Context) {
 
 func (s *storageSampler) sampleAll(ctx context.Context) {
 	orgs := s.listOrgs()
-	var sampled, failed int
+	var sampled, skipped, failed int
 	for _, org := range orgs {
 		if ctx.Err() != nil {
 			return
+		}
+		if org.TeamID <= 0 {
+			// No resolved default team: unattributable storage, keep it out of
+			// the pull (team_id 0 collides across orgs). Count for alerting —
+			// post-backfill this should stay flat at zero.
+			storageSamplesSkippedNoTeamCounter.WithLabelValues(org.OrgID).Inc()
+			skipped++
+			continue
 		}
 		if err := s.sampleOrg(ctx, org); err != nil {
 			slog.Warn("Storage-billing sample failed; interval under-billed for this org.", "org", org.OrgID, "error", err)
@@ -138,8 +153,8 @@ func (s *storageSampler) sampleAll(ctx context.Context) {
 		}
 		sampled++
 	}
-	if sampled > 0 || failed > 0 {
-		slog.Info("Storage-billing sample pass complete.", "sampled", sampled, "failed", failed)
+	if sampled > 0 || failed > 0 || skipped > 0 {
+		slog.Info("Storage-billing sample pass complete.", "sampled", sampled, "failed", failed, "skipped_no_team", skipped)
 	}
 }
 

--- a/controlplane/storage_meter_test.go
+++ b/controlplane/storage_meter_test.go
@@ -44,7 +44,7 @@ func newTestStorageSampler(store storageUsageStore, orgs []storageOrg, footprint
 func TestStorageSamplerCreditsOneIntervalPerOrg(t *testing.T) {
 	store := &fakeStorageStore{}
 	s := newTestStorageSampler(store,
-		[]storageOrg{{OrgID: "orgA", TeamID: 42}, {OrgID: "orgB", TeamID: 0}},
+		[]storageOrg{{OrgID: "orgA", TeamID: 42}, {OrgID: "orgB", TeamID: 7}},
 		func(_ context.Context, dsn string) (int64, int64, error) {
 			if dsn == "postgres://meta/orgA" {
 				return 10 * 1024 * 1024 * 1024, 0, nil // 10 GiB
@@ -66,8 +66,24 @@ func TestStorageSamplerCreditsOneIntervalPerOrg(t *testing.T) {
 	if want := int64(10*1024*1024*1024) * 1800; a.byteSeconds != want {
 		t.Fatalf("orgA byteSeconds = %d, want %d (bytes × interval)", a.byteSeconds, want)
 	}
-	if b := store.samples[1]; b.orgID != "orgB" || b.teamID != 0 || b.byteSeconds != 512*1800 {
+	if b := store.samples[1]; b.orgID != "orgB" || b.teamID != 7 || b.byteSeconds != 512*1800 {
 		t.Fatalf("orgB sample = %+v", b)
+	}
+}
+
+func TestStorageSamplerSkipsUnresolvedTeam(t *testing.T) {
+	// An org whose default team is unresolved (TeamID 0) is not sampled: its
+	// storage can't be attributed to a billable team, so it stays out of the
+	// pull (team_id 0 collides across orgs on billing's team-keyed mirror).
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "noteam", TeamID: 0}, {OrgID: "healthy", TeamID: 5}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 1024 * 1024 * 1024, 0, nil })
+
+	s.sampleAll(context.Background())
+
+	if len(store.samples) != 1 || store.samples[0].orgID != "healthy" {
+		t.Fatalf("samples = %+v, want exactly the resolved-team org", store.samples)
 	}
 }
 


### PR DESCRIPTION
Skips managed-warehouse usage for orgs with no resolved default team (`team_id 0`) so it never enters the billing pull. Such usage is unattributable — billing keys the usage mirror by team alone, and `0` collides across orgs.

- **Source**: compute meter + storage sampler skip `team_id <= 0` (counted via `duckgres_*_skipped_no_team_total` for alerting; should stay flat at zero post-backfill).
- **Serve**: `GET /billing/usage` drops `team_id <= 0` rows — covers any buckets written before this shipped.

**To confirm**: assumes there are no pre-existing `team_id 0` buckets that ought to be billed. The serve-side filter makes the change safe regardless of store contents, but flagging for anyone who knows whether teamless billable orgs exist today.