### PR TITLE
chore: bump DUCKLAKE_EXTENSION_TAG to v1.0-posthog.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 ARG TARGETARCH
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
 ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
-ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.6
+ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable
 # extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -52,7 +52,7 @@ RUN go mod download
 # ran after the source COPY + build, so they re-fetched on every edit.)
 ARG DUCKDB_EXTENSION_VERSION=1.5.3
 ARG HTTPFS_EXTENSION_TAG=v1.5.3-cred-refresh-write-retry
-ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.6
+ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
 # Repository for postgres_scanner specifically. Defaults to the stable
 # extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions


### PR DESCRIPTION
## Summary

Bumps the pinned ducklake extension from `v1.0-posthog.6` → [`v1.0-posthog.7`](https://github.com/PostHog/ducklake/releases/tag/v1.0-posthog.7) in `Dockerfile` and `Dockerfile.worker`.

What the new tag carries (all CI-verified on `posthog/v1.5.5`):
- **Commit-loop instrumentation + `ducklake_commit_stats()`** (PostHog/ducklake#35) — with this deployed, the worker-side poller from #1012 activates and `duckgres_worker_ducklake_commit_*` metrics (attempts, per-cause conflicts, retries exhausted, backoff, commit latency) start flowing per catalog. This is the collision-observability baseline.
- **Upstream v1.5-variegata sync** (PostHog/ducklake#36) — notably the partition-id remap fix on commit retries (upstream #1288/#1223), inlined-table cleanup on drop/flush, and `hive_file_pattern` support in `ducklake_flush_inlined_data`.
- Release-line consolidation (PostHog/ducklake#34).

Release assets (`ducklake-linux-{amd64,arm64}.duckdb_extension` + SHA256SUMS) are published and fetchable — Docker builds will resolve.

## Test plan

- [x] Extension tag published with both linux assets
- [ ] CI Docker builds fetch and bake the new binary
- [ ] Post-deploy: `duckgres_worker_ducklake_commit_*` series appear in VictoriaMetrics (probe flips from dormant to active); existing `duckgres_worker_ducklake_conflict_*` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUnQHp46rmLKdupmDUr7kG