### PR TITLE
fix(admin): open the daily-usage window at the UTC day boundary

### DIFF
--- a/controlplane/admin/usage_api.go
+++ b/controlplane/admin/usage_api.go
@@ -185,7 +185,12 @@ func (h *usageAPIHandler) getDailyUsage(c *gin.Context) {
 		}
 		days = n
 	}
-	from := h.now().UTC().AddDate(0, 0, -(days - 1)) // today plus (days-1) prior days
+	// The window opens at the START of the UTC day (days-1) days before today —
+	// the rows are day-grained, so a mid-day cutoff would silently drop the
+	// morning of the leftmost day, and for days=1 would open the window at the
+	// current second and show nothing at all (mw-dev e2e regression).
+	now := h.now().UTC()
+	from := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(days - 1))
 
 	compute, err := h.store.AggregateComputeUsageDaily(orgID, from)
 	if err != nil {

--- a/controlplane/admin/usage_api_test.go
+++ b/controlplane/admin/usage_api_test.go
@@ -308,14 +308,26 @@ func TestDailyUsageWindowAndValidation(t *testing.T) {
 	store := &fakeMonthlyUsageStore{}
 	r := setupUsageRouterAt(store, now)
 
-	// days=7 from mid-Aug-15 → window opens 2026-08-09 (7 x 24h back), not at a
-	// month boundary — day granularity means partial days at both edges.
+	// days=7 on Aug-15 (any time of day) → window opens at the START of the
+	// UTC day 6 days back, 2026-08-09T00:00Z. Truncating to the day boundary
+	// is load-bearing: without it, days=1 opens the window at the current
+	// SECOND and excludes every bucket written earlier today (the mw-dev e2e
+	// caught exactly that against the real stack).
 	code, _ := usageRequest(t, r, "/api/v1/orgs/acme/usage/daily?days=7")
 	if code != http.StatusOK {
 		t.Fatalf("status %d", code)
 	}
-	if want := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC); !store.lastDailyFrom.Equal(want) {
-		t.Fatalf("from = %s, want %s", store.lastDailyFrom, want)
+	if want := time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC); !store.lastDailyFrom.Equal(want) {
+		t.Fatalf("from = %s, want %s (start of UTC day)", store.lastDailyFrom, want)
+	}
+
+	// days=1 must cover ALL of today, not just the current second.
+	code, _ = usageRequest(t, r, "/api/v1/orgs/acme/usage/daily?days=1")
+	if code != http.StatusOK {
+		t.Fatalf("status %d", code)
+	}
+	if want := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC); !store.lastDailyFrom.Equal(want) {
+		t.Fatalf("days=1: from = %s, want %s (start of today UTC)", store.lastDailyFrom, want)
 	}
 
 	for _, bad := range []string{"0", "-1", "abc", "32"} {


### PR DESCRIPTION
## Summary

Fixes the bug the mw-dev e2e caught on the first run of #1098's new `usage-daily` assertion ([failed run](https://github.com/PostHog/duckgres/actions/runs/32182150332)):

`GET /orgs/:id/usage/daily` computed its window as `now − (days−1)` with **no day-boundary truncation**. For `days=1` the window opened at the current *second*, excluding every bucket written earlier today — the org detail page's charts rendered empty for fresh usage (e2e response: `"from":"2026-08-18T20:46:32Z", "rows":[]`).

Fix: truncate to the start of the UTC day (days−1) days back, mirroring how the monthly endpoint truncates to the month boundary.

## Testing

- Updated `TestDailyUsageWindowAndValidation` pins the day-boundary truncation AND the `days=1` covers-all-of-today case. The prior version pinned the wrong expectation — its fake store ignores `from`, so only the real-cluster e2e could catch this (which it did).
- The existing `usage-daily` harness assertion is the regression net that caught it; it stays as-is.

`just lint` clean; admin package green.