### PR TITLE
Reshard: real claim-on-create for the ext-target password case

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,8 +558,18 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
   (precedence would fall through to the freshly-stamped bogus status pin);
   ext→cnpg rollback must null `cnpgShard` (XRD CEL forbids it on external).
 - **The ext target password is ephemeral**: request → in-process stash →
-  runner memory; never in the op row, log, or audit. Takeover mid-copy fails
-  with a clear re-run message instead of proceeding without it.
+  runner memory; never in the op row, log, or audit. Because it lives only in
+  the creating replica's memory, the op must run on THAT replica —
+  **claim-on-create**: the admin start handler creates the op via
+  `CreateReshardOperationClaimed(op, cpID)` (single insert, lands `running` +
+  owned, `runner_epoch=1`, fresh heartbeat) and hands it straight to the local
+  runner via `AdoptClaimedOperation(op, password)`, which executes it on the
+  runner's LIFECYCLE ctx (NOT the HTTP request ctx). A fresh-heartbeat running
+  op owned by the local CP is unclaimable by any sibling replica's scanOnce, so
+  a passwordless replica can never win it. (cnpg targets are create-claimed too
+  when a local runner exists; with none they fall back to `pending`, any
+  replica — no password needed.) A genuine crash-takeover mid-copy still fails
+  with a clear re-run message instead of proceeding without the password.
 - **The ext SM secret must be ESO-readable and a raw string**: the ESO IAM
   policy only allows `posthog-*`/`duckling-*` names (RDS-managed
   `rds!…`/`rds/…/master` secrets never work → start handler 400s them,

--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -34,6 +34,7 @@ import (
 // ReshardStore is the config-store surface these handlers need.
 type ReshardStore interface {
 	CreateReshardOperation(op *configstore.ReshardOperation) error
+	CreateReshardOperationClaimed(op *configstore.ReshardOperation, runnerCP string) error
 	GetReshardOperation(id int64) (*configstore.ReshardOperation, error)
 	ListReshardOperationsForOrg(orgID string, limit int) ([]configstore.ReshardOperation, error)
 	ListReshardOperations(limit int) ([]configstore.ReshardOperation, error)
@@ -45,11 +46,15 @@ type ReshardStore interface {
 	ListExternalMetadataStores() ([]configstore.ExternalMetadataStoreInfo, error)
 }
 
-// ReshardPasswordStash hands the runner the ephemeral external password for
-// an op created on this CP (claim-on-create handoff). Satisfied by
-// *provisioner.ReshardRunner.
-type ReshardPasswordStash interface {
-	StashExternalPassword(opID int64, password string)
+// ReshardRunnerHandle is the LOCAL reshard runner surface the start handler
+// needs for claim-on-create: its CP id (so the op is created already owned by
+// this replica) and AdoptClaimedOperation (to hand the just-created op — plus
+// the ephemeral external password — straight to the runner to execute).
+// Satisfied by *provisioner.ReshardRunner. nil when this CP has no runner (no
+// k8s API); external targets are refused up front in that case.
+type ReshardRunnerHandle interface {
+	CPID() string
+	AdoptClaimedOperation(op *configstore.ReshardOperation, password string)
 }
 
 // reshardShardNamePattern mirrors the Duckling XRD's cnpgShard pattern.
@@ -90,11 +95,12 @@ type startReshardRequest struct {
 
 // RegisterReshardAPI wires the reshard endpoints. lister may be nil (duckling
 // client unavailable) — starting a reshard then 503s; reads still work.
-// stash may be nil (no local runner) — external targets then 503. cluster may
-// be nil (non-k8s) — shard discovery then falls back to the shards tenants
-// already occupy.
-func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, stash ReshardPasswordStash, cluster kubernetes.Interface) {
-	h := &reshardHandler{store: store, lister: lister, stash: stash, cluster: cluster}
+// runner may be nil (no local runner) — external targets then 503, cnpg
+// targets fall back to a pending op any replica may claim. cluster may be nil
+// (non-k8s) — shard discovery then falls back to the shards tenants already
+// occupy.
+func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, runner ReshardRunnerHandle, cluster kubernetes.Interface) {
+	h := &reshardHandler{store: store, lister: lister, runner: runner, cluster: cluster}
 	r.POST("/orgs/:id/reshard", h.start)
 	r.GET("/orgs/:id/reshards", h.listForOrg)
 	r.GET("/reshards", h.listAll)
@@ -107,7 +113,7 @@ func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingM
 type reshardHandler struct {
 	store   ReshardStore
 	lister  DucklingMetadataLister
-	stash   ReshardPasswordStash
+	runner  ReshardRunnerHandle
 	cluster kubernetes.Interface
 }
 
@@ -270,7 +276,7 @@ func (h *reshardHandler) start(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "external target requires the password (sent once, never stored — the runner uses it for the copy; password_aws_secret must contain the same value)"})
 			return
 		}
-		if h.stash == nil {
+		if h.runner == nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no reshard runner on this control plane — external targets unavailable"})
 			return
 		}
@@ -284,20 +290,34 @@ func (h *reshardHandler) start(c *gin.Context) {
 		return
 	}
 
-	if err := h.store.CreateReshardOperation(op); err != nil {
-		if errors.Is(err, configstore.ErrReshardConflict) {
+	// Claim-on-create: when this CP has a local runner, create the op ALREADY
+	// claimed by it (single insert, state running + owned) so no other
+	// replica's scanOnce can pick it up. This is mandatory for external
+	// targets — the ephemeral password lives only in THIS replica's memory, so
+	// a different replica winning the op would fail the copy for want of it
+	// (the production bug this fixes). It is harmless and lower-latency for
+	// cnpg targets too. With no local runner (cnpg only — external is 503'd
+	// above) fall back to a pending op any replica may claim.
+	var createErr error
+	if h.runner != nil {
+		createErr = h.store.CreateReshardOperationClaimed(op, h.runner.CPID())
+	} else {
+		createErr = h.store.CreateReshardOperation(op)
+	}
+	if createErr != nil {
+		if errors.Is(createErr, configstore.ErrReshardConflict) {
 			c.JSON(http.StatusConflict, gin.H{"error": "org already has an active reshard operation"})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": createErr.Error()})
 		return
 	}
-	if op.TargetKind == configstore.MetadataStoreKindExternal && h.stash != nil {
-		// Ephemeral handoff to the LOCAL runner — never persisted. The local
-		// runner claims pending ops within its poll tick; only a crash before
-		// the claim loses the password (the runner then fails the op with a
-		// clear re-run message).
-		h.stash.StashExternalPassword(op.ID, req.Target.Password)
+	if h.runner != nil {
+		// Hand the create-claimed op straight to the local runner to execute on
+		// its OWN lifecycle context (not this request ctx). For external
+		// targets this also carries the ephemeral password (never persisted);
+		// for cnpg targets the password arg is empty.
+		h.runner.AdoptClaimedOperation(op, req.Target.Password)
 	}
 	_ = h.store.AppendReshardLog(op.ID, "info", "operation created by "+actorForAudit(c)+": "+describeReshard(op))
 	// Audit detail carries no secrets.

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -33,7 +34,10 @@ type fakeReshardStore struct {
 
 	logs      []configstore.ReshardLogEntry
 	cancelled []int64
-	stashed   map[int64]string
+	// adopted records AdoptClaimedOperation calls (opID -> password); the
+	// claimed map records CreateReshardOperationClaimed calls (opID -> runnerCP).
+	adopted map[int64]string
+	claimed map[int64]string
 }
 
 func newFakeReshardStore() *fakeReshardStore {
@@ -54,6 +58,26 @@ func (f *fakeReshardStore) CreateReshardOperation(op *configstore.ReshardOperati
 	f.nextID++
 	op.State = configstore.ReshardStatePending
 	f.ops[op.ID] = op
+	return nil
+}
+
+func (f *fakeReshardStore) CreateReshardOperationClaimed(op *configstore.ReshardOperation, runnerCP string) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	op.ID = f.nextID
+	f.nextID++
+	op.State = configstore.ReshardStateRunning
+	op.RunnerCP = runnerCP
+	op.RunnerEpoch = 1
+	now := time.Now().UTC()
+	op.HeartbeatAt = &now
+	op.StartedAt = &now
+	f.ops[op.ID] = op
+	if f.claimed == nil {
+		f.claimed = map[int64]string{}
+	}
+	f.claimed[op.ID] = runnerCP
 	return nil
 }
 
@@ -135,11 +159,15 @@ func (f *fakeReshardStore) ListExternalMetadataStores() ([]configstore.ExternalM
 	}, nil
 }
 
-func (f *fakeReshardStore) StashExternalPassword(opID int64, password string) {
-	if f.stashed == nil {
-		f.stashed = map[int64]string{}
+// The fake doubles as the local runner handle (passed as both store and runner
+// to RegisterReshardAPI).
+func (f *fakeReshardStore) CPID() string { return "cp-test" }
+
+func (f *fakeReshardStore) AdoptClaimedOperation(op *configstore.ReshardOperation, password string) {
+	if f.adopted == nil {
+		f.adopted = map[int64]string{}
 	}
-	f.stashed[opID] = password
+	f.adopted[op.ID] = password
 }
 
 type fakeShardLister struct {
@@ -187,6 +215,18 @@ func TestReshardStartCnpg(t *testing.T) {
 	}
 	if op.SourceKind != "cnpg-shard" || op.FromShard != "shard-001" || op.ToShard != "shard-002" || op.DrainTimeoutSeconds != 120 || op.CutoverTimeoutSeconds != 45 {
 		t.Fatalf("op = %+v", op)
+	}
+	// Claim-on-create: the op is created ALREADY claimed by the local CP
+	// (state running, runner_cp set) and handed to the runner to execute — no
+	// pending window a sibling replica could claim.
+	if op.State != configstore.ReshardStateRunning || op.RunnerCP != "cp-test" {
+		t.Fatalf("op not create-claimed: state=%s runner_cp=%q", op.State, op.RunnerCP)
+	}
+	if store.claimed[op.ID] != "cp-test" {
+		t.Fatalf("create-claimed not recorded: %v", store.claimed)
+	}
+	if _, ok := store.adopted[op.ID]; !ok {
+		t.Fatalf("op was not adopted by the runner: %v", store.adopted)
 	}
 }
 
@@ -241,8 +281,11 @@ func TestReshardStartValidation(t *testing.T) {
 }
 
 // TestReshardExtPasswordStashedNotPersisted pins the ephemeral-password
-// contract: the password reaches the stash, the op row carries only the
-// secret NAME, and neither the response nor the log contains the password.
+// contract: the password reaches the runner via the claim-on-create adopt
+// handoff, the op row carries only the secret NAME, and neither the response
+// nor the log contains the password. The op is also create-claimed by the
+// local CP so no other replica can win it and fail the copy for want of the
+// password (the production multi-replica bug).
 func TestReshardExtPasswordStashedNotPersisted(t *testing.T) {
 	store := newFakeReshardStore()
 	w := doJSON(reshardRouter(store), http.MethodPost, "/api/v1/orgs/acme/reshard",
@@ -250,10 +293,16 @@ func TestReshardExtPasswordStashedNotPersisted(t *testing.T) {
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d body %s, want 202", w.Code, w.Body.String())
 	}
-	if store.stashed[1] != "hunter2" {
-		t.Fatalf("stash = %v, want the password handed to the runner", store.stashed)
+	if store.adopted[1] != "hunter2" {
+		t.Fatalf("adopted = %v, want the password handed to the runner", store.adopted)
+	}
+	if store.claimed[1] != "cp-test" {
+		t.Fatalf("external op not create-claimed by local CP: %v", store.claimed)
 	}
 	op := store.ops[1]
+	if op.State != configstore.ReshardStateRunning || op.RunnerCP != "cp-test" {
+		t.Fatalf("external op not create-claimed: state=%s runner_cp=%q", op.State, op.RunnerCP)
+	}
 	if op.TargetPasswordSecret != "my-secret" || op.TargetEndpoint != "rds.example.com" {
 		t.Fatalf("op = %+v", op)
 	}
@@ -314,25 +363,26 @@ func TestReshardGetListLogCancel(t *testing.T) {
 		t.Fatalf("after_id poll returned %d entries, want 0", len(resp.Entries))
 	}
 
-	// Cancel a PENDING op → finished immediately as cancelled.
+	// Op 1 is create-claimed (running), so cancel sets the flag → 202 (the
+	// runner rolls back from wherever it is).
 	w = doJSON(r, http.MethodPost, "/api/v1/reshards/1/cancel", "")
+	if w.Code != http.StatusAccepted || !store.ops[1].CancelRequested {
+		t.Fatalf("cancel running op 1: status %d, flag %t", w.Code, store.ops[1].CancelRequested)
+	}
+
+	// A PENDING op (the no-local-runner path) finishes immediately as
+	// cancelled; a re-cancel is 409 (terminal).
+	store.ops[3] = &configstore.ReshardOperation{ID: 3, OrgID: "acme", State: configstore.ReshardStatePending}
+	w = doJSON(r, http.MethodPost, "/api/v1/reshards/3/cancel", "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("cancel pending status = %d body %s", w.Code, w.Body.String())
 	}
-	if store.ops[1].State != configstore.ReshardStateCancelled {
-		t.Fatalf("pending op state = %s, want cancelled", store.ops[1].State)
+	if store.ops[3].State != configstore.ReshardStateCancelled {
+		t.Fatalf("pending op state = %s, want cancelled", store.ops[3].State)
 	}
-	// Cancel again → 409 (terminal).
-	w = doJSON(r, http.MethodPost, "/api/v1/reshards/1/cancel", "")
+	w = doJSON(r, http.MethodPost, "/api/v1/reshards/3/cancel", "")
 	if w.Code != http.StatusConflict {
 		t.Fatalf("re-cancel status = %d, want 409", w.Code)
-	}
-
-	// Cancel a RUNNING op → flag set, 202.
-	store.ops[2] = &configstore.ReshardOperation{ID: 2, OrgID: "acme", State: configstore.ReshardStateRunning}
-	w = doJSON(r, http.MethodPost, "/api/v1/reshards/2/cancel", "")
-	if w.Code != http.StatusAccepted || !store.ops[2].CancelRequested {
-		t.Fatalf("cancel running: status %d, flag %t", w.Code, store.ops[2].CancelRequested)
 	}
 }
 

--- a/controlplane/configstore/reshard.go
+++ b/controlplane/configstore/reshard.go
@@ -141,6 +141,34 @@ func (cs *ConfigStore) CreateReshardOperation(op *ReshardOperation) error {
 	return nil
 }
 
+// CreateReshardOperationClaimed inserts an operation that is ALREADY claimed
+// by runnerCP — state running, runner_epoch 1, heartbeat/started stamped now —
+// in a single insert. This is the real claim-on-create: because the row lands
+// as a fresh-heartbeat running op owned by runnerCP, no other replica's
+// scanOnce loop can list or claim it (ListClaimableReshardOperations /
+// ClaimReshardOperation only touch pending or stale-heartbeat running ops). It
+// is mandatory for external-target ops, whose ephemeral password lives only in
+// the creating CP's memory: a different replica must never win the op and then
+// fail the copy for want of the password. The partial unique index on (org_id)
+// WHERE state IN (pending, running) still fails a second active op →
+// ErrReshardConflict.
+func (cs *ConfigStore) CreateReshardOperationClaimed(op *ReshardOperation, runnerCP string) error {
+	now := time.Now().UTC()
+	op.State = ReshardStateRunning
+	op.RunnerCP = runnerCP
+	op.RunnerEpoch = 1
+	op.HeartbeatAt = &now
+	op.StartedAt = &now
+	op.CreatedAt = now
+	if err := cs.db.Create(op).Error; err != nil {
+		if isUniqueViolationErr(err) {
+			return ErrReshardConflict
+		}
+		return fmt.Errorf("create claimed reshard operation: %w", err)
+	}
+	return nil
+}
+
 // GetReshardOperation loads one operation by id.
 func (cs *ConfigStore) GetReshardOperation(id int64) (*ReshardOperation, error) {
 	var op ReshardOperation

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -573,11 +573,11 @@ func SetupMultiTenant(
 
 	// Reshard operations (metadata-store migrations). The runner may be nil
 	// (no k8s API) — reads still work, starts fail with a clear error.
-	var reshardStash admin.ReshardPasswordStash
+	var reshardRunnerHandle admin.ReshardRunnerHandle
 	if reshardRunner != nil {
-		reshardStash = reshardRunner
+		reshardRunnerHandle = reshardRunner
 	}
-	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardStash, clusterClient)
+	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardRunnerHandle, clusterClient)
 
 	// Break-glass internal-secret login (the SPA owns "/" and app routes).
 	admin.RegisterLogin(engine, adminTokens)

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -48,6 +48,13 @@ type ReshardRunner struct {
 	// cancel checks). 5s in production; tests shrink it.
 	loopPoll time.Duration
 
+	// baseCtx is the runner's LIFECYCLE context (the one handed to Run). Ops
+	// adopted straight from the admin HTTP handler (claim-on-create) execute
+	// under this context, NOT the request context — a reshard runs for minutes
+	// and the request ctx is cancelled the moment the 202 response returns.
+	// Defaults to context.Background(); Run overwrites it with its own ctx.
+	baseCtx context.Context
+
 	// extPasswords holds the EPHEMERAL external passwords by op id: the
 	// cnpg→ext target password and the ext→cnpg source password (both come
 	// from the create request and are never persisted). A takeover runner
@@ -108,6 +115,7 @@ func NewReshardRunner(store *configstore.ConfigStore, duckling *DucklingClient, 
 		duckling:           duckling,
 		copier:             PGCatalogCopier{},
 		cpID:               cpID,
+		baseCtx:            context.Background(),
 		pollInterval:       10 * time.Second,
 		configPollInterval: configPollInterval,
 		heartbeatInterval:  30 * time.Second,
@@ -118,17 +126,51 @@ func NewReshardRunner(store *configstore.ConfigStore, duckling *DucklingClient, 
 	}
 }
 
-// StashExternalPassword hands the runner an ephemeral password for an op it
-// is expected to claim (claim-on-create: the admin handler creates the op on
-// this CP and stashes the password here before the runner picks it up).
+// CPID returns this runner's control-plane id — the value the admin handler
+// passes to CreateReshardOperationClaimed so the op is created already owned by
+// THIS replica (the one holding the ephemeral password).
+func (r *ReshardRunner) CPID() string { return r.cpID }
+
+// StashExternalPassword hands the runner an ephemeral password for an op it is
+// expected to run. Used by AdoptClaimedOperation and by tests.
 func (r *ReshardRunner) StashExternalPassword(opID int64, password string) {
 	if password != "" {
 		r.extPasswords.Store(opID, password)
 	}
 }
 
+// AdoptClaimedOperation takes an op that was just created ALREADY claimed by
+// this CP (CreateReshardOperationClaimed) and executes it directly, without
+// waiting for the scanOnce poll tick. This is the second half of
+// claim-on-create: the admin handler creates the op owned by this replica and
+// hands it straight here so the replica that holds the ephemeral external
+// password is the one that runs the copy. For external targets password is the
+// ephemeral credential (stashed for copyCatalog); for cnpg targets it is "".
+//
+// Execution runs under the runner's LIFECYCLE context (r.baseCtx), never the
+// caller's (HTTP request) context — a reshard runs for minutes. The r.running
+// map dedups against a racing scanOnce pickup (which cannot happen anyway: a
+// fresh-heartbeat running op owned by this CP is neither listed nor claimable
+// elsewhere).
+func (r *ReshardRunner) AdoptClaimedOperation(op *configstore.ReshardOperation, password string) {
+	r.StashExternalPassword(op.ID, password)
+	if _, alreadyRunning := r.running.LoadOrStore(op.ID, struct{}{}); alreadyRunning {
+		return
+	}
+	ctx := r.baseCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go func() {
+		defer r.running.Delete(op.ID)
+		defer r.extPasswords.Delete(op.ID)
+		r.execute(ctx, op)
+	}()
+}
+
 // Run is the claim loop. Blocks until ctx is done.
 func (r *ReshardRunner) Run(ctx context.Context) {
+	r.baseCtx = ctx
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 	for {

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -646,6 +646,69 @@ func TestReshardCancelDuringDrain(t *testing.T) {
 	}
 }
 
+// waitOpTerminal polls the fake store until the op reaches a terminal state
+// (or the deadline), for tests that drive the runner via AdoptClaimedOperation
+// (which launches execution on its own goroutine rather than via runOp).
+func waitOpTerminal(t *testing.T, store *fakeReshardStore) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		store.mu.Lock()
+		st := store.op.State
+		store.mu.Unlock()
+		if st.Terminal() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("operation did not reach a terminal state in time")
+}
+
+// TestReshardAdoptClaimedExecutesWithStashedPassword pins the claim-on-create
+// handoff: an op handed straight to the runner via AdoptClaimedOperation (as
+// the admin start handler does for a create-claimed op) executes to completion
+// using the stashed external password — no scanOnce poll tick, no password on
+// the op row.
+func TestReshardAdoptClaimedExecutesWithStashedPassword(t *testing.T) {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	// Already claimed by this CP (what CreateReshardOperationClaimed stamps).
+	op.State = configstore.ReshardStateRunning
+	op.RunnerCP = "cp-test"
+	op.RunnerEpoch = 1
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	// AdoptClaimedOperation must run under the runner's lifecycle context, not
+	// a request context — leave baseCtx nil to prove it falls back safely.
+	r.AdoptClaimedOperation(op, "ext-pw")
+	waitOpTerminal(t, store)
+
+	if store.op.State != configstore.ReshardStateSucceeded {
+		t.Fatalf("state = %s (err %q), want succeeded", store.op.State, store.op.Error)
+	}
+	// The stashed password flowed into the copy's target endpoint.
+	var sawCopy bool
+	for _, call := range copier.calls {
+		if call.kind == "copy" {
+			sawCopy = true
+			if call.target.Password != "ext-pw" {
+				t.Fatalf("copy target password = %q, want the stashed ext-pw", call.target.Password)
+			}
+		}
+	}
+	if !sawCopy {
+		t.Fatalf("copy never ran; copier calls = %v", copier.kinds())
+	}
+}
+
 // TestReshardExtTargetWithoutPasswordFails pins the takeover semantics of the
 // ephemeral password: a runner without the stash must fail with the re-run
 // message, never proceed with an empty password.

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -105,12 +105,30 @@ cutover → finalizing`. The flip IS the source cleanup and only runs after
 verify passed.
 
 The target password is **ephemeral**: sent once in the start request,
-validated by connecting, handed in-process to the local runner
-(claim-on-create), never persisted to the op row/log/audit — the row stores
-the AWS SM secret NAME only. Consequence: a crash-takeover mid-copy cannot
-resume (password lost); the new runner fails the op with a clear re-run
-message. After the flip, the runner checks the ESO-synced status password
-matches the provided one (catches a wrong/missing SM secret).
+validated by connecting, handed in-process to the local runner, never
+persisted to the op row/log/audit — the row stores the AWS SM secret NAME
+only. Because the password lives only in the creating replica's memory, the op
+must be run by THAT replica. This is **claim-on-create** (real, not just a
+comment): the admin start handler creates the op via
+`CreateReshardOperationClaimed(op, cpID)`, a single insert that lands the row
+already `running` and owned by the local CP (`runner_epoch=1`,
+`heartbeat_at=now`), then hands it straight to the local runner via
+`AdoptClaimedOperation(op, password)` — which stashes the password and launches
+execution on the runner's LIFECYCLE context (not the HTTP request context,
+which dies with the 202 response). A create-claimed op has a fresh-heartbeat
+`running` row owned by the local CP, so no sibling replica's scanOnce loop can
+list or claim it. (The prior code created the op `pending` and only stashed the
+password locally; on a multi-replica CP a *different* replica's scanOnce would
+win the op ~2/3 of the time and fail the copy — "external target password is
+not available to this runner". Fixed.) cnpg targets are create-claimed too when
+a local runner exists (lower latency, uniform path); with no local runner they
+fall back to a `pending` op any replica may claim (no password needed).
+Consequence for external targets: a genuine crash-takeover mid-copy still
+cannot resume (password lost with the dead replica's memory); the new runner
+fails the op with a clear re-run message, and — because cnpg→ext copies BEFORE
+the flip — a pre-flip failure leaves the cnpg source untouched. After the flip,
+the runner checks the ESO-synced status password matches the provided one
+(catches a wrong/missing SM secret).
 
 **The SM secret name and value are constrained by the ESO wiring.** After the
 flip, the composition renders an ExternalSecret
@@ -151,6 +169,10 @@ where the source is rebuilt rather than left untouched.
 - Runner fencing: claim bumps `runner_epoch`; every runner write is CAS-fenced
   on (runner, epoch); heartbeat ~30s; an op with a >5m-stale heartbeat is
   claimable (takeover). The target-DB advisory lock fences the copy itself.
+  Claim-on-create (see the cnpg→external section) creates the op already at
+  `runner_epoch=1`, owned by the creating CP — a fresh-heartbeat running row no
+  sibling replica can steal, which is what keeps the ephemeral external
+  password with the one runner that has it.
 - An org is never stranded: every failure path restores `resharding→ready`
   (or logs at ERROR if it can't — that's the page-someone signal).
 

--- a/tests/configstore/reshard_postgres_test.go
+++ b/tests/configstore/reshard_postgres_test.go
@@ -147,6 +147,67 @@ func TestReshardTakeoverFencingPostgres(t *testing.T) {
 	}
 }
 
+// TestReshardCreateClaimedPostgres pins claim-on-create: the op lands running
+// and owned by the creating CP in a single insert, a second active op for the
+// org still conflicts, and a sibling replica cannot steal the fresh-heartbeat
+// running op (the fix for the multi-replica ephemeral-password bug).
+func TestReshardCreateClaimedPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	op := newReshardOp("org-cc")
+	if err := store.CreateReshardOperationClaimed(op, "cp-a"); err != nil {
+		t.Fatalf("create claimed: %v", err)
+	}
+	if op.ID == 0 || op.State != cpconfigstore.ReshardStateRunning || op.RunnerCP != "cp-a" || op.RunnerEpoch != 1 {
+		t.Fatalf("create-claimed returned op %+v, want running/cp-a/epoch=1", op)
+	}
+	if op.HeartbeatAt == nil || op.StartedAt == nil {
+		t.Fatalf("create-claimed did not stamp heartbeat/started: %+v", op)
+	}
+
+	// Persisted row matches.
+	fresh, err := store.GetReshardOperation(op.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh.State != cpconfigstore.ReshardStateRunning || fresh.RunnerCP != "cp-a" || fresh.RunnerEpoch != 1 {
+		t.Fatalf("persisted op = %+v, want running/cp-a/epoch=1", fresh)
+	}
+
+	// A second active op for the same org still conflicts (partial unique index).
+	if err := store.CreateReshardOperationClaimed(newReshardOp("org-cc"), "cp-b"); !errors.Is(err, cpconfigstore.ErrReshardConflict) {
+		t.Fatalf("second create-claimed error = %v, want ErrReshardConflict", err)
+	}
+
+	// A fresh-heartbeat running op is NOT claimable by another replica — the
+	// whole point: cp-b's scanOnce can never win it away from cp-a.
+	if !claimListExcludes(t, store, op.ID) {
+		t.Fatal("create-claimed op is listed as claimable — a sibling replica could steal it")
+	}
+	stolen, err := store.ClaimReshardOperation(op.ID, "cp-b", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if stolen != nil {
+		t.Fatalf("cp-b stole a fresh-heartbeat create-claimed op: %+v", stolen)
+	}
+}
+
+// claimListExcludes reports whether id is absent from the claimable set.
+func claimListExcludes(t *testing.T, store *cpconfigstore.ConfigStore, id int64) bool {
+	t.Helper()
+	ids, err := store.ListClaimableReshardOperations(5 * time.Minute)
+	if err != nil {
+		t.Fatalf("list claimable: %v", err)
+	}
+	for _, got := range ids {
+		if got == id {
+			return false
+		}
+	}
+	return true
+}
+
 // TestReshardCancelPostgres pins the cancel flag on active ops and the
 // immediate finish of unclaimed (pending) ops.
 func TestReshardCancelPostgres(t *testing.T) {

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2410,6 +2410,15 @@ reshard_ext_to_cnpg() { # ext-org password
     || fail "reshard ext→cnpg: start failed: $out"
   opid="$(echo "$out" | jq -r .id)"
 
+  # Claim-on-create regression (multi-replica CP): a password-bearing
+  # (external-source here) op must be created ALREADY claimed by the replica
+  # that holds the ephemeral password — state running + runner_cp set in the
+  # 202 response — so no sibling replica's scanOnce can win it and fail the
+  # copy for want of the password. (Before the fix the op was created pending
+  # and ~2/3 of the time a passwordless replica claimed it.)
+  echo "$out" | jq -e '.state == "running" and (.runner_cp | length > 0)' >/dev/null \
+    || fail "reshard ext→cnpg: op not create-claimed (state/runner_cp): $out"
+
   # Budget: drain (org quiet) + provider-sql role/db create on the shard (the
   # cnpg SASL propagation tail can add minutes — see READY_TIMEOUT) + copy +
   # verify.


### PR DESCRIPTION
## Problem

A cnpg→external reshard on a multi-replica (3×) control plane failed at the copy step:

> external target password is not available to this runner (takeover after a crash?) — cancel and re-run the operation

Root cause: the external target password is **ephemeral** — the admin start handler stashes it in the *local* replica's in-memory map. But the op was created in state `pending`, and every replica's reshard `scanOnce` loop (10s tick) can `ClaimReshardOperation` a pending op. So ~2/3 of the time a replica that does **not** hold the password claimed and ran the op, and the copy failed. The code comments already claimed "claim-on-create" but it was never implemented.

## Fix

Real claim-on-create so the replica that stashed the password is the one that runs the op:

- **`configstore`**: `CreateReshardOperationClaimed(op, runnerCP)` — a single insert that lands the row already `running`, owned by `runnerCP` (`runner_epoch=1`, `heartbeat_at`/`started_at` stamped now). A fresh-heartbeat running op owned by a CP is neither listed nor claimable by any other replica's `scanOnce`, so no sibling can steal it. Still honors the partial-unique-index → `ErrReshardConflict`.
- **`provisioner` runner**: `AdoptClaimedOperation(op, password)` — stashes the password and launches `execute()` directly (no scan-tick wait), running under the runner's **lifecycle context** (new `baseCtx`, set by `Run`), **not** the admin HTTP request context (which is cancelled the moment the 202 returns — a reshard runs for minutes). `r.running` dedups against a racing `scanOnce`. Adds `CPID()`.
- **`admin`**: create-claimed when a local runner exists (mandatory for external targets; lower-latency + uniform for cnpg), then adopt. With no local runner (cnpg only — external already 503s) fall back to a `pending` op any replica may claim. `ReshardPasswordStash` → `ReshardRunnerHandle`.

Failure hardening is unchanged and still correct: a genuine crash-takeover of an external-target op fails with the clear re-run message; because cnpg→ext copies before the flip, a pre-flip failure leaves the cnpg source untouched.

## Tests

- `tests/configstore/reshard_postgres_test.go`: `CreateReshardOperationClaimed` lands running+owned, a second active op → `ErrReshardConflict`, and a sibling replica's `ClaimReshardOperation` returns nil (can't steal a fresh-heartbeat op). *(Docker-gated `*Postgres` tests can't run locally — no docker; written for CI.)*
- `controlplane/provisioner/reshard_runner_test.go`: an op adopted via `AdoptClaimedOperation` executes to completion using the stashed password; the passwordless-runner regression is already covered by `TestReshardExtTargetWithoutPasswordFails`.
- `controlplane/admin/reshard_test.go`: starting an external (and cnpg) reshard create-claims the op (state running, `runner_cp` set) and adopts on the fake runner handle; ephemeral password still never persisted.
- `tests/mw-dev/e2e/harness.sh`: the ext→cnpg positive path now asserts the op comes back `state=running` with a non-empty `runner_cp` (claim-on-create).
- Docs: `docs/design/resharding.md` + `CLAUDE.md` reshard section updated.

`go build ./... && go build -tags kubernetes ./...` clean; `go test -tags kubernetes ./controlplane/provisioner ./controlplane/admin -run TestReshard` passes; harness `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)