### PR TITLE
Add pulled Bloom summary peer lookup

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -12,6 +12,8 @@ available, and forwards cache misses to origin object storage.
 | `CACHE_MAX_PERCENT` | `80` | Ceiling for the cache's share of the cache filesystem, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute: when something outside the cache consumes disk, the budget only ever shrinks, so the cache never evicts healthy entries to make room for writes the disk can't take. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
+| `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing `/cache/has` fanout. `summary` uses periodically pushed Bloom-filter hints and performs at most two direct peer GETs per request; any other value causes startup to fail. |
+| `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque proxy identity carried in summary metadata; it must not be a customer or object identifier. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
 | `CACHE_BLOCK_MODE` | `off` | `on` enables block-aligned caching; any other value (including unset) keeps the legacy exact-range path. See [Block-aligned mode](#block-aligned-mode). |
@@ -21,6 +23,33 @@ available, and forwards cache misses to origin object storage.
 | `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
 
 ## Cluster-wide fetch dedup
+
+### Pushed-summary lookup mode
+
+Set `CACHE_PEER_LOOKUP_MODE=summary` only after deploying an image containing
+the summary endpoint to every cache-proxy pod. Each proxy snapshots at most
+1,000,000 opaque SHA-256 cache locators, builds a versioned Bloom filter at a
+1% target false-positive rate, and publishes it with a 45-second TTL about
+every 20 seconds (with jitter). The uncompressed summary body is capped at
+16 MiB; an oversized snapshot is skipped rather than truncated, so published
+filters never have false negatives for their source snapshot. At 1%, filters
+are about 1.20 bytes per entry: roughly 117 KiB for 100k entries and 1.14 MiB
+for 1m entries, plus small metadata and wire encoding overhead.
+
+On a local miss the requester tests received, non-expired filters locally. No
+positive hint goes straight to origin. Positive hints are ranked by the opaque
+locator and stable proxy identity, then at most two peers receive a direct
+`/cache/get`; 404s, timeouts, stale hints, incompatible peers, and missing
+summaries all safely fall back to origin. There is no cache-body replication.
+The peer transport is the existing internal HTTP boundary and does not itself
+provide authentication; membership validation only bounds retained hints.
+
+Roll out in non-production first. During a rolling enablement, missing
+summaries reduce peer hits but remain safe. Validate that peer probes per
+logical lookup approach zero, direct peer GET attempts stay at or below two,
+peer bytes remain useful, origin latency/bytes do not regress excessively,
+and summary memory/publication traffic remain bounded. Recover by restoring
+`CACHE_PEER_LOOKUP_MODE=probe`; do not delete cache contents.
 
 When several nodes want the same key at the same moment, only the first to
 start the fill should ever hit the origin. The peer API makes each node's

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -31,13 +31,16 @@ the summary endpoint to every cache-proxy pod. Each proxy snapshots at most
 1,000,000 opaque SHA-256 cache locators, builds a versioned Bloom filter at a
 1% target false-positive rate, and publishes it with a 45-second TTL about
 every 20 seconds (with jitter). The uncompressed summary body is capped at
-16 MiB; an oversized snapshot is skipped rather than truncated, so published
+2 MiB and resident peer summaries at 512 MiB; an oversized snapshot is skipped rather than truncated, so published
 filters never have false negatives for their source snapshot. At 1%, filters
 are about 1.20 bytes per entry: roughly 117 KiB for 100k entries and 1.14 MiB
 for 1m entries, plus small metadata and wire encoding overhead.
 
 On a local miss the requester tests received, non-expired filters locally. No
-positive hint goes straight to origin. Positive hints are ranked by the opaque
+positive hint goes straight to origin once every discovered peer has supplied a
+valid summary. During startup or after a peer joins, only peers that have not
+yet supplied a valid summary retain the legacy probe fallback; this preserves
+cold-start peer-hit behavior while summaries converge. Positive hints are ranked by the opaque
 locator and stable proxy identity, then at most two peers receive a direct
 `/cache/get`; 404s, timeouts, stale hints, incompatible peers, and missing
 summaries all safely fall back to origin. There is no cache-body replication.
@@ -46,7 +49,7 @@ provide authentication; membership validation only bounds retained hints.
 
 Roll out in non-production first. During a rolling enablement, missing
 summaries reduce peer hits but remain safe. Validate that peer probes per
-logical lookup approach zero, direct peer GET attempts stay at or below two,
+logical lookup approach zero after peer-summary coverage converges, direct peer GET attempts stay at or below two,
 peer bytes remain useful, origin latency/bytes do not regress excessively,
 and summary memory/publication traffic remain bounded. Recover by restoring
 `CACHE_PEER_LOOKUP_MODE=probe`; do not delete cache contents.

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -10,9 +10,13 @@ available, and forwards cache misses to origin object storage.
 | --- | --- | --- |
 | `CACHE_DIR` | `/cache` | Local disk cache directory. |
 | `CACHE_MAX_PERCENT` | `80` | Ceiling for the cache's share of the cache filesystem, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute: when something outside the cache consumes disk, the budget only ever shrinks, so the cache never evicts healthy entries to make room for writes the disk can't take. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Hard LRU entry-count ceiling, enforced alongside the disk-byte ceiling. Bounds local cache-index memory. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing `/cache/has` fanout. `summary` uses periodically pushed Bloom-filter hints and performs at most two direct peer GETs per request; any other value causes startup to fail. |
+| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Total local Bloom-state budget: counting filter, publication/receipt reserve, and dynamically retained remote peer summaries. Peers that do not fit remain uncovered. |
+| `CACHE_PEER_MAX_PROBES` | `5` | In summary mode, maximum fallback `/cache/has` probes per client request across all missing blocks. |
+| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Per-pod non-blocking cap on concurrent summary-mode fallback probes. When exhausted, the request skips probes and fetches origin. |
 | `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque proxy identity carried in summary metadata; it must not be a customer or object identifier. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
@@ -36,11 +40,18 @@ locators at a 1% target false-positive rate (1.14 MiB bits plus 18.3 MiB local
 16-bit counters); the JSON wire body is bounded to 2 MiB and resident peer
 summaries to 512 MiB.
 
-The filter continues accepting entries above 1,000,000 rather than ceasing
-publication. Its false-positive rate then rises smoothly; monitor
+The default local cache entry limit keeps this filter at its 1,000,000-key,
+1% design point. If an operator raises that limit, the filter continues
+accepting entries and its false-positive rate rises smoothly; monitor
 `cache_proxy_summary_bloom_false_positive_ratio` and
 `cache_proxy_summary_bloom_saturated`. Counter overflow is deliberately
 sticky, which can add false positives but cannot create false negatives.
+
+The aggregate Bloom budget retains a deterministic subset of remote peer
+summaries when the cluster is too large to fit them all. Unretained peers are
+explicitly uncovered. A request probes at most `CACHE_PEER_MAX_PROBES` of
+those peers, and the per-pod in-flight probe limit is non-blocking: an
+exhausted budget goes straight to origin instead of queuing work.
 
 On a local miss the requester tests received, non-expired filters locally. No
 positive hint goes straight to origin once every discovered peer has supplied a

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -9,15 +9,15 @@ available, and forwards cache misses to origin object storage.
 | Setting | Default | Notes |
 | --- | --- | --- |
 | `CACHE_DIR` | `/cache` | Local disk cache directory. |
-| `CACHE_MAX_PERCENT` | `80` | Convergent target for the cache's share of the cache filesystem, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute: when something outside the cache consumes disk, the budget only ever shrinks, so the cache never evicts healthy entries to make room for writes the disk can't take. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Convergent LRU entry-count target, enforced alongside the disk-byte target. Bounds steady-state local cache-index memory. |
+| `CACHE_MAX_PERCENT` | `80` | Target for tracked cache bytes, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute; the target only shrinks. Completed commits evict to this target, except that one entry larger than the target is retained. Concurrent temporary files are outside tracked-byte accounting. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Strict maximum tracked LRU entries after each serialized final commit. Bounds local cache-index memory. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing fleet-wide `/cache/has` behavior. `summary` pulls Bloom-filter hints and uses them to eliminate definite-negative peers before bounded `/cache/has` confirmation; any other value causes startup to fail. |
 | `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Total local Bloom-state budget: counting filter, snapshot and pull-work reserve, and a deterministic receiver-selected subset of remote peer summaries. Peers that do not fit remain uncovered. |
 | `CACHE_PEER_MAX_PROBES` | `5` | In summary mode, maximum parallel `/cache/has` confirmations per client request across all missing blocks. |
-| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Per-pod non-blocking cap on concurrent summary-mode `/cache/has` confirmations. When exhausted, confirmations are skipped and the request fetches origin. |
-| `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque proxy identity carried in summary metadata; it must not be a customer or object identifier. |
+| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Per-pod non-blocking cap on active summary-mode `/cache/has` HTTP requests and sockets. It is not a process goroutine limit. When exhausted, confirmations are skipped and the request fetches origin. |
+| `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque receiver identity used for deterministic peer-summary selection; it must not be a customer or object identifier. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
 | `CACHE_BLOCK_MODE` | `off` | `on` enables block-aligned caching; any other value (including unset) keeps the legacy exact-range path. See [Block-aligned mode](#block-aligned-mode). |
@@ -26,99 +26,44 @@ available, and forwards cache misses to origin object storage.
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` | empty | OTLP/HTTP trace endpoint. Unset → tracing is a no-op. |
 | `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
 
-The byte and entry-count limits are convergent rather than strict admission
-limits. Cache fills write concurrently and make room using the cache state
-visible before they commit, so several fills completing together may leave the
-cache temporarily above either target. Entry-count overshoot is bounded by the
-number of concurrently committing distinct entries; byte overshoot is bounded
-by the aggregate size of those concurrent commits. A subsequent cache insertion
-evicts least-recently-used entries back toward both targets. This keeps body and
-filesystem I/O concurrent instead of serializing it behind the cache-index lock.
+Cache bodies stream concurrently into temporary files. Only the short final
+rename plus exact-index, LRU, byte-count, and counting-Bloom update is serialized.
+That commit evicts before returning, so completed commits cannot exceed
+`CACHE_MAX_ENTRIES`, and tracked bytes do not exceed the current disk target
+unless a single retained entry is itself larger than that target. Concurrent
+temporary files consume real disk but are not yet tracked cache entries.
 
 ## Cluster-wide fetch dedup
 
 ### Pulled-summary lookup mode
 
 Set `CACHE_PEER_LOOKUP_MODE=summary` only after deploying an image containing
-the summary endpoint to every cache-proxy pod. Each proxy maintains a bounded,
-versioned counting Bloom filter incrementally as cache entries are committed
-and evicted. About every 20 seconds, with per-process jitter, it creates an
-immutable snapshot with a 45-second TTL and pulls snapshots from the peers it
-has selected to track. Snapshotting copies the bits; it does not scan or rehash
-the cache index. `GET /cache/summary` supports `ETag`/`If-None-Match`, has a
-strict 2 MiB body limit, and never includes raw URLs, ranges, object paths, or
-cache locators.
+the summary endpoint to every cache-proxy pod. Each proxy incrementally tracks
+its local entries in a fixed counting Bloom filter and periodically exposes an
+immutable snapshot through `GET /cache/summary`. Receivers pull only the
+deterministic peer subset that fits `CACHE_SUMMARY_MEMORY_LIMIT_BYTES`.
+Probe-mode pods do not build or serve summaries, so a canary starts with
+partial coverage and uses the bounded fallback while snapshots converge.
 
-The filter is sized for 1,000,000 opaque SHA-256 cache locators at a 1% target
-false-positive rate: approximately 1.14 MiB of published bits plus 18.3 MiB of
-local 16-bit counters. The 512 MiB default aggregate budget also reserves room
-for the local filter, overlapping immutable snapshot generations, a temporary
-raw snapshot, and four concurrent bounded pulls. The remaining approximately
-474.8 MiB fits 415 fixed-size peer filters. At smaller fleet sizes, approximate
-per-pod Bloom-state usage is 47.5 MiB for 10 nodes, 70.3 MiB for 30 nodes, and
-150.3 MiB for 100 nodes. These
-figures exclude the exact local cache index and general Go/HTTP runtime memory.
+Bloom filters are used only to eliminate definite negatives. Bloom-positive
+and not-yet-covered peers remain candidates and must pass an exact, bounded
+`/cache/has` confirmation before the requester sends one `/cache/get` to the
+confirmed holder. The per-request and pod-wide settings above bound candidate
+selection and active confirmation HTTP work; skipped or failed peer work falls
+back to origin.
 
-The default local cache entry limit keeps this filter at its 1,000,000-key,
-1% design point. If an operator raises that limit, the filter continues
-accepting entries and its false-positive rate rises smoothly; monitor
-`cache_proxy_summary_bloom_false_positive_ratio` and
-`cache_proxy_summary_bloom_saturated`. Counter overflow is deliberately
-sticky, which can add false positives but cannot create false negatives.
+DNS membership is refreshed every 10 seconds. Newly selected peers receive a
+priority pull and remain uncovered until a valid snapshot arrives; departed
+peer summaries are removed at the next successful refresh. A fully covered
+Bloom-negative miss goes directly to origin, so summaries can trade some
+cold-key fleet-wide deduplication for bounded request-time work.
 
-Each receiver ranks discovered peers deterministically from its own stable
-identity and peer address, then pulls only the subset that fits its remaining
-summary budget. This admission happens before network transfer. Unselected,
-expired, incompatible, and not-yet-pulled peers are explicitly uncovered.
-Four workers pull selected peers with a two-second whole-response timeout,
-short connect and response-header deadlines, a 15-second whole-cycle deadline,
-fair rotation across deadline-limited cycles, and cancellation on shutdown.
-Peer ETags are retained only in a small bounded form, and the summary endpoint
-has its own two-second write deadline without constraining streamed peer cache
-bodies. Failed pulls retain the last valid, unexpired snapshot; there is no
-retry queue. The next membership-triggered or periodic pull is the retry.
-
-On a local miss the requester tests current, compatible, non-expired summaries
-locally. A Bloom negative eliminates that covered peer. Bloom positives are
-only candidates: they are never trusted as proof that the peer has the entry.
-The requester deterministically selects at most `CACHE_PEER_MAX_PROBES`
-candidates from the positives and uncovered peers. With at least two slots it
-reserves one for an uncovered peer when both classes exist; a one-slot override
-ranks both classes together. It then sends parallel `/cache/has`
-confirmations. The first useful `200` stored or `202` in-flight claim wins.
-Losing confirmations are canceled, and only the confirmed holder receives the
-subsequent `/cache/get`. The per-pod in-flight limit is non-blocking: when all
-64 default permits are occupied, excess work skips peer confirmation and goes
-to origin rather than queuing.
-
-When every discovered peer has a valid summary and none is positive, the
-request goes directly to origin with no peer RPC. This also means summary mode
-does not discover a just-started in-flight fill whose key is absent from the
-last snapshot; simultaneous first access on multiple pods can duplicate that
-origin fetch. Entries committed after a peer's last snapshot may similarly be
-missed until the next pull. These are safe locality losses, not correctness
-failures. False positives cost only a bounded `/cache/has`, and evictions
-advertised by an older snapshot cannot cause an unconfirmed body GET.
-
-DNS membership is refreshed every 10 seconds. A newly selected peer triggers
-an immediate pull and remains uncovered until a valid snapshot arrives; a new
-peer outside the receiver's memory-selected subset remains uncovered. When a
-peer disappears, its snapshot is removed on the next successful membership
-refresh and it is no longer selected for lookup. Until then, transport failure
-falls back safely. There is no cache-body replication. The peer transport is
-the existing internal HTTP boundary and does not itself provide authentication;
-membership and selection checks bound retained hints but are not authorization.
-
-Roll out in non-production first. During a rolling enablement, peers without a
-compatible GET summary endpoint remain uncovered; their bounded confirmation
-or origin fallback is safe. Validate that physical probes per logical lookup
-remain below the configured cap, confirmed peer GETs stay useful, Bloom
-false-positive rate remains within the rollout budget, origin latency and bytes
-do not regress excessively, and summary pull traffic and resident memory remain
-bounded. Recover by restoring `CACHE_PEER_LOOKUP_MODE=probe`; do not delete
-cache contents. See
-[the pulled-summary design and runbook](../../docs/design/cache-proxy-pulled-summary-lookup.md)
-for sizing, failure behavior, and detailed rollout checks.
+Roll out in non-production, monitor summary coverage and memory, confirmation
+amplification, confirmed GET usefulness, and origin latency/bytes, then enable
+gradually. Roll back by restoring `CACHE_PEER_LOOKUP_MODE=probe`; cache contents
+do not need deletion. The authoritative protocol, sizing model, failure table,
+rollout procedure, and runbook are in
+[the pulled-summary design](../../docs/design/cache-proxy-pulled-summary-lookup.md).
 
 In `probe` mode, when several nodes want the same key at the same moment, the
 fleet-wide lookup lets later requesters observe the first node's in-flight

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -27,14 +27,20 @@ available, and forwards cache misses to origin object storage.
 ### Pushed-summary lookup mode
 
 Set `CACHE_PEER_LOOKUP_MODE=summary` only after deploying an image containing
-the summary endpoint to every cache-proxy pod. Each proxy snapshots at most
-1,000,000 opaque SHA-256 cache locators, builds a versioned Bloom filter at a
-1% target false-positive rate, and publishes it with a 45-second TTL about
-every 20 seconds (with jitter). The uncompressed summary body is capped at
-2 MiB and resident peer summaries at 512 MiB; an oversized snapshot is skipped rather than truncated, so published
-filters never have false negatives for their source snapshot. At 1%, filters
-are about 1.20 bytes per entry: roughly 117 KiB for 100k entries and 1.14 MiB
-for 1m entries, plus small metadata and wire encoding overhead.
+the summary endpoint to every cache-proxy pod. Each proxy maintains a bounded,
+versioned counting Bloom filter incrementally as cache entries are committed
+and evicted, then publishes an immutable bit snapshot with a 45-second TTL
+about every 20 seconds (with jitter). Publication therefore does not scan or
+rehash the cache index. The filter is sized for 1,000,000 opaque SHA-256 cache
+locators at a 1% target false-positive rate (1.14 MiB bits plus 18.3 MiB local
+16-bit counters); the JSON wire body is bounded to 2 MiB and resident peer
+summaries to 512 MiB.
+
+The filter continues accepting entries above 1,000,000 rather than ceasing
+publication. Its false-positive rate then rises smoothly; monitor
+`cache_proxy_summary_bloom_false_positive_ratio` and
+`cache_proxy_summary_bloom_saturated`. Counter overflow is deliberately
+sticky, which can add false positives but cannot create false negatives.
 
 On a local miss the requester tests received, non-expired filters locally. No
 positive hint goes straight to origin once every discovered peer has supplied a
@@ -50,8 +56,9 @@ provide authentication; membership validation only bounds retained hints.
 Roll out in non-production first. During a rolling enablement, missing
 summaries reduce peer hits but remain safe. Validate that peer probes per
 logical lookup approach zero after peer-summary coverage converges, direct peer GET attempts stay at or below two,
-peer bytes remain useful, origin latency/bytes do not regress excessively,
-and summary memory/publication traffic remain bounded. Recover by restoring
+peer bytes remain useful, Bloom false-positive rate stays within the rollout
+budget, origin latency/bytes do not regress excessively, and summary
+memory/publication traffic remain bounded. Recover by restoring
 `CACHE_PEER_LOOKUP_MODE=probe`; do not delete cache contents.
 
 When several nodes want the same key at the same moment, only the first to

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -9,8 +9,8 @@ available, and forwards cache misses to origin object storage.
 | Setting | Default | Notes |
 | --- | --- | --- |
 | `CACHE_DIR` | `/cache` | Local disk cache directory. |
-| `CACHE_MAX_PERCENT` | `80` | Ceiling for the cache's share of the cache filesystem, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute: when something outside the cache consumes disk, the budget only ever shrinks, so the cache never evicts healthy entries to make room for writes the disk can't take. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Hard LRU entry-count ceiling, enforced alongside the disk-byte ceiling. Bounds local cache-index memory. |
+| `CACHE_MAX_PERCENT` | `80` | Convergent target for the cache's share of the cache filesystem, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute: when something outside the cache consumes disk, the budget only ever shrinks, so the cache never evicts healthy entries to make room for writes the disk can't take. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Convergent LRU entry-count target, enforced alongside the disk-byte target. Bounds steady-state local cache-index memory. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing `/cache/has` fanout. `summary` uses periodically pushed Bloom-filter hints and performs at most two direct peer GETs per request; any other value causes startup to fail. |
@@ -25,6 +25,15 @@ available, and forwards cache misses to origin object storage.
 | `CACHE_BLOCK_MAX_SPAN_BLOCKS` | `8` | Max blocks coalesced into one origin range fetch. Ignored when block mode is off. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` | empty | OTLP/HTTP trace endpoint. Unset → tracing is a no-op. |
 | `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
+
+The byte and entry-count limits are convergent rather than strict admission
+limits. Cache fills write concurrently and make room using the cache state
+visible before they commit, so several fills completing together may leave the
+cache temporarily above either target. Entry-count overshoot is bounded by the
+number of concurrently committing distinct entries; byte overshoot is bounded
+by the aggregate size of those concurrent commits. A subsequent cache insertion
+evicts least-recently-used entries back toward both targets. This keeps body and
+filesystem I/O concurrent instead of serializing it behind the cache-index lock.
 
 ## Cluster-wide fetch dedup
 

--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -13,10 +13,10 @@ available, and forwards cache misses to origin object storage.
 | `CACHE_MAX_ENTRIES` | `1000000` | Convergent LRU entry-count target, enforced alongside the disk-byte target. Bounds steady-state local cache-index memory. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
-| `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing `/cache/has` fanout. `summary` uses periodically pushed Bloom-filter hints and performs at most two direct peer GETs per request; any other value causes startup to fail. |
-| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Total local Bloom-state budget: counting filter, publication/receipt reserve, and dynamically retained remote peer summaries. Peers that do not fit remain uncovered. |
-| `CACHE_PEER_MAX_PROBES` | `5` | In summary mode, maximum fallback `/cache/has` probes per client request across all missing blocks. |
-| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Per-pod non-blocking cap on concurrent summary-mode fallback probes. When exhausted, the request skips probes and fetches origin. |
+| `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing fleet-wide `/cache/has` behavior. `summary` pulls Bloom-filter hints and uses them to eliminate definite-negative peers before bounded `/cache/has` confirmation; any other value causes startup to fail. |
+| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Total local Bloom-state budget: counting filter, snapshot and pull-work reserve, and a deterministic receiver-selected subset of remote peer summaries. Peers that do not fit remain uncovered. |
+| `CACHE_PEER_MAX_PROBES` | `5` | In summary mode, maximum parallel `/cache/has` confirmations per client request across all missing blocks. |
+| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Per-pod non-blocking cap on concurrent summary-mode `/cache/has` confirmations. When exhausted, confirmations are skipped and the request fetches origin. |
 | `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque proxy identity carried in summary metadata; it must not be a customer or object identifier. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
@@ -37,17 +37,27 @@ filesystem I/O concurrent instead of serializing it behind the cache-index lock.
 
 ## Cluster-wide fetch dedup
 
-### Pushed-summary lookup mode
+### Pulled-summary lookup mode
 
 Set `CACHE_PEER_LOOKUP_MODE=summary` only after deploying an image containing
 the summary endpoint to every cache-proxy pod. Each proxy maintains a bounded,
 versioned counting Bloom filter incrementally as cache entries are committed
-and evicted, then publishes an immutable bit snapshot with a 45-second TTL
-about every 20 seconds (with jitter). Publication therefore does not scan or
-rehash the cache index. The filter is sized for 1,000,000 opaque SHA-256 cache
-locators at a 1% target false-positive rate (1.14 MiB bits plus 18.3 MiB local
-16-bit counters); the JSON wire body is bounded to 2 MiB and resident peer
-summaries to 512 MiB.
+and evicted. About every 20 seconds, with per-process jitter, it creates an
+immutable snapshot with a 45-second TTL and pulls snapshots from the peers it
+has selected to track. Snapshotting copies the bits; it does not scan or rehash
+the cache index. `GET /cache/summary` supports `ETag`/`If-None-Match`, has a
+strict 2 MiB body limit, and never includes raw URLs, ranges, object paths, or
+cache locators.
+
+The filter is sized for 1,000,000 opaque SHA-256 cache locators at a 1% target
+false-positive rate: approximately 1.14 MiB of published bits plus 18.3 MiB of
+local 16-bit counters. The 512 MiB default aggregate budget also reserves room
+for the local filter, overlapping immutable snapshot generations, a temporary
+raw snapshot, and four concurrent bounded pulls. The remaining approximately
+474.8 MiB fits 415 fixed-size peer filters. At smaller fleet sizes, approximate
+per-pod Bloom-state usage is 47.5 MiB for 10 nodes, 70.3 MiB for 30 nodes, and
+150.3 MiB for 100 nodes. These
+figures exclude the exact local cache index and general Go/HTTP runtime memory.
 
 The default local cache entry limit keeps this filter at its 1,000,000-key,
 1% design point. If an operator raises that limit, the filter continues
@@ -56,34 +66,65 @@ accepting entries and its false-positive rate rises smoothly; monitor
 `cache_proxy_summary_bloom_saturated`. Counter overflow is deliberately
 sticky, which can add false positives but cannot create false negatives.
 
-The aggregate Bloom budget retains a deterministic subset of remote peer
-summaries when the cluster is too large to fit them all. Unretained peers are
-explicitly uncovered. A request probes at most `CACHE_PEER_MAX_PROBES` of
-those peers, and the per-pod in-flight probe limit is non-blocking: an
-exhausted budget goes straight to origin instead of queuing work.
+Each receiver ranks discovered peers deterministically from its own stable
+identity and peer address, then pulls only the subset that fits its remaining
+summary budget. This admission happens before network transfer. Unselected,
+expired, incompatible, and not-yet-pulled peers are explicitly uncovered.
+Four workers pull selected peers with a two-second whole-response timeout,
+short connect and response-header deadlines, a 15-second whole-cycle deadline,
+fair rotation across deadline-limited cycles, and cancellation on shutdown.
+Peer ETags are retained only in a small bounded form, and the summary endpoint
+has its own two-second write deadline without constraining streamed peer cache
+bodies. Failed pulls retain the last valid, unexpired snapshot; there is no
+retry queue. The next membership-triggered or periodic pull is the retry.
 
-On a local miss the requester tests received, non-expired filters locally. No
-positive hint goes straight to origin once every discovered peer has supplied a
-valid summary. During startup or after a peer joins, only peers that have not
-yet supplied a valid summary retain the legacy probe fallback; this preserves
-cold-start peer-hit behavior while summaries converge. Positive hints are ranked by the opaque
-locator and stable proxy identity, then at most two peers receive a direct
-`/cache/get`; 404s, timeouts, stale hints, incompatible peers, and missing
-summaries all safely fall back to origin. There is no cache-body replication.
-The peer transport is the existing internal HTTP boundary and does not itself
-provide authentication; membership validation only bounds retained hints.
+On a local miss the requester tests current, compatible, non-expired summaries
+locally. A Bloom negative eliminates that covered peer. Bloom positives are
+only candidates: they are never trusted as proof that the peer has the entry.
+The requester deterministically selects at most `CACHE_PEER_MAX_PROBES`
+candidates from the positives and uncovered peers. With at least two slots it
+reserves one for an uncovered peer when both classes exist; a one-slot override
+ranks both classes together. It then sends parallel `/cache/has`
+confirmations. The first useful `200` stored or `202` in-flight claim wins.
+Losing confirmations are canceled, and only the confirmed holder receives the
+subsequent `/cache/get`. The per-pod in-flight limit is non-blocking: when all
+64 default permits are occupied, excess work skips peer confirmation and goes
+to origin rather than queuing.
 
-Roll out in non-production first. During a rolling enablement, missing
-summaries reduce peer hits but remain safe. Validate that peer probes per
-logical lookup approach zero after peer-summary coverage converges, direct peer GET attempts stay at or below two,
-peer bytes remain useful, Bloom false-positive rate stays within the rollout
-budget, origin latency/bytes do not regress excessively, and summary
-memory/publication traffic remain bounded. Recover by restoring
-`CACHE_PEER_LOOKUP_MODE=probe`; do not delete cache contents.
+When every discovered peer has a valid summary and none is positive, the
+request goes directly to origin with no peer RPC. This also means summary mode
+does not discover a just-started in-flight fill whose key is absent from the
+last snapshot; simultaneous first access on multiple pods can duplicate that
+origin fetch. Entries committed after a peer's last snapshot may similarly be
+missed until the next pull. These are safe locality losses, not correctness
+failures. False positives cost only a bounded `/cache/has`, and evictions
+advertised by an older snapshot cannot cause an unconfirmed body GET.
 
-When several nodes want the same key at the same moment, only the first to
-start the fill should ever hit the origin. The peer API makes each node's
-in-flight fetches visible to the rest:
+DNS membership is refreshed every 10 seconds. A newly selected peer triggers
+an immediate pull and remains uncovered until a valid snapshot arrives; a new
+peer outside the receiver's memory-selected subset remains uncovered. When a
+peer disappears, its snapshot is removed on the next successful membership
+refresh and it is no longer selected for lookup. Until then, transport failure
+falls back safely. There is no cache-body replication. The peer transport is
+the existing internal HTTP boundary and does not itself provide authentication;
+membership and selection checks bound retained hints but are not authorization.
+
+Roll out in non-production first. During a rolling enablement, peers without a
+compatible GET summary endpoint remain uncovered; their bounded confirmation
+or origin fallback is safe. Validate that physical probes per logical lookup
+remain below the configured cap, confirmed peer GETs stay useful, Bloom
+false-positive rate remains within the rollout budget, origin latency and bytes
+do not regress excessively, and summary pull traffic and resident memory remain
+bounded. Recover by restoring `CACHE_PEER_LOOKUP_MODE=probe`; do not delete
+cache contents. See
+[the pulled-summary design and runbook](../../docs/design/cache-proxy-pulled-summary-lookup.md)
+for sizing, failure behavior, and detailed rollout checks.
+
+In `probe` mode, when several nodes want the same key at the same moment, the
+fleet-wide lookup lets later requesters observe the first node's in-flight
+fill. Summary mode preserves the `202` mechanism among its bounded confirmation
+candidates, but a fully covered Bloom-negative lookup goes directly to origin
+as described above. The peer API exposes cached and in-flight state:
 
 - `GET /cache/has?key=…` — `200` the entry is cached (counts as an access for
   LRU recency); `202` the entry isn't cached yet but a local fill is
@@ -94,11 +135,12 @@ in-flight fetches visible to the rest:
   of 404ing the requester back to the origin for the same bytes it is already
   fetching.
 
-A missing key therefore resolves as: local index → peer that has it (`200`,
-first answer wins) → peer mid-flight on it (`202`, wait for that fill) →
-origin. Transfers from a peer have no whole-request timeout (a multi-MB body
-moving over a loaded link must not be killed for being large) — only a
-response-header deadline sized to cover the bounded flight wait.
+A probe-mode missing key therefore resolves as: local index → peer that has
+it (`200`, first answer wins) → peer mid-flight on it (`202`, wait for that
+fill) → origin. Summary mode inserts local Bloom elimination before a bounded
+version of that confirmation step. Transfers from a peer have no whole-request
+timeout (a multi-MB body moving over a loaded link must not be killed for being
+large) — only a response-header deadline sized to cover the bounded flight wait.
 
 All lookup state comes from the in-memory index under the cache mutex, not
 from filesystem stats, so `/cache/has` and eviction/size accounting can never

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -243,6 +243,10 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	// merely per block. Remaining block misses safely coalesce to origin.
 	summaryGetsLeft := 2
 	summaryLookupRecorded := false
+	summaryProbesLeft := 0
+	if p.peers != nil {
+		summaryProbesLeft = p.peers.peerMaxProbes
+	}
 	flushRun := func(runEnd int64) bool {
 		if missRunStart < 0 {
 			return true
@@ -338,9 +342,12 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 					}
 					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
 				}
-				if len(positive) == 0 {
-					if holder, flight, found := p.peers.LocateKeyAmong(r.Context(), key, uncovered); found {
+				if len(positive) == 0 && summaryProbesLeft > 0 {
+					if holder, flight, found, selected := p.peers.LocateKeyAmong(r.Context(), key, uncovered, summaryProbesLeft); found {
+						summaryProbesLeft -= selected
 						_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) { return p.store.PutStream(key, rd) })
+					} else {
+						summaryProbesLeft -= selected
 					}
 				}
 			} else if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -182,19 +180,11 @@ func (p *CacheProxy) fetchOriginSpan(r *http.Request, blockSize, firstIdx, lastI
 	return nil
 }
 
-// blockPresent reports whether a block's bytes are on local disk. It checks
-// the tracked index first (the common case, and the one that drives LRU
-// recency) but also accepts a tracked-file-still-syncing entry: a concurrent
-// PutStream lands its file (rename) a moment before it lands the LRU
-// accounting (addLocked), so an index-only Has can race a just-filled block
-// and report it missing while its bytes are already servable. Neither peek
-// counts as an access — openFile (phase 2) does the touching.
+// blockPresent reports whether a block is a committed, tracked cache entry.
+// PutStream makes rename and index accounting one atomic commit under the
+// cache mutex, so an untracked file is never authoritative.
 func (p *CacheProxy) blockPresent(key string) bool {
-	if p.store.Has(key) {
-		return true
-	}
-	_, err := os.Stat(filepath.Join(p.store.dir, key))
-	return err == nil
+	return p.store.Has(key)
 }
 
 // serveBlockAligned serves a cacheable GET whose Range is an absolute
@@ -337,9 +327,9 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 						summaryGetsLeft--
 						_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) { return p.store.PutStream(key, rd) })
 						if ok {
-							peerDirectGetsTotal.WithLabelValues("success").Inc()
+							summaryConfirmedGetsTotal.WithLabelValues("success").Inc()
 						} else {
-							peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+							summaryConfirmedGetsTotal.WithLabelValues("miss_or_error").Inc()
 						}
 					}
 				}

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -243,8 +243,6 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	// merely per block. Remaining block misses safely coalesce to origin.
 	summaryGetsLeft := 2
 	summaryLookupRecorded := false
-	summaryCtx, cancelSummary := context.WithTimeout(r.Context(), peerHasTimeout)
-	defer cancelSummary()
 	flushRun := func(runEnd int64) bool {
 		if missRunStart < 0 {
 			return true
@@ -325,12 +323,13 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 					peerFetchesTotal.Inc()
 					summaryLookupRecorded = true
 				}
-				for _, holder := range p.peers.SummaryCandidates(key, time.Now()) {
-					if summaryGetsLeft == 0 || summaryCtx.Err() != nil {
+				positive, uncovered := p.peers.SummaryLookup(key, time.Now())
+				for _, holder := range positive {
+					if summaryGetsLeft == 0 {
 						break
 					}
 					summaryGetsLeft--
-					_, ok = p.peers.FetchFromPeer(summaryCtx, holder, key, false, func(rd io.Reader) (int64, error) {
+					_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, false, func(rd io.Reader) (int64, error) {
 						return p.store.PutStream(key, rd)
 					})
 					if ok {
@@ -338,6 +337,11 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 						break
 					}
 					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+				}
+				if len(positive) == 0 {
+					if holder, flight, found := p.peers.LocateKeyAmong(r.Context(), key, uncovered); found {
+						_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) { return p.store.PutStream(key, rd) })
+					}
 				}
 			} else if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {
 				_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) {

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -17,6 +17,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const maxSummaryBlockPeerGetsPerRequest = 2
+
 var (
 	cacheOriginBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "cache_proxy_origin_bytes_total",
@@ -241,7 +243,7 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	var missRunStart int64 = -1
 	// Summary mode bounds direct peer I/O across the entire block request, not
 	// merely per block. Remaining block misses safely coalesce to origin.
-	summaryGetsLeft := 2
+	summaryGetsLeft := maxSummaryBlockPeerGetsPerRequest
 	summaryLookupRecorded := false
 	summaryProbesLeft := 0
 	if p.peers != nil {
@@ -323,31 +325,22 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 			peerStart := time.Now()
 			ok := false
 			if p.peers.lookupMode == peerLookupSummary {
-				if !summaryLookupRecorded {
-					peerFetchesTotal.Inc()
-					summaryLookupRecorded = true
-				}
-				positive, uncovered := p.peers.SummaryLookup(key, time.Now())
-				for _, holder := range positive {
-					if summaryGetsLeft == 0 {
-						break
+				if summaryGetsLeft > 0 && summaryProbesLeft > 0 {
+					if !summaryLookupRecorded {
+						peerFetchesTotal.Inc()
+						summaryLookupRecorded = true
 					}
-					summaryGetsLeft--
-					_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, false, func(rd io.Reader) (int64, error) {
-						return p.store.PutStream(key, rd)
-					})
-					if ok {
-						peerDirectGetsTotal.WithLabelValues("success").Inc()
-						break
-					}
-					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
-				}
-				if len(positive) == 0 && summaryProbesLeft > 0 {
-					if holder, flight, found, selected := p.peers.LocateKeyAmong(r.Context(), key, uncovered, summaryProbesLeft); found {
-						summaryProbesLeft -= selected
+					positive, uncovered := p.peers.SummaryLookup(key, time.Now())
+					holder, flight, found, selected := p.peers.LocateSummaryKey(r.Context(), key, positive, uncovered, summaryProbesLeft)
+					summaryProbesLeft -= selected
+					if found {
+						summaryGetsLeft--
 						_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) { return p.store.PutStream(key, rd) })
-					} else {
-						summaryProbesLeft -= selected
+						if ok {
+							peerDirectGetsTotal.WithLabelValues("success").Inc()
+						} else {
+							peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+						}
 					}
 				}
 			} else if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {

--- a/cmd/cache-proxy/block_serve.go
+++ b/cmd/cache-proxy/block_serve.go
@@ -239,6 +239,12 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 	// hit/miss accounting and the log line.
 	var nLocal, nPeer, nOrigin int64
 	var missRunStart int64 = -1
+	// Summary mode bounds direct peer I/O across the entire block request, not
+	// merely per block. Remaining block misses safely coalesce to origin.
+	summaryGetsLeft := 2
+	summaryLookupRecorded := false
+	summaryCtx, cancelSummary := context.WithTimeout(r.Context(), peerHasTimeout)
+	defer cancelSummary()
 	flushRun := func(runEnd int64) bool {
 		if missRunStart < 0 {
 			return true
@@ -314,7 +320,26 @@ func (p *CacheProxy) serveBlockAligned(w http.ResponseWriter, r *http.Request, r
 		if p.peers != nil {
 			peerStart := time.Now()
 			ok := false
-			if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {
+			if p.peers.lookupMode == peerLookupSummary {
+				if !summaryLookupRecorded {
+					peerFetchesTotal.Inc()
+					summaryLookupRecorded = true
+				}
+				for _, holder := range p.peers.SummaryCandidates(key, time.Now()) {
+					if summaryGetsLeft == 0 || summaryCtx.Err() != nil {
+						break
+					}
+					summaryGetsLeft--
+					_, ok = p.peers.FetchFromPeer(summaryCtx, holder, key, false, func(rd io.Reader) (int64, error) {
+						return p.store.PutStream(key, rd)
+					})
+					if ok {
+						peerDirectGetsTotal.WithLabelValues("success").Inc()
+						break
+					}
+					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+				}
+			} else if holder, flight, found := p.peers.LocateKey(r.Context(), key); found {
 				_, ok = p.peers.FetchFromPeer(r.Context(), holder, key, flight, func(rd io.Reader) (int64, error) {
 					return p.store.PutStream(key, rd)
 				})

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -94,8 +94,8 @@ type DiskCache struct {
 	// at the back. index maps a key to its element for O(1) touch/drop.
 	order *list.List
 	index map[string]*list.Element
-	// summary is enabled only in pushed-summary mode. It mirrors index
-	// mutations incrementally, so publishing never scans the cache index.
+	// summary is enabled only in summary lookup mode. It mirrors index
+	// mutations incrementally, so snapshot serving never scans the cache index.
 	summary *summaryIndex
 }
 
@@ -247,7 +247,9 @@ func (c *DiskCache) scanExisting() {
 	defer func() { _ = dir.Close() }()
 	// Only count real cache entries — the .tmp dir's contents and any
 	// stray non-key files must not enter the LRU accounting.
-	found := make(oldestEntries, 0, c.maxEntries)
+	// Do not reserve a million cacheEntry structs for an empty/new cache. The
+	// heap remains bounded by maxEntries but grows with actual disk contents.
+	found := make(oldestEntries, 0, min(c.maxEntries, 1024))
 	for {
 		entries, readErr := dir.ReadDir(1024)
 		for _, e := range entries {
@@ -294,7 +296,7 @@ func (c *DiskCache) scanExisting() {
 			c.summary.Add(entry.key)
 		}
 	}
-	for c.order.Len() > c.maxEntries {
+	for (c.order.Len() > c.maxEntries || c.currentSize > c.maxBytes) && c.order.Len() > 0 {
 		c.evictOldest()
 	}
 	cacheSizeBytes.Set(float64(c.currentSize))

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -97,6 +97,8 @@ type DiskCache struct {
 	// summary is enabled only in summary lookup mode. It mirrors index
 	// mutations incrementally, so snapshot serving never scans the cache index.
 	summary *summaryIndex
+	// renameFile is os.Rename in production and a per-cache failure seam in tests.
+	renameFile func(string, string) error
 }
 
 const defaultCacheMaxEntries = 1_000_000
@@ -164,6 +166,7 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		maxEntries: defaultCacheMaxEntries,
 		order:      list.New(),
 		index:      make(map[string]*list.Element),
+		renameFile: os.Rename,
 	}
 	if len(options) > 0 {
 		if options[0].MaxEntries > 0 {
@@ -358,28 +361,42 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 		return 0, closeErr
 	}
 
-	// Now that the actual size is known, drop any prior accounting for this key
-	// (the rename below overwrites it) and evict to make room.
-	c.mu.Lock()
-	c.dropLocked(key)
-	for (c.currentSize+size > c.maxBytes || c.order.Len() >= c.maxEntries) && c.order.Len() > 0 {
-		c.evictOldest()
-	}
-	c.mu.Unlock()
-
 	path := filepath.Join(c.dir, key)
-	if err := os.Rename(tmpPath, path); err != nil {
+	renameFile := c.renameFile
+	if renameFile == nil {
+		renameFile = os.Rename
+	}
+	// Make the local metadata rename and its index/Bloom bookkeeping one atomic
+	// commit. Streaming happened above without this lock; only the short rename
+	// syscall is serialized so eviction cannot delete the replacement in between.
+	c.mu.Lock()
+	if err := renameFile(tmpPath, path); err != nil {
+		c.mu.Unlock()
 		_ = os.Remove(tmpPath)
 		return 0, fmt.Errorf("commit cache entry: %w", err)
 	}
 
-	c.mu.Lock()
-	// addLocked drops any existing entry first: in production singleFlight
-	// serializes writes per key so the earlier drop is enough, but the guard
-	// keeps the "one entry per key" invariant (and currentSize) correct even
-	// if some future caller writes the same key concurrently — a duplicate
-	// entry would otherwise permanently inflate currentSize.
-	c.addLocked(key, size)
+	if el, replacing := c.index[key]; replacing {
+		// The key remained represented throughout the filesystem commit. Update
+		// its accounting in place so a concurrent Bloom snapshot can never see a
+		// transient negative for an already committed entry.
+		entry := el.Value.(*cacheEntry)
+		c.currentSize += size - entry.size
+		entry.size = size
+		entry.lastAccess = time.Now()
+		c.order.MoveToBack(el)
+		// Keep the replacement itself even when it exceeds maxBytes; this matches
+		// the existing oversized-object behavior. Evict older entries first.
+		for (c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries) && c.order.Len() > 1 {
+			c.evictOldest()
+		}
+		cacheSizeBytes.Set(float64(c.currentSize))
+	} else {
+		for (c.currentSize+size > c.maxBytes || c.order.Len() >= c.maxEntries) && c.order.Len() > 0 {
+			c.evictOldest()
+		}
+		c.addLocked(key, size)
+	}
 	c.mu.Unlock()
 
 	return size, nil

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -92,6 +92,9 @@ type DiskCache struct {
 	// at the back. index maps a key to its element for O(1) touch/drop.
 	order *list.List
 	index map[string]*list.Element
+	// summary is enabled only in pushed-summary mode. It mirrors index
+	// mutations incrementally, so publishing never scans the cache index.
+	summary *summaryIndex
 }
 
 type cacheEntry struct {
@@ -102,7 +105,7 @@ type cacheEntry struct {
 
 // NewDiskCache creates a cache backed by the given directory.
 // maxPercent is the percentage of filesystem capacity to use (e.g. 80).
-func NewDiskCache(dir string, maxPercent int) (*DiskCache, error) {
+func NewDiskCache(dir string, maxPercent int, incrementalSummary ...bool) (*DiskCache, error) {
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
@@ -142,6 +145,9 @@ func NewDiskCache(dir string, maxPercent int) (*DiskCache, error) {
 		maxBytes: maxBytes,
 		order:    list.New(),
 		index:    make(map[string]*list.Element),
+	}
+	if len(incrementalSummary) > 0 && incrementalSummary[0] {
+		dc.summary = newSummaryIndex()
 	}
 
 	// Scan existing cache entries
@@ -241,8 +247,21 @@ func (c *DiskCache) scanExisting() {
 		entry := found[i]
 		c.index[entry.key] = c.order.PushBack(&entry)
 		c.currentSize += entry.size
+		if c.summary != nil {
+			c.summary.Add(entry.key)
+		}
 	}
 	cacheSizeBytes.Set(float64(c.currentSize))
+}
+
+// SummarySnapshot returns an immutable bounded copy of the locally maintained
+// Bloom bits. It does not scan or lock the cache index.
+func (c *DiskCache) SummarySnapshot() (items int, bits []byte, ok bool) {
+	if c.summary == nil {
+		return 0, nil, false
+	}
+	items, bits = c.summary.Snapshot()
+	return items, bits, true
 }
 
 // Has returns true if the key is a tracked cache entry. It answers from the
@@ -253,25 +272,6 @@ func (c *DiskCache) Has(key string) bool {
 	_, ok := c.index[key]
 	c.mu.Unlock()
 	return ok
-}
-
-// SnapshotKeys returns a bounded, point-in-time copy of opaque cache keys.
-// It never exposes URLs or paths and holds the request-path mutex for at most
-// maxItems map iterations; the Bloom filter is built after the lock is gone.
-func (c *DiskCache) SnapshotKeys(maxItems int) ([]string, bool) {
-	if maxItems <= 0 {
-		return nil, false
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if len(c.index) > maxItems {
-		return nil, false
-	}
-	keys := make([]string, 0, len(c.index))
-	for key := range c.index {
-		keys = append(keys, key)
-	}
-	return keys, true
 }
 
 // Touch marks a key as most recently used without serving it. HandlePeerHas
@@ -395,6 +395,9 @@ func (c *DiskCache) dropLocked(key string) {
 	c.currentSize -= el.Value.(*cacheEntry).size
 	c.order.Remove(el)
 	delete(c.index, key)
+	if c.summary != nil {
+		c.summary.Remove(key)
+	}
 }
 
 // addLocked records a freshly written entry as most recently used, replacing
@@ -408,6 +411,9 @@ func (c *DiskCache) addLocked(key string, size int64) {
 		lastAccess: time.Now(),
 	})
 	c.currentSize += size
+	if c.summary != nil {
+		c.summary.Add(key)
+	}
 	cacheSizeBytes.Set(float64(c.currentSize))
 }
 
@@ -425,6 +431,9 @@ func (c *DiskCache) evictOldest() {
 	c.currentSize -= oldest.size
 	c.order.Remove(front)
 	delete(c.index, oldest.key)
+	if c.summary != nil {
+		c.summary.Remove(oldest.key)
+	}
 	cacheEvictionsTotal.Inc()
 	cacheSizeBytes.Set(float64(c.currentSize))
 }

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -255,6 +255,25 @@ func (c *DiskCache) Has(key string) bool {
 	return ok
 }
 
+// SnapshotKeys returns a bounded, point-in-time copy of opaque cache keys.
+// It never exposes URLs or paths and holds the request-path mutex for at most
+// maxItems map iterations; the Bloom filter is built after the lock is gone.
+func (c *DiskCache) SnapshotKeys(maxItems int) ([]string, bool) {
+	if maxItems <= 0 {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.index) > maxItems {
+		return nil, false
+	}
+	keys := make([]string, 0, len(c.index))
+	for key := range c.index {
+		keys = append(keys, key)
+	}
+	return keys, true
+}
+
 // Touch marks a key as most recently used without serving it. HandlePeerHas
 // uses it: a peer /cache/has probe counts as an access, so an entry that is
 // popular with peers is not evicted as "least recently used" while it is in

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"container/heap"
 	"container/list"
 	"crypto/sha256"
 	"fmt"
@@ -85,6 +86,7 @@ type DiskCache struct {
 	// cache can never grow into disk it doesn't own. currentSize is the sum
 	// of tracked entry sizes.
 	maxBytes    int64
+	maxEntries  int
 	currentSize int64
 
 	mu sync.Mutex
@@ -97,15 +99,31 @@ type DiskCache struct {
 	summary *summaryIndex
 }
 
+const defaultCacheMaxEntries = 1_000_000
+
 type cacheEntry struct {
 	key        string
 	size       int64
 	lastAccess time.Time
 }
 
+type oldestEntries []cacheEntry
+
+func (h oldestEntries) Len() int           { return len(h) }
+func (h oldestEntries) Less(i, j int) bool { return h[i].lastAccess.Before(h[j].lastAccess) }
+func (h oldestEntries) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *oldestEntries) Push(x any)        { *h = append(*h, x.(cacheEntry)) }
+func (h *oldestEntries) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
 // NewDiskCache creates a cache backed by the given directory.
 // maxPercent is the percentage of filesystem capacity to use (e.g. 80).
-func NewDiskCache(dir string, maxPercent int, incrementalSummary ...bool) (*DiskCache, error) {
+func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*DiskCache, error) {
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
@@ -141,19 +159,30 @@ func NewDiskCache(dir string, maxPercent int, incrementalSummary ...bool) (*Disk
 	cacheCapacityBytes.Set(float64(maxBytes))
 
 	dc := &DiskCache{
-		dir:      dir,
-		maxBytes: maxBytes,
-		order:    list.New(),
-		index:    make(map[string]*list.Element),
+		dir:        dir,
+		maxBytes:   maxBytes,
+		maxEntries: defaultCacheMaxEntries,
+		order:      list.New(),
+		index:      make(map[string]*list.Element),
 	}
-	if len(incrementalSummary) > 0 && incrementalSummary[0] {
-		dc.summary = newSummaryIndex()
+	if len(options) > 0 {
+		if options[0].MaxEntries > 0 {
+			dc.maxEntries = options[0].MaxEntries
+		}
+		if options[0].IncrementalSummary {
+			dc.summary = newSummaryIndex()
+		}
 	}
 
 	// Scan existing cache entries
 	dc.scanExisting()
 
 	return dc, nil
+}
+
+type DiskCacheOptions struct {
+	IncrementalSummary bool
+	MaxEntries         int
 }
 
 // clampToFree bounds a capacity target by the space actually available on the
@@ -211,29 +240,43 @@ func (c *DiskCache) refreshCapacity(maxPercent int) {
 }
 
 func (c *DiskCache) scanExisting() {
-	entries, err := os.ReadDir(c.dir)
+	dir, err := os.Open(c.dir)
 	if err != nil {
 		return
 	}
+	defer func() { _ = dir.Close() }()
 	// Only count real cache entries — the .tmp dir's contents and any
 	// stray non-key files must not enter the LRU accounting.
-	var found []cacheEntry
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	found := make(oldestEntries, 0, c.maxEntries)
+	for {
+		entries, readErr := dir.ReadDir(1024)
+		for _, e := range entries {
+			if e.IsDir() || !IsValidCacheKey(e.Name()) {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			entry := cacheEntry{key: e.Name(), size: info.Size(), lastAccess: info.ModTime()}
+			if found.Len() < c.maxEntries {
+				heap.Push(&found, entry)
+				continue
+			}
+			if !entry.lastAccess.After(found[0].lastAccess) {
+				_ = os.Remove(filepath.Join(c.dir, entry.key))
+				continue
+			}
+			dropped := heap.Pop(&found).(cacheEntry)
+			_ = os.Remove(filepath.Join(c.dir, dropped.key))
+			heap.Push(&found, entry)
 		}
-		if !IsValidCacheKey(e.Name()) {
-			continue
+		if readErr == io.EOF {
+			break
 		}
-		info, err := e.Info()
-		if err != nil {
-			continue
+		if readErr != nil {
+			return
 		}
-		found = append(found, cacheEntry{
-			key:        e.Name(),
-			size:       info.Size(),
-			lastAccess: info.ModTime(),
-		})
 	}
 	// The access list must start in recency order (front = oldest) or the
 	// first evictions after a restart would remove arbitrary entries.
@@ -250,6 +293,9 @@ func (c *DiskCache) scanExisting() {
 		if c.summary != nil {
 			c.summary.Add(entry.key)
 		}
+	}
+	for c.order.Len() > c.maxEntries {
+		c.evictOldest()
 	}
 	cacheSizeBytes.Set(float64(c.currentSize))
 }
@@ -314,7 +360,7 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	// (the rename below overwrites it) and evict to make room.
 	c.mu.Lock()
 	c.dropLocked(key)
-	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
+	for (c.currentSize+size > c.maxBytes || c.order.Len() >= c.maxEntries) && c.order.Len() > 0 {
 		c.evictOldest()
 	}
 	c.mu.Unlock()

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -365,6 +365,133 @@ func TestPutStreamOverwrite(t *testing.T) {
 	_ = r.Close()
 }
 
+func TestPutStreamFailedOverwritePreservesExistingEntryAndSummary(t *testing.T) {
+	c, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := strings.Repeat("d", 64)
+	oldBody := []byte("previously-committed-body")
+	if _, err := c.PutStream(key, bytes.NewReader(oldBody)); err != nil {
+		t.Fatalf("seed PutStream: %v", err)
+	}
+
+	c.renameFile = func(string, string) error { return errors.New("forced rename failure") }
+	if _, err := c.PutStream(key, strings.NewReader("replacement")); err == nil {
+		t.Fatal("overwrite should report the forced rename failure")
+	}
+
+	if !c.Has(key) {
+		t.Fatal("failed overwrite removed the existing exact-index entry")
+	}
+	if c.currentSize != int64(len(oldBody)) {
+		t.Fatalf("currentSize=%d, want preserved size %d", c.currentSize, len(oldBody))
+	}
+	r, size, ok := c.Open(key)
+	if !ok {
+		t.Fatal("failed overwrite made the existing body unservable")
+	}
+	got, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if size != int64(len(oldBody)) || !bytes.Equal(got, oldBody) {
+		t.Fatalf("preserved body size/data=%d/%q, want %d/%q", size, got, len(oldBody), oldBody)
+	}
+	items, bits, ok := c.SummarySnapshot()
+	if !ok {
+		t.Fatal("incremental summary unavailable")
+	}
+	summary, err := newIncrementalCacheSummary(bits, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != 1 || !summary.Contains(key) {
+		t.Fatalf("failed overwrite removed key from Bloom summary: items=%d contains=%v", items, summary.Contains(key))
+	}
+	if left := tmpDirEntries(t, c); left != 0 {
+		t.Fatalf("temp dir has %d leftover files after failed overwrite", left)
+	}
+}
+
+func TestPutStreamConcurrentSameKeyCommitsKeepBodyAndAccountingConsistent(t *testing.T) {
+	c, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := strings.Repeat("e", 64)
+	if _, err := c.PutStream(key, strings.NewReader("old")); err != nil {
+		t.Fatalf("seed PutStream: %v", err)
+	}
+
+	firstBody := bytes.Repeat([]byte("a"), 100)
+	secondBody := bytes.Repeat([]byte("b"), 40)
+	firstRenamed := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	c.renameFile = func(oldPath, newPath string) error {
+		body, err := os.ReadFile(oldPath)
+		if err != nil {
+			return err
+		}
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return err
+		}
+		if len(body) == len(firstBody) {
+			close(firstRenamed)
+			<-releaseFirst
+		}
+		return nil
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := c.PutStream(key, bytes.NewReader(firstBody))
+		firstDone <- err
+	}()
+	<-firstRenamed
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := c.PutStream(key, bytes.NewReader(secondBody))
+		secondDone <- err
+	}()
+
+	// Before commits were serialized, the second writer could finish its rename
+	// and accounting while the first writer was paused between those two steps.
+	// Give that interleaving a chance, then let the first commit finish.
+	var secondErr error
+	secondFinishedEarly := false
+	select {
+	case secondErr = <-secondDone:
+		secondFinishedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first overwrite: %v", err)
+	}
+	if !secondFinishedEarly {
+		secondErr = <-secondDone
+	}
+	if secondErr != nil {
+		t.Fatalf("second overwrite: %v", secondErr)
+	}
+
+	r, size, ok := c.Open(key)
+	if !ok {
+		t.Fatal("final same-key commit is missing")
+	}
+	got, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if size != int64(len(secondBody)) || c.currentSize != int64(len(secondBody)) || !bytes.Equal(got, secondBody) {
+		t.Fatalf("final size/accounting/body=%d/%d/%q, want %d/%d/%q", size, c.currentSize, got, len(secondBody), len(secondBody), secondBody)
+	}
+}
+
 // TestPutStreamOversizedObject documents that an object larger than maxBytes is
 // stored anyway (the eviction loop drains the cache but stops when empty), so a
 // single huge range is never silently dropped.

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -595,3 +595,34 @@ func TestScanExistingSeedsRecencyOrder(t *testing.T) {
 		t.Error("newer entries were evicted before the oldest")
 	}
 }
+
+func TestScanExistingEnforcesByteAndEntryCeilings(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)}
+	base := time.Now().Add(-time.Hour)
+	for i, key := range keys {
+		path := filepath.Join(dir, key)
+		if err := os.WriteFile(path, []byte(strings.Repeat("x", 10)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		when := base.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := &DiskCache{
+		dir:        dir,
+		maxBytes:   15,
+		maxEntries: 2,
+		order:      list.New(),
+		index:      make(map[string]*list.Element),
+	}
+	c.scanExisting()
+	if c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries {
+		t.Fatalf("startup cache exceeds ceilings: bytes=%d/%d entries=%d/%d", c.currentSize, c.maxBytes, c.order.Len(), c.maxEntries)
+	}
+	if !c.Has(keys[2]) {
+		t.Fatal("startup pruning did not retain the newest entry")
+	}
+}

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -208,6 +209,48 @@ func TestDiskCacheEviction(t *testing.T) {
 	// The most recent must still be present.
 	if !c.Has(keys[2]) {
 		t.Error("newest entry should still be cached")
+	}
+}
+
+func TestDiskCacheEntryLimitEvictsOldest(t *testing.T) {
+	c := newTestCache(t)
+	c.maxEntries = 2
+	keys := []string{strings.Repeat("4", 64), strings.Repeat("5", 64), strings.Repeat("6", 64)}
+	for _, key := range keys {
+		if _, err := c.PutStream(key, bytes.NewReader([]byte("x"))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if c.order.Len() != 2 || c.Has(keys[0]) || !c.Has(keys[1]) || !c.Has(keys[2]) {
+		t.Fatalf("entry-limited cache retained unexpected keys: len=%d first=%t second=%t third=%t", c.order.Len(), c.Has(keys[0]), c.Has(keys[1]), c.Has(keys[2]))
+	}
+}
+
+func TestDiskCacheEntryLimitAppliesDuringStartupScan(t *testing.T) {
+	dir := t.TempDir()
+	entries := []struct {
+		key  string
+		when time.Time
+	}{
+		{strings.Repeat("7", 64), time.Now().Add(-2 * time.Hour)},
+		{strings.Repeat("8", 64), time.Now().Add(-time.Hour)},
+		{strings.Repeat("9", 64), time.Now()},
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.key)
+		if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, entry.when, entry.when); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := NewDiskCache(dir, 100, DiskCacheOptions{MaxEntries: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.order.Len() != 2 || c.Has(entries[0].key) || !c.Has(entries[1].key) || !c.Has(entries[2].key) {
+		t.Fatalf("startup scan did not retain newest two entries")
 	}
 }
 

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -140,7 +140,7 @@ func main() {
 	slog.Info("Block mode configured.", "enabled", blockMode, "block_size", blockSize, "max_span_blocks", maxSpanBlocks)
 
 	// Initialize cache store
-	store, err := NewDiskCache(cacheDir, maxPercent)
+	store, err := NewDiskCache(cacheDir, maxPercent, lookupMode == peerLookupSummary && peerService != "")
 	if err != nil {
 		slog.Error("Failed to initialize cache store.", "error", err)
 		os.Exit(1)

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -94,10 +94,22 @@ func main() {
 
 	cacheDir := envOrDefault("CACHE_DIR", "/cache")
 	maxPercent, _ := strconv.Atoi(envOrDefault("CACHE_MAX_PERCENT", "80"))
-	maxEntries := int(envInt64("CACHE_MAX_ENTRIES", defaultCacheMaxEntries))
+	maxEntries, err := positiveEnvInt("CACHE_MAX_ENTRIES", defaultCacheMaxEntries)
+	if err != nil {
+		slog.Error("Invalid cache entry limit.", "error", err)
+		return
+	}
 	summaryMemoryLimit := envInt64("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", defaultSummaryMemoryLimitBytes)
-	peerMaxProbes := int(envInt64("CACHE_PEER_MAX_PROBES", defaultPeerMaxProbes))
-	maxPeerProbesInFlight := int(envInt64("CACHE_MAX_PEER_PROBES_IN_FLIGHT", defaultMaxPeerProbesInFlight))
+	peerMaxProbes, err := positiveEnvInt("CACHE_PEER_MAX_PROBES", defaultPeerMaxProbes)
+	if err != nil {
+		slog.Error("Invalid peer probe limit.", "error", err)
+		return
+	}
+	maxPeerProbesInFlight, err := positiveEnvInt("CACHE_MAX_PEER_PROBES_IN_FLIGHT", defaultMaxPeerProbesInFlight)
+	if err != nil {
+		slog.Error("Invalid global peer probe limit.", "error", err)
+		return
+	}
 	listenAddr := envOrDefault("LISTEN_ADDR", ":8080")
 	peerAddr := envOrDefault("PEER_ADDR", ":8081")
 	healthAddr := envOrDefault("HEALTH_ADDR", ":8082")
@@ -106,6 +118,12 @@ func main() {
 	if err != nil {
 		slog.Error("Invalid cache peer lookup mode.", "error", err)
 		return
+	}
+	if lookupMode == peerLookupSummary {
+		if err := validateSummaryMemoryLimit(summaryMemoryLimit); err != nil {
+			slog.Error("Invalid summary memory limit.", "error", err)
+			return
+		}
 	}
 	hostname, _ := os.Hostname()
 	identity := envOrDefault("CACHE_PROXY_ID", envOrDefault("POD_NAME", envOrDefault("NODE_NAME", hostname)))
@@ -178,7 +196,7 @@ func main() {
 			MaxPeerProbesInFlight: maxPeerProbesInFlight,
 			MemoryLimitBytes:      summaryMemoryLimit,
 		})
-		peers.StartSummaryPublisher(rootCtx, store)
+		peers.StartSummarySynchronizer(rootCtx, store)
 		go peers.WatchEndpoints(rootCtx)
 	}
 
@@ -242,7 +260,7 @@ func main() {
 	slog.Info("Shutting down...")
 	stopBackground()
 	if peers != nil {
-		peers.StopSummaryPublisher()
+		peers.StopSummarySynchronizer()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -256,6 +274,21 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func positiveEnvInt(key string, def int) (int, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a positive integer: %w", key, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("%s must be positive", key)
+	}
+	return n, nil
 }
 
 // envInt64 parses an integer env var, falling back to def (with a warning)

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -94,6 +94,10 @@ func main() {
 
 	cacheDir := envOrDefault("CACHE_DIR", "/cache")
 	maxPercent, _ := strconv.Atoi(envOrDefault("CACHE_MAX_PERCENT", "80"))
+	maxEntries := int(envInt64("CACHE_MAX_ENTRIES", defaultCacheMaxEntries))
+	summaryMemoryLimit := envInt64("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", defaultSummaryMemoryLimitBytes)
+	peerMaxProbes := int(envInt64("CACHE_PEER_MAX_PROBES", defaultPeerMaxProbes))
+	maxPeerProbesInFlight := int(envInt64("CACHE_MAX_PEER_PROBES_IN_FLIGHT", defaultMaxPeerProbesInFlight))
 	listenAddr := envOrDefault("LISTEN_ADDR", ":8080")
 	peerAddr := envOrDefault("PEER_ADDR", ":8081")
 	healthAddr := envOrDefault("HEALTH_ADDR", ":8082")
@@ -123,6 +127,10 @@ func main() {
 	slog.Info("Starting cache-proxy.",
 		"cache_dir", cacheDir,
 		"max_percent", maxPercent,
+		"max_entries", maxEntries,
+		"summary_memory_limit", summaryMemoryLimit,
+		"peer_max_probes", peerMaxProbes,
+		"max_peer_probes_in_flight", maxPeerProbesInFlight,
 		"listen", listenAddr,
 		"peer_listen", peerAddr,
 		"health", healthAddr,
@@ -140,7 +148,10 @@ func main() {
 	slog.Info("Block mode configured.", "enabled", blockMode, "block_size", blockSize, "max_span_blocks", maxSpanBlocks)
 
 	// Initialize cache store
-	store, err := NewDiskCache(cacheDir, maxPercent, lookupMode == peerLookupSummary && peerService != "")
+	store, err := NewDiskCache(cacheDir, maxPercent, DiskCacheOptions{
+		IncrementalSummary: lookupMode == peerLookupSummary && peerService != "",
+		MaxEntries:         maxEntries,
+	})
 	if err != nil {
 		slog.Error("Failed to initialize cache store.", "error", err)
 		os.Exit(1)
@@ -162,7 +173,11 @@ func main() {
 	var peers *PeerManager
 	if peerService != "" {
 		peers = NewPeerManager(peerService, peerAddr)
-		peers.ConfigureSummary(lookupMode, identity)
+		peers.ConfigureSummary(lookupMode, identity, SummaryConfig{
+			PeerMaxProbes:         peerMaxProbes,
+			MaxPeerProbesInFlight: maxPeerProbesInFlight,
+			MemoryLimitBytes:      summaryMemoryLimit,
+		})
 		peers.StartSummaryPublisher(rootCtx, store)
 		go peers.WatchEndpoints(rootCtx)
 	}

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -120,10 +120,13 @@ func main() {
 		return
 	}
 	if lookupMode == peerLookupSummary {
+		summaryMemoryLimitBytes.Set(float64(summaryMemoryLimit))
 		if err := validateSummaryMemoryLimit(summaryMemoryLimit); err != nil {
 			slog.Error("Invalid summary memory limit.", "error", err)
 			return
 		}
+	} else {
+		summaryMemoryLimitBytes.Set(0)
 	}
 	hostname, _ := os.Hostname()
 	identity := envOrDefault("CACHE_PROXY_ID", envOrDefault("POD_NAME", envOrDefault("NODE_NAME", hostname)))

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -98,6 +98,16 @@ func main() {
 	peerAddr := envOrDefault("PEER_ADDR", ":8081")
 	healthAddr := envOrDefault("HEALTH_ADDR", ":8082")
 	peerService := os.Getenv("PEER_SERVICE") // headless K8s service for peer discovery
+	lookupMode, err := parsePeerLookupMode(os.Getenv("CACHE_PEER_LOOKUP_MODE"))
+	if err != nil {
+		slog.Error("Invalid cache peer lookup mode.", "error", err)
+		return
+	}
+	hostname, _ := os.Hostname()
+	identity := envOrDefault("CACHE_PROXY_ID", envOrDefault("POD_NAME", envOrDefault("NODE_NAME", hostname)))
+	if identity == "" {
+		identity = peerAddr
+	}
 
 	// Comma-separated Host substrings we should cache. Anything else is tunneled
 	// or forwarded without caching. Empty means "cache everything" (legacy).
@@ -117,6 +127,7 @@ func main() {
 		"peer_listen", peerAddr,
 		"health", healthAddr,
 		"peer_service", peerService,
+		"peer_lookup_mode", lookupMode,
 		"cache_host_suffixes", cacheHostSuffixes,
 	)
 
@@ -146,10 +157,14 @@ func main() {
 	}()
 
 	// Initialize peer manager
+	rootCtx, stopBackground := context.WithCancel(context.Background())
+	defer stopBackground()
 	var peers *PeerManager
 	if peerService != "" {
 		peers = NewPeerManager(peerService, peerAddr)
-		go peers.WatchEndpoints(context.Background())
+		peers.ConfigureSummary(lookupMode, identity)
+		peers.StartSummaryPublisher(rootCtx, store)
+		go peers.WatchEndpoints(rootCtx)
 	}
 
 	proxy := NewCacheProxy(store, peers, cacheHostSuffixes)
@@ -165,6 +180,7 @@ func main() {
 	peerMux := http.NewServeMux()
 	peerMux.HandleFunc("/cache/has", proxy.HandlePeerHas)
 	peerMux.HandleFunc("/cache/get", proxy.HandlePeerGet)
+	peerMux.HandleFunc("/cache/summary", proxy.HandlePeerSummary)
 	peerServer := &http.Server{Addr: peerAddr, Handler: peerMux}
 
 	// Health + metrics
@@ -209,6 +225,10 @@ func main() {
 	<-sigCh
 
 	slog.Info("Shutting down...")
+	stopBackground()
+	if peers != nil {
+		peers.StopSummaryPublisher()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	_ = s3Server.Shutdown(ctx)

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -294,16 +294,16 @@ func (pm *PeerManager) StopSummaryPublisher() {
 func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
 	pm.summaries.removeNonMembers(pm.isMember, time.Now())
 	pm.updateSummaryGauges()
-	keys, ok := store.SnapshotKeys(maxSummaryItems)
+	items, bits, ok := store.SummarySnapshot()
 	if !ok {
-		summaryPushesTotal.WithLabelValues("snapshot_too_large").Inc()
+		summaryPushesTotal.WithLabelValues("summary_index_unavailable").Inc()
 		return
 	}
 	pm.summaryMu.Lock()
 	pm.generation++
 	generation := pm.generation
 	pm.summaryMu.Unlock()
-	s, err := newCacheSummary(pm.identity, generation, keys, time.Now(), defaultSummaryTTL)
+	s, err := newIncrementalCacheSummary(pm.identity, generation, items, bits, time.Now(), defaultSummaryTTL)
 	if err != nil {
 		summaryPushesTotal.WithLabelValues("build_error").Inc()
 		return

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -38,7 +38,7 @@ var (
 	}, []string{"outcome"}) // hit, miss, timeout, canceled, error
 	peerProbeSkippedTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "cache_proxy_peer_probes_skipped_total",
-		Help: "Summary-mode fallback probes skipped because the per-pod budget is exhausted",
+		Help: "Summary-mode confirmations skipped because the per-pod HTTP probe budget is exhausted",
 	})
 )
 
@@ -75,13 +75,13 @@ type PeerManager struct {
 	identity                  string
 	peerMaxProbes             int
 	probePermits              chan struct{}
+	summaryMemoryLimitBytes   int64
 	summaryRemoteMemoryBudget int
 
 	summaries         summaryStore
-	summaryMu         sync.Mutex // protects current local summary, ETag, and generation
+	summaryMu         sync.Mutex // protects the current local summary and ETag
 	localSummary      []byte
 	localSummaryETag  string
-	generation        uint64
 	syncCancel        context.CancelFunc
 	syncDone          chan struct{}
 	membershipChanged chan struct{}
@@ -91,6 +91,9 @@ type PeerManager struct {
 	mu           sync.RWMutex
 	peers        []string // all discovered peer addresses (ip:port)
 	summaryPeers []string // deterministic receiver-selected subset to pull
+	// pendingSummaryPeers are newly selected peers awaiting one priority pull.
+	// Membership signals are coalesced, so the queue itself retains every peer.
+	pendingSummaryPeers []string
 }
 
 func NewPeerManager(serviceName, peerPort string) *PeerManager {
@@ -125,20 +128,16 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 		lookupMode:                peerLookupProbe,
 		peerMaxProbes:             defaultPeerMaxProbes,
 		probePermits:              make(chan struct{}, defaultMaxPeerProbesInFlight),
+		summaryMemoryLimitBytes:   defaultSummaryMemoryLimitBytes,
 		summaryRemoteMemoryBudget: summaryRemoteMemoryBudget(defaultSummaryMemoryLimitBytes),
 		summaries:                 summaryStore{records: make(map[string]summaryRecord)},
-		generation:                uint64(time.Now().UnixNano()),
 		membershipChanged:         make(chan struct{}, 1),
 	}
 }
 
-func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, configs ...SummaryConfig) {
+func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, config SummaryConfig) {
 	pm.lookupMode = mode
 	pm.identity = identity
-	if len(configs) == 0 {
-		return
-	}
-	config := configs[0]
 	if config.PeerMaxProbes > 0 {
 		pm.peerMaxProbes = config.PeerMaxProbes
 	}
@@ -146,8 +145,10 @@ func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, co
 		pm.probePermits = make(chan struct{}, config.MaxPeerProbesInFlight)
 	}
 	if config.MemoryLimitBytes > 0 {
+		pm.summaryMemoryLimitBytes = config.MemoryLimitBytes
 		pm.summaryRemoteMemoryBudget = summaryRemoteMemoryBudget(config.MemoryLimitBytes)
 	}
+	pm.updateSummaryGauges()
 }
 
 // WatchEndpoints periodically resolves the headless Service DNS to
@@ -203,21 +204,45 @@ func (pm *PeerManager) resolve() {
 		peers = append(peers, peer)
 	}
 	sort.Strings(peers)
-	selected := pm.selectSummaryPeers(peers)
-
-	pm.mu.Lock()
-	selectionChanged := !stringSlicesEqual(pm.summaryPeers, selected)
-	pm.peers = peers
-	pm.summaryPeers = selected
-	pm.mu.Unlock()
-	pm.summaries.retainPeers(stringSet(selected), time.Now())
-	pm.updateSummaryGauges()
-	if pm.lookupMode == peerLookupSummary && selectionChanged {
-		pm.signalMembershipChanged()
-	}
+	pm.updateResolvedPeers(peers, time.Now())
 
 	if len(peers) > 0 {
 		slog.Debug("Discovered peers.", "count", len(peers), "peers", peers)
+	}
+}
+
+func (pm *PeerManager) updateResolvedPeers(peers []string, now time.Time) {
+	selected := pm.selectSummaryPeers(peers)
+	selectedSet := stringSet(selected)
+
+	pm.mu.Lock()
+	oldSelected := stringSet(pm.summaryPeers)
+	pendingSet := stringSet(pm.pendingSummaryPeers)
+	pending := make([]string, 0, len(pm.pendingSummaryPeers)+len(selected))
+	for _, peer := range pm.pendingSummaryPeers {
+		if _, stillSelected := selectedSet[peer]; stillSelected {
+			pending = append(pending, peer)
+		}
+	}
+	added := false
+	for _, peer := range selected {
+		if _, existed := oldSelected[peer]; existed {
+			continue
+		}
+		if _, queued := pendingSet[peer]; !queued {
+			pending = append(pending, peer)
+			pendingSet[peer] = struct{}{}
+		}
+		added = true
+	}
+	pm.peers = append([]string(nil), peers...)
+	pm.summaryPeers = selected
+	pm.pendingSummaryPeers = pending
+	pm.mu.Unlock()
+	pm.summaries.retainPeers(selectedSet, now)
+	pm.updateSummaryGauges()
+	if pm.lookupMode == peerLookupSummary && added {
+		pm.signalMembershipChanged()
 	}
 }
 
@@ -227,18 +252,6 @@ func stringSet(values []string) map[string]struct{} {
 		set[value] = struct{}{}
 	}
 	return set
-}
-
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func (pm *PeerManager) selectSummaryPeers(peers []string) []string {
@@ -287,17 +300,6 @@ func (pm *PeerManager) signalMembershipChanged() {
 	}
 }
 
-func (pm *PeerManager) isMember(peer string) bool {
-	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-	for _, p := range pm.peers {
-		if p == peer {
-			return true
-		}
-	}
-	return false
-}
-
 func (pm *PeerManager) isSummaryPeer(peer string) bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
@@ -309,59 +311,46 @@ func (pm *PeerManager) isSummaryPeer(peer string) bool {
 	return false
 }
 
-func (pm *PeerManager) localSummaryCopy() []byte {
-	pm.summaryMu.Lock()
-	defer pm.summaryMu.Unlock()
-	return append([]byte(nil), pm.localSummary...)
-}
-
 func (pm *PeerManager) localSummarySnapshot() ([]byte, string) {
 	pm.summaryMu.Lock()
 	defer pm.summaryMu.Unlock()
 	return pm.localSummary, pm.localSummaryETag
 }
 
-// ReceiveSummary validates an untrusted peer payload before atomically
-// replacing that peer's prior hint. It intentionally logs neither body nor
-// cache keys.
-func (pm *PeerManager) ReceiveSummary(sender string, body []byte, now time.Time) error {
-	return pm.receiveSummary(sender, body, "", now, pm.isMember)
-}
-
 func (pm *PeerManager) receivePulledSummary(sender string, body []byte, etag string, now time.Time) error {
-	return pm.receiveSummary(sender, body, etag, now, pm.isSummaryPeer)
-}
-
-func (pm *PeerManager) receiveSummary(sender string, body []byte, etag string, now time.Time, eligible func(string) bool) error {
-	err := pm.summaries.receive(sender, body, etag, now, eligible, pm.summaryRemoteMemoryBudget, pm.identity)
+	err := pm.summaries.receive(sender, body, etag, now, pm.isSummaryPeer, pm.summaryRemoteMemoryBudget)
 	if err != nil {
-		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
 		return err
 	}
 	// Membership may change after the initial admission check but before the
 	// store replacement. Revalidate and undo that replacement immediately.
-	if !eligible(sender) {
+	if !pm.isSummaryPeer(sender) {
 		pm.summaries.removePeer(sender)
 		pm.updateSummaryGauges()
-		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
 		return errors.New("summary sender no longer selected")
 	}
-	summaryReceiptsTotal.WithLabelValues("accepted").Inc()
 	pm.updateSummaryGauges()
 	return nil
 }
 
-func (pm *PeerManager) summaryCount() int {
-	pm.summaries.mu.RLock()
-	defer pm.summaries.mu.RUnlock()
-	return len(pm.summaries.records)
-}
 func (pm *PeerManager) updateSummaryGauges() {
 	pm.summaries.mu.RLock()
 	n, b := len(pm.summaries.records), pm.summaries.bytes
 	pm.summaries.mu.RUnlock()
+	accountedBytes := int64(0)
+	effectiveLimit := int64(0)
+	if pm.lookupMode == peerLookupSummary {
+		// The ceiling reserves the fixed local counting Bloom plus the maximum
+		// concurrent snapshot/pull working set before admitting remote summaries.
+		// Report that same conservative accounting so resident/limit is alertable.
+		accountedBytes = summaryMemoryReserveBytes() + int64(b)
+		effectiveLimit = pm.summaryMemoryLimitBytes
+	} else {
+		n = 0
+	}
 	summaryResidentCount.Set(float64(n))
-	summaryResidentBytes.Set(float64(b))
+	summaryResidentBytes.Set(float64(accountedBytes))
+	summaryMemoryLimitBytes.Set(float64(effectiveLimit))
 }
 
 func (pm *PeerManager) peerSnapshot() []string {
@@ -384,11 +373,6 @@ func (pm *PeerManager) SummaryLookup(cacheKey string, now time.Time) (positive, 
 		summaryLookupTotal.WithLabelValues("positive_candidate").Inc()
 	}
 	return positive, uncovered
-}
-
-func (pm *PeerManager) SummaryCandidates(cacheKey string, now time.Time) []string {
-	positive, _ := pm.SummaryLookup(cacheKey, now)
-	return positive
 }
 
 // StartSummarySynchronizer builds the local immutable summary and owns bounded,
@@ -417,7 +401,7 @@ func (pm *PeerManager) StartSummarySynchronizer(ctx context.Context, store *Disk
 				return
 			case <-pm.membershipChanged:
 				timer.Stop()
-				pm.pullSummaries(ctx, pm.summaryPeerSnapshot())
+				pm.pullPendingSummaryPeers(ctx)
 			case <-timer.C:
 				cycleStarted = time.Now()
 				cycleInterval = jitteredSummaryInterval(cycleStarted)
@@ -451,16 +435,12 @@ func (pm *PeerManager) StopSummarySynchronizer() {
 }
 
 func (pm *PeerManager) buildLocalSummary(store *DiskCache) {
-	items, bits, ok := store.SummarySnapshot()
+	_, bits, ok := store.SummarySnapshot()
 	if !ok {
 		summaryServesTotal.WithLabelValues("summary_index_unavailable").Inc()
 		return
 	}
-	pm.summaryMu.Lock()
-	pm.generation++
-	generation := pm.generation
-	pm.summaryMu.Unlock()
-	s, err := newIncrementalCacheSummary(pm.identity, generation, items, bits, time.Now(), defaultSummaryTTL)
+	s, err := newIncrementalCacheSummary(bits, time.Now(), defaultSummaryTTL)
 	if err != nil {
 		summaryServesTotal.WithLabelValues("build_error").Inc()
 		return
@@ -474,7 +454,7 @@ func (pm *PeerManager) buildLocalSummary(store *DiskCache) {
 	etag := fmt.Sprintf("\"%x\"", digest[:16])
 	pm.summaryMu.Lock()
 	// Assign a fresh immutable backing slice. GET handlers can safely retain the
-	// old slice after releasing summaryMu while the next generation is built.
+	// old slice after releasing summaryMu while the next snapshot is built.
 	pm.localSummary = body
 	pm.localSummaryETag = etag
 	pm.summaryMu.Unlock()
@@ -497,43 +477,91 @@ func (pm *PeerManager) pullSummaries(ctx context.Context, peers []string) {
 	for i := range peers {
 		ordered[i] = peers[(start+i)%len(peers)]
 	}
+	started := pm.pullSummaryBatch(ctx, ordered)
+	pm.advancePullOffset(start, len(started), len(peers))
+}
+
+type summaryPullJob struct {
+	peer    string
+	started chan bool
+}
+
+func (pm *PeerManager) pullSummaryBatch(ctx context.Context, ordered []string) []string {
+	if len(ordered) == 0 {
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(ctx, pm.summaryPullCycleTimeout)
 	defer cancel()
-	jobs := make(chan string)
+	jobs := make(chan summaryPullJob)
 	var workers sync.WaitGroup
-	workerCount := min(maxSummaryPulls, len(peers))
+	workerCount := min(maxSummaryPulls, len(ordered))
 	for range workerCount {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			for peer := range jobs {
-				pm.pullSummary(ctx, peer)
+			for job := range jobs {
+				if ctx.Err() != nil {
+					job.started <- false
+					continue
+				}
+				job.started <- true
+				pm.pullSummary(ctx, job.peer)
 			}
 		}()
 	}
-	submitted := 0
+	started := make([]string, 0, len(ordered))
+	dispatching := true
 	for _, peer := range ordered {
+		ack := make(chan bool, 1)
 		select {
-		case jobs <- peer:
-			submitted++
+		case jobs <- summaryPullJob{peer: peer, started: ack}:
+			if <-ack {
+				started = append(started, peer)
+				continue
+			}
+			dispatching = false
 		case <-ctx.Done():
-			close(jobs)
-			workers.Wait()
-			pm.advancePullOffset(start, submitted, len(peers))
-			return
+			dispatching = false
+		}
+		if !dispatching {
+			break
 		}
 	}
 	close(jobs)
 	workers.Wait()
-	pm.advancePullOffset(start, submitted, len(peers))
+	return started
+}
+
+func (pm *PeerManager) pendingSummaryPeerSnapshot() []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return append([]string(nil), pm.pendingSummaryPeers...)
+}
+
+func (pm *PeerManager) pullPendingSummaryPeers(ctx context.Context) {
+	pending := pm.pendingSummaryPeerSnapshot()
+	if len(pending) == 0 {
+		return
+	}
+	started := stringSet(pm.pullSummaryBatch(ctx, pending))
+	pm.mu.Lock()
+	remaining := pm.pendingSummaryPeers[:0]
+	for _, peer := range pm.pendingSummaryPeers {
+		if _, attempted := started[peer]; !attempted {
+			remaining = append(remaining, peer)
+		}
+	}
+	pm.pendingSummaryPeers = remaining
+	hasRemaining := len(remaining) > 0
+	pm.mu.Unlock()
+	if hasRemaining && ctx.Err() == nil {
+		pm.signalMembershipChanged()
+	}
 }
 
 func (pm *PeerManager) advancePullOffset(start, submitted, peerCount int) {
 	if peerCount == 0 {
 		return
-	}
-	if submitted == 0 {
-		submitted = 1
 	}
 	pm.pullOrderMu.Lock()
 	pm.nextPullOffset = (start + submitted) % peerCount
@@ -602,14 +630,6 @@ type probeResult struct {
 // in-flight fetch answers 202, so every other node waits for that fill.
 func (pm *PeerManager) LocateKey(ctx context.Context, cacheKey string) (holder string, flight, ok bool) {
 	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true, false, false)
-}
-
-// LocateKeyAmong retains probe-mode behavior for only the peers that have not
-// delivered a valid summary. The caller already counted its logical lookup.
-func (pm *PeerManager) LocateKeyAmong(ctx context.Context, cacheKey string, peers []string, maxProbes int) (holder string, flight, ok bool, selected int) {
-	peers = selectProbePeers(cacheKey, peers, maxProbes)
-	holder, flight, ok = pm.locateKey(ctx, cacheKey, peers, false, true, false)
-	return holder, flight, ok, len(peers)
 }
 
 // LocateSummaryKey uses Bloom filters only to eliminate definite negatives.

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -69,23 +69,28 @@ type PeerManager struct {
 	peerPort                  string       // port for peer API (e.g. ":8081")
 	client                    *http.Client // /cache/has probes (short whole-request timeout)
 	streamClient              *http.Client // /cache/get transfers (header deadline, no body timeout)
+	summaryClient             *http.Client // bounded /cache/summary pulls
+	summaryPullCycleTimeout   time.Duration
 	lookupMode                peerLookupMode
 	identity                  string
 	peerMaxProbes             int
 	probePermits              chan struct{}
 	summaryRemoteMemoryBudget int
 
-	summaries       summaryStore
-	summaryMu       sync.Mutex // protects current local summary and generation
-	localSummary    []byte
-	generation      uint64
-	publisherCancel context.CancelFunc
-	pushPermits     chan struct{}
-	receivePermits  chan struct{}
-	backgroundCtx   context.Context
+	summaries         summaryStore
+	summaryMu         sync.Mutex // protects current local summary, ETag, and generation
+	localSummary      []byte
+	localSummaryETag  string
+	generation        uint64
+	syncCancel        context.CancelFunc
+	syncDone          chan struct{}
+	membershipChanged chan struct{}
+	pullOrderMu       sync.Mutex
+	nextPullOffset    int
 
-	mu    sync.RWMutex
-	peers []string // peer addresses (ip:port)
+	mu           sync.RWMutex
+	peers        []string // all discovered peer addresses (ip:port)
+	summaryPeers []string // deterministic receiver-selected subset to pull
 }
 
 func NewPeerManager(serviceName, peerPort string) *PeerManager {
@@ -106,13 +111,24 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 				ResponseHeaderTimeout: peerGetResponseHeaderLimit,
 			},
 		},
+		summaryClient: &http.Client{
+			Timeout: summaryPullTimeout,
+			Transport: &http.Transport{
+				DialContext:            (&net.Dialer{Timeout: 200 * time.Millisecond, KeepAlive: 30 * time.Second}).DialContext,
+				MaxIdleConnsPerHost:    maxSummaryPulls,
+				IdleConnTimeout:        30 * time.Second,
+				ResponseHeaderTimeout:  500 * time.Millisecond,
+				MaxResponseHeaderBytes: maxSummaryResponseHeaderBytes,
+			},
+		},
+		summaryPullCycleTimeout:   defaultSummaryPullCycleTimeout,
 		lookupMode:                peerLookupProbe,
 		peerMaxProbes:             defaultPeerMaxProbes,
 		probePermits:              make(chan struct{}, defaultMaxPeerProbesInFlight),
 		summaryRemoteMemoryBudget: summaryRemoteMemoryBudget(defaultSummaryMemoryLimitBytes),
 		summaries:                 summaryStore{records: make(map[string]summaryRecord)},
-		pushPermits:               make(chan struct{}, maxSummaryPushes),
-		receivePermits:            make(chan struct{}, maxSummaryReceives),
+		generation:                uint64(time.Now().UnixNano()),
+		membershipChanged:         make(chan struct{}, 1),
 	}
 }
 
@@ -174,32 +190,100 @@ func (pm *PeerManager) resolve() {
 	}
 
 	var peers []string
+	seen := make(map[string]struct{}, len(ips))
 	for _, ip := range ips {
 		if mySet[ip] {
 			continue // skip self
 		}
-		peers = append(peers, fmt.Sprintf("%s:%s", ip, port))
+		peer := net.JoinHostPort(ip, port)
+		if _, exists := seen[peer]; exists {
+			continue
+		}
+		seen[peer] = struct{}{}
+		peers = append(peers, peer)
 	}
+	sort.Strings(peers)
+	selected := pm.selectSummaryPeers(peers)
 
 	pm.mu.Lock()
-	old := make(map[string]struct{}, len(pm.peers))
-	for _, peer := range pm.peers {
-		old[peer] = struct{}{}
-	}
+	selectionChanged := !stringSlicesEqual(pm.summaryPeers, selected)
 	pm.peers = peers
+	pm.summaryPeers = selected
 	pm.mu.Unlock()
-	pm.summaries.removeNonMembers(pm.isMember, time.Now())
+	pm.summaries.retainPeers(stringSet(selected), time.Now())
 	pm.updateSummaryGauges()
-	if pm.lookupMode == peerLookupSummary && len(pm.localSummaryCopy()) > 0 {
-		for _, peer := range peers {
-			if _, existed := old[peer]; !existed {
-				pm.schedulePush(peer, pm.localSummaryCopy())
-			}
-		}
+	if pm.lookupMode == peerLookupSummary && selectionChanged {
+		pm.signalMembershipChanged()
 	}
 
 	if len(peers) > 0 {
 		slog.Debug("Discovered peers.", "count", len(peers), "peers", peers)
+	}
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (pm *PeerManager) selectSummaryPeers(peers []string) []string {
+	if pm.lookupMode != peerLookupSummary || pm.summaryRemoteMemoryBudget <= 0 {
+		return nil
+	}
+	maxPeers := pm.summaryRemoteMemoryBudget / int(summaryBloomBits/8)
+	if maxPeers <= 0 {
+		return nil
+	}
+	type rankedPeer struct {
+		addr string
+		rank [sha256.Size]byte
+	}
+	ranked := make([]rankedPeer, 0, len(peers))
+	for _, peer := range peers {
+		ranked = append(ranked, rankedPeer{addr: peer, rank: sha256.Sum256([]byte(pm.identity + "\x00" + peer))})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return bytes.Compare(ranked[i].rank[:], ranked[j].rank[:]) < 0 })
+	if maxPeers > len(ranked) {
+		maxPeers = len(ranked)
+	}
+	selected := make([]string, maxPeers)
+	for i := range selected {
+		selected[i] = ranked[i].addr
+	}
+	return selected
+}
+
+func (pm *PeerManager) refreshSummarySelection() {
+	pm.mu.RLock()
+	peers := append([]string(nil), pm.peers...)
+	pm.mu.RUnlock()
+	selected := pm.selectSummaryPeers(peers)
+	pm.mu.Lock()
+	pm.summaryPeers = selected
+	pm.mu.Unlock()
+	pm.summaries.retainPeers(stringSet(selected), time.Now())
+	pm.updateSummaryGauges()
+}
+
+func (pm *PeerManager) signalMembershipChanged() {
+	select {
+	case pm.membershipChanged <- struct{}{}:
+	default:
 	}
 }
 
@@ -214,20 +298,15 @@ func (pm *PeerManager) isMember(peer string) bool {
 	return false
 }
 
-func (pm *PeerManager) memberForRemoteAddr(remote string) (string, bool) {
-	host, _, err := net.SplitHostPort(remote)
-	if err != nil {
-		return "", false
-	}
+func (pm *PeerManager) isSummaryPeer(peer string) bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	for _, peer := range pm.peers {
-		peerHost, _, err := net.SplitHostPort(peer)
-		if err == nil && peerHost == host {
-			return peer, true
+	for _, selected := range pm.summaryPeers {
+		if selected == peer {
+			return true
 		}
 	}
-	return "", false
+	return false
 }
 
 func (pm *PeerManager) localSummaryCopy() []byte {
@@ -236,14 +315,36 @@ func (pm *PeerManager) localSummaryCopy() []byte {
 	return append([]byte(nil), pm.localSummary...)
 }
 
+func (pm *PeerManager) localSummarySnapshot() ([]byte, string) {
+	pm.summaryMu.Lock()
+	defer pm.summaryMu.Unlock()
+	return pm.localSummary, pm.localSummaryETag
+}
+
 // ReceiveSummary validates an untrusted peer payload before atomically
 // replacing that peer's prior hint. It intentionally logs neither body nor
 // cache keys.
 func (pm *PeerManager) ReceiveSummary(sender string, body []byte, now time.Time) error {
-	err := pm.summaries.receive(sender, body, now, pm.isMember, pm.summaryRemoteMemoryBudget, pm.identity)
+	return pm.receiveSummary(sender, body, "", now, pm.isMember)
+}
+
+func (pm *PeerManager) receivePulledSummary(sender string, body []byte, etag string, now time.Time) error {
+	return pm.receiveSummary(sender, body, etag, now, pm.isSummaryPeer)
+}
+
+func (pm *PeerManager) receiveSummary(sender string, body []byte, etag string, now time.Time, eligible func(string) bool) error {
+	err := pm.summaries.receive(sender, body, etag, now, eligible, pm.summaryRemoteMemoryBudget, pm.identity)
 	if err != nil {
 		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
 		return err
+	}
+	// Membership may change after the initial admission check but before the
+	// store replacement. Revalidate and undo that replacement immediately.
+	if !eligible(sender) {
+		pm.summaries.removePeer(sender)
+		pm.updateSummaryGauges()
+		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
+		return errors.New("summary sender no longer selected")
 	}
 	summaryReceiptsTotal.WithLabelValues("accepted").Inc()
 	pm.updateSummaryGauges()
@@ -281,9 +382,6 @@ func (pm *PeerManager) SummaryLookup(cacheKey string, now time.Time) (positive, 
 		summaryLookupTotal.WithLabelValues("no_positive").Inc()
 	} else {
 		summaryLookupTotal.WithLabelValues("positive_candidate").Inc()
-		if len(positive) > 2 {
-			positive = positive[:2]
-		}
 	}
 	return positive, uncovered
 }
@@ -293,43 +391,69 @@ func (pm *PeerManager) SummaryCandidates(cacheKey string, now time.Time) []strin
 	return positive
 }
 
-// StartSummaryPublisher owns a cancellable background publisher. Publication
-// work is bounded and never runs on a request goroutine.
-func (pm *PeerManager) StartSummaryPublisher(ctx context.Context, store *DiskCache) {
+// StartSummarySynchronizer builds the local immutable summary and owns bounded,
+// receiver-driven pulls of the peer summaries selected by this pod's memory
+// budget. A buffered membership signal coalesces changes instead of queuing
+// unbounded sync work.
+func (pm *PeerManager) StartSummarySynchronizer(ctx context.Context, store *DiskCache) {
 	if pm.lookupMode != peerLookupSummary {
 		return
 	}
-	ctx, pm.publisherCancel = context.WithCancel(ctx)
-	pm.backgroundCtx = ctx
+	ctx, pm.syncCancel = context.WithCancel(ctx)
+	pm.syncDone = make(chan struct{})
+	pm.refreshSummarySelection()
 	go func() {
-		pm.publish(ctx, store)
+		defer close(pm.syncDone)
+		cycleStarted := time.Now()
+		cycleInterval := jitteredSummaryInterval(cycleStarted)
+		pm.buildLocalSummary(store)
+		pm.pullSummaries(ctx, pm.summaryPeerSnapshot())
 		for {
-			// Deterministic jitter avoids a fleet-wide synchronized burst.
-			delay := defaultSummaryInterval + time.Duration(time.Now().UnixNano()%int64(defaultSummaryInterval/5))
+			delay := remainingSummaryCycleDelay(cycleStarted, time.Now(), cycleInterval)
 			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
 				timer.Stop()
 				return
+			case <-pm.membershipChanged:
+				timer.Stop()
+				pm.pullSummaries(ctx, pm.summaryPeerSnapshot())
 			case <-timer.C:
-				pm.publish(ctx, store)
+				cycleStarted = time.Now()
+				cycleInterval = jitteredSummaryInterval(cycleStarted)
+				pm.buildLocalSummary(store)
+				pm.pullSummaries(ctx, pm.summaryPeerSnapshot())
 			}
 		}
 	}()
 }
 
-func (pm *PeerManager) StopSummaryPublisher() {
-	if pm.publisherCancel != nil {
-		pm.publisherCancel()
+func jitteredSummaryInterval(now time.Time) time.Duration {
+	// Per-process jitter avoids a fleet-wide synchronized pull burst.
+	return defaultSummaryInterval + time.Duration(now.UnixNano()%int64(defaultSummaryInterval/5))
+}
+
+func remainingSummaryCycleDelay(started, now time.Time, interval time.Duration) time.Duration {
+	remaining := interval - now.Sub(started)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (pm *PeerManager) StopSummarySynchronizer() {
+	if pm.syncCancel != nil {
+		pm.syncCancel()
+	}
+	if pm.syncDone != nil {
+		<-pm.syncDone
 	}
 }
 
-func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
-	pm.summaries.removeNonMembers(pm.isMember, time.Now())
-	pm.updateSummaryGauges()
+func (pm *PeerManager) buildLocalSummary(store *DiskCache) {
 	items, bits, ok := store.SummarySnapshot()
 	if !ok {
-		summaryPushesTotal.WithLabelValues("summary_index_unavailable").Inc()
+		summaryServesTotal.WithLabelValues("summary_index_unavailable").Inc()
 		return
 	}
 	pm.summaryMu.Lock()
@@ -338,89 +462,127 @@ func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
 	pm.summaryMu.Unlock()
 	s, err := newIncrementalCacheSummary(pm.identity, generation, items, bits, time.Now(), defaultSummaryTTL)
 	if err != nil {
-		summaryPushesTotal.WithLabelValues("build_error").Inc()
+		summaryServesTotal.WithLabelValues("build_error").Inc()
 		return
 	}
 	body, err := s.MarshalBinary()
 	if err != nil {
-		summaryPushesTotal.WithLabelValues("build_error").Inc()
+		summaryServesTotal.WithLabelValues("build_error").Inc()
 		return
 	}
+	digest := sha256.Sum256(body)
+	etag := fmt.Sprintf("\"%x\"", digest[:16])
 	pm.summaryMu.Lock()
-	pm.localSummary = append(pm.localSummary[:0], body...)
+	// Assign a fresh immutable backing slice. GET handlers can safely retain the
+	// old slice after releasing summaryMu while the next generation is built.
+	pm.localSummary = body
+	pm.localSummaryETag = etag
 	pm.summaryMu.Unlock()
+}
+
+func (pm *PeerManager) summaryPeerSnapshot() []string {
 	pm.mu.RLock()
-	peers := append([]string(nil), pm.peers...)
-	pm.mu.RUnlock()
+	defer pm.mu.RUnlock()
+	return append([]string(nil), pm.summaryPeers...)
+}
+
+func (pm *PeerManager) pullSummaries(ctx context.Context, peers []string) {
+	if len(peers) == 0 {
+		return
+	}
+	pm.pullOrderMu.Lock()
+	start := pm.nextPullOffset % len(peers)
+	pm.pullOrderMu.Unlock()
+	ordered := make([]string, len(peers))
+	for i := range peers {
+		ordered[i] = peers[(start+i)%len(peers)]
+	}
+	ctx, cancel := context.WithTimeout(ctx, pm.summaryPullCycleTimeout)
+	defer cancel()
 	jobs := make(chan string)
 	var workers sync.WaitGroup
-	for range maxSummaryPushes {
+	workerCount := min(maxSummaryPulls, len(peers))
+	for range workerCount {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
 			for peer := range jobs {
-				select {
-				case pm.pushPermits <- struct{}{}:
-				case <-ctx.Done():
-					return
-				}
-				pm.pushSummary(ctx, peer, body)
-				<-pm.pushPermits
+				pm.pullSummary(ctx, peer)
 			}
 		}()
 	}
-	for _, peer := range peers {
+	submitted := 0
+	for _, peer := range ordered {
 		select {
 		case jobs <- peer:
+			submitted++
 		case <-ctx.Done():
 			close(jobs)
 			workers.Wait()
+			pm.advancePullOffset(start, submitted, len(peers))
 			return
 		}
 	}
 	close(jobs)
 	workers.Wait()
+	pm.advancePullOffset(start, submitted, len(peers))
 }
 
-func (pm *PeerManager) pushSummary(ctx context.Context, peer string, body []byte) {
-	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
+func (pm *PeerManager) advancePullOffset(start, submitted, peerCount int) {
+	if peerCount == 0 {
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, summaryPushTimeout)
+	if submitted == 0 {
+		submitted = 1
+	}
+	pm.pullOrderMu.Lock()
+	pm.nextPullOffset = (start + submitted) % peerCount
+	pm.pullOrderMu.Unlock()
+}
+
+func (pm *PeerManager) pullSummary(ctx context.Context, peer string) {
+	ctx, cancel := context.WithTimeout(ctx, summaryPullTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+peer+"/cache/summary", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+peer+"/cache/summary", nil)
 	if err != nil {
-		summaryPushesTotal.WithLabelValues("error").Inc()
+		summaryPullsTotal.WithLabelValues("error").Inc()
 		return
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Cache-Proxy-ID", pm.identity)
-	resp, err := pm.client.Do(req)
+	if etag := pm.summaries.etag(peer, time.Now()); etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+	resp, err := pm.summaryClient.Do(req)
 	if err != nil {
-		summaryPushesTotal.WithLabelValues(peerProbeErrorOutcome(err)).Inc()
+		summaryPullsTotal.WithLabelValues(peerProbeErrorOutcome(err)).Inc()
 		return
 	}
-	_ = resp.Body.Close()
-	if resp.StatusCode/100 == 2 {
-		summaryPushesTotal.WithLabelValues("success").Inc()
-	} else {
-		summaryPushesTotal.WithLabelValues("rejected").Inc()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotModified {
+		summaryPullsTotal.WithLabelValues("not_modified").Inc()
+		return
 	}
-}
-
-// schedulePush is deliberately lossy when all permits are busy. There is no
-// retry queue; the next periodic generation retries delivery.
-func (pm *PeerManager) schedulePush(peer string, body []byte) {
-	select {
-	case pm.pushPermits <- struct{}{}:
-		ctx := pm.backgroundCtx
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		go func() { defer func() { <-pm.pushPermits }(); pm.pushSummary(ctx, peer, body) }()
-	default:
-		summaryPushesTotal.WithLabelValues("concurrency_limited").Inc()
+	if resp.StatusCode != http.StatusOK {
+		summaryPullsTotal.WithLabelValues("status_error").Inc()
+		return
 	}
+	if resp.ContentLength > maxSummaryBodyBytes {
+		summaryPullsTotal.WithLabelValues("oversized").Inc()
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSummaryBodyBytes+1))
+	if err != nil {
+		summaryPullsTotal.WithLabelValues("read_error").Inc()
+		return
+	}
+	if len(body) > maxSummaryBodyBytes {
+		summaryPullsTotal.WithLabelValues("oversized").Inc()
+		return
+	}
+	if err := pm.receivePulledSummary(peer, body, resp.Header.Get("ETag"), time.Now()); err != nil {
+		summaryPullsTotal.WithLabelValues("rejected").Inc()
+		return
+	}
+	summaryPullsTotal.WithLabelValues("success").Inc()
 }
 
 // probeResult is one peer's answer to a /cache/has probe.
@@ -439,23 +601,55 @@ type probeResult struct {
 // bursting into one duplicate origin fetch per node: the first node's
 // in-flight fetch answers 202, so every other node waits for that fill.
 func (pm *PeerManager) LocateKey(ctx context.Context, cacheKey string) (holder string, flight, ok bool) {
-	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true, false)
+	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true, false, false)
 }
 
 // LocateKeyAmong retains probe-mode behavior for only the peers that have not
 // delivered a valid summary. The caller already counted its logical lookup.
 func (pm *PeerManager) LocateKeyAmong(ctx context.Context, cacheKey string, peers []string, maxProbes int) (holder string, flight, ok bool, selected int) {
 	peers = selectProbePeers(cacheKey, peers, maxProbes)
-	holder, flight, ok = pm.locateKey(ctx, cacheKey, peers, false, true)
+	holder, flight, ok = pm.locateKey(ctx, cacheKey, peers, false, true, false)
 	return holder, flight, ok, len(peers)
+}
+
+// LocateSummaryKey uses Bloom filters only to eliminate definite negatives.
+// It confirms a bounded mix of positive and uncovered peers in parallel, then
+// returns the first exact 200/202 claim for one subsequent body GET.
+func (pm *PeerManager) LocateSummaryKey(ctx context.Context, cacheKey string, positive, uncovered []string, maxProbes int) (holder string, flight, ok bool, selected int) {
+	peers := selectSummaryProbePeers(cacheKey, positive, uncovered, maxProbes)
+	holder, flight, ok = pm.locateKey(ctx, cacheKey, peers, false, true, true)
+	return holder, flight, ok, len(peers)
+}
+
+func selectSummaryProbePeers(cacheKey string, positive, uncovered []string, maxProbes int) []string {
+	if maxProbes <= 0 {
+		return nil
+	}
+	if maxProbes == 1 && len(positive) > 0 && len(uncovered) > 0 {
+		combined := make([]string, 0, len(positive)+len(uncovered))
+		combined = append(combined, positive...)
+		combined = append(combined, uncovered...)
+		return selectProbePeers(cacheKey, combined, 1)
+	}
+	rankedPositive := selectProbePeers(cacheKey, positive, len(positive))
+	rankedUncovered := selectProbePeers(cacheKey, uncovered, len(uncovered))
+	positiveLimit := min(len(rankedPositive), maxProbes)
+	if len(rankedPositive) > 0 && len(rankedUncovered) > 0 && maxProbes > 1 {
+		positiveLimit = min(positiveLimit, maxProbes-1)
+	}
+	selected := append([]string(nil), rankedPositive[:positiveLimit]...)
+	uncoveredLimit := min(len(rankedUncovered), maxProbes-len(selected))
+	selected = append(selected, rankedUncovered[:uncoveredLimit]...)
+	if len(selected) < maxProbes && positiveLimit < len(rankedPositive) {
+		remaining := min(len(rankedPositive)-positiveLimit, maxProbes-len(selected))
+		selected = append(selected, rankedPositive[positiveLimit:positiveLimit+remaining]...)
+	}
+	return selected
 }
 
 func selectProbePeers(cacheKey string, peers []string, maxProbes int) []string {
 	if maxProbes <= 0 || len(peers) == 0 {
 		return nil
-	}
-	if len(peers) <= maxProbes {
-		return append([]string(nil), peers...)
 	}
 	type rankedPeer struct {
 		addr string
@@ -466,6 +660,9 @@ func selectProbePeers(cacheKey string, peers []string, maxProbes int) []string {
 		ranked = append(ranked, rankedPeer{addr: peer, rank: sha256.Sum256([]byte(cacheKey + "\x00" + peer))})
 	}
 	sort.Slice(ranked, func(i, j int) bool { return bytes.Compare(ranked[i].rank[:], ranked[j].rank[:]) < 0 })
+	if maxProbes > len(ranked) {
+		maxProbes = len(ranked)
+	}
 	selected := make([]string, maxProbes)
 	for i := range selected {
 		selected[i] = ranked[i].addr
@@ -473,7 +670,7 @@ func selectProbePeers(cacheKey string, peers []string, maxProbes int) []string {
 	return selected
 }
 
-func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []string, countLogical, useProbePermits bool) (holder string, flight, ok bool) {
+func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []string, countLogical, useProbePermits, firstUseful bool) (holder string, flight, ok bool) {
 	if len(peers) == 0 {
 		return "", false, false
 	}
@@ -548,6 +745,16 @@ func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []s
 			}(len(peers) - i - 1)
 			return res.addr, false, true
 		case http.StatusAccepted:
+			if firstUseful {
+				cancel()
+				go func(remaining int) {
+					defer span.End()
+					for range remaining {
+						recordProbe(<-resCh)
+					}
+				}(len(peers) - i - 1)
+				return res.addr, true, true
+			}
 			if firstFlight == "" {
 				firstFlight = res.addr
 			}

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -34,6 +36,10 @@ var (
 		Name: "cache_proxy_peer_probes_total",
 		Help: "Physical peer availability probe attempts, by outcome",
 	}, []string{"outcome"}) // hit, miss, timeout, canceled, error
+	peerProbeSkippedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_peer_probes_skipped_total",
+		Help: "Summary-mode fallback probes skipped because the per-pod budget is exhausted",
+	})
 )
 
 // Peer timeouts. The /cache/has probe is a tiny HEAD-like check, so it gets a
@@ -44,19 +50,30 @@ var (
 // guard is a response-header deadline long enough to also cover the bounded
 // wait a peer does when we ask about its in-flight fill.
 const (
-	peerHasTimeout             = 1 * time.Second
-	peerGetResponseHeaderLimit = peerFillWait + 2*time.Second
+	peerHasTimeout               = 1 * time.Second
+	peerGetResponseHeaderLimit   = peerFillWait + 2*time.Second
+	defaultPeerMaxProbes         = 5
+	defaultMaxPeerProbesInFlight = 64
 )
+
+type SummaryConfig struct {
+	PeerMaxProbes         int
+	MaxPeerProbesInFlight int
+	MemoryLimitBytes      int64
+}
 
 // PeerManager discovers and communicates with cache proxy peers
 // via a Kubernetes headless Service.
 type PeerManager struct {
-	serviceName  string
-	peerPort     string       // port for peer API (e.g. ":8081")
-	client       *http.Client // /cache/has probes (short whole-request timeout)
-	streamClient *http.Client // /cache/get transfers (header deadline, no body timeout)
-	lookupMode   peerLookupMode
-	identity     string
+	serviceName               string
+	peerPort                  string       // port for peer API (e.g. ":8081")
+	client                    *http.Client // /cache/has probes (short whole-request timeout)
+	streamClient              *http.Client // /cache/get transfers (header deadline, no body timeout)
+	lookupMode                peerLookupMode
+	identity                  string
+	peerMaxProbes             int
+	probePermits              chan struct{}
+	summaryRemoteMemoryBudget int
 
 	summaries       summaryStore
 	summaryMu       sync.Mutex // protects current local summary and generation
@@ -89,16 +106,32 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 				ResponseHeaderTimeout: peerGetResponseHeaderLimit,
 			},
 		},
-		lookupMode:     peerLookupProbe,
-		summaries:      summaryStore{records: make(map[string]summaryRecord)},
-		pushPermits:    make(chan struct{}, maxSummaryPushes),
-		receivePermits: make(chan struct{}, maxSummaryReceives),
+		lookupMode:                peerLookupProbe,
+		peerMaxProbes:             defaultPeerMaxProbes,
+		probePermits:              make(chan struct{}, defaultMaxPeerProbesInFlight),
+		summaryRemoteMemoryBudget: summaryRemoteMemoryBudget(defaultSummaryMemoryLimitBytes),
+		summaries:                 summaryStore{records: make(map[string]summaryRecord)},
+		pushPermits:               make(chan struct{}, maxSummaryPushes),
+		receivePermits:            make(chan struct{}, maxSummaryReceives),
 	}
 }
 
-func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string) {
+func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, configs ...SummaryConfig) {
 	pm.lookupMode = mode
 	pm.identity = identity
+	if len(configs) == 0 {
+		return
+	}
+	config := configs[0]
+	if config.PeerMaxProbes > 0 {
+		pm.peerMaxProbes = config.PeerMaxProbes
+	}
+	if config.MaxPeerProbesInFlight > 0 {
+		pm.probePermits = make(chan struct{}, config.MaxPeerProbesInFlight)
+	}
+	if config.MemoryLimitBytes > 0 {
+		pm.summaryRemoteMemoryBudget = summaryRemoteMemoryBudget(config.MemoryLimitBytes)
+	}
 }
 
 // WatchEndpoints periodically resolves the headless Service DNS to
@@ -207,7 +240,7 @@ func (pm *PeerManager) localSummaryCopy() []byte {
 // replacing that peer's prior hint. It intentionally logs neither body nor
 // cache keys.
 func (pm *PeerManager) ReceiveSummary(sender string, body []byte, now time.Time) error {
-	err := pm.summaries.receive(sender, body, now, pm.isMember)
+	err := pm.summaries.receive(sender, body, now, pm.isMember, pm.summaryRemoteMemoryBudget, pm.identity)
 	if err != nil {
 		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
 		return err
@@ -406,16 +439,41 @@ type probeResult struct {
 // bursting into one duplicate origin fetch per node: the first node's
 // in-flight fetch answers 202, so every other node waits for that fill.
 func (pm *PeerManager) LocateKey(ctx context.Context, cacheKey string) (holder string, flight, ok bool) {
-	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true)
+	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true, false)
 }
 
 // LocateKeyAmong retains probe-mode behavior for only the peers that have not
 // delivered a valid summary. The caller already counted its logical lookup.
-func (pm *PeerManager) LocateKeyAmong(ctx context.Context, cacheKey string, peers []string) (holder string, flight, ok bool) {
-	return pm.locateKey(ctx, cacheKey, peers, false)
+func (pm *PeerManager) LocateKeyAmong(ctx context.Context, cacheKey string, peers []string, maxProbes int) (holder string, flight, ok bool, selected int) {
+	peers = selectProbePeers(cacheKey, peers, maxProbes)
+	holder, flight, ok = pm.locateKey(ctx, cacheKey, peers, false, true)
+	return holder, flight, ok, len(peers)
 }
 
-func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []string, countLogical bool) (holder string, flight, ok bool) {
+func selectProbePeers(cacheKey string, peers []string, maxProbes int) []string {
+	if maxProbes <= 0 || len(peers) == 0 {
+		return nil
+	}
+	if len(peers) <= maxProbes {
+		return append([]string(nil), peers...)
+	}
+	type rankedPeer struct {
+		addr string
+		rank [sha256.Size]byte
+	}
+	ranked := make([]rankedPeer, 0, len(peers))
+	for _, peer := range peers {
+		ranked = append(ranked, rankedPeer{addr: peer, rank: sha256.Sum256([]byte(cacheKey + "\x00" + peer))})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return bytes.Compare(ranked[i].rank[:], ranked[j].rank[:]) < 0 })
+	selected := make([]string, maxProbes)
+	for i := range selected {
+		selected[i] = ranked[i].addr
+	}
+	return selected
+}
+
+func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []string, countLogical, useProbePermits bool) (holder string, flight, ok bool) {
 	if len(peers) == 0 {
 		return "", false, false
 	}
@@ -432,6 +490,16 @@ func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []s
 	resCh := make(chan probeResult, len(peers))
 	for _, addr := range peers {
 		go func(addr string) {
+			if useProbePermits {
+				select {
+				case pm.probePermits <- struct{}{}:
+					defer func() { <-pm.probePermits }()
+				default:
+					peerProbeSkippedTotal.Inc()
+					resCh <- probeResult{addr: addr, status: -1}
+					return
+				}
+			}
 			startedAt := time.Now()
 			res := probeResult{addr: addr, status: -1}
 			hasURL := fmt.Sprintf("http://%s/cache/has?key=%s", addr, cacheKey)

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -64,6 +64,7 @@ type PeerManager struct {
 	generation      uint64
 	publisherCancel context.CancelFunc
 	pushPermits     chan struct{}
+	receivePermits  chan struct{}
 	backgroundCtx   context.Context
 
 	mu    sync.RWMutex
@@ -88,9 +89,10 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 				ResponseHeaderTimeout: peerGetResponseHeaderLimit,
 			},
 		},
-		lookupMode:  peerLookupProbe,
-		summaries:   summaryStore{records: make(map[string]summaryRecord)},
-		pushPermits: make(chan struct{}, maxSummaryPushes),
+		lookupMode:     peerLookupProbe,
+		summaries:      summaryStore{records: make(map[string]summaryRecord)},
+		pushPermits:    make(chan struct{}, maxSummaryPushes),
+		receivePermits: make(chan struct{}, maxSummaryReceives),
 	}
 }
 
@@ -228,28 +230,34 @@ func (pm *PeerManager) updateSummaryGauges() {
 	summaryResidentBytes.Set(float64(b))
 }
 
-// SummaryCandidates is strictly local: it does no /cache/has I/O. It returns
-// deterministic positive peers, at most two of which a caller may contact.
-func (pm *PeerManager) SummaryCandidates(cacheKey string, now time.Time) []string {
-	pm.summaries.removeNonMembers(pm.isMember, now)
-	pm.updateSummaryGauges()
-	pm.summaries.mu.RLock()
-	n := len(pm.summaries.records)
-	pm.summaries.mu.RUnlock()
-	if n == 0 {
+func (pm *PeerManager) peerSnapshot() []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return append([]string(nil), pm.peers...)
+}
+
+// SummaryLookup is local-only. Positive peers have valid summaries; uncovered
+// peers have not yet supplied one and retain legacy probe behavior during
+// convergence. A fully covered negative lookup never issues /cache/has.
+func (pm *PeerManager) SummaryLookup(cacheKey string, now time.Time) (positive, uncovered []string) {
+	members := pm.peerSnapshot()
+	positive, uncovered = pm.summaries.candidates(cacheKey, members, now)
+	if len(positive) == 0 && len(uncovered) == len(members) {
 		summaryLookupTotal.WithLabelValues("no_valid_summary").Inc()
-		return nil
-	}
-	peers := pm.summaries.candidates(cacheKey, now)
-	if len(peers) == 0 {
+	} else if len(positive) == 0 {
 		summaryLookupTotal.WithLabelValues("no_positive").Inc()
-		return nil
+	} else {
+		summaryLookupTotal.WithLabelValues("positive_candidate").Inc()
+		if len(positive) > 2 {
+			positive = positive[:2]
+		}
 	}
-	summaryLookupTotal.WithLabelValues("positive_candidate").Inc()
-	if len(peers) > 2 {
-		peers = peers[:2]
-	}
-	return peers
+	return positive, uncovered
+}
+
+func (pm *PeerManager) SummaryCandidates(cacheKey string, now time.Time) []string {
+	positive, _ := pm.SummaryLookup(cacheKey, now)
+	return positive
 }
 
 // StartSummaryPublisher owns a cancellable background publisher. Publication
@@ -284,6 +292,8 @@ func (pm *PeerManager) StopSummaryPublisher() {
 }
 
 func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
+	pm.summaries.removeNonMembers(pm.isMember, time.Now())
+	pm.updateSummaryGauges()
 	keys, ok := store.SnapshotKeys(maxSummaryItems)
 	if !ok {
 		summaryPushesTotal.WithLabelValues("snapshot_too_large").Inc()
@@ -309,28 +319,41 @@ func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
 	pm.mu.RLock()
 	peers := append([]string(nil), pm.peers...)
 	pm.mu.RUnlock()
-	var wg sync.WaitGroup
-	for _, peer := range peers {
-		wg.Add(1)
-		go func(peer string) {
-			defer wg.Done()
-			select {
-			case pm.pushPermits <- struct{}{}:
-				defer func() { <-pm.pushPermits }()
-			case <-ctx.Done():
-				return
+	jobs := make(chan string)
+	var workers sync.WaitGroup
+	for range maxSummaryPushes {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for peer := range jobs {
+				select {
+				case pm.pushPermits <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+				pm.pushSummary(ctx, peer, body)
+				<-pm.pushPermits
 			}
-			pm.pushSummary(ctx, peer, body)
-		}(peer)
+		}()
 	}
-	wg.Wait()
+	for _, peer := range peers {
+		select {
+		case jobs <- peer:
+		case <-ctx.Done():
+			close(jobs)
+			workers.Wait()
+			return
+		}
+	}
+	close(jobs)
+	workers.Wait()
 }
 
 func (pm *PeerManager) pushSummary(ctx context.Context, peer string, body []byte) {
 	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, peerHasTimeout)
+	ctx, cancel := context.WithTimeout(ctx, summaryPushTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+peer+"/cache/summary", bytes.NewReader(body))
 	if err != nil {
@@ -383,16 +406,22 @@ type probeResult struct {
 // bursting into one duplicate origin fetch per node: the first node's
 // in-flight fetch answers 202, so every other node waits for that fill.
 func (pm *PeerManager) LocateKey(ctx context.Context, cacheKey string) (holder string, flight, ok bool) {
-	pm.mu.RLock()
-	peers := make([]string, len(pm.peers))
-	copy(peers, pm.peers)
-	pm.mu.RUnlock()
+	return pm.locateKey(ctx, cacheKey, pm.peerSnapshot(), true)
+}
 
+// LocateKeyAmong retains probe-mode behavior for only the peers that have not
+// delivered a valid summary. The caller already counted its logical lookup.
+func (pm *PeerManager) LocateKeyAmong(ctx context.Context, cacheKey string, peers []string) (holder string, flight, ok bool) {
+	return pm.locateKey(ctx, cacheKey, peers, false)
+}
+
+func (pm *PeerManager) locateKey(ctx context.Context, cacheKey string, peers []string, countLogical bool) (holder string, flight, ok bool) {
 	if len(peers) == 0 {
 		return "", false, false
 	}
-
-	peerFetchesTotal.Inc()
+	if countLogical {
+		peerFetchesTotal.Inc()
+	}
 	ctx, span := proxyTracer.Start(ctx, "cache.peer_lookup", trace.WithAttributes(
 		attribute.Int("duckgres.cache.peer_count", len(peers)),
 	))

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -54,6 +55,16 @@ type PeerManager struct {
 	peerPort     string       // port for peer API (e.g. ":8081")
 	client       *http.Client // /cache/has probes (short whole-request timeout)
 	streamClient *http.Client // /cache/get transfers (header deadline, no body timeout)
+	lookupMode   peerLookupMode
+	identity     string
+
+	summaries       summaryStore
+	summaryMu       sync.Mutex // protects current local summary and generation
+	localSummary    []byte
+	generation      uint64
+	publisherCancel context.CancelFunc
+	pushPermits     chan struct{}
+	backgroundCtx   context.Context
 
 	mu    sync.RWMutex
 	peers []string // peer addresses (ip:port)
@@ -77,7 +88,15 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 				ResponseHeaderTimeout: peerGetResponseHeaderLimit,
 			},
 		},
+		lookupMode:  peerLookupProbe,
+		summaries:   summaryStore{records: make(map[string]summaryRecord)},
+		pushPermits: make(chan struct{}, maxSummaryPushes),
 	}
+}
+
+func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string) {
+	pm.lookupMode = mode
+	pm.identity = identity
 }
 
 // WatchEndpoints periodically resolves the headless Service DNS to
@@ -128,11 +147,223 @@ func (pm *PeerManager) resolve() {
 	}
 
 	pm.mu.Lock()
+	old := make(map[string]struct{}, len(pm.peers))
+	for _, peer := range pm.peers {
+		old[peer] = struct{}{}
+	}
 	pm.peers = peers
 	pm.mu.Unlock()
+	pm.summaries.removeNonMembers(pm.isMember, time.Now())
+	pm.updateSummaryGauges()
+	if pm.lookupMode == peerLookupSummary && len(pm.localSummaryCopy()) > 0 {
+		for _, peer := range peers {
+			if _, existed := old[peer]; !existed {
+				pm.schedulePush(peer, pm.localSummaryCopy())
+			}
+		}
+	}
 
 	if len(peers) > 0 {
 		slog.Debug("Discovered peers.", "count", len(peers), "peers", peers)
+	}
+}
+
+func (pm *PeerManager) isMember(peer string) bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	for _, p := range pm.peers {
+		if p == peer {
+			return true
+		}
+	}
+	return false
+}
+
+func (pm *PeerManager) memberForRemoteAddr(remote string) (string, bool) {
+	host, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		return "", false
+	}
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	for _, peer := range pm.peers {
+		peerHost, _, err := net.SplitHostPort(peer)
+		if err == nil && peerHost == host {
+			return peer, true
+		}
+	}
+	return "", false
+}
+
+func (pm *PeerManager) localSummaryCopy() []byte {
+	pm.summaryMu.Lock()
+	defer pm.summaryMu.Unlock()
+	return append([]byte(nil), pm.localSummary...)
+}
+
+// ReceiveSummary validates an untrusted peer payload before atomically
+// replacing that peer's prior hint. It intentionally logs neither body nor
+// cache keys.
+func (pm *PeerManager) ReceiveSummary(sender string, body []byte, now time.Time) error {
+	err := pm.summaries.receive(sender, body, now, pm.isMember)
+	if err != nil {
+		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
+		return err
+	}
+	summaryReceiptsTotal.WithLabelValues("accepted").Inc()
+	pm.updateSummaryGauges()
+	return nil
+}
+
+func (pm *PeerManager) summaryCount() int {
+	pm.summaries.mu.RLock()
+	defer pm.summaries.mu.RUnlock()
+	return len(pm.summaries.records)
+}
+func (pm *PeerManager) updateSummaryGauges() {
+	pm.summaries.mu.RLock()
+	n, b := len(pm.summaries.records), pm.summaries.bytes
+	pm.summaries.mu.RUnlock()
+	summaryResidentCount.Set(float64(n))
+	summaryResidentBytes.Set(float64(b))
+}
+
+// SummaryCandidates is strictly local: it does no /cache/has I/O. It returns
+// deterministic positive peers, at most two of which a caller may contact.
+func (pm *PeerManager) SummaryCandidates(cacheKey string, now time.Time) []string {
+	pm.summaries.removeNonMembers(pm.isMember, now)
+	pm.updateSummaryGauges()
+	pm.summaries.mu.RLock()
+	n := len(pm.summaries.records)
+	pm.summaries.mu.RUnlock()
+	if n == 0 {
+		summaryLookupTotal.WithLabelValues("no_valid_summary").Inc()
+		return nil
+	}
+	peers := pm.summaries.candidates(cacheKey, now)
+	if len(peers) == 0 {
+		summaryLookupTotal.WithLabelValues("no_positive").Inc()
+		return nil
+	}
+	summaryLookupTotal.WithLabelValues("positive_candidate").Inc()
+	if len(peers) > 2 {
+		peers = peers[:2]
+	}
+	return peers
+}
+
+// StartSummaryPublisher owns a cancellable background publisher. Publication
+// work is bounded and never runs on a request goroutine.
+func (pm *PeerManager) StartSummaryPublisher(ctx context.Context, store *DiskCache) {
+	if pm.lookupMode != peerLookupSummary {
+		return
+	}
+	ctx, pm.publisherCancel = context.WithCancel(ctx)
+	pm.backgroundCtx = ctx
+	go func() {
+		pm.publish(ctx, store)
+		for {
+			// Deterministic jitter avoids a fleet-wide synchronized burst.
+			delay := defaultSummaryInterval + time.Duration(time.Now().UnixNano()%int64(defaultSummaryInterval/5))
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				pm.publish(ctx, store)
+			}
+		}
+	}()
+}
+
+func (pm *PeerManager) StopSummaryPublisher() {
+	if pm.publisherCancel != nil {
+		pm.publisherCancel()
+	}
+}
+
+func (pm *PeerManager) publish(ctx context.Context, store *DiskCache) {
+	keys, ok := store.SnapshotKeys(maxSummaryItems)
+	if !ok {
+		summaryPushesTotal.WithLabelValues("snapshot_too_large").Inc()
+		return
+	}
+	pm.summaryMu.Lock()
+	pm.generation++
+	generation := pm.generation
+	pm.summaryMu.Unlock()
+	s, err := newCacheSummary(pm.identity, generation, keys, time.Now(), defaultSummaryTTL)
+	if err != nil {
+		summaryPushesTotal.WithLabelValues("build_error").Inc()
+		return
+	}
+	body, err := s.MarshalBinary()
+	if err != nil {
+		summaryPushesTotal.WithLabelValues("build_error").Inc()
+		return
+	}
+	pm.summaryMu.Lock()
+	pm.localSummary = append(pm.localSummary[:0], body...)
+	pm.summaryMu.Unlock()
+	pm.mu.RLock()
+	peers := append([]string(nil), pm.peers...)
+	pm.mu.RUnlock()
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		wg.Add(1)
+		go func(peer string) {
+			defer wg.Done()
+			select {
+			case pm.pushPermits <- struct{}{}:
+				defer func() { <-pm.pushPermits }()
+			case <-ctx.Done():
+				return
+			}
+			pm.pushSummary(ctx, peer, body)
+		}(peer)
+	}
+	wg.Wait()
+}
+
+func (pm *PeerManager) pushSummary(ctx context.Context, peer string, body []byte) {
+	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, peerHasTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+peer+"/cache/summary", bytes.NewReader(body))
+	if err != nil {
+		summaryPushesTotal.WithLabelValues("error").Inc()
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Cache-Proxy-ID", pm.identity)
+	resp, err := pm.client.Do(req)
+	if err != nil {
+		summaryPushesTotal.WithLabelValues(peerProbeErrorOutcome(err)).Inc()
+		return
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode/100 == 2 {
+		summaryPushesTotal.WithLabelValues("success").Inc()
+	} else {
+		summaryPushesTotal.WithLabelValues("rejected").Inc()
+	}
+}
+
+// schedulePush is deliberately lossy when all permits are busy. There is no
+// retry queue; the next periodic generation retries delivery.
+func (pm *PeerManager) schedulePush(peer string, body []byte) {
+	select {
+	case pm.pushPermits <- struct{}{}:
+		ctx := pm.backgroundCtx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		go func() { defer func() { <-pm.pushPermits }(); pm.pushSummary(ctx, peer, body) }()
+	default:
+		summaryPushesTotal.WithLabelValues("concurrency_limited").Inc()
 	}
 }
 

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -419,7 +419,24 @@ func (p *CacheProxy) HandleProxy(w http.ResponseWriter, r *http.Request) {
 func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader string) (fetchResult, error) {
 	return p.flights.Do(cacheKey, func() (fetchResult, error) {
 		if p.peers != nil {
-			if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
+			if p.peers.lookupMode == peerLookupSummary {
+				// One logical lookup consists entirely of local Bloom tests and
+				// at most two direct GETs under a shared deadline.
+				peerFetchesTotal.Inc()
+				peerCtx, cancel := context.WithTimeout(r.Context(), peerHasTimeout)
+				defer cancel()
+				for _, holder := range p.peers.SummaryCandidates(cacheKey, time.Now()) {
+					res, ok := p.fetchFromPeer(holder, false, cacheKey, r.WithContext(peerCtx))
+					if ok {
+						peerDirectGetsTotal.WithLabelValues("success").Inc()
+						return res, nil
+					}
+					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+					if peerCtx.Err() != nil {
+						break
+					}
+				}
+			} else if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
 				res, ok := p.fetchFromPeer(holder, flight, cacheKey, r)
 				if ok {
 					return res, nil
@@ -900,6 +917,29 @@ func (p *CacheProxy) HandlePeerHas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNotFound)
+}
+
+// HandlePeerSummary receives best-effort Bloom hints over the existing peer
+// transport. That transport is currently unauthenticated; membership checks
+// merely avoid retaining unsolicited state and are not an auth boundary.
+func (p *CacheProxy) HandlePeerSummary(w http.ResponseWriter, r *http.Request) {
+	if p.peers == nil || p.peers.lookupMode != peerLookupSummary || r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxSummaryBodyBytes))
+	if err != nil {
+		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
+		http.Error(w, "summary too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	peer, ok := p.peers.memberForRemoteAddr(r.RemoteAddr)
+	if !ok || p.peers.ReceiveSummary(peer, body, time.Now()) != nil {
+		http.Error(w, "invalid summary", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // HandlePeerGet returns cached data to a peer. With flight=1 and the key not

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -420,20 +420,24 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 	return p.flights.Do(cacheKey, func() (fetchResult, error) {
 		if p.peers != nil {
 			if p.peers.lookupMode == peerLookupSummary {
-				// One logical lookup consists entirely of local Bloom tests and
-				// at most two direct GETs under a shared deadline.
+				// One logical lookup uses local Bloom tests first. Peers without a
+				// valid summary remain on the legacy probe path only while this
+				// proxy is converging after startup or membership changes.
 				peerFetchesTotal.Inc()
-				peerCtx, cancel := context.WithTimeout(r.Context(), peerHasTimeout)
-				defer cancel()
-				for _, holder := range p.peers.SummaryCandidates(cacheKey, time.Now()) {
-					res, ok := p.fetchFromPeer(holder, false, cacheKey, r.WithContext(peerCtx))
+				positive, uncovered := p.peers.SummaryLookup(cacheKey, time.Now())
+				for _, holder := range positive {
+					res, ok := p.fetchFromPeer(holder, false, cacheKey, r)
 					if ok {
 						peerDirectGetsTotal.WithLabelValues("success").Inc()
 						return res, nil
 					}
 					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
-					if peerCtx.Err() != nil {
-						break
+				}
+				if len(positive) == 0 {
+					if holder, flight, ok := p.peers.LocateKeyAmong(r.Context(), cacheKey, uncovered); ok {
+						if res, ok := p.fetchFromPeer(holder, flight, cacheKey, r); ok {
+							return res, nil
+						}
 					}
 				}
 			} else if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
@@ -925,6 +929,14 @@ func (p *CacheProxy) HandlePeerHas(w http.ResponseWriter, r *http.Request) {
 func (p *CacheProxy) HandlePeerSummary(w http.ResponseWriter, r *http.Request) {
 	if p.peers == nil || p.peers.lookupMode != peerLookupSummary || r.Method != http.MethodPost {
 		http.NotFound(w, r)
+		return
+	}
+	select {
+	case p.peers.receivePermits <- struct{}{}:
+		defer func() { <-p.peers.receivePermits }()
+	default:
+		summaryReceiptsTotal.WithLabelValues("busy").Inc()
+		http.Error(w, "summary receiver busy", http.StatusServiceUnavailable)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -427,10 +427,10 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 				positive, uncovered := p.peers.SummaryLookup(cacheKey, time.Now())
 				if holder, flight, ok, _ := p.peers.LocateSummaryKey(r.Context(), cacheKey, positive, uncovered, p.peers.peerMaxProbes); ok {
 					if res, ok := p.fetchFromPeer(holder, flight, cacheKey, r); ok {
-						peerDirectGetsTotal.WithLabelValues("success").Inc()
+						summaryConfirmedGetsTotal.WithLabelValues("success").Inc()
 						return res, nil
 					}
-					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
+					summaryConfirmedGetsTotal.WithLabelValues("miss_or_error").Inc()
 				}
 			} else if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
 				res, ok := p.fetchFromPeer(holder, flight, cacheKey, r)

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -425,20 +425,12 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 				// proxy is converging after startup or membership changes.
 				peerFetchesTotal.Inc()
 				positive, uncovered := p.peers.SummaryLookup(cacheKey, time.Now())
-				for _, holder := range positive {
-					res, ok := p.fetchFromPeer(holder, false, cacheKey, r)
-					if ok {
+				if holder, flight, ok, _ := p.peers.LocateSummaryKey(r.Context(), cacheKey, positive, uncovered, p.peers.peerMaxProbes); ok {
+					if res, ok := p.fetchFromPeer(holder, flight, cacheKey, r); ok {
 						peerDirectGetsTotal.WithLabelValues("success").Inc()
 						return res, nil
 					}
 					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
-				}
-				if len(positive) == 0 {
-					if holder, flight, ok, _ := p.peers.LocateKeyAmong(r.Context(), cacheKey, uncovered, p.peers.peerMaxProbes); ok {
-						if res, ok := p.fetchFromPeer(holder, flight, cacheKey, r); ok {
-							return res, nil
-						}
-					}
 				}
 			} else if holder, flight, ok := p.peers.LocateKey(r.Context(), cacheKey); ok {
 				res, ok := p.fetchFromPeer(holder, flight, cacheKey, r)
@@ -923,35 +915,37 @@ func (p *CacheProxy) HandlePeerHas(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 }
 
-// HandlePeerSummary receives best-effort Bloom hints over the existing peer
-// transport. That transport is currently unauthenticated; membership checks
-// merely avoid retaining unsolicited state and are not an auth boundary.
+// HandlePeerSummary serves the current immutable Bloom snapshot over the
+// existing unauthenticated peer transport. Receivers decide whether this peer
+// belongs in their bounded retained subset before pulling the body.
 func (p *CacheProxy) HandlePeerSummary(w http.ResponseWriter, r *http.Request) {
-	if p.peers == nil || p.peers.lookupMode != peerLookupSummary || r.Method != http.MethodPost {
+	if p.peers == nil || p.peers.lookupMode != peerLookupSummary || r.Method != http.MethodGet {
 		http.NotFound(w, r)
 		return
 	}
-	select {
-	case p.peers.receivePermits <- struct{}{}:
-		defer func() { <-p.peers.receivePermits }()
-	default:
-		summaryReceiptsTotal.WithLabelValues("busy").Inc()
-		http.Error(w, "summary receiver busy", http.StatusServiceUnavailable)
+	body, etag := p.peers.localSummarySnapshot()
+	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
+		summaryServesTotal.WithLabelValues("unavailable").Inc()
+		http.Error(w, "summary unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	defer func() { _ = r.Body.Close() }()
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxSummaryBodyBytes))
-	if err != nil {
-		summaryReceiptsTotal.WithLabelValues("rejected").Inc()
-		http.Error(w, "summary too large", http.StatusRequestEntityTooLarge)
+	// The peer server intentionally has no server-wide WriteTimeout because
+	// /cache/get streams large bodies. Bound only this small snapshot response.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(summaryServeTimeout))
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	if r.Header.Get("If-None-Match") == etag {
+		summaryServesTotal.WithLabelValues("not_modified").Inc()
+		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	peer, ok := p.peers.memberForRemoteAddr(r.RemoteAddr)
-	if !ok || p.peers.ReceiveSummary(peer, body, time.Now()) != nil {
-		http.Error(w, "invalid summary", http.StatusBadRequest)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		summaryServesTotal.WithLabelValues("write_error").Inc()
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	summaryServesTotal.WithLabelValues("success").Inc()
 }
 
 // HandlePeerGet returns cached data to a peer. With flight=1 and the key not

--- a/cmd/cache-proxy/proxy.go
+++ b/cmd/cache-proxy/proxy.go
@@ -434,7 +434,7 @@ func (p *CacheProxy) fetchDedup(cacheKey string, r *http.Request, rangeHeader st
 					peerDirectGetsTotal.WithLabelValues("miss_or_error").Inc()
 				}
 				if len(positive) == 0 {
-					if holder, flight, ok := p.peers.LocateKeyAmong(r.Context(), cacheKey, uncovered); ok {
+					if holder, flight, ok, _ := p.peers.LocateKeyAmong(r.Context(), cacheKey, uncovered, p.peers.peerMaxProbes); ok {
 						if res, ok := p.fetchFromPeer(holder, flight, cacheKey, r); ok {
 							return res, nil
 						}

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -21,15 +21,15 @@ import (
 // Summary data deliberately contains only opaque cache-key digests. It is a
 // best-effort hint: rejecting it or losing it must only reduce peer hits.
 const (
-	summaryFormatVersion   = 1
-	cacheLayoutVersion     = 1
-	defaultSummaryTTL      = 45 * time.Second
-	defaultSummaryInterval = 20 * time.Second
-	summaryTargetFPR       = 0.01
+	summaryFormatVersion    = 2
+	cacheLayoutVersion      = 1
+	defaultSummaryTTL       = 45 * time.Second
+	defaultSummaryInterval  = 20 * time.Second
+	summaryTargetFPR        = 0.01
+	summaryBloomTargetItems = 1_000_000
 	// A 1m-entry filter at 1% false-positive rate is ~1.15 MiB before JSON
 	// base64 encoding. Two MiB is a hard wire cap with modest headroom.
 	maxSummaryBodyBytes     = 2 << 20
-	maxSummaryItems         = 1_000_000
 	maxSummaryPeers         = 256
 	maxSummaryPushes        = 4
 	maxSummaryReceives      = 4
@@ -38,13 +38,28 @@ const (
 )
 
 var (
-	summaryPushesTotal   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pushes_total", Help: "Summary publications by outcome"}, []string{"outcome"})
-	summaryReceiptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_receipts_total", Help: "Peer summary receipts by outcome"}, []string{"outcome"})
-	summaryResidentCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
-	summaryResidentBytes = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Current valid peer summary bytes"})
-	summaryAgeSeconds    = promauto.NewHistogram(prometheus.HistogramOpts{Name: "cache_proxy_summary_age_seconds", Help: "Age of a summary used during lookup", Buckets: prometheus.ExponentialBuckets(0.1, 2, 10)})
-	summaryLookupTotal   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_lookups_total", Help: "Summary lookup decisions"}, []string{"outcome"})
-	peerDirectGetsTotal  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_peer_direct_gets_total", Help: "Direct peer GET attempts in summary mode"}, []string{"outcome"})
+	summaryBloomBits, summaryBloomHashes = bloomParams(summaryBloomTargetItems)
+)
+
+var (
+	summaryPushesTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pushes_total", Help: "Summary publications by outcome"}, []string{"outcome"})
+	summaryReceiptsTotal                = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_receipts_total", Help: "Peer summary receipts by outcome"}, []string{"outcome"})
+	summaryResidentCount                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
+	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Current valid peer summary bytes"})
+	summaryAgeSeconds                   = promauto.NewHistogram(prometheus.HistogramOpts{Name: "cache_proxy_summary_age_seconds", Help: "Age of a summary used during lookup", Buckets: prometheus.ExponentialBuckets(0.1, 2, 10)})
+	summaryLookupTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_lookups_total", Help: "Summary lookup decisions"}, []string{"outcome"})
+	peerDirectGetsTotal                 = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_peer_direct_gets_total", Help: "Direct peer GET attempts in summary mode"}, []string{"outcome"})
+	summaryBloomItems                   = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_items", Help: "Current local cache keys represented by the incremental Bloom filter"})
+	summaryBloomBitsGauge               = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_bits", Help: "Allocated bits in the local incremental Bloom filter"})
+	summaryBloomHashesGauge             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_hashes", Help: "Hash functions in the local incremental Bloom filter"})
+	summaryBloomFPR                     = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_false_positive_ratio", Help: "Predicted local Bloom false-positive ratio"})
+	summaryBloomSaturated               = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_saturated", Help: "Whether local Bloom entries exceed its 1 percent target capacity"})
+	summaryBloomOccupancy               = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_bit_occupancy_ratio", Help: "Fraction of local Bloom bits currently set"})
+	summaryBloomAddsTotal               = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_additions_total", Help: "Cache insertions applied to the incremental Bloom filter"})
+	summaryBloomRemovalsTotal           = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_removals_total", Help: "Cache evictions applied to the incremental Bloom filter"})
+	summaryBloomCounterSaturationsTotal = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_counter_saturations_total", Help: "Counting Bloom cells that reached uint16 saturation"})
+	summaryBloomSnapshotsTotal          = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_snapshots_total", Help: "Immutable Bloom snapshots prepared for publication"})
+	summaryBloomSnapshotBytes           = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_snapshot_bytes", Help: "Bytes in the most recent local Bloom snapshot"})
 )
 
 type peerLookupMode string
@@ -80,7 +95,7 @@ type cacheSummary struct {
 }
 
 func newCacheSummary(sender string, generation uint64, keys []string, now time.Time, ttl time.Duration) (*cacheSummary, error) {
-	if sender == "" || generation == 0 || ttl <= 0 || len(keys) > maxSummaryItems {
+	if sender == "" || generation == 0 || ttl <= 0 || len(keys) > summaryBloomTargetItems {
 		return nil, errors.New("invalid summary inputs")
 	}
 	m, k := bloomParams(len(keys))
@@ -95,6 +110,125 @@ func newCacheSummary(sender string, generation uint64, keys []string, now time.T
 		s.add(key)
 	}
 	return s, nil
+}
+
+// summaryIndex is a bounded counting Bloom filter. Counters make eviction
+// safe: a bit is cleared only when no remaining key uses it. A saturated
+// counter is intentionally never cleared, which can only add false positives.
+type summaryIndex struct {
+	mu          sync.RWMutex
+	bits        []byte
+	counters    []uint16
+	bitCount    uint64
+	hashes      uint8
+	targetItems int
+	itemCount   int
+	setBits     uint64
+}
+
+func newSummaryIndex() *summaryIndex {
+	return newSummaryIndexWithParams(summaryBloomBits, summaryBloomHashes, summaryBloomTargetItems)
+}
+
+func newSummaryIndexWithParams(bitCount uint64, hashes uint8, targetItems int) *summaryIndex {
+	if bitCount < 8 || bitCount%8 != 0 || hashes == 0 || targetItems <= 0 {
+		panic("invalid incremental Bloom parameters")
+	}
+	i := &summaryIndex{
+		bits:        make([]byte, bitCount/8),
+		counters:    make([]uint16, bitCount),
+		bitCount:    bitCount,
+		hashes:      hashes,
+		targetItems: targetItems,
+	}
+	return i
+}
+
+func (i *summaryIndex) Add(key string) {
+	if !IsValidCacheKey(key) {
+		return
+	}
+	i.mu.Lock()
+	bloomHashes(key, i.bitCount, i.hashes, func(bit uint64) {
+		if i.counters[bit] < ^uint16(0) {
+			if i.counters[bit] == ^uint16(0)-1 {
+				summaryBloomCounterSaturationsTotal.Inc()
+			}
+			i.counters[bit]++
+		}
+		if i.bits[bit/8]&(1<<(bit%8)) == 0 {
+			i.setBits++
+		}
+		i.bits[bit/8] |= 1 << (bit % 8)
+	})
+	i.itemCount++
+	summaryBloomAddsTotal.Inc()
+	i.mu.Unlock()
+}
+
+func (i *summaryIndex) Remove(key string) {
+	if !IsValidCacheKey(key) {
+		return
+	}
+	i.mu.Lock()
+	bloomHashes(key, i.bitCount, i.hashes, func(bit uint64) {
+		// Saturated counters stay set. Clearing them could cause a false
+		// negative after more than MaxUint16 colliding additions.
+		if i.counters[bit] > 0 && i.counters[bit] < ^uint16(0) {
+			i.counters[bit]--
+			if i.counters[bit] == 0 {
+				i.bits[bit/8] &^= 1 << (bit % 8)
+				i.setBits--
+			}
+		}
+	})
+	if i.itemCount > 0 {
+		i.itemCount--
+	}
+	summaryBloomRemovalsTotal.Inc()
+	i.mu.Unlock()
+}
+
+func (i *summaryIndex) Snapshot() (int, []byte) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	i.updateMetricsLocked()
+	summaryBloomSnapshotsTotal.Inc()
+	summaryBloomSnapshotBytes.Set(float64(len(i.bits)))
+	return i.itemCount, append([]byte(nil), i.bits...)
+}
+
+func (i *summaryIndex) FalsePositiveRate() float64 {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return bloomFalsePositiveRate(i.itemCount, i.bitCount, i.hashes)
+}
+
+func (i *summaryIndex) Saturated() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.itemCount > i.targetItems
+}
+
+func (i *summaryIndex) updateMetricsLocked() {
+	summaryBloomItems.Set(float64(i.itemCount))
+	summaryBloomBitsGauge.Set(float64(i.bitCount))
+	summaryBloomHashesGauge.Set(float64(i.hashes))
+	summaryBloomFPR.Set(bloomFalsePositiveRate(i.itemCount, i.bitCount, i.hashes))
+	summaryBloomOccupancy.Set(float64(i.setBits) / float64(i.bitCount))
+	if i.itemCount > i.targetItems {
+		summaryBloomSaturated.Set(1)
+	} else {
+		summaryBloomSaturated.Set(0)
+	}
+}
+
+func bloomFalsePositiveRate(items int, bitCount uint64, hashes uint8) float64 {
+	if items <= 0 || bitCount == 0 || hashes == 0 {
+		return 0
+	}
+	set := -math.Expm1(-float64(hashes) * float64(items) / float64(bitCount))
+	return math.Pow(set, float64(hashes))
 }
 
 func bloomParams(items int) (uint64, uint8) {
@@ -114,10 +248,14 @@ func bloomParams(items int) (uint64, uint8) {
 }
 
 func (s *cacheSummary) hashes(key string, fn func(uint64)) {
+	bloomHashes(key, s.MBits, s.Hashes, fn)
+}
+
+func bloomHashes(key string, bits uint64, hashes uint8, fn func(uint64)) {
 	d := sha256.Sum256([]byte(key))
 	h1, h2 := binary.LittleEndian.Uint64(d[:8]), binary.LittleEndian.Uint64(d[8:16])
-	for i := uint8(0); i < s.Hashes; i++ {
-		fn((h1 + uint64(i)*h2) % s.MBits)
+	for i := uint8(0); i < hashes; i++ {
+		fn((h1 + uint64(i)*h2) % bits)
 	}
 }
 
@@ -146,6 +284,17 @@ func (s *cacheSummary) MarshalBinary() ([]byte, error) {
 	}
 	return b, nil
 }
+
+func summaryFromIncrementalBits(sender string, generation uint64, itemCount int, bitCount uint64, hashes uint8, bits []byte, now time.Time, ttl time.Duration) *cacheSummary {
+	return &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, Sender: sender, Generation: generation, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), ItemCount: itemCount, MBits: bitCount, Hashes: hashes, Bits: bits}
+}
+
+func newIncrementalCacheSummary(sender string, generation uint64, itemCount int, bits []byte, now time.Time, ttl time.Duration) (*cacheSummary, error) {
+	if sender == "" || generation == 0 || ttl <= 0 || itemCount < 0 || len(bits) != int(summaryBloomBits/8) {
+		return nil, errors.New("invalid incremental summary inputs")
+	}
+	return summaryFromIncrementalBits(sender, generation, itemCount, summaryBloomBits, summaryBloomHashes, bits, now, ttl), nil
+}
 func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
 		return nil, errors.New("invalid summary body size")
@@ -159,11 +308,13 @@ func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion || s.Sender == "" || len(s.Sender) > 253 || strings.ContainsAny(s.Sender, "\r\n") || s.Generation == 0 {
 		return nil, errors.New("incompatible summary")
 	}
-	if s.ItemCount < 0 || s.ItemCount > maxSummaryItems {
+	if s.ItemCount < 0 {
 		return nil, errors.New("invalid bloom parameters")
 	}
 	wantBits, wantHashes := bloomParams(s.ItemCount)
-	if s.MBits != wantBits || s.Hashes != wantHashes || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) {
+	dynamicParams := s.MBits == wantBits && s.Hashes == wantHashes
+	incrementalParams := s.MBits == summaryBloomBits && s.Hashes == summaryBloomHashes
+	if (!dynamicParams && !incrementalParams) || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) {
 		return nil, errors.New("invalid bloom parameters")
 	}
 	created, expires := time.Unix(0, s.CreatedNS), time.Unix(0, s.ExpiresNS)

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -30,18 +30,40 @@ const (
 	// A 1m-entry filter at 1% false-positive rate is ~1.15 MiB before JSON
 	// base64 encoding. Two MiB is a hard wire cap with modest headroom.
 	maxSummaryBodyBytes            = 2 << 20
-	maxSummaryPushes               = 4
-	maxSummaryReceives             = 4
+	maxSummaryResponseHeaderBytes  = 16 << 10
+	maxSummaryPulls                = 4
 	defaultSummaryMemoryLimitBytes = 512 << 20
-	summaryPushTimeout             = 200 * time.Millisecond
+	summaryPullTimeout             = 2 * time.Second
+	summaryServeTimeout            = 2 * time.Second
+	defaultSummaryPullCycleTimeout = 15 * time.Second
 )
 
+func summaryMemoryReserveBytes() int64 {
+	rawBits := int64(summaryBloomBits / 8)
+	localIndex := rawBits + int64(summaryBloomBits)*2
+	// Keep room for both the currently served and next encoded bodies, the
+	// temporary raw-bit snapshot used to build the next body, and each pull
+	// worker's encoded body plus decoded bits.
+	transient := 2*int64(maxSummaryBodyBytes) + rawBits + int64(maxSummaryPulls)*(int64(maxSummaryBodyBytes)+rawBits+maxSummaryResponseHeaderBytes)
+	return localIndex + transient
+}
+
+func validateSummaryMemoryLimit(total int64) error {
+	minimum := summaryMemoryReserveBytes() + int64(summaryBloomBits/8)
+	if total < minimum {
+		return fmt.Errorf("CACHE_SUMMARY_MEMORY_LIMIT_BYTES must be at least %d", minimum)
+	}
+	return nil
+}
+
 func summaryRemoteMemoryBudget(total int64) int {
-	localIndex := int64(summaryBloomBits/8) + int64(summaryBloomBits)*2
-	transient := int64(maxSummaryBodyBytes * (maxSummaryReceives + 1))
-	budget := total - localIndex - transient
+	budget := total - summaryMemoryReserveBytes()
 	if budget < 0 {
 		return 0
+	}
+	maxInt := int64(^uint(0) >> 1)
+	if budget > maxInt {
+		return int(maxInt)
 	}
 	return int(budget)
 }
@@ -51,7 +73,8 @@ var (
 )
 
 var (
-	summaryPushesTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pushes_total", Help: "Summary publications by outcome"}, []string{"outcome"})
+	summaryPullsTotal                   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pulls_total", Help: "Peer summary pulls by outcome"}, []string{"outcome"})
+	summaryServesTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_serves_total", Help: "Local summary endpoint responses by outcome"}, []string{"outcome"})
 	summaryReceiptsTotal                = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_receipts_total", Help: "Peer summary receipts by outcome"}, []string{"outcome"})
 	summaryResidentCount                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
 	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Current valid peer summary bytes"})
@@ -336,6 +359,16 @@ func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 type summaryRecord struct {
 	summary *cacheSummary
 	bytes   int
+	etag    string
+}
+
+func boundedSummaryETag(etag string) string {
+	// ETags are optional synchronization metadata. Never let a peer-controlled
+	// response header become unbounded resident state.
+	if len(etag) < 2 || len(etag) > 128 || etag[0] != '"' || etag[len(etag)-1] != '"' || strings.ContainsAny(etag, "\r\n") {
+		return ""
+	}
+	return etag
 }
 
 // summaryStore owns bounded peer hints. The small lock is only held to replace
@@ -346,7 +379,7 @@ type summaryStore struct {
 	bytes   int
 }
 
-func (st *summaryStore) receive(peer string, body []byte, now time.Time, member func(string) bool, remoteBudget int, identity string) error {
+func (st *summaryStore) receive(peer string, body []byte, etag string, now time.Time, member func(string) bool, remoteBudget int, identity string) error {
 	s, err := parseCacheSummary(body, now)
 	if err != nil {
 		return err
@@ -367,7 +400,7 @@ func (st *summaryStore) receive(peer string, body []byte, now time.Time, member 
 	for addr, rec := range st.records {
 		candidates[addr] = rec
 	}
-	candidates[peer] = summaryRecord{summary: s, bytes: residentBytes}
+	candidates[peer] = summaryRecord{summary: s, bytes: residentBytes, etag: boundedSummaryETag(etag)}
 	type candidate struct {
 		addr string
 		rec  summaryRecord
@@ -393,6 +426,38 @@ func (st *summaryStore) receive(peer string, body []byte, now time.Time, member 
 	st.records, st.bytes = kept, used
 	return nil
 }
+
+func (st *summaryStore) etag(peer string, now time.Time) string {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	rec, ok := st.records[peer]
+	if !ok || !time.Unix(0, rec.summary.ExpiresNS).After(now) {
+		return ""
+	}
+	return rec.etag
+}
+
+func (st *summaryStore) retainPeers(peers map[string]struct{}, now time.Time) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for peer, rec := range st.records {
+		_, retained := peers[peer]
+		if !retained || !time.Unix(0, rec.summary.ExpiresNS).After(now) {
+			delete(st.records, peer)
+			st.bytes -= rec.bytes
+		}
+	}
+}
+
+func (st *summaryStore) removePeer(peer string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if rec, ok := st.records[peer]; ok {
+		delete(st.records, peer)
+		st.bytes -= rec.bytes
+	}
+}
+
 func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time) {
 	st.mu.Lock()
 	defer st.mu.Unlock()

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -29,13 +29,22 @@ const (
 	summaryBloomTargetItems = 1_000_000
 	// A 1m-entry filter at 1% false-positive rate is ~1.15 MiB before JSON
 	// base64 encoding. Two MiB is a hard wire cap with modest headroom.
-	maxSummaryBodyBytes     = 2 << 20
-	maxSummaryPeers         = 256
-	maxSummaryPushes        = 4
-	maxSummaryReceives      = 4
-	maxSummaryResidentBytes = 512 << 20
-	summaryPushTimeout      = 200 * time.Millisecond
+	maxSummaryBodyBytes            = 2 << 20
+	maxSummaryPushes               = 4
+	maxSummaryReceives             = 4
+	defaultSummaryMemoryLimitBytes = 512 << 20
+	summaryPushTimeout             = 200 * time.Millisecond
 )
+
+func summaryRemoteMemoryBudget(total int64) int {
+	localIndex := int64(summaryBloomBits/8) + int64(summaryBloomBits)*2
+	transient := int64(maxSummaryBodyBytes * (maxSummaryReceives + 1))
+	budget := total - localIndex - transient
+	if budget < 0 {
+		return 0
+	}
+	return int(budget)
+}
 
 var (
 	summaryBloomBits, summaryBloomHashes = bloomParams(summaryBloomTargetItems)
@@ -337,7 +346,7 @@ type summaryStore struct {
 	bytes   int
 }
 
-func (st *summaryStore) receive(peer string, body []byte, now time.Time, member func(string) bool) error {
+func (st *summaryStore) receive(peer string, body []byte, now time.Time, member func(string) bool, remoteBudget int, identity string) error {
 	s, err := parseCacheSummary(body, now)
 	if err != nil {
 		return err
@@ -350,24 +359,38 @@ func (st *summaryStore) receive(peer string, body []byte, now time.Time, member 
 	if old, ok := st.records[peer]; ok && old.summary.Generation >= s.Generation {
 		return errors.New("stale summary generation")
 	}
-	if len(st.records) >= maxSummaryPeers {
-		if _, exists := st.records[peer]; !exists {
-			return errors.New("summary peer limit")
-		}
-	}
 	residentBytes := len(s.Bits)
-	oldBytes := 0
-	if old, ok := st.records[peer]; ok {
-		oldBytes = old.bytes
+	if residentBytes > remoteBudget {
+		return errors.New("summary exceeds remote memory budget")
 	}
-	if st.bytes-oldBytes+residentBytes > maxSummaryResidentBytes {
-		return errors.New("summary resident byte limit")
+	candidates := make(map[string]summaryRecord, len(st.records)+1)
+	for addr, rec := range st.records {
+		candidates[addr] = rec
 	}
-	if oldBytes > 0 {
-		st.bytes -= oldBytes
+	candidates[peer] = summaryRecord{summary: s, bytes: residentBytes}
+	type candidate struct {
+		addr string
+		rec  summaryRecord
+		rank [sha256.Size]byte
 	}
-	st.records[peer] = summaryRecord{summary: s, bytes: residentBytes}
-	st.bytes += residentBytes
+	ranked := make([]candidate, 0, len(candidates))
+	for addr, rec := range candidates {
+		ranked = append(ranked, candidate{addr: addr, rec: rec, rank: sha256.Sum256([]byte(identity + "\x00" + addr))})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return bytes.Compare(ranked[i].rank[:], ranked[j].rank[:]) < 0 })
+	kept := make(map[string]summaryRecord, len(ranked))
+	used := 0
+	for _, candidate := range ranked {
+		if used+candidate.rec.bytes > remoteBudget {
+			continue
+		}
+		kept[candidate.addr] = candidate.rec
+		used += candidate.rec.bytes
+	}
+	if _, keptIncoming := kept[peer]; !keptIncoming {
+		return errors.New("summary remote memory budget exhausted")
+	}
+	st.records, st.bytes = kept, used
 	return nil
 }
 func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time) {

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -26,10 +26,15 @@ const (
 	defaultSummaryTTL      = 45 * time.Second
 	defaultSummaryInterval = 20 * time.Second
 	summaryTargetFPR       = 0.01
-	maxSummaryBodyBytes    = 16 << 20
-	maxSummaryItems        = 1_000_000
-	maxSummaryPeers        = 256
-	maxSummaryPushes       = 4
+	// A 1m-entry filter at 1% false-positive rate is ~1.15 MiB before JSON
+	// base64 encoding. Two MiB is a hard wire cap with modest headroom.
+	maxSummaryBodyBytes     = 2 << 20
+	maxSummaryItems         = 1_000_000
+	maxSummaryPeers         = 256
+	maxSummaryPushes        = 4
+	maxSummaryReceives      = 4
+	maxSummaryResidentBytes = 512 << 20
+	summaryPushTimeout      = 200 * time.Millisecond
 )
 
 var (
@@ -78,22 +83,9 @@ func newCacheSummary(sender string, generation uint64, keys []string, now time.T
 	if sender == "" || generation == 0 || ttl <= 0 || len(keys) > maxSummaryItems {
 		return nil, errors.New("invalid summary inputs")
 	}
-	// m = -n ln(p)/(ln(2)^2), k = round(m/n ln(2)). Do not cap m by
-	// silently dropping entries: that would create false negatives.
-	m := uint64(math.Ceil(-float64(len(keys)) * math.Log(summaryTargetFPR) / (math.Ln2 * math.Ln2)))
-	if m < 8 {
-		m = 8
-	}
-	m = (m + 7) &^ 7
+	m, k := bloomParams(len(keys))
 	if m/8 > maxSummaryBodyBytes {
 		return nil, fmt.Errorf("summary bloom exceeds %d-byte limit", maxSummaryBodyBytes)
-	}
-	k := uint8(math.Round(float64(m) / math.Max(float64(len(keys)), 1) * math.Ln2))
-	if k == 0 {
-		k = 1
-	}
-	if k > 32 {
-		k = 32
 	}
 	s := &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, Sender: sender, Generation: generation, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), ItemCount: len(keys), MBits: m, Hashes: k, Bits: make([]byte, m/8)}
 	for _, key := range keys {
@@ -103,6 +95,22 @@ func newCacheSummary(sender string, generation uint64, keys []string, now time.T
 		s.add(key)
 	}
 	return s, nil
+}
+
+func bloomParams(items int) (uint64, uint8) {
+	m := uint64(math.Ceil(-float64(items) * math.Log(summaryTargetFPR) / (math.Ln2 * math.Ln2)))
+	if m < 8 {
+		m = 8
+	}
+	m = (m + 7) &^ 7
+	k := uint8(math.Round(float64(m) / math.Max(float64(items), 1) * math.Ln2))
+	if k == 0 {
+		k = 1
+	}
+	if k > 32 {
+		k = 32
+	}
+	return m, k
 }
 
 func (s *cacheSummary) hashes(key string, fn func(uint64)) {
@@ -151,7 +159,11 @@ func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion || s.Sender == "" || len(s.Sender) > 253 || strings.ContainsAny(s.Sender, "\r\n") || s.Generation == 0 {
 		return nil, errors.New("incompatible summary")
 	}
-	if s.ItemCount < 0 || s.ItemCount > maxSummaryItems || s.MBits < 8 || s.MBits%8 != 0 || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) || s.Hashes == 0 || s.Hashes > 32 {
+	if s.ItemCount < 0 || s.ItemCount > maxSummaryItems {
+		return nil, errors.New("invalid bloom parameters")
+	}
+	wantBits, wantHashes := bloomParams(s.ItemCount)
+	if s.MBits != wantBits || s.Hashes != wantHashes || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) {
 		return nil, errors.New("invalid bloom parameters")
 	}
 	created, expires := time.Unix(0, s.CreatedNS), time.Unix(0, s.ExpiresNS)
@@ -192,11 +204,19 @@ func (st *summaryStore) receive(peer string, body []byte, now time.Time, member 
 			return errors.New("summary peer limit")
 		}
 	}
+	residentBytes := len(s.Bits)
+	oldBytes := 0
 	if old, ok := st.records[peer]; ok {
-		st.bytes -= old.bytes
+		oldBytes = old.bytes
 	}
-	st.records[peer] = summaryRecord{summary: s, bytes: len(body)}
-	st.bytes += len(body)
+	if st.bytes-oldBytes+residentBytes > maxSummaryResidentBytes {
+		return errors.New("summary resident byte limit")
+	}
+	if oldBytes > 0 {
+		st.bytes -= oldBytes
+	}
+	st.records[peer] = summaryRecord{summary: s, bytes: residentBytes}
+	st.bytes += residentBytes
 	return nil
 }
 func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time) {
@@ -209,24 +229,33 @@ func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time
 		}
 	}
 }
-func (st *summaryStore) candidates(key string, now time.Time) []string {
+func (st *summaryStore) candidates(key string, members []string, now time.Time) (positive, uncovered []string) {
 	st.mu.RLock()
 	defer st.mu.RUnlock()
 	type candidate struct{ addr, identity string }
 	var cs []candidate
-	for peer, rec := range st.records {
-		if time.Unix(0, rec.summary.ExpiresNS).After(now) && rec.summary.Contains(key) {
+	for _, peer := range members {
+		rec, covered := st.records[peer]
+		if !covered || !time.Unix(0, rec.summary.ExpiresNS).After(now) {
+			uncovered = append(uncovered, peer)
+			continue
+		}
+		if rec.summary.Contains(key) {
 			summaryAgeSeconds.Observe(now.Sub(time.Unix(0, rec.summary.CreatedNS)).Seconds())
 			cs = append(cs, candidate{peer, rec.summary.Sender})
 		}
 	}
 	sort.Slice(cs, func(i, j int) bool {
-		a, b := sha256.Sum256([]byte(key+cs[i].identity)), sha256.Sum256([]byte(key+cs[j].identity))
-		return string(a[:]) < string(b[:])
+		a, b := rankPeer(key, cs[i].identity, cs[i].addr), rankPeer(key, cs[j].identity, cs[j].addr)
+		return bytes.Compare(a[:], b[:]) < 0
 	})
-	peers := make([]string, len(cs))
+	positive = make([]string, len(cs))
 	for i := range cs {
-		peers[i] = cs[i].addr
+		positive[i] = cs[i].addr
 	}
-	return peers
+	return positive, uncovered
+}
+
+func rankPeer(key, identity, addr string) [sha256.Size]byte {
+	return sha256.Sum256([]byte(key + "\x00" + identity + "\x00" + addr))
 }

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Summary data deliberately contains only opaque cache-key digests. It is a
+// best-effort hint: rejecting it or losing it must only reduce peer hits.
+const (
+	summaryFormatVersion   = 1
+	cacheLayoutVersion     = 1
+	defaultSummaryTTL      = 45 * time.Second
+	defaultSummaryInterval = 20 * time.Second
+	summaryTargetFPR       = 0.01
+	maxSummaryBodyBytes    = 16 << 20
+	maxSummaryItems        = 1_000_000
+	maxSummaryPeers        = 256
+	maxSummaryPushes       = 4
+)
+
+var (
+	summaryPushesTotal   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pushes_total", Help: "Summary publications by outcome"}, []string{"outcome"})
+	summaryReceiptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_receipts_total", Help: "Peer summary receipts by outcome"}, []string{"outcome"})
+	summaryResidentCount = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
+	summaryResidentBytes = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Current valid peer summary bytes"})
+	summaryAgeSeconds    = promauto.NewHistogram(prometheus.HistogramOpts{Name: "cache_proxy_summary_age_seconds", Help: "Age of a summary used during lookup", Buckets: prometheus.ExponentialBuckets(0.1, 2, 10)})
+	summaryLookupTotal   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_lookups_total", Help: "Summary lookup decisions"}, []string{"outcome"})
+	peerDirectGetsTotal  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_peer_direct_gets_total", Help: "Direct peer GET attempts in summary mode"}, []string{"outcome"})
+)
+
+type peerLookupMode string
+
+const (
+	peerLookupProbe   peerLookupMode = "probe"
+	peerLookupSummary peerLookupMode = "summary"
+)
+
+func parsePeerLookupMode(value string) (peerLookupMode, error) {
+	if value == "" || value == string(peerLookupProbe) {
+		return peerLookupProbe, nil
+	}
+	if value == string(peerLookupSummary) {
+		return peerLookupSummary, nil
+	}
+	return "", fmt.Errorf("invalid CACHE_PEER_LOOKUP_MODE %q (want probe or summary)", value)
+}
+
+// cacheSummary is the complete versioned wire payload. []byte is base64 in
+// JSON; no raw cache locator can be recovered from the Bloom bits.
+type cacheSummary struct {
+	Version    int    `json:"v"`
+	Layout     int    `json:"l"`
+	Sender     string `json:"s"`
+	Generation uint64 `json:"g"`
+	CreatedNS  int64  `json:"c"`
+	ExpiresNS  int64  `json:"e"`
+	ItemCount  int    `json:"n"`
+	MBits      uint64 `json:"m"`
+	Hashes     uint8  `json:"k"`
+	Bits       []byte `json:"b"`
+}
+
+func newCacheSummary(sender string, generation uint64, keys []string, now time.Time, ttl time.Duration) (*cacheSummary, error) {
+	if sender == "" || generation == 0 || ttl <= 0 || len(keys) > maxSummaryItems {
+		return nil, errors.New("invalid summary inputs")
+	}
+	// m = -n ln(p)/(ln(2)^2), k = round(m/n ln(2)). Do not cap m by
+	// silently dropping entries: that would create false negatives.
+	m := uint64(math.Ceil(-float64(len(keys)) * math.Log(summaryTargetFPR) / (math.Ln2 * math.Ln2)))
+	if m < 8 {
+		m = 8
+	}
+	m = (m + 7) &^ 7
+	if m/8 > maxSummaryBodyBytes {
+		return nil, fmt.Errorf("summary bloom exceeds %d-byte limit", maxSummaryBodyBytes)
+	}
+	k := uint8(math.Round(float64(m) / math.Max(float64(len(keys)), 1) * math.Ln2))
+	if k == 0 {
+		k = 1
+	}
+	if k > 32 {
+		k = 32
+	}
+	s := &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, Sender: sender, Generation: generation, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), ItemCount: len(keys), MBits: m, Hashes: k, Bits: make([]byte, m/8)}
+	for _, key := range keys {
+		if !IsValidCacheKey(key) {
+			return nil, errors.New("invalid cache key in summary snapshot")
+		}
+		s.add(key)
+	}
+	return s, nil
+}
+
+func (s *cacheSummary) hashes(key string, fn func(uint64)) {
+	d := sha256.Sum256([]byte(key))
+	h1, h2 := binary.LittleEndian.Uint64(d[:8]), binary.LittleEndian.Uint64(d[8:16])
+	for i := uint8(0); i < s.Hashes; i++ {
+		fn((h1 + uint64(i)*h2) % s.MBits)
+	}
+}
+
+func (s *cacheSummary) add(key string) {
+	s.hashes(key, func(bit uint64) { s.Bits[bit/8] |= 1 << (bit % 8) })
+}
+func (s *cacheSummary) Contains(key string) bool {
+	if !IsValidCacheKey(key) || s.MBits == 0 || len(s.Bits) != int(s.MBits/8) {
+		return false
+	}
+	ok := true
+	s.hashes(key, func(bit uint64) {
+		if s.Bits[bit/8]&(1<<(bit%8)) == 0 {
+			ok = false
+		}
+	})
+	return ok
+}
+func (s *cacheSummary) MarshalBinary() ([]byte, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > maxSummaryBodyBytes {
+		return nil, errors.New("summary exceeds wire limit")
+	}
+	return b, nil
+}
+func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
+	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
+		return nil, errors.New("invalid summary body size")
+	}
+	var s cacheSummary
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&s); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return nil, errors.New("invalid summary encoding")
+	}
+	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion || s.Sender == "" || len(s.Sender) > 253 || strings.ContainsAny(s.Sender, "\r\n") || s.Generation == 0 {
+		return nil, errors.New("incompatible summary")
+	}
+	if s.ItemCount < 0 || s.ItemCount > maxSummaryItems || s.MBits < 8 || s.MBits%8 != 0 || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) || s.Hashes == 0 || s.Hashes > 32 {
+		return nil, errors.New("invalid bloom parameters")
+	}
+	created, expires := time.Unix(0, s.CreatedNS), time.Unix(0, s.ExpiresNS)
+	if !expires.After(now) || !expires.After(created) || created.After(now.Add(2*time.Minute)) || expires.Sub(created) > 2*defaultSummaryTTL {
+		return nil, errors.New("invalid summary timestamps")
+	}
+	return &s, nil
+}
+
+type summaryRecord struct {
+	summary *cacheSummary
+	bytes   int
+}
+
+// summaryStore owns bounded peer hints. The small lock is only held to replace
+// pointers and copy candidates; Bloom membership tests happen after release.
+type summaryStore struct {
+	mu      sync.RWMutex
+	records map[string]summaryRecord
+	bytes   int
+}
+
+func (st *summaryStore) receive(peer string, body []byte, now time.Time, member func(string) bool) error {
+	s, err := parseCacheSummary(body, now)
+	if err != nil {
+		return err
+	}
+	if !member(peer) {
+		return errors.New("unknown summary sender")
+	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if old, ok := st.records[peer]; ok && old.summary.Generation >= s.Generation {
+		return errors.New("stale summary generation")
+	}
+	if len(st.records) >= maxSummaryPeers {
+		if _, exists := st.records[peer]; !exists {
+			return errors.New("summary peer limit")
+		}
+	}
+	if old, ok := st.records[peer]; ok {
+		st.bytes -= old.bytes
+	}
+	st.records[peer] = summaryRecord{summary: s, bytes: len(body)}
+	st.bytes += len(body)
+	return nil
+}
+func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for peer, rec := range st.records {
+		if !member(peer) || time.Unix(0, rec.summary.ExpiresNS).Before(now) {
+			delete(st.records, peer)
+			st.bytes -= rec.bytes
+		}
+	}
+}
+func (st *summaryStore) candidates(key string, now time.Time) []string {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	type candidate struct{ addr, identity string }
+	var cs []candidate
+	for peer, rec := range st.records {
+		if time.Unix(0, rec.summary.ExpiresNS).After(now) && rec.summary.Contains(key) {
+			summaryAgeSeconds.Observe(now.Sub(time.Unix(0, rec.summary.CreatedNS)).Seconds())
+			cs = append(cs, candidate{peer, rec.summary.Sender})
+		}
+	}
+	sort.Slice(cs, func(i, j int) bool {
+		a, b := sha256.Sum256([]byte(key+cs[i].identity)), sha256.Sum256([]byte(key+cs[j].identity))
+		return string(a[:]) < string(b[:])
+	})
+	peers := make([]string, len(cs))
+	for i := range cs {
+		peers[i] = cs[i].addr
+	}
+	return peers
+}

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -23,7 +23,7 @@ import (
 const (
 	summaryFormatVersion    = 2
 	cacheLayoutVersion      = 1
-	defaultSummaryTTL       = 45 * time.Second
+	defaultSummaryTTL       = 60 * time.Second
 	defaultSummaryInterval  = 20 * time.Second
 	summaryTargetFPR        = 0.01
 	summaryBloomTargetItems = 1_000_000
@@ -75,12 +75,12 @@ var (
 var (
 	summaryPullsTotal                   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pulls_total", Help: "Peer summary pulls by outcome"}, []string{"outcome"})
 	summaryServesTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_serves_total", Help: "Local summary endpoint responses by outcome"}, []string{"outcome"})
-	summaryReceiptsTotal                = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_receipts_total", Help: "Peer summary receipts by outcome"}, []string{"outcome"})
 	summaryResidentCount                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
-	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Current valid peer summary bytes"})
+	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Conservative Bloom-state memory accounting: fixed local index, transient reserve, and retained peer summaries"})
+	summaryMemoryLimitBytes             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_memory_limit_bytes", Help: "Effective configured ceiling for total Bloom-state memory accounting"})
 	summaryAgeSeconds                   = promauto.NewHistogram(prometheus.HistogramOpts{Name: "cache_proxy_summary_age_seconds", Help: "Age of a summary used during lookup", Buckets: prometheus.ExponentialBuckets(0.1, 2, 10)})
 	summaryLookupTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_lookups_total", Help: "Summary lookup decisions"}, []string{"outcome"})
-	peerDirectGetsTotal                 = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_peer_direct_gets_total", Help: "Direct peer GET attempts in summary mode"}, []string{"outcome"})
+	summaryConfirmedGetsTotal           = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_confirmed_gets_total", Help: "Peer body GET attempts after exact summary-mode confirmation"}, []string{"outcome"})
 	summaryBloomItems                   = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_items", Help: "Current local cache keys represented by the incremental Bloom filter"})
 	summaryBloomBitsGauge               = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_bits", Help: "Allocated bits in the local incremental Bloom filter"})
 	summaryBloomHashesGauge             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_hashes", Help: "Hash functions in the local incremental Bloom filter"})
@@ -90,7 +90,7 @@ var (
 	summaryBloomAddsTotal               = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_additions_total", Help: "Cache insertions applied to the incremental Bloom filter"})
 	summaryBloomRemovalsTotal           = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_removals_total", Help: "Cache evictions applied to the incremental Bloom filter"})
 	summaryBloomCounterSaturationsTotal = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_counter_saturations_total", Help: "Counting Bloom cells that reached uint16 saturation"})
-	summaryBloomSnapshotsTotal          = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_snapshots_total", Help: "Immutable Bloom snapshots prepared for publication"})
+	summaryBloomSnapshotsTotal          = promauto.NewCounter(prometheus.CounterOpts{Name: "cache_proxy_summary_bloom_snapshots_total", Help: "Immutable Bloom snapshots prepared for serving"})
 	summaryBloomSnapshotBytes           = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_snapshot_bytes", Help: "Bytes in the most recent local Bloom snapshot"})
 )
 
@@ -114,34 +114,13 @@ func parsePeerLookupMode(value string) (peerLookupMode, error) {
 // cacheSummary is the complete versioned wire payload. []byte is base64 in
 // JSON; no raw cache locator can be recovered from the Bloom bits.
 type cacheSummary struct {
-	Version    int    `json:"v"`
-	Layout     int    `json:"l"`
-	Sender     string `json:"s"`
-	Generation uint64 `json:"g"`
-	CreatedNS  int64  `json:"c"`
-	ExpiresNS  int64  `json:"e"`
-	ItemCount  int    `json:"n"`
-	MBits      uint64 `json:"m"`
-	Hashes     uint8  `json:"k"`
-	Bits       []byte `json:"b"`
-}
-
-func newCacheSummary(sender string, generation uint64, keys []string, now time.Time, ttl time.Duration) (*cacheSummary, error) {
-	if sender == "" || generation == 0 || ttl <= 0 || len(keys) > summaryBloomTargetItems {
-		return nil, errors.New("invalid summary inputs")
-	}
-	m, k := bloomParams(len(keys))
-	if m/8 > maxSummaryBodyBytes {
-		return nil, fmt.Errorf("summary bloom exceeds %d-byte limit", maxSummaryBodyBytes)
-	}
-	s := &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, Sender: sender, Generation: generation, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), ItemCount: len(keys), MBits: m, Hashes: k, Bits: make([]byte, m/8)}
-	for _, key := range keys {
-		if !IsValidCacheKey(key) {
-			return nil, errors.New("invalid cache key in summary snapshot")
-		}
-		s.add(key)
-	}
-	return s, nil
+	Version   int    `json:"v"`
+	Layout    int    `json:"l"`
+	CreatedNS int64  `json:"c"`
+	ExpiresNS int64  `json:"e"`
+	MBits     uint64 `json:"m"`
+	Hashes    uint8  `json:"k"`
+	Bits      []byte `json:"b"`
 }
 
 // summaryIndex is a bounded counting Bloom filter. Counters make eviction
@@ -230,18 +209,6 @@ func (i *summaryIndex) Snapshot() (int, []byte) {
 	return i.itemCount, append([]byte(nil), i.bits...)
 }
 
-func (i *summaryIndex) FalsePositiveRate() float64 {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return bloomFalsePositiveRate(i.itemCount, i.bitCount, i.hashes)
-}
-
-func (i *summaryIndex) Saturated() bool {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.itemCount > i.targetItems
-}
-
 func (i *summaryIndex) updateMetricsLocked() {
 	summaryBloomItems.Set(float64(i.itemCount))
 	summaryBloomBitsGauge.Set(float64(i.bitCount))
@@ -291,9 +258,6 @@ func bloomHashes(key string, bits uint64, hashes uint8, fn func(uint64)) {
 	}
 }
 
-func (s *cacheSummary) add(key string) {
-	s.hashes(key, func(bit uint64) { s.Bits[bit/8] |= 1 << (bit % 8) })
-}
 func (s *cacheSummary) Contains(key string) bool {
 	if !IsValidCacheKey(key) || s.MBits == 0 || len(s.Bits) != int(s.MBits/8) {
 		return false
@@ -317,15 +281,15 @@ func (s *cacheSummary) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
-func summaryFromIncrementalBits(sender string, generation uint64, itemCount int, bitCount uint64, hashes uint8, bits []byte, now time.Time, ttl time.Duration) *cacheSummary {
-	return &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, Sender: sender, Generation: generation, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), ItemCount: itemCount, MBits: bitCount, Hashes: hashes, Bits: bits}
+func summaryFromIncrementalBits(bitCount uint64, hashes uint8, bits []byte, now time.Time, ttl time.Duration) *cacheSummary {
+	return &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), MBits: bitCount, Hashes: hashes, Bits: bits}
 }
 
-func newIncrementalCacheSummary(sender string, generation uint64, itemCount int, bits []byte, now time.Time, ttl time.Duration) (*cacheSummary, error) {
-	if sender == "" || generation == 0 || ttl <= 0 || itemCount < 0 || len(bits) != int(summaryBloomBits/8) {
+func newIncrementalCacheSummary(bits []byte, now time.Time, ttl time.Duration) (*cacheSummary, error) {
+	if ttl <= 0 || len(bits) != int(summaryBloomBits/8) {
 		return nil, errors.New("invalid incremental summary inputs")
 	}
-	return summaryFromIncrementalBits(sender, generation, itemCount, summaryBloomBits, summaryBloomHashes, bits, now, ttl), nil
+	return summaryFromIncrementalBits(summaryBloomBits, summaryBloomHashes, bits, now, ttl), nil
 }
 func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
@@ -337,16 +301,10 @@ func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if err := decoder.Decode(&s); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
 		return nil, errors.New("invalid summary encoding")
 	}
-	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion || s.Sender == "" || len(s.Sender) > 253 || strings.ContainsAny(s.Sender, "\r\n") || s.Generation == 0 {
+	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion {
 		return nil, errors.New("incompatible summary")
 	}
-	if s.ItemCount < 0 {
-		return nil, errors.New("invalid bloom parameters")
-	}
-	wantBits, wantHashes := bloomParams(s.ItemCount)
-	dynamicParams := s.MBits == wantBits && s.Hashes == wantHashes
-	incrementalParams := s.MBits == summaryBloomBits && s.Hashes == summaryBloomHashes
-	if (!dynamicParams && !incrementalParams) || s.MBits/8 > maxSummaryBodyBytes || len(s.Bits) != int(s.MBits/8) {
+	if s.MBits != summaryBloomBits || s.Hashes != summaryBloomHashes || len(s.Bits) != int(summaryBloomBits/8) {
 		return nil, errors.New("invalid bloom parameters")
 	}
 	created, expires := time.Unix(0, s.CreatedNS), time.Unix(0, s.ExpiresNS)
@@ -379,7 +337,7 @@ type summaryStore struct {
 	bytes   int
 }
 
-func (st *summaryStore) receive(peer string, body []byte, etag string, now time.Time, member func(string) bool, remoteBudget int, identity string) error {
+func (st *summaryStore) receive(peer string, body []byte, etag string, now time.Time, member func(string) bool, remoteBudget int) error {
 	s, err := parseCacheSummary(body, now)
 	if err != nil {
 		return err
@@ -389,41 +347,20 @@ func (st *summaryStore) receive(peer string, body []byte, etag string, now time.
 	}
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	if old, ok := st.records[peer]; ok && old.summary.Generation >= s.Generation {
-		return errors.New("stale summary generation")
-	}
 	residentBytes := len(s.Bits)
 	if residentBytes > remoteBudget {
 		return errors.New("summary exceeds remote memory budget")
 	}
-	candidates := make(map[string]summaryRecord, len(st.records)+1)
-	for addr, rec := range st.records {
-		candidates[addr] = rec
+	oldBytes := 0
+	if old, ok := st.records[peer]; ok {
+		oldBytes = old.bytes
 	}
-	candidates[peer] = summaryRecord{summary: s, bytes: residentBytes, etag: boundedSummaryETag(etag)}
-	type candidate struct {
-		addr string
-		rec  summaryRecord
-		rank [sha256.Size]byte
-	}
-	ranked := make([]candidate, 0, len(candidates))
-	for addr, rec := range candidates {
-		ranked = append(ranked, candidate{addr: addr, rec: rec, rank: sha256.Sum256([]byte(identity + "\x00" + addr))})
-	}
-	sort.Slice(ranked, func(i, j int) bool { return bytes.Compare(ranked[i].rank[:], ranked[j].rank[:]) < 0 })
-	kept := make(map[string]summaryRecord, len(ranked))
-	used := 0
-	for _, candidate := range ranked {
-		if used+candidate.rec.bytes > remoteBudget {
-			continue
-		}
-		kept[candidate.addr] = candidate.rec
-		used += candidate.rec.bytes
-	}
-	if _, keptIncoming := kept[peer]; !keptIncoming {
+	used := st.bytes - oldBytes + residentBytes
+	if used > remoteBudget {
 		return errors.New("summary remote memory budget exhausted")
 	}
-	st.records, st.bytes = kept, used
+	st.records[peer] = summaryRecord{summary: s, bytes: residentBytes, etag: boundedSummaryETag(etag)}
+	st.bytes = used
 	return nil
 }
 
@@ -458,21 +395,10 @@ func (st *summaryStore) removePeer(peer string) {
 	}
 }
 
-func (st *summaryStore) removeNonMembers(member func(string) bool, now time.Time) {
-	st.mu.Lock()
-	defer st.mu.Unlock()
-	for peer, rec := range st.records {
-		if !member(peer) || time.Unix(0, rec.summary.ExpiresNS).Before(now) {
-			delete(st.records, peer)
-			st.bytes -= rec.bytes
-		}
-	}
-}
 func (st *summaryStore) candidates(key string, members []string, now time.Time) (positive, uncovered []string) {
 	st.mu.RLock()
 	defer st.mu.RUnlock()
-	type candidate struct{ addr, identity string }
-	var cs []candidate
+	var candidates []string
 	for _, peer := range members {
 		rec, covered := st.records[peer]
 		if !covered || !time.Unix(0, rec.summary.ExpiresNS).After(now) {
@@ -481,20 +407,16 @@ func (st *summaryStore) candidates(key string, members []string, now time.Time) 
 		}
 		if rec.summary.Contains(key) {
 			summaryAgeSeconds.Observe(now.Sub(time.Unix(0, rec.summary.CreatedNS)).Seconds())
-			cs = append(cs, candidate{peer, rec.summary.Sender})
+			candidates = append(candidates, peer)
 		}
 	}
-	sort.Slice(cs, func(i, j int) bool {
-		a, b := rankPeer(key, cs[i].identity, cs[i].addr), rankPeer(key, cs[j].identity, cs[j].addr)
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := rankPeer(key, candidates[i]), rankPeer(key, candidates[j])
 		return bytes.Compare(a[:], b[:]) < 0
 	})
-	positive = make([]string, len(cs))
-	for i := range cs {
-		positive[i] = cs[i].addr
-	}
-	return positive, uncovered
+	return candidates, uncovered
 }
 
-func rankPeer(key, identity, addr string) [sha256.Size]byte {
-	return sha256.Sum256([]byte(key + "\x00" + identity + "\x00" + addr))
+func rankPeer(key, addr string) [sha256.Size]byte {
+	return sha256.Sum256([]byte(key + "\x00" + addr))
 }

--- a/cmd/cache-proxy/summary_pull_redesign_test.go
+++ b/cmd/cache-proxy/summary_pull_redesign_test.go
@@ -1,0 +1,837 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests describe the pull-based summary protocol and the request-time
+// confirmation contract. Bloom summaries only eliminate definite negatives;
+// they never authorize a body GET without an exact /cache/has confirmation.
+
+func TestSummarySyncImmediatelyPullsNewPeerWithGET(t *testing.T) {
+	key := strings.Repeat("a", 64)
+	summary, err := newCacheSummary("remote", 1, []string{key}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gets, posts int32
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			atomic.AddInt32(&gets, 1)
+			w.Header().Set("ETag", `"generation-1"`)
+			_, _ = w.Write(body)
+		case http.MethodPost:
+			atomic.AddInt32(&posts, 1)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer remote.Close()
+
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm.StartSummarySynchronizer(ctx, store)
+	defer pm.StopSummarySynchronizer()
+
+	eventually(t, time.Second, func() bool {
+		return len(pm.SummaryCandidates(key, time.Now())) == 1
+	})
+	if got := atomic.LoadInt32(&gets); got != 1 {
+		t.Fatalf("initial summary GETs=%d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&posts); got != 0 {
+		t.Fatalf("summary POSTs=%d, want 0 in receiver-driven protocol", got)
+	}
+}
+
+func TestPeerSummaryGETServesSnapshotAndSupportsETag(t *testing.T) {
+	key := strings.Repeat("b", 64)
+	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PutStream(key, strings.NewReader("cached")); err != nil {
+		t.Fatal(err)
+	}
+	pm := peerManagerWith(nil)
+	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm.StartSummarySynchronizer(ctx, store)
+	defer pm.StopSummarySynchronizer()
+	eventually(t, time.Second, func() bool { return len(pm.localSummaryCopy()) > 0 })
+
+	proxy := NewCacheProxy(store, pm, nil)
+	first := httptest.NewRecorder()
+	proxy.HandlePeerSummary(first, httptest.NewRequest(http.MethodGet, "/cache/summary", nil))
+	if first.Code != http.StatusOK {
+		t.Fatalf("GET /cache/summary status=%d, want 200", first.Code)
+	}
+	etag := first.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("GET /cache/summary omitted ETag")
+	}
+	if got, want := first.Header().Get("Content-Length"), strconv.Itoa(first.Body.Len()); got != want {
+		t.Fatalf("GET /cache/summary Content-Length=%q, want %q", got, want)
+	}
+	parsed, err := parseCacheSummary(first.Body.Bytes(), time.Now())
+	if err != nil || !parsed.Contains(key) {
+		t.Fatalf("served snapshot contains key=%t, parse error=%v", err == nil && parsed.Contains(key), err)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodGet, "/cache/summary", nil)
+	secondReq.Header.Set("If-None-Match", etag)
+	second := httptest.NewRecorder()
+	proxy.HandlePeerSummary(second, secondReq)
+	if second.Code != http.StatusNotModified || second.Body.Len() != 0 {
+		t.Fatalf("conditional GET status/body=%d/%d, want 304/0", second.Code, second.Body.Len())
+	}
+	if got := second.Header().Get("ETag"); got != etag {
+		t.Fatalf("conditional GET ETag=%q, want %q", got, etag)
+	}
+	if got, want := second.Header().Get("Content-Length"), strconv.Itoa(first.Body.Len()); got != want {
+		t.Fatalf("conditional GET Content-Length=%q, want selected representation length %q", got, want)
+	}
+}
+
+func TestPeerSummaryGETSetsHandlerLocalWriteDeadline(t *testing.T) {
+	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pm := peerManagerWith(nil)
+	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
+	pm.buildLocalSummary(store)
+	proxy := NewCacheProxy(store, pm, nil)
+	w := &deadlineResponseWriter{header: make(http.Header)}
+	started := time.Now()
+	proxy.HandlePeerSummary(w, httptest.NewRequest(http.MethodGet, "/cache/summary", nil))
+	if w.deadline.IsZero() {
+		t.Fatal("summary GET did not set a handler-local write deadline")
+	}
+	if got := w.deadline.Sub(started); got <= 0 || got > summaryServeTimeout+time.Second {
+		t.Fatalf("summary write deadline offset=%s, want within %s", got, summaryServeTimeout)
+	}
+}
+
+type deadlineResponseWriter struct {
+	header   http.Header
+	status   int
+	deadline time.Time
+}
+
+func (w *deadlineResponseWriter) Header() http.Header { return w.header }
+func (w *deadlineResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+func (w *deadlineResponseWriter) Write(body []byte) (int, error) { return len(body), nil }
+func (w *deadlineResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadline = deadline
+	return nil
+}
+
+func TestSummarySelectionIsDeterministicAndFitsRemoteMemoryBudget(t *testing.T) {
+	peers := []string{"peer-e:8081", "peer-b:8081", "peer-d:8081", "peer-a:8081", "peer-c:8081"}
+	filterBytes := int(summaryBloomBits / 8)
+	memoryLimit := summaryMemoryLimitForRemoteBytes(int64(2*filterBytes + filterBytes/2))
+
+	first := NewPeerManager("test.svc", ":8081")
+	first.ConfigureSummary(peerLookupSummary, "receiver-a", SummaryConfig{MemoryLimitBytes: memoryLimit})
+	firstSelection := first.selectSummaryPeers(peers)
+	if len(firstSelection) != 2 {
+		t.Fatalf("selected peers=%v, want exactly two summaries within budget", firstSelection)
+	}
+
+	reversed := append([]string(nil), peers...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+	second := NewPeerManager("test.svc", ":8081")
+	second.ConfigureSummary(peerLookupSummary, "receiver-a", SummaryConfig{MemoryLimitBytes: memoryLimit})
+	secondSelection := second.selectSummaryPeers(reversed)
+	if !stringSlicesEqual(firstSelection, secondSelection) {
+		t.Fatalf("selection depends on DNS order: first=%v reversed=%v", firstSelection, secondSelection)
+	}
+	if used := len(firstSelection) * filterBytes; used > first.summaryRemoteMemoryBudget || used+filterBytes <= first.summaryRemoteMemoryBudget {
+		t.Fatalf("selected bytes=%d budget=%d does not form the maximal fitting subset", used, first.summaryRemoteMemoryBudget)
+	}
+}
+
+func TestSummarySyncPullsOnlyReceiverSelectedSubset(t *testing.T) {
+	filterBytes := int64(summaryBloomBits / 8)
+	var totalGets int32
+	peers := make([]string, 0, 6)
+	peerGets := make(map[string]*int32, 6)
+	for range 6 {
+		calls := new(int32)
+		remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				atomic.AddInt32(calls, 1)
+				atomic.AddInt32(&totalGets, 1)
+			}
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		t.Cleanup(remote.Close)
+		peer := strings.TrimPrefix(remote.URL, "http://")
+		peers = append(peers, peer)
+		peerGets[peer] = calls
+	}
+
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: summaryMemoryLimitForRemoteBytes(2 * filterBytes)})
+	wantSelected := pm.selectSummaryPeers(peers)
+	if len(wantSelected) != 2 {
+		t.Fatalf("selected peers=%v, want two", wantSelected)
+	}
+	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	pm.StartSummarySynchronizer(ctx, store)
+	eventually(t, time.Second, func() bool { return atomic.LoadInt32(&totalGets) == 2 })
+	cancel()
+	pm.StopSummarySynchronizer()
+	for peer, calls := range peerGets {
+		got := atomic.LoadInt32(calls)
+		want := int32(0)
+		for _, selected := range wantSelected {
+			if peer == selected {
+				want = 1
+				break
+			}
+		}
+		if got != want {
+			t.Fatalf("peer %q pull count=%d, want %d for selected subset %v", peer, got, want, wantSelected)
+		}
+	}
+}
+
+func TestConditionalSummaryPullPreservesRecordOnNotModified(t *testing.T) {
+	key := strings.Repeat("1", 64)
+	now := time.Now()
+	summary, err := newCacheSummary("remote", 1, []string{key}, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const etag = `"remote-generation-1"`
+	var calls int32
+	var conditional atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			_, _ = w.Write(body)
+			return
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			conditional.Store(true)
+		}
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer remote.Close()
+
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.refreshSummarySelection()
+	pm.pullSummary(context.Background(), peer)
+	pm.pullSummary(context.Background(), peer)
+	if !conditional.Load() {
+		t.Fatal("second summary pull omitted If-None-Match for the retained ETag")
+	}
+	if candidates := pm.SummaryCandidates(key, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+		t.Fatalf("304 discarded the last valid summary: candidates=%v", candidates)
+	}
+}
+
+func TestFailedSummaryPullRetainsHintUntilTTLThenBecomesUncovered(t *testing.T) {
+	key := strings.Repeat("2", 64)
+	created := time.Now()
+	summary, err := newCacheSummary("remote", 1, []string{key}, created, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fail atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("ETag", `"remote-generation-1"`)
+		_, _ = w.Write(body)
+	}))
+	defer remote.Close()
+
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.refreshSummarySelection()
+	pm.pullSummary(context.Background(), peer)
+	fail.Store(true)
+	pm.pullSummary(context.Background(), peer)
+	positive, uncovered := pm.SummaryLookup(key, created.Add(time.Second))
+	if len(positive) != 1 || positive[0] != peer || len(uncovered) != 0 {
+		t.Fatalf("failed refresh discarded valid hint early: positive=%v uncovered=%v", positive, uncovered)
+	}
+	positive, uncovered = pm.SummaryLookup(key, created.Add(6*time.Second))
+	if len(positive) != 0 || len(uncovered) != 1 || uncovered[0] != peer {
+		t.Fatalf("expired hint remained authoritative: positive=%v uncovered=%v", positive, uncovered)
+	}
+}
+
+func TestExpiredSummaryETagDoesNotPreventUnconditionalRecoveryPull(t *testing.T) {
+	oldKey, newKey := strings.Repeat("5", 64), strings.Repeat("6", 64)
+	first, err := newCacheSummary("remote", 1, []string{oldKey}, time.Now(), 200*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstBody, err := first.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newCacheSummary("remote", 2, []string{newKey}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBody, err := second.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const firstETag = `"remote-generation-1"`
+	var calls int32
+	var staleConditional atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("ETag", firstETag)
+			_, _ = w.Write(firstBody)
+			return
+		}
+		if r.Header.Get("If-None-Match") != "" {
+			staleConditional.Store(true)
+		}
+		w.Header().Set("ETag", `"remote-generation-2"`)
+		_, _ = w.Write(secondBody)
+	}))
+	defer remote.Close()
+
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.refreshSummarySelection()
+	pm.pullSummary(context.Background(), peer)
+	time.Sleep(250 * time.Millisecond)
+	pm.pullSummary(context.Background(), peer)
+	if staleConditional.Load() {
+		t.Fatal("pull sent If-None-Match for an expired summary")
+	}
+	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+		t.Fatalf("unconditional recovery pull did not install new summary: candidates=%v", candidates)
+	}
+}
+
+func TestRejectedSummaryPullDoesNotReplaceLastValidHint(t *testing.T) {
+	oldKey, newKey := strings.Repeat("3", 64), strings.Repeat("4", 64)
+	now := time.Now()
+	valid, err := newCacheSummary("remote", 1, []string{oldKey}, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validBody, err := valid.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid, err := newCacheSummary("remote", 2, []string{newKey}, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidBody, err := invalid.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidBody[0] ^= 0xff
+	var serveInvalid atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if serveInvalid.Load() {
+			w.Header().Set("ETag", `"remote-generation-2"`)
+			_, _ = w.Write(invalidBody)
+			return
+		}
+		w.Header().Set("ETag", `"remote-generation-1"`)
+		_, _ = w.Write(validBody)
+	}))
+	defer remote.Close()
+
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.refreshSummarySelection()
+	pm.pullSummary(context.Background(), peer)
+	serveInvalid.Store(true)
+	pm.pullSummary(context.Background(), peer)
+	if candidates := pm.SummaryCandidates(oldKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+		t.Fatalf("invalid refresh replaced last valid hint: candidates=%v", candidates)
+	}
+	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 0 {
+		t.Fatalf("invalid refresh installed new key: candidates=%v", candidates)
+	}
+}
+
+func TestOversizedPeerETagIsNotRetainedWithValidSummary(t *testing.T) {
+	peer := "peer-a:8081"
+	oldKey, newKey := strings.Repeat("7", 64), strings.Repeat("8", 64)
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.refreshSummarySelection()
+
+	first, err := newCacheSummary("remote", 1, []string{oldKey}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstBody, err := first.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const ordinaryETag = `"generation-1"`
+	if err := pm.receivePulledSummary(peer, firstBody, ordinaryETag, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if got := pm.summaries.etag(peer, time.Now()); got != ordinaryETag {
+		t.Fatalf("ordinary ETag=%q, want %q", got, ordinaryETag)
+	}
+
+	second, err := newCacheSummary("remote", 2, []string{newKey}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBody, err := second.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversizedETag := `"` + strings.Repeat("x", 1<<20) + `"`
+	if err := pm.receivePulledSummary(peer, secondBody, oversizedETag, time.Now()); err != nil {
+		t.Fatalf("valid summary was rejected solely because its optional ETag was oversized: %v", err)
+	}
+	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+		t.Fatalf("valid newer summary was not installed: candidates=%v", candidates)
+	}
+	if got := pm.summaries.etag(peer, time.Now()); got != "" {
+		t.Fatalf("peer-controlled oversized ETag retained %d bytes, want it discarded", len(got))
+	}
+}
+
+func TestSummaryClientBoundsResponseHeaders(t *testing.T) {
+	pm := NewPeerManager("test.svc", ":8081")
+	transport, ok := pm.summaryClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("summary transport type=%T, want *http.Transport", pm.summaryClient.Transport)
+	}
+	if transport.MaxResponseHeaderBytes != maxSummaryResponseHeaderBytes {
+		t.Fatalf("summary response-header cap=%d, want %d", transport.MaxResponseHeaderBytes, maxSummaryResponseHeaderBytes)
+	}
+}
+
+func TestShortSummaryPullCyclesRotateAcrossSelectedPeers(t *testing.T) {
+	peers := make([]string, 12)
+	for i := range peers {
+		peers[i] = "peer-" + strconv.Itoa(i) + ":8081"
+	}
+	var mu sync.Mutex
+	attempted := make(map[string]int, len(peers))
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.summaryPullCycleTimeout = 10 * time.Millisecond
+	pm.summaryClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		attempted[req.URL.Host]++
+		mu.Unlock()
+		<-req.Context().Done()
+		// Keep all workers occupied briefly after the cycle deadline. The job
+		// producer therefore observes cancellation before a worker can accept a
+		// fifth job, making each cycle's attempted window deterministic.
+		time.Sleep(5 * time.Millisecond)
+		return nil, req.Context().Err()
+	})}
+
+	for range 3 {
+		pm.pullSummaries(context.Background(), peers)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, peer := range peers {
+		if attempted[peer] == 0 {
+			t.Fatalf("later selected peer %q was starved across repeated deadline-limited cycles; attempts=%v", peer, attempted)
+		}
+	}
+}
+
+func TestMaxOneSummaryProbeCanSelectUncoveredPeer(t *testing.T) {
+	positive := []string{"positive:8081"}
+	uncovered := []string{"uncovered:8081"}
+	var key string
+	for i := 0; i < 10_000; i++ {
+		candidate := strings.Repeat(strconv.FormatInt(int64(i%16), 16), 64)
+		if selected := selectProbePeers(candidate, append(append([]string(nil), positive...), uncovered...), 1); len(selected) == 1 && selected[0] == uncovered[0] {
+			key = candidate
+			break
+		}
+	}
+	if key == "" {
+		t.Fatal("test could not find a deterministic key ranking the uncovered peer first")
+	}
+	selected := selectSummaryProbePeers(key, positive, uncovered, 1)
+	if len(selected) != 1 || selected[0] != uncovered[0] {
+		t.Fatalf("maxProbes=1 selected %v, want uncovered peer %q for key whose combined rank prefers it", selected, uncovered[0])
+	}
+}
+
+func TestSummaryPullConcurrencyIsBoundedAndCancellationStopsWork(t *testing.T) {
+	var active, maximum, started int32
+	release := make(chan struct{})
+	peers := make([]string, 0, 12)
+	for range 12 {
+		remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			atomic.AddInt32(&started, 1)
+			now := atomic.AddInt32(&active, 1)
+			for {
+				old := atomic.LoadInt32(&maximum)
+				if now <= old || atomic.CompareAndSwapInt32(&maximum, old, now) {
+					break
+				}
+			}
+			defer atomic.AddInt32(&active, -1)
+			select {
+			case <-release:
+				w.WriteHeader(http.StatusNotFound)
+			case <-r.Context().Done():
+			}
+		}))
+		t.Cleanup(remote.Close)
+		peers = append(peers, strings.TrimPrefix(remote.URL, "http://"))
+	}
+
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	pm.StartSummarySynchronizer(ctx, store)
+	eventually(t, time.Second, func() bool { return atomic.LoadInt32(&started) > 0 })
+	const maxPullConcurrency = 4
+	if got := atomic.LoadInt32(&maximum); got > maxPullConcurrency {
+		t.Fatalf("simultaneous summary pulls=%d, want <=%d", got, maxPullConcurrency)
+	}
+	cancel()
+	pm.StopSummarySynchronizer()
+	eventually(t, time.Second, func() bool { return atomic.LoadInt32(&active) == 0 })
+	close(release)
+}
+
+func TestSummaryPositivesAreConfirmedBeforeExactlyOnePeerGET(t *testing.T) {
+	key := strings.Repeat("c", 64)
+	var falseHas, falseGet, realHas, realGet, originCalls int32
+	falsePeer := confirmationPeer(t, key, http.StatusNotFound, http.StatusNotFound, nil, 0, &falseHas, &falseGet, nil)
+	realPeer := confirmationPeer(t, key, http.StatusOK, http.StatusOK, []byte("peer"), 25*time.Millisecond, &realHas, &realGet, nil)
+
+	pm := peerManagerWith([]string{falsePeer, realPeer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	installPositiveSummary(t, pm, falsePeer, key)
+	installPositiveSummary(t, pm, realPeer, key)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+
+	proxy := NewCacheProxy(newTestCache(t), pm, nil)
+	proxy.client = origin.Client()
+	got, err := proxy.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "peer" {
+		t.Fatalf("fetch=%+v err=%v, want peer", got, err)
+	}
+	if gotFalse, gotReal := atomic.LoadInt32(&falseHas), atomic.LoadInt32(&realHas); gotFalse != 1 || gotReal != 1 {
+		t.Fatalf("confirmation calls false/real=%d/%d, want 1/1", gotFalse, gotReal)
+	}
+	if gotFalse, gotReal, gotOrigin := atomic.LoadInt32(&falseGet), atomic.LoadInt32(&realGet), atomic.LoadInt32(&originCalls); gotFalse != 0 || gotReal != 1 || gotOrigin != 0 {
+		t.Fatalf("body GETs false/real=%d/%d origin=%d, want 0/1/0", gotFalse, gotReal, gotOrigin)
+	}
+}
+
+func TestFalsePositiveDoesNotSuppressUncoveredPeerProbe(t *testing.T) {
+	key := strings.Repeat("d", 64)
+	var falseHas, falseGet, realHas, realGet, originCalls int32
+	falsePeer := confirmationPeer(t, key, http.StatusNotFound, http.StatusNotFound, nil, 0, &falseHas, &falseGet, nil)
+	realPeer := confirmationPeer(t, key, http.StatusOK, http.StatusOK, []byte("peer"), 20*time.Millisecond, &realHas, &realGet, nil)
+	pm := peerManagerWith([]string{falsePeer, realPeer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	installPositiveSummary(t, pm, falsePeer, key) // realPeer is intentionally uncovered
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+
+	proxy := NewCacheProxy(newTestCache(t), pm, nil)
+	proxy.client = origin.Client()
+	got, err := proxy.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "peer" {
+		t.Fatalf("fetch=%+v err=%v, want uncovered peer", got, err)
+	}
+	gotFalseHas, gotRealHas := atomic.LoadInt32(&falseHas), atomic.LoadInt32(&realHas)
+	gotFalseGet, gotRealGet, gotOrigin := atomic.LoadInt32(&falseGet), atomic.LoadInt32(&realGet), atomic.LoadInt32(&originCalls)
+	if gotFalseHas != 1 || gotRealHas != 1 || gotFalseGet != 0 || gotRealGet != 1 || gotOrigin != 0 {
+		t.Fatalf("false has/get=%d/%d real has/get=%d/%d origin=%d, want 1/0 1/1 0", gotFalseHas, gotFalseGet, gotRealHas, gotRealGet, gotOrigin)
+	}
+}
+
+func TestFirstUsefulConfirmationTriggersExactlyOnePeerGET(t *testing.T) {
+	key := strings.Repeat("f", 64)
+	var flightHas, flightGet, presentHas, presentGet, originCalls int32
+	var flightSeen atomic.Bool
+	flightPeer := confirmationPeer(t, key, http.StatusAccepted, http.StatusOK, []byte("in-flight"), 0, &flightHas, &flightGet, &flightSeen)
+	presentPeer := confirmationPeer(t, key, http.StatusOK, http.StatusOK, []byte("present"), 100*time.Millisecond, &presentHas, &presentGet, nil)
+	pm := peerManagerWith([]string{flightPeer, presentPeer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	installPositiveSummary(t, pm, flightPeer, key)
+	installPositiveSummary(t, pm, presentPeer, key)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+
+	proxy := NewCacheProxy(newTestCache(t), pm, nil)
+	proxy.client = origin.Client()
+	got, err := proxy.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "peer" {
+		t.Fatalf("fetch=%+v err=%v, want peer", got, err)
+	}
+	if gotFlight, gotPresent := atomic.LoadInt32(&flightGet), atomic.LoadInt32(&presentGet); gotFlight != 1 || gotPresent != 0 {
+		t.Fatalf("peer GETs in-flight/present=%d/%d, want 1/0", gotFlight, gotPresent)
+	}
+	if !flightSeen.Load() {
+		t.Fatal("GET selected by a 202 confirmation omitted flight=1")
+	}
+	if got := atomic.LoadInt32(&originCalls); got != 0 {
+		t.Fatalf("origin calls=%d, want 0", got)
+	}
+}
+
+func TestSummaryTotalConfirmationWorkIsCappedPerRequest(t *testing.T) {
+	key := strings.Repeat("e", 64)
+	var hasCalls, getCalls, originCalls int32
+	peers := make([]string, 0, 11)
+	for i := 0; i < 11; i++ {
+		peer := confirmationPeer(t, key, http.StatusNotFound, http.StatusNotFound, nil, 0, &hasCalls, &getCalls, nil)
+		peers = append(peers, peer)
+	}
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	for _, peer := range peers[:8] {
+		installPositiveSummary(t, pm, peer, key)
+	}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	proxy := NewCacheProxy(newTestCache(t), pm, nil)
+	proxy.client = origin.Client()
+	got, err := proxy.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "miss" {
+		t.Fatalf("fetch=%+v err=%v, want origin miss", got, err)
+	}
+	if got := atomic.LoadInt32(&hasCalls); got != 5 {
+		t.Fatalf("confirmation probes=%d, want request cap 5", got)
+	}
+	if gotGET, gotOrigin := atomic.LoadInt32(&getCalls), atomic.LoadInt32(&originCalls); gotGET != 0 || gotOrigin != 1 {
+		t.Fatalf("peer GETs/origin=%d/%d, want 0/1", gotGET, gotOrigin)
+	}
+}
+
+func TestBlockRequestSharesOneConfirmationBudgetAcrossAllBlocks(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 8*blockSize)
+	defer origin.Close()
+	target := origin.URL + "/bucket/large.parquet"
+	keys := make([]string, 8)
+	for i := range keys {
+		keys[i] = BlockKey(target, int64(i), blockSize)
+	}
+
+	var hasCalls, getCalls int32
+	peers := make([]string, 0, 8)
+	for range 8 {
+		peers = append(peers, confirmationPeer(t, keys[0], http.StatusNotFound, http.StatusNotFound, nil, 0, &hasCalls, &getCalls, nil))
+	}
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	for _, peer := range peers {
+		installPositiveSummaryForKeys(t, pm, peer, keys)
+	}
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewCacheProxy(store, pm, nil)
+	proxy.client = origin.Client()
+	proxy.blockSize = blockSize
+	proxy.maxSpanBlocks = 8
+
+	lookupsBefore := counterValue(t, summaryLookupTotal.WithLabelValues("positive_candidate"))
+	response := doBlockRequest(t, proxy, target, "bytes=0-8191")
+	if response.Code != http.StatusPartialContent {
+		t.Fatalf("status=%d, want 206", response.Code)
+	}
+	if got := atomic.LoadInt32(&hasCalls); got != 5 {
+		t.Fatalf("confirmation probes across eight blocks=%d, want one request budget of 5", got)
+	}
+	if got := atomic.LoadInt32(&getCalls); got != 0 {
+		t.Fatalf("peer GETs=%d, want 0 after confirmation misses", got)
+	}
+	if delta := counterValue(t, summaryLookupTotal.WithLabelValues("positive_candidate")) - lookupsBefore; delta != 1 {
+		t.Fatalf("summary lookups after shared probe budget exhaustion=%v, want 1 total", delta)
+	}
+}
+
+func TestBlockRequestStopsSummaryLookupsAfterGETBudgetExhaustion(t *testing.T) {
+	const blockSize = 1024
+	origin := originServer(t, 4*blockSize)
+	defer origin.Close()
+	target := origin.URL + "/bucket/get-budget.parquet"
+	keys := make([]string, 4)
+	for i := range keys {
+		keys[i] = BlockKey(target, int64(i), blockSize)
+	}
+
+	var hasCalls, getCalls int32
+	peer := confirmationPeer(t, keys[0], http.StatusOK, http.StatusNotFound, nil, 0, &hasCalls, &getCalls, nil)
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	installPositiveSummaryForKeys(t, pm, peer, keys)
+	store, err := NewDiskCache(t.TempDir(), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewCacheProxy(store, pm, nil)
+	proxy.client = origin.Client()
+	proxy.blockSize = blockSize
+	proxy.maxSpanBlocks = 4
+
+	lookupsBefore := counterValue(t, summaryLookupTotal.WithLabelValues("positive_candidate"))
+	response := doBlockRequest(t, proxy, target, "bytes=0-4095")
+	if response.Code != http.StatusPartialContent {
+		t.Fatalf("status=%d, want 206", response.Code)
+	}
+	if gotHas, gotGET := atomic.LoadInt32(&hasCalls), atomic.LoadInt32(&getCalls); gotHas != 2 || gotGET != 2 {
+		t.Fatalf("peer has/get calls=%d/%d, want 2/2 before GET budget exhaustion", gotHas, gotGET)
+	}
+	if delta := counterValue(t, summaryLookupTotal.WithLabelValues("positive_candidate")) - lookupsBefore; delta != 2 {
+		t.Fatalf("summary lookups after shared GET budget exhaustion=%v, want 2 total", delta)
+	}
+}
+
+func installPositiveSummary(t *testing.T, pm *PeerManager, peer, key string) {
+	installPositiveSummaryForKeys(t, pm, peer, []string{key})
+}
+
+func installPositiveSummaryForKeys(t *testing.T, pm *PeerManager, peer string, keys []string) {
+	t.Helper()
+	summary, err := newCacheSummary(peer, 1, keys, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func confirmationPeer(t *testing.T, key string, hasStatus, getStatus int, data []byte, hasDelay time.Duration, hasCalls, getCalls *int32, flightSeen *atomic.Bool) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cache/has":
+			atomic.AddInt32(hasCalls, 1)
+			if hasDelay > 0 {
+				select {
+				case <-time.After(hasDelay):
+				case <-r.Context().Done():
+					return
+				}
+			}
+			w.WriteHeader(hasStatus)
+		case "/cache/get":
+			atomic.AddInt32(getCalls, 1)
+			if flightSeen != nil && r.URL.Query().Get("flight") == "1" {
+				flightSeen.Store(true)
+			}
+			w.WriteHeader(getStatus)
+			if getStatus == http.StatusOK {
+				_, _ = w.Write(data)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return strings.TrimPrefix(server.URL, "http://")
+}
+
+func eventually(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !condition() {
+		t.Fatal("condition did not become true before timeout")
+	}
+}
+
+func summaryMemoryLimitForRemoteBytes(remoteBytes int64) int64 {
+	return summaryMemoryReserveBytes() + remoteBytes
+}

--- a/cmd/cache-proxy/summary_pull_test.go
+++ b/cmd/cache-proxy/summary_pull_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -16,23 +20,49 @@ import (
 // confirmation contract. Bloom summaries only eliminate definite negatives;
 // they never authorize a body GET without an exact /cache/has confirmation.
 
-func TestSummarySyncImmediatelyPullsNewPeerWithGET(t *testing.T) {
+func TestSummaryParserRejectsLegacyDynamicBloomLayout(t *testing.T) {
 	key := strings.Repeat("a", 64)
-	summary, err := newCacheSummary("remote", 1, []string{key}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bits, hashes := bloomParams(1)
+	payload := make([]byte, bits/8)
+	bloomHashes(key, bits, hashes, func(bit uint64) {
+		payload[bit/8] |= 1 << (bit % 8)
+	})
+	summary := summaryFromIncrementalBits(bits, hashes, payload, time.Now(), time.Minute)
 	body, err := summary.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err := parseCacheSummary(body, time.Now()); err == nil {
+		t.Fatal("accepted legacy dynamically sized Bloom layout; want fixed incremental layout only")
+	}
+}
+
+func TestBlockPresentRejectsUntrackedDiskFile(t *testing.T) {
+	store, err := NewDiskCache(t.TempDir(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := BlockKey("https://example.invalid/object", 0, 1024)
+	if err := os.WriteFile(filepath.Join(store.dir, key), []byte("stray"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewCacheProxy(store, peerManagerWith(nil), nil)
+	if proxy.blockPresent(key) {
+		t.Fatal("untracked on-disk file reported as a present block")
+	}
+}
+
+func TestSummarySyncImmediatelyPullsNewPeerWithGET(t *testing.T) {
+	key := strings.Repeat("a", 64)
+	summary := fixedCacheSummaryForKeys(t, []string{key}, time.Now(), time.Minute)
+	body := marshalCacheSummaryForTest(t, summary)
 
 	var gets, posts int32
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
 			atomic.AddInt32(&gets, 1)
-			w.Header().Set("ETag", `"generation-1"`)
+			w.Header().Set("ETag", `"snapshot-1"`)
 			_, _ = w.Write(body)
 		case http.MethodPost:
 			atomic.AddInt32(&posts, 1)
@@ -45,7 +75,7 @@ func TestSummarySyncImmediatelyPullsNewPeerWithGET(t *testing.T) {
 
 	peer := strings.TrimPrefix(remote.URL, "http://")
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +86,7 @@ func TestSummarySyncImmediatelyPullsNewPeerWithGET(t *testing.T) {
 	defer pm.StopSummarySynchronizer()
 
 	eventually(t, time.Second, func() bool {
-		return len(pm.SummaryCandidates(key, time.Now())) == 1
+		return len(summaryPositivesForTest(pm, key, time.Now())) == 1
 	})
 	if got := atomic.LoadInt32(&gets); got != 1 {
 		t.Fatalf("initial summary GETs=%d, want 1", got)
@@ -76,12 +106,12 @@ func TestPeerSummaryGETServesSnapshotAndSupportsETag(t *testing.T) {
 		t.Fatal(err)
 	}
 	pm := peerManagerWith(nil)
-	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
+	pm.ConfigureSummary(peerLookupSummary, "snapshot-server", SummaryConfig{})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	pm.StartSummarySynchronizer(ctx, store)
 	defer pm.StopSummarySynchronizer()
-	eventually(t, time.Second, func() bool { return len(pm.localSummaryCopy()) > 0 })
+	eventually(t, time.Second, func() bool { return len(localSummaryBodyForTest(pm)) > 0 })
 
 	proxy := NewCacheProxy(store, pm, nil)
 	first := httptest.NewRecorder()
@@ -122,7 +152,7 @@ func TestPeerSummaryGETSetsHandlerLocalWriteDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 	pm := peerManagerWith(nil)
-	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
+	pm.ConfigureSummary(peerLookupSummary, "snapshot-server", SummaryConfig{})
 	pm.buildLocalSummary(store)
 	proxy := NewCacheProxy(store, pm, nil)
 	w := &deadlineResponseWriter{header: make(http.Header)}
@@ -171,7 +201,7 @@ func TestSummarySelectionIsDeterministicAndFitsRemoteMemoryBudget(t *testing.T) 
 	second := NewPeerManager("test.svc", ":8081")
 	second.ConfigureSummary(peerLookupSummary, "receiver-a", SummaryConfig{MemoryLimitBytes: memoryLimit})
 	secondSelection := second.selectSummaryPeers(reversed)
-	if !stringSlicesEqual(firstSelection, secondSelection) {
+	if !slices.Equal(firstSelection, secondSelection) {
 		t.Fatalf("selection depends on DNS order: first=%v reversed=%v", firstSelection, secondSelection)
 	}
 	if used := len(firstSelection) * filterBytes; used > first.summaryRemoteMemoryBudget || used+filterBytes <= first.summaryRemoteMemoryBudget {
@@ -232,15 +262,9 @@ func TestSummarySyncPullsOnlyReceiverSelectedSubset(t *testing.T) {
 func TestConditionalSummaryPullPreservesRecordOnNotModified(t *testing.T) {
 	key := strings.Repeat("1", 64)
 	now := time.Now()
-	summary, err := newCacheSummary("remote", 1, []string{key}, now, time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := summary.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	const etag = `"remote-generation-1"`
+	summary := fixedCacheSummaryForKeys(t, []string{key}, now, time.Minute)
+	body := marshalCacheSummaryForTest(t, summary)
+	const etag = `"remote-snapshot-1"`
 	var calls int32
 	var conditional atomic.Bool
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -260,14 +284,14 @@ func TestConditionalSummaryPullPreservesRecordOnNotModified(t *testing.T) {
 
 	peer := strings.TrimPrefix(remote.URL, "http://")
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.refreshSummarySelection()
 	pm.pullSummary(context.Background(), peer)
 	pm.pullSummary(context.Background(), peer)
 	if !conditional.Load() {
 		t.Fatal("second summary pull omitted If-None-Match for the retained ETag")
 	}
-	if candidates := pm.SummaryCandidates(key, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+	if candidates := summaryPositivesForTest(pm, key, time.Now()); len(candidates) != 1 || candidates[0] != peer {
 		t.Fatalf("304 discarded the last valid summary: candidates=%v", candidates)
 	}
 }
@@ -275,28 +299,22 @@ func TestConditionalSummaryPullPreservesRecordOnNotModified(t *testing.T) {
 func TestFailedSummaryPullRetainsHintUntilTTLThenBecomesUncovered(t *testing.T) {
 	key := strings.Repeat("2", 64)
 	created := time.Now()
-	summary, err := newCacheSummary("remote", 1, []string{key}, created, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := summary.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	summary := fixedCacheSummaryForKeys(t, []string{key}, created, 5*time.Second)
+	body := marshalCacheSummaryForTest(t, summary)
 	var fail atomic.Bool
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if fail.Load() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		w.Header().Set("ETag", `"remote-generation-1"`)
+		w.Header().Set("ETag", `"remote-snapshot-1"`)
 		_, _ = w.Write(body)
 	}))
 	defer remote.Close()
 
 	peer := strings.TrimPrefix(remote.URL, "http://")
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.refreshSummarySelection()
 	pm.pullSummary(context.Background(), peer)
 	fail.Store(true)
@@ -313,23 +331,11 @@ func TestFailedSummaryPullRetainsHintUntilTTLThenBecomesUncovered(t *testing.T) 
 
 func TestExpiredSummaryETagDoesNotPreventUnconditionalRecoveryPull(t *testing.T) {
 	oldKey, newKey := strings.Repeat("5", 64), strings.Repeat("6", 64)
-	first, err := newCacheSummary("remote", 1, []string{oldKey}, time.Now(), 200*time.Millisecond)
-	if err != nil {
-		t.Fatal(err)
-	}
-	firstBody, err := first.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := newCacheSummary("remote", 2, []string{newKey}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondBody, err := second.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	const firstETag = `"remote-generation-1"`
+	first := fixedCacheSummaryForKeys(t, []string{oldKey}, time.Now(), 200*time.Millisecond)
+	firstBody := marshalCacheSummaryForTest(t, first)
+	second := fixedCacheSummaryForKeys(t, []string{newKey}, time.Now(), time.Minute)
+	secondBody := marshalCacheSummaryForTest(t, second)
+	const firstETag = `"remote-snapshot-1"`
 	var calls int32
 	var staleConditional atomic.Bool
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -341,14 +347,14 @@ func TestExpiredSummaryETagDoesNotPreventUnconditionalRecoveryPull(t *testing.T)
 		if r.Header.Get("If-None-Match") != "" {
 			staleConditional.Store(true)
 		}
-		w.Header().Set("ETag", `"remote-generation-2"`)
+		w.Header().Set("ETag", `"remote-snapshot-2"`)
 		_, _ = w.Write(secondBody)
 	}))
 	defer remote.Close()
 
 	peer := strings.TrimPrefix(remote.URL, "http://")
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.refreshSummarySelection()
 	pm.pullSummary(context.Background(), peer)
 	time.Sleep(250 * time.Millisecond)
@@ -356,7 +362,7 @@ func TestExpiredSummaryETagDoesNotPreventUnconditionalRecoveryPull(t *testing.T)
 	if staleConditional.Load() {
 		t.Fatal("pull sent If-None-Match for an expired summary")
 	}
-	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+	if candidates := summaryPositivesForTest(pm, newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
 		t.Fatalf("unconditional recovery pull did not install new summary: candidates=%v", candidates)
 	}
 }
@@ -364,46 +370,34 @@ func TestExpiredSummaryETagDoesNotPreventUnconditionalRecoveryPull(t *testing.T)
 func TestRejectedSummaryPullDoesNotReplaceLastValidHint(t *testing.T) {
 	oldKey, newKey := strings.Repeat("3", 64), strings.Repeat("4", 64)
 	now := time.Now()
-	valid, err := newCacheSummary("remote", 1, []string{oldKey}, now, time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	validBody, err := valid.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	invalid, err := newCacheSummary("remote", 2, []string{newKey}, now, time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	invalidBody, err := invalid.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	valid := fixedCacheSummaryForKeys(t, []string{oldKey}, now, time.Minute)
+	validBody := marshalCacheSummaryForTest(t, valid)
+	invalid := fixedCacheSummaryForKeys(t, []string{newKey}, now, time.Minute)
+	invalidBody := marshalCacheSummaryForTest(t, invalid)
 	invalidBody[0] ^= 0xff
 	var serveInvalid atomic.Bool
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if serveInvalid.Load() {
-			w.Header().Set("ETag", `"remote-generation-2"`)
+			w.Header().Set("ETag", `"remote-snapshot-2"`)
 			_, _ = w.Write(invalidBody)
 			return
 		}
-		w.Header().Set("ETag", `"remote-generation-1"`)
+		w.Header().Set("ETag", `"remote-snapshot-1"`)
 		_, _ = w.Write(validBody)
 	}))
 	defer remote.Close()
 
 	peer := strings.TrimPrefix(remote.URL, "http://")
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.refreshSummarySelection()
 	pm.pullSummary(context.Background(), peer)
 	serveInvalid.Store(true)
 	pm.pullSummary(context.Background(), peer)
-	if candidates := pm.SummaryCandidates(oldKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+	if candidates := summaryPositivesForTest(pm, oldKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
 		t.Fatalf("invalid refresh replaced last valid hint: candidates=%v", candidates)
 	}
-	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 0 {
+	if candidates := summaryPositivesForTest(pm, newKey, time.Now()); len(candidates) != 0 {
 		t.Fatalf("invalid refresh installed new key: candidates=%v", candidates)
 	}
 }
@@ -412,18 +406,12 @@ func TestOversizedPeerETagIsNotRetainedWithValidSummary(t *testing.T) {
 	peer := "peer-a:8081"
 	oldKey, newKey := strings.Repeat("7", 64), strings.Repeat("8", 64)
 	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.refreshSummarySelection()
 
-	first, err := newCacheSummary("remote", 1, []string{oldKey}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	firstBody, err := first.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	const ordinaryETag = `"generation-1"`
+	first := fixedCacheSummaryForKeys(t, []string{oldKey}, time.Now(), time.Minute)
+	firstBody := marshalCacheSummaryForTest(t, first)
+	const ordinaryETag = `"snapshot-1"`
 	if err := pm.receivePulledSummary(peer, firstBody, ordinaryETag, time.Now()); err != nil {
 		t.Fatal(err)
 	}
@@ -431,19 +419,13 @@ func TestOversizedPeerETagIsNotRetainedWithValidSummary(t *testing.T) {
 		t.Fatalf("ordinary ETag=%q, want %q", got, ordinaryETag)
 	}
 
-	second, err := newCacheSummary("remote", 2, []string{newKey}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondBody, err := second.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	second := fixedCacheSummaryForKeys(t, []string{newKey}, time.Now(), time.Minute)
+	secondBody := marshalCacheSummaryForTest(t, second)
 	oversizedETag := `"` + strings.Repeat("x", 1<<20) + `"`
 	if err := pm.receivePulledSummary(peer, secondBody, oversizedETag, time.Now()); err != nil {
 		t.Fatalf("valid summary was rejected solely because its optional ETag was oversized: %v", err)
 	}
-	if candidates := pm.SummaryCandidates(newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
+	if candidates := summaryPositivesForTest(pm, newKey, time.Now()); len(candidates) != 1 || candidates[0] != peer {
 		t.Fatalf("valid newer summary was not installed: candidates=%v", candidates)
 	}
 	if got := pm.summaries.etag(peer, time.Now()); got != "" {
@@ -452,13 +434,20 @@ func TestOversizedPeerETagIsNotRetainedWithValidSummary(t *testing.T) {
 }
 
 func TestSummaryClientBoundsResponseHeaders(t *testing.T) {
-	pm := NewPeerManager("test.svc", ":8081")
-	transport, ok := pm.summaryClient.Transport.(*http.Transport)
-	if !ok {
-		t.Fatalf("summary transport type=%T, want *http.Transport", pm.summaryClient.Transport)
-	}
-	if transport.MaxResponseHeaderBytes != maxSummaryResponseHeaderBytes {
-		t.Fatalf("summary response-header cap=%d, want %d", transport.MaxResponseHeaderBytes, maxSummaryResponseHeaderBytes)
+	key := strings.Repeat("9", 64)
+	body := marshalCacheSummaryForTest(t, fixedCacheSummaryForKeys(t, []string{key}, time.Now(), time.Minute))
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Oversized", strings.Repeat("x", maxSummaryResponseHeaderBytes+1))
+		_, _ = w.Write(body)
+	}))
+	defer remote.Close()
+	peer := strings.TrimPrefix(remote.URL, "http://")
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	pm.refreshSummarySelection()
+	pm.pullSummary(context.Background(), peer)
+	if positive := summaryPositivesForTest(pm, key, time.Now()); len(positive) != 0 {
+		t.Fatalf("summary behind oversized response headers was retained: %v", positive)
 	}
 }
 
@@ -470,7 +459,7 @@ func TestShortSummaryPullCyclesRotateAcrossSelectedPeers(t *testing.T) {
 	var mu sync.Mutex
 	attempted := make(map[string]int, len(peers))
 	pm := peerManagerWith(peers)
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.summaryPullCycleTimeout = 10 * time.Millisecond
 	pm.summaryClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		mu.Lock()
@@ -493,6 +482,31 @@ func TestShortSummaryPullCyclesRotateAcrossSelectedPeers(t *testing.T) {
 		if attempted[peer] == 0 {
 			t.Fatalf("later selected peer %q was starved across repeated deadline-limited cycles; attempts=%v", peer, attempted)
 		}
+	}
+}
+
+func TestMembershipPullPrioritizesNewlySelectedPeer(t *testing.T) {
+	oldPeers := []string{"peer-a:8081", "peer-b:8081", "peer-c:8081", "peer-d:8081"}
+	newPeer := "peer-e:8081"
+	pm := peerManagerWith(oldPeers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	pm.refreshSummarySelection()
+	pm.updateResolvedPeers(append(append([]string(nil), oldPeers...), newPeer), time.Now())
+
+	var mu sync.Mutex
+	var attempted []string
+	pm.summaryClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		attempted = append(attempted, req.URL.Host)
+		mu.Unlock()
+		return nil, errors.New("test pull failure")
+	})}
+	pm.pullPendingSummaryPeers(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(attempted) != 1 || attempted[0] != newPeer {
+		t.Fatalf("membership pull attempts=%v, want only newly selected peer %q", attempted, newPeer)
 	}
 }
 
@@ -546,7 +560,7 @@ func TestSummaryPullConcurrencyIsBoundedAndCancellationStopsWork(t *testing.T) {
 	}
 
 	pm := peerManagerWith(peers)
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
@@ -774,17 +788,7 @@ func installPositiveSummary(t *testing.T, pm *PeerManager, peer, key string) {
 
 func installPositiveSummaryForKeys(t *testing.T, pm *PeerManager, peer string, keys []string) {
 	t.Helper()
-	summary, err := newCacheSummary(peer, 1, keys, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := summary.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	installPulledSummaryForTest(t, pm, peer, fixedCacheSummaryForKeys(t, keys, time.Now(), time.Minute), time.Now())
 }
 
 func confirmationPeer(t *testing.T, key string, hasStatus, getStatus int, data []byte, hasDelay time.Duration, hasCalls, getCalls *int32, flightSeen *atomic.Bool) string {

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -418,7 +418,7 @@ func TestIncrementalSummaryIndexContinuesPastCapacityAndReportsFPR(t *testing.T)
 }
 
 func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.T) {
-	cache, err := NewDiskCache(t.TempDir(), 100, true)
+	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -445,7 +445,7 @@ func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.
 }
 
 func TestPublisherContinuesPastBloomTargetCapacity(t *testing.T) {
-	cache, err := NewDiskCache(t.TempDir(), 100, true)
+	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,5 +462,63 @@ func TestPublisherContinuesPastBloomTargetCapacity(t *testing.T) {
 	}
 	if got.ItemCount != summaryBloomTargetItems+1 || got.MBits != summaryBloomBits || got.Hashes != summaryBloomHashes {
 		t.Fatalf("published summary = items=%d bits=%d hashes=%d", got.ItemCount, got.MBits, got.Hashes)
+	}
+}
+
+func TestSummaryFallbackProbesAreBounded(t *testing.T) {
+	key := strings.Repeat("b", 64)
+	var hasCalls int32
+	peers := make([]string, 0, 8)
+	for range 8 {
+		peers = append(peers, newPeerServer(t, key, nil, http.StatusNotFound, &hasCalls, nil))
+	}
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "requester", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
+	if _, _, found, selected := pm.LocateKeyAmong(context.Background(), key, peers, pm.peerMaxProbes); found || selected != 5 {
+		t.Fatalf("found=%t selected=%d, want false/5", found, selected)
+	}
+	if got := atomic.LoadInt32(&hasCalls); got != 5 {
+		t.Fatalf("physical probes=%d, want 5", got)
+	}
+}
+
+func TestSummaryFallbackSkipsWhenProbeCapacityIsExhausted(t *testing.T) {
+	key := strings.Repeat("c", 64)
+	var hasCalls int32
+	peer := newPeerServer(t, key, nil, http.StatusNotFound, &hasCalls, nil)
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "requester", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 1})
+	pm.probePermits <- struct{}{}
+	defer func() { <-pm.probePermits }()
+	if _, _, found, _ := pm.LocateKeyAmong(context.Background(), key, []string{peer}, pm.peerMaxProbes); found {
+		t.Fatal("probe found a peer despite exhausted permit capacity")
+	}
+	if got := atomic.LoadInt32(&hasCalls); got != 0 {
+		t.Fatalf("physical probes=%d, want 0 when capacity is exhausted", got)
+	}
+}
+
+func TestSummaryMemoryBudgetRetainsOnlyPeersThatFit(t *testing.T) {
+	peers := []string{"peer-a:8081", "peer-b:8081"}
+	bits := make([]byte, summaryBloomBits/8)
+	reserve := int64(summaryBloomBits/8) + int64(summaryBloomBits)*2 + int64(maxSummaryBodyBytes*(maxSummaryReceives+1))
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: reserve + int64(len(bits))})
+	for i, peer := range peers {
+		s, err := newIncrementalCacheSummary(peer, uint64(i+1), 0, append([]byte(nil), bits...), time.Now(), time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := s.MarshalBinary()
+		_ = pm.ReceiveSummary(peer, body, time.Now())
+	}
+	if got := pm.summaryCount(); got != 1 {
+		t.Fatalf("retained summary count=%d, want one within the configured budget", got)
+	}
+	pm.summaries.mu.RLock()
+	used := pm.summaries.bytes
+	pm.summaries.mu.RUnlock()
+	if used > len(bits) {
+		t.Fatalf("retained bytes=%d exceed one-summary budget=%d", used, len(bits))
 	}
 }

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -186,3 +186,189 @@ func TestFetchDedupSummaryHitPreservesPeerSourceAndAvoidsProbes(t *testing.T) {
 		t.Fatalf("logical peer lookups=%v, want 1", delta)
 	}
 }
+
+func TestSummaryLookupReportsOnlyUncoveredPeersForWarmupProbes(t *testing.T) {
+	covered, uncovered := "covered:8081", "uncovered:8081"
+	pm := peerManagerWith([]string{covered, uncovered})
+	key := strings.Repeat("e", 64)
+	s, err := newCacheSummary("node-covered", 1, []string{strings.Repeat("f", 64)}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	positive, missing := pm.SummaryLookup(key, time.Now())
+	if len(positive) != 0 {
+		t.Fatalf("positive peers = %v, want none", positive)
+	}
+	if len(missing) != 1 || missing[0] != uncovered {
+		t.Fatalf("uncovered peers = %v, want %q", missing, uncovered)
+	}
+}
+
+func TestSummaryRejectsBloomParametersNotDerivedFromItemCount(t *testing.T) {
+	s, err := newCacheSummary("peer-a", 1, []string{strings.Repeat("a", 64)}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.MBits += 8
+	s.Bits = append(s.Bits, 0)
+	body, _ := s.MarshalBinary()
+	if _, err := parseCacheSummary(body, time.Now()); err == nil {
+		t.Fatal("accepted a Bloom filter larger than the declared item count requires")
+	}
+}
+
+func TestSummaryFetchDoesNotCancelHealthyBodyAfterProbeTimeout(t *testing.T) {
+	key := strings.Repeat("9", 64)
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cache/get" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte("first"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(peerHasTimeout + 100*time.Millisecond)
+		_, _ = w.Write([]byte("second"))
+	}))
+	defer peer.Close()
+	addr := strings.TrimPrefix(peer.URL, "http://")
+	pm := peerManagerWith([]string{addr})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("node-a", 1, []string{key}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	r := httptest.NewRequest(http.MethodGet, "http://origin.test/object", nil)
+	got, err := p.fetchDedup(key, r, "")
+	if err != nil || got.source != "peer" || got.size != int64(len("firstsecond")) {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+}
+
+func TestSummaryWarmupProbesOnlyPeersWithoutSummaries(t *testing.T) {
+	key, other := strings.Repeat("1", 64), strings.Repeat("2", 64)
+	var coveredHas, coveredGet, uncoveredHas, uncoveredGet, originCalls int32
+	covered := newPeerServer(t, other, []byte("other"), http.StatusOK, &coveredHas, &coveredGet)
+	uncovered := newPeerServer(t, key, []byte("peer"), http.StatusOK, &uncoveredHas, &uncoveredGet)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	pm := peerManagerWith([]string{covered, uncovered})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("covered", 1, []string{other}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	p.client = origin.Client()
+	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
+	got, err := p.fetchDedup(key, r, "")
+	if err != nil || got.source != "peer" {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+	if coveredHas != 0 || coveredGet != 0 || uncoveredHas != 1 || uncoveredGet != 1 || originCalls != 0 {
+		t.Fatalf("covered has/get=%d/%d, uncovered has/get=%d/%d, origin=%d", coveredHas, coveredGet, uncoveredHas, uncoveredGet, originCalls)
+	}
+}
+
+func TestFullyCoveredSummaryNegativeGoesDirectlyToOrigin(t *testing.T) {
+	key, other := strings.Repeat("3", 64), strings.Repeat("4", 64)
+	var hasCalls, getCalls, originCalls int32
+	peer := newPeerServer(t, other, []byte("other"), http.StatusOK, &hasCalls, &getCalls)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	pm := peerManagerWith([]string{peer})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("peer", 1, []string{other}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	p.client = origin.Client()
+	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
+	got, err := p.fetchDedup(key, r, "")
+	if err != nil || got.source != "miss" {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+	if hasCalls != 0 || getCalls != 0 || originCalls != 1 {
+		t.Fatalf("has=%d get=%d origin=%d", hasCalls, getCalls, originCalls)
+	}
+}
+
+func TestJoiningPeerIsProbedUntilItsSummaryArrives(t *testing.T) {
+	key, other := strings.Repeat("5", 64), strings.Repeat("6", 64)
+	var coveredHas, coveredGet, joiningHas, joiningGet, originCalls int32
+	covered := newPeerServer(t, other, []byte("other"), http.StatusOK, &coveredHas, &coveredGet)
+	joining := newPeerServer(t, key, []byte("joining-peer"), http.StatusOK, &joiningHas, &joiningGet)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	pm := peerManagerWith([]string{covered})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("covered", 1, []string{other}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// DNS membership changes before this proxy has received the new peer's
+	// summary. That peer is intentionally the only one left on probe fallback.
+	pm.mu.Lock()
+	pm.peers = append(pm.peers, joining)
+	pm.mu.Unlock()
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	p.client = origin.Client()
+	got, err := p.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "peer" {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+	if coveredHas != 0 || coveredGet != 0 || joiningHas != 1 || joiningGet != 1 || originCalls != 0 {
+		t.Fatalf("covered has/get=%d/%d joining has/get=%d/%d origin=%d", coveredHas, coveredGet, joiningHas, joiningGet, originCalls)
+	}
+}
+
+func TestDepartedPeerIsNeverSelectedFromAStaleSummary(t *testing.T) {
+	key := strings.Repeat("7", 64)
+	var hasCalls, getCalls, originCalls int32
+	peer := newPeerServer(t, key, []byte("peer"), http.StatusOK, &hasCalls, &getCalls)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	pm := peerManagerWith([]string{peer})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("departed", 1, []string{key}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	pm.mu.Lock()
+	pm.peers = nil
+	pm.mu.Unlock()
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	p.client = origin.Client()
+	got, err := p.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
+	if err != nil || got.source != "miss" {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+	if hasCalls != 0 || getCalls != 0 || originCalls != 1 {
+		t.Fatalf("has=%d get=%d origin=%d", hasCalls, getCalls, originCalls)
+	}
+}

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -372,3 +372,95 @@ func TestDepartedPeerIsNeverSelectedFromAStaleSummary(t *testing.T) {
 		t.Fatalf("has=%d get=%d origin=%d", hasCalls, getCalls, originCalls)
 	}
 }
+
+func TestIncrementalSummaryIndexTracksInsertionsAndEvictions(t *testing.T) {
+	index := newSummaryIndexWithParams(128, 3, 2)
+	keys := []string{strings.Repeat("8", 64), strings.Repeat("9", 64), strings.Repeat("a", 64)}
+	for _, key := range keys {
+		index.Add(key)
+	}
+	count, bits := index.Snapshot()
+	if count != len(keys) {
+		t.Fatalf("entry count = %d, want %d", count, len(keys))
+	}
+	s := summaryFromIncrementalBits("peer-a", 1, count, 128, 3, bits, time.Now(), time.Minute)
+	for _, key := range keys {
+		if !s.Contains(key) {
+			t.Fatalf("incremental filter omitted inserted key %q", key)
+		}
+	}
+	index.Remove(keys[1])
+	count, bits = index.Snapshot()
+	if count != 2 {
+		t.Fatalf("entry count after eviction = %d, want 2", count)
+	}
+	s = summaryFromIncrementalBits("peer-a", 2, count, 128, 3, bits, time.Now(), time.Minute)
+	if !s.Contains(keys[0]) || !s.Contains(keys[2]) {
+		t.Fatal("eviction cleared a bit shared by a remaining key")
+	}
+}
+
+func TestIncrementalSummaryIndexContinuesPastCapacityAndReportsFPR(t *testing.T) {
+	index := newSummaryIndexWithParams(256, 4, 2)
+	for _, key := range []string{strings.Repeat("b", 64), strings.Repeat("c", 64), strings.Repeat("d", 64)} {
+		index.Add(key)
+	}
+	count, _ := index.Snapshot()
+	if count != 3 {
+		t.Fatalf("entry count = %d, want entries beyond capacity retained", count)
+	}
+	if fpr := index.FalsePositiveRate(); fpr <= 0 {
+		t.Fatalf("FPR = %v, want positive value", fpr)
+	}
+	if !index.Saturated() {
+		t.Fatal("index should report saturation after capacity is exceeded")
+	}
+}
+
+func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.T) {
+	cache, err := NewDiskCache(t.TempDir(), 100, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.maxBytes = 8
+	first, second := strings.Repeat("e", 64), strings.Repeat("f", 64)
+	if _, err := cache.PutStream(first, strings.NewReader("12345")); err != nil {
+		t.Fatal(err)
+	}
+	items, bits, ok := cache.SummarySnapshot()
+	if !ok || items != 1 {
+		t.Fatalf("summary snapshot available=%t items=%d, want true/1", ok, items)
+	}
+	s := summaryFromIncrementalBits("peer-a", 1, items, summaryBloomBits, summaryBloomHashes, bits, time.Now(), time.Minute)
+	if !s.Contains(first) {
+		t.Fatal("published Bloom omitted committed cache entry")
+	}
+	if _, err := cache.PutStream(second, strings.NewReader("67890")); err != nil {
+		t.Fatal(err)
+	}
+	items, _, ok = cache.SummarySnapshot()
+	if !ok || items != 1 || cache.Has(first) || !cache.Has(second) {
+		t.Fatalf("post-eviction summary/cache state: available=%t items=%d first=%t second=%t", ok, items, cache.Has(first), cache.Has(second))
+	}
+}
+
+func TestPublisherContinuesPastBloomTargetCapacity(t *testing.T) {
+	cache, err := NewDiskCache(t.TempDir(), 100, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.summary.mu.Lock()
+	cache.summary.itemCount = summaryBloomTargetItems + 1
+	cache.summary.mu.Unlock()
+	pm := peerManagerWith(nil)
+	pm.ConfigureSummary(peerLookupSummary, "publisher")
+	pm.publish(context.Background(), cache)
+	body := pm.localSummaryCopy()
+	got, err := parseCacheSummary(body, time.Now())
+	if err != nil {
+		t.Fatalf("publisher skipped an over-target summary: %v", err)
+	}
+	if got.ItemCount != summaryBloomTargetItems+1 || got.MBits != summaryBloomBits || got.Hashes != summaryBloomHashes {
+		t.Fatalf("published summary = items=%d bits=%d hashes=%d", got.ItemCount, got.MBits, got.Hashes)
+	}
+}

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,6 +90,31 @@ func TestSummaryReplacementExpiryAndMembershipCleanup(t *testing.T) {
 	}
 }
 
+func TestSummaryReceiptRevalidatesSelectionAfterCommit(t *testing.T) {
+	peer := "peer-a:8081"
+	s, err := newCacheSummary("peer-a", 1, nil, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := s.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pm := NewPeerManager("test.svc", ":8081")
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	checks := 0
+	eligible := func(string) bool {
+		checks++
+		return checks == 1
+	}
+	if err := pm.receiveSummary(peer, body, "", time.Now(), eligible); err == nil {
+		t.Fatal("receipt succeeded after the sender became deselected during commit")
+	}
+	if pm.summaryCount() != 0 {
+		t.Fatal("deselected peer was reinserted after membership cleanup")
+	}
+}
+
 func TestParsePeerLookupMode(t *testing.T) {
 	for _, tt := range []struct {
 		in   string
@@ -106,7 +130,73 @@ func TestParsePeerLookupMode(t *testing.T) {
 	}
 }
 
-func TestSummaryLookupUsesAtMostTwoDirectGetsAndNoProbes(t *testing.T) {
+func TestPositiveEnvIntRejectsInvalidAndOverflowingValues(t *testing.T) {
+	t.Setenv("TEST_POSITIVE_INT", "")
+	if got, err := positiveEnvInt("TEST_POSITIVE_INT", 7); err != nil || got != 7 {
+		t.Fatalf("unset setting = %d, %v; want default 7", got, err)
+	}
+
+	for _, value := range []string{"0", "-1", "not-a-number", "999999999999999999999999999999"} {
+		t.Setenv("TEST_POSITIVE_INT", value)
+		if _, err := positiveEnvInt("TEST_POSITIVE_INT", 7); err == nil {
+			t.Fatalf("value %q unexpectedly accepted", value)
+		}
+	}
+
+	t.Setenv("TEST_POSITIVE_INT", "11")
+	if got, err := positiveEnvInt("TEST_POSITIVE_INT", 7); err != nil || got != 11 {
+		t.Fatalf("valid setting = %d, %v; want 11", got, err)
+	}
+}
+
+func TestValidateSummaryMemoryLimit(t *testing.T) {
+	minimum := summaryMemoryReserveBytes()
+	if err := validateSummaryMemoryLimit(minimum); err == nil {
+		t.Fatal("memory limit equal to the fixed reserve was accepted")
+	}
+	if err := validateSummaryMemoryLimit(minimum + int64(summaryBloomBits/8)); err != nil {
+		t.Fatalf("memory limit with room for one peer summary rejected: %v", err)
+	}
+}
+
+func TestSummaryPullCycleHasTotalDeadline(t *testing.T) {
+	release := make(chan struct{})
+	peers := make([]string, 0, 12)
+	for range 12 {
+		remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-release:
+				w.WriteHeader(http.StatusServiceUnavailable)
+			case <-r.Context().Done():
+			}
+		}))
+		t.Cleanup(remote.Close)
+		peers = append(peers, strings.TrimPrefix(remote.URL, "http://"))
+	}
+
+	pm := peerManagerWith(peers)
+	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.summaryPullCycleTimeout = 50 * time.Millisecond
+	started := time.Now()
+	pm.pullSummaries(context.Background(), peers)
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		close(release)
+		t.Fatalf("bounded pull cycle took %s", elapsed)
+	}
+	close(release)
+}
+
+func TestSummaryCycleCadenceIncludesPullWork(t *testing.T) {
+	started := time.Unix(100, 0)
+	if got := remainingSummaryCycleDelay(started, started.Add(15*time.Second), 20*time.Second); got != 5*time.Second {
+		t.Fatalf("remaining delay=%s, want 5s after 15s of a 20s cycle", got)
+	}
+	if got := remainingSummaryCycleDelay(started, started.Add(25*time.Second), 20*time.Second); got != 0 {
+		t.Fatalf("overdue cycle delay=%s, want immediate", got)
+	}
+}
+
+func TestSummaryCandidatesAreComputedLocallyWithoutPeerRPC(t *testing.T) {
 	key := strings.Repeat("c", 64)
 	var hasCalls, getCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -135,16 +225,12 @@ func TestSummaryLookupUsesAtMostTwoDirectGetsAndNoProbes(t *testing.T) {
 	if len(candidates) != 1 {
 		t.Fatalf("candidates=%v, want one", candidates)
 	}
-	_, ok := pm.FetchFromPeer(context.Background(), candidates[0], key, false, func(r io.Reader) (int64, error) { return 0, nil })
-	if ok {
-		t.Fatal("404 peer GET succeeded")
-	}
-	if hasCalls != 0 || getCalls != 1 {
-		t.Fatalf("has=%d get=%d, want 0 and 1", hasCalls, getCalls)
+	if hasCalls != 0 || getCalls != 0 {
+		t.Fatalf("has=%d get=%d, want no RPC during local Bloom lookup", hasCalls, getCalls)
 	}
 }
 
-func TestFetchDedupSummaryHitPreservesPeerSourceAndAvoidsProbes(t *testing.T) {
+func TestFetchDedupSummaryHitPreservesPeerSourceAfterConfirmation(t *testing.T) {
 	key := strings.Repeat("d", 64)
 	data := []byte("peer body")
 	var hasCalls, getCalls, originCalls int32
@@ -179,7 +265,7 @@ func TestFetchDedupSummaryHitPreservesPeerSourceAndAvoidsProbes(t *testing.T) {
 	if err != nil || got.source != "peer" || got.size != int64(len(data)) {
 		t.Fatalf("fetch=%+v err=%v", got, err)
 	}
-	if hasCalls != 0 || getCalls != 1 || originCalls != 0 {
+	if hasCalls != 1 || getCalls != 1 || originCalls != 0 {
 		t.Fatalf("has=%d get=%d origin=%d", hasCalls, getCalls, originCalls)
 	}
 	if delta := counterValue(t, peerFetchesTotal) - before; delta != 1 {
@@ -224,6 +310,10 @@ func TestSummaryRejectsBloomParametersNotDerivedFromItemCount(t *testing.T) {
 func TestSummaryFetchDoesNotCancelHealthyBodyAfterProbeTimeout(t *testing.T) {
 	key := strings.Repeat("9", 64)
 	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cache/has" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		if r.URL.Path != "/cache/get" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -433,7 +523,7 @@ func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.
 	}
 	s := summaryFromIncrementalBits("peer-a", 1, items, summaryBloomBits, summaryBloomHashes, bits, time.Now(), time.Minute)
 	if !s.Contains(first) {
-		t.Fatal("published Bloom omitted committed cache entry")
+		t.Fatal("served Bloom snapshot omitted committed cache entry")
 	}
 	if _, err := cache.PutStream(second, strings.NewReader("67890")); err != nil {
 		t.Fatal(err)
@@ -444,7 +534,7 @@ func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.
 	}
 }
 
-func TestPublisherContinuesPastBloomTargetCapacity(t *testing.T) {
+func TestSnapshotServingContinuesPastBloomTargetCapacity(t *testing.T) {
 	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
@@ -453,15 +543,15 @@ func TestPublisherContinuesPastBloomTargetCapacity(t *testing.T) {
 	cache.summary.itemCount = summaryBloomTargetItems + 1
 	cache.summary.mu.Unlock()
 	pm := peerManagerWith(nil)
-	pm.ConfigureSummary(peerLookupSummary, "publisher")
-	pm.publish(context.Background(), cache)
+	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
+	pm.buildLocalSummary(cache)
 	body := pm.localSummaryCopy()
 	got, err := parseCacheSummary(body, time.Now())
 	if err != nil {
-		t.Fatalf("publisher skipped an over-target summary: %v", err)
+		t.Fatalf("snapshot server skipped an over-target summary: %v", err)
 	}
 	if got.ItemCount != summaryBloomTargetItems+1 || got.MBits != summaryBloomBits || got.Hashes != summaryBloomHashes {
-		t.Fatalf("published summary = items=%d bits=%d hashes=%d", got.ItemCount, got.MBits, got.Hashes)
+		t.Fatalf("served summary = items=%d bits=%d hashes=%d", got.ItemCount, got.MBits, got.Hashes)
 	}
 }
 
@@ -501,7 +591,10 @@ func TestSummaryFallbackSkipsWhenProbeCapacityIsExhausted(t *testing.T) {
 func TestSummaryMemoryBudgetRetainsOnlyPeersThatFit(t *testing.T) {
 	peers := []string{"peer-a:8081", "peer-b:8081"}
 	bits := make([]byte, summaryBloomBits/8)
-	reserve := int64(summaryBloomBits/8) + int64(summaryBloomBits)*2 + int64(maxSummaryBodyBytes*(maxSummaryReceives+1))
+	rawBits := int64(summaryBloomBits / 8)
+	// During a rebuild, both the currently served and next encoded bodies are
+	// live alongside the copied raw bits.
+	reserve := rawBits + int64(summaryBloomBits)*2 + 2*int64(maxSummaryBodyBytes) + rawBits + int64(maxSummaryPulls)*(int64(maxSummaryBodyBytes)+rawBits+maxSummaryResponseHeaderBytes)
 	pm := peerManagerWith(peers)
 	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: reserve + int64(len(bits))})
 	for i, peer := range peers {

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCacheSummaryContainsSnapshotKeysButNotRawKeys(t *testing.T) {
+	keys := []string{strings.Repeat("a", 64), strings.Repeat("b", 64)}
+	s, err := newCacheSummary("peer-a", 1, keys, time.Now(), defaultSummaryTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range keys {
+		if !s.Contains(key) {
+			t.Fatalf("summary omitted source key %q", key)
+		}
+	}
+	body, err := s.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range append(keys, "https://bucket.example/object?X-Amz-Signature=secret") {
+		if bytes.Contains(body, []byte(secret)) {
+			t.Fatalf("wire summary leaked raw cache locator %q", secret)
+		}
+	}
+}
+
+func TestReceiveSummaryRejectsInvalidWithoutReplacingLastValid(t *testing.T) {
+	pm := peerManagerWith([]string{"peer-a:8081"})
+	now := time.Now()
+	valid, err := newCacheSummary("peer-a:8081", 1, []string{strings.Repeat("a", 64)}, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := valid.MarshalBinary()
+	if err := pm.ReceiveSummary("peer-a:8081", body, now); err != nil {
+		t.Fatalf("receive valid summary: %v", err)
+	}
+	bad := append([]byte(nil), body...)
+	bad[0] ^= 0xff
+	if err := pm.ReceiveSummary("peer-a:8081", bad, now); err == nil {
+		t.Fatal("malformed summary accepted")
+	}
+	if got := pm.summaryCount(); got != 1 {
+		t.Fatalf("invalid summary replaced last valid one; count=%d", got)
+	}
+}
+
+func TestSummaryReplacementExpiryAndMembershipCleanup(t *testing.T) {
+	peer := "peer-a:8081"
+	pm := peerManagerWith([]string{peer})
+	now := time.Now()
+	old, _ := newCacheSummary("node-a", 1, []string{strings.Repeat("a", 64)}, now, time.Minute)
+	oldBody, _ := old.MarshalBinary()
+	if err := pm.ReceiveSummary(peer, oldBody, now); err != nil {
+		t.Fatal(err)
+	}
+	newer, _ := newCacheSummary("node-a", 2, []string{strings.Repeat("b", 64)}, now, time.Minute)
+	newerBody, _ := newer.MarshalBinary()
+	if err := pm.ReceiveSummary(peer, newerBody, now); err != nil {
+		t.Fatal(err)
+	}
+	if got := pm.SummaryCandidates(strings.Repeat("a", 64), now); len(got) != 0 {
+		t.Fatalf("old generation remained selectable: %v", got)
+	}
+	if got := pm.SummaryCandidates(strings.Repeat("b", 64), now); len(got) != 1 {
+		t.Fatalf("new generation was not installed: %v", got)
+	}
+	pm.summaries.removeNonMembers(pm.isMember, now.Add(2*time.Minute))
+	if pm.summaryCount() != 0 {
+		t.Fatal("expired summary remained resident")
+	}
+	if err := pm.ReceiveSummary(peer, newerBody, now); err != nil {
+		t.Fatal(err)
+	}
+	pm.mu.Lock()
+	pm.peers = nil
+	pm.mu.Unlock()
+	pm.summaries.removeNonMembers(pm.isMember, now)
+	if pm.summaryCount() != 0 {
+		t.Fatal("departed peer summary remained resident")
+	}
+}
+
+func TestParsePeerLookupMode(t *testing.T) {
+	for _, tt := range []struct {
+		in   string
+		want peerLookupMode
+		ok   bool
+	}{
+		{"", peerLookupProbe, true}, {"probe", peerLookupProbe, true}, {"summary", peerLookupSummary, true}, {"typo", "", false},
+	} {
+		got, err := parsePeerLookupMode(tt.in)
+		if (err == nil) != tt.ok || got != tt.want {
+			t.Fatalf("parse %q = %q, %v", tt.in, got, err)
+		}
+	}
+}
+
+func TestSummaryLookupUsesAtMostTwoDirectGetsAndNoProbes(t *testing.T) {
+	key := strings.Repeat("c", 64)
+	var hasCalls, getCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cache/has":
+			hasCalls++
+			w.WriteHeader(http.StatusOK)
+		case "/cache/get":
+			getCalls++
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+	pm := peerManagerWith([]string{addr})
+	pm.lookupMode = peerLookupSummary
+	s, err := newCacheSummary(addr, 1, []string{key}, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	candidates := pm.SummaryCandidates(key, time.Now())
+	if len(candidates) != 1 {
+		t.Fatalf("candidates=%v, want one", candidates)
+	}
+	_, ok := pm.FetchFromPeer(context.Background(), candidates[0], key, false, func(r io.Reader) (int64, error) { return 0, nil })
+	if ok {
+		t.Fatal("404 peer GET succeeded")
+	}
+	if hasCalls != 0 || getCalls != 1 {
+		t.Fatalf("has=%d get=%d, want 0 and 1", hasCalls, getCalls)
+	}
+}
+
+func TestFetchDedupSummaryHitPreservesPeerSourceAndAvoidsProbes(t *testing.T) {
+	key := strings.Repeat("d", 64)
+	data := []byte("peer body")
+	var hasCalls, getCalls, originCalls int32
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cache/has":
+			atomic.AddInt32(&hasCalls, 1)
+		case "/cache/get":
+			atomic.AddInt32(&getCalls, 1)
+			_, _ = w.Write(data)
+		}
+	}))
+	defer peer.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&originCalls, 1)
+		_, _ = w.Write([]byte("origin"))
+	}))
+	defer origin.Close()
+	addr := strings.TrimPrefix(peer.URL, "http://")
+	pm := peerManagerWith([]string{addr})
+	pm.lookupMode = peerLookupSummary
+	s, _ := newCacheSummary("node-a", 1, []string{key}, time.Now(), time.Minute)
+	body, _ := s.MarshalBinary()
+	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	p := NewCacheProxy(newTestCache(t), pm, nil)
+	p.client = origin.Client()
+	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
+	before := counterValue(t, peerFetchesTotal)
+	got, err := p.fetchDedup(key, r, "")
+	if err != nil || got.source != "peer" || got.size != int64(len(data)) {
+		t.Fatalf("fetch=%+v err=%v", got, err)
+	}
+	if hasCalls != 0 || getCalls != 1 || originCalls != 0 {
+		t.Fatalf("has=%d get=%d origin=%d", hasCalls, getCalls, originCalls)
+	}
+	if delta := counterValue(t, peerFetchesTotal) - before; delta != 1 {
+		t.Fatalf("logical peer lookups=%v, want 1", delta)
+	}
+}

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,21 +12,68 @@ import (
 	"time"
 )
 
-func TestCacheSummaryContainsSnapshotKeysButNotRawKeys(t *testing.T) {
-	keys := []string{strings.Repeat("a", 64), strings.Repeat("b", 64)}
-	s, err := newCacheSummary("peer-a", 1, keys, time.Now(), defaultSummaryTTL)
+func fixedCacheSummaryForKeys(t testing.TB, keys []string, now time.Time, ttl time.Duration) *cacheSummary {
+	t.Helper()
+	bits := make([]byte, summaryBloomBits/8)
+	for _, key := range keys {
+		if !IsValidCacheKey(key) {
+			t.Fatalf("invalid test cache key %q", key)
+		}
+		bloomHashes(key, summaryBloomBits, summaryBloomHashes, func(bit uint64) {
+			bits[bit/8] |= 1 << (bit % 8)
+		})
+	}
+	summary, err := newIncrementalCacheSummary(bits, now, ttl)
 	if err != nil {
 		t.Fatal(err)
 	}
+	return summary
+}
+
+func marshalCacheSummaryForTest(t testing.TB, summary *cacheSummary) []byte {
+	t.Helper()
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func installPulledSummaryForTest(t testing.TB, pm *PeerManager, peer string, summary *cacheSummary, now time.Time) {
+	t.Helper()
+	pm.refreshSummarySelection()
+	if err := pm.receivePulledSummary(peer, marshalCacheSummaryForTest(t, summary), "", now); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func summaryPositivesForTest(pm *PeerManager, key string, now time.Time) []string {
+	positive, _ := pm.SummaryLookup(key, now)
+	return positive
+}
+
+func localSummaryBodyForTest(pm *PeerManager) []byte {
+	body, _ := pm.localSummarySnapshot()
+	return append([]byte(nil), body...)
+}
+
+func TestSummaryTTLCoversTwoWorstCaseSyncIntervals(t *testing.T) {
+	maxSyncInterval := defaultSummaryInterval + defaultSummaryInterval/5
+	minimumTTL := 2*maxSyncInterval + summaryPullTimeout
+	if defaultSummaryTTL < minimumTTL {
+		t.Fatalf("summary TTL %s is shorter than two worst-case sync intervals plus pull margin %s", defaultSummaryTTL, minimumTTL)
+	}
+}
+
+func TestCacheSummaryContainsSnapshotKeysButNotRawKeys(t *testing.T) {
+	keys := []string{strings.Repeat("a", 64), strings.Repeat("b", 64)}
+	s := fixedCacheSummaryForKeys(t, keys, time.Now(), defaultSummaryTTL)
 	for _, key := range keys {
 		if !s.Contains(key) {
 			t.Fatalf("summary omitted source key %q", key)
 		}
 	}
-	body, err := s.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
+	body := marshalCacheSummaryForTest(t, s)
 	for _, secret := range append(keys, "https://bucket.example/object?X-Amz-Signature=secret") {
 		if bytes.Contains(body, []byte(secret)) {
 			t.Fatalf("wire summary leaked raw cache locator %q", secret)
@@ -33,85 +81,17 @@ func TestCacheSummaryContainsSnapshotKeysButNotRawKeys(t *testing.T) {
 	}
 }
 
-func TestReceiveSummaryRejectsInvalidWithoutReplacingLastValid(t *testing.T) {
-	pm := peerManagerWith([]string{"peer-a:8081"})
-	now := time.Now()
-	valid, err := newCacheSummary("peer-a:8081", 1, []string{strings.Repeat("a", 64)}, now, time.Minute)
-	if err != nil {
+func TestCacheSummaryWireOmitsPushEraMetadata(t *testing.T) {
+	s := fixedCacheSummaryForKeys(t, nil, time.Now(), defaultSummaryTTL)
+	body := marshalCacheSummaryForTest(t, s)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
 		t.Fatal(err)
 	}
-	body, _ := valid.MarshalBinary()
-	if err := pm.ReceiveSummary("peer-a:8081", body, now); err != nil {
-		t.Fatalf("receive valid summary: %v", err)
-	}
-	bad := append([]byte(nil), body...)
-	bad[0] ^= 0xff
-	if err := pm.ReceiveSummary("peer-a:8081", bad, now); err == nil {
-		t.Fatal("malformed summary accepted")
-	}
-	if got := pm.summaryCount(); got != 1 {
-		t.Fatalf("invalid summary replaced last valid one; count=%d", got)
-	}
-}
-
-func TestSummaryReplacementExpiryAndMembershipCleanup(t *testing.T) {
-	peer := "peer-a:8081"
-	pm := peerManagerWith([]string{peer})
-	now := time.Now()
-	old, _ := newCacheSummary("node-a", 1, []string{strings.Repeat("a", 64)}, now, time.Minute)
-	oldBody, _ := old.MarshalBinary()
-	if err := pm.ReceiveSummary(peer, oldBody, now); err != nil {
-		t.Fatal(err)
-	}
-	newer, _ := newCacheSummary("node-a", 2, []string{strings.Repeat("b", 64)}, now, time.Minute)
-	newerBody, _ := newer.MarshalBinary()
-	if err := pm.ReceiveSummary(peer, newerBody, now); err != nil {
-		t.Fatal(err)
-	}
-	if got := pm.SummaryCandidates(strings.Repeat("a", 64), now); len(got) != 0 {
-		t.Fatalf("old generation remained selectable: %v", got)
-	}
-	if got := pm.SummaryCandidates(strings.Repeat("b", 64), now); len(got) != 1 {
-		t.Fatalf("new generation was not installed: %v", got)
-	}
-	pm.summaries.removeNonMembers(pm.isMember, now.Add(2*time.Minute))
-	if pm.summaryCount() != 0 {
-		t.Fatal("expired summary remained resident")
-	}
-	if err := pm.ReceiveSummary(peer, newerBody, now); err != nil {
-		t.Fatal(err)
-	}
-	pm.mu.Lock()
-	pm.peers = nil
-	pm.mu.Unlock()
-	pm.summaries.removeNonMembers(pm.isMember, now)
-	if pm.summaryCount() != 0 {
-		t.Fatal("departed peer summary remained resident")
-	}
-}
-
-func TestSummaryReceiptRevalidatesSelectionAfterCommit(t *testing.T) {
-	peer := "peer-a:8081"
-	s, err := newCacheSummary("peer-a", 1, nil, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := s.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	pm := NewPeerManager("test.svc", ":8081")
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
-	checks := 0
-	eligible := func(string) bool {
-		checks++
-		return checks == 1
-	}
-	if err := pm.receiveSummary(peer, body, "", time.Now(), eligible); err == nil {
-		t.Fatal("receipt succeeded after the sender became deselected during commit")
-	}
-	if pm.summaryCount() != 0 {
-		t.Fatal("deselected peer was reinserted after membership cleanup")
+	for _, field := range []string{"s", "g", "n"} {
+		if _, ok := fields[field]; ok {
+			t.Fatalf("pull summary retained obsolete wire field %q", field)
+		}
 	}
 }
 
@@ -175,7 +155,7 @@ func TestSummaryPullCycleHasTotalDeadline(t *testing.T) {
 	}
 
 	pm := peerManagerWith(peers)
-	pm.ConfigureSummary(peerLookupSummary, "receiver")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	pm.summaryPullCycleTimeout = 50 * time.Millisecond
 	started := time.Now()
 	pm.pullSummaries(context.Background(), peers)
@@ -193,40 +173,6 @@ func TestSummaryCycleCadenceIncludesPullWork(t *testing.T) {
 	}
 	if got := remainingSummaryCycleDelay(started, started.Add(25*time.Second), 20*time.Second); got != 0 {
 		t.Fatalf("overdue cycle delay=%s, want immediate", got)
-	}
-}
-
-func TestSummaryCandidatesAreComputedLocallyWithoutPeerRPC(t *testing.T) {
-	key := strings.Repeat("c", 64)
-	var hasCalls, getCalls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/cache/has":
-			hasCalls++
-			w.WriteHeader(http.StatusOK)
-		case "/cache/get":
-			getCalls++
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-	addr := strings.TrimPrefix(server.URL, "http://")
-	pm := peerManagerWith([]string{addr})
-	pm.lookupMode = peerLookupSummary
-	s, err := newCacheSummary(addr, 1, []string{key}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	candidates := pm.SummaryCandidates(key, time.Now())
-	if len(candidates) != 1 {
-		t.Fatalf("candidates=%v, want one", candidates)
-	}
-	if hasCalls != 0 || getCalls != 0 {
-		t.Fatalf("has=%d get=%d, want no RPC during local Bloom lookup", hasCalls, getCalls)
 	}
 }
 
@@ -251,12 +197,8 @@ func TestFetchDedupSummaryHitPreservesPeerSourceAfterConfirmation(t *testing.T) 
 	defer origin.Close()
 	addr := strings.TrimPrefix(peer.URL, "http://")
 	pm := peerManagerWith([]string{addr})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("node-a", 1, []string{key}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, addr, fixedCacheSummaryForKeys(t, []string{key}, time.Now(), time.Minute), time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	p.client = origin.Client()
 	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
@@ -276,34 +218,15 @@ func TestFetchDedupSummaryHitPreservesPeerSourceAfterConfirmation(t *testing.T) 
 func TestSummaryLookupReportsOnlyUncoveredPeersForWarmupProbes(t *testing.T) {
 	covered, uncovered := "covered:8081", "uncovered:8081"
 	pm := peerManagerWith([]string{covered, uncovered})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
 	key := strings.Repeat("e", 64)
-	s, err := newCacheSummary("node-covered", 1, []string{strings.Repeat("f", 64)}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	installPulledSummaryForTest(t, pm, covered, fixedCacheSummaryForKeys(t, []string{strings.Repeat("f", 64)}, time.Now(), time.Minute), time.Now())
 	positive, missing := pm.SummaryLookup(key, time.Now())
 	if len(positive) != 0 {
 		t.Fatalf("positive peers = %v, want none", positive)
 	}
 	if len(missing) != 1 || missing[0] != uncovered {
 		t.Fatalf("uncovered peers = %v, want %q", missing, uncovered)
-	}
-}
-
-func TestSummaryRejectsBloomParametersNotDerivedFromItemCount(t *testing.T) {
-	s, err := newCacheSummary("peer-a", 1, []string{strings.Repeat("a", 64)}, time.Now(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.MBits += 8
-	s.Bits = append(s.Bits, 0)
-	body, _ := s.MarshalBinary()
-	if _, err := parseCacheSummary(body, time.Now()); err == nil {
-		t.Fatal("accepted a Bloom filter larger than the declared item count requires")
 	}
 }
 
@@ -328,12 +251,8 @@ func TestSummaryFetchDoesNotCancelHealthyBodyAfterProbeTimeout(t *testing.T) {
 	defer peer.Close()
 	addr := strings.TrimPrefix(peer.URL, "http://")
 	pm := peerManagerWith([]string{addr})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("node-a", 1, []string{key}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(addr, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, addr, fixedCacheSummaryForKeys(t, []string{key}, time.Now(), time.Minute), time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	r := httptest.NewRequest(http.MethodGet, "http://origin.test/object", nil)
 	got, err := p.fetchDedup(key, r, "")
@@ -353,12 +272,8 @@ func TestSummaryWarmupProbesOnlyPeersWithoutSummaries(t *testing.T) {
 	}))
 	defer origin.Close()
 	pm := peerManagerWith([]string{covered, uncovered})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("covered", 1, []string{other}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, covered, fixedCacheSummaryForKeys(t, []string{other}, time.Now(), time.Minute), time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	p.client = origin.Client()
 	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
@@ -381,12 +296,8 @@ func TestFullyCoveredSummaryNegativeGoesDirectlyToOrigin(t *testing.T) {
 	}))
 	defer origin.Close()
 	pm := peerManagerWith([]string{peer})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("peer", 1, []string{other}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, peer, fixedCacheSummaryForKeys(t, []string{other}, time.Now(), time.Minute), time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	p.client = origin.Client()
 	r := httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil)
@@ -410,18 +321,12 @@ func TestJoiningPeerIsProbedUntilItsSummaryArrives(t *testing.T) {
 	}))
 	defer origin.Close()
 	pm := peerManagerWith([]string{covered})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("covered", 1, []string{other}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(covered, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, covered, fixedCacheSummaryForKeys(t, []string{other}, time.Now(), time.Minute), time.Now())
 
 	// DNS membership changes before this proxy has received the new peer's
 	// summary. That peer is intentionally the only one left on probe fallback.
-	pm.mu.Lock()
-	pm.peers = append(pm.peers, joining)
-	pm.mu.Unlock()
+	pm.updateResolvedPeers([]string{covered, joining}, time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	p.client = origin.Client()
 	got, err := p.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
@@ -443,15 +348,9 @@ func TestDepartedPeerIsNeverSelectedFromAStaleSummary(t *testing.T) {
 	}))
 	defer origin.Close()
 	pm := peerManagerWith([]string{peer})
-	pm.lookupMode = peerLookupSummary
-	s, _ := newCacheSummary("departed", 1, []string{key}, time.Now(), time.Minute)
-	body, _ := s.MarshalBinary()
-	if err := pm.ReceiveSummary(peer, body, time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	pm.mu.Lock()
-	pm.peers = nil
-	pm.mu.Unlock()
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	installPulledSummaryForTest(t, pm, peer, fixedCacheSummaryForKeys(t, []string{key}, time.Now(), time.Minute), time.Now())
+	pm.updateResolvedPeers(nil, time.Now())
 	p := NewCacheProxy(newTestCache(t), pm, nil)
 	p.client = origin.Client()
 	got, err := p.fetchDedup(key, httptest.NewRequest(http.MethodGet, origin.URL+"/object", nil), "")
@@ -473,7 +372,7 @@ func TestIncrementalSummaryIndexTracksInsertionsAndEvictions(t *testing.T) {
 	if count != len(keys) {
 		t.Fatalf("entry count = %d, want %d", count, len(keys))
 	}
-	s := summaryFromIncrementalBits("peer-a", 1, count, 128, 3, bits, time.Now(), time.Minute)
+	s := summaryFromIncrementalBits(128, 3, bits, time.Now(), time.Minute)
 	for _, key := range keys {
 		if !s.Contains(key) {
 			t.Fatalf("incremental filter omitted inserted key %q", key)
@@ -484,7 +383,7 @@ func TestIncrementalSummaryIndexTracksInsertionsAndEvictions(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("entry count after eviction = %d, want 2", count)
 	}
-	s = summaryFromIncrementalBits("peer-a", 2, count, 128, 3, bits, time.Now(), time.Minute)
+	s = summaryFromIncrementalBits(128, 3, bits, time.Now(), time.Minute)
 	if !s.Contains(keys[0]) || !s.Contains(keys[2]) {
 		t.Fatal("eviction cleared a bit shared by a remaining key")
 	}
@@ -499,15 +398,15 @@ func TestIncrementalSummaryIndexContinuesPastCapacityAndReportsFPR(t *testing.T)
 	if count != 3 {
 		t.Fatalf("entry count = %d, want entries beyond capacity retained", count)
 	}
-	if fpr := index.FalsePositiveRate(); fpr <= 0 {
+	if fpr := bloomFalsePositiveRate(count, index.bitCount, index.hashes); fpr <= 0 {
 		t.Fatalf("FPR = %v, want positive value", fpr)
 	}
-	if !index.Saturated() {
+	if count <= index.targetItems {
 		t.Fatal("index should report saturation after capacity is exceeded")
 	}
 }
 
-func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.T) {
+func TestDiskCacheIncrementallyUpdatesSummaryBloomOnPutAndEviction(t *testing.T) {
 	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
 		t.Fatal(err)
@@ -521,7 +420,7 @@ func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.
 	if !ok || items != 1 {
 		t.Fatalf("summary snapshot available=%t items=%d, want true/1", ok, items)
 	}
-	s := summaryFromIncrementalBits("peer-a", 1, items, summaryBloomBits, summaryBloomHashes, bits, time.Now(), time.Minute)
+	s := summaryFromIncrementalBits(summaryBloomBits, summaryBloomHashes, bits, time.Now(), time.Minute)
 	if !s.Contains(first) {
 		t.Fatal("served Bloom snapshot omitted committed cache entry")
 	}
@@ -534,84 +433,49 @@ func TestDiskCacheIncrementallyUpdatesPublishedBloomOnPutAndEviction(t *testing.
 	}
 }
 
-func TestSnapshotServingContinuesPastBloomTargetCapacity(t *testing.T) {
-	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+func TestSummaryMemoryMetricsIncludeLocalTransientAndRemoteState(t *testing.T) {
+	peer := "peer-a:8081"
+	bits := make([]byte, summaryBloomBits/8)
+	limit := summaryMemoryReserveBytes() + int64(len(bits))
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: limit})
+	pm.refreshSummarySelection()
+
+	if got := int64(gaugeValue(t, summaryMemoryLimitBytes)); got != limit {
+		t.Fatalf("summary memory limit metric=%d, want %d", got, limit)
+	}
+	if got := int64(gaugeValue(t, summaryResidentBytes)); got != summaryMemoryReserveBytes() {
+		t.Fatalf("summary resident bytes before remote receipt=%d, want fixed/transient reserve %d", got, summaryMemoryReserveBytes())
+	}
+
+	s, err := newIncrementalCacheSummary(bits, time.Now(), time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cache.summary.mu.Lock()
-	cache.summary.itemCount = summaryBloomTargetItems + 1
-	cache.summary.mu.Unlock()
-	pm := peerManagerWith(nil)
-	pm.ConfigureSummary(peerLookupSummary, "snapshot-server")
-	pm.buildLocalSummary(cache)
-	body := pm.localSummaryCopy()
-	got, err := parseCacheSummary(body, time.Now())
-	if err != nil {
-		t.Fatalf("snapshot server skipped an over-target summary: %v", err)
+	if err := pm.receivePulledSummary(peer, marshalCacheSummaryForTest(t, s), "", time.Now()); err != nil {
+		t.Fatal(err)
 	}
-	if got.ItemCount != summaryBloomTargetItems+1 || got.MBits != summaryBloomBits || got.Hashes != summaryBloomHashes {
-		t.Fatalf("served summary = items=%d bits=%d hashes=%d", got.ItemCount, got.MBits, got.Hashes)
+	wantResident := summaryMemoryReserveBytes() + int64(len(bits))
+	if got := int64(gaugeValue(t, summaryResidentBytes)); got != wantResident {
+		t.Fatalf("summary resident bytes after remote receipt=%d, want %d", got, wantResident)
 	}
 }
 
-func TestSummaryFallbackProbesAreBounded(t *testing.T) {
-	key := strings.Repeat("b", 64)
-	var hasCalls int32
-	peers := make([]string, 0, 8)
-	for range 8 {
-		peers = append(peers, newPeerServer(t, key, nil, http.StatusNotFound, &hasCalls, nil))
+func TestSummaryMemoryMetricsAreZeroOutsideSummaryMode(t *testing.T) {
+	pm := NewPeerManager("test.svc", ":8081")
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	if got := int64(gaugeValue(t, summaryMemoryLimitBytes)); got != defaultSummaryMemoryLimitBytes {
+		t.Fatalf("default summary memory limit metric=%d, want %d", got, defaultSummaryMemoryLimitBytes)
 	}
-	pm := peerManagerWith(peers)
-	pm.ConfigureSummary(peerLookupSummary, "requester", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 5})
-	if _, _, found, selected := pm.LocateKeyAmong(context.Background(), key, peers, pm.peerMaxProbes); found || selected != 5 {
-		t.Fatalf("found=%t selected=%d, want false/5", found, selected)
+	if got := int64(gaugeValue(t, summaryResidentBytes)); got != summaryMemoryReserveBytes() {
+		t.Fatalf("default summary resident metric=%d, want reserve %d", got, summaryMemoryReserveBytes())
 	}
-	if got := atomic.LoadInt32(&hasCalls); got != 5 {
-		t.Fatalf("physical probes=%d, want 5", got)
-	}
-}
 
-func TestSummaryFallbackSkipsWhenProbeCapacityIsExhausted(t *testing.T) {
-	key := strings.Repeat("c", 64)
-	var hasCalls int32
-	peer := newPeerServer(t, key, nil, http.StatusNotFound, &hasCalls, nil)
-	pm := peerManagerWith([]string{peer})
-	pm.ConfigureSummary(peerLookupSummary, "requester", SummaryConfig{PeerMaxProbes: 5, MaxPeerProbesInFlight: 1})
-	pm.probePermits <- struct{}{}
-	defer func() { <-pm.probePermits }()
-	if _, _, found, _ := pm.LocateKeyAmong(context.Background(), key, []string{peer}, pm.peerMaxProbes); found {
-		t.Fatal("probe found a peer despite exhausted permit capacity")
+	pm.ConfigureSummary(peerLookupProbe, "receiver", SummaryConfig{})
+	if got := gaugeValue(t, summaryMemoryLimitBytes); got != 0 {
+		t.Fatalf("probe-mode summary memory limit metric=%v, want 0", got)
 	}
-	if got := atomic.LoadInt32(&hasCalls); got != 0 {
-		t.Fatalf("physical probes=%d, want 0 when capacity is exhausted", got)
-	}
-}
-
-func TestSummaryMemoryBudgetRetainsOnlyPeersThatFit(t *testing.T) {
-	peers := []string{"peer-a:8081", "peer-b:8081"}
-	bits := make([]byte, summaryBloomBits/8)
-	rawBits := int64(summaryBloomBits / 8)
-	// During a rebuild, both the currently served and next encoded bodies are
-	// live alongside the copied raw bits.
-	reserve := rawBits + int64(summaryBloomBits)*2 + 2*int64(maxSummaryBodyBytes) + rawBits + int64(maxSummaryPulls)*(int64(maxSummaryBodyBytes)+rawBits+maxSummaryResponseHeaderBytes)
-	pm := peerManagerWith(peers)
-	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: reserve + int64(len(bits))})
-	for i, peer := range peers {
-		s, err := newIncrementalCacheSummary(peer, uint64(i+1), 0, append([]byte(nil), bits...), time.Now(), time.Minute)
-		if err != nil {
-			t.Fatal(err)
-		}
-		body, _ := s.MarshalBinary()
-		_ = pm.ReceiveSummary(peer, body, time.Now())
-	}
-	if got := pm.summaryCount(); got != 1 {
-		t.Fatalf("retained summary count=%d, want one within the configured budget", got)
-	}
-	pm.summaries.mu.RLock()
-	used := pm.summaries.bytes
-	pm.summaries.mu.RUnlock()
-	if used > len(bits) {
-		t.Fatalf("retained bytes=%d exceed one-summary budget=%d", used, len(bits))
+	if got := gaugeValue(t, summaryResidentBytes); got != 0 {
+		t.Fatalf("probe-mode summary resident metric=%v, want 0", got)
 	}
 }

--- a/docs/design/cache-proxy-pulled-summary-lookup.md
+++ b/docs/design/cache-proxy-pulled-summary-lookup.md
@@ -1,0 +1,298 @@
+# Cache-proxy pulled-summary peer lookup
+
+## Status and scope
+
+This design replaces request-time fleet-wide cache discovery with
+receiver-driven Bloom-summary synchronization and bounded exact confirmation.
+It applies only when `CACHE_PEER_LOOKUP_MODE=summary`. The default remains
+`probe`, which preserves the existing fleet-wide `/cache/has` behavior.
+
+The design does not introduce worker affinity, organization-aware placement,
+a central key directory, proactive cache-body replication, or ownership of
+origin fills. Summaries contain only opaque cache-locator membership hints.
+
+## Goals
+
+- Bound request-time peer RPCs independently of fleet size.
+- Bound each pod's Bloom state and synchronization work.
+- Use Bloom filters only for definite-negative elimination; verify every
+  candidate through the peer's exact cache index before fetching its body.
+- Make missing, stale, malformed, or incompatible summaries reduce locality
+  without failing a client request.
+- Preserve the current local cache, peer-transfer, and origin byte semantics.
+
+## Configuration and bounds
+
+| Setting | Default | Bound |
+| --- | --- | --- |
+| `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` or `summary`; unknown values fail startup. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Convergent local cache-index target. |
+| `CACHE_MAX_PERCENT` | `80` | Convergent cache-disk target. |
+| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Local counting Bloom, snapshot and pull reserve, and retained remote Bloom bits. |
+| `CACHE_PEER_MAX_PROBES` | `5` | Maximum summary-mode `/cache/has` confirmations per client request, shared across block misses. |
+| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Pod-wide, non-blocking confirmation semaphore. |
+
+The entry and disk ceilings are soft, convergent targets. Concurrent fills
+make admission decisions from the state visible before their commits, so the
+cache can briefly exceed either target. Entry overshoot is bounded by the
+number of concurrently committing distinct entries; byte overshoot is bounded
+by the aggregate size of concurrent commits. Later insertions evict LRU entries
+back toward both targets. This avoids serializing body and filesystem I/O on a
+global commit lock.
+
+The process-level backstop remains the pod memory limit and Go memory policy.
+The settings above bound the largest cache-proxy-owned contributors, but do not
+replace a container memory limit or account exactly for Go, HTTP, tracing, and
+kernel memory.
+
+## Local counting Bloom filter
+
+Each cache proxy owns one fixed-layout counting Bloom filter. Cache commits add
+the opaque SHA-256 cache locator and evictions remove it. Sixteen-bit counters
+allow incremental deletion. A counter that reaches `uint16` saturation becomes
+sticky: this may add false positives but cannot create a false negative for a
+key represented by that filter.
+
+The filter is designed for 1,000,000 entries at a 1% per-peer false-positive
+rate:
+
+- 9,585,064 published bits, approximately 1.14 MiB;
+- approximately 18.3 MiB of local 16-bit counters;
+- hash count derived from the target item count and false-positive rate.
+
+`CACHE_MAX_ENTRIES=1000000` keeps the default cache at this design point. If an
+operator raises the entry target, additions continue rather than disabling
+summaries; the predicted false-positive rate rises smoothly and is exported as
+a metric. The filter is a hint and never authorizes a body transfer.
+
+About every 20 seconds, with per-process jitter, the proxy copies the current
+bitset into an immutable, versioned wire snapshot. It does not rescan or rehash
+the cache index. Each snapshot has a 45-second advertised TTL and a strict
+2 MiB encoded-body limit. It contains only:
+
+- summary and cache-layout versions;
+- stable proxy identity and generation;
+- creation and expiration timestamps;
+- item count, Bloom parameters, and Bloom bits.
+
+Raw URLs, signed query strings, ranges, object paths, organization identifiers,
+and cache locators are never serialized or logged.
+
+The no-false-negative statement applies to entries present in the exact local
+snapshot. An entry committed after that snapshot is absent until a newer
+snapshot is pulled. An entry evicted after the snapshot can remain positive
+until refresh; exact confirmation prevents that stale positive from causing a
+body read.
+
+## Receiver-driven synchronization
+
+Each pod discovers peer addresses from the headless Service every 10 seconds.
+It ranks the current membership deterministically using its stable receiver
+identity and peer address. Before any summary RPC, it selects only as many
+peers as fit the remote-summary portion of
+`CACHE_SUMMARY_MEMORY_LIMIT_BYTES`. Different receivers can select different
+subsets, distributing degraded coverage when a fleet is larger than the
+memory budget.
+
+The selected peers are pulled through `GET /cache/summary`:
+
+- the endpoint serves the current immutable snapshot;
+- `ETag` and `If-None-Match` avoid transferring an unchanged generation;
+- retained ETags are syntax-checked and capped at 128 bytes;
+- pull response headers are capped at 16 KiB;
+- the summary response has a two-second handler-local write deadline;
+- four workers bound pull concurrency;
+- a pull has a two-second whole-response timeout, a 200 ms connect deadline,
+  and a 500 ms response-header deadline;
+- a whole pull cycle is capped at 15 seconds and rotates its starting peer by
+  the work submitted, so slow early peers cannot starve the same suffix;
+- declared and actual bodies above 2 MiB are rejected;
+- cancellation closes requests, bodies, workers, timers, and the coordinator;
+- there is no retry queue.
+
+The receiver validates the version, cache layout, declared Bloom parameters,
+timestamps, body size, and current selection before atomically replacing the
+last record for that peer. A failed or invalid pull leaves the previous valid
+record in place until its advertised expiration. `304 Not Modified` retains
+the record but does not extend it beyond that expiration. The next periodic or
+membership-triggered cycle is the retry.
+
+### Membership transitions
+
+On startup, a pod builds its local snapshot immediately. The initial DNS
+membership selection triggers an immediate pull, so it does not wait for the
+periodic timer. Until a selected peer's first valid response arrives, that peer
+is uncovered and eligible for bounded exact confirmation.
+
+When a peer appears, each receiver recomputes its deterministic subset:
+
+- if selected, the new peer is pulled immediately;
+- if not selected because of the memory ceiling, it remains uncovered;
+- if it displaces another selected peer, the displaced record is removed before
+  further lookup and the new selected peer begins uncovered.
+
+When a peer disappears, the next successful DNS refresh removes it from both
+the selected set and resident summary store. It is not probed after removal.
+During the discovery delay, connection failure is treated as an ordinary peer
+miss and the request falls back safely.
+
+## Request path
+
+Summary mode performs the following steps for a local cache miss:
+
+1. Test every current, compatible, non-expired retained summary locally.
+2. Eliminate covered peers whose Bloom filter is negative.
+3. Treat positive and uncovered peers as candidates, not holders.
+4. Deterministically choose at most `CACHE_PEER_MAX_PROBES` candidates. With a
+   budget of at least two and both classes present, reserve at least one slot
+   for an uncovered peer so false positives cannot entirely suppress
+   convergence. A one-slot override ranks both classes together.
+5. Issue parallel `/cache/has` confirmations under the pod-wide semaphore.
+6. Use the first useful `200` stored or `202` in-flight response and cancel
+   losing confirmations.
+7. Issue `/cache/get` only to the one confirmed holder for that cache-key
+   lookup. A failed transfer falls back to origin.
+8. If no confirmation succeeds, fetch from origin.
+
+The semaphore is deliberately non-blocking. If all
+`CACHE_MAX_PEER_PROBES_IN_FLIGHT` permits are occupied, excess confirmations
+are skipped instead of queued, and those requests use origin. This bounds
+goroutines, sockets, and aggregate peer work during a miss storm.
+
+Block-aligned requests can contain several distinct cache keys. They share one
+`CACHE_PEER_MAX_PROBES` budget across their missing blocks, so the request does
+not multiply confirmation work by its block count. Each successful block
+confirmation can lead to one peer body transfer, capped at two peer block GETs
+for the entire client request.
+
+### Bloom false positives and fleet size
+
+For `N` covered peers with independent per-peer false-positive probability
+`p`, a true fleet miss produces approximately `Binomial(N, p)` confirmation
+requests before applying the cap. At the 1% design point, the average is 0.1,
+0.3, and 1.0 confirmations for 10, 30, and 100 covered peers respectively.
+At 100 peers, the 99th percentile is approximately four. The cap of five is a
+circuit breaker for correlated filters, saturation, malformed all-positive
+state that passes validation, and fleets larger than the design range.
+
+False-positive independence is not guaranteed: caches can overlap and use the
+same hash layout. Operators must therefore rely on the hard confirmation cap,
+not the average-case calculation, for capacity planning.
+
+### Known cold-key limitation
+
+If all discovered peers are covered and every summary is negative, the request
+goes directly to origin without a peer RPC. Periodic summaries do not contain
+newly started in-flight fills, so simultaneous first access to a cold key can
+issue duplicate origin fetches on several pods. Similarly, a peer entry added
+after its last snapshot can be missed until the next pull.
+
+Preserving complete fleet-wide in-flight dedup would require negative-peer
+sampling, fill ownership, or a separate in-flight protocol. Those mechanisms
+either restore request-time work or expand this design's scope, so they are not
+included here.
+
+## Memory model
+
+The default 512 MiB summary budget is divided conservatively:
+
+- local published bitset and 16-bit counters: approximately 19.4 MiB;
+- current and next immutable encoded snapshots plus a temporary raw snapshot;
+- four simultaneous pulls, each reserving a 2 MiB encoded body plus decoded
+  bits;
+- retained remote raw bitsets with the remaining approximately 474.8 MiB.
+
+One remote fixed-layout bitset is approximately 1.14 MiB, so the default fits
+up to 415 remote summaries after reserves. Representative steady-state
+Bloom-state estimates are:
+
+| Fleet nodes | Remote summaries per pod | Approximate Bloom state per pod |
+| ---: | ---: | ---: |
+| 10 | 9 | 47.5 MiB |
+| 30 | 29 | 70.3 MiB |
+| 100 | 99 | 150.3 MiB |
+| At default ceiling | 415 | Up to 512 MiB |
+
+These numbers deliberately exclude the exact local cache index. Its key-count
+growth is independently bounded toward `CACHE_MAX_ENTRIES`; the disk target
+also bounds the number of fixed-size blocks that can be retained. Actual RSS
+includes map/list entries, strings, goroutine stacks, HTTP buffers, tracing,
+and allocator overhead.
+
+## Failure behavior
+
+| Failure | Result |
+| --- | --- |
+| Summary endpoint absent during rolling deployment | Peer remains uncovered; bounded confirmation or origin is used. |
+| Pull timeout or transport failure | Last valid unexpired record remains; normal cadence retries. |
+| Oversized, malformed, expired, or incompatible body | Body is rejected without replacing the last valid record. |
+| Record expires | Peer becomes uncovered until a valid pull succeeds. |
+| Summary memory ceiling reached | Receiver tracks only its deterministic subset; other peers remain uncovered and request work stays capped. |
+| Bloom false positive or stale eviction | Exact `/cache/has` returns a miss; no body GET is attempted. |
+| Global confirmation semaphore full | Confirmation is skipped without queuing; request falls back to origin. |
+| Peer disappears between discovery and lookup | Confirmation or GET fails and the request falls back to origin. |
+| Synchronizer shuts down | Context cancellation stops timers, pulls, workers, and response-body reads. |
+
+No client request fails solely because summary synchronization or a peer is
+unavailable. Origin remains the correctness fallback.
+
+## Metrics and rollout
+
+Summary and peer metrics have no peer, node, organization, URL, locator, or
+worker identity labels. The primary rollout signals are:
+
+- `cache_proxy_peer_probes_total / cache_proxy_peer_fetches_total`: physical
+  confirmation amplification; it should remain below the configured cap and
+  near the fleet-aware false-positive expectation when coverage is complete;
+- `cache_proxy_peer_direct_gets_total`: confirmed peer body transfers;
+- peer and origin bytes and latency: useful locality versus fallback cost;
+- `cache_proxy_summary_pulls_total` and
+  `cache_proxy_summary_serves_total`: synchronization health;
+- resident summary count/bytes and summary age: coverage and memory;
+- predicted Bloom false-positive rate, saturation, and bit occupancy.
+
+Rollout procedure:
+
+1. Deploy an image containing the GET summary endpoint to every cache-proxy
+   pod while leaving `CACHE_PEER_LOOKUP_MODE=probe`.
+2. Enable `summary` mode in non-production first.
+3. Confirm summaries converge after startup and membership changes, pull work
+   remains bounded, and request-time probes never exceed the configured cap.
+4. Compare peer usefulness, origin bytes, and origin latency with probe mode.
+5. Confirm resident Bloom bytes remain under the configured budget and process
+   RSS remains below the pod memory limit with sufficient headroom.
+6. Roll out gradually to production.
+
+Mixed summary implementations fail safely: a pull sent to a POST-only endpoint
+or a push sent to a GET-only endpoint is rejected, leaving that peer uncovered.
+
+Rollback by restoring `CACHE_PEER_LOOKUP_MODE=probe`. Cache keys and on-disk
+layout are unchanged, so do not delete cache contents.
+
+## Operator runbook
+
+If origin traffic or latency regresses:
+
+1. Check summary pull outcomes, resident count, summary age, and uncovered-peer
+   behavior.
+2. Check Bloom FPR, saturation, and cache entry count. Lower
+   `CACHE_MAX_ENTRIES` if filters are materially beyond their design point.
+3. Check skipped probes. If the pod has memory and socket headroom, adjust
+   `CACHE_MAX_PEER_PROBES_IN_FLIGHT`; otherwise retain the non-blocking fallback.
+4. Restore `CACHE_PEER_LOOKUP_MODE=probe` if locality is unacceptable while
+   investigating.
+
+If process memory approaches the pod limit:
+
+1. Reduce `CACHE_SUMMARY_MEMORY_LIMIT_BYTES`; fewer peer summaries will be
+   selected automatically and request-time work remains capped.
+2. Reduce `CACHE_MAX_ENTRIES` to lower exact-index memory and return the Bloom
+   filter toward its target FPR.
+3. Reduce `CACHE_MAX_PEER_PROBES_IN_FLIGHT` if concurrent HTTP work contributes
+   to the peak.
+4. Verify the pod memory limit and Go memory policy leave headroom for native,
+   kernel, and request buffers.
+
+Changing summary memory does not require cache deletion. A restart recomputes
+the deterministic selected subset and rebuilds the local counting filter from
+the bounded on-disk cache index.

--- a/docs/design/cache-proxy-pulled-summary-lookup.md
+++ b/docs/design/cache-proxy-pulled-summary-lookup.md
@@ -26,19 +26,20 @@ origin fills. Summaries contain only opaque cache-locator membership hints.
 | Setting | Default | Bound |
 | --- | --- | --- |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` or `summary`; unknown values fail startup. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Convergent local cache-index target. |
-| `CACHE_MAX_PERCENT` | `80` | Convergent cache-disk target. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Strict maximum tracked entries after each final commit. |
+| `CACHE_MAX_PERCENT` | `80` | Target for tracked cache bytes; one entry larger than the target is retained. |
 | `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Local counting Bloom, snapshot and pull reserve, and retained remote Bloom bits. |
 | `CACHE_PEER_MAX_PROBES` | `5` | Maximum summary-mode `/cache/has` confirmations per client request, shared across block misses. |
-| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Pod-wide, non-blocking confirmation semaphore. |
+| `CACHE_MAX_PEER_PROBES_IN_FLIGHT` | `64` | Pod-wide, non-blocking cap on active confirmation HTTP requests and sockets. |
 
-The entry and disk ceilings are soft, convergent targets. Concurrent fills
-make admission decisions from the state visible before their commits, so the
-cache can briefly exceed either target. Entry overshoot is bounded by the
-number of concurrently committing distinct entries; byte overshoot is bounded
-by the aggregate size of concurrent commits. Later insertions evict LRU entries
-back toward both targets. This avoids serializing body and filesystem I/O on a
-global commit lock.
+Body copies remain concurrent: each fill streams into a temporary file without
+holding the cache-index lock. The short final commit is serialized across the
+rename, LRU eviction, exact-index and byte accounting, and counting-Bloom
+update. A completed commit therefore cannot exceed `CACHE_MAX_ENTRIES`.
+Tracked bytes are evicted to the current disk target before the commit returns,
+except that a single entry larger than the target is retained rather than
+silently discarded. Concurrent temporary files consume real disk but are not
+yet tracked cache entries.
 
 The process-level backstop remains the pod memory limit and Go memory policy.
 The settings above bound the largest cache-proxy-owned contributors, but do not
@@ -56,7 +57,7 @@ key represented by that filter.
 The filter is designed for 1,000,000 entries at a 1% per-peer false-positive
 rate:
 
-- 9,585,064 published bits, approximately 1.14 MiB;
+- 9,585,064 snapshot bits, approximately 1.14 MiB;
 - approximately 18.3 MiB of local 16-bit counters;
 - hash count derived from the target item count and false-positive rate.
 
@@ -67,13 +68,12 @@ a metric. The filter is a hint and never authorizes a body transfer.
 
 About every 20 seconds, with per-process jitter, the proxy copies the current
 bitset into an immutable, versioned wire snapshot. It does not rescan or rehash
-the cache index. Each snapshot has a 45-second advertised TTL and a strict
+the cache index. Each snapshot has a 60-second advertised TTL and a strict
 2 MiB encoded-body limit. It contains only:
 
 - summary and cache-layout versions;
-- stable proxy identity and generation;
 - creation and expiration timestamps;
-- item count, Bloom parameters, and Bloom bits.
+- fixed Bloom parameters and Bloom bits.
 
 Raw URLs, signed query strings, ranges, object paths, organization identifiers,
 and cache locators are never serialized or logged.
@@ -97,7 +97,7 @@ memory budget.
 The selected peers are pulled through `GET /cache/summary`:
 
 - the endpoint serves the current immutable snapshot;
-- `ETag` and `If-None-Match` avoid transferring an unchanged generation;
+- `ETag` and `If-None-Match` support conditional pulls between rebuilds;
 - retained ETags are syntax-checked and capped at 128 bytes;
 - pull response headers are capped at 16 KiB;
 - the summary response has a two-second handler-local write deadline;
@@ -107,15 +107,16 @@ The selected peers are pulled through `GET /cache/summary`:
 - a whole pull cycle is capped at 15 seconds and rotates its starting peer by
   the work submitted, so slow early peers cannot starve the same suffix;
 - declared and actual bodies above 2 MiB are rejected;
-- cancellation closes requests, bodies, workers, timers, and the coordinator;
-- there is no retry queue.
+- cancellation closes requests, bodies, workers, timers, and the coordinator.
 
 The receiver validates the version, cache layout, declared Bloom parameters,
 timestamps, body size, and current selection before atomically replacing the
 last record for that peer. A failed or invalid pull leaves the previous valid
 record in place until its advertised expiration. `304 Not Modified` retains
-the record but does not extend it beyond that expiration. The next periodic or
-membership-triggered cycle is the retry.
+the record but does not extend it beyond that expiration. Failures do not create
+an independent retry queue; the next periodic or membership-triggered cycle is
+the retry. Newly selected peers that have not yet started their priority pull
+remain in the bounded pending-membership set.
 
 ### Membership transitions
 
@@ -157,7 +158,10 @@ Summary mode performs the following steps for a local cache miss:
 The semaphore is deliberately non-blocking. If all
 `CACHE_MAX_PEER_PROBES_IN_FLIGHT` permits are occupied, excess confirmations
 are skipped instead of queued, and those requests use origin. This bounds
-goroutines, sockets, and aggregate peer work during a miss storm.
+active `/cache/has` HTTP requests, sockets, and aggregate peer work during a
+miss storm. It does not bound total process goroutines: each client request has
+its own handler and may briefly create up to its
+`CACHE_PEER_MAX_PROBES` candidate-coordination goroutines.
 
 Block-aligned requests can contain several distinct cache keys. They share one
 `CACHE_PEER_MAX_PROBES` budget across their missing blocks, so the request does
@@ -192,11 +196,53 @@ sampling, fill ownership, or a separate in-flight protocol. Those mechanisms
 either restore request-time work or expand this design's scope, so they are not
 included here.
 
+## Known limitations and follow-up work
+
+The initial production target is the current fleet size of approximately
+10–20 cache-proxy nodes. The request-time probe and memory bounds remain hard
+outside that range, but some synchronization and observability properties need
+more work before treating the documented 100-node examples or the 415-peer
+memory maximum as a sustained operating target:
+
+- Pull throughput, not only memory, must eventually cap the selected peer set.
+  Four workers, two-second per-peer timeouts, and a 15-second cycle budget can
+  refresh the current fleet within the 60-second TTL. A much larger set of
+  consistently slow peers can require several rotations, allowing records to
+  expire before their next refresh. Before scaling materially beyond the
+  current fleet, derive the selection cap from worst-case refresh throughput or
+  redesign scheduling so a full rotation fits within the TTL.
+- The periodically rebuilt body contains new creation and expiration times, so
+  its ETag changes even when the Bloom bits do not. Conditional GETs therefore
+  help only for repeated pulls between rebuilds; they do not currently remove
+  the regular full-snapshot transfer. A future lease/ETag design can separate
+  unchanged filter content from freshness renewal.
+- `cache_proxy_summary_resident_count` counts retained records and can include
+  an expired record until the next successful membership refresh prunes it.
+  There is no discovered/selected-peer denominator, and the age histogram is
+  observed only for Bloom-positive records. Pull outcomes, probe amplification,
+  and origin traffic expose degradation, but they cannot prove full summary
+  convergence. Add discovered, selected, and valid-unexpired gauges before
+  making readiness or autoscaling depend on summary coverage.
+- Lookup currently scans current membership and tests retained filters under a
+  shared read lock, then ranks candidates. This is acceptable at 10–20 nodes
+  but request CPU, allocations, and writer-lock contention scale with fleet
+  size. Use bounded top-K selection and immutable lookup snapshots before large
+  fleets.
+- `cache_proxy_peer_hits_total` counts successful peer body transfers, while
+  `cache_proxy_peer_fetches_total` counts logical lookups. A block request can
+  transfer two peer blocks after one logical lookup, so their ratio is a
+  transfers-per-lookup measure and can exceed one; it is not a percentage.
+
+Probe mode does not allocate, build, or serve Bloom summaries. It returns 404
+from `/cache/summary`. Enabling summary mode on a canary therefore starts with
+partial coverage and uses the bounded uncovered-peer/origin fallback while the
+canary and compatible peers build and pull their first snapshots.
+
 ## Memory model
 
 The default 512 MiB summary budget is divided conservatively:
 
-- local published bitset and 16-bit counters: approximately 19.4 MiB;
+- local snapshot bitset and 16-bit counters: approximately 19.4 MiB;
 - current and next immutable encoded snapshots plus a temporary raw snapshot;
 - four simultaneous pulls, each reserving a 2 MiB encoded body plus decoded
   bits;
@@ -244,27 +290,36 @@ worker identity labels. The primary rollout signals are:
 - `cache_proxy_peer_probes_total / cache_proxy_peer_fetches_total`: physical
   confirmation amplification; it should remain below the configured cap and
   near the fleet-aware false-positive expectation when coverage is complete;
-- `cache_proxy_peer_direct_gets_total`: confirmed peer body transfers;
+- `cache_proxy_summary_confirmed_gets_total`: confirmed peer body transfers;
 - peer and origin bytes and latency: useful locality versus fallback cost;
 - `cache_proxy_summary_pulls_total` and
   `cache_proxy_summary_serves_total`: synchronization health;
-- resident summary count/bytes and summary age: coverage and memory;
+- `cache_proxy_summary_resident_count` and summary age: retained-summary health,
+  subject to the coverage limitations above;
+- `cache_proxy_summary_resident_bytes` versus
+  `cache_proxy_summary_memory_limit_bytes`: conservative Bloom-state accounting
+  versus its configured ceiling. Resident bytes include the fixed local filter,
+  maximum transient reserve, and retained remote bits; they are not process RSS;
 - predicted Bloom false-positive rate, saturation, and bit occupancy.
 
 Rollout procedure:
 
-1. Deploy an image containing the GET summary endpoint to every cache-proxy
-   pod while leaving `CACHE_PEER_LOOKUP_MODE=probe`.
-2. Enable `summary` mode in non-production first.
+1. Deploy the compatible image to every cache-proxy pod while leaving
+   `CACHE_PEER_LOOKUP_MODE=probe`. Probe-mode pods contain the endpoint code but
+   return 404 and do not prebuild summaries.
+2. Enable `summary` mode in non-production first. Expect partial coverage while
+   the restarted/canary pods build and pull their initial snapshots.
 3. Confirm summaries converge after startup and membership changes, pull work
    remains bounded, and request-time probes never exceed the configured cap.
 4. Compare peer usefulness, origin bytes, and origin latency with probe mode.
-5. Confirm resident Bloom bytes remain under the configured budget and process
-   RSS remains below the pod memory limit with sufficient headroom.
+5. Confirm `cache_proxy_summary_resident_bytes` remains below
+   `cache_proxy_summary_memory_limit_bytes`, and process RSS remains below the
+   pod memory limit with sufficient headroom.
 6. Roll out gradually to production.
 
-Mixed summary implementations fail safely: a pull sent to a POST-only endpoint
-or a push sent to a GET-only endpoint is rejected, leaving that peer uncovered.
+During a rolling deployment, a peer without the compatible GET summary endpoint
+remains uncovered; bounded confirmation or origin fallback is used until the
+endpoint is available.
 
 Rollback by restoring `CACHE_PEER_LOOKUP_MODE=probe`. Cache keys and on-disk
 layout are unchanged, so do not delete cache contents.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -240,14 +240,15 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
 | `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
-| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In pushed-summary mode it approaches zero once every discovered peer has supplied a valid summary; uncovered joining peers temporarily retain probe fallback. |
-| `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode fallback probes skipped because the pod's in-flight probe budget was exhausted; those requests fall back to origin. |
-| `cache_proxy_summary_pushes_total` | Counter | `outcome` | Bounded summary publication outcomes. |
-| `cache_proxy_summary_receipts_total` | Counter | `outcome` | Accepted or rejected peer summary bodies. |
+| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In summary mode these are bounded confirmations of Bloom-positive or uncovered peers, never fleet-wide fanout. The per-request maximum is `CACHE_PEER_MAX_PROBES`. |
+| `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode confirmations skipped because the pod-wide in-flight probe budget was exhausted; those requests fall back to origin without queuing. |
+| `cache_proxy_summary_pulls_total` | Counter | `outcome` | Receiver-driven `GET /cache/summary` attempts by outcome, including success, not-modified, timeout, rejection, and size/read failures. |
+| `cache_proxy_summary_serves_total` | Counter | `outcome` | Local summary endpoint and snapshot-build outcomes. |
+| `cache_proxy_summary_receipts_total` | Counter | `outcome` | Pulled summary bodies accepted into or rejected from the bounded local store. |
 | `cache_proxy_summary_resident_count` / `cache_proxy_summary_resident_bytes` | Gauge | None | Current bounded peer-summary state. |
 | `cache_proxy_summary_age_seconds` | Histogram | None | Age of summaries used in local Bloom lookups. |
 | `cache_proxy_summary_lookups_total` | Counter | `outcome` | `no_valid_summary`, `no_positive`, or `positive_candidate`. |
-| `cache_proxy_peer_direct_gets_total` | Counter | `outcome` | Bounded direct peer GET outcomes in summary mode. |
+| `cache_proxy_peer_direct_gets_total` | Counter | `outcome` | Peer body GET outcomes in summary mode. A GET is attempted only after an exact bounded `/cache/has` confirmation. |
 | `cache_proxy_summary_bloom_items` | Gauge | None | Local live cache keys represented by the incrementally maintained counting Bloom filter. |
 | `cache_proxy_summary_bloom_bits` / `cache_proxy_summary_bloom_hashes` | Gauge | None | Fixed Bloom-filter layout, sized for 1m keys at a 1% target false-positive rate. |
 | `cache_proxy_summary_bloom_false_positive_ratio` | Gauge | None | Predicted per-peer false-positive ratio from live item count and filter layout. This rises smoothly after 1m keys; use fleet size to interpret aggregate request cost. |
@@ -255,7 +256,7 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_summary_bloom_bit_occupancy_ratio` | Gauge | None | Fraction of local Bloom bits set; a direct saturation signal independent of the FPR estimate. |
 | `cache_proxy_summary_bloom_additions_total` / `cache_proxy_summary_bloom_removals_total` | Counter | None | Cache commits and evictions applied incrementally to the local Bloom index. |
 | `cache_proxy_summary_bloom_counter_saturations_total` | Counter | None | Counting-Bloom cells that reached `uint16` saturation and were made sticky to avoid false negatives. |
-| `cache_proxy_summary_bloom_snapshots_total` / `cache_proxy_summary_bloom_snapshot_bytes` | Counter / Gauge | None | Immutable local Bloom snapshots prepared for periodic publication and their bounded size. |
+| `cache_proxy_summary_bloom_snapshots_total` / `cache_proxy_summary_bloom_snapshot_bytes` | Counter / Gauge | None | Immutable local Bloom snapshots prepared for the pull endpoint and their bounded raw-bit size. |
 
 Cache-proxy metrics deliberately have no org label. Use the existing per-org
 Duckgres query and worker-acquisition metrics for customer-facing rollout

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -239,20 +239,21 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_misses_total` | Counter | None | Worker-facing cacheable requests that require a peer or origin fill before they can be served. |
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
-| `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
+| `cache_proxy_peer_hits_total` | Counter | None | Successful peer body transfers. A block-mode request can record up to two transfers for one logical lookup. |
 | `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In summary mode these are bounded confirmations of Bloom-positive or uncovered peers, never fleet-wide fanout. The per-request maximum is `CACHE_PEER_MAX_PROBES`. |
-| `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode confirmations skipped because the pod-wide in-flight probe budget was exhausted; those requests fall back to origin without queuing. |
+| `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode confirmations skipped because the pod-wide active `/cache/has` HTTP-request/socket budget was exhausted; those requests fall back to origin without queuing. This budget does not count total process goroutines. |
 | `cache_proxy_summary_pulls_total` | Counter | `outcome` | Receiver-driven `GET /cache/summary` attempts by outcome, including success, not-modified, timeout, rejection, and size/read failures. |
 | `cache_proxy_summary_serves_total` | Counter | `outcome` | Local summary endpoint and snapshot-build outcomes. |
-| `cache_proxy_summary_receipts_total` | Counter | `outcome` | Pulled summary bodies accepted into or rejected from the bounded local store. |
-| `cache_proxy_summary_resident_count` / `cache_proxy_summary_resident_bytes` | Gauge | None | Current bounded peer-summary state. |
+| `cache_proxy_summary_resident_count` | Gauge | None | Current retained peer summaries. |
+| `cache_proxy_summary_resident_bytes` | Gauge | None | Conservative total Bloom-state accounting: the fixed local counting filter, maximum snapshot/pull transient reserve, and retained remote summary bits. This is reserved/accounted memory, not measured process RSS. It is `0` outside summary mode. |
+| `cache_proxy_summary_memory_limit_bytes` | Gauge | None | Effective `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` ceiling used for the total Bloom-state accounting above. It is `0` outside summary mode. Alert when resident bytes approach this value. |
 | `cache_proxy_summary_age_seconds` | Histogram | None | Age of summaries used in local Bloom lookups. |
 | `cache_proxy_summary_lookups_total` | Counter | `outcome` | `no_valid_summary`, `no_positive`, or `positive_candidate`. |
-| `cache_proxy_peer_direct_gets_total` | Counter | `outcome` | Peer body GET outcomes in summary mode. A GET is attempted only after an exact bounded `/cache/has` confirmation. |
+| `cache_proxy_summary_confirmed_gets_total` | Counter | `outcome` | Peer body GET outcomes in summary mode. A GET is attempted only after an exact bounded `/cache/has` confirmation. |
 | `cache_proxy_summary_bloom_items` | Gauge | None | Local live cache keys represented by the incrementally maintained counting Bloom filter. |
 | `cache_proxy_summary_bloom_bits` / `cache_proxy_summary_bloom_hashes` | Gauge | None | Fixed Bloom-filter layout, sized for 1m keys at a 1% target false-positive rate. |
 | `cache_proxy_summary_bloom_false_positive_ratio` | Gauge | None | Predicted per-peer false-positive ratio from live item count and filter layout. This rises smoothly after 1m keys; use fleet size to interpret aggregate request cost. |
-| `cache_proxy_summary_bloom_saturated` | Gauge | None | `1` when the local live key count exceeds the 1m target capacity; publication continues. |
+| `cache_proxy_summary_bloom_saturated` | Gauge | None | `1` when the local live key count exceeds the 1m target capacity; snapshot refresh and serving continue. |
 | `cache_proxy_summary_bloom_bit_occupancy_ratio` | Gauge | None | Fraction of local Bloom bits set; a direct saturation signal independent of the FPR estimate. |
 | `cache_proxy_summary_bloom_additions_total` / `cache_proxy_summary_bloom_removals_total` | Counter | None | Cache commits and evictions applied incrementally to the local Bloom index. |
 | `cache_proxy_summary_bloom_counter_saturations_total` | Counter | None | Counting-Bloom cells that reached `uint16` saturation and were made sticky to avoid false negatives. |
@@ -282,7 +283,8 @@ sum(rate(cache_proxy_peer_probes_total[5m]))
 clamp_min(sum(rate(cache_proxy_peer_fetches_total[5m])), 1e-9)
 ```
 
-Peer lookup yield:
+Successful peer body transfers per logical lookup (this can exceed `1` for a
+multi-block request):
 
 ```promql
 sum(rate(cache_proxy_peer_hits_total[5m]))

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -241,6 +241,7 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
 | `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
 | `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In pushed-summary mode it approaches zero once every discovered peer has supplied a valid summary; uncovered joining peers temporarily retain probe fallback. |
+| `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode fallback probes skipped because the pod's in-flight probe budget was exhausted; those requests fall back to origin. |
 | `cache_proxy_summary_pushes_total` | Counter | `outcome` | Bounded summary publication outcomes. |
 | `cache_proxy_summary_receipts_total` | Counter | `outcome` | Accepted or rejected peer summary bodies. |
 | `cache_proxy_summary_resident_count` / `cache_proxy_summary_resident_bytes` | Gauge | None | Current bounded peer-summary state. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -240,7 +240,7 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
 | `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
-| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. It stays zero for pushed-summary lookups. |
+| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In pushed-summary mode it approaches zero once every discovered peer has supplied a valid summary; uncovered joining peers temporarily retain probe fallback. |
 | `cache_proxy_summary_pushes_total` | Counter | `outcome` | Bounded summary publication outcomes. |
 | `cache_proxy_summary_receipts_total` | Counter | `outcome` | Accepted or rejected peer summary bodies. |
 | `cache_proxy_summary_resident_count` / `cache_proxy_summary_resident_bytes` | Gauge | None | Current bounded peer-summary state. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -238,9 +238,15 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_hits_total` | Counter | None | Worker-facing cacheable requests served entirely from data already present on local NVMe. Peer API reads and requests that first fetch any block from a peer are excluded. |
 | `cache_proxy_misses_total` | Counter | None | Worker-facing cacheable requests that require a peer or origin fill before they can be served. |
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
-| `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups. One lookup can issue multiple physical `/cache/has` probes. |
+| `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
 | `cache_proxy_peer_hits_total` | Counter | None | Logical peer lookups followed by a successful peer body transfer. |
-| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical peer availability probe attempts, classified as `hit`, `miss`, `timeout`, `canceled`, or `error`. Both a present entry (`200`) and an in-flight claim (`202`) are `hit`; `canceled` normally means a losing probe was released after another peer answered and is not itself a failure. |
+| `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. It stays zero for pushed-summary lookups. |
+| `cache_proxy_summary_pushes_total` | Counter | `outcome` | Bounded summary publication outcomes. |
+| `cache_proxy_summary_receipts_total` | Counter | `outcome` | Accepted or rejected peer summary bodies. |
+| `cache_proxy_summary_resident_count` / `cache_proxy_summary_resident_bytes` | Gauge | None | Current bounded peer-summary state. |
+| `cache_proxy_summary_age_seconds` | Histogram | None | Age of summaries used in local Bloom lookups. |
+| `cache_proxy_summary_lookups_total` | Counter | `outcome` | `no_valid_summary`, `no_positive`, or `positive_candidate`. |
+| `cache_proxy_peer_direct_gets_total` | Counter | `outcome` | Bounded direct peer GET outcomes in summary mode. |
 
 Cache-proxy metrics deliberately have no org label. Use the existing per-org
 Duckgres query and worker-acquisition metrics for customer-facing rollout

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -247,6 +247,14 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_summary_age_seconds` | Histogram | None | Age of summaries used in local Bloom lookups. |
 | `cache_proxy_summary_lookups_total` | Counter | `outcome` | `no_valid_summary`, `no_positive`, or `positive_candidate`. |
 | `cache_proxy_peer_direct_gets_total` | Counter | `outcome` | Bounded direct peer GET outcomes in summary mode. |
+| `cache_proxy_summary_bloom_items` | Gauge | None | Local live cache keys represented by the incrementally maintained counting Bloom filter. |
+| `cache_proxy_summary_bloom_bits` / `cache_proxy_summary_bloom_hashes` | Gauge | None | Fixed Bloom-filter layout, sized for 1m keys at a 1% target false-positive rate. |
+| `cache_proxy_summary_bloom_false_positive_ratio` | Gauge | None | Predicted per-peer false-positive ratio from live item count and filter layout. This rises smoothly after 1m keys; use fleet size to interpret aggregate request cost. |
+| `cache_proxy_summary_bloom_saturated` | Gauge | None | `1` when the local live key count exceeds the 1m target capacity; publication continues. |
+| `cache_proxy_summary_bloom_bit_occupancy_ratio` | Gauge | None | Fraction of local Bloom bits set; a direct saturation signal independent of the FPR estimate. |
+| `cache_proxy_summary_bloom_additions_total` / `cache_proxy_summary_bloom_removals_total` | Counter | None | Cache commits and evictions applied incrementally to the local Bloom index. |
+| `cache_proxy_summary_bloom_counter_saturations_total` | Counter | None | Counting-Bloom cells that reached `uint16` saturation and were made sticky to avoid false negatives. |
+| `cache_proxy_summary_bloom_snapshots_total` / `cache_proxy_summary_bloom_snapshot_bytes` | Counter / Gauge | None | Immutable local Bloom snapshots prepared for periodic publication and their bounded size. |
 
 Cache-proxy metrics deliberately have no org label. Use the existing per-org
 Duckgres query and worker-acquisition metrics for customer-facing rollout


### PR DESCRIPTION
## Summary

Adds an opt-in pulled-summary peer lookup mode while keeping
`CACHE_PEER_LOOKUP_MODE=probe` as the default/current behavior.

In `summary` mode, each cache proxy maintains a fixed-layout counting Bloom
filter incrementally on cache insertion and eviction. It serves an immutable,
versioned snapshot through `GET /cache/summary`; receivers pull a deterministic
subset of peers that fits their configured memory budget. Bloom filters are
used only to eliminate definite-negative peers. Every positive or uncovered
candidate is exact-confirmed through bounded parallel `/cache/has` requests
before one `/cache/get` is sent to a confirmed holder.

This avoids fleet-wide request fanout while preserving safe origin fallback.
No cache bodies are proactively replicated, and raw URLs, ranges, object paths,
organization identifiers, and cache locators are never included in summaries.

## Bounds and lifecycle

- `CACHE_MAX_ENTRIES=1000000`: soft/convergent local index target, alongside
  the existing 80% disk target.
- `CACHE_SUMMARY_MEMORY_LIMIT_BYTES=536870912`: reserves the local counting
  filter, overlapping snapshots, four bounded pulls, headers/bodies, and the
  retained remote filters. The default fits 415 peer filters.
- `CACHE_PEER_MAX_PROBES=5`: request-wide confirmation cap, shared across
  missing blocks.
- `CACHE_MAX_PEER_PROBES_IN_FLIGHT=64`: pod-wide non-blocking semaphore; excess
  confirmations skip peer work and use origin rather than queueing.
- Snapshots are refreshed about every 20 seconds with jitter and have a
  45-second TTL. Pulls use four workers, two-second request deadlines, a
  15-second fair rotating cycle deadline, bounded headers, and cancellation on
  shutdown.
- Block requests share the five-probe budget and attempt at most two confirmed
  peer block GETs for the entire client request.

When a new peer appears, membership selection is recomputed and a selected peer
is pulled immediately. Until a valid summary arrives, it remains uncovered and
is eligible only for bounded confirmation. A peer outside the memory-selected
subset also remains uncovered. When a peer disappears or is deselected, its
summary is removed and in-flight receipts are revalidated so stale state cannot
be reinserted. Pull failure retains the last valid record only until its
advertised TTL.

See the [design and operator runbook](docs/design/cache-proxy-pulled-summary-lookup.md)
for sizing, false-positive math, failure behavior, and recovery.

## Rollout

1. Deploy this image to every cache-proxy pod while leaving lookup mode at the
   default `probe` value.
2. Enable `CACHE_PEER_LOOKUP_MODE=summary` in non-production first.
3. During rolling enablement or cold start, absent/incompatible summaries leave
   peers uncovered; confirmation remains capped and requests safely fall back
   to origin.
4. Validate physical probes per logical lookup against the fleet-aware Bloom
   expectation (`N * p`, capped at five), confirmed peer GET usefulness, peer
   bytes, origin bytes/latency, summary age/coverage, pull outcomes, resident
   summary memory, and process RSS.
5. Roll back by restoring `CACHE_PEER_LOOKUP_MODE=probe`; cache contents and
   layout are unchanged and must not be deleted.

Known limitation: a fully covered Bloom-negative key goes directly to origin,
so a key inserted or entering an in-flight fill after the last snapshot can be
missed until the next pull. This is a locality loss, not a correctness failure.

## Validation

- `just test-cache-proxy`
- `go test -race ./cmd/cache-proxy/... -count=1`
- `just test-unit`
- `just lint`
