### PR TITLE
Remove DuckDB 1.5.3 rollback row from worker image CI

### DIFF
--- a/.github/workflows/container-image-worker-cd.yml
+++ b/.github/workflows/container-image-worker-cd.yml
@@ -24,9 +24,8 @@ env:
 # To add a DuckDB version, add a row under matrix.duckdb. The
 # DUCKDB_GO_VERSION / DUCKDB_BINDINGS_VERSION pair maps to the
 # duckdb-go module versions; the encoding is `v0.<major><minor:02d><patch:02d>.0`,
-# so DuckDB 1.5.3 → v0.10503.0 / v2.10503.0 and 1.5.5 → v0.10505.0 /
-# v2.10505.0. See scripts/ducklake_version_matrix.sh for the same
-# mapping in test code.
+# so DuckDB 1.5.5 → v0.10505.0 / v2.10505.0. See
+# scripts/ducklake_version_matrix.sh for the same mapping in test code.
 #
 # Each row must declare every field below — Dockerfile.worker asserts the
 # build-args are non-empty (`:?must be set`) so a forgotten key produces a
@@ -68,32 +67,14 @@ jobs:
             fail-fast: false
             matrix:
                 duckdb:
-                    - version: "1.5.3"
-                      go: "v2.10503.0"
-                      bindings: "v0.10503.0"
-                      # cred-refresh-write-retry: mid-statement S3 credential
-                      # recovery on ExpiredToken read/write auth failures
-                      # (supersedes v1.5.3-cred-refresh, which it is based on).
-                      # Lets statements outlive their starting STS token as long
-                      # as the credential-refresh scheduler keeps rotating the
-                      # ducklake_s3 secret.
-                      httpfs: "v1.5.3-cred-refresh-write-retry"
-                      ducklake: "v1.0-posthog.6"
-                      # Keep the rollback row on the previously validated
-                      # stable scanner artifact.
-                      pg_scanner_repo: "https://extensions.duckdb.org"
-                      pg_scanner_sha256_amd64: "42e9ba5c2a9f9f77f1415e4cd320295f9623d4c20e09b20687d384a06681e54c"
-                      pg_scanner_sha256_arm64: "39eb0d153a2454397963b26aa2c2ceba853c21033277e06968b51173a5965a2f"
-                      # Rollback row: publishes suffixed tags only. Operators
-                      # roll a tenant back by re-pointing its `image`
-                      # config-store column at a …-duckdb1.5.3 tag.
-                      default: false
                     - version: "1.5.5"
                       go: "v2.10505.0"
                       bindings: "v0.10505.0"
-                      # cred-refresh-write-retry rebuilt against DuckDB 1.5.5:
-                      # mid-statement S3 credential recovery on ExpiredToken
-                      # read/write auth failures (see the 1.5.3 row).
+                      # cred-refresh-write-retry: mid-statement S3 credential
+                      # recovery on ExpiredToken read/write auth failures.
+                      # Lets statements outlive their starting STS token as long
+                      # as the credential-refresh scheduler keeps rotating the
+                      # ducklake_s3 secret.
                       httpfs: "v1.5.5-cred-refresh-write-retry"
                       # First PostHog DuckLake release built for DuckDB 1.5.5.
                       ducklake: "v1.0-posthog.7"
@@ -311,8 +292,6 @@ jobs:
             fail-fast: false
             matrix:
                 duckdb:
-                    - version: "1.5.3"
-                      default: false
                     - version: "1.5.5"
                       default: true
         runs-on: ubuntu-24.04

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -64,8 +64,8 @@ ARG POSTGRES_SCANNER_SHA256_ARM64=9ea7d5a3610f2b460bd2a5075684c5f6dad55fa19745a3
 # Cross-check that DUCKDB_EXTENSION_VERSION (which keys the bundled-extension
 # directory layout) matches the DuckDB version implied by DUCKDB_BINDINGS_VERSION.
 # Encoding is `v0.<major><minor:02d><patch:02d>.0`, so 1.5.5 ↔ v0.10505.0.
-# Without this, a CI matrix slip (e.g. extension_version=1.5.5 while bindings=v0.10503.0)
-# would seed extensions under v1.5.5/ for a 1.5.3 engine that looks under v1.5.3/,
+# Without this, a CI matrix slip (e.g. extension_version=1.5.5 while bindings=v0.10502.0)
+# would seed extensions under v1.5.5/ for a 1.5.2 engine that looks under v1.5.2/,
 # silently falling back to upstream extensions.duckdb.org for httpfs/ducklake
 # — the bundled PostHog forks would never load.
 RUN if [ -n "$DUCKDB_BINDINGS_VERSION" ] && [ -n "$DUCKDB_EXTENSION_VERSION" ]; then \

--- a/scripts/ducklake_version_matrix.sh
+++ b/scripts/ducklake_version_matrix.sh
@@ -24,11 +24,10 @@ TEST_TIMEOUT="${DUCKLAKE_TEST_TIMEOUT:-300s}"
 # Format: "module_version" — maps to duckdb-go/v2 + duckdb-go-bindings.
 # The encoding is v2.<major><minor:02d><patch:02d>.0, e.g.
 #   v2.10502.0 → DuckDB 1.5.2 (DuckLake 1.0)
-#   v2.10503.0 → DuckDB 1.5.3 (DuckLake 1.0)
 #   v2.10505.0 → DuckDB 1.5.5 (DuckLake 1.0)
-# The current default and rollback versions are benchmarked by default; older
+# The current default version is benchmarked by default; older
 # versions remain testable on demand via DUCKLAKE_VERSIONS.
-DEFAULT_VERSIONS="v2.10505.0 v2.10503.0"
+DEFAULT_VERSIONS="v2.10505.0"
 VERSIONS="${DUCKLAKE_VERSIONS:-$DEFAULT_VERSIONS}"
 
 CURRENT_ONLY=false


### PR DESCRIPTION
## Summary

Removes the DuckDB 1.5.3 build from CI: the 1.5.3 matrix rows (build + manifest) in `container-image-worker-cd.yml` are gone, so the workflow now only builds the 1.5.5 default. Also drops 1.5.3 from the `ducklake_version_matrix.sh` benchmark defaults and cleans up the comments that pointed at the removed row.

## Why

The 1.5.3 image was kept as a rollback fallback while 1.5.5 rolled out; 1.5.5 is now the fleet default and the extra row just costs CI time on every main push.

## Test plan

- Verified the YAML parses and the validate-matrix invariant (exactly one `default: true` in both build and manifest matrices) still holds — 1.5.5 is the only row and is default.
- CI on this PR exercises the workflow's changed files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*