### PR TITLE
Capture profiles from Flight DoGet

### DIFF
--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -721,10 +721,6 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare query: %v", err)
 	}
 
-	// Send DuckDB profiling output as gRPC trailing metadata so the
-	// control plane can attach it to the trace span.
-	sendProfilingMetadata(ctx, session)
-
 	handleID := fmt.Sprintf("query-%d", session.handleCounter.Add(1))
 	ticketBytes, err := flightsql.CreateStatementQueryTicket([]byte(handleID))
 	if err != nil {
@@ -822,6 +818,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 
 		inTxn := tx != nil || session.sqlTxActive.Load()
 		var closeRows func() error
+		execStartedAt := clearProfilingOutput()
 		queryFn := func() (*sql.Rows, error) {
 			rows, closer, err := session.queryRows(ctx, tx, handle.Query)
 			if err != nil {
@@ -862,6 +859,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		}
 		defer func() {
 			_ = closeRows()
+			sendProfilingMetadataSince(ctx, execStartedAt)
 		}()
 
 		for {
@@ -937,6 +935,7 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	defer session.progress.queryActive.Store(false)
 	endTxnWork := ttx.beginWork()
 	defer endTxnWork()
+	execStartedAt := clearProfilingOutput()
 
 	execFn := func() (sql.Result, error) {
 		return session.exec(ctx, tx, query)
@@ -1003,7 +1002,7 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 		return 0, status.Errorf(codes.InvalidArgument, "failed to execute update: %v", execErr)
 	}
 
-	sendProfilingMetadata(ctx, session)
+	sendProfilingMetadataSince(ctx, execStartedAt)
 
 	affected, err := result.RowsAffected()
 	if err != nil {

--- a/duckdbservice/profiling.go
+++ b/duckdbservice/profiling.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -17,20 +18,38 @@ const profilingMetadataKey = "x-duckgres-profiling"
 // profilingOutputPath is the fixed file path where DuckDB writes profiling
 // output. Only one query runs per worker at a time (control plane enforces
 // this), so a single file is safe.
-const profilingOutputPath = "/tmp/duckgres-profiling.json"
+var profilingOutputPath = "/tmp/duckgres-profiling.json"
 
-// sendProfilingMetadata reads the profiling output file written by DuckDB
-// and sends it as gRPC trailing metadata so the control plane can attach
-// it to the trace span.
-func sendProfilingMetadata(ctx context.Context, session *Session) {
+// clearProfilingOutput removes the previous statement's profile before a
+// statement begins. The returned timestamp is used to reject a profile that
+// was not produced by this execution.
+func clearProfilingOutput() time.Time {
+	_ = os.Remove(profilingOutputPath)
+	return time.Now()
+}
+
+func profilingMetadataSince(startedAt time.Time) string {
+	info, err := os.Stat(profilingOutputPath)
+	if err != nil || !info.ModTime().After(startedAt) {
+		return ""
+	}
 	data, err := os.ReadFile(profilingOutputPath)
 	if err != nil || len(data) == 0 {
-		return
+		return ""
 	}
 	// Compact JSON to a single line — gRPC metadata values cannot contain newlines.
 	var compact bytes.Buffer
 	if json.Compact(&compact, data) != nil {
-		return
+		return ""
 	}
-	_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, compact.String()))
+	return compact.String()
+}
+
+// sendProfilingMetadataSince sends the profile written by the execution that
+// began at startedAt. It deliberately ignores absent, stale, and malformed
+// files so canceled or failed statements cannot reuse an earlier profile.
+func sendProfilingMetadataSince(ctx context.Context, startedAt time.Time) {
+	if profile := profilingMetadataSince(startedAt); profile != "" {
+		_ = grpc.SetTrailer(ctx, metadata.Pairs(profilingMetadataKey, profile))
+	}
 }

--- a/duckdbservice/profiling_test.go
+++ b/duckdbservice/profiling_test.go
@@ -129,9 +129,12 @@ func TestSendProfilingMetadataSinceRejectsStaleOutput(t *testing.T) {
 	}
 
 	startedAt := clearProfilingOutput()
-	time.Sleep(time.Millisecond)
 	if err := os.WriteFile(profilingOutputPath, []byte(`{"latency":0.2}`), 0o600); err != nil {
 		t.Fatalf("write completed profile: %v", err)
+	}
+	freshAt := startedAt.Add(time.Second)
+	if err := os.Chtimes(profilingOutputPath, freshAt, freshAt); err != nil {
+		t.Fatalf("set completed profile mtime: %v", err)
 	}
 	if got := profilingMetadataSince(startedAt); got != `{"latency":0.2}` {
 		t.Fatalf("completed profile metadata = %q", got)

--- a/duckdbservice/profiling_test.go
+++ b/duckdbservice/profiling_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // validateGRPCMetadataValue checks that a string is safe for use as a gRPC
@@ -111,5 +113,27 @@ func TestProfilingOutputGRPCSafety(t *testing.T) {
 	}
 	if parsed["query_name"] != "SELECT * FROM \"my_table\" WHERE name = 'O''Brien'" {
 		t.Errorf("query_name mangled: %v", parsed["query_name"])
+	}
+}
+
+func TestSendProfilingMetadataSinceRejectsStaleOutput(t *testing.T) {
+	previousPath := profilingOutputPath
+	profilingOutputPath = t.TempDir() + "/profiling.json"
+	t.Cleanup(func() { profilingOutputPath = previousPath })
+
+	if err := os.WriteFile(profilingOutputPath, []byte(`{"latency":0.1}`), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	if got := profilingMetadataSince(time.Now()); got != "" {
+		t.Fatalf("stale profile metadata = %q, want empty", got)
+	}
+
+	startedAt := clearProfilingOutput()
+	time.Sleep(time.Millisecond)
+	if err := os.WriteFile(profilingOutputPath, []byte(`{"latency":0.2}`), 0o600); err != nil {
+		t.Fatalf("write completed profile: %v", err)
+	}
+	if got := profilingMetadataSince(startedAt); got != `{"latency":0.2}` {
+		t.Fatalf("completed profile metadata = %q", got)
 	}
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -129,6 +129,9 @@ type portalExec struct {
 	originalQuery  string
 	convertedQuery string
 	start          time.Time // first Execute leg's start, so the query log spans all legs
+	// finishProfiling runs after rows.Close has allowed a Flight DoGet trailer
+	// to arrive. A suspended portal retains it until its terminal Execute.
+	finishProfiling func()
 }
 
 // closeExec releases a suspended portal's open rowset (if any). Must be
@@ -139,6 +142,9 @@ func (p *portal) closeExec() {
 		return
 	}
 	_ = p.exec.rows.Close()
+	if p.exec.finishProfiling != nil {
+		p.exec.finishProfiling()
+	}
 	p.exec = nil
 }
 

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -912,9 +912,9 @@ func (c *clientConn) handleExecute(body []byte) {
 		}
 		rows, err = runQuery()
 	}
-	c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
-	execSpan.End()
 	if err != nil {
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		execSpan.End()
 		queryFinalErr = err
 		errCode := classifyErrorCode(err)
 		errMsg := err.Error()
@@ -929,9 +929,19 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 	keepRowsOpen := false
+	profilingFinished := false
+	finishProfiling := func() {
+		if profilingFinished {
+			return
+		}
+		profilingFinished = true
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		execSpan.End()
+	}
 	defer func() {
 		if !keepRowsOpen {
 			_ = rows.Close()
+			finishProfiling()
 		}
 	}()
 
@@ -1041,14 +1051,15 @@ func (c *clientConn) handleExecute(body []byte) {
 		// entry is written by the leg that completes the portal.
 		keepRowsOpen = true
 		p.exec = &portalExec{
-			rows:           activeRows,
-			cols:           cols,
-			typeOIDs:       typeOIDs,
-			cmdType:        cmdType,
-			rowCount:       int64(rowCount),
-			originalQuery:  originalQuery,
-			convertedQuery: convertedQuery,
-			start:          start,
+			rows:            activeRows,
+			cols:            cols,
+			typeOIDs:        typeOIDs,
+			cmdType:         cmdType,
+			rowCount:        int64(rowCount),
+			originalQuery:   originalQuery,
+			convertedQuery:  convertedQuery,
+			start:           start,
+			finishProfiling: finishProfiling,
 		}
 		_ = wire.WritePortalSuspended(c.writer)
 		return

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -929,6 +929,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		return
 	}
 	keepRowsOpen := false
+	rowsFinished := false
 	profilingFinished := false
 	finishProfiling := func() {
 		if profilingFinished {
@@ -939,9 +940,10 @@ func (c *clientConn) handleExecute(body []byte) {
 		execSpan.End()
 	}
 	finishRows := func() {
-		if keepRowsOpen {
+		if keepRowsOpen || rowsFinished {
 			return
 		}
+		rowsFinished = true
 		_ = rows.Close()
 		finishProfiling()
 	}
@@ -1008,11 +1010,6 @@ func (c *clientConn) handleExecute(body []byte) {
 			// including as the rowset a suspension keeps open.
 			rows = retryRows
 			activeRows = retryRows
-			defer func() {
-				if !keepRowsOpen {
-					_ = retryRows.Close()
-				}
-			}()
 			stream = c.streamSelectRows(retryRows, cols, colTypes, typeOIDs, false, p.resultFormats, maxRows)
 		}
 	}

--- a/server/conn_extended_query.go
+++ b/server/conn_extended_query.go
@@ -938,11 +938,15 @@ func (c *clientConn) handleExecute(body []byte) {
 		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
 		execSpan.End()
 	}
-	defer func() {
-		if !keepRowsOpen {
-			_ = rows.Close()
-			finishProfiling()
+	finishRows := func() {
+		if keepRowsOpen {
+			return
 		}
+		_ = rows.Close()
+		finishProfiling()
+	}
+	defer func() {
+		finishRows()
 	}()
 
 	cols, err := rows.Columns()
@@ -951,6 +955,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		c.logger().Error("Columns error.", "error", err)
 		c.sendError("ERROR", "42000", err.Error())
 		c.setTxError()
+		finishRows()
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, "42000", err.Error(), "extended")
 		return
 	}
@@ -1001,6 +1006,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		} else {
 			// The retried rowset replaces the original everywhere below —
 			// including as the rowset a suspension keeps open.
+			rows = retryRows
 			activeRows = retryRows
 			defer func() {
 				if !keepRowsOpen {
@@ -1015,6 +1021,7 @@ func (c *clientConn) handleExecute(body []byte) {
 		queryFinalErr = stream.scanErr
 		c.sendError("ERROR", "42000", stream.scanErr.Error())
 		c.setTxError()
+		finishRows()
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, "42000", stream.scanErr.Error(), "extended")
 		return
 	}
@@ -1039,6 +1046,7 @@ func (c *clientConn) handleExecute(body []byte) {
 			c.sendError("ERROR", errCode, errMsg)
 		}
 		c.setTxError()
+		finishRows()
 		c.logQuery(start, originalQuery, convertedQuery, cmdType, 0, 0, errCode, errMsg, "extended")
 		return
 	}
@@ -1068,6 +1076,7 @@ func (c *clientConn) handleExecute(body []byte) {
 	c.updateTxStatus(cmdType)
 	tag := buildCommandTagFromRowCount(cmdType, int64(rowCount))
 	_ = c.writeCommandComplete(tag)
+	finishRows()
 	c.logQuery(start, originalQuery, convertedQuery, cmdType, int64(rowCount), 0, "", "", "extended")
 }
 

--- a/server/conn_query_exec.go
+++ b/server/conn_query_exec.go
@@ -204,9 +204,9 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string, workerStat
 		}
 		rows, err = runQuery()
 	}
-	c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
-	execSpan.End()
 	if err != nil {
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		execSpan.End()
 		queryFinalErr = err
 		errCode := classifyErrorCode(err)
 		errMsg := err.Error()
@@ -221,7 +221,11 @@ func (c *clientConn) executeSelectQuery(query string, cmdType string, workerStat
 		_ = c.flushWriter()
 		return 0, errCode, errMsg, nil
 	}
-	defer func() { _ = rows.Close() }()
+	defer func() {
+		_ = rows.Close()
+		c.lastProfilingSummary = observe.EnrichSpanWithProfiling(execCtx, execSpan, execStart, c.executor, c.orgID)
+		execSpan.End()
+	}()
 
 	cols, err := rows.Columns()
 	if err != nil {

--- a/server/conn_querylog_lifecycle_test.go
+++ b/server/conn_querylog_lifecycle_test.go
@@ -349,3 +349,79 @@ func TestLifecyclePairFiresOnHandleExecuteQuery(t *testing.T) {
 	c.handleExecute(body)
 	assertLifecyclePair(t, buf, "handleExecute-Query")
 }
+
+func TestHandleExecuteLogsProfileAfterResultStreamCloses(t *testing.T) {
+	c, cleanup := newLifecycleClientConn(t)
+	defer cleanup()
+
+	profile := `{"cpu_time":2.5,"system_peak_buffer_memory":8192,"children":[]}`
+	exec := &closeProfileExecutor{profile: profile}
+	exec.rows = &closeProfileRowSet{onClose: func() { exec.ready = true }}
+	c.executor = exec
+	c.portals["p1"] = &portal{stmt: &preparedStmt{
+		query:          "SELECT 1",
+		convertedQuery: "SELECT 1",
+	}}
+
+	c.handleExecute(append([]byte("p1\x00"), 0, 0, 0, 0))
+
+	select {
+	case entry := <-c.server.queryLogger.ch:
+		if entry.CPUTimeSeconds != 2.5 {
+			t.Fatalf("CPUTimeSeconds = %f, want 2.5", entry.CPUTimeSeconds)
+		}
+		if entry.PeakBufferMemoryBytes != 8192 {
+			t.Fatalf("PeakBufferMemoryBytes = %d, want 8192", entry.PeakBufferMemoryBytes)
+		}
+	default:
+		t.Fatal("expected terminal query-log entry")
+	}
+}
+
+type closeProfileExecutor struct {
+	rows    RowSet
+	profile string
+	ready   bool
+}
+
+func (e *closeProfileExecutor) QueryContext(context.Context, string, ...any) (RowSet, error) {
+	return e.rows, nil
+}
+func (e *closeProfileExecutor) ExecContext(context.Context, string, ...any) (ExecResult, error) {
+	return nil, errors.New("not implemented")
+}
+func (e *closeProfileExecutor) Query(string, ...any) (RowSet, error) { return e.rows, nil }
+func (e *closeProfileExecutor) Exec(string, ...any) (ExecResult, error) {
+	return nil, errors.New("not implemented")
+}
+func (e *closeProfileExecutor) ConnContext(context.Context) (RawConn, error) {
+	return nil, errors.New("not implemented")
+}
+func (e *closeProfileExecutor) PingContext(context.Context) error { return nil }
+func (e *closeProfileExecutor) Close() error                      { return nil }
+func (e *closeProfileExecutor) LastProfilingOutput() string {
+	if !e.ready {
+		return ""
+	}
+	return e.profile
+}
+
+type closeProfileRowSet struct {
+	closed  bool
+	onClose func()
+}
+
+func (*closeProfileRowSet) Columns() ([]string, error) { return []string{"x"}, nil }
+func (*closeProfileRowSet) ColumnTypes() ([]ColumnTyper, error) {
+	return []ColumnTyper{stringColumnTyper{}}, nil
+}
+func (*closeProfileRowSet) Next() bool        { return false }
+func (*closeProfileRowSet) Scan(...any) error { return nil }
+func (r *closeProfileRowSet) Close() error {
+	if !r.closed {
+		r.closed = true
+		r.onClose()
+	}
+	return nil
+}
+func (*closeProfileRowSet) Err() error { return nil }

--- a/server/conn_tier_exec_test.go
+++ b/server/conn_tier_exec_test.go
@@ -1284,11 +1284,12 @@ func TestExtendedExecuteOOMEscalationFailureIsConnectionFatal(t *testing.T) {
 // identical schema.
 func TestExtendedExecuteZeroRowMidStreamOOMReexecutes(t *testing.T) {
 	first := &tierRowSet{err: errors.New(tierOOMError)}
+	retry := &tierRowSet{rows: []int64{5, 6}}
 	small := &tierExecutor{name: "small", queryFn: func(int, string) (RowSet, error) {
 		return first, nil
 	}}
 	big := &tierExecutor{name: "big", queryFn: func(int, string) (RowSet, error) {
-		return &tierRowSet{rows: []int64{5, 6}}, nil
+		return retry, nil
 	}}
 	c, out, reasons := newExtendedTierConn(small, big)
 
@@ -1298,8 +1299,11 @@ func TestExtendedExecuteZeroRowMidStreamOOMReexecutes(t *testing.T) {
 	if len(*reasons) != 1 || (*reasons)[0] != escalateReasonOOM {
 		t.Fatalf("switcher reasons = %v, want [%q]", *reasons, escalateReasonOOM)
 	}
-	if first.closed == 0 {
-		t.Fatal("the abandoned first RowSet was never closed")
+	if first.closed != 1 {
+		t.Fatalf("abandoned first RowSet closed %d times, want once", first.closed)
+	}
+	if retry.closed != 1 {
+		t.Fatalf("retried RowSet closed %d times, want once", retry.closed)
 	}
 	msgs := parseWireMsgs(t, out.Bytes())
 	if countMsgs(msgs, 'E') != 0 {

--- a/server/flightclient/flight_executor.go
+++ b/server/flightclient/flight_executor.go
@@ -243,6 +243,7 @@ func (e *FlightExecutor) QueryContext(ctx context.Context, query string, args ..
 	// Return empty results for queries that are only semicolons, whitespace,
 	// and/or comments. These represent PostgreSQL client pings (e.g., pgx sends "-- ping").
 	if sqlcore.IsEmptyQuery(query) {
+		e.lastProfiling.Store("")
 		return &emptyRowSet{}, nil
 	}
 
@@ -288,7 +289,8 @@ func (e *FlightExecutor) QueryContext(ctx context.Context, query string, args ..
 		return nil, err
 	}
 
-	reader, err := e.client.DoGet(reqCtx, ticket)
+	var doGetTrailer metadata.MD
+	reader, err := e.client.DoGet(reqCtx, ticket, grpc.Trailer(&doGetTrailer))
 	if err != nil {
 		// If cancellation lands after Execute has registered a worker-side
 		// handle but before DoGet returns a RowSet, there is no Close call to
@@ -313,6 +315,9 @@ func (e *FlightExecutor) QueryContext(ctx context.Context, query string, args ..
 		schema:        schema,
 		cancel:        cancel,
 		waitForClosed: e.waitForSessionIdle,
+		storeProfiling: func() {
+			e.storeProfilingFromTrailer(doGetTrailer)
+		},
 	}, nil
 }
 
@@ -781,14 +786,24 @@ type FlightRowSet struct {
 	schema *arrow.Schema
 
 	// Current batch state
-	currentBatch  arrow.RecordBatch
-	batchRow      int // current row index within currentBatch
-	done          bool
-	err           error
-	closeOnce     sync.Once
-	closeErr      error
-	cancel        context.CancelFunc
-	waitForClosed func() error
+	currentBatch   arrow.RecordBatch
+	batchRow       int // current row index within currentBatch
+	done           bool
+	err            error
+	closeOnce      sync.Once
+	closeErr       error
+	cancel         context.CancelFunc
+	waitForClosed  func() error
+	storeProfiling func()
+	profilingOnce  sync.Once
+}
+
+func (r *FlightRowSet) captureProfiling() {
+	r.profilingOnce.Do(func() {
+		if r.storeProfiling != nil {
+			r.storeProfiling()
+		}
+	})
 }
 
 func (r *FlightRowSet) Columns() ([]string, error) {
@@ -838,6 +853,9 @@ func (r *FlightRowSet) Next() bool {
 
 	r.done = true
 	r.err = r.reader.Err()
+	if r.err == nil {
+		r.captureProfiling()
+	}
 	return false
 }
 
@@ -874,6 +892,9 @@ func (r *FlightRowSet) Close() error {
 			r.currentBatch = nil
 		}
 		r.reader.Release()
+		if r.done && r.err == nil {
+			r.captureProfiling()
+		}
 		if r.waitForClosed != nil && (!r.done || r.err != nil) {
 			r.closeErr = r.waitForClosed()
 		}

--- a/server/flightclient/flight_executor_test.go
+++ b/server/flightclient/flight_executor_test.go
@@ -69,6 +69,7 @@ type closeWaitFlightServer struct {
 	closeAfterFirstBatch  bool
 	invalidInfoSchema     bool
 	doGetErr              error
+	doGetTrailer          metadata.MD
 	doActionErr           error
 }
 
@@ -123,6 +124,7 @@ func (s *closeWaitFlightServer) DoGet(_ *flight.Ticket, stream pb.FlightService_
 		return err
 	}
 	if s.closeAfterFirstBatch {
+		stream.SetTrailer(s.doGetTrailer)
 		close(s.doGetDone)
 		return nil
 	}
@@ -132,6 +134,30 @@ func (s *closeWaitFlightServer) DoGet(_ *flight.Ticket, stream pb.FlightService_
 	<-s.allowDoGetReturn
 	close(s.doGetDone)
 	return stream.Context().Err()
+}
+
+func TestFlightExecutorStoresDoGetProfilingTrailerAfterEOF(t *testing.T) {
+	srv := newCloseWaitFlightServer()
+	srv.closeAfterFirstBatch = true
+	srv.doGetTrailer = metadata.Pairs(profilingMetadataKey, `{"latency": 2}`)
+	exec, ctx := newCloseWaitExecutor(t, srv)
+	exec.lastProfiling.Store(`{"latency": 0.1}`)
+
+	rows, err := exec.QueryContext(ctx, "SELECT 1")
+	if err != nil {
+		t.Fatalf("QueryContext: %v", err)
+	}
+	for rows.Next() {
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row stream: %v", err)
+	}
+	if got := exec.LastProfilingOutput(); got != `{"latency": 2}` {
+		t.Fatalf("profiling output = %q, want DoGet trailer", got)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 }
 
 func (s *closeWaitFlightServer) DoAction(action *flight.Action, stream pb.FlightService_DoActionServer) error {

--- a/server/observe/tracing.go
+++ b/server/observe/tracing.go
@@ -139,13 +139,14 @@ type QueryProfilingSummary struct {
 	PostgresScanSeconds float64
 }
 
-// EnrichSpanWithProfiling creates child spans from DuckDB profiling output
-// showing where execution time was spent: planning, scanning (I/O), and compute.
-// Also emits Prometheus metrics for baseline measurement.
+// EnrichSpanWithProfiling attaches DuckDB's completed profiling summary to the
+// execution span. Operator timings are cumulative thread time, so they are
+// recorded as aggregate attributes rather than fabricated sequential spans.
+// It also emits Prometheus metrics for baseline measurement.
 //
 // Returns a per-query rollup so callers (e.g. query log) can persist key
 // metrics without re-parsing the profiling JSON.
-func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart time.Time, executor sqlcore.QueryExecutor, orgID string) QueryProfilingSummary {
+func EnrichSpanWithProfiling(_ context.Context, span trace.Span, _ time.Time, executor sqlcore.QueryExecutor, orgID string) QueryProfilingSummary {
 	output := executor.LastProfilingOutput()
 	if output == "" {
 		return QueryProfilingSummary{}
@@ -165,75 +166,22 @@ func EnrichSpanWithProfiling(ctx context.Context, span trace.Span, execStart tim
 		attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
 	)
 
-	planningDur := m.Planner + m.PlannerBinding + m.CumulativeOptimizerTiming + m.PhysicalPlanner
 	scanTime, scanRows, computeTime, pgScanTime, pgScanRows := collectOperatorTimings(m.Children)
-
-	cursor := execStart
-
-	if planningDur > 0 {
-		_, planSpan := tracer.Start(ctx, "duckdb.planning", trace.WithTimestamp(cursor))
-		planSpan.SetAttributes(
-			attribute.Float64("duckdb.planner_s", m.Planner),
-			attribute.Float64("duckdb.optimizer_s", m.CumulativeOptimizerTiming),
-			attribute.Float64("duckdb.physical_planner_s", m.PhysicalPlanner),
-		)
-		cursor = cursor.Add(time.Duration(planningDur * float64(time.Second)))
-		planSpan.End(trace.WithTimestamp(cursor))
-	}
-
-	execWall := m.Latency - planningDur
-	totalOpTime := scanTime + computeTime
-	scanWall := execWall
-	computeWall := 0.0
-	if totalOpTime > 0 {
-		scanWall = execWall * (scanTime / totalOpTime)
-		computeWall = execWall * (computeTime / totalOpTime)
-	}
+	span.SetAttributes(
+		attribute.Float64("duckdb.planner_s", m.Planner),
+		attribute.Float64("duckdb.planner_binding_s", m.PlannerBinding),
+		attribute.Float64("duckdb.optimizer_s", m.CumulativeOptimizerTiming),
+		attribute.Float64("duckdb.physical_planner_s", m.PhysicalPlanner),
+		attribute.Float64("duckdb.scan_thread_s", scanTime),
+		attribute.Float64("duckdb.compute_thread_s", computeTime),
+		attribute.Float64("duckdb.postgres_scan_thread_s", pgScanTime),
+		attribute.Float64("duckdb.scan_rows_cumulative", scanRows),
+		attribute.Float64("duckdb.postgres_scan_rows_cumulative", pgScanRows),
+		attribute.String("duckdb.timing_kind", "cumulative_thread_time"),
+	)
 
 	S3BytesReadTotal.WithLabelValues(orgID).Add(float64(m.TotalBytesRead))
-	ScanWallSecondsHistogram.WithLabelValues(orgID).Observe(scanWall)
 	PostgresScanSecondsHistogram.WithLabelValues(orgID).Observe(pgScanTime)
-	scanRowsWallEstimate := scanRows
-	if m.CPUTime > 0 && m.Latency > 0 {
-		if p := m.CPUTime / m.Latency; p > 1 {
-			scanRowsWallEstimate = scanRows / p
-		}
-	}
-	if scanWall > 0 && scanRowsWallEstimate > 0 {
-		ScanRowsPerSecondHistogram.WithLabelValues(orgID).Observe(scanRowsWallEstimate / scanWall)
-	}
-
-	if scanTime > 0 {
-		scanRowsWall := scanRows
-		if m.CPUTime > 0 && m.Latency > 0 {
-			parallelism := m.CPUTime / m.Latency
-			if parallelism > 1 {
-				scanRowsWall = scanRows / parallelism
-			}
-		}
-		_, scanSpan := tracer.Start(ctx, "duckdb.scan", trace.WithTimestamp(cursor))
-		scanSpan.SetAttributes(
-			attribute.Float64("duckdb.scan_wall_s", scanWall),
-			attribute.Float64("duckdb.scan_thread_s", scanTime),
-			attribute.Float64("duckdb.scan_rows_wall", scanRowsWall),
-			attribute.Float64("duckdb.scan_rows_cumulative", scanRows),
-			attribute.Float64("duckdb.postgres_scan_thread_s", pgScanTime),
-			attribute.Float64("duckdb.postgres_scan_rows_cumulative", pgScanRows),
-			attribute.Int64("duckdb.total_bytes_read", int64(m.TotalBytesRead)),
-		)
-		cursor = cursor.Add(time.Duration(scanWall * float64(time.Second)))
-		scanSpan.End(trace.WithTimestamp(cursor))
-	}
-
-	if computeTime > 0 {
-		_, compSpan := tracer.Start(ctx, "duckdb.compute", trace.WithTimestamp(cursor))
-		compSpan.SetAttributes(
-			attribute.Float64("duckdb.compute_wall_s", computeWall),
-			attribute.Float64("duckdb.compute_thread_s", computeTime),
-		)
-		cursor = cursor.Add(time.Duration(computeWall * float64(time.Second)))
-		compSpan.End(trace.WithTimestamp(cursor))
-	}
 
 	return QueryProfilingSummary{
 		CPUTimeSeconds:        m.CPUTime,


### PR DESCRIPTION
## Summary

- capture DuckDB profiling only from the completed Flight `DoGet` execution
- consume the `DoGet` trailer after the Flight result stream reaches EOF
- defer query span and query-log enrichment until result streaming is complete
- represent DuckDB operator timing as cumulative attributes instead of a fabricated sequential timeline

## Why

`GetFlightInfo` performs schema discovery, so its profile described the schema probe rather than the statement execution. The completed `DoGet` profile was never returned to the control plane.

## Impact

Query traces and terminal query-log profile fields now describe the actual result-producing execution. Stale, canceled, and absent profile files are ignored.

## Validation

- `go test ./duckdbservice ./server/flightclient ./server ./server/observe`
- `just lint`
