### PR TITLE
build: link patched PostHog DuckDB engine (v1.5.5-posthog.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,3 +154,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1
+
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1 h1:tNEwT0I3opiyExELmRWDMqog4y8QMULw9Y4sfPRoV0w=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1/go.mod h1:si4fhkU5nVX82UqieuHih5FkAIzbHQaJCxJ6BITL4U8=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1 h1:vuaMkqfPSQ7RuSwtCOYKQVbK4F5L37qrzr1P3XGS02s=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1/go.mod h1:MSpni+1dJdPoTQjbn+H702kD1iVveoQ6qWDdshBn140=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=
@@ -73,10 +77,6 @@ github.com/duckdb/duckdb-go-bindings/lib/darwin-amd64 v0.10505.0 h1:FrMqquFBQlMs
 github.com/duckdb/duckdb-go-bindings/lib/darwin-amd64 v0.10505.0/go.mod h1:EnAvZh1kNJHp5yF+M1ZHNEvapnmt6anq1xXHVrAGqMo=
 github.com/duckdb/duckdb-go-bindings/lib/darwin-arm64 v0.10505.0 h1:lbRbpQwT1MmUhh/VTwukV9K8bxKByV3UghAP3MvsbBo=
 github.com/duckdb/duckdb-go-bindings/lib/darwin-arm64 v0.10505.0/go.mod h1:IGLSeEcFhNeZF16aVjQCULD7TsFZKG5G7SyKJAXKp5c=
-github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 v0.10505.0 h1:nrsaVYj3XYCRbS2FpdOMD/KHE7egRMr+/NR1IHmjT84=
-github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 v0.10505.0/go.mod h1:KAIynZ0GHCS7X5fRyuFnQMg/SZBPK/bS9OCOVojClxw=
-github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 v0.10505.0 h1:qM6oGDgwXBILJGbTY4fCy6QOczLpucUA6yn6g3ORjh4=
-github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 v0.10505.0/go.mod h1:81SGOYoEUs8qaAfSk1wRfM5oobrIJ5KI7AzYhK6/bvQ=
 github.com/duckdb/duckdb-go-bindings/lib/windows-amd64 v0.10505.0 h1:DjqZl9rYreHkSOqnqLmkrqH5T8UdQNcxZLJVZzGmXXA=
 github.com/duckdb/duckdb-go-bindings/lib/windows-amd64 v0.10505.0/go.mod h1:K25pJL26ARblGDeuAkrdblFvUen92+CwksLtPEHRqqQ=
 github.com/duckdb/duckdb-go/v2 v2.10505.0 h1:SWwvLn2Qx/RQSnQNupwgIF8VbnJ5A6OQU9lYb/mDETI=

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -135,11 +135,15 @@ READY_TIMEOUT="${READY_TIMEOUT:-1200}"
 # without masking a genuinely missing worker forever.
 WORKER_INSPECTION_ATTEMPTS=30
 
-# The bundled extensions MUST be the PostHog forks. These are the short commit
-# SHAs duckdb_extensions() reports for the tags the image pins
+# The bundled engine and extensions MUST be the PostHog forks. The extension
+# SHAs are what duckdb_extensions() reports for the tags the image pins
 # (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7, HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry).
-# If the image accidentally ships upstream, the version differs and we fail.
+# The engine itself is the PostHog/duckdb patchline build: library_version
+# stays v1.5.5 (extension resolution), while source_id identifies the
+# patchline commit (posthog/v1.5.5 prefetch-accounting patch).
+# If the image accidentally ships upstream, the version/source differs and we fail.
 EXPECT_DUCKDB_VERSION="v1.5.5"
+EXPECT_DUCKDB_SOURCE_ID="911c1d6428"
 EXPECT_DUCKLAKE_SHA="6768849c"
 EXPECT_HTTPFS_SHA="575da0b"
 
@@ -1068,6 +1072,12 @@ assert_fork_extensions() { # org password
     "SELECT library_version FROM pragma_version()")"
   [ "$engine" = "$EXPECT_DUCKDB_VERSION" ] || \
     fail "DuckDB library version '$engine' != '$EXPECT_DUCKDB_VERSION'"
+  source_id="$(pg "$1" "$2" ducklake \
+    "SELECT source_id FROM pragma_version()")"
+  case "$source_id" in
+    "$EXPECT_DUCKDB_SOURCE_ID"*) ;;
+    *) fail "DuckDB source_id '$source_id' does not start with patchline commit '$EXPECT_DUCKDB_SOURCE_ID' (upstream engine?)" ;;
+  esac
   dl="$(pg "$1" "$2" ducklake \
     "SELECT extension_version FROM duckdb_extensions() WHERE extension_name='ducklake' AND loaded")"
   [ "$dl" = "$EXPECT_DUCKLAKE_SHA" ] || \


### PR DESCRIPTION
## Summary

Links the **PostHog patched DuckDB engine** into duckgres, replacing the two upstream linux lib modules in `go.mod`:

```
replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1
replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1
```

The patchline is **upstream v1.5.5 + one patch** ([PostHog/duckdb@`posthog/v1.5.5`](https://github.com/PostHog/duckdb/compare/v1.5.5...posthog/v1.5.5)):

- **Count each parquet chunk once in prefetch accounting** — fixes spurious `The parquet file ... seems to have incorrectly set page offsets` IOErrors on **remote (S3) parquet reads** when pushed-down VARIANT/struct field extracts create multiple readers over the same physical column. Each extract's reader reported the column's full compressed size, inflating the sum past the row-group span; on remote files that trips the hard error, locally it just silently disabled prefetch.

Versioning: `library_version` stays **`v1.5.5`** (extension resolution + bundled fork extensions unchanged); the build is identified by **`source_id = 911c1d6428…`** in `pragma_version()`. The mw-dev harness now asserts both.

darwin/windows lib modules stay upstream — macOS devs build the unpatched 1.5.5 engine until fork darwin bundles are published.

## Validation

- Patchline CI: Main workflow Linux Debug (compile + tests) green on PostHog/duckdb.
- Full local duckgres suite against the patched engine: `go test ./server ./duckdbservice ./controlplane` and the complete `tests/integration` run — all green.
- REPL probe: `pragma_version()` → `v1.5.5 / 911c1d6428`.
- **This PR's e2e-mw-dev run is the behavioral gate**: the harness exercises DuckLake/parquet on real S3 with the patched prefetch accounting and asserts the engine `source_id`.
