### PR TITLE
feat(duckdbservice): set late_materialization_max_rows=6000 on all workers

### DIFF
--- a/duckdbservice/duckdb_pair.go
+++ b/duckdbservice/duckdb_pair.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"log/slog"
 	"time"
 
 	duckdb "github.com/duckdb/duckdb-go/v2"
@@ -86,6 +87,12 @@ type workerRequiredExtensionExecer interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
+// workerLateMaterializationMaxRows caps how many rows DuckDB late-materializes
+// for LIMIT/SAMPLE queries. late_materialization_max_rows is session-scoped
+// (LOCAL) in DuckDB, so it must be applied with SET GLOBAL for the value to
+// reach every session connection on the shared connector.
+const workerLateMaterializationMaxRows = 6000
+
 func loadWorkerRequiredExtensions(db workerRequiredExtensionExecer) error {
 	if _, err := db.Exec("LOAD postgres_scanner"); err != nil {
 		return fmt.Errorf("load required worker extension postgres_scanner: %w", err)
@@ -146,6 +153,9 @@ func OpenDuckDBPair(cfg server.Config, username string) (*DuckDBPair, error) {
 		_ = controlDB.Close()
 		_ = connector.Close()
 		return nil, err
+	}
+	if _, err := mainDB.Exec(fmt.Sprintf("SET GLOBAL late_materialization_max_rows = %d", workerLateMaterializationMaxRows)); err != nil {
+		slog.Warn("Failed to set DuckDB late_materialization_max_rows.", "late_materialization_max_rows", workerLateMaterializationMaxRows, "error", err)
 	}
 	if err := loadWorkerRequiredExtensions(mainDB); err != nil {
 		_ = mainDB.Close()

--- a/duckdbservice/duckdb_pair_test.go
+++ b/duckdbservice/duckdb_pair_test.go
@@ -1,0 +1,35 @@
+package duckdbservice
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/posthog/duckgres/server"
+)
+
+// TestOpenDuckDBPairSetsLateMaterializationMaxRows is the regression guard for
+// the worker rollout that caps late materialization: every worker DB opened via
+// OpenDuckDBPair must have late_materialization_max_rows = 6000.
+//
+// The assertion runs on a *fresh* connection from the same connector — the
+// same shape as a session-pool connection serving user queries — so it also
+// proves the setting is visible beyond the warmup connection that applied it.
+func TestOpenDuckDBPairSetsLateMaterializationMaxRows(t *testing.T) {
+	cfg := server.Config{DataDir: t.TempDir()}
+	pair, err := OpenDuckDBPair(cfg, "worker")
+	if err != nil {
+		t.Fatalf("OpenDuckDBPair: %v", err)
+	}
+	defer func() { _ = pair.Close() }()
+
+	sessionDB := sql.OpenDB(pair.connector)
+	defer func() { _ = sessionDB.Close() }()
+
+	var got string
+	if err := sessionDB.QueryRow("SELECT current_setting('late_materialization_max_rows')").Scan(&got); err != nil {
+		t.Fatalf("read late_materialization_max_rows: %v", err)
+	}
+	if got != "6000" {
+		t.Errorf("late_materialization_max_rows = %q, want %q", got, "6000")
+	}
+}


### PR DESCRIPTION
## What

Sets `late_materialization_max_rows = 6000` on every DuckDB worker, applied in `OpenDuckDBPair` (the worker-process DB factory in `duckdbservice/duckdb_pair.go`), so it covers all workers regardless of how they were spawned (local process pools and K8s pods both go through this path).

## Why SET GLOBAL

`late_materialization_max_rows` is **session-scoped (LOCAL)** in DuckDB 1.5.x — verified against the bundled bindings:

- plain `SET` on the warmup connection: fresh connection on the same connector still sees the default (50)
- `SET GLOBAL`: fresh connection sees the new value
- `duckdb_settings()` reports `scope = LOCAL`

So a one-time `SET GLOBAL` at open is what propagates the cap to every session-pool connection serving user queries. Users can still override it per session if needed.

## Test

`TestOpenDuckDBPairSetsLateMaterializationMaxRows` (TDD: failed with `50` before the change, passes after) opens a real worker pair and asserts the value from a **fresh connector connection** — the same shape as a session-pool connection — so it also guards the SET GLOBAL scope assumption.

## Verification

- `go test ./duckdbservice/` — pass
- `go vet`, `gofmt` — clean
- `just lint` could not run locally (golangci-lint not installed); relies on CI