### PR TITLE
feat(metrics): org/team/duckling identity info-metrics for dashboards

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -569,6 +569,18 @@ type OrgTeamConfig struct {
 // (stale snapshot / mid-provision): a committed org always has at least one
 // team (provision requires one, DeleteOrgTeamTx keeps the last).
 func (oc *OrgConfig) OldestTeamID() int64 {
+	best := oc.OldestTeam()
+	if best == nil {
+		return 0
+	}
+	return best.TeamID
+}
+
+// OldestTeam returns the org's oldest team row under OldestTeamID's exact
+// ordering (min created_at, ties broken by the smaller team_id), or nil when
+// the org has no team rows. Shared by the org-info metric so its per-org
+// representative team matches the id usage buckets already stamp.
+func (oc *OrgConfig) OldestTeam() *OrgTeamConfig {
 	var best *OrgTeamConfig
 	for i := range oc.Teams {
 		t := &oc.Teams[i]
@@ -578,15 +590,19 @@ func (oc *OrgConfig) OldestTeamID() int64 {
 			best = t
 		}
 	}
-	if best == nil {
-		return 0
-	}
-	return best.TeamID
+	return best
 }
 
 // ManagedWarehouseConfig is the in-memory snapshot view of an org's warehouse metadata.
 type ManagedWarehouseConfig struct {
 	OrgID string
+
+	// DucklingName is the k8s Duckling CR name (and therefore the prefix of
+	// every composed per-tenant resource, e.g. the <name>-compaction
+	// maintenance CronJob). NOT derivable from OrgID: legacy tenants
+	// stripped uuid hyphens, newer ones keep them. Carried in the snapshot
+	// as the org-teams info metric's join key.
+	DucklingName string
 
 	Image           string
 	DuckLakeVersion string
@@ -619,6 +635,7 @@ func copyManagedWarehouseConfig(warehouse *ManagedWarehouse) *ManagedWarehouseCo
 
 	cfg := &ManagedWarehouseConfig{
 		OrgID:                        warehouse.OrgID,
+		DucklingName:                 warehouse.DucklingName,
 		Image:                        warehouse.Image,
 		DuckLakeVersion:              warehouse.DuckLakeVersion,
 		WarehouseDatabase:            warehouse.WarehouseDatabase,

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -193,6 +193,10 @@ func SetupMultiTenant(
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
+	// Identity info-metric for dashboards (org ↔ team ↔ duckling). Reads the
+	// snapshot at scrape time — registered here where the concrete store is
+	// in hand (the interface returned upward deliberately hides Snapshot).
+	registerOrgTeamsInfoMetric(store)
 
 	// Per-user persistent secret manager (CREATE PERSISTENT SECRET). With no
 	// key configured the manager still loads so DROP can clean up stale rows,

--- a/controlplane/org_teams_info_metric.go
+++ b/controlplane/org_teams_info_metric.go
@@ -1,0 +1,134 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// Org ↔ team ↔ duckling identity mapping as info-style metrics (constant
+// value 1), so dashboards can render human meaning onto resources that only
+// carry duckling names — e.g. the composition-stamped maintenance CronJobs
+// (cronjob = "<duckling>-compaction").
+//
+// TWO shapes, because PromQL join direction dictates which is usable where
+// (both verified against the real engine — a multi-team org on the "one"
+// side of group_left is a hard many-to-many error that poisons the whole
+// panel, and NOT expressible around with topk):
+//
+//   - duckgres_org_info: ONE series per org, team_id/schema_name from the
+//     org's oldest team (OldestTeam — the same representative-team semantics
+//     usage buckets stamp). Safe as the "one" side of a kube-left join:
+//
+//     max by (duckling) (label_replace(
+//       kube_cronjob_status_last_successful_time{cronjob=~".+-compaction"},
+//       "duckling", "$1", "cronjob", "(.+)-compaction"))
+//     * on (duckling) group_left(team_id, schema_name)
+//       duckgres_org_info{duckling!=""}
+//
+//   - duckgres_org_teams_info: one series per (org, team) — the complete,
+//     truthful mapping. NEVER put it on the "one" side of a duckling join;
+//     use it as the many/left side instead:
+//
+//     duckgres_org_teams_info{duckling!=""}
+//     * on (duckling) group_left() max by (duckling) (label_replace(...))
+//
+// Every duckling-keyed join MUST filter {duckling!=""} on the info side and
+// anchor the kube side's regex (cronjob=~".+-compaction"): label_replace
+// keeps non-matching series with duckling="", which otherwise cross-matches
+// the warehouse-less orgs' rows — silently attributing an unrelated
+// cronjob's value to them.
+//
+// Labels use `org` per the repo's per-org metric convention
+// (duckgres_org_sessions_active etc.), so `on (org)` decoration of existing
+// metrics needs no label_replace shim. The duckling label is the k8s join
+// key and comes from the warehouse row's DucklingName — NOT derivable from
+// org id (legacy tenants stripped uuid hyphens; newer ones keep them).
+// Orgs without a live warehouse (none, or state=deleted — the row lingers
+// after deprovision until an admin purge) emit duckling="" so the org/team
+// mapping stays complete without pointing at torn-down infra.
+//
+// Read from the in-memory config snapshot at scrape time: zero database
+// access, always as fresh as the snapshot poller; series for removed
+// orgs/teams vanish on the next scrape by construction. Duplicate label
+// sets (which would fail the ENTIRE /metrics scrape) are structurally
+// impossible: Orgs is keyed by org id and (org_id, team_id) is the
+// duckgres_org_teams primary key.
+
+type orgTeamsSnapshotter interface {
+	Snapshot() *configstore.Snapshot
+}
+
+type orgTeamsInfoCollector struct {
+	store    orgTeamsSnapshotter
+	teamDesc *prometheus.Desc
+	orgDesc  *prometheus.Desc
+}
+
+func newOrgTeamsInfoCollector(store orgTeamsSnapshotter) *orgTeamsInfoCollector {
+	labels := []string{"org", "duckling", "team_id", "schema_name"}
+	return &orgTeamsInfoCollector{
+		store: store,
+		teamDesc: prometheus.NewDesc(
+			"duckgres_org_teams_info",
+			"Org/team/duckling identity mapping, one series per team (constant 1). Join key material for dashboards — see org_teams_info_metric.go for the safe join shapes",
+			labels, nil,
+		),
+		orgDesc: prometheus.NewDesc(
+			"duckgres_org_info",
+			"Org/duckling identity mapping, one series per org with the oldest team as representative (constant 1). Safe one-side for group_left joins",
+			labels, nil,
+		),
+	}
+}
+
+func (c *orgTeamsInfoCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.teamDesc
+	ch <- c.orgDesc
+}
+
+func (c *orgTeamsInfoCollector) Collect(ch chan<- prometheus.Metric) {
+	snap := c.store.Snapshot()
+	if snap == nil {
+		return
+	}
+	for orgID, org := range snap.Orgs {
+		if org == nil {
+			continue
+		}
+		duckling := ""
+		if org.Warehouse != nil && org.Warehouse.State != configstore.ManagedWarehouseStateDeleted {
+			duckling = org.Warehouse.DucklingName
+		}
+		for _, t := range org.Teams {
+			ch <- prometheus.MustNewConstMetric(
+				c.teamDesc, prometheus.GaugeValue, 1,
+				orgID, duckling, strconv.FormatInt(t.TeamID, 10), t.SchemaName,
+			)
+		}
+		if oldest := org.OldestTeam(); oldest != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.orgDesc, prometheus.GaugeValue, 1,
+				orgID, duckling, strconv.FormatInt(oldest.TeamID, 10), oldest.SchemaName,
+			)
+		}
+	}
+}
+
+// registerOrgTeamsInfoMetric registers the collector on the default registry.
+// First registration wins: an AlreadyRegistered error is ignored (defensive
+// only — SetupMultiTenant has a single call site per process), anything else
+// is a programming error and panics like promauto would.
+func registerOrgTeamsInfoMetric(store orgTeamsSnapshotter) {
+	if err := prometheus.Register(newOrgTeamsInfoCollector(store)); err != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+	}
+}

--- a/controlplane/org_teams_info_metric_test.go
+++ b/controlplane/org_teams_info_metric_test.go
@@ -1,0 +1,93 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+type stubSnapshotter struct{ snap *configstore.Snapshot }
+
+func (s *stubSnapshotter) Snapshot() *configstore.Snapshot { return s.snap }
+
+func TestOrgTeamsInfoCollector(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snap := &configstore.Snapshot{
+		Orgs: map[string]*configstore.OrgConfig{
+			// Legacy tenant: duckling name is the org id with hyphens
+			// stripped — the case that makes the label non-derivable.
+			"4dc8564d-bd82-1065-2f40-97f7c50f67cf": {
+				Teams: []configstore.OrgTeamConfig{
+					{TeamID: 2, SchemaName: "team_2", CreatedAt: t0},
+				},
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "4dc8564dbd8210652f4097f7c50f67cf",
+					State:        configstore.ManagedWarehouseStateReady,
+				},
+			},
+			// Multi-team org: teams metric emits one series per team; org
+			// metric emits ONE row carrying the OLDEST team (created
+			// earlier wins even with a higher id — OldestTeam ordering).
+			"org-multi": {
+				Teams: []configstore.OrgTeamConfig{
+					{TeamID: 10, SchemaName: "team_10", CreatedAt: t0.Add(time.Hour)},
+					{TeamID: 11, SchemaName: "team_11", CreatedAt: t0},
+				},
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-multi",
+					State:        configstore.ManagedWarehouseStateReady,
+				},
+			},
+			// No warehouse row: mapping still emitted, empty duckling.
+			"org-legacy": {
+				Teams: []configstore.OrgTeamConfig{
+					{TeamID: 7, SchemaName: "team_7", CreatedAt: t0},
+				},
+			},
+			// Deprovisioned: the warehouse row lingers at state=deleted
+			// until an admin purge — must NOT point at torn-down infra.
+			"org-deleted": {
+				Teams: []configstore.OrgTeamConfig{
+					{TeamID: 9, SchemaName: "team_9", CreatedAt: t0},
+				},
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-deleted",
+					State:        configstore.ManagedWarehouseStateDeleted,
+				},
+			},
+		},
+	}
+
+	want := `# HELP duckgres_org_info Org/duckling identity mapping, one series per org with the oldest team as representative (constant 1). Safe one-side for group_left joins
+# TYPE duckgres_org_info gauge
+duckgres_org_info{duckling="",org="org-deleted",schema_name="team_9",team_id="9"} 1
+duckgres_org_info{duckling="",org="org-legacy",schema_name="team_7",team_id="7"} 1
+duckgres_org_info{duckling="4dc8564dbd8210652f4097f7c50f67cf",org="4dc8564d-bd82-1065-2f40-97f7c50f67cf",schema_name="team_2",team_id="2"} 1
+duckgres_org_info{duckling="org-multi",org="org-multi",schema_name="team_11",team_id="11"} 1
+# HELP duckgres_org_teams_info Org/team/duckling identity mapping, one series per team (constant 1). Join key material for dashboards — see org_teams_info_metric.go for the safe join shapes
+# TYPE duckgres_org_teams_info gauge
+duckgres_org_teams_info{duckling="",org="org-deleted",schema_name="team_9",team_id="9"} 1
+duckgres_org_teams_info{duckling="",org="org-legacy",schema_name="team_7",team_id="7"} 1
+duckgres_org_teams_info{duckling="4dc8564dbd8210652f4097f7c50f67cf",org="4dc8564d-bd82-1065-2f40-97f7c50f67cf",schema_name="team_2",team_id="2"} 1
+duckgres_org_teams_info{duckling="org-multi",org="org-multi",schema_name="team_10",team_id="10"} 1
+duckgres_org_teams_info{duckling="org-multi",org="org-multi",schema_name="team_11",team_id="11"} 1
+`
+	c := newOrgTeamsInfoCollector(&stubSnapshotter{snap: snap})
+	if err := testutil.CollectAndCompare(c, strings.NewReader(want)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOrgTeamsInfoCollectorNilSnapshot(t *testing.T) {
+	// Pre-first-load scrape (startup race): no series, no panic.
+	c := newOrgTeamsInfoCollector(&stubSnapshotter{snap: nil})
+	if n := testutil.CollectAndCount(c); n != 0 {
+		t.Fatalf("nil snapshot must emit nothing, got %d series", n)
+	}
+}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2047,7 +2047,9 @@ admin_console_api() {
   # Includes the per-org/per-source worker-acquire-latency panels. (The raw
   # histogram emission — org+source labels on duckgres_worker_acquire_total_seconds
   # — is unit-tested, not asserted here: the :9090 metrics port is
-  # NetworkPolicy-blocked from this in-cluster Job.)
+  # NetworkPolicy-blocked from this in-cluster Job. Same carve-out for the
+  # duckgres_org_info / duckgres_org_teams_info identity metrics:
+  # exposition pinned by TestOrgTeamsInfoCollector.)
   panels="$(curl -fsS -H "$H" "$API/api/v1/metrics/panels")"
   for p in query_rate acquire_p95 acquire_by_source; do
     echo "$panels" | jq -e --arg p "$p" '.panels | index($p)' >/dev/null \


### PR DESCRIPTION
## Why

The composition-stamped maintenance CronJobs (and every composed per-tenant resource) carry only duckling names — org uuids, sometimes hyphen-stripped — so dashboards show unreadable GUIDs with no team mapping. The org↔team mapping lives only in `duckgres_org_teams`.

## What

Info-style metrics (constant 1) from a custom collector over the in-memory config snapshot — zero DB access per scrape, series lifecycle follows the snapshot:

- **`duckgres_org_info`**: one series per org, `team_id`/`schema_name` from the org's oldest team (`OldestTeam`, extracted from `OldestTeamID` — the same representative-team semantics usage buckets stamp). The safe **one-side** for `group_left` joins from kube metrics.
- **`duckgres_org_teams_info`**: one series per (org, team) — the complete mapping, **many-side only**. A multi-team org on the one-side of `group_left` is a hard many-to-many error that poisons the whole panel — verified against the real Prometheus engine during review, which is why both shapes exist. Verified join recipes are documented in-file.
- `duckling` label = the k8s join key from the warehouse row's `DucklingName` (added to the snapshot view); not derivable from org id (legacy tenants stripped uuid hyphens). No live warehouse (none, or `state=deleted` lingering post-deprovision) → `duckling=""`; joins must filter `{duckling!=""}` and anchor the cronjob regex — the empty-label cross-match hazard is documented in-file.
- Labels use `org` per the repo's per-org metric convention (renamed from `org_id` pre-ship, before any dashboard depends on it).

## How did you test this code?

Authored by an agent; adversarial QE + SWE review agents ran empirical verification:
- Builds/vet/tests green on both build-tag lanes; gofmt clean; exposition pinned by `TestOrgTeamsInfoCollector` (legacy hyphen-stripped duckling, multi-team ordering, warehouse-less, deleted-state cases).
- Probes (run then deleted): double-registration non-panic via `errors.As` on the real registry; race detector on Collect vs snapshot swaps; end-to-end `promhttp` scrape; nil/empty edge cases; duplicate-labelset Gather behavior (impossible today — `(org_id, team_id)` PK — documented in-file).
- PromQL join semantics tested against the Prometheus engine (`promqltest`): multi-team one-side failure, empty-duckling cross-match, safe shapes.
- e2e: `:9090` is NetworkPolicy-blocked from the in-cluster Job — explicit carve-out note added beside the existing acquire-histogram precedent.