### PR TITLE
feat(cache): add passthrough S3 cache mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,7 +516,7 @@ unreliable; secrets are consulted per request). Instance-global secret + one
 session per worker = session-scoped in effect. Invariants:
 
 - **State follows the worker, never leads it.** The session flag
-  (`clientConn.s3CacheOff` / `clientConn.s3CachePassthrough`) flips only after the worker swap succeeds; a
+  (`clientConn.s3CacheMode`) flips only after the worker swap succeeds; a
   failed swap fails the SET (`XX000`) / the batch / the connect (startup
   option), so `SHOW` can never report a transport the worker isn't using.
 - **A bypass must never leak into the org's next session.** `CreateSession`
@@ -525,7 +525,7 @@ session per worker = session-scoped in effect. Invariants:
   best-effort. Both no-op unless a bypass is actually in effect.
 - **Credential rotation respects the flag.** The hot-idle/mid-session refresh
   (`reuseExistingActivation`) rebuilds the secret with or without the proxy
-  transport according to `s3CacheBypassed`; all secret rebuilds serialize on
+  transport according to `s3CacheMode`; all secret rebuilds serialize on
   `secretSwapMu` so the last write always matches the flag. (Without this, an
   hourly STS rotation silently re-enables the cache mid-benchmark — the
   inverse of the 2026-07-17 incident.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,23 +496,27 @@ release lets shutdown kill live work); `reapIdle` releases tokens stranded by a
 
 ## Per-Session S3 Cache Bypass (`duckgres.s3_cache`, remote backend)
 
-`SET duckgres.s3_cache = on|off` (default `on`; also a `-c` startup option)
-lets a session bypass the node-local S3 cache-proxy DaemonSet — for cold-read
-benchmarking and ruling the cache out of correctness/staleness questions.
+`SET duckgres.s3_cache = on|off|passthrough` (default `on`; also a `-c`
+startup option) controls the node-local S3 cache-proxy DaemonSet. `off`
+bypasses its cache transport for cold-read benchmarking; `passthrough` keeps
+requests flowing through cache-proxy while skipping its cache, so cache-off
+workloads retain per-request proxy instrumentation.
 Mechanism: the CP intercepts the duckgres-namespaced GUC (never forwarded to
 DuckDB) and, on every state flip, calls the worker's `SetSessionS3Cache`
-action (`flightclient.FlightExecutor.SetS3CacheEnabled` →
-`SessionPool.SetS3CacheEnabled`), which rebuilds the `ducklake_s3` secret:
+action (`flightclient.FlightExecutor.SetS3CacheMode` →
+`SessionPool.SetS3CacheMode`), which rebuilds the `ducklake_s3` secret:
 `off` = the org's native HTTPS transport, so httpfs CONNECT-tunnels through
 the proxy as opaque TLS (no cache reads/fills — the deliberate, reversible
-form of the mw-prod-us 2026-07-17 incident); `on` = the
-`overrideS3EndpointForCacheProxy` transport. Global `http_proxy` is never
-touched (post-attach propagation to DuckLake subcatalogs is unreliable;
-secrets are consulted per request). Instance-global secret + one session per
-worker = session-scoped in effect. Invariants:
+form of the mw-prod-us 2026-07-17 incident); `passthrough` = the same
+`overrideS3EndpointForCacheProxy` transport as `on`, with a worker-local
+marker that makes cache-proxy use `forwardUncached` and strips that marker
+before it reaches S3; `on` = the normal caching transport. Global `http_proxy`
+is never touched (post-attach propagation to DuckLake subcatalogs is
+unreliable; secrets are consulted per request). Instance-global secret + one
+session per worker = session-scoped in effect. Invariants:
 
 - **State follows the worker, never leads it.** The session flag
-  (`clientConn.s3CacheOff`) flips only after the worker swap succeeds; a
+  (`clientConn.s3CacheOff` / `clientConn.s3CachePassthrough`) flips only after the worker swap succeeds; a
   failed swap fails the SET (`XX000`) / the batch / the connect (startup
   option), so `SHOW` can never report a transport the worker isn't using.
 - **A bypass must never leak into the org's next session.** `CreateSession`
@@ -535,7 +539,7 @@ worker = session-scoped in effect. Invariants:
   still pending, so it can neither lie nor spend a pod needlessly. See the
   Exploratory Worker Tier section.
 - **Closed enum, validated on every set path** (`transform.NormalizeS3Cache`):
-  PostgreSQL boolean spellings, normalized to on/off; anything else is `22023`
+  PostgreSQL boolean spellings, normalized to on/off, plus `passthrough`; anything else is `22023`
   (simple/batched SET, extended Parse, and the startup option — which the CP
   validates BEFORE acquiring a worker). The rejection never echoes the value.
 - **Scope: remote/k8s shared-warm workers with a cache proxy.** Elsewhere

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -265,6 +265,11 @@ var hopByHop = map[string]bool{
 	"upgrade":             true,
 }
 
+// cachePassthroughHeader is added only by duckgres's worker-local router.
+// It selects the proxy's observable-but-uncached request path and is stripped
+// before the origin request so it cannot affect S3 or a SigV4 request.
+const cachePassthroughHeader = "X-Duckgres-Cache-Passthrough"
+
 // HandleProxy handles forward HTTP proxy requests from DuckDB httpfs.
 // Expects absolute-form URIs (scheme + host + path in the request-line).
 func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
@@ -287,6 +292,10 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Non-GET (HEAD, etc.) is never cached — forward and return.
 	if r.Method != http.MethodGet {
+		p.forwardUncached(w, r)
+		return
+	}
+	if r.Header.Get(cachePassthroughHeader) == "true" {
 		p.forwardUncached(w, r)
 		return
 	}
@@ -726,6 +735,10 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	forwardStart := time.Now()
 	ctx, span := proxyTracer.Start(r.Context(), "cache.forward", trace.WithAttributes(requestSpanAttrs(r)...))
 	defer span.End()
+	passthrough := r.Header.Get(cachePassthroughHeader) == "true"
+	if passthrough {
+		span.SetAttributes(attribute.Bool("duckgres.cache.passthrough", true))
+	}
 	r = r.WithContext(ctx)
 
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
@@ -742,7 +755,7 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	req.TransferEncoding = r.TransferEncoding
 	req.Trailer = r.Trailer
 	for k, vv := range r.Header {
-		if hopByHop[strings.ToLower(k)] {
+		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, cachePassthroughHeader) {
 			continue
 		}
 		for _, v := range vv {

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -155,6 +155,34 @@ func TestHandleProxyGETMissThenHit(t *testing.T) {
 	}
 }
 
+func TestHandleProxyPassthroughGETSkipsCacheAndStripsMarker(t *testing.T) {
+	proxy := newTestProxy(t)
+	var originCalls atomic.Int32
+	var markerReachedOrigin atomic.Bool
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		originCalls.Add(1)
+		markerReachedOrigin.Store(r.Header.Get(cachePassthroughHeader) != "")
+		_, _ = w.Write([]byte("uncached"))
+	})
+
+	headers := http.Header{cachePassthroughHeader: []string{"true"}}
+	for range 2 {
+		rec := doForwardProxyRequest(proxy, http.MethodGet, originURL+"/bucket/file.parquet", headers)
+		if rec.Code != http.StatusOK || rec.Body.String() != "uncached" {
+			t.Fatalf("passthrough response = %d %q, want 200 uncached", rec.Code, rec.Body.String())
+		}
+	}
+	if got := originCalls.Load(); got != 2 {
+		t.Fatalf("origin calls = %d, want 2 because passthrough must not cache", got)
+	}
+	if markerReachedOrigin.Load() {
+		t.Fatal("passthrough marker reached origin")
+	}
+	if _, _, ok := proxy.store.Open(CacheKey(originURL+"/bucket/file.parquet", "")); ok {
+		t.Fatal("passthrough request populated the cache")
+	}
+}
+
 func TestHandleProxyHEADForwardedUncached(t *testing.T) {
 	proxy := newTestProxy(t)
 

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/transpiler/transform"
 )
 
 // ActivationPayload carries the tenant-specific runtime that is delivered to a
@@ -152,8 +153,7 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	}
 	// A fresh activation always attaches with the cache-proxy transport
 	// (overrideS3EndpointForCacheProxy above), so the bypass flag starts clean.
-	p.s3CacheBypassed = false
-	p.s3CachePassthrough = false
+	p.s3CacheMode = transform.S3CacheOn
 	if p.cacheRouter != nil {
 		p.cacheRouter.setPassthrough(false)
 	}
@@ -192,7 +192,8 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 // retains the cache-proxy transport while instructing the worker-local router
 // to forward each request without cache reads or fills.
 func (p *SessionPool) SetS3CacheMode(mode string) error {
-	if mode != "on" && mode != "off" && mode != "passthrough" {
+	requested := transform.S3CacheMode(mode)
+	if requested != transform.S3CacheOn && requested != transform.S3CacheOff && requested != transform.S3CachePassthrough {
 		return fmt.Errorf("invalid s3 cache mode %q", mode)
 	}
 	if !p.sharedWarmMode || !cacheEnabled() {
@@ -218,8 +219,7 @@ func (p *SessionPool) SetS3CacheMode(mode string) error {
 		orgID = p.activation.payload.OrgID
 		actDB = p.activation.db
 	}
-	bypassed := p.s3CacheBypassed
-	passthrough := p.s3CachePassthrough
+	currentMode := p.currentS3CacheModeLocked()
 	refreshDB := p.controlDB
 	refreshFn := p.refreshS3Secret
 	sem := p.duckLakeSem
@@ -228,7 +228,7 @@ func (p *SessionPool) SetS3CacheMode(mode string) error {
 	if !activated {
 		return fmt.Errorf("worker is not activated")
 	}
-	if bypassed == (mode == "off") && passthrough == (mode == "passthrough") {
+	if currentMode == requested {
 		return nil
 	}
 	if cfg.ObjectStore == "" {
@@ -241,7 +241,7 @@ func (p *SessionPool) SetS3CacheMode(mode string) error {
 	if refreshFn == nil {
 		refreshFn = server.RefreshS3Secret
 	}
-	if mode != "off" {
+	if requested != transform.S3CacheOff {
 		p.overrideS3EndpointForCacheProxy(&cfg)
 	}
 	if err := refreshFn(refreshDB, cfg, sem); err != nil {
@@ -249,13 +249,12 @@ func (p *SessionPool) SetS3CacheMode(mode string) error {
 	}
 
 	p.mu.Lock()
-	p.s3CacheBypassed = mode == "off"
-	p.s3CachePassthrough = mode == "passthrough"
+	p.s3CacheMode = requested
 	if p.cacheRouter != nil {
-		p.cacheRouter.setPassthrough(mode == "passthrough")
+		p.cacheRouter.setPassthrough(requested == transform.S3CachePassthrough)
 	}
 	p.mu.Unlock()
-	slog.Info("Swapped tenant S3 secret transport.", "org", orgID, "s3_cache_mode", mode)
+	slog.Info("Swapped tenant S3 secret transport.", "org", orgID, "s3_cache_mode", requested)
 	return nil
 }
 
@@ -356,8 +355,8 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			// off`): then the rebuild must keep the native HTTPS transport, or
 			// a mid-session credential rotation would silently re-route the
 			// session through the cache. secretSwapMu serializes this rebuild
-			// against SetS3CacheEnabled so the secret always matches
-			// s3CacheBypassed — and it is held (via defer) all the way through
+			// against SetS3CacheMode so the secret always matches s3CacheMode —
+			// and it is held (via defer) all the way through
 			// the Phase 3 payload commit below: released any earlier, a toggle
 			// could sneak in, read the not-yet-committed OLD payload, and
 			// last-write the secret with the OLD (soon-to-expire) STS creds
@@ -369,10 +368,10 @@ func (p *SessionPool) reuseExistingActivation(payload ActivationPayload) bool {
 			p.secretSwapMu.Lock()
 			defer p.secretSwapMu.Unlock()
 			p.mu.RLock()
-			bypassed := p.s3CacheBypassed
+			cacheMode := p.currentS3CacheModeLocked()
 			p.mu.RUnlock()
 			refreshCfg := payload.DuckLake
-			if !bypassed {
+			if cacheMode != transform.S3CacheOff {
 				p.overrideS3EndpointForCacheProxy(&refreshCfg)
 			}
 			if err := refreshFn(refreshDB, refreshCfg, sem); err != nil {

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -153,6 +153,10 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 	// A fresh activation always attaches with the cache-proxy transport
 	// (overrideS3EndpointForCacheProxy above), so the bypass flag starts clean.
 	p.s3CacheBypassed = false
+	p.s3CachePassthrough = false
+	if p.cacheRouter != nil {
+		p.cacheRouter.setPassthrough(false)
+	}
 	p.ownerEpoch = payload.OwnerEpoch
 	p.ownerCPInstanceID = payload.CPInstanceID
 	p.workerID = payload.WorkerID
@@ -177,6 +181,20 @@ func (p *SessionPool) activateTenant(payload ActivationPayload) error {
 // not a shared-warm tenant worker (the proxy transport is applied only by
 // tenant activation).
 func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
+	mode := "off"
+	if enabled {
+		mode = "on"
+	}
+	return p.SetS3CacheMode(mode)
+}
+
+// SetS3CacheMode applies the cache mode for the active session. Passthrough
+// retains the cache-proxy transport while instructing the worker-local router
+// to forward each request without cache reads or fills.
+func (p *SessionPool) SetS3CacheMode(mode string) error {
+	if mode != "on" && mode != "off" && mode != "passthrough" {
+		return fmt.Errorf("invalid s3 cache mode %q", mode)
+	}
 	if !p.sharedWarmMode || !cacheEnabled() {
 		return nil
 	}
@@ -201,6 +219,7 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 		actDB = p.activation.db
 	}
 	bypassed := p.s3CacheBypassed
+	passthrough := p.s3CachePassthrough
 	refreshDB := p.controlDB
 	refreshFn := p.refreshS3Secret
 	sem := p.duckLakeSem
@@ -209,7 +228,7 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 	if !activated {
 		return fmt.Errorf("worker is not activated")
 	}
-	if bypassed == !enabled {
+	if bypassed == (mode == "off") && passthrough == (mode == "passthrough") {
 		return nil
 	}
 	if cfg.ObjectStore == "" {
@@ -222,17 +241,21 @@ func (p *SessionPool) SetS3CacheEnabled(enabled bool) error {
 	if refreshFn == nil {
 		refreshFn = server.RefreshS3Secret
 	}
-	if enabled {
+	if mode != "off" {
 		p.overrideS3EndpointForCacheProxy(&cfg)
 	}
 	if err := refreshFn(refreshDB, cfg, sem); err != nil {
-		return fmt.Errorf("swap S3 secret transport (s3_cache=%v): %w", enabled, err)
+		return fmt.Errorf("swap S3 secret transport (s3_cache=%s): %w", mode, err)
 	}
 
 	p.mu.Lock()
-	p.s3CacheBypassed = !enabled
+	p.s3CacheBypassed = mode == "off"
+	p.s3CachePassthrough = mode == "passthrough"
+	if p.cacheRouter != nil {
+		p.cacheRouter.setPassthrough(mode == "passthrough")
+	}
 	p.mu.Unlock()
-	slog.Info("Swapped tenant S3 secret transport.", "org", orgID, "s3_cache_enabled", enabled)
+	slog.Info("Swapped tenant S3 secret transport.", "org", orgID, "s3_cache_mode", mode)
 	return nil
 }
 

--- a/duckdbservice/cache_proxy_router.go
+++ b/duckdbservice/cache_proxy_router.go
@@ -50,6 +50,9 @@ type cacheProxyRouter struct {
 
 	mu   sync.RWMutex
 	mode cacheProxyMode
+	// passthrough marks daemon-bound requests so cache-proxy records and
+	// forwards them but never serves from or writes to its cache.
+	passthrough bool
 }
 
 type cacheProxySupervisorConfig struct {
@@ -154,6 +157,20 @@ func (r *cacheProxyRouter) setMode(mode cacheProxyMode) {
 	}
 }
 
+const cacheProxyPassthroughHeader = "X-Duckgres-Cache-Passthrough"
+
+func (r *cacheProxyRouter) setPassthrough(enabled bool) {
+	r.mu.Lock()
+	r.passthrough = enabled
+	r.mu.Unlock()
+}
+
+func (r *cacheProxyRouter) isPassthrough() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.passthrough
+}
+
 func recordCacheProxyMode(mode cacheProxyMode) {
 	for _, candidate := range []cacheProxyMode{cacheProxyModeDisabled, cacheProxyModeCached, cacheProxyModeBypassed} {
 		value := 0.0
@@ -170,7 +187,11 @@ func (r *cacheProxyRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if r.Mode() == cacheProxyModeCached {
-		resp, err := r.cacheClient.Do(cloneProxyRequest(req, false))
+		cacheReq := cloneProxyRequest(req, false)
+		if r.isPassthrough() {
+			cacheReq.Header.Set(cacheProxyPassthroughHeader, "true")
+		}
+		resp, err := r.cacheClient.Do(cacheReq)
 		if err == nil {
 			defer func() { _ = resp.Body.Close() }()
 			copyProxyResponse(w, resp)

--- a/duckdbservice/cache_proxy_router_test.go
+++ b/duckdbservice/cache_proxy_router_test.go
@@ -76,6 +76,38 @@ func TestCacheProxyRouterFallsOpenToAuthoritativeSource(t *testing.T) {
 	}
 }
 
+func TestCacheProxyRouterMarksPassthroughRequests(t *testing.T) {
+	var marked atomic.Bool
+	cache := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		marked.Store(r.Header.Get(cacheProxyPassthroughHeader) == "true")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer cache.Close()
+
+	router := newCacheProxyRouter(cache.Listener.Addr().String(), false)
+	router.setMode(cacheProxyModeCached)
+	router.setPassthrough(true)
+	proxy := httptest.NewServer(router)
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get("http://example.com/warehouse/file.parquet")
+	if err != nil {
+		t.Fatalf("GET through router: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !marked.Load() {
+		t.Fatal("cache-bound request was not marked as passthrough")
+	}
+}
+
 // ResponseHeaderTimeout must bound an unavailable upstream without imposing a
 // whole-response deadline: S3 range bodies can legitimately outlive it.
 func TestCacheProxyRouterStreamsPastResponseHeaderTimeout(t *testing.T) {

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -518,7 +518,14 @@ func (h *FlightSQLHandler) doSetSessionS3Cache(body []byte, stream flight.Flight
 	if _, err := h.sessionFromContext(stream.Context()); err != nil {
 		return err
 	}
-	if err := h.pool.SetS3CacheEnabled(req.Enabled); err != nil {
+	mode := req.Mode
+	if mode == "" {
+		mode = "off"
+		if req.Enabled {
+			mode = "on"
+		}
+	}
+	if err := h.pool.SetS3CacheMode(mode); err != nil {
 		return status.Errorf(codes.Internal, "set session s3 cache: %v", err)
 	}
 

--- a/duckdbservice/s3_cache_test.go
+++ b/duckdbservice/s3_cache_test.go
@@ -108,6 +108,28 @@ func TestSetS3CacheEnabledSwapsTransportAndBack(t *testing.T) {
 	}
 }
 
+func TestSetS3CachePassthroughKeepsProxyTransport(t *testing.T) {
+	t.Setenv("DUCKGRES_CACHE_ENABLED", "true")
+	t.Setenv("NODE_IP", "10.0.0.9")
+	pool, calls := s3CacheTestPool(t, "s3://analytics/warehouse/")
+
+	if err := pool.SetS3CacheMode("passthrough"); err != nil {
+		t.Fatalf("SetS3CacheMode(passthrough): %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("passthrough: %d secret rebuilds, want 1", len(*calls))
+	}
+	if got := (*calls)[0]; got.HTTPProxy != "http://10.0.0.9:8080" || got.S3UseSSL || got.S3Endpoint != "s3.us-east-1.amazonaws.com" {
+		t.Fatalf("passthrough must retain the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v S3Endpoint=%q", got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
+	}
+	pool.mu.RLock()
+	passthrough := pool.s3CachePassthrough
+	pool.mu.RUnlock()
+	if !passthrough {
+		t.Fatal("s3CachePassthrough = false after passthrough mode, want true")
+	}
+}
+
 // TestSetS3CacheEnabledNoOpWithoutCacheProxy asserts the toggle degrades to a
 // silent no-op when the node runs no cache proxy (DUCKGRES_CACHE_ENABLED
 // unset): the org transport is already direct, there is nothing to bypass,

--- a/duckdbservice/s3_cache_test.go
+++ b/duckdbservice/s3_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/server"
+	"github.com/posthog/duckgres/transpiler/transform"
 )
 
 // s3CacheTestPool builds a shared-warm pool with a synthetic activation and a
@@ -23,6 +24,7 @@ func s3CacheTestPool(t *testing.T, objectStore string) (*SessionPool, *[]server.
 		startTime:      time.Now(),
 		warmupDone:     make(chan struct{}),
 		sharedWarmMode: true,
+		s3CacheMode:    transform.S3CacheOn,
 		activation: &activatedTenantRuntime{payload: ActivationPayload{
 			OrgID: "analytics",
 			DuckLake: server.DuckLakeConfig{
@@ -75,10 +77,10 @@ func TestSetS3CacheEnabledSwapsTransportAndBack(t *testing.T) {
 			got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
 	}
 	pool.mu.RLock()
-	bypassed := pool.s3CacheBypassed
+	mode := pool.s3CacheMode
 	pool.mu.RUnlock()
-	if !bypassed {
-		t.Fatal("s3CacheBypassed = false after disable, want true")
+	if mode != transform.S3CacheOff {
+		t.Fatalf("s3CacheMode after disable = %q, want off", mode)
 	}
 
 	// Redundant disable: no secret touch.
@@ -101,10 +103,10 @@ func TestSetS3CacheEnabledSwapsTransportAndBack(t *testing.T) {
 			got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
 	}
 	pool.mu.RLock()
-	bypassed = pool.s3CacheBypassed
+	mode = pool.s3CacheMode
 	pool.mu.RUnlock()
-	if bypassed {
-		t.Fatal("s3CacheBypassed = true after enable, want false")
+	if mode != transform.S3CacheOn {
+		t.Fatalf("s3CacheMode after enable = %q, want on", mode)
 	}
 }
 
@@ -123,10 +125,10 @@ func TestSetS3CachePassthroughKeepsProxyTransport(t *testing.T) {
 		t.Fatalf("passthrough must retain the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v S3Endpoint=%q", got.HTTPProxy, got.S3UseSSL, got.S3Endpoint)
 	}
 	pool.mu.RLock()
-	passthrough := pool.s3CachePassthrough
+	mode := pool.s3CacheMode
 	pool.mu.RUnlock()
-	if !passthrough {
-		t.Fatal("s3CachePassthrough = false after passthrough mode, want true")
+	if mode != transform.S3CachePassthrough {
+		t.Fatalf("s3CacheMode after passthrough = %q, want passthrough", mode)
 	}
 }
 
@@ -198,10 +200,10 @@ func TestSetS3CacheEnabledFailurePreservesState(t *testing.T) {
 		t.Fatalf("SetS3CacheEnabled(false) with failing rebuild: err = %v, want boom", err)
 	}
 	pool.mu.RLock()
-	bypassed := pool.s3CacheBypassed
+	mode := pool.s3CacheMode
 	pool.mu.RUnlock()
-	if bypassed {
-		t.Fatal("failed rebuild still flipped s3CacheBypassed")
+	if mode != transform.S3CacheOn {
+		t.Fatalf("failed rebuild changed s3CacheMode to %q, want on", mode)
 	}
 
 	fail = false
@@ -540,7 +542,7 @@ func TestCreateSessionRestoresS3CacheTransport(t *testing.T) {
 					S3UseSSL:    true,
 				},
 			}, db: db},
-			s3CacheBypassed: true, // previous session left the cache off
+			s3CacheMode:     transform.S3CacheOff, // previous session left the cache off
 			refreshS3Secret: refresh,
 		}
 		close(pool.warmupDone)
@@ -567,10 +569,10 @@ func TestCreateSessionRestoresS3CacheTransport(t *testing.T) {
 			t.Fatalf("restore rebuild must carry the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v", got.HTTPProxy, got.S3UseSSL)
 		}
 		pool.mu.RLock()
-		bypassed := pool.s3CacheBypassed
+		mode := pool.s3CacheMode
 		pool.mu.RUnlock()
-		if bypassed {
-			t.Fatal("s3CacheBypassed still true after CreateSession restore")
+		if mode != transform.S3CacheOn {
+			t.Fatalf("s3CacheMode after CreateSession restore = %q, want on", mode)
 		}
 	})
 
@@ -657,9 +659,9 @@ func TestDestroySessionRestoresS3CacheTransport(t *testing.T) {
 		t.Fatalf("destroy restore must carry the cache-proxy transport, got HTTPProxy=%q S3UseSSL=%v", got.HTTPProxy, got.S3UseSSL)
 	}
 	pool.mu.RLock()
-	bypassed := pool.s3CacheBypassed
+	mode := pool.s3CacheMode
 	pool.mu.RUnlock()
-	if bypassed {
-		t.Fatal("s3CacheBypassed still true after DestroySession restore")
+	if mode != transform.S3CacheOn {
+		t.Fatalf("s3CacheMode after DestroySession restore = %q, want on", mode)
 	}
 }

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
+	"github.com/posthog/duckgres/transpiler/transform"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -97,26 +98,24 @@ type SessionPool struct {
 
 	// secretSwapMu serializes rebuilds of the tenant ducklake_s3 secret (the
 	// credential-refresh path in reuseExistingActivation vs the per-session
-	// duckgres.s3_cache toggle in SetS3CacheEnabled) so the last-applied
-	// transport always matches s3CacheBypassed. The refresh path holds it from
+	// duckgres.s3_cache toggle in SetS3CacheMode) so the last-applied transport
+	// always matches s3CacheMode. The refresh path holds it from
 	// before its rebuild until AFTER the rotated payload is committed, so a
 	// concurrent toggle can never rebuild from the stale pre-rotation payload.
 	// Lock order: secretSwapMu → p.mu (both paths); p.mu is never held while
 	// acquiring secretSwapMu. Held across the (slow) CREATE OR REPLACE SECRET,
 	// which p.mu must not be — health checks only need p.mu.RLock.
 	secretSwapMu sync.Mutex
-	// s3CacheBypassed is true while the tenant S3 secret carries the org's
-	// native HTTPS transport instead of the cache-proxy transport, i.e. the
-	// current session set `duckgres.s3_cache = off`. s3CachePassthrough keeps
-	// that transport but marks requests to skip cache reads and fills. Flipped only under
-	// secretSwapMu (read under p.mu); the one exception is activateTenant's
-	// reset-to-false at first-activation commit, which cannot race a swap
-	// because SetS3CacheEnabled refuses to run before an activation exists
-	// (and taking secretSwapMu there would invert the secretSwapMu→p.mu lock
-	// order). CreateSession restores the proxy transport before a new session
-	// starts so a bypass can never leak into the org's next session.
-	s3CacheBypassed    bool
-	s3CachePassthrough bool
+	// s3CacheMode is the tenant secret/router state selected by
+	// `duckgres.s3_cache`. It is changed only under secretSwapMu (read under
+	// p.mu). The enum prevents impossible combinations such as both bypass and
+	// passthrough being active. The one exception is activateTenant's reset to
+	// the default, which cannot race a swap because SetS3CacheMode refuses to
+	// run before an activation exists (and taking secretSwapMu there would
+	// invert the secretSwapMu→p.mu lock order). CreateSession restores the
+	// normal caching mode before a new session starts so an opt-out can never
+	// leak into the org's next session.
+	s3CacheMode transform.S3CacheMode
 
 	drainMu       sync.Mutex
 	draining      bool
@@ -129,6 +128,13 @@ type SessionPool struct {
 	// plane on every health check so the worker is retired instead of being
 	// handed to the org's next connection (see instance_fatal.go).
 	instance instanceHealth
+}
+
+func (p *SessionPool) currentS3CacheModeLocked() transform.S3CacheMode {
+	if p.s3CacheMode == "" {
+		return transform.S3CacheOn
+	}
+	return p.s3CacheMode
 }
 
 type trackedTx struct {

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -107,14 +107,16 @@ type SessionPool struct {
 	secretSwapMu sync.Mutex
 	// s3CacheBypassed is true while the tenant S3 secret carries the org's
 	// native HTTPS transport instead of the cache-proxy transport, i.e. the
-	// current session set `duckgres.s3_cache = off`. Flipped only under
+	// current session set `duckgres.s3_cache = off`. s3CachePassthrough keeps
+	// that transport but marks requests to skip cache reads and fills. Flipped only under
 	// secretSwapMu (read under p.mu); the one exception is activateTenant's
 	// reset-to-false at first-activation commit, which cannot race a swap
 	// because SetS3CacheEnabled refuses to run before an activation exists
 	// (and taking secretSwapMu there would invert the secretSwapMu→p.mu lock
 	// order). CreateSession restores the proxy transport before a new session
 	// starts so a bypass can never leak into the org's next session.
-	s3CacheBypassed bool
+	s3CacheBypassed    bool
+	s3CachePassthrough bool
 
 	drainMu       sync.Mutex
 	draining      bool
@@ -1843,6 +1845,8 @@ func (s *customActionServer) DoAction(cmd *flight.Action, stream flight.FlightSe
 	case "WaitSessionIdle":
 		return s.handler.doWaitSessionIdle(cmd.Body, stream)
 	case "SetSessionS3Cache":
+		return s.handler.doSetSessionS3Cache(cmd.Body, stream)
+	case "SetSessionS3CacheMode":
 		return s.handler.doSetSessionS3Cache(cmd.Body, stream)
 	case "ReleaseQueryHandle":
 		return s.handler.doReleaseQueryHandle(cmd.Body, stream)

--- a/server/conn.go
+++ b/server/conn.go
@@ -245,14 +245,12 @@ type clientConn struct {
 	// this only ever holds "", "standard", or "endpoints".
 	querySource string
 
-	// s3CacheOff and s3CachePassthrough hold the `duckgres.s3_cache` session
-	// GUC state (another duckgres-namespaced custom parameter, NOT forwarded to
-	// DuckDB). Passthrough retains the cache-proxy transport but skips its
-	// cache so the proxy still records individual request instrumentation.
-	// Both are flipped only AFTER the worker-side transport swap succeeds, so
-	// SHOW never reports a state the worker isn't in. See conn_s3_cache.go.
-	s3CacheOff         bool
-	s3CachePassthrough bool
+	// s3CacheMode holds the `duckgres.s3_cache` session GUC state (another
+	// duckgres-namespaced custom parameter, NOT forwarded to DuckDB). A single
+	// mode prevents impossible combinations such as both direct bypass and
+	// proxy passthrough. It changes only AFTER the worker-side transport swap
+	// succeeds, so SHOW never reports a state the worker isn't in.
+	s3CacheMode transform.S3CacheMode
 
 	// Provisioned worker pod size for compute-usage billing (remote/k8s backend
 	// only). Counted in milli-units to avoid truncating a fractional-core or

--- a/server/conn.go
+++ b/server/conn.go
@@ -245,13 +245,14 @@ type clientConn struct {
 	// this only ever holds "", "standard", or "endpoints".
 	querySource string
 
-	// s3CacheOff holds the `duckgres.s3_cache` session GUC state (another
-	// duckgres-namespaced custom parameter, NOT forwarded to DuckDB): true
-	// when this session asked to bypass the node-local S3 cache proxy. Only
-	// flipped by applyS3CacheSetting AFTER the worker-side transport swap
-	// succeeded, so SHOW never reports a state the worker isn't in. See
-	// conn_s3_cache.go.
-	s3CacheOff bool
+	// s3CacheOff and s3CachePassthrough hold the `duckgres.s3_cache` session
+	// GUC state (another duckgres-namespaced custom parameter, NOT forwarded to
+	// DuckDB). Passthrough retains the cache-proxy transport but skips its
+	// cache so the proxy still records individual request instrumentation.
+	// Both are flipped only AFTER the worker-side transport swap succeeds, so
+	// SHOW never reports a state the worker isn't in. See conn_s3_cache.go.
+	s3CacheOff         bool
+	s3CachePassthrough bool
 
 	// Provisioned worker pod size for compute-usage billing (remote/k8s backend
 	// only). Counted in milli-units to avoid truncating a fractional-core or

--- a/server/conn_s3_cache.go
+++ b/server/conn_s3_cache.go
@@ -32,6 +32,14 @@ type S3CacheControl interface {
 	SetS3CacheEnabled(ctx context.Context, enabled bool) error
 }
 
+// S3CacheModeControl extends S3CacheControl for workers that can distinguish
+// the cache-on, cache-off, and proxy-passthrough transports. Passthrough keeps
+// cache-proxy on the request path while ensuring it neither reads nor fills
+// its cache.
+type S3CacheModeControl interface {
+	SetS3CacheMode(ctx context.Context, mode string) error
+}
+
 // S3CacheEnabled reports the session's `duckgres.s3_cache` state. Defaults to
 // true: the cache proxy serves all S3 traffic unless this session explicitly
 // opted out.
@@ -41,6 +49,9 @@ func (c *clientConn) S3CacheEnabled() bool {
 
 // s3CacheValue is the SHOW-facing rendering of the session state.
 func (c *clientConn) s3CacheValue() string {
+	if c.s3CachePassthrough {
+		return transform.S3CachePassthrough
+	}
 	if c.s3CacheOff {
 		return transform.S3CacheOff
 	}
@@ -48,7 +59,7 @@ func (c *clientConn) s3CacheValue() string {
 }
 
 // applyS3CacheSetting applies an already-normalized `duckgres.s3_cache` value
-// ("on", "off", or "" = reset to the default "on") to the session. When the
+// ("on", "off", "passthrough", or "" = reset to the default "on") to the session. When the
 // effective state changes and the session executor supports per-session S3
 // cache control, the worker swap RPC runs FIRST and the session state is only
 // updated on success — a SET that failed to take effect on the worker must
@@ -56,19 +67,32 @@ func (c *clientConn) s3CacheValue() string {
 // pass validated values only (transform.NormalizeS3Cache, rejecting anything
 // else with 22023 before this is reached).
 func (c *clientConn) applyS3CacheSetting(value string) error {
-	enabled := value != transform.S3CacheOff
-	if enabled != c.S3CacheEnabled() {
-		if ctrl, ok := c.executor.(S3CacheControl); ok {
+	effective := value
+	if effective == "" {
+		effective = transform.S3CacheOn
+	}
+	if effective != c.s3CacheValue() {
+		if effective == transform.S3CachePassthrough {
+			if ctrl, ok := c.executor.(S3CacheModeControl); ok {
+				c.ensureConnectionContext()
+				ctx, cancel := context.WithTimeout(c.ctx, s3CacheApplyTimeout)
+				defer cancel()
+				if err := ctrl.SetS3CacheMode(ctx, effective); err != nil {
+					return fmt.Errorf("failed to apply %s: %w", s3CacheGUCName, err)
+				}
+			}
+		} else if ctrl, ok := c.executor.(S3CacheControl); ok {
 			c.ensureConnectionContext()
 			ctx, cancel := context.WithTimeout(c.ctx, s3CacheApplyTimeout)
 			defer cancel()
-			if err := ctrl.SetS3CacheEnabled(ctx, enabled); err != nil {
+			if err := ctrl.SetS3CacheEnabled(ctx, effective == transform.S3CacheOn); err != nil {
 				return fmt.Errorf("failed to apply %s: %w", s3CacheGUCName, err)
 			}
 		}
-		c.logger().Info("Set duckgres.s3_cache.", "enabled", enabled)
+		c.logger().Info("Set duckgres.s3_cache.", "mode", effective)
 	}
-	c.s3CacheOff = !enabled
+	c.s3CacheOff = effective == transform.S3CacheOff
+	c.s3CachePassthrough = effective == transform.S3CachePassthrough
 	return nil
 }
 
@@ -87,8 +111,8 @@ func (c *clientConn) applyStartupS3Cache(raw string) error {
 }
 
 // reapplyS3CacheAfterWorkerSwitch re-asserts this session's `duckgres.s3_cache`
-// state on a freshly acquired worker after a tier escalation. The bypass lives
-// in the WORKER's `ducklake_s3` secret, not in session state, and a new session
+// state on a freshly acquired worker after a tier escalation. The bypass and
+// passthrough mode live in the WORKER, not in session state, and a new session
 // always starts on the cache-proxy transport (CreateSession restores it before
 // the session starts, so a bypass never leaks into the org's next session).
 // Without this re-apply, a connection that asked for `off` would silently start
@@ -98,7 +122,21 @@ func (c *clientConn) applyStartupS3Cache(raw string) error {
 // change. No-op when the session never bypassed the cache, or when the executor
 // has no cache to bypass.
 func (c *clientConn) reapplyS3CacheAfterWorkerSwitch(ctx context.Context) error {
-	if !c.s3CacheOff {
+	mode := c.s3CacheValue()
+	if mode == transform.S3CacheOn {
+		return nil
+	}
+	if mode == transform.S3CachePassthrough {
+		ctrl, ok := c.executor.(S3CacheModeControl)
+		if !ok {
+			return nil
+		}
+		applyCtx, cancel := context.WithTimeout(ctx, s3CacheApplyTimeout)
+		defer cancel()
+		if err := ctrl.SetS3CacheMode(applyCtx, mode); err != nil {
+			return fmt.Errorf("failed to re-apply %s on the new worker: %w", s3CacheGUCName, err)
+		}
+		c.logger().Info("Re-applied duckgres.s3_cache after worker switch.", "mode", mode)
 		return nil
 	}
 	ctrl, ok := c.executor.(S3CacheControl)
@@ -110,7 +148,7 @@ func (c *clientConn) reapplyS3CacheAfterWorkerSwitch(ctx context.Context) error 
 	if err := ctrl.SetS3CacheEnabled(applyCtx, false); err != nil {
 		return fmt.Errorf("failed to re-apply %s on the new worker: %w", s3CacheGUCName, err)
 	}
-	c.logger().Info("Re-applied duckgres.s3_cache after worker switch.", "enabled", false)
+	c.logger().Info("Re-applied duckgres.s3_cache after worker switch.", "mode", mode)
 	return nil
 }
 

--- a/server/conn_s3_cache.go
+++ b/server/conn_s3_cache.go
@@ -44,18 +44,19 @@ type S3CacheModeControl interface {
 // true: the cache proxy serves all S3 traffic unless this session explicitly
 // opted out.
 func (c *clientConn) S3CacheEnabled() bool {
-	return !c.s3CacheOff
+	return c.currentS3CacheMode() != transform.S3CacheOff
+}
+
+func (c *clientConn) currentS3CacheMode() transform.S3CacheMode {
+	if c.s3CacheMode == "" {
+		return transform.S3CacheOn
+	}
+	return c.s3CacheMode
 }
 
 // s3CacheValue is the SHOW-facing rendering of the session state.
 func (c *clientConn) s3CacheValue() string {
-	if c.s3CachePassthrough {
-		return transform.S3CachePassthrough
-	}
-	if c.s3CacheOff {
-		return transform.S3CacheOff
-	}
-	return transform.S3CacheOn
+	return string(c.currentS3CacheMode())
 }
 
 // applyS3CacheSetting applies an already-normalized `duckgres.s3_cache` value
@@ -67,17 +68,17 @@ func (c *clientConn) s3CacheValue() string {
 // pass validated values only (transform.NormalizeS3Cache, rejecting anything
 // else with 22023 before this is reached).
 func (c *clientConn) applyS3CacheSetting(value string) error {
-	effective := value
+	effective := transform.S3CacheMode(value)
 	if effective == "" {
 		effective = transform.S3CacheOn
 	}
-	if effective != c.s3CacheValue() {
+	if effective != c.currentS3CacheMode() {
 		if effective == transform.S3CachePassthrough {
 			if ctrl, ok := c.executor.(S3CacheModeControl); ok {
 				c.ensureConnectionContext()
 				ctx, cancel := context.WithTimeout(c.ctx, s3CacheApplyTimeout)
 				defer cancel()
-				if err := ctrl.SetS3CacheMode(ctx, effective); err != nil {
+				if err := ctrl.SetS3CacheMode(ctx, string(effective)); err != nil {
 					return fmt.Errorf("failed to apply %s: %w", s3CacheGUCName, err)
 				}
 			}
@@ -91,8 +92,7 @@ func (c *clientConn) applyS3CacheSetting(value string) error {
 		}
 		c.logger().Info("Set duckgres.s3_cache.", "mode", effective)
 	}
-	c.s3CacheOff = effective == transform.S3CacheOff
-	c.s3CachePassthrough = effective == transform.S3CachePassthrough
+	c.s3CacheMode = effective
 	return nil
 }
 
@@ -122,7 +122,7 @@ func (c *clientConn) applyStartupS3Cache(raw string) error {
 // change. No-op when the session never bypassed the cache, or when the executor
 // has no cache to bypass.
 func (c *clientConn) reapplyS3CacheAfterWorkerSwitch(ctx context.Context) error {
-	mode := c.s3CacheValue()
+	mode := c.currentS3CacheMode()
 	if mode == transform.S3CacheOn {
 		return nil
 	}
@@ -133,7 +133,7 @@ func (c *clientConn) reapplyS3CacheAfterWorkerSwitch(ctx context.Context) error 
 		}
 		applyCtx, cancel := context.WithTimeout(ctx, s3CacheApplyTimeout)
 		defer cancel()
-		if err := ctrl.SetS3CacheMode(applyCtx, mode); err != nil {
+		if err := ctrl.SetS3CacheMode(applyCtx, string(mode)); err != nil {
 			return fmt.Errorf("failed to re-apply %s on the new worker: %w", s3CacheGUCName, err)
 		}
 		c.logger().Info("Re-applied duckgres.s3_cache after worker switch.", "mode", mode)

--- a/server/conn_tier.go
+++ b/server/conn_tier.go
@@ -227,6 +227,7 @@ func (c *clientConn) escalateWorker(ctx context.Context, reason string) error {
 	// rolled back.
 	if err := c.reapplyS3CacheAfterWorkerSwitch(ctx); err != nil {
 		c.s3CacheOff = false
+		c.s3CachePassthrough = false
 		return &s3CacheReapplyError{err: err}
 	}
 	return nil

--- a/server/conn_tier.go
+++ b/server/conn_tier.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/posthog/duckgres/server/usersecrets"
+	"github.com/posthog/duckgres/transpiler/transform"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -226,8 +227,7 @@ func (c *clientConn) escalateWorker(ctx context.Context, reason string) error {
 	// counted "ok" above — the swap happened), so the pin is deliberately NOT
 	// rolled back.
 	if err := c.reapplyS3CacheAfterWorkerSwitch(ctx); err != nil {
-		c.s3CacheOff = false
-		c.s3CachePassthrough = false
+		c.s3CacheMode = transform.S3CacheOn
 		return &s3CacheReapplyError{err: err}
 	}
 	return nil

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -37,13 +37,14 @@ import (
 const MaxGRPCMessageSize = 1 << 30 // 1GB
 
 const (
-	waitSessionIdleAction    = "WaitSessionIdle"
-	releaseQueryHandleAction = "ReleaseQueryHandle"
-	logQueryAction           = "LogQuery"
-	setSessionS3CacheAction  = "SetSessionS3Cache"
-	queryCloseWaitTimeout    = 30 * time.Second
-	queryLogForwardTimeout   = 5 * time.Second
-	queryLogMaxInFlight      = 64
+	waitSessionIdleAction       = "WaitSessionIdle"
+	releaseQueryHandleAction    = "ReleaseQueryHandle"
+	logQueryAction              = "LogQuery"
+	setSessionS3CacheAction     = "SetSessionS3Cache"
+	setSessionS3CacheModeAction = "SetSessionS3CacheMode"
+	queryCloseWaitTimeout       = 30 * time.Second
+	queryLogForwardTimeout      = 5 * time.Second
+	queryLogMaxInFlight         = 64
 )
 
 // ErrWorkerDead is returned when the backing worker process has crashed.
@@ -636,6 +637,49 @@ func (e *FlightExecutor) SetS3CacheEnabled(ctx context.Context, enabled bool) (e
 	stream, err := e.client.Client.DoAction(
 		e.withSession(merged),
 		&flight.Action{Type: setSessionS3CacheAction, Body: payload},
+	)
+	if err != nil {
+		return err
+	}
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// SetS3CacheMode selects the cache transport mode on the session worker.
+func (e *FlightExecutor) SetS3CacheMode(ctx context.Context, mode string) (err error) {
+	if e.dead.Load() {
+		return ErrWorkerDead
+	}
+	if e.client == nil || e.client.Client == nil {
+		return ErrWorkerDead
+	}
+	defer recoverClientPanic(&err)
+
+	payload, err := json.Marshal(wire.WorkerSetS3CachePayload{
+		WorkerControlMetadata: wire.WorkerControlMetadata{
+			WorkerID:     e.workerID,
+			OwnerEpoch:   e.ownerEpoch,
+			CPInstanceID: e.cpInstanceID,
+		},
+		Mode: mode,
+	})
+	if err != nil {
+		return err
+	}
+
+	merged, cancel := e.mergedContext(ctx)
+	defer cancel()
+
+	stream, err := e.client.Client.DoAction(
+		e.withSession(merged),
+		&flight.Action{Type: setSessionS3CacheModeAction, Body: payload},
 	)
 	if err != nil {
 		return err

--- a/server/s3_cache_test.go
+++ b/server/s3_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -20,6 +21,19 @@ type s3CacheRecordingExecutor struct {
 	// swap must land before the first user query).
 	onSwap  func(enabled bool)
 	onQuery func()
+}
+
+// s3CacheModeRecordingExecutor also records the three-state cache mode RPC.
+// Production remote executors implement this capability so passthrough can
+// retain cache-proxy request instrumentation without using its cache.
+type s3CacheModeRecordingExecutor struct {
+	s3CacheRecordingExecutor
+	modeCalls []string
+}
+
+func (e *s3CacheModeRecordingExecutor) SetS3CacheMode(_ context.Context, mode string) error {
+	e.modeCalls = append(e.modeCalls, mode)
+	return e.err
 }
 
 func (e *s3CacheRecordingExecutor) SetS3CacheEnabled(_ context.Context, enabled bool) error {
@@ -99,6 +113,36 @@ func TestS3CacheSimpleSetAppliesToExecutor(t *testing.T) {
 	}
 	if !c.S3CacheEnabled() {
 		t.Fatalf("S3CacheEnabled() = false after RESET, want true")
+	}
+}
+
+func TestS3CachePassthroughAppliesModeAndReportsIt(t *testing.T) {
+	exec := &s3CacheModeRecordingExecutor{}
+	c, out := newBufferedConn(exec)
+
+	if err := c.handleQuery([]byte("SET duckgres.s3_cache = passthrough\x00")); err != nil {
+		t.Fatalf("handleQuery(SET passthrough): %v", err)
+	}
+	if got, want := exec.modeCalls, []string{"passthrough"}; !slices.Equal(got, want) {
+		t.Fatalf("mode calls = %v, want %v", got, want)
+	}
+
+	out.Reset()
+	if err := c.handleQuery([]byte("SHOW duckgres.s3_cache\x00")); err != nil {
+		t.Fatalf("handleQuery(SHOW): %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("passthrough")) {
+		t.Fatalf("SHOW duckgres.s3_cache did not report passthrough: %s", describeMsgs(parseWireMsgs(t, out.Bytes())))
+	}
+
+	if err := c.handleQuery([]byte("RESET duckgres.s3_cache\x00")); err != nil {
+		t.Fatalf("handleQuery(RESET): %v", err)
+	}
+	if got, want := exec.calls, []bool{true}; !slices.Equal(got, want) {
+		t.Fatalf("boolean calls after RESET = %v, want %v", got, want)
+	}
+	if got := c.s3CacheValue(); got != "on" {
+		t.Fatalf("s3CacheValue after RESET = %q, want on", got)
 	}
 }
 

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -66,6 +66,9 @@ type WorkerWaitSessionIdlePayload struct {
 type WorkerSetS3CachePayload struct {
 	WorkerControlMetadata
 	Enabled bool `json:"enabled"`
+	// Mode is one of on, off, or passthrough. Empty retains the legacy Enabled
+	// behavior for requests from older control planes.
+	Mode string `json:"mode,omitempty"`
 }
 
 // WorkerReleaseQueryHandlePayload asks a worker to release a statement query

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -639,7 +639,7 @@ s3_cache_guc() { # org password
     fail "s3_cache: invalid value 'junk' was accepted: $out"
   fi
   case "$out" in
-    *'must be "on" or "off"'*) ;;
+    *'must be "on", "off", or "passthrough"'*) ;;
     *) fail "s3_cache: invalid-value rejection did not name the valid values: '$out'" ;;
   esac
   # Fresh-session default: a previous session's off must never leak into the
@@ -662,7 +662,7 @@ s3_cache_guc() { # org password
     fail "s3_cache: invalid startup option was accepted: $out"
   fi
   case "$out" in
-    *'must be "on" or "off"'*) ;;
+    *'must be "on", "off", or "passthrough"'*) ;;
     *) fail "s3_cache: invalid startup-option rejection did not name the valid values: '$out'" ;;
   esac
 }

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -627,6 +627,7 @@ s3_cache_guc() { # org password
   # the worker RPC — a worker-side failure would error the SET).
   assert_compat   "$1" "$2" ducklake "SHOW duckgres.s3_cache" "on" "s3_cache_default"
   assert_lastline "$1" "$2" ducklake "SET duckgres.s3_cache = off; SHOW duckgres.s3_cache" "off" "s3_cache_set_off"
+  assert_lastline "$1" "$2" ducklake "SET duckgres.s3_cache = passthrough; SHOW duckgres.s3_cache" "passthrough" "s3_cache_set_passthrough"
   # DuckLake R/W still works inside a bypassed session (real S3 round-trip
   # over whatever transport the worker now carries).
   t="e2e_s3cache_$(echo "$1" | tr -c 'a-z0-9' _)"

--- a/transpiler/s3_cache_test.go
+++ b/transpiler/s3_cache_test.go
@@ -17,6 +17,7 @@ func TestTranspile_S3CacheSet(t *testing.T) {
 	}{
 		{"set off", "SET duckgres.s3_cache = 'off'", "off"},
 		{"set on", "SET duckgres.s3_cache = 'on'", "on"},
+		{"set passthrough", "SET duckgres.s3_cache = 'passthrough'", "passthrough"},
 		{"unquoted off", "SET duckgres.s3_cache = off", "off"},
 		{"unquoted boolean keyword", "SET duckgres.s3_cache = false", "off"},
 		{"true normalizes to on", "SET duckgres.s3_cache = 'true'", "on"},

--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -64,6 +64,9 @@ func errInvalidQuerySource() *CodedError {
 // forwarded to DuckDB. See clientConn.S3CacheEnabled in server/.
 const s3CacheParam = "duckgres.s3_cache"
 
+// S3CacheMode is the closed state set for the duckgres.s3_cache GUC.
+type S3CacheMode string
+
 // Canonical values for the duckgres.s3_cache GUC.
 const (
 	S3CacheOn          = "on"

--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -66,8 +66,9 @@ const s3CacheParam = "duckgres.s3_cache"
 
 // Canonical values for the duckgres.s3_cache GUC.
 const (
-	S3CacheOn  = "on"
-	S3CacheOff = "off"
+	S3CacheOn          = "on"
+	S3CacheOff         = "off"
+	S3CachePassthrough = "passthrough"
 )
 
 // NormalizeS3Cache validates a client-supplied duckgres.s3_cache value. The
@@ -84,6 +85,8 @@ func NormalizeS3Cache(raw string) (string, error) {
 		return S3CacheOn, nil
 	case S3CacheOff, "false", "no", "0":
 		return S3CacheOff, nil
+	case S3CachePassthrough:
+		return S3CachePassthrough, nil
 	default:
 		return "", errInvalidS3Cache()
 	}
@@ -94,8 +97,8 @@ func NormalizeS3Cache(raw string) (string, error) {
 func errInvalidS3Cache() *CodedError {
 	return &CodedError{
 		Code: "22023", // invalid_parameter_value
-		Message: fmt.Sprintf("invalid value for %q: must be %q or %q",
-			s3CacheParam, S3CacheOn, S3CacheOff),
+		Message: fmt.Sprintf("invalid value for %q: must be %q, %q, or %q",
+			s3CacheParam, S3CacheOn, S3CacheOff, S3CachePassthrough),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `duckgres.s3_cache = passthrough`, which preserves cache-proxy request instrumentation while skipping all cache reads and fills.
- Propagate the new mode through the control plane and worker lifecycle, including startup options, tier re-application, credential refresh, and session restore.
- Make cache-proxy strip the worker-local passthrough marker before forwarding to S3; older workers reject the new action rather than silently treating it as cache-off.

## Validation

- `go test ./... -count=1`
- `just lint`
