### PR TITLE
feat(provisioner): mirror duckling metadata-store details into warehouse rows for discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -613,9 +613,12 @@ are load-bearing for those consumers:
   `TestLatestConfigChangeCoversTeamsPostgres` pins that pair; keep them in
   sync. Compare for equality only.
 - **No plaintext credentials in the payload** — metadata-store passwords are
-  k8s SecretRefs. cnpg rows currently carry only the metadata-store KIND
-  (endpoint/db/user live in the Duckling CR status until the provisioner
-  backfills the row on Ready); external rows round-trip fully.
+  k8s SecretRefs. cnpg connection details are MIRRORED from the Duckling CR
+  status into the row by the provisioner's ready-reconcile
+  (`reconcileMetadataStoreRow`; drift-only writes so steady-state ticks
+  never bump `updated_at`/the change token; the state-CAS write is the
+  reshard fence — the runner owns those columns mid-flip). External rows
+  are provision-time inputs; only their credential Secret ref is mirrored.
 - **Auth is a SEPARATE, scoped surface** (`RegisterDiscoveryAPI` + its own
   group in `multitenant.go` behind `admin.AnyTokenAuthMiddleware`): the
   read-only discovery secret (`--read-only-secret` /

--- a/controlplane/configstore/migrations/000030_add_metadata_store_secret_ref.sql
+++ b/controlplane/configstore/migrations/000030_add_metadata_store_secret_ref.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+
+-- Discovery-only mirror of the Duckling CR's metadata credential Secret
+-- reference (status.metadataStore.credentialSecretRef), written by the
+-- provisioner's ready-reconcile (reconcileMetadataStoreRow) and served on
+-- GET /api/v1/warehouses as password_secret_ref.
+--
+-- DELIBERATELY SEPARATE from metadata_store_credentials_*: that column set
+-- is a worker-activation input validated tenant-owned by
+-- ValidateManagedWarehouseSecretRefs (ref namespace must equal
+-- worker_identity.namespace, name must be org-prefixed) — the
+-- composition-owned refs the mirror carries (ducklings namespace,
+-- cnpg-tenant-<org>-password) fail that validation by design, and writing
+-- them there would break every cold worker activation.
+-- Plain nullable, matching the sibling SecretRef column sets (and the gorm
+-- model, pinned by TestConfigStoreSQLMigrationsMatchGORMModelMetadata).
+ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS metadata_store_secret_ref_namespace VARCHAR(255);
+ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS metadata_store_secret_ref_name VARCHAR(255);
+ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS metadata_store_secret_ref_key VARCHAR(255);
+
+-- +goose Down
+ALTER TABLE duckgres_managed_warehouses DROP COLUMN IF EXISTS metadata_store_secret_ref_namespace;
+ALTER TABLE duckgres_managed_warehouses DROP COLUMN IF EXISTS metadata_store_secret_ref_name;
+ALTER TABLE duckgres_managed_warehouses DROP COLUMN IF EXISTS metadata_store_secret_ref_key;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -300,6 +300,17 @@ type ManagedWarehouse struct {
 	DuckLake          ManagedWarehouseDuckLake       `gorm:"embedded;embeddedPrefix:ducklake_" json:"ducklake"`
 	WorkerIdentity    ManagedWarehouseWorkerIdentity `gorm:"embedded;embeddedPrefix:worker_identity_" json:"worker_identity"`
 
+	// MetadataStoreSecretRef is the DISCOVERY-ONLY mirror of the Duckling
+	// CR's status.metadataStore.credentialSecretRef, written by the
+	// provisioner's ready-reconcile and served as password_secret_ref on
+	// GET /api/v1/warehouses. Deliberately separate from
+	// MetadataStoreCredentials below: that column set is a worker-activation
+	// input validated tenant-owned by ValidateManagedWarehouseSecretRefs —
+	// the composition-owned refs mirrored here (ducklings namespace,
+	// cnpg-tenant-<org>-password) fail that validation by design, and
+	// writing them there breaks every cold worker activation.
+	MetadataStoreSecretRef SecretRef `gorm:"embedded;embeddedPrefix:metadata_store_secret_ref_" json:"metadata_store_secret_ref"`
+
 	WarehouseDatabaseCredentials SecretRef `gorm:"embedded;embeddedPrefix:warehouse_database_credentials_" json:"warehouse_database_credentials"`
 	MetadataStoreCredentials     SecretRef `gorm:"embedded;embeddedPrefix:metadata_store_credentials_" json:"metadata_store_credentials"`
 	S3Credentials                SecretRef `gorm:"embedded;embeddedPrefix:s3_credentials_" json:"s3_credentials"`

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -4,6 +4,7 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -452,6 +453,133 @@ func (c *Controller) reconcileReady(ctx context.Context, w *configstore.ManagedW
 	// prerequisite for shard-migration cutovers, which patch this field to a
 	// DIFFERENT shard (an explicitly operator-driven step, never done here).
 	c.reconcileCnpgShard(ctx, w, log)
+
+	// Mirror the CR-status metadata-store connection details into the
+	// warehouse row so machine consumers (the provisioning API's discovery
+	// endpoints) can serve them without a Kubernetes dependency. Same
+	// derived-output → durable-copy move as the two backfills above.
+	c.reconcileMetadataStoreRow(ctx, w, log)
+}
+
+// metadataStoreRowUpdates computes the drift between the warehouse row's
+// metadata-store block and the Duckling CR status — the row is a MIRROR of
+// the CR for cnpg tenants (the provision handler writes only the kind; the
+// composition picks the shard and publishes endpoint/database/user + the
+// credential Secret ref in status). Pure function so the sync logic is
+// testable without a cluster.
+//
+// external tenants: endpoint/database/user are provision-time INPUTS on the
+// row — never overwritten from status; only the credential Secret ref (which
+// has no provisioning-time writer for either kind) is mirrored.
+//
+// Empty status fields are never synced over non-empty row values, and an
+// empty map means "no drift" — the caller must skip the write entirely so a
+// steady-state reconcile tick doesn't bump updated_at (which would churn the
+// discovery config_generation every tick).
+//
+// A status whose metadata-store TYPE contradicts the row kind (both
+// non-empty) produces no updates at all: that's identity drift (the condition
+// recordSource refuses a reshard over), and mirroring across it would stamp
+// one store's connection details onto a row claiming the other — worse than
+// serving nothing. Either side empty is "unknown", not "mismatched" — older
+// compositions publish no status type, and a kind-less row must not silently
+// strand the secret-ref mirror.
+func metadataStoreRowUpdates(w *configstore.ManagedWarehouse, status *DucklingStatus) map[string]interface{} {
+	updates := map[string]interface{}{}
+
+	if status.MetadataStore.Type != "" && w.MetadataStore.Kind != "" &&
+		status.MetadataStore.Type != w.MetadataStore.Kind {
+		return updates
+	}
+
+	if w.MetadataStore.Kind == configstore.MetadataStoreKindCnpgShard && status.MetadataStore.Endpoint != "" {
+		if w.MetadataStore.Endpoint != status.MetadataStore.Endpoint {
+			updates["metadata_store_endpoint"] = status.MetadataStore.Endpoint
+		}
+		if status.MetadataStore.Database != "" && w.MetadataStore.DatabaseName != status.MetadataStore.Database {
+			updates["metadata_store_database_name"] = status.MetadataStore.Database
+		}
+		if status.MetadataStore.User != "" && w.MetadataStore.Username != status.MetadataStore.User {
+			updates["metadata_store_username"] = status.MetadataStore.User
+		}
+		if w.MetadataStore.Port == 0 {
+			// The CR status carries no port; cnpg pooler serves 5432.
+			updates["metadata_store_port"] = 5432
+		}
+	}
+
+	ref := status.MetadataCredentialSecretRef
+	if ref.Name != "" {
+		if ref.Namespace == "" {
+			// The composition publishes same-namespace refs without an
+			// explicit namespace; Duckling CRs live in "ducklings". A
+			// non-ducklings namespace, if ever published, is mirrored
+			// verbatim — consumers' RBAC fails closed on it.
+			ref.Namespace = ducklingNamespace
+		}
+		if ref.Key == "" {
+			// Key-less refs are a real mid-migration shape (#972's harness
+			// defaults them the same way); every credential secret uses the
+			// conventional "password" key.
+			ref.Key = "password"
+		}
+		if w.MetadataStoreSecretRef.Namespace != ref.Namespace {
+			updates["metadata_store_secret_ref_namespace"] = ref.Namespace
+		}
+		if w.MetadataStoreSecretRef.Name != ref.Name {
+			updates["metadata_store_secret_ref_name"] = ref.Name
+		}
+		if w.MetadataStoreSecretRef.Key != ref.Key {
+			updates["metadata_store_secret_ref_key"] = ref.Key
+		}
+	}
+	return updates
+}
+
+// reconcileMetadataStoreRow syncs the row's metadata-store mirror from CR
+// status. Runs ONLY from reconcileReady, and the write itself is the
+// state-CAS UpdateWarehouseState(…, Ready, …) — so a warehouse that left
+// ready mid-tick (a reshard starting) is never written: during resharding
+// the reshard runner has exclusive ownership of these columns, and the
+// post-flip transition back to ready lets the next tick mirror the new
+// store.
+func (c *Controller) reconcileMetadataStoreRow(ctx context.Context, w *configstore.ManagedWarehouse, log *slog.Logger) {
+	// Unresolved read: the mirror needs connection fields and the Secret
+	// REFERENCE only — resolving would add a Secret GET (and a plaintext
+	// credential read) per ready tick for no consumer.
+	status, err := c.duckling.GetStatusUnresolved(ctx, ducklingCRName(w))
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		log.Warn("Failed to read Duckling CR status for metadata-store row sync.", "error", err)
+		return
+	}
+
+	if status.MetadataStore.Type != "" && w.MetadataStore.Kind != "" &&
+		status.MetadataStore.Type != w.MetadataStore.Kind {
+		// The pure function suppresses all updates on this contradiction;
+		// surface it — it's the same identity drift recordSource refuses a
+		// reshard over, and it needs an operator, not silence.
+		log.Warn("Metadata-store identity drift: CR status type contradicts the row kind — mirror suppressed.",
+			"status_type", status.MetadataStore.Type, "row_kind", w.MetadataStore.Kind)
+		return
+	}
+
+	updates := metadataStoreRowUpdates(w, status)
+	if len(updates) == 0 {
+		return
+	}
+	log.Info("Mirroring metadata-store connection details from CR status into the warehouse row.",
+		"fields", len(updates))
+	if err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateReady, updates); err != nil {
+		if errors.Is(err, configstore.ErrWarehouseStateMismatch) {
+			// Left ready mid-tick (reshard starting) — the runner owns the
+			// columns now; the post-flip tick will re-sync.
+			return
+		}
+		log.Warn("Failed to mirror metadata-store details into the warehouse row.", "error", err)
+	}
 }
 
 // reconcileBucketName backfills spec.dataStore.bucketName (and the config-store

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -320,7 +320,21 @@ func (d *DucklingClient) CRStatus(ctx context.Context, name string) (present boo
 	return true, status.ReadyCondition, nil
 }
 
-// Get fetches the named Duckling CR and parses its status.
+// GetStatusUnresolved returns the parsed CR status WITHOUT resolving the
+// credential Secret — for consumers that need only the connection fields and
+// the Secret REFERENCE (the metadata-store row mirror). Skipping resolution
+// avoids one Secret GET + a plaintext credential read per call, and decouples
+// the mirror from Secret readability (endpoint/db/user need no secret).
+func (d *DucklingClient) GetStatusUnresolved(ctx context.Context, name string) (*DucklingStatus, error) {
+	cr, err := d.getCR(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("get duckling CR %q: %w", name, err)
+	}
+	return parseDucklingStatus(cr)
+}
+
+// Get fetches the named Duckling CR, parses its status, and resolves the
+// metadata credential Secret into MetadataStore.Password.
 func (d *DucklingClient) Get(ctx context.Context, name string) (*DucklingStatus, error) {
 	cr, err := d.getCR(ctx, name)
 	if err != nil {

--- a/controlplane/provisioner/metadata_store_sync_test.go
+++ b/controlplane/provisioner/metadata_store_sync_test.go
@@ -1,0 +1,202 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+func syncTestCnpgWarehouse() *configstore.ManagedWarehouse {
+	return &configstore.ManagedWarehouse{
+		OrgID: "acme",
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind: configstore.MetadataStoreKindCnpgShard,
+		},
+	}
+}
+
+func syncTestCnpgStatus() *DucklingStatus {
+	st := &DucklingStatus{}
+	st.MetadataStore.Type = configstore.MetadataStoreKindCnpgShard
+	st.MetadataStore.Endpoint = "shard-001-pooler.cnpg-shards.svc.cluster.local"
+	st.MetadataStore.Database = "mdstore_acme"
+	st.MetadataStore.User = "mdstore_acme"
+	st.MetadataCredentialSecretRef = SecretReference{
+		Namespace: "ducklings",
+		Name:      "cnpg-tenant-acme-password",
+		Key:       "password",
+	}
+	return st
+}
+
+func syncTestSteadyCnpgWarehouse() *configstore.ManagedWarehouse {
+	w := syncTestCnpgWarehouse()
+	st := syncTestCnpgStatus()
+	w.MetadataStore.Endpoint = st.MetadataStore.Endpoint
+	w.MetadataStore.DatabaseName = st.MetadataStore.Database
+	w.MetadataStore.Username = st.MetadataStore.User
+	w.MetadataStore.Port = 5432
+	w.MetadataStoreSecretRef = configstore.SecretRef{
+		Namespace: "ducklings", Name: "cnpg-tenant-acme-password", Key: "password",
+	}
+	return w
+}
+
+func TestMetadataStoreRowUpdatesCnpgFullSync(t *testing.T) {
+	updates := metadataStoreRowUpdates(syncTestCnpgWarehouse(), syncTestCnpgStatus())
+	want := map[string]interface{}{
+		"metadata_store_endpoint":             "shard-001-pooler.cnpg-shards.svc.cluster.local",
+		"metadata_store_database_name":        "mdstore_acme",
+		"metadata_store_username":             "mdstore_acme",
+		"metadata_store_port":                 5432,
+		"metadata_store_secret_ref_namespace": "ducklings",
+		"metadata_store_secret_ref_name":      "cnpg-tenant-acme-password",
+		"metadata_store_secret_ref_key":       "password",
+	}
+	if len(updates) != len(want) {
+		t.Fatalf("updates = %v, want %v", updates, want)
+	}
+	for k, v := range want {
+		if updates[k] != v {
+			t.Fatalf("updates[%s] = %v, want %v", k, updates[k], v)
+		}
+	}
+}
+
+func TestMetadataStoreRowUpdatesNeverTouchActivationCredentials(t *testing.T) {
+	// The mirror writes the DISCOVERY-ONLY metadata_store_secret_ref_*
+	// columns. metadata_store_credentials_* is a worker-activation input
+	// validated tenant-owned by ValidateManagedWarehouseSecretRefs — the
+	// composition-owned refs mirrored here fail that validation by design,
+	// and writing them there breaks every cold worker activation.
+	updates := metadataStoreRowUpdates(syncTestCnpgWarehouse(), syncTestCnpgStatus())
+	for k := range updates {
+		if k == "metadata_store_credentials_namespace" ||
+			k == "metadata_store_credentials_name" ||
+			k == "metadata_store_credentials_key" {
+			t.Fatalf("mirror must never write activation credential column %s: %v", k, updates)
+		}
+	}
+}
+
+func TestMetadataStoreRowUpdatesNoDriftIsEmpty(t *testing.T) {
+	// A steady-state reconcile tick must produce ZERO updates — a non-empty
+	// map bumps updated_at, which would churn the discovery
+	// config_generation every tick.
+	if updates := metadataStoreRowUpdates(syncTestSteadyCnpgWarehouse(), syncTestCnpgStatus()); len(updates) != 0 {
+		t.Fatalf("steady state must be a no-op, got %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesTypeDriftProducesNothing(t *testing.T) {
+	// A status whose metadata-store type contradicts the row kind is
+	// identity drift (the condition recordSource refuses a reshard over) —
+	// mirroring across it would stamp one store's connection details onto a
+	// row claiming the other. The gate must silence the WHOLE update set,
+	// secret ref included.
+	w := syncTestCnpgWarehouse()
+	st := syncTestCnpgStatus()
+	st.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	if updates := metadataStoreRowUpdates(w, st); len(updates) != 0 {
+		t.Fatalf("type drift must produce no updates, got %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesEmptyStatusTypeStillSyncs(t *testing.T) {
+	// Older compositions publish no status.metadataStore.type — the gate
+	// must not strand them (empty type is "unknown", not "mismatched").
+	st := syncTestCnpgStatus()
+	st.MetadataStore.Type = ""
+	if updates := metadataStoreRowUpdates(syncTestCnpgWarehouse(), st); len(updates) == 0 {
+		t.Fatal("empty status type must not block the mirror")
+	}
+}
+
+func TestMetadataStoreRowUpdatesEmptyRowKindStillSyncsSecretRef(t *testing.T) {
+	// A kind-less row (should not happen — the provision handler writes it,
+	// but the column is nullable) is "unknown" to the gate, not
+	// "mismatched": the secret-ref mirror must still flow. The cnpg
+	// connection block stays gated on the row EXPLICITLY claiming cnpg.
+	w := syncTestCnpgWarehouse()
+	w.MetadataStore.Kind = ""
+	updates := metadataStoreRowUpdates(w, syncTestCnpgStatus())
+	if updates["metadata_store_secret_ref_name"] != "cnpg-tenant-acme-password" {
+		t.Fatalf("empty row kind must not strand the secret-ref mirror: %v", updates)
+	}
+	if _, ok := updates["metadata_store_endpoint"]; ok {
+		t.Fatalf("connection block requires the row to claim cnpg explicitly: %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesEmptyStatusKeyDefaultsPassword(t *testing.T) {
+	// A ref with a name but no key is a real mid-migration shape (#972's
+	// harness defaults it too): the mirror must default to the conventional
+	// "password" key, never write an empty key. Against a steady row whose
+	// key IS "password", the default therefore means no-op — the drift
+	// invariant holds through the defaulting.
+	w := syncTestSteadyCnpgWarehouse()
+	st := syncTestCnpgStatus()
+	st.MetadataCredentialSecretRef.Key = ""
+	if updates := metadataStoreRowUpdates(w, st); len(updates) != 0 {
+		t.Fatalf("key-less status vs steady password-keyed row must be a no-op, got %v", updates)
+	}
+	if updates := metadataStoreRowUpdates(syncTestCnpgWarehouse(), st); updates["metadata_store_secret_ref_key"] != "password" {
+		t.Fatalf("key-less status vs empty row must default the key to password, got %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesEmptyRefNamespaceDefaultsDucklings(t *testing.T) {
+	// The composition publishes same-namespace refs without an explicit
+	// namespace field; Duckling CRs live in "ducklings". Serving an
+	// empty namespace would send consumers' Secret GETs to their OWN
+	// namespace, where the secret doesn't exist.
+	st := syncTestCnpgStatus()
+	st.MetadataCredentialSecretRef.Namespace = ""
+	updates := metadataStoreRowUpdates(syncTestCnpgWarehouse(), st)
+	if updates["metadata_store_secret_ref_namespace"] != "ducklings" {
+		t.Fatalf("empty ref namespace must default to ducklings, got %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesExternalSyncsOnlySecretRef(t *testing.T) {
+	// External stores: endpoint/db/user are provision-time INPUTS on the
+	// row — never overwritten from status. Only the credential Secret ref
+	// (no provisioning-time writer for either kind) is mirrored.
+	w := &configstore.ManagedWarehouse{
+		OrgID: "ext",
+		MetadataStore: configstore.ManagedWarehouseMetadataStore{
+			Kind:         configstore.MetadataStoreKindExternal,
+			Endpoint:     "duckling-ext.rds.example",
+			DatabaseName: "ducklingext",
+			Username:     "ducklingext",
+			Port:         5432,
+		},
+	}
+	st := &DucklingStatus{}
+	st.MetadataStore.Type = configstore.MetadataStoreKindExternal
+	st.MetadataStore.Endpoint = "something-else-derived"
+	st.MetadataCredentialSecretRef = SecretReference{
+		Namespace: "ducklings", Name: "duckling-ext-password", Key: "password",
+	}
+
+	updates := metadataStoreRowUpdates(w, st)
+	if len(updates) != 3 {
+		t.Fatalf("external must sync only the 3 secret-ref fields, got %v", updates)
+	}
+	if updates["metadata_store_secret_ref_name"] != "duckling-ext-password" {
+		t.Fatalf("secret ref name wrong: %v", updates)
+	}
+}
+
+func TestMetadataStoreRowUpdatesEmptyStatusFieldsNeverClobber(t *testing.T) {
+	// Partial/blank status (composition mid-render) must not overwrite
+	// non-empty row values or write empty strings.
+	w := syncTestSteadyCnpgWarehouse()
+	st := &DucklingStatus{} // everything empty
+	st.MetadataStore.Type = configstore.MetadataStoreKindCnpgShard
+	if updates := metadataStoreRowUpdates(w, st); len(updates) != 0 {
+		t.Fatalf("empty status must never clobber, got %v", updates)
+	}
+}

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -1325,14 +1325,22 @@ func (o *opRun) finalize(ctx context.Context) error {
 		"state":          configstore.ManagedWarehouseStateReady,
 		"status_message": "metadata-store reshard complete",
 	}
-	if o.op.TargetKind == configstore.MetadataStoreKindCnpgShard && o.op.SourceKind == configstore.MetadataStoreKindExternal {
+	if o.op.TargetKind == configstore.MetadataStoreKindCnpgShard {
+		// ALL cnpg targets (ext→cnpg AND cnpg→cnpg shard moves): clear the
+		// connection block rather than leaving the SOURCE store's mirrored
+		// details on a row that now claims the target — discovery consumers
+		// damp on an empty block, but they'd act on a stale one. The
+		// ready-reconcile mirror (reconcileMetadataStoreRow) repopulates
+		// from the post-flip CR status on the next tick.
 		updates["metadata_store_kind"] = configstore.MetadataStoreKindCnpgShard
 		updates["metadata_store_endpoint"] = ""
 		updates["metadata_store_port"] = 0
 		updates["metadata_store_database_name"] = ""
 		updates["metadata_store_username"] = ""
 		updates["metadata_store_password_aws_secret"] = ""
-		updates["pgbouncer_enabled"] = false
+		if o.op.SourceKind == configstore.MetadataStoreKindExternal {
+			updates["pgbouncer_enabled"] = false
+		}
 	}
 	if o.op.TargetKind == configstore.MetadataStoreKindExternal {
 		updates["metadata_store_kind"] = configstore.MetadataStoreKindExternal
@@ -1344,6 +1352,12 @@ func (o *opRun) finalize(ctx context.Context) error {
 		// The XRD defaults stand up a per-duckling pgbouncer for external.
 		updates["pgbouncer_enabled"] = true
 	}
+	// Both directions: the discovery-only credential Secret ref mirror
+	// (metadata_store_secret_ref_*) points at the SOURCE store's secret —
+	// stale either way. Cleared here, repopulated by the ready-reconcile.
+	updates["metadata_store_secret_ref_namespace"] = ""
+	updates["metadata_store_secret_ref_name"] = ""
+	updates["metadata_store_secret_ref_key"] = ""
 	now := time.Now().UTC()
 	if err := o.r.store.FinalizeReshardOperation(o.op.ID, o.r.cpID, o.op.RunnerEpoch, o.op.OrgID, updates, now); err != nil {
 		return fmt.Errorf("atomically finalize reshard and unblock warehouse: %w", err)

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -656,6 +656,13 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	if !store.hasLog("COPY command tags matched for 3 tables") {
 		t.Fatalf("COPY verification log missing: %v", store.logs)
 	}
+	// A cnpg→cnpg shard move must clear the row's mirrored connection block
+	// and the discovery-only secret ref — both describe the SOURCE shard;
+	// the ready-reconcile re-mirrors the target from CR status.
+	last := store.warehouseUpds[len(store.warehouseUpds)-1]
+	if last["metadata_store_endpoint"] != "" || last["metadata_store_secret_ref_name"] != "" {
+		t.Fatalf("cnpg→cnpg finalize must clear the mirrored connection block + secret ref: %v", last)
+	}
 }
 
 // TestReshardHappyPathExtToCnpg pins that an external source is NEVER
@@ -697,6 +704,9 @@ func TestReshardHappyPathExtToCnpg(t *testing.T) {
 	last := store.warehouseUpds[len(store.warehouseUpds)-1]
 	if last["metadata_store_kind"] != configstore.MetadataStoreKindCnpgShard {
 		t.Fatalf("warehouse row not reconciled to cnpg: %v", last)
+	}
+	if last["metadata_store_secret_ref_name"] != "" {
+		t.Fatalf("finalize must clear the discovery secret-ref mirror: %v", last)
 	}
 }
 
@@ -763,6 +773,9 @@ func TestReshardHappyPathCnpgToExt(t *testing.T) {
 	last := store.warehouseUpds[len(store.warehouseUpds)-1]
 	if last["metadata_store_kind"] != configstore.MetadataStoreKindExternal || last["metadata_store_endpoint"] != "escape.rds.amazonaws.com" {
 		t.Fatalf("warehouse row not reconciled to external: %v", last)
+	}
+	if last["metadata_store_secret_ref_name"] != "" {
+		t.Fatalf("finalize must clear the discovery secret-ref mirror: %v", last)
 	}
 	if !store.hasLog("COPY command tags matched for 1 tables") {
 		t.Fatalf("COPY verification log missing: %v", store.logs)

--- a/controlplane/provisioning/discovery.go
+++ b/controlplane/provisioning/discovery.go
@@ -30,13 +30,14 @@ import (
 // removal (team deleted / warehouse leaving the discoverable states).
 //
 // Metadata-store note: for Kind == "external" the connection block comes
-// straight off the warehouse row. For Kind == "cnpg-shard" the row carries
-// ONLY the kind today — the composition picks the shard and the authoritative
-// endpoint/database/user + secret live in the Duckling CR status, which the
-// provisioner does not (yet) write back to the row. Until that backfill
-// exists, cnpg tenants serve an empty connection block here; the teams
-// array and lifecycle fields are correct regardless, so team-level
-// consumers (millpond) are unaffected.
+// straight off the warehouse row (provision-time inputs). For Kind ==
+// "cnpg-shard" the composition picks the shard and publishes the
+// authoritative endpoint/database/user + credential Secret ref in the
+// Duckling CR status; the provisioner MIRRORS that into the row on the
+// ready-reconcile tick (provisioner.reconcileMetadataStoreRow), so this
+// endpoint serves it without any Kubernetes dependency. A just-turned-ready
+// warehouse may serve an empty connection block for up to one reconcile
+// interval until the mirror lands.
 
 // discoveryStates are the lifecycle states external writers must see.
 // Resharding is INCLUDED, with writable=false: if a resharding warehouse
@@ -259,10 +260,13 @@ func (h *handler) assembleDiscovery() (*discoveryResponse, error) {
 				Port:     w.MetadataStore.Port,
 				Database: w.MetadataStore.DatabaseName,
 				Username: w.MetadataStore.Username,
+				// Served from the DISCOVERY-ONLY mirror columns (see
+				// ManagedWarehouse.MetadataStoreSecretRef) — NOT the
+				// activation-validated MetadataStoreCredentials.
 				PasswordSecretRef: discoverySecretRef{
-					Namespace: w.MetadataStoreCredentials.Namespace,
-					Name:      w.MetadataStoreCredentials.Name,
-					Key:       w.MetadataStoreCredentials.Key,
+					Namespace: w.MetadataStoreSecretRef.Namespace,
+					Name:      w.MetadataStoreSecretRef.Name,
+					Key:       w.MetadataStoreSecretRef.Key,
 				},
 			},
 			Bucket: w.DataStore.BucketName,

--- a/controlplane/provisioning/discovery_test.go
+++ b/controlplane/provisioning/discovery_test.go
@@ -58,7 +58,9 @@ func seedWarehouse(s *fakeStore, orgID string, teamID *int64, state configstore.
 			// the discovery payload (see TestListWarehousesPayloadNoSecrets).
 			PasswordAWSSecret: "rds-master-secret-value",
 		},
-		MetadataStoreCredentials: configstore.SecretRef{
+		// The discovery-only mirror columns (NOT MetadataStoreCredentials,
+		// the activation-validated set) — what password_secret_ref serves.
+		MetadataStoreSecretRef: configstore.SecretRef{
 			Namespace: "ducklings",
 			Name:      "duckling-" + orgID + "-password",
 			Key:       "password",

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -253,6 +253,14 @@ blocking → draining → pausing_compaction → backup_catalog → cutover → 
    that read the new CR status; no cache invalidation needed
    (`migrationChecked` is orgID-keyed and endpoint-independent;
    `ducklake.migrations` is DSN-keyed → new endpoint = new entry).
+   The row's discovery mirror is CLEARED here, never carried across: any cnpg
+   target clears the mirrored connection block (it describes the source
+   shard), and both directions clear `metadata_store_secret_ref_*` (the
+   discovery-only credential ref mirror — see `reconcileMetadataStoreRow`).
+   The provisioner's next ready-reconcile tick repopulates them from the
+   post-flip CR status; discovery consumers damp on the momentarily-empty
+   block. During the op the CAS state fence keeps the ready-reconcile's
+   mirror write out entirely — the runner owns these columns mid-flip.
 
 ## Pre-flip catalog backup (safety net)
 

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -48,7 +48,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 27)
 	requireGooseMigrationRecorded(t, db, 28)
 	requireGooseMigrationRecorded(t, db, 29)
-	requireGooseLatestVersion(t, db, 29)
+	requireGooseMigrationRecorded(t, db, 30)
+	requireGooseLatestVersion(t, db, 30)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -203,7 +204,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -246,7 +247,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 27)
 	requireGooseMigrationRecorded(t, upgradedDB, 28)
 	requireGooseMigrationRecorded(t, upgradedDB, 29)
-	requireGooseLatestVersion(t, upgradedDB, 29)
+	requireGooseMigrationRecorded(t, upgradedDB, 30)
+	requireGooseLatestVersion(t, upgradedDB, 30)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1450,8 +1450,35 @@ discovery_endpoints() { # org team_id
     /tmp/discovery_out >/dev/null \
     || fail "discovery: $org team $team resolved table names wrong: $(cat /tmp/discovery_out)"
 
-  kind="$(jq -r --arg o "$org" '.warehouses[] | select(.org_id == $o) | .metadata_store.kind' /tmp/discovery_out)"
-  [ "$kind" = "cnpg-shard" ] || fail "discovery: $org metadata_store.kind = '$kind' want 'cnpg-shard'"
+  # cnpg metadata_store block: mirrored from the Duckling CR status by the
+  # provisioner's ready-reconcile (reconcileMetadataStoreRow), which fires on
+  # the tick AFTER the warehouse turns ready — poll briefly rather than
+  # asserting the first response. The mirror must carry the pooler endpoint,
+  # the per-tenant mdstore identifiers, and a ducklings-namespace credential
+  # Secret ref (never plaintext).
+  cnpg_ok=""
+  for _ in $(seq 1 12); do
+    # Write-through-temp so a failed curl leaves the last good payload for
+    # the failure diagnostic instead of a truncated file (|| true: transient
+    # poll failures must re-loop, not trip set -e).
+    { curl -fsS -H "$H" "$API/api/v1/warehouses" > /tmp/discovery_out.tmp \
+      && mv /tmp/discovery_out.tmp /tmp/discovery_out; } || true
+    if jq -e --arg o "$org" '
+        .warehouses[] | select(.org_id == $o) | .metadata_store
+        | .kind == "cnpg-shard"
+          and (.endpoint | test("pooler"))
+          and (.database | startswith("mdstore_"))
+          and (.username | startswith("mdstore_"))
+          and .port == 5432
+          and .password_secret_ref.namespace == "ducklings"
+          and (.password_secret_ref.name | length > 0)
+          and .password_secret_ref.key == "password"
+      ' /tmp/discovery_out >/dev/null; then
+      cnpg_ok=1; break
+    fi
+    sleep 10
+  done
+  [ -n "$cnpg_ok" ]     || fail "discovery: $org metadata_store block never mirrored from CR status: $(jq --arg o "$org" '.warehouses[] | select(.org_id == $o) | .metadata_store' /tmp/discovery_out)"
 
   # No password material: the only key containing "password" anywhere in the
   # payload must be password_secret_ref (k8s Secret reference, not material).
@@ -2715,6 +2742,25 @@ reshard_dump_log() { # opid — the log TAIL (where the failure/report lands)
   reshard_log_fetch "$1" | tail -30 || true
 }
 
+discovery_metadata_converged() { # org — poll until discovery serves writable=true + a complete cnpg mirror block
+  # Post-reshard convergence: whatever the op did to the row (rollback leaves
+  # the mirror untouched; a successful finalize clears it for the
+  # ready-reconcile to repopulate), the discovery surface must end up serving
+  # writable=true with the FULL metadata_store mirror again.
+  for _ in $(seq 1 18); do
+    if curl -fsS -H "$H" "$API/api/v1/warehouses" 2>/dev/null | jq -e --arg o "$1" '
+        .warehouses[] | select(.org_id == $o)
+        | .writable == true and .metadata_store.kind == "cnpg-shard"
+          and (.metadata_store.endpoint | test("pooler"))
+          and (.metadata_store.password_secret_ref.name | length > 0)
+      ' >/dev/null; then
+      return 0
+    fi
+    sleep 10
+  done
+  fail "discovery: $1 metadata_store mirror never re-converged after the reshard op: $(curl -fsS -H "$H" "$API/api/v1/warehouses" | jq --arg o "$1" '.warehouses[] | select(.org_id == $o)')"
+}
+
 reshard_targets() { # destination discovery response shape
   log "reshard targets: destination discovery"
   out="$(curl -fsS -H "$H" "$API/api/v1/reshards/targets")" \
@@ -2813,6 +2859,13 @@ reshard_cancel_during_drain() { # org password
   echo "$out2" | grep -qi "reshard" \
     || fail "reshard cancel: blocked-connection error did not mention reshard: $out2"
 
+  # The discovery fence: while resharding, polling external writers must see
+  # writable=false — until the lease protocol exists this flag is their ONLY
+  # fence, so it must flip with the state, not lag it.
+  curl -fsS -H "$H" "$API/api/v1/warehouses" | jq -e --arg o "$org" \
+    '.warehouses[] | select(.org_id == $o) | .state == "resharding" and .writable == false' >/dev/null \
+    || fail "reshard cancel: discovery must report $org resharding/writable=false during the op"
+
   curl -fsS -X POST -H "$H" "$API/api/v1/reshards/$opid/cancel" >/dev/null \
     || fail "reshard cancel: cancel POST failed"
   st="$(reshard_wait_terminal "$opid" 300)"
@@ -2823,6 +2876,7 @@ reshard_cancel_during_drain() { # org password
   wait "$holder" 2>/dev/null || true
   [ "$(state_of "$org")" = "ready" ] || fail "reshard cancel: warehouse state $(state_of "$org"), want ready"
   pg "$org" "$pw" ducklake "SELECT 1" >/dev/null
+  discovery_metadata_converged "$org"
   log "reshard cancel OK (op $opid)"
 }
 
@@ -2860,6 +2914,7 @@ reshard_bogus_shard_rollback() { # org password
   got="$(pg "$org" "$pw" ducklake "SELECT v FROM reshard_marker")"
   echo "$got" | grep -q 42 || fail "reshard rollback: marker data lost (got '$got')"
   pg "$org" "$pw" ducklake "DROP TABLE reshard_marker;"
+  discovery_metadata_converged "$org"
   log "reshard rollback OK (op $opid)"
 }
 


### PR DESCRIPTION
## Why

cnpg warehouse rows carry only the metadata-store **kind** — the composition picks the shard and publishes endpoint/database/user + the credential Secret ref in the Duckling CR status, and nothing wrote them back to the row. The discovery endpoints (#966) therefore serve an empty connection block for every cnpg tenant: prod viaduck currently skips **10/10** warehouses with `no_metadata_store`.

## What

- **Ready-reconcile mirror** (`reconcileMetadataStoreRow`): cnpg tenants get the full connection block mirrored from CR status; both kinds get the credential Secret ref (#972's `status.metadataStore.credentialSecretRef`, copied verbatim).
- **New discovery-only columns** `metadata_store_secret_ref_*` (migration 000030), deliberately separate from the activation-validated `metadata_store_credentials_*` — composition-owned ducklings-namespace refs would fail `ValidateManagedWarehouseSecretRefs` and break cold worker activation if written there. Discovery serves `password_secret_ref` from the mirror.
- **Sync semantics** (pure `metadataStoreRowUpdates`, unit-pinned): drift-only writes (steady-state ticks never bump `updated_at` → no `config_generation` churn); empty status never clobbers; namespace defaults to `ducklings`, key to `password`; a status type contradicting a non-empty row kind suppresses everything and logs (identity drift). The write is the state-CAS `UpdateWarehouseState(Ready)` — the reshard runner owns these columns mid-flip.
- **Reshard finalize clears the mirror** instead of carrying it: all cnpg targets clear the connection block (previously only ext→cnpg — a cnpg→cnpg shard move left the *source* shard's details on the row), both directions clear the secret ref; the next ready tick repopulates. Rollback leaves the mirror intact.
- **`GetStatusUnresolved`**: CR read without the Secret GET for the mirror path.
- **e2e**: discovery polls for the full cnpg mirror block; reshard cancel asserts discovery `writable=false` mid-drain (the only external-writer fence today); cancel + rollback assert post-op convergence.

## Rollout notes

- External tenants' `password_secret_ref` previously served `metadata_store_credentials_*`, which has **no production writer** (dev seed SQL only) — prod already serves empty there; the mirror populates within one 10s reconcile tick of deploy.
- Never-mirrored by design: rows with empty `metadata_store_kind`, and discovery-visible warehouses with no Duckling CR. Worth a one-time prod check: `SELECT org_id FROM duckgres_managed_warehouses WHERE metadata_store_kind = '' AND state = 'ready'`.

## Follow-ups (deliberate)

- Consolidate the now-4 uncached CR GETs per ready warehouse per tick into one fetch.
- Ext-lane e2e coverage left with #979; the external mirror branch is unit-covered.