### PR TITLE
reshard: drain PostgreSQL connections when idle

### DIFF
--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -234,6 +234,12 @@ func (tr *OrgRouter) HandleConfigChange(old, new *configstore.Snapshot) {
 	// Detect new orgs or orgs whose warehouse just became ready
 	for name, tc := range new.Orgs {
 		oldTC, existed := old.Orgs[name]
+		if tr.srv != nil && tc.Warehouse != nil && tc.Warehouse.State == configstore.ManagedWarehouseStateResharding &&
+			(!existed || oldTC.Warehouse == nil || oldTC.Warehouse.State != configstore.ManagedWarehouseStateResharding) {
+			drained := tr.srv.DrainOrgConnections(name)
+			slog.Info("Warehouse resharding, draining PostgreSQL connections at their next idle boundary.",
+				"org", name, "connections", drained)
+		}
 
 		// Skip orgs with warehouses that aren't ready
 		if tc.Warehouse != nil && tc.Warehouse.State != configstore.ManagedWarehouseStateReady {

--- a/server/conn.go
+++ b/server/conn.go
@@ -177,6 +177,8 @@ type clientConn struct {
 	catalogUseRewrite  bool                     // true when bare `USE ducklake` should expand to the reliable two-part target
 	ctx                context.Context          // connection context, cancelled when connection is closed
 	cancel             context.CancelFunc       // cancels the connection context
+	drainRequested     atomic.Bool              // close at the next idle protocol boundary
+	idleRead           atomic.Bool              // blocked reading the next top-level client message
 
 	// sharedDB is true when this connection uses a shared file-persistence DB pool.
 	// Cleanup differs: we return the pinned conn to the pool instead of closing the DB.
@@ -1144,11 +1146,26 @@ func (c *clientConn) armIdleReadDeadline() {
 }
 
 func (c *clientConn) messageLoop() error {
+	atReadyBoundary := true
 	for {
+		if atReadyBoundary && c.drainRequested.Load() {
+			return nil
+		}
 		c.armIdleReadDeadline()
 
+		c.idleRead.Store(atReadyBoundary)
+		// Close the race where a drain was requested after the check above but
+		// before this connection advertised that its top-level read is idle.
+		if atReadyBoundary && c.drainRequested.Load() {
+			c.idleRead.Store(false)
+			return nil
+		}
 		msgType, body, err := wire.ReadMessage(c.reader)
+		c.idleRead.Store(false)
 		if err != nil {
+			if c.drainRequested.Load() {
+				return nil
+			}
 			if err == io.EOF {
 				return nil
 			}
@@ -1159,6 +1176,13 @@ func (c *clientConn) messageLoop() error {
 			}
 			return err
 		}
+		// A drain may race with the client sending its next message while the
+		// loop is blocked in ReadMessage. The previous ReadyForQuery is still a
+		// safe idle boundary, so do not start new work after the drain request.
+		if atReadyBoundary && c.drainRequested.Load() {
+			return nil
+		}
+		atReadyBoundary = false
 
 		switch msgType {
 		case wire.MsgQuery:
@@ -1173,6 +1197,10 @@ func (c *clientConn) messageLoop() error {
 				}
 				c.logger().Error("Query error.", "error", err)
 			}
+			if c.drainRequested.Load() {
+				return nil
+			}
+			atReadyBoundary = true
 
 		case wire.MsgParse:
 			// Extended query protocol - Parse
@@ -1198,6 +1226,10 @@ func (c *clientConn) messageLoop() error {
 				return err
 			}
 			_ = c.flushWriter()
+			if c.drainRequested.Load() {
+				return nil
+			}
+			atReadyBoundary = true
 
 		case wire.MsgClose:
 			// Extended query protocol - Close

--- a/server/conn_idle_test.go
+++ b/server/conn_idle_test.go
@@ -11,6 +11,24 @@ import (
 	"github.com/posthog/duckgres/server/wire"
 )
 
+type blockingDrainExecutor struct {
+	QueryExecutor
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingDrainExecutor) LastProfilingOutput() string { return "" }
+
+func (e *blockingDrainExecutor) ExecContext(ctx context.Context, _ string, _ ...any) (ExecResult, error) {
+	close(e.entered)
+	select {
+	case <-e.release:
+		return nil, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // TestMessageLoopIdleTimeoutClosesConnection proves the mechanism the
 // control-plane idle default relies on: with IdleTimeout configured, a
 // connection that sends nothing hits the read deadline and the message loop
@@ -47,6 +65,111 @@ func TestMessageLoopIdleTimeoutClosesConnection(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("messageLoop did not return on idle timeout")
+	}
+}
+
+// TestDrainOrgConnectionsClosesBlockedIdleConnection proves a reshard drain
+// does not have to wait for the normal idle timeout. A PostgreSQL connection
+// blocked waiting for its next client message is already at a safe idle
+// boundary, so requesting a drain for its org must wake the read and make the
+// message loop return immediately.
+func TestDrainOrgConnectionsClosesBlockedIdleConnection(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	s := &Server{}
+	InitMinimalServer(s, Config{IdleTimeout: -1}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cc := &clientConn{
+		server: s,
+		conn:   serverSide,
+		reader: bufio.NewReader(serverSide),
+		writer: bufio.NewWriter(serverSide),
+		pid:    42,
+		orgID:  "org-a",
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	s.registerConn(cc)
+	defer s.unregisterConn(cc.pid)
+
+	done := make(chan error, 1)
+	go func() { done <- cc.messageLoop() }()
+
+	if got := s.DrainOrgConnections("org-a"); got != 1 {
+		t.Fatalf("DrainOrgConnections returned %d, want 1", got)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected clean close at idle drain boundary, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("messageLoop remained blocked after org drain was requested")
+	}
+}
+
+// TestDrainOrgConnectionsWaitsForActiveQueryBoundary proves requesting a
+// reshard drain never cancels work already executing. The connection closes
+// only after that query has completed and its ReadyForQuery boundary is safe.
+func TestDrainOrgConnectionsWaitsForActiveQueryBoundary(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	s := &Server{activeQueries: make(map[BackendKey]context.CancelFunc)}
+	InitMinimalServer(s, Config{IdleTimeout: -1}, nil)
+	executor := &blockingDrainExecutor{entered: make(chan struct{}), release: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cc := &clientConn{
+		server:   s,
+		conn:     serverSide,
+		reader:   bufio.NewReader(serverSide),
+		writer:   bufio.NewWriter(serverSide),
+		executor: executor,
+		pid:      43,
+		orgID:    "org-a",
+		txStatus: txStatusIdle,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+	s.registerConn(cc)
+	defer s.unregisterConn(cc.pid)
+
+	done := make(chan error, 1)
+	go func() { done <- cc.messageLoop() }()
+	go func() { _, _ = io.Copy(io.Discard, clientSide) }()
+	if err := wire.WriteMessage(clientSide, wire.MsgQuery, []byte("BEGIN\x00")); err != nil {
+		t.Fatalf("write query: %v", err)
+	}
+	select {
+	case <-executor.entered:
+	case <-time.After(time.Second):
+		t.Fatal("query did not start")
+	}
+
+	if got := s.DrainOrgConnections("org-a"); got != 1 {
+		t.Fatalf("DrainOrgConnections returned %d, want 1", got)
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("messageLoop returned during active query: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(executor.release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected clean close after active query, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("messageLoop did not close at post-query idle boundary")
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -742,6 +742,32 @@ func (s *Server) unregisterConn(pid int32) {
 	s.connsMu.Unlock()
 }
 
+// DrainOrgConnections requests a clean close of every PostgreSQL connection
+// for orgID at its next idle protocol boundary. Connections already blocked
+// waiting for client input are woken immediately; executing queries are not
+// cancelled and close after their next ReadyForQuery.
+func (s *Server) DrainOrgConnections(orgID string) int {
+	s.connsMu.RLock()
+	conns := make([]*clientConn, 0)
+	for _, c := range s.conns {
+		if c != nil && c.orgID == orgID {
+			conns = append(conns, c)
+		}
+	}
+	s.connsMu.RUnlock()
+
+	for _, c := range conns {
+		c.drainRequested.Store(true)
+		if c.conn != nil && c.idleRead.Load() {
+			// Wake a message loop already blocked at an idle boundary. An active
+			// query (including COPY reading client data) is not marked idle and is
+			// therefore unaffected.
+			_ = c.conn.SetReadDeadline(time.Now())
+		}
+	}
+	return len(conns)
+}
+
 // listConns returns a snapshot of all registered client connections.
 func (s *Server) listConns() []*clientConn {
 	s.connsMu.RLock()


### PR DESCRIPTION
## Summary

- close already-idle PostgreSQL connections when an org enters resharding
- let in-flight queries finish, then close at the next `ReadyForQuery` boundary
- avoid interrupting active protocol work, including `COPY FROM STDIN`

## Tests

- `just test-unit`
- `just build`
- `just lint`