### PR TITLE
feat(scenarios): publish performance history

### DIFF
--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -89,7 +89,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test scenario workflow scripts
-        run: go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev
+        run: go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev ./tests/perf/publishercli
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -152,3 +152,37 @@ jobs:
           path: artifacts/scenario-dev/
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Publish scenario perf results
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        timeout-minutes: 10
+        env:
+          MW_DEV_SCENARIO_PERF_SECRET_ID: ${{ vars.MW_DEV_SCENARIO_PERF_SECRET_ID }}
+        run: |
+          set -euo pipefail
+          mapfile -d '' perf_summaries < <(
+            find artifacts/scenario-dev -type f -path '*/perf/summary.json' -print0 2>/dev/null | sort -z
+          )
+          if [ "${#perf_summaries[@]}" -eq 0 ]; then
+            echo "No scenario perf artifact was produced; skipping historical publish."
+            exit 0
+          fi
+          : "${MW_DEV_SCENARIO_PERF_SECRET_ID:?MW_DEV_SCENARIO_PERF_SECRET_ID repository variable is required}"
+          publish_failed=0
+          for perf_summary in "${perf_summaries[@]}"; do
+            perf_dir="$(dirname "$perf_summary")"
+            echo "Publishing scenario perf artifacts from $perf_dir"
+            if ! aws secretsmanager get-secret-value \
+              --secret-id "$MW_DEV_SCENARIO_PERF_SECRET_ID" \
+              --query SecretString \
+              --output text \
+              | go run ./cmd/duckgres-perf-publisher \
+                  --run-dir "$perf_dir" \
+                  --connection-secret-stdin \
+                  --schema duckgres_scenario_perf \
+                  --bootstrap-schema=true; then
+              echo "::error::Failed to publish scenario perf artifacts from $perf_dir"
+              publish_failed=1
+            fi
+          done
+          exit "$publish_failed"

--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -179,6 +179,7 @@ jobs:
               | go run ./cmd/duckgres-perf-publisher \
                   --run-dir "$perf_dir" \
                   --connection-secret-stdin \
+                  --publish-timeout 2m \
                   --schema duckgres_scenario_perf \
                   --bootstrap-schema=true; then
               echo "::error::Failed to publish scenario perf artifacts from $perf_dir"

--- a/cmd/duckgres-perf-publisher/main.go
+++ b/cmd/duckgres-perf-publisher/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/posthog/duckgres/tests/perf/publishercli"
+)
+
+func main() {
+	if err := publishercli.Run(context.Background(), os.Args[1:], publishercli.Dependencies{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+	}); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/runbooks/scenario-dev.md
+++ b/docs/runbooks/scenario-dev.md
@@ -40,6 +40,13 @@ Configure these repository variables:
 
 - `TS_WIF_CLIENT_ID_MW_DEV`
 - `TS_WIF_AUDIENCE_MW_DEV`
+- `MW_DEV_SCENARIO_PERF_SECRET_ID`
+
+`MW_DEV_SCENARIO_PERF_SECRET_ID` names the AWS Secrets Manager JSON secret used
+only by historical perf publishing. The secret must contain `host`, `port`,
+`database`, `username`, and `password`. The workflow pipes it directly from
+AWS CLI into the publisher process so the password is not placed in a shell
+argument, environment variable, or log.
 
 The workflow hardcodes the stable mw-dev cluster name/context and builds the
 control-plane pod identity role ARN from `MW_DEV_ACCOUNT_ID`, matching
@@ -77,6 +84,12 @@ independent sibling branches: for example, `dbt_models` still runs because it
 depends on `setup_frozen_views`, not `perf_queries`. Only true dependants are
 skipped, and `always_run` teardown still executes. The final workflow result is
 reported after all eligible steps and artifact collection finish.
+
+After teardown, scheduled and manually dispatched runs on `main` publish any
+collected `perf/summary.json` and `perf/query_results.csv` into the persistent
+scenario perf result schema. Publishing runs with `if: always()` so measured
+query failures remain visible. Runs without a perf artifact skip publishing,
+and non-`main` branch runs never publish into the shared history.
 
 If cleanup did not complete, the scenario-created org is
 `ci-pr-<workflow-run-id>-cnpg`; deprovision it manually through the relevant dev

--- a/docs/runbooks/scenario-dev.md
+++ b/docs/runbooks/scenario-dev.md
@@ -89,7 +89,10 @@ After teardown, scheduled and manually dispatched runs on `main` publish any
 collected `perf/summary.json` and `perf/query_results.csv` into the persistent
 scenario perf result schema. Publishing runs with `if: always()` so measured
 query failures remain visible. Runs without a perf artifact skip publishing,
-and non-`main` branch runs never publish into the shared history.
+and non-`main` branch runs never publish into the shared history. Each artifact
+has a two-minute publish timeout so one stalled database operation cannot
+prevent later artifacts from being attempted; the workflow step retains a
+ten-minute overall timeout.
 
 If cleanup did not complete, the scenario-created org is
 `ci-pr-<workflow-run-id>-cnpg`; deprovision it manually through the relevant dev

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -132,11 +132,15 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"DUCKGRES_SCENARIO_SNI_SUFFIX: ${{ secrets.",
 		"DUCKGRES_SCENARIO_FROZEN_S3_URI: ${{ secrets.",
 		"DUCKGRES_SCENARIO_FLIGHT_ADDR: ${{ secrets.",
-		"373313242555",
-		"645773004826",
-		"posthog-duckling-perfprodus",
-		"scenario_perf_writer",
-		"perf.dw.dev.postwh.com",
+		"MW_DEV_SCENARIO_PERF_HOST",
+		"MW_DEV_SCENARIO_PERF_PORT",
+		"MW_DEV_SCENARIO_PERF_DATABASE",
+		"MW_DEV_SCENARIO_PERF_USERNAME",
+		"MW_DEV_SCENARIO_PERF_PASSWORD",
+		"postgres://",
+		"postgresql://",
+		"--dsn",
+		"--password",
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("workflow contains internal detail %q", forbidden)

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -97,7 +97,14 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"$GITHUB_STEP_SUMMARY",
 		"tests/mw-dev/run.sh diagnostics",
 		"tests/mw-dev/run.sh teardown",
-		"go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev",
+		"- name: Publish scenario perf results",
+		"github.ref == 'refs/heads/main'",
+		"MW_DEV_SCENARIO_PERF_SECRET_ID: ${{ vars.MW_DEV_SCENARIO_PERF_SECRET_ID }}",
+		"aws secretsmanager get-secret-value",
+		"go run ./cmd/duckgres-perf-publisher",
+		"--connection-secret-stdin",
+		"--schema duckgres_scenario_perf",
+		"go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev ./tests/perf/publishercli",
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("workflow missing %q", required)
@@ -128,10 +135,31 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"373313242555",
 		"645773004826",
 		"posthog-duckling-perfprodus",
+		"scenario_perf_writer",
+		"perf.dw.dev.postwh.com",
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("workflow contains internal detail %q", forbidden)
 		}
+	}
+
+	teardownIndex := strings.Index(workflow, "- name: Teardown")
+	publishPerfIndex := strings.Index(workflow, "- name: Publish scenario perf results")
+	uploadIndex := strings.Index(workflow, "- name: Upload scenario artifacts")
+	if teardownIndex < 0 || uploadIndex < teardownIndex || publishPerfIndex < uploadIndex {
+		t.Fatalf("artifact upload must run after teardown and before perf publishing")
+	}
+	for _, required := range []string{
+		"timeout-minutes: 10",
+		"mapfile -d '' perf_summaries",
+		"for perf_summary in \"${perf_summaries[@]}\"",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("perf publishing must support bounded publication of every result: missing %q", required)
+		}
+	}
+	if strings.Contains(workflow, "-path '*/perf/summary.json' -print -quit") {
+		t.Fatal("perf publishing must not silently select only the first result")
 	}
 }
 

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -157,6 +157,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"timeout-minutes: 10",
 		"mapfile -d '' perf_summaries",
 		"for perf_summary in \"${perf_summaries[@]}\"",
+		"--publish-timeout 2m",
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("perf publishing must support bounded publication of every result: missing %q", required)

--- a/tests/perf/publishercli/cli.go
+++ b/tests/perf/publishercli/cli.go
@@ -1,0 +1,128 @@
+package publishercli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/posthog/duckgres/tests/perf/publisher"
+)
+
+type Dependencies struct {
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Publish func(context.Context, publisher.Config, string) error
+}
+
+type connectionSecret struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Database string `json:"database"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func Run(ctx context.Context, args []string, deps Dependencies) error {
+	stdin := deps.Stdin
+	if stdin == nil {
+		stdin = strings.NewReader("")
+	}
+	stdout := deps.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	publish := deps.Publish
+	if publish == nil {
+		publish = publisher.PublishRunDir
+	}
+
+	flags := flag.NewFlagSet("duckgres-perf-publisher", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	runDir := flags.String("run-dir", "", "directory containing summary.json and query_results.csv")
+	dsn := flags.String("dsn", "", "publisher PGWire DSN")
+	password := flags.String("password", "", "optional password override for --dsn")
+	secretStdin := flags.Bool("connection-secret-stdin", false, "read host, port, database, username, and password JSON from stdin")
+	schema := flags.String("schema", "", "target schema (publisher default when empty)")
+	bootstrap := flags.Bool("bootstrap-schema", true, "create the target schema and tables when missing")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*runDir) == "" {
+		return errors.New("run-dir is required")
+	}
+	if (strings.TrimSpace(*dsn) == "") == !*secretStdin {
+		return errors.New("exactly one of --dsn and --connection-secret-stdin is required")
+	}
+
+	cfg := publisher.Config{
+		DSN:             strings.TrimSpace(*dsn),
+		Password:        *password,
+		Schema:          strings.TrimSpace(*schema),
+		BootstrapSchema: *bootstrap,
+	}
+	if *secretStdin {
+		secret, err := decodeConnectionSecret(stdin)
+		if err != nil {
+			return err
+		}
+		cfg.DSN = secret.dsn()
+		cfg.Password = secret.Password
+	}
+
+	if err := publish(ctx, cfg, *runDir); err != nil {
+		return fmt.Errorf("publish perf artifacts: %w", err)
+	}
+	_, _ = fmt.Fprintf(stdout, "published perf artifacts from %s\n", *runDir)
+	return nil
+}
+
+func decodeConnectionSecret(r io.Reader) (connectionSecret, error) {
+	var secret connectionSecret
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&secret); err != nil {
+		return connectionSecret{}, fmt.Errorf("decode connection secret: %w", err)
+	}
+	required := []struct {
+		name  string
+		value string
+	}{
+		{name: "host", value: secret.Host},
+		{name: "database", value: secret.Database},
+		{name: "username", value: secret.Username},
+		{name: "password", value: secret.Password},
+	}
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return connectionSecret{}, fmt.Errorf("connection secret is missing %s", field.name)
+		}
+	}
+	if secret.Port < 1 || secret.Port > 65535 {
+		return connectionSecret{}, errors.New("connection secret port must be between 1 and 65535")
+	}
+	return secret, nil
+}
+
+func (s connectionSecret) dsn() string {
+	query := url.Values{
+		"connect_timeout": {"15"},
+		"sslmode":         {"require"},
+	}
+	return (&url.URL{
+		Scheme:   "postgresql",
+		User:     url.User(s.Username),
+		Host:     net.JoinHostPort(s.Host, strconv.Itoa(s.Port)),
+		Path:     "/" + s.Database,
+		RawQuery: query.Encode(),
+	}).String()
+}

--- a/tests/perf/publishercli/cli.go
+++ b/tests/perf/publishercli/cli.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/posthog/duckgres/tests/perf/publisher"
 )
@@ -51,6 +52,7 @@ func Run(ctx context.Context, args []string, deps Dependencies) error {
 	secretStdin := flags.Bool("connection-secret-stdin", false, "read host, port, database, username, and password JSON from stdin")
 	schema := flags.String("schema", "", "target schema (publisher default when empty)")
 	bootstrap := flags.Bool("bootstrap-schema", true, "create the target schema and tables when missing")
+	publishTimeout := flags.Duration("publish-timeout", 2*time.Minute, "maximum duration for publishing one perf artifact")
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("parse flags: %w", err)
 	}
@@ -62,6 +64,9 @@ func Run(ctx context.Context, args []string, deps Dependencies) error {
 	}
 	if (strings.TrimSpace(*dsn) == "") == !*secretStdin {
 		return errors.New("exactly one of --dsn and --connection-secret-stdin is required")
+	}
+	if *publishTimeout <= 0 {
+		return errors.New("publish-timeout must be greater than zero")
 	}
 
 	cfg := publisher.Config{
@@ -79,7 +84,10 @@ func Run(ctx context.Context, args []string, deps Dependencies) error {
 		cfg.Password = secret.Password
 	}
 
-	if err := publish(ctx, cfg, *runDir); err != nil {
+	publishCtx, cancel := context.WithTimeout(ctx, *publishTimeout)
+	err := publish(publishCtx, cfg, *runDir)
+	cancel()
+	if err != nil {
 		return fmt.Errorf("publish perf artifacts: %w", err)
 	}
 	_, _ = fmt.Fprintf(stdout, "published perf artifacts from %s\n", *runDir)

--- a/tests/perf/publishercli/cli_test.go
+++ b/tests/perf/publishercli/cli_test.go
@@ -1,0 +1,103 @@
+package publishercli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/tests/perf/publisher"
+)
+
+func TestRunPublishesRunDirFromConnectionSecret(t *testing.T) {
+	t.Parallel()
+
+	var gotConfig publisher.Config
+	var gotRunDir string
+	deps := Dependencies{
+		Stdin: strings.NewReader(`{
+  "host": "perf.example.test",
+  "port": 5432,
+  "database": "ducklake",
+  "username": "scenario-writer",
+  "password": "secret value"
+}`),
+		Stdout: io.Discard,
+		Publish: func(_ context.Context, cfg publisher.Config, runDir string) error {
+			gotConfig = cfg
+			gotRunDir = runDir
+			return nil
+		},
+	}
+
+	err := Run(context.Background(), []string{
+		"--run-dir", "/artifacts/run/perf",
+		"--connection-secret-stdin",
+		"--schema", "duckgres_scenario_perf",
+		"--bootstrap-schema=true",
+	}, deps)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if gotRunDir != "/artifacts/run/perf" {
+		t.Fatalf("run dir = %q", gotRunDir)
+	}
+	if gotConfig.DSN != "postgresql://scenario-writer@perf.example.test:5432/ducklake?connect_timeout=15&sslmode=require" {
+		t.Fatalf("dsn = %q", gotConfig.DSN)
+	}
+	if gotConfig.Password != "secret value" {
+		t.Fatal("publisher password was not passed separately")
+	}
+	if gotConfig.Schema != "duckgres_scenario_perf" || !gotConfig.BootstrapSchema {
+		t.Fatalf("publisher config = %#v", gotConfig)
+	}
+}
+
+func TestRunRejectsMissingRunDir(t *testing.T) {
+	t.Parallel()
+
+	err := Run(context.Background(), []string{"--connection-secret-stdin"}, Dependencies{
+		Stdin:   strings.NewReader(`{}`),
+		Stdout:  io.Discard,
+		Publish: func(context.Context, publisher.Config, string) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "run-dir is required") {
+		t.Fatalf("expected missing run-dir error, got %v", err)
+	}
+}
+
+func TestRunRejectsIncompleteConnectionSecret(t *testing.T) {
+	t.Parallel()
+
+	err := Run(context.Background(), []string{
+		"--run-dir", "/artifacts/run/perf",
+		"--connection-secret-stdin",
+	}, Dependencies{
+		Stdin:  strings.NewReader(`{"host":"perf.example.test","port":5432}`),
+		Stdout: io.Discard,
+		Publish: func(context.Context, publisher.Config, string) error {
+			t.Fatal("publisher should not be called")
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "connection secret is missing database") {
+		t.Fatalf("expected incomplete secret error, got %v", err)
+	}
+}
+
+func TestRunRequiresExactlyOneConnectionSource(t *testing.T) {
+	t.Parallel()
+
+	err := Run(context.Background(), []string{
+		"--run-dir", "/artifacts/run/perf",
+		"--dsn", "host=localhost",
+		"--connection-secret-stdin",
+	}, Dependencies{
+		Stdin:   strings.NewReader(`{}`),
+		Stdout:  io.Discard,
+		Publish: func(context.Context, publisher.Config, string) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --dsn and --connection-secret-stdin") {
+		t.Fatalf("expected connection-source error, got %v", err)
+	}
+}

--- a/tests/perf/publishercli/cli_test.go
+++ b/tests/perf/publishercli/cli_test.go
@@ -2,6 +2,7 @@ package publishercli
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -99,5 +100,40 @@ func TestRunRequiresExactlyOneConnectionSource(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "exactly one of --dsn and --connection-secret-stdin") {
 		t.Fatalf("expected connection-source error, got %v", err)
+	}
+}
+
+func TestRunBoundsPublishingWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	err := Run(context.Background(), []string{
+		"--run-dir", "/artifacts/run/perf",
+		"--dsn", "host=localhost",
+		"--publish-timeout", "1ms",
+	}, Dependencies{
+		Stdout: io.Discard,
+		Publish: func(ctx context.Context, _ publisher.Config, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected publish deadline, got %v", err)
+	}
+}
+
+func TestRunRejectsNonPositivePublishTimeout(t *testing.T) {
+	t.Parallel()
+
+	err := Run(context.Background(), []string{
+		"--run-dir", "/artifacts/run/perf",
+		"--dsn", "host=localhost",
+		"--publish-timeout", "0s",
+	}, Dependencies{
+		Stdout:  io.Discard,
+		Publish: func(context.Context, publisher.Config, string) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "publish-timeout must be greater than zero") {
+		t.Fatalf("expected invalid publish-timeout error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- add a publish-only CLI for existing scenario performance artifacts
- accept the AWS connection JSON on stdin so the password never enters arguments, environment variables, or logs
- publish every completed perf output from scheduled or manually dispatched `main` runs
- preserve raw artifacts before publishing, bound publishing to ten minutes, and continue through independent publish failures before reporting the aggregate result
- document the repository variable and publishing behavior

## Dependency

The infrastructure secret and exact-secret IAM grant must be applied before the `main` workflow can publish: https://github.com/PostHog/posthog-cloud-infra/pull/9577

## Verification

- `go test -count=100 ./tests/perf/publishercli`
- `go test -count=1 ./cmd/duckgres-perf-publisher ./tests/perf/publishercli ./tests/perf/publisher ./tests/mw-dev/scenario ./tests/mw-dev`
- `just lint`
- independent review findings fixed; follow-up review clean
