### PR TITLE
feat(configstore): replace org default_team_id with duckgres_org_teams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,12 +471,14 @@ worker size: `cpu_seconds = vCPU × ceil(conn_secs)`, `memory_seconds = GiB ×
 ceil(conn_secs)`. Counted internally in integer **millicore-seconds** /
 **MiB-seconds** (`compute_meter.go`) to avoid truncating a fractional-core /
 sub-GiB worker; worker size is stored in the bucket key as exact NUMERIC
-decimals (vCPU / GiB). `team_id` is the org's `default_team_id` (an integer —
-PostHog's `Team.id`; a JSON NUMBER on every API surface, a **NOT NULL** BIGINT
-in the config store — required at org creation on both the provisioning and
-admin APIs, never clearable via the admin API, so every org always has one;
-resolved from the config snapshot at connection end, where 0 can still appear
-only for an unknown org / stale snapshot); `query_source` is the
+decimals (vCPU / GiB). `team_id` is the org's **billing team** (an integer —
+PostHog's `Team.id`; a JSON NUMBER on every API surface, kept under the
+historical `default_team_id` field name; stored as the org's
+`duckgres_org_teams` row with `is_billing_team = TRUE` — required at org
+creation on both the provisioning and admin APIs, never clearable via the
+admin API, so every org always has one; resolved from the config snapshot at
+connection end, where 0 can still appear only for an unknown org / stale
+snapshot); `query_source` is the
 `duckgres.query_source` session GUC (`standard` unless set; a mid-connection
 change bills the whole connection under the final value). The GUC is a **closed
 enum validated at SET time** (`transform.NormalizeQuerySource`): only
@@ -523,8 +525,9 @@ touching this path:
 - **Graceful shutdown does a final flush** after connections drain to their
   natural end (`shutdown`/`drainAndShutdown`), so a departing CP pod lands its
   last interval before exit.
-- **Changing an org's `default_team_id` re-attributes its unacked buckets** to
-  the new team in the SAME transaction as the org update, on BOTH paths (admin
+- **Changing an org's billing team (`default_team_id` on the wire)
+  re-attributes its unacked buckets** to
+  the new team in the SAME transaction as the billing-team repoint, on BOTH paths (admin
   `PUT /orgs/:id` and provisioning re-provision) via
   `configstore.ReattributeUsageTeamTx` — additive fold on PK collisions; a
   small in-flight residual under the old team is tolerated (snapshot poll

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -23,6 +23,11 @@ import (
 
 var errWarehousePayloadNotAllowed = errors.New("warehouse payload must be updated via /orgs/:id/warehouse")
 
+// The teams association is read-only through the org endpoints: the billing
+// team is managed via the default_team_id field, and there is no direct
+// team-list mutation surface yet.
+var errOrgTeamsPayloadNotAllowed = errors.New("teams cannot be set directly; set the billing team via default_team_id")
+
 var errWarehouseStillExists = errors.New("managed warehouse still exists for org")
 
 // maxWarehousePutBodyBytes caps the admin PUT body. Warehouse payloads are
@@ -129,10 +134,12 @@ type apiStore interface {
 	CreateOrg(org *configstore.Org) error
 	GetOrg(name string) (*configstore.Org, error)
 	// UpdateOrg persists the merged org row. reattributeUsageTeam is non-nil
-	// when the update changes default_team_id: the store must then re-attribute
-	// the org's buffered (unacked) billing buckets to that new team id in the
-	// SAME transaction as the org-row update, so a committed team change never
-	// leaves usage stranded under the old team.
+	// when the update changes the org's billing team (the wire field
+	// default_team_id): the store must then repoint the org's billing team row
+	// (duckgres_org_teams) AND re-attribute the org's buffered (unacked)
+	// billing buckets to that new team id in the SAME transaction as the
+	// org-row update, so a committed team change never leaves usage stranded
+	// under the old team.
 	UpdateOrg(name string, updates configstore.Org, reattributeUsageTeam *int64) (*configstore.Org, bool, error)
 	DeleteOrg(name string) (bool, error)
 
@@ -167,22 +174,37 @@ func (s *gormAPIStore) db() *gorm.DB {
 
 func (s *gormAPIStore) ListOrgs() ([]configstore.Org, error) {
 	var orgs []configstore.Org
-	if err := s.db().Preload("Users").Preload("Warehouse").Find(&orgs).Error; err != nil {
+	if err := s.db().Preload("Users").Preload("Warehouse").Preload("Teams").Find(&orgs).Error; err != nil {
 		return nil, err
+	}
+	for i := range orgs {
+		orgs[i].DefaultTeamID = orgs[i].BillingTeamID()
 	}
 	return orgs, nil
 }
 
 func (s *gormAPIStore) CreateOrg(org *configstore.Org) error {
 	org.Warehouse = nil
-	return s.db().Omit("Warehouse").Create(org).Error
+	// One transaction: org row + its billing team row (duckgres_org_teams).
+	// The handler already required a positive DefaultTeamID, so a created org
+	// is always born with its billing team.
+	return s.db().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Omit("Warehouse", "Teams").Create(org).Error; err != nil {
+			return err
+		}
+		if org.DefaultTeamID == nil {
+			return nil
+		}
+		return configstore.SetOrgBillingTeamTx(tx, org.Name, *org.DefaultTeamID)
+	})
 }
 
 func (s *gormAPIStore) GetOrg(name string) (*configstore.Org, error) {
 	var org configstore.Org
-	if err := s.db().Preload("Users").Preload("Warehouse").First(&org, "name = ?", name).Error; err != nil {
+	if err := s.db().Preload("Users").Preload("Warehouse").Preload("Teams").First(&org, "name = ?", name).Error; err != nil {
 		return nil, err
 	}
+	org.DefaultTeamID = org.BillingTeamID()
 	return &org, nil
 }
 
@@ -207,24 +229,12 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org, reattribu
 			fields["hostname_alias"] = *updates.HostnameAlias
 		}
 	}
-	// DefaultTeamID is *int64: nil = preserve, n = set. There is no clear
-	// path — the column is NOT NULL (every org must keep a default team; it
-	// is the billing bucket key) and the handler rejects 0/null/negative
-	// before this runs.
-	if updates.DefaultTeamID != nil {
-		fields["default_team_id"] = *updates.DefaultTeamID
-	}
+	// The billing team (wire field default_team_id) is not an org column: a
+	// change repoints the org's duckgres_org_teams billing row inside the same
+	// transaction below. The handler rejects 0/null/negative before this runs
+	// and only passes reattributeUsageTeam when the value actually changes.
 	found := false
 	err := s.db().Transaction(func(tx *gorm.DB) error {
-		// Read the pre-update team id before writing, purely for the log line —
-		// the handler already decided reattribution is needed.
-		var oldTeams []int64
-		if reattributeUsageTeam != nil {
-			if err := tx.Model(&configstore.Org{}).Where("name = ?", name).
-				Pluck("default_team_id", &oldTeams).Error; err != nil {
-				return err
-			}
-		}
 		result := tx.Model(&configstore.Org{}).Where("name = ?", name).Updates(fields)
 		if result.Error != nil {
 			return result.Error
@@ -234,21 +244,26 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org, reattribu
 		}
 		found = true
 		if reattributeUsageTeam != nil {
-			// Same transaction as the org-row update: a committed team change
-			// always carries its buffered buckets along. In-flight metering under
-			// the old team can still land a small residual row right after this
-			// (config-snapshot poll lag, ~30s) — tolerated, see
-			// configstore.ReattributeUsageTeamTx.
+			// Read the pre-update team id purely for the log line — the
+			// handler already decided the billing team changes.
+			oldTeam, err := configstore.OrgBillingTeamIDTx(tx, name)
+			if err != nil {
+				return err
+			}
+			if err := configstore.SetOrgBillingTeamTx(tx, name, *reattributeUsageTeam); err != nil {
+				return err
+			}
+			// Same transaction as the billing-team repoint: a committed team
+			// change always carries its buffered buckets along. In-flight
+			// metering under the old team can still land a small residual row
+			// right after this (config-snapshot poll lag, ~30s) — tolerated,
+			// see configstore.ReattributeUsageTeamTx.
 			moved, err := configstore.ReattributeUsageTeamTx(tx, name, *reattributeUsageTeam)
 			if err != nil {
 				return err
 			}
-			old := int64(0)
-			if len(oldTeams) > 0 {
-				old = oldTeams[0]
-			}
-			slog.Info("Re-attributed org usage buckets to new default team.",
-				"org", name, "old_team", old, "new_team", *reattributeUsageTeam, "rows", moved)
+			slog.Info("Re-attributed org usage buckets to new billing team.",
+				"org", name, "old_team", oldTeam, "new_team", *reattributeUsageTeam, "rows", moved)
 		}
 		return nil
 	})
@@ -580,12 +595,14 @@ func (h *apiHandler) createOrg(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
 		return
 	}
-	// Every org must be born with its default PostHog team id — it is the
-	// billing bucket key and the column is NOT NULL (same invariant as the
-	// provisioning API's ErrDefaultTeamIDRequired). Positivity of a present
-	// value is enforced by validateOrgMutationPayload above.
+	// Every org must be born with its billing PostHog team — it is the
+	// billing bucket key, stored as the org's duckgres_org_teams row with
+	// is_billing_team = TRUE (same invariant as the provisioning API's
+	// ErrDefaultTeamIDRequired). The wire field keeps its historical
+	// default_team_id name. Positivity of a present value is enforced by
+	// validateOrgMutationPayload above.
 	if org.DefaultTeamID == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id is required (the org's default PostHog team id)"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id is required (the org's billing PostHog team id)"})
 		return
 	}
 	// Normalize empty hostname_alias to NULL on insert so the unique index
@@ -669,19 +686,20 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
-	// Set when the PUT actually changes default_team_id: the store then
-	// re-attributes the org's buffered (unacked) billing buckets to the new
+	// Set when the PUT actually changes default_team_id (the org's billing
+	// team): the store then repoints the org's duckgres_org_teams billing row
+	// and re-attributes the buffered (unacked) billing buckets to the new
 	// team in the same transaction as the org update, so the next billing pull
 	// reports them under the new team (docs/design/billing-pull-api.md,
 	// "Changing an org's default team").
 	var reattributeUsageTeam *int64
 	if _, ok := fields["default_team_id"]; ok {
-		// Key present: a positive number sets. Clearing is rejected — the
-		// column is NOT NULL (the org's default team is the billing bucket
-		// key). An explicit JSON null unmarshals to a nil pointer here; 0 and
-		// negatives are already rejected by validateOrgMutationPayload above.
+		// Key present: a positive number sets. Clearing is rejected — every
+		// org must keep a billing team (the billing bucket key). An explicit
+		// JSON null unmarshals to a nil pointer here; 0 and negatives are
+		// already rejected by validateOrgMutationPayload above.
 		if updates.DefaultTeamID == nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id cannot be cleared (every org must keep a default team); pass a valid team id"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "default_team_id cannot be cleared (every org must keep a billing team); pass a valid team id"})
 			return
 		}
 		merged.DefaultTeamID = updates.DefaultTeamID
@@ -776,8 +794,8 @@ func orgStrPtr(s *string) string {
 }
 
 // orgInt64Ptr renders an optional org config integer (nil or 0 == unset) for
-// audit detail. default_team_id is NOT NULL and never 0 nowadays, so
-// "(unset)" only ever renders for legacy display of rows predating that.
+// audit detail. Every org keeps a billing team nowadays, so "(unset)" only
+// ever renders for legacy display of orgs predating that.
 func orgInt64Ptr(v *int64) string {
 	if v == nil || *v == 0 {
 		return "(unset)"
@@ -791,6 +809,9 @@ func validateOrgMutationPayload(org *configstore.Org) error {
 	}
 	if org.Warehouse != nil {
 		return errWarehousePayloadNotAllowed
+	}
+	if len(org.Teams) > 0 {
+		return errOrgTeamsPayloadNotAllowed
 	}
 	if org.HostnameAlias != nil {
 		if err := validateHostnameAlias(*org.HostnameAlias); err != nil {
@@ -808,10 +829,10 @@ func validateOrgMutationPayload(org *configstore.Org) error {
 	}
 	// Shared by create and update: nil stays allowed here (create requires
 	// the field itself; update treats an absent field as "preserve"), but a
-	// present value must be a positive PostHog team id — the column is NOT
-	// NULL and 0 is never stored, so there is no clear sentinel.
+	// present value must be a positive PostHog team id — a billing team row
+	// is never stored with team 0, so there is no clear sentinel.
 	if org.DefaultTeamID != nil && *org.DefaultTeamID <= 0 {
-		return fmt.Errorf("default_team_id: value %d must be a positive PostHog team id (it cannot be cleared — every org must keep a default team)", *org.DefaultTeamID)
+		return fmt.Errorf("default_team_id: value %d must be a positive PostHog team id (it cannot be cleared — every org must keep a billing team)", *org.DefaultTeamID)
 	}
 	return nil
 }

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -17,14 +17,6 @@ import (
 
 const testConfigStoreConnString = "host=127.0.0.1 port=35432 user=postgres password=postgres dbname=testdb sslmode=disable"
 
-// testDefaultTeamID returns a pointer to a placeholder PostHog team id for
-// seeded org rows — default_team_id is NOT NULL (migration 000020), so every
-// test fixture that inserts an org must carry one.
-func testDefaultTeamID() *int64 {
-	teamID := int64(1)
-	return &teamID
-}
-
 func newPostgresConfigStore(t *testing.T) *configstore.ConfigStore {
 	t.Helper()
 
@@ -115,7 +107,7 @@ func TestUpsertManagedWarehousePreservesCreatedAt(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 
@@ -180,8 +172,11 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics_db"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
+	}
+	if err := configstore.SetOrgBillingTeamTx(store.DB(), "analytics", 1); err != nil {
+		t.Fatalf("seed billing team: %v", err)
 	}
 	wh := &configstore.ManagedWarehouse{OrgID: "analytics", State: configstore.ManagedWarehouseStateReady}
 	if err := store.DB().Create(wh).Error; err != nil {
@@ -209,18 +204,22 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 		t.Fatal("expected org row to be deleted")
 	}
 
-	var orgs, warehouses int64
+	var orgs, warehouses, teams int64
 	store.DB().Model(&configstore.Org{}).Where("name = ?", "analytics").Count(&orgs)
 	store.DB().Model(&configstore.ManagedWarehouse{}).Where("org_id = ?", "analytics").Count(&warehouses)
+	store.DB().Model(&configstore.OrgTeam{}).Where("org_id = ?", "analytics").Count(&teams)
 	if orgs != 0 {
 		t.Fatalf("expected org row gone, found %d", orgs)
 	}
 	if warehouses != 0 {
 		t.Fatalf("expected deleted warehouse row cascaded away, found %d", warehouses)
 	}
+	if teams != 0 {
+		t.Fatalf("expected org team rows cascaded away (FK ON DELETE CASCADE), found %d", teams)
+	}
 
 	// The database_name is now free for reuse (no unique-index squat).
-	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db"}).Error; err != nil {
 		t.Fatalf("expected database_name to be reusable after org deletion: %v", err)
 	}
 }
@@ -235,8 +234,11 @@ func TestUpdateOrgReattributesUsagePostgres(t *testing.T) {
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
 	oldTeam := int64(1)
-	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acmedb", DefaultTeamID: &oldTeam}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acmedb"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
+	}
+	if err := configstore.SetOrgBillingTeamTx(store.DB(), "acme", oldTeam); err != nil {
+		t.Fatalf("seed billing team: %v", err)
 	}
 
 	bucket := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
@@ -281,6 +283,14 @@ func TestUpdateOrgReattributesUsagePostgres(t *testing.T) {
 	if updated.DefaultTeamID == nil || *updated.DefaultTeamID != 2 {
 		t.Fatalf("org default_team_id = %v, want 2", updated.DefaultTeamID)
 	}
+	// The billing mark moved to team 2; the old team row stays, demoted.
+	var billingTeams []int64
+	if err := store.DB().Raw(`SELECT team_id FROM duckgres_org_teams WHERE org_id = 'acme' AND is_billing_team IS TRUE`).Scan(&billingTeams).Error; err != nil {
+		t.Fatalf("read billing teams: %v", err)
+	}
+	if len(billingTeams) != 1 || billingTeams[0] != 2 {
+		t.Fatalf("billing team rows = %v, want [2]", billingTeams)
+	}
 	var compute []struct {
 		TeamID        int64
 		CPUSeconds    int64
@@ -308,7 +318,7 @@ func TestMutateManagedWarehouseSerializesConcurrentWriters(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	apiStore := newGormAPIStore(store).(*gormAPIStore)
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.ManagedWarehouse{

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -91,8 +91,8 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org, reattribu
 			org.HostnameAlias = &alias
 		}
 	}
-	// Mirrors gormAPIStore: nil = preserve, n = set. No clear path — the
-	// column is NOT NULL and the handler rejects 0/null/negative.
+	// Mirrors gormAPIStore: nil = preserve, n = set (repointing the billing
+	// team). No clear path — the handler rejects 0/null/negative.
 	if updates.DefaultTeamID != nil {
 		teamID := *updates.DefaultTeamID
 		org.DefaultTeamID = &teamID

--- a/controlplane/admin/models_api_test.go
+++ b/controlplane/admin/models_api_test.go
@@ -81,7 +81,7 @@ func TestModelsAPIPostgres(t *testing.T) {
 	store := newPostgresConfigStore(t)
 
 	const secretHash = "$2a$10$DEADBEEFdeadbeefDEADBEEFdeadbeefDEADBEEFdeadbeefDEADBE"
-	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acme_db", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "acme", DatabaseName: "acme_db"}).Error; err != nil {
 		t.Fatalf("seed org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.OrgUser{OrgID: "acme", Username: "reader", Password: secretHash}).Error; err != nil {

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -54,7 +54,7 @@ function orgToForm(o: {
   default_worker_ttl: string;
   default_worker_min_hot_idle: number;
   hostname_alias: string | null;
-  default_team_id: number | null;
+  default_team_id?: number | null;
 }): FormState {
   return {
     max_workers: String(o.max_workers),

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -44,7 +44,11 @@ export interface Org {
   name: string;
   database_name: string;
   hostname_alias: string | null;
-  default_team_id: number | null;
+  // The org's billing PostHog team (stored server-side as the
+  // duckgres_org_teams row with is_billing_team = TRUE; the wire field keeps
+  // its historical name). Absent only for legacy orgs with no billing team.
+  default_team_id?: number | null;
+  teams?: OrgTeam[];
   max_workers: number;
   max_vcpus: number;
   default_worker_cpu: string;
@@ -66,9 +70,24 @@ export interface OrgUpdate {
   default_worker_ttl?: string;
   default_worker_min_hot_idle?: number;
   hostname_alias?: string | null;
-  // Positive number sets, absent preserves. Clearing is not possible: the
-  // column is NOT NULL and the backend rejects 0/null/negative with a 400.
+  // Positive number sets (repointing the org's billing team), absent
+  // preserves. Clearing is not possible: every org must keep a billing team
+  // and the backend rejects 0/null/negative with a 400.
   default_team_id?: number;
+}
+
+// One duckgres_org_teams row: a PostHog team mapped to this org and the
+// warehouse schema its data lives in. At most one row per org is the billing
+// team.
+export interface OrgTeam {
+  org_id: string;
+  team_id: number;
+  schema_name: string;
+  enabled: boolean;
+  is_billing_team?: boolean | null;
+  backfill_enabled?: boolean | null;
+  created_at: string;
+  updated_at: string;
 }
 
 // ---- Users (confirmed) ----

--- a/controlplane/compute_meter.go
+++ b/controlplane/compute_meter.go
@@ -151,11 +151,11 @@ type computeUsageStore interface {
 
 // computeMeter wires the per-org counter to a flusher. Nil-safe: a disabled
 // meter (non-remote backend) leaves this nil and every call site no-ops.
-// resolveTeam maps an org to its default PostHog team id at record time (a
-// config-snapshot read — no I/O); 0 is tolerated per the OrgDefaultTeamID
-// contract and the bucket then carries team_id 0. The column is NOT NULL and
-// required at org creation, so 0 can only mean an unknown org or a
-// not-yet-loaded snapshot — never a stored "no default team".
+// resolveTeam maps an org to its billing PostHog team id at record time (a
+// config-snapshot read — no I/O); 0 is tolerated per the OrgBillingTeamID
+// contract and the bucket then carries team_id 0. Every org create path
+// establishes a billing team row, so 0 can only mean an unknown org or a
+// not-yet-loaded snapshot — never a stored "no billing team".
 type computeMeter struct {
 	counter     *computeUsageCounter
 	store       computeUsageStore

--- a/controlplane/compute_meter_test.go
+++ b/controlplane/compute_meter_test.go
@@ -176,7 +176,7 @@ func TestComputeMeterFlush(t *testing.T) {
 }
 
 func TestComputeMeterUnknownTeamTolerated(t *testing.T) {
-	// An org with no default_team_id (or a nil resolver) still meters — the
+	// An org with no billing team (or a nil resolver) still meters — the
 	// bucket carries team_id 0 rather than dropping usage.
 	store := &fakeFlushStore{}
 	m := newComputeMeter(store, teamResolverA)

--- a/controlplane/configstore/migrations/000024_add_org_teams.sql
+++ b/controlplane/configstore/migrations/000024_add_org_teams.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+
+-- duckgres_org_teams replaces the single per-org default_team_id column: an
+-- org can now carry MANY PostHog teams, each mapped to a warehouse schema.
+-- Exactly one row per org may be the billing team (is_billing_team = TRUE):
+-- the team pull-based billing keys the org's usage buckets by, taking over
+-- the role default_team_id played. enabled is the per-team serving switch;
+-- backfill_enabled is tri-state (NULL = unset).
+CREATE TABLE IF NOT EXISTS duckgres_org_teams (
+    org_id VARCHAR(255) NOT NULL REFERENCES duckgres_orgs (name) ON DELETE CASCADE,
+    team_id BIGINT NOT NULL,
+    schema_name VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    is_billing_team BOOLEAN,
+    backfill_enabled BOOLEAN,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    PRIMARY KEY (org_id, team_id)
+);
+
+-- At most ONE billing team per org (partial: non-billing rows are unlimited).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_duckgres_org_teams_billing_org ON duckgres_org_teams (org_id) WHERE is_billing_team IS TRUE;
+
+-- Backfill: every org's default team becomes its (only) team row, marked as
+-- the billing team, with the conventional per-team schema name. The column is
+-- NOT NULL (migration 000020) so the NULL guard is belt-and-braces only.
+INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, backfill_enabled, created_at, updated_at)
+SELECT name, default_team_id, 'team_' || default_team_id, TRUE, TRUE, NULL, now(), now()
+FROM duckgres_orgs
+WHERE default_team_id IS NOT NULL
+ON CONFLICT (org_id, team_id) DO NOTHING;
+
+ALTER TABLE duckgres_orgs DROP COLUMN IF EXISTS default_team_id;
+
+-- +goose Down
+
+-- Best-effort reversal: restore the column (nullable — the NOT NULL stance of
+-- 000020 belongs to the forward world) from each org's billing-team row, then
+-- drop the table. Non-billing team rows are lost by design.
+ALTER TABLE duckgres_orgs ADD COLUMN IF NOT EXISTS default_team_id BIGINT;
+
+UPDATE duckgres_orgs o
+SET default_team_id = t.team_id
+FROM duckgres_org_teams t
+WHERE t.org_id = o.name
+  AND t.is_billing_team IS TRUE;
+
+DROP TABLE IF EXISTS duckgres_org_teams;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -25,15 +25,16 @@ type Org struct {
 	DefaultWorkerMemory     string `gorm:"size:32" json:"default_worker_memory"`
 	DefaultWorkerTTL        string `gorm:"size:32" json:"default_worker_ttl"`
 	DefaultWorkerMinHotIdle int    `gorm:"default:0" json:"default_worker_min_hot_idle"`
-	// DefaultTeamID links the org to its default PostHog team id (an integer,
-	// matching PostHog's Team.id). It is a prerequisite for pull-based compute
-	// billing — usage buckets are keyed by team_id = the org's default team.
-	// The column is a NOT NULL BIGINT (migration 000020) and 0 is never stored:
-	// every create path (provisioning + admin API) requires a positive team id
-	// and the admin API rejects clears. The field stays *int64 anyway — the
-	// admin PUT presence-merge relies on nil = "field absent, preserve", and a
-	// plain int64 would make gorm treat 0 as a zero value to skip.
-	DefaultTeamID *int64            `gorm:"not null" json:"default_team_id,omitempty"`
+	// DefaultTeamID is NOT a column — it is the admin/provisioning API view of
+	// the org's billing team (the duckgres_org_teams row with is_billing_team
+	// = TRUE, see OrgTeam). The JSON field name is kept for wire compat with
+	// existing callers and the admin UI. Read paths populate it from the
+	// preloaded Teams association; write paths (admin create/update org,
+	// provisioning) translate it into a billing-team upsert via
+	// SetOrgBillingTeamTx. *int64 because the admin PUT presence-merge relies
+	// on nil = "field absent, preserve".
+	DefaultTeamID *int64            `gorm:"-" json:"default_team_id,omitempty"`
+	Teams         []OrgTeam         `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"teams,omitempty"`
 	Users         []OrgUser         `gorm:"foreignKey:OrgID;references:Name" json:"users,omitempty"`
 	Warehouse     *ManagedWarehouse `gorm:"foreignKey:OrgID;references:Name;constraint:OnDelete:CASCADE" json:"warehouse,omitempty"`
 	CreatedAt     time.Time         `json:"created_at"`
@@ -41,6 +42,40 @@ type Org struct {
 }
 
 func (Org) TableName() string { return "duckgres_orgs" }
+
+// BillingTeamID returns the org's billing PostHog team id from the loaded
+// Teams association (the row with is_billing_team = TRUE), or nil when the
+// org has none — including when Teams was not preloaded.
+func (o *Org) BillingTeamID() *int64 {
+	for i := range o.Teams {
+		t := &o.Teams[i]
+		if t.IsBillingTeam != nil && *t.IsBillingTeam {
+			return &t.TeamID
+		}
+	}
+	return nil
+}
+
+// OrgTeam maps one PostHog team to an org and the warehouse schema its data
+// lives in (conventionally "team_<id>"). An org can carry many teams; exactly
+// one may be the billing team — the team pull-based billing keys the org's
+// usage buckets by (enforced by a partial unique index, migration 000024).
+// IsBillingTeam and BackfillEnabled are tri-state (*bool): NULL means "not the
+// billing team" / "backfill preference unset".
+type OrgTeam struct {
+	OrgID string `gorm:"primaryKey;size:255;index:idx_duckgres_org_teams_billing_org,unique,where:is_billing_team IS TRUE" json:"org_id"`
+	// autoIncrement:false — int fields in a composite primary key default to
+	// auto-increment in gorm, which would make this a bigserial.
+	TeamID          int64     `gorm:"primaryKey;autoIncrement:false" json:"team_id"`
+	SchemaName      string    `gorm:"size:255;not null" json:"schema_name"`
+	Enabled         bool      `gorm:"not null;default:true" json:"enabled"`
+	IsBillingTeam   *bool     `json:"is_billing_team,omitempty"`
+	BackfillEnabled *bool     `json:"backfill_enabled,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+func (OrgTeam) TableName() string { return "duckgres_org_teams" }
 
 // OrgUser maps a username to an org with credentials.
 //
@@ -490,9 +525,31 @@ type OrgConfig struct {
 	DefaultWorkerMemory     string            // org default worker profile: pod memory quantity ("" = unset)
 	DefaultWorkerTTL        string            // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
 	DefaultWorkerMinHotIdle int               // minimum default-profile hot-idle workers to retain for this org
-	DefaultTeamID           int64             // org's default PostHog team id (NOT NULL in the store; 0 only for a missing org / stale snapshot); prereq for pull-based compute billing
+	Teams                   []OrgTeamConfig   // the org's PostHog teams (duckgres_org_teams); at most one is the billing team
 	Users                   map[string]string // username -> password
 	Warehouse               *ManagedWarehouseConfig
+}
+
+// OrgTeamConfig is the in-memory snapshot view of one duckgres_org_teams row.
+// IsBillingTeam folds the tri-state column to a plain bool (NULL == false) —
+// snapshot consumers only care whether a row IS the billing team.
+type OrgTeamConfig struct {
+	TeamID        int64
+	SchemaName    string
+	Enabled       bool
+	IsBillingTeam bool
+}
+
+// BillingTeamID returns the org's billing PostHog team id (the team with
+// is_billing_team = TRUE), or 0 when the org has none. Prereq for pull-based
+// compute billing — usage buckets are keyed by it.
+func (oc *OrgConfig) BillingTeamID() int64 {
+	for _, t := range oc.Teams {
+		if t.IsBillingTeam {
+			return t.TeamID
+		}
+	}
+	return 0
 }
 
 // ManagedWarehouseConfig is the in-memory snapshot view of an org's warehouse metadata.

--- a/controlplane/configstore/org_teams.go
+++ b/controlplane/configstore/org_teams.go
@@ -1,0 +1,53 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// OrgBillingTeamIDTx returns the org's current billing team id (the
+// duckgres_org_teams row with is_billing_team = TRUE) inside the caller's
+// transaction, or 0 when the org has none.
+func OrgBillingTeamIDTx(tx *gorm.DB, orgID string) (int64, error) {
+	var ids []int64
+	if err := tx.Model(&OrgTeam{}).
+		Where("org_id = ? AND is_billing_team IS TRUE", orgID).
+		Pluck("team_id", &ids).Error; err != nil {
+		return 0, fmt.Errorf("read billing team (org=%s): %w", orgID, err)
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	return ids[0], nil
+}
+
+// SetOrgBillingTeamTx points the org's billing team at teamID inside the
+// caller's transaction. Any other row currently marked billing is demoted
+// first — the partial unique index (at most one billing row per org, migration
+// 000024) is checked immediately, not deferred, so the order matters. When the
+// org doesn't have teamID yet the row is inserted with the conventional
+// "team_<id>" schema and enabled = TRUE; an existing row keeps its
+// schema/enabled/backfill state and only gains the billing mark.
+//
+// Callers that change an EXISTING org's billing team must re-attribute its
+// buffered usage buckets in the same transaction (ReattributeUsageTeamTx) so
+// the billing pull never strands usage under the stale team.
+func SetOrgBillingTeamTx(tx *gorm.DB, orgID string, teamID int64) error {
+	if err := tx.Exec(`
+		UPDATE duckgres_org_teams
+		SET is_billing_team = NULL, updated_at = now()
+		WHERE org_id = ? AND team_id <> ? AND is_billing_team IS TRUE`,
+		orgID, teamID).Error; err != nil {
+		return fmt.Errorf("demote billing team (org=%s): %w", orgID, err)
+	}
+	if err := tx.Exec(`
+		INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+		VALUES (?, ?, ?, TRUE, TRUE, now(), now())
+		ON CONFLICT (org_id, team_id)
+		DO UPDATE SET is_billing_team = TRUE, updated_at = now()`,
+		orgID, teamID, fmt.Sprintf("team_%d", teamID)).Error; err != nil {
+		return fmt.Errorf("set billing team (org=%s team=%d): %w", orgID, teamID, err)
+	}
+	return nil
+}

--- a/controlplane/configstore/reattribute_usage.go
+++ b/controlplane/configstore/reattribute_usage.go
@@ -24,7 +24,7 @@ func (cs *ConfigStore) ReattributeUsageTeam(orgID string, newTeamID int64) (int6
 // ReattributeUsageTeamTx re-attributes the org's buffered usage buckets
 // (duckgres_org_compute_usage + duckgres_org_storage_usage) to newTeamID
 // inside the caller's transaction, so the move commits atomically with the
-// org-row update that changes default_team_id.
+// billing-team change (SetOrgBillingTeamTx).
 //
 // team_id is part of both tables' primary keys, so this is a fold-then-delete
 // per table, not a blind UPDATE: an additive upsert copies every row keyed

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -178,7 +178,7 @@ func (cs *ConfigStore) Start(ctx context.Context) {
 // load fetches all config from the database and builds a Snapshot.
 func (cs *ConfigStore) load() (*Snapshot, error) {
 	var orgs []Org
-	if err := cs.db.Preload("Users").Preload("Warehouse").Find(&orgs).Error; err != nil {
+	if err := cs.db.Preload("Users").Preload("Warehouse").Preload("Teams").Find(&orgs).Error; err != nil {
 		return nil, fmt.Errorf("load orgs: %w", err)
 	}
 
@@ -197,9 +197,14 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 		if o.HostnameAlias != nil {
 			alias = *o.HostnameAlias
 		}
-		defaultTeamID := int64(0)
-		if o.DefaultTeamID != nil {
-			defaultTeamID = *o.DefaultTeamID
+		teams := make([]OrgTeamConfig, 0, len(o.Teams))
+		for _, team := range o.Teams {
+			teams = append(teams, OrgTeamConfig{
+				TeamID:        team.TeamID,
+				SchemaName:    team.SchemaName,
+				Enabled:       team.Enabled,
+				IsBillingTeam: team.IsBillingTeam != nil && *team.IsBillingTeam,
+			})
 		}
 		oc := &OrgConfig{
 			Name:                    o.Name,
@@ -211,7 +216,7 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 			DefaultWorkerMemory:     o.DefaultWorkerMemory,
 			DefaultWorkerTTL:        o.DefaultWorkerTTL,
 			DefaultWorkerMinHotIdle: o.DefaultWorkerMinHotIdle,
-			DefaultTeamID:           defaultTeamID,
+			Teams:                   teams,
 			Users:                   make(map[string]string),
 			Warehouse:               copyManagedWarehouseConfig(o.Warehouse),
 		}
@@ -484,12 +489,13 @@ func (cs *ConfigStore) OrgDefaultWorkerMinHotIdle(orgID string) int {
 	return oc.DefaultWorkerMinHotIdle
 }
 
-// OrgDefaultTeamID returns the org's default PostHog team id from the current
-// snapshot, or 0 when unset (including unknown orgs and a not-yet-loaded
-// snapshot). A zero return is a valid, non-error state — callers must
-// tolerate it and MUST NOT fail a connection or activation on it.
-// Prerequisite for pull-based compute billing (usage keyed by team id).
-func (cs *ConfigStore) OrgDefaultTeamID(orgID string) int64 {
+// OrgBillingTeamID returns the org's billing PostHog team id (the org team
+// with is_billing_team = TRUE) from the current snapshot, or 0 when unset
+// (including unknown orgs and a not-yet-loaded snapshot). A zero return is a
+// valid, non-error state — callers must tolerate it and MUST NOT fail a
+// connection or activation on it. Prerequisite for pull-based compute billing
+// (usage keyed by team id).
+func (cs *ConfigStore) OrgBillingTeamID(orgID string) int64 {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 	if cs.snapshot == nil {
@@ -499,7 +505,7 @@ func (cs *ConfigStore) OrgDefaultTeamID(orgID string) int64 {
 	if !ok {
 		return 0
 	}
-	return oc.DefaultTeamID
+	return oc.BillingTeamID()
 }
 
 // ValidateOrgUser checks username/password scoped to a specific org.

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -500,6 +500,7 @@ func TestTableNames(t *testing.T) {
 	}{
 		{Org{}, "duckgres_orgs"},
 		{OrgUser{}, "duckgres_org_users"},
+		{OrgTeam{}, "duckgres_org_teams"},
 		{OrgUserSecret{}, "duckgres_org_user_secrets"},
 		{ManagedWarehouse{}, "duckgres_managed_warehouses"},
 	}
@@ -548,6 +549,49 @@ func TestOrgDefaultWorkerProfile(t *testing.T) {
 	empty := &ConfigStore{}
 	if cpu, mem, ttl := empty.OrgDefaultWorkerProfile("full"); cpu != "" || mem != "" || ttl != "" {
 		t.Errorf("nil-snapshot OrgDefaultWorkerProfile = (%q,%q,%q); want all empty", cpu, mem, ttl)
+	}
+}
+
+func TestOrgBillingTeamID(t *testing.T) {
+	cs := &ConfigStore{
+		snapshot: &Snapshot{
+			Orgs: map[string]*OrgConfig{
+				"no-teams": {Name: "no-teams"},
+				"no-billing-team": {
+					Name:  "no-billing-team",
+					Teams: []OrgTeamConfig{{TeamID: 7, SchemaName: "team_7", Enabled: true}},
+				},
+				"billing": {
+					Name: "billing",
+					Teams: []OrgTeamConfig{
+						{TeamID: 7, SchemaName: "team_7", Enabled: true},
+						{TeamID: 42, SchemaName: "team_42", Enabled: true, IsBillingTeam: true},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		orgID string
+		want  int64
+	}{
+		{"unknown", 0},
+		{"no-teams", 0},
+		{"no-billing-team", 0},
+		{"billing", 42},
+	}
+	for _, tt := range tests {
+		if got := cs.OrgBillingTeamID(tt.orgID); got != tt.want {
+			t.Errorf("OrgBillingTeamID(%q) = %d; want %d", tt.orgID, got, tt.want)
+		}
+	}
+
+	// Nil snapshot (store not yet loaded) must read as 0, not panic — callers
+	// tolerate 0 per the documented contract.
+	empty := &ConfigStore{}
+	if got := empty.OrgBillingTeamID("billing"); got != 0 {
+		t.Errorf("nil-snapshot OrgBillingTeamID = %d; want 0", got)
 	}
 }
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -650,7 +650,7 @@ func SetupMultiTenant(
 	// GET/ack API registered above. Best-effort throughout — queries are NEVER
 	// failed on its account. The 30-day safety GC is leader-only, co-located
 	// under the janitor lease so exactly one CP pod sweeps.
-	meter := newComputeMeter(store, store.OrgDefaultTeamID)
+	meter := newComputeMeter(store, store.OrgBillingTeamID)
 	go meter.Run(context.Background())
 	if janitorLeader != nil {
 		janitorLeader.AttachLeaderLoop(func(ctx context.Context) { runComputeUsageGC(ctx, store) })
@@ -673,7 +673,7 @@ func SetupMultiTenant(
 			var orgs []storageOrg
 			for _, org := range snap.Orgs {
 				if org.Warehouse != nil && org.Warehouse.State == configstore.ManagedWarehouseStateReady {
-					orgs = append(orgs, storageOrg{OrgID: org.Name, TeamID: org.DefaultTeamID})
+					orgs = append(orgs, storageOrg{OrgID: org.Name, TeamID: org.BillingTeamID()})
 				}
 			}
 			return orgs

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -135,12 +135,13 @@ type connectionDetails struct {
 
 type provisionRequest struct {
 	DatabaseName string `json:"database_name"`
-	// DefaultTeamID links the org to its default PostHog team id — a JSON
-	// NUMBER, matching PostHog's integer Team.id (a quoted string is a 400 at
-	// decode time). REQUIRED when the provision creates a NEW org (400
-	// otherwise — every org carries its team id from birth; pull-based compute
-	// billing keys usage buckets by it). Optional on re-provision of an
-	// existing org: absent/0 keeps the stored value, never wipes it.
+	// DefaultTeamID is the org's billing PostHog team id — a JSON NUMBER,
+	// matching PostHog's integer Team.id (a quoted string is a 400 at decode
+	// time). Stored as the org's duckgres_org_teams billing row. REQUIRED
+	// when the provision creates a NEW org (400 otherwise — every org carries
+	// its billing team from birth; pull-based compute billing keys usage
+	// buckets by it). Optional on re-provision of an existing org: absent/0
+	// keeps the stored billing team, never wipes it.
 	DefaultTeamID int64                  `json:"default_team_id,omitempty"`
 	MetadataStore *provisionMetadataReq  `json:"metadata_store,omitempty"`
 	DataStore     *provisionDataStoreReq `json:"data_store,omitempty"`

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -19,11 +19,12 @@ import (
 var ErrWarehouseNonTerminal = errors.New("warehouse already exists in non-terminal state")
 
 // ErrDefaultTeamIDRequired is returned by Provision when the request would
-// create a NEW org without a default_team_id. Every org must carry its default
-// PostHog team id from birth (pull-based compute billing keys usage buckets by
-// it); all pre-existing orgs have been backfilled. Re-provisioning an EXISTING
-// org without the field stays valid — the stored value is kept, never wiped.
-// HTTP handlers map this to 400.
+// create a NEW org without a default_team_id. Every org must carry its billing
+// PostHog team from birth — the request's team id becomes the org's first
+// duckgres_org_teams row, marked is_billing_team (pull-based compute billing
+// keys usage buckets by it); all pre-existing orgs have been backfilled.
+// Re-provisioning an EXISTING org without the field stays valid — the stored
+// billing team is kept, never wiped. HTTP handlers map this to 400.
 var ErrDefaultTeamIDRequired = errors.New("default_team_id is required when creating a new org")
 
 // ProvisionRequest is the all-or-nothing input the Provision endpoint
@@ -38,12 +39,12 @@ var ErrDefaultTeamIDRequired = errors.New("default_team_id is required when crea
 type ProvisionRequest struct {
 	OrgID        string
 	DatabaseName string
-	// DefaultTeamID links the org to its default PostHog team id (an
-	// integer, matching PostHog's Team.id). REQUIRED when the org does not
-	// exist yet (Provision returns ErrDefaultTeamIDRequired otherwise);
-	// optional (0) on re-provision of an existing org, where it keeps the
-	// stored value (never a wipe). Prerequisite for pull-based compute
-	// billing.
+	// DefaultTeamID is the org's billing PostHog team id (an integer,
+	// matching PostHog's Team.id), stored as the org's duckgres_org_teams
+	// billing row. REQUIRED when the org does not exist yet (Provision
+	// returns ErrDefaultTeamIDRequired otherwise); optional (0) on
+	// re-provision of an existing org, where it keeps the stored billing
+	// team (never a wipe). Prerequisite for pull-based compute billing.
 	DefaultTeamID int64
 	Warehouse     *configstore.ManagedWarehouse
 	// RootUserHash is the bcrypt hash of the freshly-generated root
@@ -64,9 +65,10 @@ func NewGormStore(cs *configstore.ConfigStore) Store {
 
 func (s *gormStore) GetOrg(orgID string) (*configstore.Org, error) {
 	var org configstore.Org
-	if err := s.cs.DB().First(&org, "name = ?", orgID).Error; err != nil {
+	if err := s.cs.DB().Preload("Teams").First(&org, "name = ?", orgID).Error; err != nil {
 		return nil, err
 	}
+	org.DefaultTeamID = org.BillingTeamID()
 	return &org, nil
 }
 
@@ -89,8 +91,8 @@ func (s *gormStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWareh
 func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error {
 	return s.cs.DB().Transaction(func(tx *gorm.DB) error {
 		// No default_team_id on this standalone path — an existing org keeps
-		// its column as-is; creating a NEW org through here now fails with
-		// ErrDefaultTeamIDRequired (same invariant as Provision).
+		// its billing team as-is; creating a NEW org through here now fails
+		// with ErrDefaultTeamIDRequired (same invariant as Provision).
 		return createPendingWarehouseTx(tx, orgID, databaseName, 0, warehouse)
 	})
 }
@@ -106,21 +108,25 @@ func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 // without an extra error type.
 func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, defaultTeamID int64, warehouse *configstore.ManagedWarehouse) error {
 	// Auto-create org if it doesn't exist (PostHog calls provision, duckgres
-	// creates everything). A NEW org MUST carry default_team_id (pull-based
-	// compute billing keys usage buckets by it; all pre-existing orgs are
-	// backfilled) — creating one without it is rejected. Re-provisioning an
-	// existing org without it keeps the stored value (never a wipe).
+	// creates everything). A NEW org MUST carry default_team_id — it becomes
+	// the org's first duckgres_org_teams row, marked as the billing team
+	// (pull-based compute billing keys usage buckets by it; all pre-existing
+	// orgs are backfilled) — creating one without it is rejected.
+	// Re-provisioning an existing org without it keeps the stored billing
+	// team (never a wipe).
 	var org configstore.Org
+	orgCreated := false
 	err := tx.Where("name = ?", orgID).First(&org).Error
 	switch {
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		if defaultTeamID == 0 {
 			return ErrDefaultTeamIDRequired
 		}
-		org = configstore.Org{Name: orgID, DatabaseName: databaseName, DefaultTeamID: &defaultTeamID}
+		org = configstore.Org{Name: orgID, DatabaseName: databaseName}
 		if err := tx.Create(&org).Error; err != nil {
 			return err
 		}
+		orgCreated = true
 	case err != nil:
 		return err
 	}
@@ -130,31 +136,35 @@ func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, defaultTe
 			return err
 		}
 	}
-	// If a default_team_id was supplied, persist it even when the org already
-	// existed (the create branch above only runs on insert). Only ever set,
-	// never cleared here, so an omitted value is a no-op rather than a wipe.
+	// If a default_team_id was supplied, persist it as the org's billing team
+	// row. Only ever set, never cleared here, so an omitted value is a no-op
+	// rather than a wipe.
 	if defaultTeamID != 0 {
 		oldTeamID := int64(0)
-		if org.DefaultTeamID != nil {
-			oldTeamID = *org.DefaultTeamID
+		if !orgCreated {
+			var err error
+			oldTeamID, err = configstore.OrgBillingTeamIDTx(tx, orgID)
+			if err != nil {
+				return err
+			}
 		}
-		if err := tx.Model(&org).Update("default_team_id", defaultTeamID).Error; err != nil {
+		if err := configstore.SetOrgBillingTeamTx(tx, orgID, defaultTeamID); err != nil {
 			return err
 		}
-		// The org's default team changed: re-attribute its buffered (unacked)
-		// billing buckets to the new team in this same transaction, so the next
-		// billing pull reports them under the new team instead of stranding
-		// them under the stale one. A freshly-created org lands here with
-		// oldTeamID == defaultTeamID (set on insert above), so this only fires
-		// on a real re-provision change. In-flight metering under the old team
-		// (config-snapshot poll lag, ~30s) can still land a small residual
-		// old-team bucket — tolerated, see configstore.ReattributeUsageTeamTx.
-		if oldTeamID != defaultTeamID {
+		// The org's billing team changed on a re-provision: re-attribute its
+		// buffered (unacked) billing buckets to the new team in this same
+		// transaction, so the next billing pull reports them under the new
+		// team instead of stranding them under the stale one. A
+		// freshly-created org has no buckets, so it skips this. In-flight
+		// metering under the old team (config-snapshot poll lag, ~30s) can
+		// still land a small residual old-team bucket — tolerated, see
+		// configstore.ReattributeUsageTeamTx.
+		if !orgCreated && oldTeamID != defaultTeamID {
 			moved, err := configstore.ReattributeUsageTeamTx(tx, orgID, defaultTeamID)
 			if err != nil {
 				return err
 			}
-			slog.Info("Re-attributed org usage buckets to new default team.",
+			slog.Info("Re-attributed org usage buckets to new billing team.",
 				"org", orgID, "old_team", oldTeamID, "new_team", defaultTeamID, "rows", moved)
 		}
 	}

--- a/docs/design/billing-pull-api.md
+++ b/docs/design/billing-pull-api.md
@@ -151,7 +151,10 @@ sizes; stored as `NUMERIC` so grouping is exact.)
 
 ## Changing an org's default team
 
-Buckets are stamped with the org's `default_team_id` **at record time**, so an
+Buckets are stamped with the org's billing team (historically the
+`default_team_id` column, now the `duckgres_org_teams` row with
+`is_billing_team = TRUE`; the wire field keeps the `default_team_id` name)
+**at record time**, so an
 update to the org (admin `PUT /orgs/:id` or a re-provision carrying a different
 `default_team_id`) would otherwise strand already-buffered usage under the old
 team — including a team that was just deleted in PostHog (duckgres treats the
@@ -195,7 +198,9 @@ folds it in.
 - **Add:** a `default_team_id` column on the org (BIGINT **NOT NULL** — required
   at org creation on both the provisioning and admin APIs, and not clearable
   via the admin API; used as the bucket `team_id` — fixed per org, no per-team
-  logic yet); a `duckgres.query_source` session GUC
+  logic yet. Since replaced by the `duckgres_org_teams` table, migration
+  000024: the bucket `team_id` is now the org's `is_billing_team = TRUE` row,
+  still surfaced as `default_team_id` on the wire); a `duckgres.query_source` session GUC
   (`standard` | `endpoints`, default `standard`, validated at SET time — anything
   else is a `22023` error) read by the meter; a bearer secret
   for the API.

--- a/k8s/kind/config-store-seed.sql
+++ b/k8s/kind/config-store-seed.sql
@@ -1,9 +1,15 @@
--- default_team_id is NOT NULL (every org must carry its default PostHog team
--- id); 1 is a placeholder for local dev.
-INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
+INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
+
+-- Every org must carry its billing PostHog team (duckgres_org_teams row with
+-- is_billing_team = TRUE); team 1 is a placeholder for local dev.
+INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+VALUES ('local', 1, 'team_1', TRUE, TRUE, NOW(), NOW())
+ON CONFLICT (org_id, team_id) DO UPDATE
+SET is_billing_team = TRUE,
+    updated_at = NOW();
 
 INSERT INTO duckgres_managed_warehouses (
     org_id,

--- a/k8s/kind/config-store.seed.sql
+++ b/k8s/kind/config-store.seed.sql
@@ -1,9 +1,15 @@
--- default_team_id is NOT NULL (every org must carry its default PostHog team
--- id); 1 is a placeholder for local dev.
-INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
+INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
+
+-- Every org must carry its billing PostHog team (duckgres_org_teams row with
+-- is_billing_team = TRUE); team 1 is a placeholder for local dev.
+INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+VALUES ('local', 1, 'team_1', TRUE, TRUE, NOW(), NOW())
+ON CONFLICT (org_id, team_id) DO UPDATE
+SET is_billing_team = TRUE,
+    updated_at = NOW();
 
 INSERT INTO duckgres_managed_warehouses (
     org_id,

--- a/k8s/local-config-store.seed.sql
+++ b/k8s/local-config-store.seed.sql
@@ -1,9 +1,15 @@
--- default_team_id is NOT NULL (every org must carry its default PostHog team
--- id); 1 is a placeholder for local dev.
-INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
-VALUES ('local', 'duckgres', 0, 1, NOW(), NOW())
+INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
+VALUES ('local', 'duckgres', 0, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET updated_at = NOW();
+
+-- Every org must carry its billing PostHog team (duckgres_org_teams row with
+-- is_billing_team = TRUE); team 1 is a placeholder for local dev.
+INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+VALUES ('local', 1, 'team_1', TRUE, TRUE, NOW(), NOW())
+ON CONFLICT (org_id, team_id) DO UPDATE
+SET is_billing_team = TRUE,
+    updated_at = NOW();
 
 INSERT INTO duckgres_managed_warehouses (
     org_id,

--- a/tests/configstore/helpers_test.go
+++ b/tests/configstore/helpers_test.go
@@ -64,14 +64,6 @@ func newIsolatedConfigStoreSchema(t *testing.T) (*sql.DB, string) {
 	return adminDB, connStr
 }
 
-// testDefaultTeamID returns a pointer to a placeholder PostHog team id for
-// seeded org rows — default_team_id is NOT NULL (migration 000020), so every
-// test fixture that inserts an org must carry one.
-func testDefaultTeamID() *int64 {
-	teamID := int64(1)
-	return &teamID
-}
-
 func cpconfigStoreNew(connStr string) (*cpconfigstore.ConfigStore, error) {
 	return cpconfigstore.NewConfigStore(connStr, time.Hour)
 }

--- a/tests/configstore/managed_warehouse_postgres_test.go
+++ b/tests/configstore/managed_warehouse_postgres_test.go
@@ -20,7 +20,7 @@ func TestManagedWarehouseConfigStorePostgres(t *testing.T) {
 		t.Fatalf("hash password: %v", err)
 	}
 
-	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "analytics", DatabaseName: "analytics"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.OrgUser{
@@ -81,7 +81,7 @@ func TestManagedWarehouseConfigStorePostgres(t *testing.T) {
 		t.Fatal("expected user credentials to remain loaded in snapshot")
 	}
 
-	if err := store.DB().Create(&configstore.Org{Name: "cleanup", DatabaseName: "cleanup", DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "cleanup", DatabaseName: "cleanup"}).Error; err != nil {
 		t.Fatalf("create cleanup org: %v", err)
 	}
 	if err := store.DB().Create(&configstore.ManagedWarehouse{

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -42,7 +42,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 21)
 	requireGooseMigrationRecorded(t, db, 22)
 	requireGooseMigrationRecorded(t, db, 23)
-	requireGooseLatestVersion(t, db, 23)
+	requireGooseMigrationRecorded(t, db, 24)
+	requireGooseLatestVersion(t, db, 24)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -73,11 +74,14 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 
 	// Migration 000013 added the per-org default_team_id column (nullable at
 	// the time); 000017 converted it (and the usage-bucket team_id below) to
-	// BIGINT to match PostHog's integer team ids; 000020 made it NOT NULL —
-	// every org must keep its default team (the billing bucket key).
-	requireColumnPresent(t, db, "duckgres_orgs", "default_team_id")
-	requireColumnType(t, db, "duckgres_orgs", "default_team_id", "bigint")
-	requireColumnNotNull(t, db, "duckgres_orgs", "default_team_id")
+	// BIGINT; 000024 replaced it with the per-org teams table — many PostHog
+	// teams per org, exactly one marked as the billing team (the billing
+	// bucket key) — and dropped the column.
+	requireColumnAbsent(t, db, "duckgres_orgs", "default_team_id")
+	requireTablePresent(t, db, "duckgres_org_teams")
+	requireColumnType(t, db, "duckgres_org_teams", "team_id", "bigint")
+	requireColumnNotNull(t, db, "duckgres_org_teams", "schema_name")
+	requireColumnDefault(t, db, "duckgres_org_teams", "enabled", "true")
 	requireColumnType(t, db, "duckgres_org_compute_usage", "team_id", "bigint")
 
 	// Migration 000007 added the compute-usage billing buffer; 000015 widened
@@ -150,7 +154,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			ALTER TABLE duckgres_org_users DROP COLUMN disabled;
 			ALTER TABLE duckgres_orgs ADD COLUMN IF NOT EXISTS max_connections BIGINT DEFAULT 0;
 			ALTER TABLE duckgres_managed_warehouses ALTER COLUMN duckling_name DROP NOT NULL;
-			ALTER TABLE duckgres_orgs DROP COLUMN default_team_id;
+			DROP TABLE IF EXISTS duckgres_org_teams;
 			ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS iceberg_enabled BOOLEAN DEFAULT false;
 			ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS iceberg_state VARCHAR(32);
 			ALTER TABLE duckgres_org_users ADD COLUMN IF NOT EXISTS default_catalog VARCHAR(255);
@@ -171,7 +175,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -208,14 +212,15 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 21)
 	requireGooseMigrationRecorded(t, upgradedDB, 22)
 	requireGooseMigrationRecorded(t, upgradedDB, 23)
-	requireGooseLatestVersion(t, upgradedDB, 23)
+	requireGooseMigrationRecorded(t, upgradedDB, 24)
+	requireGooseLatestVersion(t, upgradedDB, 24)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "max_vcpus", "0")
 	requireColumnDefault(t, upgradedDB, "duckgres_org_users", "disabled", "false")
-	requireColumnPresent(t, upgradedDB, "duckgres_orgs", "default_team_id")
-	requireColumnNotNull(t, upgradedDB, "duckgres_orgs", "default_team_id")
+	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "default_team_id")
+	requireTablePresent(t, upgradedDB, "duckgres_org_teams")
 	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "max_connections")
 	requireColumnAbsent(t, upgradedDB, "duckgres_managed_warehouses", "iceberg_enabled")
 	requireColumnAbsent(t, upgradedDB, "duckgres_org_users", "default_catalog")
@@ -287,6 +292,23 @@ func TestConfigStoreSQLMigrationsUpgradeOldOrgSchema(t *testing.T) {
 	}
 	requireColumnAbsent(t, sqlDB, "duckgres_orgs", "max_connections")
 	requireGooseMigrationRecorded(t, sqlDB, 3)
+
+	// Migration 000024 backfilled the legacy default_team_id value into the
+	// org's (billing) team row and dropped the column.
+	requireColumnAbsent(t, sqlDB, "duckgres_orgs", "default_team_id")
+	var team cpconfigstore.OrgTeam
+	if err := store.DB().First(&team, "org_id = ?", "old-org").Error; err != nil {
+		t.Fatalf("read backfilled org team row: %v", err)
+	}
+	if team.TeamID != 1 || team.SchemaName != "team_1" || !team.Enabled {
+		t.Fatalf("backfilled team row = %+v, want team 1, schema team_1, enabled", team)
+	}
+	if team.IsBillingTeam == nil || !*team.IsBillingTeam {
+		t.Fatalf("backfilled team row must be the billing team, got %+v", team)
+	}
+	if team.BackfillEnabled != nil {
+		t.Fatalf("backfilled team row backfill_enabled = %v, want NULL", *team.BackfillEnabled)
+	}
 }
 
 // TestConfigStoreMigrationFailsLoudlyOnNullDefaultTeamID pins the deploy-time
@@ -430,6 +452,7 @@ func TestConfigStoreSQLMigrationsMatchGORMModelMetadata(t *testing.T) {
 		&cpconfigstore.Org{},
 		&cpconfigstore.ManagedWarehouse{},
 		&cpconfigstore.OrgUser{},
+		&cpconfigstore.OrgTeam{},
 		&cpconfigstore.OrgUserSecret{},
 		&cpconfigstore.Operator{},
 	); err != nil {
@@ -694,6 +717,7 @@ func loadConfigStoreColumnMetadata(t *testing.T, db *sql.DB) map[string]columnMe
 		  AND table_name IN (
 			'duckgres_orgs',
 			'duckgres_org_users',
+			'duckgres_org_teams',
 			'duckgres_org_user_secrets',
 			'duckgres_managed_warehouses',
 			'duckgres_operators',
@@ -751,6 +775,7 @@ func loadConfigStorePrimaryKeys(t *testing.T, db *sql.DB) map[string]primaryKeyM
 		  AND src.relname IN (
 			'duckgres_orgs',
 			'duckgres_org_users',
+			'duckgres_org_teams',
 			'duckgres_org_user_secrets',
 			'duckgres_managed_warehouses',
 			'duckgres_operators',
@@ -803,6 +828,7 @@ func loadConfigStoreIndexes(t *testing.T, db *sql.DB) map[string]indexMetadata {
 		  AND src.relname IN (
 			'duckgres_orgs',
 			'duckgres_org_users',
+			'duckgres_org_teams',
 			'duckgres_org_user_secrets',
 			'duckgres_managed_warehouses',
 			'duckgres_operators',
@@ -867,6 +893,7 @@ func loadConfigStoreForeignKeys(t *testing.T, db *sql.DB) map[string]foreignKeyM
 		  AND src.relname IN (
 			'duckgres_orgs',
 			'duckgres_org_users',
+			'duckgres_org_teams',
 			'duckgres_org_user_secrets',
 			'duckgres_managed_warehouses',
 			'duckgres_operators',

--- a/tests/configstore/reattribute_usage_postgres_test.go
+++ b/tests/configstore/reattribute_usage_postgres_test.go
@@ -148,14 +148,18 @@ func TestReattributeUsageTeamPostgres(t *testing.T) {
 }
 
 // TestProvisionReattributesUsageOnTeamChangePostgres: re-provisioning an
-// EXISTING org with a different default_team_id must update the org row AND
-// re-attribute its buffered usage buckets to the new team, atomically.
+// EXISTING org with a different default_team_id must repoint the org's
+// billing team row (duckgres_org_teams) AND re-attribute its buffered usage
+// buckets to the new team, atomically.
 func TestProvisionReattributesUsageOnTeamChangePostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 
 	oldTeam := int64(1)
-	if err := store.DB().Create(&configstore.Org{Name: "reprov", DatabaseName: "reprovdb", DefaultTeamID: &oldTeam}).Error; err != nil {
+	if err := store.DB().Create(&configstore.Org{Name: "reprov", DatabaseName: "reprovdb"}).Error; err != nil {
 		t.Fatalf("create org: %v", err)
+	}
+	if err := configstore.SetOrgBillingTeamTx(store.DB(), "reprov", oldTeam); err != nil {
+		t.Fatalf("seed billing team: %v", err)
 	}
 	bucket := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
 	seedUsage(t, store, "reprov", oldTeam, bucket, 10, 20, 1000)
@@ -171,12 +175,30 @@ func TestProvisionReattributesUsageOnTeamChangePostgres(t *testing.T) {
 		t.Fatalf("re-provision with new team: %v", err)
 	}
 
-	var org configstore.Org
-	if err := store.DB().First(&org, "name = ?", "reprov").Error; err != nil {
+	org, err := pstore.GetOrg("reprov")
+	if err != nil {
 		t.Fatalf("read org: %v", err)
 	}
 	if org.DefaultTeamID == nil || *org.DefaultTeamID != 2 {
-		t.Fatalf("org default_team_id = %v, want 2", org.DefaultTeamID)
+		t.Fatalf("org billing team = %v, want 2", org.DefaultTeamID)
+	}
+	// The old team row survives the flip, demoted; team 2 carries the
+	// (single) billing mark and the conventional schema name.
+	var teamRows []configstore.OrgTeam
+	if err := store.DB().Where("org_id = ?", "reprov").Order("team_id").Find(&teamRows).Error; err != nil {
+		t.Fatalf("read org team rows: %v", err)
+	}
+	if len(teamRows) != 2 || teamRows[0].TeamID != 1 || teamRows[1].TeamID != 2 {
+		t.Fatalf("org team rows = %+v, want teams [1 2]", teamRows)
+	}
+	if teamRows[0].IsBillingTeam != nil && *teamRows[0].IsBillingTeam {
+		t.Fatal("old team 1 must be demoted from billing")
+	}
+	if teamRows[1].IsBillingTeam == nil || !*teamRows[1].IsBillingTeam {
+		t.Fatal("team 2 must carry the billing mark")
+	}
+	if teamRows[1].SchemaName != "team_2" {
+		t.Fatalf("team 2 schema_name = %q, want team_2", teamRows[1].SchemaName)
 	}
 
 	compute := computeRowsForOrg(t, store, "reprov")

--- a/tests/configstore/reshard_postgres_test.go
+++ b/tests/configstore/reshard_postgres_test.go
@@ -15,9 +15,8 @@ func seedReadyWarehouse(t *testing.T, store *cpconfigstore.ConfigStore, orgID st
 	t.Helper()
 	// The warehouse row has an FK to the org row (fk_duckgres_orgs_warehouse).
 	if err := store.DB().Create(&cpconfigstore.Org{
-		Name:          orgID,
-		DatabaseName:  orgID,
-		DefaultTeamID: testDefaultTeamID(),
+		Name:         orgID,
+		DatabaseName: orgID,
 	}).Error; err != nil {
 		t.Fatalf("seed org: %v", err)
 	}
@@ -391,7 +390,7 @@ func TestListExternalMetadataStoresPostgres(t *testing.T) {
 
 	seed := func(org, endpoint string, state cpconfigstore.ManagedWarehouseProvisioningState) {
 		t.Helper()
-		if err := store.DB().Create(&cpconfigstore.Org{Name: org, DatabaseName: org, DefaultTeamID: testDefaultTeamID()}).Error; err != nil {
+		if err := store.DB().Create(&cpconfigstore.Org{Name: org, DatabaseName: org}).Error; err != nil {
 			t.Fatalf("seed org %s: %v", org, err)
 		}
 		wh := &cpconfigstore.ManagedWarehouse{OrgID: org, DucklingName: org, State: state}

--- a/tests/configstore/testdata/tenant-isolation.seed.sql
+++ b/tests/configstore/testdata/tenant-isolation.seed.sql
@@ -1,9 +1,17 @@
-INSERT INTO duckgres_orgs (name, database_name, max_workers, default_team_id, created_at, updated_at)
+INSERT INTO duckgres_orgs (name, database_name, max_workers, created_at, updated_at)
 VALUES
-    ('analytics', 'analytics', 0, 1, NOW(), NOW()),
-    ('billing', 'billing', 0, 2, NOW(), NOW())
+    ('analytics', 'analytics', 0, NOW(), NOW()),
+    ('billing', 'billing', 0, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE
 SET database_name = EXCLUDED.database_name,
+    updated_at = NOW();
+
+INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+VALUES
+    ('analytics', 1, 'team_1', TRUE, TRUE, NOW(), NOW()),
+    ('billing', 2, 'team_2', TRUE, TRUE, NOW(), NOW())
+ON CONFLICT (org_id, team_id) DO UPDATE
+SET is_billing_team = TRUE,
     updated_at = NOW();
 
 INSERT INTO duckgres_managed_warehouses (

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1281,10 +1281,11 @@ org_default_profile() { # org password catalog
 }
 
 # ---- org default_team_id (mandatory on new orgs) ----------------------------
-# default_team_id links an org to its default PostHog team id (a BIGINT
-# config-store column — a JSON NUMBER on the wire, matching PostHog's integer
-# Team.id; prereq for pull-based compute billing where usage buckets are keyed
-# by team_id). Contract: MANDATORY when a provision creates a NEW org (400, nothing
+# default_team_id is the org's billing PostHog team id (a JSON NUMBER on the
+# wire, matching PostHog's integer Team.id; stored as the org's
+# duckgres_org_teams row with is_billing_team = TRUE; prereq for pull-based
+# compute billing where usage buckets are keyed by team_id). Contract:
+# MANDATORY when a provision creates a NEW org (400, nothing
 # created); optional on re-provision of an existing org, where omission keeps
 # the stored value (set-only, never a wipe — the keep path is covered by
 # TestReprovisionExistingOrgKeepsDefaultTeamID, since same-id re-provision
@@ -1296,10 +1297,9 @@ org_default_profile() { # org password catalog
 #      400 naming the field, and must create nothing (org GET stays 404).
 #   3. Mutate path: PUT /orgs/:id can set it to a positive team id on the EXT
 #      org, round-tripping on GET; clearing (0 or null) is REJECTED with a 400
-#      and must leave the stored value untouched — the column is NOT NULL
-#      (migration 000020) and every org must keep its default team (the
-#      billing bucket key). The provisioned value is restored afterwards so
-#      the org stays contract-conformant.
+#      and must leave the stored value untouched — every org must keep its
+#      billing team (the billing bucket key). The provisioned value is
+#      restored afterwards so the org stays contract-conformant.
 # get_org_default_team_id prints the raw JSON value ("null" when NULL) so the
 # assertions can distinguish an unset column from an empty string.
 get_org_default_team_id() { # org -> prints default_team_id (jq raw; "null" when unset)


### PR DESCRIPTION
## Problem

An org maps to exactly one PostHog team via the `default_team_id` column on `duckgres_orgs`. Managed warehouses need to serve many teams per org (multi-environment orgs), and per-team state — which warehouse schema a team's data lives in, whether the team is enabled, whether its backfill runs — has no home in the config store.

## Change

Migration `000024` introduces **`duckgres_org_teams`**: one row per (org, team) with

- `schema_name` (required) — the warehouse schema the team's data lives in (`team_<id>` convention)
- `enabled` (NOT NULL, default TRUE) — per-team serving switch
- `is_billing_team` (nullable) — the team pull-based billing keys the org's usage buckets by; a partial unique index allows at most one billing row per org
- `backfill_enabled` (nullable, tri-state)

The migration backfills one billing row per org from `default_team_id` (`team_<id>` schema) and **drops the column**. Down restores the column (nullable) from the billing row.

## Billing keeps its contract, keyed off the billing team

- `ConfigStore.OrgDefaultTeamID` → `OrgBillingTeamID`, same 0-when-missing contract; the snapshot loads Teams alongside Users/Warehouse so reads stay snapshot-backed
- Compute meter and storage sampler resolve the billing team
- Provisioning inserts/repoints the billing row (`SetOrgBillingTeamTx`: demote-then-upsert, ordered for the immediate partial-index check) and re-attributes unacked usage buckets in the same transaction, exactly as the column update used to
- Repointing keeps the old team's row, demoted to non-billing (teams are members; billing is a mark)

## API compat

The admin/provisioning **wire field stays `default_team_id`**: `Org.DefaultTeamID` is now a `gorm:"-"` view populated from the preloaded Teams association on reads, translated into the billing-team upsert on writes. Admin UI and e2e payloads unchanged (TS types extended with `OrgTeam`). Clearing is still rejected.

## Tests

- Migration tests against real Postgres: table shape, legacy-schema backfill, v8-upgrade replay, Up/Down, GORM-model/goose-schema metadata match (partial unique index + CASCADE FK included)
- `TestOrgBillingTeamID` snapshot lookup (billing row → id, absent → 0, nil snapshot → 0)
- Billing-repoint + cascade assertions in the admin/provisioning postgres tests; seeds insert team rows
- Ran green: `go build ./...`, `go vet ./...` (+ `-tags kubernetes`), `go test ./controlplane/...`, admin + configstore suites against a real DB, admin UI tsc + vitest. The live-k8s e2e harness was not run (needs a cluster); its payloads use the unchanged wire field.
