### PR TITLE
fix(protocol): portal suspension for extended-query Execute row limits (Hex 1024-row truncation)

### DIFF
--- a/docs/postgres-compatibility.md
+++ b/docs/postgres-compatibility.md
@@ -163,6 +163,7 @@ Operational guidance: allow the import to complete, then manually deduplicate af
 |---------|--------|---------|-------|
 | Simple query | ✅ | `protocol_test.go::TestProtocolSimpleQuery` | |
 | Extended query (Parse/Bind/Describe/Execute/Sync) | ✅ | `protocol_test.go::TestProtocolExtendedQuery`; server `conn_bind_test.go`, `conn_describe_test.go` | |
+| Portal suspension (Execute row limit / PortalSuspended) | ✅ | `portal_suspension_test.go::TestPortalSuspensionPaging` (raw-frontend paging); server `conn_portal_suspension_test.go` | Paging clients (JDBC `setFetchSize`, Hex) resume with repeat Execute; the query runs once. Suspended portals are destroyed at transaction end (PostgreSQL parity + the same single-connection liveness rule as cursors). Pre-fix, the first page was answered with CommandComplete — silent truncation at the client's page size |
 | Extended-query error recovery (skip-until-Sync, pipelining) | ✅ | server `conn_skip_until_sync_test.go`; clients `clients_test.go::TestExtendedQueryErrorHandling` | #718 |
 | Prepared statements (PREPARE/EXECUTE, reuse, NULL, 20+ params) | ✅ | `edge_cases_test.go::TestPreparedStatementEdgeCases`; clients `::TestPreparedStatements` | |
 | Binary vs text result format | ✅ | `protocol_test.go::TestProtocolDataTypes`; clients `::TestPgxBinaryFormatResults`; server `types_test.go` encode/decode | |

--- a/server/conn.go
+++ b/server/conn.go
@@ -110,6 +110,36 @@ type portal struct {
 	paramFormats  []int16 // 0=text, 1=binary for each parameter
 	resultFormats []int16
 	described     bool // true if Describe was called on this portal
+	// exec is set while the portal is suspended: Execute hit its row limit
+	// (PortalSuspended sent) with the result set unexhausted. The next
+	// Execute on this portal resumes streaming from exec.rows instead of
+	// re-running the query.
+	exec *portalExec
+}
+
+// portalExec is the streaming state of a suspended portal: the still-open
+// RowSet positioned after the last row sent, plus what the resuming Execute
+// and the completion query-log entry need.
+type portalExec struct {
+	rows           RowSet
+	cols           []string
+	typeOIDs       []int32
+	cmdType        string
+	rowCount       int64 // cumulative rows streamed across Execute legs
+	originalQuery  string
+	convertedQuery string
+	start          time.Time // first Execute leg's start, so the query log spans all legs
+}
+
+// closeExec releases a suspended portal's open rowset (if any). Must be
+// called before the portal is discarded or its query re-run: the open rowset
+// pins the session's single DuckDB connection (see closeCursorsAtTxEnd).
+func (p *portal) closeExec() {
+	if p.exec == nil {
+		return
+	}
+	_ = p.exec.rows.Close()
+	p.exec = nil
 }
 
 // decodeParams converts raw parameter bytes to Go values based on format codes.
@@ -968,6 +998,7 @@ func (c *clientConn) serve() error {
 		}
 	}()
 	defer c.closeAllCursors()
+	defer c.closeSuspendedPortals()
 	defer func() {
 		if stopRefresh != nil {
 			stopRefresh()
@@ -2447,6 +2478,7 @@ func (c *clientConn) updateTxStatus(cmdType string) {
 	case "COMMIT", "ROLLBACK":
 		c.txStatus = txStatusIdle
 		c.closeAllCursors()
+		c.closeSuspendedPortals()
 	}
 	// For other commands, keep the current status
 }

--- a/server/conn_cursor.go
+++ b/server/conn_cursor.go
@@ -109,6 +109,9 @@ func (c *clientConn) closeCursorsAtTxEnd(cmdType string) {
 		return
 	}
 	c.closeAllCursors()
+	// Suspended portals hold an open rowset for the same liveness reason
+	// cursors do, and PostgreSQL destroys portals at transaction end anyway.
+	c.closeSuspendedPortals()
 }
 
 // getCursorSchema opens the cursor if needed to retrieve column metadata,

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -586,6 +586,14 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 
+	// Continuation of a suspended portal: resume streaming from the open
+	// rowset. The query must NOT re-run — the client is fetching the next
+	// page of the same result set.
+	if p.exec != nil {
+		c.resumeSuspendedPortal(p, maxRows)
+		return
+	}
+
 	// Redacted form for everything observable (pg_stat_activity, spans,
 	// logs): CREATE SECRET option lists carry credential material.
 	loggableQuery := usersecrets.RedactForLog(p.stmt.query)
@@ -920,7 +928,12 @@ func (c *clientConn) handleExecute(body []byte) {
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, errCode, errMsg, "extended")
 		return
 	}
-	defer func() { _ = rows.Close() }()
+	keepRowsOpen := false
+	defer func() {
+		if !keepRowsOpen {
+			_ = rows.Close()
+		}
+	}()
 
 	cols, err := rows.Columns()
 	if err != nil {
@@ -952,8 +965,10 @@ func (c *clientConn) handleExecute(body []byte) {
 
 	// Send rows with the format codes from Bind. Shared with the simple-query
 	// path so the exploratory tier's zero-row retry below behaves identically
-	// on both protocols; maxRows still caps the DataRows (portal suspension is
-	// not implemented) and the RowDescription was already handled above.
+	// on both protocols; the RowDescription was already handled above. maxRows
+	// caps the DataRows sent, and reaching it suspends the portal
+	// (stream.limitReached below) instead of completing it.
+	activeRows := rows
 	stream := c.streamSelectRows(rows, cols, colTypes, typeOIDs, false, p.resultFormats, maxRows)
 
 	// Exploratory tier: an OOM raised before a SINGLE DataRow reached the
@@ -974,7 +989,14 @@ func (c *clientConn) handleExecute(body []byte) {
 		if retryErr != nil {
 			stream.rowsErr = retryErr
 		} else {
-			defer func() { _ = retryRows.Close() }()
+			// The retried rowset replaces the original everywhere below —
+			// including as the rowset a suspension keeps open.
+			activeRows = retryRows
+			defer func() {
+				if !keepRowsOpen {
+					_ = retryRows.Close()
+				}
+			}()
 			stream = c.streamSelectRows(retryRows, cols, colTypes, typeOIDs, false, p.resultFormats, maxRows)
 		}
 	}
@@ -1011,10 +1033,112 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 
+	if stream.limitReached {
+		// The row limit was reached with the result set possibly unexhausted:
+		// keep the rowset open on the portal and tell the client to Execute
+		// again. CommandComplete here would silently truncate the result set
+		// to the client's page size (the Hex 1024-row bug). The query log
+		// entry is written by the leg that completes the portal.
+		keepRowsOpen = true
+		p.exec = &portalExec{
+			rows:           activeRows,
+			cols:           cols,
+			typeOIDs:       typeOIDs,
+			cmdType:        cmdType,
+			rowCount:       int64(rowCount),
+			originalQuery:  originalQuery,
+			convertedQuery: convertedQuery,
+			start:          start,
+		}
+		_ = wire.WritePortalSuspended(c.writer)
+		return
+	}
+
 	c.updateTxStatus(cmdType)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
 	_ = c.writeCommandComplete(tag)
 	c.logQuery(start, originalQuery, convertedQuery, cmdType, int64(rowCount), 0, "", "", "extended")
+}
+
+// resumeSuspendedPortal continues streaming a portal previously suspended by
+// Execute hitting its row limit. The query is not re-executed — the portal's
+// open rowset picks up exactly where the previous Execute leg stopped. The
+// query log entry (spanning all legs, with the cumulative row count) is
+// written by whichever leg finishes the portal. There is deliberately no
+// exploratory-tier retry here: rows from earlier legs are already out the
+// door, so an error must surface (same rule as the mid-stream case above).
+func (c *clientConn) resumeSuspendedPortal(p *portal, maxRows int32) {
+	exec := p.exec
+
+	loggableQuery := usersecrets.RedactForLog(exec.originalQuery)
+	c.currentQuery.Store(loggableQuery)
+	c.queryStart.Store(time.Now())
+	defer func() {
+		c.currentQuery.Store("")
+		c.queryStart.Store(time.Time{})
+	}()
+
+	// Each Execute leg is one protocol message, so it gets its own metrics
+	// scope, mirroring the fresh path — which also gives the leg the terminal
+	// wire flush (finishQueryMetrics) every Execute relies on.
+	queryMetrics := c.beginQueryMetrics(time.Now())
+	queryMetrics.queryText = loggableQuery
+	defer c.finishQueryMetrics(queryMetrics)
+
+	stream := c.streamSelectRows(exec.rows, exec.cols, nil, exec.typeOIDs, false, p.resultFormats, maxRows)
+	exec.rowCount += int64(stream.rowsSent)
+
+	if stream.scanErr != nil {
+		p.closeExec()
+		c.sendError("ERROR", "42000", stream.scanErr.Error())
+		c.setTxError()
+		c.logQuery(exec.start, exec.originalQuery, exec.convertedQuery, exec.cmdType, 0, 0, "42000", stream.scanErr.Error(), "extended")
+		return
+	}
+	if stream.writeErr != nil {
+		p.closeExec()
+		return
+	}
+	if err := stream.rowsErr; err != nil {
+		p.closeExec()
+		errCode := "42000"
+		errMsg := err.Error()
+		if c.isCallerCancellation(err) {
+			errCode = "57014"
+			errMsg = "canceling statement due to user request"
+		} else {
+			c.logger().Error("Row iteration error.", "error", err)
+		}
+		c.sendError("ERROR", errCode, errMsg)
+		c.setTxError()
+		c.logQuery(exec.start, exec.originalQuery, exec.convertedQuery, exec.cmdType, 0, 0, errCode, errMsg, "extended")
+		return
+	}
+	if stream.limitReached {
+		_ = wire.WritePortalSuspended(c.writer)
+		return
+	}
+
+	p.closeExec()
+	c.updateTxStatus(exec.cmdType)
+	tag := buildCommandTagFromRowCount(exec.cmdType, exec.rowCount)
+	_ = c.writeCommandComplete(tag)
+	c.logQuery(exec.start, exec.originalQuery, exec.convertedQuery, exec.cmdType, exec.rowCount, 0, "", "", "extended")
+}
+
+// closeSuspendedPortals releases every suspended portal's open rowset and
+// destroys the portal, matching PostgreSQL (portals do not survive
+// transaction end). Destroying — not just releasing — matters: a suspended
+// portal whose rowset was closed but whose entry survived would re-run the
+// query from row 0 on the next Execute, silently replaying the first page as
+// a continuation. A 34000 "portal does not exist" is the honest answer.
+func (c *clientConn) closeSuspendedPortals() {
+	for name, p := range c.portals {
+		if p.exec != nil {
+			p.closeExec()
+			delete(c.portals, name)
+		}
+	}
 }
 
 func (c *clientConn) handleClose(body []byte) {
@@ -1034,6 +1158,9 @@ func (c *clientConn) handleClose(body []byte) {
 	case 'S':
 		delete(c.stmts, name)
 	case 'P':
+		if p, ok := c.portals[name]; ok {
+			p.closeExec()
+		}
 		delete(c.portals, name)
 	}
 
@@ -1220,8 +1347,12 @@ func (c *clientConn) handleBind(body []byte) {
 		}
 	}
 
-	// Close existing portal with same name
-	delete(c.portals, portalName)
+	// Close existing portal with same name — including the open rowset of a
+	// suspended portal being abandoned.
+	if old, ok := c.portals[portalName]; ok {
+		old.closeExec()
+		delete(c.portals, portalName)
+	}
 
 	c.portals[portalName] = &portal{
 		stmt:          ps,

--- a/server/conn_portal_suspension_test.go
+++ b/server/conn_portal_suspension_test.go
@@ -1,0 +1,272 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// Portal suspension (#Hex 1024-row truncation): a client that sends Execute
+// with a nonzero row limit (JDBC setFetchSize, Hex's paging driver) must get
+// PortalSuspended when the limit is reached with the result set unexhausted,
+// and a subsequent Execute on the same portal must resume streaming from
+// where the previous one stopped — without re-running the query. Pre-fix,
+// duckgres sent CommandComplete after the first page, silently truncating
+// every result set to the client's page size.
+
+// newPortalSuspConn builds a clientConn whose wire output is captured in the
+// returned buffer, so tests can assert on the exact message sequence sent.
+func newPortalSuspConn(t *testing.T) (*clientConn, *bytes.Buffer, func()) {
+	t.Helper()
+	serverSide, clientSide := net.Pipe()
+	out := &bytes.Buffer{}
+	ql := &QueryLogger{ch: make(chan QueryLogEntry, 100)}
+	srv := &Server{activeQueries: make(map[BackendKey]context.CancelFunc), queryLogger: ql}
+	c := &clientConn{
+		server:   srv,
+		conn:     serverSide,
+		reader:   bufio.NewReader(serverSide),
+		writer:   bufio.NewWriter(out),
+		txStatus: txStatusIdle,
+		cursors:  map[string]*cursorState{},
+		portals:  map[string]*portal{},
+		stmts:    map[string]*preparedStmt{},
+		ctx:      context.Background(),
+	}
+	cleanup := func() {
+		_ = serverSide.Close()
+		_ = clientSide.Close()
+	}
+	return c, out, cleanup
+}
+
+// portalExecBody builds an Execute message body: portal name + int32 maxRows.
+func portalExecBody(portalName string, maxRows int32) []byte {
+	b := append([]byte(portalName), 0)
+	var mr [4]byte
+	binary.BigEndian.PutUint32(mr[:], uint32(maxRows))
+	return append(b, mr[:]...)
+}
+
+// drainWire parses buffered wire messages into a type sequence (e.g. "TDDs")
+// and returns the CommandComplete tags encountered. Resets the buffer.
+func drainWire(t *testing.T, c *clientConn, out *bytes.Buffer) (string, []string) {
+	t.Helper()
+	if err := c.writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	data := out.Bytes()
+	seq := make([]byte, 0, 8)
+	var tags []string
+	for len(data) > 0 {
+		if len(data) < 5 {
+			t.Fatalf("truncated wire message: % x", data)
+		}
+		msgType := data[0]
+		msgLen := binary.BigEndian.Uint32(data[1:5])
+		if int(msgLen)+1 > len(data) {
+			t.Fatalf("wire message length %d exceeds buffer %d", msgLen, len(data))
+		}
+		payload := data[5 : 1+msgLen]
+		if msgType == 'C' {
+			tags = append(tags, string(bytes.TrimRight(payload, "\x00")))
+		}
+		seq = append(seq, msgType)
+		data = data[1+msgLen:]
+	}
+	out.Reset()
+	return string(seq), tags
+}
+
+func newSuspensionRowSet(n int) *streamingRowSet {
+	rows := make([][]any, n)
+	for i := range rows {
+		rows[i] = []any{"v"}
+	}
+	return &streamingRowSet{
+		rows:      rows,
+		cols:      []string{"c"},
+		colTypers: []ColumnTyper{stringColumnTyper{}},
+	}
+}
+
+func newSuspensionPortal(c *clientConn, name string) {
+	stmt := &preparedStmt{
+		query:          "SELECT * FROM t",
+		convertedQuery: "SELECT * FROM t",
+	}
+	c.stmts["s1"] = stmt
+	c.portals[name] = &portal{stmt: stmt}
+}
+
+// TestExecuteMaxRowsSuspendsAndResumes pages a 5-row result set with
+// Execute(maxRows=2): 2 rows + PortalSuspended, 2 rows + PortalSuspended,
+// then the final row + CommandComplete. The query must execute exactly once.
+func TestExecuteMaxRowsSuspendsAndResumes(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(5)
+	ex := &lifecycleExecutor{queryRows: rs}
+	c.executor = ex
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, _ := drainWire(t, c, out)
+	if seq != "TDDs" {
+		t.Fatalf("first Execute: expected RowDescription + 2 DataRows + PortalSuspended (TDDs), got %q", seq)
+	}
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, _ = drainWire(t, c, out)
+	if seq != "DDs" {
+		t.Fatalf("second Execute: expected 2 DataRows + PortalSuspended (DDs), got %q", seq)
+	}
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, tags := drainWire(t, c, out)
+	if seq != "DC" {
+		t.Fatalf("final Execute: expected last DataRow + CommandComplete (DC), got %q", seq)
+	}
+	if len(tags) != 1 || tags[0] != "SELECT 5" {
+		t.Errorf("expected cumulative CommandComplete tag \"SELECT 5\", got %v", tags)
+	}
+	if got := ex.queryCalls.Load(); got != 1 {
+		t.Errorf("query must execute exactly once across Execute legs, ran %d times", got)
+	}
+	if !rs.closed {
+		t.Error("rows must be closed after the portal completes")
+	}
+}
+
+// TestExecuteMaxRowsExactBoundarySuspends matches PostgreSQL semantics when
+// the row limit equals the result size: the server can't know the set is
+// exhausted, so it suspends; the next Execute returns 0 rows + CommandComplete.
+func TestExecuteMaxRowsExactBoundarySuspends(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(4)
+	c.executor = &lifecycleExecutor{queryRows: rs}
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 4))
+	seq, _ := drainWire(t, c, out)
+	if seq != "TDDDDs" {
+		t.Fatalf("expected 4 DataRows + PortalSuspended (TDDDDs), got %q", seq)
+	}
+
+	c.handleExecute(portalExecBody("p1", 4))
+	seq, tags := drainWire(t, c, out)
+	if seq != "C" {
+		t.Fatalf("expected bare CommandComplete (C), got %q", seq)
+	}
+	if len(tags) != 1 || tags[0] != "SELECT 4" {
+		t.Errorf("expected CommandComplete tag \"SELECT 4\", got %v", tags)
+	}
+	if !rs.closed {
+		t.Error("rows must be closed after the portal completes")
+	}
+}
+
+// TestExecuteNoMaxRowsStreamsAll guards the common path: maxRows=0 streams
+// the whole result set in one Execute with no suspension.
+func TestExecuteNoMaxRowsStreamsAll(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(5)
+	c.executor = &lifecycleExecutor{queryRows: rs}
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 0))
+	seq, tags := drainWire(t, c, out)
+	if seq != "TDDDDDC" {
+		t.Fatalf("expected all rows + CommandComplete (TDDDDDC), got %q", seq)
+	}
+	if len(tags) != 1 || tags[0] != "SELECT 5" {
+		t.Errorf("expected CommandComplete tag \"SELECT 5\", got %v", tags)
+	}
+	if !rs.closed {
+		t.Error("rows must be closed after completion")
+	}
+}
+
+// TestCloseSuspendedPortalClosesRows: Close('P') on a suspended portal must
+// close its open RowSet — an open rowset pins the session's single DuckDB
+// connection (see closeCursorsAtTxEnd).
+func TestCloseSuspendedPortalClosesRows(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(5)
+	c.executor = &lifecycleExecutor{queryRows: rs}
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, _ := drainWire(t, c, out)
+	if seq != "TDDs" {
+		t.Fatalf("expected suspension (TDDs), got %q", seq)
+	}
+
+	c.handleClose(append([]byte{'P'}, append([]byte("p1"), 0)...))
+	if !rs.closed {
+		t.Error("Close('P') on a suspended portal must close its rows")
+	}
+}
+
+// TestTxEndClosesSuspendedPortalRows: COMMIT/ROLLBACK must release suspended
+// portals' rowsets before executing, mirroring closeCursorsAtTxEnd — the open
+// rowset holds the session's only DuckDB connection and would deadlock the
+// transaction-end statement.
+func TestTxEndClosesSuspendedPortalRows(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(5)
+	c.executor = &lifecycleExecutor{queryRows: rs, execResult: emptyExecResult{}}
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, _ := drainWire(t, c, out)
+	if seq != "TDDs" {
+		t.Fatalf("expected suspension (TDDs), got %q", seq)
+	}
+
+	commitStmt := &preparedStmt{query: "COMMIT", convertedQuery: "COMMIT"}
+	c.portals["p2"] = &portal{stmt: commitStmt}
+	c.handleExecute(portalExecBody("p2", 0))
+	if !rs.closed {
+		t.Error("COMMIT must close suspended portals' rows before executing")
+	}
+}
+
+// TestBindOverwriteClosesSuspendedPortalRows: re-Binding a portal name whose
+// previous portal is suspended must close the abandoned RowSet.
+func TestBindOverwriteClosesSuspendedPortalRows(t *testing.T) {
+	c, out, cleanup := newPortalSuspConn(t)
+	defer cleanup()
+
+	rs := newSuspensionRowSet(5)
+	c.executor = &lifecycleExecutor{queryRows: rs}
+	newSuspensionPortal(c, "p1")
+
+	c.handleExecute(portalExecBody("p1", 2))
+	seq, _ := drainWire(t, c, out)
+	if seq != "TDDs" {
+		t.Fatalf("expected suspension (TDDs), got %q", seq)
+	}
+
+	// Bind message: portal "p1", statement "s1", 0 param formats, 0 params,
+	// 0 result formats.
+	bind := append([]byte("p1"), 0)
+	bind = append(bind, append([]byte("s1"), 0)...)
+	bind = append(bind, 0, 0, 0, 0, 0, 0)
+	c.handleBind(bind)
+	if !rs.closed {
+		t.Error("Bind overwriting a suspended portal must close the old rows")
+	}
+}

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -357,6 +357,12 @@ type selectStream struct {
 	// can reproduce the exact log wording.
 	writeErr   error
 	writeStage string
+	// limitReached is set when maxRows stopped the stream with the rowset not
+	// (yet) known to be exhausted — the extended protocol suspends the portal
+	// (PortalSuspended) and a later Execute resumes from the same rowset. All
+	// three errors are nil when it is set, and rows.Err() has deliberately
+	// NOT been consulted: the rowset is still live.
+	limitReached bool
 }
 
 // streamSelectRows sends (optionally) the RowDescription and then every DataRow
@@ -366,9 +372,11 @@ type selectStream struct {
 //
 // formats are the Bind result-format codes (nil = all text, the simple-query
 // case). maxRows > 0 caps the DataRows sent, for the extended protocol's
-// Execute row limit; portal suspension is not implemented, so the row already
-// fetched when the cap is reached is dropped, and rows.Err() is still consulted
-// by the caller exactly as on a fully drained stream.
+// Execute row limit (portal suspension): the limit is checked BEFORE advancing
+// the rowset, so a suspended stream never consumes — and loses — the first row
+// of the next page. Matching PostgreSQL, the cap suspends even when the rowset
+// happens to be exactly exhausted: knowing would mean consuming the next row,
+// so the client's follow-up Execute gets 0 rows and the completion instead.
 func (c *clientConn) streamSelectRows(rows RowSet, cols []string, colTypes []ColumnTyper, typeOIDs []int32, sendRowDesc bool, formats []int16, maxRows int32) selectStream {
 	if sendRowDesc {
 		if err := c.sendRowDescription(cols, colTypes); err != nil {
@@ -377,8 +385,12 @@ func (c *clientConn) streamSelectRows(rows RowSet, cols []string, colTypes []Col
 	}
 
 	var out selectStream
-	for rows.Next() {
+	for {
 		if maxRows > 0 && int32(out.rowsSent) >= maxRows {
+			out.limitReached = true
+			return out
+		}
+		if !rows.Next() {
 			break
 		}
 

--- a/server/conn_tier.go
+++ b/server/conn_tier.go
@@ -211,6 +211,11 @@ func (c *clientConn) escalateWorker(ctx context.Context, reason string) error {
 	c.workerID = workerID
 	c.workerPod = workerPod
 	c.onExploratoryWorker = false
+	// The switcher destroyed the previous session, so any suspended portal's
+	// open rowset died with it. Destroy those portals now: a later Execute on
+	// one gets an honest 34000 instead of a dangling rowset (or, worse, a
+	// silent from-row-0 re-run presented as a continuation).
+	c.closeSuspendedPortals()
 	exploratoryEscalationsTotal.WithLabelValues(reason, AcquisitionOutcomeOK).Inc()
 	c.logger().Info("Escalated connection off exploratory worker.", "reason", reason, "worker", workerID, "worker_pod", workerPod)
 	// The `duckgres.s3_cache` bypass is worker-side state, and the new session

--- a/server/conn_tier_exec_test.go
+++ b/server/conn_tier_exec_test.go
@@ -1340,11 +1340,13 @@ func TestExtendedExecuteMidStreamOOMAfterRowsSurfaces(t *testing.T) {
 	}
 }
 
-// TestExtendedExecuteMaxRowsUnchanged pins the non-tier behavior of the
-// Execute row loop through the shared streaming helper: maxRows still caps the
-// DataRows sent (portal suspension is not implemented — the surplus row is
-// fetched and dropped, as before).
-func TestExtendedExecuteMaxRowsUnchanged(t *testing.T) {
+// TestExtendedExecuteMaxRowsSuspends pins the non-tier behavior of the
+// Execute row loop through the shared streaming helper: maxRows caps the
+// DataRows sent and suspends the portal (PortalSuspended, no CommandComplete);
+// a follow-up Execute on the same portal streams the rest and completes with
+// the cumulative row count. Full sequence coverage lives in
+// conn_portal_suspension_test.go — this pins the tier harness's view of it.
+func TestExtendedExecuteMaxRowsSuspends(t *testing.T) {
 	exec := &tierExecutor{name: "std", queryFn: func(int, string) (RowSet, error) {
 		return &tierRowSet{rows: []int64{1, 2, 3}}, nil
 	}}
@@ -1365,8 +1367,22 @@ func TestExtendedExecuteMaxRowsUnchanged(t *testing.T) {
 	if got := countMsgs(msgs, 'D'); got != 2 {
 		t.Fatalf("DataRow count = %d, want 2 (maxRows): %s", got, describeMsgs(msgs))
 	}
-	if !commandCompleteWith(msgs, "SELECT 2") {
-		t.Fatalf("want CommandComplete 'SELECT 2': %s", describeMsgs(msgs))
+	if got := countMsgs(msgs, 's'); got != 1 {
+		t.Fatalf("want PortalSuspended after the capped page: %s", describeMsgs(msgs))
+	}
+	if commandCompleteWith(msgs, "SELECT 2") {
+		t.Fatalf("CommandComplete at the row cap would silently truncate: %s", describeMsgs(msgs))
+	}
+	out.Reset()
+	if err := extExecute(c, "s1", 2); err != nil {
+		t.Fatalf("resume Execute: %v", err)
+	}
+	msgs = parseWireMsgs(t, out.Bytes())
+	if got := countMsgs(msgs, 'D'); got != 1 {
+		t.Fatalf("resume DataRow count = %d, want the remaining 1: %s", got, describeMsgs(msgs))
+	}
+	if !commandCompleteWith(msgs, "SELECT 3") {
+		t.Fatalf("want cumulative CommandComplete 'SELECT 3': %s", describeMsgs(msgs))
 	}
 }
 

--- a/server/wire/protocol.go
+++ b/server/wire/protocol.go
@@ -36,6 +36,7 @@ const (
 	MsgBindComplete    = '2'
 	MsgCloseComplete   = '3'
 	MsgNoData          = 'n'
+	MsgPortalSuspended = 's'
 
 	// COPY messages (both directions)
 	MsgCopyData        = 'd' // Contains COPY data
@@ -338,6 +339,13 @@ func WriteCloseComplete(w io.Writer) error {
 // writeNoData sends no data response
 func WriteNoData(w io.Writer) error {
 	return WriteMessage(w, MsgNoData, nil)
+}
+
+// WritePortalSuspended signals that Execute reached its row-count limit
+// before exhausting the portal; the client issues another Execute on the
+// same portal to continue fetching.
+func WritePortalSuspended(w io.Writer) error {
+	return WriteMessage(w, MsgPortalSuspended, nil)
 }
 
 // writeCopyOutResponse tells client we're about to send COPY data

--- a/tests/integration/portal_suspension_test.go
+++ b/tests/integration/portal_suspension_test.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// Portal suspension regression (Hex 1024-row truncation): clients that page
+// result sets by sending Execute with a nonzero row limit (JDBC
+// setFetchSize, Hex) must receive PortalSuspended at each page boundary and
+// be able to fetch the full result set with follow-up Executes. Pre-fix,
+// duckgres answered the first page with CommandComplete, silently truncating
+// every result set to the client's page size.
+//
+// psql/libpq clients never send a nonzero Execute row limit, so this can't
+// be exercised through the usual helpers — the test drives the raw
+// extended-query protocol via pgconn's frontend.
+func TestPortalSuspensionPaging(t *testing.T) {
+	ctx := context.Background()
+
+	connStr := fmt.Sprintf("host=127.0.0.1 port=%d user=testuser password=testpass dbname=test sslmode=require", testHarness.dgPort)
+	cfg, err := pgconn.ParseConfig(connStr)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	cfg.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	conn, err := pgconn.ConnectConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	const (
+		totalRows = 1000
+		pageSize  = 128
+	)
+
+	f := conn.Frontend()
+	f.Send(&pgproto3.Parse{Query: fmt.Sprintf("SELECT * FROM range(%d)", totalRows)})
+	f.Send(&pgproto3.Bind{})
+	f.Send(&pgproto3.Describe{ObjectType: 'P'})
+	f.Send(&pgproto3.Execute{MaxRows: pageSize})
+	f.Send(&pgproto3.Sync{})
+	if err := f.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	dataRows := 0
+	suspensions := 0
+	commandTag := ""
+	awaitingPage := true
+	for awaitingPage {
+		msg, err := f.Receive()
+		if err != nil {
+			t.Fatalf("receive: %v", err)
+		}
+		switch m := msg.(type) {
+		case *pgproto3.DataRow:
+			dataRows++
+		case *pgproto3.PortalSuspended:
+			suspensions++
+			if suspensions > totalRows/pageSize+1 {
+				t.Fatalf("runaway suspension loop: %d suspensions for %d rows", suspensions, dataRows)
+			}
+			// Fetch the next page on the same (unnamed) portal.
+			f.Send(&pgproto3.Execute{MaxRows: pageSize})
+			f.Send(&pgproto3.Sync{})
+			if err := f.Flush(); err != nil {
+				t.Fatalf("flush next page: %v", err)
+			}
+		case *pgproto3.CommandComplete:
+			commandTag = string(m.CommandTag)
+		case *pgproto3.ErrorResponse:
+			t.Fatalf("server error: %s %s", m.Code, m.Message)
+		case *pgproto3.ReadyForQuery:
+			// One ReadyForQuery arrives per Sync; the stream is done only
+			// after the leg that carried CommandComplete.
+			if commandTag != "" {
+				awaitingPage = false
+			}
+		}
+	}
+
+	if dataRows != totalRows {
+		t.Errorf("paged fetch returned %d rows, want %d (silent truncation)", dataRows, totalRows)
+	}
+	// 1000/128 = 7 full pages + a partial page; PostgreSQL semantics also
+	// allow a trailing empty page when the total is an exact multiple.
+	if suspensions < totalRows/pageSize {
+		t.Errorf("expected at least %d PortalSuspended messages, got %d", totalRows/pageSize, suspensions)
+	}
+	if want := fmt.Sprintf("SELECT %d", totalRows); commandTag != want {
+		t.Errorf("CommandComplete tag = %q, want %q (cumulative row count)", commandTag, want)
+	}
+}

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -206,6 +206,16 @@ normal `go test ./...` lane.
 
 ### Deliberately not covered here
 
+- **Portal suspension (extended-query Execute row limit)** — the harness
+  drives all SQL through psql, and libpq never sends a nonzero Execute row
+  limit, so a paging client (JDBC `setFetchSize`, Hex) cannot be simulated
+  in-Job. The behavior is deterministically covered against a real server by
+  `tests/integration/portal_suspension_test.go::TestPortalSuspensionPaging`
+  (raw pgproto3 frontend paging a 1000-row result set over TLS) and by the
+  server unit tests in `server/conn_portal_suspension_test.go`; the path is
+  identical on the remote backend (suspension lives entirely in the CP's
+  pgwire layer above the executor).
+
 - **Native metadata proxy denial for an external metadata-store org** — the
   live suite intentionally provisions only CNPG-backed orgs and has no RDS
   credential with which to create an external-store tenant. The backend-kind


### PR DESCRIPTION
## Problem

A customer reported that Hex caps every result set at exactly **1,024 rows** — `select * from ducklake.posthog.persons_production limit 3000` returned 1,024 rows with no error. Hex confirmed they apply no client-side limit.

Root cause: duckgres did not implement **portal suspension**. Hex's driver (like JDBC with `setFetchSize`) pages result sets by sending `Execute` with a row limit of 1024. Per the PostgreSQL protocol, a server that hits the limit with rows remaining must send `PortalSuspended` so the client issues another `Execute` for the next page. Duckgres instead sent `CommandComplete` after the first page (`server/conn_extended_query.go`: `// Portal suspended - but we don't support this yet`), so the client — correctly, per protocol — concluded the result set was complete. Silent truncation at exactly the client's page size, for any paging client.

Reproduced against a local standalone build with a raw `pgproto3` client: `Execute{MaxRows: 1024}` on a 3,000-row query → 1,024 `DataRow`s + `CommandComplete "SELECT 1024"`.

## Fix

Implement portal suspension per the protocol:

- Hitting the row limit sends **`PortalSuspended`** and keeps the portal's rowset open (`portal.exec`); a follow-up `Execute` on the same portal **resumes** streaming where the previous leg stopped — the query executes exactly once across legs. The limit is now checked *before* advancing the rowset, fixing a latent off-by-one where the first row of the next page was consumed and dropped.
- `CommandComplete` is sent only when the rowset is exhausted, with the cumulative row count (PostgreSQL semantics: a limit equal to the result size still suspends; the next `Execute` returns 0 rows + complete).
- **Cleanup**: suspended portals are destroyed (rowset closed, portal deleted) at transaction end — mirroring `closeCursorsAtTxEnd`, both for PostgreSQL parity and because the open rowset pins the session's single DuckDB connection. `Close('P')`, Bind-overwrite of the portal name, and connection teardown also release the rowset. Destroying rather than keeping the tx-ended portal matters: a kept entry would re-run the query from row 0 on the next `Execute`, silently replaying page one as a continuation; `34000 "portal does not exist"` is the honest answer.
- The query-log entry is written by the leg that completes (or errors) the portal, spanning all legs with the cumulative row count.

## Verification

- **Unit** (`server/conn_portal_suspension_test.go`, written first, watched fail): exact wire-message sequences for suspend/resume paging (`TDDs`/`DDs`/`DC` + `SELECT 5` tag, query executed once), exact-boundary suspension, `maxRows=0` regression guard, and rows-closed asserts for Close/tx-end/Bind-overwrite.
- **Integration** (`tests/integration/portal_suspension_test.go`): raw `pgproto3` frontend pages a 1,000-row result set in 128-row pages against the real server over TLS — passes with all 1,000 rows, ≥7 suspensions, cumulative `SELECT 1000` tag.
- **End-to-end repro**: the original failing scenario (3,000 rows, `MaxRows: 1024`) against a locally running standalone build now returns `PortalSuspended` at 1,024 and 2,048 and all 3,000 rows with `CommandComplete "SELECT 3000"`.
- `go build ./...`, `go test ./server/... ./transpiler/... ./duckdbservice/... ./controlplane/` all pass; cursor/JDBC/session integration subsets pass.
- **mw-dev harness**: not assertable in-Job — the harness drives SQL through psql, and libpq never sends a nonzero Execute row limit. Noted under "Deliberately not covered here" in `tests/mw-dev/README.md` per the testing policy; the suspension path lives entirely in the CP's pgwire layer above the executor, so it is identical on the remote backend.

Docs: `docs/postgres-compatibility.md` wire-protocol table gains a Portal suspension row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)