### PR TITLE
reshard: fail-fast cnpg→ext at submit (ESO-name allowlist + pre-flight connect check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,13 +561,22 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
   runner memory; never in the op row, log, or audit. Takeover mid-copy fails
   with a clear re-run message instead of proceeding without it.
 - **The ext SM secret must be ESO-readable and a raw string**: the ESO IAM
-  policy only allows `posthog-*`/`duckling-*` names (RDS-managed
-  `rds!…`/`rds/…/master` secrets never work → start handler 400s them,
-  `rdsManagedSecretNamePattern`), and the composition's ExternalSecret copies
-  the whole value verbatim (no JSON property). An unreadable name that slips
-  through just hangs the cutover wait until the per-op timeout, then recovers
-  (flip-back + copy-back). The form teaches the same rules
-  (`ui/src/lib/reshard.ts::classifySecretName`).
+  policy only allows `posthog-*`/`duckling-*` names, so the start handler
+  enforces a POSITIVE allowlist (`esoReadableSecretPrefixes`) — a name outside
+  it is 400'd, with RDS-managed `rds!…`/`rds/…/master` names
+  (`rdsManagedSecretNamePattern`) detected first for a more specific message.
+  The composition's ExternalSecret copies the whole value verbatim (no JSON
+  property). An unreadable name that slips through just hangs the cutover wait
+  until the per-op timeout, then recovers (flip-back + copy-back). The form
+  teaches the same rules (`ui/src/lib/reshard.ts::classifySecretName`).
+- **cnpg→ext fails fast at submit, before the destructive flip**: the flip
+  DELETEs the cnpg source, so both submit-time gates (the ESO-name allowlist
+  above + a bounded `SELECT 1` pre-flight connection check to the external
+  target, `admin.ExternalTargetProber` over `provisioner.PGCatalogCopier.Probe`,
+  `sslmode=require`, wired in `multitenant.go`) 400 a doomed op before anything
+  is created. The prober nil-degrades (tests / non-k8s → check skipped; the
+  runner's copy still catches a bad credential); when present and the connect
+  fails, the op is refused. The 400 never echoes the password.
 - **Runner fencing**: claim bumps `runner_epoch`; every runner write is
   CAS-fenced on (runner, epoch); stale-heartbeat (>5m) ops are takeover-able;
   the copy holds a target-DB advisory lock.

--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -5,11 +5,13 @@ package admin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -66,6 +68,48 @@ var reshardShardNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?
 // it up front.
 var rdsManagedSecretNamePattern = regexp.MustCompile(`^rds[!/]`)
 
+// esoReadableSecretPrefixes is the positive allowlist of Secrets Manager name
+// prefixes the external-secrets IAM role can GetSecretValue on. The policy is
+// identical across every managed-warehouse environment (dev / prod-us /
+// prod-eu) — see the external-secrets-pod-identity terraform module in
+// posthog-cloud-infra — so these two prefixes are hardcoded rather than
+// resolved per-env. A cnpg→external reshard whose SM secret name is outside
+// this set would pass the catalog copy and then hang the destructive cutover on
+// an ESO AccessDenied, so the start handler rejects it up front (Fix 1).
+var esoReadableSecretPrefixes = []string{"posthog-", "duckling-"}
+
+// hasESOReadablePrefix reports whether name begins with a prefix the
+// external-secrets role is allowed to read.
+func hasESOReadablePrefix(name string) bool {
+	for _, p := range esoReadableSecretPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// externalProbeTimeout bounds the pre-flight connection check to the external
+// target so a black-holed endpoint can't hang the admin HTTP handler; a timeout
+// counts as a connect failure → 400.
+const externalProbeTimeout = 8 * time.Second
+
+// ExternalTargetProber verifies the CP can actually reach + authenticate
+// against a cnpg→external reshard target Postgres before the op is created —
+// the destructive cnpg→ext flip (Crossplane DELETEs the source role/DB) happens
+// long after submit, so a doomed credential/endpoint is far cheaper to catch
+// here than after the flip. Satisfied in production by an adapter over
+// provisioner.PGCatalogCopier (wired in controlplane/multitenant.go); nil in
+// tests / non-k8s builds, in which case the check is SKIPPED (the runner's copy
+// step still catches a bad credential later — this is a fail-fast optimization,
+// not the only line of defense).
+type ExternalTargetProber interface {
+	// Probe opens a bounded connection to endpoint (host[:port], default port
+	// 5432) as user/database with password over the given sslmode and runs a
+	// trivial liveness query. It MUST NOT echo the password in its error.
+	Probe(ctx context.Context, endpoint, user, database, password, sslMode string) error
+}
+
 type reshardTargetRequest struct {
 	Type string `json:"type"` // "cnpg-shard" | "external"
 
@@ -92,9 +136,10 @@ type startReshardRequest struct {
 // client unavailable) — starting a reshard then 503s; reads still work.
 // stash may be nil (no local runner) — external targets then 503. cluster may
 // be nil (non-k8s) — shard discovery then falls back to the shards tenants
-// already occupy.
-func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, stash ReshardPasswordStash, cluster kubernetes.Interface) {
-	h := &reshardHandler{store: store, lister: lister, stash: stash, cluster: cluster}
+// already occupy. prober may be nil (tests / non-k8s) — the external target
+// pre-flight connection check is then SKIPPED (see ExternalTargetProber).
+func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, stash ReshardPasswordStash, cluster kubernetes.Interface, prober ExternalTargetProber) {
+	h := &reshardHandler{store: store, lister: lister, stash: stash, cluster: cluster, prober: prober}
 	r.POST("/orgs/:id/reshard", h.start)
 	r.GET("/orgs/:id/reshards", h.listForOrg)
 	r.GET("/reshards", h.listAll)
@@ -109,6 +154,7 @@ type reshardHandler struct {
 	lister  DucklingMetadataLister
 	stash   ReshardPasswordStash
 	cluster kubernetes.Interface
+	prober  ExternalTargetProber
 }
 
 // cnpgShardsNamespace is where the shared CNPG metadata shards run; instance
@@ -258,12 +304,21 @@ func (h *reshardHandler) start(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "external → external is not supported"})
 			return
 		}
-		if strings.TrimSpace(req.Target.Endpoint) == "" || strings.TrimSpace(req.Target.PasswordAWSSecret) == "" {
+		targetEndpoint := strings.TrimSpace(req.Target.Endpoint)
+		targetSecret := strings.TrimSpace(req.Target.PasswordAWSSecret)
+		if targetEndpoint == "" || targetSecret == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "external target requires endpoint and password_aws_secret"})
 			return
 		}
-		if rdsManagedSecretNamePattern.MatchString(strings.TrimSpace(req.Target.PasswordAWSSecret)) {
+		// Fix 1 — the SM secret NAME must be ESO-readable. Detect the more
+		// specific RDS-managed-master shape first (its message is more helpful),
+		// then fall back to the general positive-allowlist message.
+		switch {
+		case rdsManagedSecretNamePattern.MatchString(targetSecret):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "password_aws_secret looks like an RDS-managed master secret (rds!… / rds/…) — the external-secrets role cannot read those, so the cutover would hang on an ESO AccessDenied. Create a Secrets Manager secret whose name the ESO policy allows (e.g. duckling-<name>-…-rds-password) with the raw password string as its value, and use that name"})
+			return
+		case !hasESOReadablePrefix(targetSecret):
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("password_aws_secret %q is not readable by the external-secrets role: its IAM policy only allows Secrets Manager names starting with %s, so the cutover would hang on an ESO AccessDenied. Create a secret whose name starts with one of those (convention: duckling-<name>-<env>-<region>-rds-password) holding the raw password string, and use that name", targetSecret, strings.Join(esoReadableSecretPrefixes, " or "))})
 			return
 		}
 		if req.Target.Password == "" {
@@ -274,9 +329,34 @@ func (h *reshardHandler) start(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no reshard runner on this control plane — external targets unavailable"})
 			return
 		}
+		targetUser := strings.TrimSpace(req.Target.User)
+		if targetUser == "" {
+			targetUser = "postgres"
+		}
+		targetDatabase := strings.TrimSpace(req.Target.Database)
+		if targetDatabase == "" {
+			targetDatabase = "postgres"
+		}
+		// Fix 2 — pre-flight connection check. Prove the CP can reach the target
+		// Postgres AND that the endpoint/user/database/password are valid before
+		// the op is created — the destructive cnpg→ext flip happens much later,
+		// so a doomed target is far cheaper to catch here than after the flip.
+		// External RDS uses sslmode=require (matches the runner's copy of the
+		// external target). Skipped when no prober is configured (tests / non-k8s
+		// — the runner's copy still catches a bad credential later). The error is
+		// redacted: it never echoes the password.
+		if h.prober != nil {
+			probeCtx, cancel := context.WithTimeout(c.Request.Context(), externalProbeTimeout)
+			err := h.prober.Probe(probeCtx, targetEndpoint, targetUser, targetDatabase, req.Target.Password, "require")
+			cancel()
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("cannot connect to the external target %s/%s as %s with the provided password: %v", targetEndpoint, targetDatabase, targetUser, err)})
+				return
+			}
+		}
 		op.TargetKind = configstore.MetadataStoreKindExternal
-		op.TargetEndpoint = strings.TrimSpace(req.Target.Endpoint)
-		op.TargetPasswordSecret = strings.TrimSpace(req.Target.PasswordAWSSecret)
+		op.TargetEndpoint = targetEndpoint
+		op.TargetPasswordSecret = targetSecret
 		op.TargetUser = strings.TrimSpace(req.Target.User)
 		op.TargetDatabase = strings.TrimSpace(req.Target.Database)
 	default:

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -150,17 +151,35 @@ func (f fakeShardLister) CRMetadataStores(context.Context) (map[string]DucklingM
 	return f.stores, nil
 }
 
+// fakeProber records the last probe and returns a canned error (nil = success).
+type fakeProber struct {
+	err    error
+	called bool
+	// last* capture the resolved args so a test can assert defaulting.
+	lastEndpoint, lastUser, lastDatabase, lastPassword, lastSSLMode string
+}
+
+func (p *fakeProber) Probe(_ context.Context, endpoint, user, database, password, sslMode string) error {
+	p.called = true
+	p.lastEndpoint, p.lastUser, p.lastDatabase, p.lastPassword, p.lastSSLMode = endpoint, user, database, password, sslMode
+	return p.err
+}
+
 func reshardRouter(store *fakeReshardStore) *gin.Engine {
-	return reshardRouterWithCluster(store, nil)
+	return reshardRouterFull(store, nil, nil)
 }
 
 func reshardRouterWithCluster(store *fakeReshardStore, cluster kubernetes.Interface) *gin.Engine {
+	return reshardRouterFull(store, cluster, nil)
+}
+
+func reshardRouterFull(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	lister := fakeShardLister{stores: map[string]DucklingMetadataStore{
 		"acme": {Kind: "cnpg-shard", Endpoint: "shard-001-pooler.cnpg-shards.svc.cluster.local"},
 	}}
-	RegisterReshardAPI(r.Group("/api/v1"), store, lister, store, cluster)
+	RegisterReshardAPI(r.Group("/api/v1"), store, lister, store, cluster, prober)
 	return r
 }
 
@@ -240,13 +259,104 @@ func TestReshardStartValidation(t *testing.T) {
 	}
 }
 
+// TestReshardExtSecretNameValidation pins the positive ESO-readable allowlist
+// (Fix 1): posthog-/duckling- names reach op creation; an RDS-managed master
+// name gets the specific rds message; any other prefix gets the general
+// allowlist message. No prober here (nil) so the connection check is skipped.
+func TestReshardExtSecretNameValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		secret     string
+		wantCode   int
+		wantSubstr string
+	}{
+		{"posthog prefix accepted", "posthog-x", http.StatusAccepted, ""},
+		{"duckling prefix accepted", "duckling-x", http.StatusAccepted, ""},
+		{"rds slash master rejected", "rds/some-db/master", http.StatusBadRequest, "RDS-managed master secret"},
+		{"rds bang managed rejected", "rds!db-0000-1111", http.StatusBadRequest, "RDS-managed master secret"},
+		{"other prefix rejected", "whatever-else", http.StatusBadRequest, "is not readable by the external-secrets role"},
+	}
+	for _, tc := range cases {
+		store := newFakeReshardStore()
+		body := `{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"` + tc.secret + `","password":"p"}}`
+		w := doJSON(reshardRouter(store), http.MethodPost, "/api/v1/orgs/acme/reshard", body)
+		if w.Code != tc.wantCode {
+			t.Errorf("%s: status = %d body %s, want %d", tc.name, w.Code, w.Body.String(), tc.wantCode)
+			continue
+		}
+		if tc.wantSubstr != "" && !strings.Contains(w.Body.String(), tc.wantSubstr) {
+			t.Errorf("%s: body %s, want substring %q", tc.name, w.Body.String(), tc.wantSubstr)
+		}
+		if tc.wantCode == http.StatusAccepted {
+			if len(store.ops) != 1 {
+				t.Errorf("%s: op not created (%d ops)", tc.name, len(store.ops))
+			}
+		} else if len(store.ops) != 0 {
+			t.Errorf("%s: op created despite rejection (%d ops)", tc.name, len(store.ops))
+		}
+	}
+}
+
+// TestReshardExtPreflightProbe pins Fix 2: a passing prober lets the op be
+// created (202); a failing prober rejects with a redacted 400 and creates NO
+// op; a nil prober skips the check (op created). It also pins that the probe
+// received the defaulted user/database + sslmode=require and that neither the
+// error body nor any log leaks the password.
+func TestReshardExtPreflightProbe(t *testing.T) {
+	body := `{"target":{"type":"external","endpoint":"rds.example.com:6543","password_aws_secret":"duckling-x","password":"hunter2"}}`
+
+	// Passing prober → 202, op created, probe saw the resolved args.
+	store := newFakeReshardStore()
+	pb := &fakeProber{}
+	w := doJSON(reshardRouterFull(store, nil, pb), http.MethodPost, "/api/v1/orgs/acme/reshard", body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("passing prober: status = %d body %s, want 202", w.Code, w.Body.String())
+	}
+	if !pb.called {
+		t.Fatal("passing prober: probe was not called")
+	}
+	if pb.lastEndpoint != "rds.example.com:6543" || pb.lastUser != "postgres" || pb.lastDatabase != "postgres" || pb.lastSSLMode != "require" {
+		t.Fatalf("passing prober: probe args = %q/%q/%q sslmode=%q, want defaulted postgres + require", pb.lastEndpoint, pb.lastUser, pb.lastDatabase, pb.lastSSLMode)
+	}
+	if len(store.ops) != 1 {
+		t.Fatalf("passing prober: op count = %d, want 1", len(store.ops))
+	}
+
+	// Failing prober → 400, redacted message, NO op created.
+	store = newFakeReshardStore()
+	pb = &fakeProber{err: errors.New("connection refused")}
+	w = doJSON(reshardRouterFull(store, nil, pb), http.MethodPost, "/api/v1/orgs/acme/reshard", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("failing prober: status = %d body %s, want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cannot connect to the external target") || !strings.Contains(w.Body.String(), "connection refused") {
+		t.Fatalf("failing prober: body %s, want the redacted connect-failure message", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "hunter2") {
+		t.Fatal("failing prober: error body leaked the password")
+	}
+	if len(store.ops) != 0 {
+		t.Fatalf("failing prober: op created despite connect failure (%d ops)", len(store.ops))
+	}
+
+	// Nil prober → check skipped, op created.
+	store = newFakeReshardStore()
+	w = doJSON(reshardRouterFull(store, nil, nil), http.MethodPost, "/api/v1/orgs/acme/reshard", body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("nil prober: status = %d body %s, want 202", w.Code, w.Body.String())
+	}
+	if len(store.ops) != 1 {
+		t.Fatalf("nil prober: op count = %d, want 1", len(store.ops))
+	}
+}
+
 // TestReshardExtPasswordStashedNotPersisted pins the ephemeral-password
 // contract: the password reaches the stash, the op row carries only the
 // secret NAME, and neither the response nor the log contains the password.
 func TestReshardExtPasswordStashedNotPersisted(t *testing.T) {
 	store := newFakeReshardStore()
 	w := doJSON(reshardRouter(store), http.MethodPost, "/api/v1/orgs/acme/reshard",
-		`{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"my-secret","user":"postgres","database":"postgres","password":"hunter2"}}`)
+		`{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"duckling-my-secret","user":"postgres","database":"postgres","password":"hunter2"}}`)
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d body %s, want 202", w.Code, w.Body.String())
 	}
@@ -254,7 +364,7 @@ func TestReshardExtPasswordStashedNotPersisted(t *testing.T) {
 		t.Fatalf("stash = %v, want the password handed to the runner", store.stashed)
 	}
 	op := store.ops[1]
-	if op.TargetPasswordSecret != "my-secret" || op.TargetEndpoint != "rds.example.com" {
+	if op.TargetPasswordSecret != "duckling-my-secret" || op.TargetEndpoint != "rds.example.com" {
 		t.Fatalf("op = %+v", op)
 	}
 	if strings.Contains(w.Body.String(), "hunter2") {

--- a/controlplane/admin/ui/src/lib/reshard.ts
+++ b/controlplane/admin/ui/src/lib/reshard.ts
@@ -5,10 +5,12 @@
 // `duckling-*` in every managed-warehouse environment (see the
 // external-secrets-pod-identity terraform module in posthog-cloud-infra). An
 // RDS-managed master secret (`rds!db-…` / `rds/…/master`) never matches, so
-// the cutover would hang on an ESO AccessDenied; the server rejects those
-// with a 400 and the form warns before submit. Names outside the known
-// prefixes only WARN (soft): the prefix list is per-environment terraform and
-// the console can't know its environment's extras.
+// the cutover would hang on an ESO AccessDenied. The server enforces a POSITIVE
+// allowlist: it 400s any name that isn't `posthog-`/`duckling-`-prefixed (the
+// RDS-managed shape gets a more specific message). The two prefixes are
+// identical across every managed-warehouse environment, so this classifier
+// mirrors the server rule and warns before submit — an unknown prefix will be
+// rejected, not merely flagged.
 export type SecretNameVerdict = "empty" | "rds-managed" | "unknown-prefix" | "ok";
 
 export function classifySecretName(name: string): SecretNameVerdict {

--- a/controlplane/admin/ui/src/pages/ReshardForm.tsx
+++ b/controlplane/admin/ui/src/pages/ReshardForm.tsx
@@ -264,10 +264,11 @@ export function ReshardForm() {
                       </p>
                     )}
                     {secretVerdict === "unknown-prefix" && (
-                      <p className="flex items-start gap-1 text-xs text-warning">
+                      <p className="flex items-start gap-1 text-xs text-destructive">
                         <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
                         Name doesn't start with duckling- or posthog- — the ESO role can only read
-                        secrets matching its allowed name prefixes. Double-check before running.
+                        secrets matching those prefixes, so the server will reject this. Rename the
+                        secret to duckling-…-rds-password (same password) and use that.
                       </p>
                     )}
                   </div>

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -21,6 +23,32 @@ import (
 	"github.com/posthog/duckgres/server"
 	"k8s.io/client-go/kubernetes"
 )
+
+// catalogCopierProber adapts provisioner.PGCatalogCopier's SELECT-1 probe to
+// the admin.ExternalTargetProber seam so the reshard start handler can
+// fail-fast a doomed cnpg→external target (unreachable endpoint / wrong
+// credentials / missing DB) BEFORE the destructive flip. It parses the
+// admin-supplied endpoint as host[:port] (default 5432), mirroring how the
+// reshard runner builds the external target CatalogEndpoint.
+type catalogCopierProber struct{}
+
+func (catalogCopierProber) Probe(ctx context.Context, endpoint, user, database, password, sslMode string) error {
+	host, port := endpoint, 5432
+	if h, p, err := net.SplitHostPort(endpoint); err == nil {
+		host = h
+		if n, convErr := strconv.Atoi(p); convErr == nil {
+			port = n
+		}
+	}
+	return provisioner.PGCatalogCopier{}.Probe(ctx, provisioner.CatalogEndpoint{
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Database: database,
+		Password: password,
+		SSLMode:  sslMode,
+	})
+}
 
 // orgRouterAdapter wraps OrgRouter to implement both OrgRouterInterface
 // (for the control plane) and admin.OrgStackInfo (for the admin API).
@@ -577,7 +605,11 @@ func SetupMultiTenant(
 	if reshardRunner != nil {
 		reshardStash = reshardRunner
 	}
-	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardStash, clusterClient)
+	// Pre-flight prober for cnpg→external targets: reuses the catalog copier's
+	// SELECT-1 probe to fail-fast an unreachable/bad-credential target before
+	// the destructive flip. Always available in the k8s CP build; nil-degrades
+	// in tests / non-k8s (the runner's copy still catches a bad credential).
+	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardStash, clusterClient, catalogCopierProber{})
 
 	// Break-glass internal-secret login (the SPA owns "/" and app routes).
 	admin.RegisterLogin(engine, adminTokens)

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -125,13 +125,36 @@ IAM role can only `GetSecretValue` on a per-env name-prefix allowlist —
 so an RDS-managed master secret (`rds!db-…` / `rds/…/master`) is NEVER
 readable and would hang the cutover on an ESO AccessDenied. Defenses: the reshard form documents the convention
 (`duckling-<name>-<env>-<region>-rds-password`) and warns live on suspicious
-names (`classifySecretName`), and the start handler 400s names matching
-`^rds[!/]` (`rdsManagedSecretNamePattern`). If a name that slips through is
+names (`classifySecretName`), and the start handler enforces a **positive
+allowlist** — the SM secret name MUST start with `posthog-` or `duckling-`
+(`esoReadableSecretPrefixes`), else 400. RDS-managed names (`^rds[!/]`,
+`rdsManagedSecretNamePattern`) are detected first and get a more specific
+message; any other non-allowlisted name gets the general allowlist message.
+The two prefixes are identical across every env, so they're hardcoded (not
+resolved per-env). If a name that slips through is
 still unreadable by ESO, the cutover simply waits for the status password
 until its per-op timeout and then recovers (below) — the op log shows the
 generic "waiting for external target" line. (Surfacing the ExternalSecret's
 own AccessDenied into the op log would need an `external-secrets.io` read
 grant on the CP SA, which it does not have; not worth the extra RBAC.)
+
+**Pre-flight connection check (fail before the destructive flip).** The
+cnpg→ext flip is destructive — Crossplane DELETEs the cnpg source role/DB on
+the TYPE change, so a doomed external target that only fails *after* the flip
+forces the flip-back + copy-back recovery, which can wedge a Crossplane Role
+MR for a long time. Two submit-time gates make a doomed op fail fast with a
+400 (nothing created): Fix 1 above (the ESO-readable name allowlist), and a
+bounded `SELECT 1` against the target Postgres (`ExternalTargetProber`, an
+adapter over `provisioner.PGCatalogCopier.Probe` wired in `multitenant.go`)
+that proves endpoint reachability + the user/database/password all work,
+before any maintenance window or flip. External RDS uses `sslmode=require`
+(matches the runner's copy). The whole check is bounded (~8s) so a black-holed
+endpoint can't hang the handler; a timeout counts as a connect failure. The
+400 message is redacted (never echoes the password). The prober nil-degrades
+in tests / non-k8s builds — the check is then skipped and the runner's copy
+step still catches a bad credential later (fail-fast optimization, not the
+only line of defense). When the prober IS present and the connect fails, the
+op is refused.
 
 **Recovery if the flip goes bad** (ESO secret missing/mismatched): flip back
 to the source shard — provider-sql re-creates the role/DB **empty** — then
@@ -159,8 +182,10 @@ where the source is rebuilt rather than left untouched.
 Unit: `configstore` (tests/configstore/reshard_postgres_test.go — claim CAS,
 takeover fencing, cancel, log pagination, the grant-path gate),
 `provisioner/reshard_runner_test.go` (all three directions, rollbacks, cancel,
-ephemeral-password loss), `admin/reshard_test.go` (validation, secrets never
-persisted). e2e (`tests/mw-dev/e2e/harness.sh`): validation 400s,
+ephemeral-password loss), `admin/reshard_test.go` (validation incl. the
+ESO-name allowlist + the pre-flight connection-check pass/fail/skip, secrets
+never persisted). e2e (`tests/mw-dev/e2e/harness.sh`): validation 400s (incl. a
+non-allowlisted external secret name),
 cancel-during-drain (drain-not-kill + 57P03 visible), bogus-shard rollback
 (real flip → Synced=False → rollback, data intact), and the **ext→cnpg
 positive path** (real catalog move off the harness RDS onto shard-001).

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2301,17 +2301,25 @@ reshard_targets() { # destination discovery; ext org's RDS must appear too
 
 reshard_validation() { # cnpg-org currently on shard-001
   log "reshard validation: same-shard + bad targets are 400"
-  # The last two pin the RDS-managed-master-secret rejection: names matching
-  # rds/… or rds!… are outside the ESO IAM policy's allowed prefixes
-  # (posthog-*/duckling-*), so a cutover pointed at one would hang on an ESO
-  # AccessDenied — the start handler refuses them up front.
+  # The RDS-managed-master and generic-prefix rows pin Fix 1's positive ESO
+  # allowlist: the external-secrets IAM policy only allows GetSecretValue on
+  # posthog-*/duckling-* names, so the start handler 400s an SM secret name
+  # outside that set (rds/…/rds!… gets the more-specific RDS-managed message,
+  # anything else the general allowlist message) — otherwise the destructive
+  # cnpg→ext cutover would hang on an ESO AccessDenied. All of these are
+  # rejected at name validation, BEFORE the pre-flight connection check (Fix 2),
+  # so they need no reachable target. The connect check itself needs a real
+  # reachable RDS + a valid password, which this Job lacks (same reason the
+  # cnpg→ext positive path is unit-only), so it stays covered by
+  # controlplane/admin/reshard_test.go (TestReshardExtPreflightProbe).
   for body in \
     '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-001"}}' \
     '{"target":{"type":"cnpg-shard","cnpg_shard":"Bad_Shard"}}' \
     '{"target":{"type":"nonsense"}}' \
     '{"target":{"type":"external","endpoint":"x"}}' \
     '{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds/some-db/master","password":"p"}}' \
-    '{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-0000-1111","password":"p"}}'; do
+    '{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-0000-1111","password":"p"}}' \
+    '{"target":{"type":"external","endpoint":"x","password_aws_secret":"my-own-secret","password":"p"}}'; do
     code="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "$H" -H 'Content-Type: application/json' \
       -d "$body" "$API/api/v1/orgs/$1/reshard")"
     [ "$code" = "400" ] || fail "reshard validation: body $body -> $code, want 400"


### PR DESCRIPTION
## Why

The cnpg→external reshard escape hatch is **destructive at the flip**: on the metadata-store TYPE change, Crossplane DELETEs the cnpg source role/DB. A doomed external target that only fails *after* the flip forces the flip-back + copy-back recovery, which can wedge a Crossplane Role managed-resource for a long time. Two cheap submit-time gates make a doomed op fail fast with a `400` (nothing created), before the destructive flip / before entering maintenance mode. Both live in the admin reshard `start` handler (`controlplane/admin/reshard.go`, external `case`), in the validation region above op creation.

## Fix 1 — positive ESO-readable secret-name allowlist

The external-secrets IAM policy only allows `GetSecretValue` on `posthog-*` / `duckling-*` names (identical across dev / prod-us / prod-eu). The previous rds-only reject is replaced with a **positive allowlist** (`esoReadableSecretPrefixes`, one greppable place):

- RDS-managed names (`^rds[!/]`) are detected **first** → keep the specific "RDS-managed master secret is never ESO-readable" message.
- Any other non-allowlisted name → general allowlist message citing the constraint and the working convention (`duckling-<name>-<env>-<region>-rds-password`).

The two prefixes are the same everywhere, so they're hardcoded with a comment citing the terraform module (no per-env logic).

## Fix 2 — pre-flight connection check to the external target

Before creating the op, a bounded (~8s) `SELECT 1` against the target Postgres proves endpoint reachability + user/database/password all work — before any maintenance window or destructive flip. On failure, a **redacted** `400` (`cannot connect to the external target <endpoint>/<database> as <user> with the provided password: <err>`), never echoing the password.

- New `admin.ExternalTargetProber` seam, satisfied by an adapter (`catalogCopierProber` in `multitenant.go`) over `provisioner.PGCatalogCopier.Probe`. No import cycle (provisioner only imports configstore; the adapter lives in the root package that already imports both).
- Injected through `RegisterReshardAPI`. **Nil-degrades**: no prober configured (tests / non-k8s) → check **skipped** (the runner's copy still catches a bad credential later — this is a fail-fast optimization, not the only line of defense). Prober present + connect fails → `400`.
- `sslmode=require` (external RDS; matches the runner's copy). Timeout counts as a connect failure → `400`.

## Tests

- `controlplane/admin/reshard_test.go`: table-driven name validation (`posthog-x`/`duckling-x` → op created; `rds/…/master` → rds message; `whatever-else` → allowlist message) and the connection check (fake prober nil → 202, error → redacted 400 with **no op created**, nil prober → skipped/202). Existing ephemeral-password test updated to an allowlisted secret name.
- `tests/mw-dev/e2e/harness.sh`: `reshard_validation` gains a non-allowlisted external secret name → `400` (rejected at name validation, needs no reachable target). The live connect check needs a real reachable RDS + valid password the Job lacks (same reason cnpg→ext positive path is unit-only), so it stays covered by the unit test — noted in the harness comment.
- UI: `classifySecretName` guidance + the `ReshardForm` warning updated so the form reflects that the server now **rejects** (not merely flags) an unknown prefix. `npm run build` + the classifier vitest pass.

## Verify

`go build ./...` and `go build -tags kubernetes ./...` clean. `go test -tags kubernetes ./controlplane/admin -run TestReshard -count=1` passes (docker-gated `*Postgres` tests fail locally without docker — unrelated). `bash -n tests/mw-dev/e2e/harness.sh` clean. Docs updated in the same PR (`docs/design/resharding.md`, `CLAUDE.md` reshard section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)