### PR TITLE
feat(admin): show org names in live panel

### DIFF
--- a/controlplane/admin/ui/src/pages/Live.test.tsx
+++ b/controlplane/admin/ui/src/pages/Live.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const hooks = vi.hoisted(() => ({
+  useCancelSession: vi.fn(),
+  useKillUserSessions: vi.fn(),
+  useOrgs: vi.fn(),
+  useQueries: vi.fn(),
+  useQueryDetail: vi.fn(),
+  useSessions: vi.fn(),
+}));
+vi.mock("@/hooks/useApi", () => hooks);
+
+const identity = vi.hoisted(() => ({ useIdentity: vi.fn() }));
+vi.mock("@/components/IdentityProvider", () => identity);
+
+import { Live } from "./Live";
+
+const ok = <T,>(data: T) => ({
+  data,
+  isSuccess: true,
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+});
+const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+
+describe("Live page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    identity.useIdentity.mockReturnValue({ isAdmin: true });
+    hooks.useCancelSession.mockReturnValue(mutation());
+    hooks.useKillUserSessions.mockReturnValue(mutation());
+    hooks.useQueryDetail.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+    hooks.useOrgs.mockReturnValue(
+      ok([
+        {
+          name: "org-a-id",
+          database_name: "product_analytics",
+          hostname_alias: null,
+        },
+      ]),
+    );
+    hooks.useQueries.mockReturnValue(
+      ok([
+        {
+          org: "org-a-id",
+          user: "query-user",
+          pid: 101,
+          worker_id: 11,
+          protocol: "pg",
+          percentage: 25,
+          rows: 10,
+          total_rows: 40,
+          stalled: false,
+          started_at: "2026-08-04T12:00:00Z",
+          elapsed_ms: 500,
+          state: "active",
+        },
+      ]),
+    );
+    hooks.useSessions.mockReturnValue(
+      ok([
+        {
+          org: "org-a-id",
+          user: "session-user",
+          pid: 202,
+          worker_id: 22,
+          protocol: "flight",
+        },
+      ]),
+    );
+  });
+
+  it("shows the readable org name next to the org ID in both live tables", () => {
+    render(
+      <TooltipProvider>
+        <Live />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getAllByText("product_analytics")).toHaveLength(2);
+    expect(screen.getAllByText("org-a-id")).toHaveLength(2);
+  });
+});

--- a/controlplane/admin/ui/src/pages/Live.tsx
+++ b/controlplane/admin/ui/src/pages/Live.tsx
@@ -18,15 +18,32 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useCancelSession, useKillUserSessions, useQueries, useSessions } from "@/hooks/useApi";
-import { fmtAge, fmtDurationMs, fmtInt, fmtTime } from "@/lib/format";
+import { useCancelSession, useKillUserSessions, useOrgs, useQueries, useSessions } from "@/hooks/useApi";
+import { fmtAge, fmtDurationMs, fmtInt, fmtTime, orgLabel } from "@/lib/format";
 import { idleInTransaction, isIdleSession, sessionStateLabel } from "@/lib/session";
 import { compareByStarted, compareByWorker } from "@/lib/liveSort";
 import { QueryDetailDialog } from "@/components/QueryDetailDialog";
 
+function OrgIdentity({ id, label }: { id: string; label?: string }) {
+  if (!label || label === id) {
+    return <span className="font-mono text-xs">{id}</span>;
+  }
+  return (
+    <span className="block min-w-0">
+      <span className="block truncate text-xs font-medium text-foreground" title={label}>
+        {label}
+      </span>
+      <span className="block truncate font-mono text-[11px] text-muted-foreground" title={id}>
+        {id}
+      </span>
+    </span>
+  );
+}
+
 export function Live() {
   const queries = useQueries();
   const sessions = useSessions();
+  const orgs = useOrgs();
   const cancel = useCancelSession();
   const killUser = useKillUserSessions();
   const [org, setOrg] = useState("");
@@ -36,6 +53,11 @@ export function Live() {
   // The kill endpoint targets an EXACT (org, user); the filter boxes are
   // substring matches, so only offer it once both are set, and pass them verbatim.
   const canKillUser = org.trim() !== "" && user.trim() !== "";
+
+  const orgLabels = useMemo(
+    () => new Map((orgs.data ?? []).map((o) => [o.name, orgLabel(o)])),
+    [orgs.data],
+  );
 
   const matchOrg = (o?: string) => !org || (o ?? "").toLowerCase().includes(org.toLowerCase());
   const matchUser = (u?: string) => !user || (u ?? "").toLowerCase().includes(user.toLowerCase());
@@ -164,7 +186,9 @@ export function Live() {
                         title="View query detail"
                       >
                         <TableCell className="font-mono text-xs">{q.pid}</TableCell>
-                        <TableCell className="font-mono text-xs">{q.org}</TableCell>
+                        <TableCell>
+                          <OrgIdentity id={q.org} label={orgLabels.get(q.org)} />
+                        </TableCell>
                         <TableCell className="font-mono text-xs">{q.user || "—"}</TableCell>
                         <TableCell className="font-mono text-xs tabular-nums text-muted-foreground">
                           <Tooltip>
@@ -263,7 +287,9 @@ export function Live() {
                   {liveSessions.map((s) => (
                     <TableRow key={`${s.pid}-${s.worker_id}`} className="[&>td]:py-1.5">
                       <TableCell className="font-mono text-xs">{s.pid}</TableCell>
-                      <TableCell className="font-mono text-xs">{s.org}</TableCell>
+                      <TableCell>
+                        <OrgIdentity id={s.org} label={orgLabels.get(s.org)} />
+                      </TableCell>
                       <TableCell className="font-mono text-xs">{s.user || "—"}</TableCell>
                       <TableCell className="font-mono text-xs">#{s.worker_id}</TableCell>
                       <TableCell>


### PR DESCRIPTION
## Summary

- show the readable database name above the raw org ID in both Live tables
- preserve raw org IDs for filtering, session targeting, and fallback display
- add a render-level regression test for running queries and active sessions

## Test plan

- `just ui-test`
- `just lint`
- `npm run lint` (0 errors; 8 pre-existing warnings)
