### PR TITLE
Propagate traces through peer cache work

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -98,16 +98,21 @@ opened so LRU eviction cannot truncate an in-progress assembled response.
 ## Tracing
 
 When a trace endpoint is set the proxy exports OpenTelemetry spans under
-`service.name=duckgres-cache-proxy`. Each cacheable request is its own root span
-(`cache.get`, with `cache.origin_fetch` / `cache.peer_fetch` children); `CONNECT`
-tunnels emit `cache.connect` and non-cached methods emit `cache.forward`.
+`service.name=duckgres-cache-proxy`. A cacheable request emits `cache.get`, with
+`cache.origin_fetch`, `cache.peer_lookup`, and `cache.peer_get` children as
+needed; peer transfers emit `cache.peer_serve` on the selected remote proxy.
+`CONNECT` tunnels emit `cache.connect` and non-cached methods emit
+`cache.forward`.
 
-These are **standalone traces** — DuckDB `httpfs` sends no `traceparent`, so they
-are deliberately **not** stitched into the duckgres query trace. Correlate to a
-query by hand on the shared attributes: `client.address` (the worker pod IP, →
-org/session via Kubernetes), the S3 object (`server.address` + `url.path` +
-`duckgres.s3.range`), span timestamp, and `cache.source` (`hit`/`peer`/`miss`).
-`org_id` is intentionally absent — the proxy has no per-request tenant identity.
+The proxy extracts W3C context at its forward-proxy ingress. Requests from a
+Duckgres worker therefore join the existing query trace; requests without a
+`traceparent` retain the prior standalone-root behavior. Peer lookup and
+transfer requests also propagate W3C context. A lookup is one
+`cache.peer_lookup` span with bounded `cache.peer_probe` events carrying each
+observed peer outcome (`present`, `in_flight`, `negative`, `timeout`,
+`transport_error`, or `canceled`) and duration; the proxy intentionally does not create a
+span for every probe. `org_id` is intentionally absent — the proxy has no
+per-request tenant identity.
 
 > The cache proxy is not deployed in the `tests/e2e-mw-dev` environment
 > (`DUCKGRES_CACHE_ENABLED` is off there), so this behavior is gated by the unit

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -307,8 +307,8 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		if p.peers != nil {
 			peerStart := time.Now()
 			ok := false
-			if holder, flight, found := p.peers.LocateKey(key); found {
-				_, ok = p.peers.FetchFromPeer(holder, key, flight, func(rd io.Reader) (int64, error) {
+			if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {
+				_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) {
 					return p.store.PutStream(key, rd)
 				})
 			}

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -128,8 +134,10 @@ func (pm *PeerManager) resolve() {
 
 // probeResult is one peer's answer to a /cache/has probe.
 type probeResult struct {
-	addr   string
-	status int // 200 has it · 202 mid-flight filling it · anything else: no
+	addr     string
+	status   int // 200 has it · 202 mid-flight filling it · anything else: no
+	err      error
+	duration time.Duration
 }
 
 // LocateKey asks every peer in parallel whether it has cacheKey (200) or is
@@ -139,7 +147,7 @@ type probeResult struct {
 // caller should go to the origin. Cluster-wide this is what stops a cold key
 // bursting into one duplicate origin fetch per node: the first node's
 // in-flight fetch answers 202, so every other node waits for that fill.
-func (pm *PeerManager) LocateKey(cacheKey string) (holder string, flight, ok bool) {
+func (pm *PeerManager) LocateKey(ctx context.Context, cacheKey string) (holder string, flight, ok bool) {
 	pm.mu.RLock()
 	peers := make([]string, len(pm.peers))
 	copy(peers, pm.peers)
@@ -150,31 +158,57 @@ func (pm *PeerManager) LocateKey(cacheKey string) (holder string, flight, ok boo
 	}
 
 	peerFetchesTotal.Inc()
+	ctx, span := proxyTracer.Start(ctx, "cache.peer_lookup", trace.WithAttributes(
+		attribute.Int("duckgres.cache.peer_count", len(peers)),
+	))
 
-	ctx, cancel := context.WithTimeout(context.Background(), peerHasTimeout)
+	ctx, cancel := context.WithTimeout(ctx, peerHasTimeout)
 	defer cancel()
 
 	resCh := make(chan probeResult, len(peers))
 	for _, addr := range peers {
 		go func(addr string) {
+			startedAt := time.Now()
 			res := probeResult{addr: addr, status: -1}
 			hasURL := fmt.Sprintf("http://%s/cache/has?key=%s", addr, cacheKey)
 			if req, err := http.NewRequestWithContext(ctx, "GET", hasURL, nil); err == nil {
+				otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 				if resp, err := pm.client.Do(req); err == nil {
 					res.status = resp.StatusCode
 					_ = resp.Body.Close()
+				} else {
+					res.err = err
 				}
+			} else {
+				res.err = err
 			}
+			res.duration = time.Since(startedAt)
 			resCh <- res
 		}(addr)
 	}
 
+	recordProbe := func(res probeResult) {
+		span.AddEvent("cache.peer_probe", trace.WithAttributes(
+			attribute.String("duckgres.cache.peer.address", res.addr),
+			attribute.String("duckgres.cache.peer.outcome", probeOutcome(res)),
+			attribute.Int64("duckgres.cache.peer.duration_ms", res.duration.Milliseconds()),
+		))
+	}
 	firstFlight := ""
-	for range peers {
+	for i := 0; i < len(peers); i++ {
 		res := <-resCh
+		recordProbe(res)
 		switch res.status {
 		case http.StatusOK:
 			cancel() // release the losing probes
+			// Preserve the first-present response latency while the lookup span
+			// records the canceled peers' bounded outcomes in the background.
+			go func(remaining int) {
+				defer span.End()
+				for range remaining {
+					recordProbe(<-resCh)
+				}
+			}(len(peers) - i - 1)
 			return res.addr, false, true
 		case http.StatusAccepted:
 			if firstFlight == "" {
@@ -182,29 +216,68 @@ func (pm *PeerManager) LocateKey(cacheKey string) (holder string, flight, ok boo
 			}
 		}
 	}
+	span.End()
 	if firstFlight != "" {
 		return firstFlight, true, true
 	}
 	return "", false, false
 }
 
+func probeOutcome(res probeResult) string {
+	if res.err != nil {
+		if errors.Is(res.err, context.DeadlineExceeded) {
+			return "timeout"
+		}
+		if errors.Is(res.err, context.Canceled) {
+			return "canceled"
+		}
+		return "transport_error"
+	}
+	switch res.status {
+	case http.StatusOK:
+		return "present"
+	case http.StatusAccepted:
+		return "in_flight"
+	case http.StatusNotFound:
+		return "negative"
+	default:
+		return "negative"
+	}
+}
+
 // FetchFromPeer streams cacheKey's body from one peer into sink. flight=true
 // tells the peer the key is expected from its in-flight fill: it waits
 // (bounded) for the fill instead of 404ing. ok is false if the peer couldn't
 // deliver the body — the caller then falls back to the origin.
-func (pm *PeerManager) FetchFromPeer(holder, cacheKey string, flight bool, sink func(io.Reader) (int64, error)) (int64, bool) {
+func (pm *PeerManager) FetchFromPeer(ctx context.Context, holder, cacheKey string, flight bool, sink func(io.Reader) (int64, error)) (int64, bool) {
+	ctx, span := proxyTracer.Start(ctx, "cache.peer_get", trace.WithAttributes(
+		attribute.String("server.address", holder),
+		attribute.Bool("duckgres.cache.peer_flight", flight),
+	))
+	defer span.End()
+
 	getURL := fmt.Sprintf("http://%s/cache/get?key=%s", holder, cacheKey)
 	if flight {
 		getURL += "&flight=1"
 	}
-	req, err := http.NewRequest(http.MethodGet, getURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return 0, false
 	}
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 	resp, err := pm.streamClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		if resp != nil {
+			span.SetAttributes(attribute.Int("http.response.status_code", resp.StatusCode))
 			_ = resp.Body.Close()
+		}
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		} else {
+			span.SetStatus(codes.Error, fmt.Sprintf("peer status %d", resp.StatusCode))
 		}
 		return 0, false
 	}
@@ -212,8 +285,11 @@ func (pm *PeerManager) FetchFromPeer(holder, cacheKey string, flight bool, sink 
 
 	n, err := sink(resp.Body)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return 0, false
 	}
+	span.SetAttributes(attribute.Int64("duckgres.bytes", n))
 	peerHitsTotal.Inc()
 	return n, true
 }

--- a/cmd/cache-proxy/peers_test.go
+++ b/cmd/cache-proxy/peers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,7 +71,7 @@ func TestPeerRoundTripHit(t *testing.T) {
 	addr := newPeerServer(t, key, data, http.StatusOK, &hasCalls, &getCalls)
 	pm := peerManagerWith([]string{addr})
 
-	holder, flight, ok := pm.LocateKey(key)
+	holder, flight, ok := pm.LocateKey(context.Background(), key)
 	if !ok {
 		t.Fatal("expected peer claim")
 	}
@@ -82,7 +83,7 @@ func TestPeerRoundTripHit(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	n, ok := pm.FetchFromPeer(holder, key, flight, collectSink(&buf))
+	n, ok := pm.FetchFromPeer(context.Background(), holder, key, flight, collectSink(&buf))
 	if !ok {
 		t.Fatal("expected peer fetch to succeed")
 	}
@@ -109,7 +110,7 @@ func TestLocateKeyMissFromAll(t *testing.T) {
 	addr := newPeerServer(t, other, []byte("not-ours"), http.StatusOK, &hasCalls, &getCalls)
 	pm := peerManagerWith([]string{addr})
 
-	if _, _, ok := pm.LocateKey(key); ok {
+	if _, _, ok := pm.LocateKey(context.Background(), key); ok {
 		t.Fatal("expected miss from every peer")
 	}
 	if atomic.LoadInt32(&hasCalls) != 1 {
@@ -128,7 +129,7 @@ func TestLocateKeyInFlightClaim(t *testing.T) {
 	addr := newPeerServer(t, key, []byte("filling"), http.StatusAccepted, &hasCalls, &getCalls)
 	pm := peerManagerWith([]string{addr})
 
-	holder, flight, ok := pm.LocateKey(key)
+	holder, flight, ok := pm.LocateKey(context.Background(), key)
 	if !ok {
 		t.Fatal("a 202 peer is still a claim")
 	}
@@ -151,7 +152,7 @@ func TestLocateKeyPrefersPresentEntryOverInFlight(t *testing.T) {
 	filling := newPeerServer(t, key, []byte("filling"), http.StatusAccepted, &h202, &g202)
 	pm := peerManagerWith([]string{filling, present})
 
-	holder, flight, ok := pm.LocateKey(key)
+	holder, flight, ok := pm.LocateKey(context.Background(), key)
 	if !ok {
 		t.Fatal("expected a claim")
 	}
@@ -171,7 +172,7 @@ func TestLocateKeyReturnsFirstHit(t *testing.T) {
 	addr2 := newPeerServer(t, key, data, http.StatusOK, &has2, &get2)
 	pm := peerManagerWith([]string{addr1, addr2})
 
-	holder, flight, ok := pm.LocateKey(key)
+	holder, flight, ok := pm.LocateKey(context.Background(), key)
 	if !ok {
 		t.Fatal("expected peer claim from one of two peers")
 	}
@@ -189,7 +190,7 @@ func TestLocateKeyReturnsFirstHit(t *testing.T) {
 
 func TestFetchFromPeerEmptyPeerList(t *testing.T) {
 	pm := peerManagerWith(nil)
-	if _, _, ok := pm.LocateKey(strings.Repeat("a", 64)); ok {
+	if _, _, ok := pm.LocateKey(context.Background(), strings.Repeat("a", 64)); ok {
 		t.Error("expected miss when no peers are known")
 	}
 }
@@ -222,7 +223,7 @@ func TestFetchFromPeerLargeBodyHasNoClockTimeout(t *testing.T) {
 	pm := peerManagerWith([]string{strings.TrimPrefix(srv.URL, "http://")})
 
 	var buf bytes.Buffer
-	n, ok := pm.FetchFromPeer(strings.TrimPrefix(srv.URL, "http://"), key, false, collectSink(&buf))
+	n, ok := pm.FetchFromPeer(context.Background(), strings.TrimPrefix(srv.URL, "http://"), key, false, collectSink(&buf))
 	if !ok {
 		t.Fatal("large slow body must complete — no whole-request timeout")
 	}

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -419,7 +419,7 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader string) (fetchResult, error) {
 	return p.flights.Do(cacheKey, func() (fetchResult, error) {
 		if p.peers != nil {
-			if holder, flight, ok := p.peers.LocateKey(cacheKey); ok {
+			if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
 				res, ok := p.fetchFromPeer(holder, flight, cacheKey, r)
 				if ok {
 					return res, nil
@@ -444,21 +444,12 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 // briefly on its fill instead of 404ing, so we read the bytes the peer just
 // fetched rather than re-fetching them from the origin ourselves).
 func (p *CacheProxy) fetchFromPeer(holder string, flight bool, cacheKey string, r *http.Request) (fetchResult, bool) {
-	_, peerSpan := proxyTracer.Start(r.Context(), "cache.peer_fetch")
-	defer peerSpan.End()
-	peerSpan.SetAttributes(attribute.Bool("duckgres.cache.peer_flight", flight))
-
-	n, ok := p.peers.FetchFromPeer(holder, cacheKey, flight, func(body io.Reader) (int64, error) {
+	n, ok := p.peers.FetchFromPeer(r.Context(), holder, cacheKey, flight, func(body io.Reader) (int64, error) {
 		return p.store.PutStream(cacheKey, body)
 	})
 	if !ok {
-		peerSpan.SetAttributes(attribute.Bool("duckgres.cache.peer_hit", false))
 		return fetchResult{}, false
 	}
-	peerSpan.SetAttributes(
-		attribute.Bool("duckgres.cache.peer_hit", true),
-		attribute.Int64("duckgres.bytes", n),
-	)
 	cacheBytesServed.WithLabelValues("peer").Add(float64(n))
 	return fetchResult{size: n, source: "peer"}, true
 }
@@ -871,6 +862,7 @@ func (p *CacheProxy) forwardUncached(w http.ResponseWriter, r *http.Request) {
 //	      its own origin fetch for the same bytes
 //	404 — neither
 func (p *CacheProxy) HandlePeerHas(w http.ResponseWriter, r *http.Request) {
+	r = r.WithContext(otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header)))
 	key := r.URL.Query().Get("key")
 	if !IsValidCacheKey(key) {
 		http.Error(w, "invalid key", http.StatusBadRequest)
@@ -894,8 +886,17 @@ func (p *CacheProxy) HandlePeerHas(w http.ResponseWriter, r *http.Request) {
 // waited for instead of a 404 that would send it to the origin for the same
 // bytes the peer is already fetching.
 func (p *CacheProxy) HandlePeerGet(w http.ResponseWriter, r *http.Request) {
+	r = r.WithContext(otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header)))
+	ctx, span := proxyTracer.Start(r.Context(), "cache.peer_serve", trace.WithAttributes(
+		attribute.String("http.request.method", r.Method),
+		attribute.String("client.address", r.RemoteAddr),
+	))
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	key := r.URL.Query().Get("key")
 	if !IsValidCacheKey(key) {
+		span.SetAttributes(attribute.Int("http.response.status_code", http.StatusBadRequest))
 		http.Error(w, "invalid key", http.StatusBadRequest)
 		return
 	}
@@ -906,13 +907,18 @@ func (p *CacheProxy) HandlePeerGet(w http.ResponseWriter, r *http.Request) {
 
 	reader, size, ok := p.store.Open(key)
 	if !ok {
+		span.SetAttributes(attribute.Int("http.response.status_code", http.StatusNotFound))
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	defer func() { _ = reader.Close() }()
 
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
-	_, _ = io.Copy(w, reader)
+	n, _ := io.Copy(w, reader)
+	span.SetAttributes(
+		attribute.Int("http.response.status_code", http.StatusOK),
+		attribute.Int64("duckgres.bytes", n),
+	)
 }
 
 // waitForLocalFill blocks (bounded) until key lands on local disk or the

--- a/cmd/cache-proxy/tracing.go
+++ b/cmd/cache-proxy/tracing.go
@@ -26,11 +26,10 @@ var proxyTracer = otel.Tracer("duckgres/cache-proxy")
 // import cliboot because cliboot transitively pulls in the DuckDB CGO runtime
 // (via posthog/duckgres/server), which this standalone proxy must not link.
 //
-// Cache-proxy spans are emitted as their own root traces (DuckDB httpfs sends
-// no traceparent), tagged with service.name=duckgres-cache-proxy so they're
-// distinguishable from query traces in Tempo. They are NOT stitched into the
-// query trace — cross-reference by time + s3 path + client.address (worker pod
-// IP) + node. Returns a shutdown func that flushes the batch processor.
+// Cache-proxy spans are tagged with service.name=duckgres-cache-proxy. Requests
+// carrying W3C context from a Duckgres worker join that query trace; requests
+// without a parent remain standalone roots. Returns a shutdown func that
+// flushes the batch processor.
 func initTracing() func() {
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 	if endpoint == "" {

--- a/cmd/cache-proxy/tracing_test.go
+++ b/cmd/cache-proxy/tracing_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -179,5 +184,105 @@ func TestTracingExtractsRemoteParentAtIngress(t *testing.T) {
 	}
 	if getSpan.Parent().SpanID() != parent.SpanID() {
 		t.Fatalf("cache.get parent = %s, want remote parent %s", getSpan.Parent().SpanID(), parent.SpanID())
+	}
+}
+
+func TestPeerTransferPropagatesContextAndRecordsLookup(t *testing.T) {
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(previousPropagator) })
+
+	sr := withSpanRecorder(t)
+	key := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer := NewCacheProxy(store, nil, nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cache/has", peer.HandlePeerHas)
+	mux.HandleFunc("/cache/get", peer.HandlePeerGet)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	if _, err := store.PutStream(key, strings.NewReader("peer-data")); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), parent)
+	pm := peerManagerWith([]string{strings.TrimPrefix(server.URL, "http://")})
+	holder, flight, ok := pm.LocateKey(ctx, key)
+	if !ok || flight {
+		t.Fatalf("LocateKey = (%q, flight=%v, ok=%v), want present peer", holder, flight, ok)
+	}
+	if _, ok := pm.FetchFromPeer(ctx, holder, key, false, func(r io.Reader) (int64, error) {
+		return io.Copy(io.Discard, r)
+	}); !ok {
+		t.Fatal("FetchFromPeer failed")
+	}
+
+	lookup := findSpan(t, sr, "cache.peer_lookup")
+	if lookup.SpanContext().TraceID() != parent.TraceID() || lookup.Parent().SpanID() != parent.SpanID() {
+		t.Fatalf("lookup is not parented to the original query context")
+	}
+	if len(lookup.Events()) != 1 || lookup.Events()[0].Name != "cache.peer_probe" {
+		t.Fatalf("lookup events = %#v, want one cache.peer_probe event", lookup.Events())
+	}
+	probe := lookup.Events()[0]
+	var outcome string
+	var hasDuration bool
+	for _, attr := range probe.Attributes {
+		switch string(attr.Key) {
+		case "duckgres.cache.peer.outcome":
+			outcome = attr.Value.AsString()
+		case "duckgres.cache.peer.duration_ms":
+			hasDuration = true
+		}
+	}
+	if outcome != "present" || !hasDuration {
+		t.Fatalf("lookup probe attributes = %v, want present outcome and duration", probe.Attributes)
+	}
+	get := findSpan(t, sr, "cache.peer_get")
+	serve := findSpan(t, sr, "cache.peer_serve")
+	if get.SpanContext().TraceID() != parent.TraceID() {
+		t.Fatalf("peer get trace = %s, want %s", get.SpanContext().TraceID(), parent.TraceID())
+	}
+	if serve.Parent().SpanID() != get.SpanContext().SpanID() {
+		t.Fatalf("peer serve parent = %s, want peer get %s", serve.Parent().SpanID(), get.SpanContext().SpanID())
+	}
+}
+
+func TestPeerTransferCancellationStopsPeerWork(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(canceled)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm := peerManagerWith(nil)
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := pm.FetchFromPeer(ctx, strings.TrimPrefix(server.URL, "http://"), strings.Repeat("a", 64), false, func(io.Reader) (int64, error) {
+			return 0, nil
+		})
+		done <- ok
+	}()
+	<-started
+	cancel()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("peer handler did not receive request cancellation")
+	}
+	if ok := <-done; ok {
+		t.Fatal("canceled peer transfer succeeded")
 	}
 }


### PR DESCRIPTION
## Summary
- propagate caller context through peer lookup and transfer requests
- add bounded lookup outcome events plus peer get/serve spans
- preserve existing peer fallback and timeout behavior while documenting trace propagation

## Verification
- go test ./cmd/cache-proxy -count=1
- go test -race ./cmd/cache-proxy -run 'TestPeerTransferPropagatesContextAndRecordsLookup|TestPeerTransferCancellationStopsPeerWork' -count=1
- just test-unit
- just lint