### PR TITLE
Fix pgwire DATE text encoding

### DIFF
--- a/server/conn_results.go
+++ b/server/conn_results.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -289,13 +290,13 @@ func (c *clientConn) sendDataRowWithFormats(values []interface{}, formatCodes []
 				buf.Write(encoded)
 			}
 		} else {
-			// Text encoding — use JSON re-serialization for JSON columns
-			var str string
-			if typeOIDs != nil && i < len(typeOIDs) && (typeOIDs[i] == OidJSON || typeOIDs[i] == OidJSONB) {
-				str = string(encodeJSON(v))
-			} else {
-				str = formatValue(v)
+			// Text encoding must use the column OID for types whose PostgreSQL
+			// representation cannot be inferred from the scanned Go value alone.
+			var typeOID int32
+			if typeOIDs != nil && i < len(typeOIDs) {
+				typeOID = typeOIDs[i]
 			}
+			str := formatTextValue(v, typeOID)
 			_ = binary.Write(&buf, binary.BigEndian, int32(len(str)))
 			buf.WriteString(str)
 		}
@@ -306,6 +307,51 @@ func (c *clientConn) sendDataRowWithFormats(values []interface{}, formatCodes []
 		return err
 	}
 	return nil
+}
+
+// formatTextValue converts a value to its PostgreSQL text representation when
+// the result column's OID is known. DuckDB scans DATE values into time.Time, so
+// the OID is required to distinguish a DATE (YYYY-MM-DD) from timestamp types.
+func formatTextValue(v interface{}, oid int32) string {
+	switch oid {
+	case OidJSON, OidJSONB:
+		return string(encodeJSON(v))
+	case OidDate:
+		if date, ok := normalizeDriverValue(v).(time.Time); ok {
+			return formatDate(date)
+		}
+	case OidDateArray:
+		if dates, ok := normalizeDriverValue(v).([]any); ok {
+			return formatArrayValueWithElementOID(dates, OidDate)
+		}
+	}
+	return formatValue(v)
+}
+
+const secondsPerDay int64 = 24 * 60 * 60
+
+var (
+	// DuckDB stores DATE as signed days since 1970-01-01 and reserves
+	// ±MaxInt32 for infinity. duckdb-go converts those values to time.Time.
+	duckDBPositiveInfinityDate = time.Unix(int64(math.MaxInt32)*secondsPerDay, 0).UTC()
+	duckDBNegativeInfinityDate = time.Unix(-int64(math.MaxInt32)*secondsPerDay, 0).UTC()
+)
+
+func formatDate(date time.Time) string {
+	if sameDate(date, duckDBPositiveInfinityDate) {
+		return "infinity"
+	}
+	if sameDate(date, duckDBNegativeInfinityDate) {
+		return "-infinity"
+	}
+	if date.Year() <= 0 {
+		return fmt.Sprintf("%04d-%02d-%02d BC", 1-date.Year(), date.Month(), date.Day())
+	}
+	return date.Format("2006-01-02")
+}
+
+func sameDate(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.Month() == b.Month() && a.Day() == b.Day()
 }
 
 // formatValue converts a value to its PostgreSQL text representation
@@ -426,6 +472,10 @@ func formatInterval(iv arrowmap.IntervalValue) string {
 
 // formatArrayValue formats a []any slice as PostgreSQL text array: {1,2,3}
 func formatArrayValue(arr []any) string {
+	return formatArrayValueWithElementOID(arr, 0)
+}
+
+func formatArrayValueWithElementOID(arr []any, elementOID int32) string {
 	var buf strings.Builder
 	buf.WriteByte('{')
 	for i, elem := range arr {
@@ -435,7 +485,7 @@ func formatArrayValue(arr []any) string {
 		if elem == nil {
 			buf.WriteString("NULL")
 		} else {
-			s := formatValue(elem)
+			s := formatTextValue(elem, elementOID)
 			// Quote strings that contain special characters
 			if needsArrayQuoting(s) {
 				buf.WriteByte('"')

--- a/server/conn_results_test.go
+++ b/server/conn_results_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/server/wire"
+)
+
+func TestSendDataRowWithFormatsUsesTypeOIDForTextDates(t *testing.T) {
+	date := time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC)
+	farFutureDate := time.Date(9999, time.December, 31, 0, 0, 0, 0, time.UTC)
+	positiveInfinity := time.Date(5881580, time.July, 11, 0, 0, 0, 0, time.UTC)
+	negativeInfinity := time.Date(-5877641, time.June, 24, 0, 0, 0, 0, time.UTC)
+	oneBC := time.Date(0, time.January, 1, 0, 0, 0, 0, time.UTC)
+	twoBC := time.Date(-1, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		value       any
+		formatCodes []int16
+		typeOID     int32
+		want        string
+	}{
+		{
+			name:    "implicit text format date",
+			value:   farFutureDate,
+			typeOID: OidDate,
+			want:    "9999-12-31",
+		},
+		{
+			name:        "explicit text format date",
+			value:       farFutureDate,
+			formatCodes: []int16{0},
+			typeOID:     OidDate,
+			want:        "9999-12-31",
+		},
+		{
+			name:    "timestamp remains a timestamp",
+			value:   date,
+			typeOID: OidTimestamp,
+			want:    "2022-04-01 00:00:00",
+		},
+		{
+			name:    "date array",
+			value:   []any{date, nil, date.AddDate(0, 0, 1)},
+			typeOID: OidDateArray,
+			want:    "{2022-04-01,NULL,2022-04-02}",
+		},
+		{
+			name:    "positive infinity date",
+			value:   positiveInfinity,
+			typeOID: OidDate,
+			want:    "infinity",
+		},
+		{
+			name:    "negative infinity date",
+			value:   negativeInfinity,
+			typeOID: OidDate,
+			want:    "-infinity",
+		},
+		{
+			name:    "one BC date",
+			value:   oneBC,
+			typeOID: OidDate,
+			want:    "0001-01-01 BC",
+		},
+		{
+			name:    "two BC date",
+			value:   twoBC,
+			typeOID: OidDate,
+			want:    "0002-01-01 BC",
+		},
+		{
+			name:    "date array with infinities and BC dates",
+			value:   []any{positiveInfinity, negativeInfinity, oneBC, twoBC},
+			typeOID: OidDateArray,
+			want:    `{infinity,-infinity,"0001-01-01 BC","0002-01-01 BC"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			conn := &clientConn{writer: bufio.NewWriter(&out)}
+
+			if err := conn.sendDataRowWithFormats(
+				[]any{tt.value},
+				tt.formatCodes,
+				[]int32{tt.typeOID},
+			); err != nil {
+				t.Fatalf("sendDataRowWithFormats: %v", err)
+			}
+			if err := conn.writer.Flush(); err != nil {
+				t.Fatalf("flush DataRow: %v", err)
+			}
+
+			if got := oneColumnTextDataRow(t, out.Bytes()); got != tt.want {
+				t.Fatalf("text DataRow = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDateUsesDuckDBScannedInfinityValues(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open DuckDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var positiveInfinity, negativeInfinity, oneBC, twoBC any
+	err = db.QueryRow(`
+		SELECT
+			DATE 'infinity',
+			DATE '-infinity',
+			DATE '0001-01-01 (BC)',
+			DATE '-0001-01-01'
+	`).Scan(&positiveInfinity, &negativeInfinity, &oneBC, &twoBC)
+	if err != nil {
+		t.Fatalf("scan DuckDB DATE values: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "positive infinity", value: positiveInfinity, want: "infinity"},
+		{name: "negative infinity", value: negativeInfinity, want: "-infinity"},
+		{name: "one BC", value: oneBC, want: "0001-01-01 BC"},
+		{name: "two BC", value: twoBC, want: "0002-01-01 BC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date, ok := tt.value.(time.Time)
+			if !ok {
+				t.Fatalf("DuckDB DATE type = %T, want time.Time", tt.value)
+			}
+			if got := formatDate(date); got != tt.want {
+				t.Fatalf("formatDate(%v) = %q, want %q", date, got, tt.want)
+			}
+		})
+	}
+}
+
+func oneColumnTextDataRow(t *testing.T, message []byte) string {
+	t.Helper()
+
+	if len(message) < 11 {
+		t.Fatalf("DataRow message too short: %d bytes", len(message))
+	}
+	if message[0] != wire.MsgDataRow {
+		t.Fatalf("message type = %q, want DataRow", message[0])
+	}
+	messageLength := int(binary.BigEndian.Uint32(message[1:5]))
+	if messageLength != len(message)-1 {
+		t.Fatalf("DataRow length = %d, want %d", messageLength, len(message)-1)
+	}
+	body := message[5:]
+	if columnCount := binary.BigEndian.Uint16(body[:2]); columnCount != 1 {
+		t.Fatalf("DataRow column count = %d, want 1", columnCount)
+	}
+	valueLength := int(int32(binary.BigEndian.Uint32(body[2:6])))
+	if valueLength < 0 || valueLength != len(body)-6 {
+		t.Fatalf("DataRow value length = %d, payload bytes = %d", valueLength, len(body)-6)
+	}
+	return string(body[6:])
+}

--- a/tests/integration/types_test.go
+++ b/tests/integration/types_test.go
@@ -82,6 +82,9 @@ func TestTypesDateTime(t *testing.T) {
 		// Date
 		{Name: "date_literal", Query: "SELECT DATE '2024-01-15'"},
 		{Name: "date_cast", Query: "SELECT '2024-01-15'::DATE"},
+		{Name: "date_far_future_sentinel", Query: "SELECT DATE '9999-12-31'"},
+		{Name: "date_positive_infinity", Query: "SELECT DATE 'infinity'"},
+		{Name: "date_negative_infinity", Query: "SELECT DATE '-infinity'"},
 		{Name: "current_date", Query: "SELECT CURRENT_DATE IS NOT NULL"},
 
 		// Time


### PR DESCRIPTION
## Summary

- encode pgwire text results with the result column OID when the scanned Go value is ambiguous
- serialize `DATE` and `DATE[]` without an erroneous midnight timestamp suffix
- preserve PostgreSQL text forms for far-future dates, `infinity`, `-infinity`, and BC dates
- add direct wire-message, real DuckDB scan, and integration regression coverage

## Root cause

DuckDB scans both `DATE` and timestamp values into `time.Time`. The text serializer formatted values only from their Go type, so a PostgreSQL `DATE` result was indistinguishable from a timestamp and was emitted with `00:00:00`. Clients still received the DATE OID, creating an invalid type/value representation at the pgwire boundary.

The formatter now uses the result OID to select PostgreSQL-compatible DATE text encoding. DuckDB's raw DATE infinity sentinels are derived from their signed day representation, and astronomical Go years are converted to PostgreSQL BC notation.

## Impact

DATE values such as `9999-12-31` now arrive as canonical PostgreSQL DATE text. Existing timestamp formatting remains unchanged, and DATE arrays inherit the same element-aware behavior.

## Validation

- `just test-unit`
- `go test -v ./tests/integration -run '^TestTypesDateTime$' -count=1`
- focused DATE formatter and DuckDB scan regression tests
- `just lint` (0 issues)
- `git diff --check`