### PR TITLE
admin UI: lead with the readable database name instead of the org id

### DIFF
--- a/controlplane/admin/ui/src/components/CopyButton.tsx
+++ b/controlplane/admin/ui/src/components/CopyButton.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+// CopyButton is the small inline clipboard affordance used next to ids an
+// operator wants to grab verbatim (org id, trace id). Shows a check briefly
+// on success. Keeps the visual noise low — ghost icon button, mono-friendly.
+export function CopyButton({ value, label }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  if (!value) return null;
+  return (
+    <button
+      type="button"
+      className="inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
+      title={label ?? `Copy ${value}`}
+      aria-label={label ?? `Copy ${value}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        void navigator.clipboard?.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+    >
+      {copied ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3" />}
+    </button>
+  );
+}

--- a/controlplane/admin/ui/src/components/OrgRef.tsx
+++ b/controlplane/admin/ui/src/components/OrgRef.tsx
@@ -1,0 +1,25 @@
+import { CopyButton } from "@/components/CopyButton";
+
+// OrgRef renders an org reference the way a human actually reads it: the
+// database name (or alias) as the primary, the raw org id as a small subline.
+// When only the id is known (org lookup unresolved) it degrades to just the
+// id. Use inside table cells where a bare org-id string is all the row has.
+//
+// Deliberately single-column-friendly: the id subline is compact (11px,
+// muted, truncated) so rows stay one-line-tall for scanning, with the full
+// id reachable via title + copy button.
+export function OrgRef({ id, label, copyable = true }: { id: string; label?: string; copyable?: boolean }) {
+  const text = label && label !== "" ? label : id;
+  const differ = text !== id;
+  return (
+    <span className="block min-w-0" title={differ ? `${text} • ${id}` : id}>
+      <span className={`block truncate text-xs ${differ ? "font-medium text-foreground" : "font-mono"}`}>{text}</span>
+      {differ && (
+        <span className="flex items-center gap-1">
+          <span className="block truncate font-mono text-[11px] text-muted-foreground">{id}</span>
+          {copyable && <CopyButton value={id} />}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
+++ b/controlplane/admin/ui/src/components/OrgTeamDialogs.tsx
@@ -88,12 +88,19 @@ export function CreateTeamDialog({
   open,
   onClose,
   org,
+  orgLabel,
   orgs,
 }: {
   open: boolean;
   onClose: () => void;
+  // org: the fixed target org id when the dialog is scoped to one org
+  // (org-detail page). orgLabel is its readable name for display.
   org?: string;
-  orgs?: string[];
+  orgLabel?: string;
+  // orgs: the picker choices when not org-scoped (the /org-teams global "Add
+  // team" flow) — carries the readable label alongside the id so the picker
+  // shows a name a human recognises, not a bare UUID.
+  orgs?: { name: string; label: string }[];
 }) {
   const create = useCreateOrgTeam();
   const [orgChoice, setOrgChoice] = useState(org ?? "");
@@ -138,8 +145,18 @@ export function CreateTeamDialog({
         <DialogHeader>
           <DialogTitle>Add team</DialogTitle>
           <DialogDescription>
-            Map a PostHog team to {org ? <span className="font-mono">{org}</span> : "an org"} and the
-            warehouse schema its data lives in.
+            Map a PostHog team to{" "}
+            {org ? (
+              <span>
+                <span className="font-medium">{orgLabel ?? org}</span>{" "}
+                {orgLabel && orgLabel !== org && (
+                  <span className="font-mono text-xs text-muted-foreground">({org})</span>
+                )}
+              </span>
+            ) : (
+              "an org"
+            )}{" "}
+            and the warehouse schema its data lives in.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
@@ -151,8 +168,11 @@ export function CreateTeamDialog({
                 </SelectTrigger>
                 <SelectContent>
                   {(orgs ?? []).map((o) => (
-                    <SelectItem key={o} value={o}>
-                      {o}
+                    <SelectItem key={o.name} value={o.name}>
+                      <span className="font-medium">{o.label}</span>
+                      {o.label !== o.name && (
+                        <span className="ml-2 font-mono text-xs text-muted-foreground">{o.name}</span>
+                      )}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -220,7 +240,15 @@ function legacyNameBody(edited: string, current: string | null | undefined): str
 
 // EditTeamDialog: the operator break-glass — every setting is editable,
 // including the schema name and the legacy table-name overrides.
-export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () => void }) {
+export function EditTeamDialog({
+  team,
+  orgLabel,
+  onClose,
+}: {
+  team: OrgTeam;
+  orgLabel?: string;
+  onClose: () => void;
+}) {
   const update = useUpdateOrgTeam();
   const [schemaName, setSchemaName] = useState(team.schema_name);
   const [enabled, setEnabled] = useState(team.enabled);
@@ -268,7 +296,10 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            Edit team {team.team_id} in "{team.org_id}"
+            Edit team {team.team_id} in {orgLabel ?? team.org_id}
+            {orgLabel && orgLabel !== team.org_id && (
+              <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">({team.org_id})</span>
+            )}
           </DialogTitle>
           <DialogDescription>
             Operator repair tool: every setting is editable here, including the schema name.
@@ -361,12 +392,14 @@ export function EditTeamDialog({ team, onClose }: { team: OrgTeam; onClose: () =
 export function DeleteTeamDialog({
   team,
   teamCount,
+  orgLabel,
   onClose,
 }: {
   team: OrgTeam;
   // How many teams the org currently has, so the last-team refusal shows
   // before the request instead of as a raw 409.
   teamCount: number;
+  orgLabel?: string;
   onClose: () => void;
 }) {
   const del = useDeleteOrgTeam();
@@ -388,7 +421,11 @@ export function DeleteTeamDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            Delete team {team.team_id} from "{team.org_id}"?
+            Delete team {team.team_id} from {orgLabel ?? team.org_id}
+            {orgLabel && orgLabel !== team.org_id && (
+              <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">({team.org_id})</span>
+            )}
+            ?
           </DialogTitle>
           <DialogDescription>
             Removes only the team's config row. The warehouse schema{" "}

--- a/controlplane/admin/ui/src/components/QueryDetailDialog.tsx
+++ b/controlplane/admin/ui/src/components/QueryDetailDialog.tsx
@@ -29,10 +29,12 @@ function Field({ label, value, mono }: { label: string; value: React.ReactNode; 
 // replica that owns the connection, so a 404 renders a clear notice.
 export function QueryDetailDialog({
   workerId,
+  orgLabels,
   onClose,
   onCancel,
 }: {
   workerId: number | null;
+  orgLabels?: Map<string, string>;
   onClose: () => void;
   onCancel: (workerId: number) => void;
 }) {
@@ -40,6 +42,7 @@ export function QueryDetailDialog({
   const d = detail.data;
   const notFound = detail.isError && (detail.error as { status?: number })?.status === 404;
   const pct = d && d.percentage > 0 ? d.percentage : undefined;
+  const orgLabel = d ? orgLabels?.get(d.org) : undefined;
 
   return (
     <Dialog open={workerId != null} onOpenChange={(o) => !o && onClose()}>
@@ -89,7 +92,7 @@ export function QueryDetailDialog({
             </div>
 
             <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
-              <Field label="Org" value={d.org} mono />
+              <Field label="Org" value={orgLabel && orgLabel !== d.org ? `${orgLabel} (${d.org})` : d.org} mono />
               <Field label="User" value={d.user || "—"} mono />
               <Field label="Protocol" value={d.protocol || "pg"} />
               <Field label="Worker" value={`#${d.worker_id}`} mono />

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -11,6 +11,7 @@ import {
   type UseQueryOptions,
 } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
+import { orgLabel } from "@/lib/format";
 import { POLL } from "@/lib/query";
 import { useRevealedCount } from "@/lib/logReplay";
 import { useIdentity } from "@/components/IdentityProvider";
@@ -126,6 +127,23 @@ export function useOrg(id: string | undefined) {
     queryFn: () => api.getOrg(id!),
     enabled: !!id,
   });
+}
+
+// useOrgLabels resolves an org id (org.name / team.org_id / worker.org / …)
+// to its human-readable label from orgLabel(): the database_name (preferred)
+// or hostname_alias. Returns a Map keyed by org id so a detail page where the
+// underlying list row only carries a bare org-id string can still render the
+// readable name. Falls back gracefully (no entry) when the org lookup 404s —
+// callers render the raw id in that case.
+export function useOrgLabels(): Map<string, string> {
+  const orgs = useOrgs();
+  return useMemo(() => {
+    const m = new Map<string, string>();
+    for (const o of orgs.data ?? []) {
+      m.set(o.name, orgLabel(o));
+    }
+    return m;
+  }, [orgs.data]);
 }
 
 export function useUpdateOrg(id: string) {

--- a/controlplane/admin/ui/src/pages/Audit.tsx
+++ b/controlplane/admin/ui/src/pages/Audit.tsx
@@ -8,7 +8,8 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
 import { useIdentity } from "@/components/IdentityProvider";
-import { useAudit } from "@/hooks/useApi";
+import { useAudit, useOrgLabels } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import { fmtTime } from "@/lib/format";
 import { auditSummary } from "@/lib/audit";
 import type { AuditEntry } from "@/types/api";
@@ -40,6 +41,7 @@ export function Audit() {
   const [q, setQ] = useState("");
   const [org, setOrg] = useState("");
   const audit = useAudit({ org });
+  const orgLabels = useOrgLabels();
 
   const columns = useMemo<ColumnDef<AuditEntry, any>[]>(
     () => [
@@ -99,10 +101,12 @@ export function Audit() {
       {
         accessorKey: "org",
         header: "Org",
-        cell: ({ getValue }) => {
-          const v = getValue() as string | undefined;
-          return v ? <span className="font-mono text-xs">{v}</span> : <span className="text-muted-foreground">—</span>;
-        },
+        cell: ({ row }) =>
+          row.original.org ? (
+            <OrgRef id={row.original.org} label={orgLabels.get(row.original.org)} />
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          ),
       },
       {
         accessorKey: "sql_redacted",
@@ -127,7 +131,7 @@ export function Audit() {
         },
       },
     ],
-    [],
+    [orgLabels],
   );
 
   if (!isAdmin) {

--- a/controlplane/admin/ui/src/pages/Errors.tsx
+++ b/controlplane/admin/ui/src/pages/Errors.tsx
@@ -22,7 +22,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useErrors } from "@/hooks/useApi";
+import { useErrors, useOrgLabels } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import { fmtAge, fmtInt, fmtTime } from "@/lib/format";
 import { categoryLabel, categoryVariant, isSystemError } from "@/lib/errors";
 import type { ErrorEntry } from "@/types/api";
@@ -73,7 +74,15 @@ function CopyableField({ label, value }: { label: string; value: string }) {
 // detail, so this reads the passed row directly — no extra fetch. query +
 // message are redacted server-side (a CREATE SECRET error never carries the
 // credential), so it is safe to render both verbatim here.
-function ErrorDetailDialog({ error, onClose }: { error: ErrorEntry | null; onClose: () => void }) {
+function ErrorDetailDialog({
+  error,
+  orgLabel,
+  onClose,
+}: {
+  error: ErrorEntry | null;
+  orgLabel?: string;
+  onClose: () => void;
+}) {
   return (
     <Dialog open={error != null} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="max-w-2xl">
@@ -89,7 +98,7 @@ function ErrorDetailDialog({ error, onClose }: { error: ErrorEntry | null; onClo
           <div className="min-w-0 space-y-4">
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
               <Field label="Time" value={fmtTime(error.time)} mono />
-              <Field label="Org" value={error.org} mono />
+              <Field label="Org" value={orgLabel && orgLabel !== error.org ? `${orgLabel} (${error.org})` : error.org} mono />
               <Field label="User" value={error.user || "—"} mono />
               <Field label="PID" value={error.pid} mono />
               <Field label="Worker" value={`#${error.worker_id}`} mono />
@@ -122,6 +131,7 @@ export function Errors() {
   const [sqlstate, setSqlstate] = useState("");
   const [category, setCategory] = useState<string>("any");
   const [detail, setDetail] = useState<ErrorEntry | null>(null);
+  const orgLabels = useOrgLabels();
 
   // Filters are applied server-side (after the cross-CP merge). Trim so a stray
   // space doesn't over-filter; empty string → omitted by the api layer.
@@ -238,7 +248,9 @@ export function Errors() {
                           <TooltipContent>{fmtTime(e.time)}</TooltipContent>
                         </Tooltip>
                       </TableCell>
-                      <TableCell className="font-mono text-xs">{e.org}</TableCell>
+                      <TableCell>
+                        <OrgRef id={e.org} label={orgLabels.get(e.org)} />
+                      </TableCell>
                       <TableCell className="font-mono text-xs">{e.user || "—"}</TableCell>
                       <TableCell className="font-mono text-xs">{e.sqlstate || "—"}</TableCell>
                       <TableCell>
@@ -256,7 +268,11 @@ export function Errors() {
           </CardContent>
         </Card>
       </PageBody>
-      <ErrorDetailDialog error={detail} onClose={() => setDetail(null)} />
+      <ErrorDetailDialog
+        error={detail}
+        orgLabel={detail ? orgLabels.get(detail.org) : undefined}
+        onClose={() => setDetail(null)}
+      />
     </>
   );
 }

--- a/controlplane/admin/ui/src/pages/Live.tsx
+++ b/controlplane/admin/ui/src/pages/Live.tsx
@@ -22,23 +22,12 @@ import { useCancelSession, useKillUserSessions, useOrgs, useQueries, useSessions
 import { fmtAge, fmtDurationMs, fmtInt, fmtTime, orgLabel } from "@/lib/format";
 import { idleInTransaction, isIdleSession, sessionStateLabel } from "@/lib/session";
 import { compareByStarted, compareByWorker } from "@/lib/liveSort";
+import { OrgRef } from "@/components/OrgRef";
 import { QueryDetailDialog } from "@/components/QueryDetailDialog";
 
-function OrgIdentity({ id, label }: { id: string; label?: string }) {
-  if (!label || label === id) {
-    return <span className="font-mono text-xs">{id}</span>;
-  }
-  return (
-    <span className="block min-w-0">
-      <span className="block truncate text-xs font-medium text-foreground" title={label}>
-        {label}
-      </span>
-      <span className="block truncate font-mono text-[11px] text-muted-foreground" title={id}>
-        {id}
-      </span>
-    </span>
-  );
-}
+// OrgRef is the shared readable-org cell (components/OrgRef). The local copy
+// that used to live here ("OrgIdentity") was replaced so every page renders
+// an org reference the same way.
 
 export function Live() {
   const queries = useQueries();
@@ -187,7 +176,7 @@ export function Live() {
                       >
                         <TableCell className="font-mono text-xs">{q.pid}</TableCell>
                         <TableCell>
-                          <OrgIdentity id={q.org} label={orgLabels.get(q.org)} />
+                          <OrgRef id={q.org} label={orgLabels.get(q.org)} />
                         </TableCell>
                         <TableCell className="font-mono text-xs">{q.user || "—"}</TableCell>
                         <TableCell className="font-mono text-xs tabular-nums text-muted-foreground">
@@ -288,7 +277,7 @@ export function Live() {
                     <TableRow key={`${s.pid}-${s.worker_id}`} className="[&>td]:py-1.5">
                       <TableCell className="font-mono text-xs">{s.pid}</TableCell>
                       <TableCell>
-                        <OrgIdentity id={s.org} label={orgLabels.get(s.org)} />
+                        <OrgRef id={s.org} label={orgLabels.get(s.org)} />
                       </TableCell>
                       <TableCell className="font-mono text-xs">{s.user || "—"}</TableCell>
                       <TableCell className="font-mono text-xs">#{s.worker_id}</TableCell>
@@ -318,6 +307,7 @@ export function Live() {
       </PageBody>
       <QueryDetailDialog
         workerId={detailWid}
+        orgLabels={orgLabels}
         onClose={() => setDetailWid(null)}
         onCancel={(workerId) => cancel.mutate(workerId)}
       />

--- a/controlplane/admin/ui/src/pages/Metrics.tsx
+++ b/controlplane/admin/ui/src/pages/Metrics.tsx
@@ -14,7 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { LoadingState } from "@/components/states";
 import { useMetricRange, useMetricsPanels, useOrgs } from "@/hooks/useApi";
-import { fmtMetricAxis, fmtMetricValue, promToSeries } from "@/lib/format";
+import { fmtMetricAxis, fmtMetricValue, orgLabel, promToSeries } from "@/lib/format";
 
 // Window selector. The backend caps the step at ~250 points per window.
 const WINDOWS = ["15m", "1h", "6h", "24h"];
@@ -62,7 +62,10 @@ export function Metrics() {
                 <SelectItem value="__all__">All orgs</SelectItem>
                 {(orgs.data ?? []).map((o) => (
                   <SelectItem key={o.name} value={o.name}>
-                    {o.name}
+                    <span className="font-medium">{orgLabel(o)}</span>
+                    {orgLabel(o) !== o.name && (
+                      <span className="ml-2 font-mono text-xs text-muted-foreground">{o.name}</span>
+                    )}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -135,6 +135,19 @@ describe("Org detail", () => {
     hooks.useDucklingsMetadata.mockReturnValue(ok({ available: true, entries: [] }));
     hooks.useOrgReshards.mockReturnValue(ok([]));
     hooks.useOrgTeams.mockReturnValue(ok([]));
+  });
+
+  it("headline leads with the database name; the org id is a subline with a copy button", () => {
+    // The URL org id ("acme") is the subline; the readable database_name is
+    // the headline. (The headline falls back to the raw id while the org is
+    // still loading, covered by the loading branch of Header.)
+    hooks.useOrg.mockReturnValue(ok({ ...ORG, database_name: "posthog" }));
+    renderPage(false);
+
+    const headline = screen.getByRole("heading", { level: 1 });
+    expect(within(headline).getByText("posthog")).toBeInTheDocument();
+    expect(within(headline).getByText("acme")).toBeInTheDocument();
+    expect(within(headline).getByRole("button", { name: /copy acme/i })).toBeInTheDocument();
   });
 
   it.each([

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -24,7 +24,8 @@ import {
 } from "@/components/ui/dialog";
 import { ApiError } from "@/lib/api";
 import { databaseNameProblem } from "@/lib/databaseName";
-import { ducklingBroken, ducklingEntryFor, fmtTime } from "@/lib/format";
+import { ducklingBroken, ducklingEntryFor, fmtTime, orgLabel } from "@/lib/format";
+import { CopyButton } from "@/components/CopyButton";
 import { ShardBadge } from "@/components/ShardBadge";
 import {
   useDatabaseNameAvailable,
@@ -47,7 +48,7 @@ import {
   LegacyNamesBadge,
 } from "@/components/OrgTeamDialogs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import type { DataImportsTableNamingVersion, ManagedWarehouse, OrgTeam, OrgUpdate } from "@/types/api";
+import type { DataImportsTableNamingVersion, ManagedWarehouse, Org, OrgTeam, OrgUpdate } from "@/types/api";
 
 interface FormState {
   database_name: string;
@@ -124,7 +125,7 @@ export function OrgDetail() {
   if (org.isLoading || !form) {
     return (
       <>
-        <Header id={id} />
+        <Header id={id} org={org.data} />
         <PageBody>{org.isError ? <ErrorState error={org.error} /> : <LoadingState />}</PageBody>
       </>
     );
@@ -132,7 +133,7 @@ export function OrgDetail() {
   if (org.isError) {
     return (
       <>
-        <Header id={id} />
+        <Header id={id} org={org.data} />
         <PageBody>
           <ErrorState error={org.error} onRetry={() => org.refetch()} />
         </PageBody>
@@ -199,6 +200,7 @@ export function OrgDetail() {
     <>
       <Header
         id={id}
+        org={org.data}
         actions={
           <AdminGate>
             {orgHasWarehouse ? (
@@ -406,7 +408,12 @@ export function OrgDetail() {
   );
 }
 
-function Header({ id, actions }: { id: string; actions?: React.ReactNode }) {
+function Header({ id, org, actions }: { id: string; org?: Org; actions?: React.ReactNode }) {
+  // Headline leads with the human-readable name (database_name, else alias)
+  // — that is what an operator recognizes at a glance ("Posthog") — and drops
+  // the opaque org id (a UUID for most tenants) to a subline with a copy
+  // button for when it is actually needed (config store, API, k8s labels).
+  const label = org ? orgLabel(org) : id;
   return (
     <PageHeader
       title={
@@ -414,7 +421,15 @@ function Header({ id, actions }: { id: string; actions?: React.ReactNode }) {
           <Link to="/orgs" className="text-muted-foreground hover:text-foreground">
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <span className="font-mono">{id}</span>
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate font-medium">{label}</span>
+            <span className="flex items-center gap-1.5">
+              <span className="truncate font-mono text-xs font-normal text-muted-foreground" title={id}>
+                {id}
+              </span>
+              <CopyButton value={id} />
+            </span>
+          </span>
         </span>
       }
       description="Per-org configuration and managed warehouse."
@@ -771,6 +786,8 @@ function ReshardHistory({ orgId }: { orgId: string }) {
 // OrgTeamsCard lists the org's duckgres_org_teams rows with full CRUD.
 function OrgTeamsCard({ orgId }: { orgId: string }) {
   const teams = useOrgTeams(orgId);
+  const org = useOrg(orgId);
+  const orgName = org.data ? orgLabel(org.data) : undefined;
   const [creating, setCreating] = useState(false);
   const [editing, setEditing] = useState<OrgTeam | null>(null);
   const [deleting, setDeleting] = useState<OrgTeam | null>(null);
@@ -867,10 +884,10 @@ function OrgTeamsCard({ orgId }: { orgId: string }) {
         )}
       </CardContent>
 
-      <CreateTeamDialog open={creating} onClose={() => setCreating(false)} org={orgId} />
-      {editing && <EditTeamDialog team={editing} onClose={() => setEditing(null)} />}
+      <CreateTeamDialog open={creating} onClose={() => setCreating(false)} org={orgId} orgLabel={orgName} />
+      {editing && <EditTeamDialog team={editing} orgLabel={orgName} onClose={() => setEditing(null)} />}
       {deleting && (
-        <DeleteTeamDialog team={deleting} teamCount={rows.length} onClose={() => setDeleting(null)} />
+        <DeleteTeamDialog team={deleting} teamCount={rows.length} orgLabel={orgName} onClose={() => setDeleting(null)} />
       )}
     </Card>
   );

--- a/controlplane/admin/ui/src/pages/OrgTeams.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTeams.test.tsx
@@ -70,7 +70,14 @@ describe("Org teams page", () => {
     vi.clearAllMocks();
     identity.useIdentity.mockReturnValue({ isAdmin: true, me: { email: "a@posthog.com", role: "admin", source: "sso" } });
     hooks.useAllOrgTeams.mockReturnValue(ok(TEAMS));
-    hooks.useOrgs.mockReturnValue(ok([{ name: "acme" }, { name: "solo" }]));
+    // Orgs carry readable database_names; 'acme' id ≠ its db name 'posthog',
+    // 'solo' has no distinct readable name (falls back to the id).
+    hooks.useOrgs.mockReturnValue(
+      ok([
+        { name: "acme", database_name: "posthog", hostname_alias: null },
+        { name: "solo", database_name: "solo", hostname_alias: null },
+      ]),
+    );
     hooks.useCreateOrgTeam.mockReturnValue(mut());
     hooks.useUpdateOrgTeam.mockReturnValue(mut());
     hooks.useDeleteOrgTeam.mockReturnValue(mut());
@@ -79,7 +86,10 @@ describe("Org teams page", () => {
   it("lists every team with schema, enabled and backfill state", () => {
     renderPage();
 
-    expect(screen.getAllByText("acme")).toHaveLength(2);
+    // The Org column leads with the readable database name; the org id sits
+    // under it for orgs whose id differs from the db name.
+    expect(screen.getAllByText("posthog")).toHaveLength(2);
+    expect(screen.getAllByText("acme").length).toBeGreaterThan(0);
     expect(screen.getByText("solo")).toBeInTheDocument();
     expect(screen.getByText("team_1")).toBeInTheDocument();
     expect(screen.getByText("team_2")).toBeInTheDocument();
@@ -94,6 +104,17 @@ describe("Org teams page", () => {
     expect(screen.getByText("none")).toBeInTheDocument();
     // Admin affordance present.
     expect(screen.getByRole("button", { name: /add team/i })).toBeInTheDocument();
+  });
+
+  it("the Org cell is not a link and clicking a row opens the team", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Row click opens the team's edit dialog (the Org cell is deliberately
+    // not a link to the org page — the team's own dialog is the action).
+    await user.click(screen.getAllByText("posthog")[0]);
+    expect(await screen.findByText(/operator repair tool/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /posthog|acme|solo/i })).not.toBeInTheDocument();
   });
 
   it("refuses deleting an org's last team up front", async () => {

--- a/controlplane/admin/ui/src/pages/OrgTeams.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTeams.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { Layers, Pencil, Plus, Search, Trash2 } from "lucide-react";
-import { Link } from "react-router-dom";
 import { PageBody, PageHeader } from "@/components/AppShell";
 import { DataTable } from "@/components/DataTable";
 import { Card } from "@/components/ui/card";
@@ -18,8 +17,9 @@ import {
   LegacyNamesBadge,
 } from "@/components/OrgTeamDialogs";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
+import { OrgRef } from "@/components/OrgRef";
 import { useAllOrgTeams, useOrgs } from "@/hooks/useApi";
-import { fmtTime } from "@/lib/format";
+import { fmtTime, orgLabel } from "@/lib/format";
 import type { OrgTeam } from "@/types/api";
 
 export function OrgTeams() {
@@ -39,23 +39,26 @@ export function OrgTeams() {
     return m;
   }, [teams.data]);
 
+  // Readable org names keyed by org id. Shown instead of the raw id — an
+  // operator scans for "Posthog", not a UUID. The id stays visible under
+  // the label and via the copy button.
+  const orgLabels = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const o of orgs.data ?? []) {
+      m.set(o.name, orgLabel(o));
+    }
+    return m;
+  }, [orgs.data]);
+
   const columns = useMemo<ColumnDef<OrgTeam, any>[]>(
     () => [
       {
         accessorKey: "org_id",
         header: "Org",
-        cell: ({ getValue }) => {
-          const org = String(getValue());
-          return (
-            <Link
-              to={`/orgs/${encodeURIComponent(org)}`}
-              className="font-mono text-xs font-medium hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {org}
-            </Link>
-          );
-        },
+        // Human-readable database name first; the org id sits under it.
+        // Deliberately NOT a link: click-through opens the team edit dialog
+        // (row click), matching the rest of this page's action model.
+        cell: ({ row }) => <OrgRef id={row.original.org_id} label={orgLabels.get(row.original.org_id)} />,
       },
       {
         accessorKey: "team_id",
@@ -99,7 +102,7 @@ export function OrgTeams() {
         header: "",
         enableSorting: false,
         cell: ({ row }) => (
-          <div className="-my-1 flex justify-end gap-1">
+          <div className="-my-1 flex justify-end gap-1" onClick={(e) => e.stopPropagation()}>
             <AdminGate>
               <Button
                 variant="ghost"
@@ -126,7 +129,7 @@ export function OrgTeams() {
         ),
       },
     ],
-    [],
+    [orgLabels],
   );
 
   return (
@@ -165,6 +168,9 @@ export function OrgTeams() {
               columns={columns}
               globalFilter={filter}
               onGlobalFilterChange={setFilter}
+              // Click anywhere on a team row opens it (the edit dialog) —
+              // the Org cell is deliberately not a link to the org page.
+              onRowClick={(team) => setEditing(team)}
               initialSorting={[
                 { id: "org_id", desc: false },
                 { id: "team_id", desc: false },
@@ -184,13 +190,20 @@ export function OrgTeams() {
       <CreateTeamDialog
         open={creating}
         onClose={() => setCreating(false)}
-        orgs={(orgs.data ?? []).map((o) => o.name)}
+        orgs={(orgs.data ?? []).map((o) => ({ name: o.name, label: orgLabel(o) }))}
       />
-      {editing && <EditTeamDialog team={editing} onClose={() => setEditing(null)} />}
+      {editing && (
+        <EditTeamDialog
+          team={editing}
+          orgLabel={orgLabels.get(editing.org_id)}
+          onClose={() => setEditing(null)}
+        />
+      )}
       {deleting && (
         <DeleteTeamDialog
           team={deleting}
           teamCount={countByOrg.get(deleting.org_id) ?? 1}
+          orgLabel={orgLabels.get(deleting.org_id)}
           onClose={() => setDeleting(null)}
         />
       )}

--- a/controlplane/admin/ui/src/pages/ReshardForm.tsx
+++ b/controlplane/admin/ui/src/pages/ReshardForm.tsx
@@ -25,7 +25,8 @@ import {
 } from "@/components/ui/select";
 import { ducklingEntryFor } from "@/lib/format";
 import { classifySecretName } from "@/lib/reshard";
-import { useDucklingsMetadata, useReshardTargets, useStartReshard, useWarehouse } from "@/hooks/useApi";
+import { useDucklingsMetadata, useOrg, useReshardTargets, useStartReshard, useWarehouse } from "@/hooks/useApi";
+import { orgLabel } from "@/lib/format";
 import type { StartReshardBody } from "@/types/api";
 
 // Reshard start form: pick a target metadata store for the org, confirm, run.
@@ -37,6 +38,8 @@ export function ReshardForm() {
   const warehouse = useWarehouse(id);
   const metadata = useDucklingsMetadata();
   const start = useStartReshard(id);
+  const org = useOrg(id);
+  const displayName = org.data ? orgLabel(org.data) : id;
 
   const [targetType, setTargetType] = useState<"cnpg-shard" | "external">("cnpg-shard");
   const [shard, setShard] = useState("");
@@ -120,7 +123,7 @@ export function ReshardForm() {
   return (
     <>
       <PageHeader
-        title={`Reshard ${id}`}
+        title={`Reshard ${displayName}`}
         actions={
           <Button variant="outline" size="sm" asChild>
             <Link to={`/orgs/${encodeURIComponent(id)}`}>
@@ -374,7 +377,7 @@ export function ReshardForm() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              Reshard "{id}": {sourceLabel} → {targetLabel}?
+              Reshard "{displayName}": {sourceLabel} → {targetLabel}?
             </DialogTitle>
             <DialogDescription>
               The org goes into maintenance mode: new connections are refused, existing sessions

--- a/controlplane/admin/ui/src/pages/ReshardOperation.tsx
+++ b/controlplane/admin/ui/src/pages/ReshardOperation.tsx
@@ -18,7 +18,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { fmtBytes, fmtInt, fmtTime } from "@/lib/format";
-import { useCancelReshard, useReshard, useReshardLog } from "@/hooks/useApi";
+import { useCancelReshard, useOrgLabels, useReshard, useReshardLog } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import type { ReshardOperation as ReshardOp } from "@/types/api";
 
 // Human labels for the runner's step machine.
@@ -57,6 +58,7 @@ export function ReshardOperation() {
   const op = useReshard(id);
   const entries = useReshardLog(id, op.data?.state);
   const cancel = useCancelReshard();
+  const orgLabels = useOrgLabels();
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [autoScroll, setAutoScroll] = useState(true);
   const [msg, setMsg] = useState<string | null>(null);
@@ -119,7 +121,7 @@ export function ReshardOperation() {
             )}
             <Button variant="outline" size="sm" asChild>
               <Link to={`/orgs/${encodeURIComponent(o.org_id)}`}>
-                <ArrowLeft className="h-4 w-4" /> {o.org_id}
+                <ArrowLeft className="h-4 w-4" /> {orgLabels.get(o.org_id) ?? o.org_id}
               </Link>
             </Button>
           </div>
@@ -131,7 +133,7 @@ export function ReshardOperation() {
             <CardHeader className="flex-row items-center justify-between">
               <CardTitle className="flex items-center gap-3">
                 <Link to={`/orgs/${encodeURIComponent(o.org_id)}`} className="hover:underline">
-                  {o.org_id}
+                  <OrgRef id={o.org_id} label={orgLabels.get(o.org_id)} />
                 </Link>
                 <span className="flex items-center gap-2 font-mono text-xs font-normal text-muted-foreground">
                   {describeStore(o.source_kind, o.from_shard, o.source_endpoint)}

--- a/controlplane/admin/ui/src/pages/Reshards.tsx
+++ b/controlplane/admin/ui/src/pages/Reshards.tsx
@@ -13,7 +13,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { fmtTime } from "@/lib/format";
-import { useAllReshards } from "@/hooks/useApi";
+import { useAllReshards, useOrgLabels } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import type { ReshardOperation } from "@/types/api";
 
 function describeStore(kind: string, shard: string, endpoint: string): string {
@@ -38,6 +39,7 @@ function duration(from: string | null, to: string | null): string {
 // reshard lives on the org detail page — this page is the fleet overview.
 export function Reshards() {
   const reshards = useAllReshards();
+  const orgLabels = useOrgLabels();
   const ops = reshards.data ?? [];
 
   return (
@@ -81,11 +83,8 @@ export function Reshards() {
                         </Link>
                       </TableCell>
                       <TableCell>
-                        <Link
-                          to={`/orgs/${encodeURIComponent(op.org_id)}`}
-                          className="font-mono text-xs hover:underline"
-                        >
-                          {op.org_id}
+                        <Link to={`/orgs/${encodeURIComponent(op.org_id)}`} className="hover:underline">
+                          <OrgRef id={op.org_id} label={orgLabels.get(op.org_id)} />
                         </Link>
                       </TableCell>
                       <TableCell>

--- a/controlplane/admin/ui/src/pages/Users.tsx
+++ b/controlplane/admin/ui/src/pages/Users.tsx
@@ -27,10 +27,12 @@ import {
   useDisableUser,
   useEnableUser,
   useKillUserSessions,
+  useOrgLabels,
   useUpdateUser,
   useUserSecrets,
   useUsers,
 } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import { fmtInt, fmtTime } from "@/lib/format";
 import type { OrgUser } from "@/types/api";
 
@@ -48,13 +50,14 @@ export function UsersPage() {
   const killUser = useKillUserSessions();
   const disableUser = useDisableUser();
   const enableUser = useEnableUser();
+  const orgLabels = useOrgLabels();
 
   const columns = useMemo<ColumnDef<OrgUser, any>[]>(
     () => [
       {
         accessorKey: "org_id",
         header: "Org",
-        cell: ({ getValue }) => <span className="font-mono text-xs">{String(getValue())}</span>,
+        cell: ({ row }) => <OrgRef id={row.original.org_id} label={orgLabels.get(row.original.org_id)} />,
       },
       {
         accessorKey: "username",
@@ -154,7 +157,7 @@ export function UsersPage() {
         ),
       },
     ],
-    [enableUser],
+    [enableUser, orgLabels],
   );
 
   return (
@@ -211,8 +214,16 @@ export function UsersPage() {
       </PageBody>
 
       {creating && <CreateUserDialog onClose={() => setCreating(false)} />}
-      {editing && <EditUserDialog user={editing} onClose={() => setEditing(null)} />}
-      {secretsFor && <SecretsDialog user={secretsFor} onClose={() => setSecretsFor(null)} />}
+      {editing && (
+        <EditUserDialog user={editing} orgLabel={orgLabels.get(editing.org_id)} onClose={() => setEditing(null)} />
+      )}
+      {secretsFor && (
+        <SecretsDialog
+          user={secretsFor}
+          orgLabel={orgLabels.get(secretsFor.org_id)}
+          onClose={() => setSecretsFor(null)}
+        />
+      )}
 
       <Dialog open={!!killing} onOpenChange={(o) => !o && setKilling(null)}>
         <DialogContent>
@@ -221,8 +232,10 @@ export function UsersPage() {
             <DialogDescription>
               Immediately terminates every active session and in-flight query for{" "}
               <span className="font-mono">{killing?.username}</span> @{" "}
-              <span className="font-mono">{killing?.org_id}</span> across all control-plane replicas. The
-              user can reconnect right away — use Disable to also block new connections.
+              <span className="font-medium">{killing && (orgLabels.get(killing.org_id) ?? killing.org_id)}</span>{" "}
+              <span className="font-mono text-xs text-muted-foreground">({killing?.org_id})</span> across all
+              control-plane replicas. The user can reconnect right away — use Disable to also block new
+              connections.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -251,8 +264,9 @@ export function UsersPage() {
             <DialogTitle>Disable "{disabling?.username}"?</DialogTitle>
             <DialogDescription>
               Blocks all new connections for <span className="font-mono">{disabling?.username}</span> @{" "}
-              <span className="font-mono">{disabling?.org_id}</span> over pgwire and kills their
-              live sessions now. Reverse it any time with Enable.
+              <span className="font-medium">{disabling && (orgLabels.get(disabling.org_id) ?? disabling.org_id)}</span>{" "}
+              <span className="font-mono text-xs text-muted-foreground">({disabling?.org_id})</span> over pgwire
+              and kills their live sessions now. Reverse it any time with Enable.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -281,7 +295,9 @@ export function UsersPage() {
             <DialogTitle>Delete user "{deleting?.username}"?</DialogTitle>
             <DialogDescription>
               Removes <span className="font-mono">{deleting?.username}</span> from org{" "}
-              <span className="font-mono">{deleting?.org_id}</span>. This cannot be undone.
+              <span className="font-medium">{deleting && (orgLabels.get(deleting.org_id) ?? deleting.org_id)}</span>{" "}
+              <span className="font-mono text-xs text-muted-foreground">({deleting?.org_id})</span>. This cannot
+              be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -378,7 +394,7 @@ function CreateUserDialog({ onClose }: { onClose: () => void }) {
   );
 }
 
-function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void }) {
+function EditUserDialog({ user, orgLabel, onClose }: { user: OrgUser; orgLabel?: string; onClose: () => void }) {
   const update = useUpdateUser();
   const [password, setPassword] = useState("");
   const [passthrough, setPassthrough] = useState(user.passthrough);
@@ -411,7 +427,9 @@ function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void 
             Edit <span className="font-mono">{user.username}</span>
           </DialogTitle>
           <DialogDescription>
-            Org <span className="font-mono">{user.org_id}</span>. Leave password blank to keep it unchanged.
+            Org <span className="font-medium">{orgLabel ?? user.org_id}</span>{" "}
+            {orgLabel && <span className="font-mono text-xs text-muted-foreground">({user.org_id})</span>} Leave
+            password blank to keep it unchanged.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
@@ -443,7 +461,7 @@ function EditUserDialog({ user, onClose }: { user: OrgUser; onClose: () => void 
   );
 }
 
-function SecretsDialog({ user, onClose }: { user: OrgUser; onClose: () => void }) {
+function SecretsDialog({ user, orgLabel, onClose }: { user: OrgUser; orgLabel?: string; onClose: () => void }) {
   const secrets = useUserSecrets(user.org_id, user.username);
   const del = useDeleteUserSecret();
 
@@ -455,8 +473,10 @@ function SecretsDialog({ user, onClose }: { user: OrgUser; onClose: () => void }
             <KeyRound className="h-4 w-4" /> Persistent secrets
           </DialogTitle>
           <DialogDescription>
-            <span className="font-mono">{user.username}</span> @ <span className="font-mono">{user.org_id}</span>.
-            Secret material is never exposed — only names and timestamps.
+            <span className="font-mono">{user.username}</span> @{" "}
+            <span className="font-medium">{orgLabel ?? user.org_id}</span>{" "}
+            {orgLabel && <span className="font-mono text-xs text-muted-foreground">({user.org_id})</span>}. Secret
+            material is never exposed — only names and timestamps.
           </DialogDescription>
         </DialogHeader>
         <div className="max-h-80 overflow-y-auto">

--- a/controlplane/admin/ui/src/pages/Workers.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.tsx
@@ -8,7 +8,8 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
-import { useFleet, useWorkers } from "@/hooks/useApi";
+import { useFleet, useOrgLabels, useWorkers } from "@/hooks/useApi";
+import { OrgRef } from "@/components/OrgRef";
 import { fmtBytes, fmtDuration, fmtInt } from "@/lib/format";
 import type { WorkerStatus } from "@/types/api";
 
@@ -18,6 +19,7 @@ const STATE_ORDER = ["spawning", "idle", "reserved", "activating", "hot", "hot_i
 export function Workers() {
   const fleet = useFleet();
   const workers = useWorkers();
+  const orgLabels = useOrgLabels();
   const [filter, setFilter] = useState("");
 
   const fleetRows = fleet.data ?? [];
@@ -49,7 +51,7 @@ export function Workers() {
       {
         accessorKey: "org",
         header: "Org",
-        cell: ({ getValue }) => <span className="font-mono text-xs">{String(getValue())}</span>,
+        cell: ({ row }) => <OrgRef id={row.original.org} label={orgLabels.get(row.original.org)} />,
       },
       {
         accessorKey: "status",
@@ -93,7 +95,7 @@ export function Workers() {
         },
       },
     ],
-    [],
+    [orgLabels],
   );
 
   return (


### PR DESCRIPTION
## Why

Operators recognise "posthog", not `4dc8564d-bd82-…` — but most of the console labelled orgs by their raw org id (a UUID for most tenants), so finding the right tenant meant memorising ids. This makes the human-readable database name the primary label everywhere an org shows up, and keeps the org id one glance/one click away for when it's actually needed.

## Changes

- **New shared building blocks** — `OrgRef` (readable name primary, compact id subline, inline copy), `CopyButton` (clipboard affordance), and a `useOrgLabels()` hook that builds an id→label map from the orgs list via the existing `orgLabel()` helper (`database_name` → `hostname_alias` → id).
- **Org detail page** (`/orgs/:id`) — headline leads with the database name; the org id sits beneath it as a subline with a copy icon.
- **Org teams page** (`/org-teams`) — the Org column shows the database name and is **no longer a link to the org page**; clicking anywhere on a team row opens that team (its edit dialog) directly.
- **Readable names across the console** — Users (list + kill/disable/delete/edit/secrets dialogs), Workers, Reshards, Reshard operation, Reshard form, Errors (+ detail dialog), Audit, and the Metrics org picker all resolve bare org-id strings to readable names. Destructive confirms show `Posthog (4dc8…cf)` — name plus id, so the exact target is unambiguous.
- **Consolidation** — Live.tsx's one-off `OrgIdentity` cell is replaced by the shared `OrgRef`.
- **Tests** — OrgDetail header (headline/id/copy), OrgTeams (readable display, no org link, row-click opens the team); the 3 other pre-existing label tests (Live, Impersonate) still pass and pin the shared rendering.

Reviewed the whole UI for stragglers: Overview and Impersonate already led with readable names; the Orgs list keeps `id` + `database_name` as separate sortable columns by design; free-text filter/type-to-confirm inputs consciously keep the raw id (that's what they validate against); `ConfigStore`/nodes views carry no org identity of their own.

Frontend bundle is a CI/Docker build artifact (`just ui-build`), not committed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*