### PR TITLE
feat(controlplane): serve persons_distinct_ids_table in discovery payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,6 +762,10 @@ are load-bearing for those consumers:
   reads as fleet-wide removal to every consumer).
 - **Teams come from `duckgres_org_teams`**, with RESOLVED table locations:
   `events_table`/`persons_table` = `<schema_name>.<override-or-derived>`,
+  `persons_distinct_ids_table` = `<schema_name>.` + the resolved persons
+  name with its `persons` prefix replaced by `persons_distinct_ids` (so a
+  suffixed override stays disambiguated: persons_ab12 →
+  persons_distinct_ids_ab12),
   `data_imports_schema` = override-or-`<schema>_data_imports`. The
   derivation lives ONCE, in `resolveTeamTables`; the legacy overrides are
   BARE identifiers (never schema-qualified), enforced at every write surface

--- a/controlplane/provisioning/discovery.go
+++ b/controlplane/provisioning/discovery.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -88,9 +89,16 @@ type discoveryTeam struct {
 	// schema_name + grandfathered overrides happens HERE, once, so no
 	// consumer reimplements (or mis-guesses the qualification of) the
 	// rule. See resolveTeamTables.
-	EventsTable       string `json:"events_table"`
-	PersonsTable      string `json:"persons_table"`
-	DataImportsSchema string `json:"data_imports_schema"`
+	EventsTable  string `json:"events_table"`
+	PersonsTable string `json:"persons_table"`
+	// PersonsDistinctIDsTable is where a streamed persons pipeline writes
+	// the team's distinct-id mapping rows (the person ↔ distinct_id join
+	// side). It follows the resolved persons name: a `persons` prefix is
+	// replaced with `persons_distinct_ids`, so a suffixed override
+	// (persons_ab12) maps to persons_distinct_ids_ab12; a persons override
+	// without the `persons` prefix gets `_distinct_ids` appended.
+	PersonsDistinctIDsTable string `json:"persons_distinct_ids_table"`
+	DataImportsSchema       string `json:"data_imports_schema"`
 }
 
 // resolveTeamTables derives the team's fully-qualified table locations.
@@ -100,7 +108,7 @@ type discoveryTeam struct {
 // repair repoints overrides too); absent overrides derive `events` /
 // `persons`. The data-imports override is a SCHEMA name and replaces the
 // `<schema>_data_imports` derivation wholesale.
-func resolveTeamTables(t *configstore.OrgTeam) (events, persons, dataImports string) {
+func resolveTeamTables(t *configstore.OrgTeam) (events, persons, personsDistinctIDs, dataImports string) {
 	eventsName := "events"
 	if t.EventsTableName != nil && *t.EventsTableName != "" {
 		eventsName = *t.EventsTableName
@@ -113,7 +121,19 @@ func resolveTeamTables(t *configstore.OrgTeam) (events, persons, dataImports str
 	if t.SchemaDataImportsName != nil && *t.SchemaDataImportsName != "" {
 		dataImports = *t.SchemaDataImportsName
 	}
-	return t.SchemaName + "." + eventsName, t.SchemaName + "." + personsName, dataImports
+	return t.SchemaName + "." + eventsName, t.SchemaName + "." + personsName,
+		t.SchemaName + "." + distinctIDsTableName(personsName), dataImports
+}
+
+// distinctIDsTableName derives the team's distinct-ids table from its
+// resolved persons table name. The persons suffix (if any) is the team's
+// disambiguator inside a shared schema, so the distinct-ids table must carry
+// the same suffix: persons_ab12 → persons_distinct_ids_ab12.
+func distinctIDsTableName(personsName string) string {
+	if rest, ok := strings.CutPrefix(personsName, "persons"); ok {
+		return "persons_distinct_ids" + rest
+	}
+	return personsName + "_distinct_ids"
 }
 
 type discoverySecretRef struct {
@@ -226,14 +246,15 @@ func (h *handler) assembleDiscovery() (*discoveryResponse, error) {
 		}
 		for ti := range rows {
 			t := &rows[ti]
-			events, persons, dataImports := resolveTeamTables(t)
+			events, persons, personsDistinctIDs, dataImports := resolveTeamTables(t)
 			teams = append(teams, discoveryTeam{
-				TeamID:            t.TeamID,
-				SchemaName:        t.SchemaName,
-				Enabled:           t.Enabled,
-				EventsTable:       events,
-				PersonsTable:      persons,
-				DataImportsSchema: dataImports,
+				TeamID:                  t.TeamID,
+				SchemaName:              t.SchemaName,
+				Enabled:                 t.Enabled,
+				EventsTable:             events,
+				PersonsTable:            persons,
+				PersonsDistinctIDsTable: personsDistinctIDs,
+				DataImportsSchema:       dataImports,
 			})
 			if owner, dup := teamOwners[t.TeamID]; dup {
 				// One team claimed by two orgs is a routing ambiguity — both

--- a/controlplane/provisioning/discovery_test.go
+++ b/controlplane/provisioning/discovery_test.go
@@ -426,6 +426,32 @@ func TestResolvedTableNames(t *testing.T) {
 	if tm.EventsTable != "posthog.legacy_events" || tm.PersonsTable != "posthog.persons" || tm.DataImportsSchema != "posthog_data_imports" {
 		t.Fatalf("resolved table names wrong: %+v", tm)
 	}
+	// The distinct-ids table follows the resolved persons name.
+	if tm.PersonsDistinctIDsTable != "posthog.persons_distinct_ids" {
+		t.Fatalf("resolved distinct-ids table wrong: %+v", tm)
+	}
+}
+
+func TestResolvedDistinctIDsTableFollowsPersonsSuffix(t *testing.T) {
+	// Streamed persons replication lands two tables per team (persons +
+	// distinct-ids). The distinct-ids location must track the team's
+	// resolved persons name — including a suffixed override — so a viaduck
+	// persons pipeline never re-derives the suffix rule itself.
+	s := newFakeStore()
+	seedWarehouse(s, "org-a", nil, configstore.ManagedWarehouseStateReady, time.Now())
+	seedTeam(s, "org-a", configstore.OrgTeam{
+		TeamID:           2,
+		SchemaName:       "posthog",
+		Enabled:          true,
+		PersonsTableName: strPtrD("persons_ab12"),
+	})
+
+	var resp discoveryResponse
+	getJSON(t, newTestRouter(s), "/api/v1/warehouses", &resp)
+	tm := resp.Warehouses[0].Teams[0]
+	if tm.PersonsTable != "posthog.persons_ab12" || tm.PersonsDistinctIDsTable != "posthog.persons_distinct_ids_ab12" {
+		t.Fatalf("distinct-ids table must follow the persons suffix: %+v", tm)
+	}
 }
 
 func TestConfigGenerationAdvancesOnTeamChange(t *testing.T) {


### PR DESCRIPTION
## What

Adds `persons_distinct_ids_table` to the per-team payload served by `GET /api/v1/warehouses` (destination discovery for external writers).

## Why

Streamed persons replication (millpond → shared DuckLake changelog → viaduck `full_cdc` fanout) lands **two** tables per team in the duckling: the persons table and its distinct-id mapping table (the join side of today's denormalized batch export). Discovery already resolves `events_table`/`persons_table`; the distinct-ids location belongs in the same single derivation site so a viaduck persons pipeline never re-derives the suffix rule itself.

## Derivation rule

`resolveTeamTables` now also returns `<schema_name>.` + the resolved persons name with its `persons` prefix replaced by `persons_distinct_ids`:

- `persons` → `persons_distinct_ids`
- `persons_ab12` (suffixed override) → `persons_distinct_ids_ab12`
- an override without the `persons` prefix → `<name>_distinct_ids`

No new configstore column: this table has no legacy/grandfathered shape, so convention-only derivation is sufficient.

## Compatibility

Additive field on the existing team payload — wire-compatible per the discovery module's own contract (adding a field is safe, removing one is not).

## Tests

- `TestResolvedTableNames` extended to assert the default derivation
- New `TestResolvedDistinctIDsTableFollowsPersonsSuffix` for the suffixed-override case
- `go test ./controlplane/...` green; `golangci-lint run` clean

🤖 Prepared by an agent as part of the persons-backfill → millpond/viaduck streaming migration.