### PR TITLE
build(docker): switch runtime images from debian to wolfi-base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -840,7 +840,7 @@ entrypoint), `controlplane/reshard_pod.go` (spawner) +
   kept on success. The objects carry NO object tag: PutObject with x-amz-tagging
   needs `s3:PutObjectTagging`, which the org duckling roles do not grant (a
   tagged upload 403s on the real cluster — mw-dev e2e regression). pg_dump/pg_restore ship in the CP image
-  (`postgresql-client-18`, PGDG repo, in BOTH `Dockerfile` and
+  (Wolfi's `postgresql-18-client` apk, in BOTH `Dockerfile` and
   `Dockerfile.controlplane`). Full design + restore procedure:
   `docs/design/resharding.md`.
 - **Source identity: the duckling STATUS is authoritative, validated at

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,22 +71,17 @@ RUN CGO_ENABLED=1 \
       ./duckdbservice
 RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o duckgres .
 
-FROM debian:bookworm-slim
+FROM chainguard/wolfi-base:latest
 
-# postgresql-client-18 provides pg_dump/pg_restore, used by the control-plane
+# postgresql-18-client provides pg_dump/pg_restore, used by the control-plane
 # reshard runner's pre-flip catalog backup (docs/design/resharding.md). Pinned
-# to PG 18 to match the cnpg shard major so it can dump PG-18 catalogs. From the
-# PGDG apt repo because Debian bookworm's stock repo only carries PG 15. mw-dev
+# to PG 18 to match the cnpg shard major so it can dump PG-18 catalogs. mw-dev
 # runs this single all-in-one image as BOTH control plane and workers, so the
-# client must live here (not only in Dockerfile.controlplane).
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
-    && install -d /usr/share/postgresql-common/pgdg \
-    && wget -qO /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-18 \
-    && apt-get purge -y gnupg wget && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
-RUN groupadd -r duckgres && useradd -r -g duckgres -d /app duckgres
+# client must live here (not only in Dockerfile.controlplane). libstdc++ is
+# the C++ runtime the CGO-linked DuckDB engine needs — present implicitly on
+# debian-slim, but not in wolfi-base.
+RUN apk add --no-cache ca-certificates-bundle libstdc++ postgresql-18-client \
+    && addgroup -S duckgres && adduser -S -G duckgres -h /app duckgres
 
 WORKDIR /app
 COPY --from=builder /build/duckgres .

--- a/Dockerfile.controlplane
+++ b/Dockerfile.controlplane
@@ -43,20 +43,14 @@ RUN CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" \
     -o duckgres-controlplane \
     ./cmd/duckgres-controlplane
 
-FROM debian:bookworm-slim
+FROM chainguard/wolfi-base:latest
 
-# postgresql-client-18 provides pg_dump/pg_restore for the reshard runner's
+# postgresql-18-client provides pg_dump/pg_restore for the reshard runner's
 # pre-flip catalog backup (docs/design/resharding.md). Pinned to PG 18 to match
-# the cnpg shard major so it can dump PG-18 catalogs. From the PGDG apt repo
-# because Debian bookworm's stock repo only carries PG 15.
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
-    && install -d /usr/share/postgresql-common/pgdg \
-    && wget -qO /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-18 \
-    && apt-get purge -y gnupg wget && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
-RUN groupadd -r duckgres && useradd -r -g duckgres -d /app duckgres
+# the cnpg shard major so it can dump PG-18 catalogs. No libstdc++ here: this
+# image does not link libduckdb (pg_query_go's libpg_query is plain C).
+RUN apk add --no-cache ca-certificates-bundle postgresql-18-client \
+    && addgroup -S duckgres && adduser -S -G duckgres -h /app duckgres
 
 WORKDIR /app
 COPY --from=builder /build/duckgres-controlplane .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -155,10 +155,12 @@ RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ]; then \
       echo "Verified: duckgres-worker linked against duckdb-go-bindings@$embedded" ; \
     fi
 
-FROM debian:bookworm-slim
+FROM chainguard/wolfi-base:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN groupadd -r duckgres && useradd -r -g duckgres -d /app duckgres
+# libstdc++ is the C++ runtime the CGO-linked DuckDB engine needs — present
+# implicitly on debian-slim, but not in wolfi-base.
+RUN apk add --no-cache ca-certificates-bundle libstdc++ \
+    && addgroup -S duckgres && adduser -S -G duckgres -h /app duckgres
 
 WORKDIR /app
 COPY --from=builder /build/duckgres-worker .


### PR DESCRIPTION
Switches the runtime stage of all three images (`Dockerfile`, `Dockerfile.controlplane`, `Dockerfile.worker`) from `debian:bookworm-slim` to `chainguard/wolfi-base`. Builder stages are unchanged.

- **PG-18 client without the PGDG bootstrap**: Wolfi carries `postgresql-18-client` natively, so the wget/gnupg/apt-repo dance for the reshard runner's `pg_dump`/`pg_restore` is gone (pin to PG 18 preserved).
- **`libstdc++` added explicitly** where the CGO-linked DuckDB engine needs it (`Dockerfile`, `Dockerfile.worker`) — debian-slim shipped it implicitly, wolfi-base doesn't. Deliberately omitted from the CP image, which doesn't link libduckdb.
- Non-root `duckgres` user now created via busybox `addgroup`/`adduser`.
- Image sizes: all-in-one 660→535MB, CP 292MB, worker 497MB.

Verified locally: all-in-one serves psql over TLS with DDL/DML + JSON-extension queries; worker pre-warms DuckDB and loads the bundled ducklake extension; CP binary runs with `pg_dump` 18.4 present; all run as non-root on Wolfi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)