### PR TITLE
Add session admission saturation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ A PostgreSQL wire protocol compatible server backed by DuckDB. Connect with any 
 
 Duckgres exposes Prometheus metrics on `:9090/metrics`. The metrics port is currently fixed at 9090 and cannot be changed via configuration.
 
+See [docs/metrics.md](docs/metrics.md) for exact request-path boundaries,
+labels, aggregation rules, PromQL examples, and admission metric migration.
+
 | Metric | Type | Description |
 |--------|------|-------------|
 | `duckgres_connections_open` | Gauge | Number of currently open client connections |
@@ -77,17 +80,19 @@ Duckgres exposes Prometheus metrics on `:9090/metrics`. The metrics port is curr
 | `duckgres_control_plane_worker_acquire_seconds` | Histogram | Time spent acquiring a worker for a new session |
 | `duckgres_control_plane_worker_queue_depth` | Gauge | Approximate number of session requests waiting on worker acquisition |
 | `duckgres_control_plane_worker_spawn_seconds` | Histogram | Time spent spawning and health-checking a new worker |
-| `duckgres_org_connection_admission_duration_seconds{outcome}` | Histogram | DB-backed request-owned org connection admission evaluation latency by outcome |
-| `duckgres_org_connection_admission_queue_depth` | Histogram | Pending org connection queue depth observed during admission evaluation |
-| `duckgres_org_connection_admission_user_queues` | Histogram | Number of per-user queue heads considered during admission evaluation |
-| `duckgres_org_connection_admission_attempts_total{outcome}` | Counter | Total org connection admission evaluations by outcome, including terminal `rejected_org_vcpu` / `rejected_user_vcpu` and `ineligible_user` for a missing or disabled configured user |
-| `duckgres_org_connection_admission_user_limit_skips_total` | Counter | Per-user queue heads skipped because that user was at its vCPU limit |
-| `duckgres_org_connection_admission_ineligible_user_skips_total` | Counter | Per-user queue heads skipped because that configured user was missing or disabled |
-| `duckgres_org_connection_reclaim_pending` | Gauge | Activated org connection cleanup intents awaiting or executing exact database reclamation |
-| `duckgres_org_connection_reclaim_attempts_total{outcome}` | Counter | Exact org connection cleanup attempts by `success` or `error` outcome |
-| `duckgres_org_connection_reclaim_reservations_in_use` | Gauge | Bounded cleanup-ownership slots held by queued admissions, live leases, and pending cleanup |
-| `duckgres_org_connection_reclaim_reservation_capacity` | Gauge | Cleanup-ownership slot capacity for this control-plane process (4096 per reclaimer by default) |
-| `duckgres_org_connection_reclaim_reservation_rejections_total{reason}` | Counter | Reservations rejected before durable enqueue because capacity was `full`, the reclaimer was `closed`, or the exact reference was a `duplicate` |
+| `duckgres_session_admission_evaluation_duration_seconds{decision,reason}` | Histogram | Latency of one DB-backed admission poll for the polling request |
+| `duckgres_session_admission_evaluations_total{decision,reason}` | Counter | Admission request polls; repeated polls are distinct evaluations |
+| `duckgres_session_admission_wait_seconds{org,outcome,reason}` | Histogram | End-to-end wait for one successfully enqueued admission request |
+| `duckgres_session_admission_requests_total{org,outcome,reason}` | Counter | Exactly one terminal event per successfully enqueued admission request |
+| `duckgres_session_admission_queue_depth{org}` | Gauge | Local callers waiting after successful durable enqueue; sum across replicas |
+| `duckgres_session_admission_active_vcpus{org}` | Gauge | Requested vCPUs held by local live lease handles; cleanup-pending durable rows are excluded |
+| `duckgres_session_admission_limit_vcpus{org}` | Gauge | Config-reconciled effective org cap for active org stacks; zero means unlimited, max across replicas |
+| `duckgres_session_admission_reclaim_pending` | Gauge | Activated cleanup intents awaiting or executing exact database reclamation |
+| `duckgres_session_admission_reclaim_attempts_total{outcome}` | Counter | Exact cleanup attempts by `success` or `error` outcome |
+| `duckgres_session_admission_reclaim_reservations_in_use` | Gauge | Cleanup-ownership slots held before enqueue, while queued or live, and during pending cleanup |
+| `duckgres_session_admission_reclaim_reservation_capacity` | Gauge | Cleanup-ownership slot capacity for this control-plane process (4096 per reclaimer by default) |
+| `duckgres_session_admission_reclaim_reservation_rejections_total{reason}` | Counter | Reservations rejected because capacity was `full`, the reclaimer was `closed`, or the exact reference was a `duplicate` |
+| `duckgres_session_start_duration_seconds{org,protocol,outcome}` | Histogram | Authenticated PostgreSQL session bootstrap through flushed `ReadyForQuery` |
 | `duckgres_flight_rpc_duration_seconds{method}` | Histogram | Flight ingress RPC duration by method |
 | `duckgres_flight_ingress_sessions_total{outcome}` | Counter | Flight ingress session outcomes (`created|reused|auth_failed|rate_limited|create_failed|token_invalid`) |
 | `duckgres_flight_sessions_reaped_total{trigger}` | Counter | Number of Flight auth sessions reaped (`trigger=periodic|forced`) |

--- a/controlplane/admission_metrics.go
+++ b/controlplane/admission_metrics.go
@@ -1,0 +1,116 @@
+package controlplane
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var sessionAdmissionWaitHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_session_admission_wait_seconds",
+	Help:    "Time a successfully enqueued session admission request waited for a terminal result, partitioned by org, outcome, and retained blocking reason.",
+	Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+}, []string{"org", "outcome", "reason"})
+
+var sessionAdmissionRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_session_admission_requests_total",
+	Help: "Total successfully enqueued session admission requests by terminal outcome and retained blocking reason.",
+}, []string{"org", "outcome", "reason"})
+
+var sessionAdmissionQueueDepthGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_session_admission_queue_depth",
+	Help: "Current session admission callers waiting in this control-plane process; sum by org across replicas for cluster-wide logical queue depth.",
+}, []string{"org"})
+
+var sessionAdmissionActiveVCPUsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_session_admission_active_vcpus",
+	Help: "Requested vCPUs held by live local admission lease handles; cleanup-pending durable rows are excluded.",
+}, []string{"org"})
+
+var sessionAdmissionLimitVCPUsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_session_admission_limit_vcpus",
+	Help: "Effective org session-admission vCPU limit for active org stacks, reconciled from this control-plane process's current config snapshot; zero means unlimited and max by org collapses replica duplication.",
+}, []string{"org"})
+
+func observeSessionAdmissionTerminal(org, outcome, reason string, wait time.Duration) {
+	if wait < 0 {
+		wait = 0
+	}
+	outcome = normalizedSessionAdmissionOutcome(outcome)
+	reason = normalizedSessionAdmissionReason(reason)
+	sessionAdmissionWaitHistogram.WithLabelValues(org, outcome, reason).Observe(wait.Seconds())
+	sessionAdmissionRequestsCounter.WithLabelValues(org, outcome, reason).Inc()
+}
+
+func normalizedSessionAdmissionOutcome(outcome string) string {
+	switch outcome {
+	case "granted", "rejected", "timeout", "canceled", "error":
+		return outcome
+	default:
+		return "error"
+	}
+}
+
+func normalizedSessionAdmissionReason(reason string) string {
+	switch reason {
+	case "", "none":
+		return "none"
+	case "org_vcpu", "user_vcpu", "org_user_vcpu", "user_ineligible", "resharding", "fifo", "store_error", "mixed":
+		return reason
+	default:
+		return "store_error"
+	}
+}
+
+type sessionAdmissionReasons struct {
+	firstNonVCPU string
+	mixedNonVCPU bool
+	orgVCPU      bool
+	userVCPU     bool
+}
+
+func (r *sessionAdmissionReasons) add(reason string) {
+	reason = normalizedSessionAdmissionReason(reason)
+	if reason == "none" {
+		return
+	}
+	switch reason {
+	case "org_vcpu":
+		r.orgVCPU = true
+		return
+	case "user_vcpu":
+		r.userVCPU = true
+		return
+	case "org_user_vcpu":
+		r.orgVCPU = true
+		r.userVCPU = true
+		return
+	}
+	if r.firstNonVCPU == "" {
+		r.firstNonVCPU = reason
+		return
+	}
+	if r.firstNonVCPU != reason {
+		r.mixedNonVCPU = true
+	}
+}
+
+func (r sessionAdmissionReasons) value() string {
+	if r.orgVCPU && r.userVCPU {
+		return "org_user_vcpu"
+	}
+	if r.orgVCPU {
+		return "org_vcpu"
+	}
+	if r.userVCPU {
+		return "user_vcpu"
+	}
+	if r.mixedNonVCPU {
+		return "mixed"
+	}
+	if r.firstNonVCPU == "" {
+		return "none"
+	}
+	return r.firstNonVCPU
+}

--- a/controlplane/admission_metrics_test.go
+++ b/controlplane/admission_metrics_test.go
@@ -1,0 +1,33 @@
+package controlplane
+
+import "testing"
+
+func TestSessionAdmissionReasonsValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		reasons []string
+		want    string
+	}{
+		{name: "none", want: "none"},
+		{name: "single non-vCPU reason", reasons: []string{"fifo"}, want: "fifo"},
+		{name: "repeated non-vCPU reason", reasons: []string{"fifo", "fifo"}, want: "fifo"},
+		{name: "mixed non-vCPU reasons", reasons: []string{"fifo", "resharding"}, want: "mixed"},
+		{name: "org vCPU takes precedence", reasons: []string{"fifo", "org_vcpu", "resharding"}, want: "org_vcpu"},
+		{name: "user vCPU takes precedence", reasons: []string{"fifo", "user_vcpu", "store_error"}, want: "user_vcpu"},
+		{name: "both vCPU limits", reasons: []string{"org_vcpu", "fifo", "user_vcpu"}, want: "org_user_vcpu"},
+		{name: "both vCPU limits in reverse order", reasons: []string{"user_vcpu", "resharding", "org_vcpu"}, want: "org_user_vcpu"},
+		{name: "unknown reason is bounded", reasons: []string{"future_dynamic_reason"}, want: "store_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sessionAdmissionReasons
+			for _, reason := range tt.reasons {
+				got.add(reason)
+			}
+			if value := got.value(); value != tt.want {
+				t.Fatalf("value() = %q, want %q", value, tt.want)
+			}
+		})
+	}
+}

--- a/controlplane/admission_reclaimer.go
+++ b/controlplane/admission_reclaimer.go
@@ -36,23 +36,23 @@ var (
 	errAdmissionReclaimerDuplicateReservation = errors.New("admission reclaimer reference is already reserved")
 
 	orgConnectionReclaimPendingGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "duckgres_org_connection_reclaim_pending",
-		Help: "Number of org connection admission cleanup intents retained by this control-plane replica.",
+		Name: "duckgres_session_admission_reclaim_pending",
+		Help: "Number of activated session admission cleanup intents retained by this control-plane replica.",
 	})
 	orgConnectionReclaimAttemptsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "duckgres_org_connection_reclaim_attempts_total",
-		Help: "Org connection admission cleanup attempts by outcome.",
+		Name: "duckgres_session_admission_reclaim_attempts_total",
+		Help: "Session admission cleanup attempts by outcome.",
 	}, []string{"outcome"})
 	orgConnectionReclaimReservationsInUseGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "duckgres_org_connection_reclaim_reservations_in_use",
-		Help: "Number of admission cleanup reservations held by this control-plane process, including live leases and pending cleanup.",
+		Name: "duckgres_session_admission_reclaim_reservations_in_use",
+		Help: "Number of admission cleanup reservations held before enqueue, while queued, by live leases, or by pending cleanup in this control-plane process.",
 	})
 	orgConnectionReclaimReservationCapacityGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "duckgres_org_connection_reclaim_reservation_capacity",
+		Name: "duckgres_session_admission_reclaim_reservation_capacity",
 		Help: "Total admission cleanup reservation capacity of reclaimers in this control-plane process.",
 	})
 	orgConnectionReclaimReservationRejectionsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "duckgres_org_connection_reclaim_reservation_rejections_total",
+		Name: "duckgres_session_admission_reclaim_reservation_rejections_total",
 		Help: "Admission cleanup reservation attempts rejected before durable admission work, by reason.",
 	}, []string{"reason"})
 )

--- a/controlplane/admission_reclaimer_test.go
+++ b/controlplane/admission_reclaimer_test.go
@@ -13,8 +13,55 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func TestAdmissionReclaimerMetricFamiliesUseCanonicalNames(t *testing.T) {
+	orgConnectionReclaimAttemptsCounter.WithLabelValues(admissionReclaimAttemptOutcomeSuccess)
+	orgConnectionReclaimReservationRejectionsCounter.WithLabelValues(admissionReclaimReservationRejectFull)
+
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(
+		orgConnectionReclaimPendingGauge,
+		orgConnectionReclaimAttemptsCounter,
+		orgConnectionReclaimReservationsInUseGauge,
+		orgConnectionReclaimReservationCapacityGauge,
+		orgConnectionReclaimReservationRejectionsCounter,
+	)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather reclaimer metrics: %v", err)
+	}
+
+	want := map[string]bool{
+		"duckgres_session_admission_reclaim_pending":                      false,
+		"duckgres_session_admission_reclaim_attempts_total":               false,
+		"duckgres_session_admission_reclaim_reservations_in_use":          false,
+		"duckgres_session_admission_reclaim_reservation_capacity":         false,
+		"duckgres_session_admission_reclaim_reservation_rejections_total": false,
+	}
+	for _, family := range families {
+		if _, ok := want[family.GetName()]; ok {
+			want[family.GetName()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("canonical reclaimer metric %q was not registered", name)
+		}
+	}
+
+	defaultFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather default metrics registry: %v", err)
+	}
+	for _, family := range defaultFamilies {
+		if strings.HasPrefix(family.GetName(), "duckgres_org_connection_reclaim_") {
+			t.Fatalf("retired reclaimer metric %q is still registered", family.GetName())
+		}
+	}
+}
 
 func TestAdmissionReclaimerSubmitRetainsAndDeduplicates(t *testing.T) {
 	entered := make(chan struct{}, 1)

--- a/controlplane/configstore/org_connection_metrics.go
+++ b/controlplane/configstore/org_connection_metrics.go
@@ -8,89 +8,85 @@ import (
 )
 
 const (
-	orgConnectionAdmissionOutcomeGranted          = "granted"
-	orgConnectionAdmissionOutcomeAlreadyGranted   = "already_granted"
-	orgConnectionAdmissionOutcomeBlockedOrgVCPU   = "blocked_org_vcpu"
-	orgConnectionAdmissionOutcomeBlockedUserVCPU  = "blocked_user_vcpu"
-	orgConnectionAdmissionOutcomeRejectedOrgVCPU  = "rejected_org_vcpu"
-	orgConnectionAdmissionOutcomeRejectedUserVCPU = "rejected_user_vcpu"
-	orgConnectionAdmissionOutcomeIneligibleUser   = "ineligible_user"
-	orgConnectionAdmissionOutcomeInactive         = "inactive_request"
-	orgConnectionAdmissionOutcomeMissing          = "missing_request"
-	orgConnectionAdmissionOutcomeWaiting          = "waiting"
-	orgConnectionAdmissionOutcomeError            = "error"
-	orgConnectionAdmissionOutcomeResharding       = "blocked_resharding"
+	orgConnectionAdmissionOutcomeGranted            = "granted"
+	orgConnectionAdmissionOutcomeAlreadyGranted     = "already_granted"
+	orgConnectionAdmissionOutcomeBlockedOrgVCPU     = "blocked_org_vcpu"
+	orgConnectionAdmissionOutcomeBlockedUserVCPU    = "blocked_user_vcpu"
+	orgConnectionAdmissionOutcomeBlockedOrgUserVCPU = "blocked_org_user_vcpu"
+	orgConnectionAdmissionOutcomeRejectedOrgVCPU    = "rejected_org_vcpu"
+	orgConnectionAdmissionOutcomeRejectedUserVCPU   = "rejected_user_vcpu"
+	orgConnectionAdmissionOutcomeIneligibleUser     = "ineligible_user"
+	orgConnectionAdmissionOutcomeInactive           = "inactive_request"
+	orgConnectionAdmissionOutcomeMissing            = "missing_request"
+	orgConnectionAdmissionOutcomeWaiting            = "waiting"
+	orgConnectionAdmissionOutcomeCanceled           = "canceled"
+	orgConnectionAdmissionOutcomeTimeout            = "timeout"
+	orgConnectionAdmissionOutcomeError              = "error"
+	orgConnectionAdmissionOutcomeResharding         = "blocked_resharding"
 )
 
 var orgConnectionAdmissionDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "duckgres_org_connection_admission_duration_seconds",
-	Help:    "Duration of one DB-backed org connection admission evaluation, including the serialized per-org transaction.",
+	Name:    "duckgres_session_admission_evaluation_duration_seconds",
+	Help:    "Duration of one DB-backed session admission request poll, partitioned by its decision and reason.",
 	Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
-}, []string{"outcome"})
+}, []string{"decision", "reason"})
 
 var orgConnectionAdmissionAttemptsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "duckgres_org_connection_admission_attempts_total",
-	Help: "Total org connection admission evaluations by outcome.",
-}, []string{"outcome"})
+	Name: "duckgres_session_admission_evaluations_total",
+	Help: "Total DB-backed session admission request polls, partitioned by decision and reason.",
+}, []string{"decision", "reason"})
 
-var orgConnectionAdmissionQueueDepthHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-	Name:    "duckgres_org_connection_admission_queue_depth",
-	Help:    "Pending org connection queue depth observed during admission evaluation.",
-	Buckets: prometheus.ExponentialBuckets(1, 2, 14),
-})
-
-var orgConnectionAdmissionUserQueuesHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-	Name:    "duckgres_org_connection_admission_user_queues",
-	Help:    "Number of per-user queue heads considered during org connection admission evaluation.",
-	Buckets: prometheus.ExponentialBuckets(1, 2, 12),
-})
-
-var orgConnectionAdmissionUserLimitSkipsCounter = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "duckgres_org_connection_admission_user_limit_skips_total",
-	Help: "Total per-user queue heads skipped during org connection admission because the user was at its vCPU limit.",
-})
-
-var orgConnectionAdmissionIneligibleUserSkipsCounter = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "duckgres_org_connection_admission_ineligible_user_skips_total",
-	Help: "Total per-user queue heads skipped during org connection admission because the configured user was missing or disabled.",
-})
-
-type orgConnectionAdmissionStats struct {
-	queueDepth          int64
-	userQueues          int
-	userLimitSkips      int
-	ineligibleUserSkips int
+// OrgConnectionAdmissionEvaluation describes one DB-backed admission poll for
+// the polling request. Decision records what happened to that request; Reason
+// records why it could not be granted when it waited, was blocked, or rejected.
+type OrgConnectionAdmissionEvaluation struct {
+	Decision string
+	Reason   string
 }
 
-func observeOrgConnectionAdmission(d time.Duration, outcome string, stats orgConnectionAdmissionStats) {
+func observeOrgConnectionAdmission(d time.Duration, outcome string) OrgConnectionAdmissionEvaluation {
 	if d < 0 {
 		d = 0
 	}
-	if outcome == "" {
-		outcome = orgConnectionAdmissionOutcomeWaiting
-	}
-	orgConnectionAdmissionDurationHistogram.WithLabelValues(outcome).Observe(d.Seconds())
-	orgConnectionAdmissionAttemptsCounter.WithLabelValues(outcome).Inc()
-	orgConnectionAdmissionQueueDepthHistogram.Observe(float64(nonNegativeInt64(stats.queueDepth)))
-	orgConnectionAdmissionUserQueuesHistogram.Observe(float64(nonNegativeInt(stats.userQueues)))
-	if stats.userLimitSkips > 0 {
-		orgConnectionAdmissionUserLimitSkipsCounter.Add(float64(stats.userLimitSkips))
-	}
-	if stats.ineligibleUserSkips > 0 {
-		orgConnectionAdmissionIneligibleUserSkipsCounter.Add(float64(stats.ineligibleUserSkips))
-	}
+	evaluation := orgConnectionAdmissionEvaluationForOutcome(outcome)
+	orgConnectionAdmissionDurationHistogram.WithLabelValues(evaluation.Decision, evaluation.Reason).Observe(d.Seconds())
+	orgConnectionAdmissionAttemptsCounter.WithLabelValues(evaluation.Decision, evaluation.Reason).Inc()
+	return evaluation
 }
 
-func nonNegativeInt(v int) int {
-	if v < 0 {
-		return 0
+func orgConnectionAdmissionEvaluationForOutcome(outcome string) OrgConnectionAdmissionEvaluation {
+	switch outcome {
+	case orgConnectionAdmissionOutcomeGranted:
+		return OrgConnectionAdmissionEvaluation{Decision: "granted_current", Reason: "none"}
+	case orgConnectionAdmissionOutcomeAlreadyGranted:
+		return OrgConnectionAdmissionEvaluation{Decision: "already_granted", Reason: "none"}
+	case orgConnectionAdmissionOutcomeBlockedOrgVCPU:
+		return OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "org_vcpu"}
+	case orgConnectionAdmissionOutcomeBlockedUserVCPU:
+		return OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "user_vcpu"}
+	case orgConnectionAdmissionOutcomeBlockedOrgUserVCPU:
+		return OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "org_user_vcpu"}
+	case orgConnectionAdmissionOutcomeRejectedOrgVCPU:
+		return OrgConnectionAdmissionEvaluation{Decision: "rejected", Reason: "org_vcpu"}
+	case orgConnectionAdmissionOutcomeRejectedUserVCPU:
+		return OrgConnectionAdmissionEvaluation{Decision: "rejected", Reason: "user_vcpu"}
+	case orgConnectionAdmissionOutcomeIneligibleUser:
+		return OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "user_ineligible"}
+	case orgConnectionAdmissionOutcomeResharding:
+		return OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "resharding"}
+	case orgConnectionAdmissionOutcomeInactive:
+		return OrgConnectionAdmissionEvaluation{Decision: "inactive", Reason: "none"}
+	case orgConnectionAdmissionOutcomeMissing:
+		return OrgConnectionAdmissionEvaluation{Decision: "missing", Reason: "none"}
+	case orgConnectionAdmissionOutcomeWaiting, "":
+		return OrgConnectionAdmissionEvaluation{Decision: "waiting", Reason: "fifo"}
+	case orgConnectionAdmissionOutcomeCanceled:
+		return OrgConnectionAdmissionEvaluation{Decision: "canceled", Reason: "none"}
+	case orgConnectionAdmissionOutcomeTimeout:
+		return OrgConnectionAdmissionEvaluation{Decision: "timeout", Reason: "none"}
+	case orgConnectionAdmissionOutcomeError:
+		return OrgConnectionAdmissionEvaluation{Decision: "error", Reason: "store_error"}
+	default:
+		return OrgConnectionAdmissionEvaluation{Decision: "error", Reason: "store_error"}
 	}
-	return v
-}
-
-func nonNegativeInt64(v int64) int64 {
-	if v < 0 {
-		return 0
-	}
-	return v
 }

--- a/controlplane/configstore/org_connection_metrics_test.go
+++ b/controlplane/configstore/org_connection_metrics_test.go
@@ -1,0 +1,35 @@
+package configstore
+
+import "testing"
+
+func TestOrgConnectionAdmissionEvaluationForOutcome(t *testing.T) {
+	tests := []struct {
+		outcome  string
+		decision string
+		reason   string
+	}{
+		{orgConnectionAdmissionOutcomeGranted, "granted_current", "none"},
+		{orgConnectionAdmissionOutcomeAlreadyGranted, "already_granted", "none"},
+		{orgConnectionAdmissionOutcomeBlockedOrgVCPU, "blocked", "org_vcpu"},
+		{orgConnectionAdmissionOutcomeBlockedUserVCPU, "blocked", "user_vcpu"},
+		{orgConnectionAdmissionOutcomeBlockedOrgUserVCPU, "blocked", "org_user_vcpu"},
+		{orgConnectionAdmissionOutcomeRejectedOrgVCPU, "rejected", "org_vcpu"},
+		{orgConnectionAdmissionOutcomeRejectedUserVCPU, "rejected", "user_vcpu"},
+		{orgConnectionAdmissionOutcomeIneligibleUser, "blocked", "user_ineligible"},
+		{orgConnectionAdmissionOutcomeResharding, "blocked", "resharding"},
+		{orgConnectionAdmissionOutcomeInactive, "inactive", "none"},
+		{orgConnectionAdmissionOutcomeMissing, "missing", "none"},
+		{orgConnectionAdmissionOutcomeWaiting, "waiting", "fifo"},
+		{orgConnectionAdmissionOutcomeCanceled, "canceled", "none"},
+		{orgConnectionAdmissionOutcomeTimeout, "timeout", "none"},
+		{orgConnectionAdmissionOutcomeError, "error", "store_error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			got := orgConnectionAdmissionEvaluationForOutcome(tt.outcome)
+			if got.Decision != tt.decision || got.Reason != tt.reason {
+				t.Fatalf("evaluation = %#v, want decision=%q reason=%q", got, tt.decision, tt.reason)
+			}
+		})
+	}
+}

--- a/controlplane/configstore/org_connections.go
+++ b/controlplane/configstore/org_connections.go
@@ -190,17 +190,15 @@ func (cs *ConfigStore) TryAcquireOrgConnectionLeaseWithLimitLookupForRefContext(
 
 	start := time.Now()
 	outcome := orgConnectionAdmissionOutcomeWaiting
-	var stats orgConnectionAdmissionStats
 	defer func() {
-		observeOrgConnectionAdmission(time.Since(start), outcome, stats)
+		observeOrgConnectionAdmission(time.Since(start), outcome)
 	}()
 
-	lease, attemptStats, attemptOutcome, err := cs.scheduleAndClaimOrgConnectionLeaseOnce(ctx, ref, limitLookup)
-	stats = attemptStats
+	lease, attemptOutcome, err := cs.scheduleAndClaimOrgConnectionLeaseOnce(ctx, ref, limitLookup)
 	outcome = attemptOutcome
 	if err != nil {
 		if !errors.Is(err, ErrOrgConnectionAdmissionRejected) {
-			outcome = orgConnectionAdmissionOutcomeError
+			outcome = orgConnectionAdmissionOutcomeForError(ctx, err)
 		}
 		return nil, fmt.Errorf("try acquire org connection lease: %w", err)
 	}
@@ -250,31 +248,51 @@ func (cs *ConfigStore) ScheduleAndClaimOrgConnectionLeaseForRef(ref OrgConnectio
 }
 
 func (cs *ConfigStore) ScheduleAndClaimOrgConnectionLeaseForRefContext(ctx context.Context, ref OrgConnectionAdmissionRef) (*OrgConnectionLease, error) {
+	lease, _, err := cs.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(ctx, ref)
+	return lease, err
+}
+
+// ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext is the
+// structured exact-identity admission API used by the runtime limiter. The
+// returned evaluation and the exported admission metrics describe only ref.
+func (cs *ConfigStore) ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(ctx context.Context, ref OrgConnectionAdmissionRef) (lease *OrgConnectionLease, evaluation OrgConnectionAdmissionEvaluation, err error) {
 	if err := ref.validate(); err != nil {
-		return nil, err
+		return nil, OrgConnectionAdmissionEvaluation{}, err
 	}
 
 	start := time.Now()
 	outcome := orgConnectionAdmissionOutcomeWaiting
-	var stats orgConnectionAdmissionStats
 	defer func() {
-		observeOrgConnectionAdmission(time.Since(start), outcome, stats)
+		evaluation = observeOrgConnectionAdmission(time.Since(start), outcome)
 	}()
 
 	if err := ctx.Err(); err != nil {
-		outcome = orgConnectionAdmissionOutcomeError
-		return nil, err
+		outcome = orgConnectionAdmissionOutcomeForError(ctx, err)
+		return nil, OrgConnectionAdmissionEvaluation{}, err
 	}
-	lease, attemptStats, attemptOutcome, err := cs.scheduleAndClaimOrgConnectionLeaseOnce(ctx, ref, nil)
-	stats = attemptStats
+	lease, attemptOutcome, err := cs.scheduleAndClaimOrgConnectionLeaseOnce(ctx, ref, nil)
 	outcome = attemptOutcome
 	if err != nil {
 		if !errors.Is(err, ErrOrgConnectionAdmissionRejected) {
-			outcome = orgConnectionAdmissionOutcomeError
+			outcome = orgConnectionAdmissionOutcomeForError(ctx, err)
 		}
-		return nil, fmt.Errorf("schedule and claim org connection lease: %w", err)
+		return nil, OrgConnectionAdmissionEvaluation{}, fmt.Errorf("schedule and claim org connection lease: %w", err)
 	}
-	return lease, nil
+	return lease, OrgConnectionAdmissionEvaluation{}, nil
+}
+
+func orgConnectionAdmissionOutcomeForError(ctx context.Context, err error) string {
+	if ctx != nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return orgConnectionAdmissionOutcomeCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return orgConnectionAdmissionOutcomeTimeout
+	default:
+		return orgConnectionAdmissionOutcomeError
+	}
 }
 
 type orgConnectionRuntimeTables struct {
@@ -289,11 +307,10 @@ func (cs *ConfigStore) orgConnectionRuntimeTables() orgConnectionRuntimeTables {
 	}
 }
 
-func (cs *ConfigStore) scheduleAndClaimOrgConnectionLeaseOnce(ctx context.Context, ref OrgConnectionAdmissionRef, fallbackLimitLookup func(string) OrgResourceLimits) (*OrgConnectionLease, orgConnectionAdmissionStats, string, error) {
+func (cs *ConfigStore) scheduleAndClaimOrgConnectionLeaseOnce(ctx context.Context, ref OrgConnectionAdmissionRef, fallbackLimitLookup func(string) OrgResourceLimits) (*OrgConnectionLease, string, error) {
 	tables := cs.orgConnectionRuntimeTables()
 	var lease *OrgConnectionLease
 	var rejection *OrgConnectionAdmissionRejectedError
-	var stats orgConnectionAdmissionStats
 	outcome := orgConnectionAdmissionOutcomeMissing
 
 	err := cs.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -397,8 +414,7 @@ func (cs *ConfigStore) scheduleAndClaimOrgConnectionLeaseOnce(ctx context.Contex
 				Delete(&OrgConnectionQueueEntry{}).Error
 		}
 
-		next, selectionStats, selectionOutcome, err := cs.nextEligibleOrgConnectionRequestLocked(tx, tables, ref.OrgID, limitLookup, userAllowed, now)
-		stats = selectionStats
+		next, selectionOutcome, err := cs.nextEligibleOrgConnectionRequestLocked(tx, tables, request, limitLookup, userAllowed, now)
 		if err != nil {
 			return err
 		}
@@ -420,7 +436,7 @@ func (cs *ConfigStore) scheduleAndClaimOrgConnectionLeaseOnce(ctx context.Contex
 	if err == nil && rejection != nil {
 		err = rejection
 	}
-	return lease, stats, outcome, err
+	return lease, outcome, err
 }
 
 // lockActiveControlPlaneOwner closes the race between cleanup's active-owner
@@ -610,27 +626,57 @@ func (cs *ConfigStore) authoritativeOrgConnectionLimits(tx *gorm.DB, orgID strin
 	return limits, true, nil
 }
 
-func (cs *ConfigStore) nextEligibleOrgConnectionRequestLocked(tx *gorm.DB, tables orgConnectionRuntimeTables, orgID string, limitLookup func(string) OrgResourceLimits, userAllowed func(string) bool, now time.Time) (*OrgConnectionQueueEntry, orgConnectionAdmissionStats, string, error) {
-	heads, stats, err := cs.pendingOrgConnectionUserQueueHeads(tx, tables.queue, orgID, now)
+// nextEligibleOrgConnectionRequestLocked preserves the admission selection
+// policy while reporting why target itself did not advance. It never grants or
+// mutates a foreign request; the caller creates a lease only for target.
+func (cs *ConfigStore) nextEligibleOrgConnectionRequestLocked(tx *gorm.DB, tables orgConnectionRuntimeTables, target *OrgConnectionQueueEntry, limitLookup func(string) OrgResourceLimits, userAllowed func(string) bool, now time.Time) (*OrgConnectionQueueEntry, string, error) {
+	heads, err := cs.pendingOrgConnectionUserQueueHeads(tx, tables.queue, target.OrgID, now)
 	if err != nil {
-		return nil, stats, orgConnectionAdmissionOutcomeError, err
+		return nil, orgConnectionAdmissionOutcomeError, err
 	}
 	if len(heads) == 0 {
-		return nil, stats, orgConnectionAdmissionOutcomeWaiting, nil
+		return nil, orgConnectionAdmissionOutcomeWaiting, nil
 	}
 
-	orgUsed, userUsed, legacyUserUsed, err := cs.activeOrgConnectionLeaseVCPUUsage(tx, orgID)
+	orgUsed, userUsed, legacyUserUsed, err := cs.activeOrgConnectionLeaseVCPUUsage(tx, target.OrgID)
 	if err != nil {
-		return nil, stats, orgConnectionAdmissionOutcomeError, err
+		return nil, orgConnectionAdmissionOutcomeError, err
+	}
+
+	targetIsUserHead := false
+	for i := range heads {
+		if sameOrgConnectionAdmissionRequest(&heads[i], target) {
+			targetIsUserHead = true
+			break
+		}
+	}
+	if !targetIsUserHead {
+		return nil, orgConnectionAdmissionOutcomeWaiting, nil
+	}
+	if userAllowed != nil && !userAllowed(target.Username) {
+		return nil, orgConnectionAdmissionOutcomeIneligibleUser, nil
+	}
+
+	targetLimits := limitLookup(target.Username)
+	targetRequested := int64(target.RequestedVCPUs)
+	targetUserBlocked := targetLimits.UserMaxVCPUs > 0 && legacyUserUsed+userUsed[target.Username]+targetRequested > int64(targetLimits.UserMaxVCPUs)
+	targetOrgBlocked := targetLimits.OrgMaxVCPUs > 0 && orgUsed+targetRequested > int64(targetLimits.OrgMaxVCPUs)
+	if targetUserBlocked {
+		if targetOrgBlocked {
+			return nil, orgConnectionAdmissionOutcomeBlockedOrgUserVCPU, nil
+		}
+		return nil, orgConnectionAdmissionOutcomeBlockedUserVCPU, nil
 	}
 
 	for i := range heads {
 		head := &heads[i]
 		if userAllowed != nil && !userAllowed(head.Username) {
-			stats.ineligibleUserSkips++
 			continue
 		}
 		limits := limitLookup(head.Username)
+		if sameOrgConnectionAdmissionRequest(head, target) {
+			limits = targetLimits
+		}
 		requested := int64(head.RequestedVCPUs)
 		// A permanently impossible foreign head must not block unrelated
 		// requests. Only that request's owner deletes and receives the typed
@@ -644,34 +690,30 @@ func (cs *ConfigStore) nextEligibleOrgConnectionRequestLocked(tx *gorm.DB, table
 		if limits.UserMaxVCPUs > 0 {
 			used := legacyUserUsed + userUsed[head.Username]
 			if used+requested > int64(limits.UserMaxVCPUs) {
-				stats.userLimitSkips++
 				continue
 			}
 		}
 		if limits.OrgMaxVCPUs > 0 && orgUsed+requested > int64(limits.OrgMaxVCPUs) {
-			return nil, stats, orgConnectionAdmissionOutcomeBlockedOrgVCPU, nil
+			return nil, orgConnectionAdmissionOutcomeBlockedOrgVCPU, nil
 		}
 
-		return head, stats, orgConnectionAdmissionOutcomeGranted, nil
+		if sameOrgConnectionAdmissionRequest(head, target) {
+			return head, orgConnectionAdmissionOutcomeGranted, nil
+		}
+		return head, orgConnectionAdmissionOutcomeWaiting, nil
 	}
 
-	if stats.userLimitSkips > 0 {
-		return nil, stats, orgConnectionAdmissionOutcomeBlockedUserVCPU, nil
-	}
-	if stats.ineligibleUserSkips > 0 {
-		return nil, stats, orgConnectionAdmissionOutcomeIneligibleUser, nil
-	}
-	return nil, stats, orgConnectionAdmissionOutcomeWaiting, nil
+	return nil, orgConnectionAdmissionOutcomeWaiting, nil
 }
 
-func (cs *ConfigStore) pendingOrgConnectionUserQueueHeads(tx *gorm.DB, queueTable, orgID string, now time.Time) ([]OrgConnectionQueueEntry, orgConnectionAdmissionStats, error) {
-	var stats orgConnectionAdmissionStats
-	if err := tx.Table(queueTable).
-		Where("org_id = ? AND granted_at IS NULL AND expires_at > ?", orgID, now).
-		Count(&stats.queueDepth).Error; err != nil {
-		return nil, stats, err
-	}
+func sameOrgConnectionAdmissionRequest(a, b *OrgConnectionQueueEntry) bool {
+	return a != nil && b != nil &&
+		a.RequestID == b.RequestID &&
+		a.OrgID == b.OrgID &&
+		a.CPInstanceID == b.CPInstanceID
+}
 
+func (cs *ConfigStore) pendingOrgConnectionUserQueueHeads(tx *gorm.DB, queueTable, orgID string, now time.Time) ([]OrgConnectionQueueEntry, error) {
 	var heads []OrgConnectionQueueEntry
 	if err := tx.Raw(
 		"SELECT * FROM ("+
@@ -681,10 +723,9 @@ func (cs *ConfigStore) pendingOrgConnectionUserQueueHeads(tx *gorm.DB, queueTabl
 			") AS user_heads ORDER BY enqueued_at ASC, request_id ASC",
 		orgID, now,
 	).Scan(&heads).Error; err != nil {
-		return nil, stats, err
+		return nil, err
 	}
-	stats.userQueues = len(heads)
-	return heads, stats, nil
+	return heads, nil
 }
 
 func (cs *ConfigStore) activeOrgConnectionLeaseVCPUUsage(tx *gorm.DB, orgID string) (int64, map[string]int64, int64, error) {

--- a/controlplane/connection_limiter.go
+++ b/controlplane/connection_limiter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -57,6 +58,10 @@ type runtimeOrgConnectionScheduleAndClaimStore interface {
 
 type runtimeOrgConnectionScheduleAndClaimContextStore interface {
 	ScheduleAndClaimOrgConnectionLeaseForRefContext(ctx context.Context, ref configstore.OrgConnectionAdmissionRef) (*configstore.OrgConnectionLease, error)
+}
+
+type runtimeOrgConnectionScheduleAndClaimEvaluationContextStore interface {
+	ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(ctx context.Context, ref configstore.OrgConnectionAdmissionRef) (*configstore.OrgConnectionLease, configstore.OrgConnectionAdmissionEvaluation, error)
 }
 
 type runtimeOrgConnectionLimiter struct {
@@ -157,15 +162,32 @@ func (l *runtimeOrgConnectionLimiter) Acquire(ctx context.Context, request conne
 		return nil, enqueueErr
 	}
 
+	waitStarted := time.Now()
+	outcome := "error"
+	var reasons sessionAdmissionReasons
+	sessionAdmissionQueueDepthGauge.WithLabelValues(l.orgID).Inc()
+	defer func() {
+		sessionAdmissionQueueDepthGauge.WithLabelValues(l.orgID).Dec()
+		observeSessionAdmissionTerminal(l.orgID, outcome, reasons.value(), time.Since(waitStarted))
+	}()
+
 	for {
+		if err := ctx.Err(); err != nil {
+			outcome = sessionAdmissionContextOutcome(err)
+			return nil, runtimeAdmissionContextError(err)
+		}
 		now := l.now()
 		if !now.Before(expiresAt) {
+			outcome = "timeout"
 			return nil, ErrTooManyConnections
 		}
 
 		var lease *configstore.OrgConnectionLease
+		var evaluation configstore.OrgConnectionAdmissionEvaluation
 		var err error
-		if schedulerStore, ok := l.store.(runtimeOrgConnectionScheduleAndClaimContextStore); ok {
+		if schedulerStore, ok := l.store.(runtimeOrgConnectionScheduleAndClaimEvaluationContextStore); ok {
+			lease, evaluation, err = schedulerStore.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(ctx, ref)
+		} else if schedulerStore, ok := l.store.(runtimeOrgConnectionScheduleAndClaimContextStore); ok {
 			lease, err = schedulerStore.ScheduleAndClaimOrgConnectionLeaseForRefContext(ctx, ref)
 		} else if schedulerStore, ok := l.store.(runtimeOrgConnectionScheduleAndClaimStore); ok {
 			lease, err = schedulerStore.ScheduleAndClaimOrgConnectionLeaseForRef(ref)
@@ -176,15 +198,42 @@ func (l *runtimeOrgConnectionLimiter) Acquire(ctx context.Context, request conne
 		} else {
 			return nil, errRuntimeOrgConnectionExactAcquisitionUnsupported
 		}
-		if ctx.Err() != nil {
-			return nil, runtimeAdmissionContextError(ctx.Err())
+		if contextErr := runtimeAdmissionContextCause(ctx, err); contextErr != nil {
+			// A completed blocking evaluation may race with cancellation. Retain
+			// that real blocker, but never reinterpret an interrupted DB call as
+			// a store failure on the logical request.
+			if err == nil && evaluation.Decision != "canceled" && evaluation.Decision != "timeout" && evaluation.Decision != "error" {
+				if evaluation.Decision == "waiting" && (evaluation.Reason == "" || evaluation.Reason == "none") {
+					evaluation.Reason = "fifo"
+				}
+				reasons.add(evaluation.Reason)
+			}
+			outcome = sessionAdmissionContextOutcome(contextErr)
+			return nil, runtimeAdmissionContextError(contextErr)
 		}
+		if evaluation.Decision == "waiting" && (evaluation.Reason == "" || evaluation.Reason == "none") {
+			evaluation.Reason = "fifo"
+		}
+		reasons.add(evaluation.Reason)
 		if err != nil {
+			var rejection *configstore.OrgConnectionAdmissionRejectedError
+			if errors.As(err, &rejection) {
+				outcome = "rejected"
+				reasons.add(sessionAdmissionRejectionReason(rejection))
+				return nil, err
+			}
+			reasons.add("store_error")
 			return nil, err
 		}
 		if lease != nil {
+			outcome = "granted"
+			sessionAdmissionActiveVCPUsGauge.WithLabelValues(l.orgID).Add(float64(request.RequestedVCPUs))
 			cleanupArmed = false
-			return &runtimeOrgConnectionLease{reservation: reservation}, nil
+			return &runtimeOrgConnectionLease{
+				reservation:    reservation,
+				orgID:          l.orgID,
+				requestedVCPUs: request.RequestedVCPUs,
+			}, nil
 		}
 
 		wait := l.pollInterval
@@ -195,9 +244,45 @@ func (l *runtimeOrgConnectionLimiter) Acquire(ctx context.Context, request conne
 		select {
 		case <-ctx.Done():
 			timer.Stop()
+			outcome = sessionAdmissionContextOutcome(ctx.Err())
 			return nil, runtimeAdmissionContextError(ctx.Err())
 		case <-timer.C:
 		}
+	}
+}
+
+func sessionAdmissionContextOutcome(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	return "canceled"
+}
+
+func runtimeAdmissionContextCause(ctx context.Context, err error) error {
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return context.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+func sessionAdmissionRejectionReason(rejection *configstore.OrgConnectionAdmissionRejectedError) string {
+	if rejection == nil {
+		return "store_error"
+	}
+	switch rejection.Reason {
+	case configstore.OrgConnectionAdmissionRejectedOrgVCPU:
+		return "org_vcpu"
+	case configstore.OrgConnectionAdmissionRejectedUserVCPU:
+		return "user_vcpu"
+	default:
+		return "store_error"
 	}
 }
 
@@ -209,14 +294,20 @@ func runtimeAdmissionContextError(err error) error {
 }
 
 type runtimeOrgConnectionLease struct {
-	reservation AdmissionReclaimReservation
+	reservation    AdmissionReclaimReservation
+	orgID          string
+	requestedVCPUs int
+	released       sync.Once
 }
 
 func (l *runtimeOrgConnectionLease) Release(context.Context) error {
 	if l == nil || l.reservation == nil {
 		return nil
 	}
-	l.reservation.Reclaim(admissionReclaimCauseLeaseRelease)
+	l.released.Do(func() {
+		l.reservation.Reclaim(admissionReclaimCauseLeaseRelease)
+		sessionAdmissionActiveVCPUsGauge.WithLabelValues(l.orgID).Sub(float64(l.requestedVCPUs))
+	})
 	return nil
 }
 

--- a/controlplane/connection_limiter_test.go
+++ b/controlplane/connection_limiter_test.go
@@ -523,3 +523,377 @@ func TestRuntimeOrgConnectionLimiterReclaimsLeaseGrantedWithCancellation(t *test
 		t.Fatalf("cleanup submissions = %#v, want exact grant/cancel request ref", submissions)
 	}
 }
+
+type admissionMetricsScheduleResult struct {
+	evaluation configstore.OrgConnectionAdmissionEvaluation
+	err        error
+}
+
+type admissionMetricsScheduleStore struct {
+	mu           sync.Mutex
+	results      []admissionMetricsScheduleResult
+	enqueueErr   error
+	enqueueCalls int
+	onEvaluate   func()
+}
+
+func (s *admissionMetricsScheduleStore) EnqueueOrgConnectionRequest(*configstore.OrgConnectionQueueEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enqueueCalls++
+	return s.enqueueErr
+}
+
+func (s *admissionMetricsScheduleStore) ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(_ context.Context, ref configstore.OrgConnectionAdmissionRef) (*configstore.OrgConnectionLease, configstore.OrgConnectionAdmissionEvaluation, error) {
+	s.mu.Lock()
+	if len(s.results) == 0 {
+		s.mu.Unlock()
+		return nil, configstore.OrgConnectionAdmissionEvaluation{Decision: "waiting", Reason: "fifo"}, nil
+	}
+	result := s.results[0]
+	s.results = s.results[1:]
+	onEvaluate := s.onEvaluate
+	s.mu.Unlock()
+	if onEvaluate != nil {
+		onEvaluate()
+	}
+	if result.evaluation.Decision == "granted_current" {
+		return &configstore.OrgConnectionLease{LeaseID: ref.RequestID, RequestID: ref.RequestID}, result.evaluation, result.err
+	}
+	return nil, result.evaluation, result.err
+}
+
+func newAdmissionMetricsLimiter(store runtimeOrgConnectionStore, reclaimer admissionReclaimer, org, requestID string) *runtimeOrgConnectionLimiter {
+	return &runtimeOrgConnectionLimiter{
+		store:        store,
+		reclaimer:    reclaimer,
+		orgID:        org,
+		cpInstanceID: "cp-metrics",
+		queueTTL:     time.Minute,
+		pollInterval: time.Millisecond,
+		now:          time.Now,
+		newID:        func() (string, error) { return requestID, nil },
+	}
+}
+
+func resetSessionAdmissionMetricGauges(t *testing.T, org string) {
+	t.Helper()
+	sessionAdmissionQueueDepthGauge.DeleteLabelValues(org)
+	sessionAdmissionActiveVCPUsGauge.DeleteLabelValues(org)
+	sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org)
+	t.Cleanup(func() {
+		sessionAdmissionQueueDepthGauge.DeleteLabelValues(org)
+		sessionAdmissionActiveVCPUsGauge.DeleteLabelValues(org)
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org)
+	})
+}
+
+func TestRuntimeOrgConnectionLimiterObservesGrantedRequestLifecycle(t *testing.T) {
+	const org = "org-admission-metrics-granted"
+	resetSessionAdmissionMetricGauges(t, org)
+	sessionAdmissionLimitVCPUsGauge.WithLabelValues(org).Set(7)
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{
+		{evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "org_vcpu"}},
+		{evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "granted_current", Reason: "none"}},
+	}}
+	reclaimer := &recordingAdmissionReclaimer{}
+	limiter := newAdmissionMetricsLimiter(store, reclaimer, org, "request-metrics-granted")
+
+	requestsBefore := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "granted", "org_vcpu")
+	waitsBefore := histogramVecLabelSampleCount(t, sessionAdmissionWaitHistogram, org, "granted", "org_vcpu")
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1001, Username: "alice", Protocol: "postgres", RequestedVCPUs: 2,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if err != nil || lease == nil {
+		t.Fatalf("Acquire = (%v, %v), want lease", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "granted", "org_vcpu") - requestsBefore; got != 1 {
+		t.Fatalf("request counter delta = %v, want 1", got)
+	}
+	if got := histogramVecLabelSampleCount(t, sessionAdmissionWaitHistogram, org, "granted", "org_vcpu") - waitsBefore; got != 1 {
+		t.Fatalf("wait histogram count delta = %d, want 1", got)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionQueueDepthGauge, org); got != 0 {
+		t.Fatalf("queue depth = %v, want 0", got)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionActiveVCPUsGauge, org); got != 2 {
+		t.Fatalf("active vCPUs = %v, want 2", got)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionLimitVCPUsGauge, org); got != 7 {
+		t.Fatalf("limit vCPUs = %v, want config-reconciled value 7", got)
+	}
+
+	if err := lease.Release(context.Background()); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if err := lease.Release(context.Background()); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionActiveVCPUsGauge, org); got != 0 {
+		t.Fatalf("active vCPUs after repeated release = %v, want 0", got)
+	}
+	submissions, _ := reclaimer.snapshot()
+	if len(submissions) != 1 || submissions[0].cause != admissionReclaimCauseLeaseRelease {
+		t.Fatalf("lease cleanup submissions = %#v, want exactly one release", submissions)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterRetainsCombinedVCPULimitReason(t *testing.T) {
+	const org = "org-admission-metrics-combined"
+	resetSessionAdmissionMetricGauges(t, org)
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{
+		{evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "org_vcpu"}},
+		{evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "user_vcpu"}},
+		{evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "granted_current", Reason: "none"}},
+	}}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-combined")
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "granted", "org_user_vcpu")
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1002, Username: "alice", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if err != nil || lease == nil {
+		t.Fatalf("Acquire = (%v, %v), want lease", lease, err)
+	}
+	t.Cleanup(func() { _ = lease.Release(context.Background()) })
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "granted", "org_user_vcpu") - before; got != 1 {
+		t.Fatalf("combined-vCPU request counter delta = %v, want 1", got)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterObservesCancellationAfterEnqueue(t *testing.T) {
+	const org = "org-admission-metrics-canceled"
+	resetSessionAdmissionMetricGauges(t, org)
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{{
+		evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "user_vcpu"},
+	}}}
+	store.onEvaluate = cancel
+	reclaimer := &recordingAdmissionReclaimer{}
+	limiter := newAdmissionMetricsLimiter(store, reclaimer, org, "request-metrics-canceled")
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "canceled", "user_vcpu")
+	lease, err := limiter.Acquire(ctx, connectionAdmissionRequest{
+		PID: 1003, Username: "bob", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire = (%v, %v), want context.Canceled", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "canceled", "user_vcpu") - before; got != 1 {
+		t.Fatalf("canceled request counter delta = %v, want 1", got)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionQueueDepthGauge, org); got != 0 {
+		t.Fatalf("queue depth = %v, want 0", got)
+	}
+	submissions, _ := reclaimer.snapshot()
+	if len(submissions) != 1 || submissions[0].cause != admissionReclaimCauseAcquireAbandoned {
+		t.Fatalf("cleanup submissions = %#v, want one abandoned request", submissions)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterTracksQueueDepthWhileEvaluationIsInFlight(t *testing.T) {
+	const org = "org-admission-metrics-queue-depth"
+	resetSessionAdmissionMetricGauges(t, org)
+	evaluationStarted := make(chan struct{})
+	releaseEvaluation := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseEvaluation) }) })
+
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{{
+		evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "blocked", Reason: "user_vcpu"},
+	}}}
+	store.onEvaluate = func() {
+		close(evaluationStarted)
+		<-releaseEvaluation
+	}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-queue-depth")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	type acquireResult struct {
+		lease connectionLease
+		err   error
+	}
+	result := make(chan acquireResult, 1)
+	go func() {
+		lease, err := limiter.Acquire(ctx, connectionAdmissionRequest{
+			PID: 1009, Username: "heidi", Protocol: "postgres", RequestedVCPUs: 1,
+		}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+		result <- acquireResult{lease: lease, err: err}
+	}()
+
+	select {
+	case <-evaluationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("admission evaluation did not start")
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionQueueDepthGauge, org); got != 1 {
+		t.Fatalf("queue depth during evaluation = %v, want 1", got)
+	}
+
+	cancel()
+	releaseOnce.Do(func() { close(releaseEvaluation) })
+	select {
+	case got := <-result:
+		if got.lease != nil || !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("Acquire = (%v, %v), want context.Canceled", got.lease, got.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("admission acquire did not stop after cancellation")
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionQueueDepthGauge, org); got != 0 {
+		t.Fatalf("queue depth after cancellation = %v, want 0", got)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterClassifiesInterruptedEvaluationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		evaluation  error
+		wantOutcome string
+		wantError   error
+	}{
+		{name: "canceled", evaluation: context.Canceled, wantOutcome: "canceled", wantError: context.Canceled},
+		{name: "deadline", evaluation: context.DeadlineExceeded, wantOutcome: "timeout", wantError: ErrTooManyConnections},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			org := "org-admission-metrics-interrupted-" + tc.name
+			resetSessionAdmissionMetricGauges(t, org)
+			store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{{
+				err: tc.evaluation,
+			}}}
+			limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-interrupted-"+tc.name)
+			before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, tc.wantOutcome, "none")
+			storeErrorsBefore := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error")
+
+			lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+				PID: int32(1010 + i), Username: "ivan", Protocol: "postgres", RequestedVCPUs: 1,
+			}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+			if lease != nil || !errors.Is(err, tc.wantError) {
+				t.Fatalf("Acquire = (%v, %v), want %v", lease, err, tc.wantError)
+			}
+			if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, tc.wantOutcome, "none") - before; got != 1 {
+				t.Fatalf("%s/none request counter delta = %v, want 1", tc.wantOutcome, got)
+			}
+			if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error") - storeErrorsBefore; got != 0 {
+				t.Fatalf("error/store_error request counter delta = %v, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterObservesPermanentRejection(t *testing.T) {
+	const org = "org-admission-metrics-rejected"
+	resetSessionAdmissionMetricGauges(t, org)
+	rejection := &configstore.OrgConnectionAdmissionRejectedError{
+		Reason: configstore.OrgConnectionAdmissionRejectedOrgVCPU, RequestedVCPUs: 4, MaximumVCPUs: 2,
+	}
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{{
+		evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "rejected", Reason: "org_vcpu"},
+		err:        rejection,
+	}}}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-rejected")
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "rejected", "org_vcpu")
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1004, Username: "carol", Protocol: "postgres", RequestedVCPUs: 4,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || !errors.Is(err, configstore.ErrOrgConnectionAdmissionRejected) {
+		t.Fatalf("Acquire = (%v, %v), want permanent rejection", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "rejected", "org_vcpu") - before; got != 1 {
+		t.Fatalf("rejected request counter delta = %v, want 1", got)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterExcludesPreEnqueueFailuresFromRequestMetrics(t *testing.T) {
+	const org = "org-admission-metrics-enqueue-error"
+	resetSessionAdmissionMetricGauges(t, org)
+	store := &admissionMetricsScheduleStore{enqueueErr: errors.New("enqueue unavailable")}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-enqueue-error")
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error")
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1005, Username: "dana", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || err == nil {
+		t.Fatalf("Acquire = (%v, %v), want enqueue error", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error") - before; got != 0 {
+		t.Fatalf("request counter delta = %v, want 0 before successful enqueue", got)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterExcludesPreCanceledRequestFromMetrics(t *testing.T) {
+	const org = "org-admission-metrics-pre-canceled"
+	resetSessionAdmissionMetricGauges(t, org)
+	store := &admissionMetricsScheduleStore{}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-pre-canceled")
+	before := metricCounterFamilyTotal(t, "duckgres_session_admission_requests_total")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lease, err := limiter.Acquire(ctx, connectionAdmissionRequest{
+		PID: 1006, Username: "erin", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("Acquire = (%v, %v), want pre-enqueue context cancellation", lease, err)
+	}
+	if got := metricCounterFamilyTotal(t, "duckgres_session_admission_requests_total") - before; got != 0 {
+		t.Fatalf("request counter delta = %v, want 0 before successful enqueue", got)
+	}
+	if store.enqueueCalls != 0 {
+		t.Fatalf("enqueue calls = %d, want 0", store.enqueueCalls)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterObservesTimeoutAfterEnqueue(t *testing.T) {
+	const org = "org-admission-metrics-timeout"
+	resetSessionAdmissionMetricGauges(t, org)
+	store := &admissionMetricsScheduleStore{}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-timeout")
+	start := time.Now()
+	nowCalls := 0
+	limiter.queueTTL = time.Millisecond
+	limiter.now = func() time.Time {
+		nowCalls++
+		if nowCalls == 1 {
+			return start
+		}
+		return start.Add(2 * time.Millisecond)
+	}
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "timeout", "none")
+
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1007, Username: "frank", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || !errors.Is(err, ErrTooManyConnections) {
+		t.Fatalf("Acquire = (%v, %v), want admission timeout", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "timeout", "none") - before; got != 1 {
+		t.Fatalf("timeout request counter delta = %v, want 1", got)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionQueueDepthGauge, org); got != 0 {
+		t.Fatalf("queue depth = %v, want 0", got)
+	}
+}
+
+func TestRuntimeOrgConnectionLimiterObservesEvaluationError(t *testing.T) {
+	const org = "org-admission-metrics-error"
+	resetSessionAdmissionMetricGauges(t, org)
+	boom := errors.New("config store unavailable")
+	store := &admissionMetricsScheduleStore{results: []admissionMetricsScheduleResult{{
+		evaluation: configstore.OrgConnectionAdmissionEvaluation{Decision: "error", Reason: "store_error"},
+		err:        boom,
+	}}}
+	limiter := newAdmissionMetricsLimiter(store, &recordingAdmissionReclaimer{}, org, "request-metrics-error")
+	before := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error")
+
+	lease, err := limiter.Acquire(context.Background(), connectionAdmissionRequest{
+		PID: 1008, Username: "grace", Protocol: "postgres", RequestedVCPUs: 1,
+	}, func(string) configstore.OrgResourceLimits { return configstore.OrgResourceLimits{} })
+	if lease != nil || !errors.Is(err, boom) {
+		t.Fatalf("Acquire = (%v, %v), want evaluation error", lease, err)
+	}
+	if got := counterVecLabelValue(t, sessionAdmissionRequestsCounter, org, "error", "store_error") - before; got != 1 {
+		t.Fatalf("error request counter delta = %v, want 1", got)
+	}
+}

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -27,6 +27,7 @@ import (
 	"github.com/posthog/duckgres/server/ducklake"
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/flightsqlingress"
+	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -1137,6 +1138,8 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	server.RecordSuccessfulAuthAttempt(cp.rateLimiter, remoteAddr)
 	clog.Info("User authenticated.")
+	sessionStart := observe.BeginSessionStart(orgID, "postgres")
+	defer sessionStart.Finish("error")
 
 	// Resolve the requested worker shape from the connection-string startup
 	// options (duckgres.worker_cpu / worker_memory / worker_ttl), layered on
@@ -1238,12 +1241,14 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		rebalancer = cp.rebalancer
 	}
 	if cp.isDraining() {
+		sessionStart.Finish("draining")
 		_ = server.WriteErrorResponse(writer, "FATAL", "57P03", "control plane is draining, retry shortly")
 		_ = writer.Flush()
 		return
 	}
 	preReadyCtx, finishPreReady, err := cp.beginPreReadyHandshake(context.Background())
 	if err != nil {
+		sessionStart.Finish("draining")
 		_ = server.WriteErrorResponse(writer, "FATAL", "57P03", "control plane is draining, retry shortly")
 		_ = writer.Flush()
 		return
@@ -1304,6 +1309,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			sessions.DestroySession(createdPID)
 			executor = nil
 		}
+		sessionStart.Finish(controlPlaneSessionStartOutcome(err))
 		clog.Error("Failed to create session.", "error", err)
 		code, message := sessionCreationErrorResponse(err)
 		_ = server.WriteErrorResponse(writer, "FATAL", code, message)
@@ -1330,8 +1336,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// requested catalog isn't attached.
 	attachCtx, attachCancel := context.WithTimeout(admissionCtx, cp.cfg.SessionInitTimeout)
 	duckLakeAttached, probeErr := sessionmeta.HasAttachedCatalog(attachCtx, executor, physicalDuckLakeCatalog)
+	attachContextErr := attachCtx.Err()
 	attachCancel()
 	if probeErr != nil {
+		sessionStart.Finish(controlPlaneSessionStartOperationOutcome(probeErr, attachContextErr, cp.isDraining()))
 		clog.Error("Failed to detect attached catalogs.", "error", probeErr)
 		_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to detect attached catalogs")
 		_ = writer.Flush()
@@ -1382,7 +1390,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 			}
 		}
 		if err := sessionmeta.InitSessionDatabaseMetadataWithAccess(initCtx, executor, effectiveCatalog, metadataAccess); err != nil {
+			initContextErr := initCtx.Err()
 			initCancel()
+			sessionStart.Finish(controlPlaneSessionStartOperationOutcome(err, initContextErr, cp.isDraining()))
 			clog.Error("Failed to initialize session database metadata.", "database", database, "error", err)
 			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to initialize session database metadata")
 			_ = writer.Flush()
@@ -1398,9 +1408,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		if cmd, source := effectiveSessionDefaultCommand(clientSearchPath, effectiveCatalog); cmd != "" {
 			spCtx, spCancel := context.WithTimeout(admissionCtx, cp.cfg.SessionInitTimeout)
 			_, err := executor.ExecContext(spCtx, cmd)
+			spContextErr := spCtx.Err()
 			spCancel()
 			if err != nil {
 				if source == sessionDefaultSourceConfiguredCatalog {
+					sessionStart.Finish(controlPlaneSessionStartOperationOutcome(err, spContextErr, cp.isDraining()))
 					clog.Error("Failed to apply session default catalog.", "catalog", effectiveCatalog, "error", err)
 					_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply default catalog")
 					_ = writer.Flush()
@@ -1420,8 +1432,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		if cmd := passthroughSessionDefaultCatalogCommand(effectiveCatalog); cmd != "" {
 			initCtx, initCancel := context.WithTimeout(admissionCtx, cp.cfg.SessionInitTimeout)
 			_, err := executor.ExecContext(initCtx, cmd)
+			initContextErr := initCtx.Err()
 			initCancel()
 			if err != nil {
+				sessionStart.Finish(controlPlaneSessionStartOperationOutcome(err, initContextErr, cp.isDraining()))
 				clog.Error("Failed to apply passthrough session default catalog.", "command", cmd, "error", err)
 				_ = server.WriteErrorResponse(writer, "FATAL", "XX000", "failed to apply default catalog")
 				_ = writer.Flush()
@@ -1473,15 +1487,18 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	server.SetCatalogUseRewrite(cc, duckLakeAttached && !passthroughUser)
 	server.SetPassthrough(cc, passthroughUser)
 	server.SetQueryAccessPolicy(cc, queryAccessPolicy)
-	if orgID != "" {
-		observeOrgPgSessionAccepted(orgID, passthroughUser)
-	}
-
 	// The normal PostgreSQL message loop is about to take ownership of reader.
 	// Join the disconnect watcher first; a FIN/RST at any point during session
 	// admission or metadata initialization tears down the session via the defer
 	// above instead of retaining its worker and vCPU lease.
-	if disconnectWatcher.Stop().ClientCanceled || finishPreReady() {
+	disconnect := disconnectWatcher.Stop()
+	drained := finishPreReady()
+	if disconnect.ClientCanceled {
+		sessionStart.Finish("canceled")
+		return
+	}
+	if drained {
+		sessionStart.Finish("draining")
 		return
 	}
 
@@ -1494,6 +1511,10 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		clog.Error("Failed to flush writer.", "error", err)
 		return
 	}
+	sessionStart.Finish("success")
+	if orgID != "" {
+		observeOrgPgSessionAccepted(orgID, passthroughUser)
+	}
 
 	// Run message loop. Disconnect log + duration histogram are emitted by the
 	// deferred CloseConnectionMetrics above on every return path.
@@ -1501,6 +1522,35 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		clog.Error("Message loop error.", "error", err)
 		return
 	}
+}
+
+func controlPlaneSessionStartOutcome(err error) string {
+	var capacityErr *WorkerCapacityExhaustedError
+	var rejection *configstore.OrgConnectionAdmissionRejectedError
+	switch {
+	case err == nil:
+		return "success"
+	case errors.As(err, &capacityErr), errors.As(err, &rejection):
+		return "capacity"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, ErrTooManyConnections):
+		return "timeout"
+	case errors.Is(err, ErrSessionManagerDraining):
+		return "draining"
+	default:
+		return "error"
+	}
+}
+
+func controlPlaneSessionStartOperationOutcome(err, contextErr error, draining bool) string {
+	if draining {
+		return "draining"
+	}
+	if contextErr != nil {
+		return controlPlaneSessionStartOutcome(contextErr)
+	}
+	return controlPlaneSessionStartOutcome(err)
 }
 
 func authorizedClientSearchPath(searchPath string, policy *server.QueryAccessPolicy) string {

--- a/controlplane/control_cancel_test.go
+++ b/controlplane/control_cancel_test.go
@@ -196,6 +196,55 @@ func TestSessionCreationErrorResponse(t *testing.T) {
 	})
 }
 
+func TestControlPlaneSessionStartOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "success", want: "success"},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "queue timeout", err: ErrTooManyConnections, want: "timeout"},
+		{name: "draining", err: ErrSessionManagerDraining, want: "draining"},
+		{name: "worker capacity", err: NewWorkerCapacityExhaustedError(time.Second), want: "capacity"},
+		{
+			name: "admission hard rejection",
+			err: &configstore.OrgConnectionAdmissionRejectedError{
+				Reason:         configstore.OrgConnectionAdmissionRejectedOrgVCPU,
+				RequestedVCPUs: 4,
+				MaximumVCPUs:   2,
+			},
+			want: "capacity",
+		},
+		{name: "generic error", err: errors.New("bootstrap failed"), want: "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := controlPlaneSessionStartOutcome(tt.err); got != tt.want {
+				t.Fatalf("controlPlaneSessionStartOutcome(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControlPlaneSessionStartOperationOutcomePrefersContext(t *testing.T) {
+	operationErr := errors.New("metadata initialization failed")
+	if got := controlPlaneSessionStartOperationOutcome(operationErr, context.Canceled, false); got != "canceled" {
+		t.Fatalf("canceled operation outcome = %q, want canceled", got)
+	}
+	if got := controlPlaneSessionStartOperationOutcome(operationErr, context.DeadlineExceeded, false); got != "timeout" {
+		t.Fatalf("timed-out operation outcome = %q, want timeout", got)
+	}
+	if got := controlPlaneSessionStartOperationOutcome(operationErr, nil, false); got != "error" {
+		t.Fatalf("ordinary operation outcome = %q, want error", got)
+	}
+	if got := controlPlaneSessionStartOperationOutcome(operationErr, context.Canceled, true); got != "draining" {
+		t.Fatalf("drain-canceled operation outcome = %q, want draining", got)
+	}
+}
+
 func TestBeginSessionDrainMarksControlPlaneDraining(t *testing.T) {
 	sessions := NewSessionManager(nil, nil)
 	cp := &ControlPlane{sessions: sessions}

--- a/controlplane/metrics_test_helpers_test.go
+++ b/controlplane/metrics_test_helpers_test.go
@@ -33,6 +33,19 @@ func metricGaugeValue(t *testing.T, metricName string) float64 {
 	return 0
 }
 
+func gaugeVecLabelValue(t *testing.T, gv *prometheus.GaugeVec, labels ...string) float64 {
+	t.Helper()
+	gauge, err := gv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("gauge labels %v: %v", labels, err)
+	}
+	metric := &dto.Metric{}
+	if err := gauge.Write(metric); err != nil {
+		t.Fatalf("gauge write labels %v: %v", labels, err)
+	}
+	return metric.GetGauge().GetValue()
+}
+
 func metricHistogramCount(t *testing.T, metricName string) uint64 {
 	t.Helper()
 	families, err := prometheus.DefaultGatherer.Gather()

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -376,6 +376,13 @@ func (tr *OrgRouter) publishOrgStack(orgID string, stack *OrgStack) orgStackPubl
 		stack.Sessions.BeginDrain()
 	}
 	tr.orgs[orgID] = stack
+	if stack != nil && stack.Config != nil {
+		sessionAdmissionLimitVCPUsGauge.WithLabelValues(orgID).Set(float64(stack.Config.MaxVCPUs))
+	} else {
+		// Minimal stacks are valid in lifecycle and concurrency paths. Without a
+		// config there is no authoritative limit value to publish.
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(orgID)
+	}
 	tr.mu.Unlock()
 	return orgStackPublishAccepted
 }
@@ -491,6 +498,7 @@ func (tr *OrgRouter) refreshOrgStackWhileMutationHeld(orgID string, stack *OrgSt
 	}
 	oldTC := stack.Config
 	stack.Config = tc
+	sessionAdmissionLimitVCPUsGauge.WithLabelValues(orgID).Set(float64(tc.MaxVCPUs))
 	tr.mu.Unlock()
 
 	limitsChanged := oldTC == nil || oldTC.MaxWorkers != tc.MaxWorkers
@@ -541,11 +549,17 @@ func (tr *OrgRouter) refreshOrgStackWhileMutationHeld(orgID string, stack *OrgSt
 func (tr *OrgRouter) removeOrgStackWhileMutationHeld(orgID string, expected *OrgStack) {
 	tr.mu.Lock()
 	stack, ok := tr.orgs[orgID]
-	if !ok || (expected != nil && stack != expected) {
+	if !ok {
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(orgID)
+		tr.mu.Unlock()
+		return
+	}
+	if expected != nil && stack != expected {
 		tr.mu.Unlock()
 		return
 	}
 	delete(tr.orgs, orgID)
+	sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(orgID)
 	tr.mu.Unlock()
 
 	slog.Info("Destroying org stack.", "org", orgID)
@@ -800,6 +814,7 @@ func (tr *OrgRouter) shutdownAll() {
 	orgs := make(map[string]*OrgStack, len(tr.orgs))
 	for k, v := range tr.orgs {
 		orgs[k] = v
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(k)
 	}
 	tr.orgs = make(map[string]*OrgStack)
 	tr.mu.Unlock()

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -154,6 +154,13 @@ func TestOrgRouterDestroyOrgStackDrainsSessionsBeforePoolShutdownAndReleasesSess
 }
 
 func TestOrgRouterShutdownAllDrainsAdmissionReclaimerAfterAllSessions(t *testing.T) {
+	orgs := []string{"first", "second"}
+	for i, org := range orgs {
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org)
+		sessionAdmissionLimitVCPUsGauge.WithLabelValues(org).Set(float64(i + 1))
+		org := org
+		t.Cleanup(func() { sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org) })
+	}
 	events := []string{}
 	firstPool := &recordingOrgRouterPool{events: &events}
 	secondPool := &recordingOrgRouterPool{events: &events}
@@ -193,6 +200,11 @@ func TestOrgRouterShutdownAllDrainsAdmissionReclaimerAfterAllSessions(t *testing
 	_, drainCalls := reclaimer.snapshot()
 	if drainCalls != 1 {
 		t.Fatalf("admission reclaimer drain calls = %d, want 1", drainCalls)
+	}
+	for _, org := range orgs {
+		if _, ok := metricGaugeFamilyLabelValue(t, "duckgres_session_admission_limit_vcpus", map[string]string{"org": org}); ok {
+			t.Fatalf("shutdown left admission limit series for org %q", org)
+		}
 	}
 }
 
@@ -1117,6 +1129,57 @@ func TestOrgRouterHandleConfigChangeRefreshesRuntimeOnlyUpdates(t *testing.T) {
 
 	if got := tr.orgs["analytics"].Config.Warehouse.MetadataStore.Endpoint; got != "new-metadata.internal" {
 		t.Fatalf("expected runtime-only update to refresh stack config, got %q", got)
+	}
+}
+
+func TestOrgRouterReconcilesAdmissionLimitGaugeWithOrgStackLifecycle(t *testing.T) {
+	const org = "admission-limit-lifecycle"
+	sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org)
+
+	sharedPool, _ := newTestK8sPool(t, 10)
+	initial := &configstore.OrgConfig{Name: org, MaxVCPUs: 16}
+	initialSnapshot := &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{org: initial}}
+	store := newTestConfigStoreWithSnapshot(initialSnapshot)
+	tr := &OrgRouter{
+		orgs:        make(map[string]*OrgStack),
+		configStore: store,
+		baseCfg:     K8sWorkerPoolConfig{},
+		sharedPool:  sharedPool,
+		globalCfg:   ControlPlaneConfig{},
+	}
+	t.Cleanup(func() {
+		tr.DestroyOrgStack(org)
+		sessionAdmissionLimitVCPUsGauge.DeleteLabelValues(org)
+	})
+
+	if _, err := tr.createOrgStack(initial); err != nil {
+		t.Fatalf("createOrgStack: %v", err)
+	}
+	if got := gaugeVecLabelValue(t, sessionAdmissionLimitVCPUsGauge, org); got != 16 {
+		t.Fatalf("initial admission limit = %v, want 16", got)
+	}
+
+	lowered := &configstore.OrgConfig{Name: org, MaxVCPUs: 8}
+	loweredSnapshot := &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{org: lowered}}
+	setTestConfigStoreSnapshot(store, loweredSnapshot)
+	tr.HandleConfigChange(initialSnapshot, loweredSnapshot)
+	if got := gaugeVecLabelValue(t, sessionAdmissionLimitVCPUsGauge, org); got != 8 {
+		t.Fatalf("lowered admission limit = %v, want 8", got)
+	}
+
+	unlimited := &configstore.OrgConfig{Name: org, MaxVCPUs: 0}
+	unlimitedSnapshot := &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{org: unlimited}}
+	setTestConfigStoreSnapshot(store, unlimitedSnapshot)
+	tr.HandleConfigChange(loweredSnapshot, unlimitedSnapshot)
+	if got := gaugeVecLabelValue(t, sessionAdmissionLimitVCPUsGauge, org); got != 0 {
+		t.Fatalf("unlimited admission limit = %v, want 0", got)
+	}
+
+	removedSnapshot := &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{}}
+	setTestConfigStoreSnapshot(store, removedSnapshot)
+	tr.HandleConfigChange(unlimitedSnapshot, removedSnapshot)
+	if _, ok := metricGaugeFamilyLabelValue(t, "duckgres_session_admission_limit_vcpus", map[string]string{"org": org}); ok {
+		t.Fatal("expected removed org's admission limit series to be deleted")
 	}
 }
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,185 @@
+# Metrics
+
+Duckgres exposes Prometheus metrics on `:9090/metrics`. The port is currently
+fixed. Some control-plane and per-org metrics are available only in the
+Kubernetes build.
+
+This document is the reference for request-path metrics. The short catalog in
+the README links here rather than duplicating boundary and aggregation details.
+
+## Naming and labels
+
+Metric names follow `duckgres_<domain>_<operation>_<measurement>`. Durations
+end in `_seconds`, monotonically increasing event counts end in `_total`, and
+current state uses a gauge without either suffix.
+
+The request path uses these label terms consistently:
+
+- `org`: managed warehouse organization ID. It is empty in standalone mode.
+- `protocol`: protocol boundary; session-start metrics currently emit `postgres`.
+- `outcome`: terminal result at the metric's documented boundary.
+- `decision`: what happened to the polling request in one admission poll.
+- `reason`: a bounded, metric-specific cause. It is not a poll count.
+- `source`: how a worker was obtained.
+- `phase`: one internal worker-acquisition phase.
+
+Histograms expose the usual `_bucket`, `_count`, and `_sum` series.
+
+## Request path boundaries
+
+| Stage | Metrics | Boundary |
+|---|---|---|
+| Admission evaluation | `duckgres_session_admission_evaluation_*` | One request-owned DB admission poll, including its serialized transaction and lock wait. |
+| Admission queue | `duckgres_session_admission_wait_seconds`, `duckgres_session_admission_requests_total` | After a request is successfully enqueued until grant, hard rejection, timeout, cancellation, or evaluation error. Enqueue failures are excluded. |
+| Admission state | `duckgres_session_admission_queue_depth`, `duckgres_session_admission_active_vcpus`, `duckgres_session_admission_limit_vcpus` | Local waiting callers, live local lease handles, and the effective org cap reconciled for active org stacks from each control-plane process's current config snapshot. |
+| Worker acquisition | `duckgres_worker_acquire_*` | After admission grants until an existing, hot-idle, or newly spawned worker is allocated. |
+| Session start | `duckgres_session_start_duration_seconds` | After successful PostgreSQL authentication until `ReadyForQuery` is flushed or session bootstrap terminates. |
+| Query | `duckgres_query_total`, `duckgres_query_duration_seconds` | One non-empty query attempt and its execution duration. |
+
+Session start includes profile resolution, admission, worker
+allocation, worker session creation, catalog probing, metadata initialization,
+session defaults, and the final ready flush. It excludes failed authentication.
+
+## Admission metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `duckgres_session_admission_evaluation_duration_seconds` | Histogram | `decision`, `reason` | Latency of one DB-backed admission poll for the polling request. It intentionally has no `org` label. |
+| `duckgres_session_admission_evaluations_total` | Counter | `decision`, `reason` | Admission poll volume. This can be much larger than request volume because a queued request is polled repeatedly. |
+| `duckgres_session_admission_wait_seconds` | Histogram | `org`, `outcome`, `reason` | End-to-end queue wait for each successfully enqueued request. |
+| `duckgres_session_admission_requests_total` | Counter | `org`, `outcome`, `reason` | Exactly one terminal event per successfully enqueued request. |
+| `duckgres_session_admission_queue_depth` | Gauge | `org` | In-process callers still waiting after successful durable enqueue. It is not a count of durable queue rows. |
+| `duckgres_session_admission_active_vcpus` | Gauge | `org` | Requested vCPUs held by live local lease handles. It is admitted capacity, not measured CPU usage or the exact durable lease-row total. |
+| `duckgres_session_admission_limit_vcpus` | Gauge | `org` | Effective org cap for an active org stack, reconciled from this process's current config snapshot. `0` means unlimited. |
+| `duckgres_session_start_duration_seconds` | Histogram | `org`, `protocol`, `outcome` | Authenticated PostgreSQL create-to-ready latency. |
+
+Admission request outcomes are `granted`, `rejected`, `timeout`, `canceled`,
+and `error`. `rejected` means the requested worker shape can never fit its hard
+organization or user vCPU ceiling.
+Session-start outcomes are `success`, `timeout`, `canceled`, `capacity`,
+`draining`, and `error`.
+
+Evaluation decisions are `granted_current`, `already_granted`, `rejected`,
+`blocked`, `waiting`, `inactive`, `missing`, `canceled`, `timeout`, and `error`.
+Each evaluation describes only the polling request. Evaluation reasons are
+`none`, `org_vcpu`, `user_vcpu`, `org_user_vcpu`, `user_ineligible`,
+`resharding`, `fifo`, and `store_error`.
+
+A terminal request retains vCPU-cap attribution across every admission poll.
+No blocking poll produces `reason="none"`. If the request encountered an org
+cap, a user cap, or both, its terminal reason is `org_vcpu`, `user_vcpu`, or
+`org_user_vcpu`, respectively, even when it also encountered another reason.
+Without a vCPU-cap reason, one distinct reason is kept as-is and multiple
+distinct reasons become `mixed`. An admission store failure contributes
+`store_error`; interruption by the caller is classified as cancellation or
+timeout instead.
+
+Queue depth and active vCPUs are process-local logical contributions. Use
+`sum by (org)` across control-plane replicas. Active vCPUs drop when a live
+lease handle transfers cleanup ownership to the reclaimer; durable rows still
+awaiting cleanup are excluded, so database-enforced usage can temporarily be
+higher. Each replica reconciles the limit when it creates, updates, or removes
+an active org stack, so use `max by (org)` to collapse the duplicated replica
+values. Replicas can briefly differ while a config update propagates. Process
+exit removes its local gauge series automatically.
+
+### Admission cleanup metrics
+
+Cleanup ownership is reserved before durable enqueue and retained through the
+request and lease lifetime. These process-level metrics intentionally omit org
+and request labels:
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `duckgres_session_admission_reclaim_pending` | Gauge | None | Activated cleanup work retained or executing. |
+| `duckgres_session_admission_reclaim_attempts_total` | Counter | `outcome` | Exact cleanup attempts; outcomes are `success` and `error`. |
+| `duckgres_session_admission_reclaim_reservations_in_use` | Gauge | None | Reservations held before enqueue, while queued, by live leases, or by cleanup-pending work. |
+| `duckgres_session_admission_reclaim_reservation_capacity` | Gauge | None | Process-local cleanup reservation ceiling. |
+| `duckgres_session_admission_reclaim_reservation_rejections_total` | Counter | `reason` | Reservation failures: `full`, `closed`, or `duplicate`. |
+
+Sum the gauges across control-plane replicas for fleet totals. Pair cleanup
+backlog and error rate with the logical admission gauges when diagnosing a gap
+between live sessions and database-enforced vCPU usage.
+
+## Worker and query metrics
+
+The Kubernetes worker allocator keeps its existing names:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `duckgres_worker_acquire_total_seconds` | `org`, `source`, `outcome` | End-to-end worker allocation latency after admission. Sources are `idle_reuse`, `hot_idle_claim`, `spawn`, or `none`. |
+| `duckgres_worker_acquire_gate_wait_seconds` | `org`, `outcome` | Time waiting for the per-org FIFO worker-acquire gate. |
+| `duckgres_worker_acquire_phase_seconds` | `org`, `phase`, `outcome` | Individual `hot_idle_claim`, `spawn`, or `activate` phase latency. |
+| `duckgres_query_total` | `org`, `outcome` | One event per non-empty query attempt; outcomes are `success`, `error`, or `canceled`. |
+| `duckgres_query_duration_seconds` | `org` | Query execution latency. Use `duckgres_query_total` for terminal result counts. |
+
+The older fleet-level `duckgres_control_plane_worker_*` metrics remain useful
+for process-wide worker counts, spawn time, and the approximate post-admission
+worker queue. They have no org label and are not admission saturation metrics.
+
+## PromQL recipes
+
+Admission wait p95 by org and terminal result:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (org, outcome, le) (
+    rate(duckgres_session_admission_wait_seconds_bucket[5m])
+  )
+)
+```
+
+Terminal requests affected by an org or user vCPU cap:
+
+```promql
+sum by (org, reason) (
+  rate(duckgres_session_admission_requests_total{reason=~"org_vcpu|user_vcpu|org_user_vcpu"}[5m])
+)
+```
+
+Current queue depth and admitted vCPUs:
+
+```promql
+sum by (org) (duckgres_session_admission_queue_depth)
+sum by (org) (duckgres_session_admission_active_vcpus)
+```
+
+Live admitted-session utilization for capped orgs (`limit=0` is deliberately
+filtered out):
+
+```promql
+sum by (org) (duckgres_session_admission_active_vcpus)
+  / on (org)
+(max by (org) (duckgres_session_admission_limit_vcpus) > 0)
+```
+
+Authenticated session-start p95:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (org, protocol, outcome, le) (
+    rate(duckgres_session_start_duration_seconds_bucket[5m])
+  )
+)
+```
+
+## Admission metric migration
+
+The pre-canonical admission family is retired. Existing TSDB history remains,
+but old series stop receiving samples.
+
+| Retired metric | Replacement | Compatibility note |
+|---|---|---|
+| `duckgres_org_connection_admission_duration_seconds{outcome}` | `duckgres_session_admission_evaluation_duration_seconds{decision,reason}` | Same admission-evaluation layer, with the overloaded outcome split into decision and reason. |
+| `duckgres_org_connection_admission_attempts_total{outcome}` | `duckgres_session_admission_evaluations_total{decision,reason}` | Counts admission polls, not logical requests. |
+| `duckgres_org_connection_admission_queue_depth` histogram | `duckgres_session_admission_queue_depth{org}` gauge | A current per-process count of waiting callers replaces samples of durable queue shape; the values are not numerically equivalent. |
+| `duckgres_org_connection_admission_user_queues` | None | Per-user queue-head shape is no longer exported. |
+| `duckgres_org_connection_admission_user_limit_skips_total` | `duckgres_session_admission_requests_total{reason=~"user_vcpu|org_user_vcpu"}` | Measures affected logical requests rather than repeated skipped admission polls; the values are not numerically equivalent. |
+| `duckgres_org_connection_admission_ineligible_user_skips_total` | `duckgres_session_admission_requests_total{reason="user_ineligible"}` | Measures affected logical requests rather than repeated admission polls; use `duckgres_session_admission_evaluations_total{decision="blocked",reason="user_ineligible"}` for poll-level diagnostics. |
+| `duckgres_org_connection_reclaim_pending` | `duckgres_session_admission_reclaim_pending` | Semantics-preserving prefix rename. |
+| `duckgres_org_connection_reclaim_attempts_total{outcome}` | `duckgres_session_admission_reclaim_attempts_total{outcome}` | Semantics-preserving prefix rename. |
+| `duckgres_org_connection_reclaim_reservations_in_use` | `duckgres_session_admission_reclaim_reservations_in_use` | Semantics-preserving prefix rename. |
+| `duckgres_org_connection_reclaim_reservation_capacity` | `duckgres_session_admission_reclaim_reservation_capacity` | Semantics-preserving prefix rename. |
+| `duckgres_org_connection_reclaim_reservation_rejections_total{reason}` | `duckgres_session_admission_reclaim_reservation_rejections_total{reason}` | Semantics-preserving prefix rename. |

--- a/docs/runbooks/org-connection-admission.md
+++ b/docs/runbooks/org-connection-admission.md
@@ -27,7 +27,8 @@ transaction determines the eligible queue head, but creates a lease only when
 that head is the polling request. Otherwise the caller remains queued and the
 head's owner admits itself on its next poll.
 
-During a rolling deployment from the previous scheduler, old replicas may
+During a rolling deployment from the previous admission implementation, old
+replicas may
 still grant a foreign queue head and evaluate limits from their local config
 snapshot. Capacity remains protected by the shared org lock, but the strict
 request-owned and authoritative-limit invariants begin only after every old
@@ -76,16 +77,24 @@ admission reclaimer.
   control-plane runtime record and let the serialized cleanup path reclaim its
   admission rows.
 
-Monitor `duckgres_org_connection_reclaim_pending` for activated cleanup work,
-`duckgres_org_connection_reclaim_attempts_total{outcome}` for retry outcomes,
-and the ratio of `duckgres_org_connection_reclaim_reservations_in_use` to
-`duckgres_org_connection_reclaim_reservation_capacity` for ownership headroom.
-`duckgres_org_connection_reclaim_reservation_rejections_total{reason}` records
+Monitor `duckgres_session_admission_reclaim_pending` for activated cleanup work,
+`duckgres_session_admission_reclaim_attempts_total{outcome}` for cleanup-attempt
+outcomes,
+and the ratio of `duckgres_session_admission_reclaim_reservations_in_use` to
+`duckgres_session_admission_reclaim_reservation_capacity` for ownership
+headroom.
+`duckgres_session_admission_reclaim_reservation_rejections_total{reason}` records
 requests rejected before enqueue. Diagnose sustained backlog growth or high
 reservation utilization together with reclaim error rate; a continuously
 non-zero pending count can be healthy during steady connection churn. Reclaim
 logs include the request, org, retry count, and age; the metrics deliberately
 omit request and org labels.
+
+The org-labeled admission queue and active-vCPU gauges are logical local
+contributions, not exact durable row counts. Active vCPUs drop when cleanup is
+transferred to the reclaimer, before the durable lease row is necessarily
+deleted. Use the reclaim backlog and attempt metrics above when that distinction
+matters; [the metrics reference](../metrics.md) documents aggregation rules.
 
 For local verification, run `just test-configstore-integration`; it exercises
 cross-replica ordering, cancellation races, eventual live-owner reclamation,

--- a/server/observe/metrics.go
+++ b/server/observe/metrics.go
@@ -1,6 +1,7 @@
 package observe
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,6 +39,48 @@ var connectionDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramO
 // ObserveConnectionDuration records one completed connection's lifetime.
 func ObserveConnectionDuration(org string, seconds float64) {
 	connectionDurationHistogram.WithLabelValues(org).Observe(seconds)
+}
+
+var sessionStartDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "duckgres_session_start_duration_seconds",
+	Help:    "Authenticated session bootstrap time through protocol readiness, partitioned by org, protocol, and terminal outcome.",
+	Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+}, []string{"org", "protocol", "outcome"})
+
+// SessionStartScope records one logical protocol bootstrap. Finish is
+// idempotent so a default-error defer can coexist with an explicit success.
+type SessionStartScope struct {
+	started  time.Time
+	org      string
+	protocol string
+	once     sync.Once
+}
+
+func BeginSessionStart(org, protocol string) *SessionStartScope {
+	switch protocol {
+	case "postgres":
+	default:
+		protocol = "unknown"
+	}
+	return &SessionStartScope{started: time.Now(), org: org, protocol: protocol}
+}
+
+func (s *SessionStartScope) Finish(outcome string) {
+	if s == nil {
+		return
+	}
+	switch outcome {
+	case "success", "timeout", "canceled", "capacity", "draining", "error":
+	default:
+		outcome = "error"
+	}
+	s.once.Do(func() {
+		duration := time.Since(s.started)
+		if duration < 0 {
+			duration = 0
+		}
+		sessionStartDurationHistogram.WithLabelValues(s.org, s.protocol, outcome).Observe(duration.Seconds())
+	})
 }
 
 // S3BytesReadTotal counts bytes read from S3 by DuckDB, labeled by org.

--- a/server/observe/metrics_test.go
+++ b/server/observe/metrics_test.go
@@ -82,6 +82,35 @@ func TestObserveConnectionDurationRecordsPerOrgSample(t *testing.T) {
 	}
 }
 
+func TestSessionStartScopeRecordsExactlyOnce(t *testing.T) {
+	const org = "session-start-test-org"
+	before := sessionStartSampleCount(t, org, "postgres", "success")
+
+	scope := BeginSessionStart(org, "postgres")
+	scope.Finish("success")
+	scope.Finish("error")
+
+	if got := sessionStartSampleCount(t, org, "postgres", "success"); got != before+1 {
+		t.Fatalf("success sample count = %d, want %d", got, before+1)
+	}
+	if got := sessionStartSampleCount(t, org, "postgres", "error"); got != 0 {
+		t.Fatalf("error sample count = %d, want 0", got)
+	}
+}
+
+func sessionStartSampleCount(t *testing.T, org, protocol, outcome string) uint64 {
+	t.Helper()
+	observer, err := sessionStartDurationHistogram.GetMetricWithLabelValues(org, protocol, outcome)
+	if err != nil {
+		t.Fatalf("session start histogram labels: %v", err)
+	}
+	metric := &dto.Metric{}
+	if err := observer.(interface{ Write(*dto.Metric) error }).Write(metric); err != nil {
+		t.Fatalf("session start histogram write: %v", err)
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
 func TestQueryLogMetricsHelpersRecordBufferFlushAndDrops(t *testing.T) {
 	enqueuedBefore := counterValue(t, queryLogEnqueuedEntriesTotal)
 	flushedBefore := counterValue(t, queryLogFlushedEntriesTotal)

--- a/tests/configstore/org_connection_limiter_test.go
+++ b/tests/configstore/org_connection_limiter_test.go
@@ -3,7 +3,9 @@
 package configstore_test
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strings"
@@ -1116,16 +1118,15 @@ func TestOrgConnectionLeasesReordersUserQueueAfterHeadGranted(t *testing.T) {
 	}
 }
 
-func TestOrgConnectionAdmissionMetricsObserveAttemptsAndQueueShape(t *testing.T) {
+func TestOrgConnectionAdmissionMetricsObservePollingRequestEvaluation(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	upsertActiveCP(t, store, "cp-a")
 
-	durationBefore := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_duration_seconds")
-	queueBefore := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_queue_depth")
-	userQueuesBefore := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_user_queues")
-	outcomesBefore := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_attempts_total")
+	durationBefore := configstoreMetricHistogramCount(t, "duckgres_session_admission_evaluation_duration_seconds")
+	evaluationsBefore := configstoreMetricCounterFamilyTotal(t, "duckgres_session_admission_evaluations_total")
 
 	now := time.Now()
+	seedAuthoritativeOrgConnectionLimits(t, store, "org-metrics", 2, map[string]int{"alice": 0})
 	request := &cpconfigstore.OrgConnectionQueueEntry{
 		RequestID:      "request-metrics",
 		OrgID:          "org-metrics",
@@ -1140,30 +1141,38 @@ func TestOrgConnectionAdmissionMetricsObserveAttemptsAndQueueShape(t *testing.T)
 	if err := store.EnqueueOrgConnectionRequest(request); err != nil {
 		t.Fatalf("enqueue metrics request: %v", err)
 	}
-	lease, err := store.TryAcquireOrgConnectionLease(request.RequestID, cpconfigstore.OrgResourceLimits{OrgMaxVCPUs: 2}, now)
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: request.RequestID, OrgID: request.OrgID, CPInstanceID: request.CPInstanceID}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
 	if err != nil {
 		t.Fatalf("acquire metrics request: %v", err)
 	}
 	if lease == nil {
 		t.Fatal("expected metrics request to acquire")
 	}
+	if evaluation.Decision != "granted_current" || evaluation.Reason != "none" {
+		t.Fatalf("evaluation = %#v, want granted_current/none", evaluation)
+	}
 
-	durationAfter := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_duration_seconds")
-	queueAfter := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_queue_depth")
-	userQueuesAfter := configstoreMetricHistogramCount(t, "duckgres_org_connection_admission_user_queues")
-	outcomesAfter := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_attempts_total")
+	durationAfter := configstoreMetricHistogramCount(t, "duckgres_session_admission_evaluation_duration_seconds")
+	evaluationsAfter := configstoreMetricCounterFamilyTotal(t, "duckgres_session_admission_evaluations_total")
 
 	if durationAfter-durationBefore != 1 {
 		t.Fatalf("expected admission duration sample delta 1, got %d", durationAfter-durationBefore)
 	}
-	if queueAfter-queueBefore != 1 {
-		t.Fatalf("expected queue depth sample delta 1, got %d", queueAfter-queueBefore)
+	if evaluationsAfter-evaluationsBefore != 1 {
+		t.Fatalf("expected admission evaluations counter delta 1, got %f", evaluationsAfter-evaluationsBefore)
 	}
-	if userQueuesAfter-userQueuesBefore != 1 {
-		t.Fatalf("expected user queues sample delta 1, got %d", userQueuesAfter-userQueuesBefore)
-	}
-	if outcomesAfter-outcomesBefore != 1 {
-		t.Fatalf("expected admission attempts counter delta 1, got %f", outcomesAfter-outcomesBefore)
+	for _, retired := range []string{
+		"duckgres_org_connection_admission_duration_seconds",
+		"duckgres_org_connection_admission_attempts_total",
+		"duckgres_org_connection_admission_queue_depth",
+		"duckgres_org_connection_admission_user_queues",
+		"duckgres_org_connection_admission_user_limit_skips_total",
+		"duckgres_org_connection_admission_ineligible_user_skips_total",
+	} {
+		if configstoreMetricExists(t, retired) {
+			t.Fatalf("retired metric %q is still registered", retired)
+		}
 	}
 }
 
@@ -1192,26 +1201,21 @@ func TestOrgConnectionAdmissionMetricsDoNotCountDisabledUserAsVCPULimit(t *testi
 		t.Fatalf("enqueue disabled-user metrics request: %v", err)
 	}
 
-	userLimitBefore := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_user_limit_skips_total")
-	ineligibleBefore := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_ineligible_user_skips_total")
-	outcomeBefore := configstoreMetricCounterValue(t, "duckgres_org_connection_admission_attempts_total", "outcome", "ineligible_user")
+	evaluationBefore := configstoreMetricCounterValue(t, "duckgres_session_admission_evaluations_total", "decision", "blocked", "reason", "user_ineligible")
 
-	lease, err := store.ScheduleAndClaimOrgConnectionLease(requestID, "cp-disabled-metrics")
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: requestID, OrgID: orgID, CPInstanceID: "cp-disabled-metrics"}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
 	if err != nil {
 		t.Fatalf("admit disabled-user metrics request: %v", err)
 	}
 	if lease != nil {
 		t.Fatalf("disabled user received lease %#v", lease)
 	}
-
-	if delta := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_user_limit_skips_total") - userLimitBefore; delta != 0 {
-		t.Fatalf("disabled user changed vCPU-limit skip counter by %f, want 0", delta)
+	if evaluation.Decision != "blocked" || evaluation.Reason != "user_ineligible" {
+		t.Fatalf("disabled-user evaluation = %#v, want blocked/user_ineligible", evaluation)
 	}
-	if delta := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_ineligible_user_skips_total") - ineligibleBefore; delta != 1 {
-		t.Fatalf("disabled user changed ineligible-user skip counter by %f, want 1", delta)
-	}
-	if delta := configstoreMetricCounterValue(t, "duckgres_org_connection_admission_attempts_total", "outcome", "ineligible_user") - outcomeBefore; delta != 1 {
-		t.Fatalf("disabled user changed ineligible outcome counter by %f, want 1", delta)
+	if delta := configstoreMetricCounterValue(t, "duckgres_session_admission_evaluations_total", "decision", "blocked", "reason", "user_ineligible") - evaluationBefore; delta != 1 {
+		t.Fatalf("disabled user changed blocked/user_ineligible evaluations by %f, want 1", delta)
 	}
 }
 
@@ -1244,13 +1248,188 @@ func TestOrgConnectionAdmissionMetricsDoNotCountPermanentlyImpossibleForeignHead
 		}
 	}
 
-	userLimitBefore := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_user_limit_skips_total")
-	lease, err := store.ScheduleAndClaimOrgConnectionLease("request-eligible-behind", "cp-eligible-behind")
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: "request-eligible-behind", OrgID: orgID, CPInstanceID: "cp-eligible-behind"}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
 	if err != nil || lease == nil {
 		t.Fatalf("eligible request behind impossible head = %#v, err = %v", lease, err)
 	}
-	if delta := configstoreMetricCounterFamilyTotal(t, "duckgres_org_connection_admission_user_limit_skips_total") - userLimitBefore; delta != 0 {
-		t.Fatalf("permanently impossible foreign head changed saturation skip counter by %f, want 0", delta)
+	if evaluation.Decision != "granted_current" || evaluation.Reason != "none" {
+		t.Fatalf("eligible request evaluation = %#v, want granted_current/none", evaluation)
+	}
+}
+
+func TestOrgConnectionAdmissionEvaluationUsesPollingRequestCapacity(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-a")
+	upsertActiveCP(t, store, "cp-b")
+	const orgID = "org-evaluation-attribution"
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 4, map[string]int{
+		"alice": 1,
+		"bob":   0,
+		"carol": 0,
+	})
+
+	now := time.Now()
+	active := []*cpconfigstore.OrgConnectionQueueEntry{
+		{RequestID: "request-active-alice", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a", PID: 1001, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute)},
+		{RequestID: "request-active-carol", OrgID: orgID, Username: "carol", CPInstanceID: "cp-b", PID: 1002, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now.Add(time.Millisecond), ExpiresAt: now.Add(time.Minute)},
+	}
+	for _, entry := range active {
+		if err := store.EnqueueOrgConnectionRequest(entry); err != nil {
+			t.Fatalf("enqueue active request %q: %v", entry.RequestID, err)
+		}
+		ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: entry.RequestID, OrgID: entry.OrgID, CPInstanceID: entry.CPInstanceID}
+		lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+		if err != nil || lease == nil || evaluation.Decision != "granted_current" {
+			t.Fatalf("grant active request %q = lease %#v, evaluation %#v, err %v", entry.RequestID, lease, evaluation, err)
+		}
+	}
+
+	blockedAlice := &cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: "request-blocked-alice", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+		PID: 1003, Protocol: "postgres", RequestedVCPUs: 1,
+		EnqueuedAt: now.Add(2 * time.Millisecond), ExpiresAt: now.Add(time.Minute),
+	}
+	blockedBob := &cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: "request-blocked-bob", OrgID: orgID, Username: "bob", CPInstanceID: "cp-b",
+		PID: 1004, Protocol: "postgres", RequestedVCPUs: 3,
+		EnqueuedAt: now.Add(3 * time.Millisecond), ExpiresAt: now.Add(time.Minute),
+	}
+	for _, entry := range []*cpconfigstore.OrgConnectionQueueEntry{blockedAlice, blockedBob} {
+		if err := store.EnqueueOrgConnectionRequest(entry); err != nil {
+			t.Fatalf("enqueue blocked request %q: %v", entry.RequestID, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		entry  *cpconfigstore.OrgConnectionQueueEntry
+		reason string
+	}{
+		{entry: blockedAlice, reason: "user_vcpu"},
+		{entry: blockedBob, reason: "org_vcpu"},
+	} {
+		ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: tc.entry.RequestID, OrgID: tc.entry.OrgID, CPInstanceID: tc.entry.CPInstanceID}
+		lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+		if err != nil || lease != nil {
+			t.Fatalf("evaluate %q = lease %#v, err %v", tc.entry.RequestID, lease, err)
+		}
+		if evaluation.Decision != "blocked" || evaluation.Reason != tc.reason {
+			t.Fatalf("evaluation for %q = %#v, want blocked/%s", tc.entry.RequestID, evaluation, tc.reason)
+		}
+	}
+}
+
+func TestOrgConnectionAdmissionEvaluationReportsCombinedVCPULimits(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-a")
+	const orgID = "org-evaluation-combined"
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 2, map[string]int{"alice": 2})
+	now := time.Now()
+	active := &cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: "request-active", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+		PID: 1001, Protocol: "postgres", RequestedVCPUs: 2, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute),
+	}
+	if err := store.EnqueueOrgConnectionRequest(active); err != nil {
+		t.Fatalf("enqueue active request: %v", err)
+	}
+	activeRef := cpconfigstore.OrgConnectionAdmissionRef{RequestID: active.RequestID, OrgID: orgID, CPInstanceID: active.CPInstanceID}
+	if lease, _, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), activeRef); err != nil || lease == nil {
+		t.Fatalf("grant active request = %#v, err %v", lease, err)
+	}
+
+	blocked := &cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: "request-blocked", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+		PID: 1002, Protocol: "postgres", RequestedVCPUs: 1,
+		EnqueuedAt: now.Add(time.Millisecond), ExpiresAt: now.Add(time.Minute),
+	}
+	if err := store.EnqueueOrgConnectionRequest(blocked); err != nil {
+		t.Fatalf("enqueue blocked request: %v", err)
+	}
+	blockedRef := cpconfigstore.OrgConnectionAdmissionRef{RequestID: blocked.RequestID, OrgID: orgID, CPInstanceID: blocked.CPInstanceID}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), blockedRef)
+	if err != nil || lease != nil {
+		t.Fatalf("evaluate blocked request = lease %#v, err %v", lease, err)
+	}
+	if evaluation.Decision != "blocked" || evaluation.Reason != "org_user_vcpu" {
+		t.Fatalf("evaluation = %#v, want blocked/org_user_vcpu", evaluation)
+	}
+}
+
+func TestOrgConnectionAdmissionEvaluationReportsHardRejection(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-a")
+	const orgID = "org-evaluation-rejected"
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 2, map[string]int{"alice": 0})
+	now := time.Now()
+	request := &cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: "request-rejected", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+		PID: 1001, Protocol: "postgres", RequestedVCPUs: 3, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute),
+	}
+	if err := store.EnqueueOrgConnectionRequest(request); err != nil {
+		t.Fatalf("enqueue rejected request: %v", err)
+	}
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: request.RequestID, OrgID: orgID, CPInstanceID: request.CPInstanceID}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+	if lease != nil || !errors.Is(err, cpconfigstore.ErrOrgConnectionAdmissionRejected) {
+		t.Fatalf("hard rejection = lease %#v, err %v", lease, err)
+	}
+	if evaluation.Decision != "rejected" || evaluation.Reason != "org_vcpu" {
+		t.Fatalf("hard-rejection evaluation = %#v, want rejected/org_vcpu", evaluation)
+	}
+	assertOrgConnectionRequestAbsent(t, store, request.RequestID)
+}
+
+func TestOrgConnectionAdmissionEvaluationKeepsSameUserNonHeadInFIFO(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-a")
+	const orgID = "org-evaluation-same-user-fifo"
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 4, map[string]int{"alice": 4})
+	now := time.Now()
+	requests := []*cpconfigstore.OrgConnectionQueueEntry{
+		{
+			RequestID: "request-first", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+			PID: 1001, Protocol: "postgres", RequestedVCPUs: 1,
+			EnqueuedAt: now, ExpiresAt: now.Add(time.Minute),
+		},
+		{
+			RequestID: "request-second", OrgID: orgID, Username: "alice", CPInstanceID: "cp-a",
+			PID: 1002, Protocol: "postgres", RequestedVCPUs: 1,
+			EnqueuedAt: now.Add(time.Millisecond), ExpiresAt: now.Add(time.Minute),
+		},
+	}
+	for _, request := range requests {
+		if err := store.EnqueueOrgConnectionRequest(request); err != nil {
+			t.Fatalf("enqueue %q: %v", request.RequestID, err)
+		}
+	}
+
+	second := requests[1]
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: second.RequestID, OrgID: orgID, CPInstanceID: second.CPInstanceID}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+	if err != nil || lease != nil {
+		t.Fatalf("evaluate same-user non-head = lease %#v, err %v", lease, err)
+	}
+	if evaluation.Decision != "waiting" || evaluation.Reason != "fifo" {
+		t.Fatalf("same-user non-head evaluation = %#v, want waiting/fifo", evaluation)
+	}
+	assertOrgConnectionRequestPending(t, store, requests[0].RequestID)
+	assertOrgConnectionRequestPending(t, store, requests[1].RequestID)
+}
+
+func TestOrgConnectionAdmissionEvaluationClassifiesCanceledContext(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	ref := cpconfigstore.OrgConnectionAdmissionRef{
+		RequestID: "request-context-canceled", OrgID: "org-context-canceled", CPInstanceID: "cp-context-canceled",
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(ctx, ref)
+	if lease != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled evaluation = lease %#v, err %v", lease, err)
+	}
+	if evaluation.Decision != "canceled" || evaluation.Reason != "none" {
+		t.Fatalf("canceled evaluation = %#v, want canceled/none", evaluation)
 	}
 }
 
@@ -2151,6 +2330,20 @@ func configstoreMetricHistogramCount(t *testing.T, metricName string) uint64 {
 	return 0
 }
 
+func configstoreMetricExists(t *testing.T, metricName string) bool {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() == metricName {
+			return true
+		}
+	}
+	return false
+}
+
 func configstoreMetricCounterFamilyTotal(t *testing.T, metricName string) float64 {
 	t.Helper()
 	families, err := prometheus.DefaultGatherer.Gather()
@@ -2173,8 +2366,11 @@ func configstoreMetricCounterFamilyTotal(t *testing.T, metricName string) float6
 	return 0
 }
 
-func configstoreMetricCounterValue(t *testing.T, metricName, labelName, labelValue string) float64 {
+func configstoreMetricCounterValue(t *testing.T, metricName string, labelPairs ...string) float64 {
 	t.Helper()
+	if len(labelPairs)%2 != 0 {
+		t.Fatalf("metric %q label pairs must be name/value pairs: %v", metricName, labelPairs)
+	}
 	families, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("failed to gather metrics: %v", err)
@@ -2187,10 +2383,22 @@ func configstoreMetricCounterValue(t *testing.T, metricName, labelName, labelVal
 			t.Fatalf("metric %q is not a counter", metricName)
 		}
 		for _, metric := range fam.GetMetric() {
-			for _, label := range metric.GetLabel() {
-				if label.GetName() == labelName && label.GetValue() == labelValue {
-					return metric.GetCounter().GetValue()
+			matches := true
+			for i := 0; i < len(labelPairs); i += 2 {
+				found := false
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == labelPairs[i] && label.GetValue() == labelPairs[i+1] {
+						found = true
+						break
+					}
 				}
+				if !found {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return metric.GetCounter().GetValue()
 			}
 		}
 		return 0


### PR DESCRIPTION
## Summary

- add org-labelled logical admission wait/count metrics plus queue-depth, active-vCPU, and config-reconciled limit gauges
- split each DB-backed admission poll into bounded `decision` and `reason` labels, attributed only to the polling request
- preserve #974's exact-ref, request-owned admission protocol while distinguishing org, user, combined-vCPU, FIFO, ineligible-user, resharding, and store-error reasons
- canonicalize admission-reclaimer metric names under `duckgres_session_admission_*`
- measure PostgreSQL session bootstrap from successful authentication through flushed `ReadyForQuery`, including capacity, timeout, cancellation, drain, and error outcomes
- document metric boundaries, replica aggregation, PromQL examples, and the current-to-new migration

## Verification

- `just lint`
- `just test-controlplane`
- `just test-controlplane-k8s`
- `just test-configstore-integration`
- focused cancellation, queue-depth, gauge-lifecycle, exact-ref attribution, and session-start tests
- concurrent limiter tests with `-race`
- new synchronization-sensitive tests repeated 20 times
- `just test-impact-plan origin/main HEAD` reports neutral or increased coverage, with no reduction warnings

`just ci` reaches the repository integration suite, where the pre-existing `TestCatalogPsqlCommands/psql_dn` row-count mismatch fails identically on this branch and clean `origin/main`. The changed-package suites above are green.

## Compatibility

The six legacy `duckgres_org_connection_admission_*` metrics and five `duckgres_org_connection_reclaim_*` metric names are intentionally retired. `docs/metrics.md` contains the replacement mapping and calls out where request-level semantics are not numerically equivalent to the retired poll-level metrics.

## Out of scope

- Flight session-start instrumentation; that endpoint is pending removal.
- Pre-existing gauge cleanup behavior: `duckgres_org_sessions_active{org}` can retain a removed org's last series, while the storage gauges can retain last-successful samples across org removal or leader handoff. This PR applies explicit lifecycle reconciliation only to the new admission-limit gauge.
