### PR TITLE
refactor: require duckling credential secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,11 +751,9 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
   `status.metadataStore.credentialSecretRef` names one key in a Secret in the
   `ducklings` namespace; `DucklingClient.Get` resolves it before returning the
   status used by activation, probes, metering, and resharding. References to
-  any other namespace are rejected. The plaintext `status.metadataStore.password`
-  read is a temporary deploy-order fallback only: it is used when no reference
-  exists, or when a referenced Secret is temporarily unreadable while the
-  legacy password is still present. Once charts stops publishing plaintext,
-  an unreadable/missing Secret is a hard error.
+  any other namespace are rejected. The name, namespace, and key are all
+  mandatory; an incomplete reference or an unreadable/missing Secret is a hard
+  error. Duckgres never reads credential material from Duckling CR status.
 - **Rollback patches the source shard VALUE back — never removes the key**
   (precedence would fall through to the freshly-stamped bogus status pin);
   ext→cnpg rollback must null `cnpgShard` (XRD CEL forbids it on external).

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -238,7 +238,7 @@ type ManagedWarehouseMetadataStore struct {
 	// metadata DB password. Only meaningful when Kind == "external": it's
 	// passed through to the Duckling CR's spec.metadataStore.external.
 	// passwordAwsSecret, where the composition resolves it (via ESO) into the
-	// status password the worker activator reads. Empty for cnpg-shard
+	// Kubernetes Secret referenced by Duckling status. Empty for cnpg-shard
 	// (which mints its own credentials).
 	PasswordAWSSecret string `gorm:"size:255" json:"password_aws_secret,omitempty"`
 }

--- a/controlplane/provisioner/controller_analytics_test.go
+++ b/controlplane/provisioner/controller_analytics_test.go
@@ -93,7 +93,7 @@ func TestReconcileProvisioningSuccessEmitsEvent(t *testing.T) {
 		"metadata":   map[string]interface{}{"name": "org-ok", "namespace": ducklingNamespace},
 		"status": map[string]interface{}{
 			"metadataStore": map[string]interface{}{
-				"type": "external", "endpoint": "rds.example", "password": "secret", "user": "postgres", "database": "postgres",
+				"type": "external", "endpoint": "rds.example", "credentialSecretRef": testCredentialSecretRef("org-ok"), "user": "postgres", "database": "postgres",
 			},
 			"dataStore":  map[string]interface{}{"type": "s3bucket", "bucketName": "org-ok-bucket"},
 			"iamRoleArn": "arn:aws:iam::123456789012:role/duckling-org-ok",

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -111,7 +111,21 @@ func newFakeDucklingClient() (*DucklingClient, *dynamicfake.FakeDynamicClient) {
 	}, &unstructured.UnstructuredList{})
 
 	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	installFakeCredentialSecretReader(fakeClient)
 	return NewDucklingClientWithDynamic(fakeClient), fakeClient
+}
+
+func testCredentialSecretRef(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name": name + "-metadata-password", "namespace": ducklingNamespace, "key": "password",
+	}
+}
+
+func installFakeCredentialSecretReader(fakeClient *dynamicfake.FakeDynamicClient) {
+	fakeClient.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		name := action.(k8stesting.GetAction).GetName()
+		return true, credentialSecret(name, "test-metadata-password"), nil
+	})
 }
 
 func TestReconcilePendingCreatesCR(t *testing.T) {
@@ -524,11 +538,11 @@ func TestReconcileProvisioningAllReady(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":     "external",
-					"endpoint": "org-b.cluster.us-east-1.rds.amazonaws.com",
-					"password": "supersecret123",
-					"user":     "postgres",
-					"database": "postgres",
+					"type":                "external",
+					"endpoint":            "org-b.cluster.us-east-1.rds.amazonaws.com",
+					"credentialSecretRef": testCredentialSecretRef("org-b"),
+					"user":                "postgres",
+					"database":            "postgres",
 				},
 				"dataStore": map[string]interface{}{
 					"type":       "s3bucket",
@@ -609,12 +623,12 @@ func TestReconcileProvisioningProbeFailsKeepsProvisioning(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":              "external",
-					"endpoint":          "org-probe.cluster.us-east-1.rds.amazonaws.com",
-					"pgbouncerEndpoint": "pgbouncer-duckling-org-probe.ducklings.svc.cluster.local:6543",
-					"password":          "supersecret123",
-					"user":              "postgres",
-					"database":          "postgres",
+					"type":                "external",
+					"endpoint":            "org-probe.cluster.us-east-1.rds.amazonaws.com",
+					"pgbouncerEndpoint":   "pgbouncer-duckling-org-probe.ducklings.svc.cluster.local:6543",
+					"credentialSecretRef": testCredentialSecretRef("org-probe"),
+					"user":                "postgres",
+					"database":            "postgres",
 				},
 				"dataStore": map[string]interface{}{
 					"type":       "s3bucket",
@@ -700,12 +714,12 @@ func TestReconcileProvisioningProbesPgBouncerWhenEnabled(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":              "external",
-					"endpoint":          "org-pgb.cluster.us-east-1.rds.amazonaws.com",
-					"pgbouncerEndpoint": "pgbouncer-duckling-org-pgb.ducklings.svc.cluster.local:6543",
-					"password":          "supersecret123",
-					"user":              "postgres",
-					"database":          "postgres",
+					"type":                "external",
+					"endpoint":            "org-pgb.cluster.us-east-1.rds.amazonaws.com",
+					"pgbouncerEndpoint":   "pgbouncer-duckling-org-pgb.ducklings.svc.cluster.local:6543",
+					"credentialSecretRef": testCredentialSecretRef("org-pgb"),
+					"user":                "postgres",
+					"database":            "postgres",
 				},
 				"dataStore":  map[string]interface{}{"type": "s3bucket", "bucketName": "org-pgb-bucket"},
 				"iamRoleArn": "arn:aws:iam::123456789012:role/duckling-org-pgb",
@@ -842,7 +856,6 @@ func TestParseDucklingStatusPgBouncerEndpoint(t *testing.T) {
 					"pgbouncerEndpoint": "pgbouncer-duckling-foo.ducklings.svc.cluster.local:6543",
 					"user":              "postgres",
 					"database":          "postgres",
-					"password":          "s3cret",
 				},
 			},
 		},
@@ -981,6 +994,7 @@ func newFakeDucklingClientWithComposed(objects ...runtime.Object) *DucklingClien
 		bucketGVR:   "BucketList",
 	}
 	fake := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+	installFakeCredentialSecretReader(fake)
 	return NewDucklingClientWithDynamic(fake)
 }
 
@@ -1008,7 +1022,7 @@ func TestReconcileProvisioningStuckBucketSurfacesError(t *testing.T) {
 		},
 		"status": map[string]interface{}{
 			// Populated infra fields — what fooled the old presence check.
-			"metadataStore": map[string]interface{}{"type": "external", "endpoint": "org-stuck.rds.amazonaws.com", "password": "pw", "user": "postgres", "database": "postgres"},
+			"metadataStore": map[string]interface{}{"type": "external", "endpoint": "org-stuck.rds.amazonaws.com", "credentialSecretRef": testCredentialSecretRef("org-stuck"), "user": "postgres", "database": "postgres"},
 			"dataStore":     map[string]interface{}{"type": "s3bucket", "bucketName": bucketName},
 			"iamRoleArn":    "arn:aws:iam::123456789012:role/duckling-org-stuck",
 			// XR composed fine but the bucket never reconciled.
@@ -1164,11 +1178,11 @@ func TestReconcileProvisioningCnpgShardReadiness(t *testing.T) {
 			},
 			"status": map[string]interface{}{
 				"metadataStore": map[string]interface{}{
-					"type":     configstore.MetadataStoreKindCnpgShard,
-					"endpoint": "shard-001-pooler.cnpg-shards.svc.cluster.local",
-					"password": "from-provider-sql",
-					"user":     "duckgres_org_cs",
-					"database": "duckgres_org_cs",
+					"type":                configstore.MetadataStoreKindCnpgShard,
+					"endpoint":            "shard-001-pooler.cnpg-shards.svc.cluster.local",
+					"credentialSecretRef": testCredentialSecretRef("org-cs"),
+					"user":                "duckgres_org_cs",
+					"database":            "duckgres_org_cs",
 				},
 				"dataStore": map[string]interface{}{
 					"type":       "s3bucket",

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -332,16 +332,17 @@ func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus,
 	}
 	ref := status.MetadataCredentialSecretRef
 	if ref.Name == "" {
-		return status, nil // Legacy composition: plaintext status fallback.
+		// A newly-created or failed Duckling can legitimately have no resolved
+		// metadata-store status yet. Return its conditions so provisioning can
+		// report Crossplane failures; once a metadata store is published, its
+		// credential reference is mandatory.
+		if status.MetadataStore.Type == "" {
+			return status, nil
+		}
+		return nil, fmt.Errorf("duckling %q status.metadataStore.credentialSecretRef.name is required", name)
 	}
 	password, err := d.readSecretKey(ctx, ref)
 	if err != nil {
-		// During the staged rollout an older/temporarily unavailable Secret must
-		// not strand tenants whose legacy status password is still populated.
-		if status.MetadataStore.Password != "" {
-			slog.Warn("Failed to resolve Duckling metadata credential Secret; using legacy status password.", "duckling", name, "secret", ref.Name, "error", err)
-			return status, nil
-		}
 		return nil, fmt.Errorf("resolve metadata credential Secret for duckling %q: %w", name, err)
 	}
 	status.MetadataStore.Password = password
@@ -351,14 +352,14 @@ func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus,
 func (d *DucklingClient) readSecretKey(ctx context.Context, ref SecretReference) (string, error) {
 	namespace := ref.Namespace
 	if namespace == "" {
-		namespace = ducklingNamespace
+		return "", fmt.Errorf("namespace is required")
 	}
 	if namespace != ducklingNamespace {
 		return "", fmt.Errorf("namespace %q is not allowed", namespace)
 	}
 	key := ref.Key
 	if key == "" {
-		key = "password"
+		return "", fmt.Errorf("key is required")
 	}
 	secret, err := d.client.Resource(secretGVR).Namespace(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1086,7 +1087,6 @@ func parseDucklingStatus(cr *unstructured.Unstructured) (*DucklingStatus, error)
 		ds.MetadataStore.Type = getNestedString(md, "type")
 		ds.MetadataStore.Endpoint = getNestedString(md, "endpoint")
 		ds.MetadataStore.PgBouncerEndpoint = getNestedString(md, "pgbouncerEndpoint")
-		ds.MetadataStore.Password = getNestedString(md, "password")
 		ds.MetadataStore.User = getNestedString(md, "user")
 		ds.MetadataStore.Database = getNestedString(md, "database")
 		if ref, ok := md["credentialSecretRef"].(map[string]interface{}); ok {

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -16,15 +16,12 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
-func ducklingWithCredentialRef(name, legacyPassword string, ref SecretReference) *unstructured.Unstructured {
+func ducklingWithCredentialRef(name string, ref SecretReference) *unstructured.Unstructured {
 	metadataStore := map[string]interface{}{
 		"type":     configstore.MetadataStoreKindCnpgShard,
 		"endpoint": "metadata.internal",
 		"user":     "tenant",
 		"database": "tenant",
-	}
-	if legacyPassword != "" {
-		metadataStore["password"] = legacyPassword
 	}
 	if ref.Name != "" {
 		metadataStore["credentialSecretRef"] = map[string]interface{}{
@@ -49,7 +46,7 @@ func credentialSecret(name, password string) *unstructured.Unstructured {
 }
 
 func TestGetResolvesMetadataPasswordFromCredentialSecretRef(t *testing.T) {
-	cr := ducklingWithCredentialRef("acme", "stale-status-password", SecretReference{
+	cr := ducklingWithCredentialRef("acme", SecretReference{
 		Name: "cnpg-tenant-acme-password", Namespace: ducklingNamespace, Key: "password",
 	})
 	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr, credentialSecret("cnpg-tenant-acme-password", "live-secret-password"))
@@ -63,23 +60,30 @@ func TestGetResolvesMetadataPasswordFromCredentialSecretRef(t *testing.T) {
 	}
 }
 
-func TestGetFallsBackToLegacyStatusPasswordDuringRollout(t *testing.T) {
-	cr := ducklingWithCredentialRef("acme", "legacy-password", SecretReference{
-		Name: "missing-password", Namespace: ducklingNamespace, Key: "password",
-	})
+func TestGetRequiresMetadataCredentialSecretRef(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", SecretReference{})
 	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
 
-	status, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if got := status.MetadataStore.Password; got != "legacy-password" {
-		t.Fatalf("password = %q, want legacy fallback", got)
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), "credentialSecretRef") {
+		t.Fatalf("Get error = %v, want missing credentialSecretRef error", err)
 	}
 }
 
-func TestGetFailsWhenReferencedCredentialIsUnavailableWithoutLegacyFallback(t *testing.T) {
-	cr := ducklingWithCredentialRef("acme", "", SecretReference{
+func TestGetDoesNotUsePlaintextCredentialFromStatus(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", SecretReference{})
+	metadataStore := cr.Object["status"].(map[string]interface{})["metadataStore"].(map[string]interface{})
+	metadataStore["password"] = "retired-plaintext-password"
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
+
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), "credentialSecretRef") {
+		t.Fatalf("Get error = %v, want missing credentialSecretRef error", err)
+	}
+}
+
+func TestGetFailsWhenReferencedCredentialIsUnavailable(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", SecretReference{
 		Name: "missing-password", Namespace: ducklingNamespace, Key: "password",
 	})
 	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
@@ -91,7 +95,7 @@ func TestGetFailsWhenReferencedCredentialIsUnavailableWithoutLegacyFallback(t *t
 }
 
 func TestGetRejectsCredentialSecretOutsideDucklingsNamespace(t *testing.T) {
-	cr := ducklingWithCredentialRef("acme", "", SecretReference{
+	cr := ducklingWithCredentialRef("acme", SecretReference{
 		Name: "password", Namespace: "other-namespace", Key: "password",
 	})
 	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr)
@@ -99,6 +103,30 @@ func TestGetRejectsCredentialSecretOutsideDucklingsNamespace(t *testing.T) {
 	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
 	if err == nil || !strings.Contains(err.Error(), `namespace "other-namespace" is not allowed`) {
 		t.Fatalf("Get error = %v, want namespace rejection", err)
+	}
+}
+
+func TestGetRequiresExplicitCredentialSecretNamespace(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", SecretReference{
+		Name: "cnpg-tenant-acme-password", Key: "password",
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr, credentialSecret("cnpg-tenant-acme-password", "password"))
+
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), "namespace is required") {
+		t.Fatalf("Get error = %v, want missing namespace error", err)
+	}
+}
+
+func TestGetRequiresExplicitCredentialSecretKey(t *testing.T) {
+	cr := ducklingWithCredentialRef("acme", SecretReference{
+		Name: "cnpg-tenant-acme-password", Namespace: ducklingNamespace,
+	})
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cr, credentialSecret("cnpg-tenant-acme-password", "password"))
+
+	_, err := NewDucklingClientWithDynamic(fakeK8s).Get(context.Background(), "acme")
+	if err == nil || !strings.Contains(err.Error(), "key is required") {
+		t.Fatalf("Get error = %v, want missing key error", err)
 	}
 }
 

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -200,9 +200,9 @@ func isAuthProbeError(err error) bool {
 
 // describeProbeFailure renders a tenant-role probe failure for the op log.
 // Authentication failures are named explicitly, with the operator remedy: the
-// role's ACTUAL Postgres password differing from the freshly published status
-// password (a stranded password — e.g. a re-adopted role whose status password
-// the composition regenerated) is effectively permanent, and retrying to the
+// role's ACTUAL Postgres password differing from the referenced Secret
+// password (a stranded password — e.g. a re-adopted role whose credential the
+// composition regenerated) is effectively permanent, and retrying to the
 // timeout cannot fix it by itself. We keep polling anyway (a composition fix
 // can converge the password mid-wait, and bailing early would leave the org
 // worse off), but the log must tell the operator what to do.
@@ -214,7 +214,7 @@ func describeProbeFailure(err error, role string) string {
 	if !isAuthProbeError(err) {
 		return fmt.Sprintf("tenant-role probe failing: %v", err)
 	}
-	return fmt.Sprintf("tenant-role probe failing with an AUTHENTICATION error: %v — the role's actual Postgres password likely differs from the published status password (stranded password). If this persists, align it manually on the shard primary: ALTER ROLE %s WITH PASSWORD '<status password>' (take the password from the duckling CR status — it is never logged here)", err, role)
+	return fmt.Sprintf("tenant-role probe failing with an AUTHENTICATION error: %v — the role's actual Postgres password likely differs from the referenced Secret (stranded password). If this persists, align it manually on the shard primary: ALTER ROLE %s WITH PASSWORD '<referenced Secret password>' (read the key named by status.metadataStore.credentialSecretRef — it is never logged here)", err, role)
 }
 
 // StashExternalPassword hands the runner the ephemeral external-target

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -1472,7 +1472,7 @@ func stuckExtOp() *configstore.ReshardOperation {
 }
 
 // TestReshardExtFlipTimeoutRecovers pins the ORPHAN-ADOPT recovery: when the
-// cnpg→ext cutover never becomes ready (the target's status password never
+// cnpg→ext cutover never becomes ready (the target's credential Secret never
 // syncs), the flip times out and the runner recovers by flipping back to the
 // source shard and RE-ADOPTING the still-present (orphaned) cnpg role/DB — NO
 // copy-back, NO empty-recreate — leaving the org in service. The source is
@@ -1846,7 +1846,7 @@ func TestProbeErrorAuthClassification(t *testing.T) {
 // TestReshardExtRecoveryProbeAuthFailureDiagnosed is the regression for the
 // mw-dev incident where the cnpg→ext post-flip recovery spun silently for ~8
 // minutes on `FATAL: SASL authentication failed` (the re-adopted role's actual
-// password differed from the freshly regenerated status password) and the
+// password differed from the freshly regenerated referenced Secret password) and the
 // operator had to reproduce the probe from a shell to see why. The recovery
 // wait must (a) announce its deadline, (b) periodically log the classified
 // probe failure naming the stranded-password condition + the manual ALTER ROLE

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -71,9 +71,9 @@ identity is incomplete or contradicted:
 
 The status contains only a non-sensitive `credentialSecretRef`; Duckgres reads
 the referenced key from the Secret in the `ducklings` namespace before any
-catalog copy, verification, or rollback. During the ordered rollout it still
-accepts the legacy plaintext status password as a fallback, but the reference
-is authoritative whenever it can be resolved.
+catalog copy, verification, or rollback. The complete reference is mandatory;
+missing or unreadable credentials stop the operation instead of falling back
+to credential material in custom-resource status.
 
 - **kind drift** — the row's `metadata_store_kind` (when set) disagrees with
   the status type → 400 naming both values ("refusing to reshard until
@@ -433,7 +433,7 @@ allowlist** — the SM secret name MUST start with `posthog-` or `duckling-`
 message; any other non-allowlisted name gets the general allowlist message.
 The two prefixes are identical across every env, so they're hardcoded (not
 resolved per-env). If a name that slips through is
-still unreadable by ESO, the cutover simply waits for the status password
+still unreadable by ESO, the cutover simply waits for the credential Secret
 until its per-op timeout and then recovers (below) — the op log shows the
 generic "waiting for external target" line. (Surfacing the ExternalSecret's
 own AccessDenied into the op log would need an `external-secrets.io` read
@@ -473,12 +473,12 @@ recovery) announces its deadline on entry and logs what it observes every ~15s
 error/log line carries the LAST observation — a stuck reshard is diagnosable
 from the op log alone. One recovery failure mode deserves naming: the
 re-adopted role's ACTUAL Postgres password can differ from the freshly
-regenerated status password (a **stranded password** — the probe fails with
+regenerated referenced Secret password (a **stranded password** — the probe fails with
 `FATAL: SASL authentication failed` / SQLSTATE 28P01 until the composition
 converges the password). The runner classifies auth probe failures
 (`isAuthProbeError`) and the observation names the condition and the manual
-remedy — `ALTER ROLE <role> WITH PASSWORD '<status password>'` on the source
-shard primary — but it still polls to the deadline rather than bailing early,
+remedy — `ALTER ROLE <role> WITH PASSWORD '<referenced Secret password>'` on
+the source shard primary — but it still polls to the deadline rather than bailing early,
 since a charts/composition fix can converge the password mid-wait. Passwords
 never appear in the op log.
 

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -340,10 +340,10 @@ got through, in order — each was a real fix:
 5. ✅ catalog selection — `dbname` must be `ducklake`, not the org
    (PR #651: *database = catalog selection*). harness.sh now does this.
 
-6. ✅ **activation (cnpg DuckLake)** — the blocker was NOT a metadata
-   SecretRef; the duckling-status path reads the metadata password straight
-   from the CR. It failed at **S3 STS brokering** because the isolated CP had no
-   AWS identity. Fixed by binding the per-PR `duckgres` SA to the **same EKS Pod
+6. ✅ **activation (cnpg DuckLake)** — the control plane resolves the metadata
+   password from the Secret referenced by Duckling status. Activation failed at
+   **S3 STS brokering** because the isolated CP had no AWS identity. Fixed by
+   binding the per-PR `duckgres` SA to the **same EKS Pod
    Identity role the real mw-dev control plane uses**
    (`duckgres-control-plane-dev`), via `aws eks create-pod-identity-association`
    in `run.sh` deploy (deleted in teardown). With it, the CP brokers per-duckling


### PR DESCRIPTION
## Summary

Remove the completed Duckling plaintext-credential rollout compatibility from Duckgres. `status.metadataStore.credentialSecretRef` is now the only credential interface.

- Require explicit Secret name, namespace, and key once metadata-store status exists.
- Fail closed when the reference is incomplete or the Secret cannot be read.
- Stop parsing `status.metadataStore.password`.
- Remove the fallback to plaintext status when Secret resolution fails.
- Update controller fixtures, reshard diagnostics, operational documentation, and regression tests.

The internal `MetadataStore.Password` value remains intentionally: it contains the credential resolved from Kubernetes Secret memory and is consumed by activation, probes, and resharding. It is no longer populated from CR status.

## Tests

```sh
go test -count=1 -tags kubernetes ./controlplane/provisioner -run TestGet
go test -count=1 -tags kubernetes ./controlplane/provisioner
just test-controlplane
just lint
```

All passed. `just test-controlplane-k8s` also passed all changed provisioner tests; its unrelated `controlplane/admin.TestModelsAPIPostgres` fails against a stale test DB schema missing `duckgres_org_users.access_mode`.

## Deployment order

Depends on PostHog/charts#13406 being merged and deployed first. All managed-warehouse Ducklings have already been verified Secret-backed with zero plaintext, but the charts cleanup formally removes the old status schema/writer before this binary drops the fallback.

## Review notes

An independent adversarial cross-repository audit found no remaining credential migration modes, gates, observers, legacy managers, plaintext parsing, or fallback behavior. Remaining shard/identifier/reshard state is unrelated and load-bearing.