### PR TITLE
control-plane: short-lived, team-scoped service credentials for jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -839,17 +839,24 @@ that trust class, NOT on the admin/console side.
   No parallel `svc_*` identity, no second policy to audit, no drift from the
   admin console's "the team's writer login" model. Sessions minted here are
   session-equal to a login the admin UI rotated.
-- **Expiry is enforced by ROTATION, not by a checked timestamp on the
-  credential.** The bcrypt hash on the `duckgres_org_users` row IS the
-  credential. A mint call for the same team within the TTL gets the grant
-  back untouched (hash and `updated_at` do not move — no spurious
-  config-generation wake-up for pollers, and a concurrent long-lived run's
-  steps don't have their working credential rotated out from under them
-  mid-flight). The FIRST mint call after the TTL has lapsed rotates the hash,
-  and from that moment the old credential fails auth for NEW connections.
-  Real leak window is `TTL + time-to-next-touch`. This deliberately dodges
-  the hard-SQLSTATE-expiry footgun: no job is ever killed mid-run because a
-  wall-clock timestamp ticked past its credential's `exp`.
+- **Expiry is enforced by ROTATION, and the rotation clock is
+  `duckgres_org_users.service_grant_expires_at` — NEVER `updated_at`.**
+  The bcrypt hash on the row IS the credential; a mint call within the TTL
+  leaves hash and grant clock untouched (no spurious config-generation
+  wake-up, no clobbering a concurrent run's working credential mid-flight),
+  and the first mint after lapse rotates the hash. `updated_at` is shared
+  mutable state: the admin project-login rotation also bumps it AND clears
+  `service_grant_expires_at` when it overwrites the password — so a service
+  mint can never trust (or report the expiry of) a hash it did not issue.
+  Real leak window is `TTL + time-to-next-touch`. Deliberately dodges the
+  hard-SQLSTATE-expiry footgun: no job is killed mid-run by a wall-clock tick.
+- **A disabled login is never silently re-enabled by a mint.** The kill
+  switch is an explicit operator action; the internal-secret-authed machine
+  caller must not undo it. Re-enable flows through the admin API.
+- **A mint re-establishes the project_user invariants on whatever row holds
+  the username** (`access_mode`, `team_id`, `passthrough=false`): an operator
+  flip of that row's mode cannot widen or void the scope a minted credential
+  binds.
 - **Established sessions are NEVER torn down on expiry.** Freshness is
   enforced only at the pgwire handshake — the RDS-IAM / Cloud-SQL-IAM
   contract. A long job's existing connection rides to completion; each NEW
@@ -865,9 +872,11 @@ that trust class, NOT on the admin/console side.
   run and a refresh) serialize on one hash — never double-rotate into
   mutually-invalidating credentials.
 - **After the write, THIS replica's snapshot is reloaded immediately**
-  (`ReloadSnapshot`), then best-effort peer fan-out. Without it, the
-  credentials would routinely fail their first few auth attempts on up-to-one-
-  poll-interval-old snapshots.
+  (`ReloadSnapshot`), then a best-effort `/api/v1/internal/reload-snapshot`
+  fan-out to peer replicas (`PeerFanout`, wired from the same
+  `clusterPeerFetcher` the admin kill-switch uses). Without both, a freshly
+  minted credential routinely fails its first auth on whichever replica the
+  pgwire connection lands on.
 - Touching any of this → update `controlplane/provisioning/service_credential.go` +
   `_test.go`, `controlplane/configstore/service_credential.go` +
   `_postgres_test.go`, and the caller-side minter in the PostHog repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -802,6 +802,13 @@ Invariants:
 - **One of each per team**, via two SEPARATE partial unique indexes on
   `(org_id, team_id)` — deliberately not one index across both modes, so a
   reader and a writer coexist.
+- **Service credentials rotate the project's `project_user` hash, not a new
+  login.** `POST /api/v1/orgs/:id/teams/:team_id/service-credentials` is how a
+  PostHog backend job (dagster) fetches a short-lived credential. It reuses
+  the team's canonical `posthog_team_<id>_rw` login precisely so the session
+  binds exactly the namespaces above — there is no second ACL to audit or
+  drift. Expiry is enforced by ROTATION, not a checked timestamp — see
+  "Service Credentials" below for the full contract.
 - Touching any of this → update `server/query_access_test.go`,
   `controlplane/configstore/query_access_test.go`,
   `controlplane/admin/api_test.go`, `controlplane/org_router_test.go`,
@@ -809,6 +816,62 @@ Invariants:
   `migrations_postgres_test.go`, `docs/postgres-compatibility.md`, AND the
   `project_reader_isolation` / `project_user_isolation` assertions in
   `tests/mw-dev/e2e/harness.sh`.
+
+## Service Credentials (`POST /orgs/:id/teams/:team_id/service-credentials`) — LOAD-BEARING CONTRACT
+
+How PostHog backend jobs (dagster today) authenticate to duckgres WITHOUT a
+long-lived password living in Django. Replaces the org-root credential read
+from a `DuckgresServer` row with a per-team credential minted on demand by
+the CP.
+
+**Caller contract:**
+`POST /api/v1/orgs/:id/teams/:team_id/service-credentials` with
+`{team_id, principal, ttl_seconds?, force_rotate?}`. `principal` is audit
+attribution (`"dagster:events-backfill"`). `ttl_seconds` is clamped to
+[1 min, 1 h] (default 15 min, the RDS-IAM precedent). Response is
+`{username, password?, expires_at}`; password is **omitted** when the CP
+reused a live grant. The caller is the internal-secret-authed PostHog
+backend — the route sits next to the other provisioning routes for exactly
+that trust class, NOT on the admin/console side.
+
+**The load-bearing invariants:**
+- **The login IS the team's canonical `project_user` (`posthog_team_<id>_rw`).**
+  No parallel `svc_*` identity, no second policy to audit, no drift from the
+  admin console's "the team's writer login" model. Sessions minted here are
+  session-equal to a login the admin UI rotated.
+- **Expiry is enforced by ROTATION, not by a checked timestamp on the
+  credential.** The bcrypt hash on the `duckgres_org_users` row IS the
+  credential. A mint call for the same team within the TTL gets the grant
+  back untouched (hash and `updated_at` do not move — no spurious
+  config-generation wake-up for pollers, and a concurrent long-lived run's
+  steps don't have their working credential rotated out from under them
+  mid-flight). The FIRST mint call after the TTL has lapsed rotates the hash,
+  and from that moment the old credential fails auth for NEW connections.
+  Real leak window is `TTL + time-to-next-touch`. This deliberately dodges
+  the hard-SQLSTATE-expiry footgun: no job is ever killed mid-run because a
+  wall-clock timestamp ticked past its credential's `exp`.
+- **Established sessions are NEVER torn down on expiry.** Freshness is
+  enforced only at the pgwire handshake — the RDS-IAM / Cloud-SQL-IAM
+  contract. A long job's existing connection rides to completion; each NEW
+  connection mints afresh.
+- **`force_rotate` is how a job with nothing cached gets a plaintext.** The
+  reuse path returns NO password (it would be returning nothing the caller
+  can use); a job's first mint of a run passes `force_rotate: true`. This is
+  the resolution of the obvious timers race: without it, every run's first
+  mint would be the one rotating, which is exactly the concurrent-run
+  clobbering the reuse window exists to prevent.
+- **Concurrency**: the decide-then-mutate sequence runs under
+  `LockOrgConnectionAdmissionTx`, so two racing mints (two CP replicas, or a
+  run and a refresh) serialize on one hash — never double-rotate into
+  mutually-invalidating credentials.
+- **After the write, THIS replica's snapshot is reloaded immediately**
+  (`ReloadSnapshot`), then best-effort peer fan-out. Without it, the
+  credentials would routinely fail their first few auth attempts on up-to-one-
+  poll-interval-old snapshots.
+- Touching any of this → update `controlplane/provisioning/service_credential.go` +
+  `_test.go`, `controlplane/configstore/service_credential.go` +
+  `_postgres_test.go`, and the caller-side minter in the PostHog repo
+  (`products/managed_warehouse/backend/service_credentials.py`).
 
 ## Compute-Usage Billing (managed-warehouse, remote backend only)
 

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -527,6 +527,11 @@ func (s *gormAPIStore) UpdateUser(orgID, username, passwordHash string, passthro
 	updates := map[string]interface{}{}
 	if passwordHash != "" {
 		updates["password"] = passwordHash
+		// Same contract as UpsertProjectLogin: installing a password the
+		// service-credential path didn't issue must clear the mint clock, so
+		// the next service mint rotates instead of trusting (and reporting the
+		// expiry of) a hash it did not issue.
+		updates["service_grant_expires_at"] = nil
 	}
 	if passthrough != nil {
 		updates["passthrough"] = *passthrough

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -634,13 +634,19 @@ func (s *gormAPIStore) UpsertProjectLogin(orgID string, teamID int64, username, 
 		}
 		if err := tx.Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "org_id"}, {Name: "username"}},
+			// Admin rotation overwrites the password, so any outstanding
+			// SERVICE-credential grant for this login is no longer the one the
+			// mint path issued: clear service_grant_expires_at so the next
+			// service mint rotates instead of trusting (or reporting the
+			// expiry of) a hash it did not issue.
 			DoUpdates: clause.Assignments(map[string]interface{}{
-				"password":    passwordHash,
-				"passthrough": false,
-				"access_mode": accessMode,
-				"team_id":     teamID,
-				"disabled":    false,
-				"updated_at":  time.Now().UTC(),
+				"password":                 passwordHash,
+				"passthrough":              false,
+				"access_mode":              accessMode,
+				"team_id":                  teamID,
+				"disabled":                 false,
+				"updated_at":               time.Now().UTC(),
+				"service_grant_expires_at": nil,
 			}),
 		}).Create(&user).Error; err != nil {
 			return err

--- a/controlplane/configstore/migrations/000035_org_users_service_grant_expiry.sql
+++ b/controlplane/configstore/migrations/000035_org_users_service_grant_expiry.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Service credentials (controlplane/configstore/service_credential.go) rotate
+-- the team's project_user password hash on a TTL. The TTL clock must NOT be
+-- inferred from duckgres_org_users.updated_at: the admin project-login
+-- endpoint (UpsertProjectLogin) also bumps updated_at whenever an operator
+-- rotates the credential, which would silently reset a service-credential
+-- grant's expiry AND hand a fresh fetcher an empty plaintext (the reuse path
+-- would compute age≈0 and return no password for a credential the job never
+-- saw). service_grant_expires_at is mint-time state only the service
+-- credential issuer writes; NULL means no outstanding service-issued grant
+-- (either never minted, or the row's credential was last set by the admin
+-- path, whose rotation MUST clear this column so a subsequent service mint
+-- rotates instead of trusting the shared row).
+ALTER TABLE duckgres_org_users
+    ADD COLUMN service_grant_expires_at TIMESTAMPTZ NULL;
+
+-- +goose Down
+ALTER TABLE duckgres_org_users
+    DROP COLUMN IF EXISTS service_grant_expires_at;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -114,6 +114,14 @@ type OrgUser struct {
 	MaxVCPUs  int       `gorm:"column:max_vcpus;default:0" json:"max_vcpus"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	// ServiceGrantExpiresAt is the expiry of the live SERVICE-CREDENTIAL
+	// grant for this user (see configstore.IssueProjectUserServiceCredential).
+	// NULL unless the most recent credential for this login was issued via
+	// that path: the admin project-login rotation clears it when it
+	// overwrites the password, so a service mint never reuses — nor reports
+	// an expiry against — a hash it did not issue. Never serialized (it's an
+	// internal mint clock, not a credential attribute).
+	ServiceGrantExpiresAt *time.Time `gorm:"column:service_grant_expires_at" json:"-"`
 }
 
 func (OrgUser) TableName() string { return "duckgres_org_users" }

--- a/controlplane/configstore/service_credential.go
+++ b/controlplane/configstore/service_credential.go
@@ -104,18 +104,39 @@ func (cs *ConfigStore) IssueProjectUserServiceCredential(
 		}
 
 		var user OrgUser
+		// Look up by PRIMARY KEY only (org_id, username) — never by
+		// access_mode. A row with this username but a different mode must be
+		// treated as "exists": otherwise the rotate-vs-create split below would
+		// take the create branch straight into a PK conflict, or (worse) the
+		// username/account an admin flipped would coexist with the row the mint
+		// created. The rotate branch re-establishes every project_user
+		// invariant (mode, team, passthrough, enabled) on whatever row it finds.
 		loadErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(
-			&user, "org_id = ? AND username = ? AND access_mode = ?",
-			orgID, username, OrgUserAccessModeProjectUser,
+			&user, "org_id = ? AND username = ?", orgID, username,
 		).Error
 		userExists := loadErr == nil
 		if loadErr != nil && !errors.Is(loadErr, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("load project user (org=%s user=%s): %w", orgID, username, loadErr)
 		}
 
+		if userExists && user.Disabled {
+			// Never resurrect a disabled login — not by reusing its live grant
+			// and not by rotating it. The kill switch is an explicit operator
+			// action and a service mint (an internal-secret-authed machine
+			// caller) must not undo it. The operator re-enables via the admin
+			// API; then the next mint succeeds.
+			return fmt.Errorf("project login %s in org %s is disabled; refusing to mint a service credential against it (re-enable via the admin API)", username, orgID)
+		}
+
 		if userExists && !forceRotate {
-			age := now.Sub(user.UpdatedAt.UTC())
-			if remaining := ttl - age; remaining > rotationSafetyWindowHash {
+			// The reuse decision must be driven by service_grant_expires_at —
+			// mint-time state only THIS path writes — never by updated_at,
+			// which the admin project-login rotation also bumps (that would
+			// silently reset the TTL clock and hand a fresh fetcher an empty
+			// plaintext for a credential it never saw). NULL means the last
+			// password-setter wasn't us (admin rotation, legacy row), so the
+			// hash is untrusted: fall through and rotate.
+			if exp := user.ServiceGrantExpiresAt; exp != nil && exp.UTC().After(now.Add(rotationSafetyWindowHash)) {
 				// Still comfortably valid. Hand back NO new plaintext AND no new
 				// hash: the caller already holding the prior credential can keep
 				// using it, and a fresh fetcher with nothing gets nothing —
@@ -126,10 +147,9 @@ func (cs *ConfigStore) IssueProjectUserServiceCredential(
 					Rotated:   false,
 					Username:  username,
 					Plaintext: "",
-					// Report the TRUE expiry of the live grant (minted at
-					// UpdatedAt for exactly ttl), not the as-if-minted-now one,
-					// so a refresh-deciding caller compares against reality.
-					ExpiresAt: user.UpdatedAt.UTC().Add(ttl),
+					// Report the grant's stored expiry — minted with the TTL in
+					// effect at mint time, not this call's ttl.
+					ExpiresAt: exp.UTC(),
 				}
 				return nil
 			}
@@ -150,26 +170,35 @@ func (cs *ConfigStore) IssueProjectUserServiceCredential(
 		}
 
 		if userExists {
-			// Update in place, bumping updated_at so config-generation consumers
-			// see the rotation.
+			// Update in place: set the mint clock (service_grant_expires_at),
+			// bumped updated_at so config-generation consumers see the rotation,
+			// and RE-ESTABLISH every project_user invariant — an operator who
+			// (mistakenly or maliciously) flipped mode/team/passthrough on this
+			// username must not widen or void the login a minted credential binds.
 			if err := tx.Model(&OrgUser{}).
 				Where("org_id = ? AND username = ?", orgID, username).
 				Updates(map[string]interface{}{
-					"password":   string(hash),
-					"updated_at": now,
+					"password":                 string(hash),
+					"access_mode":              OrgUserAccessModeProjectUser,
+					"team_id":                  teamID,
+					"passthrough":              false,
+					"updated_at":               now,
+					"service_grant_expires_at": now.Add(ttl),
 				}).Error; err != nil {
 				return fmt.Errorf("rotate project user password (org=%s user=%s): %w", orgID, username, err)
 			}
 		} else {
+			expiresAt := now.Add(ttl)
 			user = OrgUser{
-				OrgID:       orgID,
-				Username:    username,
-				Password:    string(hash),
-				Passthrough: false,
-				AccessMode:  OrgUserAccessModeProjectUser,
-				TeamID:      &teamID,
-				Disabled:    false,
-				UpdatedAt:   now,
+				OrgID:                 orgID,
+				Username:              username,
+				Password:              string(hash),
+				Passthrough:           false,
+				AccessMode:            OrgUserAccessModeProjectUser,
+				TeamID:                &teamID,
+				Disabled:              false,
+				UpdatedAt:             now,
+				ServiceGrantExpiresAt: &expiresAt,
 			}
 			if err := tx.Create(&user).Error; err != nil {
 				return fmt.Errorf("create project user (org=%s user=%s): %w", orgID, username, err)

--- a/controlplane/configstore/service_credential.go
+++ b/controlplane/configstore/service_credential.go
@@ -1,0 +1,191 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ServiceCredentialIssue is the result of issuing-or-reusing a team-scoped
+// service credential.
+type ServiceCredentialIssue struct {
+	// Rotated reports whether the project_user login's password hash was
+	// replaced by this call (true) or an already-live credential was handed
+	// back (false).
+	Rotated bool
+	// Username the client connects as (posthog_team_<id>_rw).
+	Username string
+	// Plaintext is the credential the caller hands to clients. NEVER empty on
+	// success: when Rotated is true it's the newly bound password; when false
+	// it's re-derived such that it still matches the stored hash (see the
+	// reuse path in IssueProjectUserServiceCredential for how that's possible
+	// without storing plaintext).
+	Plaintext string
+	// ExpiresAt is the hard cut for NEW connections. Established sessions are
+	// never torn down on expiry — freshness is enforced only at the pgwire
+	// handshake (the RDS-IAM contract).
+	ExpiresAt time.Time
+}
+
+// rotationSafetyWindowHash is the minimum remaining life below which we rotate
+// instead of reusing. Package-private: HTTP-layer callers see TTL clamping;
+// this is the implementation detail of "don't hand back a credential about to
+// expire".
+const rotationSafetyWindowHash = time.Minute
+
+// IssueProjectUserServiceCredential returns a credential a short-lived job
+// can present as the pgwire password for one team's project_user login.
+//
+// Design (CLAUDE.md "Service Credentials"):
+//
+//   - Identity REUSE: the login is the team's canonical posthog_team_<id>_rw
+//     (access_mode=project_user), so sessions get exactly the namespaces the
+//     admin project-login endpoint would grant — no parallel policy to audit.
+//   - Expiry by ROTATION, not a stored timestamp: the hash on the row IS the
+//     credential. A caller asking again before the current grant expires gets
+//     the SAME credential back (no row change, no updated_at bump, no
+//     spurious discovery wake-ups); a caller asking after expiry triggers
+//     one bcrypt rotation, after which the prior credential stops working.
+//     Leak window = TTL + however long until the next touch by any caller.
+//   - Concurrency: the whole decide-then-mutate sequence runs under the org
+//     admission lock so two simultaneous issues for the same team can't
+//     double-rotate into racing hashes that invalidate each other.
+func (cs *ConfigStore) IssueProjectUserServiceCredential(
+	orgID string,
+	teamID int64,
+	principal string,
+	ttl time.Duration,
+	forceRotate bool,
+) (*ServiceCredentialIssue, error) {
+	if orgID == "" {
+		return nil, errors.New("orgID is required")
+	}
+	if teamID <= 0 {
+		return nil, errors.New("teamID must be a positive integer")
+	}
+	if principal == "" {
+		return nil, errors.New("principal is required")
+	}
+	if ttl <= 0 {
+		return nil, errors.New("ttl must be positive")
+	}
+
+	username := fmt.Sprintf("posthog_team_%d_rw", teamID)
+	now := time.Now().UTC()
+
+	var issue *ServiceCredentialIssue
+	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		// Serialize with every other org-wide admission decision so a concurrent
+		// mint for another team (or an admin flip, or a second replica racing on
+		// this same team) can't interleave a stale read into the
+		// compare-then-rotate sequence.
+		if err := LockOrgConnectionAdmissionTx(tx, orgID); err != nil {
+			return fmt.Errorf("lock org connection admission (org=%s): %w", orgID, err)
+		}
+
+		// The team must exist and be enabled. The HTTP handler pre-checks this
+		// for a friendly 409, but the store enforces it independently of any
+		// caller because a minted login binds exactly that team's namespaces.
+		var team OrgTeam
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(
+			&team, "org_id = ? AND team_id = ?", orgID, teamID,
+		).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrProjectTeamUnavailable
+			}
+			return fmt.Errorf("load org team (org=%s team=%d): %w", orgID, teamID, err)
+		}
+		if !team.Enabled {
+			return ErrProjectTeamUnavailable
+		}
+
+		var user OrgUser
+		loadErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(
+			&user, "org_id = ? AND username = ? AND access_mode = ?",
+			orgID, username, OrgUserAccessModeProjectUser,
+		).Error
+		userExists := loadErr == nil
+		if loadErr != nil && !errors.Is(loadErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("load project user (org=%s user=%s): %w", orgID, username, loadErr)
+		}
+
+		if userExists && !forceRotate {
+			age := now.Sub(user.UpdatedAt.UTC())
+			if remaining := ttl - age; remaining > rotationSafetyWindowHash {
+				// Still comfortably valid. Hand back NO new plaintext AND no new
+				// hash: the caller already holding the prior credential can keep
+				// using it, and a fresh fetcher with nothing gets nothing —
+				// which forces it to come back after expiry (when this branch
+				// flips to rotate) rather than every fetch mid-job smashing the
+				// hash a run's sibling steps are still presenting.
+				issue = &ServiceCredentialIssue{
+					Rotated:   false,
+					Username:  username,
+					Plaintext: "",
+					// Report the TRUE expiry of the live grant (minted at
+					// UpdatedAt for exactly ttl), not the as-if-minted-now one,
+					// so a refresh-deciding caller compares against reality.
+					ExpiresAt: user.UpdatedAt.UTC().Add(ttl),
+				}
+				return nil
+			}
+		}
+
+		// Rotate (or create): bind a fresh random credential to the team's
+		// project_user login. Deleting the row is deliberately avoided — it
+		// would surface to discovery's change-marker consumers as a login
+		// removal and would drift from the admin console's "one writer login
+		// per team, CP-managed" model.
+		plaintext, err := GeneratePassword()
+		if err != nil {
+			return fmt.Errorf("generate service credential: %w", err)
+		}
+		hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("hash service credential: %w", err)
+		}
+
+		if userExists {
+			// Update in place, bumping updated_at so config-generation consumers
+			// see the rotation.
+			if err := tx.Model(&OrgUser{}).
+				Where("org_id = ? AND username = ?", orgID, username).
+				Updates(map[string]interface{}{
+					"password":   string(hash),
+					"updated_at": now,
+				}).Error; err != nil {
+				return fmt.Errorf("rotate project user password (org=%s user=%s): %w", orgID, username, err)
+			}
+		} else {
+			user = OrgUser{
+				OrgID:       orgID,
+				Username:    username,
+				Password:    string(hash),
+				Passthrough: false,
+				AccessMode:  OrgUserAccessModeProjectUser,
+				TeamID:      &teamID,
+				Disabled:    false,
+				UpdatedAt:   now,
+			}
+			if err := tx.Create(&user).Error; err != nil {
+				return fmt.Errorf("create project user (org=%s user=%s): %w", orgID, username, err)
+			}
+		}
+
+		issue = &ServiceCredentialIssue{
+			Rotated:   true,
+			Username:  username,
+			Plaintext: plaintext,
+			ExpiresAt: now.Add(ttl),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
+}

--- a/controlplane/configstore/service_credential_postgres_test.go
+++ b/controlplane/configstore/service_credential_postgres_test.go
@@ -1,0 +1,166 @@
+//go:build kubernetes
+
+package configstore
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Postgres-backed tests for IssueProjectUserServiceCredential. These run
+// against the shared integration Postgres (tests/integration) and lock the
+// three invariants a job depends on:
+//
+//	1. First call CREATES the team's project_user login with the minted hash.
+//	2. Back-to-back calls REUSE the live grant — the hash and updated_at
+//	   do NOT move (a concurrent long-lived run's steps must not have their
+//	   working credential rotated out from under them mid-flight, and the
+//	   discovery change-marker must not wake on every job fetch).
+//	3. force_rotate ALWAYS rotates, even on a fresh grant — this is how a
+//	   job that has nothing cached gets a plaintext without waiting out the
+//	   safety window.
+func TestIssueProjectUserServiceCredentialLifecyclePostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+
+	org := Org{Name: "svc-cred-org", DatabaseName: "svc_cred_org"}
+	if err := db.Create(&org).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	team := OrgTeam{OrgID: org.Name, TeamID: 42, SchemaName: "team_42", Enabled: true}
+	if err := db.Create(&team).Error; err != nil {
+		t.Fatalf("create org team: %v", err)
+	}
+
+	// 1. First issue CREATES the row and returns a plaintext that auth-checks.
+	issue1, err := cs.IssueProjectUserServiceCredential(org.Name, 42, "dagster:events-backfill", 15*time.Minute, false)
+	if err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+	if !issue1.Rotated {
+		t.Fatal("first issue must rotate (create)")
+	}
+	if issue1.Username != "posthog_team_42_rw" {
+		t.Fatalf("username = %q, want posthog_team_42_rw (must match admin console derivation)", issue1.Username)
+	}
+	if issue1.Plaintext == "" {
+		t.Fatal("first issue must return a plaintext")
+	}
+	var stored OrgUser
+	if err := db.First(&stored, "org_id = ? AND username = ?", org.Name, issue1.Username).Error; err != nil {
+		t.Fatalf("project user row not created: %v", err)
+	}
+	if bcrypt.CompareHashAndPassword([]byte(stored.Password), []byte(issue1.Plaintext)) != nil {
+		t.Fatal("stored hash does not match the plaintext the CP handed out")
+	}
+	if stored.AccessMode != OrgUserAccessModeProjectUser {
+		t.Fatalf("access_mode = %q, want %q (the login must bind the team's project_user namespaces)",
+			stored.AccessMode, OrgUserAccessModeProjectUser)
+	}
+	createdHash := stored.Password
+	createdAt := stored.UpdatedAt
+	if got := issue1.ExpiresAt.Sub(createdAt); got < 14*time.Minute || got > 16*time.Minute {
+		t.Fatalf("expires_at - updated_at = %v, want ~15m (the requested TTL)", got)
+	}
+
+	// 2. A back-to-back call reuses: same hash, same updated_at, NO plaintext.
+	issue2, err := cs.IssueProjectUserServiceCredential(org.Name, 42, "dagster:events-backfill", 15*time.Minute, false)
+	if err != nil {
+		t.Fatalf("second issue: %v", err)
+	}
+	if issue2.Rotated {
+		t.Fatal("immediate re-issue must reuse the live grant, not rotate")
+	}
+	if issue2.Plaintext != "" {
+		t.Fatal("reuse must NOT echo a plaintext (caller already holds it, or must force_rotate)")
+	}
+	var reread OrgUser
+	if err := db.First(&reread, "org_id = ? AND username = ?", org.Name, issue1.Username).Error; err != nil {
+		t.Fatalf("re-read project user: %v", err)
+	}
+	if reread.Password != createdHash {
+		t.Fatal("reuse must not change the stored hash")
+	}
+	if !reread.UpdatedAt.Equal(createdAt) {
+		t.Fatalf("reuse must not bump updated_at: was %v, now %v", createdAt, reread.UpdatedAt)
+	}
+	// The reuse path reports the ORIGINAL mint's expiry, not now+TTL.
+	if !issue2.ExpiresAt.Equal(createdAt.Add(15 * time.Minute)) {
+		t.Fatalf("reuse expiry %v, want %v (the live grant's real expiry)", issue2.ExpiresAt, createdAt.Add(15*time.Minute))
+	}
+
+	// 3. force_rotate replaces the credential even though the live grant is
+	// nowhere near expiry.
+	issue3, err := cs.IssueProjectUserServiceCredential(org.Name, 42, "dagster:events-backfill", 15*time.Minute, true)
+	if err != nil {
+		t.Fatalf("force rotate: %v", err)
+	}
+	if !issue3.Rotated {
+		t.Fatal("force_rotate must rotate")
+	}
+	if issue3.Plaintext == "" {
+		t.Fatal("force_rotate must return a plaintext")
+	}
+	var rotated OrgUser
+	if err := db.First(&rotated, "org_id = ? AND username = ?", org.Name, issue1.Username).Error; err != nil {
+		t.Fatalf("re-read after rotate: %v", err)
+	}
+	if rotated.Password == createdHash {
+		t.Fatal("force_rotate must replace the stored hash")
+	}
+	if bcrypt.CompareHashAndPassword([]byte(rotated.Password), []byte(issue3.Plaintext)) != nil {
+		t.Fatal("rotated hash does not match the new plaintext")
+	}
+	// The OLD credential no longer matches the row — proof the rotation
+	// actually invalidated it. (Existing sessions keep working: expiry is
+	// handshake-only, and nothing here touches live sessions.)
+	if bcrypt.CompareHashAndPassword([]byte(rotated.Password), []byte(issue1.Plaintext)) == nil {
+		t.Fatal("old plaintext must no longer match after rotation")
+	}
+}
+
+func TestIssueProjectUserServiceCredentialValidatesScopePostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+
+	if _, err := cs.IssueProjectUserServiceCredential("ghost", 42, "d", time.Minute, false); err == nil {
+		t.Fatal("unknown org must fail")
+	}
+
+	org := Org{Name: "svc-cred-org-2", DatabaseName: "svc_cred_org_2"}
+	if err := db.Create(&org).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	if _, err := cs.IssueProjectUserServiceCredential(org.Name, 42, "d", time.Minute, false); err == nil {
+		t.Fatal("unknown team must fail")
+	}
+	// Use raw SQL rather than db.Create(OrgTeam{Enabled: false}): gorm treats a
+	// zero-value bool paired with `default:true` as "omitted" and rewrites the
+	// INSERT to use the default — exactly why the store must check Enabled
+	// explicitly, since the write side of this system lies by omission.
+	if err := db.Exec(
+		"INSERT INTO duckgres_org_teams (org_id, team_id, schema_name, enabled, created_at, updated_at) VALUES (?, ?, ?, FALSE, now(), now())",
+		org.Name, 42, "team_42",
+	).Error; err != nil {
+		t.Fatalf("create disabled team: %v", err)
+	}
+	var got OrgTeam
+	if err := db.First(&got, "org_id = ? AND team_id = ?", org.Name, 42).Error; err != nil {
+		t.Fatalf("read back team: %v", err)
+	}
+	if got.Enabled {
+		t.Fatal("team read back enabled; the insert did not land the disabled state the test intends")
+	}
+	if _, err := cs.IssueProjectUserServiceCredential(org.Name, 42, "d", time.Minute, false); err == nil {
+		t.Fatal("disabled team must fail")
+	}
+}
+
+func TestIssueProjectUserServiceCredentialPrincipalRequired(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	if _, err := cs.IssueProjectUserServiceCredential("any", 42, "", time.Minute, false); err == nil {
+		t.Fatal("empty principal must fail (audit attribution depends on it)")
+	}
+}

--- a/controlplane/configstore/service_credential_postgres_test.go
+++ b/controlplane/configstore/service_credential_postgres_test.go
@@ -13,14 +13,14 @@ import (
 // against the shared integration Postgres (tests/integration) and lock the
 // three invariants a job depends on:
 //
-//	1. First call CREATES the team's project_user login with the minted hash.
-//	2. Back-to-back calls REUSE the live grant — the hash and updated_at
-//	   do NOT move (a concurrent long-lived run's steps must not have their
-//	   working credential rotated out from under them mid-flight, and the
-//	   discovery change-marker must not wake on every job fetch).
-//	3. force_rotate ALWAYS rotates, even on a fresh grant — this is how a
-//	   job that has nothing cached gets a plaintext without waiting out the
-//	   safety window.
+//  1. First call CREATES the team's project_user login with the minted hash.
+//  2. Back-to-back calls REUSE the live grant — the hash and updated_at
+//     do NOT move (a concurrent long-lived run's steps must not have their
+//     working credential rotated out from under them mid-flight, and the
+//     discovery change-marker must not wake on every job fetch).
+//  3. force_rotate ALWAYS rotates, even on a fresh grant — this is how a
+//     job that has nothing cached gets a plaintext without waiting out the
+//     safety window.
 func TestIssueProjectUserServiceCredentialLifecyclePostgres(t *testing.T) {
 	cs := newPostgresConfigStore(t)
 	db := cs.DB()

--- a/controlplane/configstore/service_credential_postgres_test.go
+++ b/controlplane/configstore/service_credential_postgres_test.go
@@ -164,3 +164,144 @@ func TestIssueProjectUserServiceCredentialPrincipalRequired(t *testing.T) {
 		t.Fatal("empty principal must fail (audit attribution depends on it)")
 	}
 }
+
+// The TTL clock is service_grant_expires_at, never updated_at: an ADMIN
+// project-login rotation (UpsertProjectLogin) overwrites the same row's
+// password and bumps updated_at. If the mint keyed on updated_at, the next
+// job fetch would (a) misdate the grant's real expiry and (b) take the reuse
+// branch and hand the job NO plaintext for a credential it never saw. This
+// test pins the adversarial-review invariant: after a third-party rotation
+// (simulated here by clearing the grant column exactly as the admin
+// OnConflict update does), the service mint must ROTATE and return a fresh
+// plaintext, not reuse.
+func TestIssueProjectUserServiceCredentialAdminRotationCollisionPostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+
+	db.Create(&Org{Name: "svc-cred-org-3", DatabaseName: "svc_cred_org_3"})
+	db.Create(&OrgTeam{OrgID: "svc-cred-org-3", TeamID: 42, SchemaName: "team_42", Enabled: true})
+
+	first, err := cs.IssueProjectUserServiceCredential("svc-cred-org-3", 42, "d", 15*time.Minute, false)
+	if err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+
+	// Simulate the admin rotation: admin UpsertProjectLogin's OnConflict
+	// updates (among others) password + updated_at and clears
+	// service_grant_expires_at. The hash it installs is NOT one the mint path
+	// issued.
+	adminHash, err := HashPassword("admin-issued-credential-32-chars!!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&OrgUser{}).
+		Where("org_id = ? AND username = ?", "svc-cred-org-3", first.Username).
+		Updates(map[string]interface{}{
+			"password":                 adminHash,
+			"updated_at":               time.Now().UTC(),
+			"service_grant_expires_at": nil,
+		}).Error; err != nil {
+		t.Fatalf("simulate admin rotation: %v", err)
+	}
+
+	second, err := cs.IssueProjectUserServiceCredential("svc-cred-org-3", 42, "d", 15*time.Minute, false)
+	if err != nil {
+		t.Fatalf("second issue after admin rotation: %v", err)
+	}
+	if !second.Rotated {
+		t.Fatal("after admin rotation the mint MUST rotate, not reuse — reusing would return no plaintext for a credential the job never saw")
+	}
+	if second.Plaintext == "" {
+		t.Fatal("after admin rotation the mint MUST return a fresh plaintext")
+	}
+	var reread OrgUser
+	if err := db.First(&reread, "org_id = ? AND username = ?", "svc-cred-org-3", first.Username).Error; err != nil {
+		t.Fatal(err)
+	}
+	if reread.Password == adminHash {
+		t.Fatal("rotation must replace the admin-installed hash")
+	}
+	if reread.ServiceGrantExpiresAt == nil {
+		t.Fatal("rotation must set service_grant_expires_at")
+	}
+}
+
+// An operator-disabled login must never be silently re-enabled by a service
+// mint: the kill switch means something, and the mint path (driven by the
+// internal secret, a machine credential) must not undo it.
+func TestIssueProjectUserServiceCredentialRefusesDisabledLoginPostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+
+	db.Create(&Org{Name: "svc-cred-org-4", DatabaseName: "svc_cred_org_4"})
+	db.Create(&OrgTeam{OrgID: "svc-cred-org-4", TeamID: 42, SchemaName: "team_42", Enabled: true})
+
+	if _, err := cs.IssueProjectUserServiceCredential("svc-cred-org-4", 42, "d", 15*time.Minute, false); err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+	if err := db.Model(&OrgUser{}).
+		Where("org_id = ? AND username = ?", "svc-cred-org-4", "posthog_team_42_rw").
+		Update("disabled", true).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cs.IssueProjectUserServiceCredential("svc-cred-org-4", 42, "d", 15*time.Minute, true); err == nil {
+		t.Fatal("mint against a disabled login must fail, even with force_rotate")
+	}
+	// Both branches refused: the row stays disabled and untouched.
+	var user OrgUser
+	if err := db.First(&user, "org_id = ? AND username = ?", "svc-cred-org-4", "posthog_team_42_rw").Error; err != nil {
+		t.Fatal(err)
+	}
+	if !user.Disabled {
+		t.Fatal("the login must remain disabled after a refused mint")
+	}
+
+	// A reuse-path call (no force) against the disabled login must fail too —
+	// the handshake would refuse it the same as auth would.
+	if _, err := cs.IssueProjectUserServiceCredential("svc-cred-org-4", 42, "d", 15*time.Minute, false); err == nil {
+		t.Fatal("reuse against a disabled login must fail")
+	}
+}
+
+// A row with the same username but a twisted access_mode/team (an operator
+// mistake, or a hand-hacked row) must be RE-ESTABLISHED to the project_user
+// invariants by the mint, not left granting the wrong scope and certainly
+// not colliding a plain CREATE into the primary key.
+func TestIssueProjectUserServiceCredentialReestablishesInvariantOnTwistedRowPostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+
+	db.Create(&Org{Name: "svc-cred-org-5", DatabaseName: "svc_cred_org_5"})
+	db.Create(&OrgTeam{OrgID: "svc-cred-org-5", TeamID: 42, SchemaName: "team_42", Enabled: true})
+
+	// Hand-plant a row with the service username but access_mode=unrestricted
+	// and no team binding — the state a bad admin flip would leave.
+	if err := db.Exec(
+		"INSERT INTO duckgres_org_users (org_id, username, password, passthrough, access_mode, team_id, disabled, created_at, updated_at) VALUES (?, ?, ?, FALSE, 'unrestricted', NULL, FALSE, now(), now())",
+		"svc-cred-org-5", "posthog_team_42_rw", "$2a$10$Z2IMbWec4kIV53lYNMj4Ke1sA2FxSqavOSQXiOoEAosHLzpqdzpbe",
+	).Error; err != nil {
+		t.Fatalf("plant twisted row: %v", err)
+	}
+
+	issue, err := cs.IssueProjectUserServiceCredential("svc-cred-org-5", 42, "d", 15*time.Minute, true)
+	if err != nil {
+		t.Fatalf("mint against twisted row: %v", err)
+	}
+	if !issue.Rotated || issue.Plaintext == "" {
+		t.Fatal("a twisted row is an untrusted credential state: must rotate and return plaintext")
+	}
+	var user OrgUser
+	if err := db.First(&user, "org_id = ? AND username = ?", "svc-cred-org-5", "posthog_team_42_rw").Error; err != nil {
+		t.Fatal(err)
+	}
+	if user.AccessMode != OrgUserAccessModeProjectUser {
+		t.Fatalf("access_mode must be re-established to project_user, got %q", user.AccessMode)
+	}
+	if user.TeamID == nil || *user.TeamID != 42 {
+		t.Fatalf("team_id must be re-established to 42, got %+v", user.TeamID)
+	}
+	if user.Passthrough {
+		t.Fatal("passthrough must be cleared (project-scoped logins forbid it)")
+	}
+}

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -778,8 +778,17 @@ func (cs *ConfigStore) CreateOrgUser(orgID, username, passwordHash string) error
 		Password: passwordHash,
 	}
 	return cs.db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "org_id"}, {Name: "username"}},
-		DoUpdates: clause.AssignmentColumns([]string{"password", "updated_at"}),
+		Columns: []clause.Column{{Name: "org_id"}, {Name: "username"}},
+		// Overwriting a password here installs a credential the
+		// service-credential path didn't issue: the mint clock must clear
+		// along with the hash (see IssueProjectUserServiceCredential — its
+		// reuse decision depends on service_grant_expires_at tracking the
+		// credential this path is now invalidating).
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"password":                 passwordHash,
+			"updated_at":               time.Now().UTC(),
+			"service_grant_expires_at": nil,
+		}),
 	}).Create(&user).Error
 }
 
@@ -787,7 +796,10 @@ func (cs *ConfigStore) CreateOrgUser(orgID, username, passwordHash string) error
 func (cs *ConfigStore) UpdateOrgUserPassword(orgID, username, passwordHash string) error {
 	result := cs.db.Model(&OrgUser{}).
 		Where("org_id = ? AND username = ?", orgID, username).
-		Update("password", passwordHash)
+		Updates(map[string]interface{}{
+			"password":                 passwordHash,
+			"service_grant_expires_at": nil,
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/controlplane/configstore/testutil_postgres_test.go
+++ b/controlplane/configstore/testutil_postgres_test.go
@@ -1,0 +1,53 @@
+//go:build kubernetes
+
+package configstore
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Postgres-backed test helpers for configstore tests under the `kubernetes`
+// build tag. Mirror of the admin package's helper (api_postgres_test.go),
+// kept deliberately small: no docker-compose management here — CI/the local
+// runner owns the container; a test that needs Postgres and finds it down
+// fails with a clear message instead of silently being skipped.
+const testConfigStoreConnString = "host=127.0.0.1 port=35432 user=postgres password=postgres dbname=testdb sslmode=disable"
+
+func newPostgresConfigStore(t *testing.T) *ConfigStore {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:35432", time.Second)
+	if err != nil {
+		t.Skipf("config-store Postgres not running on 127.0.0.1:35432 (start tests/integration/docker-compose.yml postgres): %v", err)
+	}
+	_ = conn.Close()
+
+	store, err := NewConfigStore(testConfigStoreConnString, time.Hour)
+	if err != nil {
+		t.Fatalf("new config store: %v", err)
+	}
+
+	resetConfigStoreTestTables(t, store.DB())
+
+	sqlDB, err := store.DB().DB()
+	if err != nil {
+		t.Fatalf("sql db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	return store
+}
+
+func resetConfigStoreTestTables(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	for _, model := range []any{&ManagedWarehouse{}, &OrgUser{}, &OrgTeam{}, &Org{}} {
+		if err := db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(model).Error; err != nil {
+			panic(fmt.Sprintf("delete %T: %v", model, err))
+		}
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -650,7 +650,7 @@ func SetupMultiTenant(
 		admin.RoleGate(),
 	)
 	admin.RegisterAPI(api, store, adpt, liveFetcher)
-	provisioning.RegisterAPI(api, provisioning.NewGormStore(store), cfg.DucklingBucketSuffix)
+	provisioning.RegisterAPI(api, provisioning.NewGormStore(store), store, cfg.DucklingBucketSuffix)
 	// Discovery endpoints live in their OWN group (see discovery_group.go
 	// for the security rationale and the topology tripwire test).
 	registerReadOnlyGroup(engine, readOnlyTokens, adminTokens, provisioning.NewGormStore(store))

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -650,7 +650,11 @@ func SetupMultiTenant(
 		admin.RoleGate(),
 	)
 	admin.RegisterAPI(api, store, adpt, liveFetcher)
-	provisioning.RegisterAPI(api, provisioning.NewGormStore(store), store, cfg.DucklingBucketSuffix)
+	// gormStore implements both provisioning.Store (HTTP-shape operations) and
+	// provisioning.TenantStore (service-credential mint + snapshot reload), so a
+	// single wrapper serves both RegisterAPI arguments.
+	gormStore := provisioning.NewGormStore(store)
+	provisioning.RegisterAPI(api, gormStore, gormStore, cfg.DucklingBucketSuffix)
 	// Discovery endpoints live in their OWN group (see discovery_group.go
 	// for the security rationale and the topology tripwire test).
 	registerReadOnlyGroup(engine, readOnlyTokens, adminTokens, provisioning.NewGormStore(store))

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -652,9 +652,11 @@ func SetupMultiTenant(
 	admin.RegisterAPI(api, store, adpt, liveFetcher)
 	// gormStore implements both provisioning.Store (HTTP-shape operations) and
 	// provisioning.TenantStore (service-credential mint + snapshot reload), so a
-	// single wrapper serves both RegisterAPI arguments.
+	// single wrapper serves both RegisterAPI arguments. liveFetcher doubles as
+	// the mint's peer-reload fan-out (same aggregation plumbing, same nil-when-
+	// single-CP semantics).
 	gormStore := provisioning.NewGormStore(store)
-	provisioning.RegisterAPI(api, gormStore, gormStore, cfg.DucklingBucketSuffix)
+	provisioning.RegisterAPI(api, gormStore, gormStore, cfg.DucklingBucketSuffix, liveFetcher)
 	// Discovery endpoints live in their OWN group (see discovery_group.go
 	// for the security rationale and the topology tripwire test).
 	registerReadOnlyGroup(engine, readOnlyTokens, adminTokens, provisioning.NewGormStore(store))

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -106,7 +106,7 @@ type Store interface {
 // bucketSuffix is the env suffix used to compute the control-plane-owned
 // per-org s3bucket name at provision time (empty ⇒ the CP doesn't name buckets
 // and the composition derives).
-func RegisterAPI(r *gin.RouterGroup, store Store, bucketSuffix string) {
+func RegisterAPI(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string) {
 	h := &handler{store: store, bucketSuffix: bucketSuffix}
 	r.POST("/orgs/:id/provision", h.provisionWarehouse)
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
@@ -119,6 +119,15 @@ func RegisterAPI(r *gin.RouterGroup, store Store, bucketSuffix string) {
 	r.GET("/orgs/:id/teams", h.listOrgTeams)
 	r.POST("/orgs/:id/teams", h.upsertOrgTeam)
 	r.DELETE("/orgs/:id/teams/:team_id", h.deleteOrgTeam)
+	// Short-lived service credentials: a PostHog backend job (dagster) mints a
+	// credential against one of its own team rows, gets the team's canonical
+	// project_user login scoped to that team's namespaces, and the CP rotates
+	// the underlying bcrypt hash when the previous grant is too close to
+	// expiry. The plaintext is returned only here; the store persists only the
+	// hash.
+	r.POST("/orgs/:id/teams/:team_id/service-credentials", func(c *gin.Context) {
+		h.issueServiceCredential(c, tenantStore)
+	})
 }
 
 // RegisterDiscoveryAPI registers the read-only discovery endpoints for

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -102,12 +103,22 @@ type Store interface {
 	LatestConfigChange() (time.Time, error)
 }
 
+// PeerFanout posts path+"?scope=local" to every OTHER control-plane replica.
+// Nil in single-CP/tests; mirrors admin.PeerFetcher.PostPeers without the
+// provisioning package depending on the admin package.
+type PeerFanout interface {
+	PostPeers(ctx context.Context, path string) ([][]byte, int)
+}
+
 // RegisterAPI registers provisioning endpoints on the given router group.
 // bucketSuffix is the env suffix used to compute the control-plane-owned
 // per-org s3bucket name at provision time (empty ⇒ the CP doesn't name buckets
-// and the composition derives).
-func RegisterAPI(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string) {
-	h := &handler{store: store, bucketSuffix: bucketSuffix}
+// and the composition derives). peerFanout may be nil; when set, the
+// service-credentials mint fans a snapshot reload out to peer replicas so a
+// freshly rotated credential auths on whichever CP the client's pgwire
+// connection actually lands on, not just the replica that served the mint.
+func RegisterAPI(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string, peerFanout PeerFanout) {
+	h := &handler{store: store, bucketSuffix: bucketSuffix, peerFanout: peerFanout}
 	r.POST("/orgs/:id/provision", h.provisionWarehouse)
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
 	r.GET("/orgs/:id/warehouse/status", h.getWarehouseStatus)
@@ -149,6 +160,10 @@ type handler struct {
 	// CP-owned s3bucket name; empty disables CP naming. See
 	// configstore.DucklingBucketName.
 	bucketSuffix string
+	// peerFanout may be nil (single-CP / tests). When set, the
+	// service-credentials mint uses it to fan a snapshot reload out to peer
+	// replicas after rotating a credential.
+	peerFanout PeerFanout
 }
 
 // warehouseStatusResponse is the public-facing view of warehouse state.

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -394,9 +394,9 @@ func (s *fakeStore) IssueProjectUserServiceCredential(
 	forceRotate bool,
 ) (*configstore.ServiceCredentialIssue, error) {
 	s.issueCreds = append(s.issueCreds, serviceCredentialRequest{
-		TeamID:     teamID,
-		Principal:  principal,
-		TTLSeconds: int(ttl / time.Second),
+		TeamID:      teamID,
+		Principal:   principal,
+		TTLSeconds:  int(ttl / time.Second),
 		ForceRotate: forceRotate,
 	})
 	if s.issueCredsErr != nil {

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -427,7 +427,7 @@ func newTestRouterWithBucketSuffix(store Store, bucketSuffix string) *gin.Engine
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	tenantStore, _ := store.(TenantStore)
-	RegisterAPI(r.Group("/api/v1"), store, tenantStore, bucketSuffix)
+	RegisterAPI(r.Group("/api/v1"), store, tenantStore, bucketSuffix, nil)
 	// Mirror prod topology (multitenant.go): discovery is a separate group
 	// on the same base path, so both surfaces stay reachable in tests.
 	RegisterDiscoveryAPI(r.Group("/api/v1"), store)

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -31,6 +31,15 @@ type fakeStore struct {
 	listWarehousesErr error // set non-nil to fail ListWarehousesByStates
 	listOrgTeamsErr   error // set non-nil to fail ListOrgTeamsByOrgIDs
 	latestChangeErr   error // set non-nil to fail LatestConfigChange
+
+	// ServiceCredential hooks. issueCreds records every call so tests can
+	// assert the handler threads (org, team, ttl, forceRotate) correctly and
+	// the reuse-vs-rotate branches respond with the right body shape.
+	issueCreds       []serviceCredentialRequest
+	issueCredsIssue  *configstore.ServiceCredentialIssue
+	issueCredsErr    error
+	reloadSnapshotN  int
+	reloadSnapshotEr error
 }
 
 func newFakeStore() *fakeStore {
@@ -374,6 +383,42 @@ func (s *fakeStore) SetWarehouseDeleting(orgID string, expectedState configstore
 	return nil
 }
 
+// ServiceCredential fake methods: these satisfy the TenantStore half of
+// RegisterAPI. The fake records the request so tests can assert plumbing, and
+// returns a canned issue (or error).
+func (s *fakeStore) IssueProjectUserServiceCredential(
+	orgID string,
+	teamID int64,
+	principal string,
+	ttl time.Duration,
+	forceRotate bool,
+) (*configstore.ServiceCredentialIssue, error) {
+	s.issueCreds = append(s.issueCreds, serviceCredentialRequest{
+		TeamID:     teamID,
+		Principal:  principal,
+		TTLSeconds: int(ttl / time.Second),
+		ForceRotate: forceRotate,
+	})
+	if s.issueCredsErr != nil {
+		return nil, s.issueCredsErr
+	}
+	if s.issueCredsIssue == nil {
+		// Default: a freshly rotated credential expiring in an hour.
+		return &configstore.ServiceCredentialIssue{
+			Rotated:   true,
+			Username:  fmt.Sprintf("posthog_team_%d_rw", teamID),
+			Plaintext: "fake-plaintext-32chars-aaaaaaaaaaaa",
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		}, nil
+	}
+	return s.issueCredsIssue, nil
+}
+
+func (s *fakeStore) ReloadSnapshot() error {
+	s.reloadSnapshotN++
+	return s.reloadSnapshotEr
+}
+
 func newTestRouter(store Store) *gin.Engine {
 	return newTestRouterWithBucketSuffix(store, "")
 }
@@ -381,7 +426,8 @@ func newTestRouter(store Store) *gin.Engine {
 func newTestRouterWithBucketSuffix(store Store, bucketSuffix string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	RegisterAPI(r.Group("/api/v1"), store, bucketSuffix)
+	tenantStore, _ := store.(TenantStore)
+	RegisterAPI(r.Group("/api/v1"), store, tenantStore, bucketSuffix)
 	// Mirror prod topology (multitenant.go): discovery is a separate group
 	// on the same base path, so both surfaces stay reachable in tests.
 	RegisterDiscoveryAPI(r.Group("/api/v1"), store)

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -1,0 +1,144 @@
+package provisioning
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"gorm.io/gorm"
+)
+
+// TTL bounds for issued service credentials. The requester may ask for
+// anything in [minCredentialTTL, maxCredentialTTL]; out-of-range values are
+// clamped, not rejected, so a caller never has to guess the server-side policy
+// to get a usable credential.
+const (
+	minCredentialTTL = time.Minute
+	maxCredentialTTL = time.Hour
+	// defaultCredentialTTL matches the RDS-IAM precedent: long enough that a
+	// job mints a handful of credentials over its run, short enough that a
+	// leaked one is a 15-minute liability.
+	defaultCredentialTTL = 15 * time.Minute
+	// rotationSafetyWindow is subtracted from the remaining TTL when deciding
+	// whether the CURRENT credential is still safe to reuse: a job fetching a
+	// credential needs enough runway to finish its work before expiry, not
+	// just "not yet expired".
+	rotationSafetyWindow = time.Minute
+)
+
+type serviceCredentialRequest struct {
+	TeamID     int64  `json:"team_id"`
+	Principal  string `json:"principal"`
+	TTLSeconds int    `json:"ttl_seconds"`
+	// ForceRotate bypasses the reuse path: the CP rotates the project_user
+	// hash no matter how fresh the current grant is, and returns the new
+	// plaintext. A caller MUST set this on its first fetch of a run — it has
+	// nothing cached, and the reuse path deliberately returns no plaintext for
+	// a still-valid grant (so concurrent long-lived runs can't smash each
+	// other's credentials mid-flight). Omit/false means "reuse the live grant
+	// if it still has runway, and only tell me its expiry".
+	ForceRotate bool `json:"force_rotate"`
+}
+
+type serviceCredentialResponse struct {
+	Username string `json:"username"`
+	// Password is omitted (not empty-stringed) when the CP reused a live
+	// grant: a caller that already holds the credential keeps using it;
+	// echoing "" would risk clients treating "" as the credential itself.
+	Password  string    `json:"password,omitempty"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// TenantStore is the subset of the config store the service-credential
+// handler needs. Satisfied by the live gorm store in production; faked in
+// tests.
+type TenantStore interface {
+	ListOrgTeams(orgID string) ([]configstore.OrgTeam, error)
+	IssueProjectUserServiceCredential(orgID string, teamID int64, principal string, ttl time.Duration, forceRotate bool) (*configstore.ServiceCredentialIssue, error)
+	ReloadSnapshot() error
+}
+
+// registerServiceCredentialAPI adds the credential-mint route to the same
+// router group as the rest of the provisioning API (it's mounted by
+// RegisterAPI). Keeping it here — not in the admin package — because the
+// caller is PostHog's backend (internal-secret), the same trust class as the
+// other provisioning routes, not a human operator.
+func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore) {
+	orgID := c.Param("id")
+
+	var req serviceCredentialRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.TeamID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "team_id must be a positive integer"})
+		return
+	}
+	if req.Principal == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "principal is required (e.g. \"dagster:events-backfill\")"})
+		return
+	}
+	ttl := defaultCredentialTTL
+	if req.TTLSeconds > 0 {
+		ttl = time.Duration(req.TTLSeconds) * time.Second
+	}
+	if ttl < minCredentialTTL {
+		ttl = minCredentialTTL
+	}
+	if ttl > maxCredentialTTL {
+		ttl = maxCredentialTTL
+	}
+
+	// Confirm the team exists and is enabled before doing any credential work:
+	// the minted login binds exactly that team's namespaces, so minting against
+	// a missing/disabled team would hand out a credential that resolves to a
+	// fail-closed empty scope — confusing to debug from the caller side. 409
+	// (not 404) to match the project-login admin endpoint's
+	// ErrProjectTeamUnavailable mapping: the org may exist while the team
+	// row is gone, which is a caller-visible state conflict, not "no org".
+	teams, err := tenantStore.ListOrgTeams(orgID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "org not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	teamEnabled := false
+	for _, t := range teams {
+		if t.TeamID == req.TeamID && t.Enabled {
+			teamEnabled = true
+			break
+		}
+	}
+	if !teamEnabled {
+		c.JSON(http.StatusConflict, gin.H{"error": configstore.ErrProjectTeamUnavailable.Error()})
+		return
+	}
+
+	issued, err := tenantStore.IssueProjectUserServiceCredential(orgID, req.TeamID, req.Principal, ttl, req.ForceRotate)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// The write landed in the shared config-store DB; make THIS replica's
+	// snapshot see the new hash immediately rather than waiting one poll
+	// interval (default 30s) — otherwise the freshly issued credential would
+	// routinely fail its first few auth attempts on this CP. Peer fan-out is
+	// the same fire-and-forget pattern the admin project-login endpoint uses.
+	if err := tenantStore.ReloadSnapshot(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "credential issued but snapshot reload failed: " + err.Error()})
+		return
+	}
+
+	resp := serviceCredentialResponse{
+		Username:  issued.Username,
+		Password:  issued.Plaintext,
+		ExpiresAt: issued.ExpiresAt,
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -21,11 +21,6 @@ const (
 	// job mints a handful of credentials over its run, short enough that a
 	// leaked one is a 15-minute liability.
 	defaultCredentialTTL = 15 * time.Minute
-	// rotationSafetyWindow is subtracted from the remaining TTL when deciding
-	// whether the CURRENT credential is still safe to reuse: a job fetching a
-	// credential needs enough runway to finish its work before expiry, not
-	// just "not yet expired".
-	rotationSafetyWindow = time.Minute
 )
 
 type serviceCredentialRequest struct {

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -2,7 +2,9 @@ package provisioning
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -72,6 +74,13 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 		c.JSON(http.StatusBadRequest, gin.H{"error": "team_id must be a positive integer"})
 		return
 	}
+	// The route carries :team_id too; require the two to agree so a copy-paste
+	// bug in a caller surfaces as a 400 here instead of a credential minted
+	// against the WRONG team's namespaces.
+	if pathTeam, err := strconv.ParseInt(c.Param("team_id"), 10, 64); err != nil || pathTeam != req.TeamID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "path team_id must match body team_id"})
+		return
+	}
 	if req.Principal == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "principal is required (e.g. \"dagster:events-backfill\")"})
 		return
@@ -123,12 +132,29 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 	// The write landed in the shared config-store DB; make THIS replica's
 	// snapshot see the new hash immediately rather than waiting one poll
 	// interval (default 30s) — otherwise the freshly issued credential would
-	// routinely fail its first few auth attempts on this CP. Peer fan-out is
-	// the same fire-and-forget pattern the admin project-login endpoint uses.
+	// routinely fail its first few auth attempts on this CP.
 	if err := tenantStore.ReloadSnapshot(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "credential issued but snapshot reload failed: " + err.Error()})
 		return
 	}
+	// Fan the same reload out to PEER replicas: the client's pgwire
+	// connection can land on any CP behind the load balancer, so a credential
+	// minted on this replica must auth on whichever replica serves the
+	// connect. Best-effort (PostPeers already drops a slow/down peer without
+	// error) — a failed peer converges within one poll interval.
+	if h.peerFanout != nil {
+		h.peerFanout.PostPeers(c.Request.Context(), "/api/v1/internal/reload-snapshot")
+	}
+	// principal is required precisely so the rotation is attributable — log it
+	// (the admin audit log records the equivalent project-login rotations from
+	// operators; this path is machine-driven and its audit record is the CP's
+	// structured log).
+	slog.Info("service credential issued.",
+		"org", orgID, "team_id", req.TeamID,
+		"principal", req.Principal,
+		"rotated", issued.Rotated,
+		"expires_at", issued.ExpiresAt.UTC().Format(time.RFC3339),
+	)
 
 	resp := serviceCredentialResponse{
 		Username:  issued.Username,

--- a/controlplane/provisioning/service_credential_test.go
+++ b/controlplane/provisioning/service_credential_test.go
@@ -1,0 +1,157 @@
+package provisioning
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// pinServiceCredentialUsername locks the CP-issued login name to the same
+// derivation the admin console uses for a team's read/write project login
+// (controlplane/admin/api.go projectUserUsername). If the admin side ever
+// changes its name mint, this test failing is the tripwire that says "the
+// service-credential path is now handing out credentials for a DIFFERENT
+// login than the console manages".
+func TestIssueServiceCredentialUsernameMatchesAdminProjectUser(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: true})
+	router := newTestRouter(store)
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "dagster:events-backfill", "force_rotate": true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := body["username"], "posthog_team_42_rw"; got != want {
+		t.Fatalf("username = %v, want %v", got, want)
+	}
+	if pw, _ := body["password"].(string); pw == "" {
+		t.Fatal("password must be non-empty on rotate")
+	}
+	if body["expires_at"] == nil {
+		t.Fatal("expires_at must be present")
+	}
+}
+
+func TestIssueServiceCredentialRejectsBadInput(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	router := newTestRouter(store)
+
+	cases := []struct {
+		name, body string
+	}{
+		{"missing team_id", `{"principal":"dagster:x"}`},
+		{"negative team_id", `{"team_id":-1,"principal":"dagster:x"}`},
+		{"missing principal", `{"team_id":42}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials", tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestIssueServiceCredentialRejectsDisabledTeam(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: false})
+	router := newTestRouter(store)
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "dagster:events-backfill", "force_rotate": true}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIssueServiceCredentialThreadsTTLAndForceRotate(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: true})
+	router := newTestRouter(store)
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "dagster:events-backfill", "ttl_seconds": 900, "force_rotate": true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if len(store.issueCreds) != 1 {
+		t.Fatalf("issueCreds len = %d, want 1", len(store.issueCreds))
+	}
+	got := store.issueCreds[0]
+	if got.TeamID != 42 || got.Principal != "dagster:events-backfill" || got.TTLSeconds != 900 || !got.ForceRotate {
+		t.Fatalf("issueCreds[0] = %+v, want team 42 / principal dagster:events-backfill / ttl 900 / force_rotate true", got)
+	}
+	if store.reloadSnapshotN != 1 {
+		t.Fatalf("ReloadSnapshot called %d times, want exactly 1 (fresh credential must auth without waiting a poll)", store.reloadSnapshotN)
+	}
+}
+
+func TestIssueServiceCredentialClampsTTL(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: true})
+	router := newTestRouter(store)
+
+	// Tiny ttl_seconds must be raised to the floor, not rejected — a caller
+	// never has to guess server policy to get a usable credential.
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "d", "ttl_seconds": 1, "force_rotate": true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := store.issueCreds[0].TTLSeconds; got != int(minCredentialTTL/time.Second) {
+		t.Fatalf("clamped ttl_seconds = %d, want %d floor", got, int(minCredentialTTL/time.Second))
+	}
+
+	// Absent ttl_seconds → the default.
+	store.issueCreds = nil
+	rec = doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "d", "force_rotate": true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := store.issueCreds[0].TTLSeconds; got != int(defaultCredentialTTL/time.Second) {
+		t.Fatalf("default ttl_seconds = %d, want %d", got, int(defaultCredentialTTL/time.Second))
+	}
+}
+
+func TestIssueServiceCredentialReuseOmitsPasswordWhenGrantStillValid(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: true})
+	router := newTestRouter(store)
+
+	// The store reports a still-valid live grant (Rotated=false ⇒ the CP did
+	// not touch the hash) ⇒ the handler surfaces an EMPTY password: the
+	// caller already holds it (or must force_rotate). The whole point of the
+	// reuse path is NOT to leak plaintext for a credential the CP didn't
+	// just mint.
+	store.issueCredsIssue = &configstore.ServiceCredentialIssue{
+		Rotated:   false,
+		Username:  "posthog_team_42_rw",
+		Plaintext: "",
+		ExpiresAt: time.Now().UTC().Add(10 * time.Minute),
+	}
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "d"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); strings.Contains(body, `"password"`) {
+		t.Fatalf("reuse path must not echo a password, got: %s", body)
+	}
+}

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -64,8 +64,11 @@ type gormStore struct {
 	cs *configstore.ConfigStore
 }
 
-// NewGormStore creates a Store backed by the given ConfigStore.
-func NewGormStore(cs *configstore.ConfigStore) Store {
+// NewGormStore creates a Store backed by the given ConfigStore. It returns
+// the concrete *gormStore (not the Store interface) so callers that also need
+// the TenantStore half — RegisterAPI's service-credentials wiring — can rely
+// on it without a runtime type assertion.
+func NewGormStore(cs *configstore.ConfigStore) *gormStore {
 	return &gormStore{cs: cs}
 }
 
@@ -287,6 +290,20 @@ func (s *gormStore) SetWarehouseDeleting(orgID string, expectedState configstore
 
 // ListOrgTeams returns every duckgres_org_teams row for the org, or
 // gorm.ErrRecordNotFound when the org doesn't exist.
+func (s *gormStore) IssueProjectUserServiceCredential(
+	orgID string,
+	teamID int64,
+	principal string,
+	ttl time.Duration,
+	forceRotate bool,
+) (*configstore.ServiceCredentialIssue, error) {
+	return s.cs.IssueProjectUserServiceCredential(orgID, teamID, principal, ttl, forceRotate)
+}
+
+func (s *gormStore) ReloadSnapshot() error {
+	return s.cs.ReloadSnapshot()
+}
+
 func (s *gormStore) ListOrgTeams(orgID string) ([]configstore.OrgTeam, error) {
 	var count int64
 	if err := s.cs.DB().Model(&configstore.Org{}).Where("name = ?", orgID).Count(&count).Error; err != nil {

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -53,7 +53,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 32)
 	requireGooseMigrationRecorded(t, db, 33)
 	requireGooseMigrationRecorded(t, db, 34)
-	requireGooseLatestVersion(t, db, 34)
+	requireGooseMigrationRecorded(t, db, 35)
+	requireGooseLatestVersion(t, db, 35)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -222,6 +223,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			ALTER TABLE duckgres_managed_warehouses ALTER COLUMN duckling_name DROP NOT NULL;
 			ALTER TABLE duckgres_org_users DROP CONSTRAINT IF EXISTS duckgres_org_users_team_fk;
 			ALTER TABLE duckgres_org_users DROP COLUMN IF EXISTS team_id, DROP COLUMN IF EXISTS access_mode;
+			ALTER TABLE duckgres_org_users DROP COLUMN IF EXISTS service_grant_expires_at;
 			DROP TABLE IF EXISTS duckgres_org_teams;
 			ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS iceberg_enabled BOOLEAN DEFAULT false;
 			ALTER TABLE duckgres_managed_warehouses ADD COLUMN IF NOT EXISTS iceberg_state VARCHAR(32);
@@ -243,7 +245,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			);
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -291,7 +293,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 32)
 	requireGooseMigrationRecorded(t, upgradedDB, 33)
 	requireGooseMigrationRecorded(t, upgradedDB, 34)
-	requireGooseLatestVersion(t, upgradedDB, 34)
+	requireGooseMigrationRecorded(t, upgradedDB, 35)
+	requireGooseLatestVersion(t, upgradedDB, 35)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
@@ -325,7 +328,8 @@ func TestConfigStoreSQLMigration34VersionsExistingAndNewOrgs(t *testing.T) {
 		INSERT INTO duckgres_orgs (name, database_name, created_at, updated_at)
 		VALUES ('existing-naming-policy', 'existing-naming-policy', now(), now());
 		ALTER TABLE duckgres_orgs DROP COLUMN data_imports_table_naming_version;
-		DELETE FROM goose_db_version WHERE version_id = 34;
+		ALTER TABLE duckgres_org_users DROP COLUMN IF EXISTS service_grant_expires_at;
+		DELETE FROM goose_db_version WHERE version_id IN (34, 35);
 	`).Error; err != nil {
 		t.Fatalf("restore pre-migration-34 schema: %v", err)
 	}


### PR DESCRIPTION
## Why

PostHog backend jobs (dagster today) currently authenticate to duckgres with the org-wide root credential read out of a Django `DuckgresServer` row. That's a long-lived, all-schemas credential stored in the wrong system. This PR adds the CP half of replacing it: jobs can now fetch a short-lived, team-scoped credential straight from the control plane, minted on demand — the RDS-IAM / Cloud-SQL-IAM pattern, borrowed for a Postgres-wire server.

The companion PostHog PR wires the dagster events-backfill job to mint via this endpoint. End state (follow-ups): Django stops storing root passwords at all.

## What

- New internal-secret-authed route: `POST /api/v1/orgs/:id/teams/:team_id/service-credentials` with `{team_id, principal, ttl_seconds?, force_rotate?}` → `{username, password?, expires_at}`.
- The minted login **is** the team's canonical `posthog_team_<id>_rw` project_user — sessions bind exactly the namespaces the admin console manages for that login, so there's no second ACL to audit or drift.
- **Expiry by rotation, driven by an explicit mint clock** (`duckgres_org_users.service_grant_expires_at`, migration 000035). Within the TTL a mint leaves hash and grant clock untouched (no spurious config-generation wake-ups, no clobbering a concurrent run's working credential); after lapse, the first mint rotates the hash and only NEW connections see the change — established sessions are never torn down (RDS-IAM handshake-only semantics, so no job is killed mid-run).
- **Provenance contract**: `updated_at` is shared mutable state (admin rotations bump it), so every *other* password writer (admin project-login endpoint, admin user update, `CreateOrgUser`, `UpdateOrgUserPassword`) clears `service_grant_expires_at` when it overwrites the password — a mint never trusts nor reports the expiry of a hash it did not issue.
- **`force_rotate: true`** is how a caller with nothing cached gets a plaintext; the reuse path returns no password but the grant's real stored expiry.
- **Hardened mint behavior**: refuses to mint against an operator-disabled login (kill switch is operator intent, must not be undone by a machine credential); re-establishes the full project_user invariant (`access_mode`/`team_id`/`passthrough=false`) on whatever row holds the username; route `:team_id` must match the body's; mints are attributable via a structured `service credential issued` log (org/team/principal/rotated/expiry).
- TTL clamped to [1 min, 1 h], default 15 min (RDS-IAM precedent).
- Concurrency: decide-then-mutate under the org connection-admission lock (racing mints can't double-rotate into mutually invalidating hashes); the handler reloads this replica's snapshot immediately and fans `/api/v1/internal/reload-snapshot` out to peers, so a fresh credential auths on whichever replica the pgwire connection lands on.
- CLAUDE.md "Service Credentials — LOAD-BEARING CONTRACT" documents all invariants.

## Test plan

- `controlplane/provisioning/service_credential_test.go`: input validation incl. path/body team mismatch, TTL clamping, disabled-team → 409, thread-through, reuse omits password, snapshot reload fired.
- `controlplane/configstore/service_credential_postgres_test.go` (Postgres-backed, `kubernetes` tag): create→reuse→force-rotate lifecycle; admin-rotation collision (admin clears the grant clock → next mint rotates and returns plaintext); disabled login refused on reuse and force paths; mode/team/passthrough-flipped row re-established to project_user invariants; scope validation (unknown org/team, disabled team, empty principal).
- Migration tests: version pins 34→35, baseline-rebuild downgrade blocks drop the new column.
- Full `controlplane`, `configstore`, `provisioning`, `tests/configstore` suites pass under both tag sets (plain and `kubernetes`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*