### PR TITLE
feat(cache-proxy): per-request phase timing, in-flight gauge, pprof

### DIFF
--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -27,6 +28,15 @@ var (
 		Name: "cache_proxy_block_reads_total",
 		Help: "Blocks resolved while assembling responses, by source",
 	}, []string{"source"}) // local, peer, s3
+	// requestDurationSeconds is shared between the block-serve path (this
+	// file) and the forward-proxy path (proxy.go); buckets start at 1ms
+	// because a local cache hit can be sub-millisecond and top out around 8s
+	// to cover multi-block cold-origin fetches.
+	requestDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "cache_proxy_request_duration_seconds",
+		Help:    "End-to-end proxy request duration by served path and byte source",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 14),
+	}, []string{"path", "source"})
 )
 
 type exactLengthReader struct {
@@ -174,6 +184,9 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 // at maxSpanBlocks per origin request). Returns false when the request shape
 // is not block-servable; the caller then runs the legacy exact-range path.
 func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, rangeHeader string) bool {
+	requestStart := time.Now()
+	var peerDur, s3Dur, writeDur time.Duration
+
 	// A misconfigured or not-yet-wired proxy (blockSize/maxSpanBlocks left at
 	// their zero value) must fall back rather than divide by zero in
 	// blockSpan or loop forever in flushRun's `lo += p.maxSpanBlocks`.
@@ -223,7 +236,10 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			// covered — silently leaving trailing blocks unfetched.
 			flightKey := fmt.Sprintf("%s|%d", BlockKey(urlStr, lo, p.blockSize), hi)
 			_, err := p.flights.Do(flightKey, func() (fetchResult, error) {
-				return fetchResult{}, p.fetchOriginSpan(r, p.blockSize, lo, hi)
+				fetchStart := time.Now()
+				fetchErr := p.fetchOriginSpan(r, p.blockSize, lo, hi)
+				s3Dur += time.Since(fetchStart)
+				return fetchResult{}, fetchErr
 			})
 			if err != nil {
 				var oe *originStatusError
@@ -272,9 +288,12 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			continue
 		}
 		if p.peers != nil {
-			if _, _, ok := p.peers.FetchFromPeers(key, func(rd io.Reader) (int64, error) {
+			peerStart := time.Now()
+			_, _, ok := p.peers.FetchFromPeers(key, func(rd io.Reader) (int64, error) {
 				return p.store.PutStream(key, rd)
-			}); ok {
+			})
+			peerDur += time.Since(peerStart)
+			if ok {
 				if !flushRun(idx - 1) {
 					return true
 				}
@@ -308,7 +327,10 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		}
 		lo := reverifyStart
 		reverifyStart = -1
-		if err := p.fetchOriginSpan(r, p.blockSize, lo, runEnd); err != nil {
+		fetchStart := time.Now()
+		err := p.fetchOriginSpan(r, p.blockSize, lo, runEnd)
+		s3Dur += time.Since(fetchStart)
+		if err != nil {
 			slog.Warn("Presence re-fetch failed; failing closed below if blocks are still missing.",
 				"url", urlStr, "blocks", fmt.Sprintf("%d-%d", lo, runEnd), "error", err)
 			return
@@ -429,6 +451,7 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 
 	served := int64(0)
 	for i := range opened {
+		writeStart := time.Now()
 		if opened[i].skip > 0 {
 			// Block readers are disk files, so jump to the slice instead of
 			// reading and discarding the prefix — the discard costs up to a
@@ -442,14 +465,20 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			}
 		}
 		n, _ := io.CopyN(w, opened[i].reader, opened[i].want)
+		writeDur += time.Since(writeStart)
 		served += n
 		if n < opened[i].want {
 			return true
 		}
 	}
-	cacheBytesServed.WithLabelValues(sourceLabel(nPeer, nOrigin)).Add(float64(served))
+	source := sourceLabel(nPeer, nOrigin)
+	cacheBytesServed.WithLabelValues(source).Add(float64(served))
+	totalDur := time.Since(requestStart)
+	requestDurationSeconds.WithLabelValues("block", source).Observe(totalDur.Seconds())
 	slog.Info("Served.", "source", "blocks", "url", urlStr, "range", rangeHeader,
-		"bytes", served, "blocks_local", nLocal, "blocks_peer", nPeer, "blocks_s3", nOrigin)
+		"bytes", served, "blocks_local", nLocal, "blocks_peer", nPeer, "blocks_s3", nOrigin,
+		"dur_ms", totalDur.Milliseconds(), "peer_ms", peerDur.Milliseconds(),
+		"s3_ms", s3Dur.Milliseconds(), "write_ms", writeDur.Milliseconds())
 	return true
 }
 

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // originServer serves a synthetic object of objSize bytes where byte i has
@@ -812,6 +814,42 @@ func TestServeBlockAlignedPinsBlocksBeforeHeaders(t *testing.T) {
 		if want := byte(int64(i) % 251); b != want {
 			t.Fatalf("byte %d = %d, want %d", i, b, want)
 		}
+	}
+}
+
+// TestHandleProxyBlockModeRecordsInflightAndDuration guards the two
+// signals the phase-timing instrumentation exists to provide during an
+// investigation: the in-flight gauge must return to its pre-request value
+// once HandleProxy returns (so it reflects live queue depth, not a leak),
+// and a served block-mode request must land exactly one sample in the
+// request-duration histogram under its resolved source label.
+func TestHandleProxyBlockModeRecordsInflightAndDuration(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	p, _ := newBlockProxy(t, origin, blockSize)
+	p.blockMode = true
+	originURL, _ := url.Parse(origin.URL)
+	p.cacheHostSuffixes = []string{originURL.Host}
+
+	inflightBefore := gaugeValue(t, inflightRequests)
+	countBefore := histogramSampleCount(t, requestDurationSeconds.WithLabelValues("block", "s3").(prometheus.Histogram))
+
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+	req.URL = u
+	req.Header.Set("Range", "bytes=100-2100")
+	w := httptest.NewRecorder()
+	p.HandleProxy(w, req)
+
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", w.Code)
+	}
+	if got := gaugeValue(t, inflightRequests); got != inflightBefore {
+		t.Fatalf("inflightRequests after request = %v, want back to pre-request value %v", got, inflightBefore)
+	}
+	if got := histogramSampleCount(t, requestDurationSeconds.WithLabelValues("block", "s3").(prometheus.Histogram)); got != countBefore+1 {
+		t.Fatalf("requestDurationSeconds{block,s3} sample count delta = %v, want 1", got-countBefore)
 	}
 }
 

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -33,6 +33,15 @@ func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
 	return m.GetGauge().GetValue()
 }
 
+func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("read histogram: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
 // errAfterReader yields n bytes then returns a non-EOF error, simulating an
 // origin/peer connection dropping mid-body.
 type errAfterReader struct {

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -163,6 +164,13 @@ func main() {
 		_, _ = fmt.Fprint(w, "OK")
 	})
 	healthMux.Handle("/metrics", promhttp.Handler())
+	// net/http/pprof's init() only registers on http.DefaultServeMux; since
+	// this server uses its own mux, the handlers must be added explicitly.
+	healthMux.HandleFunc("/debug/pprof/", pprof.Index)
+	healthMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	healthMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	healthMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	healthMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	healthServer := &http.Server{Addr: healthAddr, Handler: healthMux}
 
 	// Start servers

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -268,6 +268,9 @@ var hopByHop = map[string]bool{
 // HandleProxy handles forward HTTP proxy requests from DuckDB httpfs.
 // Expects absolute-form URIs (scheme + host + path in the request-line).
 func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
+	inflightRequests.Inc()
+	defer inflightRequests.Dec()
+
 	// HTTPS via CONNECT tunnel — we can't cache encrypted traffic, but we must
 	// still tunnel it so DuckDB can reach external HTTPS sources (e.g.
 	// read_parquet('https://datasets.clickhouse.com/...')) while
@@ -719,6 +722,8 @@ func (p *CacheProxy) serveStream(w http.ResponseWriter, r io.Reader, size int64,
 // S3 rejected it. The fix is to mirror ContentLength + TransferEncoding +
 // Trailer from the inbound request so the proxy is wire-shape-transparent.
 func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
+	forwardRequestsTotal.WithLabelValues(r.Method).Inc()
+	forwardStart := time.Now()
 	ctx, span := proxyTracer.Start(r.Context(), "cache.forward", trace.WithAttributes(requestSpanAttrs(r)...))
 	defer span.End()
 	r = r.WithContext(ctx)
@@ -775,9 +780,11 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(resp.StatusCode)
 		n, _ := io.Copy(w, resp.Body)
 		span.SetAttributes(attribute.Int64("duckgres.bytes", n))
+		dur := time.Since(forwardStart)
+		requestDurationSeconds.WithLabelValues("forward", "origin").Observe(dur.Seconds())
 		slog.Info("Forward-proxy served.",
 			"method", r.Method, "url", r.URL.String(),
-			"status", resp.StatusCode, "bytes", n)
+			"status", resp.StatusCode, "bytes", n, "dur_ms", dur.Milliseconds())
 		return
 	}
 

--- a/cmd/cache-proxy/proxy_metrics.go
+++ b/cmd/cache-proxy/proxy_metrics.go
@@ -18,4 +18,12 @@ var (
 		Name: "cache_proxy_origin_fetches_in_flight",
 		Help: "Current number of origin fetches filling the local cache",
 	})
+	forwardRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_forward_requests_total",
+		Help: "Requests handled by the uncached forward-proxy path, by method",
+	}, []string{"method"})
+	inflightRequests = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_inflight_requests",
+		Help: "Requests currently being handled by HandleProxy",
+	})
 )

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -214,6 +214,16 @@ These worker-local metrics have no tenant labels. Exactly one
 | `duckgres_worker_cache_proxy_reconnect_attempts_total` | None | Health checks made by the recovery supervisor. |
 | `duckgres_worker_cache_proxy_recoveries_total` | None | Successful cache re-enablement events. |
 
+### Cache proxy request-path metrics
+
+These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-proxy`), on its own `HEALTH_ADDR` `/metrics` endpoint — a separate process and port from the control plane's `:9090`. The `duckgres_worker_cache_proxy_*` family above is the worker-side client wrapper's view; these are the proxy's own view of the requests it served.
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `cache_proxy_request_duration_seconds` | Histogram | `path`, `source` | End-to-end duration of a served request. `path` is `block` (block-aligned cache path) or `forward` (uncached forward-proxy path); `source` is `local`, `peer`, or `s3` for `block`, and always `origin` for `forward`. |
+| `cache_proxy_forward_requests_total` | Counter | `method` | Requests handled by the uncached forward-proxy path, by HTTP method. |
+| `cache_proxy_inflight_requests` | Gauge | None | Requests currently being handled by the proxy's request entry point; the queue-depth signal. |
+
 ## PromQL recipes
 
 Admission wait p95 by org and terminal result:


### PR DESCRIPTION
## Problem

Production investigation of slow cold scans found requests spending 100-400ms each inside the cache proxy, served strictly one at a time, with every externally observable component healthy — no errors, no retries, idle CPU, fast peers. The proxy exposes no per-request timing, no queue-depth signal, and no pprof, so the remaining decomposition (origin fetch vs disk vs response write vs queueing) is unmeasurable. Separately, a continuous stream of co-tenant HEAD requests was found traversing the uncached forward path to origin with no metric counting it.

## Change

Instrumentation only — no request-path behavior changes:

- `Served.` log line gains `dur_ms`, `peer_ms`, `s3_ms`, `write_ms` (existing fields unchanged, in order). `Forward-proxy served.` gains `dur_ms`.
- New `cache_proxy_request_duration_seconds` histogram, labels `{path=block|forward, source}`, 1ms–8s exponential buckets.
- New `cache_proxy_inflight_requests` gauge around `HandleProxy` — the queue-depth signal. Note: CONNECT tunnels count for their lifetime.
- New `cache_proxy_forward_requests_total{method}` counter — quantifies the forward-path HEAD stream.
- pprof handlers registered explicitly on the health mux (side-effect import only covers `DefaultServeMux`).
- `docs/metrics.md` documents the new family, distinguishing it from the worker-side `duckgres_worker_cache_proxy_*` view.

Accounting nuance: origin-fetch time under singleflight is attributed to the winning request; followers' waits appear in `dur_ms` but not `s3_ms`.

## Testing

- `go test ./cmd/cache-proxy -count=1` green; `-race` green except the pre-existing `TestHandleConnectLogsOpenAndClose` race (fails identically on the base branch).
- New test asserts the in-flight gauge returns to its pre-request value after a served request and the duration histogram records exactly one sample, using the repo's existing `dto.Metric` helper convention.

## Notes

Stacked on #1042 (seek fix) — both touch the serve loop. Merge that first; this PR's base is set accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
