### PR TITLE
ci: publish e2e/scenario test images to the duckgres-prs ECR repo

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -82,7 +82,7 @@ jobs:
     uses: ./.github/workflows/_image-build.yml
     with:
       dockerfile: Dockerfile
-      image-name: duckgres
+      image-name: duckgres-prs
       tag: pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}-arm64
       platform: linux/arm64
       cache-scope: e2e-duckgres-arm64
@@ -95,7 +95,7 @@ jobs:
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
         POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
     secrets:
-      ecr-role: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+      ecr-role: ${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}
 
   e2e_lanes:
     needs: [build]

--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -29,19 +29,19 @@ jobs:
     uses: ./.github/workflows/_image-build.yml
     with:
       dockerfile: tests/mw-dev/scenario/Dockerfile
-      image-name: duckgres
+      image-name: duckgres-prs
       tag: scenario-runner-${{ github.run_id }}-${{ github.run_attempt }}-arm64
       platform: linux/arm64
       cache-scope: scenario-runner-arm64
     secrets:
-      ecr-role: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+      ecr-role: ${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}
 
   duckgres-image:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.duckgres_image == '' }}
     uses: ./.github/workflows/_image-build.yml
     with:
       dockerfile: Dockerfile
-      image-name: duckgres
+      image-name: duckgres-prs
       tag: scenario-duckgres-${{ github.run_id }}-${{ github.run_attempt }}-arm64
       platform: linux/arm64
       cache-scope: scenario-duckgres-arm64
@@ -52,7 +52,7 @@ jobs:
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
         POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
     secrets:
-      ecr-role: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+      ecr-role: ${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}
 
   scenario:
     needs: [scenario-runner-image, duckgres-image]


### PR DESCRIPTION
Moves the e2e/scenario **test** images out of the **prod** `duckgres` ECR repo and into a dedicated `duckgres-prs` repo, using a dedicated any-ref publish role instead of the shared org-secret one.

### Why
`e2e-mw-dev.yml` and `scenario-dev.yml` currently push `pr-<n>-<sha>` / `scenario-runner-<run_id>-<attempt>` / `scenario-duckgres-<run_id>-<attempt>` into the prod `duckgres` repo (via the reusable `_image-build.yml`). That is why the prod repo has to keep a mutable `pr-*` carve-out, and it means PR builds can write to a production image repo. These are also the last two workflows still using the shared `github-posthog-ecr-publish-role`.

### What changes
Three call sites of `_image-build.yml`:
- `image-name: duckgres` → `duckgres-prs`
- `ecr-role: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}` → `${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}`

`_image-build.yml` itself is unchanged (already parameterised), and it is called **only** by these two workflows — the four `container-image-*-cd.yml` prod pushers authenticate inline and are untouched.

Downstream jobs consume `needs.<job>.outputs.image` (the full registry URL), so the new repo propagates automatically. The mw-dev cluster can pull `duckgres-prs` — the `-prs` repos get the same cross-account read policy as the prod ones.

### Depends on
posthog-cloud-infra#9715 (creates `duckgres-prs` + `github-duckgres-prs-publish-role`) applied, and the repo variable `AWS_ECR_PRS_PUBLISH_IAM_ROLE` set. Merging before that will fail to assume the role.

Once this lands, a follow-up infra PR flips the prod `duckgres` repo to fully immutable (dropping `exclusions = ["pr-*"]`).