### PR TITLE
Make default_team_id NOT NULL and close the admin clear/create holes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,9 +463,11 @@ ceil(conn_secs)`. Counted internally in integer **millicore-seconds** /
 **MiB-seconds** (`compute_meter.go`) to avoid truncating a fractional-core /
 sub-GiB worker; worker size is stored in the bucket key as exact NUMERIC
 decimals (vCPU / GiB). `team_id` is the org's `default_team_id` (an integer —
-PostHog's `Team.id`; a JSON NUMBER on every API surface, BIGINT in the config
-store, 0 = "no default team"; resolved from the config snapshot at connection
-end); `query_source` is the
+PostHog's `Team.id`; a JSON NUMBER on every API surface, a **NOT NULL** BIGINT
+in the config store — required at org creation on both the provisioning and
+admin APIs, never clearable via the admin API, so every org always has one;
+resolved from the config snapshot at connection end, where 0 can still appear
+only for an unknown org / stale snapshot); `query_source` is the
 `duckgres.query_source` session GUC (`standard` unless set; a mid-connection
 change bills the whole connection under the final value). Invariants for anyone
 touching this path:

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -201,15 +201,12 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 			fields["hostname_alias"] = *updates.HostnameAlias
 		}
 	}
-	// DefaultTeamID is *int64: nil = preserve, 0 = clear (NULL), n = set.
-	// (PostHog team ids start at 1, so 0 is a safe clear sentinel; the
-	// handler also maps an explicit JSON null onto it.)
+	// DefaultTeamID is *int64: nil = preserve, n = set. There is no clear
+	// path — the column is NOT NULL (every org must keep a default team; it
+	// is the billing bucket key) and the handler rejects 0/null/negative
+	// before this runs.
 	if updates.DefaultTeamID != nil {
-		if *updates.DefaultTeamID == 0 {
-			fields["default_team_id"] = nil
-		} else {
-			fields["default_team_id"] = *updates.DefaultTeamID
-		}
+		fields["default_team_id"] = *updates.DefaultTeamID
 	}
 	result := s.db().Model(&configstore.Org{}).Where("name = ?", name).Updates(fields)
 	if result.Error != nil {
@@ -540,6 +537,14 @@ func (h *apiHandler) createOrg(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
 		return
 	}
+	// Every org must be born with its default PostHog team id — it is the
+	// billing bucket key and the column is NOT NULL (same invariant as the
+	// provisioning API's ErrDefaultTeamIDRequired). Positivity of a present
+	// value is enforced by validateOrgMutationPayload above.
+	if org.DefaultTeamID == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id is required (the org's default PostHog team id)"})
+		return
+	}
 	// Normalize empty hostname_alias to NULL on insert so the unique index
 	// doesn't reject a second org with an explicit empty string. Centralizing
 	// the rule at the handler layer keeps any future store impl from having
@@ -622,15 +627,15 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
 	if _, ok := fields["default_team_id"]; ok {
-		// Key present: a number sets, and an explicit JSON null (which
-		// unmarshals to a nil pointer) clears — normalize null onto the 0
-		// clear-sentinel so the store layer sees one shape.
+		// Key present: a positive number sets. Clearing is rejected — the
+		// column is NOT NULL (the org's default team is the billing bucket
+		// key). An explicit JSON null unmarshals to a nil pointer here; 0 and
+		// negatives are already rejected by validateOrgMutationPayload above.
 		if updates.DefaultTeamID == nil {
-			zero := int64(0)
-			merged.DefaultTeamID = &zero
-		} else {
-			merged.DefaultTeamID = updates.DefaultTeamID
+			c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id cannot be cleared (every org must keep a default team); pass a valid team id"})
+			return
 		}
+		merged.DefaultTeamID = updates.DefaultTeamID
 	}
 
 	// Audit detail: which fields changed and their old → new values, so the
@@ -719,7 +724,8 @@ func orgStrPtr(s *string) string {
 }
 
 // orgInt64Ptr renders an optional org config integer (nil or 0 == unset) for
-// audit detail.
+// audit detail. default_team_id is NOT NULL and never 0 nowadays, so
+// "(unset)" only ever renders for legacy display of rows predating that.
 func orgInt64Ptr(v *int64) string {
 	if v == nil || *v == 0 {
 		return "(unset)"
@@ -747,6 +753,13 @@ func validateOrgMutationPayload(org *configstore.Org) error {
 	}
 	if org.MaxVCPUs < 0 {
 		return fmt.Errorf("max_vcpus: value %d must be >= 0", org.MaxVCPUs)
+	}
+	// Shared by create and update: nil stays allowed here (create requires
+	// the field itself; update treats an absent field as "preserve"), but a
+	// present value must be a positive PostHog team id — the column is NOT
+	// NULL and 0 is never stored, so there is no clear sentinel.
+	if org.DefaultTeamID != nil && *org.DefaultTeamID <= 0 {
+		return fmt.Errorf("default_team_id: value %d must be a positive PostHog team id (it cannot be cleared — every org must keep a default team)", *org.DefaultTeamID)
 	}
 	return nil
 }

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -17,6 +17,14 @@ import (
 
 const testConfigStoreConnString = "host=127.0.0.1 port=35432 user=postgres password=postgres dbname=testdb sslmode=disable"
 
+// testDefaultTeamID returns a pointer to a placeholder PostHog team id for
+// seeded org rows — default_team_id is NOT NULL (migration 000020), so every
+// test fixture that inserts an org must carry one.
+func testDefaultTeamID() *int64 {
+	teamID := int64(1)
+	return &teamID
+}
+
 func newPostgresConfigStore(t *testing.T) *configstore.ConfigStore {
 	t.Helper()
 
@@ -100,7 +108,7 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 
@@ -165,7 +173,7 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics_db"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 	wh := &configstore.ManagedWarehouse{OrgID: "analytics", State: configstore.ManagedWarehouseStateReady}
@@ -205,7 +213,7 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 	}
 
 	// The database_name is now free for reuse (no unique-index squat).
-	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("expected database_name to be reusable after org deletion: %v", err)
 	}
 }
@@ -214,7 +222,7 @@ func TestMutateManagedWarehouseSerializesConcurrentWriters(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.ManagedWarehouse{

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -79,6 +79,12 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 			org.HostnameAlias = &alias
 		}
 	}
+	// Mirrors gormAPIStore: nil = preserve, n = set. No clear path — the
+	// column is NOT NULL and the handler rejects 0/null/negative.
+	if updates.DefaultTeamID != nil {
+		teamID := *updates.DefaultTeamID
+		org.DefaultTeamID = &teamID
+	}
 	return copyOrg(org), true, nil
 }
 
@@ -1404,7 +1410,7 @@ func TestCreateOrgPersistsHostnameAlias(t *testing.T) {
 	store := newFakeAPIStore()
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"name":"tenant-alpha-id","database_name":"tenant_alpha","hostname_alias":"entirely-chief-wildcat"}`)
+	body := []byte(`{"name":"tenant-alpha-id","database_name":"tenant_alpha","hostname_alias":"entirely-chief-wildcat","default_team_id":12345}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1426,7 +1432,7 @@ func TestCreateOrgEmptyHostnameAliasIsTreatedAsNone(t *testing.T) {
 	store := newFakeAPIStore()
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"name":"plain","database_name":"plain","hostname_alias":""}`)
+	body := []byte(`{"name":"plain","database_name":"plain","hostname_alias":"","default_team_id":12345}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1511,7 +1517,7 @@ func TestCreateOrgAcceptsLongValidHostnameAlias(t *testing.T) {
 
 	// 63 chars exactly — at the RFC 1035 DNS label limit.
 	alias := strings.Repeat("a", 63)
-	body := []byte(fmt.Sprintf(`{"name":"acme","database_name":"acme","hostname_alias":%q}`, alias))
+	body := []byte(fmt.Sprintf(`{"name":"acme","database_name":"acme","hostname_alias":%q,"default_team_id":12345}`, alias))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1527,7 +1533,7 @@ func TestCreateOrgRejectsHostnameAliasOver63Chars(t *testing.T) {
 	router := newTestAPIRouter(store)
 
 	alias := strings.Repeat("a", 64) // one over the limit
-	body := []byte(fmt.Sprintf(`{"name":"acme","database_name":"acme","hostname_alias":%q}`, alias))
+	body := []byte(fmt.Sprintf(`{"name":"acme","database_name":"acme","hostname_alias":%q,"default_team_id":12345}`, alias))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1560,6 +1566,163 @@ func TestUpdateOrgOmittingHostnameAliasPreservesIt(t *testing.T) {
 	stored := store.orgs["tenant-alpha-id"]
 	if stored.HostnameAlias == nil || *stored.HostnameAlias != "entirely-chief-wildcat" {
 		t.Errorf("HostnameAlias not preserved: %v", stored.HostnameAlias)
+	}
+}
+
+func TestCreateOrgRequiresDefaultTeamID(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"name":"acme","database_name":"acme"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "default_team_id") {
+		t.Fatalf("rejection should name default_team_id: %s", rec.Body.String())
+	}
+	if _, ok := store.orgs["acme"]; ok {
+		t.Fatal("org should NOT have been created without default_team_id")
+	}
+}
+
+func TestCreateOrgRejectsNonPositiveDefaultTeamID(t *testing.T) {
+	for _, teamID := range []int64{0, -5} {
+		t.Run(fmt.Sprintf("team_id=%d", teamID), func(t *testing.T) {
+			store := newFakeAPIStore()
+			router := newTestAPIRouter(store)
+
+			body := []byte(fmt.Sprintf(`{"name":"acme","database_name":"acme","default_team_id":%d}`, teamID))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "default_team_id") {
+				t.Fatalf("rejection should name default_team_id: %s", rec.Body.String())
+			}
+			if _, ok := store.orgs["acme"]; ok {
+				t.Fatal("org should NOT have been created")
+			}
+		})
+	}
+}
+
+func TestCreateOrgPersistsDefaultTeamID(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"name":"acme","database_name":"acme","default_team_id":42424}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored == nil || stored.DefaultTeamID == nil || *stored.DefaultTeamID != 42424 {
+		t.Fatalf("DefaultTeamID = %v, want pointer to 42424", stored.DefaultTeamID)
+	}
+}
+
+// TestUpdateOrgRejectsClearingDefaultTeamID pins the closed hole: the column is
+// NOT NULL, so the old clear semantics (0 or explicit JSON null → NULL) must be
+// rejected with a 400 and must not mutate the stored value. Negative values are
+// rejected too.
+func TestUpdateOrgRejectsClearingDefaultTeamID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"zero clear sentinel", `{"default_team_id":0}`},
+		{"explicit JSON null", `{"default_team_id":null}`},
+		{"negative", `{"default_team_id":-3}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAPIStore()
+			teamID := int64(12345)
+			store.orgs["acme"] = &configstore.Org{
+				Name:          "acme",
+				DatabaseName:  "acme",
+				DefaultTeamID: &teamID,
+			}
+			router := newTestAPIRouter(store)
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "default_team_id") {
+				t.Fatalf("rejection should name default_team_id: %s", rec.Body.String())
+			}
+			stored := store.orgs["acme"]
+			if stored.DefaultTeamID == nil || *stored.DefaultTeamID != 12345 {
+				t.Fatalf("DefaultTeamID mutated by rejected PUT: %v, want 12345", stored.DefaultTeamID)
+			}
+		})
+	}
+}
+
+func TestUpdateOrgOmittingDefaultTeamIDPreservesIt(t *testing.T) {
+	store := newFakeAPIStore()
+	teamID := int64(12345)
+	store.orgs["acme"] = &configstore.Org{
+		Name:          "acme",
+		DatabaseName:  "acme",
+		DefaultTeamID: &teamID,
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"max_workers":8}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultTeamID == nil || *stored.DefaultTeamID != 12345 {
+		t.Fatalf("DefaultTeamID not preserved: %v, want 12345", stored.DefaultTeamID)
+	}
+}
+
+func TestUpdateOrgSetsDefaultTeamID(t *testing.T) {
+	store := newFakeAPIStore()
+	teamID := int64(12345)
+	store.orgs["acme"] = &configstore.Org{
+		Name:          "acme",
+		DatabaseName:  "acme",
+		DefaultTeamID: &teamID,
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"default_team_id":67890}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.DefaultTeamID == nil || *stored.DefaultTeamID != 67890 {
+		t.Fatalf("DefaultTeamID = %v, want 67890", stored.DefaultTeamID)
 	}
 }
 
@@ -1897,7 +2060,7 @@ func TestCreateOrgAcceptsDefaultWorkerProfile(t *testing.T) {
 	store := newFakeAPIStore()
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"name":"acme","database_name":"acme","default_worker_cpu":"2","default_worker_memory":"8Gi","default_worker_ttl":"75m"}`)
+	body := []byte(`{"name":"acme","database_name":"acme","default_worker_cpu":"2","default_worker_memory":"8Gi","default_worker_ttl":"75m","default_team_id":12345}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1917,7 +2080,7 @@ func TestCreateOrgAcceptsDefaultWorkerMinHotIdle(t *testing.T) {
 	store := newFakeAPIStore()
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"name":"acme","database_name":"acme","default_worker_min_hot_idle":1}`)
+	body := []byte(`{"name":"acme","database_name":"acme","default_worker_min_hot_idle":1,"default_team_id":12345}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/controlplane/admin/models_api_test.go
+++ b/controlplane/admin/models_api_test.go
@@ -81,7 +81,7 @@ func TestModelsAPIPostgres(t *testing.T) {
 	store := newPostgresConfigStore(t)
 
 	const secretHash = "$2a$10$DEADBEEFdeadbeefDEADBEEFdeadbeefDEADBEEFdeadbeefDEADBE"
-	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acme_db"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acme_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("seed org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.OrgUser{OrgID: "acme", Username: "reader", Password: secretHash}).Error; err != nil {

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -109,10 +109,12 @@ export function OrgDetail() {
   const save = async () => {
     setMsg(null);
     // default_team_id is an integer on the wire (PostHog team id); the text
-    // input needs a digits-only guard so junk can't silently clear it.
+    // input needs a digits-only guard so junk can't reach the backend. It is
+    // required (NOT NULL) server-side and cannot be cleared, so only a
+    // positive value is ever sent.
     const teamIdText = form.default_team_id.trim();
-    if (teamIdText !== "" && !/^\d+$/.test(teamIdText)) {
-      setMsg({ kind: "err", text: "Default team id must be a number (or empty to clear)." });
+    if (teamIdText !== "" && (!/^\d+$/.test(teamIdText) || Number(teamIdText) === 0)) {
+      setMsg({ kind: "err", text: "Default team id must be a positive number." });
       return;
     }
     const body: OrgUpdate = {
@@ -123,8 +125,12 @@ export function OrgDetail() {
       default_worker_ttl: form.default_worker_ttl,
       default_worker_min_hot_idle: Number(form.default_worker_min_hot_idle) || 0,
       hostname_alias: form.hostname_alias === "" ? "" : form.hostname_alias,
-      default_team_id: teamIdText === "" ? 0 : Number(teamIdText),
     };
+    // Empty input = preserve the stored value (omit the field). Sending 0 or
+    // null would be a clear, which the backend now rejects with a 400.
+    if (teamIdText !== "") {
+      body.default_team_id = Number(teamIdText);
+    }
     try {
       await update.mutateAsync(body);
       setMsg({ kind: "ok", text: "Saved." });
@@ -244,7 +250,7 @@ export function OrgDetail() {
                   onChange={(e) => set("hostname_alias", e.target.value)}
                 />
               </Field>
-              <Field label="Default team id (empty clears)">
+              <Field label="Default team id (required)">
                 <Input
                   value={form.default_team_id}
                   placeholder="PostHog team id, e.g. 12345"

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -66,7 +66,8 @@ export interface OrgUpdate {
   default_worker_ttl?: string;
   default_worker_min_hot_idle?: number;
   hostname_alias?: string | null;
-  // Number sets, 0 clears (backend maps 0 → NULL), absent preserves.
+  // Positive number sets, absent preserves. Clearing is not possible: the
+  // column is NOT NULL and the backend rejects 0/null/negative with a 400.
   default_team_id?: number;
 }
 

--- a/controlplane/compute_meter.go
+++ b/controlplane/compute_meter.go
@@ -153,7 +153,9 @@ type computeUsageStore interface {
 // meter (non-remote backend) leaves this nil and every call site no-ops.
 // resolveTeam maps an org to its default PostHog team id at record time (a
 // config-snapshot read — no I/O); 0 is tolerated per the OrgDefaultTeamID
-// contract and the bucket then carries team_id 0 ("no default team").
+// contract and the bucket then carries team_id 0. The column is NOT NULL and
+// required at org creation, so 0 can only mean an unknown org or a
+// not-yet-loaded snapshot — never a stored "no default team".
 type computeMeter struct {
 	counter     *computeUsageCounter
 	store       computeUsageStore

--- a/controlplane/configstore/migrations/000020_default_team_id_not_null.sql
+++ b/controlplane/configstore/migrations/000020_default_team_id_not_null.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+-- default_team_id becomes NOT NULL: every org must carry its default PostHog
+-- team id (the compute/storage billing bucket key). All orgs in all envs have
+-- been backfilled, and every create path (provisioning API, admin API) already
+-- requires a positive team id, so no NULL should exist. If one does, this
+-- migration fails loudly at deploy — which is the correct outcome: fix the
+-- row, not the constraint. The admin API's clear-to-NULL semantics were
+-- removed alongside this migration, so nothing can reintroduce a NULL.
+ALTER TABLE duckgres_orgs
+    ALTER COLUMN default_team_id SET NOT NULL;
+
+-- +goose Down
+
+ALTER TABLE duckgres_orgs
+    ALTER COLUMN default_team_id DROP NOT NULL;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -28,10 +28,12 @@ type Org struct {
 	// DefaultTeamID links the org to its default PostHog team id (an integer,
 	// matching PostHog's Team.id). It is a prerequisite for pull-based compute
 	// billing — usage buckets are keyed by team_id = the org's default team.
-	// *int64 so the column is a nullable BIGINT: NULL means "unset" (required
-	// at provision time for new orgs; the admin API can still clear it).
-	// Callers must tolerate an absent value.
-	DefaultTeamID *int64            `json:"default_team_id,omitempty"`
+	// The column is a NOT NULL BIGINT (migration 000020) and 0 is never stored:
+	// every create path (provisioning + admin API) requires a positive team id
+	// and the admin API rejects clears. The field stays *int64 anyway — the
+	// admin PUT presence-merge relies on nil = "field absent, preserve", and a
+	// plain int64 would make gorm treat 0 as a zero value to skip.
+	DefaultTeamID *int64            `gorm:"not null" json:"default_team_id,omitempty"`
 	Users         []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
 	Warehouse     *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
 	CreatedAt     time.Time         `json:"created_at"`
@@ -488,7 +490,7 @@ type OrgConfig struct {
 	DefaultWorkerMemory     string            // org default worker profile: pod memory quantity ("" = unset)
 	DefaultWorkerTTL        string            // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
 	DefaultWorkerMinHotIdle int               // minimum default-profile hot-idle workers to retain for this org
-	DefaultTeamID           int64             // org's default PostHog team id (0 = unset); prereq for pull-based compute billing
+	DefaultTeamID           int64             // org's default PostHog team id (NOT NULL in the store; 0 only for a missing org / stale snapshot); prereq for pull-based compute billing
 	Users                   map[string]string // username -> password
 	Warehouse               *ManagedWarehouseConfig
 }

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -163,8 +163,10 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   (`NUMERIC`) in the key (new migration); add a single `last_acked` cursor row; add
   the HTTP API (aggregate-on-read into one row per key per UTC day + watermark ack)
   + safety GC.
-- **Add:** a `default_team_id` column on the org (BIGINT; used as the bucket
-  `team_id` — fixed per org, no per-team logic yet); a `duckgres.query_source` session GUC
+- **Add:** a `default_team_id` column on the org (BIGINT **NOT NULL** — required
+  at org creation on both the provisioning and admin APIs, and not clearable
+  via the admin API; used as the bucket `team_id` — fixed per org, no per-team
+  logic yet); a `duckgres.query_source` session GUC
   (`standard` | `endpoints`, default `standard`) read by the meter; a bearer secret
   for the API.
 

--- a/k8s/kind/config-store-seed.sql
+++ b/k8s/kind/config-store-seed.sql
@@ -1,5 +1,7 @@
-INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, NOW(), NOW())
+-- default_team_id is NOT NULL (every org must carry its default PostHog team
+-- id); 1 is a placeholder for local dev.
+INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
 

--- a/k8s/kind/config-store.seed.sql
+++ b/k8s/kind/config-store.seed.sql
@@ -1,5 +1,7 @@
-INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, NOW(), NOW())
+-- default_team_id is NOT NULL (every org must carry its default PostHog team
+-- id); 1 is a placeholder for local dev.
+INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
 

--- a/k8s/local-config-store.seed.sql
+++ b/k8s/local-config-store.seed.sql
@@ -1,5 +1,7 @@
-INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, NOW(), NOW())
+-- default_team_id is NOT NULL (every org must carry its default PostHog team
+-- id); 1 is a placeholder for local dev.
+INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
 

--- a/tests/configstore/helpers_test.go
+++ b/tests/configstore/helpers_test.go
@@ -64,6 +64,14 @@ func newIsolatedConfigStoreSchema(t *testing.T) (*sql.DB, string) {
 	return adminDB, connStr
 }
 
+// testDefaultTeamID returns a pointer to a placeholder PostHog team id for
+// seeded org rows — default_team_id is NOT NULL (migration 000020), so every
+// test fixture that inserts an org must carry one.
+func testDefaultTeamID() *int64 {
+	teamID := int64(1)
+	return &teamID
+}
+
 func cpconfigStoreNew(connStr string) (*cpconfigstore.ConfigStore, error) {
 	return cpconfigstore.NewConfigStore(connStr, time.Hour)
 }

--- a/tests/configstore/managed_warehouse_postgres_test.go
+++ b/tests/configstore/managed_warehouse_postgres_test.go
@@ -20,7 +20,7 @@ func TestManagedWarehouseConfigStorePostgres(t *testing.T) {
 		t.Fatalf("hash password: %v", err)
 	}
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.OrgUser{
@@ -81,7 +81,7 @@ func TestManagedWarehouseConfigStorePostgres(t *testing.T) {
 		t.Fatal("expected user credentials to remain loaded in snapshot")
 	}
 
-	if err := store.DB().Create(&configstore.Org{Name: "cleanup", DatabaseName: "cleanup"}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "cleanup", DatabaseName: "cleanup", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("create cleanup org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.ManagedWarehouse{

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	cpconfigstore "github.com/posthog/duckgres/controlplane/configstore"
@@ -37,7 +38,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 17)
 	requireGooseMigrationRecorded(t, db, 18)
 	requireGooseMigrationRecorded(t, db, 19)
-	requireGooseLatestVersion(t, db, 19)
+	requireGooseMigrationRecorded(t, db, 20)
+	requireGooseLatestVersion(t, db, 20)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -59,11 +61,13 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireColumnPresent(t, db, "duckgres_worker_spawn_log", "mem_bytes")
 	requireColumnPresent(t, db, "duckgres_worker_spawn_log", "spawned_at")
 
-	// Migration 000013 added the nullable per-org default_team_id column;
-	// 000017 converted it (and the usage-bucket team_id below) to BIGINT to
-	// match PostHog's integer team ids.
+	// Migration 000013 added the per-org default_team_id column (nullable at
+	// the time); 000017 converted it (and the usage-bucket team_id below) to
+	// BIGINT to match PostHog's integer team ids; 000020 made it NOT NULL —
+	// every org must keep its default team (the billing bucket key).
 	requireColumnPresent(t, db, "duckgres_orgs", "default_team_id")
 	requireColumnType(t, db, "duckgres_orgs", "default_team_id", "bigint")
+	requireColumnNotNull(t, db, "duckgres_orgs", "default_team_id")
 	requireColumnType(t, db, "duckgres_org_compute_usage", "team_id", "bigint")
 
 	// Migration 000007 added the compute-usage billing buffer; 000015 widened
@@ -157,7 +161,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -190,12 +194,14 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 17)
 	requireGooseMigrationRecorded(t, upgradedDB, 18)
 	requireGooseMigrationRecorded(t, upgradedDB, 19)
-	requireGooseLatestVersion(t, upgradedDB, 19)
+	requireGooseMigrationRecorded(t, upgradedDB, 20)
+	requireGooseLatestVersion(t, upgradedDB, 20)
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "disabled", "false")
 	requireColumnPresent(t, upgradedDB, "duckgres_orgs", "default_team_id")
+	requireColumnNotNull(t, upgradedDB, "duckgres_orgs", "default_team_id")
 	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "max_connections")
 	requireColumnAbsent(t, upgradedDB, "duckgres_managed_warehouses", "iceberg_enabled")
 	requireColumnAbsent(t, upgradedDB, "duckgres_org_users", "default_catalog")
@@ -211,6 +217,11 @@ func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
 		_ = db.Close()
 	})
 
+	// default_team_id is seeded pre-populated: migration 000013 adds the
+	// column with IF NOT EXISTS (so this no-ops there) and 000020 makes it
+	// NOT NULL, failing loudly on any NULL row. Real envs were backfilled
+	// before 000020 shipped, so a legacy-with-rows fixture must carry a value
+	// too (the loud-fail path has its own regression test below).
 	if _, err := db.Exec(`
 		CREATE TABLE duckgres_orgs (
 			name VARCHAR(255) PRIMARY KEY,
@@ -225,13 +236,14 @@ func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
 			default_worker_cpu VARCHAR(32),
 			default_worker_memory VARCHAR(32),
 			default_worker_ttl VARCHAR(32),
+			default_team_id VARCHAR(255),
 			created_at TIMESTAMPTZ,
 			updated_at TIMESTAMPTZ
 		);
 		CREATE UNIQUE INDEX idx_duckgres_orgs_database_name ON duckgres_orgs(database_name);
 		CREATE UNIQUE INDEX idx_duckgres_orgs_hostname_alias ON duckgres_orgs(hostname_alias);
-		INSERT INTO duckgres_orgs (name, database_name, created_at, updated_at)
-		VALUES ('old-org', 'old-org', now(), now());
+		INSERT INTO duckgres_orgs (name, database_name, default_team_id, created_at, updated_at)
+		VALUES ('old-org', 'old-org', '1', now(), now());
 	`); err != nil {
 		t.Fatalf("create old org schema: %v", err)
 	}
@@ -263,6 +275,47 @@ func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
 	requireGooseMigrationRecorded(t, sqlDB, 3)
 }
 
+// TestConfigStoreMigrationFailsLoudlyOnNullDefaultTeamID pins the deploy-time
+// stance of migration 000020: a NULL default_team_id row (an org that somehow
+// escaped the backfill) makes SET NOT NULL fail loudly instead of being
+// silently papered over. The correct outcome is to fix the row, not the
+// constraint.
+func TestConfigStoreMigrationFailsLoudlyOnNullDefaultTeamID(t *testing.T) {
+	_, connStr := newIsolatedConfigStoreSchema(t)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		t.Fatalf("open schema db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	// Minimal pre-000013 org schema with a live row and no default_team_id:
+	// 000013 adds the column as NULL for the row, 000020 must then refuse.
+	if _, err := db.Exec(`
+		CREATE TABLE duckgres_orgs (
+			name VARCHAR(255) PRIMARY KEY,
+			database_name VARCHAR(255),
+			created_at TIMESTAMPTZ,
+			updated_at TIMESTAMPTZ
+		);
+		INSERT INTO duckgres_orgs (name, database_name, created_at, updated_at)
+		VALUES ('unbackfilled-org', 'unbackfilled-org', now(), now());
+	`); err != nil {
+		t.Fatalf("create unbackfilled org schema: %v", err)
+	}
+
+	store, err := cpconfigStoreNew(connStr)
+	if err == nil {
+		sqlDB := storeDB(t, store)
+		_ = sqlDB.Close()
+		t.Fatal("config store migration succeeded, want loud failure on NULL default_team_id")
+	}
+	if !strings.Contains(err.Error(), "default_team_id") || !strings.Contains(err.Error(), "null") {
+		t.Fatalf("migration error should name the NULL default_team_id violation, got: %v", err)
+	}
+}
+
 func TestConfigStoreSQLMigrationsUpgradeLegacyOrgUsersUsernamePK(t *testing.T) {
 	_, connStr := newIsolatedConfigStoreSchema(t)
 	db, err := sql.Open("postgres", connStr)
@@ -278,10 +331,13 @@ func TestConfigStoreSQLMigrationsUpgradeLegacyOrgUsersUsernamePK(t *testing.T) {
 		t.Fatalf("hash password: %v", err)
 	}
 
+	// default_team_id pre-populated for the same reason as the old-org-schema
+	// test above: 000020 makes it NOT NULL and real envs are backfilled.
 	if _, err := db.Exec(`
 		CREATE TABLE duckgres_orgs (
 			name VARCHAR(255) PRIMARY KEY,
 			database_name VARCHAR(255),
+			default_team_id VARCHAR(255),
 			created_at TIMESTAMPTZ,
 			updated_at TIMESTAMPTZ
 		);
@@ -292,8 +348,8 @@ func TestConfigStoreSQLMigrationsUpgradeLegacyOrgUsersUsernamePK(t *testing.T) {
 			created_at TIMESTAMPTZ,
 			updated_at TIMESTAMPTZ
 		);
-		INSERT INTO duckgres_orgs (name, database_name, created_at, updated_at)
-		VALUES ('old-org', 'old-org', now(), now());
+		INSERT INTO duckgres_orgs (name, database_name, default_team_id, created_at, updated_at)
+		VALUES ('old-org', 'old-org', '1', now(), now());
 	`); err != nil {
 		t.Fatalf("create legacy org user schema: %v", err)
 	}
@@ -567,6 +623,28 @@ func requireColumnType(t *testing.T, db *sql.DB, tableName, columnName, wantType
 	}
 	if got != wantType {
 		t.Fatalf("%s.%s type = %q, want %q", tableName, columnName, got, wantType)
+	}
+}
+
+func requireColumnNotNull(t *testing.T, db *sql.DB, tableName, columnName string) {
+	t.Helper()
+
+	var isNullable string
+	err := db.QueryRow(`
+		SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+		  AND table_name = $1
+		  AND column_name = $2
+	`, tableName, columnName).Scan(&isNullable)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			t.Fatalf("%s.%s column missing", tableName, columnName)
+		}
+		t.Fatalf("query %s.%s nullability: %v", tableName, columnName, err)
+	}
+	if isNullable != "NO" {
+		t.Fatalf("%s.%s is_nullable = %q, want %q (column must be NOT NULL)", tableName, columnName, isNullable, "NO")
 	}
 }
 

--- a/tests/configstore/reshard_postgres_test.go
+++ b/tests/configstore/reshard_postgres_test.go
@@ -14,8 +14,9 @@ func seedReadyWarehouse(t *testing.T, store *cpconfigstore.ConfigStore, orgID st
 	t.Helper()
 	// The warehouse row has an FK to the org row (fk_duckgres_orgs_warehouse).
 	if err := store.DB().Create(&cpconfigstore.Org{
-		Name:         orgID,
-		DatabaseName: orgID,
+		Name:          orgID,
+		DatabaseName:  orgID,
+		DefaultTeamID: testDefaultTeamID(),
 	}).Error; err != nil {
 		t.Fatalf("seed org: %v", err)
 	}
@@ -333,7 +334,7 @@ func TestListExternalMetadataStoresPostgres(t *testing.T) {
 
 	seed := func(org, endpoint string, state cpconfigstore.ManagedWarehouseProvisioningState) {
 		t.Helper()
-		if err := store.DB().Create(&cpconfigstore.Org{Name: org, DatabaseName: org}).Error; err != nil {
+		if err := store.DB().Create(&cpconfigstore.Org{Name: org, DatabaseName: org, DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 			t.Fatalf("seed org %s: %v", org, err)
 		}
 		wh := &cpconfigstore.ManagedWarehouse{OrgID: org, DucklingName: org, State: state}

--- a/tests/configstore/testdata/tenant-isolation.seed.sql
+++ b/tests/configstore/testdata/tenant-isolation.seed.sql
@@ -1,7 +1,7 @@
-INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
+INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
 VALUES
-    ('analytics', 'analytics', 0, NOW(), NOW()),
-    ('billing', 'billing', 0, NOW(), NOW())
+    ('analytics', 'analytics', 0, 1, NOW(), NOW()),
+    ('billing', 'billing', 0, 2, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET database_name = EXCLUDED.database_name,
     updated_at = NOW();

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1141,9 +1141,12 @@ org_default_profile() { # org password catalog
 #      bodies (mandatory now); GET /orgs/:id must round-trip exactly each value.
 #   2. Reject path: provisioning a brand-new org WITHOUT default_team_id must be
 #      400 naming the field, and must create nothing (org GET stays 404).
-#   3. Mutate path: PUT /orgs/:id can set and clear it (0=NULL) on the EXT org
-#      (admin escape hatch), round-tripping on GET; the provisioned value is
-#      restored afterwards so the org stays contract-conformant.
+#   3. Mutate path: PUT /orgs/:id can set it to a positive team id on the EXT
+#      org, round-tripping on GET; clearing (0 or null) is REJECTED with a 400
+#      and must leave the stored value untouched — the column is NOT NULL
+#      (migration 000020) and every org must keep its default team (the
+#      billing bucket key). The provisioned value is restored afterwards so
+#      the org stays contract-conformant.
 # get_org_default_team_id prints the raw JSON value ("null" when NULL) so the
 # assertions can distinguish an unset column from an empty string.
 get_org_default_team_id() { # org -> prints default_team_id (jq raw; "null" when unset)
@@ -1176,18 +1179,28 @@ default_team_id_mandatory() { # cnpg_org ext_org
     || fail "default_team_id: rejected provision must create nothing, GET /orgs/$noteam -> HTTP $code want 404"
   log "default_team_id OK: new org without it rejected with 400, nothing created"
 
-  # 3. Mutate path: PUT can set, clear ("" -> NULL), then restore on the ext org.
+  # 3. Mutate path: PUT with a positive value sets; clearing (0 or JSON null)
+  # is rejected with a 400 and must not change the stored value (the column is
+  # NOT NULL — every org must keep a default team).
   code="$(put_org "$ext_org" '{"default_team_id":424242}')"
   [ "$code" = "200" ] || fail "default_team_id: PUT set -> HTTP $code: $(cat /tmp/put_org_out)"
   got="$(get_org_default_team_id "$ext_org")"
   [ "$got" = "424242" ] || fail "default_team_id: after PUT set, GET = '$got' want '424242'"
   code="$(put_org "$ext_org" '{"default_team_id":0}')"
-  [ "$code" = "200" ] || fail "default_team_id: PUT clear -> HTTP $code: $(cat /tmp/put_org_out)"
+  [ "$code" = "400" ] || fail "default_team_id: PUT clear (0) -> HTTP $code want 400 (clearing must be rejected): $(cat /tmp/put_org_out)"
+  grep -q "default_team_id" /tmp/put_org_out \
+    || fail "default_team_id: PUT clear rejection should name the field: $(cat /tmp/put_org_out)"
   got="$(get_org_default_team_id "$ext_org")"
-  [ "$got" = "null" ] || fail "default_team_id: after PUT clear, GET = '$got' want 'null' (0 must clear to NULL)"
+  [ "$got" = "424242" ] || fail "default_team_id: after rejected PUT clear, GET = '$got' want '424242' (stored value must be unchanged)"
+  code="$(put_org "$ext_org" '{"default_team_id":null}')"
+  [ "$code" = "400" ] || fail "default_team_id: PUT clear (null) -> HTTP $code want 400 (clearing must be rejected): $(cat /tmp/put_org_out)"
+  got="$(get_org_default_team_id "$ext_org")"
+  [ "$got" = "424242" ] || fail "default_team_id: after rejected PUT null, GET = '$got' want '424242' (stored value must be unchanged)"
   code="$(put_org "$ext_org" "{\"default_team_id\":$EXT_DEFAULT_TEAM_ID}")"
   [ "$code" = "200" ] || fail "default_team_id: PUT restore -> HTTP $code: $(cat /tmp/put_org_out)"
-  log "default_team_id OK: PUT set/clear/restore round-trips on $ext_org"
+  got="$(get_org_default_team_id "$ext_org")"
+  [ "$got" = "$EXT_DEFAULT_TEAM_ID" ] || fail "default_team_id: after PUT restore, GET = '$got' want '$EXT_DEFAULT_TEAM_ID'"
+  log "default_team_id OK: PUT set round-trips, clear (0/null) rejected 400, value preserved on $ext_org"
 }
 
 # ---- user persistent secrets ------------------------------------------------


### PR DESCRIPTION
## Why

`duckgres_orgs.default_team_id` (the org's PostHog team id) is the billing bucket key. It was already required when the provisioning API creates a new org (`ErrDefaultTeamIDRequired`), and all existing orgs in all envs are backfilled — but the invariant wasn't structural. Two admin-API holes could still put a NULL back:

1. `PUT /orgs/:id` treated `0` / explicit JSON `null` as "clear to NULL".
2. `POST /orgs` didn't require the field at all.

#929 works around the resulting team-0/NULL rows by skipping them at meter/serve time. This PR makes the invariant structural instead: the column becomes NOT NULL and every create/update path enforces a positive team id, which makes #929's record-time skip structurally unnecessary; its serve-side filter for pre-existing team-0 rows remains useful.

## What

- **Migration `000020`**: `ALTER TABLE duckgres_orgs ALTER COLUMN default_team_id SET NOT NULL` (down: `DROP NOT NULL`). A NULL row fails the migration loudly at deploy — deliberately: fix the row, not the constraint.
- **Admin `PUT /orgs/:id`**: clearing rejected. `0`, explicit JSON `null`, and negatives → 400 with a message naming the field, stored value untouched. Absent = preserve, positive = set (unchanged). The store-layer 0→NULL mapping is gone.
- **Admin `POST /orgs`**: `default_team_id` is now required and must be positive (400 naming the field otherwise) — same invariant as the provisioning API.
- **Model**: `Org.DefaultTeamID` gets `gorm:"not null"` + updated comment; stays `*int64` (the PUT presence-merge relies on nil = field absent).
- **Admin UI** (`OrgDetail.tsx`): field relabeled "Default team id (required)"; an empty input now omits the field (preserve) instead of sending the old `0` clear-sentinel; digits-only validation kept and tightened to positive.
- **Dev seed SQL + postgres test fixtures** now carry a `default_team_id` so they satisfy the constraint.
- **Docs**: `CLAUDE.md` + `docs/design/billing-pull-api.md` updated to describe the column as NOT NULL / required instead of clearable.

## Tests

- `controlplane/admin`: new tests — PUT with `0` / JSON `null` / negative → 400 and stored value unchanged; PUT without the field preserves; PUT positive sets; POST without `default_team_id` → 400 (naming the field, nothing created); POST with non-positive → 400; POST with positive → 201 and persisted.
- `tests/configstore/migrations_postgres_test.go`: version assertions bumped to 20 (both the fresh-migrate and v8-replay paths), new `requireColumnNotNull` assertion on `duckgres_orgs.default_team_id`, and a regression test pinning the loud-fail: an unbackfilled NULL row makes migration 000020 fail with the 23502 error.
- e2e harness (`tests/mw-dev/e2e/harness.sh`): `default_team_id_mandatory` flipped — PUT `0` and PUT `null` must 400 with the stored value unchanged on GET, and a positive PUT still round-trips (`bash -n` clean).
- Sweeps run locally against a real Postgres: `go build ./...`, `go build -tags kubernetes ./...`, `go vet ./...`, `go vet -tags kubernetes ./controlplane/...`, `go test ./controlplane/... ./configresolve/`, `go test -count=1 ./tests/configstore/`, `go test -count=1 -tags kubernetes . ./controlplane ./controlplane/admin` — all green. Admin UI: `npm run typecheck && npm run test && npm run build` — green.

## Deploy note

The migration fails loudly if any env still has a NULL `default_team_id` — verify via the admin UI Orgs page (or the config store) that every org has one before rolling this out. All envs were confirmed backfilled at the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)