### PR TITLE
fix: create scoped staging S3 secret from activation creds

### DIFF
--- a/duckdbservice/user_secrets_test.go
+++ b/duckdbservice/user_secrets_test.go
@@ -59,6 +59,7 @@ func TestWipeUserSecrets(t *testing.T) {
 	// System-managed secrets (created with plain CREATE OR REPLACE SECRET, so
 	// they land in in-memory/temporary storage). These must survive the wipe.
 	mustExec("CREATE OR REPLACE SECRET ducklake_s3 (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
+	mustExec("CREATE OR REPLACE SECRET posthog_staging_delta_https (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
 	mustExec("CREATE OR REPLACE SECRET duckgres_internal (TYPE s3, KEY_ID 'sys', SECRET 'sys')")
 	// User secrets: a persistent one and a temporary one. Both must be dropped.
 	mustExec("CREATE PERSISTENT SECRET user_a (TYPE s3, KEY_ID 'a', SECRET 'a')")
@@ -78,7 +79,7 @@ func TestWipeUserSecrets(t *testing.T) {
 			t.Errorf("user secret %q remains after wipe; remaining: %v", leaked, remaining)
 		}
 	}
-	for _, sys := range []string{"ducklake_s3", "duckgres_internal"} {
+	for _, sys := range []string{"ducklake_s3", "posthog_staging_delta_https", "duckgres_internal"} {
 		if !remaining[sys] {
 			t.Errorf("system secret %q was wiped; remaining: %v", sys, remaining)
 		}

--- a/server/s3_secret_test.go
+++ b/server/s3_secret_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 )
@@ -121,6 +122,179 @@ func TestBuildConfigSecretAlwaysEmitsSessionToken(t *testing.T) {
 	})
 	if !strings.Contains(withToken, "SESSION_TOKEN 'tok'") {
 		t.Errorf("config secret must carry the explicit token:\n%s", withToken)
+	}
+}
+
+func TestBuildStagingDeltaHTTPSSecret(t *testing.T) {
+	t.Run("uses the activated credentials with a bucket-root staging scope", func(t *testing.T) {
+		stmt, ok := buildStagingDeltaHTTPSSecret(DuckLakeConfig{
+			ObjectStore:    "s3://managed-warehouse/catalog/",
+			S3Provider:     "config",
+			S3AccessKey:    "ASIAEXAMPLE",
+			S3SecretKey:    "secret",
+			S3SessionToken: "token",
+			S3Region:       "us-east-1",
+			S3Endpoint:     "s3.us-east-1.amazonaws.com",
+			S3UseSSL:       false,
+			S3URLStyle:     "path",
+			HTTPProxy:      "http://10.0.0.1:8080",
+		})
+		if !ok {
+			t.Fatal("expected an explicit staging secret")
+		}
+
+		for _, want := range []string{
+			"CREATE OR REPLACE SECRET posthog_staging_delta_https",
+			"PROVIDER config",
+			"KEY_ID 'ASIAEXAMPLE'",
+			"SECRET 'secret'",
+			"SESSION_TOKEN 'token'",
+			"REGION 'us-east-1'",
+			"URL_STYLE 'vhost'",
+			"USE_SSL true",
+			"SCOPE 's3://managed-warehouse/__posthog_staging'",
+		} {
+			if !strings.Contains(stmt, want) {
+				t.Errorf("staging secret missing %q:\n%s", want, stmt)
+			}
+		}
+		for _, forbidden := range []string{"PROVIDER credential_chain", "ENDPOINT", "10.0.0.1"} {
+			if strings.Contains(stmt, forbidden) {
+				t.Errorf("staging secret must bypass the cache transport; found %q:\n%s", forbidden, stmt)
+			}
+		}
+	})
+
+	t.Run("pins an empty session token", func(t *testing.T) {
+		stmt, ok := buildStagingDeltaHTTPSSecret(DuckLakeConfig{
+			ObjectStore: "s3://managed-warehouse/",
+			S3Provider:  "config",
+			S3AccessKey: "AKIAEXAMPLE",
+			S3SecretKey: "secret",
+		})
+		if !ok {
+			t.Fatal("expected an explicit staging secret")
+		}
+		if !strings.Contains(stmt, "SESSION_TOKEN ''") {
+			t.Fatalf("staging secret must pin the empty token:\n%s", stmt)
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		cfg  DuckLakeConfig
+	}{
+		{
+			name: "credential chain remains a legacy client fallback",
+			cfg: DuckLakeConfig{
+				ObjectStore: "s3://legacy-bucket/",
+				S3Provider:  "credential_chain",
+			},
+		},
+		{
+			name: "non-S3 object store",
+			cfg: DuckLakeConfig{
+				ObjectStore: "file:///tmp/ducklake",
+				S3Provider:  "config",
+				S3AccessKey: "key",
+				S3SecretKey: "secret",
+			},
+		},
+		{
+			name: "missing explicit credentials",
+			cfg: DuckLakeConfig{
+				ObjectStore: "s3://managed-warehouse/",
+				S3Provider:  "config",
+			},
+		},
+		{
+			name: "S3-compatible non-AWS endpoint",
+			cfg: DuckLakeConfig{
+				ObjectStore: "s3://local-bucket/",
+				S3Provider:  "config",
+				S3AccessKey: "key",
+				S3SecretKey: "secret",
+				S3Endpoint:  "localhost:19000",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if stmt, ok := buildStagingDeltaHTTPSSecret(tt.cfg); ok || stmt != "" {
+				t.Fatalf("buildStagingDeltaHTTPSSecret() = (%q, %v), want no secret", stmt, ok)
+			}
+		})
+	}
+}
+
+func TestCreateAndRefreshS3SecretManageStagingDeltaHTTPSSecret(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("INSTALL httpfs"); err != nil {
+		t.Skip("httpfs extension not available:", err)
+	}
+	if _, err := db.Exec("LOAD httpfs"); err != nil {
+		t.Skip("httpfs extension not loadable:", err)
+	}
+
+	cfg := DuckLakeConfig{
+		ObjectStore:    "s3://managed-warehouse/",
+		S3Provider:     "config",
+		S3AccessKey:    "ASIAINITIAL",
+		S3SecretKey:    "initial-secret",
+		S3SessionToken: "initial-token",
+		S3Region:       "us-east-1",
+	}
+	if err := createS3Secret(db, cfg); err != nil {
+		t.Fatalf("createS3Secret() error: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`
+		SELECT count(*)
+		FROM duckdb_secrets()
+		WHERE name IN ('ducklake_s3', 'posthog_staging_delta_https')
+	`).Scan(&count); err != nil {
+		t.Fatalf("query managed secrets: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("managed secret count = %d, want 2", count)
+	}
+	if _, err := db.Exec("DROP SECRET posthog_staging_delta_https"); err != nil {
+		t.Fatalf("drop staging secret: %v", err)
+	}
+	if err := createS3Secret(db, cfg); err != nil {
+		t.Fatalf("createS3Secret() with existing catalog secret error: %v", err)
+	}
+	if err := db.QueryRow(`
+		SELECT count(*)
+		FROM duckdb_secrets()
+		WHERE name = 'posthog_staging_delta_https'
+	`).Scan(&count); err != nil {
+		t.Fatalf("query restored staging secret: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("restored staging secret count = %d, want 1", count)
+	}
+
+	cfg.S3AccessKey = "ASIAROTATED"
+	cfg.S3SecretKey = "rotated-secret"
+	cfg.S3SessionToken = "rotated-token"
+	if err := RefreshS3Secret(db, cfg, nil); err != nil {
+		t.Fatalf("RefreshS3Secret() error: %v", err)
+	}
+	if err := db.QueryRow(`
+		SELECT count(*)
+		FROM duckdb_secrets()
+		WHERE name IN ('ducklake_s3', 'posthog_staging_delta_https')
+	`).Scan(&count); err != nil {
+		t.Fatalf("query refreshed managed secrets: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("refreshed managed secret count = %d, want 2", count)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -2051,43 +2052,66 @@ func createS3SecretWith(db attachSQLRunner, dlCfg DuckLakeConfig) error {
 	// Check if secret already exists to avoid unnecessary creation
 	var count int
 	err := db.queryRowScan("SELECT COUNT(*) FROM duckdb_secrets() WHERE name = 'ducklake_s3'", &count)
-	if err == nil && count > 0 {
-		return nil // Secret already exists
-	}
+	if err != nil || count == 0 {
+		// Determine provider: use credential_chain if explicitly set or if no access key provided
+		provider := S3ProviderForConfig(dlCfg)
 
-	// Determine provider: use credential_chain if explicitly set or if no access key provided
-	provider := S3ProviderForConfig(dlCfg)
+		var secretStmt string
 
-	var secretStmt string
-
-	switch provider {
-	case "aws_sdk":
-		// Use Go AWS SDK to fetch credentials (supports EKS Pod Identity, IRSA, etc.)
-		// Bounded so a hung credential source (e.g. a blackholed IMDS/Pod
-		// Identity endpoint) fails fast instead of stalling the attach.
-		sdkCtx, sdkCancel := context.WithTimeout(context.Background(), attachStepTimeout)
-		defer sdkCancel()
-		var err error
-		secretStmt, err = buildAWSSdkSecret(sdkCtx, dlCfg)
-		if err != nil {
-			return fmt.Errorf("aws_sdk credential fetch failed: %w", err)
+		switch provider {
+		case "aws_sdk":
+			// Use Go AWS SDK to fetch credentials (supports EKS Pod Identity, IRSA, etc.)
+			// Bounded so a hung credential source (e.g. a blackholed IMDS/Pod
+			// Identity endpoint) fails fast instead of stalling the attach.
+			sdkCtx, sdkCancel := context.WithTimeout(context.Background(), attachStepTimeout)
+			defer sdkCancel()
+			var err error
+			secretStmt, err = buildAWSSdkSecret(sdkCtx, dlCfg)
+			if err != nil {
+				return fmt.Errorf("aws_sdk credential fetch failed: %w", err)
+			}
+			slog.Info("Creating S3 secret with aws_sdk provider (Go SDK credentials).")
+		case "credential_chain":
+			// Use DuckDB's built-in credential chain (does NOT support EKS Pod Identity)
+			secretStmt = buildCredentialChainSecret(dlCfg)
+			slog.Info("Creating S3 secret with credential_chain provider.")
+		default:
+			// Use explicit credentials (config provider)
+			secretStmt = buildConfigSecret(dlCfg)
+			slog.Info("Creating S3 secret with config provider.", "endpoint", dlCfg.S3Endpoint)
 		}
-		slog.Info("Creating S3 secret with aws_sdk provider (Go SDK credentials).")
-	case "credential_chain":
-		// Use DuckDB's built-in credential chain (does NOT support EKS Pod Identity)
-		secretStmt = buildCredentialChainSecret(dlCfg)
-		slog.Info("Creating S3 secret with credential_chain provider.")
-	default:
-		// Use explicit credentials (config provider)
-		secretStmt = buildConfigSecret(dlCfg)
-		slog.Info("Creating S3 secret with config provider.", "endpoint", dlCfg.S3Endpoint)
+
+		if _, err := db.Exec(secretStmt); err != nil {
+			return err
+		}
+
+		slog.Info("Created S3 secret successfully.")
 	}
 
-	if _, err := db.Exec(secretStmt); err != nil {
+	if err := ensureStagingDeltaHTTPSSecret(db, dlCfg); err != nil {
 		return err
 	}
+	return nil
+}
 
-	slog.Info("Created S3 secret successfully.")
+func ensureStagingDeltaHTTPSSecret(db attachSQLRunner, dlCfg DuckLakeConfig) error {
+	stmt, ok := buildStagingDeltaHTTPSSecret(dlCfg)
+	if !ok {
+		return nil
+	}
+
+	var count int
+	err := db.queryRowScan(
+		"SELECT COUNT(*) FROM duckdb_secrets() WHERE name = 'posthog_staging_delta_https'",
+		&count,
+	)
+	if err == nil && count > 0 {
+		return nil
+	}
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("create staging Delta HTTPS secret: %s", redactSecretStatementError(err.Error()))
+	}
+	slog.Info("Created staging Delta HTTPS S3 secret.")
 	return nil
 }
 
@@ -2121,17 +2145,24 @@ func RefreshS3Secret(db *sql.DB, dlCfg DuckLakeConfig, duckLakeSem chan struct{}
 		secretStmt = buildConfigSecret(dlCfg)
 	}
 
-	// If the previous session left the connection in DuckDB's "Current
-	// transaction is aborted" state, the exec will always fail. Issue a
-	// ROLLBACK to recover, matching the pattern in StartCredentialRefresh.
-	if _, err := ae.Exec(secretStmt); err != nil {
-		if isTransactionAborted(err) {
-			_, _ = ae.Exec("ROLLBACK")
-			if _, retryErr := ae.Exec(secretStmt); retryErr != nil {
-				return fmt.Errorf("refresh S3 secret after rollback: %s", redactSecretStatementError(retryErr.Error()))
+	secretStmts := []string{secretStmt}
+	if stagingStmt, ok := buildStagingDeltaHTTPSSecret(dlCfg); ok {
+		secretStmts = append(secretStmts, stagingStmt)
+	}
+
+	for _, stmt := range secretStmts {
+		// If the previous session left the connection in DuckDB's "Current
+		// transaction is aborted" state, the exec will always fail. Issue a
+		// ROLLBACK to recover, matching the pattern in StartCredentialRefresh.
+		if _, err := ae.Exec(stmt); err != nil {
+			if isTransactionAborted(err) {
+				_, _ = ae.Exec("ROLLBACK")
+				if _, retryErr := ae.Exec(stmt); retryErr != nil {
+					return fmt.Errorf("refresh S3 secret after rollback: %s", redactSecretStatementError(retryErr.Error()))
+				}
+			} else {
+				return fmt.Errorf("refresh S3 secret: %s", redactSecretStatementError(err.Error()))
 			}
-		} else {
-			return fmt.Errorf("refresh S3 secret: %s", redactSecretStatementError(err.Error()))
 		}
 	}
 	slog.Debug("Refreshed S3 secret for hot-idle reuse.", "provider", provider)
@@ -2237,6 +2268,52 @@ func buildConfigSecret(dlCfg DuckLakeConfig) string {
 
 	secret += "\n\t\t)"
 	return secret
+}
+
+func buildStagingDeltaHTTPSSecret(dlCfg DuckLakeConfig) (string, bool) {
+	if S3ProviderForConfig(dlCfg) != "config" || dlCfg.S3AccessKey == "" || dlCfg.S3SecretKey == "" {
+		return "", false
+	}
+	if dlCfg.S3Endpoint != "" && !isAWSS3Endpoint(dlCfg.S3Endpoint) {
+		return "", false
+	}
+	objectStore, err := url.Parse(dlCfg.ObjectStore)
+	if err != nil || objectStore.Scheme != "s3" || objectStore.Host == "" {
+		return "", false
+	}
+
+	region := dlCfg.S3Region
+	if region == "" {
+		region = "us-east-1"
+	}
+	scope := fmt.Sprintf("s3://%s/__posthog_staging", objectStore.Host)
+	stmt := fmt.Sprintf(`
+		CREATE OR REPLACE SECRET posthog_staging_delta_https (
+			TYPE s3,
+			PROVIDER config,
+			KEY_ID '%s',
+			SECRET '%s',
+			REGION '%s',
+			URL_STYLE 'vhost',
+			USE_SSL true,
+			SESSION_TOKEN '%s',
+			SCOPE '%s'
+		)`,
+		dlCfg.S3AccessKey,
+		dlCfg.S3SecretKey,
+		region,
+		dlCfg.S3SessionToken,
+		scope,
+	)
+	return stmt, true
+}
+
+func isAWSS3Endpoint(endpoint string) bool {
+	host := strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
+	host = strings.SplitN(host, "/", 2)[0]
+	host = strings.SplitN(host, ":", 2)[0]
+	return host == "s3.amazonaws.com" ||
+		(strings.HasPrefix(host, "s3.") && strings.HasSuffix(host, ".amazonaws.com"))
 }
 
 // buildCredentialChainSecret builds a CREATE SECRET statement using AWS SDK credential chain

--- a/server/usersecrets/classify.go
+++ b/server/usersecrets/classify.go
@@ -53,7 +53,8 @@ type Statement struct {
 // system-issued catalog secrets, DuckDB's default names for unnamed secrets,
 // and a duckgres_ prefix reserved for future system use.
 var reservedNames = map[string]struct{}{
-	"ducklake_s3": {},
+	"ducklake_s3":                 {},
+	"posthog_staging_delta_https": {},
 }
 
 var reservedPrefixes = []string{"__default_", "duckgres_"}

--- a/server/usersecrets/classify_test.go
+++ b/server/usersecrets/classify_test.go
@@ -124,7 +124,13 @@ func TestClassify(t *testing.T) {
 }
 
 func TestIsReservedName(t *testing.T) {
-	for _, name := range []string{"ducklake_s3", "DUCKLAKE_S3", "__default_s3", "duckgres_internal"} {
+	for _, name := range []string{
+		"ducklake_s3",
+		"posthog_staging_delta_https",
+		"DUCKLAKE_S3",
+		"__default_s3",
+		"duckgres_internal",
+	} {
 		if !IsReservedName(name) {
 			t.Errorf("IsReservedName(%q) = false, want true", name)
 		}


### PR DESCRIPTION
## Summary

- create a server-managed HTTPS S3 secret scoped to the managed warehouse staging prefix
- build it from the explicit credentials already supplied in the tenant activation payload
- refresh it alongside the primary DuckLake S3 secret when STS credentials rotate
- preserve the secret during shared-worker session cleanup

## Why

The primary DuckLake secret may use the cache proxy's HTTP transport. Delta staging reads need a more-specific direct HTTPS secret. Creating that secret through DuckDB's credential chain fails on multi-tenant workers because their per-tenant credentials are brokered into the activation payload rather than exposed through a provider that DuckDB can discover.

Duckgres already has the correct temporary credential bundle, so it can create both secrets without another credential lookup.

## Compatibility

The additional secret is only created for AWS S3 configurations with explicit credentials. Credential-chain deployments and custom S3-compatible endpoints keep their existing behavior.

## Testing

- `just ci`
