### PR TITLE
Allow client to change idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Run with config file:
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
 | `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |
 | `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` |
+| `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX` | Maximum client-requested `duckgres.idle_timeout`; unset disables client overrides | disabled |
 | `DUCKGRES_SESSION_INIT_TIMEOUT` | Session startup metadata initialization and catalog probe timeout | `10s` |
 | `DUCKGRES_WORKER_QUEUE_TIMEOUT` | Max time to wait for worker acquisition and per-org/per-user vCPU resource admission; the managed K8s queue TTL uses this value | `60s` |
 | `DUCKGRES_ADMISSION_RECLAIMER_MAX_RESERVATIONS` | Max queued/live admission identities whose cleanup ownership one control plane may retain; new admissions are rejected before enqueue when full | `4096` |
@@ -394,6 +395,21 @@ Run with config file:
 | `POSTHOG_HOST` | PostHog ingest host (shared by both exporters) | `us.i.posthog.com` |
 | `ADDITIONAL_POSTHOG_API_KEYS` | **(Experimental)** Comma-separated list of additional PostHog API keys to publish logs to. Requires `POSTHOG_API_KEY` to be set. | - |
 | `DUCKGRES_IDENTIFIER` | Suffix appended to the OTel `service.name` (e.g., `duckgres-acme`). Applies to **both** the log export and the OTLP trace export — they share one resource — so setting it renames the service in traces too, not just logs | - |
+
+### Client-requested idle timeout
+
+The control plane closes inactive client sessions after its configured
+`DUCKGRES_IDLE_TIMEOUT` (60 seconds by default). To let clients request a
+longer, bounded timeout, set a positive `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX` on
+the control plane. For example, with `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX=15m`:
+
+```bash
+PGOPTIONS='-c duckgres.idle_timeout=15m' psql "host=<host> dbname=ducklake sslmode=require"
+```
+
+Requests must be positive and no greater than the configured maximum. Leaving
+the maximum unset disables client overrides, and clients cannot request an
+unlimited timeout because idle sessions retain worker capacity.
 
 ### PostHog Logging
 

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -588,6 +588,13 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 			warn("Invalid DUCKGRES_IDLE_TIMEOUT duration: " + err.Error())
 		}
 	}
+	if v := getenv("DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.ClientIdleTimeoutMax = d
+		} else {
+			warn("Invalid DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX: must be a positive duration")
+		}
+	}
 	if v := getenv("DUCKGRES_SESSION_INIT_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			cfg.SessionInitTimeout = d

--- a/configresolve/resolve_k8s_test.go
+++ b/configresolve/resolve_k8s_test.go
@@ -60,6 +60,40 @@ func TestResolveEffectiveParsesK8sWorkerMaxTTL(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveParsesClientIdleTimeoutMax(t *testing.T) {
+	var warned []string
+	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		switch key {
+		case "DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX":
+			return "15m"
+		default:
+			return ""
+		}
+	}, func(msg string) { warned = append(warned, msg) })
+	if resolved.Server.ClientIdleTimeoutMax != 15*time.Minute {
+		t.Fatalf("ClientIdleTimeoutMax = %s, want 15m", resolved.Server.ClientIdleTimeoutMax)
+	}
+	if len(warned) != 0 {
+		t.Fatalf("unexpected warnings: %v", warned)
+	}
+}
+
+func TestResolveEffectiveRejectsInvalidClientIdleTimeoutMax(t *testing.T) {
+	var warned []string
+	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		if key == "DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX" {
+			return "-1s"
+		}
+		return ""
+	}, func(msg string) { warned = append(warned, msg) })
+	if resolved.Server.ClientIdleTimeoutMax != 0 {
+		t.Fatalf("ClientIdleTimeoutMax = %s, want disabled", resolved.Server.ClientIdleTimeoutMax)
+	}
+	if len(warned) != 1 {
+		t.Fatalf("warnings = %v, want one invalid-duration warning", warned)
+	}
+}
+
 func TestResolveEffectiveParsesK8sWorkerDefaultTTL(t *testing.T) {
 	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {
 		if key == "DUCKGRES_K8S_WORKER_DEFAULT_TTL" {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1148,6 +1148,21 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	sessionStart := observe.BeginSessionStart(orgID, "postgres")
 	defer sessionStart.Finish("error", observe.SessionStartReasonUnknown)
 
+	// Validate a client-requested idle timeout before acquiring a worker so a
+	// rejected request cannot consume worker or admission capacity.
+	var clientIdleTimeout time.Duration
+	if raw, ok := startupOptions[server.ClientIdleTimeoutGUCName]; ok {
+		var err error
+		clientIdleTimeout, err = server.ValidateClientIdleTimeoutOption(raw, cp.cfg.ClientIdleTimeoutMax)
+		if err != nil {
+			sessionStart.Finish("error", observe.SessionStartReasonClient)
+			clog.Warn("Rejected client idle-timeout request.", "error", err)
+			_ = server.WriteErrorResponse(writer, "FATAL", "22023", err.Error())
+			_ = writer.Flush()
+			return
+		}
+	}
+
 	// Resolve the requested worker shape from the connection-string startup
 	// options (duckgres.worker_cpu / worker_memory / worker_ttl), layered on
 	// top of the org's operator-set default profile (multi-tenant only).
@@ -1508,6 +1523,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 		sessionExec = executor
 	}
 	cc := server.NewClientConn(cp.srv, tlsConn, reader, writer, username, orgID, database, applicationName, sessionExec, pid, secretKey, workerID, workerPod)
+	server.SetConnectionIdleTimeout(cc, clientIdleTimeout)
 	// Stamp the PostHog team id (config-snapshot read, no I/O) so this
 	// connection's product-analytics events carry a PostHog-native key. Same
 	// resolution the compute meter uses: the connecting user's team, else the

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_FILE_PERSISTENCE   Persist DuckDB to <data_dir>/<username>.duckdb (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_PROCESS_ISOLATION  Enable process isolation (1 or true)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_IDLE_TIMEOUT       Connection idle timeout (e.g., 30m, 1h, -1 to disable)\n")
+		fmt.Fprintf(os.Stderr, "  DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX  Maximum client-requested idle timeout; unset disables client overrides\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_SESSION_INIT_TIMEOUT  Session startup metadata/probe timeout (default: 10s)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_MEMORY_LIMIT       DuckDB memory_limit per session (e.g., 4GB)\n")
 		fmt.Fprintf(os.Stderr, "  DUCKGRES_THREADS            DuckDB threads per session\n")

--- a/server/client_idle_timeout.go
+++ b/server/client_idle_timeout.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/posthog/duckgres/transpiler/transform"
+)
+
+// ClientIdleTimeoutGUCName is the connect-time option a client may use to
+// request a longer idle timeout, for example:
+//
+//	PGOPTIONS='-c duckgres.idle_timeout=15m' psql ...
+//
+// It is deliberately a Duckgres-specific option: PostgreSQL's
+// idle_session_timeout has different semantics and is currently ignored for
+// compatibility. This option is accepted only when the operator sets a
+// positive Config.ClientIdleTimeoutMax.
+const ClientIdleTimeoutGUCName = "duckgres.idle_timeout"
+
+// ValidateClientIdleTimeoutOption parses a client-requested idle timeout and
+// enforces the operator-configured maximum. A non-positive maximum disables
+// the feature. Client values must be positive: clients cannot disable idle
+// reaping and retain a worker indefinitely.
+func ValidateClientIdleTimeoutOption(raw string, max time.Duration) (time.Duration, error) {
+	if max <= 0 {
+		return 0, invalidClientIdleTimeout("client idle-timeout overrides are disabled")
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil || d <= 0 {
+		return 0, invalidClientIdleTimeout("duckgres.idle_timeout must be a positive Go duration")
+	}
+	if d > max {
+		return 0, invalidClientIdleTimeout(fmt.Sprintf("duckgres.idle_timeout must not exceed %s", max))
+	}
+	return d, nil
+}
+
+func invalidClientIdleTimeout(message string) error {
+	return &transform.CodedError{Code: "22023", Message: message}
+}
+
+func (c *clientConn) applyStartupIdleTimeout(raw string) error {
+	d, err := ValidateClientIdleTimeoutOption(raw, c.server.cfg.ClientIdleTimeoutMax)
+	if err != nil {
+		return err
+	}
+	c.idleTimeout = d
+	return nil
+}
+
+func (c *clientConn) effectiveIdleTimeout() time.Duration {
+	if c.idleTimeout > 0 {
+		return c.idleTimeout
+	}
+	return c.server.cfg.IdleTimeout
+}

--- a/server/client_idle_timeout_test.go
+++ b/server/client_idle_timeout_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// Client-controlled idle timeout is a connect-time escape hatch from the
+// control-plane default. It is deliberately bounded by an operator cap: a
+// client must never be able to pin a worker indefinitely by requesting an
+// unbounded, zero, or negative duration.
+func TestValidateClientIdleTimeoutOption(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		max     time.Duration
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "valid below cap", raw: "1m", max: 5 * time.Minute, want: time.Minute},
+		{name: "valid at cap", raw: "5m", max: 5 * time.Minute, want: 5 * time.Minute},
+		{name: "valid whitespace", raw: " 90s ", max: 5 * time.Minute, want: 90 * time.Second},
+		{name: "feature disabled by zero cap", raw: "1m", max: 0, wantErr: true},
+		{name: "feature disabled by negative cap", raw: "1m", max: -time.Second, wantErr: true},
+		{name: "over cap", raw: "6m", max: 5 * time.Minute, wantErr: true},
+		{name: "zero rejected", raw: "0s", max: 5 * time.Minute, wantErr: true},
+		{name: "negative rejected", raw: "-1s", max: 5 * time.Minute, wantErr: true},
+		{name: "invalid duration rejected", raw: "forever", max: 5 * time.Minute, wantErr: true},
+		{name: "empty rejected", raw: "", max: 5 * time.Minute, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateClientIdleTimeoutOption(tt.raw, tt.max)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateClientIdleTimeoutOption(%q, %s) = %s, nil error; want SQLSTATE 22023 rejection", tt.raw, tt.max, got)
+				}
+				var coded interface{ SQLState() string }
+				if !errors.As(err, &coded) || coded.SQLState() != "22023" {
+					t.Fatalf("ValidateClientIdleTimeoutOption(%q, %s) error = %v; want SQLSTATE 22023", tt.raw, tt.max, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateClientIdleTimeoutOption(%q, %s): %v", tt.raw, tt.max, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ValidateClientIdleTimeoutOption(%q, %s) = %s, want %s", tt.raw, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/conn.go
+++ b/server/conn.go
@@ -253,6 +253,11 @@ type clientConn struct {
 	// conn_s3_cache.go.
 	s3CacheOff bool
 
+	// idleTimeout is a validated, connect-time client override. Zero means use
+	// the server default. It is initialized before the message loop starts and
+	// never changes, so it needs no synchronization.
+	idleTimeout time.Duration
+
 	// Provisioned worker pod size for compute-usage billing (remote/k8s backend
 	// only). Counted in milli-units to avoid truncating a fractional-core or
 	// sub-GiB worker. workerMillicores == 0 means "unknown size" (non-remote /
@@ -1137,6 +1142,12 @@ func (c *clientConn) handleStartup() error {
 		// duckgres.s3_cache only records session state here; the worker-swap
 		// path is control-plane-only.)
 		if opts := ParseStartupOptions(params["options"]); len(opts) > 0 {
+			if v, ok := opts[ClientIdleTimeoutGUCName]; ok {
+				if err := c.applyStartupIdleTimeout(v); err != nil {
+					c.sendError("FATAL", "22023", err.Error())
+					return fmt.Errorf("invalid %s startup option", ClientIdleTimeoutGUCName)
+				}
+			}
 			if v, ok := opts[querySourceGUCName]; ok {
 				if err := c.applyStartupQuerySource(v); err != nil {
 					c.sendError("FATAL", "22023", err.Error())
@@ -1238,8 +1249,8 @@ func (c *clientConn) sendInitialParams() {
 // out, a stalled/abandoned one is reaped after the idle timeout. No-op when the
 // idle timeout is disabled (IdleTimeout <= 0), matching the message loop.
 func (c *clientConn) armIdleReadDeadline() {
-	if c.server.cfg.IdleTimeout > 0 {
-		_ = c.conn.SetReadDeadline(time.Now().Add(c.server.cfg.IdleTimeout))
+	if idleTimeout := c.effectiveIdleTimeout(); idleTimeout > 0 {
+		_ = c.conn.SetReadDeadline(time.Now().Add(idleTimeout))
 	}
 }
 

--- a/server/conn_idle_test.go
+++ b/server/conn_idle_test.go
@@ -87,6 +87,45 @@ func TestMessageLoopIdleTimeoutClosesConnection(t *testing.T) {
 	}
 }
 
+func TestMessageLoopUsesClientIdleTimeoutOverride(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	s := &Server{}
+	InitMinimalServer(s, Config{IdleTimeout: 40 * time.Millisecond, ClientIdleTimeoutMax: time.Second}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cc := &clientConn{
+		server:      s,
+		conn:        serverSide,
+		reader:      bufio.NewReader(serverSide),
+		writer:      bufio.NewWriter(serverSide),
+		ctx:         ctx,
+		cancel:      cancel,
+		idleTimeout: 180 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cc.messageLoop() }()
+
+	// The server default expires at 40ms. The request must keep this session
+	// alive beyond it, then expire according to the bounded client value.
+	select {
+	case err := <-done:
+		t.Fatalf("message loop used the server default instead of client override: %v", err)
+	case <-time.After(90 * time.Millisecond):
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on idle close, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("messageLoop did not close on client idle timeout")
+	}
+}
+
 func TestLateCopyFramesPreserveReadyBoundary(t *testing.T) {
 	for _, msgType := range []byte{wire.MsgCopyData, wire.MsgCopyDone, wire.MsgCopyFail} {
 		t.Run(string(msgType), func(t *testing.T) {

--- a/server/exports.go
+++ b/server/exports.go
@@ -279,6 +279,14 @@ func SetConnectionTeamID(cc *clientConn, teamID int64) {
 	}
 }
 
+// SetConnectionIdleTimeout applies a previously validated connect-time client
+// idle-timeout request. The control plane calls this before RunMessageLoop.
+func SetConnectionIdleTimeout(cc *clientConn, timeout time.Duration) {
+	if cc != nil && timeout > 0 {
+		cc.idleTimeout = timeout
+	}
+}
+
 // ConnectionBilling returns the data needed to meter one connection's
 // compute-usage at teardown: the org, the authenticated username (used to
 // resolve the informational team id stamped onto the bucket — the user's own

--- a/server/parent.go
+++ b/server/parent.go
@@ -151,17 +151,18 @@ func (s *Server) spawnChildForTLS(conn net.Conn) (*ChildProcess, error) {
 	// Prepare child configuration
 	// Note: Username is not known yet - child will read it from the startup message after TLS
 	childCfg := ChildConfig{
-		RemoteAddr:       remoteAddr,
-		DataDir:          s.cfg.DataDir,
-		Extensions:       s.cfg.Extensions,
-		IdleTimeout:      int64(s.cfg.IdleTimeout),
-		TLSCertFile:      s.cfg.TLSCertFile,
-		TLSKeyFile:       s.cfg.TLSKeyFile,
-		DuckLake:         s.cfg.DuckLake,
-		Users:            s.cfg.Users, // Pass all users - child will look up after getting username
-		BackendSecretKey: backendSecretKey,
-		ServerStartTime:  processStartTime.UnixNano(),
-		ServerVersion:    processVersion,
+		RemoteAddr:           remoteAddr,
+		DataDir:              s.cfg.DataDir,
+		Extensions:           s.cfg.Extensions,
+		IdleTimeout:          int64(s.cfg.IdleTimeout),
+		ClientIdleTimeoutMax: int64(s.cfg.ClientIdleTimeoutMax),
+		TLSCertFile:          s.cfg.TLSCertFile,
+		TLSKeyFile:           s.cfg.TLSKeyFile,
+		DuckLake:             s.cfg.DuckLake,
+		Users:                s.cfg.Users, // Pass all users - child will look up after getting username
+		BackendSecretKey:     backendSecretKey,
+		ServerStartTime:      processStartTime.UnixNano(),
+		ServerVersion:        processVersion,
 	}
 
 	configJSON, err := json.Marshal(childCfg)

--- a/server/parent_test.go
+++ b/server/parent_test.go
@@ -9,14 +9,15 @@ import (
 
 func TestChildConfigSerialization(t *testing.T) {
 	cfg := ChildConfig{
-		RemoteAddr:       "192.168.1.1:12345",
-		DataDir:          "/data",
-		Extensions:       []string{"ducklake", "json"},
-		IdleTimeout:      int64(10 * time.Minute),
-		TLSCertFile:      "/certs/server.crt",
-		TLSKeyFile:       "/certs/server.key",
-		Users:            map[string]string{"postgres": "secret123"},
-		BackendSecretKey: 12345678,
+		RemoteAddr:           "192.168.1.1:12345",
+		DataDir:              "/data",
+		Extensions:           []string{"ducklake", "json"},
+		IdleTimeout:          int64(10 * time.Minute),
+		ClientIdleTimeoutMax: int64(15 * time.Minute),
+		TLSCertFile:          "/certs/server.crt",
+		TLSKeyFile:           "/certs/server.key",
+		Users:                map[string]string{"postgres": "secret123"},
+		BackendSecretKey:     12345678,
 		DuckLake: DuckLakeConfig{
 			MetadataStore: "postgres:host=localhost",
 			S3Region:      "us-east-1",
@@ -47,6 +48,9 @@ func TestChildConfigSerialization(t *testing.T) {
 	}
 	if cfg2.IdleTimeout != cfg.IdleTimeout {
 		t.Errorf("IdleTimeout mismatch: got %d, want %d", cfg2.IdleTimeout, cfg.IdleTimeout)
+	}
+	if cfg2.ClientIdleTimeoutMax != cfg.ClientIdleTimeoutMax {
+		t.Errorf("ClientIdleTimeoutMax mismatch: got %d, want %d", cfg2.ClientIdleTimeoutMax, cfg.ClientIdleTimeoutMax)
 	}
 	if cfg2.TLSCertFile != cfg.TLSCertFile {
 		t.Errorf("TLSCertFile mismatch: got %q, want %q", cfg2.TLSCertFile, cfg.TLSCertFile)

--- a/server/server.go
+++ b/server/server.go
@@ -215,6 +215,12 @@ type Config struct {
 	// uncleanly. Default: 24 hours. Set to a negative value (e.g., -1) to disable.
 	IdleTimeout time.Duration
 
+	// ClientIdleTimeoutMax is the largest timeout a client may request through
+	// the connect-time duckgres.idle_timeout option. A non-positive value disables
+	// client overrides. This must remain bounded because idle control-plane
+	// sessions retain workers and admission capacity.
+	ClientIdleTimeoutMax time.Duration
+
 	// SessionInitTimeout bounds startup metadata initialization and catalog probes.
 	// Default: 10 seconds.
 	SessionInitTimeout time.Duration

--- a/server/worker.go
+++ b/server/worker.go
@@ -37,9 +37,10 @@ type ChildConfig struct {
 	RemoteAddr string `json:"remote_addr"`
 
 	// Server config
-	DataDir     string   `json:"data_dir"`
-	Extensions  []string `json:"extensions"`
-	IdleTimeout int64    `json:"idle_timeout"` // nanoseconds
+	DataDir              string   `json:"data_dir"`
+	Extensions           []string `json:"extensions"`
+	IdleTimeout          int64    `json:"idle_timeout"`            // nanoseconds
+	ClientIdleTimeoutMax int64    `json:"client_idle_timeout_max"` // nanoseconds
 
 	// TLS config
 	TLSCertFile string `json:"tls_cert_file"`
@@ -292,13 +293,14 @@ func runChildWorker(tcpConn *net.TCPConn, cfg *ChildConfig) int {
 
 	// Create a minimal server config for the worker
 	serverCfg := Config{
-		DataDir:     cfg.DataDir,
-		Extensions:  cfg.Extensions,
-		DuckLake:    cfg.DuckLake,
-		IdleTimeout: time.Duration(cfg.IdleTimeout),
-		TLSCertFile: cfg.TLSCertFile,
-		TLSKeyFile:  cfg.TLSKeyFile,
-		Users:       cfg.Users,
+		DataDir:              cfg.DataDir,
+		Extensions:           cfg.Extensions,
+		DuckLake:             cfg.DuckLake,
+		IdleTimeout:          time.Duration(cfg.IdleTimeout),
+		ClientIdleTimeoutMax: time.Duration(cfg.ClientIdleTimeoutMax),
+		TLSCertFile:          cfg.TLSCertFile,
+		TLSKeyFile:           cfg.TLSKeyFile,
+		Users:                cfg.Users,
 	}
 
 	// Reconstruct parent server start time for uptime() macro.


### PR DESCRIPTION
## Summary

- add an opt-in, bounded `duckgres.idle_timeout` connect-time option for PostgreSQL clients
- configure the maximum request with `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX`; unset keeps client overrides disabled
- propagate the cap through process-isolated workers and document the `PGOPTIONS` usage

## Why

Control-plane sessions are reaped after the short server idle timeout to release worker capacity. Interactive clients need an operator-controlled way to request a longer session lifetime without allowing unbounded worker retention.

## Validation

- `just test-unit`
- `just lint`
