### PR TITLE
feat(monitoring): add organization warehouse telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,14 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   panel KEY, PromQL is built server-side from `rangePanels` (never an open PromQL
   relay) and forwarded to `DUCKGRES_PROMETHEUS_URL`. Org-labelled panels keep
   slicing enforced.
+- **Product monitoring API is tenant-safe** (`monitoring.go`):
+  `GET /api/v1/orgs/:id/monitoring/{snapshot,series}` is internal-secret-only
+  for the PostHog backend. It fixes tenant identity from the path, uses only
+  org-scoped runtime-store reads and Prometheus selectors, returns CP coverage
+  for partial live-state fan-out, and strips usernames, PIDs, pod/image names,
+  CP ownership, SQL, client/trace data, and secrets. The series metric and
+  window are closed enums; never turn it into arbitrary PromQL or reuse the
+  operator payloads wholesale.
 - **Env-only knobs**: `DUCKGRES_PROMETHEUS_URL` (read in
   `multitenant.go`; set by the chart). The audit table `duckgres_admin_audit` is
   AutoMigrated at startup (operational state, not goose-migrated tenant config).

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -71,6 +71,8 @@ Added for the console:
 | `POST /api/v1/orgs/:id/users/:username/disable` | admin | persist `disabled=true` (refused at pgwire connect), reload the snapshot cluster-wide so the block is immediate, AND kill the user's live sessions. Returns `{disabled, killed, …}` |
 | `POST /api/v1/orgs/:id/users/:username/enable` | admin | persist `disabled=false` + reload cluster-wide so the user can reconnect at once |
 | `GET /api/v1/metrics/panels`, `/metrics/query_range` | viewer | Prometheus proxy (allow-listed panels only) |
+| `GET /api/v1/orgs/:id/monitoring/snapshot` | internal secret | Customer-safe org warehouse state, resource limits, workers, sessions, queue depth, and CP coverage. Omits user, pod, image, SQL, client, trace, and control-plane identifiers |
+| `GET /api/v1/orgs/:id/monitoring/series` | internal secret | Customer-safe, org-forced Prometheus range query. Requires an allow-listed `metric`; `window` is one of `1h`, `6h`, `24h` (default), `7d`, `30d` |
 | `GET /api/v1/orgs/:id/users/:username/secrets`, `DELETE .../:name` | viewer/admin | list/delete stored persistent secrets (ciphertext never returned) |
 | `POST /api/v1/orgs/:id/impersonate/query` | admin | run SQL as an org user on their worker |
 | `GET /api/v1/audit` | admin | admin action log |
@@ -123,6 +125,31 @@ the PromQL is built server-side from the allow-list (`rangePanels`). Forwards to
 `DUCKGRES_PROMETHEUS_URL` (the in-cluster VictoriaMetrics vmselect, Prometheus-
 compatible). Org-labelled panels (`duckgres_query_total{org,status,reason}` etc.) keep
 slicing enforced. Unset URL → 503 so the UI shows "metrics not configured".
+
+### Product monitoring API (`monitoring.go`)
+
+The PostHog backend reads `GET /api/v1/orgs/:id/monitoring/snapshot` and
+`/series` with the internal secret. These routes are not operator-dashboard
+shortcuts: they are a deliberately smaller customer-safe contract. The org is
+fixed by the path, every config-store query uses that org, and every Prometheus
+query includes an exact `org` label selector. SSO identities, including admin
+operators, receive 403.
+
+The snapshot combines durable worker records and connection leases/queue rows
+with the cross-CP live-session fan-out. It reports `cp_responders`, `cp_total`,
+and `partial` so a missing control plane never looks like zero activity. Worker
+limits use the current org defaults with deployment fallbacks. Empty worker
+profile and zero-TTL sentinels use deployment defaults because org-shaped
+workers persist explicit profiles. Query progress is `null` when DuckDB does not
+provide a percentage. It intentionally omits usernames, PIDs, pod/image names,
+control-plane ownership, SQL, client metadata, trace identifiers, and secrets.
+
+The series endpoint accepts only `query_rate`, `error_ratio`, `duration_p50`,
+`duration_p95`, `sessions_active`, `acquire_p95`,
+`acquire_by_source`, `storage_bytes`, and `worker_crash_rate`. It normalizes the
+Prometheus response and retains only the `status`, `reason`, or `source` labels needed by
+the corresponding chart. Unknown metrics and windows return 400; unknown orgs
+return 404 with `code: "managed_warehouse_not_found"` before Prometheus is called.
 
 ## Local UI development
 

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -2071,8 +2071,8 @@ func (h *apiHandler) listWorkers(c *gin.Context) {
 	}
 	// A worker is owned by exactly one CP (disjoint union); dedup makes it idempotent.
 	if !localScope(c) && h.fetcher != nil {
-		bodies, _ := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/workers")
-		mergePeer(&workers, bodies, func(e []WorkerStatus) []WorkerStatus { return e })
+		peerResult := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/workers")
+		mergePeer(&workers, peerResult.Bodies, func(e []WorkerStatus) []WorkerStatus { return e })
 		workers = dedupeBy(workers, func(w WorkerStatus) int { return w.ID })
 	}
 	c.JSON(http.StatusOK, workers)
@@ -2087,8 +2087,8 @@ func (h *apiHandler) listSessions(c *gin.Context) {
 	}
 	// A session lives on exactly one CP (disjoint union); dedup makes it idempotent.
 	if !localScope(c) && h.fetcher != nil {
-		bodies, _ := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/sessions")
-		mergePeer(&sessions, bodies, func(e []SessionStatus) []SessionStatus { return e })
+		peerResult := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/sessions")
+		mergePeer(&sessions, peerResult.Bodies, func(e []SessionStatus) []SessionStatus { return e })
 		sessions = dedupeBy(sessions, func(s SessionStatus) int { return s.WorkerID })
 	}
 	c.JSON(http.StatusOK, sessions)
@@ -2104,8 +2104,8 @@ func (h *apiHandler) getClusterStatus(c *gin.Context) {
 	// Per-org active-session counts are per-CP; merge every CP's slice so the
 	// Overview cards reflect the whole cluster instead of one replica's view.
 	if !localScope(c) && h.fetcher != nil {
-		bodies, _ := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/status")
-		orgStats = mergeOrgStats(orgStats, bodies)
+		peerResult := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/status")
+		orgStats = mergeOrgStats(orgStats, peerResult.Bodies)
 	}
 
 	totalWorkers := 0

--- a/controlplane/admin/extras.go
+++ b/controlplane/admin/extras.go
@@ -11,13 +11,15 @@ import (
 // original orgs/users/warehouse CRUD: live cluster state, user-secret
 // management, impersonation, audit log, and the Prometheus metrics proxy.
 type Extras struct {
-	Store        secretStore // *configstore.ConfigStore
-	Live         LiveInfo
-	Users        UserAdmin // per-user kill switch (disable/enable); *configstore.ConfigStore
-	Impersonator Impersonator
-	Audit        *AuditStore
-	Metrics      *MetricsProxy
-	Fetcher      PeerFetcher // cross-CP live-state aggregation (nil = single-CP)
+	Store                    secretStore // *configstore.ConfigStore
+	Monitoring               monitoringStore
+	MonitoringWorkerDefaults MonitoringWorkerDefaults
+	Live                     LiveInfo
+	Users                    UserAdmin // per-user kill switch (disable/enable); *configstore.ConfigStore
+	Impersonator             Impersonator
+	Audit                    *AuditStore
+	Metrics                  *MetricsProxy
+	Fetcher                  PeerFetcher // cross-CP live-state aggregation (nil = single-CP)
 	// ClusterClient backs the read-only node-overview topology endpoints
 	// (/cluster/nodes,/pods,/events,/nodepools). nil (non-k8s backends, tests)
 	// leaves those routes unregistered.
@@ -30,6 +32,7 @@ type Extras struct {
 func RegisterExtras(r *gin.RouterGroup, x Extras) {
 	r.GET("/me", meHandler)
 	registerLiveAPI(r, x.Live, x.Fetcher, x.Users)
+	registerMonitoringAPI(r, x.Monitoring, x.Live, x.Fetcher, x.Metrics, x.MonitoringWorkerDefaults)
 	if x.ClusterClient != nil {
 		registerClusterAPI(r, x.ClusterClient)
 	}

--- a/controlplane/admin/live.go
+++ b/controlplane/admin/live.go
@@ -193,12 +193,12 @@ func registerLiveAPI(r *gin.RouterGroup, live LiveInfo, fetcher PeerFetcher, use
 		// Aggregate every other CP's in-memory view (a query lives on exactly
 		// one CP, so the union is disjoint; dedupeBy makes it idempotent anyway).
 		if !localScope(c) && fetcher != nil {
-			bodies, peers := fetcher.FetchPeers(c.Request.Context(), "/api/v1/queries")
+			peerResult := fetcher.FetchPeers(c.Request.Context(), "/api/v1/queries")
 			type env struct {
 				Queries []QueryStatus `json:"queries"`
 			}
-			responders += mergePeer(&queries, bodies, func(e env) []QueryStatus { return e.Queries })
-			total += peers
+			coverage := peerReadCoverage(peerResult, mergePeer(&queries, peerResult.Bodies, func(e env) []QueryStatus { return e.Queries }))
+			responders, total = coverage.Responders, coverage.Total
 			queries = dedupeBy(queries, func(q QueryStatus) int { return q.WorkerID })
 		}
 		// Optional org/user slicing (applied AFTER the merge).
@@ -238,12 +238,12 @@ func registerLiveAPI(r *gin.RouterGroup, live LiveInfo, fetcher PeerFetcher, use
 		errs := live.RecentErrors(errorsMaxLimit)
 		responders, total := 1, 1
 		if !local && fetcher != nil {
-			bodies, peers := fetcher.FetchPeers(c.Request.Context(), "/api/v1/errors")
+			peerResult := fetcher.FetchPeers(c.Request.Context(), "/api/v1/errors")
 			type env struct {
 				Errors []ErrorEntry `json:"errors"`
 			}
-			responders += mergePeer(&errs, bodies, func(e env) []ErrorEntry { return e.Errors })
-			total += peers
+			coverage := peerReadCoverage(peerResult, mergePeer(&errs, peerResult.Bodies, func(e env) []ErrorEntry { return e.Errors }))
+			responders, total = coverage.Responders, coverage.Total
 		}
 		// Newest first across the merged set.
 		sort.Slice(errs, func(i, j int) bool { return errs[i].Time.After(errs[j].Time) })
@@ -304,8 +304,8 @@ func registerLiveAPI(r *gin.RouterGroup, live LiveInfo, fetcher PeerFetcher, use
 		// Not owned locally. A peer fan-out call (scope=local) stops here so a
 		// missing worker can't recurse across the cluster.
 		if !localScope(c) && fetcher != nil {
-			bodies, _ := fetcher.FetchPeers(c.Request.Context(), "/api/v1/queries/by-worker/"+strconv.Itoa(wid))
-			for _, b := range bodies {
+			peerResult := fetcher.FetchPeers(c.Request.Context(), "/api/v1/queries/by-worker/"+strconv.Itoa(wid))
+			for _, b := range peerResult.Bodies {
 				var d QueryDetail
 				if json.Unmarshal(b, &d) == nil && d.WorkerID == wid {
 					c.JSON(http.StatusOK, d)

--- a/controlplane/admin/live_aggregate.go
+++ b/controlplane/admin/live_aggregate.go
@@ -19,10 +19,16 @@ import (
 // FetchPeers GETs path+"?scope=local" from each peer (the scope param makes the
 // peer return ONLY its own in-memory view, never re-fanning out — that's the
 // recursion guard). It returns each peer's raw response body plus the total
-// number of peers attempted, so a handler can report "N of M CPs responded"
-// and degrade gracefully when a peer is slow/down.
+// number of peers attempted and whether discovery completed, so a handler can
+// distinguish a healthy single-CP deployment from a failed Kubernetes lookup.
+type PeerFetchResult struct {
+	Bodies            [][]byte
+	Peers             int
+	DiscoveryComplete bool
+}
+
 type PeerFetcher interface {
-	FetchPeers(ctx context.Context, path string) (bodies [][]byte, peers int)
+	FetchPeers(ctx context.Context, path string) PeerFetchResult
 	// PostPeers is FetchPeers for a mutating action: it POSTs path+"?scope=local"
 	// to every OTHER replica and returns each peer's raw 200 body plus the number
 	// of peers attempted. Cluster-wide actions (the per-user kill switch) use it so
@@ -36,6 +42,16 @@ type PeerFetcher interface {
 type aggMeta struct {
 	Responders int `json:"cp_responders"`
 	Total      int `json:"cp_total"`
+}
+
+func peerReadCoverage(result PeerFetchResult, peerResponders int) aggMeta {
+	total := 1 + result.Peers
+	if !result.DiscoveryComplete {
+		// Discovery failure makes the peer count unknown, so reserve one missing
+		// responder instead of presenting the local slice as complete coverage.
+		total++
+	}
+	return aggMeta{Responders: 1 + peerResponders, Total: total}
 }
 
 // localScope reports whether this request is a peer-to-peer fan-out call that

--- a/controlplane/admin/live_aggregate_test.go
+++ b/controlplane/admin/live_aggregate_test.go
@@ -96,18 +96,19 @@ func (f *fakeUserAdmin) isDisabled(org, user string) bool {
 // (to prove ?scope=local does NOT fan out). It serves GET (byPath) and POST
 // (postByPath) fan-outs separately so a test can assert which verb was used.
 type fakePeerFetcher struct {
-	byPath     map[string][][]byte
-	postByPath map[string][][]byte
-	calls      int32
-	postCalls  int32
-	mu         sync.Mutex
-	postPaths  []string
+	byPath          map[string][][]byte
+	postByPath      map[string][][]byte
+	discoveryFailed bool
+	calls           int32
+	postCalls       int32
+	mu              sync.Mutex
+	postPaths       []string
 }
 
-func (f *fakePeerFetcher) FetchPeers(_ context.Context, path string) ([][]byte, int) {
+func (f *fakePeerFetcher) FetchPeers(_ context.Context, path string) PeerFetchResult {
 	atomic.AddInt32(&f.calls, 1)
 	b := f.byPath[path]
-	return b, len(b)
+	return PeerFetchResult{Bodies: b, Peers: len(b), DiscoveryComplete: !f.discoveryFailed}
 }
 
 func (f *fakePeerFetcher) PostPeers(_ context.Context, path string) ([][]byte, int) {
@@ -159,6 +160,18 @@ func TestQueriesAggregateAcrossCPs(t *testing.T) {
 	}
 	if atomic.LoadInt32(&fetcher.calls) != 0 {
 		t.Fatalf("scope=local must NOT fan out, but fetcher ran %d times", fetcher.calls)
+	}
+
+	failedDiscovery := &fakePeerFetcher{discoveryFailed: true}
+	r = gin.New()
+	registerLiveAPI(r.Group("/api/v1"), local, failedDiscovery, nil)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/queries", nil))
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal failed-discovery response: %v", err)
+	}
+	if got.Responders != 1 || got.Total != 2 {
+		t.Fatalf("failed-discovery coverage = %d/%d, want incomplete 1/2", got.Responders, got.Total)
 	}
 }
 

--- a/controlplane/admin/monitoring.go
+++ b/controlplane/admin/monitoring.go
@@ -1,0 +1,551 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	monitoringSchemaVersion         = 1
+	monitoringWarehouseNotFoundCode = "managed_warehouse_not_found"
+)
+
+type monitoringStore interface {
+	Snapshot() *configstore.Snapshot
+	ListWorkerRecordsForOrg(orgID string) ([]configstore.WorkerRecord, error)
+	OrgConnectionMonitoringState(orgID string) (configstore.OrgConnectionMonitoringStatus, error)
+}
+
+// MonitoringWorkerDefaults resolves empty default-profile worker records to
+// the deployment shape that the Kubernetes worker pool actually provisions.
+type MonitoringWorkerDefaults struct {
+	CPU    string
+	Memory string
+	TTL    time.Duration
+}
+
+type monitoringWarehouse struct {
+	State string `json:"state"`
+}
+
+type monitoringLimits struct {
+	MaxWorkers              int    `json:"max_workers"`
+	MaxVCPUs                int    `json:"max_vcpus"`
+	DefaultWorkerCPU        string `json:"default_worker_cpu"`
+	DefaultWorkerMemory     string `json:"default_worker_memory"`
+	DefaultWorkerTTLSeconds int    `json:"default_worker_ttl_seconds"`
+	DefaultWorkerMinHotIdle int    `json:"default_worker_min_hot_idle"`
+}
+
+type monitoringTotals struct {
+	Workers              int     `json:"workers"`
+	AllocatedCPUCores    float64 `json:"allocated_cpu_cores"`
+	AllocatedMemoryBytes int64   `json:"allocated_memory_bytes"`
+	ActiveSessions       int64   `json:"active_sessions"`
+	RunningQueries       int     `json:"running_queries"`
+	QueuedConnections    int64   `json:"queued_connections"`
+}
+
+type monitoringSession struct {
+	Protocol   string   `json:"protocol"`
+	State      string   `json:"state"`
+	ElapsedMS  int64    `json:"elapsed_ms"`
+	Percentage *float64 `json:"percentage"`
+	Rows       uint64   `json:"rows"`
+	TotalRows  uint64   `json:"total_rows"`
+	Stalled    bool     `json:"stalled"`
+}
+
+type monitoringWorker struct {
+	ID              int                `json:"id"`
+	State           string             `json:"state"`
+	CPU             string             `json:"cpu"`
+	Memory          string             `json:"memory"`
+	TTLSeconds      int                `json:"ttl_seconds"`
+	CreatedAt       time.Time          `json:"created_at"`
+	LastHeartbeatAt time.Time          `json:"last_heartbeat_at"`
+	Session         *monitoringSession `json:"session,omitempty"`
+}
+
+type monitoringCoverage struct {
+	CPResponders int  `json:"cp_responders"`
+	CPTotal      int  `json:"cp_total"`
+	Partial      bool `json:"partial"`
+}
+
+type monitoringSnapshotResponse struct {
+	SchemaVersion int                 `json:"schema_version"`
+	OrgID         string              `json:"org_id"`
+	AsOf          time.Time           `json:"as_of"`
+	Warehouse     monitoringWarehouse `json:"warehouse"`
+	Limits        monitoringLimits    `json:"limits"`
+	Totals        monitoringTotals    `json:"totals"`
+	Workers       []monitoringWorker  `json:"workers"`
+	Coverage      monitoringCoverage  `json:"coverage"`
+}
+
+type monitoringMetricSpec struct {
+	PromQL        string
+	Unit          string
+	AllowedLabels map[string]struct{}
+}
+
+var monitoringMetrics = map[string]monitoringMetricSpec{
+	"query_rate": {
+		PromQL: rangePanels["query_rate"], Unit: "queries_per_second",
+		AllowedLabels: labelSet("status", "reason"),
+	},
+	"error_ratio": {
+		PromQL: `(sum(rate(duckgres_query_total$ORGERR[$WIN])) or vector(0)) / clamp_min((sum(rate(duckgres_query_total$ORG[$WIN])) or vector(0)), 1e-9)`,
+		Unit:   "ratio", AllowedLabels: labelSet(),
+	},
+	"duration_p95": {PromQL: rangePanels["duration_p95"], Unit: "seconds", AllowedLabels: labelSet()},
+	"duration_p50": {PromQL: rangePanels["duration_p50"], Unit: "seconds", AllowedLabels: labelSet()},
+	"sessions_active": {
+		PromQL: rangePanels["sessions_active"], Unit: "sessions", AllowedLabels: labelSet(),
+	},
+	"acquire_p95": {
+		PromQL: rangePanels["acquire_p95"], Unit: "seconds", AllowedLabels: labelSet("source"),
+	},
+	"acquire_by_source": {
+		PromQL: rangePanels["acquire_by_source"], Unit: "acquisitions_per_second", AllowedLabels: labelSet("source"),
+	},
+	"storage_bytes": {
+		PromQL: `max(duckgres_org_storage_tracked_bytes$ORG)`, Unit: "bytes", AllowedLabels: labelSet(),
+	},
+	"worker_crash_rate": {
+		PromQL: `(sum(rate(duckgres_org_worker_crashes_total$ORG[$WIN])) or vector(0))`, Unit: "crashes_per_second", AllowedLabels: labelSet(),
+	},
+}
+
+var monitoringWindows = map[string]time.Duration{
+	"1h":  time.Hour,
+	"6h":  6 * time.Hour,
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+	"30d": 30 * 24 * time.Hour,
+}
+
+type monitoringPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     float64   `json:"value"`
+}
+
+type monitoringSeries struct {
+	Labels map[string]string `json:"labels"`
+	Points []monitoringPoint `json:"points"`
+}
+
+type monitoringSeriesResponse struct {
+	SchemaVersion int                `json:"schema_version"`
+	OrgID         string             `json:"org_id"`
+	Metric        string             `json:"metric"`
+	Unit          string             `json:"unit"`
+	Start         time.Time          `json:"start"`
+	End           time.Time          `json:"end"`
+	StepSeconds   int64              `json:"step_seconds"`
+	Series        []monitoringSeries `json:"series"`
+}
+
+type prometheusRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string   `json:"metric"`
+			Values [][]json.RawMessage `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func labelSet(labels ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		set[label] = struct{}{}
+	}
+	return set
+}
+
+func registerMonitoringAPI(r *gin.RouterGroup, store monitoringStore, live LiveInfo, fetcher PeerFetcher, metrics *MetricsProxy, defaults MonitoringWorkerDefaults) {
+	h := &monitoringHandler{store: store, live: live, fetcher: fetcher, metrics: metrics, defaults: defaults}
+	group := r.Group("/orgs/:id/monitoring", requireInternalSecret())
+	group.GET("/snapshot", h.snapshot)
+	group.GET("/series", h.series)
+}
+
+func requireInternalSecret() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		identity := IdentityFromContext(c)
+		if identity == nil || identity.Source != "internal-secret" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "internal secret required"})
+			return
+		}
+		c.Next()
+	}
+}
+
+type monitoringHandler struct {
+	store    monitoringStore
+	live     LiveInfo
+	fetcher  PeerFetcher
+	metrics  *MetricsProxy
+	defaults MonitoringWorkerDefaults
+}
+
+func (h *monitoringHandler) snapshot(c *gin.Context) {
+	if h.store == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "monitoring unavailable"})
+		return
+	}
+
+	orgID := c.Param("id")
+	snapshot := h.store.Snapshot()
+	if snapshot == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration snapshot unavailable"})
+		return
+	}
+	org, ok := snapshot.Orgs[orgID]
+	if !ok || org == nil || org.Warehouse == nil {
+		monitoringWarehouseNotFound(c)
+		return
+	}
+
+	workerRecords, err := h.store.ListWorkerRecordsForOrg(orgID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "monitoring snapshot unavailable"})
+		return
+	}
+	connections, err := h.store.OrgConnectionMonitoringState(orgID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "monitoring snapshot unavailable"})
+		return
+	}
+
+	queries, coverage := h.orgQueries(c, orgID)
+	queriesByWorker := make(map[int]QueryStatus, len(queries))
+	runningQueries := 0
+	for _, query := range queries {
+		queriesByWorker[query.WorkerID] = query
+		if query.State == "active" {
+			runningQueries++
+		}
+	}
+
+	workers := make([]monitoringWorker, 0, len(workerRecords))
+	var allocatedCPUCores float64
+	var allocatedMemoryBytes int64
+	deploymentDefaults := normalizedMonitoringWorkerDefaults(h.defaults)
+	configuredDefaults := configuredMonitoringWorkerDefaults(org, deploymentDefaults)
+	for _, record := range workerRecords {
+		cpu := firstNonEmptyMonitoring(record.ProfileCPU, deploymentDefaults.CPU)
+		memory := firstNonEmptyMonitoring(record.ProfileMemory, deploymentDefaults.Memory)
+		allocatedCPUCores += cpuCores(cpu)
+		allocatedMemoryBytes += memoryBytes(memory)
+
+		ttlSeconds := record.TTLMinutes * 60
+		if ttlSeconds == 0 {
+			ttlSeconds = int(deploymentDefaults.TTL / time.Second)
+		}
+		worker := monitoringWorker{
+			ID:              record.WorkerID,
+			State:           string(record.State),
+			CPU:             cpu,
+			Memory:          memory,
+			TTLSeconds:      ttlSeconds,
+			CreatedAt:       record.CreatedAt.UTC(),
+			LastHeartbeatAt: record.LastHeartbeatAt.UTC(),
+		}
+		if query, ok := queriesByWorker[record.WorkerID]; ok {
+			worker.Session = &monitoringSession{
+				Protocol:   query.Protocol,
+				State:      query.State,
+				ElapsedMS:  query.ElapsedMS,
+				Percentage: monitoringPercentage(query.Percentage),
+				Rows:       query.Rows,
+				TotalRows:  query.TotalRows,
+				Stalled:    query.Stalled,
+			}
+		}
+		workers = append(workers, worker)
+	}
+	sort.Slice(workers, func(i, j int) bool { return workers[i].ID < workers[j].ID })
+
+	c.JSON(http.StatusOK, monitoringSnapshotResponse{
+		SchemaVersion: monitoringSchemaVersion,
+		OrgID:         orgID,
+		AsOf:          time.Now().UTC(),
+		Warehouse:     monitoringWarehouse{State: string(org.Warehouse.State)},
+		Limits: monitoringLimits{
+			MaxWorkers:              org.MaxWorkers,
+			MaxVCPUs:                org.MaxVCPUs,
+			DefaultWorkerCPU:        configuredDefaults.CPU,
+			DefaultWorkerMemory:     configuredDefaults.Memory,
+			DefaultWorkerTTLSeconds: int(configuredDefaults.TTL / time.Second),
+			DefaultWorkerMinHotIdle: org.DefaultWorkerMinHotIdle,
+		},
+		Totals: monitoringTotals{
+			Workers:              len(workers),
+			AllocatedCPUCores:    allocatedCPUCores,
+			AllocatedMemoryBytes: allocatedMemoryBytes,
+			ActiveSessions:       connections.ActiveLeases,
+			RunningQueries:       runningQueries,
+			QueuedConnections:    connections.QueuedConns,
+		},
+		Workers:  workers,
+		Coverage: coverage,
+	})
+}
+
+func (h *monitoringHandler) orgQueries(c *gin.Context, orgID string) ([]QueryStatus, monitoringCoverage) {
+	queries := make([]QueryStatus, 0)
+	if h.live != nil {
+		queries = append(queries, h.live.RunningQueries()...)
+	}
+	responders, total := 1, 1
+	if h.fetcher != nil {
+		peerResult := h.fetcher.FetchPeers(c.Request.Context(), "/api/v1/queries")
+		type envelope struct {
+			Queries []QueryStatus `json:"queries"`
+		}
+		coverage := peerReadCoverage(peerResult, mergePeer(&queries, peerResult.Bodies, func(e envelope) []QueryStatus { return e.Queries }))
+		responders, total = coverage.Responders, coverage.Total
+		queries = dedupeBy(queries, func(q QueryStatus) int { return q.WorkerID })
+	}
+	filtered := make([]QueryStatus, 0, len(queries))
+	for _, query := range queries {
+		if query.Org == orgID {
+			filtered = append(filtered, query)
+		}
+	}
+	return filtered, monitoringCoverage{CPResponders: responders, CPTotal: total, Partial: responders < total}
+}
+
+func (h *monitoringHandler) series(c *gin.Context) {
+	metric := c.Query("metric")
+	spec, ok := monitoringMetrics[metric]
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown monitoring metric"})
+		return
+	}
+	windowKey := c.DefaultQuery("window", "24h")
+	window, ok := monitoringWindows[windowKey]
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported monitoring window"})
+		return
+	}
+	if h.store == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "monitoring unavailable"})
+		return
+	}
+	snapshot := h.store.Snapshot()
+	var org *configstore.OrgConfig
+	found := false
+	if snapshot != nil {
+		org, found = snapshot.Orgs[c.Param("id")]
+	}
+	if !found || org == nil || org.Warehouse == nil {
+		monitoringWarehouseNotFound(c)
+		return
+	}
+	if h.metrics == nil || h.metrics.promURL == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "metrics not configured"})
+		return
+	}
+
+	response, err := h.metrics.queryMonitoringRange(c, c.Param("id"), metric, spec, window)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "metrics unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (m *MetricsProxy) queryMonitoringRange(c *gin.Context, orgID, metric string, spec monitoringMetricSpec, window time.Duration) (monitoringSeriesResponse, error) {
+	step := window / 240
+	if step < 15*time.Second {
+		step = 15 * time.Second
+	}
+	end := time.Now().UTC().Truncate(step)
+	start := end.Add(-window)
+	rateWindow := monitoringRateWindow(window)
+	orgSelector := fmt.Sprintf(`{org=%q}`, orgID)
+	orgErrorSelector := fmt.Sprintf(`{org=%q,status="error"}`, orgID)
+	promQL := renderPanel(spec.PromQL, orgSelector, orgErrorSelector, rateWindow)
+
+	query := url.Values{}
+	query.Set("query", promQL)
+	query.Set("start", strconv.FormatInt(start.Unix(), 10))
+	query.Set("end", strconv.FormatInt(end.Unix(), 10))
+	query.Set("step", strconv.FormatInt(int64(step/time.Second), 10)+"s")
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, m.promURL+"/api/v1/query_range?"+query.Encode(), nil)
+	if err != nil {
+		return monitoringSeriesResponse{}, err
+	}
+	client := m.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	upstream, err := client.Do(req)
+	if err != nil {
+		return monitoringSeriesResponse{}, err
+	}
+	defer func() { _ = upstream.Body.Close() }()
+	if upstream.StatusCode != http.StatusOK {
+		return monitoringSeriesResponse{}, fmt.Errorf("prometheus returned status %d", upstream.StatusCode)
+	}
+
+	var promResponse prometheusRangeResponse
+	decoder := json.NewDecoder(io.LimitReader(upstream.Body, 10<<20))
+	if err := decoder.Decode(&promResponse); err != nil {
+		return monitoringSeriesResponse{}, fmt.Errorf("decode prometheus response: %w", err)
+	}
+	if promResponse.Status != "success" || promResponse.Data.ResultType != "matrix" {
+		return monitoringSeriesResponse{}, fmt.Errorf("unexpected prometheus response")
+	}
+
+	series := make([]monitoringSeries, 0, len(promResponse.Data.Result))
+	for _, result := range promResponse.Data.Result {
+		labels := make(map[string]string, len(spec.AllowedLabels))
+		for key := range spec.AllowedLabels {
+			if value, ok := result.Metric[key]; ok {
+				labels[key] = value
+			}
+		}
+		points := make([]monitoringPoint, 0, len(result.Values))
+		for _, pair := range result.Values {
+			point, ok := decodePrometheusPoint(pair)
+			if ok {
+				points = append(points, point)
+			}
+		}
+		series = append(series, monitoringSeries{Labels: labels, Points: points})
+	}
+
+	return monitoringSeriesResponse{
+		SchemaVersion: monitoringSchemaVersion,
+		OrgID:         orgID,
+		Metric:        metric,
+		Unit:          spec.Unit,
+		Start:         start,
+		End:           end,
+		StepSeconds:   int64(step / time.Second),
+		Series:        series,
+	}, nil
+}
+
+func decodePrometheusPoint(pair []json.RawMessage) (monitoringPoint, bool) {
+	if len(pair) != 2 {
+		return monitoringPoint{}, false
+	}
+	var timestamp float64
+	var rawValue string
+	if json.Unmarshal(pair[0], &timestamp) != nil || json.Unmarshal(pair[1], &rawValue) != nil {
+		return monitoringPoint{}, false
+	}
+	value, err := strconv.ParseFloat(rawValue, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return monitoringPoint{}, false
+	}
+	seconds, fraction := math.Modf(timestamp)
+	return monitoringPoint{
+		Timestamp: time.Unix(int64(seconds), int64(fraction*float64(time.Second))).UTC(),
+		Value:     value,
+	}, true
+}
+
+func monitoringRateWindow(window time.Duration) string {
+	switch {
+	case window >= 30*24*time.Hour:
+		return "2h"
+	case window >= 7*24*time.Hour:
+		return "30m"
+	default:
+		return "5m"
+	}
+}
+
+func monitoringWarehouseNotFound(c *gin.Context) {
+	c.JSON(http.StatusNotFound, gin.H{
+		"code":  monitoringWarehouseNotFoundCode,
+		"error": "managed warehouse not found",
+	})
+}
+
+func monitoringPercentage(value float64) *float64 {
+	if value < 0 {
+		return nil
+	}
+	return &value
+}
+
+func normalizedMonitoringWorkerDefaults(deployment MonitoringWorkerDefaults) MonitoringWorkerDefaults {
+	effective := MonitoringWorkerDefaults{
+		CPU:    strings.TrimSpace(deployment.CPU),
+		Memory: strings.TrimSpace(deployment.Memory),
+		TTL:    deployment.TTL,
+	}
+	if cpuCores(effective.CPU) <= 0 {
+		effective.CPU = ""
+	}
+	if memoryBytes(effective.Memory) <= 0 {
+		effective.Memory = ""
+	}
+	if effective.TTL <= 0 {
+		effective.TTL = 0
+	}
+	return effective
+}
+
+func configuredMonitoringWorkerDefaults(org *configstore.OrgConfig, deployment MonitoringWorkerDefaults) MonitoringWorkerDefaults {
+	effective := deployment
+	if org == nil {
+		return deployment
+	}
+	if orgCPU := strings.TrimSpace(org.DefaultWorkerCPU); cpuCores(orgCPU) > 0 {
+		effective.CPU = orgCPU
+	}
+	if orgMemory := strings.TrimSpace(org.DefaultWorkerMemory); memoryBytes(orgMemory) > 0 {
+		effective.Memory = orgMemory
+	}
+	if orgTTL, err := time.ParseDuration(strings.TrimSpace(org.DefaultWorkerTTL)); err == nil && orgTTL > 0 {
+		effective.TTL = orgTTL
+	}
+	return effective
+}
+
+func firstNonEmptyMonitoring(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+func cpuCores(raw string) float64 {
+	quantity, err := resource.ParseQuantity(raw)
+	if err != nil || quantity.Sign() <= 0 {
+		return 0
+	}
+	return quantity.AsApproximateFloat64()
+}
+
+func memoryBytes(raw string) int64 {
+	quantity, err := resource.ParseQuantity(raw)
+	if err != nil || quantity.Sign() <= 0 {
+		return 0
+	}
+	return quantity.Value()
+}

--- a/controlplane/admin/monitoring_test.go
+++ b/controlplane/admin/monitoring_test.go
@@ -1,0 +1,415 @@
+//go:build kubernetes
+
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+type fakeMonitoringStore struct {
+	snapshot    *configstore.Snapshot
+	workers     map[string][]configstore.WorkerRecord
+	connections map[string]configstore.OrgConnectionMonitoringStatus
+	orgIDs      []string
+}
+
+func (f *fakeMonitoringStore) Snapshot() *configstore.Snapshot { return f.snapshot }
+
+func (f *fakeMonitoringStore) ListWorkerRecordsForOrg(orgID string) ([]configstore.WorkerRecord, error) {
+	f.orgIDs = append(f.orgIDs, orgID)
+	return f.workers[orgID], nil
+}
+
+func (f *fakeMonitoringStore) OrgConnectionMonitoringState(orgID string) (configstore.OrgConnectionMonitoringStatus, error) {
+	f.orgIDs = append(f.orgIDs, orgID)
+	return f.connections[orgID], nil
+}
+
+func internalMonitoringRouter(store monitoringStore, live LiveInfo, fetcher PeerFetcher, metrics *MetricsProxy) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(ctxIdentityKey, &Identity{Role: RoleAdmin, Source: "internal-secret"})
+		c.Next()
+	})
+	registerMonitoringAPI(r.Group("/api/v1"), store, live, fetcher, metrics, MonitoringWorkerDefaults{
+		CPU: "750m", Memory: "3Gi", TTL: 45 * time.Minute,
+	})
+	return r
+}
+
+func TestMonitoringSnapshotIsOrgScopedSanitizedAndReportsPartialCoverage(t *testing.T) {
+	created := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	heartbeat := created.Add(5 * time.Minute)
+	store := &fakeMonitoringStore{
+		snapshot: &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{
+			"org-a": {
+				Name:                    "org-a",
+				MaxWorkers:              4,
+				MaxVCPUs:                8,
+				DefaultWorkerCPU:        "1",
+				DefaultWorkerMemory:     "2Gi",
+				DefaultWorkerTTL:        "30m",
+				DefaultWorkerMinHotIdle: 1,
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					OrgID: "org-a",
+					State: configstore.ManagedWarehouseStateReady,
+				},
+			},
+		}},
+		workers: map[string][]configstore.WorkerRecord{
+			"org-a": {
+				{
+					WorkerID:          7,
+					PodName:           "sensitive-pod-name",
+					Image:             "sensitive-image",
+					ProfileCPU:        "2",
+					ProfileMemory:     "4Gi",
+					TTLMinutes:        15,
+					State:             configstore.WorkerStateHot,
+					OrgID:             "org-a",
+					OwnerCPInstanceID: "sensitive-control-plane",
+					CreatedAt:         created,
+					LastHeartbeatAt:   heartbeat,
+				},
+				{
+					WorkerID:        8,
+					ProfileCPU:      "",
+					ProfileMemory:   "",
+					State:           configstore.WorkerStateHotIdle,
+					OrgID:           "org-a",
+					CreatedAt:       created,
+					LastHeartbeatAt: heartbeat,
+				},
+			},
+		},
+		connections: map[string]configstore.OrgConnectionMonitoringStatus{
+			"org-a": {ActiveLeases: 2, QueuedConns: 3},
+		},
+	}
+	live := &fakeLiveInfo{queries: []QueryStatus{
+		{Org: "org-a", User: "sensitive-user", PID: 101, WorkerID: 7, Protocol: "pg", State: "active", ElapsedMS: 1200, Percentage: -1},
+		{Org: "org-b", User: "other-org-user", PID: 102, WorkerID: 99, Protocol: "pg", State: "active"},
+	}}
+	peerBody, err := json.Marshal(map[string]any{"queries": []QueryStatus{
+		{Org: "org-a", User: "peer-user", PID: 201, WorkerID: 8, Protocol: "flight", State: "idle"},
+		{Org: "org-b", User: "other-peer-user", PID: 202, WorkerID: 98, Protocol: "pg", State: "active"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fetcher := &fakePeerFetcher{byPath: map[string][][]byte{
+		"/api/v1/queries": {peerBody, []byte("not-json")},
+	}}
+
+	rec := httptest.NewRecorder()
+	internalMonitoringRouter(store, live, fetcher, nil).ServeHTTP(
+		rec,
+		httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-a/monitoring/snapshot", nil),
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var got monitoringSnapshotResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.OrgID != "org-a" || got.Warehouse.State != "ready" {
+		t.Fatalf("identity/state = %q/%q, want org-a/ready", got.OrgID, got.Warehouse.State)
+	}
+	if got.Limits.DefaultWorkerCPU != "1" || got.Limits.DefaultWorkerMemory != "2Gi" || got.Limits.DefaultWorkerTTLSeconds != 1800 {
+		t.Fatalf("configured defaults = %+v, want current org defaults", got.Limits)
+	}
+	if got.Totals.Workers != 2 || got.Totals.AllocatedCPUCores != 2.75 || got.Totals.AllocatedMemoryBytes != 7*1024*1024*1024 {
+		t.Fatalf("worker totals = %+v, want 2 workers / 2.75 cores / 7Gi", got.Totals)
+	}
+	if got.Totals.ActiveSessions != 2 || got.Totals.RunningQueries != 1 || got.Totals.QueuedConnections != 3 {
+		t.Fatalf("session totals = %+v, want 2 active / 1 running / 3 queued", got.Totals)
+	}
+	if len(got.Workers) != 2 || got.Workers[0].Session == nil || got.Workers[1].Session == nil {
+		t.Fatalf("workers/sessions = %+v, want two joined worker sessions", got.Workers)
+	}
+	if got.Workers[0].Session.Percentage != nil {
+		t.Fatalf("unknown query percentage = %v, want null", *got.Workers[0].Session.Percentage)
+	}
+	if got.Workers[1].Session.Percentage == nil || *got.Workers[1].Session.Percentage != 0 {
+		t.Fatalf("known query percentage = %v, want 0", got.Workers[1].Session.Percentage)
+	}
+	if got.Workers[0].CPU != "2" || got.Workers[0].Memory != "4Gi" || got.Workers[0].TTLSeconds != 900 {
+		t.Fatalf("explicit worker profile = %+v", got.Workers[0])
+	}
+	if got.Workers[1].CPU != "750m" || got.Workers[1].Memory != "3Gi" || got.Workers[1].TTLSeconds != 2700 {
+		t.Fatalf("deployment-default worker profile = %+v", got.Workers[1])
+	}
+	if got.Coverage.CPResponders != 2 || got.Coverage.CPTotal != 3 || !got.Coverage.Partial {
+		t.Fatalf("coverage = %+v, want partial 2/3", got.Coverage)
+	}
+	if len(store.orgIDs) != 2 || store.orgIDs[0] != "org-a" || store.orgIDs[1] != "org-a" {
+		t.Fatalf("store org scopes = %v, want only org-a", store.orgIDs)
+	}
+	for _, forbidden := range []string{
+		"sensitive-pod-name", "sensitive-image", "sensitive-control-plane",
+		"sensitive-user", "peer-user", "other-org-user", "other-peer-user", "org-b",
+		"pod_name", "image", "owner_cp_instance_id", "user", "pid",
+	} {
+		if strings.Contains(rec.Body.String(), forbidden) {
+			t.Errorf("snapshot leaked forbidden value/field %q: %s", forbidden, rec.Body.String())
+		}
+	}
+}
+
+func TestMonitoringSnapshotUsesDeploymentDefaultsForDefaultProfileSentinel(t *testing.T) {
+	created := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	store := &fakeMonitoringStore{
+		snapshot: monitoringTestSnapshot("org-a"),
+		workers: map[string][]configstore.WorkerRecord{
+			"org-a": {{WorkerID: 1, State: configstore.WorkerStateHotIdle, OrgID: "org-a", CreatedAt: created}},
+		},
+		connections: map[string]configstore.OrgConnectionMonitoringStatus{"org-a": {}},
+	}
+
+	rec := httptest.NewRecorder()
+	internalMonitoringRouter(store, nil, nil, nil).ServeHTTP(
+		rec,
+		httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-a/monitoring/snapshot", nil),
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var got monitoringSnapshotResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Limits.DefaultWorkerCPU != "750m" || got.Limits.DefaultWorkerMemory != "3Gi" || got.Limits.DefaultWorkerTTLSeconds != 2700 {
+		t.Fatalf("effective limits = %+v, want deployment defaults", got.Limits)
+	}
+	if len(got.Workers) != 1 || got.Workers[0].CPU != "750m" || got.Workers[0].Memory != "3Gi" || got.Workers[0].TTLSeconds != 2700 {
+		t.Fatalf("default-profile worker = %+v, want deployment defaults", got.Workers)
+	}
+	if got.Totals.AllocatedCPUCores != 0.75 || got.Totals.AllocatedMemoryBytes != 3*1024*1024*1024 {
+		t.Fatalf("allocated totals = %+v, want 0.75 cores / 3Gi", got.Totals)
+	}
+}
+
+func TestMonitoringRequiresInternalSecret(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(ctxIdentityKey, &Identity{Role: RoleAdmin, Source: "sso"})
+		c.Next()
+	})
+	registerMonitoringAPI(r.Group("/api/v1"), &fakeMonitoringStore{}, nil, nil, nil, MonitoringWorkerDefaults{})
+
+	for _, path := range []string{
+		"/api/v1/orgs/org-a/monitoring/snapshot",
+		"/api/v1/orgs/org-a/monitoring/series?metric=query_rate&window=1h",
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("GET %s status = %d, want 403", path, rec.Code)
+		}
+	}
+}
+
+func TestMonitoringSeriesIsAllowListedOrgScopedAndNormalized(t *testing.T) {
+	var upstreamQuery url.Values
+	prom := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"org":"org-a","status":"success","reason":"none","pod":"must-not-leak"},"values":[[1723456800,"2.5"],[1723456815,"3"]]}]}}`))
+	}))
+	defer prom.Close()
+
+	metrics := NewMetricsProxy(prom.URL)
+	r := internalMonitoringRouter(&fakeMonitoringStore{snapshot: monitoringTestSnapshot("org-a")}, nil, nil, metrics)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-a/monitoring/series?metric=query_rate&window=6h", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if q := upstreamQuery.Get("query"); !strings.Contains(q, `org="org-a"`) || !strings.Contains(q, "duckgres_query_total") {
+		t.Fatalf("upstream PromQL is not fixed to org-a query metric: %s", q)
+	}
+
+	var got monitoringSeriesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.OrgID != "org-a" || got.Metric != "query_rate" || got.Unit != "queries_per_second" {
+		t.Fatalf("series identity = %+v", got)
+	}
+	if got.StepSeconds <= 0 || len(got.Series) != 1 || len(got.Series[0].Points) != 2 {
+		t.Fatalf("series shape = %+v", got)
+	}
+	endUnix, err := strconv.ParseInt(upstreamQuery.Get("end"), 10, 64)
+	if err != nil {
+		t.Fatalf("end = %q: %v", upstreamQuery.Get("end"), err)
+	}
+	stepSeconds := got.StepSeconds
+	if endUnix%stepSeconds != 0 {
+		t.Fatalf("query_range end = %d, want alignment to %ds step", endUnix, stepSeconds)
+	}
+	startUnix, err := strconv.ParseInt(upstreamQuery.Get("start"), 10, 64)
+	if err != nil {
+		t.Fatalf("start = %q: %v", upstreamQuery.Get("start"), err)
+	}
+	if endUnix-startUnix != int64((6*time.Hour)/time.Second) {
+		t.Fatalf("query_range span = %ds, want 21600s", endUnix-startUnix)
+	}
+	if len(got.Series[0].Labels) != 2 || got.Series[0].Labels["status"] != "success" || got.Series[0].Labels["reason"] != "none" {
+		t.Fatalf("labels = %v, want only status=success and reason=none", got.Series[0].Labels)
+	}
+	if got.Series[0].Points[0].Value != 2.5 {
+		t.Fatalf("first value = %v, want 2.5", got.Series[0].Points[0].Value)
+	}
+}
+
+func TestMonitoringSeriesRejectsUnknownMetricAndWindowBeforePrometheus(t *testing.T) {
+	var calls int
+	prom := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	defer prom.Close()
+	r := internalMonitoringRouter(&fakeMonitoringStore{snapshot: monitoringTestSnapshot("org-a")}, nil, nil, NewMetricsProxy(prom.URL))
+
+	for _, path := range []string{
+		"/api/v1/orgs/org-a/monitoring/series?metric=worker_states&window=1h",
+		"/api/v1/orgs/org-a/monitoring/series?metric=s3_bytes_rate&window=1h",
+		"/api/v1/orgs/org-a/monitoring/series?metric=query_rate&window=2h",
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("GET %s status = %d, want 400: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("Prometheus called %d times for rejected requests, want 0", calls)
+	}
+}
+
+func TestMonitoringMetricAllowListAlwaysRequiresOrgSelector(t *testing.T) {
+	for metric, spec := range monitoringMetrics {
+		if !strings.Contains(spec.PromQL, "$ORG") {
+			t.Errorf("monitoring metric %q does not require an org selector: %s", metric, spec.PromQL)
+		}
+	}
+}
+
+func TestMonitoringErrorRatioPreservesLowTrafficRatios(t *testing.T) {
+	spec := monitoringMetrics["error_ratio"]
+	rendered := renderPanel(spec.PromQL, `{org="org-a"}`, `{org="org-a",status="error"}`, "5m")
+	if !strings.Contains(rendered, "1e-9") {
+		t.Fatalf("error_ratio denominator does not use a near-zero safety floor: %s", rendered)
+	}
+	if strings.Contains(rendered, "clamp_min(sum(rate(duckgres_query_total"+`{org="org-a"}`+"[5m])), 1)") {
+		t.Fatalf("error_ratio still clamps low-traffic orgs to one query per second: %s", rendered)
+	}
+	if !strings.Contains(rendered, "or vector(0)") {
+		t.Fatalf("error_ratio does not return zero when the error counter is absent: %s", rendered)
+	}
+}
+
+func TestMonitoringSparseGaugesAndCountersAvoidDoubleCountingOrMissingSeries(t *testing.T) {
+	if promQL := monitoringMetrics["worker_crash_rate"].PromQL; !strings.Contains(promQL, "or vector(0)") {
+		t.Fatalf("worker_crash_rate does not return zero when the counter is absent: %s", promQL)
+	}
+	if promQL := monitoringMetrics["storage_bytes"].PromQL; !strings.HasPrefix(promQL, "max(") {
+		t.Fatalf("storage_bytes can sum stale leader series: %s", promQL)
+	}
+}
+
+func TestMonitoringSeriesRejectsUnknownOrgBeforePrometheus(t *testing.T) {
+	var calls int
+	prom := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	defer prom.Close()
+	r := internalMonitoringRouter(&fakeMonitoringStore{snapshot: monitoringTestSnapshot("org-a")}, nil, nil, NewMetricsProxy(prom.URL))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-b/monitoring/series?metric=query_rate&window=1h", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != monitoringWarehouseNotFoundCode {
+		t.Fatalf("404 code = %q, want %q", body.Code, monitoringWarehouseNotFoundCode)
+	}
+	if calls != 0 {
+		t.Fatalf("Prometheus called %d times for unknown org, want 0", calls)
+	}
+}
+
+func TestMonitoringSnapshotUnknownWarehouseHasStableCode(t *testing.T) {
+	r := internalMonitoringRouter(&fakeMonitoringStore{snapshot: monitoringTestSnapshot("org-a")}, nil, nil, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-b/monitoring/snapshot", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != monitoringWarehouseNotFoundCode {
+		t.Fatalf("404 code = %q, want %q", body.Code, monitoringWarehouseNotFoundCode)
+	}
+}
+
+func TestMonitoringSnapshotMarksPeerDiscoveryFailurePartial(t *testing.T) {
+	store := &fakeMonitoringStore{
+		snapshot:    monitoringTestSnapshot("org-a"),
+		workers:     map[string][]configstore.WorkerRecord{"org-a": {}},
+		connections: map[string]configstore.OrgConnectionMonitoringStatus{"org-a": {}},
+	}
+	fetcher := &fakePeerFetcher{discoveryFailed: true}
+	rec := httptest.NewRecorder()
+	internalMonitoringRouter(store, &fakeLiveInfo{}, fetcher, nil).ServeHTTP(
+		rec,
+		httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-a/monitoring/snapshot", nil),
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got monitoringSnapshotResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Coverage.Partial || got.Coverage.CPResponders != 1 || got.Coverage.CPTotal != 2 {
+		t.Fatalf("coverage = %+v, want discovery-failed partial 1/2", got.Coverage)
+	}
+}
+
+func TestMonitoringSeriesRejectsUnknownOrgWhenMetricsAreUnconfigured(t *testing.T) {
+	r := internalMonitoringRouter(&fakeMonitoringStore{snapshot: monitoringTestSnapshot("org-a")}, nil, nil, NewMetricsProxy(""))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/orgs/org-b/monitoring/series?metric=query_rate&window=1h", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func monitoringTestSnapshot(orgID string) *configstore.Snapshot {
+	return &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{
+		orgID: {Name: orgID, Warehouse: &configstore.ManagedWarehouseConfig{OrgID: orgID, State: configstore.ManagedWarehouseStateReady}},
+	}}
+}
+
+var _ PeerFetcher = (*fakePeerFetcher)(nil)

--- a/controlplane/configstore/org_connections.go
+++ b/controlplane/configstore/org_connections.go
@@ -70,6 +70,14 @@ func (e *OrgConnectionAdmissionRejectedError) Unwrap() error {
 	return ErrOrgConnectionAdmissionRejected
 }
 
+// OrgConnectionMonitoringStatus is the live connection picture exposed to
+// tenant monitoring. Unlike reshard drain state, it excludes expired queue
+// entries and leases whose control-plane owner is no longer live.
+type OrgConnectionMonitoringStatus struct {
+	ActiveLeases int64
+	QueuedConns  int64
+}
+
 // EnqueueOrgConnectionRequest inserts a pending cluster-wide connection
 // admission request. FIFO ordering is scoped to org_id and ordered by
 // enqueued_at, then request_id. RequestedVCPUs is charged against active
@@ -958,6 +966,35 @@ func (cs *ConfigStore) ActiveOrgConnectionLeaseCount(orgID string) (int64, error
 		return 0, fmt.Errorf("count active org connection leases: %w", err)
 	}
 	return count, nil
+}
+
+// OrgConnectionMonitoringState reads the org's effective live leases and
+// pending queue depth without mutating the runtime coordination tables.
+func (cs *ConfigStore) OrgConnectionMonitoringState(orgID string) (OrgConnectionMonitoringStatus, error) {
+	tables := cs.orgConnectionRuntimeTables()
+	cpTable := cs.runtimeTable((&ControlPlaneInstance{}).TableName())
+	var status OrgConnectionMonitoringStatus
+	err := cs.db.Transaction(func(tx *gorm.DB) error {
+		now, err := cs.orgConnectionDatabaseNow(tx)
+		if err != nil {
+			return err
+		}
+		if err := tx.Table(tables.lease+" AS l").
+			Joins("LEFT JOIN "+cpTable+" AS cp ON cp.id = l.cp_instance_id").
+			Where("l.org_id = ?", orgID).
+			Where("(cp.id IS NOT NULL AND cp.state <> ?) OR (cp.id IS NULL AND l.acquired_at > ?)",
+				ControlPlaneInstanceStateExpired, now.Add(-missingOwnerOrgConnectionLeaseGrace)).
+			Count(&status.ActiveLeases).Error; err != nil {
+			return err
+		}
+		return tx.Table(tables.queue).
+			Where("org_id = ? AND granted_at IS NULL AND expires_at > ?", orgID, now).
+			Count(&status.QueuedConns).Error
+	})
+	if err != nil {
+		return OrgConnectionMonitoringStatus{}, fmt.Errorf("org connection monitoring state: %w", err)
+	}
+	return status, nil
 }
 
 func (cs *ConfigStore) cleanupOrgConnectionRowsLocked(tx *gorm.DB, orgID string, now time.Time) error {

--- a/controlplane/live_aggregator.go
+++ b/controlplane/live_aggregator.go
@@ -86,23 +86,29 @@ func cpDeploymentPrefix(podName string) string {
 // FetchPeers returns each peer CP's body for path+"?scope=local" and the total
 // number of peers attempted. Peers are fetched concurrently with a short
 // per-peer timeout; a slow/down peer is simply omitted (graceful degradation).
-func (f *clusterPeerFetcher) FetchPeers(ctx context.Context, path string) ([][]byte, int) {
-	return f.fanOut(ctx, http.MethodGet, path)
+func (f *clusterPeerFetcher) FetchPeers(ctx context.Context, path string) admin.PeerFetchResult {
+	bodies, peers, discoveryComplete := f.fanOut(ctx, http.MethodGet, path)
+	return admin.PeerFetchResult{Bodies: bodies, Peers: peers, DiscoveryComplete: discoveryComplete}
 }
 
 // PostPeers is FetchPeers for a mutating action — same discovery, concurrency,
 // timeouts, and scope=local recursion guard, but with POST.
 func (f *clusterPeerFetcher) PostPeers(ctx context.Context, path string) ([][]byte, int) {
-	return f.fanOut(ctx, http.MethodPost, path)
+	bodies, peers, _ := f.fanOut(ctx, http.MethodPost, path)
+	return bodies, peers
 }
 
-func (f *clusterPeerFetcher) fanOut(ctx context.Context, method, path string) ([][]byte, int) {
+func (f *clusterPeerFetcher) fanOut(ctx context.Context, method, path string) ([][]byte, int, bool) {
 	if f == nil || f.clientset == nil || f.selfPod == "" {
-		return nil, 0
+		return nil, 0, false
 	}
-	ips := f.discoverPeerIPs(ctx)
+	ips, err := f.discoverPeerIPs(ctx)
+	if err != nil {
+		slog.Warn("admin live aggregation failed to discover peer control planes", "error", err)
+		return nil, 0, false
+	}
 	if len(ips) == 0 {
-		return nil, 0
+		return nil, 0, true
 	}
 	bodies := make([][]byte, 0, len(ips))
 	var mu sync.Mutex
@@ -119,17 +125,17 @@ func (f *clusterPeerFetcher) fanOut(ctx context.Context, method, path string) ([
 		}(ip)
 	}
 	wg.Wait()
-	return bodies, len(ips)
+	return bodies, len(ips), true
 }
 
-func (f *clusterPeerFetcher) discoverPeerIPs(ctx context.Context) []string {
+func (f *clusterPeerFetcher) discoverPeerIPs(ctx context.Context) ([]string, error) {
 	lctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	pods, err := f.clientset.CoreV1().Pods(f.namespace).List(lctx, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=duckgres",
 	})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var ips []string
 	for i := range pods.Items {
@@ -155,7 +161,7 @@ func (f *clusterPeerFetcher) discoverPeerIPs(ctx context.Context) []string {
 	if len(ips) == 0 && len(pods.Items) <= 1 {
 		slog.Debug("admin live aggregation found no peer CPs", "namespace", f.namespace, "deploy_prefix", f.deployPrefix, "pods_listed", len(pods.Items))
 	}
-	return ips
+	return ips, nil
 }
 
 func (f *clusterPeerFetcher) doOne(ctx context.Context, method, ip, path string) ([]byte, bool) {

--- a/controlplane/live_aggregator_test.go
+++ b/controlplane/live_aggregator_test.go
@@ -4,6 +4,7 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCPDeploymentPrefix(t *testing.T) {
@@ -58,10 +60,35 @@ func TestDiscoverPeerIPs(t *testing.T) {
 		selfIPs:      map[string]struct{}{"10.0.0.1": {}},
 		deployPrefix: "duckgres-control-plane",
 	}
-	got := f.discoverPeerIPs(context.Background())
+	got, err := f.discoverPeerIPs(context.Background())
+	if err != nil {
+		t.Fatalf("discoverPeerIPs: %v", err)
+	}
 	sort.Strings(got)
 	want := []string{"10.0.0.2", "10.0.0.3"}
 	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("discoverPeerIPs = %v, want %v", got, want)
+	}
+}
+
+func TestFetchPeersReportsDiscoveryFailure(t *testing.T) {
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("kubernetes API unavailable")
+	})
+	f := &clusterPeerFetcher{
+		clientset:    clientset,
+		namespace:    "duckgres",
+		selfPod:      "duckgres-control-plane-rs1-self",
+		selfIPs:      map[string]struct{}{"10.0.0.1": {}},
+		deployPrefix: "duckgres-control-plane",
+	}
+
+	result := f.FetchPeers(context.Background(), "/api/v1/queries")
+	if result.DiscoveryComplete {
+		t.Fatalf("discovery complete = true, want false after Kubernetes list failure: %+v", result)
+	}
+	if len(result.Bodies) != 0 || result.Peers != 0 {
+		t.Fatalf("failed discovery result = %+v, want no known peers", result)
 	}
 }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -681,7 +681,13 @@ func SetupMultiTenant(
 		clusterClient = router.sharedPool.clientset
 	}
 	admin.RegisterExtras(api, admin.Extras{
-		Store:         store,
+		Store:      store,
+		Monitoring: store,
+		MonitoringWorkerDefaults: admin.MonitoringWorkerDefaults{
+			CPU:    firstNonEmpty(cfg.K8s.WorkerCPURequest, defaultWorkerCPU),
+			Memory: firstNonEmpty(cfg.K8s.WorkerMemoryRequest, defaultWorkerMemory),
+			TTL:    effectiveDefaultWorkerTTL(cfg.K8s.WorkerDefaultTTL),
+		},
 		Live:          clusterInfo,
 		Users:         store,
 		Fetcher:       liveFetcher,

--- a/controlplane/storage_meter.go
+++ b/controlplane/storage_meter.go
@@ -111,10 +111,14 @@ func newStorageSampler(store storageUsageStore, interval time.Duration, listOrgs
 // leader change (deploys, lease flaps), i.e. systematic over-billing. Waiting
 // one full interval for the first tick keeps failover in the documented
 // direction: a leadership change under-bills at most one interval.
+// Gauge labels are cleared on exit because Prometheus scrapes every CP, and a
+// former leader's last values would otherwise overlap the next leader's data.
 func (s *storageSampler) Run(ctx context.Context) {
 	if s == nil || s.store == nil || s.listOrgs == nil || s.resolveDSN == nil {
 		return
 	}
+	defer storageTrackedBytesGauge.Reset()
+	defer storagePendingDeleteFilesGauge.Reset()
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {

--- a/controlplane/storage_meter_test.go
+++ b/controlplane/storage_meter_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type fakeStorageStore struct {
@@ -120,6 +122,51 @@ func TestStorageSamplerRunStopsOnCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("sampler did not stop on cancel")
+	}
+}
+
+func TestStorageSamplerClearsLeaderOwnedGaugesOnCancel(t *testing.T) {
+	storageTrackedBytesGauge.Reset()
+	storagePendingDeleteFilesGauge.Reset()
+	t.Cleanup(func() {
+		storageTrackedBytesGauge.Reset()
+		storagePendingDeleteFilesGauge.Reset()
+	})
+
+	store := &fakeStorageStore{}
+	s := newStorageSampler(store, 20*time.Millisecond,
+		func() []storageOrg { return []storageOrg{{OrgID: "orgA", TeamID: 42}} },
+		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
+	)
+	s.queryFootprint = func(_ context.Context, _ string) (int64, int64, error) { return 2048, 3, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	if got := waitForSamples(store, 1, 2*time.Second); got < 1 {
+		cancel()
+		t.Fatal("ticker sample pass never ran")
+	}
+	if got := testutil.CollectAndCount(storageTrackedBytesGauge); got != 1 {
+		cancel()
+		t.Fatalf("tracked storage gauge series while leading = %d, want 1", got)
+	}
+	if got := testutil.CollectAndCount(storagePendingDeleteFilesGauge); got != 1 {
+		cancel()
+		t.Fatalf("pending-delete gauge series while leading = %d, want 1", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sampler did not stop on cancel")
+	}
+	if got := testutil.CollectAndCount(storageTrackedBytesGauge); got != 0 {
+		t.Fatalf("tracked storage gauge series after leadership loss = %d, want 0", got)
+	}
+	if got := testutil.CollectAndCount(storagePendingDeleteFilesGauge); got != 0 {
+		t.Fatalf("pending-delete gauge series after leadership loss = %d, want 0", got)
 	}
 }
 

--- a/tests/configstore/org_connection_limiter_test.go
+++ b/tests/configstore/org_connection_limiter_test.go
@@ -1952,6 +1952,56 @@ func TestOrgConnectionLeasesIgnoreExpiredControlPlaneOwners(t *testing.T) {
 	}
 }
 
+func TestOrgConnectionMonitoringStateExcludesExpiredRuntimeRows(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	upsertActiveCP(t, store, "cp-active")
+
+	now := time.Now().UTC()
+	expiredAt := now.Add(-time.Minute)
+	if err := store.UpsertControlPlaneInstance(&cpconfigstore.ControlPlaneInstance{
+		ID:              "cp-expired",
+		PodName:         "cp-expired",
+		State:           cpconfigstore.ControlPlaneInstanceStateExpired,
+		StartedAt:       now.Add(-time.Hour),
+		LastHeartbeatAt: now.Add(-10 * time.Minute),
+		ExpiredAt:       &expiredAt,
+	}); err != nil {
+		t.Fatalf("upsert expired control plane: %v", err)
+	}
+
+	leaseTable := store.RuntimeSchema() + ".org_connection_leases"
+	leases := []*cpconfigstore.OrgConnectionLease{
+		{LeaseID: "active", RequestID: "request-active", OrgID: "org-monitoring", Username: "alice", CPInstanceID: "cp-active", PID: 1, Protocol: "postgres", RequestedVCPUs: 1, AcquiredAt: now},
+		{LeaseID: "expired-owner", RequestID: "request-expired-owner", OrgID: "org-monitoring", Username: "bob", CPInstanceID: "cp-expired", PID: 2, Protocol: "postgres", RequestedVCPUs: 1, AcquiredAt: now},
+		{LeaseID: "recent-missing-owner", RequestID: "request-recent-missing-owner", OrgID: "org-monitoring", Username: "carol", CPInstanceID: "cp-missing", PID: 3, Protocol: "postgres", RequestedVCPUs: 1, AcquiredAt: now},
+		{LeaseID: "stale-missing-owner", RequestID: "request-stale-missing-owner", OrgID: "org-monitoring", Username: "dave", CPInstanceID: "cp-stale", PID: 4, Protocol: "postgres", RequestedVCPUs: 1, AcquiredAt: now.Add(-10 * time.Minute)},
+		{LeaseID: "other-org", RequestID: "request-other-org", OrgID: "org-other", Username: "eve", CPInstanceID: "cp-active", PID: 5, Protocol: "postgres", RequestedVCPUs: 1, AcquiredAt: now},
+	}
+	if err := store.DB().Table(leaseTable).Create(leases).Error; err != nil {
+		t.Fatalf("insert monitoring leases: %v", err)
+	}
+
+	grantedAt := now
+	queueTable := store.RuntimeSchema() + ".org_connection_queue"
+	queue := []*cpconfigstore.OrgConnectionQueueEntry{
+		{RequestID: "pending", OrgID: "org-monitoring", Username: "alice", CPInstanceID: "cp-active", PID: 11, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute)},
+		{RequestID: "expired", OrgID: "org-monitoring", Username: "bob", CPInstanceID: "cp-active", PID: 12, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now.Add(-2 * time.Minute), ExpiresAt: now.Add(-time.Minute)},
+		{RequestID: "granted", OrgID: "org-monitoring", Username: "carol", CPInstanceID: "cp-active", PID: 13, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute), GrantedAt: &grantedAt},
+		{RequestID: "other-org-pending", OrgID: "org-other", Username: "eve", CPInstanceID: "cp-active", PID: 14, Protocol: "postgres", RequestedVCPUs: 1, EnqueuedAt: now, ExpiresAt: now.Add(time.Minute)},
+	}
+	if err := store.DB().Table(queueTable).Create(queue).Error; err != nil {
+		t.Fatalf("insert monitoring queue: %v", err)
+	}
+
+	status, err := store.OrgConnectionMonitoringState("org-monitoring")
+	if err != nil {
+		t.Fatalf("monitoring state: %v", err)
+	}
+	if status.ActiveLeases != 2 || status.QueuedConns != 1 {
+		t.Fatalf("monitoring state = %+v, want 2 active leases / 1 queued connection", status)
+	}
+}
+
 func TestTryAcquireOrgConnectionLeasePrunesStaleMissingControlPlaneOwner(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	upsertActiveCP(t, store, "cp-a")

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2766,6 +2766,31 @@ admin_console_api() {
     echo "$panels" | jq -e --arg p "$p" '.panels | index($p)' >/dev/null \
       || fail "/metrics/panels missing '$p'"
   done
+
+  # Product monitoring is an internal-secret-only tenant surface, distinct
+  # from the operator endpoints. The snapshot is sourced from the org-scoped
+  # durable runtime store plus live CP state and must retain its sanitized
+  # envelope even when the org is idle. The series request may be 503 in this
+  # environment when Prometheus is intentionally unset, but an unknown metric
+  # must be rejected by the allow-list before any upstream call.
+  curl -fsS -H "$H" "$API/api/v1/orgs/$CNPG/monitoring/snapshot" \
+    | jq -e --arg o "$CNPG" '
+        .schema_version == 1 and .org_id == $o and
+        (.warehouse.state | type) == "string" and
+        (.workers | type) == "array" and
+        (.coverage.cp_total >= 1) and
+        ([.workers[]? | has("pod_name") or has("image") or has("owner_cp_instance_id") or has("user") or has("pid")] | any | not)
+      ' >/dev/null \
+    || fail "/orgs/$CNPG/monitoring/snapshot envelope or redaction wrong"
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "$H" \
+    "$API/api/v1/orgs/$CNPG/monitoring/series?metric=worker_states&window=1h")"
+  [ "$code" = "400" ] || fail "monitoring series unknown metric returned $code, want 400"
+  body="$(curl -sS -H "$H" "$API/api/v1/orgs/__missing_monitoring_org__/monitoring/snapshot")"
+  echo "$body" | jq -e '.code == "managed_warehouse_not_found"' >/dev/null \
+    || fail "monitoring snapshot missing warehouse returned an unstable error: $body"
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "$H" \
+    "$API/api/v1/orgs/__missing_monitoring_org__/monitoring/snapshot")"
+  [ "$code" = "404" ] || fail "monitoring snapshot missing warehouse returned $code, want 404"
 }
 
 # ---- admin: operators CRUD (console access list) ---------------------------


### PR DESCRIPTION
## Problem

Managed warehouse operators cannot retrieve tenant-safe visibility into one organization's workers, query health, capacity, and storage.

## Changes

- Adds authenticated organization-scoped snapshot and time-series endpoints.
- Aggregates worker state across control planes and reports incomplete discovery.
- Exposes allocated capacity and operational metrics without billing totals.
- Restricts query dimensions to approved status, reason, and acquisition-source labels.
- Excludes the data-read rate from the organization monitoring contract.
- Resets storage gauges after leadership changes to prevent stale series.
- The [PostHog dashboard PR](https://github.com/PostHog/posthog/pull/82885) consumes this contract.

## How did you test this code?

- `just lint`
- `just test-controlplane-k8s`
- `just test-configstore-integration`
- `bash -n tests/mw-dev/e2e/harness.sh`
- `just ci` reached an unrelated local cache-proxy test failure because a cache proxy was already reachable.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and reviewed the change with `/signed-git-publish` and `/writing-pr-descriptions`. Test fixtures contain invented organization and worker identifiers.