### PR TITLE
fix(controlplane): preserve active workers during shutdown

### DIFF
--- a/controlplane/k8s_pool_lifecycle.go
+++ b/controlplane/k8s_pool_lifecycle.go
@@ -613,8 +613,10 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 	}
 }
 
-// ShutdownAll stops all workers by deleting their pods. Per worker it runs a
-// 3-step CAS chain against the runtime store and K8s API:
+// ShutdownAll stops idle workers by deleting their pods. Workers with active
+// sessions are preserved so a shutdown path cannot cancel their live queries.
+// Per idle worker it runs a 3-step CAS chain against the runtime store and K8s
+// API:
 //
 //  1. MarkWorkerDraining — atomic SQL CAS from a non-terminal state to
 //     draining. Fences the worker against claims by other CPs: their claim
@@ -649,8 +651,19 @@ func (p *K8sWorkerPool) ShutdownAll() {
 	close(p.stopInform)
 
 	ctx := context.Background()
+	preserved := make(map[int]*ManagedWorker)
 	for _, w := range workers {
 		podName := p.workerPodName(w)
+
+		// ShutdownAll normally follows the control-plane drain, but worker and
+		// connection drain accounting can race. Do not turn that race into an
+		// immediate cancellation of a live query: leave workers with active
+		// sessions running and keep their in-memory bookkeeping intact.
+		if w.activeSessions > 0 {
+			p.logw(w.ID).Info("ShutdownAll: worker has active sessions; leaving pod alive.", "worker_pod", podName, "active_sessions", w.activeSessions)
+			preserved[w.ID] = w
+			continue
+		}
 
 		p.logw(w.ID).Info("Shutting down K8s worker.", "worker_pod", podName)
 
@@ -748,9 +761,9 @@ func (p *K8sWorkerPool) ShutdownAll() {
 	}
 
 	p.mu.Lock()
-	p.workers = make(map[int]*ManagedWorker)
+	p.workers = preserved
 	p.mu.Unlock()
-	observeControlPlaneWorkers(0)
+	observeControlPlaneWorkers(len(preserved))
 }
 
 // retireWorkerPod closes the gRPC client and deletes the worker pod.

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -4309,7 +4309,7 @@ func TestShutdownAll_LeavesInDrainingWhenPodDeleteFails(t *testing.T) {
 	}
 }
 
-func TestShutdownAll_RetiresWorkersWithActiveSessions(t *testing.T) {
+func TestShutdownAll_SparesWorkersWithActiveSessions(t *testing.T) {
 	store := &captureRuntimeWorkerStore{}
 	pool, cs := shutdownTestPool(t, store)
 
@@ -4320,14 +4320,17 @@ func TestShutdownAll_RetiresWorkersWithActiveSessions(t *testing.T) {
 
 	pool.ShutdownAll()
 
-	if podExists(t, cs, "worker-1") {
-		t.Fatal("worker-1 has active sessions but no reconnectable client; ShutdownAll should delete its pod")
+	if !podExists(t, cs, "worker-1") {
+		t.Fatal("worker-1 has active sessions; ShutdownAll must not delete its pod")
 	}
-	if len(store.markDrainingCalledIDs) != 2 {
-		t.Fatalf("expected both workers to enter draining, got calls=%v", store.markDrainingCalledIDs)
+	if _, ok := pool.Worker(1); !ok {
+		t.Fatal("worker-1 has active sessions; ShutdownAll must retain its bookkeeping")
 	}
-	if len(store.retireDrainingCalledIDs) != 2 {
-		t.Fatalf("expected both workers to retire, got calls=%v", store.retireDrainingCalledIDs)
+	if len(store.markDrainingCalledIDs) != 1 || store.markDrainingCalledIDs[0] != 2 {
+		t.Fatalf("expected only the idle worker to enter draining, got calls=%v", store.markDrainingCalledIDs)
+	}
+	if len(store.retireDrainingCalledIDs) != 1 || store.retireDrainingCalledIDs[0] != 2 {
+		t.Fatalf("expected only the idle worker to retire, got calls=%v", store.retireDrainingCalledIDs)
 	}
 
 	if podExists(t, cs, "worker-2") {


### PR DESCRIPTION
## Summary

Restore the shutdown safeguard for Kubernetes workers that still have active sessions.

## Root cause

Commit 1039c1df removed `ShutdownAll`'s `activeSessions > 0` branch while removing the Flight ingress. That made a shutdown delete every owned worker, including one serving a live query. The delete uses a ten-second grace override, so the query's worker connection is cut off and the client receives EOF.

## Change

- Preserve workers with active sessions and their in-memory bookkeeping during `ShutdownAll`.
- Continue the drain/delete/retire chain for idle workers.
- Reinstate a regression test proving that only idle workers are deleted.

## Validation

- `go test -tags kubernetes ./controlplane -run '^TestShutdownAll_SparesWorkersWithActiveSessions$' -count=1`
- `just test-controlplane-k8s`
- `just lint`
