### PR TITLE
controlplane+admin: per-org hot-idle pool reporting and caps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,50 @@ connect) and **escalation** (small → standard, one-way). Env-only knobs:
   `exploratory_tier` records which existing assertions the tier's connect
   semantics changed and why — keep that audit current.
 
+## Hot-Idle Pool Reporting + Per-Org Caps (remote backend)
+
+Two operator surfaces for the hot-idle pool, both over the durable runtime
+store (`worker_records`, the only source that sees parked workers — they hold
+no session):
+
+- **Reporting**: `configstore.ListHotIdleByOrg` aggregates `hot_idle` rows
+  per org (count, summed vCPU/memory, oldest park) and
+  `GET /api/v1/workers/hot-idle` (`controlplane/admin/live.go`) joins each
+  org's configured caps. Backs the Workers page "Hot idle by org" card.
+  Worker shape resolution mirrors the fleet rollup: the worker's explicit
+  profile wins, else the org's default worker profile; unparseable
+  quantities contribute 0.
+- **Caps**: `max_hot_idle_workers` (count), `max_hot_idle_cpu` and
+  `max_hot_idle_memory` (k8s quantity strings, e.g. `"16"` / `"64Gi"`) on
+  `duckgres_orgs` (migration 000037; 0/"" = unlimited). Editable via the
+  admin org PUT + the org detail form. Invariants:
+  - **Enforcement is a convergent janitor sweep** (`reapHotIdleCaps`), NOT a
+    park-time check: on each tick it retires the OLDEST parked workers
+    (oldest-first listing) until the org is within ALL configured limits.
+    This uniformly covers every park path AND cap decreases — lowering a cap
+    drains the excess on the next ticks (config-poll reload, then the 5s
+    janitor tick). Retires go through the fenced `RetireFromSnapshot` CAS
+    with origin `janitor_hot_idle_cap` (a distinct metric origin — a nonzero
+    rate means an operator's cost ceiling is biting, not stale capacity).
+    On a retire error the sweep STOPS that org for the tick (never marches
+    on and over-reaps on a transient failure).
+  - **Cap wins over the floor** (`DefaultWorkerMinHotIdle`): the floor only
+    guards the TTL reaper; the cap is the explicit operator intent. An org
+    with floor > cap is a contradictory config that resolves to the cap.
+  - **Validation is fail-closed on the write path**: a cap quantity that
+    doesn't parse (or is zero/negative) is 400'd by the admin org PUT,
+    because the sweep reads those as UNLIMITED — accepting them would
+    silently mean "no cap".
+  - The sweep runs even when the TTL reaper is disabled (`hotIdleTTL == 0`)
+    — a cap is a hard ceiling, not a freshness rule.
+- Touching any of this → update `tests/configstore/hot_idle_reporting_postgres_test.go`
+  (+ the migration asserts in `migrations_postgres_test.go`),
+  `controlplane/janitor_test.go` (the cap sweep cases),
+  `controlplane/admin/api_test.go` (`TestUpdateOrgHotIdleCaps*`) +
+  `live_test.go` (`TestHotIdleRoute`), `ui/src/pages/Workers.test.tsx` +
+  `OrgDetail.test.tsx`, AND the `/workers/hot-idle` envelope +
+  `hot_idle_reporting_and_cap` assertions in `tests/mw-dev/e2e/harness.sh`.
+
 ## Worker Drain Protocol (graceful shutdown, #690)
 
 Remote worker pods drain on SIGTERM (pod deletion): they reject new work, keep

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -64,6 +64,7 @@ Added for the console:
 | `GET /api/v1/errors` | viewer | recent redacted query errors (live-triage ring, newest-first), `?org=&user=&sqlstate=&category=&limit=` slicing. Fans out + merges across CPs (each error belongs to one CP — disjoint, no dedup). `query`/`message` redacted server-side |
 | `GET /api/v1/sessions`, `/workers` | viewer | live sessions / session-holding workers |
 | `GET /api/v1/workers/fleet` | viewer | cluster worker counts by lifecycle state |
+| `GET /api/v1/workers/hot-idle` | viewer | per-org hot-idle pool reporting (count, vCPU, memory, oldest park) + each org's configured `max_hot_idle_*` caps; backs the Workers page "Hot idle by org" card |
 | `GET /api/v1/cluster/instances` | viewer | live CP replicas (self-flagged) |
 | `POST /api/v1/sessions/:pid/cancel` | admin | tear down a session by pid — LOCAL only (pid is per-CP); prefer the worker-id form |
 | `POST /api/v1/sessions/by-worker/:wid/cancel` | admin | tear down the session on a cluster-unique worker id; fans out to whichever CP owns it (pid can't be fanned out — it collides across CPs). Returns `{killed, cp_responders, cp_total}` |

--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -296,6 +296,11 @@ func (s *gormAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 		"default_worker_memory":       updates.DefaultWorkerMemory,
 		"default_worker_ttl":          updates.DefaultWorkerTTL,
 		"default_worker_min_hot_idle": updates.DefaultWorkerMinHotIdle,
+		// Hot-idle pool caps: written unconditionally for the same reason —
+		// 0 / "" clears the cap back to unlimited after the presence-merge.
+		"max_hot_idle_workers": updates.MaxHotIdleWorkers,
+		"max_hot_idle_cpu":     updates.MaxHotIdleCPU,
+		"max_hot_idle_memory":  updates.MaxHotIdleMemory,
 	}
 	if updates.DataImportsTableNamingVersion != "" {
 		fields["data_imports_table_naming_version"] = updates.DataImportsTableNamingVersion
@@ -1060,6 +1065,17 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	if _, ok := fields["default_worker_min_hot_idle"]; ok {
 		merged.DefaultWorkerMinHotIdle = updates.DefaultWorkerMinHotIdle
 	}
+	// Hot-idle pool caps: present-in-payload wins, including an explicit
+	// 0 / "" which clears the cap back to unlimited.
+	if _, ok := fields["max_hot_idle_workers"]; ok {
+		merged.MaxHotIdleWorkers = updates.MaxHotIdleWorkers
+	}
+	if _, ok := fields["max_hot_idle_cpu"]; ok {
+		merged.MaxHotIdleCPU = updates.MaxHotIdleCPU
+	}
+	if _, ok := fields["max_hot_idle_memory"]; ok {
+		merged.MaxHotIdleMemory = updates.MaxHotIdleMemory
+	}
 	if _, ok := fields["hostname_alias"]; ok {
 		merged.HostnameAlias = updates.HostnameAlias
 	}
@@ -1082,6 +1098,9 @@ func (h *apiHandler) updateOrg(c *gin.Context) {
 	addChange("default_worker_memory", orgStr(existing.DefaultWorkerMemory), orgStr(merged.DefaultWorkerMemory))
 	addChange("default_worker_ttl", orgStr(existing.DefaultWorkerTTL), orgStr(merged.DefaultWorkerTTL))
 	addChange("default_worker_min_hot_idle", existing.DefaultWorkerMinHotIdle, merged.DefaultWorkerMinHotIdle)
+	addChange("max_hot_idle_workers", existing.MaxHotIdleWorkers, merged.MaxHotIdleWorkers)
+	addChange("max_hot_idle_cpu", orgStr(existing.MaxHotIdleCPU), orgStr(merged.MaxHotIdleCPU))
+	addChange("max_hot_idle_memory", orgStr(existing.MaxHotIdleMemory), orgStr(merged.MaxHotIdleMemory))
 	addChange("hostname_alias", orgStrPtr(existing.HostnameAlias), orgStrPtr(merged.HostnameAlias))
 	addChange("data_imports_table_naming_version", existing.DataImportsTableNamingVersion, merged.DataImportsTableNamingVersion)
 	if len(changes) > 0 {
@@ -1434,6 +1453,27 @@ func validateOrgMutationPayload(org *configstore.Org) error {
 	}
 	if org.MaxVCPUs < 0 {
 		return fmt.Errorf("max_vcpus: value %d must be >= 0", org.MaxVCPUs)
+	}
+	if org.MaxHotIdleWorkers < 0 {
+		return fmt.Errorf("max_hot_idle_workers: value %d must be >= 0", org.MaxHotIdleWorkers)
+	}
+	// The cap quantities must be positive when set: an unparseable or zero
+	// value would silently mean UNLIMITED in the sweep — fail closed here so
+	// an operator typo can never read as "no cap".
+	for _, f := range []struct{ name, raw string }{
+		{"max_hot_idle_cpu", org.MaxHotIdleCPU},
+		{"max_hot_idle_memory", org.MaxHotIdleMemory},
+	} {
+		if f.raw == "" {
+			continue
+		}
+		q, err := resource.ParseQuantity(f.raw)
+		if err != nil {
+			return fmt.Errorf("%s: invalid quantity %q", f.name, f.raw)
+		}
+		if q.Sign() <= 0 {
+			return fmt.Errorf("%s: quantity %q must be positive (clear the field for unlimited)", f.name, f.raw)
+		}
 	}
 	return nil
 }

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -91,6 +91,9 @@ func (s *fakeAPIStore) UpdateOrg(name string, updates configstore.Org) (*configs
 	org.DefaultWorkerMemory = updates.DefaultWorkerMemory
 	org.DefaultWorkerTTL = updates.DefaultWorkerTTL
 	org.DefaultWorkerMinHotIdle = updates.DefaultWorkerMinHotIdle
+	org.MaxHotIdleWorkers = updates.MaxHotIdleWorkers
+	org.MaxHotIdleCPU = updates.MaxHotIdleCPU
+	org.MaxHotIdleMemory = updates.MaxHotIdleMemory
 	if updates.DataImportsTableNamingVersion != "" {
 		org.DataImportsTableNamingVersion = updates.DataImportsTableNamingVersion
 	}
@@ -3371,5 +3374,70 @@ func TestAdminRevokeServiceGrant(t *testing.T) {
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("ghost org: status = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The hot-idle pool caps merge presence-aware like every other org column:
+// present wins (including 0/"" clearing back to unlimited), absent preserves.
+func TestUpdateOrgHotIdleCaps(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{
+		Name:              "acme",
+		DatabaseName:      "acme_db",
+		MaxHotIdleWorkers: 9,
+		MaxHotIdleCPU:     "4",
+	}
+	router := newTestAPIRouter(store)
+
+	put := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Set all three; the stored row must carry them.
+	rec := put(`{"max_hot_idle_workers":5,"max_hot_idle_cpu":"16","max_hot_idle_memory":"64Gi"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	stored := store.orgs["acme"]
+	if stored.MaxHotIdleWorkers != 5 || stored.MaxHotIdleCPU != "16" || stored.MaxHotIdleMemory != "64Gi" {
+		t.Fatalf("caps not stored: %+v", stored)
+	}
+
+	// Absent fields preserve; an explicit 0/"" clears back to unlimited.
+	rec = put(`{"max_hot_idle_workers":0,"max_hot_idle_memory":""}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	stored = store.orgs["acme"]
+	if stored.MaxHotIdleWorkers != 0 || stored.MaxHotIdleMemory != "" || stored.MaxHotIdleCPU != "16" {
+		t.Fatalf("presence-aware merge wrong: %+v", stored)
+	}
+}
+
+// A cap quantity that won't parse (or is zero) must 400: the sweep reads
+// those as UNLIMITED, so accepting them would silently mean "no cap".
+func TestUpdateOrgHotIdleCapsRejectBadQuantities(t *testing.T) {
+	store := newFakeAPIStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme", DatabaseName: "acme_db"}
+	router := newTestAPIRouter(store)
+
+	for _, body := range []string{
+		`{"max_hot_idle_cpu":"sixteen"}`,
+		`{"max_hot_idle_cpu":"0"}`,
+		`{"max_hot_idle_memory":"lots"}`,
+		`{"max_hot_idle_memory":"-4Gi"}`,
+		`{"max_hot_idle_workers":-1}`,
+	} {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/orgs/acme", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want 400", body, rec.Code)
+		}
 	}
 }

--- a/controlplane/admin/live.go
+++ b/controlplane/admin/live.go
@@ -113,6 +113,22 @@ type CPInstance struct {
 	Self bool   `json:"self"`
 }
 
+// HotIdleOrg is one org's hot-idle pool footprint plus its configured pool
+// ceiling, for the admin dashboard's hot-idle reporting: who is holding
+// parked workers, how much resource that pins, the longest park, and the
+// org's max_hot_idle_* caps (0/"" = unlimited) so the operator can see both
+// the load and the knob in one place.
+type HotIdleOrg struct {
+	OrgID              string     `json:"org_id"`
+	Count              int64      `json:"count"`
+	CPUCores           float64    `json:"cpu_cores"`
+	MemoryBytes        int64      `json:"memory_bytes"`
+	OldestHotIdleSince *time.Time `json:"oldest_hot_idle_since"`
+	CapWorkers         int        `json:"cap_workers"`
+	CapCPU             string     `json:"cap_cpu"`
+	CapMemory          string     `json:"cap_memory"`
+}
+
 // LiveInfo surfaces live cluster state beyond the basic OrgStackInfo summary.
 // Implemented by the controlplane adapter.
 type LiveInfo interface {
@@ -127,6 +143,10 @@ type LiveInfo interface {
 	QueryDetailForWorkerID(workerID int) (QueryDetail, bool)
 	// WorkerFleet returns worker counts by lifecycle state across the cluster.
 	WorkerFleet() ([]FleetStat, error)
+	// HotIdleByOrg returns each org's hot-idle pool footprint + configured
+	// pool caps, from the durable runtime store (the only source that sees
+	// parked workers — they hold no session).
+	HotIdleByOrg() ([]HotIdleOrg, error)
 	// ControlPlaneInstances returns the live CP replicas.
 	ControlPlaneInstances() ([]CPInstance, error)
 	// KillSession tears down the session (and its exclusive worker) for pid.
@@ -323,6 +343,18 @@ func registerLiveAPI(r *gin.RouterGroup, live LiveInfo, fetcher PeerFetcher, use
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"fleet": stats})
+	})
+
+	// Hot-idle pool reporting: which orgs are holding parked workers, how much
+	// resource that pins, and each org's configured pool caps. Read-only
+	// operational fleet state (like /workers/fleet) — viewer-allowed.
+	r.GET("/workers/hot-idle", func(c *gin.Context) {
+		orgs, err := live.HotIdleByOrg()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"orgs": orgs})
 	})
 
 	r.GET("/cluster/instances", func(c *gin.Context) {

--- a/controlplane/admin/live_aggregate_test.go
+++ b/controlplane/admin/live_aggregate_test.go
@@ -18,6 +18,7 @@ import (
 
 // fakeLiveInfo returns a fixed local view.
 type fakeLiveInfo struct {
+	hotIdle []HotIdleOrg
 	queries  []QueryStatus
 	sessions []SessionStatus
 	orgStats []OrgStatus
@@ -42,6 +43,7 @@ func (f *fakeLiveInfo) QueryDetailForWorkerID(wid int) (QueryDetail, bool) {
 	return QueryDetail{}, false
 }
 func (f *fakeLiveInfo) WorkerFleet() ([]FleetStat, error)            { return nil, nil }
+func (f *fakeLiveInfo) HotIdleByOrg() ([]HotIdleOrg, error)          { return f.hotIdle, nil }
 func (f *fakeLiveInfo) ControlPlaneInstances() ([]CPInstance, error) { return nil, nil }
 func (f *fakeLiveInfo) KillSession(int32) error                      { return nil }
 func (f *fakeLiveInfo) KillSessionByWorkerID(wid int) int {

--- a/controlplane/admin/live_test.go
+++ b/controlplane/admin/live_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -175,5 +176,39 @@ func TestCancelByWorkerFansOut(t *testing.T) {
 	r3.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/v1/sessions/by-worker/99/cancel", nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("unknown worker cancel should 404, got %d", w.Code)
+	}
+}
+
+// The hot-idle reporting endpoint serves the provider's per-org rows under
+// {orgs:[...]} — the operator's "who is holding parked workers, and at what
+// configured ceiling" view.
+func TestHotIdleRoute(t *testing.T) {
+	since := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	live := &fakeLiveInfo{hotIdle: []HotIdleOrg{
+		{OrgID: "acme", Count: 3, CPUCores: 8, MemoryBytes: 32 << 30, OldestHotIdleSince: &since, CapWorkers: 5, CapCPU: "16", CapMemory: "64Gi"},
+		{OrgID: "globex", Count: 1, CPUCores: 2, MemoryBytes: 8 << 30},
+	}}
+	r := liveTestRouter(live, nil)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/workers/hot-idle", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /workers/hot-idle = %d (%s)", w.Code, w.Body.String())
+	}
+	var body struct {
+		Orgs []HotIdleOrg `json:"orgs"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Orgs) != 2 {
+		t.Fatalf("want 2 orgs, got %+v", body.Orgs)
+	}
+	acme := body.Orgs[0]
+	if acme.OrgID != "acme" || acme.Count != 3 || acme.CPUCores != 8 || acme.CapWorkers != 5 || acme.CapCPU != "16" || acme.CapMemory != "64Gi" {
+		t.Fatalf("acme row wrong: %+v", acme)
+	}
+	if acme.OldestHotIdleSince == nil || !acme.OldestHotIdleSince.Equal(since) {
+		t.Fatalf("oldest since not carried: %+v", acme)
 	}
 }

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -28,6 +28,7 @@ import type {
   ErrorEntry,
   ErrorFilters,
   FleetStat,
+  HotIdleOrg,
   ImpersonateBody,
   ManagedWarehouse,
   Me,
@@ -470,6 +471,15 @@ export function useFleet() {
   return useQuery<FleetStat[]>({
     queryKey: ["fleet"],
     queryFn: () => tolerate404<FleetStat[]>([])(api.fleet()),
+    refetchInterval: POLL.normal,
+  });
+}
+
+// Hot-idle pool reporting: which orgs hold parked workers + their caps.
+export function useHotIdle() {
+  return useQuery<HotIdleOrg[]>({
+    queryKey: ["hot-idle"],
+    queryFn: () => tolerate404<HotIdleOrg[]>([])(api.hotIdle()),
     refetchInterval: POLL.normal,
   });
 }

--- a/controlplane/admin/ui/src/lib/api.ts
+++ b/controlplane/admin/ui/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   ErrorEntry,
   ErrorFilters,
   FleetStat,
+  HotIdleOrg,
   ImpersonateBody,
   Me,
   MonthlyUsageResponse,
@@ -188,6 +189,7 @@ export const api = {
   // workers / sessions / live
   listWorkers: () => get<WorkerStatus[]>("/workers"),
   fleet: () => get<{ fleet: FleetStat[] }>("/workers/fleet").then((r) => r.fleet ?? []),
+  hotIdle: () => get<{ orgs: HotIdleOrg[] }>("/workers/hot-idle").then((r) => r.orgs ?? []),
   instances: () =>
     get<{ instances: CPInstance[] }>("/cluster/instances").then((r) => r.instances ?? []),
   listSessions: () => get<SessionStatus[]>("/sessions"),

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -65,6 +65,9 @@ const ORG: Org = {
   default_worker_memory: "8Gi",
   default_worker_ttl: "75m",
   default_worker_min_hot_idle: 0,
+  max_hot_idle_workers: 0,
+  max_hot_idle_cpu: "",
+  max_hot_idle_memory: "",
   data_imports_table_naming_version: "legacy_batch_v1",
   created_at: "2026-07-01T00:00:00Z",
   updated_at: "2026-07-01T00:00:00Z",
@@ -298,6 +301,30 @@ describe("Org detail", () => {
     expect(orgUpdate).toHaveBeenCalledTimes(1);
     expect(orgUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ data_imports_table_naming_version: "copy_v1" }),
+    );
+  });
+
+  it("saves the hot-idle pool caps with the org form", async () => {
+    const user = userEvent.setup();
+    renderPage(false);
+
+    const workers = await screen.findByLabelText(/max hot-idle workers/i);
+    await user.clear(workers);
+    await user.type(workers, "5");
+    const cpu = screen.getByLabelText(/max hot-idle vcpu/i);
+    await user.clear(cpu);
+    await user.type(cpu, "16");
+    const mem = screen.getByLabelText(/max hot-idle memory/i);
+    await user.clear(mem);
+    await user.type(mem, "64Gi");
+    await user.click(screen.getByText("Save changes"));
+
+    expect(orgUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_hot_idle_workers: 5,
+        max_hot_idle_cpu: "16",
+        max_hot_idle_memory: "64Gi",
+      }),
     );
   });
 });

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -59,6 +59,9 @@ interface FormState {
   default_worker_memory: string;
   default_worker_ttl: string;
   default_worker_min_hot_idle: string;
+  max_hot_idle_workers: string;
+  max_hot_idle_cpu: string;
+  max_hot_idle_memory: string;
   hostname_alias: string;
   data_imports_table_naming_version: DataImportsTableNamingVersion;
 }
@@ -71,6 +74,9 @@ function orgToForm(o: {
   default_worker_memory: string;
   default_worker_ttl: string;
   default_worker_min_hot_idle: number;
+  max_hot_idle_workers: number;
+  max_hot_idle_cpu: string;
+  max_hot_idle_memory: string;
   hostname_alias: string | null;
   data_imports_table_naming_version: DataImportsTableNamingVersion;
 }): FormState {
@@ -82,6 +88,9 @@ function orgToForm(o: {
     default_worker_memory: o.default_worker_memory,
     default_worker_ttl: o.default_worker_ttl,
     default_worker_min_hot_idle: String(o.default_worker_min_hot_idle),
+    max_hot_idle_workers: String(o.max_hot_idle_workers),
+    max_hot_idle_cpu: o.max_hot_idle_cpu,
+    max_hot_idle_memory: o.max_hot_idle_memory,
     hostname_alias: o.hostname_alias ?? "",
     data_imports_table_naming_version: o.data_imports_table_naming_version,
   };
@@ -154,6 +163,9 @@ export function OrgDetail() {
       default_worker_memory: form.default_worker_memory,
       default_worker_ttl: form.default_worker_ttl,
       default_worker_min_hot_idle: Number(form.default_worker_min_hot_idle) || 0,
+      max_hot_idle_workers: Number(form.max_hot_idle_workers) || 0,
+      max_hot_idle_cpu: form.max_hot_idle_cpu,
+      max_hot_idle_memory: form.max_hot_idle_memory,
       hostname_alias: form.hostname_alias === "" ? "" : form.hostname_alias,
       data_imports_table_naming_version: form.data_imports_table_naming_version,
     };
@@ -275,6 +287,31 @@ export function OrgDetail() {
                     type="number"
                     value={form.default_worker_min_hot_idle}
                     onChange={(e) => set("default_worker_min_hot_idle", e.target.value)}
+                  />
+                </Field>
+                <Field label="Max hot-idle workers (0 = unlimited)">
+                  <Input
+                    type="number"
+                    min={0}
+                    aria-label="Max hot-idle workers"
+                    value={form.max_hot_idle_workers}
+                    onChange={(e) => set("max_hot_idle_workers", e.target.value)}
+                  />
+                </Field>
+                <Field label="Max hot-idle vCPU (empty = unlimited)">
+                  <Input
+                    aria-label="Max hot-idle vCPU"
+                    value={form.max_hot_idle_cpu}
+                    placeholder='e.g. "16"'
+                    onChange={(e) => set("max_hot_idle_cpu", e.target.value)}
+                  />
+                </Field>
+                <Field label="Max hot-idle memory (empty = unlimited)">
+                  <Input
+                    aria-label="Max hot-idle memory"
+                    value={form.max_hot_idle_memory}
+                    placeholder='e.g. "64Gi"'
+                    onChange={(e) => set("max_hot_idle_memory", e.target.value)}
                   />
                 </Field>
               </div>

--- a/controlplane/admin/ui/src/pages/Workers.test.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { HotIdleOrg } from "@/types/api";
+
+const hooks = vi.hoisted(() => ({
+  useFleet: vi.fn(),
+  useWorkers: vi.fn(),
+  useHotIdle: vi.fn(),
+  useOrgLabels: vi.fn(),
+}));
+vi.mock("@/hooks/useApi", () => hooks);
+
+import { Workers } from "./Workers";
+
+const ok = <T,>(data: T) => ({ data, isSuccess: true, isLoading: false, isError: false, refetch: vi.fn() });
+
+const HOT_IDLE: HotIdleOrg[] = [
+  {
+    org_id: "acme",
+    count: 3,
+    cpu_cores: 8,
+    memory_bytes: 32 * 1024 ** 3,
+    oldest_hot_idle_since: "2026-08-19T10:00:00Z",
+    cap_workers: 5,
+    cap_cpu: "16",
+    cap_memory: "64Gi",
+  },
+  {
+    org_id: "globex",
+    count: 1,
+    cpu_cores: 2,
+    memory_bytes: 8 * 1024 ** 3,
+    oldest_hot_idle_since: null,
+    cap_workers: 0,
+    cap_cpu: "",
+    cap_memory: "",
+  },
+];
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <Workers />
+    </MemoryRouter>,
+  );
+}
+
+describe("Workers page hot-idle card", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooks.useFleet.mockReturnValue(ok([]));
+    hooks.useWorkers.mockReturnValue(ok([]));
+    hooks.useOrgLabels.mockReturnValue(new Map([["acme", "Acme Inc"]]));
+    hooks.useHotIdle.mockReturnValue(ok(HOT_IDLE));
+  });
+
+  it("lists each org's parked pool with its caps and links to the org page", () => {
+    renderPage();
+    expect(screen.getByText("Hot idle by org")).toBeInTheDocument();
+    // Org label resolves; the row links through to the org detail page.
+    const link = screen.getByRole("link", { name: /acme inc/i });
+    expect(link).toHaveAttribute("href", "/orgs/acme");
+    // acme: 3 parked against a 5-worker cap, with the cpu/memory caps shown.
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText(/\/ 5/)).toBeInTheDocument();
+    expect(screen.getByText("5 workers · 16 · 64Gi")).toBeInTheDocument();
+    // globex has no cap configured.
+    expect(screen.getByText("globex")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when nothing is parked", () => {
+    hooks.useHotIdle.mockReturnValue(ok([]));
+    renderPage();
+    expect(screen.getByText(/no workers are parked hot-idle/i)).toBeInTheDocument();
+  });
+});

--- a/controlplane/admin/ui/src/pages/Workers.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { type ColumnDef } from "@tanstack/react-table";
 import { Search, Server } from "lucide-react";
 import { PageBody, PageHeader } from "@/components/AppShell";
@@ -8,9 +9,10 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
-import { useFleet, useOrgLabels, useWorkers } from "@/hooks/useApi";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useFleet, useHotIdle, useOrgLabels, useWorkers } from "@/hooks/useApi";
 import { OrgRef } from "@/components/OrgRef";
-import { fmtBytes, fmtDuration, fmtInt } from "@/lib/format";
+import { fmtAge, fmtBytes, fmtDuration, fmtInt, fmtUnits } from "@/lib/format";
 import type { WorkerStatus } from "@/types/api";
 
 // Canonical lifecycle-state order for the rollup chips.
@@ -19,11 +21,13 @@ const STATE_ORDER = ["spawning", "idle", "reserved", "activating", "hot", "hot_i
 export function Workers() {
   const fleet = useFleet();
   const workers = useWorkers();
+  const hotIdle = useHotIdle();
   const orgLabels = useOrgLabels();
   const [filter, setFilter] = useState("");
 
   const fleetRows = fleet.data ?? [];
   const workerRows = workers.data ?? [];
+  const hotIdleRows = hotIdle.data ?? [];
 
   // Per-state rollup: sum the durable runtime-store counts grouped by lifecycle
   // state (a state may span several image/binding rows).
@@ -102,7 +106,7 @@ export function Workers() {
     <>
       <PageHeader
         title="Workers"
-        description="Fleet rollup by lifecycle state (GET /api/v1/workers/fleet) plus session-holding workers (GET /api/v1/workers)."
+        description="Fleet rollup by lifecycle state (GET /api/v1/workers/fleet), per-org hot-idle pools (GET /api/v1/workers/hot-idle), plus session-holding workers (GET /api/v1/workers)."
         actions={
           <div className="relative">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -165,6 +169,73 @@ export function Workers() {
             </CardContent>
           </Card>
         </div>
+
+        <Card className="mb-4">
+          <CardHeader className="flex-row items-center justify-between">
+            <div>
+              <CardTitle>Hot idle by org</CardTitle>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Parked (hot-idle) workers held per org and each org's configured pool cap — the janitor retires the
+                oldest excess past it. Caps are edited on the org page.
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {hotIdle.isError ? (
+              <p className="py-4 text-center text-sm text-destructive">Hot-idle endpoint error.</p>
+            ) : hotIdleRows.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">No workers are parked hot-idle.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>Org</TableHead>
+                    <TableHead>Workers</TableHead>
+                    <TableHead>vCPU</TableHead>
+                    <TableHead>Memory</TableHead>
+                    <TableHead>Longest idle</TableHead>
+                    <TableHead>Cap</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {hotIdleRows.map((o) => (
+                    <TableRow key={o.org_id}>
+                      <TableCell>
+                        <Link to={`/orgs/${encodeURIComponent(o.org_id)}`} className="block hover:underline">
+                          <OrgRef id={o.org_id} label={orgLabels.get(o.org_id)} copyable={false} />
+                        </Link>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {fmtInt(o.count)}
+                        {o.cap_workers > 0 && (
+                          <span className={o.count > o.cap_workers ? "text-destructive" : "text-muted-foreground"}>
+                            {" "}/ {o.cap_workers}
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">{fmtUnits(o.cpu_cores)}</TableCell>
+                      <TableCell className="font-mono text-xs">{fmtBytes(o.memory_bytes)}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {o.oldest_hot_idle_since ? fmtAge(o.oldest_hot_idle_since) : "—"}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {o.cap_workers > 0 || o.cap_cpu || o.cap_memory
+                          ? [
+                              o.cap_workers > 0 ? `${o.cap_workers} workers` : null,
+                              o.cap_cpu || null,
+                              o.cap_memory || null,
+                            ]
+                              .filter(Boolean)
+                              .join(" · ")
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
 
         <Card className="overflow-hidden">
           <CardHeader>

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -49,6 +49,9 @@ export interface Org {
   teams?: OrgTeam[];
   max_workers: number;
   max_vcpus: number;
+  max_hot_idle_workers: number;
+  max_hot_idle_cpu: string;
+  max_hot_idle_memory: string;
   default_worker_cpu: string;
   default_worker_memory: string;
   default_worker_ttl: string;
@@ -69,6 +72,9 @@ export interface OrgUpdate {
   // collisions.
   database_name?: string;
   max_workers?: number;
+  max_hot_idle_workers?: number;
+  max_hot_idle_cpu?: string;
+  max_hot_idle_memory?: string;
   max_vcpus?: number;
   default_worker_cpu?: string;
   default_worker_memory?: string;
@@ -723,4 +729,18 @@ export interface DailyUsageResponse {
   from: string;
   watermark_low: string | null;
   rows: DailyUsageRow[];
+}
+
+// GET /api/v1/workers/hot-idle — one org's hot-idle pool footprint + its
+// configured pool caps (0/"" = unlimited), for the Workers page's hot-idle
+// reporting card.
+export interface HotIdleOrg {
+  org_id: string;
+  count: number;
+  cpu_cores: number;
+  memory_bytes: number;
+  oldest_hot_idle_since: string | null;
+  cap_workers: number;
+  cap_cpu: string;
+  cap_memory: string;
 }

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -153,6 +153,42 @@ func (p *clusterInfoProvider) WorkerFleet() ([]admin.FleetStat, error) {
 	return out, nil
 }
 
+// HotIdleByOrg returns each org's hot-idle pool footprint (durable runtime
+// store) joined with its configured max_hot_idle_* caps (config orgs table).
+func (p *clusterInfoProvider) HotIdleByOrg() ([]admin.HotIdleOrg, error) {
+	stats, err := p.store.ListHotIdleByOrg()
+	if err != nil {
+		return nil, err
+	}
+	var orgs []configstore.Org
+	if err := p.store.DB().
+		Select("name", "max_hot_idle_workers", "max_hot_idle_cpu", "max_hot_idle_memory").
+		Find(&orgs).Error; err != nil {
+		return nil, err
+	}
+	caps := make(map[string]configstore.Org, len(orgs))
+	for _, o := range orgs {
+		caps[o.Name] = o
+	}
+	out := make([]admin.HotIdleOrg, 0, len(stats))
+	for _, s := range stats {
+		row := admin.HotIdleOrg{
+			OrgID:              s.OrgID,
+			Count:              s.Count,
+			CPUCores:           s.CPUCores,
+			MemoryBytes:        s.MemoryBytes,
+			OldestHotIdleSince: s.OldestHotIdleSince,
+		}
+		if org, ok := caps[s.OrgID]; ok {
+			row.CapWorkers = org.MaxHotIdleWorkers
+			row.CapCPU = org.MaxHotIdleCPU
+			row.CapMemory = org.MaxHotIdleMemory
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
 // ControlPlaneInstances returns the live CP replicas, flagging this one.
 func (p *clusterInfoProvider) ControlPlaneInstances() ([]admin.CPInstance, error) {
 	ids, err := p.store.ListLiveControlPlaneInstanceIDs()

--- a/controlplane/configstore/hot_idle.go
+++ b/controlplane/configstore/hot_idle.go
@@ -1,0 +1,95 @@
+package configstore
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// HotIdleOrgStat is one org's hot-idle pool footprint for the admin
+// dashboard's hot-idle reporting: how many workers the org is holding parked,
+// their summed shape (vCPU / bytes), and when the longest-parked one went
+// idle. Read from the durable runtime store (worker_records), the same source
+// the fleet rollup uses — a parked worker holds no session, so the in-memory
+// session map cannot see it.
+type HotIdleOrgStat struct {
+	OrgID              string     `json:"org_id"`
+	Count              int64      `json:"count"`
+	CPUCores           float64    `json:"cpu_cores"`
+	MemoryBytes        int64      `json:"memory_bytes"`
+	OldestHotIdleSince *time.Time `json:"oldest_hot_idle_since"`
+}
+
+// ListHotIdleByOrg aggregates hot_idle worker rows per org for the admin
+// dashboard. Worker shape resolution mirrors ListWorkerLifecycleStats: the
+// worker's explicit profile wins, else the org's default worker profile;
+// unparseable/empty quantities contribute 0. Orgs with no hot-idle workers
+// do not appear.
+func (cs *ConfigStore) ListHotIdleByOrg() ([]HotIdleOrgStat, error) {
+	workerTable := cs.runtimeTable((&WorkerRecord{}).TableName())
+	orgTable := (&Org{}).TableName()
+	type workerRow struct {
+		OrgID        string
+		CPU          string
+		Memory       string
+		HotIdleSince *time.Time
+	}
+	var rows []workerRow
+	err := cs.db.Table(workerTable + " AS w").
+		Select("w.org_id AS org_id, "+
+			"COALESCE(NULLIF(w.profile_cpu, ''), o.default_worker_cpu, '') AS cpu, "+
+			"COALESCE(NULLIF(w.profile_memory, ''), o.default_worker_memory, '') AS memory, "+
+			"w.hot_idle_since AS hot_idle_since").
+		Joins("LEFT JOIN " + orgTable + " AS o ON o.name = w.org_id").
+		Where("w.state = ? AND w.org_id <> ''", WorkerStateHotIdle).
+		Order("w.org_id ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("list hot-idle workers by org: %w", err)
+	}
+
+	index := make(map[string]int)
+	var out []HotIdleOrgStat
+	for _, r := range rows {
+		i, ok := index[r.OrgID]
+		if !ok {
+			i = len(out)
+			index[r.OrgID] = i
+			out = append(out, HotIdleOrgStat{OrgID: r.OrgID})
+		}
+		out[i].Count++
+		if r.CPU != "" {
+			if q, err := resource.ParseQuantity(r.CPU); err == nil {
+				out[i].CPUCores += q.AsApproximateFloat64()
+			}
+		}
+		if r.Memory != "" {
+			if q, err := resource.ParseQuantity(r.Memory); err == nil {
+				out[i].MemoryBytes += q.Value()
+			}
+		}
+		if r.HotIdleSince != nil && (out[i].OldestHotIdleSince == nil || r.HotIdleSince.Before(*out[i].OldestHotIdleSince)) {
+			since := *r.HotIdleSince
+			out[i].OldestHotIdleSince = &since
+		}
+	}
+	return out, nil
+}
+
+// ListOrgHotIdleWorkers returns one org's hot_idle worker rows ordered by
+// idle age, OLDEST first (COALESCE(hot_idle_since, updated_at) ascending —
+// the same clock the TTL reaper uses). The janitor's hot-idle cap sweep
+// retires the (count − cap) PREFIX of this list: the longest-parked workers
+// go first, keeping the freshest warm capacity.
+func (cs *ConfigStore) ListOrgHotIdleWorkers(orgID string) ([]WorkerRecord, error) {
+	var workers []WorkerRecord
+	err := cs.db.Table(cs.runtimeTable((&WorkerRecord{}).TableName())+" AS w").
+		Where("w.state = ? AND w.org_id = ?", WorkerStateHotIdle, orgID).
+		Order("COALESCE(w.hot_idle_since, w.updated_at) ASC, w.worker_id ASC").
+		Find(&workers).Error
+	if err != nil {
+		return nil, fmt.Errorf("list org hot-idle workers (org=%s): %w", orgID, err)
+	}
+	return workers, nil
+}

--- a/controlplane/configstore/lifecycle_store.go
+++ b/controlplane/configstore/lifecycle_store.go
@@ -51,6 +51,17 @@ func (cs *ConfigStore) ListExpiredHotIdleSnapshotsForCP(ownerCPInstanceID string
 	return workerSnapshotsFromRecords(records), nil
 }
 
+// ListOrgHotIdleSnapshots is the snapshot-typed variant of
+// ListOrgHotIdleWorkers used by the janitor's hot-idle cap sweep. Each
+// snapshot binds the observation to the subsequent retire CAS, oldest-first.
+func (cs *ConfigStore) ListOrgHotIdleSnapshots(orgID string) ([]WorkerSnapshot, error) {
+	records, err := cs.ListOrgHotIdleWorkers(orgID)
+	if err != nil {
+		return nil, err
+	}
+	return workerSnapshotsFromRecords(records), nil
+}
+
 // ListStuckWorkerSnapshots is the snapshot-typed variant of
 // ListStuckWorkers used by the janitor's stuck-spawn/activate reaper.
 func (cs *ConfigStore) ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]WorkerSnapshot, error) {

--- a/controlplane/configstore/migrations/000037_add_org_max_hot_idle_workers.sql
+++ b/controlplane/configstore/migrations/000037_add_org_max_hot_idle_workers.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+ALTER TABLE duckgres_orgs
+    ADD COLUMN IF NOT EXISTS max_hot_idle_workers BIGINT DEFAULT 0;
+
+ALTER TABLE duckgres_orgs
+    ADD COLUMN IF NOT EXISTS max_hot_idle_cpu VARCHAR(32) NOT NULL DEFAULT '';
+
+ALTER TABLE duckgres_orgs
+    ADD COLUMN IF NOT EXISTS max_hot_idle_memory VARCHAR(32) NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE duckgres_orgs
+    DROP COLUMN IF EXISTS max_hot_idle_workers;
+
+ALTER TABLE duckgres_orgs
+    DROP COLUMN IF EXISTS max_hot_idle_cpu;
+
+ALTER TABLE duckgres_orgs
+    DROP COLUMN IF EXISTS max_hot_idle_memory;

--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -15,6 +15,18 @@ type Org struct {
 	HostnameAlias *string `gorm:"size:255;uniqueIndex" json:"hostname_alias"`
 	MaxWorkers    int     `gorm:"default:0" json:"max_workers"`
 	MaxVCPUs      int     `gorm:"column:max_vcpus;default:0" json:"max_vcpus"`
+	// MaxHotIdleWorkers/MaxHotIdleCPU/MaxHotIdleMemory cap what the org may
+	// hold in the hot-idle pool at once — by count, total vCPU, and total
+	// memory (k8s quantity strings like DefaultWorkerCPU/Memory, e.g. "8" /
+	// "64Gi"). 0 / "" = unlimited (the defaults). Enforced by the janitor's
+	// hot-idle cap sweep, which retires the OLDEST parked workers until the
+	// org is within ALL configured limits — convergent (handles cap decreases
+	// and every park path uniformly) rather than park-time. These are the
+	// cost-control counterpart of DefaultWorkerMinHotIdle (the warm-pool
+	// floor); on conflict the caps win — they are the explicit operator intent.
+	MaxHotIdleWorkers int    `gorm:"default:0" json:"max_hot_idle_workers"`
+	MaxHotIdleCPU     string `gorm:"size:32;not null;default:''" json:"max_hot_idle_cpu"`
+	MaxHotIdleMemory  string `gorm:"size:32;not null;default:''" json:"max_hot_idle_memory"`
 	// DefaultWorkerCPU/Memory/TTL are the org's operator-set default worker
 	// profile: the pod shape (k8s resource quantities, e.g. "2"/"8Gi") and
 	// hot-idle TTL (Go duration string, e.g. "75m" — stored as a string for
@@ -563,13 +575,19 @@ type OrgConfig struct {
 	HostnameAlias           string // empty when no alias is configured
 	MaxWorkers              int
 	MaxVCPUs                int
-	DefaultWorkerCPU        string            // org default worker profile: pod cpu quantity ("" = unset)
-	DefaultWorkerMemory     string            // org default worker profile: pod memory quantity ("" = unset)
-	DefaultWorkerTTL        string            // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
-	DefaultWorkerMinHotIdle int               // minimum default-profile hot-idle workers to retain for this org
-	Teams                   []OrgTeamConfig   // the org's PostHog teams (duckgres_org_teams)
-	Users                   map[string]string // username -> password
-	Warehouse               *ManagedWarehouseConfig
+	DefaultWorkerCPU        string // org default worker profile: pod cpu quantity ("" = unset)
+	DefaultWorkerMemory     string // org default worker profile: pod memory quantity ("" = unset)
+	DefaultWorkerTTL        string // org default worker profile: hot-idle TTL, Go duration string ("" = unset)
+	DefaultWorkerMinHotIdle int    // minimum default-profile hot-idle workers to retain for this org
+	// The org's hot-idle pool ceilings (the caps counterpart of
+	// DefaultWorkerMinHotIdle): 0/"" = unlimited. Enforced by the janitor's
+	// hot-idle cap sweep.
+	MaxHotIdleWorkers int
+	MaxHotIdleCPU     string
+	MaxHotIdleMemory  string
+	Teams             []OrgTeamConfig   // the org's PostHog teams (duckgres_org_teams)
+	Users             map[string]string // username -> password
+	Warehouse         *ManagedWarehouseConfig
 }
 
 // OrgTeamConfig is the in-memory snapshot view of one duckgres_org_teams row.

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -7,12 +7,30 @@ import (
 	"time"
 
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
 	janitorRetireReasonOrphaned        = "orphaned"
 	janitorRetireReasonStuckActivating = "stuck_activating"
+	janitorRetireReasonHotIdleCap      = "hot_idle_cap_exceeded"
 )
+
+// orgHotIdleLimit is one org's configured hot-idle pool ceiling. Zero/empty
+// fields are unlimited. DefaultCPU/DefaultMemory are the org's default worker
+// profile, used to resolve the shape of a parked worker that carries no
+// explicit profile (same fallback as the fleet/hot-idle reporting).
+type orgHotIdleLimit struct {
+	Workers       int
+	CPU           string
+	Memory        string
+	DefaultCPU    string
+	DefaultMemory string
+}
+
+func (l orgHotIdleLimit) unlimited() bool {
+	return l.Workers <= 0 && l.CPU == "" && l.Memory == ""
+}
 
 type controlPlaneExpiryStore interface {
 	ExpireControlPlaneInstances(cutoff time.Time) (int64, error)
@@ -21,6 +39,7 @@ type controlPlaneExpiryStore interface {
 	ListStuckWorkerSnapshots(spawningBefore, activatingBefore time.Time) ([]configstore.WorkerSnapshot, error)
 	ListExpiredHotIdleSnapshots(now time.Time, defaultTTL time.Duration) ([]configstore.WorkerSnapshot, error)
 	CountHotIdleWorkers(orgID, image, profileCPU, profileMemory string) (int, error)
+	ListOrgHotIdleSnapshots(orgID string) ([]configstore.WorkerSnapshot, error)
 }
 
 type ControlPlaneJanitor struct {
@@ -41,6 +60,11 @@ type ControlPlaneJanitor struct {
 	cleanupOrphanedWorkerPods     func() // deletes K8s worker pods whose DB row is terminal (retired/lost) or missing (leader-only)
 	reconcileHeadroom             func() // maintains low-priority placeholder pods at the dynamic headroom target (spawn-log-derived count/size; leader-only)
 	hotIdleFloor                  func(configstore.WorkerSnapshot) int
+	// hotIdleCaps returns every org's configured hot-idle pool ceiling (orgs
+	// with no limit set may be omitted). nil disables the cap sweep. Wired
+	// from the config snapshot in multitenant.go, so a cap edit takes effect
+	// on the next tick after the poll reload.
+	hotIdleCaps func() map[string]orgHotIdleLimit
 }
 
 func NewControlPlaneJanitor(store controlPlaneExpiryStore, interval, expiryTimeout time.Duration) *ControlPlaneJanitor {
@@ -195,6 +219,8 @@ func (j *ControlPlaneJanitor) runOnce() {
 				observeHotIdleReapRun(j.now())
 			}
 		}
+
+		j.reapHotIdleCaps()
 	}
 
 	// Gradual rolling replacement of workers whose Deployment version
@@ -221,4 +247,108 @@ func (j *ControlPlaneJanitor) runOnce() {
 		j.reconcileHeadroom()
 	}
 
+}
+
+// reapHotIdleCaps retires each capped org's OLDEST hot-idle workers until the
+// org's parked pool is within ALL of its configured limits (count, total
+// vCPU, total memory). It is deliberately a convergent sweep on the janitor
+// tick — not a park-time check — so it uniformly covers every park path
+// (session release, drain sweep, takeover) AND cap decreases: lower the cap
+// in the admin console and the excess drains on the next ticks. The fenced
+// RetireFromSnapshot CAS makes concurrent leader/fallback/janitor retires
+// safe; the leader janitor runs this, and a wedged leader is already caught
+// by the TTL reaper's last-reap gauge. On conflict with the warm-pool floor
+// (DefaultWorkerMinHotIdle) the CAP wins — it is the explicit operator
+// intent; the floor only guards the TTL reaper. Disabled when hotIdleCaps is
+// nil. Runs even when hotIdleTTL is 0 (the TTL reaper is off) — a cap is a
+// hard ceiling, not a freshness rule.
+func (j *ControlPlaneJanitor) reapHotIdleCaps() {
+	if j.hotIdleCaps == nil {
+		return
+	}
+	caps := j.hotIdleCaps()
+	if len(caps) == 0 {
+		return
+	}
+	for org, lim := range caps {
+		if lim.unlimited() {
+			continue
+		}
+		snaps, err := j.store.ListOrgHotIdleSnapshots(org)
+		if err != nil {
+			slog.Warn("Janitor failed to list org hot-idle workers for cap sweep.", "org", org, "error", err)
+			continue
+		}
+		cpuCap := quantityCores(lim.CPU)    // 0 = unlimited
+		memCap := quantityBytes(lim.Memory) // 0 = unlimited
+
+		// Resolve each parked worker's shape (explicit profile, else the org
+		// default — same fallback as the reporting) and total the pool.
+		type shape struct {
+			cpu float64
+			mem int64
+		}
+		shapes := make([]shape, len(snaps))
+		var totalCPU float64
+		var totalMem int64
+		for i, s := range snaps {
+			cpu, mem := s.ProfileCPU(), s.ProfileMemory()
+			if cpu == "" {
+				cpu = lim.DefaultCPU
+			}
+			if mem == "" {
+				mem = lim.DefaultMemory
+			}
+			shapes[i] = shape{cpu: quantityCores(cpu), mem: quantityBytes(mem)}
+			totalCPU += shapes[i].cpu
+			totalMem += shapes[i].mem
+		}
+
+		// Retire the oldest-first prefix until within ALL limits. On a retire
+		// error, STOP this org (rather than marching on and over-reaping on a
+		// transient failure) — the next tick retries.
+		remaining := len(snaps)
+		for i, s := range snaps {
+			overCount := lim.Workers > 0 && remaining > lim.Workers
+			overCPU := cpuCap > 0 && totalCPU > cpuCap
+			overMem := memCap > 0 && totalMem > memCap
+			if !overCount && !overCPU && !overMem {
+				break
+			}
+			if _, err := j.lifecycle.RetireFromSnapshot(s, configstore.WorkerStateRetired, janitorRetireReasonHotIdleCap, LifecycleOriginJanitorHotIdleCap); err != nil {
+				slog.Warn("Janitor failed to retire hot-idle worker over cap.", "worker", s.WorkerID(), "worker_pod", s.PodName(), "org", org, "error", err)
+				break
+			}
+			slog.Info("Janitor retired hot-idle worker over the org's cap.", "worker", s.WorkerID(), "worker_pod", s.PodName(), "org", org)
+			remaining--
+			totalCPU -= shapes[i].cpu
+			totalMem -= shapes[i].mem
+		}
+	}
+}
+
+// quantityCores/quantityBytes parse k8s quantity strings ("4", "500m",
+// "16Gi") for cap accounting. Unparseable or empty input is 0 — for CAPS
+// that means unlimited, for worker shapes it means the worker contributes
+// nothing (consistent with the fleet/hot-idle reporting's resolution).
+func quantityCores(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0
+	}
+	return q.AsApproximateFloat64()
+}
+
+func quantityBytes(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0
+	}
+	return q.Value()
 }

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -24,6 +24,9 @@ type captureControlPlaneExpiryStore struct {
 	expiredHotIdleWorkers []configstore.WorkerRecord
 	hotIdleCounts         map[string]int
 	hotIdleCountCalls     []string
+	// orgHotIdle fixtures the cap sweep's per-org listing (oldest-first, as
+	// the store guarantees).
+	orgHotIdle map[string][]configstore.WorkerRecord
 }
 
 func (s *captureControlPlaneExpiryStore) ExpireControlPlaneInstances(cutoff time.Time) (int64, error) {
@@ -96,6 +99,19 @@ func (s *captureControlPlaneExpiryStore) ListExpiredHotIdleSnapshots(now time.Ti
 		out = append(out, configstore.NewWorkerSnapshot(rec))
 	}
 	return out, nil
+}
+
+// ListOrgHotIdleSnapshots serves the orgHotIdle fixture (already ordered
+// oldest-first, as the real query guarantees) for the cap sweep.
+func (s *captureControlPlaneExpiryStore) ListOrgHotIdleSnapshots(orgID string) ([]configstore.WorkerSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records := s.orgHotIdle[orgID]
+	snaps := make([]configstore.WorkerSnapshot, len(records))
+	for i, r := range records {
+		snaps[i] = configstore.NewWorkerSnapshot(r)
+	}
+	return snaps, nil
 }
 
 func (s *captureControlPlaneExpiryStore) CountHotIdleWorkers(orgID, image, profileCPU, profileMemory string) (int, error) {
@@ -512,5 +528,103 @@ func TestControlPlaneJanitorRunOnceContinuesAfterExpireError(t *testing.T) {
 	defer mu.Unlock()
 	if lifecycleObserved != 1 {
 		t.Fatalf("expected worker lifecycle observation despite expiry error, got %d", lifecycleObserved)
+	}
+}
+
+// The hot-idle cap sweep retires ONLY the oldest parked workers past a
+// capped org's limits — by count, by total vCPU, and by total memory —
+// leaving orgs within their limits alone. The store returns oldest-first; the
+// sweep must retire exactly the prefix needed to get within ALL limits — the
+// longest-parked excess goes first, fresh warm capacity stays.
+func TestControlPlaneJanitorHotIdleCapSweep(t *testing.T) {
+	since := time.Now().Add(-time.Hour)
+	hotIdle := func(id int, pod, org, cpu, mem string) configstore.WorkerRecord {
+		return configstore.WorkerRecord{
+			WorkerID: id, PodName: pod, State: configstore.WorkerStateHotIdle, OrgID: org,
+			OwnerCPInstanceID: "cp-a", OwnerEpoch: 1, HotIdleSince: &since,
+			ProfileCPU: cpu, ProfileMemory: mem,
+		}
+	}
+	store := &captureControlPlaneExpiryStore{
+		orgHotIdle: map[string][]configstore.WorkerRecord{
+			// Count cap 2 with 3 parked → retire exactly the oldest.
+			"acme": {
+				hotIdle(11, "w-acme-old", "acme", "2", "8Gi"),
+				hotIdle(12, "w-acme-mid", "acme", "2", "8Gi"),
+				hotIdle(13, "w-acme-new", "acme", "2", "8Gi"),
+			},
+			// CPU cap "6" with 2×4 cores parked → retire the oldest (4 ≤ 6).
+			// Second worker carries no profile → resolves via the org default.
+			"globex": {
+				hotIdle(21, "w-globex-old", "globex", "4", "16Gi"),
+				hotIdle(22, "w-globex-new", "globex", "", ""),
+			},
+			// Memory cap "20Gi" with 2×16Gi parked → retire the oldest (16 ≤ 20).
+			"initech": {
+				hotIdle(31, "w-initech-old", "initech", "4", "16Gi"),
+				hotIdle(32, "w-initech-new", "initech", "4", "16Gi"),
+			},
+			// Under all its limits — left alone.
+			"under": {
+				hotIdle(41, "w-under-1", "under", "2", "8Gi"),
+			},
+		},
+	}
+	lifecycleStore := &fakeLifecycleStore{terminalReturn: true}
+	cleanup := &fakePhysicalCleanup{}
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.now = func() time.Time { return time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC) }
+	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, cleanup)
+	janitor.hotIdleCaps = func() map[string]orgHotIdleLimit {
+		return map[string]orgHotIdleLimit{
+			"acme":    {Workers: 2},
+			"globex":  {CPU: "6", DefaultCPU: "4", DefaultMemory: "16Gi"},
+			"initech": {Memory: "20Gi"},
+			"under":   {Workers: 5, CPU: "16", Memory: "64Gi"},
+		}
+	}
+
+	janitor.runOnce()
+
+	var retired []int
+	for _, tr := range lifecycleStore.terminalTransitions {
+		if tr.target != configstore.WorkerStateRetired || tr.reason != janitorRetireReasonHotIdleCap {
+			t.Fatalf("unexpected transition: %#v", tr)
+		}
+		retired = append(retired, tr.workerID)
+	}
+	want := []int{11, 21, 31} // exactly the oldest excess of each over-limit org
+	if len(retired) != len(want) {
+		t.Fatalf("retired %v, want %v", retired, want)
+	}
+	seen := map[int]bool{}
+	for _, id := range retired {
+		seen[id] = true
+	}
+	for _, id := range want {
+		if !seen[id] {
+			t.Fatalf("worker %d not retired: %v", id, retired)
+		}
+	}
+}
+
+// A nil hotIdleCaps function (unwired) must disable the sweep entirely — no
+// store calls, no retires.
+func TestControlPlaneJanitorHotIdleCapSweepDisabledWhenUnwired(t *testing.T) {
+	store := &captureControlPlaneExpiryStore{
+		orgHotIdle: map[string][]configstore.WorkerRecord{
+			"acme": {
+				{WorkerID: 11, PodName: "w-acme-1", State: configstore.WorkerStateHotIdle, OrgID: "acme", OwnerCPInstanceID: "cp-a", OwnerEpoch: 1},
+			},
+		},
+	}
+	lifecycleStore := &fakeLifecycleStore{terminalReturn: true}
+	janitor := NewControlPlaneJanitor(store, 10*time.Millisecond, 20*time.Second)
+	janitor.lifecycle = NewWorkerLifecycle(lifecycleStore, &fakePhysicalCleanup{})
+
+	janitor.runOnce()
+
+	if len(lifecycleStore.terminalTransitions) != 0 {
+		t.Fatalf("unwired caps must retire nothing, got %#v", lifecycleStore.terminalTransitions)
 	}
 }

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -428,6 +428,30 @@ func SetupMultiTenant(
 		}
 		return org.DefaultWorkerMinHotIdle
 	}
+	// Hot-idle pool caps (max_hot_idle_*): the sweep reads the same config
+	// snapshot as the floor, so an admin-console cap edit takes effect on the
+	// next tick after the config poll reloads. Only orgs with at least one
+	// limit set appear (the sweep skips unlimited orgs anyway).
+	janitor.hotIdleCaps = func() map[string]orgHotIdleLimit {
+		snapshot := store.Snapshot()
+		if snapshot == nil {
+			return nil
+		}
+		caps := make(map[string]orgHotIdleLimit)
+		for name, org := range snapshot.Orgs {
+			if org == nil || (org.MaxHotIdleWorkers <= 0 && org.MaxHotIdleCPU == "" && org.MaxHotIdleMemory == "") {
+				continue
+			}
+			caps[name] = orgHotIdleLimit{
+				Workers:       org.MaxHotIdleWorkers,
+				CPU:           org.MaxHotIdleCPU,
+				Memory:        org.MaxHotIdleMemory,
+				DefaultCPU:    org.DefaultWorkerCPU,
+				DefaultMemory: org.DefaultWorkerMemory,
+			}
+		}
+		return caps
+	}
 	// Node-headroom controller: keep low-priority placeholder pods as warm,
 	// preemptible spare capacity so worker spawns schedule immediately.
 	// Leader-only (runs on the janitor tick). Always wired — reconcileHeadroom

--- a/controlplane/worker_lifecycle_metrics.go
+++ b/controlplane/worker_lifecycle_metrics.go
@@ -47,6 +47,12 @@ const (
 	LifecycleOriginJanitorOrphan           LifecycleOrigin = "janitor_orphan"
 	LifecycleOriginJanitorHotIdleTTL       LifecycleOrigin = "janitor_hot_idle_ttl"
 	LifecycleOriginJanitorStuckActivating  LifecycleOrigin = "janitor_stuck_activating"
+	// LifecycleOriginJanitorHotIdleCap marks the janitor's hot-idle cap sweep
+	// (reapHotIdleCaps) retiring the oldest parked workers of an org past its
+	// configured max_hot_idle_* limits. Distinct from the TTL reaper: a
+	// nonzero rate here means an operator's cost ceiling is biting, not that
+	// warm capacity went stale.
+	LifecycleOriginJanitorHotIdleCap LifecycleOrigin = "janitor_hot_idle_cap"
 	LifecycleOriginMismatchedVersionReaper LifecycleOrigin = "mismatched_version_reaper"
 	LifecycleOriginShutdownAll             LifecycleOrigin = "shutdown_all"
 	// LifecycleOriginDrainReleaseIdle marks the hot -> hot_idle park performed

--- a/tests/configstore/hot_idle_reporting_postgres_test.go
+++ b/tests/configstore/hot_idle_reporting_postgres_test.go
@@ -1,0 +1,92 @@
+//go:build linux || darwin
+
+package configstore_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+// Hot-idle reporting + the cap sweep's listing, against the real migrated
+// schema: per-org hot-idle counts with resolved worker shapes for the admin
+// dashboard, and the oldest-first ordering the cap reaper relies on to retire
+// the longest-parked excess first.
+func TestHotIdleReportingPostgres(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	seedOrg(t, store, "acme")
+	seedOrg(t, store, "globex")
+	if err := store.DB().Exec(`UPDATE duckgres_orgs SET default_worker_cpu = '2', default_worker_memory = '8Gi' WHERE name = 'acme'`).Error; err != nil {
+		t.Fatalf("set acme default profile: %v", err)
+	}
+
+	now := time.Now().UTC()
+	ago := func(d time.Duration) *time.Time { t := now.Add(-d); return &t }
+	records := []configstore.WorkerRecord{
+		// acme: three hot-idle workers — one with an explicit profile, two
+		// falling back to the org default — plus a Hot one (not idle, must
+		// not count).
+		{WorkerID: 2101, PodName: "w-acme-1", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "acme", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(3 * time.Hour), ProfileCPU: "4", ProfileMemory: "16Gi", LastHeartbeatAt: now},
+		{WorkerID: 2102, PodName: "w-acme-2", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "acme", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(1 * time.Hour), LastHeartbeatAt: now},
+		{WorkerID: 2103, PodName: "w-acme-3", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "acme", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(2 * time.Hour), LastHeartbeatAt: now},
+		{WorkerID: 2104, PodName: "w-acme-4", Image: "img", State: configstore.WorkerStateHot, OrgID: "acme", OwnerCPInstanceID: "cp-a", LastHeartbeatAt: now},
+		// globex: one hot-idle worker.
+		{WorkerID: 2105, PodName: "w-globex-1", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "globex", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(30 * time.Minute), ProfileCPU: "1", ProfileMemory: "4Gi", LastHeartbeatAt: now},
+	}
+	for _, r := range records {
+		r := r
+		if err := store.UpsertWorkerRecord(&r); err != nil {
+			t.Fatalf("upsert worker %d: %v", r.WorkerID, err)
+		}
+	}
+
+	// ---- per-org reporting ----
+	stats, err := store.ListHotIdleByOrg()
+	if err != nil {
+		t.Fatalf("ListHotIdleByOrg: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("want 2 orgs with hot-idle workers, got %d: %+v", len(stats), stats)
+	}
+	byOrg := map[string]configstore.HotIdleOrgStat{}
+	for _, s := range stats {
+		byOrg[s.OrgID] = s
+	}
+	acme, ok := byOrg["acme"]
+	if !ok || acme.Count != 3 {
+		t.Fatalf("acme stat wrong (Hot worker must not count): %+v", acme)
+	}
+	// CPU: 4 (explicit) + 2 + 2 (org default) = 8 cores; mem: 16 + 8 + 8 = 32 Gi.
+	if acme.CPUCores != 8 {
+		t.Fatalf("acme cpu = %v, want 8 (explicit profile + org-default fallback)", acme.CPUCores)
+	}
+	if acme.MemoryBytes != 32*1024*1024*1024 {
+		t.Fatalf("acme mem = %v, want 32Gi", acme.MemoryBytes)
+	}
+	if acme.OldestHotIdleSince == nil || acme.OldestHotIdleSince.After(now.Add(-2*time.Hour)) {
+		t.Fatalf("acme oldest since = %v, want ~3h ago", acme.OldestHotIdleSince)
+	}
+	globex, ok := byOrg["globex"]
+	if !ok || globex.Count != 1 || globex.CPUCores != 1 {
+		t.Fatalf("globex stat wrong: %+v", globex)
+	}
+
+	// ---- cap sweep listing: one org, oldest first ----
+	snaps, err := store.ListOrgHotIdleSnapshots("acme")
+	if err != nil {
+		t.Fatalf("ListOrgHotIdleSnapshots: %v", err)
+	}
+	if len(snaps) != 3 {
+		t.Fatalf("want 3 acme hot-idle snapshots, got %d", len(snaps))
+	}
+	// Oldest (3h ago = worker 2101) first — the cap reaper retires the prefix.
+	if snaps[0].WorkerID() != 2101 || snaps[1].WorkerID() != 2103 || snaps[2].WorkerID() != 2102 {
+		t.Fatalf("not ordered oldest-first: %d %d %d", snaps[0].WorkerID(), snaps[1].WorkerID(), snaps[2].WorkerID())
+	}
+	// An org with no hot-idle workers returns empty, not error.
+	snaps, err = store.ListOrgHotIdleSnapshots("no-such-org")
+	if err != nil || len(snaps) != 0 {
+		t.Fatalf("unknown org: snaps=%d err=%v", len(snaps), err)
+	}
+}

--- a/tests/configstore/migrations_postgres_test.go
+++ b/tests/configstore/migrations_postgres_test.go
@@ -55,7 +55,8 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireGooseMigrationRecorded(t, db, 34)
 	requireGooseMigrationRecorded(t, db, 35)
 	requireGooseMigrationRecorded(t, db, 36)
-	requireGooseLatestVersion(t, db, 36)
+	requireGooseMigrationRecorded(t, db, 37)
+	requireGooseLatestVersion(t, db, 37)
 	requireTableAbsent(t, db, "duckgres_schema_migrations")
 
 	// Migration 000018 added the reshard operation + verbose log tables.
@@ -169,6 +170,13 @@ func TestConfigStoreRunsVersionedSQLMigrations(t *testing.T) {
 	requireColumnType(t, db, "duckgres_org_storage_usage", "team_id", "bigint")
 	requireColumnType(t, db, "duckgres_org_storage_usage", "byte_seconds", "numeric")
 
+	// Migration 000037 added the per-org hot-idle pool caps: count (0 =
+	// unlimited) plus vCPU / memory totals as k8s quantity strings ('' =
+	// unlimited).
+	requireColumnType(t, db, "duckgres_orgs", "max_hot_idle_workers", "bigint")
+	requireColumnPresent(t, db, "duckgres_orgs", "max_hot_idle_cpu")
+	requireColumnPresent(t, db, "duckgres_orgs", "max_hot_idle_memory")
+
 	// Migration 000008 added the explicit Duckling CR name column on
 	// managed warehouses, backfilled from lower(org_id).
 	requireColumnPresent(t, db, "duckgres_managed_warehouses", "duckling_name")
@@ -242,6 +250,9 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	})
 	if err := store.DB().Exec(`
 			ALTER TABLE duckgres_orgs DROP COLUMN data_imports_table_naming_version;
+			ALTER TABLE duckgres_orgs DROP COLUMN max_hot_idle_workers;
+			ALTER TABLE duckgres_orgs DROP COLUMN max_hot_idle_cpu;
+			ALTER TABLE duckgres_orgs DROP COLUMN max_hot_idle_memory;
 			ALTER TABLE duckgres_orgs DROP COLUMN max_vcpus;
 			ALTER TABLE duckgres_org_users DROP COLUMN max_vcpus;
 			ALTER TABLE duckgres_org_users DROP COLUMN disabled;
@@ -272,7 +283,7 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 			DROP TABLE IF EXISTS duckgres_reshard_operation_log;
 			DROP TABLE IF EXISTS duckgres_reshard_operations;
 			DROP TABLE IF EXISTS duckgres_service_grants;
-			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36);
+			DELETE FROM goose_db_version WHERE version_id IN (9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37);
 		`).Error; err != nil {
 		t.Fatalf("downgrade baseline schema to pre-v9 shape: %v", err)
 	}
@@ -322,7 +333,8 @@ func TestConfigStoreSQLMigrationsUpgradeVersion8Schema(t *testing.T) {
 	requireGooseMigrationRecorded(t, upgradedDB, 34)
 	requireGooseMigrationRecorded(t, upgradedDB, 35)
 	requireGooseMigrationRecorded(t, upgradedDB, 36)
-	requireGooseLatestVersion(t, upgradedDB, 36)
+	requireGooseMigrationRecorded(t, upgradedDB, 37)
+	requireGooseLatestVersion(t, upgradedDB, 37)
 	requireColumnPresent(t, upgradedDB, "duckgres_reshard_operations", "password_url")
 	requireTablePresent(t, upgradedDB, "duckgres_worker_spawn_log")
 	requireColumnDefault(t, upgradedDB, "duckgres_orgs", "max_vcpus", "0")
@@ -365,7 +377,7 @@ func TestConfigStoreSQLMigration34VersionsExistingAndNewOrgs(t *testing.T) {
 		ALTER TABLE duckgres_orgs DROP COLUMN data_imports_table_naming_version;
 		ALTER TABLE duckgres_org_users DROP COLUMN IF EXISTS service_grant_expires_at;
 		DROP TABLE IF EXISTS duckgres_service_grants;
-		DELETE FROM goose_db_version WHERE version_id IN (34, 35, 36);
+		DELETE FROM goose_db_version WHERE version_id IN (34, 35, 36, 37);
 	`).Error; err != nil {
 		t.Fatalf("restore pre-migration-34 schema: %v", err)
 	}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -874,6 +874,50 @@ compute_usage_pull_api() { # org password
   log "storage-usage OK: shared ack advanced the cursor past storage buckets"
 }
 
+# Hot-idle pool reporting + the per-org cap sweep. compute_usage_pull_api
+# just closed its connections, so this org holds >=1 parked hot-idle worker
+# that must be visible in GET /api/v1/workers/hot-idle (per-org count, vCPU,
+# memory, oldest-park, configured caps). Setting the org's
+# max_hot_idle_workers below its parked count must converge the pool DOWN via
+# the janitor's cap sweep (5s tick + config-poll snapshot reload — the poll
+# below covers both), retiring the OLDEST excess; restoring 0 (unlimited)
+# afterwards leaves the remaining parked worker alone.
+hot_idle_reporting_and_cap() { # org
+  org="$1"
+  log "hot-idle reporting + cap sweep on $org"
+
+  a=0 count=0 body=""
+  while [ "$a" -lt 12 ]; do
+    body="$(curl -fsS -H "$H" "$API/api/v1/workers/hot-idle")" || body=""
+    count="$(echo "$body" | jq -r --arg o "$org" '[.orgs[] | select(.org_id==$o)][0].count // 0')"
+    [ "${count:-0}" -ge 1 ] && break
+    sleep 10; a=$((a + 1))
+  done
+  [ "${count:-0}" -ge 1 ] || fail "hot-idle: $org never showed a parked worker in /workers/hot-idle: $(echo "$body" | head -c 400)"
+  echo "$body" | jq -e --arg o "$org" '.orgs[] | select(.org_id==$o) | has("cpu_cores") and has("memory_bytes") and has("oldest_hot_idle_since") and has("cap_workers") and has("cap_cpu") and has("cap_memory")' >/dev/null \
+    || fail "hot-idle: $org row missing shape/cap fields: $(echo "$body" | head -c 400)"
+  log "hot-idle OK: $org holds $count parked worker(s) with shape + cap fields"
+
+  # Cap the pool at 1: the sweep must retire the excess down to <= 1.
+  curl -fsS -X PUT -H "$H" -H 'Content-Type: application/json' \
+    -d '{"max_hot_idle_workers":1}' "$API/api/v1/orgs/$org" >/dev/null \
+    || fail "hot-idle: PUT max_hot_idle_workers=1 failed"
+  a=0 after=999
+  while [ "$a" -lt 12 ]; do
+    after="$(curl -fsS -H "$H" "$API/api/v1/workers/hot-idle" | jq -r --arg o "$org" '[.orgs[] | select(.org_id==$o)][0].count // 0')"
+    [ "${after:-999}" -le 1 ] && break
+    sleep 10; a=$((a + 1))
+  done
+  [ "${after:-999}" -le 1 ] || fail "hot-idle: cap=1 never converged for $org (count=$after after 2m)"
+  log "hot-idle OK: cap=1 converged $org (count=$after)"
+
+  # Restore unlimited so the rest of the lane sees default behavior.
+  curl -fsS -X PUT -H "$H" -H 'Content-Type: application/json' \
+    -d '{"max_hot_idle_workers":0}' "$API/api/v1/orgs/$org" >/dev/null \
+    || fail "hot-idle: PUT restore max_hot_idle_workers=0 failed"
+  log "hot-idle OK: cap restored to unlimited"
+}
+
 # jsonb || must keep Postgres concatenation semantics through the full CP
 # transpile → worker DuckDB execute path (regression for #716: the transpiler
 # used to rewrite it to json_merge_patch, which REPLACED arrays instead of
@@ -2825,6 +2869,12 @@ admin_console_api() {
     || fail "/orgs/$CNPG/usage/daily did not return its envelope"
   code="$(curl -s -o /dev/null -w '%{http_code}' -H "$H" "$API/api/v1/orgs/$CNPG/usage/daily?days=99")"
   [ "$code" = "400" ] || fail "/orgs/$CNPG/usage/daily?days=99 returned $code, want 400"
+  # Hot-idle pool reporting (Workers page "Hot idle by org" card): envelope
+  # only here; the populated path + cap convergence are asserted in
+  # hot_idle_reporting_and_cap against real parked workers.
+  curl -fsS -H "$H" "$API/api/v1/workers/hot-idle" \
+    | jq -e 'has("orgs") and (.orgs | type == "array")' >/dev/null \
+    || fail "/workers/hot-idle did not return its {orgs:[...]} envelope"
 
   # The metrics proxy advertises its allow-listed panels (not an open PromQL relay).
   # Includes the per-org/per-source worker-acquire-latency panels. (The raw
@@ -4495,6 +4545,9 @@ main() {
 
   # ---- compute-usage billing pull API (meter → buffer → GET → ack) ----
   compute_usage_pull_api "$CNPG" "$cnpg_pw"
+
+  # ---- hot-idle pool reporting + per-org cap sweep ----
+  hot_idle_reporting_and_cap "$CNPG"
 
   # ---- cross-tenant isolation between independent CNPG-backed orgs ----
   tenant_isolation "$CNPG" "$cnpg_pw" "$RES1" "$res1_pw"


### PR DESCRIPTION
## Summary

Two operator surfaces for the hot-idle pool, both over the durable runtime store ( — the only source that sees parked workers, since they hold no session):

**Reporting** — see which orgs are holding workers in the hot-idle pool:
- `GET /api/v1/workers/hot-idle` (viewer-allowed, operational fleet state): per-org parked count, summed vCPU/memory (explicit profile → org-default fallback, same as the fleet rollup), oldest park, **plus each org's configured caps**.
- Workers page gains a **"Hot idle by org"** card linking through to each org.

**Caps** — tune the max hot-idle pool per org, the cost-control counterpart of the existing `DefaultWorkerMinHotIdle` floor:
- `max_hot_idle_workers` (count), `max_hot_idle_cpu`, `max_hot_idle_memory` (k8s quantity strings like the default worker profile; 0/"" = unlimited). Migration 000037; editable on the org detail page + admin org PUT (presence-aware, audited).
- **Enforcement is a convergent janitor sweep**, not a park-time check: each tick retires the OLDEST parked workers (fenced CAS, new `janitor_hot_idle_cap` metric origin) until the org is within ALL configured limits. Uniform across every park path, and a cap *decrease* drains the excess on the next ticks. A retire error stops that org for the tick rather than over-reaping.
- **Cap wins over the floor** (explicit operator intent); the sweep runs even when the TTL reaper is disabled.
- **Fail-closed validation**: an unparseable or non-positive cap quantity 400s at write time, because the sweep reads those as UNLIMITED — a typo must never silently mean "no cap".

## Testing (TDD red-green)

- `tests/configstore/hot_idle_reporting_postgres_test.go` — real-Postgres per-org aggregation (Hot excluded, profile fallback, oldest-since) + oldest-first listing; migration asserts (incl. goose-version bumps + GORM-metadata parity).
- `controlplane/janitor_test.go` — count/vCPU/memory caps retire exactly the oldest excess; under-limit orgs untouched; nil caps disable the sweep.
- `controlplane/admin` — `TestUpdateOrgHotIdleCaps` (presence-aware merge incl. clearing), `TestUpdateOrgHotIdleCapsRejectBadQuantities`, `TestHotIdleRoute`.
- UI — `Workers.test.tsx` (card, caps, org link, empty state), `OrgDetail.test.tsx` (form mapping).
- `tests/mw-dev/e2e/harness.sh` — `/workers/hot-idle` envelope in `admin_console_api`, plus `hot_idle_reporting_and_cap`: reporting on real parked workers after `compute_usage_pull_api`, then cap=1 convergence via the real janitor, then restore.

`just lint` clean; controlplane + admin + configstore + provisioning suites green; UI suite green (123 tests, typecheck + build).

Docs: admin README API table, CLAUDE.md hot-idle section (invariants + touching-list).