### PR TITLE
feat(server): reader-path and compaction DuckLake metadata indexes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1916,6 +1916,12 @@ type duckLakeMetadataIndex struct {
 // duckLakeMetadataIndexes lists indexes that improve DuckDB postgres scanner
 // performance. The scanner uses COPY with ctid batches and pushes down filters,
 // but without indexes each batch requires a sequential scan.
+//
+// Keep in sync with the catalog-maintenance side of the house: the same index
+// set (under ducklake_*_idx names) is applied to shared/standalone catalogs by
+// the DuckLake maintenance tooling (PostHog/millpond, tools/ducklake_maintenance.py
+// CATALOG_INDEXES). The two never overlap here because workers attach per-tenant
+// catalogs, not the shared one.
 var duckLakeMetadataIndexes = []duckLakeMetadataIndex{
 	// Critical: ducklake_file_column_stats is often the largest table (millions of rows).
 	// Filter pushdown CTEs query by (table_id, column_id) on every query.
@@ -1944,6 +1950,39 @@ var duckLakeMetadataIndexes = []duckLakeMetadataIndex{
 	{
 		name: "idx_ducklake_data_file_tbl_snap",
 		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_data_file_tbl_snap ON ducklake_data_file (table_id, begin_snapshot, end_snapshot)",
+	},
+	// Per-file and table-scoped per-file reads of the stats/partition side
+	// tables. Those tables have no index at all in the stock DuckLake schema,
+	// so per-snapshot file listings seq-scan them once they grow (measured:
+	// minutes per listing on a shared catalog with ~10^8 stats rows). The
+	// (table_id, data_file_id) composites serve `WHERE table_id = ? AND
+	// data_file_id IN (...)` fetches; the solo data_file_id indexes serve
+	// per-file lookups.
+	{
+		name: "idx_ducklake_file_col_stats_file",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_file_col_stats_file ON ducklake_file_column_stats (data_file_id)",
+	},
+	{
+		name: "idx_ducklake_file_col_stats_tbl_file",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_file_col_stats_tbl_file ON ducklake_file_column_stats (table_id, data_file_id)",
+	},
+	{
+		name: "idx_ducklake_file_part_val_file",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_file_part_val_file ON ducklake_file_partition_value (data_file_id)",
+	},
+	{
+		name: "idx_ducklake_file_part_val_tbl_file",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_file_part_val_tbl_file ON ducklake_file_partition_value (table_id, data_file_id)",
+	},
+	// Live-file scans ordered by size (compaction / metrics): partial on
+	// end_snapshot IS NULL so expired files never bloat the index.
+	{
+		name: "idx_ducklake_data_file_compaction",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_data_file_compaction ON ducklake_data_file (table_id, end_snapshot, file_size_bytes) WHERE end_snapshot IS NULL",
+	},
+	{
+		name: "idx_ducklake_delete_file_compaction",
+		stmt: "CREATE INDEX IF NOT EXISTS idx_ducklake_delete_file_compaction ON ducklake_delete_file (table_id, end_snapshot, file_size_bytes) WHERE end_snapshot IS NULL",
 	},
 	{
 		name: "idx_ducklake_delete_file_tbl_snap",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -410,6 +410,20 @@ func TestDuckLakeMetadataIndexesNamesMatchStatements(t *testing.T) {
 	if _, ok := seen["idx_ducklake_schema_versions_tbl_schema_version"]; !ok {
 		t.Errorf("expected ducklake_schema_versions table/schema_version index")
 	}
+	// Reader-path indexes (per-file lookups and table-scoped per-file fetches)
+	// plus the live-file compaction scans.
+	for _, name := range []string{
+		"idx_ducklake_file_col_stats_file",
+		"idx_ducklake_file_col_stats_tbl_file",
+		"idx_ducklake_file_part_val_file",
+		"idx_ducklake_file_part_val_tbl_file",
+		"idx_ducklake_data_file_compaction",
+		"idx_ducklake_delete_file_compaction",
+	} {
+		if _, ok := seen[name]; !ok {
+			t.Errorf("expected index %q in duckLakeMetadataIndexes", name)
+		}
+	}
 }
 
 func TestStartCredentialRefresh_NoOpForStaticCredentials(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends the worker-side `ensureDuckLakeMetadataIndexes` with the index shapes learned from running a ClickHouse DuckLake reader against a large shared catalog (see PostHog/charts#14353 for the deployment and PostHog/millpond#121 for the catalog-maintenance side).

## Changes

Six new entries in `duckLakeMetadataIndexes`:

- `idx_ducklake_file_col_stats_file` / `idx_ducklake_file_part_val_file` — per-file lookups by `data_file_id`. The stock DuckLake schema has no index on the stats/partition side tables at all, so per-snapshot file listings seq-scan them (measured in minutes once the stats table reached ~10^8 rows on a shared catalog).
- `idx_ducklake_file_col_stats_tbl_file` / `idx_ducklake_file_part_val_tbl_file` — `(table_id, data_file_id)` composites for the reader's table-scoped fetch shape (`WHERE table_id = ? AND data_file_id IN (...)`).
- `idx_ducklake_data_file_compaction` / `idx_ducklake_delete_file_compaction` — partial indexes on `(table_id, end_snapshot, file_size_bytes) WHERE end_snapshot IS NULL` for live-file compaction/metrics scans; expired files never bloat the index.

Names follow the existing `idx_ducklake_*` convention, and a comment cross-references the same set as applied to shared/standalone catalogs by the millpond maintenance tooling (`CATALOG_INDEXES` in `tools/ducklake_maintenance.py`). The two never collide in practice: workers attach per-tenant catalogs, not the shared one.

## Testing

- TDD per repo convention: extended `TestDuckLakeMetadataIndexesNamesMatchStatements` first (red), then the list (green).
- `go test ./server/` green; `just lint` clean.

Agent-authored (Shelley on exe.dev).
