### PR TITLE
Register frozen Parquet files for DuckLake perf

### DIFF
--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -101,12 +101,12 @@ just scenario-frozen-perf
 ```
 
 This runs, in order: raw-view setup, source-column preflight, explicit PostHog
-table DDL and partition setup, deterministic rewritten inserts, then schema,
-partition, count, timestamp-range, key-null-count, and bidirectional parity
-validation. The setup records the pinned revision, `rewritten_insert`, partition
-specifications, and source/destination row counts in
-`main.posthog_table_setup_manifest`. Neither `fast-suite` nor `full-suite` enables
-these tables yet.
+table DDL, registration of the frozen Parquet files in DuckLake, then partition
+and file-metadata validation. Registration reads Parquet footers but does not
+rewrite the fixture rows, so the raw-view and DuckLake-table queries use the
+same frozen S3 objects. The setup records the pinned revision, registration
+mode, and source/registered file counts in `main.posthog_table_setup_manifest`.
+Neither `fast-suite` nor `full-suite` enables these tables yet.
 
 Run frozen dbt lifecycle:
 

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -601,6 +601,8 @@ func TestPostHogTableSetupValidatesRequiredSourceColumnsAndMappings(t *testing.T
 		"CAST(historical_migration AS BOOLEAN)",
 		"CAST(\"timestamp\" AS TIMESTAMPTZ)",
 		"CAST(_timestamp AS TIMESTAMPTZ)",
+		"SET preserve_insertion_order = false",
+		"streaming_rewritten_insert",
 	} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("posthog setup missing explicit source mapping or diagnostic %q", want)

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -564,12 +564,14 @@ func TestPostHogTableSetupIsExplicitAndRerunnable(t *testing.T) {
 	sql := string(raw)
 	for _, want := range []string{
 		"CREATE SCHEMA IF NOT EXISTS posthog",
-		"CREATE TABLE IF NOT EXISTS posthog.events (",
-		"CREATE TABLE IF NOT EXISTS posthog.persons (",
-		"DELETE FROM posthog.events",
-		"DELETE FROM posthog.persons",
-		"INSERT INTO posthog.events (",
-		"INSERT INTO posthog.persons (",
+		"DROP TABLE IF EXISTS posthog.events",
+		"DROP TABLE IF EXISTS posthog.persons",
+		"CREATE TABLE posthog.events (",
+		"CREATE TABLE posthog.persons (",
+		"CALL ducklake_add_data_files(",
+		"${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet",
+		"${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet",
+		"allow_missing => true",
 		"SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))",
 		"SET PARTITIONED BY (year(_timestamp), month(_timestamp))",
 	} {
@@ -577,8 +579,14 @@ func TestPostHogTableSetupIsExplicitAndRerunnable(t *testing.T) {
 			t.Fatalf("posthog setup missing %q", want)
 		}
 	}
-	if strings.Contains(sql, "CREATE TABLE AS") || strings.Contains(sql, "SELECT *") {
-		t.Fatal("posthog setup must use explicit table and select column lists")
+	for _, unwanted := range []string{
+		"INSERT INTO posthog.events",
+		"INSERT INTO posthog.persons",
+		"SET preserve_insertion_order",
+	} {
+		if strings.Contains(sql, unwanted) {
+			t.Fatalf("posthog setup must register files, not contain %q", unwanted)
+		}
 	}
 }
 
@@ -590,47 +598,43 @@ func TestPostHogTableSetupValidatesRequiredSourceColumnsAndMappings(t *testing.T
 	sql := string(raw)
 	for _, want := range []string{
 		"056583335dc739b9e025efede811c9b4f5e153f5",
-		"frozen_v1.events_file_view",
-		"frozen_v1.persons_file_view",
+		"table_schema = 'frozen_v1'",
+		"table_name = 'events_file_view'",
+		"table_name = 'persons_file_view'",
 		"information_schema.columns",
 		"missing required source columns",
-		"CAST(properties AS VARCHAR)",
-		"CAST(person_properties AS VARCHAR)",
-		"CAST(team_id AS BIGINT) AS project_id",
-		"CAST(person_version AS UBIGINT)",
-		"CAST(historical_migration AS BOOLEAN)",
-		"CAST(\"timestamp\" AS TIMESTAMPTZ)",
-		"CAST(_timestamp AS TIMESTAMPTZ)",
-		"SET preserve_insertion_order = false",
-		"streaming_rewritten_insert",
+		"('project_id')",
+		"registered_frozen_parquet",
+		"ducklake_list_files",
 	} {
 		if !strings.Contains(sql, want) {
-			t.Fatalf("posthog setup missing explicit source mapping or diagnostic %q", want)
+			t.Fatalf("posthog setup missing registration diagnostic %q", want)
 		}
 	}
 }
 
-func TestPostHogTableValidationFailsOnParityMismatchWithUsefulDiagnostics(t *testing.T) {
+func TestPostHogTableValidationChecksRegisteredFixtureMetadata(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join("sql", "validate_posthog_tables.sql"))
 	if err != nil {
 		t.Fatalf("read posthog table validation: %v", err)
 	}
 	sql := string(raw)
 	for _, want := range []string{
-		"EXCEPT ALL",
 		"ordinal_position",
-		"posthog events parity mismatch",
-		"posthog persons parity mismatch",
-		"posthog.events row-count mismatch",
-		"posthog.persons row-count mismatch",
-		"posthog.events timestamp range mismatch",
-		"posthog.persons timestamp range mismatch",
+		"ducklake_list_files",
+		"glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet')",
+		"glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet')",
+		"posthog frozen-file registration mismatch",
+		"posthog table-registration manifest mismatch",
 		"DESCRIBE posthog.events",
 		"DESCRIBE posthog.persons",
 	} {
 		if !strings.Contains(sql, want) {
-			t.Fatalf("posthog setup missing parity validation %q", want)
+			t.Fatalf("posthog setup missing registration validation %q", want)
 		}
+	}
+	if strings.Contains(sql, "FROM posthog.events") || strings.Contains(sql, "FROM posthog.persons") {
+		t.Fatal("posthog registration validation must not scan table rows before perf")
 	}
 }
 

--- a/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
@@ -1,14 +1,19 @@
 -- Production schema reference: PostHog/posthog@056583335dc739b9e025efede811c9b4f5e153f5
 -- posthog/dags/events_backfill_to_duckling.py (EVENTS_TABLE_DDL and PERSONS_TABLE_DDL).
--- The frozen Parquet views remain the raw performance-control representation.
--- Mapping exception: production derives project_id from team_id, so this rewrite
--- does the same and intentionally does not require a project_id fixture column.
+--
+-- The frozen objects are immutable, read-only fixtures. Register their Parquet
+-- footers in DuckLake rather than copying their rows into new Parquet files:
+-- this preserves the raw/table comparison while avoiding a large rewrite and
+-- its temporary-disk use. The source object names are not Hive directories, so
+-- registration has to precede the table partition specification.
 
--- Verify the frozen export carries every production backfill column before DDL or
--- DML. The column names are non-sensitive and make a stale fixture failure actionable.
+-- Verify that the unioned source schema can populate the production table
+-- schema. `allow_missing` below remains necessary for individual files from a
+-- schema-evolving export: an absent field is read as NULL, as it is by the raw
+-- `union_by_name` view.
 WITH expected_events(column_name) AS (
     VALUES
-        ('uuid'), ('event'), ('properties'), ('timestamp'), ('team_id'),
+        ('uuid'), ('event'), ('properties'), ('timestamp'), ('team_id'), ('project_id'),
         ('distinct_id'), ('elements_chain'), ('created_at'), ('person_id'),
         ('person_created_at'), ('person_properties'), ('group0_properties'),
         ('group1_properties'), ('group2_properties'), ('group3_properties'),
@@ -54,7 +59,24 @@ FROM missing_persons;
 
 CREATE SCHEMA IF NOT EXISTS posthog;
 
-CREATE TABLE IF NOT EXISTS posthog.events (
+CREATE TABLE IF NOT EXISTS main.posthog_table_setup_manifest (
+    fixture_schema_revision VARCHAR,
+    load_mode VARCHAR,
+    events_source_files BIGINT,
+    events_registered_files BIGINT,
+    persons_source_files BIGINT,
+    persons_registered_files BIGINT,
+    created_at TIMESTAMPTZ
+);
+
+-- `ducklake_add_data_files` appends metadata registrations. Drop and recreate
+-- these scenario-only tables so a retry cannot retain a partial registration.
+BEGIN TRANSACTION;
+
+DROP TABLE IF EXISTS posthog.events;
+DROP TABLE IF EXISTS posthog.persons;
+
+CREATE TABLE posthog.events (
     uuid VARCHAR,
     event VARCHAR,
     properties VARCHAR,
@@ -82,7 +104,7 @@ CREATE TABLE IF NOT EXISTS posthog.events (
     _inserted_at TIMESTAMPTZ
 );
 
-CREATE TABLE IF NOT EXISTS posthog.persons (
+CREATE TABLE posthog.persons (
     team_id BIGINT,
     distinct_id VARCHAR,
     id VARCHAR,
@@ -95,114 +117,50 @@ CREATE TABLE IF NOT EXISTS posthog.persons (
     _inserted_at TIMESTAMPTZ
 );
 
+CALL ducklake_add_data_files(
+    'ducklake',
+    'events',
+    '${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet',
+    schema => 'posthog',
+    allow_missing => true
+);
+
+CALL ducklake_add_data_files(
+    'ducklake',
+    'persons',
+    '${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet',
+    schema => 'posthog',
+    allow_missing => true
+);
+
+-- The registered fixture paths are flat names, not `key=value/` Hive paths.
+-- Defining this afterwards retains the production table specification without
+-- making the registration infer nonexistent partition values from those paths.
 ALTER TABLE posthog.events
 SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp));
 
 ALTER TABLE posthog.persons
 SET PARTITIONED BY (year(_timestamp), month(_timestamp));
 
-CREATE TABLE IF NOT EXISTS main.posthog_table_setup_manifest (
-    production_schema_revision VARCHAR,
-    load_mode VARCHAR,
-    events_partition_spec VARCHAR,
-    persons_partition_spec VARCHAR,
-    events_source_rows BIGINT,
-    events_destination_rows BIGINT,
-    persons_source_rows BIGINT,
-    persons_destination_rows BIGINT,
-    created_at TIMESTAMPTZ
-);
-
--- Rewritten inserts make a partial setup retry deterministic: each run replaces
--- the table contents rather than appending a second copy of the frozen fixture.
-DELETE FROM posthog.events;
-DELETE FROM posthog.persons;
-
--- The frozen fixture is larger than the worker's temporary disk. Do not retain
--- insertion order while writing its partitioned DuckLake tables: this lets
--- DuckDB flush completed data blocks instead of accumulating spill state for
--- the full backfill. Each large insert commits independently so its temporary
--- state cannot be retained by the other relation's load.
-SET preserve_insertion_order = false;
-
-INSERT INTO posthog.events (
-    uuid, event, properties, timestamp, team_id, project_id, distinct_id,
-    elements_chain, created_at, person_id, person_created_at, person_properties,
-    group0_properties, group1_properties, group2_properties, group3_properties,
-    group4_properties, group0_created_at, group1_created_at, group2_created_at,
-    group3_created_at, group4_created_at, person_mode, historical_migration,
-    _inserted_at
-)
-SELECT
-    CAST(uuid AS VARCHAR),
-    CAST(event AS VARCHAR),
-    CAST(properties AS VARCHAR),
-    CAST("timestamp" AS TIMESTAMPTZ),
-    CAST(team_id AS BIGINT),
-    CAST(team_id AS BIGINT) AS project_id,
-    CAST(distinct_id AS VARCHAR),
-    CAST(elements_chain AS VARCHAR),
-    CAST(created_at AS TIMESTAMPTZ),
-    CAST(person_id AS VARCHAR),
-    CAST(person_created_at AS TIMESTAMPTZ),
-    CAST(person_properties AS VARCHAR),
-    CAST(group0_properties AS VARCHAR),
-    CAST(group1_properties AS VARCHAR),
-    CAST(group2_properties AS VARCHAR),
-    CAST(group3_properties AS VARCHAR),
-    CAST(group4_properties AS VARCHAR),
-    CAST(group0_created_at AS TIMESTAMPTZ),
-    CAST(group1_created_at AS TIMESTAMPTZ),
-    CAST(group2_created_at AS TIMESTAMPTZ),
-    CAST(group3_created_at AS TIMESTAMPTZ),
-    CAST(group4_created_at AS TIMESTAMPTZ),
-    CAST(person_mode AS VARCHAR),
-    CAST(historical_migration AS BOOLEAN),
-    CAST(_inserted_at AS TIMESTAMPTZ)
-FROM frozen_v1.events_file_view;
-
-INSERT INTO posthog.persons (
-    team_id, distinct_id, id, properties, created_at, is_identified,
-    person_distinct_id_version, person_version, _timestamp, _inserted_at
-)
-SELECT
-    CAST(team_id AS BIGINT),
-    CAST(distinct_id AS VARCHAR),
-    CAST(id AS VARCHAR),
-    CAST(properties AS VARCHAR),
-    CAST(created_at AS TIMESTAMPTZ),
-    CAST(is_identified AS BOOLEAN),
-    CAST(person_distinct_id_version AS BIGINT),
-    CAST(person_version AS UBIGINT),
-    CAST(_timestamp AS TIMESTAMPTZ),
-    CAST(_inserted_at AS TIMESTAMPTZ)
-FROM frozen_v1.persons_file_view;
-
-BEGIN TRANSACTION;
-
 DELETE FROM main.posthog_table_setup_manifest
-WHERE production_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5';
+WHERE fixture_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5';
 
 INSERT INTO main.posthog_table_setup_manifest (
-    production_schema_revision,
+    fixture_schema_revision,
     load_mode,
-    events_partition_spec,
-    persons_partition_spec,
-    events_source_rows,
-    events_destination_rows,
-    persons_source_rows,
-    persons_destination_rows,
+    events_source_files,
+    events_registered_files,
+    persons_source_files,
+    persons_registered_files,
     created_at
 )
 SELECT
     '056583335dc739b9e025efede811c9b4f5e153f5',
-    'streaming_rewritten_insert',
-    'year(timestamp), month(timestamp), day(timestamp)',
-    'year(_timestamp), month(_timestamp)',
-    (SELECT COUNT(*) FROM frozen_v1.events_file_view),
-    (SELECT COUNT(*) FROM posthog.events),
-    (SELECT COUNT(*) FROM frozen_v1.persons_file_view),
-    (SELECT COUNT(*) FROM posthog.persons),
+    'registered_frozen_parquet',
+    (SELECT COUNT(*) FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet')),
+    (SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'events', schema => 'posthog')),
+    (SELECT COUNT(*) FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet')),
+    (SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'persons', schema => 'posthog')),
     now();
 
 COMMIT;

--- a/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
@@ -113,12 +113,17 @@ CREATE TABLE IF NOT EXISTS main.posthog_table_setup_manifest (
     created_at TIMESTAMPTZ
 );
 
-BEGIN TRANSACTION;
-
 -- Rewritten inserts make a partial setup retry deterministic: each run replaces
 -- the table contents rather than appending a second copy of the frozen fixture.
 DELETE FROM posthog.events;
 DELETE FROM posthog.persons;
+
+-- The frozen fixture is larger than the worker's temporary disk. Do not retain
+-- insertion order while writing its partitioned DuckLake tables: this lets
+-- DuckDB flush completed data blocks instead of accumulating spill state for
+-- the full backfill. Each large insert commits independently so its temporary
+-- state cannot be retained by the other relation's load.
+SET preserve_insertion_order = false;
 
 INSERT INTO posthog.events (
     uuid, event, properties, timestamp, team_id, project_id, distinct_id,
@@ -173,6 +178,8 @@ SELECT
     CAST(_inserted_at AS TIMESTAMPTZ)
 FROM frozen_v1.persons_file_view;
 
+BEGIN TRANSACTION;
+
 DELETE FROM main.posthog_table_setup_manifest
 WHERE production_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5';
 
@@ -189,7 +196,7 @@ INSERT INTO main.posthog_table_setup_manifest (
 )
 SELECT
     '056583335dc739b9e025efede811c9b4f5e153f5',
-    'rewritten_insert',
+    'streaming_rewritten_insert',
     'year(timestamp), month(timestamp), day(timestamp)',
     'year(_timestamp), month(_timestamp)',
     (SELECT COUNT(*) FROM frozen_v1.events_file_view),

--- a/tests/mw-dev/scenario/sql/steps_test.go
+++ b/tests/mw-dev/scenario/sql/steps_test.go
@@ -504,6 +504,8 @@ func TestExecutorTemplatesSQLFileEnvVars(t *testing.T) {
 }
 
 func TestExecutorPropagatesPostHogValidationDiagnostics(t *testing.T) {
+	t.Setenv("DUCKGRES_SCENARIO_FROZEN_S3_URI", "s3://example-frozen/frozen_v1/")
+
 	for _, tc := range []struct {
 		name       string
 		file       string
@@ -517,10 +519,10 @@ func TestExecutorPropagatesPostHogValidationDiagnostics(t *testing.T) {
 			contains:   "information_schema.columns",
 		},
 		{
-			name:       "parity mismatch",
+			name:       "registered fixture mismatch",
 			file:       filepath.Join("validate_posthog_tables.sql"),
-			diagnostic: "posthog events parity mismatch",
-			contains:   "EXCEPT ALL",
+			diagnostic: "posthog frozen-file registration mismatch",
+			contains:   "ducklake_list_files",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
@@ -1,5 +1,6 @@
--- Validation for the production-shaped PostHog DuckLake tables. Every assertion
--- raises a concise, non-sensitive SQL error so the scenario fails before perf runs.
+-- Validation for the registered PostHog DuckLake tables. These assertions use
+-- schemas and file metadata only: the perf step is the first one that reads
+-- the fixture rows.
 
 DESCRIBE posthog.events;
 DESCRIBE posthog.persons;
@@ -104,140 +105,52 @@ SELECT CASE
 END
 FROM partition_mismatches;
 
-WITH counts AS (
-    SELECT
-        (SELECT COUNT(*) FROM frozen_v1.events_file_view) AS events_source_rows,
-        (SELECT COUNT(*) FROM posthog.events) AS events_destination_rows,
-        (SELECT COUNT(*) FROM frozen_v1.persons_file_view) AS persons_source_rows,
-        (SELECT COUNT(*) FROM posthog.persons) AS persons_destination_rows
-)
-SELECT CASE
-    WHEN events_source_rows = events_destination_rows THEN 1
-    ELSE error('posthog.events row-count mismatch')
-END,
-CASE
-    WHEN persons_source_rows = persons_destination_rows THEN 1
-    ELSE error('posthog.persons row-count mismatch')
-END
-FROM counts;
-
-WITH ranges AS (
-    SELECT
-        (SELECT MIN(CAST("timestamp" AS TIMESTAMPTZ)) FROM frozen_v1.events_file_view) AS events_source_min,
-        (SELECT MAX(CAST("timestamp" AS TIMESTAMPTZ)) FROM frozen_v1.events_file_view) AS events_source_max,
-        (SELECT MIN(timestamp) FROM posthog.events) AS events_destination_min,
-        (SELECT MAX(timestamp) FROM posthog.events) AS events_destination_max,
-        (SELECT MIN(CAST(_timestamp AS TIMESTAMPTZ)) FROM frozen_v1.persons_file_view) AS persons_source_min,
-        (SELECT MAX(CAST(_timestamp AS TIMESTAMPTZ)) FROM frozen_v1.persons_file_view) AS persons_source_max,
-        (SELECT MIN(_timestamp) FROM posthog.persons) AS persons_destination_min,
-        (SELECT MAX(_timestamp) FROM posthog.persons) AS persons_destination_max
-)
-SELECT CASE
-    WHEN events_source_min IS NOT DISTINCT FROM events_destination_min
-     AND events_source_max IS NOT DISTINCT FROM events_destination_max THEN 1
-    ELSE error('posthog.events timestamp range mismatch')
-END,
-CASE
-    WHEN persons_source_min IS NOT DISTINCT FROM persons_destination_min
-     AND persons_source_max IS NOT DISTINCT FROM persons_destination_max THEN 1
-    ELSE error('posthog.persons timestamp range mismatch')
-END
-FROM ranges;
-
-WITH null_counts AS (
-    SELECT
-        (SELECT COUNT(*) FROM frozen_v1.events_file_view WHERE uuid IS NULL OR event IS NULL OR "timestamp" IS NULL OR team_id IS NULL) AS events_source_nulls,
-        (SELECT COUNT(*) FROM posthog.events WHERE uuid IS NULL OR event IS NULL OR timestamp IS NULL OR team_id IS NULL) AS events_destination_nulls,
-        (SELECT COUNT(*) FROM frozen_v1.persons_file_view WHERE team_id IS NULL OR distinct_id IS NULL OR id IS NULL OR _timestamp IS NULL) AS persons_source_nulls,
-        (SELECT COUNT(*) FROM posthog.persons WHERE team_id IS NULL OR distinct_id IS NULL OR id IS NULL OR _timestamp IS NULL) AS persons_destination_nulls
-)
-SELECT CASE
-    WHEN events_source_nulls = events_destination_nulls THEN 1
-    ELSE error('posthog.events key null-count mismatch')
-END,
-CASE
-    WHEN persons_source_nulls = persons_destination_nulls THEN 1
-    ELSE error('posthog.persons key null-count mismatch')
-END
-FROM null_counts;
-
-WITH source_events AS (
-    SELECT
-        CAST(uuid AS VARCHAR) AS uuid, CAST(event AS VARCHAR) AS event,
-        CAST(properties AS VARCHAR) AS properties, CAST("timestamp" AS TIMESTAMPTZ) AS timestamp,
-        CAST(team_id AS BIGINT) AS team_id, CAST(team_id AS BIGINT) AS project_id,
-        CAST(distinct_id AS VARCHAR) AS distinct_id, CAST(elements_chain AS VARCHAR) AS elements_chain,
-        CAST(created_at AS TIMESTAMPTZ) AS created_at, CAST(person_id AS VARCHAR) AS person_id,
-        CAST(person_created_at AS TIMESTAMPTZ) AS person_created_at, CAST(person_properties AS VARCHAR) AS person_properties,
-        CAST(group0_properties AS VARCHAR) AS group0_properties, CAST(group1_properties AS VARCHAR) AS group1_properties,
-        CAST(group2_properties AS VARCHAR) AS group2_properties, CAST(group3_properties AS VARCHAR) AS group3_properties,
-        CAST(group4_properties AS VARCHAR) AS group4_properties, CAST(group0_created_at AS TIMESTAMPTZ) AS group0_created_at,
-        CAST(group1_created_at AS TIMESTAMPTZ) AS group1_created_at, CAST(group2_created_at AS TIMESTAMPTZ) AS group2_created_at,
-        CAST(group3_created_at AS TIMESTAMPTZ) AS group3_created_at, CAST(group4_created_at AS TIMESTAMPTZ) AS group4_created_at,
-        CAST(person_mode AS VARCHAR) AS person_mode, CAST(historical_migration AS BOOLEAN) AS historical_migration,
-        CAST(_inserted_at AS TIMESTAMPTZ) AS _inserted_at
-    FROM frozen_v1.events_file_view
+-- Exact file-list equality proves the tables refer to precisely the frozen
+-- objects. No data-file scan is required for this check.
+WITH expected_files AS (
+    SELECT 'events' AS table_name, file AS data_file
+    FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet')
+    UNION ALL
+    SELECT 'persons' AS table_name, file AS data_file
+    FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet')
 ),
-left_difference AS (
-    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
-        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
-        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
-        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
-    FROM source_events
-    EXCEPT ALL
-    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
-        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
-        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
-        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
-    FROM posthog.events
+registered_files AS (
+    SELECT 'events' AS table_name, data_file, delete_file
+    FROM ducklake_list_files('ducklake', 'events', schema => 'posthog')
+    UNION ALL
+    SELECT 'persons' AS table_name, data_file, delete_file
+    FROM ducklake_list_files('ducklake', 'persons', schema => 'posthog')
 ),
-right_difference AS (
-    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
-        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
-        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
-        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
-    FROM posthog.events
+missing_registrations AS (
+    SELECT table_name, data_file FROM expected_files
     EXCEPT ALL
-    SELECT uuid, event, properties, timestamp, team_id, project_id, distinct_id, elements_chain, created_at,
-        person_id, person_created_at, person_properties, group0_properties, group1_properties, group2_properties,
-        group3_properties, group4_properties, group0_created_at, group1_created_at, group2_created_at,
-        group3_created_at, group4_created_at, person_mode, historical_migration, _inserted_at
-    FROM source_events
+    SELECT table_name, data_file FROM registered_files
+),
+unexpected_registrations AS (
+    SELECT table_name, data_file FROM registered_files
+    EXCEPT ALL
+    SELECT table_name, data_file FROM expected_files
+),
+delete_files AS (
+    SELECT table_name FROM registered_files WHERE delete_file IS NOT NULL
 )
 SELECT CASE
-    WHEN (SELECT COUNT(*) FROM left_difference) = 0 AND (SELECT COUNT(*) FROM right_difference) = 0 THEN 1
-    ELSE error('posthog events parity mismatch')
+    WHEN (SELECT COUNT(*) FROM missing_registrations) = 0
+     AND (SELECT COUNT(*) FROM unexpected_registrations) = 0
+     AND (SELECT COUNT(*) FROM delete_files) = 0 THEN 1
+    ELSE error('posthog frozen-file registration mismatch')
 END;
 
-WITH source_persons AS (
-    SELECT
-        CAST(team_id AS BIGINT) AS team_id, CAST(distinct_id AS VARCHAR) AS distinct_id,
-        CAST(id AS VARCHAR) AS id, CAST(properties AS VARCHAR) AS properties,
-        CAST(created_at AS TIMESTAMPTZ) AS created_at, CAST(is_identified AS BOOLEAN) AS is_identified,
-        CAST(person_distinct_id_version AS BIGINT) AS person_distinct_id_version,
-        CAST(person_version AS UBIGINT) AS person_version, CAST(_timestamp AS TIMESTAMPTZ) AS _timestamp,
-        CAST(_inserted_at AS TIMESTAMPTZ) AS _inserted_at
-    FROM frozen_v1.persons_file_view
-),
-left_difference AS (
-    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
-        person_distinct_id_version, person_version, _timestamp, _inserted_at
-    FROM source_persons
-    EXCEPT ALL
-    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
-        person_distinct_id_version, person_version, _timestamp, _inserted_at
-    FROM posthog.persons
-),
-right_difference AS (
-    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
-        person_distinct_id_version, person_version, _timestamp, _inserted_at
-    FROM posthog.persons
-    EXCEPT ALL
-    SELECT team_id, distinct_id, id, properties, created_at, is_identified,
-        person_distinct_id_version, person_version, _timestamp, _inserted_at
-    FROM source_persons
+WITH manifest AS (
+    SELECT *
+    FROM main.posthog_table_setup_manifest
+    WHERE fixture_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5'
 )
 SELECT CASE
-    WHEN (SELECT COUNT(*) FROM left_difference) = 0 AND (SELECT COUNT(*) FROM right_difference) = 0 THEN 1
-    ELSE error('posthog persons parity mismatch')
-END;
+    WHEN COUNT(*) = 1
+     AND MIN(load_mode) = 'registered_frozen_parquet'
+     AND MIN(events_source_files) = MIN(events_registered_files)
+     AND MIN(persons_source_files) = MIN(persons_registered_files) THEN 1
+    ELSE error('posthog table-registration manifest mismatch')
+END
+FROM manifest;


### PR DESCRIPTION
## Summary

- replace the memory/disk-heavy `INSERT … SELECT` backfill with `ducklake_add_data_files` registration of the frozen events and persons Parquet objects
- create the DuckLake tables before registration, then apply the existing production partition specifications; the fixture keys are flat rather than Hive-partitioned
- validate exact file-list registration and schema metadata without scanning the corpus before the perf step

## Why

The first real mw-dev run failed during `setup_posthog_tables`: rewriting the production-sized fixture exhausted worker ephemeral storage. Registration reads Parquet footers and writes DuckLake catalog metadata only, so raw-view and DuckLake-table perf queries use the same immutable S3 objects.

## Validation

- `go test ./tests/mw-dev/scenario ./tests/mw-dev/scenario/sql`
- local smoke test with the pinned DuckLake extension: register a Parquet file, apply partitioning afterward, query it successfully, and confirm no replacement Parquet files were written
- `git diff --check`

Next: dispatch `posthog_frozen_perf` from this branch to validate mw-dev setup and performance.