### PR TITLE
docs/e2e: PostHog Logs multi-tenant contract and worker env asserts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,43 @@ release lets shutdown kill live work); `reapIdle` releases tokens stranded by a
 `GetFlightInfo` whose `DoGet` never arrived. `terminationGracePeriodSeconds=3600`
 (`k8s_pool.go`) must stay above `workerShutdownDrainTime` (55m).
 
+## PostHog Logs (OTLP) — LOAD-BEARING CONTRACT
+
+Process-level slog → PostHog Logs via OTLP (`internal/cliboot.InitLogging`).
+This is **not** a replacement for `ducklake.system.query_log`. Product-analytics
+events (`POSTHOG_ANALYTICS_API_KEY`) stay on the capture API.
+
+- **`service.name` is the process role**, not `duckgres-<identifier>`:
+  `duckgres-control-plane` / `duckgres-worker` / `duckgres-reshard` /
+  `duckgres` (standalone). `DUCKGRES_IDENTIFIER` is resource attr
+  `duckgres.deployment`. Logs and traces share `otelResource(bi)`.
+- **Default PostHog level is WARN** (`DUCKGRES_POSTHOG_LOG_LEVEL`); stderr
+  stays at `DUCKGRES_LOG_LEVEL`. User-class `Query execution failed.` stays
+  Info and does not export at the default.
+- **Query text default is `redacted`** (`RedactForLog`+4096). Secret DDL is a
+  placeholder; ordinary SELECT text still leaves. Never redact on `LINE 1:`.
+- **Public connection key is `pid`**, not `connection_id`. Org/worker are
+  process-scoped on workers (`stampWorkerLogIdentity`); `user`/`pid` live on
+  the session logger and must never be `SetDefault`'d.
+- **Worker `POSTHOG_API_KEY` is a named `env:` `secretKeyRef`** copied from
+  the CP pod spec (`controlplane/pod_env.go`, `k8s_pool_spawn.go`). Never
+  `envFrom`. Never `os.Getenv` → `value:`. If Get/`POD_NAME`/named env misses:
+  one WARN and omit — **never fail spawn**. Do not forward
+  `ADDITIONAL_POSTHOG_API_KEYS` or `POSTHOG_ANALYTICS_API_KEY`.
+- **`FlushLogging()`** only on the listed drain `os.Exit` sites (worker
+  success/timeout; CP SIGTERM after drain; `drainAfterUpgrade`). Do not wrap
+  every startup `os.Exit(1)`.
+- **Exporter health** is scraped on the CP:
+  `duckgres_otlp_log_export_failures_total{source,reason}` (no `{org}`).
+  Workers report `otlp_export_enabled` / `otlp_export_failures` on the
+  health-check JSON; the CP `Add`s last-seen **deltas** only. Workers do not
+  call `InitMetrics`.
+- Touching spawn env, health JSON, or the handler stack → update
+  `controlplane/k8s_pool_spawn_test.go`, `controlplane/otlp_export_test.go`,
+  `internal/cliboot/*_test.go`, AND `assert_worker_pod` in
+  `tests/mw-dev/e2e/harness.sh` (plaintext-key assert; secretKeyRef copy when
+  the CP named env has one).
+
 ## Per-Session S3 Cache Bypass (`duckgres.s3_cache`, remote backend)
 
 `SET duckgres.s3_cache = on|off|passthrough` (default `on`; also a `-c`

--- a/README.md
+++ b/README.md
@@ -454,7 +454,15 @@ export POSTHOG_HOST=eu.i.posthog.com
 ./duckgres
 ```
 
-Remote worker pods do **not** inherit `POSTHOG_*` from the control-plane Deployment automatically — spawn builds an explicit env list. Until worker Secret-ref plumbing is in place, only processes that already have `POSTHOG_API_KEY` in their own env (control plane, process-backend children) export.
+Remote worker pods do **not** inherit the CP process env. Spawn copies a closed allowlist of **named** `env:` entries from the CP pod spec (`Get(namespace, POD_NAME)` once at pool start):
+
+- `POSTHOG_API_KEY` is copied only as `valueFrom.secretKeyRef`. A literal `value:` is refused. `envFrom` is insufficient (those keys do not appear on a Pod GET) and is not invented-around as `os.Getenv` → `value:`.
+- `POSTHOG_HOST`, `DUCKGRES_POSTHOG_LOG_LEVEL`, `DUCKGRES_POSTHOG_LOG_INFO_SAMPLE`, `DUCKGRES_POSTHOG_LOG_QUERY_TEXT`, and `DUCKGRES_IDENTIFIER` may be a value or a `valueFrom`.
+- `ADDITIONAL_POSTHOG_API_KEYS` and `POSTHOG_ANALYTICS_API_KEY` stay CP-only and are never forwarded.
+
+Charts must put `POSTHOG_API_KEY` on the CP container as a first-class named `env:` `secretKeyRef` (not `envFrom`). If `POD_NAME` is empty, the Get fails, or the named env is missing, the CP logs one WARN (`PostHog log env not found on CP pod spec; workers will not export.`) and **omits** the vars — a logging-config miss must never fail a worker spawn. Reshard runner pods use the same allowlist copy.
+
+The first operational slice is CP-only export. Worker records in PostHog (`service.name=duckgres-worker`) appear only after the charts Secret exists **and** the worker can reach `*.i.posthog.com:443`. In-repo NetworkPolicy 443 is not proof of production Cilium egress. The first mw-dev `duckgres-worker` line in the **analytics** project is the egress proof.
 
 ### PostHog Product-Analytics Events
 

--- a/tests/manifests/manifests_test.go
+++ b/tests/manifests/manifests_test.go
@@ -127,6 +127,33 @@ func TestNetworkPolicyCoversReshardRunnerPods(t *testing.T) {
 	}
 }
 
+// TestNetworkPolicyAllowsHTTPSEgressOnControlPlaneWorkerAndReshard pins 443
+// egress on all three process roles that may export PostHog Logs. This is
+// the in-repo kind/manifest contract only — not proof production Cilium
+// allows worker → *.i.posthog.com.
+func TestNetworkPolicyAllowsHTTPSEgressOnControlPlaneWorkerAndReshard(t *testing.T) {
+	manifest := readManifest(t, "k8s", "networkpolicy.yaml")
+	for _, name := range []string{
+		"duckgres-worker-ingress",
+		"duckgres-control-plane-boundaries",
+		"duckgres-reshard-runner-boundaries",
+	} {
+		var doc string
+		for _, candidate := range strings.Split(manifest, "---") {
+			if strings.Contains(candidate, "name: "+name) {
+				doc = candidate
+				break
+			}
+		}
+		if doc == "" {
+			t.Fatalf("could not find %s in k8s/networkpolicy.yaml", name)
+		}
+		if !strings.Contains(doc, "- port: 443") {
+			t.Fatalf("expected 443 egress in %s", name)
+		}
+	}
+}
+
 func TestManifestTestsRunInUnitRecipe(t *testing.T) {
 	content := readManifest(t, "justfile")
 	if !strings.Contains(content, "./tests/manifests/...") {

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -355,6 +355,16 @@ normal `go test ./...` lane.
   and the event stream back, which the Job cannot do for the reason above; the
   key resolution is covered by `TestAnalyticsAPIKeyPrefersDedicatedKey` in
   `internal/cliboot/analytics_test.go`.
+- **PostHog Logs (OTLP)** — `assert_worker_pod` checks plumbing only: the
+  worker must not carry a plaintext `POSTHOG_API_KEY` `value:`, and when the
+  CP container's *named* env has a `secretKeyRef` the worker must copy the
+  same secret name+key. Until charts set that named env the copy branch is
+  skipped; the plaintext assert still runs. **Ingest cannot be asserted
+  in-Job** for the same reason as analytics: the Job holds no PostHog
+  query-API creds and cannot read the destination project. Do not require a
+  successful export. The first mw-dev `service.name=duckgres-worker` record
+  in the **analytics** project is the human egress proof; in-repo
+  NetworkPolicy 443 is not production Cilium.
 
 ## Isolation model
 

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1427,6 +1427,25 @@ assert_worker_pod() { # org password
   [ "$gml" = "$want_gomem" ] || fail "unsized worker $pod ($dcpu/$dmem) GOMEMLIMIT='$gml' want '$want_gomem' (1/8 of pod memory)"
   thr="$worker_threads"
   [ "$thr" = "$want_threads" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_THREADS='$thr' want '$want_threads' (2.5x CPU, rounded up)"
+
+  # PostHog Logs plumbing — not ingest. The Job cannot read PostHog (same
+  # reason as product-analytics events). A plaintext POSTHOG_API_KEY value:
+  # on the worker is always a regression. secretKeyRef copy is asserted only
+  # when the CP named env already has one (charts follow-up); until then this
+  # branch is skipped and the plaintext assert still runs.
+  worker_ph_val="$(k get pod "$pod" -o jsonpath='{range .spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POSTHOG_API_KEY")]}{.value}{end}' 2>/dev/null || true)"
+  [ -z "$worker_ph_val" ] || fail "worker $pod has plaintext POSTHOG_API_KEY value (must be secretKeyRef or omitted)"
+  cp_pod="$(k get pod -l app=duckgres-control-plane --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [ -n "$cp_pod" ]; then
+    cp_ph_name="$(k get pod "$cp_pod" -o jsonpath='{range .spec.containers[*].env[?(@.name=="POSTHOG_API_KEY")]}{.valueFrom.secretKeyRef.name}{end}' 2>/dev/null || true)"
+    cp_ph_key="$(k get pod "$cp_pod" -o jsonpath='{range .spec.containers[*].env[?(@.name=="POSTHOG_API_KEY")]}{.valueFrom.secretKeyRef.key}{end}' 2>/dev/null || true)"
+    if [ -n "$cp_ph_name" ] && [ -n "$cp_ph_key" ]; then
+      w_ph_name="$(k get pod "$pod" -o jsonpath='{range .spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POSTHOG_API_KEY")]}{.valueFrom.secretKeyRef.name}{end}' 2>/dev/null || true)"
+      w_ph_key="$(k get pod "$pod" -o jsonpath='{range .spec.containers[?(@.name=="duckdb-worker")].env[?(@.name=="POSTHOG_API_KEY")]}{.valueFrom.secretKeyRef.key}{end}' 2>/dev/null || true)"
+      [ "$w_ph_name" = "$cp_ph_name" ] && [ "$w_ph_key" = "$cp_ph_key" ] \
+        || fail "worker $pod POSTHOG_API_KEY secretKeyRef '$w_ph_name/$w_ph_key' != CP $cp_pod '$cp_ph_name/$cp_ph_key'"
+    fi
+  fi
 }
 
 # ---- worker sizing (TTL-pool model) ---------------------------------------

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -853,8 +853,11 @@ exit 1
 	if got := strings.Count(callLog, "get pod transitioned-worker"); got != 1 {
 		t.Fatalf("terminal transition inspections = %d, want 1; calls:\n%s", got, callLog)
 	}
-	if got := strings.Count(callLog, "get pod replacement-worker"); got != 1 {
-		t.Fatalf("replacement inspection reads = %d, want 1 atomic snapshot; calls:\n%s", got, callLog)
+	if got := strings.Count(callLog, "get pod replacement-worker -o jsonpath={.metadata.deletionTimestamp"); got != 1 {
+		t.Fatalf("replacement inspection snapshots = %d, want 1; calls:\n%s", got, callLog)
+	}
+	if !strings.Contains(callLog, "get pod replacement-worker -o jsonpath={range .spec.containers") {
+		t.Fatalf("did not run plaintext POSTHOG_API_KEY check on replacement; calls:\n%s", callLog)
 	}
 }
 

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -787,6 +787,11 @@ if [[ "$*" == *"get pods -l app=duckgres-worker,duckgres/active-org=test-org"* ]
   esac
   exit 0
 fi
+if [[ "$*" == *"POSTHOG_API_KEY"* ]]; then
+  # Fixture workers have no PostHog env. Empty output is the success case
+  # for the plaintext-forbidden assert (and skips the secretKeyRef copy).
+  exit 0
+fi
 if [[ "$*" == *"get pod stale-worker"* ]]; then
   echo 'Error from server (NotFound): pods "stale-worker" not found' >&2
   exit 1

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -841,7 +841,7 @@ exit 1
 	if got := strings.Count(callLog, "get pods -l app=duckgres-worker,duckgres/active-org=test-org"); got != 3 {
 		t.Fatalf("worker selections = %d, want 3 (stale, terminal, then replacement); calls:\n%s", got, callLog)
 	}
-	if got := strings.Count(callLog, "--field-selector=status.phase=Running"); got != 3 {
+	if got := strings.Count(callLog, "app=duckgres-worker,duckgres/active-org=test-org --field-selector=status.phase=Running"); got != 3 {
 		t.Fatalf("running-worker selections = %d, want 3; calls:\n%s", got, callLog)
 	}
 	if !strings.Contains(callLog, "get pod stale-worker") {


### PR DESCRIPTION
## Summary

Closes the user-visible contract for PostHog Logs multi-tenant now that worker Secret-ref plumbing exists (#1084).

- README: worker/reshard named `secretKeyRef` copy, never-fail-spawn, charts contract, CP-only first slice, egress proof.
- CLAUDE.md: load-bearing contract (`service.name` roles, redacted query default, WARN default, named secretKeyRef, never fail spawn, `pid` join key, `FlushLogging` drain sites, do not replace `query_log`).
- `assert_worker_pod`: worker must **not** have a plaintext `POSTHOG_API_KEY` `value:`. If the CP named env has a `secretKeyRef`, the worker has the same name+key. Until charts set that, the copy branch is skipped; the plaintext assert still runs. Do **not** require a successful export.
- `tests/mw-dev/README.md`: ingest cannot be asserted in-Job (the Job cannot read PostHog — same reason as analytics). First mw-dev `duckgres-worker` record in the **analytics** project is the egress proof.
- Manifests: keep asserting 443 egress on worker + CP + reshard.

**Stack** #1081 → #1082 → #1083 → #1084 → **(5/5)**

Depends on #1084.

## Test plan

- [x] `go test ./tests/manifests/`
- [x] `bash -n tests/mw-dev/e2e/harness.sh`
- [ ] Charts follow-up still required before the secretKeyRef copy branch fires on mw-dev