### PR TITLE
reshard: remove full-table verification scans

### DIFF
--- a/controlplane/provisioner/catalog_copy.go
+++ b/controlplane/provisioner/catalog_copy.go
@@ -4,8 +4,6 @@ package provisioner
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -96,19 +94,9 @@ type CatalogCopyResult struct {
 	Tables int64
 	Rows   int64
 	Bytes  int64
-	// PerTableRows are the row counts observed INSIDE the source snapshot
-	// transaction — the reference for both the target verify and the
-	// post-copy source-stability recheck.
-	PerTableRows         map[string]int64
-	PerTableFingerprints map[string]CatalogTableFingerprint
 	// ReleaseSourceFence releases the source snapshot and its SHARE locks.
 	// The runner keeps it until verification and destructive cleanup finish.
 	ReleaseSourceFence func()
-}
-
-type CatalogTableFingerprint struct {
-	Rows   int64
-	Digest string
 }
 
 // CatalogCopier is the interface the reshard runner drives; *PGCatalogCopier
@@ -117,15 +105,9 @@ type CatalogCopier interface {
 	// Probe runs SELECT 1 against the endpoint.
 	Probe(ctx context.Context, ep CatalogEndpoint) error
 	// Copy streams the full ducklake_* catalog from source into target and
-	// verifies per-table row counts against the snapshot. log receives
+	// verifies the source and target COPY command-tag row counts. log receives
 	// verbose operator-facing progress lines.
 	Copy(ctx context.Context, source, target CatalogEndpoint, log func(level, msg string)) (CatalogCopyResult, error)
-	// SnapshotCounts re-reads the current per-table row counts (no snapshot
-	// tx) — the post-copy source-stability recheck and the external-catalog
-	// verify. log receives periodic progress lines (a ~20k-table catalog
-	// takes minutes to count).
-	SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error)
-	SnapshotFingerprints(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]CatalogTableFingerprint, error)
 	// DropCatalogTables drops all ducklake_* tables (rollback cleanup of a
 	// partially copied target).
 	DropCatalogTables(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) error
@@ -156,7 +138,7 @@ WHERE table_schema = 'public' AND table_name LIKE 'ducklake\_%' ESCAPE '\'
 ORDER BY table_name`
 
 func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint, log func(level, msg string)) (CatalogCopyResult, error) {
-	result := CatalogCopyResult{PerTableRows: map[string]int64{}, PerTableFingerprints: map[string]CatalogTableFingerprint{}}
+	result := CatalogCopyResult{}
 
 	src, err := pgx.Connect(ctx, source.DSN())
 	if err != nil {
@@ -239,7 +221,6 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 		result.Tables++
 		result.Rows += rows
 		result.Bytes += bytes
-		result.PerTableRows[table] = rows
 		log("info", fmt.Sprintf("copied %s: %d rows, %d bytes", table, rows, bytes))
 	}
 
@@ -252,41 +233,6 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 		return applyIndexes(ctx, tx, dst, table)
 	}, log); err != nil {
 		return result, err
-	}
-
-	// Verify inside the same snapshot: source snapshot counts vs live target.
-	verified, err := verifyCopiedRowCounts(tables,
-		func(table string) (int64, error) {
-			var c int64
-			err := tx.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c)
-			return c, err
-		},
-		func(table string) (int64, error) {
-			var c int64
-			err := dst.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c)
-			return c, err
-		},
-		log)
-	if err != nil {
-		return result, err
-	}
-	for table, c := range verified {
-		result.PerTableRows[table] = c
-	}
-	log("info", fmt.Sprintf("fingerprinting source and target contents across %d tables…", len(tables)))
-	for _, table := range tables {
-		sourceFingerprint, err := fingerprintTable(ctx, tx, table)
-		if err != nil {
-			return result, fmt.Errorf("fingerprint source %s: %w", table, err)
-		}
-		targetFingerprint, err := fingerprintTable(ctx, dst, table)
-		if err != nil {
-			return result, fmt.Errorf("fingerprint target %s: %w", table, err)
-		}
-		if sourceFingerprint != targetFingerprint {
-			return result, fmt.Errorf("content fingerprint mismatch on %s: source %s, target %s", table, sourceFingerprint.Digest, targetFingerprint.Digest)
-		}
-		result.PerTableFingerprints[table] = sourceFingerprint
 	}
 
 	keepSourceFence = true
@@ -302,106 +248,6 @@ func (PGCatalogCopier) Copy(ctx context.Context, source, target CatalogEndpoint,
 	return result, nil
 }
 
-type fingerprintQuerier interface {
-	Query(context.Context, string, ...any) (pgx.Rows, error)
-}
-
-// fingerprintTable computes a streaming, order-independent multiset digest.
-// Each canonical jsonb row is SHA-256 hashed; the hashes are added modulo
-// 2^256, so row order does not matter while duplicates remain significant.
-func fingerprintTable(ctx context.Context, q fingerprintQuerier, table string) (CatalogTableFingerprint, error) {
-	rows, err := q.Query(ctx, "SELECT to_jsonb(t)::text FROM "+quoteIdent(table)+" AS t")
-	if err != nil {
-		return CatalogTableFingerprint{}, err
-	}
-	defer rows.Close()
-	var out CatalogTableFingerprint
-	var sum [sha256.Size]byte
-	for rows.Next() {
-		var canonical string
-		if err := rows.Scan(&canonical); err != nil {
-			return CatalogTableFingerprint{}, err
-		}
-		addRowFingerprint(&sum, canonical)
-		out.Rows++
-	}
-	if err := rows.Err(); err != nil {
-		return CatalogTableFingerprint{}, err
-	}
-	out.Digest = hex.EncodeToString(sum[:])
-	return out, nil
-}
-
-func addRowFingerprint(sum *[sha256.Size]byte, canonical string) {
-	h := sha256.Sum256([]byte(canonical))
-	carry := uint16(0)
-	for i := len(sum) - 1; i >= 0; i-- {
-		total := uint16(sum[i]) + uint16(h[i]) + carry
-		sum[i] = byte(total)
-		carry = total >> 8
-	}
-}
-
-func (PGCatalogCopier) SnapshotCounts(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]int64, error) {
-	conn, err := pgx.Connect(ctx, ep.DSN())
-	if err != nil {
-		return nil, fmt.Errorf("connect %s: %w", ep.Redacted(), err)
-	}
-	defer conn.Close(context.WithoutCancel(ctx))
-
-	tables, err := queryStrings(ctx, conn, catalogTablesQuery)
-	if err != nil {
-		return nil, fmt.Errorf("discover catalog tables: %w", err)
-	}
-	counts := make(map[string]int64, len(tables))
-	for i, table := range tables {
-		var c int64
-		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM "+quoteIdent(table)).Scan(&c); err != nil {
-			return nil, fmt.Errorf("count %s: %w", table, err)
-		}
-		counts[table] = c
-		maybeLogProgress(log, "counted", i+1, len(tables))
-	}
-	return counts, nil
-}
-
-func (PGCatalogCopier) SnapshotFingerprints(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) (map[string]CatalogTableFingerprint, error) {
-	conn, err := pgx.Connect(ctx, ep.DSN())
-	if err != nil {
-		return nil, fmt.Errorf("connect %s: %w", ep.Redacted(), err)
-	}
-	defer conn.Close(context.WithoutCancel(ctx))
-	tables, err := queryStrings(ctx, conn, catalogTablesQuery)
-	if err != nil {
-		return nil, fmt.Errorf("discover catalog tables: %w", err)
-	}
-	result := make(map[string]CatalogTableFingerprint, len(tables))
-	for i, table := range tables {
-		fingerprint, err := fingerprintTable(ctx, conn, table)
-		if err != nil {
-			return nil, fmt.Errorf("fingerprint %s: %w", table, err)
-		}
-		result[table] = fingerprint
-		maybeLogProgress(log, "fingerprinted", i+1, len(tables))
-	}
-	return result, nil
-}
-
-// verifyProgressEvery is the periodic-progress cadence of the loops that visit
-// every catalog table (row-count verification and recounts): one
-// "<verb> N/M tables…" line per this many tables — ~8 lines on a ~20k-table
-// catalog, never per-table — so the op log does not go silent for minutes
-// while the loop is healthy.
-const verifyProgressEvery = 2500
-
-// maybeLogProgress emits the periodic progress line every verifyProgressEvery
-// items. The final item is skipped — the caller logs its own completion line.
-func maybeLogProgress(log func(level, msg string), verb string, done, total int) {
-	if done > 0 && done < total && done%verifyProgressEvery == 0 {
-		log("info", fmt.Sprintf("%s %d/%d tables…", verb, done, total))
-	}
-}
-
 // applyConstraintsAndIndexes drives the constraint/index replay across all
 // tables. On a large catalog (~20k tables) this runs tens of seconds, so the
 // phase announces itself before the first ALTER instead of logging only on
@@ -415,31 +261,6 @@ func applyConstraintsAndIndexes(tables []string, apply func(table string) error,
 	}
 	log("info", "constraints and indexes applied on target")
 	return nil
-}
-
-// verifyCopiedRowCounts compares the source-snapshot row count of every table
-// against the live target, announcing the phase up front and emitting periodic
-// progress. Returns the per-table source counts on success.
-func verifyCopiedRowCounts(tables []string, srcCount, dstCount func(table string) (int64, error), log func(level, msg string)) (map[string]int64, error) {
-	log("info", fmt.Sprintf("verifying row counts across %d tables… (may take a few minutes)", len(tables)))
-	counts := make(map[string]int64, len(tables))
-	for i, table := range tables {
-		src, err := srcCount(table)
-		if err != nil {
-			return nil, fmt.Errorf("count source %s: %w", table, err)
-		}
-		dst, err := dstCount(table)
-		if err != nil {
-			return nil, fmt.Errorf("count target %s: %w", table, err)
-		}
-		if src != dst {
-			return nil, fmt.Errorf("row count mismatch on %s: source %d, target %d", table, src, dst)
-		}
-		counts[table] = src
-		maybeLogProgress(log, "verified", i+1, len(tables))
-	}
-	log("info", fmt.Sprintf("verified %d tables: target row counts match the source snapshot", len(tables)))
-	return counts, nil
 }
 
 func (PGCatalogCopier) DropCatalogTables(ctx context.Context, ep CatalogEndpoint, log func(level, msg string)) error {
@@ -554,23 +375,37 @@ func copyTableBinary(ctx context.Context, srcTx pgx.Tx, dst *pgx.Conn, table str
 	copyOut := fmt.Sprintf("COPY %s TO STDOUT (FORMAT binary)", quoteIdent(table))
 	copyIn := fmt.Sprintf("COPY %s FROM STDIN (FORMAT binary)", quoteIdent(table))
 
-	errCh := make(chan error, 1)
+	type copyToResult struct {
+		rows int64
+		err  error
+	}
+	resultCh := make(chan copyToResult, 1)
 	go func() {
-		_, copyErr := srcTx.Conn().PgConn().CopyTo(ctx, counter, copyOut)
+		tag, copyErr := srcTx.Conn().PgConn().CopyTo(ctx, counter, copyOut)
 		_ = pw.CloseWithError(copyErr)
-		errCh <- copyErr
+		resultCh <- copyToResult{rows: tag.RowsAffected(), err: copyErr}
 	}()
 
 	tag, inErr := dst.PgConn().CopyFrom(ctx, pr, copyIn)
-	outErr := <-errCh
+	out := <-resultCh
 	_ = pr.Close()
-	if outErr != nil {
-		return 0, counter.n, fmt.Errorf("source COPY TO: %w", outErr)
+	if out.err != nil {
+		return 0, counter.n, fmt.Errorf("source COPY TO: %w", out.err)
 	}
 	if inErr != nil {
 		return 0, counter.n, fmt.Errorf("target COPY FROM: %w", inErr)
 	}
-	return tag.RowsAffected(), counter.n, nil
+	if err := validateCopyRowCounts(table, out.rows, tag.RowsAffected()); err != nil {
+		return 0, counter.n, err
+	}
+	return out.rows, counter.n, nil
+}
+
+func validateCopyRowCounts(table string, sourceRows, targetRows int64) error {
+	if sourceRows != targetRows {
+		return fmt.Errorf("COPY row count mismatch on %s: source COPY TO reported %d rows, target COPY FROM reported %d", table, sourceRows, targetRows)
+	}
+	return nil
 }
 
 type countingWriter struct {

--- a/controlplane/provisioner/catalog_copy_test.go
+++ b/controlplane/provisioner/catalog_copy_test.go
@@ -3,7 +3,6 @@
 package provisioner
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,22 +10,13 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-func TestContentFingerprintDetectsSameCountMutationAndIgnoresRowOrder(t *testing.T) {
-	fingerprint := func(rows ...string) [sha256.Size]byte {
-		var sum [sha256.Size]byte
-		for _, row := range rows {
-			addRowFingerprint(&sum, row)
-		}
-		return sum
+func TestValidateCopyRowCounts(t *testing.T) {
+	if err := validateCopyRowCounts("ducklake_metadata", 2, 2); err != nil {
+		t.Fatalf("matching COPY command tags: %v", err)
 	}
-	original := fingerprint(`{"id":1,"value":"a"}`, `{"id":2,"value":"b"}`)
-	reordered := fingerprint(`{"id":2,"value":"b"}`, `{"id":1,"value":"a"}`)
-	mutated := fingerprint(`{"id":1,"value":"changed"}`, `{"id":2,"value":"b"}`)
-	if original != reordered {
-		t.Fatal("multiset fingerprint changed with row order")
-	}
-	if original == mutated {
-		t.Fatal("same-row-count UPDATE was not detected by content fingerprint")
+	err := validateCopyRowCounts("ducklake_metadata", 2, 1)
+	if err == nil || !strings.Contains(err.Error(), "source COPY TO reported 2 rows, target COPY FROM reported 1") {
+		t.Fatalf("err = %v, want COPY command-tag mismatch", err)
 	}
 }
 
@@ -60,71 +50,6 @@ func (l *logRecorder) count(substr string) int {
 		}
 	}
 	return n
-}
-
-func fakeTables(n int) []string {
-	tables := make([]string, n)
-	for i := range tables {
-		tables[i] = fmt.Sprintf("ducklake_t%05d", i)
-	}
-	return tables
-}
-
-// TestVerifyCopiedRowCountsAnnouncesAndEmitsProgress pins the op-log
-// liveness contract of the copy-verify loop: it announces itself with the
-// table total BEFORE the first count, emits a periodic progress line every
-// verifyProgressEvery tables (never per-table — a 20k-table catalog must
-// produce ~8 lines, not 20k), and closes with the completion line.
-func TestVerifyCopiedRowCountsAnnouncesAndEmitsProgress(t *testing.T) {
-	tables := fakeTables(2*verifyProgressEvery + 1000) // 6000: progress at 2500 and 5000
-	rec := &logRecorder{}
-	one := func(string) (int64, error) { return 1, nil }
-
-	counts, err := verifyCopiedRowCounts(tables, one, one, rec.log)
-	if err != nil {
-		t.Fatalf("verifyCopiedRowCounts: %v", err)
-	}
-	if len(counts) != len(tables) {
-		t.Fatalf("returned %d counts, want %d", len(counts), len(tables))
-	}
-	if len(rec.lines) == 0 || !strings.Contains(rec.lines[0], "verifying row counts across 6000 tables") {
-		t.Fatalf("first line must be the announce with the table total, got %v", rec.lines)
-	}
-	if rec.count("verified 2500/6000 tables…") != 1 || rec.count("verified 5000/6000 tables…") != 1 {
-		t.Fatalf("periodic progress lines missing: %v", rec.lines)
-	}
-	if !strings.Contains(rec.lines[len(rec.lines)-1], "verified 6000 tables: target row counts match the source snapshot") {
-		t.Fatalf("last line must be the completion line, got %v", rec.lines)
-	}
-	// Log volume is bounded: announce + 2 progress + completion. Never per-table.
-	if len(rec.lines) != 4 {
-		t.Fatalf("emitted %d lines, want exactly 4 (announce, 2 progress, completion): %v", len(rec.lines), rec.lines)
-	}
-}
-
-// TestVerifyCopiedRowCountsSmallCatalogNoProgress pins the no-spam rule: a
-// small catalog gets the announce and the completion line only.
-func TestVerifyCopiedRowCountsSmallCatalogNoProgress(t *testing.T) {
-	rec := &logRecorder{}
-	one := func(string) (int64, error) { return 1, nil }
-	if _, err := verifyCopiedRowCounts(fakeTables(3), one, one, rec.log); err != nil {
-		t.Fatalf("verifyCopiedRowCounts: %v", err)
-	}
-	if len(rec.lines) != 2 {
-		t.Fatalf("emitted %d lines, want exactly 2 (announce + completion): %v", len(rec.lines), rec.lines)
-	}
-}
-
-// TestVerifyCopiedRowCountsMismatch pins the mismatch error text (asserted by
-// operators reading the op log).
-func TestVerifyCopiedRowCountsMismatch(t *testing.T) {
-	rec := &logRecorder{}
-	src := func(string) (int64, error) { return 2, nil }
-	dst := func(string) (int64, error) { return 1, nil }
-	_, err := verifyCopiedRowCounts([]string{"ducklake_metadata"}, src, dst, rec.log)
-	if err == nil || !strings.Contains(err.Error(), "row count mismatch on ducklake_metadata: source 2, target 1") {
-		t.Fatalf("err = %v, want the row-count-mismatch error", err)
-	}
 }
 
 // TestApplyConstraintsAndIndexesAnnounces pins that the constraint/index
@@ -326,19 +251,5 @@ func TestConstraintCreatesIndex(t *testing.T) {
 		if got := constraintCreatesIndex(contype); got != want {
 			t.Errorf("constraintCreatesIndex(%q) = %t, want %t", contype, got, want)
 		}
-	}
-}
-
-// TestMaybeLogProgressSkipsFinalItem pins that the final item never emits a
-// progress line even when it lands exactly on the cadence — the caller's
-// completion line covers it.
-func TestMaybeLogProgressSkipsFinalItem(t *testing.T) {
-	rec := &logRecorder{}
-	total := 2 * verifyProgressEvery
-	for i := 1; i <= total; i++ {
-		maybeLogProgress(rec.log, "counted", i, total)
-	}
-	if len(rec.lines) != 1 || !strings.Contains(rec.lines[0], fmt.Sprintf("counted %d/%d tables…", verifyProgressEvery, total)) {
-		t.Fatalf("lines = %v, want exactly one mid-loop progress line (the final on-cadence item is skipped)", rec.lines)
 	}
 }

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -770,7 +770,7 @@ func (o *opRun) pauseCompaction(ctx context.Context) error {
 	o.compactionPaused = true
 	o.op.CompactionWasPresent = present
 	o.op.CompactionWasEnabled = enabled
-	o.logf("info", "compaction paused on the duckling spec (was: present=%t enabled=%t). Note: an already-running compaction job (≤30m) can outlive this; the post-copy stability check catches its writes", present, enabled)
+	o.logf("info", "compaction paused on the duckling spec (was: present=%t enabled=%t). Note: an already-running compaction job (≤30m) can outlive this; the source SHARE fence blocks its writes during the copy", present, enabled)
 	return nil
 }
 
@@ -1111,45 +1111,14 @@ func (o *opRun) flipToExternal(ctx context.Context) error {
 	}
 }
 
-// verifyExternalCatalog is the cnpg→ext gate BEFORE dropping the orphaned cnpg
-// source: it re-reads the live external target's per-table ducklake_* row
-// counts and requires an EXACT match against the copy snapshot
-// (o.copied.PerTableRows). An incomplete/diverged target fails here — the cnpg
-// source is still present (orphaned), so rollback flips back and re-adopts it
-// with no data loss. Only a clean match lets dropOrphanedCnpgSource run.
+// verifyExternalCatalog records the cnpg→ext gate before dropping the
+// orphaned source. Copy already compared PostgreSQL's source COPY TO and target
+// COPY FROM command tags for every table while holding the source SHARE fence.
 func (o *opRun) verifyExternalCatalog(ctx context.Context) error {
 	if err := o.step("verifying_external"); err != nil {
 		return err
 	}
-	o.logf("info", "verifying the external target catalog: counting rows across %d tables… (may take a few minutes)", len(o.copied.PerTableRows))
-	current, err := o.r.copier.SnapshotCounts(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) })
-	if err != nil {
-		return fmt.Errorf("re-reading external target counts: %w", err)
-	}
-	if len(current) != len(o.copied.PerTableRows) {
-		return fmt.Errorf("external target table set differs from the copy (%d tables now, %d copied) — catalog incomplete; NOT dropping the retained cnpg source", len(current), len(o.copied.PerTableRows))
-	}
-	for table, want := range o.copied.PerTableRows {
-		got, ok := current[table]
-		if !ok {
-			return fmt.Errorf("external target is missing table %s — catalog incomplete; NOT dropping the retained cnpg source", table)
-		}
-		if got != want {
-			return fmt.Errorf("external target table %s row count %d != copied %d — catalog incomplete; NOT dropping the retained cnpg source", table, got, want)
-		}
-	}
-	if len(o.copied.PerTableFingerprints) > 0 {
-		fingerprints, err := o.r.copier.SnapshotFingerprints(ctx, o.target, func(level, msg string) { o.logf(level, "%s", msg) })
-		if err != nil {
-			return fmt.Errorf("fingerprinting external target: %w", err)
-		}
-		for table, want := range o.copied.PerTableFingerprints {
-			if got, ok := fingerprints[table]; !ok || got != want {
-				return fmt.Errorf("external target table %s content fingerprint differs from the copy — NOT dropping the retained cnpg source", table)
-			}
-		}
-	}
-	o.logf("info", "verified external target catalog: %d tables match the copied row counts exactly — safe to drop the retained cnpg source", len(current))
+	o.logf("info", "external target catalog copy completed: source and target COPY command tags matched for %d tables — safe to drop the retained cnpg source", o.copied.Tables)
 	return nil
 }
 
@@ -1237,47 +1206,14 @@ func (o *opRun) copyCatalog(ctx context.Context) error {
 	return nil
 }
 
-// verifySourceStable re-reads the source row counts OUTSIDE the snapshot
-// transaction: any difference means something wrote the source after the
-// snapshot (a straggler compaction job, a stray client) and the copy cannot
-// be trusted.
+// verifySourceStable records the verification phase. Copy verifies each
+// table's source and target PostgreSQL COPY command tags while the source
+// SHARE fence remains held, so additional full-table scans are redundant.
 func (o *opRun) verifySourceStable(ctx context.Context) error {
 	if err := o.step("verifying"); err != nil {
 		return err
 	}
-	o.logf("info", "verifying source stability: re-counting rows across %d tables outside the snapshot… (may take a few minutes)", len(o.copied.PerTableRows))
-	current, err := o.r.copier.SnapshotCounts(ctx, o.source, func(level, msg string) { o.logf(level, "%s", msg) })
-	if err != nil {
-		return fmt.Errorf("re-reading source counts: %w", err)
-	}
-	if len(current) != len(o.copied.PerTableRows) {
-		return fmt.Errorf("source table set changed during the copy (%d tables now, %d in snapshot) — a concurrent writer is active", len(current), len(o.copied.PerTableRows))
-	}
-	for table, snapCount := range o.copied.PerTableRows {
-		nowCount, ok := current[table]
-		if !ok {
-			return fmt.Errorf("source table %s disappeared during the copy — a concurrent writer is active", table)
-		}
-		if nowCount != snapCount {
-			return fmt.Errorf("source table %s changed during the copy (%d rows now, %d in snapshot) — a concurrent writer is active", table, nowCount, snapCount)
-		}
-	}
-	if len(o.copied.PerTableFingerprints) > 0 {
-		fingerprints, err := o.r.copier.SnapshotFingerprints(ctx, o.source, func(level, msg string) { o.logf(level, "%s", msg) })
-		if err != nil {
-			return fmt.Errorf("re-fingerprinting source contents: %w", err)
-		}
-		if len(fingerprints) != len(o.copied.PerTableFingerprints) {
-			return fmt.Errorf("source fingerprint table set changed during the copy")
-		}
-		for table, snapshot := range o.copied.PerTableFingerprints {
-			current, ok := fingerprints[table]
-			if !ok || current != snapshot {
-				return fmt.Errorf("source table %s content changed during the copy despite stable row count — a concurrent writer is active", table)
-			}
-		}
-	}
-	o.logf("info", "verified: source is unchanged since the snapshot (%d tables) — no concurrent writer", len(current))
+	o.logf("info", "verified: source and target COPY command tags matched for %d tables while the source write fence remained held", o.copied.Tables)
 	return nil
 }
 

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -394,7 +394,7 @@ func (f *fakeDuckling) callKinds() []string {
 }
 
 type copierCall struct {
-	kind   string // "probe" | "copy" | "counts" | "droptables" | "dropdb"
+	kind   string // "probe" | "copy" | "droptables" | "dropdb"
 	source CatalogEndpoint
 	target CatalogEndpoint
 	dbName string
@@ -410,15 +410,6 @@ type fakeCopier struct {
 	// succeed). It sees the probed endpoint so tests can fail e.g. only the
 	// post-flip-back recovery probe.
 	probeFn func(ep CatalogEndpoint) error
-	// countsAfter is what SnapshotCounts returns for the SOURCE stability
-	// recheck (sslmode!=require); defaults to copyResult.PerTableRows (stable).
-	countsAfter map[string]int64
-	// externalCounts is what SnapshotCounts returns for the EXTERNAL target
-	// verify (sslmode==require, cnpg→ext verifyExternalCatalog); defaults to
-	// copyResult.PerTableRows (complete target).
-	externalCounts       map[string]int64
-	fingerprintsAfter    map[string]CatalogTableFingerprint
-	externalFingerprints map[string]CatalogTableFingerprint
 }
 
 type blockingCopier struct {
@@ -445,7 +436,7 @@ func (f *blockingCopier) Copy(ctx context.Context, source, target CatalogEndpoin
 		close(f.canceled)
 		return CatalogCopyResult{}, ctx.Err()
 	case <-f.released:
-		return CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}, nil
+		return CatalogCopyResult{}, nil
 	}
 }
 
@@ -473,32 +464,6 @@ func (f *fakeCopier) Copy(_ context.Context, source, target CatalogEndpoint, log
 	}
 	log("info", "fake copy done")
 	return f.copyResult, nil
-}
-
-func (f *fakeCopier) SnapshotCounts(_ context.Context, ep CatalogEndpoint, _ func(string, string)) (map[string]int64, error) {
-	f.record(copierCall{kind: "counts", target: ep})
-	// The external target is reached with sslmode=require (verifyExternalCatalog);
-	// the cnpg source with sslmode=disable (verifySourceStable).
-	if ep.SSLMode == "require" {
-		if f.externalCounts != nil {
-			return f.externalCounts, nil
-		}
-		return f.copyResult.PerTableRows, nil
-	}
-	if f.countsAfter != nil {
-		return f.countsAfter, nil
-	}
-	return f.copyResult.PerTableRows, nil
-}
-
-func (f *fakeCopier) SnapshotFingerprints(_ context.Context, ep CatalogEndpoint, _ func(string, string)) (map[string]CatalogTableFingerprint, error) {
-	if ep.SSLMode == "require" && f.externalFingerprints != nil {
-		return f.externalFingerprints, nil
-	}
-	if ep.SSLMode != "require" && f.fingerprintsAfter != nil {
-		return f.fingerprintsAfter, nil
-	}
-	return f.copyResult.PerTableFingerprints, nil
 }
 
 func (f *fakeCopier) DropCatalogTables(_ context.Context, ep CatalogEndpoint, _ func(string, string)) error {
@@ -631,7 +596,6 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: true}
 	copier := &fakeCopier{copyResult: CatalogCopyResult{
 		Tables: 3, Rows: 42, Bytes: 1000,
-		PerTableRows: map[string]int64{"ducklake_metadata": 1, "ducklake_snapshot": 40, "ducklake_table": 1},
 	}}
 	runOp(t, testRunner(store, duckling, copier), store)
 
@@ -646,7 +610,7 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	kinds := copier.kinds()
 	// probe(target, flip wait) → probe(source) → probe(target) → copy →
 	// stability recheck → source drop.
-	if fmt.Sprint(kinds) != fmt.Sprint([]string{"probe", "probe", "probe", "copy", "counts", "dropdb"}) {
+	if fmt.Sprint(kinds) != fmt.Sprint([]string{"probe", "probe", "probe", "copy", "dropdb"}) {
 		t.Fatalf("copier calls = %v", kinds)
 	}
 	// The copy's SOURCE is the recorded pre-flip endpoint, not the new one.
@@ -689,11 +653,8 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	if !store.hasLog("reshard report (succeeded)") || !store.hasLog("maintenance mode (connections blocked)") {
 		t.Fatalf("report missing from log: %v", store.logs)
 	}
-	// Long-running phases announce themselves when they START (an operator
-	// watching the live op log must never wonder whether a silent op is stuck):
-	// the source-stability recheck re-counts every table outside the snapshot.
-	if !store.hasLog("verifying source stability: re-counting rows across 3 tables") {
-		t.Fatalf("stability-recheck announce missing from log: %v", store.logs)
+	if !store.hasLog("COPY command tags matched for 3 tables") {
+		t.Fatalf("COPY verification log missing: %v", store.logs)
 	}
 }
 
@@ -717,7 +678,7 @@ func TestReshardHappyPathExtToCnpg(t *testing.T) {
 	st.IAMRoleARN = "arn:aws:iam::123:role/duckling-org-a"
 	st.ReadyCondition = true
 	duckling := &fakeDuckling{status: st}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	runOp(t, testRunner(store, duckling, copier), store)
 
@@ -754,7 +715,7 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	op.TargetDatabase = "postgres"
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	r.StashExternalPassword(op.ID, "ext-pw")
@@ -765,7 +726,7 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	}
 	// copy + source-stability recheck BEFORE the flip, external-catalog verify
 	// AFTER the flip, then the explicit source drop.
-	if fmt.Sprint(copier.kinds()) != fmt.Sprint([]string{"probe", "probe", "copy", "counts", "counts", "dropdb"}) {
+	if fmt.Sprint(copier.kinds()) != fmt.Sprint([]string{"probe", "probe", "copy", "dropdb"}) {
 		t.Fatalf("copier calls = %v", copier.kinds())
 	}
 	// The source drop names the recorded source DB and runs against the source.
@@ -803,12 +764,10 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	if last["metadata_store_kind"] != configstore.MetadataStoreKindExternal || last["metadata_store_endpoint"] != "escape.rds.amazonaws.com" {
 		t.Fatalf("warehouse row not reconciled to external: %v", last)
 	}
-	// Both count-verification phases announce themselves with the table total
-	// before the (potentially multi-minute) recount starts.
-	if !store.hasLog("verifying source stability: re-counting rows across 1 tables") {
-		t.Fatalf("stability-recheck announce missing from log: %v", store.logs)
+	if !store.hasLog("COPY command tags matched for 1 tables") {
+		t.Fatalf("COPY verification log missing: %v", store.logs)
 	}
-	if !store.hasLog("verifying the external target catalog: counting rows across 1 tables") {
+	if !store.hasLog("external target catalog copy completed") {
 		t.Fatalf("external-verify announce missing from log: %v", store.logs)
 	}
 }
@@ -928,7 +887,7 @@ func TestReshardTakeoverPreservesOriginalCompactionSnapshot(t *testing.T) {
 	op.CompactionWasEnabled = true
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: false}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{}}
 
 	runOp(t, testRunner(store, duckling, copier), store)
 
@@ -955,7 +914,7 @@ func TestReshardTakeoverAfterCutoverDoesNotReplaySourceDiscovery(t *testing.T) {
 	targetStatus := cnpgSourceStatus()
 	targetStatus.MetadataStore.Endpoint = "shard-002-pooler.cnpg-shards.svc.cluster.local"
 	duckling := &fakeDuckling{status: targetStatus, compPresent: true, compEnabled: false}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{}}
 
 	runOp(t, testRunner(store, duckling, copier), store)
 
@@ -1052,7 +1011,7 @@ func TestReshardFinalizeFailureRollsBackBeforeReadmittingTraffic(t *testing.T) {
 	store := newFakeReshardStore(cnpgOp())
 	store.failUnblockedWrite = true
 	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{}}
 
 	runOp(t, testRunner(store, duckling, copier), store)
 
@@ -1195,7 +1154,7 @@ func TestReshardRunSingleOperationWithStashedPassword(t *testing.T) {
 	op.TargetDatabase = "postgres"
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	r.StashExternalPassword(op.ID, "ext-pw")
@@ -1337,7 +1296,7 @@ func stuckExtOp() *configstore.ReshardOperation {
 func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 	store := newFakeReshardStore(stuckExtOp())
 	duckling := &stuckExternalDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	r.StashExternalPassword(store.op.ID, "ext-pw")
@@ -1384,7 +1343,7 @@ func TestReshardExtFlipTimeoutRecovers(t *testing.T) {
 func TestReshardBackupRecordedBeforeFlip(t *testing.T) {
 	store := newFakeReshardStore(cnpgOp())
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: true}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 	backuper := &fakeBackuper{}
 	r := testRunner(store, duckling, copier)
 	r.backuper = backuper
@@ -1451,7 +1410,7 @@ func TestReshardBackupFailureCnpgToExtFailsBeforeFlip(t *testing.T) {
 	op.TargetDatabase = "postgres"
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 	r := testRunner(store, duckling, copier)
 	r.backuper = &fakeBackuper{backupErr: fmt.Errorf("pg_dump exploded")}
 	r.StashExternalPassword(op.ID, "ext-pw")
@@ -1482,7 +1441,7 @@ func TestReshardBackupFailureCnpgToExtFailsBeforeFlip(t *testing.T) {
 func TestReshardBackupFailureNonDestructiveContinues(t *testing.T) {
 	store := newFakeReshardStore(cnpgOp())
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), compPresent: true, compEnabled: true}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 	r := testRunner(store, duckling, copier)
 	r.backuper = &fakeBackuper{backupErr: fmt.Errorf("s3 upload timed out")}
 
@@ -1496,46 +1455,6 @@ func TestReshardBackupFailureNonDestructiveContinues(t *testing.T) {
 	}
 	if store.op.BackupS3URI != "" {
 		t.Fatalf("op.BackupS3URI = %q, want empty when backup failed", store.op.BackupS3URI)
-	}
-}
-
-// TestReshardExtVerifyMismatchAdopts pins the step-5 gate: if the external
-// target catalog does NOT exactly match the copied row counts, the runner
-// REFUSES to drop the retained cnpg source and instead flips back + re-adopts
-// it — no data loss.
-func TestReshardExtVerifyMismatchAdopts(t *testing.T) {
-	op := cnpgOp()
-	op.TargetKind = configstore.MetadataStoreKindExternal
-	op.ToShard = ""
-	op.TargetEndpoint = "escape.rds.amazonaws.com"
-	op.TargetPasswordSecret = "escape-secret"
-	op.TargetUser = "postgres"
-	op.TargetDatabase = "postgres"
-	store := newFakeReshardStore(op)
-	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{
-		copyResult: CatalogCopyResult{Tables: 1, Rows: 5, PerTableRows: map[string]int64{"ducklake_data_file": 5}},
-		// External target verify sees a DIFFERENT count than the copy snapshot.
-		externalCounts: map[string]int64{"ducklake_data_file": 4},
-	}
-
-	r := testRunner(store, duckling, copier)
-	r.StashExternalPassword(op.ID, "ext-pw")
-	runOp(t, r, store)
-
-	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "catalog incomplete") {
-		t.Fatalf("state=%s err=%q, want external-verify (catalog incomplete) failure", store.op.State, store.op.Error)
-	}
-	// The retained cnpg source must NEVER be dropped on a verify mismatch.
-	if containsStr(copier.kinds(), "dropdb") {
-		t.Fatalf("verify mismatch dropped the source — must retain it for adoption: %v", copier.kinds())
-	}
-	// Recovery flips back + re-adopts.
-	if !containsStr(duckling.callKinds(), "cnpg-adopt") {
-		t.Fatalf("verify mismatch did not flip back + adopt: %v", duckling.callKinds())
-	}
-	if store.warehouseState != configstore.ManagedWarehouseStateReady {
-		t.Fatalf("warehouse state = %s, want ready after adopt recovery", store.warehouseState)
 	}
 }
 
@@ -1554,7 +1473,7 @@ func TestReshardCnpgToExtXRDUnsupportedRefuses(t *testing.T) {
 	op.TargetDatabase = "postgres"
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), retainFieldUnsupported: true}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	r.StashExternalPassword(op.ID, "ext-pw")
@@ -1607,7 +1526,7 @@ func TestReshardCnpgToExtOrphanWaitForbiddenFailsFast(t *testing.T) {
 			schema.GroupResource{Group: "postgresql.sql.m.crossplane.io", Resource: "databases"},
 			"org-a-db", errors.New("no RBAC grant")))
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), mrsReadErr: forbidden}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	// An hour-long flip timeout proves the failure is the fail-fast, not the
@@ -1658,7 +1577,7 @@ func TestReshardCnpgToExtOrphanWaitTimeoutReportsObservation(t *testing.T) {
 	op.TargetDatabase = "postgres"
 	store := newFakeReshardStore(op)
 	duckling := &fakeDuckling{status: cnpgSourceStatus(), mrsStuckWithDelete: true}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	r := testRunner(store, duckling, copier)
 	r.flipTimeout = 150 * time.Millisecond
@@ -1689,67 +1608,6 @@ func containsStr(ss []string, want string) bool {
 		}
 	}
 	return false
-}
-
-// TestReshardVerifyMismatchRollsBack pins the concurrent-writer detection: a
-// source that changed after the snapshot fails verify and rolls back.
-func TestReshardVerifyMismatchRollsBack(t *testing.T) {
-	store := newFakeReshardStore(cnpgOp())
-	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{
-		copyResult:  CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_snapshot": 1}},
-		countsAfter: map[string]int64{"ducklake_snapshot": 2}, // writer snuck in
-	}
-
-	runOp(t, testRunner(store, duckling, copier), store)
-
-	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "concurrent writer") {
-		t.Fatalf("state=%s err=%q, want concurrent-writer failure", store.op.State, store.op.Error)
-	}
-	// Rollback of a flipped cnpg→cnpg: shard value patched back + partial
-	// target dropped; source NEVER dropped.
-	for _, k := range copier.kinds() {
-		if k == "dropdb" {
-			t.Fatal("verify failure must never drop the source database")
-		}
-	}
-	foundDropTables := false
-	for _, k := range copier.kinds() {
-		if k == "droptables" {
-			foundDropTables = true
-		}
-	}
-	if !foundDropTables {
-		t.Fatal("partial target tables were not dropped on rollback")
-	}
-	if store.warehouseState != configstore.ManagedWarehouseStateReady {
-		t.Fatalf("warehouse state = %s, want ready after rollback", store.warehouseState)
-	}
-}
-
-func TestReshardVerifyDetectsSameCountContentMutation(t *testing.T) {
-	store := newFakeReshardStore(cnpgOp())
-	duckling := &fakeDuckling{status: cnpgSourceStatus()}
-	copier := &fakeCopier{
-		copyResult: CatalogCopyResult{
-			Tables: 1, Rows: 1,
-			PerTableRows: map[string]int64{"ducklake_metadata": 1},
-			PerTableFingerprints: map[string]CatalogTableFingerprint{
-				"ducklake_metadata": {Rows: 1, Digest: "before"},
-			},
-		},
-		countsAfter: map[string]int64{"ducklake_metadata": 1},
-		fingerprintsAfter: map[string]CatalogTableFingerprint{
-			"ducklake_metadata": {Rows: 1, Digest: "after"},
-		},
-	}
-	runOp(t, testRunner(store, duckling, copier), store)
-	if store.op.State != configstore.ReshardStateFailed {
-		t.Fatalf("state = %s, want failed for same-count content mutation", store.op.State)
-	}
-	if !strings.Contains(store.op.Error, "content changed") {
-		t.Fatalf("error = %q, want content-change diagnosis", store.op.Error)
-	}
 }
 
 // TestProbeErrorAuthClassification pins isAuthProbeError/describeProbeFailure
@@ -1813,7 +1671,7 @@ func TestProbeErrorAuthClassification(t *testing.T) {
 func TestReshardExtRecoveryProbeAuthFailureDiagnosed(t *testing.T) {
 	store := newFakeReshardStore(stuckExtOp())
 	duckling := &stuckExternalDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
-	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1, PerTableRows: map[string]int64{"ducklake_metadata": 1}}}
+	copier := &fakeCopier{copyResult: CatalogCopyResult{Tables: 1, Rows: 1}}
 
 	// The forward copy pre-flight probes the cnpg source once (must succeed so
 	// the op reaches the flip); every LATER probe of the cnpg endpoint is the

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -162,11 +162,11 @@ blocking → draining → pausing_compaction → backup_catalog → cutover → 
    `SHARE` locks on every discovered `ducklake_*` table, re-discovers the table
    set after locking, and remains open through verification and source cleanup;
    this blocks DML and conflicting DDL without killing an already-running
-   writer. Source and target also receive streaming, order-independent SHA-256
-   multiset fingerprints of canonical `jsonb` rows, so same-count UPDATEs and
-   balanced DELETE+INSERT changes cannot pass verification. Faithful DDL
-   from `pg_catalog` introspection; rows via raw binary COPY passthrough;
-   constraints then non-constraint indexes (PK-backed indexes excluded — ADD
+   writer. Faithful DDL from `pg_catalog` introspection; rows via raw binary
+   COPY passthrough. The source `COPY TO` and target `COPY FROM` command-tag row
+   counts must match for every table; no additional full-table count or
+   fingerprint scans are performed. Constraints then non-constraint indexes
+   (PK-backed indexes excluded — ADD
    CONSTRAINT already made them). No sequences exist in the DuckLake catalog
    (next-ids are rows). A `pg_advisory_lock` in the TARGET database fences a
    zombie ex-runner for copy+verify. The target database may be REUSED
@@ -320,11 +320,9 @@ blocking → draining → pausing_compaction → backup_catalog → copying → 
 3. **cutover** — flip `type` to external (`cnpgShard: null`, external block set;
    `retainCnpgOnFlip` left true). The un-render now ORPHANS the cnpg role/DB.
    Wait for external Ready + ESO password synced + matching the typed password.
-4. **verifying_external** — connect to the now-live external target and require
-   its per-table `ducklake_*` row counts to match the copy snapshot
-   (`CatalogCopyResult.PerTableRows`) EXACTLY. A missing table / count mismatch
-   fails here — the cnpg source is still present (orphaned), so recovery adopts
-   it back with no data loss.
+4. **verifying_external** — record that the copy completed with matching source
+   `COPY TO` and target `COPY FROM` command-tag row counts for every table while
+   the source SHARE fence remained held.
 5. **cleaning_up** — only after external verify passes: `DROP DATABASE … WITH
    (FORCE)` the retained cnpg source database via the source pooler (best-effort;
    a leftover DB is cruft, not data loss — the external target is verified live),


### PR DESCRIPTION
## Summary

Simplify reshard catalog verification to avoid repeated full-table scans at large catalog sizes.

- compare PostgreSQL `COPY TO` and `COPY FROM` command-tag row counts for every table
- retain the source `SHARE` fence and target copier lock through copy and cleanup
- retain constraint and index reconstruction as structural validation
- remove content fingerprints, standalone `COUNT(*)` passes, and post-copy rescans

This reduces the copy path by 531 lines and makes verification proportional to the streamed copy itself.

## Verification

- focused red/green COPY row-count mismatch test
- Kubernetes-tagged provisioner tests
- `just build`
- `just test-unit`
- `just lint`
