### PR TITLE
Re-attribute unacked billing buckets when default_team_id changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,15 @@ touching this path:
 - **Graceful shutdown does a final flush** after connections drain to their
   natural end (`shutdown`/`drainAndShutdown`), so a departing CP pod lands its
   last interval before exit.
+- **Changing an org's `default_team_id` re-attributes its unacked buckets** to
+  the new team in the SAME transaction as the org update, on BOTH paths (admin
+  `PUT /orgs/:id` and provisioning re-provision) via
+  `configstore.ReattributeUsageTeamTx` — additive fold on PK collisions; a
+  small in-flight residual under the old team is tolerated (snapshot poll
+  lag, ~30s). Tests: `tests/configstore/reattribute_usage_postgres_test.go`,
+  `controlplane/admin/api_test.go` + `api_postgres_test.go`
+  (`TestUpdateOrg*Reattribut*`), and the re-attribution leg of
+  `compute_usage_pull_api` in the e2e harness.
 - **Storage metric** (`managed_warehouse_storage_gib_seconds`,
   `storage_meter.go`): a LEADER-ONLY sampler (double writers would
   double-bill — the UPSERT is additive) visits each Ready warehouse's DuckLake

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -127,7 +128,12 @@ type apiStore interface {
 	ListOrgs() ([]configstore.Org, error)
 	CreateOrg(org *configstore.Org) error
 	GetOrg(name string) (*configstore.Org, error)
-	UpdateOrg(name string, updates configstore.Org) (*configstore.Org, bool, error)
+	// UpdateOrg persists the merged org row. reattributeUsageTeam is non-nil
+	// when the update changes default_team_id: the store must then re-attribute
+	// the org's buffered (unacked) billing buckets to that new team id in the
+	// SAME transaction as the org-row update, so a committed team change never
+	// leaves usage stranded under the old team.
+	UpdateOrg(name string, updates configstore.Org, reattributeUsageTeam *int64) (*configstore.Org, bool, error)
 	DeleteOrg(name string) (bool, error)
 
 	ListUsers() ([]configstore.OrgUser, error)
@@ -180,7 +186,7 @@ func (s *gormAPIStore) GetOrg(name string) (*configstore.Org, error) {
 	return &org, nil
 }
 
-func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configstore.Org, bool, error) {
+func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org, reattributeUsageTeam *int64) (*configstore.Org, bool, error) {
 	fields := map[string]interface{}{
 		"max_workers": updates.MaxWorkers,
 		"max_vcpus":   updates.MaxVCPUs,
@@ -208,11 +214,48 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 	if updates.DefaultTeamID != nil {
 		fields["default_team_id"] = *updates.DefaultTeamID
 	}
-	result := s.db().Model(&configstore.Org{}).Where("name = ?", name).Updates(fields)
-	if result.Error != nil {
-		return nil, false, result.Error
+	found := false
+	err := s.db().Transaction(func(tx *gorm.DB) error {
+		// Read the pre-update team id before writing, purely for the log line —
+		// the handler already decided reattribution is needed.
+		var oldTeams []int64
+		if reattributeUsageTeam != nil {
+			if err := tx.Model(&configstore.Org{}).Where("name = ?", name).
+				Pluck("default_team_id", &oldTeams).Error; err != nil {
+				return err
+			}
+		}
+		result := tx.Model(&configstore.Org{}).Where("name = ?", name).Updates(fields)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
+		found = true
+		if reattributeUsageTeam != nil {
+			// Same transaction as the org-row update: a committed team change
+			// always carries its buffered buckets along. In-flight metering under
+			// the old team can still land a small residual row right after this
+			// (config-snapshot poll lag, ~30s) — tolerated, see
+			// configstore.ReattributeUsageTeamTx.
+			moved, err := configstore.ReattributeUsageTeamTx(tx, name, *reattributeUsageTeam)
+			if err != nil {
+				return err
+			}
+			old := int64(0)
+			if len(oldTeams) > 0 {
+				old = oldTeams[0]
+			}
+			slog.Info("Re-attributed org usage buckets to new default team.",
+				"org", name, "old_team", old, "new_team", *reattributeUsageTeam, "rows", moved)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
 	}
-	if result.RowsAffected == 0 {
+	if !found {
 		return nil, false, nil
 	}
 	org, err := s.GetOrg(name)
@@ -626,6 +669,12 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
+	// Set when the PUT actually changes default_team_id: the store then
+	// re-attributes the org's buffered (unacked) billing buckets to the new
+	// team in the same transaction as the org update, so the next billing pull
+	// reports them under the new team (docs/design/billing-pull-api.md,
+	// "Changing an org's default team").
+	var reattributeUsageTeam *int64
 	if _, ok := fields["default_team_id"]; ok {
 		// Key present: a positive number sets. Clearing is rejected — the
 		// column is NOT NULL (the org's default team is the billing bucket
@@ -636,6 +685,9 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 			return
 		}
 		merged.DefaultTeamID = updates.DefaultTeamID
+		if existing.DefaultTeamID == nil || *existing.DefaultTeamID != *updates.DefaultTeamID {
+			reattributeUsageTeam = updates.DefaultTeamID
+		}
 	}
 
 	// Audit detail: which fields changed and their old → new values, so the
@@ -659,7 +711,7 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 		setAuditDetail(c, strings.Join(changes, ", "))
 	}
 
-	org, ok, err := h.store.UpdateOrg(name, merged)
+	org, ok, err := h.store.UpdateOrg(name, merged, reattributeUsageTeam)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -102,6 +102,13 @@ func resetConfigStoreTables(t *testing.T, db *gorm.DB) {
 			t.Fatalf("delete %T: %v", model, err)
 		}
 	}
+	// Billing usage buffers have no gorm model (raw goose-migrated tables) but
+	// leak across tests on the shared schema all the same.
+	for _, table := range []string{"duckgres_org_compute_usage", "duckgres_org_storage_usage"} {
+		if err := db.Exec("DELETE FROM " + table).Error; err != nil {
+			t.Fatalf("delete %s: %v", table, err)
+		}
+	}
 }
 
 func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
@@ -215,6 +222,85 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 	// The database_name is now free for reuse (no unique-index squat).
 	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
 		t.Fatalf("expected database_name to be reusable after org deletion: %v", err)
+	}
+}
+
+// TestUpdateOrgReattributesUsagePostgres drives the real gormAPIStore against
+// Postgres: an UpdateOrg carrying reattributeUsageTeam must move the org's
+// buffered billing buckets (both tables) to the new team in the same
+// transaction as the org-row update — folding a colliding target-key row
+// additively — while an UpdateOrg without it leaves the buckets alone.
+func TestUpdateOrgReattributesUsagePostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+
+	oldTeam := int64(1)
+	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acmedb", DefaultTeamID: &oldTeam}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	bucket := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	seed := func(teamID, cpuSeconds, byteSeconds int64) {
+		t.Helper()
+		if err := store.FlushComputeUsage([]configstore.ComputeUsageDelta{{
+			OrgID: "acme", TeamID: teamID, QuerySource: "standard",
+			Millicores: 2000, MiB: 4096, BucketStart: bucket,
+			CPUSeconds: cpuSeconds, MemorySeconds: cpuSeconds * 2,
+		}}); err != nil {
+			t.Fatalf("seed compute usage: %v", err)
+		}
+		if err := store.UpsertStorageSample("acme", teamID, bucket, byteSeconds); err != nil {
+			t.Fatalf("seed storage usage: %v", err)
+		}
+	}
+	seed(1, 10, 1000)
+	// Pre-existing rows under the target team at the same bucket — the
+	// collision the additive fold must absorb instead of violating the PK.
+	seed(2, 5, 500)
+
+	// An update WITHOUT reattribution must not touch the buckets.
+	merged := configstore.Org{MaxWorkers: 3, DefaultTeamID: &oldTeam}
+	if _, ok, err := apiStore.UpdateOrg("acme", merged, nil); err != nil || !ok {
+		t.Fatalf("UpdateOrg without reattribution: ok=%v err=%v", ok, err)
+	}
+	var teams []int64
+	if err := store.DB().Raw(`SELECT DISTINCT team_id FROM duckgres_org_compute_usage WHERE org_id = 'acme' ORDER BY team_id`).Scan(&teams).Error; err != nil {
+		t.Fatalf("read teams: %v", err)
+	}
+	if len(teams) != 2 {
+		t.Fatalf("buckets mutated by non-team update: teams=%v", teams)
+	}
+
+	// The team change moves everything onto team 2 and folds the collision.
+	newTeam := int64(2)
+	merged.DefaultTeamID = &newTeam
+	updated, ok, err := apiStore.UpdateOrg("acme", merged, &newTeam)
+	if err != nil || !ok {
+		t.Fatalf("UpdateOrg with reattribution: ok=%v err=%v", ok, err)
+	}
+	if updated.DefaultTeamID == nil || *updated.DefaultTeamID != 2 {
+		t.Fatalf("org default_team_id = %v, want 2", updated.DefaultTeamID)
+	}
+	var compute []struct {
+		TeamID        int64
+		CPUSeconds    int64
+		MemorySeconds int64
+	}
+	if err := store.DB().Raw(`SELECT team_id, cpu_seconds, memory_seconds FROM duckgres_org_compute_usage WHERE org_id = 'acme'`).Scan(&compute).Error; err != nil {
+		t.Fatalf("read compute rows: %v", err)
+	}
+	if len(compute) != 1 || compute[0].TeamID != 2 || compute[0].CPUSeconds != 15 || compute[0].MemorySeconds != 30 {
+		t.Fatalf("compute rows not folded onto team 2: %+v", compute)
+	}
+	var storage []struct {
+		TeamID      int64
+		ByteSeconds int64
+	}
+	if err := store.DB().Raw(`SELECT team_id, byte_seconds FROM duckgres_org_storage_usage WHERE org_id = 'acme'`).Scan(&storage).Error; err != nil {
+		t.Fatalf("read storage rows: %v", err)
+	}
+	if len(storage) != 1 || storage[0].TeamID != 2 || storage[0].ByteSeconds != 1500 {
+		t.Fatalf("storage rows not folded onto team 2: %+v", storage)
 	}
 }
 

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -22,6 +22,15 @@ type fakeAPIStore struct {
 	orgs       map[string]*configstore.Org
 	users      map[string]*configstore.OrgUser
 	warehouses map[string]*configstore.ManagedWarehouse
+	// reattributeCalls records every non-nil reattributeUsageTeam passed to
+	// UpdateOrg (org → new team ids, in order), so tests can assert the handler
+	// requests bucket re-attribution exactly when default_team_id changes.
+	reattributeCalls []fakeReattributeCall
+}
+
+type fakeReattributeCall struct {
+	org    string
+	teamID int64
 }
 
 func newFakeAPIStore() *fakeAPIStore {
@@ -58,10 +67,13 @@ func (s *fakeAPIStore) GetOrg(name string) (*configstore.Org, error) {
 	return copyOrg(org), nil
 }
 
-func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configstore.Org, bool, error) {
+func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org, reattributeUsageTeam *int64) (*configstore.Org, bool, error) {
 	org, ok := s.orgs[name]
 	if !ok {
 		return nil, false, nil
+	}
+	if reattributeUsageTeam != nil {
+		s.reattributeCalls = append(s.reattributeCalls, fakeReattributeCall{org: name, teamID: *reattributeUsageTeam})
 	}
 	org.MaxWorkers = updates.MaxWorkers
 	org.MaxVCPUs = updates.MaxVCPUs
@@ -1723,6 +1735,46 @@ func TestUpdateOrgSetsDefaultTeamID(t *testing.T) {
 	stored := store.orgs["acme"]
 	if stored.DefaultTeamID == nil || *stored.DefaultTeamID != 67890 {
 		t.Fatalf("DefaultTeamID = %v, want 67890", stored.DefaultTeamID)
+	}
+}
+
+// TestUpdateOrgDefaultTeamIDChangeReattributesUsage pins the billing contract:
+// a PUT that CHANGES default_team_id must ask the store to re-attribute the
+// org's buffered usage buckets to the new team (in the same transaction as the
+// org update), while a PUT carrying the SAME value — or not carrying the field
+// at all — must not.
+func TestUpdateOrgDefaultTeamIDChangeReattributesUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want []fakeReattributeCall
+	}{
+		{"changed value triggers reattribution", `{"default_team_id":67890}`, []fakeReattributeCall{{org: "acme", teamID: 67890}}},
+		{"same value does not", `{"default_team_id":12345}`, nil},
+		{"omitted field does not", `{"max_workers":8}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAPIStore()
+			teamID := int64(12345)
+			store.orgs["acme"] = &configstore.Org{
+				Name:          "acme",
+				DatabaseName:  "acme",
+				DefaultTeamID: &teamID,
+			}
+			router := newTestAPIRouter(store)
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if !slices.Equal(store.reattributeCalls, tc.want) {
+				t.Fatalf("reattribute calls = %+v, want %+v", store.reattributeCalls, tc.want)
+			}
+		})
 	}
 }
 

--- a/controlplane/configstore/reattribute_usage.go
+++ b/controlplane/configstore/reattribute_usage.go
@@ -1,0 +1,89 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// ReattributeUsageTeam moves every buffered (unacked) billing bucket for the
+// org — both metric families — onto newTeamID, so the next billing pull
+// reports them under the org's new default team instead of the stale one.
+// Runs in its own transaction; returns the number of buffer rows moved across
+// both tables. See ReattributeUsageTeamTx for the semantics.
+func (cs *ConfigStore) ReattributeUsageTeam(orgID string, newTeamID int64) (int64, error) {
+	var moved int64
+	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		moved, err = ReattributeUsageTeamTx(tx, orgID, newTeamID)
+		return err
+	})
+	return moved, err
+}
+
+// ReattributeUsageTeamTx re-attributes the org's buffered usage buckets
+// (duckgres_org_compute_usage + duckgres_org_storage_usage) to newTeamID
+// inside the caller's transaction, so the move commits atomically with the
+// org-row update that changes default_team_id.
+//
+// team_id is part of both tables' primary keys, so this is a fold-then-delete
+// per table, not a blind UPDATE: an additive upsert copies every row keyed
+// under a different team onto the newTeamID key (summing the value columns
+// when the target row already exists — e.g. a team changed A→B→A, or a
+// straggler bucket from the old era sharing a bucket_start), then the source
+// rows are deleted. The SELECT groups per target key so two distinct stale
+// teams landing on the same key fold cleanly instead of tripping ON
+// CONFLICT's affect-row-twice error.
+//
+// In-flight race (bounded, tolerated): connections and storage samples keep
+// stamping the OLD team id until the config snapshot poll (~30s) picks up the
+// new one, so a flush racing this transaction can land a small residual
+// old-team bucket just after the move (or, in the sliver between the fold and
+// the delete, lose one ≤15s flush increment — within the flusher's
+// best-effort log-and-drop contract). Billing tolerates the residual (it
+// shows up as one tiny old-team row on a later pull), and re-running the
+// update folds it in. Do NOT add locking around the metering hot path for
+// this.
+//
+// Returns the number of source rows moved across both tables.
+func ReattributeUsageTeamTx(tx *gorm.DB, orgID string, newTeamID int64) (int64, error) {
+	var moved int64
+	for _, t := range []struct {
+		insert string
+		table  string
+	}{
+		{
+			insert: `
+INSERT INTO duckgres_org_compute_usage (org_id, team_id, query_source, cpu, mem_gib, bucket_start, cpu_seconds, memory_seconds)
+SELECT org_id, ?, query_source, cpu, mem_gib, bucket_start, SUM(cpu_seconds), SUM(memory_seconds)
+FROM duckgres_org_compute_usage
+WHERE org_id = ? AND team_id <> ?
+GROUP BY org_id, query_source, cpu, mem_gib, bucket_start
+ON CONFLICT (org_id, team_id, query_source, cpu, mem_gib, bucket_start)
+DO UPDATE SET cpu_seconds    = duckgres_org_compute_usage.cpu_seconds    + EXCLUDED.cpu_seconds,
+              memory_seconds = duckgres_org_compute_usage.memory_seconds + EXCLUDED.memory_seconds`,
+			table: "duckgres_org_compute_usage",
+		},
+		{
+			insert: `
+INSERT INTO duckgres_org_storage_usage (org_id, team_id, bucket_start, byte_seconds)
+SELECT org_id, ?, bucket_start, SUM(byte_seconds)
+FROM duckgres_org_storage_usage
+WHERE org_id = ? AND team_id <> ?
+GROUP BY org_id, bucket_start
+ON CONFLICT (org_id, team_id, bucket_start)
+DO UPDATE SET byte_seconds = duckgres_org_storage_usage.byte_seconds + EXCLUDED.byte_seconds`,
+			table: "duckgres_org_storage_usage",
+		},
+	} {
+		if err := tx.Exec(t.insert, newTeamID, orgID, newTeamID).Error; err != nil {
+			return moved, fmt.Errorf("reattribute %s (org=%s team=%d): %w", t.table, orgID, newTeamID, err)
+		}
+		res := tx.Exec(`DELETE FROM `+t.table+` WHERE org_id = ? AND team_id <> ?`, orgID, newTeamID)
+		if res.Error != nil {
+			return moved, fmt.Errorf("delete reattributed %s rows (org=%s team=%d): %w", t.table, orgID, newTeamID, res.Error)
+		}
+		moved += res.RowsAffected
+	}
+	return moved, nil
+}

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"gorm.io/gorm"
@@ -133,8 +134,28 @@ func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, defaultTe
 	// existed (the create branch above only runs on insert). Only ever set,
 	// never cleared here, so an omitted value is a no-op rather than a wipe.
 	if defaultTeamID != 0 {
+		oldTeamID := int64(0)
+		if org.DefaultTeamID != nil {
+			oldTeamID = *org.DefaultTeamID
+		}
 		if err := tx.Model(&org).Update("default_team_id", defaultTeamID).Error; err != nil {
 			return err
+		}
+		// The org's default team changed: re-attribute its buffered (unacked)
+		// billing buckets to the new team in this same transaction, so the next
+		// billing pull reports them under the new team instead of stranding
+		// them under the stale one. A freshly-created org lands here with
+		// oldTeamID == defaultTeamID (set on insert above), so this only fires
+		// on a real re-provision change. In-flight metering under the old team
+		// (config-snapshot poll lag, ~30s) can still land a small residual
+		// old-team bucket — tolerated, see configstore.ReattributeUsageTeamTx.
+		if oldTeamID != defaultTeamID {
+			moved, err := configstore.ReattributeUsageTeamTx(tx, orgID, defaultTeamID)
+			if err != nil {
+				return err
+			}
+			slog.Info("Re-attributed org usage buckets to new default team.",
+				"org", orgID, "old_team", oldTeamID, "new_team", defaultTeamID, "rows", moved)
 		}
 	}
 

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -139,6 +139,25 @@ sizes; stored as `NUMERIC` so grouping is exact.)
   minute is never in the window, so an ack can't delete buckets that were never
   served.
 
+## Changing an org's default team
+
+Buckets are stamped with the org's `default_team_id` **at record time**, so an
+update to the org (admin `PUT /orgs/:id` or a re-provision carrying a different
+`default_team_id`) would otherwise strand already-buffered usage under the old
+team — including a team that was just deleted in PostHog (duckgres treats the
+id as opaque and never validates it against PostHog). Both update paths
+therefore **re-attribute every unacked bucket** — both metric families — to the
+new team id in the **same transaction** as the org-row update
+(`configstore.ReattributeUsageTeamTx`; colliding target keys, e.g. after an
+A→B→A flip, merge additively since `team_id` is part of both primary keys).
+The next pull reports the org's whole buffered window under the new team.
+
+One bounded race: connections and storage samples record under the team id from
+the config snapshot, which trails the update by up to the poll interval
+(~30s) — a flush landing just after the flip can leave a **small residual
+old-team row** on a later pull. Billing tolerates it, and re-running the update
+folds it in.
+
 ## No infinite accumulation
 
 - Ack deletes everything `≤ watermark_high` immediately.

--- a/tests/configstore/reattribute_usage_postgres_test.go
+++ b/tests/configstore/reattribute_usage_postgres_test.go
@@ -1,0 +1,190 @@
+//go:build linux || darwin
+
+package configstore_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/provisioning"
+)
+
+type reattrComputeRow struct {
+	TeamID        int64
+	QuerySource   string
+	BucketStart   time.Time
+	CPUSeconds    int64
+	MemorySeconds int64
+}
+
+type reattrStorageRow struct {
+	TeamID      int64
+	BucketStart time.Time
+	ByteSeconds int64
+}
+
+func computeRowsForOrg(t *testing.T, store *configstore.ConfigStore, orgID string) []reattrComputeRow {
+	t.Helper()
+	var rows []reattrComputeRow
+	if err := store.DB().Raw(`
+SELECT team_id, query_source, bucket_start, cpu_seconds, memory_seconds
+FROM duckgres_org_compute_usage WHERE org_id = ?
+ORDER BY team_id, query_source, bucket_start`, orgID).Scan(&rows).Error; err != nil {
+		t.Fatalf("read compute rows for %s: %v", orgID, err)
+	}
+	return rows
+}
+
+func storageRowsForOrg(t *testing.T, store *configstore.ConfigStore, orgID string) []reattrStorageRow {
+	t.Helper()
+	var rows []reattrStorageRow
+	if err := store.DB().Raw(`
+SELECT team_id, bucket_start, byte_seconds
+FROM duckgres_org_storage_usage WHERE org_id = ?
+ORDER BY team_id, bucket_start`, orgID).Scan(&rows).Error; err != nil {
+		t.Fatalf("read storage rows for %s: %v", orgID, err)
+	}
+	return rows
+}
+
+func seedUsage(t *testing.T, store *configstore.ConfigStore, orgID string, teamID int64, bucket time.Time, cpuSeconds, memSeconds, byteSeconds int64) {
+	t.Helper()
+	if err := store.FlushComputeUsage([]configstore.ComputeUsageDelta{{
+		OrgID:         orgID,
+		TeamID:        teamID,
+		QuerySource:   "standard",
+		Millicores:    2000,
+		MiB:           4096,
+		BucketStart:   bucket,
+		CPUSeconds:    cpuSeconds,
+		MemorySeconds: memSeconds,
+	}}); err != nil {
+		t.Fatalf("seed compute usage: %v", err)
+	}
+	if err := store.UpsertStorageSample(orgID, teamID, bucket, byteSeconds); err != nil {
+		t.Fatalf("seed storage usage: %v", err)
+	}
+}
+
+// TestReattributeUsageTeamPostgres covers the billing-bucket re-attribution
+// that runs when an org's default_team_id changes: every buffered (unacked)
+// bucket in BOTH usage tables moves to the new team, colliding rows (a target
+// key that already exists — e.g. a stale-snapshot straggler after an earlier
+// flip) fold additively instead of violating the PK, and other orgs' buckets
+// are untouched.
+func TestReattributeUsageTeamPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	b1 := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	b2 := b1.Add(time.Minute)
+
+	// acme has buckets under the old team 1 at b1+b2, plus a pre-existing
+	// team-2 bucket at b2 (the collision case: same key once team 1 → 2).
+	seedUsage(t, store, "acme", 1, b1, 10, 20, 1000)
+	seedUsage(t, store, "acme", 1, b2, 30, 60, 2000)
+	seedUsage(t, store, "acme", 2, b2, 5, 7, 500)
+	// A second org under team 1 must not be touched.
+	seedUsage(t, store, "other", 1, b1, 100, 200, 999)
+
+	moved, err := store.ReattributeUsageTeam("acme", 2)
+	if err != nil {
+		t.Fatalf("ReattributeUsageTeam: %v", err)
+	}
+	// 2 compute rows + 2 storage rows moved off team 1.
+	if moved != 4 {
+		t.Fatalf("moved = %d, want 4", moved)
+	}
+
+	compute := computeRowsForOrg(t, store, "acme")
+	if len(compute) != 2 {
+		t.Fatalf("acme compute rows = %+v, want 2 rows all under team 2", compute)
+	}
+	for i, want := range []reattrComputeRow{
+		{TeamID: 2, QuerySource: "standard", BucketStart: b1, CPUSeconds: 10, MemorySeconds: 20},
+		// b2 folded: moved team-1 row summed into the pre-existing team-2 row.
+		{TeamID: 2, QuerySource: "standard", BucketStart: b2, CPUSeconds: 35, MemorySeconds: 67},
+	} {
+		got := compute[i]
+		if got.TeamID != want.TeamID || got.QuerySource != want.QuerySource ||
+			!got.BucketStart.Equal(want.BucketStart) ||
+			got.CPUSeconds != want.CPUSeconds || got.MemorySeconds != want.MemorySeconds {
+			t.Fatalf("acme compute row %d = %+v, want %+v", i, got, want)
+		}
+	}
+
+	storage := storageRowsForOrg(t, store, "acme")
+	if len(storage) != 2 {
+		t.Fatalf("acme storage rows = %+v, want 2 rows all under team 2", storage)
+	}
+	for i, want := range []reattrStorageRow{
+		{TeamID: 2, BucketStart: b1, ByteSeconds: 1000},
+		{TeamID: 2, BucketStart: b2, ByteSeconds: 2500}, // folded 2000 + 500
+	} {
+		got := storage[i]
+		if got.TeamID != want.TeamID || !got.BucketStart.Equal(want.BucketStart) || got.ByteSeconds != want.ByteSeconds {
+			t.Fatalf("acme storage row %d = %+v, want %+v", i, got, want)
+		}
+	}
+
+	// Other orgs keep their team and values.
+	otherCompute := computeRowsForOrg(t, store, "other")
+	if len(otherCompute) != 1 || otherCompute[0].TeamID != 1 || otherCompute[0].CPUSeconds != 100 {
+		t.Fatalf("other org compute rows mutated: %+v", otherCompute)
+	}
+	otherStorage := storageRowsForOrg(t, store, "other")
+	if len(otherStorage) != 1 || otherStorage[0].TeamID != 1 || otherStorage[0].ByteSeconds != 999 {
+		t.Fatalf("other org storage rows mutated: %+v", otherStorage)
+	}
+
+	// Re-running with the same team is a no-op (everything already there).
+	moved, err = store.ReattributeUsageTeam("acme", 2)
+	if err != nil {
+		t.Fatalf("ReattributeUsageTeam (repeat): %v", err)
+	}
+	if moved != 0 {
+		t.Fatalf("repeat moved = %d, want 0", moved)
+	}
+}
+
+// TestProvisionReattributesUsageOnTeamChangePostgres: re-provisioning an
+// EXISTING org with a different default_team_id must update the org row AND
+// re-attribute its buffered usage buckets to the new team, atomically.
+func TestProvisionReattributesUsageOnTeamChangePostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+
+	oldTeam := int64(1)
+	if err := store.DB().Create(&configstore.Org{Name: "reprov", DatabaseName: "reprovdb", DefaultTeamID: &oldTeam}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	bucket := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	seedUsage(t, store, "reprov", oldTeam, bucket, 10, 20, 1000)
+
+	pstore := provisioning.NewGormStore(store)
+	if err := pstore.Provision(provisioning.ProvisionRequest{
+		OrgID:         "reprov",
+		DatabaseName:  "reprovdb",
+		DefaultTeamID: 2,
+		Warehouse:     &configstore.ManagedWarehouse{DucklingName: "reprov"},
+		RootUserHash:  "hash",
+	}); err != nil {
+		t.Fatalf("re-provision with new team: %v", err)
+	}
+
+	var org configstore.Org
+	if err := store.DB().First(&org, "name = ?", "reprov").Error; err != nil {
+		t.Fatalf("read org: %v", err)
+	}
+	if org.DefaultTeamID == nil || *org.DefaultTeamID != 2 {
+		t.Fatalf("org default_team_id = %v, want 2", org.DefaultTeamID)
+	}
+
+	compute := computeRowsForOrg(t, store, "reprov")
+	if len(compute) != 1 || compute[0].TeamID != 2 || compute[0].CPUSeconds != 10 {
+		t.Fatalf("compute rows not re-attributed to team 2: %+v", compute)
+	}
+	storage := storageRowsForOrg(t, store, "reprov")
+	if len(storage) != 1 || storage[0].TeamID != 2 || storage[0].ByteSeconds != 1000 {
+		t.Fatalf("storage rows not re-attributed to team 2: %+v", storage)
+	}
+}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -568,8 +568,10 @@ connection_duration_logged() { # org password
 # the same round-trip: the leader's sampler (60s here) must serve a storage row
 # with gib_seconds > 0 for the org, and the shared ack must advance past it. A bucket closes ~90s after the
 # connection ends (60s width + 30s grace) plus ≤15s flush, so the poll allows
-# ~4 minutes. This e2e stack has its own config store, so acking here cannot
-# eat production usage.
+# ~4 minutes. Between serve and ack, an admin PUT changing the org's
+# default_team_id must re-attribute the unacked buckets to the new team (and a
+# restore PUT moves them back — the merge path). This e2e stack has its own
+# config store, so acking here cannot eat production usage.
 compute_usage_pull_api() { # org password
   org="$1"; pw="$2"
   log "compute-usage pull API round-trip on $org"
@@ -595,6 +597,38 @@ compute_usage_pull_api() { # org password
   wl="$(echo "$body" | jq -r '.watermark_low')"
   wh="$(echo "$body" | jq -r '.watermark_high')"
   log "compute-usage OK: usage served (low=$wl high=$wh)"
+
+  # ---- default_team_id re-attribution (unacked buckets follow the org) ----
+  # Changing an org's default_team_id must re-attribute ALL buffered (unacked)
+  # buckets to the NEW team in the same transaction as the org update, so the
+  # next pull reports them under the new team and none stay stranded under the
+  # old one. Only the compute (.usage) family is asserted team-exclusively:
+  # the storage sampler keeps stamping the stale snapshot's team until the
+  # config poll catches up, so a fresh old-team storage bucket may legitimately
+  # appear; compute rows for this org can only come from the two connections
+  # above, whose buckets are already closed and flushed (that's why the poll
+  # found them — anything metered after the flip lands in a not-yet-served
+  # open bucket). The provisioned team id is restored right after (the restore
+  # PUT re-attributes back — the A→B→A merge path), so the ack flow and every
+  # later assertion still see the canonical team.
+  reattr_team=515151
+  code="$(put_org "$org" "{\"default_team_id\":$reattr_team}")"
+  [ "$code" = "200" ] || fail "reattribute: PUT default_team_id=$reattr_team -> HTTP $code: $(cat /tmp/put_org_out)"
+  rbody="$(curl -fsS -H "$H" "$API/api/v1/billing/usage")" \
+    || fail "reattribute: GET /billing/usage after team change failed"
+  echo "$rbody" | jq -e --arg o "$org" --argjson new "$reattr_team" --argjson old "$CNPG_DEFAULT_TEAM_ID" '
+      (.usage | map(select(.org_id==$o and .team_id==$new)) | length >= 2)
+      and (.usage | map(select(.org_id==$o and .team_id==$old)) | length == 0)' >/dev/null \
+    || fail "reattribute: after default_team_id $CNPG_DEFAULT_TEAM_ID -> $reattr_team, unacked compute rows not re-attributed: $(echo "$rbody" | jq -c --arg o "$org" '[.usage[] | select(.org_id==$o)]' | head -c 600)"
+  code="$(put_org "$org" "{\"default_team_id\":$CNPG_DEFAULT_TEAM_ID}")"
+  [ "$code" = "200" ] || fail "reattribute: PUT restore default_team_id=$CNPG_DEFAULT_TEAM_ID -> HTTP $code: $(cat /tmp/put_org_out)"
+  rbody="$(curl -fsS -H "$H" "$API/api/v1/billing/usage")" \
+    || fail "reattribute: GET /billing/usage after team restore failed"
+  echo "$rbody" | jq -e --arg o "$org" --argjson new "$reattr_team" --argjson old "$CNPG_DEFAULT_TEAM_ID" '
+      (.usage | map(select(.org_id==$o and .team_id==$old)) | length >= 2)
+      and (.usage | map(select(.org_id==$o and .team_id==$new)) | length == 0)' >/dev/null \
+    || fail "reattribute: after restoring default_team_id=$CNPG_DEFAULT_TEAM_ID, compute rows not moved back: $(echo "$rbody" | jq -c --arg o "$org" '[.usage[] | select(.org_id==$o)]' | head -c 600)"
+  log "compute-usage OK: default_team_id change re-attributed unacked buckets ($CNPG_DEFAULT_TEAM_ID -> $reattr_team -> restored)"
 
   # Ack the served watermark; the cursor must advance and acked buckets die.
   ack="$(curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Why

Billing buckets (`duckgres_org_compute_usage` + `duckgres_org_storage_usage`) are stamped with the org's `default_team_id` **at record time**. When the team behind an org changes (or is deleted in PostHog — duckgres treats the id as opaque and never validates it), updating the org's `default_team_id` only affected *future* buckets: everything already buffered-but-unacked stayed stranded under the stale team id, so the next billing pull attributed that usage to the wrong (possibly nonexistent) team.

## What

- **`configstore.ReattributeUsageTeam(Tx)`**: moves every unacked bucket for an org — both metric families — onto the new team id inside one transaction. `team_id` is part of both tables' primary keys, so it's an additive upsert-fold + delete per table (colliding target keys, e.g. after an A→B→A flip or a stale-snapshot straggler, merge by summing the value columns) rather than a blind `UPDATE`.
- **Both update paths call it atomically with the org-row update:**
  - admin `PUT /orgs/:id`: the handler detects an actual `default_team_id` change (existing vs merged) and `gormAPIStore.UpdateOrg` now wraps org update + re-attribution in one transaction, logging INFO with org / old team / new team / rows moved. The existing audit field-change detail is unchanged.
  - provisioning re-provision of an existing org with a different `default_team_id` (`createPendingWarehouseTx`): same-transaction re-attribution + INFO log. A freshly created org never triggers it.
- **Docs:** `docs/design/billing-pull-api.md` gains a "Changing an org's default team" section; `CLAUDE.md` billing section gains the invariant + test pointers.

### In-flight residual (bounded, tolerated)

Connections and storage samples keep stamping the old team id until the config-snapshot poll (~30s) picks up the change, so a flush racing the flip can land a small residual old-team row on a later pull. Billing tolerates it, and re-running the update folds it in. No locking was added around the metering hot path (best-effort contract).

## Tests

- `tests/configstore/reattribute_usage_postgres_test.go` (real Postgres): simple move, collision-merge (old- and new-team rows at the same bucket sum correctly, compute + storage), other orgs untouched, repeat is a no-op; plus re-provision via `provisioning.Provision` with a changed team re-attributes.
- `controlplane/admin/api_test.go`: PUT changing `default_team_id` triggers re-attribution; same-value / omitted-field PUTs do not.
- `controlplane/admin/api_postgres_test.go`: real `gormAPIStore.UpdateOrg` transaction moves + folds both tables; non-team updates leave buckets alone.
- e2e (`tests/mw-dev/e2e/harness.sh`, `compute_usage_pull_api`): with closed-but-unacked usage served, a PUT to a new team must show all of the org's compute rows under the new team (none under the old) in `GET /billing/usage`, then a restore PUT moves them back (the A→B→A merge path) before the ack assertions. `bash -n` passes.
- Verified: `go build ./...`, `go build -tags kubernetes ./...`, `go vet ./...`, `go vet -tags kubernetes ./controlplane/...`, `go test ./controlplane/...`, `go test -count=1 ./tests/configstore/`, `go test -count=1 -tags kubernetes . ./controlplane ./controlplane/admin` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)