### PR TITLE
reshard: diagnose silent recovery waits — periodic observations + stranded-password classification

### DIFF
--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -61,6 +62,13 @@ type ReshardRunner struct {
 	// loopPoll is the inner-loop poll cadence (drain checks, flip waits,
 	// cancel checks). 5s in production; tests shrink it.
 	loopPoll time.Duration
+	// progressLogInterval is how often a wait loop (drain, flip converge,
+	// orphan-policy wait, recovery) writes what it currently observes to the
+	// op log. 15s in production; tests shrink it. Every wait loop MUST emit
+	// periodic observations at this cadence — a silent multi-minute poll loop
+	// is undebuggable from the op log (the mw-dev recovery that spun for ~8
+	// minutes on SASL auth failures with zero diagnostics).
+	progressLogInterval time.Duration
 
 	// extPasswords holds the EPHEMERAL external passwords by op id: the
 	// cnpg→ext target password (pulled from the creating CP replica's stash
@@ -124,18 +132,57 @@ func NewReshardRunner(store *configstore.ConfigStore, duckling *DucklingClient, 
 		}
 	}
 	return &ReshardRunner{
-		store:              store,
-		duckling:           duckling,
-		copier:             PGCatalogCopier{},
-		backuper:           backuper,
-		cpID:               cpID,
-		configPollInterval: configPollInterval,
-		heartbeatInterval:  30 * time.Second,
-		staleAfter:         5 * time.Minute,
-		flipTimeout:        flipTimeout,
-		hotIdleGrace:       30 * time.Second,
-		loopPoll:           5 * time.Second,
+		store:               store,
+		duckling:            duckling,
+		copier:              PGCatalogCopier{},
+		backuper:            backuper,
+		cpID:                cpID,
+		configPollInterval:  configPollInterval,
+		heartbeatInterval:   30 * time.Second,
+		staleAfter:          5 * time.Minute,
+		flipTimeout:         flipTimeout,
+		hotIdleGrace:        30 * time.Second,
+		loopPoll:            5 * time.Second,
+		progressLogInterval: 15 * time.Second,
 	}
+}
+
+// isAuthProbeError reports whether a catalog-probe failure is an
+// authentication failure: SQLSTATE 28P01 (invalid_password) / 28000
+// (invalid_authorization_specification), or the "SASL authentication failed" /
+// "password authentication failed" server messages (pgbouncer/poolers vary in
+// which they emit). pgx surfaces these as a *pgconn.PgError inside the connect
+// error chain; the string match covers errors that arrive pre-flattened.
+func isAuthProbeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && (pgErr.Code == "28P01" || pgErr.Code == "28000") {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "sasl authentication failed") ||
+		strings.Contains(msg, "password authentication failed")
+}
+
+// describeProbeFailure renders a tenant-role probe failure for the op log.
+// Authentication failures are named explicitly, with the operator remedy: the
+// role's ACTUAL Postgres password differing from the freshly published status
+// password (a stranded password — e.g. a re-adopted role whose status password
+// the composition regenerated) is effectively permanent, and retrying to the
+// timeout cannot fix it by itself. We keep polling anyway (a composition fix
+// can converge the password mid-wait, and bailing early would leave the org
+// worse off), but the log must tell the operator what to do.
+//
+// Safe to log verbatim: Probe wraps the endpoint via CatalogEndpoint.Redacted()
+// (password elided) and pgx's ConnectError/PgError texts carry user/database
+// but never the password.
+func describeProbeFailure(err error, role string) string {
+	if !isAuthProbeError(err) {
+		return fmt.Sprintf("tenant-role probe failing: %v", err)
+	}
+	return fmt.Sprintf("tenant-role probe failing with an AUTHENTICATION error: %v — the role's actual Postgres password likely differs from the published status password (stranded password). If this persists, align it manually on the shard primary: ALTER ROLE %s WITH PASSWORD '<status password>' (take the password from the duckling CR status — it is never logged here)", err, role)
 }
 
 // StashExternalPassword hands the runner the ephemeral external-target
@@ -587,7 +634,7 @@ func (o *opRun) drain(ctx context.Context) error {
 			return nil
 		}
 
-		if time.Since(lastLog) >= 15*time.Second {
+		if time.Since(lastLog) >= o.r.progressLogInterval {
 			o.logf("info", "waiting for connections to drain: %d active sessions, %d queued connections, %d live workers",
 				conns.ActiveLeases, conns.QueuedConns, len(workers))
 			lastLog = time.Now()
@@ -806,8 +853,10 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 	o.flipped = true
 
 	targetPrefix := o.op.ToShard + "-pooler."
+	o.logf("info", "cutover patch applied; waiting up to %s for the composition to converge on %s* and the tenant role to answer", o.flipTimeout(), targetPrefix)
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -816,7 +865,7 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 			return errReshardCancelled
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("target shard %s did not become ready within %s", o.op.ToShard, o.flipTimeout())
+			return fmt.Errorf("target shard %s did not become ready within %s; last observation: %s", o.op.ToShard, o.flipTimeout(), lastObserved)
 		}
 
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
@@ -826,22 +875,24 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
 				SSLMode: "disable",
 			}
-			if probeErr := o.r.copier.Probe(ctx, o.target); probeErr == nil {
+			probeErr := o.r.copier.Probe(ctx, o.target)
+			if probeErr == nil {
 				o.logf("info", "target ready: duckling converged on %s and the tenant role answers", st.MetadataStore.Endpoint)
 				return nil
-			} else if time.Since(lastLog) >= 15*time.Second {
-				o.logf("info", "waiting for target: composition converged, probe still failing: %v", probeErr)
-				lastLog = time.Now()
 			}
-		} else if time.Since(lastLog) >= 15*time.Second {
+			lastObserved = "composition converged, " + describeProbeFailure(probeErr, st.MetadataStore.User)
+		} else {
 			switch {
 			case err != nil:
-				o.logf("info", "waiting for target: reading duckling failed: %v", err)
+				lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
 			case st.SyncedFalseMessage != "":
-				o.logf("info", "waiting for target: duckling Synced=False: %s", st.SyncedFalseMessage)
+				lastObserved = "duckling Synced=False: " + st.SyncedFalseMessage
 			default:
-				o.logf("info", "waiting for target: duckling endpoint %q, ready=%t", st.MetadataStore.Endpoint, st.ReadyCondition)
+				lastObserved = fmt.Sprintf("duckling endpoint %q, ready=%t", st.MetadataStore.Endpoint, st.ReadyCondition)
 			}
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "waiting for target: %s", lastObserved)
 			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
@@ -914,7 +965,7 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 		default:
 			lastObserved = detail
 		}
-		if time.Since(lastLog) >= 15*time.Second {
+		if time.Since(lastLog) >= o.r.progressLogInterval {
 			o.logf("info", "waiting for the cnpg source MRs to reflect the retain (no-Delete) policy: %s", lastObserved)
 			lastLog = time.Now()
 		}
@@ -943,8 +994,10 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 	o.flipped = true
 
 	providedPassword := o.target.Password
+	o.logf("info", "cutover patch applied; waiting up to %s for the external target (ESO password sync + Ready condition)", o.flipTimeout())
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -952,13 +1005,14 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 		// No cancel check: past this flip the only ways out are forward or
 		// the orphan-adopt recovery in rollback().
 		if time.Now().After(deadline) {
-			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string)", o.flipTimeout(), o.op.TargetPasswordSecret)
+			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string); last observation: %s", o.flipTimeout(), o.op.TargetPasswordSecret, lastObserved)
 		}
 
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
 		switch {
 		case err != nil:
 			// transient — keep polling
+			lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
 		case st.MetadataStore.Type == configstore.MetadataStoreKindExternal && st.MetadataStore.Password != "":
 			if st.MetadataStore.Password != providedPassword {
 				return fmt.Errorf("ESO-synced password from secret %q does not match the password the catalog was copied with — fix the secret and re-run", o.op.TargetPasswordSecret)
@@ -967,13 +1021,15 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 				o.logf("info", "external target ready: ESO password synced and matches, duckling Ready")
 				return nil
 			}
+			lastObserved = "ESO password synced and matches, but the duckling is not Ready yet"
+		default:
+			lastObserved = fmt.Sprintf("duckling type %q, ESO password synced=%t, ready=%t", st.MetadataStore.Type, st.MetadataStore.Password != "", st.ReadyCondition)
 		}
-		if time.Since(lastLog) >= 15*time.Second {
-			msg := "waiting for external target (ESO password sync + Ready condition)"
-			if err == nil && st.SyncedFalseMessage != "" {
-				msg += ": " + st.SyncedFalseMessage
-			}
-			o.logf("info", "%s", msg)
+		if err == nil && st.SyncedFalseMessage != "" {
+			lastObserved += "; duckling Synced=False: " + st.SyncedFalseMessage
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "waiting for external target (ESO password sync + Ready condition): %s", lastObserved)
 			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
@@ -1319,25 +1375,51 @@ func (o *opRun) recoverFromExternal(ctx context.Context) {
 	}
 
 	// Wait for the composition to re-adopt the role/DB on the source shard and
-	// the tenant role to answer again.
+	// the tenant role to answer again. NEVER silently: this loop logs what it
+	// observes every progressLogInterval — a recovery that spins on a failing
+	// probe (e.g. SASL auth failures from a stranded re-adopted-role password,
+	// the mw-dev incident) must be diagnosable from the op log alone, and the
+	// terminal timeout line must carry the last observation (the root cause).
+	// An auth probe failure is effectively permanent, but we still poll to the
+	// deadline rather than bail: a charts/composition fix can converge the
+	// password mid-wait, and giving up early would leave the org worse off.
 	sourcePrefix := o.op.FromShard + "-pooler."
+	o.logf("info", "recovery: waiting up to %s for the composition to re-adopt the cnpg role/DB on %s* and for the tenant role to answer", o.flipTimeout(), sourcePrefix)
 	deadline := time.Now().Add(o.flipTimeout())
+	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if time.Now().After(deadline) {
-			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s)", o.flipTimeout(), o.op.FromShard)
+			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", o.flipTimeout(), o.op.FromShard, lastObserved)
 			return
 		}
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
-		if err == nil && strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) && st.ReadyCondition {
+		switch {
+		case err != nil:
+			lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
+		case !strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) || !st.ReadyCondition:
+			lastObserved = fmt.Sprintf("duckling endpoint %q, ready=%t (waiting for %s*)", st.MetadataStore.Endpoint, st.ReadyCondition, sourcePrefix)
+			if st.SyncedFalseMessage != "" {
+				lastObserved += "; duckling Synced=False: " + st.SyncedFalseMessage
+			}
+		default:
 			restored := CatalogEndpoint{
 				Host: st.MetadataStore.Endpoint, Port: 5432,
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
 				SSLMode: "disable",
 			}
-			if o.r.copier.Probe(ctx, restored) == nil {
+			probeErr := o.r.copier.Probe(ctx, restored)
+			if probeErr == nil {
 				o.logf("info", "recovery complete: duckling re-adopted the orphaned cnpg role/DB on %s and the tenant role answers — no data was copied back (the catalog never left the source)", o.op.FromShard)
 				return
 			}
+			// describeProbeFailure names an auth failure explicitly (stranded
+			// re-adopted-role password) with the manual ALTER ROLE remedy.
+			lastObserved = "duckling converged on " + st.MetadataStore.Endpoint + " (Ready), " + describeProbeFailure(probeErr, st.MetadataStore.User)
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "recovery: waiting for the source shard: %s", lastObserved)
+			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
 	}

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -188,6 +190,18 @@ func (f *fakeReshardStore) hasLog(substr string) bool {
 	return f.countLog(substr) > 0
 }
 
+// findLog returns the first op-log line containing substr ("" if none).
+func (f *fakeReshardStore) findLog(substr string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, l := range f.logs {
+		if strings.Contains(l, substr) {
+			return l
+		}
+	}
+	return ""
+}
+
 func (f *fakeReshardStore) countLog(substr string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -356,6 +370,10 @@ type fakeCopier struct {
 
 	copyResult CatalogCopyResult
 	copyErr    error
+	// probeFn, when set, decides each Probe's result (nil = all probes
+	// succeed). It sees the probed endpoint so tests can fail e.g. only the
+	// post-flip-back recovery probe.
+	probeFn func(ep CatalogEndpoint) error
 	// countsAfter is what SnapshotCounts returns for the SOURCE stability
 	// recheck (sslmode!=require); defaults to copyResult.PerTableRows (stable).
 	countsAfter map[string]int64
@@ -373,6 +391,12 @@ func (f *fakeCopier) record(c copierCall) {
 
 func (f *fakeCopier) Probe(_ context.Context, ep CatalogEndpoint) error {
 	f.record(copierCall{kind: "probe", target: ep})
+	f.mu.Lock()
+	fn := f.probeFn
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(ep)
+	}
 	return nil
 }
 
@@ -472,6 +496,9 @@ func testRunner(store *fakeReshardStore, duckling reshardDucklingClient, copier 
 		flipTimeout:        2 * time.Second,
 		hotIdleGrace:       time.Millisecond,
 		loopPoll:           5 * time.Millisecond,
+		// Shrunk so tests observe the periodic wait-loop observations (15s in
+		// production, > any test's whole runtime).
+		progressLogInterval: 15 * time.Millisecond,
 	}
 }
 
@@ -757,6 +784,10 @@ func TestReshardFlipTimeoutRollsBackShardValue(t *testing.T) {
 
 	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "did not become ready") {
 		t.Fatalf("state=%s err=%q, want flip-timeout failure", store.op.State, store.op.Error)
+	}
+	// The timeout error carries the last converge observation (root cause).
+	if !strings.Contains(store.op.Error, "last observation:") {
+		t.Fatalf("flip-timeout error lacks the last observation: %q", store.op.Error)
 	}
 	// Last cnpg patch must be the flip-back to the source shard value.
 	var shardPatches []string
@@ -1062,6 +1093,11 @@ func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 	}
 	if !store.hasLog("waiting for external target") {
 		t.Fatalf("generic waiting line missing: %v", store.logs)
+	}
+	// The timeout error carries the last observed duckling state (root cause).
+	if !strings.Contains(store.op.Error, "last observation:") ||
+		!strings.Contains(store.op.Error, "ESO password synced=false") {
+		t.Fatalf("flip-timeout error lacks the last ESO/Ready observation: %q", store.op.Error)
 	}
 	// Recovery is flip-back + adopt (SetMetadataStoreCnpgAdopt), never copy-back.
 	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
@@ -1433,5 +1469,134 @@ func TestReshardVerifyMismatchRollsBack(t *testing.T) {
 	}
 	if store.warehouseState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("warehouse state = %s, want ready after rollback", store.warehouseState)
+	}
+}
+
+// TestProbeErrorAuthClassification pins isAuthProbeError/describeProbeFailure
+// against errors shaped the way catalog_copy.go::Probe actually wraps them
+// (`connect <redacted>: %w` / `probe <redacted>: %w` around pgx errors, whose
+// chain carries a *pgconn.PgError for server-side auth failures).
+func TestProbeErrorAuthClassification(t *testing.T) {
+	saslPgErr := &pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: "SASL authentication failed"}
+	pwPgErr := &pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: `password authentication failed for user "mdstore_org"`}
+	authSpecErr := &pgconn.PgError{Severity: "FATAL", Code: "28000", Message: `no pg_hba.conf entry for host "10.0.0.1"`}
+
+	auth := []error{
+		// Wrapped the way Probe wraps a pgx connect failure (the mw-dev
+		// incident shape: pooler answered FATAL: SASL authentication failed).
+		fmt.Errorf("connect host=shard-001-pooler user=mdstore_org: failed to connect to `user=mdstore_org database=mdstore_org`: server error: %w", saslPgErr),
+		fmt.Errorf("probe host=shard-001-pooler user=mdstore_org: %w", pwPgErr),
+		fmt.Errorf("connect host=x user=y: %w", authSpecErr),
+		// Pre-flattened text (no PgError left in the chain).
+		errors.New("connect host=x user=y: FATAL: SASL authentication failed (SQLSTATE 28P01)"),
+		errors.New("failed to connect: password authentication failed for user \"mdstore_org\""),
+	}
+	for _, err := range auth {
+		if !isAuthProbeError(err) {
+			t.Errorf("isAuthProbeError(%v) = false, want true", err)
+		}
+		got := describeProbeFailure(err, "mdstore_org")
+		if !strings.Contains(got, "AUTHENTICATION error") ||
+			!strings.Contains(got, "stranded password") ||
+			!strings.Contains(got, "ALTER ROLE mdstore_org WITH PASSWORD") {
+			t.Errorf("describeProbeFailure(%v) lacks the named condition + operator remedy: %q", err, got)
+		}
+		if strings.Contains(got, "'pinned-pw'") {
+			t.Errorf("describeProbeFailure must never embed a password: %q", got)
+		}
+	}
+
+	notAuth := []error{
+		errors.New("connect host=x user=y: dial tcp 10.0.0.1:5432: connect: connection refused"),
+		context.DeadlineExceeded,
+		fmt.Errorf("probe host=x user=y: %w", &pgconn.PgError{Severity: "FATAL", Code: "57P03", Message: "the database system is starting up"}),
+	}
+	for _, err := range notAuth {
+		if isAuthProbeError(err) {
+			t.Errorf("isAuthProbeError(%v) = true, want false", err)
+		}
+		if got := describeProbeFailure(err, "mdstore_org"); strings.Contains(got, "AUTHENTICATION") {
+			t.Errorf("describeProbeFailure(%v) misclassified as auth: %q", err, got)
+		}
+	}
+}
+
+// TestReshardExtRecoveryProbeAuthFailureDiagnosed is the regression for the
+// mw-dev incident where the cnpg→ext post-flip recovery spun silently for ~8
+// minutes on `FATAL: SASL authentication failed` (the re-adopted role's actual
+// password differed from the freshly regenerated status password) and the
+// operator had to reproduce the probe from a shell to see why. The recovery
+// wait must (a) announce its deadline, (b) periodically log the classified
+// probe failure naming the stranded-password condition + the manual ALTER ROLE
+// remedy, and (c) end with a timeout line carrying that last observation —
+// all without ever logging a password.
+func TestReshardExtRecoveryProbeAuthFailureDiagnosed(t *testing.T) {
+	store := newFakeReshardStore(stuckExtOp())
+	duckling := &stuckExternalDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	// The forward copy pre-flight probes the cnpg source once (must succeed so
+	// the op reaches the flip); every LATER probe of the cnpg endpoint is the
+	// recovery loop re-probing the re-adopted role — those fail with the
+	// incident-shaped SASL error, persistently (stranded password).
+	saslErr := fmt.Errorf("connect host=shard-001-pooler user=mdstore_org: failed to connect to `user=mdstore_org database=mdstore_org`: server error: %w",
+		&pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: "SASL authentication failed"})
+	var cnpgProbes atomic.Int32
+	copier.probeFn = func(ep CatalogEndpoint) error {
+		if ep.SSLMode != "disable" {
+			return nil // external target pre-flight
+		}
+		if cnpgProbes.Add(1) == 1 {
+			return nil // forward-copy source pre-flight
+		}
+		return saslErr
+	}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(store.op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state=%s err=%q, want failed", store.op.State, store.op.Error)
+	}
+	// (a) The recovery wait announces itself with its deadline.
+	if !store.hasLog("recovery: waiting up to") {
+		t.Fatalf("recovery deadline announce missing: %v", store.logs)
+	}
+	// (b) Periodic observations name the auth failure + operator remedy.
+	if n := store.countLog("AUTHENTICATION error"); n < 2 {
+		t.Fatalf("want >=2 periodic auth-failure observations, got %d: %v", n, store.logs)
+	}
+	if !store.hasLog("stranded password") || !store.hasLog("ALTER ROLE mdstore_org WITH PASSWORD") {
+		t.Fatalf("stranded-password condition/remedy missing from the periodic observations: %v", store.logs)
+	}
+	// (c) The terminal recovery-timeout line carries the last observation.
+	terminal := store.findLog("recovery: source shard did not become ready within")
+	if terminal == "" {
+		t.Fatalf("recovery timeout line missing: %v", store.logs)
+	}
+	if !strings.Contains(terminal, "last observation:") ||
+		!strings.Contains(terminal, "SASL authentication failed") ||
+		!strings.Contains(terminal, "AUTHENTICATION error") {
+		t.Fatalf("recovery timeout line lacks the classified root cause: %q", terminal)
+	}
+	// Never a password in the op log — neither the pinned cnpg password nor
+	// the ephemeral external one.
+	store.mu.Lock()
+	logs := append([]string(nil), store.logs...)
+	store.mu.Unlock()
+	for _, l := range logs {
+		if strings.Contains(l, "pinned-pw") || strings.Contains(l, "ext-pw") {
+			t.Fatalf("op log leaked a password: %q", l)
+		}
+	}
+	// The recovery still ran to its normal conclusion: flip-back + adopt,
+	// warehouse unblocked (auth failures do NOT abort the wait early — a
+	// composition fix may still converge the password mid-wait).
+	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
+		t.Fatalf("recovery did not flip back + adopt: %v", duckling.callKinds())
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
 	}
 }

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -405,6 +405,21 @@ recovery (which stranded the tenant with an empty catalog when the copy-back
 also failed, the prod-shaped data-loss incident this change fixes) and avoids
 the `2BP01` "role can't drop while its DB exists" wedge the coupled delete hit.
 
+Every wait loop in the runner (drain, flip converge, orphan-policy wait, this
+recovery) announces its deadline on entry and logs what it observes every ~15s
+(duckling endpoint/Ready state, classified probe errors), and its timeout
+error/log line carries the LAST observation — a stuck reshard is diagnosable
+from the op log alone. One recovery failure mode deserves naming: the
+re-adopted role's ACTUAL Postgres password can differ from the freshly
+regenerated status password (a **stranded password** — the probe fails with
+`FATAL: SASL authentication failed` / SQLSTATE 28P01 until the composition
+converges the password). The runner classifies auth probe failures
+(`isAuthProbeError`) and the observation names the condition and the manual
+remedy — `ALTER ROLE <role> WITH PASSWORD '<status password>'` on the source
+shard primary — but it still polls to the deadline rather than bailing early,
+since a charts/composition fix can converge the password mid-wait. Passwords
+never appear in the op log.
+
 ## Rollback, cancel, crash-safety
 
 - Rollback never removes `spec.metadataStore.cnpgShard` — it patches the

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2236,7 +2236,13 @@ duckling_shard_backfill() { # cnpgOrg
 #     connections are 57P03-blocked; cancel rolls back; org healthy)
 #   * bogus-shard rollback (flip → Synced=False → flip-timeout → rollback;
 #     data intact, spec.cnpgShard patched back; short per-op
-#     cutover_timeout_seconds keeps it fast)
+#     cutover_timeout_seconds keeps it fast). Also asserts the wait-loop
+#     diagnostics: deadline announce, periodic "waiting for target"
+#     observations, and the flip-timeout error carrying the last observation.
+#     (The cnpg→ext RECOVERY loop's stranded-password/SASL classification
+#     can't be provoked here — it needs a role whose actual password diverged
+#     from the status password — so that path is pinned by
+#     provisioner/reshard_runner_test.go instead.)
 #   * ext→cnpg POSITIVE path (real catalog copy off the harness RDS onto
 #     shard-001, data intact after, report in the log) — including the pod
 #     model: every reshard executes in a dedicated duckgres-reshard-op-<id>
@@ -2435,6 +2441,13 @@ reshard_bogus_shard_rollback() { # org password
   [ "$st" = "failed" ] || { reshard_dump_log "$opid"; fail "reshard rollback: final state $st, want failed"; }
   reshard_log_has "$opid" "rolling back" || fail "reshard rollback: no rollback log"
   reshard_log_has "$opid" "reshard report (failed)" || fail "reshard rollback: report missing"
+  # Wait-loop diagnostics: the converge wait announces its deadline, logs what
+  # it observes every ~15s, and the flip-timeout failure carries the LAST
+  # observation — a stuck cutover must be diagnosable from the op log alone
+  # (the mw-dev recovery that spun ~8 min on silent SASL probe failures).
+  reshard_log_has "$opid" "cutover patch applied; waiting up to" || { reshard_dump_log "$opid"; fail "reshard rollback: converge-wait deadline announce missing"; }
+  reshard_log_has "$opid" "waiting for target:" || { reshard_dump_log "$opid"; fail "reshard rollback: periodic converge observations missing"; }
+  reshard_log_has "$opid" "last observation:" || { reshard_dump_log "$opid"; fail "reshard rollback: flip-timeout error lacks the last observation"; }
 
   # The duckling spec must be back on the real shard (the rollback patches the
   # VALUE back — it never removes the key).

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2270,8 +2270,7 @@ reshard_backup_debug() { # opid — focused debug for a backup-assert failure:
   # error the op log only summarizes). Best effort — the reconciler may have
   # reaped the pod already.
   echo "---- op $1 backup-related log lines ----"
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" 2>/dev/null \
-    | jq -r '.entries[] | select(.message | test("(?i)backup|sts|assume|s3")) | "\(.level): \(.message)"' || true
+  reshard_log_fetch "$1" 2>/dev/null | grep -iE 'backup|sts|assume|s3' || true
   echo "---- runner pod duckgres-reshard-op-$1 logs (tail) ----"
   k logs "duckgres-reshard-op-$1" --tail=150 2>/dev/null || echo "(runner pod already gone)"
 }
@@ -2318,14 +2317,30 @@ reshard_wait_step() { # opid step timeout_s
   fail "reshard op $1 never reached step $2 (last=$cur)"
 }
 
-reshard_log_has() { # opid substr
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" \
-    | jq -r '.entries[].message' | grep -qF "$2"
+reshard_log_fetch() { # opid -> the FULL op log, one "level: message" line per entry
+  # Pages with after_id until exhausted. A single first-page fetch is NOT
+  # enough: the catalog copy logs one op-log line per table, and the shared
+  # ext-RDS catalog has accumulated 20k+ ducklake_* tables across e2e runs —
+  # far past the server's 2000-per-page cap — so a one-shot fetch saw only the
+  # first page and the asserts on END-of-log lines (the terminal "reshard
+  # report" block) failed on an op that actually succeeded.
+  _after=0
+  while :; do
+    _page="$(curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=${_after}&limit=2000")" || break
+    _n="$(echo "$_page" | jq '.entries | length')" || break
+    [ "${_n:-0}" -gt 0 ] || break
+    echo "$_page" | jq -r '.entries[] | "\(.level): \(.message)"'
+    _after="$(echo "$_page" | jq '.entries[-1].id')" || break
+    if [ "$_n" -lt 2000 ]; then break; fi
+  done
 }
 
-reshard_dump_log() { # opid
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" \
-    | jq -r '.entries[] | "\(.level): \(.message)"' | tail -30 || true
+reshard_log_has() { # opid substr
+  reshard_log_fetch "$1" | grep -qF "$2"
+}
+
+reshard_dump_log() { # opid — the log TAIL (where the failure/report lands)
+  reshard_log_fetch "$1" | tail -30 || true
 }
 
 reshard_targets() { # destination discovery; ext org's RDS must appear too


### PR DESCRIPTION
## Incident shape

During a cnpg→external reshard, the post-flip **recovery** (`recoverFromExternal`) hit its adopt-wait with a re-adopted role whose *actual* Postgres password differed from the freshly regenerated status password (a charts-side bug, fixed separately). Every probe failed with `FATAL: SASL authentication failed` — for ~8 minutes — and the op log showed **nothing** between the recovery announce and the eventual timeout. The operator saw a "stuck" reshard with zero diagnostics; the SASL failure was only found by reproducing the probe manually from a shell.

#947 fixed exactly this observability gap for the orphan-policy wait. This PR gives the remaining wait loops the same treatment.

## What each loop now logs

Every wait loop announces its **deadline** on entry, logs **what it observes** every ~15s (shared `progressLogInterval` knob, test-shrinkable; drain + orphan-wait moved onto it too), and its timeout error/log line carries the **last observation** so the terminal op-log line names the root cause:

- **`recoverFromExternal`** (the incident loop, cnpg→ext post-flip rollback): duckling read failures, endpoint/Ready state (+ `Synced=False` message), and classified probe errors; the timeout line ends with `last observation: …`.
- **`flipToCnpg` converge wait**: same treatment; the `did not become ready within …` error now carries the last observation (probe failures classified here too).
- **`flipToExternal` ESO/Ready wait**: already logged periodically — now the periodic line says what it observes (`duckling type/ESO password synced/ready` + `Synced=False`), plus deadline announce and last observation in the timeout error.
- The rollback flip-backs (cnpg→cnpg, ext→cnpg) are patch-and-move-on with no wait loop — nothing to instrument there.

## Stranded-password classification

`isAuthProbeError` recognizes authentication probe failures — SQLSTATE `28P01`/`28000` via the wrapped `*pgconn.PgError` chain (matching how `catalog_copy.go::Probe` wraps pgx connect errors), plus the `SASL authentication failed` / `password authentication failed` message texts for pre-flattened errors. `describeProbeFailure` then emits the operator-facing line:

> tenant-role probe failing with an AUTHENTICATION error: … — the role's actual Postgres password likely differs from the published status password (stranded password). If this persists, align it manually on the shard primary: `ALTER ROLE <role> WITH PASSWORD '<status password>'` (take the password from the duckling CR status — it is never logged here)

Deliberately **not** fail-fast: a composition fix can converge the password mid-wait, and bailing early would leave the org worse off — the loop polls to the deadline, but names the condition the whole way. No password can reach the op log: pgx `ConnectError`/`PgError` texts carry user/database only, and endpoints are logged via `Redacted()` (verified against pgx v5.9.2).

## Tests

- `TestProbeErrorAuthClassification`: classifier against realistically wrapped pgx errors (PgError-in-chain and flattened strings), plus negatives (connection refused, 57P03, ctx deadline).
- `TestReshardExtRecoveryProbeAuthFailureDiagnosed` (regression for the incident): recovery whose probe persistently fails SASL must produce the deadline announce, ≥2 periodic classified observations naming the stranded password + ALTER ROLE remedy, a timeout line carrying the root cause, no password anywhere in the log — and recovery still completes flip-back+adopt with the warehouse unblocked.
- Extended the existing flip-timeout tests to assert both timeout errors carry `last observation: …`.
- e2e (`tests/mw-dev/e2e/harness.sh`): the bogus-shard rollback lane now asserts the converge-wait deadline announce, periodic `waiting for target:` observations, and the last-observation-carrying flip-timeout error. (The recovery SASL path itself can't be provoked in-harness — it needs a role whose actual password diverged from the status password — noted in the harness comment; pinned by the unit regression instead.)
- Docs: `docs/design/resharding.md` gains a paragraph on the wait-loop diagnostics + the stranded-password diagnosis/remedy.

`go build ./…`, `go build -tags kubernetes ./…`, `go vet -tags kubernetes ./…`, `go test -tags kubernetes ./controlplane/provisioner/ -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)