### PR TITLE
Add local Trino DuckLake smoke benchmark

### DIFF
--- a/justfile
+++ b/justfile
@@ -353,6 +353,12 @@ test-perf:
 test-ducklake:
     ./scripts/test_ducklake.sh
 
+# Verify read-only Trino access to the Duckgres-created local DuckLake fixture.
+# Set TRINO_DUCKLAKE_SMOKE_ARTIFACT_DIR to override the version-report location.
+[group('test')]
+trino-ducklake-smoke:
+    TZ=UTC TRINO_DUCKLAKE_SMOKE_ARTIFACT_DIR=artifacts/trino-ducklake-smoke go test -v -count=1 -timeout 10m ./tests/trino-ducklake-smoke
+
 # Run DuckLake concurrency benchmarks (current version)
 [group('test')]
 test-ducklake-concurrency:
@@ -397,6 +403,18 @@ test-metrics:
 [group('test')]
 perf-smoke:
     ./scripts/perf_smoke.sh
+
+# Compare local Duckgres PGWire and Trino against the same synthetic DuckLake data.
+# Override TRINO_DUCKLAKE_PERF_ROWS (default 1000000) to change the fixture size.
+[group('test')]
+perf-trino-ducklake:
+    TZ=UTC TRINO_DUCKLAKE_PERF=1 TRINO_DUCKLAKE_PERF_ARTIFACT_DIR=artifacts/trino-ducklake-perf go test -v -count=1 -timeout 30m -run TestTrinoDuckLakePerf ./tests/trino-ducklake-smoke
+
+# Compare local Duckgres and Trino with wide, PostHog-shaped synthetic DuckLake events.
+# Set TRINO_DUCKLAKE_REALISTIC_PERF_PROFILE=realistic-local for 1m events.
+[group('test')]
+perf-trino-ducklake-realistic:
+    TZ=UTC TRINO_DUCKLAKE_REALISTIC_PERF=1 TRINO_DUCKLAKE_PERF_ARTIFACT_DIR=artifacts/trino-ducklake-perf go test -v -count=1 -timeout 30m -run TestTrinoDuckLakeRealisticPerf ./tests/trino-ducklake-smoke
 
 # Full perf nightly suite
 [group('test')]

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -70,6 +70,57 @@ services:
       /bin/sh -c "
       mc alias set minio http://minio:9000 minioadmin minioadmin;
       mc mb minio/ducklake --ignore-existing;
-      mc anonymous set download minio/ducklake;
+      mc admin policy create minio trino-ducklake-read /policies/trino-ducklake-read.json || true;
+      mc admin user add minio trino-reader trino-reader || true;
+      mc admin policy attach minio trino-ducklake-read --user trino-reader;
       echo 'Bucket ducklake created successfully';
       "
+    volumes:
+      - ./trino/trino-ducklake-read-policy.json:/policies/trino-ducklake-read.json:ro
+
+  # Re-run after the DuckDB fixture creates metadata tables so the Trino
+  # connector has read-only access to every DuckLake metadata relation.
+  trino-metadata-reader-init:
+    image: postgres:16-alpine
+    depends_on:
+      ducklake-metadata:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ducklake
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        psql -h ducklake-metadata -U ducklake -d ducklake -v ON_ERROR_STOP=1 \
+          -c "CREATE ROLE trino_reader LOGIN PASSWORD 'trino-reader'" 2>/dev/null || true
+        psql -h ducklake-metadata -U ducklake -d ducklake -v ON_ERROR_STOP=1 \
+          -c "GRANT CONNECT ON DATABASE ducklake TO trino_reader" \
+          -c "GRANT USAGE ON SCHEMA public TO trino_reader" \
+          -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO trino_reader" \
+          -c "ALTER DEFAULT PRIVILEGES FOR ROLE ducklake IN SCHEMA public GRANT SELECT ON TABLES TO trino_reader"
+    restart: "no"
+
+  # Single-node, read-only Trino verification of the DuckDB-created DuckLake.
+  # The test starts this service only after the Duckgres fixture has seeded it.
+  trino:
+    build:
+      context: .
+      dockerfile: trino/Dockerfile
+    container_name: duckgres-test-trino-ducklake
+    depends_on:
+      trino-metadata-reader-init:
+        condition: service_completed_successfully
+    environment:
+      TRINO_DUCKLAKE_DB_PASSWORD: trino-reader
+      TRINO_DUCKLAKE_S3_ACCESS_KEY: trino-reader
+      TRINO_DUCKLAKE_S3_SECRET_KEY: trino-reader
+    ports:
+      - "38080:8080"
+    volumes:
+      - ./trino/ducklake.properties:/etc/trino/catalog/ducklake.properties:ro
+    healthcheck:
+      test: ["CMD", "/usr/lib/trino/bin/health-check"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s

--- a/tests/integration/trino/Dockerfile
+++ b/tests/integration/trino/Dockerfile
@@ -1,0 +1,21 @@
+FROM busybox:1.37.0@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0 AS gzip
+
+FROM trinodb/trino:483@sha256:db58cc93e593a2706553745f276bb119c9810e69918be56ecde088ba7ccb0534
+
+USER root
+
+COPY --from=gzip /bin/busybox /usr/local/bin/busybox
+
+ARG BRIKK_CONNECTOR_VERSION=483-0.2.0
+ARG BRIKK_CONNECTOR_SHA256=b8967c47b940c82d357c657c743b703aec7d9523a3ed2213b356ab7424729450
+
+RUN curl --fail --location --silent --show-error \
+      "https://github.com/brikk/trino-ducklake/releases/download/v${BRIKK_CONNECTOR_VERSION}/trino-ducklake-${BRIKK_CONNECTOR_VERSION}.tar.gz" \
+      --output /tmp/trino-ducklake.tar.gz \
+    && echo "${BRIKK_CONNECTOR_SHA256}  /tmp/trino-ducklake.tar.gz" | sha256sum --check --status \
+    && mkdir -p /usr/lib/trino/plugin/ducklake \
+    && /usr/local/bin/busybox gunzip --stdout /tmp/trino-ducklake.tar.gz | tar --extract --file - --strip-components=1 --directory /usr/lib/trino/plugin/ducklake \
+    && rm /tmp/trino-ducklake.tar.gz \
+    && chown -R trino:trino /usr/lib/trino/plugin/ducklake
+
+USER trino

--- a/tests/integration/trino/ducklake.properties
+++ b/tests/integration/trino/ducklake.properties
@@ -1,0 +1,18 @@
+connector.name=ducklake
+
+# The fixture’s Duckgres instance creates and seeds this catalog before Trino
+# starts. Its current DuckLake extension stores metadata in PostgreSQL's public
+# schema; these dedicated credentials have SELECT-only access to that schema.
+ducklake.catalog.database-url=jdbc:postgresql://ducklake-metadata:5432/ducklake
+ducklake.catalog.database-user=trino_reader
+ducklake.catalog.database-password=${ENV:TRINO_DUCKLAKE_DB_PASSWORD}
+ducklake.data-path=s3://ducklake/data/
+
+# Brikk’s connector uses Trino's native S3 filesystem. The MinIO policy grants
+# only ListBucket for data/ and GetObject for data/*; no writes are permitted.
+fs.native-s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=us-east-1
+s3.aws-access-key=${ENV:TRINO_DUCKLAKE_S3_ACCESS_KEY}
+s3.aws-secret-key=${ENV:TRINO_DUCKLAKE_S3_SECRET_KEY}
+s3.path-style-access=true

--- a/tests/integration/trino/trino-ducklake-read-policy.json
+++ b/tests/integration/trino/trino-ducklake-read-policy.json
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::ducklake"],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["data/*"]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::ducklake/data/*"]
+    }
+  ]
+}

--- a/tests/trino-ducklake-smoke/README.md
+++ b/tests/trino-ducklake-smoke/README.md
@@ -1,0 +1,58 @@
+# Trino DuckLake Smoke Test
+
+`just trino-ducklake-smoke` creates the existing local DuckLake fixture through
+Duckgres, then starts one pinned Trino coordinator with the pinned Brikk
+DuckLake connector. It verifies that read-only Trino credentials can discover
+and query the same PostgreSQL metadata catalog and MinIO data path.
+
+The test is intentionally separate from the normal integration suite because
+it downloads and starts Trino. It uses only local Docker services and test
+credentials; it does not contact managed-warehouse infrastructure.
+
+The `just` recipe writes the version artifact to
+`artifacts/trino-ducklake-smoke/`. Set `TRINO_DUCKLAKE_SMOKE_ARTIFACT_DIR` to
+override it, for example:
+
+```bash
+TRINO_DUCKLAKE_SMOKE_ARTIFACT_DIR=artifacts/my-trino-ducklake-smoke \
+  just trino-ducklake-smoke
+```
+
+## Local DuckLake performance comparison
+
+Run the opt-in local comparison between Duckgres PGWire and Trino HTTP against
+the same synthetic DuckLake events table:
+
+```bash
+just perf-trino-ducklake
+```
+
+It seeds 1,000,000 deterministic events by default, warms each engine once,
+checks that result fingerprints match, then records three measured executions
+per query. Set `TRINO_DUCKLAKE_PERF_ROWS` to a value from 1 through 5,000,000
+to change the dataset size. Artifacts are written to
+`artifacts/trino-ducklake-perf/` unless `TRINO_DUCKLAKE_PERF_ARTIFACT_DIR` is
+set.
+
+This is a local end-to-end comparison, including PGWire or HTTP client overhead
+and local Postgres/MinIO access. It is not a production capacity benchmark.
+
+For wide, PostHog-shaped synthetic events, use the explicit realistic profile:
+
+```bash
+just perf-trino-ducklake-realistic
+```
+
+The default `realistic-smoke` profile writes 100,000 events across timestamp
+partitions. It includes wide valid JSON event payloads, person payloads,
+optional group payloads, and an events/persons join. Set
+`TRINO_DUCKLAKE_REALISTIC_PERF_PROFILE=realistic-local` for 1,000,000 events,
+or override `TRINO_DUCKLAKE_REALISTIC_PERF_ROWS` (up to 1,000,000).
+
+If a previous local run leaves the coordinator unhealthy, inspect its logs and
+recreate only the test services:
+
+```bash
+docker compose -f tests/integration/docker-compose.yml logs trino
+docker compose -f tests/integration/docker-compose.yml rm -sf trino trino-metadata-reader-init
+```

--- a/tests/trino-ducklake-smoke/perf_test.go
+++ b/tests/trino-ducklake-smoke/perf_test.go
@@ -1,0 +1,202 @@
+package trino_ducklake_smoke
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	integration "github.com/posthog/duckgres/tests/integration"
+)
+
+const (
+	defaultPerfRows       = 1_000_000
+	maxPerfRows           = 5_000_000
+	perfWarmupIterations  = 1
+	perfMeasureIterations = 3
+)
+
+type localPerfArtifact struct {
+	CreatedAt         time.Time         `json:"created_at"`
+	Profile           string            `json:"profile,omitempty"`
+	Rows              int               `json:"rows"`
+	WarmupIterations  int               `json:"warmup_iterations"`
+	MeasureIterations int               `json:"measure_iterations"`
+	TrinoImage        string            `json:"trino_image"`
+	Results           []localPerfResult `json:"results"`
+}
+
+type localPerfResult struct {
+	QueryID          string    `json:"query_id"`
+	Query            string    `json:"query"`
+	TrinoQuery       string    `json:"trino_query,omitempty"`
+	ResultChecksum   string    `json:"result_checksum"`
+	PGWireDurationMS []float64 `json:"pgwire_duration_ms"`
+	TrinoDurationMS  []float64 `json:"trino_duration_ms"`
+}
+
+func TestTrinoDuckLakePerf(t *testing.T) {
+	setDuckLakeTestTimeZone(t)
+	if os.Getenv("TRINO_DUCKLAKE_PERF") != "1" {
+		t.Skip("set TRINO_DUCKLAKE_PERF=1 or run just perf-trino-ducklake")
+	}
+	rowCount := localPerfRowCount(t)
+	root := repositoryRoot(t)
+	composeFile := filepath.Join(root, "tests", "integration", "docker-compose.yml")
+	composeUp(t, composeFile, "ducklake-metadata", "minio")
+	compose(t, composeFile, "run", "--rm", "--no-deps", "minio-init")
+	compose(t, composeFile, "run", "--rm", "--no-deps", "trino-metadata-reader-init")
+
+	cfg := integration.DefaultConfig()
+	cfg.SkipPostgres = true
+	harness, err := integration.NewTestHarness(cfg)
+	if err != nil {
+		t.Fatalf("start Duckgres DuckLake writer: %v", err)
+	}
+	t.Cleanup(func() { _ = harness.Close() })
+
+	seedSyntheticEvents(t, harness.DuckgresDB, rowCount)
+	// The reader grant must follow table creation so Trino can discover it.
+	compose(t, composeFile, "run", "--rm", "--no-deps", "trino-metadata-reader-init")
+	composeUp(t, composeFile, "trino")
+
+	trino := newTrinoClient(2 * time.Minute)
+	assertTrinoUTC(t, trino)
+	artifact := localPerfArtifact{
+		CreatedAt:         time.Now().UTC(),
+		Rows:              rowCount,
+		WarmupIterations:  perfWarmupIterations,
+		MeasureIterations: perfMeasureIterations,
+		TrinoImage:        trinoImage,
+	}
+	for _, benchmark := range localPerfQueries {
+		want := duckgresRows(t, harness.DuckgresDB, benchmark.sql)
+		got := canonicalTrinoRows(trino.query(t, benchmark.sql))
+		checksum := checksumRows(want)
+		if trinoChecksum := checksumRows(got); trinoChecksum != checksum {
+			t.Fatalf("Trino result checksum differs for %s: trino=%s duckgres=%s", benchmark.id, trinoChecksum, checksum)
+		}
+
+		for range perfWarmupIterations {
+			_ = duckgresRows(t, harness.DuckgresDB, benchmark.sql)
+			_ = trino.query(t, benchmark.sql)
+		}
+		result := localPerfResult{QueryID: benchmark.id, Query: benchmark.sql, ResultChecksum: checksum}
+		for range perfMeasureIterations {
+			_, duration := timedDuckgresQuery(t, harness.DuckgresDB, benchmark.sql)
+			result.PGWireDurationMS = append(result.PGWireDurationMS, durationMilliseconds(duration))
+			_, duration = timedTrinoQuery(t, trino, benchmark.sql)
+			result.TrinoDurationMS = append(result.TrinoDurationMS, durationMilliseconds(duration))
+		}
+		artifact.Results = append(artifact.Results, result)
+	}
+	writeLocalPerfArtifact(t, artifact)
+}
+
+type localPerfQuery struct {
+	id  string
+	sql string
+}
+
+var localPerfQueries = []localPerfQuery{
+	{
+		id:  "events_total",
+		sql: "SELECT COUNT(*) FROM ducklake.main.perf_events",
+	},
+	{
+		id:  "events_one_day",
+		sql: "SELECT COUNT(*) FROM ducklake.main.perf_events WHERE event_time >= TIMESTAMP '2024-03-01 00:00:00' AND event_time < TIMESTAMP '2024-03-02 00:00:00'",
+	},
+	{
+		id:  "events_by_name",
+		sql: "SELECT event, COUNT(*) FROM ducklake.main.perf_events WHERE event_time >= TIMESTAMP '2024-03-01 00:00:00' AND event_time < TIMESTAMP '2024-04-01 00:00:00' GROUP BY event ORDER BY count(*) DESC, event",
+	},
+	{
+		id:  "distinct_persons",
+		sql: "SELECT COUNT(DISTINCT person_id) FROM ducklake.main.perf_events WHERE event_time >= TIMESTAMP '2024-03-01 00:00:00' AND event_time < TIMESTAMP '2024-04-01 00:00:00'",
+	},
+}
+
+func localPerfRowCount(t *testing.T) int {
+	t.Helper()
+	value := os.Getenv("TRINO_DUCKLAKE_PERF_ROWS")
+	if value == "" {
+		return defaultPerfRows
+	}
+	rows, err := strconv.Atoi(value)
+	if err != nil || rows < 1 || rows > maxPerfRows {
+		t.Fatalf("TRINO_DUCKLAKE_PERF_ROWS must be an integer from 1 through %d, got %q", maxPerfRows, value)
+	}
+	return rows
+}
+
+func seedSyntheticEvents(t *testing.T, db *sql.DB, rowCount int) {
+	t.Helper()
+	if _, err := db.Exec("DROP TABLE IF EXISTS ducklake.main.perf_events"); err != nil {
+		t.Fatalf("drop synthetic events table: %v", err)
+	}
+	statement := fmt.Sprintf(`
+CREATE TABLE ducklake.main.perf_events AS
+SELECT
+  id,
+  'event_' || (id %% 20)::VARCHAR AS event,
+  id %% 100000 AS person_id,
+  TIMESTAMP '2024-01-01 00:00:00' + (id %% 180) * INTERVAL 1 DAY AS event_time,
+  id %% 100 AS team_id,
+  id %% 100000 AS amount_cents
+FROM range(1, %d) AS source(id)`, rowCount+1)
+	if _, err := db.Exec(statement); err != nil {
+		t.Fatalf("create %d synthetic DuckLake events: %v", rowCount, err)
+	}
+}
+
+func timedDuckgresQuery(t *testing.T, db *sql.DB, query string) ([][]string, time.Duration) {
+	t.Helper()
+	started := time.Now()
+	rows := duckgresRows(t, db, query)
+	return rows, time.Since(started)
+}
+
+func timedTrinoQuery(t *testing.T, trino *trinoClient, query string) ([][]string, time.Duration) {
+	t.Helper()
+	started := time.Now()
+	rows := canonicalTrinoRows(trino.query(t, query))
+	return rows, time.Since(started)
+}
+
+func durationMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
+}
+
+func writeLocalPerfArtifact(t *testing.T, artifact localPerfArtifact) {
+	t.Helper()
+	dir := os.Getenv("TRINO_DUCKLAKE_PERF_ARTIFACT_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	} else if !filepath.IsAbs(dir) {
+		dir = filepath.Join(repositoryRoot(t), dir)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create local perf artifact directory: %v", err)
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		t.Fatalf("encode local perf artifact: %v", err)
+	}
+	path := filepath.Join(dir, "trino-ducklake-perf-"+artifact.CreatedAt.Format("20060102T150405Z")+".json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write local perf artifact: %v", err)
+	}
+	t.Logf("local performance artifact: %s", path)
+}
+
+func TestLocalPerfRowCount(t *testing.T) {
+	t.Setenv("TRINO_DUCKLAKE_PERF_ROWS", "1000")
+	if got := localPerfRowCount(t); got != 1000 {
+		t.Fatalf("localPerfRowCount() = %d, want 1000", got)
+	}
+}

--- a/tests/trino-ducklake-smoke/realistic_perf_test.go
+++ b/tests/trino-ducklake-smoke/realistic_perf_test.go
@@ -1,0 +1,235 @@
+package trino_ducklake_smoke
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	integration "github.com/posthog/duckgres/tests/integration"
+)
+
+const (
+	realisticSmokeRows         = 100_000
+	realisticLocalRows         = 1_000_000
+	realisticMaxRows           = 1_000_000
+	realisticPersonDivisor     = 10
+	realisticInsertBatchRows   = 1_000
+	realisticWarmupIterations  = 1
+	realisticMeasureIterations = 3
+)
+
+type realisticPerfProfile struct {
+	Name        string
+	DefaultRows int
+}
+
+var realisticPerfProfiles = map[string]realisticPerfProfile{
+	"realistic-smoke": {Name: "realistic-smoke", DefaultRows: realisticSmokeRows},
+	"realistic-local": {Name: "realistic-local", DefaultRows: realisticLocalRows},
+}
+
+func TestTrinoDuckLakeRealisticPerf(t *testing.T) {
+	setDuckLakeTestTimeZone(t)
+	if os.Getenv("TRINO_DUCKLAKE_REALISTIC_PERF") != "1" {
+		t.Skip("set TRINO_DUCKLAKE_REALISTIC_PERF=1 or run just perf-trino-ducklake-realistic")
+	}
+	profile, rows := realisticPerfConfig(t)
+	root := repositoryRoot(t)
+	composeFile := filepath.Join(root, "tests", "integration", "docker-compose.yml")
+	composeUp(t, composeFile, "ducklake-metadata", "minio")
+	compose(t, composeFile, "run", "--rm", "--no-deps", "minio-init")
+
+	cfg := integration.DefaultConfig()
+	cfg.SkipPostgres = true
+	harness, err := integration.NewTestHarness(cfg)
+	if err != nil {
+		t.Fatalf("start Duckgres DuckLake writer: %v", err)
+	}
+	t.Cleanup(func() { _ = harness.Close() })
+
+	seedRealisticEvents(t, harness.DuckgresDB, rows)
+	compose(t, composeFile, "run", "--rm", "--no-deps", "trino-metadata-reader-init")
+	composeUp(t, composeFile, "trino")
+	trino := newTrinoClient(2 * time.Minute)
+	assertTrinoUTC(t, trino)
+
+	artifact := localPerfArtifact{
+		CreatedAt:         time.Now().UTC(),
+		Profile:           profile.Name,
+		Rows:              rows,
+		WarmupIterations:  realisticWarmupIterations,
+		MeasureIterations: realisticMeasureIterations,
+		TrinoImage:        trinoImage,
+	}
+	for _, benchmark := range realisticPerfQueries {
+		result := compareAndMeasureQuery(t, harness.DuckgresDB, trino, benchmark, realisticWarmupIterations, realisticMeasureIterations)
+		artifact.Results = append(artifact.Results, result)
+	}
+	writeLocalPerfArtifact(t, artifact)
+}
+
+func realisticPerfConfig(t *testing.T) (realisticPerfProfile, int) {
+	t.Helper()
+	name := os.Getenv("TRINO_DUCKLAKE_REALISTIC_PERF_PROFILE")
+	if name == "" {
+		name = "realistic-smoke"
+	}
+	profile, ok := realisticPerfProfiles[name]
+	if !ok {
+		t.Fatalf("TRINO_DUCKLAKE_REALISTIC_PERF_PROFILE must be realistic-smoke or realistic-local, got %q", name)
+	}
+	rows := profile.DefaultRows
+	if value := os.Getenv("TRINO_DUCKLAKE_REALISTIC_PERF_ROWS"); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 1 || parsed > realisticMaxRows {
+			t.Fatalf("TRINO_DUCKLAKE_REALISTIC_PERF_ROWS must be an integer from 1 through %d, got %q", realisticMaxRows, value)
+		}
+		rows = parsed
+	}
+	return profile, rows
+}
+
+func seedRealisticEvents(t *testing.T, db *sql.DB, rowCount int) {
+	t.Helper()
+	personCount := max(1, rowCount/realisticPersonDivisor)
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ducklake.posthog.events",
+		"DROP TABLE IF EXISTS ducklake.posthog.persons",
+		"CREATE SCHEMA IF NOT EXISTS ducklake.posthog",
+		`CREATE TABLE ducklake.posthog.events (
+uuid VARCHAR, event VARCHAR, properties VARCHAR, timestamp TIMESTAMPTZ,
+team_id BIGINT, project_id BIGINT, distinct_id VARCHAR, elements_chain VARCHAR,
+created_at TIMESTAMPTZ, person_id VARCHAR, person_created_at TIMESTAMPTZ,
+person_properties VARCHAR, group0_properties VARCHAR, group1_properties VARCHAR,
+group2_properties VARCHAR, group3_properties VARCHAR, group4_properties VARCHAR,
+group0_created_at TIMESTAMPTZ, group1_created_at TIMESTAMPTZ,
+group2_created_at TIMESTAMPTZ, group3_created_at TIMESTAMPTZ,
+group4_created_at TIMESTAMPTZ, person_mode VARCHAR, historical_migration BOOLEAN,
+_inserted_at TIMESTAMPTZ)`,
+		"ALTER TABLE ducklake.posthog.events SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))",
+		`CREATE TABLE ducklake.posthog.persons (
+team_id BIGINT, distinct_id VARCHAR, id VARCHAR, properties VARCHAR,
+created_at TIMESTAMPTZ, is_identified BOOLEAN, person_distinct_id_version BIGINT,
+person_version UBIGINT, _timestamp TIMESTAMPTZ, _inserted_at TIMESTAMPTZ)`,
+		"ALTER TABLE ducklake.posthog.persons SET PARTITIONED BY (year(_timestamp), month(_timestamp))",
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("prepare realistic DuckLake fixture: %v", err)
+		}
+	}
+
+	eventsSQL := `WITH payload_templates AS (
+  SELECT 'small' AS kind, json_group_object('property_' || key, CASE WHEN key = 0 THEN repeat('s', 7000) ELSE 'value' END)::VARCHAR AS properties FROM range(0, 50) AS keys(key)
+  UNION ALL
+  SELECT 'medium', json_group_object('property_' || key, CASE WHEN key = 0 THEN repeat('m', 23000) ELSE 'value' END)::VARCHAR FROM range(0, 150) AS keys(key)
+  UNION ALL
+  SELECT 'large', json_group_object('property_' || key, CASE WHEN key = 0 THEN repeat('l', 50000) ELSE 'value' END)::VARCHAR FROM range(0, 500) AS keys(key)
+  UNION ALL
+  SELECT 'wide', json_group_object('property_' || key, CASE WHEN key = 0 THEN repeat('w', 150000) ELSE 'value' END)::VARCHAR FROM range(0, 1200) AS keys(key)
+), person_template AS (
+  SELECT json_group_object('person_property_' || key, CASE WHEN key = 0 THEN repeat('p', 4000) ELSE 'value' END)::VARCHAR AS properties FROM range(0, 150) AS keys(key)
+)
+INSERT INTO ducklake.posthog.events
+SELECT
+  md5('event-' || id::VARCHAR),
+  'event_' || (id % 100)::VARCHAR,
+  CASE WHEN id % 100 < 50 THEN small.properties WHEN id % 100 < 75 THEN medium.properties WHEN id % 100 < 89 THEN large.properties ELSE wide.properties END,
+  TIMESTAMPTZ '2024-01-01 00:00:00+00' + ((id - 1) * 180 / {{TOTAL_ROWS}}) * INTERVAL 1 DAY + (id % 86400) * INTERVAL 1 SECOND,
+  id % 10, id % 25, 'distinct_' || (id % {{PERSON_COUNT}})::VARCHAR, repeat('el>', 66),
+  TIMESTAMPTZ '2023-01-01 00:00:00+00' + (id % 365) * INTERVAL 1 DAY,
+  'person_' || (id % {{PERSON_COUNT}})::VARCHAR,
+  TIMESTAMPTZ '2023-01-01 00:00:00+00' + (id % 365) * INTERVAL 1 DAY,
+  CASE WHEN id % 20 = 0 THEN '' ELSE person_template.properties END,
+  CASE WHEN id % 10 = 0 THEN medium.properties END,
+  CASE WHEN id % 50 = 0 THEN small.properties END,
+  CASE WHEN id % 100 = 0 THEN small.properties END,
+  NULL, NULL,
+  TIMESTAMPTZ '2023-01-01 00:00:00+00', TIMESTAMPTZ '2023-01-01 00:00:00+00',
+  TIMESTAMPTZ '2023-01-01 00:00:00+00', TIMESTAMPTZ '2023-01-01 00:00:00+00',
+  TIMESTAMPTZ '2023-01-01 00:00:00+00', 'identified', false,
+  TIMESTAMPTZ '2024-01-01 00:00:00+00'
+FROM range({{ROW_START}}, {{ROW_END}}) AS source(id)
+CROSS JOIN (SELECT properties FROM payload_templates WHERE kind = 'small') AS small
+CROSS JOIN (SELECT properties FROM payload_templates WHERE kind = 'medium') AS medium
+CROSS JOIN (SELECT properties FROM payload_templates WHERE kind = 'large') AS large
+CROSS JOIN (SELECT properties FROM payload_templates WHERE kind = 'wide') AS wide
+CROSS JOIN person_template`
+	for start := 1; start <= rowCount; start += realisticInsertBatchRows {
+		end := min(start+realisticInsertBatchRows, rowCount+1)
+		batchSQL := strings.NewReplacer(
+			"{{PERSON_COUNT}}", strconv.Itoa(personCount),
+			"{{ROW_START}}", strconv.Itoa(start),
+			"{{ROW_END}}", strconv.Itoa(end),
+			"{{TOTAL_ROWS}}", strconv.Itoa(rowCount),
+		).Replace(eventsSQL)
+		if _, err := db.Exec(batchSQL); err != nil {
+			t.Fatalf("seed realistic DuckLake events %d through %d: %v", start, end-1, err)
+		}
+	}
+	personsSQL := `WITH person_template AS (
+  SELECT json_group_object('person_property_' || key, CASE WHEN key = 0 THEN repeat('p', 4000) ELSE 'value' END)::VARCHAR AS properties FROM range(0, 150) AS keys(key)
+)
+INSERT INTO ducklake.posthog.persons
+SELECT id % 10, 'distinct_' || id::VARCHAR, 'person_' || id::VARCHAR, person_template.properties,
+  TIMESTAMPTZ '2023-01-01 00:00:00+00', true, 1, id,
+  TIMESTAMPTZ '2023-01-01 00:00:00+00' + (id % 365) * INTERVAL 1 DAY,
+  TIMESTAMPTZ '2024-01-01 00:00:00+00'
+FROM range(1, {{PERSON_ROW_END}}) AS source(id)
+CROSS JOIN person_template`
+	personsSQL = strings.ReplaceAll(personsSQL, "{{PERSON_ROW_END}}", strconv.Itoa(personCount+1))
+	if _, err := db.Exec(personsSQL); err != nil {
+		t.Fatalf("seed %d realistic DuckLake persons: %v", personCount, err)
+	}
+}
+
+type crossEnginePerfQuery struct {
+	id          string
+	duckgresSQL string
+	trinoSQL    string
+}
+
+var realisticPerfQueries = []crossEnginePerfQuery{
+	{"events_total", "SELECT COUNT(*) FROM ducklake.posthog.events", "SELECT COUNT(*) FROM ducklake.posthog.events"},
+	{"events_one_day", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE timestamp >= TIMESTAMPTZ '2024-03-01 00:00:00+00' AND timestamp < TIMESTAMPTZ '2024-03-02 00:00:00+00'", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE timestamp >= from_iso8601_timestamp('2024-03-01T00:00:00Z') AND timestamp < from_iso8601_timestamp('2024-03-02T00:00:00Z')"},
+	{"events_by_name", "SELECT event, COUNT(*) FROM ducklake.posthog.events WHERE timestamp >= TIMESTAMPTZ '2024-03-01 00:00:00+00' AND timestamp < TIMESTAMPTZ '2024-04-01 00:00:00+00' GROUP BY event ORDER BY count(*) DESC, event", "SELECT event, COUNT(*) FROM ducklake.posthog.events WHERE timestamp >= from_iso8601_timestamp('2024-03-01T00:00:00Z') AND timestamp < from_iso8601_timestamp('2024-04-01T00:00:00Z') GROUP BY event ORDER BY count(*) DESC, event"},
+	{"distinct_persons", "SELECT COUNT(DISTINCT person_id) FROM ducklake.posthog.events WHERE timestamp >= TIMESTAMPTZ '2024-03-01 00:00:00+00' AND timestamp < TIMESTAMPTZ '2024-04-01 00:00:00+00'", "SELECT COUNT(DISTINCT person_id) FROM ducklake.posthog.events WHERE timestamp >= from_iso8601_timestamp('2024-03-01T00:00:00Z') AND timestamp < from_iso8601_timestamp('2024-04-01T00:00:00Z')"},
+	{"event_person_join", "SELECT e.event, COUNT(*) FROM ducklake.posthog.events e JOIN ducklake.posthog.persons p ON p.id = e.person_id WHERE e.timestamp >= TIMESTAMPTZ '2024-03-01 00:00:00+00' AND e.timestamp < TIMESTAMPTZ '2024-04-01 00:00:00+00' GROUP BY e.event ORDER BY e.event", "SELECT e.event, COUNT(*) FROM ducklake.posthog.events e JOIN ducklake.posthog.persons p ON p.id = e.person_id WHERE e.timestamp >= from_iso8601_timestamp('2024-03-01T00:00:00Z') AND e.timestamp < from_iso8601_timestamp('2024-04-01T00:00:00Z') GROUP BY e.event ORDER BY e.event"},
+	{"wide_payload_scan", "SELECT SUM(length(properties)) FROM ducklake.posthog.events WHERE timestamp >= TIMESTAMPTZ '2024-03-01 00:00:00+00' AND timestamp < TIMESTAMPTZ '2024-04-01 00:00:00+00'", "SELECT SUM(length(properties)) FROM ducklake.posthog.events WHERE timestamp >= from_iso8601_timestamp('2024-03-01T00:00:00Z') AND timestamp < from_iso8601_timestamp('2024-04-01T00:00:00Z')"},
+	{"json_property_filter", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE json_extract_string(properties, '$.property_1') = 'value'", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE json_extract_scalar(properties, '$.property_1') = 'value'"},
+	{"sparse_group_payload", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE group0_properties IS NOT NULL AND length(group0_properties) > 10000", "SELECT COUNT(*) FROM ducklake.posthog.events WHERE group0_properties IS NOT NULL AND length(group0_properties) > 10000"},
+}
+
+func compareAndMeasureQuery(t *testing.T, duckgres *sql.DB, trino *trinoClient, query crossEnginePerfQuery, warmups, measurements int) localPerfResult {
+	t.Helper()
+	want := duckgresRows(t, duckgres, query.duckgresSQL)
+	got := canonicalTrinoRows(trino.query(t, query.trinoSQL))
+	checksum := checksumRows(want)
+	if trinoChecksum := checksumRows(got); trinoChecksum != checksum {
+		t.Fatalf("Trino result checksum differs for %s: trino=%s duckgres=%s trino_rows=%v duckgres_rows=%v", query.id, trinoChecksum, checksum, got, want)
+	}
+	for range warmups {
+		_ = duckgresRows(t, duckgres, query.duckgresSQL)
+		_ = trino.query(t, query.trinoSQL)
+	}
+	result := localPerfResult{QueryID: query.id, Query: query.duckgresSQL, TrinoQuery: query.trinoSQL, ResultChecksum: checksum}
+	for range measurements {
+		_, duration := timedDuckgresQuery(t, duckgres, query.duckgresSQL)
+		result.PGWireDurationMS = append(result.PGWireDurationMS, durationMilliseconds(duration))
+		_, duration = timedTrinoQuery(t, trino, query.trinoSQL)
+		result.TrinoDurationMS = append(result.TrinoDurationMS, durationMilliseconds(duration))
+	}
+	return result
+}
+
+func TestRealisticPerfConfig(t *testing.T) {
+	t.Setenv("TRINO_DUCKLAKE_REALISTIC_PERF_PROFILE", "realistic-smoke")
+	t.Setenv("TRINO_DUCKLAKE_REALISTIC_PERF_ROWS", "1000")
+	profile, rows := realisticPerfConfig(t)
+	if profile.Name != "realistic-smoke" || rows != 1000 {
+		t.Fatalf("realisticPerfConfig() = (%+v, %d), want realistic-smoke/1000", profile, rows)
+	}
+}

--- a/tests/trino-ducklake-smoke/smoke_test.go
+++ b/tests/trino-ducklake-smoke/smoke_test.go
@@ -1,0 +1,469 @@
+package trino_ducklake_smoke
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	integration "github.com/posthog/duckgres/tests/integration"
+)
+
+const (
+	trinoImage             = "trinodb/trino:483@sha256:db58cc93e593a2706553745f276bb119c9810e69918be56ecde088ba7ccb0534"
+	brikkConnectorVersion  = "483-0.2.0"
+	brikkConnectorSHA256   = "b8967c47b940c82d357c657c743b703aec7d9523a3ed2213b356ab7424729450"
+	trinoStatementEndpoint = "http://127.0.0.1:38080/v1/statement"
+	testTimeZone           = "UTC"
+)
+
+type trinoError struct {
+	Message string `json:"message"`
+}
+
+type trinoResponse struct {
+	Data    [][]any     `json:"data"`
+	NextURI string      `json:"nextUri"`
+	Error   *trinoError `json:"error"`
+}
+
+type versionArtifact struct {
+	TrinoImage               string `json:"trino_image"`
+	TrinoVersion             string `json:"trino_version"`
+	BrikkConnectorVersion    string `json:"brikk_connector_version"`
+	BrikkConnectorSHA256     string `json:"brikk_connector_sha256"`
+	DuckDBVersion            string `json:"duckdb_version"`
+	DuckLakeExtensionVersion string `json:"ducklake_extension_version"`
+	DuckLakeCatalogVersion   string `json:"ducklake_catalog_version"`
+}
+
+func TestTrinoDuckLakeSmoke(t *testing.T) {
+	setDuckLakeTestTimeZone(t)
+	root := repositoryRoot(t)
+	composeFile := filepath.Join(root, "tests", "integration", "docker-compose.yml")
+	composeUp(t, composeFile, "ducklake-metadata", "minio")
+	compose(t, composeFile, "run", "--rm", "--no-deps", "minio-init")
+	compose(t, composeFile, "run", "--rm", "--no-deps", "trino-metadata-reader-init")
+
+	cfg := integration.DefaultConfig()
+	cfg.SkipPostgres = true
+	harness, err := integration.NewTestHarness(cfg)
+	if err != nil {
+		t.Fatalf("seed DuckLake through Duckgres: %v", err)
+	}
+	t.Cleanup(func() { _ = harness.Close() })
+
+	// Run after seeding so grants cover the DuckLake metadata tables created by DuckDB.
+	compose(t, composeFile, "run", "--rm", "--no-deps", "trino-metadata-reader-init")
+	assertMetadataReaderIsReadOnly(t)
+	assertS3ReaderCannotWrite(t, composeFile)
+	composeUp(t, composeFile, "trino")
+
+	trino := newTrinoClient(30 * time.Second)
+	assertTrinoUTC(t, trino)
+	assertDiscovery(t, trino)
+	assertRepresentativeTypes(t, trino)
+	assertQueriesMatchDuckgres(t, harness.DuckgresDB, trino)
+	assertChecksumsMatchDuckgres(t, harness.DuckgresDB, trino)
+	writeVersionArtifact(t, harness.DuckgresDB, trino)
+}
+
+// setDuckLakeTestTimeZone is inherited by the Duckgres child worker that
+// materializes DuckLake partitions. Keep it test-scoped: production server
+// timezone policy is outside this local interoperability test.
+func setDuckLakeTestTimeZone(t *testing.T) {
+	t.Helper()
+	t.Setenv("TZ", testTimeZone)
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("determine repository root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func composeUp(t *testing.T, composeFile string, services ...string) {
+	t.Helper()
+	args := append([]string{"up", "-d", "--wait"}, services...)
+	compose(t, composeFile, args...)
+}
+
+func compose(t *testing.T, composeFile string, args ...string) {
+	t.Helper()
+	cmdArgs := append([]string{"compose", "-f", composeFile}, args...)
+	cmd := exec.Command("docker", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker %s: %v\n%s", strings.Join(cmdArgs, " "), err, output)
+	}
+	if len(output) != 0 {
+		t.Logf("docker %s:\n%s", strings.Join(cmdArgs, " "), output)
+	}
+}
+
+func assertMetadataReaderIsReadOnly(t *testing.T) {
+	t.Helper()
+	db, err := sql.Open("postgres", "host=127.0.0.1 port=35433 user=trino_reader password=trino-reader dbname=ducklake sslmode=disable")
+	if err != nil {
+		t.Fatalf("open Trino metadata reader: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		t.Fatalf("connect Trino metadata reader: %v", err)
+	}
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM public.ducklake_metadata").Scan(&count); err != nil {
+		t.Fatalf("Trino metadata reader cannot read DuckLake metadata: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO public.ducklake_metadata(key, value) VALUES ('smoke_write_probe', 'blocked')"); err == nil {
+		t.Fatal("Trino metadata reader unexpectedly wrote DuckLake metadata")
+	}
+}
+
+func assertS3ReaderCannotWrite(t *testing.T, composeFile string) {
+	t.Helper()
+	cmdArgs := []string{
+		"compose", "-f", composeFile, "run", "--rm", "--no-deps", "--entrypoint", "/bin/sh", "minio-init", "-ec",
+		"mc alias set reader http://minio:9000 trino-reader trino-reader && " +
+			"printf blocked | mc pipe reader/ducklake/data/trino-smoke-write-probe",
+	}
+	cmd := exec.Command("docker", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("Trino S3 reader unexpectedly wrote an object:\n%s", output)
+	}
+}
+
+func assertDiscovery(t *testing.T, trino *trinoClient) {
+	t.Helper()
+	schemas := trino.query(t, "SHOW SCHEMAS FROM ducklake")
+	if !containsCell(schemas, "main") {
+		t.Fatalf("DuckLake main schema not discovered: %v", schemas)
+	}
+	tables := trino.query(t, "SHOW TABLES FROM ducklake.main")
+	for _, table := range []string{"users", "products", "orders", "types_test"} {
+		if !containsCell(tables, table) {
+			t.Fatalf("DuckLake table %q not discovered: %v", table, tables)
+		}
+	}
+}
+
+func assertRepresentativeTypes(t *testing.T, trino *trinoClient) {
+	t.Helper()
+	rows := trino.query(t, "DESCRIBE ducklake.main.types_test")
+	actual := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if len(row) < 2 {
+			continue
+		}
+		actual[fmt.Sprint(row[0])] = strings.ToLower(fmt.Sprint(row[1]))
+	}
+	for column, wantType := range map[string]string{
+		"bool_col":      "boolean",
+		"int4_col":      "integer",
+		"numeric_col":   "decimal(12,4)",
+		"date_col":      "date",
+		"timestamp_col": "timestamp(6)",
+		"uuid_col":      "uuid",
+		"bytea_col":     "varbinary",
+	} {
+		if got := actual[column]; got != wantType {
+			t.Errorf("type for %s = %q, want %q (all types: %v)", column, got, wantType, actual)
+		}
+	}
+}
+
+func assertQueriesMatchDuckgres(t *testing.T, duckgres *sql.DB, trino *trinoClient) {
+	t.Helper()
+	queries := []string{
+		"SELECT id, name FROM ducklake.main.users WHERE active = true ORDER BY id",
+		"SELECT COUNT(*), SUM(id * age) FROM ducklake.main.users WHERE active = true",
+		"SELECT u.name, p.name, o.quantity FROM ducklake.main.orders o JOIN ducklake.main.users u ON u.id = o.user_id JOIN ducklake.main.products p ON p.id = o.product_id WHERE o.status = 'completed' ORDER BY o.id",
+		"SELECT COUNT(*) FROM ducklake.main.types_test WHERE bool_col = true AND int4_col = 100 AND numeric_col = 123.4567 AND uuid_col = UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'",
+		"SELECT COUNT(*) FROM ducklake.main.types_test WHERE date_col = DATE '2024-01-15' AND timestamp_col = TIMESTAMP '2024-01-15 12:30:45'",
+	}
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			want := duckgresRows(t, duckgres, query)
+			got := canonicalTrinoRows(trino.query(t, query))
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Trino result differs from Duckgres\nquery: %s\nTrino: %v\nDuckgres: %v", query, got, want)
+			}
+		})
+	}
+}
+
+func assertChecksumsMatchDuckgres(t *testing.T, duckgres *sql.DB, trino *trinoClient) {
+	t.Helper()
+	for _, query := range []string{
+		"SELECT id, name, active, age FROM ducklake.main.users ORDER BY id",
+		"SELECT id, user_id, product_id, quantity, status FROM ducklake.main.orders ORDER BY id",
+	} {
+		want := checksumRows(duckgresRows(t, duckgres, query))
+		got := checksumRows(canonicalTrinoRows(trino.query(t, query)))
+		if got != want {
+			t.Fatalf("Trino checksum differs from Duckgres\\nquery: %s\\nTrino: %s\\nDuckgres: %s", query, got, want)
+		}
+	}
+}
+
+func checksumRows(rows [][]string) string {
+	hash := sha256.New()
+	for _, row := range rows {
+		_, _ = io.WriteString(hash, strings.Join(row, "\\x1f"))
+		_, _ = io.WriteString(hash, "\\x1e")
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func duckgresRows(t *testing.T, db *sql.DB, query string) [][]string {
+	t.Helper()
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("Duckgres query %q: %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("Duckgres columns: %v", err)
+	}
+	var result [][]string
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		if err := rows.Scan(pointers...); err != nil {
+			t.Fatalf("Duckgres scan: %v", err)
+		}
+		row := make([]string, len(values))
+		for i, value := range values {
+			row[i] = canonicalValue(value)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Duckgres rows: %v", err)
+	}
+	return result
+}
+
+func canonicalTrinoRows(rows [][]any) [][]string {
+	result := make([][]string, len(rows))
+	for i, values := range rows {
+		result[i] = make([]string, len(values))
+		for j, value := range values {
+			result[i][j] = canonicalValue(value)
+		}
+	}
+	return result
+}
+
+func canonicalValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "<NULL>"
+	case []byte:
+		return string(v)
+	case json.Number:
+		return v.String()
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func containsCell(rows [][]any, want string) bool {
+	for _, row := range rows {
+		for _, value := range row {
+			if fmt.Sprint(value) == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type trinoClient struct {
+	endpoint   string
+	httpClient *http.Client
+	timeZone   string
+}
+
+func newTrinoClient(timeout time.Duration) *trinoClient {
+	return &trinoClient{
+		endpoint:   trinoStatementEndpoint,
+		httpClient: &http.Client{Timeout: timeout},
+		timeZone:   testTimeZone,
+	}
+}
+
+func (c *trinoClient) setHeaders(req *http.Request) {
+	req.Header.Set("X-Trino-User", "smoke")
+	req.Header.Set("X-Trino-Catalog", "ducklake")
+	req.Header.Set("X-Trino-Schema", "main")
+	req.Header.Set("X-Trino-Time-Zone", c.timeZone)
+}
+
+func (c *trinoClient) query(t *testing.T, statement string) [][]any {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, c.endpoint, strings.NewReader(statement))
+	if err != nil {
+		t.Fatalf("create Trino request: %v", err)
+	}
+	c.setHeaders(req)
+	response := c.do(t, req)
+	var rows [][]any
+	for {
+		rows = append(rows, response.Data...)
+		if response.Error != nil {
+			t.Fatalf("Trino query %q: %s", statement, response.Error.Message)
+		}
+		if response.NextURI == "" {
+			return rows
+		}
+		next, err := http.NewRequest(http.MethodGet, response.NextURI, nil)
+		if err != nil {
+			t.Fatalf("create Trino next request: %v", err)
+		}
+		c.setHeaders(next)
+		response = c.do(t, next)
+	}
+}
+
+func (c *trinoClient) do(t *testing.T, req *http.Request) trinoResponse {
+	t.Helper()
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("Trino request %s %s: %v", req.Method, req.URL, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("Trino request %s %s: status %s: %s", req.Method, req.URL, response.Status, body)
+	}
+	decoder := json.NewDecoder(response.Body)
+	decoder.UseNumber()
+	var decoded trinoResponse
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatalf("decode Trino response: %v", err)
+	}
+	return decoded
+}
+
+func writeVersionArtifact(t *testing.T, duckgres *sql.DB, trino *trinoClient) {
+	t.Helper()
+	artifact := versionArtifact{
+		TrinoImage:               trinoImage,
+		TrinoVersion:             singleTrinoValue(t, trino, "SELECT version()"),
+		BrikkConnectorVersion:    brikkConnectorVersion,
+		BrikkConnectorSHA256:     brikkConnectorSHA256,
+		DuckDBVersion:            singleDuckgresValue(t, duckgres, "SELECT library_version FROM pragma_version()"),
+		DuckLakeExtensionVersion: singleDuckgresValue(t, duckgres, "SELECT extension_version FROM duckdb_extensions() WHERE extension_name = 'ducklake' AND loaded"),
+		DuckLakeCatalogVersion:   singleMetadataValue(t, "SELECT value FROM public.ducklake_metadata WHERE key = 'version' AND scope IS NULL"),
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		t.Fatalf("encode version artifact: %v", err)
+	}
+	dir := os.Getenv("TRINO_DUCKLAKE_SMOKE_ARTIFACT_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create artifact directory: %v", err)
+	}
+	path := filepath.Join(dir, "trino-ducklake-smoke-versions.json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write version artifact: %v", err)
+	}
+	t.Logf("version artifact: %s\n%s", path, bytes.TrimSpace(data))
+}
+
+func singleDuckgresValue(t *testing.T, db *sql.DB, query string) string {
+	t.Helper()
+	var value string
+	if err := db.QueryRow(query).Scan(&value); err != nil {
+		t.Fatalf("Duckgres version query %q: %v", query, err)
+	}
+	return value
+}
+
+func singleMetadataValue(t *testing.T, query string) string {
+	t.Helper()
+	db, err := sql.Open("postgres", "host=127.0.0.1 port=35433 user=trino_reader password=trino-reader dbname=ducklake sslmode=disable")
+	if err != nil {
+		t.Fatalf("open Trino metadata reader for version artifact: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var value string
+	if err := db.QueryRow(query).Scan(&value); err != nil {
+		t.Fatalf("DuckLake metadata version query %q: %v", query, err)
+	}
+	return value
+}
+
+func singleTrinoValue(t *testing.T, trino *trinoClient, query string) string {
+	t.Helper()
+	rows := trino.query(t, query)
+	if len(rows) != 1 || len(rows[0]) != 1 {
+		t.Fatalf("Trino version query %q returned %v", query, rows)
+	}
+	return canonicalValue(rows[0][0])
+}
+
+func assertTrinoUTC(t *testing.T, trino *trinoClient) {
+	t.Helper()
+	if got := singleTrinoValue(t, trino, "SELECT current_timezone()"); got != testTimeZone {
+		t.Fatalf("Trino timezone = %q, want %s", got, testTimeZone)
+	}
+}
+
+func TestPinnedVersionsAreComplete(t *testing.T) {
+	if !strings.HasPrefix(trinoImage, "trinodb/trino:") || !strings.Contains(trinoImage, "@sha256:") {
+		t.Fatalf("Trino image must be version-pinned, got %q", trinoImage)
+	}
+	if brikkConnectorVersion == "" || len(brikkConnectorSHA256) != 64 {
+		t.Fatalf("Brikk connector version/checksum must be pinned: version=%q checksum=%q", brikkConnectorVersion, brikkConnectorSHA256)
+	}
+	checksum := strings.ToLower(brikkConnectorSHA256)
+	if checksum != brikkConnectorSHA256 || strings.Trim(checksum, "0123456789abcdef") != "" {
+		t.Fatalf("Brikk connector checksum is not lowercase hexadecimal: %q", brikkConnectorSHA256)
+	}
+}
+
+func TestCanonicalTrinoRows(t *testing.T) {
+	got := canonicalTrinoRows([][]any{{json.Number("1"), "Alice", nil}})
+	want := [][]string{{"1", "Alice", "<NULL>"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonicalTrinoRows() = %v, want %v", got, want)
+	}
+}
+
+func TestTrinoClientUsesUTC(t *testing.T) {
+	client := newTrinoClient(time.Second)
+	req, err := http.NewRequest(http.MethodPost, trinoStatementEndpoint, nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	client.setHeaders(req)
+	if got := req.Header.Get("X-Trino-Time-Zone"); got != "UTC" {
+		t.Fatalf("X-Trino-Time-Zone = %q, want UTC", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a pinned, single-node Trino + Brikk DuckLake service to the local integration Compose stack
- give local Trino dedicated PostgreSQL metadata and MinIO reader identities with no write permissions
- add a hermetic smoke test plus opt-in narrow and production-shaped local Duckgres-versus-Trino performance runs
- configure DuckDB and Trino tests for UTC timestamp partition semantics and record version/performance artifacts under `artifacts/`

## Why

This establishes a checksum-validated local compatibility and performance baseline for Trino reading the same DuckLake catalog and data created by Duckgres. It keeps the test fully local and isolated from managed-warehouse infrastructure.

## Validation

- `just lint`
- `just trino-ducklake-smoke`
- `just perf-trino-ducklake-realistic`
- `docker compose -f tests/integration/docker-compose.yml config --quiet`
- `git diff --check`
