### PR TITLE
Add DuckLake golden perf corpus

### DIFF
--- a/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
@@ -60,7 +60,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       catalog: ducklake
-      catalog_file: ../../../perf/queries/ducklake_frozen.yaml
+      catalog_file: ../../../perf/queries/ducklake_posthog_tables.yaml
       targets: [pgwire]
       run_id: ${run_id}
       dataset_version: posthog-file-views-v1

--- a/tests/perf/queries/ducklake_posthog_tables.yaml
+++ b/tests/perf/queries/ducklake_posthog_tables.yaml
@@ -1,0 +1,106 @@
+name: posthog-frozen-ducklake-golden-v1
+description: Paired raw-Parquet-view and DuckLake-table queries, plus table-only regression probes, over the frozen PostHog dataset.
+seed: 42
+dataset_scale: 1
+targets:
+  - pgwire
+  - flight
+warmup_iterations: 1
+measure_iterations: 3
+queries:
+  # Paired probes use identical SQL shapes to compare raw Parquet access with
+  # DuckLake-managed-table execution in the same artifact.
+  - query_id: q_events_total__raw_view
+    intent_id: intent_events_total
+    tags: [nightly, frozen, posthog, events, aggregate, paired, raw-view]
+    params: {}
+    pgwire_sql: SELECT COUNT(*) AS events FROM frozen_v1.events_file_view
+    duckhog_sql: SELECT COUNT(*) AS events FROM frozen_v1.events_file_view
+
+  - query_id: q_events_total__ducklake_table
+    intent_id: intent_events_total
+    tags: [nightly, frozen, posthog, events, aggregate, paired, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT COUNT(*) AS events FROM posthog.events
+    duckhog_sql: SELECT COUNT(*) AS events FROM posthog.events
+
+  - query_id: q_events_count_one_day__raw_view
+    intent_id: intent_events_count_one_day
+    tags: [nightly, frozen, posthog, events, aggregate, one-day, paired, raw-view]
+    params: {}
+    pgwire_sql: >
+      SELECT COUNT(*) AS events
+      FROM frozen_v1.events_file_view
+      WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
+        AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
+    duckhog_sql: >
+      SELECT COUNT(*) AS events
+      FROM frozen_v1.events_file_view
+      WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
+        AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
+
+  - query_id: q_events_count_one_day__ducklake_table
+    intent_id: intent_events_count_one_day
+    tags: [nightly, frozen, posthog, events, aggregate, one-day, paired, ducklake-table]
+    params: {}
+    pgwire_sql: >
+      SELECT COUNT(*) AS events
+      FROM posthog.events
+      WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
+        AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
+    duckhog_sql: >
+      SELECT COUNT(*) AS events
+      FROM posthog.events
+      WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
+        AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
+
+  - query_id: q_events_by_name_march_2026__raw_view
+    intent_id: intent_events_by_name_march_2026
+    tags: [nightly, frozen, posthog, events, aggregate, analytics, paired, raw-view]
+    params: {}
+    pgwire_sql: SELECT event, COUNT(*) AS events FROM frozen_v1.events_file_view WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
+    duckhog_sql: SELECT event, COUNT(*) AS events FROM frozen_v1.events_file_view WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
+
+  - query_id: q_events_by_name_march_2026__ducklake_table
+    intent_id: intent_events_by_name_march_2026
+    tags: [nightly, frozen, posthog, events, aggregate, analytics, paired, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT event, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
+    duckhog_sql: SELECT event, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
+
+  - query_id: q_events_distinct_persons__raw_view
+    intent_id: intent_events_distinct_persons
+    tags: [nightly, frozen, posthog, events, aggregate, distinct, paired, raw-view]
+    params: {}
+    pgwire_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM frozen_v1.events_file_view WHERE person_id IS NOT NULL
+    duckhog_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM frozen_v1.events_file_view WHERE person_id IS NOT NULL
+
+  - query_id: q_events_distinct_persons__ducklake_table
+    intent_id: intent_events_distinct_persons
+    tags: [nightly, frozen, posthog, events, aggregate, distinct, paired, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM posthog.events WHERE person_id IS NOT NULL
+    duckhog_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM posthog.events WHERE person_id IS NOT NULL
+
+  # Table-only probes track the DuckLake workload over time without a raw
+  # Parquet control query.
+  - query_id: q_persons_total__ducklake_table
+    intent_id: intent_persons_total
+    tags: [nightly, frozen, posthog, persons, aggregate, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT COUNT(*) AS persons FROM posthog.persons
+    duckhog_sql: SELECT COUNT(*) AS persons FROM posthog.persons
+
+  - query_id: q_persons_daily_april_2026__ducklake_table
+    intent_id: intent_persons_daily_april_2026
+    tags: [nightly, frozen, posthog, persons, aggregate, time-series, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT date_trunc('day', _timestamp) AS day, COUNT(*) AS persons FROM posthog.persons WHERE _timestamp >= TIMESTAMPTZ '2026-04-01 00:00:00+00' AND _timestamp < TIMESTAMPTZ '2026-05-01 00:00:00+00' GROUP BY 1 ORDER BY 1
+    duckhog_sql: SELECT date_trunc('day', _timestamp) AS day, COUNT(*) AS persons FROM posthog.persons WHERE _timestamp >= TIMESTAMPTZ '2026-04-01 00:00:00+00' AND _timestamp < TIMESTAMPTZ '2026-05-01 00:00:00+00' GROUP BY 1 ORDER BY 1
+
+  - query_id: q_events_daily_march_2026__ducklake_table
+    intent_id: intent_events_daily_march_2026
+    tags: [nightly, frozen, posthog, events, aggregate, time-series, ducklake-table]
+    params: {}
+    pgwire_sql: SELECT date_trunc('day', "timestamp") AS day, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY 1 ORDER BY 1
+    duckhog_sql: SELECT date_trunc('day', "timestamp") AS day, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY 1 ORDER BY 1


### PR DESCRIPTION
## Summary

- replace the targeted scenario's raw-view-only perf catalog with one golden corpus and one result artifact
- run four equivalent raw-Parquet-view / DuckLake-table query pairs: total events, one-day filtered event count, event-name aggregation, and distinct persons
- keep three DuckLake-table-only regression probes for persons totals/daily series and event daily series
- preserve the existing one warmup / three measurement-iteration cadence

## Why

The scenario already creates and validates `posthog.events` and `posthog.persons`. The perf corpus should use those tables while retaining raw-Parquet controls for like-for-like comparison. The one-day table count is the direct perf probe for filtered metadata aggregation.

## Validation

`go test ./tests/mw-dev/scenario ./tests/mw-dev/scenario/perf ./tests/perf/core`
`git diff --check origin/main`