### PR TITLE
tests: cover goose migration 000021 in the v8 downgrade round-trip

### DIFF
--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -164,7 +164,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -198,7 +198,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 18)
 	requireGooseMigrationRecorded(t, upgradedDB, 19)
 	requireGooseMigrationRecorded(t, upgradedDB, 20)
-	requireGooseLatestVersion(t, upgradedDB, 20)
+	requireGooseMigrationRecorded(t, upgradedDB, 21)
+	requireGooseLatestVersion(t, upgradedDB, 21)
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")


### PR DESCRIPTION
## Problem

`configstore-integration-tests` fails on **every run of main** since #939 merged:

```
--- FAIL: TestConfigStoreSQLMigrationsUpgradeVersion8Schema
migrations_postgres_test.go:178: latest goose migration version = {21 true}, want 8
```

#939 added goose migration `000021_add_reshard_backup_uri.sql` and updated `TestConfigStoreRunsVersionedSQLMigrations`, but missed the downgrade round-trip test: its downgrade block deletes only versions 9–20 from `goose_db_version`, so version 21 survives and the `want 8` assert fails. This is also what failed CI on #940 (which doesn't touch migrations at all).

## Fix

- Add `21` to the downgrade `DELETE FROM goose_db_version` list.
- Assert 21 is re-recorded after the upgrade and bump the latest-version assert 20 → 21.

No schema reversal needed for 000021 itself: `backup_s3_uri` lives on `duckgres_reshard_operations`, which the downgrade block already drops entirely.

Mechanical test-only change; validated by this PR's own `configstore-integration-tests` job (no local container runtime available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)