### PR TITLE
perf(cache-proxy): seek to range start instead of discard-reading block prefix

### DIFF
--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -430,7 +430,14 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	served := int64(0)
 	for i := range opened {
 		if opened[i].skip > 0 {
-			if _, err := io.CopyN(io.Discard, opened[i].reader, opened[i].skip); err != nil {
+			// Block readers are disk files, so jump to the slice instead of
+			// reading and discarding the prefix — the discard costs up to a
+			// full block of disk reads and copies per request.
+			if seeker, ok := opened[i].reader.(io.Seeker); ok {
+				if _, err := seeker.Seek(opened[i].skip, io.SeekStart); err != nil {
+					return true
+				}
+			} else if _, err := io.CopyN(io.Discard, opened[i].reader, opened[i].skip); err != nil {
 				return true
 			}
 		}


### PR DESCRIPTION
## Problem

In block-aligned mode, serving a range that starts mid-block opens the block file and then `io.CopyN(io.Discard, ...)`s its way to the slice start — reading and copying up to a full block of unwanted prefix per request. Requests almost never start on a block boundary, so a lazy scan issuing thousands of small reads pays this on nearly every one. At 8MiB blocks that's ~half a block (~4MiB) of wasted disk/page-cache reads per request, several seconds per scan, sitting on the serving path.

Benchmarks against a production table are consistent with the cost: shrinking blocks 8MiB→1MiB (which shrinks the average discard 8×) moved the fully-warm scan floor from ~6.2s to a stable ~5.3s. Seeking captures that win at any block size.

## Change

Block readers come from `DiskCache.openFile` and are plain `*os.File`s, so seek to the slice start instead of discard-reading the prefix. The discard path stays as a fallback for any non-seekable reader. Response bytes are unchanged.

## Testing

- `go test ./cmd/cache-proxy -count=1` green; `-race` green for the block-aligned/drifted/concurrent tests.
- Existing drifted-range warm-hit tests assert body content for mid-block slices, which is exactly the behavior this touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
