### PR TITLE
admin console: pricing-sensitivity calculator on the Usage page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1119,6 +1119,14 @@ touching this path:
   GC'd, so responses carry the ack cursor as `watermark_low` and the UI
   shows the retention caveat instead of implying all-time totals. They add NO
   second accounting pipeline — keep them pure reads over the buffer.
+  The Usage page also carries a **client-side pricing-sensitivity calculator**
+  (`ui/src/pages/UsagePricing.tsx` + `lib/pricing.ts`): named unit-price
+  scenarios ($/CPU-min, $/GiB·min, $/GiB·h) priced against each org's month
+  totals. It is pure browser math over the monthly rows — no endpoint, no
+  persistence beyond the operator's own localStorage — so it inherits the
+  page's admin-only gate and needs no server-side access control of its own
+  (a PM gets it by holding the console admin role; a lighter pricing-viewer
+  role is a named follow-up, not implemented).
 - Touching the meter/flush/API/GC, the worker-size or query-source plumbing,
   the storage sampler, or the bucket keys → update
   `controlplane/compute_meter_test.go`, `compute_billing_api_test.go`,

--- a/controlplane/admin/ui/src/lib/pricing.test.ts
+++ b/controlplane/admin/ui/src/lib/pricing.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { fmtMoney, orgTotals, parsePrice, scenarioCost, type PriceScenario } from "./pricing";
+import type { MonthlyUsageRow } from "@/types/api";
+
+const ROWS: MonthlyUsageRow[] = [
+  // acme: two teams in the same month → org totals must sum across teams.
+  { month: "2026-08", org_id: "acme", team_id: 5, schema_name: "team_5", cpu_seconds: 7200, memory_seconds: 3600, gib_seconds: 3600 },
+  { month: "2026-08", org_id: "acme", team_id: 6, schema_name: "team_6", cpu_seconds: 600, memory_seconds: 600, gib_seconds: 7200 },
+  { month: "2026-08", org_id: "globex", team_id: 9, schema_name: "team_9", cpu_seconds: 1200, memory_seconds: 0, gib_seconds: 0 },
+];
+
+describe("orgTotals", () => {
+  it("sums usage units per org across teams", () => {
+    const totals = orgTotals(ROWS);
+    expect(totals).toHaveLength(2);
+    // Sorted by org id for a stable table.
+    expect(totals[0].orgId).toBe("acme");
+    // acme: cpu (7200+600)/60 = 130 min; mem (3600+600)/60 = 70 GiB·min; storage (3600+7200)/3600 = 3 GiB·h.
+    expect(totals[0].cpuMinutes).toBeCloseTo(130);
+    expect(totals[0].memGiBMinutes).toBeCloseTo(70);
+    expect(totals[0].storageGiBHours).toBeCloseTo(3);
+    expect(totals[1].orgId).toBe("globex");
+    expect(totals[1].cpuMinutes).toBeCloseTo(20);
+  });
+
+  it("returns an empty list for no rows", () => {
+    expect(orgTotals([])).toEqual([]);
+  });
+});
+
+describe("scenarioCost", () => {
+  it("multiplies each usage unit by its price", () => {
+    const s: PriceScenario = { id: "a", name: "A", cpuPerMin: 0.1, memPerGiBMin: 0.01, storagePerGiBH: 2 };
+    // acme: 130×0.1 + 70×0.01 + 3×2 = 13 + 0.7 + 6 = 19.7
+    const t = orgTotals(ROWS)[0];
+    expect(scenarioCost(t, s)).toBeCloseTo(19.7);
+  });
+
+  it("zero prices cost zero", () => {
+    const s: PriceScenario = { id: "z", name: "Z", cpuPerMin: 0, memPerGiBMin: 0, storagePerGiBH: 0 };
+    expect(scenarioCost(orgTotals(ROWS)[1], s)).toBe(0);
+  });
+});
+
+describe("parsePrice", () => {
+  it("accepts non-negative numbers", () => {
+    expect(parsePrice("0.05")).toBeCloseTo(0.05);
+    expect(parsePrice("2")).toBe(2);
+    expect(parsePrice("")).toBe(0);
+  });
+  it("rejects NaN and negatives as 0", () => {
+    expect(parsePrice("abc")).toBe(0);
+    expect(parsePrice("-1")).toBe(0);
+  });
+});
+
+describe("fmtMoney", () => {
+  it("formats USD with two decimals", () => {
+    expect(fmtMoney(19.7)).toBe("$19.70");
+    expect(fmtMoney(0)).toBe("$0.00");
+    expect(fmtMoney(1234567.891)).toBe("$1,234,567.89");
+  });
+});

--- a/controlplane/admin/ui/src/lib/pricing.ts
+++ b/controlplane/admin/ui/src/lib/pricing.ts
@@ -1,0 +1,60 @@
+// Pricing-sensitivity logic for the Usage page's cost calculator. Pure
+// functions — the feature is entirely client-side over the monthly usage
+// endpoint's rows (per-team usage units per org per month), so the math here
+// is the whole feature and is unit-tested directly.
+
+import type { MonthlyUsageRow } from "@/types/api";
+
+// PriceScenario is one named set of unit prices ("what if CPU cost X?").
+// Prices are USD per usage unit, matching the units the Usage page displays.
+export interface PriceScenario {
+  id: string;
+  name: string;
+  cpuPerMin: number; // $ per CPU-minute
+  memPerGiBMin: number; // $ per GiB·minute of memory
+  storagePerGiBH: number; // $ per GiB·hour of S3
+}
+
+// OrgUsageTotals is one org's month totals in display units (the sums of its
+// teams' rows).
+export interface OrgUsageTotals {
+  orgId: string;
+  cpuMinutes: number;
+  memGiBMinutes: number;
+  storageGiBHours: number;
+}
+
+// orgTotals aggregates per-team monthly rows into one totals line per org,
+// sorted by org id for a stable table.
+export function orgTotals(rows: MonthlyUsageRow[]): OrgUsageTotals[] {
+  const byOrg = new Map<string, OrgUsageTotals>();
+  for (const r of rows) {
+    let t = byOrg.get(r.org_id);
+    if (!t) {
+      t = { orgId: r.org_id, cpuMinutes: 0, memGiBMinutes: 0, storageGiBHours: 0 };
+      byOrg.set(r.org_id, t);
+    }
+    t.cpuMinutes += r.cpu_seconds / 60;
+    t.memGiBMinutes += r.memory_seconds / 60;
+    t.storageGiBHours += Number(r.gib_seconds) / 3600;
+  }
+  return [...byOrg.values()].sort((a, b) => a.orgId.localeCompare(b.orgId));
+}
+
+// scenarioCost prices one org's month under one scenario.
+export function scenarioCost(t: OrgUsageTotals, s: PriceScenario): number {
+  return t.cpuMinutes * s.cpuPerMin + t.memGiBMinutes * s.memPerGiBMin + t.storageGiBHours * s.storagePerGiBH;
+}
+
+// parsePrice reads a price input: non-negative finite numbers pass through,
+// anything else (empty, NaN, negative) is 0 — a half-typed input must never
+// make a cost cell NaN.
+export function parsePrice(raw: string): number {
+  const v = Number.parseFloat(raw);
+  return Number.isFinite(v) && v >= 0 ? v : 0;
+}
+
+// fmtMoney formats a USD amount with grouping and two decimals.
+export function fmtMoney(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 });
+}

--- a/controlplane/admin/ui/src/pages/Usage.test.tsx
+++ b/controlplane/admin/ui/src/pages/Usage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { MonthlyUsageResponse } from "@/types/api";
 
@@ -72,8 +72,9 @@ describe("Usage page", () => {
     hooks.useMonthlyUsage.mockReturnValue(ok(RESPONSE));
     renderPage();
 
-    // August total CPU-minutes = 120 + 1 = 121.
-    expect(screen.getByText("121")).toBeInTheDocument();
+    // August total CPU-minutes = 120 + 1 = 121 (scoped to the stat card — the
+    // pricing table shows the same org sum).
+    expect(within(screen.getByTestId("stat-CPU-min")).getByText("121")).toBeInTheDocument();
   });
 
   it("renders the retention caveat when billing has acked a watermark", () => {

--- a/controlplane/admin/ui/src/pages/Usage.tsx
+++ b/controlplane/admin/ui/src/pages/Usage.tsx
@@ -6,6 +6,7 @@ import { PageBody, PageHeader } from "@/components/AppShell";
 import { DataTable } from "@/components/DataTable";
 import { OrgRef } from "@/components/OrgRef";
 import { StatCard } from "@/components/StatCard";
+import { UsagePricing } from "@/pages/UsagePricing";
 import { Card } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
@@ -200,6 +201,7 @@ export function Usage() {
                 />
               </Card>
             )}
+            <UsagePricing rows={monthRows} />
           </>
         )}
       </PageBody>

--- a/controlplane/admin/ui/src/pages/UsagePricing.test.tsx
+++ b/controlplane/admin/ui/src/pages/UsagePricing.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { UsagePricing } from "./UsagePricing";
+import type { MonthlyUsageRow } from "@/types/api";
+
+// UsagePricing is a pure-props component (rows come from the Usage page's
+// monthly query) — no hook mocks needed. localStorage is cleared per test so
+// scenario persistence doesn't leak between cases.
+const ROWS: MonthlyUsageRow[] = [
+  // acme: cpu 130 min, mem 70 GiB·min, storage 3 GiB·h (two teams summed).
+  { month: "2026-08", org_id: "acme", team_id: 5, schema_name: "team_5", cpu_seconds: 7200, memory_seconds: 3600, gib_seconds: 3600 },
+  { month: "2026-08", org_id: "acme", team_id: 6, schema_name: "team_6", cpu_seconds: 600, memory_seconds: 600, gib_seconds: 7200 },
+  // globex: cpu 20 min.
+  { month: "2026-08", org_id: "globex", team_id: 9, schema_name: "team_9", cpu_seconds: 1200, memory_seconds: 0, gib_seconds: 0 },
+];
+
+function renderPricing(rows = ROWS) {
+  return render(
+    <MemoryRouter>
+      <UsagePricing rows={rows} />
+    </MemoryRouter>,
+  );
+}
+
+describe("UsagePricing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts with one baseline scenario and zero costs", () => {
+    renderPricing();
+    // One scenario editor.
+    expect(screen.getByDisplayValue("Baseline")).toBeInTheDocument();
+    // acme + globex rows and the all-orgs total, each $0.00.
+    expect(screen.getByText("acme")).toBeInTheDocument();
+    expect(screen.getByText("globex")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00")).toHaveLength(3);
+  });
+
+  it("prices each org and the grand total from the entered prices", () => {
+    renderPricing();
+    fireEvent.change(screen.getByLabelText("Baseline $/CPU-min"), { target: { value: "0.1" } });
+    fireEvent.change(screen.getByLabelText("Baseline $/GiB·min"), { target: { value: "0.01" } });
+    fireEvent.change(screen.getByLabelText("Baseline $/GiB·h"), { target: { value: "2" } });
+    // acme: 130×0.1 + 70×0.01 + 3×2 = $19.70; globex: 20×0.1 = $2.00; total $21.70.
+    expect(screen.getByText("$19.70")).toBeInTheDocument();
+    expect(screen.getByText("$2.00")).toBeInTheDocument();
+    expect(screen.getByText("$21.70")).toBeInTheDocument();
+  });
+
+  it("adds a scenario column for side-by-side sensitivity", () => {
+    renderPricing();
+    fireEvent.click(screen.getByRole("button", { name: /add scenario/i }));
+    // Two scenario editors now: Baseline + Scenario B.
+    expect(screen.getByDisplayValue("Baseline")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Scenario B")).toBeInTheDocument();
+    // Price only B: acme = 130 × 0.5 = $65.00 under B, still $0.00 under Baseline.
+    fireEvent.change(screen.getByLabelText("Scenario B $/CPU-min"), { target: { value: "0.5" } });
+    expect(screen.getByText("$65.00")).toBeInTheDocument();
+    // acme's Baseline cell stays $0.00 while B prices at $65.00.
+    const acmeRow = screen.getByText("acme").closest("tr")!;
+    expect(within(acmeRow).getByText("$0.00")).toBeInTheDocument();
+  });
+
+  it("persists scenarios to localStorage across remounts", () => {
+    const { unmount } = renderPricing();
+    fireEvent.change(screen.getByLabelText("Baseline $/CPU-min"), { target: { value: "0.1" } });
+    unmount();
+    renderPricing();
+    expect(screen.getByText("$13.00")).toBeInTheDocument(); // acme 130 × 0.1
+  });
+
+  it("renders a friendly empty state without usage rows", () => {
+    renderPricing([]);
+    expect(screen.getByText(/no usage rows/i)).toBeInTheDocument();
+  });
+});

--- a/controlplane/admin/ui/src/pages/UsagePricing.tsx
+++ b/controlplane/admin/ui/src/pages/UsagePricing.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useState } from "react";
+import { Plus, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/states";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { fmtUnits } from "@/lib/format";
+import { fmtMoney, orgTotals, parsePrice, scenarioCost, type PriceScenario } from "@/lib/pricing";
+import type { MonthlyUsageRow } from "@/types/api";
+
+// Pricing sensitivity: enter unit-price scenarios and see each org's monthly
+// fee under each of them, side by side. Entirely client-side over the monthly
+// usage rows (the same admin-only data as the table above) — nothing is sent
+// anywhere; scenarios persist in localStorage so a PM's what-ifs survive a
+// reload but never leave their browser.
+
+const STORAGE_KEY = "duckgres-usage-pricing-scenarios-v1";
+
+function newScenario(n: number): PriceScenario {
+  return {
+    id: `s${Date.now()}-${n}`,
+    name: n === 1 ? "Baseline" : `Scenario ${String.fromCharCode(64 + n)}`,
+    cpuPerMin: 0,
+    memPerGiBMin: 0,
+    storagePerGiBH: 0,
+  };
+}
+
+function loadScenarios(): PriceScenario[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as PriceScenario[];
+      if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((s) => typeof s?.name === "string")) {
+        return parsed;
+      }
+    }
+  } catch {
+    // corrupted storage → fall through to the default
+  }
+  return [newScenario(1)];
+}
+
+export function UsagePricing({ rows }: { rows: MonthlyUsageRow[] }) {
+  const [scenarios, setScenarios] = useState<PriceScenario[]>(loadScenarios);
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(scenarios));
+    } catch {
+      // storage full/unavailable — the calculator still works for the session
+    }
+  }, [scenarios]);
+
+  const totals = useMemo(() => orgTotals(rows), [rows]);
+  const grand = useMemo(
+    () => ({
+      cpuMinutes: totals.reduce((s, t) => s + t.cpuMinutes, 0),
+      memGiBMinutes: totals.reduce((s, t) => s + t.memGiBMinutes, 0),
+      storageGiBHours: totals.reduce((s, t) => s + t.storageGiBHours, 0),
+      orgId: "",
+    }),
+    [totals],
+  );
+
+  const update = (id: string, patch: Partial<PriceScenario>) =>
+    setScenarios((ss) => ss.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+  const remove = (id: string) => setScenarios((ss) => (ss.length > 1 ? ss.filter((s) => s.id !== id) : ss));
+  const add = () => setScenarios((ss) => [...ss, newScenario(ss.length + 1)]);
+
+  return (
+    <Card className="mt-4">
+      <CardHeader className="flex-row items-center justify-between gap-3">
+        <div>
+          <CardTitle>Pricing sensitivity</CardTitle>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Enter unit prices to see each org's fee for the selected month under each scenario. Prices stay in your
+            browser.
+          </p>
+        </div>
+        <Button size="sm" variant="outline" onClick={add}>
+          <Plus className="h-4 w-4" /> Add scenario
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-3">
+          {scenarios.map((s) => (
+            <div key={s.id} className="rounded-md border border-border p-3">
+              <div className="mb-2 flex items-center gap-2">
+                <Input
+                  value={s.name}
+                  onChange={(e) => update(s.id, { name: e.target.value })}
+                  className="h-7 w-32 text-xs font-medium"
+                  aria-label="Scenario name"
+                />
+                {scenarios.length > 1 && (
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label={`Remove ${s.name}`}
+                    onClick={() => remove(s.id)}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {(
+                  [
+                    ["cpuPerMin", "$/CPU-min"],
+                    ["memPerGiBMin", "$/GiB·min"],
+                    ["storagePerGiBH", "$/GiB·h"],
+                  ] as const
+                ).map(([field, label]) => (
+                  <label key={field} className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+                    {label}
+                    <Input
+                      type="number"
+                      min={0}
+                      step="any"
+                      value={s[field] === 0 ? "" : String(s[field])}
+                      placeholder="0"
+                      aria-label={`${s.name} ${label}`}
+                      className="h-7 w-24 text-xs"
+                      onChange={(e) => update(s.id, { [field]: parsePrice(e.target.value) })}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {totals.length === 0 ? (
+          <EmptyState title="No usage rows" description="Pick a month with usage above to price it." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>Org</TableHead>
+                <TableHead>CPU-min</TableHead>
+                <TableHead>GiB·min</TableHead>
+                <TableHead>GiB·h</TableHead>
+                {scenarios.map((s) => (
+                  <TableHead key={s.id} className="text-right">
+                    {s.name}/mo
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {totals.map((t) => (
+                <TableRow key={t.orgId}>
+                  <TableCell className="font-mono text-xs">{t.orgId}</TableCell>
+                  <TableCell className="font-mono text-xs">{fmtUnits(t.cpuMinutes)}</TableCell>
+                  <TableCell className="font-mono text-xs">{fmtUnits(t.memGiBMinutes)}</TableCell>
+                  <TableCell className="font-mono text-xs">{fmtUnits(t.storageGiBHours)}</TableCell>
+                  {scenarios.map((s) => (
+                    <TableCell key={s.id} className="text-right font-mono text-xs font-medium">
+                      {fmtMoney(scenarioCost(t, s))}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+              <TableRow className="border-t-2 font-semibold">
+                <TableCell className="text-xs">All orgs</TableCell>
+                <TableCell className="font-mono text-xs">{fmtUnits(grand.cpuMinutes)}</TableCell>
+                <TableCell className="font-mono text-xs">{fmtUnits(grand.memGiBMinutes)}</TableCell>
+                <TableCell className="font-mono text-xs">{fmtUnits(grand.storageGiBHours)}</TableCell>
+                {scenarios.map((s) => (
+                  <TableCell key={s.id} className="text-right font-mono text-xs">
+                    {fmtMoney(scenarioCost(grand, s))}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -2808,7 +2808,10 @@ admin_console_api() {
     || fail "/cluster/summary missing numeric totals (nodes/workers/cpu/mem/placeholders/pending)"
   # The monthly per-team usage read backing the admin "Usage" page: envelope
   # only here (rows may be empty before any usage lands); the populated path
-  # is asserted in compute_usage_pull_api against real generated usage.
+  # is asserted in compute_usage_pull_api against real generated usage. (The
+  # page's pricing-sensitivity calculator has no e2e assertion BY DESIGN: it
+  # is pure client-side math over this endpoint's rows — no backend surface —
+  # covered by ui/src/pages/UsagePricing.test.tsx + lib/pricing.test.ts.)
   curl -fsS -H "$H" "$API/api/v1/usage/monthly?months=1" \
     | jq -e 'has("rows") and (.rows | type == "array") and has("months") and has("from") and has("watermark_low")' >/dev/null \
     || fail "/usage/monthly did not return its envelope"


### PR DESCRIPTION
## Summary

A PM (e.g. Anna) workflow: enter named unit-price scenarios — **$/CPU-min**, **$/GiB·min** (memory), **$/GiB·h** (S3) — and see each org's fee for the selected month under each scenario **side by side**, with an all-orgs total row. Sensitivity analysis on monthly fees without a spreadsheet round-trip.

**Pure client-side feature** over the existing admin-only monthly usage rows:

- No endpoint, no server state — scenarios persist only in the operator's own **localStorage** (survive reloads, never leave the browser).
- Inherits the Usage page's `RequireAdmin` gate — no new access surface, and nothing to exfiltrate that the page doesn't already show.

### Access note (decision, not silently chosen)

Pricing math needs the per-org usage data, so the feature lives behind the same admin-only gate as the Usage page. Anna gets it by holding the console **admin** role (one row on the Operators page). If we want PMs to have this *without* full console admin (config mutation, impersonation, etc.), that's a third RBAC role — flagged as a follow-up, not implemented here.

## Testing (TDD)

- `lib/pricing.test.ts` — 7 cases over the pure logic: per-org month totals summed across teams, scenario cost math, price parsing (half-typed input never becomes NaN), USD formatting.
- `UsagePricing.test.tsx` — 5 cases: zero-default baseline, per-org + grand-total pricing, side-by-side scenario columns, localStorage persistence across remounts, empty state.
- `Usage.test.tsx` totals assertion scoped to the stat card (the pricing table now shows the same org sum).
- **No new e2e assertion, by design**: no backend surface — the endpoint it reads is already e2e-asserted. Noted explicitly in the harness next to the `usage-monthly` checks per the repo's e2e-mandate carve-out.

`just lint` clean; full UI suite green (120 tests, incl. typecheck + build).