### PR TITLE
build: pin postgres scanner snapshot fix

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -79,10 +79,11 @@ jobs:
                       # ducklake_s3 secret.
                       httpfs: "v1.5.3-cred-refresh-write-retry"
                       ducklake: "v1.0-posthog.6"
-                      # Stable repo hosts postgres_scanner for 1.5.3; nightly
-                      # does not. See scripts/ducklake_version_matrix.sh
-                      # commit history for the rationale on each row.
+                      # Keep the rollback row on the previously validated
+                      # stable scanner artifact.
                       pg_scanner_repo: "https://extensions.duckdb.org"
+                      pg_scanner_sha256_amd64: "42e9ba5c2a9f9f77f1415e4cd320295f9623d4c20e09b20687d384a06681e54c"
+                      pg_scanner_sha256_arm64: "39eb0d153a2454397963b26aa2c2ceba853c21033277e06968b51173a5965a2f"
                       # Rollback row: publishes suffixed tags only. Operators
                       # roll a tenant back by re-pointing its `image`
                       # config-store column at a …-duckdb1.5.3 tag.
@@ -96,7 +97,13 @@ jobs:
                       httpfs: "v1.5.5-cred-refresh-write-retry"
                       # First PostHog DuckLake release built for DuckDB 1.5.5.
                       ducklake: "v1.0-posthog.7"
-                      pg_scanner_repo: "https://extensions.duckdb.org"
+                      # The stable 1.5.5 scanner predates duckdb-postgres
+                      # 71b85668, which fixes inconsistent snapshots across
+                      # scan connections. These checksums content-pin the
+                      # nightly artifact built from descendant ab217c6.
+                      pg_scanner_repo: "https://nightly-extensions.duckdb.org"
+                      pg_scanner_sha256_amd64: "afc9a0f7ef0158e11235294929df7ea71995e168146c8b0a6409e9181b02766b"
+                      pg_scanner_sha256_arm64: "6ae9474e39f1b091e44104d8c4a3d7af45b290696edf87fca10bba13e78a61fd"
                       # Fleet default: also publishes the unsuffixed tags and
                       # dispatches Charts.
                       default: true
@@ -156,6 +163,8 @@ jobs:
                       HTTPFS_EXTENSION_TAG=${{ matrix.duckdb.httpfs }}
                       DUCKLAKE_EXTENSION_TAG=${{ matrix.duckdb.ducklake }}
                       POSTGRES_SCANNER_REPOSITORY=${{ matrix.duckdb.pg_scanner_repo }}
+                      POSTGRES_SCANNER_SHA256_AMD64=${{ matrix.duckdb.pg_scanner_sha256_amd64 }}
+                      POSTGRES_SCANNER_SHA256_ARM64=${{ matrix.duckdb.pg_scanner_sha256_arm64 }}
                   cache-from: type=gha,scope=worker-${{ matrix.duckdb.version }}-${{ matrix.platform.slug }}
                   cache-to: type=gha,mode=max,scope=worker-${{ matrix.duckdb.version }}-${{ matrix.platform.slug }}
 

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -93,7 +93,9 @@ jobs:
         HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry
         DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
-        POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
+        POSTGRES_SCANNER_REPOSITORY=https://nightly-extensions.duckdb.org
+        POSTGRES_SCANNER_SHA256_AMD64=afc9a0f7ef0158e11235294929df7ea71995e168146c8b0a6409e9181b02766b
+        POSTGRES_SCANNER_SHA256_ARM64=6ae9474e39f1b091e44104d8c4a3d7af45b290696edf87fca10bba13e78a61fd
     secrets:
       ecr-role: ${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}
 

--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -50,7 +50,9 @@ jobs:
         HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry
         DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
         DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
-        POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
+        POSTGRES_SCANNER_REPOSITORY=https://nightly-extensions.duckdb.org
+        POSTGRES_SCANNER_SHA256_AMD64=afc9a0f7ef0158e11235294929df7ea71995e168146c8b0a6409e9181b02766b
+        POSTGRES_SCANNER_SHA256_ARM64=6ae9474e39f1b091e44104d8c4a3d7af45b290696edf87fca10bba13e78a61fd
     secrets:
       ecr-role: ${{ vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,12 @@ ARG DUCKDB_EXTENSION_VERSION=1.5.5
 ARG HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
-# Repository for postgres_scanner specifically. Defaults to the stable
-# extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions
-# may need the nightly repo to match what was previously published).
-ARG POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
+# Repository for postgres_scanner specifically. The checksums content-pin the
+# DuckDB 1.5.5 nightly artifact built from duckdb-postgres ab217c6; CI overrides
+# all three values together for rollback rows.
+ARG POSTGRES_SCANNER_REPOSITORY=https://nightly-extensions.duckdb.org
+ARG POSTGRES_SCANNER_SHA256_AMD64=afc9a0f7ef0158e11235294929df7ea71995e168146c8b0a6409e9181b02766b
+ARG POSTGRES_SCANNER_SHA256_ARM64=6ae9474e39f1b091e44104d8c4a3d7af45b290696edf87fca10bba13e78a61fd
 # `: ${VAR:?msg}` asserts every required input is non-empty — catches a
 # CI matrix row that forgets to pass a build-arg and would otherwise
 # silently fall back to the ARG default, producing a cross-version
@@ -43,6 +45,12 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && : "${DUCKLAKE_EXTENSION_TAG:?must be set}" \
     && : "${DUCKDB_EXTENSION_REPOSITORY:?must be set}" \
     && : "${POSTGRES_SCANNER_REPOSITORY:?must be set}" \
+    && case "${TARGETARCH}" in \
+         amd64) postgres_scanner_sha256="${POSTGRES_SCANNER_SHA256_AMD64}" ;; \
+         arm64) postgres_scanner_sha256="${POSTGRES_SCANNER_SHA256_ARM64}" ;; \
+         *) echo "ERROR: unsupported TARGETARCH for postgres_scanner: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && : "${postgres_scanner_sha256:?postgres_scanner checksum must be set}" \
     && mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/PostHog/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
@@ -51,7 +59,11 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${POSTGRES_SCANNER_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
-      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
+      -o /tmp/postgres_scanner.duckdb_extension.gz \
+    && echo "${postgres_scanner_sha256}  /tmp/postgres_scanner.duckdb_extension.gz" | sha256sum -c - \
+    && gunzip -c /tmp/postgres_scanner.duckdb_extension.gz \
+      > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
+    && rm /tmp/postgres_scanner.duckdb_extension.gz \
     && for f in httpfs ducklake json postgres_scanner; do \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -54,10 +54,12 @@ ARG DUCKDB_EXTENSION_VERSION=1.5.5
 ARG HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry
 ARG DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7
 ARG DUCKDB_EXTENSION_REPOSITORY=https://extensions.duckdb.org
-# Repository for postgres_scanner specifically. Defaults to the stable
-# extensions repo, overridable per-row in CI (e.g. legacy DuckDB versions
-# may need the nightly repo to match what was previously published).
-ARG POSTGRES_SCANNER_REPOSITORY=https://extensions.duckdb.org
+# Repository for postgres_scanner specifically. The checksums content-pin the
+# DuckDB 1.5.5 nightly artifact built from duckdb-postgres ab217c6; CI overrides
+# all three values together for rollback rows.
+ARG POSTGRES_SCANNER_REPOSITORY=https://nightly-extensions.duckdb.org
+ARG POSTGRES_SCANNER_SHA256_AMD64=afc9a0f7ef0158e11235294929df7ea71995e168146c8b0a6409e9181b02766b
+ARG POSTGRES_SCANNER_SHA256_ARM64=6ae9474e39f1b091e44104d8c4a3d7af45b290696edf87fca10bba13e78a61fd
 
 # Cross-check that DUCKDB_EXTENSION_VERSION (which keys the bundled-extension
 # directory layout) matches the DuckDB version implied by DUCKDB_BINDINGS_VERSION.
@@ -91,6 +93,12 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && : "${DUCKLAKE_EXTENSION_TAG:?must be set}" \
     && : "${DUCKDB_EXTENSION_REPOSITORY:?must be set}" \
     && : "${POSTGRES_SCANNER_REPOSITORY:?must be set}" \
+    && case "${TARGETARCH}" in \
+         amd64) postgres_scanner_sha256="${POSTGRES_SCANNER_SHA256_AMD64}" ;; \
+         arm64) postgres_scanner_sha256="${POSTGRES_SCANNER_SHA256_ARM64}" ;; \
+         *) echo "ERROR: unsupported TARGETARCH for postgres_scanner: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && : "${postgres_scanner_sha256:?postgres_scanner checksum must be set}" \
     && mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/PostHog/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
@@ -99,7 +107,11 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \
     && curl -fsSL "${POSTGRES_SCANNER_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension.gz" \
-      | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
+      -o /tmp/postgres_scanner.duckdb_extension.gz \
+    && echo "${postgres_scanner_sha256}  /tmp/postgres_scanner.duckdb_extension.gz" | sha256sum -c - \
+    && gunzip -c /tmp/postgres_scanner.duckdb_extension.gz \
+      > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/postgres_scanner.duckdb_extension" \
+    && rm /tmp/postgres_scanner.duckdb_extension.gz \
     && for f in httpfs ducklake json postgres_scanner; do \
          [ -s "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/$f.duckdb_extension" ] \
            || { echo "ERROR: $f.duckdb_extension is empty after fetch" >&2; exit 1; }; \

--- a/server/server.go
+++ b/server/server.go
@@ -1152,11 +1152,12 @@ func seedBundledExtensions(srcRoot, dstRoot string) error {
 // metadata work) and ship updated binaries between DuckDB releases.
 // postgres_scanner is here because PR #447 originally bundled it from the
 // nightly repo to overwrite stale stable copies seeded on prior worker
-// upgrades; even now that we pull from stable, refreshing on every boot
-// keeps the on-disk extension cache in sync with whatever the running
-// image bundles. json is a stock DuckDB extension that we pull from the
-// stable repo for the engine's version — it doesn't ship intra-version
-// changes, so it's intentionally omitted.
+// upgrades. It can also carry checksum-pinned upstream fixes within one
+// DuckDB patch release, so refreshing on every boot keeps the on-disk
+// extension cache in sync with whatever the running image bundles. json is
+// a stock DuckDB extension that we pull from the stable repo for the engine's
+// version — it doesn't ship intra-version changes, so it's intentionally
+// omitted.
 func shouldRefreshBundledExtension(srcPath string) bool {
 	switch filepath.Base(srcPath) {
 	case "httpfs.duckdb_extension",
@@ -1456,7 +1457,7 @@ func shouldInstallExtension(name string) bool {
 	// The bundle-skip optimization assumes a bundled .duckdb_extension on disk
 	// is enough — LOAD finds the file via extension_directory and DuckDB treats
 	// it as installed. That holds for the PostHog-fork extensions (httpfs,
-	// ducklake) and the stable ones we ship (json, postgres_scanner): LOAD
+	// ducklake) and the upstream ones we ship (json, postgres_scanner): LOAD
 	// against the seeded extension_directory file just works.
 	return !hasBundledExtensionBinary(name)
 }


### PR DESCRIPTION
## Summary

- use the DuckDB 1.5.5 nightly `postgres_scanner` built from `ab217c6`, which contains upstream snapshot fix [`71b85668`](https://github.com/duckdb/duckdb-postgres/commit/71b85668afdff00bd947fc21b0e6bde397690971)
- content-pin the amd64 and arm64 compressed artifacts with SHA-256 checks in both image builders
- propagate the repository and checksums through worker CD, mw-dev E2E, and scenario builds
- retain the DuckDB 1.5.3 rollback row on its previously validated stable scanner

## Why

The stable DuckDB 1.5.5 scanner artifact reports source revision `41223e5`, which predates the fix that puts every forced scan connection in the exported PostgreSQL snapshot. Under concurrent DuckLake metadata commits, that can make related catalog scans observe different snapshots and surface missing- or duplicate-column failures.

The nightly URL is mutable, so the checksum verification fails closed instead of silently accepting a different artifact. A future follow-up can mirror these exact binaries to an immutable PostHog-owned location.

## Validation

- checksum guard rejected the current stable 1.5.5 artifact before the repository switch
- `Dockerfile` arm64 builder image, including the existing bundled-scanner COPY test
- `Dockerfile.worker` arm64 builder image for DuckDB 1.5.5
- `Dockerfile.worker` arm64 rollback image for DuckDB 1.5.3
- confirmed the bundled 1.5.5 scanner contains revision `ab217c6`
- `just test-unit`
- `just test-scenario`
- `just lint`
- workflow YAML parsing and `git diff --check`