### PR TITLE
fix(reshard): validate destination shard connectivity

### DIFF
--- a/controlplane/admin/reshard.go
+++ b/controlplane/admin/reshard.go
@@ -158,6 +158,11 @@ func hasESOReadablePrefix(name string) bool {
 // counts as a connect failure → 400.
 const externalProbeTimeout = 8 * time.Second
 
+// cnpgProbeTimeout bounds the destination-shard preflight. Unlike checking
+// for a Pooler pod or TCP listener, this executes SELECT 1 through PostgreSQL
+// with the shard provisioner credential, proving a real primary is available.
+const cnpgProbeTimeout = 8 * time.Second
+
 // ExternalTargetProber verifies the CP can actually reach + authenticate
 // against a cnpg→external reshard target Postgres before the op is created —
 // the destructive cnpg→ext flip (Crossplane DELETEs the source role/DB) happens
@@ -172,6 +177,14 @@ type ExternalTargetProber interface {
 	// 5432) as user/database with password over the given sslmode and runs a
 	// trivial liveness query. It MUST NOT echo the password in its error.
 	Probe(ctx context.Context, endpoint, user, database, password, sslMode string) error
+}
+
+// CnpgTargetProber verifies that a destination shard is accepting real
+// PostgreSQL queries before an operation is created. Production uses the
+// shard-scoped provisioner Secret; failure to configure this guard fails
+// reshard submission closed.
+type CnpgTargetProber interface {
+	ProbeCNPG(ctx context.Context, shard string) error
 }
 
 type reshardTargetRequest struct {
@@ -205,8 +218,8 @@ type startReshardRequest struct {
 // back to the shards tenants already occupy. prober may be nil (tests /
 // non-k8s) — the external target pre-flight connection check is then SKIPPED
 // (see ExternalTargetProber).
-func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, spawner ReshardPodSpawner, cluster kubernetes.Interface, prober ExternalTargetProber) {
-	h := &reshardHandler{store: store, lister: lister, spawner: spawner, cluster: cluster, prober: prober, stash: newReshardPasswordStash()}
+func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingMetadataLister, spawner ReshardPodSpawner, cluster kubernetes.Interface, prober ExternalTargetProber, cnpgProber CnpgTargetProber) {
+	h := &reshardHandler{store: store, lister: lister, spawner: spawner, cluster: cluster, prober: prober, cnpgProber: cnpgProber, stash: newReshardPasswordStash()}
 	r.POST("/orgs/:id/reshard", h.start)
 	r.GET("/orgs/:id/reshards", h.listForOrg)
 	r.GET("/reshards", h.listAll)
@@ -219,12 +232,13 @@ func RegisterReshardAPI(r *gin.RouterGroup, store ReshardStore, lister DucklingM
 }
 
 type reshardHandler struct {
-	store   ReshardStore
-	lister  DucklingMetadataLister
-	spawner ReshardPodSpawner
-	cluster kubernetes.Interface
-	prober  ExternalTargetProber
-	stash   *reshardPasswordStash
+	store      ReshardStore
+	lister     DucklingMetadataLister
+	spawner    ReshardPodSpawner
+	cluster    kubernetes.Interface
+	prober     ExternalTargetProber
+	cnpgProber CnpgTargetProber
+	stash      *reshardPasswordStash
 }
 
 // cnpgShardsNamespace is where the shared CNPG metadata shards run; instance
@@ -425,6 +439,23 @@ func (h *reshardHandler) start(c *gin.Context) {
 		}
 		if sourceKind == configstore.MetadataStoreKindCnpgShard && currentShard != "" && shard == currentShard {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "target shard equals the org's current shard (" + currentShard + ")"})
+			return
+		}
+		if h.cnpgProber == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"code":  "destination_shard_guard_unavailable",
+				"error": "destination shard connectivity guard is unavailable; refusing to create a reshard operation",
+			})
+			return
+		}
+		probeCtx, cancel := context.WithTimeout(c.Request.Context(), cnpgProbeTimeout)
+		err := h.cnpgProber.ProbeCNPG(probeCtx, shard)
+		cancel()
+		if err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"code":  "destination_shard_unavailable",
+				"error": fmt.Sprintf("destination shard %s is not accepting PostgreSQL connections: %v", shard, err),
+			})
 			return
 		}
 		op.TargetKind = configstore.MetadataStoreKindCnpgShard

--- a/controlplane/admin/reshard_test.go
+++ b/controlplane/admin/reshard_test.go
@@ -187,8 +187,11 @@ func (f fakeShardLister) CRMetadataStores(context.Context) (map[string]DucklingM
 
 // fakeProber records the last probe and returns a canned error (nil = success).
 type fakeProber struct {
-	err    error
-	called bool
+	err        error
+	called     bool
+	cnpgErr    error
+	cnpgCalled bool
+	lastShard  string
 	// last* capture the resolved args so a test can assert defaulting.
 	lastEndpoint, lastUser, lastDatabase, lastPassword, lastSSLMode string
 }
@@ -197,6 +200,12 @@ func (p *fakeProber) Probe(_ context.Context, endpoint, user, database, password
 	p.called = true
 	p.lastEndpoint, p.lastUser, p.lastDatabase, p.lastPassword, p.lastSSLMode = endpoint, user, database, password, sslMode
 	return p.err
+}
+
+func (p *fakeProber) ProbeCNPG(_ context.Context, shard string) error {
+	p.cnpgCalled = true
+	p.lastShard = shard
+	return p.cnpgErr
 }
 
 // defaultShardLister matches the default fake warehouse: a cnpg-shard org
@@ -216,30 +225,30 @@ func externalShardLister(endpoint string) DucklingMetadataLister {
 }
 
 func reshardRouter(store *fakeReshardStore) *gin.Engine {
-	r, _ := reshardRouterFull(store, nil, nil)
+	r, _ := reshardRouterFull(store, nil, nil, &fakeProber{})
 	return r
 }
 
 func reshardRouterWithCluster(store *fakeReshardStore, cluster kubernetes.Interface) *gin.Engine {
-	r, _ := reshardRouterFull(store, cluster, nil)
+	r, _ := reshardRouterFull(store, cluster, nil, &fakeProber{})
 	return r
 }
 
 // reshardRouterLister registers the API with a specific duckling lister (nil
 // allowed — the degraded no-duckling-client path).
 func reshardRouterLister(store *fakeReshardStore, lister DucklingMetadataLister) *gin.Engine {
-	r, _ := reshardRouterSpawner(store, nil, nil, &fakeSpawner{}, "internal-secret", lister)
+	r, _ := reshardRouterSpawner(store, nil, nil, &fakeProber{}, &fakeSpawner{}, "internal-secret", lister)
 	return r
 }
 
 // reshardRouterFull registers the API with a fakeSpawner and an
 // internal-secret identity on every request (the password endpoint gates on
 // it; production wiring runs AuthMiddleware in front).
-func reshardRouterFull(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber) (*gin.Engine, *fakeSpawner) {
-	return reshardRouterSpawner(store, cluster, prober, &fakeSpawner{}, "internal-secret", defaultShardLister())
+func reshardRouterFull(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber, cnpgProber CnpgTargetProber) (*gin.Engine, *fakeSpawner) {
+	return reshardRouterSpawner(store, cluster, prober, cnpgProber, &fakeSpawner{}, "internal-secret", defaultShardLister())
 }
 
-func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber, spawner ReshardPodSpawner, identitySource string, lister DucklingMetadataLister) (*gin.Engine, *fakeSpawner) {
+func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface, prober ExternalTargetProber, cnpgProber CnpgTargetProber, spawner ReshardPodSpawner, identitySource string, lister DucklingMetadataLister) (*gin.Engine, *fakeSpawner) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -252,7 +261,7 @@ func reshardRouterSpawner(store *fakeReshardStore, cluster kubernetes.Interface,
 		}
 		c.Next()
 	})
-	RegisterReshardAPI(r.Group("/api/v1"), store, lister, spawner, cluster, prober)
+	RegisterReshardAPI(r.Group("/api/v1"), store, lister, spawner, cluster, prober, cnpgProber)
 	fs, _ := spawner.(*fakeSpawner)
 	return r, fs
 }
@@ -269,11 +278,15 @@ func doJSON(r *gin.Engine, method, path, body string) *httptest.ResponseRecorder
 // target on the op row.
 func TestReshardStartCnpg(t *testing.T) {
 	store := newFakeReshardStore()
-	r, spawner := reshardRouterFull(store, nil, nil)
+	prober := &fakeProber{}
+	r, spawner := reshardRouterFull(store, nil, nil, prober)
 	w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"},"drain_timeout_seconds":120,"cutover_timeout_seconds":45}`)
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d body %s, want 202", w.Code, w.Body.String())
+	}
+	if !prober.cnpgCalled || prober.lastShard != "shard-002" {
+		t.Fatalf("CNPG preflight = called %t shard %q, want called for shard-002", prober.cnpgCalled, prober.lastShard)
 	}
 	var op configstore.ReshardOperation
 	if err := json.Unmarshal(w.Body.Bytes(), &op); err != nil {
@@ -293,6 +306,32 @@ func TestReshardStartCnpg(t *testing.T) {
 	}
 	if spawner.spawned[0].PasswordURL != "" || op.PasswordURL != "" {
 		t.Fatalf("cnpg target must carry no password URL (got %q)", spawner.spawned[0].PasswordURL)
+	}
+}
+
+func TestReshardStartCnpgRequiresSuccessfulConnectivityProbe(t *testing.T) {
+	body := `{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`
+
+	for _, tc := range []struct {
+		name       string
+		prober     CnpgTargetProber
+		wantStatus int
+		wantError  string
+	}{
+		{name: "unreachable", prober: &fakeProber{cnpgErr: errors.New("no PostgreSQL backend")}, wantStatus: http.StatusServiceUnavailable, wantError: `"code":"destination_shard_unavailable"`},
+		{name: "guard unavailable", prober: nil, wantStatus: http.StatusServiceUnavailable, wantError: "destination shard connectivity guard is unavailable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeReshardStore()
+			r, _ := reshardRouterFull(store, nil, nil, tc.prober)
+			w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard", body)
+			if w.Code != tc.wantStatus || !strings.Contains(w.Body.String(), tc.wantError) {
+				t.Fatalf("status/body = %d %s, want %d containing %q", w.Code, w.Body.String(), tc.wantStatus, tc.wantError)
+			}
+			if len(store.ops) != 0 {
+				t.Fatalf("created %d operations despite failed-closed destination guard", len(store.ops))
+			}
+		})
 	}
 }
 
@@ -503,7 +542,7 @@ func TestReshardExtPreflightProbe(t *testing.T) {
 	// Passing prober → 202, op created, probe saw the resolved args.
 	store := newFakeReshardStore()
 	pb := &fakeProber{}
-	rp, _ := reshardRouterFull(store, nil, pb)
+	rp, _ := reshardRouterFull(store, nil, pb, &fakeProber{})
 	w := doJSON(rp, http.MethodPost, "/api/v1/orgs/acme/reshard", body)
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("passing prober: status = %d body %s, want 202", w.Code, w.Body.String())
@@ -521,7 +560,7 @@ func TestReshardExtPreflightProbe(t *testing.T) {
 	// Failing prober → 400, redacted message, NO op created.
 	store = newFakeReshardStore()
 	pb = &fakeProber{err: errors.New("connection refused")}
-	rp, _ = reshardRouterFull(store, nil, pb)
+	rp, _ = reshardRouterFull(store, nil, pb, &fakeProber{})
 	w = doJSON(rp, http.MethodPost, "/api/v1/orgs/acme/reshard", body)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("failing prober: status = %d body %s, want 400", w.Code, w.Body.String())
@@ -538,7 +577,7 @@ func TestReshardExtPreflightProbe(t *testing.T) {
 
 	// Nil prober → check skipped, op created.
 	store = newFakeReshardStore()
-	rp, _ = reshardRouterFull(store, nil, nil)
+	rp, _ = reshardRouterFull(store, nil, nil, &fakeProber{})
 	w = doJSON(rp, http.MethodPost, "/api/v1/orgs/acme/reshard", body)
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("nil prober: status = %d body %s, want 202", w.Code, w.Body.String())
@@ -556,7 +595,7 @@ func TestReshardExtPreflightProbe(t *testing.T) {
 // only endpoint (covered by TestReshardPasswordEndpoint).
 func TestReshardExtPasswordStashedNotPersisted(t *testing.T) {
 	store := newFakeReshardStore()
-	r, spawner := reshardRouterFull(store, nil, nil)
+	r, spawner := reshardRouterFull(store, nil, nil, &fakeProber{})
 	w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"duckling-my-secret","user":"postgres","database":"postgres","password":"hunter2"}}`)
 	if w.Code != http.StatusAccepted {
@@ -596,7 +635,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 
 	// Same handler instance must serve start + pull (the stash is in-memory).
 	store := newFakeReshardStore()
-	r, _ := reshardRouterFull(store, nil, nil)
+	r, _ := reshardRouterFull(store, nil, nil, &fakeProber{})
 	if w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard", start); w.Code != http.StatusAccepted {
 		t.Fatalf("start: %d %s", w.Code, w.Body.String())
 	}
@@ -628,7 +667,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 
 	// An SSO admin identity is refused — internal secret ONLY.
 	ssoStore := newFakeReshardStore()
-	ssoR, _ := reshardRouterSpawner(ssoStore, nil, nil, &fakeSpawner{}, "sso", defaultShardLister())
+	ssoR, _ := reshardRouterSpawner(ssoStore, nil, nil, &fakeProber{}, &fakeSpawner{}, "sso", defaultShardLister())
 	if w := doJSON(ssoR, http.MethodPost, "/api/v1/orgs/acme/reshard", start); w.Code != http.StatusAccepted {
 		t.Fatalf("sso start: %d", w.Code)
 	}
@@ -643,7 +682,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 	// A replica that never saw the start request has no stash → 404.
 	otherStore := newFakeReshardStore()
 	otherStore.ops[1] = &configstore.ReshardOperation{ID: 1, OrgID: "acme", State: configstore.ReshardStateRunning}
-	otherR, _ := reshardRouterFull(otherStore, nil, nil)
+	otherR, _ := reshardRouterFull(otherStore, nil, nil, &fakeProber{})
 	if w := doJSON(otherR, http.MethodGet, "/api/v1/reshards/1/password", ""); w.Code != http.StatusNotFound {
 		t.Fatalf("stashless replica pull = %d, want 404", w.Code)
 	}
@@ -657,7 +696,7 @@ func TestReshardPasswordEndpoint(t *testing.T) {
 func TestReshardStartSpawnFailure(t *testing.T) {
 	// Spawn error → 502, op failed.
 	store := newFakeReshardStore()
-	r, _ := reshardRouterSpawner(store, nil, nil, &fakeSpawner{spawnErr: errors.New("pods is forbidden")}, "internal-secret", defaultShardLister())
+	r, _ := reshardRouterSpawner(store, nil, nil, &fakeProber{}, &fakeSpawner{spawnErr: errors.New("pods is forbidden")}, "internal-secret", defaultShardLister())
 	w := doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`)
 	if w.Code != http.StatusBadGateway {
@@ -670,7 +709,7 @@ func TestReshardStartSpawnFailure(t *testing.T) {
 	// Ext target + no self pod IP → 500, op failed, no spawn attempted.
 	store = newFakeReshardStore()
 	sp := &fakeSpawner{noURL: true}
-	r, _ = reshardRouterSpawner(store, nil, nil, sp, "internal-secret", defaultShardLister())
+	r, _ = reshardRouterSpawner(store, nil, nil, &fakeProber{}, sp, "internal-secret", defaultShardLister())
 	w = doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"external","endpoint":"rds.example.com","password_aws_secret":"duckling-x","password":"p"}}`)
 	if w.Code != http.StatusInternalServerError {
@@ -682,7 +721,7 @@ func TestReshardStartSpawnFailure(t *testing.T) {
 
 	// Nil spawner → 503, nothing created.
 	store = newFakeReshardStore()
-	r, _ = reshardRouterSpawner(store, nil, nil, nil, "internal-secret", defaultShardLister())
+	r, _ = reshardRouterSpawner(store, nil, nil, &fakeProber{}, nil, "internal-secret", defaultShardLister())
 	w = doJSON(r, http.MethodPost, "/api/v1/orgs/acme/reshard",
 		`{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"}}`)
 	if w.Code != http.StatusServiceUnavailable {

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -21,6 +21,7 @@ import (
 	"github.com/posthog/duckgres/controlplane/provisioner"
 	"github.com/posthog/duckgres/controlplane/provisioning"
 	"github.com/posthog/duckgres/server"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -30,9 +31,12 @@ import (
 // credentials / missing DB) BEFORE the destructive flip. It parses the
 // admin-supplied endpoint as host[:port] (default 5432), mirroring how the
 // reshard runner builds the external target CatalogEndpoint.
-type catalogCopierProber struct{}
+type catalogCopierProber struct {
+	cluster kubernetes.Interface
+	probe   func(context.Context, provisioner.CatalogEndpoint) error
+}
 
-func (catalogCopierProber) Probe(ctx context.Context, endpoint, user, database, password, sslMode string) error {
+func (p catalogCopierProber) Probe(ctx context.Context, endpoint, user, database, password, sslMode string) error {
 	host, port := endpoint, 5432
 	if h, p, err := net.SplitHostPort(endpoint); err == nil {
 		host = h
@@ -40,14 +44,40 @@ func (catalogCopierProber) Probe(ctx context.Context, endpoint, user, database, 
 			port = n
 		}
 	}
-	return provisioner.PGCatalogCopier{}.Probe(ctx, provisioner.CatalogEndpoint{
+	target := provisioner.CatalogEndpoint{
 		Host:     host,
 		Port:     port,
 		User:     user,
 		Database: database,
 		Password: password,
 		SSLMode:  sslMode,
-	})
+	}
+	if p.probe != nil {
+		return p.probe(ctx, target)
+	}
+	return provisioner.PGCatalogCopier{}.Probe(ctx, target)
+}
+
+func (p catalogCopierProber) ProbeCNPG(ctx context.Context, shard string) error {
+	if p.cluster == nil {
+		return fmt.Errorf("kubernetes client unavailable")
+	}
+	secretName := "cnpg-" + shard + "-provisioner"
+	secret, err := p.cluster.CoreV1().Secrets("ducklings").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("read shard provisioner credential %s: %w", secretName, err)
+	}
+	endpoint := string(secret.Data["endpoint"])
+	user := string(secret.Data["username"])
+	password := string(secret.Data["password"])
+	port := string(secret.Data["port"])
+	if endpoint == "" || user == "" || password == "" {
+		return fmt.Errorf("shard provisioner credential %s is missing endpoint, username, or password", secretName)
+	}
+	if port != "" {
+		endpoint = net.JoinHostPort(endpoint, port)
+	}
+	return p.Probe(ctx, endpoint, user, "postgres", password, "require")
 }
 
 // orgRouterAdapter wraps OrgRouter to implement both OrgRouterInterface
@@ -655,7 +685,8 @@ func SetupMultiTenant(
 	// SELECT-1 probe to fail-fast an unreachable/bad-credential target before
 	// the destructive flip. Always available in the k8s CP build; nil-degrades
 	// in tests / non-k8s (the runner's copy still catches a bad credential).
-	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardSpawnerHandle, clusterClient, catalogCopierProber{})
+	targetProber := catalogCopierProber{cluster: clusterClient}
+	admin.RegisterReshardAPI(api, store, ducklingMetadata, reshardSpawnerHandle, clusterClient, targetProber, targetProber)
 
 	// Break-glass internal-secret login (the SPA owns "/" and app routes).
 	admin.RegisterLogin(engine, adminTokens)

--- a/controlplane/multitenant_test.go
+++ b/controlplane/multitenant_test.go
@@ -3,11 +3,16 @@
 package controlplane
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/provisioner"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestHealthHandlerReturnsServiceUnavailableWhenUnhealthy(t *testing.T) {
@@ -35,5 +40,34 @@ func TestHealthHandlerReturnsOKWhenHealthy(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 while healthy, got %d", rec.Code)
+	}
+}
+
+func TestCatalogCopierProberUsesShardProvisionerSecret(t *testing.T) {
+	cluster := k8sfake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cnpg-shard-004-provisioner", Namespace: "ducklings"},
+		Data: map[string][]byte{
+			"endpoint": []byte("shard-004-rw.cnpg-shards.svc.cluster.local"),
+			"port":     []byte("5432"),
+			"username": []byte("tenant_provisioner"),
+			"password": []byte("not-logged"),
+		},
+	})
+	var got provisioner.CatalogEndpoint
+	prober := catalogCopierProber{
+		cluster: cluster,
+		probe: func(_ context.Context, endpoint provisioner.CatalogEndpoint) error {
+			got = endpoint
+			return nil
+		},
+	}
+
+	if err := prober.ProbeCNPG(context.Background(), "shard-004"); err != nil {
+		t.Fatalf("ProbeCNPG: %v", err)
+	}
+	if got.Host != "shard-004-rw.cnpg-shards.svc.cluster.local" || got.Port != 5432 ||
+		got.User != "tenant_provisioner" || got.Database != "postgres" ||
+		got.Password != "not-logged" || got.SSLMode != "require" {
+		t.Fatalf("probe endpoint = %+v", got)
 	}
 }

--- a/controlplane/provisioner/k8s_client.go
+++ b/controlplane/provisioner/k8s_client.go
@@ -573,6 +573,55 @@ func (d *DucklingClient) readSecretKey(ctx context.Context, ref SecretReference)
 	return string(decoded), nil
 }
 
+// CnpgProvisionerEndpoint resolves the shard-scoped administrative credential
+// used to prove a real primary accepts queries. The Secret is restricted by
+// resourceName in deployment RBAC and its values are never logged.
+func (d *DucklingClient) CnpgProvisionerEndpoint(ctx context.Context, shard string) (CatalogEndpoint, error) {
+	name := "cnpg-" + shard + "-provisioner"
+	secret, err := d.client.Resource(secretGVR).Namespace(ducklingNamespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return CatalogEndpoint{}, fmt.Errorf("get Secret %s/%s: %w", ducklingNamespace, name, err)
+	}
+	read := func(key string) (string, error) {
+		encoded, found, nestedErr := unstructured.NestedString(secret.Object, "data", key)
+		if nestedErr != nil {
+			return "", fmt.Errorf("read Secret %s/%s key %q: %w", ducklingNamespace, name, key, nestedErr)
+		}
+		if !found || encoded == "" {
+			return "", fmt.Errorf("Secret %s/%s has no non-empty %q key", ducklingNamespace, name, key)
+		}
+		decoded, decodeErr := base64.StdEncoding.DecodeString(encoded)
+		if decodeErr != nil || len(decoded) == 0 {
+			return "", fmt.Errorf("Secret %s/%s has invalid %q data", ducklingNamespace, name, key)
+		}
+		return string(decoded), nil
+	}
+	endpoint, err := read("endpoint")
+	if err != nil {
+		return CatalogEndpoint{}, err
+	}
+	portText, err := read("port")
+	if err != nil {
+		return CatalogEndpoint{}, err
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return CatalogEndpoint{}, fmt.Errorf("Secret %s/%s has invalid port", ducklingNamespace, name)
+	}
+	user, err := read("username")
+	if err != nil {
+		return CatalogEndpoint{}, err
+	}
+	password, err := read("password")
+	if err != nil {
+		return CatalogEndpoint{}, err
+	}
+	return CatalogEndpoint{
+		Host: endpoint, Port: port, User: user, Password: password,
+		Database: "postgres", SSLMode: "require",
+	}, nil
+}
+
 // ComposedResourceError describes one composed managed resource that is not
 // healthy — Crossplane could not sync it to the provider (Synced=False) or the
 // provider reports it not ready (Ready=False) — along with that condition's

--- a/controlplane/provisioner/k8s_client_test.go
+++ b/controlplane/provisioner/k8s_client_test.go
@@ -48,6 +48,32 @@ func credentialSecret(name, password string) *unstructured.Unstructured {
 	}}
 }
 
+func TestCnpgProvisionerEndpointReadsCompleteScopedSecret(t *testing.T) {
+	data := map[string]interface{}{}
+	for key, value := range map[string]string{
+		"endpoint": "shard-004-rw.cnpg-shards.svc.cluster.local",
+		"port":     "5432", "username": "tenant_provisioner", "password": "secret",
+	} {
+		data[key] = base64.StdEncoding.EncodeToString([]byte(value))
+	}
+	secret := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1", "kind": "Secret",
+		"metadata": map[string]interface{}{"name": "cnpg-shard-004-provisioner", "namespace": ducklingNamespace},
+		"data":     data,
+	}}
+	fakeK8s := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), secret)
+
+	endpoint, err := NewDucklingClientWithDynamic(fakeK8s).CnpgProvisionerEndpoint(context.Background(), "shard-004")
+	if err != nil {
+		t.Fatalf("CnpgProvisionerEndpoint: %v", err)
+	}
+	if endpoint.Host != "shard-004-rw.cnpg-shards.svc.cluster.local" || endpoint.Port != 5432 ||
+		endpoint.User != "tenant_provisioner" || endpoint.Database != "postgres" ||
+		endpoint.Password != "secret" || endpoint.SSLMode != "require" {
+		t.Fatalf("endpoint = %+v", endpoint.Redacted())
+	}
+}
+
 func TestGetResolvesMetadataPasswordFromCredentialSecretRef(t *testing.T) {
 	cr := ducklingWithCredentialRef("acme", SecretReference{
 		Name: "cnpg-tenant-acme-password", Namespace: ducklingNamespace, Key: "password",

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -145,6 +145,7 @@ type reshardDucklingClient interface {
 	SetReshardMaintenanceCleanup(ctx context.Context, name string, operationID int64) error
 	ReshardMaintenanceRoleRemoved(ctx context.Context, name string) (bool, error)
 	ReshardMaintenanceCleanupComplete(ctx context.Context, name string) (complete bool, detail string, err error)
+	CnpgProvisionerEndpoint(ctx context.Context, shard string) (CatalogEndpoint, error)
 }
 
 // NewReshardRunner builds a runner over the real config store + duckling
@@ -655,6 +656,9 @@ func (o *opRun) run(ctx context.Context, fenced <-chan struct{}) error {
 			}
 		}
 	} else {
+		if err := o.preflightCnpgTarget(ctx); err != nil {
+			return err
+		}
 		if err := o.flipToCnpg(ctx); err != nil {
 			return err
 		}
@@ -670,6 +674,20 @@ func (o *opRun) run(ctx context.Context, fenced <-chan struct{}) error {
 	}
 
 	return o.finalize(ctx)
+}
+
+func (o *opRun) preflightCnpgTarget(ctx context.Context) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	target, err := o.r.duckling.CnpgProvisionerEndpoint(probeCtx, o.op.ToShard)
+	if err != nil {
+		return fmt.Errorf("destination shard %s preflight credential: %w", o.op.ToShard, err)
+	}
+	if err := o.r.copier.Probe(probeCtx, target); err != nil {
+		return fmt.Errorf("destination shard %s stopped accepting PostgreSQL connections before cutover: %w", o.op.ToShard, err)
+	}
+	o.logf("info", "destination shard %s passed the immediate pre-cutover PostgreSQL probe", o.op.ToShard)
+	return nil
 }
 
 // resumeTakeover continues only phases whose durable inputs are sufficient to

--- a/controlplane/provisioner/reshard_runner.go
+++ b/controlplane/provisioner/reshard_runner.go
@@ -153,10 +153,10 @@ type reshardDucklingClient interface {
 // post-block propagation wait is honest.
 //
 // Env-only knob DUCKGRES_RESHARD_FLIP_TIMEOUT (Go duration) overrides the
-// DEFAULT cutover wait (15m) — how long a flip waits for the composition to
-// converge before rolling back. Individual operations override it per-op via
-// cutover_timeout_seconds (what the e2e's bogus-shard rollback uses to stay
-// fast without shortening real cutovers).
+// DEFAULT controller-convergence and cutover wait (15m). Individual operations
+// may shorten only the target cutover convergence wait via
+// cutover_timeout_seconds; source fencing, cleanup, and recovery always retain
+// the full default budget.
 // backuper is the pre-flip catalog backuper (nil-safe: a nil backuper skips the
 // best-effort backup on non-destructive directions and HARD-fails the
 // destructive cnpg→external direction, which must never flip without a backup).
@@ -406,12 +406,20 @@ func (o *opRun) flipTimeout() time.Duration {
 	return o.r.flipTimeout
 }
 
+// sourceMaintenanceTimeout is deliberately independent of a per-operation
+// cutover override. Preparing, fencing, disabling, retaining, and cleaning up
+// source resources are safety-critical controller/database transitions; they
+// retain the runner's full convergence budget.
+func (o *opRun) sourceMaintenanceTimeout() time.Duration {
+	return o.r.flipTimeout
+}
+
 // sourceRecoveryTimeout is deliberately independent of a per-operation
 // cutover override. Operators may shorten an expected-to-fail target wait, but
 // restoring provider-sql resources on the known-good source can require the
 // full controller convergence budget and must not inherit that shorter bound.
 func (o *opRun) sourceRecoveryTimeout() time.Duration {
-	return o.r.flipTimeout
+	return o.sourceMaintenanceTimeout()
 }
 
 func (o *opRun) step(step string) error {
@@ -831,7 +839,8 @@ func (o *opRun) prepareSourceAccess(ctx context.Context) error {
 }
 
 func (o *opRun) waitForMaintenance(ctx context.Context, wantFenced bool) (*DucklingStatus, error) {
-	deadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceMaintenanceTimeout()
+	deadline := time.Now().Add(timeout)
 	var last string
 	for time.Now().Before(deadline) {
 		if err := ctx.Err(); err != nil {
@@ -856,7 +865,7 @@ func (o *opRun) waitForMaintenance(ctx context.Context, wantFenced bool) (*Duckl
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("reshard maintenance did not reach fenced=%t within %s; last observation: %s", wantFenced, o.flipTimeout(), last)
+	return nil, fmt.Errorf("reshard maintenance did not reach fenced=%t within %s; last observation: %s", wantFenced, timeout, last)
 }
 
 func (o *opRun) waitForSourceMaintenanceUnfenced(ctx context.Context) error {
@@ -894,7 +903,8 @@ func (o *opRun) waitForSourceMaintenanceUnfenced(ctx context.Context) error {
 }
 
 func (o *opRun) waitForMaintenanceEnabled(ctx context.Context) (*DucklingStatus, error) {
-	deadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceMaintenanceTimeout()
+	deadline := time.Now().Add(timeout)
 	var last string
 	for time.Now().Before(deadline) {
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
@@ -914,11 +924,12 @@ func (o *opRun) waitForMaintenanceEnabled(ctx context.Context) (*DucklingStatus,
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("maintenance LOGIN was not observed within %s; last observation: %s", o.flipTimeout(), last)
+	return nil, fmt.Errorf("maintenance LOGIN was not observed within %s; last observation: %s", timeout, last)
 }
 
 func (o *opRun) waitForMaintenanceDisabled(ctx context.Context) error {
-	deadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceMaintenanceTimeout()
+	deadline := time.Now().Add(timeout)
 	var last string
 	for time.Now().Before(deadline) {
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
@@ -936,7 +947,7 @@ func (o *opRun) waitForMaintenanceDisabled(ctx context.Context) error {
 			return err
 		}
 	}
-	return fmt.Errorf("maintenance identity was not disabled within %s; last observation: %s", o.flipTimeout(), last)
+	return fmt.Errorf("maintenance identity was not disabled within %s; last observation: %s", timeout, last)
 }
 
 func (o *opRun) cleanupMaintenance(ctx context.Context) error {
@@ -950,7 +961,8 @@ func (o *opRun) cleanupMaintenance(ctx context.Context) error {
 	if err := o.r.duckling.SetReshardMaintenanceCleanup(ctx, o.op.DucklingName, o.op.ID); err != nil {
 		return err
 	}
-	roleDeadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceMaintenanceTimeout()
+	roleDeadline := time.Now().Add(timeout)
 	for time.Now().Before(roleDeadline) {
 		removed, err := o.r.duckling.ReshardMaintenanceRoleRemoved(ctx, o.op.DucklingName)
 		if err != nil {
@@ -968,12 +980,12 @@ func (o *opRun) cleanupMaintenance(ctx context.Context) error {
 		return err
 	}
 	if !removed {
-		return fmt.Errorf("operation-scoped maintenance role was not removed within %s", o.flipTimeout())
+		return fmt.Errorf("operation-scoped maintenance role was not removed within %s", timeout)
 	}
 	if err := o.r.duckling.SetReshardMaintenance(ctx, o.op.DucklingName, nil); err != nil {
 		return err
 	}
-	deadline := time.Now().Add(o.flipTimeout())
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)
 		statusGone := err == nil && st.ReshardMaintenance.OperationID != o.op.ID
@@ -992,7 +1004,7 @@ func (o *opRun) cleanupMaintenance(ctx context.Context) error {
 			return err
 		}
 	}
-	return fmt.Errorf("operation-scoped maintenance identity was not removed within %s", o.flipTimeout())
+	return fmt.Errorf("operation-scoped maintenance identity was not removed within %s", timeout)
 }
 
 // disableMaintenance closes the privileged-login cleanup race. The fencer
@@ -1036,7 +1048,7 @@ func (o *opRun) disableMaintenance(ctx context.Context, beforeDisable func() err
 		Host: host, Port: 5432, User: m.User, Password: m.Password,
 		Database: "postgres", SSLMode: sslModeFor(o.op.SourceKind),
 	}
-	disableCtx, cancel := context.WithTimeout(ctx, o.flipTimeout())
+	disableCtx, cancel := context.WithTimeout(ctx, o.sourceMaintenanceTimeout())
 	defer cancel()
 	if err := o.r.fencer.DisableMaintenanceAndTerminate(disableCtx, admin, func() error {
 		if beforeDisable != nil {
@@ -1103,7 +1115,7 @@ func (o *opRun) fenceSource(ctx context.Context) error {
 		Host: ms.Endpoint, Port: 5432, User: m.User, Password: m.Password,
 		Database: ms.Database, SSLMode: sslModeFor(o.op.SourceKind),
 	}
-	fenceCtx, cancel := context.WithTimeout(ctx, o.flipTimeout())
+	fenceCtx, cancel := context.WithTimeout(ctx, o.sourceMaintenanceTimeout())
 	defer cancel()
 	if err := o.r.fencer.TerminateAndWait(fenceCtx, maintenance, o.tenantUser, o.tenantDatabase); err != nil {
 		return err
@@ -1546,8 +1558,9 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 	// Wait until the cnpg Role+Database MRs reflect the no-Delete policy, so the
 	// type flip orphans (not deletes) them. Closes the race where the flip
 	// un-renders the MRs before the retain policy propagated.
-	o.logf("info", "retainCnpgOnFlip=true confirmed on the duckling spec (the XRD carries the field); waiting up to %s for the composition to re-render the cnpg Role/Database MRs without Delete", o.flipTimeout())
-	deadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceMaintenanceTimeout()
+	o.logf("info", "retainCnpgOnFlip=true confirmed on the duckling spec (the XRD carries the field); waiting up to %s for the composition to re-render the cnpg Role/Database MRs without Delete", timeout)
+	deadline := time.Now().Add(timeout)
 	lastLog := time.Time{}
 	lastObserved := "no successful read yet"
 	for {
@@ -1558,7 +1571,7 @@ func (o *opRun) orphanCnpgSource(ctx context.Context) error {
 			return errReshardCancelled
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("cnpg source role/DB did not reflect the retain (no-Delete) policy within %s — refusing to flip (the composition may not honor retainCnpgOnFlip; charts/composition skew?); last observation: %s", o.flipTimeout(), lastObserved)
+			return fmt.Errorf("cnpg source role/DB did not reflect the retain (no-Delete) policy within %s — refusing to flip (the composition may not honor retainCnpgOnFlip; charts/composition skew?); last observation: %s", timeout, lastObserved)
 		}
 		orphaned, mrsPresent, detail, err := o.r.duckling.CnpgSourceMRsOrphaned(ctx, o.op.DucklingName)
 		switch {
@@ -2100,14 +2113,15 @@ func (o *opRun) recoverFromExternal(ctx context.Context) bool {
 	// deadline rather than bail: a charts/composition fix can converge the
 	// password mid-wait, and giving up early would leave the org worse off.
 	sourcePrefix := o.op.FromShard + "-pooler."
-	o.logf("info", "recovery: waiting up to %s for the composition to re-adopt the cnpg role/DB on %s* and for the tenant role to answer", o.flipTimeout(), sourcePrefix)
-	deadline := time.Now().Add(o.flipTimeout())
+	timeout := o.sourceRecoveryTimeout()
+	o.logf("info", "recovery: waiting up to %s for the composition to re-adopt the cnpg role/DB on %s* and for the tenant role to answer", timeout, sourcePrefix)
+	deadline := time.Now().Add(timeout)
 	lastLog := time.Time{}
 	lastObserved := "no successful duckling read yet"
 	preparedRequested := false
 	for {
 		if time.Now().After(deadline) {
-			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", o.flipTimeout(), o.op.FromShard, lastObserved)
+			o.logf("error", "recovery: source shard did not become ready within %s — org stays blocked; investigate (the orphaned role/DB should still exist on %s); last observation: %s", timeout, o.op.FromShard, lastObserved)
 			return false
 		}
 		st, err := o.r.duckling.Get(ctx, o.op.DucklingName)

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -301,11 +301,23 @@ type fakeDuckling struct {
 	mrsReadErr error
 	// mrsStuckWithDelete models a composition that never honors the retain
 	// flag: the MRs stay at full lifecycle ["*"] no matter what.
-	mrsStuckWithDelete bool
-	maintenancePhase   string
-	maintenanceShard   string
-	cleanupRemaining   int
-	cleanupChecks      int
+	mrsStuckWithDelete  bool
+	maintenancePhase    string
+	maintenanceShard    string
+	cleanupRemaining    int
+	cleanupChecks       int
+	provisionerEndpoint CatalogEndpoint
+	provisionerErr      error
+}
+
+func (f *fakeDuckling) CnpgProvisionerEndpoint(context.Context, string) (CatalogEndpoint, error) {
+	if f.provisionerErr != nil {
+		return CatalogEndpoint{}, f.provisionerErr
+	}
+	if f.provisionerEndpoint.Host != "" {
+		return f.provisionerEndpoint, nil
+	}
+	return CatalogEndpoint{Host: "target-rw", Port: 5432, User: "tenant_provisioner", Database: "postgres", Password: "pw", SSLMode: "require"}, nil
 }
 
 func (f *fakeDuckling) Get(context.Context, string) (*DucklingStatus, error) {
@@ -520,6 +532,31 @@ type blockingCopier struct {
 	started  chan struct{}
 	released chan struct{}
 	canceled chan struct{}
+}
+
+func TestCnpgDestinationIsReprobedImmediatelyBeforeCutover(t *testing.T) {
+	op := cnpgOp()
+	duckling := &fakeDuckling{status: cnpgSourceStatus()}
+	copier := &fakeCopier{probeFn: func(ep CatalogEndpoint) error {
+		if ep.Host == "target-rw" {
+			return errors.New("primary unavailable")
+		}
+		return nil
+	}}
+	run := &opRun{
+		r:  &ReshardRunner{duckling: duckling, copier: copier},
+		op: op,
+	}
+
+	err := run.preflightCnpgTarget(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "stopped accepting PostgreSQL connections before cutover") {
+		t.Fatalf("preflight error = %v", err)
+	}
+	for _, kind := range duckling.callKinds() {
+		if kind == "cnpg" {
+			t.Fatal("Duckling was repointed despite failed immediate destination probe")
+		}
+	}
 }
 
 func newBlockingCopier() *blockingCopier {
@@ -749,9 +786,9 @@ func TestReshardHappyPathCnpgToCnpg(t *testing.T) {
 	}
 	// flip → copy → recheck → drop source, in that order.
 	kinds := copier.kinds()
-	// probe(target, flip wait) → probe(source) → probe(target) → copy →
-	// stability recheck → source drop.
-	if fmt.Sprint(kinds) != fmt.Sprint([]string{"probe", "probe", "probe", "copy", "dropdb"}) {
+	// provisioner preflight → probe(target, flip wait) → probe(source) →
+	// probe(target) → copy → stability recheck → source drop.
+	if fmt.Sprint(kinds) != fmt.Sprint([]string{"probe", "probe", "probe", "probe", "copy", "dropdb"}) {
 		t.Fatalf("copier calls = %v", kinds)
 	}
 	// The copy's SOURCE is the recorded pre-flip endpoint, not the new one.

--- a/controlplane/provisioner/reshard_runner_test.go
+++ b/controlplane/provisioner/reshard_runner_test.go
@@ -1476,6 +1476,44 @@ func TestSourceRecoveryTimeoutIgnoresShortCutoverOverride(t *testing.T) {
 	}
 }
 
+func TestSourceMaintenanceTimeoutIgnoresShortCutoverOverride(t *testing.T) {
+	runner := &ReshardRunner{flipTimeout: 15 * time.Minute}
+	run := &opRun{
+		r: runner,
+		op: &configstore.ReshardOperation{
+			CutoverTimeoutSeconds: 1,
+		},
+	}
+	if got, want := run.sourceMaintenanceTimeout(), 15*time.Minute; got != want {
+		t.Fatalf("source maintenance timeout = %s, want %s", got, want)
+	}
+	if got, want := run.flipTimeout(), time.Second; got != want {
+		t.Fatalf("target cutover timeout = %s, want %s", got, want)
+	}
+}
+
+func TestMaintenanceWaitUsesFullSourceBudgetInsteadOfCutoverOverride(t *testing.T) {
+	op := &configstore.ReshardOperation{
+		ID:                    1,
+		DucklingName:          "org-a",
+		CutoverTimeoutSeconds: 1,
+	}
+	runner := &ReshardRunner{
+		duckling:    &fakeDuckling{status: cnpgSourceStatus()},
+		store:       newFakeReshardStore(op),
+		flipTimeout: 25 * time.Millisecond,
+		loopPoll:    time.Millisecond,
+	}
+	run := &opRun{r: runner, op: op}
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	_, err := run.waitForMaintenance(ctx, false)
+	if err == nil || !strings.Contains(err.Error(), "within 25ms") {
+		t.Fatalf("maintenance wait error = %v, want full source timeout", err)
+	}
+}
+
 func TestReshardCrashAfterSourceDropRollsForwardInsteadOfRepointingEmptySource(t *testing.T) {
 	store := newFakeReshardStore(cnpgOp())
 	duckling := &fakeDuckling{status: cnpgSourceStatus()}

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -632,17 +632,15 @@ charts side (composition + `retainCnpgOnFlip` XRD field) is tested by
 managementPolicies variants render; the XRD field defaults false). e2e
 (`tests/mw-dev/e2e/harness.sh`): validation 400s (incl. a non-allowlisted
 external secret name), cancel-during-drain (drain-not-kill + 57P03 visible),
-bogus-shard rollback (real flip → Synced=False → rollback, data intact), the
-**ext→cnpg positive path** (real catalog move off the harness RDS onto
-shard-001) — which, since reshards execute in dedicated pods, also asserts the
-op is created `pending`, the `duckgres-reshard-op-<id>` pod appears with the
-right labels while the op runs, and the leader reconciler reaps it after the
-op finishes — and which also asserts the pre-flip backup completed and recorded a
-`backup_s3_uri` under `_reshard_catalog_backups/` (the Job has no aws CLI, so it
-asserts the recorded URI + restore command in the op log, not an S3 list — same
-limitation as the tenant-isolation object-store half), and the LOAD-BEARING
-`lifecycle_teardown_cnpg` (a normal cnpg tenant deprovision still fully deletes
-the Duckling CR + its cnpg role/DB — the deprovision-unaffected regression net
-for `retainCnpgOnFlip`). cnpg→cnpg positive path needs a second mw-dev shard
-(follow-up infra); the cnpg→ext positive path is unit-test-only (the harness has
-no RDS password — the start API requires it ephemerally).
+a credentialed destination preflight against healthy shard-002, and a forced
+one-second target-convergence timeout (real flip → rollback to shard-001, data
+intact). The short per-op timeout applies only to the target wait; source
+fencing and rollback retain the full controller-convergence budget. Since
+reshards execute in dedicated pods, the lane also asserts the operation is
+created `pending`, the `duckgres-reshard-op-<id>` pod appears with the right
+labels while the operation runs, and the leader reconciler reaps it afterwards.
+The full lane retains the LOAD-BEARING `lifecycle_teardown_cnpg` assertion: a
+normal cnpg tenant deprovision still fully deletes the Duckling CR and its cnpg
+role/DB (the deprovision-unaffected regression net for
+`retainCnpgOnFlip`). External-store positive paths remain unit-test-only
+because the live harness deliberately provisions CNPG metadata stores only.

--- a/docs/design/resharding.md
+++ b/docs/design/resharding.md
@@ -91,6 +91,20 @@ The runner re-checks at `recordSource` (pre-flip, defense in depth for ops
 created by older CPs or hand-inserted rows): a status type that contradicts
 the op's recorded `source_kind` fails the op before anything is flipped.
 
+## Destination connectivity preflight
+
+Before accepting a cnpg-shard target, the start handler reads that shard's
+resource-name-scoped `cnpg-<shard>-provisioner` Secret and runs `SELECT 1`
+against the shard primary (`-rw`), using the provisioner login and `postgres`
+database. A Ready Pooler or open TCP port is not sufficient: PgBouncer can be
+healthy while the CNPG cluster has no PostgreSQL instances. An unavailable
+guard fails closed with 503; an unreadable Secret, authentication failure,
+timeout, or query failure also returns retryable 503 with the stable
+`destination_shard_unavailable` code, before an operation or runner pod exists.
+The runner repeats the same credentialed probe immediately before cutover to
+close the admission-to-cutover race. External targets retain their equivalent
+credentialed preflight.
+
 This guards against a real prod incident: an org whose config-store metadata
 block was EMPTY (previously silently defaulted to cnpg-shard) and whose
 duckling *spec* type had drifted from its *status* (the org actually lived on

--- a/docs/runbooks/resharding.md
+++ b/docs/runbooks/resharding.md
@@ -12,6 +12,15 @@ Runner pod resources default to `2` CPU and `8Gi` memory. Override them with
 quantities fail the pod spawn with an operator-visible error; they never panic
 the control plane.
 
+## Destination preflight rejection
+
+A cnpg-shard reshard is rejected before operation creation unless the control
+plane can read the destination's provisioner Secret and execute `SELECT 1`
+against its primary service. Check the CNPG Cluster `Ready` condition, database
+instance pods, PVCs, and init-job scheduling events. Pooler readiness alone
+does not establish shard health. Fix the shard and retry; there is no reshard
+operation to recover or cancel after a preflight rejection.
+
 ## Consuming the resharding signal
 
 The runner's first mutation is the advisory-locked warehouse

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2968,22 +2968,22 @@ duckling_shard_backfill() { # cnpgOrg
 
 # ---- reshard operations (metadata-store migrations) -------------------------
 # Backed by controlplane/admin/reshard.go + provisioner/reshard_runner.go +
-# configstore/reshard.go. mw-dev has ONE cnpg shard, so the shard→shard
-# positive path can't run here; these exercise what matters against the real
-# cluster instead:
+# configstore/reshard.go. The dedicated lane uses shard-001 as the source and
+# the healthy shard-002 provisioner endpoint as its destination:
 #   * validation 400s (same shard, bad targets)
 #   * cancel during drain (a held session keeps the drain waiting; new
 #     connections are 57P03-blocked; cancel rolls back; org healthy)
-#   * bogus-shard rollback (flip → Synced=False → flip-timeout → rollback;
-#     data intact, spec.cnpgShard patched back; short per-op
-#     cutover_timeout_seconds keeps it fast). Also asserts the wait-loop
+#   * forced target-convergence timeout (flip → timeout → rollback; data
+#     intact, spec.cnpgShard patched back; short per-op cutover_timeout_seconds
+#     keeps it fast without shortening source fencing/recovery). Also asserts
+#     the wait-loop
 #     diagnostics: deadline announce, periodic "waiting for target"
 #     observations, and the flip-timeout error carrying the last observation.
 # External-store migrations are covered by the focused admin/provisioner unit
 # tests. This live harness intentionally provisions CNPG metadata stores only.
 
 reshard_post() { # org body
-  curl -fsS -X POST -H "$H" -H 'Content-Type: application/json' -d "$2" \
+  curl --fail-with-body -sS -X POST -H "$H" -H 'Content-Type: application/json' -d "$2" \
     "$API/api/v1/orgs/$1/reshard"
 }
 
@@ -3117,7 +3117,7 @@ reshard_cancel_during_drain() { # org password
   holder=$!
   sleep 5
 
-  out="$(reshard_post "$org" '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-009"},"drain_timeout_seconds":600}')" \
+  out="$(reshard_post "$org" '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"},"drain_timeout_seconds":600}')" \
     || fail "reshard cancel: start failed: $out"
   opid="$(echo "$out" | jq -r .id)"
   [ -n "$opid" ] && [ "$opid" != "null" ] || fail "reshard cancel: no op id: $out"
@@ -3169,19 +3169,21 @@ reshard_cancel_during_drain() { # org password
   log "reshard cancel OK (op $opid)"
 }
 
-reshard_bogus_shard_rollback() { # org password
+reshard_forced_cutover_rollback() { # org password
   org="$1"; pw="$2"; d="$(echo "$org" | tr 'A-Z' 'a-z')"
-  log "reshard rollback: bogus target shard → flip-timeout → rollback, data intact"
+  log "reshard rollback: reachable target → forced flip-timeout → rollback, data intact"
   pg "$org" "$pw" ducklake "DROP TABLE IF EXISTS reshard_marker; CREATE TABLE reshard_marker AS SELECT 42 AS v;"
 
-  # Short per-op cutover timeout: the bogus shard can never converge, so the
-  # flip wait is pure dead time before the rollback we're here to assert.
-  out="$(reshard_post "$org" '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-099"},"drain_timeout_seconds":300,"cutover_timeout_seconds":90}')" \
+  # The target must pass the new credentialed destination preflight. A
+  # one-second cutover budget is deliberately shorter than Crossplane's
+  # reconciliation loop, forcing the same pre-commit rollback path without
+  # relying on a nonexistent/unreachable shard.
+  out="$(reshard_post "$org" '{"target":{"type":"cnpg-shard","cnpg_shard":"shard-002"},"drain_timeout_seconds":300,"cutover_timeout_seconds":1}')" \
     || fail "reshard rollback: start failed: $out"
   opid="$(echo "$out" | jq -r .id)"
 
   # Budget: runner-pod schedule/pull + drain + snapshot-propagation waits +
-  # the 90s per-op cutover timeout + rollback convergence.
+  # the forced per-op cutover timeout + rollback convergence.
   st="$(reshard_wait_terminal "$opid" 900)"
   [ "$st" = "failed" ] || { reshard_dump_log "$opid"; fail "reshard rollback: final state $st, want failed"; }
   reshard_log_has "$opid" "rolling back" || fail "reshard rollback: no rollback log"
@@ -3787,8 +3789,8 @@ main() {
     reshard_targets
     reshard_validation "$CNPG"
     reshard_cancel_during_drain "$RES2" "$res2_pw"
-    reshard_bogus_shard_rollback "$RES2" "$res2_pw"
-    log "PASS: reshard(targets-discovery + validation + cancel-during-drain + bogus-shard-rollback)"
+    reshard_forced_cutover_rollback "$RES2" "$res2_pw"
+    log "PASS: reshard(targets-discovery + validation + cancel-during-drain + forced-cutover-rollback)"
     return
   fi
 

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -188,6 +188,38 @@ roleRef:
 # the grant must live on duckgres-duckling-reader (see charts repo,
 # charts/duckgres/templates/rbac.yaml) and be deployed to the cluster.
 ---
+# Destination preflight uses the same two configured dev-shard provisioner
+# Secrets as the production chart. Keep this disposable grant by-name and
+# read-only; its ci-pr label lets teardown remove the cross-namespace objects.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: duckgres-ci-pr-${PR_NUMBER}-cnpg-provisioner-secret-reader
+  namespace: ducklings
+  labels:
+    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - cnpg-shard-001-provisioner
+      - cnpg-shard-002-provisioner
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: duckgres-ci-pr-${PR_NUMBER}-cnpg-provisioner-secret-reader
+  namespace: ducklings
+  labels:
+    duckgres.posthog.com/ci-pr: "${PR_NUMBER}"
+subjects:
+  - { kind: ServiceAccount, name: duckgres, namespace: ${NAMESPACE} }
+roleRef:
+  kind: Role
+  name: duckgres-ci-pr-${PR_NUMBER}-cnpg-provisioner-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -244,6 +244,8 @@ wait_ci_ducklings_deleted() { # pr-number timeout
 delete_ci_bindings() { # pr-number
   local pr="$1"
   "${KUBECTL[@]}" delete clusterrolebinding -l "duckgres.posthog.com/ci-pr=${pr}" --ignore-not-found
+  "${KUBECTL[@]}" -n ducklings delete role,rolebinding \
+    -l "duckgres.posthog.com/ci-pr=${pr}" --ignore-not-found
 }
 
 reset_pr_stack() {

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -13,6 +13,17 @@ import (
 	kjsonpath "k8s.io/client-go/util/jsonpath"
 )
 
+func stringSlice(value any) []string {
+	items, _ := value.([]any)
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
 func TestDeployFailsWhenSamePRDucklingsDoNotDelete(t *testing.T) {
 	fakes := newRunSHFakes(t)
 
@@ -913,6 +924,100 @@ func TestControlPlaneServiceExposesFlight(t *testing.T) {
 	}
 
 	t.Fatal("duckgres-control-plane Service missing from manifests template")
+}
+
+func TestReshardLaneCanReadOnlyConfiguredShardProvisionerSecrets(t *testing.T) {
+	raw, err := os.ReadFile("manifests.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read manifests template: %v", err)
+	}
+	rendered := strings.NewReplacer(
+		"${NAMESPACE}", "test-namespace",
+		"${PR_NUMBER}", "123",
+		"${CONTROLPLANE_IMAGE}", "example.invalid/duckgres:test",
+		"${WORKER_IMAGE}", "example.invalid/duckgres:test",
+		"${INTERNAL_SECRET}", "test-secret",
+		"${INTERNAL_SECRET_FALLBACK}", "test-secret-fallback",
+		"${USER_SECRET_KEY}", "test-user-secret-key",
+	).Replace(string(raw))
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(rendered), 4096)
+	var role, binding map[string]any
+	for {
+		var manifest map[string]any
+		err := decoder.Decode(&manifest)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode manifests template: %v", err)
+		}
+		switch {
+		case manifest["kind"] == "Role" && manifestName(manifest) == "duckgres-ci-pr-123-cnpg-provisioner-secret-reader":
+			role = manifest
+		case manifest["kind"] == "RoleBinding" && manifestName(manifest) == "duckgres-ci-pr-123-cnpg-provisioner-secret-reader":
+			binding = manifest
+		}
+	}
+	if role == nil || binding == nil {
+		t.Fatalf("scoped provisioner Role/RoleBinding missing: role=%t binding=%t", role != nil, binding != nil)
+	}
+	metadata := role["metadata"].(map[string]any)
+	if metadata["namespace"] != "ducklings" {
+		t.Fatalf("Role namespace = %v, want ducklings", metadata["namespace"])
+	}
+	labels := metadata["labels"].(map[string]any)
+	if labels["duckgres.posthog.com/ci-pr"] != "123" {
+		t.Fatalf("Role cleanup label = %v, want PR number", labels)
+	}
+	rules := role["rules"].([]any)
+	if len(rules) != 1 {
+		t.Fatalf("Role rules = %v, want exactly one", rules)
+	}
+	rule := rules[0].(map[string]any)
+	if got := strings.Join(stringSlice(rule["apiGroups"]), ","); got != "" {
+		t.Fatalf("apiGroups = %q, want core API group", got)
+	}
+	if got := strings.Join(stringSlice(rule["resources"]), ","); got != "secrets" {
+		t.Fatalf("resources = %q, want secrets", got)
+	}
+	if got := strings.Join(stringSlice(rule["verbs"]), ","); got != "get" {
+		t.Fatalf("verbs = %q, want get", got)
+	}
+	if got := strings.Join(stringSlice(rule["resourceNames"]), ","); got != "cnpg-shard-001-provisioner,cnpg-shard-002-provisioner" {
+		t.Fatalf("resourceNames = %q", got)
+	}
+	bindingMetadata := binding["metadata"].(map[string]any)
+	if bindingMetadata["namespace"] != "ducklings" {
+		t.Fatalf("RoleBinding namespace = %v, want ducklings", bindingMetadata["namespace"])
+	}
+	subjects := binding["subjects"].([]any)
+	if len(subjects) != 1 {
+		t.Fatalf("RoleBinding subjects = %v, want exactly one", subjects)
+	}
+	subject := subjects[0].(map[string]any)
+	if subject["kind"] != "ServiceAccount" || subject["name"] != "duckgres" || subject["namespace"] != "test-namespace" {
+		t.Fatalf("RoleBinding subject = %v, want disposable lane ServiceAccount", subject)
+	}
+	roleRef := binding["roleRef"].(map[string]any)
+	if roleRef["kind"] != "Role" || roleRef["name"] != "duckgres-ci-pr-123-cnpg-provisioner-secret-reader" {
+		t.Fatalf("RoleBinding roleRef = %v, want scoped Role", roleRef)
+	}
+}
+
+func TestReshardE2EUsesReachableDestinationAndForcesRollbackAfterPreflight(t *testing.T) {
+	raw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read harness: %v", err)
+	}
+	script := string(raw)
+	if strings.Contains(script, `"cnpg_shard":"shard-009"`) || strings.Contains(script, `"cnpg_shard":"shard-099"`) {
+		t.Fatal("reshard e2e still relies on an unreachable destination rejected by preflight")
+	}
+	if !strings.Contains(script, `"cnpg_shard":"shard-002"`) ||
+		!strings.Contains(script, `"cutover_timeout_seconds":1`) {
+		t.Fatal("reshard rollback e2e must use reachable shard-002 with a forced one-second cutover timeout")
+	}
 }
 
 func TestControlPlaneWorkerDefaultsAreConfigurable(t *testing.T) {


### PR DESCRIPTION
## Summary
- fail reshard submission closed unless the destination CNPG primary accepts an authenticated SQL query
- repeat the provisioner-credential probe immediately before cutover to close the drain-time race
- return retryable, machine-readable API errors without exposing credentials
- document preflight rejection and recovery checks

## Validation
- focused Kubernetes guardrail tests pass
- full reshard admin test suite passes
- full provisioner package tests pass
- `just lint` passes

Companion charts RBAC is required before deployment.