### PR TITLE
perf(cache-proxy): O(1) LRU index instead of linear scans under the cache mutex

### DIFF
--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"container/list"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -70,14 +71,22 @@ func CacheKey(url, rangeHeader string) string {
 }
 
 // DiskCache manages cached S3 responses on local NVMe storage with LRU eviction.
+//
+// Every operation below holds the one mutex, and a production node tracks
+// hundreds of thousands of entries — so each critical section must be O(1).
+// The previous slice-based order ([]cacheEntry with linear scans and splices)
+// put ~half the proxy's CPU into LRU bookkeeping under this lock, serializing
+// all cache traffic behind it.
 type DiskCache struct {
 	dir         string
 	maxBytes    int64
 	currentSize int64
 
 	mu sync.Mutex
-	// access order: most recently used at the end
-	order []cacheEntry
+	// order is the access list: least recently used at the front, most recent
+	// at the back. index maps a key to its element for O(1) touch/drop.
+	order *list.List
+	index map[string]*list.Element
 }
 
 type cacheEntry struct {
@@ -121,6 +130,8 @@ func NewDiskCache(dir string, maxPercent int) (*DiskCache, error) {
 	dc := &DiskCache{
 		dir:      dir,
 		maxBytes: maxBytes,
+		order:    list.New(),
+		index:    make(map[string]*list.Element),
 	}
 
 	// Scan existing cache entries
@@ -134,15 +145,13 @@ func (c *DiskCache) scanExisting() {
 	if err != nil {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+	// Only count real cache entries — the .tmp dir's contents and any
+	// stray non-key files must not enter the LRU accounting.
+	var found []cacheEntry
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		// Only count real cache entries — the .tmp dir's contents and any
-		// stray non-key files must not enter the LRU accounting.
 		if !IsValidCacheKey(e.Name()) {
 			continue
 		}
@@ -150,12 +159,24 @@ func (c *DiskCache) scanExisting() {
 		if err != nil {
 			continue
 		}
-		c.order = append(c.order, cacheEntry{
+		found = append(found, cacheEntry{
 			key:        e.Name(),
 			size:       info.Size(),
 			lastAccess: info.ModTime(),
 		})
-		c.currentSize += info.Size()
+	}
+	// The access list must start in recency order (front = oldest) or the
+	// first evictions after a restart would remove arbitrary entries.
+	sort.Slice(found, func(i, j int) bool {
+		return found[i].lastAccess.Before(found[j].lastAccess)
+	})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range found {
+		entry := found[i]
+		c.index[entry.key] = c.order.PushBack(&entry)
+		c.currentSize += entry.size
 	}
 	cacheSizeBytes.Set(float64(c.currentSize))
 }
@@ -198,7 +219,7 @@ func (c *DiskCache) Put(key string, data []byte) error {
 
 	c.mu.Lock()
 	// Evict until we have space
-	for c.currentSize+size > c.maxBytes && len(c.order) > 0 {
+	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
 		c.evictOldest()
 	}
 	c.mu.Unlock()
@@ -209,13 +230,7 @@ func (c *DiskCache) Put(key string, data []byte) error {
 	}
 
 	c.mu.Lock()
-	c.order = append(c.order, cacheEntry{
-		key:        key,
-		size:       size,
-		lastAccess: time.Now(),
-	})
-	c.currentSize += size
-	cacheSizeBytes.Set(float64(c.currentSize))
+	c.addLocked(key, size)
 	c.mu.Unlock()
 
 	return nil
@@ -251,7 +266,7 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	// (the rename below overwrites it) and evict to make room.
 	c.mu.Lock()
 	c.dropLocked(key)
-	for c.currentSize+size > c.maxBytes && len(c.order) > 0 {
+	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
 		c.evictOldest()
 	}
 	c.mu.Unlock()
@@ -263,19 +278,12 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	}
 
 	c.mu.Lock()
-	// dropLocked again before appending: in production singleFlight serializes
-	// writes per key so the earlier drop is enough, but guarding here keeps the
-	// "one entry per key" invariant (and currentSize) correct even if some
-	// future caller writes the same key concurrently — a duplicate entry would
-	// otherwise permanently inflate currentSize.
-	c.dropLocked(key)
-	c.order = append(c.order, cacheEntry{
-		key:        key,
-		size:       size,
-		lastAccess: time.Now(),
-	})
-	c.currentSize += size
-	cacheSizeBytes.Set(float64(c.currentSize))
+	// addLocked drops any existing entry first: in production singleFlight
+	// serializes writes per key so the earlier drop is enough, but the guard
+	// keeps the "one entry per key" invariant (and currentSize) correct even
+	// if some future caller writes the same key concurrently — a duplicate
+	// entry would otherwise permanently inflate currentSize.
+	c.addLocked(key, size)
 	c.mu.Unlock()
 
 	return size, nil
@@ -317,47 +325,58 @@ func (c *DiskCache) openFile(key string) (io.ReadCloser, int64, bool) {
 	return f, info.Size(), true
 }
 
+// touchLocked marks key as most recently used. No-op if the key isn't
+// tracked. Caller holds c.mu.
 func (c *DiskCache) touchLocked(key string) {
-	for i := range c.order {
-		if c.order[i].key == key {
-			c.order[i].lastAccess = time.Now()
-			// Move to end (most recent)
-			entry := c.order[i]
-			c.order = append(c.order[:i], c.order[i+1:]...)
-			c.order = append(c.order, entry)
-			return
-		}
+	el, ok := c.index[key]
+	if !ok {
+		return
 	}
+	el.Value.(*cacheEntry).lastAccess = time.Now()
+	c.order.MoveToBack(el)
 }
 
 // dropLocked removes any accounting for key (used when an overwrite is about to
 // replace the file under it) so currentSize doesn't double-count. No-op if the
 // key isn't tracked. Caller holds c.mu.
 func (c *DiskCache) dropLocked(key string) {
-	for i := range c.order {
-		if c.order[i].key == key {
-			c.currentSize -= c.order[i].size
-			c.order = append(c.order[:i], c.order[i+1:]...)
-			return
-		}
-	}
-}
-
-func (c *DiskCache) evictOldest() {
-	if len(c.order) == 0 {
+	el, ok := c.index[key]
+	if !ok {
 		return
 	}
+	c.currentSize -= el.Value.(*cacheEntry).size
+	c.order.Remove(el)
+	delete(c.index, key)
+}
 
-	// Sort by last access, evict the oldest
-	sort.Slice(c.order, func(i, j int) bool {
-		return c.order[i].lastAccess.Before(c.order[j].lastAccess)
+// addLocked records a freshly written entry as most recently used, replacing
+// any prior entry for the key so "one entry per key" (and currentSize) holds.
+// Caller holds c.mu.
+func (c *DiskCache) addLocked(key string, size int64) {
+	c.dropLocked(key)
+	c.index[key] = c.order.PushBack(&cacheEntry{
+		key:        key,
+		size:       size,
+		lastAccess: time.Now(),
 	})
+	c.currentSize += size
+	cacheSizeBytes.Set(float64(c.currentSize))
+}
 
-	oldest := c.order[0]
+// evictOldest removes the least recently used entry. The list front is the
+// LRU entry by construction: adds and touches always move entries to the
+// back, and scanExisting seeds the list in recency order.
+func (c *DiskCache) evictOldest() {
+	front := c.order.Front()
+	if front == nil {
+		return
+	}
+	oldest := front.Value.(*cacheEntry)
 	path := filepath.Join(c.dir, oldest.key)
 	_ = os.Remove(path)
 	c.currentSize -= oldest.size
-	c.order = c.order[1:]
+	c.order.Remove(front)
+	delete(c.index, oldest.key)
 	cacheEvictionsTotal.Inc()
 	cacheSizeBytes.Set(float64(c.currentSize))
 }

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"container/list"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -276,8 +279,8 @@ func TestPutStreamErrorMidStream(t *testing.T) {
 	if c.currentSize != 0 {
 		t.Errorf("currentSize = %d after failed stream, want 0", c.currentSize)
 	}
-	if len(c.order) != 0 {
-		t.Errorf("order has %d entries after failed stream, want 0", len(c.order))
+	if c.order.Len() != 0 {
+		t.Errorf("order has %d entries after failed stream, want 0", c.order.Len())
 	}
 	if left := tmpDirEntries(t, c); left != 0 {
 		t.Errorf("temp dir has %d leftover files after failed stream, want 0", left)
@@ -301,13 +304,16 @@ func TestPutStreamOverwrite(t *testing.T) {
 		t.Errorf("currentSize = %d after overwrite, want 40 (not 140)", c.currentSize)
 	}
 	count := 0
-	for _, e := range c.order {
-		if e.key == key {
+	for el := c.order.Front(); el != nil; el = el.Next() {
+		if el.Value.(*cacheEntry).key == key {
 			count++
 		}
 	}
 	if count != 1 {
 		t.Errorf("key appears %d times in order, want exactly 1", count)
+	}
+	if len(c.index) != c.order.Len() {
+		t.Errorf("index has %d entries, order has %d — must match", len(c.index), c.order.Len())
 	}
 	r, size, ok := c.Open(key)
 	if !ok || size != 40 {
@@ -367,5 +373,95 @@ func TestOpenCountsHitOpenFileDoesNot(t *testing.T) {
 	_ = r.Close()
 	if after := counterValue(t, cacheHitsTotal); after != before+1 {
 		t.Errorf("Open changed hit counter by %v, want 1", after-before)
+	}
+}
+
+// TestEvictionRespectsTouchRecency locks in true LRU semantics across the
+// rewrite: touching an old entry must move it out of eviction's path, so the
+// victim is the least recently *used* entry, not the least recently written.
+func TestEvictionRespectsTouchRecency(t *testing.T) {
+	c := newTestCache(t)
+	c.maxBytes = 100
+
+	a, b := strings.Repeat("a", 64), strings.Repeat("b", 64)
+	if err := c.Put(a, make([]byte, 45)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put(b, make([]byte, 45)); err != nil {
+		t.Fatal(err)
+	}
+	// Touch a so b becomes the LRU entry.
+	if _, ok := c.Get(a); !ok {
+		t.Fatal("Get(a) should hit")
+	}
+	if err := c.Put(strings.Repeat("d", 64), make([]byte, 45)); err != nil {
+		t.Fatal(err)
+	}
+	if !c.Has(a) {
+		t.Error("recently touched entry was evicted; eviction must follow access recency")
+	}
+	if c.Has(b) {
+		t.Error("least recently used entry survived eviction")
+	}
+}
+
+// BenchmarkTouchLargeCache documents why the LRU must be O(1): a production
+// node tracks ~285k entries (285GB at 1MiB blocks), and every cache operation
+// touches under one mutex. The prior slice implementation scanned and spliced
+// the whole slice per touch, putting ~half the proxy's CPU into bookkeeping.
+func BenchmarkTouchLargeCache(b *testing.B) {
+	c := &DiskCache{order: list.New(), index: make(map[string]*list.Element)}
+	keys := make([]string, 285000)
+	for i := range keys {
+		keys[i] = CacheKey(fmt.Sprintf("http://bucket/f%d.parquet", i), "bytes=0-1")
+		c.addLocked(keys[i], 1)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.mu.Lock()
+		c.touchLocked(keys[i%len(keys)])
+		c.mu.Unlock()
+	}
+}
+
+// TestScanExistingSeedsRecencyOrder covers eviction correctness after a
+// restart: scanExisting must seed the access list in mtime order, because
+// evictOldest trusts the list front to be the LRU entry. If the seed order
+// were arbitrary, the first evictions after every proxy restart would remove
+// arbitrary entries instead of the oldest.
+func TestScanExistingSeedsRecencyOrder(t *testing.T) {
+	dir := t.TempDir()
+	old, mid, recent := strings.Repeat("a", 64), strings.Repeat("b", 64), strings.Repeat("c", 64)
+	now := time.Now()
+	// Write in an order unrelated to the mtimes we stamp.
+	for _, e := range []struct {
+		key string
+		age time.Duration
+	}{{mid, 2 * time.Hour}, {recent, time.Hour}, {old, 3 * time.Hour}} {
+		path := dir + "/" + e.key
+		if err := os.WriteFile(path, make([]byte, 45), 0o640); err != nil {
+			t.Fatal(err)
+		}
+		ts := now.Add(-e.age)
+		if err := os.Chtimes(path, ts, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := NewDiskCache(dir, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 135 bytes are resident; a fourth 45-byte entry against a 170-byte cap
+	// forces exactly one eviction — which must be the oldest-mtime entry.
+	c.maxBytes = 170
+
+	if err := c.Put(strings.Repeat("d", 64), make([]byte, 45)); err != nil {
+		t.Fatal(err)
+	}
+	if c.Has(old) {
+		t.Error("oldest-mtime entry survived post-restart eviction")
+	}
+	if !c.Has(recent) || !c.Has(mid) {
+		t.Error("newer entries were evicted before the oldest")
 	}
 }


### PR DESCRIPTION
## Problem

A 30-second CPU profile of a loaded production cache proxy (pprof, added in #1045) localized **~48% of the proxy's total CPU** to LRU bookkeeping: `runtime.memequal` 39% flat, inside `DiskCache.dropLocked` (30% cum) and `touchLocked` (18.5% cum).

The access order was a `[]cacheEntry`. Every touch (each local block serve, each peer `/cache/get` serve, each `Get`), every drop, and every overwrite did a **linear scan with string compares plus a slice splice — under the single cache mutex**. A production node tracks ~285k entries at 1MiB blocks, so each cache operation cost milliseconds and all cache traffic serialized behind one effectively single-core queue. `evictOldest` additionally ran a full `sort.Slice` per evicted entry inside the eviction loop.

This is the mechanism behind loaded peer-serve latencies of hundreds of milliseconds on nodes with abundant idle CPU: operations queue on the mutex, not on any resource that is actually scarce. It also means the 8MiB→1MiB block-size change multiplied the per-operation cost ~8× via entry count.

## Change

Replace the slice with a doubly-linked access list plus key index (`container/list` + `map[string]*list.Element`):

- `touchLocked` / `dropLocked` / `addLocked` / `evictOldest` are all O(1)
- `evictOldest` trusts the list front to be the LRU entry (maintained by construction); `scanExisting` therefore seeds the list in mtime order so post-restart evictions remove the oldest entries
- Behavior, LRU semantics, size accounting, and metrics are unchanged

Benchmark at production scale (285k entries): **~49ns per touch**, versus milliseconds for the previous scan+splice.

## Testing

- Full package suite passes (`-race` too, except the pre-existing `TestHandleConnectLogsOpenAndClose` flake, which reproduces on unmodified main)
- New `TestEvictionRespectsTouchRecency`: touching an entry must redirect eviction to the true LRU victim
- New `TestScanExistingSeedsRecencyOrder`: post-restart evictions must follow mtime order (the invariant that moved from evictOldest's lazy sort into the scan)
- `BenchmarkTouchLargeCache` documents the O(1) requirement at 285k entries