### PR TITLE
control-plane: return connect host on service-credential mint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -829,10 +829,30 @@ the CP.
 `{team_id, principal, ttl_seconds?, force_rotate?}`. `principal` is audit
 attribution (`"dagster:events-backfill"`). `ttl_seconds` is clamped to
 [1 min, 1 h] (default 15 min, the RDS-IAM precedent). Response is
-`{username, password?, expires_at}`; password is **omitted** when the CP
-reused a live grant. The caller is the internal-secret-authed PostHog
+`{username, password?, expires_at, connect}`; password is **omitted** when the
+CP reused a live grant, but `connect` is **always present** (reuse and rotate
+alike). The caller is the internal-secret-authed PostHog
 backend — the route sits next to the other provisioning routes for exactly
 that trust class, NOT on the admin/console side.
+
+The `connect` block tells the caller WHERE to use the credential from the same
+authoritative CP response that issued it, so nothing downstream re-derives its
+own idea of the warehouse endpoint out of band (a Django `DuckgresServer` row
+is exactly the drift this kills). It is
+`{host, port: 5432, database: "ducklake", sslmode: "require"}`.
+**`connect.host` is ALWAYS the org's canonical ingress name
+`<org-id>` + the CP's configured managed-ingress suffix** (e.g.
+`<org-id>.dw.us.postwh.com`) — the very value the pgwire TLS `server_name`
+pins (the wildcard cert is `*<suffix>` and the SNI router resolves the
+single-label prefix as the org; see "Native metadata Postgres proxy" /
+`controlplane/sni_kubernetes.go`). It is one logical name handed back verbatim
+for every caller: NEVER a pod IP, NEVER a ClusterIP, NEVER resolved per caller
+network. How that name resolves for a given caller — public ingress vs an AWS
+PrivateLink endpoint for dagster workers — is the caller network's business,
+not the CP's. The CP wires the suffix from its first configured
+`ManagedHostnameSuffixes` entry (`DUCKGRES_MANAGED_HOSTNAME_SUFFIXES`) at the
+`RegisterAPI` site (`controlplane/multitenant.go`), falling back to
+`provisioning.DefaultManagedIngressSuffix` when unwired.
 
 **The load-bearing invariants:**
 - **The login IS the team's canonical `project_user` (`posthog_team_<id>_rw`).**

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -656,7 +656,17 @@ func SetupMultiTenant(
 	// the mint's peer-reload fan-out (same aggregation plumbing, same nil-when-
 	// single-CP semantics).
 	gormStore := provisioning.NewGormStore(store)
-	provisioning.RegisterAPI(api, gormStore, gormStore, cfg.DucklingBucketSuffix, liveFetcher)
+	// Wire the service-credential connect block's ingress host to the same
+	// managed hostname suffix the pgwire TLS server_name pins (the CP's first
+	// configured ManagedHostnameSuffixes entry), so the mint response tells the
+	// caller the exact ingress the credential authenticates against. When the
+	// CP has no managed suffix configured, provisioning falls back to its
+	// DefaultManagedIngressSuffix.
+	var ingressSuffix string
+	if len(cfg.ManagedHostnameSuffixes) > 0 {
+		ingressSuffix = cfg.ManagedHostnameSuffixes[0]
+	}
+	provisioning.RegisterAPIWithIngressSuffix(api, gormStore, gormStore, cfg.DucklingBucketSuffix, liveFetcher, ingressSuffix)
 	// Discovery endpoints live in their OWN group (see discovery_group.go
 	// for the security rationale and the topology tripwire test).
 	registerReadOnlyGroup(engine, readOnlyTokens, adminTokens, provisioning.NewGormStore(store))

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -118,7 +118,19 @@ type PeerFanout interface {
 // freshly rotated credential auths on whichever CP the client's pgwire
 // connection actually lands on, not just the replica that served the mint.
 func RegisterAPI(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string, peerFanout PeerFanout) {
-	h := &handler{store: store, bucketSuffix: bucketSuffix, peerFanout: peerFanout}
+	RegisterAPIWithIngressSuffix(r, store, tenantStore, bucketSuffix, peerFanout, "")
+}
+
+// RegisterAPIWithIngressSuffix is RegisterAPI plus an explicit managed tenant
+// ingress DNS suffix (leading dot, e.g. ".dw.us.postwh.com") used to build
+// connect.host in the service-credential response as <org-id><suffix>. The
+// caller must pass the CP's configured managed-ingress suffix — the same value
+// the pgwire TLS server_name pins (the wildcard cert is *<suffix> and the SNI
+// router resolves the single-label prefix as the org) — so the host the mint
+// response hands back is the ingress the credential authenticates against. An
+// empty ingressSuffix falls back to DefaultManagedIngressSuffix.
+func RegisterAPIWithIngressSuffix(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string, peerFanout PeerFanout, ingressSuffix string) {
+	h := &handler{store: store, bucketSuffix: bucketSuffix, peerFanout: peerFanout, ingressSuffix: ingressSuffix}
 	r.POST("/orgs/:id/provision", h.provisionWarehouse)
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
 	r.GET("/orgs/:id/warehouse/status", h.getWarehouseStatus)
@@ -164,6 +176,12 @@ type handler struct {
 	// service-credentials mint uses it to fan a snapshot reload out to peer
 	// replicas after rotating a credential.
 	peerFanout PeerFanout
+	// ingressSuffix is the managed tenant DNS suffix (leading dot) joined onto
+	// the org ID to build connect.host in the service-credential response. It
+	// must match the TLS server_name the CP pins for managed tenants so the
+	// host handed back is the ingress the credential auths against. Empty ⇒
+	// managedIngressSuffix() falls back to DefaultManagedIngressSuffix.
+	ingressSuffix string
 }
 
 // warehouseStatusResponse is the public-facing view of warehouse state.

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -25,6 +25,17 @@ const (
 	defaultCredentialTTL = 15 * time.Minute
 )
 
+// DefaultManagedIngressSuffix is the fallback managed tenant ingress DNS
+// suffix used to build connect.host in the service-credential response
+// (<org-id><suffix>) when the CP wasn't wired with an explicit ingress suffix.
+// It matches the only managed production ingress today (*.dw.us.postwh.com,
+// same as DUCKGRES_MANAGED_HOSTNAME_SUFFIXES). Production wiring
+// (controlplane/multitenant.go) passes the CP's first configured
+// ManagedHostnameSuffixes entry — the exact TLS server_name value the pgwire
+// handshake pins — so this constant is only a safety net for unwired callers,
+// never the source of truth for a configured CP.
+const DefaultManagedIngressSuffix = ".dw.us.postwh.com"
+
 type serviceCredentialRequest struct {
 	TeamID     int64  `json:"team_id"`
 	Principal  string `json:"principal"`
@@ -39,6 +50,30 @@ type serviceCredentialRequest struct {
 	ForceRotate bool `json:"force_rotate"`
 }
 
+// connectDetails is the always-present `connect` block of the mint response:
+// it tells the caller WHERE to use the credential from the same authoritative
+// CP response that issued it, so nothing downstream re-derives its own idea of
+// the warehouse endpoint (out-of-band endpoint knowledge — a Django
+// `DuckgresServer` row — is exactly the drift this field exists to kill).
+//
+// Host is the org's canonical ingress hostname — orgID + the managed ingress
+// suffix the CP is configured with — i.e. the very value the pgwire TLS
+// server_name pins (the wildcard cert is *<suffix> and the SNI router resolves
+// the single-label prefix as the org; see controlplane/sni_kubernetes.go). It
+// is a single LOGICAL name returned verbatim for every caller: whether that
+// name resolves over the public ingress or a caller-network-specific path
+// (e.g. an AWS PrivateLink endpoint for dagster workers) is the caller
+// network's business — NEVER an IP, NEVER resolved per caller network.
+// Database/SslMode pin the pgwire handshake shape the CP enforces (managed
+// warehouses accept only the ducklake catalog database, and TLS is required on
+// the pgwire handshake).
+type connectDetails struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Database string `json:"database"`
+	SslMode  string `json:"sslmode"`
+}
+
 type serviceCredentialResponse struct {
 	Username string `json:"username"`
 	// Password is omitted (not empty-stringed) when the CP reused a live
@@ -46,6 +81,10 @@ type serviceCredentialResponse struct {
 	// echoing "" would risk clients treating "" as the credential itself.
 	Password  string    `json:"password,omitempty"`
 	ExpiresAt time.Time `json:"expires_at"`
+	// Connect is unconditional (unlike Password): identical shape on reuse
+	// and rotate, so the client can always take its connection target from
+	// this same response instead of holding its own out-of-band copy.
+	Connect connectDetails `json:"connect"`
 }
 
 // TenantStore is the subset of the config store the service-credential
@@ -160,6 +199,27 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 		Username:  issued.Username,
 		Password:  issued.Plaintext,
 		ExpiresAt: issued.ExpiresAt,
+		Connect: connectDetails{
+			// The org's canonical ingress hostname — orgID + the CP's
+			// configured managed-ingress suffix — i.e. exactly the value the
+			// pgwire TLS server_name pins (never an IP, never resolved per
+			// caller network; see the connectDetails doc).
+			Host:     orgID + h.managedIngressSuffix(),
+			Port:     5432,
+			Database: "ducklake",
+			SslMode:  "require",
+		},
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// managedIngressSuffix returns the DNS suffix joined onto the org ID to build
+// connect.host. The wired value (the CP's configured managed hostname suffix)
+// wins; when unwired (unit tests that build a handler directly) it falls back
+// to DefaultManagedIngressSuffix.
+func (h *handler) managedIngressSuffix() string {
+	if h.ingressSuffix != "" {
+		return h.ingressSuffix
+	}
+	return DefaultManagedIngressSuffix
 }

--- a/controlplane/provisioning/service_credential_test.go
+++ b/controlplane/provisioning/service_credential_test.go
@@ -7,8 +7,45 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
+
+// newServiceCredentialRouter mounts the provisioning API with an explicit
+// managed tenant ingress suffix so tests can assert the exact connect.host the
+// handler derives from it (orgID + suffix).
+func newServiceCredentialRouter(store Store, ingressSuffix string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	tenantStore, _ := store.(TenantStore)
+	RegisterAPIWithIngressSuffix(r.Group("/api/v1"), store, tenantStore, "", nil, ingressSuffix)
+	return r
+}
+
+// assertConnectBlock checks the always-present connect block's exact shape and
+// values against the org's canonical ingress hostname.
+func assertConnectBlock(t *testing.T, body map[string]any, wantHost string) {
+	t.Helper()
+	connect, ok := body["connect"].(map[string]any)
+	if !ok {
+		t.Fatalf("connect block must be an object, got top-level body: %v", body)
+	}
+	if len(connect) != 4 {
+		t.Fatalf("connect must have exactly 4 keys, got %v", connect)
+	}
+	if got := connect["host"]; got != wantHost {
+		t.Fatalf("connect.host = %v, want %v (the org's canonical ingress hostname)", got, wantHost)
+	}
+	if got := connect["port"]; got != float64(5432) {
+		t.Fatalf("connect.port = %v, want 5432", got)
+	}
+	if got := connect["database"]; got != "ducklake" {
+		t.Fatalf("connect.database = %v, want \"ducklake\"", got)
+	}
+	if got := connect["sslmode"]; got != "require" {
+		t.Fatalf("connect.sslmode = %v, want \"require\"", got)
+	}
+}
 
 // pinServiceCredentialUsername locks the CP-issued login name to the same
 // derivation the admin console uses for a team's read/write project login
@@ -40,6 +77,9 @@ func TestIssueServiceCredentialUsernameMatchesAdminProjectUser(t *testing.T) {
 	if body["expires_at"] == nil {
 		t.Fatal("expires_at must be present")
 	}
+	// newTestRouter wires no ingress suffix ⇒ the handler falls back to the
+	// default managed ingress suffix.
+	assertConnectBlock(t, body, "acme"+DefaultManagedIngressSuffix)
 }
 
 func TestIssueServiceCredentialRejectsBadInput(t *testing.T) {
@@ -154,4 +194,35 @@ func TestIssueServiceCredentialReuseOmitsPasswordWhenGrantStillValid(t *testing.
 	if body := rec.Body.String(); strings.Contains(body, `"password"`) {
 		t.Fatalf("reuse path must not echo a password, got: %s", body)
 	}
+	// ...but the connect block is unconditional: identical shape and values on
+	// the reuse path, so a caller can always take its connection target from
+	// the mint response even when it gets no plaintext back.
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	assertConnectBlock(t, body, "acme"+DefaultManagedIngressSuffix)
+}
+
+// TestIssueServiceCredentialConnectHostUsesWiredSuffix locks the wiring: the
+// connect block's host is orgID + the ingress suffix the CP was wired with —
+// the same DNS suffix the pgwire TLS server_name pins for managed tenants —
+// never an IP and never a caller-network-resolved address, so both a
+// public-ingress client and a PrivateLink client get the one logical name.
+func TestIssueServiceCredentialConnectHostUsesWiredSuffix(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+	store.seedTeam(configstore.OrgTeam{OrgID: "acme", TeamID: 42, SchemaName: "team_42", Enabled: true})
+	router := newServiceCredentialRouter(store, ".dw.eu.postwh.com")
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
+		`{"team_id": 42, "principal": "dagster:events-backfill", "force_rotate": true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	assertConnectBlock(t, body, "acme.dw.eu.postwh.com")
 }


### PR DESCRIPTION
## Summary

The service-credential mint response (`POST /api/v1/orgs/:id/teams/:team_id/service-credentials`, PR #1058) now also tells the caller **where** to connect. Both the reuse and rotate paths gain an always-present `connect` block:

```json
{ "username": "...", "password"?: "...", "expires_at": "...", "connect": {"host": "<org-id>.dw.us.postwh.com", "port": 5432, "database": "ducklake", "sslmode": "require"} }
```

`connect.host` is constructed as `<org-id>` + the CP's configured managed-ingress suffix (`ManagedHostnameSuffixes[0]`, env `DUCKGRES_MANAGED_HOSTNAME_SUFFIXES`) — the exact TLS `server_name` value the pgwire handshake pins (wildcard cert `*<suffix>`, single-label prefix resolved as the org in `controlplane/sni_kubernetes.go`). Wired through `RegisterAPIWithIngressSuffix` from `controlplane/multitenant.go`, falling back to `provisioning.DefaultManagedIngressSuffix` (`.dw.us.postwh.com`) when unwired.

## Why

Out-of-band host knowledge in Django `DuckgresServer` rows is the drift that must die: the host must come from the same authoritative control-plane response as the credential itself, so a consumer (dagster) never holds its own copy of the warehouse endpoint. The CP always hands back the single TLS-pinned ingress name — never a pod IP, ClusterIP, or per-caller-network resolution. How that name resolves for a given caller (public ingress vs an AWS PrivateLink endpoint for dagster workers) is the caller network's business, not the CP's.

## Shape / compat

- Additive only. `password` is still omitted on reuse (unchanged); `connect` is unconditional.
- Rotation / expiry / `force_rotate` / provenance / disabled-login invariants are untouched.
- The response shape does not leak into the configstore postgres facade (it deals in `ServiceCredentialIssue`, not the HTTP struct), so `service_credential_postgres_test.go` needed no change.

## Test plan

- `controlplane/provisioning`: `go test ./provisioning/...` — PASS (was `ok`); all `TestIssueServiceCredential*` pass including new `TestIssueServiceCredentialConnectHostUsesWiredSuffix` (wired-suffix host) and connect assertions on both the rotate (`TestIssueServiceCredentialUsernameMatchesAdminProjectUser`) and reuse (`TestIssueServiceCredentialReuseOmitsPasswordWhenGrantStillValid`) paths. 7 service-credential tests PASS.
- `controlplane` package (default tags), `go test . -skip '^TestCheckSocketDirWritable$'` — PASS. (`TestCheckSocketDirWritable` fails identically on pristine `origin/main` in this root/sandbox env — pre-existing, unrelated.)
- `controlplane` package with `-tags kubernetes`, `go test -tags kubernetes . -skip '^TestCheckSocketDirWritable$'` — PASS (compiles the `multitenant.go` wiring).
- `golangci-lint run ./...` (v2.11.4, matching CI) — 0 issues.
- `go build ./...` and `go build -tags kubernetes ./...` — clean; `gofmt -l` on touched dirs — clean.
- Other postgres-container suites under `-tags kubernetes` (`controlplane/admin`, `configstore` Postgres tests) are skipped in this env: `docker-compose` executable not present (pre-existing env limitation, not a regression).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*