### PR TITLE
admin/ui: friendly org names + grounded default prices in pricing calculator

### DIFF
--- a/controlplane/admin/ui/src/lib/pricing.ts
+++ b/controlplane/admin/ui/src/lib/pricing.ts
@@ -46,6 +46,15 @@ export function scenarioCost(t: OrgUsageTotals, s: PriceScenario): number {
   return t.cpuMinutes * s.cpuPerMin + t.memGiBMinutes * s.memPerGiBMin + t.storageGiBHours * s.storagePerGiBH;
 }
 
+// Grounded defaults for a fresh scenario, so the calculator is useful on
+// first open — roughly EC2 on-demand m6i/r6gd-class economics (≈$0.024/vCPU·h
+// and ≈$0.006/GiB·h RAM, i.e. half the instance price attributed to each)
+// plus S3 standard storage (≈$0.023/GiB·mo ≈ $0.00003/GiB·h). These are
+// editable starting points for sensitivity analysis, not PostHog pricing.
+export const DEFAULT_CPU_PER_MIN = 0.0004;
+export const DEFAULT_MEM_PER_GIB_MIN = 0.0001;
+export const DEFAULT_STORAGE_PER_GIB_H = 0.00003;
+
 // parsePrice reads a price input: non-negative finite numbers pass through,
 // anything else (empty, NaN, negative) is 0 — a half-typed input must never
 // make a cost cell NaN.

--- a/controlplane/admin/ui/src/pages/Usage.tsx
+++ b/controlplane/admin/ui/src/pages/Usage.tsx
@@ -201,7 +201,7 @@ export function Usage() {
                 />
               </Card>
             )}
-            <UsagePricing rows={monthRows} />
+            <UsagePricing rows={monthRows} labels={orgLabels} />
           </>
         )}
       </PageBody>

--- a/controlplane/admin/ui/src/pages/UsagePricing.test.tsx
+++ b/controlplane/admin/ui/src/pages/UsagePricing.test.tsx
@@ -15,10 +15,15 @@ const ROWS: MonthlyUsageRow[] = [
   { month: "2026-08", org_id: "globex", team_id: 9, schema_name: "team_9", cpu_seconds: 1200, memory_seconds: 0, gib_seconds: 0 },
 ];
 
+const LABELS = new Map([
+  ["acme", "Acme Inc"],
+  ["globex", "Globex Corp"],
+]);
+
 function renderPricing(rows = ROWS) {
   return render(
     <MemoryRouter>
-      <UsagePricing rows={rows} />
+      <UsagePricing rows={rows} labels={LABELS} />
     </MemoryRouter>,
   );
 }
@@ -28,14 +33,28 @@ describe("UsagePricing", () => {
     localStorage.clear();
   });
 
-  it("starts with one baseline scenario and zero costs", () => {
+  it("starts with a baseline scenario prefilled with grounded default prices", () => {
     renderPricing();
-    // One scenario editor.
     expect(screen.getByDisplayValue("Baseline")).toBeInTheDocument();
-    // acme + globex rows and the all-orgs total, each $0.00.
-    expect(screen.getByText("acme")).toBeInTheDocument();
-    expect(screen.getByText("globex")).toBeInTheDocument();
-    expect(screen.getAllByText("$0.00")).toHaveLength(3);
+    // Defaults ≈ EC2 on-demand m6i-class economics + S3 standard storage:
+    // $0.0004/CPU-min ($0.024/vCPU·h), $0.0001/GiB·min ($0.006/GiB·h RAM),
+    // $0.00003/GiB·h (~$0.022/GiB·mo S3).
+    expect(screen.getByLabelText("Baseline $/CPU-min")).toHaveValue(0.0004);
+    expect(screen.getByLabelText("Baseline $/GiB·min")).toHaveValue(0.0001);
+    expect(screen.getByLabelText("Baseline $/GiB·h")).toHaveValue(0.00003);
+    // The defaults already price the orgs — the calculator is useful on open:
+    // acme: 130×0.0004 + 70×0.0001 + 3×0.00003 = $0.0590 → $0.06;
+    // globex: 20×0.0004 = $0.008 → $0.01; total $0.067 → $0.07.
+    expect(screen.getByText("$0.06")).toBeInTheDocument();
+    expect(screen.getByText("$0.01")).toBeInTheDocument();
+    expect(screen.getByText("$0.07")).toBeInTheDocument();
+  });
+
+  it("shows the org's friendly name with its ID, linked to the org page", () => {
+    renderPricing();
+    expect(screen.getByText("Acme Inc")).toBeInTheDocument();
+    expect(screen.getByText("Globex Corp")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /acme inc/i })).toHaveAttribute("href", "/orgs/acme");
   });
 
   it("prices each org and the grand total from the entered prices", () => {
@@ -52,15 +71,15 @@ describe("UsagePricing", () => {
   it("adds a scenario column for side-by-side sensitivity", () => {
     renderPricing();
     fireEvent.click(screen.getByRole("button", { name: /add scenario/i }));
-    // Two scenario editors now: Baseline + Scenario B.
+    // Two scenario editors now: Baseline + Scenario B (also prefilled).
     expect(screen.getByDisplayValue("Baseline")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Scenario B")).toBeInTheDocument();
-    // Price only B: acme = 130 × 0.5 = $65.00 under B, still $0.00 under Baseline.
+    // Price only B's CPU: acme = 130×0.5 + 70×0.0001 + 3×0.00003 = $65.00709
+    // → $65.01 under B; Baseline keeps its default-priced $0.06.
     fireEvent.change(screen.getByLabelText("Scenario B $/CPU-min"), { target: { value: "0.5" } });
-    expect(screen.getByText("$65.00")).toBeInTheDocument();
-    // acme's Baseline cell stays $0.00 while B prices at $65.00.
-    const acmeRow = screen.getByText("acme").closest("tr")!;
-    expect(within(acmeRow).getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getByText("$65.01")).toBeInTheDocument();
+    const acmeRow = screen.getByText("Acme Inc").closest("tr")!;
+    expect(within(acmeRow).getByText("$0.06")).toBeInTheDocument();
   });
 
   it("persists scenarios to localStorage across remounts", () => {
@@ -68,7 +87,8 @@ describe("UsagePricing", () => {
     fireEvent.change(screen.getByLabelText("Baseline $/CPU-min"), { target: { value: "0.1" } });
     unmount();
     renderPricing();
-    expect(screen.getByText("$13.00")).toBeInTheDocument(); // acme 130 × 0.1
+    // acme 130×0.1 + 70×0.0001 + 3×0.00003 = $13.00709 → $13.01
+    expect(screen.getByText("$13.01")).toBeInTheDocument();
   });
 
   it("renders a friendly empty state without usage rows", () => {

--- a/controlplane/admin/ui/src/pages/UsagePricing.tsx
+++ b/controlplane/admin/ui/src/pages/UsagePricing.tsx
@@ -1,12 +1,23 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { Plus, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/states";
+import { OrgRef } from "@/components/OrgRef";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { fmtUnits } from "@/lib/format";
-import { fmtMoney, orgTotals, parsePrice, scenarioCost, type PriceScenario } from "@/lib/pricing";
+import {
+  DEFAULT_CPU_PER_MIN,
+  DEFAULT_MEM_PER_GIB_MIN,
+  DEFAULT_STORAGE_PER_GIB_H,
+  fmtMoney,
+  orgTotals,
+  parsePrice,
+  scenarioCost,
+  type PriceScenario,
+} from "@/lib/pricing";
 import type { MonthlyUsageRow } from "@/types/api";
 
 // Pricing sensitivity: enter unit-price scenarios and see each org's monthly
@@ -17,13 +28,16 @@ import type { MonthlyUsageRow } from "@/types/api";
 
 const STORAGE_KEY = "duckgres-usage-pricing-scenarios-v1";
 
+// A fresh scenario starts from the grounded defaults (EC2-on-demand-ish
+// compute + S3 standard storage — see lib/pricing.ts) so the calculator
+// prices orgs sensibly on first open; every price is editable.
 function newScenario(n: number): PriceScenario {
   return {
     id: `s${Date.now()}-${n}`,
     name: n === 1 ? "Baseline" : `Scenario ${String.fromCharCode(64 + n)}`,
-    cpuPerMin: 0,
-    memPerGiBMin: 0,
-    storagePerGiBH: 0,
+    cpuPerMin: DEFAULT_CPU_PER_MIN,
+    memPerGiBMin: DEFAULT_MEM_PER_GIB_MIN,
+    storagePerGiBH: DEFAULT_STORAGE_PER_GIB_H,
   };
 }
 
@@ -42,7 +56,7 @@ function loadScenarios(): PriceScenario[] {
   return [newScenario(1)];
 }
 
-export function UsagePricing({ rows }: { rows: MonthlyUsageRow[] }) {
+export function UsagePricing({ rows, labels }: { rows: MonthlyUsageRow[]; labels?: Map<string, string> }) {
   const [scenarios, setScenarios] = useState<PriceScenario[]>(loadScenarios);
   useEffect(() => {
     try {
@@ -74,8 +88,8 @@ export function UsagePricing({ rows }: { rows: MonthlyUsageRow[] }) {
         <div>
           <CardTitle>Pricing sensitivity</CardTitle>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            Enter unit prices to see each org's fee for the selected month under each scenario. Prices stay in your
-            browser.
+            Enter unit prices to see each org's fee for the selected month under each scenario. Baseline starts
+            from EC2-on-demand-ish unit costs + S3 standard storage — edit freely. Prices stay in your browser.
           </p>
         </div>
         <Button size="sm" variant="outline" onClick={add}>
@@ -151,7 +165,11 @@ export function UsagePricing({ rows }: { rows: MonthlyUsageRow[] }) {
             <TableBody>
               {totals.map((t) => (
                 <TableRow key={t.orgId}>
-                  <TableCell className="font-mono text-xs">{t.orgId}</TableCell>
+                  <TableCell>
+                    <Link to={`/orgs/${encodeURIComponent(t.orgId)}`} className="block hover:underline">
+                      <OrgRef id={t.orgId} label={labels?.get(t.orgId)} copyable={false} />
+                    </Link>
+                  </TableCell>
                   <TableCell className="font-mono text-xs">{fmtUnits(t.cpuMinutes)}</TableCell>
                   <TableCell className="font-mono text-xs">{fmtUnits(t.memGiBMinutes)}</TableCell>
                   <TableCell className="font-mono text-xs">{fmtUnits(t.storageGiBHours)}</TableCell>


### PR DESCRIPTION
## Summary

Two fixes to the Usage page's pricing-sensitivity calculator from PM feedback (the table showed raw org UUIDs and everything priced at $0.00 until you typed numbers):

1. **Friendly org names** — the org column now renders the friendly label + ID and links to the org page (labels passed down from the Usage page's `useOrgLabels`; the calculator component stays pure-props).
2. **Grounded default prices** — a fresh scenario now starts from defensible unit costs instead of 0, so the calculator is useful on first open:
   - **$0.0004/CPU-min** (≈ $0.024/vCPU·h)
   - **$0.0001/GiB·min** (≈ $0.006/GiB·h RAM)
   - **$0.00003/GiB·h** (≈ $0.023/GiB·mo, S3 standard)

   Derivation (EC2 on-demand m6i/r6gd-class, half instance price to CPU / half to RAM; S3 standard) is documented at the constants. Everything stays editable; scenarios already saved in a browser's localStorage are untouched.

## Testing (TDD)

`UsagePricing.test.tsx`: prefilled-default assertions + default-priced org/total values, friendly-name + link cell, updated scenario-B / persistence arithmetic. UI suite green (125 tests), typecheck + build clean. No server or e2e surface — client-side calculator only.

Docs: CLAUDE.md pricing paragraph updated with the defaults.