### PR TITLE
Forward query logs without control-plane batching

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -585,7 +585,11 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 			"pid", pid, "worker", worker.ID, "user", username, "warning", w)
 	}
 
-	executor := flightclient.NewFlightExecutorFromClient(worker.client, sessionToken)
+	executor := flightclient.NewFlightExecutorFromClientWithQueryLogLimiter(
+		worker.client,
+		sessionToken,
+		worker.workerQueryLogLimiter(),
+	)
 	executor.SetControlMetadata(worker.ID, worker.OwnerCPInstanceID(), worker.OwnerEpoch())
 
 	if pid == 0 {

--- a/controlplane/session_mgr_drain_test.go
+++ b/controlplane/session_mgr_drain_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -718,7 +717,6 @@ func TestDestroyAllSessions_ReleasesAllLeasesAndClearsSessions(t *testing.T) {
 }
 
 func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T) {
-	queryLogForwardersBefore := countFlightExecutorQueryLogForwarders()
 	flightClient := &blockingCreateSessionFlightClient{
 		createStarted:   make(chan struct{}),
 		allowCreate:     make(chan struct{}),
@@ -792,7 +790,6 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 	if got := flightClient.destroyCalls.Load(); got != 1 {
 		t.Fatalf("expected worker session to be destroyed once, got %d", got)
 	}
-	waitForFlightExecutorQueryLogForwardersAtMost(t, queryLogForwardersBefore)
 }
 
 func TestDestroyAllSessionsWaitsForCreateBlockedInLimiterAcquire(t *testing.T) {
@@ -977,24 +974,6 @@ func waitForSessionManagerDraining(t *testing.T, sm *SessionManager) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("timed out waiting for session manager to start draining")
-}
-
-func waitForFlightExecutorQueryLogForwardersAtMost(t *testing.T, want int) {
-	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if got := countFlightExecutorQueryLogForwarders(); got <= want {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("flight executor query-log forwarder count = %d, want <= %d", countFlightExecutorQueryLogForwarders(), want)
-}
-
-func countFlightExecutorQueryLogForwarders() int {
-	buf := make([]byte, 1<<20)
-	n := runtime.Stack(buf, true)
-	return strings.Count(string(buf[:n]), "(*FlightExecutor).queryLogForwardLoop")
 }
 
 func countEvents(events []string, want string) int {

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -26,25 +26,27 @@ import (
 
 // ManagedWorker represents a duckdb-service worker process.
 type ManagedWorker struct {
-	ID             int
-	podName        string
-	nodeName       string        //nolint:unused // only set in kubernetes remote backend; drives cache-locality-aware scheduling
-	image          string        //nolint:unused // only set in kubernetes remote backend; carried through runtime store records
-	profile        WorkerProfile //nolint:unused // only set in kubernetes remote backend; pod-shape this worker was spawned with (zero = default exclusive)
-	cmd            *exec.Cmd
-	socketPath     string
-	bearerToken    string
-	client         *flightsql.Client
-	parentListener net.Listener    // CP-side listener; lifecycle managed by releaseSocket
-	prebound       *preboundSocket // non-nil if using a pre-bound socket slot
-	releaseOnce    sync.Once       // ensures releaseWorkerSocket body runs exactly once
-	done           chan struct{}   // closed when process exits
-	exitErr        error
-	activeSessions int       // Number of sessions currently assigned to this worker
-	lastUsed       time.Time // Last time a session was destroyed on this worker
-	sharedState    SharedWorkerState
-	reservedAt     time.Time //nolint:unused // only set in kubernetes remote backend reservation path
-	peakSessions   int       // High-water mark of concurrent sessions (for retirement metrics)
+	ID                  int
+	podName             string
+	nodeName            string        //nolint:unused // only set in kubernetes remote backend; drives cache-locality-aware scheduling
+	image               string        //nolint:unused // only set in kubernetes remote backend; carried through runtime store records
+	profile             WorkerProfile //nolint:unused // only set in kubernetes remote backend; pod-shape this worker was spawned with (zero = default exclusive)
+	cmd                 *exec.Cmd
+	socketPath          string
+	bearerToken         string
+	client              *flightsql.Client
+	queryLogLimiterOnce sync.Once
+	queryLogLimiter     *flightclient.QueryLogLimiter
+	parentListener      net.Listener    // CP-side listener; lifecycle managed by releaseSocket
+	prebound            *preboundSocket // non-nil if using a pre-bound socket slot
+	releaseOnce         sync.Once       // ensures releaseWorkerSocket body runs exactly once
+	done                chan struct{}   // closed when process exits
+	exitErr             error
+	activeSessions      int       // Number of sessions currently assigned to this worker
+	lastUsed            time.Time // Last time a session was destroyed on this worker
+	sharedState         SharedWorkerState
+	reservedAt          time.Time //nolint:unused // only set in kubernetes remote backend reservation path
+	peakSessions        int       // High-water mark of concurrent sessions (for retirement metrics)
 	// ownerEpoch is guarded by epochMu so cred-refresh's
 	// "RefreshLease then SetOwnerEpoch" sequence appears atomic to
 	// concurrent readers (notably ShutdownAll's lease minting).
@@ -56,6 +58,13 @@ type ManagedWorker struct {
 	ownerCPInstanceID       string
 	hotIdleReclaimed        bool //nolint:unused // only set in kubernetes hot-idle reclaim path
 	cachedActivationPayload any  //nolint:unused // *TenantActivationPayload, cached in kubernetes activation path
+}
+
+func (w *ManagedWorker) workerQueryLogLimiter() *flightclient.QueryLogLimiter {
+	w.queryLogLimiterOnce.Do(func() {
+		w.queryLogLimiter = flightclient.NewQueryLogLimiter()
+	})
+	return w.queryLogLimiter
 }
 
 // Profile returns the pod-shape profile this worker was spawned with (zero =

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -42,13 +42,47 @@ const (
 	logQueryAction           = "LogQuery"
 	queryCloseWaitTimeout    = 30 * time.Second
 	queryLogForwardTimeout   = 5 * time.Second
-	queryLogForwardBatchSize = 100
-	queryLogForwardInterval  = 1 * time.Second
-	queryLogForwardQueueSize = 10000
+	queryLogMaxInFlight      = 64
 )
 
 // ErrWorkerDead is returned when the backing worker process has crashed.
 var ErrWorkerDead = errors.New("flight worker is dead")
+
+// QueryLogLimiter bounds concurrent control-plane query-log RPCs for one
+// worker. It holds no entries itself; sessions sharing a worker share the
+// same limiter so a stalled endpoint cannot accumulate unbounded goroutines.
+type QueryLogLimiter struct {
+	limit    int64
+	inFlight atomic.Int64
+}
+
+// NewQueryLogLimiter creates a limiter with the production per-worker limit.
+func NewQueryLogLimiter() *QueryLogLimiter {
+	return newQueryLogLimiter(queryLogMaxInFlight)
+}
+
+func newQueryLogLimiter(limit int64) *QueryLogLimiter {
+	if limit <= 0 {
+		limit = 1
+	}
+	return &QueryLogLimiter{limit: limit}
+}
+
+func (l *QueryLogLimiter) tryAcquire() bool {
+	for {
+		current := l.inFlight.Load()
+		if current >= l.limit {
+			return false
+		}
+		if l.inFlight.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func (l *QueryLogLimiter) release() {
+	l.inFlight.Add(-1)
+}
 
 // FlightExecutor implements QueryExecutor backed by an Arrow Flight SQL client.
 // It routes queries to a duckdb-service worker process over a Unix socket.
@@ -72,9 +106,11 @@ type FlightExecutor struct {
 	// from the worker via gRPC trailing metadata.
 	lastProfiling atomic.Value // stores string
 
-	queryLogCh       chan wire.QueryLogEntry
-	queryLogDone     chan struct{}
+	queryLogMu       sync.Mutex
+	queryLogClosed   bool
+	queryLogWG       sync.WaitGroup
 	queryLogStopOnce sync.Once
+	queryLogLimiter  *QueryLogLimiter
 }
 
 // NewFlightExecutor creates a FlightExecutor connected to the given address.
@@ -104,15 +140,15 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 
 	ctx, cancel := context.WithCancel(context.Background())
 	e := &FlightExecutor{
-		client:       client,
-		sessionToken: sessionToken,
-		ownerEpoch:   0,
-		alloc:        memory.DefaultAllocator,
-		ownsClient:   true,
-		ctx:          ctx,
-		cancel:       cancel,
+		client:          client,
+		sessionToken:    sessionToken,
+		ownerEpoch:      0,
+		alloc:           memory.DefaultAllocator,
+		ownsClient:      true,
+		ctx:             ctx,
+		cancel:          cancel,
+		queryLogLimiter: NewQueryLogLimiter(),
 	}
-	e.startQueryLogForwarder()
 	return e, nil
 }
 
@@ -120,17 +156,26 @@ func NewFlightExecutor(addr, bearerToken, sessionToken string) (*FlightExecutor,
 // Flight SQL client. The client is NOT closed when this executor is closed.
 // This avoids creating a new gRPC connection per session.
 func NewFlightExecutorFromClient(client *flightsql.Client, sessionToken string) *FlightExecutor {
+	return NewFlightExecutorFromClientWithQueryLogLimiter(client, sessionToken, nil)
+}
+
+// NewFlightExecutorFromClientWithQueryLogLimiter creates a per-session
+// executor whose asynchronous query-log calls share a worker-wide limiter.
+func NewFlightExecutorFromClientWithQueryLogLimiter(client *flightsql.Client, sessionToken string, limiter *QueryLogLimiter) *FlightExecutor {
+	if limiter == nil {
+		limiter = NewQueryLogLimiter()
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	e := &FlightExecutor{
-		client:       client,
-		sessionToken: sessionToken,
-		ownerEpoch:   0,
-		alloc:        memory.DefaultAllocator,
-		ownsClient:   false,
-		ctx:          ctx,
-		cancel:       cancel,
+		client:          client,
+		sessionToken:    sessionToken,
+		ownerEpoch:      0,
+		alloc:           memory.DefaultAllocator,
+		ownsClient:      false,
+		ctx:             ctx,
+		cancel:          cancel,
+		queryLogLimiter: limiter,
 	}
-	e.startQueryLogForwarder()
 	return e
 }
 
@@ -339,9 +384,10 @@ func (e *FlightExecutor) mergedContext(ctx context.Context) (context.Context, co
 }
 
 func (e *FlightExecutor) Close() error {
-	if !e.stopQueryLogForwarder() && e.cancel != nil {
+	e.stopQueryLogForwarding()
+	if !e.waitQueryLogForwarding() && e.cancel != nil {
 		e.cancel()
-		e.waitQueryLogForwarder()
+		e.queryLogWG.Wait()
 	}
 	if e.cancel != nil {
 		e.cancel()
@@ -362,102 +408,84 @@ func (e *FlightExecutor) Log(entry wire.QueryLogEntry) {
 		observe.AddQueryLogDroppedEntries("forward_worker_dead", 1)
 		return
 	}
-	if e.queryLogCh == nil {
+
+	e.queryLogMu.Lock()
+	if e.queryLogClosed {
+		e.queryLogMu.Unlock()
+		observe.AddQueryLogDroppedEntries("forward_closed", 1)
+		return
+	}
+	if e.dead.Load() {
+		e.queryLogMu.Unlock()
+		observe.AddQueryLogDroppedEntries("forward_worker_dead", 1)
+		return
+	}
+	if e.client == nil || e.client.Client == nil {
+		e.queryLogMu.Unlock()
 		observe.AddQueryLogDroppedEntries("forward_unavailable", 1)
 		return
 	}
-	defer func() {
-		if recover() != nil {
-			observe.AddQueryLogDroppedEntries("forward_closed", 1)
-		}
+	limiter := e.queryLogLimiter
+	if limiter == nil {
+		limiter = NewQueryLogLimiter()
+		e.queryLogLimiter = limiter
+	}
+	if !limiter.tryAcquire() {
+		e.queryLogMu.Unlock()
+		observe.AddQueryLogDroppedEntries("forward_in_flight_limit", 1)
+		return
+	}
+	baseCtx := context.Background()
+	if e.ctx != nil {
+		baseCtx = e.ctx
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, queryLogForwardTimeout)
+	e.queryLogWG.Add(1)
+	e.queryLogMu.Unlock()
+
+	go func() {
+		defer e.queryLogWG.Done()
+		defer limiter.release()
+		defer cancel()
+		_ = e.forwardQueryLogEntry(ctx, entry)
+	}()
+}
+
+func (e *FlightExecutor) stopQueryLogForwarding() {
+	e.queryLogStopOnce.Do(func() {
+		e.queryLogMu.Lock()
+		e.queryLogClosed = true
+		e.queryLogMu.Unlock()
+	})
+}
+
+func (e *FlightExecutor) waitQueryLogForwarding() bool {
+	done := make(chan struct{})
+	go func() {
+		e.queryLogWG.Wait()
+		close(done)
 	}()
 	select {
-	case e.queryLogCh <- entry:
-	default:
-		observe.AddQueryLogDroppedEntries("forward_buffer_full", 1)
-	}
-}
-
-func (e *FlightExecutor) startQueryLogForwarder() {
-	e.queryLogCh = make(chan wire.QueryLogEntry, queryLogForwardQueueSize)
-	e.queryLogDone = make(chan struct{})
-	go e.queryLogForwardLoop()
-}
-
-func (e *FlightExecutor) stopQueryLogForwarder() bool {
-	stopped := true
-	e.queryLogStopOnce.Do(func() {
-		if e.queryLogCh != nil {
-			close(e.queryLogCh)
-		}
-		stopped = e.waitQueryLogForwarder()
-	})
-	return stopped
-}
-
-func (e *FlightExecutor) waitQueryLogForwarder() bool {
-	if e.queryLogDone == nil {
-		return true
-	}
-	select {
-	case <-e.queryLogDone:
+	case <-done:
 		return true
 	case <-time.After(queryLogForwardTimeout):
 		return false
 	}
 }
 
-func (e *FlightExecutor) queryLogForwardLoop() {
-	defer close(e.queryLogDone)
-	ticker := time.NewTicker(queryLogForwardInterval)
-	defer ticker.Stop()
-
-	batch := make([]wire.QueryLogEntry, 0, queryLogForwardBatchSize)
-	flush := func() {
-		if len(batch) == 0 {
-			return
-		}
-		// forwardQueryLogBatch records dropped-entry metrics for failed batches.
-		_ = e.forwardQueryLogBatch(batch)
-		batch = batch[:0]
-	}
-
-	for {
-		select {
-		case entry, ok := <-e.queryLogCh:
-			if !ok {
-				flush()
-				return
-			}
-			batch = append(batch, entry)
-			if len(batch) >= queryLogForwardBatchSize {
-				flush()
-			}
-		case <-ticker.C:
-			flush()
-		case <-e.ctx.Done():
-			observe.AddQueryLogDroppedEntries("forward_context_done", len(batch)+len(e.queryLogCh))
-			return
-		}
-	}
-}
-
-func (e *FlightExecutor) forwardQueryLogBatch(entries []wire.QueryLogEntry) (err error) {
-	if len(entries) == 0 {
-		return nil
-	}
+func (e *FlightExecutor) forwardQueryLogEntry(ctx context.Context, entry wire.QueryLogEntry) (err error) {
 	if e.dead.Load() {
-		observe.AddQueryLogDroppedEntries("forward_worker_dead", len(entries))
+		observe.AddQueryLogDroppedEntries("forward_worker_dead", 1)
 		return nil
 	}
 	if e.client == nil || e.client.Client == nil {
-		observe.AddQueryLogDroppedEntries("forward_unavailable", len(entries))
+		observe.AddQueryLogDroppedEntries("forward_unavailable", 1)
 		return nil
 	}
 	defer func() {
 		recoverClientPanic(&err)
 		if err != nil {
-			observe.AddQueryLogDroppedEntries("forward_error", len(entries))
+			observe.AddQueryLogDroppedEntries("forward_error", 1)
 		}
 	}()
 
@@ -467,18 +495,12 @@ func (e *FlightExecutor) forwardQueryLogBatch(entries []wire.QueryLogEntry) (err
 			OwnerEpoch:   e.ownerEpoch,
 			CPInstanceID: e.cpInstanceID,
 		},
-		Entries: entries,
+		Entries: []wire.QueryLogEntry{entry},
 	})
 	if err != nil {
 		return err
 	}
 
-	baseCtx := context.Background()
-	if e.ctx != nil {
-		baseCtx = e.ctx
-	}
-	ctx, cancel := context.WithTimeout(baseCtx, queryLogForwardTimeout)
-	defer cancel()
 	stream, err := e.client.Client.DoAction(
 		e.withSession(ctx),
 		&flight.Action{Type: logQueryAction, Body: payload},

--- a/server/flightclient/flight_executor_test.go
+++ b/server/flightclient/flight_executor_test.go
@@ -62,9 +62,8 @@ type closeWaitFlightServer struct {
 	releaseActionCalled   chan struct{}
 	releaseActionOnce     sync.Once
 	releaseTicket         []byte
-	logQueryCalled        chan struct{}
-	logQueryOnce          sync.Once
-	logQueryPayload       wire.WorkerQueryLogPayload
+	logQueryPayloads      chan wire.WorkerQueryLogPayload
+	blockLogQuery         <-chan struct{}
 	waitBeforeDoGetCancel chan struct{}
 	waitBeforeOnce        sync.Once
 	closeAfterFirstBatch  bool
@@ -82,7 +81,7 @@ func newCloseWaitFlightServer() *closeWaitFlightServer {
 		doGetDone:            make(chan struct{}),
 		doActionCalled:       make(chan struct{}),
 		releaseActionCalled:  make(chan struct{}),
-		logQueryCalled:       make(chan struct{}),
+		logQueryPayloads:     make(chan wire.WorkerQueryLogPayload, 100),
 	}
 }
 
@@ -148,11 +147,21 @@ func (s *closeWaitFlightServer) DoAction(action *flight.Action, stream pb.Flight
 		s.releaseTicket = payload.Ticket
 		return stream.Send(&flight.Result{Body: []byte(`{"ok":true}`)})
 	case logQueryAction:
-		s.logQueryOnce.Do(func() {
-			close(s.logQueryCalled)
-		})
-		if err := json.Unmarshal(action.Body, &s.logQueryPayload); err != nil {
+		var payload wire.WorkerQueryLogPayload
+		if err := json.Unmarshal(action.Body, &payload); err != nil {
 			return err
+		}
+		select {
+		case s.logQueryPayloads <- payload:
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		}
+		if s.blockLogQuery != nil {
+			select {
+			case <-s.blockLogQuery:
+			case <-stream.Context().Done():
+				return stream.Context().Err()
+			}
 		}
 		return stream.Send(&flight.Result{Body: []byte(`{"ok":true}`)})
 	case waitSessionIdleAction:
@@ -210,45 +219,182 @@ func newCloseWaitExecutor(t *testing.T, srv *closeWaitFlightServer) (*FlightExec
 	return exec, ctx
 }
 
-func TestFlightExecutorLogForwardsQueryLogBatch(t *testing.T) {
+func TestFlightExecutorLogForwardsEachEntryAsSingletonAction(t *testing.T) {
 	srv := newCloseWaitFlightServer()
 	exec, _ := newCloseWaitExecutor(t, srv)
 	exec.SetControlMetadata(17, "cp-live:boot-a", 7)
 
-	exec.Log(wire.QueryLogEntry{
+	entries := []wire.QueryLogEntry{{
 		Query:                 "SELECT 1",
 		UserName:              "alice",
 		OrgID:                 "analytics",
 		CPUTimeSeconds:        1.5,
 		PeakBufferMemoryBytes: 2048,
-	})
+	}, {
+		Query:                 "SELECT 2",
+		UserName:              "bob",
+		OrgID:                 "analytics",
+		CPUTimeSeconds:        2.5,
+		PeakBufferMemoryBytes: 4096,
+	}}
+	for _, entry := range entries {
+		exec.Log(entry)
+	}
 	if err := exec.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
+	gotEntries := make(map[string]wire.QueryLogEntry, len(entries))
+	for range entries {
+		select {
+		case payload := <-srv.logQueryPayloads:
+			if got := payload.WorkerID; got != 17 {
+				t.Fatalf("worker_id = %d, want 17", got)
+			}
+			if got := payload.OwnerEpoch; got != 7 {
+				t.Fatalf("owner_epoch = %d, want 7", got)
+			}
+			if got := payload.CPInstanceID; got != "cp-live:boot-a" {
+				t.Fatalf("cp_instance_id = %q, want cp-live:boot-a", got)
+			}
+			if len(payload.Entries) != 1 {
+				t.Fatalf("entries = %d, want 1", len(payload.Entries))
+			}
+			entry := payload.Entries[0]
+			gotEntries[entry.Query] = entry
+		case <-time.After(time.Second):
+			t.Fatal("LogQuery action was not sent")
+		}
+	}
+	for _, want := range entries {
+		got, ok := gotEntries[want.Query]
+		if !ok {
+			t.Fatalf("query %q was not forwarded", want.Query)
+		}
+		if got.UserName != want.UserName || got.OrgID != want.OrgID ||
+			got.CPUTimeSeconds != want.CPUTimeSeconds || got.PeakBufferMemoryBytes != want.PeakBufferMemoryBytes {
+			t.Fatalf("forwarded entry = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestFlightExecutorLogAllowsConcurrentInFlightActions(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseLogs := func() { releaseOnce.Do(func() { close(release) }) }
+
+	srv := newCloseWaitFlightServer()
+	srv.blockLogQuery = release
+	exec, _ := newCloseWaitExecutor(t, srv)
+	// Registered after the executor cleanup so blocked handlers are released
+	// before Close waits for the query-log calls to finish.
+	t.Cleanup(releaseLogs)
+
+	logQueryWithoutBlocking(t, exec, wire.QueryLogEntry{Query: "SELECT 1"})
+	first := receiveQueryLogPayload(t, srv.logQueryPayloads, 2*time.Second)
+	if len(first.Entries) != 1 || first.Entries[0].Query != "SELECT 1" {
+		t.Fatalf("first payload = %#v, want singleton SELECT 1", first)
+	}
+
+	logQueryWithoutBlocking(t, exec, wire.QueryLogEntry{Query: "SELECT 2"})
+	second := receiveQueryLogPayload(t, srv.logQueryPayloads, 250*time.Millisecond)
+	if len(second.Entries) != 1 || second.Entries[0].Query != "SELECT 2" {
+		t.Fatalf("second payload = %#v, want singleton SELECT 2", second)
+	}
+
+	releaseLogs()
+}
+
+func TestFlightExecutorLogLimitsStalledActionsAcrossWorkerSessions(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseLogs := func() { releaseOnce.Do(func() { close(release) }) }
+
+	srv := newCloseWaitFlightServer()
+	srv.blockLogQuery = release
+	exec1, _ := newCloseWaitExecutor(t, srv)
+	exec2 := NewFlightExecutorFromClient(exec1.client, "session-2")
+	t.Cleanup(func() { _ = exec2.Close() })
+	t.Cleanup(releaseLogs)
+
+	limiter := newQueryLogLimiter(2)
+	exec1.queryLogLimiter = limiter
+	exec2.queryLogLimiter = limiter
+
+	logQueryWithoutBlocking(t, exec1, wire.QueryLogEntry{Query: "SELECT 1"})
+	receiveQueryLogPayload(t, srv.logQueryPayloads, time.Second)
+	logQueryWithoutBlocking(t, exec2, wire.QueryLogEntry{Query: "SELECT 2"})
+	receiveQueryLogPayload(t, srv.logQueryPayloads, time.Second)
+
+	logQueryWithoutBlocking(t, exec1, wire.QueryLogEntry{Query: "SELECT 3"})
 	select {
-	case <-srv.logQueryCalled:
+	case payload := <-srv.logQueryPayloads:
+		t.Fatalf("LogQuery action started after the shared worker limit was reached: %#v", payload)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseLogs()
+}
+
+func TestFlightExecutorCloseWaitsForInFlightQueryLogAction(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseLog := func() { releaseOnce.Do(func() { close(release) }) }
+
+	srv := newCloseWaitFlightServer()
+	srv.blockLogQuery = release
+	exec, _ := newCloseWaitExecutor(t, srv)
+	// Registered after the executor cleanup so a failed assertion cannot leave
+	// Close blocked behind the test server.
+	t.Cleanup(releaseLog)
+
+	exec.Log(wire.QueryLogEntry{Query: "SELECT 1"})
+	receiveQueryLogPayload(t, srv.logQueryPayloads, time.Second)
+
+	closeReturned := make(chan error, 1)
+	go func() {
+		closeReturned <- exec.Close()
+	}()
+
+	select {
+	case err := <-closeReturned:
+		t.Fatalf("Close returned before the in-flight LogQuery action: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseLog()
+	select {
+	case err := <-closeReturned:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
 	case <-time.After(time.Second):
-		t.Fatal("LogQuery action was not sent")
+		t.Fatal("Close did not return after the LogQuery action completed")
 	}
-	if got := srv.logQueryPayload.WorkerID; got != 17 {
-		t.Fatalf("worker_id = %d, want 17", got)
+}
+
+func receiveQueryLogPayload(t *testing.T, payloads <-chan wire.WorkerQueryLogPayload, timeout time.Duration) wire.WorkerQueryLogPayload {
+	t.Helper()
+	select {
+	case payload := <-payloads:
+		return payload
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for LogQuery action")
+		return wire.WorkerQueryLogPayload{}
 	}
-	if got := srv.logQueryPayload.OwnerEpoch; got != 7 {
-		t.Fatalf("owner_epoch = %d, want 7", got)
-	}
-	if got := srv.logQueryPayload.CPInstanceID; got != "cp-live:boot-a" {
-		t.Fatalf("cp_instance_id = %q, want cp-live:boot-a", got)
-	}
-	if len(srv.logQueryPayload.Entries) != 1 {
-		t.Fatalf("entries = %d, want 1", len(srv.logQueryPayload.Entries))
-	}
-	entry := srv.logQueryPayload.Entries[0]
-	if entry.Query != "SELECT 1" || entry.UserName != "alice" || entry.OrgID != "analytics" {
-		t.Fatalf("unexpected forwarded entry: %#v", entry)
-	}
-	if entry.CPUTimeSeconds != 1.5 || entry.PeakBufferMemoryBytes != 2048 {
-		t.Fatalf("resource fields not forwarded: %#v", entry)
+}
+
+func logQueryWithoutBlocking(t *testing.T, exec *FlightExecutor, entry wire.QueryLogEntry) {
+	t.Helper()
+	returned := make(chan struct{})
+	go func() {
+		exec.Log(entry)
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Log blocked on the worker LogQuery action")
 	}
 }
 


### PR DESCRIPTION
## Summary

- remove the control plane's per-session 10,000-entry query-log queue, timer, and transport batching
- forward every completed bounded entry immediately as its own asynchronous `LogQuery` action
- share a non-buffering 64-call concurrency limiter across sessions on the same worker, with the existing five-second deadline starting before goroutine scheduling
- keep worker-side durable batching and best-effort/no-retry behavior unchanged

## Why

The worker already batches query-log writes to Postgres. The additional control-plane queue eagerly allocated a large backing array for every session and retained query-log payloads while waiting for a batch. Removing that duplicate buffering reduces control-plane memory without adding logging latency to user queries.

Independent asynchronous actions may overlap on the shared Flight connection. The worker-scoped limiter bounds memory during a stalled endpoint without dropping ordinary overlap; saturation is reported through the existing dropped-entry metric.

## Validation

- `just lint`
- `just test-unit`
- `just test-controlplane`
- focused query-log tests under Go's race detector
- `just test-impact-plan origin/main HEAD`

The new tests cover singleton actions, non-blocking calls, concurrent in-flight actions, worker-wide saturation across sessions, and shutdown waiting for admitted calls.
