### PR TITLE
test(cache-proxy): fix data race in captureSlog test harness

### DIFF
--- a/cmd/cache-proxy/proxy_test.go
+++ b/cmd/cache-proxy/proxy_test.go
@@ -77,12 +77,36 @@ func waitForRecorder(t *testing.T, ch <-chan *httptest.ResponseRecorder, msg str
 // and returns the buffer + a restore function. Used by the forward-uncached
 // logging tests to assert presence of the request/response log lines that
 // were missing pre-PR (every PUT/POST through the proxy was a black hole).
-func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+//
+// The buffer must be concurrency-safe: proxy handlers log from goroutines
+// that outlive the request (e.g. the CONNECT close logger fires after both
+// tunnel legs finish), so test-goroutine String reads would race an
+// unsynchronized bytes.Buffer.
+func captureSlog(t *testing.T) (*syncBuffer, func()) {
 	t.Helper()
 	prev := slog.Default()
-	var buf bytes.Buffer
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	return &buf, func() { slog.SetDefault(prev) }
+	buf := &syncBuffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+// syncBuffer serializes slog-handler Write calls from proxy goroutines
+// against String reads from the test goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // newTestProxy wires a CacheProxy with no peers and a tempdir-backed store.


### PR DESCRIPTION
## Problem

`TestHandleConnectLogsOpenAndClose` flakes under `-race`:

```
WARNING: DATA RACE
Read at ... by goroutine ...:
  bytes.(*Buffer).String()
  ...TestHandleConnectLogsOpenAndClose()  proxy_test.go:1168
Previous write at ... by goroutine ...:
  bytes.(*Buffer).Write()
  log/slog.(*TextHandler).Handle()
```

Reproduces on unmodified `main`: 3/5 runs fail with `go test -race -count=5 -run TestHandleConnectLogsOpenAndClose ./cmd/cache-proxy/`.

Root cause: `captureSlog` installs a `slog.TextHandler` backed by a plain `bytes.Buffer`, but proxy handlers log from goroutines that outlive the request — the CONNECT close-logger fires after both tunnel legs finish, racing the test goroutine's `buf.String()` reads. The race is in the test harness, not the proxy: production slog writes to `os.Stderr`, which is concurrency-safe.

## Fix

Replace the plain `bytes.Buffer` with a mutex-guarded `syncBuffer` so handler `Write` calls serialize against test `String` reads. All five `captureSlog` call sites get the fix at once; no assertions or production code changed.

## Testing

- `go test -race -count=20 -run TestHandleConnect ./cmd/cache-proxy/` — clean (was 3/5 failing)
- `go test -race -count=1 ./cmd/cache-proxy/` — full package clean
- `just lint` — 0 issues
