### PR TITLE
reshard: make catalog-copy index replay idempotent on a reused external target

### DIFF
--- a/controlplane/provisioner/catalog_copy.go
+++ b/controlplane/provisioner/catalog_copy.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // Catalog copy for reshard operations: streams every ducklake_* table of one
@@ -30,6 +32,16 @@ import (
 //     so a table copy carries counters correctly.
 //   - Indexes backing constraints (PKs) are excluded from the pg_indexes
 //     replay — ADD CONSTRAINT already created them.
+//   - The target database may be REUSED (it survives failed/rolled-back
+//     attempts and an earlier residence of the same catalog, and a dev target
+//     can even host another tenant's live catalog): the per-table
+//     DROP TABLE IF EXISTS covers same-named tables, but index NAMES are
+//     schema-global, so replay is idempotent — every CREATE INDEX (and every
+//     index-backed ADD CONSTRAINT) drops a same-named stale index first, and
+//     a create that STILL collides (a live worker's
+//     ensureDuckLakeMetadataIndexes CREATE INDEX IF NOT EXISTS racing between
+//     our drop and create) is re-dropped and retried a bounded number of
+//     times.
 
 // CatalogEndpoint describes one side of the copy.
 type CatalogEndpoint struct {
@@ -492,6 +504,16 @@ ORDER BY conname`, table)
 		if !shouldReplayConstraint(c.typ) {
 			continue
 		}
+		if constraintCreatesIndex(c.typ) {
+			// The backing index is named after the constraint and index names
+			// are schema-global: on a reused target a stale index (attached to
+			// a table outside the source's table set, so it survived the
+			// per-table drop) can squat the name and fail the ADD CONSTRAINT
+			// with 42P07.
+			if _, err := dst.Exec(ctx, "DROP INDEX IF EXISTS public."+quoteIdent(c.name)); err != nil {
+				return fmt.Errorf("drop stale index %s on target (squats the constraint name for %s): %w", c.name, table, err)
+			}
+		}
 		stmt := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s %s", quoteIdent(table), quoteIdent(c.name), c.def)
 		if _, err := dst.Exec(ctx, stmt); err != nil {
 			return fmt.Errorf("apply constraint %s on %s: %w", c.name, table, err)
@@ -504,8 +526,8 @@ ORDER BY conname`, table)
 // EXCLUDING indexes backing constraints — ADD CONSTRAINT already created
 // those, and replaying them would collide on the index name.
 func applyIndexes(ctx context.Context, srcTx pgx.Tx, dst *pgx.Conn, table string) error {
-	defs, err := queryStrings(ctx, srcTx, `
-SELECT i.indexdef
+	rows, err := srcTx.Query(ctx, `
+SELECT i.indexname, i.indexdef
 FROM pg_indexes i
 WHERE i.schemaname = 'public' AND i.tablename = $1
   AND NOT EXISTS (
@@ -518,12 +540,82 @@ ORDER BY i.indexname`, table)
 	if err != nil {
 		return fmt.Errorf("introspect indexes of %s: %w", table, err)
 	}
-	for _, def := range defs {
-		if _, err := dst.Exec(ctx, def); err != nil {
-			return fmt.Errorf("apply index on %s (%s): %w", table, def, err)
+	var indexes []indexReplay
+	for rows.Next() {
+		var ix indexReplay
+		if err := rows.Scan(&ix.name, &ix.def); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan index of %s: %w", table, err)
+		}
+		indexes = append(indexes, ix)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("introspect indexes of %s: %w", table, err)
+	}
+	return replayIndexes(table, indexes, func(sql string) error {
+		_, err := dst.Exec(ctx, sql)
+		return err
+	}, isDuplicateRelationError)
+}
+
+// indexReplay is one standalone index to recreate on the target.
+type indexReplay struct {
+	name string // pg_indexes.indexname — index names are schema-global
+	def  string // pg_indexes.indexdef — a complete CREATE INDEX statement
+}
+
+// maxIndexReplayAttempts bounds the drop+create retry of one index replay when
+// the create keeps colliding with a concurrently recreated same-named index.
+const maxIndexReplayAttempts = 3
+
+// replayIndexes recreates a table's standalone indexes on the target
+// idempotently. The target may be a reused database where a same-named index
+// already exists, in two flavors (both observed on the real mw-dev target):
+//
+//   - stale: left over from a prior residence/attempt, attached to a table
+//     outside the source's table set, so the per-table DROP TABLE missed it;
+//   - concurrent: a live worker attached to the same (dev, shared) database
+//     re-created a duckgres metadata performance index via
+//     ensureDuckLakeMetadataIndexes' CREATE INDEX IF NOT EXISTS on a table
+//     this copy had just recreated — mid-copy, before this replay ran.
+//
+// So each index is dropped BY NAME first, and a create that still collides
+// (SQLSTATE 42P07 — the concurrent ensure raced between our drop and our
+// create) is re-dropped and retried, bounded by maxIndexReplayAttempts.
+// IF NOT EXISTS instead would silently keep a possibly-wrong stale index; the
+// replayed definition must win.
+func replayIndexes(table string, indexes []indexReplay, exec func(sql string) error, isDuplicate func(error) bool) error {
+	for _, ix := range indexes {
+		drop := "DROP INDEX IF EXISTS public." + quoteIdent(ix.name)
+		var lastCreateErr error
+		created := false
+		for attempt := 0; attempt < maxIndexReplayAttempts && !created; attempt++ {
+			if err := exec(drop); err != nil {
+				return fmt.Errorf("drop stale index %s on target (before replaying it for %s): %w", ix.name, table, err)
+			}
+			err := exec(ix.def)
+			switch {
+			case err == nil:
+				created = true
+			case isDuplicate(err):
+				lastCreateErr = err // concurrently recreated — drop and retry
+			default:
+				return fmt.Errorf("apply index on %s (%s): %w", table, ix.def, err)
+			}
+		}
+		if !created {
+			return fmt.Errorf("apply index on %s (%s): still colliding after %d drop+create attempts: %w", table, ix.def, maxIndexReplayAttempts, lastCreateErr)
 		}
 	}
 	return nil
+}
+
+// isDuplicateRelationError reports whether err is PostgreSQL "relation ...
+// already exists" (SQLSTATE 42P07).
+func isDuplicateRelationError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "42P07"
 }
 
 func quoteIdent(s string) string {
@@ -536,4 +628,12 @@ func quoteIdent(s string) string {
 // and its ADD CONSTRAINT syntax doesn't parse on older targets.
 func shouldReplayConstraint(contype string) bool {
 	return contype != "n"
+}
+
+// constraintCreatesIndex reports whether replaying a pg_constraint row of the
+// given contype creates a backing index named after the constraint (primary
+// key, unique, exclusion). Those names are schema-global on the target, so a
+// stale same-named index must be dropped before the ADD CONSTRAINT.
+func constraintCreatesIndex(contype string) bool {
+	return contype == "p" || contype == "u" || contype == "x"
 }

--- a/controlplane/provisioner/catalog_copy_test.go
+++ b/controlplane/provisioner/catalog_copy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // TestShouldReplayConstraint pins the PG-18 NOT NULL skip: catalogued
@@ -139,6 +141,171 @@ func TestApplyConstraintsAndIndexesAnnounces(t *testing.T) {
 	}
 	if failRec.count("constraints and indexes applied on target") != 0 {
 		t.Fatalf("completion line logged despite failure: %v", failRec.lines)
+	}
+}
+
+// statementRecorder fakes the target-side exec of replayIndexes, recording
+// every statement and optionally failing specific create attempts.
+type statementRecorder struct {
+	statements []string
+	// failCreates maps a CREATE statement to a queue of errors returned on
+	// successive attempts (nil entry = success).
+	failCreates map[string][]error
+}
+
+func (r *statementRecorder) exec(sql string) error {
+	r.statements = append(r.statements, sql)
+	if q, ok := r.failCreates[sql]; ok && len(q) > 0 {
+		err := q[0]
+		r.failCreates[sql] = q[1:]
+		return err
+	}
+	return nil
+}
+
+func (r *statementRecorder) count(stmt string) int {
+	n := 0
+	for _, s := range r.statements {
+		if s == stmt {
+			n++
+		}
+	}
+	return n
+}
+
+var errDup = fmt.Errorf("ERROR: relation already exists (fake 42P07)")
+
+func isFakeDup(err error) bool { return err == errDup }
+
+// TestReplayIndexesDropsByNameBeforeEachCreate pins the reused-target
+// idempotency contract (the 2026-07 mw-dev cnpg→ext reshard failure: a stale /
+// concurrently recreated idx_ducklake_column_tbl_snap on the shared external
+// target 42P07'd the plain CREATE INDEX): every replayed index is dropped BY
+// NAME (schema-qualified) immediately before its CREATE, and each definition
+// executes exactly once on the happy path.
+func TestReplayIndexesDropsByNameBeforeEachCreate(t *testing.T) {
+	indexes := []indexReplay{
+		{name: "idx_ducklake_column_tbl_snap", def: "CREATE INDEX idx_ducklake_column_tbl_snap ON public.ducklake_column USING btree (table_id)"},
+		{name: `weird"name`, def: `CREATE INDEX "weird""name" ON public.ducklake_tag USING btree (object_id)`},
+	}
+	rec := &statementRecorder{}
+	if err := replayIndexes("ducklake_column", indexes, rec.exec, isFakeDup); err != nil {
+		t.Fatalf("replayIndexes: %v", err)
+	}
+	want := []string{
+		`DROP INDEX IF EXISTS public."idx_ducklake_column_tbl_snap"`,
+		indexes[0].def,
+		`DROP INDEX IF EXISTS public."weird""name"`,
+		indexes[1].def,
+	}
+	if len(rec.statements) != len(want) {
+		t.Fatalf("statements = %v, want %v", rec.statements, want)
+	}
+	for i := range want {
+		if rec.statements[i] != want[i] {
+			t.Fatalf("statement[%d] = %q, want %q", i, rec.statements[i], want[i])
+		}
+	}
+}
+
+// TestReplayIndexesRetriesConcurrentDuplicate pins the race recovery: a
+// CREATE that collides (a live worker's CREATE INDEX IF NOT EXISTS landed
+// between our drop and create) is re-dropped and retried, and succeeds.
+func TestReplayIndexesRetriesConcurrentDuplicate(t *testing.T) {
+	def := "CREATE INDEX idx_ducklake_column_tbl_snap ON public.ducklake_column USING btree (table_id)"
+	rec := &statementRecorder{failCreates: map[string][]error{def: {errDup, nil}}}
+	err := replayIndexes("ducklake_column", []indexReplay{{name: "idx_ducklake_column_tbl_snap", def: def}}, rec.exec, isFakeDup)
+	if err != nil {
+		t.Fatalf("replayIndexes: %v", err)
+	}
+	drop := `DROP INDEX IF EXISTS public."idx_ducklake_column_tbl_snap"`
+	if rec.count(drop) != 2 || rec.count(def) != 2 {
+		t.Fatalf("want drop+create retried once (2 each), got drops=%d creates=%d: %v", rec.count(drop), rec.count(def), rec.statements)
+	}
+	// Ordering: drop always precedes its create.
+	if rec.statements[0] != drop || rec.statements[1] != def || rec.statements[2] != drop || rec.statements[3] != def {
+		t.Fatalf("wrong ordering: %v", rec.statements)
+	}
+}
+
+// TestReplayIndexesGivesUpAfterBoundedAttempts pins that a persistent 42P07
+// does not loop forever: after maxIndexReplayAttempts drop+create rounds the
+// replay fails with the offending definition in the error.
+func TestReplayIndexesGivesUpAfterBoundedAttempts(t *testing.T) {
+	def := "CREATE INDEX idx_x ON public.ducklake_column USING btree (table_id)"
+	fails := make([]error, maxIndexReplayAttempts)
+	for i := range fails {
+		fails[i] = errDup
+	}
+	rec := &statementRecorder{failCreates: map[string][]error{def: fails}}
+	err := replayIndexes("ducklake_column", []indexReplay{{name: "idx_x", def: def}}, rec.exec, isFakeDup)
+	if err == nil || !strings.Contains(err.Error(), def) || !strings.Contains(err.Error(), "still colliding") {
+		t.Fatalf("err = %v, want a still-colliding error naming the definition", err)
+	}
+	if got := rec.count(def); got != maxIndexReplayAttempts {
+		t.Fatalf("create attempted %d times, want %d", got, maxIndexReplayAttempts)
+	}
+}
+
+// TestReplayIndexesNonDuplicateErrorFailsFast pins that only 42P07 is
+// retried — any other create error propagates immediately.
+func TestReplayIndexesNonDuplicateErrorFailsFast(t *testing.T) {
+	def := "CREATE INDEX idx_x ON public.ducklake_column USING btree (table_id)"
+	boom := fmt.Errorf("boom")
+	rec := &statementRecorder{failCreates: map[string][]error{def: {boom}}}
+	err := replayIndexes("ducklake_column", []indexReplay{{name: "idx_x", def: def}}, rec.exec, isFakeDup)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want the create error", err)
+	}
+	if rec.count(def) != 1 {
+		t.Fatalf("create attempted %d times, want exactly 1 (no retry on non-42P07)", rec.count(def))
+	}
+}
+
+// TestReplayIndexesDropFailureSurfaces pins that a failing pre-drop is a hard
+// error (a name we cannot free means the create is doomed anyway).
+func TestReplayIndexesDropFailureSurfaces(t *testing.T) {
+	drop := `DROP INDEX IF EXISTS public."idx_x"`
+	rec := &statementRecorder{failCreates: map[string][]error{drop: {fmt.Errorf("cannot drop")}}}
+	err := replayIndexes("ducklake_column", []indexReplay{{name: "idx_x", def: "CREATE INDEX idx_x ON public.t (c)"}}, rec.exec, isFakeDup)
+	if err == nil || !strings.Contains(err.Error(), "drop stale index idx_x") {
+		t.Fatalf("err = %v, want the drop error", err)
+	}
+	if len(rec.statements) != 1 {
+		t.Fatalf("statements = %v, want only the failed drop", rec.statements)
+	}
+}
+
+// TestIsDuplicateRelationError pins the SQLSTATE classification driving the
+// retry: 42P07 (possibly wrapped) is a duplicate, everything else is not.
+func TestIsDuplicateRelationError(t *testing.T) {
+	dup := &pgconn.PgError{Code: "42P07", Message: `relation "idx_ducklake_column_tbl_snap" already exists`}
+	if !isDuplicateRelationError(dup) {
+		t.Error("bare 42P07 PgError must classify as duplicate")
+	}
+	if !isDuplicateRelationError(fmt.Errorf("apply index: %w", dup)) {
+		t.Error("wrapped 42P07 PgError must classify as duplicate")
+	}
+	if isDuplicateRelationError(&pgconn.PgError{Code: "42P01"}) {
+		t.Error("a different SQLSTATE must not classify as duplicate")
+	}
+	if isDuplicateRelationError(fmt.Errorf("plain error")) {
+		t.Error("a non-PgError must not classify as duplicate")
+	}
+}
+
+// TestConstraintCreatesIndex pins which constraint types get the stale-index
+// pre-drop: exactly those whose ADD CONSTRAINT creates a backing index named
+// after the constraint.
+func TestConstraintCreatesIndex(t *testing.T) {
+	creates := map[string]bool{
+		"p": true, "u": true, "x": true,
+		"f": false, "c": false, "n": false,
+	}
+	for contype, want := range creates {
+		if got := constraintCreatesIndex(contype); got != want {
+			t.Errorf("constraintCreatesIndex(%q) = %t, want %t", contype, got, want)
+		}
 	}
 }
 

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -161,7 +161,17 @@ blocking → draining → pausing_compaction → backup_catalog → cutover → 
    constraints then non-constraint indexes (PK-backed indexes excluded — ADD
    CONSTRAINT already made them). No sequences exist in the DuckLake catalog
    (next-ids are rows). A `pg_advisory_lock` in the TARGET database fences a
-   zombie ex-runner for copy+verify.
+   zombie ex-runner for copy+verify. The target database may be REUSED
+   (failed/rolled-back attempts and prior residences leave their catalog in
+   place — external stores are never cleaned up — and a dev target can even
+   host another tenant's live catalog): each table is `DROP TABLE IF EXISTS`d
+   before CREATE, and because index names are schema-global the index replay
+   is idempotent — `DROP INDEX IF EXISTS` by name before every `CREATE INDEX`
+   and every index-backed `ADD CONSTRAINT` (never `IF NOT EXISTS`, which would
+   silently keep a wrong stale index), with a bounded re-drop+retry when the
+   create still hits 42P07 because a live worker's
+   `ensureDuckLakeMetadataIndexes` (`CREATE INDEX IF NOT EXISTS` on attach)
+   raced the replay on a shared target.
 7. **verifying** — per-table counts (snapshot vs target), then re-read the
    source OUTSIDE the transaction: any change means a concurrent writer
    (straggler compactor, stray client) → rollback.

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2247,6 +2247,11 @@ duckling_shard_backfill() { # cnpgOrg
 #     what the step itself needs.
 # cnpg→ext stays unit-test-only: the harness knows the RDS SM secret NAME but
 # not the password, and the start API requires the password (ephemerally).
+# That includes the reused-/shared-target index-replay idempotency (a stale or
+# concurrently ensured idx_ducklake_* on the shared ext RDS 42P07'd a real
+# cnpg→ext copy): the collision only arises on the cnpg→ext COPY onto that
+# reused RDS, so it is pinned by the replayIndexes unit tests
+# (provisioner/catalog_copy_test.go) instead.
 # That also keeps the in-cutover ESO-sync-error surfacing (the deduped warn in
 # flipToExternal when the ExternalSecret is SecretSyncedError) unit-test-only
 # (provisioner/reshard_runner_test.go): asserting it live needs a real


### PR DESCRIPTION
## Symptom

A cnpg→external reshard (~20k-table catalog) failed ~1s into the constraint/index phase:

```
step "copying" failed: catalog copy: apply index on ducklake_column
(CREATE INDEX idx_ducklake_column_tbl_snap ON public.ducklake_column USING btree (…)):
ERROR: relation "idx_ducklake_column_tbl_snap" already exists (SQLSTATE 42P07) — rolling back
```

Rollback worked (warehouse back to `ready`), but the reshard cannot complete.

## Root cause

Not a regression from the recent copy refactor — the replay still applies each index exactly once. The collision comes from the **reused external target database**:

- External targets are never cleaned up, so a failed/rolled-back attempt or a prior residence leaves the full catalog (tables + indexes) in place, and on the shared dev target other tenants' catalogs coexist in the same `public` schema. The per-table `DROP TABLE IF EXISTS` only covers tables in the *current source's* table set — but **index names are schema-global**.
- Decisive evidence from the live target (OID forensics): the colliding index's OID (and 4 sibling `idx_ducklake_*` OIDs) sits *between* the OIDs of tables recreated early vs late in the failing run's copy phase — i.e. the indexes were created **mid-copy, by someone else**. That someone is `ensureDuckLakeMetadataIndexes` (`server/server.go`), which every worker runs on attach (`CREATE INDEX IF NOT EXISTS idx_ducklake_column_tbl_snap …`): a concurrently running e2e job's ext-backend workers were attached to the same shared dev database and re-planted the metadata performance indexes onto tables the copier had just recreated. The present/missing split of the 10 ensure indexes matches exactly which tables the copier had already recreated at ensure time.
- The copier's index replay then executed a plain `CREATE INDEX` → 42P07.

In production the target is per-org and the org is drained, so the *concurrent* flavor is dev-specific — but the *stale* flavor (leftover relations on a reused target attached to tables outside the source's set) is a real production hazard of the documented reuse semantics.

## Fix

`controlplane/provisioner/catalog_copy.go`:

- **Index replay is now idempotent**: each replayed index is `DROP INDEX IF EXISTS public."<name>"`'d immediately before its `CREATE INDEX`, and a create that *still* hits 42P07 (the concurrent ensure racing between our drop and create) is re-dropped and retried, bounded (`maxIndexReplayAttempts = 3`).
- **Index-backed constraints** (`p`/`u`/`x`) get the same pre-drop before `ADD CONSTRAINT`, since their backing index name can be squatted the same way.
- `CREATE INDEX IF NOT EXISTS` was deliberately **not** used — it would silently keep a possibly-wrong stale index; the replayed definition must win.

Docs updated: reused-target invariant in the file header and in `docs/design/resharding.md` (copying step).

## Test

- New unit tests in `catalog_copy_test.go` fake the target exec and pin: drop-by-name (schema-qualified, quoted) immediately before every create with each definition executed exactly once; retry on a concurrent 42P07; bounded give-up with the offending definition in the error; fail-fast on non-42P07; drop-failure surfacing; the 42P07 classifier; which constraint types get the pre-drop.
- The cnpg→ext copy can't run in the e2e harness (it needs the RDS password, which the harness doesn't have — already documented); the harness comment now records that the reused-target replay idempotency is pinned at unit level for the same reason.
- `go build ./…`, `go build -tags kubernetes ./…`, `go vet -tags kubernetes ./…`, `go test -tags kubernetes ./controlplane/provisioner/ -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
