### PR TITLE
chore: bump linux duckdb bindings to v0.10505.0-posthog.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2
 
-replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2

--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 => github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.3
 
-replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2
+replace github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 => github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.3

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1 h1:tNEwT0I3opiyExELmRWDMqog4y8QMULw9Y4sfPRoV0w=
-github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.1/go.mod h1:si4fhkU5nVX82UqieuHih5FkAIzbHQaJCxJ6BITL4U8=
-github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1 h1:vuaMkqfPSQ7RuSwtCOYKQVbK4F5L37qrzr1P3XGS02s=
-github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.1/go.mod h1:MSpni+1dJdPoTQjbn+H702kD1iVveoQ6qWDdshBn140=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2 h1:KdEhonJoT4L6AypJVPOLrJapHgvxw/VslB2DUqQYunQ=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2/go.mod h1:si4fhkU5nVX82UqieuHih5FkAIzbHQaJCxJ6BITL4U8=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2 h1:sZ0N4tyJcvUkX4fiyj9mCbFY+lDjG/RoE8R71rbyfjw=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2/go.mod h1:MSpni+1dJdPoTQjbn+H702kD1iVveoQ6qWDdshBn140=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2 h1:KdEhonJoT4L6AypJVPOLrJapHgvxw/VslB2DUqQYunQ=
-github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.2/go.mod h1:si4fhkU5nVX82UqieuHih5FkAIzbHQaJCxJ6BITL4U8=
-github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2 h1:sZ0N4tyJcvUkX4fiyj9mCbFY+lDjG/RoE8R71rbyfjw=
-github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.2/go.mod h1:MSpni+1dJdPoTQjbn+H702kD1iVveoQ6qWDdshBn140=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.3 h1:imLksCd041JuUbdg4FUx2/VgUfLXpXlHmiIUkiLmRUM=
+github.com/PostHog/duckdb-go-bindings/lib/linux-amd64 v0.10505.0-posthog.3/go.mod h1:si4fhkU5nVX82UqieuHih5FkAIzbHQaJCxJ6BITL4U8=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.3 h1:F/IIs7AU5iR/qe2pjRVVXIYLywkAPDgjogxs9RkZ3MI=
+github.com/PostHog/duckdb-go-bindings/lib/linux-arm64 v0.10505.0-posthog.3/go.mod h1:MSpni+1dJdPoTQjbn+H702kD1iVveoQ6qWDdshBn140=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4LdHdI=

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -140,10 +140,10 @@ WORKER_INSPECTION_ATTEMPTS=30
 # (DUCKLAKE_EXTENSION_TAG=v1.0-posthog.7, HTTPFS_EXTENSION_TAG=v1.5.5-cred-refresh-write-retry).
 # The engine itself is the PostHog/duckdb patchline build: library_version
 # stays v1.5.5 (extension resolution), while source_id identifies the
-# patchline commit (posthog/v1.5.5 prefetch-accounting patch).
+# patchline commit (PostHog/duckdb v1.5.5-posthog.5, gcc-toolset-12).
 # If the image accidentally ships upstream, the version/source differs and we fail.
 EXPECT_DUCKDB_VERSION="v1.5.5"
-EXPECT_DUCKDB_SOURCE_ID="911c1d6428"
+EXPECT_DUCKDB_SOURCE_ID="697fa6fb44"
 EXPECT_DUCKLAKE_SHA="6768849c"
 EXPECT_HTTPFS_SHA="575da0b"
 


### PR DESCRIPTION
## Summary

Point linux DuckDB static libs at [PostHog/duckdb-go-bindings `v0.10505.0-posthog.3`](https://github.com/PostHog/duckdb-go-bindings/pull/2) (built from [PostHog/duckdb v1.5.5-posthog.5](https://github.com/PostHog/duckdb/releases/tag/v1.5.5-posthog.5)).

- VARIANT shred allowlist + extract pushdown
- gcc-toolset-12 — does **not** reference `__cxa_call_terminate` (the GCC 14 symbol that broke bookworm/wolfi)
- `library_version` stays `v1.5.5` so official `INSTALL ducklake` still resolves
- e2e harness `EXPECT_DUCKDB_SOURCE_ID` is `697fa6fb44`
- Darwin/Windows stay on upstream `v0.10505.0`

Do not merge until bindings #2 is tagged (already: `lib/linux-{amd64,arm64}/v0.10505.0-posthog.3`).