### PR TITLE
Add best-effort org-local worker placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Run with config file:
 | `DUCKGRES_EXPLORATORY_WORKER_CPU` | CPU request/limit of the exploratory worker pod (e.g. `1`, `500m`). Required (with the memory knob) for the tier to activate; a missing or invalid value logs a warning and leaves the tier OFF. Env-only. | - |
 | `DUCKGRES_EXPLORATORY_WORKER_MEMORY` | Memory request/limit of the exploratory worker pod (e.g. `2Gi`). Same requirement as the CPU knob. Env-only. | - |
 | `DUCKGRES_EXPLORATORY_WORKER_TTL` | Hot-idle TTL of exploratory worker pods (Go duration) — how long one stays parked for the org's next connection after its last one ends. Env-only. | `48h` |
+| `DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED` | Deployment-wide static preference for new trusted org-bound workers to land on a hostname already running a worker for that org. It never creates a required scheduling constraint. Env-only. | `false` |
+| `DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT` | Weight for the preferred same-org worker pod-affinity term. Must be within `[1,100]`. Env-only. | `100` |
 | `POSTHOG_API_KEY` | PostHog project API key (`phc_...`); enables log export **and product-analytics events**. Application logs carry query text — to get events without exporting SQL, leave this unset and use `POSTHOG_ANALYTICS_API_KEY` | - |
 | `POSTHOG_ANALYTICS_API_KEY` | PostHog project API key for product-analytics events **only**, leaving log export off. Takes precedence over `POSTHOG_API_KEY` for analytics | - |
 | `POSTHOG_HOST` | PostHog ingest host (shared by both exporters) | `us.i.posthog.com` |

--- a/cmd/duckgres-controlplane/main.go
+++ b/cmd/duckgres-controlplane/main.go
@@ -266,6 +266,8 @@ func main() {
 			WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,
 			WorkerTolerationKey:          resolved.K8sWorkerTolerationKey,
 			WorkerTolerationValue:        resolved.K8sWorkerTolerationValue,
+			WorkerOrgAffinityEnabled:     resolved.K8sWorkerOrgAffinityEnabled,
+			WorkerOrgAffinityWeight:      resolved.K8sWorkerOrgAffinityWeight,
 			AllowClientWorkerProfile:     resolved.K8sAllowClientWorkerProfile,
 			WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 			PlaceholderImage:             resolved.K8sPlaceholderImage,

--- a/configresolve/resolve.go
+++ b/configresolve/resolve.go
@@ -106,6 +106,8 @@ type Resolved struct {
 	K8sWorkerNodeSelector           string
 	K8sWorkerTolerationKey          string
 	K8sWorkerTolerationValue        string
+	K8sWorkerOrgAffinityEnabled     bool
+	K8sWorkerOrgAffinityWeight      int
 	K8sAllowClientWorkerProfile     bool
 	K8sWorkerPriorityClassName      string
 	K8sPlaceholderImage             string
@@ -207,6 +209,8 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	k8sWorkerServiceAccount := controlplane.DefaultK8sWorkerServiceAccount
 	var k8sWorkerCPURequest, k8sWorkerMemoryRequest string
 	var k8sWorkerNodeSelector, k8sWorkerTolerationKey, k8sWorkerTolerationValue string
+	var k8sWorkerOrgAffinityEnabled bool
+	k8sWorkerOrgAffinityWeight := 100
 	var k8sReshardPodCPU, k8sReshardPodMemory string
 	var k8sExploratoryTierEnabled bool
 	var k8sExploratoryWorkerCPU, k8sExploratoryWorkerMemory string
@@ -800,6 +804,24 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 	if v := getenv("DUCKGRES_K8S_WORKER_TOLERATION_VALUE"); v != "" {
 		k8sWorkerTolerationValue = v
 	}
+	// Env-only and deployment-wide: this is not an org-scoped feature flag.
+	if v := getenv("DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			k8sWorkerOrgAffinityEnabled = b
+		} else {
+			warn("Invalid DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED: " + err.Error())
+		}
+	}
+	if v := getenv("DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			// Preserve invalid numeric values so startup validation rejects the
+			// deployment instead of silently changing scheduling behavior.
+			k8sWorkerOrgAffinityWeight = n
+		} else {
+			warn("Invalid DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT: " + err.Error())
+			k8sWorkerOrgAffinityWeight = 0
+		}
+	}
 	// Reshard runner pod shape (env-only, like the other pod-scheduling knobs):
 	// the dedicated duckgres-reshard-op-<id> pods' requests=limits. Empty →
 	// built-in defaults (2 CPU / 8Gi).
@@ -1175,6 +1197,8 @@ func ResolveEffective(fileCfg *configloader.FileConfig, cli CLIInputs, getenv fu
 		K8sWorkerNodeSelector:           k8sWorkerNodeSelector,
 		K8sWorkerTolerationKey:          k8sWorkerTolerationKey,
 		K8sWorkerTolerationValue:        k8sWorkerTolerationValue,
+		K8sWorkerOrgAffinityEnabled:     k8sWorkerOrgAffinityEnabled,
+		K8sWorkerOrgAffinityWeight:      k8sWorkerOrgAffinityWeight,
 		K8sAllowClientWorkerProfile:     k8sAllowClientWorkerProfile,
 		K8sWorkerPriorityClassName:      k8sWorkerPriorityClassName,
 		K8sPlaceholderImage:             k8sPlaceholderImage,

--- a/configresolve/resolve_k8s_test.go
+++ b/configresolve/resolve_k8s_test.go
@@ -60,6 +60,48 @@ func TestResolveEffectiveParsesK8sWorkerMaxTTL(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveK8sWorkerOrgAffinityDefaultsAndValidatesWeight(t *testing.T) {
+	resolved := ResolveEffective(nil, CLIInputs{}, func(string) string { return "" }, nil)
+	if resolved.K8sWorkerOrgAffinityEnabled {
+		t.Fatal("org affinity must default to disabled")
+	}
+	if resolved.K8sWorkerOrgAffinityWeight != 100 {
+		t.Fatalf("default org affinity weight = %d, want 100", resolved.K8sWorkerOrgAffinityWeight)
+	}
+
+	var warned []string
+	resolved = ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		switch key {
+		case "DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED":
+			return "true"
+		case "DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT":
+			return "73"
+		default:
+			return ""
+		}
+	}, func(message string) { warned = append(warned, message) })
+	if !resolved.K8sWorkerOrgAffinityEnabled || resolved.K8sWorkerOrgAffinityWeight != 73 {
+		t.Fatalf("enabled org affinity = enabled:%v weight:%d", resolved.K8sWorkerOrgAffinityEnabled, resolved.K8sWorkerOrgAffinityWeight)
+	}
+	if len(warned) != 0 {
+		t.Fatalf("unexpected configuration warnings: %v", warned)
+	}
+
+	warned = nil
+	resolved = ResolveEffective(nil, CLIInputs{}, func(key string) string {
+		if key == "DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT" {
+			return "101"
+		}
+		return ""
+	}, func(message string) { warned = append(warned, message) })
+	if resolved.K8sWorkerOrgAffinityWeight != 101 {
+		t.Fatalf("invalid configured weight must reach startup validation, got %d", resolved.K8sWorkerOrgAffinityWeight)
+	}
+	if len(warned) != 0 {
+		t.Fatalf("out-of-range weight should be rejected by startup validation, not silently reset: %v", warned)
+	}
+}
+
 func TestResolveEffectiveParsesClientIdleTimeoutMax(t *testing.T) {
 	var warned []string
 	resolved := ResolveEffective(nil, CLIInputs{}, func(key string) string {

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -161,6 +161,8 @@ type K8sConfig struct {
 	WorkerNodeSelector      string // JSON map for worker pod nodeSelector (e.g., '{"posthog.com/nodepool":"workers"}')
 	WorkerTolerationKey     string // Taint key for worker pod NoSchedule toleration
 	WorkerTolerationValue   string // Taint value for worker pod NoSchedule toleration
+	WorkerOrgAffinityEnabled bool // Prefer same-org workers on the same hostname. Deployment-wide; default false.
+	WorkerOrgAffinityWeight  int  // Preferred same-org pod-affinity weight, validated in [1,100].
 	WorkerPriorityClassName string // PriorityClass for worker pods, so they preempt overprovision headroom pause pods (empty = none)
 	AWSRegion               string // AWS region for STS client
 
@@ -346,6 +348,12 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 	if err := validateWorkerBackendConfig(cfg); err != nil {
 		slog.Error("Invalid worker backend configuration.", "error", err)
 		os.Exit(1)
+	}
+	if cfg.WorkerBackend == "remote" {
+		if err := validateK8sWorkerOrgAffinityConfig(cfg); err != nil {
+			slog.Error("Invalid Kubernetes worker placement configuration.", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	isK8s := cfg.WorkerBackend == "remote"

--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -73,6 +73,8 @@ type K8sWorkerPool struct {
 	workerNodeSelector      map[string]string // node selector for worker pods
 	workerTolerationKey     string            // taint key for NoSchedule toleration
 	workerTolerationValue   string            // taint value for NoSchedule toleration
+	workerOrgAffinityEnabled bool             // add soft same-org pod affinity to trusted org-bound workers
+	workerOrgAffinityWeight  int              // preferred same-org pod-affinity weight, validated at control-plane startup
 	workerPriorityClassName string            // PriorityClass for worker pods (preempts overprovision pause pods)
 
 	// Headroom controller holds preemptible low-priority placeholder pods so a
@@ -195,6 +197,8 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		workerNodeSelector:      cfg.WorkerNodeSelector,
 		workerTolerationKey:     cfg.WorkerTolerationKey,
 		workerTolerationValue:   cfg.WorkerTolerationValue,
+		workerOrgAffinityEnabled: cfg.WorkerOrgAffinityEnabled,
+		workerOrgAffinityWeight:  cfg.WorkerOrgAffinityWeight,
 		workerPriorityClassName: cfg.WorkerPriorityClassName,
 
 		placeholderImage:             cfg.PlaceholderImage,

--- a/controlplane/k8s_pool_acquire.go
+++ b/controlplane/k8s_pool_acquire.go
@@ -568,6 +568,10 @@ func (p *K8sWorkerPool) adoptClaimedWorker(ctx context.Context, claimed *configs
 	if err != nil {
 		return nil, fmt.Errorf("get claimed worker pod %s: %w", claimed.PodName, err)
 	}
+	// Claimed worker records are durable trusted assignment state. Backfill the
+	// scheduling-only label before reusing a pre-existing worker; do not infer
+	// the org from active-org or any other pod label.
+	stampWorkerPlacementOrgLabel(ctx, p.clientset, p.namespace, claimed.PodName, claimed.OrgID, pod.Labels)
 
 	// For hot-idle workers, skip the epoch-validated health check. The worker's
 	// epoch and CP instance ID are from the previous owner, and ClaimHotIdleWorker

--- a/controlplane/k8s_pool_reconcile.go
+++ b/controlplane/k8s_pool_reconcile.go
@@ -222,6 +222,10 @@ func (p *K8sWorkerPool) cleanupOrphanedWorkerPods(ctx context.Context, minAge ti
 		outcome := StrandedOutcomeDeletedMissingRow
 		if rec != nil {
 			if rec.State != configstore.WorkerStateRetired && rec.State != configstore.WorkerStateLost {
+				// The durable record is the only trusted source for this metadata.
+				// Reconciliation must not infer an org from active-org, whose
+				// authorization semantics are intentionally separate.
+				stampWorkerPlacementOrgLabel(ctx, p.clientset, p.namespace, pod.Name, rec.OrgID, pod.Labels)
 				// Pod is still claimed by an active runtime row — not
 				// stranded. Record it under "kept" so dashboards can
 				// see reconciler saturation (large kept counts =

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -35,6 +35,13 @@ func (p *K8sWorkerPool) SpawnWorker(ctx context.Context, id int, image string) e
 }
 
 func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, profile WorkerProfile, publishIdle bool) error {
+	return p.spawnWorkerForOrg(ctx, id, image, profile, publishIdle, "")
+}
+
+// spawnWorkerForOrg creates a worker pod for a trusted assignment org. Callers
+// without assignment state must pass an empty org ID; the placement label is
+// scheduler metadata only and is never inferred from pod labels.
+func (p *K8sWorkerPool) spawnWorkerForOrg(ctx context.Context, id int, image string, profile WorkerProfile, publishIdle bool, orgID string) error {
 	// Test seam: lets unit tests stub pod creation (register the worker in
 	// p.workers themselves) without a real K8s spawn / pod-ready wait.
 	if p.spawnWorkerFunc != nil {
@@ -72,6 +79,9 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 	}
 	if p.orgID != "" {
 		podLabels["duckgres/org"] = p.orgID
+	}
+	if orgID != "" {
+		podLabels[placementOrgLabelKey] = placementOrgLabelValue(orgID)
 	}
 
 	// Resolve the pod's resource shape once: the container Resources AND the
@@ -166,6 +176,7 @@ func (p *K8sWorkerPool) spawnWorker(ctx context.Context, id int, image string, p
 		Name:  "DUCKGRES_SHARED_WARM_WORKER",
 		Value: "true",
 	})
+	p.addWorkerOrgPlacementAffinity(pod, orgID)
 
 	// Pre-session memory hygiene. Without an explicit DUCKGRES_MEMORY_LIMIT the
 	// worker's ConfigureMainDB falls back to sysinfo.AutoMemoryLimit(), which
@@ -436,6 +447,46 @@ func controlPlaneIDLabelValue(cpInstanceID string) string {
 	return prefix + "-" + suffix
 }
 
+// placementOrgLabelKey is scheduling metadata for org-bound workers. It must
+// never be used as authorization data; duckgres/active-org remains the
+// activation-time network-policy label.
+const placementOrgLabelKey = "duckgres/placement-org"
+
+// placementOrgLabelValue uses the same Kubernetes label-value safety rules as
+// control-plane identity labels. The same canonical value is used both on the
+// pod and in its affinity selector.
+func placementOrgLabelValue(orgID string) string {
+	return controlPlaneIDLabelValue(orgID)
+}
+
+// addWorkerOrgPlacementAffinity appends one soft same-org preference without
+// replacing any affinity fields the pod already has. An empty org means there
+// is no trusted placement identity, so scheduling is left unchanged.
+func (p *K8sWorkerPool) addWorkerOrgPlacementAffinity(pod *corev1.Pod, orgID string) {
+	if pod == nil || !p.workerOrgAffinityEnabled || orgID == "" {
+		return
+	}
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+	if pod.Spec.Affinity.PodAffinity == nil {
+		pod.Spec.Affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+	pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		corev1.WeightedPodAffinityTerm{
+			Weight: int32(p.workerOrgAffinityWeight),
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					placementOrgLabelKey: placementOrgLabelValue(orgID),
+				}},
+				Namespaces:  []string{p.namespace},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	)
+}
+
 // createPodWithBackoff creates a pod, retrying transient K8s API errors
 // with exponential backoff (500ms, 1s, 2s, 4s).
 func (p *K8sWorkerPool) createPodWithBackoff(ctx context.Context, pod *corev1.Pod) error {
@@ -616,7 +667,7 @@ func (p *K8sWorkerPool) spawnReservedWorkerForSlot(ctx context.Context, id int, 
 	}
 	p.spawning++
 	p.mu.Unlock()
-	err = p.spawnWorker(ctx, id, assignment.Image, profile, false)
+	err = p.spawnWorkerForOrg(ctx, id, assignment.Image, profile, false, assignment.OrgID)
 	p.mu.Lock()
 	p.spawning--
 	p.mu.Unlock()

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -293,6 +293,8 @@ func SetupMultiTenant(
 		WorkerNodeSelector:           parseNodeSelector(cfg.K8s.WorkerNodeSelector),
 		WorkerTolerationKey:          cfg.K8s.WorkerTolerationKey,
 		WorkerTolerationValue:        cfg.K8s.WorkerTolerationValue,
+		WorkerOrgAffinityEnabled:     cfg.K8s.WorkerOrgAffinityEnabled,
+		WorkerOrgAffinityWeight:      cfg.K8s.WorkerOrgAffinityWeight,
 		WorkerPriorityClassName:      cfg.K8s.WorkerPriorityClassName,
 		PlaceholderImage:             cfg.K8s.PlaceholderImage,
 		PlaceholderPriorityClassName: cfg.K8s.PlaceholderPriorityClassName,

--- a/controlplane/org_placement_test.go
+++ b/controlplane/org_placement_test.go
@@ -1,0 +1,235 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestK8sPoolReservedSpawnAddsPlacementLabelAndAffinityBeforeCreate(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	pool.workerOrgAffinityEnabled = true
+	pool.workerOrgAffinityWeight = 37
+	pool.workerNodeSelector = map[string]string{"example.com/pool": "workers"}
+	pool.workerTolerationKey = "example.com/dedicated"
+	pool.workerTolerationValue = "workers"
+	pool.workerPriorityClassName = "worker-priority"
+
+	var created *corev1.Pod
+	cs.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := create.GetObject().(*corev1.Pod)
+		if !ok || pod.Labels["app"] != "duckgres-worker" {
+			return false, nil, nil
+		}
+		created = pod.DeepCopy()
+		return true, nil, errors.New("stop after capture")
+	})
+
+	_, err := pool.spawnReservedWorkerForSlot(context.Background(), 41, &WorkerAssignment{
+		OrgID: "org-a",
+		Image: "duckgres:test",
+	})
+	if err == nil {
+		t.Fatal("reserved spawn unexpectedly succeeded")
+	}
+	if created == nil {
+		t.Fatal("worker pod was not submitted to Kubernetes")
+	}
+
+	if got := created.Labels[placementOrgLabelKey]; got != "org-a" {
+		t.Fatalf("placement label = %q, want org-a", got)
+	}
+	if _, ok := created.Labels[activeOrgLabelKey]; ok {
+		t.Fatalf("new worker must not treat placement metadata as active-org authorization: %#v", created.Labels)
+	}
+
+	if created.Spec.Affinity == nil || created.Spec.Affinity.PodAffinity == nil {
+		t.Fatal("expected pod affinity on an org-bound worker")
+	}
+	terms := created.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 1 {
+		t.Fatalf("preferred pod-affinity terms = %d, want 1", len(terms))
+	}
+	term := terms[0]
+	if term.Weight != 37 {
+		t.Fatalf("affinity weight = %d, want 37", term.Weight)
+	}
+	if term.PodAffinityTerm.TopologyKey != "kubernetes.io/hostname" {
+		t.Fatalf("topology key = %q", term.PodAffinityTerm.TopologyKey)
+	}
+	if !reflect.DeepEqual(term.PodAffinityTerm.Namespaces, []string{"default"}) {
+		t.Fatalf("affinity namespaces = %#v, want worker namespace", term.PodAffinityTerm.Namespaces)
+	}
+	if !reflect.DeepEqual(term.PodAffinityTerm.LabelSelector.MatchLabels, map[string]string{placementOrgLabelKey: "org-a"}) {
+		t.Fatalf("affinity selector = %#v", term.PodAffinityTerm.LabelSelector)
+	}
+	if created.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Fatal("placement must never add required pod affinity")
+	}
+
+	if got := created.Spec.NodeSelector["example.com/pool"]; got != "workers" {
+		t.Fatalf("node selector = %#v", created.Spec.NodeSelector)
+	}
+	if len(created.Spec.Tolerations) != 1 || created.Spec.Tolerations[0].Key != "example.com/dedicated" {
+		t.Fatalf("tolerations = %#v", created.Spec.Tolerations)
+	}
+	if created.Spec.PriorityClassName != "worker-priority" {
+		t.Fatalf("priority class = %q", created.Spec.PriorityClassName)
+	}
+	if cpu := created.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; cpu.Cmp(resource.MustParse(defaultWorkerCPU)) != 0 {
+		t.Fatalf("cpu request = %s, want %s", cpu.String(), defaultWorkerCPU)
+	}
+}
+
+func TestK8sPoolReservedSpawnWithoutTrustedOrgHasNoPlacementMetadataOrAffinity(t *testing.T) {
+	pool, cs := newTestK8sPool(t, 5)
+	pool.workerOrgAffinityEnabled = true
+
+	var created *corev1.Pod
+	cs.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := create.GetObject().(*corev1.Pod)
+		if !ok || pod.Labels["app"] != "duckgres-worker" {
+			return false, nil, nil
+		}
+		created = pod.DeepCopy()
+		return true, nil, errors.New("stop after capture")
+	})
+
+	_, _ = pool.spawnReservedWorkerForSlot(context.Background(), 42, &WorkerAssignment{Image: "duckgres:test"})
+	if created == nil {
+		t.Fatal("worker pod was not submitted to Kubernetes")
+	}
+	if _, ok := created.Labels[placementOrgLabelKey]; ok {
+		t.Fatalf("worker without a trusted org received placement metadata: %#v", created.Labels)
+	}
+	if created.Spec.Affinity != nil {
+		t.Fatalf("worker without a trusted org received affinity: %#v", created.Spec.Affinity)
+	}
+}
+
+func TestAddWorkerOrgPlacementAffinityMergesAndDisabledIsNoop(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{Weight: 7}},
+		},
+		PodAffinity: &corev1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{Weight: 11}},
+		},
+	}}}
+	p := &K8sWorkerPool{namespace: "workers", workerOrgAffinityEnabled: true, workerOrgAffinityWeight: 73}
+	p.addWorkerOrgPlacementAffinity(pod, "org-a")
+
+	if pod.Spec.Affinity.NodeAffinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil {
+		t.Fatal("existing affinity fields were overwritten")
+	}
+	terms := pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 2 || terms[0].Weight != 11 {
+		t.Fatalf("existing pod affinity was not preserved: %#v", terms)
+	}
+	if got := terms[1]; got.Weight != 73 || got.PodAffinityTerm.TopologyKey != "kubernetes.io/hostname" || !reflect.DeepEqual(got.PodAffinityTerm.Namespaces, []string{"workers"}) || !reflect.DeepEqual(got.PodAffinityTerm.LabelSelector.MatchLabels, map[string]string{placementOrgLabelKey: "org-a"}) {
+		t.Fatalf("unexpected appended placement affinity: %#v", got)
+	}
+
+	disabled := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}}}}
+	want := disabled.DeepCopy()
+	(&K8sWorkerPool{namespace: "workers", workerOrgAffinityWeight: 73}).addWorkerOrgPlacementAffinity(disabled, "org-a")
+	if !reflect.DeepEqual(disabled, want) {
+		t.Fatalf("disabled affinity mutated scheduling fields: got %#v, want %#v", disabled.Spec.Affinity, want.Spec.Affinity)
+	}
+}
+
+func TestReconcilePlacementLabelsUsesTrustedRecordAndIsIdempotent(t *testing.T) {
+	const namespace = "default"
+	old := metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	orgBound := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:              "existing-org-worker",
+		Namespace:         namespace,
+		CreationTimestamp: old,
+		Labels: map[string]string{
+			"app":                "duckgres-worker",
+			"duckgres/worker-id": "51",
+			activeOrgLabelKey:    "network-policy-org",
+		},
+	}}
+	unknown := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:              "unknown-worker",
+		Namespace:         namespace,
+		CreationTimestamp: old,
+		Labels: map[string]string{
+			"app": "duckgres-worker", "duckgres/worker-id": "52",
+		},
+	}}
+	pool, cs := newTestK8sPool(t, 5)
+	_, _ = cs.CoreV1().Pods(namespace).Create(context.Background(), orgBound, metav1.CreateOptions{})
+	_, _ = cs.CoreV1().Pods(namespace).Create(context.Background(), unknown, metav1.CreateOptions{})
+	pool.runtimeStore = &captureRuntimeWorkerStore{preloadedRecords: map[int]*configstore.WorkerRecord{
+		51: {WorkerID: 51, PodName: orgBound.Name, OrgID: "org-a", State: configstore.WorkerStateHot},
+		52: {WorkerID: 52, PodName: unknown.Name, State: configstore.WorkerStateHot},
+	}}
+
+	if got := pool.cleanupOrphanedWorkerPods(context.Background(), 2*time.Minute); got != 0 {
+		t.Fatalf("reconciliation deleted %d live worker pods", got)
+	}
+	got, err := cs.CoreV1().Pods(namespace).Get(context.Background(), orgBound.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get org-bound worker: %v", err)
+	}
+	if got.Labels[placementOrgLabelKey] != "org-a" {
+		t.Fatalf("placement label = %q, want org-a", got.Labels[placementOrgLabelKey])
+	}
+	if got.Labels[activeOrgLabelKey] != "network-policy-org" {
+		t.Fatalf("active-org was replaced or weakened: %#v", got.Labels)
+	}
+	if got, err := cs.CoreV1().Pods(namespace).Get(context.Background(), unknown.Name, metav1.GetOptions{}); err != nil || got.Labels[placementOrgLabelKey] != "" {
+		t.Fatalf("untrusted worker received placement label: pod=%#v err=%v", got, err)
+	}
+	patchesAfterFirstPass := countPodPatches(cs)
+	if patchesAfterFirstPass != 1 {
+		t.Fatalf("placement patches after first pass = %d, want 1", patchesAfterFirstPass)
+	}
+
+	pool.cleanupOrphanedWorkerPods(context.Background(), 2*time.Minute)
+	if got := countPodPatches(cs); got != patchesAfterFirstPass {
+		t.Fatalf("reconciliation repeated an already-converged patch: %d -> %d", patchesAfterFirstPass, got)
+	}
+}
+
+func countPodPatches(cs interface{ Actions() []k8stesting.Action }) int {
+	count := 0
+	for _, action := range cs.Actions() {
+		if action.Matches("patch", "pods") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestPlacementOrgLabelValueIsKubernetesSafe(t *testing.T) {
+	label := placementOrgLabelValue("tenant:with/slashes and a very long value that exceeds the Kubernetes label value limit")
+	if len(label) > 63 {
+		t.Fatalf("placement label exceeds Kubernetes limit: %q", label)
+	}
+	if label == "" {
+		t.Fatal("placement label must remain matchable after sanitization")
+	}
+}

--- a/controlplane/shared_worker_activator.go
+++ b/controlplane/shared_worker_activator.go
@@ -183,6 +183,7 @@ func (a *SharedWorkerActivator) ActivateReservedWorker(ctx context.Context, work
 	// See also docs on activeOrgLabelKey.
 	if err == nil {
 		a.stampActiveOrgLabel(ctx, worker.PodName(), payload.OrgID)
+		a.stampPlacementOrgLabel(ctx, worker.PodName(), payload.OrgID)
 	}
 
 	// Clear the migration lock after the worker finishes activation
@@ -236,6 +237,37 @@ func (a *SharedWorkerActivator) stampActiveOrgLabel(ctx context.Context, podName
 		metav1.PatchOptions{},
 	); err != nil {
 		slog.Warn("Failed to stamp active-org label on worker pod.",
+			"pod", podName, "org", orgID, "error", err)
+	}
+}
+
+// stampPlacementOrgLabel makes an already-existing org-bound worker usable as
+// a soft scheduler target. Unlike active-org, this label is scheduling metadata
+// only; it is never read for authorization or network-policy decisions.
+func (a *SharedWorkerActivator) stampPlacementOrgLabel(ctx context.Context, podName, orgID string) {
+	stampWorkerPlacementOrgLabel(ctx, a.clientset, a.defaultNamespace, podName, orgID, nil)
+}
+
+// stampWorkerPlacementOrgLabel applies the placement label from trusted
+// assignment state. currentLabels avoids an unnecessary patch during adoption
+// and reconciliation when the caller already fetched the pod.
+func stampWorkerPlacementOrgLabel(ctx context.Context, clientset kubernetes.Interface, namespace, podName, orgID string, currentLabels map[string]string) {
+	if clientset == nil || podName == "" || orgID == "" {
+		return
+	}
+	labelValue := placementOrgLabelValue(orgID)
+	if currentLabels != nil && currentLabels[placementOrgLabelKey] == labelValue {
+		return
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, placementOrgLabelKey, labelValue)
+	if _, err := clientset.CoreV1().Pods(namespace).Patch(
+		ctx,
+		podName,
+		types.StrategicMergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+	); err != nil {
+		slog.Warn("Failed to stamp placement-org label on worker pod.",
 			"pod", podName, "org", orgID, "error", err)
 	}
 }

--- a/controlplane/shared_worker_activator_label_test.go
+++ b/controlplane/shared_worker_activator_label_test.go
@@ -79,6 +79,38 @@ func TestStampActiveOrgLabelIdempotent(t *testing.T) {
 	}
 }
 
+func TestStampPlacementOrgLabelPreservesActiveOrgAuthorization(t *testing.T) {
+	const (
+		ns      = "duckgres"
+		podName = "duckgres-cp-worker-8"
+		orgID   = "tenant-alpha"
+	)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      podName,
+		Namespace: ns,
+		Labels: map[string]string{
+			activeOrgLabelKey: "network-policy-org",
+		},
+	}}
+	cs := fake.NewSimpleClientset(pod)
+	a := &SharedWorkerActivator{clientset: cs, defaultNamespace: ns}
+
+	// Activation and credential refresh both run this best-effort stamp.
+	a.stampPlacementOrgLabel(context.Background(), podName, orgID)
+	a.stampPlacementOrgLabel(context.Background(), podName, orgID)
+
+	got, err := cs.CoreV1().Pods(ns).Get(context.Background(), podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if got.Labels[placementOrgLabelKey] != orgID {
+		t.Fatalf("placement label = %q, want %q", got.Labels[placementOrgLabelKey], orgID)
+	}
+	if got.Labels[activeOrgLabelKey] != "network-policy-org" {
+		t.Fatalf("placement stamp changed active-org authorization label: %#v", got.Labels)
+	}
+}
+
 // TestStampActiveOrgLabelSwallowsErrors verifies the patch is best-effort:
 // a Patch failure (e.g. pod was just retired and 404s) must not panic or
 // surface back to the activation caller.

--- a/controlplane/validation.go
+++ b/controlplane/validation.go
@@ -48,3 +48,11 @@ func validateWorkerBackendConfig(cfg ControlPlaneConfig) error {
 	}
 	return nil
 }
+
+func validateK8sWorkerOrgAffinityConfig(cfg ControlPlaneConfig) error {
+	weight := cfg.K8s.WorkerOrgAffinityWeight
+	if weight < 1 || weight > 100 {
+		return fmt.Errorf("k8s worker org affinity weight must be within [1,100], got %d", weight)
+	}
+	return nil
+}

--- a/controlplane/validation_test.go
+++ b/controlplane/validation_test.go
@@ -150,6 +150,26 @@ func TestValidateWorkerBackendConfig(t *testing.T) {
 	}
 }
 
+func TestValidateK8sWorkerOrgAffinityConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		weight  int
+		wantErr bool
+	}{
+		{name: "minimum", weight: 1},
+		{name: "maximum", weight: 100},
+		{name: "zero", weight: 0, wantErr: true},
+		{name: "too large", weight: 101, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateK8sWorkerOrgAffinityConfig(ControlPlaneConfig{K8s: K8sConfig{WorkerOrgAffinityWeight: tt.weight}})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateK8sWorkerOrgAffinityConfig(weight=%d) error = %v, wantErr %v", tt.weight, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCheckSocketDirWritable(t *testing.T) {
 	// Happy path: writable directory
 	tmpDir := t.TempDir()

--- a/controlplane/worker_pool.go
+++ b/controlplane/worker_pool.go
@@ -107,6 +107,8 @@ type K8sWorkerPoolConfig struct {
 	WorkerNodeSelector           map[string]string                            // Node selector for worker pods. Nil = no selector.
 	WorkerTolerationKey          string                                       // Taint key for worker pod NoSchedule toleration. Empty = no toleration.
 	WorkerTolerationValue        string                                       // Taint value for worker pod NoSchedule toleration.
+	WorkerOrgAffinityEnabled     bool                                         // Prefer same-org workers on the same hostname. False preserves existing scheduling.
+	WorkerOrgAffinityWeight      int                                          // Preferred same-org pod-affinity weight, validated in [1,100].
 	WorkerPriorityClassName      string                                       // PriorityClass for worker pods (so they preempt overprovision pause pods). Empty = none.
 	PlaceholderImage             string                                       // Image for headroom placeholder pods (a pause image).
 	PlaceholderPriorityClassName string                                       // PriorityClass for placeholder pods — MUST be below WorkerPriorityClassName so workers preempt them.

--- a/docs/runbooks/org-local-worker-placement.md
+++ b/docs/runbooks/org-local-worker-placement.md
@@ -1,0 +1,33 @@
+# Org-local worker placement
+
+Duckgres can add a best-effort scheduling preference for a newly created,
+org-bound worker to run on a hostname that already has another worker for the
+same org. It is never a required constraint: the normal worker node selector
+remains the only hard placement requirement.
+
+## Local development
+
+The preference is disabled by default. To exercise it in a local control-plane
+deployment, set both deployment environment variables:
+
+```text
+DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED=true
+DUCKGRES_K8S_WORKER_ORG_AFFINITY_WEIGHT=100
+```
+
+After an org-bound worker is created or activated, inspect its
+`duckgres/placement-org` label and its preferred pod-affinity term. Do not use
+this label for cache authorization or replace `duckgres/active-org`; the latter
+continues to select the per-org network policy.
+
+## Rollout and recovery
+
+1. Deploy with affinity disabled and confirm org-bound worker pods gain the
+   placement label.
+2. Enable the setting in non-production and observe scheduling behavior.
+3. Enable one production region, then the remaining regions.
+
+To roll back immediately, set
+`DUCKGRES_K8S_WORKER_ORG_AFFINITY_ENABLED=false` and roll the control-plane
+deployment. Existing placement labels are harmless metadata and remain for
+future scheduler matching; new pods then have no org-affinity preference.

--- a/main.go
+++ b/main.go
@@ -407,6 +407,8 @@ func main() {
 				WorkerNodeSelector:           resolved.K8sWorkerNodeSelector,
 				WorkerTolerationKey:          resolved.K8sWorkerTolerationKey,
 				WorkerTolerationValue:        resolved.K8sWorkerTolerationValue,
+				WorkerOrgAffinityEnabled:     resolved.K8sWorkerOrgAffinityEnabled,
+				WorkerOrgAffinityWeight:      resolved.K8sWorkerOrgAffinityWeight,
 				AllowClientWorkerProfile:     resolved.K8sAllowClientWorkerProfile,
 				WorkerPriorityClassName:      resolved.K8sWorkerPriorityClassName,
 				PlaceholderImage:             resolved.K8sPlaceholderImage,


### PR DESCRIPTION
Summary:
- Add scheduling-only duckgres/placement-org metadata from trusted worker assignments.
- Add optional same-org preferred pod affinity while preserving existing scheduling fields.
- Reconcile existing org-bound workers from durable assignment state without changing duckgres/active-org.

Rollout:
1. Deploy with affinity disabled and verify placement-label coverage.
2. Enable across non-production.
3. Enable one production region.
4. Enable remaining regions.
5. Roll back by disabling the static deployment setting.

Verification:
- just test-unit
- just test-controlplane-k8s
- just lint