### PR TITLE
k8s: copy PostHog log env as secretKeyRef; never fail spawn

### DIFF
--- a/controlplane/k8s_pool.go
+++ b/controlplane/k8s_pool.go
@@ -56,26 +56,26 @@ type K8sWorkerPool struct {
 	shuttingDown bool
 	shutdownCh   chan struct{}
 
-	clientset               kubernetes.Interface
-	namespace               string
-	cpID                    string
-	cpInstanceID            string
-	cpUID                   types.UID
-	workerImage             string
-	workerPort              int
-	secretName              string
-	configMap               string
-	configPath              string
-	imagePullPolicy         corev1.PullPolicy
-	serviceAccount          string
-	workerCPURequest        string            // CPU request for worker pods (e.g., "500m")
-	workerMemoryRequest     string            // memory request for worker pods (e.g., "1Gi")
-	workerNodeSelector      map[string]string // node selector for worker pods
-	workerTolerationKey     string            // taint key for NoSchedule toleration
-	workerTolerationValue   string            // taint value for NoSchedule toleration
-	workerOrgAffinityEnabled bool             // add soft same-org pod affinity to trusted org-bound workers
-	workerOrgAffinityWeight  int              // preferred same-org pod-affinity weight, validated at control-plane startup
-	workerPriorityClassName string            // PriorityClass for worker pods (preempts overprovision pause pods)
+	clientset                kubernetes.Interface
+	namespace                string
+	cpID                     string
+	cpInstanceID             string
+	cpUID                    types.UID
+	workerImage              string
+	workerPort               int
+	secretName               string
+	configMap                string
+	configPath               string
+	imagePullPolicy          corev1.PullPolicy
+	serviceAccount           string
+	workerCPURequest         string            // CPU request for worker pods (e.g., "500m")
+	workerMemoryRequest      string            // memory request for worker pods (e.g., "1Gi")
+	workerNodeSelector       map[string]string // node selector for worker pods
+	workerTolerationKey      string            // taint key for NoSchedule toleration
+	workerTolerationValue    string            // taint value for NoSchedule toleration
+	workerOrgAffinityEnabled bool              // add soft same-org pod affinity to trusted org-bound workers
+	workerOrgAffinityWeight  int               // preferred same-org pod-affinity weight, validated at control-plane startup
+	workerPriorityClassName  string            // PriorityClass for worker pods (preempts overprovision pause pods)
 
 	// Headroom controller holds preemptible low-priority placeholder pods so a
 	// worker spawn schedules immediately (preempting a placeholder) instead of
@@ -119,6 +119,11 @@ type K8sWorkerPool struct {
 
 	activatingTimeout time.Duration // max time a worker can stay in reserved/activating before being reaped
 
+	// posthogEnv is the allowlisted PostHog log EnvVars copied from this
+	// CP pod's named env at pool start. SecretKeyRef is live when the
+	// worker pod starts — no refresh loop. Empty if POD_NAME is unset,
+	// Get fails, or the named env is missing.
+	posthogEnv []corev1.EnvVar
 }
 
 // NewK8sWorkerPool creates a K8sWorkerPool using in-cluster credentials.
@@ -178,28 +183,28 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		workers: make(map[int]*ManagedWorker),
 		// maxWorkers defaults to 0 (unbounded); there is no global cluster cap.
 		// Per-org caps are applied by OrgReservedPool, not the shared pool.
-		idleTimeout:             cfg.IdleTimeout,
-		shutdownCh:              make(chan struct{}),
-		stopInform:              make(chan struct{}),
-		clientset:               clientset,
-		namespace:               cfg.Namespace,
-		cpID:                    cfg.CPID,
-		cpInstanceID:            cfg.CPInstanceID,
-		workerImage:             cfg.WorkerImage,
-		workerPort:              cfg.WorkerPort,
-		secretName:              cfg.SecretName,
-		configMap:               cfg.ConfigMap,
-		configPath:              cfg.ConfigPath,
-		imagePullPolicy:         corev1.PullPolicy(cfg.ImagePullPolicy),
-		serviceAccount:          cfg.ServiceAccount,
-		workerCPURequest:        cfg.WorkerCPURequest,
-		workerMemoryRequest:     cfg.WorkerMemoryRequest,
-		workerNodeSelector:      cfg.WorkerNodeSelector,
-		workerTolerationKey:     cfg.WorkerTolerationKey,
-		workerTolerationValue:   cfg.WorkerTolerationValue,
+		idleTimeout:              cfg.IdleTimeout,
+		shutdownCh:               make(chan struct{}),
+		stopInform:               make(chan struct{}),
+		clientset:                clientset,
+		namespace:                cfg.Namespace,
+		cpID:                     cfg.CPID,
+		cpInstanceID:             cfg.CPInstanceID,
+		workerImage:              cfg.WorkerImage,
+		workerPort:               cfg.WorkerPort,
+		secretName:               cfg.SecretName,
+		configMap:                cfg.ConfigMap,
+		configPath:               cfg.ConfigPath,
+		imagePullPolicy:          corev1.PullPolicy(cfg.ImagePullPolicy),
+		serviceAccount:           cfg.ServiceAccount,
+		workerCPURequest:         cfg.WorkerCPURequest,
+		workerMemoryRequest:      cfg.WorkerMemoryRequest,
+		workerNodeSelector:       cfg.WorkerNodeSelector,
+		workerTolerationKey:      cfg.WorkerTolerationKey,
+		workerTolerationValue:    cfg.WorkerTolerationValue,
 		workerOrgAffinityEnabled: cfg.WorkerOrgAffinityEnabled,
 		workerOrgAffinityWeight:  cfg.WorkerOrgAffinityWeight,
-		workerPriorityClassName: cfg.WorkerPriorityClassName,
+		workerPriorityClassName:  cfg.WorkerPriorityClassName,
 
 		placeholderImage:             cfg.PlaceholderImage,
 		placeholderPriorityClassName: cfg.PlaceholderPriorityClassName,
@@ -228,6 +233,10 @@ func newK8sWorkerPool(cfg K8sWorkerPoolConfig, clientset kubernetes.Interface) (
 		}
 	}
 
+	// Cache PostHog log env from this CP pod's named env. Missing
+	// logging config must never fail pool start or later spawn.
+	pool.loadPostHogLogEnv(context.Background())
+
 	// Resolve CP pod UID for owner references
 	if err := pool.resolveCPUID(context.Background()); err != nil {
 		slog.Warn("Could not resolve CP pod UID for owner references. Worker pods will not be garbage-collected if CP is deleted.", "error", err)
@@ -252,6 +261,38 @@ func (p *K8sWorkerPool) resolveCPUID(ctx context.Context) error {
 	}
 	p.cpUID = pod.UID
 	return nil
+}
+
+// loadPostHogLogEnv reads this CP pod's named env (Get(namespace, POD_NAME))
+// and caches the allowlisted PostHog log vars. POD_NAME empty, Get fail, or
+// a missing named POSTHOG_API_KEY → one WARN and empty cache. Never errors.
+func (p *K8sWorkerPool) loadPostHogLogEnv(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	podName := strings.TrimSpace(os.Getenv("POD_NAME"))
+	if podName == "" || p.clientset == nil {
+		slog.Warn("PostHog log env not found on CP pod spec; workers will not export.")
+		p.posthogEnv = nil
+		return
+	}
+	pod, err := p.clientset.CoreV1().Pods(p.namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil || pod == nil || len(pod.Spec.Containers) == 0 {
+		slog.Warn("PostHog log env not found on CP pod spec; workers will not export.", "error", err)
+		p.posthogEnv = nil
+		return
+	}
+	copied := filterPostHogLogEnv(pod.Spec.Containers[0].Env)
+	p.posthogEnv = copied
+	if envHasName(copied, "POSTHOG_API_KEY") {
+		return
+	}
+	// A literal value: already WARNs "refusing to materialize"; do not
+	// also claim the named env was missing.
+	if present, secretRef := namedPostHogAPIKey(pod.Spec.Containers[0].Env); present && !secretRef {
+		return
+	}
+	slog.Warn("PostHog log env not found on CP pod spec; workers will not export.")
 }
 
 func (p *K8sWorkerPool) workerServiceAccountName() string {

--- a/controlplane/k8s_pool_lifecycle.go
+++ b/controlplane/k8s_pool_lifecycle.go
@@ -41,6 +41,7 @@ func (p *K8sWorkerPool) retireWorkerWithReason(id int, reason string, origin Lif
 	workerCount := len(p.workers)
 	p.mu.Unlock()
 	observeControlPlaneWorkers(workerCount)
+	forgetWorkerOTLPExport(id)
 
 	go p.retireWorkerPod(id, w)
 	return true
@@ -70,6 +71,7 @@ func (p *K8sWorkerPool) retireWorkerIfNoSessionsWithReason(id int, reason string
 		workerCount := len(p.workers)
 		p.mu.Unlock()
 		observeControlPlaneWorkers(workerCount)
+		forgetWorkerOTLPExport(id)
 		go p.retireWorkerPod(id, w)
 		return true
 	}
@@ -136,6 +138,7 @@ func (p *K8sWorkerPool) RetireIfDrainingAndEmpty(id int, origin LifecycleOrigin)
 	workerCount := len(p.workers)
 	p.mu.Unlock()
 	observeControlPlaneWorkers(workerCount)
+	forgetWorkerOTLPExport(id)
 	go p.retireWorkerPod(id, w)
 }
 
@@ -437,6 +440,9 @@ func (p *K8sWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Durat
 							hcResult, healthErr = doHealthCheckWithMetadata(hctx, w.client, p.healthCheckPayloadForLease(lease))
 							cancel()
 						}()
+						if hcResult != nil {
+							observeWorkerOTLPExportFromHealth(lease.workerID, hcResult)
+						}
 						// Skip both metric emission AND failure-counter
 						// increment when the parent loop ctx was canceled
 						// (CP shutting down). Without this guard:

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -126,44 +126,7 @@ func (p *K8sWorkerPool) spawnWorkerForOrg(ctx context.Context, id int, image str
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					Env: []corev1.EnvVar{
-						{
-							Name: "DUCKGRES_DUCKDB_TOKEN",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-									Key:                  "bearer-token",
-								},
-							},
-						},
-						{
-							Name:  "DUCKGRES_MODE",
-							Value: "duckdb-service",
-						},
-						{
-							Name:  "DUCKGRES_CERT",
-							Value: workerRPCMountDir + "/" + workerRPCCertKey,
-						},
-						{
-							Name:  "DUCKGRES_KEY",
-							Value: workerRPCMountDir + "/" + workerRPCKeyKey,
-						},
-						{
-							// One client query session per worker pod: the pod's full
-							// resources (workerDuckDBLimits gives the session ~75% of pod RAM
-							// + 2.5 DuckDB threads per requested CPU) belong to a single query,
-							// so queries never
-							// contend and a heavy query can't be OOM'd by a co-resident
-							// one. The CP scheduler (OrgReservedPool) already never
-							// co-assigns; this is the hard worker-side guarantee — a 2nd
-							// CreateSession is rejected rather than silently overcommitting.
-							// Internal control/maintenance work runs on the worker's side
-							// connections (controlDB/warmupDB), which are NOT counted
-							// sessions, so this does not starve them.
-							Name:  "DUCKGRES_DUCKDB_MAX_SESSIONS",
-							Value: "1",
-						},
-					},
+					Env: p.workerPodEnv(secretName, workerResources),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: boolPtr(false),
 					},
@@ -172,91 +135,7 @@ func (p *K8sWorkerPool) spawnWorkerForOrg(ctx context.Context, id int, image str
 			},
 		},
 	}
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
-		Name:  "DUCKGRES_SHARED_WARM_WORKER",
-		Value: "true",
-	})
 	p.addWorkerOrgPlacementAffinity(pod, orgID)
-
-	// Pre-session memory hygiene. Without an explicit DUCKGRES_MEMORY_LIMIT the
-	// worker's ConfigureMainDB falls back to sysinfo.AutoMemoryLimit(), which
-	// reads the NODE's /proc/meminfo — so all pre-session work (DuckLake
-	// ATTACH, activation, warmup, controlDB) runs with a memory_limit sized to
-	// the node, not the pod cgroup. Pass the pod-derived limit (same 75% the
-	// per-session SET uses, via duckdbMemoryLimitForPodMemory) and the CPU-derived
-	// thread count so the base DB is correctly bounded from process start.
-	// GOMEMLIMIT (read by the Go runtime directly) gives the Go side a soft
-	// ceiling at 1/8 of the pod so GC pushes back before the cgroup OOM-kills;
-	// DuckDB's buffer manager is unaffected (C allocations are untracked by Go).
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, workerMemoryHygieneEnv(workerResources)...)
-
-	// Stamp every log line with pod and node identifiers via the Downward API.
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
-		corev1.EnvVar{
-			Name: "POD_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-			},
-		},
-		corev1.EnvVar{
-			Name: "NODE_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-			},
-		},
-	)
-
-	// Pass OTEL trace config to worker pods.
-	for _, envName := range []string{
-		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-		"OTEL_EXPORTER_OTLP_TRACES_PATH",
-	} {
-		if v := os.Getenv(envName); v != "" {
-			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
-				Name:  envName,
-				Value: v,
-			})
-		}
-	}
-
-	// Cache proxy integration: when enabled, workers need to reach the
-	// DaemonSet proxy on the same node via the node IP + fixed hostPort.
-	// Inject NODE_IP via the Downward API so the worker process can resolve
-	// the proxy address at runtime.
-	if os.Getenv("DUCKGRES_CACHE_ENABLED") == "true" {
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
-			corev1.EnvVar{
-				Name:  "DUCKGRES_CACHE_ENABLED",
-				Value: "true",
-			},
-			corev1.EnvVar{
-				Name: "NODE_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.hostIP",
-					},
-				},
-			},
-		)
-		if timeout := os.Getenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT"); timeout != "" {
-			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
-				Name:  "DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT",
-				Value: timeout,
-			})
-		}
-	}
-
-	// Worker pods get an explicitly-constructed env list (this function), not
-	// a copy of the CP's own env, so any flag the worker reads at startup
-	// (here: configresolve's DisableParquetPrefetching, applied in
-	// applyParquetPrefetchPolicy) must be mirrored through explicitly or
-	// setting it on the CP deployment silently does nothing on workers.
-	if disabled, err := strconv.ParseBool(os.Getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING")); err == nil && disabled {
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
-			Name:  "DUCKGRES_DISABLE_PARQUET_PREFETCHING",
-			Value: "true",
-		})
-	}
 
 	// Add toleration if configured.
 	tolKey, tolValue := p.workerTolerationKey, p.workerTolerationValue
@@ -710,6 +589,115 @@ func (p *K8sWorkerPool) spawnReservedWorkerForSlot(ctx context.Context, id int, 
 // When set, limits are equal to requests (Guaranteed QoS).
 func (p *K8sWorkerPool) workerResources() corev1.ResourceRequirements {
 	return p.workerResourcesForProfile(WorkerProfile{})
+}
+
+// workerPodEnv builds the explicit worker container env list. Worker pods do
+// not inherit the CP process env — every startup flag must be mirrored here.
+func (p *K8sWorkerPool) workerPodEnv(secretName string, workerResources corev1.ResourceRequirements) []corev1.EnvVar {
+	env := []corev1.EnvVar{
+		{
+			Name: "DUCKGRES_DUCKDB_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  "bearer-token",
+				},
+			},
+		},
+		{
+			Name:  "DUCKGRES_MODE",
+			Value: "duckdb-service",
+		},
+		{
+			Name:  "DUCKGRES_CERT",
+			Value: workerRPCMountDir + "/" + workerRPCCertKey,
+		},
+		{
+			Name:  "DUCKGRES_KEY",
+			Value: workerRPCMountDir + "/" + workerRPCKeyKey,
+		},
+		{
+			// One client query session per worker pod: the pod's full
+			// resources (workerDuckDBLimits gives the session ~75% of pod RAM
+			// + 2.5 DuckDB threads per requested CPU) belong to a single query,
+			// so queries never
+			// contend and a heavy query can't be OOM'd by a co-resident
+			// one. The CP scheduler (OrgReservedPool) already never
+			// co-assigns; this is the hard worker-side guarantee — a 2nd
+			// CreateSession is rejected rather than silently overcommitting.
+			// Internal control/maintenance work runs on the worker's side
+			// connections (controlDB/warmupDB), which are NOT counted
+			// sessions, so this does not starve them.
+			Name:  "DUCKGRES_DUCKDB_MAX_SESSIONS",
+			Value: "1",
+		},
+		{
+			Name:  "DUCKGRES_SHARED_WARM_WORKER",
+			Value: "true",
+		},
+	}
+	// Pre-session memory hygiene. Without an explicit DUCKGRES_MEMORY_LIMIT the
+	// worker's ConfigureMainDB falls back to sysinfo.AutoMemoryLimit(), which
+	// reads the NODE's /proc/meminfo — so all pre-session work (DuckLake
+	// ATTACH, activation, warmup, controlDB) runs with a memory_limit sized to
+	// the node, not the pod cgroup. Pass the pod-derived limit (same 75% the
+	// per-session SET uses, via duckdbMemoryLimitForPodMemory) and the CPU-derived
+	// thread count so the base DB is correctly bounded from process start.
+	// GOMEMLIMIT (read by the Go runtime directly) gives the Go side a soft
+	// ceiling at 1/8 of the pod so GC pushes back before the cgroup OOM-kills;
+	// DuckDB's buffer manager is unaffected (C allocations are untracked by Go).
+	env = append(env, workerMemoryHygieneEnv(workerResources)...)
+	env = append(env, downwardAPIIdentityEnv()...)
+
+	// Pass OTEL trace config to worker pods (collector URL, not a token).
+	for _, envName := range []string{
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_PATH",
+	} {
+		if v := os.Getenv(envName); v != "" {
+			env = append(env, corev1.EnvVar{Name: envName, Value: v})
+		}
+	}
+
+	// Cache proxy integration: when enabled, workers need to reach the
+	// DaemonSet proxy on the same node via the node IP + fixed hostPort.
+	// Inject NODE_IP via the Downward API so the worker process can resolve
+	// the proxy address at runtime.
+	if os.Getenv("DUCKGRES_CACHE_ENABLED") == "true" {
+		env = append(env,
+			corev1.EnvVar{Name: "DUCKGRES_CACHE_ENABLED", Value: "true"},
+			corev1.EnvVar{
+				Name: "NODE_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+				},
+			},
+		)
+		if timeout := os.Getenv("DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT"); timeout != "" {
+			env = append(env, corev1.EnvVar{
+				Name:  "DUCKGRES_CACHE_PROXY_CONNECT_TIMEOUT",
+				Value: timeout,
+			})
+		}
+	}
+
+	// Any flag the worker reads at startup must be mirrored through explicitly
+	// or setting it on the CP deployment silently does nothing on workers.
+	if disabled, err := strconv.ParseBool(os.Getenv("DUCKGRES_DISABLE_PARQUET_PREFETCHING")); err == nil && disabled {
+		env = append(env, corev1.EnvVar{
+			Name:  "DUCKGRES_DISABLE_PARQUET_PREFETCHING",
+			Value: "true",
+		})
+	}
+
+	// Cached named PostHog log env from the CP pod spec (secretKeyRef stays
+	// a ref). Empty when POD_NAME/Get/named env missed — never fail spawn.
+	if p != nil && len(p.posthogEnv) > 0 {
+		for i := range p.posthogEnv {
+			env = append(env, *p.posthogEnv[i].DeepCopy())
+		}
+	}
+	return env
 }
 
 // workerMemoryHygieneEnv derives the memory/thread env vars for a worker pod

--- a/controlplane/k8s_pool_spawn_test.go
+++ b/controlplane/k8s_pool_spawn_test.go
@@ -1,0 +1,205 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func secretKeyRefEnv(name, secret, key string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secret},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+func setCPPodNamedEnv(t *testing.T, pool *K8sWorkerPool, env []corev1.EnvVar, envFrom []corev1.EnvFromSource) {
+	t.Helper()
+	pod, err := pool.clientset.CoreV1().Pods(pool.namespace).Get(context.Background(), pool.cpID, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get CP pod: %v", err)
+	}
+	pod.Spec.Containers = []corev1.Container{{
+		Name:    "controlplane",
+		Image:   "example/duckgres-controlplane:test",
+		Env:     env,
+		EnvFrom: envFrom,
+	}}
+	if _, err := pool.clientset.CoreV1().Pods(pool.namespace).Update(context.Background(), pod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update CP pod: %v", err)
+	}
+}
+
+func captureSpawnedWorkerEnv(t *testing.T, pool *K8sWorkerPool) []corev1.EnvVar {
+	t.Helper()
+	cs, ok := pool.clientset.(interface {
+		PrependReactor(string, string, k8stesting.ReactionFunc)
+	})
+	if !ok {
+		t.Fatal("clientset does not support PrependReactor")
+	}
+	var created *corev1.Pod
+	cs.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		pod, ok := createAction.GetObject().(*corev1.Pod)
+		if !ok || pod.Labels["app"] != "duckgres-worker" {
+			return false, nil, nil
+		}
+		created = pod.DeepCopy()
+		return true, nil, k8serrors.NewForbidden(
+			schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("stop after capture"),
+		)
+	})
+	if err := pool.spawnWorker(context.Background(), 3, pool.workerImage, WorkerProfile{}, false); err == nil {
+		t.Fatal("spawnWorker unexpectedly succeeded")
+	}
+	if created == nil {
+		t.Fatal("worker Pod was not submitted")
+	}
+	if len(created.Spec.Containers) == 0 {
+		t.Fatal("worker Pod has no containers")
+	}
+	return created.Spec.Containers[0].Env
+}
+
+func loadPostHogFromPODNAME(t *testing.T, pool *K8sWorkerPool) {
+	t.Helper()
+	t.Setenv("POD_NAME", pool.cpID)
+	pool.loadPostHogLogEnv(context.Background())
+}
+
+// TestWorkerSpawnPostHogEnvIsSecretRef pins the charts contract: a named
+// POSTHOG_API_KEY secretKeyRef on the CP pod is copied as a ref. A literal
+// value is refused so the token never appears as value: on the worker spec.
+func TestWorkerSpawnPostHogEnvIsSecretRef(t *testing.T) {
+	t.Run("secretKeyRef is copied with other log knobs", func(t *testing.T) {
+		pool, _ := newTestK8sPool(t, 5)
+		setCPPodNamedEnv(t, pool, []corev1.EnvVar{
+			secretKeyRefEnv("POSTHOG_API_KEY", "duckgres-posthog", "api-key"),
+			{Name: "POSTHOG_HOST", Value: "us.i.posthog.com"},
+			{Name: "DUCKGRES_POSTHOG_LOG_LEVEL", Value: "warn"},
+			{Name: "DUCKGRES_POSTHOG_LOG_INFO_SAMPLE", Value: "0"},
+			{Name: "DUCKGRES_POSTHOG_LOG_QUERY_TEXT", Value: "redacted"},
+			{Name: "DUCKGRES_IDENTIFIER", Value: "mw-dev"},
+			{Name: "ADDITIONAL_POSTHOG_API_KEYS", Value: "phc_must_not_copy"},
+			{Name: "POSTHOG_ANALYTICS_API_KEY", Value: "phc_analytics_only"},
+		}, nil)
+		loadPostHogFromPODNAME(t, pool)
+
+		env := envByName(captureSpawnedWorkerEnv(t, pool))
+		got, ok := env["POSTHOG_API_KEY"]
+		if !ok {
+			t.Fatal("POSTHOG_API_KEY missing on worker")
+		}
+		if got.Value != "" {
+			t.Fatalf("POSTHOG_API_KEY materialized as value %q", got.Value)
+		}
+		if got.ValueFrom == nil || got.ValueFrom.SecretKeyRef == nil {
+			t.Fatalf("POSTHOG_API_KEY is not a secretKeyRef: %+v", got)
+		}
+		if got.ValueFrom.SecretKeyRef.Name != "duckgres-posthog" || got.ValueFrom.SecretKeyRef.Key != "api-key" {
+			t.Fatalf("POSTHOG_API_KEY secretKeyRef = %s/%s", got.ValueFrom.SecretKeyRef.Name, got.ValueFrom.SecretKeyRef.Key)
+		}
+		if env["POSTHOG_HOST"].Value != "us.i.posthog.com" {
+			t.Fatalf("POSTHOG_HOST = %+v", env["POSTHOG_HOST"])
+		}
+		if env["DUCKGRES_POSTHOG_LOG_LEVEL"].Value != "warn" {
+			t.Fatalf("DUCKGRES_POSTHOG_LOG_LEVEL = %+v", env["DUCKGRES_POSTHOG_LOG_LEVEL"])
+		}
+		if env["DUCKGRES_IDENTIFIER"].Value != "mw-dev" {
+			t.Fatalf("DUCKGRES_IDENTIFIER = %+v", env["DUCKGRES_IDENTIFIER"])
+		}
+		if _, leaked := env["ADDITIONAL_POSTHOG_API_KEYS"]; leaked {
+			t.Fatal("ADDITIONAL_POSTHOG_API_KEYS must not be forwarded")
+		}
+		if _, leaked := env["POSTHOG_ANALYTICS_API_KEY"]; leaked {
+			t.Fatal("POSTHOG_ANALYTICS_API_KEY must not be forwarded")
+		}
+		ns := env["POD_NAMESPACE"]
+		if ns.ValueFrom == nil || ns.ValueFrom.FieldRef == nil || ns.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+			t.Fatalf("POD_NAMESPACE downward API = %+v", ns)
+		}
+	})
+
+	t.Run("literal value is not copied", func(t *testing.T) {
+		pool, _ := newTestK8sPool(t, 5)
+		setCPPodNamedEnv(t, pool, []corev1.EnvVar{
+			{Name: "POSTHOG_API_KEY", Value: "phc_literal_must_not_appear"},
+			{Name: "POSTHOG_HOST", Value: "us.i.posthog.com"},
+		}, nil)
+		loadPostHogFromPODNAME(t, pool)
+
+		env := envByName(captureSpawnedWorkerEnv(t, pool))
+		if got, ok := env["POSTHOG_API_KEY"]; ok {
+			t.Fatalf("literal POSTHOG_API_KEY was copied onto the worker: %+v", got)
+		}
+		if env["POSTHOG_HOST"].Value != "us.i.posthog.com" {
+			t.Fatalf("POSTHOG_HOST should still copy: %+v", env["POSTHOG_HOST"])
+		}
+	})
+}
+
+// TestWorkerSpawnOmitsPostHogWhenCPHasOnlyEnvFrom pins that envFrom is
+// insufficient: a Pod GET does not resolve those keys, and we must not invent
+// a plaintext value: from os.Getenv.
+func TestWorkerSpawnOmitsPostHogWhenCPHasOnlyEnvFrom(t *testing.T) {
+	t.Setenv("POSTHOG_API_KEY", "phc_from_process_env_must_not_be_invented")
+	pool, _ := newTestK8sPool(t, 5)
+	setCPPodNamedEnv(t, pool, nil, []corev1.EnvFromSource{{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "duckgres-posthog"},
+		},
+	}})
+	loadPostHogFromPODNAME(t, pool)
+
+	env := envByName(captureSpawnedWorkerEnv(t, pool))
+	if got, ok := env["POSTHOG_API_KEY"]; ok {
+		t.Fatalf("envFrom-only CP must not invent POSTHOG_API_KEY on the worker: %+v", got)
+	}
+}
+
+// TestWorkerSpawnSucceedsWhenCPPodGetFails: a missing CP pod (or empty
+// POD_NAME) must not fail spawn. Workers just will not export.
+func TestWorkerSpawnSucceedsWhenCPPodGetFails(t *testing.T) {
+	t.Run("get fails", func(t *testing.T) {
+		pool, _ := newTestK8sPool(t, 5)
+		t.Setenv("POD_NAME", "no-such-cp-pod")
+		pool.loadPostHogLogEnv(context.Background())
+
+		env := envByName(captureSpawnedWorkerEnv(t, pool))
+		if got, ok := env["POSTHOG_API_KEY"]; ok {
+			t.Fatalf("failed CP Get must omit POSTHOG_API_KEY, got %+v", got)
+		}
+	})
+
+	t.Run("POD_NAME empty", func(t *testing.T) {
+		pool, _ := newTestK8sPool(t, 5)
+		if err := os.Unsetenv("POD_NAME"); err != nil {
+			t.Fatal(err)
+		}
+		pool.loadPostHogLogEnv(context.Background())
+
+		env := envByName(captureSpawnedWorkerEnv(t, pool))
+		if got, ok := env["POSTHOG_API_KEY"]; ok {
+			t.Fatalf("empty POD_NAME must omit POSTHOG_API_KEY, got %+v", got)
+		}
+	})
+}

--- a/controlplane/otlp_export.go
+++ b/controlplane/otlp_export.go
@@ -1,0 +1,127 @@
+package controlplane
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/posthog/duckgres/internal/cliboot"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// otlpLogExportFailuresTotal is scraped on the CP only. Labels are
+// {source,reason} — never {org}. source=cp is this process's exporter
+// (otel.SetErrorHandler). source=worker is the last-seen *delta* of
+// worker health JSON otlp_export_failures.
+var otlpLogExportFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "duckgres_otlp_log_export_failures_total",
+	Help: "OTLP log export failures. source=cp is this process; source=worker is rolled up from worker health checks. No org label.",
+}, []string{"source", "reason"})
+
+const (
+	otlpExportSourceCP      = "cp"
+	otlpExportSourceWorker  = "worker"
+	otlpExportReasonWorker  = "worker"
+	otlpExportReasonExport  = "export"
+	otlpExportReasonTimeout = "timeout"
+	otlpExportReasonAuth    = "auth"
+)
+
+func init() {
+	cliboot.SetOTLPErrorHook(func(err error) {
+		observeOTLPExportFailures(otlpExportSourceCP, classifyOTLPError(err), 1)
+	})
+}
+
+func observeOTLPExportFailures(source, reason string, n int64) {
+	if n <= 0 {
+		return
+	}
+	if source == "" {
+		source = otlpExportSourceCP
+	}
+	if reason == "" {
+		reason = otlpExportReasonExport
+	}
+	otlpLogExportFailuresTotal.WithLabelValues(source, reason).Add(float64(n))
+}
+
+func classifyOTLPError(err error) string {
+	if err == nil {
+		return otlpExportReasonExport
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "timeout") || strings.Contains(s, "deadline"):
+		return otlpExportReasonTimeout
+	case strings.Contains(s, "unauthorized") || strings.Contains(s, "forbidden") ||
+		strings.Contains(s, "401") || strings.Contains(s, "403"):
+		return otlpExportReasonAuth
+	default:
+		return otlpExportReasonExport
+	}
+}
+
+// otlpExportFailureRollup converts a worker's process-lifetime monotonic
+// failure count into CP-scrape deltas. Old workers omit the field (nil) and
+// must not be treated as 0 (that would spike on the first modern worker).
+type otlpExportFailureRollup struct {
+	mu       sync.Mutex
+	lastSeen map[int]int64
+}
+
+func newOTLPExportFailureRollup() *otlpExportFailureRollup {
+	return &otlpExportFailureRollup{lastSeen: make(map[int]int64)}
+}
+
+var workerOTLPExportRollup = newOTLPExportFailureRollup()
+
+func (r *otlpExportFailureRollup) observeFromHealth(workerID int, hc *healthCheckResult) {
+	if r == nil || hc == nil {
+		return
+	}
+	r.observe(workerID, hc.OTLPExportFailures)
+}
+
+func (r *otlpExportFailureRollup) observe(workerID int, n *int64) {
+	if r == nil || n == nil {
+		return
+	}
+	val := *n
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastSeen == nil {
+		r.lastSeen = make(map[int]int64)
+	}
+	last, seen := r.lastSeen[workerID]
+	if !seen {
+		observeOTLPExportFailures(otlpExportSourceWorker, otlpExportReasonWorker, val)
+		r.lastSeen[workerID] = val
+		return
+	}
+	if val >= last {
+		observeOTLPExportFailures(otlpExportSourceWorker, otlpExportReasonWorker, val-last)
+		r.lastSeen[workerID] = val
+		return
+	}
+	// Worker process restart (counter reset): treat last as 0, then Add(n).
+	observeOTLPExportFailures(otlpExportSourceWorker, otlpExportReasonWorker, val)
+	r.lastSeen[workerID] = val
+}
+
+func (r *otlpExportFailureRollup) forget(workerID int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	delete(r.lastSeen, workerID)
+	r.mu.Unlock()
+}
+
+func observeWorkerOTLPExportFromHealth(workerID int, hc *healthCheckResult) {
+	workerOTLPExportRollup.observeFromHealth(workerID, hc)
+}
+
+func forgetWorkerOTLPExport(workerID int) {
+	workerOTLPExportRollup.forget(workerID)
+}

--- a/controlplane/otlp_export_test.go
+++ b/controlplane/otlp_export_test.go
@@ -1,0 +1,78 @@
+package controlplane
+
+import (
+	"testing"
+)
+
+func TestOTLPExportFailureRollupFirstSeeAddsN(t *testing.T) {
+	r := newOTLPExportFailureRollup()
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	n := int64(3)
+	r.observe(7, &n)
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	if delta := after - before; delta != 3 {
+		t.Fatalf("first see Add(n): delta=%v want 3", delta)
+	}
+}
+
+func TestOTLPExportFailureRollupAddsDeltaOnly(t *testing.T) {
+	r := newOTLPExportFailureRollup()
+	n := int64(2)
+	r.observe(1, &n)
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	n = 5
+	r.observe(1, &n)
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	if delta := after - before; delta != 3 {
+		t.Fatalf("n>=last Add(n-last): delta=%v want 3", delta)
+	}
+}
+
+func TestOTLPExportFailureRollupRestartTreatsLastAsZero(t *testing.T) {
+	r := newOTLPExportFailureRollup()
+	n := int64(9)
+	r.observe(2, &n)
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	n = 2
+	r.observe(2, &n)
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	if delta := after - before; delta != 2 {
+		t.Fatalf("restart n<last must Add(n) not Add(n-last): delta=%v want 2", delta)
+	}
+}
+
+func TestOTLPExportFailureRollupOmitsMissingField(t *testing.T) {
+	r := newOTLPExportFailureRollup()
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	r.observe(3, nil)
+	r.observeFromHealth(3, &healthCheckResult{})
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	if after != before {
+		t.Fatalf("omitted otlp_export_failures must not invent 0 then spike: before=%v after=%v", before, after)
+	}
+}
+
+func TestOTLPExportFailureRollupForgetThenFirstSee(t *testing.T) {
+	r := newOTLPExportFailureRollup()
+	n := int64(4)
+	r.observe(9, &n)
+	r.forget(9)
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	n = 4
+	r.observe(9, &n)
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceWorker, otlpExportReasonWorker)
+	if delta := after - before; delta != 4 {
+		t.Fatalf("after forget, next see is first see Add(n): delta=%v want 4", delta)
+	}
+}
+
+func TestObserveOTLPExportFailureHasNoOrgLabel(t *testing.T) {
+	// Label set is {source,reason} only — constructing with those two must work
+	// and there is no org dimension on the vec.
+	before := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceCP, otlpExportReasonExport)
+	observeOTLPExportFailures(otlpExportSourceCP, otlpExportReasonExport, 1)
+	after := counterVecLabelValue(t, otlpLogExportFailuresTotal, otlpExportSourceCP, otlpExportReasonExport)
+	if after-before != 1 {
+		t.Fatalf("cp/export increment: before=%v after=%v", before, after)
+	}
+}

--- a/controlplane/pod_env.go
+++ b/controlplane/pod_env.go
@@ -1,0 +1,102 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"log/slog"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// posthogLogEnvAllowlist is copied onto worker and reshard pods from the CP
+// container's named env (never envFrom, never os.Getenv → value:).
+// ADDITIONAL_POSTHOG_API_KEYS and POSTHOG_ANALYTICS_API_KEY stay CP-only.
+var posthogLogEnvAllowlist = []string{
+	"POSTHOG_API_KEY",
+	"POSTHOG_HOST",
+	"DUCKGRES_POSTHOG_LOG_LEVEL",
+	"DUCKGRES_POSTHOG_LOG_INFO_SAMPLE",
+	"DUCKGRES_POSTHOG_LOG_QUERY_TEXT",
+	"DUCKGRES_IDENTIFIER",
+}
+
+var refusePostHogAPIKeyValueOnce sync.Once
+
+// copyAllowlistedEnv DeepCopies named entries from src. Missing names are
+// omitted. POSTHOG_API_KEY is copied only as a secretKeyRef — a literal
+// value: is refused so the token never appears in a child pod spec.
+func copyAllowlistedEnv(src []corev1.EnvVar, allowlist []string) []corev1.EnvVar {
+	byName := make(map[string]corev1.EnvVar, len(src))
+	for i := range src {
+		byName[src[i].Name] = src[i]
+	}
+	var out []corev1.EnvVar
+	for _, name := range allowlist {
+		e, ok := byName[name]
+		if !ok {
+			continue
+		}
+		if name == "POSTHOG_API_KEY" && !envIsSecretKeyRef(e) {
+			if e.Value != "" {
+				refusePostHogAPIKeyValueOnce.Do(func() {
+					slog.Warn("refusing to materialize POSTHOG_API_KEY as a pod spec value")
+				})
+			}
+			continue
+		}
+		out = append(out, *e.DeepCopy())
+	}
+	return out
+}
+
+func envIsSecretKeyRef(e corev1.EnvVar) bool {
+	return e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil && e.ValueFrom.SecretKeyRef.Name != ""
+}
+
+func filterPostHogLogEnv(src []corev1.EnvVar) []corev1.EnvVar {
+	return copyAllowlistedEnv(src, posthogLogEnvAllowlist)
+}
+
+func envHasName(env []corev1.EnvVar, name string) bool {
+	for i := range env {
+		if env[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func namedPostHogAPIKey(env []corev1.EnvVar) (present, secretRef bool) {
+	for i := range env {
+		if env[i].Name == "POSTHOG_API_KEY" {
+			return true, envIsSecretKeyRef(env[i])
+		}
+	}
+	return false, false
+}
+
+// downwardAPIIdentityEnv stamps pod/node/namespace onto child pods next to
+// the existing POD_NAME / NODE_NAME Downward API fields.
+func downwardAPIIdentityEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		},
+	}
+}

--- a/controlplane/reshard_pod.go
+++ b/controlplane/reshard_pod.go
@@ -63,6 +63,12 @@ var reshardPodEnvAllowlist = []string{
 	"DUCKGRES_RESHARD_FLIP_TIMEOUT",
 	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 	"OTEL_EXPORTER_OTLP_TRACES_PATH",
+	"POSTHOG_API_KEY",
+	"POSTHOG_HOST",
+	"DUCKGRES_POSTHOG_LOG_LEVEL",
+	"DUCKGRES_POSTHOG_LOG_INFO_SAMPLE",
+	"DUCKGRES_POSTHOG_LOG_QUERY_TEXT",
+	"DUCKGRES_IDENTIFIER",
 }
 
 // ReshardPodName is the deterministic per-operation pod name.
@@ -172,30 +178,10 @@ func (s *ReshardPodSpawner) SpawnReshardPod(ctx context.Context, op *configstore
 
 	// Inherit the allowlisted env VERBATIM — a secretKeyRef stays a
 	// secretKeyRef; nothing secret is copied by value into the pod spec.
-	var env []corev1.EnvVar
-	for _, name := range reshardPodEnvAllowlist {
-		for i := range cpContainer.Env {
-			if cpContainer.Env[i].Name == name {
-				env = append(env, *cpContainer.Env[i].DeepCopy())
-				break
-			}
-		}
-	}
-	env = append(env,
-		corev1.EnvVar{Name: "DUCKGRES_RESHARD_OP_ID", Value: strconv.FormatInt(op.ID, 10)},
-		corev1.EnvVar{
-			Name: "POD_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-			},
-		},
-		corev1.EnvVar{
-			Name: "NODE_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-			},
-		},
-	)
+	// POSTHOG_API_KEY is copied only as a secretKeyRef (see copyAllowlistedEnv).
+	env := copyAllowlistedEnv(cpContainer.Env, reshardPodEnvAllowlist)
+	env = append(env, corev1.EnvVar{Name: "DUCKGRES_RESHARD_OP_ID", Value: strconv.FormatInt(op.ID, 10)})
+	env = append(env, downwardAPIIdentityEnv()...)
 	// The password pull URL (ext targets only; the URL is on the op row so a
 	// reconciler respawn re-wires the same handoff).
 	if op.PasswordURL != "" {

--- a/controlplane/reshard_pod_test.go
+++ b/controlplane/reshard_pod_test.go
@@ -41,6 +41,19 @@ func fakeCPPod() *corev1.Pod {
 						{Name: "DUCKGRES_CONFIG_POLL_INTERVAL", Value: "5s"},
 						{Name: "DUCKGRES_K8S_WORKER_IMAGE", Value: "must-not-leak"},
 						{Name: "DUCKGRES_USER_SECRET_KEY", Value: "must-not-leak"},
+						{
+							Name: "POSTHOG_API_KEY",
+							ValueFrom: &corev1.EnvVarSource{
+								SecretKeyRef: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "duckgres-posthog"},
+									Key:                  "api-key",
+								},
+							},
+						},
+						{Name: "POSTHOG_HOST", Value: "us.i.posthog.com"},
+						{Name: "DUCKGRES_POSTHOG_LOG_LEVEL", Value: "warn"},
+						{Name: "ADDITIONAL_POSTHOG_API_KEYS", Value: "phc_must_not_copy"},
+						{Name: "POSTHOG_ANALYTICS_API_KEY", Value: "phc_analytics_only"},
 					},
 				},
 			},
@@ -120,6 +133,10 @@ func TestSpawnReshardPodSpec(t *testing.T) {
 			t.Fatalf("non-allowlisted CP env %s leaked into the runner pod", name)
 		}
 	}
+	ns := env["POD_NAMESPACE"]
+	if ns.ValueFrom == nil || ns.ValueFrom.FieldRef == nil || ns.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+		t.Fatalf("POD_NAMESPACE downward API = %+v", ns)
+	}
 
 	// Default resource shape 2 CPU / 8Gi, requests=limits.
 	cpu := c.Resources.Requests[corev1.ResourceCPU]
@@ -171,6 +188,38 @@ func TestSpawnReshardPodRejectsInvalidResourceKnobsWithoutPanicking(t *testing.T
 	err := s.SpawnReshardPod(context.Background(), &configstore.ReshardOperation{ID: 8})
 	if err == nil || !strings.Contains(err.Error(), "invalid reshard pod") {
 		t.Fatalf("error = %v, want invalid reshard pod resource error", err)
+	}
+}
+
+// TestReshardAllowlistIncludesPostHog pins the PostHog log env names on the
+// runner allowlist: secretKeyRef is copied as a ref, extra analytics keys are
+// not forwarded.
+func TestReshardAllowlistIncludesPostHog(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset(fakeCPPod())
+	s := NewReshardPodSpawner(cs, "duckgres", "duckgres-control-plane-abc-xyz", "", "")
+	if err := s.SpawnReshardPod(context.Background(), &configstore.ReshardOperation{ID: 11}); err != nil {
+		t.Fatalf("SpawnReshardPod: %v", err)
+	}
+	pod, err := cs.CoreV1().Pods("duckgres").Get(context.Background(), "duckgres-reshard-op-11", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	env := envByName(pod.Spec.Containers[0].Env)
+	key := env["POSTHOG_API_KEY"]
+	if key.Value != "" || key.ValueFrom == nil || key.ValueFrom.SecretKeyRef == nil ||
+		key.ValueFrom.SecretKeyRef.Name != "duckgres-posthog" || key.ValueFrom.SecretKeyRef.Key != "api-key" {
+		t.Fatalf("POSTHOG_API_KEY not copied as secretKeyRef: %+v", key)
+	}
+	if env["POSTHOG_HOST"].Value != "us.i.posthog.com" {
+		t.Fatalf("POSTHOG_HOST = %+v", env["POSTHOG_HOST"])
+	}
+	if env["DUCKGRES_POSTHOG_LOG_LEVEL"].Value != "warn" {
+		t.Fatalf("DUCKGRES_POSTHOG_LOG_LEVEL = %+v", env["DUCKGRES_POSTHOG_LOG_LEVEL"])
+	}
+	for _, name := range []string{"ADDITIONAL_POSTHOG_API_KEYS", "POSTHOG_ANALYTICS_API_KEY"} {
+		if _, leaked := env[name]; leaked {
+			t.Fatalf("%s must not be on the reshard allowlist", name)
+		}
 	}
 }
 

--- a/controlplane/worker_mgr.go
+++ b/controlplane/worker_mgr.go
@@ -594,6 +594,10 @@ type healthCheckResult struct {
 	// log names the bug instead of just reporting "unhealthy".
 	InstanceInvalidReason string                          `json:"instance_invalid_reason"`
 	SessionProgress       map[string]*sessionProgressJSON `json:"session_progress"`
+	// OTLPExportEnabled / OTLPExportFailures are optional (old workers omit
+	// them). Failures is process-lifetime monotonic. Pointers so omit ≠ 0.
+	OTLPExportEnabled  *bool  `json:"otlp_export_enabled"`
+	OTLPExportFailures *int64 `json:"otlp_export_failures"`
 }
 
 // toSessionProgress converts wire-format progress data to SessionProgress values.
@@ -969,6 +973,7 @@ func (p *FlightWorkerPool) RetireWorker(id int) {
 	workerCount := len(p.workers)
 	p.mu.Unlock()
 	observeControlPlaneWorkers(workerCount)
+	forgetWorkerOTLPExport(id)
 
 	// Run the actual process cleanup asynchronously so DestroySession
 	// doesn't block the connection handler goroutine for up to 3s+.
@@ -997,6 +1002,7 @@ func (p *FlightWorkerPool) RetireWorkerIfNoSessions(id int) bool {
 		workerCount := len(p.workers)
 		p.mu.Unlock()
 		observeControlPlaneWorkers(workerCount)
+		forgetWorkerOTLPExport(id)
 		go p.retireWorkerProcess(w)
 		return true
 	}
@@ -1207,6 +1213,9 @@ func (p *FlightWorkerPool) HealthCheckLoop(ctx context.Context, interval time.Du
 							hcResult, healthErr = doHealthCheck(hctx, w.client)
 							cancel()
 						}()
+						if hcResult != nil {
+							observeWorkerOTLPExportFromHealth(w.ID, hcResult)
+						}
 						err := healthErr
 
 						if err != nil {

--- a/duckdbservice/flight_handler.go
+++ b/duckdbservice/flight_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	bindings "github.com/duckdb/duckdb-go-bindings"
+	"github.com/posthog/duckgres/internal/cliboot"
 	"github.com/posthog/duckgres/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -471,6 +472,8 @@ func (h *FlightSQLHandler) doHealthCheck(body []byte, stream flight.FlightServic
 		"session_progress":        sessionProgress,
 		"instance_invalidated":    instanceInvalidated,
 		"instance_invalid_reason": h.pool.InstanceInvalidReason(),
+		"otlp_export_enabled":     cliboot.OTLPExportEnabled(),
+		"otlp_export_failures":    cliboot.OTLPExportFailures(),
 	})
 	return sendActionResult(stream, &flight.Result{Body: resp})
 }

--- a/duckdbservice/flight_handler_test.go
+++ b/duckdbservice/flight_handler_test.go
@@ -460,6 +460,41 @@ func TestHealthCheckReportsDraining(t *testing.T) {
 	}
 }
 
+func TestHealthCheckReportsOTLPExportFields(t *testing.T) {
+	pool := &SessionPool{
+		sessions:    make(map[string]*Session),
+		stopRefresh: make(map[string]func()),
+		warmupDone:  make(chan struct{}),
+		startTime:   time.Now(),
+	}
+	close(pool.warmupDone)
+	handler := &FlightSQLHandler{pool: pool, alloc: memory.DefaultAllocator}
+	stream := &mockDoActionStream{}
+	if err := handler.doHealthCheck([]byte(`{}`), stream); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(stream.results[0].Body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp["otlp_export_enabled"]; !ok {
+		t.Fatal("health JSON missing otlp_export_enabled")
+	}
+	if _, ok := resp["otlp_export_failures"]; !ok {
+		t.Fatal("health JSON missing otlp_export_failures")
+	}
+	if enabled, ok := resp["otlp_export_enabled"].(bool); !ok {
+		t.Fatalf("otlp_export_enabled type %T", resp["otlp_export_enabled"])
+	} else if enabled {
+		t.Fatal("export is off in this test process; otlp_export_enabled must be false")
+	}
+	if n, ok := resp["otlp_export_failures"].(float64); !ok {
+		t.Fatalf("otlp_export_failures type %T", resp["otlp_export_failures"])
+	} else if n < 0 {
+		t.Fatalf("otlp_export_failures = %v, want >= 0", n)
+	}
+}
+
 func TestHealthCheckAcceptsMismatchedEpochInSharedWarmMode(t *testing.T) {
 	pool := &SessionPool{
 		sessions:          make(map[string]*Session),

--- a/internal/cliboot/logging.go
+++ b/internal/cliboot/logging.go
@@ -370,6 +370,7 @@ func InitLogging(bi BuildInfo) func() {
 
 	opts := append(processors, sdklog.WithResource(res))
 	provider := sdklog.NewLoggerProvider(opts...)
+	markOTLPExportEnabled()
 
 	otelHandler := otelslog.NewHandler("duckgres", otelslog.WithLoggerProvider(provider))
 	posthog := newPostHogBranch(otelHandler, parsePostHogLogLevel(), parsePostHogInfoSample(), parsePostHogQueryText())

--- a/internal/cliboot/otlp_export.go
+++ b/internal/cliboot/otlp_export.go
@@ -1,0 +1,68 @@
+package cliboot
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel"
+)
+
+// Process-lifetime OTLP log-export state. Workers report these on the
+// health-check JSON (they do not serve Prometheus). The CP rolls worker
+// counts up via last-seen deltas.
+var (
+	otlpExportEnabled  atomic.Bool
+	otlpExportFailures atomic.Int64
+	lastOTLPErrLog     atomic.Int64
+	otlpErrorHook      atomic.Pointer[func(error)]
+	otlpErrorHandler   sync.Once
+)
+
+// OTLPExportEnabled is true when this process has a live PostHog OTLP exporter.
+func OTLPExportEnabled() bool { return otlpExportEnabled.Load() }
+
+// OTLPExportFailures is the process-lifetime monotonic export-failure count.
+func OTLPExportFailures() int64 { return otlpExportFailures.Load() }
+
+// SetOTLPErrorHook registers an extra observer (the CP increments its
+// Prometheus series). Workers leave this unset.
+func SetOTLPErrorHook(fn func(error)) {
+	if fn == nil {
+		otlpErrorHook.Store(nil)
+		return
+	}
+	otlpErrorHook.Store(&fn)
+}
+
+func markOTLPExportEnabled() {
+	otlpExportEnabled.Store(true)
+	installOTLPErrorHandler()
+}
+
+func installOTLPErrorHandler() {
+	otlpErrorHandler.Do(func() {
+		otel.SetErrorHandler(otel.ErrorHandlerFunc(handleOTLPError))
+	})
+}
+
+func handleOTLPError(err error) {
+	if err == nil {
+		return
+	}
+	otlpExportFailures.Add(1)
+	if hook := otlpErrorHook.Load(); hook != nil && *hook != nil {
+		(*hook)(err)
+	}
+	// Never slog here: the exporter callback must not recurse into OTLP.
+	now := time.Now().UnixNano()
+	last := lastOTLPErrLog.Load()
+	if last != 0 && now-last < int64(time.Minute) {
+		return
+	}
+	if lastOTLPErrLog.CompareAndSwap(last, now) {
+		fmt.Fprintf(os.Stderr, "PostHog OTLP log export failed: %v\n", err)
+	}
+}


### PR DESCRIPTION
## Summary

Worker and reshard pods get the same PostHog log export config as the control plane, without putting the project token in the pod spec as a plaintext `value:` — and without failing spawn if the logging env is missing.

- Cache allowlisted named env from `Get(namespace, POD_NAME)` once at pool start. `SecretKeyRef` is resolved when the **worker** pod starts.
- `POSTHOG_API_KEY` is copied only as `valueFrom.secretKeyRef`. A literal `value:` is refused. `envFrom` is not invented-around (unit test: CP pod with only `envFrom` → worker has no key).
- Missing `POD_NAME`, Get failure, or missing named env: one WARN (`PostHog log env not found on CP pod spec; workers will not export.`) and omit. **Never fail spawn.**
- Allowlist: `POSTHOG_API_KEY`, `POSTHOG_HOST`, `DUCKGRES_POSTHOG_LOG_*`, `DUCKGRES_IDENTIFIER`. Do **not** forward `ADDITIONAL_POSTHOG_API_KEYS` or `POSTHOG_ANALYTICS_API_KEY`.
- Reshard allowlist uses the same copy helper. Inject Downward API `POD_NAMESPACE` next to `POD_NAME`/`NODE_NAME`.
- Health-check JSON grows `otlp_export_enabled` + `otlp_export_failures` (process-lifetime monotonic). CP stores last-seen per worker and `Add(delta)` only (restart → treat last as 0 then `Add(n)`). Metric: `duckgres_otlp_log_export_failures_total{source,reason}` — **no `{org}`**. Workers do not call `InitMetrics`.

Rebased onto current `main` after #1081 / #1088 / #1089. Keeps #1080 org-local worker placement affinity; worker env construction now lives in `workerPodEnv`. Replaces stacked #1084.

Design: `docs/design/posthog-logs-multitenant.md` (Key Decisions 5/12).

## Test plan

- [x] `go test -tags kubernetes ./controlplane` — `TestWorkerSpawnPostHogEnvIsSecretRef`, `TestWorkerSpawnOmitsPostHogWhenCPHasOnlyEnvFrom`, `TestWorkerSpawnSucceedsWhenCPPodGetFails`, `TestReshardAllowlistIncludesPostHog`
- [x] `go test ./controlplane ./duckdbservice ./internal/cliboot` — health JSON fields + last-seen delta roll-up
- [ ] Charts follow-up: named `POSTHOG_API_KEY` `secretKeyRef` on the CP Deployment (not mergeable here)