### PR TITLE
Validate duckgres.query_source against its allowed values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,7 +470,15 @@ admin APIs, never clearable via the admin API, so every org always has one;
 resolved from the config snapshot at connection end, where 0 can still appear
 only for an unknown org / stale snapshot); `query_source` is the
 `duckgres.query_source` session GUC (`standard` unless set; a mid-connection
-change bills the whole connection under the final value). Invariants for anyone
+change bills the whole connection under the final value). The GUC is a **closed
+enum validated at SET time** (`transform.NormalizeQuerySource`): only
+`standard` | `endpoints` (case-insensitive, normalized to lowercase; empty =
+reset to default) — anything else is rejected with `22023` on every set path
+(simple/batched SET, extended Parse, and the `-c` startup option, which rejects
+the connection like invalid `duckgres.worker_*` options), and
+`server.ConnectionBilling` clamps a non-canonical value to `standard` as
+defense in depth so client junk can never become a billing bucket key.
+Invariants for anyone
 touching this path:
 
 - **Metering is strictly best-effort and off the hot path.** A metering error

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -43,7 +43,17 @@ Internally, one row per unique key, values accumulated:
   org's default team. `query_source` (`standard` | `endpoints`) is set by a session
   GUC (`duckgres.query_source`), defaulting to `standard` when unset; the meter
   reads it per connection. (If it's changed mid-connection the per-connection meter
-  uses a single value — same future refinement as team.)
+  uses a single value — same future refinement as team.) The GUC is **validated at
+  SET time** against the closed `{standard, endpoints}` set — case-insensitive,
+  normalized to lowercase; empty resets to the default; any other value is
+  rejected with SQLSTATE `22023` (`invalid value for "duckgres.query_source":
+  must be "standard" or "endpoints"`) on every set path (simple SET, batched,
+  extended-protocol Parse). An invalid `-c duckgres.query_source=…` startup
+  option rejects the connection (FATAL `22023`), matching the
+  `duckgres.worker_*` startup options. As defense in depth,
+  `server.ConnectionBilling` clamps a non-canonical value to `standard` at the
+  metering boundary, so client input can never put unbounded-cardinality junk
+  in the bucket key or the billing export.
 - Worker size (`cpu`, `mem_gib`) is part of the key, so different worker sizes
   accumulate — and bill — separately. Units match the values (vCPU / GiB).
 
@@ -167,7 +177,8 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   at org creation on both the provisioning and admin APIs, and not clearable
   via the admin API; used as the bucket `team_id` — fixed per org, no per-team
   logic yet); a `duckgres.query_source` session GUC
-  (`standard` | `endpoints`, default `standard`) read by the meter; a bearer secret
+  (`standard` | `endpoints`, default `standard`, validated at SET time — anything
+  else is a `22023` error) read by the meter; a bearer secret
   for the API.
 
 ## Storage metric

--- a/server/conn.go
+++ b/server/conn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/posthog/duckgres/server/usersecrets"
 	"github.com/posthog/duckgres/server/wire"
 	"github.com/posthog/duckgres/transpiler"
+	"github.com/posthog/duckgres/transpiler/transform"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -196,7 +197,9 @@ type clientConn struct {
 	// This is a prerequisite for pull-based compute billing (usage buckets are
 	// keyed by query_source). Set via `SET duckgres.query_source = '...'` (or a
 	// `-c duckgres.query_source=...` startup option) and read back via
-	// `SHOW duckgres.query_source` / current_setting.
+	// `SHOW duckgres.query_source` / current_setting. Every set path validates
+	// against the closed {standard, endpoints} set (22023 on anything else), so
+	// this only ever holds "", "standard", or "endpoints".
 	querySource string
 
 	// Provisioned worker pod size for compute-usage billing (remote/k8s backend
@@ -265,11 +268,29 @@ func (c *clientConn) QuerySource() string {
 }
 
 // setQuerySource records a client-supplied `duckgres.query_source` value on the
-// session. Pass-through: any string is accepted (only "standard"/"endpoints" are
-// meaningful downstream, but other values are stored, not rejected). An empty
-// value resets to the default.
+// session. Callers must pass an already-validated canonical value ("standard",
+// "endpoints", or "" = reset to default): the transpiler validates SET
+// statements (transform.NormalizeQuerySource, rejecting anything else with
+// 22023 before this is reached) and applyStartupQuerySource validates the
+// startup option. The setter itself stays dumb; ConnectionBilling additionally
+// clamps at the metering boundary as defense in depth.
 func (c *clientConn) setQuerySource(value string) {
 	c.querySource = value
+}
+
+// applyStartupQuerySource validates and applies a `-c duckgres.query_source=…`
+// startup-option value. The GUC is a billing dimension, so the value must be
+// in the closed {standard, endpoints} set (case-insensitive, normalized to
+// lowercase; empty = default). An invalid value returns the 22023 error for
+// the caller to reject the connection with, mirroring how the control plane
+// rejects invalid duckgres.worker_* startup options.
+func (c *clientConn) applyStartupQuerySource(raw string) error {
+	norm, err := transform.NormalizeQuerySource(raw)
+	if err != nil {
+		return err
+	}
+	c.setQuerySource(norm)
+	return nil
 }
 
 // generateSecretKey is a thin alias for wire.GenerateSecretKey kept for the
@@ -1017,9 +1038,16 @@ func (c *clientConn) handleStartup() error {
 
 		// Honor a `-c duckgres.query_source=...` startup option (libpq `options`
 		// keyword / PGOPTIONS). Other GUCs in `options` are not applied here.
+		// An invalid value rejects the connection with FATAL 22023 — the same
+		// treatment resolveWorkerProfile gives an invalid duckgres.worker_*
+		// startup option, and what PostgreSQL itself does with an invalid
+		// `options` GUC value.
 		if opts := ParseStartupOptions(params["options"]); len(opts) > 0 {
 			if v, ok := opts[querySourceGUCName]; ok {
-				c.setQuerySource(v)
+				if err := c.applyStartupQuerySource(v); err != nil {
+					c.sendError("FATAL", "22023", err.Error())
+					return fmt.Errorf("invalid %s startup option", querySourceGUCName)
+				}
 			}
 		}
 

--- a/server/exports.go
+++ b/server/exports.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/posthog/duckgres/server/wire"
+	"github.com/posthog/duckgres/transpiler/transform"
 )
 
 // Exported wrappers for protocol functions used by the control plane worker.
@@ -213,11 +214,25 @@ func SetConnectionWorkerSize(cc *clientConn, millicores, mib int64) {
 // size). Call at the same teardown point as CloseConnectionMetrics. A
 // mid-connection GUC change is not split: the whole connection is metered
 // under the final value (documented in docs/design/billing-pull-api.md).
+//
+// The query source is clamped to the closed {standard, endpoints} set as
+// defense in depth: every set path already validates (22023 at SET / startup
+// time), so a non-canonical value here means a validation bypass — degrade it
+// to the default rather than writing unbounded-cardinality client input into
+// the billing bucket key (and onward into billing exports).
 func ConnectionBilling(cc *clientConn) (orgID, querySource string, millicores, mib int64, dur time.Duration) {
 	if cc == nil {
 		return "", "", 0, 0, 0
 	}
-	return cc.orgID, cc.QuerySource(), cc.workerMillicores, cc.workerMiB, time.Since(cc.backendStart)
+	qs := cc.QuerySource()
+	if qs != transform.QuerySourceStandard && qs != transform.QuerySourceEndpoints {
+		// Should be unreachable. Log the length, not the value — it is
+		// arbitrary client input.
+		cc.logger().Warn("Non-canonical duckgres.query_source at billing teardown; degrading to default.",
+			"value_len", len(qs))
+		qs = defaultQuerySource
+	}
+	return cc.orgID, qs, cc.workerMillicores, cc.workerMiB, time.Since(cc.backendStart)
 }
 
 // CancelClientConn cancels the context of a clientConn.

--- a/server/query_source_test.go
+++ b/server/query_source_test.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
+	"time"
 )
 
-// TestQuerySourceGetter covers the session accessor a future compute meter
-// reads: unset defaults to "standard", a SET value round-trips, and reset to
-// empty falls back to the default.
+// TestQuerySourceGetter covers the session accessor the compute meter reads:
+// unset defaults to "standard", a SET value round-trips, and reset to empty
+// falls back to the default. Callers of setQuerySource pass already-validated
+// canonical values (the transpiler / startup-option validation reject anything
+// outside {standard, endpoints} with 22023 before the setter is reached).
 func TestQuerySourceGetter(t *testing.T) {
 	c := &clientConn{}
 
@@ -23,15 +27,10 @@ func TestQuerySourceGetter(t *testing.T) {
 		t.Fatalf("unset QuerySource() = %q, want defaultQuerySource %q", got, defaultQuerySource)
 	}
 
-	// SET → value round-trips (pass-through: any string is accepted).
+	// SET → value round-trips.
 	c.setQuerySource("endpoints")
 	if got := c.QuerySource(); got != "endpoints" {
 		t.Fatalf("after set, QuerySource() = %q, want %q", got, "endpoints")
-	}
-
-	c.setQuerySource("whatever")
-	if got := c.QuerySource(); got != "whatever" {
-		t.Fatalf("after set, QuerySource() = %q, want %q", got, "whatever")
 	}
 
 	// RESET / empty → back to default.
@@ -42,12 +41,51 @@ func TestQuerySourceGetter(t *testing.T) {
 }
 
 // TestQuerySourceStartupOption asserts a `-c duckgres.query_source=...` startup
-// option is parsed into the map ParseStartupOptions returns (the value the
-// startup handler applies to the session).
+// option is parsed into the map ParseStartupOptions returns and applied to the
+// session by applyStartupQuerySource, with the same validation as SET:
+// canonical values (case-insensitively, normalized to lowercase) are applied,
+// anything else is a 22023 error the startup handler turns into a FATAL
+// connection rejection — matching resolveWorkerProfile's handling of invalid
+// duckgres.worker_* startup options.
 func TestQuerySourceStartupOption(t *testing.T) {
 	opts := ParseStartupOptions("-c duckgres.query_source=endpoints")
 	if got := opts[querySourceGUCName]; got != "endpoints" {
 		t.Fatalf("ParseStartupOptions[%q] = %q, want %q", querySourceGUCName, got, "endpoints")
+	}
+
+	valid := map[string]string{
+		"endpoints":  "endpoints",
+		"standard":   "standard",
+		"ENDPOINTS":  "endpoints", // case-insensitive, normalized to lowercase
+		" standard ": "standard",  // surrounding whitespace ignored
+		"":           "standard",  // empty = default
+	}
+	for raw, want := range valid {
+		c := &clientConn{}
+		if err := c.applyStartupQuerySource(raw); err != nil {
+			t.Fatalf("applyStartupQuerySource(%q) error: %v", raw, err)
+		}
+		if got := c.QuerySource(); got != want {
+			t.Fatalf("after startup option %q, QuerySource() = %q, want %q", raw, got, want)
+		}
+	}
+
+	for _, raw := range []string{"garbage", "endpointss", strings.Repeat("x", 10*1024), "café\n\ttab"} {
+		c := &clientConn{}
+		err := c.applyStartupQuerySource(raw)
+		if err == nil {
+			t.Fatalf("applyStartupQuerySource(%.40q) = nil error, want 22023 rejection", raw)
+		}
+		var coded interface{ SQLState() string }
+		if !errors.As(err, &coded) || coded.SQLState() != "22023" {
+			t.Fatalf("applyStartupQuerySource(%.40q) error = %v, want SQLSTATE 22023", raw, err)
+		}
+		if !strings.Contains(err.Error(), `"standard"`) || !strings.Contains(err.Error(), `"endpoints"`) {
+			t.Fatalf("rejection must name the valid values, got %q", err.Error())
+		}
+		if got := c.QuerySource(); got != "standard" {
+			t.Fatalf("after rejected startup option, QuerySource() = %q, want default %q", got, "standard")
+		}
 	}
 }
 
@@ -212,6 +250,180 @@ func TestQuerySourceMixedBatchWithNormalStatement(t *testing.T) {
 	}
 	if !sawSelectComplete {
 		t.Fatalf("SELECT 1 after the GUC did not complete; msgs=%s", describeMsgs(msgs))
+	}
+}
+
+// errorResponseWith reports whether msgs contain an ErrorResponse ('E') whose
+// body carries all the given substrings (e.g. the SQLSTATE and message parts).
+func errorResponseWith(msgs []wireMsg, wants ...string) bool {
+	for _, m := range msgs {
+		if m.typ != 'E' {
+			continue
+		}
+		ok := true
+		for _, w := range wants {
+			if !bytes.Contains(m.body, []byte(w)) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestQuerySourceInvalidSimpleSetRejected asserts the simple-protocol SET path
+// rejects a value outside {standard, endpoints} with SQLSTATE 22023, names the
+// valid values, leaves the session value untouched, and a subsequent SHOW
+// still reports the default. The value is the billing bucket key
+// (duckgres_org_compute_usage.query_source), so junk here would flow into the
+// billing table and its exports with unbounded cardinality.
+func TestQuerySourceInvalidSimpleSetRejected(t *testing.T) {
+	c, out := newBufferedConn(&selectOneExecutor{})
+
+	if err := c.handleQuery([]byte("SET duckgres.query_source = 'garbage'\x00")); err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "22023", `"standard"`, `"endpoints"`) {
+		t.Fatalf("no 22023 ErrorResponse naming the valid values; msgs=%s", describeMsgs(msgs))
+	}
+	if errorResponseWith(msgs, "garbage") {
+		t.Fatalf("rejection echoes the offending value; msgs=%s", describeMsgs(msgs))
+	}
+	for _, m := range msgs {
+		if m.typ == 'C' && bytes.Contains(m.body, []byte("SET")) {
+			t.Fatalf("rejected SET still produced CommandComplete(SET); msgs=%s", describeMsgs(msgs))
+		}
+	}
+	if got := c.QuerySource(); got != "standard" {
+		t.Fatalf("after rejected SET, QuerySource() = %q, want default %q", got, "standard")
+	}
+
+	// SHOW after the failed SET still reports the default.
+	out.Reset()
+	if err := c.handleQuery([]byte("SHOW duckgres.query_source\x00")); err != nil {
+		t.Fatalf("handleQuery(SHOW): %v", err)
+	}
+	msgs = parseWireMsgs(t, out.Bytes())
+	found := false
+	for _, m := range msgs {
+		if m.typ == 'D' && bytes.Contains(m.body, []byte("standard")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("SHOW after rejected SET did not report 'standard'; msgs=%s", describeMsgs(msgs))
+	}
+}
+
+// TestQuerySourceInvalidSetKeepsPreviousValue asserts a rejected SET (here via
+// the split multi-statement batch path) does not clobber a previously-set
+// valid value.
+func TestQuerySourceInvalidSetKeepsPreviousValue(t *testing.T) {
+	c, out := newBufferedConn(&selectOneExecutor{})
+
+	if err := c.handleQuery([]byte("SET duckgres.query_source = 'endpoints'\x00")); err != nil {
+		t.Fatalf("handleQuery(valid SET): %v", err)
+	}
+	if got := c.QuerySource(); got != "endpoints" {
+		t.Fatalf("QuerySource() = %q, want %q", got, "endpoints")
+	}
+
+	// Multi-statement batch: the connection layer splits it and re-transpiles
+	// each statement, so the invalid SET is rejected on the per-statement path.
+	out.Reset()
+	if err := c.handleQuery([]byte("SELECT 1; SET duckgres.query_source = 'garbage'\x00")); err != nil {
+		t.Fatalf("handleQuery(batch): %v", err)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "22023", `"standard"`, `"endpoints"`) {
+		t.Fatalf("batched invalid SET not rejected with 22023; msgs=%s", describeMsgs(msgs))
+	}
+	if got := c.QuerySource(); got != "endpoints" {
+		t.Fatalf("rejected SET clobbered the session value: QuerySource() = %q, want %q", got, "endpoints")
+	}
+}
+
+// TestQuerySourceCaseAndEmptySet asserts value normalization on the SET path:
+// a mixed-case value is accepted and stored lowercase, and an empty string
+// resets to the default (SHOW reports "standard" again).
+func TestQuerySourceCaseAndEmptySet(t *testing.T) {
+	c, _ := newBufferedConn(&selectOneExecutor{})
+
+	if err := c.handleQuery([]byte("SET duckgres.query_source = 'ENDPOINTS'\x00")); err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+	if got := c.QuerySource(); got != "endpoints" {
+		t.Fatalf("mixed-case SET: QuerySource() = %q, want normalized %q", got, "endpoints")
+	}
+
+	if err := c.handleQuery([]byte("SET duckgres.query_source = ''\x00")); err != nil {
+		t.Fatalf("handleQuery(empty): %v", err)
+	}
+	if got := c.QuerySource(); got != "standard" {
+		t.Fatalf("empty SET must reset to default: QuerySource() = %q, want %q", got, "standard")
+	}
+}
+
+// TestQuerySourceExtendedParseInvalidRejected asserts the extended-protocol
+// path rejects an invalid value at Parse time (before anything is stored on
+// the session or the statement map).
+func TestQuerySourceExtendedParseInvalidRejected(t *testing.T) {
+	c, out := newBufferedConn(&selectOneExecutor{})
+	c.stmts = make(map[string]*preparedStmt)
+
+	// Parse message body: statement name, query (both NUL-terminated), then
+	// int16 parameter-type count.
+	body := append([]byte("s1\x00SET duckgres.query_source = 'garbage'\x00"), 0, 0)
+	c.handleParse(body)
+	_ = c.flushWriter()
+
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "22023", `"standard"`, `"endpoints"`) {
+		t.Fatalf("extended Parse of invalid SET not rejected with 22023; msgs=%s", describeMsgs(msgs))
+	}
+	if _, ok := c.stmts["s1"]; ok {
+		t.Fatalf("rejected Parse still stored the prepared statement")
+	}
+	if got := c.QuerySource(); got != "standard" {
+		t.Fatalf("after rejected Parse, QuerySource() = %q, want default %q", got, "standard")
+	}
+
+	// A valid value still parses and applies at Execute time (portal run).
+	out.Reset()
+	body = append([]byte("s2\x00SET duckgres.query_source = 'endpoints'\x00"), 0, 0)
+	c.handleParse(body)
+	_ = c.flushWriter()
+	st, ok := c.stmts["s2"]
+	if !ok {
+		t.Fatalf("valid SET did not parse: msgs=%s", describeMsgs(parseWireMsgs(t, out.Bytes())))
+	}
+	if st.querySourceSet == nil || *st.querySourceSet != "endpoints" {
+		t.Fatalf("prepared stmt querySourceSet = %v, want endpoints", st.querySourceSet)
+	}
+}
+
+// TestConnectionBillingClampsQuerySource is the defense-in-depth assert: if a
+// non-canonical value ever reaches teardown despite SET/startup validation
+// (i.e. a future bypass), ConnectionBilling degrades it to "standard" instead
+// of writing arbitrary client input into the billing bucket key.
+func TestConnectionBillingClampsQuerySource(t *testing.T) {
+	cases := map[string]string{
+		"":          "standard",
+		"standard":  "standard",
+		"endpoints": "endpoints",
+		"garbage":   "standard", // bypassed junk degrades to the default
+		"ENDPOINTS": "standard", // non-canonical case counts as junk here too
+	}
+	for stored, want := range cases {
+		cc := &clientConn{querySource: stored, backendStart: time.Now(), workerMillicores: 1000, workerMiB: 1024}
+		_, qs, _, _, _ := ConnectionBilling(cc)
+		if qs != want {
+			t.Fatalf("ConnectionBilling with stored %q: querySource = %q, want %q", stored, qs, want)
+		}
 	}
 }
 

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -463,14 +463,20 @@ pg_compat_functions() { # org password
 # unknown settings). Assertions, each in a single simple-query session:
 #   1. unset SHOW → default "standard" (never errors on a missing value)
 #   2. SET then SHOW in the same session → the value round-trips
-#   3. an arbitrary (non-standard/endpoints) value is accepted pass-through,
-#      not rejected — only "standard"/"endpoints" are meaningful downstream.
-#   4. a batch mixing the GUC SET with a normal statement runs the normal
+#   3. the value is a billing dimension (bucket key in
+#      duckgres_org_compute_usage + the billing pull API), so it is a closed
+#      enum: a non-{standard,endpoints} value MUST be rejected at SET time
+#      (22023 invalid_parameter_value) with an error naming the valid values,
+#      and a subsequent SHOW still reports the default — client junk must
+#      never reach the billing key (unbounded cardinality + junk in exports).
+#   4. matching is case-insensitive, normalized to lowercase (SHOW reports the
+#      canonical form).
+#   5. a batch mixing the GUC SET with a normal statement runs the normal
 #      statement too — the intercepted GUC must NOT swallow the rest of the
 #      batch (regression for the multi-statement-swallow bug).
-# Assertions 2-4 are multi-statement simple queries: the CP splits the batch and
-# runs each statement in order, so the SET applies session-side before the
-# trailing SHOW/SELECT. If any statement forwarded to DuckDB, the query would
+# The batched assertions are multi-statement simple queries: the CP splits the
+# batch and runs each statement in order, so the SET applies session-side before
+# the trailing SHOW/SELECT. If any statement forwarded to DuckDB, the query would
 # error ("unrecognized configuration parameter"), failing the assert; if the GUC
 # swallowed the batch, the trailing statement's value would be missing.
 query_source_guc() { # org password
@@ -479,7 +485,19 @@ query_source_guc() { # org password
   # psql's `SET` command tag on its own line first, so assert only the last line.
   assert_compat  "$1" "$2" ducklake "SHOW duckgres.query_source" "standard" "query_source_default"
   assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'endpoints'; SHOW duckgres.query_source" "endpoints" "query_source_set"
-  assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'anything'; SHOW duckgres.query_source" "anything" "query_source_passthrough"
+  # Invalid value → rejected at SET time with an error naming the valid values.
+  # The trailing SHOW never runs (ON_ERROR_STOP), and the session value is
+  # untouched: a fresh session's SHOW below still reports the default.
+  if out="$(pg_try "$1" "$2" ducklake "SET duckgres.query_source = 'garbage'; SHOW duckgres.query_source")"; then
+    fail "query_source: invalid value 'garbage' was accepted (junk would reach the billing bucket key): $out"
+  fi
+  case "$out" in
+    *'must be "standard" or "endpoints"'*) ;;
+    *) fail "query_source: invalid-value rejection did not name the valid values: '$out'" ;;
+  esac
+  assert_compat "$1" "$2" ducklake "SHOW duckgres.query_source" "standard" "query_source_after_rejected_set"
+  # Case-insensitive, normalized to lowercase.
+  assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'ENDPOINTS'; SHOW duckgres.query_source" "endpoints" "query_source_case_insensitive"
   assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'endpoints'; SELECT 1" "1" "query_source_set_then_query"
 }
 

--- a/transpiler/config.go
+++ b/transpiler/config.go
@@ -94,6 +94,9 @@ type Result struct {
 	// '<value>'` on the duckgres-namespaced custom GUC. The connection layer
 	// stores the pointed-to value on the session and acknowledges it as "SET"
 	// (it is NOT forwarded to DuckDB, which would reject the unknown setting).
+	// The value is pre-validated and canonical: "standard", "endpoints", or ""
+	// (reset to default) — an invalid value never reaches here (it surfaces as
+	// Error with SQLSTATE 22023 instead).
 	QuerySourceSet *string
 
 	// QuerySourceShow indicates a `SHOW duckgres.query_source`; the connection

--- a/transpiler/query_source_test.go
+++ b/transpiler/query_source_test.go
@@ -1,6 +1,10 @@
 package transpiler
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 // TestTranspile_QuerySourceSet asserts that `SET duckgres.query_source = '...'`
 // is intercepted as a duckgres-namespaced custom GUC (QuerySourceSet populated,
@@ -15,7 +19,11 @@ func TestTranspile_QuerySourceSet(t *testing.T) {
 		{"set standard", "SET duckgres.query_source = 'standard'", "standard"},
 		{"set local", "SET LOCAL duckgres.query_source = 'endpoints'", "endpoints"},
 		{"case-insensitive name", "SET DUCKGRES.QUERY_SOURCE = 'endpoints'", "endpoints"},
-		{"arbitrary passthrough value", "SET duckgres.query_source = 'whatever'", "whatever"},
+		{"case-insensitive value normalized", "SET duckgres.query_source = 'ENDPOINTS'", "endpoints"},
+		{"whitespace trimmed", "SET duckgres.query_source = '  standard '", "standard"},
+		{"unquoted identifier value", "SET duckgres.query_source = endpoints", "endpoints"},
+		{"empty string resets to default", "SET duckgres.query_source = ''", ""},
+		{"set to default clears to empty", "SET duckgres.query_source TO DEFAULT", ""},
 		{"reset clears to empty", "RESET duckgres.query_source", ""},
 	}
 
@@ -36,6 +44,58 @@ func TestTranspile_QuerySourceSet(t *testing.T) {
 			// Custom GUC must never be forwarded to DuckDB.
 			if result.QuerySourceShow {
 				t.Errorf("Transpile(%q): QuerySourceShow = true, want false", tt.input)
+			}
+		})
+	}
+}
+
+// TestTranspile_QuerySourceSetInvalidRejected asserts that a SET with a value
+// outside the closed {standard, endpoints} set surfaces Result.Error with
+// SQLSTATE 22023 (invalid_parameter_value) and does NOT populate
+// QuerySourceSet. The value is the billing-bucket key, so accepting arbitrary
+// strings would hand clients unbounded cardinality (and junk) in the billing
+// table and its exports. The error message must name the valid values but must
+// NOT echo the offending value (arbitrary client input flowing into logs / the
+// recent-errors ring).
+func TestTranspile_QuerySourceSetInvalidRejected(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	longJunk := strings.Repeat("x", 10*1024)
+	inputs := map[string]string{
+		"garbage":                 "SET duckgres.query_source = 'garbage'",
+		"10KB string":             "SET duckgres.query_source = '" + longJunk + "'",
+		"unicode + control chars": "SET duckgres.query_source = e'caf\\u00e9\\n\\ttab'",
+		"integer constant":        "SET duckgres.query_source = 123",
+		"boolean constant":        "SET duckgres.query_source = true",
+		"multiple values":         "SET duckgres.query_source = 'standard', 'endpoints'",
+		"set local garbage":       "SET LOCAL duckgres.query_source = 'garbage'",
+	}
+	for name, in := range inputs {
+		t.Run(name, func(t *testing.T) {
+			result, err := tr.Transpile(in)
+			if err != nil {
+				t.Fatalf("Transpile(%.80q) error: %v", in, err)
+			}
+			if result.Error == nil {
+				got := "<nil>"
+				if result.QuerySourceSet != nil {
+					got = *result.QuerySourceSet
+				}
+				t.Fatalf("Transpile(%.80q): Error = nil, want 22023 rejection (QuerySourceSet=%.80q)", in, got)
+			}
+			var coded interface{ SQLState() string }
+			if !errors.As(result.Error, &coded) || coded.SQLState() != "22023" {
+				t.Errorf("Transpile(%.80q): Error SQLSTATE = %v, want 22023", in, result.Error)
+			}
+			msg := result.Error.Error()
+			if !strings.Contains(msg, `"standard"`) || !strings.Contains(msg, `"endpoints"`) {
+				t.Errorf("error message must name the valid values, got %q", msg)
+			}
+			if strings.Contains(msg, "garbage") || strings.Contains(msg, longJunk[:64]) {
+				t.Errorf("error message must not echo the offending value, got %.120q", msg)
+			}
+			if result.QuerySourceSet != nil {
+				t.Errorf("Transpile(%.80q): QuerySourceSet = %q, want nil on rejection", in, *result.QuerySourceSet)
 			}
 		})
 	}

--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -18,6 +18,45 @@ var configParamPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 // (DuckDB rejects unknown settings). See clientConn.QuerySource in server/.
 const querySourceParam = "duckgres.query_source"
 
+// Valid values for the duckgres.query_source GUC. The value is a billing
+// dimension — it lands verbatim in the compute-usage bucket key
+// (duckgres_org_compute_usage.query_source) and in the billing pull API — so
+// it is a closed enum: accepting arbitrary strings would hand clients
+// unbounded cardinality (and arbitrary junk) in the billing table and its
+// exports.
+const (
+	QuerySourceStandard  = "standard"
+	QuerySourceEndpoints = "endpoints"
+)
+
+// NormalizeQuerySource validates a client-supplied duckgres.query_source value
+// against the closed set above. Matching is case-insensitive (and ignores
+// surrounding whitespace); the returned value is canonical lowercase. Empty is
+// valid and means "reset to default" (the session then reports "standard").
+// An invalid value returns a 22023 (invalid_parameter_value) CodedError. The
+// message deliberately does NOT echo the offending value: it is arbitrary
+// client input (possibly huge) and error messages flow into logs, the query
+// log, and the admin recent-errors ring.
+func NormalizeQuerySource(raw string) (string, error) {
+	switch v := strings.ToLower(strings.TrimSpace(raw)); v {
+	case "", QuerySourceStandard, QuerySourceEndpoints:
+		return v, nil
+	default:
+		return "", errInvalidQuerySource()
+	}
+}
+
+// errInvalidQuerySource is the SET-time rejection for a bad
+// duckgres.query_source value: 22023 invalid_parameter_value, matching how the
+// control plane rejects invalid duckgres.worker_* startup options.
+func errInvalidQuerySource() *CodedError {
+	return &CodedError{
+		Code: "22023", // invalid_parameter_value
+		Message: fmt.Sprintf("invalid value for %q: must be %q or %q",
+			querySourceParam, QuerySourceStandard, QuerySourceEndpoints),
+	}
+}
+
 // duckdbShowCommands are DuckDB-specific SHOW commands that should be passed
 // through to DuckDB rather than treated as PostgreSQL config parameters.
 var duckdbShowCommands = map[string]bool{
@@ -251,19 +290,38 @@ func (t *SetShowTransform) Transform(tree *pg_query.ParseResult, result *Result)
 				// duckgres.query_source: a duckgres-namespaced custom GUC. Intercept
 				// and hand the value to the connection layer to store on the session;
 				// do NOT forward to DuckDB (it would reject the unknown setting).
-				// RESET restores the default (empty value). SET LOCAL is treated the
-				// same as SET here (there is no transaction-scoped restore for this
-				// billing GUC).
+				// RESET / SET ... TO DEFAULT restore the default (empty value).
+				// SET LOCAL is treated the same as SET here (there is no
+				// transaction-scoped restore for this billing GUC). The value is a
+				// billing dimension, so it is validated against the closed
+				// {standard, endpoints} set (case-insensitively, normalized to
+				// lowercase); anything else — including a value that is not a
+				// single simple constant/identifier — is rejected with 22023 via
+				// result.Error, which every protocol path (simple, split-batch,
+				// extended Parse) surfaces before storing anything on the session.
 				if paramName == querySourceParam && !multiStatement {
 					value := ""
 					if n.VariableSetStmt.Kind == pg_query.VariableSetKind_VAR_SET_VALUE {
+						extracted := false
 						if len(n.VariableSetStmt.Args) == 1 {
 							if v, ok := searchPathValue(n.VariableSetStmt.Args[0]); ok {
-								value = v
+								value, extracted = v, true
 							}
 						}
+						if !extracted {
+							// Multiple values / a non-string constant can never
+							// name a valid query source; reject rather than
+							// silently resetting to the default.
+							result.Error = errInvalidQuerySource()
+							return true, nil
+						}
 					}
-					result.QuerySourceSet = &value
+					norm, err := NormalizeQuerySource(value)
+					if err != nil {
+						result.Error = err
+						return true, nil
+					}
+					result.QuerySourceSet = &norm
 					return true, nil
 				}
 

--- a/transpiler/transform/transform.go
+++ b/transpiler/transform/transform.go
@@ -27,7 +27,9 @@ type Result struct {
 	// `SET duckgres.query_source = '<value>'` (a duckgres-namespaced custom GUC
 	// that must NOT be forwarded to DuckDB). The pointed-to string is the value
 	// to store on the session; the connection layer intercepts and acknowledges
-	// it as "SET" without executing anything against DuckDB.
+	// it as "SET" without executing anything against DuckDB. The value has been
+	// validated + normalized by NormalizeQuerySource ("standard", "endpoints",
+	// or "" = reset); an invalid value sets Error (22023) instead.
 	QuerySourceSet *string
 
 	// QuerySourceShow indicates the statement is `SHOW duckgres.query_source`.


### PR DESCRIPTION
## Why

`duckgres.query_source` is a billing dimension: the session value flows verbatim into the compute-usage bucket key (`duckgres_org_compute_usage.query_source`) and onward into the billing pull API (`GET /api/v1/billing/usage` groups by it). It was completely unvalidated on **every** set path — simple `SET`, split multi-statement batches, extended-protocol Parse, and the `-c duckgres.query_source=…` startup option — so any client could persist arbitrary strings (`'garbage'`, 10KB blobs, unicode/control characters) into the billing table:

- **unbounded key cardinality** — every distinct junk value is a new bucket row per minute, and a new output row per UTC day in the billing export;
- **arbitrary client input in billing data** — junk flows into the billing consumer and anything downstream of the export;
- the e2e harness even asserted the pass-through (`query_source_passthrough` accepted `'anything'`).

## What

- **Single validation point for all SQL paths**: the transpiler interception (`transpiler/transform/setshow.go`) now validates via the new `transform.NormalizeQuerySource`. Values outside the closed `{standard, endpoints}` set are rejected with SQLSTATE `22023` (`invalid value for "duckgres.query_source": must be "standard" or "endpoints"`) through the existing `Result.Error` machinery, which all three paths (simple, split-batch, extended Parse) surface **before** anything is stored on the session. A `SET` whose value isn't a single simple constant/identifier (e.g. `= 123`, multiple values) is rejected too, instead of silently resetting to the default.
- **Case-insensitive, normalized to lowercase** (`'ENDPOINTS'` → `endpoints`); surrounding whitespace ignored; **empty string / `RESET` / `TO DEFAULT` keep the existing reset-to-`standard` semantics**. `SHOW` always reports the canonical value.
- **Startup option** (`server/conn.go::applyStartupQuerySource`): an invalid `-c duckgres.query_source=…` rejects the connection with `FATAL 22023` — the same treatment `resolveWorkerProfile` gives invalid `duckgres.worker_*` startup options, and what PostgreSQL itself does for an invalid `options` GUC.
- **Defense in depth at the metering boundary**: `server.ConnectionBilling` clamps a non-canonical value to `standard` (warn log with value *length* only), so a future validation bypass still can't write junk into the bucket key.
- The rejection message deliberately does **not** echo the offending value — it's arbitrary client input and error text lands in logs, the query log, and the admin recent-errors ring.
- Docs updated: `docs/design/billing-pull-api.md`, `CLAUDE.md`.

## Tests

- `transpiler/query_source_test.go`: invalid values (garbage, 10KB string, unicode/control chars, int/bool constants, multiple values, `SET LOCAL`) → `Result.Error` with SQLSTATE 22023 naming the valid values and not echoing the input; valid values incl. mixed case / whitespace / unquoted identifier / empty / `TO DEFAULT` / `RESET` normalize correctly.
- `server/query_source_test.go`: wire-level rejection on the simple path (ErrorResponse `22023`, no `CommandComplete(SET)`, session value unchanged, subsequent `SHOW` still `standard`), split-batch rejection keeps a previously-set valid value, case/empty normalization, extended-protocol Parse rejection (statement not stored), startup-option validation, and the `ConnectionBilling` clamp.
- e2e (`tests/mw-dev/e2e/harness.sh` `query_source_guc`): replaced the pass-through assertion with `SET … = 'garbage'` must **fail** naming the valid values, `SHOW` afterwards still reports `standard`, plus a case-insensitivity assertion. `bash -n` passes.
- `go build ./…`, `go build -tags kubernetes ./…`, `go vet ./…`, `go test ./server/... ./transpiler/... ./controlplane/...` all green.
- Verified live against a running standalone server with psql: default SHOW, valid/invalid SET (verbose SQLSTATE `22023`), batch abort keeps prior value, mixed-case normalization, empty reset, 10KB junk rejected, valid/mixed-case/invalid startup options (invalid → `FATAL` connection rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)