### PR TITLE
admin: catch up reshard op log instantly instead of paging at poll cadence

### DIFF
--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -499,37 +499,82 @@ export function useReshard(opId: number | null) {
   });
 }
 
-// Incremental log accumulation: polls /log?after_id=<last seen> and appends.
-// Keeps polling (slower) even after the op is terminal so the final report
-// lines always land; the page unmount stops it. Returned entries are revealed
-// PROGRESSIVELY (useRevealedCount): opening the page of a running or finished
-// op replays the accumulated backlog line-by-line over a few seconds like a
-// live terminal, then live-appends new lines as they arrive.
+// Catch-up page size: the server's hard cap (ListReshardLog clamps >2000 back
+// to the 500 default), so a many-thousand-line backlog drains in a handful of
+// round-trips.
+export const RESHARD_LOG_CATCHUP_PAGE = 2000;
+
+// Reshard op log accumulation, in two phases:
+//
+// 1. Catch-up (mount / opId change): drain the ENTIRE existing backlog in an
+//    immediate tight loop of full pages — no poll-interval sleep between
+//    pages — and land it in ONE state update, revealed instantly. Opening the
+//    page of an op that already logged thousands of lines (a 20k-table copy
+//    logs one line per table) jumps straight to the newest lines instead of
+//    pumping batches at poll cadence.
+// 2. Live tail: poll /log?after_id=<last seen> and append; new lines are
+//    revealed progressively (useRevealedCount) like a live terminal. Keeps
+//    polling (slower) even after the op is terminal so the final report lines
+//    always land; the page unmount stops it.
 export function useReshardLog(opId: number | null, opState: string | undefined) {
   const [entries, setEntries] = useState<ReshardLogEntry[]>([]);
+  // Size of the instantly-revealed backlog; null until catch-up completes.
+  const [backlog, setBacklog] = useState<number | null>(null);
   const lastID = entries.length > 0 ? entries[entries.length - 1].id : 0;
   const terminal = opState != null && RESHARD_TERMINAL.has(opState);
 
+  useEffect(() => {
+    if (opId == null) return;
+    let cancelled = false;
+    setEntries([]);
+    setBacklog(null);
+    (async () => {
+      const acc: ReshardLogEntry[] = [];
+      let after = 0;
+      try {
+        for (;;) {
+          const page = await api.getReshardLog(opId, after, RESHARD_LOG_CATCHUP_PAGE);
+          if (cancelled) return;
+          acc.push(...page);
+          if (page.length < RESHARD_LOG_CATCHUP_PAGE) break;
+          after = page[page.length - 1].id;
+        }
+      } catch {
+        // Partial backlog is fine — the incremental poll resumes from its tail.
+      }
+      if (!cancelled) {
+        setEntries(acc);
+        setBacklog(acc.length);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [opId]);
+
+  const caughtUp = backlog != null;
   const poll = useQuery<ReshardLogEntry[]>({
     queryKey: ["reshardLog", opId, lastID],
     queryFn: () => api.getReshardLog(opId as number, lastID),
-    enabled: opId != null,
+    enabled: opId != null && caughtUp,
     retry: false,
+    // A full poll page changes lastID → new query key → immediate refetch, so
+    // an over-500-line gap between polls also drains without interval sleeps.
     refetchInterval: terminal ? POLL.slow : POLL.fast,
   });
 
   useEffect(() => {
     const fresh = poll.data;
-    if (fresh && fresh.length > 0) {
+    if (caughtUp && fresh && fresh.length > 0) {
       setEntries((prev) => {
         const seen = prev.length > 0 ? prev[prev.length - 1].id : 0;
         const append = fresh.filter((e) => e.id > seen);
         return append.length > 0 ? [...prev, ...append] : prev;
       });
     }
-  }, [poll.data]);
+  }, [poll.data, caughtUp]);
 
-  const revealed = useRevealedCount(entries.length);
+  const revealed = useRevealedCount(entries.length, backlog ?? 0);
   return useMemo(() => entries.slice(0, revealed), [entries, revealed]);
 }
 

--- a/controlplane/admin/ui/src/hooks/useReshardLog.test.tsx
+++ b/controlplane/admin/ui/src/hooks/useReshardLog.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { RESHARD_LOG_CATCHUP_PAGE, useReshardLog } from "./useApi";
+import { api } from "@/lib/api";
+import type { ReshardLogEntry } from "@/types/api";
+
+// Only getReshardLog is exercised here; keep the rest of the client intact so
+// unrelated hooks in useApi.ts still type-check against the real module.
+vi.mock("@/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/api")>();
+  return { ...mod, api: { ...mod.api, getReshardLog: vi.fn() } };
+});
+
+const getLog = vi.mocked(api.getReshardLog);
+
+function makeLines(n: number): ReshardLogEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: i + 1,
+    operation_id: 1,
+    ts: "2026-01-01T00:00:00Z",
+    level: "info",
+    message: `line ${i + 1}`,
+  }));
+}
+
+// Serve pages from `lines` the way the server does: id > after, capped at the
+// requested limit (500 default, like the handler).
+function serveFrom(lines: ReshardLogEntry[]) {
+  getLog.mockImplementation(async (_opId, afterId, limit) =>
+    lines.filter((e) => e.id > afterId).slice(0, limit ?? 500),
+  );
+}
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useReshardLog catch-up", () => {
+  beforeEach(() => getLog.mockReset());
+
+  it("drains a long backlog in a tight loop of max-size pages and reveals it instantly", async () => {
+    const lines = makeLines(2 * RESHARD_LOG_CATCHUP_PAGE + 300);
+    serveFrom(lines);
+
+    const { result } = renderHook(() => useReshardLog(1, "running"), {
+      wrapper: makeWrapper(),
+    });
+
+    // The whole backlog lands well within one poll interval and is revealed
+    // at once — no line-by-line replay, no page-per-poll-tick pumping.
+    await waitFor(() => expect(result.current).toHaveLength(lines.length));
+
+    const catchup = getLog.mock.calls.filter(([, , limit]) => limit === RESHARD_LOG_CATCHUP_PAGE);
+    expect(catchup).toEqual([
+      [1, 0, RESHARD_LOG_CATCHUP_PAGE],
+      [1, RESHARD_LOG_CATCHUP_PAGE, RESHARD_LOG_CATCHUP_PAGE],
+      [1, 2 * RESHARD_LOG_CATCHUP_PAGE, RESHARD_LOG_CATCHUP_PAGE],
+    ]);
+  });
+
+  it("stops after one short page when the backlog fits", async () => {
+    const lines = makeLines(42);
+    serveFrom(lines);
+
+    const { result } = renderHook(() => useReshardLog(1, "succeeded"), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current).toHaveLength(42));
+    const catchup = getLog.mock.calls.filter(([, , limit]) => limit === RESHARD_LOG_CATCHUP_PAGE);
+    expect(catchup).toEqual([[1, 0, RESHARD_LOG_CATCHUP_PAGE]]);
+  });
+
+  it("falls back to the incremental poll when catch-up fails", async () => {
+    const lines = makeLines(3);
+    getLog.mockRejectedValueOnce(new Error("boom"));
+    serveFrom(lines); // mockImplementation serves calls after the one-shot rejection
+
+    const { result } = renderHook(() => useReshardLog(1, "running"), {
+      wrapper: makeWrapper(),
+    });
+    // The poll (default page size) picks the lines up and replays them live.
+    await waitFor(() => expect(result.current).toHaveLength(3), { timeout: 3000 });
+  });
+
+  it("does nothing without an operation id", () => {
+    const { result } = renderHook(() => useReshardLog(null, undefined), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current).toEqual([]);
+    expect(getLog).not.toHaveBeenCalled();
+  });
+});

--- a/controlplane/admin/ui/src/lib/api.ts
+++ b/controlplane/admin/ui/src/lib/api.ts
@@ -231,11 +231,14 @@ export const api = {
       (r) => r.operations ?? [],
     ),
   getReshard: (opId: number) => get<ReshardOperation>(`/reshards/${opId}`),
-  // Incremental log poll: pass the last seen entry id.
-  getReshardLog: (opId: number, afterId: number) =>
-    get<{ entries: ReshardLogEntry[] }>(`/reshards/${opId}/log`, { after_id: afterId }).then(
-      (r) => r.entries ?? [],
-    ),
+  // Incremental log poll: pass the last seen entry id. `limit` caps the page
+  // size (server default 500, hard cap 2000 in ListReshardLog) — the catch-up
+  // loop asks for big pages to drain a long backlog in few round-trips.
+  getReshardLog: (opId: number, afterId: number, limit?: number) =>
+    get<{ entries: ReshardLogEntry[] }>(`/reshards/${opId}/log`, {
+      after_id: afterId,
+      limit,
+    }).then((r) => r.entries ?? []),
   cancelReshard: (opId: number) =>
     post<{ cancel_requested?: boolean; state?: string }>(`/reshards/${opId}/cancel`, {}),
   // Global operation list (all orgs, newest first) for the Reshards nav page.

--- a/controlplane/admin/ui/src/lib/logReplay.test.tsx
+++ b/controlplane/admin/ui/src/lib/logReplay.test.tsx
@@ -63,4 +63,48 @@ describe("useRevealedCount", () => {
     for (let i = 0; i < 20; i++) tick();
     expect(result.current).toBe(5);
   });
+
+  it("reveals the instant floor immediately, with no replay", () => {
+    const { result } = renderHook(
+      ({ total, instant }) => useRevealedCount(total, instant),
+      { initialProps: { total: 5000, instant: 5000 } },
+    );
+    // The whole backlog is visible on first render — no ticks needed.
+    expect(result.current).toBe(5000);
+  });
+
+  it("replays only lines beyond the instant floor", () => {
+    const { result, rerender } = renderHook(
+      ({ total, instant }) => useRevealedCount(total, instant),
+      { initialProps: { total: 100, instant: 100 } },
+    );
+    expect(result.current).toBe(100);
+
+    // Live appends after the backlog still surface tick-by-tick.
+    rerender({ total: 102, instant: 100 });
+    expect(result.current).toBe(100);
+    tick();
+    expect(result.current).toBeGreaterThan(100);
+    tick();
+    expect(result.current).toBe(102);
+  });
+
+  it("a raised instant floor mid-flight surfaces at once", () => {
+    const { result, rerender } = renderHook(
+      ({ total, instant }) => useRevealedCount(total, instant),
+      { initialProps: { total: 0, instant: 0 } },
+    );
+    expect(result.current).toBe(0);
+    // Catch-up completes: entries and the floor land together.
+    rerender({ total: 3000, instant: 3000 });
+    expect(result.current).toBe(3000);
+  });
+
+  it("clamps the instant floor to the total", () => {
+    const { result } = renderHook(
+      ({ total, instant }) => useRevealedCount(total, instant),
+      { initialProps: { total: 3, instant: 10 } },
+    );
+    expect(result.current).toBe(3);
+  });
 });

--- a/controlplane/admin/ui/src/lib/logReplay.ts
+++ b/controlplane/admin/ui/src/lib/logReplay.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
-// Progressive log replay: opening an operation page with an accumulated log
-// reveals it line-by-line like a live terminal instead of dumping everything
-// at once. The step is derived from the backlog size so ANY backlog finishes
-// within REVEAL_TICKS_TARGET ticks (~3.2s); once caught up, live appends
-// surface within a single tick.
+// Progressive log replay for LIVE appends: new lines surface tick-by-tick like
+// a live terminal. The backlog that already exists when a page opens is NOT
+// replayed — callers pass its size as `instant` so an operation with thousands
+// of accumulated lines shows its tail immediately (operators open the page to
+// see the newest lines, not an animation). The step is derived from the total
+// so any burst finishes within REVEAL_TICKS_TARGET ticks (~3.2s); once caught
+// up, live appends surface within a single tick.
 export const REVEAL_TICK_MS = 80;
 export const REVEAL_TICKS_TARGET = 40;
 
@@ -14,11 +16,17 @@ export function revealStep(total: number): number {
   return Math.max(1, Math.ceil(total / REVEAL_TICKS_TARGET));
 }
 
-// useRevealedCount returns how many of `total` items should be visible:
-// starts at 0 and climbs by revealStep(total) per tick until it catches up.
-// Monotonic (never goes backwards) and never exceeds total.
-export function useRevealedCount(total: number): number {
-  const [revealed, setRevealed] = useState(0);
+// useRevealedCount returns how many of `total` items should be visible.
+// Items up to `instant` (a monotonic floor — e.g. the accumulated backlog at
+// page open) are visible immediately, with no replay; anything beyond climbs
+// by revealStep(total) per tick. Monotonic (never goes backwards) and never
+// exceeds total.
+export function useRevealedCount(total: number, instant = 0): number {
+  const [revealed, setRevealed] = useState(() => Math.min(instant, total));
+  useEffect(() => {
+    // A raised floor (the backlog landing after catch-up) surfaces at once.
+    setRevealed((r) => Math.max(r, Math.min(instant, total)));
+  }, [instant, total]);
   useEffect(() => {
     if (revealed >= total) return;
     const t = setTimeout(() => {


### PR DESCRIPTION
## Symptom

Opening the admin console's reshard operation page for an op that already has a long log (thousands of lines — a 20k-table catalog copy logs one "copied X" line per table) visibly "pumps out" the log batch by batch. The operator has to wait until it finishes catching up before seeing the latest lines.

## Cause

`useReshardLog` accumulated the backlog **one page per poll tick**: each `/reshards/:id/log?after_id=N` request returned at most 500 lines (the server default), and the next page only landed on the next poll interval (3s while running, **15s once terminal** — a finished 20k-line log took minutes to appear). On top of that, the `useRevealedCount` replay animation revealed each landed batch line-by-line, so the pane kept animating for the whole catch-up.

## Fix (client-side only)

- **Tight catch-up loop on mount**: `useReshardLog` now drains the entire existing backlog in an immediate loop of max-size pages (2000 — the cap `ListReshardLog` already enforces server-side) with no poll-interval sleep between pages, and lands it in a **single state update**. Only then does it drop into the normal incremental `after_id` poll cadence.
- **Backlog revealed instantly**: `useRevealedCount` gained an `instant` floor — everything fetched during catch-up shows at once (the page's pinned-to-bottom auto-scroll jumps straight to the tail; the manual auto-scroll toggle is respected as before). The line-by-line "live terminal" replay now applies only to lines that arrive *after* catch-up.
- A catch-up fetch failure degrades to the old incremental poll from wherever it got to.

No server or log-write-path changes: the handler already accepted `?limit` and the store already capped it at 2000; the client just never asked for more than the 500 default.

## Verification

- `npm test` (vitest): 67 passed, including new tests — `useReshardLog` catch-up (max-size tight-loop pages, single-update instant reveal, short-page stop, failure fallback, null-op no-op) and `useRevealedCount` `instant`-floor semantics (instant backlog, replay only beyond the floor, clamping).
- `npm run build` (tsc -b + vite) green; `npm run lint` clean for the touched files (remaining warnings pre-existing, elsewhere).
- Go side untouched (no handler/store changes), so no Go test changes needed.
- UI-only polling behavior; the e2e harness exercises the reshard API, not the SPA — no harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)