### PR TITLE
ci: pin container images to digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     services:
       # PostgreSQL for comparison tests
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -146,7 +146,7 @@ jobs:
 
       # DuckLake metadata store
       ducklake-metadata:
-        image: public.ecr.aws/docker/library/postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
         env:
           POSTGRES_USER: ducklake
           POSTGRES_PASSWORD: ducklake
@@ -222,7 +222,7 @@ jobs:
 
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -255,7 +255,7 @@ jobs:
 
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## What

Pins the four `services.*.image` references in `ci.yml` to the digest their tag resolves to today.

```
public.ecr.aws/docker/library/postgres:16-alpine
  → …:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
```

The tag stays for readability; the digest is what's enforced.

## Why

Tags are mutable. Whoever controls an image — or whoever compromises their registry credentials — can repoint a tag at a new manifest after review, and every job that pulls it runs the new code against that workflow's secrets and permissions. A digest is content-addressed and can't be repointed.

GitHub's [SHA-pinning policy](https://docs.github.com/en/actions/reference/security/secure-use) covers `uses:` action references only and explicitly excludes registry images, so this isn't enforced by the platform. PostHog/.github#67 adds a Semgrep rule (`github-actions-unpinned-image`) that will flag these org-wide once it lands. This PR is part of clearing the org ahead of that, so nobody gets a surprise red check.

## Behaviour

None. `sha256:57c72fd2…` is the manifest `16-alpine` points to right now, independently confirmed three ways: Docker Hub, the ECR Public mirror (identical digest — manifests are content-addressed across registries), and the pin already in use in `PostHog/revenue-model`.

Renovate/Dependabot both understand `tag@digest` and will keep bumping the pair.
