### PR TITLE
reshard: refuse ops with incomplete/drifted source identity; never emit invalid rollback patches; fix takeover sslmode; pin ducklake enablement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,9 +634,36 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
   (`postgresql-client-18`, PGDG repo, in BOTH `Dockerfile` and
   `Dockerfile.controlplane`). Full design + restore procedure:
   `docs/design/resharding.md`.
+- **Source identity: the duckling STATUS is authoritative, validated at
+  submit.** The start handler derives source_kind/from_shard/the external
+  source block from the duckling STATUS (where the catalog actually lives) and
+  400s an op whose identity is incomplete or contradicts the config-store row
+  (kind drift, cnpg source with unresolvable shard, external source with an
+  incomplete row block). The runner re-checks at recordSource (pre-flip).
+  Never re-introduce the old "empty row kind defaults to cnpg-shard" fallback
+  — it pointed a flip-before-copy reshard at a phantom cnpg source while the
+  org lived on an external RDS (prod incident: org re-pointed onto an empty
+  catalog, rollback patch rejected).
 - **Rollback patches the source shard VALUE back — never removes the key**
   (precedence would fall through to the freshly-stamped bogus status pin);
   ext→cnpg rollback must null `cnpgShard` (XRD CEL forbids it on external).
+  **Never emit a patch the XRD would reject**: an empty/invalid recorded
+  from_shard (`isValidCnpgShardName`, mirrors the XRD pattern) or an
+  incomplete external source block skips the flip-back/adopt patch, logs
+  ERROR operator instructions, and **intentionally leaves the warehouse
+  blocked in `resharding`** — unblocking onto the wrong store is worse than a
+  blocked org (see docs/design/resharding.md's never-stranded carve-out).
+  Takeover/endpoint reconstructions derive sslmode from the metadata-store
+  KIND via `sslModeFor` (cnpg → disable, external → require) — never
+  hardcode an sslmode.
+- **The compaction pause must never let XRD defaulting disable DuckLake**:
+  `SetCompactionEnabled` pins the org's effective `spec.ducklake.enabled`
+  (legacy type coupling, as the activator derives it) into the patch when the
+  CR has no `spec.ducklake` object — otherwise materializing the object gets
+  `enabled: false` stamped by the XRD default and every later activation
+  fails ("tenant activation requires a ducklake metadata_store"). The pinned
+  value is never removed afterwards (deliberate — see
+  `TestSetCompactionEnabledPinsDuckLakeEnablement`).
 - **The ext target password is ephemeral**: request → creating replica's
   in-memory stash → one-shot pull by the runner pod → runner memory; never in
   the op row, log, audit, k8s Secret, or any pod spec. The runner pod fetches
@@ -690,6 +717,7 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
   marked the op `cancelled` while leaving the warehouse blocked.
 - Touching any of this → update `tests/configstore/reshard_postgres_test.go`,
   `provisioner/reshard_runner_test.go` (incl. the `TestReshardBackup*` cases),
+  `provisioner/k8s_client_test.go` (the compaction/ducklake-pin cases),
   `admin/reshard_test.go`, `controlplane/reshard_pod_test.go` +
   `reshard_reconciler_test.go` + `reshard_runner_mode_test.go`, the
   migration asserts in `tests/configstore/migrations_postgres_test.go`, the

--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -197,7 +197,9 @@ type startReshardRequest struct {
 }
 
 // RegisterReshardAPI wires the reshard endpoints. lister may be nil (duckling
-// client unavailable) — shard discovery degrades; reads still work. spawner
+// client unavailable) — shard discovery degrades, reads still work, and
+// starting a reshard whose source identity needs the duckling status (any
+// cnpg-shard source) is then refused. spawner
 // may be nil (no kubernetes API) — starting a reshard then 503s (nothing would
 // execute the op). cluster may be nil (non-k8s) — shard discovery then falls
 // back to the shards tenants already occupy. prober may be nil (tests /
@@ -326,40 +328,93 @@ func (h *reshardHandler) start(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": "warehouse must be in ready state to reshard (currently " + string(wh.State) + ")"})
 		return
 	}
-	sourceKind := wh.MetadataStore.Kind
-	if sourceKind == "" {
-		sourceKind = configstore.MetadataStoreKindCnpgShard
+
+	ducklingName := wh.DucklingName
+	if ducklingName == "" {
+		ducklingName = orgID
+	}
+
+	// ---- source identity (submit-time guard) --------------------------------
+	// The duckling STATUS is authoritative for where the org's catalog actually
+	// lives: the composition writes it after convergence, while the config-store
+	// row and the duckling SPEC are operator-editable inputs that can drift. An
+	// op recorded from a drifted row (empty metadata block defaulted to
+	// cnpg-shard while the org actually lived on an external RDS) once flipped
+	// an org onto a freshly created EMPTY catalog with no copy performed
+	// (cnpg→cnpg flips BEFORE copying) and then could not roll back — the empty
+	// recorded from_shard produced a patch the XRD rejects. Refuse to create an
+	// op whose source identity is incomplete or contradicted by the live status.
+	rowKind := wh.MetadataStore.Kind
+	statusStore, statusKnown := h.ducklingStatusStore(c, ducklingName)
+	var sourceKind string
+	switch {
+	case statusKnown:
+		sourceKind = statusStore.Kind
+		if rowKind != "" && rowKind != sourceKind {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf(
+				"metadata-store identity drift between config store and duckling status — refusing to reshard until reconciled: the config-store warehouse row says kind %q but duckling %s's status says %q (endpoint %q). Fix the warehouse row (metadata_store_* columns) and/or the duckling spec so they agree with where the catalog actually lives, then retry",
+				rowKind, ducklingName, statusStore.Kind, statusStore.Endpoint)})
+			return
+		}
+	case rowKind != "":
+		// No live status to cross-check against (lister unavailable or the CR
+		// status is not populated) — fall back to the row, still subject to the
+		// completeness checks below.
+		sourceKind = rowKind
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "the org's metadata-store identity is incomplete: the config-store warehouse row has no metadata-store kind and duckling " + ducklingName + "'s status is unavailable — reconcile the warehouse row (metadata_store_* columns) and the duckling spec/status before resharding"})
+		return
 	}
 	if sourceKind != configstore.MetadataStoreKindCnpgShard && sourceKind != configstore.MetadataStoreKindExternal {
 		c.JSON(http.StatusConflict, gin.H{"error": "unsupported source metadata-store kind " + sourceKind})
 		return
 	}
 
+	currentShard := ""
+	if statusKnown && statusStore.Kind == configstore.MetadataStoreKindCnpgShard {
+		currentShard = cnpgShardFromEndpoint(statusStore.Endpoint)
+	}
+	if sourceKind == configstore.MetadataStoreKindCnpgShard {
+		// An op with an empty (or malformed) from_shard cannot roll back: the
+		// rollback patches the shard VALUE back and the XRD rejects anything
+		// outside its shard-name pattern — including the empty string.
+		if currentShard == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "the org's metadata-store identity is incomplete: the source resolves to cnpg-shard but the current shard could not be determined from duckling " + ducklingName + "'s status — an operation recorded with an empty from_shard cannot roll back (the XRD rejects an empty cnpgShard patch). Reconcile the config-store warehouse row (metadata_store_* columns) and the duckling spec/status, then retry"})
+			return
+		}
+		if len(currentShard) > 63 || !reshardShardNamePattern.MatchString(currentShard) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("the org's current shard %q (from duckling status endpoint %q) is not a valid cnpg shard name (%s) — refusing to record it as the rollback target", currentShard, statusStore.Endpoint, reshardShardNamePattern.String())})
+			return
+		}
+	}
+
 	op := &configstore.ReshardOperation{
 		OrgID:                 orgID,
-		DucklingName:          wh.DucklingName,
+		DucklingName:          ducklingName,
 		SourceKind:            sourceKind,
+		FromShard:             currentShard,
 		DrainTimeoutSeconds:   req.DrainTimeoutSeconds,
 		CutoverTimeoutSeconds: req.CutoverTimeoutSeconds,
 	}
 	if op.CutoverTimeoutSeconds < 0 {
 		op.CutoverTimeoutSeconds = 0
 	}
-	if op.DucklingName == "" {
-		op.DucklingName = orgID
-	}
 	if op.DrainTimeoutSeconds <= 0 {
 		op.DrainTimeoutSeconds = 1800
 	}
 	if sourceKind == configstore.MetadataStoreKindExternal {
+		// The rollback of an ext→cnpg op re-renders the external spec from
+		// these fields; an incomplete block would emit an invalid patch, so
+		// refuse up front rather than record a source we cannot restore.
+		if wh.MetadataStore.Endpoint == "" || wh.MetadataStore.PasswordAWSSecret == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("the org's metadata-store identity is incomplete: the source is external but the config-store warehouse row's external block is missing its endpoint (%q) or password secret (%q) — a rollback could not re-render the external metadata-store spec. Reconcile the warehouse row (metadata_store_* columns), then retry", wh.MetadataStore.Endpoint, wh.MetadataStore.PasswordAWSSecret)})
+			return
+		}
 		op.SourceEndpoint = wh.MetadataStore.Endpoint
 		op.SourceUser = wh.MetadataStore.Username
 		op.SourceDatabase = wh.MetadataStore.DatabaseName
 		op.SourcePasswordSecret = wh.MetadataStore.PasswordAWSSecret
 	}
-
-	currentShard := h.currentShard(c, op.DucklingName)
-	op.FromShard = currentShard
 
 	switch req.Target.Type {
 	case configstore.MetadataStoreKindCnpgShard:
@@ -556,26 +611,29 @@ func describeReshard(op *configstore.ReshardOperation) string {
 	return "org " + op.OrgID + ": " + src + " → " + dst
 }
 
-// currentShard resolves the org's live shard from the duckling CR status
-// (best-effort — empty when the lister is unavailable).
-func (h *reshardHandler) currentShard(c *gin.Context, ducklingName string) string {
+// ducklingStatusStore resolves the org's live metadata store from the duckling
+// CR STATUS — the authoritative record of where the catalog actually lives.
+// ok=false when the lister is unavailable, the CR list fails, or the CR's
+// status is not populated (still provisioning); the start handler then falls
+// back to the config-store row and its completeness checks.
+func (h *reshardHandler) ducklingStatusStore(c *gin.Context, ducklingName string) (DucklingMetadataStore, bool) {
 	if h.lister == nil {
-		return ""
+		return DucklingMetadataStore{}, false
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), ducklingMetadataTimeout)
 	defer cancel()
 	stores, err := h.lister.CRMetadataStores(ctx)
 	if err != nil {
-		return ""
+		return DucklingMetadataStore{}, false
 	}
 	ms, ok := stores[strings.ToLower(ducklingName)]
 	if !ok {
 		ms, ok = stores[ducklingName]
 	}
-	if !ok || ms.Kind != "cnpg-shard" {
-		return ""
+	if !ok || ms.Kind == "" {
+		return DucklingMetadataStore{}, false
 	}
-	return cnpgShardFromEndpoint(ms.Endpoint)
+	return ms, true
 }
 
 // listAll returns operations across every org, newest first — the console's

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -199,6 +199,22 @@ func (p *fakeProber) Probe(_ context.Context, endpoint, user, database, password
 	return p.err
 }
 
+// defaultShardLister matches the default fake warehouse: a cnpg-shard org
+// living on shard-001 per its duckling STATUS.
+func defaultShardLister() DucklingMetadataLister {
+	return fakeShardLister{stores: map[string]DucklingMetadataStore{
+		"acme": {Kind: "cnpg-shard", Endpoint: "shard-001-pooler.cnpg-shards.svc.cluster.local"},
+	}}
+}
+
+// externalShardLister models an org whose duckling STATUS says the catalog
+// lives on an external RDS.
+func externalShardLister(endpoint string) DucklingMetadataLister {
+	return fakeShardLister{stores: map[string]DucklingMetadataStore{
+		"acme": {Kind: "external", Endpoint: endpoint},
+	}}
+}
+
 func reshardRouter(store *fakeReshardStore) *gin.Engine {
 	r, _ := reshardRouterFull(store, nil, nil)
 	return r
@@ -209,14 +225,21 @@ func reshardRouterWithCluster(store *fakeReshardStore, cluster kubernetes.Interf
 	return r
 }
 
+// reshardRouterLister registers the API with a specific duckling lister (nil
+// allowed — the degraded no-duckling-client path).
+func reshardRouterLister(store *fakeReshardStore, lister DucklingMetadataLister) *gin.Engine {
+	r, _ := reshardRouterSpawner(store, nil, nil, &fakeSpawner{}, "internal-secret", lister)
+	return r
+}
+
 // reshardRouterFull registers the API with a fakeSpawner and an
 // internal-secret identity on every request (the password endpoint gates on
 // it; production wiring runs AuthMiddleware in front).
 func reshardRouterFull(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber) (*gin.Engine, *fakeSpawner) {
-	return reshardRouterSpawner(store, cluster, prober, &fakeSpawner{}, "internal-secret")
+	return reshardRouterSpawner(store, cluster, prober, &fakeSpawner{}, "internal-secret", defaultShardLister())
 }
 
-func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber, spawner ReshardPodSpawner, identitySource string) (*gin.Engine, *fakeSpawner) {
+func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber, spawner ReshardPodSpawner, identitySource string, lister DucklingMetadataLister) (*gin.Engine, *fakeSpawner) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -229,9 +252,6 @@ func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface,
 		}
 		c.Next()
 	})
-	lister := fakeShardLister{stores: map[string]DucklingMetadataStore{
-		"acme": {Kind: "cnpg-shard", Endpoint: "shard-001-pooler.cnpg-shards.svc.cluster.local"},
-	}}
 	RegisterReshardAPI(r.Group("/api/v1"), store, lister, spawner, cluster, prober)
 	fs, _ := spawner.(*fakeSpawner)
 	return r, fs
@@ -281,37 +301,47 @@ func TestReshardStartCnpg(t *testing.T) {
 // active-op conflict.
 func TestReshardStartValidation(t *testing.T) {
 	cases := []struct {
-		name string
-		prep func(*fakeReshardStore)
-		body string
-		want int
+		name   string
+		prep   func(*fakeReshardStore)
+		lister DucklingMetadataLister // nil = defaultShardLister()
+		body   string
+		want   int
 	}{
-		{"same shard", nil, `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-001"}}`, 400},
-		{"bad shard name", nil, `{"target":{"type":"cnpg-shard","cnpg_shard":"Shard_002"}}`, 400},
-		{"bad target type", nil, `{"target":{"type":"nonsense"}}`, 400},
-		{"missing ext fields", nil, `{"target":{"type":"external","endpoint":"x"}}`, 400},
-		{"missing ext password", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"s"}}`, 400},
+		{name: "same shard", body: `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-001"}}`, want: 400},
+		{name: "bad shard name", body: `{"target":{"type":"cnpg-shard","cnpg_shard":"Shard_002"}}`, want: 400},
+		{name: "bad target type", body: `{"target":{"type":"nonsense"}}`, want: 400},
+		{name: "missing ext fields", body: `{"target":{"type":"external","endpoint":"x"}}`, want: 400},
+		{name: "missing ext password", body: `{"target":{"type":"external","endpoint":"x","password_aws_secret":"s"}}`, want: 400},
 		// RDS-managed master secrets are outside every env's ESO IAM policy
 		// (posthog-*/duckling-* prefixes only) — the cutover would hang on an
 		// ESO AccessDenied, so the start handler rejects them up front.
-		{"rds slash master secret", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds/duckling-example/master","password":"p"}}`, 400},
-		{"rds bang managed secret", nil, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-1234-abcd","password":"p"}}`, 400},
-		{"not ready", func(f *fakeReshardStore) {
+		{name: "rds slash master secret", body: `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds/duckling-example/master","password":"p"}}`, want: 400},
+		{name: "rds bang managed secret", body: `{"target":{"type":"external","endpoint":"x","password_aws_secret":"rds!db-1234-abcd","password":"p"}}`, want: 400},
+		{name: "not ready", prep: func(f *fakeReshardStore) {
 			f.warehouse.State = configstore.ManagedWarehouseStateProvisioning
-		}, `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`, 409},
-		{"active op conflict", func(f *fakeReshardStore) {
+		}, body: `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`, want: 409},
+		{name: "active op conflict", prep: func(f *fakeReshardStore) {
 			f.createErr = configstore.ErrReshardConflict
-		}, `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`, 409},
-		{"ext to ext", func(f *fakeReshardStore) {
+		}, body: `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`, want: 409},
+		// A genuinely-external org (row + duckling status agree) may not
+		// reshard to another external store.
+		{name: "ext to ext", prep: func(f *fakeReshardStore) {
 			f.warehouse.MetadataStore.Kind = configstore.MetadataStoreKindExternal
-		}, `{"target":{"type":"external","endpoint":"x","password_aws_secret":"s","password":"p"}}`, 400},
+			f.warehouse.MetadataStore.Endpoint = "src.rds.example.com"
+			f.warehouse.MetadataStore.PasswordAWSSecret = "duckling-src-secret"
+		}, lister: externalShardLister("src.rds.example.com"),
+			body: `{"target":{"type":"external","endpoint":"x","password_aws_secret":"s","password":"p"}}`, want: 400},
 	}
 	for _, tc := range cases {
 		store := newFakeReshardStore()
 		if tc.prep != nil {
 			tc.prep(store)
 		}
-		w := doJSON(reshardRouter(store), http.MethodPost, "/api/v1/orgs/acme/reshard", tc.body)
+		lister := tc.lister
+		if lister == nil {
+			lister = defaultShardLister()
+		}
+		w := doJSON(reshardRouterLister(store, lister), http.MethodPost, "/api/v1/orgs/acme/reshard", tc.body)
 		if w.Code != tc.want {
 			t.Errorf("%s: status = %d body %s, want %d", tc.name, w.Code, w.Body.String(), tc.want)
 		}
@@ -323,6 +353,104 @@ func TestReshardStartValidation(t *testing.T) {
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("unknown org status = %d, want 404", w.Code)
+	}
+}
+
+// TestReshardStartSourceIdentityValidation pins the submit-time source-identity
+// guard: the duckling STATUS is authoritative for where the catalog actually
+// lives, and the start handler refuses (400, no op created) when that identity
+// is incomplete or contradicted by the config-store row. Regression for a prod
+// incident: an org whose config-store metadata block was EMPTY (defaulted to
+// cnpg-shard) while its duckling status pointed at an external RDS got a
+// cnpg→cnpg op with an empty from_shard — the flip-before-copy re-pointed the
+// org at a fresh empty catalog and the rollback patch (empty shard) was
+// rejected by the XRD.
+func TestReshardStartSourceIdentityValidation(t *testing.T) {
+	cnpgTarget := `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`
+	emptyLister := fakeShardLister{stores: map[string]DucklingMetadataStore{}}
+
+	cases := []struct {
+		name       string
+		prep       func(*fakeReshardStore)
+		lister     DucklingMetadataLister
+		body       string
+		wantCode   int
+		wantSubstr string
+	}{
+		// cnpg source whose current shard cannot be resolved → the op would
+		// record an empty from_shard, which cannot roll back. Refused.
+		{name: "cnpg source, shard unresolvable (no CR status)", lister: emptyLister,
+			body: cnpgTarget, wantCode: 400, wantSubstr: "identity is incomplete"},
+		{name: "cnpg source, no duckling lister", lister: nil,
+			body: cnpgTarget, wantCode: 400, wantSubstr: "identity is incomplete"},
+		// Row has no kind at all AND no status to fall back on.
+		{name: "empty row kind and no status", prep: func(f *fakeReshardStore) {
+			f.warehouse.MetadataStore.Kind = ""
+		}, lister: emptyLister, body: cnpgTarget, wantCode: 400, wantSubstr: "identity is incomplete"},
+		// Type drift between row and status — both directions.
+		{name: "row cnpg, status external (drift)", lister: externalShardLister("real.rds.example.com"),
+			body: cnpgTarget, wantCode: 400, wantSubstr: "identity drift"},
+		{name: "row external, status cnpg (drift)", prep: func(f *fakeReshardStore) {
+			f.warehouse.MetadataStore.Kind = configstore.MetadataStoreKindExternal
+			f.warehouse.MetadataStore.Endpoint = "real.rds.example.com"
+			f.warehouse.MetadataStore.PasswordAWSSecret = "duckling-src-secret"
+		}, lister: defaultShardLister(), body: cnpgTarget, wantCode: 400, wantSubstr: "identity drift"},
+		// The incident shape: EMPTY row metadata block, status says external.
+		// The source is external per the status, but the row block a rollback
+		// would need (endpoint + password secret) is missing. Refused.
+		{name: "incident: empty row block, external status", prep: func(f *fakeReshardStore) {
+			f.warehouse.MetadataStore.Kind = ""
+		}, lister: externalShardLister("real.rds.example.com"),
+			body: cnpgTarget, wantCode: 400, wantSubstr: "external block is missing"},
+		// Happy: legacy empty row kind on a cnpg org — status resolves it.
+		{name: "empty row kind, cnpg status resolves", prep: func(f *fakeReshardStore) {
+			f.warehouse.MetadataStore.Kind = ""
+		}, lister: defaultShardLister(), body: cnpgTarget, wantCode: 202},
+		// Happy: external source with row + status in agreement.
+		{name: "external source consistent", prep: func(f *fakeReshardStore) {
+			f.warehouse.MetadataStore.Kind = configstore.MetadataStoreKindExternal
+			f.warehouse.MetadataStore.Endpoint = "real.rds.example.com"
+			f.warehouse.MetadataStore.PasswordAWSSecret = "duckling-src-secret"
+		}, lister: externalShardLister("real.rds.example.com"), body: cnpgTarget, wantCode: 202},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeReshardStore()
+			if tc.prep != nil {
+				tc.prep(store)
+			}
+			w := doJSON(reshardRouterLister(store, tc.lister), http.MethodPost, "/api/v1/orgs/acme/reshard", tc.body)
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d body %s, want %d", w.Code, w.Body.String(), tc.wantCode)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(w.Body.String(), tc.wantSubstr) {
+				t.Fatalf("body %s, want substring %q", w.Body.String(), tc.wantSubstr)
+			}
+			if tc.wantCode != http.StatusAccepted && len(store.ops) != 0 {
+				t.Fatalf("op created despite rejection (%d ops)", len(store.ops))
+			}
+		})
+	}
+
+	// The source side of a created op is recorded from the duckling STATUS:
+	// an external source keeps from_shard empty and carries the row's external
+	// block; a cnpg source records the status-derived shard (pinned by
+	// TestReshardStartCnpg).
+	store := newFakeReshardStore()
+	store.warehouse.MetadataStore.Kind = configstore.MetadataStoreKindExternal
+	store.warehouse.MetadataStore.Endpoint = "real.rds.example.com"
+	store.warehouse.MetadataStore.Username = "postgres"
+	store.warehouse.MetadataStore.DatabaseName = "postgres"
+	store.warehouse.MetadataStore.PasswordAWSSecret = "duckling-src-secret"
+	w := doJSON(reshardRouterLister(store, externalShardLister("real.rds.example.com")),
+		http.MethodPost, "/api/v1/orgs/acme/reshard", cnpgTarget)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("ext→cnpg start: status = %d body %s, want 202", w.Code, w.Body.String())
+	}
+	op := store.ops[1]
+	if op.SourceKind != configstore.MetadataStoreKindExternal || op.FromShard != "" ||
+		op.SourceEndpoint != "real.rds.example.com" || op.SourcePasswordSecret != "duckling-src-secret" {
+		t.Fatalf("op source identity = %+v", op)
 	}
 }
 
@@ -500,7 +628,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 
 	// An SSO admin identity is refused — internal secret ONLY.
 	ssoStore := newFakeReshardStore()
-	ssoR, _ := reshardRouterSpawner(ssoStore, nil, nil, &fakeSpawner{}, "sso")
+	ssoR, _ := reshardRouterSpawner(ssoStore, nil, nil, &fakeSpawner{}, "sso", defaultShardLister())
 	if w := doJSON(ssoR, http.MethodPost, "/api/v1/orgs/acme/reshard", start); w.Code != http.StatusAccepted {
 		t.Fatalf("sso start: %d", w.Code)
 	}
@@ -529,7 +657,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 func TestReshardStartSpawnFailure(t *testing.T) {
 	// Spawn error → 502, op failed.
 	store := newFakeReshardStore()
-	r, _ := reshardRouterSpawner(store, nil, nil, &fakeSpawner{spawnErr: errors.New("pods is forbidden")}, "internal-secret")
+	r, _ := reshardRouterSpawner(store, nil, nil, &fakeSpawner{spawnErr: errors.New("pods is forbidden")}, "internal-secret", defaultShardLister())
 	w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`)
 	if w.Code != http.StatusBadGateway {
@@ -542,7 +670,7 @@ func TestReshardStartSpawnFailure(t *testing.T) {
 	// Ext target + no self pod IP → 500, op failed, no spawn attempted.
 	store = newFakeReshardStore()
 	sp := &fakeSpawner{noURL: true}
-	r, _ = reshardRouterSpawner(store, nil, nil, sp, "internal-secret")
+	r, _ = reshardRouterSpawner(store, nil, nil, sp, "internal-secret", defaultShardLister())
 	w = doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"duckling-x","password":"p"}}`)
 	if w.Code != http.StatusInternalServerError {
@@ -554,7 +682,7 @@ func TestReshardStartSpawnFailure(t *testing.T) {
 
 	// Nil spawner → 503, nothing created.
 	store = newFakeReshardStore()
-	r, _ = reshardRouterSpawner(store, nil, nil, nil, "internal-secret")
+	r, _ = reshardRouterSpawner(store, nil, nil, nil, "internal-secret", defaultShardLister())
 	w = doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`)
 	if w.Code != http.StatusServiceUnavailable {

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -631,20 +632,66 @@ func (d *DucklingClient) GetCompactionSetting(ctx context.Context, name string) 
 // SetCompactionEnabled patches spec.ducklake.maintenance.compaction.enabled
 // to an explicit value. enabled=nil REMOVES the key (JSON merge patch null),
 // restoring the pre-reshard "absent" state.
+//
+// XRD-defaulting guard (prod incident): a legacy CR can have NO spec.ducklake
+// object at all — its DuckLake enablement then comes from the legacy
+// metadata-store type coupling (see shared_worker_activator.go::
+// buildDuckLakeConfigFromDuckling). This merge patch MATERIALIZES the
+// spec.ducklake object, and the XRD's `ducklake.enabled: {default: false}`
+// stamps `enabled: false` onto the freshly created object — silently DISABLING
+// DuckLake for the org (the CP then builds an S3-only activation payload and
+// every activation fails with "tenant activation requires a ducklake
+// metadata_store"). When the object is absent, pin the org's EFFECTIVE
+// enablement into the same patch so defaulting cannot flip it; when it already
+// exists, patch exactly the compaction key and nothing else. The pinned
+// explicit value is deliberately NEVER removed afterwards (not by
+// restoreCompaction, not on takeover): it equals the effective value, so it is
+// a harmless no-op — whereas removing it after a successful flip would hand
+// enablement back to the type coupling, whose answer may have CHANGED with the
+// new metadata-store type (ext→cnpg would re-derive false — the same outage
+// through another door).
 func (d *DucklingClient) SetCompactionEnabled(ctx context.Context, name string, enabled *bool) error {
 	var value interface{}
 	if enabled != nil {
 		value = *enabled
 	}
+	ducklakeBlock := map[string]interface{}{
+		"maintenance": map[string]interface{}{
+			"compaction": map[string]interface{}{
+				"enabled": value,
+			},
+		},
+	}
+
+	cr, gerr := d.getCR(ctx, name)
+	if gerr != nil {
+		return fmt.Errorf("get duckling CR %q before compaction patch: %w", name, gerr)
+	}
+	hasDucklakeObject := false
+	if spec, ok := cr.Object["spec"].(map[string]interface{}); ok {
+		_, hasDucklakeObject = spec["ducklake"].(map[string]interface{})
+	}
+	if !hasDucklakeObject {
+		st, perr := parseDucklingStatus(cr)
+		if perr != nil {
+			return fmt.Errorf("parse duckling CR %q status before compaction patch: %w", name, perr)
+		}
+		// Mirror buildDuckLakeConfigFromDuckling's effective enablement: an
+		// explicit spec.ducklake.enabled wins (impossible here — the object is
+		// absent — but kept for symmetry), else the legacy coupling
+		// status.metadataStore.type != cnpg-shard.
+		effective := st.MetadataStore.Type != configstore.MetadataStoreKindCnpgShard
+		if st.DuckLakeEnabled != nil {
+			effective = *st.DuckLakeEnabled
+		}
+		ducklakeBlock["enabled"] = effective
+		slog.Info("Duckling has no spec.ducklake object; pinning effective ducklake enablement into the compaction patch so XRD defaulting cannot disable it.",
+			"duckling", name, "effective_enabled", effective, "status_metadata_store_type", st.MetadataStore.Type)
+	}
+
 	patch, err := json.Marshal(map[string]interface{}{
 		"spec": map[string]interface{}{
-			"ducklake": map[string]interface{}{
-				"maintenance": map[string]interface{}{
-					"compaction": map[string]interface{}{
-						"enabled": value,
-					},
-				},
-			},
+			"ducklake": ducklakeBlock,
 		},
 	})
 	if err != nil {

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -3,9 +3,14 @@
 package provisioner
 
 import (
+	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
 func mrWithPolicies(policies []interface{}) *unstructured.Unstructured {
@@ -43,4 +48,157 @@ func TestDescribeManagementPolicies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// seedDucklingForCompaction creates a Duckling CR with the given spec.ducklake
+// block (nil = the legacy no-spec.ducklake shape) and status metadata-store
+// type, for the compaction-patch tests.
+func seedDucklingForCompaction(t *testing.T, fakeK8s *dynamicfake.FakeDynamicClient, name string, ducklake map[string]interface{}, statusMetadataType string) {
+	t.Helper()
+	spec := map[string]interface{}{
+		"metadataStore": map[string]interface{}{"type": statusMetadataType},
+	}
+	if ducklake != nil {
+		spec["ducklake"] = ducklake
+	}
+	obj := map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata":   map[string]interface{}{"name": name, "namespace": ducklingNamespace},
+		"spec":       spec,
+		"status": map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"type":     statusMetadataType,
+				"endpoint": "endpoint.example.internal",
+			},
+		},
+	}
+	cr := &unstructured.Unstructured{Object: obj}
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(context.Background(), cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+}
+
+// applyXRDDucklakeDefault simulates the Duckling XRD's structural-schema
+// defaulting: when spec.ducklake exists WITHOUT an `enabled` key, the API
+// server stamps the schema default `enabled: false` onto it. The fake dynamic
+// client performs no defaulting, so the tests apply it explicitly after each
+// patch — this is what makes the regression real: without the pin in
+// SetCompactionEnabled, a compaction patch that materializes spec.ducklake on
+// a legacy CR gets `enabled: false` stamped and DuckLake is silently disabled
+// for the org (the prod incident).
+func applyXRDDucklakeDefault(t *testing.T, fakeK8s *dynamicfake.FakeDynamicClient, name string) {
+	t.Helper()
+	ctx := context.Background()
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CR for defaulting: %v", err)
+	}
+	spec, _ := cr.Object["spec"].(map[string]interface{})
+	dl, ok := spec["ducklake"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if _, has := dl["enabled"]; !has {
+		dl["enabled"] = false
+		if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("apply XRD default: %v", err)
+		}
+	}
+}
+
+// specDucklakeOf re-fetches the CR's spec.ducklake block (nil when absent).
+func specDucklakeOf(t *testing.T, fakeK8s *dynamicfake.FakeDynamicClient, name string) map[string]interface{} {
+	t.Helper()
+	cr, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch CR: %v", err)
+	}
+	spec, _ := cr.Object["spec"].(map[string]interface{})
+	dl, _ := spec["ducklake"].(map[string]interface{})
+	return dl
+}
+
+// TestSetCompactionEnabledPinsDuckLakeEnablement pins the XRD-defaulting guard
+// (prod incident): the reshard's compaction merge patch on a legacy CR with NO
+// spec.ducklake object materializes that object, and the XRD's
+// `ducklake.enabled: {default: false}` then stamps `enabled: false` onto it —
+// silently disabling DuckLake for the org (every later activation fails with
+// "tenant activation requires a ducklake metadata_store"). SetCompactionEnabled
+// must pin the org's EFFECTIVE enablement (the legacy metadata-store type
+// coupling: external → enabled, matching
+// shared_worker_activator.buildDuckLakeConfigFromDuckling) into the same patch
+// when — and only when — it materializes the object.
+func TestSetCompactionEnabledPinsDuckLakeEnablement(t *testing.T) {
+	ctx := context.Background()
+	off := false
+
+	// Legacy CR (no spec.ducklake) on an EXTERNAL metadata store: the coupling
+	// says DuckLake is enabled, so the patch must pin enabled=true — XRD
+	// defaulting must find the key already present.
+	t.Run("legacy CR external status pins enabled=true", func(t *testing.T) {
+		dc, fakeK8s := newFakeDucklingClient()
+		seedDucklingForCompaction(t, fakeK8s, "org-a", nil, configstore.MetadataStoreKindExternal)
+		if err := dc.SetCompactionEnabled(ctx, "org-a", &off); err != nil {
+			t.Fatalf("SetCompactionEnabled: %v", err)
+		}
+		applyXRDDucklakeDefault(t, fakeK8s, "org-a")
+		dl := specDucklakeOf(t, fakeK8s, "org-a")
+		if enabled, ok := dl["enabled"].(bool); !ok || !enabled {
+			t.Fatalf("spec.ducklake.enabled = %v (present %t), want pinned true — XRD defaulting would otherwise disable DuckLake", dl["enabled"], ok)
+		}
+		enabled, present, err := dc.GetCompactionSetting(ctx, "org-a")
+		if err != nil || !present || enabled {
+			t.Fatalf("compaction = enabled %t present %t err %v, want explicit false", enabled, present, err)
+		}
+	})
+
+	// Legacy CR on a cnpg-shard metadata store: the coupling derives
+	// enabled=false, so pinning false matches (and the XRD default agrees).
+	t.Run("legacy CR cnpg status pins the coupling value", func(t *testing.T) {
+		dc, fakeK8s := newFakeDucklingClient()
+		seedDucklingForCompaction(t, fakeK8s, "org-b", nil, configstore.MetadataStoreKindCnpgShard)
+		if err := dc.SetCompactionEnabled(ctx, "org-b", &off); err != nil {
+			t.Fatalf("SetCompactionEnabled: %v", err)
+		}
+		applyXRDDucklakeDefault(t, fakeK8s, "org-b")
+		dl := specDucklakeOf(t, fakeK8s, "org-b")
+		if enabled, ok := dl["enabled"].(bool); !ok || enabled {
+			t.Fatalf("spec.ducklake.enabled = %v (present %t), want pinned false (matches the type coupling)", dl["enabled"], ok)
+		}
+	})
+
+	// CR that already HAS spec.ducklake: the patch must not touch `enabled`.
+	// enabled=true with a cnpg status is the discriminating shape — if the
+	// code wrongly pinned the coupling value (false), this would flip.
+	t.Run("existing spec.ducklake is left untouched", func(t *testing.T) {
+		dc, fakeK8s := newFakeDucklingClient()
+		seedDucklingForCompaction(t, fakeK8s, "org-c", map[string]interface{}{"enabled": true}, configstore.MetadataStoreKindCnpgShard)
+		if err := dc.SetCompactionEnabled(ctx, "org-c", &off); err != nil {
+			t.Fatalf("SetCompactionEnabled: %v", err)
+		}
+		applyXRDDucklakeDefault(t, fakeK8s, "org-c")
+		dl := specDucklakeOf(t, fakeK8s, "org-c")
+		if enabled, ok := dl["enabled"].(bool); !ok || !enabled {
+			t.Fatalf("spec.ducklake.enabled = %v (present %t), want the pre-existing true left untouched", dl["enabled"], ok)
+		}
+	})
+
+	// The restore path (enabled=nil removes the compaction key) can materialize
+	// the object just the same on a legacy CR — it must pin too.
+	t.Run("restore remove-path pins on a legacy CR", func(t *testing.T) {
+		dc, fakeK8s := newFakeDucklingClient()
+		seedDucklingForCompaction(t, fakeK8s, "org-d", nil, configstore.MetadataStoreKindExternal)
+		if err := dc.SetCompactionEnabled(ctx, "org-d", nil); err != nil {
+			t.Fatalf("SetCompactionEnabled(nil): %v", err)
+		}
+		applyXRDDucklakeDefault(t, fakeK8s, "org-d")
+		dl := specDucklakeOf(t, fakeK8s, "org-d")
+		if enabled, ok := dl["enabled"].(bool); !ok || !enabled {
+			t.Fatalf("spec.ducklake.enabled = %v (present %t), want pinned true on the remove-path too", dl["enabled"], ok)
+		}
+		if _, present, _ := dc.GetCompactionSetting(ctx, "org-d"); present {
+			t.Fatal("compaction key present after the remove-path, want absent")
+		}
+	})
 }

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,36 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+// cnpgShardNamePattern mirrors the Duckling XRD's spec.metadataStore.cnpgShard
+// validation (charts repo: pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$, max 63
+// chars). The API server REJECTS a patch whose shard value violates it —
+// including the empty string — so a rollback must never emit such a patch: the
+// refused patch would leave the duckling pointing at the WRONG (target) store.
+// A prod incident did exactly that: an op created with an empty from_shard
+// rolled back into a rejected patch and the org was left activated against a
+// freshly created empty catalog.
+var cnpgShardNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// isValidCnpgShardName reports whether s would pass the XRD's cnpgShard
+// admission validation.
+func isValidCnpgShardName(s string) bool {
+	return s != "" && len(s) <= 63 && cnpgShardNamePattern.MatchString(s)
+}
+
+// sslModeFor derives the sslmode a metadata store of the given kind requires,
+// exactly like recordSource: cnpg poolers are in-cluster plaintext
+// ("disable"); external stores are RDS, which requires TLS ("require" — a
+// plaintext attempt fails pg_hba with "no encryption"). Every CatalogEndpoint
+// (re)construction MUST derive its sslmode through this helper instead of
+// hardcoding one: a takeover-resume path that hardcoded "disable" broke
+// against an external source in production.
+func sslModeFor(kind string) string {
+	if kind == configstore.MetadataStoreKindExternal {
+		return "require"
+	}
+	return "disable"
+}
 
 // ReshardRunner drives reshard operations (see docs/design/resharding.md and
 // configstore/reshard.go). It runs inside a DEDICATED per-operation pod
@@ -586,14 +617,7 @@ func (o *opRun) resumeTakeover(ctx context.Context) error {
 		if o.op.SourceEndpoint == "" || o.op.SourceUser == "" || o.op.SourceDatabase == "" {
 			return fmt.Errorf("takeover at step %q has incomplete durable source identity", o.op.Step)
 		}
-		o.source = CatalogEndpoint{
-			Host: o.op.SourceEndpoint, Port: 5432, User: o.op.SourceUser,
-			Password: st.MetadataStore.Password, Database: o.op.SourceDatabase, SSLMode: "disable",
-		}
-		o.target = CatalogEndpoint{
-			Host: st.MetadataStore.Endpoint, Port: 5432, User: st.MetadataStore.User,
-			Password: st.MetadataStore.Password, Database: st.MetadataStore.Database, SSLMode: "disable",
-		}
+		o.source, o.target = takeoverEndpoints(o.op, st)
 		if err := o.copyCatalog(ctx); err != nil {
 			return err
 		}
@@ -612,6 +636,30 @@ func (o *opRun) resumeTakeover(ctx context.Context) error {
 	default:
 		return fmt.Errorf("takeover at step %q cannot be resumed safely; rolling back from durable progress", o.op.Step)
 	}
+}
+
+// takeoverEndpoints reconstructs the copy endpoints for a takeover resume from
+// the durable op row (source identity) plus the live duckling status (target +
+// the pinned tenant password, which a cnpg shard change preserves). Each
+// side's sslmode is derived from its metadata-store KIND via sslModeFor —
+// NEVER hardcoded: a reconstruction that hardcoded "disable" was probed
+// against an external RDS source in production and failed pg_hba with
+// "no encryption". Today resumeTakeover only reaches this for cnpg→cnpg ops
+// (other directions fail into the conservative rollback), but the derivation
+// must stay kind-correct so relaxing that guard — or a drifted op row — can
+// never reintroduce the wrong sslmode.
+func takeoverEndpoints(op *configstore.ReshardOperation, st *DucklingStatus) (source, target CatalogEndpoint) {
+	source = CatalogEndpoint{
+		Host: op.SourceEndpoint, Port: 5432, User: op.SourceUser,
+		Password: st.MetadataStore.Password, Database: op.SourceDatabase,
+		SSLMode: sslModeFor(op.SourceKind),
+	}
+	target = CatalogEndpoint{
+		Host: st.MetadataStore.Endpoint, Port: 5432, User: st.MetadataStore.User,
+		Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
+		SSLMode: sslModeFor(op.TargetKind),
+	}
+	return source, target
 }
 
 // ---- steps ----------------------------------------------------------------
@@ -786,6 +834,15 @@ func (o *opRun) recordSource(ctx context.Context) error {
 	if ms.Endpoint == "" || ms.User == "" || ms.Database == "" {
 		return fmt.Errorf("duckling status has incomplete metadata-store info (endpoint %q user %q database %q)", ms.Endpoint, ms.User, ms.Database)
 	}
+	// Defense in depth behind the admin start handler's submit-time check: the
+	// duckling STATUS is authoritative for where the catalog actually lives.
+	// An op whose recorded source kind contradicts it (a drifted config-store
+	// row, an op created by an older CP, or a hand-inserted row) would treat
+	// e.g. an external RDS as a cnpg source — the incident that flipped an org
+	// onto an empty catalog. Refuse pre-flip: rollback from here is clean.
+	if ms.Type != "" && ms.Type != o.op.SourceKind {
+		return fmt.Errorf("metadata-store identity drift: the duckling status says the catalog lives on %q (endpoint %q) but the operation recorded source kind %q — refusing to proceed; reconcile the config-store warehouse row and the duckling spec/status, then re-run the reshard", ms.Type, ms.Endpoint, o.op.SourceKind)
+	}
 
 	switch o.op.SourceKind {
 	case configstore.MetadataStoreKindCnpgShard:
@@ -794,7 +851,7 @@ func (o *opRun) recordSource(ctx context.Context) error {
 		o.source = CatalogEndpoint{
 			Host: ms.Endpoint, Port: 5432,
 			User: ms.User, Password: ms.Password, Database: ms.Database,
-			SSLMode: "disable",
+			SSLMode: sslModeFor(o.op.SourceKind),
 		}
 	case configstore.MetadataStoreKindExternal:
 		// Post-flip the composition deletes the ESO sync + pgbouncer, so the
@@ -804,7 +861,7 @@ func (o *opRun) recordSource(ctx context.Context) error {
 		o.source = CatalogEndpoint{
 			Host: ms.Endpoint, Port: 5432,
 			User: ms.User, Password: ms.Password, Database: ms.Database,
-			SSLMode: "require",
+			SSLMode: sslModeFor(o.op.SourceKind),
 		}
 		o.r.extPasswords.Store(o.op.ID, ms.Password)
 	default:
@@ -948,7 +1005,7 @@ func (o *opRun) flipToCnpg(ctx context.Context) error {
 			o.target = CatalogEndpoint{
 				Host: st.MetadataStore.Endpoint, Port: 5432,
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
-				SSLMode: "disable",
+				SSLMode: sslModeFor(o.op.TargetKind),
 			}
 			probeErr := o.r.copier.Probe(ctx, o.target)
 			if probeErr == nil {
@@ -1169,7 +1226,7 @@ func (o *opRun) copyCatalog(ctx context.Context) error {
 			User:     orDefault(o.op.TargetUser, "postgres"),
 			Password: pw.(string),
 			Database: orDefault(o.op.TargetDatabase, "postgres"),
-			SSLMode:  "require",
+			SSLMode:  sslModeFor(o.op.TargetKind),
 		}
 	}
 	if o.op.SourceKind == configstore.MetadataStoreKindExternal && o.source.Password == "" {
@@ -1331,6 +1388,18 @@ func (o *opRun) rollback(ctx context.Context) {
 			// Patch the source shard VALUE back — never remove the key: the
 			// precedence chain would fall through to the freshly-stamped
 			// (bogus) status pin.
+			if !isValidCnpgShardName(o.op.FromShard) {
+				// NEVER emit a patch the XRD would reject (empty/malformed
+				// shard): the refused patch would burn the one rollback
+				// attempt and mislead the log. The duckling stays pointing at
+				// the WRONG (target) store, so the org must stay blocked —
+				// recovered=false below intentionally leaves the warehouse in
+				// resharding. Leave the half-copied target untouched too, for
+				// forensics.
+				o.logf("error", "rollback CANNOT re-point the duckling at the source shard: recorded from_shard %q is empty or not a valid cnpg shard name (XRD pattern %s) — the org's source identity was incomplete when this operation was created. Duckling %s still points at %s, which does NOT hold the org's catalog. Operator action: determine where the catalog actually lives (check the duckling STATUS history / the pre-flip backup URI on this op), patch spec.metadataStore on the duckling to point at it, verify a client can activate against the real catalog, and only then set the warehouse state back to ready. The warehouse is intentionally left in the resharding state so clients cannot activate against the wrong (likely empty) catalog", o.op.FromShard, cnpgShardNamePattern, o.op.DucklingName, o.op.ToShard)
+				recovered = false
+				break
+			}
 			o.logf("warn", "rolling back: re-pointing duckling at source shard %s", o.op.FromShard)
 			if err := o.r.duckling.SetMetadataStoreCnpg(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
 				o.logf("error", "rollback flip failed: %v — duckling still points at %s; fix manually", err, o.op.ToShard)
@@ -1340,6 +1409,14 @@ func (o *opRun) rollback(ctx context.Context) {
 		case o.op.TargetKind == configstore.MetadataStoreKindCnpgShard && o.op.SourceKind == configstore.MetadataStoreKindExternal:
 			// ext→cnpg rollback: back to external; cnpgShard must be removed
 			// (CEL forbids it on the external type).
+			if o.op.SourceEndpoint == "" || o.op.SourcePasswordSecret == "" {
+				// Same never-emit-an-invalid-patch guard as the cnpg case: an
+				// external spec without endpoint/password secret would be
+				// rejected (or worse, rendered broken). Leave the org blocked.
+				o.logf("error", "rollback CANNOT re-point the duckling at the external source: recorded source endpoint %q / password secret %q are incomplete — refusing to emit an invalid external metadata-store patch. Duckling %s still points at cnpg %s, which does NOT hold the org's catalog. Operator action: determine the org's real external metadata store (endpoint, user, database, SM password secret), patch spec.metadataStore on the duckling to it, verify a client can activate against the real catalog, and only then set the warehouse state back to ready. The warehouse is intentionally left in the resharding state so clients cannot activate against the wrong catalog", o.op.SourceEndpoint, o.op.SourcePasswordSecret, o.op.DucklingName, o.op.ToShard)
+				recovered = false
+				break
+			}
 			o.logf("warn", "rolling back: re-pointing duckling at external source %s", o.op.SourceEndpoint)
 			if err := o.r.duckling.SetMetadataStoreExternal(ctx, o.op.DucklingName, ExternalMetadataStoreSpec{
 				Endpoint:          o.op.SourceEndpoint,
@@ -1416,6 +1493,12 @@ func (o *opRun) dropPartialTarget(ctx context.Context) {
 // No empty-recreate, no copy-back — the catalog never left the source. This is
 // the whole point of the orphan-adopt escape hatch.
 func (o *opRun) recoverFromExternal(ctx context.Context) bool {
+	if !isValidCnpgShardName(o.op.FromShard) {
+		// Same guard as the rollback flip-backs: never emit an adopt patch the
+		// XRD would reject (empty/malformed shard).
+		o.logf("error", "recovery CANNOT flip back and re-adopt the cnpg source: recorded from_shard %q is empty or not a valid cnpg shard name (XRD pattern %s) — the org's source identity was incomplete when this operation was created. Duckling %s still points at external %s. The orphaned cnpg role/DB survive on the source shard and can be re-adopted manually (patch spec.metadataStore to {type: cnpg-shard, cnpgShard: <real shard>, retainCnpgOnFlip: false}); verify a client can activate against the real catalog, then set the warehouse state back to ready. The warehouse is intentionally left in the resharding state so clients cannot activate against the wrong catalog", o.op.FromShard, cnpgShardNamePattern, o.op.DucklingName, o.op.TargetEndpoint)
+		return false
+	}
 	o.logf("warn", "cnpg→external cutover failed AFTER the flip — the cnpg source role/DB were RETAINED (orphaned), not deleted; recovering by flipping back to shard %s and re-adopting them (no data copy)", o.op.FromShard)
 
 	if err := o.r.duckling.SetMetadataStoreCnpgAdopt(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
@@ -1455,7 +1538,9 @@ func (o *opRun) recoverFromExternal(ctx context.Context) bool {
 			restored := CatalogEndpoint{
 				Host: st.MetadataStore.Endpoint, Port: 5432,
 				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
-				SSLMode: "disable",
+				// The flip-back re-adopts the cnpg source (this recovery only
+				// runs for cnpg→ext ops), so the probe goes via the pooler.
+				SSLMode: sslModeFor(o.op.SourceKind),
 			}
 			probeErr := o.r.copier.Probe(ctx, restored)
 			if probeErr == nil {

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -878,6 +878,183 @@ func TestReshardRollbackKeepsWarehouseBlockedWhenSourceRecoveryFails(t *testing.
 	}
 }
 
+// TestReshardRollbackRefusesInvalidFromShardPatch pins the never-emit-an-
+// invalid-patch guard (prod incident): a cnpg→cnpg op recorded with an EMPTY
+// from_shard (incomplete source identity — pre-guard CPs could create these)
+// must NOT attempt the rollback re-point (the XRD rejects an empty cnpgShard,
+// so the patch would just fail and mislead), must log explicit operator
+// instructions, and must leave the warehouse BLOCKED in resharding — unblocking
+// would let clients activate against the wrong (likely empty) target catalog.
+func TestReshardRollbackRefusesInvalidFromShardPatch(t *testing.T) {
+	op := cnpgOp()
+	op.FromShard = "" // the incident shape: source identity was incomplete
+	op.CutoverTimeoutSeconds = 1
+	store := newFakeReshardStore(op)
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	stuck := &stuckCnpgDuckling{fakeDuckling: duckling} // flip never converges
+	copier := &fakeCopier{}
+
+	runOp(t, testRunner(store, stuck, copier), store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state = %s (err %q), want failed", store.op.State, store.op.Error)
+	}
+	// Exactly ONE cnpg patch: the forward flip. No rollback patch was emitted.
+	var shardPatches []string
+	for _, call := range duckling.calls {
+		if call.kind == "cnpg" {
+			shardPatches = append(shardPatches, call.shard)
+		}
+	}
+	if fmt.Sprint(shardPatches) != fmt.Sprint([]string{"shard-002"}) {
+		t.Fatalf("shard patches = %v, want only the forward flip (no invalid rollback patch)", shardPatches)
+	}
+	// Loud operator instructions, and the deliberate left-blocked decision.
+	if !store.hasLog("rollback CANNOT re-point the duckling at the source shard") {
+		t.Fatalf("invalid-from_shard refusal missing from log: %v", store.logs)
+	}
+	if !store.hasLog("intentionally left in the resharding state") {
+		t.Fatalf("left-blocked decision missing from log: %v", store.logs)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding (left blocked — never unblock onto the wrong store)", store.warehouseState)
+	}
+	if store.op.UnblockedAt != nil {
+		t.Fatalf("unblocked_at = %v, want nil (org left blocked)", store.op.UnblockedAt)
+	}
+	if !store.hasLog("reshard report (failed)") {
+		t.Fatal("failure report missing")
+	}
+}
+
+// TestReshardRollbackRefusesIncompleteExternalSourcePatch is the ext→cnpg
+// sibling of the invalid-from_shard guard: a post-flip rollback whose recorded
+// external source identity is incomplete (no password secret — the admin
+// handler records it; recordSource cannot) must not emit an invalid external
+// spec patch, and must leave the warehouse blocked with operator instructions.
+func TestReshardRollbackRefusesIncompleteExternalSourcePatch(t *testing.T) {
+	op := cnpgOp()
+	op.SourceKind = configstore.MetadataStoreKindExternal
+	op.FromShard = ""
+	op.SourcePasswordSecret = "" // incomplete: rollback could not re-render the spec
+	op.CutoverTimeoutSeconds = 1
+	store := newFakeReshardStore(op)
+
+	var st DucklingStatus
+	st.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	st.MetadataStore.Endpoint = "db.example.rds.amazonaws.com"
+	st.MetadataStore.User = "postgres"
+	st.MetadataStore.Database = "postgres"
+	st.MetadataStore.Password = "rds-pw"
+	st.DataStore.BucketName = "org-a-data-bucket"
+	st.DataStore.S3Region = "us-east-1"
+	st.IAMRoleARN = "arn:aws:iam::123:role/duckling-org-a"
+	st.ReadyCondition = true
+	duckling := &fakeDuckling{status: st}
+	stuck := &stuckCnpgDuckling{fakeDuckling: duckling} // flip never converges
+	copier := &fakeCopier{}
+
+	runOp(t, testRunner(store, stuck, copier), store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state = %s (err %q), want failed", store.op.State, store.op.Error)
+	}
+	// No rollback flip to external was emitted.
+	if containsStr(duckling.callKinds(), "external") {
+		t.Fatalf("rollback emitted an external patch despite the incomplete source identity: %v", duckling.callKinds())
+	}
+	if !store.hasLog("rollback CANNOT re-point the duckling at the external source") {
+		t.Fatalf("incomplete-external-source refusal missing from log: %v", store.logs)
+	}
+	if !store.hasLog("intentionally left in the resharding state") {
+		t.Fatalf("left-blocked decision missing from log: %v", store.logs)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding (left blocked)", store.warehouseState)
+	}
+}
+
+// TestReshardRecordSourceRefusesStatusKindDrift pins the runner-side defense
+// in depth behind the admin submit-time guard: an op whose recorded source
+// kind contradicts the duckling STATUS (where the catalog actually lives)
+// fails PRE-flip — nothing is flipped, and the rollback unblocks the
+// warehouse cleanly. This is the incident shape: an empty config-store
+// metadata block defaulted to cnpg-shard while the org lived on an external
+// RDS.
+func TestReshardRecordSourceRefusesStatusKindDrift(t *testing.T) {
+	op := cnpgOp() // recorded as cnpg→cnpg…
+	store := newFakeReshardStore(op)
+	// …but the duckling status says the catalog lives on an external RDS.
+	var st DucklingStatus
+	st.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	st.MetadataStore.Endpoint = "db.example.rds.amazonaws.com"
+	st.MetadataStore.User = "postgres"
+	st.MetadataStore.Database = "postgres"
+	st.MetadataStore.Password = "rds-pw"
+	st.ReadyCondition = true
+	duckling := &fakeDuckling{status: st}
+	copier := &fakeCopier{}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.op.State != configstore.ReshardStateFailed || !strings.Contains(store.op.Error, "identity drift") {
+		t.Fatalf("state=%s err=%q, want identity-drift failure", store.op.State, store.op.Error)
+	}
+	// Refused BEFORE any flip: the duckling was never patched to a store.
+	for _, k := range duckling.callKinds() {
+		if k == "cnpg" || k == "external" || k == "cnpg-adopt" {
+			t.Fatalf("duckling flipped (%s) despite the identity drift — must refuse pre-flip", k)
+		}
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready (pre-flip failure rolls back cleanly)", store.warehouseState)
+	}
+}
+
+// TestReshardTakeoverEndpointsDeriveSSLModeFromKind pins that a takeover
+// resume reconstructs each endpoint's sslmode from its metadata-store KIND —
+// never hardcoded. Regression for the takeover path that hardcoded "disable"
+// and hit RDS pg_hba "no encryption" against an external source in prod.
+func TestReshardTakeoverEndpointsDeriveSSLModeFromKind(t *testing.T) {
+	st := &DucklingStatus{}
+	st.MetadataStore.Endpoint = "shard-002-pooler.cnpg-shards.svc.cluster.local"
+	st.MetadataStore.User = "mdstore_org"
+	st.MetadataStore.Database = "mdstore_org"
+	st.MetadataStore.Password = "pinned-pw"
+
+	cases := []struct {
+		name                string
+		sourceKind, tgtKind string
+		wantSrcSSL, wantTgt string
+	}{
+		{"cnpg→cnpg", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindCnpgShard, "disable", "disable"},
+		{"ext→cnpg (external source needs TLS)", configstore.MetadataStoreKindExternal, configstore.MetadataStoreKindCnpgShard, "require", "disable"},
+		{"cnpg→ext (external target needs TLS)", configstore.MetadataStoreKindCnpgShard, configstore.MetadataStoreKindExternal, "disable", "require"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := &configstore.ReshardOperation{
+				SourceKind:     tc.sourceKind,
+				TargetKind:     tc.tgtKind,
+				SourceEndpoint: "src.example.internal",
+				SourceUser:     "u",
+				SourceDatabase: "d",
+			}
+			source, target := takeoverEndpoints(op, st)
+			if source.SSLMode != tc.wantSrcSSL || target.SSLMode != tc.wantTgt {
+				t.Fatalf("sslmodes = source %q / target %q, want %q / %q", source.SSLMode, target.SSLMode, tc.wantSrcSSL, tc.wantTgt)
+			}
+		})
+	}
+
+	if got := sslModeFor(configstore.MetadataStoreKindExternal); got != "require" {
+		t.Fatalf("sslModeFor(external) = %q, want require", got)
+	}
+	if got := sslModeFor(configstore.MetadataStoreKindCnpgShard); got != "disable" {
+		t.Fatalf("sslModeFor(cnpg-shard) = %q, want disable", got)
+	}
+}
+
 // TestReshardTakeoverPreservesOriginalCompactionSnapshot ensures replay cannot
 // replace the persisted pre-reshard setting with the already-paused live value.
 func TestReshardTakeoverPreservesOriginalCompactionSnapshot(t *testing.T) {
@@ -924,6 +1101,13 @@ func TestReshardTakeoverAfterCutoverDoesNotReplaySourceDiscovery(t *testing.T) {
 	for _, call := range copier.calls {
 		if call.kind == "copy" && call.source.Host != "shard-001-pooler.cnpg-shards.svc.cluster.local" {
 			t.Fatalf("takeover copied from %q, want durable source shard-001", call.source.Host)
+		}
+		if call.kind == "copy" && (call.source.SSLMode != "disable" || call.target.SSLMode != "disable") {
+			// cnpg endpoints are in-cluster plaintext; the sslmode must be
+			// KIND-derived (sslModeFor), never hardcoded — see
+			// TestReshardTakeoverEndpointsDeriveSSLModeFromKind for the
+			// external cases.
+			t.Fatalf("takeover copy sslmodes = source %q / target %q, want disable/disable for cnpg→cnpg", call.source.SSLMode, call.target.SSLMode)
 		}
 		if call.kind == "dropdb" && call.target.Host == "shard-002-pooler.cnpg-shards.svc.cluster.local" {
 			t.Fatal("takeover attempted destructive cleanup against the live target")

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -59,6 +59,42 @@ behavior is bound to the reshard type-flip, never to Duckling deletion. The e2e
 `lifecycle_teardown_cnpg` asserts the finalizer cascade still fully deletes the
 CR (and its cnpg role/DB) on a normal deprovision.
 
+## Source identity: the duckling STATUS is authoritative
+
+The start handler (`admin/reshard.go`) derives the op's **source side**
+(`source_kind`, `from_shard`, the external source block) with the live
+Duckling **status** as the source of truth: the composition writes the status
+after convergence, so it records where the catalog *actually* lives, while
+the config-store warehouse row and the duckling *spec* are operator-editable
+inputs that can drift. The op is **refused (400, nothing created)** when the
+identity is incomplete or contradicted:
+
+- **kind drift** — the row's `metadata_store_kind` (when set) disagrees with
+  the status type → 400 naming both values ("refusing to reshard until
+  reconciled").
+- **cnpg source with an unresolvable current shard** (no lister / no CR
+  status / empty endpoint) → 400: an op recorded with an empty `from_shard`
+  cannot roll back — the XRD rejects an empty `cnpgShard` patch. The resolved
+  shard is also shape-checked against the XRD pattern.
+- **external source with an incomplete row block** (no endpoint or SM
+  password secret) → 400: an ext→cnpg rollback re-renders the external spec
+  from those fields.
+- **empty row kind AND no status** → 400 (nothing to derive from).
+
+The runner re-checks at `recordSource` (pre-flip, defense in depth for ops
+created by older CPs or hand-inserted rows): a status type that contradicts
+the op's recorded `source_kind` fails the op before anything is flipped.
+
+This guards against a real prod incident: an org whose config-store metadata
+block was EMPTY (previously silently defaulted to cnpg-shard) and whose
+duckling *spec* type had drifted from its *status* (the org actually lived on
+an external RDS) got a cnpg→cnpg op with `from_shard=""`. cnpg→cnpg flips
+BEFORE copying, so the org was re-pointed at a freshly created EMPTY catalog
+with no copy performed; the copy then failed (the external source was probed
+with the cnpg branch's `sslmode=disable`), and the rollback patch
+(`cnpgShard: ""`) was rejected by the XRD — leaving the duckling on the empty
+target while the warehouse was unblocked to ready.
+
 ## Execution model: one dedicated pod per operation
 
 A reshard never executes inside a control-plane process. When an operator
@@ -143,6 +179,22 @@ blocking → draining → pausing_compaction → backup_catalog → cutover → 
    absent). Residual window: an already-running millpond Job (≤30m, source
    endpoint baked in) can outlive the pause — covered by the verify step and
    the cleanup fence.
+   **XRD-defaulting guard (prod incident)**: a legacy CR can have NO
+   `spec.ducklake` object at all — its DuckLake enablement then comes from the
+   legacy metadata-store type coupling (`status.metadataStore.type !=
+   cnpg-shard`, the same derivation the worker activator uses). The compaction
+   merge patch MATERIALIZES `spec.ducklake`, and the XRD's
+   `ducklake.enabled: {default: false}` stamps `enabled: false` onto the fresh
+   object — silently disabling DuckLake for the org (activation then builds an
+   S3-only payload and the worker fails with "tenant activation requires a
+   ducklake metadata_store"). `SetCompactionEnabled` therefore reads the CR
+   first and, when the object is absent, pins the org's EFFECTIVE enablement
+   into the same patch; an existing `spec.ducklake` is patched exactly as
+   before (compaction key only). The pinned explicit value is deliberately
+   never removed afterwards: it equals the effective value (a no-op), whereas
+   removing it after a successful flip would hand enablement back to the type
+   coupling, whose answer may have CHANGED with the new store type (ext→cnpg
+   would re-derive false — the same outage through another door).
 4. **backup_catalog** — the safety net (§ Pre-flip catalog backup below). Dump
    the SOURCE catalog to the org's own S3 data bucket BEFORE any flip. Runs for
    every direction; the source is quiescent here (post-drain, compaction paused)
@@ -433,6 +485,22 @@ never appear in the op log.
   post-flip → adopt recovery (above); pre-flip → if `retainCnpgOnFlip` was set,
   reset it to false so the still-cnpg source keeps full-lifecycle (Delete) MRs
   and deprovision stays clean.
+- **Rollback never emits a patch the XRD would reject.** If the recorded
+  source identity is unusable — `from_shard` empty or outside the XRD's
+  shard-name pattern (`isValidCnpgShardName` mirrors it), or an external
+  source block missing endpoint/password secret — the rollback flip-back (and
+  the cnpg→ext adopt recovery) is SKIPPED with an ERROR carrying explicit
+  operator instructions, and the warehouse is **intentionally left blocked in
+  `resharding`** (see the never-stranded caveat below). Emitting the invalid
+  patch would just be refused by the API server and mislead the log — the
+  prod incident's rollback failed exactly that way. The submit-time
+  source-identity validation makes such ops unrepresentable going forward;
+  this guard covers pre-guard rows and drift after creation.
+- Takeover-resume reconstructs `o.source`/`o.target` from the durable op row +
+  live duckling status with each side's **sslmode derived from its
+  metadata-store kind** (`sslModeFor`: cnpg pooler → `disable`, external RDS →
+  `require`) — never hardcoded; a hardcoded `disable` fails RDS pg_hba with
+  "no encryption".
 - Cancel (`POST /reshards/:id/cancel`): flag checked between steps and inside
   every wait loop; rolls back like a failure at that step → `cancelled`.
   Pending (unclaimed) ops finish immediately. On cnpg→ext, cancel is refused
@@ -460,7 +528,16 @@ never appear in the op log.
   prove a step completed flip a flag) and every rollback action is idempotent, so
   a takeover rolls back identically to the original runner.
 - An org is never stranded: every failure path restores `resharding→ready`
-  (or logs at ERROR if it can't — that's the page-someone signal).
+  (or logs at ERROR if it can't — that's the page-someone signal) — with ONE
+  deliberate carve-out: when the duckling is known to point at the WRONG
+  store and rollback cannot repair it (an invalid/incomplete recorded source
+  identity, or a flip-back that failed), the warehouse stays BLOCKED in
+  `resharding`. Unblocking would let clients activate against the wrong
+  (likely empty) catalog — worse than a blocked org: the prod incident
+  unblocked after a failed rollback and clients landed on an empty catalog.
+  The ERROR log carries the manual repair steps (verify where the catalog
+  actually lives, patch `spec.metadataStore`, verify activation, then set the
+  warehouse ready).
 
 ## Testing
 
@@ -477,9 +554,15 @@ ephemeral-password loss, the pre-flip backup: recorded before the flip, the
 destructive-direction hard-fail-before-flip, the non-destructive
 warning-and-continue; for cnpg→ext specifically the two-step orphan flip, the
 external-catalog verify gate, the flip-back adopt recovery with NO copy-back,
-and the XRD-without-`retainCnpgOnFlip` refusal), `admin/reshard_test.go`
+and the XRD-without-`retainCnpgOnFlip` refusal; plus the source-identity
+guards: the recordSource status-drift refusal, the invalid-from_shard /
+incomplete-external-source rollback refusals with the warehouse left blocked,
+and the kind-derived takeover sslmode reconstruction), `admin/reshard_test.go`
 (validation incl. the ESO-name allowlist + the pre-flight connection-check
-pass/fail/skip, secrets never persisted). The `backup_s3_uri` column is asserted
+pass/fail/skip, the submit-time source-identity validation
+(`TestReshardStartSourceIdentityValidation`), secrets never persisted).
+`provisioner/k8s_client_test.go` pins the compaction patch's XRD-defaulting
+guard (`TestSetCompactionEnabledPinsDuckLakeEnablement`). The `backup_s3_uri` column is asserted
 in `tests/configstore/migrations_postgres_test.go` (migration `000021`). The
 charts side (composition + `retainCnpgOnFlip` XRD field) is tested by
 `charts/charts/crossplane-config/tests/composition_retain_cnpg_test.sh` (both

--- a/docs/runbooks/resharding.md
+++ b/docs/runbooks/resharding.md
@@ -40,5 +40,16 @@ the catalog fingerprint/table set is complete. Only then restore warehouse
 readiness. For a damaged catalog, use the `pg_restore` command recorded beside
 `backup_s3_uri` in the operation log.
 
+One blocked shape is deliberate: when the op's recorded source identity was
+unusable (empty/invalid `from_shard`, or an external source block without
+endpoint/password secret), rollback refuses to emit the flip-back patch — the
+XRD would reject it — and leaves the warehouse blocked with an ERROR carrying
+the manual steps. The duckling then still points at the WRONG (target) store.
+Determine where the catalog actually lives (duckling status history, the
+pre-flip `backup_s3_uri`), patch `spec.metadataStore` to it, verify a client
+can activate against the real catalog, and only then set the warehouse state
+back to `ready`. Never unblock first — clients would activate against the
+wrong (likely empty) catalog.
+
 Never delete or recreate a retained cnpg database until the operation log shows
 that the external target passed content fingerprint verification.

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2473,6 +2473,18 @@ reshard_targets() { # destination discovery; ext org's RDS must appear too
 
 reshard_validation() { # cnpg-org currently on shard-001
   log "reshard validation: same-shard + bad targets are 400"
+  # NOT asserted here: the submit-time source-identity 400s (empty/unresolvable
+  # from_shard, config-store-row vs duckling-status kind drift, incomplete
+  # external source block — controlplane/admin/reshard.go). Those trigger on a
+  # BROKEN org state (empty metadata block / drifted duckling), which cannot be
+  # provoked in-Job without corrupting a live org's duckling spec (a
+  # spec.metadataStore patch is exactly the destructive flip the guard exists
+  # to prevent). Covered by admin/reshard_test.go
+  # (TestReshardStartSourceIdentityValidation) and
+  # provisioner/reshard_runner_test.go (the recordSource drift + rollback
+  # guards). The positive side — from_shard/source_kind being derived from the
+  # duckling STATUS — IS asserted on the live ops below (cancel + ext→cnpg
+  # lanes).
   # The RDS-managed-master and generic-prefix rows pin Fix 1's positive ESO
   # allowlist: the external-secrets IAM policy only allows GetSecretValue on
   # posthog-*/duckling-* names, so the start handler 400s an SM secret name
@@ -2517,6 +2529,12 @@ reshard_cancel_during_drain() { # org password
     || fail "reshard cancel: start failed: $out"
   opid="$(echo "$out" | jq -r .id)"
   [ -n "$opid" ] && [ "$opid" != "null" ] || fail "reshard cancel: no op id: $out"
+  # Source identity is derived from the duckling STATUS (authoritative) and
+  # must be complete on the created op: a cnpg-shard source always carries the
+  # real current shard (an op with an empty from_shard cannot roll back and is
+  # refused at submit — the source-identity guard).
+  echo "$out" | jq -e '.source_kind == "cnpg-shard" and .from_shard == "shard-001"' >/dev/null \
+    || fail "reshard cancel: op source identity not derived from duckling status: $out"
 
   # The op executes in a dedicated runner pod now: budget covers pod schedule
   # + (first-time) image pull on an arch-pinned node before the drain step.
@@ -2605,6 +2623,12 @@ reshard_ext_to_cnpg() { # ext-org password
   # read from the CR status pre-flip), so password_url stays empty.
   echo "$out" | jq -e '.state == "pending"' >/dev/null \
     || fail "reshard ext→cnpg: op not created pending (pod model): $out"
+  # Source identity: derived from the duckling STATUS (external) and complete
+  # (endpoint + SM secret name recorded from the warehouse row — the rollback
+  # needs them to re-render the external spec; incomplete would have been a
+  # submit-time 400).
+  echo "$out" | jq -e '.source_kind == "external" and (.source_endpoint | length > 0) and (.source_password_secret | length > 0)' >/dev/null \
+    || fail "reshard ext→cnpg: op source identity incomplete or not status-derived: $out"
 
   # The dedicated runner pod appears (spawned by the start handler; the leader
   # reconciler would backstop it) and carries the op-id label.


### PR DESCRIPTION
## Incident

A reshard of an org whose **config-store metadata block was empty** and whose **duckling spec type had drifted from its status** (the org actually lived on an external RDS) went wrong end to end:

1. The op was created as `source_kind=cnpg-shard` with an **empty `from_shard`** — the empty row kind silently defaulted to cnpg-shard and no validation refused it.
2. cnpg→cnpg is **flip-before-copy**: the runner patched the target shard onto the duckling → the composition converged → the org was re-pointed at a **freshly created empty catalog** with no copy performed.
3. The copy step then failed: the recorded source (an RDS endpoint, taken from pre-flip duckling status) was probed with the cnpg branch's `sslmode=disable` → RDS pg_hba rejected "no encryption". The pre-flip backup failed the same way (best-effort in this direction → continued).
4. Rollback patched `cnpgShard: ""` — rejected by the XRD pattern → **rollback failed, duckling left on the empty target**, warehouse unblocked to ready → clients activated against an empty warehouse.
5. Bonus root cause: the org's legacy CR had **no `spec.ducklake` object**; the compaction pause materialized it and the XRD's `enabled: {default: false}` stamped `enabled: false` → DuckLake silently disabled → every activation failed with "tenant activation requires a ducklake metadata_store" until a manual spec patch.

## Fixes

**1. Submit-time source-identity validation** (`controlplane/admin/reshard.go`)
The duckling **STATUS** is now authoritative for the source side (`source_kind`, `from_shard`, external block). The start handler 400s (nothing created) on:
- row/status **kind drift** (message names both values),
- a **cnpg source whose current shard cannot be resolved** (an op with an empty `from_shard` cannot roll back) or fails the XRD shard-name shape,
- an **external source whose row block lacks endpoint/password secret** (rollback couldn't re-render the spec),
- an empty row kind with no status to derive from.

The runner re-checks at `recordSource` (pre-flip, defense in depth for pre-guard/hand-inserted rows): a status type contradicting the op's recorded source kind fails the op before anything flips.

**2. Rollback never emits a patch the XRD would reject** (`controlplane/provisioner/reshard_runner.go`)
If the recorded `from_shard` is empty/invalid (`isValidCnpgShardName`, mirroring the XRD pattern) or the external source block is incomplete, the flip-back / adopt-recovery patch is **skipped** and the warehouse is **deliberately left blocked in `resharding`**, with ERROR-level operator instructions (what to verify, what to patch, unblock only after verifying the real catalog). Rationale: the incident showed a wrong-store unblock is worse than a blocked org — clients activated against an empty catalog. `docs/design/resharding.md`'s "never stranded" invariant now carves this case out, and the runbook documents the manual path.

**3. Takeover-resume sslmode is kind-derived** — the #953 resume path reconstructed endpoints with hardcoded `SSLMode: "disable"`, always wrong for an external side (RDS requires TLS). Endpoint reconstruction now goes through `sslModeFor(kind)` (cnpg pooler → `disable`, external → `require`), shared by `recordSource`, the takeover reconstruction (`takeoverEndpoints`), the flip waits, and the adopt recovery. Audit of every `SSLMode:` site in the provisioner package: the two #953 resume sites were the only hardcoded-wrong ones (currently shielded by the cnpg→cnpg-only resume guard, fixed anyway so relaxing the guard or a drifted row can't reintroduce it); `catalog_backup.go` inherits the recorded source's sslmode; `controller.go`'s provisioning probe was already kind-derived.

**4. Compaction pause cannot let XRD defaulting disable DuckLake** (`controlplane/provisioner/k8s_client.go`)
`SetCompactionEnabled` reads the CR first; when `spec.ducklake` is absent (legacy CR), it pins the org's **effective** enablement into the same merge patch (mirroring the activator's legacy type coupling: explicit `spec.ducklake.enabled` wins, else `status.metadataStore.type != cnpg-shard`), so the XRD default can't flip it. An existing `spec.ducklake` is patched exactly as before. The pinned value is deliberately never removed afterwards: it equals the effective value (harmless no-op), whereas removing it after a successful ext→cnpg flip would hand enablement back to the coupling, which would then re-derive `false` — the same outage through another door.

## Tests

- `admin/reshard_test.go`: `TestReshardStartSourceIdentityValidation` (empty/unresolvable from_shard, both drift directions, the incident shape empty-row+external-status, happy paths incl. status-derived source recording); existing happy paths unchanged.
- `provisioner/reshard_runner_test.go`: rollback with empty `from_shard` → no duckling patch, operator-instruction ERROR, warehouse left in `resharding`, op failed with report; the ext→cnpg sibling (incomplete external source block); `recordSource` status-drift refusal (pre-flip, clean rollback to ready); `takeoverEndpoints` sslmode derivation for all three directions + sslmode asserts on the existing #953 takeover test.
- `provisioner/k8s_client_test.go`: `TestSetCompactionEnabledPinsDuckLakeEnablement` — legacy CR + external status pins `enabled=true` (with the XRD defaulting simulated so the regression is real), legacy CR + cnpg status pins the coupling value, an existing `spec.ducklake` is left untouched, and the restore remove-path pins too.
- e2e harness: the source-identity 400s need a deliberately broken org state that cannot be provoked in-Job without a destructive duckling patch — documented in `reshard_validation` with pointers to the unit coverage; the positive side is asserted on live ops (cancel lane: `source_kind=cnpg-shard` + `from_shard=shard-001` from status; ext→cnpg lane: `source_kind=external` + complete endpoint/secret). `reshard_bogus_shard_rollback` (valid `from_shard`) is unaffected and still asserts warehouse ready after rollback.
- `go build` / `go build -tags kubernetes` / `go vet -tags kubernetes` green; `go test -tags kubernetes ./controlplane/...` green (except pre-existing docker-compose-dependent Postgres container tests unavailable locally).

## Docs

`docs/design/resharding.md` (new "Source identity" section, compaction-pause invariant, rollback guard + never-stranded carve-out, testing), `docs/runbooks/resharding.md` (deliberate blocked shape + manual path), `CLAUDE.md` reshard invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
