### PR TITLE
test: stabilize e2e worker pod inspection

### DIFF
--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1087,36 +1087,47 @@ newest_org_worker() { # org
     -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null
 }
 
+newest_running_org_worker() { # org
+  k get pods -l "app=duckgres-worker,duckgres/active-org=$1" \
+    --field-selector=status.phase=Running \
+    --sort-by=.metadata.creationTimestamp \
+    -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null
+}
+
 # A pod list only proves the selected name existed at list time. Read every
 # assertion field in one GET so a successful snapshot can still be checked even
 # if Kubernetes removes the pod immediately afterward. The pipe separator is
 # safe for these Kubernetes scalar fields and avoids a JSON parser dependency in
 # the harness image.
-WORKER_INSPECTION_JSONPATH='{.metadata.deletionTimestamp}{"|"}{.metadata.labels.app}{"|"}{.metadata.labels.duckgres/control-plane}{"|"}{.metadata.labels.duckgres/worker-id}{"|"}{.spec.securityContext.runAsNonRoot}{"|"}{.spec.securityContext.runAsUser}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].securityContext.allowPrivilegeEscalation}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="NODE_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{range .spec.volumes[*]}{.name}{","}{end}{"|"}{range .spec.containers[*].volumeMounts[*]}{.mountPath}{","}{end}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.cpu}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.memory}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_MEMORY_LIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="GOMEMLIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_THREADS")].value}'
+WORKER_INSPECTION_JSONPATH='{.metadata.deletionTimestamp}{"|"}{.status.phase}{"|"}{.metadata.labels.app}{"|"}{.metadata.labels.duckgres/control-plane}{"|"}{.metadata.labels.duckgres/worker-id}{"|"}{.spec.securityContext.runAsNonRoot}{"|"}{.spec.securityContext.runAsUser}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].securityContext.allowPrivilegeEscalation}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="NODE_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{range .spec.volumes[*]}{.name}{","}{end}{"|"}{range .spec.containers[*].volumeMounts[*]}{.mountPath}{","}{end}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.cpu}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.memory}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_MEMORY_LIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="GOMEMLIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_THREADS")].value}'
 
 worker_inspection_snapshot() { # org password
   org="$1"; pw="$2"; attempt=0; replacement_requested=false
   while [ "$attempt" -lt "$WORKER_INSPECTION_ATTEMPTS" ]; do
     # A NotFound from either the list or GET is normal lifecycle churn. Retry a
     # newly selected name; never reuse a name that has already raced away.
-    pod="$(newest_org_worker "$org" || true)"
+    pod="$(newest_running_org_worker "$org" || true)"
     if [ -n "$pod" ] && snapshot="$(k get pod "$pod" -o jsonpath="$WORKER_INSPECTION_JSONPATH" 2>/dev/null)"; then
-      IFS='|' read -r worker_deleting worker_app worker_control_plane worker_id \
-        worker_non_root worker_uid worker_privilege_escalation worker_pod_name \
-        worker_node_name worker_volumes worker_mounts worker_cpu worker_memory \
-        worker_memory_limit worker_go_memory_limit worker_threads <<EOF
+      IFS='|' read -r worker_deleting worker_phase worker_app worker_control_plane \
+        worker_id worker_non_root worker_uid worker_privilege_escalation \
+        worker_pod_name worker_node_name worker_volumes worker_mounts worker_cpu \
+        worker_memory worker_memory_limit worker_go_memory_limit worker_threads <<EOF
 $snapshot
 EOF
-      if [ -z "$worker_deleting" ]; then
+      if [ -z "$worker_deleting" ] && [ "$worker_phase" = "Running" ]; then
         worker_pod="$pod"
         return 0
       fi
-      log "worker $pod is retiring during inspection; reselecting"
-      if [ "$replacement_requested" = false ]; then
-        # A terminating worker can remain visible for its grace period. Trigger
-        # the normal on-demand acquire path once instead of polling that pod.
-        wait_worker "$org" "$pw" ducklake
-        replacement_requested=true
+      if [ -n "$worker_deleting" ]; then
+        log "worker $pod is retiring during inspection; reselecting"
+        if [ "$replacement_requested" = false ]; then
+          # A terminating worker can remain visible for its grace period. Trigger
+          # the normal on-demand acquire path once instead of polling that pod.
+          wait_worker "$org" "$pw" ducklake
+          replacement_requested=true
+        fi
+      else
+        log "worker $pod phase=$worker_phase during inspection; reselecting"
       fi
     elif [ -n "$pod" ]; then
       log "worker $pod disappeared during inspection; reselecting"

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -125,6 +125,11 @@ RES2="ci-pr-${PR_NUMBER}-res2"
 # before this budget.
 READY_TIMEOUT="${READY_TIMEOUT:-1200}"
 
+# A worker can retire immediately after the harness's prior query. Bound the
+# pod-inspection reselect loop so the assertion tolerates normal replacement
+# without masking a genuinely missing worker forever.
+WORKER_INSPECTION_ATTEMPTS=30
+
 # The bundled extensions MUST be the PostHog forks. These are the short commit
 # SHAs duckdb_extensions() reports for the tags the image pins
 # (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.6, HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry).
@@ -1082,39 +1087,89 @@ newest_org_worker() { # org
     -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null
 }
 
-assert_worker_pod() { # org
+# A pod list only proves the selected name existed at list time. Read every
+# assertion field in one GET so a successful snapshot can still be checked even
+# if Kubernetes removes the pod immediately afterward. The pipe separator is
+# safe for these Kubernetes scalar fields and avoids a JSON parser dependency in
+# the harness image.
+WORKER_INSPECTION_JSONPATH='{.metadata.deletionTimestamp}{"|"}{.metadata.labels.app}{"|"}{.metadata.labels.duckgres/control-plane}{"|"}{.metadata.labels.duckgres/worker-id}{"|"}{.spec.securityContext.runAsNonRoot}{"|"}{.spec.securityContext.runAsUser}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].securityContext.allowPrivilegeEscalation}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="NODE_NAME")].valueFrom.fieldRef.fieldPath}{"|"}{range .spec.volumes[*]}{.name}{","}{end}{"|"}{range .spec.containers[*].volumeMounts[*]}{.mountPath}{","}{end}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.cpu}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].resources.requests.memory}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_MEMORY_LIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="GOMEMLIMIT")].value}{"|"}{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="DUCKGRES_THREADS")].value}'
+
+worker_inspection_snapshot() { # org password
+  org="$1"; pw="$2"; attempt=0; replacement_requested=false
+  while [ "$attempt" -lt "$WORKER_INSPECTION_ATTEMPTS" ]; do
+    # A NotFound from either the list or GET is normal lifecycle churn. Retry a
+    # newly selected name; never reuse a name that has already raced away.
+    pod="$(newest_org_worker "$org" || true)"
+    if [ -n "$pod" ] && snapshot="$(k get pod "$pod" -o jsonpath="$WORKER_INSPECTION_JSONPATH" 2>/dev/null)"; then
+      IFS='|' read -r worker_deleting worker_app worker_control_plane worker_id \
+        worker_non_root worker_uid worker_privilege_escalation worker_pod_name \
+        worker_node_name worker_volumes worker_mounts worker_cpu worker_memory \
+        worker_memory_limit worker_go_memory_limit worker_threads <<EOF
+$snapshot
+EOF
+      if [ -z "$worker_deleting" ]; then
+        worker_pod="$pod"
+        return 0
+      fi
+      log "worker $pod is retiring during inspection; reselecting"
+      if [ "$replacement_requested" = false ]; then
+        # A terminating worker can remain visible for its grace period. Trigger
+        # the normal on-demand acquire path once instead of polling that pod.
+        wait_worker "$org" "$pw" ducklake
+        replacement_requested=true
+      fi
+    elif [ -n "$pod" ]; then
+      log "worker $pod disappeared during inspection; reselecting"
+    else
+      log "no live worker pod found for $org; waiting for an on-demand replacement"
+      if [ "$replacement_requested" = false ]; then
+        # There is no warm pool. A normal query is the only supported way to
+        # ensure an org with no remaining worker gets a replacement to inspect.
+        wait_worker "$org" "$pw" ducklake
+        replacement_requested=true
+      fi
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+assert_worker_pod() { # org password
   log "worker pod labels / securityContext / downward-env / SA-token"
-  pod="$(newest_org_worker "$1")"; [ -n "$pod" ] || fail "no worker pod found for $1"
+  worker_inspection_snapshot "$1" "$2" \
+    || fail "no live worker pod found for $1 after ${WORKER_INSPECTION_ATTEMPTS} inspection attempts"
+  pod="$worker_pod"
 
   # Labels: app + non-empty control-plane + worker-id (TestK8sWorkerPodCreation).
-  [ "$(k get pod "$pod" -o jsonpath='{.metadata.labels.app}')" = "duckgres-worker" ] \
+  [ "$worker_app" = "duckgres-worker" ] \
     || fail "worker $pod missing app=duckgres-worker"
-  [ -n "$(k get pod "$pod" -o jsonpath='{.metadata.labels.duckgres/control-plane}')" ] \
+  [ -n "$worker_control_plane" ] \
     || fail "worker $pod missing duckgres/control-plane label"
-  [ -n "$(k get pod "$pod" -o jsonpath='{.metadata.labels.duckgres/worker-id}')" ] \
+  [ -n "$worker_id" ] \
     || fail "worker $pod missing duckgres/worker-id label"
 
   # securityContext: non-root, uid 1000, no privilege escalation
   # (TestK8sWorkerSecurityContext).
-  [ "$(k get pod "$pod" -o jsonpath='{.spec.securityContext.runAsNonRoot}')" = "true" ] \
+  [ "$worker_non_root" = "true" ] \
     || fail "worker $pod runAsNonRoot != true"
-  [ "$(k get pod "$pod" -o jsonpath='{.spec.securityContext.runAsUser}')" = "1000" ] \
+  [ "$worker_uid" = "1000" ] \
     || fail "worker $pod runAsUser != 1000"
-  esc="$(k get pod "$pod" -o jsonpath='{.spec.containers[?(@.name=="duckdb-worker")].securityContext.allowPrivilegeEscalation}')"
+  esc="$worker_privilege_escalation"
   [ "$esc" = "false" ] || fail "worker $pod allowPrivilegeEscalation != false ('$esc')"
 
   # Downward-API env: POD_NAME / NODE_NAME (TestK8sWorkerAlwaysStampedWithPodAndNode).
-  pn="$(k get pod "$pod" -o jsonpath='{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}')"
+  pn="$worker_pod_name"
   [ "$pn" = "metadata.name" ] || fail "worker $pod POD_NAME fieldRef '$pn' != metadata.name"
-  nn="$(k get pod "$pod" -o jsonpath='{.spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="NODE_NAME")].valueFrom.fieldRef.fieldPath}')"
+  nn="$worker_node_name"
   [ "$nn" = "spec.nodeName" ] || fail "worker $pod NODE_NAME fieldRef '$nn' != spec.nodeName"
 
   # No ambient SA token (TestK8sWorkerPodsDoNotMountServiceAccountToken). The
   # worker SA is automountServiceAccountToken:false, so the pod has no
   # kube-api-access volume and no token mount.
-  vols="$(k get pod "$pod" -o jsonpath='{.spec.volumes[*].name}')"
+  vols="$worker_volumes"
   case " $vols " in *kube-api-access*) fail "worker $pod has a kube-api-access SA-token volume" ;; esac
-  mounts="$(k get pod "$pod" -o jsonpath='{range .spec.containers[*].volumeMounts[*]}{.mountPath}{"\n"}{end}')"
+  mounts="$worker_mounts"
   if echo "$mounts" | grep -q '/var/run/secrets/kubernetes.io/serviceaccount'; then
     fail "worker $pod mounts a kubernetes.io/serviceaccount token"
   fi
@@ -1123,8 +1178,8 @@ assert_worker_pod() { # org
   # the pool-default resource requests. With the exclusive-node pod anti-affinity
   # removed, requests are the ONLY thing keeping co-scheduled workers from
   # overcommitting a node — a BestEffort default worker is a regression.
-  dcpu="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.cpu}")"
-  dmem="$(k get pod "$pod" -o jsonpath="${WORKER_C}.resources.requests.memory}")"
+  dcpu="$worker_cpu"
+  dmem="$worker_memory"
   [ "$dcpu" = "750m" ] || fail "default worker $pod requests.cpu='$dcpu' want '750m' (pool default; BestEffort regression?)"
   [ "$dmem" = "1536Mi" ] || fail "default worker $pod requests.memory='$dmem' want '1536Mi'"
 
@@ -1134,11 +1189,11 @@ assert_worker_pod() { # org
   # /proc/meminfo and all pre-session work (DuckLake ATTACH, activation) runs
   # effectively unbounded. Values derive from the 750m/1536Mi pool default:
   # 75% of 1536Mi floors to 1GB; GOMEMLIMIT is 1/8 pod = 192MiB; 750m -> 1.
-  dml="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"DUCKGRES_MEMORY_LIMIT\")].value}")"
+  dml="$worker_memory_limit"
   [ "$dml" = "1GB" ] || fail "default worker $pod DUCKGRES_MEMORY_LIMIT='$dml' want '1GB' (75% of 1536Mi, GB-floored)"
-  gml="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"GOMEMLIMIT\")].value}")"
+  gml="$worker_go_memory_limit"
   [ "$gml" = "192MiB" ] || fail "default worker $pod GOMEMLIMIT='$gml' want '192MiB' (1/8 of 1536Mi)"
-  thr="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"DUCKGRES_THREADS\")].value}")"
+  thr="$worker_threads"
   [ "$thr" = "1" ] || fail "default worker $pod DUCKGRES_THREADS='$thr' want '1' (750m rounds up)"
 }
 
@@ -3456,7 +3511,7 @@ lane_cnpg() { # full wire/catalog/concurrency/sizing coverage on the cnpg org
   server_side_cursors    "$CNPG" "$cnpg_pw"
   cancel_then_reuse_same_session "$CNPG" "$cnpg_pw"
   assert_fork_extensions "$CNPG" "$cnpg_pw"   # after a DuckLake R/W (httpfs loaded)
-  assert_worker_pod      "$CNPG"   # newest org pod = a DuckLake worker above
+  assert_worker_pod      "$CNPG" "$cnpg_pw"  # reacquires a live DuckLake worker if one just retired
   concurrent_connections "$CNPG" "$cnpg_pw"
   concurrent_writers     "$CNPG" "$cnpg_pw"
   # Worker sizing on DuckLake: verified fresh sized spawn + same-shape reuse.

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1,6 +1,7 @@
 package e2emwdev_test
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	kjsonpath "k8s.io/client-go/util/jsonpath"
 )
 
 func TestDeployFailsWhenSamePRDucklingsDoNotDelete(t *testing.T) {
@@ -596,6 +598,151 @@ func TestE2EHarnessUsesOnlyCnpgMetadataStores(t *testing.T) {
 	}
 	if strings.Contains(string(runRaw), "ci-pr-${pr}-ext") {
 		t.Error("run.sh still includes the external-metadata org in e2e lifecycle cleanup")
+	}
+}
+
+func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
+	raw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read e2e harness: %v", err)
+	}
+	const prefix = "WORKER_INSPECTION_JSONPATH='"
+	_, expression, found := strings.Cut(string(raw), prefix)
+	if !found {
+		t.Fatal("worker inspection JSONPath is missing")
+	}
+	expression, _, found = strings.Cut(expression, "'\n")
+	if !found {
+		t.Fatal("worker inspection JSONPath is not a single quoted expression")
+	}
+
+	pod := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				"app":                    "duckgres-worker",
+				"duckgres/control-plane": "control-plane",
+				"duckgres/worker-id":     "worker-123",
+			},
+		},
+		"spec": map[string]any{
+			"securityContext": map[string]any{
+				"runAsNonRoot": true,
+				"runAsUser":    1000,
+			},
+			"volumes": []any{map[string]any{"name": "data"}},
+			"containers": []any{map[string]any{
+				"name": "duckdb-worker",
+				"securityContext": map[string]any{
+					"allowPrivilegeEscalation": false,
+				},
+				"env": []any{
+					map[string]any{"name": "POD_NAME", "valueFrom": map[string]any{"fieldRef": map[string]any{"fieldPath": "metadata.name"}}},
+					map[string]any{"name": "NODE_NAME", "valueFrom": map[string]any{"fieldRef": map[string]any{"fieldPath": "spec.nodeName"}}},
+					map[string]any{"name": "DUCKGRES_MEMORY_LIMIT", "value": "1GB"},
+					map[string]any{"name": "GOMEMLIMIT", "value": "192MiB"},
+					map[string]any{"name": "DUCKGRES_THREADS", "value": "1"},
+				},
+				"volumeMounts": []any{map[string]any{"mountPath": "/data"}},
+				"resources": map[string]any{
+					"requests": map[string]any{"cpu": "750m", "memory": "1536Mi"},
+				},
+			}},
+		},
+	}
+
+	template := kjsonpath.New("worker-inspection").AllowMissingKeys(true)
+	if err := template.Parse(expression); err != nil {
+		t.Fatalf("parse worker inspection JSONPath: %v", err)
+	}
+	var got bytes.Buffer
+	if err := template.Execute(&got, pod); err != nil {
+		t.Fatalf("execute worker inspection JSONPath: %v", err)
+	}
+	const want = "|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1"
+	if got.String() != want {
+		t.Fatalf("worker inspection snapshot = %q, want %q", got.String(), want)
+	}
+}
+
+func TestE2EHarnessWorkerPodInspectionReacquiresReplacement(t *testing.T) {
+	raw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read e2e harness: %v", err)
+	}
+
+	// Run only the assertion against a fake in-cluster kubectl. The first list
+	// returns a worker that disappears before its GET; a replacement is then
+	// immediately available. This is the normal worker-retirement race the e2e
+	// harness must tolerate without turning the NotFound into empty assertions.
+	harness := strings.Replace(string(raw), "\nstart_kubectl_download\nk() {", "\nKUBECTL=\"${TEST_KUBECTL:?}\"\nk() {", 1)
+	harness = strings.Replace(harness, "\nmain \"$@\"\n", "\nassert_worker_pod test-org test-password\n", 1)
+	if harness == string(raw) {
+		t.Fatal("could not prepare e2e harness assertion fixture")
+	}
+
+	dir := t.TempDir()
+	harnessPath := filepath.Join(dir, "harness.sh")
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o755); err != nil {
+		t.Fatalf("write harness fixture: %v", err)
+	}
+
+	callsPath := filepath.Join(dir, "kubectl-calls.log")
+	selectionPath := filepath.Join(dir, "worker-selection")
+	kubectlPath := filepath.Join(dir, "kubectl")
+	writeFake(t, dir, "kubectl", `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HARNESS_TEST_CALLS"
+if [[ "$*" == *"get pods -l app=duckgres-worker,duckgres/active-org=test-org"* ]]; then
+  if [[ -e "$HARNESS_TEST_SELECTION" ]]; then
+    printf 'replacement-worker'
+  else
+    touch "$HARNESS_TEST_SELECTION"
+    printf 'stale-worker'
+  fi
+  exit 0
+fi
+if [[ "$*" == *"get pod stale-worker"* ]]; then
+  echo 'Error from server (NotFound): pods "stale-worker" not found' >&2
+  exit 1
+fi
+if [[ "$*" == *"get pod replacement-worker"* && "$*" == *"-o jsonpath="* ]]; then
+  printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1'
+  exit 0
+fi
+echo "unexpected kubectl invocation: $*" >&2
+exit 1
+`)
+	writeFake(t, dir, "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+	cmd := exec.Command("sh", harnessPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_KUBECTL="+kubectlPath,
+		"HARNESS_TEST_CALLS="+callsPath,
+		"HARNESS_TEST_SELECTION="+selectionPath,
+		"CP_API=http://test.invalid",
+		"CP_PG_HOST=control-plane.test",
+		"INTERNAL_SECRET=test-secret",
+		"NAMESPACE=test-namespace",
+		"PR_NUMBER=123",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("worker pod inspection did not reacquire a replacement: %v\n%s", err, out)
+	}
+
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read kubectl calls: %v", err)
+	}
+	callLog := string(calls)
+	if got := strings.Count(callLog, "get pods -l app=duckgres-worker,duckgres/active-org=test-org"); got != 2 {
+		t.Fatalf("worker selections = %d, want 2 (stale then replacement); calls:\n%s", got, callLog)
+	}
+	if !strings.Contains(callLog, "get pod stale-worker") {
+		t.Fatalf("fixture did not inspect the stale worker first; calls:\n%s", callLog)
+	}
+	if got := strings.Count(callLog, "get pod replacement-worker"); got != 1 {
+		t.Fatalf("replacement inspection reads = %d, want 1 atomic snapshot; calls:\n%s", got, callLog)
 	}
 }
 

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -624,6 +624,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 				"duckgres/worker-id":     "worker-123",
 			},
 		},
+		"status": map[string]any{"phase": "Running"},
 		"spec": map[string]any{
 			"securityContext": map[string]any{
 				"runAsNonRoot": true,
@@ -658,7 +659,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 	if err := template.Execute(&got, pod); err != nil {
 		t.Fatalf("execute worker inspection JSONPath: %v", err)
 	}
-	const want = "|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1"
+	const want = "|Running|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1"
 	if got.String() != want {
 		t.Fatalf("worker inspection snapshot = %q, want %q", got.String(), want)
 	}
@@ -692,19 +693,46 @@ func TestE2EHarnessWorkerPodInspectionReacquiresReplacement(t *testing.T) {
 	writeFake(t, dir, "kubectl", `#!/usr/bin/env bash
 printf '%s\n' "$*" >> "$HARNESS_TEST_CALLS"
 if [[ "$*" == *"get pods -l app=duckgres-worker,duckgres/active-org=test-org"* ]]; then
-  if [[ -e "$HARNESS_TEST_SELECTION" ]]; then
-    printf 'replacement-worker'
-  else
-    touch "$HARNESS_TEST_SELECTION"
+  selection="$(cat "$HARNESS_TEST_SELECTION" 2>/dev/null || true)"
+  case "$selection" in
+  "")
+    printf 'stale' > "$HARNESS_TEST_SELECTION"
     printf 'stale-worker'
-  fi
+    ;;
+  stale)
+    printf 'transitioned' > "$HARNESS_TEST_SELECTION"
+    if [[ "$*" == *"--field-selector=status.phase=Running"* ]]; then
+      printf 'transitioned-worker'
+    else
+      printf 'pending-worker'
+    fi
+    ;;
+  *)
+    if [[ "$*" == *"--field-selector=status.phase=Running"* ]]; then
+      printf 'replacement-worker'
+    else
+      printf 'pending-worker'
+    fi
+    ;;
+  esac
   exit 0
 fi
 if [[ "$*" == *"get pod stale-worker"* ]]; then
   echo 'Error from server (NotFound): pods "stale-worker" not found' >&2
   exit 1
 fi
-if [[ "$*" == *"get pod replacement-worker"* && "$*" == *"-o jsonpath="* ]]; then
+if [[ "$*" == *"get pod pending-worker"* && "$*" == *"-o jsonpath="* ]] || \
+   [[ "$*" == *"get pod transitioned-worker"* && "$*" == *"-o jsonpath="* ]] || \
+   [[ "$*" == *"get pod replacement-worker"* && "$*" == *"-o jsonpath="* ]]; then
+  phase=""
+  case "$*" in
+    *"get pod pending-worker"*) phase=Pending ;;
+    *"get pod transitioned-worker"*) phase=Succeeded ;;
+    *"get pod replacement-worker"*) phase=Running ;;
+  esac
+  if [[ "$*" == *".status.phase"* ]]; then
+    printf '|%s' "$phase"
+  fi
   printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1'
   exit 0
 fi
@@ -735,11 +763,20 @@ exit 1
 		t.Fatalf("read kubectl calls: %v", err)
 	}
 	callLog := string(calls)
-	if got := strings.Count(callLog, "get pods -l app=duckgres-worker,duckgres/active-org=test-org"); got != 2 {
-		t.Fatalf("worker selections = %d, want 2 (stale then replacement); calls:\n%s", got, callLog)
+	if got := strings.Count(callLog, "get pods -l app=duckgres-worker,duckgres/active-org=test-org"); got != 3 {
+		t.Fatalf("worker selections = %d, want 3 (stale, terminal, then replacement); calls:\n%s", got, callLog)
+	}
+	if got := strings.Count(callLog, "--field-selector=status.phase=Running"); got != 3 {
+		t.Fatalf("running-worker selections = %d, want 3; calls:\n%s", got, callLog)
 	}
 	if !strings.Contains(callLog, "get pod stale-worker") {
 		t.Fatalf("fixture did not inspect the stale worker first; calls:\n%s", callLog)
+	}
+	if strings.Contains(callLog, "get pod pending-worker") {
+		t.Fatalf("inspection accepted a non-Running pod; calls:\n%s", callLog)
+	}
+	if got := strings.Count(callLog, "get pod transitioned-worker"); got != 1 {
+		t.Fatalf("terminal transition inspections = %d, want 1; calls:\n%s", got, callLog)
 	}
 	if got := strings.Count(callLog, "get pod replacement-worker"); got != 1 {
 		t.Fatalf("replacement inspection reads = %d, want 1 atomic snapshot; calls:\n%s", got, callLog)


### PR DESCRIPTION
## Summary

- make the mw-dev worker-pod inspection resilient to normal worker retirement and replacement
- add regression coverage for a stale pod selected by the list call and for the combined Kubernetes JSONPath snapshot

## Root cause

The harness selected the newest org worker once, then issued separate Kubernetes reads for every label, security, environment, volume, and resource assertion. An idle worker can be retired asynchronously between the list and any one of those reads. A resulting `NotFound` produced empty JSONPath output, which was reported as a false configuration failure.

## Why this is safe

The harness now retries only lifecycle races (missing, deleted, terminating, or no-longer-Running pods) with a bounded reselect loop. It checks every existing strict assertion from one successful, `Running`, non-terminating pod snapshot. Assertion mismatches still fail immediately; they are never retried or ignored. If an org has no worker left, one normal acquire query requests an on-demand replacement before retrying inspection.

PR #1006 was also checked: its diff is limited to scenario and scenario-runbook files, with no harness, Kubernetes worker, or control-plane lifecycle changes.

## Validation

- `go test -count=1 ./tests/mw-dev`
- `just test-scenario`
- `sh -n tests/mw-dev/e2e/harness.sh`
- `just lint`

The mw-dev AWS profile and Kubernetes API read access are valid. A live e2e run was not started locally because this checkout has no branch-built/pushed arm64 all-in-one image or required e2e deployment variables, and the repository has no `just test-e2e` recipe. The PR workflow will build the correctly tagged image and run the full isolated e2e job.
