### PR TITLE
Default DuckDB threads to 2.5x worker CPU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,9 @@ DML with RETURNING is rejected at extended-query Describe time with SQLSTATE `0A
 In the **control-plane remote/k8s backend** a worker pod serves **exactly one
 client query session at a time**. This is deliberate: `workerDuckDBLimits`
 (`controlplane/control.go`) gives the single session ~75% of the *whole pod's*
-RAM + all CPU cores — it does NOT divide by session count. Two sessions on one
-pod would each believe they own 75% → ~150% overcommit → nondeterministic OOM /
+RAM plus 2.5 DuckDB threads per requested CPU, rounded up. It does NOT divide
+by session count. Two sessions on one pod would each believe they own 75% →
+~150% overcommit → nondeterministic OOM /
 a heavy query killed by a co-resident one. Do not break the following:
 
 - **One session per worker is enforced, not emergent.** The CP spawns remote

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Run with config file:
 | `DUCKGRES_CERT` | TLS certificate file | `./certs/server.crt` |
 | `DUCKGRES_KEY` | TLS private key file | `./certs/server.key` |
 | `DUCKGRES_MEMORY_LIMIT` | DuckDB memory_limit per session (e.g., `4GB`) | Auto-detected |
-| `DUCKGRES_THREADS` | DuckDB threads per session | `runtime.NumCPU()` |
+| `DUCKGRES_THREADS` | DuckDB threads per session | `2.5 × runtime.NumCPU()`, rounded up |
 | `DUCKGRES_DISABLE_PARQUET_PREFETCHING` | Disable DuckDB Parquet prefetching for standalone/process workers and control-plane-spawned K8s workers. Boolean values use Go's accepted forms (`true`, `TRUE`, `1`, etc.). | `false` |
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
 | `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -265,8 +265,8 @@ func (im *impersonator) Impersonate(c *gin.Context, org, username, sql string, a
 	ctx := c.Request.Context()
 
 	pid := impersonationPIDSeq.Add(-1)
-	// Empty memoryLimit/threads + nil profile: the worker auto-sizes DuckDB to
-	// its own pod and the default org worker shape is acquired/reused.
+	// Empty memoryLimit/threads + nil profile: the default org worker shape is
+	// acquired/reused, and its DuckDB limits are derived by the org stack.
 	_, executor, err := stack.Sessions.CreateSessionWithProtocol(ctx, username, pid, "", 0, "admin", nil)
 	if err != nil {
 		return nil, fmt.Errorf("open session as %s@%s: %w", username, org, err)

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -2170,7 +2170,7 @@ func authorizedClientSearchPath(searchPath string, policy *server.QueryAccessPol
 
 // workerDuckDBLimits derives DuckDB memory_limit and threads from the worker
 // pod's K8s resource spec. Uses 75% of the worker's memory limit for DuckDB
-// and the full CPU request as thread count. Returns empty/zero if worker
+// and 2.5x the CPU request, rounded up, as the thread count. Returns empty/zero if worker
 // resources are not configured (DuckDB will then auto-detect on the worker).
 func (cp *ControlPlane) workerDuckDBLimits(profile *WorkerProfile) (memLimit string, threads int) {
 	// A non-default profile sizes DuckDB from the profile's pod shape, not the
@@ -2192,7 +2192,7 @@ func (cp *ControlPlane) workerDuckDBLimits(profile *WorkerProfile) (memLimit str
 	}
 
 	if cpuReq != "" {
-		threads = parseK8sCPU(cpuReq)
+		threads = duckDBThreadsForK8sCPU(cpuReq)
 	}
 
 	return memLimit, threads
@@ -2270,25 +2270,11 @@ func parseK8sMemory(s string) uint64 {
 	return server.ParseMemoryBytes(s)
 }
 
-// parseK8sCPU parses a Kubernetes CPU string (e.g., "46", "46000m", "500m")
-// into a whole thread count. Millicores below 1000 round down to 0.
-func parseK8sCPU(s string) int {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0
-	}
-	if strings.HasSuffix(s, "m") {
-		var millicores int
-		if _, err := fmt.Sscanf(strings.TrimSuffix(s, "m"), "%d", &millicores); err != nil {
-			return 0
-		}
-		return millicores / 1000
-	}
-	var cores int
-	if _, err := fmt.Sscanf(s, "%d", &cores); err != nil {
-		return 0
-	}
-	return cores
+// duckDBThreadsForK8sCPU derives the default DuckDB thread count from a
+// Kubernetes CPU quantity. The shared helper keeps this per-session value in
+// sync with the worker's spawn-time DUCKGRES_THREADS value.
+func duckDBThreadsForK8sCPU(s string) int {
+	return server.DefaultDuckDBThreads(parseK8sCPUMillicores(s))
 }
 
 // parseK8sCPUMillicores parses a Kubernetes CPU string (e.g. "8", "8000m",

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -140,8 +140,9 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 						},
 						{
 							// One client query session per worker pod: the pod's full
-							// resources (workerDuckDBLimits gives the session ~75% of pod
-							// RAM + all cores) belong to a single query, so queries never
+							// resources (workerDuckDBLimits gives the session ~75% of pod RAM
+							// + 2.5 DuckDB threads per requested CPU) belong to a single query,
+							// so queries never
 							// contend and a heavy query can't be OOM'd by a co-resident
 							// one. The CP scheduler (OrgReservedPool) already never
 							// co-assigns; this is the hard worker-side guarantee — a 2nd
@@ -171,8 +172,8 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	// reads the NODE's /proc/meminfo — so all pre-session work (DuckLake
 	// ATTACH, activation, warmup, controlDB) runs with a memory_limit sized to
 	// the node, not the pod cgroup. Pass the pod-derived limit (same 75% the
-	// per-session SET uses, via duckdbMemoryLimitForPodMemory) and the pod's
-	// CPU count so the base DB is correctly bounded from process start.
+	// per-session SET uses, via duckdbMemoryLimitForPodMemory) and the CPU-derived
+	// thread count so the base DB is correctly bounded from process start.
 	// GOMEMLIMIT (read by the Go runtime directly) gives the Go side a soft
 	// ceiling at 1/8 of the pod so GC pushes back before the cgroup OOM-kills;
 	// DuckDB's buffer manager is unaffected (C allocations are untracked by Go).
@@ -675,9 +676,8 @@ func workerMemoryHygieneEnv(res corev1.ResourceRequirements) []corev1.EnvVar {
 		}
 	}
 	if cpu, ok := res.Requests[corev1.ResourceCPU]; ok {
-		// Value() rounds fractional cores up, so a "500m" worker gets 1 thread.
-		if threads := cpu.Value(); threads > 0 {
-			env = append(env, corev1.EnvVar{Name: "DUCKGRES_THREADS", Value: strconv.FormatInt(threads, 10)})
+		if threads := server.DefaultDuckDBThreads(cpu.MilliValue()); threads > 0 {
+			env = append(env, corev1.EnvVar{Name: "DUCKGRES_THREADS", Value: strconv.Itoa(threads)})
 		}
 	}
 	return env

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -2966,8 +2966,8 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	if got := envByName["DUCKGRES_MEMORY_LIMIT"]; got != "12GB" {
 		t.Fatalf("expected DUCKGRES_MEMORY_LIMIT=12GB (75%% of 16Gi pod), got %q", got)
 	}
-	if got := envByName["DUCKGRES_THREADS"]; got != "8" {
-		t.Fatalf("expected DUCKGRES_THREADS=8 (pod CPU request), got %q", got)
+	if got := envByName["DUCKGRES_THREADS"]; got != "20" {
+		t.Fatalf("expected DUCKGRES_THREADS=20 (2.5x the 8 CPU pod request), got %q", got)
 	}
 	if got := envByName["GOMEMLIMIT"]; got != "2048MiB" {
 		t.Fatalf("expected GOMEMLIMIT=2048MiB (1/8 of 16Gi pod), got %q", got)
@@ -4558,11 +4558,11 @@ func TestWorkerMemoryHygieneEnv(t *testing.T) {
 		expected map[string]string
 	}{
 		{"prod-like 15/120Gi", mk("15", "120Gi"), map[string]string{
-			"DUCKGRES_MEMORY_LIMIT": "90GB", "GOMEMLIMIT": "15360MiB", "DUCKGRES_THREADS": "15"}},
+			"DUCKGRES_MEMORY_LIMIT": "90GB", "GOMEMLIMIT": "15360MiB", "DUCKGRES_THREADS": "38"}},
 		{"dev 15/64Gi", mk("15", "64Gi"), map[string]string{
-			"DUCKGRES_MEMORY_LIMIT": "48GB", "GOMEMLIMIT": "8192MiB", "DUCKGRES_THREADS": "15"}},
+			"DUCKGRES_MEMORY_LIMIT": "48GB", "GOMEMLIMIT": "8192MiB", "DUCKGRES_THREADS": "38"}},
 		{"sub-GB pod formats MB", mk("500m", "512Mi"), map[string]string{
-			"DUCKGRES_MEMORY_LIMIT": "384MB", "GOMEMLIMIT": "64MiB", "DUCKGRES_THREADS": "1"}},
+			"DUCKGRES_MEMORY_LIMIT": "384MB", "GOMEMLIMIT": "64MiB", "DUCKGRES_THREADS": "2"}},
 		{"no requests -> no env", corev1.ResourceRequirements{}, map[string]string{}},
 	}
 	for _, tc := range cases {

--- a/controlplane/memory_rebalancer.go
+++ b/controlplane/memory_rebalancer.go
@@ -55,7 +55,7 @@ type MemoryRebalancer struct {
 
 // NewMemoryRebalancer creates a rebalancer with the given budgets.
 // If memoryBudget is 0, it defaults to 75% of system RAM.
-// If threadBudget is 0, it defaults to runtime.NumCPU().
+// If threadBudget is 0, it defaults to 2.5x runtime.NumCPU(), rounded up.
 // If enabled is false, RequestRebalance is a no-op and sessions only get
 // their limits set once at creation time.
 func NewMemoryRebalancer(memoryBudget uint64, threadBudget int, sessions SessionLister, enabled bool) *MemoryRebalancer {
@@ -68,7 +68,7 @@ func NewMemoryRebalancer(memoryBudget uint64, threadBudget int, sessions Session
 		}
 	}
 	if threadBudget == 0 {
-		threadBudget = runtime.NumCPU()
+		threadBudget = server.DefaultDuckDBThreads(int64(runtime.NumCPU()) * 1000)
 	}
 
 	r := &MemoryRebalancer{

--- a/controlplane/memory_rebalancer_test.go
+++ b/controlplane/memory_rebalancer_test.go
@@ -3,6 +3,7 @@
 package controlplane
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -75,6 +76,10 @@ func TestNewMemoryRebalancerDefaults(t *testing.T) {
 	}
 	if r.threadBudget == 0 {
 		t.Error("expected non-zero thread budget")
+	}
+	wantThreads := (runtime.NumCPU()*5 + 1) / 2
+	if r.threadBudget != wantThreads {
+		t.Errorf("thread budget = %d, want ceil(2.5 * %d CPUs) = %d", r.threadBudget, runtime.NumCPU(), wantThreads)
 	}
 }
 

--- a/controlplane/org_router.go
+++ b/controlplane/org_router.go
@@ -155,9 +155,10 @@ func (tr *OrgRouter) createOrgStackWhileMutationHeld(tc *configstore.OrgConfig) 
 	activator.setMigrating = tr.SetMigrating
 	activator.clearMigrating = tr.ClearMigrating
 	pool.activateReservedWorker = activator.ActivateReservedWorker
-	// In K8s mode, DuckDB auto-detects memory from the container's cgroup limits.
-	// Pass 0/false to disable budget-based rebalancing.
-	rebalancer := NewMemoryRebalancer(0, 0, nil, false)
+	// In K8s mode, normal client sessions supply pod-derived limits directly.
+	// Keep the default worker's thread count here as the fallback for internal
+	// sessions (such as admin impersonation) that do not carry a profile.
+	rebalancer := NewMemoryRebalancer(0, tr.defaultWorkerDuckDBThreads(), nil, false)
 	sessions := NewOrgSessionManager(pool, rebalancer, tc.Name)
 	if tr.userSecrets != nil {
 		sessions.SetUserSecretLoader(tr.userSecrets.SessionSecretLoader(tc.Name))
@@ -219,6 +220,11 @@ func (tr *OrgRouter) createOrgStackWhileMutationHeld(tc *configstore.OrgConfig) 
 
 	slog.Info("Org stack created.", "org", tc.Name, "max_workers", stack.Config.MaxWorkers)
 	return stack, nil
+}
+
+func (tr *OrgRouter) defaultWorkerDuckDBThreads() int {
+	cpuRequest := firstNonEmpty(tr.baseCfg.WorkerCPURequest, defaultWorkerCPU)
+	return duckDBThreadsForK8sCPU(cpuRequest)
 }
 
 // beginOrgStackOperation registers a create/destroy operation while holding the

--- a/controlplane/org_router_test.go
+++ b/controlplane/org_router_test.go
@@ -16,6 +16,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestOrgRouterDefaultWorkerDuckDBThreads(t *testing.T) {
+	tests := []struct {
+		name       string
+		cpuRequest string
+		want       int
+	}{
+		{name: "production shape", cpuRequest: "15", want: 38},
+		{name: "fractional shape", cpuRequest: "750m", want: 2},
+		{name: "built-in worker shape", cpuRequest: "", want: 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &OrgRouter{baseCfg: K8sWorkerPoolConfig{WorkerCPURequest: tt.cpuRequest}}
+			if got := router.defaultWorkerDuckDBThreads(); got != tt.want {
+				t.Fatalf("defaultWorkerDuckDBThreads() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 type recordingOrgRouterPool struct {
 	events        *[]string
 	shutdownCount *atomic.Int32

--- a/controlplane/worker_limits_test.go
+++ b/controlplane/worker_limits_test.go
@@ -19,35 +19,35 @@ func TestWorkerDuckDBLimits_RemoteBackend(t *testing.T) {
 			cpuReq:     "46000m",
 			memReq:     "360Gi",
 			wantMem:    "270GB", // 75% of 360Gi (386547056640 bytes) = 270GB
-			wantThread: 46,
+			wantThread: 115,
 		},
 		{
 			name:       "whole core CPU notation",
 			cpuReq:     "46",
 			memReq:     "360Gi",
 			wantMem:    "270GB",
-			wantThread: 46,
+			wantThread: 115,
 		},
 		{
 			name:       "small worker",
 			cpuReq:     "4000m",
 			memReq:     "8Gi",
 			wantMem:    "6GB",
-			wantThread: 4,
+			wantThread: 10,
 		},
 		{
-			name:       "fractional CPU rounds down to zero",
+			name:       "fractional CPU rounds multiplied threads up",
 			cpuReq:     "500m",
 			memReq:     "1Gi",
 			wantMem:    "768MB",
-			wantThread: 0, // 500m < 1 core, rounds to 0
+			wantThread: 2,
 		},
 		{
 			name:       "1 core minimum",
 			cpuReq:     "1000m",
 			memReq:     "2Gi",
 			wantMem:    "1GB",
-			wantThread: 1,
+			wantThread: 3,
 		},
 		{
 			name:       "empty resources",
@@ -128,7 +128,7 @@ func TestSessionLimitsRouting(t *testing.T) {
 		if memLimit != "270GB" {
 			t.Errorf("remote mode should use worker memory, got %q", memLimit)
 		}
-		if threads != 46 {
+		if threads != 115 {
 			t.Errorf("remote mode should use worker CPU, got %d", threads)
 		}
 
@@ -199,23 +199,27 @@ func TestParseK8sMemory(t *testing.T) {
 	}
 }
 
-func TestParseK8sCPU(t *testing.T) {
+func TestDuckDBThreadsForK8sCPU(t *testing.T) {
 	tests := []struct {
 		input string
 		want  int
 	}{
-		{"46000m", 46},
-		{"46", 46},
-		{"500m", 0},
-		{"1000m", 1},
-		{"4", 4},
+		{"46000m", 115},
+		{"46", 115},
+		{"500m", 2},
+		{"750m", 2},
+		{"1000m", 3},
+		{"1500m", 4},
+		{"1.5", 4},
+		{"4", 10},
 		{"", 0},
+		{"garbage", 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := parseK8sCPU(tt.input)
+			got := duckDBThreadsForK8sCPU(tt.input)
 			if got != tt.want {
-				t.Errorf("parseK8sCPU(%q) = %d, want %d", tt.input, got, tt.want)
+				t.Errorf("duckDBThreadsForK8sCPU(%q) = %d, want %d", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -73,8 +73,8 @@ worker on a small query. On reuse, the worker's TTL is reset to the request's
 ttl and it transitions hot-idle → hot-active.
 
 DuckDB limits for the single session derive from the worker's **actual** size
-(75% of pod memory, all cores) — unchanged from `workerDuckDBLimits`, now keyed
-off size not profile.
+(75% of pod memory and 2.5 threads per requested CPU, rounded up) through
+`workerDuckDBLimits`, keyed off size rather than profile.
 
 ## Lifecycle
 

--- a/server/server.go
+++ b/server/server.go
@@ -263,7 +263,7 @@ type Config struct {
 	MemoryLimit string
 
 	// Threads is the DuckDB threads per session.
-	// If zero, defaults to runtime.NumCPU().
+	// If zero, defaults to 2.5x runtime.NumCPU(), rounded up.
 	Threads int
 
 	// MemoryBudget is the total memory available for all DuckDB sessions (e.g., "24GB").
@@ -951,7 +951,7 @@ func ConfigureMainDB(db *sql.DB, cfg Config, username string) error {
 	// Set DuckDB threads
 	threads := cfg.Threads
 	if threads == 0 {
-		threads = runtime.NumCPU() * 2
+		threads = DefaultDuckDBThreads(int64(runtime.NumCPU()) * 1000)
 	}
 	if _, err := db.Exec(fmt.Sprintf("SET threads = %d", threads)); err != nil {
 		slog.Warn("Failed to set DuckDB threads.", "threads", threads, "error", err)

--- a/server/thread_defaults.go
+++ b/server/thread_defaults.go
@@ -1,0 +1,17 @@
+package server
+
+const cpuMillicoresPerDefaultDuckDBThread int64 = 400
+
+// DefaultDuckDBThreads returns the default DuckDB thread count for a CPU
+// allocation expressed in millicores. DuckDB gets 2.5 threads per CPU, rounded
+// up so fractional CPU allocations never lose their share of parallelism.
+func DefaultDuckDBThreads(cpuMillicores int64) int {
+	if cpuMillicores <= 0 {
+		return 0
+	}
+	threads := cpuMillicores / cpuMillicoresPerDefaultDuckDBThread
+	if cpuMillicores%cpuMillicoresPerDefaultDuckDBThread != 0 {
+		threads++
+	}
+	return int(threads)
+}

--- a/server/thread_defaults_test.go
+++ b/server/thread_defaults_test.go
@@ -1,0 +1,28 @@
+package server
+
+import "testing"
+
+func TestDefaultDuckDBThreads(t *testing.T) {
+	tests := []struct {
+		name            string
+		cpuMillicores   int64
+		expectedThreads int
+	}{
+		{name: "no CPU", cpuMillicores: 0, expectedThreads: 0},
+		{name: "negative CPU", cpuMillicores: -1, expectedThreads: 0},
+		{name: "fractional CPU", cpuMillicores: 500, expectedThreads: 2},
+		{name: "three quarters CPU", cpuMillicores: 750, expectedThreads: 2},
+		{name: "one CPU", cpuMillicores: 1000, expectedThreads: 3},
+		{name: "one and a half CPUs", cpuMillicores: 1500, expectedThreads: 4},
+		{name: "default production worker", cpuMillicores: 15000, expectedThreads: 38},
+		{name: "maximum production worker", cpuMillicores: 46000, expectedThreads: 115},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DefaultDuckDBThreads(tt.cpuMillicores); got != tt.expectedThreads {
+				t.Fatalf("DefaultDuckDBThreads(%d) = %d, want %d", tt.cpuMillicores, got, tt.expectedThreads)
+			}
+		})
+	}
+}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1408,9 +1408,9 @@ assert_worker_pod() { # org password
   dmem="$worker_memory"
   case "$dcpu/$dmem" in
     # Pool default (DUCKGRES_K8S_WORKER_{CPU,MEMORY}_REQUEST).
-    750m/1536Mi) want_gomem="192MiB" ;;
+    750m/1536Mi) want_gomem="192MiB"; want_threads="2" ;;
     # Exploratory tier (DUCKGRES_EXPLORATORY_WORKER_{CPU,MEMORY}).
-    1/2Gi)        want_gomem="256MiB" ;;
+    1/2Gi)        want_gomem="256MiB"; want_threads="3" ;;
     *) fail "unsized worker $pod requests cpu='$dcpu' memory='$dmem' — neither the pool default (750m/1536Mi) nor the exploratory shape (1/2Gi); BestEffort regression?" ;;
   esac
 
@@ -1419,15 +1419,14 @@ assert_worker_pod() { # org password
   # count at spawn — otherwise the worker sizes its base DB off the NODE's
   # /proc/meminfo and all pre-session work (DuckLake ATTACH, activation) runs
   # effectively unbounded. Both shapes above derive DUCKGRES_MEMORY_LIMIT=1GB
-  # (75% of 1536Mi and of 2Gi both GB-floor to 1) and DUCKGRES_THREADS=1 (750m
-  # and 1 both round up to 1); only GOMEMLIMIT (1/8 of the pod) distinguishes
-  # them, which is exactly what makes this a real derivation check.
+  # (75% of 1536Mi and of 2Gi both GB-floor to 1). DUCKGRES_THREADS is 2.5x
+  # CPU, rounded up: 750m -> 2 and 1 CPU -> 3.
   dml="$worker_memory_limit"
   [ "$dml" = "1GB" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_MEMORY_LIMIT='$dml' want '1GB' (75% of pod memory, GB-floored)"
   gml="$worker_go_memory_limit"
   [ "$gml" = "$want_gomem" ] || fail "unsized worker $pod ($dcpu/$dmem) GOMEMLIMIT='$gml' want '$want_gomem' (1/8 of pod memory)"
   thr="$worker_threads"
-  [ "$thr" = "1" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_THREADS='$thr' want '1' (sub-2-CPU rounds up to 1)"
+  [ "$thr" = "$want_threads" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_THREADS='$thr' want '$want_threads' (2.5x CPU, rounded up)"
 }
 
 # ---- worker sizing (TTL-pool model) ---------------------------------------

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -711,7 +711,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 					map[string]any{"name": "NODE_NAME", "valueFrom": map[string]any{"fieldRef": map[string]any{"fieldPath": "spec.nodeName"}}},
 					map[string]any{"name": "DUCKGRES_MEMORY_LIMIT", "value": "1GB"},
 					map[string]any{"name": "GOMEMLIMIT", "value": "192MiB"},
-					map[string]any{"name": "DUCKGRES_THREADS", "value": "1"},
+					map[string]any{"name": "DUCKGRES_THREADS", "value": "2"},
 				},
 				"volumeMounts": []any{map[string]any{"mountPath": "/data"}},
 				"resources": map[string]any{
@@ -729,7 +729,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 	if err := template.Execute(&got, pod); err != nil {
 		t.Fatalf("execute worker inspection JSONPath: %v", err)
 	}
-	const want = "|Running|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1"
+	const want = "|Running|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|2"
 	if got.String() != want {
 		t.Fatalf("worker inspection snapshot = %q, want %q", got.String(), want)
 	}
@@ -803,7 +803,7 @@ if [[ "$*" == *"get pod pending-worker"* && "$*" == *"-o jsonpath="* ]] || \
   if [[ "$*" == *".status.phase"* ]]; then
     printf '|%s' "$phase"
   fi
-  printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|1'
+  printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|2'
   exit 0
 fi
 echo "unexpected kubectl invocation: $*" >&2


### PR DESCRIPTION
## Summary

- Default DuckDB to `ceil(2.5 × allocated CPUs)` threads while preserving explicit overrides.
- Use one derivation for standalone, process-isolated, and managed Kubernetes workers, including fractional CPU shapes and internal sessions.
- Update worker assertions and architecture/configuration docs; a 15-CPU worker now defaults to 38 threads.

## Testing

- `just lint`
- `just test-controlplane`
- `just test-controlplane-k8s`
- `go test -count=1 ./server ./tests/mw-dev`