### PR TITLE
chore(ci): drop the dead DuckDB 1.5.2 canary build

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -84,20 +84,6 @@ jobs:
                       # commit history for the rationale on each row.
                       pg_scanner_repo: "https://extensions.duckdb.org"
                       default: true
-                    - version: "1.5.2"
-                      go: "v2.10502.0"
-                      bindings: "v0.10502.0"
-                      httpfs: "v1.5.2-stoi-fix"
-                      ducklake: "v1.0-posthog.2"
-                      # Nightly repo: preserves byte-identity with the
-                      # previously-published 1.5.2 worker image, which
-                      # bundled the nightly build for the DuckLake
-                      # metadata-pool reaper fix (PR #447). Stable v1.5.2
-                      # postgres_scanner exists too but the binary differs;
-                      # keep this row aligned with what was last shipped so
-                      # it remains a true rollback target.
-                      pg_scanner_repo: "http://nightly-extensions.duckdb.org"
-                      default: false
                 platform:
                     - platform: linux/arm64
                       runner: ubuntu-24.04-arm
@@ -269,9 +255,9 @@ jobs:
         name: Multi-arch manifest worker ${{ matrix.duckdb.version }}
         needs: build
         if: github.repository == 'PostHog/duckgres'
-        # Mirror the build job's tolerance: if the 1.5.2 manifest fails
-        # (e.g. because that row's build was continue-on-errored), the
-        # default 1.5.3 manifest still publishes and Charts dispatch
+        # Mirror the build job's tolerance: if a non-default row's manifest
+        # fails (e.g. because that row's build was continue-on-errored), the
+        # default row's manifest still publishes and Charts dispatch
         # proceeds.
         continue-on-error: ${{ !matrix.duckdb.default }}
         strategy:
@@ -280,8 +266,6 @@ jobs:
                 duckdb:
                     - version: "1.5.3"
                       default: true
-                    - version: "1.5.2"
-                      default: false
         runs-on: ubuntu-24.04
         permissions:
             id-token: write

--- a/scripts/ducklake_version_matrix.sh
+++ b/scripts/ducklake_version_matrix.sh
@@ -8,7 +8,7 @@
 # Usage:
 #   ./scripts/ducklake_version_matrix.sh                   # run matrix
 #   ./scripts/ducklake_version_matrix.sh --current-only    # benchmark current version only
-#   DUCKLAKE_VERSIONS="v2.10502.0" ./scripts/ducklake_version_matrix.sh  # custom versions
+#   DUCKLAKE_VERSIONS="v2.10502.0" ./scripts/ducklake_version_matrix.sh  # custom/older versions
 #   DUCKGRES_BENCH_LATENCIES=0ms,50ms,100ms ./scripts/ducklake_version_matrix.sh  # latency sweep
 #
 # Requires: Docker running (for DuckLake infra), go, git, jq (for comparison)
@@ -22,9 +22,12 @@ TEST_TIMEOUT="${DUCKLAKE_TEST_TIMEOUT:-300s}"
 
 # DuckDB Go driver versions to test.
 # Format: "module_version" — maps to duckdb-go/v2 + duckdb-go-bindings.
+# The encoding is v2.<major><minor:02d><patch:02d>.0, e.g.
 #   v2.10502.0 → DuckDB 1.5.2 (DuckLake 1.0)
 #   v2.10503.0 → DuckDB 1.5.3 (DuckLake 1.0)
-DEFAULT_VERSIONS="v2.10503.0 v2.10502.0"
+# Only shipping versions are benchmarked by default; older versions remain
+# testable on demand via DUCKLAKE_VERSIONS.
+DEFAULT_VERSIONS="v2.10503.0"
 VERSIONS="${DUCKLAKE_VERSIONS:-$DEFAULT_VERSIONS}"
 
 CURRENT_ONLY=false


### PR DESCRIPTION
The DuckDB 1.5.2 canary is long retired — only 1.5.3 ships today. The 1.5.2 row was still burning a full build + manifest leg on every push to `main` producing an image nobody can actually roll back to.

## Removed

- **`.jobs.build.strategy.matrix.duckdb`** — the `1.5.2` row (`go: v2.10502.0`, `bindings: v0.10502.0`, `httpfs: v1.5.2-stoi-fix`, `ducklake: v1.0-posthog.2`, nightly `pg_scanner_repo`), plus the comment block that existed solely to explain why that row pinned the nightly `postgres_scanner` for the DuckLake metadata-pool reaper fix (PR #447).
- **`.jobs.manifest.strategy.matrix.duckdb`** — the `1.5.2` / `default: false` row.
- **`scripts/ducklake_version_matrix.sh`** — `DEFAULT_VERSIONS` no longer runs the `v2.10502.0` leg by default.

## Invariant preserved

`validate-matrix` asserts exactly one `default: true` row in **both** matrices. 1.5.3 remains that row, untouched, and still declares every build-arg `Dockerfile.worker` asserts non-empty (`version`, `go`, `bindings`, `httpfs`, `ducklake`, `pg_scanner_repo`). Ran the job's own check locally:

```
$ for path in '.jobs.build.strategy.matrix.duckdb' '.jobs.manifest.strategy.matrix.duckdb'; do
      yq "$path | [.[] | select(.default == true)] | length" .github/workflows/container-image-worker-cd.yml
  done
1
1
```

The file also still parses as valid YAML overall (verified independently via `python3` + PyYAML), and `bash -n` passes on the script.

## Deliberately left alone

So remaining greps for `1.5.2` don't confuse a reviewer — these are **illustrative, not build targets**:

- `Dockerfile.worker` ~L65-66 — the extension/bindings skew-guard comment uses 1.5.2 vs 1.5.3 to explain *why* the guard exists.
- `container-image-worker-cd.yml` ~L27 — the `v0.<major><minor:02d><patch:02d>.0` version-encoding explanation uses 1.5.2 and 1.5.3 as worked examples.
- `scripts/ducklake_version_matrix.sh` — the encoding table and the `DUCKLAKE_VERSIONS` override are kept. It is a benchmarking harness, so running an older engine on demand is still legitimate; only the *default* set changed.

The manifest job's `continue-on-error` comment was reworded from "the 1.5.2 manifest" to "a non-default row's manifest" — the mechanism is retained for whenever the next canary row lands.

## Follow-up spotted, not fixed here

`docs/runbooks/worker-upgrades.md` is independently stale (L20 says the default is "1.5.2 today", L142 says the matrix is "currently 1.5.1 + 1.5.2"). Both were already wrong before this PR since the default is 1.5.3. Left out to keep this diff to the CI change — happy to fix here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mntu6YhMuqNBFD9snXqvBR