### PR TITLE
reshard: orphan-adopt then verified-delete for the cnpg→ext escape hatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,9 +551,28 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
   Flight sessions are destroyed locally per CP (they'd hold leases ~1h).
 - **Flip semantics differ by direction**: a `cnpgShard` change re-points
   role/DB in place (source ORPHANED — explicit cleanup after verify); a TYPE
-  flip to external makes Crossplane DELETE the cnpg role/DB → cnpg→ext runs
-  **copy-before-flip** (the flip IS the cleanup, only after verify).
-  **External stores are never modified/deleted.**
+  flip to external un-renders the cnpg MRs, and whether Crossplane then DELETES
+  or ORPHANS the role/DB depends on `spec.metadataStore.retainCnpgOnFlip`
+  (charts). **External stores are never modified/deleted.**
+- **cnpg→ext escape hatch = orphan-adopt then verified-delete** (charts
+  `retainCnpgOnFlip`): copy → verify source → set `retainCnpgOnFlip=true` AND
+  poll the cnpg Role/Database MRs until they carry the no-Delete policy (two-step
+  flip, closes the un-render-before-policy race) → flip type to external (now
+  ORPHANS, not deletes, the cnpg role/DB) → verify the external catalog row
+  counts match the copy EXACTLY → only THEN `DROP DATABASE` the retained source +
+  clear the flag. ANY failure before that drop → flip back to cnpg-shard +
+  clear flag in one patch (`SetMetadataStoreCnpgAdopt`), provider-sql re-ADOPTS
+  the still-present role/DB by external-name — NO copy-back, NO empty-recreate
+  (replaces the old recreate+copy-back recovery that caused a data-loss
+  incident). **XRD-compat**: if the read-back shows the cluster's XRD lacks
+  `retainCnpgOnFlip` (patch pruned), REFUSE the reshard ("deploy charts first")
+  — safer than the destructive delete-on-flip.
+- **DEPROVISION-UNAFFECTED (non-negotiable)**: `retainCnpgOnFlip` defaults false
+  and is true only transiently mid-reshard; a normal never-resharded cnpg tenant
+  always has it false → its cnpg Role/DB render with full lifecycle `["*"]`
+  (Delete) → deprovision (Duckling delete → finalizer) drops them exactly as
+  before. The orphan is bound to the reshard type-flip, NEVER to Duckling
+  deletion. `lifecycle_teardown_cnpg` in the e2e is the regression net.
 - **Rollback patches the source shard VALUE back — never removes the key**
   (precedence would fall through to the freshly-stamped bogus status pin);
   ext→cnpg rollback must null `cnpgShard` (XRD CEL forbids it on external).
@@ -584,8 +603,12 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
 - Touching any of this → update `tests/configstore/reshard_postgres_test.go`,
   `provisioner/reshard_runner_test.go`, `admin/reshard_test.go`, the
   migration asserts in `tests/configstore/migrations_postgres_test.go`, AND
-  the `reshard_*` assertions in `tests/e2e-mw-dev/harness.sh` (validation,
-  cancel-during-drain, bogus-shard-rollback, ext→cnpg positive path).
+  the `reshard_*` + `lifecycle_teardown_cnpg` assertions in
+  `tests/e2e-mw-dev/harness.sh` (validation, cancel-during-drain,
+  bogus-shard-rollback, ext→cnpg positive path, and the deprovision-unaffected
+  net). The cnpg→ext orphan-adopt charts side (composition managementPolicies +
+  `retainCnpgOnFlip` XRD field) lives in the `charts` repo and is covered by
+  `charts/charts/crossplane-config/tests/composition_retain_cnpg_test.sh`.
   cnpg→ext positive path is unit-only (harness lacks the RDS password);
   cnpg→cnpg positive path needs a second mw-dev shard (follow-up).
 

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -697,11 +697,16 @@ type ExternalMetadataStoreSpec struct {
 // SetMetadataStoreExternal patches the metadata store to external in one
 // merge patch, REMOVING cnpgShard (JSON merge patch null) — the XRD's CEL
 // forbids cnpgShard on the external type, so leaving the key would fail
-// admission. Used for the cnpg→ext escape-hatch flip and as the ext→cnpg
+// admission. It deliberately does NOT touch retainCnpgOnFlip: the reshard
+// runner sets that true BEFORE this flip so the un-render ORPHANS the cnpg
+// role/DB. Used for the cnpg→ext escape-hatch flip and as the ext→cnpg
 // rollback patch. NOTE: this flip makes the composition STOP rendering the
-// cnpg Role/Database managed resources — Crossplane then DELETES the cnpg
-// role/database. Callers sequence this only after the catalog has been
-// copied and verified elsewhere.
+// cnpg Role/Database managed resources. Whether Crossplane then DELETES the
+// cnpg role/database or ORPHANS it depends on their managementPolicies:
+// retainCnpgOnFlip=true renders them WITHOUT Delete, so the flip orphans (the
+// orphan-adopt safety net); false (a normal tenant) renders them WITH Delete,
+// so the flip deletes them. Callers sequence this only after the catalog has
+// been copied and verified elsewhere.
 func (d *DucklingClient) SetMetadataStoreExternal(ctx context.Context, name string, ext ExternalMetadataStoreSpec) error {
 	if ext.Endpoint == "" || ext.PasswordAWSSecret == "" {
 		return fmt.Errorf("patch duckling CR %q metadata store to external: endpoint and passwordAwsSecret are required", name)
@@ -735,6 +740,160 @@ func (d *DucklingClient) SetMetadataStoreExternal(ctx context.Context, name stri
 		return fmt.Errorf("patch duckling CR %q metadata store to external: %w", name, err)
 	}
 	return nil
+}
+
+// SetMetadataStoreRetainCnpgOnFlip patches spec.metadataStore.retainCnpgOnFlip
+// on the named Duckling CR (JSON merge patch, idempotent, touches only that
+// field). true makes the composition render the per-tenant cnpg Role/Database
+// MRs WITHOUT Delete (managementPolicies ["Observe","Create","Update"], the v2
+// Orphan equivalent), so a subsequent type flip cnpg-shard→external ORPHANS the
+// role/DB instead of deleting them — the cnpg→external reshard escape hatch's
+// orphan-adopt safety net. false restores full lifecycle (Delete) so a normal
+// deprovision drops them. Callers MUST read the value back with
+// GetMetadataStoreRetainCnpgOnFlip: an XRD predating the field silently prunes
+// the patch, so a successful Patch alone does not mean the flag applied.
+func (d *DucklingClient) SetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string, retain bool) error {
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"retainCnpgOnFlip": retain,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal retainCnpgOnFlip patch for %q: %w", name, err)
+	}
+	_, err = d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patch duckling CR %q metadataStore retainCnpgOnFlip: %w", name, err)
+	}
+	return nil
+}
+
+// GetMetadataStoreRetainCnpgOnFlip reads spec.metadataStore.retainCnpgOnFlip.
+// present is false when the key is absent — which, right after a
+// SetMetadataStoreRetainCnpgOnFlip(true), means the cluster's Duckling XRD
+// predates the field and the API server pruned the patch. The reshard runner
+// uses a post-set read-back (retain==true) to decide whether it is safe to
+// flip: if the field did not stick it REFUSES the cnpg→external flip rather
+// than risk the destructive delete-on-flip with no orphan-adopt safety net.
+func (d *DucklingClient) GetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string) (retain, present bool, err error) {
+	cr, gerr := d.getCR(ctx, name)
+	if gerr != nil {
+		return false, false, fmt.Errorf("get duckling CR %q: %w", name, gerr)
+	}
+	spec, ok := cr.Object["spec"].(map[string]interface{})
+	if !ok {
+		return false, false, nil
+	}
+	ms, ok := spec["metadataStore"].(map[string]interface{})
+	if !ok {
+		return false, false, nil
+	}
+	v, ok := ms["retainCnpgOnFlip"].(bool)
+	if !ok {
+		return false, false, nil
+	}
+	return v, true, nil
+}
+
+// SetMetadataStoreCnpgAdopt is the cnpg→external orphan-adopt RECOVERY patch: it
+// flips the metadata store back to a cnpg shard AND clears retainCnpgOnFlip in
+// ONE merge patch. The composition re-renders the per-tenant cnpg Role/Database
+// MRs at full lifecycle (Delete restored) and provider-sql ADOPTS the
+// still-present orphaned role/DB by external-name (same pgIdent, same pinned
+// password) — instant recovery, no empty-recreate, no copy-back. Clearing the
+// flag in the same patch closes any window where the tenant is back on cnpg but
+// a deprovision would orphan (leak) the role/DB. Any leftover external block is
+// ignored by the composition for the cnpg-shard type (as with SetMetadataStoreCnpg).
+func (d *DucklingClient) SetMetadataStoreCnpgAdopt(ctx context.Context, name, shard string) error {
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"type":             configstore.MetadataStoreKindCnpgShard,
+				"cnpgShard":        shard,
+				"retainCnpgOnFlip": false,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal cnpg-adopt patch for %q: %w", name, err)
+	}
+	_, err = d.client.Resource(ducklingGVR).Namespace(ducklingNamespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patch duckling CR %q metadata store to cnpg (adopt): %w", name, err)
+	}
+	return nil
+}
+
+// cnpgTenantMRGroup is the provider-sql API group the per-tenant cnpg Role and
+// Database managed resources belong to (the composition's cnpg-tenant-role /
+// cnpg-tenant-database composed resources).
+const cnpgTenantMRGroup = "postgresql.sql.m.crossplane.io"
+
+// CnpgSourceMRsOrphaned reports whether the named Duckling's per-tenant cnpg
+// Role AND Database managed resources currently carry the retain (no-Delete)
+// managementPolicies — i.e. a type flip away from cnpg-shard will ORPHAN them
+// rather than delete them. present is true only when BOTH MRs were found (while
+// type is cnpg-shard the composite renders exactly one Role + one Database, the
+// source's). The reshard runner polls this after setting retainCnpgOnFlip=true
+// and only flips once both MRs reflect the policy — closing the race where the
+// flip un-renders the MRs before the retain policy propagated.
+func (d *DucklingClient) CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, err error) {
+	cr, gerr := d.getCR(ctx, name)
+	if gerr != nil {
+		return false, false, fmt.Errorf("get duckling CR %q: %w", name, gerr)
+	}
+	var roleFound, dbFound, roleNoDelete, dbNoDelete bool
+	for _, ref := range nestedComposedRefs(cr) {
+		gvr, kind, refName, ok := composedRefGVR(ref)
+		if !ok || gvr.Group != cnpgTenantMRGroup {
+			continue
+		}
+		if kind != "Role" && kind != "Database" {
+			continue
+		}
+		obj, gerr := d.client.Resource(gvr).Namespace(ducklingNamespace).Get(ctx, refName, metav1.GetOptions{})
+		if gerr != nil {
+			if apierrors.IsNotFound(gerr) {
+				continue
+			}
+			return false, false, fmt.Errorf("get %s %q: %w", kind, refName, gerr)
+		}
+		noDelete := !managementPoliciesHaveDelete(obj)
+		switch kind {
+		case "Role":
+			roleFound, roleNoDelete = true, noDelete
+		case "Database":
+			dbFound, dbNoDelete = true, noDelete
+		}
+	}
+	present = roleFound && dbFound
+	orphaned = present && roleNoDelete && dbNoDelete
+	return orphaned, present, nil
+}
+
+// managementPoliciesHaveDelete reports whether a managed resource's
+// spec.managementPolicies includes Delete (or the "*" wildcard). An
+// absent/empty field means the MR uses Crossplane's default ["*"] (full
+// lifecycle), so it is treated as HAVING Delete — the conservative reading:
+// only an explicit no-Delete policy counts as orphan-ready.
+func managementPoliciesHaveDelete(obj *unstructured.Unstructured) bool {
+	spec, _ := obj.Object["spec"].(map[string]interface{})
+	raw, ok := spec["managementPolicies"].([]interface{})
+	if !ok || len(raw) == 0 {
+		return true
+	}
+	for _, p := range raw {
+		if s, _ := p.(string); s == "Delete" || s == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 // readSpecDuckLakeEnabled returns spec.ducklake.enabled as *bool — nil when the

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -26,9 +26,12 @@ import (
 // provider-sql MRs in place, orphaning the old role/DB) → verify stability →
 // cleanup source (cnpg sources only) → finalize.
 //
-// cnpg→external inverts copy and flip: the type flip makes the composition
-// stop rendering the cnpg Role/Database MRs and Crossplane DELETES them, so
-// the flip IS the source cleanup and only runs after the copy verified.
+// cnpg→external inverts copy and flip: copy → verify source → ORPHAN the cnpg
+// source (retainCnpgOnFlip=true, so the type flip un-renders the cnpg MRs
+// WITHOUT deleting the role/DB) → flip type to external → verify the external
+// catalog is complete → only THEN drop the orphaned cnpg source. Any failure
+// before that drop flips back to cnpg-shard and re-adopts the still-present
+// role/DB by external-name — instant recovery, no empty-recreate, no copy-back.
 type ReshardRunner struct {
 	store    reshardStore
 	duckling reshardDucklingClient
@@ -90,6 +93,11 @@ type reshardDucklingClient interface {
 	SetCompactionEnabled(ctx context.Context, name string, enabled *bool) error
 	SetMetadataStoreCnpg(ctx context.Context, name, shard string) error
 	SetMetadataStoreExternal(ctx context.Context, name string, ext ExternalMetadataStoreSpec) error
+	// cnpg→external orphan-adopt escape hatch:
+	SetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string, retain bool) error
+	GetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string) (retain, present bool, err error)
+	CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, err error)
+	SetMetadataStoreCnpgAdopt(ctx context.Context, name, shard string) error
 }
 
 // NewReshardRunner builds a runner over the real config store + duckling
@@ -222,6 +230,11 @@ type opRun struct {
 	blocked          bool
 	compactionPaused bool
 	flipped          bool
+	// retainRequested: we set retainCnpgOnFlip=true on the source (cnpg→ext
+	// orphan step). If we roll back BEFORE the flip, reset it to false so the
+	// still-cnpg source keeps full-lifecycle (Delete) MRs and deprovision stays
+	// clean. (After the flip, recoverFromExternal's adopt patch clears it.)
+	retainRequested bool
 
 	// resolved source/target connection info (source recorded pre-flip)
 	source CatalogEndpoint
@@ -383,17 +396,34 @@ func (o *opRun) run(ctx context.Context, fenced <-chan struct{}) error {
 	}
 
 	toExternal := o.op.TargetKind == configstore.MetadataStoreKindExternal
+	cnpgSource := o.op.SourceKind == configstore.MetadataStoreKindCnpgShard
 	if toExternal {
-		// Escape hatch: copy BEFORE flip — the type flip deletes the cnpg
-		// source role/DB, so it doubles as the cleanup and must come last.
+		// Escape hatch (orphan-adopt then verified-delete): copy BEFORE flip,
+		// orphan the cnpg source so the flip does NOT delete it, flip, verify
+		// the external target caught the full catalog, and only THEN drop the
+		// orphaned cnpg source. Any failure before the drop flips back and
+		// re-adopts the still-present role/DB.
 		if err := o.copyCatalog(ctx); err != nil {
 			return err
 		}
 		if err := o.verifySourceStable(ctx); err != nil {
 			return err
 		}
+		if cnpgSource {
+			if err := o.orphanCnpgSource(ctx); err != nil {
+				return err
+			}
+		}
 		if err := o.flipToExternal(ctx); err != nil {
 			return err
+		}
+		if err := o.verifyExternalCatalog(ctx); err != nil {
+			return err
+		}
+		if cnpgSource {
+			if err := o.dropOrphanedCnpgSource(ctx); err != nil {
+				return err
+			}
 		}
 	} else {
 		if err := o.flipToCnpg(ctx); err != nil {
@@ -677,13 +707,82 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 	}
 }
 
-// flipToExternal is the cnpg→ext cutover: runs only AFTER copy+verify (the
-// flip deletes the cnpg source role/DB — it IS the cleanup).
+// orphanCnpgSource makes the cnpg source role/DB survive the upcoming type
+// flip: it sets spec.metadataStore.retainCnpgOnFlip=true (composition renders
+// the cnpg Role/Database MRs WITHOUT Delete) and waits until BOTH MRs reflect
+// that no-Delete policy before returning — so the subsequent flip orphans them
+// instead of deleting them. Two guards make this safe:
+//   - XRD-compat: after the patch we read the flag back; if it did not stick
+//     (present=false / retain=false) the cluster's Duckling XRD predates the
+//     field, so we REFUSE the flip — the destructive delete-on-flip with no
+//     orphan-adopt safety net is exactly what this whole change avoids.
+//   - Race close: we poll the actual Role/Database MRs' managementPolicies and
+//     only proceed once both are no-Delete, so the flip can never un-render the
+//     MRs before the retain policy propagated.
+func (o *opRun) orphanCnpgSource(ctx context.Context) error {
+	if err := o.step("orphaning_source"); err != nil {
+		return err
+	}
+	o.logf("info", "retaining the cnpg source role/DB across the flip (retainCnpgOnFlip=true) so the type flip ORPHANS them instead of deleting them")
+	if err := o.r.duckling.SetMetadataStoreRetainCnpgOnFlip(ctx, o.op.DucklingName, true); err != nil {
+		return fmt.Errorf("set retainCnpgOnFlip: %w", err)
+	}
+	o.retainRequested = true
+
+	// XRD-compat read-back: a cluster whose Duckling XRD predates the field
+	// silently prunes the patch. Refuse rather than risk delete-on-flip.
+	retain, present, err := o.r.duckling.GetMetadataStoreRetainCnpgOnFlip(ctx, o.op.DucklingName)
+	if err != nil {
+		return fmt.Errorf("read back retainCnpgOnFlip: %w", err)
+	}
+	if !present || !retain {
+		return fmt.Errorf("the cluster's Duckling XRD does not support spec.metadataStore.retainCnpgOnFlip (patch pruned) — deploy the crossplane-config charts carrying that field BEFORE running a cnpg→external reshard; refusing to flip because the type change would DELETE the cnpg source catalog with no orphan-adopt safety net")
+	}
+
+	// Wait until the cnpg Role+Database MRs reflect the no-Delete policy, so the
+	// type flip orphans (not deletes) them. Closes the race where the flip
+	// un-renders the MRs before the retain policy propagated.
+	deadline := time.Now().Add(o.flipTimeout())
+	lastLog := time.Time{}
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if o.cancelRequested() {
+			return errReshardCancelled
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("cnpg source role/DB did not reflect the retain (no-Delete) policy within %s — refusing to flip (the composition may not honor retainCnpgOnFlip; charts/composition skew?)", o.flipTimeout())
+		}
+		orphaned, mrsPresent, err := o.r.duckling.CnpgSourceMRsOrphaned(ctx, o.op.DucklingName)
+		if err == nil && mrsPresent && orphaned {
+			o.logf("info", "cnpg source role/DB now carry the retain (no-Delete) policy — safe to flip")
+			return nil
+		}
+		if time.Since(lastLog) >= 15*time.Second {
+			switch {
+			case err != nil:
+				o.logf("info", "waiting for the cnpg source MRs to reflect the retain policy: read failed: %v", err)
+			case !mrsPresent:
+				o.logf("info", "waiting for the cnpg source MRs to reflect the retain policy: Role/Database MRs not both observed yet")
+			default:
+				o.logf("info", "waiting for the cnpg source MRs to reflect the retain (no-Delete) policy")
+			}
+			lastLog = time.Now()
+		}
+		time.Sleep(o.r.loopPoll)
+	}
+}
+
+// flipToExternal is the cnpg→ext cutover: runs only AFTER copy+verify and the
+// orphan step (retainCnpgOnFlip=true), so the type flip ORPHANS the cnpg source
+// role/DB rather than deleting them. The explicit drop happens later, only once
+// the external catalog is verified complete.
 func (o *opRun) flipToExternal(ctx context.Context) error {
 	if err := o.step("cutover"); err != nil {
 		return err
 	}
-	o.logf("info", "flipping duckling metadata store to external %s — Crossplane will DELETE the cnpg source role/DB (%s)", o.op.TargetEndpoint, o.op.SourceDatabase)
+	o.logf("info", "flipping duckling metadata store to external %s — the cnpg source role/DB (%s) are RETAINED (orphaned, not deleted) so this flip is recoverable", o.op.TargetEndpoint, o.op.SourceDatabase)
 	ext := ExternalMetadataStoreSpec{
 		Endpoint:          o.op.TargetEndpoint,
 		PasswordAWSSecret: o.op.TargetPasswordSecret,
@@ -703,7 +802,7 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 			return err
 		}
 		// No cancel check: past this flip the only ways out are forward or
-		// the copy-back recovery in rollback().
+		// the orphan-adopt recovery in rollback().
 		if time.Now().After(deadline) {
 			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string)", o.flipTimeout(), o.op.TargetPasswordSecret)
 		}
@@ -731,6 +830,64 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 		}
 		time.Sleep(o.r.loopPoll)
 	}
+}
+
+// verifyExternalCatalog is the cnpg→ext gate BEFORE dropping the orphaned cnpg
+// source: it re-reads the live external target's per-table ducklake_* row
+// counts and requires an EXACT match against the copy snapshot
+// (o.copied.PerTableRows). An incomplete/diverged target fails here — the cnpg
+// source is still present (orphaned), so rollback flips back and re-adopts it
+// with no data loss. Only a clean match lets dropOrphanedCnpgSource run.
+func (o *opRun) verifyExternalCatalog(ctx context.Context) error {
+	if err := o.step("verifying_external"); err != nil {
+		return err
+	}
+	current, err := o.r.copier.SnapshotCounts(ctx, o.target)
+	if err != nil {
+		return fmt.Errorf("re-reading external target counts: %w", err)
+	}
+	if len(current) != len(o.copied.PerTableRows) {
+		return fmt.Errorf("external target table set differs from the copy (%d tables now, %d copied) — catalog incomplete; NOT dropping the retained cnpg source", len(current), len(o.copied.PerTableRows))
+	}
+	for table, want := range o.copied.PerTableRows {
+		got, ok := current[table]
+		if !ok {
+			return fmt.Errorf("external target is missing table %s — catalog incomplete; NOT dropping the retained cnpg source", table)
+		}
+		if got != want {
+			return fmt.Errorf("external target table %s row count %d != copied %d — catalog incomplete; NOT dropping the retained cnpg source", table, got, want)
+		}
+	}
+	o.logf("info", "verified external target catalog: %d tables match the copied row counts exactly — safe to drop the retained cnpg source", len(current))
+	return nil
+}
+
+// dropOrphanedCnpgSource drops the retained (orphaned) cnpg source database —
+// cnpg→ext only, and only after verifyExternalCatalog passed. It mirrors
+// cleanupSource: DROP DATABASE … WITH (FORCE) via the source pooler, best-effort
+// (a leftover DB is cruft, not data loss, since the external target is verified
+// live); the source role is left (orphaned, harmless — roles cannot drop
+// themselves). It then clears retainCnpgOnFlip: harmless on the now-external
+// tenant, but it keeps a later ext→cnpg reshard from inheriting a no-Delete cnpg
+// MR that would leak on deprovision.
+func (o *opRun) dropOrphanedCnpgSource(ctx context.Context) error {
+	if err := o.step("cleaning_up"); err != nil {
+		return err
+	}
+	if o.source.Database == "" {
+		o.logf("error", "source database name is empty (recordSource did not run?) — skipping DROP DATABASE; the orphaned cnpg database on %s must be dropped manually", o.op.FromShard)
+	} else {
+		o.logf("info", "dropping the orphaned cnpg source database %s on %s (WITH FORCE) — external catalog verified complete", o.source.Database, o.op.FromShard)
+		if err := o.r.copier.DropDatabase(ctx, o.source, o.source.Database); err != nil {
+			o.logf("error", "DROP DATABASE on the orphaned cnpg source failed — it still exists on %s and must be dropped manually: %v", o.op.FromShard, err)
+		} else {
+			o.logf("info", "orphaned cnpg source database dropped (the source role remains — orphaned, harmless; roles cannot drop themselves)")
+		}
+	}
+	if err := o.r.duckling.SetMetadataStoreRetainCnpgOnFlip(ctx, o.op.DucklingName, false); err != nil {
+		o.logf("warn", "clearing retainCnpgOnFlip after cnpg→ext completion failed: %v — harmless while on external; a later ext→cnpg reshard should ensure it is false", err)
+	}
+	return nil
 }
 
 // copyCatalog resolves the target endpoint (for →cnpg it was resolved by the
@@ -942,17 +1099,27 @@ func (o *opRun) rollback(ctx context.Context) {
 			}
 			o.dropPartialTarget(ctx)
 		case o.op.TargetKind == configstore.MetadataStoreKindExternal:
-			// cnpg→ext flipped means copy+verify already PASSED (flip is
-			// last). The cnpg source is being deleted by Crossplane; recovery
-			// is flip-back + copy-back from the verified external target.
+			// cnpg→ext flipped: the cnpg source was ORPHANED (retained), not
+			// deleted, so recovery flips back and re-ADOPTS it — no copy-back.
 			o.recoverFromExternal(ctx)
 		}
-	} else if o.op.TargetKind == configstore.MetadataStoreKindExternal && o.copied.Tables > 0 {
-		// cnpg→ext failed before the flip: source untouched; drop what we
-		// copied onto the external target (best-effort).
-		o.logf("warn", "rolling back: dropping partially copied tables from the external target")
-		if err := o.r.copier.DropCatalogTables(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) }); err != nil {
-			o.logf("warn", "dropping copied tables from the external target failed: %v (harmless leftover)", err)
+	} else if o.op.TargetKind == configstore.MetadataStoreKindExternal {
+		// cnpg→ext failed BEFORE the flip: source untouched.
+		if o.retainRequested {
+			// We set retainCnpgOnFlip=true but never flipped — reset it so the
+			// still-cnpg source keeps full-lifecycle (Delete) MRs and a later
+			// deprovision stays clean.
+			o.logf("warn", "rolling back: clearing retainCnpgOnFlip on the still-cnpg source (restores full-lifecycle Delete so deprovision stays clean)")
+			if err := o.r.duckling.SetMetadataStoreRetainCnpgOnFlip(ctx, o.op.DucklingName, false); err != nil {
+				o.logf("error", "clearing retainCnpgOnFlip failed: %v — the cnpg role/DB MRs may lack Delete and a deprovision could ORPHAN (leak) them; fix by setting spec.metadataStore.retainCnpgOnFlip=false", err)
+			}
+		}
+		if o.copied.Tables > 0 {
+			// Drop what we copied onto the external target (best-effort).
+			o.logf("warn", "rolling back: dropping partially copied tables from the external target")
+			if err := o.r.copier.DropCatalogTables(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) }); err != nil {
+				o.logf("warn", "dropping copied tables from the external target failed: %v (harmless leftover)", err)
+			}
 		}
 	}
 
@@ -985,50 +1152,45 @@ func (o *opRun) dropPartialTarget(ctx context.Context) {
 	}
 }
 
-// recoverFromExternal handles the one genuinely hairy rollback: cnpg→ext
-// flipped, then the external target never became Ready (ESO secret missing/
-// mismatched). Crossplane already deleted the cnpg source role/DB, so we flip
-// back (provider-sql re-creates them EMPTY) and copy back from the external
-// target — whose data passed verify before the flip.
+// recoverFromExternal handles the cnpg→ext post-flip rollback: the external
+// target never became Ready, or the external-catalog verify failed. Because the
+// orphan step retained the cnpg source, the role/DB are STILL PRESENT on the
+// shard — so recovery flips the type back to cnpg-shard AND clears
+// retainCnpgOnFlip in one patch (SetMetadataStoreCnpgAdopt), and provider-sql
+// re-ADOPTS the role/DB by external-name (same pgIdent, same pinned password).
+// No empty-recreate, no copy-back — the catalog never left the source. This is
+// the whole point of the orphan-adopt escape hatch.
 func (o *opRun) recoverFromExternal(ctx context.Context) {
-	o.logf("error", "cnpg→external cutover failed AFTER the flip — the cnpg source was deleted by the flip; recovering by flipping back and copying back from the external target")
+	o.logf("warn", "cnpg→external cutover failed AFTER the flip — the cnpg source role/DB were RETAINED (orphaned), not deleted; recovering by flipping back to shard %s and re-adopting them (no data copy)", o.op.FromShard)
 
-	if err := o.r.duckling.SetMetadataStoreCnpg(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
-		o.logf("error", "recovery flip-back failed: %v — duckling still points at the external target; fix manually", err)
+	if err := o.r.duckling.SetMetadataStoreCnpgAdopt(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
+		o.logf("error", "recovery flip-back failed: %v — duckling still points at the external target; the orphaned cnpg role/DB survive on %s and can be re-adopted manually (patch spec.metadataStore to {type: cnpg-shard, cnpgShard: %s, retainCnpgOnFlip: false}); fix manually", err, o.op.FromShard, o.op.FromShard)
 		return
 	}
 
-	// Wait for the composition to re-create the (empty) role/DB on the
-	// source shard.
+	// Wait for the composition to re-adopt the role/DB on the source shard and
+	// the tenant role to answer again.
 	sourcePrefix := o.op.FromShard + "-pooler."
 	deadline := time.Now().Add(o.flipTimeout())
-	var restored CatalogEndpoint
 	for {
 		if time.Now().After(deadline) {
-			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate", o.flipTimeout())
+			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s)", o.flipTimeout(), o.op.FromShard)
 			return
 		}
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
 		if err == nil && strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) && st.ReadyCondition {
-			restored = CatalogEndpoint{
+			restored := CatalogEndpoint{
 				Host: st.MetadataStore.Endpoint, Port: 5432,
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
 				SSLMode: "disable",
 			}
 			if o.r.copier.Probe(ctx, restored) == nil {
-				break
+				o.logf("info", "recovery complete: duckling re-adopted the orphaned cnpg role/DB on %s and the tenant role answers — no data was copied back (the catalog never left the source)", o.op.FromShard)
+				return
 			}
 		}
 		time.Sleep(o.r.loopPoll)
 	}
-
-	o.logf("warn", "recovery: copying the catalog back from the external target into the re-created source database")
-	result, err := o.r.copier.Copy(ctx, o.target, restored, func(level, msg string) { o.logf(level, "%s", msg) })
-	if err != nil {
-		o.logf("error", "recovery copy-back FAILED: %v — the verified catalog lives on the external target %s; restore manually before unblocking", err, o.op.TargetEndpoint)
-		return
-	}
-	o.logf("info", "recovery copy-back complete: %d tables, %d rows — org is back on %s", result.Tables, result.Rows, o.op.FromShard)
 }
 
 // report writes the end-of-op report to the log — also on failure/cancel.

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -191,10 +191,11 @@ func (f *fakeReshardStore) countLog(substr string) int {
 }
 
 type ducklingCall struct {
-	kind  string // "cnpg" | "external" | "compaction"
-	shard string
-	ext   ExternalMetadataStoreSpec
-	comp  *bool
+	kind   string // "cnpg" | "external" | "compaction" | "retain" | "cnpg-adopt"
+	shard  string
+	ext    ExternalMetadataStoreSpec
+	comp   *bool
+	retain *bool
 }
 
 type fakeDuckling struct {
@@ -205,6 +206,15 @@ type fakeDuckling struct {
 
 	compEnabled, compPresent bool
 	calls                    []ducklingCall
+
+	// cnpg→ext orphan-adopt escape hatch simulation.
+	// retainFieldUnsupported=true models an XRD that predates
+	// spec.metadataStore.retainCnpgOnFlip (the API server prunes the patch, so
+	// the read-back reports present=false). retainFlag is the current spec
+	// value; CnpgSourceMRsOrphaned reports the MRs as orphaned once it is true
+	// (composition converges instantly).
+	retainFieldUnsupported bool
+	retainFlag             bool
 }
 
 func (f *fakeDuckling) Get(context.Context, string) (*DucklingStatus, error) {
@@ -254,6 +264,50 @@ func (f *fakeDuckling) SetMetadataStoreExternal(_ context.Context, _ string, ext
 	return nil
 }
 
+func (f *fakeDuckling) SetMetadataStoreRetainCnpgOnFlip(_ context.Context, _ string, retain bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := retain
+	f.calls = append(f.calls, ducklingCall{kind: "retain", retain: &r})
+	if !f.retainFieldUnsupported {
+		f.retainFlag = retain
+	}
+	return nil
+}
+
+func (f *fakeDuckling) GetMetadataStoreRetainCnpgOnFlip(context.Context, string) (bool, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.retainFieldUnsupported {
+		return false, false, nil // XRD pruned the field
+	}
+	return f.retainFlag, true, nil
+}
+
+func (f *fakeDuckling) CnpgSourceMRsOrphaned(context.Context, string) (bool, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Composition converges instantly: once retain is set, the cnpg source MRs
+	// reflect the no-Delete policy. present is always true (the source cnpg
+	// Role/Database MRs exist while type is cnpg-shard).
+	return f.retainFlag, true, nil
+}
+
+func (f *fakeDuckling) SetMetadataStoreCnpgAdopt(_ context.Context, _ string, shard string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, ducklingCall{kind: "cnpg-adopt", shard: shard})
+	// Composition re-adopts the orphaned role/DB and converges back to cnpg.
+	f.status.MetadataStore.Type = configstore.MetadataStoreKindCnpgShard
+	f.status.MetadataStore.Endpoint = shard + "-pooler.cnpg-shards.svc.cluster.local"
+	f.status.MetadataStore.User = "mdstore_org"
+	f.status.MetadataStore.Database = "mdstore_org"
+	f.status.MetadataStore.Password = "pinned-pw"
+	f.status.ReadyCondition = true
+	f.retainFlag = false
+	return nil
+}
+
 func (f *fakeDuckling) callKinds() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -277,9 +331,13 @@ type fakeCopier struct {
 
 	copyResult CatalogCopyResult
 	copyErr    error
-	// countsAfter is what SnapshotCounts returns (the stability recheck);
-	// defaults to copyResult.PerTableRows (stable source).
+	// countsAfter is what SnapshotCounts returns for the SOURCE stability
+	// recheck (sslmode!=require); defaults to copyResult.PerTableRows (stable).
 	countsAfter map[string]int64
+	// externalCounts is what SnapshotCounts returns for the EXTERNAL target
+	// verify (sslmode==require, cnpg→ext verifyExternalCatalog); defaults to
+	// copyResult.PerTableRows (complete target).
+	externalCounts map[string]int64
 }
 
 func (f *fakeCopier) record(c copierCall) {
@@ -302,8 +360,16 @@ func (f *fakeCopier) Copy(_ context.Context, source, target CatalogEndpoint, log
 	return f.copyResult, nil
 }
 
-func (f *fakeCopier) SnapshotCounts(context.Context, CatalogEndpoint) (map[string]int64, error) {
-	f.record(copierCall{kind: "counts"})
+func (f *fakeCopier) SnapshotCounts(_ context.Context, ep CatalogEndpoint) (map[string]int64, error) {
+	f.record(copierCall{kind: "counts", target: ep})
+	// The external target is reached with sslmode=require (verifyExternalCatalog);
+	// the cnpg source with sslmode=disable (verifySourceStable).
+	if ep.SSLMode == "require" {
+		if f.externalCounts != nil {
+			return f.externalCounts, nil
+		}
+		return f.copyResult.PerTableRows, nil
+	}
 	if f.countsAfter != nil {
 		return f.countsAfter, nil
 	}
@@ -496,9 +562,11 @@ func TestReshardHappyPathExtToCnpg(t *testing.T) {
 	}
 }
 
-// TestReshardHappyPathCnpgToExt pins the ESCAPE-HATCH ordering: copy and
-// verify BEFORE the flip (the flip deletes the cnpg source), and no explicit
-// source drop (the flip is the cleanup).
+// TestReshardHappyPathCnpgToExt pins the ORPHAN-ADOPT-then-VERIFIED-DELETE
+// escape-hatch ordering: copy + verify, then a TWO-STEP flip (retain flag set +
+// MRs observed no-Delete WHILE still cnpg, THEN the type flip), then external
+// catalog verify, then the explicit source drop (only after verify), then the
+// retain flag cleared.
 func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	op := cnpgOp()
 	op.TargetKind = configstore.MetadataStoreKindExternal
@@ -518,15 +586,39 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	if store.op.State != configstore.ReshardStateSucceeded {
 		t.Fatalf("state = %s (err %q), want succeeded", store.op.State, store.op.Error)
 	}
-	// Copy + stability recheck happen BEFORE the flip; no dropdb ever.
-	if fmt.Sprint(copier.kinds()) != fmt.Sprint([]string{"probe", "probe", "copy", "counts"}) {
+	// copy + source-stability recheck BEFORE the flip, external-catalog verify
+	// AFTER the flip, then the explicit source drop.
+	if fmt.Sprint(copier.kinds()) != fmt.Sprint([]string{"probe", "probe", "copy", "counts", "counts", "dropdb"}) {
 		t.Fatalf("copier calls = %v", copier.kinds())
 	}
-	dkinds := duckling.callKinds()
-	if fmt.Sprint(dkinds) != fmt.Sprint([]string{"compaction", "external", "compaction"}) {
-		t.Fatalf("duckling calls = %v, want flip AFTER copy", dkinds)
+	// The source drop names the recorded source DB and runs against the source.
+	for _, call := range copier.calls {
+		if call.kind == "dropdb" {
+			if call.dbName != "mdstore_org" {
+				t.Fatalf("dropdb database = %q, want the recorded source database mdstore_org", call.dbName)
+			}
+			if !strings.HasPrefix(call.target.Host, "shard-001-pooler") {
+				t.Fatalf("dropdb ran against %q, want the recorded shard-001 source", call.target.Host)
+			}
+		}
 	}
-	wantSteps := []string{"blocking", "draining", "pausing_compaction", "copying", "verifying", "cutover", "finalizing"}
+	// Two-step flip: retain(true) → type flip(external) → source drop clears
+	// retain(false). Compaction pause/restore bracket it.
+	dkinds := duckling.callKinds()
+	if fmt.Sprint(dkinds) != fmt.Sprint([]string{"compaction", "retain", "external", "retain", "compaction"}) {
+		t.Fatalf("duckling calls = %v, want retain-before-flip + retain-clear-after-drop", dkinds)
+	}
+	// The retain flag is set true BEFORE the flip and cleared false after.
+	var retainVals []bool
+	for _, c := range duckling.calls {
+		if c.kind == "retain" && c.retain != nil {
+			retainVals = append(retainVals, *c.retain)
+		}
+	}
+	if len(retainVals) != 2 || retainVals[0] != true || retainVals[1] != false {
+		t.Fatalf("retain patches = %v, want [true false]", retainVals)
+	}
+	wantSteps := []string{"blocking", "draining", "pausing_compaction", "copying", "verifying", "orphaning_source", "cutover", "verifying_external", "cleaning_up", "finalizing"}
 	if fmt.Sprint(store.steps) != fmt.Sprint(wantSteps) {
 		t.Fatalf("steps = %v, want %v", store.steps, wantSteps)
 	}
@@ -760,7 +852,6 @@ func (s *stuckExternalDuckling) SetMetadataStoreExternal(_ context.Context, _ st
 	return nil
 }
 
-
 func stuckExtOp() *configstore.ReshardOperation {
 	op := cnpgOp()
 	op.TargetKind = configstore.MetadataStoreKindExternal
@@ -773,10 +864,12 @@ func stuckExtOp() *configstore.ReshardOperation {
 	return op
 }
 
-// TestReshardExtFlipTimeoutRecovers pins the escape-hatch recovery: when the
+// TestReshardExtFlipTimeoutRecovers pins the ORPHAN-ADOPT recovery: when the
 // cnpg→ext cutover never becomes ready (the target's status password never
-// syncs), the flip times out and the runner recovers — flips back to the
-// source shard and copies the catalog back — leaving the org in service.
+// syncs), the flip times out and the runner recovers by flipping back to the
+// source shard and RE-ADOPTING the still-present (orphaned) cnpg role/DB — NO
+// copy-back, NO empty-recreate — leaving the org in service. The source is
+// never dropped (external verify never reached).
 func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 	store := newFakeReshardStore(stuckExtOp())
 	duckling := &stuckExternalDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
@@ -792,10 +885,122 @@ func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 	if !store.hasLog("waiting for external target") {
 		t.Fatalf("generic waiting line missing: %v", store.logs)
 	}
-	// The op still recovers (flip-back + copy-back) and unblocks.
+	// Recovery is flip-back + adopt (SetMetadataStoreCnpgAdopt), never copy-back.
+	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
+		t.Fatalf("recovery did not flip back + adopt (no cnpg-adopt call): %v", duckling.callKinds())
+	}
+	// Exactly ONE copy (the forward copy) — no copy-back to a recreated source.
+	nCopy := 0
+	for _, k := range copier.kinds() {
+		if k == "copy" {
+			nCopy++
+		}
+	}
+	if nCopy != 1 {
+		t.Fatalf("copy ran %d times, want exactly 1 (no copy-back on adopt recovery): %v", nCopy, copier.kinds())
+	}
+	// The orphaned cnpg source is NEVER dropped when the flip failed.
+	if containsStr(copier.kinds(), "dropdb") {
+		t.Fatalf("orphaned cnpg source was dropped on a failed flip — must be retained for adoption: %v", copier.kinds())
+	}
 	if store.warehouseState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
 	}
+}
+
+// TestReshardExtVerifyMismatchAdopts pins the step-5 gate: if the external
+// target catalog does NOT exactly match the copied row counts, the runner
+// REFUSES to drop the retained cnpg source and instead flips back + re-adopts
+// it — no data loss.
+func TestReshardExtVerifyMismatchAdopts(t *testing.T) {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := &fakeCopier{
+		copyResult: CatalogCopyResult{Tables: 1, Rows: 5, PerTableRows: map[string]int64{"ducklake_data_file": 5}},
+		// External target verify sees a DIFFERENT count than the copy snapshot.
+		externalCounts: map[string]int64{"ducklake_data_file": 4},
+	}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "catalog incomplete") {
+		t.Fatalf("state=%s err=%q, want external-verify (catalog incomplete) failure", store.op.State, store.op.Error)
+	}
+	// The retained cnpg source must NEVER be dropped on a verify mismatch.
+	if containsStr(copier.kinds(), "dropdb") {
+		t.Fatalf("verify mismatch dropped the source — must retain it for adoption: %v", copier.kinds())
+	}
+	// Recovery flips back + re-adopts.
+	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
+		t.Fatalf("verify mismatch did not flip back + adopt: %v", duckling.callKinds())
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after adopt recovery", store.warehouseState)
+	}
+}
+
+// TestReshardCnpgToExtXRDUnsupportedRefuses pins the XRD-compat fallback: a
+// cluster whose Duckling XRD predates spec.metadataStore.retainCnpgOnFlip (the
+// patch is pruned) makes the runner REFUSE the cnpg→ext flip BEFORE touching
+// the source — no flip, no drop, source intact, retain flag reset, org back to
+// ready.
+func TestReshardCnpgToExtXRDUnsupportedRefuses(t *testing.T) {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus(), retainFieldUnsupported: true}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "does not support") {
+		t.Fatalf("state=%s err=%q, want XRD-unsupported refusal", store.op.State, store.op.Error)
+	}
+	// Never flipped, never dropped — the source is untouched.
+	if containsStr(duckling.callKinds(), "external") {
+		t.Fatalf("flip ran despite an unsupported XRD: %v", duckling.callKinds())
+	}
+	if containsStr(copier.kinds(), "dropdb") {
+		t.Fatalf("source dropped despite refusing the flip: %v", copier.kinds())
+	}
+	// The retain flag we attempted to set is reset on rollback.
+	var retainVals []bool
+	for _, c := range duckling.calls {
+		if c.kind == "retain" && c.retain != nil {
+			retainVals = append(retainVals, *c.retain)
+		}
+	}
+	if len(retainVals) == 0 || retainVals[len(retainVals)-1] != false {
+		t.Fatalf("retain patches = %v, want the last to reset to false on rollback", retainVals)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after refusal rollback", store.warehouseState)
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestReshardVerifyMismatchRollsBack pins the concurrent-writer detection: a

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -20,7 +20,7 @@ those stay valid because the bucket is untouched.
 | Operation row + verbose log (config store) | `controlplane/configstore/reshard.go`, migration `000018` |
 | Runner (claims + executes ops) | `controlplane/provisioner/reshard_runner.go` |
 | Catalog copier (schema + rows + verify) | `controlplane/provisioner/catalog_copy.go` |
-| Duckling CR patches (flip, compaction pause) | `controlplane/provisioner/k8s_client.go` |
+| Duckling CR patches (flip, compaction pause, cnpg-orphan/adopt: `SetMetadataStoreRetainCnpgOnFlip`, `CnpgSourceMRsOrphaned`, `SetMetadataStoreCnpgAdopt`) | `controlplane/provisioner/k8s_client.go` |
 | Admin REST API (start/read/cancel + `GET /reshards/targets` destination discovery: all cnpg shards incl. empty ones via the cluster-topology pod read, RBAC-degrading to occupied shards; known external stores from live warehouse rows) | `controlplane/admin/reshard.go` |
 | Console UI (form + operation page with live log) | `admin/ui/src/pages/ReshardForm.tsx`, `ReshardOperation.tsx` |
 | Connection gates | `controlplane/control.go` (57P03), `flight_ingress.go`, grant-path check in `configstore/org_connections.go` |
@@ -30,8 +30,30 @@ Duckling CR (charts #12918): changing it re-points the provider-sql
 Role/Database at the target shard's ProviderConfig **in place** — same
 role/database name (pinned `pgIdentPrefix`), same pinned password, old shard's
 role/DB **orphaned, not dropped**, no data copied. A **type** flip
-(cnpg↔external) is different: the composition stops rendering the cnpg MRs and
-Crossplane **deletes** the cnpg role/DB (`managementPolicies: ["*"]`).
+(cnpg↔external) is different: the composition stops rendering the cnpg MRs, and
+what Crossplane does with the underlying role/DB then depends on those MRs'
+`managementPolicies` — which the composition renders conditionally on
+`spec.metadataStore.retainCnpgOnFlip` (charts):
+
+- `retainCnpgOnFlip=false` (default, every normal tenant): the cnpg
+  Role/Database render with **full lifecycle** `["*"]` (Delete included), so the
+  un-render **deletes** the role/DB. This is also what makes a normal
+  **deprovision** (delete the whole Duckling → finalizer cascade) cleanly DROP
+  them — the clean-slate-on-recreate guarantee.
+- `retainCnpgOnFlip=true` (set ONLY by the reshard runner, ONLY for the
+  cnpg→external escape hatch): they render **without Delete**
+  `["Observe","Create","Update"]` (the v2 Orphan equivalent), so the un-render
+  **orphans** the role/DB (they survive on the shard) — the orphan-adopt safety
+  net below.
+
+**Deprovision-unaffected invariant (non-negotiable):** `retainCnpgOnFlip` is a
+per-Duckling spec field defaulting to false, flipped true only transiently
+during a cnpg→ext reshard (and cleared again on success/recovery/rollback). A
+normal never-resharded tenant always has it false, so provisioning and
+deprovisioning drop/create the cnpg role/DB exactly as before. The orphan
+behavior is bound to the reshard type-flip, never to Duckling deletion. The e2e
+`lifecycle_teardown_cnpg` asserts the finalizer cascade still fully deletes the
+CR (and its cnpg role/DB) on a normal deprovision.
 
 ## Step machine (→cnpg targets)
 
@@ -97,12 +119,47 @@ blocking → draining → pausing_compaction → cutover → copying → verifyi
    (`migrationChecked` is orgID-keyed and endpoint-independent;
    `ducklake.migrations` is DSN-keyed → new endpoint = new entry).
 
-## cnpg→external (escape hatch): copy-before-flip
+## cnpg→external (escape hatch): orphan-adopt then verified-delete
 
-The type flip DELETES the cnpg source role/DB, so this direction inverts the
-order: `blocking → draining → pausing_compaction → copying → verifying →
-cutover → finalizing`. The flip IS the source cleanup and only runs after
-verify passed.
+This direction never destroys the cnpg copy coupled to the flip. Instead it
+retains the cnpg role/DB across the flip (so a bad flip is instantly
+recoverable), verifies the external target actually caught the full catalog, and
+only THEN drops the retained source:
+
+```
+blocking → draining → pausing_compaction → copying → verifying
+        → orphaning_source → cutover → verifying_external → cleaning_up
+        → finalizing
+```
+
+1. **copying / verifying** — as for →cnpg, but the source is read via its
+   recorded pre-flip cnpg pooler endpoint (unchanged by the flip since the
+   role/DB are retained).
+2. **orphaning_source** — patch `spec.metadataStore.retainCnpgOnFlip=true`
+   *while type is still cnpg-shard*, then WAIT until the cnpg Role AND Database
+   MRs actually reflect the no-Delete policy (poll their
+   `spec.managementPolicies` via `CnpgSourceMRsOrphaned`) before proceeding.
+   This two-step-flip closes the race where the type flip un-renders the MRs
+   before the retain policy propagated. **XRD-compat:** after the patch the
+   runner reads the flag back; if it did not stick (the cluster's Duckling XRD
+   predates the field → the API server pruned the patch) the runner **REFUSES**
+   the reshard with a clear "deploy the charts first" error rather than risk the
+   old destructive delete-on-flip. (Refuse is safer than silently falling back
+   to data-loss risk.)
+3. **cutover** — flip `type` to external (`cnpgShard: null`, external block set;
+   `retainCnpgOnFlip` left true). The un-render now ORPHANS the cnpg role/DB.
+   Wait for external Ready + ESO password synced + matching the typed password.
+4. **verifying_external** — connect to the now-live external target and require
+   its per-table `ducklake_*` row counts to match the copy snapshot
+   (`CatalogCopyResult.PerTableRows`) EXACTLY. A missing table / count mismatch
+   fails here — the cnpg source is still present (orphaned), so recovery adopts
+   it back with no data loss.
+5. **cleaning_up** — only after external verify passes: `DROP DATABASE … WITH
+   (FORCE)` the retained cnpg source database via the source pooler (best-effort;
+   a leftover DB is cruft, not data loss — the external target is verified live),
+   then clear `retainCnpgOnFlip` (harmless on the now-external tenant; keeps a
+   later ext→cnpg reshard from inheriting a no-Delete cnpg MR). The role is left
+   (orphaned, harmless — roles cannot drop themselves).
 
 The target password is **ephemeral**: sent once in the start request,
 validated by connecting, handed in-process to the local runner, never
@@ -151,17 +208,26 @@ generic "waiting for external target" line. (Surfacing the ExternalSecret's
 own AccessDenied into the op log would need an `external-secrets.io` read
 grant on the CP SA, which it does not have; not worth the extra RBAC.)
 
-**Recovery if the flip goes bad** (ESO secret missing/mismatched): flip back
-to the source shard — provider-sql re-creates the role/DB **empty** — then
-copy back from the external target, whose data passed verify. The one path
-where the source is rebuilt rather than left untouched.
+**Recovery if the flip goes bad** (external never Ready, ESO secret
+missing/mismatched, or external-catalog verify fails): flip `type` back to
+cnpg-shard AND clear `retainCnpgOnFlip` in one patch (`SetMetadataStoreCnpgAdopt`)
+— the composition re-renders the cnpg Role/Database MRs at full lifecycle and
+provider-sql **ADOPTS** the still-present orphaned role/DB by external-name (same
+`pgIdent`, same pinned password). **No empty-recreate, no copy-back** — the
+catalog never left the source. This replaces the old recreate-then-copy-back
+recovery (which stranded the tenant with an empty catalog when the copy-back
+also failed, the prod-shaped data-loss incident this change fixes) and avoids
+the `2BP01` "role can't drop while its DB exists" wedge the coupled delete hit.
 
 ## Rollback, cancel, crash-safety
 
 - Rollback never removes `spec.metadataStore.cnpgShard` — it patches the
   source VALUE back (key-absent would fall through to the freshly-stamped
   bogus status pin). ext→cnpg rollback patches `{type: external, cnpgShard:
-  null}` (the XRD's CEL forbids the key on external).
+  null}` (the XRD's CEL forbids the key on external). cnpg→ext rollback:
+  post-flip → adopt recovery (above); pre-flip → if `retainCnpgOnFlip` was set,
+  reset it to false so the still-cnpg source keeps full-lifecycle (Delete) MRs
+  and deprovision stays clean.
 - Cancel (`POST /reshards/:id/cancel`): flag checked between steps and inside
   every wait loop; rolls back like a failure at that step → `cancelled`.
   Pending (unclaimed) ops finish immediately. On cnpg→ext, cancel is refused
@@ -181,11 +247,19 @@ where the source is rebuilt rather than left untouched.
 Unit: `configstore` (tests/configstore/reshard_postgres_test.go — claim CAS,
 takeover fencing, cancel, log pagination, the grant-path gate),
 `provisioner/reshard_runner_test.go` (all three directions, rollbacks, cancel,
-ephemeral-password loss), `admin/reshard_test.go` (validation, secrets never
-persisted). e2e (`tests/mw-dev/e2e/harness.sh`): validation 400s,
-cancel-during-drain (drain-not-kill + 57P03 visible), bogus-shard rollback
-(real flip → Synced=False → rollback, data intact), and the **ext→cnpg
-positive path** (real catalog move off the harness RDS onto shard-001).
-cnpg→cnpg positive path needs a second mw-dev shard (follow-up infra);
-cnpg→ext positive path is unit-test-only (the harness has no RDS password —
-the start API requires it ephemerally).
+ephemeral-password loss; for cnpg→ext specifically the two-step orphan flip, the
+external-catalog verify gate, the flip-back adopt recovery with NO copy-back,
+and the XRD-without-`retainCnpgOnFlip` refusal), `admin/reshard_test.go`
+(validation, secrets never persisted). The charts side (composition +
+`retainCnpgOnFlip` XRD field) is tested by
+`charts/charts/crossplane-config/tests/composition_retain_cnpg_test.sh` (both
+managementPolicies variants render; the XRD field defaults false). e2e
+(`tests/mw-dev/e2e/harness.sh`): validation 400s, cancel-during-drain
+(drain-not-kill + 57P03 visible), bogus-shard rollback (real flip →
+Synced=False → rollback, data intact), the **ext→cnpg positive path** (real
+catalog move off the harness RDS onto shard-001), and the LOAD-BEARING
+`lifecycle_teardown_cnpg` (a normal cnpg tenant deprovision still fully deletes
+the Duckling CR + its cnpg role/DB — the deprovision-unaffected regression net
+for `retainCnpgOnFlip`). cnpg→cnpg positive path needs a second mw-dev shard
+(follow-up infra); the cnpg→ext positive path is unit-test-only (the harness has
+no RDS password — the start API requires it ephemerally).

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2462,6 +2462,18 @@ tenant_isolation() { # orgA pwA orgB pwB
 # Crossplane Duckling CR removed, and its finalizer cascade (which drops the
 # cnpg metadata role+db) completed.
 #
+# LOAD-BEARING for the cnpg→ext orphan-adopt change (retainCnpgOnFlip): this is
+# the deprovision-UNAFFECTED regression net. A normal never-resharded cnpg
+# tenant has spec.metadataStore.retainCnpgOnFlip=false, so its cnpg Role/Database
+# MRs render with full lifecycle ["*"] (Delete) and the finalizer cascade below
+# MUST still fully DROP them. The `kubectl wait --for=delete duckling/<org>`
+# only completes once every composed MR — including the provider-sql Role +
+# Database — finished deleting, i.e. the role/DB were dropped. If a future
+# change ever "always orphaned" the cnpg MRs, this wait would hang on the
+# retained Role/Database finalizers and this assertion would (correctly) fail.
+# The cnpg→ext orphan path itself is unit-only (harness has no RDS password —
+# see the reshard section above and provisioner/reshard_runner_test.go).
+#
 # NOTE: same-org-id *re-provision* in the SAME run is intentionally NOT done
 # here. It is the regression net for the stranded-cnpg-role bugs
 # (#649/#650/#11518/#11522), but it cannot be made reliable from inside the Job:


### PR DESCRIPTION
## What

Replaces the cnpg→external reshard escape hatch's "delete-on-flip then recreate+copy-back recovery" with **orphan-adopt then verified-delete**.

New runner sequence for cnpg→ext:

1. copy cnpg→external (before flip) — existing
2. verify source stable — existing
3. **orphan the cnpg source**: set `spec.metadataStore.retainCnpgOnFlip=true` while type is still cnpg-shard, and poll the cnpg Role + Database MRs' `managementPolicies` until both are no-Delete (two-step flip — closes the un-render-before-policy race)
4. flip type to external — the un-render now **orphans** the cnpg role/DB instead of deleting them; wait for external Ready + ESO password match — existing
5. **verify external catalog**: re-read the external target's per-table `ducklake_*` row counts and require an EXACT match against the copy snapshot (`CatalogCopyResult.PerTableRows`)
6. **only then** DROP the retained cnpg source DB (+ clear the flag)
7. on ANY failure before step 6 → flip back to cnpg-shard + clear flag in one patch (`SetMetadataStoreCnpgAdopt`); provider-sql **re-adopts** the still-present role/DB by external-name — no empty-recreate, no copy-back

## Why

The old path deleted the cnpg role/DB coupled to the flip. If the external side failed to come up, recovery recreated the cnpg DB empty and copied back from the failed external target — stranding the tenant with an empty catalog when the copy-back also failed (a prod-shaped data-loss incident on mw-dev), and it could wedge on `2BP01` (role can't drop while its DB exists). Orphaning the cnpg copy across the flip makes a bad flip instantly recoverable by adoption, and the external-catalog verify makes the destructive drop conditional on the target actually being complete.

## Deprovision is unaffected (the hard acceptance gate)

`retainCnpgOnFlip` (new XRD field, charts side) defaults `false` and is set `true` only transiently mid-reshard, cleared on success/recovery/rollback. A normal never-resharded cnpg tenant always has it `false`, so its cnpg Role/Database MRs render with full lifecycle `["*"]` (Delete) and the deprovision finalizer cascade drops them exactly as before. The orphan is bound to the reshard type-flip, never to Duckling deletion.

Tested: `provisioner/reshard_runner_test.go` (two-step flip happy path, external-verify count-mismatch → adopt, flip-timeout → adopt with NO copy-back / NO dropdb, XRD-without-field → refuse), and the e2e `lifecycle_teardown_cnpg` remains the load-bearing deprovision-unaffected regression net (its `kubectl wait --for=delete duckling/<org>` only completes once provider-sql finished dropping the cnpg Role + Database).

## XRD-compat fallback

After patching `retainCnpgOnFlip=true` the runner reads it back; if the field didn't stick (the cluster's Duckling XRD predates it → the API server pruned the patch), the runner **REFUSES** the cnpg→ext reshard with a clear "deploy the crossplane-config charts first" error rather than risk the old destructive delete-on-flip. Refuse is safer than a silent fallback to data-loss risk.

## Deploy order

The charts change (composition + `retainCnpgOnFlip` XRD field) — **PostHog/charts#13111** — must deploy **BEFORE** this runner starts setting the flag. This runner falls back safely (refuses cnpg→ext) on an old XRD, so an out-of-order deploy degrades to "cnpg→ext temporarily refused", never data loss.

## Build / tests

- `go build ./... && go build -tags kubernetes ./...` — clean
- `go test -tags kubernetes ./controlplane/provisioner ./controlplane/admin -run TestReshard -count=1` — pass (also `-race`)
- `bash -n tests/mw-dev/e2e/harness.sh` — clean
- Docs updated: `docs/design/resharding.md`, `CLAUDE.md` reshard section, `harness.sh` `lifecycle_teardown_cnpg` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
