### PR TITLE
fix(admin): reload snapshots after user mutations

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -132,6 +132,8 @@ func registerAPIWithStore(r *gin.RouterGroup, store apiStore, info OrgStackInfo,
 	r.GET("/orgs/:id/users/:username", h.getUser)
 	r.PUT("/orgs/:id/users/:username", h.updateUser)
 	r.DELETE("/orgs/:id/users/:username", h.deleteUser)
+	// Peer-only fan-out target: see reloadSnapshot below.
+	r.POST("/internal/reload-snapshot", h.reloadSnapshot)
 
 	// Workers (read-only)
 	r.GET("/workers", h.listWorkers)
@@ -188,6 +190,12 @@ type apiStore interface {
 	// when concurrent PUTs target the same org. Returns (nil, false, nil) if
 	// the org doesn't exist.
 	MutateManagedWarehouse(orgID string, mutate func(*configstore.ManagedWarehouse) error) (*configstore.ManagedWarehouse, bool, error)
+
+	// ReloadSnapshot forces this replica's in-memory config snapshot to reload
+	// from the config-store DB immediately, bypassing the poll interval. Used
+	// by createUser/updateUser/deleteUser so a write is authable on this
+	// replica the instant the request returns — see notifyPeersOfChange.
+	ReloadSnapshot() error
 }
 
 type gormAPIStore struct {
@@ -585,6 +593,10 @@ func (s *gormAPIStore) DeleteUser(orgID, username string) (bool, error) {
 		return false, result.Error
 	}
 	return result.RowsAffected > 0, nil
+}
+
+func (s *gormAPIStore) ReloadSnapshot() error {
+	return s.store.ReloadSnapshot()
 }
 
 func (s *gormAPIStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error) {
@@ -1573,6 +1585,10 @@ func (h *apiHandler) createUser(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 		return
 	}
+	if err := h.notifyPeersOfChange(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusCreated, user)
 }
 
@@ -1654,6 +1670,10 @@ func (h *apiHandler) updateUser(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
 	}
+	if err := h.notifyPeersOfChange(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, user)
 }
 
@@ -1669,7 +1689,44 @@ func (h *apiHandler) deleteUser(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
 	}
+	if err := h.notifyPeersOfChange(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"deleted": username})
+}
+
+// notifyPeersOfChange reloads THIS replica's config snapshot immediately
+// (bypassing the poll interval, default 30s) and fans the same reload out to
+// every other CP replica, mirroring the disable/enable reload pattern in
+// live.go. Unlike disable/enable, the write has already landed in the shared
+// config-store DB by the time this runs, so a peer only needs to reload — it
+// must never re-run the create/update/delete (that would 409 or double-apply
+// against a row that's already there). Peer fan-out is best-effort: PostPeers
+// already drops a slow/down peer without error, so only a failure to reload
+// THIS replica is surfaced to the caller.
+func (h *apiHandler) notifyPeersOfChange(c *gin.Context) error {
+	if err := h.store.ReloadSnapshot(); err != nil {
+		return err
+	}
+	if h.fetcher != nil {
+		h.fetcher.PostPeers(c.Request.Context(), "/api/v1/internal/reload-snapshot")
+	}
+	return nil
+}
+
+// reloadSnapshot is a peer-fan-out target only (see notifyPeersOfChange): it
+// forces this replica's config snapshot to reload immediately. There is
+// nothing to re-execute here — the write already landed in the shared
+// config-store DB — so unlike the per-user kill-switch actions this handler
+// has no scope=local branch to guard: it never calls PostPeers itself, so it
+// cannot recurse regardless of who calls it.
+func (h *apiHandler) reloadSnapshot(c *gin.Context) {
+	if err := h.store.ReloadSnapshot(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"reloaded": true})
 }
 
 // --- Workers ---

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -31,6 +31,8 @@ type fakeAPIStore struct {
 	// teamBillingRepoints records every billing repoint requested through
 	// UpdateOrgTeam (usage re-attribution rides along in the real store).
 	teamBillingRepoints []fakeReattributeCall
+	reloadSnapshotCalls int
+	reloadSnapshotErr   error
 }
 
 type fakeReattributeCall struct {
@@ -259,6 +261,11 @@ func (s *fakeAPIStore) DeleteUser(orgID, username string) (bool, error) {
 	return true, nil
 }
 
+func (s *fakeAPIStore) ReloadSnapshot() error {
+	s.reloadSnapshotCalls++
+	return s.reloadSnapshotErr
+}
+
 func (s *fakeAPIStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error) {
 	warehouse, ok := s.warehouses[orgID]
 	if !ok {
@@ -325,6 +332,15 @@ func newTestAPIRouter(store apiStore) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	registerAPIWithStore(r.Group("/api/v1"), store, nil, nil)
+	return r
+}
+
+// newTestAPIRouterWithFetcher is newTestAPIRouter plus a PeerFetcher, for
+// tests asserting the create/update/delete user reload + peer fan-out.
+func newTestAPIRouterWithFetcher(store apiStore, fetcher PeerFetcher) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerAPIWithStore(r.Group("/api/v1"), store, nil, fetcher)
 	return r
 }
 
@@ -598,6 +614,153 @@ func TestUpdateUserIgnoresRemovedDefaultCatalogField(t *testing.T) {
 	}
 	if bytes.Contains(rec.Body.Bytes(), []byte("default_catalog")) {
 		t.Fatalf("response must not echo removed default_catalog field: %s", rec.Body.String())
+	}
+}
+
+// TestUserCRUDReloadsSnapshotAndNotifiesPeers covers create/update/delete: each
+// must reload THIS replica's snapshot immediately (bypassing the poll
+// interval) and fan the same reload out to every other CP replica, mirroring
+// the disable/enable reload pattern — so a freshly created/updated/deleted
+// user is authable cluster-wide right away instead of on each replica's next
+// poll tick.
+func TestUserCRUDReloadsSnapshotAndNotifiesPeers(t *testing.T) {
+	const reloadPath = "/api/v1/internal/reload-snapshot"
+
+	cases := []struct {
+		name    string
+		method  string
+		path    string
+		body    string
+		preseed bool // seed an existing "analytics/reader" row before the request
+	}{
+		{"create", http.MethodPost, "/api/v1/users", `{"org_id":"analytics","username":"reader","password":"secret"}`, false},
+		{"update", http.MethodPut, "/api/v1/orgs/analytics/users/reader", `{"passthrough":true}`, true},
+		{"delete", http.MethodDelete, "/api/v1/orgs/analytics/users/reader", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAPIStore()
+			if tc.preseed {
+				store.users["analytics/reader"] = &configstore.OrgUser{OrgID: "analytics", Username: "reader", Password: "hash"}
+			}
+			fetcher := &fakePeerFetcher{}
+			router := newTestAPIRouterWithFetcher(store, fetcher)
+
+			var body *bytes.Reader
+			if tc.body != "" {
+				body = bytes.NewReader([]byte(tc.body))
+			} else {
+				body = bytes.NewReader(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code < 200 || rec.Code >= 300 {
+				t.Fatalf("status = %d, want 2xx: %s", rec.Code, rec.Body.String())
+			}
+			if store.reloadSnapshotCalls != 1 {
+				t.Fatalf("reloadSnapshotCalls = %d, want 1", store.reloadSnapshotCalls)
+			}
+			if got := fetcher.postCallCount(); got != 1 {
+				t.Fatalf("peer fan-out POSTs = %d, want 1", got)
+			}
+			fetcher.mu.Lock()
+			paths := append([]string(nil), fetcher.postPaths...)
+			fetcher.mu.Unlock()
+			if len(paths) != 1 || paths[0] != reloadPath {
+				t.Fatalf("peer fan-out path = %v, want [%s]", paths, reloadPath)
+			}
+		})
+	}
+}
+
+// TestUserCRUDSkipsPeerFanOutWithoutFetcher: a single-CP deployment (no
+// PeerFetcher wired) must still reload locally and must not panic.
+func TestUserCRUDSkipsPeerFanOutWithoutFetcher(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"org_id":"analytics","username":"reader","password":"secret"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if store.reloadSnapshotCalls != 1 {
+		t.Fatalf("reloadSnapshotCalls = %d, want 1", store.reloadSnapshotCalls)
+	}
+}
+
+// TestUserCRUDPeerFanOutIsBestEffort: the DB write must succeed even when no
+// peer answers the fan-out (PostPeers already degrades gracefully — this just
+// proves the handler doesn't treat an empty peer response as an error).
+func TestUserCRUDPeerFanOutIsBestEffort(t *testing.T) {
+	store := newFakeAPIStore()
+	fetcher := &fakePeerFetcher{} // no bodies configured for any path
+	router := newTestAPIRouterWithFetcher(store, fetcher)
+
+	body := []byte(`{"org_id":"analytics","username":"reader","password":"secret"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if store.users["analytics/reader"] == nil {
+		t.Fatal("expected user to be created despite no peer responding")
+	}
+}
+
+// TestUserCRUDReturnsErrorWhenLocalReloadFails: mirrors disable/enable — a
+// failed LOCAL reload surfaces as a request error even though the write
+// already landed (the caller needs to know the change may not be immediately
+// visible on this replica).
+func TestUserCRUDReturnsErrorWhenLocalReloadFails(t *testing.T) {
+	store := newFakeAPIStore()
+	store.reloadSnapshotErr = errors.New("reload failed")
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"org_id":"analytics","username":"reader","password":"secret"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if store.users["analytics/reader"] == nil {
+		t.Fatal("expected the user row to still be created even though the reload response errored")
+	}
+}
+
+// TestReloadSnapshotEndpoint covers the peer-fan-out target itself: it reloads
+// and returns 200, or surfaces a reload error as 500.
+func TestReloadSnapshotEndpoint(t *testing.T) {
+	store := newFakeAPIStore()
+	router := newTestAPIRouter(store)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/internal/reload-snapshot", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if store.reloadSnapshotCalls != 1 {
+		t.Fatalf("reloadSnapshotCalls = %d, want 1", store.reloadSnapshotCalls)
+	}
+
+	store.reloadSnapshotErr = errors.New("boom")
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/internal/reload-snapshot", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

User create, update, and delete operations write the shared config store but previously waited for each control-plane replica to poll before the change affected authentication.

## Changes

After a successful mutation, the handler reloads the local snapshot and sends a reload-only notification to peer control planes. Peers do not repeat the mutation, and peer notification remains best-effort. A failed local reload is surfaced to the caller.

This is stacked on #970 and is the base for #971.

## Tests

- golangci-lint: passed.
- Focused Kubernetes-tagged user CRUD, peer reload, and snapshot endpoint tests: passed.
- GitHub lint and unit tests: passed; remaining integration checks are running.

Human-directed, agent-assisted implementation.