### PR TITLE
feat(monitoring): expose managed warehouse state

### DIFF
--- a/controlplane/org_teams_info_metric.go
+++ b/controlplane/org_teams_info_metric.go
@@ -65,9 +65,10 @@ type orgTeamsSnapshotter interface {
 }
 
 type orgTeamsInfoCollector struct {
-	store    orgTeamsSnapshotter
-	teamDesc *prometheus.Desc
-	orgDesc  *prometheus.Desc
+	store         orgTeamsSnapshotter
+	teamDesc      *prometheus.Desc
+	orgDesc       *prometheus.Desc
+	warehouseDesc *prometheus.Desc
 }
 
 func newOrgTeamsInfoCollector(store orgTeamsSnapshotter) *orgTeamsInfoCollector {
@@ -84,12 +85,18 @@ func newOrgTeamsInfoCollector(store orgTeamsSnapshotter) *orgTeamsInfoCollector 
 			"Org/duckling identity mapping, one series per org with the oldest team as representative (constant 1). Safe one-side for group_left joins",
 			labels, nil,
 		),
+		warehouseDesc: prometheus.NewDesc(
+			"duckgres_managed_warehouse_state",
+			"Managed warehouse lifecycle state, one series per live warehouse (constant 1)",
+			[]string{"org", "duckling", "state"}, nil,
+		),
 	}
 }
 
 func (c *orgTeamsInfoCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.teamDesc
 	ch <- c.orgDesc
+	ch <- c.warehouseDesc
 }
 
 func (c *orgTeamsInfoCollector) Collect(ch chan<- prometheus.Metric) {
@@ -100,6 +107,12 @@ func (c *orgTeamsInfoCollector) Collect(ch chan<- prometheus.Metric) {
 	for orgID, org := range snap.Orgs {
 		if org == nil {
 			continue
+		}
+		if org.Warehouse != nil && org.Warehouse.State != configstore.ManagedWarehouseStateDeleted {
+			ch <- prometheus.MustNewConstMetric(
+				c.warehouseDesc, prometheus.GaugeValue, 1,
+				orgID, org.Warehouse.DucklingName, managedWarehouseMetricState(org.Warehouse.State),
+			)
 		}
 		duckling := ""
 		if org.Warehouse != nil && org.Warehouse.State != configstore.ManagedWarehouseStateDeleted {
@@ -117,6 +130,20 @@ func (c *orgTeamsInfoCollector) Collect(ch chan<- prometheus.Metric) {
 				orgID, duckling, strconv.FormatInt(oldest.TeamID, 10), oldest.SchemaName,
 			)
 		}
+	}
+}
+
+func managedWarehouseMetricState(state configstore.ManagedWarehouseProvisioningState) string {
+	switch state {
+	case configstore.ManagedWarehouseStatePending,
+		configstore.ManagedWarehouseStateProvisioning,
+		configstore.ManagedWarehouseStateReady,
+		configstore.ManagedWarehouseStateFailed,
+		configstore.ManagedWarehouseStateDeleting,
+		configstore.ManagedWarehouseStateResharding:
+		return string(state)
+	default:
+		return "unknown"
 	}
 }
 

--- a/controlplane/org_teams_info_metric_test.go
+++ b/controlplane/org_teams_info_metric_test.go
@@ -20,6 +20,45 @@ func TestOrgTeamsInfoCollector(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	snap := &configstore.Snapshot{
 		Orgs: map[string]*configstore.OrgConfig{
+			"org-deleting": {
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-deleting",
+					State:        configstore.ManagedWarehouseStateDeleting,
+				},
+			},
+			"org-failed": {
+				Teams: []configstore.OrgTeamConfig{
+					{TeamID: 12, SchemaName: "team_12", CreatedAt: t0},
+				},
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-failed",
+					State:        configstore.ManagedWarehouseStateFailed,
+				},
+			},
+			"org-pending": {
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-pending",
+					State:        configstore.ManagedWarehouseStatePending,
+				},
+			},
+			"org-provisioning": {
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-provisioning",
+					State:        configstore.ManagedWarehouseStateProvisioning,
+				},
+			},
+			"org-resharding": {
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-resharding",
+					State:        configstore.ManagedWarehouseStateResharding,
+				},
+			},
+			"org-unknown": {
+				Warehouse: &configstore.ManagedWarehouseConfig{
+					DucklingName: "org-unknown",
+					State:        configstore.ManagedWarehouseProvisioningState("unexpected"),
+				},
+			},
 			// Legacy tenant: duckling name is the org id with hyphens
 			// stripped — the case that makes the label non-derivable.
 			"4dc8564d-bd82-1065-2f40-97f7c50f67cf": {
@@ -69,14 +108,26 @@ func TestOrgTeamsInfoCollector(t *testing.T) {
 duckgres_org_info{duckling="",org="org-deleted",schema_name="team_9",team_id="9"} 1
 duckgres_org_info{duckling="",org="org-legacy",schema_name="team_7",team_id="7"} 1
 duckgres_org_info{duckling="4dc8564dbd8210652f4097f7c50f67cf",org="4dc8564d-bd82-1065-2f40-97f7c50f67cf",schema_name="team_2",team_id="2"} 1
+duckgres_org_info{duckling="org-failed",org="org-failed",schema_name="team_12",team_id="12"} 1
 duckgres_org_info{duckling="org-multi",org="org-multi",schema_name="team_11",team_id="11"} 1
 # HELP duckgres_org_teams_info Org/team/duckling identity mapping, one series per team (constant 1). Join key material for dashboards — see org_teams_info_metric.go for the safe join shapes
 # TYPE duckgres_org_teams_info gauge
 duckgres_org_teams_info{duckling="",org="org-deleted",schema_name="team_9",team_id="9"} 1
 duckgres_org_teams_info{duckling="",org="org-legacy",schema_name="team_7",team_id="7"} 1
 duckgres_org_teams_info{duckling="4dc8564dbd8210652f4097f7c50f67cf",org="4dc8564d-bd82-1065-2f40-97f7c50f67cf",schema_name="team_2",team_id="2"} 1
+duckgres_org_teams_info{duckling="org-failed",org="org-failed",schema_name="team_12",team_id="12"} 1
 duckgres_org_teams_info{duckling="org-multi",org="org-multi",schema_name="team_10",team_id="10"} 1
 duckgres_org_teams_info{duckling="org-multi",org="org-multi",schema_name="team_11",team_id="11"} 1
+# HELP duckgres_managed_warehouse_state Managed warehouse lifecycle state, one series per live warehouse (constant 1)
+# TYPE duckgres_managed_warehouse_state gauge
+duckgres_managed_warehouse_state{duckling="4dc8564dbd8210652f4097f7c50f67cf",org="4dc8564d-bd82-1065-2f40-97f7c50f67cf",state="ready"} 1
+duckgres_managed_warehouse_state{duckling="org-deleting",org="org-deleting",state="deleting"} 1
+duckgres_managed_warehouse_state{duckling="org-failed",org="org-failed",state="failed"} 1
+duckgres_managed_warehouse_state{duckling="org-multi",org="org-multi",state="ready"} 1
+duckgres_managed_warehouse_state{duckling="org-pending",org="org-pending",state="pending"} 1
+duckgres_managed_warehouse_state{duckling="org-provisioning",org="org-provisioning",state="provisioning"} 1
+duckgres_managed_warehouse_state{duckling="org-resharding",org="org-resharding",state="resharding"} 1
+duckgres_managed_warehouse_state{duckling="org-unknown",org="org-unknown",state="unknown"} 1
 `
 	c := newOrgTeamsInfoCollector(&stubSnapshotter{snap: snap})
 	if err := testutil.CollectAndCompare(c, strings.NewReader(want)); err != nil {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,6 +27,18 @@ The request path uses these label terms consistently:
 
 Histograms expose the usual `_bucket`, `_count`, and `_sum` series.
 
+## Managed warehouse state
+
+`duckgres_managed_warehouse_state{org,duckling,state}` is a Kubernetes-only
+gauge with value `1` for each warehouse that has not finished deletion. The
+state label is one of `pending`, `provisioning`, `ready`, `failed`, `deleting`,
+`resharding`, or `unknown`. Unexpected stored values map to `unknown` to keep
+metric cardinality bounded.
+
+Each control-plane replica emits the same snapshot-backed series. Use `max by`
+instead of `sum by` when evaluating warehouse state across replicas. A deleted
+warehouse disappears from the metric on the next snapshot refresh.
+
 ## Request path boundaries
 
 | Stage | Metrics | Boundary |


### PR DESCRIPTION
## Problem

- Operators learn about failed warehouse provisioning through downstream job errors because Duckgres exposes no warehouse lifecycle signal.

## Changes

- Emit one bounded state series for each non-deleted warehouse from the in-memory configuration snapshot.
- Preserve canonical lifecycle states and normalize unexpected values to `unknown`.
- Document replica deduplication and warehouse deletion behavior.
- [Charts #14367](https://github.com/PostHog/charts/pull/14367) uses the metric for regional alerting.

## Testing

- `just test-controlplane-k8s`
- `just lint`

## Agent context

- Codex authored this change and used read-only subagents to review state semantics, cardinality, and test coverage.
- The final test covers every canonical non-deleted state, deleted warehouses, missing warehouses, and unexpected states.
