### PR TITLE
logging: stamp pid on CP loggers; session-scope user/pid on worker WARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,9 +465,10 @@ on.
 
 The two exporters can be enabled independently, and the distinction matters
 because they carry different data. These events are metadata only. Application
-logs are not: `logQuery` / `logQueryError` attach the statement, and
-`usersecrets.RedactForLog` only rewrites secret DDL, so ordinary SQL and its
-literals reach PostHog Logs.
+logs are not: only **exported WARN/ERROR** records attach the statement after
+`usersecrets.RedactForLog` + a 4096-byte cap (secret DDL is a placeholder;
+ordinary SELECT text still leaves). Default `DUCKGRES_POSTHOG_LOG_LEVEL=warn`
+does not export user-class `Query execution failed.` Info lines.
 
 | Set | Analytics events | Log export |
 | --- | --- | --- |

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -1327,6 +1327,7 @@ func (cp *ControlPlane) handleConnection(conn net.Conn) {
 	// Feed initial parameters and backend key data to the client IMMEDIATELY.
 	// This keeps JDBC drivers happy while we perform the slow worker acquisition.
 	pid := sessions.ReservePID()
+	clog = clog.With("pid", pid)
 	secretKey := server.GenerateSecretKey()
 
 	// Use a temporary clientConn just to send initial params

--- a/controlplane/session_mgr.go
+++ b/controlplane/session_mgr.go
@@ -540,7 +540,7 @@ func (sm *SessionManager) createSessionOnWorker(ctx context.Context, username st
 		}
 	}
 
-	sessionToken, secretWarnings, err := worker.CreateSession(ctx, username, memoryLimit, threads, secretStatements)
+	sessionToken, secretWarnings, err := worker.CreateSession(ctx, username, memoryLimit, threads, secretStatements, pid)
 	if err != nil {
 		sm.log.Warn("Failed to create session on worker.",
 			"pid", pid,

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -1322,7 +1322,7 @@ func recoverWorkerPanic(err *error) {
 // CreateSession creates a new session on the given worker. secretStatements
 // are the user's persistent secrets to replay on the worker before the
 // session serves queries; secretWarnings reports any that failed to apply.
-func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit string, threads int, secretStatements []string) (token string, secretWarnings []string, err error) {
+func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit string, threads int, secretStatements []string, pid int32) (token string, secretWarnings []string, err error) {
 	defer recoverWorkerPanic(&err)
 
 	body, _ := json.Marshal(server.WorkerCreateSessionPayload{
@@ -1335,6 +1335,7 @@ func (w *ManagedWorker) CreateSession(ctx context.Context, username, memoryLimit
 		MemoryLimit:      memoryLimit,
 		Threads:          threads,
 		SecretStatements: secretStatements,
+		PID:              pid,
 	})
 
 	stream, err := w.client.Client.DoAction(ctx, &flight.Action{

--- a/duckdbservice/activation.go
+++ b/duckdbservice/activation.go
@@ -267,15 +267,20 @@ var workerLogIdentityOnce sync.Once
 // logger, so EVERY worker log line — session create/destroy, query execution,
 // drain — carries org= and worker= alongside the pod=/node= stamps, matching
 // the control plane's per-connection identity attrs.
+func workerIdentityAttrs(orgID string, workerID int) []any {
+	attrs := make([]any, 0, 4)
+	if orgID != "" {
+		attrs = append(attrs, "org", orgID)
+	}
+	if workerID > 0 {
+		attrs = append(attrs, "worker", workerID)
+	}
+	return attrs
+}
+
 func stampWorkerLogIdentity(orgID string, workerID int) {
 	workerLogIdentityOnce.Do(func() {
-		attrs := make([]any, 0, 4)
-		if orgID != "" {
-			attrs = append(attrs, "org", orgID)
-		}
-		if workerID > 0 {
-			attrs = append(attrs, "worker", workerID)
-		}
+		attrs := workerIdentityAttrs(orgID, workerID)
 		if len(attrs) > 0 {
 			slog.SetDefault(slog.Default().With(attrs...))
 		}

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -689,7 +689,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	if inTransaction {
 		schema, err = session.getQuerySchema(ctx, query, tx)
 	} else {
-		schema, err = retryOnTransient(func() (*arrow.Schema, error) {
+		schema, err = retryOnTransient(session.Logger(), func() (*arrow.Schema, error) {
 			return session.getQuerySchema(ctx, query, tx)
 		})
 	}
@@ -698,7 +698,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	// conflict retry — acceptable since the error patterns are distinct in practice.
 	if shouldRetryDuckLakeConflict(err, inTransaction) {
 		ducklakeConflictTotal.Inc()
-		schema, err = retryOnConflict(func() (*arrow.Schema, error) {
+		schema, err = retryOnConflict(session.Logger(), func() (*arrow.Schema, error) {
 			return session.getQuerySchema(ctx, query, tx)
 		})
 	}
@@ -708,6 +708,7 @@ func (h *FlightSQLHandler) GetFlightInfoStatement(ctx context.Context, cmd fligh
 	h.pool.noteInstanceError(query, err)
 	if err != nil {
 		schema, err, _ = recoverAbortedTransaction(
+			session.Logger(),
 			err,
 			!inTransaction,
 			func() error { return session.rollbackConn(context.Background()) },
@@ -835,12 +836,12 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		if inTxn {
 			rows, qerr = queryFn()
 		} else {
-			rows, qerr = retryOnTransient(queryFn)
+			rows, qerr = retryOnTransient(session.Logger(), queryFn)
 		}
 		// Conflict retry for autocommit only (see GetFlightInfoStatement comment).
 		if shouldRetryDuckLakeConflict(qerr, inTxn) {
 			ducklakeConflictTotal.Inc()
-			rows, qerr = retryOnConflict(func() (*sql.Rows, error) {
+			rows, qerr = retryOnConflict(session.Logger(), func() (*sql.Rows, error) {
 				return queryFn()
 			})
 		}
@@ -849,6 +850,7 @@ func (h *FlightSQLHandler) DoGetStatement(ctx context.Context, ticket flightsql.
 		h.pool.noteInstanceError(handle.Query, qerr)
 		if qerr != nil {
 			rows, qerr, _ = recoverAbortedTransaction(
+				session.Logger(),
 				qerr,
 				!inTxn,
 				func() error { return session.rollbackConn(context.Background()) },
@@ -962,18 +964,19 @@ func (h *FlightSQLHandler) DoPutCommandStatementUpdate(ctx context.Context,
 	if inTransaction || isTxControl {
 		result, execErr = execFn()
 	} else {
-		result, execErr = retryOnTransient(execFn)
+		result, execErr = retryOnTransient(session.Logger(), execFn)
 	}
 
 	// Conflict retry for autocommit only (see GetFlightInfoStatement comment).
 	if shouldRetryDuckLakeConflict(execErr, inTransaction) {
 		ducklakeConflictTotal.Inc()
-		result, execErr = retryOnConflict(func() (sql.Result, error) {
+		result, execErr = retryOnConflict(session.Logger(), func() (sql.Result, error) {
 			return session.execConn(ctx, query)
 		})
 	}
 	if execErr != nil {
 		result, execErr, _ = recoverAbortedTransaction(
+			session.Logger(),
 			execErr,
 			!inTransaction,
 			func() error { return session.rollbackConn(context.Background()) },

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -237,6 +236,7 @@ func (h *FlightSQLHandler) doCreateSession(body []byte, stream flight.FlightServ
 	}
 
 	session, secretWarnings, err := h.pool.CreateSession(req.Username, req.MemoryLimit, req.Threads, req.SecretStatements)
+	attachSessionLog(session, req.Username, req.PID)
 	if drainErr := workerDrainingStatus(err); drainErr != nil {
 		return drainErr
 	}
@@ -373,6 +373,7 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 
 	type sessionSnapshot struct {
 		key      string
+		session  *Session
 		conn     duckdbConnHandle
 		progress *progressState
 		queryID  string
@@ -390,6 +391,7 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 		}
 		snapshots = append(snapshots, sessionSnapshot{
 			key:      key,
+			session:  session,
 			conn:     session.duckdbConn,
 			progress: &session.progress,
 			queryID:  session.CurrentQueryID(),
@@ -437,7 +439,7 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 						// is exactly the case whose query-log row may never get
 						// a terminal event, and this is what ties the two
 						// together.
-						slog.Warn("Query appears stuck — no progress detected.",
+						logStuckQuery(snap.session,
 							withQueryIDAttr([]any{
 								"session", snap.key, "rows_processed", pr.rows, "total_rows", pr.total,
 								"stalled_checks", stallCheckThreshold,

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -973,8 +973,9 @@ func Run(cfg ServiceConfig) {
 		if !svc.WaitForDrain(ctx) {
 			slog.Warn("DuckDB service drain timed out before shutdown.", "timeout", workerShutdownDrainTime)
 			cancel()
-			cliboot.FlushLogging()
+			// Close first so teardown WARNs land in the batch, then flush.
 			svc.CloseAll()
+			cliboot.FlushLogging()
 			os.Exit(0)
 		}
 		cancel()
@@ -1325,7 +1326,11 @@ func (p *SessionPool) DestroySession(token string) error {
 	p.mu.Lock()
 	session, ok := p.sessions[token]
 	stop := p.stopRefresh[token]
+	var log *slog.Logger
 	if ok {
+		// Snapshot before clear so destroy-path WARNs keep user+pid
+		// without leaving the field set for a later Logger() leak.
+		log = session.Logger()
 		delete(p.sessions, token)
 		delete(p.stopRefresh, token)
 		clearSessionLog(session)
@@ -1437,7 +1442,7 @@ func (p *SessionPool) DestroySession(token string) error {
 	if p.sharedWarmMode && p.maxSessions == 1 && session.DB != nil {
 		wipeCtx, wipeCancel := context.WithTimeout(context.Background(), userSecretOpTimeout)
 		if _, err := wipeUserSecrets(wipeCtx, session.DB); err != nil {
-			slog.Warn("Failed to wipe user secrets on session destroy.", "user", session.Username, "error", err)
+			log.Warn("Failed to wipe user secrets on session destroy.", "user", session.Username, "error", err)
 		}
 		wipeCancel()
 	}
@@ -1448,7 +1453,7 @@ func (p *SessionPool) DestroySession(token string) error {
 	// which the worker's checkpointer would write past the cache proxy.
 	if p.sharedWarmMode {
 		if err := p.SetS3CacheEnabled(true); err != nil {
-			slog.Warn("Failed to restore S3 cache transport on session destroy.", "user", session.Username, "error", err)
+			log.Warn("Failed to restore S3 cache transport on session destroy.", "user", session.Username, "error", err)
 		}
 	}
 

--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -191,6 +191,10 @@ type Session struct {
 
 	duckdbConn duckdbConnHandle // raw handle for progress polling (zero if extraction failed)
 	progress   progressState    // stall detection state
+
+	// logger carries user+pid for in-session WARN/ERROR. Discarded on
+	// DestroySession so a hot-idle reuse cannot leak the previous user.
+	logger *slog.Logger
 }
 
 // QueryHandle stores an ad-hoc query awaiting its DoGet.
@@ -746,7 +750,7 @@ func (p *SessionPool) reapIdle(now time.Time) {
 				if !s.connMu.TryLock() {
 					continue
 				}
-				slog.Warn("Rolling back idle transaction.", "user", s.Username, "txn", id)
+				s.Logger().Warn("Rolling back idle transaction.", "txn", id)
 				if ttx.tx != nil {
 					_ = ttx.tx.Rollback()
 				}
@@ -773,15 +777,15 @@ func (p *SessionPool) reapIdle(now time.Time) {
 					// The connection may be executing, streaming, or planning work inside
 					// this raw SQL transaction. Leave the transaction drain token active.
 				} else if s.Conn == nil {
-					slog.Warn("Skipping idle raw SQL transaction rollback without a session connection.", "user", s.Username)
+					s.Logger().Warn("Skipping idle raw SQL transaction rollback without a session connection.")
 				} else if !s.connMu.TryLock() {
 					// A same-session operation is using the connection but has not reached
 					// a connWork-tracked path. Skip instead of blocking the reaper loop.
 				} else {
-					slog.Warn("Rolling back idle raw SQL transaction.", "user", s.Username)
+					s.Logger().Warn("Rolling back idle raw SQL transaction.")
 					rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), time.Second)
 					if _, err := s.Conn.ExecContext(rollbackCtx, "ROLLBACK"); err != nil {
-						slog.Warn("Idle raw SQL transaction rollback failed; keeping drain work active.", "user", s.Username, "error", err)
+						s.Logger().Warn("Idle raw SQL transaction rollback failed; keeping drain work active.", "error", err)
 					} else {
 						releaseDrains = append(releaseDrains, s.sqlTxDrain)
 						s.sqlTxDrain = nil
@@ -806,7 +810,7 @@ func (p *SessionPool) reapIdle(now time.Time) {
 					releaseDrains = append(releaseDrains, h.finishOperation)
 					h.finishOperation = nil
 				}
-				slog.Warn("Reaping abandoned query handle (no DoGet).", "user", s.Username, "handle", id)
+				s.Logger().Warn("Reaping abandoned query handle (no DoGet).", "handle", id)
 				delete(s.queries, id)
 			}
 		}
@@ -1324,6 +1328,7 @@ func (p *SessionPool) DestroySession(token string) error {
 	if ok {
 		delete(p.sessions, token)
 		delete(p.stopRefresh, token)
+		clearSessionLog(session)
 	}
 	p.mu.Unlock()
 

--- a/duckdbservice/session_log.go
+++ b/duckdbservice/session_log.go
@@ -1,0 +1,36 @@
+package duckdbservice
+
+import "log/slog"
+
+// attachSessionLog stamps user and pid on the session logger. Org/worker
+// stay on slog.Default() via stampWorkerLogIdentity. Never SetDefault(user).
+func attachSessionLog(s *Session, username string, pid int32) {
+	if s == nil {
+		return
+	}
+	attrs := []any{"user", username}
+	if pid > 0 {
+		attrs = append(attrs, "pid", pid)
+	}
+	s.logger = slog.Default().With(attrs...)
+}
+
+func clearSessionLog(s *Session) {
+	if s == nil {
+		return
+	}
+	s.logger = nil
+}
+
+// Logger returns the session-scoped logger (user+pid), or the default
+// org+worker logger when the session is gone or not yet attached.
+func (s *Session) Logger() *slog.Logger {
+	if s == nil || s.logger == nil {
+		return slog.Default()
+	}
+	return s.logger
+}
+
+func logStuckQuery(s *Session, attrs ...any) {
+	s.Logger().Warn("Query appears stuck — no progress detected.", attrs...)
+}

--- a/duckdbservice/session_log_test.go
+++ b/duckdbservice/session_log_test.go
@@ -1,0 +1,78 @@
+package duckdbservice
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNeverSetDefaultWithUser(t *testing.T) {
+	attrs := workerIdentityAttrs("org-a", 17)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		key, _ := attrs[i].(string)
+		if key == "user" {
+			t.Fatal("worker default identity must not include user")
+		}
+	}
+	if len(attrs) != 4 || attrs[0] != "org" || attrs[2] != "worker" {
+		t.Fatalf("worker identity attrs = %#v", attrs)
+	}
+}
+
+func TestSessionLoggerClearedOnDestroy(t *testing.T) {
+	s := &Session{Username: "alice"}
+	attachSessionLog(s, "alice", 9)
+	if s.Logger() == slog.Default() {
+		t.Fatal("expected session logger after attach")
+	}
+	clearSessionLog(s)
+	if s.Logger() != slog.Default() {
+		t.Fatal("session logger still set after clear")
+	}
+}
+
+func TestCreateSessionPIDOnLogger(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	s := &Session{}
+	attachSessionLog(s, "root", 1001)
+	s.Logger().Info("probe")
+	out := buf.String()
+	if !strings.Contains(out, "user=root") {
+		t.Fatalf("missing user: %s", out)
+	}
+	if !strings.Contains(out, "pid=1001") {
+		t.Fatalf("missing pid: %s", out)
+	}
+}
+
+func TestStuckQueryWarnCarriesSessionIdentity(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	s := &Session{Username: "alice"}
+	attachSessionLog(s, "alice", 42)
+	logStuckQuery(s, "session", "abc", "rows_processed", 0)
+	out := buf.String()
+	if !strings.Contains(out, "Query appears stuck — no progress detected.") {
+		t.Fatalf("missing stuck-query message: %s", out)
+	}
+	if !strings.Contains(out, "user=alice") || !strings.Contains(out, "pid=42") {
+		t.Fatalf("stuck-query WARN missing session identity: %s", out)
+	}
+}
+
+func TestStampWorkerLogIdentityDoesNotIncludeUser(t *testing.T) {
+	attrs := workerIdentityAttrs("acme", 3)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		if attrs[i] == "user" {
+			t.Fatalf("user leaked onto worker identity: %#v", attrs)
+		}
+	}
+}

--- a/duckdbservice/transient.go
+++ b/duckdbservice/transient.go
@@ -106,9 +106,18 @@ const (
 	transientInitialBackoff = 250 * time.Millisecond
 )
 
+// retryLog is the session logger when one exists; slog.Default() otherwise.
+func retryLog(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return slog.Default()
+	}
+	return logger
+}
+
 // retryOnTransient calls fn up to transientMaxRetries additional times when it
 // returns a transient DuckLake error, using exponential backoff.
-func retryOnTransient[T any](fn func() (T, error)) (T, error) {
+func retryOnTransient[T any](logger *slog.Logger, fn func() (T, error)) (T, error) {
+	log := retryLog(logger)
 	result, err := fn()
 	if err == nil || !isTransientDuckLakeError(err) {
 		return result, err
@@ -116,7 +125,7 @@ func retryOnTransient[T any](fn func() (T, error)) (T, error) {
 
 	backoff := transientInitialBackoff
 	for attempt := 1; attempt <= transientMaxRetries; attempt++ {
-		slog.Warn("Transient DuckLake error, retrying.",
+		log.Warn("Transient DuckLake error, retrying.",
 			"attempt", attempt, "max_retries", transientMaxRetries,
 			"backoff", backoff, "error", err)
 
@@ -126,13 +135,13 @@ func retryOnTransient[T any](fn func() (T, error)) (T, error) {
 		result, err = fn()
 		if err == nil || !isTransientDuckLakeError(err) {
 			if err == nil {
-				slog.Info("DuckLake retry succeeded.", "attempt", attempt)
+				log.Info("DuckLake retry succeeded.", "attempt", attempt)
 			}
 			return result, err
 		}
 	}
 
-	slog.Error("DuckLake retries exhausted.", "attempts", transientMaxRetries+1, "error", err)
+	log.Error("DuckLake retries exhausted.", "attempts", transientMaxRetries+1, "error", err)
 	return result, err
 }
 
@@ -146,6 +155,7 @@ func isTransactionAborted(err error) bool {
 // user transaction). Callers should pass canRollback=false for explicit user
 // transactions so the original error is surfaced unchanged.
 func recoverAbortedTransaction[T any](
+	logger *slog.Logger,
 	err error,
 	canRollback bool,
 	rollback func() error,
@@ -156,16 +166,17 @@ func recoverAbortedTransaction[T any](
 		return zero, err, false
 	}
 
-	slog.Warn("DuckLake connection hit aborted transaction state; issuing ROLLBACK before retry.", "error", err)
+	log := retryLog(logger)
+	log.Warn("DuckLake connection hit aborted transaction state; issuing ROLLBACK before retry.", "error", err)
 	if rollbackErr := rollback(); rollbackErr != nil {
 		return zero, fmt.Errorf("DuckLake aborted transaction recovery rollback failed: %w (original error: %v)", rollbackErr, err), true
 	}
 
 	result, retryErr := retry()
 	if retryErr == nil {
-		slog.Info("DuckLake aborted transaction recovery succeeded.")
+		log.Info("DuckLake aborted transaction recovery succeeded.")
 	} else {
-		slog.Warn("DuckLake aborted transaction recovery retry failed.", "error", retryErr)
+		log.Warn("DuckLake aborted transaction recovery retry failed.", "error", retryErr)
 	}
 	return result, retryErr, true
 }
@@ -195,7 +206,8 @@ const (
 // exponential backoff and jitter (50-100% of backoff interval).
 // Only used for autocommit queries — user-managed transactions propagate
 // the error since the entire transaction is invalid after a conflict.
-func retryOnConflict[T any](fn func() (T, error)) (T, error) {
+func retryOnConflict[T any](logger *slog.Logger, fn func() (T, error)) (T, error) {
+	log := retryLog(logger)
 	var lastErr error
 	backoff := conflictInitialBackoff
 	for attempt := 1; attempt <= conflictMaxRetries; attempt++ {
@@ -203,7 +215,7 @@ func retryOnConflict[T any](fn func() (T, error)) (T, error) {
 
 		// Jitter: 50-100% of backoff to decorrelate retry storms.
 		jittered := time.Duration(float64(backoff) * (0.5 + rand.Float64()*0.5))
-		slog.Warn("DuckLake transaction conflict, retrying.",
+		log.Warn("DuckLake transaction conflict, retrying.",
 			"attempt", attempt, "max_retries", conflictMaxRetries,
 			"backoff", jittered)
 
@@ -212,7 +224,7 @@ func retryOnConflict[T any](fn func() (T, error)) (T, error) {
 		result, err := fn()
 		if err == nil {
 			ducklakeConflictRetrySuccessesTotal.Inc()
-			slog.Info("DuckLake conflict retry succeeded.", "attempt", attempt)
+			log.Info("DuckLake conflict retry succeeded.", "attempt", attempt)
 			return result, nil
 		}
 		lastErr = err
@@ -228,6 +240,6 @@ func retryOnConflict[T any](fn func() (T, error)) (T, error) {
 
 	ducklakeConflictRetriesExhaustedTotal.Inc()
 	var zero T
-	slog.Error("DuckLake conflict retries exhausted.", "attempts", conflictMaxRetries, "error", lastErr)
+	log.Error("DuckLake conflict retries exhausted.", "attempts", conflictMaxRetries, "error", lastErr)
 	return zero, fmt.Errorf("DuckLake transaction conflict: retries exhausted after %d attempts: %w", conflictMaxRetries, lastErr)
 }

--- a/duckdbservice/transient_test.go
+++ b/duckdbservice/transient_test.go
@@ -1,7 +1,9 @@
 package duckdbservice
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -79,7 +81,7 @@ func TestIsTransientDuckLakeError(t *testing.T) {
 
 func TestRetryOnTransientSucceedsAfterRetry(t *testing.T) {
 	calls := 0
-	result, err := retryOnTransient(func() (string, error) {
+	result, err := retryOnTransient(nil, func() (string, error) {
 		calls++
 		if calls < 3 {
 			return "", errors.New("could not translate host name: Temporary failure in name resolution")
@@ -100,7 +102,7 @@ func TestRetryOnTransientSucceedsAfterRetry(t *testing.T) {
 
 func TestRetryOnTransientNoRetryForNonTransient(t *testing.T) {
 	calls := 0
-	_, err := retryOnTransient(func() (string, error) {
+	_, err := retryOnTransient(nil, func() (string, error) {
 		calls++
 		return "", errors.New("syntax error at position 42")
 	})
@@ -139,7 +141,7 @@ func TestIsDuckLakeTransactionConflict(t *testing.T) {
 
 func TestRetryOnConflictSucceedsAfterRetry(t *testing.T) {
 	calls := 0
-	result, err := retryOnConflict(func() (string, error) {
+	result, err := retryOnConflict(nil, func() (string, error) {
 		calls++
 		if calls <= 2 {
 			return "", errors.New(`Transaction conflict - attempting to insert into table with index "29784"`)
@@ -162,7 +164,7 @@ func TestRetryOnConflictSucceedsAfterRetry(t *testing.T) {
 
 func TestRetryOnConflictExhaustsRetries(t *testing.T) {
 	calls := 0
-	_, err := retryOnConflict(func() (string, error) {
+	_, err := retryOnConflict(nil, func() (string, error) {
 		calls++
 		return "", errors.New("Transaction conflict on commit")
 	})
@@ -181,7 +183,7 @@ func TestRetryOnConflictExhaustsRetries(t *testing.T) {
 
 func TestRetryOnConflictStopsOnNonConflictError(t *testing.T) {
 	calls := 0
-	_, err := retryOnConflict(func() (string, error) {
+	_, err := retryOnConflict(nil, func() (string, error) {
 		calls++
 		return "", errors.New("syntax error at position 42")
 	})
@@ -215,6 +217,7 @@ func TestRecoverAbortedTransactionRetriesAfterRollbackInAutocommit(t *testing.T)
 	retryCalls := 0
 
 	result, err, recovered := recoverAbortedTransaction(
+		nil,
 		errors.New("TransactionContext Error: Current transaction is aborted (please ROLLBACK)"),
 		true,
 		func() error {
@@ -250,6 +253,7 @@ func TestRecoverAbortedTransactionSkipsRecoveryInsideUserTransaction(t *testing.
 	origErr := errors.New("TransactionContext Error: Current transaction is aborted (please ROLLBACK)")
 
 	_, err, recovered := recoverAbortedTransaction(
+		nil,
 		origErr,
 		false,
 		func() error {
@@ -281,6 +285,7 @@ func TestRecoverAbortedTransactionReturnsRollbackFailure(t *testing.T) {
 	retryCalls := 0
 
 	_, err, recovered := recoverAbortedTransaction(
+		nil,
 		errors.New("TransactionContext Error: Current transaction is aborted (please ROLLBACK)"),
 		true,
 		func() error {
@@ -383,7 +388,7 @@ func TestSQLTxActiveSkipsRetry(t *testing.T) {
 	if inTransaction || isTxControl {
 		_, err = execFn()
 	} else {
-		_, err = retryOnTransient(execFn)
+		_, err = retryOnTransient(nil, execFn)
 	}
 
 	if err == nil {
@@ -420,7 +425,7 @@ func TestSQLTxActiveAllowsRetryOutsideTransaction(t *testing.T) {
 	if inTransaction || isTxControl {
 		result, err = execFn()
 	} else {
-		result, err = retryOnTransient(execFn)
+		result, err = retryOnTransient(nil, execFn)
 	}
 
 	if err != nil {
@@ -445,5 +450,37 @@ func TestStartTransactionTracking(t *testing.T) {
 	trackSQLTransactionState("ROLLBACK", nil, &flag)
 	if flag.Load() {
 		t.Fatal("sqlTxActive should be false after ROLLBACK")
+	}
+}
+
+func TestRetryWarnCarriesSessionIdentity(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	s := &Session{Username: "alice"}
+	attachSessionLog(s, "alice", 42)
+
+	_, err, recovered := recoverAbortedTransaction(
+		s.Logger(),
+		errors.New("TransactionContext Error: Current transaction is aborted (please ROLLBACK)"),
+		true,
+		func() error { return nil },
+		func() (string, error) { return "", errors.New("still aborted") },
+	)
+	if !recovered {
+		t.Fatal("expected recovery attempt")
+	}
+	if err == nil {
+		t.Fatal("expected retry error")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "DuckLake connection hit aborted transaction state") &&
+		!strings.Contains(out, "DuckLake aborted transaction recovery retry failed.") {
+		t.Fatalf("missing retry WARN: %s", out)
+	}
+	if !strings.Contains(out, "user=alice") || !strings.Contains(out, "pid=42") {
+		t.Fatalf("retry WARN missing session identity: %s", out)
 	}
 }

--- a/internal/cliboot/logging.go
+++ b/internal/cliboot/logging.go
@@ -306,7 +306,9 @@ func FlushLogging() {
 // POSTHOG_API_KEY is set. Additional PostHog projects can be targeted by
 // setting ADDITIONAL_POSTHOG_API_KEYS to a comma-separated list of API keys.
 // Logs always go to stderr; PostHog is additive.
-// The log level is controlled by DUCKGRES_LOG_LEVEL (debug, info, warn, error).
+// Stderr level is controlled by DUCKGRES_LOG_LEVEL (debug, info, warn, error).
+// PostHog export level is independently controlled by DUCKGRES_POSTHOG_LOG_LEVEL
+// (default warn).
 // Returns a shutdown function that flushes all OTLP batch processors.
 func InitLogging(bi BuildInfo) func() {
 	level := parseLogLevel()

--- a/internal/cliboot/otel_resource.go
+++ b/internal/cliboot/otel_resource.go
@@ -34,6 +34,9 @@ func otelResource(bi BuildInfo) *resource.Resource {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
 		attrs = append(attrs, semconv.K8SNamespaceName(ns))
 	}
+	if mode := os.Getenv("DUCKGRES_MODE"); mode != "" {
+		attrs = append(attrs, attribute.String("duckgres.mode", mode))
+	}
 	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 }
 

--- a/internal/cliboot/otel_resource_test.go
+++ b/internal/cliboot/otel_resource_test.go
@@ -31,7 +31,7 @@ func TestOTelServiceNameFromMode(t *testing.T) {
 				t.Fatalf("resolveServiceName() = %q, want %q", got, tt.want)
 			}
 			res := otelResource(BuildInfo{Version: "1.2.3"})
-			var gotName, gotDeploy, gotVersion string
+			var gotName, gotDeploy, gotVersion, gotMode string
 			for _, a := range res.Attributes() {
 				switch a.Key {
 				case semconv.ServiceNameKey:
@@ -40,6 +40,8 @@ func TestOTelServiceNameFromMode(t *testing.T) {
 					gotDeploy = a.Value.AsString()
 				case semconv.ServiceVersionKey:
 					gotVersion = a.Value.AsString()
+				case "duckgres.mode":
+					gotMode = a.Value.AsString()
 				}
 			}
 			if gotName != tt.want {
@@ -50,6 +52,12 @@ func TestOTelServiceNameFromMode(t *testing.T) {
 			}
 			if gotVersion != "1.2.3" {
 				t.Fatalf("service.version = %q, want 1.2.3", gotVersion)
+			}
+			if tt.mode != "" && gotMode != tt.mode {
+				t.Fatalf("duckgres.mode = %q, want %q", gotMode, tt.mode)
+			}
+			if tt.mode == "" && gotMode != "" {
+				t.Fatalf("duckgres.mode = %q, want empty when DUCKGRES_MODE is unset", gotMode)
 			}
 		})
 	}

--- a/internal/cliboot/posthog_handler.go
+++ b/internal/cliboot/posthog_handler.go
@@ -58,24 +58,23 @@ type infoSampleHandler struct {
 }
 
 func (h *infoSampleHandler) Enabled(ctx context.Context, l slog.Level) bool {
-	if l >= slog.LevelWarn {
-		return h.inner.Enabled(ctx, l)
-	}
-	if l < slog.LevelInfo {
-		return h.inner.Enabled(ctx, l)
-	}
-	if h.sample <= 0 {
+	// Deterministic: a mid-range sample must not roll here. slog, the
+	// level wrapper, and Handle all consult Enabled; a rand draw in each
+	// would cube the keep-fraction.
+	if l >= slog.LevelInfo && l < slog.LevelWarn && h.sample <= 0 {
 		return false
 	}
-	if h.sample >= 1 {
-		return h.inner.Enabled(ctx, l)
-	}
-	return rand.Float64() < h.sample && h.inner.Enabled(ctx, l)
+	return h.inner.Enabled(ctx, l)
 }
 
 func (h *infoSampleHandler) Handle(ctx context.Context, r slog.Record) error {
-	if !h.Enabled(ctx, r.Level) {
-		return nil
+	if r.Level >= slog.LevelInfo && r.Level < slog.LevelWarn {
+		if h.sample <= 0 {
+			return nil
+		}
+		if h.sample < 1 && rand.Float64() >= h.sample {
+			return nil
+		}
 	}
 	return h.inner.Handle(ctx, r)
 }

--- a/internal/cliboot/query_strip_test.go
+++ b/internal/cliboot/query_strip_test.go
@@ -213,6 +213,41 @@ func TestPostHogLevelIndependentOfStderr(t *testing.T) {
 	}
 }
 
+func TestInfoSampleEnabledDeterministic(t *testing.T) {
+	cap := newCapture(slog.LevelDebug)
+	h := &infoSampleHandler{sample: 0.5, inner: cap}
+	for i := 0; i < 200; i++ {
+		if !h.Enabled(context.Background(), slog.LevelInfo) {
+			t.Fatalf("Enabled(INFO) at sample=0.5 must be deterministic true (draw %d)", i)
+		}
+	}
+	if !h.Enabled(context.Background(), slog.LevelWarn) {
+		t.Fatal("WARN must stay enabled")
+	}
+	if h.Enabled(context.Background(), slog.LevelInfo) != cap.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("Enabled at sample=0.5 must match inner, not a random draw")
+	}
+}
+
+func TestInfoSampleNotCubed(t *testing.T) {
+	cap := newCapture(slog.LevelDebug)
+	logger := slog.New(newPostHogBranch(cap, slog.LevelInfo, 0.5, queryTextRedacted))
+	const n = 2000
+	for i := 0; i < n; i++ {
+		logger.Info("sampled info")
+	}
+	kept := 0
+	for _, rec := range cap.all() {
+		if rec.msg == "sampled info" {
+			kept++
+		}
+	}
+	// One draw of p=0.5 → ~1000. Cubed (Enabled+Handle+wrapper, p=0.125) → ~250.
+	if kept < 700 || kept > 1300 {
+		t.Fatalf("INFO keep at sample=0.5 = %d/%d (cubed would be ~250)", kept, n)
+	}
+}
+
 func TestPostHogInfoSampleKeepsErrors(t *testing.T) {
 	cap := newCapture(slog.LevelDebug)
 	logger := slog.New(newPostHogBranch(cap, slog.LevelInfo, 0, queryTextRedacted))

--- a/server/conn.go
+++ b/server/conn.go
@@ -596,9 +596,6 @@ func (c *clientConn) logger() *slog.Logger {
 	if c.pid != 0 {
 		attrs = append(attrs, "pid", c.pid)
 	}
-	if qs := c.QuerySource(); qs != "" && qs != "standard" {
-		attrs = append(attrs, "query_source", qs)
-	}
 	return slog.With(attrs...)
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -593,6 +593,12 @@ func (c *clientConn) logger() *slog.Logger {
 	if c.workerPod != "" {
 		attrs = append(attrs, "worker_pod", c.workerPod)
 	}
+	if c.pid != 0 {
+		attrs = append(attrs, "pid", c.pid)
+	}
+	if qs := c.QuerySource(); qs != "" && qs != "standard" {
+		attrs = append(attrs, "query_source", qs)
+	}
 	return slog.With(attrs...)
 }
 

--- a/server/conn_logger_test.go
+++ b/server/conn_logger_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestClientConnLoggerIncludesPID(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	c := &clientConn{
+		username: "alice",
+		orgID:    "acme",
+		workerID: 7,
+		pid:      42,
+	}
+	c.logger().Info("probe")
+	out := buf.String()
+	for _, want := range []string{"user=alice", "org=acme", "worker=7", "pid=42"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in %s", want, out)
+		}
+	}
+}

--- a/server/conn_logger_test.go
+++ b/server/conn_logger_test.go
@@ -14,10 +14,11 @@ func TestClientConnLoggerIncludesPID(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 
 	c := &clientConn{
-		username: "alice",
-		orgID:    "acme",
-		workerID: 7,
-		pid:      42,
+		username:    "alice",
+		orgID:       "acme",
+		workerID:    7,
+		pid:         42,
+		querySource: "endpoints",
 	}
 	c.logger().Info("probe")
 	out := buf.String()
@@ -25,5 +26,8 @@ func TestClientConnLoggerIncludesPID(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in %s", want, out)
 		}
+	}
+	if strings.Contains(out, "query_source") {
+		t.Errorf("logger() must not stamp query_source: %s", out)
 	}
 }

--- a/server/wire/worker_proto.go
+++ b/server/wire/worker_proto.go
@@ -35,6 +35,9 @@ type WorkerCreateSessionPayload struct {
 	// ephemeral, so this is the only way a user secret survives across
 	// sessions. Carries credential material: never log this payload.
 	SecretStatements []string `json:"secret_statements,omitempty"`
+	// PID is the control-plane backend-key pid. Optional so older CPs
+	// and tests can omit it; zero means "not stamped on the session logger".
+	PID int32 `json:"pid,omitempty"`
 }
 
 // WorkerDestroySessionPayload is the control plane request body for


### PR DESCRIPTION
## Summary

Makes CP and worker logs joinable by the existing backend-key `pid` without leaking the previous user on hot-idle worker reuse.

- `clientConn.logger()` and `handleConnection` `clog` stamp `pid`.
- Workers attach `user`+`pid` on a session logger and clear it on `DestroySession`. Org/worker stay on the process default logger — never `SetDefault(user)`.
- Stuck-query WARN (`Query appears stuck — no progress detected.`) uses the session logger.
- `WorkerCreateSessionPayload` carries optional `pid`.

**Stack** #1081 → #1082 → **(3/3)**

Depends on #1082.

## Test plan

- [x] `go test ./duckdbservice/ ./server/ ./controlplane/`
- [x] `TestStuckQueryWarnCarriesSessionIdentity`, `TestNeverSetDefaultWithUser`, `TestClientConnLoggerIncludesPID`