### PR TITLE
feat(cache-proxy): block-aligned caching + env-gated parquet prefetch disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Run with config file:
 | `DUCKGRES_KEY` | TLS private key file | `./certs/server.key` |
 | `DUCKGRES_MEMORY_LIMIT` | DuckDB memory_limit per session (e.g., `4GB`) | Auto-detected |
 | `DUCKGRES_THREADS` | DuckDB threads per session | `runtime.NumCPU()` |
+| `DUCKGRES_DISABLE_PARQUET_PREFETCHING` | Disable DuckDB Parquet prefetching for standalone/process workers and control-plane-spawned K8s workers. Boolean values use Go's accepted forms (`true`, `TRUE`, `1`, etc.). | `false` |
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
 | `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |
 | `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` |

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -14,8 +14,53 @@ available, and forwards cache misses to origin object storage.
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
+| `CACHE_BLOCK_MODE` | `off` | `on` enables block-aligned caching; any other value (including unset) keeps the legacy exact-range path. See [Block-aligned mode](#block-aligned-mode). |
+| `CACHE_BLOCK_SIZE_BYTES` | `8388608` (8 MiB) | Fixed block size for block-aligned mode. Ignored when block mode is off. |
+| `CACHE_BLOCK_MAX_SPAN_BLOCKS` | `8` | Max blocks coalesced into one origin range fetch. Ignored when block mode is off. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` | empty | OTLP/HTTP trace endpoint. Unset → tracing is a no-op. |
 | `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
+
+## Block-aligned mode
+
+The legacy cache key is `sha256(url|range)` — an exact match on the client's
+`Range` header. DuckDB's Parquet reader rarely issues the same byte range
+twice, even across repeat runs of the same query: footer probes, row-group
+reads, and column-chunk reads all drift by a few bytes depending on prior
+reader state, so a second run of an identical query produces a mostly
+disjoint set of ranges from the first. Measured on one workload, 0 of 7,370
+range keys from a second run matched any key cached by the first — a 100%
+miss rate on a workload that should have been fully warm.
+
+Block-aligned mode fixes this by keying the cache on fixed-size blocks of the
+underlying object instead of the client's exact range. The key is
+`sha256(url|blk|idx|blockSize)`, where `idx` is the block index (`start /
+blockSize`) and `blockSize` is part of the key so a config change can't serve
+a wrong-sized entry — old-size entries just become unreachable and age out
+normally. A request is served by locating the blocks its range overlaps
+(locally, then from peers, then coalescing missing runs into origin range
+fetches bounded by `CACHE_BLOCK_MAX_SPAN_BLOCKS` per request) and assembling
+the requested byte range from them. Because the key no longer depends on the
+exact range, two requests over the same bytes with different start/end always
+hit the same cached blocks.
+
+**Trade-off:** the first read of an uncached object always fetches at least
+one full block, even if the request only needs a few bytes — a 40 KB Parquet
+footer read on an uncached object still fetches one full 8 MiB block. This
+first-touch amplification is bounded by `CACHE_BLOCK_SIZE_BYTES` and
+amortized away by object immutability — every subsequent read of any byte
+range overlapping that block is a pure cache hit, including reads with
+different boundaries than the one that populated it.
+
+Only requests with a specific shape are served from block-aligned entries;
+everything else keeps behaving exactly as it does with block mode off:
+
+| Request shape | Path |
+| --- | --- |
+| Absolute `Range: bytes=start-end` on a cacheable bucket `GET` | Block-aligned |
+| Suffix range (`bytes=-N`), open-ended (`bytes=N-`), multi-range, or missing `Range` | Legacy exact-range path |
+| Non-`GET` (`HEAD`, `PUT`, ...) | Passthrough (never cached), unchanged |
+| Non-bucket `GET` (`CACHE_HOST_SUFFIXES` doesn't match) | Passthrough, unchanged |
+| `CACHE_BLOCK_SIZE_BYTES` or `CACHE_BLOCK_MAX_SPAN_BLOCKS` misconfigured (≤ 0) | Legacy exact-range path |
 
 ## Tracing
 

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -61,6 +61,14 @@ everything else keeps behaving exactly as it does with block mode off:
 | Non-`GET` (`HEAD`, `PUT`, ...) | Passthrough (never cached), unchanged |
 | Non-bucket `GET` (`CACHE_HOST_SUFFIXES` doesn't match) | Passthrough, unchanged |
 | `CACHE_BLOCK_SIZE_BYTES` or `CACHE_BLOCK_MAX_SPAN_BLOCKS` misconfigured (≤ 0) | Legacy exact-range path |
+| Requested block span cannot fit in the configured cache capacity | Legacy exact-range path |
+
+Origin `206 Partial Content` responses are accepted only when their
+`Content-Range` exactly matches the requested block span (allowing the final
+span to end at the advertised object size). The validated object size is used
+to clamp ranges that cross EOF and return `416` for ranges that start at or
+beyond EOF. Before a `206` response is committed, every required cache block is
+opened so LRU eviction cannot truncate an in-progress assembled response.
 
 ## Tracing
 

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	cacheOriginBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_origin_bytes_total",
+		Help: "Bytes fetched from S3 origin (block mode; the origin-offload SLI numerator)",
+	})
+	blockFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_block_fallback_total",
+		Help: "Requests that fell back to the legacy exact-range path, by reason",
+	}, []string{"reason"}) // range_shape, origin_error, entry_vanished
+	blockReadsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_block_reads_total",
+		Help: "Blocks resolved while assembling responses, by source",
+	}, []string{"source"}) // local, peer, s3
+)
+
+// fetchOriginSpan fetches blocks [firstIdx, lastIdx] of r.URL in ONE origin
+// range GET and commits each block to the store under its BlockKey. Rewriting
+// the Range header is legal: DuckDB httpfs signs only
+// host;x-amz-content-sha256;x-amz-date (see forwardUncached), so Range is not
+// covered by the SigV4 signature. The final block of an object is naturally
+// short — a clean EOF mid-span is success, not an error.
+func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastIdx int64) error {
+	timeout := p.originTimeout
+	if timeout <= 0 {
+		timeout = defaultOriginTimeout
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.URL.String(), nil)
+	if err != nil {
+		return err
+	}
+	for k, vv := range r.Header {
+		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, "Range") {
+			continue
+		}
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	req.Host = r.Host
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", firstIdx*blockSize, (lastIdx+1)*blockSize-1))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, originErrorBodyCap))
+		return &originStatusError{status: resp.StatusCode, headers: resp.Header.Clone(), body: body}
+	}
+
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		size, err := p.store.PutStream(BlockKey(r.URL.String(), idx, blockSize), io.LimitReader(resp.Body, blockSize))
+		if err != nil {
+			return fmt.Errorf("commit block %d: %w", idx, err)
+		}
+		cacheOriginBytesTotal.Add(float64(size))
+		if size < blockSize {
+			// Object ended inside this block — it is the tail. Done.
+			break
+		}
+	}
+	return nil
+}

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -78,4 +80,137 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 		}
 	}
 	return nil
+}
+
+// serveBlockAligned serves a cacheable GET whose Range is an absolute
+// bytes=start-end pair from block-aligned cache entries: local disk, then
+// peers, then coalesced origin fetches for contiguous missing runs (chunked
+// at maxSpanBlocks per origin request). Returns false when the request shape
+// is not block-servable; the caller then runs the legacy exact-range path.
+func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, rangeHeader string) bool {
+	start, end, ok := parseAbsoluteRange(rangeHeader)
+	if !ok {
+		blockFallbackTotal.WithLabelValues("range_shape").Inc()
+		return false
+	}
+	firstIdx, lastIdx := blockSpan(start, end, p.blockSize)
+	urlStr := r.URL.String()
+
+	// Phase 1: ensure every block is present locally. Track sources for the
+	// hit/miss accounting and the log line.
+	var nLocal, nPeer, nOrigin int64
+	var missRunStart int64 = -1
+	flushRun := func(runEnd int64) bool {
+		if missRunStart < 0 {
+			return true
+		}
+		for lo := missRunStart; lo <= runEnd; lo += p.maxSpanBlocks {
+			hi := min(lo+p.maxSpanBlocks-1, runEnd)
+			_, err := p.flights.Do(BlockKey(urlStr, lo, p.blockSize), func() (fetchResult, error) {
+				return fetchResult{}, p.fetchOriginSpan(r, p.blockSize, lo, hi)
+			})
+			if err != nil {
+				var oe *originStatusError
+				if errors.As(err, &oe) {
+					oe.writeTo(w)
+					return false
+				}
+				slog.Error("Block span fetch failed.", "url", urlStr, "blocks", fmt.Sprintf("%d-%d", lo, hi), "error", err)
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return false
+			}
+			nOrigin += hi - lo + 1
+		}
+		missRunStart = -1
+		return true
+	}
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		key := BlockKey(urlStr, idx, p.blockSize)
+		if p.store.Has(key) {
+			if !flushRun(idx - 1) {
+				return true // error already written
+			}
+			nLocal++
+			continue
+		}
+		if p.peers != nil {
+			if _, _, ok := p.peers.FetchFromPeers(key, func(rd io.Reader) (int64, error) {
+				return p.store.PutStream(key, rd)
+			}); ok {
+				if !flushRun(idx - 1) {
+					return true
+				}
+				nPeer++
+				continue
+			}
+		}
+		if missRunStart < 0 {
+			missRunStart = idx
+		}
+	}
+	if !flushRun(lastIdx) {
+		return true
+	}
+	blockReadsTotal.WithLabelValues("local").Add(float64(nLocal))
+	blockReadsTotal.WithLabelValues("peer").Add(float64(nPeer))
+	blockReadsTotal.WithLabelValues("s3").Add(float64(nOrigin))
+
+	// Request-level hit/miss accounting mirrors the legacy meaning: a hit is
+	// "no origin traffic needed".
+	if nOrigin == 0 {
+		cacheHitsTotal.Inc()
+	} else {
+		cacheMissesTotal.Inc()
+	}
+
+	// Phase 2: stream the assembled range. Mirrors serveStream's legacy
+	// response shape: 206 + Content-Range with served size after the slash.
+	total := end - start + 1
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", total))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+	w.WriteHeader(http.StatusPartialContent)
+
+	served := int64(0)
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		reader, size, ok := p.store.openFile(BlockKey(urlStr, idx, p.blockSize))
+		if !ok {
+			// Evicted in the window between phase 1 and here (or object
+			// shorter than the requested range). Nothing sane to send after
+			// headers are out; abort so httpfs sees a short body and retries.
+			blockFallbackTotal.WithLabelValues("entry_vanished").Inc()
+			slog.Warn("Block vanished during assembly.", "url", urlStr, "block", idx)
+			return true
+		}
+		blockStart := idx * p.blockSize
+		skip := max(0, start-blockStart)
+		want := min(size-skip, end-blockStart+1-skip, total-served)
+		if skip > 0 {
+			_, _ = io.CopyN(io.Discard, reader, skip)
+		}
+		n, _ := io.CopyN(w, reader, want)
+		served += n
+		_ = reader.Close()
+		if n < want {
+			return true
+		}
+	}
+	cacheBytesServed.WithLabelValues(sourceLabel(nPeer, nOrigin)).Add(float64(served))
+	slog.Info("Served.", "source", "blocks", "url", urlStr, "range", rangeHeader,
+		"bytes", served, "blocks_local", nLocal, "blocks_peer", nPeer, "blocks_s3", nOrigin)
+	return true
+}
+
+// sourceLabel picks the legacy bytes_served source label for an assembled
+// response: s3 if any origin fetch happened, else peer if any peer fill, else
+// local — so the existing "Bytes served by source" dashboard keeps meaning
+// "where did the slowest byte come from".
+func sourceLabel(nPeer, nOrigin int64) string {
+	switch {
+	case nOrigin > 0:
+		return "s3"
+	case nPeer > 0:
+		return "peer"
+	default:
+		return "local"
+	}
 }

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,19 +22,63 @@ var (
 	blockFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_fallback_total",
 		Help: "Requests that fell back to the legacy exact-range path, by reason",
-	}, []string{"reason"}) // no_range, range_shape, entry_vanished, config
+	}, []string{"reason"}) // no_range, range_shape, entry_vanished, config, capacity
 	blockReadsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_reads_total",
 		Help: "Blocks resolved while assembling responses, by source",
 	}, []string{"source"}) // local, peer, s3
 )
 
+type exactLengthReader struct {
+	r         io.Reader
+	remaining int64
+}
+
+func (r *exactLengthReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= int64(n)
+	if err == io.EOF && r.remaining > 0 {
+		return n, io.ErrUnexpectedEOF
+	}
+	if err == io.EOF && r.remaining == 0 {
+		return n, nil
+	}
+	return n, err
+}
+
+func (p *CacheProxy) rememberObjectSize(url string, size int64) {
+	if size >= 0 {
+		p.objectSizes.Store(url, size)
+	}
+}
+
+func (p *CacheProxy) knownObjectSize(url string) (int64, bool) {
+	v, ok := p.objectSizes.Load(url)
+	if !ok {
+		return 0, false
+	}
+	size, ok := v.(int64)
+	return size, ok
+}
+
+func writeRangeNotSatisfiable(w http.ResponseWriter, objectSize int64) {
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", objectSize))
+	w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+}
+
 // fetchOriginSpan fetches blocks [firstIdx, lastIdx] of r.URL in ONE origin
 // range GET and commits each block to the store under its BlockKey. Rewriting
 // the Range header is legal: DuckDB httpfs signs only
 // host;x-amz-content-sha256;x-amz-date (see forwardUncached), so Range is not
-// covered by the SigV4 signature. The final block of an object is naturally
-// short — a clean EOF mid-span is success, not an error.
+// covered by the SigV4 signature. Content-Range is validated before any block
+// is committed, and each selected block must contain exactly the advertised
+// number of bytes.
 func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastIdx int64) error {
 	timeout := p.originTimeout
 	if timeout <= 0 {
@@ -55,7 +100,9 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 		}
 	}
 	req.Host = r.Host
-	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", firstIdx*blockSize, (lastIdx+1)*blockSize-1))
+	wantStart := firstIdx * blockSize
+	wantEnd := (lastIdx+1)*blockSize - 1
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", wantStart, wantEnd))
 
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -64,6 +111,11 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
+		if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+			if objectSize, ok := parseUnsatisfiedContentRange(resp.Header.Get("Content-Range")); ok {
+				p.rememberObjectSize(r.URL.String(), objectSize)
+			}
+		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, originErrorBodyCap))
 		return &originStatusError{status: resp.StatusCode, headers: resp.Header.Clone(), body: body}
 	}
@@ -79,18 +131,40 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 	if resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("origin ignored Range (status %d): refusing to cache misaligned blocks", resp.StatusCode)
 	}
+	gotStart, gotEnd, objectSize, ok := parsePartialContentRange(resp.Header.Get("Content-Range"))
+	if !ok {
+		return fmt.Errorf("origin returned invalid Content-Range %q", resp.Header.Get("Content-Range"))
+	}
+	wantResponseEnd := min(wantEnd, objectSize-1)
+	if gotStart != wantStart || gotEnd != wantResponseEnd {
+		return fmt.Errorf("origin returned Content-Range bytes %d-%d/%d for requested bytes %d-%d",
+			gotStart, gotEnd, objectSize, wantStart, wantEnd)
+	}
+	expectedBodySize := gotEnd - gotStart + 1
+	if resp.ContentLength >= 0 && resp.ContentLength != expectedBodySize {
+		return fmt.Errorf("origin Content-Length %d does not match Content-Range length %d", resp.ContentLength, expectedBodySize)
+	}
 
-	for idx := firstIdx; idx <= lastIdx; idx++ {
-		size, err := p.store.PutStream(BlockKey(r.URL.String(), idx, blockSize), io.LimitReader(resp.Body, blockSize))
+	remaining := expectedBodySize
+	for idx := firstIdx; idx <= lastIdx && remaining > 0; idx++ {
+		blockBytes := min(blockSize, remaining)
+		size, err := p.store.PutStream(BlockKey(r.URL.String(), idx, blockSize), &exactLengthReader{
+			r:         resp.Body,
+			remaining: blockBytes,
+		})
 		if err != nil {
 			return fmt.Errorf("commit block %d: %w", idx, err)
 		}
-		cacheOriginBytesTotal.Add(float64(size))
-		if size < blockSize {
-			// Object ended inside this block — it is the tail. Done.
-			break
+		if size != blockBytes {
+			return fmt.Errorf("commit block %d: stored %d bytes, expected %d", idx, size, blockBytes)
 		}
+		cacheOriginBytesTotal.Add(float64(size))
+		remaining -= size
 	}
+	if remaining != 0 {
+		return fmt.Errorf("origin body ended with %d bytes still expected", remaining)
+	}
+	p.rememberObjectSize(r.URL.String(), objectSize)
 	return nil
 }
 
@@ -116,8 +190,20 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		blockFallbackTotal.WithLabelValues("range_shape").Inc()
 		return false
 	}
-	firstIdx, lastIdx := blockSpan(start, end, p.blockSize)
 	urlStr := r.URL.String()
+	if objectSize, known := p.knownObjectSize(urlStr); known {
+		if start >= objectSize {
+			writeRangeNotSatisfiable(w, objectSize)
+			return true
+		}
+		end = min(end, objectSize-1)
+	}
+	firstIdx, lastIdx := blockSpan(start, end, p.blockSize)
+	blockCount := lastIdx - firstIdx + 1
+	if p.store.maxBytes <= 0 || blockCount > p.store.maxBytes/p.blockSize {
+		blockFallbackTotal.WithLabelValues("capacity").Inc()
+		return false
+	}
 
 	// Phase 1: ensure every block is present locally. Track sources for the
 	// hit/miss accounting and the log line.
@@ -142,6 +228,14 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			if err != nil {
 				var oe *originStatusError
 				if errors.As(err, &oe) {
+					if oe.status == http.StatusRequestedRangeNotSatisfiable {
+						if objectSize, known := p.knownObjectSize(urlStr); known && start < objectSize {
+							end = min(end, objectSize-1)
+							lastIdx = end / p.blockSize
+							missRunStart = -1
+							return true
+						}
+					}
 					oe.writeTo(w)
 					return false
 				}
@@ -149,7 +243,18 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 				http.Error(w, err.Error(), http.StatusBadGateway)
 				return false
 			}
-			nOrigin += hi - lo + 1
+			if objectSize, known := p.knownObjectSize(urlStr); known {
+				if start >= objectSize {
+					writeRangeNotSatisfiable(w, objectSize)
+					return false
+				}
+				end = min(end, objectSize-1)
+				lastIdx = end / p.blockSize
+			}
+			actualHi := min(hi, lastIdx)
+			if actualHi >= lo {
+				nOrigin += actualHi - lo + 1
+			}
 		}
 		missRunStart = -1
 		return true
@@ -160,6 +265,9 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			if !flushRun(idx - 1) {
 				return true // error already written
 			}
+			if idx > lastIdx {
+				break
+			}
 			nLocal++
 			continue
 		}
@@ -169,6 +277,9 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			}); ok {
 				if !flushRun(idx - 1) {
 					return true
+				}
+				if idx > lastIdx {
+					break
 				}
 				nPeer++
 				continue
@@ -184,11 +295,12 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 
 	// Phase 1.5: verify every block phase 1 believes is present is actually
 	// on disk before any response header is written. This is the backstop for
-	// the single-flight race above (and any other residual gap, e.g. a true
-	// object-EOF short span leaving trailing indices uncommitted): one direct
+	// the single-flight race above (and any other residual gap): one direct
 	// re-fetch of each residual missing run, bypassing the single-flight so it
-	// always runs. If blocks are still missing afterward we fail closed with a
-	// retryable 502 rather than risk assembling a corrupt short body.
+	// always runs. A validated short object tail shrinks lastIdx during phase 1
+	// and is therefore not considered a gap. If blocks are still missing after
+	// the re-fetch we fail closed with a retryable 502 rather than risk
+	// assembling a corrupt short body.
 	var reverifyStart int64 = -1
 	reverify := func(runEnd int64) {
 		if reverifyStart < 0 {
@@ -221,6 +333,80 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		}
 	}
 
+	// Phase 2: open every block before committing response headers. Open file
+	// descriptors keep their contents readable even if the LRU removes the
+	// directory entries while the response is being assembled. If an entry
+	// vanished before it could be opened, return false so HandleProxy can use
+	// the legacy exact-range path while the response is still untouched.
+	type openedBlock struct {
+		idx    int64
+		reader io.ReadCloser
+		size   int64
+		skip   int64
+		want   int64
+	}
+	opened := make([]openedBlock, 0, lastIdx-firstIdx+1)
+	closeOpened := func() {
+		for i := range opened {
+			_ = opened[i].reader.Close()
+		}
+	}
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		reader, size, ok := p.store.openFile(BlockKey(urlStr, idx, p.blockSize))
+		if !ok {
+			closeOpened()
+			blockFallbackTotal.WithLabelValues("entry_vanished").Inc()
+			slog.Warn("Block vanished before assembly; falling back.", "url", urlStr, "block", idx)
+			return false
+		}
+		if size <= 0 || size > p.blockSize {
+			_ = reader.Close()
+			closeOpened()
+			slog.Error("Cached block has invalid size; falling back.",
+				"url", urlStr, "block", idx, "size", size, "block_size", p.blockSize)
+			return false
+		}
+		if size < p.blockSize {
+			// A validated short block is the object's tail. Remembering its
+			// boundary also recovers exact range semantics after a process
+			// restart, when the in-memory object-size map starts empty.
+			objectSize := idx*p.blockSize + size
+			p.rememberObjectSize(urlStr, objectSize)
+			if start >= objectSize {
+				_ = reader.Close()
+				closeOpened()
+				writeRangeNotSatisfiable(w, objectSize)
+				return true
+			}
+			end = min(end, objectSize-1)
+			lastIdx = idx
+		}
+		opened = append(opened, openedBlock{idx: idx, reader: reader, size: size})
+	}
+
+	total := end - start + 1
+	planned := int64(0)
+	for i := range opened {
+		blockStart := opened[i].idx * p.blockSize
+		opened[i].skip = max(0, start-blockStart)
+		opened[i].want = min(opened[i].size-opened[i].skip, end-blockStart+1-opened[i].skip, total-planned)
+		if opened[i].want <= 0 {
+			closeOpened()
+			slog.Error("Cached block cannot satisfy requested range; falling back.",
+				"url", urlStr, "block", opened[i].idx, "start", start,
+				"block_start", blockStart, "size", opened[i].size)
+			return false
+		}
+		planned += opened[i].want
+	}
+	if planned != total {
+		closeOpened()
+		slog.Error("Opened blocks do not cover requested range; falling back.",
+			"url", urlStr, "planned", planned, "total", total)
+		return false
+	}
+	defer closeOpened()
+
 	blockReadsTotal.WithLabelValues("local").Add(float64(nLocal))
 	blockReadsTotal.WithLabelValues("peer").Add(float64(nPeer))
 	blockReadsTotal.WithLabelValues("s3").Add(float64(nOrigin))
@@ -233,46 +419,24 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		cacheMissesTotal.Inc()
 	}
 
-	// Phase 2: stream the assembled range. Mirrors serveStream's legacy
-	// response shape: 206 + Content-Range with served size after the slash.
-	total := end - start + 1
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", total))
-	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+	representationSize := "*"
+	if objectSize, known := p.knownObjectSize(urlStr); known {
+		representationSize = strconv.FormatInt(objectSize, 10)
+	}
+	w.Header().Set("Content-Length", strconv.FormatInt(total, 10))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%s", start, end, representationSize))
 	w.WriteHeader(http.StatusPartialContent)
 
 	served := int64(0)
-	for idx := firstIdx; idx <= lastIdx; idx++ {
-		reader, size, ok := p.store.openFile(BlockKey(urlStr, idx, p.blockSize))
-		if !ok {
-			// Evicted in the window between phase 1 and here (or object
-			// shorter than the requested range). Nothing sane to send after
-			// headers are out; abort so httpfs sees a short body and retries.
-			blockFallbackTotal.WithLabelValues("entry_vanished").Inc()
-			slog.Warn("Block vanished during assembly.", "url", urlStr, "block", idx)
-			return true
+	for i := range opened {
+		if opened[i].skip > 0 {
+			if _, err := io.CopyN(io.Discard, opened[i].reader, opened[i].skip); err != nil {
+				return true
+			}
 		}
-		blockStart := idx * p.blockSize
-		skip := max(0, start-blockStart)
-		want := min(size-skip, end-blockStart+1-skip, total-served)
-		if want <= 0 {
-			// start lies past the end of this block (a short cached tail
-			// block whose object EOF falls before the requested start).
-			// io.CopyN silently no-ops on a non-positive n instead of erroring,
-			// so without this guard the loop would fall through the "n < want"
-			// short-body check below and produce a truncated 206 instead of
-			// failing closed.
-			_ = reader.Close()
-			slog.Warn("Computed zero-or-negative want for block; aborting response.",
-				"url", urlStr, "block", idx, "start", start, "block_start", blockStart, "size", size)
-			return true
-		}
-		if skip > 0 {
-			_, _ = io.CopyN(io.Discard, reader, skip)
-		}
-		n, _ := io.CopyN(w, reader, want)
+		n, _ := io.CopyN(w, opened[i].reader, opened[i].want)
 		served += n
-		_ = reader.Close()
-		if n < want {
+		if n < opened[i].want {
 			return true
 		}
 	}

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -21,7 +21,7 @@ var (
 	blockFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_fallback_total",
 		Help: "Requests that fell back to the legacy exact-range path, by reason",
-	}, []string{"reason"}) // range_shape, entry_vanished, config
+	}, []string{"reason"}) // no_range, range_shape, entry_vanished, config
 	blockReadsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_reads_total",
 		Help: "Blocks resolved while assembling responses, by source",
@@ -68,6 +68,18 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 		return &originStatusError{status: resp.StatusCode, headers: resp.Header.Clone(), body: body}
 	}
 
+	// This function always sends a Range header, so anything other than 206
+	// means the origin ignored it and is sending the full object from byte 0
+	// (e.g. a proxy/CDN in front of origin stripping Range, or an origin that
+	// doesn't support it). Storing that body under this span's block keys
+	// would put object-offset-0 bytes into blocks tagged with firstIdx..lastIdx
+	// — every read of those blocks would silently return the wrong bytes, and
+	// since blocks are treated as immutable once cached, the corruption would
+	// never self-heal. Fail closed instead.
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("origin ignored Range (status %d): refusing to cache misaligned blocks", resp.StatusCode)
+	}
+
 	for idx := firstIdx; idx <= lastIdx; idx++ {
 		size, err := p.store.PutStream(BlockKey(r.URL.String(), idx, blockSize), io.LimitReader(resp.Body, blockSize))
 		if err != nil {
@@ -93,6 +105,10 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	// blockSpan or loop forever in flushRun's `lo += p.maxSpanBlocks`.
 	if p.blockSize <= 0 || p.maxSpanBlocks <= 0 {
 		blockFallbackTotal.WithLabelValues("config").Inc()
+		return false
+	}
+	if rangeHeader == "" {
+		blockFallbackTotal.WithLabelValues("no_range").Inc()
 		return false
 	}
 	start, end, ok := parseAbsoluteRange(rangeHeader)
@@ -238,6 +254,18 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		blockStart := idx * p.blockSize
 		skip := max(0, start-blockStart)
 		want := min(size-skip, end-blockStart+1-skip, total-served)
+		if want <= 0 {
+			// start lies past the end of this block (a short cached tail
+			// block whose object EOF falls before the requested start).
+			// io.CopyN silently no-ops on a non-positive n instead of erroring,
+			// so without this guard the loop would fall through the "n < want"
+			// short-body check below and produce a truncated 206 instead of
+			// failing closed.
+			_ = reader.Close()
+			slog.Warn("Computed zero-or-negative want for block; aborting response.",
+				"url", urlStr, "block", idx, "start", start, "block_start", blockStart, "size", size)
+			return true
+		}
 		if skip > 0 {
 			_, _ = io.CopyN(io.Discard, reader, skip)
 		}

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -21,7 +21,7 @@ var (
 	blockFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_fallback_total",
 		Help: "Requests that fell back to the legacy exact-range path, by reason",
-	}, []string{"reason"}) // range_shape, origin_error, entry_vanished
+	}, []string{"reason"}) // range_shape, entry_vanished, config
 	blockReadsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cache_proxy_block_reads_total",
 		Help: "Blocks resolved while assembling responses, by source",
@@ -88,6 +88,13 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 // at maxSpanBlocks per origin request). Returns false when the request shape
 // is not block-servable; the caller then runs the legacy exact-range path.
 func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, rangeHeader string) bool {
+	// A misconfigured or not-yet-wired proxy (blockSize/maxSpanBlocks left at
+	// their zero value) must fall back rather than divide by zero in
+	// blockSpan or loop forever in flushRun's `lo += p.maxSpanBlocks`.
+	if p.blockSize <= 0 || p.maxSpanBlocks <= 0 {
+		blockFallbackTotal.WithLabelValues("config").Inc()
+		return false
+	}
 	start, end, ok := parseAbsoluteRange(rangeHeader)
 	if !ok {
 		blockFallbackTotal.WithLabelValues("range_shape").Inc()
@@ -106,7 +113,14 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		}
 		for lo := missRunStart; lo <= runEnd; lo += p.maxSpanBlocks {
 			hi := min(lo+p.maxSpanBlocks-1, runEnd)
-			_, err := p.flights.Do(BlockKey(urlStr, lo, p.blockSize), func() (fetchResult, error) {
+			// hi must be part of the single-flight key, not just lo: two
+			// concurrent requests can both start a missing run at the same lo
+			// but need different-length spans (their own runEnd differs), and
+			// if only lo keyed the call, the loser would adopt the winner's
+			// (shorter) fetch result while believing its own longer span was
+			// covered — silently leaving trailing blocks unfetched.
+			flightKey := fmt.Sprintf("%s|%d", BlockKey(urlStr, lo, p.blockSize), hi)
+			_, err := p.flights.Do(flightKey, func() (fetchResult, error) {
 				return fetchResult{}, p.fetchOriginSpan(r, p.blockSize, lo, hi)
 			})
 			if err != nil {
@@ -151,6 +165,46 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	if !flushRun(lastIdx) {
 		return true
 	}
+
+	// Phase 1.5: verify every block phase 1 believes is present is actually
+	// on disk before any response header is written. This is the backstop for
+	// the single-flight race above (and any other residual gap, e.g. a true
+	// object-EOF short span leaving trailing indices uncommitted): one direct
+	// re-fetch of each residual missing run, bypassing the single-flight so it
+	// always runs. If blocks are still missing afterward we fail closed with a
+	// retryable 502 rather than risk assembling a corrupt short body.
+	var reverifyStart int64 = -1
+	reverify := func(runEnd int64) {
+		if reverifyStart < 0 {
+			return
+		}
+		lo := reverifyStart
+		reverifyStart = -1
+		if err := p.fetchOriginSpan(r, p.blockSize, lo, runEnd); err != nil {
+			slog.Warn("Presence re-fetch failed; failing closed below if blocks are still missing.",
+				"url", urlStr, "blocks", fmt.Sprintf("%d-%d", lo, runEnd), "error", err)
+			return
+		}
+		nOrigin += runEnd - lo + 1
+	}
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		if p.store.Has(BlockKey(urlStr, idx, p.blockSize)) {
+			reverify(idx - 1)
+			continue
+		}
+		if reverifyStart < 0 {
+			reverifyStart = idx
+		}
+	}
+	reverify(lastIdx)
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		if !p.store.Has(BlockKey(urlStr, idx, p.blockSize)) {
+			slog.Error("Block still missing after presence re-fetch; failing closed.", "url", urlStr, "block", idx)
+			http.Error(w, "block cache entry missing after re-fetch", http.StatusBadGateway)
+			return true
+		}
+	}
+
 	blockReadsTotal.WithLabelValues("local").Add(float64(nLocal))
 	blockReadsTotal.WithLabelValues("peer").Add(float64(nPeer))
 	blockReadsTotal.WithLabelValues("s3").Add(float64(nOrigin))

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,5 +115,108 @@ func TestFetchOriginSpanSendsBlockAlignedRange(t *testing.T) {
 	}
 	if strings.Contains(gotRange, "1500") {
 		t.Fatal("client range leaked to origin")
+	}
+}
+
+func newBlockProxy(t *testing.T, origin *httptest.Server, blockSize int64) (*CacheProxy, *DiskCache) {
+	t.Helper()
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+	p.blockSize = blockSize
+	p.maxSpanBlocks = 8
+	return p, store
+}
+
+func doBlockRequest(t *testing.T, p *CacheProxy, rawURL, rangeHeader string) *httptest.ResponseRecorder {
+	t.Helper()
+	u, _ := url.Parse(rawURL)
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{rangeHeader}}}
+	req = req.WithContext(context.Background())
+	w := httptest.NewRecorder()
+	if !p.serveBlockAligned(w, req, rangeHeader) {
+		t.Fatalf("serveBlockAligned returned false for %q", rangeHeader)
+	}
+	return w
+}
+
+func TestServeBlockAlignedColdThenWarm(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 10*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	// Cold: range crossing blocks 1-3.
+	w := doBlockRequest(t, p, target, "bytes=1500-3500")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status %d, want 206", w.Code)
+	}
+	body := w.Body.Bytes()
+	if int64(len(body)) != 2001 {
+		t.Fatalf("body length %d, want 2001", len(body))
+	}
+	for i, b := range body {
+		if want := byte((1500 + i) % 251); b != want {
+			t.Fatalf("byte %d: got %d, want %d", i, b, want)
+		}
+	}
+	if got := w.Header().Get("Content-Range"); got != "bytes 1500-3500/2001" {
+		t.Fatalf("Content-Range %q; want legacy served-size shape %q", got, "bytes 1500-3500/2001")
+	}
+
+	// Warm with a DIFFERENT range over the same bytes (the drift scenario):
+	// must be served entirely from stored blocks — origin must not be touched.
+	origin.Close() // any origin fetch now fails the request
+	w2 := doBlockRequest(t, p, target, "bytes=1400-3400")
+	if w2.Code != http.StatusPartialContent || w2.Body.Len() != 2001 {
+		t.Fatalf("drifted warm read failed: status %d len %d", w2.Code, w2.Body.Len())
+	}
+	_ = store
+}
+
+func TestServeBlockAlignedFallsBackOnRangeShape(t *testing.T) {
+	origin := originServer(t, 4096)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, 1024)
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=-500"}}}
+	req = req.WithContext(context.Background())
+	if p.serveBlockAligned(httptest.NewRecorder(), req, "bytes=-500") {
+		t.Fatal("suffix range must return false (legacy fallback)")
+	}
+}
+
+func TestServeBlockAlignedSpansChunkedByMaxSpan(t *testing.T) {
+	const blockSize = 1024
+	var originRanges []string
+	body := make([]byte, 32*blockSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originRanges = append(originRanges, r.Header.Get("Range"))
+		start, end, _ := parseAbsoluteRange(r.Header.Get("Range"))
+		if end >= int64(len(body)) {
+			end = int64(len(body)) - 1
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(body)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body[start : end+1])
+	}))
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+	p.maxSpanBlocks = 4
+
+	// 20 cold blocks with maxSpanBlocks=4 → 5 origin fetches, never more than
+	// 4 blocks per request.
+	doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=0-20479")
+	if len(originRanges) != 5 {
+		t.Fatalf("origin fetches: %d, want 5 (got %v)", len(originRanges), originRanges)
 	}
 }

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -340,6 +340,57 @@ func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testi
 	}
 }
 
+func TestHandleProxyRoutesToBlockMode(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	p.blockMode = true
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host} // make shouldCache match the test origin
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=100-2100")
+	w := httptest.NewRecorder()
+	p.HandleProxy(w, req)
+
+	if w.Code != http.StatusPartialContent || w.Body.Len() != 2001 {
+		t.Fatalf("block-mode HandleProxy: status %d len %d", w.Code, w.Body.Len())
+	}
+	// Blocks 0-2 stored under block keys; the legacy exact-range key must NOT exist.
+	if store.Has(CacheKey(u.String(), "bytes=100-2100")) {
+		t.Fatal("legacy key written in block mode")
+	}
+	if !store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block 0 missing after block-mode request")
+	}
+}
+
+func TestHandleProxyBlockModeOffUsesLegacyPath(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	p.blockMode = false
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host}
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=100-2100")
+	p.HandleProxy(httptest.NewRecorder(), req)
+
+	if !store.Has(CacheKey(u.String(), "bytes=100-2100")) {
+		t.Fatal("legacy key missing with block mode off")
+	}
+	if store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block key written with block mode off")
+	}
+}
+
 // TestServeBlockAlignedRejectsDegenerateConfig guards the infinite-loop /
 // divide-by-zero hazard: if blockSize or maxSpanBlocks is left at its zero
 // value (e.g. Task 4's wiring is skipped), serveBlockAligned must fall back

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -29,6 +29,11 @@ func originServer(t *testing.T, objSize int64) *httptest.Server {
 			_, _ = w.Write(body)
 			return
 		}
+		if start >= objSize {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", objSize))
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
 		if end >= objSize {
 			end = objSize - 1 // S3 clamps to object end
 		}
@@ -131,6 +136,64 @@ func TestFetchOriginSpanRejects200(t *testing.T) {
 		if store.Has(BlockKey(u.String(), idx, blockSize)) {
 			t.Fatalf("block %d must not be committed when the origin ignored Range", idx)
 		}
+	}
+}
+
+func TestFetchOriginSpanRejectsMismatchedContentRange(t *testing.T) {
+	const blockSize = 1024
+	body := make([]byte, 2*blockSize)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The proxy asks for blocks 1..2, but a broken intermediary returns a
+		// different 206 range starting at byte zero.
+		w.Header().Set("Content-Range", "bytes 0-2047/4096")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body)
+	}))
+	defer origin.Close()
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{}}
+
+	if err := p.fetchOriginSpan(req, blockSize, 1, 2); err == nil {
+		t.Fatal("expected mismatched Content-Range to be rejected")
+	}
+	for idx := int64(1); idx <= 2; idx++ {
+		if store.Has(BlockKey(u.String(), idx, blockSize)) {
+			t.Fatalf("block %d committed from a mismatched Content-Range", idx)
+		}
+	}
+}
+
+func TestFetchOriginSpanRejectsCleanShortBody(t *testing.T) {
+	const blockSize = 1024
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Range", "bytes 1024-3071/4096")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, blockSize)) // clean EOF one block too soon
+	}))
+	defer origin.Close()
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{}}
+
+	if err := p.fetchOriginSpan(req, blockSize, 1, 2); err == nil {
+		t.Fatal("expected clean short 206 body to be rejected")
+	}
+	if store.Has(BlockKey(u.String(), 2, blockSize)) {
+		t.Fatal("truncated block committed from a short 206 body")
 	}
 }
 
@@ -251,8 +314,8 @@ func TestServeBlockAlignedColdThenWarm(t *testing.T) {
 			t.Fatalf("byte %d: got %d, want %d", i, b, want)
 		}
 	}
-	if got := w.Header().Get("Content-Range"); got != "bytes 1500-3500/2001" {
-		t.Fatalf("Content-Range %q; want legacy served-size shape %q", got, "bytes 1500-3500/2001")
+	if got := w.Header().Get("Content-Range"); got != "bytes 1500-3500/10240" {
+		t.Fatalf("Content-Range %q; want representation size %q", got, "bytes 1500-3500/10240")
 	}
 
 	// Warm with a DIFFERENT range over the same bytes (the drift scenario):
@@ -263,6 +326,54 @@ func TestServeBlockAlignedColdThenWarm(t *testing.T) {
 		t.Fatalf("drifted warm read failed: status %d len %d", w2.Code, w2.Body.Len())
 	}
 	_ = store
+}
+
+func TestServeBlockAlignedClampsColdRangeAtObjectEOF(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(2*blockSize + 100)
+	origin := originServer(t, objSize)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+
+	w := doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=2000-4095")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", w.Code)
+	}
+	if got, want := w.Body.Len(), int(objSize-2000); got != want {
+		t.Fatalf("body length = %d, want %d", got, want)
+	}
+	if got := w.Header().Get("Content-Length"); got != "148" {
+		t.Fatalf("Content-Length = %q, want 148", got)
+	}
+	if got := w.Header().Get("Content-Range"); got != "bytes 2000-2147/2148" {
+		t.Fatalf("Content-Range = %q, want bytes 2000-2147/2148", got)
+	}
+}
+
+func TestServeBlockAlignedReturns416ForKnownPastEOFStart(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(2*blockSize + 100)
+	origin := originServer(t, objSize)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	// Learn and cache the representation size from a valid tail response.
+	first := doBlockRequest(t, p, target, "bytes=2000-2147")
+	if first.Code != http.StatusPartialContent {
+		t.Fatalf("setup status = %d, want 206", first.Code)
+	}
+
+	w := doBlockRequest(t, p, target, "bytes=2200-2500")
+	if w.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want 416", w.Code)
+	}
+	if got := w.Header().Get("Content-Range"); got != "bytes */2148" {
+		t.Fatalf("Content-Range = %q, want bytes */2148", got)
+	}
+	if w.Body.Len() != 0 {
+		t.Fatalf("416 body length = %d, want 0", w.Body.Len())
+	}
 }
 
 // TestServeBlockAlignedFallsBackOnRangeShape covers both non-block-servable
@@ -389,16 +500,12 @@ func TestServeBlockAlignedPeerFillCountsAsHit(t *testing.T) {
 	}
 }
 
-// TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify covers
-// the Phase 1.5 presence-verification backstop: Phase 1's coalesced origin
-// fetch can return success (nil error) while still leaving a trailing block
-// uncommitted — a real object-shorter-than-requested EOF is one legitimate
-// way this happens (see fetchOriginSpan's "clean EOF is not an error"
-// comment). The one direct re-fetch attempt of that residual block is made
-// to fail here too, so the block is still missing afterward; the request
-// must fail closed with a 502 before any header is written, not serve a
-// corrupt short body.
-func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testing.T) {
+// TestServeBlockAlignedDoesNotReverifyPastObjectEOF covers the cold-request
+// case where the requested end lies past the true object size. The validated
+// Content-Range must clamp the response and shrink the block span immediately,
+// rather than treating the nonexistent trailing block as a residual miss and
+// issuing a phase 1.5 re-fetch that can never fill it.
+func TestServeBlockAlignedDoesNotReverifyPastObjectEOF(t *testing.T) {
 	const blockSize = 1024
 	const objSize = int64(2*blockSize + 100) // true tail is block 2; block 3 doesn't exist
 	body := make([]byte, objSize)
@@ -422,8 +529,8 @@ func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testi
 			_, _ = w.Write(body[start : end+1])
 			return
 		}
-		// Phase 1.5's direct re-fetch of the residual block: fail outright so
-		// the block is still missing after the one retry attempt.
+		// Any second request indicates that the proxy still believes the
+		// nonexistent block after EOF must be fetched.
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer origin.Close()
@@ -438,23 +545,26 @@ func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testi
 	if !p.serveBlockAligned(w, req, "bytes=0-4095") {
 		t.Fatal("expected serveBlockAligned to handle the request (not fall back)")
 	}
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", w.Code)
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", w.Code)
 	}
-	if got := w.Header().Get("Content-Range"); got != "" {
-		t.Fatalf("Content-Range = %q, want unset: headers must not be committed before the 502", got)
+	if got := w.Header().Get("Content-Range"); got != "bytes 0-2147/2148" {
+		t.Fatalf("Content-Range = %q, want bytes 0-2147/2148", got)
 	}
-	if atomic.LoadInt32(&callCount) != 2 {
-		t.Fatalf("origin calls = %d, want 2 (phase 1 fetch + one phase 1.5 re-fetch attempt)", callCount)
+	if got := w.Body.Len(); got != int(objSize) {
+		t.Fatalf("body length = %d, want %d", got, objSize)
+	}
+	if atomic.LoadInt32(&callCount) != 1 {
+		t.Fatalf("origin calls = %d, want 1 (no impossible past-EOF re-fetch)", callCount)
 	}
 }
 
-// TestServeBlockAlignedAbortsOnDegenerateStart covers the phase-2 copy guard:
-// a request whose start lies past the actual (short) content of a cached
-// tail block must abort the response loop rather than let io.CopyN's
-// negative-length no-op fall through the "n < want" short-body check and
-// keep going as if nothing were wrong.
-func TestServeBlockAlignedAbortsOnDegenerateStart(t *testing.T) {
+// TestServeBlockAlignedReturns416ForColdPastEOFStart covers a past-EOF start
+// before the object size has been learned. The aligned origin fetch starts at
+// the beginning of the tail block, whose validated short Content-Range teaches
+// the proxy the true size. The client still receives a standards-compliant 416
+// instead of a zero-byte 206.
+func TestServeBlockAlignedReturns416ForColdPastEOFStart(t *testing.T) {
 	const blockSize = 1024
 	const objSize = int64(2*blockSize + 100) // tail block 2 has only 100 real bytes
 	origin := originServer(t, objSize)
@@ -474,17 +584,17 @@ func TestServeBlockAlignedAbortsOnDegenerateStart(t *testing.T) {
 	if !p.serveBlockAligned(w, req, "bytes=2200-3000") {
 		t.Fatal("expected serveBlockAligned to handle the request (not fall back)")
 	}
-	if !store.Has(BlockKey(target, 2, blockSize)) {
-		t.Fatal("test setup: tail block 2 should have been cached by phase 1")
+	if w.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want 416", w.Code)
 	}
-	// Headers are already committed by the time phase 2 discovers the
-	// degenerate want (mirrors the entry_vanished abort path), so the status
-	// stays 206; what must not happen is a body claiming bytes it can't send.
-	if w.Code != http.StatusPartialContent {
-		t.Fatalf("status = %d, want 206 (headers already sent before the abort)", w.Code)
+	if got := w.Header().Get("Content-Range"); got != "bytes */2148" {
+		t.Fatalf("Content-Range = %q, want bytes */2148", got)
 	}
 	if got := w.Body.Len(); got != 0 {
-		t.Fatalf("body length = %d, want 0: aborted before any bytes for this degenerate block were written", got)
+		t.Fatalf("body length = %d, want 0", got)
+	}
+	if !store.Has(BlockKey(target, 2, blockSize)) {
+		t.Fatal("validated tail block was not cached while learning object size")
 	}
 }
 
@@ -641,5 +751,97 @@ func TestServeBlockAlignedRejectsDegenerateConfig(t *testing.T) {
 				t.Fatal("expected false (legacy fallback) for degenerate config")
 			}
 		})
+	}
+}
+
+type writeHeaderHookRecorder struct {
+	*httptest.ResponseRecorder
+	hook func()
+}
+
+func (w *writeHeaderHookRecorder) WriteHeader(statusCode int) {
+	if w.hook != nil {
+		hook := w.hook
+		w.hook = nil
+		hook()
+	}
+	w.ResponseRecorder.WriteHeader(statusCode)
+}
+
+func TestServeBlockAlignedPinsBlocksBeforeHeaders(t *testing.T) {
+	const blockSize = int64(1024)
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.maxBytes = 2 * blockSize
+	target := "http://origin.test/bucket/f.parquet"
+
+	for idx := int64(0); idx < 2; idx++ {
+		data := make([]byte, blockSize)
+		for i := range data {
+			data[i] = byte((idx*blockSize + int64(i)) % 251)
+		}
+		if _, err := store.PutStream(BlockKey(target, idx, blockSize), strings.NewReader(string(data))); err != nil {
+			t.Fatalf("seed block %d: %v", idx, err)
+		}
+	}
+
+	p := NewCacheProxy(store, nil, []string{})
+	p.blockSize = blockSize
+	p.maxSpanBlocks = 8
+	u, _ := url.Parse(target)
+	req := (&http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=0-2047"}}}).WithContext(context.Background())
+	w := &writeHeaderHookRecorder{ResponseRecorder: httptest.NewRecorder()}
+	w.hook = func() {
+		// Force eviction precisely after headers are committed. Readers opened
+		// before this point remain valid on Unix even though their paths vanish.
+		if _, err := store.PutStream(strings.Repeat("f", 64), strings.NewReader(string(make([]byte, blockSize)))); err != nil {
+			t.Fatalf("trigger eviction: %v", err)
+		}
+	}
+
+	if !p.serveBlockAligned(w, req, "bytes=0-2047") {
+		t.Fatal("serveBlockAligned unexpectedly fell back")
+	}
+	if w.Code != http.StatusPartialContent || w.Body.Len() != 2*int(blockSize) {
+		t.Fatalf("response status=%d len=%d, want 206 and %d bytes", w.Code, w.Body.Len(), 2*blockSize)
+	}
+	for i, b := range w.Body.Bytes() {
+		if want := byte(int64(i) % 251); b != want {
+			t.Fatalf("byte %d = %d, want %d", i, b, want)
+		}
+	}
+}
+
+func TestHandleProxyOversizedBlockSpanFallsBackToLegacy(t *testing.T) {
+	const blockSize = int64(1024)
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	store.maxBytes = 2 * blockSize
+	p.blockMode = true
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host}
+	target := origin.URL + "/bucket/f.parquet"
+	u, _ := url.Parse(target)
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=0-3071")
+	w := httptest.NewRecorder()
+
+	p.HandleProxy(w, req)
+
+	if w.Code != http.StatusPartialContent || w.Body.Len() != 3*int(blockSize) {
+		t.Fatalf("response status=%d len=%d, want legacy 206 and %d bytes", w.Code, w.Body.Len(), 3*blockSize)
+	}
+	if !store.Has(CacheKey(target, "bytes=0-3071")) {
+		t.Fatal("legacy exact-range entry was not written")
+	}
+	for idx := int64(0); idx < 3; idx++ {
+		if store.Has(BlockKey(target, idx, blockSize)) {
+			t.Fatalf("block %d was written before oversized-span fallback", idx)
+		}
 	}
 }

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -218,5 +219,162 @@ func TestServeBlockAlignedSpansChunkedByMaxSpan(t *testing.T) {
 	doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=0-20479")
 	if len(originRanges) != 5 {
 		t.Fatalf("origin fetches: %d, want 5 (got %v)", len(originRanges), originRanges)
+	}
+}
+
+// TestServeBlockAlignedPeerFillCountsAsHit exercises the previously-untested
+// peer branch of Phase 1: a block resolvable from a peer must never touch
+// origin, must land under blockReadsTotal{peer} / cacheBytesServed{peer}, and
+// (having triggered zero origin fetches) must count as a cache hit, not a
+// miss — the same "hit" meaning the legacy path uses.
+func TestServeBlockAlignedPeerFillCountsAsHit(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	blockData := make([]byte, blockSize)
+	for i := range blockData {
+		blockData[i] = byte(i % 251)
+	}
+	key := BlockKey(target, 0, blockSize)
+	var hasCalls, getCalls int32
+	peerAddr := newPeerServer(t, key, blockData, &hasCalls, &getCalls)
+
+	origin.Close() // the block is fully resolvable from the peer; origin must never be touched
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, peerManagerWith([]string{peerAddr}), []string{})
+	p.blockSize = blockSize
+	p.maxSpanBlocks = 8
+
+	hitsBefore := counterValue(t, cacheHitsTotal)
+	missesBefore := counterValue(t, cacheMissesTotal)
+	peerReadsBefore := counterValue(t, blockReadsTotal.WithLabelValues("peer"))
+	peerBytesBefore := counterValue(t, cacheBytesServed.WithLabelValues("peer"))
+
+	w := doBlockRequest(t, p, target, "bytes=0-99")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status %d, want 206", w.Code)
+	}
+	if got := w.Body.Bytes(); string(got) != string(blockData[:100]) {
+		t.Fatalf("body mismatch: got %d bytes", len(got))
+	}
+	if atomic.LoadInt32(&getCalls) != 1 {
+		t.Fatalf("peer /cache/get calls = %d, want 1", getCalls)
+	}
+
+	if got := counterValue(t, cacheHitsTotal); got != hitsBefore+1 {
+		t.Fatalf("cacheHitsTotal delta = %v, want 1 (peer fill with zero origin fetches must count as a hit)", got-hitsBefore)
+	}
+	if got := counterValue(t, cacheMissesTotal); got != missesBefore {
+		t.Fatalf("cacheMissesTotal delta = %v, want 0", got-missesBefore)
+	}
+	if got := counterValue(t, blockReadsTotal.WithLabelValues("peer")); got != peerReadsBefore+1 {
+		t.Fatalf("blockReadsTotal{peer} delta = %v, want 1", got-peerReadsBefore)
+	}
+	if got := counterValue(t, cacheBytesServed.WithLabelValues("peer")); got != peerBytesBefore+100 {
+		t.Fatalf("cacheBytesServed{peer} delta = %v, want 100 (sourceLabel must resolve to peer when no origin fetch happened)", got-peerBytesBefore)
+	}
+}
+
+// TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify covers
+// the Phase 1.5 presence-verification backstop: Phase 1's coalesced origin
+// fetch can return success (nil error) while still leaving a trailing block
+// uncommitted — a real object-shorter-than-requested EOF is one legitimate
+// way this happens (see fetchOriginSpan's "clean EOF is not an error"
+// comment). The one direct re-fetch attempt of that residual block is made
+// to fail here too, so the block is still missing afterward; the request
+// must fail closed with a 502 before any header is written, not serve a
+// corrupt short body.
+func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(2*blockSize + 100) // true tail is block 2; block 3 doesn't exist
+	body := make([]byte, objSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+
+	var callCount int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&callCount, 1) == 1 {
+			// Phase 1's single coalesced fetch: origin honestly reports its
+			// true (short) length, like S3 clamping a range past EOF.
+			// fetchOriginSpan stores the short tail and returns success —
+			// leaving block 3 uncommitted even though this call "succeeded".
+			start, end, _ := parseAbsoluteRange(r.Header.Get("Range"))
+			if end >= objSize {
+				end = objSize - 1
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, objSize))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(body[start : end+1])
+			return
+		}
+		// Phase 1.5's direct re-fetch of the residual block: fail outright so
+		// the block is still missing after the one retry attempt.
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer origin.Close()
+
+	p, _ := newBlockProxy(t, origin, blockSize)
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=0-4095"}}}
+	req = req.WithContext(context.Background())
+	w := httptest.NewRecorder()
+
+	if !p.serveBlockAligned(w, req, "bytes=0-4095") {
+		t.Fatal("expected serveBlockAligned to handle the request (not fall back)")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if got := w.Header().Get("Content-Range"); got != "" {
+		t.Fatalf("Content-Range = %q, want unset: headers must not be committed before the 502", got)
+	}
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Fatalf("origin calls = %d, want 2 (phase 1 fetch + one phase 1.5 re-fetch attempt)", callCount)
+	}
+}
+
+// TestServeBlockAlignedRejectsDegenerateConfig guards the infinite-loop /
+// divide-by-zero hazard: if blockSize or maxSpanBlocks is left at its zero
+// value (e.g. Task 4's wiring is skipped), serveBlockAligned must fall back
+// to the legacy path rather than hang or panic.
+func TestServeBlockAlignedRejectsDegenerateConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		blockSize     int64
+		maxSpanBlocks int64
+	}{
+		{"zero block size", 0, 8},
+		{"negative block size", -1, 8},
+		{"zero max span blocks", 1024, 0},
+		{"negative max span blocks", 1024, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origin := originServer(t, 4096)
+			defer origin.Close()
+			store, err := NewDiskCache(t.TempDir(), 80)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := NewCacheProxy(store, nil, []string{})
+			p.client = origin.Client()
+			p.blockSize = tt.blockSize
+			p.maxSpanBlocks = tt.maxSpanBlocks
+
+			u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+			req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+				Header: http.Header{"Range": []string{"bytes=0-100"}}}
+			req = req.WithContext(context.Background())
+			if p.serveBlockAligned(httptest.NewRecorder(), req, "bytes=0-100") {
+				t.Fatal("expected false (legacy fallback) for degenerate config")
+			}
+		})
 	}
 }

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -85,6 +86,90 @@ func TestFetchOriginSpan(t *testing.T) {
 	// Block 0 was outside the span and must not exist.
 	if store.Has(BlockKey(u.String(), 0, blockSize)) {
 		t.Fatal("block 0 should not have been fetched")
+	}
+}
+
+// TestFetchOriginSpanRejects200 guards the immutable-block-cache poisoning
+// hazard: fetchOriginSpan always sends a Range header, so an origin that
+// ignores it and returns 200 + the full body would otherwise be split from
+// byte 0 into blocks tagged with the requested (non-zero) indices — every
+// future read of those blocks would silently return the wrong bytes forever,
+// since cached blocks are never revalidated. The fetch must fail instead of
+// committing anything.
+func TestFetchOriginSpanRejects200(t *testing.T) {
+	const blockSize = 1024
+	body := make([]byte, 4*blockSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Ignore the Range header entirely — respond 200 with the full body,
+		// as a Range-blind proxy/CDN or misbehaving origin might.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer origin.Close()
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{}}
+
+	err = p.fetchOriginSpan(req, blockSize, 1, 2)
+	if err == nil {
+		t.Fatal("expected fetchOriginSpan to fail closed on a 200 response to a ranged request")
+	}
+	if !strings.Contains(err.Error(), "200") {
+		t.Fatalf("error %q should mention the unexpected status code", err.Error())
+	}
+	for idx := int64(0); idx <= 3; idx++ {
+		if store.Has(BlockKey(u.String(), idx, blockSize)) {
+			t.Fatalf("block %d must not be committed when the origin ignored Range", idx)
+		}
+	}
+}
+
+// TestServeBlockAlignedFailsClosedOn200Origin exercises the same hazard at
+// the serveBlockAligned level: a cold request against an origin that returns
+// 200 (Range-blind) must fail the whole request with a retryable 502 rather
+// than serve a 206 assembled from misaligned blocks.
+func TestServeBlockAlignedFailsClosedOn200Origin(t *testing.T) {
+	const blockSize = 1024
+	body := make([]byte, 4*blockSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer origin.Close()
+
+	p, store := newBlockProxy(t, origin, blockSize)
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=1500-2500"}}}
+	req = req.WithContext(context.Background())
+	w := httptest.NewRecorder()
+
+	if !p.serveBlockAligned(w, req, "bytes=1500-2500") {
+		t.Fatal("expected serveBlockAligned to handle the request (not fall back)")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	if got := w.Header().Get("Content-Range"); got != "" {
+		t.Fatalf("Content-Range = %q, want unset: headers must not be committed before the 502", got)
+	}
+	for idx := int64(0); idx <= 3; idx++ {
+		if store.Has(BlockKey(u.String(), idx, blockSize)) {
+			t.Fatalf("block %d must not be committed when the origin ignored Range", idx)
+		}
 	}
 }
 
@@ -180,16 +265,40 @@ func TestServeBlockAlignedColdThenWarm(t *testing.T) {
 	_ = store
 }
 
+// TestServeBlockAlignedFallsBackOnRangeShape covers both non-block-servable
+// Range shapes: no Range header at all (reason "no_range") and a shape
+// parseAbsoluteRange rejects, e.g. a suffix range (reason "range_shape").
+// These get distinct fallback reasons so the dashboard can tell "client sent
+// no Range" apart from "client sent a Range shape we don't handle" — a
+// sustained no_range rate would mean something upstream of DuckDB httpfs is
+// stripping Range, which range_shape wouldn't surface.
 func TestServeBlockAlignedFallsBackOnRangeShape(t *testing.T) {
-	origin := originServer(t, 4096)
-	defer origin.Close()
-	p, _ := newBlockProxy(t, origin, 1024)
-	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
-	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
-		Header: http.Header{"Range": []string{"bytes=-500"}}}
-	req = req.WithContext(context.Background())
-	if p.serveBlockAligned(httptest.NewRecorder(), req, "bytes=-500") {
-		t.Fatal("suffix range must return false (legacy fallback)")
+	tests := []struct {
+		name        string
+		rangeHeader string
+		reason      string
+	}{
+		{"no range header", "", "no_range"},
+		{"suffix range", "bytes=-500", "range_shape"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origin := originServer(t, 4096)
+			defer origin.Close()
+			p, _ := newBlockProxy(t, origin, 1024)
+			u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+			req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+				Header: http.Header{"Range": []string{tt.rangeHeader}}}
+			req = req.WithContext(context.Background())
+
+			before := counterValue(t, blockFallbackTotal.WithLabelValues(tt.reason))
+			if p.serveBlockAligned(httptest.NewRecorder(), req, tt.rangeHeader) {
+				t.Fatalf("range %q must return false (legacy fallback)", tt.rangeHeader)
+			}
+			if got := counterValue(t, blockFallbackTotal.WithLabelValues(tt.reason)); got != before+1 {
+				t.Fatalf("blockFallbackTotal{reason=%q} delta = %v, want 1", tt.reason, got-before)
+			}
+		})
 	}
 }
 
@@ -340,6 +449,45 @@ func TestServeBlockAlignedFailsClosedWhenBlockStillMissingAfterReverify(t *testi
 	}
 }
 
+// TestServeBlockAlignedAbortsOnDegenerateStart covers the phase-2 copy guard:
+// a request whose start lies past the actual (short) content of a cached
+// tail block must abort the response loop rather than let io.CopyN's
+// negative-length no-op fall through the "n < want" short-body check and
+// keep going as if nothing were wrong.
+func TestServeBlockAlignedAbortsOnDegenerateStart(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(2*blockSize + 100) // tail block 2 has only 100 real bytes
+	origin := originServer(t, objSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	// Request entirely within block 2, but starting 52 bytes past the tail's
+	// real end (2048+100=2148): start=2200, well inside the object's nominal
+	// [2048, 3072) block range yet past its actual short content.
+	u, _ := url.Parse(target)
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=2200-3000"}}}
+	req = req.WithContext(context.Background())
+	w := httptest.NewRecorder()
+
+	if !p.serveBlockAligned(w, req, "bytes=2200-3000") {
+		t.Fatal("expected serveBlockAligned to handle the request (not fall back)")
+	}
+	if !store.Has(BlockKey(target, 2, blockSize)) {
+		t.Fatal("test setup: tail block 2 should have been cached by phase 1")
+	}
+	// Headers are already committed by the time phase 2 discovers the
+	// degenerate want (mirrors the entry_vanished abort path), so the status
+	// stays 206; what must not happen is a body claiming bytes it can't send.
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206 (headers already sent before the abort)", w.Code)
+	}
+	if got := w.Body.Len(); got != 0 {
+		t.Fatalf("body length = %d, want 0: aborted before any bytes for this degenerate block were written", got)
+	}
+}
+
 func TestHandleProxyRoutesToBlockMode(t *testing.T) {
 	const blockSize = 1024
 	origin := originServer(t, 4*blockSize)
@@ -389,6 +537,72 @@ func TestHandleProxyBlockModeOffUsesLegacyPath(t *testing.T) {
 	if store.Has(BlockKey(u.String(), 0, blockSize)) {
 		t.Fatal("block key written with block mode off")
 	}
+}
+
+// TestServeBlockAlignedConcurrentDriftedRanges is a -race regression test for
+// the single-flight-keyed-by-run-end fix described on flushRun: many
+// goroutines issue overlapping but differently-shaped ("drifted") cold ranges
+// against the same object at once, through one shared DiskCache and one
+// shared CacheProxy. Each response body must be byte-correct for exactly the
+// range that goroutine asked for — a race in the missing-run coalescing or
+// single-flight keying would surface here as wrong bytes, not just a crash.
+func TestServeBlockAlignedConcurrentDriftedRanges(t *testing.T) {
+	const blockSize = 1024
+	const numBlocks = 32
+	const objSize = int64(numBlocks * blockSize)
+	origin := originServer(t, objSize)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	const numGoroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			// Drift the start by a non-block-aligned offset per goroutine so
+			// ranges overlap but don't share block boundaries, and vary the
+			// length so missing runs differ in size across concurrent callers.
+			start := int64(i * 733 % int(objSize-200))
+			length := int64(200 + (i%5)*300)
+			end := start + length - 1
+			if end >= objSize {
+				end = objSize - 1
+			}
+			rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+			u, _ := url.Parse(target)
+			req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+				Header: http.Header{"Range": []string{rangeHeader}}}
+			req = req.WithContext(context.Background())
+			w := httptest.NewRecorder()
+			// t.Errorf (not Fatalf) below: FailNow must only be called from
+			// the goroutine running the test function, not spawned ones.
+			if !p.serveBlockAligned(w, req, rangeHeader) {
+				t.Errorf("goroutine %d: serveBlockAligned returned false (legacy fallback) for %q", i, rangeHeader)
+				return
+			}
+			if w.Code != http.StatusPartialContent {
+				t.Errorf("goroutine %d: status %d, want 206 for range %s", i, w.Code, rangeHeader)
+				return
+			}
+			body := w.Body.Bytes()
+			wantLen := end - start + 1
+			if int64(len(body)) != wantLen {
+				t.Errorf("goroutine %d: body length %d, want %d for range %s", i, len(body), wantLen, rangeHeader)
+				return
+			}
+			for j, b := range body {
+				if want := byte((start + int64(j)) % 251); b != want {
+					t.Errorf("goroutine %d: byte %d (abs %d) = %d, want %d for range %s",
+						i, j, start+int64(j), b, want, rangeHeader)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // TestServeBlockAlignedRejectsDegenerateConfig guards the infinite-loop /

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// originServer serves a synthetic object of objSize bytes where byte i has
+// value byte(i % 251), honoring absolute Range headers like S3.
+func originServer(t *testing.T, objSize int64) *httptest.Server {
+	t.Helper()
+	body := make([]byte, objSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, end, ok := parseAbsoluteRange(r.Header.Get("Range"))
+		if !ok {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+			return
+		}
+		if end >= objSize {
+			end = objSize - 1 // S3 clamps to object end
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, objSize))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body[start : end+1])
+	}))
+}
+
+func TestFetchOriginSpan(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(3*blockSize + 100) // 4 blocks, last one short
+
+	origin := originServer(t, objSize)
+	defer origin.Close()
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{}}
+
+	// Fetch blocks 1..3 in one span (block 3 is the short tail).
+	if err := p.fetchOriginSpan(req, blockSize, 1, 3); err != nil {
+		t.Fatalf("fetchOriginSpan: %v", err)
+	}
+
+	// Every block in the span must now be a complete, correct cache entry.
+	for idx := int64(1); idx <= 3; idx++ {
+		key := BlockKey(u.String(), idx, blockSize)
+		reader, size, ok := store.Open(key)
+		if !ok {
+			t.Fatalf("block %d not committed to store", idx)
+		}
+		data, _ := io.ReadAll(reader)
+		_ = reader.Close()
+		wantSize := int64(blockSize)
+		if idx == 3 {
+			wantSize = 100 // tail block truncated at object end
+		}
+		if size != wantSize || int64(len(data)) != wantSize {
+			t.Fatalf("block %d: size %d, want %d", idx, size, wantSize)
+		}
+		for i, b := range data {
+			if want := byte((idx*blockSize + int64(i)) % 251); b != want {
+				t.Fatalf("block %d byte %d: got %d, want %d", idx, i, b, want)
+			}
+		}
+	}
+
+	// Block 0 was outside the span and must not exist.
+	if store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block 0 should not have been fetched")
+	}
+}
+
+func TestFetchOriginSpanSendsBlockAlignedRange(t *testing.T) {
+	const blockSize = 1024
+	var gotRange string
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRange = r.Header.Get("Range")
+		w.Header().Set("Content-Range", "bytes 1024-3071/4096")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, 2*blockSize))
+	}))
+	defer origin.Close()
+
+	store, _ := NewDiskCache(t.TempDir(), 80)
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{
+		"Range": []string{"bytes=1500-2500"}, // client's original, must be ignored
+	}}
+	if err := p.fetchOriginSpan(req, blockSize, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+	want := "bytes=" + strconv.Itoa(1*blockSize) + "-" + strconv.Itoa(3*blockSize-1)
+	if gotRange != want {
+		t.Fatalf("origin saw Range %q, want block-aligned %q", gotRange, want)
+	}
+	if strings.Contains(gotRange, "1500") {
+		t.Fatal("client range leaked to origin")
+	}
+}

--- a/cmd/cache-proxy/blocks.go
+++ b/cmd/cache-proxy/blocks.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseAbsoluteRange parses a Range header of the exact form "bytes=start-end"
+// (both bounds present, start <= end). Every other shape — suffix ("bytes=-N"),
+// open-ended ("bytes=N-"), multi-range, empty — returns ok=false and the
+// caller falls back to the legacy exact-range cache path. DuckDB httpfs knows
+// file sizes up front (it HEADs first) and only issues absolute ranges, so the
+// fallback is expected to be cold-path only.
+func parseAbsoluteRange(rangeHeader string) (start, end int64, ok bool) {
+	spec, found := strings.CutPrefix(rangeHeader, "bytes=")
+	if !found {
+		return 0, 0, false
+	}
+	lo, hi, found := strings.Cut(spec, "-")
+	if !found || lo == "" || hi == "" || strings.Contains(hi, ",") {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(lo, 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(hi, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// blockSpan returns the inclusive index range of blocks covering [start, end].
+func blockSpan(start, end, blockSize int64) (firstIdx, lastIdx int64) {
+	return start / blockSize, end / blockSize
+}
+
+// BlockKey computes the cache key for one block of an object. blockSize is
+// part of the key so a block-size config change can never serve a
+// wrong-sized entry — old-size entries simply become unreachable and age out.
+func BlockKey(url string, blockIdx, blockSize int64) string {
+	h := sha256.New()
+	_, _ = fmt.Fprintf(h, "%s|blk|%d|%d", url, blockIdx, blockSize)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/cmd/cache-proxy/blocks.go
+++ b/cmd/cache-proxy/blocks.go
@@ -33,6 +33,50 @@ func parseAbsoluteRange(rangeHeader string) (start, end int64, ok bool) {
 	return start, end, true
 }
 
+// parsePartialContentRange parses the response form
+// "bytes start-end/completeLength". Block mode requires a known complete
+// length so it can distinguish a legitimate short tail from a truncated body.
+func parsePartialContentRange(header string) (start, end, completeLength int64, ok bool) {
+	spec, found := strings.CutPrefix(header, "bytes ")
+	if !found {
+		return 0, 0, 0, false
+	}
+	selected, total, found := strings.Cut(spec, "/")
+	if !found || total == "" || total == "*" {
+		return 0, 0, 0, false
+	}
+	lo, hi, found := strings.Cut(selected, "-")
+	if !found || lo == "" || hi == "" {
+		return 0, 0, 0, false
+	}
+	start, err := strconv.ParseInt(lo, 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, 0, false
+	}
+	end, err = strconv.ParseInt(hi, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, 0, false
+	}
+	completeLength, err = strconv.ParseInt(total, 10, 64)
+	if err != nil || completeLength <= end {
+		return 0, 0, 0, false
+	}
+	return start, end, completeLength, true
+}
+
+// parseUnsatisfiedContentRange parses the 416 response form "bytes */N".
+func parseUnsatisfiedContentRange(header string) (completeLength int64, ok bool) {
+	total, found := strings.CutPrefix(header, "bytes */")
+	if !found || total == "" {
+		return 0, false
+	}
+	completeLength, err := strconv.ParseInt(total, 10, 64)
+	if err != nil || completeLength < 0 {
+		return 0, false
+	}
+	return completeLength, true
+}
+
 // blockSpan returns the inclusive index range of blocks covering [start, end].
 func blockSpan(start, end, blockSize int64) (firstIdx, lastIdx int64) {
 	return start / blockSize, end / blockSize

--- a/cmd/cache-proxy/blocks_test.go
+++ b/cmd/cache-proxy/blocks_test.go
@@ -1,0 +1,80 @@
+package main
+
+import "testing"
+
+func TestParseAbsoluteRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		start  int64
+		end    int64
+		ok     bool
+	}{
+		{"absolute", "bytes=100-199", 100, 199, true},
+		{"zero start", "bytes=0-0", 0, 0, true},
+		{"large offsets", "bytes=43730341-82843457", 43730341, 82843457, true},
+		{"suffix form", "bytes=-500", 0, 0, false},
+		{"open ended", "bytes=100-", 0, 0, false},
+		{"multi range", "bytes=0-1,5-9", 0, 0, false},
+		{"empty", "", 0, 0, false},
+		{"garbage", "bytes=a-b", 0, 0, false},
+		{"inverted", "bytes=200-100", 0, 0, false},
+		{"no prefix", "100-199", 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, ok := parseAbsoluteRange(tt.header)
+			if ok != tt.ok || start != tt.start || end != tt.end {
+				t.Fatalf("parseAbsoluteRange(%q) = (%d, %d, %v); want (%d, %d, %v)",
+					tt.header, start, end, ok, tt.start, tt.end, tt.ok)
+			}
+		})
+	}
+}
+
+func TestBlockSpan(t *testing.T) {
+	const bs = 8 << 20 // 8 MiB
+	tests := []struct {
+		name     string
+		start    int64
+		end      int64
+		firstIdx int64
+		lastIdx  int64
+	}{
+		{"within first block", 0, 100, 0, 0},
+		{"exact block", 0, bs - 1, 0, 0},
+		{"crosses boundary", bs - 1, bs, 0, 1},
+		{"multi block", 0, 3*bs - 1, 0, 2},
+		{"interior", 2*bs + 5, 4*bs + 5, 2, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, last := blockSpan(tt.start, tt.end, bs)
+			if first != tt.firstIdx || last != tt.lastIdx {
+				t.Fatalf("blockSpan(%d, %d) = (%d, %d); want (%d, %d)",
+					tt.start, tt.end, first, last, tt.firstIdx, tt.lastIdx)
+			}
+		})
+	}
+}
+
+func TestBlockKey(t *testing.T) {
+	k1 := BlockKey("http://s3/bucket/f.parquet", 0, 8<<20)
+	k2 := BlockKey("http://s3/bucket/f.parquet", 1, 8<<20)
+	k3 := BlockKey("http://s3/bucket/f.parquet", 0, 16<<20)
+	if !IsValidCacheKey(k1) {
+		t.Fatalf("BlockKey output %q is not a valid cache key", k1)
+	}
+	if k1 == k2 {
+		t.Fatal("different block indexes must produce different keys")
+	}
+	if k1 == k3 {
+		t.Fatal("different block sizes must produce different keys")
+	}
+	if k1 != BlockKey("http://s3/bucket/f.parquet", 0, 8<<20) {
+		t.Fatal("BlockKey must be deterministic")
+	}
+	if k1 == CacheKey("http://s3/bucket/f.parquet", "bytes=0-100") {
+		t.Fatal("block keys must not collide with legacy keys")
+	}
+}

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -119,6 +119,14 @@ func main() {
 		"cache_host_suffixes", cacheHostSuffixes,
 	)
 
+	// Block-aligned cache mode: fixed-size, content-addressed blocks instead of
+	// exact-range keys, so repeat reads over drifting ranges of the same object
+	// still hit cache. See README.md "Block-aligned mode".
+	blockMode := os.Getenv("CACHE_BLOCK_MODE") == "on"
+	blockSize := envInt64("CACHE_BLOCK_SIZE_BYTES", 8<<20)
+	maxSpanBlocks := envInt64("CACHE_BLOCK_MAX_SPAN_BLOCKS", 8)
+	slog.Info("Block mode configured.", "enabled", blockMode, "block_size", blockSize, "max_span_blocks", maxSpanBlocks)
+
 	// Initialize cache store
 	store, err := NewDiskCache(cacheDir, maxPercent)
 	if err != nil {
@@ -134,6 +142,9 @@ func main() {
 	}
 
 	proxy := NewCacheProxy(store, peers, cacheHostSuffixes)
+	proxy.blockMode = blockMode
+	proxy.blockSize = blockSize
+	proxy.maxSpanBlocks = maxSpanBlocks
 
 	// Forward HTTP proxy (DuckDB httpfs traffic). ServeMux can't match absolute
 	// URLs in forward-proxy requests, so use the handler directly.
@@ -192,4 +203,19 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envInt64 parses an integer env var, falling back to def (with a warning)
+// when the variable is unset or fails to parse.
+func envInt64(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		slog.Warn("Invalid integer env var; using default.", "key", key, "value", v, "default", def, "error", err)
+		return def
+	}
+	return n
 }

--- a/cmd/cache-proxy/peers_test.go
+++ b/cmd/cache-proxy/peers_test.go
@@ -145,3 +145,41 @@ func TestFetchFromPeersEmptyPeerList(t *testing.T) {
 		t.Error("expected miss when no peers are known")
 	}
 }
+
+func TestPeerServesBlockKeys(t *testing.T) {
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatalf("NewDiskCache: %v", err)
+	}
+
+	// Create a block key for a parquet block.
+	key := BlockKey("http://s3/bucket/f.parquet", 3, 8<<20)
+	blockContent := "block-content"
+
+	// Store the block.
+	if _, err := store.PutStream(key, strings.NewReader(blockContent)); err != nil {
+		t.Fatalf("PutStream: %v", err)
+	}
+
+	// Create a proxy with the store and no peer manager.
+	p := NewCacheProxy(store, nil, []string{})
+
+	// HandlePeerHas must recognize the block key and return 200.
+	hasReq := httptest.NewRequest(http.MethodGet, "/peer/has?key="+key, nil)
+	hasW := httptest.NewRecorder()
+	p.HandlePeerHas(hasW, hasReq)
+	if hasW.Code != http.StatusOK {
+		t.Fatalf("HandlePeerHas(%s) = %d, want 200", key, hasW.Code)
+	}
+
+	// HandlePeerGet must stream the content and return 200.
+	getReq := httptest.NewRequest(http.MethodGet, "/peer/get?key="+key, nil)
+	getW := httptest.NewRecorder()
+	p.HandlePeerGet(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("HandlePeerGet: %d, want 200", getW.Code)
+	}
+	if getW.Body.String() != blockContent {
+		t.Fatalf("HandlePeerGet body = %q, want %q", getW.Body.String(), blockContent)
+	}
+}

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -54,6 +54,14 @@ type CacheProxy struct {
 	// traffic worth caching. Requests whose Host doesn't contain any of these
 	// are passed through without caching.
 	cacheHostSuffixes []string
+
+	// blockMode, blockSize, and maxSpanBlocks configure the block-aligned
+	// serve path (serveBlockAligned): whether it's active, the fixed block
+	// size in bytes, and the max number of blocks coalesced into one origin
+	// fetch. Wired to HandleProxy in a later task.
+	blockMode     bool
+	blockSize     int64
+	maxSpanBlocks int64
 }
 
 // fetchResult describes a body that fetchDedup has materialized onto local

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -62,6 +62,12 @@ type CacheProxy struct {
 	blockMode     bool
 	blockSize     int64
 	maxSpanBlocks int64
+
+	// objectSizes remembers validated complete lengths learned from origin
+	// Content-Range responses. Disk blocks remain the durable cache; this map
+	// lets subsequent requests in the same process emit precise range headers
+	// and reject starts beyond EOF without another origin request.
+	objectSizes sync.Map // map[string]int64, keyed by full object URL
 }
 
 // fetchResult describes a body that fetchDedup has materialized onto local

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -290,6 +290,11 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rangeHeader := r.Header.Get("Range")
+
+	if p.blockMode && p.serveBlockAligned(w, r, rangeHeader) {
+		return
+	}
+	// Legacy exact-range path (also the fallback for non-absolute ranges).
 	cacheKey := CacheKey(r.URL.String(), rangeHeader)
 
 	// Root span for this cacheable GET. DuckDB httpfs sends no traceparent, so

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -615,6 +615,13 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 			warn("Invalid DUCKGRES_MEMORY_REBALANCE: " + err.Error())
 		}
 	}
+	if v := getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DisableParquetPrefetching = b
+		} else {
+			warn("Invalid DUCKGRES_DISABLE_PARQUET_PREFETCHING: " + err.Error())
+		}
+	}
 	if v := getenv("DUCKGRES_PROCESS_MIN_WORKERS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			processMinWorkers = n

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -239,7 +239,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	// (here: configresolve's DisableParquetPrefetching, applied in
 	// applyParquetPrefetchPolicy) must be mirrored through explicitly or
 	// setting it on the CP deployment silently does nothing on workers.
-	if os.Getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING") == "true" {
+	if disabled, err := strconv.ParseBool(os.Getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING")); err == nil && disabled {
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  "DUCKGRES_DISABLE_PARQUET_PREFETCHING",
 			Value: "true",

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -234,6 +234,18 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 		}
 	}
 
+	// Worker pods get an explicitly-constructed env list (this function), not
+	// a copy of the CP's own env, so any flag the worker reads at startup
+	// (here: configresolve's DisableParquetPrefetching, applied in
+	// applyParquetPrefetchPolicy) must be mirrored through explicitly or
+	// setting it on the CP deployment silently does nothing on workers.
+	if os.Getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING") == "true" {
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "DUCKGRES_DISABLE_PARQUET_PREFETCHING",
+			Value: "true",
+		})
+	}
+
 	// Add toleration if configured.
 	tolKey, tolValue := p.workerTolerationKey, p.workerTolerationValue
 	if tolKey != "" {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -2809,6 +2809,63 @@ func TestK8sPool_SpawnWorkerCreatesCorrectPod(t *testing.T) {
 	}
 }
 
+func TestK8sPool_SpawnWorkerPropagatesDisableParquetPrefetching(t *testing.T) {
+	const key = "DUCKGRES_DISABLE_PARQUET_PREFETCHING"
+	tests := []struct {
+		name        string
+		value       string
+		wantEnabled bool
+	}{
+		{name: "canonical true", value: "true", wantEnabled: true},
+		{name: "uppercase true", value: "TRUE", wantEnabled: true},
+		{name: "numeric true", value: "1", wantEnabled: true},
+		{name: "false", value: "false", wantEnabled: false},
+		{name: "invalid", value: "banana", wantEnabled: false},
+		{name: "unset equivalent", value: "", wantEnabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(key, tt.value)
+			pool, cs := newTestK8sPool(t, 5)
+			var created *corev1.Pod
+			cs.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction, ok := action.(k8stesting.CreateAction)
+				if !ok {
+					return false, nil, nil
+				}
+				pod, ok := createAction.GetObject().(*corev1.Pod)
+				if !ok || pod.Labels["app"] != "duckgres-worker" {
+					return false, nil, nil
+				}
+				created = pod.DeepCopy()
+				return true, nil, k8serrors.NewForbidden(
+					schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stop after capture"),
+				)
+			})
+
+			if err := pool.spawnWorker(context.Background(), 91, "duckgres:test", WorkerProfile{}, false); err == nil {
+				t.Fatal("spawnWorker unexpectedly succeeded")
+			}
+			if created == nil {
+				t.Fatal("worker Pod was not submitted")
+			}
+
+			env, present := envByName(created.Spec.Containers[0].Env)[key]
+			if tt.wantEnabled {
+				if !present {
+					t.Fatalf("%s=%q was not propagated", key, tt.value)
+				}
+				if env.Value != "true" || env.ValueFrom != nil {
+					t.Fatalf("spawned worker %s=%q ValueFrom=%v, want literal true", key, env.Value, env.ValueFrom)
+				}
+			} else if present {
+				t.Fatalf("spawned worker unexpectedly has %s=%q for parent value %q", key, env.Value, tt.value)
+			}
+		})
+	}
+}
+
 func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	t.Helper()
 

--- a/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
+++ b/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
@@ -1,0 +1,1043 @@
+# Block-Aligned Cache Proxy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-key the node-local NVMe cache on fixed-size blocks per S3 object (instead of exact request ranges) so cache hits are independent of DuckDB's read-boundary drift, then disable parquet prefetching on workers to eliminate cold-scan read amplification without losing warm performance.
+
+**Architecture:** The cache proxy (`cmd/cache-proxy/`, a per-node DaemonSet) currently keys entries by `sha256(url|Range)`. DuckDB's lazy (non-prefetch) reads produce differently-aligned ranges on every execution, so identical repeat workloads miss 100% of the time (measured: 0 of 7,370 repeat ranges matched) and re-fetch from S3. This plan decomposes every absolute-range GET into fixed 8 MiB blocks keyed `sha256(url|blk|idx|blockSize)`, serves any sub-range from stored blocks (local → peer → one coalesced origin fetch for missing runs), and keeps the legacy exact-range path as fallback for non-standard range shapes. Once block mode is validated, a worker-side env flag sets `disable_parquet_prefetching=true`, which is a measured 2.6–3.5× cold-scan speedup (57.8s vs 179.9s narrow; 141.7s vs 363.2s wide; 34× fewer bytes) that is only safe to ship once the cache serves drifted ranges.
+
+**Tech Stack:** Go (stdlib `net/http`, `httptest`), Prometheus client, existing `DiskCache`/`PeerManager`/`singleFlight` machinery.
+
+## Global Constraints
+
+- **Range rewriting is legal:** DuckDB httpfs SigV4 signs only `host;x-amz-content-sha256;x-amz-date` (`duckdb-httpfs/src/s3fs.cpp:84`, documented in `proxy.go` `forwardUncached` comment). The `Range` header is NOT signed; the proxy may fetch different ranges than the client requested. Task 2 adds a runtime guard anyway.
+- **Feature-flagged, default off:** block mode ships behind `CACHE_BLOCK_MODE=on` (default `off`). The legacy exact-range path is preserved untouched and remains the fallback for non-`bytes=start-end` ranges even when block mode is on.
+- **Peer HTTP API unchanged:** `HandlePeerHas`/`HandlePeerGet` take opaque 64-hex keys; block keys are the same shape and pass `IsValidCacheKey` unchanged. Old-format and block-format entries coexist (different keys, no collision); old entries age out naturally (cache is at ~7% fill, zero evictions).
+- **Response-shape compatibility:** mirror the legacy `serveStream` behavior exactly — `206 Partial Content` with `Content-Range: bytes <start>-<end>/<served-size>` when the client sent a Range header. Do not "fix" the Content-Range total to the object size; DuckDB tolerates the current shape and changing two variables at once masks regressions.
+- **DuckLake parquet files are immutable** — no etag validation, no TTL, no content invalidation (matches existing design).
+- Go style: table tests, `slog` structured logging, `promauto` metrics, conventional commits.
+
+## Out of Scope (follow-up plans)
+
+- Write-through cache warming from the sink's upload path.
+- Worker→node soft affinity per org.
+- Per-org cache accounting/quotas.
+- Upstream DuckDB fix (coalesce prefetch only within projected columns) — file the issue, but don't block on it.
+
+## File Structure
+
+- Create: `cmd/cache-proxy/blocks.go` — pure functions: range parsing, block-span math, `BlockKey`.
+- Create: `cmd/cache-proxy/blocks_test.go`
+- Create: `cmd/cache-proxy/block_serve.go` — `serveBlockAligned` (assembly: local → peer → origin), `fetchOriginSpan` (one coalesced origin GET split into per-block cache entries).
+- Create: `cmd/cache-proxy/block_serve_test.go`
+- Modify: `cmd/cache-proxy/proxy.go` — branch in `HandleProxy` (~line 284), new metrics.
+- Modify: `cmd/cache-proxy/main.go` — env config plumbing.
+- Modify: `tests/mw-dev/manifests.tmpl.yaml` — mw-dev env vars for rollout.
+- Modify: `server/server.go` — `applyParquetPrefetchPolicy` next to `applyHTTPFSRetryBudget` (line 1071).
+- Modify: `cmd/cache-proxy/README.md` — document block mode.
+
+---
+
+### Task 1: Block math and keys (`blocks.go`)
+
+**Files:**
+- Create: `cmd/cache-proxy/blocks.go`
+- Test: `cmd/cache-proxy/blocks_test.go`
+
+**Interfaces:**
+- Produces: `parseAbsoluteRange(rangeHeader string) (start, end int64, ok bool)`; `blockSpan(start, end, blockSize int64) (firstIdx, lastIdx int64)`; `BlockKey(url string, blockIdx, blockSize int64) string` (64-hex, passes `IsValidCacheKey`). Task 3 consumes all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package main
+
+import "testing"
+
+func TestParseAbsoluteRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		start  int64
+		end    int64
+		ok     bool
+	}{
+		{"absolute", "bytes=100-199", 100, 199, true},
+		{"zero start", "bytes=0-0", 0, 0, true},
+		{"large offsets", "bytes=43730341-82843457", 43730341, 82843457, true},
+		{"suffix form", "bytes=-500", 0, 0, false},
+		{"open ended", "bytes=100-", 0, 0, false},
+		{"multi range", "bytes=0-1,5-9", 0, 0, false},
+		{"empty", "", 0, 0, false},
+		{"garbage", "bytes=a-b", 0, 0, false},
+		{"inverted", "bytes=200-100", 0, 0, false},
+		{"no prefix", "100-199", 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, ok := parseAbsoluteRange(tt.header)
+			if ok != tt.ok || start != tt.start || end != tt.end {
+				t.Fatalf("parseAbsoluteRange(%q) = (%d, %d, %v); want (%d, %d, %v)",
+					tt.header, start, end, ok, tt.start, tt.end, tt.ok)
+			}
+		})
+	}
+}
+
+func TestBlockSpan(t *testing.T) {
+	const bs = 8 << 20 // 8 MiB
+	tests := []struct {
+		name     string
+		start    int64
+		end      int64
+		firstIdx int64
+		lastIdx  int64
+	}{
+		{"within first block", 0, 100, 0, 0},
+		{"exact block", 0, bs - 1, 0, 0},
+		{"crosses boundary", bs - 1, bs, 0, 1},
+		{"multi block", 0, 3*bs - 1, 0, 2},
+		{"interior", 2*bs + 5, 4*bs + 5, 2, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, last := blockSpan(tt.start, tt.end, bs)
+			if first != tt.firstIdx || last != tt.lastIdx {
+				t.Fatalf("blockSpan(%d, %d) = (%d, %d); want (%d, %d)",
+					tt.start, tt.end, first, last, tt.firstIdx, tt.lastIdx)
+			}
+		})
+	}
+}
+
+func TestBlockKey(t *testing.T) {
+	k1 := BlockKey("http://s3/bucket/f.parquet", 0, 8<<20)
+	k2 := BlockKey("http://s3/bucket/f.parquet", 1, 8<<20)
+	k3 := BlockKey("http://s3/bucket/f.parquet", 0, 16<<20)
+	if !IsValidCacheKey(k1) {
+		t.Fatalf("BlockKey output %q is not a valid cache key", k1)
+	}
+	if k1 == k2 {
+		t.Fatal("different block indexes must produce different keys")
+	}
+	if k1 == k3 {
+		t.Fatal("different block sizes must produce different keys")
+	}
+	if k1 != BlockKey("http://s3/bucket/f.parquet", 0, 8<<20) {
+		t.Fatal("BlockKey must be deterministic")
+	}
+	if k1 == CacheKey("http://s3/bucket/f.parquet", "bytes=0-100") {
+		t.Fatal("block keys must not collide with legacy keys")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/cache-proxy && go test -run 'TestParseAbsoluteRange|TestBlockSpan|TestBlockKey' -v`
+Expected: FAIL — `undefined: parseAbsoluteRange` etc.
+
+- [ ] **Step 3: Implement `blocks.go`**
+
+```go
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseAbsoluteRange parses a Range header of the exact form "bytes=start-end"
+// (both bounds present, start <= end). Every other shape — suffix ("bytes=-N"),
+// open-ended ("bytes=N-"), multi-range, empty — returns ok=false and the
+// caller falls back to the legacy exact-range cache path. DuckDB httpfs knows
+// file sizes up front (it HEADs first) and only issues absolute ranges, so the
+// fallback is expected to be cold-path only.
+func parseAbsoluteRange(rangeHeader string) (start, end int64, ok bool) {
+	spec, found := strings.CutPrefix(rangeHeader, "bytes=")
+	if !found {
+		return 0, 0, false
+	}
+	lo, hi, found := strings.Cut(spec, "-")
+	if !found || lo == "" || hi == "" || strings.Contains(hi, ",") {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(lo, 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(hi, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// blockSpan returns the inclusive index range of blocks covering [start, end].
+func blockSpan(start, end, blockSize int64) (firstIdx, lastIdx int64) {
+	return start / blockSize, end / blockSize
+}
+
+// BlockKey computes the cache key for one block of an object. blockSize is
+// part of the key so a block-size config change can never serve a
+// wrong-sized entry — old-size entries simply become unreachable and age out.
+func BlockKey(url string, blockIdx, blockSize int64) string {
+	h := sha256.New()
+	_, _ = fmt.Fprintf(h, "%s|blk|%d|%d", url, blockIdx, blockSize)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cmd/cache-proxy && go test -run 'TestParseAbsoluteRange|TestBlockSpan|TestBlockKey' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cache-proxy/blocks.go cmd/cache-proxy/blocks_test.go
+git commit -m "feat(cache-proxy): block-aligned range math and cache keys"
+```
+
+---
+
+### Task 2: Coalesced origin span fetch (`fetchOriginSpan`)
+
+**Files:**
+- Create: `cmd/cache-proxy/block_serve.go`
+- Test: `cmd/cache-proxy/block_serve_test.go`
+
+**Interfaces:**
+- Consumes: `BlockKey` (Task 1); `DiskCache.PutStream(key string, r io.Reader) (int64, error)`, `p.client`, `p.originTimeout`, `hopByHop` (existing).
+- Produces: `(p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastIdx int64) error` — fetches blocks `[firstIdx, lastIdx]` of `r.URL` in ONE origin range GET and commits each block under its `BlockKey`. Task 3 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// originServer serves a synthetic object of objSize bytes where byte i has
+// value byte(i % 251), honoring absolute Range headers like S3.
+func originServer(t *testing.T, objSize int64) *httptest.Server {
+	t.Helper()
+	body := make([]byte, objSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, end, ok := parseAbsoluteRange(r.Header.Get("Range"))
+		if !ok {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+			return
+		}
+		if end >= objSize {
+			end = objSize - 1 // S3 clamps to object end
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, objSize))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body[start : end+1])
+	}))
+}
+
+func TestFetchOriginSpan(t *testing.T) {
+	const blockSize = 1024
+	const objSize = int64(3*blockSize + 100) // 4 blocks, last one short
+
+	origin := originServer(t, objSize)
+	defer origin.Close()
+
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{}}
+
+	// Fetch blocks 1..3 in one span (block 3 is the short tail).
+	if err := p.fetchOriginSpan(req, blockSize, 1, 3); err != nil {
+		t.Fatalf("fetchOriginSpan: %v", err)
+	}
+
+	// Every block in the span must now be a complete, correct cache entry.
+	for idx := int64(1); idx <= 3; idx++ {
+		key := BlockKey(u.String(), idx, blockSize)
+		reader, size, ok := store.Open(key)
+		if !ok {
+			t.Fatalf("block %d not committed to store", idx)
+		}
+		data, _ := io.ReadAll(reader)
+		_ = reader.Close()
+		wantSize := int64(blockSize)
+		if idx == 3 {
+			wantSize = 100 // tail block truncated at object end
+		}
+		if size != wantSize || int64(len(data)) != wantSize {
+			t.Fatalf("block %d: size %d, want %d", idx, size, wantSize)
+		}
+		for i, b := range data {
+			if want := byte((idx*blockSize + int64(i)) % 251); b != want {
+				t.Fatalf("block %d byte %d: got %d, want %d", idx, i, b, want)
+			}
+		}
+	}
+
+	// Block 0 was outside the span and must not exist.
+	if store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block 0 should not have been fetched")
+	}
+}
+
+func TestFetchOriginSpanSendsBlockAlignedRange(t *testing.T) {
+	const blockSize = 1024
+	var gotRange string
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRange = r.Header.Get("Range")
+		w.Header().Set("Content-Range", "bytes 1024-3071/4096")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, 2*blockSize))
+	}))
+	defer origin.Close()
+
+	store, _ := NewDiskCache(t.TempDir(), 80)
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host, Header: http.Header{
+		"Range": []string{"bytes=1500-2500"}, // client's original, must be ignored
+	}}
+	if err := p.fetchOriginSpan(req, blockSize, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+	want := "bytes=" + strconv.Itoa(1*blockSize) + "-" + strconv.Itoa(3*blockSize-1)
+	if gotRange != want {
+		t.Fatalf("origin saw Range %q, want block-aligned %q", gotRange, want)
+	}
+	if strings.Contains(gotRange, "1500") {
+		t.Fatal("client range leaked to origin")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/cache-proxy && go test -run TestFetchOriginSpan -v`
+Expected: FAIL — `undefined: (*CacheProxy).fetchOriginSpan`
+
+- [ ] **Step 3: Implement `fetchOriginSpan` in `block_serve.go`**
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	cacheOriginBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_origin_bytes_total",
+		Help: "Bytes fetched from S3 origin (block mode; the origin-offload SLI numerator)",
+	})
+	blockFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_block_fallback_total",
+		Help: "Requests that fell back to the legacy exact-range path, by reason",
+	}, []string{"reason"}) // range_shape, origin_error, entry_vanished
+	blockReadsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_block_reads_total",
+		Help: "Blocks resolved while assembling responses, by source",
+	}, []string{"source"}) // local, peer, s3
+)
+
+// fetchOriginSpan fetches blocks [firstIdx, lastIdx] of r.URL in ONE origin
+// range GET and commits each block to the store under its BlockKey. Rewriting
+// the Range header is legal: DuckDB httpfs signs only
+// host;x-amz-content-sha256;x-amz-date (see forwardUncached), so Range is not
+// covered by the SigV4 signature. The final block of an object is naturally
+// short — a clean EOF mid-span is success, not an error.
+func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastIdx int64) error {
+	timeout := p.originTimeout
+	if timeout <= 0 {
+		timeout = defaultOriginTimeout
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.URL.String(), nil)
+	if err != nil {
+		return err
+	}
+	for k, vv := range r.Header {
+		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, "Range") {
+			continue
+		}
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	req.Host = r.Host
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", firstIdx*blockSize, (lastIdx+1)*blockSize-1))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, originErrorBodyCap))
+		return &originStatusError{status: resp.StatusCode, headers: resp.Header.Clone(), body: body}
+	}
+
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		size, err := p.store.PutStream(BlockKey(r.URL.String(), idx, blockSize), io.LimitReader(resp.Body, blockSize))
+		if err != nil {
+			return fmt.Errorf("commit block %d: %w", idx, err)
+		}
+		cacheOriginBytesTotal.Add(float64(size))
+		if size < blockSize {
+			// Object ended inside this block — it is the tail. Done.
+			break
+		}
+	}
+	return nil
+}
+```
+
+Note: if `PutStream` rejects zero-byte writes (check its implementation at `cache.go:229` while implementing — if a `size == 0` entry would be committed for an `idx` past the object end, drop it with `store.dropLocked`-style cleanup or skip commit by checking `size == 0` before treating the block as stored; the span math in Task 3 never requests blocks past `end`, so this only matters when the client's `end` exceeds the object size, which S3 clamps).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cmd/cache-proxy && go test -run TestFetchOriginSpan -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cache-proxy/block_serve.go cmd/cache-proxy/block_serve_test.go
+git commit -m "feat(cache-proxy): coalesced block-aligned origin span fetch"
+```
+
+---
+
+### Task 3: Block-aligned serve path (`serveBlockAligned`)
+
+**Files:**
+- Modify: `cmd/cache-proxy/block_serve.go`
+- Test: `cmd/cache-proxy/block_serve_test.go`
+
+**Interfaces:**
+- Consumes: `parseAbsoluteRange`, `blockSpan`, `BlockKey` (Task 1); `fetchOriginSpan` (Task 2); `DiskCache.Open/openFile/Has`, `PeerManager.FetchFromPeers`, `p.flights.Do`, `cacheHitsTotal`, `cacheMissesTotal`, `cacheBytesServed` (existing).
+- Produces: `(p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, rangeHeader string) bool` — returns `false` if the request is not block-servable (caller runs the legacy path). Task 4 consumes it. `p.blockSize int64` and `p.maxSpanBlocks int64` fields on `CacheProxy`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func newBlockProxy(t *testing.T, origin *httptest.Server, blockSize int64) (*CacheProxy, *DiskCache) {
+	t.Helper()
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+	p.client = origin.Client()
+	p.blockSize = blockSize
+	p.maxSpanBlocks = 8
+	return p, store
+}
+
+func doBlockRequest(t *testing.T, p *CacheProxy, rawURL, rangeHeader string) *httptest.ResponseRecorder {
+	t.Helper()
+	u, _ := url.Parse(rawURL)
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{rangeHeader}}}
+	req = req.WithContext(context.Background())
+	w := httptest.NewRecorder()
+	if !p.serveBlockAligned(w, req, rangeHeader) {
+		t.Fatalf("serveBlockAligned returned false for %q", rangeHeader)
+	}
+	return w
+}
+
+func TestServeBlockAlignedColdThenWarm(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 10*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	target := origin.URL + "/bucket/f.parquet"
+
+	// Cold: range crossing blocks 1-3.
+	w := doBlockRequest(t, p, target, "bytes=1500-3500")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status %d, want 206", w.Code)
+	}
+	body := w.Body.Bytes()
+	if int64(len(body)) != 2001 {
+		t.Fatalf("body length %d, want 2001", len(body))
+	}
+	for i, b := range body {
+		if want := byte((1500 + i) % 251); b != want {
+			t.Fatalf("byte %d: got %d, want %d", i, b, want)
+		}
+	}
+	if got := w.Header().Get("Content-Range"); got != "bytes 1500-3500/2001" {
+		t.Fatalf("Content-Range %q; want legacy served-size shape %q", got, "bytes 1500-3500/2001")
+	}
+
+	// Warm with a DIFFERENT range over the same bytes (the drift scenario):
+	// must be served entirely from stored blocks — origin must not be touched.
+	origin.Close() // any origin fetch now fails the request
+	w2 := doBlockRequest(t, p, target, "bytes=1400-3400")
+	if w2.Code != http.StatusPartialContent || w2.Body.Len() != 2001 {
+		t.Fatalf("drifted warm read failed: status %d len %d", w2.Code, w2.Body.Len())
+	}
+	_ = store
+}
+
+func TestServeBlockAlignedFallsBackOnRangeShape(t *testing.T) {
+	origin := originServer(t, 4096)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, 1024)
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := &http.Request{Method: http.MethodGet, URL: u, Host: u.Host,
+		Header: http.Header{"Range": []string{"bytes=-500"}}}
+	req = req.WithContext(context.Background())
+	if p.serveBlockAligned(httptest.NewRecorder(), req, "bytes=-500") {
+		t.Fatal("suffix range must return false (legacy fallback)")
+	}
+}
+
+func TestServeBlockAlignedSpansChunkedByMaxSpan(t *testing.T) {
+	const blockSize = 1024
+	var originRanges []string
+	body := make([]byte, 32*blockSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originRanges = append(originRanges, r.Header.Get("Range"))
+		start, end, _ := parseAbsoluteRange(r.Header.Get("Range"))
+		if end >= int64(len(body)) {
+			end = int64(len(body)) - 1
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(body)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body[start : end+1])
+	}))
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+	p.maxSpanBlocks = 4
+
+	// 20 cold blocks with maxSpanBlocks=4 → 5 origin fetches, never more than
+	// 4 blocks per request.
+	doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=0-20479")
+	if len(originRanges) != 5 {
+		t.Fatalf("origin fetches: %d, want 5 (got %v)", len(originRanges), originRanges)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/cache-proxy && go test -run TestServeBlockAligned -v`
+Expected: FAIL — `undefined: (*CacheProxy).serveBlockAligned`, missing fields.
+
+- [ ] **Step 3: Implement `serveBlockAligned`**
+
+Add fields to `CacheProxy` in `proxy.go` (`blockMode bool`, `blockSize int64`, `maxSpanBlocks int64` — wired in Task 4), then in `block_serve.go`:
+
+```go
+// serveBlockAligned serves a cacheable GET whose Range is an absolute
+// bytes=start-end pair from block-aligned cache entries: local disk, then
+// peers, then coalesced origin fetches for contiguous missing runs (chunked
+// at maxSpanBlocks per origin request). Returns false when the request shape
+// is not block-servable; the caller then runs the legacy exact-range path.
+func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, rangeHeader string) bool {
+	start, end, ok := parseAbsoluteRange(rangeHeader)
+	if !ok {
+		blockFallbackTotal.WithLabelValues("range_shape").Inc()
+		return false
+	}
+	firstIdx, lastIdx := blockSpan(start, end, p.blockSize)
+	urlStr := r.URL.String()
+
+	// Phase 1: ensure every block is present locally. Track sources for the
+	// hit/miss accounting and the log line.
+	var nLocal, nPeer, nOrigin int64
+	var missRunStart int64 = -1
+	flushRun := func(runEnd int64) bool {
+		if missRunStart < 0 {
+			return true
+		}
+		for lo := missRunStart; lo <= runEnd; lo += p.maxSpanBlocks {
+			hi := min(lo+p.maxSpanBlocks-1, runEnd)
+			_, err := p.flights.Do(BlockKey(urlStr, lo, p.blockSize), func() (fetchResult, error) {
+				return fetchResult{}, p.fetchOriginSpan(r, p.blockSize, lo, hi)
+			})
+			if err != nil {
+				var oe *originStatusError
+				if errors.As(err, &oe) {
+					oe.writeTo(w)
+					return false
+				}
+				slog.Error("Block span fetch failed.", "url", urlStr, "blocks", fmt.Sprintf("%d-%d", lo, hi), "error", err)
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return false
+			}
+			nOrigin += hi - lo + 1
+		}
+		missRunStart = -1
+		return true
+	}
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		key := BlockKey(urlStr, idx, p.blockSize)
+		if p.store.Has(key) {
+			if !flushRun(idx - 1) {
+				return true // error already written
+			}
+			nLocal++
+			continue
+		}
+		if p.peers != nil {
+			if _, _, ok := p.peers.FetchFromPeers(key, func(rd io.Reader) (int64, error) {
+				return p.store.PutStream(key, rd)
+			}); ok {
+				if !flushRun(idx - 1) {
+					return true
+				}
+				nPeer++
+				continue
+			}
+		}
+		if missRunStart < 0 {
+			missRunStart = idx
+		}
+	}
+	if !flushRun(lastIdx) {
+		return true
+	}
+	blockReadsTotal.WithLabelValues("local").Add(float64(nLocal))
+	blockReadsTotal.WithLabelValues("peer").Add(float64(nPeer))
+	blockReadsTotal.WithLabelValues("s3").Add(float64(nOrigin))
+
+	// Request-level hit/miss accounting mirrors the legacy meaning: a hit is
+	// "no origin traffic needed".
+	if nOrigin == 0 {
+		cacheHitsTotal.Inc()
+	} else {
+		cacheMissesTotal.Inc()
+	}
+
+	// Phase 2: stream the assembled range. Mirrors serveStream's legacy
+	// response shape: 206 + Content-Range with served size after the slash.
+	total := end - start + 1
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", total))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+	w.WriteHeader(http.StatusPartialContent)
+
+	served := int64(0)
+	for idx := firstIdx; idx <= lastIdx; idx++ {
+		reader, size, ok := p.store.openFile(BlockKey(urlStr, idx, p.blockSize))
+		if !ok {
+			// Evicted in the window between phase 1 and here (or object
+			// shorter than the requested range). Nothing sane to send after
+			// headers are out; abort so httpfs sees a short body and retries.
+			blockFallbackTotal.WithLabelValues("entry_vanished").Inc()
+			slog.Warn("Block vanished during assembly.", "url", urlStr, "block", idx)
+			return true
+		}
+		blockStart := idx * p.blockSize
+		skip := max(0, start-blockStart)
+		want := min(size-skip, end-blockStart+1-skip, total-served)
+		if skip > 0 {
+			_, _ = io.CopyN(io.Discard, reader, skip)
+		}
+		n, _ := io.CopyN(w, reader, want)
+		served += n
+		_ = reader.Close()
+		if n < want {
+			return true
+		}
+	}
+	cacheBytesServed.WithLabelValues(sourceLabel(nPeer, nOrigin)).Add(float64(served))
+	slog.Info("Served.", "source", "blocks", "url", urlStr, "range", rangeHeader,
+		"bytes", served, "blocks_local", nLocal, "blocks_peer", nPeer, "blocks_s3", nOrigin)
+	return true
+}
+
+// sourceLabel picks the legacy bytes_served source label for an assembled
+// response: s3 if any origin fetch happened, else peer if any peer fill, else
+// local — so the existing "Bytes served by source" dashboard keeps meaning
+// "where did the slowest byte come from".
+func sourceLabel(nPeer, nOrigin int64) string {
+	switch {
+	case nOrigin > 0:
+		return "s3"
+	case nPeer > 0:
+		return "peer"
+	default:
+		return "local"
+	}
+}
+```
+
+Add `"errors"` to imports. Note the `fetchResult{}` sentinel through `p.flights.Do`: the single-flight keyed on the run's first block dedups concurrent identical span fetches; duplicate fetches of overlapping spans from different starting blocks are benign (atomic rename, idempotent immutable content).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cmd/cache-proxy && go test -run TestServeBlockAligned -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package suite for regressions**
+
+Run: `cd cmd/cache-proxy && go test ./... -count=1`
+Expected: PASS (legacy path untouched)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cache-proxy/block_serve.go cmd/cache-proxy/block_serve_test.go cmd/cache-proxy/proxy.go
+git commit -m "feat(cache-proxy): block-aligned serve path with peer and coalesced origin fill"
+```
+
+---
+
+### Task 4: Wire block mode into `HandleProxy` + env config
+
+**Files:**
+- Modify: `cmd/cache-proxy/proxy.go` (`HandleProxy`, ~line 284, right after `rangeHeader := r.Header.Get("Range")`)
+- Modify: `cmd/cache-proxy/main.go` (env parsing where `CACHE_MAX_PERCENT` is read)
+- Test: `cmd/cache-proxy/block_serve_test.go`
+
+**Interfaces:**
+- Consumes: `serveBlockAligned` (Task 3).
+- Produces: env contract `CACHE_BLOCK_MODE` (`on`/`off`, default `off`), `CACHE_BLOCK_SIZE_BYTES` (default `8388608`), `CACHE_BLOCK_MAX_SPAN_BLOCKS` (default `8`). Tasks 6/8 (rollout) consume the env contract.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestHandleProxyRoutesToBlockMode(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	p.blockMode = true
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host} // make shouldCache match the test origin
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=100-2100")
+	w := httptest.NewRecorder()
+	p.HandleProxy(w, req)
+
+	if w.Code != http.StatusPartialContent || w.Body.Len() != 2001 {
+		t.Fatalf("block-mode HandleProxy: status %d len %d", w.Code, w.Body.Len())
+	}
+	// Blocks 0-2 stored under block keys; the legacy exact-range key must NOT exist.
+	if store.Has(CacheKey(u.String(), "bytes=100-2100")) {
+		t.Fatal("legacy key written in block mode")
+	}
+	if !store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block 0 missing after block-mode request")
+	}
+}
+
+func TestHandleProxyBlockModeOffUsesLegacyPath(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, store := newBlockProxy(t, origin, blockSize)
+	p.blockMode = false
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host}
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=100-2100")
+	p.HandleProxy(httptest.NewRecorder(), req)
+
+	if !store.Has(CacheKey(u.String(), "bytes=100-2100")) {
+		t.Fatal("legacy key missing with block mode off")
+	}
+	if store.Has(BlockKey(u.String(), 0, blockSize)) {
+		t.Fatal("block key written with block mode off")
+	}
+}
+```
+
+(Adapt the `shouldCache` wiring to how `cacheHostSuffixes` is actually stored on `CacheProxy` — check `NewCacheProxy` at `proxy.go:112` when implementing; if it's a private field of a different name, set it the way `proxy_test.go` already does.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/cache-proxy && go test -run TestHandleProxy -v`
+Expected: new tests FAIL (block mode never routes).
+
+- [ ] **Step 3: Implement the branch and env plumbing**
+
+In `HandleProxy`, immediately after `rangeHeader := r.Header.Get("Range")` and before the legacy `cacheKey := CacheKey(...)` line:
+
+```go
+	if p.blockMode && p.serveBlockAligned(w, r, rangeHeader) {
+		return
+	}
+	// Legacy exact-range path (also the fallback for non-absolute ranges).
+```
+
+In `main.go`, next to the existing env parsing:
+
+```go
+	blockMode := os.Getenv("CACHE_BLOCK_MODE") == "on"
+	blockSize := envInt64("CACHE_BLOCK_SIZE_BYTES", 8<<20)
+	maxSpanBlocks := envInt64("CACHE_BLOCK_MAX_SPAN_BLOCKS", 8)
+```
+
+with an `envInt64(name string, def int64) int64` helper (parse with `strconv.ParseInt`, warn + default on error), assigned onto the `CacheProxy` after `NewCacheProxy`, and logged at startup:
+
+```go
+	slog.Info("Block mode configured.", "enabled", blockMode, "block_size", blockSize, "max_span_blocks", maxSpanBlocks)
+```
+
+- [ ] **Step 4: Run the full package suite**
+
+Run: `cd cmd/cache-proxy && go test ./... -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Update `cmd/cache-proxy/README.md`**
+
+Add a "Block-aligned mode" section: the three env vars, the key format `sha256(url|blk|idx|blockSize)`, the drift problem it solves (identical repeat workloads previously missed 100% — 0/7,370 range keys matched between two runs of the same query), first-touch amplification tradeoff (a 40 KB footer read on an uncached object fetches one full block; bounded by block size, amortized by immutability), and the fallback matrix (suffix/open/multi ranges, non-GET, non-bucket → legacy path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cache-proxy/proxy.go cmd/cache-proxy/main.go cmd/cache-proxy/README.md cmd/cache-proxy/block_serve_test.go
+git commit -m "feat(cache-proxy): CACHE_BLOCK_MODE flag wiring and docs"
+```
+
+---
+
+### Task 5: Peer round-trip for block keys
+
+**Files:**
+- Test: `cmd/cache-proxy/peers_test.go`
+
+**Interfaces:**
+- Consumes: `BlockKey` (Task 1), `HandlePeerHas`/`HandlePeerGet` (`proxy.go:775/789`, unchanged).
+
+- [ ] **Step 1: Write the test** (follow the existing peer test pattern in `peers_test.go` — two proxies with real `DiskCache`s, the second's `PeerManager` pointed at the first's test server):
+
+```go
+func TestPeerServesBlockKeys(t *testing.T) {
+	store, _ := NewDiskCache(t.TempDir(), 80)
+	key := BlockKey("http://s3/bucket/f.parquet", 3, 8<<20)
+	if _, err := store.PutStream(key, strings.NewReader("block-content")); err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(store, nil, []string{})
+
+	// HandlePeerHas must recognize the block key.
+	hasReq := httptest.NewRequest(http.MethodGet, "/peer/has?key="+key, nil)
+	hasW := httptest.NewRecorder()
+	p.HandlePeerHas(hasW, hasReq)
+	if hasW.Code != http.StatusOK {
+		t.Fatalf("HandlePeerHas(%s) = %d, want 200", key, hasW.Code)
+	}
+
+	// HandlePeerGet must stream it.
+	getReq := httptest.NewRequest(http.MethodGet, "/peer/get?key="+key, nil)
+	getW := httptest.NewRecorder()
+	p.HandlePeerGet(getW, getReq)
+	if getW.Code != http.StatusOK || getW.Body.String() != "block-content" {
+		t.Fatalf("HandlePeerGet: %d %q", getW.Code, getW.Body.String())
+	}
+}
+```
+
+(Adjust the paths/params to match how `HandlePeerHas`/`HandlePeerGet` actually read the key — check the handlers at `proxy.go:775/789` and mirror the existing tests.)
+
+- [ ] **Step 2: Run it**
+
+Run: `cd cmd/cache-proxy && go test -run TestPeerServesBlockKeys -v`
+Expected: PASS immediately (block keys are ordinary 64-hex keys). If it fails, the peer API made an assumption about key provenance — fix the handler, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/cache-proxy/peers_test.go
+git commit -m "test(cache-proxy): peer round-trip covers block-format keys"
+```
+
+---
+
+### Task 6: mw-dev rollout + drift validation
+
+**Files:**
+- Modify: `tests/mw-dev/manifests.tmpl.yaml` (cache-proxy DaemonSet env)
+
+- [ ] **Step 1: Add env to the mw-dev cache-proxy DaemonSet spec**
+
+```yaml
+            - name: CACHE_BLOCK_MODE
+              value: "on"
+            - name: CACHE_BLOCK_SIZE_BYTES
+              value: "8388608"
+```
+
+(Match the indentation/structure of the existing env entries in that DaemonSet block.)
+
+- [ ] **Step 2: Deploy to mw-dev and confirm startup**
+
+Deploy the way duckgres normally ships to mw-dev (see repo `CLAUDE.md` / `tests/mw-dev/` docs). Then:
+
+```bash
+kubectl --context mw-dev logs -n duckgres -l app=duckgres-cache-proxy --tail=50 | grep "Block mode configured"
+```
+
+Expected: `enabled=true block_size=8388608`.
+
+- [ ] **Step 3: Run the drift validation — the experiment that motivated this plan**
+
+Against an mw-dev org endpoint with a multi-GB ducklake table (psql, standard worker via `options='-c duckgres.worker_cpu=4'`, keepalives on):
+
+1. Run a narrow aggregation twice in one session, e.g. `SELECT count(*) FROM <schema>.<table> WHERE "timestamp" >= '...' AND "timestamp" < '...';`
+2. Between runs, snapshot `cache_proxy_origin_bytes_total` from the proxy metrics (or sum `source=miss` bytes from proxy logs for the table's URL path).
+
+Pass criteria:
+- Run 2 origin bytes ≈ 0 (< 1% of run 1) — with legacy keying this was 100% re-fetch.
+- Run 2 wall-clock ≤ run 1 warm time under legacy mode (no regression from assembly overhead).
+- Zero `cache_proxy_block_fallback_total{reason="range_shape"}` growth during the runs (DuckDB only sends absolute ranges; growth means the parser is too strict — investigate before prod).
+
+- [ ] **Step 4: Soak with the sink**
+
+Leave block mode on in mw-dev for at least one full data-import cycle; confirm no `block_fallback_total{reason="origin_error"}` growth and no sink pipeline errors (the sink's `read_parquet` verification queries also flow through the proxy).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/mw-dev/manifests.tmpl.yaml
+git commit -m "chore(mw-dev): enable cache-proxy block mode"
+```
+
+---
+
+### Task 7: Worker prefetch policy flag
+
+**Files:**
+- Modify: `server/server.go` (next to `applyHTTPFSRetryBudget`, line 1071, and its call site)
+- Test: wherever `applyHTTPFSRetryBudget` is covered (check `server/server_test.go`; if it has no direct test, assert statement generation only)
+
+**Interfaces:**
+- Consumes: the `applyHTTPFSRetryBudget` pattern — post-attach, `SET GLOBAL`, warn-only on failure.
+- Produces: env contract `DUCKGRES_DISABLE_PARQUET_PREFETCHING` (`true`/unset, default unset=off). Task 8 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestParquetPrefetchPolicyStatements(t *testing.T) {
+	if got := parquetPrefetchPolicyStatements(false); len(got) != 0 {
+		t.Fatalf("disabled policy must produce no statements, got %v", got)
+	}
+	got := parquetPrefetchPolicyStatements(true)
+	want := []string{"SET GLOBAL disable_parquet_prefetching = true"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./server/ -run TestParquetPrefetchPolicy -v`
+Expected: FAIL — undefined function.
+
+- [ ] **Step 3: Implement**
+
+```go
+// parquetPrefetchPolicyStatements returns the SET statements for the
+// deployment's parquet prefetch policy. Prefetch coalesces reads across
+// non-projected columns on remote files — measured at up to ~50x byte
+// amplification on narrow scans of wide tables — so deployments whose
+// cache proxy runs in block-aligned mode (which serves drifted lazy-read
+// ranges from cache) turn it off. SET GLOBAL for the same reason as
+// applyHTTPFSRetryBudget: workers recycle connections between sessions.
+func parquetPrefetchPolicyStatements(disablePrefetch bool) []string {
+	if !disablePrefetch {
+		return nil
+	}
+	return []string{"SET GLOBAL disable_parquet_prefetching = true"}
+}
+```
+
+At `applyHTTPFSRetryBudget`'s call site, apply the statements the same warn-only way, gated on the config value; thread the env through however `applyHTTPFSRetryBudget`'s caller gets its config (follow the existing pattern — likely a field on the server/duckdbservice config populated from `DUCKGRES_DISABLE_PARQUET_PREFETCHING` where other `DUCKGRES_*` envs are read). Grep `DUCKGRES_EXPLORATORY_TIER_ENABLED` for the canonical env-to-config path and mirror it.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./server/ -run TestParquetPrefetchPolicy -v` — PASS.
+Run the package suite: `go test ./server/ -count=1` — PASS.
+
+- [ ] **Step 5: Enable in mw-dev and re-run the Task 6 Step 3 validation**
+
+Set `DUCKGRES_DISABLE_PARQUET_PREFETCHING=true` on the mw-dev worker deployment env (same manifest file as Task 6). Re-run the two-run drift test plus one wide-projection query (`SELECT max(length(<large-text-column>)) FROM ...`). Pass criteria:
+- Cold narrow scan: bytes through proxy within ~2× of the column's actual compressed size (vs ~50× with prefetch on).
+- Warm repeat: served from blocks, origin bytes ≈ 0, wall-clock at or better than prefetch-on warm.
+- Wide query cold and warm: no regression vs prefetch-on block mode (measured baseline expectation: prefetch-off is *faster* cold even for wide reads).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/server.go server/server_test.go tests/mw-dev/manifests.tmpl.yaml
+git commit -m "feat(server): env-gated disable_parquet_prefetching worker policy"
+```
+
+---
+
+### Task 8: Production rollout
+
+**Files:** none in this repo — prod env values live in the charts/cloud-infra deploy repo (same place mw-prod worker/proxy env is set today). This task is the runbook.
+
+- [ ] **Step 1: Enable `CACHE_BLOCK_MODE=on` on the prod cache-proxy DaemonSet (proxy only — prefetch stays on).** Watch for 24h:
+  - `Cache hit ratio` on the duckgres-cache-proxy Grafana dashboard: expect climb from ~60% baseline toward 85%+ as block entries populate (mixed traffic during transition; old exact-range entries still serve legacy-path requests).
+  - `cache_proxy_block_fallback_total` by reason: `range_shape` should be ~0; any sustained growth means real traffic uses range forms the parser rejects — capture samples from proxy logs before proceeding.
+  - No growth in worker-side query failures (`ducklake.system.query_log` exception rates per org).
+  - Revert = flip the env back; legacy keys were never removed.
+- [ ] **Step 2: Enable `DUCKGRES_DISABLE_PARQUET_PREFETCHING=true` on prod workers.** Watch for 48h:
+  - `cache_proxy_origin_bytes_total` rate: expect a large drop (amplified fetches gone) — this is the S3 egress cost lever.
+  - p50/p95 of `duckgres_query_duration_seconds` per org: cold-heavy orgs should improve markedly; no org should regress >10% warm.
+  - `Bytes served by source`: total volume should drop ~an order of magnitude during heavy scans (amplification removed), with the `s3` share shrinking toward first-touch-only.
+  - Revert = flip this env back first (prefetch returns, block mode still on — that combination is strictly safe: deterministic prefetch ranges hit block cache fine).
+- [ ] **Step 3: Success snapshot.** Re-run the original benchmark on a real org table and record in the PR: month-bucket full-table aggregation, fresh standard worker — target cold ≤ ~4 min (from 13.7–65+ min) and warm repeat ≤ legacy warm, with run-2 origin bytes ≈ 0. Update `docs/metrics.md` if it enumerates proxy metrics, adding `cache_proxy_origin_bytes_total`, `cache_proxy_block_reads_total`, `cache_proxy_block_fallback_total`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** drift fix (Tasks 1–5), rollout gating (4, 6, 8), prefetch flip only after block mode validated (7 ordered after 6, prod ordering enforced in 8), origin-offload SLI (`cache_proxy_origin_bytes_total`, Tasks 2/8), legacy compatibility (Global Constraints + Task 4 off-mode test).
+- **Known simplifications, deliberate:** no per-URL object-size cache (S3 clamps over-long spans; short tail handled by `PutStream` size); request-level hit/miss redefined as "no origin traffic" (documented in Task 3 code); suffix/open ranges fall back to legacy rather than being block-served (DuckDB doesn't emit them; counter watches for surprises).
+- **Type consistency check:** `parseAbsoluteRange`/`blockSpan`/`BlockKey` signatures match across Tasks 1→3; `fetchOriginSpan(r, blockSize, firstIdx, lastIdx)` matches 2→3; env names match 4→6→8; `parquetPrefetchPolicyStatements(bool) []string` self-contained in 7.

--- a/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
+++ b/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
@@ -898,8 +898,9 @@ git commit -m "test(cache-proxy): peer round-trip covers block-format keys"
 
 ### Task 6: mw-dev rollout + drift validation
 
-**Files:**
-- Modify: `tests/mw-dev/manifests.tmpl.yaml` (cache-proxy DaemonSet env)
+**Correction (found during execution):** the cache-proxy DaemonSet is NOT defined in this repo — `tests/mw-dev/manifests.tmpl.yaml` only holds the per-PR e2e stack, and the DaemonSet deploys from the charts/cloud-infra repo for mw-dev and prod alike. Step 1's env change happens there; this repo ships only the image (`.github/workflows/container-image-cache-proxy-cd.yml`).
+
+**Files:** none here — Step 1 lands in the charts/cloud-infra repo.
 
 - [ ] **Step 1: Add env to the mw-dev cache-proxy DaemonSet spec**
 

--- a/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
+++ b/docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md
@@ -1035,6 +1035,14 @@ git commit -m "feat(server): env-gated disable_parquet_prefetching worker policy
   - Revert = flip this env back first (prefetch returns, block mode still on — that combination is strictly safe: deterministic prefetch ranges hit block cache fine).
 - [ ] **Step 3: Success snapshot.** Re-run the original benchmark on a real org table and record in the PR: month-bucket full-table aggregation, fresh standard worker — target cold ≤ ~4 min (from 13.7–65+ min) and warm repeat ≤ legacy warm, with run-2 origin bytes ≈ 0. Update `docs/metrics.md` if it enumerates proxy metrics, adding `cache_proxy_origin_bytes_total`, `cache_proxy_block_reads_total`, `cache_proxy_block_fallback_total`.
 
+#### Pre-flag-flip checklist (from final review)
+
+- [ ] `fetchOriginSpan` has no internal retry loop, unlike legacy `fetchOrigin`'s 4-attempt backoff. Accept as-is (httpfs itself retries up to 10x on the client side, and each retry makes progress because blocks already committed by an earlier attempt stay cached) or add retry to `fetchOriginSpan` before flipping the flag.
+- [ ] Origin fetch metrics (the `cache_proxy_origin_fetches_total` family) are not incremented on the block-mode path. Existing dashboard panels built on that metric will go dark as block-mode traffic comes to dominate — wire block-mode origin fetches into the same metric family, or annotate the affected dashboard panels, before flipping the flag.
+- [ ] Per-block sequential peer probing in Phase 1 can stall roughly 1 second per missing block when a peer is unresponsive (no per-peer timeout tuning yet). Consider probing peers per contiguous missing run instead of per block before flipping the flag, to bound worst-case stall time.
+- [ ] The block-aligned path emits no trace spans — the legacy `cache.get` span (and its child spans) simply vanish for block-mode traffic. Anyone correlating a duckgres query trace to proxy behavior loses that path once block mode is on; either add spans to `serveBlockAligned`/`fetchOriginSpan` or document the tracing gap for on-call before flipping the flag.
+- [ ] Reverting `DUCKGRES_DISABLE_PARQUET_PREFETCHING` only takes effect on newly-recycled workers: the setting is applied via `SET GLOBAL`, which persists on already-running workers until they recycle. A rollback of this env var does not immediately restore prefetching fleet-wide — factor that lag into rollback runbooks.
+
 ---
 
 ## Self-Review Notes

--- a/server/server.go
+++ b/server/server.go
@@ -277,6 +277,13 @@ type Config struct {
 
 	// QueryLog configures query-log collection and flushing.
 	QueryLog QueryLogConfig
+
+	// DisableParquetPrefetching turns off DuckDB's parquet prefetch, which
+	// coalesces reads across non-projected columns on remote files. Set for
+	// deployments whose cache proxy runs in block-aligned mode, where
+	// prefetch's coalesced reads cause byte amplification the proxy can't
+	// avoid. See applyParquetPrefetchPolicy / parquetPrefetchPolicyStatements.
+	DisableParquetPrefetching bool
 }
 
 // QueryLogConfig configures the query log feature.
@@ -1080,6 +1087,33 @@ func applyHTTPFSRetryBudget(db *sql.DB) {
 	}
 }
 
+// parquetPrefetchPolicyStatements returns the SET statements for the
+// deployment's parquet prefetch policy. Prefetch coalesces reads across
+// non-projected columns on remote files — measured at up to ~50x byte
+// amplification on narrow scans of wide tables — so deployments whose
+// cache proxy runs in block-aligned mode (which serves drifted lazy-read
+// ranges from cache) turn it off. SET GLOBAL for the same reason as
+// applyHTTPFSRetryBudget: workers recycle connections between sessions.
+func parquetPrefetchPolicyStatements(disablePrefetch bool) []string {
+	if !disablePrefetch {
+		return nil
+	}
+	return []string{"SET GLOBAL disable_parquet_prefetching = true"}
+}
+
+// applyParquetPrefetchPolicy applies the deployment's parquet prefetch
+// policy after the ATTACH calls, same call site as applyHTTPFSRetryBudget
+// and for the same reason: httpfs (and its settable options) only exist
+// once DuckLake's ATTACH has auto-loaded it. Warn-only: a SET failure must
+// not fail the connection.
+func applyParquetPrefetchPolicy(db *sql.DB, disablePrefetch bool) {
+	for _, stmt := range parquetPrefetchPolicyStatements(disablePrefetch) {
+		if _, err := db.Exec(stmt); err != nil {
+			slog.Warn("Failed to set parquet prefetch policy.", "stmt", stmt, "error", err)
+		}
+	}
+}
+
 func seedBundledExtensions(srcRoot, dstRoot string) error {
 	srcRoot = filepath.Clean(srcRoot)
 	dstRoot = filepath.Clean(dstRoot)
@@ -1309,6 +1343,7 @@ func ConfigureDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, us
 	// httpfs (DuckLake auto-loads it on the first S3 touch). See
 	// applyHTTPFSRetryBudget for why this can't run in ConfigureMainDB.
 	applyHTTPFSRetryBudget(db)
+	applyParquetPrefetchPolicy(db, cfg.DisableParquetPrefetching)
 
 	return nil
 }
@@ -1345,6 +1380,7 @@ func ActivateDBConnection(db *sql.DB, cfg Config, duckLakeSem chan struct{}, use
 	// httpfs (DuckLake auto-loads it on the first S3 touch). See
 	// applyHTTPFSRetryBudget for why this can't run in ConfigureMainDB.
 	applyHTTPFSRetryBudget(db)
+	applyParquetPrefetchPolicy(db, cfg.DisableParquetPrefetching)
 
 	return nil
 }
@@ -1392,6 +1428,7 @@ func CreatePassthroughDBConnection(cfg Config, duckLakeSem chan struct{}, userna
 	// httpfs (DuckLake auto-loads it on the first S3 touch). See
 	// applyHTTPFSRetryBudget for why this can't run in ConfigureMainDB.
 	applyHTTPFSRetryBudget(db)
+	applyParquetPrefetchPolicy(db, cfg.DisableParquetPrefetching)
 
 	return db, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -828,3 +828,14 @@ func TestFileDBPoolRefCounting(t *testing.T) {
 		t.Fatal("entry should be removed after last release")
 	}
 }
+
+func TestParquetPrefetchPolicyStatements(t *testing.T) {
+	if got := parquetPrefetchPolicyStatements(false); len(got) != 0 {
+		t.Fatalf("disabled policy must produce no statements, got %v", got)
+	}
+	got := parquetPrefetchPolicyStatements(true)
+	want := []string{"SET GLOBAL disable_parquet_prefetching = true"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

The node-local NVMe cache keys entries by exact `sha256(url|Range)`. DuckDB's lazy (non-prefetch) reads produce differently-aligned byte ranges on every execution, so identical repeat workloads can miss 100% of the time and re-fetch everything from S3 — measured in prod-US: two runs of the same aggregation shared **0 of 7,370** range keys, re-pulling 15.4GB from origin on the "warm" run.

Separately, DuckDB's parquet prefetcher coalesces reads across non-projected columns on remote files: a timestamp-only aggregation over a 25-column events table moved **96GB+ through the proxy for ~1.6GB of needed column data** (~57× amplification). Disabling prefetch is a measured 2.6–3.5× cold-scan win (57.8s vs 179.9s narrow; 141.7s vs 363.2s wide) — but is only safe once the cache can serve drifted ranges.

## Change

Two flag-gated pieces, both **default off**, legacy behavior byte-identical when off:

1. **Block-aligned cache mode** (`CACHE_BLOCK_MODE=on`, `CACHE_BLOCK_SIZE_BYTES` default 8MiB, `CACHE_BLOCK_MAX_SPAN_BLOCKS` default 8): absolute-range GETs are decomposed into fixed blocks keyed `sha256(url|blk|idx|blockSize)`, assembled local → peer → coalesced origin fetch (one rewritten range GET per contiguous missing run — legal since DuckDB's SigV4 signs only `host;x-amz-content-sha256;x-amz-date`). Non-standard range shapes fall back to the untouched legacy path. Fail-closed: a pre-header verification pass turns any missing-block race into a retryable 502, never a short body; non-206 origin responses are rejected rather than cached at wrong offsets.
2. **Worker prefetch policy** (`DUCKGRES_DISABLE_PARQUET_PREFETCHING=true`): warn-only post-attach `SET GLOBAL disable_parquet_prefetching = true`, same pattern and call sites as the httpfs retry budget.

New metrics: `cache_proxy_origin_bytes_total` (origin-offload SLI), `cache_proxy_block_reads_total{source}`, `cache_proxy_block_fallback_total{reason}`.

## Testing

- Unit + integration tests for range parsing, block math/keys, span fetch (incl. Range rewriting and tail truncation), cold/warm assembly, drifted-range warm hits, peer fill accounting, fail-closed 502, degenerate config, flag-off key isolation, 206 enforcement (cache-poisoning guard), and a 32-goroutine drifted-concurrent-reads regression test (`-race` clean).
- `go test ./... -count=1` green; `-race` green except one pre-existing unrelated failure (`TestHandleConnectLogsOpenAndClose`, present on `main`).

## Rollout

Plan + runbook committed at `docs/superpowers/plans/2026-08-06-block-aligned-cache-proxy.md`: enable block mode on the DaemonSet first (env lives in the charts repo — no manifest here), watch hit ratio / fallback reasons, then flip prefetch off on workers. Task 8 carries the pre-flag-flip checklist (origin retry gap, dark origin-fetch metric panels in block mode, per-block peer probe stalls, missing trace spans, SET GLOBAL revert asymmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
