### PR TITLE
feat(controlplane): expose metadata Postgres proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ PG Client → TLS/Auth/PG Protocol → Control Plane pod
 
 The Kubernetes control plane can expose explicitly opted-in CNPG-backed
 warehouse metadata databases on a separate SNI suffix
-(`DUCKGRES_METADATA_HOSTNAME_SUFFIXES`, for example
-`.md.us.postwh.com`). This is an early connection branch, not a DuckDB
+(`DUCKGRES_METADATA_HOSTNAME_SUFFIXES`; managed-warehouse deployments use
+`.md.dev.postwh.com`, `.md.us.postwh.com`, or `.md.eu.postwh.com`). This is an
+early connection branch, not a DuckDB
 executor: the existing org `root` password authenticates at Duckgres, the
 startup database MUST be exactly `metadata`, and the control plane resolves
 the real endpoint/database/tenant role/password internally through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,68 @@ PG Client → TLS/Auth/PG Protocol → Control Plane pod
                                  → Flight SQL (TCP+TLS) → per-org Worker pod (DuckDB)
 ```
 
+### Native metadata Postgres proxy
+
+The Kubernetes control plane can expose explicitly opted-in CNPG-backed
+warehouse metadata databases on a separate SNI suffix
+(`DUCKGRES_METADATA_HOSTNAME_SUFFIXES`, for example
+`.md.us.postwh.com`). This is an early connection branch, not a DuckDB
+executor: the existing org `root` password authenticates at Duckgres, the
+startup database MUST be exactly `metadata`, and the control plane resolves
+the real endpoint/database/tenant role/password internally through
+`SharedWorkerActivator.MetadataPostgresURL`. After authenticating upstream
+with that internal credential, protocol traffic is relayed byte-for-byte. The
+endpoint and password remain internal; the upstream role and database can be
+visible to the fully privileged client through normal PostgreSQL introspection
+such as `current_user` and `current_database()`.
+
+Access is fail-closed on the warehouse row's `metadata_proxy_enabled` flag,
+`state=ready`, and `metadata_store_kind=cnpg-shard`. Never infer publication
+from shard placement and never pass a client-supplied upstream database,
+username, host, or password. `DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG`
+(default 20 per control-plane replica) bounds public sessions so they cannot
+exhaust the internal PgBouncer pool. These sessions participate in the
+existing per-user kill / disable fan-out, and an established session is closed
+if the warehouse gate stops being eligible. An admin warehouse PUT that
+explicitly includes `metadata_proxy_enabled` reloads the local config snapshot
+and notifies peer replicas; established sessions observe the new gate on their
+next five-second recheck after snapshot propagation.
+
+The initial scope is dedicated, single-customer CNPG shards only. Do not enable
+an org on a shared shard until upstream `CONNECT` ACLs and role hardening are in
+place. The exact virtual database check prevents selecting a different startup
+database, but after connection the customer `root` credential has the full
+access of the internally resolved metadata role.
+
+Observability stays explicit at the branch boundary:
+`duckgres_connections_open` includes these client sockets because it is the
+process-wide accepted-connection gauge, while
+`duckgres_metadata_proxy_connections_open`,
+`duckgres_metadata_proxy_connection_attempts_total`,
+`duckgres_metadata_proxy_connection_duration_seconds`,
+`duckgres_metadata_proxy_upstream_connect_duration_seconds`, and
+`duckgres_metadata_proxy_bytes_total` isolate proxy load and failures. The
+relay is intentionally opaque, so DuckDB query metrics, query logs, and query
+traces do not include SQL executed through it. Use the CNPG/PgBouncer metrics
+and the fixed upstream `application_name=duckgres-metadata-proxy` for
+database-side attribution; never make one org's metadata target part of the
+control-plane health check. Target resolution plus upstream
+connect/auth/synchronization has a fixed 10-second bootstrap deadline; the
+deadline is canceled after hijack and never applies to established relay
+traffic. `duckgres_auth_failures_total` includes wrong-password proxy attempts;
+the dedicated attempt counter with `outcome="auth_failed"` is the proxy split.
+Pre-TLS `duckgres_rate_limit_rejects_total` events cannot be assigned to either
+endpoint because SNI has not yet been observed.
+
+Metadata-proxy `CancelRequest` handling is session-terminating. Synthetic
+backend keys map to the exact established frontend/upstream connection pair on
+the owning control-plane replica, which closes both rather than redialing a
+PgBouncer Service where instance-local cancel keys could reach the wrong pod.
+Raw cancel connections remain control-plane-local behind the NLB, matching the
+existing cancellation locality: a synthetic-key miss on another replica is
+absorbed and counted by
+`duckgres_metadata_proxy_cancel_requests_total{outcome="not_local"}`.
+
 In topologies 2 and 3, the control plane also exposes an Arrow Flight SQL ingress (`--flight-port`) for clients that prefer Flight over the PG wire protocol.
 
 ### Key Components

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Run with config file:
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_SNI_ROUTING_MODE` | Multi-tenant managed-hostname routing: `off`, `passthrough`, or `enforce`. Postgres uses the requested dbname first; managed SNI must resolve to the same org, and SNI supplies the database only when dbname is empty. | `off` |
 | `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES` | Comma-separated managed hostname suffixes such as `.dw.us.postwh.com` | - |
-| `DUCKGRES_METADATA_HOSTNAME_SUFFIXES` | Comma-separated SNI suffixes for the explicitly enabled native metadata Postgres proxy, such as `.md.us.postwh.com` | - |
+| `DUCKGRES_METADATA_HOSTNAME_SUFFIXES` | Comma-separated SNI suffixes for the explicitly enabled native metadata Postgres proxy, such as `.md.dev.postwh.com`, `.md.us.postwh.com`, or `.md.eu.postwh.com` | - |
 | `DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG` | Maximum admitted metadata proxy sessions per org on each control-plane replica | `20` |
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` | Attach a Delta Lake catalog/table during worker boot/activation | `false` |
@@ -906,8 +906,11 @@ existing Duckgres password and must send the exact non-empty
 database, and PgBouncer endpoint internally. The endpoint and password are
 never sent to the client; the upstream role and database may be visible
 through normal PostgreSQL introspection such as `current_user` and
-`current_database()`. The per-org connection limit is enforced independently
-on every control-plane replica. Internal target resolution and
+`current_database()`. Managed-warehouse deployments configure their own
+environment suffix (`.md.dev.postwh.com`, `.md.us.postwh.com`, or
+`.md.eu.postwh.com`); suffixes are never inferred from the ordinary Duckgres
+hostname. The per-org connection limit is enforced independently on every
+control-plane replica. Internal target resolution and
 connect/auth/synchronization have a fixed 10-second bootstrap deadline; the
 deadline does not apply after the relay is established. An admin/UI update that
 includes `metadata_proxy_enabled` reloads the local config snapshot and

--- a/README.md
+++ b/README.md
@@ -68,12 +68,18 @@ labels, aggregation rules, PromQL examples, and admission metric migration.
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `duckgres_connections_open` | Gauge | Number of currently open client connections |
-| `duckgres_connection_duration_seconds{org}` | Histogram | Client connection lifetime, accept→disconnect (includes `_count`, `_sum`, `_bucket`); `_sum` is exact total connection-seconds (per org) with no scrape-integral bias. The disconnect log also carries `duration_ms` |
+| `duckgres_connections_open` | Gauge | Process-wide number of currently open client connections, including native metadata-proxy sockets |
+| `duckgres_connection_duration_seconds{org}` | Histogram | Worker-backed Duckgres connection lifetime, accept→disconnect (includes `_count`, `_sum`, `_bucket`); excludes native metadata-proxy connections, which use their dedicated duration family |
+| `duckgres_metadata_proxy_connections_open{org}` | Gauge | Current admitted native metadata Postgres proxy connections; process-local, so sum across control-plane replicas |
+| `duckgres_metadata_proxy_connection_attempts_total{org,outcome}` | Counter | Metadata proxy attempts by bounded terminal outcome |
+| `duckgres_metadata_proxy_connection_duration_seconds{org}` | Histogram | Lifetime of admitted metadata proxy connections, including upstream bootstrap |
+| `duckgres_metadata_proxy_upstream_connect_duration_seconds{org,outcome}` | Histogram | Internal metadata Postgres connect/auth latency; outcome is `success` or `error` |
+| `duckgres_metadata_proxy_bytes_total{org,direction}` | Counter | Post-authentication pgwire bytes relayed in `client_to_upstream` or `upstream_to_client` direction |
+| `duckgres_metadata_proxy_cancel_requests_total{outcome}` | Counter | Raw metadata-proxy CancelRequests handled as `session_terminated` on the owning control-plane replica or `not_local` on another replica |
 | `duckgres_query_total{org,status,reason}` | Counter | Total non-empty query attempts. Valid status/reason pairs: `success/none`; `failure/user`, `failure/canceled`, `failure/conflict`; `error/metadata_connection_lost`, `error/system`. |
 | `duckgres_query_duration_seconds{org}` | Histogram | Simple/extended query execution latency (includes `_count`, `_sum`, `_bucket`); use `duckgres_query_total` for attempt totals |
-| `duckgres_auth_failures_total` | Counter | Total number of authentication failures |
-| `duckgres_rate_limit_rejects_total` | Counter | Total number of connections rejected due to rate limiting |
+| `duckgres_auth_failures_total` | Counter | Process-wide authentication failures, including wrong-password metadata-proxy attempts; use `duckgres_metadata_proxy_connection_attempts_total{outcome="auth_failed"}` for the proxy-specific split |
+| `duckgres_rate_limit_rejects_total` | Counter | Process-wide pre-TLS connection rejections due to rate limiting; these cannot be attributed to the worker or metadata endpoint because SNI is not available yet |
 | `duckgres_rate_limited_ips` | Gauge | Number of currently rate-limited IP addresses |
 | `duckgres_flight_auth_sessions_active` | Gauge | Number of active Flight auth sessions on the control plane |
 | `duckgres_control_plane_workers_active` | Gauge | Number of active control-plane worker processes |
@@ -367,6 +373,8 @@ Run with config file:
 | `DUCKGRES_HANDOVER_DRAIN_TIMEOUT` | Max time to drain planned shutdowns and upgrades before forcing exit | `24h` in process mode, `15m` in remote K8s mode |
 | `DUCKGRES_SNI_ROUTING_MODE` | Multi-tenant managed-hostname routing: `off`, `passthrough`, or `enforce`. Postgres uses the requested dbname first; managed SNI must resolve to the same org, and SNI supplies the database only when dbname is empty. | `off` |
 | `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES` | Comma-separated managed hostname suffixes such as `.dw.us.postwh.com` | - |
+| `DUCKGRES_METADATA_HOSTNAME_SUFFIXES` | Comma-separated SNI suffixes for the explicitly enabled native metadata Postgres proxy, such as `.md.us.postwh.com` | - |
+| `DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG` | Maximum admitted metadata proxy sessions per org on each control-plane replica | `20` |
 | `DUCKGRES_DUCKLAKE_METADATA_STORE` | DuckLake metadata connection string | - |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_ENABLED` | Attach a Delta Lake catalog/table during worker boot/activation | `false` |
 | `DUCKGRES_DUCKLAKE_DELTA_CATALOG_PATH` | Delta Lake catalog/table path; defaults to sibling `delta/` prefix at the DuckLake object-store root when enabled | Derived |
@@ -888,6 +896,40 @@ kill -USR2 <control-plane-pid>
 In Kubernetes environments, `--worker-backend remote` is the multitenant path. It requires `--config-store`. Control-plane replicas coordinate through durable runtime rows in the config-store Postgres DB, spawn worker pods via the Kubernetes API, and communicate with them over gRPC (Arrow Flight SQL). Planned rolling deploys mark old replicas draining, fail readiness, and wait up to `handover_drain_timeout` before forcing shutdown. Unplanned control-plane failure still drops live pgwire connections; Flight may use a durable session token to create a fresh remote session on the surviving worker if the token is still valid.
 
 Managed-hostname routing is controlled by `--sni-routing-mode` and `--managed-hostname-suffixes`. For Postgres, an explicit startup `database`/`dbname` takes priority, but when SNI matches a managed suffix the hostname prefix and requested database must resolve to the same org. If the startup database is empty, the managed SNI prefix is used as the database fallback. Unknown `--sni-routing-mode` values behave like `off`.
+
+The native metadata Postgres proxy is a separate, fail-closed SNI path selected
+by `DUCKGRES_METADATA_HOSTNAME_SUFFIXES`. It is available only when an org's
+warehouse explicitly has `metadata_proxy_enabled=true`, is ready, and uses a
+CNPG-shard metadata store. The client must connect as `root` with the org's
+existing Duckgres password and must send the exact non-empty
+`dbname=metadata`. Duckgres resolves and uses the real metadata role, password,
+database, and PgBouncer endpoint internally. The endpoint and password are
+never sent to the client; the upstream role and database may be visible
+through normal PostgreSQL introspection such as `current_user` and
+`current_database()`. The per-org connection limit is enforced independently
+on every control-plane replica. Internal target resolution and
+connect/auth/synchronization have a fixed 10-second bootstrap deadline; the
+deadline does not apply after the relay is established. An admin/UI update that
+includes `metadata_proxy_enabled` reloads the local config snapshot and
+notifies peer replicas; established sessions close on their next five-second
+authorization recheck after the updated snapshot arrives.
+
+The initial rollout is restricted operationally to dedicated,
+single-customer CNPG shards. Do not enable `metadata_proxy_enabled` for an org
+on a shared shard until upstream database `CONNECT` ACLs and role hardening are
+in place: once the exact `metadata` database connection is established, the
+customer's `root` credential intentionally receives full access available to
+the internally resolved metadata role.
+
+Metadata-proxy cancellation is deliberately session-terminating: when a raw
+PostgreSQL `CancelRequest` reaches the control-plane replica that owns the
+synthetic backend key, Duckgres closes that exact frontend and upstream
+connection pair. PgBouncer cancellation keys are instance-local, so Duckgres
+does not redial the pooler Service. Like existing Duckgres cancellation, the
+raw follow-up TCP connection is control-plane-local behind the NLB; a request
+routed to another replica is counted as
+`duckgres_metadata_proxy_cancel_requests_total{outcome="not_local"}` and cannot
+terminate the owning session.
 
 Workers are spawned on demand: when an org opens a session with no reusable worker, the control plane creates a worker pod (sized from the connection's `duckgres.worker_cpu`/`worker_memory` request, or a default), activates it over the worker control RPC, and it becomes hot for that org. When its last session ends, the worker moves to `hot_idle` instead of being retired immediately: it keeps the org assignment and DuckLake attachment so any control-plane replica can reclaim it for the same org (by exact worker shape) without full reactivation, until its `duckgres.worker_ttl` expires. Hot-idle reuse is image/version strict. The janitor retires hot-idle workers at their TTL, but `default_worker_min_hot_idle` lets an org retain a minimum number of compatible default-profile hot-idle workers by skipping TTL retirement when the count is already at or below the floor. The default is `0` (disabled). The main lifecycle is: idle → reserved → activating → hot → hot_idle → retired. Workers can also move through `draining` during shutdown, rollout, or cleanup. (Spawn latency is hidden by the node-headroom controller, which keeps placeholder pods ready for real workers to preempt.)
 

--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -246,6 +246,8 @@ func main() {
 		ReadOnlySecretFallbacks:   resolved.ReadOnlySecretFallbacks,
 		SNIRoutingMode:             resolved.SNIRoutingMode,
 		ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
+		MetadataHostnameSuffixes:   resolved.MetadataHostnameSuffixes,
+		MetadataProxyMaxConns:      resolved.MetadataProxyMaxConns,
 		DucklingBucketSuffix:       resolved.DucklingBucketSuffix,
 		DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
 

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -133,6 +133,8 @@ type Resolved struct {
 	UserSecretKey                   string
 	SNIRoutingMode                  string
 	ManagedHostnameSuffixes         []string
+	MetadataHostnameSuffixes        []string
+	MetadataProxyMaxConns           int
 	DucklingBucketSuffix            string
 	DuckLakeDefaultSpecVersion      string
 
@@ -222,6 +224,8 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	var userSecretKey string
 	var sniRoutingMode string
 	var managedHostnameSuffixes []string
+	var metadataHostnameSuffixes []string
+	metadataProxyMaxConnections := 20
 	var ducklingBucketSuffix string
 
 	if fileCfg != nil {
@@ -786,6 +790,18 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_MANAGED_HOSTNAME_SUFFIXES"); v != "" {
 		managedHostnameSuffixes = splitAndTrim(v, ",")
 	}
+	if v := getenv("DUCKGRES_METADATA_HOSTNAME_SUFFIXES"); v != "" {
+		metadataHostnameSuffixes = splitAndTrim(v, ",")
+	}
+	if v := getenv("DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			metadataProxyMaxConnections = n
+		} else if err != nil {
+			warn("Invalid DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG: " + err.Error())
+		} else {
+			warn("DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG must be > 0")
+		}
+	}
 	// Env-only (set by the duckgres Helm chart per environment). The env suffix
 	// the control plane uses to name a type=s3bucket Duckling's per-org bucket:
 	// posthog-duckling-<compact-org>-<suffix>. Must equal crossplane-config's
@@ -1244,6 +1260,8 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		UserSecretKey:                   userSecretKey,
 		SNIRoutingMode:                  sniRoutingMode,
 		ManagedHostnameSuffixes:         managedHostnameSuffixes,
+		MetadataHostnameSuffixes:        metadataHostnameSuffixes,
+		MetadataProxyMaxConns:           metadataProxyMaxConnections,
 		DucklingBucketSuffix:            ducklingBucketSuffix,
 		DuckLakeDefaultSpecVersion:      cfg.DuckLake.SpecVersion,
 

--- a/configresolve/resolve_k8s_test.go
+++ b/configresolve/resolve_k8s_test.go
@@ -1,6 +1,7 @@
 package configresolve
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -22,6 +23,26 @@ func TestResolveEffectiveExposesDuckLakeDefaultSpecVersionForControlPlane(t *tes
 
 	if resolved.DuckLakeDefaultSpecVersion != "1.1" {
 		t.Fatalf("expected DuckLake default spec version 1.1, got %q", resolved.DuckLakeDefaultSpecVersion)
+	}
+}
+
+func TestResolveEffectiveParsesMetadataHostnameSuffixes(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		switch key {
+		case "DUCKGRES_METADATA_HOSTNAME_SUFFIXES":
+			return " .md.us.postwh.com, .md.eu.postwh.com "
+		case "DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG":
+			return "7"
+		}
+		return ""
+	}, nil)
+
+	want := []string{".md.us.postwh.com", ".md.eu.postwh.com"}
+	if !slices.Equal(resolved.MetadataHostnameSuffixes, want) {
+		t.Fatalf("expected metadata hostname suffixes %v, got %v", want, resolved.MetadataHostnameSuffixes)
+	}
+	if resolved.MetadataProxyMaxConns != 7 {
+		t.Fatalf("expected metadata per-org connection cap 7, got %d", resolved.MetadataProxyMaxConns)
 	}
 }
 

--- a/configresolve/resolve_k8s_test.go
+++ b/configresolve/resolve_k8s_test.go
@@ -30,14 +30,14 @@ func TestResolveEffectiveParsesMetadataHostnameSuffixes(t *testing.T) {
 	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
 		switch key {
 		case "DUCKGRES_METADATA_HOSTNAME_SUFFIXES":
-			return " .md.us.postwh.com, .md.eu.postwh.com "
+			return " .md.dev.postwh.com, .md.us.postwh.com, .md.eu.postwh.com "
 		case "DUCKGRES_METADATA_PROXY_MAX_CONNECTIONS_PER_ORG":
 			return "7"
 		}
 		return ""
 	}, nil)
 
-	want := []string{".md.us.postwh.com", ".md.eu.postwh.com"}
+	want := []string{".md.dev.postwh.com", ".md.us.postwh.com", ".md.eu.postwh.com"}
 	if !slices.Equal(resolved.MetadataHostnameSuffixes, want) {
 		t.Fatalf("expected metadata hostname suffixes %v, got %v", want, resolved.MetadataHostnameSuffixes)
 	}

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -747,6 +747,7 @@ func managedWarehouseUpsertColumns() []string {
 		// DB column name. Mismatching this against the actual column makes
 		// the ON CONFLICT … DO UPDATE clause throw 42703.
 		"duck_lake_version",
+		"metadata_proxy_enabled",
 		"duckling_name",
 		"warehouse_database_endpoint",
 		"warehouse_database_port",
@@ -807,6 +808,7 @@ type apiHandler struct {
 type managedWarehouseRequest struct {
 	Image                        string                                        `json:"image"`
 	DuckLakeVersion              string                                        `json:"ducklake_version"`
+	MetadataProxyEnabled         bool                                          `json:"metadata_proxy_enabled"`
 	DucklingName                 string                                        `json:"duckling_name"`
 	WarehouseDatabase            configstore.ManagedWarehouseDatabase          `json:"warehouse_database"`
 	MetadataStore                configstore.ManagedWarehouseMetadataStore     `json:"metadata_store"`
@@ -1420,8 +1422,16 @@ func (h *apiHandler) putManagedWarehouse(c *gin.Context) {
 	// NAMES only — the values can carry credentials/secret refs, so we never put
 	// them in the audit log). Gives "changed: metadata_store, s3" instead of a
 	// bare "warehouse.update".
-	if changed := topLevelJSONKeys(body); len(changed) > 0 {
-		setAuditDetail(c, "changed: "+strings.Join(changed, ", "))
+	changedFields := topLevelJSONKeys(body)
+	if len(changedFields) > 0 {
+		setAuditDetail(c, "changed: "+strings.Join(changedFields, ", "))
+	}
+	metadataProxyChanged := false
+	for _, field := range changedFields {
+		if field == "metadata_proxy_enabled" {
+			metadataProxyChanged = true
+			break
+		}
 	}
 
 	// MutateManagedWarehouse locks the row inside a transaction, runs the
@@ -1466,6 +1476,16 @@ func (h *apiHandler) putManagedWarehouse(c *gin.Context) {
 	if !ok {
 		c.JSON(http.StatusNotFound, gin.H{"error": "org not found"})
 		return
+	}
+	if metadataProxyChanged {
+		// The proxy gate is consumed from each CP's in-memory snapshot. Reload
+		// locally and notify peers now so an explicit admin/UI toggle does not
+		// wait for the normal config poll interval. Established sessions
+		// recheck the refreshed gate at most five seconds later.
+		if err := h.notifyPeersOfChange(c); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 	}
 	c.JSON(http.StatusOK, stored)
 }

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -1176,6 +1176,64 @@ func TestPutWarehouseDisablesPgBouncerWhenSetToFalse(t *testing.T) {
 	}
 }
 
+func TestPutWarehouseTogglesMetadataProxy(t *testing.T) {
+	const reloadPath = "/api/v1/internal/reload-snapshot"
+	store := newFakeAPIStore()
+	seedOrgWithWarehouse(store, "analytics")
+	fetcher := &fakePeerFetcher{}
+	router := newTestAPIRouterWithFetcher(store, fetcher)
+
+	for i, enabled := range []bool{true, false} {
+		body := []byte(fmt.Sprintf(`{"metadata_proxy_enabled": %t}`, enabled))
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/warehouse", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("enabled=%v: status = %d, want %d: %s", enabled, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		if got := store.warehouses["analytics"].MetadataProxyEnabled; got != enabled {
+			t.Fatalf("enabled=%v: stored metadata_proxy_enabled = %v", enabled, got)
+		}
+		if got := store.reloadSnapshotCalls; got != i+1 {
+			t.Fatalf("enabled=%v: reloadSnapshotCalls = %d, want %d", enabled, got, i+1)
+		}
+		if got := fetcher.postCallCount(); got != int32(i+1) {
+			t.Fatalf("enabled=%v: peer fan-out POSTs = %d, want %d", enabled, got, i+1)
+		}
+		fetcher.mu.Lock()
+		lastPath := fetcher.postPaths[len(fetcher.postPaths)-1]
+		fetcher.mu.Unlock()
+		if lastPath != reloadPath {
+			t.Fatalf("enabled=%v: peer fan-out path = %q, want %q", enabled, lastPath, reloadPath)
+		}
+	}
+}
+
+func TestPutWarehouseWithoutMetadataProxyFieldDoesNotReloadSnapshots(t *testing.T) {
+	store := newFakeAPIStore()
+	seedOrgWithWarehouse(store, "analytics")
+	fetcher := &fakePeerFetcher{}
+	router := newTestAPIRouterWithFetcher(store, fetcher)
+
+	body := []byte(`{"pgbouncer":{"enabled":true}}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/analytics/warehouse", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.reloadSnapshotCalls; got != 0 {
+		t.Fatalf("reloadSnapshotCalls = %d, want 0 for unrelated warehouse PUT", got)
+	}
+	if got := fetcher.postCallCount(); got != 0 {
+		t.Fatalf("peer fan-out POSTs = %d, want 0 for unrelated warehouse PUT", got)
+	}
+}
+
 func TestPutWarehouseRejectsRemovedIcebergField(t *testing.T) {
 	// Iceberg support was removed: "iceberg" is no longer a whitelisted field
 	// on the warehouse PUT, so the strict decode rejects it as unknown.
@@ -1698,6 +1756,9 @@ func TestManagedWarehouseUpsertColumnsExcludeCreatedAt(t *testing.T) {
 	}
 	if !slices.Contains(columns, "metadata_store_database_name") {
 		t.Fatal("expected metadata_store_database_name to be included in managed warehouse upserts")
+	}
+	if !slices.Contains(columns, "metadata_proxy_enabled") {
+		t.Fatal("expected metadata_proxy_enabled to be included in managed warehouse upserts")
 	}
 	// Regression guards: image and duck_lake_version must be in the upsert
 	// column list so the per-tenant pinning patch endpoint actually

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ManagedWarehouse, Org } from "@/types/api";
+
+const hooks = vi.hoisted(() => ({
+  useDeleteOrg: vi.fn(),
+  useDeprovisionWarehouse: vi.fn(),
+  useDucklingsMetadata: vi.fn(),
+  useOrg: vi.fn(),
+  useOrgReshards: vi.fn(),
+  useOrgTeams: vi.fn(),
+  useUpdateOrg: vi.fn(),
+  useUpdateWarehouse: vi.fn(),
+  useWarehouse: vi.fn(),
+}));
+vi.mock("@/hooks/useApi", () => hooks);
+
+const identity = vi.hoisted(() => ({ useIdentity: vi.fn() }));
+vi.mock("@/components/IdentityProvider", () => identity);
+
+vi.mock("@/components/OrgTeamDialogs", () => ({
+  BackfillBadge: () => null,
+  CreateTeamDialog: () => null,
+  DeleteTeamDialog: () => null,
+  EarliestEventDateCell: () => null,
+  EditTeamDialog: () => null,
+  LegacyNamesBadge: () => null,
+}));
+
+import { OrgDetail } from "./OrgDetail";
+
+const warehouseUpdate = vi.fn();
+const ok = <T,>(data: T) => ({
+  data,
+  isSuccess: true,
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+});
+const mut = (mutateAsync = vi.fn().mockResolvedValue(undefined)) => ({
+  mutateAsync,
+  isPending: false,
+});
+
+const ORG: Org = {
+  name: "acme",
+  database_name: "acme",
+  hostname_alias: null,
+  max_workers: 1,
+  max_vcpus: 2,
+  default_worker_cpu: "2",
+  default_worker_memory: "8Gi",
+  default_worker_ttl: "75m",
+  default_worker_min_hot_idle: 0,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+};
+
+function warehouse(metadataProxyEnabled: boolean): ManagedWarehouse {
+  return {
+    org_id: "acme",
+    duckling_name: "duckling-acme",
+    image: "duckgres:latest",
+    ducklake_version: "0.4",
+    metadata_proxy_enabled: metadataProxyEnabled,
+    warehouse_database: { endpoint: "", port: 5432 },
+    metadata_store: {
+      kind: "cnpg-shard",
+      endpoint: "",
+      port: 5432,
+      database_name: "acme",
+      username: "acme",
+    },
+    pgbouncer: { enabled: true },
+    s3: {
+      provider: "aws",
+      region: "us-east-1",
+      bucket: "test",
+      path_prefix: "",
+      endpoint: "",
+      use_ssl: true,
+      url_style: "vhost",
+      delta_catalog_enabled: false,
+      delta_catalog_path: "",
+    },
+    worker_identity: { namespace: "ducklings", iam_role_arn: "" },
+    warehouse_database_credentials: { namespace: "ducklings", name: "warehouse", key: "url" },
+    metadata_store_credentials: { namespace: "ducklings", name: "metadata", key: "url" },
+    s3_credentials: { namespace: "ducklings", name: "s3", key: "credentials" },
+    runtime_config: { namespace: "ducklings", name: "runtime", key: "config" },
+    state: "ready",
+    status_message: "",
+    metadata_store_state: "ready",
+    s3_state: "ready",
+    identity_state: "ready",
+    secrets_state: "ready",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+  } as ManagedWarehouse;
+}
+
+function renderPage(metadataProxyEnabled: boolean) {
+  hooks.useWarehouse.mockReturnValue(ok(warehouse(metadataProxyEnabled)));
+  render(
+    <MemoryRouter initialEntries={["/orgs/acme"]}>
+      <TooltipProvider>
+        <Routes>
+          <Route path="/orgs/:id" element={<OrgDetail />} />
+        </Routes>
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Org warehouse metadata proxy setting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    identity.useIdentity.mockReturnValue({
+      isAdmin: true,
+      me: { email: "admin@example.com", role: "admin", source: "sso" },
+    });
+    hooks.useOrg.mockReturnValue(ok(ORG));
+    hooks.useUpdateOrg.mockReturnValue(mut());
+    hooks.useDeleteOrg.mockReturnValue(mut());
+    hooks.useUpdateWarehouse.mockReturnValue(mut(warehouseUpdate));
+    hooks.useDeprovisionWarehouse.mockReturnValue(mut());
+    hooks.useDucklingsMetadata.mockReturnValue(ok({ available: true, entries: [] }));
+    hooks.useOrgReshards.mockReturnValue(ok([]));
+    hooks.useOrgTeams.mockReturnValue(ok([]));
+  });
+
+  it.each([
+    { current: false, next: true },
+    { current: true, next: false },
+  ])("saves an explicit $next when the current value is $current", async ({ current, next }) => {
+    const user = userEvent.setup();
+    renderPage(current);
+
+    const toggle = screen.getByRole("switch", { name: /public metadata postgres/i });
+    expect(toggle).toHaveAttribute("aria-checked", String(current));
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", String(next));
+    await user.click(screen.getByRole("button", { name: /save warehouse/i }));
+
+    expect(warehouseUpdate).toHaveBeenCalledTimes(1);
+    expect(warehouseUpdate).toHaveBeenCalledWith({ metadata_proxy_enabled: next });
+  });
+});

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import { StateBadge } from "@/components/StateBadge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AdminGate } from "@/components/AdminOnly";
@@ -359,6 +360,7 @@ function WarehousePanel({
   const metadata = useDucklingsMetadata();
   const [image, setImage] = useState("");
   const [version, setVersion] = useState("");
+  const [metadataProxyEnabled, setMetadataProxyEnabled] = useState(false);
   const [ducklingNameInput, setDucklingNameInput] = useState("");
   const [confirmDeprovision, setConfirmDeprovision] = useState(false);
   const [deprovisionConfirmText, setDeprovisionConfirmText] = useState("");
@@ -368,6 +370,7 @@ function WarehousePanel({
     if (data) {
       setImage(data.image ?? "");
       setVersion(data.ducklake_version ?? "");
+      setMetadataProxyEnabled(data.metadata_proxy_enabled ?? false);
       setDucklingNameInput(data.duckling_name ?? "");
     }
   }, [data]);
@@ -397,6 +400,9 @@ function WarehousePanel({
     const body: Partial<ManagedWarehouse> = {};
     if (image !== (data?.image ?? "")) body.image = image;
     if (version !== (data?.ducklake_version ?? "")) body.ducklake_version = version;
+    if (metadataProxyEnabled !== (data?.metadata_proxy_enabled ?? false)) {
+      body.metadata_proxy_enabled = metadataProxyEnabled;
+    }
     if (ducklingNameInput !== (data?.duckling_name ?? "")) {
       body.duckling_name = ducklingNameInput;
     }
@@ -513,6 +519,22 @@ function WarehousePanel({
                   className="font-mono text-xs"
                 />
               </Field>
+              <div className="flex items-center justify-between gap-4 rounded-md border border-border bg-background/40 px-3 py-2">
+                <div className="space-y-1">
+                  <Label htmlFor="metadata-proxy-enabled">Public metadata Postgres</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Initial scope: dedicated, single-customer CNPG shards only. Do not enable this
+                    for a shared shard until upstream CONNECT and role hardening lands. Clients use
+                    the org&apos;s root credential and exact dbname=metadata, with full metadata
+                    database access.
+                  </p>
+                </div>
+                <Switch
+                  id="metadata-proxy-enabled"
+                  checked={metadataProxyEnabled}
+                  onCheckedChange={setMetadataProxyEnabled}
+                />
+              </div>
               <div className="flex items-center gap-3">
                 <AdminGate>
                   <Button size="sm" onClick={save} disabled={update.isPending || ducklingNameEmpty}>

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -209,6 +209,7 @@ export interface ManagedWarehouse {
   };
   data_store?: { kind: string; bucket_name?: string; region?: string };
   pgbouncer: { enabled: boolean };
+  metadata_proxy_enabled: boolean;
   s3: {
     provider: string;
     region: string;

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -18,10 +18,11 @@ import (
 // srv is the local PG wire server, the only place the (redacted) in-flight SQL
 // text lives — so QueryDetailForPID is scoped to queries this replica owns.
 type clusterInfoProvider struct {
-	router   *OrgRouter
-	store    *configstore.ConfigStore
-	srv      *server.Server
-	selfCPID string
+	router           *OrgRouter
+	store            *configstore.ConfigStore
+	srv              *server.Server
+	selfCPID         string
+	metadataSessions *metadataProxySessionRegistry
 }
 
 var _ admin.LiveInfo = (*clusterInfoProvider)(nil)
@@ -228,11 +229,12 @@ func (p *clusterInfoProvider) RecentErrors(limit int) []admin.ErrorEntry {
 // connection) and sums the counts. An org with no live stack on this replica
 // (returns 0, not an error) is normal — its sessions, if any, live elsewhere.
 func (p *clusterInfoProvider) KillUserSessions(orgID, username string) int {
+	killed := p.metadataSessions.KillUser(orgID, username)
 	stack, ok := p.router.AllStacks()[orgID]
 	if !ok {
-		return 0
+		return killed
 	}
-	return stack.Sessions.DestroySessionsForUser(username)
+	return killed + stack.Sessions.DestroySessionsForUser(username)
 }
 
 // impersonator implements admin.Impersonator. It opens a real session as the

--- a/controlplane/configstore/migrations/000033_add_metadata_proxy_enabled.sql
+++ b/controlplane/configstore/migrations/000033_add_metadata_proxy_enabled.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE duckgres_managed_warehouses
+    ADD COLUMN IF NOT EXISTS metadata_proxy_enabled BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE duckgres_managed_warehouses
+    DROP COLUMN IF EXISTS metadata_proxy_enabled;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -289,6 +289,10 @@ type ManagedWarehouse struct {
 
 	Image           string `gorm:"size:512" json:"image"`
 	DuckLakeVersion string `gorm:"size:32" json:"ducklake_version"`
+	// MetadataProxyEnabled explicitly opts this org into the customer-facing
+	// native Postgres metadata endpoint. It is never inferred from shard
+	// placement: moving an org must not silently publish its catalog database.
+	MetadataProxyEnabled bool `gorm:"not null;default:false" json:"metadata_proxy_enabled"`
 
 	// DucklingName is THE authoritative k8s Duckling CR name — nothing in the
 	// control plane derives or re-derives it. On warehouse create it defaults
@@ -619,8 +623,9 @@ type ManagedWarehouseConfig struct {
 	// as the org-teams info metric's join key.
 	DucklingName string
 
-	Image           string
-	DuckLakeVersion string
+	Image                string
+	DuckLakeVersion      string
+	MetadataProxyEnabled bool
 
 	WarehouseDatabase ManagedWarehouseDatabase
 	MetadataStore     ManagedWarehouseMetadataStore
@@ -653,6 +658,7 @@ func copyManagedWarehouseConfig(warehouse *ManagedWarehouse) *ManagedWarehouseCo
 		DucklingName:                 warehouse.DucklingName,
 		Image:                        warehouse.Image,
 		DuckLakeVersion:              warehouse.DuckLakeVersion,
+		MetadataProxyEnabled:         warehouse.MetadataProxyEnabled,
 		WarehouseDatabase:            warehouse.WarehouseDatabase,
 		MetadataStore:                warehouse.MetadataStore,
 		PgBouncer:                    warehouse.PgBouncer,

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -38,6 +38,11 @@ const (
 	OrgUserAccessModeProjectUser = "project_user"
 )
 
+// dummyBcryptHash is a syntactically valid bcrypt cost-10 hash used only to
+// equalize unknown-user authentication work. Its plaintext is irrelevant: no
+// code path accepts a successful comparison against it.
+const dummyBcryptHash = "$2a$10$Z2IMbWec4kIV53lYNMj4Ke1sA2FxSqavOSQXiOoEAosHLzpqdzpbe"
+
 // IsProjectScopedAccessMode reports whether mode binds a user to one team's
 // namespaces. Both scoped modes require a team_id and forbid passthrough.
 func IsProjectScopedAccessMode(mode string) bool {
@@ -557,7 +562,7 @@ func (cs *ConfigStore) ResolvePostgresConnection(startupDatabase, sniPrefix stri
 	storedHash, ok := cs.snapshot.OrgUserPassword[key]
 	if !ok {
 		// Timing-leak guard: still spend bcrypt time on unknown users.
-		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte(password))
 		return result
 	}
 	if bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) != nil {
@@ -599,6 +604,72 @@ func (cs *ConfigStore) OrgWarehouseStatus(orgID string) (string, bool) {
 		return "", true
 	}
 	return string(oc.Warehouse.State), true
+}
+
+// OrgMetadataProxyEnabled is a snapshot-only, fail-closed check for the
+// customer-facing native metadata Postgres endpoint.
+func (cs *ConfigStore) OrgMetadataProxyEnabled(orgID string) bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return metadataProxyEnabledFromSnapshot(cs.snapshot, orgID)
+}
+
+func metadataProxyEnabledFromSnapshot(snapshot *Snapshot, orgID string) bool {
+	if snapshot == nil {
+		return false
+	}
+	org, ok := snapshot.Orgs[orgID]
+	return ok && org.Warehouse != nil &&
+		org.Warehouse.MetadataProxyEnabled &&
+		org.Warehouse.State == ManagedWarehouseStateReady &&
+		org.Warehouse.MetadataStore.Kind == MetadataStoreKindCnpgShard
+}
+
+// MetadataProxySessionAllowed rechecks the mutable authorization state of an
+// established metadata session without re-running bcrypt. An explicit admin
+// metadata_proxy_enabled update reloads local/peer snapshots immediately, then
+// established proxy sessions observe the new gate on their periodic recheck.
+// Per-user disable additionally closes matching registered connections.
+func (cs *ConfigStore) MetadataProxySessionAllowed(orgID, username string) bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if !metadataProxyEnabledFromSnapshot(cs.snapshot, orgID) || username != "root" {
+		return false
+	}
+	key := OrgUserKey{OrgID: orgID, Username: username}
+	_, exists := cs.snapshot.OrgUserPassword[key]
+	return exists && !cs.snapshot.OrgUserDisabled[key]
+}
+
+// ResolveMetadataProxyConnection atomically resolves the public hostname,
+// checks the explicit publication gate, and authenticates the org-scoped
+// credential against one immutable snapshot. Keeping all three decisions
+// under the same read lock prevents an alias or credential update from mixing
+// identities across snapshots.
+func (cs *ConfigStore) ResolveMetadataProxyConnection(prefix, username, password string) (orgID string, enabled, authenticated bool) {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.snapshot == nil {
+		return "", false, false
+	}
+	orgID, _, _ = resolveSNIPrefixFromSnapshot(cs.snapshot, prefix)
+	if !metadataProxyEnabledFromSnapshot(cs.snapshot, orgID) {
+		return "", false, false
+	}
+
+	key := OrgUserKey{OrgID: orgID, Username: username}
+	storedHash, ok := cs.snapshot.OrgUserPassword[key]
+	if !ok {
+		// Spend bcrypt time on unknown users so the public endpoint does not
+		// expose a useful username-enumeration timing signal.
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte(password))
+		return orgID, true, false
+	}
+	if bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) != nil ||
+		cs.snapshot.OrgUserDisabled[key] {
+		return orgID, true, false
+	}
+	return orgID, true, true
 }
 
 // OrgDefaultWorkerProfile returns the org's operator-set default worker
@@ -692,7 +763,7 @@ func (cs *ConfigStore) ValidateOrgUser(orgID, username, password string) bool {
 	storedHash, ok := cs.snapshot.OrgUserPassword[OrgUserKey{OrgID: orgID, Username: username}]
 	if !ok {
 		// Spend time on a dummy bcrypt compare to avoid timing leaks on username enumeration.
-		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte(password))
 		return false
 	}
 	if bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) != nil {
@@ -729,13 +800,13 @@ func (cs *ConfigStore) ValidateOrgUserAndGetPassthrough(orgID, username, passwor
 	if cs.snapshot == nil {
 		// Match ValidateOrgUser's timing-leak guard: still spend bcrypt time
 		// on failed auth so unknown-user paths look the same as wrong-password.
-		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte(password))
 		return false, false
 	}
 	key := OrgUserKey{OrgID: orgID, Username: username}
 	storedHash, ok := cs.snapshot.OrgUserPassword[key]
 	if !ok {
-		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$000000000000000000000000000000000000000000000000000000"), []byte(password))
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte(password))
 		return false, false
 	}
 	if bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)) != nil {

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -456,6 +456,19 @@ func TestHashPassword(t *testing.T) {
 	}
 }
 
+func TestDummyBcryptHashIsValidAtDefaultCost(t *testing.T) {
+	cost, err := bcrypt.Cost([]byte(dummyBcryptHash))
+	if err != nil {
+		t.Fatalf("dummy bcrypt hash is invalid: %v", err)
+	}
+	if cost != bcrypt.DefaultCost {
+		t.Fatalf("dummy bcrypt cost = %d, want %d", cost, bcrypt.DefaultCost)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(dummyBcryptHash), []byte("never-the-dummy-password")); err != bcrypt.ErrMismatchedHashAndPassword {
+		t.Fatalf("dummy bcrypt comparison returned %v, want ErrMismatchedHashAndPassword", err)
+	}
+}
+
 func TestOrgWarehouseStatus(t *testing.T) {
 	cs := &ConfigStore{
 		snapshot: &Snapshot{
@@ -489,6 +502,113 @@ func TestOrgWarehouseStatus(t *testing.T) {
 			t.Errorf("OrgWarehouseStatus(%q) = (%q, %v); want (%q, %v)",
 				tt.orgID, gotState, gotExists, tt.wantState, tt.wantExists)
 		}
+	}
+}
+
+func TestOrgMetadataProxyEnabledFailsClosed(t *testing.T) {
+	cs := &ConfigStore{}
+	cs.snapshot = &Snapshot{Orgs: map[string]*OrgConfig{
+		"enabled": {
+			Name: "enabled",
+			Warehouse: &ManagedWarehouseConfig{
+				MetadataProxyEnabled: true,
+				State:                ManagedWarehouseStateReady,
+				MetadataStore:        ManagedWarehouseMetadataStore{Kind: MetadataStoreKindCnpgShard},
+			},
+		},
+		"external": {
+			Name: "external",
+			Warehouse: &ManagedWarehouseConfig{
+				MetadataProxyEnabled: true,
+				State:                ManagedWarehouseStateReady,
+				MetadataStore:        ManagedWarehouseMetadataStore{Kind: MetadataStoreKindExternal},
+			},
+		},
+		"disabled": {
+			Name: "disabled",
+			Warehouse: &ManagedWarehouseConfig{
+				State:         ManagedWarehouseStateReady,
+				MetadataStore: ManagedWarehouseMetadataStore{Kind: MetadataStoreKindCnpgShard},
+			},
+		},
+		"pending": {
+			Name: "pending",
+			Warehouse: &ManagedWarehouseConfig{
+				MetadataProxyEnabled: true,
+				State:                ManagedWarehouseStateProvisioning,
+				MetadataStore:        ManagedWarehouseMetadataStore{Kind: MetadataStoreKindCnpgShard},
+			},
+		},
+		"no-warehouse": {Name: "no-warehouse"},
+	}}
+	if !cs.OrgMetadataProxyEnabled("enabled") {
+		t.Fatal("explicitly enabled ready CNPG org should be allowed")
+	}
+	for _, orgID := range []string{"external", "disabled", "pending", "no-warehouse", "unknown"} {
+		if cs.OrgMetadataProxyEnabled(orgID) {
+			t.Fatalf("org %q must fail closed", orgID)
+		}
+	}
+}
+
+func TestResolveMetadataProxyConnection(t *testing.T) {
+	root := OrgUserKey{OrgID: "acme", Username: "root"}
+	cs := &ConfigStore{snapshot: &Snapshot{
+		Orgs: map[string]*OrgConfig{
+			"acme": {
+				Name:         "acme",
+				DatabaseName: "acme_db",
+				Warehouse: &ManagedWarehouseConfig{
+					MetadataProxyEnabled: true,
+					State:                ManagedWarehouseStateReady,
+					MetadataStore:        ManagedWarehouseMetadataStore{Kind: MetadataStoreKindCnpgShard},
+				},
+			},
+		},
+		HostnameAliasOrg: map[string]string{"acme-alias": "acme"},
+		OrgUserPassword:  map[OrgUserKey]string{root: mustHash(t, "secret")},
+		OrgUserDisabled:  map[OrgUserKey]bool{},
+	}}
+
+	orgID, enabled, authenticated := cs.ResolveMetadataProxyConnection("acme-alias", "root", "secret")
+	if orgID != "acme" || !enabled || !authenticated {
+		t.Fatalf("valid metadata connection = (%q, %v, %v), want (acme, true, true)",
+			orgID, enabled, authenticated)
+	}
+	if !cs.MetadataProxySessionAllowed("acme", "root") {
+		t.Fatal("authenticated root session should remain allowed")
+	}
+	if cs.MetadataProxySessionAllowed("acme", "other") {
+		t.Fatal("non-root metadata session must not be allowed")
+	}
+
+	for _, tc := range []struct {
+		name     string
+		prefix   string
+		username string
+		password string
+		enabled  bool
+	}{
+		{name: "wrong password", prefix: "acme-alias", username: "root", password: "wrong", enabled: true},
+		{name: "wrong user", prefix: "acme-alias", username: "other", password: "secret", enabled: true},
+		{name: "unknown host", prefix: "unknown", username: "root", password: "secret", enabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotOrg, gotEnabled, gotAuthenticated := cs.ResolveMetadataProxyConnection(tc.prefix, tc.username, tc.password)
+			if gotEnabled != tc.enabled || gotAuthenticated {
+				t.Fatalf("metadata connection = (%q, %v, %v), want enabled=%v authenticated=false",
+					gotOrg, gotEnabled, gotAuthenticated, tc.enabled)
+			}
+		})
+	}
+
+	cs.snapshot.OrgUserDisabled[root] = true
+	_, enabled, authenticated = cs.ResolveMetadataProxyConnection("acme-alias", "root", "secret")
+	if !enabled || authenticated {
+		t.Fatalf("disabled root = (enabled=%v, authenticated=%v), want (true, false)", enabled, authenticated)
+	}
+	if cs.MetadataProxySessionAllowed("acme", "root") {
+		t.Fatal("disabled root's established metadata session must be revoked")
 	}
 }
 
@@ -634,12 +754,12 @@ func TestOrgUsageTeamID(t *testing.T) {
 		orgID, username string
 		want            int64
 	}{
-		{"multi", "reader", 99},    // user's own team wins
-		{"multi", "root", 42},      // user without a team → org's oldest team
-		{"multi", "zeroteam", 42},  // non-positive user team → oldest-team fallback
-		{"multi", "unknown", 42},   // unknown user → oldest-team fallback
-		{"no-teams", "anyone", 0},  // defensive: teamless org
-		{"unknown", "anyone", 0},   // unknown org
+		{"multi", "reader", 99},   // user's own team wins
+		{"multi", "root", 42},     // user without a team → org's oldest team
+		{"multi", "zeroteam", 42}, // non-positive user team → oldest-team fallback
+		{"multi", "unknown", 42},  // unknown user → oldest-team fallback
+		{"no-teams", "anyone", 0}, // defensive: teamless org
+		{"unknown", "anyone", 0},  // unknown org
 	}
 	for _, tt := range tests {
 		if got := cs.OrgUsageTeamID(tt.orgID, tt.username); got != tt.want {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -123,7 +123,9 @@ type ControlPlaneConfig struct {
 	// single-label prefix is resolved as hostname_alias, database_name, or org
 	// name. Postgres still honors an explicit startup database, but only when it
 	// resolves to the same org as the managed hostname.
-	ManagedHostnameSuffixes []string
+	ManagedHostnameSuffixes  []string
+	MetadataHostnameSuffixes []string
+	MetadataProxyMaxConns    int
 
 	// DucklingBucketSuffix is the env suffix the control plane uses to name a
 	// type=s3bucket Duckling's per-org S3 bucket
@@ -244,7 +246,11 @@ type ControlPlane struct {
 	// durable buffer (remote/k8s backend with billing config only; nil
 	// otherwise — every call site is nil-safe). The leader-only drain loop that
 	// ships buffered usage to PostHog is wired separately in SetupMultiTenant.
-	computeMeter *computeMeter
+	computeMeter            *computeMeter
+	metadataPostgresURL     func(context.Context, string) (string, error)
+	metadataPostgresConnect func(context.Context, string) (metadataPostgresConn, error)
+	metadataSessions        *metadataProxySessionRegistry
+	proxyCancels            sync.Map
 }
 
 // ConfigStoreInterface abstracts the config store for the control plane.
@@ -536,6 +542,13 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		}
 		cp.configStore = store
 		cp.orgRouter = adapter
+		if resolver, ok := adapter.(interface {
+			MetadataPostgresURL(context.Context, string) (string, error)
+			MetadataProxySessions() *metadataProxySessionRegistry
+		}); ok {
+			cp.metadataPostgresURL = resolver.MetadataPostgresURL
+			cp.metadataSessions = resolver.MetadataProxySessions()
+		}
 		cp.apiServer = apiServer
 		cp.runtimeTracker = runtimeTracker
 		cp.janitorLeader = janitorLeader
@@ -915,7 +928,9 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Handle cancel request
 	if params.cancelRequest {
 		key := server.BackendKey{Pid: params.cancelPid, SecretKey: params.cancelSecretKey}
-		cp.srv.CancelQuery(key)
+		if !cp.forwardMetadataCancel(key) {
+			cp.srv.CancelQuery(key)
+		}
 		_ = conn.Close()
 		return
 	}
@@ -1032,6 +1047,11 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	}
 
 	password := string(bytes.TrimRight(body, "\x00"))
+
+	if cp.tryMetadataProxy(context.Background(), tlsConn, reader, writer,
+		tlsConn.ConnectionState().ServerName, username, database, password) {
+		return
+	}
 
 	// Authenticate.
 	// In multi-tenant mode the org is resolved solely from the managed hostname

--- a/controlplane/metadata_proxy.go
+++ b/controlplane/metadata_proxy.go
@@ -1,0 +1,404 @@
+package controlplane
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/posthog/duckgres/server"
+)
+
+const (
+	metadataProxyDatabase                = "metadata"
+	metadataProxyUpstreamApplicationName = "duckgres-metadata-proxy"
+	metadataProxyBootstrapTimeout        = 10 * time.Second
+)
+
+type metadataProxyCancelTarget struct {
+	frontend net.Conn
+	upstream net.Conn
+}
+
+type metadataPostgresConn interface {
+	SyncConn(context.Context) error
+	Hijack() (*pgconn.HijackedConn, error)
+	Close(context.Context) error
+}
+
+type metadataProxySessionRegistry struct {
+	mu        sync.Mutex
+	maxPerOrg int
+	byOrg     map[string]map[net.Conn]string
+	closed    bool
+}
+
+func (r *metadataProxySessionRegistry) Register(orgID, username string, conn net.Conn) (func(), bool) {
+	if r == nil || conn == nil {
+		return nil, false
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil, false
+	}
+	sessions := r.byOrg[orgID]
+	if len(sessions) >= r.maxPerOrg {
+		r.mu.Unlock()
+		return nil, false
+	}
+	if sessions == nil {
+		sessions = make(map[net.Conn]string)
+		r.byOrg[orgID] = sessions
+	}
+	sessions[conn] = username
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		if sessions := r.byOrg[orgID]; sessions != nil {
+			delete(sessions, conn)
+			if len(sessions) == 0 {
+				delete(r.byOrg, orgID)
+			}
+		}
+		r.mu.Unlock()
+	}, true
+}
+
+func (r *metadataProxySessionRegistry) KillUser(orgID, username string) int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	var conns []net.Conn
+	for conn, sessionUser := range r.byOrg[orgID] {
+		if sessionUser == username {
+			conns = append(conns, conn)
+			delete(r.byOrg[orgID], conn)
+		}
+	}
+	if len(r.byOrg[orgID]) == 0 {
+		delete(r.byOrg, orgID)
+	}
+	r.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	return len(conns)
+}
+
+func (r *metadataProxySessionRegistry) KillAll() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	r.closed = true
+	var conns []net.Conn
+	for orgID, sessions := range r.byOrg {
+		for conn := range sessions {
+			conns = append(conns, conn)
+		}
+		delete(r.byOrg, orgID)
+	}
+	r.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	return len(conns)
+}
+
+// tryMetadataProxy handles every connection whose SNI matches the metadata
+// suffix, including denials. Such connections must never fall through to the
+// DuckDB worker path.
+func (cp *ControlPlane) tryMetadataProxy(
+	ctx context.Context,
+	tlsConn net.Conn,
+	reader *bufio.Reader,
+	writer *bufio.Writer,
+	sni, username, database, password string,
+) bool {
+	prefix, matched := cp.extractMetadataOrgFromSNI(sni)
+	if !matched {
+		return false
+	}
+
+	attemptMetrics := newMetadataProxyAttemptMetrics()
+	defer attemptMetrics.Finish(metadataProxyOutcomeUnavailable)
+	finish := func(outcome string) bool {
+		attemptMetrics.Finish(outcome)
+		return true
+	}
+	fail := func(outcome, code, message string) bool {
+		attemptMetrics.Finish(outcome)
+		_ = server.WriteErrorResponse(writer, "FATAL", code, message)
+		_ = writer.Flush()
+		return true
+	}
+	if cp.configStore == nil || cp.metadataPostgresURL == nil {
+		return fail(metadataProxyOutcomeUnavailable, "08006", "metadata endpoint is unavailable")
+	}
+	metadataStore, supportsMetadataProxy := cp.configStore.(interface {
+		ResolveMetadataProxyConnection(prefix, username, password string) (orgID string, enabled, authenticated bool)
+	})
+	if !supportsMetadataProxy {
+		return fail(metadataProxyOutcomeUnavailable, "08006", "metadata endpoint is unavailable")
+	}
+	orgID, enabled, authenticated := metadataStore.ResolveMetadataProxyConnection(prefix, username, password)
+	attemptMetrics.SetOrg(orgID)
+	if orgID == "" || !enabled {
+		return fail(metadataProxyOutcomeUnavailable, "08006", "metadata endpoint is unavailable")
+	}
+	if database != metadataProxyDatabase {
+		return fail(metadataProxyOutcomeInvalidDatabase, "3D000", `database does not exist; connect with dbname="metadata"`)
+	}
+	if username != "root" || !authenticated {
+		server.RecordFailedAuthAttempt(cp.rateLimiter, tlsConn.RemoteAddr())
+		return fail(metadataProxyOutcomeAuthFailed, "28P01", "password authentication failed")
+	}
+	if cp.isDraining() {
+		return fail(metadataProxyOutcomeDraining, "57P03", "control plane is draining, retry shortly")
+	}
+	if cp.metadataSessions == nil {
+		return fail(metadataProxyOutcomeUnavailable, "08006", "metadata endpoint is unavailable")
+	}
+	releaseSession, admitted := cp.metadataSessions.Register(orgID, username, tlsConn)
+	if !admitted {
+		return fail(metadataProxyOutcomeCapacity, "53300", "too many metadata connections for this organization")
+	}
+	defer releaseSession()
+	sessionStarted := time.Now()
+	releaseConnectionMetrics := beginMetadataProxyConnection(orgID)
+	established := false
+	defer func() {
+		releaseConnectionMetrics()
+		if established {
+			slog.Info("Metadata proxy session closed.",
+				"org", orgID,
+				"user", username,
+				"duration_ms", time.Since(sessionStarted).Milliseconds())
+		}
+	}()
+
+	// Target resolution may read Kubernetes resources and the upstream connect
+	// includes DNS, TCP, TLS, and Postgres authentication. Bound the whole
+	// bootstrap; established relay traffic deliberately does not inherit this
+	// deadline.
+	bootstrapCtx, cancelBootstrap := context.WithTimeout(ctx, metadataProxyBootstrapTimeout)
+	defer cancelBootstrap()
+
+	upstreamURL, err := cp.metadataPostgresURL(bootstrapCtx, orgID)
+	if err != nil {
+		// Resolver implementations can wrap secret or connection data. The
+		// bounded outcome identifies the failure without serializing that
+		// untrusted error into logs.
+		slog.Error("Metadata proxy target resolution failed.",
+			"org", orgID,
+			"error_type", fmt.Sprintf("%T", err))
+		return fail(metadataProxyOutcomeTargetResolutionError, "08006", "metadata endpoint is unavailable")
+	}
+	upstreamURL, err = metadataProxyTaggedUpstreamURL(upstreamURL)
+	if err != nil {
+		// net/url parse errors can contain the full input URL, including its
+		// password. Never attach that error (or the URL) to the log record.
+		slog.Error("Metadata proxy target URL was invalid.", "org", orgID)
+		return fail(metadataProxyOutcomeTargetResolutionError, "08006", "metadata endpoint is unavailable")
+	}
+	var pgConn metadataPostgresConn
+	upstreamConnectStarted := time.Now()
+	if cp.metadataPostgresConnect != nil {
+		pgConn, err = cp.metadataPostgresConnect(bootstrapCtx, upstreamURL)
+	} else {
+		pgConn, err = pgconn.Connect(bootstrapCtx, upstreamURL)
+	}
+	if err != nil {
+		observeMetadataProxyUpstreamConnect(orgID, metadataProxyUpstreamOutcomeError, upstreamConnectStarted)
+		// pgconn's ConnectError omits the password and ParseConfigError redacts
+		// it. The type-gated helper degrades injected/custom errors to their
+		// type so a connector can never smuggle the DSN into logs.
+		slog.Error("Metadata proxy upstream connection failed.",
+			"org", orgID,
+			"error", metadataProxySafeConnectError(err))
+		return fail(metadataProxyOutcomeUpstreamConnectError, "08006", "metadata endpoint is unavailable")
+	}
+	observeMetadataProxyUpstreamConnect(orgID, metadataProxyUpstreamOutcomeSuccess, upstreamConnectStarted)
+	if err := pgConn.SyncConn(bootstrapCtx); err != nil {
+		slog.Error("Metadata proxy upstream synchronization failed.",
+			"org", orgID,
+			"error", metadataProxySafeConnectError(err))
+		_ = pgConn.Close(bootstrapCtx)
+		return fail(metadataProxyOutcomeUpstreamSyncError, "08006", "metadata endpoint is unavailable")
+	}
+	hijacked, err := pgConn.Hijack()
+	if err != nil {
+		slog.Error("Metadata proxy upstream hijack failed.",
+			"org", orgID,
+			"error", metadataProxySafeConnectError(err))
+		_ = pgConn.Close(bootstrapCtx)
+		return fail(metadataProxyOutcomeUpstreamHijackError, "08006", "metadata endpoint is unavailable")
+	}
+	cancelBootstrap()
+	defer func() { _ = hijacked.Conn.Close() }()
+
+	target := metadataProxyCancelTarget{
+		frontend: tlsConn,
+		upstream: hijacked.Conn,
+	}
+	key, err := cp.registerMetadataCancel(target)
+	if err != nil {
+		slog.Error("Metadata proxy could not allocate a cancel key.", "org", orgID, "error", err)
+		return fail(metadataProxyOutcomeCancelKeyError, "08006", "metadata endpoint is unavailable")
+	}
+	defer cp.proxyCancels.Delete(key)
+
+	if err := server.WriteAuthOK(writer); err != nil {
+		slog.Info("Metadata proxy frontend handshake ended before authentication response.", "org", orgID, "error", err)
+		return finish(metadataProxyOutcomeHandshakeError)
+	}
+	for name, value := range hijacked.ParameterStatuses {
+		if err := server.WriteParameterStatus(writer, name, value); err != nil {
+			slog.Info("Metadata proxy frontend handshake ended while writing parameter status.", "org", orgID, "error", err)
+			return finish(metadataProxyOutcomeHandshakeError)
+		}
+	}
+	if err := server.WriteBackendKeyData(writer, key.Pid, key.SecretKey); err != nil {
+		slog.Info("Metadata proxy frontend handshake ended while writing cancel key.", "org", orgID, "error", err)
+		return finish(metadataProxyOutcomeHandshakeError)
+	}
+	if err := server.WriteReadyForQuery(writer, hijacked.TxStatus); err != nil {
+		slog.Info("Metadata proxy frontend handshake ended before readiness.", "org", orgID, "error", err)
+		return finish(metadataProxyOutcomeHandshakeError)
+	}
+	if err := writer.Flush(); err != nil {
+		slog.Info("Metadata proxy frontend handshake flush failed.", "org", orgID, "error", err)
+		return finish(metadataProxyOutcomeHandshakeError)
+	}
+	server.RecordSuccessfulAuthAttempt(cp.rateLimiter, tlsConn.RemoteAddr())
+	attemptMetrics.Finish(metadataProxyOutcomeSuccess)
+	established = true
+
+	slog.Info("Metadata proxy session established.", "org", orgID, "user", username)
+	type relayResult struct {
+		direction string
+		err       error
+	}
+	relays := make(chan relayResult, 2)
+	go func() {
+		_, err := io.Copy(
+			metadataProxyTrafficWriter(hijacked.Conn, orgID, metadataProxyDirectionClientToUpstream),
+			reader,
+		)
+		relays <- relayResult{direction: metadataProxyDirectionClientToUpstream, err: err}
+	}()
+	go func() {
+		_, err := io.Copy(
+			metadataProxyTrafficWriter(tlsConn, orgID, metadataProxyDirectionUpstreamToClient),
+			hijacked.Conn,
+		)
+		relays <- relayResult{direction: metadataProxyDirectionUpstreamToClient, err: err}
+	}()
+	recheck := time.NewTicker(5 * time.Second)
+	defer recheck.Stop()
+	for {
+		select {
+		case relay := <-relays:
+			slog.Info("Metadata proxy relay ended.",
+				"org", orgID,
+				"user", username,
+				"direction", relay.direction,
+				"error", relay.err)
+			return true
+		case <-recheck.C:
+			enabledStore, ok := cp.configStore.(interface {
+				MetadataProxySessionAllowed(orgID, username string) bool
+			})
+			if !ok || !enabledStore.MetadataProxySessionAllowed(orgID, username) {
+				slog.Info("Metadata proxy session revoked.", "org", orgID, "user", username)
+				return true
+			}
+		}
+	}
+}
+
+func metadataProxyTaggedUpstreamURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return "", errors.New("metadata proxy upstream URL must use postgres")
+	}
+	query := parsed.Query()
+	// This fixed internal tag intentionally ignores the client startup
+	// application_name. It distinguishes proxy sessions from DuckDB
+	// postgres_scanner sessions in pg_stat_activity without forwarding any
+	// client-controlled value to the privileged upstream connection.
+	query.Set("application_name", metadataProxyUpstreamApplicationName)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func metadataProxySafeConnectError(err error) string {
+	var connectErr *pgconn.ConnectError
+	if errors.As(err, &connectErr) {
+		return connectErr.Error()
+	}
+	var parseErr *pgconn.ParseConfigError
+	if errors.As(err, &parseErr) {
+		return parseErr.Error()
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+func (cp *ControlPlane) registerMetadataCancel(target metadataProxyCancelTarget) (server.BackendKey, error) {
+	var raw [8]byte
+	for range 16 {
+		if _, err := rand.Read(raw[:]); err != nil {
+			return server.BackendKey{}, err
+		}
+		// Use the high positive PID range for broad client compatibility while
+		// staying away from normal OS and Duckgres session PIDs. The random
+		// secret still makes the full key collision-resistant.
+		key := server.BackendKey{
+			Pid:       int32(binary.BigEndian.Uint32(raw[:4])&0x3fffffff | 0x40000000),
+			SecretKey: int32(binary.BigEndian.Uint32(raw[4:])),
+		}
+		if _, loaded := cp.proxyCancels.LoadOrStore(key, target); !loaded {
+			return key, nil
+		}
+	}
+	return server.BackendKey{}, errors.New("could not allocate unique metadata proxy cancel key")
+}
+
+func (cp *ControlPlane) forwardMetadataCancel(key server.BackendKey) bool {
+	raw, ok := cp.proxyCancels.LoadAndDelete(key)
+	if !ok {
+		// CancelRequest is a fresh raw TCP connection and the NLB may route it
+		// to a different control-plane replica than the established session.
+		// Synthetic high-range PIDs belong to this proxy, so absorb a miss and
+		// expose it instead of falling through to the normal local query map.
+		if key.Pid >= 0x40000000 {
+			metadataProxyCancelRequestsCounter.WithLabelValues(metadataProxyCancelOutcomeNotLocal).Inc()
+			return true
+		}
+		return false
+	}
+	target := raw.(metadataProxyCancelTarget)
+	// PgBouncer cancel keys are instance-local. Re-dialing the pooler Service
+	// can reach the wrong pod, so terminate the exact established frontend and
+	// upstream sockets instead. This intentionally cancels the whole metadata
+	// session, not just its current statement.
+	_ = target.frontend.Close()
+	_ = target.upstream.Close()
+	metadataProxyCancelRequestsCounter.WithLabelValues(metadataProxyCancelOutcomeSessionTerminated).Inc()
+	return true
+}

--- a/controlplane/metadata_proxy_kubernetes.go
+++ b/controlplane/metadata_proxy_kubernetes.go
@@ -1,0 +1,15 @@
+//go:build kubernetes
+
+package controlplane
+
+import "net"
+
+func newMetadataProxySessionRegistry(maxPerOrg int) *metadataProxySessionRegistry {
+	if maxPerOrg <= 0 {
+		maxPerOrg = 20
+	}
+	return &metadataProxySessionRegistry{
+		maxPerOrg: maxPerOrg,
+		byOrg:     make(map[string]map[net.Conn]string),
+	}
+}

--- a/controlplane/metadata_proxy_metrics.go
+++ b/controlplane/metadata_proxy_metrics.go
@@ -1,0 +1,154 @@
+package controlplane
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	metadataProxyOutcomeSuccess               = "success"
+	metadataProxyOutcomeUnavailable           = "unavailable"
+	metadataProxyOutcomeInvalidDatabase       = "invalid_database"
+	metadataProxyOutcomeAuthFailed            = "auth_failed"
+	metadataProxyOutcomeDraining              = "draining"
+	metadataProxyOutcomeCapacity              = "capacity"
+	metadataProxyOutcomeTargetResolutionError = "target_resolution_error"
+	metadataProxyOutcomeUpstreamConnectError  = "upstream_connect_error"
+	metadataProxyOutcomeUpstreamSyncError     = "upstream_sync_error"
+	metadataProxyOutcomeUpstreamHijackError   = "upstream_hijack_error"
+	metadataProxyOutcomeCancelKeyError        = "cancel_key_error"
+	metadataProxyOutcomeHandshakeError        = "handshake_error"
+
+	metadataProxyUpstreamOutcomeSuccess = "success"
+	metadataProxyUpstreamOutcomeError   = "error"
+
+	metadataProxyDirectionClientToUpstream = "client_to_upstream"
+	metadataProxyDirectionUpstreamToClient = "upstream_to_client"
+
+	metadataProxyCancelOutcomeSessionTerminated = "session_terminated"
+	metadataProxyCancelOutcomeNotLocal          = "not_local"
+)
+
+// Metadata proxy metrics use a distinct namespace rather than adding a
+// protocol label to established Duckgres metric families. In particular,
+// duckgres_connections_open intentionally remains the process-wide count of
+// every accepted client socket (including metadata proxy sockets), while the
+// metrics below isolate the early proxy branch without changing existing
+// dashboards or alerts. The org label is bounded by configured tenants and all
+// outcome/direction values are closed enums defined above.
+var (
+	metadataProxyConnectionsOpenGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "duckgres_metadata_proxy_connections_open",
+		Help: "Current admitted native metadata Postgres proxy connections, including upstream bootstrap, partitioned by org.",
+	}, []string{"org"})
+
+	metadataProxyConnectionAttemptsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_metadata_proxy_connection_attempts_total",
+		Help: "Metadata proxy connection attempts partitioned by org and bounded terminal outcome.",
+	}, []string{"org", "outcome"})
+
+	metadataProxyConnectionDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "duckgres_metadata_proxy_connection_duration_seconds",
+		Help:    "Lifetime of admitted metadata proxy connections, including upstream bootstrap, partitioned by org.",
+		Buckets: []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 18000, 36000, 86400},
+	}, []string{"org"})
+
+	metadataProxyUpstreamConnectDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "duckgres_metadata_proxy_upstream_connect_duration_seconds",
+		Help:    "Time to connect and authenticate to the internal metadata Postgres target, partitioned by org and bounded outcome.",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{"org", "outcome"})
+
+	metadataProxyBytesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_metadata_proxy_bytes_total",
+		Help: "Post-authentication pgwire bytes relayed by the metadata proxy, partitioned by org and bounded direction.",
+	}, []string{"org", "direction"})
+
+	metadataProxyCancelRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_metadata_proxy_cancel_requests_total",
+		Help: "Metadata proxy CancelRequest handling partitioned by bounded outcome (session_terminated or not_local).",
+	}, []string{"outcome"})
+)
+
+type metadataProxyAttemptMetrics struct {
+	mu       sync.Mutex
+	org      string
+	finished bool
+}
+
+func newMetadataProxyAttemptMetrics() *metadataProxyAttemptMetrics {
+	return &metadataProxyAttemptMetrics{}
+}
+
+func (m *metadataProxyAttemptMetrics) SetOrg(org string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if !m.finished {
+		m.org = org
+	}
+	m.mu.Unlock()
+}
+
+// Finish records exactly one terminal attempt outcome even when a caller has a
+// fallback defer and an explicit success path.
+func (m *metadataProxyAttemptMetrics) Finish(outcome string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.finished {
+		m.mu.Unlock()
+		return
+	}
+	m.finished = true
+	org := m.org
+	m.mu.Unlock()
+	metadataProxyConnectionAttemptsCounter.WithLabelValues(org, outcome).Inc()
+}
+
+func beginMetadataProxyConnection(org string) func() {
+	started := time.Now()
+	metadataProxyConnectionsOpenGauge.WithLabelValues(org).Inc()
+	return func() {
+		metadataProxyConnectionsOpenGauge.WithLabelValues(org).Dec()
+		duration := time.Since(started)
+		if duration < 0 {
+			duration = 0
+		}
+		metadataProxyConnectionDurationHistogram.WithLabelValues(org).Observe(duration.Seconds())
+	}
+}
+
+func observeMetadataProxyUpstreamConnect(org, outcome string, started time.Time) {
+	duration := time.Since(started)
+	if duration < 0 {
+		duration = 0
+	}
+	metadataProxyUpstreamConnectDurationHistogram.WithLabelValues(org, outcome).Observe(duration.Seconds())
+}
+
+type metadataProxyCountingWriter struct {
+	dst     io.Writer
+	counter prometheus.Counter
+}
+
+func (w metadataProxyCountingWriter) Write(p []byte) (int, error) {
+	n, err := w.dst.Write(p)
+	if n > 0 {
+		w.counter.Add(float64(n))
+	}
+	return n, err
+}
+
+func metadataProxyTrafficWriter(dst io.Writer, org, direction string) io.Writer {
+	return metadataProxyCountingWriter{
+		dst:     dst,
+		counter: metadataProxyBytesCounter.WithLabelValues(org, direction),
+	}
+}

--- a/controlplane/metadata_proxy_test.go
+++ b/controlplane/metadata_proxy_test.go
@@ -1,0 +1,633 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/posthog/duckgres/server"
+)
+
+type metadataProxyTestStore struct {
+	*fakeConfigStore
+	orgID         string
+	enabled       bool
+	authenticated bool
+	resolveCalls  int
+	gotPrefix     string
+	gotUsername   string
+	gotPassword   string
+}
+
+func (s *metadataProxyTestStore) ResolveMetadataProxyConnection(prefix, username, password string) (string, bool, bool) {
+	s.resolveCalls++
+	s.gotPrefix = prefix
+	s.gotUsername = username
+	s.gotPassword = password
+	return s.orgID, s.enabled, s.authenticated
+}
+
+func (s *metadataProxyTestStore) MetadataProxySessionAllowed(string, string) bool {
+	return s.enabled && s.authenticated
+}
+
+type fakeMetadataPostgresConn struct {
+	hijacked   *pgconn.HijackedConn
+	onSyncConn func(context.Context)
+}
+
+func (c *fakeMetadataPostgresConn) SyncConn(ctx context.Context) error {
+	if c.onSyncConn != nil {
+		c.onSyncConn(ctx)
+	}
+	return nil
+}
+func (c *fakeMetadataPostgresConn) Hijack() (*pgconn.HijackedConn, error) {
+	return c.hijacked, nil
+}
+func (c *fakeMetadataPostgresConn) Close(context.Context) error {
+	return c.hijacked.Conn.Close()
+}
+
+func TestMetadataProxyRequiresExactVirtualDatabase(t *testing.T) {
+	for _, database := range []string{"", "ducklake", "other"} {
+		t.Run(database, func(t *testing.T) {
+			store := &metadataProxyTestStore{
+				fakeConfigStore: &fakeConfigStore{},
+				orgID:           "org-a",
+				enabled:         true,
+				authenticated:   true,
+			}
+			cp := &ControlPlane{
+				cfg:         ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+				configStore: store,
+				metadataPostgresURL: func(context.Context, string) (string, error) {
+					return "", nil
+				},
+			}
+			serverConn, clientConn := net.Pipe()
+			defer serverConn.Close()
+			defer clientConn.Close()
+			var output strings.Builder
+			if !cp.tryMetadataProxy(context.Background(), serverConn, bufio.NewReader(serverConn),
+				bufio.NewWriter(&output), "org-a.md.us.postwh.com", "root", database, "secret") {
+				t.Fatal("metadata hostname must be handled, not fall through")
+			}
+			if !strings.Contains(output.String(), `connect with dbname="metadata"`) {
+				t.Fatalf("response %q does not contain strict database hint", output.String())
+			}
+			if !strings.Contains(output.String(), "3D000") {
+				t.Fatalf("response %q does not contain invalid-database SQLSTATE", output.String())
+			}
+		})
+	}
+}
+
+func TestMetadataProxyDisabledOrgFailsClosed(t *testing.T) {
+	store := &metadataProxyTestStore{
+		fakeConfigStore: &fakeConfigStore{},
+		orgID:           "",
+		enabled:         false,
+	}
+	resolverCalled := false
+	cp := &ControlPlane{
+		cfg:         ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+		configStore: store,
+		metadataPostgresURL: func(context.Context, string) (string, error) {
+			resolverCalled = true
+			return "", nil
+		},
+	}
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+	var output strings.Builder
+	if !cp.tryMetadataProxy(context.Background(), serverConn, bufio.NewReader(serverConn),
+		bufio.NewWriter(&output), "org-a.md.us.postwh.com", "root", "metadata", "secret") {
+		t.Fatal("disabled metadata hostname must be denied, not fall through")
+	}
+	if !strings.Contains(output.String(), "metadata endpoint is unavailable") {
+		t.Fatalf("response %q does not contain generic denial", output.String())
+	}
+	if store.resolveCalls != 1 {
+		t.Fatalf("expected one atomic metadata resolution, got %d", store.resolveCalls)
+	}
+	if resolverCalled {
+		t.Fatal("disabled org must not reach the internal metadata resolver")
+	}
+}
+
+func TestMetadataProxyAuthenticatesBeforeResolvingInternalCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		username      string
+		authenticated bool
+		draining      bool
+		wantResolver  bool
+		wantSQLState  string
+		wantOutcome   string
+	}{
+		{name: "wrong password", username: "root", authenticated: false, wantSQLState: "28P01", wantOutcome: metadataProxyOutcomeAuthFailed},
+		{name: "non-root user", username: "reader", authenticated: true, wantSQLState: "28P01", wantOutcome: metadataProxyOutcomeAuthFailed},
+		{name: "draining", username: "root", authenticated: true, draining: true, wantSQLState: "57P03", wantOutcome: metadataProxyOutcomeDraining},
+		{name: "valid root", username: "root", authenticated: true, wantResolver: true, wantOutcome: metadataProxyOutcomeTargetResolutionError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &metadataProxyTestStore{
+				fakeConfigStore: &fakeConfigStore{},
+				orgID:           "org-a",
+				enabled:         true,
+				authenticated:   tc.authenticated,
+			}
+			resolverCalled := false
+			cp := &ControlPlane{
+				cfg:              ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+				configStore:      store,
+				metadataSessions: newMetadataProxySessionRegistry(2),
+				metadataPostgresURL: func(_ context.Context, orgID string) (string, error) {
+					resolverCalled = true
+					if orgID != "org-a" {
+						t.Fatalf("internal resolver org = %q, want org-a", orgID)
+					}
+					return "", errors.New("stop before dialing")
+				},
+			}
+			cp.sessionDraining.Store(tc.draining)
+			outcomeBefore := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, "org-a", tc.wantOutcome)
+			serverConn, clientConn := net.Pipe()
+			defer serverConn.Close()
+			defer clientConn.Close()
+			var output strings.Builder
+			if !cp.tryMetadataProxy(context.Background(), serverConn, bufio.NewReader(serverConn),
+				bufio.NewWriter(&output), "alias.md.us.postwh.com", tc.username, "metadata", "secret") {
+				t.Fatal("metadata hostname must be handled")
+			}
+			if resolverCalled != tc.wantResolver {
+				t.Fatalf("internal resolver called = %v, want %v", resolverCalled, tc.wantResolver)
+			}
+			if store.gotPrefix != "alias" || store.gotUsername != tc.username || store.gotPassword != "secret" {
+				t.Fatalf("atomic auth got (%q, %q, %q)", store.gotPrefix, store.gotUsername, store.gotPassword)
+			}
+			if tc.wantSQLState != "" && !strings.Contains(output.String(), tc.wantSQLState) {
+				t.Fatalf("response %q does not contain SQLSTATE %s", output.String(), tc.wantSQLState)
+			}
+			if got := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, "org-a", tc.wantOutcome); got != outcomeBefore+1 {
+				t.Fatalf("metadata proxy outcome %q = %v, want %v", tc.wantOutcome, got, outcomeBefore+1)
+			}
+		})
+	}
+}
+
+func TestMetadataProxyConnectionLimitRecordsCapacityOutcome(t *testing.T) {
+	const orgID = "org-a"
+	store := &metadataProxyTestStore{
+		fakeConfigStore: &fakeConfigStore{},
+		orgID:           orgID,
+		enabled:         true,
+		authenticated:   true,
+	}
+	registry := newMetadataProxySessionRegistry(1)
+	occupiedServer, occupiedClient := net.Pipe()
+	defer occupiedServer.Close()
+	defer occupiedClient.Close()
+	releaseOccupied, admitted := registry.Register(orgID, "root", occupiedServer)
+	if !admitted {
+		t.Fatal("failed to reserve the test org's only metadata proxy slot")
+	}
+	defer releaseOccupied()
+
+	resolverCalled := false
+	cp := &ControlPlane{
+		cfg:              ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+		configStore:      store,
+		metadataSessions: registry,
+		metadataPostgresURL: func(context.Context, string) (string, error) {
+			resolverCalled = true
+			return "", nil
+		},
+	}
+	outcomeBefore := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, orgID, metadataProxyOutcomeCapacity)
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+	var output strings.Builder
+	if !cp.tryMetadataProxy(context.Background(), serverConn, bufio.NewReader(serverConn),
+		bufio.NewWriter(&output), "alias.md.us.postwh.com", "root", "metadata", "secret") {
+		t.Fatal("metadata hostname must be handled")
+	}
+	if resolverCalled {
+		t.Fatal("capacity rejection must happen before resolving internal credentials")
+	}
+	if !strings.Contains(output.String(), "53300") {
+		t.Fatalf("response %q does not contain too-many-connections SQLSTATE", output.String())
+	}
+	if got := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, orgID, metadataProxyOutcomeCapacity); got != outcomeBefore+1 {
+		t.Fatalf("metadata proxy capacity outcome = %v, want %v", got, outcomeBefore+1)
+	}
+}
+
+func TestMetadataProxyRelaysAuthenticatedSession(t *testing.T) {
+	const orgID = "org-a"
+	openBefore := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID)
+	successBefore := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, orgID, metadataProxyOutcomeSuccess)
+	durationBefore := histogramVecLabelSampleCount(t, metadataProxyConnectionDurationHistogram, orgID)
+	connectBefore := histogramVecLabelSampleCount(t, metadataProxyUpstreamConnectDurationHistogram, orgID, metadataProxyUpstreamOutcomeSuccess)
+	clientBytesBefore := counterVecLabelValue(t, metadataProxyBytesCounter, orgID, metadataProxyDirectionClientToUpstream)
+	upstreamBytesBefore := counterVecLabelValue(t, metadataProxyBytesCounter, orgID, metadataProxyDirectionUpstreamToClient)
+
+	store := &metadataProxyTestStore{
+		fakeConfigStore: &fakeConfigStore{},
+		orgID:           orgID,
+		enabled:         true,
+		authenticated:   true,
+	}
+	upstreamProxy, upstreamServer := net.Pipe()
+	defer upstreamServer.Close()
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(i + 1)
+	}
+	fakeUpstream := &fakeMetadataPostgresConn{
+		hijacked: &pgconn.HijackedConn{
+			Conn:              upstreamProxy,
+			PID:               42,
+			SecretKey:         secret,
+			ParameterStatuses: map[string]string{"server_version": "18.3"},
+			TxStatus:          'I',
+			Config: &pgconn.Config{DialFunc: func(context.Context, string, string) (net.Conn, error) {
+				return nil, errors.New("cancel dial is not used in this test")
+			}},
+		},
+		onSyncConn: func(ctx context.Context) {
+			assertMetadataProxyBootstrapDeadline(t, ctx)
+		},
+	}
+	var upstreamConnectURL string
+	cp := &ControlPlane{
+		cfg:              ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+		configStore:      store,
+		metadataSessions: newMetadataProxySessionRegistry(2),
+		metadataPostgresURL: func(ctx context.Context, orgID string) (string, error) {
+			assertMetadataProxyBootstrapDeadline(t, ctx)
+			if orgID != "org-a" {
+				t.Fatalf("internal resolver org = %q, want org-a", orgID)
+			}
+			return "postgres://metadata_user:secret@internal/warehouse?sslmode=disable", nil
+		},
+		metadataPostgresConnect: func(ctx context.Context, upstreamURL string) (metadataPostgresConn, error) {
+			assertMetadataProxyBootstrapDeadline(t, ctx)
+			upstreamConnectURL = upstreamURL
+			return fakeUpstream, nil
+		},
+	}
+
+	proxySide, clientSide := net.Pipe()
+	defer clientSide.Close()
+	_ = clientSide.SetDeadline(time.Now().Add(3 * time.Second))
+	done := make(chan bool, 1)
+	go func() {
+		defer proxySide.Close()
+		done <- cp.tryMetadataProxy(context.Background(), proxySide, bufio.NewReader(proxySide),
+			bufio.NewWriter(proxySide), "alias.md.us.postwh.com", "root", "metadata", "secret")
+	}()
+
+	frontend := pgproto3.NewFrontend(clientSide, clientSide)
+	var sawAuthOK, sawParameter, sawLegacyKey bool
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatalf("receive proxy handshake: %v", err)
+		}
+		switch msg := msg.(type) {
+		case *pgproto3.AuthenticationOk:
+			sawAuthOK = true
+		case *pgproto3.ParameterStatus:
+			if msg.Name == "server_version" && msg.Value == "18.3" {
+				sawParameter = true
+			}
+		case *pgproto3.BackendKeyData:
+			sawLegacyKey = len(msg.SecretKey) == 4 &&
+				msg.ProcessID >= 0x40000000 && msg.ProcessID < 0x80000000
+		case *pgproto3.ReadyForQuery:
+			if !sawAuthOK || !sawParameter || !sawLegacyKey || msg.TxStatus != 'I' {
+				t.Fatalf("incomplete proxy handshake: auth=%v parameter=%v legacy_key=%v tx=%q",
+					sawAuthOK, sawParameter, sawLegacyKey, msg.TxStatus)
+			}
+			goto relay
+		}
+	}
+
+relay:
+	if got := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID); got != openBefore+1 {
+		t.Fatalf("metadata proxy open connections = %v, want %v", got, openBefore+1)
+	}
+	upstreamConfig, err := pgconn.ParseConfig(upstreamConnectURL)
+	if err != nil {
+		t.Fatalf("parse tagged upstream URL: %v", err)
+	}
+	if got := upstreamConfig.RuntimeParams["application_name"]; got != metadataProxyUpstreamApplicationName {
+		t.Fatalf("upstream application_name = %q, want %q", got, metadataProxyUpstreamApplicationName)
+	}
+
+	clientPayload := []byte("frontend-to-upstream")
+	clientWrite := make(chan error, 1)
+	go func() {
+		_, err := clientSide.Write(clientPayload)
+		clientWrite <- err
+	}()
+	gotClientPayload := make([]byte, len(clientPayload))
+	if _, err := io.ReadFull(upstreamServer, gotClientPayload); err != nil {
+		t.Fatalf("read client payload upstream: %v", err)
+	}
+	if err := <-clientWrite; err != nil {
+		t.Fatalf("write client payload: %v", err)
+	}
+	if string(gotClientPayload) != string(clientPayload) {
+		t.Fatalf("upstream payload = %q, want %q", gotClientPayload, clientPayload)
+	}
+
+	upstreamPayload := []byte("upstream-to-frontend")
+	upstreamWrite := make(chan error, 1)
+	go func() {
+		_, err := upstreamServer.Write(upstreamPayload)
+		upstreamWrite <- err
+	}()
+	gotUpstreamPayload := make([]byte, len(upstreamPayload))
+	if _, err := io.ReadFull(clientSide, gotUpstreamPayload); err != nil {
+		t.Fatalf("read upstream payload from proxy: %v", err)
+	}
+	if err := <-upstreamWrite; err != nil {
+		t.Fatalf("write upstream payload: %v", err)
+	}
+	if string(gotUpstreamPayload) != string(upstreamPayload) {
+		t.Fatalf("frontend payload = %q, want %q", gotUpstreamPayload, upstreamPayload)
+	}
+
+	_ = clientSide.Close()
+	select {
+	case handled := <-done:
+		if !handled {
+			t.Fatal("metadata session unexpectedly fell through")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("metadata proxy did not stop after the client closed")
+	}
+
+	if got := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID); got != openBefore {
+		t.Fatalf("metadata proxy open connections after close = %v, want %v", got, openBefore)
+	}
+	if got := counterVecLabelValue(t, metadataProxyConnectionAttemptsCounter, orgID, metadataProxyOutcomeSuccess); got != successBefore+1 {
+		t.Fatalf("successful metadata proxy attempts = %v, want %v", got, successBefore+1)
+	}
+	if got := histogramVecLabelSampleCount(t, metadataProxyConnectionDurationHistogram, orgID); got != durationBefore+1 {
+		t.Fatalf("metadata proxy duration samples = %v, want %v", got, durationBefore+1)
+	}
+	if got := histogramVecLabelSampleCount(t, metadataProxyUpstreamConnectDurationHistogram, orgID, metadataProxyUpstreamOutcomeSuccess); got != connectBefore+1 {
+		t.Fatalf("metadata proxy upstream connect samples = %v, want %v", got, connectBefore+1)
+	}
+	if got := counterVecLabelValue(t, metadataProxyBytesCounter, orgID, metadataProxyDirectionClientToUpstream); got != clientBytesBefore+float64(len(clientPayload)) {
+		t.Fatalf("metadata proxy client bytes = %v, want %v", got, clientBytesBefore+float64(len(clientPayload)))
+	}
+	if got := counterVecLabelValue(t, metadataProxyBytesCounter, orgID, metadataProxyDirectionUpstreamToClient); got != upstreamBytesBefore+float64(len(upstreamPayload)) {
+		t.Fatalf("metadata proxy upstream bytes = %v, want %v", got, upstreamBytesBefore+float64(len(upstreamPayload)))
+	}
+}
+
+func TestHandleConnectionMetadataProxyKeepsGlobalAndWorkerMetricsDistinct(t *testing.T) {
+	const orgID = "metadata-metrics-org"
+	globalBefore := metricGaugeValue(t, "duckgres_connections_open")
+	proxyBefore := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID)
+	workerAcceptedBefore := counterVecLabelValue(t, orgPgSessionsAcceptedCounter, orgID, "false")
+
+	store := &metadataProxyTestStore{
+		fakeConfigStore: &fakeConfigStore{},
+		orgID:           orgID,
+		enabled:         true,
+		authenticated:   true,
+	}
+	upstreamProxy, upstreamServer := net.Pipe()
+	fakeUpstream := &fakeMetadataPostgresConn{hijacked: &pgconn.HijackedConn{
+		Conn:              upstreamProxy,
+		PID:               42,
+		SecretKey:         []byte{1, 2, 3, 4},
+		ParameterStatuses: map[string]string{"server_version": "18.3"},
+		TxStatus:          'I',
+		Config: &pgconn.Config{DialFunc: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("cancel dial is not used in this test")
+		}},
+	}}
+	var upstreamConnectURL string
+	cp := &ControlPlane{
+		cfg:                 ControlPlaneConfig{MetadataHostnameSuffixes: []string{".md.us.postwh.com"}},
+		tlsConfig:           testControlPlaneTLSConfig(t),
+		configStore:         store,
+		metadataSessions:    newMetadataProxySessionRegistry(2),
+		metadataPostgresURL: func(context.Context, string) (string, error) { return "postgres://internal/metadata", nil },
+		metadataPostgresConnect: func(_ context.Context, upstreamURL string) (metadataPostgresConn, error) {
+			upstreamConnectURL = upstreamURL
+			return fakeUpstream, nil
+		},
+	}
+
+	cfg, err := pgconn.ParseConfig("postgres://root:secret@127.0.0.1/metadata?sslmode=require&application_name=customer-controlled")
+	if err != nil {
+		t.Fatalf("parse frontend config: %v", err)
+	}
+	cfg.TLSConfig = testMetadataProxyClientTLSConfig()
+	clientClosed := make(chan struct{})
+	cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+		client, serverConn := net.Pipe()
+		go func() {
+			cp.handleConnection(serverConn)
+			close(clientClosed)
+		}()
+		return client, nil
+	}
+
+	conn, err := pgconn.ConnectConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("connect through metadata proxy: %v", err)
+	}
+	if got := metricGaugeValue(t, "duckgres_connections_open"); got != globalBefore+1 {
+		t.Fatalf("global open connections = %v, want %v", got, globalBefore+1)
+	}
+	if got := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID); got != proxyBefore+1 {
+		t.Fatalf("metadata proxy open connections = %v, want %v", got, proxyBefore+1)
+	}
+	if got := counterVecLabelValue(t, orgPgSessionsAcceptedCounter, orgID, "false"); got != workerAcceptedBefore {
+		t.Fatalf("worker-backed accepted sessions changed for metadata proxy: got %v, want %v", got, workerAcceptedBefore)
+	}
+	upstreamConfig, err := pgconn.ParseConfig(upstreamConnectURL)
+	if err != nil {
+		t.Fatalf("parse internally tagged upstream URL: %v", err)
+	}
+	if got := upstreamConfig.RuntimeParams["application_name"]; got != metadataProxyUpstreamApplicationName {
+		t.Fatalf("client application_name reached upstream: got %q, want fixed %q", got, metadataProxyUpstreamApplicationName)
+	}
+
+	frontendHijacked, err := conn.Hijack()
+	if err != nil {
+		t.Fatalf("hijack frontend test connection: %v", err)
+	}
+	_ = frontendHijacked.Conn.Close()
+	_ = upstreamServer.Close()
+	select {
+	case <-clientClosed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("control-plane metadata connection did not close")
+	}
+	if got := metricGaugeValue(t, "duckgres_connections_open"); got != globalBefore {
+		t.Fatalf("global open connections after close = %v, want %v", got, globalBefore)
+	}
+	if got := gaugeVecLabelValue(t, metadataProxyConnectionsOpenGauge, orgID); got != proxyBefore {
+		t.Fatalf("metadata proxy open connections after close = %v, want %v", got, proxyBefore)
+	}
+}
+
+func testMetadataProxyClientTLSConfig() *tls.Config {
+	return &tls.Config{
+		ServerName:         "alias.md.us.postwh.com",
+		InsecureSkipVerify: true,
+	}
+}
+
+func assertMetadataProxyBootstrapDeadline(t *testing.T, ctx context.Context) {
+	t.Helper()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("metadata proxy bootstrap context has no deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > metadataProxyBootstrapTimeout {
+		t.Fatalf("metadata proxy bootstrap deadline remaining = %s, want (0, %s]", remaining, metadataProxyBootstrapTimeout)
+	}
+}
+
+func TestMetadataProxySafeConnectErrorNeverLogsInjectedDSN(t *testing.T) {
+	const secret = "metadata-password-must-not-appear"
+	got := metadataProxySafeConnectError(errors.New("postgres://internal_user:" + secret + "@metadata.internal/db"))
+	if strings.Contains(got, secret) || strings.Contains(got, "postgres://") {
+		t.Fatalf("safe connect error leaked the injected DSN: %q", got)
+	}
+
+	parseErr := pgconn.NewParseConfigError(
+		"postgres://internal_user:"+secret+"@metadata.internal/db",
+		"test parse failure",
+		nil,
+	)
+	if got := metadataProxySafeConnectError(parseErr); strings.Contains(got, secret) {
+		t.Fatalf("safe pgconn parse error leaked password: %q", got)
+	}
+}
+
+func TestMetadataProxySessionRegistryCapsAndKillsByUser(t *testing.T) {
+	registry := newMetadataProxySessionRegistry(1)
+	serverA, clientA := net.Pipe()
+	defer clientA.Close()
+	releaseA, ok := registry.Register("org-a", "root", serverA)
+	if !ok {
+		t.Fatal("first org session should be admitted")
+	}
+	defer releaseA()
+
+	serverB, clientB := net.Pipe()
+	defer serverB.Close()
+	defer clientB.Close()
+	if _, ok := registry.Register("org-a", "root", serverB); ok {
+		t.Fatal("second session for capped org should be rejected")
+	}
+
+	serverOther, clientOther := net.Pipe()
+	defer serverOther.Close()
+	defer clientOther.Close()
+	releaseOther, ok := registry.Register("org-b", "root", serverOther)
+	if !ok {
+		t.Fatal("cap must be scoped per org")
+	}
+	defer releaseOther()
+
+	if killed := registry.KillUser("org-a", "root"); killed != 1 {
+		t.Fatalf("killed = %d, want 1", killed)
+	}
+	_ = clientA.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := clientA.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Fatalf("killed connection read error = %v, want EOF", err)
+	}
+	serverAfterKill, clientAfterKill := net.Pipe()
+	defer clientAfterKill.Close()
+	releaseAfterKill, ok := registry.Register("org-a", "root", serverAfterKill)
+	if !ok {
+		t.Fatal("per-user kill must not close future metadata admission")
+	}
+	defer releaseAfterKill()
+
+	if killed := registry.KillAll(); killed != 2 {
+		t.Fatalf("drain killed = %d, want org-a and org-b sessions", killed)
+	}
+	serverAfterDrain, clientAfterDrain := net.Pipe()
+	defer serverAfterDrain.Close()
+	defer clientAfterDrain.Close()
+	if _, ok := registry.Register("org-a", "root", serverAfterDrain); ok {
+		t.Fatal("drained metadata registry must reject new sessions")
+	}
+}
+
+func TestForwardMetadataCancelClosesExactSessionConnections(t *testing.T) {
+	cp := &ControlPlane{}
+	frontendKey := server.BackendKey{Pid: 0x40000123, SecretKey: 456}
+	terminatedBefore := counterVecLabelValue(
+		t,
+		metadataProxyCancelRequestsCounter,
+		metadataProxyCancelOutcomeSessionTerminated,
+	)
+	notLocalBefore := counterVecLabelValue(
+		t,
+		metadataProxyCancelRequestsCounter,
+		metadataProxyCancelOutcomeNotLocal,
+	)
+	frontend, frontendPeer := net.Pipe()
+	defer frontendPeer.Close()
+	upstream, upstreamPeer := net.Pipe()
+	defer upstreamPeer.Close()
+	cp.proxyCancels.Store(frontendKey, metadataProxyCancelTarget{
+		frontend: frontend,
+		upstream: upstream,
+	})
+	defer cp.proxyCancels.Delete(frontendKey)
+
+	if !cp.forwardMetadataCancel(frontendKey) {
+		t.Fatal("known proxy key should be handled")
+	}
+	for name, peer := range map[string]net.Conn{
+		"frontend": frontendPeer,
+		"upstream": upstreamPeer,
+	} {
+		var oneByte [1]byte
+		if _, err := peer.Read(oneByte[:]); !errors.Is(err, io.EOF) {
+			t.Fatalf("%s peer read error = %v, want EOF from exact connection close", name, err)
+		}
+	}
+	if got := counterVecLabelValue(t, metadataProxyCancelRequestsCounter, metadataProxyCancelOutcomeSessionTerminated); got != terminatedBefore+1 {
+		t.Fatalf("metadata proxy terminated cancel outcomes = %v, want %v", got, terminatedBefore+1)
+	}
+	nonLocalKey := server.BackendKey{Pid: 0x40000001, SecretKey: 789}
+	if !cp.forwardMetadataCancel(nonLocalKey) {
+		t.Fatal("unknown synthetic proxy key must be handled as non-local")
+	}
+	if got := counterVecLabelValue(t, metadataProxyCancelRequestsCounter, metadataProxyCancelOutcomeNotLocal); got != notLocalBefore+1 {
+		t.Fatalf("metadata proxy non-local cancel outcomes = %v, want %v", got, notLocalBefore+1)
+	}
+	if cp.forwardMetadataCancel(server.BackendKey{Pid: 1, SecretKey: 2}) {
+		t.Fatal("unknown key must fall through to the local cancel handler")
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -83,7 +83,20 @@ func (p catalogCopierProber) ProbeCNPG(ctx context.Context, shard string) error 
 // orgRouterAdapter wraps OrgRouter to implement both OrgRouterInterface
 // (for the control plane) and admin.OrgStackInfo (for the admin API).
 type orgRouterAdapter struct {
-	router *OrgRouter
+	router              *OrgRouter
+	metadataPostgresURL func(context.Context, string) (string, error)
+	metadataSessions    *metadataProxySessionRegistry
+}
+
+func (a *orgRouterAdapter) MetadataPostgresURL(ctx context.Context, orgID string) (string, error) {
+	if a.metadataPostgresURL == nil {
+		return "", fmt.Errorf("metadata Postgres resolver is not configured")
+	}
+	return a.metadataPostgresURL(ctx, orgID)
+}
+
+func (a *orgRouterAdapter) MetadataProxySessions() *metadataProxySessionRegistry {
+	return a.metadataSessions
 }
 
 // effectiveDefaultWorkerTTL resolves the janitor's hot-idle retention: the
@@ -113,10 +126,12 @@ func (a *orgRouterAdapter) IsMigratingForOrg(orgID string) bool {
 }
 
 func (a *orgRouterAdapter) BeginDrain() {
+	a.metadataSessions.KillAll()
 	a.router.BeginDrain()
 }
 
 func (a *orgRouterAdapter) ShutdownAll() {
+	a.metadataSessions.KillAll()
 	a.router.ShutdownAll()
 }
 
@@ -335,7 +350,8 @@ func SetupMultiTenant(
 		return nil, nil, nil, nil, nil, nil, err
 	}
 
-	adpt := &orgRouterAdapter{router: router}
+	metadataSessions := newMetadataProxySessionRegistry(cfg.MetadataProxyMaxConns)
+	adpt := &orgRouterAdapter{router: router, metadataSessions: metadataSessions}
 	runtimeTracker := NewControlPlaneRuntimeTracker(
 		store,
 		cpInstanceID,
@@ -468,6 +484,7 @@ func SetupMultiTenant(
 		},
 	)
 	if refreshActivator != nil {
+		adpt.metadataPostgresURL = refreshActivator.MetadataPostgresURL
 		refreshActivator.resolveDucklingStatus = resolveDucklingStatus
 	}
 
@@ -606,7 +623,13 @@ func SetupMultiTenant(
 		return nil, nil, nil, nil, nil, nil, fmt.Errorf("init admin audit store: %w", err)
 	}
 	metricsProxy := admin.NewMetricsProxy(os.Getenv("DUCKGRES_PROMETHEUS_URL"))
-	clusterInfo := &clusterInfoProvider{router: router, store: store, srv: srv, selfCPID: cpInstanceID}
+	clusterInfo := &clusterInfoProvider{
+		router:           router,
+		store:            store,
+		srv:              srv,
+		selfCPID:         cpInstanceID,
+		metadataSessions: metadataSessions,
+	}
 	imp := &impersonator{router: router}
 	// Cross-CP live-state aggregation: live sessions/queries are per-CP in
 	// memory, so a single replica only sees its own slice. The fetcher fans the

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -676,16 +676,17 @@ func orgName(org *configstore.OrgConfig) string {
 	return org.Name
 }
 
-// MetadataPostgresURL resolves a standard postgres:// URL for an org's
-// DuckLake metadata Postgres, for CP-side read-only queries (the storage
-// sampler — see storage_meter.go). Mirrors the resolution the worker
-// activation uses: prefer the Duckling CR (pgbouncer endpoint when present,
-// else the direct metadata endpoint), fall back to the config-store warehouse
-// shape. sslmode follows provisioner.ProbeMetadataStore's rules: "disable"
-// through the duckling's pgbouncer (plaintext worker↔pooler; the pooler
-// carries TLS to RDS), "require" against a direct RDS endpoint, "prefer" for
-// config-store warehouses (matches the DuckDB ATTACH default there).
-// Returns an error when the org has no DuckLake-enabled warehouse.
+// MetadataPostgresURL resolves a standard postgres:// URL for internal
+// control-plane callers of an org's DuckLake metadata Postgres (the storage
+// sampler and the explicitly enabled native metadata proxy). Mirrors the
+// resolution the worker activation uses: prefer the Duckling CR (pgbouncer
+// endpoint when present, else the direct metadata endpoint), fall back to the
+// config-store warehouse shape. sslmode follows
+// provisioner.ProbeMetadataStore's rules: "disable" through the duckling's
+// pgbouncer (plaintext worker↔pooler; the pooler carries TLS to RDS), "require"
+// against a direct RDS endpoint, "prefer" for config-store warehouses (matches
+// the DuckDB ATTACH default there). Returns an error when the org has no
+// DuckLake-enabled warehouse.
 func (a *SharedWorkerActivator) MetadataPostgresURL(ctx context.Context, orgID string) (string, error) {
 	if a.resolveDucklingStatus != nil {
 		status, err := a.resolveDucklingStatus(ctx, orgID)

--- a/controlplane/sni_kubernetes.go
+++ b/controlplane/sni_kubernetes.go
@@ -15,7 +15,15 @@ import "strings"
 // covers single-label prefixes, so a multi-label SNI ("evil.acme.dw...")
 // would have already failed TLS — but we keep the check as defense in depth.
 func (cp *ControlPlane) extractOrgFromSNI(sni string) (string, bool) {
-	for _, suffix := range cp.cfg.ManagedHostnameSuffixes {
+	return extractPrefixFromSNI(sni, cp.cfg.ManagedHostnameSuffixes)
+}
+
+func (cp *ControlPlane) extractMetadataOrgFromSNI(sni string) (string, bool) {
+	return extractPrefixFromSNI(sni, cp.cfg.MetadataHostnameSuffixes)
+}
+
+func extractPrefixFromSNI(sni string, suffixes []string) (string, bool) {
+	for _, suffix := range suffixes {
 		if !strings.HasSuffix(sni, suffix) {
 			continue
 		}

--- a/controlplane/sni_kubernetes_test.go
+++ b/controlplane/sni_kubernetes_test.go
@@ -58,6 +58,44 @@ func TestExtractOrgFromSNIEmptySuffixes(t *testing.T) {
 	}
 }
 
+func TestExtractMetadataOrgFromSNIAllManagedWarehouseEnvironments(t *testing.T) {
+	cp := &ControlPlane{
+		cfg: ControlPlaneConfig{
+			MetadataHostnameSuffixes: []string{
+				".md.dev.postwh.com",
+				".md.us.postwh.com",
+				".md.eu.postwh.com",
+			},
+		},
+	}
+
+	for _, hostname := range []string{
+		"acme.md.dev.postwh.com",
+		"acme.md.us.postwh.com",
+		"acme.md.eu.postwh.com",
+	} {
+		t.Run(hostname, func(t *testing.T) {
+			org, ok := cp.extractMetadataOrgFromSNI(hostname)
+			if !ok || org != "acme" {
+				t.Fatalf("extractMetadataOrgFromSNI(%q) = (%q, %v); want (\"acme\", true)", hostname, org, ok)
+			}
+		})
+	}
+
+	for _, hostname := range []string{
+		"acme.md.postwh.com",
+		"nested.acme.md.eu.postwh.com",
+		".md.dev.postwh.com",
+	} {
+		t.Run(hostname, func(t *testing.T) {
+			org, ok := cp.extractMetadataOrgFromSNI(hostname)
+			if ok || org != "" {
+				t.Fatalf("extractMetadataOrgFromSNI(%q) = (%q, %v); want (\"\", false)", hostname, org, ok)
+			}
+		})
+	}
+}
+
 func TestManagedHostnameHint(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/controlplane/sni_other.go
+++ b/controlplane/sni_other.go
@@ -10,3 +10,7 @@ package controlplane
 func (cp *ControlPlane) extractOrgFromSNI(_ string) (string, bool) {
 	return "", false
 }
+
+func (cp *ControlPlane) extractMetadataOrgFromSNI(_ string) (string, bool) {
+	return "", false
+}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,6 +22,8 @@ The request path uses these label terms consistently:
 - `reason`: a bounded, metric-specific cause. It is not a poll count.
 - `source`: how a worker was obtained.
 - `phase`: one internal worker-acquisition phase.
+- `direction`: a bounded byte-flow direction; the metadata proxy emits
+  `client_to_upstream` and `upstream_to_client`.
 
 Histograms expose the usual `_bucket`, `_count`, and `_sum` series.
 
@@ -35,10 +37,80 @@ Histograms expose the usual `_bucket`, `_count`, and `_sum` series.
 | Worker acquisition | `duckgres_worker_acquire_*` | After admission grants until an existing, hot-idle, or newly spawned worker is allocated. |
 | Session start | `duckgres_session_start_duration_seconds`, `duckgres_postgres_session_start_total` | After successful PostgreSQL authentication until `ReadyForQuery` is flushed or session bootstrap terminates. The counter records exactly one terminal result after server-side retries. |
 | Query | `duckgres_query_total`, `duckgres_query_duration_seconds` | One non-empty query attempt and its execution duration. |
+| Native metadata proxy | `duckgres_metadata_proxy_*` | The separate metadata SNI branch, from its fail-closed auth/gate through internal Postgres connect and opaque pgwire relay. |
 
 Session start includes profile resolution, admission, worker
 allocation, worker session creation, catalog probing, metadata initialization,
 session defaults, and the final ready flush. It excludes failed authentication.
+
+## Native metadata Postgres proxy metrics
+
+The native metadata proxy branches before worker allocation. It has dedicated
+metric families rather than adding a protocol label to established metrics:
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `duckgres_metadata_proxy_connections_open` | Gauge | `org` | Admitted proxy connections on this control-plane process, including upstream bootstrap. |
+| `duckgres_metadata_proxy_connection_attempts_total` | Counter | `org`, `outcome` | Exactly one terminal event per connection that matched a configured metadata SNI suffix. `success` is recorded when frontend `ReadyForQuery` is flushed. |
+| `duckgres_metadata_proxy_connection_duration_seconds` | Histogram | `org` | Lifetime from admission against the per-org proxy cap until teardown, including failed upstream bootstrap. |
+| `duckgres_metadata_proxy_upstream_connect_duration_seconds` | Histogram | `org`, `outcome` | Time spent connecting and authenticating to the internally resolved metadata Postgres target. Outcomes are `success` and `error`. |
+| `duckgres_metadata_proxy_bytes_total` | Counter | `org`, `direction` | Post-authentication pgwire bytes relayed in the fixed `client_to_upstream` or `upstream_to_client` direction. |
+| `duckgres_metadata_proxy_cancel_requests_total` | Counter | `outcome` | Raw proxy CancelRequests handled as `session_terminated` on the owning replica or `not_local` when the synthetic key is not registered on this replica. |
+
+Connection-attempt outcomes are the closed set `success`, `unavailable`,
+`invalid_database`, `auth_failed`, `draining`, `capacity`,
+`target_resolution_error`, `upstream_connect_error`, `upstream_sync_error`,
+`upstream_hijack_error`, `cancel_key_error`, and `handshake_error`. Unknown or
+disabled SNI prefixes use an empty `org` label so denial metrics do not invent
+tenant values.
+
+The open gauge is process-local because the configured safety cap is enforced
+per org on each replica. Use `sum by (org)` for fleet totals and retain the
+scrape target's `pod` label when diagnosing one replica at its cap. Counters
+and histograms can be summed across replicas normally.
+
+`duckgres_connections_open` is incremented before the SNI branch and therefore
+includes metadata proxy sockets. Existing worker-path metrics intentionally do
+not: `duckgres_connection_duration_seconds`,
+`duckgres_org_sessions_active`, `duckgres_org_pg_sessions_accepted_total`,
+admission/worker metrics, query metrics, durable query logs, and query traces
+remain DuckDB-worker-only. The relay is byte-opaque and cannot safely produce
+statement-level observations. Use the proxy connection/byte metrics together
+with CNPG and PgBouncer metrics for this path.
+
+Two process-wide security metrics also span the branch boundary.
+`duckgres_auth_failures_total` includes wrong-password metadata-proxy attempts;
+use
+`duckgres_metadata_proxy_connection_attempts_total{outcome="auth_failed"}` for
+the proxy-specific subset. `duckgres_rate_limit_rejects_total` is incremented
+for pre-TLS rate-limit rejections, before SNI is available, so those rejected
+sockets cannot be attributed to either the metadata endpoint or the DuckDB
+worker endpoint.
+
+The internal upstream session starts with the fixed
+`application_name=duckgres-metadata-proxy`, rather than forwarding the
+client-controlled application name, so it can be distinguished from DuckDB
+`postgres_scanner` sessions in `pg_stat_activity`. A client with full metadata
+database access can change its application name later, so this is operational
+attribution, not an authorization control. Upstream availability does not feed
+the control-plane health endpoint: one org's shard must not remove healthy
+control-plane pods from service. Target resolution and upstream
+connect/auth/synchronization share a 10-second bootstrap deadline; established
+relay traffic has no inherited bootstrap deadline. An admin warehouse update
+that includes `metadata_proxy_enabled` reloads the local snapshot and fans a
+reload out to peer replicas. Established sessions observe a disabled gate on
+their next five-second authorization recheck after that snapshot reaches the
+replica.
+
+Metadata-proxy cancellation intentionally closes the whole session, not only
+the in-flight statement. On a matching synthetic backend key, the owning
+control-plane replica closes the exact established frontend and upstream
+connections. It does not redial the PgBouncer Service because cancellation
+keys are local to the PgBouncer instance that accepted the session. A raw
+PostgreSQL `CancelRequest` uses a new TCP connection and the NLB can route it to
+a different control-plane replica, matching the existing control-plane
+locality constraint. Such a high-range synthetic-key miss is absorbed and
+counted with `outcome="not_local"`; the owning session remains active.
 
 ## Admission metrics
 
@@ -174,6 +246,31 @@ histogram_quantile(
   sum by (org, protocol, outcome, le) (
     rate(duckgres_session_start_duration_seconds_bucket[5m])
   )
+)
+```
+
+Current metadata proxy connections by org and control-plane pod:
+
+```promql
+sum by (org, pod) (duckgres_metadata_proxy_connections_open)
+```
+
+Metadata proxy target-phase failure ratio:
+
+```promql
+sum by (org) (
+  rate(duckgres_metadata_proxy_connection_attempts_total{
+    outcome=~"target_resolution_error|upstream_(connect|sync|hijack)_error|cancel_key_error"
+  }[5m])
+)
+/
+clamp_min(
+  sum by (org) (
+    rate(duckgres_metadata_proxy_connection_attempts_total{
+      outcome=~"success|target_resolution_error|upstream_(connect|sync|hijack)_error|cancel_key_error"
+    }[5m])
+  ),
+  0.001
 )
 ```
 

--- a/main.go
+++ b/main.go
@@ -391,6 +391,8 @@ func main() {
 			UserSecretKey:              resolved.UserSecretKey,
 			SNIRoutingMode:             resolved.SNIRoutingMode,
 			ManagedHostnameSuffixes:    resolved.ManagedHostnameSuffixes,
+			MetadataHostnameSuffixes:   resolved.MetadataHostnameSuffixes,
+			MetadataProxyMaxConns:      resolved.MetadataProxyMaxConns,
 			DucklingBucketSuffix:       resolved.DucklingBucketSuffix,
 			DuckLakeDefaultSpecVersion: resolved.DuckLakeDefaultSpecVersion,
 

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -237,7 +237,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -51,7 +51,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 30)
 	requireGooseMigrationRecorded(t, db, 31)
 	requireGooseMigrationRecorded(t, db, 32)
-	requireGooseLatestVersion(t, db, 32)
+	requireGooseMigrationRecorded(t, db, 33)
+	requireGooseLatestVersion(t, db, 33)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -86,6 +87,10 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	} {
 		requireColumnPresent(t, db, "duckgres_reshard_operations", column)
 	}
+	// Migration 000033 added the fail-closed public metadata Postgres opt-in.
+	requireColumnPresent(t, db, "duckgres_managed_warehouses", "metadata_proxy_enabled")
+	requireColumnNotNull(t, db, "duckgres_managed_warehouses", "metadata_proxy_enabled")
+	requireColumnDefault(t, db, "duckgres_managed_warehouses", "metadata_proxy_enabled", "false")
 	requireTablePresent(t, db, "duckgres_reshard_operation_log")
 	requireColumnPresent(t, db, "duckgres_reshard_operation_log", "operation_id")
 
@@ -278,7 +283,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 30)
 	requireGooseMigrationRecorded(t, upgradedDB, 31)
 	requireGooseMigrationRecorded(t, upgradedDB, 32)
-	requireGooseLatestVersion(t, upgradedDB, 32)
+	requireGooseMigrationRecorded(t, upgradedDB, 33)
+	requireGooseLatestVersion(t, upgradedDB, 33)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
@@ -292,6 +298,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireUniqueIndex(t, upgradedDB, "duckgres_org_teams", "org_id,schema_name")
 	requireColumnAbsent(t, upgradedDB, "duckgres_orgs", "max_connections")
 	requireColumnAbsent(t, upgradedDB, "duckgres_managed_warehouses", "iceberg_enabled")
+	requireColumnDefault(t, upgradedDB, "duckgres_managed_warehouses", "metadata_proxy_enabled", "false")
 	requireColumnAbsent(t, upgradedDB, "duckgres_org_users", "default_catalog")
 }
 

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -96,6 +96,17 @@ client-go:
   backpressure was observed **and** handles it (queries retry through it).
 - **activation** — DuckLake catalogs attach, read/write, and run
   `EXPLAIN`/`EXPLAIN ANALYZE` on CNPG-backed tenants.
+- **native metadata Postgres proxy** — the Job reaches the actual proxy branch
+  over the control-plane ClusterIP while libpq sends a dedicated, non-resolving
+  TLS SNI name (`<org>.md.ci.duckgres.local`). It proves a ready CNPG org is
+  denied by default, enables only that org through the admin warehouse API,
+  initializes the DuckLake catalog once through the normal worker path, then
+  queries `public.ducklake_metadata` through the proxy and hidden per-tenant
+  CNPG credentials (the proxy query itself never uses a worker). It also checks
+  that both a normal Duckgres database and an explicitly empty startup database
+  are rejected (only exact
+  `dbname=metadata` is valid). A second ready org on the same shard remains
+  denied, then disabling the opted-in org blocks new connections again.
 - **binary COPY** — a `psql`-generated PostgreSQL binary fixture traverses the
   deployed pgwire → control-plane → Flight → worker → `postgres_scanner` →
   DuckLake path. It checks every natively routed scalar type, reordered/subset
@@ -194,6 +205,14 @@ normal `go test ./...` lane.
   stay distinguishable on real traffic, not just in unit fixtures.
 
 ### Deliberately not covered here
+
+- **Native metadata proxy denial for an external metadata-store org** — the
+  live suite intentionally provisions only CNPG-backed orgs and has no RDS
+  credential with which to create an external-store tenant. The backend-kind
+  gate is deterministic and covered by
+  `TestOrgMetadataProxyEnabledFailsClosed`; the live proxy check still proves
+  the independent access boundary by leaving a second ready tenant on the same
+  CNPG shard opted out.
 
 - **The query log on an EXTERNAL (RDS) metadata store** — the suite provisions
   only cnpg-shard orgs, so `query_log_round_trip` runs on cnpg alone. The

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -39,6 +39,11 @@
 #                  discards queued messages until Sync (#718). A same pgwire
 #                  session remains usable immediately after CancelRequest.
 #   activation   : DuckLake catalogs attach, read/write, and EXPLAIN/ANALYZE on cnpg.
+#   metadata pg  : the native TLS/SNI proxy is fail-closed until the warehouse
+#                  is explicitly opted in; only exact dbname=metadata passes,
+#                  and a real DuckLake metadata-table query reaches the hidden
+#                  per-tenant CNPG role/database. Another ready CNPG org stays
+#                  denied, proving enablement is per org rather than per shard.
 #   sizing       : a client-sized connection (duckgres.worker_cpu/memory/ttl)
 #                  spawns a worker pod carrying the requested CPU+memory, and a
 #                  same-shape reconnect reuses that hot-idle worker (no respawn)
@@ -217,6 +222,7 @@ wait_state() { # org target timeout_s
 # (.ci.duckgres.local) is CI-internal and never resolves in DNS — hostaddr is
 # what actually connects.
 SNI_SUFFIX=".ci.duckgres.local"
+METADATA_SNI_SUFFIX=".md.ci.duckgres.local"
 CP_IP=""
 resolve_cp_ip() {
   CP_IP="$(getent hosts "$PGHOST" | awk '{print $1}' | head -1)"
@@ -317,6 +323,180 @@ wait_worker() { # org password catalog
     attempt=$((attempt + 1))
   done
   fail "no Duckgres worker for $1/$3 after retries"
+}
+
+# ---- native metadata Postgres proxy ---------------------------------------
+# The metadata listener is the same CP pgwire port, selected by a distinct TLS
+# SNI suffix. `hostaddr` keeps the TCP destination on the ClusterIP while
+# `host` supplies the non-resolving SNI hostname, exactly like the DuckDB path.
+metadata_pg_try() { # org password dbname sql
+  PGPASSWORD="$2" psql \
+    "sslmode=require host=$1$METADATA_SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=$3 connect_timeout=10" \
+    -X -v ON_ERROR_STOP=1 -AtF '|' -c "$4" 2>&1
+}
+
+assert_metadata_proxy_denied() { # org password label
+  if out="$(metadata_pg_try "$1" "$2" metadata 'SELECT 1')"; then
+    fail "metadata proxy $3: disabled org $1 unexpectedly connected: $out"
+  fi
+  case "$out" in
+    *"metadata endpoint is unavailable"*) ;;
+    *) fail "metadata proxy $3: disabled org $1 failed for the wrong reason: $out" ;;
+  esac
+}
+
+# libpq treats an empty dbname as "use the default database", so it cannot prove
+# that an actually-empty StartupMessage value is rejected. Send the startup
+# packet directly after the PostgreSQL SSLRequest and cleartext-password
+# exchange. The proxy must answer 3D000 before any upstream connection.
+metadata_empty_database_try() { # org password
+  METADATA_PROXY_HOST="$1$METADATA_SNI_SUFFIX" \
+  METADATA_PROXY_ADDR="$CP_IP" \
+  METADATA_PROXY_PASSWORD="$2" \
+  python3 - <<'PY'
+import os
+import socket
+import ssl
+import struct
+import sys
+
+
+def recv_exact(conn, size):
+    data = b""
+    while len(data) < size:
+        chunk = conn.recv(size - len(data))
+        if not chunk:
+            raise RuntimeError("connection closed before a complete pgwire message")
+        data += chunk
+    return data
+
+
+def recv_message(conn):
+    kind = recv_exact(conn, 1)
+    length = struct.unpack("!I", recv_exact(conn, 4))[0]
+    if length < 4:
+        raise RuntimeError(f"invalid pgwire message length {length}")
+    return kind, recv_exact(conn, length - 4)
+
+
+host = os.environ["METADATA_PROXY_HOST"]
+address = os.environ["METADATA_PROXY_ADDR"]
+password = os.environ["METADATA_PROXY_PASSWORD"].encode()
+
+raw = socket.create_connection((address, 5432), timeout=10)
+raw.sendall(struct.pack("!II", 8, 80877103))
+if recv_exact(raw, 1) != b"S":
+    raise RuntimeError("control plane refused PostgreSQL TLS")
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+conn = ctx.wrap_socket(raw, server_hostname=host)
+
+database = ""
+params = (
+    b"user\0root\0"
+    + b"database\0"
+    + database.encode()
+    + b"\0application_name\0mw-dev-metadata-empty-db\0\0"
+)
+conn.sendall(struct.pack("!II", len(params) + 8, 196608) + params)
+
+kind, payload = recv_message(conn)
+if kind != b"R" or len(payload) < 4 or struct.unpack("!I", payload[:4])[0] != 3:
+    raise RuntimeError("control plane did not request a cleartext password")
+conn.sendall(b"p" + struct.pack("!I", len(password) + 5) + password + b"\0")
+
+while True:
+    kind, payload = recv_message(conn)
+    if kind == b"E":
+        fields = {}
+        for field in payload.rstrip(b"\0").split(b"\0"):
+            if field:
+                fields[field[:1].decode()] = field[1:].decode(errors="replace")
+        print(f"SQLSTATE={fields.get('C', '')} MESSAGE={fields.get('M', '')}")
+        sys.exit(1)
+    if kind == b"Z":
+        print("empty database was accepted")
+        sys.exit(0)
+PY
+}
+
+metadata_proxy_e2e() { # opted-in org password, disabled sibling password
+  org="$1"; pw="$2"; disabled_org="$3"; disabled_pw="$4"
+  log "native metadata Postgres proxy on $org (explicit opt-in + exact virtual database)"
+
+  # The migration default is the access boundary: a ready CNPG-backed org is
+  # still private until an operator opts it in.
+  enabled="$(api_get "$org" warehouse | jq -r '.metadata_proxy_enabled')"
+  [ "$enabled" = "false" ] \
+    || fail "metadata proxy: $org default metadata_proxy_enabled=$enabled, want false"
+  assert_metadata_proxy_denied "$org" "$pw" "before opt-in"
+
+  updated="$(curl -fsS -X PUT -H "$H" -H 'Content-Type: application/json' \
+    -d '{"metadata_proxy_enabled":true}' "$API/api/v1/orgs/$org/warehouse")" \
+    || fail "metadata proxy: enable PUT failed"
+  echo "$updated" | jq -e '.metadata_proxy_enabled == true' >/dev/null \
+    || fail "metadata proxy: enable PUT did not round-trip true: $updated"
+
+  # Config-store snapshots poll asynchronously. Retry only the expected
+  # pre-poll denial; an auth/upstream/query error is a real failure.
+  expected_ident="mdstore_$(printf %s "$org" | tr 'A-Z-' 'a-z_' | tr -cd 'a-z0-9_')"
+  query="SELECT current_database(), current_user, EXISTS (SELECT 1 FROM public.ducklake_metadata WHERE key='version')"
+  out=""
+  for _ in $(seq 1 12); do
+    if out="$(metadata_pg_try "$org" "$pw" metadata "$query")"; then
+      break
+    fi
+    case "$out" in
+      *"metadata endpoint is unavailable"*) sleep 2 ;;
+      *) fail "metadata proxy: opted-in connection/query failed: $out" ;;
+    esac
+  done
+  [ "$out" = "$expected_ident|$expected_ident|t" ] \
+    || fail "metadata proxy: real metadata query returned '$out', want '$expected_ident|$expected_ident|t'"
+
+  # A normal Duckgres catalog name is forbidden on the metadata SNI.
+  if out="$(metadata_pg_try "$org" "$pw" ducklake 'SELECT 1')"; then
+    fail "metadata proxy: dbname=ducklake unexpectedly connected: $out"
+  fi
+  case "$out" in
+    *'database does not exist; connect with dbname="metadata"'*) ;;
+    *) fail "metadata proxy: wrong-database rejection was not explicit: $out" ;;
+  esac
+
+  # Exact empty database (not libpq's defaulting behavior) is also forbidden.
+  if out="$(metadata_empty_database_try "$org" "$pw")"; then
+    fail "metadata proxy: empty startup database unexpectedly connected: $out"
+  fi
+  case "$out" in
+    *'SQLSTATE=3D000'*'dbname="metadata"'*) ;;
+    *) fail "metadata proxy: empty-database rejection was wrong: $out" ;;
+  esac
+
+  # Enabling one tenant never publishes a sibling on the same CNPG shard.
+  assert_metadata_proxy_denied "$disabled_org" "$disabled_pw" "sibling remains opted out"
+
+  # Leave the shared test tenant private and prove the disable reaches the same
+  # live config-store gate used at connect time.
+  updated="$(curl -fsS -X PUT -H "$H" -H 'Content-Type: application/json' \
+    -d '{"metadata_proxy_enabled":false}' "$API/api/v1/orgs/$org/warehouse")" \
+    || fail "metadata proxy: disable PUT failed"
+  echo "$updated" | jq -e '.metadata_proxy_enabled == false' >/dev/null \
+    || fail "metadata proxy: disable PUT did not round-trip false: $updated"
+  for _ in $(seq 1 12); do
+    if out="$(metadata_pg_try "$org" "$pw" metadata 'SELECT 1')"; then
+      sleep 2
+      continue
+    fi
+    case "$out" in
+      *"metadata endpoint is unavailable"*)
+        log "native metadata Postgres proxy OK on $org"
+        return ;;
+      *) fail "metadata proxy: post-disable connection failed for the wrong reason: $out" ;;
+    esac
+  done
+  fail "metadata proxy: $org still accepted new connections after disable"
 }
 
 # ---- wire protocol --------------------------------------------------------
@@ -3812,6 +3992,14 @@ main() {
     return
   fi
 
+  # Initialize the tenant's DuckLake catalog once so public.ducklake_metadata
+  # deterministically exists before we query it through native Postgres. The
+  # subsequent metadata-proxy connection itself bypasses the worker entirely.
+  wait_worker "$CNPG" "$cnpg_pw" ducklake
+  # Assert the proxy before the three worker-churn lanes. RES2 is the
+  # same-backend disabled sibling.
+  metadata_proxy_e2e "$CNPG" "$cnpg_pw" "$RES2" "$res2_pw"
+
   # Admin models explorer: orgs + their users now exist in the config store, so
   # the sidebar counts are non-trivial and the org-users redaction check bites
   # against a real bcrypt-hash-bearing row.
@@ -3895,7 +4083,7 @@ main() {
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + project-reader(team-wide-read/cross-project-deny/read-only/legacy-override-grant) + project-user(in-project-dml+ddl/cross-project-deny/unqualified-target-deny/namespace-ddl-deny/reader-stays-read-only) + wire + binary-copy(native+fallback+route-guard+rollback) + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(cnpg) + persistent-user-secrets(cnpg, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + query-log-round-trip(cnpg, view+query_id+QueryStart/terminal pair) + query-log-access-metadata(read/write split + incomplete-not-empty + CALL opaque-but-complete) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg (3 parallel lanes)"
+  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + project-reader(team-wide-read/cross-project-deny/read-only/legacy-override-grant) + project-user(in-project-dml+ddl/cross-project-deny/unqualified-target-deny/namespace-ddl-deny/reader-stays-read-only) + native-metadata-proxy(explicit-opt-in/exact-db/real-cnpg-query/per-org-disable) + wire + binary-copy(native+fallback+route-guard+rollback) + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake) + org-default-profile(cnpg) + persistent-user-secrets(cnpg, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + query-log-round-trip(cnpg, view+query_id+QueryStart/terminal pair) + query-log-access-metadata(read/write split + incomplete-not-empty + CALL opaque-but-complete) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg (3 parallel lanes)"
 }
 
 main "$@"

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -307,7 +307,9 @@ spec:
             #   nonexistent hostPort proxy.
             # - DUCKGRES_CERT/_KEY (wildcard TLS) and DUCKGRES_TRINO_*: need
             #   cert-manager / a Trino cluster in the per-PR namespace; the CP
-            #   serves its self-signed cert and Trino is not under e2e.
+            #   serves its self-signed cert and Trino is not under e2e. The
+            #   metadata-proxy check uses sslmode=require, so that self-signed
+            #   cert still exercises the real TLS/SNI branch without public DNS.
             - { name: DUCKGRES_WORKER_QUEUE_TIMEOUT, value: "5m" }
             # Fast config-store poll for CI only (default 30s). The harness has
             # three waits bounded by this interval — the post-provision auth-cache
@@ -340,6 +342,10 @@ spec:
             # + hostaddr=<CP ClusterIP> (→ TCP target), and dbname selects the
             # catalog. Suffix is CI-internal; it never needs to resolve in DNS.
             - { name: DUCKGRES_MANAGED_HOSTNAME_SUFFIXES, value: ".ci.duckgres.local" }
+            # Separate native metadata-Postgres proxy SNI. Like the managed
+            # hostname above, libpq sends this as TLS SNI while hostaddr keeps
+            # the TCP destination on the in-cluster CP Service.
+            - { name: DUCKGRES_METADATA_HOSTNAME_SUFFIXES, value: ".md.ci.duckgres.local" }
             - { name: DUCKGRES_SNI_ROUTING_MODE, value: "passthrough" }
           ports:
             - { name: pg, containerPort: 5432 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -612,6 +612,65 @@ func TestE2EHarnessUsesOnlyCnpgMetadataStores(t *testing.T) {
 	}
 }
 
+func TestE2EHarnessCoversNativeMetadataProxy(t *testing.T) {
+	manifestRaw, err := os.ReadFile("manifests.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read manifests template: %v", err)
+	}
+	rendered := strings.NewReplacer(
+		"${NAMESPACE}", "duckgres-ci-pr-123",
+		"${PR_NUMBER}", "123",
+		"${CONTROLPLANE_IMAGE}", "example.invalid/duckgres:test",
+		"${WORKER_IMAGE}", "example.invalid/duckgres:test",
+		"${INTERNAL_SECRET}", "test-internal-secret",
+		"${INTERNAL_SECRET_FALLBACK}", "test-internal-secret-fallback",
+		"${USER_SECRET_KEY}", "test-user-secret-key",
+		"${DUCKGRES_K8S_WORKER_CPU_REQUEST}", "750m",
+		"${DUCKGRES_K8S_WORKER_MEMORY_REQUEST}", "1536Mi",
+	).Replace(string(manifestRaw))
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(rendered), 4096)
+	foundDeployment := false
+	for {
+		var manifest map[string]any
+		err := decoder.Decode(&manifest)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode manifests template: %v", err)
+		}
+		if manifest["kind"] != "Deployment" || manifestName(manifest) != "duckgres-control-plane" {
+			continue
+		}
+		foundDeployment = true
+		env := deploymentContainerEnv(manifest, "controlplane")
+		if got := env["DUCKGRES_METADATA_HOSTNAME_SUFFIXES"]; got != ".md.ci.duckgres.local" {
+			t.Fatalf("DUCKGRES_METADATA_HOSTNAME_SUFFIXES = %q, want .md.ci.duckgres.local", got)
+		}
+	}
+	if !foundDeployment {
+		t.Fatal("duckgres-control-plane Deployment missing from manifests template")
+	}
+
+	harnessRaw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read e2e harness: %v", err)
+	}
+	harness := string(harnessRaw)
+	for _, want := range []string{
+		`METADATA_SNI_SUFFIX=".md.ci.duckgres.local"`,
+		"metadata_proxy_e2e()",
+		`{"metadata_proxy_enabled":true}`,
+		`database = ""`,
+		`public.ducklake_metadata`,
+		`metadata endpoint is unavailable`,
+	} {
+		if !strings.Contains(harness, want) {
+			t.Errorf("e2e harness is missing native metadata proxy coverage marker %q", want)
+		}
+	}
+}
+
 func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 	raw, err := os.ReadFile("e2e/harness.sh")
 	if err != nil {


### PR DESCRIPTION
## Summary

- add a native PostgreSQL metadata proxy on the existing Duckgres listener
- authenticate `<org>.md.<region>.postwh.com` with the org's existing `root` credential, while resolving the real metadata PgBouncer URL and role entirely inside the control plane
- support the managed-warehouse dev, prod-US, and prod-EU suffixes supplied by each deployment
- require the exact non-empty database name `metadata`
- gate access behind a default-off `metadata_proxy_enabled` org setting, exposed through the admin API and UI
- close active proxy sessions when the org becomes ineligible, is disabled/deleted, or the control plane drains

## Security and scope

- only configured metadata SNI suffixes enter this path
- only `root`, an exact `dbname=metadata`, a ready `cnpg-shard` warehouse, and an explicitly enabled org are accepted
- clients cannot select the upstream host, database, role, password, or `application_name`
- upstream bootstrap has a 10-second deadline and connections have a configurable per-org cap
- internal connection details are omitted from errors and logs
- initial rollout is documented as dedicated/single-customer shards only; the proxied role intentionally retains full metadata-database access for this first scope
- PostgreSQL cancel keys are synthetic and never expose the upstream key; a cancel delivered to the owning control-plane process terminates that exact frontend/upstream session, while a key delivered to another process is safely ignored and counted

## Observability

- add dedicated open-connection, attempt, duration, upstream-connect, byte, and cancel metrics
- keep org/outcome/direction labels bounded and document their relationship to existing process-wide connection/auth counters
- keep DuckDB worker, admission, query, session, log, and trace metrics unchanged for proxied metadata traffic

## Validation

- `just lint`
- race-enabled metadata proxy and SNI tests
- explicit parsing and SNI-routing coverage for `.md.dev.postwh.com`, `.md.us.postwh.com`, and `.md.eu.postwh.com`
- config-store, config resolution, admin, and mw-dev test suites
- live mw-dev coverage for default deny, explicit enable, exact database enforcement, a real hidden-credential CNPG query, sibling-org isolation, and disable
- admin UI typecheck, 79 tests, and production build

`just test-controlplane-k8s` also passed the root, control-plane, and provisioner packages locally. Eight Docker-backed admin tests could not start because `docker-compose` is not installed; the complete non-Docker admin suite passed.

## Deployment dependencies

- PostHog/posthog-cloud-infra#9680
- PostHog/charts#13717
