### PR TITLE
transpiler: worker_ttl rejection message actually names whole-minute granularity

### DIFF
--- a/transpiler/transform/setshow.go
+++ b/transpiler/transform/setshow.go
@@ -141,7 +141,7 @@ func NormalizeWorkerTTL(raw string) (string, error) {
 func errInvalidWorkerTTL() *CodedError {
 	return &CodedError{
 		Code: "22023", // invalid_parameter_value
-		Message: fmt.Sprintf("invalid value for %q: must be a non-negative Go duration (e.g. \"20m\")",
+		Message: fmt.Sprintf("invalid value for %q: must be a Go duration of at least 1m in whole minutes (e.g. \"20m\")",
 			workerTTLParam),
 	}
 }

--- a/transpiler/worker_ttl_test.go
+++ b/transpiler/worker_ttl_test.go
@@ -96,8 +96,8 @@ func TestTranspile_WorkerTTLSetInvalidRejected(t *testing.T) {
 				t.Errorf("Transpile(%.80q): Error SQLSTATE = %v, want 22023", in, result.Error)
 			}
 			msg := result.Error.Error()
-			if !strings.Contains(msg, "duration") {
-				t.Errorf("error message must describe the expected duration shape, got %q", msg)
+			if !strings.Contains(msg, "whole minutes") {
+				t.Errorf("error message must name the whole-minute granularity, got %q", msg)
 			}
 			if strings.Contains(msg, "garbage") || strings.Contains(msg, longJunk[:64]) {
 				t.Errorf("error message must not echo the offending value, got %.120q", msg)


### PR DESCRIPTION
## Summary

The zero/sub-minute validation for `duckgres.worker_ttl` landed in #1054, but the error *message* still read "must be a non-negative Go duration" — a scripted edit during the review fixes missed the message literal (behavior was correct, text wasn't). The mw-dev e2e caught it: the harness asserts the rejection names the granularity.

The message now says `at least 1m in whole minutes`, and the transpiler rejection test asserts the message contains "whole minutes" so it can't silently drift again.

No behavior change; unit-tested.