### PR TITLE
e2e: per-run external metadata database on the shared RDS

### DIFF
--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -61,6 +62,13 @@ type ReshardRunner struct {
 	// loopPoll is the inner-loop poll cadence (drain checks, flip waits,
 	// cancel checks). 5s in production; tests shrink it.
 	loopPoll time.Duration
+	// progressLogInterval is how often a wait loop (drain, flip converge,
+	// orphan-policy wait, recovery) writes what it currently observes to the
+	// op log. 15s in production; tests shrink it. Every wait loop MUST emit
+	// periodic observations at this cadence — a silent multi-minute poll loop
+	// is undebuggable from the op log (the mw-dev recovery that spun for ~8
+	// minutes on SASL auth failures with zero diagnostics).
+	progressLogInterval time.Duration
 
 	// extPasswords holds the EPHEMERAL external passwords by op id: the
 	// cnpg→ext target password (pulled from the creating CP replica's stash
@@ -124,18 +132,57 @@ func NewReshardRunner(store *configstore.ConfigStore, duckling *DucklingClient, 
 		}
 	}
 	return &ReshardRunner{
-		store:              store,
-		duckling:           duckling,
-		copier:             PGCatalogCopier{},
-		backuper:           backuper,
-		cpID:               cpID,
-		configPollInterval: configPollInterval,
-		heartbeatInterval:  30 * time.Second,
-		staleAfter:         5 * time.Minute,
-		flipTimeout:        flipTimeout,
-		hotIdleGrace:       30 * time.Second,
-		loopPoll:           5 * time.Second,
+		store:               store,
+		duckling:            duckling,
+		copier:              PGCatalogCopier{},
+		backuper:            backuper,
+		cpID:                cpID,
+		configPollInterval:  configPollInterval,
+		heartbeatInterval:   30 * time.Second,
+		staleAfter:          5 * time.Minute,
+		flipTimeout:         flipTimeout,
+		hotIdleGrace:        30 * time.Second,
+		loopPoll:            5 * time.Second,
+		progressLogInterval: 15 * time.Second,
 	}
+}
+
+// isAuthProbeError reports whether a catalog-probe failure is an
+// authentication failure: SQLSTATE 28P01 (invalid_password) / 28000
+// (invalid_authorization_specification), or the "SASL authentication failed" /
+// "password authentication failed" server messages (pgbouncer/poolers vary in
+// which they emit). pgx surfaces these as a *pgconn.PgError inside the connect
+// error chain; the string match covers errors that arrive pre-flattened.
+func isAuthProbeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && (pgErr.Code == "28P01" || pgErr.Code == "28000") {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "sasl authentication failed") ||
+		strings.Contains(msg, "password authentication failed")
+}
+
+// describeProbeFailure renders a tenant-role probe failure for the op log.
+// Authentication failures are named explicitly, with the operator remedy: the
+// role's ACTUAL Postgres password differing from the freshly published status
+// password (a stranded password — e.g. a re-adopted role whose status password
+// the composition regenerated) is effectively permanent, and retrying to the
+// timeout cannot fix it by itself. We keep polling anyway (a composition fix
+// can converge the password mid-wait, and bailing early would leave the org
+// worse off), but the log must tell the operator what to do.
+//
+// Safe to log verbatim: Probe wraps the endpoint via CatalogEndpoint.Redacted()
+// (password elided) and pgx's ConnectError/PgError texts carry user/database
+// but never the password.
+func describeProbeFailure(err error, role string) string {
+	if !isAuthProbeError(err) {
+		return fmt.Sprintf("tenant-role probe failing: %v", err)
+	}
+	return fmt.Sprintf("tenant-role probe failing with an AUTHENTICATION error: %v — the role's actual Postgres password likely differs from the published status password (stranded password). If this persists, align it manually on the shard primary: ALTER ROLE %s WITH PASSWORD '<status password>' (take the password from the duckling CR status — it is never logged here)", err, role)
 }
 
 // StashExternalPassword hands the runner the ephemeral external-target
@@ -587,7 +634,7 @@ func (o *opRun) drain(ctx context.Context) error {
 			return nil
 		}
 
-		if time.Since(lastLog) >= 15*time.Second {
+		if time.Since(lastLog) >= o.r.progressLogInterval {
 			o.logf("info", "waiting for connections to drain: %d active sessions, %d queued connections, %d live workers",
 				conns.ActiveLeases, conns.QueuedConns, len(workers))
 			lastLog = time.Now()
@@ -806,8 +853,10 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 	o.flipped = true
 
 	targetPrefix := o.op.ToShard + "-pooler."
+	o.logf("info", "cutover patch applied; waiting up to %s for the composition to converge on %s* and the tenant role to answer", o.flipTimeout(), targetPrefix)
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -816,7 +865,7 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 			return errReshardCancelled
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("target shard %s did not become ready within %s", o.op.ToShard, o.flipTimeout())
+			return fmt.Errorf("target shard %s did not become ready within %s; last observation: %s", o.op.ToShard, o.flipTimeout(), lastObserved)
 		}
 
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
@@ -826,22 +875,24 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
 				SSLMode: "disable",
 			}
-			if probeErr := o.r.copier.Probe(ctx, o.target); probeErr == nil {
+			probeErr := o.r.copier.Probe(ctx, o.target)
+			if probeErr == nil {
 				o.logf("info", "target ready: duckling converged on %s and the tenant role answers", st.MetadataStore.Endpoint)
 				return nil
-			} else if time.Since(lastLog) >= 15*time.Second {
-				o.logf("info", "waiting for target: composition converged, probe still failing: %v", probeErr)
-				lastLog = time.Now()
 			}
-		} else if time.Since(lastLog) >= 15*time.Second {
+			lastObserved = "composition converged, " + describeProbeFailure(probeErr, st.MetadataStore.User)
+		} else {
 			switch {
 			case err != nil:
-				o.logf("info", "waiting for target: reading duckling failed: %v", err)
+				lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
 			case st.SyncedFalseMessage != "":
-				o.logf("info", "waiting for target: duckling Synced=False: %s", st.SyncedFalseMessage)
+				lastObserved = "duckling Synced=False: " + st.SyncedFalseMessage
 			default:
-				o.logf("info", "waiting for target: duckling endpoint %q, ready=%t", st.MetadataStore.Endpoint, st.ReadyCondition)
+				lastObserved = fmt.Sprintf("duckling endpoint %q, ready=%t", st.MetadataStore.Endpoint, st.ReadyCondition)
 			}
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "waiting for target: %s", lastObserved)
 			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
@@ -914,7 +965,7 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 		default:
 			lastObserved = detail
 		}
-		if time.Since(lastLog) >= 15*time.Second {
+		if time.Since(lastLog) >= o.r.progressLogInterval {
 			o.logf("info", "waiting for the cnpg source MRs to reflect the retain (no-Delete) policy: %s", lastObserved)
 			lastLog = time.Now()
 		}
@@ -943,8 +994,10 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 	o.flipped = true
 
 	providedPassword := o.target.Password
+	o.logf("info", "cutover patch applied; waiting up to %s for the external target (ESO password sync + Ready condition)", o.flipTimeout())
 	deadline := time.Now().Add(o.flipTimeout())
 	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -952,13 +1005,14 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 		// No cancel check: past this flip the only ways out are forward or
 		// the orphan-adopt recovery in rollback().
 		if time.Now().After(deadline) {
-			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string)", o.flipTimeout(), o.op.TargetPasswordSecret)
+			return fmt.Errorf("external target did not become ready within %s (ESO secret %q missing, unreadable, or wrong? the ESO role can only read allowed secret NAME patterns — e.g. duckling-*/posthog-* — and the value must be the raw password string); last observation: %s", o.flipTimeout(), o.op.TargetPasswordSecret, lastObserved)
 		}
 
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
 		switch {
 		case err != nil:
 			// transient — keep polling
+			lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
 		case st.MetadataStore.Type == configstore.MetadataStoreKindExternal && st.MetadataStore.Password != "":
 			if st.MetadataStore.Password != providedPassword {
 				return fmt.Errorf("ESO-synced password from secret %q does not match the password the catalog was copied with — fix the secret and re-run", o.op.TargetPasswordSecret)
@@ -967,13 +1021,15 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 				o.logf("info", "external target ready: ESO password synced and matches, duckling Ready")
 				return nil
 			}
+			lastObserved = "ESO password synced and matches, but the duckling is not Ready yet"
+		default:
+			lastObserved = fmt.Sprintf("duckling type %q, ESO password synced=%t, ready=%t", st.MetadataStore.Type, st.MetadataStore.Password != "", st.ReadyCondition)
 		}
-		if time.Since(lastLog) >= 15*time.Second {
-			msg := "waiting for external target (ESO password sync + Ready condition)"
-			if err == nil && st.SyncedFalseMessage != "" {
-				msg += ": " + st.SyncedFalseMessage
-			}
-			o.logf("info", "%s", msg)
+		if err == nil && st.SyncedFalseMessage != "" {
+			lastObserved += "; duckling Synced=False: " + st.SyncedFalseMessage
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "waiting for external target (ESO password sync + Ready condition): %s", lastObserved)
 			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
@@ -1319,25 +1375,51 @@ func (o *opRun) recoverFromExternal(ctx context.Context) {
 	}
 
 	// Wait for the composition to re-adopt the role/DB on the source shard and
-	// the tenant role to answer again.
+	// the tenant role to answer again. NEVER silently: this loop logs what it
+	// observes every progressLogInterval — a recovery that spins on a failing
+	// probe (e.g. SASL auth failures from a stranded re-adopted-role password,
+	// the mw-dev incident) must be diagnosable from the op log alone, and the
+	// terminal timeout line must carry the last observation (the root cause).
+	// An auth probe failure is effectively permanent, but we still poll to the
+	// deadline rather than bail: a charts/composition fix can converge the
+	// password mid-wait, and giving up early would leave the org worse off.
 	sourcePrefix := o.op.FromShard + "-pooler."
+	o.logf("info", "recovery: waiting up to %s for the composition to re-adopt the cnpg role/DB on %s* and for the tenant role to answer", o.flipTimeout(), sourcePrefix)
 	deadline := time.Now().Add(o.flipTimeout())
+	lastLog := time.Time{}
+	lastObserved := "no successful duckling read yet"
 	for {
 		if time.Now().After(deadline) {
-			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s)", o.flipTimeout(), o.op.FromShard)
+			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", o.flipTimeout(), o.op.FromShard, lastObserved)
 			return
 		}
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
-		if err == nil && strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) && st.ReadyCondition {
+		switch {
+		case err != nil:
+			lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
+		case !strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) || !st.ReadyCondition:
+			lastObserved = fmt.Sprintf("duckling endpoint %q, ready=%t (waiting for %s*)", st.MetadataStore.Endpoint, st.ReadyCondition, sourcePrefix)
+			if st.SyncedFalseMessage != "" {
+				lastObserved += "; duckling Synced=False: " + st.SyncedFalseMessage
+			}
+		default:
 			restored := CatalogEndpoint{
 				Host: st.MetadataStore.Endpoint, Port: 5432,
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
 				SSLMode: "disable",
 			}
-			if o.r.copier.Probe(ctx, restored) == nil {
+			probeErr := o.r.copier.Probe(ctx, restored)
+			if probeErr == nil {
 				o.logf("info", "recovery complete: duckling re-adopted the orphaned cnpg role/DB on %s and the tenant role answers — no data was copied back (the catalog never left the source)", o.op.FromShard)
 				return
 			}
+			// describeProbeFailure names an auth failure explicitly (stranded
+			// re-adopted-role password) with the manual ALTER ROLE remedy.
+			lastObserved = "duckling converged on " + st.MetadataStore.Endpoint + " (Ready), " + describeProbeFailure(probeErr, st.MetadataStore.User)
+		}
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "recovery: waiting for the source shard: %s", lastObserved)
+			lastLog = time.Now()
 		}
 		time.Sleep(o.r.loopPoll)
 	}

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -188,6 +190,18 @@ func (f *fakeReshardStore) hasLog(substr string) bool {
 	return f.countLog(substr) > 0
 }
 
+// findLog returns the first op-log line containing substr ("" if none).
+func (f *fakeReshardStore) findLog(substr string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, l := range f.logs {
+		if strings.Contains(l, substr) {
+			return l
+		}
+	}
+	return ""
+}
+
 func (f *fakeReshardStore) countLog(substr string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -356,6 +370,10 @@ type fakeCopier struct {
 
 	copyResult CatalogCopyResult
 	copyErr    error
+	// probeFn, when set, decides each Probe's result (nil = all probes
+	// succeed). It sees the probed endpoint so tests can fail e.g. only the
+	// post-flip-back recovery probe.
+	probeFn func(ep CatalogEndpoint) error
 	// countsAfter is what SnapshotCounts returns for the SOURCE stability
 	// recheck (sslmode!=require); defaults to copyResult.PerTableRows (stable).
 	countsAfter map[string]int64
@@ -373,6 +391,12 @@ func (f *fakeCopier) record(c copierCall) {
 
 func (f *fakeCopier) Probe(_ context.Context, ep CatalogEndpoint) error {
 	f.record(copierCall{kind: "probe", target: ep})
+	f.mu.Lock()
+	fn := f.probeFn
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(ep)
+	}
 	return nil
 }
 
@@ -472,6 +496,9 @@ func testRunner(store *fakeReshardStore, duckling reshardDucklingClient, copier 
 		flipTimeout:        2 * time.Second,
 		hotIdleGrace:       time.Millisecond,
 		loopPoll:           5 * time.Millisecond,
+		// Shrunk so tests observe the periodic wait-loop observations (15s in
+		// production, > any test's whole runtime).
+		progressLogInterval: 15 * time.Millisecond,
 	}
 }
 
@@ -757,6 +784,10 @@ func TestReshardFlipTimeoutRollsBackShardValue(t *testing.T) {
 
 	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "did not become ready") {
 		t.Fatalf("state=%s err=%q, want flip-timeout failure", store.op.State, store.op.Error)
+	}
+	// The timeout error carries the last converge observation (root cause).
+	if !strings.Contains(store.op.Error, "last observation:") {
+		t.Fatalf("flip-timeout error lacks the last observation: %q", store.op.Error)
 	}
 	// Last cnpg patch must be the flip-back to the source shard value.
 	var shardPatches []string
@@ -1062,6 +1093,11 @@ func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 	}
 	if !store.hasLog("waiting for external target") {
 		t.Fatalf("generic waiting line missing: %v", store.logs)
+	}
+	// The timeout error carries the last observed duckling state (root cause).
+	if !strings.Contains(store.op.Error, "last observation:") ||
+		!strings.Contains(store.op.Error, "ESO password synced=false") {
+		t.Fatalf("flip-timeout error lacks the last ESO/Ready observation: %q", store.op.Error)
 	}
 	// Recovery is flip-back + adopt (SetMetadataStoreCnpgAdopt), never copy-back.
 	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
@@ -1433,5 +1469,134 @@ func TestReshardVerifyMismatchRollsBack(t *testing.T) {
 	}
 	if store.warehouseState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("warehouse state = %s, want ready after rollback", store.warehouseState)
+	}
+}
+
+// TestProbeErrorAuthClassification pins isAuthProbeError/describeProbeFailure
+// against errors shaped the way catalog_copy.go::Probe actually wraps them
+// (`connect <redacted>: %w` / `probe <redacted>: %w` around pgx errors, whose
+// chain carries a *pgconn.PgError for server-side auth failures).
+func TestProbeErrorAuthClassification(t *testing.T) {
+	saslPgErr := &pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: "SASL authentication failed"}
+	pwPgErr := &pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: `password authentication failed for user "mdstore_org"`}
+	authSpecErr := &pgconn.PgError{Severity: "FATAL", Code: "28000", Message: `no pg_hba.conf entry for host "10.0.0.1"`}
+
+	auth := []error{
+		// Wrapped the way Probe wraps a pgx connect failure (the mw-dev
+		// incident shape: pooler answered FATAL: SASL authentication failed).
+		fmt.Errorf("connect host=shard-001-pooler user=mdstore_org: failed to connect to `user=mdstore_org database=mdstore_org`: server error: %w", saslPgErr),
+		fmt.Errorf("probe host=shard-001-pooler user=mdstore_org: %w", pwPgErr),
+		fmt.Errorf("connect host=x user=y: %w", authSpecErr),
+		// Pre-flattened text (no PgError left in the chain).
+		errors.New("connect host=x user=y: FATAL: SASL authentication failed (SQLSTATE 28P01)"),
+		errors.New("failed to connect: password authentication failed for user \"mdstore_org\""),
+	}
+	for _, err := range auth {
+		if !isAuthProbeError(err) {
+			t.Errorf("isAuthProbeError(%v) = false, want true", err)
+		}
+		got := describeProbeFailure(err, "mdstore_org")
+		if !strings.Contains(got, "AUTHENTICATION error") ||
+			!strings.Contains(got, "stranded password") ||
+			!strings.Contains(got, "ALTER ROLE mdstore_org WITH PASSWORD") {
+			t.Errorf("describeProbeFailure(%v) lacks the named condition + operator remedy: %q", err, got)
+		}
+		if strings.Contains(got, "'pinned-pw'") {
+			t.Errorf("describeProbeFailure must never embed a password: %q", got)
+		}
+	}
+
+	notAuth := []error{
+		errors.New("connect host=x user=y: dial tcp 10.0.0.1:5432: connect: connection refused"),
+		context.DeadlineExceeded,
+		fmt.Errorf("probe host=x user=y: %w", &pgconn.PgError{Severity: "FATAL", Code: "57P03", Message: "the database system is starting up"}),
+	}
+	for _, err := range notAuth {
+		if isAuthProbeError(err) {
+			t.Errorf("isAuthProbeError(%v) = true, want false", err)
+		}
+		if got := describeProbeFailure(err, "mdstore_org"); strings.Contains(got, "AUTHENTICATION") {
+			t.Errorf("describeProbeFailure(%v) misclassified as auth: %q", err, got)
+		}
+	}
+}
+
+// TestReshardExtRecoveryProbeAuthFailureDiagnosed is the regression for the
+// mw-dev incident where the cnpg→ext post-flip recovery spun silently for ~8
+// minutes on `FATAL: SASL authentication failed` (the re-adopted role's actual
+// password differed from the freshly regenerated status password) and the
+// operator had to reproduce the probe from a shell to see why. The recovery
+// wait must (a) announce its deadline, (b) periodically log the classified
+// probe failure naming the stranded-password condition + the manual ALTER ROLE
+// remedy, and (c) end with a timeout line carrying that last observation —
+// all without ever logging a password.
+func TestReshardExtRecoveryProbeAuthFailureDiagnosed(t *testing.T) {
+	store := newFakeReshardStore(stuckExtOp())
+	duckling := &stuckExternalDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	// The forward copy pre-flight probes the cnpg source once (must succeed so
+	// the op reaches the flip); every LATER probe of the cnpg endpoint is the
+	// recovery loop re-probing the re-adopted role — those fail with the
+	// incident-shaped SASL error, persistently (stranded password).
+	saslErr := fmt.Errorf("connect host=shard-001-pooler user=mdstore_org: failed to connect to `user=mdstore_org database=mdstore_org`: server error: %w",
+		&pgconn.PgError{Severity: "FATAL", Code: "28P01", Message: "SASL authentication failed"})
+	var cnpgProbes atomic.Int32
+	copier.probeFn = func(ep CatalogEndpoint) error {
+		if ep.SSLMode != "disable" {
+			return nil // external target pre-flight
+		}
+		if cnpgProbes.Add(1) == 1 {
+			return nil // forward-copy source pre-flight
+		}
+		return saslErr
+	}
+
+	r := testRunner(store, duckling, copier)
+	r.StashExternalPassword(store.op.ID, "ext-pw")
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state=%s err=%q, want failed", store.op.State, store.op.Error)
+	}
+	// (a) The recovery wait announces itself with its deadline.
+	if !store.hasLog("recovery: waiting up to") {
+		t.Fatalf("recovery deadline announce missing: %v", store.logs)
+	}
+	// (b) Periodic observations name the auth failure + operator remedy.
+	if n := store.countLog("AUTHENTICATION error"); n < 2 {
+		t.Fatalf("want >=2 periodic auth-failure observations, got %d: %v", n, store.logs)
+	}
+	if !store.hasLog("stranded password") || !store.hasLog("ALTER ROLE mdstore_org WITH PASSWORD") {
+		t.Fatalf("stranded-password condition/remedy missing from the periodic observations: %v", store.logs)
+	}
+	// (c) The terminal recovery-timeout line carries the last observation.
+	terminal := store.findLog("recovery: source shard did not become ready within")
+	if terminal == "" {
+		t.Fatalf("recovery timeout line missing: %v", store.logs)
+	}
+	if !strings.Contains(terminal, "last observation:") ||
+		!strings.Contains(terminal, "SASL authentication failed") ||
+		!strings.Contains(terminal, "AUTHENTICATION error") {
+		t.Fatalf("recovery timeout line lacks the classified root cause: %q", terminal)
+	}
+	// Never a password in the op log — neither the pinned cnpg password nor
+	// the ephemeral external one.
+	store.mu.Lock()
+	logs := append([]string(nil), store.logs...)
+	store.mu.Unlock()
+	for _, l := range logs {
+		if strings.Contains(l, "pinned-pw") || strings.Contains(l, "ext-pw") {
+			t.Fatalf("op log leaked a password: %q", l)
+		}
+	}
+	// The recovery still ran to its normal conclusion: flip-back + adopt,
+	// warehouse unblocked (auth failures do NOT abort the wait early — a
+	// composition fix may still converge the password mid-wait).
+	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
+		t.Fatalf("recovery did not flip back + adopt: %v", duckling.callKinds())
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
 	}
 }

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -405,6 +405,21 @@ recovery (which stranded the tenant with an empty catalog when the copy-back
 also failed, the prod-shaped data-loss incident this change fixes) and avoids
 the `2BP01` "role can't drop while its DB exists" wedge the coupled delete hit.
 
+Every wait loop in the runner (drain, flip converge, orphan-policy wait, this
+recovery) announces its deadline on entry and logs what it observes every ~15s
+(duckling endpoint/Ready state, classified probe errors), and its timeout
+error/log line carries the LAST observation — a stuck reshard is diagnosable
+from the op log alone. One recovery failure mode deserves naming: the
+re-adopted role's ACTUAL Postgres password can differ from the freshly
+regenerated status password (a **stranded password** — the probe fails with
+`FATAL: SASL authentication failed` / SQLSTATE 28P01 until the composition
+converges the password). The runner classifies auth probe failures
+(`isAuthProbeError`) and the observation names the condition and the manual
+remedy — `ALTER ROLE <role> WITH PASSWORD '<status password>'` on the source
+shard primary — but it still polls to the deadline rather than bailing early,
+since a charts/composition fix can converge the password mid-wait. Passwords
+never appear in the op log.
+
 ## Rollback, cancel, crash-safety
 
 - Rollback never removes `spec.metadataStore.cnpgShard` — it patches the

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -257,6 +257,20 @@ erase provisioned org rows. Everything PR-specific lives in the namespace and
 is deleted; the shared-infra footprint is removed by deprovisioning the
 ducklings first.
 
+The ext org's metadata store is a **per-run database** on the shared RDS
+(`mdstore_e2e_<utc-ts>_pr<pr>`), not a shared one: a shared database's
+DuckLake catalog grows monotonically across runs (20k+ `ducklake_*` tables
+observed), inflating every catalog copy and exposing runs to each other's
+writers. The harness creates it once its own duckling status carries the
+ESO-synced RDS password (`ext_rds_setup`, concurrent with the readiness
+waits — the CP's provisioning probe retries until the database exists), drops
+it at the end of a passing run (`ext_rds_teardown`), and GCs databases leaked
+by aborted runs (name-gated, >24h old) at the start of every run. The runner
+side (`run.sh` teardown / `e2e-cleanup`) cannot drop them — no psql and no
+path to the RDS password — so the next run's GC is the backstop. The RDS
+user/secret are unchanged; only the database is per-run, and nothing outside
+`mdstore_e2e_*` is ever touched.
+
 Each deploy first reaps any existing resources for the same PR number (namespace,
 Duckling CRs, pod identity association, cross-namespace bindings, and cnpg role).
 It fails before applying manifests if the same-PR Duckling CRs do not fully

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2236,7 +2236,13 @@ duckling_shard_backfill() { # cnpgOrg
 #     connections are 57P03-blocked; cancel rolls back; org healthy)
 #   * bogus-shard rollback (flip → Synced=False → flip-timeout → rollback;
 #     data intact, spec.cnpgShard patched back; short per-op
-#     cutover_timeout_seconds keeps it fast)
+#     cutover_timeout_seconds keeps it fast). Also asserts the wait-loop
+#     diagnostics: deadline announce, periodic "waiting for target"
+#     observations, and the flip-timeout error carrying the last observation.
+#     (The cnpg→ext RECOVERY loop's stranded-password/SASL classification
+#     can't be provoked here — it needs a role whose actual password diverged
+#     from the status password — so that path is pinned by
+#     provisioner/reshard_runner_test.go instead.)
 #   * ext→cnpg POSITIVE path (real catalog copy off the harness RDS onto
 #     shard-001, data intact after, report in the log) — including the pod
 #     model: every reshard executes in a dedicated duckgres-reshard-op-<id>
@@ -2435,6 +2441,13 @@ reshard_bogus_shard_rollback() { # org password
   [ "$st" = "failed" ] || { reshard_dump_log "$opid"; fail "reshard rollback: final state $st, want failed"; }
   reshard_log_has "$opid" "rolling back" || fail "reshard rollback: no rollback log"
   reshard_log_has "$opid" "reshard report (failed)" || fail "reshard rollback: report missing"
+  # Wait-loop diagnostics: the converge wait announces its deadline, logs what
+  # it observes every ~15s, and the flip-timeout failure carries the LAST
+  # observation — a stuck cutover must be diagnosable from the op log alone
+  # (the mw-dev recovery that spun ~8 min on silent SASL probe failures).
+  reshard_log_has "$opid" "cutover patch applied; waiting up to" || { reshard_dump_log "$opid"; fail "reshard rollback: converge-wait deadline announce missing"; }
+  reshard_log_has "$opid" "waiting for target:" || { reshard_dump_log "$opid"; fail "reshard rollback: periodic converge observations missing"; }
+  reshard_log_has "$opid" "last observation:" || { reshard_dump_log "$opid"; fail "reshard rollback: flip-timeout error lacks the last observation"; }
 
   # The duckling spec must be back on the real shard (the rollback patches the
   # VALUE back — it never removes the key).

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -120,6 +120,20 @@ EXPECT_HTTPFS_SHA="0dac6fc"
 # manual validation used). Endpoint is stable in mw-dev.
 EXT_RDS_ENDPOINT="duckling-example-managed-warehouse-dev-us-east-1.c8jy2c68kipq.us-east-1.rds.amazonaws.com"
 EXT_RDS_SECRET="duckling-example-managed-warehouse-dev-us-east-1-rds-password"
+EXT_RDS_USER="ducklingexample"
+# Per-run metadata DATABASE on that shared RDS. Every run used to point its
+# ext org at the one shared database, whose DuckLake catalog therefore grew
+# monotonically across runs (20k+ ducklake_* tables observed) — inflating
+# every catalog copy (the reshard ext→cnpg lane went to ~6 min / ~95MB) and
+# exposing runs to each other's writers. Instead each run CREATEs its own
+# database (ext_rds_setup, once the run's own duckling status carries the
+# ESO-synced RDS password) and DROPs it at the end (ext_rds_teardown); the
+# name embeds a UTC timestamp so ext_rds_setup can also GC databases leaked
+# by aborted runs (>24h old). The RDS user/password/secret are unchanged —
+# only the database is per-run. run.sh teardown cannot do this drop itself
+# (the GitHub runner has neither psql nor any path to the RDS password), so
+# crash-leaked databases are reaped by the NEXT run's GC instead.
+EXT_RDS_DB="mdstore_e2e_$(date -u +%Y%m%d%H%M%S)_pr$(printf %s "${PR_NUMBER:-0}" | tr -cd 'a-z0-9')"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -180,6 +194,86 @@ provision() { # org metadata_json
   log "provision $1"
   curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' -d "$2" \
     "$API/api/v1/orgs/$1/provision"
+}
+
+# ---- per-run external metadata database (see EXT_RDS_DB above) --------------
+# rds_psql runs one statement against the shared RDS as the shared tenant user.
+# It anchors the session on the long-lived legacy database (connect only —
+# never written) because CREATE/DROP DATABASE cannot run against the database
+# being created/dropped. EXT_RDS_PW must be set (ext_rds_setup below).
+rds_psql() { # sql
+  PGPASSWORD="$EXT_RDS_PW" psql \
+    "host=$EXT_RDS_ENDPOINT port=5432 user=$EXT_RDS_USER dbname=$EXT_RDS_USER sslmode=require connect_timeout=10" \
+    -v ON_ERROR_STOP=1 -qtA -c "$1"
+}
+
+# ext_rds_setup creates this run's metadata database and GCs databases leaked
+# by aborted runs. It needs the RDS password, which the harness obtains
+# in-cluster from its OWN ext duckling's CR status (status.metadataStore
+# .password, the ESO-synced value — the same shared-user password every run
+# uses; the harness SA already has cross-namespace duckling read RBAC). That
+# status field only exists once the composition has synced the secret, so this
+# runs as a lane CONCURRENT with the readiness waits: the CP's end-to-end
+# provisioning probe (controller.go reconcileProvisioning) targets the per-run
+# database and simply retries until we create it — never terminal before the
+# CP's 30-minute provisioning timeout — so ready_ext flips shortly after the
+# CREATE DATABASE lands. Requires bootstrap_kubectl to have completed in the
+# MAIN shell first (the lane subshell must not race the background download).
+ext_rds_setup() {
+  d="$(echo "$EXT" | tr 'A-Z' 'a-z')"
+  log "ext metadata db: waiting for the ESO-synced RDS password on duckling/${d}…"
+  deadline=$(( $(date +%s) + 300 ))
+  EXT_RDS_PW=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    EXT_RDS_PW="$("$KUBECTL" -n ducklings get "duckling/$d" -o jsonpath='{.status.metadataStore.password}' 2>/dev/null || true)"
+    [ -n "$EXT_RDS_PW" ] && break
+    sleep 5
+  done
+  [ -n "$EXT_RDS_PW" ] || fail "ext metadata db: duckling/$d never published status.metadataStore.password (ESO sync stuck?)"
+  # Stash for ext_rds_teardown: this runs in a lane subshell, so a shell var
+  # would not survive back to main() (same pattern as the prov_*.json files).
+  printf %s "$EXT_RDS_PW" > "$LANE_DIR/ext_rds_pw"
+
+  # GC databases leaked by aborted runs: strictly name-gated (full per-run
+  # pattern with a parseable 14-digit UTC timestamp) and >24h old, so a
+  # concurrent run on another PR can never lose its live database and nothing
+  # outside the mdstore_e2e_* namespace is ever touched.
+  cutoff="$(python3 -c 'from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)-timedelta(hours=24)).strftime("%Y%m%d%H%M%S"))')"
+  for db in $(rds_psql "SELECT datname FROM pg_database WHERE datname LIKE 'mdstore\_e2e\_%'" || true); do
+    case "$db" in
+      *[!a-z0-9_]*) log "ext metadata db: GC skipping odd name '$db'"; continue ;;
+    esac
+    ts="${db#mdstore_e2e_}"; ts="${ts%%_*}"
+    case "$ts" in
+      [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]) ;;
+      *) log "ext metadata db: GC skipping unparseable name '$db'"; continue ;;
+    esac
+    if [ "$ts" -lt "$cutoff" ]; then
+      log "ext metadata db: GC dropping stale $db (leaked by an aborted run >24h ago)"
+      rds_psql "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE)" >/dev/null \
+        || log "ext metadata db: GC drop of $db failed (the next run retries)"
+    fi
+  done
+
+  log "ext metadata db: creating per-run database $EXT_RDS_DB"
+  rds_psql "CREATE DATABASE \"$EXT_RDS_DB\"" >/dev/null \
+    || fail "ext metadata db: CREATE DATABASE $EXT_RDS_DB failed (does $EXT_RDS_USER still have CREATEDB?)"
+  log "ext metadata db: $EXT_RDS_DB ready"
+}
+
+# ext_rds_teardown drops this run's database and asserts it is gone. By this
+# point the ext org has been resharded onto cnpg (reshard_ext_to_cnpg leaves
+# the external source untouched but unused), so the drop can never yank a
+# live catalog. On any failure the >24h GC in the next run reaps it.
+ext_rds_teardown() {
+  EXT_RDS_PW="$(cat "$LANE_DIR/ext_rds_pw" 2>/dev/null || true)"
+  [ -n "$EXT_RDS_PW" ] || { log "ext metadata db: no stashed password — skipping drop (GC will reap)"; return 0; }
+  log "ext metadata db: dropping per-run database $EXT_RDS_DB"
+  rds_psql "DROP DATABASE IF EXISTS \"$EXT_RDS_DB\" WITH (FORCE)" >/dev/null \
+    || fail "ext metadata db: DROP DATABASE $EXT_RDS_DB failed"
+  left="$(rds_psql "SELECT 1 FROM pg_database WHERE datname = '$EXT_RDS_DB'")" || left=""
+  [ -z "$left" ] || fail "ext metadata db: $EXT_RDS_DB still exists after DROP"
+  log "ext metadata db: per-run database dropped"
 }
 
 wait_state() { # org target timeout_s
@@ -2648,7 +2742,7 @@ EXT_BODY='{"database_name":"'"$EXT"'",
   "default_team_id":'"$EXT_DEFAULT_TEAM_ID"',
   "metadata_store":{"type":"external","external":{
     "endpoint":"'"$EXT_RDS_ENDPOINT"'","password_aws_secret":"'"$EXT_RDS_SECRET"'",
-    "user":"ducklingexample","database":"ducklingexample"}},
+    "user":"'"$EXT_RDS_USER"'","database":"'"$EXT_RDS_DB"'"}},
   "data_store":{"type":"external","bucket_name":"posthog-duckling-example-managed-warehouse-dev","region":"us-east-1"},
   "ducklake":{"enabled":true}}'
 
@@ -2936,11 +3030,22 @@ main() {
   for v in "$cnpg_pw" "$ext_pw" "$res1_pw" "$res2_pw"; do
     case "$v" in ""|null) fail "a provision call returned no password" ;; esac
   done
+  # kubectl must be usable BEFORE the extdb lane below (the lane subshell
+  # reads the ext duckling's CR status and must not race the background
+  # download). This trades away only the readiness-phase overlap; the fetch
+  # already overlapped the whole provisioning phase above.
+  bootstrap_kubectl
+
+  # The extdb lane creates the run's external metadata database (and GCs
+  # leaked ones) CONCURRENTLY with the readiness waits: ready_ext cannot flip
+  # before the database exists (the CP's end-to-end probe targets it and
+  # retries), so this lane completing is a hard prerequisite it races ahead of.
   run_lane ready_cnpg wait_state "$CNPG" ready "$READY_TIMEOUT"
   run_lane ready_ext  wait_state "$EXT"  ready "$READY_TIMEOUT"
   run_lane ready_res1 wait_state "$RES1" ready "$READY_TIMEOUT"
   run_lane ready_res2 wait_state "$RES2" ready "$READY_TIMEOUT"
-  join_lanes ready_cnpg ready_ext ready_res1 ready_res2
+  run_lane extdb ext_rds_setup
+  join_lanes ready_cnpg ready_ext ready_res1 ready_res2 extdb
 
   # Settle: let the CP's config-store poll pick up the provisioned orgs/users
   # before the first connection, so we don't burn failed-auth attempts against
@@ -2960,11 +3065,8 @@ main() {
   admin_console_api
   admin_rbac_viewer "$CNPG"
 
-  # Join the kubectl background download started at script load — first k use
-  # is inside the lanes, so the fetch overlapped the whole provisioning phase.
-  bootstrap_kubectl
-
   # ---- the four parallel assertion lanes (see lane_* above) ----
+  # (kubectl was bootstrapped before the readiness lanes above.)
   run_lane cnpg lane_cnpg
   run_lane res1 lane_res1
   run_lane res2 lane_res2
@@ -3032,11 +3134,17 @@ main() {
   # only needs one cnpg-shard org.)
   lifecycle_teardown_cnpg "$CNPG"
 
+  # ---- per-run external metadata database: drop + assert gone ----------------
+  # (Safe now: reshard_ext_to_cnpg moved the ext org off the RDS, so the
+  # per-run database is an orphaned source. A crashed run skips this and the
+  # next run's >24h GC in ext_rds_setup reaps the leftover.)
+  ext_rds_teardown
+
   # NOTE: the version-mismatch worker reaper is not exercised in-Job (it needs a
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + duckling-shard-backfill(cnpg) + isolation + reshard(targets-discovery + validation + cancel-during-drain + bogus-shard-rollback + ext-to-cnpg positive path) + lifecycle-teardown(+org-delete/name-release), on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + duckling-shard-backfill(cnpg) + isolation + reshard(targets-discovery + validation + cancel-during-drain + bogus-shard-rollback + ext-to-cnpg positive path) + lifecycle-teardown(+org-delete/name-release) + per-run-ext-metadata-db(create/stale-GC/drop), on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2270,8 +2270,7 @@ reshard_backup_debug() { # opid — focused debug for a backup-assert failure:
   # error the op log only summarizes). Best effort — the reconciler may have
   # reaped the pod already.
   echo "---- op $1 backup-related log lines ----"
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" 2>/dev/null \
-    | jq -r '.entries[] | select(.message | test("(?i)backup|sts|assume|s3")) | "\(.level): \(.message)"' || true
+  reshard_log_fetch "$1" 2>/dev/null | grep -iE 'backup|sts|assume|s3' || true
   echo "---- runner pod duckgres-reshard-op-$1 logs (tail) ----"
   k logs "duckgres-reshard-op-$1" --tail=150 2>/dev/null || echo "(runner pod already gone)"
 }
@@ -2318,14 +2317,30 @@ reshard_wait_step() { # opid step timeout_s
   fail "reshard op $1 never reached step $2 (last=$cur)"
 }
 
-reshard_log_has() { # opid substr
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" \
-    | jq -r '.entries[].message' | grep -qF "$2"
+reshard_log_fetch() { # opid -> the FULL op log, one "level: message" line per entry
+  # Pages with after_id until exhausted. A single first-page fetch is NOT
+  # enough: the catalog copy logs one op-log line per table, and the shared
+  # ext-RDS catalog has accumulated 20k+ ducklake_* tables across e2e runs —
+  # far past the server's 2000-per-page cap — so a one-shot fetch saw only the
+  # first page and the asserts on END-of-log lines (the terminal "reshard
+  # report" block) failed on an op that actually succeeded.
+  _after=0
+  while :; do
+    _page="$(curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=${_after}&limit=2000")" || break
+    _n="$(echo "$_page" | jq '.entries | length')" || break
+    [ "${_n:-0}" -gt 0 ] || break
+    echo "$_page" | jq -r '.entries[] | "\(.level): \(.message)"'
+    _after="$(echo "$_page" | jq '.entries[-1].id')" || break
+    if [ "$_n" -lt 2000 ]; then break; fi
+  done
 }
 
-reshard_dump_log() { # opid
-  curl -fsS -H "$H" "$API/api/v1/reshards/$1/log?after_id=0&limit=2000" \
-    | jq -r '.entries[] | "\(.level): \(.message)"' | tail -30 || true
+reshard_log_has() { # opid substr
+  reshard_log_fetch "$1" | grep -qF "$2"
+}
+
+reshard_dump_log() { # opid — the log TAIL (where the failure/report lands)
+  reshard_log_fetch "$1" | tail -30 || true
 }
 
 reshard_targets() { # destination discovery; ext org's RDS must appear too

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2768,6 +2768,32 @@ user_kill_switch() { # org rootpw
   # New-user auth is config-snapshot-driven; wait one poll before first login.
   sleep "${CONFIG_POLL_SETTLE:-12}"
 
+  # The kill can RACE query completion: on a fully warm worker (no cpu limit —
+  # a worker gets the node's cores) HEAVY_Q can finish in single-digit seconds,
+  # so between "victim visible in /queries + psql still alive" and the kill RPC
+  # actually landing on the worker, the query may deliver its FULL result. The
+  # session is then still counted (killed>=1) but the client already has its
+  # data — the test measured nothing. That inconclusive outcome (victim
+  # finished rc=0 with EXACTLY the full result) retries with a fresh query; a
+  # genuinely broken kill survives every attempt and still fails here. Any
+  # other outcome fails immediately.
+  ksa=1
+  while :; do
+    ksrc=0
+    user_kill_switch_attempt "$org" "$pw" "$vic" "$vicpw" || ksrc=$?
+    [ "$ksrc" = 0 ] && break
+    [ "$ksrc" = 2 ] || fail "user_kill_switch: attempt failed unexpectedly (rc=$ksrc)"
+    [ "$ksa" -lt 3 ] || fail "user_kill_switch: kill raced query completion in 3/3 attempts — victim query too fast to overlap the kill (raise HEAVY_Q), or the kill is not interrupting in-flight queries"
+    ksa=$((ksa + 1))
+    log "user kill switch on $org: attempt $ksa (previous kill raced query completion)"
+  done
+  log "user kill switch OK on $org (victim torn down, root untouched)"
+}
+
+# One kill-switch attempt: 0 = pass, 2 = kill raced query completion
+# (inconclusive — caller retries), any real violation fail()s the harness.
+user_kill_switch_attempt() { # org rootpw vic vicpw
+  org="$1"; pw="$2"; vic="$3"; vicpw="$4"
   vout="$(mktemp)"; vrc="$(mktemp)"; rout="$(mktemp)"; rrc="$(mktemp)"
   # Victim's long query AND a root long query run concurrently (distinct users,
   # distinct workers — MaxSessions=1). Only the victim's must die.
@@ -2785,17 +2811,29 @@ user_kill_switch() { # org rootpw
     sleep 2; a=$((a + 1))
   done
   [ "$seen" = 1 ] || { kill "$vpid" "$rpid" 2>/dev/null || true; fail "user_kill_switch: victim query never appeared in /queries"; }
-  # Overlap proof: both queries must still be running at kill time, else the test
-  # measures nothing (false pass on a query that already finished).
-  kill -0 "$vpid" 2>/dev/null || fail "user_kill_switch: victim query finished before kill (raise HEAVY_Q row count)"
+  if ! kill -0 "$vpid" 2>/dev/null; then
+    # Victim already finished before we could even send the kill — same
+    # inconclusive-overlap class as the raced outcome below.
+    log "user_kill_switch: victim finished before the kill was sent — inconclusive overlap"
+    wait "$vpid" 2>/dev/null || true
+    wait "$rpid" 2>/dev/null || true
+    rm -f "$vout" "$vrc" "$rout" "$rrc"
+    return 2
+  fi
 
   killed="$(api_post "$org" "users/$vic/kill" | jq -r '.killed')"
   [ "${killed:-0}" -ge 1 ] || fail "user_kill_switch: kill reported killed=$killed (want >=1)"
 
   wait "$vpid" 2>/dev/null || true
   wait "$rpid" 2>/dev/null || true
-  [ "$(cat "$vrc")" = 1 ] \
-    || fail "user_kill_switch: victim query survived the kill: $(tr -d '\n' <"$vout" | tail -c 200)"
+  if [ "$(cat "$vrc")" = 0 ]; then
+    if [ "$(tr -dc '0-9' <"$vout")" = "$HEAVY_EXPECT" ]; then
+      log "user_kill_switch: victim delivered its full result before the kill landed — inconclusive overlap"
+      rm -f "$vout" "$vrc" "$rout" "$rrc"
+      return 2
+    fi
+    fail "user_kill_switch: victim query survived the kill: $(tr -d '\n' <"$vout" | tail -c 200)"
+  fi
   [ "$(cat "$rrc")" = 0 ] \
     || fail "user_kill_switch: root (other user) query was wrongly killed: $(tr -d '\n' <"$rout" | tail -c 200)"
   rn="$(tr -dc '0-9' <"$rout")"
@@ -2804,7 +2842,7 @@ user_kill_switch() { # org rootpw
   n="$(curl -fsS -H "$H" "$API/api/v1/queries?org=$org&user=$vic" | jq -r '.queries | length')"
   [ "${n:-0}" = 0 ] || fail "user_kill_switch: victim still has $n live queries after kill"
   rm -f "$vout" "$vrc" "$rout" "$rrc"
-  log "user kill switch OK on $org (victim torn down, root untouched)"
+  return 0
 }
 
 # ---- per-user disable/enable block ------------------------------------------

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -520,6 +520,15 @@ cmd_teardown() {
   # cascade lagged the CR delete above (see drop_cnpg_role). Idempotent.
   for org in $(ci_cnpg_orgs "$PR_NUMBER"); do drop_cnpg_role "$org"; done
 
+  # The ext org's PER-RUN metadata database on the shared RDS
+  # (mdstore_e2e_<utc-ts>_pr<pr>, see harness.sh EXT_RDS_DB) is NOT dropped
+  # here: this runner has neither psql nor any path to the RDS password (it
+  # lives in AWS SM, synced in-cluster by ESO into the duckling's status). The
+  # harness drops its own database at the end of a passing run
+  # (ext_rds_teardown); databases leaked by crashed/cancelled runs are reaped
+  # by the NEXT run's >24h name-gated GC (ext_rds_setup). Same story for
+  # cmd_e2e_cleanup below.
+
   # Drop the Pod Identity association (it's an EKS resource, not in the ns).
   delete_pod_identity
 


### PR DESCRIPTION
**Stacked on #950** (both touch `harness.sh`; rebase onto main if #950 merges first).

## Problem

The e2e's ext-backend org pointed every run at ONE shared database on the shared RDS, so its DuckLake catalog grew monotonically across runs — **20,856 `ducklake_*` tables** observed in today's runs. That inflated every catalog copy (the reshard ext→cnpg lane reached ~6 min / ~95MB / 856k rows for a run that creates a handful of tables — and it only gets worse), triggered the op-log-volume failure #950 diagnosed, and exposed runs to each other's writers (cross-run/foreign-writer interference class).

## Change

Each run provisions its ext org against a **run-unique database** `mdstore_e2e_<utc-ts>_pr<pr>` on the same RDS — same endpoint, same user, same SM secret (no SM/ESO/IAM changes; the provisioning API passes `metadata_store.external.database` through verbatim, verified in `controlplane/provisioning/api.go`).

- **Create** (`ext_rds_setup`, a lane concurrent with the readiness waits): the harness reads the ESO-synced RDS password from its **own** ext duckling's CR status (`status.metadataStore.password` — the harness SA already has cross-namespace duckling read RBAC), then `CREATE DATABASE`. No ordering hazard: the CP's end-to-end provisioning probe targets the per-run database and retries non-terminally (`controller.go reconcileProvisioning`), so `ready` flips right after the create lands.
- **Drop** (`ext_rds_teardown`, end of a passing run): `DROP DATABASE … WITH (FORCE)` + assert gone. Safe by then — `reshard_ext_to_cnpg` has already moved the org off the RDS, so the database is an orphaned source.
- **Stale GC** (start of every run, failure backstop): drops `mdstore_e2e_*` databases **older than 24h**, name-gated to the full per-run pattern with a parseable 14-digit UTC timestamp. A concurrent run's live database can never match (runs finish in <1h), and nothing outside `mdstore_e2e_*` is ever touched — the legacy shared database and any manually-created databases are structurally excluded. `run.sh` teardown / `e2e-cleanup` can't do this drop themselves (the GitHub runner has neither psql nor a path to the RDS password) — documented inline; scheduled main runs keep the GC cadence.

Also moves the kubectl bootstrap ahead of the readiness lanes (the extdb lane must not race the background download) and notes the new lane in the PASS summary.

## Validation

- `sh -n` + `go test ./tests/mw-dev` (the CI harness-script check) green.
- Setup/GC/teardown logic driven end-to-end against faked psql/kubectl: late-appearing password poll, stale DBs (>24h) dropped, fresh / unparseable / protected names untouched, run DB created, teardown drop verified gone.
- The change is self-exercising in CI: every e2e run creates, uses (full DuckLake activation + the reshard ext→cnpg copy now runs against a fresh, small catalog), and drops its database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)