### PR TITLE
fix: thread the read-only secret through the all-in-one binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -386,6 +386,8 @@ func main() {
 			ConfigPollInterval:         resolved.ConfigPollInterval,
 			InternalSecret:             resolved.InternalSecret,
 			InternalSecretFallbacks:    resolved.InternalSecretFallbacks,
+			ReadOnlySecret:             resolved.ReadOnlySecret,
+			ReadOnlySecretFallbacks:    resolved.ReadOnlySecretFallbacks,
 			UserSecretKey:              resolved.UserSecretKey,
 			SNIRoutingMode:             resolved.SNIRoutingMode,
 			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,


### PR DESCRIPTION
## Incident hotfix

Prod millpond events-nrt pods are crashlooping: their include-values polls 401 because the prod CP boots with an empty read-only TokenSet despite `DUCKGRES_READ_ONLY_SECRET` being correctly delivered (ES synced, Secret value verified 64 bytes, env in pod spec, all CP pods log "Read-only secret not set").

Root cause: the image entrypoint is the **all-in-one root `main.go`**, and #982 threaded `ReadOnlySecret`/`ReadOnlySecretFallbacks` into `ControlPlaneConfig` only in `cmd/duckgres-controlplane/main.go`. The shipped binary parses the env and drops it at config construction. Two-line fix mirroring the internal-secret threading.

## Verification

`go build -tags kubernetes ./...` + scoping/topology tests green. On deploy, CP startup logs must NOT show "Read-only secret not set"; the crashlooping millponds then self-heal on their next backoff retry (no millpond action needed).

## Follow-up (separate)

Drift tripwire for the two `ControlPlaneConfig` construction sites (shared constructor from `Resolved`, or a field-coverage test) — this slipped past two review rounds because everything downstream of the construction site is correct in both binaries.