### PR TITLE
fix: prevent cancel keys reaching logs

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -969,12 +969,13 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	writer := bufio.NewWriter(tlsConn)
 
 	// Read startup message (user/database)
-	startupParams, err := server.ReadStartupMessage(reader)
+	startup, err := server.ReadStartupMessage(reader)
 	if err != nil {
 		clog.Error("Failed to read startup message.", "error", err)
 		return
 	}
 
+	startupParams := startup.Params
 	username := startupParams["user"]
 	database := startupParams["database"]
 	applicationName := startupParams["application_name"]

--- a/server/conn.go
+++ b/server/conn.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -937,13 +936,13 @@ func (c *clientConn) handleStartup() error {
 	}
 
 	for {
-		params, err := wire.ReadStartupMessage(c.reader)
+		startup, err := wire.ReadStartupMessage(c.reader)
 		if err != nil {
 			return err
 		}
 
 		// Handle GSSENCRequest - decline and let client retry with SSL
-		if params["__gssenc_request"] == "true" {
+		if startup.GSSENCRequest {
 			c.logger().Debug("GSSENCRequest received, declining.", "remote_addr", c.conn.RemoteAddr())
 			if _, err := c.conn.Write([]byte("N")); err != nil {
 				return err
@@ -952,7 +951,7 @@ func (c *clientConn) handleStartup() error {
 		}
 
 		// Handle SSL request - upgrade to TLS
-		if params["__ssl_request"] == "true" {
+		if startup.SSLRequest {
 			if err := c.conn.SetReadDeadline(time.Time{}); err != nil {
 				return fmt.Errorf("failed to clear startup deadline: %w", err)
 			}
@@ -985,18 +984,13 @@ func (c *clientConn) handleStartup() error {
 		}
 
 		// Handle cancel request
-		if params["__cancel_request"] == "true" {
-			// Extract pid and secret key from the cancel request
-			if pidStr, ok := params["__cancel_pid"]; ok {
-				if secretKeyStr, ok := params["__cancel_secret_key"]; ok {
-					pid, _ := strconv.ParseInt(pidStr, 10, 32)
-					secretKey, _ := strconv.ParseInt(secretKeyStr, 10, 32)
-					key := BackendKey{Pid: int32(pid), SecretKey: int32(secretKey)}
-					c.server.CancelQuery(key)
-				}
+		if startup.CancelRequest {
+			if startup.CancelCredentialsPresent {
+				c.server.CancelQuery(BackendKey{Pid: startup.CancelPID, SecretKey: startup.CancelSecretKey})
 			}
 			return errCancelHandled
 		}
+		params := startup.Params
 
 		// Reject non-TLS connections
 		if !tlsUpgraded {

--- a/server/exports.go
+++ b/server/exports.go
@@ -16,7 +16,7 @@ import (
 // Exported wrappers for protocol functions used by the control plane worker.
 // These delegate to the internal (lowercase) implementations.
 
-func ReadStartupMessage(r io.Reader) (map[string]string, error) {
+func ReadStartupMessage(r io.Reader) (wire.StartupMessage, error) {
 	return wire.ReadStartupMessage(r)
 }
 

--- a/server/parent.go
+++ b/server/parent.go
@@ -300,7 +300,7 @@ func (s *Server) CancelQueryBySignal(key BackendKey) bool {
 
 	child := s.childTracker.FindByBackendKey(key)
 	if child == nil {
-		slog.Debug("No child process found for backend key", "pid", key.Pid, "secret_key", key.SecretKey)
+		slog.Debug("No child process found for backend key", "pid", key.Pid)
 		return false
 	}
 

--- a/server/protocol_test.go
+++ b/server/protocol_test.go
@@ -50,11 +50,11 @@ func TestReadStartupMessage(t *testing.T) {
 			t.Fatalf("wire.ReadStartupMessage() error = %v", err)
 		}
 
-		if result["user"] != "testuser" {
-			t.Errorf("user = %q, want %q", result["user"], "testuser")
+		if result.Params["user"] != "testuser" {
+			t.Errorf("user = %q, want %q", result.Params["user"], "testuser")
 		}
-		if result["database"] != "testdb" {
-			t.Errorf("database = %q, want %q", result["database"], "testdb")
+		if result.Params["database"] != "testdb" {
+			t.Errorf("database = %q, want %q", result.Params["database"], "testdb")
 		}
 	})
 
@@ -70,7 +70,7 @@ func TestReadStartupMessage(t *testing.T) {
 			t.Fatalf("wire.ReadStartupMessage() error = %v", err)
 		}
 
-		if result["__ssl_request"] != "true" {
+		if !result.SSLRequest {
 			t.Error("should detect SSL request")
 		}
 	})
@@ -87,7 +87,7 @@ func TestReadStartupMessage(t *testing.T) {
 			t.Fatalf("wire.ReadStartupMessage() error = %v", err)
 		}
 
-		if result["__gssenc_request"] != "true" {
+		if !result.GSSENCRequest {
 			t.Error("should detect GSSENCRequest")
 		}
 	})
@@ -106,7 +106,7 @@ func TestReadStartupMessage(t *testing.T) {
 			t.Fatalf("wire.ReadStartupMessage() error = %v", err)
 		}
 
-		if result["__cancel_request"] != "true" {
+		if !result.CancelRequest {
 			t.Error("should detect cancel request")
 		}
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -712,7 +712,7 @@ func (s *Server) CancelQuery(key BackendKey) bool {
 	if ok && cancel != nil {
 		cancel()
 		queryCancellationsCounter.Inc()
-		slog.Info("Query cancelled via cancel request.", "pid", key.Pid, "secret_key", key.SecretKey)
+		slog.Info("Query cancelled via cancel request.", "pid", key.Pid)
 		return true
 	}
 	return false
@@ -2542,7 +2542,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 	// should be read by the child process after FD passing.
 	// The SSL request is a single, small message and the client waits for 'S'
 	// before sending the TLS ClientHello, so unbuffered reads are safe here.
-	params, err := wire.ReadStartupMessage(conn)
+	startup, err := wire.ReadStartupMessage(conn)
 	if err != nil {
 		if err == io.EOF || errors.Is(err, io.EOF) {
 			slog.Debug("Client closed connection before sending startup message.", "remote_addr", remoteAddr)
@@ -2557,7 +2557,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 	// Handle GSSENCRequest - decline and re-read for SSLRequest.
 	// Loop to handle the unlikely case of multiple GSSENCRequests.
 	for range 3 {
-		if params["__gssenc_request"] != "true" {
+		if !startup.GSSENCRequest {
 			break
 		}
 		slog.Debug("GSSENCRequest received, declining.", "remote_addr", remoteAddr)
@@ -2568,7 +2568,7 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 			return
 		}
 		// Re-read: client will send SSLRequest next
-		params, err = wire.ReadStartupMessage(conn)
+		startup, err = wire.ReadStartupMessage(conn)
 		if err != nil {
 			if err == io.EOF || errors.Is(err, io.EOF) {
 				slog.Debug("Client closed connection after GSSENC decline.", "remote_addr", remoteAddr)
@@ -2582,15 +2582,17 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 	}
 
 	// Handle cancel request in parent (no child spawn needed)
-	if params["__cancel_request"] == "true" {
-		s.handleCancelRequestIsolated(params)
+	if startup.CancelRequest {
+		if startup.CancelCredentialsPresent {
+			s.handleCancelRequestIsolated(BackendKey{Pid: startup.CancelPID, SecretKey: startup.CancelSecretKey})
+		}
 		s.rateLimiter.UnregisterConnection(remoteAddr)
 		_ = conn.Close()
 		return
 	}
 
 	// Handle SSL request: send 'S' then spawn child for TLS handshake
-	if params["__ssl_request"] == "true" {
+	if startup.SSLRequest {
 		if err := conn.SetReadDeadline(time.Time{}); err != nil {
 			slog.Error("Failed to clear startup deadline.", "remote_addr", remoteAddr, "error", err)
 			s.rateLimiter.UnregisterConnection(remoteAddr)
@@ -2643,22 +2645,6 @@ func (s *Server) handleConnectionIsolated(conn net.Conn, remoteAddr net.Addr) {
 }
 
 // handleCancelRequestIsolated handles a cancel request in process isolation mode.
-func (s *Server) handleCancelRequestIsolated(params map[string]string) {
-	pidStr := params["__cancel_pid"]
-	secretKeyStr := params["__cancel_secret_key"]
-
-	if pidStr == "" || secretKeyStr == "" {
-		return
-	}
-
-	var pid, secretKey int64
-	if _, err := fmt.Sscanf(pidStr, "%d", &pid); err != nil {
-		return
-	}
-	if _, err := fmt.Sscanf(secretKeyStr, "%d", &secretKey); err != nil {
-		return
-	}
-
-	key := BackendKey{Pid: int32(pid), SecretKey: int32(secretKey)}
+func (s *Server) handleCancelRequestIsolated(key BackendKey) {
 	s.CancelQueryBySignal(key)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,22 @@ import (
 	"testing"
 	"time"
 )
+
+func TestCancelQueryDoesNotLogSecretKey(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	key := BackendKey{Pid: 42, SecretKey: 987654321}
+	s := &Server{activeQueries: map[BackendKey]context.CancelFunc{key: func() {}}}
+	if !s.CancelQuery(key) {
+		t.Fatal("CancelQuery returned false for a registered key")
+	}
+	if strings.Contains(logs.String(), "987654321") {
+		t.Fatalf("cancel secret key leaked to logs: %s", logs.String())
+	}
+}
 
 func TestNormalizeIdleTimeout(t *testing.T) {
 	const def = 60 * time.Second

--- a/server/wire/protocol.go
+++ b/server/wire/protocol.go
@@ -64,24 +64,37 @@ const (
 	maxMessageLength = 1 << 30
 )
 
-// readStartupMessage reads the initial startup message from the client
-func ReadStartupMessage(r io.Reader) (map[string]string, error) {
+// StartupMessage is the parsed initial message from a PostgreSQL client. Cancel
+// credentials intentionally live outside Params: callers log ordinary startup
+// fields such as user and application_name, but must never log a cancel key.
+type StartupMessage struct {
+	Params                   map[string]string
+	SSLRequest               bool
+	GSSENCRequest            bool
+	CancelRequest            bool
+	CancelCredentialsPresent bool
+	CancelPID                int32
+	CancelSecretKey          int32
+}
+
+// ReadStartupMessage reads the initial startup message from the client.
+func ReadStartupMessage(r io.Reader) (StartupMessage, error) {
 	// Read message length (4 bytes)
 	var length int32
 	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
-		return nil, fmt.Errorf("failed to read startup message length: %w", err)
+		return StartupMessage{}, fmt.Errorf("failed to read startup message length: %w", err)
 	}
 
 	// Validate before allocating: minimum 8 = length field (4) + protocol
 	// version (4), which also guarantees remaining[:4] below is in range.
 	if length < 8 || length > maxStartupMessageLength {
-		return nil, fmt.Errorf("invalid startup message length: %d", length)
+		return StartupMessage{}, fmt.Errorf("invalid startup message length: %d", length)
 	}
 
 	// Read remaining bytes
 	remaining := make([]byte, length-4)
 	if _, err := io.ReadFull(r, remaining); err != nil {
-		return nil, fmt.Errorf("failed to read startup message body: %w", err)
+		return StartupMessage{}, fmt.Errorf("failed to read startup message body: %w", err)
 	}
 
 	// Read protocol version (4 bytes)
@@ -89,28 +102,27 @@ func ReadStartupMessage(r io.Reader) (map[string]string, error) {
 
 	// Check for SSL request (80877103)
 	if protocolVersion == 80877103 {
-		return map[string]string{"__ssl_request": "true"}, nil
+		return StartupMessage{SSLRequest: true}, nil
 	}
 
 	// Check for GSSENCRequest (80877104, PostgreSQL 12+)
 	// JDBC drivers with gssEncMode=prefer send this before SSLRequest.
 	if protocolVersion == 80877104 {
-		return map[string]string{"__gssenc_request": "true"}, nil
+		return StartupMessage{GSSENCRequest: true}, nil
 	}
 
 	// Check for cancel request (80877102)
 	// Format: 4 bytes length, 4 bytes request code, 4 bytes pid, 4 bytes secret key
 	if protocolVersion == 80877102 {
 		if len(remaining) >= 12 {
-			cancelPid := binary.BigEndian.Uint32(remaining[4:8])
-			cancelSecretKey := binary.BigEndian.Uint32(remaining[8:12])
-			return map[string]string{
-				"__cancel_request":    "true",
-				"__cancel_pid":        fmt.Sprintf("%d", cancelPid),
-				"__cancel_secret_key": fmt.Sprintf("%d", cancelSecretKey),
+			return StartupMessage{
+				CancelRequest:            true,
+				CancelCredentialsPresent: true,
+				CancelPID:                int32(binary.BigEndian.Uint32(remaining[4:8])),
+				CancelSecretKey:          int32(binary.BigEndian.Uint32(remaining[8:12])),
 			}, nil
 		}
-		return map[string]string{"__cancel_request": "true"}, nil
+		return StartupMessage{CancelRequest: true}, nil
 	}
 
 	// Parse parameters (null-terminated key-value pairs)
@@ -149,7 +161,7 @@ func ReadStartupMessage(r io.Reader) (map[string]string, error) {
 		}
 	}
 
-	return params, nil
+	return StartupMessage{Params: params}, nil
 }
 
 // readMessage reads a single message from the client

--- a/server/wire/protocol_test.go
+++ b/server/wire/protocol_test.go
@@ -40,12 +40,12 @@ func TestReadStartupMessageValid(t *testing.T) {
 		"user":     "alice",
 		"database": "db1",
 	})
-	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	startup, err := ReadStartupMessage(bytes.NewReader(msg))
 	if err != nil {
 		t.Fatalf("ReadStartupMessage: %v", err)
 	}
-	if params["user"] != "alice" || params["database"] != "db1" {
-		t.Fatalf("unexpected params: %v", params)
+	if startup.Params["user"] != "alice" || startup.Params["database"] != "db1" {
+		t.Fatalf("unexpected params: %v", startup.Params)
 	}
 }
 
@@ -54,12 +54,35 @@ func TestReadStartupMessageSSLRequest(t *testing.T) {
 	// SSLRequest is exactly 8 bytes: length + request code.
 	msg = msg[:8]
 	binary.BigEndian.PutUint32(msg[:4], 8)
-	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	startup, err := ReadStartupMessage(bytes.NewReader(msg))
 	if err != nil {
 		t.Fatalf("ReadStartupMessage: %v", err)
 	}
-	if params["__ssl_request"] != "true" {
-		t.Fatalf("expected SSL request, got: %v", params)
+	if !startup.SSLRequest {
+		t.Fatalf("expected SSL request, got: %+v", startup)
+	}
+}
+
+// Cancel-request credentials must not share the ordinary startup-parameter
+// container: that map is used by callers for loggable fields such as user and
+// application_name. Keeping the key in the typed cancel branch prevents an
+// accidental log sink from receiving it.
+func TestReadStartupMessageSeparatesCancelCredentials(t *testing.T) {
+	msg := buildRawStartup(16, []byte{
+		0x04, 0xd2, 0x16, 0x2e, // CancelRequest code (80877102)
+		0x00, 0x00, 0x00, 0x2a, // pid 42
+		0x00, 0x00, 0x01, 0x41, // secret key 321
+	})
+
+	startup, err := ReadStartupMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("ReadStartupMessage: %v", err)
+	}
+	if !startup.CancelRequest || !startup.CancelCredentialsPresent || startup.CancelPID != 42 || startup.CancelSecretKey != 321 {
+		t.Fatalf("unexpected cancel request: %+v", startup)
+	}
+	if len(startup.Params) != 0 {
+		t.Fatalf("cancel credentials must not be returned in startup params: %v", startup.Params)
 	}
 }
 
@@ -117,13 +140,13 @@ func TestReadStartupMessageUnterminatedValue(t *testing.T) {
 	msg := buildRawStartup(int32(len(body)+4), body)
 
 	// Must not panic.
-	params, err := ReadStartupMessage(bytes.NewReader(msg))
+	startup, err := ReadStartupMessage(bytes.NewReader(msg))
 	if err != nil {
 		t.Fatalf("ReadStartupMessage on unterminated value: %v", err)
 	}
 	// The truncated final pair is dropped (break before assignment).
-	if _, ok := params["user"]; ok {
-		t.Fatalf("expected truncated final pair to be dropped, got: %v", params)
+	if _, ok := startup.Params["user"]; ok {
+		t.Fatalf("expected truncated final pair to be dropped, got: %v", startup.Params)
 	}
 }
 

--- a/server/worker.go
+++ b/server/worker.go
@@ -262,7 +262,7 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 	writer := bufio.NewWriter(tlsConn)
 
 	// Read startup message (sent by client after TLS handshake)
-	params, err := wire.ReadStartupMessage(reader)
+	startup, err := wire.ReadStartupMessage(reader)
 	if err != nil {
 		if err == io.EOF || errors.Is(err, io.EOF) {
 			slog.Debug("Client closed connection after TLS handshake but before sending startup message.")
@@ -272,6 +272,7 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 		return ExitError
 	}
 
+	params := startup.Params
 	username := params["user"]
 	database := params["database"]
 	applicationName := params["application_name"]


### PR DESCRIPTION
Fixes the two pre-existing CodeQL clear-text logging alerts: [alert 675](https://github.com/PostHog/duckgres/security/code-scanning/675) and [alert 684](https://github.com/PostHog/duckgres/security/code-scanning/684). The startup parser previously placed CancelRequest credentials in the same string map as ordinary client startup fields; CodeQL could therefore trace the cancel secret through user/application fields into logs. Parse startup packets into typed request data so cancel credentials never enter the loggable parameters map, and omit the direct cancel-key log attributes. Adds parser isolation and log-leak regression coverage. Validated with just lint, go test ./server/... ./controlplane/ -count=1, just build, and go build -tags kubernetes -o /tmp/duckgres-kubernetes-build .