### PR TITLE
reshard: harden takeover, fencing, and catalog verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ DuckDB's `system_peak_buffer_memory` in bytes, not process RSS.
 - [Dev Scenario Runner](docs/runbooks/scenario-dev.md): Scheduled and manually dispatched scenario runs against the configured dev environment.
 - [Control Plane Rollout](docs/runbooks/control-plane-rollout.md): Zero-downtime deployment process for the control plane itself.
 - [Managed Warehouse Deprovision](docs/runbooks/managed-warehouse-deprovision.md): Destructive teardown process for managed warehouse infrastructure and org cleanup.
+- [Resharding Operations](docs/runbooks/resharding.md): Runner recovery, durable respawn reset, safety checks, and local verification.
 
 ## Quick Start
 

--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -39,6 +39,7 @@ import (
 type ReshardStore interface {
 	CreateReshardOperation(op *configstore.ReshardOperation) error
 	SetReshardOperationPasswordURL(id int64, url string) error
+	SetReshardOperationRunnerImage(id int64, image string) error
 	GetReshardOperation(id int64) (*configstore.ReshardOperation, error)
 	ListReshardOperationsForOrg(orgID string, limit int) ([]configstore.ReshardOperation, error)
 	ListReshardOperations(limit int) ([]configstore.ReshardOperation, error)
@@ -55,6 +56,7 @@ type ReshardStore interface {
 // has no kubernetes API — starting a reshard is then refused (nothing would
 // ever execute it).
 type ReshardPodSpawner interface {
+	RunnerImage(ctx context.Context) (string, error)
 	// SpawnReshardPod creates the duckgres-reshard-op-<id> pod (no wait for
 	// readiness; the pod claims the op row itself).
 	SpawnReshardPod(ctx context.Context, op *configstore.ReshardOperation) error
@@ -465,6 +467,18 @@ func (h *reshardHandler) start(c *gin.Context) {
 		op.PasswordURL = url
 		h.stash.put(op.ID, req.Target.Password)
 	}
+	image, err := h.spawner.RunnerImage(c.Request.Context())
+	if err != nil || image == "" {
+		_, _ = h.store.FinishPendingReshardOperation(op.ID, configstore.ReshardStateFailed, "resolving the reshard runner image failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "resolving the reshard runner image failed"})
+		return
+	}
+	if err := h.store.SetReshardOperationRunnerImage(op.ID, image); err != nil {
+		_, _ = h.store.FinishPendingReshardOperation(op.ID, configstore.ReshardStateFailed, "recording the reshard runner image failed: "+err.Error())
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "recording the reshard runner image failed: " + err.Error()})
+		return
+	}
+	op.RunnerImage = image
 
 	if err := h.spawner.SpawnReshardPod(c.Request.Context(), op); err != nil {
 		h.stash.delete(op.ID)

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -66,6 +66,11 @@ func (f *fakeReshardStore) SetReshardOperationPasswordURL(id int64, url string) 
 	return nil
 }
 
+func (f *fakeReshardStore) SetReshardOperationRunnerImage(id int64, image string) error {
+	f.ops[id].RunnerImage = image
+	return nil
+}
+
 func (f *fakeReshardStore) GetReshardOperation(id int64) (*configstore.ReshardOperation, error) {
 	op, ok := f.ops[id]
 	if !ok {
@@ -151,6 +156,10 @@ type fakeSpawner struct {
 	spawned  []configstore.ReshardOperation
 	spawnErr error
 	noURL    bool // PasswordURLForOp returns "" (pod IP undeterminable)
+}
+
+func (f *fakeSpawner) RunnerImage(context.Context) (string, error) {
+	return "example/duckgres:pinned", nil
 }
 
 func (f *fakeSpawner) SpawnReshardPod(_ context.Context, op *configstore.ReshardOperation) error {

--- a/controlplane/configstore/migrations/000023_add_reshard_respawn_attempts.sql
+++ b/controlplane/configstore/migrations/000023_add_reshard_respawn_attempts.sql
@@ -4,8 +4,12 @@
 -- failover and defeat the advertised retry bound.
 ALTER TABLE duckgres_reshard_operations
     ADD COLUMN IF NOT EXISTS respawn_attempts BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE duckgres_reshard_operations
+    ADD COLUMN IF NOT EXISTS runner_image TEXT NOT NULL DEFAULT '';
 
 -- +goose Down
 
+ALTER TABLE duckgres_reshard_operations
+    DROP COLUMN IF EXISTS runner_image;
 ALTER TABLE duckgres_reshard_operations
     DROP COLUMN IF EXISTS respawn_attempts;

--- a/controlplane/configstore/migrations/000023_add_reshard_respawn_attempts.sql
+++ b/controlplane/configstore/migrations/000023_add_reshard_respawn_attempts.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+-- Durable reconciler intervention count. Leader-local counters reset during
+-- failover and defeat the advertised retry bound.
+ALTER TABLE duckgres_reshard_operations
+    ADD COLUMN IF NOT EXISTS respawn_attempts BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+
+ALTER TABLE duckgres_reshard_operations
+    DROP COLUMN IF EXISTS respawn_attempts;

--- a/controlplane/configstore/reshard.go
+++ b/controlplane/configstore/reshard.go
@@ -80,6 +80,7 @@ type ReshardOperation struct {
 	RunnerCP        string     `gorm:"size:255;not null;default:''" json:"runner_cp"`
 	RunnerEpoch     int64      `gorm:"not null;default:0" json:"runner_epoch"`
 	RespawnAttempts int64      `gorm:"not null;default:0" json:"respawn_attempts"`
+	RunnerImage     string     `gorm:"size:1024;not null;default:''" json:"runner_image"`
 	HeartbeatAt     *time.Time `json:"heartbeat_at"`
 
 	// Maintenance-mode window: warehouse state resharding from block to
@@ -175,6 +176,19 @@ func (cs *ConfigStore) SetReshardOperationPasswordURL(id int64, url string) erro
 	}
 	if res.RowsAffected == 0 {
 		return fmt.Errorf("set reshard password url: operation %d is not pending", id)
+	}
+	return nil
+}
+
+func (cs *ConfigStore) SetReshardOperationRunnerImage(id int64, image string) error {
+	res := cs.db.Model(&ReshardOperation{}).
+		Where("id = ? AND state = ?", id, ReshardStatePending).
+		Update("runner_image", image)
+	if res.Error != nil {
+		return fmt.Errorf("set reshard runner image: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("set reshard runner image: operation %d is not pending", id)
 	}
 	return nil
 }

--- a/controlplane/configstore/reshard.go
+++ b/controlplane/configstore/reshard.go
@@ -77,9 +77,10 @@ type ReshardOperation struct {
 	// Runner fencing: claiming CP instance + monotonically bumped epoch. Every
 	// runner-side write is CAS-fenced on (runner_cp, runner_epoch) so a zombie
 	// ex-runner's writes fail after a takeover.
-	RunnerCP    string     `gorm:"size:255;not null;default:''" json:"runner_cp"`
-	RunnerEpoch int64      `gorm:"not null;default:0" json:"runner_epoch"`
-	HeartbeatAt *time.Time `json:"heartbeat_at"`
+	RunnerCP        string     `gorm:"size:255;not null;default:''" json:"runner_cp"`
+	RunnerEpoch     int64      `gorm:"not null;default:0" json:"runner_epoch"`
+	RespawnAttempts int64      `gorm:"not null;default:0" json:"respawn_attempts"`
+	HeartbeatAt     *time.Time `json:"heartbeat_at"`
 
 	// Maintenance-mode window: warehouse state resharding from block to
 	// unblock. UnblockedAt-BlockedAt is the org's client-visible downtime.
@@ -191,6 +192,25 @@ func (cs *ConfigStore) ListActiveReshardOperations() ([]ReshardOperation, error)
 	return ops, nil
 }
 
+// IncrementReshardRespawnAttempts durably records one reconciler intervention
+// and returns the new count. The count survives leader and process changes.
+func (cs *ConfigStore) IncrementReshardRespawnAttempts(id int64) (int64, error) {
+	var attempts int64
+	err := cs.db.Raw(`
+		UPDATE duckgres_reshard_operations
+		SET respawn_attempts = respawn_attempts + 1
+		WHERE id = ? AND state IN (?, ?)
+		RETURNING respawn_attempts`, id, ReshardStatePending, ReshardStateRunning).
+		Scan(&attempts).Error
+	if err != nil {
+		return 0, fmt.Errorf("increment reshard respawn attempts: %w", err)
+	}
+	if attempts == 0 {
+		return 0, fmt.Errorf("increment reshard respawn attempts: operation %d is not active", id)
+	}
+	return attempts, nil
+}
+
 // GetReshardOperation loads one operation by id.
 func (cs *ConfigStore) GetReshardOperation(id int64) (*ReshardOperation, error) {
 	var op ReshardOperation
@@ -299,6 +319,40 @@ func (cs *ConfigStore) FinishReshardOperation(id int64, runnerCP string, epoch i
 		"state":       state,
 		"error":       errMsg,
 		"finished_at": time.Now().UTC(),
+	})
+}
+
+// FinalizeReshardOperation atomically admits traffic and marks the operation
+// succeeded. Neither state may become visible without the other: a crash after
+// only one write would otherwise leave an unsafe takeover or a stranded org.
+func (cs *ConfigStore) FinalizeReshardOperation(id int64, runnerCP string, epoch int64, orgID string, warehouseUpdates map[string]interface{}, unblockedAt time.Time) error {
+	return cs.db.Transaction(func(tx *gorm.DB) error {
+		warehouse := tx.Model(&ManagedWarehouse{}).
+			Where("org_id = ? AND state = ?", orgID, ManagedWarehouseStateResharding).
+			Updates(warehouseUpdates)
+		if warehouse.Error != nil {
+			return fmt.Errorf("finalize reshard warehouse: %w", warehouse.Error)
+		}
+		if warehouse.RowsAffected == 0 {
+			return fmt.Errorf("warehouse %q expected state %q: %w", orgID, ManagedWarehouseStateResharding, ErrWarehouseStateMismatch)
+		}
+
+		finished := tx.Model(&ReshardOperation{}).
+			Where("id = ? AND state = ? AND runner_cp = ? AND runner_epoch = ?", id, ReshardStateRunning, runnerCP, epoch).
+			Updates(map[string]interface{}{
+				"state":        ReshardStateSucceeded,
+				"error":        "",
+				"unblocked_at": unblockedAt,
+				"finished_at":  unblockedAt,
+				"heartbeat_at": unblockedAt,
+			})
+		if finished.Error != nil {
+			return fmt.Errorf("finalize reshard operation: %w", finished.Error)
+		}
+		if finished.RowsAffected == 0 {
+			return ErrReshardFenced
+		}
+		return nil
 	})
 }
 

--- a/controlplane/provisioner/catalog_copy.go
+++ b/controlplane/provisioner/catalog_copy.go
@@ -4,6 +4,8 @@ package provisioner
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -97,7 +99,16 @@ type CatalogCopyResult struct {
 	// PerTableRows are the row counts observed INSIDE the source snapshot
 	// transaction — the reference for both the target verify and the
 	// post-copy source-stability recheck.
-	PerTableRows map[string]int64
+	PerTableRows         map[string]int64
+	PerTableFingerprints map[string]CatalogTableFingerprint
+	// ReleaseSourceFence releases the source snapshot and its SHARE locks.
+	// The runner keeps it until verification and destructive cleanup finish.
+	ReleaseSourceFence func()
+}
+
+type CatalogTableFingerprint struct {
+	Rows   int64
+	Digest string
 }
 
 // CatalogCopier is the interface the reshard runner drives; *PGCatalogCopier
@@ -114,6 +125,7 @@ type CatalogCopier interface {
 	// verify. log receives periodic progress lines (a ~20k-table catalog
 	// takes minutes to count).
 	SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error)
+	SnapshotFingerprints(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]CatalogTableFingerprint, error)
 	// DropCatalogTables drops all ducklake_* tables (rollback cleanup of a
 	// partially copied target).
 	DropCatalogTables(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) error
@@ -144,13 +156,18 @@ WHERE table_schema = 'public' AND table_name LIKE 'ducklake\_%' ESCAPE '\'
 ORDER BY table_name`
 
 func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint, log func(level, msg string)) (CatalogCopyResult, error) {
-	result := CatalogCopyResult{PerTableRows: map[string]int64{}}
+	result := CatalogCopyResult{PerTableRows: map[string]int64{}, PerTableFingerprints: map[string]CatalogTableFingerprint{}}
 
 	src, err := pgx.Connect(ctx, source.DSN())
 	if err != nil {
 		return result, fmt.Errorf("connect source %s: %w", source.Redacted(), err)
 	}
-	defer src.Close(context.WithoutCancel(ctx))
+	keepSourceFence := false
+	defer func() {
+		if !keepSourceFence {
+			src.Close(context.WithoutCancel(ctx))
+		}
+	}()
 	dst, err := pgx.Connect(ctx, target.DSN())
 	if err != nil {
 		return result, fmt.Errorf("connect target %s: %w", target.Redacted(), err)
@@ -169,11 +186,15 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 	log("info", "opening a consistent source snapshot and discovering catalog tables…")
 
 	// One consistent snapshot across every table.
-	tx, err := src.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	tx, err := src.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
 	if err != nil {
 		return result, fmt.Errorf("begin source snapshot tx: %w", err)
 	}
-	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	defer func() {
+		if !keepSourceFence {
+			_ = tx.Rollback(context.WithoutCancel(ctx))
+		}
+	}()
 
 	tables, err := queryStrings(ctx, tx, catalogTablesQuery)
 	if err != nil {
@@ -181,6 +202,21 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 	}
 	if len(tables) == 0 {
 		return result, fmt.Errorf("source has no ducklake_%% tables — refusing to copy an empty catalog")
+	}
+	lockNames := make([]string, len(tables))
+	for i, table := range tables {
+		lockNames[i] = quoteIdent(table)
+	}
+	log("info", fmt.Sprintf("acquiring source write fence across %d catalog tables…", len(tables)))
+	if _, err := tx.Exec(ctx, "LOCK TABLE "+strings.Join(lockNames, ", ")+" IN SHARE MODE"); err != nil {
+		return result, fmt.Errorf("acquire source catalog SHARE locks: %w", err)
+	}
+	lockedTables, err := queryStrings(ctx, tx, catalogTablesQuery)
+	if err != nil {
+		return result, fmt.Errorf("re-discover catalog tables after source fence: %w", err)
+	}
+	if strings.Join(lockedTables, "\x00") != strings.Join(tables, "\x00") {
+		return result, fmt.Errorf("source catalog table set changed while acquiring the write fence")
 	}
 	log("info", fmt.Sprintf("discovered %d catalog tables in source snapshot", len(tables)))
 
@@ -237,11 +273,73 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 	for table, c := range verified {
 		result.PerTableRows[table] = c
 	}
+	log("info", fmt.Sprintf("fingerprinting source and target contents across %d tables…", len(tables)))
+	for _, table := range tables {
+		sourceFingerprint, err := fingerprintTable(ctx, tx, table)
+		if err != nil {
+			return result, fmt.Errorf("fingerprint source %s: %w", table, err)
+		}
+		targetFingerprint, err := fingerprintTable(ctx, dst, table)
+		if err != nil {
+			return result, fmt.Errorf("fingerprint target %s: %w", table, err)
+		}
+		if sourceFingerprint != targetFingerprint {
+			return result, fmt.Errorf("content fingerprint mismatch on %s: source %s, target %s", table, sourceFingerprint.Digest, targetFingerprint.Digest)
+		}
+		result.PerTableFingerprints[table] = sourceFingerprint
+	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return result, fmt.Errorf("close source snapshot tx: %w", err)
+	keepSourceFence = true
+	released := false
+	result.ReleaseSourceFence = func() {
+		if released {
+			return
+		}
+		released = true
+		_ = tx.Rollback(context.Background())
+		src.Close(context.Background())
 	}
 	return result, nil
+}
+
+type fingerprintQuerier interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+// fingerprintTable computes a streaming, order-independent multiset digest.
+// Each canonical jsonb row is SHA-256 hashed; the hashes are added modulo
+// 2^256, so row order does not matter while duplicates remain significant.
+func fingerprintTable(ctx context.Context, q fingerprintQuerier, table string) (CatalogTableFingerprint, error) {
+	rows, err := q.Query(ctx, "SELECT to_jsonb(t)::text FROM "+quoteIdent(table)+" AS t")
+	if err != nil {
+		return CatalogTableFingerprint{}, err
+	}
+	defer rows.Close()
+	var out CatalogTableFingerprint
+	var sum [sha256.Size]byte
+	for rows.Next() {
+		var canonical string
+		if err := rows.Scan(&canonical); err != nil {
+			return CatalogTableFingerprint{}, err
+		}
+		addRowFingerprint(&sum, canonical)
+		out.Rows++
+	}
+	if err := rows.Err(); err != nil {
+		return CatalogTableFingerprint{}, err
+	}
+	out.Digest = hex.EncodeToString(sum[:])
+	return out, nil
+}
+
+func addRowFingerprint(sum *[sha256.Size]byte, canonical string) {
+	h := sha256.Sum256([]byte(canonical))
+	carry := uint16(0)
+	for i := len(sum) - 1; i >= 0; i-- {
+		total := uint16(sum[i]) + uint16(h[i]) + carry
+		sum[i] = byte(total)
+		carry = total >> 8
+	}
 }
 
 func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error) {
@@ -265,6 +363,28 @@ func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint, l
 		maybeLogProgress(log, "counted", i+1, len(tables))
 	}
 	return counts, nil
+}
+
+func (PGCatalogCopier) SnapshotFingerprints(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]CatalogTableFingerprint, error) {
+	conn, err := pgx.Connect(ctx, ep.DSN())
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", ep.Redacted(), err)
+	}
+	defer conn.Close(context.WithoutCancel(ctx))
+	tables, err := queryStrings(ctx, conn, catalogTablesQuery)
+	if err != nil {
+		return nil, fmt.Errorf("discover catalog tables: %w", err)
+	}
+	result := make(map[string]CatalogTableFingerprint, len(tables))
+	for i, table := range tables {
+		fingerprint, err := fingerprintTable(ctx, conn, table)
+		if err != nil {
+			return nil, fmt.Errorf("fingerprint %s: %w", table, err)
+		}
+		result[table] = fingerprint
+		maybeLogProgress(log, "fingerprinted", i+1, len(tables))
+	}
+	return result, nil
 }
 
 // verifyProgressEvery is the periodic-progress cadence of the loops that visit

--- a/controlplane/provisioner/catalog_copy_test.go
+++ b/controlplane/provisioner/catalog_copy_test.go
@@ -3,12 +3,32 @@
 package provisioner
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
+
+func TestContentFingerprintDetectsSameCountMutationAndIgnoresRowOrder(t *testing.T) {
+	fingerprint := func(rows ...string) [sha256.Size]byte {
+		var sum [sha256.Size]byte
+		for _, row := range rows {
+			addRowFingerprint(&sum, row)
+		}
+		return sum
+	}
+	original := fingerprint(`{"id":1,"value":"a"}`, `{"id":2,"value":"b"}`)
+	reordered := fingerprint(`{"id":2,"value":"b"}`, `{"id":1,"value":"a"}`)
+	mutated := fingerprint(`{"id":1,"value":"changed"}`, `{"id":2,"value":"b"}`)
+	if original != reordered {
+		t.Fatal("multiset fingerprint changed with row order")
+	}
+	if original == mutated {
+		t.Fatal("same-row-count UPDATE was not detected by content fingerprint")
+	}
+}
 
 // TestShouldReplayConstraint pins the PG-18 NOT NULL skip: catalogued
 // not-null constraints (contype 'n') must never be replayed — the CREATE

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -252,7 +252,10 @@ type opRun struct {
 	// progress flags for the rollback decision
 	blocked          bool
 	compactionPaused bool
-	flipped          bool
+	// compactionSnapshotRecorded prevents a takeover from replacing the
+	// persisted pre-reshard setting with the already-paused live value.
+	compactionSnapshotRecorded bool
+	flipped                    bool
 	// retainRequested: we set retainCnpgOnFlip=true on the source (cnpg→ext
 	// orphan step). If we roll back BEFORE the flip, reset it to false so the
 	// still-cnpg source keeps full-lifecycle (Delete) MRs and deprovision stays
@@ -338,6 +341,7 @@ func (o *opRun) reconstructProgress() {
 	if reshardStepReached(o.op, "backup_catalog") {
 		o.compactionPaused = true
 	}
+	o.compactionSnapshotRecorded = reshardStepReached(o.op, "pausing_compaction")
 	if o.op.TargetKind == configstore.MetadataStoreKindExternal && reshardStepReached(o.op, "orphaning_source") {
 		o.retainRequested = true
 	}
@@ -678,15 +682,20 @@ func (o *opRun) pauseCompaction(ctx context.Context) error {
 	if err := o.step("pausing_compaction"); err != nil {
 		return err
 	}
-	enabled, present, err := o.r.duckling.GetCompactionSetting(ctx, o.op.DucklingName)
-	if err != nil {
-		return fmt.Errorf("read compaction setting: %w", err)
-	}
-	if err := o.fields(map[string]interface{}{
-		"compaction_was_present": present,
-		"compaction_was_enabled": enabled,
-	}); err != nil {
-		return err
+	enabled, present := o.op.CompactionWasEnabled, o.op.CompactionWasPresent
+	if !o.compactionSnapshotRecorded {
+		var err error
+		enabled, present, err = o.r.duckling.GetCompactionSetting(ctx, o.op.DucklingName)
+		if err != nil {
+			return fmt.Errorf("read compaction setting: %w", err)
+		}
+		if err := o.fields(map[string]interface{}{
+			"compaction_was_present": present,
+			"compaction_was_enabled": enabled,
+		}); err != nil {
+			return err
+		}
+		o.compactionSnapshotRecorded = true
 	}
 	off := false
 	if err := o.r.duckling.SetCompactionEnabled(ctx, o.op.DucklingName, &off); err != nil {
@@ -1279,6 +1288,7 @@ func (o *opRun) restoreCompaction(ctx context.Context) {
 // the op is marked failed/cancelled regardless.
 func (o *opRun) rollback(ctx context.Context) {
 	ctx = context.WithoutCancel(ctx)
+	recovered := true
 
 	if o.flipped {
 		switch {
@@ -1289,6 +1299,7 @@ func (o *opRun) rollback(ctx context.Context) {
 			o.logf("warn", "rolling back: re-pointing duckling at source shard %s", o.op.FromShard)
 			if err := o.r.duckling.SetMetadataStoreCnpg(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
 				o.logf("error", "rollback flip failed: %v — duckling still points at %s; fix manually", err, o.op.ToShard)
+				recovered = false
 			}
 			o.dropPartialTarget(ctx)
 		case o.op.TargetKind == configstore.MetadataStoreKindCnpgShard && o.op.SourceKind == configstore.MetadataStoreKindExternal:
@@ -1302,12 +1313,13 @@ func (o *opRun) rollback(ctx context.Context) {
 				Database:          o.op.SourceDatabase,
 			}); err != nil {
 				o.logf("error", "rollback flip failed: %v — duckling still points at cnpg %s; fix manually", err, o.op.ToShard)
+				recovered = false
 			}
 			o.dropPartialTarget(ctx)
 		case o.op.TargetKind == configstore.MetadataStoreKindExternal:
 			// cnpg→ext flipped: the cnpg source was ORPHANED (retained), not
 			// deleted, so recovery flips back and re-ADOPTS it — no copy-back.
-			o.recoverFromExternal(ctx)
+			recovered = o.recoverFromExternal(ctx)
 		}
 	} else if o.op.TargetKind == configstore.MetadataStoreKindExternal {
 		// cnpg→ext failed BEFORE the flip: source untouched.
@@ -1331,7 +1343,7 @@ func (o *opRun) rollback(ctx context.Context) {
 
 	o.restoreCompaction(ctx)
 
-	if o.blocked {
+	if o.blocked && recovered {
 		if err := o.r.store.UpdateWarehouseState(o.op.OrgID, configstore.ManagedWarehouseStateResharding, map[string]interface{}{
 			"state":          configstore.ManagedWarehouseStateReady,
 			"status_message": "metadata-store reshard rolled back",
@@ -1343,6 +1355,8 @@ func (o *opRun) rollback(ctx context.Context) {
 			o.op.UnblockedAt = &now
 			o.logf("info", "warehouse unblocked: resharding → ready (rolled back)")
 		}
+	} else if o.blocked {
+		o.logf("error", "warehouse remains blocked because catalog recovery did not complete successfully; repair the metadata-store target, then explicitly restore warehouse readiness")
 	}
 }
 
@@ -1366,12 +1380,12 @@ func (o *opRun) dropPartialTarget(ctx context.Context) {
 // re-ADOPTS the role/DB by external-name (same pgIdent, same pinned password).
 // No empty-recreate, no copy-back — the catalog never left the source. This is
 // the whole point of the orphan-adopt escape hatch.
-func (o *opRun) recoverFromExternal(ctx context.Context) {
+func (o *opRun) recoverFromExternal(ctx context.Context) bool {
 	o.logf("warn", "cnpg→external cutover failed AFTER the flip — the cnpg source role/DB were RETAINED (orphaned), not deleted; recovering by flipping back to shard %s and re-adopting them (no data copy)", o.op.FromShard)
 
 	if err := o.r.duckling.SetMetadataStoreCnpgAdopt(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
 		o.logf("error", "recovery flip-back failed: %v — duckling still points at the external target; the orphaned cnpg role/DB survive on %s and can be re-adopted manually (patch spec.metadataStore to {type: cnpg-shard, cnpgShard: %s, retainCnpgOnFlip: false}); fix manually", err, o.op.FromShard, o.op.FromShard)
-		return
+		return false
 	}
 
 	// Wait for the composition to re-adopt the role/DB on the source shard and
@@ -1391,7 +1405,7 @@ func (o *opRun) recoverFromExternal(ctx context.Context) {
 	for {
 		if time.Now().After(deadline) {
 			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", o.flipTimeout(), o.op.FromShard, lastObserved)
-			return
+			return false
 		}
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
 		switch {
@@ -1411,7 +1425,7 @@ func (o *opRun) recoverFromExternal(ctx context.Context) {
 			probeErr := o.r.copier.Probe(ctx, restored)
 			if probeErr == nil {
 				o.logf("info", "recovery complete: duckling re-adopted the orphaned cnpg role/DB on %s and the tenant role answers — no data was copied back (the catalog never left the source)", o.op.FromShard)
-				return
+				return true
 			}
 			// describeProbeFailure names an auth failure explicitly (stranded
 			// re-adopted-role password) with the manual ALTER ROLE remedy.

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -87,6 +87,7 @@ type reshardStore interface {
 	UpdateReshardFields(id int64, runnerCP string, epoch int64, updates map[string]interface{}) error
 	TouchReshardHeartbeat(id int64, runnerCP string, epoch int64) error
 	FinishReshardOperation(id int64, runnerCP string, epoch int64, state configstore.ReshardState, errMsg string) error
+	FinalizeReshardOperation(id int64, runnerCP string, epoch int64, orgID string, warehouseUpdates map[string]interface{}, unblockedAt time.Time) error
 	AppendReshardLog(opID int64, level, message string) error
 
 	SetWarehouseResharding(orgID string) error
@@ -267,7 +268,8 @@ type opRun struct {
 	target CatalogEndpoint
 
 	// snapshot row counts from the copy (source-stability recheck reference)
-	copied CatalogCopyResult
+	copied      CatalogCopyResult
+	sourceFence func()
 }
 
 func (o *opRun) logf(level, format string, args ...any) {
@@ -409,7 +411,11 @@ func (r *ReshardRunner) execute(ctx context.Context, op *configstore.ReshardOper
 	o.reconstructProgress()
 	o.logf("info", "operation claimed by %s (epoch %d): %s → %s", r.cpID, op.RunnerEpoch, describeSource(op), describeTarget(op))
 
-	// Heartbeat until the op function returns. A fencing loss stops the op.
+	// Heartbeat until the op function returns. A confirmed fencing loss cancels
+	// the context used by every external side effect. Transient store errors are
+	// retried: they do not prove that ownership changed.
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
 	hbCtx, hbCancel := context.WithCancel(ctx)
 	defer hbCancel()
 	fenced := make(chan struct{})
@@ -422,15 +428,25 @@ func (r *ReshardRunner) execute(ctx context.Context, op *configstore.ReshardOper
 				return
 			case <-ticker.C:
 				if err := r.store.TouchReshardHeartbeat(op.ID, r.cpID, op.RunnerEpoch); err != nil {
-					slog.Error("Reshard: heartbeat fenced — another runner took over; abandoning.", "op", op.ID, "error", err)
-					close(fenced)
-					return
+					if errors.Is(err, configstore.ErrReshardFenced) {
+						slog.Error("Reshard: heartbeat fenced — another runner took over; abandoning.", "op", op.ID, "error", err)
+						close(fenced)
+						runCancel()
+						return
+					}
+					slog.Warn("Reshard: heartbeat update failed; retaining ownership and retrying.", "op", op.ID, "error", err)
 				}
 			}
 		}
 	}()
 
-	runErr := o.run(ctx, fenced)
+	runErr := o.run(runCtx, fenced)
+	select {
+	case <-fenced:
+		o.logf("error", "operation fenced: another runner took over; this runner abandons it")
+		return
+	default:
+	}
 	if runErr == nil {
 		return
 	}
@@ -482,6 +498,9 @@ func (o *opRun) run(ctx context.Context, fenced <-chan struct{}) error {
 	}
 	if o.cancelRequested() {
 		return errReshardCancelled
+	}
+	if o.op.Step != "" {
+		return o.resumeTakeover(ctx)
 	}
 
 	if err := o.block(ctx); err != nil {
@@ -546,6 +565,53 @@ func (o *opRun) run(ctx context.Context, fenced <-chan struct{}) error {
 	}
 
 	return o.finalize(ctx)
+}
+
+// resumeTakeover continues only phases whose durable inputs are sufficient to
+// make replay safe. In particular, it never re-runs recordSource after cutover:
+// the live Duckling status names the target at that point. Earlier and external
+// target phases fail into the conservative rollback path.
+func (o *opRun) resumeTakeover(ctx context.Context) error {
+	if o.op.TargetKind != configstore.MetadataStoreKindCnpgShard ||
+		o.op.SourceKind != configstore.MetadataStoreKindCnpgShard {
+		return fmt.Errorf("takeover at step %q cannot be resumed safely; rolling back from durable progress", o.op.Step)
+	}
+
+	switch o.op.Step {
+	case "copying", "verifying":
+		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
+		if err != nil {
+			return fmt.Errorf("read target status during takeover: %w", err)
+		}
+		if o.op.SourceEndpoint == "" || o.op.SourceUser == "" || o.op.SourceDatabase == "" {
+			return fmt.Errorf("takeover at step %q has incomplete durable source identity", o.op.Step)
+		}
+		o.source = CatalogEndpoint{
+			Host: o.op.SourceEndpoint, Port: 5432, User: o.op.SourceUser,
+			Password: st.MetadataStore.Password, Database: o.op.SourceDatabase, SSLMode: "disable",
+		}
+		o.target = CatalogEndpoint{
+			Host: st.MetadataStore.Endpoint, Port: 5432, User: st.MetadataStore.User,
+			Password: st.MetadataStore.Password, Database: st.MetadataStore.Database, SSLMode: "disable",
+		}
+		if err := o.copyCatalog(ctx); err != nil {
+			return err
+		}
+		if err := o.verifySourceStable(ctx); err != nil {
+			return err
+		}
+		if err := o.cleanupSource(ctx); err != nil {
+			return err
+		}
+		return o.finalize(ctx)
+	case "cleaning_up", "finalizing":
+		// Copy+verification already completed. Source cleanup is explicitly
+		// best-effort, so it is safer to leave possible cruft than to reconstruct
+		// credentials and risk dropping the live target.
+		return o.finalize(ctx)
+	default:
+		return fmt.Errorf("takeover at step %q cannot be resumed safely; rolling back from durable progress", o.op.Step)
+	}
 }
 
 // ---- steps ----------------------------------------------------------------
@@ -1072,6 +1138,17 @@ func (o *opRun) verifyExternalCatalog(ctx context.Context) error {
 			return fmt.Errorf("external target table %s row count %d != copied %d — catalog incomplete; NOT dropping the retained cnpg source", table, got, want)
 		}
 	}
+	if len(o.copied.PerTableFingerprints) > 0 {
+		fingerprints, err := o.r.copier.SnapshotFingerprints(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) })
+		if err != nil {
+			return fmt.Errorf("fingerprinting external target: %w", err)
+		}
+		for table, want := range o.copied.PerTableFingerprints {
+			if got, ok := fingerprints[table]; !ok || got != want {
+				return fmt.Errorf("external target table %s content fingerprint differs from the copy — NOT dropping the retained cnpg source", table)
+			}
+		}
+	}
 	o.logf("info", "verified external target catalog: %d tables match the copied row counts exactly — safe to drop the retained cnpg source", len(current))
 	return nil
 }
@@ -1101,6 +1178,7 @@ func (o *opRun) dropOrphanedCnpgSource(ctx context.Context) error {
 	if err := o.r.duckling.SetMetadataStoreRetainCnpgOnFlip(ctx, o.op.DucklingName, false); err != nil {
 		o.logf("warn", "clearing retainCnpgOnFlip after cnpg→ext completion failed: %v — harmless while on external; a later ext→cnpg reshard should ensure it is false", err)
 	}
+	o.releaseSourceFence()
 	return nil
 }
 
@@ -1147,6 +1225,7 @@ func (o *opRun) copyCatalog(ctx context.Context) error {
 		return fmt.Errorf("catalog copy: %w", err)
 	}
 	o.copied = result
+	o.sourceFence = result.ReleaseSourceFence
 	if err := o.fields(map[string]interface{}{
 		"tables_copied": result.Tables,
 		"rows_copied":   result.Rows,
@@ -1183,6 +1262,21 @@ func (o *opRun) verifySourceStable(ctx context.Context) error {
 			return fmt.Errorf("source table %s changed during the copy (%d rows now, %d in snapshot) — a concurrent writer is active", table, nowCount, snapCount)
 		}
 	}
+	if len(o.copied.PerTableFingerprints) > 0 {
+		fingerprints, err := o.r.copier.SnapshotFingerprints(ctx, o.source, func(level, msg string) { o.logf(level, "%s", msg) })
+		if err != nil {
+			return fmt.Errorf("re-fingerprinting source contents: %w", err)
+		}
+		if len(fingerprints) != len(o.copied.PerTableFingerprints) {
+			return fmt.Errorf("source fingerprint table set changed during the copy")
+		}
+		for table, snapshot := range o.copied.PerTableFingerprints {
+			current, ok := fingerprints[table]
+			if !ok || current != snapshot {
+				return fmt.Errorf("source table %s content changed during the copy despite stable row count — a concurrent writer is active", table)
+			}
+		}
+	}
 	o.logf("info", "verified: source is unchanged since the snapshot (%d tables) — no concurrent writer", len(current))
 	return nil
 }
@@ -1196,6 +1290,7 @@ func (o *opRun) cleanupSource(ctx context.Context) error {
 	}
 	if o.op.SourceKind != configstore.MetadataStoreKindCnpgShard {
 		o.logf("info", "external source left untouched (never deleted)")
+		o.releaseSourceFence()
 		return nil
 	}
 	// o.source is the copy-path source of truth (recorded from the duckling
@@ -1210,10 +1305,19 @@ func (o *opRun) cleanupSource(ctx context.Context) error {
 		// Loud but non-fatal: the copy is verified and live; a leftover
 		// source DB is cruft plus a weaker fence, not data loss.
 		o.logf("error", "DROP DATABASE on the source failed — old catalog database still exists on %s and must be dropped manually: %v", o.op.FromShard, err)
+		o.releaseSourceFence()
 		return nil
 	}
+	o.releaseSourceFence()
 	o.logf("info", "source database dropped (the source role remains; roles cannot drop themselves)")
 	return nil
+}
+
+func (o *opRun) releaseSourceFence() {
+	if o.sourceFence != nil {
+		o.sourceFence()
+		o.sourceFence = nil
+	}
 }
 
 func (o *opRun) finalize(ctx context.Context) error {
@@ -1247,20 +1351,14 @@ func (o *opRun) finalize(ctx context.Context) error {
 		// The XRD defaults stand up a per-duckling pgbouncer for external.
 		updates["pgbouncer_enabled"] = true
 	}
-	if err := o.r.store.UpdateWarehouseState(o.op.OrgID, configstore.ManagedWarehouseStateResharding, updates); err != nil {
-		return fmt.Errorf("unblock warehouse: %w", err)
-	}
 	now := time.Now().UTC()
-	if err := o.fields(map[string]interface{}{"unblocked_at": now}); err != nil {
-		return err
+	if err := o.r.store.FinalizeReshardOperation(o.op.ID, o.r.cpID, o.op.RunnerEpoch, o.op.OrgID, updates, now); err != nil {
+		return fmt.Errorf("atomically finalize reshard and unblock warehouse: %w", err)
 	}
 	o.op.UnblockedAt = &now
 	o.logf("info", "warehouse unblocked: resharding → ready; new sessions cold-spawn against the new metadata store")
 
 	o.report(configstore.ReshardStateSucceeded)
-	if err := o.r.store.FinishReshardOperation(o.op.ID, o.r.cpID, o.op.RunnerEpoch, configstore.ReshardStateSucceeded, ""); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -1288,6 +1386,7 @@ func (o *opRun) restoreCompaction(ctx context.Context) {
 // the op is marked failed/cancelled regardless.
 func (o *opRun) rollback(ctx context.Context) {
 	ctx = context.WithoutCancel(ctx)
+	defer o.releaseSourceFence()
 	recovered := true
 
 	if o.flipped {

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -37,6 +37,11 @@ type fakeReshardStore struct {
 
 	logs  []string
 	steps []string
+
+	heartbeatErrs      []error
+	heartbeatIdx       int
+	heartbeatCalls     int
+	failUnblockedWrite bool
 }
 
 func newFakeReshardStore(op *configstore.ReshardOperation) *fakeReshardStore {
@@ -86,6 +91,9 @@ func (f *fakeReshardStore) UpdateReshardStep(_ int64, _ string, _ int64, step st
 func (f *fakeReshardStore) UpdateReshardFields(_ int64, _ string, _ int64, updates map[string]interface{}) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if _, ok := updates["unblocked_at"]; ok && f.failUnblockedWrite {
+		return errors.New("persist unblocked_at failed")
+	}
 	if v, ok := updates["blocked_at"].(time.Time); ok {
 		f.op.BlockedAt = &v
 	}
@@ -119,13 +127,41 @@ func (f *fakeReshardStore) UpdateReshardFields(_ int64, _ string, _ int64, updat
 	return nil
 }
 
-func (f *fakeReshardStore) TouchReshardHeartbeat(int64, string, int64) error { return nil }
+func (f *fakeReshardStore) TouchReshardHeartbeat(int64, string, int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.heartbeatCalls++
+	if f.heartbeatIdx >= len(f.heartbeatErrs) {
+		return nil
+	}
+	err := f.heartbeatErrs[f.heartbeatIdx]
+	f.heartbeatIdx++
+	return err
+}
 
 func (f *fakeReshardStore) FinishReshardOperation(_ int64, _ string, _ int64, state configstore.ReshardState, errMsg string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.op.State = state
 	f.op.Error = errMsg
+	return nil
+}
+
+func (f *fakeReshardStore) FinalizeReshardOperation(_ int64, _ string, _ int64, _ string, updates map[string]interface{}, unblockedAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failUnblockedWrite {
+		return errors.New("persist finalization failed")
+	}
+	if f.warehouseState != configstore.ManagedWarehouseStateResharding {
+		return configstore.ErrWarehouseStateMismatch
+	}
+	if state, ok := updates["state"].(configstore.ManagedWarehouseProvisioningState); ok {
+		f.warehouseState = state
+	}
+	f.warehouseUpds = append(f.warehouseUpds, updates)
+	f.op.State = configstore.ReshardStateSucceeded
+	f.op.UnblockedAt = &unblockedAt
 	return nil
 }
 
@@ -380,7 +416,37 @@ type fakeCopier struct {
 	// externalCounts is what SnapshotCounts returns for the EXTERNAL target
 	// verify (sslmode==require, cnpg→ext verifyExternalCatalog); defaults to
 	// copyResult.PerTableRows (complete target).
-	externalCounts map[string]int64
+	externalCounts       map[string]int64
+	fingerprintsAfter    map[string]CatalogTableFingerprint
+	externalFingerprints map[string]CatalogTableFingerprint
+}
+
+type blockingCopier struct {
+	*fakeCopier
+	started  chan struct{}
+	released chan struct{}
+	canceled chan struct{}
+}
+
+func newBlockingCopier() *blockingCopier {
+	return &blockingCopier{
+		fakeCopier: &fakeCopier{},
+		started:    make(chan struct{}),
+		released:   make(chan struct{}),
+		canceled:   make(chan struct{}),
+	}
+}
+
+func (f *blockingCopier) Copy(ctx context.Context, source, target CatalogEndpoint, log func(string, string)) (CatalogCopyResult, error) {
+	f.record(copierCall{kind: "copy", source: source, target: target})
+	close(f.started)
+	select {
+	case <-ctx.Done():
+		close(f.canceled)
+		return CatalogCopyResult{}, ctx.Err()
+	case <-f.released:
+		return CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}, nil
+	}
 }
 
 func (f *fakeCopier) record(c copierCall) {
@@ -423,6 +489,16 @@ func (f *fakeCopier) SnapshotCounts(_ context.Context, ep CatalogEndpoint, _ fun
 		return f.countsAfter, nil
 	}
 	return f.copyResult.PerTableRows, nil
+}
+
+func (f *fakeCopier) SnapshotFingerprints(_ context.Context, ep CatalogEndpoint, _ func(string, string)) (map[string]CatalogTableFingerprint, error) {
+	if ep.SSLMode == "require" && f.externalFingerprints != nil {
+		return f.externalFingerprints, nil
+	}
+	if ep.SSLMode != "require" && f.fingerprintsAfter != nil {
+		return f.fingerprintsAfter, nil
+	}
+	return f.copyResult.PerTableFingerprints, nil
 }
 
 func (f *fakeCopier) DropCatalogTables(_ context.Context, ep CatalogEndpoint, _ func(string, string)) error {
@@ -858,6 +934,133 @@ func TestReshardTakeoverPreservesOriginalCompactionSnapshot(t *testing.T) {
 
 	if !store.op.CompactionWasEnabled {
 		t.Fatal("takeover overwrote original compaction=true snapshot with paused live value")
+	}
+}
+
+// TestReshardTakeoverAfterCutoverDoesNotReplaySourceDiscovery models a runner
+// crash after the CR already points at the target. A takeover must use the
+// durable source identity and resume/reconcile from the persisted phase; it
+// must never treat the live target status as the source.
+func TestReshardTakeoverAfterCutoverDoesNotReplaySourceDiscovery(t *testing.T) {
+	op := cnpgOp()
+	op.Step = "copying"
+	op.SourceEndpoint = "shard-001-pooler.cnpg-shards.svc.cluster.local"
+	op.SourceUser = "mdstore_org"
+	op.SourceDatabase = "mdstore_org"
+	blocked := time.Now().UTC().Add(-time.Minute)
+	op.BlockedAt = &blocked
+
+	store := newFakeReshardStore(op)
+	store.warehouseState = configstore.ManagedWarehouseStateResharding
+	targetStatus := cnpgSourceStatus()
+	targetStatus.MetadataStore.Endpoint = "shard-002-pooler.cnpg-shards.svc.cluster.local"
+	duckling := &fakeDuckling{status: targetStatus, compPresent: true, compEnabled: false}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.op.SourceEndpoint != "shard-001-pooler.cnpg-shards.svc.cluster.local" {
+		t.Fatalf("durable source overwritten with live target: %q", store.op.SourceEndpoint)
+	}
+	for _, call := range copier.calls {
+		if call.kind == "copy" && call.source.Host != "shard-001-pooler.cnpg-shards.svc.cluster.local" {
+			t.Fatalf("takeover copied from %q, want durable source shard-001", call.source.Host)
+		}
+		if call.kind == "dropdb" && call.target.Host == "shard-002-pooler.cnpg-shards.svc.cluster.local" {
+			t.Fatal("takeover attempted destructive cleanup against the live target")
+		}
+	}
+}
+
+func executeWithBlockingCopy(t *testing.T, store *fakeReshardStore, heartbeatErr error) (*blockingCopier, <-chan struct{}) {
+	t.Helper()
+	store.heartbeatErrs = []error{heartbeatErr}
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := newBlockingCopier()
+	r := testRunner(store, duckling, copier.fakeCopier)
+	r.copier = copier
+	r.heartbeatInterval = 5 * time.Millisecond
+	op, err := store.ClaimReshardOperation(store.op.ID, r.cpID, r.staleAfter)
+	if err != nil || op == nil {
+		t.Fatalf("claim = %v, %v", op, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.execute(context.Background(), op)
+	}()
+	select {
+	case <-copier.started:
+	case <-time.After(time.Second):
+		t.Fatal("copy did not start")
+	}
+	return copier, done
+}
+
+// TestReshardHeartbeatFenceCancelsInFlightCopy asserts that epoch fencing is
+// propagated through the operation context, including long-running external
+// side effects. Merely closing a channel checked before the first step leaves a
+// zombie copier alive after ownership has moved.
+func TestReshardHeartbeatFenceCancelsInFlightCopy(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	copier, done := executeWithBlockingCopy(t, store, configstore.ErrReshardFenced)
+	defer close(copier.released)
+
+	select {
+	case <-copier.canceled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("in-flight copy context was not cancelled after heartbeat fencing")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("fenced runner did not stop")
+	}
+}
+
+// TestReshardTransientHeartbeatErrorDoesNotFenceRunner distinguishes a store
+// outage from a lost epoch. A transient error must be retried while ownership
+// is retained; it must not silently turn the active operation into a zombie.
+func TestReshardTransientHeartbeatErrorDoesNotFenceRunner(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	copier, done := executeWithBlockingCopy(t, store, errors.New("temporary config-store outage"))
+
+	time.Sleep(30 * time.Millisecond)
+	select {
+	case <-copier.canceled:
+		t.Fatal("transient heartbeat error was treated as fencing")
+	default:
+	}
+	store.mu.Lock()
+	heartbeats := store.heartbeatCalls
+	store.mu.Unlock()
+	if heartbeats < 2 {
+		t.Fatalf("heartbeat attempts = %d, want retry after transient error", heartbeats)
+	}
+	close(copier.released)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not finish after copy release")
+	}
+}
+
+// TestReshardFinalizeFailureRollsBackBeforeReadmittingTraffic pins the final
+// commit invariant: a failed atomic finalization enters the ordinary rollback
+// path, and only that verified recovery may return the warehouse to ready.
+func TestReshardFinalizeFailureRollsBackBeforeReadmittingTraffic(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	store.failUnblockedWrite = true
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.warehouseState != configstore.ManagedWarehouseStateReady || store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state after failed atomic finalization = warehouse %s/op %s, want verified rollback ready/failed", store.warehouseState, store.op.State)
+	}
+	if len(store.warehouseUpds) == 0 || store.warehouseUpds[len(store.warehouseUpds)-1]["status_message"] != "metadata-store reshard rolled back" {
+		t.Fatalf("warehouse was not readmitted through rollback: %v", store.warehouseUpds)
 	}
 }
 
@@ -1524,6 +1727,31 @@ func TestReshardVerifyMismatchRollsBack(t *testing.T) {
 	}
 }
 
+func TestReshardVerifyDetectsSameCountContentMutation(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := &fakeCopier{
+		copyResult: CatalogCopyResult{
+			Tables: 1, Rows: 1,
+			PerTableRows: map[string]int64{"ducklake_metadata": 1},
+			PerTableFingerprints: map[string]CatalogTableFingerprint{
+				"ducklake_metadata": {Rows: 1, Digest: "before"},
+			},
+		},
+		countsAfter: map[string]int64{"ducklake_metadata": 1},
+		fingerprintsAfter: map[string]CatalogTableFingerprint{
+			"ducklake_metadata": {Rows: 1, Digest: "after"},
+		},
+	}
+	runOp(t, testRunner(store, duckling, copier), store)
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state = %s, want failed for same-count content mutation", store.op.State)
+	}
+	if !strings.Contains(store.op.Error, "content changed") {
+		t.Fatalf("error = %q, want content-change diagnosis", store.op.Error)
+	}
+}
+
 // TestProbeErrorAuthClassification pins isAuthProbeError/describeProbeFailure
 // against errors shaped the way catalog_copy.go::Probe actually wraps them
 // (`connect <redacted>: %w` / `probe <redacted>: %w` around pgx errors, whose
@@ -1642,13 +1870,12 @@ func TestReshardExtRecoveryProbeAuthFailureDiagnosed(t *testing.T) {
 			t.Fatalf("op log leaked a password: %q", l)
 		}
 	}
-	// The recovery still ran to its normal conclusion: flip-back + adopt,
-	// warehouse unblocked (auth failures do NOT abort the wait early — a
-	// composition fix may still converge the password mid-wait).
+	// The recovery attempted flip-back + adopt, but traffic must remain blocked
+	// because the tenant role never answered successfully.
 	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
 		t.Fatalf("recovery did not flip back + adopt: %v", duckling.callKinds())
 	}
-	if store.warehouseState != configstore.ManagedWarehouseStateReady {
-		t.Fatalf("warehouse state = %s, want ready after recovery", store.warehouseState)
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding after unverified recovery", store.warehouseState)
 	}
 }

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -809,6 +809,58 @@ type stuckCnpgDuckling struct {
 	*fakeDuckling
 }
 
+// failSourceRecoveryDuckling allows the initial cutover but rejects the
+// rollback patch to the source shard, modeling an API or admission failure.
+type failSourceRecoveryDuckling struct {
+	*fakeDuckling
+}
+
+func (s *failSourceRecoveryDuckling) SetMetadataStoreCnpg(ctx context.Context, name, shard string) error {
+	if shard == "shard-001" {
+		return errors.New("source recovery rejected")
+	}
+	return s.fakeDuckling.SetMetadataStoreCnpg(ctx, name, shard)
+}
+
+// TestReshardRollbackKeepsWarehouseBlockedWhenSourceRecoveryFails asserts the
+// safety invariant: traffic cannot be admitted unless rollback has positively
+// restored a usable catalog. Logging and swallowing this error is unsafe.
+func TestReshardRollbackKeepsWarehouseBlockedWhenSourceRecoveryFails(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	duckling := &failSourceRecoveryDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
+	copier := &fakeCopier{copyErr: errors.New("copy failed after cutover")}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state = %s, want failed", store.op.State)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding after failed source recovery", store.warehouseState)
+	}
+	if store.op.UnblockedAt != nil {
+		t.Fatalf("unblocked_at = %v after failed source recovery", store.op.UnblockedAt)
+	}
+}
+
+// TestReshardTakeoverPreservesOriginalCompactionSnapshot ensures replay cannot
+// replace the persisted pre-reshard setting with the already-paused live value.
+func TestReshardTakeoverPreservesOriginalCompactionSnapshot(t *testing.T) {
+	op := cnpgOp()
+	op.Step = "pausing_compaction"
+	op.CompactionWasPresent = true
+	op.CompactionWasEnabled = true
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: false}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if !store.op.CompactionWasEnabled {
+		t.Fatal("takeover overwrote original compaction=true snapshot with paused live value")
+	}
+}
+
 func (s *stuckCnpgDuckling) SetMetadataStoreCnpg(_ context.Context, _ string, shard string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/controlplane/reshard_metrics.go
+++ b/controlplane/reshard_metrics.go
@@ -1,0 +1,27 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	reshardActiveOperationsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "duckgres_reshard_active_operations",
+		Help: "Number of pending or running reshard operations.",
+	})
+	reshardStaleOperationsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "duckgres_reshard_stale_operations",
+		Help: "Number of reshard operations currently requiring runner reconciliation.",
+	})
+	reshardRecoveryRequiredGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "duckgres_reshard_recovery_required_operations",
+		Help: "Number of active reshards whose automatic runner respawns are paused.",
+	})
+	reshardRespawnCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_reshard_runner_respawns_total",
+		Help: "Reshard runner respawn interventions by outcome.",
+	}, []string{"outcome"})
+)

--- a/controlplane/reshard_pod.go
+++ b/controlplane/reshard_pod.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	corev1 "k8s.io/api/core/v1"
@@ -33,8 +34,9 @@ import (
 
 // reshardPodAppLabel / reshardPodOpIDLabel identify reshard runner pods.
 const (
-	reshardPodAppLabel  = "duckgres-reshard"
-	reshardPodOpIDLabel = "duckgres-op-id"
+	reshardPodAppLabel            = "duckgres-reshard"
+	reshardPodOpIDLabel           = "duckgres-op-id"
+	reshardPodSpawnedAtAnnotation = "duckgres.posthog.com/runner-spawned-at"
 )
 
 // reshardPodDefaultCPU / reshardPodDefaultMemory are the runner pod's resource
@@ -221,7 +223,10 @@ func (s *ReshardPodSpawner) SpawnReshardPod(ctx context.Context, op *configstore
 			},
 			// A reshard is a long single-shot maintenance operation; don't let
 			// node consolidation kill it mid-copy.
-			Annotations: map[string]string{doNotDisruptAnnotation: "true"},
+			Annotations: map[string]string{
+				doNotDisruptAnnotation:        "true",
+				reshardPodSpawnedAtAnnotation: time.Now().UTC().Format(time.RFC3339Nano),
+			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                 corev1.RestartPolicyNever,

--- a/controlplane/reshard_pod.go
+++ b/controlplane/reshard_pod.go
@@ -183,9 +183,17 @@ func (s *ReshardPodSpawner) SpawnReshardPod(ctx context.Context, op *configstore
 		env = append(env, corev1.EnvVar{Name: "DUCKGRES_RESHARD_PASSWORD_URL", Value: op.PasswordURL})
 	}
 
+	cpu, err := resource.ParseQuantity(s.cpuRequest)
+	if err != nil {
+		return fmt.Errorf("invalid reshard pod CPU %q: %w", s.cpuRequest, err)
+	}
+	memory, err := resource.ParseQuantity(s.memoryRequest)
+	if err != nil {
+		return fmt.Errorf("invalid reshard pod memory %q: %w", s.memoryRequest, err)
+	}
 	requests := corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse(s.cpuRequest),
-		corev1.ResourceMemory: resource.MustParse(s.memoryRequest),
+		corev1.ResourceCPU:    cpu,
+		corev1.ResourceMemory: memory,
 	}
 	limits := make(corev1.ResourceList, len(requests))
 	for k, v := range requests {

--- a/controlplane/reshard_pod.go
+++ b/controlplane/reshard_pod.go
@@ -83,6 +83,20 @@ type ReshardPodSpawner struct {
 	memoryRequest string // env-only DUCKGRES_RESHARD_POD_MEMORY (default 8Gi)
 }
 
+func (s *ReshardPodSpawner) RunnerImage(ctx context.Context) (string, error) {
+	if s == nil || s.clientset == nil {
+		return "", fmt.Errorf("no reshard pod spawner (kubernetes API unavailable)")
+	}
+	cpPod, err := s.clientset.CoreV1().Pods(s.namespace).Get(ctx, s.selfPodName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("read own control-plane pod %s/%s: %w", s.namespace, s.selfPodName, err)
+	}
+	if len(cpPod.Spec.Containers) == 0 || cpPod.Spec.Containers[0].Image == "" {
+		return "", fmt.Errorf("control-plane pod %s has no runner image", s.selfPodName)
+	}
+	return cpPod.Spec.Containers[0].Image, nil
+}
+
 // NewReshardPodSpawner builds a spawner over the shared in-cluster clientset.
 // cpu/memory come from the resolved env-only knobs ("" → defaults).
 func NewReshardPodSpawner(clientset kubernetes.Interface, namespace, selfPodName, cpu, memory string) *ReshardPodSpawner {
@@ -150,6 +164,11 @@ func (s *ReshardPodSpawner) SpawnReshardPod(ctx context.Context, op *configstore
 		return fmt.Errorf("control-plane pod %s has no containers", s.selfPodName)
 	}
 	cpContainer := cpPod.Spec.Containers[0]
+	runnerImage := op.RunnerImage
+	if runnerImage == "" {
+		// Legacy operations created before runner_image was persisted.
+		runnerImage = cpContainer.Image
+	}
 
 	// Inherit the allowlisted env VERBATIM — a secretKeyRef stays a
 	// secretKeyRef; nothing secret is copied by value into the pod spec.
@@ -247,7 +266,7 @@ func (s *ReshardPodSpawner) SpawnReshardPod(ctx context.Context, op *configstore
 			Containers: []corev1.Container{
 				{
 					Name:            "reshard-runner",
-					Image:           cpContainer.Image,
+					Image:           runnerImage,
 					ImagePullPolicy: cpContainer.ImagePullPolicy,
 					Args:            []string{"--mode", "reshard-runner"},
 					Env:             env,

--- a/controlplane/reshard_pod_test.go
+++ b/controlplane/reshard_pod_test.go
@@ -138,7 +138,7 @@ func TestSpawnReshardPodKnobsAndNoPasswordURL(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(fakeCPPod())
 	s := NewReshardPodSpawner(cs, "duckgres", "duckgres-control-plane-abc-xyz", "4", "16Gi")
 
-	op := &configstore.ReshardOperation{ID: 7, OrgID: "acme", TargetKind: configstore.MetadataStoreKindCnpgShard}
+	op := &configstore.ReshardOperation{ID: 7, OrgID: "acme", TargetKind: configstore.MetadataStoreKindCnpgShard, RunnerImage: "example/duckgres:pinned-at-submit"}
 	if err := s.SpawnReshardPod(context.Background(), op); err != nil {
 		t.Fatalf("SpawnReshardPod: %v", err)
 	}
@@ -147,6 +147,9 @@ func TestSpawnReshardPodKnobsAndNoPasswordURL(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	c := pod.Spec.Containers[0]
+	if c.Image != op.RunnerImage {
+		t.Fatalf("runner image = %q, want operation-pinned %q", c.Image, op.RunnerImage)
+	}
 	cpu := c.Resources.Requests[corev1.ResourceCPU]
 	mem := c.Resources.Requests[corev1.ResourceMemory]
 	if cpu.String() != "4" || mem.String() != "16Gi" {

--- a/controlplane/reshard_pod_test.go
+++ b/controlplane/reshard_pod_test.go
@@ -157,6 +157,20 @@ func TestSpawnReshardPodKnobsAndNoPasswordURL(t *testing.T) {
 	}
 }
 
+func TestSpawnReshardPodRejectsInvalidResourceKnobsWithoutPanicking(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset(fakeCPPod())
+	s := NewReshardPodSpawner(cs, "duckgres", "duckgres-control-plane-abc-xyz", "not-a-cpu", "also-bad")
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("SpawnReshardPod panicked on invalid operator config: %v", recovered)
+		}
+	}()
+	err := s.SpawnReshardPod(context.Background(), &configstore.ReshardOperation{ID: 8})
+	if err == nil || !strings.Contains(err.Error(), "invalid reshard pod") {
+		t.Fatalf("error = %v, want invalid reshard pod resource error", err)
+	}
+}
+
 // TestSpawnReshardPodMissingCPPod pins the failure mode when the CP cannot
 // read its own pod (the template): a clear error, no pod created.
 func TestSpawnReshardPodMissingCPPod(t *testing.T) {

--- a/controlplane/reshard_reconciler.go
+++ b/controlplane/reshard_reconciler.go
@@ -129,12 +129,17 @@ func (r *reshardReconciler) reconcileActiveOp(ctx context.Context, op *configsto
 		return
 	}
 	if pod != nil && pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
-		// A live (or still-starting) pod exists; give it time to claim and
-		// heartbeat. A wedged-but-Running pod keeps the op heartbeat stale and
-		// we land here again — but replacing a Running pod on every tick would
-		// thrash, so only exited pods are replaced.
-		return
+		if spawnedAt, err := time.Parse(time.RFC3339Nano, pod.Annotations[reshardPodSpawnedAtAnnotation]); err == nil && time.Since(spawnedAt) <= r.pendingGrace {
+			// A replacement was created recently and needs time to schedule, start,
+			// and claim the stale row. Do not replace it again on every tick.
+			return
+		}
 	}
+	// Reaching this point means the operation itself is stale. Pod phase is not
+	// a liveness signal: a wedged process remains Running forever. Replace even
+	// a non-terminal pod; SpawnReshardPod deletes the deterministic old pod
+	// before creating its successor. Fresh-heartbeat operations never reach
+	// this branch, so healthy runners are left alone.
 
 	attempts := r.respawnAttempts[op.ID]
 	if attempts >= r.maxRespawnAttempts {

--- a/controlplane/reshard_reconciler.go
+++ b/controlplane/reshard_reconciler.go
@@ -39,15 +39,13 @@ type reshardReconciler struct {
 	terminalPodGrace time.Duration // how long a terminal op's still-running pod is left to exit on its own
 
 	maxRespawnAttempts int
-	respawnAttempts    map[int64]int // opID → consecutive failed respawns (leader-local)
 }
 
 // reshardReconcilerStore is the config-store surface the reconciler needs.
 type reshardReconcilerStore interface {
 	ListActiveReshardOperations() ([]configstore.ReshardOperation, error)
 	GetReshardOperation(id int64) (*configstore.ReshardOperation, error)
-	ClaimReshardOperation(id int64, runnerCP string, staleAfter time.Duration) (*configstore.ReshardOperation, error)
-	FinishReshardOperation(id int64, runnerCP string, epoch int64, state configstore.ReshardState, errMsg string) error
+	IncrementReshardRespawnAttempts(id int64) (int64, error)
 	AppendReshardLog(opID int64, level, message string) error
 }
 
@@ -60,7 +58,6 @@ func newReshardReconciler(store reshardReconcilerStore, spawner *ReshardPodSpawn
 		staleAfter:         5 * time.Minute,
 		terminalPodGrace:   5 * time.Minute,
 		maxRespawnAttempts: 3,
-		respawnAttempts:    map[int64]int{},
 	}
 }
 
@@ -89,17 +86,22 @@ func (r *reshardReconciler) reconcileOnce(ctx context.Context) {
 		return
 	}
 	active := make(map[int64]struct{}, len(ops))
+	stale := 0
+	recoveryRequired := 0
 	for i := range ops {
 		op := &ops[i]
 		active[op.ID] = struct{}{}
+		if r.opNeedsPod(op) {
+			stale++
+		}
+		if op.RespawnAttempts > int64(r.maxRespawnAttempts) {
+			recoveryRequired++
+		}
 		r.reconcileActiveOp(ctx, op)
 	}
-	// Attempt counters for ops no longer active are done.
-	for id := range r.respawnAttempts {
-		if _, ok := active[id]; !ok {
-			delete(r.respawnAttempts, id)
-		}
-	}
+	reshardActiveOperationsGauge.Set(float64(len(ops)))
+	reshardStaleOperationsGauge.Set(float64(stale))
+	reshardRecoveryRequiredGauge.Set(float64(recoveryRequired))
 	r.reapTerminalPods(ctx, active)
 }
 
@@ -140,50 +142,47 @@ func (r *reshardReconciler) reconcileActiveOp(ctx context.Context, op *configsto
 	// a non-terminal pod; SpawnReshardPod deletes the deterministic old pod
 	// before creating its successor. Fresh-heartbeat operations never reach
 	// this branch, so healthy runners are left alone.
-
-	attempts := r.respawnAttempts[op.ID]
-	if attempts >= r.maxRespawnAttempts {
-		r.failOpAfterRespawnsExhausted(op)
+	if op.RespawnAttempts > int64(r.maxRespawnAttempts) {
 		return
 	}
-	r.respawnAttempts[op.ID] = attempts + 1
+
+	attempt, err := r.store.IncrementReshardRespawnAttempts(op.ID)
+	if err != nil {
+		slog.Warn("Reshard reconciler: recording durable respawn attempt failed.", "op", op.ID, "error", err)
+		return
+	}
+	if attempt > int64(r.maxRespawnAttempts) {
+		if attempt == int64(r.maxRespawnAttempts+1) {
+			r.markOpRecoveryRequired(op)
+		}
+		return
+	}
 	slog.Info("Reshard reconciler: (re)spawning runner pod.",
-		"op", op.ID, "state", op.State, "attempt", attempts+1, "pod_was", podPhaseOrAbsent(pod))
+		"op", op.ID, "state", op.State, "attempt", attempt, "pod_was", podPhaseOrAbsent(pod))
 	_ = r.store.AppendReshardLog(op.ID, "warn",
 		fmt.Sprintf("runner pod missing or dead (%s) — respawning %s (attempt %d/%d)",
-			podPhaseOrAbsent(pod), ReshardPodName(op.ID), attempts+1, r.maxRespawnAttempts))
+			podPhaseOrAbsent(pod), ReshardPodName(op.ID), attempt, r.maxRespawnAttempts))
 	if err := r.spawner.SpawnReshardPod(ctx, op); err != nil {
+		reshardRespawnCounter.WithLabelValues("failed").Inc()
 		slog.Warn("Reshard reconciler: respawn failed.", "op", op.ID, "error", err)
 		_ = r.store.AppendReshardLog(op.ID, "error", "respawning runner pod failed: "+err.Error())
 		return
 	}
+	reshardRespawnCounter.WithLabelValues("spawned").Inc()
 	// A successful spawn resets nothing: the counter counts consecutive
 	// reconciler interventions for this op, so a pod that keeps dying still
 	// converges to the failure below instead of respawning forever. The
 	// counter is dropped once the op leaves the active set.
 }
 
-// failOpAfterRespawnsExhausted terminates an op whose runner pod cannot be
-// kept alive. The claim CAS (epoch bump) fences any zombie runner first, then
-// the op is finished failed. The warehouse may still be blocked in
-// `resharding` — there is no runner to roll back — so the error says exactly
-// that; this is the page-someone signal.
-func (r *reshardReconciler) failOpAfterRespawnsExhausted(op *configstore.ReshardOperation) {
-	msg := fmt.Sprintf("reshard runner pod died/failed to start %d times — giving up. "+
-		"The warehouse may still be blocked (state resharding) and partial state may need manual rollback; "+
-		"investigate the %s pod events, then cancel/re-run.", r.maxRespawnAttempts, ReshardPodName(op.ID))
-	claimed, err := r.store.ClaimReshardOperation(op.ID, "reshard-reconciler", r.staleAfter)
-	if err != nil || claimed == nil {
-		slog.Warn("Reshard reconciler: claiming op to force-fail it did not succeed.", "op", op.ID, "error", err)
-		return
-	}
-	if err := r.store.FinishReshardOperation(op.ID, "reshard-reconciler", claimed.RunnerEpoch, configstore.ReshardStateFailed, msg); err != nil {
-		slog.Warn("Reshard reconciler: force-failing op failed.", "op", op.ID, "error", err)
-		return
-	}
-	slog.Error("Reshard reconciler: operation force-failed after exhausted respawns.", "op", op.ID)
+// markOpRecoveryRequired leaves the operation active and therefore keeps the
+// connection barrier intact. Terminal-failing without rollback creates an
+// unrecoverable state: cancel/re-run cannot operate on a blocked warehouse.
+func (r *reshardReconciler) markOpRecoveryRequired(op *configstore.ReshardOperation) {
+	msg := fmt.Sprintf("reshard runner pod died/failed to start %d times — automatic respawn paused with the operation ACTIVE and the warehouse safely blocked. "+
+		"Repair the %s scheduling/startup failure, reset respawn_attempts to 0, and let the reconciler resume; see docs/runbooks/resharding.md.", r.maxRespawnAttempts, ReshardPodName(op.ID))
+	slog.Error("Reshard reconciler: operation requires manual recovery after exhausted respawns.", "op", op.ID)
 	_ = r.store.AppendReshardLog(op.ID, "error", msg)
-	delete(r.respawnAttempts, op.ID)
 }
 
 // reapTerminalPods deletes runner pods whose operation is no longer active:

--- a/controlplane/reshard_reconciler_test.go
+++ b/controlplane/reshard_reconciler_test.go
@@ -114,6 +114,37 @@ func TestReconcilerRespawnsDeadRunner(t *testing.T) {
 	}
 }
 
+// TestReconcilerReplacesWedgedRunningPod covers the failure mode where the
+// process remains Running but has stopped heartbeating. Pod phase is not proof
+// of liveness: the stale lease must cause a replacement so takeover can occur.
+func TestReconcilerReplacesWedgedRunningPod(t *testing.T) {
+	op := staleRunningOp(9)
+	wedged := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "duckgres-reshard-op-9", Namespace: "duckgres",
+			Labels: map[string]string{"app": "duckgres-reshard", "duckgres-op-id": "9"},
+			UID:    "wedged-runner",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	store := &fakeReconcilerStore{ops: map[int64]*configstore.ReshardOperation{9: op}}
+	cs := k8sfake.NewSimpleClientset(fakeCPPod(), wedged)
+	r := testReconciler(store, cs)
+
+	r.reconcileOnce(context.Background())
+
+	pod, err := cs.CoreV1().Pods("duckgres").Get(context.Background(), wedged.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("replacement runner missing: %v", err)
+	}
+	if pod.UID == wedged.UID {
+		t.Fatal("stale-heartbeat Running pod was left in place")
+	}
+	if got := r.respawnAttempts[9]; got != 1 {
+		t.Fatalf("respawn attempts = %d, want 1", got)
+	}
+}
+
 // TestReconcilerLeavesHealthyOpsAlone pins: fresh-heartbeat running ops and
 // young pending ops are untouched.
 func TestReconcilerLeavesHealthyOpsAlone(t *testing.T) {

--- a/controlplane/reshard_reconciler_test.go
+++ b/controlplane/reshard_reconciler_test.go
@@ -69,6 +69,12 @@ func (f *fakeReconcilerStore) AppendReshardLog(_ int64, level, message string) e
 	return nil
 }
 
+func (f *fakeReconcilerStore) IncrementReshardRespawnAttempts(id int64) (int64, error) {
+	op := f.ops[id]
+	op.RespawnAttempts++
+	return op.RespawnAttempts, nil
+}
+
 func staleRunningOp(id int64) *configstore.ReshardOperation {
 	hb := time.Now().UTC().Add(-time.Hour)
 	return &configstore.ReshardOperation{
@@ -109,7 +115,7 @@ func TestReconcilerRespawnsDeadRunner(t *testing.T) {
 
 	// A live pod now exists: the next tick must NOT replace it.
 	r.reconcileOnce(context.Background())
-	if got := r.respawnAttempts[1]; got != 1 {
+	if got := store.ops[1].RespawnAttempts; got != 1 {
 		t.Fatalf("respawn attempts = %d after a successful spawn + live pod, want 1", got)
 	}
 }
@@ -140,7 +146,7 @@ func TestReconcilerReplacesWedgedRunningPod(t *testing.T) {
 	if pod.UID == wedged.UID {
 		t.Fatal("stale-heartbeat Running pod was left in place")
 	}
-	if got := r.respawnAttempts[9]; got != 1 {
+	if got := store.ops[9].RespawnAttempts; got != 1 {
 		t.Fatalf("respawn attempts = %d, want 1", got)
 	}
 }
@@ -180,10 +186,9 @@ func TestReconcilerRespawnsStalePending(t *testing.T) {
 	}
 }
 
-// TestReconcilerRetryBoundForceFails pins the bound: after maxRespawnAttempts
-// interventions the op is force-failed (claimed + finished) with the clear
-// operator-facing error, and the counter is dropped.
-func TestReconcilerRetryBoundForceFails(t *testing.T) {
+// TestReconcilerRetryBoundLeavesOperationRecoverable pins the bound without
+// terminal-stranding the blocked warehouse.
+func TestReconcilerRetryBoundLeavesOperationRecoverable(t *testing.T) {
 	store := &fakeReconcilerStore{ops: map[int64]*configstore.ReshardOperation{1: staleRunningOp(1)}}
 	// No CP pod in the fake cluster → every spawn fails (own-pod read error).
 	cs := k8sfake.NewSimpleClientset()
@@ -196,14 +201,26 @@ func TestReconcilerRetryBoundForceFails(t *testing.T) {
 		}
 	}
 	r.reconcileOnce(context.Background())
-	if store.ops[1].State != configstore.ReshardStateFailed {
-		t.Fatalf("op state = %s after exhausted respawns, want failed", store.ops[1].State)
+	if store.ops[1].State != configstore.ReshardStateRunning {
+		t.Fatalf("op state = %s after exhausted respawns, want active running", store.ops[1].State)
 	}
-	if !strings.Contains(store.ops[1].Error, "giving up") {
-		t.Fatalf("force-fail error = %q", store.ops[1].Error)
+	if !strings.Contains(strings.Join(store.logs, "\n"), "automatic respawn paused") {
+		t.Fatalf("recovery-required log missing: %v", store.logs)
 	}
-	if _, tracked := r.respawnAttempts[1]; tracked {
-		t.Fatal("respawn counter not dropped after force-fail")
+	if store.ops[1].RespawnAttempts != int64(r.maxRespawnAttempts+1) {
+		t.Fatalf("durable respawn attempts = %d", store.ops[1].RespawnAttempts)
+	}
+}
+
+func TestReconcilerRetryBoundSurvivesLeaderChurn(t *testing.T) {
+	store := &fakeReconcilerStore{ops: map[int64]*configstore.ReshardOperation{1: staleRunningOp(1)}}
+	cs := k8sfake.NewSimpleClientset()
+	for i := 0; i <= 3; i++ {
+		// A new reconciler models a process restart or janitor lease handoff.
+		testReconciler(store, cs).reconcileOnce(context.Background())
+	}
+	if store.ops[1].State != configstore.ReshardStateRunning {
+		t.Fatalf("op state after leader churn = %s, want active recovery state", store.ops[1].State)
 	}
 }
 

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -158,7 +158,13 @@ blocking → draining → pausing_compaction → backup_catalog → cutover → 
 6. **copying** — source read via its recorded pre-flip endpoint (the orphaned
    role/DB survives a shard flip; an ext source is reached direct-to-RDS with
    TLS because the flip deletes its ESO sync + pgbouncer). One
-   REPEATABLE READ read-only transaction = consistent snapshot; faithful DDL
+   REPEATABLE READ transaction = consistent snapshot. The transaction takes
+   `SHARE` locks on every discovered `ducklake_*` table, re-discovers the table
+   set after locking, and remains open through verification and source cleanup;
+   this blocks DML and conflicting DDL without killing an already-running
+   writer. Source and target also receive streaming, order-independent SHA-256
+   multiset fingerprints of canonical `jsonb` rows, so same-count UPDATEs and
+   balanced DELETE+INSERT changes cannot pass verification. Faithful DDL
    from `pg_catalog` introspection; rows via raw binary COPY passthrough;
    constraints then non-constraint indexes (PK-backed indexes excluded — ADD
    CONSTRAINT already made them). No sequences exist in the DuckLake catalog

--- a/docs/runbooks/resharding.md
+++ b/docs/runbooks/resharding.md
@@ -1,0 +1,44 @@
+# Resharding Operations
+
+## Local development
+
+Run the normal local checks with `just build`, `just test-unit`, and
+`just lint`. Kubernetes-tagged reshard tests use the fake client and run under
+`just test-controlplane-k8s`; they do not require a live cluster, though other
+packages in that recipe may require the repository's Postgres test setup.
+
+Runner pod resources default to `2` CPU and `8Gi` memory. Override them with
+`DUCKGRES_RESHARD_POD_CPU` and `DUCKGRES_RESHARD_POD_MEMORY`. Invalid
+quantities fail the pod spawn with an operator-visible error; they never panic
+the control plane.
+
+## Failed or stale runner
+
+1. Inspect the operation log and `duckgres-reshard-op-<id>` pod events.
+2. Do not manually set the warehouse to `ready`. The runner only unblocks it
+   after a verified forward completion or verified rollback.
+3. Fix the scheduling, image, RBAC, config-store, or target connectivity error.
+4. If automatic respawn paused after three attempts, reset only the operation's
+   durable counter:
+
+   ```sql
+   UPDATE duckgres_reshard_operations
+   SET respawn_attempts = 0
+   WHERE id = <operation-id> AND state IN ('pending', 'running');
+   ```
+
+5. The leader reconciler will recreate the runner. A takeover never rediscovers
+   the source from post-cutover Duckling status; it resumes only safe durable
+   phases and otherwise rolls back.
+
+## Recovery remains blocked
+
+If the operation is terminal-failed while the warehouse remains `resharding`,
+read the final recovery observations before changing state. Confirm the
+Duckling points at the intended source or target, its tenant role answers, and
+the catalog fingerprint/table set is complete. Only then restore warehouse
+readiness. For a damaged catalog, use the `pg_restore` command recorded beside
+`backup_s3_uri` in the operation log.
+
+Never delete or recreate a retained cnpg database until the operation log shows
+that the external target passed content fingerprint verification.

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -60,6 +60,7 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	// (URL only — the password itself is never persisted).
 	requireColumnPresent(t, db, "duckgres_reshard_operations", "password_url")
 	requireColumnPresent(t, db, "duckgres_reshard_operations", "respawn_attempts")
+	requireColumnPresent(t, db, "duckgres_reshard_operations", "runner_image")
 	requireTablePresent(t, db, "duckgres_reshard_operation_log")
 	requireColumnPresent(t, db, "duckgres_reshard_operation_log", "operation_id")
 

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -41,6 +41,7 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 20)
 	requireGooseMigrationRecorded(t, db, 21)
 	requireGooseMigrationRecorded(t, db, 22)
+	requireGooseMigrationRecorded(t, db, 23)
 	requireGooseLatestVersion(t, db, 22)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
@@ -58,6 +59,7 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	// Migration 000022 added the runner pod's ephemeral-password pull URL
 	// (URL only — the password itself is never persisted).
 	requireColumnPresent(t, db, "duckgres_reshard_operations", "password_url")
+	requireColumnPresent(t, db, "duckgres_reshard_operations", "respawn_attempts")
 	requireTablePresent(t, db, "duckgres_reshard_operation_log")
 	requireColumnPresent(t, db, "duckgres_reshard_operation_log", "operation_id")
 
@@ -204,6 +206,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 20)
 	requireGooseMigrationRecorded(t, upgradedDB, 21)
 	requireGooseMigrationRecorded(t, upgradedDB, 22)
+	requireGooseMigrationRecorded(t, upgradedDB, 23)
 	requireGooseLatestVersion(t, upgradedDB, 22)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -42,7 +42,7 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 21)
 	requireGooseMigrationRecorded(t, db, 22)
 	requireGooseMigrationRecorded(t, db, 23)
-	requireGooseLatestVersion(t, db, 22)
+	requireGooseLatestVersion(t, db, 23)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -171,7 +171,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 21)
 	requireGooseMigrationRecorded(t, upgradedDB, 22)
 	requireGooseMigrationRecorded(t, upgradedDB, 23)
-	requireGooseLatestVersion(t, upgradedDB, 22)
+	requireGooseLatestVersion(t, upgradedDB, 23)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")


### PR DESCRIPTION
## Summary

Hardens resharding against runner crashes, leader changes, stale pods, and concurrent catalog changes.

- Resume takeovers from the persisted phase and stop fenced runners before further side effects.
- Keep failed rollbacks blocked, finalize operation and warehouse state atomically, and persist retry state.
- Pin each operation to its original runner image and replace wedged runner pods safely.
- Hold source-table locks through verification and compare canonical row-content fingerprints before cleanup.
- Validate Kubernetes resource settings without panics, and add recovery metrics and an operator runbook.

This intentionally does not add advisory locking to every Duckgres catalog writer.

## Verification

- `just build`
- `just test-unit`
- `just lint`
- Kubernetes-tagged resharding tests

Full PostgreSQL integration and end-to-end coverage runs in CI.
