### PR TITLE
Fail open node-local cache proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Duckgres supports three configuration methods (in order of precedence):
 
 Kubernetes workers can use the optional node-local NVMe cache proxy with
 `DUCKGRES_CACHE_ENABLED=true`. The worker waits at most
-`DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` (default: `5s`) for its initial health
+`DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` (default: `5s`, maximum: `10s`) for its initial health
 check. It then starts normally: a worker-local forward router bypasses an
 unhealthy proxy and fetches signed objects from the authoritative S3 source.
 The router probes for recovery with capped exponential backoff and jitter, and

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ column cannot be added to a populated table).
 ## Runbooks
 
 - [Worker Upgrades & Canaries](docs/runbooks/worker-upgrades.md): Process for upgrading DuckDB/DuckLake versions, canarying builds for a subset of tenants, and global version management.
+- [Node-local Cache Proxy Bypass](docs/runbooks/cache-proxy-bypass.md): Fail-open cache behavior, detection, and recovery.
 - [Performance Harness](docs/perf-harness-runbook.md): Local smoke and nightly operations for performance testing.
 - [Dev Scenario Runner](docs/runbooks/scenario-dev.md): Scheduled and manually dispatched scenario runs against the configured dev environment.
 - [Control Plane Rollout](docs/runbooks/control-plane-rollout.md): Zero-downtime deployment process for the control plane itself.
@@ -278,6 +279,22 @@ Duckgres supports three configuration methods (in order of precedence):
 2. Environment variables
 3. YAML config file
 4. Built-in defaults (lowest priority)
+
+### Node-local cache proxy
+
+Kubernetes workers can use the optional node-local NVMe cache proxy with
+`DUCKGRES_CACHE_ENABLED=true`. The worker waits at most
+`DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` (default: `5s`) for its initial health
+check. It then starts normally: a worker-local forward router bypasses an
+unhealthy proxy and fetches signed objects from the authoritative S3 source.
+The router probes for recovery with capped exponential backoff and jitter, and
+re-enables the local cache after a healthy probe. This setting is an environment
+variable only; it is injected into worker pods alongside `NODE_IP`.
+
+Cache-proxy loss affects cache performance, not worker readiness or PostgreSQL
+session admission. A bypass does not hide HTTP/S3 responses from the proxy, and
+does not replay writes; only a GET/HEAD whose local-proxy connection failed
+before a response is received is retried against the authoritative source.
 
 ### YAML Configuration
 

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -226,6 +226,12 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 				},
 			},
 		)
+		if timeout := os.Getenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT"); timeout != "" {
+			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+				Name:  "DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT",
+				Value: timeout,
+			})
+		}
 	}
 
 	// Add toleration if configured.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -201,6 +201,19 @@ The older fleet-level `duckgres_control_plane_worker_*` metrics remain useful
 for process-wide worker counts, spawn time, and the approximate post-admission
 worker queue. They have no org label and are not admission saturation metrics.
 
+### Node-local cache proxy metrics
+
+These worker-local metrics have no tenant labels. Exactly one
+`duckgres_worker_cache_proxy_mode{mode}` series is `1`.
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `duckgres_worker_cache_proxy_mode` | `mode` | Current cache mode: `cached`, `bypassed`, or `disabled`; the active mode is `1`. |
+| `duckgres_worker_cache_proxy_bypass_transitions_total` | `reason` | Entries into bypass mode: `startup_unavailable`, `runtime_unavailable`, or `upstream_unavailable`. |
+| `duckgres_worker_cache_proxy_bypassed_operations_total` | `reason` | Operations routed around the node-local cache. |
+| `duckgres_worker_cache_proxy_reconnect_attempts_total` | None | Health checks made by the recovery supervisor. |
+| `duckgres_worker_cache_proxy_recoveries_total` | None | Successful cache re-enablement events. |
+
 ## PromQL recipes
 
 Admission wait p95 by org and terminal result:

--- a/docs/runbooks/cache-proxy-bypass.md
+++ b/docs/runbooks/cache-proxy-bypass.md
@@ -38,6 +38,7 @@ directly until their local proxy recovers.
 ## Startup behavior
 
 `DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` bounds the initial health check and
-defaults to `5s`. After the timeout, the worker starts in bypass mode; increasing
-this value only delays a cache decision and should not be used as a substitute
-for fixing a repeatedly unhealthy cache proxy.
+defaults to `5s`; it is clamped to `10s` to preserve the worker-start budget.
+After the timeout, the worker starts in bypass mode; increasing this value only
+delays a cache decision and should not be used as a substitute for fixing a
+repeatedly unhealthy cache proxy.

--- a/docs/runbooks/cache-proxy-bypass.md
+++ b/docs/runbooks/cache-proxy-bypass.md
@@ -1,0 +1,43 @@
+# Runbook: Node-local Cache Proxy Bypass
+
+## Impact
+
+When `duckgres-cache-proxy` is unavailable on a worker node, workers remain
+ready and PostgreSQL sessions continue. They bypass the local NVMe cache and
+fetch signed object data from the authoritative S3 source. The proxy's own
+peer-cache path is unavailable while that daemon is down, so affected workers
+may read more from S3 and have higher read latency/cost.
+
+The alert statement is therefore factually correct: **Workers on affected nodes
+will bypass local NVMe cache and fetch more data from peers or S3.** Healthy
+proxies can still satisfy cache misses from peers; bypassed workers use S3
+directly until their local proxy recovers.
+
+## Detection
+
+- `duckgres_worker_cache_proxy_mode == 0` on a cache-enabled worker.
+- Increasing `duckgres_worker_cache_proxy_bypass_transitions_total` or
+  `duckgres_worker_cache_proxy_bypassed_operations_total`.
+- Cache-proxy pod CrashLoopBackOff/OOMKilled events on the corresponding node.
+
+## Response
+
+1. Confirm the worker is serving sessions; do not recycle it solely to restore
+   cache performance.
+2. Inspect the node-local `duckgres-cache-proxy` pod for OOM or storage errors.
+   The existing `scripts/probe_worker_egress.sh` script can verify the node
+   host-port health endpoint.
+3. Restore the daemon or its NVMe capacity. Workers probe `/health` with capped
+   exponential backoff and jitter, then automatically re-enable caching after a
+   successful health check.
+4. Verify `duckgres_worker_cache_proxy_mode` returns to `1` and
+   `duckgres_worker_cache_proxy_recoveries_total` increases. Query/read errors
+   that persist after bypass are source-path errors and must be investigated as
+   S3, credentials, or data-integrity failures rather than cache availability.
+
+## Startup behavior
+
+`DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` bounds the initial health check and
+defaults to `5s`. After the timeout, the worker starts in bypass mode; increasing
+this value only delays a cache decision and should not be used as a substitute
+for fixing a repeatedly unhealthy cache proxy.

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -80,7 +80,7 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 
 	cfg := p.cfg
 	cfg.DuckLake = payload.DuckLake
-	overrideS3EndpointForCacheProxy(&cfg.DuckLake)
+	p.overrideS3EndpointForCacheProxy(&cfg.DuckLake)
 	// Tag postgres_scanner libpq connections with an application_name that
 	// includes the org so Aurora's pg_stat_activity / Performance Insights
 	// can attribute metadata-DB load back to a duckgres tenant. Skipped if
@@ -223,7 +223,7 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 		refreshFn = server.RefreshS3Secret
 	}
 	if enabled {
-		overrideS3EndpointForCacheProxy(&cfg)
+		p.overrideS3EndpointForCacheProxy(&cfg)
 	}
 	if err := refreshFn(refreshDB, cfg, sem); err != nil {
 		return fmt.Errorf("swap S3 secret transport (s3_cache=%v): %w", enabled, err)
@@ -350,7 +350,7 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			p.mu.RUnlock()
 			refreshCfg := payload.DuckLake
 			if !bypassed {
-				overrideS3EndpointForCacheProxy(&refreshCfg)
+				p.overrideS3EndpointForCacheProxy(&refreshCfg)
 			}
 			if err := refreshFn(refreshDB, refreshCfg, sem); err != nil {
 				slog.Warn("Failed to refresh S3 credentials on hot-idle reuse.", "org", payload.OrgID, "error", err)
@@ -460,7 +460,7 @@ func (p *SessionPool) currentSessionConfig() (server.Config, error) {
 
 	cfg := p.cfg
 	cfg.DuckLake = p.activation.payload.DuckLake
-	overrideS3EndpointForCacheProxy(&cfg.DuckLake)
+	p.overrideS3EndpointForCacheProxy(&cfg.DuckLake)
 	return cfg, nil
 }
 

--- a/duckdbservice/cache_proxy.go
+++ b/duckdbservice/cache_proxy.go
@@ -34,6 +34,9 @@ const (
 	// defaultCacheProxyConnectTimeout bounds worker startup when the optional
 	// node-local cache daemon is unavailable.
 	defaultCacheProxyConnectTimeout = 5 * time.Second
+	// maxCacheProxyConnectTimeout preserves enough worker-start budget for
+	// DuckDB warmup and the control-plane health RPC.
+	maxCacheProxyConnectTimeout = 10 * time.Second
 )
 
 // cacheEnabled returns true when the cache proxy integration should be used.
@@ -125,6 +128,11 @@ func cacheProxyConnectTimeout() time.Duration {
 		slog.Warn("Invalid DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT; using default.",
 			"value", value, "default", defaultCacheProxyConnectTimeout, "error", err)
 		return defaultCacheProxyConnectTimeout
+	}
+	if timeout > maxCacheProxyConnectTimeout {
+		slog.Warn("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT exceeds the safe maximum; clamping.",
+			"value", timeout, "maximum", maxCacheProxyConnectTimeout)
+		return maxCacheProxyConnectTimeout
 	}
 	return timeout
 }

--- a/duckdbservice/cache_proxy.go
+++ b/duckdbservice/cache_proxy.go
@@ -1,6 +1,8 @@
 package duckdbservice
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -13,11 +15,10 @@ import (
 //
 //	DUCKGRES_CACHE_ENABLED=true
 //
-// When enabled, duckgres assumes a cache proxy DaemonSet is running on the
-// same node and:
-//   - waits for its health endpoint before serving queries (prevents early
-//     S3 traffic from bypassing the cache)
-//   - routes DuckLake S3 requests through it (S3 endpoint override)
+// When enabled, duckgres starts a stable worker-local router. The router uses
+// the node-local DaemonSet when healthy and directly fetches from the signed
+// authoritative S3 source when it is not, so cache availability never gates
+// workers or PostgreSQL sessions.
 //
 // The proxy is reached via the node IP + fixed hostPorts. The NODE_IP env
 // var is injected into worker pods via the Kubernetes Downward API; control
@@ -29,6 +30,10 @@ const (
 
 	// NODE_IP is populated via fieldRef: status.hostIP on each pod.
 	nodeIPEnvVar = "NODE_IP"
+
+	// defaultCacheProxyConnectTimeout bounds worker startup when the optional
+	// node-local cache daemon is unavailable.
+	defaultCacheProxyConnectTimeout = 5 * time.Second
 )
 
 // cacheEnabled returns true when the cache proxy integration should be used.
@@ -88,7 +93,10 @@ func LogCacheProxyStatus() {
 // secret (otherwise it defaults to HTTPS regardless), so we pin the real S3
 // endpoint for the configured region.
 func overrideS3EndpointForCacheProxy(cfg *server.DuckLakeConfig) {
-	addr := cacheProxyS3Addr()
+	overrideS3EndpointForCacheProxyAddr(cfg, cacheProxyS3Addr())
+}
+
+func overrideS3EndpointForCacheProxyAddr(cfg *server.DuckLakeConfig, addr string) {
 	if addr == "" {
 		return
 	}
@@ -104,30 +112,51 @@ func overrideS3EndpointForCacheProxy(cfg *server.DuckLakeConfig) {
 	cfg.S3UseSSL = false
 }
 
-// waitForCacheProxy blocks until the local cache proxy responds healthy.
-// When the cache is disabled, returns immediately (no-op).
-//
-// If the worker starts before the proxy is ready, DuckDB's first S3 requests
-// would fail. Block startup until the proxy is up.
-func waitForCacheProxy() {
+// cacheProxyConnectTimeout is deliberately configurable because a node may
+// need a little time to mount NVMe after a restart. It is always bounded: the
+// cache is an optimization, not a worker-startup dependency.
+func cacheProxyConnectTimeout() time.Duration {
+	value := os.Getenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT")
+	if value == "" {
+		return defaultCacheProxyConnectTimeout
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil || timeout <= 0 {
+		slog.Warn("Invalid DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT; using default.",
+			"value", value, "default", defaultCacheProxyConnectTimeout, "error", err)
+		return defaultCacheProxyConnectTimeout
+	}
+	return timeout
+}
+
+// waitForCacheProxy performs one bounded startup health check. It never gates
+// readiness: a failure puts the worker-local router into direct-source bypass
+// mode, where it fetches from the authoritative S3 path.
+func waitForCacheProxy() cacheProxyMode {
 	url := cacheProxyHealthURL()
 	if url == "" {
-		return
+		return cacheProxyModeDisabled
 	}
 
-	client := &http.Client{Timeout: 2 * time.Second}
-
+	timeout := cacheProxyConnectTimeout()
+	client := &http.Client{Timeout: timeout}
 	start := time.Now()
-	slog.Info("Waiting for cache proxy to be ready.", "url", url)
-	for {
-		resp, err := client.Get(url)
-		if err == nil {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err == nil {
+		resp, requestErr := client.Do(req)
+		if requestErr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				slog.Info("Cache proxy is ready.", "wait_duration", time.Since(start))
-				return
+				return cacheProxyModeCached
 			}
+			err = fmt.Errorf("health endpoint returned status %d", resp.StatusCode)
+		} else {
+			err = requestErr
 		}
-		time.Sleep(1 * time.Second)
 	}
+	cacheProxyBypassTransitionsTotal.WithLabelValues(cacheProxyBypassReasonStartupUnavailable).Inc()
+	slog.Warn("Cache proxy unavailable at worker startup; bypassing local NVMe cache.",
+		"url", url, "timeout", timeout, "wait_duration", time.Since(start), "error", err)
+	return cacheProxyModeBypassed
 }

--- a/duckdbservice/cache_proxy_router.go
+++ b/duckdbservice/cache_proxy_router.go
@@ -1,0 +1,301 @@
+package duckdbservice
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+type cacheProxyMode string
+
+const (
+	cacheProxyModeDisabled cacheProxyMode = "disabled"
+	cacheProxyModeCached   cacheProxyMode = "cached"
+	cacheProxyModeBypassed cacheProxyMode = "bypassed"
+
+	cacheProxyBypassReasonStartupUnavailable  = "startup_unavailable"
+	cacheProxyBypassReasonRuntimeUnavailable  = "runtime_unavailable"
+	cacheProxyBypassReasonUpstreamUnavailable = "upstream_unavailable"
+
+	cacheProxyProbeTimeout         = 2 * time.Second
+	cacheProxyReconnectInitial     = time.Second
+	cacheProxyReconnectMaximum     = 30 * time.Second
+	cacheProxyHealthyProbeInterval = 5 * time.Second
+)
+
+// cacheProxyRouter is a stable, worker-local forward proxy. DuckDB always
+// talks to this listener while caching is enabled. The router either forwards
+// to the node daemon or directly to the signed S3 URL, so a daemon crash cannot
+// strand an in-flight session behind a dead hostPort.
+type cacheProxyRouter struct {
+	cacheURL     *url.URL
+	directUseTLS bool
+	cacheClient  *http.Client
+	directClient *http.Client
+
+	mu   sync.RWMutex
+	mode cacheProxyMode
+}
+
+type cacheProxySupervisorConfig struct {
+	probeTimeout          time.Duration
+	healthyProbeInterval  time.Duration
+	initialReconnectDelay time.Duration
+	maxReconnectDelay     time.Duration
+	jitter                func(time.Duration) time.Duration
+}
+
+func (r *cacheProxyRouter) setDirectUseTLS(useTLS bool) {
+	r.mu.Lock()
+	r.directUseTLS = useTLS
+	r.mu.Unlock()
+}
+
+func (r *cacheProxyRouter) directUsesTLS() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.directUseTLS
+}
+
+func newCacheProxyRouter(cacheAddr string, directUseTLS bool) *cacheProxyRouter {
+	cacheURL := &url.URL{Scheme: "http", Host: cacheAddr}
+	router := &cacheProxyRouter{
+		cacheURL:     cacheURL,
+		directUseTLS: directUseTLS,
+		cacheClient:  &http.Client{Timeout: 60 * time.Second, Transport: &http.Transport{Proxy: http.ProxyURL(cacheURL)}},
+		// Never inherit HTTP_PROXY here: bypass must not accidentally route back
+		// through another proxy when the node-local cache daemon is unhealthy.
+		directClient: &http.Client{Timeout: 60 * time.Second, Transport: &http.Transport{Proxy: nil}},
+		mode:         cacheProxyModeBypassed,
+	}
+	recordCacheProxyMode(router.mode)
+	return router
+}
+
+func (r *cacheProxyRouter) Mode() cacheProxyMode {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mode
+}
+
+func (r *cacheProxyRouter) setMode(mode cacheProxyMode) {
+	r.mu.Lock()
+	previous := r.mode
+	r.mode = mode
+	r.mu.Unlock()
+	if previous == mode {
+		return
+	}
+	recordCacheProxyMode(mode)
+	if mode == cacheProxyModeCached {
+		cacheProxyRecoveriesTotal.Inc()
+		slog.Info("Cache proxy recovered; re-enabled local NVMe cache.")
+		return
+	}
+	if mode == cacheProxyModeBypassed {
+		slog.Warn("Entering cache-proxy bypass mode; reads will fetch from peers or S3 through the authoritative source path.")
+	}
+}
+
+func recordCacheProxyMode(mode cacheProxyMode) {
+	for _, candidate := range []cacheProxyMode{cacheProxyModeDisabled, cacheProxyModeCached, cacheProxyModeBypassed} {
+		value := 0.0
+		if candidate == mode {
+			value = 1
+		}
+		cacheProxyModeGauge.WithLabelValues(string(candidate)).Set(value)
+	}
+}
+
+func (r *cacheProxyRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method == http.MethodConnect {
+		r.handleConnect(w, req)
+		return
+	}
+	if r.Mode() == cacheProxyModeCached {
+		resp, err := r.cacheClient.Do(cloneProxyRequest(req, false))
+		if err == nil {
+			defer func() { _ = resp.Body.Close() }()
+			copyProxyResponse(w, resp)
+			return
+		}
+		// Only retry read-only operations after a failed dial before any response
+		// exists. A cache HTTP response (including an S3 integrity error) is never
+		// hidden, and writes are never replayed.
+		if isCacheProxyUnavailable(err) && isReadOnlyRequest(req) {
+			cacheProxyBypassedOperationsTotal.WithLabelValues(cacheProxyBypassReasonUpstreamUnavailable).Inc()
+			cacheProxyBypassTransitionsTotal.WithLabelValues(cacheProxyBypassReasonUpstreamUnavailable).Inc()
+			r.setMode(cacheProxyModeBypassed)
+			resp, err = r.directClient.Do(cloneProxyRequest(req, r.directUsesTLS()))
+			if err == nil {
+				defer func() { _ = resp.Body.Close() }()
+				copyProxyResponse(w, resp)
+				return
+			}
+		}
+		http.Error(w, "cache proxy unavailable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	cacheProxyBypassedOperationsTotal.WithLabelValues(cacheProxyBypassReasonRuntimeUnavailable).Inc()
+	resp, err := r.directClient.Do(cloneProxyRequest(req, r.directUsesTLS()))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	copyProxyResponse(w, resp)
+}
+
+func isReadOnlyRequest(req *http.Request) bool {
+	return req.Method == http.MethodGet || req.Method == http.MethodHead
+}
+
+func cloneProxyRequest(req *http.Request, useTLS bool) *http.Request {
+	copy := req.Clone(req.Context())
+	copy.RequestURI = ""
+	if useTLS && copy.URL.Scheme == "http" {
+		copy.URL.Scheme = "https"
+	}
+	return copy
+}
+
+func copyProxyResponse(w http.ResponseWriter, resp *http.Response) {
+	for key, values := range resp.Header {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func isHopByHopHeader(key string) bool {
+	switch strings.ToLower(key) {
+	case "connection", "proxy-connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCacheProxyUnavailable(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+// handleConnect preserves the existing generic httpfs behavior. In bypass
+// mode it tunnels directly to the requested host; in cached mode it uses the
+// daemon as the CONNECT proxy. S3 reads use plain HTTP and take ServeHTTP's
+// direct source path above.
+func (r *cacheProxyRouter) handleConnect(w http.ResponseWriter, req *http.Request) {
+	target := req.Host
+	if target == "" {
+		target = req.URL.Host
+	}
+	if r.Mode() == cacheProxyModeCached {
+		conn, err := net.DialTimeout("tcp", r.cacheURL.Host, cacheProxyProbeTimeout)
+		if err == nil {
+			defer func() { _ = conn.Close() }()
+			if err := req.Write(conn); err == nil {
+				if hijacker, ok := w.(http.Hijacker); ok {
+					client, _, hijackErr := hijacker.Hijack()
+					if hijackErr == nil {
+						defer func() { _ = client.Close() }()
+						go func() { _, _ = io.Copy(conn, client) }()
+						_, _ = io.Copy(client, conn)
+						return
+					}
+				}
+			}
+		}
+	}
+	conn, err := net.DialTimeout("tcp", target, cacheProxyProbeTimeout)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "connection hijacking unavailable", http.StatusInternalServerError)
+		return
+	}
+	client, _, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer func() { _ = client.Close() }()
+	_, _ = client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+	go func() { _, _ = io.Copy(conn, client) }()
+	_, _ = io.Copy(client, conn)
+}
+
+func (r *cacheProxyRouter) supervise(healthURL string, stop <-chan struct{}) {
+	r.superviseWith(healthURL, stop, cacheProxySupervisorConfig{
+		probeTimeout:          cacheProxyProbeTimeout,
+		healthyProbeInterval:  cacheProxyHealthyProbeInterval,
+		initialReconnectDelay: cacheProxyReconnectInitial,
+		maxReconnectDelay:     cacheProxyReconnectMaximum,
+		jitter:                jitterCacheProxyBackoff,
+	})
+}
+
+func (r *cacheProxyRouter) superviseWith(healthURL string, stop <-chan struct{}, cfg cacheProxySupervisorConfig) {
+	backoff := cfg.initialReconnectDelay
+	for {
+		wait := cfg.healthyProbeInterval
+		if r.Mode() == cacheProxyModeBypassed {
+			wait = cfg.jitter(backoff)
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-stop:
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		cacheProxyReconnectAttemptsTotal.Inc()
+		if cacheProxyHealthy(healthURL, cfg.probeTimeout) {
+			r.setMode(cacheProxyModeCached)
+			backoff = cfg.initialReconnectDelay
+			continue
+		}
+		if r.Mode() == cacheProxyModeCached {
+			cacheProxyBypassTransitionsTotal.WithLabelValues(cacheProxyBypassReasonRuntimeUnavailable).Inc()
+			r.setMode(cacheProxyModeBypassed)
+		}
+		backoff *= 2
+		if backoff > cfg.maxReconnectDelay {
+			backoff = cfg.maxReconnectDelay
+		}
+	}
+}
+
+func jitterCacheProxyBackoff(backoff time.Duration) time.Duration {
+	return backoff/2 + time.Duration(rand.Int64N(int64(backoff/2)+1))
+}
+
+func cacheProxyHealthy(healthURL string, timeout time.Duration) bool {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(healthURL)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode == http.StatusOK
+}

--- a/duckdbservice/cache_proxy_router.go
+++ b/duckdbservice/cache_proxy_router.go
@@ -29,6 +29,13 @@ const (
 	cacheProxyReconnectInitial     = time.Second
 	cacheProxyReconnectMaximum     = 30 * time.Second
 	cacheProxyHealthyProbeInterval = 5 * time.Second
+
+	cacheProxyDialTimeout         = 5 * time.Second
+	cacheProxyTLSHandshakeTimeout = 5 * time.Second
+	// The cache daemon may materialize an origin response for up to 60s before
+	// sending headers, so leave a little coordination headroom here.
+	cacheProxyResponseHeaderTimeout = 70 * time.Second
+	cacheProxyIdleConnTimeout       = 90 * time.Second
 )
 
 // cacheProxyRouter is a stable, worker-local forward proxy. DuckDB always
@@ -53,6 +60,16 @@ type cacheProxySupervisorConfig struct {
 	jitter                func(time.Duration) time.Duration
 }
 
+// cacheProxyTransportConfig intentionally excludes a whole-request timeout.
+// The router may stream a large S3 range for longer than any sensible
+// connection/header deadline; cancelling that body would corrupt the read.
+type cacheProxyTransportConfig struct {
+	dialTimeout           time.Duration
+	tlsHandshakeTimeout   time.Duration
+	responseHeaderTimeout time.Duration
+	idleConnTimeout       time.Duration
+}
+
 func (r *cacheProxyRouter) setDirectUseTLS(useTLS bool) {
 	r.mu.Lock()
 	r.directUseTLS = useTLS
@@ -66,18 +83,50 @@ func (r *cacheProxyRouter) directUsesTLS() bool {
 }
 
 func newCacheProxyRouter(cacheAddr string, directUseTLS bool) *cacheProxyRouter {
+	return newCacheProxyRouterWithTransport(cacheAddr, directUseTLS, cacheProxyTransportConfig{})
+}
+
+func newCacheProxyRouterWithTransport(cacheAddr string, directUseTLS bool, cfg cacheProxyTransportConfig) *cacheProxyRouter {
+	cfg = normalizeCacheProxyTransportConfig(cfg)
 	cacheURL := &url.URL{Scheme: "http", Host: cacheAddr}
 	router := &cacheProxyRouter{
 		cacheURL:     cacheURL,
 		directUseTLS: directUseTLS,
-		cacheClient:  &http.Client{Timeout: 60 * time.Second, Transport: &http.Transport{Proxy: http.ProxyURL(cacheURL)}},
+		cacheClient:  &http.Client{Transport: newCacheProxyTransport(cacheURL, cfg)},
 		// Never inherit HTTP_PROXY here: bypass must not accidentally route back
 		// through another proxy when the node-local cache daemon is unhealthy.
-		directClient: &http.Client{Timeout: 60 * time.Second, Transport: &http.Transport{Proxy: nil}},
+		directClient: &http.Client{Transport: newCacheProxyTransport(nil, cfg)},
 		mode:         cacheProxyModeBypassed,
 	}
 	recordCacheProxyMode(router.mode)
 	return router
+}
+
+func normalizeCacheProxyTransportConfig(cfg cacheProxyTransportConfig) cacheProxyTransportConfig {
+	if cfg.dialTimeout == 0 {
+		cfg.dialTimeout = cacheProxyDialTimeout
+	}
+	if cfg.tlsHandshakeTimeout == 0 {
+		cfg.tlsHandshakeTimeout = cacheProxyTLSHandshakeTimeout
+	}
+	if cfg.responseHeaderTimeout == 0 {
+		cfg.responseHeaderTimeout = cacheProxyResponseHeaderTimeout
+	}
+	if cfg.idleConnTimeout == 0 {
+		cfg.idleConnTimeout = cacheProxyIdleConnTimeout
+	}
+	return cfg
+}
+
+func newCacheProxyTransport(proxyURL *url.URL, cfg cacheProxyTransportConfig) *http.Transport {
+	dialer := &net.Dialer{Timeout: cfg.dialTimeout}
+	return &http.Transport{
+		Proxy:                 http.ProxyURL(proxyURL),
+		DialContext:           dialer.DialContext,
+		TLSHandshakeTimeout:   cfg.tlsHandshakeTimeout,
+		ResponseHeaderTimeout: cfg.responseHeaderTimeout,
+		IdleConnTimeout:       cfg.idleConnTimeout,
+	}
 }
 
 func (r *cacheProxyRouter) Mode() cacheProxyMode {

--- a/duckdbservice/cache_proxy_router_test.go
+++ b/duckdbservice/cache_proxy_router_test.go
@@ -1,0 +1,169 @@
+package duckdbservice
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitForCacheProxyMode(t *testing.T, router *cacheProxyRouter, want cacheProxyMode) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if router.Mode() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("router mode = %q, want %q", router.Mode(), want)
+}
+
+func closedLocalAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve local address: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release local address: %v", err)
+	}
+	return addr
+}
+
+// A dead node-local cache must never prevent an otherwise valid S3 read. The
+// router retries only the uncommitted GET through the authoritative endpoint.
+func TestCacheProxyRouterFallsOpenToAuthoritativeSource(t *testing.T) {
+	var sourceCalls atomic.Int32
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceCalls.Add(1)
+		if r.URL.Path != "/warehouse/file.parquet" {
+			t.Fatalf("source path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, "authoritative-data")
+	}))
+	defer source.Close()
+
+	router := newCacheProxyRouter(closedLocalAddress(t), false)
+	router.setMode(cacheProxyModeCached)
+	proxy := httptest.NewServer(router)
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get(source.URL + "/warehouse/file.parquet")
+	if err != nil {
+		t.Fatalf("GET through unavailable cache proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(body) != "authoritative-data" {
+		t.Fatalf("fallback response = %d %q", resp.StatusCode, body)
+	}
+	if sourceCalls.Load() != 1 {
+		t.Fatalf("authoritative source calls = %d, want 1", sourceCalls.Load())
+	}
+	if router.Mode() != cacheProxyModeBypassed {
+		t.Fatalf("router mode = %q, want bypassed after cache dial failure", router.Mode())
+	}
+}
+
+// A response received from the cache is authoritative for that request. In
+// particular, a 5xx must not be silently replaced with a direct source read:
+// it can carry a source/data-integrity failure that the query must see.
+func TestCacheProxyRouterDoesNotHideCacheResponses(t *testing.T) {
+	var sourceCalls atomic.Int32
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sourceCalls.Add(1)
+		_, _ = io.WriteString(w, "must not be read")
+	}))
+	defer source.Close()
+
+	cache := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream checksum mismatch", http.StatusBadGateway)
+	}))
+	defer cache.Close()
+	cacheURL, err := url.Parse(cache.URL)
+	if err != nil {
+		t.Fatalf("parse cache URL: %v", err)
+	}
+
+	router := newCacheProxyRouter(cacheURL.Host, false)
+	router.setMode(cacheProxyModeCached)
+	proxy := httptest.NewServer(router)
+	defer proxy.Close()
+	proxyURL, _ := url.Parse(proxy.URL)
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get(source.URL + "/warehouse/file.parquet")
+	if err != nil {
+		t.Fatalf("GET through cache proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+	if sourceCalls.Load() != 0 {
+		t.Fatalf("source calls = %d, want 0", sourceCalls.Load())
+	}
+}
+
+func TestWaitForCacheProxyIsBoundedAndFailsOpen(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "127.0.0.1")
+	t.Setenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT", "20ms")
+
+	start := time.Now()
+	if mode := waitForCacheProxy(); mode != cacheProxyModeBypassed {
+		t.Fatalf("startup mode = %q, want bypassed", mode)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("cache-proxy startup wait = %s, want bounded wait", elapsed)
+	}
+}
+
+func TestCacheProxySupervisorBypassesRuntimeLossAndRecovers(t *testing.T) {
+	var healthy atomic.Bool
+	healthy.Store(true)
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !healthy.Load() {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthServer.Close()
+
+	router := newCacheProxyRouter("127.0.0.1:8080", false)
+	router.setMode(cacheProxyModeCached)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		router.superviseWith(healthServer.URL, stop, cacheProxySupervisorConfig{
+			probeTimeout:          50 * time.Millisecond,
+			healthyProbeInterval:  5 * time.Millisecond,
+			initialReconnectDelay: 5 * time.Millisecond,
+			maxReconnectDelay:     20 * time.Millisecond,
+			jitter:                func(delay time.Duration) time.Duration { return delay },
+		})
+	}()
+
+	healthy.Store(false)
+	waitForCacheProxyMode(t, router, cacheProxyModeBypassed)
+	healthy.Store(true)
+	waitForCacheProxyMode(t, router, cacheProxyModeCached)
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cache-proxy supervisor did not stop")
+	}
+}

--- a/duckdbservice/cache_proxy_router_test.go
+++ b/duckdbservice/cache_proxy_router_test.go
@@ -76,6 +76,50 @@ func TestCacheProxyRouterFallsOpenToAuthoritativeSource(t *testing.T) {
 	}
 }
 
+// ResponseHeaderTimeout must bound an unavailable upstream without imposing a
+// whole-response deadline: S3 range bodies can legitimately outlive it.
+func TestCacheProxyRouterStreamsPastResponseHeaderTimeout(t *testing.T) {
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer does not support flush")
+		}
+		_, _ = io.WriteString(w, "first-")
+		flusher.Flush()
+		time.Sleep(40 * time.Millisecond)
+		_, _ = io.WriteString(w, "last")
+	}))
+	defer source.Close()
+
+	router := newCacheProxyRouterWithTransport(closedLocalAddress(t), false, cacheProxyTransportConfig{
+		responseHeaderTimeout: 10 * time.Millisecond,
+	})
+	if router.directClient.Timeout != 0 || router.cacheClient.Timeout != 0 {
+		t.Fatalf("router clients must not impose a whole-response timeout: direct=%s cache=%s", router.directClient.Timeout, router.cacheClient.Timeout)
+	}
+	router.setMode(cacheProxyModeBypassed)
+	proxy := httptest.NewServer(router)
+	defer proxy.Close()
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get(source.URL + "/warehouse/large.parquet")
+	if err != nil {
+		t.Fatalf("GET through direct fallback: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read streamed fallback body: %v", err)
+	}
+	if got := string(body); got != "first-last" {
+		t.Fatalf("body = %q, want complete stream", got)
+	}
+}
+
 // A response received from the cache is authoritative for that request. In
 // particular, a 5xx must not be silently replaced with a direct source read:
 // it can carry a source/data-integrity failure that the query must see.

--- a/duckdbservice/cache_proxy_test.go
+++ b/duckdbservice/cache_proxy_test.go
@@ -81,6 +81,12 @@ func TestCacheProxyConnectTimeout(t *testing.T) {
 			t.Fatalf("timeout = %s, want default %s", got, defaultCacheProxyConnectTimeout)
 		}
 	})
+	t.Run("clamps an excessive value to preserve worker startup budget", func(t *testing.T) {
+		t.Setenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT", "2m")
+		if got := cacheProxyConnectTimeout(); got != maxCacheProxyConnectTimeout {
+			t.Fatalf("timeout = %s, want capped maximum %s", got, maxCacheProxyConnectTimeout)
+		}
+	})
 }
 
 func TestCacheProxyHealthURL(t *testing.T) {

--- a/duckdbservice/cache_proxy_test.go
+++ b/duckdbservice/cache_proxy_test.go
@@ -2,6 +2,7 @@ package duckdbservice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/posthog/duckgres/server"
 )
@@ -57,6 +58,27 @@ func TestOverrideS3EndpointForCacheProxy(t *testing.T) {
 		overrideS3EndpointForCacheProxy(&cfg)
 		if cfg.HTTPProxy != "http://localhost:8080" {
 			t.Errorf("expected localhost fallback, got %q", cfg.HTTPProxy)
+		}
+	})
+}
+
+func TestCacheProxyConnectTimeout(t *testing.T) {
+	t.Run("default is documented and bounded", func(t *testing.T) {
+		t.Setenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT", "")
+		if got := cacheProxyConnectTimeout(); got != 5*time.Second {
+			t.Fatalf("default timeout = %s, want 5s", got)
+		}
+	})
+	t.Run("uses explicit duration", func(t *testing.T) {
+		t.Setenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT", "750ms")
+		if got := cacheProxyConnectTimeout(); got != 750*time.Millisecond {
+			t.Fatalf("timeout = %s, want 750ms", got)
+		}
+	})
+	t.Run("invalid value fails safely to default", func(t *testing.T) {
+		t.Setenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT", "0s")
+		if got := cacheProxyConnectTimeout(); got != defaultCacheProxyConnectTimeout {
+			t.Fatalf("timeout = %s, want default %s", got, defaultCacheProxyConnectTimeout)
 		}
 	})
 }

--- a/duckdbservice/metrics.go
+++ b/duckdbservice/metrics.go
@@ -9,6 +9,27 @@ import (
 // These use the "duckgres_worker_" prefix to distinguish from standalone-mode
 // metrics defined in server/server.go (which use "duckgres_ducklake_").
 var (
+	cacheProxyModeGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "duckgres_worker_cache_proxy_mode",
+		Help: "Current node-local cache-proxy mode (one active mode has value 1)",
+	}, []string{"mode"})
+	cacheProxyBypassTransitionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_worker_cache_proxy_bypass_transitions_total",
+		Help: "Total transitions into cache-proxy bypass mode",
+	}, []string{"reason"})
+	cacheProxyBypassedOperationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "duckgres_worker_cache_proxy_bypassed_operations_total",
+		Help: "Total operations routed around the node-local cache proxy",
+	}, []string{"reason"})
+	cacheProxyReconnectAttemptsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "duckgres_worker_cache_proxy_reconnect_attempts_total",
+		Help: "Total cache-proxy health probes while recovering or monitoring",
+	})
+	cacheProxyRecoveriesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "duckgres_worker_cache_proxy_recoveries_total",
+		Help: "Total recoveries that re-enabled the node-local cache proxy",
+	})
+
 	ducklakeConflictTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "duckgres_worker_ducklake_conflict_total",
 		Help: "Total number of DuckLake transaction conflicts encountered (worker)",

--- a/duckdbservice/querylog.go
+++ b/duckdbservice/querylog.go
@@ -193,7 +193,7 @@ func (p *SessionPool) queryLogRuntime() (server.Config, bool) {
 			return server.Config{}, false
 		}
 		cfg.DuckLake = p.activation.payload.DuckLake
-		overrideS3EndpointForCacheProxy(&cfg.DuckLake)
+		p.overrideS3EndpointForCacheProxy(&cfg.DuckLake)
 		if cfg.DuckLake.ApplicationName == "" && p.activation.payload.OrgID != "" {
 			cfg.DuckLake.ApplicationName = "duckgres/" + p.activation.payload.OrgID
 		}

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -71,10 +72,14 @@ type SessionPool struct {
 	// controlDB is activePair.Control, surfaced for direct use by control-side
 	// ops (CREATE OR REPLACE SECRET on STS rotation). Always nil before
 	// activation; nil-check before use and fall back to the main DB.
-	controlDB    *sql.DB
-	queryLogMu   sync.Mutex
-	queryLogInit sync.Mutex
-	queryLogSink server.QueryLogSink
+	controlDB            *sql.DB
+	queryLogMu           sync.Mutex
+	queryLogInit         sync.Mutex
+	queryLogSink         server.QueryLogSink
+	cacheRouter          *cacheProxyRouter
+	cacheServer          *http.Server
+	cacheListener        net.Listener
+	cacheRouterAttempted bool
 
 	sharedWarmMode       bool
 	activation           *activatedTenantRuntime
@@ -511,6 +516,22 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		drainZero:            make(chan struct{}),
 		drainZeroOpen:        true,
 	}
+	if cacheEnabled() {
+		pool.cacheRouterAttempted = true
+		router, listener, err := startCacheProxyRouter(cacheProxyS3Addr())
+		if err != nil {
+			slog.Warn("Failed to start worker-local cache fallback router; bypassing local cache.", "error", err)
+		} else {
+			pool.cacheRouter = router
+			pool.cacheListener = listener
+			pool.cacheServer = &http.Server{Handler: router}
+			go func() {
+				if serveErr := pool.cacheServer.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+					slog.Warn("Worker-local cache fallback router stopped unexpectedly.", "error", serveErr)
+				}
+			}()
+		}
+	}
 	pool.activateTenantFunc = pool.activateTenant
 	go pool.reapLoop()
 	go pool.metadataMetricsLoop()
@@ -520,6 +541,28 @@ func NewDuckDBService(cfg ServiceConfig) *DuckDBService {
 		cfg:  cfg,
 		pool: pool,
 	}
+}
+
+func startCacheProxyRouter(cacheAddr string) (*cacheProxyRouter, net.Listener, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	return newCacheProxyRouter(cacheAddr, true), listener, nil
+}
+
+func (p *SessionPool) overrideS3EndpointForCacheProxy(cfg *server.DuckLakeConfig) {
+	if p.cacheRouter == nil {
+		// Hand-constructed unit-test pools predate the router. Keep their
+		// transport assertions meaningful, while a production startup that
+		// attempted and failed to bind the router deliberately stays direct.
+		if !p.cacheRouterAttempted {
+			overrideS3EndpointForCacheProxy(cfg)
+		}
+		return
+	}
+	p.cacheRouter.setDirectUseTLS(cfg.S3UseSSL)
+	overrideS3EndpointForCacheProxyAddr(cfg, p.cacheListener.Addr().String())
 }
 
 // wipePersistedSecrets removes DuckDB's persistent-secret directories for this
@@ -602,11 +645,13 @@ func (p *SessionPool) Warmup() error {
 	start := time.Now()
 	slog.Info("Pre-warming worker DuckDB instance...")
 
-	// Wait for the local cache proxy to be ready before serving queries.
-	// When DUCKGRES_CACHE_PROXY_ADDR is set, DuckDB will route S3 traffic
-	// through it — worker startup must block until the proxy is healthy.
-	// Included in the pre-warm duration so slow proxy startup is visible.
-	waitForCacheProxy()
+	// The local router is always available to DuckDB. A bounded check decides
+	// whether it uses NVMe cache or direct S3, and a single supervisor recovers
+	// the cache later without gating worker readiness.
+	if p.cacheRouter != nil {
+		p.cacheRouter.setMode(waitForCacheProxy())
+		go p.cacheRouter.supervise(cacheProxyHealthURL(), p.stopCh)
+	}
 	// Use a system-level username for warmup
 	pair, err := p.createDBPair(p.sharedWarmupConfig(), p.duckLakeSem, "duckgres", p.startTime, server.ProcessVersion())
 	if err != nil {
@@ -1487,6 +1532,9 @@ func (p *SessionPool) CloseAll() {
 			close(p.stopCh)
 		}
 	})
+	if p.cacheServer != nil {
+		_ = p.cacheServer.Close()
+	}
 	p.mu.Lock()
 	sessions := make(map[string]*Session, len(p.sessions))
 	stops := make(map[string]func(), len(p.stopRefresh))


### PR DESCRIPTION
## Summary
- add a worker-local stable forward router so cache-proxy failures bypass local NVMe caching and use the authoritative S3 source
- bound startup health checks with `DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT` (default `5s`), and recover cache routing via jittered capped backoff
- add cache-mode metrics, structured logs, configuration docs, and an operational bypass runbook

## Root cause
Workers previously waited indefinitely for the node-local cache daemon, and the existing cache-off transport still tunneled through that same daemon.

## Validation
- `just test-unit`
- `just lint`

Cache unavailability now degrades cache performance rather than worker readiness or PostgreSQL session startup.