### PR TITLE
ci: extend scenario AWS session

### DIFF
--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -93,6 +93,9 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/github-duckgres-e2e
           aws-region: us-east-1
+          # Covers this job's 270-minute timeout so long dbt runs can still
+          # collect artifacts and tear down the isolated namespace.
+          role-duration-seconds: 16200
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -302,6 +302,11 @@ finalizers are still running.
 | (role) | `github-duckgres-e2e` | dedicated stripped role in the mw-dev account (posthog-cloud-infra) — `eks:DescribeCluster` + Pod Identity association calls + `iam:PassRole`/`iam:GetRole` on the CP role + an EKS access entry for kubectl. The workflow assumes `arn:aws:iam::<MW_DEV_ACCOUNT_ID>:role/github-duckgres-e2e`. |
 | repo setting | "Require approval for all outside collaborators" | the access gate (see below) |
 
+The `scenario-dev` workflow requests a 16,200-second session from
+`github-duckgres-e2e`, matching its 270-minute job timeout. The role's
+`max_session_duration` in posthog-cloud-infra must be at least 16,200 seconds
+before this workflow setting is deployed.
+
 The Tailscale tailnet ACL must allow `tag:github-runner` to reach the mw-dev
 VPC subnet router (same pattern hogland set up for its dev cluster).
 

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -82,6 +82,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"CLUSTER_NAME: posthog-mw-dev",
 		"EKS_CLUSTER_NAME: posthog-mw-dev",
 		"CP_POD_IDENTITY_ROLE: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/duckgres-control-plane-dev",
+		"role-duration-seconds: 16200",
 		"tests/mw-dev/run.sh deploy",
 		"tests/mw-dev/run.sh test-scenario",
 		"tests/mw-dev/run.sh diagnostics",


### PR DESCRIPTION
## Summary

- request a 16,200-second OIDC role session for `scenario-dev`, matching its 270-minute job timeout
- document the cross-repository IAM maximum-session dependency
- pin the requested duration in the scenario workflow test

## Why

Long dbt scenarios can outlive the action's default one-hour AWS session. The scenario keeps running in-cluster, but subsequent Kubernetes calls then cannot collect artifacts, run diagnostics, or tear down the isolated namespace.

## Dependency

Depends on PostHog/posthog-cloud-infra#9457 being merged **and applied** first. The workflow's role assumption will fail if it requests 16,200 seconds while the deployed role maximum remains 3,600 seconds.

## Validation

- red: `just test-scenario` failed because `role-duration-seconds: 16200` was absent
- green: `just test-scenario`
- `just lint`
