### PR TITLE
feat(provisioning): discovery endpoints for external writers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,6 +579,51 @@ touching this path:
   `compute_usage_pull_api` assertion (compute + storage) in
   `tests/mw-dev/e2e/harness.sh`.
 
+## Discovery Endpoints (external-writer tenant listing)
+
+`GET /api/v1/warehouses` + `GET /api/v1/warehouse-team-ids` on the internal
+provisioning API (`controlplane/provisioning/discovery.go`) are the read-only
+"which tenants exist and where do I write" surface for EXTERNAL writers
+(viaduck destination discovery; millpond's include-values poller). Semantics
+are load-bearing for those consumers:
+
+- **Warehouse set = ready + resharding** (`discoveryStates`). Resharding is
+  listed with `writable=false` — vanishing would read as tenant REMOVAL
+  downstream, not a pause. The state enum is open: a new state MUST be
+  classified into `discoveryStates`/`discoveryExcludedStates`
+  (`TestDiscoveryStateClassification` is the tripwire; an unclassified state
+  reads as fleet-wide removal to every consumer).
+- **Teams come from `duckgres_org_teams`**, with RESOLVED table locations:
+  `events_table`/`persons_table` = `<schema_name>.<override-or-derived>`,
+  `data_imports_schema` = override-or-`<schema>_data_imports`. The
+  derivation lives ONCE, in `resolveTeamTables`; the legacy overrides are
+  BARE identifiers (never schema-qualified), enforced at every write surface
+  by `configstore.ValidateOrgTeamTableName`.
+- **`enabled` is passed through as information only** — it is the per-team
+  query-serving switch (migration 000024, not yet enforced), NOT an
+  ingestion signal. Disabled teams stay in BOTH endpoints; deriving
+  "stop ingesting" from it would turn a serving hold into permanent event
+  loss. The only ingestion-stop signal is row absence.
+- **Error contract:** transient store failures fail the WHOLE request (a
+  polling consumer keeps last-known-good — the safe direction); only a
+  warehouse with zero team rows degrades, per-warehouse, to an empty teams
+  array (`duckgres_discovery_broken_team_rows_total{reason}` counts it — a
+  sustained nonzero means a live tenant is silently unroutable).
+- **`config_generation` is an opaque change token**: max `updated_at` over
+  ALL warehouse+org+org-team rows regardless of state, read BEFORE the data
+  queries. Its delete-visibility depends on `DeleteOrgTeamTx` touching the
+  parent org row (a bare team DELETE leaves no timestamp behind) —
+  `TestLatestConfigChangeCoversTeamsPostgres` pins that pair; keep them in
+  sync. Compare for equality only.
+- **No plaintext credentials in the payload** — metadata-store passwords are
+  k8s SecretRefs. cnpg rows currently carry only the metadata-store KIND
+  (endpoint/db/user live in the Duckling CR status until the provisioner
+  backfills the row on Ready); external rows round-trip fully.
+- Touching the payload shape, states, team derivation, or the generation →
+  update `controlplane/provisioning/discovery_test.go`,
+  `tests/configstore/org_teams_postgres_test.go`, AND the
+  `discovery_endpoints` assertion in `tests/mw-dev/e2e/harness.sh`.
+
 ## Resharding (metadata-store migrations) — LOAD-BEARING CONTRACT
 
 Operator-driven moves of an org's DuckLake catalog between metadata stores

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -417,7 +417,27 @@ func (s *gormAPIStore) CreateOrgTeam(orgID string, team *configstore.OrgTeam) er
 			return configstore.ErrOrgTeamSchemaConflict
 		}
 		team.OrgID = orgID
-		return tx.Create(team).Error
+		// Capture intent BEFORE Create: gorm's RETURNING write-back stamps
+		// the DB row (enabled defaulted TRUE) back onto the struct, so the
+		// post-Create value lies about what the caller asked for.
+		wantDisabled := !team.Enabled
+		if err := tx.Create(team).Error; err != nil {
+			return err
+		}
+		// Enabled carries gorm's `default:true` tag: a zero-valued (false)
+		// field is omitted from the INSERT and the DB default TRUE wins —
+		// the same pitfall fixed in configstore.UpsertOrgTeamTx, on this
+		// surface reachable via POST /teams {"enabled":false}. Force the
+		// column explicitly. Pinned by TestAdminCreateOrgTeamDisabledPostgres.
+		if wantDisabled {
+			if err := tx.Model(&configstore.OrgTeam{}).
+				Where("org_id = ? AND team_id = ?", orgID, team.TeamID).
+				Update("enabled", false).Error; err != nil {
+				return err
+			}
+			team.Enabled = false // undo the RETURNING write-back for the caller
+		}
+		return nil
 	})
 }
 
@@ -1027,10 +1047,6 @@ type updateOrgTeamRequest struct {
 	SchemaDataImportsName *string `json:"schema_data_imports_name,omitempty"`
 }
 
-// maxOrgTeamTableNameLength caps the legacy table-name overrides at the
-// column width (varchar(255)) so a typo'd blob is a 400, not a DB error.
-const maxOrgTeamTableNameLength = 255
-
 // legacyTableNameUpdate folds one presence-aware legacy table-name field of
 // the PUT body into (set, value): absent = (false, nil); explicit null or ""
 // = (true, nil) — clear back to NULL / derive from schema_name; anything else
@@ -1089,8 +1105,14 @@ func (h *apiHandler) updateOrgTeam(c *gin.Context) {
 		"persons_table_name":       req.PersonsTableName,
 		"schema_data_imports_name": req.SchemaDataImportsName,
 	} {
-		if v != nil && len(*v) > maxOrgTeamTableNameLength {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s must be at most %d characters", name, maxOrgTeamTableNameLength)})
+		if v == nil {
+			continue
+		}
+		// Shared bare-identifier contract (see configstore.ValidateOrgTeamTableName):
+		// overrides are never schema-qualified; a dot stored here would be
+		// silently ambiguous to every discovery consumer. "" passes (clear).
+		if err := configstore.ValidateOrgTeamTableName(name, *v); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 	}

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -513,3 +513,34 @@ func TestAdminUpdateOrgTeamBreakGlassPostgres(t *testing.T) {
 		t.Fatalf("schema_name = %q, want shared preserved on omit", updated.SchemaName)
 	}
 }
+
+// TestAdminCreateOrgTeamDisabledPostgres pins the gorm default-tag pitfall on
+// the ADMIN create surface (POST /teams {"enabled":false}): Enabled carries
+// `default:true`, gorm omits zero-valued default-tagged fields from the
+// INSERT, and without the explicit follow-up column write the DB default
+// silently stores TRUE. Same bug class as configstore.UpsertOrgTeamTx's
+// create path (TestCreateOrgTeamDisabledPostgres).
+func TestAdminCreateOrgTeamDisabledPostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+
+	if err := store.DB().Create(&configstore.Org{Name: "heldorg", DatabaseName: "heldorgdb"}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	team := &configstore.OrgTeam{TeamID: 5, SchemaName: "team_5", Enabled: false}
+	if err := apiStore.CreateOrgTeam("heldorg", team); err != nil {
+		t.Fatalf("create disabled team: %v", err)
+	}
+	var got configstore.OrgTeam
+	if err := store.DB().First(&got, "org_id = ? AND team_id = ?", "heldorg", 5).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got.Enabled {
+		t.Fatal("admin-created team with enabled=false was stored as enabled=true (gorm default-tag pitfall)")
+	}
+	// The struct handed back to the handler (the 201 body) must not carry
+	// gorm's RETURNING write-back either.
+	if team.Enabled {
+		t.Fatal("returned team struct carries enabled=true (RETURNING write-back not undone)")
+	}
+}

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -2550,3 +2550,23 @@ func TestAdminListOrgTeams(t *testing.T) {
 		t.Fatalf("global teams order = %+v, want acme[1,2] then zeta[9]", global.Teams)
 	}
 }
+
+func TestAdminUpdateOrgTeamRejectsQualifiedLegacyName(t *testing.T) {
+	// Bare-name contract on the admin surface: a schema-qualified override
+	// is a 400 (configstore.ValidateOrgTeamTableName), because a stored dot
+	// is silently ambiguous to every discovery consumer, and the stored
+	// value must stay untouched.
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 1, SchemaName: "team_1", Enabled: true})
+	router := newTestAPIRouter(store)
+
+	rec := adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"events_table_name":"posthog.legacy_events"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("qualified events_table_name: status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if stored := store.teams["acme"][1]; stored.EventsTableName != nil {
+		t.Fatalf("rejected PUT must not store anything, got %+v", stored)
+	}
+}

--- a/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
+++ b/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
@@ -311,7 +311,7 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
             <Input
               value={eventsName}
               onChange={(e) => setEventsName(e.target.value)}
-              placeholder={`${team.schema_name}.events (derived)`}
+              placeholder={`events (derived → ${team.schema_name}.events)`}
               className="font-mono text-xs"
             />
           </FieldRow>
@@ -319,7 +319,7 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
             <Input
               value={personsName}
               onChange={(e) => setPersonsName(e.target.value)}
-              placeholder={`${team.schema_name}.persons (derived)`}
+              placeholder={`persons (derived → ${team.schema_name}.persons)`}
               className="font-mono text-xs"
             />
           </FieldRow>
@@ -327,7 +327,7 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
             <Input
               value={importsName}
               onChange={(e) => setImportsName(e.target.value)}
-              placeholder={`${team.schema_name}_data_imports (derived)`}
+              placeholder={`${team.schema_name}_data_imports (derived; bare schema name)`}
               className="font-mono text-xs"
             />
           </FieldRow>

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -38,7 +38,11 @@ type Org struct {
 	Users         []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
 	Warehouse     *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
 	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	// UpdatedAt doubles as an input to the discovery change marker
+	// (ConfigStore.LatestConfigChange): DeleteOrgTeamTx touches it so a
+	// team-row DELETE — which leaves no updated_at of its own behind —
+	// still advances the marker external pollers gate on.
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 func (Org) TableName() string { return "duckgres_orgs" }
@@ -76,11 +80,16 @@ type OrgTeam struct {
 	OrgID string `gorm:"primaryKey;size:255;index:idx_duckgres_org_teams_billing_org,unique,where:is_billing_team IS TRUE;index:idx_duckgres_org_teams_org_schema,unique,priority:1" json:"org_id"`
 	// autoIncrement:false — int fields in a composite primary key default to
 	// auto-increment in gorm, which would make this a bigserial.
-	TeamID                int64     `gorm:"primaryKey;autoIncrement:false" json:"team_id"`
-	SchemaName            string    `gorm:"size:255;not null;index:idx_duckgres_org_teams_org_schema,unique,priority:2" json:"schema_name"`
-	Enabled               bool      `gorm:"not null;default:true" json:"enabled"`
-	IsBillingTeam         *bool     `json:"is_billing_team,omitempty"`
-	BackfillEnabled       *bool     `json:"backfill_enabled,omitempty"`
+	TeamID          int64  `gorm:"primaryKey;autoIncrement:false" json:"team_id"`
+	SchemaName      string `gorm:"size:255;not null;index:idx_duckgres_org_teams_org_schema,unique,priority:2" json:"schema_name"`
+	Enabled         bool   `gorm:"not null;default:true" json:"enabled"`
+	IsBillingTeam   *bool  `json:"is_billing_team,omitempty"`
+	BackfillEnabled *bool  `json:"backfill_enabled,omitempty"`
+	// The legacy overrides are BARE identifiers (never schema-qualified):
+	// events/persons are table names within SchemaName's schema, the
+	// data-imports override is a schema name. Enforced by
+	// ValidateOrgTeamTableName on every write surface; resolved for
+	// consumers in provisioning/discovery.go resolveTeamTables.
 	EventsTableName       *string   `gorm:"size:255" json:"events_table_name,omitempty"`
 	PersonsTableName      *string   `gorm:"size:255" json:"persons_table_name,omitempty"`
 	SchemaDataImportsName *string   `gorm:"size:255" json:"schema_data_imports_name,omitempty"`

--- a/controlplane/configstore/org_teams.go
+++ b/controlplane/configstore/org_teams.go
@@ -53,6 +53,48 @@ func ValidateOrgTeamSchemaName(name string) error {
 	return nil
 }
 
+// ValidateOrgTeamTableName rejects legacy table/schema override names that
+// are not safe bare identifiers. The override contract (pinned at the
+// discovery derivation site, provisioning/discovery.go resolveTeamTables):
+// events/persons overrides are BARE TABLE NAMES within the team's schema,
+// and the data-imports override is a bare SCHEMA name — never
+// schema-qualified. A dot in a stored name would be silently ambiguous to
+// every consumer of the resolved locations, so reject at write time on
+// every surface.
+func ValidateOrgTeamTableName(field, name string) error {
+	if name == "" {
+		return nil // empty = clear back to derive-from-schema
+	}
+	if len(name) > maxOrgTeamSchemaNameLength {
+		return fmt.Errorf("%s must be at most %d characters", field, maxOrgTeamSchemaNameLength)
+	}
+	if !orgTeamSchemaNamePattern.MatchString(name) {
+		return fmt.Errorf("%s must be a bare lowercase identifier: [a-z0-9_], not starting with a digit, no schema qualification", field)
+	}
+	return nil
+}
+
+// validateOrgTeamTableNames applies ValidateOrgTeamTableName to every legacy
+// override present in the upsert.
+func validateOrgTeamTableNames(up OrgTeamUpsert) error {
+	for _, f := range []struct {
+		field string
+		value *string
+	}{
+		{"events_table_name", up.EventsTableName},
+		{"persons_table_name", up.PersonsTableName},
+		{"schema_data_imports_name", up.SchemaDataImportsName},
+	} {
+		if f.value == nil {
+			continue
+		}
+		if err := ValidateOrgTeamTableName(f.field, *f.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // OrgBillingTeamIDTx returns the org's current billing team id (the
 // duckgres_org_teams row with is_billing_team = TRUE) inside the caller's
 // transaction, or 0 when the org has none.
@@ -134,6 +176,9 @@ type OrgTeamUpsert struct {
 // migration 000025 — a concurrent insert that slips past the pre-check still
 // fails with a 23505 on that index).
 func UpsertOrgTeamTx(tx *gorm.DB, orgID string, up OrgTeamUpsert) (*OrgTeam, error) {
+	if err := validateOrgTeamTableNames(up); err != nil {
+		return nil, err
+	}
 	if err := ValidateOrgTeamSchemaName(up.SchemaName); err != nil {
 		return nil, err
 	}
@@ -173,6 +218,19 @@ func UpsertOrgTeamTx(tx *gorm.DB, orgID string, up OrgTeamUpsert) (*OrgTeam, err
 		applyOrgTeamTableNames(&row, up)
 		if err := tx.Create(&row).Error; err != nil {
 			return nil, fmt.Errorf("create org team (org=%s team=%d): %w", orgID, up.TeamID, err)
+		}
+		// Enabled carries gorm's `default:true` tag, and gorm omits
+		// zero-valued default-tagged fields from the INSERT — so a create
+		// with enabled=false silently stores (and serves, and ingests)
+		// TRUE, with row.Enabled lying to the caller. Pinned by
+		// TestCreateOrgTeamDisabledPostgres; force the column explicitly.
+		if up.Enabled != nil && !*up.Enabled {
+			if err := tx.Model(&OrgTeam{}).
+				Where("org_id = ? AND team_id = ?", orgID, up.TeamID).
+				Update("enabled", false).Error; err != nil {
+				return nil, fmt.Errorf("persist enabled=false (org=%s team=%d): %w", orgID, up.TeamID, err)
+			}
+			row.Enabled = false
 		}
 		return &row, nil
 	case err != nil:
@@ -292,6 +350,15 @@ func DeleteOrgTeamTx(tx *gorm.DB, orgID string, teamID int64) (*OrgTeamDeleteRes
 	if err := tx.Where("org_id = ? AND team_id = ?", orgID, teamID).
 		Delete(&OrgTeam{}).Error; err != nil {
 		return nil, fmt.Errorf("delete org team (org=%s team=%d): %w", orgID, teamID, err)
+	}
+	// A DELETE leaves no updated_at bump behind, so a non-billing deletion
+	// would be invisible to change-marker consumers (discovery's
+	// config_generation is MAX(updated_at) over the three config tables) —
+	// the exact removal signal a poller must not skip. Touch the parent
+	// org row in the same transaction so the marker advances.
+	if err := tx.Model(&Org{}).Where("name = ?", orgID).
+		Update("updated_at", gorm.Expr("now()")).Error; err != nil {
+		return nil, fmt.Errorf("touch org row after team delete (org=%s): %w", orgID, err)
 	}
 
 	res := &OrgTeamDeleteResult{

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -3,6 +3,7 @@ package configstore
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -670,10 +671,51 @@ func (cs *ConfigStore) GetManagedWarehouse(orgID string) (*ManagedWarehouse, err
 
 func (cs *ConfigStore) ListWarehousesByStates(states []ManagedWarehouseProvisioningState) ([]ManagedWarehouse, error) {
 	var warehouses []ManagedWarehouse
-	if err := cs.db.Where("state IN ?", states).Find(&warehouses).Error; err != nil {
+	// Deterministic order: without it Postgres heap order shuffles between
+	// reads, and discovery consumers diffing successive responses see
+	// phantom changes.
+	if err := cs.db.Where("state IN ?", states).Order("org_id").Find(&warehouses).Error; err != nil {
 		return nil, fmt.Errorf("list warehouses by states: %w", err)
 	}
 	return warehouses, nil
+}
+
+// ListOrgTeamsByOrgIDs batch-fetches duckgres_org_teams rows for a set of
+// orgs (discovery endpoints). Orgs with no rows are simply absent from the
+// result — callers decide how to degrade. Deterministic order for stable
+// consumer diffs.
+func (cs *ConfigStore) ListOrgTeamsByOrgIDs(orgIDs []string) ([]OrgTeam, error) {
+	if len(orgIDs) == 0 {
+		return nil, nil
+	}
+	var teams []OrgTeam
+	if err := cs.db.Where("org_id IN ?", orgIDs).Order("org_id, team_id").Find(&teams).Error; err != nil {
+		return nil, fmt.Errorf("list org teams by org ids: %w", err)
+	}
+	return teams, nil
+}
+
+// LatestConfigChange returns the max updated_at across ALL warehouse, org,
+// and org-team rows regardless of state — the discovery change token.
+// Unfiltered deliberately: a deprovision moves a row OUT of the
+// discoverable states while bumping its updated_at, and that transition is
+// exactly a change a poller must not skip. Team-row DELETEs leave no
+// updated_at behind, so DeleteOrgTeamTx touches the parent org row — this
+// function's delete-visibility DEPENDS on that touch; change either side
+// with the other in view (TestLatestConfigChangeCoversTeamsPostgres pins
+// the pair).
+func (cs *ConfigStore) LatestConfigChange() (time.Time, error) {
+	var latest time.Time
+	for _, model := range []any{&ManagedWarehouse{}, &Org{}, &OrgTeam{}} {
+		var t sql.NullTime
+		if err := cs.db.Model(model).Select("MAX(updated_at)").Scan(&t).Error; err != nil {
+			return time.Time{}, fmt.Errorf("latest config change: %w", err)
+		}
+		if t.Valid && t.Time.After(latest) {
+			latest = t.Time
+		}
+	}
+	return latest, nil
 }
 
 // UpdateWarehouseState performs a compare-and-swap update on a warehouse row.

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -93,6 +93,11 @@ type Store interface {
 	ListOrgTeams(orgID string) ([]configstore.OrgTeam, error)
 	UpsertOrgTeam(orgID string, up configstore.OrgTeamUpsert) (*configstore.OrgTeam, error)
 	DeleteOrgTeam(orgID string, teamID int64) (*configstore.OrgTeamDeleteResult, error)
+	// Discovery backing (discovery.go): list live warehouses, batch-fetch
+	// their team rows, and the unfiltered change marker.
+	ListWarehousesByStates(states []configstore.ManagedWarehouseProvisioningState) ([]configstore.ManagedWarehouse, error)
+	ListOrgTeamsByOrgIDs(orgIDs []string) ([]configstore.OrgTeam, error)
+	LatestConfigChange() (time.Time, error)
 }
 
 // RegisterAPI registers provisioning endpoints on the given router group.
@@ -112,6 +117,10 @@ func RegisterAPI(r *gin.RouterGroup, store Store, bucketSuffix string) {
 	r.GET("/orgs/:id/teams", h.listOrgTeams)
 	r.POST("/orgs/:id/teams", h.upsertOrgTeam)
 	r.DELETE("/orgs/:id/teams/:team_id", h.deleteOrgTeam)
+	// Discovery: read-only tenant listing for external writers (see
+	// discovery.go for payload semantics).
+	r.GET("/warehouses", h.listWarehouses)
+	r.GET("/warehouse-team-ids", h.listWarehouseTeamIDs)
 }
 
 type handler struct {

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -27,6 +27,10 @@ type fakeStore struct {
 	// tests can assert the request-field → store-request threading (the real
 	// billing-row/schema writes are covered by the Postgres-backed tests).
 	lastProvision *ProvisionRequest
+
+	listWarehousesErr error // set non-nil to fail ListWarehousesByStates
+	listOrgTeamsErr   error // set non-nil to fail ListOrgTeamsByOrgIDs
+	latestChangeErr   error // set non-nil to fail LatestConfigChange
 }
 
 func newFakeStore() *fakeStore {
@@ -270,6 +274,74 @@ func (s *fakeStore) Provision(req ProvisionRequest) error {
 	// declared-and-unused on the success path.
 	_, _ = shadowUserHash, hadUser
 	return nil
+}
+
+func (s *fakeStore) ListWarehousesByStates(states []configstore.ManagedWarehouseProvisioningState) ([]configstore.ManagedWarehouse, error) {
+	if s.listWarehousesErr != nil {
+		return nil, s.listWarehousesErr
+	}
+	want := make(map[configstore.ManagedWarehouseProvisioningState]struct{}, len(states))
+	for _, st := range states {
+		want[st] = struct{}{}
+	}
+	// Deterministic order, mirroring the production ORDER BY org_id.
+	ids := make([]string, 0, len(s.warehouses))
+	for id := range s.warehouses {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	var out []configstore.ManagedWarehouse
+	for _, id := range ids {
+		if _, ok := want[s.warehouses[id].State]; ok {
+			out = append(out, *s.warehouses[id])
+		}
+	}
+	return out, nil
+}
+
+func (s *fakeStore) ListOrgTeamsByOrgIDs(orgIDs []string) ([]configstore.OrgTeam, error) {
+	if s.listOrgTeamsErr != nil {
+		return nil, s.listOrgTeamsErr
+	}
+	var out []configstore.OrgTeam
+	for _, id := range orgIDs {
+		ids := make([]int64, 0, len(s.teams[id]))
+		for tid := range s.teams[id] {
+			ids = append(ids, tid)
+		}
+		sort.Slice(ids, func(a, b int) bool { return ids[a] < ids[b] })
+		for _, tid := range ids {
+			out = append(out, *s.teams[id][tid])
+		}
+	}
+	return out, nil
+}
+
+// LatestConfigChange mirrors production: max updated_at across ALL
+// warehouse, org, and org-team rows regardless of state.
+func (s *fakeStore) LatestConfigChange() (time.Time, error) {
+	if s.latestChangeErr != nil {
+		return time.Time{}, s.latestChangeErr
+	}
+	var latest time.Time
+	for _, w := range s.warehouses {
+		if w.UpdatedAt.After(latest) {
+			latest = w.UpdatedAt
+		}
+	}
+	for _, o := range s.orgs {
+		if o.UpdatedAt.After(latest) {
+			latest = o.UpdatedAt
+		}
+	}
+	for _, byTeam := range s.teams {
+		for _, t := range byTeam {
+			if t.UpdatedAt.After(latest) {
+				latest = t.UpdatedAt
+			}
+		}
+	}
+	return latest, nil
 }
 
 func (s *fakeStore) IsDatabaseNameAvailable(name string) (bool, error) {

--- a/controlplane/provisioning/discovery.go
+++ b/controlplane/provisioning/discovery.go
@@ -1,0 +1,319 @@
+package provisioning
+
+import (
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Discovery endpoints: the machine-facing "which tenants exist and where do
+// I write" surface consumed by external writers (viaduck destination
+// discovery, millpond's include-values source). Read-only projections of the
+// config store — the CP is a source of DESIRED config here; consumers keep
+// their own runtime state.
+//
+// Teams come from duckgres_org_teams (schema-per-team model): each row
+// carries the team's schema_name — its tables live at <schema>.events /
+// <schema>.persons — plus nullable grandfathered explicit table names for
+// pre-convention teams, an enabled flag, and the billing-team marker.
+// The enabled flag is duckgres's per-team QUERY-SERVING switch (migration
+// 000024) — it says nothing about ingestion. Discovery therefore passes it
+// through as information and derives NOTHING from it: disabled teams stay
+// in both the full listing and the values projection, because inferring
+// "stop ingesting" from "stop serving queries" would turn a serving hold
+// into permanent event loss. The only ingestion-stop signal is row
+// removal (team deleted / warehouse leaving the discoverable states).
+//
+// Metadata-store note: for Kind == "external" the connection block comes
+// straight off the warehouse row. For Kind == "cnpg-shard" the row carries
+// ONLY the kind today — the composition picks the shard and the authoritative
+// endpoint/database/user + secret live in the Duckling CR status, which the
+// provisioner does not (yet) write back to the row. Until that backfill
+// exists, cnpg tenants serve an empty connection block here; the teams
+// array and lifecycle fields are correct regardless, so team-level
+// consumers (millpond) are unaffected.
+
+// discoveryStates are the lifecycle states external writers must see.
+// Resharding is INCLUDED, with writable=false: if a resharding warehouse
+// vanished from the list instead, discovery-driven consumers would read
+// that as tenant REMOVAL (drain/retire) rather than a temporary write
+// fence. Pending/provisioning warehouses are excluded until they can
+// actually be written to; deleting/deleted/failed are gone — that absence
+// IS the removal signal, and consumers damp it on their side.
+//
+// The state enum is OPEN (models.go) — a state added without being
+// classified below silently reads as fleet-wide tenant removal to every
+// discovery consumer while tenants pass through it. TestDiscoveryStateClassification
+// is the tripwire: adding a state constant without extending one of these
+// two lists fails it.
+var discoveryStates = []configstore.ManagedWarehouseProvisioningState{
+	configstore.ManagedWarehouseStateReady,
+	configstore.ManagedWarehouseStateResharding,
+}
+
+// discoveryExcludedStates documents the deliberate exclusions (see the
+// classification tripwire above).
+var discoveryExcludedStates = []configstore.ManagedWarehouseProvisioningState{
+	configstore.ManagedWarehouseStatePending,
+	configstore.ManagedWarehouseStateProvisioning,
+	configstore.ManagedWarehouseStateFailed,
+	configstore.ManagedWarehouseStateDeleting,
+	configstore.ManagedWarehouseStateDeleted,
+}
+
+var discoveryBrokenTeamRows = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_discovery_broken_team_rows_total",
+	Help: "Warehouses served with an empty teams array (no duckgres_org_teams rows) or carrying a cross-org team conflict — sustained increase means a live tenant is silently unroutable or ambiguously routed",
+}, []string{"reason"})
+
+type discoveryTeam struct {
+	TeamID int64 `json:"team_id"`
+	// SchemaName is the team's schema (consumers still need it for DDL on
+	// new tables).
+	SchemaName string `json:"schema_name"`
+	// Enabled is duckgres's per-team QUERY-SERVING switch (not yet
+	// enforced on the serve path), passed through as information — see the
+	// module comment: nothing ingestion-shaped may be derived from it.
+	// Billing internals (is_billing_team) and backfill_enabled are
+	// deliberately NOT served: neither is a routing concern, and adding a
+	// field later is wire-compatible while removing one is not.
+	Enabled bool `json:"enabled"`
+	// Resolved, always-populated locations — the derivation from
+	// schema_name + grandfathered overrides happens HERE, once, so no
+	// consumer reimplements (or mis-guesses the qualification of) the
+	// rule. See resolveTeamTables.
+	EventsTable       string `json:"events_table"`
+	PersonsTable      string `json:"persons_table"`
+	DataImportsSchema string `json:"data_imports_schema"`
+}
+
+// resolveTeamTables derives the team's fully-qualified table locations.
+// Contract (pinned here, the single derivation site): a grandfathered
+// events/persons override is a BARE TABLE NAME within the team's schema —
+// the schema part always comes from schema_name (a break-glass schema
+// repair repoints overrides too); absent overrides derive `events` /
+// `persons`. The data-imports override is a SCHEMA name and replaces the
+// `<schema>_data_imports` derivation wholesale.
+func resolveTeamTables(t *configstore.OrgTeam) (events, persons, dataImports string) {
+	eventsName := "events"
+	if t.EventsTableName != nil && *t.EventsTableName != "" {
+		eventsName = *t.EventsTableName
+	}
+	personsName := "persons"
+	if t.PersonsTableName != nil && *t.PersonsTableName != "" {
+		personsName = *t.PersonsTableName
+	}
+	dataImports = t.SchemaName + "_data_imports"
+	if t.SchemaDataImportsName != nil && *t.SchemaDataImportsName != "" {
+		dataImports = *t.SchemaDataImportsName
+	}
+	return t.SchemaName + "." + eventsName, t.SchemaName + "." + personsName, dataImports
+}
+
+type discoverySecretRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Key       string `json:"key"`
+}
+
+type discoveryMetadataStore struct {
+	Kind     string `json:"kind"`
+	Endpoint string `json:"endpoint"`
+	Port     int    `json:"port"`
+	Database string `json:"database"`
+	Username string `json:"username"`
+	// PasswordSecretRef points at the k8s Secret holding the metadata-store
+	// password. NO plaintext credentials in this payload — consumers resolve
+	// the ref themselves (RBAC-scoped secret reads).
+	PasswordSecretRef discoverySecretRef `json:"password_secret_ref"`
+}
+
+type discoveryWarehouse struct {
+	OrgID        string                                        `json:"org_id"`
+	DucklingName string                                        `json:"duckling_name"`
+	State        configstore.ManagedWarehouseProvisioningState `json:"state"`
+	// Writable is the external-writer fence: false while resharding. Until
+	// the external-writer lease protocol exists, this polled flag is the
+	// ONLY fence external writers have — a reshard must account for their
+	// poll (and damping) lag before acting destructively; the lease barrier
+	// is the future enforcement, not the current one.
+	Writable bool `json:"writable"`
+	// Teams may be empty when the warehouse has no duckgres_org_teams rows
+	// (a data inconsistency worth surfacing rather than hiding the whole
+	// warehouse — consumers route nothing for an empty teams array).
+	Teams         []discoveryTeam        `json:"teams"`
+	MetadataStore discoveryMetadataStore `json:"metadata_store"`
+	Bucket        string                 `json:"bucket,omitempty"`
+}
+
+type discoveryResponse struct {
+	// ConfigGeneration is an opaque change token: max updated_at across
+	// ALL warehouse, org, and org-team rows regardless of state (unix
+	// seconds), so transitions OUT of the discoverable set (deprovision,
+	// team deletion — see DeleteOrgTeamTx's org-row touch) move it too.
+	// Pollers may skip processing when the value is UNCHANGED and export
+	// it to make replica skew observable. Compare for equality only:
+	// sub-second changes can share a value and a deletion of the row
+	// carrying the fleet max can move it backwards.
+	ConfigGeneration int64                `json:"config_generation"`
+	Warehouses       []discoveryWarehouse `json:"warehouses"`
+}
+
+// assembleDiscovery builds the discovery view both endpoints project from —
+// ONE assembly so the values-only projection can never drift to weaker
+// semantics (error handling, logging) than the full listing.
+//
+// Error contract: transient store failures fail the WHOLE assembly (the
+// caller 500s; a polling consumer keeps its last-known-good state — the
+// safe direction). Only genuinely-missing org data degrades, per-warehouse,
+// to an empty teams array — with a log and a counter, because a sustained
+// broken row is a live tenant silently unroutable.
+func (h *handler) assembleDiscovery() (*discoveryResponse, error) {
+	// Generation FIRST: read before the data so the stamp is never newer
+	// than the rows it accompanies — a commit landing mid-assembly then
+	// advances the NEXT poll's generation instead of hiding behind an
+	// already-served one.
+	generation, err := h.store.LatestConfigChange()
+	if err != nil {
+		return nil, err
+	}
+
+	warehouses, err := h.store.ListWarehousesByStates(discoveryStates)
+	if err != nil {
+		return nil, err
+	}
+
+	orgIDs := make([]string, 0, len(warehouses))
+	for i := range warehouses {
+		orgIDs = append(orgIDs, warehouses[i].OrgID)
+	}
+	teamRows, err := h.store.ListOrgTeamsByOrgIDs(orgIDs)
+	if err != nil {
+		// Transient failure: surface it. Treating it as "no teams" would
+		// serve every tenant teamless — indistinguishable from mass removal
+		// downstream.
+		return nil, err
+	}
+	teamsByOrg := make(map[string][]configstore.OrgTeam, len(orgIDs))
+	for i := range teamRows {
+		teamsByOrg[teamRows[i].OrgID] = append(teamsByOrg[teamRows[i].OrgID], teamRows[i])
+	}
+
+	resp := &discoveryResponse{Warehouses: make([]discoveryWarehouse, 0, len(warehouses))}
+	if !generation.IsZero() {
+		resp.ConfigGeneration = generation.Unix()
+	}
+
+	teamOwners := make(map[int64]string, len(warehouses))
+	for i := range warehouses {
+		w := &warehouses[i]
+
+		teams := []discoveryTeam{}
+		rows, ok := teamsByOrg[w.OrgID]
+		if !ok {
+			// Every org gets a billing team row at provision (migration 000024
+			// backfilled the fleet); a live warehouse with zero rows is a data
+			// inconsistency. Surface the warehouse with no teams instead of
+			// hiding it (hiding reads as removal downstream).
+			slog.Warn("discovery: warehouse has no team rows", "org_id", w.OrgID)
+			discoveryBrokenTeamRows.WithLabelValues("teams_missing").Inc()
+		}
+		for ti := range rows {
+			t := &rows[ti]
+			events, persons, dataImports := resolveTeamTables(t)
+			teams = append(teams, discoveryTeam{
+				TeamID:            t.TeamID,
+				SchemaName:        t.SchemaName,
+				Enabled:           t.Enabled,
+				EventsTable:       events,
+				PersonsTable:      persons,
+				DataImportsSchema: dataImports,
+			})
+			if owner, dup := teamOwners[t.TeamID]; dup {
+				// One team claimed by two orgs is a routing ambiguity — both
+				// warehouses carry the team in the full listing and the
+				// values projection dedupes it, so neither consumer can see
+				// the conflict without this signal.
+				slog.Warn("discovery: team claimed by multiple orgs",
+					"team_id", t.TeamID, "org_id", w.OrgID, "also_claimed_by", owner)
+				discoveryBrokenTeamRows.WithLabelValues("team_conflict").Inc()
+			} else {
+				teamOwners[t.TeamID] = w.OrgID
+			}
+		}
+
+		resp.Warehouses = append(resp.Warehouses, discoveryWarehouse{
+			OrgID:        w.OrgID,
+			DucklingName: w.DucklingName,
+			State:        w.State,
+			Writable:     w.State == configstore.ManagedWarehouseStateReady,
+			Teams:        teams,
+			MetadataStore: discoveryMetadataStore{
+				Kind:     w.MetadataStore.Kind,
+				Endpoint: w.MetadataStore.Endpoint,
+				Port:     w.MetadataStore.Port,
+				Database: w.MetadataStore.DatabaseName,
+				Username: w.MetadataStore.Username,
+				PasswordSecretRef: discoverySecretRef{
+					Namespace: w.MetadataStoreCredentials.Namespace,
+					Name:      w.MetadataStoreCredentials.Name,
+					Key:       w.MetadataStoreCredentials.Key,
+				},
+			},
+			Bucket: w.DataStore.BucketName,
+		})
+	}
+	return resp, nil
+}
+
+// listWarehouses serves GET /warehouses — the full discovery view.
+func (h *handler) listWarehouses(c *gin.Context) {
+	resp, err := h.assembleDiscovery()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// listWarehouseTeamIDs serves GET /warehouse-team-ids — a bare JSON array
+// of team ids across discoverable warehouses, shaped for generic
+// include-list pollers (millpond's HttpIncludeValues) that want values
+// only, no envelope. A pure projection of the same assembly as the full
+// listing. Resharding warehouses' teams are INCLUDED: upstream ingestion
+// keeps running during a duckling reshard, and dropping the team here
+// would (after the consumer's damping) silently stop ingesting it.
+//
+// (Not /warehouses/team-ids: org ids are free-form slugs, so a static
+// child under /warehouses would squat the namespace a future per-org
+// GET /warehouses/:org_id needs.)
+func (h *handler) listWarehouseTeamIDs(c *gin.Context) {
+	resp, err := h.assembleDiscovery()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	seen := make(map[int64]struct{})
+	ids := make([]int64, 0, len(resp.Warehouses))
+	for _, w := range resp.Warehouses {
+		for _, t := range w.Teams {
+			// ALL teams, including disabled ones: enabled is the query-
+			// serving switch, not an ingestion signal (see the module
+			// comment) — dropping a disabled team here would stop its
+			// ingestion upstream, i.e. permanent event loss from a flag
+			// that only means "don't serve queries."
+			if _, dup := seen[t.TeamID]; !dup {
+				seen[t.TeamID] = struct{}{}
+				ids = append(ids, t.TeamID)
+			}
+		}
+	}
+	sort.Slice(ids, func(a, b int) bool { return ids[a] < ids[b] })
+	c.JSON(http.StatusOK, ids)
+}

--- a/controlplane/provisioning/discovery_test.go
+++ b/controlplane/provisioning/discovery_test.go
@@ -1,0 +1,462 @@
+package provisioning
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func i64(v int64) *int64 { return &v }
+
+func boolPtrD(v bool) *bool { return &v }
+
+func strPtrD(v string) *string { return &v }
+
+// seedTeam adds one duckgres_org_teams row to the fake (delegates to the
+// fake's own seeding helper).
+func seedTeam(s *fakeStore, orgID string, t configstore.OrgTeam) {
+	t.OrgID = orgID
+	s.seedTeam(t)
+}
+
+// seedWarehouse adds an org + warehouse pair shaped like a provisioned
+// external-metadata tenant (the kind whose row actually carries connection
+// details today — see the metadata-store note in discovery.go: cnpg rows
+// carry only the kind until the CR-status backfill exists).
+func seedWarehouse(s *fakeStore, orgID string, teamID *int64, state configstore.ManagedWarehouseProvisioningState, updatedAt time.Time) {
+	s.orgs[orgID] = &configstore.Org{
+		Name:         orgID,
+		DatabaseName: "db_" + orgID,
+		UpdatedAt:    updatedAt,
+	}
+	if teamID != nil {
+		seedTeam(s, orgID, configstore.OrgTeam{
+			TeamID:        *teamID,
+			SchemaName:    fmt.Sprintf("team_%d", *teamID),
+			Enabled:       true,
+			IsBillingTeam: boolPtrD(true),
+			UpdatedAt:     updatedAt,
+		})
+	}
+	s.warehouses[orgID] = &configstore.ManagedWarehouse{
+		OrgID:        orgID,
+		DucklingName: orgID,
+		State:        state,
+		UpdatedAt:    updatedAt,
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:         configstore.MetadataStoreKindExternal,
+			Endpoint:     "duckling-" + orgID + ".rds.example",
+			Port:         5432,
+			DatabaseName: "duckling_" + orgID,
+			Username:     "duckling_" + orgID,
+			// The one genuinely sensitive row field — must NEVER appear in
+			// the discovery payload (see TestListWarehousesPayloadNoSecrets).
+			PasswordAWSSecret: "rds-master-secret-value",
+		},
+		MetadataStoreCredentials: configstore.SecretRef{
+			Namespace: "ducklings",
+			Name:      "duckling-" + orgID + "-password",
+			Key:       "password",
+		},
+		DataStore: configstore.ManagedWarehouseDataStore{
+			BucketName: "bucket-" + orgID,
+		},
+	}
+}
+
+func getJSON(t *testing.T, router http.Handler, path string, out any) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), out); err != nil {
+			t.Fatalf("decode %s: %v (body: %s)", path, err, w.Body.String())
+		}
+	}
+	return w.Code
+}
+
+func TestDiscoveryStateClassification(t *testing.T) {
+	// The state enum is open (models.go): a state added without being
+	// classified in discovery.go silently reads as fleet-wide tenant
+	// removal to every discovery consumer. This test is the tripwire —
+	// when adding a ManagedWarehouseState* constant, add it here AND to
+	// exactly one of discoveryStates / discoveryExcludedStates.
+	all := []configstore.ManagedWarehouseProvisioningState{
+		configstore.ManagedWarehouseStatePending,
+		configstore.ManagedWarehouseStateProvisioning,
+		configstore.ManagedWarehouseStateReady,
+		configstore.ManagedWarehouseStateFailed,
+		configstore.ManagedWarehouseStateDeleting,
+		configstore.ManagedWarehouseStateDeleted,
+		configstore.ManagedWarehouseStateResharding,
+	}
+	classified := make(map[configstore.ManagedWarehouseProvisioningState]int)
+	for _, st := range discoveryStates {
+		classified[st]++
+	}
+	for _, st := range discoveryExcludedStates {
+		classified[st]++
+	}
+	for _, st := range all {
+		if classified[st] != 1 {
+			t.Errorf("state %q classified %d times; every state must appear in exactly one of discoveryStates/discoveryExcludedStates", st, classified[st])
+		}
+	}
+	if len(classified) != len(all) {
+		t.Errorf("classification lists carry %d states, test knows %d — update both", len(classified), len(all))
+	}
+}
+
+func TestListWarehousesStates(t *testing.T) {
+	s := newFakeStore()
+	now := time.Now()
+	seedWarehouse(s, "ready-org", i64(2), configstore.ManagedWarehouseStateReady, now)
+	seedWarehouse(s, "resharding-org", i64(3), configstore.ManagedWarehouseStateResharding, now)
+	seedWarehouse(s, "pending-org", i64(4), configstore.ManagedWarehouseStatePending, now)
+	seedWarehouse(s, "provisioning-org", i64(5), configstore.ManagedWarehouseStateProvisioning, now)
+	seedWarehouse(s, "deleting-org", i64(6), configstore.ManagedWarehouseStateDeleting, now)
+	seedWarehouse(s, "deleted-org", i64(7), configstore.ManagedWarehouseStateDeleted, now)
+	seedWarehouse(s, "failed-org", i64(8), configstore.ManagedWarehouseStateFailed, now)
+
+	var resp discoveryResponse
+	if code := getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp); code != http.StatusOK {
+		t.Fatalf("status %d", code)
+	}
+	if len(resp.Warehouses) != 2 {
+		t.Fatalf("want 2 warehouses (ready+resharding), got %d", len(resp.Warehouses))
+	}
+	byOrg := map[string]discoveryWarehouse{}
+	for _, w := range resp.Warehouses {
+		byOrg[w.OrgID] = w
+	}
+	// Ready is writable; resharding is listed (NOT hidden — hiding reads as
+	// tenant removal downstream) but fenced.
+	if !byOrg["ready-org"].Writable {
+		t.Error("ready warehouse must be writable")
+	}
+	rw, ok := byOrg["resharding-org"]
+	if !ok {
+		t.Fatal("resharding warehouse must be listed")
+	}
+	if rw.Writable {
+		t.Error("resharding warehouse must not be writable")
+	}
+}
+
+func TestListWarehousesPayload(t *testing.T) {
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", i64(50689), configstore.ManagedWarehouseStateReady, time.Now())
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	w := resp.Warehouses[0]
+
+	if len(w.Teams) != 1 || w.Teams[0].TeamID != 50689 || w.Teams[0].SchemaName != "team_50689" {
+		t.Fatalf("teams from duckgres_org_teams rows, got %+v", w.Teams)
+	}
+	if !w.Teams[0].Enabled {
+		t.Fatalf("billing team must serve enabled=true, got %+v", w.Teams[0])
+	}
+	if w.Teams[0].EventsTable != "team_50689.events" {
+		t.Fatalf("derived events_table wrong: %+v", w.Teams[0])
+	}
+	ms := w.MetadataStore
+	if ms.Endpoint != "duckling-org-a.rds.example" || ms.Port != 5432 ||
+		ms.Database != "duckling_org-a" || ms.Username != "duckling_org-a" ||
+		ms.Kind != configstore.MetadataStoreKindExternal {
+		t.Fatalf("metadata store passthrough wrong: %+v", ms)
+	}
+	ref := ms.PasswordSecretRef
+	if ref.Namespace != "ducklings" || ref.Name != "duckling-org-a-password" || ref.Key != "password" {
+		t.Fatalf("secret ref passthrough wrong: %+v", ref)
+	}
+	if w.Bucket != "bucket-org-a" {
+		t.Fatalf("bucket passthrough wrong: %q", w.Bucket)
+	}
+}
+
+func TestListWarehousesPayloadNoSecrets(t *testing.T) {
+	// The row's PasswordAWSSecret is seeded with a sentinel VALUE; neither
+	// that value nor any password-ish KEY (other than password_secret_ref)
+	// may appear anywhere in the serialized payload. Catches both a direct
+	// leak and a future "simplify by serializing the model" refactor.
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/warehouses", nil)
+	w := httptest.NewRecorder()
+	newTestRouter(s).ServeHTTP(w, req)
+	body := w.Body.String()
+
+	if strings.Contains(body, "rds-master-secret-value") {
+		t.Fatal("payload leaks the PasswordAWSSecret value")
+	}
+	var v any
+	if err := json.Unmarshal(w.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var walk func(any)
+	walk = func(n any) {
+		switch n := n.(type) {
+		case map[string]any:
+			for k, val := range n {
+				if k != "password_secret_ref" && strings.Contains(k, "password") {
+					t.Errorf("payload carries password-ish key %q", k)
+				}
+				walk(val)
+			}
+		case []any:
+			for _, val := range n {
+				walk(val)
+			}
+		}
+	}
+	walk(v)
+}
+
+func TestListWarehousesBrokenTeamRows(t *testing.T) {
+	s := newFakeStore()
+	now := time.Now()
+	seedWarehouse(s, "org-ok", i64(2), configstore.ManagedWarehouseStateReady, now)
+	// Warehouse with NO team rows at all (every org gets a billing row at
+	// provision; zero rows is a data inconsistency — degrade to empty
+	// teams, never hide the warehouse).
+	seedWarehouse(s, "org-noteams", nil, configstore.ManagedWarehouseStateReady, now)
+
+	beforeMissing := testutil.ToFloat64(discoveryBrokenTeamRows.WithLabelValues("teams_missing"))
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	if len(resp.Warehouses) != 2 {
+		t.Fatalf("both warehouses must be listed, got %d", len(resp.Warehouses))
+	}
+	for _, w := range resp.Warehouses {
+		switch w.OrgID {
+		case "org-ok":
+			if len(w.Teams) != 1 {
+				t.Errorf("org-ok should have 1 team, got %d", len(w.Teams))
+			}
+		default:
+			if w.Teams == nil || len(w.Teams) != 0 {
+				t.Errorf("%s should have empty (non-null) teams, got %+v", w.OrgID, w.Teams)
+			}
+		}
+	}
+	if got := testutil.ToFloat64(discoveryBrokenTeamRows.WithLabelValues("teams_missing")) - beforeMissing; got != 1 {
+		t.Errorf("teams_missing counter delta = %v, want 1", got)
+	}
+}
+
+func TestDuplicateTeamAcrossOrgsCounted(t *testing.T) {
+	s := newFakeStore()
+	now := time.Now()
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, now)
+	seedWarehouse(s, "org-b", i64(2), configstore.ManagedWarehouseStateReady, now)
+
+	before := testutil.ToFloat64(discoveryBrokenTeamRows.WithLabelValues("team_conflict"))
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	// Both warehouses still carry the team (the listing doesn't arbitrate),
+	// but the conflict is counted so it can be alerted on.
+	if got := testutil.ToFloat64(discoveryBrokenTeamRows.WithLabelValues("team_conflict")) - before; got != 1 {
+		t.Errorf("team_conflict counter delta = %v, want 1", got)
+	}
+}
+
+func TestListWarehousesConfigGeneration(t *testing.T) {
+	s := newFakeStore()
+	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, older)
+	// A DELETED warehouse's newer updated_at must still advance the
+	// generation: leaving the discoverable set IS a change a poller must
+	// not skip (the whole point of the unfiltered marker).
+	seedWarehouse(s, "org-gone", i64(3), configstore.ManagedWarehouseStateDeleted, newer)
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	if resp.ConfigGeneration != newer.Unix() {
+		t.Fatalf("config_generation = %d, want %d (max over ALL rows incl. excluded states)", resp.ConfigGeneration, newer.Unix())
+	}
+}
+
+func TestListWarehousesEmpty(t *testing.T) {
+	var resp discoveryResponse
+	if code := getJSON(t, newTestRouter(newFakeStore()), "/api/v1/warehouses", &resp); code != http.StatusOK {
+		t.Fatalf("status %d", code)
+	}
+	if resp.Warehouses == nil || len(resp.Warehouses) != 0 {
+		t.Fatalf("empty fleet must serialize as [], got %+v", resp.Warehouses)
+	}
+	if resp.ConfigGeneration != 0 {
+		t.Fatalf("empty fleet generation must be 0, got %d", resp.ConfigGeneration)
+	}
+}
+
+func TestDiscoveryTransientErrorsFailTheRequest(t *testing.T) {
+	// Transient store failures must 500 the WHOLE request — a polling
+	// consumer keeps its last-known-good state. Serving a 200 with a
+	// tenant's team silently absent is indistinguishable from removal and,
+	// after consumer-side damping, silently stops ingestion for the team.
+	for name, breakStore := range map[string]func(*fakeStore){
+		"list_warehouses": func(s *fakeStore) { s.listWarehousesErr = errors.New("db down") },
+		"list_org_teams":  func(s *fakeStore) { s.listOrgTeamsErr = errors.New("db down") },
+		"latest_change":   func(s *fakeStore) { s.latestChangeErr = errors.New("db down") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := newFakeStore()
+			seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, time.Now())
+			breakStore(s)
+			router := newTestRouter(s)
+			for _, path := range []string{"/api/v1/warehouses", "/api/v1/warehouse-team-ids"} {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				if w.Code != http.StatusInternalServerError {
+					t.Errorf("%s: want 500 on transient store error, got %d", path, w.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestTeamIDsProjection(t *testing.T) {
+	s := newFakeStore()
+	now := time.Now()
+	seedWarehouse(s, "org-a", i64(50689), configstore.ManagedWarehouseStateReady, now)
+	seedWarehouse(s, "org-b", i64(2), configstore.ManagedWarehouseStateReady, now)
+	// Resharding teams stay included: upstream ingestion keeps running
+	// during a duckling reshard; dropping the team here would (post-damping)
+	// silently stop ingesting it.
+	seedWarehouse(s, "org-c", i64(81505), configstore.ManagedWarehouseStateResharding, now)
+	// Duplicate team across orgs must not duplicate in the array.
+	seedWarehouse(s, "org-dup", i64(2), configstore.ManagedWarehouseStateReady, now)
+	// A warehouse with no team rows contributes nothing (and is counted by
+	// the shared assembly — see TestListWarehousesBrokenTeamRows).
+	seedWarehouse(s, "org-noteams", nil, configstore.ManagedWarehouseStateReady, now)
+	// Excluded states contribute nothing.
+	seedWarehouse(s, "org-pending", i64(7), configstore.ManagedWarehouseStatePending, now)
+	// DISABLED teams stay in the projection: enabled is duckgres's
+	// query-serving switch (migration 000024), not an ingestion signal —
+	// see TestDisabledTeamStaysInProjection.
+	seedTeam(s, "org-a", configstore.OrgTeam{TeamID: 424242, SchemaName: "disabled_team", Enabled: false, UpdatedAt: now})
+
+	var ids []int64
+	if code := getJSON(t, newTestRouter(s), "/api/v1/warehouse-team-ids", &ids); code != http.StatusOK {
+		t.Fatalf("status %d", code)
+	}
+	want := []int64{2, 50689, 81505, 424242}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids = %v, want %v (sorted, deduped)", ids, want)
+		}
+	}
+}
+
+func TestDisabledTeamStaysInProjection(t *testing.T) {
+	// enabled is the per-team QUERY-SERVING switch (migration 000024) —
+	// not an ingestion signal. A disabled team must stay in the values
+	// projection (else a serving hold silently stops its ingestion:
+	// permanent event loss) and in the full listing with the flag.
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, time.Now())
+	seedTeam(s, "org-a", configstore.OrgTeam{TeamID: 3, SchemaName: "held_team", Enabled: false})
+
+	var ids []int64
+	getJSON(t, newTestRouter(s), "/api/v1/warehouse-team-ids", &ids)
+	found := false
+	for _, id := range ids {
+		if id == 3 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("disabled team must stay in the values projection, got %v", ids)
+	}
+}
+
+func TestDisabledTeamServedFlagged(t *testing.T) {
+	// enabled=false flows through the FULL listing as an informational
+	// flag; consumers derive nothing destructive from it.
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, time.Now())
+	seedTeam(s, "org-a", configstore.OrgTeam{TeamID: 3, SchemaName: "paused_team", Enabled: false})
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	if len(resp.Warehouses[0].Teams) != 2 {
+		t.Fatalf("disabled team must stay in the full listing, got %+v", resp.Warehouses[0].Teams)
+	}
+	for _, tm := range resp.Warehouses[0].Teams {
+		if tm.TeamID == 3 && tm.Enabled {
+			t.Fatal("team 3 must carry enabled=false")
+		}
+	}
+}
+
+func TestResolvedTableNames(t *testing.T) {
+	// The CP serves RESOLVED table locations — the derivation from
+	// schema_name + grandfathered overrides happens once, in
+	// resolveTeamTables, so consumers never guess the qualification rule.
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", nil, configstore.ManagedWarehouseStateReady, time.Now())
+	seedTeam(s, "org-a", configstore.OrgTeam{
+		TeamID:          2,
+		SchemaName:      "posthog",
+		Enabled:         true,
+		IsBillingTeam:   boolPtrD(true),
+		EventsTableName: strPtrD("legacy_events"),
+	})
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	tm := resp.Warehouses[0].Teams[0]
+	// Override resolves within the team's schema; unset fields derive.
+	if tm.EventsTable != "posthog.legacy_events" || tm.PersonsTable != "posthog.persons" || tm.DataImportsSchema != "posthog_data_imports" {
+		t.Fatalf("resolved table names wrong: %+v", tm)
+	}
+}
+
+func TestConfigGenerationAdvancesOnTeamChange(t *testing.T) {
+	// A team-row edit (enable/disable, schema repair) is a routing change a
+	// poller must not skip — the generation must cover duckgres_org_teams.
+	s := newFakeStore()
+	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	seedWarehouse(s, "org-a", i64(2), configstore.ManagedWarehouseStateReady, older)
+	s.teams["org-a"][2].UpdatedAt = newer
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	if resp.ConfigGeneration != newer.Unix() {
+		t.Fatalf("config_generation = %d, want %d (team-row updated_at)", resp.ConfigGeneration, newer.Unix())
+	}
+}
+
+func TestTeamIDsEmptyFleetIsEmptyArray(t *testing.T) {
+	// millpond's include-values source refuses empty arrays — but the
+	// ENDPOINT must still serialize [] (not null) for an empty fleet; the
+	// refusal is the consumer's decision.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/warehouse-team-ids", nil)
+	w := httptest.NewRecorder()
+	newTestRouter(newFakeStore()).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	if body := w.Body.String(); body != "[]" {
+		t.Fatalf("empty fleet must serialize as [], got %q", body)
+	}
+}

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"gorm.io/gorm"
@@ -357,4 +358,20 @@ func (s *gormStore) DeleteOrgTeam(orgID string, teamID int64) (*configstore.OrgT
 		return nil, err
 	}
 	return res, nil
+}
+
+// ListWarehousesByStates delegates to the config store (discovery endpoints).
+func (s *gormStore) ListWarehousesByStates(states []configstore.ManagedWarehouseProvisioningState) ([]configstore.ManagedWarehouse, error) {
+	return s.cs.ListWarehousesByStates(states)
+}
+
+// ListOrgTeamsByOrgIDs delegates to the config store (discovery endpoints).
+func (s *gormStore) ListOrgTeamsByOrgIDs(orgIDs []string) ([]configstore.OrgTeam, error) {
+	return s.cs.ListOrgTeamsByOrgIDs(orgIDs)
+}
+
+// LatestConfigChange delegates to the config store (discovery endpoints).
+func (s *gormStore) LatestConfigChange() (time.Time, error) {
+	return s.cs.LatestConfigChange()
+
 }

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/tests/configstore/org_teams_postgres_test.go
+++ b/tests/configstore/org_teams_postgres_test.go
@@ -243,3 +243,153 @@ func TestProvisionWithTeamIDAndSchemaNamePostgres(t *testing.T) {
 		t.Fatal("first team must be enabled")
 	}
 }
+
+// TestCreateOrgTeamDisabledPostgres pins the gorm default-tag pitfall: a team
+// created with enabled=false must be STORED as false — gorm omits zero-valued
+// default-tagged fields from the INSERT unless the create forces every
+// column, and the DB default TRUE would silently enable the team (serving it
+// on the query path and, via discovery, keeping it in ingest include-lists).
+func TestCreateOrgTeamDisabledPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	seedOrg(t, store, "held")
+	pstore := provisioning.NewGormStore(store)
+
+	if _, err := pstore.UpsertOrgTeam("held", configstore.OrgTeamUpsert{
+		TeamID:     5,
+		SchemaName: "team_5",
+		Enabled:    boolPtr(false),
+	}); err != nil {
+		t.Fatalf("create disabled team: %v", err)
+	}
+	if got := readTeam(t, store, "held", 5); got.Enabled {
+		t.Fatal("team created with enabled=false was stored as enabled=true (gorm default-tag pitfall)")
+	}
+}
+
+// TestListOrgTeamsByOrgIDsPostgres pins the discovery batch fetch: only the
+// requested orgs, deterministic (org_id, team_id) order.
+func TestListOrgTeamsByOrgIDsPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	pstore := provisioning.NewGormStore(store)
+	for _, org := range []string{"orga", "orgb", "orgc"} {
+		seedOrg(t, store, org)
+	}
+	for _, seed := range []struct {
+		org  string
+		team int64
+	}{{"orga", 9}, {"orga", 2}, {"orgb", 5}, {"orgc", 1}} {
+		if _, err := pstore.UpsertOrgTeam(seed.org, configstore.OrgTeamUpsert{
+			TeamID:     seed.team,
+			SchemaName: "s" + seed.org + "_" + string(rune('0'+seed.team)),
+		}); err != nil {
+			t.Fatalf("seed team %s/%d: %v", seed.org, seed.team, err)
+		}
+	}
+
+	teams, err := store.ListOrgTeamsByOrgIDs([]string{"orga", "orgb"})
+	if err != nil {
+		t.Fatalf("ListOrgTeamsByOrgIDs: %v", err)
+	}
+	var got []string
+	for _, tm := range teams {
+		got = append(got, tm.OrgID+"/"+string(rune('0'+tm.TeamID)))
+	}
+	want := []string{"orga/2", "orga/9", "orgb/5"}
+	if len(got) != len(want) {
+		t.Fatalf("teams = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("teams = %v, want %v (ordered org_id, team_id; only requested orgs)", got, want)
+		}
+	}
+}
+
+// TestLatestConfigChangeCoversTeamsPostgres pins the discovery change marker
+// against the real store: a team-row edit advances it, and — the case a
+// plain DELETE would hide — deleting a NON-billing team advances it too
+// (DeleteOrgTeamTx touches the parent org row in the same transaction).
+func TestLatestConfigChangeCoversTeamsPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	seedOrg(t, store, "acme")
+	pstore := provisioning.NewGormStore(store)
+
+	if _, err := pstore.UpsertOrgTeam("acme", configstore.OrgTeamUpsert{TeamID: 1, SchemaName: "team_1"}); err != nil {
+		t.Fatalf("seed team 1: %v", err)
+	}
+	if err := store.DB().Transaction(func(tx *gorm.DB) error {
+		return configstore.SetOrgBillingTeamTx(tx, "acme", 1)
+	}); err != nil {
+		t.Fatalf("set billing: %v", err)
+	}
+	if _, err := pstore.UpsertOrgTeam("acme", configstore.OrgTeamUpsert{TeamID: 2, SchemaName: "team_2"}); err != nil {
+		t.Fatalf("seed team 2: %v", err)
+	}
+
+	before, err := store.LatestConfigChange()
+	if err != nil {
+		t.Fatalf("LatestConfigChange (before): %v", err)
+	}
+
+	// A team-row UPDATE advances the marker.
+	time.Sleep(1100 * time.Millisecond) // unix-second granularity on the wire; updated_at itself is finer
+	if _, err := pstore.UpsertOrgTeam("acme", configstore.OrgTeamUpsert{TeamID: 2, SchemaName: "team_2_repointed"}); err != nil {
+		t.Fatalf("update team 2: %v", err)
+	}
+	afterUpdate, err := store.LatestConfigChange()
+	if err != nil {
+		t.Fatalf("LatestConfigChange (after update): %v", err)
+	}
+	if !afterUpdate.After(before) {
+		t.Fatalf("marker did not advance on team update: before=%v after=%v", before, afterUpdate)
+	}
+
+	// Deleting a NON-billing team must advance it as well — the removal is
+	// exactly the signal a change-marker poller must not skip.
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := pstore.DeleteOrgTeam("acme", 2); err != nil {
+		t.Fatalf("delete team 2: %v", err)
+	}
+	afterDelete, err := store.LatestConfigChange()
+	if err != nil {
+		t.Fatalf("LatestConfigChange (after delete): %v", err)
+	}
+	if !afterDelete.After(afterUpdate) {
+		t.Fatalf("marker did not advance on non-billing team delete: afterUpdate=%v afterDelete=%v", afterUpdate, afterDelete)
+	}
+}
+
+// TestUpsertOrgTeamRejectsQualifiedOverridesPostgres pins the bare-name
+// contract: legacy overrides are bare identifiers within the team's schema
+// (see resolveTeamTables in provisioning/discovery.go); a schema-qualified
+// name stored here would be silently ambiguous to every discovery consumer,
+// so the upsert rejects it at write time.
+func TestUpsertOrgTeamRejectsQualifiedOverridesPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	seedOrg(t, store, "bare")
+	pstore := provisioning.NewGormStore(store)
+
+	_, err := pstore.UpsertOrgTeam("bare", configstore.OrgTeamUpsert{
+		TeamID:          1,
+		SchemaName:      "team_1",
+		EventsTableName: strPtr("posthog.legacy_events"),
+	})
+	if err == nil {
+		t.Fatal("schema-qualified events_table_name must be rejected")
+	}
+	// Bare override + explicit clear ("") both pass.
+	if _, err := pstore.UpsertOrgTeam("bare", configstore.OrgTeamUpsert{
+		TeamID:          1,
+		SchemaName:      "team_1",
+		EventsTableName: strPtr("legacy_events"),
+	}); err != nil {
+		t.Fatalf("bare override rejected: %v", err)
+	}
+	if _, err := pstore.UpsertOrgTeam("bare", configstore.OrgTeamUpsert{
+		TeamID:          1,
+		SchemaName:      "team_1",
+		EventsTableName: strPtr(""),
+	}); err != nil {
+		t.Fatalf("clear sentinel rejected: %v", err)
+	}
+}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1429,6 +1429,79 @@ org_teams_crud() { # org billing_team_id
   log "org teams OK: list/upsert/grandfather/409/delete rules on $org"
 }
 
+# ---- discovery endpoints (external-writer tenant listing) -------------------
+# GET /warehouses + GET /warehouse-team-ids are the read-only discovery
+# surface external writers poll (viaduck destination discovery, millpond's
+# include-values source). Contract asserted against the real config store:
+#   1. Both provisioned orgs (cnpg + ext) appear in /warehouses with
+#      state=ready, writable=true, and a teams array carrying the org's
+#      billing team (duckgres_org_teams row) with its conventional
+#      team_<id> schema and enabled=true. (org_teams_crud runs before this
+#      on the EXT org and leaves it with exactly its billing team; the CNPG
+#      org may carry extra demoted rows from earlier legs — the assertions
+#      select by team_id so extras are tolerated.)
+#   2. The ext org's metadata_store block round-trips endpoint/database —
+#      cnpg rows carry only the kind today (CR-status backfill pending), so
+#      only kind is asserted there. No password-ish key may appear anywhere
+#      in the payload outside password_secret_ref (secret REFS only).
+#   3. /warehouse-team-ids is a bare sorted JSON array containing both
+#      provisioned team ids — the exact shape millpond's poller consumes.
+#      An erroneous omission here silently stops a team's ingestion after
+#      consumer-side damping, which is why the transient-error contract
+#      (store failure => 500, never a 200 with a team absent) matters; that
+#      split is pinned by unit tests (discovery_test.go).
+discovery_endpoints() { # cnpg_org ext_org
+  cnpg_org="$1"; ext_org="$2"
+  log "discovery: /warehouses + /warehouse-team-ids list $cnpg_org/$ext_org"
+
+  curl -fsS -H "$H" "$API/api/v1/warehouses" > /tmp/discovery_out     || fail "discovery: GET /warehouses failed"
+
+  for org in "$cnpg_org" "$ext_org"; do
+    state="$(jq -r --arg o "$org" '.warehouses[] | select(.org_id == $o) | .state' /tmp/discovery_out)"
+    [ "$state" = "ready" ]       || fail "discovery: $org state = '$state' want 'ready': $(cat /tmp/discovery_out)"
+    writable="$(jq -r --arg o "$org" '.warehouses[] | select(.org_id == $o) | .writable' /tmp/discovery_out)"
+    [ "$writable" = "true" ]       || fail "discovery: $org writable = '$writable' want 'true'"
+  done
+  for pair in "$cnpg_org:$CNPG_DEFAULT_TEAM_ID" "$ext_org:$EXT_DEFAULT_TEAM_ID"; do
+    org="${pair%%:*}"; team="${pair##*:}"
+    jq -e --arg o "$org" --argjson t "$team" \
+      '.warehouses[] | select(.org_id == $o) | .teams
+       | map(select(.team_id==$t and .schema_name=="team_\($t)" and .enabled==true)) | length == 1' \
+      /tmp/discovery_out >/dev/null \
+      || fail "discovery: $org must carry billing team $team with schema team_$team, enabled: $(cat /tmp/discovery_out)"
+    # Resolved table names: no legacy overrides on these teams, so the CP
+    # must serve the derived names (the derivation lives in the CP, not in
+    # every consumer).
+    jq -e --arg o "$org" --argjson t "$team" \
+      '.warehouses[] | select(.org_id == $o) | .teams[] | select(.team_id==$t)
+       | .events_table == "team_\($t).events" and .persons_table == "team_\($t).persons" and .data_imports_schema == "team_\($t)_data_imports"' \
+      /tmp/discovery_out >/dev/null \
+      || fail "discovery: $org team $team resolved table names wrong: $(cat /tmp/discovery_out)"
+  done
+
+  # Ext metadata_store round-trip (the row carries real connection details
+  # for external stores); cnpg asserts kind only until the CR-status
+  # backfill lands.
+  ep="$(jq -r --arg o "$ext_org" '.warehouses[] | select(.org_id == $o) | .metadata_store.endpoint' /tmp/discovery_out)"
+  [ "$ep" = "$EXT_RDS_ENDPOINT" ]     || fail "discovery: $ext_org metadata_store.endpoint = '$ep' want '$EXT_RDS_ENDPOINT'"
+  kind="$(jq -r --arg o "$cnpg_org" '.warehouses[] | select(.org_id == $o) | .metadata_store.kind' /tmp/discovery_out)"
+  [ "$kind" = "cnpg-shard" ]     || fail "discovery: $cnpg_org metadata_store.kind = '$kind' want 'cnpg-shard'"
+
+  # No password material: the only key containing "password" anywhere in the
+  # payload must be password_secret_ref (k8s Secret reference, not material).
+  badkeys="$(jq -r '[.. | objects | keys[] | select(test("password")) | select(. != "password_secret_ref")] | unique | join(",")' /tmp/discovery_out)"
+  [ -z "$badkeys" ]     || fail "discovery: payload carries password-ish keys: $badkeys"
+
+  # Values projection: bare sorted array containing both team ids.
+  curl -fsS -H "$H" "$API/api/v1/warehouse-team-ids" > /tmp/discovery_ids     || fail "discovery: GET /warehouse-team-ids failed"
+  jq -e 'type == "array"' /tmp/discovery_ids >/dev/null     || fail "discovery: /warehouse-team-ids must be a bare JSON array: $(cat /tmp/discovery_ids)"
+  for team in "$CNPG_DEFAULT_TEAM_ID" "$EXT_DEFAULT_TEAM_ID"; do
+    jq -e --argjson t "$team" 'index($t) != null' /tmp/discovery_ids >/dev/null       || fail "discovery: /warehouse-team-ids missing team $team: $(cat /tmp/discovery_ids)"
+  done
+  jq -e '. == sort' /tmp/discovery_ids >/dev/null     || fail "discovery: /warehouse-team-ids must be sorted: $(cat /tmp/discovery_ids)"
+  log "discovery OK: both orgs listed writable with their billing team rows + resolved table names; team-ids array carries both teams"
+}
+
 # ---- user persistent secrets ------------------------------------------------
 # CREATE PERSISTENT SECRET must survive across sessions: worker pods are
 # ephemeral, so the CP intercepts the statement, stores it encrypted in the
@@ -3251,6 +3324,7 @@ lane_ext() { # external-RDS metadata backend + org default profile
   # Team CRUD on the ext org (no other test mutates its team rows); ends with
   # the org back at exactly its provisioned billing team.
   org_teams_crud "$EXT" "$EXT_DEFAULT_TEAM_ID"
+  discovery_endpoints "$CNPG" "$EXT"
 }
 
 main() {


### PR DESCRIPTION
## What

Two read-only endpoints on the internal provisioning API — the machine-facing "which tenants exist and where do I write" surface for external writers (viaduck destination discovery; millpond's include-values poller, shipped in millpond#107):

- **`GET /api/v1/warehouses`** — per ready/resharding warehouse: org_id, duckling name, state, `writable` fence flag (false while resharding — a resharding warehouse is *listed*, not hidden, because vanishing reads as tenant removal downstream), teams, metadata-store connection with a k8s **SecretRef** (no plaintext credentials anywhere in the payload), bucket, and `config_generation`.
- **`GET /api/v1/warehouse-team-ids`** — bare sorted deduped JSON array of team ids, the values-only shape millpond's poller consumes.

## Teams (reworked for #969/#970's `duckgres_org_teams`)

Teams are the org's team rows, served with **resolved table locations**: `events_table`/`persons_table` = `<schema>.<override-or-derived>`, `data_imports_schema` = override-or-`<schema>_data_imports`. The derivation lives once, in `resolveTeamTables`; legacy overrides are **bare identifiers** (never schema-qualified), now *enforced* at every write surface by the new `ValidateOrgTeamTableName` (provisioning upsert + admin PUT), with the admin UI placeholders corrected — they previously taught the qualified form the contract forbids.

**`enabled` is passed through as information only.** It is the per-team query-serving switch (migration 000024's definition, not yet enforced on the serve path), *not* an ingestion signal — disabled teams stay in both endpoints. Deriving "stop ingesting" from "stop serving queries" would turn a serving hold into permanent event loss; the only ingestion-stop signal is row absence. `is_billing_team`/`backfill_enabled` are deliberately not served (billing internals / not a stream-start input; adding later is wire-compatible).

## Error contract (the load-bearing part)

Transient store failures fail the **whole request** — a polling consumer keeps its last-known-good state; a 200 with a team silently absent is never served (after consumer-side damping that would silently stop a team's ingestion). Only a warehouse with zero team rows degrades, per-warehouse, to an empty teams array, logged and counted on `duckgres_discovery_broken_team_rows_total{reason}`. Both endpoints project from one shared assembly.

`config_generation` is an opaque change token: max `updated_at` across **all** warehouse+org+org-team rows regardless of state, read *before* the data queries. Compare for equality only.

## Bugs found in merged code, fixed here (postgres regression tests for each)

- **Creating a team with `enabled:false` stored TRUE** on *both* the provisioning upsert and admin create paths — gorm omits zero-valued default-tagged fields from INSERTs, so the DB default won; the admin path additionally had gorm's RETURNING write-back masking the caller's intent. Proven by mutation against real postgres.
- **Deleting a non-billing team was invisible to the change token** (a plain DELETE leaves no `updated_at` behind) — `DeleteOrgTeamTx` now touches the parent org row (DB-clock `now()`) in the same transaction; the coupling is documented on `Org.UpdatedAt` and `LatestConfigChange` and pinned by `TestLatestConfigChangeCoversTeamsPostgres`.

## Known gap (documented in code, asserted as-is in the harness)

cnpg-shard rows carry only the metadata-store **kind** — endpoint/db/user + SecretRef have no production writer; truth lives in the Duckling CR status until the provisioner backfills the row on Ready (follow-up: sync in the provisioner watch, guarded to `state == ready` so the reshard runner keeps exclusive column ownership mid-flip). Team-level consumers are unaffected.

## Testing

Authored with an agent; **three adversarial review rounds** (lead-QE + principal-SWE agents ×2, then a scoped final pass over the fix-round code) — findings incorporated include the error-channel split, the resolved-name contract, the state-classification tripwire (`TestDiscoveryStateClassification`: the state enum is open, and an unclassified new state would read as fleet-wide tenant removal), the two merged-code bugs above, and a clock-source fix (`gorm.Expr("now()")` vs CP-pod time) on the generation touch. Checks actually run:
- `just test-controlplane`, `just test-configstore-integration` (docker postgres), `just test-controlplane-k8s` — all pass
- `golangci-lint` 0 issues; `gofmt` clean; harness `bash -n` clean
- New postgres-backed tests: create-disabled (both surfaces), batch-fetch ordering, generation advance on team update *and* delete, qualified-override rejection
- e2e: `discovery_endpoints` assertion in `tests/mw-dev/e2e/harness.sh` (billing team with `team_<id>` schema + resolved names, ext metadata round-trip, cnpg kind-only, no password-ish keys, bare sorted team-ids array) — runs in the per-PR mw-dev job
- UI change is placeholder-text only; no test asserts placeholders

## Follow-ups

- Provisioner CR-status→row backfill for cnpg connection details.
- CLAUDE.md gained a Discovery Endpoints section per the repo's doc-sync rule.