### PR TITLE
feat(analytics): emit per-org query_completed event

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,14 @@ the `distinct_id` is the org name and each event carries a group of type
 single-tenant standalone mode (no org) the `distinct_id` is `standalone` and no
 group is attached.
 
+The org name is duckgres-internal, so the query events additionally carry a
+`team_id` property — the PostHog `Team.id` for the connection (the connecting
+user's team, else the org's oldest team; 0 when unknown or standalone). This is
+the PostHog-native key that joins duckgres usage to the rest of PostHog (e.g.
+product-intent cohorts for managed-warehouse activation). It is a config-snapshot
+read stamped once per connection, and mirrors the informational team id the
+compute-usage meter records.
+
 Events never include SQL text, credentials, or secret values — only metadata.
 
 Provisioning and deprovisioning are asynchronous: the admin API returns `202
@@ -419,9 +427,9 @@ teardown), so you can build a provisioning funnel and alert on failures.
 | `warehouse_deprovision_success` | All underlying resources deleted (provisioner controller) | — |
 | `warehouse_deprovision_failed` | A teardown attempt failed (provisioner controller) | `reason` (`duckling_delete_failed`) |
 | `warehouse_password_reset` | An org's root password is reset (admin API) | `username` |
-| `query_initiated` | An accepted, non-empty client query is received | `user`, `trace_id` |
-| `query_completed` | A statement finishes executing successfully | `user`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows` |
-| `query_failed` | A query errors | `user`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`) |
+| `query_initiated` | An accepted, non-empty client query is received | `user`, `team_id`, `trace_id` |
+| `query_completed` | A statement finishes executing successfully | `user`, `team_id`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows` |
+| `query_failed` | A query errors | `user`, `team_id`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`) |
 
 > Note: `warehouse_provision_success` / `_failed` and `warehouse_deprovision_success`
 > are terminal and fire exactly once per warehouse (guarded on the state

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ teardown), so you can build a provisioning funnel and alert on failures.
 | `warehouse_deprovision_failed` | A teardown attempt failed (provisioner controller) | `reason` (`duckling_delete_failed`) |
 | `warehouse_password_reset` | An org's root password is reset (admin API) | `username` |
 | `query_initiated` | An accepted, non-empty client query is received | `user`, `trace_id` |
+| `query_completed` | A statement finishes executing successfully | `user`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows` |
 | `query_failed` | A query errors | `user`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`) |
 
 > Note: `warehouse_provision_success` / `_failed` and `warehouse_deprovision_success`
@@ -437,6 +438,15 @@ teardown), so you can build a provisioning funnel and alert on failures.
 > Query or extended-protocol Execute. Retries, rewrites, cursor helpers, and
 > generated COPY batches do not emit additional events. Capture is asynchronous
 > and batched, so it stays off the query latency path.
+
+> Note: `query_completed` fires on the terminal event of each *successfully*
+> executed statement, carrying that statement's resource cost (`duration_ms`,
+> `cpu_seconds`). Failures are covered by `query_failed` instead. It is emitted
+> at statement granularity, so a single logical client request can produce more
+> than one `query_completed` (e.g. cursor FETCHes or COPY batches) — unlike
+> `query_initiated`. Filter by `query_kind` to isolate real data queries from
+> utility statements. Emitted independently of the query-log configuration;
+> capture is asynchronous and batched, so it stays off the query latency path.
 
 ### Query Logs
 

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -274,6 +274,10 @@ type ConfigStoreInterface interface {
 	// Empty strings mean "not set" (including unknown orgs). Raw stored
 	// values — validation happens in resolveWorkerProfile.
 	OrgDefaultWorkerProfile(orgID string) (cpu, memory, ttl string)
+	// OrgUsageTeamID resolves the informational PostHog Team.id for a connection
+	// (the connecting user's team, else the org's oldest team; 0 when unknown).
+	// A config-snapshot read, no I/O — the same resolver the compute meter uses.
+	OrgUsageTeamID(orgID, username string) int64
 	UpsertFlightSessionRecord(record *configstore.FlightSessionRecord) error
 	GetFlightSessionRecord(sessionToken string) (*configstore.FlightSessionRecord, error)
 	TouchFlightSessionRecord(sessionToken string, lastSeenAt time.Time) error
@@ -1451,6 +1455,13 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 
 	// Create real clientConn with FlightExecutor and worker assignment
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, executor, pid, secretKey, workerID, workerPod)
+	// Stamp the PostHog team id (config-snapshot read, no I/O) so this
+	// connection's product-analytics events carry a PostHog-native key. Same
+	// resolution the compute meter uses: the connecting user's team, else the
+	// org's oldest team, else 0 (unknown / not-yet-loaded snapshot).
+	if cp.configStore != nil && orgID != "" {
+		server.SetConnectionTeamID(cc, cp.configStore.OrgUsageTeamID(orgID, username))
+	}
 	// Stamp the provisioned worker pod size for compute-usage billing. Only the
 	// remote/k8s backend has a per-org worker pod with a known size; the process
 	// backend leaves it zero so metering is skipped. Constant for the

--- a/controlplane/flight_ingress_test.go
+++ b/controlplane/flight_ingress_test.go
@@ -35,6 +35,9 @@ func (s *flightSessionAccessConfigStore) OrgWarehouseStatus(string) (string, boo
 func (s *flightSessionAccessConfigStore) OrgDefaultWorkerProfile(string) (string, string, string) {
 	return "", "", ""
 }
+func (s *flightSessionAccessConfigStore) OrgUsageTeamID(string, string) int64 {
+	return 0
+}
 func (s *flightSessionAccessConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
 	return nil
 }

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -167,6 +167,10 @@ func (f *fakeConfigStore) OrgDefaultWorkerProfile(string) (string, string, strin
 	// default (nil) profile semantics.
 	return "", "", ""
 }
+func (f *fakeConfigStore) OrgUsageTeamID(string, string) int64 {
+	// SNI tests don't exercise analytics team attribution.
+	return 0
+}
 func (f *fakeConfigStore) UpsertFlightSessionRecord(*configstore.FlightSessionRecord) error {
 	panic("UpsertFlightSessionRecord should not be called from SNI tests")
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -214,6 +214,13 @@ type clientConn struct {
 	workerMillicores int64
 	workerMiB        int64
 
+	// teamID is the PostHog Team.id this connection is attributed to for product
+	// analytics (the connecting user's team, else the org's oldest team; 0 when
+	// unknown / non-multitenant). Stamped once at setup via SetConnectionTeamID
+	// so per-org analytics events carry a PostHog-native key that joins to the
+	// rest of PostHog. A config-snapshot read, not billing attribution.
+	teamID int64
+
 	// lastProfilingSummary holds the rollup from the most recent
 	// EnrichSpanWithProfiling call on this connection. Consumed by the very
 	// next logQuery and then cleared. Per-connection state is safe because
@@ -490,6 +497,7 @@ func (c *clientConn) logClientQueryReceived(ctx context.Context, protocol, query
 	)
 	analytics.Default().Capture("query_initiated", c.orgID, map[string]any{
 		"user":     c.username,
+		"team_id":  c.teamID,
 		"trace_id": traceID,
 	})
 }
@@ -529,6 +537,7 @@ func (c *clientConn) logQueryError(query string, err error) {
 	// SQLSTATE and category — so this is unaffected by the redaction above.
 	analytics.Default().Capture("query_failed", c.orgID, map[string]any{
 		"user":           c.username,
+		"team_id":        c.teamID,
 		"trace_id":       traceID,
 		"error_code":     sqlState,
 		"error_category": category,

--- a/server/conn_analytics_test.go
+++ b/server/conn_analytics_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/posthog/duckgres/internal/analytics"
+	"github.com/posthog/duckgres/server/observe"
 )
 
 type capturedQueryEvent struct {
@@ -87,5 +89,53 @@ func TestLogQueryErrorClassifiesUserError(t *testing.T) {
 	e := fake.events[0]
 	if e.props["error_category"] != "user" {
 		t.Errorf("error_category = %v, want user", e.props["error_category"])
+	}
+}
+
+func TestLogQueryEmitsQueryCompletedOnSuccess(t *testing.T) {
+	fake := installFakeQueryTracker(t)
+	// No server → queryLogSink is nil, so this exercises the analytics emission
+	// independently of the query-log sink.
+	c := &clientConn{orgID: "acme", username: "root", ctx: context.Background()}
+	c.lastProfilingSummary = observe.QueryProfilingSummary{CPUTimeSeconds: 2.5}
+
+	c.logQuery(time.Now().Add(-100*time.Millisecond), "SELECT 1", "SELECT 1", "SELECT", 1, 0, "", "", "simple")
+
+	if len(fake.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(fake.events))
+	}
+	e := fake.events[0]
+	if e.event != "query_completed" {
+		t.Errorf("event = %q, want query_completed", e.event)
+	}
+	if e.orgID != "acme" {
+		t.Errorf("orgID = %q, want acme", e.orgID)
+	}
+	if e.props["cpu_seconds"] != 2.5 {
+		t.Errorf("cpu_seconds = %v, want 2.5", e.props["cpu_seconds"])
+	}
+	if e.props["query_kind"] != "Select" {
+		t.Errorf("query_kind = %v, want Select", e.props["query_kind"])
+	}
+	if e.props["result_rows"] != int64(1) {
+		t.Errorf("result_rows = %v, want 1", e.props["result_rows"])
+	}
+	if d, ok := e.props["duration_ms"].(int64); !ok || d <= 0 {
+		t.Errorf("duration_ms = %v, want positive int64", e.props["duration_ms"])
+	}
+}
+
+func TestLogQueryDoesNotEmitCompletedOnError(t *testing.T) {
+	fake := installFakeQueryTracker(t)
+	c := &clientConn{orgID: "acme", username: "root", ctx: context.Background()}
+
+	// A failed query carries a non-empty errCode; query_completed is success-only
+	// (the failure is covered by query_failed), so nothing should be emitted here.
+	c.logQuery(time.Now(), "SELECT * FROM nope", "SELECT * FROM nope", "SELECT", 0, 0, "42P01", "table missing", "simple")
+
+	for _, e := range fake.events {
+		if e.event == "query_completed" {
+			t.Fatalf("query_completed emitted for a failed query")
+		}
 	}
 }

--- a/server/conn_analytics_test.go
+++ b/server/conn_analytics_test.go
@@ -35,7 +35,7 @@ func installFakeQueryTracker(t *testing.T) *fakeQueryTracker {
 
 func TestLogClientQueryReceivedEmitsQueryInitiated(t *testing.T) {
 	fake := installFakeQueryTracker(t)
-	c := &clientConn{orgID: "acme", username: "root", ctx: context.Background()}
+	c := &clientConn{orgID: "acme", username: "root", teamID: 42, ctx: context.Background()}
 
 	c.logClientQueryReceived(context.Background(), "simple", "SELECT 1")
 
@@ -51,6 +51,9 @@ func TestLogClientQueryReceivedEmitsQueryInitiated(t *testing.T) {
 	}
 	if e.props["user"] != "root" {
 		t.Errorf("user = %v, want root", e.props["user"])
+	}
+	if e.props["team_id"] != int64(42) {
+		t.Errorf("team_id = %v, want 42", e.props["team_id"])
 	}
 }
 
@@ -96,7 +99,7 @@ func TestLogQueryEmitsQueryCompletedOnSuccess(t *testing.T) {
 	fake := installFakeQueryTracker(t)
 	// No server → queryLogSink is nil, so this exercises the analytics emission
 	// independently of the query-log sink.
-	c := &clientConn{orgID: "acme", username: "root", ctx: context.Background()}
+	c := &clientConn{orgID: "acme", username: "root", teamID: 42, ctx: context.Background()}
 	c.lastProfilingSummary = observe.QueryProfilingSummary{CPUTimeSeconds: 2.5}
 
 	c.logQuery(time.Now().Add(-100*time.Millisecond), "SELECT 1", "SELECT 1", "SELECT", 1, 0, "", "", "simple")
@@ -110,6 +113,9 @@ func TestLogQueryEmitsQueryCompletedOnSuccess(t *testing.T) {
 	}
 	if e.orgID != "acme" {
 		t.Errorf("orgID = %q, want acme", e.orgID)
+	}
+	if e.props["team_id"] != int64(42) {
+		t.Errorf("team_id = %v, want 42", e.props["team_id"])
 	}
 	if e.props["cpu_seconds"] != 2.5 {
 		t.Errorf("cpu_seconds = %v, want 2.5", e.props["cpu_seconds"])

--- a/server/exports.go
+++ b/server/exports.go
@@ -206,6 +206,17 @@ func SetConnectionWorkerSize(cc *clientConn, millicores, mib int64) {
 	}
 }
 
+// SetConnectionTeamID records the PostHog Team.id this connection is attributed
+// to for product analytics (query_initiated / query_completed / query_failed),
+// giving those per-org events a PostHog-native key. Resolved from the config
+// snapshot at setup (the connecting user's team, else the org's oldest team);
+// 0 when unknown or non-multitenant. Constant for the connection's life.
+func SetConnectionTeamID(cc *clientConn, teamID int64) {
+	if cc != nil {
+		cc.teamID = teamID
+	}
+}
+
 // ConnectionBilling returns the data needed to meter one connection's
 // compute-usage at teardown: the org, the authenticated username (used to
 // resolve the informational team id stamped onto the bucket — the user's own

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -485,6 +485,7 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	if errCode == "" {
 		analytics.Default().Capture("query_completed", c.orgID, map[string]any{
 			"user":        c.username,
+			"team_id":     c.teamID,
 			"trace_id":    observe.TraceIDFromContext(c.ctx),
 			"protocol":    protocol,
 			"query_kind":  classifyQuery(cmdType),

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/posthog/duckgres/internal/analytics"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/usersecrets"
 	"github.com/posthog/duckgres/server/wire"
@@ -464,13 +465,37 @@ func (c *clientConn) logQueryStart(scope *queryMetricsScope) {
 func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType string,
 	resultRows, writtenRows int64, errCode, errMsg, protocol string) {
 
-	ql := c.queryLogSink()
-	if ql == nil {
-		return
-	}
+	// Consume the profiling rollup left behind by the most recent
+	// EnrichSpanWithProfiling up front, so the per-org analytics event and the
+	// query-log row observe the same values and it is reset even when the
+	// query-log sink is disabled (a later logQuery without a fresh exec must not
+	// reuse stale timings from a previous query).
 	profilingSummary := c.lastProfilingSummary
 	c.lastProfilingSummary = observe.QueryProfilingSummary{}
+
 	if isQueryLogSelfReferential(query) {
+		return
+	}
+
+	// Per-org product analytics for the terminal event of a successful query.
+	// Failures are already captured by query_failed (logQueryError), so gate on
+	// errCode == "" to keep the lifecycle clean (initiated -> completed | failed)
+	// and avoid double-counting. Emitted independently of the query-log sink so
+	// this usage signal does not depend on query-log configuration.
+	if errCode == "" {
+		analytics.Default().Capture("query_completed", c.orgID, map[string]any{
+			"user":        c.username,
+			"trace_id":    observe.TraceIDFromContext(c.ctx),
+			"protocol":    protocol,
+			"query_kind":  classifyQuery(cmdType),
+			"duration_ms": time.Since(start).Milliseconds(),
+			"cpu_seconds": profilingSummary.CPUTimeSeconds,
+			"result_rows": resultRows,
+		})
+	}
+
+	ql := c.queryLogSink()
+	if ql == nil {
 		return
 	}
 
@@ -503,10 +528,6 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 
 	clientAddr, clientPort := c.clientAddrPort()
 
-	// Consume the profiling rollup left behind by the most recent
-	// EnrichSpanWithProfiling on this connection and reset it so a later
-	// logQuery without a fresh exec (e.g. parse-failure path) doesn't
-	// reuse stale timings from a previous query.
 	pgScanMs := int64(profilingSummary.PostgresScanSeconds * 1000)
 
 	parentQueryID, statementIndex := "", 0


### PR DESCRIPTION
## What

Adds a `query_completed` product-analytics event, emitted per org from `logQuery` on the terminal event of a **successful** statement. Props: `user`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time from the profiling rollup), `result_rows`.

It sits alongside the existing `query_initiated` / `query_failed` events and is gated on `errCode == ""`, so failures stay covered by `query_failed` and the lifecycle reads `initiated -> completed | failed` with no double-counting.

## Why

PostHog needs a per-org "the warehouse was actually used" signal to define managed-warehouse **activation** (e.g. queried on ≥2 distinct days within 14 days of provisioning, or cumulative `cpu_seconds` over a threshold). `query_initiated` gives us query starts, but not success or resource cost. The old `managed warehouse compute usage` push event that carried `cpu_seconds` was retired in #893 when billing moved to the pull API, so that signal no longer reaches PostHog. This adds it back as a lightweight product-analytics event (not a billing path), consistent with the `query_initiated`/`query_failed` events the pull-API migration kept.

## Implementation notes

- The profiling rollup (`lastProfilingSummary`) is now consumed at the **top** of `logQuery`, so the analytics event and the query-log row observe the same values, and it is reset even when the query-log sink is disabled.
- The event is emitted **independently of the query-log sink**, so this usage signal does not depend on query-log configuration.
- Capture is async and batched (existing `analytics` tracker), so it stays off the query latency path.

> [!NOTE]
> **Granularity, please sanity-check.** `query_completed` fires at *statement* granularity (it lives in `logQuery`, which covers simple, extended, simple-batch, COPY, and cursor statements). So a single logical client request can emit more than one `query_completed` — e.g. cursor FETCHes or COPY batches — unlike `query_initiated`, which fires once per accepted request. I chose statement granularity so each statement's `cpu_seconds`/`duration_ms` is captured; downstream filters by `query_kind` to isolate real data queries from utility statements. If you'd rather have a 1:1 pairing with `query_initiated`, say so and I'll rework it.

> [!NOTE]
> **Scope: pgwire only.** The Flight SQL ingress is disabled by default (`flight-port 0`) and has no per-query resource plumbing today, so it's out of scope here. Wiring an equivalent event on that path is a follow-up if/when it's enabled for managed warehouse.

## Testing

- `go build ./server/`, `go vet ./server/`, `golangci-lint run ./server/` — all clean.
- Added `TestLogQueryEmitsQueryCompletedOnSuccess` and `TestLogQueryDoesNotEmitCompletedOnError` to `conn_analytics_test.go`; existing `logQuery`/analytics tests still pass (the profiling-rollup restructure is covered by `TestLogQueryCopiesProfilingSummaryToQueryLogEntry`).
- I (Claude, via PostHog Code) could not run the warehouse end-to-end; verification is the unit tests above plus build/vet/lint.

Updated the events table + notes in `README.md`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
