### PR TITLE
fix(worker): keep cache-proxy S3 transport across credential refresh

### DIFF
--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -242,7 +242,16 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			refreshFn = server.RefreshS3Secret
 		}
 		if payload.DuckLake.ObjectStore != "" {
-			if err := refreshFn(refreshDB, payload.DuckLake, sem); err != nil {
+			// The refresh rebuilds the ducklake_s3 secret from this config, so
+			// it must carry the same cache-proxy transport (HTTPProxy +
+			// USE_SSL=false + pinned endpoint) the attach path applies —
+			// otherwise the first CP-driven credential rotation replaces the
+			// path-style plain-HTTP secret with a vhost/HTTPS one and every S3
+			// read CONNECT-tunnels past the NVMe cache for the rest of the
+			// worker's life (mw-prod-us 2026-07-17).
+			refreshCfg := payload.DuckLake
+			overrideS3EndpointForCacheProxy(&refreshCfg)
+			if err := refreshFn(refreshDB, refreshCfg, sem); err != nil {
 				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
 				return false
 			}

--- a/duckdbservice/activation_test.go
+++ b/duckdbservice/activation_test.go
@@ -365,6 +365,107 @@ func TestSessionPoolActivateTenantAllowsSameOwnerSameEpochCredentialRetry(t *tes
 	}
 }
 
+// Regression test for the mw-prod-us 2026-07-17 cache bypass: the hot-idle
+// credential refresh rebuilt ducklake_s3 from the RAW activation payload,
+// dropping the cache-proxy transport (HTTPProxy + USE_SSL=false + pinned
+// endpoint) the attach path applies. The first CP-driven STS rotation then
+// flipped every worker to vhost/HTTPS CONNECT tunnels that the NVMe cache
+// proxy cannot cache. The refresh must see the same overridden config the
+// attach saw.
+func TestSessionPoolCredentialRefreshKeepsCacheProxyTransport(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		cfg:            server.Config{Users: map[string]string{"postgres": "postgres"}},
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+
+	var opened *sql.DB
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		opened = db
+		return PairFromMain(db), nil
+	}
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		return nil
+	}
+	defer func() {
+		if opened != nil {
+			_ = opened.Close()
+		}
+	}()
+
+	first := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{
+			OwnerEpoch:   2,
+			CPInstanceID: "cp-live:boot-a",
+			WorkerID:     17,
+		},
+		OrgID: "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore:  "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:    "s3://analytics/warehouse/",
+			S3Region:       "us-east-1",
+			S3AccessKey:    "OLD_ACCESS_KEY",
+			S3SecretKey:    "OLD_SECRET_KEY",
+			S3SessionToken: "OLD_SESSION_TOKEN",
+		},
+	}
+	if err := pool.activateTenant(first); err != nil {
+		t.Fatalf("first ActivateTenant: %v", err)
+	}
+
+	var refreshCalls int
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		refreshCalls++
+		if dlCfg.HTTPProxy != "http://10.0.0.9:8080" {
+			t.Errorf("refresh config lost cache-proxy HTTPProxy: got %q", dlCfg.HTTPProxy)
+		}
+		if dlCfg.S3UseSSL {
+			t.Error("refresh config lost USE_SSL=false override — secret would be rebuilt as HTTPS and bypass the cache proxy")
+		}
+		if dlCfg.S3Endpoint != "s3.us-east-1.amazonaws.com" {
+			t.Errorf("refresh config lost pinned S3 endpoint: got %q", dlCfg.S3Endpoint)
+		}
+		if dlCfg.S3AccessKey != "NEW_ACCESS_KEY" {
+			t.Errorf("expected refresh with rotated credentials, got %q", dlCfg.S3AccessKey)
+		}
+		return nil
+	}
+
+	second := first
+	second.DuckLake.S3AccessKey = "NEW_ACCESS_KEY"
+	second.DuckLake.S3SecretKey = "NEW_SECRET_KEY"
+	second.DuckLake.S3SessionToken = "NEW_SESSION_TOKEN"
+	if err := pool.activateTenant(second); err != nil {
+		t.Fatalf("credential rotation re-activation: %v", err)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("expected one credential refresh, got %d", refreshCalls)
+	}
+
+	// The stored payload must keep the RAW config (no proxy fields) so
+	// needsRefresh DeepEqual comparisons against future raw payloads stay
+	// meaningful — the override belongs only to the exec'd refresh.
+	current := pool.currentActivation()
+	if current == nil {
+		t.Fatal("expected activation to remain present")
+	}
+	if current.payload.DuckLake.HTTPProxy != "" {
+		t.Fatalf("stored payload must stay raw, got HTTPProxy %q", current.payload.DuckLake.HTTPProxy)
+	}
+}
+
 func TestSessionPoolValidateControlMetadataAcceptsMismatchedCPInstanceID(t *testing.T) {
 	pool := &SessionPool{
 		sharedWarmMode:    true,

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -17,6 +17,13 @@
 # Anything that kills/drains/counts worker pods MUST stay inside its org's lane
 # and select pods via the org label (newest_org_worker), never globally.
 #
+# UNIT-ONLY (not assertable in this Job): the cache-proxy S3 transport override
+# (duckdbservice/cache_proxy.go + the hot-idle credential-refresh path in
+# activation.go, mw-prod-us 2026-07-17 regression) — mw-dev does not deploy the
+# duckgres-cache-proxy DaemonSet, and enabling DUCKGRES_CACHE_ENABLED without it
+# would hang worker startup on the proxy health wait. Covered by
+# TestSessionPoolCredentialRefreshKeepsCacheProxyTransport in
+# duckdbservice/activation_test.go.
 #
 #   wire/query   : SELECT 1 round-trips, N concurrent connections stay distinct,
 #                  a malformed startup-message length is rejected cleanly (no CP


### PR DESCRIPTION
## Summary

Every S3 read on mw-prod-us workers was bypassing the NVMe cache proxy as an HTTPS CONNECT tunnel (>99.9% of proxy traffic; ~0 cache hits fleet-wide; ~19 MB/s effective scan throughput on a 46-vCPU worker at ~0.1 CPU — a cold `posthog.events` July scan "never finishes").

Root cause: the hot-idle reuse path (`reuseExistingActivation`) rebuilds `ducklake_s3` from the **raw** activation payload on CP-driven STS rotation, dropping the cache-proxy transport (`HTTPProxy` + `USE_SSL=false` + pinned endpoint) that the attach path applies via `overrideS3EndpointForCacheProxy`. So a worker serves plain-HTTP path-style (cacheable) requests only from attach until its first credential rotation, then flips to vhost/HTTPS tunnels for the rest of its life. Verified live: `duckdb_secrets()` in a tenant session shows `url_style=vhost;use_ssl=true`.

## Fix

Apply the same override to the config used for the refresh exec. Stored payload stays raw so `needsRefresh` DeepEqual comparisons against future raw payloads keep working (asserted in the test).

## Testing

- `TestSessionPoolCredentialRefreshKeepsCacheProxyTransport` — fails without the fix (`refresh config lost cache-proxy HTTPProxy`), passes with it.
- `go test ./duckdbservice/` green; `go build ./...` green.
- mw-dev e2e cannot exercise this path (no cache-proxy DaemonSet in that cluster; enabling `DUCKGRES_CACHE_ENABLED` without it hangs worker startup on the proxy health wait) — documented in the harness header per the repo contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012giqawJ7J8oSAv3vx9ZGJw