### PR TITLE
Measure cache proxy peer fanout

### DIFF
--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -454,9 +454,10 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	blockReadsTotal.WithLabelValues("peer").Add(float64(nPeer))
 	blockReadsTotal.WithLabelValues("s3").Add(float64(nOrigin))
 
-	// Request-level hit/miss accounting mirrors the legacy meaning: a hit is
-	// "no origin traffic needed".
-	if nOrigin == 0 {
+	// Request-level hit/miss accounting mirrors the metric's documented
+	// meaning: a hit means every requested block was already on local NVMe.
+	// Fetching any block from a peer or origin is a local miss.
+	if nPeer == 0 && nOrigin == 0 {
 		cacheHitsTotal.Inc()
 	} else {
 		cacheMissesTotal.Inc()

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -444,12 +444,11 @@ func TestServeBlockAlignedSpansChunkedByMaxSpan(t *testing.T) {
 	}
 }
 
-// TestServeBlockAlignedPeerFillCountsAsHit exercises the previously-untested
-// peer branch of Phase 1: a block resolvable from a peer must never touch
-// origin, must land under blockReadsTotal{peer} / cacheBytesServed{peer}, and
-// (having triggered zero origin fetches) must count as a cache hit, not a
-// miss — the same "hit" meaning the legacy path uses.
-func TestServeBlockAlignedPeerFillCountsAsHit(t *testing.T) {
+// TestServeBlockAlignedPeerFillCountsAsLocalMiss exercises the peer branch of
+// Phase 1: a block resolved from another node must land under
+// blockReadsTotal{peer} / cacheBytesServed{peer}, while the request-level
+// hit/miss counters continue to mean whether the bytes were already local.
+func TestServeBlockAlignedPeerFillCountsAsLocalMiss(t *testing.T) {
 	const blockSize = 1024
 	origin := originServer(t, 4*blockSize)
 	target := origin.URL + "/bucket/f.parquet"
@@ -488,11 +487,11 @@ func TestServeBlockAlignedPeerFillCountsAsHit(t *testing.T) {
 		t.Fatalf("peer /cache/get calls = %d, want 1", getCalls)
 	}
 
-	if got := counterValue(t, cacheHitsTotal); got != hitsBefore+1 {
-		t.Fatalf("cacheHitsTotal delta = %v, want 1 (peer fill with zero origin fetches must count as a hit)", got-hitsBefore)
+	if got := counterValue(t, cacheHitsTotal); got != hitsBefore {
+		t.Fatalf("cacheHitsTotal delta = %v, want 0 (a peer fill was not already local)", got-hitsBefore)
 	}
-	if got := counterValue(t, cacheMissesTotal); got != missesBefore {
-		t.Fatalf("cacheMissesTotal delta = %v, want 0", got-missesBefore)
+	if got := counterValue(t, cacheMissesTotal); got != missesBefore+1 {
+		t.Fatalf("cacheMissesTotal delta = %v, want 1", got-missesBefore)
 	}
 	if got := counterValue(t, blockReadsTotal.WithLabelValues("peer")); got != peerReadsBefore+1 {
 		t.Fatalf("blockReadsTotal{peer} delta = %v, want 1", got-peerReadsBefore)

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -329,9 +329,9 @@ func (c *DiskCache) Open(key string) (io.ReadCloser, int64, bool) {
 	return f, size, true
 }
 
-// openFile opens a cached entry WITHOUT recording a hit. Used to serve a body
-// that was just fetched on a miss — that path already counted a miss, so
-// counting it as a hit too would double-count.
+// openFile opens and touches a cached entry WITHOUT recording a worker-facing
+// hit. It serves bodies just fetched on a miss and peer API reads; neither is a
+// local hit for the requesting worker.
 func (c *DiskCache) openFile(key string) (io.ReadCloser, int64, bool) {
 	if !IsValidCacheKey(key) {
 		return nil, 0, false

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -23,6 +24,10 @@ var (
 		Name: "cache_proxy_peer_hits_total",
 		Help: "Total successful peer cache hits",
 	})
+	peerProbesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_peer_probes_total",
+		Help: "Physical peer availability probe attempts, by outcome",
+	}, []string{"outcome"}) // hit, miss, timeout, canceled, error
 )
 
 // Peer timeouts. The /cache/has probe is a tiny HEAD-like check, so it gets a
@@ -159,12 +164,21 @@ func (pm *PeerManager) LocateKey(cacheKey string) (holder string, flight, ok boo
 		go func(addr string) {
 			res := probeResult{addr: addr, status: -1}
 			hasURL := fmt.Sprintf("http://%s/cache/has?key=%s", addr, cacheKey)
-			if req, err := http.NewRequestWithContext(ctx, "GET", hasURL, nil); err == nil {
-				if resp, err := pm.client.Do(req); err == nil {
-					res.status = resp.StatusCode
-					_ = resp.Body.Close()
-				}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, hasURL, nil)
+			if err != nil {
+				peerProbesTotal.WithLabelValues("error").Inc()
+				resCh <- res
+				return
 			}
+			resp, err := pm.client.Do(req)
+			if err != nil {
+				peerProbesTotal.WithLabelValues(peerProbeErrorOutcome(err)).Inc()
+				resCh <- res
+				return
+			}
+			res.status = resp.StatusCode
+			_ = resp.Body.Close()
+			peerProbesTotal.WithLabelValues(peerProbeStatusOutcome(resp.StatusCode)).Inc()
 			resCh <- res
 		}(addr)
 	}
@@ -186,6 +200,32 @@ func (pm *PeerManager) LocateKey(cacheKey string) (holder string, flight, ok boo
 		return firstFlight, true, true
 	}
 	return "", false, false
+}
+
+func peerProbeStatusOutcome(status int) string {
+	switch status {
+	case http.StatusOK, http.StatusAccepted:
+		return "hit"
+	case http.StatusNotFound:
+		return "miss"
+	default:
+		return "error"
+	}
+}
+
+func peerProbeErrorOutcome(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	default:
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return "timeout"
+		}
+		return "error"
+	}
 }
 
 // FetchFromPeer streams cacheKey's body from one peer into sink. flight=true

--- a/cmd/cache-proxy/peers_test.go
+++ b/cmd/cache-proxy/peers_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -118,6 +120,138 @@ func TestLocateKeyMissFromAll(t *testing.T) {
 	// On miss, /cache/get should NOT be called.
 	if atomic.LoadInt32(&getCalls) != 0 {
 		t.Errorf("peer /cache/get calls = %d, want 0 on miss", getCalls)
+	}
+}
+
+func TestLocateKeyCountsEveryPhysicalProbe(t *testing.T) {
+	key := strings.Repeat("1", 64)
+	other := strings.Repeat("2", 64)
+	peers := make([]string, 0, 3)
+	for range 3 {
+		peers = append(peers, newPeerServer(t, other, nil, http.StatusOK, nil, nil))
+	}
+	pm := peerManagerWith(peers)
+
+	lookupsBefore := counterValue(t, peerFetchesTotal)
+	missesBefore := counterValue(t, peerProbesTotal.WithLabelValues("miss"))
+	if _, _, ok := pm.LocateKey(key); ok {
+		t.Fatal("expected every peer probe to miss")
+	}
+
+	if got := counterValue(t, peerFetchesTotal); got != lookupsBefore+1 {
+		t.Fatalf("logical peer lookups = %v, want %v", got, lookupsBefore+1)
+	}
+	if got := counterValue(t, peerProbesTotal.WithLabelValues("miss")); got != missesBefore+3 {
+		t.Fatalf("physical miss probes = %v, want %v", got, missesBefore+3)
+	}
+}
+
+func TestLocateKeyClassifiesUsefulProbeAsHit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusAccepted} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			key := strings.Repeat("3", 64)
+			pm := peerManagerWith([]string{newPeerServer(t, key, nil, status, nil, nil)})
+			hitsBefore := counterValue(t, peerProbesTotal.WithLabelValues("hit"))
+
+			if _, _, ok := pm.LocateKey(key); !ok {
+				t.Fatalf("status %d should be a useful peer claim", status)
+			}
+			if got := counterValue(t, peerProbesTotal.WithLabelValues("hit")); got != hitsBefore+1 {
+				t.Fatalf("physical hit probes = %v, want %v", got, hitsBefore+1)
+			}
+		})
+	}
+}
+
+func TestPeerProbeOutcomeLabels(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{name: "present", status: http.StatusOK, want: "hit"},
+		{name: "in flight", status: http.StatusAccepted, want: "hit"},
+		{name: "absent", status: http.StatusNotFound, want: "miss"},
+		{name: "unexpected response", status: http.StatusInternalServerError, want: "error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerProbeStatusOutcome(tt.status); got != tt.want {
+				t.Fatalf("peerProbeStatusOutcome(%d) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "timeout", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "transport", err: errors.New("connection refused"), want: "error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerProbeErrorOutcome(tt.err); got != tt.want {
+				t.Fatalf("peerProbeErrorOutcome(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocateKeyCountsCanceledLosingProbes(t *testing.T) {
+	pm := peerManagerWith([]string{"winner:8081", "loser-a:8081", "loser-b:8081"})
+	started := make(chan string, len(pm.peers))
+	releaseWinner := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseWinner:
+		default:
+			close(releaseWinner)
+		}
+	}()
+	pm.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		started <- req.URL.Host
+		if req.URL.Host == "winner:8081" {
+			<-releaseWinner
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+
+	hitsBefore := counterValue(t, peerProbesTotal.WithLabelValues("hit"))
+	canceledBefore := counterValue(t, peerProbesTotal.WithLabelValues("canceled"))
+	lookupDone := make(chan bool, 1)
+	go func() {
+		_, _, ok := pm.LocateKey(strings.Repeat("4", 64))
+		lookupDone <- ok
+	}()
+
+	for range pm.peers {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for every physical probe to start")
+		}
+	}
+	close(releaseWinner)
+	if ok := <-lookupDone; !ok {
+		t.Fatal("expected the released peer to win the lookup")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for counterValue(t, peerProbesTotal.WithLabelValues("canceled")) != canceledBefore+2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := counterValue(t, peerProbesTotal.WithLabelValues("hit")); got != hitsBefore+1 {
+		t.Fatalf("physical hit probes = %v, want %v", got, hitsBefore+1)
+	}
+	if got := counterValue(t, peerProbesTotal.WithLabelValues("canceled")); got != canceledBefore+2 {
+		t.Fatalf("physical canceled probes = %v, want %v", got, canceledBefore+2)
 	}
 }
 

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -904,7 +904,9 @@ func (p *CacheProxy) HandlePeerGet(w http.ResponseWriter, r *http.Request) {
 		p.waitForLocalFill(r, key)
 	}
 
-	reader, size, ok := p.store.Open(key)
+	// Peer traffic keeps the entry warm but must not inflate the worker-facing
+	// local-hit counter. openFile touches LRU recency without recording a hit.
+	reader, size, ok := p.store.openFile(key)
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -871,6 +871,31 @@ func TestHandlePeerHasAndGet(t *testing.T) {
 	}
 }
 
+func TestHandlePeerGetDoesNotCountWorkerCacheHit(t *testing.T) {
+	proxy := newTestProxy(t)
+
+	key := strings.Repeat("e", 64)
+	body := []byte("peer-cached-payload")
+	if _, err := proxy.store.PutStream(key, bytes.NewReader(body)); err != nil {
+		t.Fatalf("seed PutStream: %v", err)
+	}
+
+	hitsBefore := counterValue(t, cacheHitsTotal)
+	req := httptest.NewRequest(http.MethodGet, "/cache/get?key="+key, nil)
+	rec := httptest.NewRecorder()
+	proxy.HandlePeerGet(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandlePeerGet status = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != string(body) {
+		t.Fatalf("HandlePeerGet body = %q, want %q", rec.Body.String(), body)
+	}
+	if hitsAfter := counterValue(t, cacheHitsTotal); hitsAfter != hitsBefore {
+		t.Fatalf("cacheHitsTotal changed from %v to %v for peer traffic; only worker-facing local hits should count", hitsBefore, hitsAfter)
+	}
+}
+
 func TestHandlePeerRejectsInvalidKey(t *testing.T) {
 	proxy := newTestProxy(t)
 	for _, key := range []string{"", "../../etc/passwd", "deadbeef"} {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -223,6 +223,68 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_request_duration_seconds` | Histogram | `path`, `source` | End-to-end duration of a served request. `path` is `block` (block-aligned cache path) or `forward` (uncached forward-proxy path); `source` is `local`, `peer`, or `s3` for `block`, and always `origin` for `forward`. |
 | `cache_proxy_forward_requests_total` | Counter | `method` | Requests handled by the uncached forward-proxy path, by HTTP method. |
 | `cache_proxy_inflight_requests` | Gauge | None | Requests currently being handled by the proxy's request entry point; the queue-depth signal. |
+| `cache_proxy_hits_total` | Counter | None | Worker-facing cacheable requests served entirely from data already present on local NVMe. Peer API reads and requests that first fetch any block from a peer are excluded. |
+| `cache_proxy_misses_total` | Counter | None | Worker-facing cacheable requests that require a peer or origin fill before they can be served. |
+| `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
+| `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups. One lookup can issue multiple physical `/cache/has` probes. |
+| `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
+| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical peer availability probe attempts, classified as `hit`, `miss`, `timeout`, `canceled`, or `error`. Both a present entry (`200`) and an in-flight claim (`202`) are `hit`; `canceled` normally means a losing probe was released after another peer answered and is not itself a failure. |
+
+Cache-proxy metrics deliberately have no org label. Use the existing per-org
+Duckgres query and worker-acquisition metrics for customer-facing rollout
+guardrails, and use these proxy metrics for cache locality and amplification.
+
+Local cache hit ratio:
+
+```promql
+sum(rate(cache_proxy_hits_total[5m]))
+/
+clamp_min(
+  sum(rate(cache_proxy_hits_total[5m]))
+    + sum(rate(cache_proxy_misses_total[5m])),
+  1e-9
+)
+```
+
+Average physical peer fanout per logical lookup:
+
+```promql
+sum(rate(cache_proxy_peer_probes_total[5m]))
+/
+clamp_min(sum(rate(cache_proxy_peer_fetches_total[5m])), 1e-9)
+```
+
+Peer lookup yield:
+
+```promql
+sum(rate(cache_proxy_peer_hits_total[5m]))
+/
+clamp_min(sum(rate(cache_proxy_peer_fetches_total[5m])), 1e-9)
+```
+
+For an org-affinity canary, pair those signals with the existing per-org
+customer failure and worker-acquisition guardrails:
+
+```promql
+sum by (org) (
+  rate(duckgres_query_total{status="error"}[5m])
+)
+/
+clamp_min(
+  sum by (org) (rate(duckgres_query_total[5m])),
+  1e-9
+)
+
+sum by (org, outcome) (
+  rate(duckgres_worker_acquire_total_seconds_count{outcome=~"capacity|error|canceled"}[5m])
+)
+/
+on (org) group_left
+clamp_min(
+  sum by (org) (rate(duckgres_worker_acquire_total_seconds_count[5m])),
+  1e-9
+)
+```
 
 ## PromQL recipes
 


### PR DESCRIPTION
## Summary

- make `cache_proxy_hits_total` represent worker-facing requests served entirely from local NVMe
- add `cache_proxy_peer_probes_total{outcome}` to measure physical `/cache/has` amplification
- document local-hit, peer-fanout, peer-yield, and existing customer guardrail queries

## Why

`cache_proxy_peer_fetches_total` counts logical lookups, so it cannot show the physical all-peer fanout behind each lookup. The existing hit counter was also inflated by peer API reads and by block requests that first fetched data from another peer.

This intentionally remains the smaller observability change. It does not add an `outcome` label to `cache_proxy_request_duration_seconds`, because that histogram does not currently cover every request path or failure mode. Customer regression guardrails continue to use the existing per-org Duckgres query-error and worker-acquisition metrics.

## Rollout notes

- Expect a one-time downward discontinuity in displayed cache hit ratio: this is the corrected local-hit definition, not a cache regression. During the DaemonSet rollout, old and new pods will expose mixed hit semantics.
- Wait until every cache-proxy pod runs the new image before evaluating `peer_probes_total / peer_fetches_total`; during rollout, the numerator exists only on upgraded pods while the denominator includes all pods.
- Existing latency metric schemas, dashboard queries, and alerts remain compatible and unchanged.
- Canceled peer probes usually represent losing probes released after another peer answered, not probe failures.

## Testing

- `just test-cache-proxy`
- `just lint`
- `just test-impact-plan origin/main HEAD`

