### PR TITLE
feat(admin): break-glass team edit — schema_name and legacy table names

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -118,9 +118,10 @@ func registerAPIWithStore(r *gin.RouterGroup, store apiStore, info OrgStackInfo,
 	// registered by the provisioning API on this same group — gin refuses
 	// duplicate routes, so the admin surface adds only what provisioning
 	// doesn't have: the cross-org list, a CREATE-ONLY POST (org_id in the
-	// body, mirroring POST /users), and the update. Unlike the internal
-	// provisioning upsert, this is a user-facing surface: schema_name is set
-	// once at create time and immutable afterwards (the PUT rejects it).
+	// body, mirroring POST /users), and the update. The PUT is the operator
+	// break-glass: it can edit EVERY team setting, including schema_name and
+	// the legacy table-name overrides — schema immutability is a rule for the
+	// user-facing product flows, not for operators repairing rows here.
 	r.GET("/teams", h.listAllOrgTeams)
 	r.POST("/teams", h.createOrgTeam)
 	r.PUT("/orgs/:id/teams/:team_id", h.updateOrgTeam)
@@ -157,16 +158,20 @@ type apiStore interface {
 	DeleteOrg(name string) (bool, error)
 
 	// Org teams. CreateOrgTeam is create-only (the admin surface never
-	// overwrites an existing row — schema_name is immutable here); it returns
-	// errOrgTeamExists / configstore.ErrOrgTeamSchemaConflict for the two
-	// conflict shapes, gorm.ErrRecordNotFound for an unknown org.
-	// UpdateOrgTeam mutates enabled / backfill_enabled and can repoint the
-	// billing team (usage buckets re-attributed in the same transaction).
+	// overwrites an existing row); it returns errOrgTeamExists /
+	// configstore.ErrOrgTeamSchemaConflict for the two conflict shapes,
+	// gorm.ErrRecordNotFound for an unknown org. UpdateOrgTeam applies the
+	// presence-aware orgTeamUpdate (every column is editable — operator
+	// break-glass) and can repoint the billing team (usage buckets
+	// re-attributed in the same transaction); it returns the row as it was
+	// BEFORE the update alongside the stored result so the handler can audit
+	// old → new per field. A schema_name change that collides with another
+	// team in the org returns configstore.ErrOrgTeamSchemaConflict.
 	// Per-org list and delete are served by the provisioning API's routes on
 	// the same router group (identical rules — configstore.DeleteOrgTeamTx).
 	ListAllOrgTeams() ([]configstore.OrgTeam, error)
 	CreateOrgTeam(orgID string, team *configstore.OrgTeam) error
-	UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (*configstore.OrgTeam, error)
+	UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (prev, stored *configstore.OrgTeam, err error)
 
 	ListUsers() ([]configstore.OrgUser, error)
 	CreateUser(user *configstore.OrgUser) error
@@ -351,14 +356,27 @@ func (s *gormAPIStore) DeleteOrg(name string) (bool, error) {
 // grandfather path), so an existing row is a 409, not an upsert.
 var errOrgTeamExists = errors.New("team already exists in this org")
 
-// orgTeamUpdate carries the admin-editable fields of one org team. Pointer
-// fields are presence-aware (nil = preserve). schema_name is deliberately NOT
-// here: it is immutable on the admin surface. BackfillSet distinguishes an
-// explicit `"backfill_enabled": null` (clear to unset) from an absent key.
+// orgTeamUpdate carries the admin-editable fields of one org team — every
+// column, this is the operator break-glass surface. Pointer fields are
+// presence-aware (nil = preserve). The *Set booleans distinguish an explicit
+// JSON null (clear to unset/NULL) from an absent key for the nullable columns.
 type orgTeamUpdate struct {
+	// SchemaName: nil = preserve. A non-nil value is the operator override —
+	// validated by the handler, refused with ErrOrgTeamSchemaConflict when
+	// another team in the org already uses it. Changing it does NOT move any
+	// warehouse data; tables under the old schema are not renamed.
+	SchemaName  *string
 	Enabled     *bool
 	BackfillSet bool
 	Backfill    *bool
+	// Legacy explicit table names for grandfathered teams (NULL = derive from
+	// schema_name). XSet + nil value clears the column back to NULL.
+	EventsTableNameSet       bool
+	EventsTableName          *string
+	PersonsTableNameSet      bool
+	PersonsTableName         *string
+	SchemaDataImportsNameSet bool
+	SchemaDataImportsName    *string
 	// MakeBilling repoints the org's billing team to this row (the buffered
 	// usage buckets follow atomically). There is no "unset billing" — every
 	// org must keep a billing team; repoint by marking another team.
@@ -403,8 +421,8 @@ func (s *gormAPIStore) CreateOrgTeam(orgID string, team *configstore.OrgTeam) er
 	})
 }
 
-func (s *gormAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (*configstore.OrgTeam, error) {
-	var stored configstore.OrgTeam
+func (s *gormAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (*configstore.OrgTeam, *configstore.OrgTeam, error) {
+	var prev, stored configstore.OrgTeam
 	err := s.db().Transaction(func(tx *gorm.DB) error {
 		var team configstore.OrgTeam
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -415,13 +433,39 @@ func (s *gormAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpda
 		if err != nil {
 			return err
 		}
+		prev = team
 
 		fields := map[string]interface{}{"updated_at": gorm.Expr("now()")}
+		if upd.SchemaName != nil && *upd.SchemaName != team.SchemaName {
+			// Pre-check the per-org schema uniqueness for a clean error; the
+			// unique (org_id, schema_name) index still backs it — a concurrent
+			// writer that slips past the check fails with a 23505 (same
+			// contract as configstore.UpsertOrgTeamTx).
+			var clash int64
+			if err := tx.Model(&configstore.OrgTeam{}).
+				Where("org_id = ? AND schema_name = ? AND team_id <> ?", orgID, *upd.SchemaName, teamID).
+				Count(&clash).Error; err != nil {
+				return err
+			}
+			if clash > 0 {
+				return configstore.ErrOrgTeamSchemaConflict
+			}
+			fields["schema_name"] = *upd.SchemaName
+		}
 		if upd.Enabled != nil {
 			fields["enabled"] = *upd.Enabled
 		}
 		if upd.BackfillSet {
 			fields["backfill_enabled"] = upd.Backfill
+		}
+		if upd.EventsTableNameSet {
+			fields["events_table_name"] = upd.EventsTableName
+		}
+		if upd.PersonsTableNameSet {
+			fields["persons_table_name"] = upd.PersonsTableName
+		}
+		if upd.SchemaDataImportsNameSet {
+			fields["schema_data_imports_name"] = upd.SchemaDataImportsName
 		}
 		if len(fields) > 1 {
 			if err := tx.Model(&configstore.OrgTeam{}).
@@ -453,9 +497,9 @@ func (s *gormAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpda
 		return tx.First(&stored, "org_id = ? AND team_id = ?", orgID, teamID).Error
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &stored, nil
+	return &prev, &stored, nil
 }
 
 func (s *gormAPIStore) ListUsers() ([]configstore.OrgUser, error) {
@@ -910,9 +954,10 @@ func (h *apiHandler) listAllOrgTeams(c *gin.Context) {
 
 // createOrgTeamRequest is the admin create body (POST /teams — the org rides
 // in the body like POST /users, because the /orgs/:id/teams POST route
-// belongs to the provisioning grandfather upsert). schema_name is set here
-// ONCE and immutable afterwards on this surface (the update endpoint rejects
-// it) — only the internal provisioning grandfather path may overwrite it.
+// belongs to the provisioning grandfather upsert). schema_name set here is
+// immutable through user-facing flows; operators can later change it via the
+// break-glass PUT, and the internal provisioning grandfather path may
+// overwrite it.
 type createOrgTeamRequest struct {
 	OrgID           string `json:"org_id"`
 	TeamID          int64  `json:"team_id"`
@@ -964,13 +1009,40 @@ func (h *apiHandler) createOrgTeam(c *gin.Context) {
 	c.JSON(http.StatusCreated, team)
 }
 
-// updateOrgTeamRequest is the admin PUT body: enabled / backfill_enabled /
-// is_billing_team only. schema_name is immutable on this surface, and billing
-// can only be pointed AT a team (is_billing_team: true) — never cleared.
+// updateOrgTeamRequest is the admin PUT body — the operator break-glass that
+// can edit every team setting. All fields are presence-aware (absent =
+// preserve). schema_name may be CHANGED here (immutability is a user-facing
+// flow rule, not an operator one) but never cleared — it stays NOT NULL. The
+// nullable columns (backfill_enabled and the three legacy table-name
+// overrides) treat an explicit JSON null — and, for the table names, "" — as
+// "clear back to NULL". Billing can only be pointed AT a team
+// (is_billing_team: true), never cleared.
 type updateOrgTeamRequest struct {
-	Enabled         *bool `json:"enabled,omitempty"`
-	BackfillEnabled *bool `json:"backfill_enabled,omitempty"`
-	IsBillingTeam   *bool `json:"is_billing_team,omitempty"`
+	SchemaName            *string `json:"schema_name,omitempty"`
+	Enabled               *bool   `json:"enabled,omitempty"`
+	BackfillEnabled       *bool   `json:"backfill_enabled,omitempty"`
+	IsBillingTeam         *bool   `json:"is_billing_team,omitempty"`
+	EventsTableName       *string `json:"events_table_name,omitempty"`
+	PersonsTableName      *string `json:"persons_table_name,omitempty"`
+	SchemaDataImportsName *string `json:"schema_data_imports_name,omitempty"`
+}
+
+// maxOrgTeamTableNameLength caps the legacy table-name overrides at the
+// column width (varchar(255)) so a typo'd blob is a 400, not a DB error.
+const maxOrgTeamTableNameLength = 255
+
+// legacyTableNameUpdate folds one presence-aware legacy table-name field of
+// the PUT body into (set, value): absent = (false, nil); explicit null or ""
+// = (true, nil) — clear back to NULL / derive from schema_name; anything else
+// = (true, &value).
+func legacyTableNameUpdate(present bool, v *string) (bool, *string) {
+	if !present {
+		return false, nil
+	}
+	if v == nil || *v == "" {
+		return true, nil
+	}
+	return true, v
 }
 
 func (h *apiHandler) updateOrgTeam(c *gin.Context) {
@@ -996,48 +1068,81 @@ func (h *apiHandler) updateOrgTeam(c *gin.Context) {
 		return
 	}
 	if _, ok := fields["schema_name"]; ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "schema_name is immutable — it is set once when the team is created"})
-		return
+		// The operator override: changing the schema is allowed HERE (and only
+		// here — user-facing flows keep it immutable), but it must stay a
+		// valid, non-null identifier. It renames NOTHING in the warehouse.
+		if req.SchemaName == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "schema_name cannot be cleared; pass a valid schema name"})
+			return
+		}
+		if err := configstore.ValidateOrgTeamSchemaName(*req.SchemaName); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 	}
 	if _, ok := fields["is_billing_team"]; ok && (req.IsBillingTeam == nil || !*req.IsBillingTeam) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "is_billing_team can only be set to true (repoint billing by marking another team); every org must keep a billing team"})
 		return
 	}
+	for name, v := range map[string]*string{
+		"events_table_name":        req.EventsTableName,
+		"persons_table_name":       req.PersonsTableName,
+		"schema_data_imports_name": req.SchemaDataImportsName,
+	} {
+		if v != nil && len(*v) > maxOrgTeamTableNameLength {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s must be at most %d characters", name, maxOrgTeamTableNameLength)})
+			return
+		}
+	}
 	_, backfillSet := fields["backfill_enabled"]
+	_, eventsPresent := fields["events_table_name"]
+	_, personsPresent := fields["persons_table_name"]
+	_, importsPresent := fields["schema_data_imports_name"]
 	upd := orgTeamUpdate{
+		SchemaName:  req.SchemaName,
 		Enabled:     req.Enabled,
 		BackfillSet: backfillSet,
 		Backfill:    req.BackfillEnabled,
 		MakeBilling: req.IsBillingTeam != nil && *req.IsBillingTeam,
 	}
+	upd.EventsTableNameSet, upd.EventsTableName = legacyTableNameUpdate(eventsPresent, req.EventsTableName)
+	upd.PersonsTableNameSet, upd.PersonsTableName = legacyTableNameUpdate(personsPresent, req.PersonsTableName)
+	upd.SchemaDataImportsNameSet, upd.SchemaDataImportsName = legacyTableNameUpdate(importsPresent, req.SchemaDataImportsName)
 
-	var changes []string
-	if req.Enabled != nil {
-		changes = append(changes, fmt.Sprintf("enabled=%v", *req.Enabled))
+	prev, team, err := h.store.UpdateOrgTeam(orgID, teamID, upd)
+	if err != nil {
+		switch {
+		case errors.Is(err, configstore.ErrOrgTeamNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "org team not found"})
+		case errors.Is(err, configstore.ErrOrgTeamSchemaConflict):
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
 	}
-	if backfillSet {
-		if req.BackfillEnabled == nil {
-			changes = append(changes, "backfill_enabled=(unset)")
-		} else {
-			changes = append(changes, fmt.Sprintf("backfill_enabled=%v", *req.BackfillEnabled))
+
+	// Audit detail: which fields actually changed and their old → new values
+	// (same idiom as the org update). Computed AFTER the store call so the
+	// "old" side is the row the update really replaced; AuditMiddleware reads
+	// the detail once the handler returns.
+	var changes []string
+	addChange := func(key, old, next string) {
+		if old != next {
+			changes = append(changes, fmt.Sprintf("%s %s → %s", key, old, next))
 		}
 	}
-	if upd.MakeBilling {
-		changes = append(changes, "billing team")
-	}
+	addChange("schema_name", prev.SchemaName, team.SchemaName)
+	addChange("enabled", fmt.Sprintf("%v", prev.Enabled), fmt.Sprintf("%v", team.Enabled))
+	addChange("backfill_enabled", orgBoolPtr(prev.BackfillEnabled), orgBoolPtr(team.BackfillEnabled))
+	addChange("is_billing_team", orgBoolPtr(prev.IsBillingTeam), orgBoolPtr(team.IsBillingTeam))
+	addChange("events_table_name", orgStrPtr(prev.EventsTableName), orgStrPtr(team.EventsTableName))
+	addChange("persons_table_name", orgStrPtr(prev.PersonsTableName), orgStrPtr(team.PersonsTableName))
+	addChange("schema_data_imports_name", orgStrPtr(prev.SchemaDataImportsName), orgStrPtr(team.SchemaDataImportsName))
 	if len(changes) > 0 {
 		setAuditDetail(c, fmt.Sprintf("team %d: %s", teamID, strings.Join(changes, ", ")))
 	}
 
-	team, err := h.store.UpdateOrgTeam(orgID, teamID, upd)
-	if err != nil {
-		if errors.Is(err, configstore.ErrOrgTeamNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "org team not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
 	c.JSON(http.StatusOK, team)
 }
 
@@ -1073,6 +1178,15 @@ func orgStrPtr(s *string) string {
 		return "(unset)"
 	}
 	return orgStr(*s)
+}
+
+// orgBoolPtr renders an optional tri-state boolean (nil == unset) for audit
+// detail.
+func orgBoolPtr(b *bool) string {
+	if b == nil {
+		return "(unset)"
+	}
+	return fmt.Sprintf("%v", *b)
 }
 
 // orgInt64Ptr renders an optional org config integer (nil or 0 == unset) for

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -391,9 +391,12 @@ func TestAdminOrgTeamStorePostgres(t *testing.T) {
 	}
 
 	// Repoint billing to team 2: the buffered bucket must follow atomically.
-	updated, err := apiStore.UpdateOrgTeam("teamsorg", 2, orgTeamUpdate{MakeBilling: true})
+	prev, updated, err := apiStore.UpdateOrgTeam("teamsorg", 2, orgTeamUpdate{MakeBilling: true})
 	if err != nil {
 		t.Fatalf("repoint billing: %v", err)
+	}
+	if prev.IsBillingTeam != nil {
+		t.Fatalf("prev must be the pre-update row (not billing), got %+v", prev)
 	}
 	if updated.IsBillingTeam == nil || !*updated.IsBillingTeam {
 		t.Fatalf("team 2 must be billing, got %+v", updated)
@@ -432,5 +435,81 @@ func TestAdminOrgTeamStorePostgres(t *testing.T) {
 	}
 	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
 		t.Fatalf("teamsorg teams = %v, want [1 2 3]", got)
+	}
+}
+
+// TestAdminUpdateOrgTeamBreakGlassPostgres exercises the operator break-glass
+// fields of gormAPIStore.UpdateOrgTeam against real Postgres: schema_name
+// change (happy path, per-org 409, cross-org reuse) and the tri-state legacy
+// table-name set / clear / preserve-on-omit semantics, including that the
+// pre-update row comes back for audit.
+func TestAdminUpdateOrgTeamBreakGlassPostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+
+	for _, org := range []string{"repairorg", "otherorg"} {
+		if err := store.DB().Create(&configstore.Org{Name: org, DatabaseName: org + "db"}).Error; err != nil {
+			t.Fatalf("create org %s: %v", org, err)
+		}
+	}
+	if err := store.DB().Exec(`
+		INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, is_billing_team, created_at, updated_at)
+		VALUES ('repairorg', 1, 'team_1', TRUE, TRUE, now(), now()),
+		       ('repairorg', 2, 'team_2', TRUE, NULL, now(), now()),
+		       ('otherorg', 9, 'shared', TRUE, TRUE, now(), now())`).Error; err != nil {
+		t.Fatalf("seed teams: %v", err)
+	}
+
+	str := func(s string) *string { return &s }
+
+	// Schema change happy path; prev carries the replaced value.
+	prev, updated, err := apiStore.UpdateOrgTeam("repairorg", 1, orgTeamUpdate{SchemaName: str("repaired_wh")})
+	if err != nil {
+		t.Fatalf("schema change: %v", err)
+	}
+	if prev.SchemaName != "team_1" || updated.SchemaName != "repaired_wh" {
+		t.Fatalf("schema change prev/updated = %q/%q, want team_1/repaired_wh", prev.SchemaName, updated.SchemaName)
+	}
+
+	// Conflict with another team in the same org.
+	if _, _, err := apiStore.UpdateOrgTeam("repairorg", 1, orgTeamUpdate{SchemaName: str("team_2")}); !errors.Is(err, configstore.ErrOrgTeamSchemaConflict) {
+		t.Fatalf("same-org conflict err = %v, want ErrOrgTeamSchemaConflict", err)
+	}
+
+	// The same schema in a different org is allowed (uniqueness is per org).
+	if _, updated, err = apiStore.UpdateOrgTeam("repairorg", 1, orgTeamUpdate{SchemaName: str("shared")}); err != nil || updated.SchemaName != "shared" {
+		t.Fatalf("cross-org schema reuse: updated = %+v, err = %v", updated, err)
+	}
+
+	// Legacy names: set all three...
+	_, updated, err = apiStore.UpdateOrgTeam("repairorg", 1, orgTeamUpdate{
+		EventsTableNameSet: true, EventsTableName: str("legacy_events"),
+		PersonsTableNameSet: true, PersonsTableName: str("legacy_persons"),
+		SchemaDataImportsNameSet: true, SchemaDataImportsName: str("legacy_imports"),
+	})
+	if err != nil {
+		t.Fatalf("set legacy names: %v", err)
+	}
+	if updated.EventsTableName == nil || *updated.EventsTableName != "legacy_events" ||
+		updated.PersonsTableName == nil || *updated.PersonsTableName != "legacy_persons" ||
+		updated.SchemaDataImportsName == nil || *updated.SchemaDataImportsName != "legacy_imports" {
+		t.Fatalf("legacy names not stored: %+v", updated)
+	}
+
+	// ...then clear one; the omitted others must be preserved.
+	_, updated, err = apiStore.UpdateOrgTeam("repairorg", 1, orgTeamUpdate{EventsTableNameSet: true})
+	if err != nil {
+		t.Fatalf("clear events_table_name: %v", err)
+	}
+	if updated.EventsTableName != nil {
+		t.Fatalf("events_table_name = %v, want NULL after clear", *updated.EventsTableName)
+	}
+	if updated.PersonsTableName == nil || *updated.PersonsTableName != "legacy_persons" ||
+		updated.SchemaDataImportsName == nil || *updated.SchemaDataImportsName != "legacy_imports" {
+		t.Fatalf("omitted legacy names must be preserved, got %+v", updated)
+	}
+	// The schema change earlier must have survived unrelated updates.
+	if updated.SchemaName != "shared" {
+		t.Fatalf("schema_name = %q, want shared preserved on omit", updated.SchemaName)
 	}
 }

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -161,16 +161,34 @@ func (s *fakeAPIStore) CreateOrgTeam(orgID string, team *configstore.OrgTeam) er
 	return nil
 }
 
-func (s *fakeAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (*configstore.OrgTeam, error) {
+func (s *fakeAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpdate) (*configstore.OrgTeam, *configstore.OrgTeam, error) {
 	team, ok := s.teams[orgID][teamID]
 	if !ok {
-		return nil, configstore.ErrOrgTeamNotFound
+		return nil, nil, configstore.ErrOrgTeamNotFound
+	}
+	prev := *team
+	if upd.SchemaName != nil && *upd.SchemaName != team.SchemaName {
+		for _, t := range s.teams[orgID] {
+			if t.TeamID != teamID && t.SchemaName == *upd.SchemaName {
+				return nil, nil, configstore.ErrOrgTeamSchemaConflict
+			}
+		}
+		team.SchemaName = *upd.SchemaName
 	}
 	if upd.Enabled != nil {
 		team.Enabled = *upd.Enabled
 	}
 	if upd.BackfillSet {
 		team.BackfillEnabled = upd.Backfill
+	}
+	if upd.EventsTableNameSet {
+		team.EventsTableName = upd.EventsTableName
+	}
+	if upd.PersonsTableNameSet {
+		team.PersonsTableName = upd.PersonsTableName
+	}
+	if upd.SchemaDataImportsNameSet {
+		team.SchemaDataImportsName = upd.SchemaDataImportsName
 	}
 	if upd.MakeBilling && (team.IsBillingTeam == nil || !*team.IsBillingTeam) {
 		for _, t := range s.teams[orgID] {
@@ -181,7 +199,7 @@ func (s *fakeAPIStore) UpdateOrgTeam(orgID string, teamID int64, upd orgTeamUpda
 		s.teamBillingRepoints = append(s.teamBillingRepoints, fakeReattributeCall{org: orgID, teamID: teamID})
 	}
 	clone := *team
-	return &clone, nil
+	return &prev, &clone, nil
 }
 
 func (s *fakeAPIStore) ListUsers() ([]configstore.OrgUser, error) {
@@ -2305,22 +2323,143 @@ func TestAdminCreateOrgTeamConflicts(t *testing.T) {
 	}
 }
 
-func TestAdminUpdateOrgTeamRejectsSchemaChange(t *testing.T) {
+// TestAdminUpdateOrgTeamSchemaChange pins the operator break-glass: the admin
+// PUT may change schema_name (unlike user-facing flows), but only to a valid
+// identifier that no other team in the org holds.
+func TestAdminUpdateOrgTeamSchemaChange(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.orgs["other"] = &configstore.Org{Name: "other"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 1, SchemaName: "team_1", Enabled: true})
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 2, SchemaName: "team_2", Enabled: true})
+	store.seedTeam(configstore.OrgTeam{OrgID: "other", TeamID: 9, SchemaName: "shared", Enabled: true})
+	router := newTestAPIRouter(store)
+
+	// Happy path: the operator override renames the config row.
+	rec := adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"schema_name":"repaired_wh"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("schema change: status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if store.teams["acme"][1].SchemaName != "repaired_wh" {
+		t.Fatalf("schema_name = %q, want repaired_wh", store.teams["acme"][1].SchemaName)
+	}
+
+	// Conflict with another team in the SAME org is a 409.
+	rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"schema_name":"team_2"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("schema conflict: status = %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+	if store.teams["acme"][1].SchemaName != "repaired_wh" {
+		t.Fatal("schema_name must not change on a refused conflict")
+	}
+
+	// The same schema in a DIFFERENT org is fine (uniqueness is per org).
+	rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"schema_name":"shared"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cross-org schema reuse: status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	// Clearing (explicit null) and invalid identifiers stay 400s.
+	for _, body := range []string{`{"schema_name":null}`, `{"schema_name":"Bad-Name"}`, `{"schema_name":""}`} {
+		rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want 400: %s", body, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestAdminUpdateOrgTeamLegacyNames pins the tri-state legacy table-name
+// semantics on the PUT: omitted = preserve, explicit null or "" = clear back
+// to NULL, a value sets.
+func TestAdminUpdateOrgTeamLegacyNames(t *testing.T) {
 	store := newFakeAPIStore()
 	store.orgs["acme"] = &configstore.Org{Name: "acme"}
 	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 1, SchemaName: "team_1", Enabled: true})
 	router := newTestAPIRouter(store)
 
+	// Set all three.
 	rec := adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
-		`{"schema_name":"renamed"}`)
+		`{"events_table_name":"legacy_events","persons_table_name":"legacy_persons","schema_data_imports_name":"legacy_imports"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set legacy names: status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	stored := store.teams["acme"][1]
+	if stored.EventsTableName == nil || *stored.EventsTableName != "legacy_events" ||
+		stored.PersonsTableName == nil || *stored.PersonsTableName != "legacy_persons" ||
+		stored.SchemaDataImportsName == nil || *stored.SchemaDataImportsName != "legacy_imports" {
+		t.Fatalf("legacy names not stored: %+v", stored)
+	}
+
+	// Omitted fields preserve; explicit null and "" both clear to NULL.
+	rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"events_table_name":null,"persons_table_name":""}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear legacy names: status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	stored = store.teams["acme"][1]
+	if stored.EventsTableName != nil {
+		t.Fatalf("events_table_name = %v, want NULL after explicit null", *stored.EventsTableName)
+	}
+	if stored.PersonsTableName != nil {
+		t.Fatalf("persons_table_name = %v, want NULL after explicit empty", *stored.PersonsTableName)
+	}
+	if stored.SchemaDataImportsName == nil || *stored.SchemaDataImportsName != "legacy_imports" {
+		t.Fatalf("omitted schema_data_imports_name must be preserved, got %+v", stored)
+	}
+
+	// Oversized value is a 400, not a DB error.
+	rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		fmt.Sprintf(`{"events_table_name":%q}`, strings.Repeat("x", 256)))
 	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+		t.Fatalf("oversized legacy name: status = %d, want 400: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "immutable") {
-		t.Fatalf("error should say schema_name is immutable: %s", rec.Body.String())
+}
+
+// TestAdminUpdateOrgTeamAuditDetail asserts the team.update audit detail
+// captures which fields changed with their old → new values (the org-update
+// idiom), including the break-glass schema change.
+func TestAdminUpdateOrgTeamAuditDetail(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 1, SchemaName: "team_1", Enabled: true})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	var detail string
+	// Capture what AuditMiddleware would read after the handler returns.
+	router.Use(func(c *gin.Context) {
+		c.Next()
+		detail = c.GetString(ctxAuditDetailKey)
+	})
+	registerAPIWithStore(router.Group("/api/v1"), store, nil, nil)
+
+	rec := adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"schema_name":"repaired_wh","enabled":false,"events_table_name":"legacy_events"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
-	if store.teams["acme"][1].SchemaName != "team_1" {
-		t.Fatal("schema_name must not change through the admin update")
+	for _, want := range []string{
+		"team 1:",
+		"schema_name team_1 → repaired_wh",
+		"enabled true → false",
+		"events_table_name (unset) → legacy_events",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("audit detail %q missing %q", detail, want)
+		}
+	}
+	// A no-op PUT records no detail.
+	detail = ""
+	rec = adminJSON(t, router, http.MethodPut, "/api/v1/orgs/acme/teams/1",
+		`{"enabled":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-op status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if detail != "" {
+		t.Fatalf("no-op update must not record changes, got %q", detail)
 	}
 }
 

--- a/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
+++ b/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
@@ -1,8 +1,11 @@
 // Create / edit / delete dialogs for org teams (duckgres_org_teams rows),
 // shared by the Org teams page and the org detail page. The dialogs encode the
-// surface rules: schema_name is set once at create time and immutable
-// afterwards; billing is repointed (never cleared) and carries the org's
-// buffered usage with it; the org's last team cannot be deleted.
+// surface rules: billing is repointed (never cleared) and carries the org's
+// buffered usage with it; the org's last team cannot be deleted. The edit
+// dialog is the operator break-glass — it can change EVERY setting, including
+// the schema name (a config-only rename that moves no warehouse data) and the
+// legacy table-name overrides; schema immutability remains a user-facing-flow
+// rule, not an admin one.
 import { useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -39,6 +42,23 @@ function backfillChoice(v: boolean | null | undefined): BackfillChoice {
 export function BackfillBadge({ value }: { value: boolean | null | undefined }) {
   if (value == null) return <span className="text-muted-foreground">—</span>;
   return value ? <Badge variant="success">on</Badge> : <Badge variant="muted">off</Badge>;
+}
+
+// LegacyNamesBadge: compact indicator that a row carries explicit legacy
+// table-name overrides (grandfathered pre-existing teams). The actual names
+// live in the hover tooltip so the tables stay narrow.
+export function LegacyNamesBadge({ team }: { team: OrgTeam }) {
+  const parts = [
+    team.events_table_name && `events: ${team.events_table_name}`,
+    team.persons_table_name && `persons: ${team.persons_table_name}`,
+    team.schema_data_imports_name && `data imports: ${team.schema_data_imports_name}`,
+  ].filter((p): p is string => Boolean(p));
+  if (parts.length === 0) return null;
+  return (
+    <Badge variant="outline" className="whitespace-nowrap" title={parts.join("\n")}>
+      legacy names
+    </Badge>
+  );
 }
 
 function errMsg(e: unknown): string {
@@ -189,24 +209,47 @@ export function CreateTeamDialog({
   );
 }
 
-// EditTeamDialog: enabled / backfill / billing repoint. The schema name is
-// shown read-only; billing can only be pointed at this team, never cleared.
+// legacyNameBody maps an edited legacy table-name input to its wire value:
+// unchanged = undefined (omit, preserve), empty = null (clear back to
+// "derive from schema name"), otherwise the trimmed value.
+function legacyNameBody(edited: string, current: string | null | undefined): string | null | undefined {
+  const trimmed = edited.trim();
+  if (trimmed === (current ?? "")) return undefined;
+  return trimmed === "" ? null : trimmed;
+}
+
+// EditTeamDialog: the operator break-glass — every setting is editable,
+// including the schema name and the legacy table-name overrides. Billing can
+// only be pointed at this team, never cleared.
 export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () => void }) {
   const update = useUpdateOrgTeam();
   const isBilling = Boolean(team.is_billing_team);
+  const [schemaName, setSchemaName] = useState(team.schema_name);
   const [enabled, setEnabled] = useState(team.enabled);
   const [backfill, setBackfill] = useState<BackfillChoice>(backfillChoice(team.backfill_enabled));
   const [makeBilling, setMakeBilling] = useState(false);
+  const [eventsName, setEventsName] = useState(team.events_table_name ?? "");
+  const [personsName, setPersonsName] = useState(team.persons_table_name ?? "");
+  const [importsName, setImportsName] = useState(team.schema_data_imports_name ?? "");
   const [error, setError] = useState<string | null>(null);
+
+  const schemaChanged = schemaName.trim() !== team.schema_name;
 
   const submit = async () => {
     setError(null);
     const body: OrgTeamUpdateBody = {};
+    if (schemaChanged) body.schema_name = schemaName.trim();
     if (enabled !== team.enabled) body.enabled = enabled;
     if (backfill !== backfillChoice(team.backfill_enabled)) {
       body.backfill_enabled = backfill === "unset" ? null : backfill === "on";
     }
     if (makeBilling && !isBilling) body.is_billing_team = true;
+    const events = legacyNameBody(eventsName, team.events_table_name);
+    if (events !== undefined) body.events_table_name = events;
+    const persons = legacyNameBody(personsName, team.persons_table_name);
+    if (persons !== undefined) body.persons_table_name = persons;
+    const imports = legacyNameBody(importsName, team.schema_data_imports_name);
+    if (imports !== undefined) body.schema_data_imports_name = imports;
     if (Object.keys(body).length === 0) {
       onClose();
       return;
@@ -227,10 +270,27 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
             Edit team {team.team_id} in "{team.org_id}"
           </DialogTitle>
           <DialogDescription>
-            Schema <span className="font-mono">{team.schema_name}</span> (immutable).
+            Operator repair tool: every setting is editable here, including the schema name.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
+          <FieldRow label="Schema name">
+            <Input
+              value={schemaName}
+              onChange={(e) => setSchemaName(e.target.value)}
+              className="font-mono text-xs"
+            />
+          </FieldRow>
+          {schemaChanged && (
+            <p className="flex items-start gap-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Changing the schema name does not move any data. Tables under the old schema are
+                not renamed — this only repoints where duckgres looks for the team's data. Use it
+                to repair a broken row, not to relocate a team.
+              </span>
+            </p>
+          )}
           <div className="flex items-center justify-between">
             <Label>Enabled</Label>
             <Switch checked={enabled} onCheckedChange={setEnabled} />
@@ -247,6 +307,34 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
               </SelectContent>
             </Select>
           </FieldRow>
+          <FieldRow label="Legacy events table">
+            <Input
+              value={eventsName}
+              onChange={(e) => setEventsName(e.target.value)}
+              placeholder={`${team.schema_name}.events (derived)`}
+              className="font-mono text-xs"
+            />
+          </FieldRow>
+          <FieldRow label="Legacy persons table">
+            <Input
+              value={personsName}
+              onChange={(e) => setPersonsName(e.target.value)}
+              placeholder={`${team.schema_name}.persons (derived)`}
+              className="font-mono text-xs"
+            />
+          </FieldRow>
+          <FieldRow label="Legacy data-imports schema">
+            <Input
+              value={importsName}
+              onChange={(e) => setImportsName(e.target.value)}
+              placeholder={`${team.schema_name}_data_imports (derived)`}
+              className="font-mono text-xs"
+            />
+          </FieldRow>
+          <p className="text-xs text-muted-foreground">
+            Legacy overrides for grandfathered teams. Leave a field empty to derive the name from
+            the schema name.
+          </p>
           {isBilling ? (
             <p className="text-xs text-muted-foreground">
               This is the org's billing team. To change it, mark another team as billing.
@@ -274,7 +362,7 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
           <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button size="sm" onClick={submit} disabled={update.isPending}>
+          <Button size="sm" onClick={submit} disabled={update.isPending || schemaName.trim() === ""}>
             {update.isPending ? "Saving…" : "Save"}
           </Button>
         </DialogFooter>

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -39,6 +39,7 @@ import {
   CreateTeamDialog,
   DeleteTeamDialog,
   EditTeamDialog,
+  LegacyNamesBadge,
 } from "@/components/OrgTeamDialogs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { ManagedWarehouse, OrgTeam, OrgUpdate } from "@/types/api";
@@ -724,7 +725,12 @@ function OrgTeamsCard({ orgId }: { orgId: string }) {
               {rows.map((t) => (
                 <TableRow key={t.team_id} className="[&>td]:py-1.5">
                   <TableCell className="font-mono text-xs font-medium tabular-nums">{t.team_id}</TableCell>
-                  <TableCell className="font-mono text-xs">{t.schema_name}</TableCell>
+                  <TableCell>
+                    <span className="flex items-center gap-1.5">
+                      <span className="font-mono text-xs">{t.schema_name}</span>
+                      <LegacyNamesBadge team={t} />
+                    </span>
+                  </TableCell>
                   <TableCell>
                     {t.enabled ? (
                       <Badge variant="secondary">enabled</Badge>

--- a/controlplane/admin/ui/src/pages/OrgTeams.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTeams.test.tsx
@@ -41,6 +41,8 @@ const TEAMS: OrgTeam[] = [
     enabled: false,
     is_billing_team: null,
     backfill_enabled: true,
+    events_table_name: "legacy_events",
+    persons_table_name: "legacy_persons",
     created_at: "2026-07-02T00:00:00Z",
     updated_at: "2026-07-02T00:00:00Z",
   },
@@ -99,6 +101,29 @@ describe("Org teams page", () => {
 
     expect(screen.getByText(/last team and cannot be deleted/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /delete team/i })).toBeDisabled();
+  });
+
+  it("flags rows carrying explicit legacy table names with a compact badge", () => {
+    renderPage();
+
+    // Only acme team 2 has legacy overrides; the names live in the tooltip.
+    const badges = screen.getAllByText("legacy names");
+    expect(badges).toHaveLength(1);
+    expect(badges[0].getAttribute("title")).toContain("legacy_events");
+  });
+
+  it("edit dialog lets an operator change the schema, warning that no data moves", async () => {
+    renderPage();
+
+    await userEvent.click(screen.getAllByTitle("Edit")[0]);
+    const schemaInput = screen.getByDisplayValue("team_1");
+    // The destructive warning only appears once the schema actually differs.
+    expect(screen.queryByText(/does not move any data/i)).not.toBeInTheDocument();
+    await userEvent.clear(schemaInput);
+    await userEvent.type(schemaInput, "repaired_wh");
+    expect(screen.getByText(/does not move any data/i)).toBeInTheDocument();
+    // Legacy table-name fields render with the derived-name hint.
+    expect(screen.getByText(/leave a field empty to derive/i)).toBeInTheDocument();
   });
 
   it("warns that deleting a billing team hands billing to the oldest remaining team", async () => {

--- a/controlplane/admin/ui/src/pages/OrgTeams.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTeams.tsx
@@ -14,6 +14,7 @@ import {
   CreateTeamDialog,
   DeleteTeamDialog,
   EditTeamDialog,
+  LegacyNamesBadge,
 } from "@/components/OrgTeamDialogs";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
 import { useAllOrgTeams, useOrgs } from "@/hooks/useApi";
@@ -63,7 +64,12 @@ export function OrgTeams() {
       {
         accessorKey: "schema_name",
         header: "Schema",
-        cell: ({ getValue }) => <span className="font-mono text-xs">{String(getValue())}</span>,
+        cell: ({ row, getValue }) => (
+          <span className="flex items-center gap-1.5">
+            <span className="font-mono text-xs">{String(getValue())}</span>
+            <LegacyNamesBadge team={row.original} />
+          </span>
+        ),
       },
       {
         accessorKey: "enabled",

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -107,14 +107,22 @@ export interface OrgTeamCreateBody {
   backfill_enabled?: boolean;
 }
 
-// PUT /api/v1/orgs/:id/teams/:team_id — enabled / backfill / billing repoint
-// only (never schema_name). is_billing_team may only be true: billing is
-// repointed by marking another team, never cleared. An explicit
-// `backfill_enabled: null` clears the tri-state back to unset.
+// PUT /api/v1/orgs/:id/teams/:team_id — the operator break-glass: every team
+// setting is editable. All fields are presence-aware (omit = preserve).
+// schema_name may be changed (409 when another team in the org holds it) but
+// never cleared; changing it does NOT move any warehouse data. An explicit
+// `backfill_enabled: null` clears the tri-state back to unset; an explicit
+// null (or "") on a legacy table-name field clears it back to NULL ("derive
+// from schema_name"). is_billing_team may only be true: billing is repointed
+// by marking another team, never cleared.
 export interface OrgTeamUpdateBody {
+  schema_name?: string;
   enabled?: boolean;
   backfill_enabled?: boolean | null;
   is_billing_team?: true;
+  events_table_name?: string | null;
+  persons_table_name?: string | null;
+  schema_data_imports_name?: string | null;
 }
 
 // DELETE /api/v1/orgs/:id/teams/:team_id response. new_billing_team_id is set


### PR DESCRIPTION
## Why

Operators need a way to repair `duckgres_org_teams` rows by hand (wrong schema mapping, missing or stale grandfathered table names) without touching the config-store DB directly. Until now the admin PUT deliberately rejected `schema_name` changes and could not edit the legacy table-name columns — schema immutability was enforced on the admin surface too.

This makes the admin API + console the operator break-glass: **every** team setting is editable there. Schema immutability remains a rule for user-facing product flows only.

## What changes

### API — `PUT /api/v1/orgs/:id/teams/:team_id`

All fields presence-aware (omitted = preserve):

- `schema_name` (string): now changeable. Validated as a safe lowercase identifier; **409** when another team in the same org already uses it (per-org uniqueness, backed by the unique `(org_id, schema_name)` index; the same schema in a different org stays allowed). Explicit `null` or an invalid identifier is a 400 — the column stays NOT NULL. **Changing it moves no data**: tables under the old schema are not renamed; it only repoints where duckgres looks for the team's data.
- `events_table_name`, `persons_table_name`, `schema_data_imports_name` (tri-state): omitted = preserve; explicit `null` **or** `""` = clear back to NULL ("derive from schema_name") — the same clear sentinels the provisioning grandfather upsert accepts; a value sets it (≤255 chars, 400 otherwise).
- `enabled` / `backfill_enabled` / `is_billing_team` semantics unchanged: backfill keeps its explicit-null tri-state, billing can only be pointed AT a team (repoint with atomic usage re-attribution), never cleared.

### Audit

`team.update` detail now records which fields changed with their old → new values (the org-update idiom), e.g. `team 1: schema_name team_1 → repaired_wh, events_table_name (unset) → legacy_events`. The store returns the pre-update row alongside the result so the handler audits what the update really replaced; no-op PUTs record no detail.

### Admin UI

- Edit dialog: schema-name input (pre-filled) with a destructive-style warning **once the value differs** — changing the schema does not move any data; plus the three legacy table-name inputs (pre-filled, clearable, placeholder shows the derived name, hint that empty = derived from schema name).
- Org teams page + org detail Teams card: a compact `legacy names` badge next to the schema when a row carries explicit overrides, with the actual names in the hover tooltip — no extra wide columns.

## Tests

- Handler (fake store): schema change happy path, same-org conflict 409, cross-org reuse allowed, null/invalid schema 400s, legacy set + clear (null and "") + preserve-on-omit + oversized 400, audit detail old → new including the no-op case.
- Postgres (`-tags kubernetes`, store level): schema change with pre-update row returned, per-org `ErrOrgTeamSchemaConflict`, cross-org reuse, legacy set/clear round-trip with preserve-on-omit.
- UI (vitest): legacy-names badge with tooltip; edit dialog schema field with the appears-when-dirty warning and derived-name hint.

Gates: `go build`/`go vet` (plain + `-tags kubernetes`), `go test ./controlplane/...` (both tag sets), `tests/configstore`, admin UI `tsc` + vitest + `vite build`, gofmt clean.