### PR TITLE
feat(analytics): include application_name in query lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,9 +509,9 @@ teardown), so you can build a provisioning funnel and alert on failures.
 | `warehouse_deprovision_success` | All underlying resources deleted (provisioner controller) | — |
 | `warehouse_deprovision_failed` | A teardown attempt failed (provisioner controller) | `reason` (`duckling_delete_failed`) |
 | `warehouse_password_reset` | An org's root password is reset (admin API) | `username` |
-| `query_initiated` | An accepted, non-empty client query is received | `user`, `team_id`, `trace_id` |
-| `query_completed` | A statement finishes executing successfully | `user`, `team_id`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows` |
-| `query_failed` | A query errors | `user`, `team_id`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`) |
+| `query_initiated` | An accepted, non-empty client query is received | `user`, `team_id`, `trace_id`, `application_name` |
+| `query_completed` | A statement finishes executing successfully | `user`, `team_id`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows`, `application_name` |
+| `query_failed` | A query errors | `user`, `team_id`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`), `application_name` |
 
 > Note: `warehouse_provision_success` / `_failed` and `warehouse_deprovision_success`
 > are terminal and fire exactly once per warehouse (guarded on the state
@@ -537,6 +537,12 @@ teardown), so you can build a provisioning funnel and alert on failures.
 > `query_initiated`. Filter by `query_kind` to isolate real data queries from
 > utility statements. Emitted independently of the query-log configuration;
 > capture is asynchronous and batched, so it stays off the query latency path.
+
+> Note: `application_name` is the client-supplied `application_name` startup
+> parameter (also shown in the admin live view), letting you distinguish
+> PostHog-side callers (e.g. the register workflow, Dagster, the SQL editor)
+> from customer `psql` connections. It is an empty string when the client
+> didn't set one.
 
 ### Query Logs
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -609,9 +609,10 @@ func (c *clientConn) logClientQueryReceived(ctx context.Context, protocol, query
 		"trace_id", traceID,
 	)
 	analytics.Default().Capture("query_initiated", c.orgID, map[string]any{
-		"user":     c.username,
-		"team_id":  c.teamID,
-		"trace_id": traceID,
+		"user":             c.username,
+		"team_id":          c.teamID,
+		"trace_id":         traceID,
+		"application_name": c.applicationName,
 	})
 }
 
@@ -649,11 +650,12 @@ func (c *clientConn) logQueryError(query string, err error) {
 	// Per-org product analytics. No SQL text or secrets are sent — only the
 	// SQLSTATE and category — so this is unaffected by the redaction above.
 	analytics.Default().Capture("query_failed", c.orgID, map[string]any{
-		"user":           c.username,
-		"team_id":        c.teamID,
-		"trace_id":       traceID,
-		"error_code":     sqlState,
-		"error_category": category,
+		"user":             c.username,
+		"team_id":          c.teamID,
+		"trace_id":         traceID,
+		"error_code":       sqlState,
+		"error_category":   category,
+		"application_name": c.applicationName,
 	})
 
 	// Retain a redacted snapshot for the admin Errors page. Both Query and

--- a/server/conn_analytics_test.go
+++ b/server/conn_analytics_test.go
@@ -35,7 +35,7 @@ func installFakeQueryTracker(t *testing.T) *fakeQueryTracker {
 
 func TestLogClientQueryReceivedEmitsQueryInitiated(t *testing.T) {
 	fake := installFakeQueryTracker(t)
-	c := &clientConn{orgID: "acme", username: "root", teamID: 42, ctx: context.Background()}
+	c := &clientConn{orgID: "acme", username: "root", teamID: 42, applicationName: "psql", ctx: context.Background()}
 
 	c.logClientQueryReceived(context.Background(), "simple", "SELECT 1")
 
@@ -55,11 +55,14 @@ func TestLogClientQueryReceivedEmitsQueryInitiated(t *testing.T) {
 	if e.props["team_id"] != int64(42) {
 		t.Errorf("team_id = %v, want 42", e.props["team_id"])
 	}
+	if e.props["application_name"] != "psql" {
+		t.Errorf("application_name = %v, want psql", e.props["application_name"])
+	}
 }
 
 func TestLogQueryErrorEmitsQueryFailed(t *testing.T) {
 	fake := installFakeQueryTracker(t)
-	c := &clientConn{orgID: "acme", username: "root", ctx: context.Background()}
+	c := &clientConn{orgID: "acme", username: "root", applicationName: "dagster", ctx: context.Background()}
 
 	// A plain error matches no DuckDB prefix → system category, XX000.
 	c.logQueryError("SELECT 1", errors.New("worker connection reset"))
@@ -80,6 +83,9 @@ func TestLogQueryErrorEmitsQueryFailed(t *testing.T) {
 	if e.props["error_code"] != "XX000" {
 		t.Errorf("error_code = %v, want XX000", e.props["error_code"])
 	}
+	if e.props["application_name"] != "dagster" {
+		t.Errorf("application_name = %v, want dagster", e.props["application_name"])
+	}
 }
 
 func TestLogQueryErrorClassifiesUserError(t *testing.T) {
@@ -99,7 +105,7 @@ func TestLogQueryEmitsQueryCompletedOnSuccess(t *testing.T) {
 	fake := installFakeQueryTracker(t)
 	// No server → queryLogSink is nil, so this exercises the analytics emission
 	// independently of the query-log sink.
-	c := &clientConn{orgID: "acme", username: "root", teamID: 42, ctx: context.Background()}
+	c := &clientConn{orgID: "acme", username: "root", teamID: 42, applicationName: "posthog-register", ctx: context.Background()}
 	c.lastProfilingSummary = observe.QueryProfilingSummary{CPUTimeSeconds: 2.5}
 
 	c.logQuery(time.Now().Add(-100*time.Millisecond), "SELECT 1", "SELECT 1", "SELECT", 1, 0, "", "", "simple")
@@ -116,6 +122,9 @@ func TestLogQueryEmitsQueryCompletedOnSuccess(t *testing.T) {
 	}
 	if e.props["team_id"] != int64(42) {
 		t.Errorf("team_id = %v, want 42", e.props["team_id"])
+	}
+	if e.props["application_name"] != "posthog-register" {
+		t.Errorf("application_name = %v, want posthog-register", e.props["application_name"])
 	}
 	if e.props["cpu_seconds"] != 2.5 {
 		t.Errorf("cpu_seconds = %v, want 2.5", e.props["cpu_seconds"])

--- a/server/querylog.go
+++ b/server/querylog.go
@@ -485,14 +485,15 @@ func (c *clientConn) logQuery(start time.Time, query, transpiledQuery, cmdType s
 	// this usage signal does not depend on query-log configuration.
 	if errCode == "" {
 		analytics.Default().Capture("query_completed", c.orgID, map[string]any{
-			"user":        c.username,
-			"team_id":     c.teamID,
-			"trace_id":    observe.TraceIDFromContext(c.ctx),
-			"protocol":    protocol,
-			"query_kind":  classifyQuery(cmdType),
-			"duration_ms": time.Since(start).Milliseconds(),
-			"cpu_seconds": profilingSummary.CPUTimeSeconds,
-			"result_rows": resultRows,
+			"user":             c.username,
+			"team_id":          c.teamID,
+			"trace_id":         observe.TraceIDFromContext(c.ctx),
+			"protocol":         protocol,
+			"query_kind":       classifyQuery(cmdType),
+			"duration_ms":      time.Since(start).Milliseconds(),
+			"cpu_seconds":      profilingSummary.CPUTimeSeconds,
+			"result_rows":      resultRows,
+			"application_name": c.applicationName,
 		})
 	}
 


### PR DESCRIPTION
## Problem

The `query_initiated` / `query_completed` / `query_failed` analytics events identify callers only by DB username. Dagster presents `svc_*` credentials, but the register workflow, SQL editor, materialization, and customer `psql` sessions all connect as the org-root user — their queries are indistinguishable in the product analytics.

## Changes

- Add `application_name` to the props of all three query lifecycle events, sourced from the existing `clientConn.applicationName` (already parsed from the client's startup parameters and shown in the admin live view). Empty string when the client sent none.
- Extend `conn_analytics_test.go` assertions and the README analytics-events table.

Companion PostHog-side change (separate PR) sets `application_name` per caller (`ducklake-register`, `ducklake-copy`, `events-backfill`, …) in `make_duckgres_conninfo`. Safe to deploy this first: untagged clients just carry an empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)