### PR TITLE
fix(auth): grant default-named legacy tables to project readers

### DIFF
--- a/controlplane/configstore/query_access_test.go
+++ b/controlplane/configstore/query_access_test.go
@@ -46,6 +46,72 @@ func TestOrgUserQueryAccessDerivesProjectNamespaces(t *testing.T) {
 	}
 }
 
+// A backfilled legacy team can carry overrides that EQUAL the derived default
+// names (posthog org team 2: events_table_name="events" → posthog.events). A
+// non-NULL override always means "this team's table lives in the shared
+// legacy posthog schema", so the grant must not depend on the override's
+// spelling.
+func TestOrgUserQueryAccessGrantsDefaultNamedLegacyTables(t *testing.T) {
+	events := "events"
+	persons := "persons"
+	teamID := int64(2)
+	key := OrgUserKey{OrgID: "acme", Username: "posthog_team_2"}
+	cs := &ConfigStore{snapshot: &Snapshot{
+		Orgs: map[string]*OrgConfig{
+			"acme": {
+				Teams: []OrgTeamConfig{{
+					TeamID:           teamID,
+					SchemaName:       "team_2",
+					Enabled:          true,
+					EventsTableName:  &events,
+					PersonsTableName: &persons,
+				}},
+			},
+		},
+		OrgUserAccess: map[OrgUserKey]OrgUserAccessConfig{
+			key: {Mode: OrgUserAccessModeProjectReader, TeamID: &teamID},
+		},
+	}}
+
+	got, ok := cs.OrgUserQueryAccess("acme", "posthog_team_2")
+	if !ok {
+		t.Fatal("expected a project reader policy")
+	}
+	wantRelations := []string{"posthog.events", "posthog.persons"}
+	if !reflect.DeepEqual(got.AllowedRelations, wantRelations) {
+		t.Fatalf("AllowedRelations = %v, want %v", got.AllowedRelations, wantRelations)
+	}
+}
+
+// NULL overrides mean "derive from schema_name" — the team is on the
+// per-team-schema model and gets no legacy posthog-schema relations.
+func TestOrgUserQueryAccessGrantsNoLegacyTablesWithoutOverrides(t *testing.T) {
+	teamID := int64(7)
+	key := OrgUserKey{OrgID: "acme", Username: "posthog_team_7"}
+	cs := &ConfigStore{snapshot: &Snapshot{
+		Orgs: map[string]*OrgConfig{
+			"acme": {
+				Teams: []OrgTeamConfig{{
+					TeamID:     teamID,
+					SchemaName: "team_7",
+					Enabled:    true,
+				}},
+			},
+		},
+		OrgUserAccess: map[OrgUserKey]OrgUserAccessConfig{
+			key: {Mode: OrgUserAccessModeProjectReader, TeamID: &teamID},
+		},
+	}}
+
+	got, ok := cs.OrgUserQueryAccess("acme", "posthog_team_7")
+	if !ok {
+		t.Fatal("expected a project reader policy")
+	}
+	if len(got.AllowedRelations) != 0 {
+		t.Fatalf("AllowedRelations = %v, want none", got.AllowedRelations)
+	}
+}
+
 func TestOrgUserQueryAccessFailsClosedForMissingOrDisabledTeam(t *testing.T) {
 	teamID := int64(42)
 	key := OrgUserKey{OrgID: "acme", Username: "posthog_team_42"}

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -367,10 +367,15 @@ func orgUserQueryAccessFromSnapshot(snapshot *Snapshot, orgID, username string) 
 			fmt.Sprintf("shadow_%d_models", team.TeamID),
 			team.SchemaName,
 		}
-		if team.EventsTableName != nil && *team.EventsTableName != "" && *team.EventsTableName != "events" {
+		// A non-NULL override means the team's table lives in the shared
+		// legacy posthog schema — even when the override spells the derived
+		// default name (posthog org team 2 is events_table_name="events" →
+		// posthog.events). NULL means derive from schema_name, which the
+		// AllowedSchemas grant above already covers.
+		if team.EventsTableName != nil && *team.EventsTableName != "" {
 			policy.AllowedRelations = append(policy.AllowedRelations, "posthog."+*team.EventsTableName)
 		}
-		if team.PersonsTableName != nil && *team.PersonsTableName != "" && *team.PersonsTableName != "persons" {
+		if team.PersonsTableName != nil && *team.PersonsTableName != "" {
 			policy.AllowedRelations = append(policy.AllowedRelations, "posthog."+*team.PersonsTableName)
 		}
 		sort.Strings(policy.AllowedSchemas)

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -56,6 +56,9 @@
 #   isolation    : two tenants see distinct catalogs (cross-tenant read denied).
 #                  A generated project reader can read every table in its team
 #                  schema, cannot read another team schema, and cannot write.
+#                  A legacy events override grants posthog.<name> even when the
+#                  override equals the derived default name; sibling legacy
+#                  relations stay denied.
 #   admin auth   : the dashboard rejects ?token= query-param auth (#721); only
 #                  the internal-secret header / POST login form authenticate.
 #   models api   : the dashboard models explorer lists every config-store model
@@ -1568,7 +1571,43 @@ project_reader_isolation() { # org root_password team_id
   echo "$out" | grep -qi "read-only\|permission denied" \
     || fail "project reader: write failed without read-only permission error: $out"
 
-  log "project reader OK: whole-schema read, cross-project denial, read-only enforcement"
+  # ---- legacy posthog-schema tables ----------------------------------------
+  # A non-NULL events/persons override grants posthog.<name> even when the
+  # override EQUALS the derived default name (posthog org team 2 regression:
+  # events_table_name="events" must grant posthog.events). The grant is
+  # per-relation: a sibling legacy table no override names stays denied.
+  pg "$org" "$rootpw" ducklake "
+    CREATE SCHEMA IF NOT EXISTS posthog;
+    CREATE TABLE IF NOT EXISTS posthog.events(value INTEGER);
+    DELETE FROM posthog.events;
+    INSERT INTO posthog.events VALUES (23);
+    CREATE TABLE IF NOT EXISTS posthog.events_other_team(value INTEGER);
+  " >/dev/null
+  cur_schema="$(curl -fsS -H "$H" "$API/api/v1/orgs/$org/teams" \
+    | jq -r ".teams[] | select(.team_id == $team) | .schema_name")"
+  curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' \
+    -d "{\"team_id\":$team,\"schema_name\":\"$cur_schema\",\"events_table_name\":\"events\"}" \
+    "$API/api/v1/orgs/$org/teams" >/dev/null \
+    || fail "project reader: legacy override upsert failed"
+  # Re-PUT the reader: rotates the credential AND forces the cluster-wide
+  # snapshot reload, so the new grant is live before the next connect.
+  creds="$(curl -fsS -X PUT -H "$H" "$API/api/v1/orgs/$org/teams/$team/project-reader")"
+  readerpw="$(echo "$creds" | jq -r .password)"
+  got="$(pg_try "$org" "$readerpw" ducklake "SELECT value FROM posthog.events" "$reader")" \
+    || fail "project reader: default-named legacy override read failed: $got"
+  [ "$got" = "23" ] || fail "project reader: posthog.events returned '$got', want 23"
+  if out="$(pg_try "$org" "$readerpw" ducklake "SELECT value FROM posthog.events_other_team" "$reader")"; then
+    fail "project reader: unrelated legacy relation unexpectedly readable: $out"
+  fi
+  echo "$out" | grep -qi "permission denied" \
+    || fail "project reader: unrelated legacy relation failed without permission error: $out"
+  # Clear the override so later assertions see the provisioned row shape.
+  curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' \
+    -d "{\"team_id\":$team,\"schema_name\":\"$cur_schema\",\"events_table_name\":\"\"}" \
+    "$API/api/v1/orgs/$org/teams" >/dev/null \
+    || fail "project reader: legacy override cleanup failed"
+
+  log "project reader OK: whole-schema read, cross-project denial, read-only enforcement, legacy default-named override grant"
 }
 
 # ---- user persistent secrets ------------------------------------------------
@@ -3549,7 +3588,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + project-reader(team-wide-read/cross-project-deny/read-only) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + duckling-shard-backfill(cnpg) + isolation + reshard(targets-discovery + validation + cancel-during-drain + bogus-shard-rollback + ext-to-cnpg positive path) + lifecycle-teardown(+org-delete/name-release) + per-run-ext-metadata-db(create/stale-GC/drop), on cnpg & ext (4 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + project-reader(team-wide-read/cross-project-deny/read-only/legacy-override-grant) + wire + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(ext) + persistent-user-secrets(cnpg+ext, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg+ext) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + duckling-shard-backfill(cnpg) + isolation + reshard(targets-discovery + validation + cancel-during-drain + bogus-shard-rollback + ext-to-cnpg positive path) + lifecycle-teardown(+org-delete/name-release) + per-run-ext-metadata-db(create/stale-GC/drop), on cnpg & ext (4 parallel lanes)"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

Found during mw-prod-us QA of #971: the posthog org's team 2 project reader could not read its own events. Its team row carries `events_table_name="events"` — an explicit override pointing at the legacy `posthog.events` table — but the policy derivation only granted `posthog.<override>` when the override differed from the derived default name:

```go
if team.EventsTableName != nil && *team.EventsTableName != "" && *team.EventsTableName != "events" {
```

That conflates "override spelled `events`" with "no legacy table". The devex team (`events_devex`) worked; team 2 was denied `posthog.events` while its `AllowedSchemas` grant pointed at a `team_2` schema that doesn't exist yet.

## Fix

A non-NULL, non-empty override always grants `posthog.<name>`. Only NULL/empty means "derive from schema_name", which the `AllowedSchemas` grant already covers — matching how the PostHog backfill actually writes rows (teams without legacy tables have NULL overrides). Single derivation point, so the PG wire gateway, Flight ingress, and filtered catalog metadata views all inherit the change.

The grant stays per-relation: sibling legacy tables no override names (e.g. `posthog.events_devex` for a team-2 reader) remain denied.

## Tests

- `TestOrgUserQueryAccessGrantsDefaultNamedLegacyTables` — team 2's exact row shape; watched fail (`AllowedRelations = [], want [posthog.events posthog.persons]`) before the fix.
- `TestOrgUserQueryAccessGrantsNoLegacyTablesWithoutOverrides` — pins that NULL overrides still grant no legacy relations.
- e2e `project_reader_isolation` new leg: sets the literal-`"events"` override via the grandfather upsert, asserts the reader reads `posthog.events` and is still denied a sibling `posthog.events_other_team`, then clears the override.
- `go test ./controlplane/... ./server/...` green with and without `-tags kubernetes`.

## Notes

- Policy is bound at session create; no data change, so deploying drains nothing. No project readers exist yet in prod (QA credential was deleted).
- Separate pre-existing tension, not addressed here: discovery's `resolveTeamTables` advertises overrides as `<schema_name>.<override>` while the reader policy (and the actual dogfood data layout) treat them as `posthog.<override>` — worth reconciling with viaduck/millpond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)