### PR TITLE
fix: reconcile failed warehouses after dependency recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ column cannot be added to a populated table).
 - [Dev Scenario Runner](docs/runbooks/scenario-dev.md): Scheduled and manually dispatched scenario runs against the configured dev environment.
 - [Control Plane Rollout](docs/runbooks/control-plane-rollout.md): Zero-downtime deployment process for the control plane itself.
 - [Org Connection Admission](docs/runbooks/org-connection-admission.md): Global vCPU admission, exact cleanup ownership, failure recovery, and operational metrics.
+- [Managed Warehouse Provisioning Recovery](docs/runbooks/managed-warehouse-provisioning-recovery.md): Diagnose a failed warehouse whose Duckling dependencies were repaired and verify automatic convergence back to ready.
 - [Managed Warehouse Deprovision](docs/runbooks/managed-warehouse-deprovision.md): Destructive teardown process for managed warehouse infrastructure and org cleanup.
 - [Resharding Operations](docs/runbooks/resharding.md): Runner recovery, durable respawn reset, safety checks, and local verification.
 
@@ -1020,6 +1021,7 @@ Managed-warehouse contract notes:
 - The typed sections are `warehouse_database`, `metadata_store`, `s3`, `worker_identity`, and structured secret refs for `warehouse_database_credentials`, `metadata_store_credentials`, `s3_credentials`, and `runtime_config`. In shared worker mode, every non-empty secret ref must store an explicit `namespace`, and it must match `worker_identity.namespace`.
 - Secret references only are stored in the config store. Secret material remains outside the database.
 - The provisioning fields are stored directly on the warehouse row as overall `state` / `status_message`, per-resource `*_state` / `*_status_message`, plus `ready_at` and `failed_at`.
+- The Kubernetes provisioner polls every 10 seconds. A `failed` warehouse remains in its observation set: it stays failed while the Duckling, required status outputs, or worker-shaped metadata-store probe are unhealthy, and returns directly to `ready` after every readiness gate passes. The admin UI polls `pending`, `provisioning`, `failed`, and `deleting` warehouse rows every 5 seconds while they are visible.
 - Those state fields are open strings. Canonical values are `pending`, `provisioning`, `ready`, `failed`, `deleting`, and `deleted`, but callers may persist other values while workflows evolve.
 
 ## Two-Tier Query Processing

--- a/controlplane/admin/ui/src/components/AddOrgDialog.test.tsx
+++ b/controlplane/admin/ui/src/components/AddOrgDialog.test.tsx
@@ -138,7 +138,8 @@ describe("AddOrgDialog", () => {
     expect(await screen.findByDisplayValue("s3cret-once")).toBeInTheDocument();
     expect(screen.getByDisplayValue("root")).toBeInTheDocument();
     expect(screen.getByText(/never shown or retrievable again/i)).toBeInTheDocument();
-    // The in-flight warehouse status is watched until ready/failed.
+    // The in-flight warehouse status is watched until ready. Failed remains
+    // observable because external dependency repair can recover it.
     await waitFor(() => expect(client.warehouseStatus).toHaveBeenCalledWith(OK_UUID));
   });
 

--- a/controlplane/admin/ui/src/components/AddOrgDialog.tsx
+++ b/controlplane/admin/ui/src/components/AddOrgDialog.tsx
@@ -33,6 +33,7 @@ import {
 import { StateBadge } from "@/components/StateBadge";
 import { api } from "@/lib/api";
 import { databaseNameProblem } from "@/lib/databaseName";
+import { warehouseNeedsPolling } from "@/lib/warehouseLifecycle";
 import { useDatabaseNameAvailable, useWarehouseStatus } from "@/hooks/useApi";
 import type { ProvisionWarehouseBody, ProvisionWarehouseResult } from "@/types/api";
 
@@ -108,14 +109,15 @@ export function AddOrgDialog({ open, onClose }: { open: boolean; onClose: () => 
   const dbCheck = useDatabaseNameAvailable(trimmedDb, dbLookupEnabled);
   const dbTaken = dbCheck.data && !dbCheck.data.available;
 
-  // Optional post-submit watch of the asynchronous provisioning; stops polling
-  // at a terminal state.
+  // Optional post-submit watch of asynchronous provisioning. Failed is an
+  // observed state, not terminal: the backend can return to Ready after an
+  // externally repaired Duckling recovers, so keep polling it.
   const status = useWarehouseStatus(result?.org, {
     refetchInterval: watch ? 5_000 : false,
   });
   useEffect(() => {
     const s = status.data?.state;
-    if (s === "ready" || s === "failed") setWatch(false);
+    if (s && !warehouseNeedsPolling(s)) setWatch(false);
   }, [status.data?.state]);
 
   const reset = () => {

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -14,6 +14,7 @@ import { api, ApiError } from "@/lib/api";
 import { orgLabel } from "@/lib/format";
 import { POLL } from "@/lib/query";
 import { useRevealedCount } from "@/lib/logReplay";
+import { warehouseNeedsPolling } from "@/lib/warehouseLifecycle";
 import { useIdentity } from "@/components/IdentityProvider";
 import type {
   AuditEntry,
@@ -118,6 +119,8 @@ export function useOrgs() {
   return useQuery<Org[]>({
     queryKey: ["orgs"],
     queryFn: () => tolerate404<Org[]>([])(api.listOrgs()),
+    refetchInterval: (q) =>
+      q.state.data?.some((org) => warehouseNeedsPolling(org.warehouse?.state)) ? POLL.normal : false,
   });
 }
 
@@ -169,6 +172,7 @@ export function useWarehouse(id: string | undefined) {
     queryKey: ["orgs", id, "warehouse"],
     queryFn: () => tolerate404<ManagedWarehouse | null>(null)(api.getWarehouse(id!)),
     enabled: !!id,
+    refetchInterval: (q) => (warehouseNeedsPolling(q.state.data?.state) ? POLL.normal : false),
   });
 }
 

--- a/controlplane/admin/ui/src/lib/warehouseLifecycle.test.ts
+++ b/controlplane/admin/ui/src/lib/warehouseLifecycle.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { warehouseNeedsPolling } from "./warehouseLifecycle";
+
+describe("warehouseNeedsPolling", () => {
+  it("keeps failed warehouses live because external dependency recovery can change their state", () => {
+    expect(warehouseNeedsPolling("failed")).toBe(true);
+  });
+
+  it("polls active transitions but not stable terminal states", () => {
+    expect(warehouseNeedsPolling("pending")).toBe(true);
+    expect(warehouseNeedsPolling("provisioning")).toBe(true);
+    expect(warehouseNeedsPolling("deleting")).toBe(true);
+    expect(warehouseNeedsPolling("ready")).toBe(false);
+    expect(warehouseNeedsPolling("deleted")).toBe(false);
+  });
+});

--- a/controlplane/admin/ui/src/lib/warehouseLifecycle.ts
+++ b/controlplane/admin/ui/src/lib/warehouseLifecycle.ts
@@ -1,0 +1,8 @@
+// Warehouse states whose value can change without an admin-UI mutation. Failed
+// is intentionally included: the provisioner keeps observing externally
+// managed Duckling dependencies and returns the row to ready after recovery.
+const POLLED_WAREHOUSE_STATES = new Set(["pending", "provisioning", "failed", "deleting"]);
+
+export function warehouseNeedsPolling(state: string | null | undefined): boolean {
+  return state !== undefined && state !== null && POLLED_WAREHOUSE_STATES.has(state.toLowerCase());
+}

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -106,8 +106,8 @@ function warehouse(metadataProxyEnabled: boolean): ManagedWarehouse {
   } as ManagedWarehouse;
 }
 
-function renderPage(metadataProxyEnabled: boolean) {
-  hooks.useWarehouse.mockReturnValue(ok(warehouse(metadataProxyEnabled)));
+function renderPage(metadataProxyEnabled: boolean, warehouseOverrides: Partial<ManagedWarehouse> = {}) {
+  hooks.useWarehouse.mockReturnValue(ok({ ...warehouse(metadataProxyEnabled), ...warehouseOverrides }));
   render(
     <MemoryRouter initialEntries={["/orgs/acme"]}>
       <TooltipProvider>
@@ -148,6 +148,33 @@ describe("Org detail", () => {
     expect(within(headline).getByText("posthog")).toBeInTheDocument();
     expect(within(headline).getByText("acme")).toBeInTheDocument();
     expect(within(headline).getByRole("button", { name: /copy acme/i })).toBeInTheDocument();
+  });
+
+  it("distinguishes ready infrastructure components from an operational readiness blocker", () => {
+    const blocker =
+      "Infrastructure is ready, but metadata-store authentication failed; the PostgreSQL role password may not match its credential Secret. Waiting for recovery.";
+    renderPage(false, {
+      state: "failed",
+      metadata_store_state: "ready",
+      s3_state: "ready",
+      identity_state: "ready",
+      secrets_state: "ready",
+      status_message: blocker,
+      failed_at: "2026-08-14T10:18:09Z",
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("Warehouse is not operationally ready")).toBeInTheDocument();
+    expect(within(alert).getByText("Current blocker")).toBeInTheDocument();
+    expect(within(alert).getByText(blocker)).toBeInTheDocument();
+    expect(within(alert).getByText(/component badges reflect Duckling infrastructure/i)).toBeInTheDocument();
+    expect(within(alert).getByText(/recovery is checked automatically/i)).toBeInTheDocument();
+    expect(screen.getByText("Metadata store").parentElement).toHaveTextContent("ready");
+    expect(screen.getByText("S3").parentElement).toHaveTextContent("ready");
+    expect(screen.getByText("Identity").parentElement).toHaveTextContent("ready");
+    expect(screen.getByText("Secrets").parentElement).toHaveTextContent("ready");
+    expect(screen.getByText("Last ready")).toBeInTheDocument();
+    expect(screen.getByText("Last failed")).toBeInTheDocument();
   });
 
   it.each([

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -494,7 +494,7 @@ function WarehousePanel({
     : missing
       ? "No duckling provisioned for this org"
       : broken
-        ? `Duckling unhealthy (state: ${data?.state})`
+        ? `Managed warehouse not ready (state: ${data?.state})`
         : null;
 
   const ducklingNameEmpty = ducklingNameInput.trim() === "";
@@ -600,12 +600,37 @@ function WarehousePanel({
                   </div>
                 ))}
               </div>
-              {data.status_message && (
+              {data.state === "failed" ? (
+                <div
+                  role="alert"
+                  className="mt-3 flex gap-3 rounded-md border border-warning/40 bg-warning/10 p-3 text-warning"
+                >
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div className="space-y-1 text-xs">
+                    <p className="font-medium">Warehouse is not operationally ready</p>
+                    <p>
+                      <span className="font-medium">Current blocker</span>
+                    </p>
+                    <p className="font-mono text-foreground">
+                      {data.status_message || "No current blocker detail is available yet."}
+                    </p>
+                    <p className="text-muted-foreground">
+                      Component badges reflect Duckling infrastructure. Overall readiness also requires a successful
+                      end-to-end metadata-store connection check. Recovery is checked automatically; this page updates
+                      when dependencies recover.
+                    </p>
+                  </div>
+                </div>
+              ) : data.status_message ? (
                 <p className="mt-2 font-mono text-xs text-muted-foreground">{data.status_message}</p>
-              )}
+              ) : null}
               <div className="mt-2 flex gap-4 text-[11px] text-muted-foreground">
-                <span>ready: {data.ready_at ? fmtTime(data.ready_at) : "—"}</span>
-                <span>failed: {data.failed_at ? fmtTime(data.failed_at) : "—"}</span>
+                <span>
+                  <span className="font-medium">Last ready</span>: {data.ready_at ? fmtTime(data.ready_at) : "—"}
+                </span>
+                <span>
+                  <span className="font-medium">Last failed</span>: {data.failed_at ? fmtTime(data.failed_at) : "—"}
+                </span>
               </div>
             </div>
 

--- a/controlplane/provisioner/controller.go
+++ b/controlplane/provisioner/controller.go
@@ -153,10 +153,14 @@ func (c *Controller) Run(ctx context.Context) {
 // actionableStates are the warehouse states the controller acts on.
 // Ready is included so we can drift-correct user-mutable CR fields (today
 // just pgbouncer.enabled) without waiting for the Duckling to be recreated.
+// Failed remains actionable as an observation state: the controller leaves it
+// failed while the Duckling or end-to-end metadata path is unhealthy, but can
+// converge the row back to ready after externally managed dependencies recover.
 var actionableStates = []configstore.ManagedWarehouseProvisioningState{
 	configstore.ManagedWarehouseStatePending,
 	configstore.ManagedWarehouseStateProvisioning,
 	configstore.ManagedWarehouseStateReady,
+	configstore.ManagedWarehouseStateFailed,
 	configstore.ManagedWarehouseStateDeleting,
 }
 
@@ -178,6 +182,8 @@ func (c *Controller) reconcile(ctx context.Context) {
 			c.reconcileProvisioning(ctx, &w)
 		case configstore.ManagedWarehouseStateReady:
 			c.reconcileReady(ctx, &w)
+		case configstore.ManagedWarehouseStateFailed:
+			c.reconcileFailed(ctx, &w)
 		case configstore.ManagedWarehouseStateDeleting:
 			c.reconcileDeleting(ctx, &w)
 		}
@@ -238,7 +244,28 @@ func (c *Controller) reconcilePending(ctx context.Context, w *configstore.Manage
 }
 
 func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.ManagedWarehouse) {
-	log := slog.With("org", w.OrgID, "phase", "provisioning")
+	c.reconcileWarehouseReadiness(ctx, w, true)
+}
+
+// reconcileFailed observes a warehouse whose previous provisioning attempt
+// exhausted the work Duckgres could do itself. Failed remains sticky while the
+// Duckling or the end-to-end metadata path is still unhealthy. If those
+// externally managed dependencies later become fully healthy, run the same
+// readiness gates as provisioning and CAS directly back to Ready.
+//
+// Failure timers are deliberately disabled here: ProvisioningStartedAt records
+// the original attempt, so applying its 10/30-minute thresholds to recovery
+// would fail the row again before observing the repaired Duckling.
+func (c *Controller) reconcileFailed(ctx context.Context, w *configstore.ManagedWarehouse) {
+	c.reconcileWarehouseReadiness(ctx, w, false)
+}
+
+// reconcileWarehouseReadiness mirrors the Duckling's aggregate/component
+// readiness and runs the worker-shaped metadata probe. A normal provisioning
+// attempt may transition to Failed on its bounded timers; a failed-row recovery
+// only observes and may transition to Ready.
+func (c *Controller) reconcileWarehouseReadiness(ctx context.Context, w *configstore.ManagedWarehouse, failureTimersEnabled bool) {
+	log := slog.With("org", w.OrgID, "phase", w.State)
 
 	// Use ProvisioningStartedAt if set (tracks when we entered provisioning state),
 	// fall back to CreatedAt for warehouses created before this field existed.
@@ -248,7 +275,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 	}
 
 	// Check for timeout (30 minutes)
-	if time.Since(startedAt) > 30*time.Minute {
+	if failureTimersEnabled && time.Since(startedAt) > 30*time.Minute {
 		log.Warn("Provisioning timed out.")
 		err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateProvisioning, map[string]interface{}{
 			"state":          configstore.ManagedWarehouseStateFailed,
@@ -269,7 +296,7 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 	// Crossplane resources commonly flap Synced=False transiently (e.g., IAM
 	// eventual consistency, metadata-store endpoint DNS propagation), so we only transition
 	// to failed if 10+ minutes have passed, giving transient errors time to resolve.
-	if status.SyncedFalseMessage != "" && time.Since(startedAt) > 10*time.Minute {
+	if failureTimersEnabled && status.SyncedFalseMessage != "" && time.Since(startedAt) > 10*time.Minute {
 		log.Warn("Crossplane sync failure.", "message", status.SyncedFalseMessage)
 		err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateProvisioning, map[string]interface{}{
 			"state":          configstore.ManagedWarehouseStateFailed,
@@ -340,14 +367,18 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 			status.MetadataStore.Database,
 			probeSSLMode,
 		); err != nil {
+			blocker := metadataProbeStatusMessage(err)
 			log.Info("Infrastructure provisioned but end-to-end probe still failing — staying in provisioning.",
-				"pgbouncer_enabled", w.PgBouncer.Enabled, "error", err)
-			updates["status_message"] = "Provisioning in progress..."
+				"pgbouncer_enabled", w.PgBouncer.Enabled, "blocker", blocker)
+			if blocker != w.StatusMessage {
+				updates["status_message"] = blocker
+			}
 		} else {
 			now := time.Now().UTC()
 			updates["state"] = configstore.ManagedWarehouseStateReady
 			updates["status_message"] = "Infrastructure ready"
 			updates["ready_at"] = now
+			updates["failed_at"] = nil
 			log.Info("Infrastructure ready, transitioning to ready.", "pgbouncer_enabled", w.PgBouncer.Enabled)
 		}
 	} else if !status.ReadyCondition {
@@ -363,13 +394,13 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 	}
 
 	if len(updates) > 0 {
-		if err := c.store.UpdateWarehouseState(w.OrgID, configstore.ManagedWarehouseStateProvisioning, updates); err != nil {
+		if err := c.store.UpdateWarehouseState(w.OrgID, w.State, updates); err != nil {
 			log.Warn("Failed to update warehouse state.", "error", err)
 		} else if updates["state"] == configstore.ManagedWarehouseStateReady {
 			// Terminal success: the warehouse just flipped to Ready and is now
-			// usable. Guarded on a successful CAS from Provisioning, so this
-			// fires exactly once — the next tick routes a Ready warehouse to
-			// reconcileReady, not here.
+			// usable. Guarded on a successful CAS from the observed Provisioning
+			// or Failed state, so this fires exactly once — the next tick routes
+			// a Ready warehouse to reconcileReady, not here.
 			analytics.Default().Capture("warehouse_provision_success", w.OrgID, provisionEventProps(w))
 		}
 	}
@@ -379,6 +410,25 @@ func (c *Controller) reconcileProvisioning(ctx context.Context, w *configstore.M
 // statusMessageMaxLen bounds the diagnostic status message so a verbose provider
 // error can't overflow the status_message column (VARCHAR(1024)).
 const statusMessageMaxLen = 1000
+
+// metadataProbeStatusMessage turns an untrusted probe error into a fixed,
+// credential-safe operator message. Probe errors normally come from pgx, but
+// MetadataProbe is injectable and a future implementation could include a raw
+// DSN (and password) in Error(), so never interpolate the original text into a
+// persisted status or log field.
+func metadataProbeStatusMessage(err error) string {
+	if isAuthProbeError(err) {
+		return "Infrastructure is ready, but metadata-store authentication failed; the PostgreSQL role password may not match its credential Secret. Waiting for recovery."
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "Infrastructure is ready, but the metadata-store connection check timed out. Waiting for recovery."
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "no such host") || strings.Contains(msg, "server misbehaving") {
+		return "Infrastructure is ready, but the metadata-store endpoint could not be resolved. Waiting for recovery."
+	}
+	return "Infrastructure is ready, but the metadata-store connection check is still failing. Waiting for recovery."
+}
 
 // diagnoseNotReady builds a human-facing explanation of why a still-provisioning
 // warehouse is not Ready. It asks Kubernetes for the failing composed resources

--- a/controlplane/provisioner/controller_test.go
+++ b/controlplane/provisioner/controller_test.go
@@ -25,6 +25,14 @@ type fakeStore struct {
 	warehouses map[string]*configstore.ManagedWarehouse
 }
 
+type testSQLStateError struct {
+	code    string
+	message string
+}
+
+func (e testSQLStateError) Error() string    { return e.message }
+func (e testSQLStateError) SQLState() string { return e.code }
+
 func newFakeStore() *fakeStore {
 	return &fakeStore{warehouses: make(map[string]*configstore.ManagedWarehouse)}
 }
@@ -84,8 +92,12 @@ func (s *fakeStore) UpdateWarehouseState(orgID string, expectedState configstore
 			t := v.(time.Time)
 			w.ReadyAt = &t
 		case "failed_at":
-			t := v.(time.Time)
-			w.FailedAt = &t
+			if v == nil {
+				w.FailedAt = nil
+			} else {
+				t := v.(time.Time)
+				w.FailedAt = &t
+			}
 		case "provisioning_started_at":
 			t := v.(time.Time)
 			w.ProvisioningStartedAt = &t
@@ -597,6 +609,158 @@ func TestReconcileProvisioningAllReady(t *testing.T) {
 	}
 }
 
+// TestReconcileFailedRecoversWhenDucklingBecomesReady is the regression for a
+// repaired Duckling remaining permanently failed in the config store. Failed
+// warehouses must stay in the controller's working set and re-run the same
+// readiness + end-to-end checks as provisioning warehouses. The historical
+// provisioning timestamp is deliberately stale: recovery must not immediately
+// trip the original 30-minute provisioning timeout again.
+func TestReconcileFailedRecoversWhenDucklingBecomesReady(t *testing.T) {
+	dc, fakeK8s := newFakeDucklingClient()
+	fs := newFakeStore()
+	startedAt := time.Now().Add(-time.Hour)
+	failedAt := time.Now().Add(-20 * time.Minute)
+	fs.warehouses["org-recovered"] = &configstore.ManagedWarehouse{
+		OrgID:                 "org-recovered",
+		DucklingName:          "org-recovered",
+		State:                 configstore.ManagedWarehouseStateFailed,
+		S3State:               configstore.ManagedWarehouseStateProvisioning,
+		MetadataStoreState:    configstore.ManagedWarehouseStateProvisioning,
+		IdentityState:         configstore.ManagedWarehouseStateProvisioning,
+		SecretsState:          configstore.ManagedWarehouseStateProvisioning,
+		CreatedAt:             startedAt,
+		ProvisioningStartedAt: &startedAt,
+		FailedAt:              &failedAt,
+	}
+
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "k8s.posthog.com/v1alpha1",
+		"kind":       "Duckling",
+		"metadata": map[string]interface{}{
+			"name":      "org-recovered",
+			"namespace": ducklingNamespace,
+		},
+		"status": map[string]interface{}{
+			"metadataStore": map[string]interface{}{
+				"type":                "external",
+				"endpoint":            "org-recovered.cluster.example.internal",
+				"credentialSecretRef": testCredentialSecretRef("org-recovered"),
+				"user":                "postgres",
+				"database":            "postgres",
+			},
+			"dataStore": map[string]interface{}{
+				"type":       "s3bucket",
+				"bucketName": "org-recovered-bucket",
+			},
+			"iamRoleArn": "arn:aws:iam::123456789012:role/duckling-org-recovered",
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+			},
+		},
+	}}
+
+	ctx := context.Background()
+	if _, err := fakeK8s.Resource(ducklingGVR).Namespace(ducklingNamespace).Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create recovered Duckling: %v", err)
+	}
+
+	ctrl := NewControllerWithClient(fs, dc, time.Second)
+	ctrl.SetProbe(func(context.Context, string, string, string, string, string) error {
+		return testSQLStateError{
+			code:    "28P01",
+			message: "password authentication failed; password=must-not-reach-status",
+		}
+	})
+	ctrl.reconcile(ctx)
+	w := fs.warehouses["org-recovered"]
+	if got := w.State; got != configstore.ManagedWarehouseStateFailed {
+		t.Fatalf("state = %q while the end-to-end probe still fails, want failed", got)
+	}
+	if w.ReadyAt != nil {
+		t.Fatalf("ready_at = %v while the end-to-end probe still fails, want nil", w.ReadyAt)
+	}
+	if w.S3State != configstore.ManagedWarehouseStateReady ||
+		w.MetadataStoreState != configstore.ManagedWarehouseStateReady ||
+		w.SecretsState != configstore.ManagedWarehouseStateReady ||
+		w.IdentityState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("component states = s3:%q metadata:%q secrets:%q identity:%q, want live Duckling components ready",
+			w.S3State, w.MetadataStoreState, w.SecretsState, w.IdentityState)
+	}
+	wantBlocker := "Infrastructure is ready, but metadata-store authentication failed; the PostgreSQL role password may not match its credential Secret. Waiting for recovery."
+	if w.StatusMessage != wantBlocker {
+		t.Fatalf("status_message = %q, want %q", w.StatusMessage, wantBlocker)
+	}
+	if strings.Contains(w.StatusMessage, "must-not-reach-status") {
+		t.Fatalf("status_message leaked probe details: %q", w.StatusMessage)
+	}
+
+	ctrl.SetProbe(func(context.Context, string, string, string, string, string) error { return nil })
+	ctrl.reconcile(ctx)
+
+	w = fs.warehouses["org-recovered"]
+	if w.State != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("state = %q, want ready after the Duckling and end-to-end probe recovered", w.State)
+	}
+	if w.S3State != configstore.ManagedWarehouseStateReady ||
+		w.MetadataStoreState != configstore.ManagedWarehouseStateReady ||
+		w.SecretsState != configstore.ManagedWarehouseStateReady ||
+		w.IdentityState != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("component states = s3:%q metadata:%q secrets:%q identity:%q, want all ready",
+			w.S3State, w.MetadataStoreState, w.SecretsState, w.IdentityState)
+	}
+	if w.ReadyAt == nil {
+		t.Fatal("ready_at was not set on recovery")
+	}
+	if w.FailedAt != nil {
+		t.Fatalf("failed_at = %v, want cleared after recovery", w.FailedAt)
+	}
+	if w.StatusMessage != "Infrastructure ready" {
+		t.Fatalf("status_message = %q, want Infrastructure ready", w.StatusMessage)
+	}
+}
+
+func TestMetadataProbeStatusMessageNeverExposesRawProbeDetails(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "authentication",
+			err:  testSQLStateError{code: "28P01", message: "password authentication failed; password=top-secret"},
+			want: "Infrastructure is ready, but metadata-store authentication failed; the PostgreSQL role password may not match its credential Secret. Waiting for recovery.",
+		},
+		{
+			name: "timeout",
+			err:  context.DeadlineExceeded,
+			want: "Infrastructure is ready, but the metadata-store connection check timed out. Waiting for recovery.",
+		},
+		{
+			name: "dns",
+			err:  errors.New("dial tcp: lookup example.invalid: no such host"),
+			want: "Infrastructure is ready, but the metadata-store endpoint could not be resolved. Waiting for recovery.",
+		},
+		{
+			name: "unknown",
+			err:  errors.New("postgres://user:top-secret@example.invalid/db"),
+			want: "Infrastructure is ready, but the metadata-store connection check is still failing. Waiting for recovery.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metadataProbeStatusMessage(tc.err)
+			if got != tc.want {
+				t.Fatalf("metadataProbeStatusMessage() = %q, want %q", got, tc.want)
+			}
+			if strings.Contains(got, "top-secret") || strings.Contains(got, "postgres://") {
+				t.Fatalf("metadataProbeStatusMessage() leaked raw probe details: %q", got)
+			}
+		})
+	}
+}
+
 // TestReconcileProvisioningProbeFailsKeepsProvisioning verifies the controller
 // stays in the Provisioning state when the metadata-store probe fails — the
 // case our load test surfaced where the RDS reports Available but its DNS
@@ -674,8 +838,9 @@ func TestReconcileProvisioningProbeFailsKeepsProvisioning(t *testing.T) {
 	if w.MetadataStoreState != configstore.ManagedWarehouseStateReady {
 		t.Fatalf("expected metadata_store_state ready, got %q", w.MetadataStoreState)
 	}
-	if w.StatusMessage != "Provisioning in progress..." {
-		t.Fatalf("expected status_message to stay %q, got %q", "Provisioning in progress...", w.StatusMessage)
+	wantMessage := "Infrastructure is ready, but the metadata-store endpoint could not be resolved. Waiting for recovery."
+	if w.StatusMessage != wantMessage {
+		t.Fatalf("expected status_message %q, got %q", wantMessage, w.StatusMessage)
 	}
 	if w.ReadyAt != nil {
 		t.Fatalf("expected ready_at to remain unset, got %v", w.ReadyAt)

--- a/docs/runbooks/managed-warehouse-provisioning-recovery.md
+++ b/docs/runbooks/managed-warehouse-provisioning-recovery.md
@@ -1,0 +1,90 @@
+# Runbook: Managed Warehouse Provisioning Recovery
+
+Use this runbook when a managed warehouse is `failed` in the Duckgres API or
+admin UI after its Duckling infrastructure was repaired externally. The checks
+below are read-only. Replace every placeholder explicitly; never rely on the
+current kubectl context.
+
+## Setup
+
+```bash
+TARGET_CONTEXT=<target-k8s-context>
+ORG=<org-id>
+DUCKLING=<duckling-cr-name>
+API_BASE=<admin-api-base-url>
+```
+
+## Diagnose
+
+1. Confirm the exact context, namespace, and Duckling aggregate conditions.
+
+```bash
+kubectl --context "$TARGET_CONTEXT" config current-context
+kubectl --context "$TARGET_CONTEXT" -n ducklings get ducklings.k8s.posthog.com "$DUCKLING"
+kubectl --context "$TARGET_CONTEXT" -n ducklings get ducklings.k8s.posthog.com "$DUCKLING" \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{" reason="}{.reason}{" message="}{.message}{"\n"}{end}'
+```
+
+The Duckling must report both `Synced=True` and `Ready=True`. If either is
+false, inspect the referenced composed resources before expecting Duckgres to
+recover:
+
+```bash
+kubectl --context "$TARGET_CONTEXT" -n ducklings get ducklings.k8s.posthog.com "$DUCKLING" \
+  -o jsonpath='{range .spec.crossplane.resourceRefs[*]}{.apiVersion}{" "}{.kind}{" "}{.name}{"\n"}{end}'
+```
+
+2. Check the persisted warehouse state through the API.
+
+```bash
+curl -sS "$API_BASE/api/v1/orgs/$ORG/warehouse/status" \
+  -H "X-Duckgres-Internal-Secret: $DUCKGRES_INTERNAL_SECRET" \
+  | jq '{state,status_message,ready_at,failed_at}'
+```
+
+3. Wait for automatic convergence. The provisioner observes failed warehouses
+every 10 seconds. It requires the Duckling aggregate Ready condition, the S3
+bucket, metadata endpoint and credential, worker IAM role, and a successful
+metadata-store connection probe. It keeps the row failed until all gates pass,
+then atomically changes it to ready and clears `failed_at`. While the probe is
+blocked, `status_message` reports a fixed, credential-safe category such as
+authentication, DNS resolution, or timeout; it never persists the raw probe
+error or connection string.
+
+```bash
+while true; do
+  curl -sS "$API_BASE/api/v1/orgs/$ORG/warehouse/status" \
+    -H "X-Duckgres-Internal-Secret: $DUCKGRES_INTERNAL_SECRET" \
+    | jq '{state,status_message,ready_at,failed_at}'
+  sleep 10
+done
+```
+
+The admin UI refreshes a visible failed warehouse every 5 seconds. A page
+reload should not be necessary.
+
+## If Recovery Does Not Complete
+
+- `Ready=False`: continue with the Duckling or composed-resource message; the
+  controller intentionally preserves `failed`.
+- `Ready=True` but Duckgres remains failed: verify that the status contains the
+  bucket, metadata connection fields and credential Secret reference, and IAM
+  role. Then inspect control-plane logs for the end-to-end metadata probe error.
+- Kubernetes read or Secret resolution errors: fix API/RBAC/Secret availability;
+  the next controller tick retries observation.
+- Do not edit the config-store state by hand. That bypasses the same readiness
+  and connection checks that protect worker activation.
+
+## Local Verification
+
+The regression and full Kubernetes-tagged control-plane suite run with:
+
+```bash
+just test-controlplane-k8s
+```
+
+The admin polling behavior, typecheck, and production UI build run with:
+
+```bash
+just ui-test
+```


### PR DESCRIPTION
## Summary

- keep failed managed warehouses in the provisioner observation set and return them to ready only after Duckling outputs and the end-to-end metadata-store probe recover
- persist credential-safe authentication, DNS, timeout, and generic readiness blockers while refreshing component states
- keep failed warehouse views polling and present the current blocker clearly in the admin UI
- document the recovery and failure-triage workflow

## Testing

- just test-controlplane-k8s
- just ui-test
- just lint