### PR TITLE
reshard: fail the orphan wait fast on RBAC Forbidden + log observed MR policies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,7 +582,11 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
 - **cnpg→ext escape hatch = orphan-adopt then verified-delete** (charts
   `retainCnpgOnFlip`): copy → verify source → set `retainCnpgOnFlip=true` AND
   poll the cnpg Role/Database MRs until they carry the no-Delete policy (two-step
-  flip, closes the un-render-before-policy race) → flip type to external (now
+  flip, closes the un-render-before-policy race; this MR read needs an explicit
+  get grant on roles+databases in `postgresql.sql.m.crossplane.io` — NOT covered
+  by duckling-reader; a Forbidden fails the wait immediately with the missing
+  grant named, and the periodic wait log + timeout error carry the observed
+  `managementPolicies`) → flip type to external (now
   ORPHANS, not deletes, the cnpg role/DB) → verify the external catalog row
   counts match the copy EXACTLY → only THEN `DROP DATABASE` the retained source +
   clear the flag. ANY failure before that drop → flip back to cnpg-shard +

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -843,12 +843,23 @@ const cnpgTenantMRGroup = "postgresql.sql.m.crossplane.io"
 // source's). The reshard runner polls this after setting retainCnpgOnFlip=true
 // and only flips once both MRs reflect the policy — closing the race where the
 // flip un-renders the MRs before the retain policy propagated.
-func (d *DucklingClient) CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, err error) {
+//
+// detail is a one-line human-readable account of what was observed (per-MR
+// found/not-found + current managementPolicies), destined for the reshard op
+// log so a wait that is not converging is diagnosable from the log alone.
+//
+// NOTE this read needs RBAC the Duckling patch itself does not: get on
+// roles+databases in cnpgTenantMRGroup (the duckling-reader grant only covers
+// ducklings). A Forbidden here is a permanent misconfiguration — callers
+// should fail fast on it (apierrors.IsForbidden unwraps the %w chain), not
+// poll to a timeout.
+func (d *DucklingClient) CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, detail string, err error) {
 	cr, gerr := d.getCR(ctx, name)
 	if gerr != nil {
-		return false, false, fmt.Errorf("get duckling CR %q: %w", name, gerr)
+		return false, false, "", fmt.Errorf("get duckling CR %q: %w", name, gerr)
 	}
 	var roleFound, dbFound, roleNoDelete, dbNoDelete bool
+	observed := map[string]string{}
 	for _, ref := range nestedComposedRefs(cr) {
 		gvr, kind, refName, ok := composedRefGVR(ref)
 		if !ok || gvr.Group != cnpgTenantMRGroup {
@@ -860,11 +871,13 @@ func (d *DucklingClient) CnpgSourceMRsOrphaned(ctx context.Context, name string)
 		obj, gerr := d.client.Resource(gvr).Namespace(ducklingNamespace).Get(ctx, refName, metav1.GetOptions{})
 		if gerr != nil {
 			if apierrors.IsNotFound(gerr) {
+				observed[kind] = fmt.Sprintf("%s %q: referenced by the composite but not found", kind, refName)
 				continue
 			}
-			return false, false, fmt.Errorf("get %s %q: %w", kind, refName, gerr)
+			return false, false, "", fmt.Errorf("get %s %q: %w", kind, refName, gerr)
 		}
 		noDelete := !managementPoliciesHaveDelete(obj)
+		observed[kind] = fmt.Sprintf("%s %q: managementPolicies %s", kind, refName, describeManagementPolicies(obj))
 		switch kind {
 		case "Role":
 			roleFound, roleNoDelete = true, noDelete
@@ -872,9 +885,18 @@ func (d *DucklingClient) CnpgSourceMRsOrphaned(ctx context.Context, name string)
 			dbFound, dbNoDelete = true, noDelete
 		}
 	}
+	parts := make([]string, 0, 2)
+	for _, kind := range []string{"Role", "Database"} {
+		if s, ok := observed[kind]; ok {
+			parts = append(parts, s)
+		} else {
+			parts = append(parts, fmt.Sprintf("%s: no composed resourceRef in group %s", kind, cnpgTenantMRGroup))
+		}
+	}
+	detail = strings.Join(parts, "; ")
 	present = roleFound && dbFound
 	orphaned = present && roleNoDelete && dbNoDelete
-	return orphaned, present, nil
+	return orphaned, present, detail, nil
 }
 
 // managementPoliciesHaveDelete reports whether a managed resource's
@@ -894,6 +916,22 @@ func managementPoliciesHaveDelete(obj *unstructured.Unstructured) bool {
 		}
 	}
 	return false
+}
+
+// describeManagementPolicies renders a managed resource's
+// spec.managementPolicies for the reshard op log, making explicit that an
+// absent/empty field means Crossplane's default full lifecycle.
+func describeManagementPolicies(obj *unstructured.Unstructured) string {
+	spec, _ := obj.Object["spec"].(map[string]interface{})
+	raw, ok := spec["managementPolicies"].([]interface{})
+	if !ok || len(raw) == 0 {
+		return `absent (defaults to ["*"], full lifecycle incl. Delete)`
+	}
+	parts := make([]string, len(raw))
+	for i, p := range raw {
+		parts[i] = fmt.Sprintf("%q", fmt.Sprint(p))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
 }
 
 // readSpecDuckLakeEnabled returns spec.ducklake.enabled as *bool — nil when the

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -1,0 +1,46 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func mrWithPolicies(policies []interface{}) *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+	if policies != nil {
+		spec["managementPolicies"] = policies
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{"spec": spec}}
+}
+
+// TestDescribeManagementPolicies pins the op-log rendering of a managed
+// resource's managementPolicies (the orphan wait's periodic diagnostic), and
+// that its reading of "absent means full lifecycle" matches the conservative
+// managementPoliciesHaveDelete used for the orphan decision itself.
+func TestDescribeManagementPolicies(t *testing.T) {
+	cases := []struct {
+		name       string
+		policies   []interface{}
+		want       string
+		haveDelete bool
+	}{
+		{"absent defaults to full lifecycle", nil, `absent (defaults to ["*"], full lifecycle incl. Delete)`, true},
+		{"wildcard", []interface{}{"*"}, `["*"]`, true},
+		{"explicit delete", []interface{}{"Observe", "Create", "Update", "Delete"}, `["Observe","Create","Update","Delete"]`, true},
+		{"orphan-ready no-delete", []interface{}{"Observe", "Create", "Update"}, `["Observe","Create","Update"]`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := mrWithPolicies(tc.policies)
+			if got := describeManagementPolicies(obj); got != tc.want {
+				t.Fatalf("describeManagementPolicies = %q, want %q", got, tc.want)
+			}
+			if got := managementPoliciesHaveDelete(obj); got != tc.haveDelete {
+				t.Fatalf("managementPoliciesHaveDelete = %t, want %t", got, tc.haveDelete)
+			}
+		})
+	}
+}

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ReshardRunner drives reshard operations (see docs/design/resharding.md and
@@ -97,7 +98,7 @@ type reshardDucklingClient interface {
 	// cnpg→external orphan-adopt escape hatch:
 	SetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string, retain bool) error
 	GetMetadataStoreRetainCnpgOnFlip(ctx context.Context, name string) (retain, present bool, err error)
-	CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, err error)
+	CnpgSourceMRsOrphaned(ctx context.Context, name string) (orphaned, present bool, detail string, err error)
 	SetMetadataStoreCnpgAdopt(ctx context.Context, name, shard string) error
 }
 
@@ -882,8 +883,10 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 	// Wait until the cnpg Role+Database MRs reflect the no-Delete policy, so the
 	// type flip orphans (not deletes) them. Closes the race where the flip
 	// un-renders the MRs before the retain policy propagated.
+	o.logf("info", "retainCnpgOnFlip=true confirmed on the duckling spec (the XRD carries the field); waiting up to %s for the composition to re-render the cnpg Role/Database MRs without Delete", o.flipTimeout())
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastObserved := "no successful read yet"
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -892,22 +895,27 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 			return errReshardCancelled
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("cnpg source role/DB did not reflect the retain (no-Delete) policy within %s — refusing to flip (the composition may not honor retainCnpgOnFlip; charts/composition skew?)", o.flipTimeout())
+			return fmt.Errorf("cnpg source role/DB did not reflect the retain (no-Delete) policy within %s — refusing to flip (the composition may not honor retainCnpgOnFlip; charts/composition skew?); last observation: %s", o.flipTimeout(), lastObserved)
 		}
-		orphaned, mrsPresent, err := o.r.duckling.CnpgSourceMRsOrphaned(ctx, o.op.DucklingName)
-		if err == nil && mrsPresent && orphaned {
-			o.logf("info", "cnpg source role/DB now carry the retain (no-Delete) policy — safe to flip")
+		orphaned, mrsPresent, detail, err := o.r.duckling.CnpgSourceMRsOrphaned(ctx, o.op.DucklingName)
+		switch {
+		case err != nil && apierrors.IsForbidden(err):
+			// An RBAC denial is a permanent misconfiguration — polling to the
+			// timeout cannot heal it and would end in a misleading error
+			// blaming the composition (mw-dev reshard op: the runner's
+			// ServiceAccount could not read the provider-sql MRs and burned
+			// the full wait on Forbidden). Fail fast, naming the exact grant.
+			return fmt.Errorf("cannot verify the retain (no-Delete) policy on the cnpg source role/DB: reading the provider-sql managed resources is Forbidden for this runner's ServiceAccount — refusing to flip. Grant get on roles+databases in API group %s (the ducklings namespace) to the control-plane ServiceAccount (duckgres chart RBAC), then re-run the reshard: %v", cnpgTenantMRGroup, err)
+		case err != nil:
+			lastObserved = fmt.Sprintf("read failed: %v", err)
+		case mrsPresent && orphaned:
+			o.logf("info", "cnpg source role/DB now carry the retain (no-Delete) policy — safe to flip (%s)", detail)
 			return nil
+		default:
+			lastObserved = detail
 		}
 		if time.Since(lastLog) >= 15*time.Second {
-			switch {
-			case err != nil:
-				o.logf("info", "waiting for the cnpg source MRs to reflect the retain policy: read failed: %v", err)
-			case !mrsPresent:
-				o.logf("info", "waiting for the cnpg source MRs to reflect the retain policy: Role/Database MRs not both observed yet")
-			default:
-				o.logf("info", "waiting for the cnpg source MRs to reflect the retain (no-Delete) policy")
-			}
+			o.logf("info", "waiting for the cnpg source MRs to reflect the retain (no-Delete) policy: %s", lastObserved)
 			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,6 +12,8 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ---- fakes -----------------------------------------------------------------
@@ -222,6 +225,12 @@ type fakeDuckling struct {
 	// (composition converges instantly).
 	retainFieldUnsupported bool
 	retainFlag             bool
+	// mrsReadErr scripts a CnpgSourceMRsOrphaned read failure (e.g. an RBAC
+	// Forbidden, wrapped the way the real client wraps it).
+	mrsReadErr error
+	// mrsStuckWithDelete models a composition that never honors the retain
+	// flag: the MRs stay at full lifecycle ["*"] no matter what.
+	mrsStuckWithDelete bool
 }
 
 func (f *fakeDuckling) Get(context.Context, string) (*DucklingStatus, error) {
@@ -291,13 +300,22 @@ func (f *fakeDuckling) GetMetadataStoreRetainCnpgOnFlip(context.Context, string)
 	return f.retainFlag, true, nil
 }
 
-func (f *fakeDuckling) CnpgSourceMRsOrphaned(context.Context, string) (bool, bool, error) {
+func (f *fakeDuckling) CnpgSourceMRsOrphaned(context.Context, string) (bool, bool, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.mrsReadErr != nil {
+		return false, false, "", f.mrsReadErr
+	}
+	if f.mrsStuckWithDelete {
+		return false, true, `Role "org-a-role": managementPolicies ["*"]; Database "org-a-db": managementPolicies ["*"]`, nil
+	}
 	// Composition converges instantly: once retain is set, the cnpg source MRs
 	// reflect the no-Delete policy. present is always true (the source cnpg
 	// Role/Database MRs exist while type is cnpg-shard).
-	return f.retainFlag, true, nil
+	if f.retainFlag {
+		return true, true, `Role "org-a-role": managementPolicies ["Observe","Create","Update"]; Database "org-a-db": managementPolicies ["Observe","Create","Update"]`, nil
+	}
+	return false, true, `Role "org-a-role": managementPolicies ["*"]; Database "org-a-db": managementPolicies ["*"]`, nil
 }
 
 func (f *fakeDuckling) SetMetadataStoreCnpgAdopt(_ context.Context, _ string, shard string) error {
@@ -1273,6 +1291,103 @@ func TestReshardCnpgToExtXRDUnsupportedRefuses(t *testing.T) {
 	}
 	if store.warehouseState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("warehouse state = %s, want ready after refusal rollback", store.warehouseState)
+	}
+}
+
+// TestReshardCnpgToExtOrphanWaitForbiddenFailsFast pins the RBAC fail-fast:
+// when the runner's ServiceAccount cannot read the provider-sql Role/Database
+// MRs (Forbidden), the orphan wait must NOT poll to its timeout and then blame
+// the composition — it fails immediately with an error naming the missing
+// grant, before any flip, and rolls back cleanly. Regression for the mw-dev
+// reshard op that burned the full 15m wait on a Forbidden read.
+func TestReshardCnpgToExtOrphanWaitForbiddenFailsFast(t *testing.T) {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	store := newFakeReshardStore(op)
+	// Wrapped exactly the way the real client wraps a Get failure — the
+	// runner's IsForbidden must see through the %w chain.
+	forbidden := fmt.Errorf("get Database %q: %w", "org-a-db",
+		apierrors.NewForbidden(
+			schema.GroupResource{Group: "postgresql.sql.m.crossplane.io", Resource: "databases"},
+			"org-a-db", errors.New("no RBAC grant")))
+	duckling := &fakeDuckling{status: cnpgSourceStatus(), mrsReadErr: forbidden}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	// An hour-long flip timeout proves the failure is the fail-fast, not the
+	// deadline (runOp's 30s guard would trip if the wait polled to timeout).
+	r.flipTimeout = time.Hour
+	r.StashExternalPassword(op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed ||
+		!strings.Contains(store.op.Error, "Forbidden") ||
+		!strings.Contains(store.op.Error, "postgresql.sql.m.crossplane.io") {
+		t.Fatalf("state=%s err=%q, want fast Forbidden failure naming the missing RBAC grant", store.op.State, store.op.Error)
+	}
+	// Never flipped, never dropped — the source is untouched.
+	if containsStr(duckling.callKinds(), "external") {
+		t.Fatalf("flip ran despite the Forbidden orphan check: %v", duckling.callKinds())
+	}
+	if containsStr(copier.kinds(), "dropdb") {
+		t.Fatalf("source dropped despite refusing the flip: %v", copier.kinds())
+	}
+	// The retain flag we set is reset on rollback.
+	var retainVals []bool
+	for _, c := range duckling.calls {
+		if c.kind == "retain" && c.retain != nil {
+			retainVals = append(retainVals, *c.retain)
+		}
+	}
+	if len(retainVals) == 0 || retainVals[len(retainVals)-1] != false {
+		t.Fatalf("retain patches = %v, want the last to reset to false on rollback", retainVals)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after fail-fast rollback", store.warehouseState)
+	}
+}
+
+// TestReshardCnpgToExtOrphanWaitTimeoutReportsObservation pins the wait-loop
+// diagnostics: when the composition never re-renders the MRs without Delete,
+// the periodic op-log lines and the final timeout error must carry the last
+// observed managementPolicies, so a stuck wait is diagnosable from the op log
+// alone.
+func TestReshardCnpgToExtOrphanWaitTimeoutReportsObservation(t *testing.T) {
+	op := cnpgOp()
+	op.TargetKind = configstore.MetadataStoreKindExternal
+	op.ToShard = ""
+	op.TargetEndpoint = "escape.rds.amazonaws.com"
+	op.TargetPasswordSecret = "escape-secret"
+	op.TargetUser = "postgres"
+	op.TargetDatabase = "postgres"
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus(), mrsStuckWithDelete: true}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	r := testRunner(store, duckling, copier)
+	r.flipTimeout = 150 * time.Millisecond
+	r.StashExternalPassword(op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed ||
+		!strings.Contains(store.op.Error, "charts/composition skew") ||
+		!strings.Contains(store.op.Error, `managementPolicies ["*"]`) {
+		t.Fatalf("state=%s err=%q, want composition-skew timeout carrying the last observed managementPolicies", store.op.State, store.op.Error)
+	}
+	// No flip, no drop — the source is untouched, and rollback recovers.
+	if containsStr(duckling.callKinds(), "external") {
+		t.Fatalf("flip ran despite the MRs never reflecting the retain policy: %v", duckling.callKinds())
+	}
+	if containsStr(copier.kinds(), "dropdb") {
+		t.Fatalf("source dropped despite refusing the flip: %v", copier.kinds())
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after timeout rollback", store.warehouseState)
 	}
 }
 

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -74,7 +74,9 @@ catalogs can be much larger than that one.
 
 The pod runs the CP's **own image** (it carries `pg_dump` and the duckgres
 binary) in `--mode reshard-runner`, under the CP's **own ServiceAccount** (the
-runner patches Duckling CRs — RBAC the CP already holds; no new grants), and
+runner patches Duckling CRs — RBAC the CP already holds; the ONE extra grant
+is the cnpg→ext orphan wait's read of the provider-sql MRs, see
+`orphaning_source` below), and
 inherits an **allowlist** of the CP container's env spec verbatim
 (`DUCKGRES_CONFIG_STORE`, `DUCKGRES_INTERNAL_SECRET`, `DUCKGRES_AWS_REGION`, …
 — a secretKeyRef is copied as a ref, so nothing secret ever lands in a pod
@@ -297,6 +299,18 @@ blocking → draining → pausing_compaction → backup_catalog → copying → 
    the reshard with a clear "deploy the charts first" error rather than risk the
    old destructive delete-on-flip. (Refuse is safer than silently falling back
    to data-loss risk.)
+   **RBAC:** this is the ONE reshard step that reads beyond the Duckling CR —
+   `CnpgSourceMRsOrphaned` gets the provider-sql `Role`/`Database` MRs
+   (`postgresql.sql.m.crossplane.io`, ducklings namespace), which the
+   duckling-reader grant does NOT cover; the runner's ServiceAccount needs an
+   explicit get grant on those resources (duckgres chart RBAC). A **Forbidden**
+   read fails the wait IMMEDIATELY with an error naming the missing grant — an
+   RBAC denial is permanent, and polling to the timeout would only produce a
+   misleading "composition skew?" error (a real mw-dev incident: the first live
+   cnpg→ext burned its full 15m orphan wait on Forbidden reads). Transient read
+   errors keep polling; every ~15s the op log records what the poll observed
+   (per-MR found/not-found + current `managementPolicies`), and the timeout
+   error carries the last observation.
 3. **cutover** — flip `type` to external (`cnpgShard: null`, external block set;
    `retainCnpgOnFlip` left true). The un-render now ORPHANS the cnpg role/DB.
    Wait for external Ready + ESO password synced + matching the typed password.


### PR DESCRIPTION
## Context

The first live cnpg→external reshard on mw-dev failed at `orphaning_source`: the runner set `retainCnpgOnFlip=true` (the flag stuck — the XRD-compat read-back passed), then polled `CnpgSourceMRsOrphaned` for the full 15m flip timeout and gave up with the generic "the composition may not honor retainCnpgOnFlip; charts/composition skew?" error.

The op log shows the real cause on every single poll: reading the provider-sql `Database`/`Role` managed resources (`postgresql.sql.m.crossplane.io`, ducklings namespace) is **Forbidden** for the runner's ServiceAccount. The duckling-reader grant covers only `ducklings` — the orphan wait is the one reshard step that reads beyond the Duckling CR, and it never had the RBAC it needs. The composition and XRD were fine (the retain conditional was already in the composition revision serving the op), and the composition demonstrably re-rendered `managementPolicies` when the flag was cleared on rollback — the runner was simply blind.

## Changes

- **Fail fast on Forbidden**: an RBAC denial is permanent — polling to the timeout cannot heal it and ends in an error blaming the wrong component. The wait now aborts immediately with the exact missing grant named (get on roles+databases in `postgresql.sql.m.crossplane.io`), and rolls back cleanly (retain flag cleared, source untouched, org back to ready).
- **Observable wait**: `CnpgSourceMRsOrphaned` now returns a per-MR observation (found/not-found + current `managementPolicies`, with "absent = default full lifecycle" made explicit). The existing 15s periodic wait log carries it, the wait announces itself (flag confirmed + how long it will wait), and the timeout error includes the **last observation** — a stuck wait is diagnosable from the op log alone.
- Docs: `docs/design/resharding.md` + `CLAUDE.md` no longer claim the runner needs "no new grants"; the RBAC requirement and the fail-fast semantics are pinned.

## Tests

- `TestReshardCnpgToExtOrphanWaitForbiddenFailsFast` — a Forbidden read (wrapped exactly like the real client wraps it, proving `IsForbidden` sees through the `%w` chain) fails the op immediately (1h flip timeout in the test — the 30s harness guard would trip if it polled), names the grant, never flips, never drops the source, resets the retain flag, unblocks the org.
- `TestReshardCnpgToExtOrphanWaitTimeoutReportsObservation` — a composition that never re-renders no-Delete times out with the last observed `managementPolicies ["*"]` in the error.
- `TestDescribeManagementPolicies` — pins the op-log rendering and its agreement with the conservative `managementPoliciesHaveDelete`.

`go build ./...`, `go build -tags kubernetes ./...`, `go vet -tags kubernetes ./...`, `go test -tags kubernetes ./controlplane/provisioner/` all green. The cnpg→ext positive path remains unit-only in the e2e harness (documented limitation: the harness lacks the RDS password), so no harness change.

## Not in this PR (charts repo)

The actual RBAC grant is a duckgres **chart** fix — see the PR comment below for the exact operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)