### PR TITLE
logging: flush OTLP batch on worker/CP drain os.Exit

### DIFF
--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cloudflare/tableflip"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/internal/netkeepalive"
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/ducklake"
@@ -659,6 +660,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		if cp.upgradeDraining.Load() {
 			slog.Info("Received shutdown signal during upgrade drain, exiting immediately.", "signal", s)
 			cp.pool.ShutdownAll()
+			cliboot.FlushLogging()
 			os.Exit(0)
 		}
 		slog.Info("Received shutdown signal.", "signal", s)
@@ -680,6 +682,7 @@ func RunControlPlane(cfg ControlPlaneConfig) {
 		} else {
 			cp.shutdown()
 		}
+		cliboot.FlushLogging()
 		os.Exit(0)
 	}()
 
@@ -2745,6 +2748,7 @@ func (cp *ControlPlane) drainAfterUpgrade() {
 	}
 
 	slog.Info("Old control plane exiting after upgrade.")
+	cliboot.FlushLogging()
 	os.Exit(0)
 }
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -969,8 +969,8 @@ func Run(cfg ServiceConfig) {
 		if !svc.WaitForDrain(ctx) {
 			slog.Warn("DuckDB service drain timed out before shutdown.", "timeout", workerShutdownDrainTime)
 			cancel()
-			cliboot.FlushLogging()
 			svc.CloseAll()
+			cliboot.FlushLogging()
 			os.Exit(0)
 		}
 		cancel()

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/observe"
@@ -968,12 +969,14 @@ func Run(cfg ServiceConfig) {
 		if !svc.WaitForDrain(ctx) {
 			slog.Warn("DuckDB service drain timed out before shutdown.", "timeout", workerShutdownDrainTime)
 			cancel()
+			cliboot.FlushLogging()
 			svc.CloseAll()
 			os.Exit(0)
 		}
 		cancel()
 		slog.Info("Shutting down DuckDB service...")
 		svc.Shutdown()
+		cliboot.FlushLogging()
 		os.Exit(0)
 	}()
 

--- a/duckdbservice/service_test.go
+++ b/duckdbservice/service_test.go
@@ -76,6 +76,89 @@ func isContextBackgroundCall(expr ast.Expr) bool {
 	return ok && pkg.Name == "context"
 }
 
+func TestDrainTimeoutFlushesAfterCloseAll(t *testing.T) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "service.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse service.go: %v", err)
+	}
+
+	timeoutClose, timeoutFlush := -1, -1
+	successShutdown, successFlush := -1, -1
+
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		block, ok := node.(*ast.BlockStmt)
+		if !ok {
+			return true
+		}
+		for i, stmt := range block.List {
+			ifStmt, ok := stmt.(*ast.IfStmt)
+			if !ok || !isNotWaitForDrain(ifStmt.Cond) {
+				continue
+			}
+			for j, bodyStmt := range ifStmt.Body.List {
+				switch exprStmtSelector(bodyStmt) {
+				case "CloseAll":
+					timeoutClose = j
+				case "FlushLogging":
+					timeoutFlush = j
+				}
+			}
+			for j := i + 1; j < len(block.List); j++ {
+				switch exprStmtSelector(block.List[j]) {
+				case "Shutdown":
+					successShutdown = j
+				case "FlushLogging":
+					successFlush = j
+				}
+			}
+		}
+		return true
+	})
+
+	if timeoutClose < 0 || timeoutFlush < 0 {
+		t.Fatal("drain timeout path missing CloseAll or FlushLogging")
+	}
+	if timeoutFlush < timeoutClose {
+		t.Fatalf("timeout path flushes at stmt %d before CloseAll at %d", timeoutFlush, timeoutClose)
+	}
+	if successShutdown < 0 || successFlush < 0 {
+		t.Fatal("success drain path missing Shutdown or FlushLogging")
+	}
+	if successFlush < successShutdown {
+		t.Fatalf("success path flushes at stmt %d before Shutdown at %d", successFlush, successShutdown)
+	}
+}
+
+func isNotWaitForDrain(cond ast.Expr) bool {
+	unary, ok := cond.(*ast.UnaryExpr)
+	if !ok || unary.Op != token.NOT {
+		return false
+	}
+	call, ok := unary.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "WaitForDrain"
+}
+
+func exprStmtSelector(stmt ast.Stmt) string {
+	es, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return ""
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
 // With MaxSessions=1 (how the control plane spawns remote worker pods), a worker
 // serves exactly one client query session — a second concurrent CreateSession is
 // rejected rather than silently overcommitting the pod's resources. Internal

--- a/internal/cliboot/logging.go
+++ b/internal/cliboot/logging.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -260,6 +261,40 @@ func parseLogLevel() slog.Level {
 	}
 }
 
+// loggingFlusher is the process-wide OTLP flush hook. InitLogging installs
+// one; FlushLogging and the returned shutdown closure share its Once so
+// os.Exit drain paths and defer loggingShutdown() cannot double-Shutdown.
+type loggingFlusher struct {
+	once sync.Once
+	fn   func()
+}
+
+var currentFlusher atomic.Pointer[loggingFlusher]
+
+// installLoggingFlusher replaces the process flush hook. Tests use it to
+// inject a counter; InitLogging uses it for the real provider.Shutdown.
+func installLoggingFlusher(fn func()) func() {
+	currentFlusher.Store(&loggingFlusher{fn: fn})
+	return FlushLogging
+}
+
+// FlushLogging flushes the OTLP batch processor (5s timeout). It is
+// idempotent and a no-op when export was never enabled. Call only from
+// the listed drain os.Exit paths — BatchProcessor already exports ~1s, so
+// this is tail-of-process insurance for the last shutdown line.
+func FlushLogging() {
+	f := currentFlusher.Load()
+	if f == nil {
+		return
+	}
+	f.once.Do(func() {
+		if f.fn == nil {
+			return
+		}
+		f.fn()
+	})
+}
+
 // InitLogging configures slog to send logs to PostHog via OTLP when
 // POSTHOG_API_KEY is set. Additional PostHog projects can be targeted by
 // setting ADDITIONAL_POSTHOG_API_KEYS to a comma-separated list of API keys.
@@ -276,7 +311,7 @@ func InitLogging() func() {
 		}
 		slog.SetDefault(slog.New(&RedactingHandler{Inner: newStderrStampedHandler(level)}))
 		fmt.Fprintln(os.Stderr, "PostHog logging disabled (POSTHOG_API_KEY not set)")
-		return func() {}
+		return installLoggingFlusher(nil)
 	}
 	fmt.Fprintln(os.Stderr, "PostHog logging enabled, configuring OTLP exporter...")
 
@@ -310,7 +345,7 @@ func InitLogging() func() {
 	if primaryExp == nil {
 		slog.SetDefault(slog.New(&RedactingHandler{Inner: newStderrStampedHandler(level)}))
 		fmt.Fprintln(os.Stderr, "Primary PostHog exporter failed to initialize, continuing with stderr only")
-		return func() {}
+		return installLoggingFlusher(nil)
 	}
 	processors := []sdklog.LoggerProviderOption{
 		sdklog.WithProcessor(sdklog.NewBatchProcessor(primaryExp)),
@@ -336,12 +371,11 @@ func InitLogging() func() {
 
 	slog.Info("PostHog logging enabled.", "host", host, "exporters", len(processors))
 
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_ = provider.Shutdown(ctx)
-		})
-	}
+	return installLoggingFlusher(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := provider.Shutdown(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to flush PostHog logs: %v\n", err)
+		}
+	})
 }

--- a/internal/cliboot/logging_test.go
+++ b/internal/cliboot/logging_test.go
@@ -147,3 +147,40 @@ func TestRedactingHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestFlushLoggingIdempotent(t *testing.T) {
+	t.Run("disabled export does not panic", func(t *testing.T) {
+		t.Setenv("POSTHOG_API_KEY", "")
+		shutdown := InitLogging()
+		FlushLogging()
+		FlushLogging()
+		shutdown()
+		FlushLogging()
+	})
+
+	t.Run("never initialized does not panic", func(t *testing.T) {
+		installLoggingFlusher(nil)
+		FlushLogging()
+		FlushLogging()
+	})
+
+	t.Run("second call is a no-op", func(t *testing.T) {
+		var calls int
+		installLoggingFlusher(func() { calls++ })
+		FlushLogging()
+		FlushLogging()
+		if calls != 1 {
+			t.Fatalf("FlushLogging ran %d times, want 1", calls)
+		}
+	})
+
+	t.Run("shutdown closure shares Once with FlushLogging", func(t *testing.T) {
+		var calls int
+		shutdown := installLoggingFlusher(func() { calls++ })
+		shutdown()
+		FlushLogging()
+		if calls != 1 {
+			t.Fatalf("shared flush ran %d times, want 1", calls)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`os.Exit` skips `defer loggingShutdown()`, so the last drain/shutdown log line never left the OTLP `BatchProcessor`.

- Add `cliboot.FlushLogging()` — idempotent, no-op when export is off, shares `sync.Once` with the `InitLogging` shutdown closure.
- Call it only on the real drain exits: worker success and timeout, CP SIGTERM (including upgrade-drain immediate exit), and `drainAfterUpgrade`.
- Do not wrap startup `os.Exit(1)` fatals.

**Stack (1/3)** → #1082 → #1083

## Test plan

- [x] `go test ./internal/cliboot/ -run TestFlushLoggingIdempotent`
- [ ] Reviewer: confirm the listed `os.Exit` sites match the drain paths you care about