### PR TITLE
reshard: announce long-running phases and emit periodic verify progress in the op log

### DIFF
--- a/controlplane/provisioner/catalog_copy.go
+++ b/controlplane/provisioner/catalog_copy.go
@@ -98,8 +98,10 @@ type CatalogCopier interface {
 	// verbose operator-facing progress lines.
 	Copy(ctx context.Context, source, target CatalogEndpoint, log func(level, msg string)) (CatalogCopyResult, error)
 	// SnapshotCounts re-reads the current per-table row counts (no snapshot
-	// tx) — the post-copy source-stability recheck.
-	SnapshotCounts(ctx context.Context, ep CatalogEndpoint) (map[string]int64, error)
+	// tx) — the post-copy source-stability recheck and the external-catalog
+	// verify. log receives periodic progress lines (a ~20k-table catalog
+	// takes minutes to count).
+	SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error)
 	// DropCatalogTables drops all ducklake_* tables (rollback cleanup of a
 	// partially copied target).
 	DropCatalogTables(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) error
@@ -152,6 +154,8 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 		return result, fmt.Errorf("target catalog is locked by another copier — refusing to interleave")
 	}
 
+	log("info", "opening a consistent source snapshot and discovering catalog tables…")
+
 	// One consistent snapshot across every table.
 	tx, err := src.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
 	if err != nil {
@@ -193,31 +197,34 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 
 	// Constraints after data (bulk-load fast path), then non-constraint
 	// indexes (constraint-backed PK indexes already exist via ADD CONSTRAINT).
-	for _, table := range tables {
+	if err := applyConstraintsAndIndexes(tables, func(table string) error {
 		if err := applyConstraints(ctx, tx, dst, table); err != nil {
-			return result, err
+			return err
 		}
-		if err := applyIndexes(ctx, tx, dst, table); err != nil {
-			return result, err
-		}
+		return applyIndexes(ctx, tx, dst, table)
+	}, log); err != nil {
+		return result, err
 	}
-	log("info", "constraints and indexes applied on target")
 
 	// Verify inside the same snapshot: source snapshot counts vs live target.
-	for _, table := range tables {
-		var srcCount, dstCount int64
-		if err := tx.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&srcCount); err != nil {
-			return result, fmt.Errorf("count source %s: %w", table, err)
-		}
-		if err := dst.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&dstCount); err != nil {
-			return result, fmt.Errorf("count target %s: %w", table, err)
-		}
-		if srcCount != dstCount {
-			return result, fmt.Errorf("row count mismatch on %s: source %d, target %d", table, srcCount, dstCount)
-		}
-		result.PerTableRows[table] = srcCount
+	verified, err := verifyCopiedRowCounts(tables,
+		func(table string) (int64, error) {
+			var c int64
+			err := tx.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c)
+			return c, err
+		},
+		func(table string) (int64, error) {
+			var c int64
+			err := dst.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c)
+			return c, err
+		},
+		log)
+	if err != nil {
+		return result, err
 	}
-	log("info", fmt.Sprintf("verified %d tables: target row counts match the source snapshot", len(tables)))
+	for table, c := range verified {
+		result.PerTableRows[table] = c
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return result, fmt.Errorf("close source snapshot tx: %w", err)
@@ -225,7 +232,7 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 	return result, nil
 }
 
-func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint) (map[string]int64, error) {
+func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error) {
 	conn, err := pgx.Connect(ctx, ep.DSN())
 	if err != nil {
 		return nil, fmt.Errorf("connect %s: %w", ep.Redacted(), err)
@@ -237,13 +244,69 @@ func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint) (
 		return nil, fmt.Errorf("discover catalog tables: %w", err)
 	}
 	counts := make(map[string]int64, len(tables))
-	for _, table := range tables {
+	for i, table := range tables {
 		var c int64
 		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c); err != nil {
 			return nil, fmt.Errorf("count %s: %w", table, err)
 		}
 		counts[table] = c
+		maybeLogProgress(log, "counted", i+1, len(tables))
 	}
+	return counts, nil
+}
+
+// verifyProgressEvery is the periodic-progress cadence of the loops that visit
+// every catalog table (row-count verification and recounts): one
+// "<verb> N/M tables…" line per this many tables — ~8 lines on a ~20k-table
+// catalog, never per-table — so the op log does not go silent for minutes
+// while the loop is healthy.
+const verifyProgressEvery = 2500
+
+// maybeLogProgress emits the periodic progress line every verifyProgressEvery
+// items. The final item is skipped — the caller logs its own completion line.
+func maybeLogProgress(log func(level, msg string), verb string, done, total int) {
+	if done > 0 && done < total && done%verifyProgressEvery == 0 {
+		log("info", fmt.Sprintf("%s %d/%d tables…", verb, done, total))
+	}
+}
+
+// applyConstraintsAndIndexes drives the constraint/index replay across all
+// tables. On a large catalog (~20k tables) this runs tens of seconds, so the
+// phase announces itself before the first ALTER instead of logging only on
+// completion.
+func applyConstraintsAndIndexes(tables []string, apply func(table string) error, log func(level, msg string)) error {
+	log("info", fmt.Sprintf("applying constraints and indexes on the target (%d tables)…", len(tables)))
+	for _, table := range tables {
+		if err := apply(table); err != nil {
+			return err
+		}
+	}
+	log("info", "constraints and indexes applied on target")
+	return nil
+}
+
+// verifyCopiedRowCounts compares the source-snapshot row count of every table
+// against the live target, announcing the phase up front and emitting periodic
+// progress. Returns the per-table source counts on success.
+func verifyCopiedRowCounts(tables []string, srcCount, dstCount func(table string) (int64, error), log func(level, msg string)) (map[string]int64, error) {
+	log("info", fmt.Sprintf("verifying row counts across %d tables… (may take a few minutes)", len(tables)))
+	counts := make(map[string]int64, len(tables))
+	for i, table := range tables {
+		src, err := srcCount(table)
+		if err != nil {
+			return nil, fmt.Errorf("count source %s: %w", table, err)
+		}
+		dst, err := dstCount(table)
+		if err != nil {
+			return nil, fmt.Errorf("count target %s: %w", table, err)
+		}
+		if src != dst {
+			return nil, fmt.Errorf("row count mismatch on %s: source %d, target %d", table, src, dst)
+		}
+		counts[table] = src
+		maybeLogProgress(log, "verified", i+1, len(tables))
+	}
+	log("info", fmt.Sprintf("verified %d tables: target row counts match the source snapshot", len(tables)))
 	return counts, nil
 }
 

--- a/controlplane/provisioner/catalog_copy_test.go
+++ b/controlplane/provisioner/catalog_copy_test.go
@@ -2,7 +2,11 @@
 
 package provisioner
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 // TestShouldReplayConstraint pins the PG-18 NOT NULL skip: catalogued
 // not-null constraints (contype 'n') must never be replayed — the CREATE
@@ -18,5 +22,136 @@ func TestShouldReplayConstraint(t *testing.T) {
 		if got := shouldReplayConstraint(contype); got != want {
 			t.Errorf("shouldReplayConstraint(%q) = %t, want %t", contype, got, want)
 		}
+	}
+}
+
+// logRecorder collects the operator-facing log lines the copy helpers emit.
+type logRecorder struct{ lines []string }
+
+func (l *logRecorder) log(level, msg string) { l.lines = append(l.lines, level+": "+msg) }
+
+func (l *logRecorder) count(substr string) int {
+	n := 0
+	for _, line := range l.lines {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+func fakeTables(n int) []string {
+	tables := make([]string, n)
+	for i := range tables {
+		tables[i] = fmt.Sprintf("ducklake_t%05d", i)
+	}
+	return tables
+}
+
+// TestVerifyCopiedRowCountsAnnouncesAndEmitsProgress pins the op-log
+// liveness contract of the copy-verify loop: it announces itself with the
+// table total BEFORE the first count, emits a periodic progress line every
+// verifyProgressEvery tables (never per-table — a 20k-table catalog must
+// produce ~8 lines, not 20k), and closes with the completion line.
+func TestVerifyCopiedRowCountsAnnouncesAndEmitsProgress(t *testing.T) {
+	tables := fakeTables(2*verifyProgressEvery + 1000) // 6000: progress at 2500 and 5000
+	rec := &logRecorder{}
+	one := func(string) (int64, error) { return 1, nil }
+
+	counts, err := verifyCopiedRowCounts(tables, one, one, rec.log)
+	if err != nil {
+		t.Fatalf("verifyCopiedRowCounts: %v", err)
+	}
+	if len(counts) != len(tables) {
+		t.Fatalf("returned %d counts, want %d", len(counts), len(tables))
+	}
+	if len(rec.lines) == 0 || !strings.Contains(rec.lines[0], "verifying row counts across 6000 tables") {
+		t.Fatalf("first line must be the announce with the table total, got %v", rec.lines)
+	}
+	if rec.count("verified 2500/6000 tables…") != 1 || rec.count("verified 5000/6000 tables…") != 1 {
+		t.Fatalf("periodic progress lines missing: %v", rec.lines)
+	}
+	if !strings.Contains(rec.lines[len(rec.lines)-1], "verified 6000 tables: target row counts match the source snapshot") {
+		t.Fatalf("last line must be the completion line, got %v", rec.lines)
+	}
+	// Log volume is bounded: announce + 2 progress + completion. Never per-table.
+	if len(rec.lines) != 4 {
+		t.Fatalf("emitted %d lines, want exactly 4 (announce, 2 progress, completion): %v", len(rec.lines), rec.lines)
+	}
+}
+
+// TestVerifyCopiedRowCountsSmallCatalogNoProgress pins the no-spam rule: a
+// small catalog gets the announce and the completion line only.
+func TestVerifyCopiedRowCountsSmallCatalogNoProgress(t *testing.T) {
+	rec := &logRecorder{}
+	one := func(string) (int64, error) { return 1, nil }
+	if _, err := verifyCopiedRowCounts(fakeTables(3), one, one, rec.log); err != nil {
+		t.Fatalf("verifyCopiedRowCounts: %v", err)
+	}
+	if len(rec.lines) != 2 {
+		t.Fatalf("emitted %d lines, want exactly 2 (announce + completion): %v", len(rec.lines), rec.lines)
+	}
+}
+
+// TestVerifyCopiedRowCountsMismatch pins the mismatch error text (asserted by
+// operators reading the op log).
+func TestVerifyCopiedRowCountsMismatch(t *testing.T) {
+	rec := &logRecorder{}
+	src := func(string) (int64, error) { return 2, nil }
+	dst := func(string) (int64, error) { return 1, nil }
+	_, err := verifyCopiedRowCounts([]string{"ducklake_metadata"}, src, dst, rec.log)
+	if err == nil || !strings.Contains(err.Error(), "row count mismatch on ducklake_metadata: source 2, target 1") {
+		t.Fatalf("err = %v, want the row-count-mismatch error", err)
+	}
+}
+
+// TestApplyConstraintsAndIndexesAnnounces pins that the constraint/index
+// replay ANNOUNCES itself before the first table (it used to log only on
+// completion — a multi-ten-second silent gap on a big catalog) and still logs
+// the completion line; an apply error propagates without the completion line.
+func TestApplyConstraintsAndIndexesAnnounces(t *testing.T) {
+	rec := &logRecorder{}
+	var applied []string
+	err := applyConstraintsAndIndexes([]string{"ducklake_metadata", "ducklake_snapshot"}, func(table string) error {
+		if len(rec.lines) == 0 {
+			t.Fatal("apply ran before the phase announced itself")
+		}
+		applied = append(applied, table)
+		return nil
+	}, rec.log)
+	if err != nil {
+		t.Fatalf("applyConstraintsAndIndexes: %v", err)
+	}
+	if len(applied) != 2 {
+		t.Fatalf("applied %v, want both tables", applied)
+	}
+	if !strings.Contains(rec.lines[0], "applying constraints and indexes on the target (2 tables)") {
+		t.Fatalf("announce missing/wrong: %v", rec.lines)
+	}
+	if rec.count("constraints and indexes applied on target") != 1 {
+		t.Fatalf("completion line missing: %v", rec.lines)
+	}
+
+	failRec := &logRecorder{}
+	failErr := fmt.Errorf("boom")
+	if err := applyConstraintsAndIndexes([]string{"ducklake_metadata"}, func(string) error { return failErr }, failRec.log); err != failErr {
+		t.Fatalf("err = %v, want the apply error", err)
+	}
+	if failRec.count("constraints and indexes applied on target") != 0 {
+		t.Fatalf("completion line logged despite failure: %v", failRec.lines)
+	}
+}
+
+// TestMaybeLogProgressSkipsFinalItem pins that the final item never emits a
+// progress line even when it lands exactly on the cadence — the caller's
+// completion line covers it.
+func TestMaybeLogProgressSkipsFinalItem(t *testing.T) {
+	rec := &logRecorder{}
+	total := 2 * verifyProgressEvery
+	for i := 1; i <= total; i++ {
+		maybeLogProgress(rec.log, "counted", i, total)
+	}
+	if len(rec.lines) != 1 || !strings.Contains(rec.lines[0], fmt.Sprintf("counted %d/%d tables…", verifyProgressEvery, total)) {
+		t.Fatalf("lines = %v, want exactly one mid-loop progress line (the final on-cadence item is skipped)", rec.lines)
 	}
 }

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -748,7 +748,7 @@ func (o *opRun) backupCatalog(ctx context.Context) error {
 	key := fmt.Sprintf("%sop-%d-%s.dump", backupPrefix, o.op.ID, ts)
 	dest := BackupDestination{Bucket: bucket, Key: key, Region: st.DataStore.S3Region, RoleARN: st.IAMRoleARN}
 
-	o.logf("info", "backing up source catalog %s → s3://%s/%s before the flip%s",
+	o.logf("info", "backing up source catalog %s → s3://%s/%s before the flip (pg_dump streamed to S3; may take several minutes — size unknown until complete)%s",
 		o.source.Redacted(), bucket, key,
 		map[bool]string{true: " (HARD prerequisite: cnpg→external destroys the source at the flip)", false: ""}[destructive])
 	uri, size, err := o.r.backuper.Backup(ctx, o.source, dest)
@@ -982,7 +982,8 @@ func (o *opRun) verifyExternalCatalog(ctx context.Context) error {
 	if err := o.step("verifying_external"); err != nil {
 		return err
 	}
-	current, err := o.r.copier.SnapshotCounts(ctx, o.target)
+	o.logf("info", "verifying the external target catalog: counting rows across %d tables… (may take a few minutes)", len(o.copied.PerTableRows))
+	current, err := o.r.copier.SnapshotCounts(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) })
 	if err != nil {
 		return fmt.Errorf("re-reading external target counts: %w", err)
 	}
@@ -1092,7 +1093,8 @@ func (o *opRun) verifySourceStable(ctx context.Context) error {
 	if err := o.step("verifying"); err != nil {
 		return err
 	}
-	current, err := o.r.copier.SnapshotCounts(ctx, o.source)
+	o.logf("info", "verifying source stability: re-counting rows across %d tables outside the snapshot… (may take a few minutes)", len(o.copied.PerTableRows))
+	current, err := o.r.copier.SnapshotCounts(ctx, o.source, func(level, msg string) { o.logf(level, "%s", msg) })
 	if err != nil {
 		return fmt.Errorf("re-reading source counts: %w", err)
 	}

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -367,7 +367,7 @@ func (f *fakeCopier) Copy(_ context.Context, source, target CatalogEndpoint, log
 	return f.copyResult, nil
 }
 
-func (f *fakeCopier) SnapshotCounts(_ context.Context, ep CatalogEndpoint) (map[string]int64, error) {
+func (f *fakeCopier) SnapshotCounts(_ context.Context, ep CatalogEndpoint, _ func(string, string)) (map[string]int64, error) {
 	f.record(copierCall{kind: "counts", target: ep})
 	// The external target is reached with sslmode=require (verifyExternalCatalog);
 	// the cnpg source with sslmode=disable (verifySourceStable).
@@ -568,6 +568,12 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	if !store.hasLog("reshard report (succeeded)") || !store.hasLog("maintenance mode (connections blocked)") {
 		t.Fatalf("report missing from log: %v", store.logs)
 	}
+	// Long-running phases announce themselves when they START (an operator
+	// watching the live op log must never wonder whether a silent op is stuck):
+	// the source-stability recheck re-counts every table outside the snapshot.
+	if !store.hasLog("verifying source stability: re-counting rows across 3 tables") {
+		t.Fatalf("stability-recheck announce missing from log: %v", store.logs)
+	}
 }
 
 // TestReshardHappyPathExtToCnpg pins that an external source is NEVER
@@ -675,6 +681,14 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	last := store.warehouseUpds[len(store.warehouseUpds)-1]
 	if last["metadata_store_kind"] != configstore.MetadataStoreKindExternal || last["metadata_store_endpoint"] != "escape.rds.amazonaws.com" {
 		t.Fatalf("warehouse row not reconciled to external: %v", last)
+	}
+	// Both count-verification phases announce themselves with the table total
+	// before the (potentially multi-minute) recount starts.
+	if !store.hasLog("verifying source stability: re-counting rows across 1 tables") {
+		t.Fatalf("stability-recheck announce missing from log: %v", store.logs)
+	}
+	if !store.hasLog("verifying the external target catalog: counting rows across 1 tables") {
+		t.Fatalf("external-verify announce missing from log: %v", store.logs)
 	}
 }
 
@@ -1104,6 +1118,11 @@ func TestReshardBackupRecordedBeforeFlip(t *testing.T) {
 	}
 	if !store.hasLog("catalog backup complete") || !store.hasLog("pg_restore --no-owner") {
 		t.Fatalf("backup URI + restore command missing from log: %v", store.logs)
+	}
+	// The backup announces itself before pg_dump starts (streamed, duration and
+	// size unknown up front — the log must not go silent while it runs).
+	if !store.hasLog("backing up source catalog") || !store.hasLog("may take several minutes") {
+		t.Fatalf("backup start announce missing from log: %v", store.logs)
 	}
 	if !store.hasLog("pre-flip catalog backup: s3://org-a-data-bucket/") {
 		t.Fatalf("backup URI missing from end-of-op report: %v", store.logs)


### PR DESCRIPTION
## Problem

The reshard operation log (streamed live in the admin UI) is the operator's only view of a running reshard — and on a large catalog (~20k tables, ~1M rows) it went silent for multiple minutes while the op was perfectly healthy:

```
copied ducklake_view: 0 rows, 21 bytes
constraints and indexes applied on target        <- 33s silent
verified 20835 tables: target row counts match   <- 107s silent
verified: source is unchanged since the snapshot <- 52s silent
```

Each long phase logged only on **completion**, so an operator could not tell a progressing op from a stuck one.

## What changes

Every potentially long-running phase now **announces itself when it starts**, and the loops that visit every catalog table emit **bounded periodic progress**:

- **Constraint + index replay** (after the table copy): announces `applying constraints and indexes on the target (N tables)…` before the first ALTER.
- **Copy-verify loop** (per-table source-snapshot vs target counts, inside `Copy`): announces `verifying row counts across N tables… (may take a few minutes)`, then emits `verified N/M tables…` every 2500 tables.
- **Source-stability recheck** and **external-target verify** (both via the shared `SnapshotCounts`, which now takes a log callback): each announces with the table total + duration hint, and the recount emits `counted N/M tables…` every 2500 tables.
- **Pre-flip pg_dump backup**: the existing start announce now says the dump is streamed to S3 and may take several minutes (size unknown until complete).
- **Snapshot open / table discovery**: cheap start announce before the source snapshot transaction opens.

Cadence: one progress line per 2500 tables (`verifyProgressEvery`), never per-table — a 20k-table verify emits ~8 lines. Small catalogs get only the announce + completion (no spam). The final on-cadence item is skipped in favor of the completion line.

All lines flow through the existing `logf`/log-callback path, so they land in the config-store op log AND the admin UI stream — no new sink.

## Tests

- `controlplane/provisioner/catalog_copy_test.go`: new unit tests for the extracted (now fake-drivable) loops — announce-before-work, periodic-progress cadence on a 6000-table catalog (exactly 4 lines: announce, 2×progress, completion), no progress lines on small catalogs, mismatch error text preserved, final-item skip.
- `controlplane/provisioner/reshard_runner_test.go`: happy-path tests now assert the stability-recheck announce, the external-verify announce (with table totals), and the backup start announce via the fake store's op log.
- `go build ./... && go build -tags kubernetes ./...`, `go vet -tags kubernetes ./...`, `go test -tags kubernetes ./controlplane/provisioner/ -count=1` green (full `./controlplane/...` green except pre-existing docker-compose-dependent postgres-container tests that don't run locally).
- e2e harness: no asserted log-line text changed (`reshard_log_has` phrases — `waiting for connections to drain`, `catalog backup complete`, `pg_restore --no-owner`, reports, `rolling back`, `external source left untouched` — all preserved verbatim). No new e2e assertion: log cosmetics only.
- `docs/design/resharding.md` quotes step names, not log lines — no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)