### PR TITLE
fix(pgwire): format timestamptz with UTC offsets

### DIFF
--- a/server/conn_results.go
+++ b/server/conn_results.go
@@ -324,6 +324,14 @@ func formatTextValue(v interface{}, oid int32) string {
 		if dates, ok := normalizeDriverValue(v).([]any); ok {
 			return formatArrayValueWithElementOID(dates, OidDate)
 		}
+	case OidTimestamptz:
+		if timestamp, ok := normalizeDriverValue(v).(time.Time); ok {
+			return formatTimestamptz(timestamp)
+		}
+	case OidTimestamptzArray:
+		if timestamps, ok := normalizeDriverValue(v).([]any); ok {
+			return formatArrayValueWithElementOID(timestamps, OidTimestamptz)
+		}
 	}
 	return formatValue(v)
 }
@@ -348,6 +356,20 @@ func formatDate(date time.Time) string {
 		return fmt.Sprintf("%04d-%02d-%02d BC", 1-date.Year(), date.Month(), date.Day())
 	}
 	return date.Format("2006-01-02")
+}
+
+// formatTimestamptz returns the PostgreSQL text representation of a TIMESTAMPTZ
+// value. The server advertises UTC, so normalize the instant before including
+// the required UTC offset.
+func formatTimestamptz(timestamp time.Time) string {
+	if timestamp.IsZero() {
+		return ""
+	}
+	timestamp = timestamp.UTC()
+	if timestamp.Nanosecond() != 0 {
+		return timestamp.Format("2006-01-02 15:04:05.999999+00")
+	}
+	return timestamp.Format("2006-01-02 15:04:05+00")
 }
 
 func sameDate(a, b time.Time) bool {

--- a/server/conn_results_test.go
+++ b/server/conn_results_test.go
@@ -40,6 +40,7 @@ func TestSendErrorDoesNotLogErrorContents(t *testing.T) {
 
 func TestSendDataRowWithFormatsUsesTypeOIDForTextDates(t *testing.T) {
 	date := time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC)
+	timestampTZ := time.Date(2022, 3, 31, 20, 0, 0, 123456000, time.FixedZone("UTC-4", -4*60*60))
 	farFutureDate := time.Date(9999, time.December, 31, 0, 0, 0, 0, time.UTC)
 	positiveInfinity := time.Date(5881580, time.July, 11, 0, 0, 0, 0, time.UTC)
 	negativeInfinity := time.Date(-5877641, time.June, 24, 0, 0, 0, 0, time.UTC)
@@ -71,6 +72,18 @@ func TestSendDataRowWithFormatsUsesTypeOIDForTextDates(t *testing.T) {
 			value:   date,
 			typeOID: OidTimestamp,
 			want:    "2022-04-01 00:00:00",
+		},
+		{
+			name:    "timestamp with timezone includes UTC offset",
+			value:   timestampTZ,
+			typeOID: OidTimestamptz,
+			want:    "2022-04-01 00:00:00.123456+00",
+		},
+		{
+			name:    "timestamp with timezone array includes UTC offsets",
+			value:   []any{timestampTZ, nil, timestampTZ.Add(time.Second)},
+			typeOID: OidTimestamptzArray,
+			want:    `{"2022-04-01 00:00:00.123456+00",NULL,"2022-04-01 00:00:01.123456+00"}`,
 		},
 		{
 			name:    "date array",


### PR DESCRIPTION
## Summary

- emit UTC offsets for PGWire text `TIMESTAMPTZ` results
- preserve offsets inside `TIMESTAMPTZ[]` results
- cover scalar and array encodings at the DataRow wire boundary

## Root cause

Duckgres advertised PostgreSQL `TIMESTAMPTZ` while serializing the text value without a timezone offset. Clients that trust the type OID could not parse the result.

## Verification

- `go test -count=1 ./server -run '^TestSendDataRowWithFormatsUsesTypeOIDForTextDates$'`
- `just test-unit`
- `just lint`