### PR TITLE
fix(controlplane): isolate service credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -831,14 +831,13 @@ project-scoped (root-shaped: unrestricted at the org level).
 
 **Caller contract:**
 `POST /api/v1/orgs/:id/service-credentials` with
-`{principal, ttl_seconds?, force_rotate?}`. `principal` is audit attribution
-(`"dagster:events-backfill"`) AND the reuse key: one live grant per
-`(org_id, principal)`. `ttl_seconds` is clamped to [1 min, 1 h]
+`{principal, ttl_seconds?}`. `principal` is audit attribution
+(`"dagster:events-backfill"`) only: every request creates an independent grant
+with a new `credential_id` and secret, even when principals are identical.
+`ttl_seconds` is clamped to [1 min, 1 h]
 (default 15 min, the RDS-IAM precedent). Response is
-`{credential_id, credential_secret?, expires_at, connect}`;
-`credential_secret` is **omitted** when the mint reused a live grant, but
-`credential_id`/`expires_at`/`connect` are **always present** (reuse and
-rotate alike). `POST /api/v1/orgs/:id/service-credentials/refresh` with
+`{credential_id, credential_secret, expires_at, connect}`; all fields are
+always present. `POST /api/v1/orgs/:id/service-credentials/refresh` with
 `{credential_id, ttl_seconds?}` **ALWAYS rotates** the named grant's secret
 and returns `{credential_id, credential_secret, expires_at, connect}`.
 The caller is the internal-secret-authed PostHog backend — the routes sit
@@ -878,22 +877,21 @@ not the CP's. The CP wires the suffix from its first configured
   expired, and hash-blanked credentials all fail identically (with equalized
   bcrypt time — which state a credential_id is in is not probeable). A live
   grant is `revoked_at IS NULL AND expires_at > now()`.
-- **Reuse is keyed `(org_id, principal)`.** A mint while a live grant exists
-  returns the grant's identity and its REAL expiry with NO new plaintext (the
-  caller already holding the secret keeps using it; a caller with nothing
-  sets `force_rotate`). The secret is returned exactly once per binding —
-  when it is created (fresh grant), rotated (`force_rotate`), or refreshed
-  (`refresh`).
-- **`force_rotate` on mint re-binds the live grant's secret** (rotating the
-  bcrypt hash, bumping `last_rotated_at`, re-arming `expires_at` from the
-  request's TTL) and returns the new plaintext. This is the resolution of
-  the obvious timers race: without it, every run's first mint would be the
-  one rotating, which is exactly the concurrent-run clobbering the reuse
-  window exists to prevent.
+- **Mint always creates.** `principal` is non-unique audit metadata, never an
+  identity or reuse key. Every mint inserts a new row, returns its new ID and
+  plaintext once, and leaves every same-principal credential untouched. This
+  lets concurrent jobs keep a stable principal without sharing secrets.
+- **Management is by `credential_id`.** A caller keeps the ID returned by its
+  mint and supplies it to refresh/revoke. Losing the plaintext means minting a
+  new credential; plaintext cannot be recovered from the stored bcrypt hash.
+  New Duckgres servers ignore the removed `force_rotate` JSON field so an old
+  caller can still reach the always-create endpoint, but that compatibility
+  is one-way: deploy the always-create Duckgres version to the whole fleet
+  BEFORE removing PostHog's `force_rotate`/reuse fallback. A new caller talking
+  to an old server could otherwise receive a reused ID without plaintext.
 - **Refresh always rotates and never creates.** Unknown `credential_id` →
   404; a REVOKED grant → 410 (revocation is terminal: refresh never
-  resurrects, and a later mint for the same principal creates a NEW
-  credential rather than touching the dead row). An EXPIRED (but unrevoked)
+  resurrects). An EXPIRED (but unrevoked)
   grant MAY be refreshed — expiry only refuses NEW handshakes, so refresh is
   how a caller that missed the window recovers without minting a second
   identity for the same principal.
@@ -907,11 +905,25 @@ not the CP's. The CP wires the suffix from its first configured
   credential can never authenticate again and the provenance (principal,
   mint/rotation times) survives for investigation. `GET
   /api/v1/orgs/:id/service-grants` is the flat, all-statuses list — no
-  plaintext, no hashes (`PasswordHash` is `json:"-"`).
-- **Concurrency**: the decide-then-mutate sequence runs under
-  `LockOrgConnectionAdmissionTx`, so two racing mints/refreshes (two CP
-  replicas, or a run and a refresh) serialize on one hash — never
-  double-rotate into mutually-invalidating credentials.
+  plaintext, no hashes (`PasswordHash` is `json:"-"`). Durable history is
+  intentional because expired, unrevoked IDs remain refreshable and audit
+  provenance must survive; do not add expiry deletion. If grant volume makes
+  the operator list expensive, add pagination/archival as a separate API
+  change rather than weakening lifecycle semantics.
+- **Org deletion deletes all of that org's grant rows.** This is the explicit
+  lifecycle boundary to the normal durable-history rule: leaving a grant
+  behind would let its old secret authenticate if the org name were reused.
+  Org creation takes the same advisory lock and clears pre-existing orphan
+  grants only when the locked lookup confirms no current org row; duplicate
+  creation and re-provisioning an existing org must preserve live grants.
+- **Concurrency**: each mint owns a new row. Mint/refresh/revoke still take
+  `LockOrgConnectionAdmissionTx` so org lifecycle changes cannot leave orphan
+  grants and management of a named ID remains serialized.
+- **Admission recognizes authenticated `svc_` identities as root-shaped.**
+  They consume the org vCPU budget but do not require an org-user row or carry
+  a normal per-user cap. Admission and post-acquisition worker switching do
+  not reapply expiry/revocation: those are handshake-only checks, so an
+  established session rides to completion.
 - **After the write, THIS replica's snapshot is reloaded immediately**
   (`ReloadSnapshot`), then a best-effort `/api/v1/internal/reload-snapshot`
   fan-out to peer replicas (`PeerFanout`, wired from the same

--- a/README.md
+++ b/README.md
@@ -235,6 +235,22 @@ column cannot be added to a populated table).
 - [Managed Warehouse Deprovision](docs/runbooks/managed-warehouse-deprovision.md): Destructive teardown process for managed warehouse infrastructure and org cleanup.
 - [Resharding Operations](docs/runbooks/resharding.md): Runner recovery, durable respawn reset, safety checks, and local verification.
 
+Managed-warehouse backend jobs mint service credentials with `POST
+/api/v1/orgs/:id/service-credentials`. Every mint creates a new
+`credential_id` and secret; `principal` is audit metadata only, so concurrent
+jobs may use the same value safely. `ttl_seconds` defaults to 900 seconds and
+is clamped to 60–3600 seconds. Refresh targets one credential explicitly with
+`POST /api/v1/orgs/:id/service-credentials/refresh` and a `credential_id`.
+Expiry and revocation block new pgwire handshakes but do not terminate an
+already-authenticated session. If a caller loses a secret, mint a new
+credential; Duckgres stores only bcrypt hashes and cannot recover plaintext.
+For a rolling contract change, deploy the always-create Duckgres version to
+the entire fleet before removing the caller's legacy `force_rotate`/reuse
+fallback. New servers ignore the old field, but a new caller reaching an old
+server could still receive a reused credential without plaintext. Org
+deletion permanently removes its service-grant rows so an old secret cannot
+become valid if that org name is created again.
+
 ## Quick Start
 
 The project uses [just](https://github.com/casey/just) as a command runner. Run `just` to see all available recipes.

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -248,6 +248,21 @@ func (s *gormAPIStore) CreateOrg(org *configstore.Org, teamID int64, schemaName 
 	// One transaction: org row + its first team row (same contract as the
 	// provisioning path — an org cannot exist without a team).
 	return s.db().Transaction(func(tx *gorm.DB) error {
+		// Serialize name reuse with credential lifecycle operations. Grants do
+		// not have a foreign key, so clean up rows orphaned by older Duckgres
+		// versions before this name becomes an org again.
+		if err := configstore.LockOrgConnectionAdmissionTx(tx, org.Name); err != nil {
+			return err
+		}
+		var existing int64
+		if err := tx.Model(&configstore.Org{}).Where("name = ?", org.Name).Count(&existing).Error; err != nil {
+			return err
+		}
+		if existing == 0 {
+			if err := tx.Where("org_id = ?", org.Name).Delete(&configstore.ServiceGrant{}).Error; err != nil {
+				return err
+			}
+		}
 		if err := tx.Omit("Warehouse", "Teams").Create(org).Error; err != nil {
 			return err
 		}
@@ -357,6 +372,12 @@ func (s *gormAPIStore) DeleteOrg(name string) (bool, error) {
 			return err
 		}
 		if err := tx.Where("org_id = ?", name).Delete(&configstore.OrgUser{}).Error; err != nil {
+			return err
+		}
+		// Org deletion is the lifecycle boundary for otherwise durable grant
+		// audit rows. Retaining them could reactivate an old secret if this org
+		// name were created again.
+		if err := tx.Where("org_id = ?", name).Delete(&configstore.ServiceGrant{}).Error; err != nil {
 			return err
 		}
 		result := tx.Where("name = ?", name).Delete(&configstore.Org{})

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -348,6 +348,7 @@ func resetConfigStoreTables(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
 	for _, model := range []any{
+		&configstore.ServiceGrant{},
 		&configstore.ManagedWarehouse{},
 		&configstore.OrgUser{},
 		&configstore.Org{},
@@ -485,6 +486,104 @@ func TestDeleteOrgCascadesDeletedWarehousePostgres(t *testing.T) {
 	// The database_name is now free for reuse (no unique-index squat).
 	if err := store.DB().Create(&configstore.Org{Name: "other", DatabaseName: "analytics_db"}).Error; err != nil {
 		t.Fatalf("expected database_name to be reusable after org deletion: %v", err)
+	}
+}
+
+func TestDeleteOrgRemovesServiceCredentialsBeforeNameReusePostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+	const orgID = "service-grant-delete"
+
+	if err := store.DB().Create(&configstore.Org{Name: orgID, DatabaseName: "service_grant_delete"}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	issued, err := store.MintServiceCredential(orgID, "dagster:backfill", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("mint service credential: %v", err)
+	}
+	if err := store.ReloadSnapshot(); err != nil {
+		t.Fatalf("reload minted credential: %v", err)
+	}
+	if got := store.ResolvePostgresConnection("ducklake", orgID, true, issued.CredentialID, issued.Plaintext); !got.Valid {
+		t.Fatalf("minted credential did not authenticate before deletion: %#v", got)
+	}
+
+	deleted, err := apiStore.DeleteOrg(orgID)
+	if err != nil || !deleted {
+		t.Fatalf("delete org: deleted=%v err=%v", deleted, err)
+	}
+	if err := store.DB().Create(&configstore.Org{Name: orgID, DatabaseName: "service_grant_delete_recreated"}).Error; err != nil {
+		t.Fatalf("recreate org: %v", err)
+	}
+	if err := store.ReloadSnapshot(); err != nil {
+		t.Fatalf("reload recreated org: %v", err)
+	}
+
+	var grantCount int64
+	if err := store.DB().Model(&configstore.ServiceGrant{}).
+		Where("org_id = ? AND credential_id = ?", orgID, issued.CredentialID).
+		Count(&grantCount).Error; err != nil {
+		t.Fatalf("count deleted org's grant: %v", err)
+	}
+	if grantCount != 0 {
+		t.Fatalf("deleted org retained %d service grant rows", grantCount)
+	}
+	if got := store.ResolvePostgresConnection("ducklake", orgID, true, issued.CredentialID, issued.Plaintext); got.Valid {
+		t.Fatalf("old credential authenticated against recreated org: %#v", got)
+	}
+	if _, err := store.RefreshServiceCredential(orgID, issued.CredentialID, time.Minute); !errors.Is(err, configstore.ErrServiceCredentialNotFound) {
+		t.Fatalf("old credential refresh after org recreation = %v, want ErrServiceCredentialNotFound", err)
+	}
+}
+
+func TestCreateOrgPurgesPreExistingOrphanServiceCredentialsPostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	apiStore := newGormAPIStore(store).(*gormAPIStore)
+	const (
+		orgID        = "orphan-service-grant"
+		credentialID = "svc_0123456789abcdef01234567"
+		secret       = "old-orphan-secret"
+	)
+	hash, err := configstore.HashPassword(secret)
+	if err != nil {
+		t.Fatalf("hash orphan secret: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := store.DB().Create(&configstore.ServiceGrant{
+		OrgID: orgID, CredentialID: credentialID, Principal: "old:lifecycle",
+		PasswordHash: hash, MintedAt: now, LastRotatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("seed orphan grant: %v", err)
+	}
+
+	if err := apiStore.CreateOrg(&configstore.Org{Name: orgID, DatabaseName: "orphan_service_grant"}, 1, "team_1"); err != nil {
+		t.Fatalf("create org over orphan history: %v", err)
+	}
+	if err := store.ReloadSnapshot(); err != nil {
+		t.Fatalf("reload created org: %v", err)
+	}
+	if got := store.ResolvePostgresConnection("ducklake", orgID, true, credentialID, secret); got.Valid {
+		t.Fatalf("orphan credential authenticated after org creation: %#v", got)
+	}
+	if _, err := store.RefreshServiceCredential(orgID, credentialID, time.Minute); !errors.Is(err, configstore.ErrServiceCredentialNotFound) {
+		t.Fatalf("refresh orphan after org creation = %v, want ErrServiceCredentialNotFound", err)
+	}
+
+	live, err := store.MintServiceCredential(orgID, "dagster:live", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("mint live credential: %v", err)
+	}
+	if err := apiStore.CreateOrg(&configstore.Org{Name: orgID, DatabaseName: "duplicate"}, 2, "team_2"); err == nil {
+		t.Fatal("duplicate org create unexpectedly succeeded")
+	}
+	var liveCount int64
+	if err := store.DB().Model(&configstore.ServiceGrant{}).
+		Where("org_id = ? AND credential_id = ?", orgID, live.CredentialID).
+		Count(&liveCount).Error; err != nil {
+		t.Fatalf("count live grant after duplicate create: %v", err)
+	}
+	if liveCount != 1 {
+		t.Fatal("duplicate create purged the existing org's live service credential")
 	}
 }
 

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -177,9 +177,9 @@ type ServiceGrant struct {
 	OrgID        string `gorm:"primaryKey;type:text;index:idx_duckgres_service_grants_org_principal,priority:1;index:idx_duckgres_service_grants_org_state,priority:1" json:"org_id"`
 	CredentialID string `gorm:"primaryKey;type:text" json:"credential_id"`
 	// Principal is audit attribution ("dagster:events-backfill") — required
-	// at mint so every invocation is attributable. Indexed per
-	// (org_id, principal) via migration 000036 so the mint path can find the
-	// reusable live grant for a caller.
+	// at mint so every invocation is attributable. It is intentionally
+	// non-unique: each invocation gets a new credential ID, even when jobs use
+	// the same principal.
 	Principal     string     `gorm:"type:text;not null;index:idx_duckgres_service_grants_org_principal,priority:2" json:"principal"`
 	PasswordHash  string     `gorm:"type:text;not null" json:"-"`
 	MintedAt      time.Time  `gorm:"not null;default:now()" json:"minted_at"`

--- a/controlplane/configstore/org_connections.go
+++ b/controlplane/configstore/org_connections.go
@@ -556,11 +556,18 @@ type authoritativeOrgConnectionUserLimit struct {
 }
 
 type authoritativeOrgConnectionLimitSet struct {
-	orgMaxVCPUs int64
-	users       map[string]authoritativeOrgConnectionUserLimit
+	orgMaxVCPUs       int64
+	users             map[string]authoritativeOrgConnectionUserLimit
+	serviceCredential map[string]struct{}
 }
 
 func (l authoritativeOrgConnectionLimitSet) lookup(username string) OrgResourceLimits {
+	if _, exists := l.serviceCredential[username]; exists {
+		// Service credentials are root-shaped org identities. They share the
+		// org budget but never inherit an ordinary user's per-user cap, even if
+		// a legacy/user row happens to have the same name.
+		return OrgResourceLimits{OrgMaxVCPUs: int(l.orgMaxVCPUs)}
+	}
 	user := l.users[username]
 	return OrgResourceLimits{
 		OrgMaxVCPUs:  int(l.orgMaxVCPUs),
@@ -569,6 +576,10 @@ func (l authoritativeOrgConnectionLimitSet) lookup(username string) OrgResourceL
 }
 
 func (l authoritativeOrgConnectionLimitSet) userAllowed(username string) bool {
+	if strings.HasPrefix(username, ServiceCredentialPrefix) {
+		_, exists := l.serviceCredential[username]
+		return exists
+	}
 	user, exists := l.users[username]
 	return exists && !user.disabled
 }
@@ -589,7 +600,8 @@ func (cs *ConfigStore) authoritativeOrgConnectionLimits(tx *gorm.DB, orgID strin
 	}
 
 	limits := authoritativeOrgConnectionLimitSet{
-		users: make(map[string]authoritativeOrgConnectionUserLimit),
+		users:             make(map[string]authoritativeOrgConnectionUserLimit),
+		serviceCredential: make(map[string]struct{}),
 	}
 	if orgRow.MaxVCPUs != nil {
 		limits.orgMaxVCPUs = *orgRow.MaxVCPUs
@@ -622,6 +634,32 @@ func (cs *ConfigStore) authoritativeOrgConnectionLimits(tx *gorm.DB, orgID strin
 			maxVCPUs: maxVCPUs,
 			disabled: row.Disabled,
 		}
+	}
+
+	// Admission happens after pgwire authentication. Include every persisted
+	// service identity, regardless of its current expiry/revocation state:
+	// those fields gate NEW handshakes only. A session authenticated before a
+	// grant expired or was revoked must still be able to wait in admission or
+	// lazily acquire/switch a worker without being killed mid-session.
+	type serviceCredentialRow struct {
+		CredentialID string `gorm:"column:credential_id"`
+	}
+	var serviceCredentials []serviceCredentialRow
+	// Restrict this authoritative lookup to identities currently queued. Grant
+	// rows are retained for audit after expiry/revocation, so loading the org's
+	// complete lifetime history on every admission poll would grow without
+	// bound.
+	queuedUsernames := tx.Table(cs.orgConnectionRuntimeTables().queue).
+		Select("username").
+		Where("org_id = ? AND granted_at IS NULL", orgID)
+	if err := tx.Model(&ServiceGrant{}).
+		Select("credential_id").
+		Where("org_id = ? AND credential_id IN (?)", orgID, queuedUsernames).
+		Scan(&serviceCredentials).Error; err != nil {
+		return authoritativeOrgConnectionLimitSet{}, false, err
+	}
+	for _, row := range serviceCredentials {
+		limits.serviceCredential[row.CredentialID] = struct{}{}
 	}
 	return limits, true, nil
 }

--- a/controlplane/configstore/service_credential.go
+++ b/controlplane/configstore/service_credential.go
@@ -29,22 +29,15 @@ var ErrServiceCredentialNotFound = errors.New("service credential not found")
 // resurrect it. HTTP handlers map it to 410.
 var ErrServiceCredentialRevoked = errors.New("service credential revoked")
 
-// ServiceCredentialIssue is the result of minting-or-reusing a service
-// credential (MintServiceCredential) or rotating one
-// (RefreshServiceCredential).
+// ServiceCredentialIssue is the result of minting a service credential or
+// refreshing one by credential ID.
 type ServiceCredentialIssue struct {
-	// Rotated reports whether this call bound a FRESH secret (true — a new
-	// grant, a force-rotate, or a refresh) or handed an already-live grant
-	// back untouched (false, mint reuse only). Plaintext is non-empty exactly
-	// when Rotated is true: the store never persists plaintext, so a reused
-	// grant has nothing new to hand back.
-	Rotated bool
 	// CredentialID is the server-generated identity the client connects as
 	// (svc_<24 random hex>).
 	CredentialID string
 	// Principal echoes the audit attribution the grant carries.
 	Principal string
-	// Plaintext is the freshly bound secret — ONLY set when Rotated is true.
+	// Plaintext is the freshly bound secret returned once by mint or refresh.
 	Plaintext string
 	// ExpiresAt is the hard cut for NEW connections. Established sessions are
 	// never torn down on expiry — freshness is enforced only at the pgwire
@@ -62,7 +55,7 @@ func GenerateCredentialID() (string, error) {
 	return ServiceCredentialPrefix + hex.EncodeToString(b), nil
 }
 
-// MintServiceCredential returns a service credential for (orgID, principal).
+// MintServiceCredential creates a new service credential for orgID.
 //
 // Design (CLAUDE.md "Service Credentials"):
 //
@@ -70,24 +63,16 @@ func GenerateCredentialID() (string, error) {
 //     duckgres_service_grants row keyed (org_id, credential_id). NOTHING is
 //     written to duckgres_org_users — there is no shared login row for an
 //     operator action to clobber mid-run.
-//   - Identity REUSE: one live grant per (org_id, principal). A mint while a
-//     live (not-revoked, not-expired) grant exists returns that grant's id and
-//     expiry with NO new plaintext (the caller already holding the secret
-//     keeps using it; a caller with nothing sets force_rotate). A mint with
-//     no live grant creates a fresh row and returns the plaintext once.
-//   - force_rotate re-binds the live grant's secret (rotating the bcrypt
-//     hash, bumping last_rotated_at, re-arming expires_at from THIS call's
-//     TTL) and returns the new plaintext. A revoked grant is terminal: reuse
-//     ignores it and force_rotate never resurrects it — the mint creates a
-//     new grant row instead.
-//   - Concurrency: the whole decide-then-mutate sequence runs under the org
-//     admission lock so two simultaneous mints for the same principal can't
-//     double-create (or rotate against a stale read).
+//   - Every call creates a fresh identity and secret. Principal is required
+//     audit attribution, not an identity or reuse key. Two jobs may therefore
+//     use the same principal without sharing or invalidating credentials.
+//   - Plaintext is returned exactly once, on this call, and never stored.
+//     Subsequent management names this credential ID explicitly through
+//     RefreshServiceCredential or RevokeServiceGrant.
 func (cs *ConfigStore) MintServiceCredential(
 	orgID string,
 	principal string,
 	ttl time.Duration,
-	forceRotate bool,
 ) (*ServiceCredentialIssue, error) {
 	if orgID == "" {
 		return nil, errors.New("orgID is required")
@@ -99,17 +84,28 @@ func (cs *ConfigStore) MintServiceCredential(
 		return nil, errors.New("ttl must be positive")
 	}
 
-	now := time.Now().UTC()
+	plaintext, err := GeneratePassword()
+	if err != nil {
+		return nil, fmt.Errorf("generate service credential secret: %w", err)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("hash service credential secret: %w", err)
+	}
+	credentialID, err := GenerateCredentialID()
+	if err != nil {
+		return nil, err
+	}
+	var expiresAt time.Time
 
-	var issue *ServiceCredentialIssue
-	err := cs.db.Transaction(func(tx *gorm.DB) error {
-		// Serialize with every other org-wide admission decision (and every
-		// other mint/refresh for this org) so a concurrent caller can't
-		// interleave a stale read into the compare-then-rotate sequence.
+	err = cs.db.Transaction(func(tx *gorm.DB) error {
+		// Serialize against org lifecycle/config mutations. Always-create no
+		// longer needs principal-based serialization, but without this lock a
+		// concurrent org deletion could commit between the existence check and
+		// insert (the grants table intentionally has no foreign key).
 		if err := LockOrgConnectionAdmissionTx(tx, orgID); err != nil {
 			return fmt.Errorf("lock org connection admission (org=%s): %w", orgID, err)
 		}
-
 		// The org must exist. The HTTP handler pre-checks for a friendly 404,
 		// but the store enforces independently of any caller — a minted
 		// credential authenticates against the org, so minting into a ghost
@@ -122,82 +118,12 @@ func (cs *ConfigStore) MintServiceCredential(
 			return fmt.Errorf("load org (org=%s): %w", orgID, err)
 		}
 
-		// Newest-first so that if legacy data ever leaves two live grants for
-		// one principal we deterministically reuse/rotate the freshest one.
-		//
-		// The expiry comparison carries 1ms of slack around captured-now:
-		// Postgres timestamptz stores at microsecond precision (rounding Go's
-		// finer wall clock), so an expires_at computed as now+ttl and read
-		// straight back can sit one rounding quantum EITHER side of what the
-		// exact comparison would classify. The probe's job is "is this grant
-		// still comfortably alive", and TTLs are minutes — treating anything
-		// within 1ms of now as still-live is always the right reuse call.
-		var grant ServiceGrant
-		loadErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("org_id = ? AND principal = ? AND revoked_at IS NULL AND expires_at > ?",
-				orgID, principal, now.Add(time.Millisecond)).
-			Order("expires_at DESC").
-			First(&grant).Error
-		liveExists := loadErr == nil
-		if loadErr != nil && !errors.Is(loadErr, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("load live service grant (org=%s principal=%s): %w", orgID, principal, loadErr)
-		}
-
-		if liveExists && !forceRotate {
-			// Reuse: hand back the grant's identity and its REAL expiry (armed
-			// with the TTL in effect when it was last minted/rotated, not this
-			// call's ttl). No row change, no updated_at bump — and no
-			// plaintext: the secret was returned exactly once, when it was
-			// bound.
-			issue = &ServiceCredentialIssue{
-				Rotated:      false,
-				CredentialID: grant.CredentialID,
-				Principal:    grant.Principal,
-				Plaintext:    "",
-				ExpiresAt:    grant.ExpiresAt.UTC(),
-			}
-			return nil
-		}
-
-		// Rotate (live grant + force_rotate) or create (no live grant): bind a
-		// fresh random secret.
-		plaintext, err := GeneratePassword()
-		if err != nil {
-			return fmt.Errorf("generate service credential secret: %w", err)
-		}
-		hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
-		if err != nil {
-			return fmt.Errorf("hash service credential secret: %w", err)
-		}
-		expiresAt := now.Add(ttl)
-
-		if liveExists {
-			result := tx.Model(&ServiceGrant{}).
-				Where("org_id = ? AND credential_id = ?", grant.OrgID, grant.CredentialID).
-				Updates(map[string]any{
-					"password_hash":   string(hash),
-					"last_rotated_at": now,
-					"expires_at":      expiresAt,
-					"updated_at":      now,
-				})
-			if result.Error != nil {
-				return fmt.Errorf("rotate service grant (org=%s credential=%s): %w", orgID, grant.CredentialID, result.Error)
-			}
-			issue = &ServiceCredentialIssue{
-				Rotated:      true,
-				CredentialID: grant.CredentialID,
-				Principal:    grant.Principal,
-				Plaintext:    plaintext,
-				ExpiresAt:    expiresAt,
-			}
-			return nil
-		}
-
-		credentialID, err := GenerateCredentialID()
-		if err != nil {
-			return err
-		}
-		grant = ServiceGrant{
+		// Start the TTL only after admission/lifecycle lock contention. Secret
+		// generation and bcrypt deliberately happen before the transaction so
+		// expensive hashing never lengthens this critical section.
+		now := time.Now().UTC()
+		expiresAt = now.Add(ttl)
+		grant := ServiceGrant{
 			OrgID:         orgID,
 			CredentialID:  credentialID,
 			Principal:     principal,
@@ -211,19 +137,17 @@ func (cs *ConfigStore) MintServiceCredential(
 		if err := tx.Create(&grant).Error; err != nil {
 			return fmt.Errorf("create service grant (org=%s principal=%s): %w", orgID, principal, err)
 		}
-		issue = &ServiceCredentialIssue{
-			Rotated:      true,
-			CredentialID: credentialID,
-			Principal:    principal,
-			Plaintext:    plaintext,
-			ExpiresAt:    expiresAt,
-		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return issue, nil
+	return &ServiceCredentialIssue{
+		CredentialID: credentialID,
+		Principal:    principal,
+		Plaintext:    plaintext,
+		ExpiresAt:    expiresAt,
+	}, nil
 }
 
 // RefreshServiceCredential ALWAYS rotates an existing grant's secret and
@@ -251,10 +175,20 @@ func (cs *ConfigStore) RefreshServiceCredential(
 		return nil, errors.New("ttl must be positive")
 	}
 
-	now := time.Now().UTC()
+	// Hash before taking the org lifecycle/admission lock. This may do a
+	// little wasted work for an unknown/revoked ID, but keeps bcrypt out of a
+	// lock shared with scheduling and org mutations.
+	plaintext, err := GeneratePassword()
+	if err != nil {
+		return nil, fmt.Errorf("generate service credential secret: %w", err)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("hash service credential secret: %w", err)
+	}
 
 	var issue *ServiceCredentialIssue
-	err := cs.db.Transaction(func(tx *gorm.DB) error {
+	err = cs.db.Transaction(func(tx *gorm.DB) error {
 		if err := LockOrgConnectionAdmissionTx(tx, orgID); err != nil {
 			return fmt.Errorf("lock org connection admission (org=%s): %w", orgID, err)
 		}
@@ -272,14 +206,8 @@ func (cs *ConfigStore) RefreshServiceCredential(
 			return ErrServiceCredentialRevoked
 		}
 
-		plaintext, err := GeneratePassword()
-		if err != nil {
-			return fmt.Errorf("generate service credential secret: %w", err)
-		}
-		hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
-		if err != nil {
-			return fmt.Errorf("hash service credential secret: %w", err)
-		}
+		// Admission lock waits must not consume the newly issued TTL.
+		now := time.Now().UTC()
 		expiresAt := now.Add(ttl)
 		result := tx.Model(&ServiceGrant{}).
 			Where("org_id = ? AND credential_id = ?", orgID, credentialID).
@@ -293,7 +221,6 @@ func (cs *ConfigStore) RefreshServiceCredential(
 			return fmt.Errorf("rotate service grant (org=%s credential=%s): %w", orgID, credentialID, result.Error)
 		}
 		issue = &ServiceCredentialIssue{
-			Rotated:      true,
 			CredentialID: credentialID,
 			Principal:    grant.Principal,
 			Plaintext:    plaintext,

--- a/controlplane/configstore/service_credential_postgres_test.go
+++ b/controlplane/configstore/service_credential_postgres_test.go
@@ -5,6 +5,7 @@ package configstore
 import (
 	"errors"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,13 +20,12 @@ import (
 //  1. First mint CREATES a duckgres_service_grants row (NEVER an
 //     duckgres_org_users row) with a server-generated svc_ credential_id and
 //     returns a plaintext that auth-checks.
-//  2. Back-to-back mints for the same principal REUSE the live grant — same
-//     credential_id, salt-and-hash untouched, NO plaintext (a concurrent
-//     long-lived run's steps must not have their working credential rotated
-//     out from under them mid-flight).
-//  3. force_rotate ALWAYS rotates the live grant's secret, even on a fresh
-//     one — this is how a job that has nothing cached gets a plaintext.
-//  4. Refresh ALWAYS rotates the named grant (unknown → 404-mappable,
+//  2. Every mint creates a fresh identity and secret, even when another live
+//     grant has the same principal. Principal is audit metadata, never an
+//     identity/reuse key, so concurrent jobs cannot rotate each other.
+//  3. A third mint remains fresh too; HTTP accepts an old caller's removed
+//     force_rotate field after the always-create server has been deployed.
+//  4. Refresh ALWAYS rotates only the named grant (unknown → 404-mappable,
 //     revoked → never resurrected).
 var credentialIDShape = regexp.MustCompile(`^svc_[0-9a-f]{24}$`)
 
@@ -40,12 +40,9 @@ func TestMintServiceCredentialLifecyclePostgres(t *testing.T) {
 
 	// 1. First mint creates the grant row and returns a plaintext that
 	// auth-checks against the STORED hash.
-	mint1, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute, false)
+	mint1, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("first mint: %v", err)
-	}
-	if !mint1.Rotated {
-		t.Fatal("first mint must rotate (create)")
 	}
 	if !credentialIDShape.MatchString(mint1.CredentialID) {
 		t.Fatalf("credential_id = %q, want svc_<24 hex>", mint1.CredentialID)
@@ -79,83 +76,79 @@ func TestMintServiceCredentialLifecyclePostgres(t *testing.T) {
 		t.Fatalf("duckgres_org_users rows = %d, want 0 — service credentials are grant rows, not org users", userCount)
 	}
 
-	// 2. A back-to-back mint reuses: same credential_id, same hash, NO
-	// plaintext.
-	mint2, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute, false)
+	// 2. A back-to-back mint with the same audit principal creates an entirely
+	// independent credential and always returns its plaintext.
+	mint2, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("second mint: %v", err)
 	}
-	if mint2.Rotated {
-		t.Fatal("immediate re-mint must reuse the live grant, not rotate")
+	if mint2.CredentialID == mint1.CredentialID {
+		t.Fatalf("second mint reused credential_id %q; each invocation must own an independent identity", mint2.CredentialID)
 	}
-	if mint2.CredentialID != mint1.CredentialID {
-		t.Fatalf("reuse credential_id = %q, want %q (the live grant's identity)", mint2.CredentialID, mint1.CredentialID)
-	}
-	if mint2.Plaintext != "" {
-		t.Fatal("reuse must NOT echo a plaintext (caller already holds it, or must force_rotate)")
+	if mint2.Plaintext == "" {
+		t.Fatal("every mint must return the new credential's plaintext")
 	}
 	var reread ServiceGrant
 	if err := db.First(&reread, "org_id = ? AND credential_id = ?", org.Name, mint1.CredentialID).Error; err != nil {
 		t.Fatalf("re-read service grant: %v", err)
 	}
 	if reread.PasswordHash != stored.PasswordHash {
-		t.Fatal("reuse must not change the stored hash")
+		t.Fatal("a second mint must not change the first credential's hash")
 	}
-	// The reuse path reports the ORIGINAL mint's expiry, not now+TTL.
-	if !mint2.ExpiresAt.Equal(stored.ExpiresAt.UTC()) {
-		t.Fatalf("reuse expiry %v, want %v (the live grant's real expiry)", mint2.ExpiresAt, stored.ExpiresAt)
+	var stored2 ServiceGrant
+	if err := db.First(&stored2, "org_id = ? AND credential_id = ?", org.Name, mint2.CredentialID).Error; err != nil {
+		t.Fatalf("second service grant row not created: %v", err)
+	}
+	if bcrypt.CompareHashAndPassword([]byte(stored2.PasswordHash), []byte(mint2.Plaintext)) != nil {
+		t.Fatal("second stored hash does not match its plaintext")
+	}
+	if bcrypt.CompareHashAndPassword([]byte(stored.PasswordHash), []byte(mint2.Plaintext)) == nil {
+		t.Fatal("second plaintext unexpectedly authenticates as the first credential")
 	}
 	var grantCount int64
 	if err := db.Model(&ServiceGrant{}).Where("org_id = ?", org.Name).Count(&grantCount).Error; err != nil {
 		t.Fatal(err)
 	}
-	if grantCount != 1 {
-		t.Fatalf("service grant rows = %d, want exactly 1 (reuse is not a second credential)", grantCount)
+	if grantCount != 2 {
+		t.Fatalf("service grant rows = %d, want exactly 2 independent credentials", grantCount)
 	}
 
-	// 3. force_rotate replaces the secret on the SAME grant row even though
-	// the live grant is nowhere near expiry.
-	mint3, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute, true)
+	// 3. A third mint creates another independent credential.
+	mint3, err := cs.MintServiceCredential(org.Name, "dagster:lifecycle", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("force rotate: %v", err)
 	}
-	if !mint3.Rotated || mint3.Plaintext == "" {
-		t.Fatal("force_rotate must rotate and return a plaintext")
+	if mint3.Plaintext == "" {
+		t.Fatal("mint must return a plaintext")
 	}
-	if mint3.CredentialID != mint1.CredentialID {
-		t.Fatalf("force rotate keeps the grant's identity: got %q, want %q", mint3.CredentialID, mint1.CredentialID)
+	if mint3.CredentialID == mint1.CredentialID || mint3.CredentialID == mint2.CredentialID {
+		t.Fatalf("third mint reused an existing identity: got %q", mint3.CredentialID)
 	}
 	var rotated ServiceGrant
-	if err := db.First(&rotated, "org_id = ? AND credential_id = ?", org.Name, mint1.CredentialID).Error; err != nil {
-		t.Fatalf("re-read after rotate: %v", err)
-	}
-	if rotated.PasswordHash == stored.PasswordHash {
-		t.Fatal("force_rotate must replace the stored hash")
+	if err := db.First(&rotated, "org_id = ? AND credential_id = ?", org.Name, mint3.CredentialID).Error; err != nil {
+		t.Fatalf("read third fresh grant: %v", err)
 	}
 	if bcrypt.CompareHashAndPassword([]byte(rotated.PasswordHash), []byte(mint3.Plaintext)) != nil {
-		t.Fatal("rotated hash does not match the new plaintext")
+		t.Fatal("third hash does not match the new plaintext")
 	}
-	// The OLD secret no longer matches — proof the rotation actually
-	// invalidated it. (Existing sessions keep working: expiry is
-	// handshake-only, and nothing here touches live sessions.)
-	if bcrypt.CompareHashAndPassword([]byte(rotated.PasswordHash), []byte(mint1.Plaintext)) == nil {
-		t.Fatal("old plaintext must no longer match after rotation")
+	if bcrypt.CompareHashAndPassword([]byte(stored.PasswordHash), []byte(mint1.Plaintext)) != nil {
+		t.Fatal("third mint invalidated the first credential")
 	}
 }
 
-// A different principal gets its OWN credential — reuse is keyed
-// (org_id, principal), never org-wide.
+// A different principal also gets its own credential; principal remains
+// useful audit attribution without participating in identity.
 func TestMintServiceCredentialDistinctPrincipalsPostgres(t *testing.T) {
 	cs := newPostgresConfigStore(t)
 	db := cs.DB()
 
 	db.Create(&Org{Name: "svc-grant-org-multi", DatabaseName: "svc_grant_org_multi"})
 
-	a, err := cs.MintServiceCredential("svc-grant-org-multi", "dagster:a", 15*time.Minute, false)
+	a, err := cs.MintServiceCredential("svc-grant-org-multi", "dagster:a", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint a: %v", err)
 	}
-	b, err := cs.MintServiceCredential("svc-grant-org-multi", "dagster:b", 15*time.Minute, false)
+	b, err := cs.MintServiceCredential("svc-grant-org-multi", "dagster:b", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint b: %v", err)
 	}
@@ -172,13 +165,13 @@ func TestMintServiceCredentialDistinctPrincipalsPostgres(t *testing.T) {
 func TestMintServiceCredentialValidatesInputPostgres(t *testing.T) {
 	cs := newPostgresConfigStore(t)
 
-	if _, err := cs.MintServiceCredential("ghost", "d", time.Minute, false); !errors.Is(err, gorm.ErrRecordNotFound) {
+	if _, err := cs.MintServiceCredential("ghost", "d", time.Minute); !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatalf("unknown org must fail with gorm.ErrRecordNotFound, got %v", err)
 	}
-	if _, err := cs.MintServiceCredential("any", "", time.Minute, false); err == nil {
+	if _, err := cs.MintServiceCredential("any", "", time.Minute); err == nil {
 		t.Fatal("empty principal must fail (audit attribution depends on it)")
 	}
-	if _, err := cs.MintServiceCredential("any", "d", 0, false); err == nil {
+	if _, err := cs.MintServiceCredential("any", "d", 0); err == nil {
 		t.Fatal("non-positive ttl must fail")
 	}
 }
@@ -192,9 +185,17 @@ func TestRefreshServiceCredentialPostgres(t *testing.T) {
 		t.Fatalf("create org: %v", err)
 	}
 
-	mint, err := cs.MintServiceCredential(org.Name, "dagster:refresh", 15*time.Minute, false)
+	mint, err := cs.MintServiceCredential(org.Name, "dagster:refresh", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint: %v", err)
+	}
+	sibling, err := cs.MintServiceCredential(org.Name, "dagster:refresh", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("mint same-principal sibling: %v", err)
+	}
+	var siblingBefore ServiceGrant
+	if err := db.First(&siblingBefore, "org_id = ? AND credential_id = ?", org.Name, sibling.CredentialID).Error; err != nil {
+		t.Fatalf("read same-principal sibling: %v", err)
 	}
 
 	// Refresh ALWAYS rotates: new plaintext, same credential_id, same row.
@@ -202,7 +203,7 @@ func TestRefreshServiceCredentialPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh: %v", err)
 	}
-	if !refresh.Rotated || refresh.Plaintext == "" {
+	if refresh.Plaintext == "" {
 		t.Fatal("refresh must always rotate and return the new plaintext")
 	}
 	if refresh.CredentialID != mint.CredentialID {
@@ -217,6 +218,16 @@ func TestRefreshServiceCredentialPostgres(t *testing.T) {
 	}
 	if bcrypt.CompareHashAndPassword([]byte(rotated.PasswordHash), []byte(mint.Plaintext)) == nil {
 		t.Fatal("the minted secret must no longer match after refresh")
+	}
+	var siblingAfter ServiceGrant
+	if err := db.First(&siblingAfter, "org_id = ? AND credential_id = ?", org.Name, sibling.CredentialID).Error; err != nil {
+		t.Fatalf("re-read same-principal sibling: %v", err)
+	}
+	if siblingAfter.PasswordHash != siblingBefore.PasswordHash || !siblingAfter.ExpiresAt.Equal(siblingBefore.ExpiresAt) {
+		t.Fatal("refresh by credential_id mutated a same-principal sibling")
+	}
+	if bcrypt.CompareHashAndPassword([]byte(siblingAfter.PasswordHash), []byte(sibling.Plaintext)) != nil {
+		t.Fatal("same-principal sibling stopped authenticating after refresh of another credential_id")
 	}
 	if got := time.Until(refresh.ExpiresAt); got < 29*time.Minute || got > 31*time.Minute {
 		t.Fatalf("refresh expires_in ≈ %v, want ~30m (the refresh TTL re-arms the clock)", got)
@@ -244,7 +255,7 @@ func TestServiceGrantRevokeIsTerminalPostgres(t *testing.T) {
 		t.Fatalf("create org: %v", err)
 	}
 
-	mint, err := cs.MintServiceCredential(org.Name, "dagster:revoke", 15*time.Minute, false)
+	mint, err := cs.MintServiceCredential(org.Name, "dagster:revoke", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint: %v", err)
 	}
@@ -272,11 +283,11 @@ func TestServiceGrantRevokeIsTerminalPostgres(t *testing.T) {
 
 	// A new mint for the same principal ignores the revoked row and creates a
 	// NEW credential.
-	mint2, err := cs.MintServiceCredential(org.Name, "dagster:revoke", 15*time.Minute, false)
+	mint2, err := cs.MintServiceCredential(org.Name, "dagster:revoke", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint after revoke: %v", err)
 	}
-	if !mint2.Rotated || mint2.Plaintext == "" {
+	if mint2.Plaintext == "" {
 		t.Fatal("mint after revoke must create a fresh credential with a plaintext")
 	}
 	if mint2.CredentialID == mint.CredentialID {
@@ -305,7 +316,7 @@ func TestServiceGrantExpirySemanticsPostgres(t *testing.T) {
 		t.Fatalf("create org: %v", err)
 	}
 
-	mint, err := cs.MintServiceCredential(org.Name, "dagster:expiry", 15*time.Minute, false)
+	mint, err := cs.MintServiceCredential(org.Name, "dagster:expiry", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint: %v", err)
 	}
@@ -317,11 +328,11 @@ func TestServiceGrantExpirySemanticsPostgres(t *testing.T) {
 	}
 
 	// Mint creates a NEW credential — the expired one is not "live".
-	mint2, err := cs.MintServiceCredential(org.Name, "dagster:expiry", 15*time.Minute, false)
+	mint2, err := cs.MintServiceCredential(org.Name, "dagster:expiry", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint after expiry: %v", err)
 	}
-	if !mint2.Rotated || mint2.CredentialID == mint.CredentialID {
+	if mint2.CredentialID == mint.CredentialID {
 		t.Fatalf("mint after expiry must create a fresh credential, got %+v", mint2)
 	}
 
@@ -331,7 +342,7 @@ func TestServiceGrantExpirySemanticsPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh of expired grant: %v", err)
 	}
-	if !refresh.Rotated || refresh.Plaintext == "" || !refresh.ExpiresAt.After(time.Now().UTC()) {
+	if refresh.Plaintext == "" || !refresh.ExpiresAt.After(time.Now().UTC()) {
 		t.Fatalf("refresh of expired grant must rotate and re-arm expiry, got %+v", refresh)
 	}
 }
@@ -347,11 +358,11 @@ func TestListServiceGrantsPostgres(t *testing.T) {
 		t.Fatalf("create org: %v", err)
 	}
 
-	live, err := cs.MintServiceCredential(org.Name, "dagster:live", 15*time.Minute, false)
+	live, err := cs.MintServiceCredential(org.Name, "dagster:live", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint live: %v", err)
 	}
-	dead, err := cs.MintServiceCredential(org.Name, "dagster:dead", 15*time.Minute, false)
+	dead, err := cs.MintServiceCredential(org.Name, "dagster:dead", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint to-be-revoked: %v", err)
 	}
@@ -394,7 +405,7 @@ func TestServiceGrantSnapshotAuthPostgres(t *testing.T) {
 	if err := db.Create(&org).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
-	mint, err := cs.MintServiceCredential(org.Name, "dagster:auth", 15*time.Minute, false)
+	mint, err := cs.MintServiceCredential(org.Name, "dagster:auth", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("mint: %v", err)
 	}
@@ -446,6 +457,9 @@ func TestServiceGrantSnapshotAuthPostgres(t *testing.T) {
 	if err := cs.ReloadSnapshot(); err != nil {
 		t.Fatal(err)
 	}
+	if _, loaded := cs.snapshot.OrgServiceGrant[OrgUserKey{OrgID: org.Name, Username: mint.CredentialID}]; loaded {
+		t.Fatal("expired grant remained in the hot auth snapshot; always-create must not grow replica memory with history")
+	}
 	if res := cs.ResolvePostgresConnection("ducklake", org.Name, true, mint.CredentialID, refresh.Plaintext); res.Valid {
 		t.Fatal("an expired grant must refuse new connections")
 	}
@@ -471,15 +485,7 @@ func TestServiceGrantSnapshotAuthPostgres(t *testing.T) {
 	}
 }
 
-// Regression pin for the Postgres µs-timestamptz rounding shape the reuse
-// probe must survive: the mint writes expires_at = captured-now + ttl with Go
-// wall-clock precision, but timestamptz rounds to the microsecond on
-// storage — so a live-grant probe comparing expires_at > captured-now can
-// misclassify a same-instant row. MintServiceCredential's probe therefore
-// compares against captured-now + one µs of slack. This test fails without
-// that slack whenever the rounding lands the stored expiry inside the probe
-// window boundary.
-func TestMintServiceCredentialMicrosecondRoundingRacePostgres(t *testing.T) {
+func TestMintServiceCredentialConcurrentSamePrincipalPostgres(t *testing.T) {
 	cs := newPostgresConfigStore(t)
 	db := cs.DB()
 
@@ -488,26 +494,98 @@ func TestMintServiceCredentialMicrosecondRoundingRacePostgres(t *testing.T) {
 		t.Fatalf("create org: %v", err)
 	}
 
-	// Two mints for the SAME principal back-to-back: the second MUST reuse the
-	// first's row even when the stored µs rounding makes expires_at look a
-	// hair NEWER than the reuse probe's wall clock.
-	first, err := cs.MintServiceCredential(org.Name, "dagster:us-race", 15*time.Minute, false)
-	if err != nil {
-		t.Fatalf("first mint: %v", err)
+	issues := make([]*ServiceCredentialIssue, 2)
+	errs := make([]error, 2)
+	var wg sync.WaitGroup
+	for i := range issues {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			issues[i], errs[i] = cs.MintServiceCredential(org.Name, "dagster:same-principal", 15*time.Minute)
+		}(i)
 	}
-	second, err := cs.MintServiceCredential(org.Name, "dagster:us-race", 15*time.Minute, false)
-	if err != nil {
-		t.Fatalf("second mint: %v", err)
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent mint %d: %v", i, err)
+		}
 	}
-	if second.Rotated {
-		t.Fatal("back-to-back mint must reuse even under timestamptz rounding")
+	if issues[0].CredentialID == issues[1].CredentialID {
+		t.Fatalf("concurrent same-principal mints shared credential %q", issues[0].CredentialID)
 	}
-	if second.CredentialID != first.CredentialID {
-		t.Fatalf("reuse returned %q, want the first mint's %q", second.CredentialID, first.CredentialID)
+	if issues[0].Plaintext == "" || issues[1].Plaintext == "" {
+		t.Fatal("both concurrent mints must return their own plaintext")
 	}
 	var count int64
 	db.Model(&ServiceGrant{}).Where("org_id = ?", org.Name).Count(&count)
-	if count != 1 {
-		t.Fatalf("grant rows = %d, want exactly 1", count)
+	if count != 2 {
+		t.Fatalf("grant rows = %d, want exactly 2", count)
 	}
+}
+
+func TestServiceCredentialTTLStartsAfterAdmissionLockPostgres(t *testing.T) {
+	cs := newPostgresConfigStore(t)
+	db := cs.DB()
+	const orgID = "svc-grant-org-lock-ttl"
+	if err := db.Create(&Org{Name: orgID, DatabaseName: "svc_grant_org_lock_ttl"}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	seed, err := cs.MintServiceCredential(orgID, "dagster:refresh-lock", time.Minute)
+	if err != nil {
+		t.Fatalf("seed refresh credential: %v", err)
+	}
+
+	const ttl = 2 * time.Second
+	assertFreshTTL := func(t *testing.T, issue func() (*ServiceCredentialIssue, error)) {
+		t.Helper()
+		blocker := db.Begin()
+		if blocker.Error != nil {
+			t.Fatalf("begin blocker: %v", blocker.Error)
+		}
+		if err := LockOrgConnectionAdmissionTx(blocker, orgID); err != nil {
+			_ = blocker.Rollback()
+			t.Fatalf("lock admission: %v", err)
+		}
+
+		type result struct {
+			issue *ServiceCredentialIssue
+			err   error
+		}
+		done := make(chan result, 1)
+		go func() {
+			got, err := issue()
+			done <- result{issue: got, err: err}
+		}()
+		// bcrypt completes well inside this window; the credential call should
+		// then remain blocked on the advisory lock. Capturing now before that
+		// wait consumes roughly half this deliberately short TTL.
+		time.Sleep(time.Second)
+		select {
+		case got := <-done:
+			_ = blocker.Rollback()
+			t.Fatalf("credential mutation bypassed org admission lock: %+v", got)
+		default:
+		}
+		if err := blocker.Commit().Error; err != nil {
+			t.Fatalf("release admission lock: %v", err)
+		}
+		got := <-done
+		if got.err != nil {
+			t.Fatalf("credential mutation: %v", got.err)
+		}
+		if remaining := time.Until(got.issue.ExpiresAt); remaining < 1500*time.Millisecond {
+			t.Fatalf("TTL remaining after lock wait = %v, want nearly the full %v", remaining, ttl)
+		}
+	}
+
+	t.Run("mint", func(t *testing.T) {
+		assertFreshTTL(t, func() (*ServiceCredentialIssue, error) {
+			return cs.MintServiceCredential(orgID, "dagster:mint-lock", ttl)
+		})
+	})
+	t.Run("refresh", func(t *testing.T) {
+		assertFreshTTL(t, func() (*ServiceCredentialIssue, error) {
+			return cs.RefreshServiceCredential(orgID, seed.CredentialID, ttl)
+		})
+	})
 }

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -247,7 +247,13 @@ func (cs *ConfigStore) load() (*Snapshot, error) {
 		return nil, fmt.Errorf("load orgs: %w", err)
 	}
 	var serviceGrants []ServiceGrant
-	if err := cs.db.Find(&serviceGrants).Error; err != nil {
+	// The grants table is durable audit history and grows on every mint. The
+	// auth snapshot only needs rows that can still pass a NEW handshake;
+	// expired/revoked rows remain queryable through the admin API and refresh
+	// reads the database directly by credential ID.
+	if err := cs.db.
+		Where("revoked_at IS NULL AND expires_at > ? AND password_hash <> ''", time.Now()).
+		Find(&serviceGrants).Error; err != nil {
 		return nil, fmt.Errorf("load service grants: %w", err)
 	}
 

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1861,7 +1861,7 @@ func (cp *ControlPlane) finishSessionAcquisition(
 		return sessionMetadataResult{}, initErr, nil
 	}
 	in.sessions.SetConnCloser(in.pid, in.tlsConn)
-	if cp.configStore != nil && in.orgID != "" {
+	if cp.configStore != nil && in.orgID != "" && requiresOrgUserSessionRecheck(in.username) {
 		if _, _, ok := cp.configStore.OrgUserSessionQueryAccess(in.orgID, in.username); !ok {
 			destroy()
 			in.meta.clog.Warn("Session acquisition aborted: user is disabled or no longer exists.")
@@ -1869,6 +1869,16 @@ func (cp *ControlPlane) finishSessionAcquisition(
 		}
 	}
 	return meta, nil, nil
+}
+
+// requiresOrgUserSessionRecheck reports whether the post-acquisition race
+// gate must consult duckgres_org_users. Service credentials have already
+// authenticated against their own grant row, and expiry/revocation are
+// handshake-only: rechecking them here would kill an established connection
+// while it lazily acquires or switches workers. Normal users still fail closed
+// if disabled or deleted during the create window.
+func requiresOrgUserSessionRecheck(username string) bool {
+	return !strings.HasPrefix(username, configstore.ServiceCredentialPrefix)
 }
 
 // workerProfileCPU / workerProfileMemory render a possibly-nil worker profile

--- a/controlplane/control_test.go
+++ b/controlplane/control_test.go
@@ -352,6 +352,21 @@ func TestUseExploratoryTierExclusions(t *testing.T) {
 // assigns the concrete store to the interface.
 var _ ConfigStoreInterface = (*configstore.ConfigStore)(nil)
 
+func TestPostAcquisitionIdentityGateOnlyRechecksOrgUsers(t *testing.T) {
+	for _, tc := range []struct {
+		username string
+		want     bool
+	}{
+		{username: "root", want: true},
+		{username: "project-user", want: true},
+		{username: "svc_0123456789abcdef01234567", want: false},
+	} {
+		if got := requiresOrgUserSessionRecheck(tc.username); got != tc.want {
+			t.Fatalf("requiresOrgUserSessionRecheck(%q) = %v, want %v", tc.username, got, tc.want)
+		}
+	}
+}
+
 // TestLazyActivationCatalogAssumption pins the invariant the lazy (deferred
 // worker acquisition) connect path leans on: with the DuckLake catalog
 // attached — the ONLY attachment a multitenant session can succeed with —

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -140,10 +140,10 @@ func RegisterAPIWithIngressSuffix(r *gin.RouterGroup, store Store, tenantStore T
 	// Short-lived service credentials (AWS AccessKey/Secret style): a PostHog
 	// backend job (dagster) mints a per-credential grant — its own
 	// duckgres_service_grants row, never a duckgres_org_users row — and
-	// connects with (credential_id, secret). The mint reuses the principal's
-	// live grant (plaintext only when freshly rotated via force_rotate);
-	// refresh ALWAYS rotates the named grant. The plaintext is returned only
-	// here; the store persists only the bcrypt hash.
+	// connects with (credential_id, secret). Every mint creates a fresh grant;
+	// principal is audit metadata only. Refresh ALWAYS rotates the explicitly
+	// named grant. Plaintext is returned only here; the store persists only
+	// the bcrypt hash.
 	r.POST("/orgs/:id/service-credentials", func(c *gin.Context) {
 		h.issueServiceCredential(c, tenantStore)
 	})

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -33,9 +33,8 @@ type fakeStore struct {
 	latestChangeErr   error // set non-nil to fail LatestConfigChange
 
 	// ServiceCredential hooks. mintCreds/refreshCreds record every call so
-	// tests can assert the handler threads (org, principal, ttl, forceRotate)
-	// correctly and the reuse-vs-rotate branches respond with the right body
-	// shape.
+	// tests can assert the handler threads (org, principal, ttl) correctly and
+	// mint/refresh return the right body shape.
 	mintCreds         []serviceCredentialRequest
 	refreshCreds      []serviceCredentialRefreshRequest
 	issueCredsIssue   *configstore.ServiceCredentialIssue
@@ -399,12 +398,10 @@ func (s *fakeStore) MintServiceCredential(
 	orgID string,
 	principal string,
 	ttl time.Duration,
-	forceRotate bool,
 ) (*configstore.ServiceCredentialIssue, error) {
 	s.mintCreds = append(s.mintCreds, serviceCredentialRequest{
-		Principal:   principal,
-		TTLSeconds:  int(ttl / time.Second),
-		ForceRotate: forceRotate,
+		Principal:  principal,
+		TTLSeconds: int(ttl / time.Second),
 	})
 	if s.issueCredsErr != nil {
 		return nil, s.issueCredsErr
@@ -412,7 +409,6 @@ func (s *fakeStore) MintServiceCredential(
 	if s.issueCredsIssue == nil {
 		// Default: a freshly rotated credential expiring in an hour.
 		return &configstore.ServiceCredentialIssue{
-			Rotated:      true,
 			CredentialID: "svc_0123456789abcdef01234567",
 			Principal:    principal,
 			Plaintext:    "fake-plaintext-32chars-aaaaaaaaaaaa",
@@ -436,7 +432,6 @@ func (s *fakeStore) RefreshServiceCredential(
 	}
 	if s.refreshCredsIssue == nil {
 		return &configstore.ServiceCredentialIssue{
-			Rotated:      true,
 			CredentialID: credentialID,
 			Principal:    "dagster:refreshed",
 			Plaintext:    "fake-plaintext-32chars-bbbbbbbbbbbb",

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -40,19 +40,11 @@ const DefaultManagedIngressSuffix = ".dw.us.postwh.com"
 // team_id: service credentials are root-shaped org credentials, not
 // project-scoped logins.
 type serviceCredentialRequest struct {
-	// Principal is audit attribution ("dagster:events-backfill") — required,
-	// and it doubles as the reuse key: one live grant per (org, principal).
+	// Principal is required audit attribution ("dagster:events-backfill"). It
+	// is intentionally not an identity or reuse key: every mint creates a new
+	// credential ID and secret.
 	Principal  string `json:"principal"`
 	TTLSeconds int    `json:"ttl_seconds"`
-	// ForceRotate bypasses the reuse path: when a live grant already exists
-	// for (org, principal) the CP rotates its secret no matter how fresh it
-	// is and returns the new plaintext. A caller MUST set this on its first
-	// fetch of a run — it has nothing cached, and the reuse path deliberately
-	// returns no plaintext for a still-valid grant (so concurrent long-lived
-	// runs can't smash each other's credentials mid-flight). Omit/false means
-	// "reuse the live grant if one exists, and only tell me its identity and
-	// expiry".
-	ForceRotate bool `json:"force_rotate"`
 }
 
 // serviceCredentialRefreshRequest is the refresh body
@@ -90,20 +82,14 @@ type connectDetails struct {
 	SslMode  string `json:"sslmode"`
 }
 
-// serviceCredentialResponse is the mint/refresh response. CredentialSecret is
-// present ONLY when the CP bound a fresh secret (a fresh mint, a
-// force_rotate, or any refresh); CredentialID/ExpiresAt/Connect are always
-// present so the caller can always take its connection target from this same
-// response.
+// serviceCredentialResponse is the mint/refresh response. Both operations
+// always bind and return a fresh secret; the store persists only its hash.
 type serviceCredentialResponse struct {
-	CredentialID string `json:"credential_id"`
-	// CredentialSecret is omitted (not empty-stringed) when the mint reused a
-	// live grant: a caller that already holds the secret keeps using it;
-	// echoing "" would risk clients treating "" as the secret itself.
-	CredentialSecret string    `json:"credential_secret,omitempty"`
+	CredentialID     string    `json:"credential_id"`
+	CredentialSecret string    `json:"credential_secret"`
 	ExpiresAt        time.Time `json:"expires_at"`
-	// Connect is unconditional (unlike CredentialSecret): identical shape on
-	// reuse and rotate, so the client can always take its connection target
+	// Connect is unconditional: identical shape on mint and refresh, so the
+	// client can always take its connection target
 	// from this same response instead of holding its own out-of-band copy.
 	Connect connectDetails `json:"connect"`
 }
@@ -113,7 +99,7 @@ type serviceCredentialResponse struct {
 // tests.
 type TenantStore interface {
 	OrgExists(orgID string) (bool, error)
-	MintServiceCredential(orgID, principal string, ttl time.Duration, forceRotate bool) (*configstore.ServiceCredentialIssue, error)
+	MintServiceCredential(orgID, principal string, ttl time.Duration) (*configstore.ServiceCredentialIssue, error)
 	RefreshServiceCredential(orgID, credentialID string, ttl time.Duration) (*configstore.ServiceCredentialIssue, error)
 	ReloadSnapshot() error
 }
@@ -199,7 +185,7 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 		return
 	}
 
-	issued, err := tenantStore.MintServiceCredential(orgID, req.Principal, ttl, req.ForceRotate)
+	issued, err := tenantStore.MintServiceCredential(orgID, req.Principal, ttl)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "org not found"})
@@ -220,7 +206,6 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 		"org", orgID,
 		"credential_id", issued.CredentialID,
 		"principal", issued.Principal,
-		"rotated", issued.Rotated,
 		"expires_at", issued.ExpiresAt.UTC().Format(time.RFC3339),
 	)
 

--- a/controlplane/provisioning/service_credential_test.go
+++ b/controlplane/provisioning/service_credential_test.go
@@ -53,7 +53,7 @@ func TestIssueServiceCredentialFreshMintShape(t *testing.T) {
 	router := newTestRouter(store)
 
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "dagster:events-backfill", "force_rotate": true}`)
+		`{"principal": "dagster:events-backfill"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -120,13 +120,13 @@ func TestIssueServiceCredentialGhostOrg404(t *testing.T) {
 	}
 }
 
-func TestIssueServiceCredentialThreadsTTLAndForceRotate(t *testing.T) {
+func TestIssueServiceCredentialThreadsPrincipalAndTTL(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["acme"] = &configstore.Org{Name: "acme"}
 	router := newTestRouter(store)
 
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "dagster:events-backfill", "ttl_seconds": 900, "force_rotate": true}`)
+		`{"principal": "dagster:events-backfill", "ttl_seconds": 900}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -134,8 +134,8 @@ func TestIssueServiceCredentialThreadsTTLAndForceRotate(t *testing.T) {
 		t.Fatalf("mintCreds len = %d, want 1", len(store.mintCreds))
 	}
 	got := store.mintCreds[0]
-	if got.Principal != "dagster:events-backfill" || got.TTLSeconds != 900 || !got.ForceRotate {
-		t.Fatalf("mintCreds[0] = %+v, want principal dagster:events-backfill / ttl 900 / force_rotate true", got)
+	if got.Principal != "dagster:events-backfill" || got.TTLSeconds != 900 {
+		t.Fatalf("mintCreds[0] = %+v, want principal dagster:events-backfill / ttl 900", got)
 	}
 	if store.reloadSnapshotN != 1 {
 		t.Fatalf("ReloadSnapshot called %d times, want exactly 1 (fresh credential must auth without waiting a poll)", store.reloadSnapshotN)
@@ -150,7 +150,7 @@ func TestIssueServiceCredentialClampsTTL(t *testing.T) {
 	// Tiny ttl_seconds must be raised to the floor, not rejected — a caller
 	// never has to guess server policy to get a usable credential.
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "d", "ttl_seconds": 1, "force_rotate": true}`)
+		`{"principal": "d", "ttl_seconds": 1}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
 	}
@@ -161,7 +161,7 @@ func TestIssueServiceCredentialClampsTTL(t *testing.T) {
 	// Huge ttl_seconds comes down to the ceiling.
 	store.mintCreds = nil
 	rec = doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "d", "ttl_seconds": 999999, "force_rotate": true}`)
+		`{"principal": "d", "ttl_seconds": 999999}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
 	}
@@ -172,7 +172,7 @@ func TestIssueServiceCredentialClampsTTL(t *testing.T) {
 	// Absent ttl_seconds → the default.
 	store.mintCreds = nil
 	rec = doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "d", "force_rotate": true}`)
+		`{"principal": "d"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
 	}
@@ -181,39 +181,31 @@ func TestIssueServiceCredentialClampsTTL(t *testing.T) {
 	}
 }
 
-func TestIssueServiceCredentialReuseOmitsSecretWhenGrantStillValid(t *testing.T) {
+func TestIssueServiceCredentialLegacyForceRotateFieldIsIgnored(t *testing.T) {
 	store := newFakeStore()
 	store.orgs["acme"] = &configstore.Org{Name: "acme"}
 	router := newTestRouter(store)
 
-	// The store reports a still-valid live grant (Rotated=false ⇒ the CP did
-	// not touch the hash) ⇒ the handler surfaces NO credential_secret: the
-	// caller already holds it (or must force_rotate). The whole point of the
-	// reuse path is NOT to leak plaintext for a credential the CP didn't just
-	// mint.
-	store.issueCredsIssue = &configstore.ServiceCredentialIssue{
-		Rotated:      false,
-		CredentialID: "svc_0123456789abcdef01234567",
-		Principal:    "d",
-		Plaintext:    "",
-		ExpiresAt:    time.Now().UTC().Add(10 * time.Minute),
-	}
+	// An older caller may still send force_rotate after the new server deploys.
+	// Gin ignores the removed field; the request remains a normal fresh mint.
+	// This is intentionally one-way compatibility: callers may drop their old
+	// reuse fallback only after every Duckgres server has always-create mint.
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "d"}`)
+		`{"principal": "d", "force_rotate": true}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
 	}
-	if body := rec.Body.String(); strings.Contains(body, `"credential_secret"`) {
-		t.Fatalf("reuse path must not echo a credential_secret, got: %s", body)
+	if len(store.mintCreds) != 1 || store.mintCreds[0].Principal != "d" {
+		t.Fatalf("legacy request did not produce a normal mint: %+v", store.mintCreds)
 	}
-	// ...but the connect block is unconditional: identical shape and values on
-	// the reuse path, so a caller can always take its connection target from
-	// the mint response even when it gets no plaintext back.
 	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 	assertConnectBlock(t, body, "acme"+DefaultManagedIngressSuffix)
+	if secret, _ := body["credential_secret"].(string); secret == "" {
+		t.Fatalf("legacy force_rotate request must still return the fresh secret: %v", body)
+	}
 }
 
 // TestIssueServiceCredentialConnectHostUsesWiredSuffix locks the wiring: the
@@ -227,7 +219,7 @@ func TestIssueServiceCredentialConnectHostUsesWiredSuffix(t *testing.T) {
 	router := newServiceCredentialRouter(store, ".dw.eu.postwh.com")
 
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials",
-		`{"principal": "dagster:events-backfill", "force_rotate": true}`)
+		`{"principal": "dagster:events-backfill"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -247,7 +239,7 @@ func TestTeamScopedServiceCredentialRouteRemoved(t *testing.T) {
 	router := newTestRouter(store)
 
 	rec := doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/teams/42/service-credentials",
-		`{"team_id": 42, "principal": "dagster:x", "force_rotate": true}`)
+		`{"team_id": 42, "principal": "dagster:x"}`)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404 (route removed): %s", rec.Code, rec.Body.String())
 	}

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -115,6 +115,11 @@ func (s *gormStore) CreatePendingWarehouse(orgID, databaseName string, warehouse
 // exists in non-terminal state") so HTTP handlers can map to 409
 // without an extra error type.
 func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, teamID int64, schemaName string, warehouse *configstore.ManagedWarehouse) error {
+	// Serialize the existence decision and any name-reuse cleanup with
+	// credential lifecycle operations and admin org deletion.
+	if err := configstore.LockOrgConnectionAdmissionTx(tx, orgID); err != nil {
+		return err
+	}
 	// Auto-create org if it doesn't exist (PostHog calls provision, duckgres
 	// creates everything). A NEW org MUST carry team_id — a warehouse cannot
 	// exist without a team; the id becomes the org's first
@@ -126,6 +131,11 @@ func createPendingWarehouseTx(tx *gorm.DB, orgID, databaseName string, teamID in
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		if teamID == 0 {
 			return ErrProvisionTeamRequired
+		}
+		// Purge grants orphaned by org deletions from older versions before
+		// reusing the org name. Existing-org reprovisioning preserves grants.
+		if err := tx.Where("org_id = ?", orgID).Delete(&configstore.ServiceGrant{}).Error; err != nil {
+			return err
 		}
 		org = configstore.Org{
 			Name:         orgID,
@@ -288,16 +298,14 @@ func (s *gormStore) SetWarehouseDeleting(orgID string, expectedState configstore
 	return nil
 }
 
-// MintServiceCredential delegates to the config store: mint-or-reuse the org's
-// live service grant for (orgID, principal) — see
-// configstore.MintServiceCredential for the full contract.
+// MintServiceCredential delegates to the config store: create a fresh
+// credential whose principal is audit attribution only.
 func (s *gormStore) MintServiceCredential(
 	orgID string,
 	principal string,
 	ttl time.Duration,
-	forceRotate bool,
 ) (*configstore.ServiceCredentialIssue, error) {
-	return s.cs.MintServiceCredential(orgID, principal, ttl, forceRotate)
+	return s.cs.MintServiceCredential(orgID, principal, ttl)
 }
 
 // RefreshServiceCredential delegates to the config store: always-rotate the

--- a/tests/configstore/org_connection_limiter_test.go
+++ b/tests/configstore/org_connection_limiter_test.go
@@ -1219,6 +1219,146 @@ func TestOrgConnectionAdmissionMetricsDoNotCountDisabledUserAsVCPULimit(t *testi
 	}
 }
 
+func TestOrgConnectionAdmissionRecognizesServiceCredentialIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+	}{
+		{name: "live", state: "live"},
+		{name: "expired after handshake", state: "expired"},
+		{name: "revoked after handshake", state: "revoked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newIsolatedConfigStore(t)
+			upsertActiveCP(t, store, "cp-service")
+			const (
+				orgID        = "org-service-admission"
+				credentialID = "svc_0123456789abcdef01234567"
+				requestID    = "request-service"
+			)
+			seedAuthoritativeOrgConnectionLimits(t, store, orgID, 2, nil)
+			if err := store.DB().Create(&cpconfigstore.ServiceGrant{
+				OrgID: orgID, CredentialID: credentialID, Principal: "dagster:backfill",
+				PasswordHash: "test-password-hash", MintedAt: time.Now(), LastRotatedAt: time.Now(),
+				ExpiresAt: time.Now().Add(time.Hour),
+			}).Error; err != nil {
+				t.Fatalf("seed service grant: %v", err)
+			}
+
+			now := time.Now()
+			if err := store.EnqueueOrgConnectionRequest(&cpconfigstore.OrgConnectionQueueEntry{
+				RequestID: requestID, OrgID: orgID, Username: credentialID, CPInstanceID: "cp-service",
+				PID: 1001, Protocol: "postgres", RequestedVCPUs: 2,
+				EnqueuedAt: now, ExpiresAt: now.Add(time.Minute),
+			}); err != nil {
+				t.Fatalf("enqueue service credential: %v", err)
+			}
+			// The request enters admission only after a successful handshake.
+			// Mutate lifecycle state after enqueue to prove expiry/revocation do
+			// not kill that established connection while it waits for a worker.
+			switch tc.state {
+			case "expired":
+				if err := store.DB().Model(&cpconfigstore.ServiceGrant{}).
+					Where("org_id = ? AND credential_id = ?", orgID, credentialID).
+					Update("expires_at", time.Now().Add(-time.Hour)).Error; err != nil {
+					t.Fatalf("expire queued credential: %v", err)
+				}
+			case "revoked":
+				revokedAt := time.Now()
+				if err := store.DB().Model(&cpconfigstore.ServiceGrant{}).
+					Where("org_id = ? AND credential_id = ?", orgID, credentialID).
+					Updates(map[string]any{"revoked_at": revokedAt, "password_hash": ""}).Error; err != nil {
+					t.Fatalf("revoke queued credential: %v", err)
+				}
+			}
+
+			ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: requestID, OrgID: orgID, CPInstanceID: "cp-service"}
+			lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+			if err != nil {
+				t.Fatalf("admit service credential: %v", err)
+			}
+			if lease == nil {
+				t.Fatalf("service credential was not admitted: evaluation = %#v", evaluation)
+			}
+			if evaluation.Decision != "granted_current" || evaluation.Reason != "none" {
+				t.Fatalf("evaluation = %#v, want granted_current/none", evaluation)
+			}
+		})
+	}
+}
+
+func TestOrgConnectionAdmissionRejectsUnknownServiceCredentialIdentity(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-unknown-service")
+	const (
+		orgID        = "org-unknown-service"
+		credentialID = "svc_eeeeeeeeeeeeeeeeeeeeeeee"
+		requestID    = "request-unknown-service"
+	)
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 2, nil)
+	now := time.Now()
+	if err := store.EnqueueOrgConnectionRequest(&cpconfigstore.OrgConnectionQueueEntry{
+		RequestID: requestID, OrgID: orgID, Username: credentialID, CPInstanceID: "cp-unknown-service",
+		PID: 1001, Protocol: "postgres", RequestedVCPUs: 1,
+		EnqueuedAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("enqueue unknown service credential: %v", err)
+	}
+	ref := cpconfigstore.OrgConnectionAdmissionRef{RequestID: requestID, OrgID: orgID, CPInstanceID: "cp-unknown-service"}
+	lease, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("evaluate unknown service credential: %v", err)
+	}
+	if lease != nil || evaluation.Decision != "blocked" || evaluation.Reason != "user_ineligible" {
+		t.Fatalf("unknown service credential = lease %#v, evaluation %#v; want blocked/user_ineligible", lease, evaluation)
+	}
+}
+
+func TestOrgConnectionAdmissionAppliesOnlyOrgLimitToServiceCredential(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-service-a")
+	upsertActiveCP(t, store, "cp-service-b")
+	const orgID = "org-service-limit"
+	seedAuthoritativeOrgConnectionLimits(t, store, orgID, 2, map[string]int{
+		// A same-named org-user row must not define the service credential's
+		// per-user cap. Service identities are root-shaped and org-limited.
+		"svc_aaaaaaaaaaaaaaaaaaaaaaaa": 1,
+	})
+	for _, credentialID := range []string{"svc_aaaaaaaaaaaaaaaaaaaaaaaa", "svc_bbbbbbbbbbbbbbbbbbbbbbbb"} {
+		if err := store.DB().Create(&cpconfigstore.ServiceGrant{
+			OrgID: orgID, CredentialID: credentialID, Principal: "dagster:backfill",
+			PasswordHash: "test-password-hash", MintedAt: time.Now(), LastRotatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+		}).Error; err != nil {
+			t.Fatalf("seed service grant %s: %v", credentialID, err)
+		}
+	}
+
+	now := time.Now()
+	requests := []*cpconfigstore.OrgConnectionQueueEntry{
+		{RequestID: "request-service-a", OrgID: orgID, Username: "svc_aaaaaaaaaaaaaaaaaaaaaaaa", CPInstanceID: "cp-service-a", PID: 1001, Protocol: "postgres", RequestedVCPUs: 2, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute)},
+		{RequestID: "request-service-b", OrgID: orgID, Username: "svc_bbbbbbbbbbbbbbbbbbbbbbbb", CPInstanceID: "cp-service-b", PID: 1002, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now.Add(time.Millisecond), ExpiresAt: now.Add(time.Minute)},
+	}
+	for _, request := range requests {
+		if err := store.EnqueueOrgConnectionRequest(request); err != nil {
+			t.Fatalf("enqueue %s: %v", request.RequestID, err)
+		}
+	}
+
+	firstRef := cpconfigstore.OrgConnectionAdmissionRef{RequestID: requests[0].RequestID, OrgID: orgID, CPInstanceID: requests[0].CPInstanceID}
+	first, _, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), firstRef)
+	if err != nil || first == nil {
+		t.Fatalf("service credential should ignore normal per-user max: lease = %#v, err = %v", first, err)
+	}
+	secondRef := cpconfigstore.OrgConnectionAdmissionRef{RequestID: requests[1].RequestID, OrgID: orgID, CPInstanceID: requests[1].CPInstanceID}
+	second, evaluation, err := store.ScheduleAndClaimOrgConnectionLeaseForRefWithEvaluationContext(t.Context(), secondRef)
+	if err != nil {
+		t.Fatalf("evaluate org-limited service credential: %v", err)
+	}
+	if second != nil || evaluation.Decision != "blocked" || evaluation.Reason != "org_vcpu" {
+		t.Fatalf("second service credential = lease %#v, evaluation %#v; want blocked/org_vcpu", second, evaluation)
+	}
+}
+
 func TestOrgConnectionAdmissionMetricsDoNotCountPermanentlyImpossibleForeignHeadAsSaturation(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	upsertActiveCP(t, store, "cp-impossible-head")

--- a/tests/configstore/org_teams_postgres_test.go
+++ b/tests/configstore/org_teams_postgres_test.go
@@ -503,6 +503,58 @@ func TestProvisionWithTeamIDAndSchemaNamePostgres(t *testing.T) {
 	}
 }
 
+func TestProvisionOrgCreationPurgesOrphanGrantsButReprovisionPreservesLiveGrants(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	pstore := provisioning.NewGormStore(store)
+	const (
+		orgID        = "provision-orphan-grant"
+		credentialID = "svc_0123456789abcdef01234567"
+	)
+	now := time.Now().UTC()
+	if err := store.DB().Create(&configstore.ServiceGrant{
+		OrgID: orgID, CredentialID: credentialID, Principal: "old:lifecycle",
+		PasswordHash: "old-hash", MintedAt: now, LastRotatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("seed orphan grant: %v", err)
+	}
+	provision := func() error {
+		return pstore.Provision(provisioning.ProvisionRequest{
+			OrgID: orgID, DatabaseName: "provision_orphan_grant", TeamID: 1,
+			Warehouse: &configstore.ManagedWarehouse{DucklingName: orgID}, RootUserHash: "root-hash",
+		})
+	}
+	if err := provision(); err != nil {
+		t.Fatalf("provision new org: %v", err)
+	}
+	var orphanCount int64
+	if err := store.DB().Model(&configstore.ServiceGrant{}).
+		Where("org_id = ? AND credential_id = ?", orgID, credentialID).
+		Count(&orphanCount).Error; err != nil {
+		t.Fatalf("count orphan grant: %v", err)
+	}
+	if orphanCount != 0 {
+		t.Fatalf("new org inherited %d orphan grants", orphanCount)
+	}
+
+	live, err := store.MintServiceCredential(orgID, "dagster:live", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("mint live grant: %v", err)
+	}
+	markWarehouseDeleted(t, store, orgID)
+	if err := provision(); err != nil {
+		t.Fatalf("reprovision existing org: %v", err)
+	}
+	var liveCount int64
+	if err := store.DB().Model(&configstore.ServiceGrant{}).
+		Where("org_id = ? AND credential_id = ?", orgID, live.CredentialID).
+		Count(&liveCount).Error; err != nil {
+		t.Fatalf("count live grant after reprovision: %v", err)
+	}
+	if liveCount != 1 {
+		t.Fatal("reprovisioning an existing org purged its live service credential")
+	}
+}
+
 // markWarehouseDeleted parks the org's warehouse row in the terminal
 // "deleted" state so a re-provision is accepted (a non-terminal row is a
 // 409/ErrWarehouseNonTerminal).


### PR DESCRIPTION
## Problem

Concurrent backend jobs sharing one audit principal can rotate the same service credential and invalidate each other. Authenticated `svc_` identities can also be rejected during admission because they have no ordinary org-user row.

## Changes

- Make every mint create a fresh credential ID and one-time secret; treat `principal` as non-unique audit metadata.
- Keep refresh and revoke scoped to an explicit credential ID.
- Admit persisted service credentials against the org vCPU budget without an org-user or per-user limit.
- Preserve handshake-only expiry and revocation semantics during queueing, lazy activation, and worker switching.
- Exclude historical grants from hot auth snapshots while retaining normal audit history.
- Hard-delete grant history when an org is deleted and purge pre-existing orphan grants before reusing an org name.
- Start credential TTL after lifecycle-lock contention and document a Duckgres-first, PostHog-second rollout.

## Testing

Added regressions for concurrent same-principal minting, ID-scoped refresh, service-credential admission, unknown IDs, post-handshake expiry/revocation, org deletion/name reuse, orphan cleanup, and TTL lock waits.

Automated checks run:

- `just test-configstore-integration`
- `just test-controlplane-k8s`
- Focused control-plane, provisioning, admin, and Postgres service-credential tests
- `just lint`
- `git diff --check`

The broader process integration stage reached an existing local socket timeout in `TestControlPlaneBasic`; its package tests and all scoped regressions passed.

## Rollout

Deploy this Duckgres change to the whole control-plane fleet before deploying the paired PostHog caller change. Compatibility with the legacy `force_rotate` body is intentionally one-way.

## Agent context

Human-driven, agent-assisted implementation and adversarial review using Codex subagents. All test identifiers and fixtures are synthetic; no operational or customer data is included.
