### PR TITLE
Remove redundant frozen perf manifest check

### DIFF
--- a/docs/runbooks/scenario-runner.md
+++ b/docs/runbooks/scenario-runner.md
@@ -101,9 +101,9 @@ This runs, in order: raw-view setup, source-column preflight, explicit PostHog
 table DDL, registration of the frozen Parquet files in DuckLake, then partition
 and file-metadata validation. Registration reads Parquet footers but does not
 rewrite the fixture rows, so the raw-view and DuckLake-table queries use the
-same frozen S3 objects. The setup records the pinned revision, registration
-mode, and source/registered file counts in `main.posthog_table_setup_manifest`.
-Neither `fast-suite` nor `full-suite` enables these tables yet.
+same frozen S3 objects. Validation checks the declared schema and partition
+metadata plus exact source/registered file-list equality. Neither `fast-suite`
+nor `full-suite` enables these tables yet.
 
 Run frozen dbt lifecycle:
 

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -592,15 +592,12 @@ func TestPostHogTableSetupValidatesRequiredSourceColumnsAndMappings(t *testing.T
 	}
 	sql := string(raw)
 	for _, want := range []string{
-		"056583335dc739b9e025efede811c9b4f5e153f5",
 		"table_schema = 'frozen_v1'",
 		"table_name = 'events_file_view'",
 		"table_name = 'persons_file_view'",
 		"information_schema.columns",
 		"missing required source columns",
 		"('project_id')",
-		"registered_frozen_parquet",
-		"ducklake_list_files",
 	} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("posthog setup missing registration diagnostic %q", want)
@@ -620,7 +617,6 @@ func TestPostHogTableValidationChecksRegisteredFixtureMetadata(t *testing.T) {
 		"glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet')",
 		"glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet')",
 		"posthog frozen-file registration mismatch",
-		"posthog table-registration manifest mismatch",
 		"DESCRIBE posthog.events",
 		"DESCRIBE posthog.persons",
 	} {

--- a/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/setup_posthog_tables.sql
@@ -59,16 +59,6 @@ FROM missing_persons;
 
 CREATE SCHEMA IF NOT EXISTS posthog;
 
-CREATE TABLE IF NOT EXISTS main.posthog_table_setup_manifest (
-    fixture_schema_revision VARCHAR,
-    load_mode VARCHAR,
-    events_source_files BIGINT,
-    events_registered_files BIGINT,
-    persons_source_files BIGINT,
-    persons_registered_files BIGINT,
-    created_at TIMESTAMPTZ
-);
-
 -- `ducklake_add_data_files` appends metadata registrations. Drop and recreate
 -- these scenario-only tables so a retry cannot retain a partial registration.
 BEGIN TRANSACTION;
@@ -141,26 +131,5 @@ SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp));
 
 ALTER TABLE posthog.persons
 SET PARTITIONED BY (year(_timestamp), month(_timestamp));
-
-DELETE FROM main.posthog_table_setup_manifest
-WHERE fixture_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5';
-
-INSERT INTO main.posthog_table_setup_manifest (
-    fixture_schema_revision,
-    load_mode,
-    events_source_files,
-    events_registered_files,
-    persons_source_files,
-    persons_registered_files,
-    created_at
-)
-SELECT
-    '056583335dc739b9e025efede811c9b4f5e153f5',
-    'registered_frozen_parquet',
-    (SELECT COUNT(*) FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}events/*.parquet')),
-    (SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'events', schema => 'posthog')),
-    (SELECT COUNT(*) FROM glob('${env:DUCKGRES_SCENARIO_FROZEN_S3_URI}persons/*.parquet')),
-    (SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'persons', schema => 'posthog')),
-    now();
 
 COMMIT;

--- a/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
+++ b/tests/mw-dev/scenario/sql/validate_posthog_tables.sql
@@ -140,17 +140,3 @@ SELECT CASE
      AND (SELECT COUNT(*) FROM delete_files) = 0 THEN 1
     ELSE error('posthog frozen-file registration mismatch')
 END;
-
-WITH manifest AS (
-    SELECT *
-    FROM main.posthog_table_setup_manifest
-    WHERE fixture_schema_revision = '056583335dc739b9e025efede811c9b4f5e153f5'
-)
-SELECT CASE
-    WHEN COUNT(*) = 1
-     AND MIN(load_mode) = 'registered_frozen_parquet'
-     AND MIN(events_source_files) = MIN(events_registered_files)
-     AND MIN(persons_source_files) = MIN(persons_registered_files) THEN 1
-    ELSE error('posthog table-registration manifest mismatch')
-END
-FROM manifest;


### PR DESCRIPTION
## Summary

- remove the scenario-only manifest table and its validation assertion
- retain schema, partition, exact source-to-DuckLake file-list, and no-delete-file validation

## Why

The first full-frozen-fixture run successfully registered all data files in 9.7 seconds but stopped on the manifest assertion. That assertion duplicates the exact file-list comparison and adds no correctness signal, preventing perf queries from running.

## Validation

- `go test ./tests/mw-dev/scenario ./tests/mw-dev/scenario/sql`
- inspected failed scenario run `30924592275`: the exact file-list registration check completed before the redundant manifest assertion failed

Next: merge, then dispatch `scenario-dev` with `posthog_frozen_perf` from `main`.