### PR TITLE
Stitch cache proxy traces to Flight queries

### DIFF
--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -104,7 +104,7 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 		return err
 	}
 	for k, vv := range r.Header {
-		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, "Range") {
+		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, "Range") || isInternalPropagationHeader(k) {
 			continue
 		}
 		for _, v := range vv {

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -14,8 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -293,11 +295,16 @@ var hopByHop = map[string]bool{
 // before the origin request so it cannot affect S3 or a SigV4 request.
 const cachePassthroughHeader = "X-Duckgres-Cache-Passthrough"
 
+func isInternalPropagationHeader(header string) bool {
+	return strings.EqualFold(header, "traceparent") || strings.EqualFold(header, "tracestate")
+}
+
 // HandleProxy handles forward HTTP proxy requests from DuckDB httpfs.
 // Expects absolute-form URIs (scheme + host + path in the request-line).
 func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	inflightRequests.Inc()
 	defer inflightRequests.Dec()
+	r = r.WithContext(otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header)))
 
 	// HTTPS via CONNECT tunnel — we can't cache encrypted traffic, but we must
 	// still tunnel it so DuckDB can reach external HTTPS sources (e.g.
@@ -338,9 +345,8 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	// Legacy exact-range path (also the fallback for non-absolute ranges).
 	cacheKey := CacheKey(r.URL.String(), rangeHeader)
 
-	// Root span for this cacheable GET. DuckDB httpfs sends no traceparent, so
-	// this starts a fresh trace (service.name=duckgres-cache-proxy). Thread its
-	// context into r so the origin/peer fetch spans nest underneath.
+	// Requests without a propagated parent still start a standalone trace.
+	// Thread the cache request span context into origin/peer work below.
 	ctx, span := proxyTracer.Start(r.Context(), "cache.get", trace.WithAttributes(requestSpanAttrs(r)...))
 	defer span.End()
 	span.SetAttributes(attribute.String("duckgres.cache.key", cacheKey))
@@ -552,7 +558,7 @@ func (p *CacheProxy) fetchOriginOnce(cacheKey string, r *http.Request) (int64, s
 		return 0, "", err
 	}
 	for k, vv := range r.Header {
-		if hopByHop[strings.ToLower(k)] {
+		if hopByHop[strings.ToLower(k)] || isInternalPropagationHeader(k) {
 			continue
 		}
 		for _, v := range vv {
@@ -800,7 +806,7 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 	req.TransferEncoding = r.TransferEncoding
 	req.Trailer = r.Trailer
 	for k, vv := range r.Header {
-		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, cachePassthroughHeader) {
+		if hopByHop[strings.ToLower(k)] || strings.EqualFold(k, cachePassthroughHeader) || isInternalPropagationHeader(k) {
 			continue
 		}
 		for _, v := range vv {

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -126,15 +126,22 @@ func TestHandleProxyGETMissThenHit(t *testing.T) {
 	proxy := newTestProxy(t)
 
 	var originCalls int32
+	var traceHeadersReachedOrigin atomic.Bool
 	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&originCalls, 1)
+		traceHeadersReachedOrigin.Store(r.Header.Get("traceparent") != "" || r.Header.Get("tracestate") != "")
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("hello-parquet-bytes"))
 	})
 
 	// First request: cache miss → origin fetch → cached.
-	rec := doForwardProxyRequest(proxy, "GET", originURL+"/bucket/file.parquet", http.Header{"Range": []string{"bytes=0-18"}})
+	headers := http.Header{
+		"Range":       []string{"bytes=0-18"},
+		"traceparent": []string{"00-00000000000000000000000000000001-0000000000000002-01"},
+		"tracestate":  []string{"vendor=value"},
+	}
+	rec := doForwardProxyRequest(proxy, "GET", originURL+"/bucket/file.parquet", headers)
 	if rec.Code != http.StatusPartialContent {
 		t.Fatalf("miss: status = %d, want 206", rec.Code)
 	}
@@ -144,9 +151,12 @@ func TestHandleProxyGETMissThenHit(t *testing.T) {
 	if atomic.LoadInt32(&originCalls) != 1 {
 		t.Errorf("origin calls = %d, want 1 on miss", originCalls)
 	}
+	if traceHeadersReachedOrigin.Load() {
+		t.Fatal("trace propagation headers reached cached origin fetch")
+	}
 
 	// Second request for the same URL + Range: cache hit, no extra origin call.
-	rec = doForwardProxyRequest(proxy, "GET", originURL+"/bucket/file.parquet", http.Header{"Range": []string{"bytes=0-18"}})
+	rec = doForwardProxyRequest(proxy, "GET", originURL+"/bucket/file.parquet", headers)
 	if rec.Code != http.StatusPartialContent {
 		t.Fatalf("hit: status = %d, want 206", rec.Code)
 	}
@@ -159,13 +169,19 @@ func TestHandleProxyPassthroughGETSkipsCacheAndStripsMarker(t *testing.T) {
 	proxy := newTestProxy(t)
 	var originCalls atomic.Int32
 	var markerReachedOrigin atomic.Bool
+	var traceHeadersReachedOrigin atomic.Bool
 	_, originURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		originCalls.Add(1)
 		markerReachedOrigin.Store(r.Header.Get(cachePassthroughHeader) != "")
+		traceHeadersReachedOrigin.Store(r.Header.Get("traceparent") != "" || r.Header.Get("tracestate") != "")
 		_, _ = w.Write([]byte("uncached"))
 	})
 
-	headers := http.Header{cachePassthroughHeader: []string{"true"}}
+	headers := http.Header{
+		cachePassthroughHeader: []string{"true"},
+		"traceparent":          []string{"00-00000000000000000000000000000001-0000000000000002-01"},
+		"tracestate":           []string{"vendor=value"},
+	}
 	for range 2 {
 		rec := doForwardProxyRequest(proxy, http.MethodGet, originURL+"/bucket/file.parquet", headers)
 		if rec.Code != http.StatusOK || rec.Body.String() != "uncached" {
@@ -177,6 +193,9 @@ func TestHandleProxyPassthroughGETSkipsCacheAndStripsMarker(t *testing.T) {
 	}
 	if markerReachedOrigin.Load() {
 		t.Fatal("passthrough marker reached origin")
+	}
+	if traceHeadersReachedOrigin.Load() {
+		t.Fatal("trace propagation headers reached origin")
 	}
 	if _, _, ok := proxy.store.Open(CacheKey(originURL+"/bucket/file.parquet", "")); ok {
 		t.Fatal("passthrough request populated the cache")

--- a/cmd/cache-proxy/tracing_test.go
+++ b/cmd/cache-proxy/tracing_test.go
@@ -4,9 +4,12 @@ import (
 	"net/http"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // withSpanRecorder installs an in-memory span recorder as proxyTracer for the
@@ -143,5 +146,38 @@ func TestTracingForwardUncached(t *testing.T) {
 	}
 	if v := mustAttr(t, fwd, "http.request.method"); v.AsString() != http.MethodHead {
 		t.Errorf("forward: method attr = %q, want HEAD", v.AsString())
+	}
+}
+
+func TestTracingExtractsRemoteParentAtIngress(t *testing.T) {
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(previousPropagator) })
+
+	sr := withSpanRecorder(t)
+	proxy := newTestProxy(t)
+	_, originURL := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload-bytes"))
+	})
+
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	rec := doForwardProxyRequest(proxy, http.MethodGet, originURL+"/obj", http.Header{
+		"traceparent": {"00-" + parent.TraceID().String() + "-" + parent.SpanID().String() + "-01"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	getSpan := findSpan(t, sr, "cache.get")
+	if getSpan.SpanContext().TraceID() != parent.TraceID() {
+		t.Fatalf("cache.get trace = %s, want remote parent trace %s", getSpan.SpanContext().TraceID(), parent.TraceID())
+	}
+	if getSpan.Parent().SpanID() != parent.SpanID() {
+		t.Fatalf("cache.get parent = %s, want remote parent %s", getSpan.Parent().SpanID(), parent.SpanID())
 	}
 }

--- a/duckdbservice/cache_proxy_router.go
+++ b/duckdbservice/cache_proxy_router.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type cacheProxyMode string
@@ -53,6 +57,11 @@ type cacheProxyRouter struct {
 	// passthrough marks daemon-bound requests so cache-proxy records and
 	// forwards them but never serves from or writes to its cache.
 	passthrough bool
+	// activeContext is scoped to the current Flight schema probe or DoGet
+	// execution. Remote workers execute one query at a time, so this is a
+	// worker-local handoff to DuckDB's HTTP proxy requests.
+	activeContext   context.Context
+	activeContextID uint64
 }
 
 type cacheProxySupervisorConfig struct {
@@ -171,6 +180,35 @@ func (r *cacheProxyRouter) isPassthrough() bool {
 	return r.passthrough
 }
 
+// setActiveContext makes a Flight RPC context available while DuckDB performs
+// HTTP work. The returned cleanup only clears the context it installed, so an
+// older deferred cleanup cannot erase a newer execution's context.
+func (r *cacheProxyRouter) setActiveContext(ctx context.Context) func() {
+	r.mu.Lock()
+	r.activeContextID++
+	id := r.activeContextID
+	r.activeContext = ctx
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.activeContextID == id {
+			r.activeContext = nil
+		}
+	}
+}
+
+func (r *cacheProxyRouter) injectActiveContext(req *http.Request) {
+	r.mu.RLock()
+	ctx := r.activeContext
+	r.mu.RUnlock()
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		return
+	}
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+}
+
 func recordCacheProxyMode(mode cacheProxyMode) {
 	for _, candidate := range []cacheProxyMode{cacheProxyModeDisabled, cacheProxyModeCached, cacheProxyModeBypassed} {
 		value := 0.0
@@ -188,6 +226,7 @@ func (r *cacheProxyRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	if r.Mode() == cacheProxyModeCached {
 		cacheReq := cloneProxyRequest(req, false)
+		r.injectActiveContext(cacheReq)
 		if r.isPassthrough() {
 			cacheReq.Header.Set(cacheProxyPassthroughHeader, "true")
 		}

--- a/duckdbservice/cache_proxy_router_test.go
+++ b/duckdbservice/cache_proxy_router_test.go
@@ -1,6 +1,7 @@
 package duckdbservice
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -9,6 +10,10 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func waitForCacheProxyMode(t *testing.T, router *cacheProxyRouter, want cacheProxyMode) {
@@ -105,6 +110,54 @@ func TestCacheProxyRouterMarksPassthroughRequests(t *testing.T) {
 	}
 	if !marked.Load() {
 		t.Fatal("cache-bound request was not marked as passthrough")
+	}
+}
+
+func TestCacheProxyRouterInjectsActiveTraceContext(t *testing.T) {
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(previousPropagator) })
+
+	var gotTraceparent string
+	cache := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer cache.Close()
+
+	router := newCacheProxyRouter(cache.Listener.Addr().String(), false)
+	router.setMode(cacheProxyModeCached)
+	tp := sdktrace.NewTracerProvider()
+	ctx, span := tp.Tracer("test").Start(context.Background(), "flight.doget")
+	defer span.End()
+	clear := router.setActiveContext(ctx)
+	defer clear()
+
+	proxy := httptest.NewServer(router)
+	defer proxy.Close()
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get("http://example.com/warehouse/file.parquet")
+	if err != nil {
+		t.Fatalf("GET through router: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if gotTraceparent == "" {
+		t.Fatal("cache-bound request missing traceparent from active Flight context")
+	}
+
+	clear()
+	gotTraceparent = "sentinel"
+	resp, err = client.Get("http://example.com/warehouse/file.parquet")
+	if err != nil {
+		t.Fatalf("GET after clearing context: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if gotTraceparent != "" {
+		t.Fatalf("cache-bound request traceparent after context cleared = %q, want empty", gotTraceparent)
 	}
 }
 

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -676,6 +676,8 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	defer session.progress.queryActive.Store(false)
 	endTxnWork := ttx.beginWork()
 	defer endTxnWork()
+	clearCacheProxyContext := h.pool.setActiveCacheProxyContext(ctx)
+	defer clearCacheProxyContext()
 
 	// Only retry on transient errors for autocommit queries. Inside a
 	// transaction, a transient error invalidates the transaction — retrying
@@ -801,6 +803,8 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 			releaseQueryHandleValue(handle)
 		}()
 		defer endConnWork()
+		clearCacheProxyContext := h.pool.setActiveCacheProxyContext(ctx)
+		defer clearCacheProxyContext()
 
 		// The query ID's lifetime mirrors queryActive exactly: the progress
 		// monitor reads both from its own goroutine, and a stuck-query warning

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -130,6 +130,13 @@ type SessionPool struct {
 	instance instanceHealth
 }
 
+func (p *SessionPool) setActiveCacheProxyContext(ctx context.Context) func() {
+	if p.cacheRouter == nil {
+		return func() {}
+	}
+	return p.cacheRouter.setActiveContext(ctx)
+}
+
 func (p *SessionPool) currentS3CacheModeLocked() transform.S3CacheMode {
 	if p.s3CacheMode == "" {
 		return transform.S3CacheOn


### PR DESCRIPTION
## Summary

- propagate the active Flight RPC context through the worker-local cache router
- extract that context at cache-proxy ingress so existing cache request and origin spans join the query trace
- prevent internal W3C propagation headers from reaching the S3 origin

## Why

Worker-local HTTP proxy requests previously lost the query context, causing cache-proxy spans to start independent traces rather than continue the existing `duckgres.query` trace.

## Impact

Cached and passthrough requests now preserve the existing query trace across the worker and cache-proxy boundary. Requests without an active context continue to create standalone cache-proxy traces.

## Validation

- `go test ./duckdbservice ./cmd/cache-proxy`
- `just lint`
