### PR TITLE
fix(controlplane): retire worker after drain cleanup failure

### DIFF
--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -659,16 +659,22 @@ func (sm *SessionManager) cleanupUnregisteredWorkerSession(worker *ManagedWorker
 		_ = session.Executor.Close()
 	}
 	if worker != nil {
+		var destroyErr error
 		select {
 		case <-worker.done:
 		default:
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := worker.DestroySession(ctx, session.SessionToken); err != nil {
-				sm.log.Warn("Failed to destroy unregistered worker session during drain.", "worker", worker.ID, "error", err)
+			destroyErr = worker.DestroySession(ctx, session.SessionToken)
+			if destroyErr != nil {
+				sm.log.Warn("Failed to destroy unregistered worker session during drain.", "worker", worker.ID, "error", destroyErr)
 			}
 			cancel()
 		}
-		sm.pool.ReleaseWorker(worker.ID)
+		if destroyErr != nil {
+			sm.pool.RetireWorker(worker.ID)
+		} else {
+			sm.pool.ReleaseWorker(worker.ID)
+		}
 	}
 }
 

--- a/controlplane/session_mgr_drain_test.go
+++ b/controlplane/session_mgr_drain_test.go
@@ -297,16 +297,22 @@ func (s *reconnectRuntimeStore) TryAcquireOrgConnectionLeaseForRef(ref configsto
 }
 
 type blockingCreateSessionPool struct {
-	worker *ManagedWorker
+	worker       *ManagedWorker
+	releaseCalls atomic.Int32
+	retireCalls  atomic.Int32
 }
 
 func (p *blockingCreateSessionPool) AcquireWorker(ctx context.Context, _ *WorkerProfile) (*ManagedWorker, error) {
 	return p.worker, nil
 }
 
-func (p *blockingCreateSessionPool) ReleaseWorker(id int) {}
+func (p *blockingCreateSessionPool) ReleaseWorker(id int) {
+	p.releaseCalls.Add(1)
+}
 
-func (p *blockingCreateSessionPool) RetireWorker(id int) {}
+func (p *blockingCreateSessionPool) RetireWorker(id int) {
+	p.retireCalls.Add(1)
+}
 
 func (p *blockingCreateSessionPool) RetireWorkerIfNoSessions(id int) bool {
 	return false
@@ -898,6 +904,62 @@ func TestDestroyAllSessionsRejectsInFlightCreateBeforeRegistration(t *testing.T)
 	}
 	if got := flightClient.destroyCalls.Load(); got != 1 {
 		t.Fatalf("expected worker session to be destroyed once, got %d", got)
+	}
+}
+
+func TestDestroyAllSessionsRetiresWorkerWhenUnregisteredSessionCleanupTimesOut(t *testing.T) {
+	flightClient := &blockingCreateSessionFlightClient{
+		createStarted:   make(chan struct{}),
+		allowCreate:     make(chan struct{}),
+		createSucceeded: make(chan struct{}),
+		destroyRecvErr:  context.DeadlineExceeded,
+	}
+	worker := &ManagedWorker{
+		ID:     7,
+		client: &flightsql.Client{Client: flightClient},
+		done:   make(chan struct{}),
+	}
+	pool := &blockingCreateSessionPool{worker: worker}
+	sm := NewSessionManager(pool, nil)
+
+	createErr := make(chan error, 1)
+	go func() {
+		_, _, err := sm.CreateSessionWithProtocol(context.Background(), "root", 1010, "", 0, "postgres", nil)
+		createErr <- err
+	}()
+
+	select {
+	case <-flightClient.createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for CreateSession RPC to start")
+	}
+
+	sm.mu.Lock()
+	close(flightClient.allowCreate)
+	select {
+	case <-flightClient.createSucceeded:
+	case <-time.After(time.Second):
+		sm.mu.Unlock()
+		t.Fatal("timed out waiting for worker CreateSession to succeed")
+	}
+	go sm.BeginDrain()
+	waitForSessionManagerDraining(t, sm)
+	sm.mu.Unlock()
+
+	select {
+	case err := <-createErr:
+		if !errors.Is(err, ErrSessionManagerDraining) {
+			t.Fatalf("CreateSessionWithProtocol error = %v, want %v", err, ErrSessionManagerDraining)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for CreateSession to return")
+	}
+
+	if got := pool.releaseCalls.Load(); got != 0 {
+		t.Fatalf("ReleaseWorker calls = %d after timed-out cleanup, want 0", got)
+	}
+	if got := pool.retireCalls.Load(); got != 1 {
+		t.Fatalf("RetireWorker calls = %d after timed-out cleanup, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- retire workers when cleanup of a newly created but unregistered session fails during drain
- release workers only after successful cleanup or when they are already dead
- add a deterministic regression test for the drain-versus-registration race

## Why

Drain can close the session lifecycle after worker-side session creation succeeds but before the control plane registers the session. If the compensating DestroySession RPC times out, worker-side cleanup may still own the worker’s sole database connection. Releasing that worker makes it schedulable and can cause the next session to time out acquiring the connection.

## Red/green

Before the fix, the regression test consistently reported:

```text
ReleaseWorker calls = 1 after timed-out cleanup, want 0
```

After the fix, it observes one retirement and no release. Adjacent cleanup timeout and successful drain-race tests also pass.

## Test plan

- focused control-plane regression and adjacent lifecycle tests
- `just lint` (0 issues)