### PR TITLE
scenario: create production-shaped PostHog tables

### DIFF
--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -6,6 +6,16 @@ The scenario runner executes end-to-end managed-warehouse flows against a config
 
 The default full workload uses one `full-suite.yaml` scenario: it provisions a fresh dev warehouse, creates read-only views over frozen persons/events parquet supplied by `DUCKGRES_SCENARIO_FROZEN_S3_URI`, runs metadata exploration, perf queries, and dbt models, then deprovisions. `fast-suite.yaml` follows the same flow without dbt. The standalone provisioning, frozen metadata, perf, and dbt scenarios remain available for focused debugging.
 
+The targeted frozen-perf scenario additionally creates production-shaped DuckLake
+tables, `posthog.events` and `posthog.persons`, from those raw views. It uses the
+PostHog backfill schema pinned at `056583335dc739b9e025efede811c9b4f5e153f5`,
+rewritten inserts, and `year(timestamp), month(timestamp), day(timestamp)` /
+`year(_timestamp), month(_timestamp)` partitioning. The raw views are deliberately
+retained as the later paired-query performance-control target.
+
+`project_id` is the one mapping exception: it is derived from `team_id`, exactly
+as the pinned production exporter does, so no `project_id` fixture column is needed.
+
 ## Required Environment
 
 Set these before running a real scenario:
@@ -90,6 +100,14 @@ Run frozen perf queries:
 just scenario-frozen-perf
 ```
 
+This runs, in order: raw-view setup, source-column preflight, explicit PostHog
+table DDL and partition setup, deterministic rewritten inserts, then schema,
+partition, count, timestamp-range, key-null-count, and bidirectional parity
+validation. The setup records the pinned revision, `rewritten_insert`, partition
+specifications, and source/destination row counts in
+`main.posthog_table_setup_manifest`. Neither `fast-suite` nor `full-suite` enables
+these tables yet.
+
 Run frozen dbt lifecycle:
 
 ```bash
@@ -164,3 +182,14 @@ The smoke scenario has an `always_run` deprovision step, but an interrupted proc
 4. If deletion does not complete, inspect the dev control-plane logs and the managed warehouse deprovision runbook.
 
 Use placeholders in shared notes and PRs; keep concrete dev values local.
+
+## Frozen PostHog Table Setup Recovery
+
+If the targeted frozen-perf setup or validation fails, retain the scenario error:
+it identifies missing required fixture column names, schema/partition drift, or a
+non-sensitive parity check. Do not edit the raw views to mask it. The warehouse is
+disposable and the next targeted run creates a new one; within a retried setup the
+transaction deletes both destination tables before inserting, so it cannot duplicate
+rows after partial setup. Refresh the fixture only after confirming the pinned
+backfill mapping remains appropriate; change the pin and mappings together when
+upstream production schema changes.

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -496,6 +496,142 @@ func TestFrozenPerfScenarioUsesSupportedStepsAndRelativeCatalog(t *testing.T) {
 	}
 }
 
+func TestFrozenPerfScenarioBuildsAndValidatesPostHogTablesBeforePerf(t *testing.T) {
+	t.Setenv("DUCKGRES_SCENARIO_FROZEN_S3_URI", "s3://example-frozen/frozen_v1/")
+	t.Setenv("DUCKGRES_SCENARIO_ORG_ID", "ci-pr-123-cnpg")
+
+	scenario, _, err := loadScenarioForRun(filepath.Join("scenarios", "posthog_frozen_perf.yaml"))
+	if err != nil {
+		t.Fatalf("load frozen perf scenario: %v", err)
+	}
+	resolved, err := resolveRunTemplates(scenario, "scenario-frozen-perf-20260102t030405z")
+	if err != nil {
+		t.Fatalf("resolve templates: %v", err)
+	}
+
+	steps := make(map[string]core.Step, len(resolved.Steps))
+	for _, step := range resolved.Steps {
+		steps[step.ID] = step
+	}
+	setup, ok := steps["setup_posthog_tables"]
+	if !ok {
+		t.Fatal("expected posthog table setup step")
+	}
+	if got := setup.DependsOn; len(got) != 1 || got[0] != "setup_frozen_views" {
+		t.Fatalf("posthog setup dependencies = %#v, want [setup_frozen_views]", got)
+	}
+	setupFile, _ := setup.With["file"].(string)
+	if !strings.HasSuffix(setupFile, filepath.Join("sql", "setup_posthog_tables.sql")) {
+		t.Fatalf("posthog setup file = %q, want setup_posthog_tables.sql", setupFile)
+	}
+	if _, err := os.Stat(setupFile); err != nil {
+		t.Fatalf("posthog setup file %q should exist: %v", setupFile, err)
+	}
+	validation, ok := steps["validate_posthog_tables"]
+	if !ok {
+		t.Fatal("expected posthog table validation step")
+	}
+	if got := validation.DependsOn; len(got) != 1 || got[0] != "setup_posthog_tables" {
+		t.Fatalf("posthog validation dependencies = %#v, want [setup_posthog_tables]", got)
+	}
+	if got := steps["perf_queries"].DependsOn; len(got) != 1 || got[0] != "validate_posthog_tables" {
+		t.Fatalf("perf dependencies = %#v, want [validate_posthog_tables]", got)
+	}
+}
+
+func TestComposedFrozenSuitesDoNotEnablePostHogTableSetup(t *testing.T) {
+	for _, scenarioFile := range []string{"fast-suite.yaml", "full-suite.yaml"} {
+		t.Run(scenarioFile, func(t *testing.T) {
+			scenario, err := core.LoadScenario(filepath.Join("scenarios", scenarioFile))
+			if err != nil {
+				t.Fatalf("load scenario: %v", err)
+			}
+			for _, step := range scenario.Steps {
+				if step.ID == "setup_posthog_tables" || step.ID == "validate_posthog_tables" {
+					t.Fatalf("%s must not enable %s before scheduled rollout", scenarioFile, step.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestPostHogTableSetupIsExplicitAndRerunnable(t *testing.T) {
+	setupFile := filepath.Join("sql", "setup_posthog_tables.sql")
+	raw, err := os.ReadFile(setupFile)
+	if err != nil {
+		t.Fatalf("read posthog table setup: %v", err)
+	}
+	sql := string(raw)
+	for _, want := range []string{
+		"CREATE SCHEMA IF NOT EXISTS posthog",
+		"CREATE TABLE IF NOT EXISTS posthog.events (",
+		"CREATE TABLE IF NOT EXISTS posthog.persons (",
+		"DELETE FROM posthog.events",
+		"DELETE FROM posthog.persons",
+		"INSERT INTO posthog.events (",
+		"INSERT INTO posthog.persons (",
+		"SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))",
+		"SET PARTITIONED BY (year(_timestamp), month(_timestamp))",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("posthog setup missing %q", want)
+		}
+	}
+	if strings.Contains(sql, "CREATE TABLE AS") || strings.Contains(sql, "SELECT *") {
+		t.Fatal("posthog setup must use explicit table and select column lists")
+	}
+}
+
+func TestPostHogTableSetupValidatesRequiredSourceColumnsAndMappings(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("sql", "setup_posthog_tables.sql"))
+	if err != nil {
+		t.Fatalf("read posthog table setup: %v", err)
+	}
+	sql := string(raw)
+	for _, want := range []string{
+		"056583335dc739b9e025efede811c9b4f5e153f5",
+		"frozen_v1.events_file_view",
+		"frozen_v1.persons_file_view",
+		"information_schema.columns",
+		"missing required source columns",
+		"CAST(properties AS VARCHAR)",
+		"CAST(person_properties AS VARCHAR)",
+		"CAST(team_id AS BIGINT) AS project_id",
+		"CAST(person_version AS UBIGINT)",
+		"CAST(historical_migration AS BOOLEAN)",
+		"CAST(\"timestamp\" AS TIMESTAMPTZ)",
+		"CAST(_timestamp AS TIMESTAMPTZ)",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("posthog setup missing explicit source mapping or diagnostic %q", want)
+		}
+	}
+}
+
+func TestPostHogTableValidationFailsOnParityMismatchWithUsefulDiagnostics(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("sql", "validate_posthog_tables.sql"))
+	if err != nil {
+		t.Fatalf("read posthog table validation: %v", err)
+	}
+	sql := string(raw)
+	for _, want := range []string{
+		"EXCEPT ALL",
+		"ordinal_position",
+		"posthog events parity mismatch",
+		"posthog persons parity mismatch",
+		"posthog.events row-count mismatch",
+		"posthog.persons row-count mismatch",
+		"posthog.events timestamp range mismatch",
+		"posthog.persons timestamp range mismatch",
+		"DESCRIBE posthog.events",
+		"DESCRIBE posthog.persons",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("posthog setup missing parity validation %q", want)
+		}
+	}
+}
+
 func TestFrozenDBTScenarioUsesSupportedStepsAndRelativeProject(t *testing.T) {
 	t.Setenv("DUCKGRES_SCENARIO_FROZEN_S3_URI", "s3://example-frozen/frozen_v1/")
 	t.Setenv("DUCKGRES_SCENARIO_ORG_ID", "ci-pr-123-cnpg")

--- a/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
@@ -34,8 +34,29 @@ steps:
       max_attempts: 12
       retry_interval: 10s
 
+  - id: setup_posthog_tables
+    type: sql
+    depends_on: [setup_frozen_views]
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      catalog: ducklake
+      file: ../sql/setup_posthog_tables.sql
+      max_attempts: 3
+      retry_interval: 10s
+
+  - id: validate_posthog_tables
+    type: sql
+    depends_on: [setup_posthog_tables]
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      catalog: ducklake
+      file: ../sql/validate_posthog_tables.sql
+      max_attempts: 3
+      retry_interval: 10s
+
   - id: perf_queries
     type: perf_queries
+    depends_on: [validate_posthog_tables]
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       catalog: ducklake

--- a/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
@@ -1,0 +1,201 @@
+-- Production schema reference: PostHog/posthog@056583335dc739b9e025efede811c9b4f5e153f5
+-- posthog/dags/events_backfill_to_duckling.py (EVENTS_TABLE_DDL and PERSONS_TABLE_DDL).
+-- The frozen Parquet views remain the raw performance-control representation.
+-- Mapping exception: production derives project_id from team_id, so this rewrite
+-- does the same and intentionally does not require a project_id fixture column.
+
+-- Verify the frozen export carries every production backfill column before DDL or
+-- DML. The column names are non-sensitive and make a stale fixture failure actionable.
+WITH expected_events(column_name) AS (
+    VALUES
+        ('uuid'), ('event'), ('properties'), ('timestamp'), ('team_id'),
+        ('distinct_id'), ('elements_chain'), ('created_at'), ('person_id'),
+        ('person_created_at'), ('person_properties'), ('group0_properties'),
+        ('group1_properties'), ('group2_properties'), ('group3_properties'),
+        ('group4_properties'), ('group0_created_at'), ('group1_created_at'),
+        ('group2_created_at'), ('group3_created_at'), ('group4_created_at'),
+        ('person_mode'), ('historical_migration'), ('_inserted_at')
+),
+missing_events AS (
+    SELECT expected_events.column_name
+    FROM expected_events
+    LEFT JOIN information_schema.columns AS source_columns
+      ON source_columns.table_schema = 'frozen_v1'
+     AND source_columns.table_name = 'events_file_view'
+     AND source_columns.column_name = expected_events.column_name
+    WHERE source_columns.column_name IS NULL
+)
+SELECT CASE
+    WHEN COUNT(*) = 0 THEN 1
+    ELSE error('posthog events missing required source columns: ' || string_agg(column_name, ', '))
+END
+FROM missing_events;
+
+WITH expected_persons(column_name) AS (
+    VALUES
+        ('team_id'), ('distinct_id'), ('id'), ('properties'), ('created_at'),
+        ('is_identified'), ('person_distinct_id_version'), ('person_version'),
+        ('_timestamp'), ('_inserted_at')
+),
+missing_persons AS (
+    SELECT expected_persons.column_name
+    FROM expected_persons
+    LEFT JOIN information_schema.columns AS source_columns
+      ON source_columns.table_schema = 'frozen_v1'
+     AND source_columns.table_name = 'persons_file_view'
+     AND source_columns.column_name = expected_persons.column_name
+    WHERE source_columns.column_name IS NULL
+)
+SELECT CASE
+    WHEN COUNT(*) = 0 THEN 1
+    ELSE error('posthog persons missing required source columns: ' || string_agg(column_name, ', '))
+END
+FROM missing_persons;
+
+CREATE SCHEMA IF NOT EXISTS posthog;
+
+CREATE TABLE IF NOT EXISTS posthog.events (
+    uuid VARCHAR,
+    event VARCHAR,
+    properties VARCHAR,
+    timestamp TIMESTAMPTZ,
+    team_id BIGINT,
+    project_id BIGINT,
+    distinct_id VARCHAR,
+    elements_chain VARCHAR,
+    created_at TIMESTAMPTZ,
+    person_id VARCHAR,
+    person_created_at TIMESTAMPTZ,
+    person_properties VARCHAR,
+    group0_properties VARCHAR,
+    group1_properties VARCHAR,
+    group2_properties VARCHAR,
+    group3_properties VARCHAR,
+    group4_properties VARCHAR,
+    group0_created_at TIMESTAMPTZ,
+    group1_created_at TIMESTAMPTZ,
+    group2_created_at TIMESTAMPTZ,
+    group3_created_at TIMESTAMPTZ,
+    group4_created_at TIMESTAMPTZ,
+    person_mode VARCHAR,
+    historical_migration BOOLEAN,
+    _inserted_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS posthog.persons (
+    team_id BIGINT,
+    distinct_id VARCHAR,
+    id VARCHAR,
+    properties VARCHAR,
+    created_at TIMESTAMPTZ,
+    is_identified BOOLEAN,
+    person_distinct_id_version BIGINT,
+    person_version UBIGINT,
+    _timestamp TIMESTAMPTZ,
+    _inserted_at TIMESTAMPTZ
+);
+
+ALTER TABLE posthog.events
+SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp));
+
+ALTER TABLE posthog.persons
+SET PARTITIONED BY (year(_timestamp), month(_timestamp));
+
+CREATE TABLE IF NOT EXISTS main.posthog_table_setup_manifest (
+    production_schema_revision VARCHAR,
+    load_mode VARCHAR,
+    events_partition_spec VARCHAR,
+    persons_partition_spec VARCHAR,
+    events_source_rows BIGINT,
+    events_destination_rows BIGINT,
+    persons_source_rows BIGINT,
+    persons_destination_rows BIGINT,
+    created_at TIMESTAMPTZ
+);
+
+BEGIN TRANSACTION;
+
+-- Rewritten inserts make a partial setup retry deterministic: each run replaces
+-- the table contents rather than appending a second copy of the frozen fixture.
+DELETE FROM posthog.events;
+DELETE FROM posthog.persons;
+
+INSERT INTO posthog.events (
+    uuid, event, properties, timestamp, team_id, project_id, distinct_id,
+    elements_chain, created_at, person_id, person_created_at, person_properties,
+    group0_properties, group1_properties, group2_properties, group3_properties,
+    group4_properties, group0_created_at, group1_created_at, group2_created_at,
+    group3_created_at, group4_created_at, person_mode, historical_migration,
+    _inserted_at
+)
+SELECT
+    CAST(uuid AS VARCHAR),
+    CAST(event AS VARCHAR),
+    CAST(properties AS VARCHAR),
+    CAST("timestamp" AS TIMESTAMPTZ),
+    CAST(team_id AS BIGINT),
+    CAST(team_id AS BIGINT) AS project_id,
+    CAST(distinct_id AS VARCHAR),
+    CAST(elements_chain AS VARCHAR),
+    CAST(created_at AS TIMESTAMPTZ),
+    CAST(person_id AS VARCHAR),
+    CAST(person_created_at AS TIMESTAMPTZ),
+    CAST(person_properties AS VARCHAR),
+    CAST(group0_properties AS VARCHAR),
+    CAST(group1_properties AS VARCHAR),
+    CAST(group2_properties AS VARCHAR),
+    CAST(group3_properties AS VARCHAR),
+    CAST(group4_properties AS VARCHAR),
+    CAST(group0_created_at AS TIMESTAMPTZ),
+    CAST(group1_created_at AS TIMESTAMPTZ),
+    CAST(group2_created_at AS TIMESTAMPTZ),
+    CAST(group3_created_at AS TIMESTAMPTZ),
+    CAST(group4_created_at AS TIMESTAMPTZ),
+    CAST(person_mode AS VARCHAR),
+    CAST(historical_migration AS BOOLEAN),
+    CAST(_inserted_at AS TIMESTAMPTZ)
+FROM frozen_v1.events_file_view;
+
+INSERT INTO posthog.persons (
+    team_id, distinct_id, id, properties, created_at, is_identified,
+    person_distinct_id_version, person_version, _timestamp, _inserted_at
+)
+SELECT
+    CAST(team_id AS BIGINT),
+    CAST(distinct_id AS VARCHAR),
+    CAST(id AS VARCHAR),
+    CAST(properties AS VARCHAR),
+    CAST(created_at AS TIMESTAMPTZ),
+    CAST(is_identified AS BOOLEAN),
+    CAST(person_distinct_id_version AS BIGINT),
+    CAST(person_version AS UBIGINT),
+    CAST(_timestamp AS TIMESTAMPTZ),
+    CAST(_inserted_at AS TIMESTAMPTZ)
+FROM frozen_v1.persons_file_view;
+
+DELETE FROM main.posthog_table_setup_manifest
+WHERE production_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5';
+
+INSERT INTO main.posthog_table_setup_manifest (
+    production_schema_revision,
+    load_mode,
+    events_partition_spec,
+    persons_partition_spec,
+    events_source_rows,
+    events_destination_rows,
+    persons_source_rows,
+    persons_destination_rows,
+    created_at
+)
+SELECT
+    '056583335dc739b9e025efede811c9b4f5e153f5',
+    'rewritten_insert',
+    'year(timestamp), month(timestamp), day(timestamp)',
+    'year(_timestamp), month(_timestamp)',
+    (SELECT COUNT(*) FROM frozen_v1.events_file_view),
+    (SELECT COUNT(*) FROM posthog.events),
+    (SELECT COUNT(*) FROM frozen_v1.persons_file_view),
+    (SELECT COUNT(*) FROM posthog.persons),
+    now();
+
+COMMIT;

--- a/tests/mw-dev/scenario/sql/steps_test.go
+++ b/tests/mw-dev/scenario/sql/steps_test.go
@@ -503,6 +503,61 @@ func TestExecutorTemplatesSQLFileEnvVars(t *testing.T) {
 	}
 }
 
+func TestExecutorPropagatesPostHogValidationDiagnostics(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		file       string
+		diagnostic string
+		contains   string
+	}{
+		{
+			name:       "missing source columns",
+			file:       filepath.Join("setup_posthog_tables.sql"),
+			diagnostic: "posthog events missing required source columns: group4_properties",
+			contains:   "information_schema.columns",
+		},
+		{
+			name:       "parity mismatch",
+			file:       filepath.Join("validate_posthog_tables.sql"),
+			diagnostic: "posthog events parity mismatch",
+			contains:   "EXCEPT ALL",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provisionState := provision.NewState()
+			provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{
+				Org: "scenario-org", Username: "root", Password: "root-password",
+			})
+			var gotSQL string
+			executor := NewExecutor(ExecutorConfig{
+				ProvisionState: provisionState,
+				Connection: ConnectionConfig{
+					DialHost: "10.0.0.10", SNISuffix: ".dev.example", Port: 5432, SSLMode: "require",
+				},
+				Driver: &fakeDriver{executeFunc: func(_ context.Context, req QueryRequest) (QueryResult, error) {
+					gotSQL = req.SQL
+					return QueryResult{}, errors.New(tc.diagnostic)
+				}},
+			})
+
+			err := executor.ExecuteStep(context.Background(), core.Step{
+				ID: "validate_posthog_tables", Type: StepTypeSQL,
+				With: map[string]any{"org_id": "scenario-org", "file": tc.file},
+			})
+			if !strings.Contains(gotSQL, tc.contains) {
+				t.Fatalf("validation SQL missing %q", tc.contains)
+			}
+			if !strings.Contains(err.Error(), tc.diagnostic) {
+				t.Fatalf("error = %v, want diagnostic %q", err, tc.diagnostic)
+			}
+			var classified classifiedError
+			if !errors.As(err, &classified) || classified.ErrorClass() != ErrorClassSQL {
+				t.Fatalf("error = %T %v, want class %q", err, err, ErrorClassSQL)
+			}
+		})
+	}
+}
+
 func TestExecutorUsesProvisionCredentialsInDSN(t *testing.T) {
 	provisionState := provision.NewState()
 	provisionState.StoreProvisionResponse("scenario-org", provision.ProvisionResponse{

--- a/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
@@ -1,0 +1,243 @@
+-- Validation for the production-shaped PostHog DuckLake tables. Every assertion
+-- raises a concise, non-sensitive SQL error so the scenario fails before perf runs.
+
+DESCRIBE posthog.events;
+DESCRIBE posthog.persons;
+
+WITH expected(table_name, ordinal_position, column_name, data_type) AS (
+    VALUES
+        ('events', 1, 'uuid', 'VARCHAR'), ('events', 2, 'event', 'VARCHAR'),
+        ('events', 3, 'properties', 'VARCHAR'), ('events', 4, 'timestamp', 'TIMESTAMP WITH TIME ZONE'),
+        ('events', 5, 'team_id', 'BIGINT'), ('events', 6, 'project_id', 'BIGINT'),
+        ('events', 7, 'distinct_id', 'VARCHAR'), ('events', 8, 'elements_chain', 'VARCHAR'),
+        ('events', 9, 'created_at', 'TIMESTAMP WITH TIME ZONE'), ('events', 10, 'person_id', 'VARCHAR'),
+        ('events', 11, 'person_created_at', 'TIMESTAMP WITH TIME ZONE'), ('events', 12, 'person_properties', 'VARCHAR'),
+        ('events', 13, 'group0_properties', 'VARCHAR'), ('events', 14, 'group1_properties', 'VARCHAR'),
+        ('events', 15, 'group2_properties', 'VARCHAR'), ('events', 16, 'group3_properties', 'VARCHAR'),
+        ('events', 17, 'group4_properties', 'VARCHAR'), ('events', 18, 'group0_created_at', 'TIMESTAMP WITH TIME ZONE'),
+        ('events', 19, 'group1_created_at', 'TIMESTAMP WITH TIME ZONE'), ('events', 20, 'group2_created_at', 'TIMESTAMP WITH TIME ZONE'),
+        ('events', 21, 'group3_created_at', 'TIMESTAMP WITH TIME ZONE'), ('events', 22, 'group4_created_at', 'TIMESTAMP WITH TIME ZONE'),
+        ('events', 23, 'person_mode', 'VARCHAR'), ('events', 24, 'historical_migration', 'BOOLEAN'),
+        ('events', 25, '_inserted_at', 'TIMESTAMP WITH TIME ZONE'),
+        ('persons', 1, 'team_id', 'BIGINT'), ('persons', 2, 'distinct_id', 'VARCHAR'),
+        ('persons', 3, 'id', 'VARCHAR'), ('persons', 4, 'properties', 'VARCHAR'),
+        ('persons', 5, 'created_at', 'TIMESTAMP WITH TIME ZONE'), ('persons', 6, 'is_identified', 'BOOLEAN'),
+        ('persons', 7, 'person_distinct_id_version', 'BIGINT'), ('persons', 8, 'person_version', 'UBIGINT'),
+        ('persons', 9, '_timestamp', 'TIMESTAMP WITH TIME ZONE'), ('persons', 10, '_inserted_at', 'TIMESTAMP WITH TIME ZONE')
+),
+schema_mismatches AS (
+    SELECT expected.table_name || '.' || expected.column_name AS mismatch
+    FROM expected
+    LEFT JOIN information_schema.columns AS actual
+      ON actual.table_schema = 'posthog'
+     AND actual.table_name = expected.table_name
+     AND actual.ordinal_position = expected.ordinal_position
+     AND actual.column_name = expected.column_name
+     AND actual.data_type = expected.data_type
+    WHERE actual.column_name IS NULL
+    UNION ALL
+    SELECT actual.table_name || '.' || actual.column_name AS mismatch
+    FROM information_schema.columns AS actual
+    LEFT JOIN expected
+     ON expected.table_name = actual.table_name
+     AND expected.ordinal_position = actual.ordinal_position
+     AND expected.column_name = actual.column_name
+     AND expected.data_type = actual.data_type
+    WHERE actual.table_schema = 'posthog'
+      AND expected.column_name IS NULL
+)
+SELECT CASE
+    WHEN COUNT(*) = 0 THEN 1
+    ELSE error('posthog schema mismatch: ' || string_agg(mismatch, ', '))
+END
+FROM schema_mismatches;
+
+WITH expected(table_name, partition_key_index, column_name, transform) AS (
+    VALUES
+        ('events', 0, 'timestamp', 'year'), ('events', 1, 'timestamp', 'month'),
+        ('events', 2, 'timestamp', 'day'), ('persons', 0, '_timestamp', 'year'),
+        ('persons', 1, '_timestamp', 'month')
+),
+actual AS (
+    SELECT
+        table_metadata.table_name,
+        partition_column.partition_key_index,
+        column_metadata.column_name,
+        partition_column.transform
+    FROM "__ducklake_metadata_ducklake".ducklake_partition_column AS partition_column
+    JOIN "__ducklake_metadata_ducklake".ducklake_partition_info AS partition_info
+      ON partition_info.partition_id = partition_column.partition_id
+     AND partition_info.table_id = partition_column.table_id
+     AND partition_info.end_snapshot IS NULL
+    JOIN "__ducklake_metadata_ducklake".ducklake_table AS table_metadata
+      ON table_metadata.table_id = partition_info.table_id
+    JOIN "__ducklake_metadata_ducklake".ducklake_schema AS schema_metadata
+      ON schema_metadata.schema_id = table_metadata.schema_id
+    JOIN "__ducklake_metadata_ducklake".ducklake_column AS column_metadata
+      ON column_metadata.column_id = partition_column.column_id
+     AND column_metadata.table_id = partition_column.table_id
+     AND column_metadata.end_snapshot IS NULL
+    WHERE schema_metadata.schema_name = 'posthog'
+),
+partition_mismatches AS (
+    SELECT expected.table_name || '.' || expected.transform || '(' || expected.column_name || ')' AS mismatch
+    FROM expected
+    LEFT JOIN actual
+      ON actual.table_name = expected.table_name
+     AND actual.partition_key_index = expected.partition_key_index
+     AND actual.column_name = expected.column_name
+     AND actual.transform = expected.transform
+    WHERE actual.column_name IS NULL
+    UNION ALL
+    SELECT actual.table_name || '.' || actual.transform || '(' || actual.column_name || ')' AS mismatch
+    FROM actual
+    LEFT JOIN expected
+      ON expected.table_name = actual.table_name
+     AND expected.partition_key_index = actual.partition_key_index
+     AND expected.column_name = actual.column_name
+     AND expected.transform = actual.transform
+    WHERE expected.column_name IS NULL
+)
+SELECT CASE
+    WHEN COUNT(*) = 0 THEN 1
+    ELSE error('posthog partition metadata mismatch: ' || string_agg(mismatch, ', '))
+END
+FROM partition_mismatches;
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM frozen_v1.events_file_view) AS events_source_rows,
+        (SELECT COUNT(*) FROM posthog.events) AS events_destination_rows,
+        (SELECT COUNT(*) FROM frozen_v1.persons_file_view) AS persons_source_rows,
+        (SELECT COUNT(*) FROM posthog.persons) AS persons_destination_rows
+)
+SELECT CASE
+    WHEN events_source_rows = events_destination_rows THEN 1
+    ELSE error('posthog.events row-count mismatch')
+END,
+CASE
+    WHEN persons_source_rows = persons_destination_rows THEN 1
+    ELSE error('posthog.persons row-count mismatch')
+END
+FROM counts;
+
+WITH ranges AS (
+    SELECT
+        (SELECT MIN(CAST("timestamp" AS TIMESTAMPTZ)) FROM frozen_v1.events_file_view) AS events_source_min,
+        (SELECT MAX(CAST("timestamp" AS TIMESTAMPTZ)) FROM frozen_v1.events_file_view) AS events_source_max,
+        (SELECT MIN(timestamp) FROM posthog.events) AS events_destination_min,
+        (SELECT MAX(timestamp) FROM posthog.events) AS events_destination_max,
+        (SELECT MIN(CAST(_timestamp AS TIMESTAMPTZ)) FROM frozen_v1.persons_file_view) AS persons_source_min,
+        (SELECT MAX(CAST(_timestamp AS TIMESTAMPTZ)) FROM frozen_v1.persons_file_view) AS persons_source_max,
+        (SELECT MIN(_timestamp) FROM posthog.persons) AS persons_destination_min,
+        (SELECT MAX(_timestamp) FROM posthog.persons) AS persons_destination_max
+)
+SELECT CASE
+    WHEN events_source_min IS NOT DISTINCT FROM events_destination_min
+     AND events_source_max IS NOT DISTINCT FROM events_destination_max THEN 1
+    ELSE error('posthog.events timestamp range mismatch')
+END,
+CASE
+    WHEN persons_source_min IS NOT DISTINCT FROM persons_destination_min
+     AND persons_source_max IS NOT DISTINCT FROM persons_destination_max THEN 1
+    ELSE error('posthog.persons timestamp range mismatch')
+END
+FROM ranges;
+
+WITH null_counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM frozen_v1.events_file_view WHERE uuid IS NULL OR event IS NULL OR "timestamp" IS NULL OR team_id IS NULL) AS events_source_nulls,
+        (SELECT COUNT(*) FROM posthog.events WHERE uuid IS NULL OR event IS NULL OR timestamp IS NULL OR team_id IS NULL) AS events_destination_nulls,
+        (SELECT COUNT(*) FROM frozen_v1.persons_file_view WHERE team_id IS NULL OR distinct_id IS NULL OR id IS NULL OR _timestamp IS NULL) AS persons_source_nulls,
+        (SELECT COUNT(*) FROM posthog.persons WHERE team_id IS NULL OR distinct_id IS NULL OR id IS NULL OR _timestamp IS NULL) AS persons_destination_nulls
+)
+SELECT CASE
+    WHEN events_source_nulls = events_destination_nulls THEN 1
+    ELSE error('posthog.events key null-count mismatch')
+END,
+CASE
+    WHEN persons_source_nulls = persons_destination_nulls THEN 1
+    ELSE error('posthog.persons key null-count mismatch')
+END
+FROM null_counts;
+
+WITH source_events AS (
+    SELECT
+        CAST(uuid AS VARCHAR) AS uuid, CAST(event AS VARCHAR) AS event,
+        CAST(properties AS VARCHAR) AS properties, CAST("timestamp" AS TIMESTAMPTZ) AS timestamp,
+        CAST(team_id AS BIGINT) AS team_id, CAST(team_id AS BIGINT) AS project_id,
+        CAST(distinct_id AS VARCHAR) AS distinct_id, CAST(elements_chain AS VARCHAR) AS elements_chain,
+        CAST(created_at AS TIMESTAMPTZ) AS created_at, CAST(person_id AS VARCHAR) AS person_id,
+        CAST(person_created_at AS TIMESTAMPTZ) AS person_created_at, CAST(person_properties AS VARCHAR) AS person_properties,
+        CAST(group0_properties AS VARCHAR) AS group0_properties, CAST(group1_properties AS VARCHAR) AS group1_properties,
+        CAST(group2_properties AS VARCHAR) AS group2_properties, CAST(group3_properties AS VARCHAR) AS group3_properties,
+        CAST(group4_properties AS VARCHAR) AS group4_properties, CAST(group0_created_at AS TIMESTAMPTZ) AS group0_created_at,
+        CAST(group1_created_at AS TIMESTAMPTZ) AS group1_created_at, CAST(group2_created_at AS TIMESTAMPTZ) AS group2_created_at,
+        CAST(group3_created_at AS TIMESTAMPTZ) AS group3_created_at, CAST(group4_created_at AS TIMESTAMPTZ) AS group4_created_at,
+        CAST(person_mode AS VARCHAR) AS person_mode, CAST(historical_migration AS BOOLEAN) AS historical_migration,
+        CAST(_inserted_at AS TIMESTAMPTZ) AS _inserted_at
+    FROM frozen_v1.events_file_view
+),
+left_difference AS (
+    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
+        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
+        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
+        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
+    FROM source_events
+    EXCEPT ALL
+    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
+        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
+        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
+        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
+    FROM posthog.events
+),
+right_difference AS (
+    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
+        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
+        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
+        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
+    FROM posthog.events
+    EXCEPT ALL
+    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
+        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
+        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
+        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
+    FROM source_events
+)
+SELECT CASE
+    WHEN (SELECT COUNT(*) FROM left_difference) = 0 AND (SELECT COUNT(*) FROM right_difference) = 0 THEN 1
+    ELSE error('posthog events parity mismatch')
+END;
+
+WITH source_persons AS (
+    SELECT
+        CAST(team_id AS BIGINT) AS team_id, CAST(distinct_id AS VARCHAR) AS distinct_id,
+        CAST(id AS VARCHAR) AS id, CAST(properties AS VARCHAR) AS properties,
+        CAST(created_at AS TIMESTAMPTZ) AS created_at, CAST(is_identified AS BOOLEAN) AS is_identified,
+        CAST(person_distinct_id_version AS BIGINT) AS person_distinct_id_version,
+        CAST(person_version AS UBIGINT) AS person_version, CAST(_timestamp AS TIMESTAMPTZ) AS _timestamp,
+        CAST(_inserted_at AS TIMESTAMPTZ) AS _inserted_at
+    FROM frozen_v1.persons_file_view
+),
+left_difference AS (
+    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
+        person_distinct_id_version, person_version, _timestamp, _inserted_at
+    FROM source_persons
+    EXCEPT ALL
+    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
+        person_distinct_id_version, person_version, _timestamp, _inserted_at
+    FROM posthog.persons
+),
+right_difference AS (
+    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
+        person_distinct_id_version, person_version, _timestamp, _inserted_at
+    FROM posthog.persons
+    EXCEPT ALL
+    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
+        person_distinct_id_version, person_version, _timestamp, _inserted_at
+    FROM source_persons
+)
+SELECT CASE
+    WHEN (SELECT COUNT(*) FROM left_difference) = 0 AND (SELECT COUNT(*) FROM right_difference) = 0 THEN 1
+    ELSE error('posthog persons parity mismatch')
+END;


### PR DESCRIPTION
## Summary

- create explicit `posthog.events` and `posthog.persons` DuckLake tables from the frozen raw views
- use the PostHog backfill schema pinned at `056583335dc739b9e025efede811c9b4f5e153f5`, production partitioning, deterministic rewritten inserts, and setup metadata
- validate source columns, exact ordered schema, partition metadata, counts, timestamp ranges, key nulls, and bidirectional parity before existing perf queries run
- keep the raw Parquet views and existing perf catalog unchanged; limit table setup to the targeted frozen-perf scenario

## Validation

- `just test-scenario`
- `just lint`

## Follow-up / risk

The live `just scenario-frozen-perf` run was not performed because the configured dev AWS SSO session is expired. The runtime preflight provides non-sensitive diagnostics for any fixture schema drift.