### PR TITLE
Fix mw-dev teardown after CNPG primary failover

### DIFF
--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -152,15 +152,44 @@ restart_cp_with_identity() {
 # rerun never inherits stranded state) and at teardown (deterministic clean
 # exit). Scoped to this PR's unique org ids, so it can't touch another PR's
 # tenant.
+discover_cnpg_primary() {
+  local primary
+  if ! primary="$("${KUBECTL[@]}" -n cnpg-shards get pod \
+    -l 'cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary' \
+    -o jsonpath='{.items[0].metadata.name}')"; then
+    echo "Failed to discover the shard-001 CNPG primary." >&2
+    return 1
+  fi
+  if [ -z "$primary" ]; then
+    echo "No shard-001 CNPG primary was found." >&2
+    return 1
+  fi
+  printf '%s\n' "$primary"
+}
+
 drop_cnpg_role() { # org-id
-  local suffix ident
+  local suffix ident primary attempt
   # Mirror the composition's PG identifier suffix: lower, [^a-z0-9_] -> _.
   suffix="$(printf %s "$1" | tr 'A-Z-' 'a-z_' | tr -cd 'a-z0-9_')"
   ident="mdstore_${suffix}"
-  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
-    psql -U postgres -c "DROP DATABASE IF EXISTS ${ident} WITH (FORCE);" >/dev/null 2>&1 || true
-  "${KUBECTL[@]}" -n cnpg-shards exec shard-001-1 -c postgres -- \
-    psql -U postgres -c "DROP ROLE IF EXISTS ${ident};" >/dev/null 2>&1 || true
+  # A failover may happen after discovery. Retry the complete pair against a
+  # newly discovered primary; both statements are idempotent, so retrying is
+  # safe even if the database drop succeeded before the role command failed.
+  for attempt in 1 2 3; do
+    if ! primary="$(discover_cnpg_primary)"; then
+      echo "CNPG cleanup attempt $attempt/3 could not discover a primary for $ident." >&2
+      continue
+    fi
+    if "${KUBECTL[@]}" -n cnpg-shards exec "$primary" -c postgres -- \
+      psql -U postgres -c "DROP DATABASE IF EXISTS ${ident} WITH (FORCE);" \
+      && "${KUBECTL[@]}" -n cnpg-shards exec "$primary" -c postgres -- \
+      psql -U postgres -c "DROP ROLE IF EXISTS ${ident};"; then
+      return 0
+    fi
+    echo "CNPG cleanup attempt $attempt/3 failed on primary $primary for $ident." >&2
+  done
+  echo "Failed to drop CNPG database and role $ident after 3 attempts." >&2
+  return 1
 }
 
 # Every CNPG-backed duckling org a harness run provisions for a PR
@@ -644,7 +673,7 @@ cmd_diagnostics() {
 }
 
 cmd_teardown() {
-  local duckling_delete_rc=0
+  local duckling_delete_rc=0 cnpg_cleanup_rc=0 org
 
   # Deprovision the ci-pr ducklings FIRST so shared-infra resources (S3 bucket,
   # cnpg role+db) are cleaned up by the control plane
@@ -700,7 +729,9 @@ cmd_teardown() {
 
   # Deterministically drop the cnpg role+db in case the composition's async
   # cascade lagged the CR delete above (see drop_cnpg_role). Idempotent.
-  for org in $(ci_orgs "$PR_NUMBER"); do drop_cnpg_role "$org"; done
+  for org in $(ci_orgs "$PR_NUMBER"); do
+    drop_cnpg_role "$org" || cnpg_cleanup_rc=1
+  done
 
   # Drop the Pod Identity association (it's an EKS resource, not in the ns).
   delete_pod_identity
@@ -708,7 +739,9 @@ cmd_teardown() {
   # Cross-namespace bindings carry the ci-pr label — sweep them, then the ns.
   delete_ci_bindings "$PR_NUMBER"
   "${KUBECTL[@]}" delete namespace "$NS" --ignore-not-found --wait=false
-  return "$duckling_delete_rc"
+  if [ "$duckling_delete_rc" -ne 0 ] || [ "$cnpg_cleanup_rc" -ne 0 ]; then
+    return 1
+  fi
 }
 
 # Sweep stale per-PR namespaces left behind by runs that died hard (cancelled

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -85,6 +85,126 @@ func TestScheduledCleanupDropsCnpgIdentifiers(t *testing.T) {
 	}
 }
 
+func TestTeardownDropsCNPGIdentifiersOnDiscoveredPrimary(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "teardown",
+		"SCENARIO_DEV_ALLOW_DUCKLING_DELETE=1",
+		"CNPG_DEV_PRIMARY=shard-001-2",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("teardown failed: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	if !strings.Contains(calls, "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary") {
+		t.Fatalf("teardown did not discover the shard-001 primary by CNPG labels; calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "exec shard-001-2 -c postgres -- psql -U postgres -c DROP DATABASE IF EXISTS mdstore_ci_pr_123_cnpg WITH (FORCE);") {
+		t.Fatalf("teardown did not drop the database on the discovered primary; calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "exec shard-001-2 -c postgres -- psql -U postgres -c DROP ROLE IF EXISTS mdstore_ci_pr_123_cnpg;") {
+		t.Fatalf("teardown did not drop the role on the discovered primary; calls:\n%s", calls)
+	}
+	if strings.Contains(calls, "exec shard-001-1 -c postgres -- psql") {
+		t.Fatalf("teardown still targets the fixed shard-001-1 pod; calls:\n%s", calls)
+	}
+}
+
+func TestTeardownRetriesCNPGCleanupAfterPrimaryFailover(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "teardown",
+		"SCENARIO_DEV_ALLOW_DUCKLING_DELETE=1",
+		"CNPG_DEV_PRIMARY_SEQUENCE=shard-001-1,shard-001-2",
+		"CNPG_DEV_FAILOVER_ONCE=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("teardown failed after retrying a primary transition: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	firstDiscovery := strings.Index(calls, "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary")
+	staleExec := strings.Index(calls, "exec shard-001-1 -c postgres -- psql")
+	secondDiscovery := -1
+	if firstDiscovery >= 0 {
+		if next := strings.Index(calls[firstDiscovery+1:], "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary"); next >= 0 {
+			secondDiscovery = firstDiscovery + 1 + next
+		}
+	}
+	newPrimaryDBExec := strings.Index(calls, "exec shard-001-2 -c postgres -- psql -U postgres -c DROP DATABASE IF EXISTS mdstore_ci_pr_123_cnpg WITH (FORCE);")
+	newPrimaryRoleExec := strings.Index(calls, "exec shard-001-2 -c postgres -- psql -U postgres -c DROP ROLE IF EXISTS mdstore_ci_pr_123_cnpg;")
+	if firstDiscovery < 0 || staleExec < firstDiscovery || secondDiscovery < staleExec || newPrimaryDBExec < secondDiscovery || newPrimaryRoleExec < newPrimaryDBExec {
+		t.Fatalf("teardown did not rediscover and retry on the replacement primary; calls:\n%s", calls)
+	}
+}
+
+func TestTeardownFailsWhenCNPGCleanupCannotReachAPrimary(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+	}{
+		{name: "discovery fails", env: "CNPG_DEV_FAIL_DISCOVERY=1"},
+		{name: "all psql executions fail", env: "CNPG_DEV_FAIL_EXEC=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakes := newRunSHFakes(t)
+
+			cmd := runSHCommand(t, fakes.binDir, "teardown",
+				"SCENARIO_DEV_ALLOW_DUCKLING_DELETE=1",
+				"CNPG_DEV_PRIMARY=shard-001-2",
+				tt.env,
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("teardown succeeded despite %s; output:\n%s", tt.name, out)
+			}
+			if !strings.Contains(string(out), "after 3 attempts") {
+				t.Fatalf("teardown did not report exhausted CNPG cleanup retries; output:\n%s", out)
+			}
+
+			calls := fakes.calls(t)
+			if got := strings.Count(calls, "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary"); got != 9 {
+				t.Fatalf("primary discovery calls = %d, want 9 (three retries for each CI org); calls:\n%s", got, calls)
+			}
+			if tt.name == "all psql executions fail" && strings.Count(calls, "exec shard-001-2 -c postgres -- psql") != 9 {
+				t.Fatalf("psql attempts were not bounded to three per CI org; calls:\n%s", calls)
+			}
+			if !strings.Contains(calls, "delete namespace duckgres-ci-pr-123 --ignore-not-found --wait=false") {
+				t.Fatalf("teardown did not continue namespace cleanup after CNPG cleanup failed; calls:\n%s", calls)
+			}
+		})
+	}
+}
+
+func TestTeardownSucceedsWhenCNPGIdentifiersAreAlreadyAbsent(t *testing.T) {
+	fakes := newRunSHFakes(t)
+
+	cmd := runSHCommand(t, fakes.binDir, "teardown",
+		"SCENARIO_DEV_ALLOW_DUCKLING_DELETE=1",
+		"CNPG_DEV_PRIMARY=shard-001-2",
+		"CNPG_DEV_MISSING_IDENTIFIERS=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("teardown failed when CNPG identifiers were already absent: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	for _, want := range []string{
+		"DROP DATABASE IF EXISTS mdstore_ci_pr_123_cnpg WITH (FORCE);",
+		"DROP ROLE IF EXISTS mdstore_ci_pr_123_cnpg;",
+	} {
+		if !strings.Contains(calls, want) {
+			t.Fatalf("teardown did not preserve idempotent SQL %q; calls:\n%s", want, calls)
+		}
+	}
+}
+
 func TestTeardownContinuesCleanupWhenDucklingsDoNotDelete(t *testing.T) {
 	fakes := newRunSHFakes(t)
 
@@ -667,6 +787,43 @@ func newRunSHFakes(t *testing.T) runSHFakes {
 	writeFake(t, binDir, "kubectl", `#!/usr/bin/env bash
 printf 'kubectl %s\n' "$*" >> "$RUN_SH_TEST_CALLS"
 
+if [[ "$*" == *" -n cnpg-shards get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary "* ]]; then
+  if [[ -n "${CNPG_DEV_FAIL_DISCOVERY:-}" ]]; then
+    exit 1
+  fi
+  primary="${CNPG_DEV_PRIMARY:-shard-001-1}"
+  if [[ -n "${CNPG_DEV_PRIMARY_SEQUENCE:-}" ]]; then
+    IFS=',' read -r -a primaries <<< "$CNPG_DEV_PRIMARY_SEQUENCE"
+    discovery=0
+    if [[ -e "$RUN_SH_TEST_CNPG_DISCOVERY_STATE" ]]; then
+      discovery="$(<"$RUN_SH_TEST_CNPG_DISCOVERY_STATE")"
+    fi
+    if (( discovery < ${#primaries[@]} )); then
+      primary="${primaries[$discovery]}"
+    else
+      primary="${primaries[${#primaries[@]}-1]}"
+    fi
+    printf '%s' $((discovery + 1)) > "$RUN_SH_TEST_CNPG_DISCOVERY_STATE"
+  fi
+  printf '%s' "$primary"
+  exit 0
+fi
+if [[ "$*" == *" -n cnpg-shards exec "* && "$*" == *" psql -U postgres -c "* ]]; then
+  if [[ -n "${CNPG_DEV_FAILOVER_ONCE:-}" && ! -e "$RUN_SH_TEST_CNPG_FAILOVER_STATE" ]]; then
+    touch "$RUN_SH_TEST_CNPG_FAILOVER_STATE"
+    exit 1
+  fi
+  if [[ -n "${CNPG_DEV_FAIL_EXEC:-}" ]]; then
+    exit 1
+  fi
+  if [[ -n "${CNPG_DEV_PRIMARY:-}" && "$*" != *" exec ${CNPG_DEV_PRIMARY} -c postgres "* ]]; then
+    exit 1
+  fi
+  if [[ -n "${CNPG_DEV_MISSING_IDENTIFIERS:-}" && "$*" != *"DROP DATABASE IF EXISTS"* && "$*" != *"DROP ROLE IF EXISTS"* ]]; then
+    exit 1
+  fi
+  exit 0
+fi
 if [[ "$*" == *" apply -f -"* ]]; then
   tee -a "$RUN_SH_TEST_CALLS" >/dev/null
   exit 0
@@ -843,6 +1000,8 @@ func runSHCommand(t *testing.T, binDir, subcommand string, extraEnv ...string) *
 		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"RUN_SH_TEST_CALLS="+filepath.Join(filepath.Dir(binDir), "calls.log"),
 		"RUN_SH_TEST_MKTEMP_STATE="+filepath.Join(filepath.Dir(binDir), "mktemp-state"),
+		"RUN_SH_TEST_CNPG_DISCOVERY_STATE="+filepath.Join(filepath.Dir(binDir), "cnpg-discovery-state"),
+		"RUN_SH_TEST_CNPG_FAILOVER_STATE="+filepath.Join(filepath.Dir(binDir), "cnpg-failover-state"),
 		"KUBE_CONTEXT=test-context",
 		"NAMESPACE=duckgres-ci-pr-123",
 		"PR_NUMBER=123",


### PR DESCRIPTION
## Summary

- discover the shard-001 CNPG primary by labels for every cleanup attempt
- retry the idempotent database and role drops after a primary transition
- surface exhausted cleanup failures while allowing teardown to finish its remaining cleanup

## Root cause

Teardown previously assumed a fixed CNPG instance. After the primary moved, `psql` against the old replica failed, but the helper suppressed that error and teardown could falsely report success while tenant metadata remained.

## Validation

- `go test -count=1 ./tests/mw-dev`
- `just lint`