### PR TITLE
fix(e2e): avoid cold burst readiness race

### DIFF
--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2525,19 +2525,6 @@ cold_burst_parallel_spawns() { # org password
   ( if pg_try "$1" "$2" ducklake "$cq" >"$cb3" 2>&1; then echo 0 >"$cbr3"; else echo 1 >"$cbr3"; fi ) &
   cp3=$!
 
-  # While the queries run, the org must reach 3 simultaneous worker pods —
-  # one per cold connection (one session per worker; no sharing).
-  cpeak=0 ca=0
-  while [ "$ca" -lt 300 ]; do
-    kill -0 "$cp1" 2>/dev/null || break
-    kill -0 "$cp2" 2>/dev/null || break
-    kill -0 "$cp3" 2>/dev/null || break
-    cc="$(k get pods -l "duckgres/active-org=$1" --no-headers 2>/dev/null | grep -c . || true)"
-    [ "$cc" -gt "$cpeak" ] && cpeak="$cc"
-    [ "$cpeak" -ge 3 ] && break
-    sleep 1; ca=$((ca + 1))
-  done
-
   wait "$cp1" 2>/dev/null || true
   wait "$cp2" 2>/dev/null || true
   wait "$cp3" 2>/dev/null || true
@@ -2547,8 +2534,6 @@ cold_burst_parallel_spawns() { # org password
     cn="$(tr -dc '0-9' <"$f")"
     [ "$cn" = "$HEAVY_EXPECT" ] || fail "cold_burst_parallel_spawns: wrong result $cn want $HEAVY_EXPECT"
   done
-  [ "$cpeak" -ge 3 ] \
-    || fail "cold_burst_parallel_spawns: org peaked at $cpeak worker pod(s) for 3 concurrent cold connections — burst did not land on distinct workers"
 
   # Parallelism: the burst's first 3 pods must have been CREATED within a
   # narrow window. ISO-8601 creationTimestamps sort lexicographically; take the
@@ -2567,7 +2552,7 @@ cold_burst_parallel_spawns() { # org password
   [ "$cspread" -le 30 ] \
     || fail "cold_burst_parallel_spawns: pod creation spread ${cspread}s (first=$cfirst third=$cthird) — spawns ramped sequentially, not in parallel"
   rm -f "$cb1" "$cb2" "$cb3" "$cbr1" "$cbr2" "$cbr3"
-  log "parallel cold-burst spawn ramp: OK (peak $cpeak pods, creation spread ${cspread}s)"
+  log "parallel cold-burst spawn ramp: OK (creation spread ${cspread}s)"
 }
 
 # Data committed to DuckLake survives a worker restart (parquet in object store +

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -853,6 +853,63 @@ exit 1
 	}
 }
 
+func TestE2EHarnessColdBurstAcceptsStaggeredWorkerReadiness(t *testing.T) {
+	raw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read e2e harness: %v", err)
+	}
+
+	harness := strings.Replace(string(raw), "\nstart_kubectl_download\nk() {", "\nKUBECTL=\"${TEST_KUBECTL:?}\"\nk() {", 1)
+	harness = strings.Replace(harness, "\nmain \"$@\"\n", "\nkill() { return 1; }\ncold_burst_parallel_spawns test-org test-password\n", 1)
+	if harness == string(raw) {
+		t.Fatal("could not prepare cold-burst harness fixture")
+	}
+
+	dir := t.TempDir()
+	harnessPath := filepath.Join(dir, "harness.sh")
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o755); err != nil {
+		t.Fatalf("write harness fixture: %v", err)
+	}
+
+	kubectlPath := filepath.Join(dir, "kubectl")
+	writeFake(t, dir, "kubectl", `#!/usr/bin/env bash
+case "$*" in
+  *"delete pods -l app=duckgres-worker,duckgres/active-org=test-org"*|*"wait --for=delete pods -l app=duckgres-worker,duckgres/active-org=test-org"*)
+    exit 0
+    ;;
+  *"get pods -l app=duckgres-worker,duckgres/active-org=test-org"*"-o jsonpath="*)
+    printf '%s' '2024-01-01T00:00:00Z 2024-01-01T00:00:01Z 2024-01-01T00:00:02Z'
+    exit 0
+    ;;
+esac
+echo "unexpected kubectl invocation: $*" >&2
+exit 1
+`)
+	writeFake(t, dir, "psql", "#!/usr/bin/env sh\nprintf 1500000000\n")
+	writeFake(t, dir, "date", `#!/usr/bin/env sh
+case "$*" in
+  *"2024-01-01T00:00:00Z"*) printf 100 ;;
+  *"2024-01-01T00:00:02Z"*) printf 102 ;;
+  *) exit 1 ;;
+esac
+`)
+
+	cmd := exec.Command("sh", harnessPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_KUBECTL="+kubectlPath,
+		"CP_API=http://test.invalid",
+		"CP_PG_HOST=control-plane.test",
+		"INTERNAL_SECRET=test-secret",
+		"NAMESPACE=test-namespace",
+		"PR_NUMBER=123",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cold burst rejected three distinct parallel-created workers after their clients exited: %v\n%s", err, out)
+	}
+}
+
 func TestE2EHarnessCoversRemoteBinaryCopy(t *testing.T) {
 	harnessRaw, err := os.ReadFile("e2e/harness.sh")
 	if err != nil {


### PR DESCRIPTION
## Problem

The managed-warehouse E2E can fail after parallel workers spawn correctly because it requires their ready lifetimes to overlap.

## Changes

- Remove the simultaneous active-pod assertion.
- Keep the query-result, worker-count, and 30-second creation-spread checks.
- Add a deterministic harness test for staggered worker readiness.

## How did you test this code?

- Ran the focused regression test 20 consecutive times.
- Ran `just test-unit`.
- Ran `just lint`.

## 🤖 Agent context

- An agent investigated the CI failure in an isolated worktree and implemented the fix.
- I reviewed the diff and applied the debugging, flaky-test, test-design, comment, and PR-description skills.
