### PR TITLE
reshard: wait for rollback source convergence

### DIFF
--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -1404,6 +1404,8 @@ func (o *opRun) rollback(ctx context.Context) {
 			if err := o.r.duckling.SetMetadataStoreCnpg(ctx, o.op.DucklingName, o.op.FromShard); err != nil {
 				o.logf("error", "rollback flip failed: %v — duckling still points at %s; fix manually", err, o.op.ToShard)
 				recovered = false
+			} else if !o.waitForRollbackSourceConvergence(ctx) {
+				recovered = false
 			}
 			o.dropPartialTarget(ctx)
 		case o.op.TargetKind == configstore.MetadataStoreKindCnpgShard && o.op.SourceKind == configstore.MetadataStoreKindExternal:
@@ -1425,6 +1427,8 @@ func (o *opRun) rollback(ctx context.Context) {
 				Database:          o.op.SourceDatabase,
 			}); err != nil {
 				o.logf("error", "rollback flip failed: %v — duckling still points at cnpg %s; fix manually", err, o.op.ToShard)
+				recovered = false
+			} else if !o.waitForRollbackSourceConvergence(ctx) {
 				recovered = false
 			}
 			o.dropPartialTarget(ctx)
@@ -1453,7 +1457,14 @@ func (o *opRun) rollback(ctx context.Context) {
 		}
 	}
 
-	o.restoreCompaction(ctx)
+	if recovered {
+		o.restoreCompaction(ctx)
+	} else if o.compactionPaused {
+		// The Duckling may still route independent compaction work to the
+		// failed target. Keep the source quiescent until an operator repairs
+		// the composition/catalog and has separately verified recovery.
+		o.logf("error", "leaving compaction paused because rollback source recovery did not converge; do not re-enable it until Duckling identifies the source and a tenant probe succeeds")
+	}
 
 	if o.blocked && recovered {
 		if err := o.r.store.UpdateWarehouseState(o.op.OrgID, configstore.ManagedWarehouseStateResharding, map[string]interface{}{
@@ -1484,6 +1495,130 @@ func (o *opRun) dropPartialTarget(ctx context.Context) {
 	}
 }
 
+// waitForRollbackSourceConvergence is the common safety gate after every
+// successful rollback metadata-store patch. A Kubernetes PATCH acknowledgement
+// only proves that the desired spec was accepted; it does not prove that the
+// Duckling composition/status or the worker activation configuration have
+// stopped referring to the failed target. Do not readmit traffic until the
+// live status identifies the recorded source, reports Ready=True, and its
+// tenant role answers a fresh probe.
+//
+// rollback deliberately passes a context.WithoutCancel context here: once a
+// cutover needs recovery, a user cancellation must not bypass recovery and
+// expose the failed target. The per-operation cutover timeout remains the hard
+// bound, including each Get/Probe attempt, so an unavailable source cannot
+// leave a runner waiting forever.
+func (o *opRun) waitForRollbackSourceConvergence(ctx context.Context) bool {
+	want := describeSource(o.op)
+	o.logf("info", "recovery: waiting up to %s for Duckling status to identify the recorded source metadata store (%s), become Ready, and for the tenant role to answer", o.flipTimeout(), want)
+
+	deadline := time.Now().Add(o.flipTimeout())
+	lastLog := time.Time{}
+	lastObserved := "no successful Duckling status read yet"
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			o.logf("error", "recovery: source metadata store did not converge within %s — org stays blocked; investigate the Duckling spec/status and source catalog; last observation: %s", o.flipTimeout(), lastObserved)
+			return false
+		}
+
+		// Bound reads and probes by the remaining recovery window. The parent
+		// context is intentionally cancellation-free (see above), not
+		// unbounded.
+		attemptCtx, cancel := context.WithTimeout(ctx, remaining)
+		st, err := o.r.duckling.Get(attemptCtx, o.op.DucklingName)
+		switch {
+		case err != nil:
+			lastObserved = fmt.Sprintf("reading Duckling failed: %v", err)
+		case st == nil:
+			lastObserved = "Duckling returned an empty status"
+		default:
+			if observation, matches := o.rollbackSourceStatusMatches(st); !matches {
+				lastObserved = observation
+			} else {
+				restored := CatalogEndpoint{
+					Host: st.MetadataStore.Endpoint, Port: 5432,
+					User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
+					SSLMode: sslModeFor(o.op.SourceKind),
+				}
+				if probeErr := o.r.copier.Probe(attemptCtx, restored); probeErr != nil {
+					lastObserved = "Duckling identifies the recorded source " + st.MetadataStore.Endpoint + " (Ready), " + describeProbeFailure(probeErr, st.MetadataStore.User)
+				} else {
+					cancel()
+					o.source = restored
+					o.logf("info", "recovery complete: Duckling status identifies the recorded source %s (Ready) and the tenant role answers", st.MetadataStore.Endpoint)
+					return true
+				}
+			}
+		}
+		cancel()
+
+		if time.Since(lastLog) >= o.r.progressLogInterval {
+			o.logf("info", "recovery: waiting for recorded source metadata store: %s", lastObserved)
+			lastLog = time.Now()
+		}
+		if sleep := minDuration(o.r.loopPoll, time.Until(deadline)); sleep > 0 {
+			time.Sleep(sleep)
+		}
+	}
+}
+
+// rollbackSourceStatusMatches reports whether Duckling's live status names
+// the source recorded before the cutover, and is ready to supply tenant
+// credentials for a probe. The exact endpoint is durable for all new ops. The
+// cnpg shard-prefix fallback only supports legacy rows that predate durable
+// source_endpoint recording; an external source without an endpoint can never
+// be proven safe and remains blocked.
+func (o *opRun) rollbackSourceStatusMatches(st *DucklingStatus) (string, bool) {
+	ms := st.MetadataStore
+	if ms.Type != o.op.SourceKind {
+		return fmt.Sprintf("duckling type %q, endpoint %q, ready=%t (waiting for recorded source type %q)", ms.Type, ms.Endpoint, st.ReadyCondition, o.op.SourceKind), false
+	}
+
+	expectedEndpoint := o.op.SourceEndpoint
+	if expectedEndpoint == "" {
+		expectedEndpoint = o.source.Host
+	}
+	switch {
+	case expectedEndpoint != "" && ms.Endpoint != expectedEndpoint:
+		return fmt.Sprintf("duckling endpoint %q, ready=%t (waiting for recorded source endpoint %q)", ms.Endpoint, st.ReadyCondition, expectedEndpoint), false
+	case expectedEndpoint == "" && o.op.SourceKind == configstore.MetadataStoreKindCnpgShard && isValidCnpgShardName(o.op.FromShard):
+		prefix := o.op.FromShard + "-pooler."
+		if !strings.HasPrefix(ms.Endpoint, prefix) {
+			return fmt.Sprintf("duckling endpoint %q, ready=%t (waiting for recorded source shard %s*)", ms.Endpoint, st.ReadyCondition, prefix), false
+		}
+	case expectedEndpoint == "":
+		return fmt.Sprintf("recorded source endpoint is empty for source type %q; cannot prove Duckling status endpoint %q is the source", o.op.SourceKind, ms.Endpoint), false
+	}
+	if o.op.SourceUser != "" && ms.User != o.op.SourceUser {
+		return fmt.Sprintf("Duckling source user %q, ready=%t (waiting for recorded source user %q)", ms.User, st.ReadyCondition, o.op.SourceUser), false
+	}
+	if o.op.SourceDatabase != "" && ms.Database != o.op.SourceDatabase {
+		return fmt.Sprintf("Duckling source database %q, ready=%t (waiting for recorded source database %q)", ms.Database, st.ReadyCondition, o.op.SourceDatabase), false
+	}
+	if !st.ReadyCondition {
+		observation := fmt.Sprintf("Duckling identifies recorded source %q but Ready=False", ms.Endpoint)
+		if st.SyncedFalseMessage != "" {
+			observation += "; Duckling Synced=False: " + st.SyncedFalseMessage
+		}
+		if st.ReadyFalseMessage != "" {
+			observation += "; Duckling Ready=False: " + st.ReadyFalseMessage
+		}
+		return observation, false
+	}
+	if ms.User == "" || ms.Database == "" || ms.Password == "" {
+		return fmt.Sprintf("Duckling identifies recorded source %q (Ready) but tenant credentials are incomplete (user set=%t database set=%t password set=%t)", ms.Endpoint, ms.User != "", ms.Database != "", ms.Password != ""), false
+	}
+	return "", true
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // recoverFromExternal handles the cnpg→ext post-flip rollback: the external
 // target never became Ready, or the external-catalog verify failed. Because the
 // orphan step retained the cnpg source, the role/DB are STILL PRESENT on the
@@ -1506,57 +1641,7 @@ func (o *opRun) recoverFromExternal(ctx context.Context) bool {
 		return false
 	}
 
-	// Wait for the composition to re-adopt the role/DB on the source shard and
-	// the tenant role to answer again. NEVER silently: this loop logs what it
-	// observes every progressLogInterval — a recovery that spins on a failing
-	// probe (e.g. SASL auth failures from a stranded re-adopted-role password,
-	// the mw-dev incident) must be diagnosable from the op log alone, and the
-	// terminal timeout line must carry the last observation (the root cause).
-	// An auth probe failure is effectively permanent, but we still poll to the
-	// deadline rather than bail: a charts/composition fix can converge the
-	// password mid-wait, and giving up early would leave the org worse off.
-	sourcePrefix := o.op.FromShard + "-pooler."
-	o.logf("info", "recovery: waiting up to %s for the composition to re-adopt the cnpg role/DB on %s* and for the tenant role to answer", o.flipTimeout(), sourcePrefix)
-	deadline := time.Now().Add(o.flipTimeout())
-	lastLog := time.Time{}
-	lastObserved := "no successful duckling read yet"
-	for {
-		if time.Now().After(deadline) {
-			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", o.flipTimeout(), o.op.FromShard, lastObserved)
-			return false
-		}
-		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
-		switch {
-		case err != nil:
-			lastObserved = fmt.Sprintf("reading duckling failed: %v", err)
-		case !strings.HasPrefix(st.MetadataStore.Endpoint, sourcePrefix) || !st.ReadyCondition:
-			lastObserved = fmt.Sprintf("duckling endpoint %q, ready=%t (waiting for %s*)", st.MetadataStore.Endpoint, st.ReadyCondition, sourcePrefix)
-			if st.SyncedFalseMessage != "" {
-				lastObserved += "; duckling Synced=False: " + st.SyncedFalseMessage
-			}
-		default:
-			restored := CatalogEndpoint{
-				Host: st.MetadataStore.Endpoint, Port: 5432,
-				User: st.MetadataStore.User, Password: st.MetadataStore.Password, Database: st.MetadataStore.Database,
-				// The flip-back re-adopts the cnpg source (this recovery only
-				// runs for cnpg→ext ops), so the probe goes via the pooler.
-				SSLMode: sslModeFor(o.op.SourceKind),
-			}
-			probeErr := o.r.copier.Probe(ctx, restored)
-			if probeErr == nil {
-				o.logf("info", "recovery complete: duckling re-adopted the orphaned cnpg role/DB on %s and the tenant role answers — no data was copied back (the catalog never left the source)", o.op.FromShard)
-				return true
-			}
-			// describeProbeFailure names an auth failure explicitly (stranded
-			// re-adopted-role password) with the manual ALTER ROLE remedy.
-			lastObserved = "duckling converged on " + st.MetadataStore.Endpoint + " (Ready), " + describeProbeFailure(probeErr, st.MetadataStore.User)
-		}
-		if time.Since(lastLog) >= o.r.progressLogInterval {
-			o.logf("info", "recovery: waiting for the source shard: %s", lastObserved)
-			lastLog = time.Now()
-		}
-		time.Sleep(o.r.loopPoll)
-	}
+	return o.waitForRollbackSourceConvergence(ctx)
 }
 
 // report writes the end-of-op report to the log — also on failure/cancel.

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -839,6 +839,176 @@ func TestReshardFlipTimeoutRollsBackShardValue(t *testing.T) {
 	}
 }
 
+// rollbackPatchPendingDuckling accepts the forward and rollback spec patches,
+// but holds status at the target after the rollback patch. This models the
+// asynchronous Duckling composition window that can otherwise admit a worker
+// against the failed target immediately after rollback.
+type rollbackPatchPendingDuckling struct {
+	*fakeDuckling
+}
+
+func (s *rollbackPatchPendingDuckling) SetMetadataStoreCnpg(ctx context.Context, name, shard string) error {
+	if shard != "shard-001" {
+		return s.fakeDuckling.SetMetadataStoreCnpg(ctx, name, shard)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, ducklingCall{kind: "cnpg", shard: shard})
+	return nil // Spec patch accepted, but status still identifies shard-002.
+}
+
+// TestReshardRollbackWaitsForDucklingStatusBeforeUnblocking pins the safety
+// boundary exposed by the bogus-shard e2e: a successful rollback PATCH alone
+// is not recovery. Until Duckling status reports the recorded source as Ready
+// (and its tenant catalog can be probed), traffic must remain blocked.
+func TestReshardRollbackWaitsForDucklingStatusBeforeUnblocking(t *testing.T) {
+	store := newFakeReshardStore(cnpgOp())
+	duckling := &rollbackPatchPendingDuckling{fakeDuckling: &fakeDuckling{status: cnpgSourceStatus()}}
+	copier := &fakeCopier{copyErr: errors.New("copy failed after cutover")}
+	r := testRunner(store, duckling, copier)
+	r.flipTimeout = 50 * time.Millisecond
+
+	runOp(t, r, store)
+
+	if store.op.State != configstore.ReshardStateFailed {
+		t.Fatalf("state = %s, want failed", store.op.State)
+	}
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding while rollback status remains on the target", store.warehouseState)
+	}
+	if store.op.UnblockedAt != nil {
+		t.Fatalf("unblocked_at = %v, want nil before Duckling reports the source ready", store.op.UnblockedAt)
+	}
+	if !store.hasLog("recovery: waiting up to") {
+		t.Fatalf("recovery wait announcement missing: %v", store.logs)
+	}
+	terminal := store.findLog("recovery: source metadata store did not converge within")
+	if terminal == "" || !strings.Contains(terminal, "shard-002-pooler") {
+		t.Fatalf("recovery terminal diagnostic = %q, want target-status observation", terminal)
+	}
+	var compactionPatches int
+	for _, call := range duckling.calls {
+		if call.kind == "compaction" {
+			compactionPatches++
+		}
+	}
+	if compactionPatches != 1 {
+		t.Fatalf("compaction patches = %d, want only the initial pause while source recovery remains unverified", compactionPatches)
+	}
+}
+
+// rollbackExternalPatchWrongSourceDuckling accepts the rollback patch but
+// reports a different Ready external catalog. Type+Ready alone must never be
+// treated as recovery: the status must identify the recorded source endpoint.
+type rollbackExternalPatchWrongSourceDuckling struct {
+	*fakeDuckling
+}
+
+func (s *rollbackExternalPatchWrongSourceDuckling) SetMetadataStoreExternal(_ context.Context, _ string, ext ExternalMetadataStoreSpec) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, ducklingCall{kind: "external", ext: ext})
+	s.status.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	s.status.MetadataStore.Endpoint = "wrong-source.example.rds.amazonaws.com"
+	s.status.MetadataStore.User = ext.User
+	s.status.MetadataStore.Database = ext.Database
+	s.status.MetadataStore.Password = "wrong-source-password"
+	s.status.ReadyCondition = true
+	return nil
+}
+
+// TestReshardExternalRollbackWaitsForRecordedSource confirms the same gate is
+// used for external→cnpg rollback. A Ready external status for a different
+// endpoint is not the catalog this operation recorded before the cutover.
+func TestReshardExternalRollbackWaitsForRecordedSource(t *testing.T) {
+	op := cnpgOp()
+	op.SourceKind = configstore.MetadataStoreKindExternal
+	op.FromShard = ""
+	op.SourceEndpoint = "source.example.rds.amazonaws.com"
+	op.SourceUser = "postgres"
+	op.SourceDatabase = "postgres"
+	op.SourcePasswordSecret = "source-secret"
+	store := newFakeReshardStore(op)
+
+	var source DucklingStatus
+	source.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	source.MetadataStore.Endpoint = op.SourceEndpoint
+	source.MetadataStore.User = op.SourceUser
+	source.MetadataStore.Database = op.SourceDatabase
+	source.MetadataStore.Password = "source-password"
+	source.DataStore.BucketName = "org-a-data-bucket"
+	source.DataStore.S3Region = "us-east-1"
+	source.IAMRoleARN = "arn:aws:iam::123:role/duckling-org-a"
+	source.ReadyCondition = true
+	duckling := &rollbackExternalPatchWrongSourceDuckling{fakeDuckling: &fakeDuckling{status: source}}
+	copier := &fakeCopier{copyErr: errors.New("copy failed after cutover")}
+	r := testRunner(store, duckling, copier)
+	r.flipTimeout = 50 * time.Millisecond
+
+	runOp(t, r, store)
+
+	if store.warehouseState != configstore.ManagedWarehouseStateResharding {
+		t.Fatalf("warehouse state = %s, want resharding while external rollback reports the wrong source", store.warehouseState)
+	}
+	if store.op.UnblockedAt != nil {
+		t.Fatalf("unblocked_at = %v, want nil before the recorded external source converges", store.op.UnblockedAt)
+	}
+	terminal := store.findLog("recovery: source metadata store did not converge within")
+	if terminal == "" || !strings.Contains(terminal, "wrong-source.example.rds.amazonaws.com") {
+		t.Fatalf("recovery terminal diagnostic = %q, want wrong-source observation", terminal)
+	}
+}
+
+// TestReshardExternalRollbackConvergesBeforeUnblocking covers the successful
+// external→cnpg reverse patch. The common recovery gate must accept the
+// recorded external source only after it is Ready and its live status
+// credentials answer a TLS probe.
+func TestReshardExternalRollbackConvergesBeforeUnblocking(t *testing.T) {
+	op := cnpgOp()
+	op.SourceKind = configstore.MetadataStoreKindExternal
+	op.FromShard = ""
+	op.SourceEndpoint = "source.example.rds.amazonaws.com"
+	op.SourceUser = "postgres"
+	op.SourceDatabase = "postgres"
+	op.SourcePasswordSecret = "source-secret"
+	store := newFakeReshardStore(op)
+
+	var source DucklingStatus
+	source.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	source.MetadataStore.Endpoint = op.SourceEndpoint
+	source.MetadataStore.User = op.SourceUser
+	source.MetadataStore.Database = op.SourceDatabase
+	source.MetadataStore.Password = "source-password"
+	source.DataStore.BucketName = "org-a-data-bucket"
+	source.DataStore.S3Region = "us-east-1"
+	source.IAMRoleARN = "arn:aws:iam::123:role/duckling-org-a"
+	source.ReadyCondition = true
+	duckling := &fakeDuckling{status: source}
+	copier := &fakeCopier{copyErr: errors.New("copy failed after cutover")}
+
+	runOp(t, testRunner(store, duckling, copier), store)
+
+	if store.warehouseState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("warehouse state = %s, want ready after external source recovery", store.warehouseState)
+	}
+	if !containsStr(duckling.callKinds(), "external") {
+		t.Fatalf("external rollback patch missing: %v", duckling.callKinds())
+	}
+	var lastProbe *copierCall
+	for i := range copier.calls {
+		if copier.calls[i].kind == "probe" {
+			lastProbe = &copier.calls[i]
+		}
+	}
+	if lastProbe == nil {
+		t.Fatalf("rollback source probe missing: %v", copier.kinds())
+	}
+	if lastProbe.target.Host != op.SourceEndpoint || lastProbe.target.SSLMode != "require" || lastProbe.target.Password != "ext-pw" {
+		t.Fatalf("rollback source probe = %+v, want live external source credentials over TLS", lastProbe.target)
+	}
+}
+
 // stuckCnpgDuckling records patches but never converges the status.
 type stuckCnpgDuckling struct {
 	*fakeDuckling
@@ -1893,7 +2063,7 @@ func TestReshardExtRecoveryProbeAuthFailureDiagnosed(t *testing.T) {
 		t.Fatalf("stranded-password condition/remedy missing from the periodic observations: %v", store.logs)
 	}
 	// (c) The terminal recovery-timeout line carries the last observation.
-	terminal := store.findLog("recovery: source shard did not become ready within")
+	terminal := store.findLog("recovery: source metadata store did not converge within")
 	if terminal == "" {
 		t.Fatalf("recovery timeout line missing: %v", store.logs)
 	}

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -461,11 +461,11 @@ recovery (which stranded the tenant with an empty catalog when the copy-back
 also failed, the prod-shaped data-loss incident this change fixes) and avoids
 the `2BP01` "role can't drop while its DB exists" wedge the coupled delete hit.
 
-Every wait loop in the runner (drain, flip converge, orphan-policy wait, this
-recovery) announces its deadline on entry and logs what it observes every ~15s
-(duckling endpoint/Ready state, classified probe errors), and its timeout
-error/log line carries the LAST observation — a stuck reshard is diagnosable
-from the op log alone. One recovery failure mode deserves naming: the
+Every wait loop in the runner (drain, flip converge, orphan-policy wait, and
+rollback recovery) announces its deadline on entry and logs what it observes
+every ~15s (duckling type/endpoint/Ready state, classified probe errors), and
+its timeout error/log line carries the LAST observation — a stuck reshard is
+diagnosable from the op log alone. One recovery failure mode deserves naming: the
 re-adopted role's ACTUAL Postgres password can differ from the freshly
 regenerated status password (a **stranded password** — the probe fails with
 `FATAL: SASL authentication failed` / SQLSTATE 28P01 until the composition
@@ -496,6 +496,19 @@ never appear in the op log.
   prod incident's rollback failed exactly that way. The submit-time
   source-identity validation makes such ops unrepresentable going forward;
   this guard covers pre-guard rows and drift after creation.
+- **A successful rollback PATCH is not recovery.** After every reverse
+  metadata-store patch (cnpg→cnpg, ext→cnpg, and cnpg→ext's re-adopt patch),
+  the warehouse stays in `resharding` until Duckling status reports the
+  recorded source kind/endpoint/user/database, `Ready=True`, and a fresh
+  tenant-credential `SELECT 1` probe succeeds against that source. This closes
+  the asynchronous spec/status window where the PATCH succeeded but worker
+  activation still saw the failed target. A timeout, missing credentials, or
+  failed probe logs periodic and terminal observations and deliberately leaves
+  the warehouse blocked with compaction still paused, so independent catalog
+  writers cannot use an unverified source/target. The recovery wait
+  intentionally does not re-honor the cancellation that triggered rollback;
+  its per-operation cutover timeout is the bound that prevents an unsafe
+  immediate unblock.
 - Takeover-resume reconstructs `o.source`/`o.target` from the durable op row +
   live duckling status with each side's **sslmode derived from its
   metadata-store kind** (`sslModeFor`: cnpg pooler → `disable`, external RDS →
@@ -528,16 +541,16 @@ never appear in the op log.
   prove a step completed flip a flag) and every rollback action is idempotent, so
   a takeover rolls back identically to the original runner.
 - An org is never stranded: every failure path restores `resharding→ready`
-  (or logs at ERROR if it can't — that's the page-someone signal) — with ONE
-  deliberate carve-out: when the duckling is known to point at the WRONG
-  store and rollback cannot repair it (an invalid/incomplete recorded source
-  identity, or a flip-back that failed), the warehouse stays BLOCKED in
-  `resharding`. Unblocking would let clients activate against the wrong
-  (likely empty) catalog — worse than a blocked org: the prod incident
-  unblocked after a failed rollback and clients landed on an empty catalog.
-  The ERROR log carries the manual repair steps (verify where the catalog
-  actually lives, patch `spec.metadataStore`, verify activation, then set the
-  warehouse ready).
+  (or logs at ERROR if it can't — that's the page-someone signal) — with
+  deliberate safety carve-outs: when the duckling is known to point at the
+  WRONG store and rollback cannot repair it (an invalid/incomplete recorded
+  source identity, a flip-back that failed, or a successful flip-back whose
+  status/probe never converges), the warehouse stays BLOCKED in `resharding`.
+  Unblocking would let clients activate against the wrong (likely empty)
+  catalog — worse than a blocked org: the prod incident unblocked after a
+  failed rollback and clients landed on an empty catalog. The ERROR log
+  carries the manual repair steps (verify where the catalog actually lives,
+  patch `spec.metadataStore`, verify activation, then set the warehouse ready).
 
 ## Testing
 

--- a/docs/runbooks/resharding.md
+++ b/docs/runbooks/resharding.md
@@ -51,5 +51,14 @@ can activate against the real catalog, and only then set the warehouse state
 back to `ready`. Never unblock first — clients would activate against the
 wrong (likely empty) catalog.
 
+The same blocked state is deliberate after an accepted rollback patch when
+Duckling status still names the failed target, is not Ready, does not identify
+the recorded source, or the source tenant-role probe does not answer. The
+runner logs periodic observations and a terminal one with the last status or
+probe error. Repair the Duckling composition/source catalog, then confirm the
+status and a tenant activation both use the intended source before setting the
+warehouse back to `ready`. Compaction intentionally remains paused in this
+state; do not re-enable it until that recovery check succeeds.
+
 Never delete or recreate a retained cnpg database until the operation log shows
 that the external target passed content fingerprint verification.


### PR DESCRIPTION
## Summary

- Gate every successful rollback metadata-store patch on Duckling reporting the recorded source, `Ready=True`, and a tenant-credential catalog probe.
- Reuse that convergence gate for cnpg→cnpg, external→cnpg, and cnpg→external adopt recovery; keep compaction paused when recovery cannot be verified.
- Add focused rollback regressions and document the blocked-recovery runbook.

## Root cause

A reverse Duckling spec patch could be accepted while status and worker activation still referenced the failed target. The runner immediately marked the warehouse ready, admitting a connection into that unsafe ready-before-recovered window.

## Validation

- Targeted Kubernetes-tagged rollback tests
- `go test -count=1 -tags kubernetes ./controlplane/provisioner`
- `just lint`