### PR TITLE
Reshard cnpg→ext: surface ESO sync errors, teach the secret-name/value rules, progressive log replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,6 +558,15 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
 - **The ext target password is ephemeral**: request → in-process stash →
   runner memory; never in the op row, log, or audit. Takeover mid-copy fails
   with a clear re-run message instead of proceeding without it.
+- **The ext SM secret must be ESO-readable and a raw string**: the ESO IAM
+  policy only allows `posthog-*`/`duckling-*` names (RDS-managed
+  `rds!…`/`rds/…/master` secrets never work → start handler 400s them,
+  `rdsManagedSecretNamePattern`), and the composition's ExternalSecret copies
+  the whole value verbatim (no JSON property). During the cutover wait the
+  runner surfaces a failing ExternalSecret sync condition into the op log at
+  warn (`ExternalSecretSyncError`, deduped by content); a diagnostic read
+  error degrades quietly — it must never fail the op. The form teaches the
+  same rules (`ui/src/lib/reshard.ts::classifySecretName`).
 - **Runner fencing**: claim bumps `runner_epoch`; every runner write is
   CAS-fenced on (runner, epoch); stale-heartbeat (>5m) ops are takeover-able;
   the copy holds a target-DB advisory lock.

--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -55,6 +55,17 @@ type ReshardPasswordStash interface {
 // reshardShardNamePattern mirrors the Duckling XRD's cnpgShard pattern.
 var reshardShardNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
+// rdsManagedSecretNamePattern matches AWS RDS-managed master-password secret
+// names: the `rds!db-…`/`rds!cluster-…` names RDS creates for
+// manage_master_user_password, and the `rds/<db>/master` alias console paths.
+// The external-secrets IAM policy only allows `secretsmanager:GetSecretValue`
+// on a per-env prefix allowlist (posthog-*, duckling-*, … — see the
+// external-secrets-pod-identity terraform module in posthog-cloud-infra); no
+// environment allows `rds…`, so a reshard pointed at one of these would pass
+// the catalog copy and then hang the cutover on an ESO AccessDenied. Reject
+// it up front.
+var rdsManagedSecretNamePattern = regexp.MustCompile(`^rds[!/]`)
+
 type reshardTargetRequest struct {
 	Type string `json:"type"` // "cnpg-shard" | "external"
 
@@ -249,6 +260,10 @@ func (h *reshardHandler) start(c *gin.Context) {
 		}
 		if strings.TrimSpace(req.Target.Endpoint) == "" || strings.TrimSpace(req.Target.PasswordAWSSecret) == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "external target requires endpoint and password_aws_secret"})
+			return
+		}
+		if rdsManagedSecretNamePattern.MatchString(strings.TrimSpace(req.Target.PasswordAWSSecret)) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "password_aws_secret looks like an RDS-managed master secret (rds!… / rds/…) — the external-secrets role cannot read those, so the cutover would hang on an ESO AccessDenied. Create a Secrets Manager secret whose name the ESO policy allows (e.g. duckling-<name>-…-rds-password) with the raw password string as its value, and use that name"})
 			return
 		}
 		if req.Target.Password == "" {

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -205,6 +205,11 @@ func TestReshardStartValidation(t *testing.T) {
 		{"bad target type", nil, `{"target":{"type":"nonsense"}}`, 400},
 		{"missing ext fields", nil, `{"target":{"type":"external","endpoint":"x"}}`, 400},
 		{"missing ext password", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"s"}}`, 400},
+		// RDS-managed master secrets are outside every env's ESO IAM policy
+		// (posthog-*/duckling-* prefixes only) — the cutover would hang on an
+		// ESO AccessDenied, so the start handler rejects them up front.
+		{"rds slash master secret", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds/duckling-example/master","password":"p"}}`, 400},
+		{"rds bang managed secret", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-1234-abcd","password":"p"}}`, 400},
 		{"not ready", func(f *fakeReshardStore) {
 			f.warehouse.State = configstore.ManagedWarehouseStateProvisioning
 		}, `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`, 409},

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -3,7 +3,7 @@
 // Read hooks for endpoints that may not exist yet (`*Optional`) swallow 404 and
 // return an empty value so pages render an empty state instead of crashing.
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useMutation,
   useQuery,
@@ -12,6 +12,7 @@ import {
 } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { POLL } from "@/lib/query";
+import { useRevealedCount } from "@/lib/logReplay";
 import { useIdentity } from "@/components/IdentityProvider";
 import type {
   AuditEntry,
@@ -500,7 +501,10 @@ export function useReshard(opId: number | null) {
 
 // Incremental log accumulation: polls /log?after_id=<last seen> and appends.
 // Keeps polling (slower) even after the op is terminal so the final report
-// lines always land; the page unmount stops it.
+// lines always land; the page unmount stops it. Returned entries are revealed
+// PROGRESSIVELY (useRevealedCount): opening the page of a running or finished
+// op replays the accumulated backlog line-by-line over a few seconds like a
+// live terminal, then live-appends new lines as they arrive.
 export function useReshardLog(opId: number | null, opState: string | undefined) {
   const [entries, setEntries] = useState<ReshardLogEntry[]>([]);
   const lastID = entries.length > 0 ? entries[entries.length - 1].id : 0;
@@ -525,7 +529,8 @@ export function useReshardLog(opId: number | null, opState: string | undefined) 
     }
   }, [poll.data]);
 
-  return entries;
+  const revealed = useRevealedCount(entries.length);
+  return useMemo(() => entries.slice(0, revealed), [entries, revealed]);
 }
 
 // Global operation list for the Reshards nav page. Polls at the normal

--- a/controlplane/admin/ui/src/lib/logReplay.test.tsx
+++ b/controlplane/admin/ui/src/lib/logReplay.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { REVEAL_TICK_MS, REVEAL_TICKS_TARGET, revealStep, useRevealedCount } from "./logReplay";
+
+describe("revealStep", () => {
+  it("reveals at least one line per tick", () => {
+    expect(revealStep(0)).toBe(1);
+    expect(revealStep(1)).toBe(1);
+    expect(revealStep(REVEAL_TICKS_TARGET)).toBe(1);
+  });
+
+  it("scales so any backlog finishes within the tick target", () => {
+    for (const total of [41, 200, 999, 10_000]) {
+      const step = revealStep(total);
+      expect(Math.ceil(total / step)).toBeLessThanOrEqual(REVEAL_TICKS_TARGET);
+    }
+  });
+});
+
+describe("useRevealedCount", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const tick = () => act(() => vi.advanceTimersByTime(REVEAL_TICK_MS));
+
+  it("replays a backlog progressively and finishes within the tick target", () => {
+    const { result } = renderHook(({ total }) => useRevealedCount(total), {
+      initialProps: { total: 200 },
+    });
+    // Starts hidden, reveals in steps — never a full dump on first render.
+    expect(result.current).toBe(0);
+    tick();
+    expect(result.current).toBe(revealStep(200));
+    expect(result.current).toBeLessThan(200);
+
+    let ticks = 1;
+    while (result.current < 200 && ticks < REVEAL_TICKS_TARGET + 5) {
+      tick();
+      ticks++;
+    }
+    expect(result.current).toBe(200);
+    expect(ticks).toBeLessThanOrEqual(REVEAL_TICKS_TARGET);
+  });
+
+  it("switches to prompt live-append once caught up", () => {
+    const { result, rerender } = renderHook(({ total }) => useRevealedCount(total), {
+      initialProps: { total: 3 },
+    });
+    for (let i = 0; i < 5; i++) tick();
+    expect(result.current).toBe(3);
+
+    // A new live line surfaces within one tick.
+    rerender({ total: 4 });
+    expect(result.current).toBe(3);
+    tick();
+    expect(result.current).toBe(4);
+  });
+
+  it("never exceeds the total", () => {
+    const { result } = renderHook(({ total }) => useRevealedCount(total), {
+      initialProps: { total: 5 },
+    });
+    for (let i = 0; i < 20; i++) tick();
+    expect(result.current).toBe(5);
+  });
+});

--- a/controlplane/admin/ui/src/lib/logReplay.ts
+++ b/controlplane/admin/ui/src/lib/logReplay.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+// Progressive log replay: opening an operation page with an accumulated log
+// reveals it line-by-line like a live terminal instead of dumping everything
+// at once. The step is derived from the backlog size so ANY backlog finishes
+// within REVEAL_TICKS_TARGET ticks (~3.2s); once caught up, live appends
+// surface within a single tick.
+export const REVEAL_TICK_MS = 80;
+export const REVEAL_TICKS_TARGET = 40;
+
+// revealStep is how many lines one tick reveals for a log of `total` lines:
+// at least 1, and enough that total/step ≤ REVEAL_TICKS_TARGET.
+export function revealStep(total: number): number {
+  return Math.max(1, Math.ceil(total / REVEAL_TICKS_TARGET));
+}
+
+// useRevealedCount returns how many of `total` items should be visible:
+// starts at 0 and climbs by revealStep(total) per tick until it catches up.
+// Monotonic (never goes backwards) and never exceeds total.
+export function useRevealedCount(total: number): number {
+  const [revealed, setRevealed] = useState(0);
+  useEffect(() => {
+    if (revealed >= total) return;
+    const t = setTimeout(() => {
+      setRevealed((r) => Math.min(total, r + revealStep(total)));
+    }, REVEAL_TICK_MS);
+    return () => clearTimeout(t);
+  }, [total, revealed]);
+  return Math.min(revealed, total);
+}

--- a/controlplane/admin/ui/src/lib/reshard.test.ts
+++ b/controlplane/admin/ui/src/lib/reshard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { classifySecretName } from "./reshard";
+
+describe("classifySecretName", () => {
+  it("accepts the duckling-* convention the ESO policy allows", () => {
+    expect(classifySecretName("duckling-acme-managed-warehouse-dev-us-east-1-rds-password")).toBe("ok");
+    expect(classifySecretName("posthog-warehouse-thing")).toBe("ok");
+    expect(classifySecretName("  duckling-x-rds-password  ")).toBe("ok");
+  });
+
+  it("flags RDS-managed master secrets (never ESO-readable)", () => {
+    expect(classifySecretName("rds/duckling-example-managed-warehouse-dev/master")).toBe("rds-managed");
+    expect(classifySecretName("rds!db-12345678-abcd")).toBe("rds-managed");
+    expect(classifySecretName("rds!cluster-12345678")).toBe("rds-managed");
+  });
+
+  it("soft-warns on names outside the known prefixes", () => {
+    expect(classifySecretName("my-own-secret")).toBe("unknown-prefix");
+    // A bare prefix without the hyphen doesn't match the IAM glob (`duckling-*`).
+    expect(classifySecretName("ducklingfoo")).toBe("unknown-prefix");
+    expect(classifySecretName("rdsish-name")).toBe("unknown-prefix");
+  });
+
+  it("treats empty as its own state (no warning while typing)", () => {
+    expect(classifySecretName("")).toBe("empty");
+    expect(classifySecretName("   ")).toBe("empty");
+  });
+});

--- a/controlplane/admin/ui/src/lib/reshard.ts
+++ b/controlplane/admin/ui/src/lib/reshard.ts
@@ -1,0 +1,20 @@
+// Client-side guidance for the cnpg→external reshard form's AWS Secrets
+// Manager secret name. The composition wires an ESO ExternalSecret that reads
+// the secret with the external-secrets IAM role, whose policy only allows
+// GetSecretValue on a per-environment name-prefix allowlist — `posthog-*` and
+// `duckling-*` in every managed-warehouse environment (see the
+// external-secrets-pod-identity terraform module in posthog-cloud-infra). An
+// RDS-managed master secret (`rds!db-…` / `rds/…/master`) never matches, so
+// the cutover would hang on an ESO AccessDenied; the server rejects those
+// with a 400 and the form warns before submit. Names outside the known
+// prefixes only WARN (soft): the prefix list is per-environment terraform and
+// the console can't know its environment's extras.
+export type SecretNameVerdict = "empty" | "rds-managed" | "unknown-prefix" | "ok";
+
+export function classifySecretName(name: string): SecretNameVerdict {
+  const n = name.trim();
+  if (n === "") return "empty";
+  if (/^rds[/!]/.test(n)) return "rds-managed";
+  if (!/^(duckling|posthog)-/.test(n)) return "unknown-prefix";
+  return "ok";
+}

--- a/controlplane/admin/ui/src/pages/ReshardForm.tsx
+++ b/controlplane/admin/ui/src/pages/ReshardForm.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ducklingEntryFor } from "@/lib/format";
+import { classifySecretName } from "@/lib/reshard";
 import { useDucklingsMetadata, useReshardTargets, useStartReshard, useWarehouse } from "@/hooks/useApi";
 import type { StartReshardBody } from "@/types/api";
 
@@ -71,6 +72,7 @@ export function ReshardForm() {
   const knownExternal = targets.data?.external_stores ?? [];
 
   const effectiveShard = shard === "__custom__" ? shardCustom.trim() : shard;
+  const secretVerdict = classifySecretName(passwordSecret);
   const targetLabel =
     targetType === "cnpg-shard" ? `cnpg ${effectiveShard || "?"}` : `external ${endpoint || "?"}`;
   const sourceLabel =
@@ -250,9 +252,24 @@ export function ReshardForm() {
                     <Input
                       value={passwordSecret}
                       onChange={(e) => setPasswordSecret(e.target.value)}
-                      placeholder="posthog-warehouse-…"
+                      placeholder="duckling-<name>-…-rds-password"
                       className="font-mono text-xs"
                     />
+                    {secretVerdict === "rds-managed" && (
+                      <p className="flex items-start gap-1 text-xs text-destructive">
+                        <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                        This looks like the RDS-managed master secret (rds/…/master or rds!…) — the
+                        ESO role can NOT read it, so the cutover would hang and roll back. Create a
+                        secret named duckling-…-rds-password holding the same password and use that.
+                      </p>
+                    )}
+                    {secretVerdict === "unknown-prefix" && (
+                      <p className="flex items-start gap-1 text-xs text-warning">
+                        <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                        Name doesn't start with duckling- or posthog- — the ESO role can only read
+                        secrets matching its allowed name prefixes. Double-check before running.
+                      </p>
+                    )}
                   </div>
                   <div className="space-y-1">
                     <Label>User</Label>
@@ -267,6 +284,18 @@ export function ReshardForm() {
                     />
                   </div>
                 </div>
+                <p className="rounded-md border border-border bg-background/40 px-3 py-2 text-xs text-muted-foreground">
+                  The secret must live in this account's Secrets Manager with a{" "}
+                  <span className="font-mono">duckling-*</span> or{" "}
+                  <span className="font-mono">posthog-*</span> name (the only prefixes the
+                  external-secrets role may read — e.g.{" "}
+                  <span className="font-mono">duckling-&lt;name&gt;-&lt;env&gt;-&lt;region&gt;-rds-password</span>
+                  ), and its value must be the <strong>raw password string</strong> — ESO copies the
+                  whole value verbatim, so JSON like{" "}
+                  <span className="font-mono">{'{"password": …}'}</span> will not work. The
+                  RDS-managed master secret (<span className="font-mono">rds/…/master</span>) will
+                  NOT work — the ESO role can't read it.
+                </p>
                 <div className="space-y-1">
                   <Label>Password (sent once, never stored)</Label>
                   <Input
@@ -276,8 +305,9 @@ export function ReshardForm() {
                     className="font-mono text-xs"
                   />
                   <p className="text-xs text-muted-foreground">
-                    Used directly for the catalog copy. The AWS secret above must contain the same
-                    value — the duckling reads it via ESO after the cutover.
+                    Used directly for the catalog copy. The AWS secret above must contain exactly
+                    this value as a plain string — the duckling reads it via ESO after the cutover
+                    and the runner refuses to finish if they differ.
                   </p>
                 </div>
               </div>

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -25,7 +25,24 @@ var ducklingGVR = schema.GroupVersionResource{
 	Resource: "ducklings",
 }
 
+// externalSecretGVR is the ESO ExternalSecret CRD. The Duckling composition
+// renders one per external-metadata-store tenant (apiVersion
+// external-secrets.io/v1 in the charts repo's crossplane-config composition).
+var externalSecretGVR = schema.GroupVersionResource{
+	Group:    "external-secrets.io",
+	Version:  "v1",
+	Resource: "externalsecrets",
+}
+
 const ducklingNamespace = "ducklings"
+
+// ExternalSecretName is the composition's name for the ESO object that syncs
+// a tenant's external metadata-store password from AWS Secrets Manager into
+// the duckling namespace (charts: crossplane-config composition.yaml renders
+// `printf "duckling-%s-password" <duckling name>`).
+func ExternalSecretName(ducklingName string) string {
+	return fmt.Sprintf("duckling-%s-password", ducklingName)
+}
 
 // DucklingStatus holds the parsed status from a Duckling CR.
 // The Duckling composition provisions AWS infrastructure (S3, IAM) and the
@@ -313,6 +330,44 @@ func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus,
 		return nil, fmt.Errorf("get duckling CR %q: %w", name, err)
 	}
 	return parseDucklingStatus(cr)
+}
+
+// ExternalSecretSyncError reads the tenant's password ExternalSecret
+// (duckling-<name>-password) and reports its sync failure, if any: a
+// Ready=False condition yields "<reason>: <message>" (e.g. the
+// AccessDeniedException ESO gets when the SM secret name is outside its IAM
+// policy's allowed patterns). Returns "" when the object is healthy or
+// carries no failing condition. A read error (RBAC Forbidden, CRD absent,
+// object not created yet) is returned as err — callers treat the whole call
+// as best-effort diagnostics and MUST degrade quietly, never fail an
+// operation on it.
+func (d *DucklingClient) ExternalSecretSyncError(ctx context.Context, name string) (string, error) {
+	es, err := d.client.Resource(externalSecretGVR).Namespace(ducklingNamespace).Get(ctx, ExternalSecretName(name), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	status, _ := es.Object["status"].(map[string]interface{})
+	conditions, _ := status["conditions"].([]interface{})
+	for _, c := range conditions {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if getNestedString(cm, "type") != "Ready" || getNestedString(cm, "status") == "True" {
+			continue
+		}
+		reason := getNestedString(cm, "reason")
+		msg := getNestedString(cm, "message")
+		switch {
+		case reason != "" && msg != "":
+			return reason + ": " + msg, nil
+		case msg != "":
+			return msg, nil
+		default:
+			return reason, nil
+		}
+	}
+	return "", nil
 }
 
 // ComposedResourceError describes one composed managed resource that is not

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -1,0 +1,91 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// newFakeESOClient builds a DucklingClient over a fake dynamic client that
+// knows the ExternalSecret kind, optionally seeded with one ExternalSecret
+// carrying the given status conditions.
+func newFakeESOClient(t *testing.T, name string, conditions []interface{}) *DucklingClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "external-secrets.io", Version: "v1", Kind: "ExternalSecret",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "external-secrets.io", Version: "v1", Kind: "ExternalSecretList",
+	}, &unstructured.UnstructuredList{})
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	if name != "" {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ExternalSecret",
+			"metadata":   map[string]interface{}{"name": name, "namespace": ducklingNamespace},
+		}}
+		if conditions != nil {
+			obj.Object["status"] = map[string]interface{}{"conditions": conditions}
+		}
+		if _, err := fakeClient.Resource(externalSecretGVR).Namespace(ducklingNamespace).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed ExternalSecret: %v", err)
+		}
+	}
+	return NewDucklingClientWithDynamic(fakeClient)
+}
+
+// TestExternalSecretSyncError pins the diagnostic read: name derivation
+// (duckling-<name>-password), Ready=False → "reason: message", healthy → "",
+// and a missing object → error (the caller's degrade-quietly signal).
+func TestExternalSecretSyncError(t *testing.T) {
+	t.Run("sync error surfaces reason and message", func(t *testing.T) {
+		dc := newFakeESOClient(t, "duckling-org-a-password", []interface{}{
+			map[string]interface{}{
+				"type": "Ready", "status": "False",
+				"reason":  "SecretSyncedError",
+				"message": "AccessDeniedException: not authorized to perform secretsmanager:GetSecretValue",
+			},
+		})
+		msg, err := dc.ExternalSecretSyncError(context.Background(), "org-a")
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if !strings.HasPrefix(msg, "SecretSyncedError: AccessDeniedException") {
+			t.Fatalf("msg = %q, want reason+message", msg)
+		}
+	})
+
+	t.Run("healthy yields empty", func(t *testing.T) {
+		dc := newFakeESOClient(t, "duckling-org-a-password", []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "True", "reason": "SecretSynced"},
+		})
+		msg, err := dc.ExternalSecretSyncError(context.Background(), "org-a")
+		if err != nil || msg != "" {
+			t.Fatalf("msg=%q err=%v, want empty and nil", msg, err)
+		}
+	})
+
+	t.Run("no status yields empty", func(t *testing.T) {
+		dc := newFakeESOClient(t, "duckling-org-a-password", nil)
+		msg, err := dc.ExternalSecretSyncError(context.Background(), "org-a")
+		if err != nil || msg != "" {
+			t.Fatalf("msg=%q err=%v, want empty and nil", msg, err)
+		}
+	})
+
+	t.Run("missing object errors (degrade signal)", func(t *testing.T) {
+		dc := newFakeESOClient(t, "", nil)
+		if _, err := dc.ExternalSecretSyncError(context.Background(), "org-a"); err == nil {
+			t.Fatal("want an error for a missing ExternalSecret")
+		}
+	})
+}

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -83,6 +83,12 @@ type reshardDucklingClient interface {
 	SetCompactionEnabled(ctx context.Context, name string, enabled *bool) error
 	SetMetadataStoreCnpg(ctx context.Context, name, shard string) error
 	SetMetadataStoreExternal(ctx context.Context, name string, ext ExternalMetadataStoreSpec) error
+	// ExternalSecretSyncError is a best-effort diagnostic read of the
+	// tenant's password ExternalSecret (duckling-<name>-password): a failing
+	// sync yields its reason+message, a healthy one yields "". err means the
+	// object couldn't be read (RBAC, CRD absent, not created yet) — callers
+	// degrade quietly and never fail the operation on it.
+	ExternalSecretSyncError(ctx context.Context, name string) (string, error)
 }
 
 // NewReshardRunner builds a runner over the real config store + duckling
@@ -656,6 +662,7 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 	providedPassword := o.target.Password
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastESOWarn := ""
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -663,7 +670,7 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 		// No cancel check: past this flip the only ways out are forward or
 		// the copy-back recovery in rollback().
 		if time.Now().After(deadline) {
-			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing or wrong?)", o.flipTimeout(), o.op.TargetPasswordSecret)
+			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string)", o.flipTimeout(), o.op.TargetPasswordSecret)
 		}
 
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
@@ -677,6 +684,20 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 			if st.ReadyCondition {
 				o.logf("info", "external target ready: ESO password synced and matches, duckling Ready")
 				return nil
+			}
+		}
+		// Diagnostic: when the status password hasn't landed, the usual
+		// culprit is the ESO sync — e.g. an SM secret name outside the ESO
+		// IAM policy's allowed patterns (an RDS-managed rds/…/master secret
+		// is never readable). Surface the ExternalSecret's own failure at
+		// warn, deduped by content so it doesn't repeat every poll. A read
+		// error (RBAC Forbidden, CRD absent, object not rendered yet)
+		// degrades quietly to the generic waiting line below.
+		if err == nil && st.MetadataStore.Password == "" {
+			if esoMsg, esoErr := o.r.duckling.ExternalSecretSyncError(ctx, o.op.DucklingName); esoErr == nil && esoMsg != "" && esoMsg != lastESOWarn {
+				o.logf("warn", "ExternalSecret %q is failing to sync secret %q: %s — the ESO role can only read allowed secret NAME patterns (e.g. duckling-*); an RDS-managed master secret (rds/…/master) will NOT work",
+					ExternalSecretName(o.op.DucklingName), o.op.TargetPasswordSecret, esoMsg)
+				lastESOWarn = esoMsg
 			}
 		}
 		if time.Since(lastLog) >= 15*time.Second {

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -175,14 +175,19 @@ func (f *fakeReshardStore) RetireHotIdleWorker(record *configstore.WorkerRecord)
 }
 
 func (f *fakeReshardStore) hasLog(substr string) bool {
+	return f.countLog(substr) > 0
+}
+
+func (f *fakeReshardStore) countLog(substr string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	n := 0
 	for _, l := range f.logs {
 		if strings.Contains(l, substr) {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
 }
 
 type ducklingCall struct {
@@ -247,6 +252,10 @@ func (f *fakeDuckling) SetMetadataStoreExternal(_ context.Context, _ string, ext
 	f.status.MetadataStore.Password = "ext-pw" // what "ESO" synced
 	f.status.ReadyCondition = true
 	return nil
+}
+
+func (f *fakeDuckling) ExternalSecretSyncError(context.Context, string) (string, error) {
+	return "", nil
 }
 
 func (f *fakeDuckling) callKinds() []string {
@@ -671,6 +680,124 @@ func TestReshardExtTargetWithoutPasswordFails(t *testing.T) {
 	}
 	if store.warehouseState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("warehouse state = %s, want ready after rollback", store.warehouseState)
+	}
+}
+
+// stuckExternalDuckling flips the type but never populates the status
+// password (ESO never syncs), and scripts ExternalSecretSyncError.
+type stuckExternalDuckling struct {
+	*fakeDuckling
+	esoErr   error  // non-nil: every diagnostic read fails (degrade path)
+	esoMsgA  string // returned for the first esoSwitchAt calls
+	esoMsgB  string // returned after (empty = keep A)
+	esoCalls int
+	// esoSwitchAt is the call count after which esoMsgB is returned.
+	esoSwitchAt int
+}
+
+func (s *stuckExternalDuckling) SetMetadataStoreExternal(_ context.Context, _ string, ext ExternalMetadataStoreSpec) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, ducklingCall{kind: "external", ext: ext})
+	s.status.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	s.status.MetadataStore.Endpoint = ext.Endpoint
+	s.status.MetadataStore.Password = "" // ESO never syncs
+	s.status.ReadyCondition = false
+	return nil
+}
+
+func (s *stuckExternalDuckling) ExternalSecretSyncError(context.Context, string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.esoErr != nil {
+		return "", s.esoErr
+	}
+	s.esoCalls++
+	if s.esoMsgB != "" && s.esoCalls > s.esoSwitchAt {
+		return s.esoMsgB, nil
+	}
+	return s.esoMsgA, nil
+}
+
+func stuckExtOp() *configstore.ReshardOperation {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "rds/duckling-example/master"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	op.CutoverTimeoutSeconds = 1
+	return op
+}
+
+// TestReshardExtFlipSurfacesESOSyncError pins the diagnostic added for the
+// hung cnpg→ext cutover: when the status password never lands and the
+// tenant's ExternalSecret reports a sync failure (e.g. AccessDenied on an SM
+// secret name outside the ESO policy), the failure is logged at warn —
+// exactly once per distinct message (deduped across the poll loop), again
+// when the message changes.
+func TestReshardExtFlipSurfacesESOSyncError(t *testing.T) {
+	store := newFakeReshardStore(stuckExtOp())
+	duckling := &stuckExternalDuckling{
+		fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()},
+		esoMsgA:      "SecretSyncedError: AccessDeniedException: not authorized to perform secretsmanager:GetSecretValue",
+		esoMsgB:      "SecretSyncedError: some other failure",
+		esoSwitchAt:  10,
+	}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(store.op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "did not become ready") {
+		t.Fatalf("state=%s err=%q, want flip-timeout failure", store.op.State, store.op.Error)
+	}
+	// The poll loop saw each message dozens of times; the warn must appear
+	// exactly once per distinct message.
+	if n := store.countLog("AccessDeniedException"); n != 1 {
+		t.Fatalf("AccessDenied ESO warn logged %d times, want exactly 1 (deduped): %v", n, store.logs)
+	}
+	if n := store.countLog("some other failure"); n != 1 {
+		t.Fatalf("changed ESO message logged %d times, want exactly 1: %v", n, store.logs)
+	}
+	if !store.hasLog(`ExternalSecret "duckling-org-a-password" is failing to sync`) {
+		t.Fatalf("ESO warn missing the ExternalSecret name: %v", store.logs)
+	}
+	// The op still recovers (flip-back + copy-back) and unblocks.
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
+	}
+}
+
+// TestReshardExtFlipESOReadErrorDegrades pins the degrade contract: when the
+// ExternalSecret can't be read at all (RBAC Forbidden, CRD absent), the
+// runner keeps the generic waiting line, never logs a bogus ESO warn, and
+// the diagnostic never fails or blocks the operation.
+func TestReshardExtFlipESOReadErrorDegrades(t *testing.T) {
+	store := newFakeReshardStore(stuckExtOp())
+	duckling := &stuckExternalDuckling{
+		fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()},
+		esoErr:       fmt.Errorf("externalsecrets.external-secrets.io is forbidden"),
+	}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(store.op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "did not become ready") {
+		t.Fatalf("state=%s err=%q, want flip-timeout failure", store.op.State, store.op.Error)
+	}
+	if store.hasLog("failing to sync") {
+		t.Fatalf("ESO warn logged despite the read failing: %v", store.logs)
+	}
+	if !store.hasLog("waiting for external target") {
+		t.Fatalf("generic waiting line missing: %v", store.logs)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
 	}
 }
 

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -112,6 +112,30 @@ resume (password lost); the new runner fails the op with a clear re-run
 message. After the flip, the runner checks the ESO-synced status password
 matches the provided one (catches a wrong/missing SM secret).
 
+**The SM secret name and value are constrained by the ESO wiring.** After the
+flip, the composition renders an ExternalSecret
+(`duckling-<name>-password` in the duckling namespace, store
+`aws-cluster-secret-store`) whose `remoteRef.key` is the typed secret NAME
+with no `property` — ESO copies the **whole secret value verbatim** into the
+k8s Secret key `password`, so the value must be the **raw password string**
+(JSON like `{"password": …}` breaks the equality check). The external-secrets
+IAM role can only `GetSecretValue` on a per-env name-prefix allowlist —
+`posthog-*` and `duckling-*` in every managed-warehouse env (see the
+`external-secrets-pod-identity` terraform module in posthog-cloud-infra) —
+so an RDS-managed master secret (`rds!db-…` / `rds/…/master`) is NEVER
+readable and would hang the cutover on an ESO AccessDenied. Defenses, outer
+to inner: the reshard form documents the convention
+(`duckling-<name>-<env>-<region>-rds-password`) and warns live on suspicious
+names (`classifySecretName`); the start handler 400s names matching
+`^rds[!/]` (`rdsManagedSecretNamePattern`); and during the cutover wait the
+runner reads the tenant's ExternalSecret (best-effort, via the duckling
+client's dynamic client — `ExternalSecretSyncError`) and, while the status
+password is still empty, surfaces a failing sync condition (reason+message,
+e.g. the AccessDenied) into the op log at warn, deduped by content. A
+diagnostic read error (RBAC Forbidden — the CP has no `external-secrets.io`
+grant today, CRD absent, object not rendered yet) degrades quietly to the
+generic waiting line and never fails the op.
+
 **Recovery if the flip goes bad** (ESO secret missing/mismatched): flip back
 to the source shard — provider-sql re-creates the role/DB **empty** — then
 copy back from the external target, whose data passed verify. The one path

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2228,6 +2228,11 @@ duckling_shard_backfill() { # cnpgOrg
 #     shard-001, data intact after, report in the log)
 # cnpg→ext stays unit-test-only: the harness knows the RDS SM secret NAME but
 # not the password, and the start API requires the password (ephemerally).
+# That also keeps the in-cutover ESO-sync-error surfacing (the deduped warn in
+# flipToExternal when the ExternalSecret is SecretSyncedError) unit-test-only
+# (provisioner/reshard_runner_test.go): asserting it live needs a real
+# cnpg→ext flip against an unreadable secret. The validation loop below does
+# pin the rds-master-name 400, the up-front defense for the same failure.
 
 reshard_post() { # org body
   curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' -d "$2" \
@@ -2283,11 +2288,17 @@ reshard_targets() { # destination discovery; ext org's RDS must appear too
 
 reshard_validation() { # cnpg-org currently on shard-001
   log "reshard validation: same-shard + bad targets are 400"
+  # The last two pin the RDS-managed-master-secret rejection: names matching
+  # rds/… or rds!… are outside the ESO IAM policy's allowed prefixes
+  # (posthog-*/duckling-*), so a cutover pointed at one would hang on an ESO
+  # AccessDenied — the start handler refuses them up front.
   for body in \
     '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-001"}}' \
     '{"target":{"type":"cnpg-shard","cnpg_shard":"Bad_Shard"}}' \
     '{"target":{"type":"nonsense"}}' \
-    '{"target":{"type":"external","endpoint":"x"}}'; do
+    '{"target":{"type":"external","endpoint":"x"}}' \
+    '{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds/some-db/master","password":"p"}}' \
+    '{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-0000-1111","password":"p"}}'; do
     code="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "$H" -H 'Content-Type: application/json' \
       -d "$body" "$API/api/v1/orgs/$1/reshard")"
     [ "$code" = "400" ] || fail "reshard validation: body $body -> $code, want 400"


### PR DESCRIPTION
## Why

A real cnpg→ext reshard hung indefinitely at `waiting for external target (ESO password sync + Ready condition)`. Root cause: the typed AWS SM secret name was the **RDS-managed master secret** (`rds/…/master`), which is outside the name patterns the external-secrets (ESO) IAM role may read — the composition's ExternalSecret sat in `SecretSyncedError` (`AccessDeniedException` on `secretsmanager:GetSecretValue`), the duckling `status.metadataStore.password` never populated, and the runner waited until the cutover timeout with only a generic message.

Authoritative constraints (from infra + charts):

- **Secret NAME**: the ESO role's policy allows `GetSecretValue` only on `posthog-*` and `duckling-*` (plus an unrelated wiz prefix) in **every** managed-warehouse environment (dev, prod-us, prod-eu — `external-secrets-pod-identity` terraform module + per-env `additional_secret_prefixes = ["duckling"]`). RDS-managed master secrets (`rds!db-…`, `rds/…/master`) never match. The working convention is `duckling-<name>-<env>-<region>-rds-password`.
- **Secret VALUE**: the composition's ExternalSecret (`duckling-<name>-password`, `external-secrets.io/v1`, `ClusterSecretStore aws-cluster-secret-store`) uses `spec.data[].remoteRef` with only `key` — no `property`, no `dataFrom` — so ESO copies the **whole secret value verbatim** into the k8s Secret key `password`. The value must be the raw password string; JSON like `{"password": …}` breaks the post-flip equality check.

## What

**1. Surface the ESO sync error in the op log** (`provisioner/reshard_runner.go`, `k8s_client.go`)
- New `DucklingClient.ExternalSecretSyncError`: reads `duckling-<name>-password` in the duckling namespace via the existing dynamic client and returns a failing `Ready` condition's `reason: message`.
- `flipToExternal`'s wait loop calls it while the status password is still empty and logs the failure at **warn**, deduped by content (a changed message logs again). Any diagnostic read error — RBAC Forbidden, CRD absent, object not rendered yet — degrades quietly to the existing generic waiting line and can never fail the op. The cutover-timeout error message now also names the likely cause.
- Note: the CP's ServiceAccount currently has **no `external-secrets.io` RBAC** (only the duckling CRD + core secrets), so this diagnostic degrades to the generic message until a charts-side grant (e.g. `externalsecrets` get on the CP SA) lands — follow-up in the charts repo.

**2. Teach the form + API the secret rules** (`admin/reshard.go`, `ui/src/pages/ReshardForm.tsx`, `ui/src/lib/reshard.ts`)
- The form now documents, next to the secret-name field: the allowed prefixes (`duckling-*`/`posthog-*`), a concrete working example shape, the raw-string value requirement, and an explicit "the RDS master secret will NOT work".
- Live client-side warning (`classifySecretName`): hard red for `rds/…`/`rds!…` names, soft amber for names outside the known prefixes (soft because the prefix allowlist is per-env terraform).
- Server-side: the start handler **400s** names matching `^rds[!/]` with an explanation. This is safe to enforce universally: every managed-warehouse environment uses the same prefix allowlist and none admits `rds…` — verified in infra terraform. Names merely outside `duckling-*`/`posthog-*` are NOT rejected server-side (env-configurable allowlist), only warned about in the UI.

**3. Progressive log replay on the operation page** (`ui/src/hooks/useApi.ts`, `ui/src/lib/logReplay.ts`)
- Opening a running or finished reshard no longer dumps the accumulated log instantly: `useReshardLog` now reveals the backlog line-by-line (step sized so any backlog finishes within ~3.2s — 40 ticks × 80ms), then switches naturally to live-append (new lines surface within one tick). Auto-scroll and the terminal feel are unchanged (the page consumes the same growing array).

## Tests

- `provisioner/reshard_runner_test.go`: `TestReshardExtFlipSurfacesESOSyncError` (warn logged exactly once per distinct message across dozens of polls; recovery still runs) and `TestReshardExtFlipESOReadErrorDegrades` (read failure → generic line only, never an op failure).
- `provisioner/k8s_client_test.go` (new): `ExternalSecretSyncError` parsing against a fake dynamic client (name derivation, reason+message, healthy, missing-object error).
- `admin/reshard_test.go`: 400 for `rds/…/master` and `rds!db-…` names.
- UI vitest: `lib/reshard.test.ts` (name classification) and `lib/logReplay.test.tsx` (backlog replays within the tick target, live-append within one tick, never exceeds total). `npm run build` + `npm test` green (59 tests).
- e2e harness (`tests/mw-dev/e2e/harness.sh`): `reshard_validation` now pins the rds-master-name 400. The in-cutover ESO warn itself stays unit-only (needs a real cnpg→ext flip against an unreadable secret; the harness can't run cnpg→ext) — noted in the harness comment.
- Docs updated in the same PR: `docs/design/resharding.md` (secret name/value constraints + the three defenses), `CLAUDE.md` reshard section.

`go build ./...`, `go build -tags kubernetes ./...`, `go test -tags kubernetes ./controlplane/...` all pass locally (docker-gated `*Postgres` tests excluded — CI runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
