### PR TITLE
Validate org database_name as a DNS label, and make it editable in admin

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -265,6 +265,16 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 	if updates.DataImportsTableNamingVersion != "" {
 		fields["data_imports_table_naming_version"] = updates.DataImportsTableNamingVersion
 	}
+	// DatabaseName is "" = preserve (the column is NOT NULL and the handler's
+	// presence-merge has already preserved omitted fields, so a "" here can
+	// only mean "key absent"). A non-empty value renames the database — and
+	// with it the org's managed hostname (<database_name>.<managed-suffix>),
+	// which is exactly the operator surface for fixing orgs whose stored name
+	// is not a routable DNS label. The unique index still guards collisions;
+	// validation lives in the handler.
+	if updates.DatabaseName != "" {
+		fields["database_name"] = updates.DatabaseName
+	}
 	// HostnameAlias is *string: nil = preserve, "" = clear (NULL), "x" = set.
 	// NULL releases the unique-index slot so other orgs can take that alias.
 	if updates.HostnameAlias != nil {
@@ -891,6 +901,12 @@ func (h *apiHandler) createOrg(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
 		return
 	}
+	// database_name becomes the org's managed hostname label, so it must be a
+	// routable single DNS label at birth (same rule as the provisioning API).
+	if err := configstore.ValidateDatabaseName(org.DatabaseName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	if req.TeamID <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "team_id is required (a positive PostHog team id — every org must have at least one team)"})
 		return
@@ -967,6 +983,18 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 		return
 	}
 	merged := *existing
+	// database_name is presence-aware like every other column: absent keeps the
+	// stored value; a present value must be a valid DNS label (it becomes the
+	// org's hostname). This is the break-glass edit surface for orgs whose
+	// stored name predates the DNS-label rule and is therefore unroutable —
+	// rename and the hostname works the moment the snapshot reloads.
+	if _, ok := fields["database_name"]; ok {
+		if err := configstore.ValidateDatabaseName(updates.DatabaseName); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		merged.DatabaseName = updates.DatabaseName
+	}
 	if _, ok := fields["max_workers"]; ok {
 		merged.MaxWorkers = updates.MaxWorkers
 	}
@@ -1002,6 +1030,7 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 			changes = append(changes, fmt.Sprintf("%s %v → %v", key, old, next))
 		}
 	}
+	addChange("database_name", existing.DatabaseName, merged.DatabaseName)
 	addChange("max_workers", existing.MaxWorkers, merged.MaxWorkers)
 	addChange("max_vcpus", existing.MaxVCPUs, merged.MaxVCPUs)
 	addChange("default_worker_cpu", orgStr(existing.DefaultWorkerCPU), orgStr(merged.DefaultWorkerCPU))

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -903,6 +903,9 @@ func (h *apiHandler) createOrg(c *gin.Context) {
 	}
 	// database_name becomes the org's managed hostname label, so it must be a
 	// routable single DNS label at birth (same rule as the provisioning API).
+	// Trim the operator's value first so " acme" fails with the real problem
+	// instead of storing leading whitespace.
+	org.DatabaseName = strings.TrimSpace(org.DatabaseName)
 	if err := configstore.ValidateDatabaseName(org.DatabaseName); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -989,6 +992,10 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	// stored name predates the DNS-label rule and is therefore unroutable —
 	// rename and the hostname works the moment the snapshot reloads.
 	if _, ok := fields["database_name"]; ok {
+		// Trim whitespace around the operator's value before validating/
+		// storing so " acme" 400s with the real problem instead of storing a
+		// subtly different name than the operator typed and saw validated.
+		updates.DatabaseName = strings.TrimSpace(updates.DatabaseName)
 		if err := configstore.ValidateDatabaseName(updates.DatabaseName); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -1045,12 +1052,28 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 
 	org, ok, err := h.store.UpdateOrg(name, merged)
 	if err != nil {
+		if configstore.IsUniqueViolationErr(err) {
+			// database_name or hostname_alias unique index — same 409 the
+			// create/provision surfaces map for the identical conflict.
+			c.JSON(http.StatusConflict, gin.H{"error": "database_name or hostname_alias is already in use by another org"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	if !ok {
 		c.JSON(http.StatusNotFound, gin.H{"error": "org not found"})
 		return
+	}
+	// A database_name rename moves the org's managed hostname: without forcing
+	// a reload, every replica routes on its stale snapshot until the next poll
+	// (the new hostname 08006s while the API here already reported success).
+	// Same snapshot-convergence contract as user/team mutations.
+	if existing.DatabaseName != org.DatabaseName {
+		if err := h.notifyPeersOfChange(c); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("renamed, but failed to reload the local snapshot: %v", err)})
+			return
+		}
 	}
 	c.JSON(http.StatusOK, org)
 }

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -140,6 +140,25 @@ func TestAdminUpdateOrgRenamesDatabaseNamePostgres(t *testing.T) {
 	if updated.DatabaseName != "acme-inc" {
 		t.Fatalf("stored database_name = %q, want acme-inc", updated.DatabaseName)
 	}
+
+	// Rename onto a squatted name trips the unique index — the handler maps
+	// the 23505 to HTTP 409 (asserted here through the store error so the
+	// IsUniqueViolationErr classification is pinned against the real driver).
+	store2 := newPostgresConfigStore(t)
+	if err := store2.DB().Create(&configstore.Org{Name: "taken-a", DatabaseName: "taken-name"}).Error; err != nil {
+		t.Fatalf("seed squatter: %v", err)
+	}
+	if err := store2.DB().Create(&configstore.Org{Name: "taken-b", DatabaseName: "other-name"}).Error; err != nil {
+		t.Fatalf("seed renamer: %v", err)
+	}
+	_, _, err = newGormAPIStore(store2).(*gormAPIStore).
+		UpdateOrg("taken-b", configstore.Org{DatabaseName: "taken-name"})
+	if err == nil {
+		t.Fatal("rename onto taken database_name: want error")
+	}
+	if !configstore.IsUniqueViolationErr(err) {
+		t.Fatalf("rename onto taken database_name: err = %v, want a 23505 the handler maps to 409", err)
+	}
 }
 
 func TestAdminUpdateOrgPersistsDataImportsTableNamingVersionPostgres(t *testing.T) {

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -104,6 +104,44 @@ func TestAdminAdmissionConfigMutationsSerializePostgres(t *testing.T) {
 	}
 }
 
+// TestAdminUpdateOrgRenamesDatabaseNamePostgres exercises the gorm store's
+// database_name threading against real Postgres: a non-empty value renames
+// (the break-glass fix for unroutable stored names), an empty value preserves
+// (absent key semantics — the handler presence-merge makes "" impossible from
+// the API, but the store contract is pinned here).
+func TestAdminUpdateOrgRenamesDatabaseNamePostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	if err := store.DB().Create(&configstore.Org{
+		Name:         "rename-org",
+		DatabaseName: "ACME INC", // grandfathered broken row: not a routable hostname label
+	}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+
+	// Empty = preserve.
+	preserved, found, err := apiStore.UpdateOrg("rename-org", configstore.Org{MaxWorkers: 1})
+	if err != nil || !found {
+		t.Fatalf("preserve update: found=%v err=%v", found, err)
+	}
+	if preserved.DatabaseName != "ACME INC" {
+		t.Fatalf("empty DatabaseName should preserve, got %q", preserved.DatabaseName)
+	}
+
+	// Non-empty = rename (and the unique index rejects squatters).
+	updated, found, err := apiStore.UpdateOrg("rename-org", configstore.Org{DatabaseName: "acme-inc"})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if !found {
+		t.Fatal("renamed org was not found")
+	}
+	if updated.DatabaseName != "acme-inc" {
+		t.Fatalf("stored database_name = %q, want acme-inc", updated.DatabaseName)
+	}
+}
+
 func TestAdminUpdateOrgPersistsDataImportsTableNamingVersionPostgres(t *testing.T) {
 	store := newPostgresConfigStore(t)
 	if err := store.DB().Create(&configstore.Org{

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -77,6 +77,10 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 	}
 	org.MaxWorkers = updates.MaxWorkers
 	org.MaxVCPUs = updates.MaxVCPUs
+	// Mirrors gormAPIStore: "" = preserve, non-empty renames.
+	if updates.DatabaseName != "" {
+		org.DatabaseName = updates.DatabaseName
+	}
 	// Mirrors gormAPIStore: written unconditionally so "" clears (the handler
 	// presence-merge already preserved omitted fields).
 	org.DefaultWorkerCPU = updates.DefaultWorkerCPU
@@ -1934,7 +1938,7 @@ func TestCreateOrgPersistsHostnameAlias(t *testing.T) {
 	store := newFakeAPIStore()
 	router := newTestAPIRouter(store)
 
-	body := []byte(`{"name":"tenant-alpha-id","database_name":"tenant_alpha","hostname_alias":"entirely-chief-wildcat","team_id":12345}`)
+	body := []byte(`{"name":"tenant-alpha-id","database_name":"tenant-alpha","hostname_alias":"entirely-chief-wildcat","team_id":12345}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -2065,6 +2069,109 @@ func TestCreateOrgRejectsHostnameAliasOver63Chars(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("64-char alias should be rejected: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateOrgRejectsInvalidDatabaseName(t *testing.T) {
+	cases := []struct {
+		name string
+		db   string
+	}{
+		{"missing database_name", ""},
+		{"space", "acme inc"},
+		{"dot", "acme.inc"},
+		{"underscore", "acme_inc"},
+		{"uppercase", "Acme"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAPIStore()
+			router := newTestAPIRouter(store)
+
+			body := []byte(fmt.Sprintf(`{"name":"acme","database_name":%q,"team_id":12345}`, tc.db))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("database_name %q: status = %d, want %d: %s", tc.db, rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if _, ok := store.orgs["acme"]; ok {
+				t.Errorf("database_name %q: org should NOT have been created", tc.db)
+			}
+		})
+	}
+}
+
+func TestUpdateOrgRenamesDatabaseName(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["tenant-alpha-id"] = &configstore.Org{
+		Name:         "tenant-alpha-id",
+		DatabaseName: "ACME INC", // pre-existing broken row: not a valid hostname label
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"database_name":"acme-inc"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/tenant-alpha-id", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.orgs["tenant-alpha-id"].DatabaseName; got != "acme-inc" {
+		t.Errorf("DatabaseName = %q, want %q", got, "acme-inc")
+	}
+}
+
+func TestUpdateOrgRejectsInvalidDatabaseName(t *testing.T) {
+	cases := []string{"", "acme.inc", "acme inc", "Acme", "-acme"}
+	for _, db := range cases {
+		t.Run(db, func(t *testing.T) {
+			store := newFakeAPIStore()
+			store.orgs["tenant-alpha-id"] = &configstore.Org{
+				Name:         "tenant-alpha-id",
+				DatabaseName: "tenant-alpha",
+			}
+			router := newTestAPIRouter(store)
+
+			body := []byte(fmt.Sprintf(`{"database_name":%q}`, db))
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/tenant-alpha-id", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("database_name %q: status = %d, want %d: %s", db, rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if got := store.orgs["tenant-alpha-id"].DatabaseName; got != "tenant-alpha" {
+				t.Errorf("database_name %q: DatabaseName = %q, want unchanged %q", db, got, "tenant-alpha")
+			}
+		})
+	}
+}
+
+func TestUpdateOrgWithoutDatabaseNameKeyPreservesIt(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["tenant-alpha-id"] = &configstore.Org{
+		Name:         "tenant-alpha-id",
+		DatabaseName: "ACME INC", // broken pre-existing value: untouched edits must not force a rename
+	}
+	router := newTestAPIRouter(store)
+
+	body := []byte(`{"max_workers":4}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/tenant-alpha-id", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.orgs["tenant-alpha-id"].DatabaseName; got != "ACME INC" {
+		t.Errorf("DatabaseName = %q, want preserved %q", got, "ACME INC")
 	}
 }
 

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -2173,6 +2173,61 @@ func TestUpdateOrgWithoutDatabaseNameKeyPreservesIt(t *testing.T) {
 	if got := store.orgs["tenant-alpha-id"].DatabaseName; got != "ACME INC" {
 		t.Errorf("DatabaseName = %q, want preserved %q", got, "ACME INC")
 	}
+	if store.reloadSnapshotCalls != 0 {
+		t.Errorf("reloadSnapshotCalls = %d, want 0 (no rename, no reload)", store.reloadSnapshotCalls)
+	}
+}
+
+func TestUpdateOrgRenameDatabaseNameTrimsAndReloadsSnapshot(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["tenant-alpha-id"] = &configstore.Org{
+		Name:         "tenant-alpha-id",
+		DatabaseName: "ACME INC",
+	}
+	router := newTestAPIRouter(store)
+
+	// The operator's whitespace is normalized, and the rename forces a local
+	// snapshot reload + peer fan-out — otherwise every replica keeps routing
+	// on the stale name until its next poll while the API already reported
+	// success.
+	body := []byte(`{"database_name":"  acme-inc  "}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/tenant-alpha-id", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := store.orgs["tenant-alpha-id"].DatabaseName; got != "acme-inc" {
+		t.Errorf("DatabaseName = %q, want trimmed %q", got, "acme-inc")
+	}
+	if store.reloadSnapshotCalls != 1 {
+		t.Errorf("reloadSnapshotCalls = %d, want 1 (rename must reload the routing snapshot)", store.reloadSnapshotCalls)
+	}
+}
+
+func TestUpdateOrgSameDatabaseNameDoesNotReload(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["tenant-alpha-id"] = &configstore.Org{
+		Name:         "tenant-alpha-id",
+		DatabaseName: "tenant-alpha",
+	}
+	router := newTestAPIRouter(store)
+
+	// Resending the stored name is a no-op for routing: no reload fan-out.
+	body := []byte(`{"database_name":"tenant-alpha"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/tenant-alpha-id", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if store.reloadSnapshotCalls != 0 {
+		t.Errorf("reloadSnapshotCalls = %d, want 0 (name unchanged)", store.reloadSnapshotCalls)
+	}
 }
 
 func TestUpdateOrgOmittingHostnameAliasPreservesIt(t *testing.T) {

--- a/controlplane/admin/ui/src/components/AddOrgDialog.test.tsx
+++ b/controlplane/admin/ui/src/components/AddOrgDialog.test.tsx
@@ -81,6 +81,20 @@ describe("AddOrgDialog", () => {
     expect(screen.getByRole("button", { name: /provision organization/i })).toBeDisabled();
   });
 
+  it("rejects a database name that is not a valid DNS label client-side", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText("Org id"), OK_UUID);
+    const dbInput = screen.getByLabelText("Database name");
+    await user.clear(dbInput);
+    await user.type(dbInput, "ACME INC");
+    await user.type(screen.getByLabelText("Team id"), "12345");
+
+    expect(screen.getByText(/single DNS label/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /provision organization/i })).toBeDisabled();
+  });
+
   it("blocks a database name that is already taken", async () => {
     const user = userEvent.setup();
     client.checkDatabaseName.mockResolvedValue({ name: OK_UUID, available: false });

--- a/controlplane/admin/ui/src/components/AddOrgDialog.tsx
+++ b/controlplane/admin/ui/src/components/AddOrgDialog.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dialog";
 import { StateBadge } from "@/components/StateBadge";
 import { api } from "@/lib/api";
+import { databaseNameProblem } from "@/lib/databaseName";
 import { useDatabaseNameAvailable, useWarehouseStatus } from "@/hooks/useApi";
 import type { ProvisionWarehouseBody, ProvisionWarehouseResult } from "@/types/api";
 
@@ -91,6 +92,7 @@ export function AddOrgDialog({ open, onClose }: { open: boolean; onClose: () => 
   const trimmedOrg = orgId.trim();
   const trimmedDb = databaseName.trim();
   const orgProblem = trimmedOrg === "" ? null : orgIdProblem(trimmedOrg);
+  const dbProblem = trimmedDb === "" ? null : databaseNameProblem(trimmedDb);
   const teamIdOk = /^\d+$/.test(teamId.trim()) && Number(teamId.trim()) > 0;
 
   // Prefill the database name with the org id (the django flow does the same)
@@ -136,9 +138,9 @@ export function AddOrgDialog({ open, onClose }: { open: boolean; onClose: () => 
   const canSubmit = useMemo(() => {
     if (pending || result) return false;
     if (trimmedOrg === "" || orgProblem) return false;
-    if (trimmedDb === "" || dbTaken) return false;
+    if (trimmedDb === "" || dbProblem || dbTaken) return false;
     return teamIdOk;
-  }, [pending, result, trimmedOrg, orgProblem, trimmedDb, dbTaken, teamIdOk]);
+  }, [pending, result, trimmedOrg, orgProblem, trimmedDb, dbProblem, dbTaken, teamIdOk]);
 
   const submit = async () => {
     setError(null);
@@ -283,7 +285,8 @@ export function AddOrgDialog({ open, onClose }: { open: boolean; onClose: () => 
                 className="font-mono text-xs"
               />
             </FieldRow>
-            {dbTaken && (
+            {dbProblem && <p className="text-xs text-destructive">{dbProblem}</p>}
+            {!dbProblem && dbTaken && (
               <p className="text-xs text-destructive">
                 The database name "{trimmedDb}" is already in use by another org.
               </p>

--- a/controlplane/admin/ui/src/lib/databaseName.ts
+++ b/controlplane/admin/ui/src/lib/databaseName.ts
@@ -1,0 +1,29 @@
+// Client-side mirror of configstore.ValidateDatabaseName (Go): an org's
+// database_name is the tenant's public socket identity — the single label of
+// its managed hostname (<database_name>.<managed-suffix>) and the dbname
+// clients connect with — so it must be a valid single DNS label (RFC 1035:
+// lowercase alphanumeric + hyphens, no leading/trailing hyphen, 1–63 chars,
+// i.e. a Kubernetes DNS-1123 label). A name with spaces, dots or underscores
+// stores fine but produces an unroutable hostname: the wildcard cert doesn't
+// cover it and SNI prefix extraction drops multi-label prefixes.
+//
+// Client-side symmetry only — the server is authoritative (400 on every write
+// surface: provision, admin create, admin update).
+const DATABASE_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const MAX_DATABASE_NAME_LENGTH = 63;
+
+// Returns a human-readable problem, or null when name is a valid database
+// name. Empty input is "no opinion" (null) so callers decide whether the
+// field is required.
+export function databaseNameProblem(name: string): string | null {
+  if (name === "") {
+    return null;
+  }
+  if (name.length > MAX_DATABASE_NAME_LENGTH) {
+    return `Must be at most ${MAX_DATABASE_NAME_LENGTH} characters (DNS label limit).`;
+  }
+  if (!DATABASE_NAME_PATTERN.test(name)) {
+    return "Lowercase letters, digits and hyphens; must start and end alphanumeric (a single DNS label — no spaces, dots or underscores: it becomes the org's hostname).";
+  }
+  return null;
+}

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -153,6 +153,38 @@ describe("Org detail", () => {
     expect(warehouseUpdate).toHaveBeenCalledWith({ metadata_proxy_enabled: next });
   });
 
+  it("sends database_name only when it changed", async () => {
+    const user = userEvent.setup();
+    renderPage(false);
+
+    // Untouched: save carries no database_name (no spurious rename).
+    await user.click(screen.getByText("Save changes"));
+    expect(orgUpdate).toHaveBeenCalledTimes(1);
+    expect(orgUpdate).toHaveBeenCalledWith(expect.not.objectContaining({ database_name: expect.anything() }));
+
+    orgUpdate.mockClear();
+
+    // Fixed a broken stored name: the rename rides the update.
+    const dbInput = screen.getByLabelText(/database name/i);
+    await user.clear(dbInput);
+    await user.type(dbInput, "acme-inc");
+    await user.click(screen.getByText("Save changes"));
+    expect(orgUpdate).toHaveBeenCalledTimes(1);
+    expect(orgUpdate).toHaveBeenCalledWith(expect.objectContaining({ database_name: "acme-inc" }));
+  });
+
+  it("rejects a database name that is not a valid DNS label client-side", async () => {
+    const user = userEvent.setup();
+    renderPage(false);
+
+    const dbInput = screen.getByLabelText(/database name/i);
+    await user.clear(dbInput);
+    await user.type(dbInput, "acme inc");
+
+    expect(screen.getByText(/single DNS label/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+  });
+
   it("saves a changed data import table naming version", async () => {
     const user = userEvent.setup();
     HTMLElement.prototype.scrollIntoView = vi.fn();

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ManagedWarehouse, Org } from "@/types/api";
 
 const hooks = vi.hoisted(() => ({
+  useDatabaseNameAvailable: vi.fn(),
   useDeleteOrg: vi.fn(),
   useDeprovisionWarehouse: vi.fn(),
   useDucklingsMetadata: vi.fn(),
@@ -126,6 +127,7 @@ describe("Org detail", () => {
       me: { email: "admin@example.com", role: "admin", source: "sso" },
     });
     hooks.useOrg.mockReturnValue(ok(ORG));
+    hooks.useDatabaseNameAvailable.mockReturnValue({ data: null, isLoading: false });
     hooks.useUpdateOrg.mockReturnValue(mut(orgUpdate));
     hooks.useDeleteOrg.mockReturnValue(mut());
     hooks.useUpdateWarehouse.mockReturnValue(mut(warehouseUpdate));
@@ -173,6 +175,31 @@ describe("Org detail", () => {
     expect(orgUpdate).toHaveBeenCalledWith(expect.objectContaining({ database_name: "acme-inc" }));
   });
 
+  it("keeps every other setting editable for an org whose stored name predates the rule", async () => {
+    // The premise of the break-glass surface: grandfathered rows like
+    // "ACME INC" must NOT wedge the whole org-config card behind a forced
+    // rename. The server preserves database_name when the key is absent
+    // (Go test TestUpdateOrgWithoutDatabaseNameKeyPreservesIt).
+    const user = userEvent.setup();
+    hooks.useOrg.mockReturnValue(ok({ ...ORG, database_name: "ACME INC" }));
+    renderPage(false);
+
+    const save = screen.getByRole("button", { name: /save changes/i });
+    expect(save).toBeEnabled();
+    expect(screen.getByLabelText(/database name/i)).toHaveValue("ACME INC");
+
+    await user.click(save);
+    expect(orgUpdate).toHaveBeenCalledTimes(1);
+    expect(orgUpdate).toHaveBeenCalledWith(expect.not.objectContaining({ database_name: expect.anything() }));
+
+    // Fixing the name unlocks the rename path.
+    const dbInput = screen.getByLabelText(/database name/i);
+    await user.clear(dbInput);
+    await user.type(dbInput, "acme-inc");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    expect(orgUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ database_name: "acme-inc" }));
+  });
+
   it("rejects a database name that is not a valid DNS label client-side", async () => {
     const user = userEvent.setup();
     renderPage(false);
@@ -182,6 +209,30 @@ describe("Org detail", () => {
     await user.type(dbInput, "acme inc");
 
     expect(screen.getByText(/single DNS label/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+  });
+
+  it("disables save with an explanation when the database name is cleared", async () => {
+    const user = userEvent.setup();
+    renderPage(false);
+
+    const dbInput = screen.getByLabelText(/database name/i);
+    await user.clear(dbInput);
+
+    expect(screen.getByText(/database name is required/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+  });
+
+  it("blocks a rename onto a database name another org already owns", async () => {
+    const user = userEvent.setup();
+    hooks.useDatabaseNameAvailable.mockReturnValue(ok({ name: "taken-name", available: false }));
+    renderPage(false);
+
+    const dbInput = screen.getByLabelText(/database name/i);
+    await user.clear(dbInput);
+    await user.type(dbInput, "taken-name");
+
+    expect(await screen.findByText(/already in use by another org/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
   });
 

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ApiError } from "@/lib/api";
+import { databaseNameProblem } from "@/lib/databaseName";
 import { ducklingBroken, ducklingEntryFor, fmtTime } from "@/lib/format";
 import { ShardBadge } from "@/components/ShardBadge";
 import {
@@ -48,6 +49,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import type { DataImportsTableNamingVersion, ManagedWarehouse, OrgTeam, OrgUpdate } from "@/types/api";
 
 interface FormState {
+  database_name: string;
   max_workers: string;
   max_vcpus: string;
   default_worker_cpu: string;
@@ -59,6 +61,7 @@ interface FormState {
 }
 
 function orgToForm(o: {
+  database_name: string;
   max_workers: number;
   max_vcpus: number;
   default_worker_cpu: string;
@@ -69,6 +72,7 @@ function orgToForm(o: {
   data_imports_table_naming_version: DataImportsTableNamingVersion;
 }): FormState {
   return {
+    database_name: o.database_name,
     max_workers: String(o.max_workers),
     max_vcpus: String(o.max_vcpus),
     default_worker_cpu: o.default_worker_cpu,
@@ -118,8 +122,15 @@ export function OrgDetail() {
 
   const set = (k: keyof FormState, v: string) => setForm((f) => (f ? { ...f, [k]: v } : f));
 
+  // Client-side mirror of the server's DNS-label rule (configstore
+  // .ValidateDatabaseName) so a typo is a red border, not a round-trip 400.
+  const trimmedDb = form.database_name.trim();
+  const dbProblem = databaseNameProblem(trimmedDb);
+  const dbChanged = trimmedDb !== org.data?.database_name;
+
   const save = async () => {
     setMsg(null);
+    const trimmedDb = form.database_name.trim();
     const body: OrgUpdate = {
       max_workers: Number(form.max_workers) || 0,
       max_vcpus: Number(form.max_vcpus) || 0,
@@ -130,6 +141,14 @@ export function OrgDetail() {
       hostname_alias: form.hostname_alias === "" ? "" : form.hostname_alias,
       data_imports_table_naming_version: form.data_imports_table_naming_version,
     };
+    // Only send database_name when it actually changed — renaming it also
+    // renames the org's managed hostname, so an untouched form never risks a
+    // spurious rename. The change reason: orgs whose stored name predates the
+    // DNS-label rule are unroutable (<name>.<suffix> isn't a valid hostname);
+    // this is the operator surface that fixes them without a SQL round-trip.
+    if (trimmedDb !== org.data?.database_name) {
+      body.database_name = trimmedDb;
+    }
     try {
       await update.mutateAsync(body);
       setMsg({ kind: "ok", text: "Saved." });
@@ -242,6 +261,31 @@ export function OrgDetail() {
                   />
                 </Field>
               </div>
+              <Field label="Database name (also the hostname label)">
+                <Input
+                  aria-label="Database name"
+                  value={form.database_name}
+                  placeholder="single DNS label, e.g. acme-prod"
+                  className={`font-mono text-xs ${dbProblem ? "border-destructive" : ""}`}
+                  onChange={(e) => set("database_name", e.target.value)}
+                />
+              </Field>
+              {dbProblem ? (
+                <p className="text-xs text-destructive">{dbProblem}</p>
+              ) : (
+                dbChanged && (
+                  <p className="flex items-start gap-2 text-xs text-warning">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>
+                      The database name is this org's hostname — clients reach it at
+                      <span className="font-mono"> {trimmedDb || "<name>"}.&lt;managed-suffix&gt;</span> and
+                      connect with dbname={trimmedDb || "<name>"}. Renaming moves the hostname and the
+                      dbname immediately; fix invalid stored names here, and coordinate the rename with
+                      the tenants' connection settings.
+                    </span>
+                  </p>
+                )
+              )}
               <Field label="Hostname alias (empty clears)">
                 <Input
                   value={form.hostname_alias}
@@ -280,7 +324,7 @@ export function OrgDetail() {
               )}
               <div className="flex items-center gap-3 pt-1">
                 <AdminGate>
-                  <Button size="sm" onClick={save} disabled={update.isPending}>
+                  <Button size="sm" onClick={save} disabled={update.isPending || dbProblem !== null}>
                     <Save className="h-4 w-4" /> {update.isPending ? "Saving…" : "Save changes"}
                   </Button>
                 </AdminGate>

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -27,6 +27,7 @@ import { databaseNameProblem } from "@/lib/databaseName";
 import { ducklingBroken, ducklingEntryFor, fmtTime } from "@/lib/format";
 import { ShardBadge } from "@/components/ShardBadge";
 import {
+  useDatabaseNameAvailable,
   useDeleteOrg,
   useDeprovisionWarehouse,
   useDucklingsMetadata,
@@ -101,6 +102,25 @@ export function OrgDetail() {
     if (org.data) setForm(orgToForm(org.data));
   }, [org.data]);
 
+  // Client-side mirror of the server's DNS-label rule (configstore
+  // .ValidateDatabaseName) so a typo is a red border, not a round-trip 400.
+  // Crucially the save gate only applies when the operator actually CHANGED
+  // the name: orgs whose stored value predates the rule (the premise of this
+  // break-glass surface) must keep every OTHER org setting editable without
+  // forcing a rename, and database_name is only sent when it differs (save()
+  // below), so an unchanged grandfathered value never blocks saving.
+  // (Derived BEFORE the early returns below: the availability hook must run
+  // on every render, unconditionally.)
+  const trimmedDb = form ? form.database_name.trim() : "";
+  const dbChanged = form !== null && trimmedDb !== org.data?.database_name;
+  const dbProblem =
+    form === null || !dbChanged ? null : trimmedDb === "" ? "Database name is required." : databaseNameProblem(trimmedDb);
+  // Availability probe for the rename target: renaming onto another org's
+  // name is the one failure an operator can hit at save time, so flag it
+  // before the round-trip (the server still 409s authoritatively).
+  const dbCheck = useDatabaseNameAvailable(trimmedDb, dbChanged && dbProblem === null);
+  const dbTaken = Boolean(dbChanged && dbProblem === null && dbCheck.data && !dbCheck.data.available);
+
   if (org.isLoading || !form) {
     return (
       <>
@@ -121,12 +141,6 @@ export function OrgDetail() {
   }
 
   const set = (k: keyof FormState, v: string) => setForm((f) => (f ? { ...f, [k]: v } : f));
-
-  // Client-side mirror of the server's DNS-label rule (configstore
-  // .ValidateDatabaseName) so a typo is a red border, not a round-trip 400.
-  const trimmedDb = form.database_name.trim();
-  const dbProblem = databaseNameProblem(trimmedDb);
-  const dbChanged = trimmedDb !== org.data?.database_name;
 
   const save = async () => {
     setMsg(null);
@@ -272,6 +286,10 @@ export function OrgDetail() {
               </Field>
               {dbProblem ? (
                 <p className="text-xs text-destructive">{dbProblem}</p>
+              ) : dbTaken ? (
+                <p className="text-xs text-destructive">
+                  The database name "{trimmedDb}" is already in use by another org.
+                </p>
               ) : (
                 dbChanged && (
                   <p className="flex items-start gap-2 text-xs text-warning">
@@ -324,7 +342,7 @@ export function OrgDetail() {
               )}
               <div className="flex items-center gap-3 pt-1">
                 <AdminGate>
-                  <Button size="sm" onClick={save} disabled={update.isPending || dbProblem !== null}>
+                  <Button size="sm" onClick={save} disabled={update.isPending || dbProblem !== null || dbTaken}>
                     <Save className="h-4 w-4" /> {update.isPending ? "Saving…" : "Save changes"}
                   </Button>
                 </AdminGate>

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -62,6 +62,12 @@ export interface Org {
 
 // Editable subset of Org accepted by PUT /api/v1/orgs/:id.
 export interface OrgUpdate {
+  // database_name renames the org's database — and with it the managed
+  // hostname (<database_name>.<managed-suffix>) — which is exactly how an org
+  // whose stored name is not a routable DNS label gets fixed. Must be a valid
+  // single DNS label (server-enforced); the unique index still guards
+  // collisions.
+  database_name?: string;
   max_workers?: number;
   max_vcpus?: number;
   default_worker_cpu?: string;

--- a/controlplane/configstore/orgs.go
+++ b/controlplane/configstore/orgs.go
@@ -24,8 +24,8 @@ var databaseNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 const maxDatabaseNameLength = 63
 
 // ValidateDatabaseName rejects org database names that are not valid single
-// DNS labels. Applied on EVERY surface that writes duckgres_orgs.database_name
-// (provisioning, admin create, admin update); pre-existing grandfathered rows
+// DNS labels. Applied on every surface that writes duckgres_orgs.database_name
+// (provisioning, admin create, admin update). Pre-existing grandfathered rows
 // that predate the rule stay readable and editable through the admin update
 // path — fixing them is the point of that surface.
 func ValidateDatabaseName(name string) error {
@@ -39,4 +39,16 @@ func ValidateDatabaseName(name string) error {
 		return fmt.Errorf("database_name %q must be a valid DNS label: lowercase letters, digits and hyphens, starting and ending alphanumeric (no spaces, dots or underscores — it becomes the org's hostname label)", name)
 	}
 	return nil
+}
+
+// IsUniqueViolationErr reports whether err comes from a Postgres 23505
+// unique-constraint violation. The pgx/jackc driver surfaces the SQLSTATE
+// through a method on the returned error (mirrors the pattern in
+// controlplane/provisioner/postgres_admin.go). HTTP handlers map it to a
+// clear 409 ("your input conflicts with existing state") instead of a 500
+// carrying the raw constraint text.
+func IsUniqueViolationErr(err error) bool {
+	type sqlStater interface{ SQLState() string }
+	var s sqlStater
+	return errors.As(err, &s) && s.SQLState() == "23505"
 }

--- a/controlplane/configstore/orgs.go
+++ b/controlplane/configstore/orgs.go
@@ -1,0 +1,42 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// databaseNamePattern constrains an org's database_name to a single DNS label
+// (RFC 1035: lowercase alphanumeric + hyphens, no leading/trailing hyphen,
+// 1–63 chars — the same rule as a Kubernetes DNS-1123 label). The database
+// name is not just a Postgres startup parameter: in multitenant deployments
+// it is the tenant's public socket identity — the single hostname label of
+// its managed SNI hostname (<database_name>.<managed-suffix>) and the
+// dbname clients connect with. A value that isn't a valid single label —
+// spaces, dots, underscores, uppercase — can be stored fine but the hostname
+// it produces is unroutable: it fails the wildcard cert and is rejected by
+// the SNI prefix extraction (sni_kubernetes.go drops multi-label prefixes),
+// leaving the tenant reachable by no hostname at all. Rejecting at write time
+// surfaces the typo as a 400 instead of a mysteriously unreachable tenant.
+var databaseNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// maxDatabaseNameLength is the DNS label length limit (RFC 1035).
+const maxDatabaseNameLength = 63
+
+// ValidateDatabaseName rejects org database names that are not valid single
+// DNS labels. Applied on EVERY surface that writes duckgres_orgs.database_name
+// (provisioning, admin create, admin update); pre-existing grandfathered rows
+// that predate the rule stay readable and editable through the admin update
+// path — fixing them is the point of that surface.
+func ValidateDatabaseName(name string) error {
+	if name == "" {
+		return errors.New("database_name is required")
+	}
+	if len(name) > maxDatabaseNameLength {
+		return fmt.Errorf("database_name must be at most %d characters (DNS label limit)", maxDatabaseNameLength)
+	}
+	if !databaseNamePattern.MatchString(name) {
+		return fmt.Errorf("database_name %q must be a valid DNS label: lowercase letters, digits and hyphens, starting and ending alphanumeric (no spaces, dots or underscores — it becomes the org's hostname label)", name)
+	}
+	return nil
+}

--- a/controlplane/configstore/orgs_test.go
+++ b/controlplane/configstore/orgs_test.go
@@ -1,0 +1,43 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateDatabaseName(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"simple slug", "acme", false},
+		{"hyphenated", "entirely-chief-wildcat", false},
+		{"digits", "acme123", false},
+		{"canonical uuid", "0123abcd-4567-4890-abcd-ef0123456789", false},
+		{"single char", "a", false},
+		{"exactly 63 chars", strings.Repeat("a", 63), false},
+
+		{"empty", "", true},
+		{"over 63 chars", strings.Repeat("a", 64), true},
+		{"space", "ACME INC", true},
+		{"dot (multi-label hostname would be unroutable)", "acme.inc", true},
+		{"underscore", "acme_inc", true},
+		{"uppercase", "Acme", true},
+		{"leading hyphen", "-acme", true},
+		{"trailing hyphen", "acme-", true},
+		{"slash", "acme/inc", true},
+		{"leading digit is fine (DNS-1123 allows)", "1acme", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDatabaseName(tc.value)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateDatabaseName(%q) = nil, want error", tc.value)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateDatabaseName(%q) = %v, want nil", tc.value, err)
+			}
+		})
+	}
+}

--- a/controlplane/configstore/reshard.go
+++ b/controlplane/configstore/reshard.go
@@ -149,11 +149,9 @@ func (ReshardLogEntry) TableName() string { return "duckgres_reshard_operation_l
 var ErrReshardConflict = errors.New("org already has an active reshard operation")
 
 // isUniqueViolationErr reports a Postgres 23505 unique-constraint violation
-// (same SQLState-through-errors.As pattern as provisioning.isUniqueViolation).
+// (kept as a thin wrapper over the shared IsUniqueViolationErr in orgs.go).
 func isUniqueViolationErr(err error) bool {
-	type sqlStater interface{ SQLState() string }
-	var s sqlStater
-	return errors.As(err, &s) && s.SQLState() == "23505"
+	return IsUniqueViolationErr(err)
 }
 
 // ErrReshardFenced is returned by runner-fenced writes when the (runner,

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -283,8 +283,12 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
-	if req.DatabaseName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "database_name is required"})
+	// database_name becomes the org's managed hostname label
+	// (<database_name>.<managed-suffix>) and the dbname clients connect with,
+	// so it must be a routable single DNS label at birth — a name with spaces
+	// or dots would store fine but leave the tenant reachable by no hostname.
+	if err := configstore.ValidateDatabaseName(req.DatabaseName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,19 +18,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// isUniqueViolation reports whether err comes from a Postgres
-// 23505 unique-constraint violation. The pgx/jackc driver surfaces
-// the SQLSTATE through a method on the returned error; we match
-// against that without importing pgconn directly (mirrors the
-// pattern in controlplane/provisioner/postgres_admin.go).
-//
-// Mapped to HTTP 409 by the provision handler so callers see a
-// clear "your input conflicts with existing state" rather than a
-// generic 500.
+// isUniqueViolation reports whether err comes from a Postgres 23505
+// unique-constraint violation (thin wrapper over the shared
+// configstore.IsUniqueViolationErr). Mapped to HTTP 409 by the provision
+// handler so callers see a clear "your input conflicts with existing state"
+// rather than a generic 500.
 func isUniqueViolation(err error) bool {
-	type sqlStater interface{ SQLState() string }
-	var s sqlStater
-	return errors.As(err, &s) && s.SQLState() == "23505"
+	return configstore.IsUniqueViolationErr(err)
 }
 
 const (
@@ -283,11 +278,23 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 		return
 	}
 
+	// Trim around the caller's value so " acme" fails with the real problem
+	// instead of storing a name that differs from what the caller intended.
+	req.DatabaseName = strings.TrimSpace(req.DatabaseName)
+
 	// database_name becomes the org's managed hostname label
 	// (<database_name>.<managed-suffix>) and the dbname clients connect with,
-	// so it must be a routable single DNS label at birth — a name with spaces
-	// or dots would store fine but leave the tenant reachable by no hostname.
-	if err := configstore.ValidateDatabaseName(req.DatabaseName); err != nil {
+	// so a new or CHANGED name must be a routable single DNS label — a name
+	// with spaces or dots would store fine but leave the tenant reachable by
+	// no hostname. Grandfather exception: re-provisioning an existing org with
+	// its STORED name (the deprovision→re-provision recovery loop) sends a
+	// value that predates this rule — rejecting it would orphan a flow that
+	// worked until now and write nothing new anyway. The break-glass rename
+	// lives in the admin API (PUT /api/v1/orgs/:id).
+	if existing, err := h.store.GetOrg(orgID); err == nil && existing.DatabaseName == req.DatabaseName {
+		// Existing org re-provisioning with its stored (possibly
+		// pre-validation-rule) database name: nothing changes, allow it.
+	} else if err := configstore.ValidateDatabaseName(req.DatabaseName); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -591,6 +598,15 @@ func (h *handler) checkDatabaseName(c *gin.Context) {
 	name := c.Query("name")
 	if name == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name query parameter is required"})
+		return
+	}
+
+	// "available" must mean "provisionable", not just "untaken": a name the
+	// provision endpoint would 400 (not a valid DNS label) is reported
+	// available=false with the reason, so a pre-flight never green-lights a
+	// payload that fails one request later.
+	if err := configstore.ValidateDatabaseName(name); err != nil {
+		c.JSON(http.StatusOK, gin.H{"name": name, "available": false, "reason": err.Error()})
 		return
 	}
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -490,6 +490,95 @@ func TestProvisionRejectsInvalidDatabaseName(t *testing.T) {
 	}
 }
 
+// TestProvisionRejectsRenameToInvalidDatabaseName pins that the grandfather
+// carve-out only covers re-provisioning an existing org with its STORED name:
+// asking to rename it to an invalid value still 400s.
+func TestProvisionRejectsRenameToInvalidDatabaseName(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["existing"] = &configstore.Org{Name: "existing", DatabaseName: "tenant_alpha"} // grandfathered invalid
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "STILL BROKEN", "team_id": 1, "metadata_store": {"type": "cnpg-shard"}, "ducklake": {"enabled": true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/existing/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := store.orgs["existing"].DatabaseName; got != "tenant_alpha" {
+		t.Errorf("DatabaseName = %q, want unchanged %q", got, "tenant_alpha")
+	}
+}
+
+// TestProvisionGrandfathersReprovisionWithStoredName pins the recovery loop:
+// an existing org whose stored database_name predates the DNS-label rule can
+// still deprovision→re-provision with that same name (the flow writes nothing
+// new to the column; rejecting it would orphan the org warehouse-less).
+func TestProvisionGrandfathersReprovisionWithStoredName(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["grandpa"] = &configstore.Org{Name: "grandpa", DatabaseName: "tenant_alpha"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "grandpa", TeamID: 7, SchemaName: "team_7", Enabled: true})
+	router := newTestRouter(store)
+
+	body := []byte(`{"database_name": "tenant_alpha", "metadata_store": {"type": "cnpg-shard"}, "ducklake": {"enabled": true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/grandpa/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("re-provision with stored grandfathered name: status = %d, want %d: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if store.warehouses["grandpa"] == nil {
+		t.Fatal("expected warehouse to be created for grandfathered re-provision")
+	}
+}
+
+// TestCheckDatabaseNameReportsInvalidAsUnavailable: "available" must mean
+// "provisionable" — a name the provision endpoint would 400 reports
+// available=false with a reason, so pre-flights never green-light a 400.
+func TestCheckDatabaseNameReportsInvalidAsUnavailable(t *testing.T) {
+	store := newFakeStore()
+	router := newTestRouter(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/database-name/check?name=acme_inc", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Available bool   `json:"available"`
+		Reason    string `json:"reason"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Available {
+		t.Error("available = true for a name provision would 400, want false")
+	}
+	if body.Reason == "" {
+		t.Error("reason empty, want the validation message")
+	}
+
+	// A valid, untaken name stays available.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/database-name/check?name=acme-inc", nil)
+	rec2 := httptest.NewRecorder()
+	router.ServeHTTP(rec2, req2)
+	var body2 struct {
+		Available bool `json:"available"`
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &body2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body2.Available {
+		t.Error("available = false for a valid untaken name, want true")
+	}
+}
+
 func TestProvisionAutoCreatesOrg(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -460,6 +460,36 @@ func TestProvisionRejectsAurora(t *testing.T) {
 	}
 }
 
+// TestProvisionRejectsInvalidDatabaseName locks in that database_name — the
+// org's managed hostname label, so an unroutable one leaves the tenant
+// reachable by no hostname — is rejected with 400 at the provisioning API
+// boundary, on every write surface.
+func TestProvisionRejectsInvalidDatabaseName(t *testing.T) {
+	cases := []string{"", "ACME INC", "acme.inc", "acme_inc", "Acme", "-acme"}
+	for _, db := range cases {
+		t.Run(db, func(t *testing.T) {
+			store := newFakeStore()
+			router := newTestRouter(store)
+
+			body := []byte(fmt.Sprintf(`{"database_name": %q, "team_id": 1, "metadata_store": {"type": "cnpg-shard"}, "ducklake": {"enabled": true}}`, db))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/new-org/provision", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("database_name %q: status = %d, want %d: %s", db, rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if _, ok := store.orgs["new-org"]; ok {
+				t.Errorf("database_name %q: org should NOT have been created", db)
+			}
+			if store.warehouses["new-org"] != nil {
+				t.Errorf("database_name %q: warehouse should NOT have been created", db)
+			}
+		})
+	}
+}
+
 func TestProvisionAutoCreatesOrg(t *testing.T) {
 	store := newFakeStore()
 	router := newTestRouter(store)

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -155,7 +155,7 @@ func TestProvisionSmokeScenarioUsesIsolatedStackWarehouseIdentityAndSupportedSte
 		t.Fatalf("provision request = %#v, want map", provisionStep.With["request"])
 	}
 	databaseName, _ := request["database_name"].(string)
-	if databaseName == "scenario_smoke" || !strings.Contains(databaseName, "scenario_smoke_") {
+	if databaseName == "scenario-smoke" || !strings.Contains(databaseName, "scenario-smoke-") {
 		t.Fatalf("database_name = %q, want run-unique templated database", databaseName)
 	}
 	requireScenarioTeamID(t, request)

--- a/tests/mw-dev/scenario/scenarios/fast-suite.yaml
+++ b/tests/mw-dev/scenario/scenarios/fast-suite.yaml
@@ -9,7 +9,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_fast_suite_${run_id_token}
+        database_name: scenario-fast-suite-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/full-suite.yaml
+++ b/tests/mw-dev/scenario/scenarios/full-suite.yaml
@@ -9,7 +9,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_full_suite_${run_id_token}
+        database_name: scenario-full-suite-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/posthog_frozen_dbt.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_frozen_dbt.yaml
@@ -9,7 +9,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_frozen_dbt_${run_id_token}
+        database_name: scenario-frozen-dbt-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/posthog_frozen_metadata.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_frozen_metadata.yaml
@@ -9,7 +9,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_frozen_${run_id_token}
+        database_name: scenario-frozen-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_frozen_perf.yaml
@@ -9,7 +9,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_frozen_perf_${run_id_token}
+        database_name: scenario-frozen-perf-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/provision_rejection.yaml
+++ b/tests/mw-dev/scenario/scenarios/provision_rejection.yaml
@@ -11,7 +11,7 @@ steps:
     with:
       org_id: scenario-reject-${run_id_compact}
       request:
-        database_name: scenario_reject_${run_id_token}
+        database_name: scenario-reject-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard

--- a/tests/mw-dev/scenario/scenarios/provision_smoke.yaml
+++ b/tests/mw-dev/scenario/scenarios/provision_smoke.yaml
@@ -8,7 +8,7 @@ steps:
     with:
       org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
       request:
-        database_name: scenario_smoke_${run_id_token}
+        database_name: scenario-smoke-${run_id_token}
         team_id: 1
         metadata_store:
           type: cnpg-shard


### PR DESCRIPTION
## Why

An org's `database_name` decides its hostname: clients reach the tenant at `<database_name>.<managed-suffix>` and connect with `dbname=<database_name>`. Some stored names predate any validation and are not valid hostname labels (spaces, dots, …) — those orgs are reachable by no hostname, and until now there was no surface to fix them short of hand-editing the config store.

## Changes

- **`configstore.ValidateDatabaseName`** — new shared rule: a single RFC 1035 / DNS-1123 label (lowercase alphanumerics + hyphens, no leading/trailing hyphen, ≤63 chars) — no spaces, dots or underscores.
- **Write-surface enforcement (400)** — `POST /api/v1/orgs/:id/provision` and admin `POST /api/v1/orgs` reject invalid names at admission. Re-provisioning an *existing* org with its **stored** name is grandfathered so the deprovision→re-provision recovery loop keeps working for pre-rule orgs; only new orgs and actual renames are gated. `GET /database-name/check` now reports an invalid name as `available: false` with a `reason`, so pre-flights can't green-light a payload that provisions as 400.
- **Break-glass fix path** — admin `PUT /api/v1/orgs/:id` accepts `database_name` (presence-aware, trimmed, validated, audit-logged). Successful renames force a local snapshot reload + peer fan-out so the new hostname routes immediately on every replica; collisions map to a clean 409 via the newly exported `configstore.IsUniqueViolationErr`.
- **Admin UI** — org detail page has an editable **Database name** field with inline validation, a taken-name probe, a rename warning, and save disabled while invalid — but only when the name actually *changed*: grandfathered orgs keep every other setting editable without a forced rename (unchanged values are never sent). The Add-org dialog validates before submit.
- **mw-dev scenarios** — scenario YAMLs + runner test switch underscore database names to hyphenated DNS labels, keeping the daily scenario lanes green on the new build.
- **Tests** — validator unit tests; handler tests (create/update/rename/preserve/grandfather/carve-out/409/check-endpoint); Postgres-backed store tests; UI tests for edit field, changed-only payload, grandfathered edits, and invalid/taken gating.

## Review process

Audited with a multi-agent adversarial review (5 independent lenses — routing/DNS, API compat, downstream callers, frontend, general sweep — each finding attacked by independent skeptics): 16 candidate findings, 11 confirmed (dups merged), 5 refuted. All confirmed issues are fixed in the second commit.

Frontend bundle is a build artifact produced by CI/Docker (`just ui-build`), not committed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*