### PR TITLE
feat: per-session S3 cache bypass (SET duckgres.s3_cache = off)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,52 @@ release lets shutdown kill live work); `reapIdle` releases tokens stranded by a
 `GetFlightInfo` whose `DoGet` never arrived. `terminationGracePeriodSeconds=3600`
 (`k8s_pool.go`) must stay above `workerShutdownDrainTime` (55m).
 
+## Per-Session S3 Cache Bypass (`duckgres.s3_cache`, remote backend)
+
+`SET duckgres.s3_cache = on|off` (default `on`; also a `-c` startup option)
+lets a session bypass the node-local S3 cache-proxy DaemonSet — for cold-read
+benchmarking and ruling the cache out of correctness/staleness questions.
+Mechanism: the CP intercepts the duckgres-namespaced GUC (never forwarded to
+DuckDB) and, on every state flip, calls the worker's `SetSessionS3Cache`
+action (`flightclient.FlightExecutor.SetS3CacheEnabled` →
+`SessionPool.SetS3CacheEnabled`), which rebuilds the `ducklake_s3` secret:
+`off` = the org's native HTTPS transport, so httpfs CONNECT-tunnels through
+the proxy as opaque TLS (no cache reads/fills — the deliberate, reversible
+form of the mw-prod-us 2026-07-17 incident); `on` = the
+`overrideS3EndpointForCacheProxy` transport. Global `http_proxy` is never
+touched (post-attach propagation to DuckLake subcatalogs is unreliable;
+secrets are consulted per request). Instance-global secret + one session per
+worker = session-scoped in effect. Invariants:
+
+- **State follows the worker, never leads it.** The session flag
+  (`clientConn.s3CacheOff`) flips only after the worker swap succeeds; a
+  failed swap fails the SET (`XX000`) / the batch / the connect (startup
+  option), so `SHOW` can never report a transport the worker isn't using.
+- **A bypass must never leak into the org's next session.** `CreateSession`
+  restores the proxy transport before the session starts and a restore
+  failure fails the create (CP retries); `DestroySession` restores
+  best-effort. Both no-op unless a bypass is actually in effect.
+- **Credential rotation respects the flag.** The hot-idle/mid-session refresh
+  (`reuseExistingActivation`) rebuilds the secret with or without the proxy
+  transport according to `s3CacheBypassed`; all secret rebuilds serialize on
+  `secretSwapMu` so the last write always matches the flag. (Without this, an
+  hourly STS rotation silently re-enables the cache mid-benchmark — the
+  inverse of the 2026-07-17 incident.)
+- **Closed enum, validated on every set path** (`transform.NormalizeS3Cache`):
+  PostgreSQL boolean spellings, normalized to on/off; anything else is `22023`
+  (simple/batched SET, extended Parse, and the startup option — which the CP
+  validates BEFORE acquiring a worker). The rejection never echoes the value.
+- **Scope: remote/k8s shared-warm workers with a cache proxy.** Elsewhere
+  (standalone, process backend, no `DUCKGRES_CACHE_ENABLED`) the worker swap
+  is a no-op and the GUC is session-state only — there is no cache to bypass.
+  The query-log sink's activation stays proxied unconditionally.
+- Touching the interception, swap, restore, or refresh interplay → update
+  `transpiler/s3_cache_test.go`, `server/s3_cache_test.go`,
+  `duckdbservice/s3_cache_test.go`, AND the `s3_cache_guc` assertion in
+  `tests/mw-dev/e2e/harness.sh` (mw-dev has no cache proxy, so the e2e covers
+  the client-visible plumbing incl. the worker action round-trip; the swap
+  itself is unit-only — see the harness header note).
+
 ## User Persistent Secrets (multitenant remote backend)
 
 `CREATE PERSISTENT SECRET` from a client survives across sessions and worker

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1159,12 +1159,28 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		_ = writer.Flush()
 		return
 	}
+
 	for _, w := range profileWarns {
 		clog.Warn("Adjusted worker profile.", "detail", w)
 	}
 	if orgProfileApplied && workerProfile != nil {
 		// Once per connection so support can see which shape a tenant got.
 		clog.Info("Applied org default worker profile.", "cpu", workerProfile.CPU, "memory", workerProfile.Memory, "ttl", workerProfile.TTL.String())
+	}
+
+	// Validate a `-c duckgres.s3_cache=...` startup option BEFORE acquiring a
+	// worker (same early-reject treatment as an invalid duckgres.worker_*
+	// option). The option is applied after the session executor is bound,
+	// below — application swaps the worker's S3 secret transport off the
+	// node-local cache proxy for this session.
+	rawS3Cache, s3CacheRequested := startupOptions[server.S3CacheGUCName]
+	if s3CacheRequested {
+		if err := server.ValidateS3CacheOption(rawS3Cache); err != nil {
+			clog.Warn("Rejected s3_cache startup option.", "error", err)
+			_ = server.WriteErrorResponse(writer, "FATAL", "22023", err.Error())
+			_ = writer.Flush()
+			return
+		}
 	}
 
 	// Resolve the session manager and rebalancer for this connection.
@@ -1487,6 +1503,18 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	server.SetCatalogUseRewrite(cc, duckLakeAttached && !passthroughUser)
 	server.SetPassthrough(cc, passthroughUser)
 	server.SetQueryAccessPolicy(cc, queryAccessPolicy)
+	// Apply the connect-time `-c duckgres.s3_cache=...` option (validated
+	// before worker acquisition, above) now that the session executor is
+	// bound. Failure refuses the connection: a session that asked for
+	// s3_cache=off must never silently run through the cache.
+	if s3CacheRequested {
+		if err := server.ApplyConnectionS3CacheOption(cc, rawS3Cache); err != nil {
+			clog.Error("Failed to apply s3_cache startup option.", "error", err)
+			_ = server.WriteErrorResponse(writer, "FATAL", "XX000", err.Error())
+			_ = writer.Flush()
+			return
+		}
+	}
 	// The normal PostgreSQL message loop is about to take ownership of reader.
 	// Join the disconnect watcher first; a FIN/RST at any point during session
 	// admission or metadata initialization tears down the session via the defer

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -441,6 +441,21 @@ func (sm *SessionManager) CreateSessionWithProtocol(ctx context.Context, usernam
 				"attempt", attempt,
 				"error", err,
 			)
+		case isWorkerS3CacheRestoreError(err):
+			// The worker couldn't restore the cache-proxy S3 transport a
+			// previous session's `duckgres.s3_cache = off` left behind (the
+			// mandatory pre-session restore in duckdbservice.CreateSession).
+			// The worker fails the create rather than start the session in an
+			// unknown transport state; a fresh (never-bypassed) worker's
+			// restore is a no-op, so recycle and re-acquire instead of failing
+			// the client — this is the retry the worker-side contract promises.
+			sm.log.Warn("Worker failed to restore its S3 cache transport before session start; recycling and re-acquiring.",
+				"pid", pid,
+				"user", username,
+				"worker", worker.ID,
+				"attempt", attempt,
+				"error", err,
+			)
 		default:
 			return 0, nil, err
 		}
@@ -468,6 +483,18 @@ const maxWorkerSessionCapDriftRetries = 2
 // "max sessions reached (N)", which propagates through the wrapped error chain.
 func isWorkerSessionCapError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "max sessions reached")
+}
+
+// isWorkerS3CacheRestoreError reports whether err is the worker-side failure
+// to restore the cache-proxy S3 transport before a new session starts (a
+// previous session's `duckgres.s3_cache = off` bypass that could not be
+// undone; duckdbservice.CreateSession's "restore S3 cache transport before
+// session start" error). The failed worker must not serve the session — its
+// transport state is unknown — but a fresh worker's restore is a no-op, so
+// this class is retried on a recycled acquisition instead of failing the
+// client's connect.
+func isWorkerS3CacheRestoreError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "restore S3 cache transport")
 }
 
 // isWorkerConnPoolTimeoutError reports whether err is the worker-side

--- a/controlplane/session_mgr_test.go
+++ b/controlplane/session_mgr_test.go
@@ -750,3 +750,22 @@ func TestIsWorkerConnPoolTimeoutError(t *testing.T) {
 		t.Fatal("nil misclassified")
 	}
 }
+
+func TestIsWorkerS3CacheRestoreError(t *testing.T) {
+	// The worker-side mandatory restore failure as it reaches the CP through
+	// the CreateSession RPC wrapping (duckdbservice doCreateSession maps it to
+	// ResourceExhausted). The CP must classify it for recycle-and-reacquire: a
+	// fresh worker's restore is a no-op, so the client's connect need not fail.
+	err := fmt.Errorf("create session: %w",
+		fmt.Errorf("create session on worker 31: create session recv: %w",
+			errors.New("rpc error: code = ResourceExhausted desc = create session: restore S3 cache transport before session start: swap S3 secret transport (s3_cache=true): refresh S3 secret: IO Error")))
+	if !isWorkerS3CacheRestoreError(err) {
+		t.Fatal("s3-cache restore failure not classified for recycle")
+	}
+	if isWorkerS3CacheRestoreError(errors.New("max sessions reached (1)")) {
+		t.Fatal("cap error misclassified as s3-cache restore failure")
+	}
+	if isWorkerS3CacheRestoreError(nil) {
+		t.Fatal("nil misclassified")
+	}
+}

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -184,27 +184,40 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 	p.secretSwapMu.Lock()
 	defer p.secretSwapMu.Unlock()
 
+	// Copy the activation payload fields while holding p.mu — never retain the
+	// *activatedTenantRuntime pointer past the unlock: reuseExistingActivation
+	// commits metadata-only re-activations (needsRefresh=false, e.g. an
+	// epoch-bump takeover with unchanged creds) by overwriting
+	// p.activation.payload in place WITHOUT taking secretSwapMu, so an
+	// unlocked read through a retained pointer is a data race.
 	p.mu.RLock()
-	act := p.activation
+	activated := p.activation != nil
+	var cfg server.DuckLakeConfig
+	var orgID string
+	var actDB *sql.DB
+	if activated {
+		cfg = p.activation.payload.DuckLake
+		orgID = p.activation.payload.OrgID
+		actDB = p.activation.db
+	}
 	bypassed := p.s3CacheBypassed
 	refreshDB := p.controlDB
 	refreshFn := p.refreshS3Secret
 	sem := p.duckLakeSem
 	p.mu.RUnlock()
 
-	if act == nil {
+	if !activated {
 		return fmt.Errorf("worker is not activated")
 	}
 	if bypassed == !enabled {
 		return nil
 	}
-	cfg := act.payload.DuckLake
 	if cfg.ObjectStore == "" {
 		// No S3-backed catalog — no secret to swap.
 		return nil
 	}
 	if refreshDB == nil {
-		refreshDB = act.db
+		refreshDB = actDB
 	}
 	if refreshFn == nil {
 		refreshFn = server.RefreshS3Secret
@@ -219,7 +232,7 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 	p.mu.Lock()
 	p.s3CacheBypassed = !enabled
 	p.mu.Unlock()
-	slog.Info("Swapped tenant S3 secret transport.", "org", act.payload.OrgID, "s3_cache_enabled", enabled)
+	slog.Info("Swapped tenant S3 secret transport.", "org", orgID, "s3_cache_enabled", enabled)
 	return nil
 }
 

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -150,10 +150,76 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 		payload: payload,
 		db:      db,
 	}
+	// A fresh activation always attaches with the cache-proxy transport
+	// (overrideS3EndpointForCacheProxy above), so the bypass flag starts clean.
+	p.s3CacheBypassed = false
 	p.ownerEpoch = payload.OwnerEpoch
 	p.ownerCPInstanceID = payload.CPInstanceID
 	p.workerID = payload.WorkerID
 	stampWorkerLogIdentity(payload.OrgID, payload.WorkerID)
+	return nil
+}
+
+// SetS3CacheEnabled applies the `duckgres.s3_cache` session GUC on the worker:
+// enabled=true keeps/restores the default cache-proxy transport on the tenant
+// ducklake_s3 secret; enabled=false rebuilds the secret with the org's native
+// HTTPS transport instead, so every S3 request CONNECT-tunnels through the
+// node-local proxy as opaque TLS — no cache reads, no cache fills. Secrets are
+// consulted per request, so the swap takes effect immediately post-attach, and
+// they are instance-global — which is session-scoped in practice because
+// remote workers serve exactly one session at a time (the same contract the
+// user-secret wipe relies on).
+//
+// The swap runs on controlDB so it never queues behind a long-running client
+// query, and under secretSwapMu so it cannot interleave with a concurrent
+// credential refresh rebuilding the same secret (reuseExistingActivation).
+// No-op when this node has no cache proxy (nothing to bypass) or the worker is
+// not a shared-warm tenant worker (the proxy transport is applied only by
+// tenant activation).
+func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
+	if !p.sharedWarmMode || !cacheEnabled() {
+		return nil
+	}
+
+	p.secretSwapMu.Lock()
+	defer p.secretSwapMu.Unlock()
+
+	p.mu.RLock()
+	act := p.activation
+	bypassed := p.s3CacheBypassed
+	refreshDB := p.controlDB
+	refreshFn := p.refreshS3Secret
+	sem := p.duckLakeSem
+	p.mu.RUnlock()
+
+	if act == nil {
+		return fmt.Errorf("worker is not activated")
+	}
+	if bypassed == !enabled {
+		return nil
+	}
+	cfg := act.payload.DuckLake
+	if cfg.ObjectStore == "" {
+		// No S3-backed catalog — no secret to swap.
+		return nil
+	}
+	if refreshDB == nil {
+		refreshDB = act.db
+	}
+	if refreshFn == nil {
+		refreshFn = server.RefreshS3Secret
+	}
+	if enabled {
+		overrideS3EndpointForCacheProxy(&cfg)
+	}
+	if err := refreshFn(refreshDB, cfg, sem); err != nil {
+		return fmt.Errorf("swap S3 secret transport (s3_cache=%v): %w", enabled, err)
+	}
+
+	p.mu.Lock()
+	p.s3CacheBypassed = !enabled
+	p.mu.Unlock()
+	slog.Info("Swapped tenant S3 secret transport.", "org", act.payload.OrgID, "s3_cache_enabled", enabled)
 	return nil
 }
 
@@ -249,9 +315,26 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			// path-style plain-HTTP secret with a vhost/HTTPS one and every S3
 			// read CONNECT-tunnels past the NVMe cache for the rest of the
 			// worker's life (mw-prod-us 2026-07-17).
+			//
+			// UNLESS the live session bypassed the cache (`duckgres.s3_cache =
+			// off`): then the rebuild must keep the native HTTPS transport, or
+			// a mid-session credential rotation would silently re-route the
+			// session through the cache. secretSwapMu serializes this rebuild
+			// against SetS3CacheEnabled so the secret always matches
+			// s3CacheBypassed; it is never held while waiting on p.mu, so the
+			// health-check responsiveness this unlocked phase exists for is
+			// preserved.
+			p.secretSwapMu.Lock()
+			p.mu.RLock()
+			bypassed := p.s3CacheBypassed
+			p.mu.RUnlock()
 			refreshCfg := payload.DuckLake
-			overrideS3EndpointForCacheProxy(&refreshCfg)
-			if err := refreshFn(refreshDB, refreshCfg, sem); err != nil {
+			if !bypassed {
+				overrideS3EndpointForCacheProxy(&refreshCfg)
+			}
+			err := refreshFn(refreshDB, refreshCfg, sem)
+			p.secretSwapMu.Unlock()
+			if err != nil {
 				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
 				return false
 			}

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -321,10 +321,17 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			// a mid-session credential rotation would silently re-route the
 			// session through the cache. secretSwapMu serializes this rebuild
 			// against SetS3CacheEnabled so the secret always matches
-			// s3CacheBypassed; it is never held while waiting on p.mu, so the
-			// health-check responsiveness this unlocked phase exists for is
-			// preserved.
+			// s3CacheBypassed — and it is held (via defer) all the way through
+			// the Phase 3 payload commit below: released any earlier, a toggle
+			// could sneak in, read the not-yet-committed OLD payload, and
+			// last-write the secret with the OLD (soon-to-expire) STS creds
+			// while Phase 3 records the new expiry — the scheduler would then
+			// skip the worker until the NEW expiry and the session dies with
+			// ExpiredToken mid-flight. Health checks only need p.mu.RLock and
+			// never touch secretSwapMu, so their responsiveness (the reason
+			// this phase runs without p.mu) is unaffected.
 			p.secretSwapMu.Lock()
+			defer p.secretSwapMu.Unlock()
 			p.mu.RLock()
 			bypassed := p.s3CacheBypassed
 			p.mu.RUnlock()
@@ -332,9 +339,7 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			if !bypassed {
 				overrideS3EndpointForCacheProxy(&refreshCfg)
 			}
-			err := refreshFn(refreshDB, refreshCfg, sem)
-			p.secretSwapMu.Unlock()
-			if err != nil {
+			if err := refreshFn(refreshDB, refreshCfg, sem); err != nil {
 				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
 				return false
 			}

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -468,6 +468,32 @@ func (h *FlightSQLHandler) doWaitSessionIdle(body []byte, stream flight.FlightSe
 	return sendActionResult(stream, &flight.Result{Body: resp})
 }
 
+// doSetSessionS3Cache applies the `duckgres.s3_cache` session GUC: it swaps
+// the tenant S3 secret between the cache-proxy transport (enabled) and the
+// org's native HTTPS transport (bypassed). Requires a live session — the swap
+// is instance-global, which is session-scoped only under the one-session-per-
+// worker contract, and a sessionless caller has no business toggling it.
+// Errors surface to the control plane so the client's SET fails rather than
+// silently not taking effect.
+func (h *FlightSQLHandler) doSetSessionS3Cache(body []byte, stream flight.FlightService_DoActionServer) error {
+	var req server.WorkerSetS3CachePayload
+	if err := json.Unmarshal(body, &req); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid SetSessionS3Cache request: %v", err)
+	}
+	if err := h.pool.validateControlMetadata(req.WorkerControlMetadata); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "stale worker owner: %v", err)
+	}
+	if _, err := h.sessionFromContext(stream.Context()); err != nil {
+		return err
+	}
+	if err := h.pool.SetS3CacheEnabled(req.Enabled); err != nil {
+		return status.Errorf(codes.Internal, "set session s3 cache: %v", err)
+	}
+
+	resp, _ := json.Marshal(map[string]bool{"ok": true})
+	return sendActionResult(stream, &flight.Result{Body: resp})
+}
+
 func (h *FlightSQLHandler) doReleaseQueryHandle(body []byte, stream flight.FlightService_DoActionServer) error {
 	var req server.WorkerReleaseQueryHandlePayload
 	if err := json.Unmarshal(body, &req); err != nil {

--- a/duckdbservice/s3_cache_test.go
+++ b/duckdbservice/s3_cache_test.go
@@ -1,0 +1,459 @@
+package duckdbservice
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/server"
+)
+
+// s3CacheTestPool builds a shared-warm pool with a synthetic activation and a
+// recording refreshS3Secret stub, for exercising SetS3CacheEnabled without a
+// real DuckDB or cache proxy.
+func s3CacheTestPool(t *testing.T, objectStore string) (*SessionPool, *[]server.DuckLakeConfig) {
+	t.Helper()
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			OrgID: "analytics",
+			DuckLake: server.DuckLakeConfig{
+				MetadataStore:  "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+				ObjectStore:    objectStore,
+				S3Region:       "us-east-1",
+				S3UseSSL:       true,
+				S3AccessKey:    "ACCESS_KEY",
+				S3SecretKey:    "SECRET_KEY",
+				S3SessionToken: "SESSION_TOKEN",
+			},
+		}},
+	}
+	close(pool.warmupDone)
+	var calls []server.DuckLakeConfig
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		calls = append(calls, dlCfg)
+		return nil
+	}
+	return pool, &calls
+}
+
+// TestSetS3CacheEnabledSwapsTransportAndBack asserts the core swap contract:
+// disabling the cache rebuilds ducklake_s3 from the RAW payload config (the
+// org's native HTTPS transport — traffic then CONNECT-tunnels through the
+// proxy uncached), re-enabling rebuilds WITH the cache-proxy transport, and
+// redundant calls never touch the secret.
+func TestSetS3CacheEnabledSwapsTransportAndBack(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+	pool, calls := s3CacheTestPool(t, "s3://analytics/warehouse/")
+
+	// Redundant enable: already on, no secret touch.
+	if err := pool.SetS3CacheEnabled(true); err != nil {
+		t.Fatalf("SetS3CacheEnabled(true) on fresh pool: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("redundant enable rebuilt the secret: %d calls", len(*calls))
+	}
+
+	// Disable: rebuild with the raw (native HTTPS) transport.
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("SetS3CacheEnabled(false): %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("disable: %d secret rebuilds, want 1", len(*calls))
+	}
+	if got := (*calls)[0]; got.HTTPProxy != "" || !got.S3UseSSL || got.S3Endpoint != "" {
+		t.Fatalf("bypass rebuild must use the raw org transport (no proxy, HTTPS, no pinned endpoint), got HTTPProxy=%q S3UseSSL=%v S3Endpoint=%q",
+			got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
+	}
+	pool.mu.RLock()
+	bypassed := pool.s3CacheBypassed
+	pool.mu.RUnlock()
+	if !bypassed {
+		t.Fatal("s3CacheBypassed = false after disable, want true")
+	}
+
+	// Redundant disable: no secret touch.
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("redundant SetS3CacheEnabled(false): %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("redundant disable rebuilt the secret: %d calls", len(*calls))
+	}
+
+	// Re-enable: rebuild WITH the cache-proxy transport.
+	if err := pool.SetS3CacheEnabled(true); err != nil {
+		t.Fatalf("SetS3CacheEnabled(true): %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("enable: %d secret rebuilds, want 2", len(*calls))
+	}
+	if got := (*calls)[1]; got.HTTPProxy != "http://10.0.0.9:8080" || got.S3UseSSL || got.S3Endpoint != "s3.us-east-1.amazonaws.com" {
+		t.Fatalf("restore rebuild must carry the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v S3Endpoint=%q",
+			got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
+	}
+	pool.mu.RLock()
+	bypassed = pool.s3CacheBypassed
+	pool.mu.RUnlock()
+	if bypassed {
+		t.Fatal("s3CacheBypassed = true after enable, want false")
+	}
+}
+
+// TestSetS3CacheEnabledNoOpWithoutCacheProxy asserts the toggle degrades to a
+// silent no-op when the node runs no cache proxy (DUCKGRES_CACHE_ENABLED
+// unset): the org transport is already direct, there is nothing to bypass,
+// and a SET from a client must not error or churn the secret.
+func TestSetS3CacheEnabledNoOpWithoutCacheProxy(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "")
+	pool, calls := s3CacheTestPool(t, "s3://analytics/warehouse/")
+
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("SetS3CacheEnabled(false) without cache proxy: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("no-op rebuilt the secret: %d calls", len(*calls))
+	}
+}
+
+// TestSetS3CacheEnabledNoOpOutsideSharedWarm asserts non-tenant workers
+// (process backend, standalone duckdb-service) no-op: the cache-proxy
+// transport override is applied only by shared-warm tenant activation, so
+// there is nothing to swap.
+func TestSetS3CacheEnabledNoOpOutsideSharedWarm(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	pool, calls := s3CacheTestPool(t, "s3://analytics/warehouse/")
+	pool.sharedWarmMode = false
+
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("SetS3CacheEnabled(false) outside shared-warm: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("non-shared-warm toggle rebuilt the secret: %d calls", len(*calls))
+	}
+}
+
+// TestSetS3CacheEnabledRequiresActivation asserts a disable on a
+// not-yet-activated shared-warm worker errors instead of silently recording a
+// state there is no secret to apply it to.
+func TestSetS3CacheEnabledRequiresActivation(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	pool, _ := s3CacheTestPool(t, "s3://analytics/warehouse/")
+	pool.activation = nil
+
+	if err := pool.SetS3CacheEnabled(false); err == nil {
+		t.Fatal("SetS3CacheEnabled(false) on unactivated worker: nil error, want failure")
+	}
+}
+
+// TestSetS3CacheEnabledFailurePreservesState asserts a failed secret rebuild
+// leaves the flag on its previous value (the session state the CP reports must
+// track the secret actually in place) and a retry can still succeed.
+func TestSetS3CacheEnabledFailurePreservesState(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+	pool, calls := s3CacheTestPool(t, "s3://analytics/warehouse/")
+
+	boom := errors.New("boom")
+	fail := true
+	inner := pool.refreshS3Secret
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		if fail {
+			return boom
+		}
+		return inner(db, dlCfg, sem)
+	}
+
+	if err := pool.SetS3CacheEnabled(false); err == nil || !errors.Is(err, boom) {
+		t.Fatalf("SetS3CacheEnabled(false) with failing rebuild: err = %v, want boom", err)
+	}
+	pool.mu.RLock()
+	bypassed := pool.s3CacheBypassed
+	pool.mu.RUnlock()
+	if bypassed {
+		t.Fatal("failed rebuild still flipped s3CacheBypassed")
+	}
+
+	fail = false
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("retry after failure: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("retry: %d successful rebuilds, want 1", len(*calls))
+	}
+}
+
+// TestCredentialRefreshPreservesS3CacheBypass is the inverse of the mw-prod-us
+// 2026-07-17 regression test: while a session is bypassing the cache
+// (`duckgres.s3_cache = off`), a CP-driven credential rotation re-activation
+// must rebuild ducklake_s3 WITHOUT the cache-proxy transport — otherwise the
+// hourly STS rotation silently re-routes the session through the cache
+// mid-benchmark.
+func TestCredentialRefreshPreservesS3CacheBypass(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		cfg:            server.Config{Users: map[string]string{"postgres": "postgres"}},
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+
+	var opened *sql.DB
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		opened = db
+		return PairFromMain(db), nil
+	}
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		return nil
+	}
+	defer func() {
+		if opened != nil {
+			_ = opened.Close()
+		}
+	}()
+
+	first := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{
+			OwnerEpoch:   2,
+			CPInstanceID: "cp-live:boot-a",
+			WorkerID:     17,
+		},
+		OrgID: "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore:  "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:    "s3://analytics/warehouse/",
+			S3Region:       "us-east-1",
+			S3UseSSL:       true,
+			S3AccessKey:    "OLD_ACCESS_KEY",
+			S3SecretKey:    "OLD_SECRET_KEY",
+			S3SessionToken: "OLD_SESSION_TOKEN",
+		},
+	}
+	if err := pool.activateTenant(first); err != nil {
+		t.Fatalf("first ActivateTenant: %v", err)
+	}
+
+	var refreshCfgs []server.DuckLakeConfig
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		refreshCfgs = append(refreshCfgs, dlCfg)
+		return nil
+	}
+
+	// The live session turns the cache off.
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("SetS3CacheEnabled(false): %v", err)
+	}
+	if len(refreshCfgs) != 1 {
+		t.Fatalf("disable: %d rebuilds, want 1", len(refreshCfgs))
+	}
+
+	// CP-driven credential rotation re-activation while bypassed.
+	second := first
+	second.DuckLake.S3AccessKey = "NEW_ACCESS_KEY"
+	second.DuckLake.S3SecretKey = "NEW_SECRET_KEY"
+	second.DuckLake.S3SessionToken = "NEW_SESSION_TOKEN"
+	if err := pool.activateTenant(second); err != nil {
+		t.Fatalf("credential rotation re-activation: %v", err)
+	}
+	if len(refreshCfgs) != 2 {
+		t.Fatalf("rotation: %d rebuilds, want 2", len(refreshCfgs))
+	}
+	rotated := refreshCfgs[1]
+	if rotated.S3AccessKey != "NEW_ACCESS_KEY" {
+		t.Fatalf("rotation rebuild lost the fresh credentials: %q", rotated.S3AccessKey)
+	}
+	if rotated.HTTPProxy != "" || !rotated.S3UseSSL || rotated.S3Endpoint != "" {
+		t.Fatalf("rotation rebuild re-applied the cache-proxy transport while bypassed: HTTPProxy=%q S3UseSSL=%v S3Endpoint=%q",
+			rotated.HTTPProxy, rotated.S3UseSSL, rotated.S3Endpoint)
+	}
+
+	// Restore, then rotate again: the proxy transport must come back.
+	if err := pool.SetS3CacheEnabled(true); err != nil {
+		t.Fatalf("SetS3CacheEnabled(true): %v", err)
+	}
+	third := second
+	third.DuckLake.S3AccessKey = "NEWER_ACCESS_KEY"
+	third.DuckLake.S3SecretKey = "NEWER_SECRET_KEY"
+	third.DuckLake.S3SessionToken = "NEWER_SESSION_TOKEN"
+	if err := pool.activateTenant(third); err != nil {
+		t.Fatalf("second rotation re-activation: %v", err)
+	}
+	last := refreshCfgs[len(refreshCfgs)-1]
+	if last.HTTPProxy != "http://10.0.0.9:8080" || last.S3UseSSL {
+		t.Fatalf("post-restore rotation rebuild lost the cache-proxy transport: HTTPProxy=%q S3UseSSL=%v", last.HTTPProxy, last.S3UseSSL)
+	}
+}
+
+// TestCreateSessionRestoresS3CacheTransport asserts the hard invariant that a
+// bypass can never leak into the org's next session: CreateSession on a worker
+// whose previous session disabled the cache rebuilds the secret with the
+// cache-proxy transport before the session starts, and a failed restore fails
+// the session create.
+func TestCreateSessionRestoresS3CacheTransport(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	newPool := func(refresh func(*sql.DB, server.DuckLakeConfig, chan struct{}) error) *SessionPool {
+		pool := &SessionPool{
+			sessions:       make(map[string]*Session),
+			stopRefresh:    make(map[string]func()),
+			duckLakeSem:    make(chan struct{}, 1),
+			warmupDB:       db,
+			warmupDone:     make(chan struct{}),
+			cfg:            server.Config{SessionInitTimeout: time.Second},
+			maxSessions:    1,
+			sharedWarmMode: true,
+			activation: &activatedTenantRuntime{payload: ActivationPayload{
+				OrgID: "analytics",
+				DuckLake: server.DuckLakeConfig{
+					ObjectStore: "s3://analytics/warehouse/",
+					S3Region:    "us-east-1",
+					S3UseSSL:    true,
+				},
+			}, db: db},
+			s3CacheBypassed: true, // previous session left the cache off
+			refreshS3Secret: refresh,
+		}
+		close(pool.warmupDone)
+		return pool
+	}
+
+	t.Run("restores proxy transport before the session starts", func(t *testing.T) {
+		var restored []server.DuckLakeConfig
+		pool := newPool(func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+			restored = append(restored, dlCfg)
+			return nil
+		})
+
+		session, _, err := pool.CreateSession("root", "", 0, nil)
+		if err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		defer func() { _ = pool.DestroySession(session.ID) }()
+
+		if len(restored) != 1 {
+			t.Fatalf("restore rebuilds = %d, want 1", len(restored))
+		}
+		if got := restored[0]; got.HTTPProxy != "http://10.0.0.9:8080" || got.S3UseSSL {
+			t.Fatalf("restore rebuild must carry the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v", got.HTTPProxy, got.S3UseSSL)
+		}
+		pool.mu.RLock()
+		bypassed := pool.s3CacheBypassed
+		pool.mu.RUnlock()
+		if bypassed {
+			t.Fatal("s3CacheBypassed still true after CreateSession restore")
+		}
+	})
+
+	t.Run("failed restore fails the session create", func(t *testing.T) {
+		pool := newPool(func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+			return errors.New("boom")
+		})
+
+		_, _, err := pool.CreateSession("root", "", 0, nil)
+		if err == nil {
+			t.Fatal("CreateSession with failing restore: nil error, want failure")
+		}
+		if !strings.Contains(err.Error(), "restore S3 cache transport") {
+			t.Fatalf("CreateSession error = %v, want restore-S3-cache failure", err)
+		}
+		// The reserved slot must have been released so the worker isn't leaked
+		// at cap: a follow-up create (with the restore now succeeding) works.
+		pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error { return nil }
+		session, _, err := pool.CreateSession("root", "", 0, nil)
+		if err != nil {
+			t.Fatalf("CreateSession after failed restore: %v", err)
+		}
+		_ = pool.DestroySession(session.ID)
+	})
+}
+
+// TestDestroySessionRestoresS3CacheTransport asserts the best-effort restore
+// at session teardown: a hot-idle worker between sessions runs its
+// checkpointer through the cache proxy again without waiting for the next
+// CreateSession.
+func TestDestroySessionRestoresS3CacheTransport(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var rebuilds []server.DuckLakeConfig
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		warmupDB:       db,
+		warmupDone:     make(chan struct{}),
+		cfg:            server.Config{SessionInitTimeout: time.Second},
+		maxSessions:    1,
+		sharedWarmMode: true,
+		activation: &activatedTenantRuntime{payload: ActivationPayload{
+			OrgID: "analytics",
+			DuckLake: server.DuckLakeConfig{
+				ObjectStore: "s3://analytics/warehouse/",
+				S3Region:    "us-east-1",
+				S3UseSSL:    true,
+			},
+		}, db: db},
+		refreshS3Secret: func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+			rebuilds = append(rebuilds, dlCfg)
+			return nil
+		},
+	}
+	close(pool.warmupDone)
+
+	session, _, err := pool.CreateSession("root", "", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// The session turns the cache off mid-flight.
+	if err := pool.SetS3CacheEnabled(false); err != nil {
+		t.Fatalf("SetS3CacheEnabled(false): %v", err)
+	}
+	rebuilds = rebuilds[:0]
+
+	if err := pool.DestroySession(session.ID); err != nil {
+		t.Fatalf("DestroySession: %v", err)
+	}
+	if len(rebuilds) != 1 {
+		t.Fatalf("destroy restore rebuilds = %d, want 1", len(rebuilds))
+	}
+	if got := rebuilds[0]; got.HTTPProxy != "http://10.0.0.9:8080" || got.S3UseSSL {
+		t.Fatalf("destroy restore must carry the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v", got.HTTPProxy, got.S3UseSSL)
+	}
+	pool.mu.RLock()
+	bypassed := pool.s3CacheBypassed
+	pool.mu.RUnlock()
+	if bypassed {
+		t.Fatal("s3CacheBypassed still true after DestroySession restore")
+	}
+}

--- a/duckdbservice/s3_cache_test.go
+++ b/duckdbservice/s3_cache_test.go
@@ -412,6 +412,79 @@ func TestS3CacheToggleDuringRotationUsesRotatedCreds(t *testing.T) {
 	}
 }
 
+// TestS3CacheToggleRacesMetadataOnlyReactivation is the -race regression for
+// the retained-pointer read: metadata-only re-activations (needsRefresh=false,
+// e.g. an epoch-bump takeover with unchanged credentials) overwrite
+// p.activation.payload in place under p.mu WITHOUT taking secretSwapMu, so
+// SetS3CacheEnabled must copy the payload while holding p.mu instead of
+// reading through a retained *activatedTenantRuntime after the unlock.
+// Meaningful under `go test -race`; the toggles and reactivations here
+// interleave freely.
+func TestS3CacheToggleRacesMetadataOnlyReactivation(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		return PairFromMain(db), nil
+	}
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		return nil
+	}
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		return nil
+	}
+
+	base := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{OwnerEpoch: 1, CPInstanceID: "cp-live:boot-a", WorkerID: 17},
+		OrgID:                 "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore: "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:   "s3://analytics/warehouse/",
+			S3Region:      "us-east-1",
+			S3UseSSL:      true,
+			S3AccessKey:   "ACCESS_KEY", // unchanged across reactivations → needsRefresh=false
+			S3SecretKey:   "SECRET_KEY",
+		},
+	}
+	if err := pool.activateTenant(base); err != nil {
+		t.Fatalf("first ActivateTenant: %v", err)
+	}
+
+	const rounds = 100
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < rounds; i++ {
+			next := base
+			next.OwnerEpoch = int64(2 + i)
+			if err := pool.activateTenant(next); err != nil {
+				t.Errorf("metadata-only re-activation (epoch %d): %v", next.OwnerEpoch, err)
+				return
+			}
+		}
+	}()
+	for i := 0; i < rounds; i++ {
+		if err := pool.SetS3CacheEnabled(i%2 == 0); err != nil {
+			t.Fatalf("SetS3CacheEnabled toggle %d: %v", i, err)
+		}
+	}
+	<-done
+}
+
 // TestCreateSessionRestoresS3CacheTransport asserts the hard invariant that a
 // bypass can never leak into the org's next session: CreateSession on a worker
 // whose previous session disabled the cache rebuilds the secret with the

--- a/duckdbservice/s3_cache_test.go
+++ b/duckdbservice/s3_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -298,6 +299,116 @@ func TestCredentialRefreshPreservesS3CacheBypass(t *testing.T) {
 	last := refreshCfgs[len(refreshCfgs)-1]
 	if last.HTTPProxy != "http://10.0.0.9:8080" || last.S3UseSSL {
 		t.Fatalf("post-restore rotation rebuild lost the cache-proxy transport: HTTPProxy=%q S3UseSSL=%v", last.HTTPProxy, last.S3UseSSL)
+	}
+}
+
+// TestS3CacheToggleDuringRotationUsesRotatedCreds pins the secretSwapMu
+// hold-through-commit invariant: a `duckgres.s3_cache` toggle that arrives
+// while a credential-rotation re-activation is mid-rebuild must wait until the
+// rotated payload is COMMITTED, so its own rebuild carries the NEW creds. If
+// the refresh path released secretSwapMu before the Phase 3 commit, the toggle
+// could read the stale pre-rotation payload and last-write the secret with the
+// old, soon-to-expire STS credentials while the scheduler records the new
+// expiry — killing the session with ExpiredToken an hour later.
+func TestS3CacheToggleDuringRotationUsesRotatedCreds(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+
+	pool := &SessionPool{
+		sessions:       make(map[string]*Session),
+		stopRefresh:    make(map[string]func()),
+		duckLakeSem:    make(chan struct{}, 1),
+		startTime:      time.Now(),
+		warmupDone:     make(chan struct{}),
+		sharedWarmMode: true,
+	}
+	close(pool.warmupDone)
+
+	var opened *sql.DB
+	pool.createDBPair = func(cfg server.Config, sem chan struct{}, username string, startTime time.Time, version string) (*DuckDBPair, error) {
+		db, err := sql.Open("duckdb", "")
+		if err != nil {
+			return nil, err
+		}
+		opened = db
+		return PairFromMain(db), nil
+	}
+	pool.activateDBConnection = func(db *sql.DB, cfg server.Config, sem chan struct{}, username string) error {
+		return nil
+	}
+	defer func() {
+		if opened != nil {
+			_ = opened.Close()
+		}
+	}()
+
+	first := ActivationPayload{
+		WorkerControlMetadata: server.WorkerControlMetadata{OwnerEpoch: 2, CPInstanceID: "cp-live:boot-a", WorkerID: 17},
+		OrgID:                 "analytics",
+		DuckLake: server.DuckLakeConfig{
+			MetadataStore: "postgres:host=metadata.internal port=5432 user=ducklake password=secret dbname=ducklake",
+			ObjectStore:   "s3://analytics/warehouse/",
+			S3Region:      "us-east-1",
+			S3UseSSL:      true,
+			S3AccessKey:   "OLD_ACCESS_KEY",
+			S3SecretKey:   "OLD_SECRET_KEY",
+		},
+	}
+	if err := pool.activateTenant(first); err != nil {
+		t.Fatalf("first ActivateTenant: %v", err)
+	}
+
+	rotationEntered := make(chan struct{})
+	toggleStarted := make(chan struct{})
+	var mu sync.Mutex
+	var toggleCfg *server.DuckLakeConfig
+	pool.refreshS3Secret = func(db *sql.DB, dlCfg server.DuckLakeConfig, sem chan struct{}) error {
+		if dlCfg.HTTPProxy != "" {
+			// The rotation rebuild (proxy transport, cache on). Signal the
+			// toggle goroutine to start, then give it time to block on
+			// secretSwapMu before this rebuild "finishes" — recreating the
+			// window between the refresh exec and the payload commit.
+			close(rotationEntered)
+			<-toggleStarted
+			time.Sleep(50 * time.Millisecond)
+			return nil
+		}
+		// The toggle's bypass rebuild (native transport).
+		mu.Lock()
+		cfg := dlCfg
+		toggleCfg = &cfg
+		mu.Unlock()
+		return nil
+	}
+
+	second := first
+	second.DuckLake.S3AccessKey = "NEW_ACCESS_KEY"
+	second.DuckLake.S3SecretKey = "NEW_SECRET_KEY"
+
+	rotationDone := make(chan error, 1)
+	go func() { rotationDone <- pool.activateTenant(second) }()
+
+	<-rotationEntered
+	toggleDone := make(chan error, 1)
+	go func() {
+		close(toggleStarted)
+		toggleDone <- pool.SetS3CacheEnabled(false)
+	}()
+
+	if err := <-rotationDone; err != nil {
+		t.Fatalf("rotation re-activation: %v", err)
+	}
+	if err := <-toggleDone; err != nil {
+		t.Fatalf("SetS3CacheEnabled(false): %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if toggleCfg == nil {
+		t.Fatal("toggle never rebuilt the secret")
+	}
+	if toggleCfg.S3AccessKey != "NEW_ACCESS_KEY" {
+		t.Fatalf("toggle rebuilt the secret with stale pre-rotation creds: %q (scheduler now believes NEW creds are installed)", toggleCfg.S3AccessKey)
 	}
 }
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -93,8 +93,12 @@ type SessionPool struct {
 	// secretSwapMu serializes rebuilds of the tenant ducklake_s3 secret (the
 	// credential-refresh path in reuseExistingActivation vs the per-session
 	// duckgres.s3_cache toggle in SetS3CacheEnabled) so the last-applied
-	// transport always matches s3CacheBypassed. Never held across p.mu waits;
-	// held across the (slow) CREATE OR REPLACE SECRET, which p.mu must not be.
+	// transport always matches s3CacheBypassed. The refresh path holds it from
+	// before its rebuild until AFTER the rotated payload is committed, so a
+	// concurrent toggle can never rebuild from the stale pre-rotation payload.
+	// Lock order: secretSwapMu → p.mu (both paths); p.mu is never held while
+	// acquiring secretSwapMu. Held across the (slow) CREATE OR REPLACE SECRET,
+	// which p.mu must not be — health checks only need p.mu.RLock.
 	secretSwapMu sync.Mutex
 	// s3CacheBypassed is true while the tenant S3 secret carries the org's
 	// native HTTPS transport instead of the cache-proxy transport, i.e. the

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -90,6 +90,23 @@ type SessionPool struct {
 	// (see TestReuseExistingActivationDoesNotBlockHealthChecks).
 	refreshS3Secret func(*sql.DB, server.DuckLakeConfig, chan struct{}) error
 
+	// secretSwapMu serializes rebuilds of the tenant ducklake_s3 secret (the
+	// credential-refresh path in reuseExistingActivation vs the per-session
+	// duckgres.s3_cache toggle in SetS3CacheEnabled) so the last-applied
+	// transport always matches s3CacheBypassed. Never held across p.mu waits;
+	// held across the (slow) CREATE OR REPLACE SECRET, which p.mu must not be.
+	secretSwapMu sync.Mutex
+	// s3CacheBypassed is true while the tenant S3 secret carries the org's
+	// native HTTPS transport instead of the cache-proxy transport, i.e. the
+	// current session set `duckgres.s3_cache = off`. Flipped only under
+	// secretSwapMu (read under p.mu); the one exception is activateTenant's
+	// reset-to-false at first-activation commit, which cannot race a swap
+	// because SetS3CacheEnabled refuses to run before an activation exists
+	// (and taking secretSwapMu there would invert the secretSwapMu→p.mu lock
+	// order). CreateSession restores the proxy transport before a new session
+	// starts so a bypass can never leak into the org's next session.
+	s3CacheBypassed bool
+
 	drainMu       sync.Mutex
 	draining      bool
 	activeWork    int
@@ -1063,6 +1080,21 @@ func (p *SessionPool) CreateSession(username, memoryLimit string, threads int, s
 		return nil, nil, cfgErr
 	}
 
+	// Restore the cache-proxy S3 transport if the previous session's
+	// `duckgres.s3_cache = off` left the tenant secret bypassing the cache. A
+	// leaked bypass silently routes every subsequent session past the NVMe
+	// cache (the mw-prod-us 2026-07-17 failure mode), so this restore is a
+	// hard invariant: failure fails the session create — the control plane
+	// retries on a fresh worker — rather than starting a session in an
+	// unknown transport state. No-op unless a bypass is actually in effect.
+	if err := p.SetS3CacheEnabled(true); err != nil {
+		_ = conn.Close()
+		p.mu.Lock()
+		p.reserved--
+		p.mu.Unlock()
+		return nil, nil, fmt.Errorf("restore S3 cache transport before session start: %w", err)
+	}
+
 	if err := initAttachedDuckLakeSessionMetadata(conn, db, sessionCfg); err != nil {
 		_ = conn.Close()
 		p.mu.Lock()
@@ -1324,6 +1356,16 @@ func (p *SessionPool) DestroySession(token string) error {
 			slog.Warn("Failed to wipe user secrets on session destroy.", "user", session.Username, "error", err)
 		}
 		wipeCancel()
+	}
+
+	// Best-effort restore of the cache-proxy S3 transport if this session
+	// disabled it (`duckgres.s3_cache = off`). The mandatory restore happens
+	// at the next CreateSession; this one just narrows the hot-idle window in
+	// which the worker's checkpointer would write past the cache proxy.
+	if p.sharedWarmMode {
+		if err := p.SetS3CacheEnabled(true); err != nil {
+			slog.Warn("Failed to restore S3 cache transport on session destroy.", "user", session.Username, "error", err)
+		}
 	}
 
 	// Do NOT close session.DB if it is a shared DB (warmup or fallback)
@@ -1736,6 +1778,8 @@ func (s *customActionServer) DoAction(cmd *flight.Action, stream flight.FlightSe
 		return s.handler.doHealthCheck(cmd.Body, stream)
 	case "WaitSessionIdle":
 		return s.handler.doWaitSessionIdle(cmd.Body, stream)
+	case "SetSessionS3Cache":
+		return s.handler.doSetSessionS3Cache(cmd.Body, stream)
 	case "ReleaseQueryHandle":
 		return s.handler.doReleaseQueryHandle(cmd.Body, stream)
 	case "LogQuery":

--- a/server/conn.go
+++ b/server/conn.go
@@ -85,6 +85,8 @@ type preparedStmt struct {
 	noOpTag           string   // Command tag for no-op commands
 	querySourceSet    *string  // non-nil: SET duckgres.query_source; pointed-to value to store on session
 	querySourceShow   bool     // True if this is SHOW duckgres.query_source (answered from session state)
+	s3CacheSet        *string  // non-nil: SET duckgres.s3_cache; pointed-to value to apply to session
+	s3CacheShow       bool     // True if this is SHOW duckgres.s3_cache (answered from session state)
 	described         bool     // True if Describe(S) was called on this statement
 	statements        []string // Multi-statement rewrite (e.g., writable CTE)
 	cleanupStatements []string // Cleanup statements for multi-statement (DROP temp tables, COMMIT)
@@ -205,6 +207,14 @@ type clientConn struct {
 	// against the closed {standard, endpoints} set (22023 on anything else), so
 	// this only ever holds "", "standard", or "endpoints".
 	querySource string
+
+	// s3CacheOff holds the `duckgres.s3_cache` session GUC state (another
+	// duckgres-namespaced custom parameter, NOT forwarded to DuckDB): true
+	// when this session asked to bypass the node-local S3 cache proxy. Only
+	// flipped by applyS3CacheSetting AFTER the worker-side transport swap
+	// succeeded, so SHOW never reports a state the worker isn't in. See
+	// conn_s3_cache.go.
+	s3CacheOff bool
 
 	// Provisioned worker pod size for compute-usage billing (remote/k8s backend
 	// only). Counted in milli-units to avoid truncating a fractional-core or
@@ -1011,17 +1021,26 @@ func (c *clientConn) handleStartup() error {
 		c.database = params["database"]
 		c.applicationName = params["application_name"]
 
-		// Honor a `-c duckgres.query_source=...` startup option (libpq `options`
-		// keyword / PGOPTIONS). Other GUCs in `options` are not applied here.
-		// An invalid value rejects the connection with FATAL 22023 — the same
-		// treatment resolveWorkerProfile gives an invalid duckgres.worker_*
-		// startup option, and what PostgreSQL itself does with an invalid
-		// `options` GUC value.
+		// Honor `-c duckgres.query_source=...` / `-c duckgres.s3_cache=...`
+		// startup options (libpq `options` keyword / PGOPTIONS). Other GUCs in
+		// `options` are not applied here. An invalid value rejects the
+		// connection with FATAL 22023 — the same treatment
+		// resolveWorkerProfile gives an invalid duckgres.worker_* startup
+		// option, and what PostgreSQL itself does with an invalid `options`
+		// GUC value. (In standalone mode there is no cache proxy, so
+		// duckgres.s3_cache only records session state here; the worker-swap
+		// path is control-plane-only.)
 		if opts := ParseStartupOptions(params["options"]); len(opts) > 0 {
 			if v, ok := opts[querySourceGUCName]; ok {
 				if err := c.applyStartupQuerySource(v); err != nil {
 					c.sendError("FATAL", "22023", err.Error())
 					return fmt.Errorf("invalid %s startup option", querySourceGUCName)
+				}
+			}
+			if v, ok := opts[s3CacheGUCName]; ok {
+				if err := c.applyStartupS3Cache(v); err != nil {
+					c.sendError("FATAL", "22023", err.Error())
+					return fmt.Errorf("invalid %s startup option", s3CacheGUCName)
 				}
 			}
 		}
@@ -1413,6 +1432,29 @@ func (c *clientConn) handleQuery(body []byte) (retErr error) {
 	if result.QuerySourceShow {
 		_ = c.sendRowDescription([]string{querySourceGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
 		_ = c.sendDataRowWithFormats([]interface{}{c.QuerySource()}, nil, nil)
+		_ = c.writeCommandComplete("SHOW")
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
+		return nil
+	}
+
+	// Handle the duckgres.s3_cache custom GUC (SET / SHOW). Intercepted
+	// session-side; applied by swapping the worker's S3 secret transport,
+	// never forwarded to DuckDB. A failed worker swap fails the SET so the
+	// session state never diverges from the worker's actual transport.
+	if result.S3CacheSet != nil {
+		if err := c.applyS3CacheSetting(*result.S3CacheSet); err != nil {
+			c.sendError("ERROR", "XX000", err.Error())
+		} else {
+			_ = c.writeCommandComplete("SET")
+		}
+		_ = c.writeReadyForQuery(c.txStatus)
+		_ = c.flushWriter()
+		return nil
+	}
+	if result.S3CacheShow {
+		_ = c.sendRowDescription([]string{s3CacheGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
+		_ = c.sendDataRowWithFormats([]interface{}{c.s3CacheValue()}, nil, nil)
 		_ = c.writeCommandComplete("SHOW")
 		_ = c.writeReadyForQuery(c.txStatus)
 		_ = c.flushWriter()

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -201,6 +201,8 @@ func (c *clientConn) handleParse(body []byte) {
 		noOpTag:           result.NoOpTag,
 		querySourceSet:    result.QuerySourceSet,    // SET duckgres.query_source (custom GUC)
 		querySourceShow:   result.QuerySourceShow,   // SHOW duckgres.query_source
+		s3CacheSet:        result.S3CacheSet,        // SET duckgres.s3_cache (custom GUC)
+		s3CacheShow:       result.S3CacheShow,       // SHOW duckgres.s3_cache
 		statements:        result.Statements,        // Multi-statement rewrite (writable CTE)
 		cleanupStatements: result.CleanupStatements, // Cleanup statements
 	}
@@ -289,6 +291,17 @@ func (c *clientConn) handleDescribe(body []byte) {
 		}
 		if ps.querySourceShow {
 			_ = c.sendRowDescription([]string{querySourceGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
+			ps.described = true
+			return
+		}
+
+		// duckgres.s3_cache custom GUC: same shape as query_source above.
+		if ps.s3CacheSet != nil {
+			_ = wire.WriteNoData(c.writer)
+			return
+		}
+		if ps.s3CacheShow {
+			_ = c.sendRowDescription([]string{s3CacheGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
 			ps.described = true
 			return
 		}
@@ -412,6 +425,25 @@ func (c *clientConn) handleDescribe(body []byte) {
 			return
 		case cursorOpPgStatActivity:
 			_ = c.sendPgStatActivityRowDescriptionWithFormats(p.resultFormats)
+			p.described = true
+			return
+		}
+
+		// duckgres-namespaced custom GUCs (query_source, s3_cache): answered
+		// from session state, never probed against DuckDB (which does not know
+		// these settings — the LIMIT-0 probe below would just fail and degrade
+		// to NoData). SET returns no rows; SHOW returns a single text column.
+		if p.stmt.querySourceSet != nil || p.stmt.s3CacheSet != nil {
+			_ = wire.WriteNoData(c.writer)
+			return
+		}
+		if p.stmt.querySourceShow {
+			_ = c.sendRowDescriptionWithFormats([]string{querySourceGUCName}, []ColumnTyper{staticColumnType("VARCHAR")}, p.resultFormats)
+			p.described = true
+			return
+		}
+		if p.stmt.s3CacheShow {
+			_ = c.sendRowDescriptionWithFormats([]string{s3CacheGUCName}, []ColumnTyper{staticColumnType("VARCHAR")}, p.resultFormats)
 			p.described = true
 			return
 		}
@@ -609,6 +641,27 @@ func (c *clientConn) handleExecute(body []byte) {
 			_ = c.sendRowDescription([]string{querySourceGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
 		}
 		_ = c.sendDataRowWithFormats([]interface{}{c.QuerySource()}, p.resultFormats, nil)
+		_ = c.writeCommandComplete("SHOW")
+		return
+	}
+
+	// duckgres.s3_cache custom GUC (SET / SHOW): intercepted session-side,
+	// applied via the worker transport swap. Determined by the transpiler
+	// during Parse. A failed swap errors the Execute so the session state
+	// never diverges from the worker's actual transport.
+	if p.stmt.s3CacheSet != nil {
+		if err := c.applyS3CacheSetting(*p.stmt.s3CacheSet); err != nil {
+			c.sendError("ERROR", "XX000", err.Error())
+			return
+		}
+		_ = c.writeCommandComplete("SET")
+		return
+	}
+	if p.stmt.s3CacheShow {
+		if !p.described {
+			_ = c.sendRowDescription([]string{s3CacheGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
+		}
+		_ = c.sendDataRowWithFormats([]interface{}{c.s3CacheValue()}, p.resultFormats, nil)
 		_ = c.writeCommandComplete("SHOW")
 		return
 	}

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -553,6 +553,24 @@ func (c *clientConn) executeSingleStatement(query string) (errSent bool, fatalEr
 		return false, nil
 	}
 
+	// duckgres.s3_cache custom GUC (SET / SHOW): intercepted session-side and
+	// applied via the worker transport swap. A failed swap aborts the rest of
+	// the batch — later statements may depend on the requested cache state.
+	if result.S3CacheSet != nil {
+		if err := c.applyS3CacheSetting(*result.S3CacheSet); err != nil {
+			c.sendError("ERROR", "XX000", err.Error())
+			return true, nil
+		}
+		_ = c.writeCommandComplete("SET")
+		return false, nil
+	}
+	if result.S3CacheShow {
+		_ = c.sendRowDescription([]string{s3CacheGUCName}, []ColumnTyper{staticColumnType("VARCHAR")})
+		_ = c.sendDataRowWithFormats([]interface{}{c.s3CacheValue()}, nil, nil)
+		_ = c.writeCommandComplete("SHOW")
+		return false, nil
+	}
+
 	if result.IsIgnoredSet {
 		_ = c.writeCommandComplete("SET")
 		return false, nil

--- a/server/conn_s3_cache.go
+++ b/server/conn_s3_cache.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/posthog/duckgres/transpiler/transform"
+)
+
+// s3CacheGUCName is the fully-qualified name of the duckgres-namespaced
+// session GUC controlling whether the session's DuckLake S3 traffic is served
+// through the node-local cache proxy (remote/k8s workers). Used as the SHOW
+// result column label.
+const s3CacheGUCName = "duckgres.s3_cache"
+
+// s3CacheApplyTimeout bounds the worker RPC that swaps the S3 secret
+// transport. The swap is a single CREATE OR REPLACE SECRET on the worker's
+// control connection, but it briefly takes the worker's DuckLake semaphore,
+// so allow for a concurrent attach/refresh to finish first.
+const s3CacheApplyTimeout = 30 * time.Second
+
+// S3CacheControl is the optional session-executor capability behind the
+// `duckgres.s3_cache` GUC: swapping the worker-side S3 secret between the
+// cache-proxy transport (enabled, the default) and the org's native HTTPS
+// transport (bypassed). flightclient.FlightExecutor implements it for
+// remote/k8s workers. Executors that don't implement it (standalone,
+// in-process) get session-state-only SET/SHOW, which is correct because those
+// deployments never route S3 traffic through a cache proxy — there is nothing
+// to bypass.
+type S3CacheControl interface {
+	SetS3CacheEnabled(ctx context.Context, enabled bool) error
+}
+
+// S3CacheEnabled reports the session's `duckgres.s3_cache` state. Defaults to
+// true: the cache proxy serves all S3 traffic unless this session explicitly
+// opted out.
+func (c *clientConn) S3CacheEnabled() bool {
+	return !c.s3CacheOff
+}
+
+// s3CacheValue is the SHOW-facing rendering of the session state.
+func (c *clientConn) s3CacheValue() string {
+	if c.s3CacheOff {
+		return transform.S3CacheOff
+	}
+	return transform.S3CacheOn
+}
+
+// applyS3CacheSetting applies an already-normalized `duckgres.s3_cache` value
+// ("on", "off", or "" = reset to the default "on") to the session. When the
+// effective state changes and the session executor supports per-session S3
+// cache control, the worker swap RPC runs FIRST and the session state is only
+// updated on success — a SET that failed to take effect on the worker must
+// error, not leave SHOW claiming a transport the worker isn't using. Callers
+// pass validated values only (transform.NormalizeS3Cache, rejecting anything
+// else with 22023 before this is reached).
+func (c *clientConn) applyS3CacheSetting(value string) error {
+	enabled := value != transform.S3CacheOff
+	if enabled != c.S3CacheEnabled() {
+		if ctrl, ok := c.executor.(S3CacheControl); ok {
+			c.ensureConnectionContext()
+			ctx, cancel := context.WithTimeout(c.ctx, s3CacheApplyTimeout)
+			defer cancel()
+			if err := ctrl.SetS3CacheEnabled(ctx, enabled); err != nil {
+				return fmt.Errorf("failed to apply %s: %w", s3CacheGUCName, err)
+			}
+		}
+		c.logger().Info("Set duckgres.s3_cache.", "enabled", enabled)
+	}
+	c.s3CacheOff = !enabled
+	return nil
+}
+
+// applyStartupS3Cache validates and applies a `-c duckgres.s3_cache=…`
+// startup-option value. An invalid value returns the 22023 error for the
+// caller to reject the connection with (mirroring duckgres.query_source and
+// the duckgres.worker_* startup options); a worker-apply failure returns that
+// error so the caller can refuse the connection rather than start a session
+// whose cache state doesn't match the requested option.
+func (c *clientConn) applyStartupS3Cache(raw string) error {
+	norm, err := transform.NormalizeS3Cache(raw)
+	if err != nil {
+		return err
+	}
+	return c.applyS3CacheSetting(norm)
+}
+
+// S3CacheGUCName is the startup-option / GUC name, exported for the control
+// plane's startup-option parsing.
+const S3CacheGUCName = s3CacheGUCName
+
+// ValidateS3CacheOption validates a `-c duckgres.s3_cache=…` startup-option
+// value without applying it. The control plane calls this BEFORE acquiring a
+// worker so a bad option is rejected (FATAL 22023) without spending a spawn.
+func ValidateS3CacheOption(raw string) error {
+	_, err := transform.NormalizeS3Cache(raw)
+	return err
+}
+
+// ApplyConnectionS3CacheOption applies a pre-validated `-c duckgres.s3_cache=…`
+// startup option on a control-plane connection whose session executor is
+// already bound. A returned error means the worker could not swap the S3
+// transport — the caller should refuse the connection (FATAL) rather than
+// start a session whose cache state doesn't match the requested option (a
+// benchmark connecting with s3_cache=off must never silently run cached).
+func ApplyConnectionS3CacheOption(cc *clientConn, raw string) error {
+	return cc.applyStartupS3Cache(raw)
+}

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -40,6 +40,7 @@ const (
 	waitSessionIdleAction    = "WaitSessionIdle"
 	releaseQueryHandleAction = "ReleaseQueryHandle"
 	logQueryAction           = "LogQuery"
+	setSessionS3CacheAction  = "SetSessionS3Cache"
 	queryCloseWaitTimeout    = 30 * time.Second
 	queryLogForwardTimeout   = 5 * time.Second
 	queryLogMaxInFlight      = 64
@@ -587,6 +588,57 @@ func (e *FlightExecutor) waitForSessionIdle() (err error) {
 			if isTerminalSessionIdleWaitError(err) {
 				return nil
 			}
+			return err
+		}
+	}
+}
+
+// SetS3CacheEnabled asks the session's worker to route the tenant's S3
+// traffic through the node-local cache proxy (true, the default) or to bypass
+// it (false) by swapping the S3 secret's transport. Implements the server
+// package's S3CacheControl capability, backing the `duckgres.s3_cache`
+// session GUC. Unlike the best-effort teardown actions above, errors are
+// surfaced: a SET that did not take effect on the worker must fail, not
+// silently leave the session in the wrong cache state. Workers running an
+// image that predates the action reject it with Unimplemented, which also
+// surfaces as an error.
+func (e *FlightExecutor) SetS3CacheEnabled(ctx context.Context, enabled bool) (err error) {
+	if e.dead.Load() {
+		return ErrWorkerDead
+	}
+	if e.client == nil || e.client.Client == nil {
+		return ErrWorkerDead
+	}
+	defer recoverClientPanic(&err)
+
+	payload, err := json.Marshal(wire.WorkerSetS3CachePayload{
+		WorkerControlMetadata: wire.WorkerControlMetadata{
+			WorkerID:     e.workerID,
+			OwnerEpoch:   e.ownerEpoch,
+			CPInstanceID: e.cpInstanceID,
+		},
+		Enabled: enabled,
+	})
+	if err != nil {
+		return err
+	}
+
+	merged, cancel := e.mergedContext(ctx)
+	defer cancel()
+
+	stream, err := e.client.Client.DoAction(
+		e.withSession(merged),
+		&flight.Action{Type: setSessionS3CacheAction, Body: payload},
+	)
+	if err != nil {
+		return err
+	}
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/server/s3_cache_test.go
+++ b/server/s3_cache_test.go
@@ -1,0 +1,340 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// s3CacheRecordingExecutor is a selectOneExecutor that also implements the
+// S3CacheControl capability, recording the worker swap calls the conn issues.
+type s3CacheRecordingExecutor struct {
+	selectOneExecutor
+	calls []bool
+	err   error
+}
+
+func (e *s3CacheRecordingExecutor) SetS3CacheEnabled(_ context.Context, enabled bool) error {
+	e.calls = append(e.calls, enabled)
+	return e.err
+}
+
+// TestS3CacheSimpleSetAppliesToExecutor asserts the core contract of the SET
+// path: `SET duckgres.s3_cache = off` invokes the executor capability with
+// enabled=false BEFORE the session state flips, SHOW then reports "off", and
+// setting it back to on invokes the capability with enabled=true. Re-setting
+// the current value must NOT re-invoke the worker (no redundant secret swaps).
+func TestS3CacheSimpleSetAppliesToExecutor(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{}
+	c, out := newBufferedConn(exec)
+
+	if !c.S3CacheEnabled() {
+		t.Fatalf("fresh session S3CacheEnabled() = false, want true (default on)")
+	}
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off\x00")); err != nil {
+		t.Fatalf("handleQuery(SET off): %v", err)
+	}
+	if len(exec.calls) != 1 || exec.calls[0] != false {
+		t.Fatalf("executor calls after SET off = %v, want [false]", exec.calls)
+	}
+	if c.S3CacheEnabled() {
+		t.Fatalf("S3CacheEnabled() = true after SET off, want false")
+	}
+
+	// SHOW reports the session state.
+	out.Reset()
+	if err := c.handleQuery([]byte("SHOW duckgres.s3_cache\x00")); err != nil {
+		t.Fatalf("handleQuery(SHOW): %v", err)
+	}
+	sawOff := false
+	for _, m := range parseWireMsgs(t, out.Bytes()) {
+		if m.typ == 'D' && bytes.Contains(m.body, []byte("off")) {
+			sawOff = true
+		}
+	}
+	if !sawOff {
+		t.Fatalf("SHOW duckgres.s3_cache did not report 'off'")
+	}
+
+	// Redundant SET to the same value: state-only, no worker call.
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off\x00")); err != nil {
+		t.Fatalf("handleQuery(redundant SET off): %v", err)
+	}
+	if len(exec.calls) != 1 {
+		t.Fatalf("redundant SET off re-invoked the worker: calls = %v", exec.calls)
+	}
+
+	// Back on (via RESET, which maps to the default).
+	if err := c.handleQuery([]byte("RESET duckgres.s3_cache\x00")); err != nil {
+		t.Fatalf("handleQuery(RESET): %v", err)
+	}
+	if len(exec.calls) != 2 || exec.calls[1] != true {
+		t.Fatalf("executor calls after RESET = %v, want [false true]", exec.calls)
+	}
+	if !c.S3CacheEnabled() {
+		t.Fatalf("S3CacheEnabled() = false after RESET, want true")
+	}
+}
+
+// TestS3CacheSetWorkerFailureKeepsState asserts a failed worker swap fails the
+// SET (ErrorResponse, no CommandComplete) and leaves the session state on its
+// previous value — SHOW must never claim a transport the worker isn't using.
+func TestS3CacheSetWorkerFailureKeepsState(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{err: errors.New("swap S3 secret transport: boom")}
+	c, out := newBufferedConn(exec)
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off\x00")); err != nil {
+		t.Fatalf("handleQuery(SET off): %v", err)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "XX000", s3CacheGUCName) {
+		t.Fatalf("failed worker swap did not surface as XX000 ErrorResponse; msgs=%s", describeMsgs(msgs))
+	}
+	for _, m := range msgs {
+		if m.typ == 'C' && bytes.Contains(m.body, []byte("SET")) {
+			t.Fatalf("failed SET still produced CommandComplete(SET); msgs=%s", describeMsgs(msgs))
+		}
+	}
+	if !c.S3CacheEnabled() {
+		t.Fatalf("failed swap flipped session state: S3CacheEnabled() = false, want true")
+	}
+
+	// SHOW after the failure still reports the (unchanged) default.
+	out.Reset()
+	if err := c.handleQuery([]byte("SHOW duckgres.s3_cache\x00")); err != nil {
+		t.Fatalf("handleQuery(SHOW): %v", err)
+	}
+	sawOn := false
+	for _, m := range parseWireMsgs(t, out.Bytes()) {
+		if m.typ == 'D' && bytes.Contains(m.body, []byte("on")) {
+			sawOn = true
+		}
+	}
+	if !sawOn {
+		t.Fatalf("SHOW after failed SET did not report 'on'")
+	}
+}
+
+// TestS3CacheSetWithoutCapabilityIsStateOnly asserts the standalone/in-process
+// case: an executor that does not implement S3CacheControl gets
+// session-state-only SET/SHOW (no error) — correct because those deployments
+// have no cache proxy to bypass.
+func TestS3CacheSetWithoutCapabilityIsStateOnly(t *testing.T) {
+	c, out := newBufferedConn(&selectOneExecutor{})
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off\x00")); err != nil {
+		t.Fatalf("handleQuery(SET off): %v", err)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	sawSet := false
+	for _, m := range msgs {
+		if m.typ == 'C' && bytes.Contains(m.body, []byte("SET")) {
+			sawSet = true
+		}
+	}
+	if !sawSet {
+		t.Fatalf("SET without capability did not complete; msgs=%s", describeMsgs(msgs))
+	}
+	if c.S3CacheEnabled() {
+		t.Fatalf("S3CacheEnabled() = true after SET off, want false (state-only)")
+	}
+}
+
+// TestS3CacheInvalidSetRejected asserts the simple-protocol SET path rejects a
+// non-boolean value with 22023, names the valid values without echoing the
+// client input, and leaves the session state untouched.
+func TestS3CacheInvalidSetRejected(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{}
+	c, out := newBufferedConn(exec)
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = 'garbage'\x00")); err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "22023", `"on"`, `"off"`) {
+		t.Fatalf("no 22023 ErrorResponse naming the valid values; msgs=%s", describeMsgs(msgs))
+	}
+	if errorResponseWith(msgs, "garbage") {
+		t.Fatalf("rejection echoes the offending value; msgs=%s", describeMsgs(msgs))
+	}
+	if len(exec.calls) != 0 {
+		t.Fatalf("rejected SET reached the executor: calls = %v", exec.calls)
+	}
+	if !c.S3CacheEnabled() {
+		t.Fatalf("rejected SET flipped session state")
+	}
+}
+
+// TestS3CacheMixedBatch asserts the split-batch path: `SET duckgres.s3_cache =
+// off; SELECT 1` applies the GUC (worker call included) and still runs the
+// trailing SELECT.
+func TestS3CacheMixedBatch(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{}
+	c, out := newBufferedConn(exec)
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off; SELECT 1\x00")); err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+	if len(exec.calls) != 1 || exec.calls[0] != false {
+		t.Fatalf("executor calls = %v, want [false]", exec.calls)
+	}
+	if exec.queryCalls != 1 {
+		t.Fatalf("SELECT did not run: QueryContext called %d times, want 1", exec.queryCalls)
+	}
+	if c.S3CacheEnabled() {
+		t.Fatalf("S3CacheEnabled() = true after batched SET off, want false")
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	var sawSet, sawSelect bool
+	for _, m := range msgs {
+		if m.typ == 'C' {
+			if bytes.Contains(m.body, []byte("SET")) {
+				sawSet = true
+			}
+			if bytes.Contains(m.body, []byte("SELECT")) {
+				sawSelect = true
+			}
+		}
+	}
+	if !sawSet || !sawSelect {
+		t.Fatalf("batch did not complete both statements (SET=%v SELECT=%v); msgs=%s", sawSet, sawSelect, describeMsgs(msgs))
+	}
+}
+
+// TestS3CacheMixedBatchWorkerFailureAborts asserts a failed swap inside a
+// batch aborts the remaining statements — they may depend on the requested
+// cache state.
+func TestS3CacheMixedBatchWorkerFailureAborts(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{err: errors.New("boom")}
+	c, out := newBufferedConn(exec)
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = off; SELECT 1\x00")); err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+	if exec.queryCalls != 0 {
+		t.Fatalf("SELECT ran after the failed SET: QueryContext called %d times, want 0", exec.queryCalls)
+	}
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "XX000") {
+		t.Fatalf("failed batched SET did not surface XX000; msgs=%s", describeMsgs(msgs))
+	}
+}
+
+// TestS3CacheStartupOption asserts `-c duckgres.s3_cache=...` parsing and
+// application: valid values apply through the executor capability, invalid
+// values return the 22023 error the startup handler turns into a FATAL
+// rejection (before session state changes).
+func TestS3CacheStartupOption(t *testing.T) {
+	opts := ParseStartupOptions("-c duckgres.s3_cache=off")
+	if got := opts[s3CacheGUCName]; got != "off" {
+		t.Fatalf("ParseStartupOptions[%q] = %q, want %q", s3CacheGUCName, got, "off")
+	}
+
+	valid := map[string]bool{ // raw -> want S3CacheEnabled
+		"off":   false,
+		"OFF":   false,
+		"false": false,
+		"0":     false,
+		"on":    true,
+		"true":  true,
+		" on ":  true,
+		"":      true, // empty = default
+	}
+	for raw, want := range valid {
+		exec := &s3CacheRecordingExecutor{}
+		c, _ := newBufferedConn(exec)
+		if err := c.applyStartupS3Cache(raw); err != nil {
+			t.Fatalf("applyStartupS3Cache(%q) error: %v", raw, err)
+		}
+		if got := c.S3CacheEnabled(); got != want {
+			t.Fatalf("after startup option %q, S3CacheEnabled() = %v, want %v", raw, got, want)
+		}
+		if !want && (len(exec.calls) != 1 || exec.calls[0] != false) {
+			t.Fatalf("startup option %q: executor calls = %v, want [false]", raw, exec.calls)
+		}
+		if want && len(exec.calls) != 0 {
+			t.Fatalf("startup option %q: executor calls = %v, want none (already on)", raw, exec.calls)
+		}
+	}
+
+	for _, raw := range []string{"garbage", "offf", strings.Repeat("x", 10*1024)} {
+		exec := &s3CacheRecordingExecutor{}
+		c, _ := newBufferedConn(exec)
+		err := c.applyStartupS3Cache(raw)
+		if err == nil {
+			t.Fatalf("applyStartupS3Cache(%.40q) = nil error, want 22023 rejection", raw)
+		}
+		var coded interface{ SQLState() string }
+		if !errors.As(err, &coded) || coded.SQLState() != "22023" {
+			t.Fatalf("applyStartupS3Cache(%.40q) error = %v, want SQLSTATE 22023", raw, err)
+		}
+		if len(exec.calls) != 0 {
+			t.Fatalf("rejected startup option reached the executor: calls = %v", exec.calls)
+		}
+		if !c.S3CacheEnabled() {
+			t.Fatalf("rejected startup option flipped session state")
+		}
+	}
+
+	// ValidateS3CacheOption (the control plane's pre-acquire gate) agrees with
+	// the apply path.
+	if err := ValidateS3CacheOption("off"); err != nil {
+		t.Fatalf("ValidateS3CacheOption(off) error: %v", err)
+	}
+	if err := ValidateS3CacheOption("junk"); err == nil {
+		t.Fatalf("ValidateS3CacheOption(junk) = nil error, want rejection")
+	}
+}
+
+// TestS3CacheExtendedParse asserts the extended-protocol path: an invalid
+// value is rejected at Parse time; a valid SET parses, applies at Execute
+// time through the executor capability, and Describe returns NoData.
+func TestS3CacheExtendedParse(t *testing.T) {
+	exec := &s3CacheRecordingExecutor{}
+	c, out := newBufferedConn(exec)
+	c.stmts = make(map[string]*preparedStmt)
+	c.portals = make(map[string]*portal)
+
+	// Invalid value: rejected at Parse, nothing stored.
+	body := append([]byte("s1\x00SET duckgres.s3_cache = 'garbage'\x00"), 0, 0)
+	c.handleParse(body)
+	_ = c.flushWriter()
+	msgs := parseWireMsgs(t, out.Bytes())
+	if !errorResponseWith(msgs, "22023", `"on"`, `"off"`) {
+		t.Fatalf("extended Parse of invalid SET not rejected with 22023; msgs=%s", describeMsgs(msgs))
+	}
+	if _, ok := c.stmts["s1"]; ok {
+		t.Fatalf("rejected Parse still stored the prepared statement")
+	}
+
+	// Valid SET: parses with s3CacheSet populated.
+	out.Reset()
+	body = append([]byte("s2\x00SET duckgres.s3_cache = 'off'\x00"), 0, 0)
+	c.handleParse(body)
+	_ = c.flushWriter()
+	st, ok := c.stmts["s2"]
+	if !ok {
+		t.Fatalf("valid SET did not parse: msgs=%s", describeMsgs(parseWireMsgs(t, out.Bytes())))
+	}
+	if st.s3CacheSet == nil || *st.s3CacheSet != "off" {
+		t.Fatalf("prepared stmt s3CacheSet = %v, want off", st.s3CacheSet)
+	}
+
+	// Bind + Execute applies through the capability.
+	out.Reset()
+	// Bind message: portal name, statement name (NUL-terminated), int16 format
+	// count (0), int16 param count (0), int16 result-format count (0).
+	bindBody := append([]byte("\x00s2\x00"), 0, 0, 0, 0, 0, 0)
+	c.handleBind(bindBody)
+	c.handleExecute(append([]byte("\x00"), 0, 0, 0, 0))
+	_ = c.flushWriter()
+	if len(exec.calls) != 1 || exec.calls[0] != false {
+		t.Fatalf("executor calls after extended Execute = %v, want [false]", exec.calls)
+	}
+	if c.S3CacheEnabled() {
+		t.Fatalf("S3CacheEnabled() = true after extended SET off, want false")
+	}
+}

--- a/server/s3_cache_test.go
+++ b/server/s3_cache_test.go
@@ -289,35 +289,48 @@ func TestS3CacheStartupOption(t *testing.T) {
 	}
 }
 
-// TestRedactS3SecretMaterial asserts RefreshS3Secret's error scrubber: a
-// DuckDB error echoing the CREATE SECRET SQL must have every credential value
-// replaced before the error leaves RefreshS3Secret — its errors reach worker
-// and CP logs and, via the duckgres.s3_cache SET / session-create restore
-// paths, client-facing error messages, the query log, and the admin
-// recent-errors ring.
-func TestRedactS3SecretMaterial(t *testing.T) {
-	cfg := DuckLakeConfig{
-		S3AccessKey:    "ASIAEXAMPLEKEY",
-		S3SecretKey:    "verysecretvalue",
-		S3SessionToken: "sessiontokenvalue",
+// TestRedactSecretStatementError asserts RefreshS3Secret's error scrubber
+// keeps only the engine error-class prefix: its errors reach worker and CP
+// logs and, via the duckgres.s3_cache SET / session-create restore paths,
+// client-facing error messages, the query log, and the admin recent-errors
+// ring. Exact-value replacement is NOT enough — DuckDB ellipsizes long echoed
+// SQL lines, so a truncated echo carries credential FRAGMENTS that no
+// full-value match catches (reproduced against a live DuckDB: a 640-char
+// secret left a 57-char fragment in the "LINE 1: ...xxx' ..." excerpt).
+func TestRedactSecretStatementError(t *testing.T) {
+	secret := strings.Repeat("S", 40) + strings.Repeat("T", 600)
+	// The ellipsized echo shape DuckDB actually produces: full value absent,
+	// contiguous fragment present.
+	echo := "Parser Error: syntax error at or near \"BROKEN\"\n" +
+		"LINE 1: ..." + secret[len(secret)-57:] + "' BROKEN"
+	got := redactSecretStatementError(echo)
+	if got != "Parser Error: [details redacted: engine errors may echo secret SQL]" {
+		t.Fatalf("unexpected redaction: %q", got)
 	}
-	echo := `Parser Error: syntax error at or near "SECRET"
-LINE 1: CREATE OR REPLACE SECRET ducklake_s3 (TYPE s3, KEY_ID 'ASIAEXAMPLEKEY', SECRET 'verysecretvalue', SESSION_TOKEN 'sessiontokenvalue')`
-	got := redactS3SecretMaterial(cfg, echo)
-	for _, leaked := range []string{"verysecretvalue", "sessiontokenvalue", "ASIAEXAMPLEKEY"} {
-		if strings.Contains(got, leaked) {
-			t.Fatalf("redacted message still contains %q: %s", leaked, got)
+	for i := 0; i+12 <= len(secret); i += 4 {
+		if strings.Contains(got, secret[i:i+12]) {
+			t.Fatalf("redacted message still contains a credential fragment: %q", got)
 		}
 	}
-	if !strings.Contains(got, "Parser Error") || !strings.Contains(got, "[REDACTED]") {
-		t.Fatalf("redaction lost the diagnostic context: %s", got)
+
+	// Ordinary runtime errors keep their class for triage, nothing more.
+	if got := redactSecretStatementError("IO Error: Connection refused (s3.us-east-1.amazonaws.com:443)"); got !=
+		"IO Error: [details redacted: engine errors may echo secret SQL]" {
+		t.Fatalf("IO error class not preserved: %q", got)
 	}
 
-	// Empty credential fields must not turn into degenerate replacements, and
-	// messages without credential material pass through unchanged.
-	plain := "IO Error: Connection refused (s3.us-east-1.amazonaws.com:443)"
-	if got := redactS3SecretMaterial(DuckLakeConfig{}, plain); got != plain {
-		t.Fatalf("credential-free message was altered: %q", got)
+	// Messages that don't follow the class-colon shape — or whose "prefix" is
+	// long or quote-bearing enough to carry echoed SQL — drop entirely.
+	for _, msg := range []string{
+		"no colon here at all",
+		"", // empty
+		"prefix with 'quoted " + secret[:24] + "' content: detail",
+		strings.Repeat("x", 80) + ": detail",
+	} {
+		got := redactSecretStatementError(msg)
+		if got != "[details redacted: engine errors may echo secret SQL]" {
+			t.Fatalf("unsafe prefix survived for %.40q: %q", msg, got)
+		}
 	}
 }
 

--- a/server/s3_cache_test.go
+++ b/server/s3_cache_test.go
@@ -289,6 +289,38 @@ func TestS3CacheStartupOption(t *testing.T) {
 	}
 }
 
+// TestRedactS3SecretMaterial asserts RefreshS3Secret's error scrubber: a
+// DuckDB error echoing the CREATE SECRET SQL must have every credential value
+// replaced before the error leaves RefreshS3Secret — its errors reach worker
+// and CP logs and, via the duckgres.s3_cache SET / session-create restore
+// paths, client-facing error messages, the query log, and the admin
+// recent-errors ring.
+func TestRedactS3SecretMaterial(t *testing.T) {
+	cfg := DuckLakeConfig{
+		S3AccessKey:    "ASIAEXAMPLEKEY",
+		S3SecretKey:    "verysecretvalue",
+		S3SessionToken: "sessiontokenvalue",
+	}
+	echo := `Parser Error: syntax error at or near "SECRET"
+LINE 1: CREATE OR REPLACE SECRET ducklake_s3 (TYPE s3, KEY_ID 'ASIAEXAMPLEKEY', SECRET 'verysecretvalue', SESSION_TOKEN 'sessiontokenvalue')`
+	got := redactS3SecretMaterial(cfg, echo)
+	for _, leaked := range []string{"verysecretvalue", "sessiontokenvalue", "ASIAEXAMPLEKEY"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("redacted message still contains %q: %s", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "Parser Error") || !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("redaction lost the diagnostic context: %s", got)
+	}
+
+	// Empty credential fields must not turn into degenerate replacements, and
+	// messages without credential material pass through unchanged.
+	plain := "IO Error: Connection refused (s3.us-east-1.amazonaws.com:443)"
+	if got := redactS3SecretMaterial(DuckLakeConfig{}, plain); got != plain {
+		t.Fatalf("credential-free message was altered: %q", got)
+	}
+}
+
 // TestS3CacheExtendedParse asserts the extended-protocol path: an invalid
 // value is rejected at Parse time; a valid SET parses, applies at Execute
 // time through the executor capability, and Describe returns NoData.

--- a/server/server.go
+++ b/server/server.go
@@ -2120,36 +2120,40 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 		if isTransactionAborted(err) {
 			_, _ = ae.Exec("ROLLBACK")
 			if _, retryErr := ae.Exec(secretStmt); retryErr != nil {
-				return fmt.Errorf("refresh S3 secret after rollback: %s", redactS3SecretMaterial(dlCfg, retryErr.Error()))
+				return fmt.Errorf("refresh S3 secret after rollback: %s", redactSecretStatementError(retryErr.Error()))
 			}
 		} else {
-			return fmt.Errorf("refresh S3 secret: %s", redactS3SecretMaterial(dlCfg, err.Error()))
+			return fmt.Errorf("refresh S3 secret: %s", redactSecretStatementError(err.Error()))
 		}
 	}
 	slog.Debug("Refreshed S3 secret for hot-idle reuse.", "provider", provider)
 	return nil
 }
 
-// redactS3SecretMaterial scrubs the S3 credential material embedded in the
-// CREATE SECRET statement out of an engine error message. DuckDB errors can
-// echo the offending SQL ("LINE 1: ... SECRET '...' ..."), and RefreshS3Secret
-// errors flow into worker and control-plane logs and — via the
-// duckgres.s3_cache SET / session-create restore paths — into client-facing
-// error messages, the query log, and the admin recent-errors ring, so raw
-// engine text must never leave RefreshS3Secret. Targeted value replacement
-// (rather than usersecrets.RedactErrorForLog's whole-message placeholder)
-// keeps the actual failure reason diagnosable. Covers the config-provider
-// credentials embedded from dlCfg — the managed-warehouse path behind every
-// RefreshS3Secret caller; aws_sdk-provider statements embed credentials
-// fetched inside buildAWSSdkSecret, which this cannot see (pre-existing
-// exposure class on the attach path, tracked by the standing CodeQL alert).
-func redactS3SecretMaterial(dlCfg DuckLakeConfig, msg string) string {
-	for _, v := range []string{dlCfg.S3SecretKey, dlCfg.S3SessionToken, dlCfg.S3AccessKey} {
-		if v != "" {
-			msg = strings.ReplaceAll(msg, v, "[REDACTED]")
-		}
+// redactSecretStatementError reduces an engine error from a CREATE SECRET
+// statement to its error-class prefix ("Parser Error", "IO Error", ...) plus
+// a fixed placeholder. RefreshS3Secret errors flow beyond internal logs —
+// via the duckgres.s3_cache SET / session-create restore paths into
+// client-facing error messages, the query log, and the admin recent-errors
+// ring — so no engine detail may survive: DuckDB errors can echo the
+// offending SQL, and the echo is ELLIPSIZED for long lines ("LINE 1:
+// ...oken' ..."), so matching-and-replacing complete credential values is NOT
+// sufficient — a truncated echo carries credential FRAGMENTS no exact match
+// catches, and even the first line's `at or near "..."` token can hold
+// string-literal content. Dropping everything after the class prefix is the
+// only airtight shape (the repo precedent is usersecrets.RedactErrorForLog's
+// whole-message placeholder; keeping the class preserves triage value at zero
+// leak surface, and works regardless of where the credentials came from —
+// dlCfg or buildAWSSdkSecret's internally-fetched ones).
+func redactSecretStatementError(msg string) string {
+	const placeholder = "[details redacted: engine errors may echo secret SQL]"
+	// An error class is a short leading tag; a "prefix" long enough to carry
+	// echoed SQL means the message doesn't follow the class-colon shape — drop
+	// it entirely.
+	if idx := strings.Index(msg, ":"); idx > 0 && idx <= 64 && !strings.ContainsAny(msg[:idx], "'\"\n") {
+		return msg[:idx] + ": " + placeholder
 	}
-	return msg
+	return placeholder
 }
 
 // resolveS3SecretTransport picks the URL_STYLE and USE_SSL values to embed in

--- a/server/server.go
+++ b/server/server.go
@@ -2120,14 +2120,36 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 		if isTransactionAborted(err) {
 			_, _ = ae.Exec("ROLLBACK")
 			if _, retryErr := ae.Exec(secretStmt); retryErr != nil {
-				return fmt.Errorf("refresh S3 secret after rollback: %w", retryErr)
+				return fmt.Errorf("refresh S3 secret after rollback: %s", redactS3SecretMaterial(dlCfg, retryErr.Error()))
 			}
 		} else {
-			return fmt.Errorf("refresh S3 secret: %w", err)
+			return fmt.Errorf("refresh S3 secret: %s", redactS3SecretMaterial(dlCfg, err.Error()))
 		}
 	}
 	slog.Debug("Refreshed S3 secret for hot-idle reuse.", "provider", provider)
 	return nil
+}
+
+// redactS3SecretMaterial scrubs the S3 credential material embedded in the
+// CREATE SECRET statement out of an engine error message. DuckDB errors can
+// echo the offending SQL ("LINE 1: ... SECRET '...' ..."), and RefreshS3Secret
+// errors flow into worker and control-plane logs and — via the
+// duckgres.s3_cache SET / session-create restore paths — into client-facing
+// error messages, the query log, and the admin recent-errors ring, so raw
+// engine text must never leave RefreshS3Secret. Targeted value replacement
+// (rather than usersecrets.RedactErrorForLog's whole-message placeholder)
+// keeps the actual failure reason diagnosable. Covers the config-provider
+// credentials embedded from dlCfg — the managed-warehouse path behind every
+// RefreshS3Secret caller; aws_sdk-provider statements embed credentials
+// fetched inside buildAWSSdkSecret, which this cannot see (pre-existing
+// exposure class on the attach path, tracked by the standing CodeQL alert).
+func redactS3SecretMaterial(dlCfg DuckLakeConfig, msg string) string {
+	for _, v := range []string{dlCfg.S3SecretKey, dlCfg.S3SessionToken, dlCfg.S3AccessKey} {
+		if v != "" {
+			msg = strings.ReplaceAll(msg, v, "[REDACTED]")
+		}
+	}
+	return msg
 }
 
 // resolveS3SecretTransport picks the URL_STYLE and USE_SSL values to embed in

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -56,6 +56,18 @@ type WorkerWaitSessionIdlePayload struct {
 	WorkerControlMetadata
 }
 
+// WorkerSetS3CachePayload asks a worker to route the tenant's S3 traffic
+// through the node-local cache proxy (Enabled=true, the default transport) or
+// to bypass it (Enabled=false: the S3 secret is rebuilt with the org's native
+// HTTPS transport, so the proxy blind-tunnels via CONNECT and never serves or
+// fills its cache). Session-scoped in effect because remote workers run one
+// session at a time; the worker restores the proxy transport before the next
+// session starts. Carries the `duckgres.s3_cache` session GUC.
+type WorkerSetS3CachePayload struct {
+	WorkerControlMetadata
+	Enabled bool `json:"enabled"`
+}
+
 // WorkerReleaseQueryHandlePayload asks a worker to release a statement query
 // handle that was created by GetFlightInfo but abandoned before DoGet could
 // consume it.

--- a/server/worker_control.go
+++ b/server/worker_control.go
@@ -12,6 +12,7 @@ type (
 	WorkerDestroySessionPayload     = wire.WorkerDestroySessionPayload
 	WorkerHealthCheckPayload        = wire.WorkerHealthCheckPayload
 	WorkerWaitSessionIdlePayload    = wire.WorkerWaitSessionIdlePayload
+	WorkerSetS3CachePayload         = wire.WorkerSetS3CachePayload
 	WorkerReleaseQueryHandlePayload = wire.WorkerReleaseQueryHandlePayload
 	WorkerQueryLogPayload           = wire.WorkerQueryLogPayload
 )

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -21,7 +21,14 @@
 # duckgres-cache-proxy DaemonSet, and enabling DUCKGRES_CACHE_ENABLED without it
 # would hang worker startup on the proxy health wait. Covered by
 # TestSessionPoolCredentialRefreshKeepsCacheProxyTransport in
-# duckdbservice/activation_test.go.
+# duckdbservice/activation_test.go. The same applies to the per-session
+# duckgres.s3_cache secret-transport SWAP (SetS3CacheEnabled, its
+# restore-at-create/destroy, and its interplay with credential rotation):
+# unit-covered in duckdbservice/s3_cache_test.go, while the s3_cache_guc
+# assertion below exercises the full client-visible plumbing (CP interception,
+# the CP→worker SetSessionS3Cache action round-trip, closed-enum rejection,
+# startup options, fresh-session default) against real workers where the swap
+# itself no-ops.
 #
 #   wire/query   : SELECT 1 round-trips, N concurrent connections stay distinct,
 #                  a malformed startup-message length is rejected cleanly (no CP
@@ -409,6 +416,64 @@ query_source_guc() { # org password
   # Case-insensitive, normalized to lowercase.
   assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'ENDPOINTS'; SHOW duckgres.query_source" "endpoints" "query_source_case_insensitive"
   assert_lastline "$1" "$2" ducklake "SET duckgres.query_source = 'endpoints'; SELECT 1" "1" "query_source_set_then_query"
+}
+
+# s3_cache_guc exercises the duckgres.s3_cache session GUC end-to-end. When a
+# session sets it off, the CP asks the session's worker (SetSessionS3Cache
+# DoAction) to rebuild the tenant ducklake_s3 secret with the org's native
+# HTTPS transport so S3 traffic CONNECT-tunnels PAST the node-local cache
+# proxy; on/RESET restores the cache-proxy transport. mw-dev deploys no cache
+# proxy, so the worker-side swap no-ops here — what this asserts is the full
+# client-visible plumbing on a REAL worker: CP interception, the CP→worker
+# action round-trip on every state flip (a worker that rejected the action
+# would fail the SET), session-state SHOW, the 22023 closed-enum rejection,
+# batch splitting, DuckLake R/W inside a bypassed session, connect-time
+# startup options, and the fresh-session default. The actual secret-transport
+# swap and its restore/rotation invariants are unit-covered
+# (duckdbservice/s3_cache_test.go).
+s3_cache_guc() { # org password
+  log "duckgres.s3_cache session GUC on $1"
+  # Default is on; SET off round-trips within the session (this flip drives
+  # the worker RPC — a worker-side failure would error the SET).
+  assert_compat   "$1" "$2" ducklake "SHOW duckgres.s3_cache" "on" "s3_cache_default"
+  assert_lastline "$1" "$2" ducklake "SET duckgres.s3_cache = off; SHOW duckgres.s3_cache" "off" "s3_cache_set_off"
+  # DuckLake R/W still works inside a bypassed session (real S3 round-trip
+  # over whatever transport the worker now carries).
+  t="e2e_s3cache_$(echo "$1" | tr -c 'a-z0-9' _)"
+  assert_lastline "$1" "$2" ducklake "SET duckgres.s3_cache = off; DROP TABLE IF EXISTS $t; CREATE TABLE $t(id INT); INSERT INTO $t VALUES (1),(2); SELECT COUNT(*) FROM $t" "2" "s3_cache_off_ducklake_rw"
+  pg "$1" "$2" ducklake "DROP TABLE $t;"
+  # Closed enum: junk is rejected at SET time (22023) naming the valid values,
+  # and a fresh session still reports the default.
+  if out="$(pg_try "$1" "$2" ducklake "SET duckgres.s3_cache = 'junk'; SHOW duckgres.s3_cache")"; then
+    fail "s3_cache: invalid value 'junk' was accepted: $out"
+  fi
+  case "$out" in
+    *'must be "on" or "off"'*) ;;
+    *) fail "s3_cache: invalid-value rejection did not name the valid values: '$out'" ;;
+  esac
+  # Fresh-session default: a previous session's off must never leak into the
+  # org's next session (this org's hot-idle worker is reused across these
+  # connects, so this also crosses the worker-side restore path).
+  assert_compat "$1" "$2" ducklake "SHOW duckgres.s3_cache" "on" "s3_cache_fresh_session_default"
+  # RESET restores the default within a session.
+  assert_lastline "$1" "$2" ducklake "SET duckgres.s3_cache = off; RESET duckgres.s3_cache; SHOW duckgres.s3_cache" "on" "s3_cache_reset"
+
+  # Connect-time startup option (libpq options / PGOPTIONS): valid applies to
+  # the session, invalid is rejected pre-worker-acquisition with FATAL 22023.
+  got="$(PGPASSWORD="$2" psql \
+      "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake options='-c duckgres.s3_cache=off'" \
+      -v ON_ERROR_STOP=1 -tAc "SHOW duckgres.s3_cache" 2>&1)" \
+    || fail "s3_cache: connect with -c duckgres.s3_cache=off failed: $got"
+  [ "$got" = "off" ] || fail "s3_cache: startup option session reports '$got', want 'off'"
+  if out="$(PGPASSWORD="$2" psql \
+      "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake options='-c duckgres.s3_cache=junk'" \
+      -v ON_ERROR_STOP=1 -tAc "SELECT 1" 2>&1)"; then
+    fail "s3_cache: invalid startup option was accepted: $out"
+  fi
+  case "$out" in
+    *'must be "on" or "off"'*) ;;
+    *) fail "s3_cache: invalid startup-option rejection did not name the valid values: '$out'" ;;
+  esac
 }
 
 # Regression for #715: the CP reads the post-TLS startup message with the shared
@@ -3164,6 +3229,7 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   basic_query            "$CNPG" "$cnpg_pw"
   pg_compat_functions    "$CNPG" "$cnpg_pw"
   query_source_guc       "$CNPG" "$cnpg_pw"
+  s3_cache_guc           "$CNPG" "$cnpg_pw"
   malformed_startup_resilience "$CNPG" "$cnpg_pw"
   jsonb_concat_semantics "$CNPG" "$cnpg_pw"
   cold_burst_absorption  "$CNPG" "$cnpg_pw"   # early, while this org is mostly cold

--- a/transpiler/config.go
+++ b/transpiler/config.go
@@ -103,6 +103,20 @@ type Result struct {
 	// layer answers it from session state (defaulting to "standard").
 	QuerySourceShow bool
 
+	// S3CacheSet, when non-nil, indicates a `SET duckgres.s3_cache = '<value>'`
+	// on the duckgres-namespaced custom GUC. The connection layer applies the
+	// pointed-to value to the session (swapping the worker's S3 secret
+	// transport on or off the node-local cache proxy) and acknowledges it as
+	// "SET" — it is NOT forwarded to DuckDB, which would reject the unknown
+	// setting. The value is pre-validated and canonical: "on", "off", or ""
+	// (reset to the default "on") — an invalid value never reaches here (it
+	// surfaces as Error with SQLSTATE 22023 instead).
+	S3CacheSet *string
+
+	// S3CacheShow indicates a `SHOW duckgres.s3_cache`; the connection layer
+	// answers it from session state (defaulting to "on").
+	S3CacheShow bool
+
 	// Error is set when a transform detects an error that should be returned to the client
 	// (e.g., unrecognized configuration parameter in SHOW command)
 	Error error

--- a/transpiler/s3_cache_test.go
+++ b/transpiler/s3_cache_test.go
@@ -1,0 +1,155 @@
+package transpiler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestTranspile_S3CacheSet asserts that `SET duckgres.s3_cache = ...` is
+// intercepted as a duckgres-namespaced custom GUC (S3CacheSet populated, not
+// forwarded to DuckDB) and the value is normalized to the canonical on/off.
+func TestTranspile_S3CacheSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"set off", "SET duckgres.s3_cache = 'off'", "off"},
+		{"set on", "SET duckgres.s3_cache = 'on'", "on"},
+		{"unquoted off", "SET duckgres.s3_cache = off", "off"},
+		{"unquoted boolean keyword", "SET duckgres.s3_cache = false", "off"},
+		{"true normalizes to on", "SET duckgres.s3_cache = 'true'", "on"},
+		{"yes normalizes to on", "SET duckgres.s3_cache = 'yes'", "on"},
+		{"zero normalizes to off", "SET duckgres.s3_cache = '0'", "off"},
+		{"set local", "SET LOCAL duckgres.s3_cache = 'off'", "off"},
+		{"case-insensitive name", "SET DUCKGRES.S3_CACHE = 'off'", "off"},
+		{"case-insensitive value normalized", "SET duckgres.s3_cache = 'OFF'", "off"},
+		{"whitespace trimmed", "SET duckgres.s3_cache = '  off '", "off"},
+		{"empty string resets to default", "SET duckgres.s3_cache = ''", ""},
+		{"set to default clears to empty", "SET duckgres.s3_cache TO DEFAULT", ""},
+		{"reset clears to empty", "RESET duckgres.s3_cache", ""},
+	}
+
+	tr := New(DefaultConfig())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tr.Transpile(tt.input)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", tt.input, err)
+			}
+			if result.S3CacheSet == nil {
+				t.Fatalf("Transpile(%q): S3CacheSet = nil, want non-nil (error=%v)", tt.input, result.Error)
+			}
+			if got := *result.S3CacheSet; got != tt.want {
+				t.Errorf("Transpile(%q): S3CacheSet = %q, want %q", tt.input, got, tt.want)
+			}
+			// Custom GUC must never be forwarded to DuckDB.
+			if result.S3CacheShow {
+				t.Errorf("Transpile(%q): S3CacheShow = true, want false", tt.input)
+			}
+			// Must not leak into the query_source interception.
+			if result.QuerySourceSet != nil || result.QuerySourceShow {
+				t.Errorf("Transpile(%q): query_source fields populated, want untouched", tt.input)
+			}
+		})
+	}
+}
+
+// TestTranspile_S3CacheSetInvalidRejected asserts that a SET with a value
+// outside the boolean spellings surfaces Result.Error with SQLSTATE 22023 and
+// does NOT populate S3CacheSet. The error message must name the valid values
+// but must NOT echo the offending value (arbitrary client input flowing into
+// logs / the recent-errors ring).
+func TestTranspile_S3CacheSetInvalidRejected(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	longJunk := strings.Repeat("x", 10*1024)
+	inputs := map[string]string{
+		"garbage":           "SET duckgres.s3_cache = 'garbage'",
+		"10KB string":       "SET duckgres.s3_cache = '" + longJunk + "'",
+		"integer constant":  "SET duckgres.s3_cache = 2",
+		"multiple values":   "SET duckgres.s3_cache = 'on', 'off'",
+		"set local garbage": "SET LOCAL duckgres.s3_cache = 'garbage'",
+	}
+	for name, in := range inputs {
+		t.Run(name, func(t *testing.T) {
+			result, err := tr.Transpile(in)
+			if err != nil {
+				t.Fatalf("Transpile(%.80q) error: %v", in, err)
+			}
+			if result.Error == nil {
+				got := "<nil>"
+				if result.S3CacheSet != nil {
+					got = *result.S3CacheSet
+				}
+				t.Fatalf("Transpile(%.80q): Error = nil, want 22023 rejection (S3CacheSet=%.80q)", in, got)
+			}
+			var coded interface{ SQLState() string }
+			if !errors.As(result.Error, &coded) || coded.SQLState() != "22023" {
+				t.Errorf("Transpile(%.80q): Error SQLSTATE = %v, want 22023", in, result.Error)
+			}
+			msg := result.Error.Error()
+			if !strings.Contains(msg, `"on"`) || !strings.Contains(msg, `"off"`) {
+				t.Errorf("error message must name the valid values, got %q", msg)
+			}
+			if strings.Contains(msg, "garbage") || strings.Contains(msg, longJunk[:64]) {
+				t.Errorf("error message must not echo the offending value, got %.120q", msg)
+			}
+			if result.S3CacheSet != nil {
+				t.Errorf("Transpile(%.80q): S3CacheSet = %q, want nil on rejection", in, *result.S3CacheSet)
+			}
+		})
+	}
+}
+
+// TestTranspile_S3CacheShow asserts `SHOW duckgres.s3_cache` is intercepted
+// (answered session-side) rather than treated as an unrecognized config
+// parameter or forwarded to DuckDB.
+func TestTranspile_S3CacheShow(t *testing.T) {
+	tr := New(DefaultConfig())
+	result, err := tr.Transpile("SHOW duckgres.s3_cache")
+	if err != nil {
+		t.Fatalf("Transpile error: %v", err)
+	}
+	if !result.S3CacheShow {
+		t.Fatalf("S3CacheShow = false, want true (error=%v)", result.Error)
+	}
+	if result.Error != nil {
+		t.Errorf("Error = %v, want nil (must not be treated as unrecognized param)", result.Error)
+	}
+	if result.S3CacheSet != nil {
+		t.Errorf("S3CacheSet = %v, want nil", result.S3CacheSet)
+	}
+}
+
+// TestTranspile_S3CacheMultiStatementNotIntercepted mirrors the query_source
+// guard: transpiling a MULTI-statement batch containing a duckgres.s3_cache
+// statement must NOT surface S3CacheSet/S3CacheShow on the whole-batch Result
+// (the early return would swallow every statement after the GUC one). The
+// connection layer splits the batch and re-transpiles each statement
+// individually — where the single-statement interception then fires.
+func TestTranspile_S3CacheMultiStatementNotIntercepted(t *testing.T) {
+	tr := New(DefaultConfig())
+
+	cases := []string{
+		"SET duckgres.s3_cache = 'off'; SHOW duckgres.s3_cache",
+		"SET duckgres.s3_cache = 'off'; SELECT 1",
+		"SHOW duckgres.s3_cache; SELECT 1",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			result, err := tr.Transpile(in)
+			if err != nil {
+				t.Fatalf("Transpile(%q) error: %v", in, err)
+			}
+			if result.S3CacheSet != nil {
+				t.Errorf("Transpile(%q): S3CacheSet = %v, want nil for a multi-statement batch (would swallow trailing statements)", in, *result.S3CacheSet)
+			}
+			if result.S3CacheShow {
+				t.Errorf("Transpile(%q): S3CacheShow = true, want false for a multi-statement batch (would swallow trailing statements)", in)
+			}
+		})
+	}
+}

--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -57,6 +57,48 @@ func errInvalidQuerySource() *CodedError {
 	}
 }
 
+// s3CacheParam is the duckgres-namespaced custom session GUC that controls
+// whether the session's DuckLake S3 traffic is served through the node-local
+// cache proxy (remote/k8s workers). Intercepted here and applied by the
+// connection layer (which swaps the worker's S3 secret transport); it is NEVER
+// forwarded to DuckDB. See clientConn.S3CacheEnabled in server/.
+const s3CacheParam = "duckgres.s3_cache"
+
+// Canonical values for the duckgres.s3_cache GUC.
+const (
+	S3CacheOn  = "on"
+	S3CacheOff = "off"
+)
+
+// NormalizeS3Cache validates a client-supplied duckgres.s3_cache value. The
+// PostgreSQL boolean spellings are accepted (case-insensitively, ignoring
+// surrounding whitespace) and normalized to "on"/"off". Empty is valid and
+// means "reset to default" (the session then reports "on"). An invalid value
+// returns a 22023 (invalid_parameter_value) CodedError that, like
+// NormalizeQuerySource, does not echo the offending client input.
+func NormalizeS3Cache(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return "", nil
+	case S3CacheOn, "true", "yes", "1":
+		return S3CacheOn, nil
+	case S3CacheOff, "false", "no", "0":
+		return S3CacheOff, nil
+	default:
+		return "", errInvalidS3Cache()
+	}
+}
+
+// errInvalidS3Cache is the SET-time rejection for a bad duckgres.s3_cache
+// value: 22023 invalid_parameter_value, same treatment as duckgres.query_source.
+func errInvalidS3Cache() *CodedError {
+	return &CodedError{
+		Code: "22023", // invalid_parameter_value
+		Message: fmt.Sprintf("invalid value for %q: must be %q or %q",
+			s3CacheParam, S3CacheOn, S3CacheOff),
+	}
+}
+
 // duckdbShowCommands are DuckDB-specific SHOW commands that should be passed
 // through to DuckDB rather than treated as PostgreSQL config parameters.
 var duckdbShowCommands = map[string]bool{
@@ -325,6 +367,35 @@ func (t *SetShowTransform) Transform(tree *pg_query.ParseResult, result *Result)
 					return true, nil
 				}
 
+				// duckgres.s3_cache: same interception contract as
+				// duckgres.query_source above (single-statement only; RESET /
+				// SET ... TO DEFAULT map to the empty value = default "on";
+				// closed value set rejected with 22023 via result.Error). The
+				// connection layer applies the value by asking the worker to
+				// swap its S3 secret transport — never forwarded to DuckDB.
+				if paramName == s3CacheParam && !multiStatement {
+					value := ""
+					if n.VariableSetStmt.Kind == pg_query.VariableSetKind_VAR_SET_VALUE {
+						extracted := false
+						if len(n.VariableSetStmt.Args) == 1 {
+							if v, ok := searchPathValue(n.VariableSetStmt.Args[0]); ok {
+								value, extracted = v, true
+							}
+						}
+						if !extracted {
+							result.Error = errInvalidS3Cache()
+							return true, nil
+						}
+					}
+					norm, err := NormalizeS3Cache(value)
+					if err != nil {
+						result.Error = err
+						return true, nil
+					}
+					result.S3CacheSet = &norm
+					return true, nil
+				}
+
 				if paramName == "search_path" {
 					if sql, ok := normalizeSearchPathSet(n.VariableSetStmt); ok {
 						result.SQLOverride = sql
@@ -381,6 +452,13 @@ func (t *SetShowTransform) Transform(tree *pg_query.ParseResult, result *Result)
 				// connection layer (defaulting to "standard"), not DuckDB.
 				if paramName == querySourceParam && !multiStatement {
 					result.QuerySourceShow = true
+					return true, nil
+				}
+
+				// duckgres.s3_cache: answered from session state by the
+				// connection layer (defaulting to "on"), not DuckDB.
+				if paramName == s3CacheParam && !multiStatement {
+					result.S3CacheShow = true
 					return true, nil
 				}
 

--- a/transpiler/transform/transform.go
+++ b/transpiler/transform/transform.go
@@ -37,6 +37,20 @@ type Result struct {
 	// unset) rather than DuckDB.
 	QuerySourceShow bool
 
+	// S3CacheSet, when non-nil, indicates the statement is
+	// `SET duckgres.s3_cache = '<value>'` (a duckgres-namespaced custom GUC
+	// that must NOT be forwarded to DuckDB). The pointed-to string is the
+	// validated canonical value ("on", "off", or "" = reset to the default
+	// "on"; an invalid value sets Error with 22023 instead). The connection
+	// layer applies it by asking the session's worker to swap its S3 secret
+	// transport on or off the node-local cache proxy.
+	S3CacheSet *string
+
+	// S3CacheShow indicates the statement is `SHOW duckgres.s3_cache`. The
+	// connection layer answers it from session state (or "on" if unset)
+	// rather than DuckDB.
+	S3CacheShow bool
+
 	// Error is set when a transform detects an error that should be returned to the client
 	// (e.g., unrecognized configuration parameter in SHOW command)
 	Error error

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -279,15 +279,19 @@ func (t *Transpiler) transpileWithFlags(sql string, flags TransformFlags) (*Resu
 			}, nil
 		}
 
-		// duckgres-namespaced custom GUC (duckgres.query_source): intercepted
-		// session-side, never deparsed/forwarded to DuckDB. Return early so the
-		// connection layer can store/echo it.
-		if transformResult.QuerySourceSet != nil || transformResult.QuerySourceShow {
+		// duckgres-namespaced custom GUCs (duckgres.query_source,
+		// duckgres.s3_cache): intercepted session-side, never
+		// deparsed/forwarded to DuckDB. Return early so the connection layer
+		// can store/apply/echo them.
+		if transformResult.QuerySourceSet != nil || transformResult.QuerySourceShow ||
+			transformResult.S3CacheSet != nil || transformResult.S3CacheShow {
 			return &Result{
 				SQL:             sql,
 				ParamCount:      transformResult.ParamCount,
 				QuerySourceSet:  transformResult.QuerySourceSet,
 				QuerySourceShow: transformResult.QuerySourceShow,
+				S3CacheSet:      transformResult.S3CacheSet,
+				S3CacheShow:     transformResult.S3CacheShow,
 			}, nil
 		}
 


### PR DESCRIPTION
## What

Adds a `duckgres.s3_cache` session GUC (default `on`) that lets a session bypass the node-local S3 cache-proxy DaemonSet:

```sql
SET duckgres.s3_cache = off;   -- subsequent queries read S3 cold
SET duckgres.s3_cache = on;    -- back through the NVMe cache
SHOW duckgres.s3_cache;
```

Also settable at connect time: `psql "... options='-c duckgres.s3_cache=off'"`. Per-query control falls out of the mid-session SET (bracket the query with off/on).

## Why

Cold-read benchmarking (cache-hit vs real-S3 latency) and ruling the cache out of correctness/staleness questions, without touching the DaemonSet or other tenants.

## How

The CP intercepts the duckgres-namespaced GUC (never forwarded to DuckDB — same pattern as `duckgres.query_source`) and, on every state flip, calls a new `SetSessionS3Cache` worker action that rebuilds the `ducklake_s3` secret:

- **off** = the org's native HTTPS transport → httpfs CONNECT-tunnels through the proxy as opaque TLS: no cache reads, no cache fills. This is the deliberate, reversible form of the mw-prod-us 2026-07-17 incident, so the mechanism is proven end-to-end in prod.
- **on** = the standard `overrideS3EndpointForCacheProxy` transport.

Global `http_proxy` is never touched (post-attach propagation to DuckLake subcatalogs is unreliable; secrets are consulted per request). The swap runs on the worker's `controlDB` so it never queues behind a client query. Instance-global secret + one-session-per-worker = session-scoped in effect.

## Invariants (new CLAUDE.md section)

- **State follows the worker, never leads it**: the session flag flips only after the worker swap succeeds; a failed swap fails the SET (`XX000`) / the batch / the connect, so `SHOW` can never report a transport the worker isn't using.
- **A bypass can never leak into the org's next session**: `CreateSession` restores the proxy transport before the session starts (restore failure fails the create; the CP retries); `DestroySession` restores best-effort.
- **Credential rotation respects the flag**: the hot-idle/mid-session refresh rebuilds the secret with or without the proxy transport per `s3CacheBypassed`, serialized on a new `secretSwapMu` — otherwise an hourly STS rotation silently re-enables the cache mid-benchmark (the inverse of the 2026-07-17 incident).
- **Closed enum on every set path** (`transform.NormalizeS3Cache`): PostgreSQL boolean spellings → on/off; anything else is `22023` (simple/batched SET, extended Parse, and the startup option, which the CP validates *before* acquiring a worker). Rejections never echo the value.
- **Scope**: remote/k8s shared-warm workers with a cache proxy. Elsewhere (standalone, process backend, no `DUCKGRES_CACHE_ENABLED`) the worker swap is a no-op and the GUC is session-state only. The query-log sink's activation stays proxied unconditionally.

## Mixed-version behavior

Hot-idle claims are image-matched (`ClaimHotIdleWorker` filters `WHERE image = ?`), so a standard release never pairs a new CP with old-image workers. The pairing only exists for orgs pinned to an older worker image (`ManagedWarehouseConfig.Image`) — there, a client explicitly requesting the bypass fails loudly (SET → `XX000`; startup option → FATAL at connect) instead of silently running cached. Plain connections are unaffected. Sessions in flight during a roll are owned end-to-end by the old CP replica, which has no s3_cache code (SET passes through to DuckDB → ordinary "unrecognized configuration parameter" error).

## Drive-by fix

Portal-Describe (`Describe('P')`) now answers both duckgres GUCs (`query_source` included) from session state instead of probing DuckDB with an unknown setting and degrading to NoData — the psycopg3 Parse/Bind/Describe(portal)/Execute flow now gets a proper RowDescription.

## Tests

- `transpiler/s3_cache_test.go` — SET/SHOW interception, boolean-spelling normalization, 22023 rejection matrix (no value echo), multi-statement-batch non-interception guard.
- `server/s3_cache_test.go` — executor capability invoked only on state flips, failed-swap-keeps-state (simple + batch abort), state-only fallback without the capability, startup-option matrix, extended Parse/Bind/Execute.
- `duckdbservice/s3_cache_test.go` — transport swap both directions, no-op scopes, failure-preserves-flag, **rotation-preserves-bypass**, **restore-at-CreateSession (incl. failure fails the create)**, restore-at-DestroySession.
- `s3_cache_guc` in `tests/mw-dev/e2e/harness.sh` — full client-visible plumbing against real workers (SET/SHOW round-trip incl. the CP→worker action RPC, DuckLake R/W inside a bypassed session, closed-enum + startup-option rejection, fresh-session default). mw-dev deploys no cache proxy, so the secret swap itself is unit-only — documented in the harness header.

Full module suite green locally, incl. `tests/integration` and the `kubernetes`-tag build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)