### PR TITLE
fix: dial scenario PGWire directly with SNI

### DIFF
--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -13,11 +13,11 @@ Set these before running a real scenario:
 ```bash
 export DUCKGRES_SCENARIO_API_BASE="<control-plane-api-base-url>"
 export DUCKGRES_SCENARIO_INTERNAL_SECRET="<internal-secret>"
-export DUCKGRES_SCENARIO_PG_HOST="<pgwire-direct-address-for-libpq-hostaddr>"
+export DUCKGRES_SCENARIO_PG_HOST="<pgwire-direct-tcp-host>"
 export DUCKGRES_SCENARIO_SNI_SUFFIX="<managed-hostname-suffix>"
 ```
 
-`DUCKGRES_SCENARIO_PG_HOST` is used as libpq `hostaddr`; the runner separately sets `host=<org><suffix>` so TLS SNI carries the managed warehouse identity.
+`DUCKGRES_SCENARIO_PG_HOST` is the direct PGWire TCP host. The Go SQL and perf clients dial it through a connector while retaining `host=<org><suffix>` for TLS SNI and managed-warehouse routing. The dbt client exports a numeric value as `PGHOSTADDR`, which libpq supports.
 
 Optional:
 

--- a/scripts/scenario_run.sh
+++ b/scripts/scenario_run.sh
@@ -10,7 +10,7 @@ Runs a Duckgres scenario through the Go test entry point.
 Required environment:
   DUCKGRES_SCENARIO_API_BASE
   DUCKGRES_SCENARIO_INTERNAL_SECRET
-  DUCKGRES_SCENARIO_PG_HOST        (libpq hostaddr / direct TCP address)
+  DUCKGRES_SCENARIO_PG_HOST        (direct PGWire TCP host)
   DUCKGRES_SCENARIO_SNI_SUFFIX
 
 Optional environment:

--- a/tests/mw-dev/scenario/dbt/runner_test.go
+++ b/tests/mw-dev/scenario/dbt/runner_test.go
@@ -45,7 +45,7 @@ func TestExecutorRunsCommandsCapturesLogsAndCopiesTargetArtifacts(t *testing.T) 
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:        "10.0.0.10",
+			DialHost:        "10.0.0.10",
 			SNISuffix:       ".dev.example",
 			Port:            5432,
 			SSLMode:         "require",
@@ -130,7 +130,7 @@ func TestExecutorRunsCommandsCapturesLogsAndCopiesTargetArtifacts(t *testing.T) 
 	}
 }
 
-func TestExecutorOmitsPGHostAddrWhenConnectionHostAddrIsNotNumeric(t *testing.T) {
+func TestExecutorOmitsPGDialHostWhenConnectionDialHostIsNotNumeric(t *testing.T) {
 	projectDir := writeDBTProject(t)
 	provisionState := provision.NewState()
 	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
@@ -142,7 +142,7 @@ func TestExecutorOmitsPGHostAddrWhenConnectionHostAddrIsNotNumeric(t *testing.T)
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "duckgres-control-plane.test.svc",
+			DialHost:  "duckgres-control-plane.test.svc",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -186,7 +186,7 @@ func TestExecutorStopsAfterFailedDBTCommand(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -243,7 +243,7 @@ func TestExecutorRetriesFailedDBTCommandAndRecordsRecoveredFailure(t *testing.T)
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},

--- a/tests/mw-dev/scenario/dbt/steps.go
+++ b/tests/mw-dev/scenario/dbt/steps.go
@@ -361,8 +361,8 @@ func (e *Executor) commandEnv(spec stepSpec) []string {
 		"DUCKGRES_DBT_SSLMODE=" + spec.SSLMode,
 		"DUCKGRES_DBT_CONNECT_TIMEOUT=" + strconv.Itoa(connectTimeout),
 	}
-	if _, err := netip.ParseAddr(e.connection.HostAddr); err == nil {
-		env = append(env, "PGHOSTADDR="+e.connection.HostAddr)
+	if _, err := netip.ParseAddr(e.connection.DialHost); err == nil {
+		env = append(env, "PGHOSTADDR="+e.connection.DialHost)
 	}
 	return env
 }

--- a/tests/mw-dev/scenario/perf/adapter_test.go
+++ b/tests/mw-dev/scenario/perf/adapter_test.go
@@ -27,7 +27,7 @@ func TestExecutorRunsPerfStepAndWritesArtifacts(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:        "10.0.0.10",
+			DialHost:        "10.0.0.10",
 			SNISuffix:       ".dev.example",
 			Port:            5432,
 			SSLMode:         "require",
@@ -63,8 +63,15 @@ func TestExecutorRunsPerfStepAndWritesArtifacts(t *testing.T) {
 	if result.Summary.RunID != "scenario-run-1" || result.Summary.TotalQueries != 2 || result.Summary.TotalErrors != 0 {
 		t.Fatalf("summary = %+v", result.Summary)
 	}
-	if got := factory.pgwireDSN; !strings.Contains(got, "host=scenario-org.dev.example") || !strings.Contains(got, "password=root-password") {
-		t.Fatalf("pgwire dsn = %q, want scenario org host and provision password", got)
+	pgwireDSN := factory.pgwireConnection.DSN
+	if !strings.Contains(pgwireDSN, "host=scenario-org.dev.example") || !strings.Contains(pgwireDSN, "password=root-password") {
+		t.Fatalf("pgwire dsn = %q, want scenario org host and provision password", pgwireDSN)
+	}
+	if strings.Contains(pgwireDSN, "hostaddr=") {
+		t.Fatalf("pgwire dsn = %q, should not use unsupported lib/pq hostaddr", pgwireDSN)
+	}
+	if factory.pgwireConnection.DialAddress != "10.0.0.10:5432" {
+		t.Fatalf("pgwire direct address = %q, want 10.0.0.10:5432", factory.pgwireConnection.DialAddress)
 	}
 	if factory.flightAddr != "flight.dev.example:443" || factory.flightUsername != "root" || factory.flightPassword != "root-password" {
 		t.Fatalf("flight config = %q/%q/%q", factory.flightAddr, factory.flightUsername, factory.flightPassword)
@@ -106,7 +113,7 @@ func TestExecutorFailsPerfStepWhenMeasuredQueryErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -151,7 +158,7 @@ func TestExecutorCanReportPerfQueryErrorsWithoutFailingStep(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -201,7 +208,7 @@ func TestExecutorRequiresFlightAddrWhenCatalogTargetsFlight(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -235,7 +242,7 @@ func TestExecutorClosesCreatedDriversWhenLaterDriverCreationFails(t *testing.T) 
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			SSLMode:   "require",
 		},
@@ -291,7 +298,7 @@ func writePerfCatalog(t *testing.T, targets []perfcore.Protocol) string {
 }
 
 type fakeDriverFactory struct {
-	pgwireDSN                string
+	pgwireConnection         scenariosql.PGWireConnection
 	pgwireErr                error
 	pgwireDriver             *fakeProtocolDriver
 	flightAddr               string
@@ -302,8 +309,8 @@ type fakeDriverFactory struct {
 	flightErr                error
 }
 
-func (f *fakeDriverFactory) NewPGWire(dsn string) (perfcore.ProtocolDriver, error) {
-	f.pgwireDSN = dsn
+func (f *fakeDriverFactory) NewPGWire(connection scenariosql.PGWireConnection) (perfcore.ProtocolDriver, error) {
+	f.pgwireConnection = connection
 	f.pgwireDriver = &fakeProtocolDriver{protocol: perfcore.ProtocolPGWire, err: f.pgwireErr}
 	return f.pgwireDriver, nil
 }

--- a/tests/mw-dev/scenario/perf/steps.go
+++ b/tests/mw-dev/scenario/perf/steps.go
@@ -19,7 +19,7 @@ import (
 const StepTypePerfQueries = "perf_queries"
 
 type DriverFactory interface {
-	NewPGWire(dsn string) (perfcore.ProtocolDriver, error)
+	NewPGWire(connection scenariosql.PGWireConnection) (perfcore.ProtocolDriver, error)
 	NewFlight(addr, serverName, username, password string, insecureSkipVerify bool) (perfcore.ProtocolDriver, error)
 }
 
@@ -263,11 +263,11 @@ func (e *Executor) driversForCatalog(catalog perfcore.Catalog, spec stepSpec) (m
 		}
 		switch target {
 		case perfcore.ProtocolPGWire:
-			dsn, err := e.pgwireDSN(spec)
+			connection, err := e.pgwireConnection(spec)
 			if err != nil {
 				return nil, err
 			}
-			driver, err := e.driverFactory.NewPGWire(dsn)
+			driver, err := e.driverFactory.NewPGWire(connection)
 			if err != nil {
 				return nil, classified(ErrorClassConfig, fmt.Errorf("create pgwire perf driver: %w", err))
 			}
@@ -299,17 +299,17 @@ func (e *Executor) defaultFlightServerName(orgID string) string {
 	return orgID + e.connection.SNISuffix
 }
 
-func (e *Executor) pgwireDSN(spec stepSpec) (string, error) {
+func (e *Executor) pgwireConnection(spec stepSpec) (scenariosql.PGWireConnection, error) {
 	cfg := e.connection
 	cfg.OrgID = spec.OrgID
 	cfg.Database = spec.Database
 	cfg.Username = spec.Username
 	cfg.Password = spec.Password
-	dsn, err := cfg.DSN()
+	connection, err := cfg.PGWire()
 	if err != nil {
-		return "", classified(ErrorClassConfig, err)
+		return scenariosql.PGWireConnection{}, classified(ErrorClassConfig, err)
 	}
-	return dsn, nil
+	return connection, nil
 }
 
 func closeDrivers(drivers map[perfcore.Protocol]perfcore.ProtocolDriver) {
@@ -318,8 +318,12 @@ func closeDrivers(drivers map[perfcore.Protocol]perfcore.ProtocolDriver) {
 	}
 }
 
-func (defaultDriverFactory) NewPGWire(dsn string) (perfcore.ProtocolDriver, error) {
-	return pgdriver.NewFromDSN(dsn)
+func (defaultDriverFactory) NewPGWire(connection scenariosql.PGWireConnection) (perfcore.ProtocolDriver, error) {
+	db, err := connection.OpenDB()
+	if err != nil {
+		return nil, err
+	}
+	return pgdriver.NewWithDB(db), nil
 }
 
 func (defaultDriverFactory) NewFlight(addr, serverName, username, password string, insecureSkipVerify bool) (perfcore.ProtocolDriver, error) {

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -71,7 +71,7 @@ func TestScenarioRunner(t *testing.T) {
 	sqlExecutor := scenariosql.NewExecutor(scenariosql.ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
+			DialHost:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
 			SNISuffix:       mustEnv(t, "DUCKGRES_SCENARIO_SNI_SUFFIX"),
 			Port:            intEnv(t, "DUCKGRES_SCENARIO_PG_PORT", 5432),
 			SSLMode:         "require",
@@ -83,7 +83,7 @@ func TestScenarioRunner(t *testing.T) {
 	perfExecutor := scenarioperf.NewExecutor(scenarioperf.ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
+			DialHost:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
 			SNISuffix:       mustEnv(t, "DUCKGRES_SCENARIO_SNI_SUFFIX"),
 			Port:            intEnv(t, "DUCKGRES_SCENARIO_PG_PORT", 5432),
 			SSLMode:         "require",
@@ -97,7 +97,7 @@ func TestScenarioRunner(t *testing.T) {
 	dbtExecutor := scenariodbt.NewExecutor(scenariodbt.ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: scenariosql.ConnectionConfig{
-			HostAddr:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
+			DialHost:        mustEnv(t, "DUCKGRES_SCENARIO_PG_HOST"),
 			SNISuffix:       mustEnv(t, "DUCKGRES_SCENARIO_SNI_SUFFIX"),
 			Port:            intEnv(t, "DUCKGRES_SCENARIO_PG_PORT", 5432),
 			SSLMode:         "require",

--- a/tests/mw-dev/scenario/sql/connection.go
+++ b/tests/mw-dev/scenario/sql/connection.go
@@ -1,15 +1,21 @@
 package sql
 
 import (
+	"context"
+	stdsql "database/sql"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/lib/pq"
 )
 
 type ConnectionConfig struct {
 	OrgID           string
 	SNISuffix       string
-	HostAddr        string
+	DialHost        string
 	Port            int
 	Database        string
 	Username        string
@@ -19,18 +25,28 @@ type ConnectionConfig struct {
 	ApplicationName string
 }
 
-func (c ConnectionConfig) DSN() (string, error) {
+// PGWireConnection separates the hostname used for managed-warehouse TLS
+// routing from the address used for the underlying TCP connection.
+//
+// lib/pq does not support libpq's hostaddr parameter. Keeping this split
+// outside the DSN prevents it from resolving the managed SNI hostname.
+type PGWireConnection struct {
+	DSN         string
+	DialAddress string
+}
+
+func (c ConnectionConfig) PGWire() (PGWireConnection, error) {
 	if c.OrgID == "" {
-		return "", classified(ErrorClassConfig, fmt.Errorf("org id is required for SQL connection"))
+		return PGWireConnection{}, classified(ErrorClassConfig, fmt.Errorf("org id is required for SQL connection"))
 	}
 	if c.SNISuffix == "" {
-		return "", classified(ErrorClassConfig, fmt.Errorf("SNI suffix is required for SQL connection"))
+		return PGWireConnection{}, classified(ErrorClassConfig, fmt.Errorf("SNI suffix is required for SQL connection"))
 	}
 	if !strings.HasPrefix(c.SNISuffix, ".") {
-		return "", classified(ErrorClassConfig, fmt.Errorf("SNI suffix must start with a dot"))
+		return PGWireConnection{}, classified(ErrorClassConfig, fmt.Errorf("SNI suffix must start with a dot"))
 	}
-	if c.HostAddr == "" {
-		return "", classified(ErrorClassConfig, fmt.Errorf("PG host address is required for SQL connection"))
+	if c.DialHost == "" {
+		return PGWireConnection{}, classified(ErrorClassConfig, fmt.Errorf("PG direct dial host is required for SQL connection"))
 	}
 	if c.Port == 0 {
 		c.Port = 5432
@@ -47,7 +63,6 @@ func (c ConnectionConfig) DSN() (string, error) {
 
 	values := [][2]string{
 		{"host", c.OrgID + c.SNISuffix},
-		{"hostaddr", c.HostAddr},
 		{"port", strconv.Itoa(c.Port)},
 		{"user", c.Username},
 		{"password", c.Password},
@@ -65,7 +80,60 @@ func (c ConnectionConfig) DSN() (string, error) {
 	for _, kv := range values {
 		parts = append(parts, kv[0]+"="+quoteConninfoValue(kv[1]))
 	}
-	return strings.Join(parts, " "), nil
+	return PGWireConnection{
+		DSN:         strings.Join(parts, " "),
+		DialAddress: net.JoinHostPort(c.DialHost, strconv.Itoa(c.Port)),
+	}, nil
+}
+
+func (c ConnectionConfig) DSN() (string, error) {
+	connection, err := c.PGWire()
+	if err != nil {
+		return "", err
+	}
+	return connection.DSN, nil
+}
+
+func (c ConnectionConfig) OpenDB() (*stdsql.DB, error) {
+	connection, err := c.PGWire()
+	if err != nil {
+		return nil, err
+	}
+	return connection.OpenDB()
+}
+
+func (c PGWireConnection) OpenDB() (*stdsql.DB, error) {
+	if c.DSN == "" {
+		return nil, classified(ErrorClassConfig, fmt.Errorf("PGWire DSN is required"))
+	}
+	if c.DialAddress == "" {
+		return nil, classified(ErrorClassConfig, fmt.Errorf("PGWire direct dial address is required"))
+	}
+	connector, err := pq.NewConnector(c.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("create PGWire connector: %w", err)
+	}
+	connector.Dialer(directDialer{address: c.DialAddress})
+	return stdsql.OpenDB(connector), nil
+}
+
+type directDialer struct {
+	address string
+	dialer  net.Dialer
+}
+
+func (d directDialer) Dial(network, _ string) (net.Conn, error) {
+	return d.dialer.Dial(network, d.address)
+}
+
+func (d directDialer) DialTimeout(network, _ string, timeout time.Duration) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return d.dialer.DialContext(ctx, network, d.address)
+}
+
+func (d directDialer) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	return d.dialer.DialContext(ctx, network, d.address)
 }
 
 func quoteConninfoValue(value string) string {

--- a/tests/mw-dev/scenario/sql/connection_test.go
+++ b/tests/mw-dev/scenario/sql/connection_test.go
@@ -1,15 +1,20 @@
 package sql
 
 import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestConnectionConfigDSNUsesSNIHostAndTCPHostAddr(t *testing.T) {
-	dsn, err := ConnectionConfig{
+func TestConnectionConfigPGWireUsesSNIHostWithoutHostAddr(t *testing.T) {
+	connection, err := (ConnectionConfig{
 		OrgID:           "scenario-org",
 		SNISuffix:       ".dev.example",
-		HostAddr:        "10.0.0.10",
+		DialHost:        "10.0.0.10",
 		Port:            5432,
 		Database:        "ducklake",
 		Username:        "root",
@@ -17,14 +22,14 @@ func TestConnectionConfigDSNUsesSNIHostAndTCPHostAddr(t *testing.T) {
 		SSLMode:         "require",
 		ConnectTimeout:  10,
 		ApplicationName: "duckgres-scenario",
-	}.DSN()
+	}).PGWire()
 	if err != nil {
-		t.Fatalf("DSN returned error: %v", err)
+		t.Fatalf("PGWire returned error: %v", err)
 	}
+	dsn := connection.DSN
 
 	for _, want := range []string{
 		"host=scenario-org.dev.example",
-		"hostaddr=10.0.0.10",
 		"port=5432",
 		"user=root",
 		"password='root password'",
@@ -37,12 +42,81 @@ func TestConnectionConfigDSNUsesSNIHostAndTCPHostAddr(t *testing.T) {
 			t.Fatalf("DSN %q missing %q", dsn, want)
 		}
 	}
+	if strings.Contains(dsn, "hostaddr=") {
+		t.Fatalf("DSN %q should not include unsupported lib/pq hostaddr", dsn)
+	}
+	if connection.DialAddress != "10.0.0.10:5432" {
+		t.Fatalf("direct dial address = %q, want 10.0.0.10:5432", connection.DialAddress)
+	}
+}
+
+func TestConnectionConfigOpenDBDialsDirectAddressAndPreservesSNI(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	sniNames := make(chan string, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = listener.Close() }()
+		defer func() { _ = conn.Close() }()
+
+		request := make([]byte, 8)
+		if _, err := io.ReadFull(conn, request); err != nil {
+			return
+		}
+		if _, err := conn.Write([]byte{'S'}); err != nil {
+			return
+		}
+		_ = tls.Server(conn, &tls.Config{
+			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+				sniNames <- hello.ServerName
+				return nil, nil
+			},
+		}).Handshake()
+	}()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	db, err := (ConnectionConfig{
+		OrgID:     "scenario-org",
+		SNISuffix: ".ci.invalid",
+		DialHost:  "127.0.0.1",
+		Port:      port,
+		Database:  "ducklake",
+		Username:  "root",
+		Password:  "root-password",
+		SSLMode:   "require",
+	}).OpenDB()
+	if err != nil {
+		t.Fatalf("OpenDB returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err == nil {
+		t.Fatal("PingContext unexpectedly succeeded against incomplete test server")
+	}
+
+	select {
+	case got := <-sniNames:
+		if got != "scenario-org.ci.invalid" {
+			t.Fatalf("TLS SNI = %q, want scenario-org.ci.invalid", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive a TLS ClientHello")
+	}
 }
 
 func TestConnectionConfigDSNRequiresSNIFields(t *testing.T) {
 	_, err := ConnectionConfig{
 		OrgID:    "scenario-org",
-		HostAddr: "10.0.0.10",
+		DialHost: "10.0.0.10",
 		Port:     5432,
 		Database: "ducklake",
 		Username: "root",
@@ -57,7 +131,7 @@ func TestConnectionConfigDSNDefaultsDatabaseAndEscapesPassword(t *testing.T) {
 	dsn, err := ConnectionConfig{
 		OrgID:     "scenario-org",
 		SNISuffix: ".dev.example",
-		HostAddr:  "10.0.0.10",
+		DialHost:  "10.0.0.10",
 		Username:  "root",
 		Password:  `pa'ss\word`,
 	}.DSN()
@@ -76,7 +150,7 @@ func TestConnectionConfigDSNRejectsSuffixWithoutLeadingDot(t *testing.T) {
 	_, err := ConnectionConfig{
 		OrgID:     "scenario-org",
 		SNISuffix: "dev.example",
-		HostAddr:  "10.0.0.10",
+		DialHost:  "10.0.0.10",
 		Username:  "root",
 		Password:  "root-password",
 	}.DSN()

--- a/tests/mw-dev/scenario/sql/driver.go
+++ b/tests/mw-dev/scenario/sql/driver.go
@@ -2,11 +2,8 @@ package sql
 
 import (
 	"context"
-	stdsql "database/sql"
 	"fmt"
 	"time"
-
-	_ "github.com/lib/pq"
 )
 
 type Driver interface {
@@ -19,7 +16,7 @@ type QueryRequest struct {
 	OrgID   string
 	Catalog string
 	SQL     string
-	DSN     string
+	PGWire  PGWireConnection
 }
 
 type QueryResult struct {
@@ -35,7 +32,7 @@ func NewDatabaseDriver() *DatabaseDriver {
 
 func (d *DatabaseDriver) Execute(ctx context.Context, req QueryRequest) (QueryResult, error) {
 	started := time.Now()
-	db, err := stdsql.Open("postgres", req.DSN)
+	db, err := req.PGWire.OpenDB()
 	if err != nil {
 		return QueryResult{}, fmt.Errorf("open pgwire connection: %w", err)
 	}

--- a/tests/mw-dev/scenario/sql/steps.go
+++ b/tests/mw-dev/scenario/sql/steps.go
@@ -216,7 +216,7 @@ func (e *Executor) queryRequest(step core.Step, spec querySpec, resultID string)
 	cfg.Database = spec.Catalog
 	cfg.Username = username
 	cfg.Password = password
-	dsn, err := cfg.DSN()
+	connection, err := cfg.PGWire()
 	if err != nil {
 		return QueryRequest{}, err
 	}
@@ -226,7 +226,7 @@ func (e *Executor) queryRequest(step core.Step, spec querySpec, resultID string)
 		OrgID:   orgID,
 		Catalog: spec.Catalog,
 		SQL:     spec.SQL,
-		DSN:     dsn,
+		PGWire:  connection,
 	}, nil
 }
 

--- a/tests/mw-dev/scenario/sql/steps_test.go
+++ b/tests/mw-dev/scenario/sql/steps_test.go
@@ -34,7 +34,7 @@ func TestExecutorRetriesTransientStartupErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -97,7 +97,7 @@ func TestExecutorRetriesEOFStartupErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -149,7 +149,7 @@ func TestExecutorRetriesConnectionResetStartupErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -201,7 +201,7 @@ func TestExecutorRetriesIOTimeoutStartupErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -250,7 +250,7 @@ func TestExecutorDoesNotRetryNonTransientSQLErrors(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -290,7 +290,7 @@ func TestExecutorFailsWhenSQLReturnsFewerThanMinRows(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -341,7 +341,7 @@ func TestExecutorRunsInlineSQLCatalog(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -405,7 +405,7 @@ queries:
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -476,7 +476,7 @@ func TestExecutorTemplatesSQLFileEnvVars(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -510,17 +510,17 @@ func TestExecutorUsesProvisionCredentialsInDSN(t *testing.T) {
 		Username: "custom-root",
 		Password: "root password",
 	})
-	var gotDSN string
+	var gotConnection PGWireConnection
 	driver := &fakeDriver{
 		executeFunc: func(_ context.Context, req QueryRequest) (QueryResult, error) {
-			gotDSN = req.DSN
+			gotConnection = req.PGWire
 			return QueryResult{Rows: 1}, nil
 		},
 	}
 	executor := NewExecutor(ExecutorConfig{
 		ProvisionState: provisionState,
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",
@@ -541,16 +541,19 @@ func TestExecutorUsesProvisionCredentialsInDSN(t *testing.T) {
 		t.Fatalf("ExecuteStep returned error: %v", err)
 	}
 	for _, want := range []string{"user=custom-root", "password='root password'", "dbname=ducklake"} {
-		if !strings.Contains(gotDSN, want) {
-			t.Fatalf("DSN %q missing %q", gotDSN, want)
+		if !strings.Contains(gotConnection.DSN, want) {
+			t.Fatalf("DSN %q missing %q", gotConnection.DSN, want)
 		}
+	}
+	if gotConnection.DialAddress != "10.0.0.10:5432" {
+		t.Fatalf("direct dial address = %q, want 10.0.0.10:5432", gotConnection.DialAddress)
 	}
 }
 
 func TestExecutorFailsWithoutProvisionState(t *testing.T) {
 	executor := NewExecutor(ExecutorConfig{
 		Connection: ConnectionConfig{
-			HostAddr:  "10.0.0.10",
+			DialHost:  "10.0.0.10",
 			SNISuffix: ".dev.example",
 			Port:      5432,
 			SSLMode:   "require",

--- a/tests/perf/drivers/pgwire/driver.go
+++ b/tests/perf/drivers/pgwire/driver.go
@@ -23,12 +23,16 @@ func NewWithExecutor(exec Executor) *Driver {
 	return &Driver{exec: exec}
 }
 
+func NewWithDB(db *sql.DB) *Driver {
+	return NewWithExecutor(&sqlExecutor{db: db})
+}
+
 func NewFromDSN(dsn string) (*Driver, error) {
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open pgwire connection: %w", err)
 	}
-	return &Driver{exec: &sqlExecutor{db: db}}, nil
+	return NewWithDB(db), nil
 }
 
 func (d *Driver) Protocol() core.Protocol {


### PR DESCRIPTION
## Summary
- separate the managed-hostname TLS/SNI identity from the direct PGWire TCP dial address
- use a `lib/pq` connector dialer for both scenario SQL and perf PGWire clients instead of the unsupported DSN `hostaddr` setting
- retain dbt's numeric `PGHOSTADDR` behavior and document the explicit transport split

## Root cause
The Go `lib/pq` driver resolves `host` for TCP dialing and does not implement libpq `hostaddr` semantics. The scenario hostname is intentionally not resolvable, so SQL and perf failed before reaching the control plane.

## Validation
- `go test -count=1 ./tests/mw-dev/scenario/... ./tests/mw-dev ./tests/perf/drivers/pgwire`
- `just lint`

The direct-dial regression test uses an unresolvable SNI hostname and a local TCP listener, proving that the connection reaches the direct address while TLS still carries the expected SNI.