### PR TITLE
feat: resolve Duckling metadata credentials from Secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -684,6 +684,15 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
   — it pointed a flip-before-copy reshard at a phantom cnpg source while the
   org lived on an external RDS (prod incident: org re-pointed onto an empty
   catalog, rollback patch rejected).
+- **Metadata credentials come from a referenced Secret, never CR status.**
+  `status.metadataStore.credentialSecretRef` names one key in a Secret in the
+  `ducklings` namespace; `DucklingClient.Get` resolves it before returning the
+  status used by activation, probes, metering, and resharding. References to
+  any other namespace are rejected. The plaintext `status.metadataStore.password`
+  read is a temporary deploy-order fallback only: it is used when no reference
+  exists, or when a referenced Secret is temporarily unreadable while the
+  legacy password is still present. Once charts stops publishing plaintext,
+  an unreadable/missing Secret is a hard error.
 - **Rollback patches the source shard VALUE back — never removes the key**
   (precedence would fall through to the freshly-stamped bogus status pin);
   ext→cnpg rollback must null `cnpgShard` (XRD CEL forbids it on external).

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -26,6 +27,8 @@ var ducklingGVR = schema.GroupVersionResource{
 	Resource: "ducklings",
 }
 
+var secretGVR = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
+
 const ducklingNamespace = "ducklings"
 
 // DucklingStatus holds the parsed status from a Duckling CR.
@@ -41,7 +44,8 @@ type DucklingStatus struct {
 		User              string
 		Database          string
 	}
-	DataStore struct {
+	MetadataCredentialSecretRef SecretReference
+	DataStore                   struct {
 		Type       string
 		BucketName string
 		S3Region   string
@@ -61,6 +65,15 @@ type DucklingStatus struct {
 	// falls back to the legacy type-based default — DuckLake on for
 	// external, off for cnpg-shard). Non-nil for decoupled ducklings.
 	DuckLakeEnabled *bool
+}
+
+// SecretReference identifies one key in a namespaced Kubernetes Secret. The
+// Duckling composition publishes this non-sensitive reference instead of
+// copying the metadata database password into the CR status.
+type SecretReference struct {
+	Name      string
+	Namespace string
+	Key       string
 }
 
 // DucklingClient wraps a Kubernetes dynamic client for Duckling CR operations.
@@ -313,7 +326,59 @@ func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus,
 	if err != nil {
 		return nil, fmt.Errorf("get duckling CR %q: %w", name, err)
 	}
-	return parseDucklingStatus(cr)
+	status, err := parseDucklingStatus(cr)
+	if err != nil {
+		return nil, err
+	}
+	ref := status.MetadataCredentialSecretRef
+	if ref.Name == "" {
+		return status, nil // Legacy composition: plaintext status fallback.
+	}
+	password, err := d.readSecretKey(ctx, ref)
+	if err != nil {
+		// During the staged rollout an older/temporarily unavailable Secret must
+		// not strand tenants whose legacy status password is still populated.
+		if status.MetadataStore.Password != "" {
+			slog.Warn("Failed to resolve Duckling metadata credential Secret; using legacy status password.", "duckling", name, "secret", ref.Name, "error", err)
+			return status, nil
+		}
+		return nil, fmt.Errorf("resolve metadata credential Secret for duckling %q: %w", name, err)
+	}
+	status.MetadataStore.Password = password
+	return status, nil
+}
+
+func (d *DucklingClient) readSecretKey(ctx context.Context, ref SecretReference) (string, error) {
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = ducklingNamespace
+	}
+	if namespace != ducklingNamespace {
+		return "", fmt.Errorf("namespace %q is not allowed", namespace)
+	}
+	key := ref.Key
+	if key == "" {
+		key = "password"
+	}
+	secret, err := d.client.Resource(secretGVR).Namespace(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get Secret %s/%s: %w", namespace, ref.Name, err)
+	}
+	encoded, found, err := unstructured.NestedString(secret.Object, "data", key)
+	if err != nil {
+		return "", fmt.Errorf("read Secret %s/%s key %q: %w", namespace, ref.Name, key, err)
+	}
+	if !found || encoded == "" {
+		return "", fmt.Errorf("Secret %s/%s has no non-empty %q key", namespace, ref.Name, key)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("decode Secret %s/%s key %q: %w", namespace, ref.Name, key, err)
+	}
+	if len(decoded) == 0 {
+		return "", fmt.Errorf("Secret %s/%s key %q is empty", namespace, ref.Name, key)
+	}
+	return string(decoded), nil
 }
 
 // ComposedResourceError describes one composed managed resource that is not
@@ -1024,6 +1089,13 @@ func parseDucklingStatus(cr *unstructured.Unstructured) (*DucklingStatus, error)
 		ds.MetadataStore.Password = getNestedString(md, "password")
 		ds.MetadataStore.User = getNestedString(md, "user")
 		ds.MetadataStore.Database = getNestedString(md, "database")
+		if ref, ok := md["credentialSecretRef"].(map[string]interface{}); ok {
+			ds.MetadataCredentialSecretRef = SecretReference{
+				Name:      getNestedString(ref, "name"),
+				Namespace: getNestedString(ref, "namespace"),
+				Key:       getNestedString(ref, "key"),
+			}
+		}
 	}
 
 	// Parse status.dataStore

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -4,14 +4,103 @@ package provisioner
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
+
+func ducklingWithCredentialRef(name, legacyPassword string, ref SecretReference) *unstructured.Unstructured {
+	metadataStore := map[string]interface{}{
+		"type":     configstore.MetadataStoreKindCnpgShard,
+		"endpoint": "metadata.internal",
+		"user":     "tenant",
+		"database": "tenant",
+	}
+	if legacyPassword != "" {
+		metadataStore["password"] = legacyPassword
+	}
+	if ref.Name != "" {
+		metadataStore["credentialSecretRef"] = map[string]interface{}{
+			"name": ref.Name, "namespace": ref.Namespace, "key": ref.Key,
+		}
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata":   map[string]interface{}{"name": name, "namespace": ducklingNamespace},
+		"status":     map[string]interface{}{"metadataStore": metadataStore},
+	}}
+}
+
+func credentialSecret(name, password string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": name, "namespace": ducklingNamespace},
+		"data":       map[string]interface{}{"password": base64.StdEncoding.EncodeToString([]byte(password))},
+	}}
+}
+
+func TestGetResolvesMetadataPasswordFromCredentialSecretRef(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", "stale-status-password", SecretReference{
+		Name: "cnpg-tenant-acme-password", Namespace: ducklingNamespace, Key: "password",
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr, credentialSecret("cnpg-tenant-acme-password", "live-secret-password"))
+
+	status, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := status.MetadataStore.Password; got != "live-secret-password" {
+		t.Fatalf("password = %q, want Secret value", got)
+	}
+}
+
+func TestGetFallsBackToLegacyStatusPasswordDuringRollout(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", "legacy-password", SecretReference{
+		Name: "missing-password", Namespace: ducklingNamespace, Key: "password",
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
+
+	status, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := status.MetadataStore.Password; got != "legacy-password" {
+		t.Fatalf("password = %q, want legacy fallback", got)
+	}
+}
+
+func TestGetFailsWhenReferencedCredentialIsUnavailableWithoutLegacyFallback(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", "", SecretReference{
+		Name: "missing-password", Namespace: ducklingNamespace, Key: "password",
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
+
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), "missing-password") {
+		t.Fatalf("Get error = %v, want missing Secret error", err)
+	}
+}
+
+func TestGetRejectsCredentialSecretOutsideDucklingsNamespace(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", "", SecretReference{
+		Name: "password", Namespace: "other-namespace", Key: "password",
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
+
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), `namespace "other-namespace" is not allowed`) {
+		t.Fatalf("Get error = %v, want namespace rejection", err)
+	}
+}
 
 func mrWithPolicies(policies []interface{}) *unstructured.Unstructured {
 	spec := map[string]interface{}{}

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -69,6 +69,12 @@ the config-store warehouse row and the duckling *spec* are operator-editable
 inputs that can drift. The op is **refused (400, nothing created)** when the
 identity is incomplete or contradicted:
 
+The status contains only a non-sensitive `credentialSecretRef`; Duckgres reads
+the referenced key from the Secret in the `ducklings` namespace before any
+catalog copy, verification, or rollback. During the ordered rollout it still
+accepts the legacy plaintext status password as a fallback, but the reference
+is authoritative whenever it can be resolved.
+
 - **kind drift** — the row's `metadata_store_kind` (when set) disagrees with
   the status type → 400 naming both values ("refusing to reshard until
   reconciled").

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -216,10 +216,12 @@ rds_psql() { # sql
 
 # ext_rds_setup creates this run's metadata database and GCs databases leaked
 # by aborted runs. It needs the RDS password, which the harness obtains
-# in-cluster from its OWN ext duckling's CR status (status.metadataStore
-# .password, the ESO-synced value — the same shared-user password every run
-# uses; the harness SA already has cross-namespace duckling read RBAC). That
-# status field only exists once the composition has synced the secret, so this
+# in-cluster from its OWN ext duckling's referenced Kubernetes Secret. During
+# the deploy-ordered migration, an older composition may not publish
+# credentialSecretRef yet, so the harness accepts the legacy plaintext status
+# field only when the reference is absent. Once the reference exists, failure
+# to read it is a hard failure rather than silently masking broken Secret RBAC.
+# The credential only becomes readable once ESO has synced the secret, so this
 # runs as a lane CONCURRENT with the readiness waits: the CP's end-to-end
 # provisioning probe (controller.go reconcileProvisioning) targets the per-run
 # database and simply retries until we create it — never terminal before the
@@ -232,11 +234,19 @@ ext_rds_setup() {
   deadline=$(( $(date +%s) + 300 ))
   EXT_RDS_PW=""
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    EXT_RDS_PW="$("$KUBECTL" -n ducklings get "duckling/$d" -o jsonpath='{.status.metadataStore.password}' 2>/dev/null || true)"
+    secret_name="$("$KUBECTL" -n ducklings get "duckling/$d" -o jsonpath='{.status.metadataStore.credentialSecretRef.name}' 2>/dev/null || true)"
+    secret_key="$("$KUBECTL" -n ducklings get "duckling/$d" -o jsonpath='{.status.metadataStore.credentialSecretRef.key}' 2>/dev/null || true)"
+    if [ -n "$secret_name" ]; then
+      [ -n "$secret_key" ] || secret_key=password
+      encoded="$("$KUBECTL" -n ducklings get secret "$secret_name" -o "jsonpath={.data.${secret_key}}" 2>/dev/null || true)"
+      [ -z "$encoded" ] || EXT_RDS_PW="$(printf %s "$encoded" | base64 -d)"
+    else
+      EXT_RDS_PW="$("$KUBECTL" -n ducklings get "duckling/$d" -o jsonpath='{.status.metadataStore.password}' 2>/dev/null || true)"
+    fi
     [ -n "$EXT_RDS_PW" ] && break
     sleep 5
   done
-  [ -n "$EXT_RDS_PW" ] || fail "ext metadata db: duckling/$d never published status.metadataStore.password (ESO sync stuck?)"
+  [ -n "$EXT_RDS_PW" ] || fail "ext metadata db: duckling/$d credential Secret never became readable (ESO sync or RBAC stuck?)"
   # Stash for ext_rds_teardown: this runs in a lane subshell, so a shell var
   # would not survive back to main() (same pattern as the prov_*.json files).
   printf %s "$EXT_RDS_PW" > "$LANE_DIR/ext_rds_pw"


### PR DESCRIPTION
## Summary
- resolve Duckling metadata database passwords from a namespaced Kubernetes Secret reference
- prefer the referenced Secret while retaining a temporary plaintext-status fallback for deploy ordering
- reject references outside the ducklings namespace and fail closed once plaintext status is removed
- update the mw-dev harness to consume the referenced Secret when charts publishes it

## Deployment order
Deploy this Duckgres change before the companion charts PR removes status.metadataStore.password.

## Testing
- env GOCACHE=/tmp/duckgres-secret-ref-gocache go test -tags kubernetes ./controlplane/provisioner
- bash -n tests/mw-dev/e2e/harness.sh
- git diff --check

The wider control-plane package tests that require local listeners or Docker were intentionally left to CI.