### PR TITLE
build: make DuckDB 1.5.5 the fleet default

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -83,19 +83,23 @@ jobs:
                       # does not. See scripts/ducklake_version_matrix.sh
                       # commit history for the rationale on each row.
                       pg_scanner_repo: "https://extensions.duckdb.org"
-                      default: true
+                      # Rollback row: publishes suffixed tags only. Operators
+                      # roll a tenant back by re-pointing its `image`
+                      # config-store column at a …-duckdb1.5.3 tag.
+                      default: false
                     - version: "1.5.5"
                       go: "v2.10505.0"
                       bindings: "v0.10505.0"
-                      # Same credential-refresh/write-retry patch set as the
-                      # default row, rebuilt against DuckDB 1.5.5.
+                      # cred-refresh-write-retry rebuilt against DuckDB 1.5.5:
+                      # mid-statement S3 credential recovery on ExpiredToken
+                      # read/write auth failures (see the 1.5.3 row).
                       httpfs: "v1.5.5-cred-refresh-write-retry"
                       # First PostHog DuckLake release built for DuckDB 1.5.5.
                       ducklake: "v1.0-posthog.7"
                       pg_scanner_repo: "https://extensions.duckdb.org"
-                      # Canary only: publishes suffixed tags without moving the
-                      # fleet-wide unsuffixed tag or dispatching Charts.
-                      default: false
+                      # Fleet default: also publishes the unsuffixed tags and
+                      # dispatches Charts.
+                      default: true
                 platform:
                     - platform: linux/arm64
                       runner: ubuntu-24.04-arm
@@ -277,9 +281,9 @@ jobs:
             matrix:
                 duckdb:
                     - version: "1.5.3"
-                      default: true
-                    - version: "1.5.5"
                       default: false
+                    - version: "1.5.5"
+                      default: true
         runs-on: ubuntu-24.04
         permissions:
             id-token: write

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -86,8 +86,8 @@ jobs:
       tag: pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}-arm64
       platform: linux/arm64
       cache-scope: e2e-duckgres-arm64
-      # DuckDB 1.5.5 canary row. The worker CD matrix keeps 1.5.3 as
-      # default:true until per-tenant canaries complete.
+      # Default DuckDB row (1.5.5) — mirrors the default:true matrix entry in
+      # container-image-worker-cd.yml. Keep in lock-step on a version bump.
       build-args: |
         DUCKDB_EXTENSION_VERSION=1.5.5
         HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry

--- a/scripts/ducklake_version_matrix.sh
+++ b/scripts/ducklake_version_matrix.sh
@@ -26,7 +26,7 @@ TEST_TIMEOUT="${DUCKLAKE_TEST_TIMEOUT:-300s}"
 #   v2.10502.0 → DuckDB 1.5.2 (DuckLake 1.0)
 #   v2.10503.0 → DuckDB 1.5.3 (DuckLake 1.0)
 #   v2.10505.0 → DuckDB 1.5.5 (DuckLake 1.0)
-# The current canary and rollback versions are benchmarked by default; older
+# The current default and rollback versions are benchmarked by default; older
 # versions remain testable on demand via DUCKLAKE_VERSIONS.
 DEFAULT_VERSIONS="v2.10505.0 v2.10503.0"
 VERSIONS="${DUCKLAKE_VERSIONS:-$DEFAULT_VERSIONS}"


### PR DESCRIPTION
## Summary

Promotes DuckDB **1.5.5** from canary to the fleet default, following #1028 (which published the 1.5.5 canary images and moved CI/e2e onto 1.5.5).

- **Worker CD matrix**: `1.5.5` is now `default: true` in both the build and manifest matrices — it publishes the unsuffixed fleet tags (`:latest`, `:<sha>`) and dispatches Charts. `1.5.3` stays in the matrix as a non-default **rollback row**, still publishing `…-duckdb1.5.3` suffixed tags, so rolling a tenant back is a config-store `image` re-point, and a full fleet rollback is a revert of this PR.
- **e2e comment** updated to reflect that 1.5.5 now mirrors the `default:true` row.
- **`ducklake_version_matrix.sh`** comment updated (default + rollback versions).

No code changes: `go.mod`, the Dockerfiles, the e2e/scenario image pins, and the mw-dev harness assertions all moved to 1.5.5 in #1028.

**This PR's e2e-mw-dev run is the gate**: it builds a 1.5.5 image and exercises the full activation pipeline (control plane → STS → worker pod → DuckDB → DuckLake on real S3/cnpg) on the mw-dev cluster, including the engine-version (`v1.5.5`) and fork-extension SHA assertions added in #1028.

Known 1.5.5 behavioral note (from #1028 testing): internal catalog schemas (e.g. `system`, `temp`) are now listed by `duckdb_schemas()`/`pg_catalog.pg_namespace`. No production impact surfaced in the test suite; worth a look during review/canary.

## Validation

- Matrix invariants re-verified locally: exactly one `default: true` (1.5.5) in both matrices.
- #1028's merge train on main was fully green (CI, CodeQL, Release Build, all three container CD workflows), and the 1.5.5 worker images published for amd64+arm64.
- Full `tests/integration` suite and DuckLake concurrency benchmark pass on 1.5.5.
