### PR TITLE
reshard: reconstruct rollback progress on takeover so cancel unblocks the warehouse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,6 +627,22 @@ verbose op log. Full design: `docs/design/resharding.md`. Pieces:
 - **Runner fencing**: claim bumps `runner_epoch`; every runner write is
   CAS-fenced on (runner, epoch); stale-heartbeat (>5m) ops are takeover-able;
   the copy holds a target-DB advisory lock.
+- **Takeover rollback reconstructs progress from the persisted row.** The
+  in-process rollback flags (`blocked`, `compactionPaused`, `flipped`,
+  `retainRequested`) start false on a fresh `opRun`. A runner that CLAIMS an op a
+  prior epoch advanced (crash-takeover or replica switch) MUST call
+  `reconstructProgress()` before `run()` — otherwise a cancel/failure that
+  short-circuits before the steps re-execute (e.g. `run()`'s first
+  `cancelRequested()` check) rolls back with all-false flags and silently skips
+  unblocking the warehouse (org stuck in `resharding`) and restoring compaction.
+  Reconstruction is conservative: `blocked` ← `blocked_at` set OR step past
+  `blocking`; `compactionPaused` ← step past `pausing_compaction` (proves the
+  prior setting was recorded, else restore could wrongly re-enable compaction);
+  `flipped`/`retainRequested` ← step reached `cutover`/`orphaning_source`
+  (over-marking is safe — the flip-back/adopt patches are idempotent no-ops when
+  the store never moved). This was a real mw-dev incident: the blocking runner
+  OOM-crashed mid-backup, a sibling replica took over, saw the cancel flag, and
+  marked the op `cancelled` while leaving the warehouse blocked.
 - Touching any of this → update `tests/configstore/reshard_postgres_test.go`,
   `provisioner/reshard_runner_test.go` (incl. the `TestReshardBackup*` cases),
   `admin/reshard_test.go`, the

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -260,6 +260,77 @@ func (o *opRun) logf(level, format string, args ...any) {
 	}
 }
 
+// reshardStepOrderCnpg / reshardStepOrderExternal are the canonical execution
+// orders of the op's step column, one per target direction. They exist so a
+// runner that CLAIMS an op a prior epoch already advanced (takeover after a
+// crash, or a switch to another replica) can reconstruct how far the work got —
+// the in-process opRun progress flags all start false, but the persisted step
+// records the prior runner's position.
+var (
+	reshardStepOrderCnpg     = []string{"blocking", "draining", "pausing_compaction", "backup_catalog", "cutover", "copying", "verifying", "cleaning_up", "finalizing"}
+	reshardStepOrderExternal = []string{"blocking", "draining", "pausing_compaction", "backup_catalog", "copying", "verifying", "orphaning_source", "cutover", "verifying_external", "cleaning_up", "finalizing"}
+)
+
+// reshardStepReached reports whether the op's persisted step is at or past
+// target in the op's direction order. An unknown/empty step (fresh op) → false.
+func reshardStepReached(op *configstore.ReshardOperation, target string) bool {
+	order := reshardStepOrderCnpg
+	if op.TargetKind == configstore.MetadataStoreKindExternal {
+		order = reshardStepOrderExternal
+	}
+	cur, tgt := -1, -1
+	for i, s := range order {
+		if s == op.Step {
+			cur = i
+		}
+		if s == target {
+			tgt = i
+		}
+	}
+	return cur >= 0 && tgt >= 0 && cur >= tgt
+}
+
+// reconstructProgress re-derives the rollback progress flags from the persisted
+// op row. On a fresh op it is a no-op (BlockedAt nil, step ""); on a TAKEOVER
+// (crash of the owning runner, or a replica switch) it makes rollback behave as
+// if this runner had performed the prior steps — otherwise the flags stay false
+// and rollback silently skips unblocking the warehouse (leaving the org stuck in
+// resharding) and restoring compaction. This is what let a cancel of an op whose
+// owning replica had OOM-crashed mark the op cancelled while the warehouse
+// stayed blocked.
+//
+// Steps are stamped at the START of a step; a progress flag is set at its
+// SUCCESS. Reconstruction is deliberately conservative so a "started but not
+// completed" step can never trigger a damaging rollback:
+//   - blocked: keyed off the persisted blocked_at timestamp (written only after
+//     the ready→resharding CAS succeeds) — exact, no step guessing.
+//   - compactionPaused: requires the step to be STRICTLY PAST pausing_compaction
+//     (i.e. backup_catalog reached), which proves pauseCompaction recorded the
+//     prior setting; restoring to an unrecorded (zero) prior could wrongly
+//     re-enable compaction (key-absent enables it), so we would rather leave it
+//     paused than guess.
+//   - flipped / retainRequested: keyed off the step reaching cutover /
+//     orphaning_source. Over-marking these is safe: every post-flip rollback
+//     patch (re-point shard, flip back, adopt) is idempotent and no-ops when the
+//     store never actually moved.
+func (o *opRun) reconstructProgress() {
+	// blocked_at is written just after the ready→resharding CAS; reaching a step
+	// past "blocking" also proves the CAS succeeded (run() aborts on a block
+	// error), covering the sliver between the CAS and the blocked_at write.
+	if o.op.BlockedAt != nil || reshardStepReached(o.op, "draining") {
+		o.blocked = true
+	}
+	if reshardStepReached(o.op, "backup_catalog") {
+		o.compactionPaused = true
+	}
+	if o.op.TargetKind == configstore.MetadataStoreKindExternal && reshardStepReached(o.op, "orphaning_source") {
+		o.retainRequested = true
+	}
+	if reshardStepReached(o.op, "cutover") {
+		o.flipped = true
+	}
+}
+
 // flipTimeout is the per-op cutover bound, falling back to the runner
 // default (15m / DUCKGRES_RESHARD_FLIP_TIMEOUT).
 func (o *opRun) flipTimeout() time.Duration {
@@ -313,6 +384,10 @@ func (o *opRun) wait(ctx context.Context, d time.Duration) error {
 
 func (r *ReshardRunner) execute(ctx context.Context, op *configstore.ReshardOperation) {
 	o := &opRun{r: r, op: op}
+	// Recover progress flags from the persisted row so a takeover/replica-switch
+	// rolls back (unblocks the warehouse, restores compaction) as if this runner
+	// had done the prior steps. No-op for a fresh op.
+	o.reconstructProgress()
 	o.logf("info", "operation claimed by %s (epoch %d): %s → %s", r.cpID, op.RunnerEpoch, describeSource(op), describeTarget(op))
 
 	// Heartbeat until the op function returns. A fencing loss stops the op.

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -785,6 +785,62 @@ func TestReshardCancelDuringDrain(t *testing.T) {
 	}
 }
 
+// TestReshardTakeoverCancelUnblocksWarehouse is the regression for the mw-dev
+// incident: the runner that BLOCKED the warehouse crashed (OOM during the
+// pre-flip backup); a different replica later claimed the op (a fresh opRun with
+// all progress flags false) and, seeing cancel_requested, rolled back. Before
+// the fix the rollback's `if o.blocked` / `if o.compactionPaused` guards were
+// false on the takeover runner, so the op was marked cancelled while the
+// warehouse stayed stuck in `resharding` and compaction stayed paused. With
+// progress reconstructed from the persisted op row, the takeover rollback must
+// unblock the warehouse and restore compaction exactly as the original runner
+// would have.
+func TestReshardTakeoverCancelUnblocksWarehouse(t *testing.T) {
+	// A cnpg→ext op a prior epoch had already carried through backup_catalog
+	// (the incident's exact step) before its runner died.
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	blocked := time.Now().UTC().Add(-2 * time.Minute)
+	op.BlockedAt = &blocked
+	op.Step = "backup_catalog"
+	op.CompactionWasPresent = true
+	op.CompactionWasEnabled = false // pre-reshard compaction was already off
+	op.CancelRequested = true       // operator hit cancel while the owner was dead
+
+	store := newFakeReshardStore(op)
+	store.warehouseState = configstore.ManagedWarehouseStateResharding // prior runner blocked it
+	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: false}
+	copier := &fakeCopier{}
+
+	// A fresh runner (different replica) claims and executes the abandoned op.
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.op.State != configstore.ReshardStateCancelled {
+		t.Fatalf("state = %s (err %q), want cancelled", store.op.State, store.op.Error)
+	}
+	// The whole point: the warehouse is returned to ready, not left resharding.
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after takeover rollback", store.warehouseState)
+	}
+	if !store.hasLog("warehouse unblocked") {
+		t.Fatal("takeover rollback did not unblock the warehouse")
+	}
+	// Compaction is restored to the recorded prior setting (a takeover must not
+	// skip this): a compaction patch back to the recorded value is issued.
+	if !store.hasLog("compaction setting restored") {
+		t.Fatal("takeover rollback did not restore compaction")
+	}
+	// backup_catalog is before any flip, so nothing may be flipped.
+	for _, k := range duckling.callKinds() {
+		if k == "cnpg" || k == "external" || k == "cnpg-adopt" {
+			t.Fatalf("takeover rollback flipped the duckling (%s) — source was never flipped", k)
+		}
+	}
+}
+
 // waitOpTerminal polls the fake store until the op reaches a terminal state
 // (or the deadline), for tests that drive the runner via AdoptClaimedOperation
 // (which launches execution on its own goroutine rather than via runOp).

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -334,6 +334,19 @@ the `2BP01` "role can't drop while its DB exists" wedge the coupled delete hit.
   `runner_epoch=1`, owned by the creating CP — a fresh-heartbeat running row no
   sibling replica can steal, which is what keeps the ephemeral external
   password with the one runner that has it.
+- Takeover rollback reconstructs progress from the persisted row. A runner that
+  claims an op a prior epoch advanced starts with all in-process rollback flags
+  false, so it calls `reconstructProgress()` before running: `blocked` from
+  `blocked_at`/step-past-`blocking`, `compactionPaused` from step-past-
+  `pausing_compaction`, `flipped`/`retainRequested` from step reaching
+  `cutover`/`orphaning_source`. Without this, a cancel or failure that
+  short-circuits before the steps re-execute (the first `cancelRequested()`
+  check) would mark the op terminal while leaving the warehouse stuck in
+  `resharding` and compaction paused — the exact mw-dev incident where the
+  blocking runner OOM-crashed mid-backup and a sibling replica finalized the
+  cancel without unblocking. Reconstruction is conservative (only signals that
+  prove a step completed flip a flag) and every rollback action is idempotent, so
+  a takeover rolls back identically to the original runner.
 - An org is never stranded: every failure path restores `resharding→ready`
   (or logs at ERROR if it can't — that's the page-someone signal).
 


### PR DESCRIPTION
## Problem

When a reshard runner **claims an op a prior epoch already advanced** (the owning replica crashed, or work switched replicas), the fresh `opRun` starts with all rollback progress flags false (`blocked`, `compactionPaused`, `flipped`, `retainRequested`). `run()` checks `cancel_requested` first, so cancelling an abandoned op short-circuits *before* any step re-executes and rolls back with `blocked=false` → the rollback's `if o.blocked` guard skips the warehouse unblock. The op is marked `cancelled` **while the warehouse stays stuck in `resharding`, refusing all new connections.** Compaction restore is skipped the same way.

### Observed on mw-dev
The runner that blocked the warehouse **OOM-crashed during the pre-flip catalog backup**. A sibling replica took over past the 5m stale-heartbeat window, saw the operator's cancel flag, and finalized the op `cancelled` while the org stayed blocked (had to hand-flip the warehouse row back to `ready` to recover connectivity).

## Fix

`reconstructProgress()` re-derives the rollback flags from the **persisted op row** before `run()`, so a takeover rolls back identically to the original runner:

| flag | reconstructed from |
|---|---|
| `blocked` | `blocked_at` set **or** step past `blocking` (proves the ready→resharding CAS succeeded) |
| `compactionPaused` | step past `pausing_compaction` (proves the prior setting was recorded — a stricter gate than the step itself, so restore can't wrongly *re-enable* compaction from a zero prior) |
| `flipped` / `retainRequested` | step reached `cutover` / `orphaning_source` (over-marking is safe: the flip-back / adopt patches are idempotent no-ops when the store never moved) |

No-op for a fresh op (`blocked_at` nil, step `""`).

**Out of scope (deliberately):** the OOM itself. The backup still shells `pg_dump` inside the 512Mi CP pod; that's a separate change per the request.

## Test

`TestReshardTakeoverCancelUnblocksWarehouse` — a cnpg→ext op a prior epoch carried through `backup_catalog`, warehouse pre-set to `resharding`, `cancel_requested=true`; a fresh runner claims + executes and must end `cancelled` **and** warehouse `ready` **and** compaction restored **and** no flip. Full `provisioner` package + `go vet` green under `-tags kubernetes`.

An in-Job e2e assertion would need to kill a runner mid-op (crash-takeover), which the harness can't do deterministically — the unit test is the gate. Docs updated in `CLAUDE.md` + `docs/design/resharding.md`.