### PR TITLE
feat(analytics): allow analytics without enabling log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,10 +388,11 @@ Run with config file:
 | `DUCKGRES_EXPLORATORY_WORKER_CPU` | CPU request/limit of the exploratory worker pod (e.g. `1`, `500m`). Required (with the memory knob) for the tier to activate; a missing or invalid value logs a warning and leaves the tier OFF. Env-only. | - |
 | `DUCKGRES_EXPLORATORY_WORKER_MEMORY` | Memory request/limit of the exploratory worker pod (e.g. `2Gi`). Same requirement as the CPU knob. Env-only. | - |
 | `DUCKGRES_EXPLORATORY_WORKER_TTL` | Hot-idle TTL of exploratory worker pods (Go duration) — how long one stays parked for the org's next connection after its last one ends. Env-only. | `48h` |
-| `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events** | - |
-| `POSTHOG_HOST` | PostHog ingest host | `us.i.posthog.com` |
+| `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events**. Application logs carry query text — to get events without exporting SQL, leave this unset and use `POSTHOG_ANALYTICS_API_KEY` | - |
+| `POSTHOG_ANALYTICS_API_KEY` | PostHog project API key for product-analytics events **only**, leaving log export off. Takes precedence over `POSTHOG_API_KEY` for analytics | - |
+| `POSTHOG_HOST` | PostHog ingest host (shared by both exporters) | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |
-| `DUCKGRES_IDENTIFIER` | Suffix appended to the OTel `service.name` in PostHog logs (e.g., `duckgres-acme`); only used when `POSTHOG_API_KEY` is set | - |
+| `DUCKGRES_IDENTIFIER` | Suffix appended to the OTel `service.name` (e.g., `duckgres-acme`). Applies to **both** the log export and the OTLP trace export — they share one resource — so setting it renames the service in traces too, not just logs | - |
 
 ### PostHog Logging
 
@@ -414,10 +415,34 @@ export POSTHOG_HOST=eu.i.posthog.com
 
 ### PostHog Product-Analytics Events
 
-The same `POSTHOG_API_KEY` (and `POSTHOG_HOST`) also enables product-analytics
-event capture via the PostHog capture API. This is separate from log export:
-logs go to PostHog Logs, these are discrete events you can build insights and
-dashboards on. When `POSTHOG_API_KEY` is unset, no events are sent.
+`POSTHOG_API_KEY` (and `POSTHOG_HOST`) also enables product-analytics event
+capture via the PostHog capture API. This is separate from log export: logs go
+to PostHog Logs, these are discrete events you can build insights and dashboards
+on.
+
+The two exporters can be enabled independently, and the distinction matters
+because they carry different data. These events are metadata only. Application
+logs are not: `logQuery` / `logQueryError` attach the statement, and
+`usersecrets.RedactForLog` only rewrites secret DDL, so ordinary SQL and its
+literals reach PostHog Logs.
+
+| Set | Analytics events | Log export |
+| --- | --- | --- |
+| `POSTHOG_ANALYTICS_API_KEY` | ✅ | ❌ |
+| `POSTHOG_API_KEY` | ✅ | ✅ |
+| both | ✅ (analytics key) | ✅ (`POSTHOG_API_KEY`) |
+| neither | ❌ | ❌ |
+
+So a deployment serving customer data — where SQL must not be exported — sets
+only `POSTHOG_ANALYTICS_API_KEY`:
+
+```bash
+export POSTHOG_ANALYTICS_API_KEY=phc_your_project_api_key
+./duckgres
+```
+
+Existing single-key deployments are unaffected: `POSTHOG_API_KEY` keeps both
+exporters on, exactly as before.
 
 Events are attributed to an org using [PostHog group analytics](https://posthog.com/docs/product-analytics/group-analytics):
 the `distinct_id` is the org name and each event carries a group of type

--- a/internal/cliboot/analytics.go
+++ b/internal/cliboot/analytics.go
@@ -7,15 +7,36 @@ import (
 	"github.com/posthog/duckgres/internal/analytics"
 )
 
+// analyticsAPIKey resolves the key used for product-analytics capture.
+//
+// POSTHOG_ANALYTICS_API_KEY enables analytics WITHOUT enabling the OTLP log
+// export, which stays gated on POSTHOG_API_KEY alone (see InitLogging). The
+// two exporters carry very different data: analytics events are metadata only
+// (see the events table in README.md), while application logs include query
+// text — `logQuery`/`logQueryError` attach the statement, and
+// usersecrets.RedactForLog only rewrites secret DDL, so arbitrary SQL and its
+// literals reach PostHog Logs. A deployment that must not ship customer SQL
+// therefore sets ONLY POSTHOG_ANALYTICS_API_KEY.
+//
+// POSTHOG_API_KEY remains a fallback so existing single-key deployments keep
+// both exporters with no config change. POSTHOG_HOST is shared by both and is
+// read independently of which key is set.
+func analyticsAPIKey() string {
+	if key := os.Getenv("POSTHOG_ANALYTICS_API_KEY"); key != "" {
+		return key
+	}
+	return os.Getenv("POSTHOG_API_KEY")
+}
+
 // InitAnalytics installs a PostHog product-analytics tracker when
-// POSTHOG_API_KEY is set, reusing the same POSTHOG_API_KEY / POSTHOG_HOST env
-// vars as the OTLP log export (see InitLogging). When the key is unset the
-// global tracker stays a no-op and Capture calls are discarded.
+// POSTHOG_ANALYTICS_API_KEY or POSTHOG_API_KEY is set (see analyticsAPIKey for
+// which one to use), reading POSTHOG_HOST for the ingest host. When neither is
+// set the global tracker stays a no-op and Capture calls are discarded.
 //
 // Returns a shutdown function that flushes buffered events; wire it alongside
 // the InitLogging shutdown in each entrypoint.
 func InitAnalytics() func() {
-	apiKey := os.Getenv("POSTHOG_API_KEY")
+	apiKey := analyticsAPIKey()
 	if apiKey == "" {
 		return func() {}
 	}

--- a/internal/cliboot/analytics_test.go
+++ b/internal/cliboot/analytics_test.go
@@ -1,0 +1,50 @@
+package cliboot
+
+import "testing"
+
+// TestAnalyticsAPIKeyPrefersDedicatedKey pins the split between the two
+// PostHog exporters. POSTHOG_ANALYTICS_API_KEY must enable product analytics
+// on its own, because InitLogging gates the OTLP log export on
+// POSTHOG_API_KEY: a deployment that sets only the dedicated key gets
+// metadata-only events and no query text exported. The POSTHOG_API_KEY
+// fallback keeps existing single-key deployments on both exporters.
+func TestAnalyticsAPIKeyPrefersDedicatedKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		analyticsKey string
+		sharedKey    string
+		want         string
+	}{
+		{
+			name:         "dedicated key alone enables analytics without log export",
+			analyticsKey: "phc_analytics",
+			want:         "phc_analytics",
+		},
+		{
+			name:      "shared key still enables analytics (existing deployments)",
+			sharedKey: "phc_shared",
+			want:      "phc_shared",
+		},
+		{
+			name:         "dedicated key wins when both are set",
+			analyticsKey: "phc_analytics",
+			sharedKey:    "phc_shared",
+			want:         "phc_analytics",
+		},
+		{
+			name: "neither set leaves the tracker a no-op",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("POSTHOG_ANALYTICS_API_KEY", tt.analyticsKey)
+			t.Setenv("POSTHOG_API_KEY", tt.sharedKey)
+
+			if got := analyticsAPIKey(); got != tt.want {
+				t.Errorf("analyticsAPIKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -348,6 +348,13 @@ normal `go test ./...` lane.
   events), `controlplane/provisioner/controller_analytics_test.go` (the
   terminal `_success`/`_failed` events the provisioner controller emits on the
   Ready/Failed/Deleted transitions), and `server/conn_analytics_test.go`.
+  The same applies to WHICH exporter a given key enables: `POSTHOG_API_KEY`
+  turns on analytics *and* the OTLP log export, while
+  `POSTHOG_ANALYTICS_API_KEY` turns on analytics alone (so query text is not
+  exported). Confirming that split end-to-end means reading both PostHog Logs
+  and the event stream back, which the Job cannot do for the reason above; the
+  key resolution is covered by `TestAnalyticsAPIKeyPrefersDedicatedKey` in
+  `internal/cliboot/analytics_test.go`.
 
 ## Isolation model
 


### PR DESCRIPTION
## What

Adds `POSTHOG_ANALYTICS_API_KEY`, read only by `InitAnalytics`. Setting it enables product-analytics capture while `InitLogging` stays gated on `POSTHOG_API_KEY` alone, so the OTLP log export stays off.

`POSTHOG_API_KEY` remains a fallback for analytics, so every existing single-key deployment keeps both exporters with no config change.

| Set | Analytics events | Log export |
| --- | --- | --- |
| `POSTHOG_ANALYTICS_API_KEY` | ✅ | ❌ |
| `POSTHOG_API_KEY` | ✅ | ✅ |
| both | ✅ (analytics key) | ✅ (`POSTHOG_API_KEY`) |
| neither | ❌ | ❌ |

## Why

One key currently gates two exporters that carry very different data. The analytics events are metadata only. The application logs are not: `logQuery` / `logQueryError` attach the statement, and `usersecrets.RedactForLog` only rewrites secret DDL — every other statement hits `return query` unchanged, so ordinary SQL and its literals reach PostHog Logs. I confirmed this against real exported log volume, not just by reading the code: query text is attached at **all four** severities (info, debug, warn, error), so `DUCKGRES_LOG_LEVEL` can't suppress it either.

The practical consequence is that a deployment serving customer data can't opt into the metadata-only events without also exporting customer query text. That's currently blocking managed-warehouse usage/activation metrics on prod — the charts side ([PostHog/charts#13941](https://github.com/PostHog/charts/pull/13941)) had to be scoped to dev only for exactly this reason.

## Implementation notes

**Opt-in key rather than a `POSTHOG_LOG_EXPORT_ENABLED=false` opt-out, because it fails closed.** An older binary recognises neither variable. With the opt-out it would still see `POSTHOG_API_KEY` set and export logs anyway — so the deployment config would be unsafe until the new image rolled out, and the chart change would have to merge strictly after the image. With the opt-in, an older binary simply does nothing, so config and image can land in any order.

`POSTHOG_HOST` is unchanged and shared — `InitAnalytics` reads it independently of which key is set, and `InitLogging` never reaches it when `POSTHOG_API_KEY` is unset.

Also corrects the `DUCKGRES_IDENTIFIER` row in the env table, which claimed the suffix was "only used when `POSTHOG_API_KEY` is set". It feeds the shared `otelResource()` used by **both** `InitLogging` and `InitTracing`, so it renames `service.name` for the OTLP trace export too. That wording caused a real unintended trace rename in a downstream chart change — fixing it here so the next reader doesn't repeat it.

## Testing

- `gofmt -l` clean, `go vet ./internal/cliboot/` clean, `go test ./internal/cliboot/` passes.
- Added `TestAnalyticsAPIKeyPrefersDedicatedKey` covering all four key combinations.
- `golangci-lint` is not available in my environment, so it was **not** run.

**No `tests/mw-dev/e2e/harness.sh` assertion**, and per CLAUDE.md I'm saying so explicitly rather than skipping silently. Confirming the split end-to-end means reading *both* PostHog Logs and the event stream back, and the in-cluster Job holds no PostHog query-API creds — the same reason the existing "PostHog product-analytics events" bullet in `tests/mw-dev/README.md` already gives for not asserting event ingestion in-Job. I extended that bullet to cover the key split and point at the new unit test. Happy to add a startup-banner assertion instead if you'd rather have something in the harness.

I'm an agent; the above is the complete set of checks I ran. No manual or in-cluster verification.

## 🤖 Agent context

Authored by Claude Opus 4.5 via PostHog Code, working backwards from "the managed-warehouse usage metric is empty".

The chain: the metric was empty because no duckgres analytics events existed → because `POSTHOG_API_KEY` was set nowhere in the charts repo → the obvious fix (set it) was blocked in review because it would also export customer SQL via the log path. This PR removes that coupling.

Rejected along the way: the `POSTHOG_LOG_EXPORT_ENABLED` opt-out (fails open on old binaries, see above), and scrubbing query text on the log path (much larger change; redacting arbitrary SQL literals is genuinely hard, and the log export is useful precisely because it includes the statement).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
