### PR TITLE
fix(cache-proxy): retry transient origin failures on the block-aligned path

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -100,7 +100,9 @@ opened so LRU eviction cannot truncate an in-progress assembled response.
 When a trace endpoint is set the proxy exports OpenTelemetry spans under
 `service.name=duckgres-cache-proxy`. A cacheable request emits `cache.get`, with
 `cache.origin_fetch`, `cache.peer_lookup`, and `cache.peer_get` children as
-needed; peer transfers emit `cache.peer_serve` on the selected remote proxy.
+needed; block-aligned origin span fetches emit `cache.origin_span_fetch` (or
+`cache.origin_span_refetch` for the presence re-fetch backstop). Peer
+transfers emit `cache.peer_serve` on the selected remote proxy.
 `CONNECT` tunnels emit `cache.connect` and non-cached methods emit
 `cache.forward`.
 
@@ -121,7 +123,11 @@ per-request tenant identity.
 Origin `GET` misses are retried up to 4 total attempts for transient failures:
 HTTP `408`, `429`, `500`, `502`, `503`, `504`, request timeouts, and common
 transport resets. Retries start with a 100 ms backoff and cap at 1 second.
+This applies both to the legacy exact-range path and to block-aligned span
+fetches (including the presence re-fetch backstop), so a brief origin blip is
+absorbed by the proxy instead of surfacing to DuckDB as a `502`.
 
 Terminal origin responses such as `400`, `403`, `404`, and `416` are not retried
-and are forwarded back to DuckDB verbatim. Failed origin responses are never
-stored in the cache.
+and are forwarded back to DuckDB verbatim — as is the final status once the
+retry budget is exhausted. Failed origin responses are never stored in the
+cache.

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -254,7 +254,14 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			flightKey := fmt.Sprintf("%s|%d", BlockKey(urlStr, lo, p.blockSize), hi)
 			_, err := p.flights.Do(flightKey, func() (fetchResult, error) {
 				fetchStart := time.Now()
-				fetchErr := p.fetchOriginSpan(r, p.blockSize, lo, hi)
+				// Retry transient origin failures inside the flight so every
+				// waiter on this key benefits, and a brief origin blip is
+				// absorbed here instead of reaching DuckDB as a 502.
+				_, fetchSpan := proxyTracer.Start(r.Context(), "cache.origin_span_fetch")
+				fetchErr := p.retryOriginFetch(r, fetchSpan, func() error {
+					return p.fetchOriginSpan(r, p.blockSize, lo, hi)
+				})
+				fetchSpan.End()
 				s3Dur += time.Since(fetchStart)
 				return fetchResult{}, fetchErr
 			})
@@ -348,7 +355,11 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		lo := reverifyStart
 		reverifyStart = -1
 		fetchStart := time.Now()
-		err := p.fetchOriginSpan(r, p.blockSize, lo, runEnd)
+		_, fetchSpan := proxyTracer.Start(r.Context(), "cache.origin_span_refetch")
+		err := p.retryOriginFetch(r, fetchSpan, func() error {
+			return p.fetchOriginSpan(r, p.blockSize, lo, runEnd)
+		})
+		fetchSpan.End()
 		s3Dur += time.Since(fetchStart)
 		if err != nil {
 			slog.Warn("Presence re-fetch failed; failing closed below if blocks are still missing.",

--- a/cmd/cache-proxy/block_serve_test.go
+++ b/cmd/cache-proxy/block_serve_test.go
@@ -16,6 +16,30 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// serveSyntheticRanged serves body honoring absolute Range headers like S3:
+// 206 with Content-Range for in-range requests, 416 for starts past the end,
+// clamping the end at the object boundary.
+func serveSyntheticRanged(w http.ResponseWriter, r *http.Request, body []byte) {
+	objSize := int64(len(body))
+	start, end, ok := parseAbsoluteRange(r.Header.Get("Range"))
+	if !ok {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return
+	}
+	if start >= objSize {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", objSize))
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+	if end >= objSize {
+		end = objSize - 1 // S3 clamps to object end
+	}
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, objSize))
+	w.WriteHeader(http.StatusPartialContent)
+	_, _ = w.Write(body[start : end+1])
+}
+
 // originServer serves a synthetic object of objSize bytes where byte i has
 // value byte(i % 251), honoring absolute Range headers like S3.
 func originServer(t *testing.T, objSize int64) *httptest.Server {
@@ -25,23 +49,7 @@ func originServer(t *testing.T, objSize int64) *httptest.Server {
 		body[i] = byte(i % 251)
 	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start, end, ok := parseAbsoluteRange(r.Header.Get("Range"))
-		if !ok {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(body)
-			return
-		}
-		if start >= objSize {
-			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", objSize))
-			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-			return
-		}
-		if end >= objSize {
-			end = objSize - 1 // S3 clamps to object end
-		}
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, objSize))
-		w.WriteHeader(http.StatusPartialContent)
-		_, _ = w.Write(body[start : end+1])
+		serveSyntheticRanged(w, r, body)
 	}))
 }
 
@@ -235,6 +243,146 @@ func TestServeBlockAlignedFailsClosedOn200Origin(t *testing.T) {
 		if store.Has(BlockKey(u.String(), idx, blockSize)) {
 			t.Fatalf("block %d must not be committed when the origin ignored Range", idx)
 		}
+	}
+}
+
+// TestServeBlockAlignedRetriesTransientOriginStatus: a cold block-mode
+// request whose origin answers with a retriable 5xx must be retried inside
+// the proxy — a transient S3 503 blip should not reach DuckDB as a failure.
+func TestServeBlockAlignedRetriesTransientOriginStatus(t *testing.T) {
+	const blockSize = 1024
+	const objSize = 4 * blockSize
+	body := make([]byte, objSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	var calls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		serveSyntheticRanged(w, r, body)
+	}))
+	defer origin.Close()
+
+	p, _ := newBlockProxy(t, origin, blockSize)
+	w := doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=1500-2500")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206 (body: %s)", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("origin calls = %d, want 3 (2 transient failures + 1 success)", got)
+	}
+	if w.Body.Len() != 1001 {
+		t.Fatalf("body len = %d, want 1001", w.Body.Len())
+	}
+	for i, b := range w.Body.Bytes() {
+		if want := body[1500+i]; b != want {
+			t.Fatalf("byte %d: got %d, want %d", i, b, want)
+		}
+	}
+}
+
+// TestServeBlockAlignedRetriesTruncatedOriginBody: a mid-body connection drop
+// while committing blocks (unexpected EOF) is retriable — the proxy must
+// re-fetch the span rather than 502ing back to DuckDB.
+func TestServeBlockAlignedRetriesTruncatedOriginBody(t *testing.T) {
+	const blockSize = 1024
+	const objSize = 4 * blockSize
+	body := make([]byte, objSize)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	var calls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			// Send a valid 206 header, then sever the connection mid-body so
+			// the client hits an unexpected EOF while committing blocks.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("hijacking not supported")
+				return
+			}
+			conn, rw, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			start, end, _ := parseAbsoluteRange(r.Header.Get("Range"))
+			_, _ = fmt.Fprintf(rw, "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes %d-%d/%d\r\nContent-Length: %d\r\n\r\n", start, end, objSize, end-start+1)
+			_, _ = rw.Write(make([]byte, 100)) // truncated: less than Content-Length
+			_ = rw.Flush()
+			return
+		}
+		serveSyntheticRanged(w, r, body)
+	}))
+	defer origin.Close()
+
+	p, store := newBlockProxy(t, origin, blockSize)
+	u, _ := url.Parse(origin.URL + "/bucket/f.parquet")
+	w := doBlockRequest(t, p, u.String(), "bytes=1500-2500")
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206 (body: %s)", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("origin calls = %d, want 2 (1 truncated + 1 success)", got)
+	}
+	// The truncated first attempt must not have left partial blocks behind:
+	// blocks 1 and 2 must be complete.
+	for idx := int64(1); idx <= 2; idx++ {
+		_, size, ok := store.Open(BlockKey(u.String(), idx, blockSize))
+		if !ok || size != blockSize {
+			t.Fatalf("block %d: present=%v size=%d, want present size %d", idx, ok, size, blockSize)
+		}
+	}
+}
+
+// TestServeBlockAlignedDoesNotRetryTerminalOriginStatus: a 4xx like 400 is
+// terminal — forward it verbatim after a single attempt, no retries.
+func TestServeBlockAlignedDoesNotRetryTerminalOriginStatus(t *testing.T) {
+	const blockSize = 1024
+	var calls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("<Error><Code>BadRequest</Code></Error>"))
+	}))
+	defer origin.Close()
+
+	p, _ := newBlockProxy(t, origin, blockSize)
+	w := doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=1500-2500")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 forwarded verbatim", w.Code)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("origin calls = %d, want 1 (terminal status must not be retried)", got)
+	}
+	if got := w.Body.String(); got != "<Error><Code>BadRequest</Code></Error>" {
+		t.Fatalf("body = %q, want verbatim origin error body", got)
+	}
+}
+
+// TestServeBlockAlignedRetriesExhausted: when the origin never recovers, the
+// proxy gives up after the configured attempts and forwards the last origin
+// status verbatim.
+func TestServeBlockAlignedRetriesExhausted(t *testing.T) {
+	const blockSize = 1024
+	var calls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer origin.Close()
+
+	p, _ := newBlockProxy(t, origin, blockSize)
+	w := doBlockRequest(t, p, origin.URL+"/bucket/f.parquet", "bytes=1500-2500")
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 forwarded verbatim after retries are exhausted", w.Code)
+	}
+	if got, want := calls.Load(), int32(defaultOriginRetryMaxAttempts); got != want {
+		t.Fatalf("origin calls = %d, want %d (retry budget exhausted)", got, want)
 	}
 }
 

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -465,18 +465,40 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 	_, originSpan := proxyTracer.Start(r.Context(), "cache.origin_fetch")
 	defer originSpan.End()
 
+	var size int64
+	var contentType string
+	err := p.retryOriginFetch(r, originSpan, func() error {
+		var attemptErr error
+		size, contentType, attemptErr = p.fetchOriginOnce(cacheKey, r)
+		return attemptErr
+	})
+	if err != nil {
+		return 0, "", err
+	}
+	originSpan.SetAttributes(attribute.Int64("duckgres.bytes", size))
+	return size, contentType, nil
+}
+
+// retryOriginFetch runs attempt (one origin fetch) up to
+// originRetryMaxAttempts times with jittered exponential backoff, while the
+// error is retriable (isRetriableOriginFetchError) and the request context is
+// alive. Shared by the legacy exact-range path (fetchOrigin) and the
+// block-aligned path (fetchOriginSpan) so a transient origin 5xx or transport
+// blip is absorbed by the cache layer instead of surfacing to DuckDB as a
+// 502. Terminal origin statuses (4xx) and poisoned-response guards fail on
+// the first attempt.
+func (p *CacheProxy) retryOriginFetch(r *http.Request, originSpan trace.Span, attempt func() error) error {
 	attempts := p.originRetryMaxAttempts
 	if attempts < 1 {
 		attempts = 1
 	}
 	backoff := p.originRetryInitialBackoff
 	var lastErr error
-	for attempt := 1; attempt <= attempts; attempt++ {
-		size, contentType, err := p.fetchOriginOnce(cacheKey, r)
-		originSpan.SetAttributes(attribute.Int("duckgres.origin.attempts", attempt))
+	for i := 1; i <= attempts; i++ {
+		err := attempt()
+		originSpan.SetAttributes(attribute.Int("duckgres.origin.attempts", i))
 		if err == nil {
-			originSpan.SetAttributes(attribute.Int64("duckgres.bytes", size))
-			return size, contentType, nil
+			return nil
 		}
 		lastErr = err
 		var oe *originStatusError
@@ -485,18 +507,18 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 		}
 		if err := r.Context().Err(); err != nil {
 			originSpan.SetStatus(codes.Error, err.Error())
-			return 0, "", err
+			return err
 		}
-		if attempt == attempts || !isRetriableOriginFetchError(err) {
+		if i == attempts || !isRetriableOriginFetchError(err) {
 			originSpan.SetStatus(codes.Error, err.Error())
-			return 0, "", err
+			return err
 		}
 
 		delay := jitteredOriginRetryDelay(backoff, p.originRetryMaxBackoff)
 		slog.Warn("Origin fetch failed with retriable error, retrying.",
 			"url", r.URL.String(),
 			"range", r.Header.Get("Range"),
-			"attempt", attempt,
+			"attempt", i,
 			"max_attempts", attempts,
 			"backoff", delay,
 			"error", err)
@@ -506,11 +528,11 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 				err = context.Canceled
 			}
 			originSpan.SetStatus(codes.Error, err.Error())
-			return 0, "", err
+			return err
 		}
 		if err := r.Context().Err(); err != nil {
 			originSpan.SetStatus(codes.Error, err.Error())
-			return 0, "", err
+			return err
 		}
 		originFetchRetriesTotal.WithLabelValues(originRetryReason(err)).Inc()
 		if backoff > 0 {
@@ -523,7 +545,7 @@ func (p *CacheProxy) fetchOrigin(cacheKey string, r *http.Request) (int64, strin
 	if lastErr != nil {
 		originSpan.SetStatus(codes.Error, lastErr.Error())
 	}
-	return 0, "", lastErr
+	return lastErr
 }
 
 func jitteredOriginRetryDelay(backoff, maxBackoff time.Duration) time.Duration {


### PR DESCRIPTION
## Problem

A long-running SQLMesh plan failed several models with errors like:

```
HTTP Error: Unable to connect to URL s3://<bucket>/.../ducklake-<uuid>.parquet: Bad Gateway (HTTP code 502)
```

The legacy exact-range path in cache-proxy already retries origin fetches (4 attempts, jittered 100ms→1s backoff) for transient 5xx / transport errors — but the **block-aligned path** (`serveBlockAligned` → `fetchOriginSpan`) sent exactly **one** origin request and surfaced the failure immediately:

- retriable origin 5xx → forwarded verbatim to DuckDB
- transport error (reset, timeout, truncated body) → `502 Bad Gateway`

So a brief origin blip during an 86-minute plan failed the whole run.

## Change

Extract the retry loop from `fetchOrigin` into a shared `retryOriginFetch` helper and wrap both block-path origin fetches with it:

- **`flushRun`** (single-flight span fetch): retries now run *inside* the flight, so every waiter on a key benefits from a retried success.
- **`reverify`** (phase-1.5 presence re-fetch backstop): same retry policy.

Behavior is unchanged where it matters:

- Terminal statuses (`400`, `403`, `404`, `416`) fail on the first attempt and are forwarded verbatim.
- The poisoned-response guards (Range-ignored `200`, Content-Range mismatch) still fail closed immediately — these are non-retriable by message match.
- Once the budget (default 4 attempts) is exhausted, the last origin status is forwarded verbatim exactly as before.
- Retriable mid-body failures (e.g. `unexpected EOF` while committing blocks) leave no partial blocks behind: `PutStream` only renames on success, so re-fetching the span is idempotent.

Also adds `cache.origin_span_fetch` / `cache.origin_span_refetch` trace spans around block-path origin fetches (previously untraced), with the same `duckgres.origin.attempts` / `http.response.status_code` attributes as the legacy path, and the existing `cache_proxy_origin_fetch_retries_total` metric now covers block-path retries too.

## Testing

TDD red-green per repo conventions. New tests in `block_serve_test.go`:

- `TestServeBlockAlignedRetriesTransientOriginStatus` — 503, 503, then success → request succeeds with 206 + correct body (red before: returned 503 verbatim)
- `TestServeBlockAlignedRetriesTruncatedOriginBody` — first attempt severs the connection mid-body → retried, 206, no partial blocks committed (red before: immediate 502)
- `TestServeBlockAlignedDoesNotRetryTerminalOriginStatus` — 400 forwarded verbatim, exactly 1 origin call
- `TestServeBlockAlignedRetriesExhausted` — persistent 503 → forwarded verbatim after exactly `defaultOriginRetryMaxAttempts` attempts

`go test -race ./cmd/cache-proxy/` passes; `just lint` clean.

Note: `TestHandleConnectLogsOpenAndClose` has a **pre-existing** data race on `main` (test reads the shared slog buffer while the CONNECT close-logger goroutine is still writing) — reproduced on unmodified `main` and unrelated to this change. Happy to open a separate issue/PR for it.
