### PR TITLE
admin: sortable hot-idle table + fix zero cpu/memory shape fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,10 +491,15 @@ no session):
 - **Reporting**: `configstore.ListHotIdleByOrg` aggregates `hot_idle` rows
   per org (count, summed vCPU/memory, oldest park) and
   `GET /api/v1/workers/hot-idle` (`controlplane/admin/live.go`) joins each
-  org's configured caps. Backs the Workers page "Hot idle by org" card.
-  Worker shape resolution mirrors the fleet rollup: the worker's explicit
-  profile wins, else the org's default worker profile; unparseable
-  quantities contribute 0.
+  org's configured caps. Backs the Workers page "Hot idle by org" card
+  (sortable, default memory-pinned desc). **Worker shape resolution is a
+  three-step chain, everywhere**: the worker's explicit profile wins, else
+  the org's default worker profile, else the CP-global default worker shape
+  (`cfg.K8s.WorkerCPURequest`/`MemoryRequest`, else the 8/16Gi constants) —
+  an unsized worker on a default-less org must never report zero cpu/memory
+  (it pins real pod requests). The same chain backs the fleet rollup
+  (`ListWorkerLifecycleStats`) and the cap sweep's shape math
+  (`orgHotIdleLimitsFromSnapshot`); unparseable quantities still contribute 0.
 - **Caps**: `max_hot_idle_workers` (count), `max_hot_idle_cpu` and
   `max_hot_idle_memory` (k8s quantity strings, e.g. `"16"` / `"64Gi"`) on
   `duckgres_orgs` (migration 000037; 0/"" = unlimited). Editable via the
@@ -520,7 +525,8 @@ no session):
     — a cap is a hard ceiling, not a freshness rule.
 - Touching any of this → update `tests/configstore/hot_idle_reporting_postgres_test.go`
   (+ the migration asserts in `migrations_postgres_test.go`),
-  `controlplane/janitor_test.go` (the cap sweep cases),
+  `controlplane/janitor_test.go` (the cap sweep cases +
+  `TestOrgHotIdleLimitsFromSnapshot` glue test),
   `controlplane/admin/api_test.go` (`TestUpdateOrgHotIdleCaps*`) +
   `live_test.go` (`TestHotIdleRoute`), `ui/src/pages/Workers.test.tsx` +
   `OrgDetail.test.tsx`, AND the `/workers/hot-idle` envelope +

--- a/controlplane/admin/ui/src/pages/Workers.test.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.test.tsx
@@ -69,6 +69,17 @@ describe("Workers page hot-idle card", () => {
     expect(screen.getByText("globex")).toBeInTheDocument();
   });
 
+  it("sorts the list by memory pinned, largest first", () => {
+    renderPage();
+    // acme pins 32Gi, globex 8Gi — acme's row must come first in document
+    // order regardless of API ordering.
+    const acmeRow = screen.getByText("Acme Inc").closest("tr")!;
+    const globexRow = screen.getByText("globex").closest("tr")!;
+    expect(
+      acmeRow.compareDocumentPosition(globexRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("renders an empty state when nothing is parked", () => {
     hooks.useHotIdle.mockReturnValue(ok([]));
     renderPage();

--- a/controlplane/admin/ui/src/pages/Workers.tsx
+++ b/controlplane/admin/ui/src/pages/Workers.tsx
@@ -9,11 +9,10 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useFleet, useHotIdle, useOrgLabels, useWorkers } from "@/hooks/useApi";
 import { OrgRef } from "@/components/OrgRef";
 import { fmtAge, fmtBytes, fmtDuration, fmtInt, fmtUnits } from "@/lib/format";
-import type { WorkerStatus } from "@/types/api";
+import type { HotIdleOrg, WorkerStatus } from "@/types/api";
 
 // Canonical lifecycle-state order for the rollup chips.
 const STATE_ORDER = ["spawning", "idle", "reserved", "activating", "hot", "hot_idle", "draining"];
@@ -44,6 +43,67 @@ export function Workers() {
   const totalFleet = useMemo(() => fleetRows.reduce((n, f) => n + f.count, 0), [fleetRows]);
   const totalCpu = useMemo(() => fleetRows.reduce((n, f) => n + (f.cpu_cores ?? 0), 0), [fleetRows]);
   const totalMem = useMemo(() => fleetRows.reduce((n, f) => n + (f.memory_bytes ?? 0), 0), [fleetRows]);
+
+  const hotIdleColumns = useMemo<ColumnDef<HotIdleOrg, any>[]>(
+    () => [
+      {
+        accessorKey: "org_id",
+        header: "Org",
+        cell: ({ row }) => (
+          <Link to={`/orgs/${encodeURIComponent(row.original.org_id)}`} className="block hover:underline">
+            <OrgRef id={row.original.org_id} label={orgLabels.get(row.original.org_id)} copyable={false} />
+          </Link>
+        ),
+      },
+      {
+        accessorKey: "count",
+        header: "Workers",
+        cell: ({ row }) => {
+          const o = row.original;
+          return (
+            <span className="font-mono text-xs">
+              {fmtInt(o.count)}
+              {o.cap_workers > 0 && (
+                <span className={o.count > o.cap_workers ? "text-destructive" : "text-muted-foreground"}>
+                  {" "}/ {o.cap_workers}
+                </span>
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        accessorKey: "cpu_cores",
+        header: "vCPU",
+        cell: ({ getValue }) => <span className="font-mono text-xs">{fmtUnits(getValue() as number)}</span>,
+      },
+      {
+        accessorKey: "memory_bytes",
+        header: "Memory",
+        cell: ({ getValue }) => <span className="font-mono text-xs">{fmtBytes(getValue() as number)}</span>,
+      },
+      {
+        accessorKey: "oldest_hot_idle_since",
+        header: "Longest idle",
+        cell: ({ getValue }) => {
+          const v = getValue() as string | null;
+          return <span className="text-xs text-muted-foreground">{v ? fmtAge(v) : "—"}</span>;
+        },
+      },
+      {
+        id: "cap",
+        header: "Cap",
+        accessorFn: (o: HotIdleOrg) =>
+          o.cap_workers > 0 || o.cap_cpu || o.cap_memory
+            ? [o.cap_workers > 0 ? `${o.cap_workers} workers` : null, o.cap_cpu || null, o.cap_memory || null]
+                .filter(Boolean)
+                .join(" · ")
+            : "—",
+        cell: ({ getValue }) => <span className="text-xs text-muted-foreground">{String(getValue())}</span>,
+      },
+    ],
+    [orgLabels],
+  );
 
   const columns = useMemo<ColumnDef<WorkerStatus, any>[]>(
     () => [
@@ -186,53 +246,14 @@ export function Workers() {
             ) : hotIdleRows.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">No workers are parked hot-idle.</p>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead>Org</TableHead>
-                    <TableHead>Workers</TableHead>
-                    <TableHead>vCPU</TableHead>
-                    <TableHead>Memory</TableHead>
-                    <TableHead>Longest idle</TableHead>
-                    <TableHead>Cap</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {hotIdleRows.map((o) => (
-                    <TableRow key={o.org_id}>
-                      <TableCell>
-                        <Link to={`/orgs/${encodeURIComponent(o.org_id)}`} className="block hover:underline">
-                          <OrgRef id={o.org_id} label={orgLabels.get(o.org_id)} copyable={false} />
-                        </Link>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">
-                        {fmtInt(o.count)}
-                        {o.cap_workers > 0 && (
-                          <span className={o.count > o.cap_workers ? "text-destructive" : "text-muted-foreground"}>
-                            {" "}/ {o.cap_workers}
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{fmtUnits(o.cpu_cores)}</TableCell>
-                      <TableCell className="font-mono text-xs">{fmtBytes(o.memory_bytes)}</TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {o.oldest_hot_idle_since ? fmtAge(o.oldest_hot_idle_since) : "—"}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {o.cap_workers > 0 || o.cap_cpu || o.cap_memory
-                          ? [
-                              o.cap_workers > 0 ? `${o.cap_workers} workers` : null,
-                              o.cap_cpu || null,
-                              o.cap_memory || null,
-                            ]
-                              .filter(Boolean)
-                              .join(" · ")
-                          : "—"}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <DataTable
+                data={hotIdleRows}
+                columns={hotIdleColumns}
+                // Default: most memory pinned first — that's the resource that
+                // pins nodes. Workers/vCPU/memory headers are clickable to
+                // re-sort.
+                initialSorting={[{ id: "memory_bytes", desc: true }]}
+              />
             )}
           </CardContent>
         </Card>

--- a/controlplane/admin_providers.go
+++ b/controlplane/admin_providers.go
@@ -23,6 +23,12 @@ type clusterInfoProvider struct {
 	srv              *server.Server
 	selfCPID         string
 	metadataSessions *metadataProxySessionRegistry
+	// defaultWorkerCPU/Memory are the CP-global default worker shape (the pod
+	// requests unsized workers are actually spawned with) — the final
+	// fallback in shape resolution for fleet/hot-idle reporting so an unsized
+	// worker on a default-less org doesn't report zero cpu/memory.
+	defaultWorkerCPU    string
+	defaultWorkerMemory string
 }
 
 var _ admin.LiveInfo = (*clusterInfoProvider)(nil)
@@ -135,7 +141,7 @@ func (p *clusterInfoProvider) QueryDetailForWorkerID(workerID int) (admin.QueryD
 // durable runtime store — the only source that sees hot-idle/spawning/draining
 // workers that hold no session.
 func (p *clusterInfoProvider) WorkerFleet() ([]admin.FleetStat, error) {
-	stats, err := p.store.ListWorkerLifecycleStats()
+	stats, err := p.store.ListWorkerLifecycleStats(p.defaultWorkerCPU, p.defaultWorkerMemory)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +162,7 @@ func (p *clusterInfoProvider) WorkerFleet() ([]admin.FleetStat, error) {
 // HotIdleByOrg returns each org's hot-idle pool footprint (durable runtime
 // store) joined with its configured max_hot_idle_* caps (config orgs table).
 func (p *clusterInfoProvider) HotIdleByOrg() ([]admin.HotIdleOrg, error) {
-	stats, err := p.store.ListHotIdleByOrg()
+	stats, err := p.store.ListHotIdleByOrg(p.defaultWorkerCPU, p.defaultWorkerMemory)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/configstore/hot_idle.go
+++ b/controlplane/configstore/hot_idle.go
@@ -22,11 +22,13 @@ type HotIdleOrgStat struct {
 }
 
 // ListHotIdleByOrg aggregates hot_idle worker rows per org for the admin
-// dashboard. Worker shape resolution mirrors ListWorkerLifecycleStats: the
-// worker's explicit profile wins, else the org's default worker profile;
-// unparseable/empty quantities contribute 0. Orgs with no hot-idle workers
-// do not appear.
-func (cs *ConfigStore) ListHotIdleByOrg() ([]HotIdleOrgStat, error) {
+// dashboard. Worker shape resolution: the worker's explicit profile wins,
+// else the org's default worker profile, else the CP-global default worker
+// shape passed by the caller (defaultCPU/defaultMemory — the pod requests the
+// worker was actually spawned with; pass "" to keep the legacy
+// zero-contribution). Unparseable quantities contribute 0. Orgs with no
+// hot-idle workers do not appear.
+func (cs *ConfigStore) ListHotIdleByOrg(defaultCPU, defaultMemory string) ([]HotIdleOrgStat, error) {
 	workerTable := cs.runtimeTable((&WorkerRecord{}).TableName())
 	orgTable := (&Org{}).TableName()
 	type workerRow struct {
@@ -36,11 +38,12 @@ func (cs *ConfigStore) ListHotIdleByOrg() ([]HotIdleOrgStat, error) {
 		HotIdleSince *time.Time
 	}
 	var rows []workerRow
-	err := cs.db.Table(workerTable + " AS w").
+	err := cs.db.Table(workerTable+" AS w").
 		Select("w.org_id AS org_id, "+
-			"COALESCE(NULLIF(w.profile_cpu, ''), o.default_worker_cpu, '') AS cpu, "+
-			"COALESCE(NULLIF(w.profile_memory, ''), o.default_worker_memory, '') AS memory, "+
-			"w.hot_idle_since AS hot_idle_since").
+			"COALESCE(NULLIF(w.profile_cpu, ''), NULLIF(o.default_worker_cpu, ''), ?) AS cpu, "+
+			"COALESCE(NULLIF(w.profile_memory, ''), NULLIF(o.default_worker_memory, ''), ?) AS memory, "+
+			"w.hot_idle_since AS hot_idle_since",
+			defaultCPU, defaultMemory).
 		Joins("LEFT JOIN " + orgTable + " AS o ON o.name = w.org_id").
 		Where("w.state = ? AND w.org_id <> ''", WorkerStateHotIdle).
 		Order("w.org_id ASC").

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1134,13 +1134,16 @@ func (cs *ConfigStore) runtimeTable(base string) string {
 // ListWorkerLifecycleStats returns grouped cluster-wide active worker lifecycle
 // state by image and tenant binding for Prometheus observability, with summed
 // cpu cores and memory bytes per group.
-func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error) {
+func (cs *ConfigStore) ListWorkerLifecycleStats(defaultCPU, defaultMemory string) ([]WorkerLifecycleStats, error) {
 	// "neutral" (empty org_id) is legacy — every worker is org-bound from spawn
 	// now; the branch only matches pre-existing/legacy rows or single-tenant mode.
 	const bindingExpr = "CASE WHEN NULLIF(w.org_id, '') IS NULL THEN 'neutral' ELSE 'org_bound' END"
 	workerTable := cs.runtimeTable((&WorkerRecord{}).TableName())
 	// Org is a config table (not runtime-qualified); its default worker profile
-	// supplies the cpu/mem for workers that carry no explicit profile.
+	// supplies the cpu/mem for workers that carry no explicit profile, and the
+	// CP-global default worker shape (the caller's pod-request defaults)
+	// backstops workers whose org has no default either — otherwise an unsized
+	// worker on a default-less org silently contributes zero shape.
 	orgTable := (&Org{}).TableName()
 
 	// k8s quantity strings can't be summed in SQL, so pull the raw filtered rows
@@ -1156,8 +1159,9 @@ func (cs *ConfigStore) ListWorkerLifecycleStats() ([]WorkerLifecycleStats, error
 	var rows []workerRow
 	err := cs.db.Table(workerTable+" AS w").
 		Select("w.image AS image, w.state AS state, "+bindingExpr+" AS binding, "+
-			"COALESCE(NULLIF(w.profile_cpu, ''), o.default_worker_cpu, '') AS cpu, "+
-			"COALESCE(NULLIF(w.profile_memory, ''), o.default_worker_memory, '') AS memory").
+			"COALESCE(NULLIF(w.profile_cpu, ''), NULLIF(o.default_worker_cpu, ''), ?) AS cpu, "+
+			"COALESCE(NULLIF(w.profile_memory, ''), NULLIF(o.default_worker_memory, ''), ?) AS memory",
+			defaultCPU, defaultMemory).
 		Joins("LEFT JOIN "+orgTable+" AS o ON o.name = w.org_id").
 		Where("w.image <> ''").
 		Where("w.state IN ?", []WorkerState{

--- a/controlplane/janitor.go
+++ b/controlplane/janitor.go
@@ -32,6 +32,32 @@ func (l orgHotIdleLimit) unlimited() bool {
 	return l.Workers <= 0 && l.CPU == "" && l.Memory == ""
 }
 
+// orgHotIdleLimitsFromSnapshot builds the janitor's per-org hot-idle pool
+// ceilings from the config snapshot. Only orgs with at least one limit set
+// appear. Each org's shape fallback (DefaultCPU/DefaultMemory — used to price
+// a parked worker that carries no explicit profile) resolves to the CP-global
+// default worker shape when the org has no default of its own, so an unsized
+// worker is priced at the pod shape it actually runs — never zero.
+func orgHotIdleLimitsFromSnapshot(snap *configstore.Snapshot, globalCPU, globalMemory string) map[string]orgHotIdleLimit {
+	if snap == nil {
+		return nil
+	}
+	caps := make(map[string]orgHotIdleLimit)
+	for name, org := range snap.Orgs {
+		if org == nil || (org.MaxHotIdleWorkers <= 0 && org.MaxHotIdleCPU == "" && org.MaxHotIdleMemory == "") {
+			continue
+		}
+		caps[name] = orgHotIdleLimit{
+			Workers:       org.MaxHotIdleWorkers,
+			CPU:           org.MaxHotIdleCPU,
+			Memory:        org.MaxHotIdleMemory,
+			DefaultCPU:    firstNonEmpty(org.DefaultWorkerCPU, globalCPU),
+			DefaultMemory: firstNonEmpty(org.DefaultWorkerMemory, globalMemory),
+		}
+	}
+	return caps
+}
+
 type controlPlaneExpiryStore interface {
 	ExpireControlPlaneInstances(cutoff time.Time) (int64, error)
 	ExpireDrainingControlPlaneInstances(before time.Time) (int64, error)

--- a/controlplane/janitor_test.go
+++ b/controlplane/janitor_test.go
@@ -628,3 +628,31 @@ func TestControlPlaneJanitorHotIdleCapSweepDisabledWhenUnwired(t *testing.T) {
 		t.Fatalf("unwired caps must retire nothing, got %#v", lifecycleStore.terminalTransitions)
 	}
 }
+
+// The multitenant.go wiring builds the caps map from the config snapshot via
+// orgHotIdleLimitsFromSnapshot — pin the glue: orgs without limits drop out,
+// an org's own default profile wins, and a default-less org falls back to the
+// CP-global shape (the zero-shape bug's fix).
+func TestOrgHotIdleLimitsFromSnapshot(t *testing.T) {
+	if got := orgHotIdleLimitsFromSnapshot(nil, "15", "120Gi"); got != nil {
+		t.Fatalf("nil snapshot must yield nil, got %v", got)
+	}
+	snap := &configstore.Snapshot{Orgs: map[string]*configstore.OrgConfig{
+		"acme":     {MaxHotIdleWorkers: 2, DefaultWorkerCPU: "4", DefaultWorkerMemory: "16Gi"},
+		"globex":   {MaxHotIdleCPU: "8"}, // no org default profile at all
+		"uncapped": {},
+		"nilorg":   nil,
+	}}
+	caps := orgHotIdleLimitsFromSnapshot(snap, "15", "120Gi")
+	if len(caps) != 2 {
+		t.Fatalf("want only the two capped orgs, got %v", caps)
+	}
+	acme := caps["acme"]
+	if acme.Workers != 2 || acme.DefaultCPU != "4" || acme.DefaultMemory != "16Gi" {
+		t.Fatalf("acme: org default profile must win: %+v", acme)
+	}
+	globex := caps["globex"]
+	if globex.CPU != "8" || globex.DefaultCPU != "15" || globex.DefaultMemory != "120Gi" {
+		t.Fatalf("globex: shape fallback must reach the CP-global default: %+v", globex)
+	}
+}

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -373,7 +373,7 @@ func SetupMultiTenant(
 	// their TTL — there is no warm pool to reconcile, so this is pure
 	// observability, leader-only.
 	janitor.observeWorkerLifecycle = func() {
-		stats, err := listWorkerLifecycleStats(store)
+		stats, err := listWorkerLifecycleStats(store, firstNonEmpty(cfg.K8s.WorkerCPURequest, defaultWorkerCPU), firstNonEmpty(cfg.K8s.WorkerMemoryRequest, defaultWorkerMemory))
 		if err != nil {
 			slog.Warn("Janitor failed to read worker lifecycle stats.", "error", err)
 			return
@@ -430,27 +430,12 @@ func SetupMultiTenant(
 	}
 	// Hot-idle pool caps (max_hot_idle_*): the sweep reads the same config
 	// snapshot as the floor, so an admin-console cap edit takes effect on the
-	// next tick after the config poll reloads. Only orgs with at least one
-	// limit set appear (the sweep skips unlimited orgs anyway).
+	// next tick after the config poll reloads. Shape fallback resolves to the
+	// CP-global default worker shape (orgHotIdleLimitsFromSnapshot).
 	janitor.hotIdleCaps = func() map[string]orgHotIdleLimit {
-		snapshot := store.Snapshot()
-		if snapshot == nil {
-			return nil
-		}
-		caps := make(map[string]orgHotIdleLimit)
-		for name, org := range snapshot.Orgs {
-			if org == nil || (org.MaxHotIdleWorkers <= 0 && org.MaxHotIdleCPU == "" && org.MaxHotIdleMemory == "") {
-				continue
-			}
-			caps[name] = orgHotIdleLimit{
-				Workers:       org.MaxHotIdleWorkers,
-				CPU:           org.MaxHotIdleCPU,
-				Memory:        org.MaxHotIdleMemory,
-				DefaultCPU:    org.DefaultWorkerCPU,
-				DefaultMemory: org.DefaultWorkerMemory,
-			}
-		}
-		return caps
+		return orgHotIdleLimitsFromSnapshot(store.Snapshot(),
+			firstNonEmpty(cfg.K8s.WorkerCPURequest, defaultWorkerCPU),
+			firstNonEmpty(cfg.K8s.WorkerMemoryRequest, defaultWorkerMemory))
 	}
 	// Node-headroom controller: keep low-priority placeholder pods as warm,
 	// preemptible spare capacity so worker spawns schedule immediately.
@@ -644,11 +629,13 @@ func SetupMultiTenant(
 	}
 	metricsProxy := admin.NewMetricsProxy(os.Getenv("DUCKGRES_PROMETHEUS_URL"))
 	clusterInfo := &clusterInfoProvider{
-		router:           router,
-		store:            store,
-		srv:              srv,
-		selfCPID:         cpInstanceID,
-		metadataSessions: metadataSessions,
+		router:              router,
+		store:               store,
+		srv:                 srv,
+		selfCPID:            cpInstanceID,
+		metadataSessions:    metadataSessions,
+		defaultWorkerCPU:    firstNonEmpty(cfg.K8s.WorkerCPURequest, defaultWorkerCPU),
+		defaultWorkerMemory: firstNonEmpty(cfg.K8s.WorkerMemoryRequest, defaultWorkerMemory),
 	}
 	imp := &impersonator{router: router}
 	// Cross-CP live-state aggregation: live sessions/queries are per-CP in
@@ -838,14 +825,14 @@ func (a ducklingMetadataAdapter) CRMetadataStores(ctx context.Context) (map[stri
 }
 
 type workerLifecycleStatsLister interface {
-	ListWorkerLifecycleStats() ([]configstore.WorkerLifecycleStats, error)
+	ListWorkerLifecycleStats(defaultCPU, defaultMemory string) ([]configstore.WorkerLifecycleStats, error)
 }
 
-func listWorkerLifecycleStats(lister workerLifecycleStatsLister) ([]configstore.WorkerLifecycleStats, error) {
+func listWorkerLifecycleStats(lister workerLifecycleStatsLister, defaultCPU, defaultMemory string) ([]configstore.WorkerLifecycleStats, error) {
 	if lister == nil {
 		return nil, nil
 	}
-	return lister.ListWorkerLifecycleStats()
+	return lister.ListWorkerLifecycleStats(defaultCPU, defaultMemory)
 }
 
 func cloneWorkerLifecycleStats(stats []configstore.WorkerLifecycleStats) []configstore.WorkerLifecycleStats {

--- a/tests/configstore/hot_idle_reporting_postgres_test.go
+++ b/tests/configstore/hot_idle_reporting_postgres_test.go
@@ -17,6 +17,7 @@ func TestHotIdleReportingPostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	seedOrg(t, store, "acme")
 	seedOrg(t, store, "globex")
+	seedOrg(t, store, "initech")
 	if err := store.DB().Exec(`UPDATE duckgres_orgs SET default_worker_cpu = '2', default_worker_memory = '8Gi' WHERE name = 'acme'`).Error; err != nil {
 		t.Fatalf("set acme default profile: %v", err)
 	}
@@ -33,6 +34,10 @@ func TestHotIdleReportingPostgres(t *testing.T) {
 		{WorkerID: 2104, PodName: "w-acme-4", Image: "img", State: configstore.WorkerStateHot, OrgID: "acme", OwnerCPInstanceID: "cp-a", LastHeartbeatAt: now},
 		// globex: one hot-idle worker.
 		{WorkerID: 2105, PodName: "w-globex-1", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "globex", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(30 * time.Minute), ProfileCPU: "1", ProfileMemory: "4Gi", LastHeartbeatAt: now},
+		// initech: NO org default profile and the worker carries NO explicit
+		// profile — its shape must resolve to the CP-global default passed by
+		// the caller (this was the zero-shape bug: it used to contribute 0).
+		{WorkerID: 2106, PodName: "w-initech-1", Image: "img", State: configstore.WorkerStateHotIdle, OrgID: "initech", OwnerCPInstanceID: "cp-a", HotIdleSince: ago(10 * time.Minute), LastHeartbeatAt: now},
 	}
 	for _, r := range records {
 		r := r
@@ -42,12 +47,12 @@ func TestHotIdleReportingPostgres(t *testing.T) {
 	}
 
 	// ---- per-org reporting ----
-	stats, err := store.ListHotIdleByOrg()
+	stats, err := store.ListHotIdleByOrg("8", "16Gi")
 	if err != nil {
 		t.Fatalf("ListHotIdleByOrg: %v", err)
 	}
-	if len(stats) != 2 {
-		t.Fatalf("want 2 orgs with hot-idle workers, got %d: %+v", len(stats), stats)
+	if len(stats) != 3 {
+		t.Fatalf("want 3 orgs with hot-idle workers, got %d: %+v", len(stats), stats)
 	}
 	byOrg := map[string]configstore.HotIdleOrgStat{}
 	for _, s := range stats {
@@ -70,6 +75,12 @@ func TestHotIdleReportingPostgres(t *testing.T) {
 	globex, ok := byOrg["globex"]
 	if !ok || globex.Count != 1 || globex.CPUCores != 1 {
 		t.Fatalf("globex stat wrong: %+v", globex)
+	}
+	// The no-profile, no-org-default worker resolves to the passed CP-global
+	// default — never silently zero.
+	initech, ok := byOrg["initech"]
+	if !ok || initech.Count != 1 || initech.CPUCores != 8 || initech.MemoryBytes != 16*1024*1024*1024 {
+		t.Fatalf("initech stat wrong (global-default fallback): %+v", initech)
 	}
 
 	// ---- cap sweep listing: one org, oldest first ----

--- a/tests/configstore/runtime_store_postgres_test.go
+++ b/tests/configstore/runtime_store_postgres_test.go
@@ -213,7 +213,7 @@ func TestListWorkerLifecycleStatsPostgres(t *testing.T) {
 		}
 	}
 
-	stats, err := store.ListWorkerLifecycleStats()
+	stats, err := store.ListWorkerLifecycleStats("8", "16Gi")
 	if err != nil {
 		t.Fatalf("ListWorkerLifecycleStats: %v", err)
 	}

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -896,6 +896,11 @@ hot_idle_reporting_and_cap() { # org
   [ "${count:-0}" -ge 1 ] || fail "hot-idle: $org never showed a parked worker in /workers/hot-idle: $(echo "$body" | head -c 400)"
   echo "$body" | jq -e --arg o "$org" '.orgs[] | select(.org_id==$o) | has("cpu_cores") and has("memory_bytes") and has("oldest_hot_idle_since") and has("cap_workers") and has("cap_cpu") and has("cap_memory")' >/dev/null \
     || fail "hot-idle: $org row missing shape/cap fields: $(echo "$body" | head -c 400)"
+  # Shape resolution must reach the CP-global default worker shape for an
+  # unsized worker on a default-less org — a zero here is the reporting bug
+  # where such workers silently contributed no cpu/memory.
+  echo "$body" | jq -e --arg o "$org" '.orgs[] | select(.org_id==$o) | .cpu_cores > 0 and .memory_bytes > 0' >/dev/null \
+    || fail "hot-idle: $org row reports zero cpu/memory (shape fallback broken): $(echo "$body" | head -c 400)"
   log "hot-idle OK: $org holds $count parked worker(s) with shape + cap fields"
 
   # Cap the pool at 1: the sweep must retire the excess down to <= 1.


### PR DESCRIPTION
## Summary

Two fixes to the Workers page **Hot idle by org** card from prod feedback:

**1. Sorting** — the card is now a sortable table: Workers / vCPU / Memory headers click to re-sort, defaulting to **memory pinned, largest first** (the resource that pins nodes).

**2. Zero cpu/memory** — orgs whose parked workers showed `0 vCPU / 0 B` were hitting the end of the shape-resolution chain: explicit profile → org default worker profile → *nothing*. Unsized workers on orgs with no default profile contributed zero. Added the third step — the **CP-global default worker shape** (`cfg.K8s.WorkerCPURequest`/`MemoryRequest`, else the 8/16Gi constants — i.e. the pod requests the worker was actually spawned with) — applied in all three places that resolve worker shape:

- `ListHotIdleByOrg` (the card) — new `defaultCPU/defaultMemory` params, threaded from `clusterInfoProvider` wired in `multitenant.go`.
- `ListWorkerLifecycleStats` (the **fleet rollup**) — same zero-shape bug for default-less orgs, same fix at the same wiring point. Fleet cpu/mem totals for such orgs will correct **upward** to what the pods actually request.
- The janitor cap sweep's shape math — the caps closure is extracted to `orgHotIdleLimitsFromSnapshot` (unit-testable glue) and falls back org default → CP-global.

## Testing (TDD)

- `hot_idle_reporting_postgres_test.go` — a no-profile worker on a no-default org now resolves to the passed global default (was 0).
- `TestOrgHotIdleLimitsFromSnapshot` — the closure glue: org default wins, global fallback, uncapped/nil orgs drop out.
- `runtime_store_postgres_test.go` — fleet signature update.
- `Workers.test.tsx` — memory-desc sort assertion + card rendering.
- Harness `hot_idle_reporting_and_cap` — asserts the org's hot-idle row reports `cpu_cores > 0` and `memory_bytes > 0` (this exact bug class, against the real cluster).

`just lint` clean; controlplane + admin + configstore suites green; UI suite green (124 tests).