### PR TITLE
feat(metrics): classify query status and reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ labels, aggregation rules, PromQL examples, and admission metric migration.
 |--------|------|-------------|
 | `duckgres_connections_open` | Gauge | Number of currently open client connections |
 | `duckgres_connection_duration_seconds{org}` | Histogram | Client connection lifetime, accept→disconnect (includes `_count`, `_sum`, `_bucket`); `_sum` is exact total connection-seconds (per org) with no scrape-integral bias. The disconnect log also carries `duration_ms` |
-| `duckgres_query_total{org,outcome}` | Counter | Total number of non-empty query attempts by terminal outcome (`success`, `error`, `canceled`) |
+| `duckgres_query_total{org,status,reason}` | Counter | Total non-empty query attempts. Valid status/reason pairs: `success/none`; `failure/user`, `failure/canceled`, `failure/conflict`; `error/metadata_connection_lost`, `error/system`. |
 | `duckgres_query_duration_seconds{org}` | Histogram | Simple/extended query execution latency (includes `_count`, `_sum`, `_bucket`); use `duckgres_query_total` for attempt totals |
 | `duckgres_auth_failures_total` | Counter | Total number of authentication failures |
 | `duckgres_rate_limit_rejects_total` | Counter | Total number of connections rejected due to rate limiting |

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -122,7 +122,7 @@ in the org's session accounting. Rows capped at `maxImpersonationRows`.
 Not an open PromQL relay: the client passes a panel KEY (+ optional org/window);
 the PromQL is built server-side from the allow-list (`rangePanels`). Forwards to
 `DUCKGRES_PROMETHEUS_URL` (the in-cluster VictoriaMetrics vmselect, Prometheus-
-compatible). Org-labelled panels (`duckgres_query_total{org,outcome}` etc.) keep
+compatible). Org-labelled panels (`duckgres_query_total{org,status,reason}` etc.) keep
 slicing enforced. Unset URL → 503 so the UI shows "metrics not configured".
 
 ## Local UI development

--- a/controlplane/admin/metrics_proxy.go
+++ b/controlplane/admin/metrics_proxy.go
@@ -36,11 +36,11 @@ func NewMetricsProxy(promURL string) *MetricsProxy {
 
 // panel maps a stable key to a PromQL template with named tokens substituted
 // server-side: $ORG = org label selector (e.g. {org="x"}, empty when no org),
-// $ORGERR = the same scoped to outcome="error", $WIN = rate window. A token
+// $ORGERR = the same scoped to status="error", $WIN = rate window. A token
 // replacer (not positional fmt) is used so a template that omits a token is
 // rendered cleanly — no surplus-argument corruption.
 var rangePanels = map[string]string{
-	"query_rate":      `sum by (outcome) (rate(duckgres_query_total$ORG[$WIN]))`,
+	"query_rate":      `sum by (status, reason) (rate(duckgres_query_total$ORG[$WIN]))`,
 	"error_ratio":     `sum(rate(duckgres_query_total$ORGERR[$WIN])) / clamp_min(sum(rate(duckgres_query_total$ORG[$WIN])), 1)`,
 	"duration_p95":    `histogram_quantile(0.95, sum by (le) (rate(duckgres_query_duration_seconds_bucket$ORG[$WIN])))`,
 	"duration_p50":    `histogram_quantile(0.50, sum by (le) (rate(duckgres_query_duration_seconds_bucket$ORG[$WIN])))`,
@@ -92,10 +92,10 @@ func (m *MetricsProxy) queryRange(c *gin.Context) {
 	// Org selectors: exact-match label selectors, empty (cluster-wide) when no
 	// org is given. orgErrSel additionally scopes to failed queries.
 	orgSel := ""
-	orgErrSel := `{outcome="error"}`
+	orgErrSel := `{status="error"}`
 	if org := c.Query("org"); org != "" {
 		orgSel = fmt.Sprintf(`{org=%q}`, org)
-		orgErrSel = fmt.Sprintf(`{org=%q,outcome="error"}`, org)
+		orgErrSel = fmt.Sprintf(`{org=%q,status="error"}`, org)
 	}
 	rateWindow := c.DefaultQuery("rate_window", "5m")
 	if d, err := time.ParseDuration(rateWindow); err != nil || d <= 0 {

--- a/controlplane/admin/metrics_proxy_test.go
+++ b/controlplane/admin/metrics_proxy_test.go
@@ -12,8 +12,8 @@ import (
 // broke worker_states / queue_depth).
 func TestRenderPanelNoCorruption(t *testing.T) {
 	for _, org := range []struct{ sel, errSel string }{
-		{"", `{outcome="error"}`},
-		{`{org="acme"}`, `{org="acme",outcome="error"}`},
+		{"", `{status="error"}`},
+		{`{org="acme"}`, `{org="acme",status="error"}`},
 	} {
 		for key, tmpl := range rangePanels {
 			got := renderPanel(tmpl, org.sel, org.errSel, "5m")
@@ -27,17 +27,17 @@ func TestRenderPanelNoCorruption(t *testing.T) {
 	}
 }
 
-// error_ratio's numerator must filter outcome="error" and differ from the
+// error_ratio's numerator must filter status="error" and differ from the
 // denominator base (regression: it previously used the same org-only selector
 // for both, always reporting ~100%).
 func TestErrorRatioFiltersErrors(t *testing.T) {
-	got := renderPanel(rangePanels["error_ratio"], `{org="acme"}`, `{org="acme",outcome="error"}`, "5m")
-	if !strings.Contains(got, `outcome="error"`) {
+	got := renderPanel(rangePanels["error_ratio"], `{org="acme"}`, `{org="acme",status="error"}`, "5m")
+	if !strings.Contains(got, `status="error"`) {
 		t.Fatalf("error_ratio numerator does not filter errors: %s", got)
 	}
-	// Denominator (after the division) must NOT carry outcome="error".
+	// Denominator (after the division) must NOT carry status="error".
 	parts := strings.SplitN(got, "/", 2)
-	if len(parts) != 2 || strings.Contains(parts[1], `outcome="error"`) {
+	if len(parts) != 2 || strings.Contains(parts[1], `status="error"`) {
 		t.Fatalf("error_ratio denominator unexpectedly scoped to errors: %s", got)
 	}
 }

--- a/controlplane/admin/ui/src/lib/format.test.ts
+++ b/controlplane/admin/ui/src/lib/format.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { fmtCompact, fmtMetricAxis, fmtMetricValue, orgLabel } from "./format";
+import { fmtCompact, fmtMetricAxis, fmtMetricValue, orgLabel, promToSeries } from "./format";
+
+describe("promToSeries", () => {
+  it("names query series by status and reason", () => {
+    const series = promToSeries({
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [{ metric: { status: "failure", reason: "user" }, values: [[1, "2"]] }],
+      },
+    });
+    expect(series[0]?.name).toBe("failure/user");
+  });
+});
 
 describe("fmtCompact", () => {
   it("renders compact SI so large numbers don't overflow an axis", () => {

--- a/controlplane/admin/ui/src/lib/format.ts
+++ b/controlplane/admin/ui/src/lib/format.ts
@@ -5,14 +5,16 @@ import type { MetricSeries, PromRangeResponse } from "@/types/api";
 // promToSeries flattens a raw Prometheus/VictoriaMetrics `matrix` range response
 // into chart-ready named series. Values arrive as [unixSeconds, "stringValue"];
 // we convert to { t: ms, v: number }. A series is named by its most meaningful
-// label (outcome/state/quantile) or the full label set.
+// label (status/reason/state/quantile) or the full label set.
 export function promToSeries(resp: PromRangeResponse | undefined): MetricSeries[] {
   const result = resp?.data?.result;
   if (!result || !Array.isArray(result)) return [];
   return result.map((r, i) => {
     const labels = r.metric ?? {};
     const name =
-      labels.outcome ??
+      (labels.status && labels.reason ? `${labels.status}/${labels.reason}` : undefined) ??
+      labels.status ??
+      labels.reason ??
       labels.state ??
       labels.quantile ??
       labels.le ??

--- a/controlplane/admin/ui/src/pages/Metrics.tsx
+++ b/controlplane/admin/ui/src/pages/Metrics.tsx
@@ -22,7 +22,7 @@ const COLORS = ["#22d3ee", "#f59e0b", "#a78bfa", "#34d399", "#f472b6", "#60a5fa"
 
 // Allow-listed panel keys (admin/metrics_proxy.go rangePanels) + presentation.
 const PANELS: { key: string; title: string; unit: string }[] = [
-  { key: "query_rate", title: "Query rate by outcome", unit: "ops/s" },
+  { key: "query_rate", title: "Query rate by status and reason", unit: "ops/s" },
   { key: "error_ratio", title: "Error ratio", unit: "" },
   { key: "duration_p95", title: "Query duration p95", unit: "s" },
   { key: "duration_p50", title: "Query duration p50", unit: "s" },

--- a/controlplane/admin/ui/src/pages/Overview.tsx
+++ b/controlplane/admin/ui/src/pages/Overview.tsx
@@ -38,8 +38,8 @@ export function Overview() {
   const activeCPs = cpRows.filter((r) => (r.state ?? "").toLowerCase() === "active").length;
 
   // Derive a query-rate sparkline + error% from the `query_rate` panel (a
-  // per-second rate labeled by outcome). Each point is ops/s, so we average
-  // across the window per outcome rather than diffing a counter.
+  // per-second rate labeled by status and reason). Each point is ops/s, so we
+  // average across the window per status rather than diffing a counter.
   const { rateSeries, errorPct } = useMemo(() => {
     const series = promToSeries(qTotal.data);
     if (series.length === 0) return { rateSeries: [] as number[], errorPct: null as number | null };
@@ -47,9 +47,9 @@ export function Overview() {
     let error = 0;
     const totalByT = new Map<number, number>();
     for (const s of series) {
-      const outcome = s.labels?.outcome ?? "";
+      const status = s.labels?.status ?? "";
       const avg = s.points.length ? s.points.reduce((n, p) => n + p.v, 0) / s.points.length : 0;
-      if (outcome === "error" || outcome === "failure") error += avg;
+      if (status === "error") error += avg;
       else success += avg;
       for (const p of s.points) totalByT.set(p.t, (totalByT.get(p.t) ?? 0) + p.v);
     }

--- a/docs/design/admin-ui.md
+++ b/docs/design/admin-ui.md
@@ -58,7 +58,7 @@ The admin package currently sees only the narrow `OrgStackInfo`
 `GET /api/v1/metrics/query` and `/api/v1/metrics/query_range` forward to
 `PROMETHEUS_URL` (`DUCKGRES_PROMETHEUS_URL` env). Allow-list the metric names we chart so
 the proxy is not an open PromQL relay. Org-labelled metrics we expose:
-`duckgres_query_total{org,outcome}` (error/success rate — the gold metric),
+`duckgres_query_total{org,status,reason}` (error/success rate — the gold metric),
 `duckgres_query_duration_seconds{org}`, `duckgres_org_sessions_active{org}`,
 `duckgres_org_worker_crashes_total{org}`, `duckgres_s3_bytes_read_total{org}`,
 `duckgres_scan_*{org}`. Fleet (no org label): worker lifecycle/spawn/reap/queue/cap-drift.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -110,7 +110,7 @@ The Kubernetes worker allocator keeps its existing names:
 | `duckgres_worker_acquire_total_seconds` | `org`, `source`, `outcome` | End-to-end worker allocation latency after admission. Sources are `idle_reuse`, `hot_idle_claim`, `spawn`, or `none`. |
 | `duckgres_worker_acquire_gate_wait_seconds` | `org`, `outcome` | Time waiting for the per-org FIFO worker-acquire gate. |
 | `duckgres_worker_acquire_phase_seconds` | `org`, `phase`, `outcome` | Individual `hot_idle_claim`, `spawn`, or `activate` phase latency. |
-| `duckgres_query_total` | `org`, `outcome` | One event per non-empty query attempt; outcomes are `success`, `error`, or `canceled`. |
+| `duckgres_query_total` | `org`, `status`, `reason` | One event per non-empty query attempt. Valid pairs: `success/none`; `failure/user`, `failure/canceled`, `failure/conflict`; `error/metadata_connection_lost`, `error/system`. |
 | `duckgres_query_duration_seconds` | `org` | Query execution latency. Use `duckgres_query_total` for terminal result counts. |
 
 The older fleet-level `duckgres_control_plane_worker_*` metrics remain useful

--- a/grafana/dashboards/duckgres.json
+++ b/grafana/dashboards/duckgres.json
@@ -261,7 +261,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(duckgres_query_total{outcome=\"error\"}[5m]))",
+          "expr": "sum(rate(duckgres_query_total{status=\"error\"}[5m]))",
           "legendFormat": "Errors/s",
           "refId": "A"
         }

--- a/metrics-compose.yml
+++ b/metrics-compose.yml
@@ -9,7 +9,7 @@
 #
 # Available metrics:
 #   - duckgres_connections_open: current number of open connections
-#   - duckgres_query_total: counter of query attempts by terminal outcome
+#   - duckgres_query_total: counter of query attempts by terminal status and reason
 #   - duckgres_query_duration_seconds: histogram of query execution latencies
 #   - duckgres_perf_query_duration_seconds: per-query perf harness latency histograms
 #

--- a/scripts/test_metrics.sh
+++ b/scripts/test_metrics.sh
@@ -27,7 +27,7 @@ PGPASSWORD=postgres psql "host=127.0.0.1 port=$PORT user=postgres sslmode=requir
 # Check metrics
 METRICS=$(curl -s "http://localhost:$METRICS_PORT/metrics")
 QUERY_COUNT=$(echo "$METRICS" | awk '/^duckgres_query_duration_seconds_count/ {sum += $2} END {print sum}')
-QUERY_SUCCESS_TOTAL=$(echo "$METRICS" | awk '/^duckgres_query_total\{.*outcome="success"/ {sum += $2} END {print sum}')
+QUERY_SUCCESS_TOTAL=$(echo "$METRICS" | awk '/^duckgres_query_total\{.*status="success"/ {sum += $2} END {print sum}')
 
 if [ -z "$QUERY_COUNT" ]; then
     echo "FAIL: could not find 'duckgres_query_duration_seconds_count' metric in metrics output"
@@ -46,7 +46,7 @@ else
 fi
 
 if [ -z "$QUERY_SUCCESS_TOTAL" ]; then
-    echo "FAIL: could not find 'duckgres_query_total{outcome=\"success\"}' metric in metrics output"
+    echo "FAIL: could not find 'duckgres_query_total{status=\"success\",reason=\"none\"}' metric in metrics output"
     exit 1
 fi
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -502,19 +502,16 @@ func (c *clientConn) logQueryError(query string, err error) {
 		"query", redactedQuery,
 		"error", redactedErr,
 	}
-	// category mirrors the severity routing below so the dashboard can split
-	// user-attributable failures from genuine system errors per org.
-	var category string
-	switch {
-	case isDuckLakeTransactionConflict(err):
-		category = "conflict"
-	case isDuckLakeMetadataConnectionLost(err):
-		category = "metadata_connection_lost"
-	case isUserQueryError(err):
-		category = "user"
-	default:
-		category = "system"
-	}
+	// This shared category also drives query metrics, analytics, and the
+	// recent-error ring so the observability surfaces cannot disagree.
+	category := queryErrorCategory(err)
+	// Preserve the category on the terminal query metric. Some protocol paths
+	// send an ErrorResponse and then return nil after handling it, so
+	// finishQueryMetrics cannot recover conflict/metadata reasons from the
+	// return value alone. Cancellations reaching this function are infra-driven
+	// (caller cancellations are gated upstream), so use the category rather
+	// than the generic cancellation shortcut in markError.
+	c.markActiveQueryMetricsErrorCategory(category)
 	sqlState := classifyErrorCode(err)
 	traceID := observe.TraceIDFromContext(c.ctx)
 	// Per-org product analytics. No SQL text or secrets are sent — only the

--- a/server/conn_errors.go
+++ b/server/conn_errors.go
@@ -262,6 +262,14 @@ var userErrorSQLSTATEClasses = map[string]struct{}{
 	"44": {}, // with_check_option_violation
 }
 
+func isUserQueryErrorCode(code string) bool {
+	if len(code) < 2 {
+		return false
+	}
+	_, ok := userErrorSQLSTATEClasses[code[:2]]
+	return ok
+}
+
 // isUserQueryError tells the log/observability path whether a query
 // failure is user-attributable (Info-level "Query execution failed.")
 // or a real system error worth alerting on (Error-level "Query
@@ -279,12 +287,23 @@ func isUserQueryError(err error) bool {
 	if err == nil {
 		return false
 	}
-	code := classifyErrorCode(err)
-	if len(code) < 2 {
-		return false
+	return isUserQueryErrorCode(classifyErrorCode(err))
+}
+
+// queryErrorCategory is the single classification used by logs, analytics,
+// the admin recent-error ring, and query metrics. Keep the values stable:
+// they are an observability API consumed outside this package.
+func queryErrorCategory(err error) string {
+	switch {
+	case isDuckLakeTransactionConflict(err):
+		return "conflict"
+	case isDuckLakeMetadataConnectionLost(err):
+		return "metadata_connection_lost"
+	case isUserQueryError(err):
+		return "user"
+	default:
+		return "system"
 	}
-	_, ok := userErrorSQLSTATEClasses[code[:2]]
-	return ok
 }
 
 // isConnectionBroken checks if an error indicates a broken connection

--- a/server/query_metrics.go
+++ b/server/query_metrics.go
@@ -7,23 +7,32 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type queryOutcome string
+type queryStatus string
+type queryReason string
 
 const (
-	queryOutcomeSuccess  queryOutcome = "success"
-	queryOutcomeError    queryOutcome = "error"
-	queryOutcomeCanceled queryOutcome = "canceled"
+	queryStatusSuccess queryStatus = "success"
+	queryStatusFailure queryStatus = "failure"
+	queryStatusError   queryStatus = "error"
+
+	queryReasonNone                   queryReason = "none"
+	queryReasonUser                   queryReason = "user"
+	queryReasonCanceled               queryReason = "canceled"
+	queryReasonConflict               queryReason = "conflict"
+	queryReasonMetadataConnectionLost queryReason = "metadata_connection_lost"
+	queryReasonSystem                 queryReason = "system"
 )
 
 var queryTotalCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "duckgres_query_total",
-	Help: "Total number of non-empty query attempts partitioned by terminal outcome.",
-}, []string{"org", "outcome"})
+	Help: "Total number of non-empty query attempts partitioned by terminal status and reason.",
+}, []string{"org", "status", "reason"})
 
 type queryMetricsScope struct {
 	start              time.Time
 	errorResponsesSent uint64
-	outcome            queryOutcome
+	status             queryStatus
+	reason             queryReason
 	previous           *queryMetricsScope
 }
 
@@ -31,7 +40,8 @@ func (c *clientConn) beginQueryMetrics(start time.Time) *queryMetricsScope {
 	scope := &queryMetricsScope{
 		start:              start,
 		errorResponsesSent: c.errorResponsesSent,
-		outcome:            queryOutcomeSuccess,
+		status:             queryStatusSuccess,
+		reason:             queryReasonNone,
 		previous:           c.activeQueryMetrics,
 	}
 	c.activeQueryMetrics = scope
@@ -47,11 +57,11 @@ func (c *clientConn) finishQueryMetrics(scope *queryMetricsScope) {
 
 	queryDurationHistogram.WithLabelValues(c.orgID).Observe(time.Since(scope.start).Seconds())
 
-	outcome := scope.outcome
-	if outcome == queryOutcomeSuccess && c.errorResponsesSent > scope.errorResponsesSent {
-		outcome = queryOutcomeFromErrorCode(c.lastErrorCode)
+	status, reason := scope.status, scope.reason
+	if status == queryStatusSuccess && c.errorResponsesSent > scope.errorResponsesSent {
+		status, reason = queryResultFromErrorCode(c.lastErrorCode)
 	}
-	observeQueryOutcome(c.orgID, outcome)
+	observeQueryResult(c.orgID, status, reason)
 
 	if c.activeQueryMetrics == scope {
 		c.activeQueryMetrics = scope.previous
@@ -63,10 +73,18 @@ func (s *queryMetricsScope) markError(err error) {
 		return
 	}
 	if isQueryCancelled(err) {
-		s.outcome = queryOutcomeCanceled
+		s.status = queryStatusFailure
+		s.reason = queryReasonCanceled
 		return
 	}
-	s.outcome = queryOutcomeError
+	s.status, s.reason = queryResultFromErrorCategory(queryErrorCategory(err))
+}
+
+func (s *queryMetricsScope) markErrorCategory(category string) {
+	if s == nil {
+		return
+	}
+	s.status, s.reason = queryResultFromErrorCategory(category)
 }
 
 func (c *clientConn) markActiveQueryMetricsError(err error) {
@@ -76,24 +94,63 @@ func (c *clientConn) markActiveQueryMetricsError(err error) {
 	c.activeQueryMetrics.markError(err)
 }
 
-func queryOutcomeFromErrorCode(code string) queryOutcome {
-	if code == "57014" {
-		return queryOutcomeCanceled
+func (c *clientConn) markActiveQueryMetricsErrorCategory(category string) {
+	if c == nil || c.activeQueryMetrics == nil {
+		return
 	}
-	return queryOutcomeError
+	c.activeQueryMetrics.markErrorCategory(category)
 }
 
-func observeQueryOutcome(org string, outcome queryOutcome) {
-	switch outcome {
-	case queryOutcomeSuccess, queryOutcomeError, queryOutcomeCanceled:
+func queryResultFromErrorCode(code string) (queryStatus, queryReason) {
+	if code == "57014" {
+		return queryStatusFailure, queryReasonCanceled
+	}
+	if isUserQueryErrorCode(code) {
+		return queryStatusFailure, queryReasonUser
+	}
+	return queryStatusError, queryReasonSystem
+}
+
+func queryResultFromErrorCategory(category string) (queryStatus, queryReason) {
+	switch category {
+	case "user":
+		return queryStatusFailure, queryReasonUser
+	case "conflict":
+		return queryStatusFailure, queryReasonConflict
+	case "metadata_connection_lost":
+		return queryStatusError, queryReasonMetadataConnectionLost
 	default:
-		outcome = queryOutcomeError
+		return queryStatusError, queryReasonSystem
+	}
+}
+
+func observeQueryResult(org string, status queryStatus, reason queryReason) {
+	switch status {
+	case queryStatusSuccess:
+		reason = queryReasonNone
+	case queryStatusFailure:
+		switch reason {
+		case queryReasonUser, queryReasonCanceled, queryReasonConflict:
+		default:
+			status = queryStatusError
+			reason = queryReasonSystem
+		}
+	case queryStatusError:
+		switch reason {
+		case queryReasonMetadataConnectionLost, queryReasonSystem:
+		default:
+			reason = queryReasonSystem
+		}
+	default:
+		status = queryStatusError
+		reason = queryReasonSystem
 	}
 
-	queryTotalCounter.WithLabelValues(org, string(outcome)).Inc()
+	queryTotalCounter.WithLabelValues(org, string(status), string(reason)).Inc()
 }
 
 func (c *clientConn) observeExtendedParseQueryError(code, message string) {
 	c.sendError("ERROR", code, message)
-	observeQueryOutcome(c.orgID, queryOutcomeError)
+	status, reason := queryResultFromErrorCode(code)
+	observeQueryResult(c.orgID, status, reason)
 }

--- a/server/query_metrics_test.go
+++ b/server/query_metrics_test.go
@@ -42,45 +42,87 @@ func serverHistogramVecSampleCount(t *testing.T, hv *prometheus.HistogramVec, la
 	return m.GetHistogram().GetSampleCount()
 }
 
-func TestObserveQueryOutcomeIncrementsCanonicalCounter(t *testing.T) {
+func TestObserveQueryResultIncrementsCanonicalCounter(t *testing.T) {
 	org := "query-metrics-outcomes"
 
-	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
-	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled))
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem))
+	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonCanceled))
 
-	observeQueryOutcome(org, queryOutcomeSuccess)
-	observeQueryOutcome(org, queryOutcomeError)
-	observeQueryOutcome(org, queryOutcomeCanceled)
+	observeQueryResult(org, queryStatusSuccess, queryReasonNone)
+	observeQueryResult(org, queryStatusError, queryReasonSystem)
+	observeQueryResult(org, queryStatusFailure, queryReasonCanceled)
 
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore+1 {
 		t.Fatalf("success query total = %v, want %v", got, successBefore+1)
 	}
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem)); got != errorBefore+1 {
 		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 	}
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled)); got != canceledBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonCanceled)); got != canceledBefore+1 {
 		t.Fatalf("canceled query total = %v, want %v", got, canceledBefore+1)
 	}
 }
 
-func TestFinishQueryMetricsClassifiesCanceledOutcomeSeparately(t *testing.T) {
+func TestQueryResultClassificationUsesStatusAndReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		category   string
+		wantStatus queryStatus
+		wantReason queryReason
+	}{
+		{name: "user", category: "user", wantStatus: queryStatusFailure, wantReason: queryReasonUser},
+		{name: "conflict", category: "conflict", wantStatus: queryStatusFailure, wantReason: queryReasonConflict},
+		{name: "metadata", category: "metadata_connection_lost", wantStatus: queryStatusError, wantReason: queryReasonMetadataConnectionLost},
+		{name: "system", category: "system", wantStatus: queryStatusError, wantReason: queryReasonSystem},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, reason := queryResultFromErrorCategory(tt.category)
+			if status != tt.wantStatus || reason != tt.wantReason {
+				t.Fatalf("result = (%q, %q), want (%q, %q)", status, reason, tt.wantStatus, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestQueryResultFromSQLState(t *testing.T) {
+	tests := []struct {
+		code       string
+		wantStatus queryStatus
+		wantReason queryReason
+	}{
+		{code: "42601", wantStatus: queryStatusFailure, wantReason: queryReasonUser},
+		{code: "57014", wantStatus: queryStatusFailure, wantReason: queryReasonCanceled},
+		{code: "XX000", wantStatus: queryStatusError, wantReason: queryReasonSystem},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			status, reason := queryResultFromErrorCode(tt.code)
+			if status != tt.wantStatus || reason != tt.wantReason {
+				t.Fatalf("result = (%q, %q), want (%q, %q)", status, reason, tt.wantStatus, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestFinishQueryMetricsClassifiesCanceledStatusSeparately(t *testing.T) {
 	org := "query-metrics-canceled"
 	c := &clientConn{orgID: org}
 	scope := c.beginQueryMetrics(time.Now())
 
-	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled))
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+	canceledBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonCanceled))
 	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
 
 	c.lastErrorCode = "57014"
 	c.errorResponsesSent = scope.errorResponsesSent + 1
 	c.finishQueryMetrics(scope)
 
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore {
 		t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
 	}
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeCanceled)); got != canceledBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonCanceled)); got != canceledBefore+1 {
 		t.Fatalf("canceled query total = %v, want %v", got, canceledBefore+1)
 	}
 	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
@@ -88,16 +130,16 @@ func TestFinishQueryMetricsClassifiesCanceledOutcomeSeparately(t *testing.T) {
 	}
 }
 
-func TestFinishQueryMetricsClassifiesSuccessAndErrorOutcomes(t *testing.T) {
+func TestFinishQueryMetricsClassifiesSuccessAndErrorStatusesAndReasons(t *testing.T) {
 	successOrg := "query-metrics-finish-success"
 	successConn := &clientConn{orgID: successOrg}
 	successScope := successConn.beginQueryMetrics(time.Now())
-	successBefore := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryOutcomeSuccess))
+	successBefore := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryStatusSuccess), string(queryReasonNone))
 	successDurationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, successOrg)
 
 	successConn.finishQueryMetrics(successScope)
 
-	if got := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryOutcomeSuccess)); got != successBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, successOrg, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore+1 {
 		t.Fatalf("success query total = %v, want %v", got, successBefore+1)
 	}
 	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, successOrg); got != successDurationBefore+1 {
@@ -107,13 +149,13 @@ func TestFinishQueryMetricsClassifiesSuccessAndErrorOutcomes(t *testing.T) {
 	errorOrg := "query-metrics-finish-error"
 	errorConn := &clientConn{orgID: errorOrg}
 	errorScope := errorConn.beginQueryMetrics(time.Now())
-	errorBefore := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryOutcomeError))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryStatusFailure), string(queryReasonUser))
 
 	errorConn.lastErrorCode = "42P01"
 	errorConn.errorResponsesSent = errorScope.errorResponsesSent + 1
 	errorConn.finishQueryMetrics(errorScope)
 
-	if got := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryOutcomeError)); got != errorBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, errorOrg, string(queryStatusFailure), string(queryReasonUser)); got != errorBefore+1 {
 		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 	}
 }
@@ -126,14 +168,14 @@ func TestQueryMetricsWrapSimpleAndExtendedEntryPoints(t *testing.T) {
 		c.orgID = org
 		c.executor = &lifecycleExecutor{execResult: emptyExecResult{}}
 
-		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
 		durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
 
 		if err := c.handleQuery([]byte("UPDATE foo SET x = 1\x00")); err != nil {
 			t.Fatalf("handleQuery: %v", err)
 		}
 
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore+1 {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore+1 {
 			t.Fatalf("success query total = %v, want %v", got, successBefore+1)
 		}
 		if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
@@ -152,14 +194,14 @@ func TestQueryMetricsWrapSimpleAndExtendedEntryPoints(t *testing.T) {
 			convertedQuery: "UPDATE missing SET x = 1",
 		}}
 
-		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonUser))
 		durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
 
 		body := append([]byte("p1"), 0)
 		body = append(body, 0, 0, 0, 0)
 		c.handleExecute(body)
 
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonUser)); got != errorBefore+1 {
 			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 		}
 		if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
@@ -175,7 +217,7 @@ func TestQueryMetricsCountExtendedParseQueryErrorsWithoutDuration(t *testing.T) 
 	c.orgID = org
 	c.executor = &pipelineRecordingExecutor{}
 
-	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonUser))
 	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
 
 	var body bytes.Buffer
@@ -188,7 +230,7 @@ func TestQueryMetricsCountExtendedParseQueryErrorsWithoutDuration(t *testing.T) 
 
 	c.handleParse(body.Bytes())
 
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusFailure), string(queryReasonUser)); got != errorBefore+1 {
 		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 	}
 	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore {
@@ -210,18 +252,18 @@ func TestQueryMetricsClassifiesSimpleWireWriteFailureAsError(t *testing.T) {
 		},
 	}
 
-	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+	successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+	errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem))
 	durationBefore := serverHistogramVecSampleCount(t, queryDurationHistogram, org)
 
 	if err := c.handleQuery([]byte("SELECT 'hello'\x00")); err == nil {
 		t.Fatal("handleQuery returned nil error, want pgwire write failure")
 	}
 
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore {
 		t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
 	}
-	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+	if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem)); got != errorBefore+1 {
 		t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 	}
 	if got := serverHistogramVecSampleCount(t, queryDurationHistogram, org); got != durationBefore+1 {
@@ -238,17 +280,17 @@ func TestQueryMetricsClassifiesTerminalWireWriteFailureAsError(t *testing.T) {
 		c.writer = bufio.NewWriterSize(failingWriter{err: errors.New("write tcp: broken pipe")}, 16)
 		c.executor = &lifecycleExecutor{execResult: &fakeExecResult{rowsAffected: 123456789012345678}}
 
-		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem))
 
 		if err := c.handleQuery([]byte("UPDATE foo SET x = 1\x00")); err != nil {
 			t.Fatalf("handleQuery: %v", err)
 		}
 
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore {
 			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
 		}
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem)); got != errorBefore+1 {
 			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 		}
 	})
@@ -265,17 +307,17 @@ func TestQueryMetricsClassifiesTerminalWireWriteFailureAsError(t *testing.T) {
 			convertedQuery: "UPDATE foo SET x = 1",
 		}}
 
-		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem))
 
 		body := append([]byte("p1"), 0)
 		body = append(body, 0, 0, 0, 0)
 		c.handleExecute(body)
 
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore {
 			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
 		}
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem)); got != errorBefore+1 {
 			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 		}
 	})
@@ -292,24 +334,24 @@ func TestQueryMetricsClassifiesTerminalWireWriteFailureAsError(t *testing.T) {
 			convertedQuery: "UPDATE foo SET x = 1",
 		}}
 
-		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess))
-		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError))
+		successBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone))
+		errorBefore := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem))
 
 		body := append([]byte("p1"), 0)
 		body = append(body, 0, 0, 0, 0)
 		c.handleExecute(body)
 
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeSuccess)); got != successBefore {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusSuccess), string(queryReasonNone)); got != successBefore {
 			t.Fatalf("success query total = %v, want unchanged %v", got, successBefore)
 		}
-		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryOutcomeError)); got != errorBefore+1 {
+		if got := serverCounterVecValue(t, queryTotalCounter, org, string(queryStatusError), string(queryReasonSystem)); got != errorBefore+1 {
 			t.Fatalf("error query total = %v, want %v", got, errorBefore+1)
 		}
 	})
 }
 
 func TestQueryErrorsLegacyMetricRemoved(t *testing.T) {
-	observeQueryOutcome("query-metrics-no-legacy-errors", queryOutcomeError)
+	observeQueryResult("query-metrics-no-legacy-errors", queryStatusError, queryReasonSystem)
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2047,9 +2047,10 @@ admin_console_api() {
   # Includes the per-org/per-source worker-acquire-latency panels. (The raw
   # histogram emission — org+source labels on duckgres_worker_acquire_total_seconds
   # — is unit-tested, not asserted here: the :9090 metrics port is
-  # NetworkPolicy-blocked from this in-cluster Job. Same carve-out for the
-  # duckgres_org_info / duckgres_org_teams_info identity metrics:
-  # exposition pinned by TestOrgTeamsInfoCollector.)
+  # NetworkPolicy-blocked from this in-cluster Job. The same carve-out covers
+  # duckgres_query_total's status+reason labels (pinned by query_metrics_test.go)
+  # and the duckgres_org_info / duckgres_org_teams_info identity metrics
+  # (exposition pinned by TestOrgTeamsInfoCollector).
   panels="$(curl -fsS -H "$H" "$API/api/v1/metrics/panels")"
   for p in query_rate acquire_p95 acquire_by_source; do
     echo "$panels" | jq -e --arg p "$p" '.panels | index($p)' >/dev/null \


### PR DESCRIPTION
## Summary

Classify `duckgres_query_total` with a bounded `status` and `reason` vocabulary so operational errors can be alerted on without counting expected user failures.

- replace `outcome` with `status=success|failure|error` and a canonical `reason`
- share one error classifier across logs, analytics, recent errors, and metrics
- preserve protocol-path classifications where an error response is handled before the query returns
- update the admin UI, metrics proxy, dashboard, documentation, and metric smoke checks

The resulting combinations are:

- `success/none`
- `failure/user`
- `failure/canceled`
- `failure/conflict`
- `error/metadata_connection_lost`
- `error/system`

## Testing

- `go test ./server`
- `go test -tags kubernetes ./controlplane/admin -run 'Test.*Metrics|TestRenderPanel'`
- admin UI typecheck, 77 tests, and production build
- `git diff --check`

The full local admin package includes integration tests that require its Postgres fixture; those could not authenticate to the local fixture. The focused metrics and panel tests pass.

## Rollout

The companion charts PR, PostHog/charts#13587, supports old `outcome="error"` and new `status="error"` series simultaneously during rollout and rollback.

## Agent context

Authored with Codex. The classification deliberately separates expected failures from operational errors while keeping the label values bounded.
