### PR TITLE
feat(admin): show mint principal in audit detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ is clamped to 60–3600 seconds. Refresh targets one credential explicitly with
 Expiry and revocation block new pgwire handshakes but do not terminate an
 already-authenticated session. If a caller loses a secret, mint a new
 credential; Duckgres stores only bcrypt hashes and cannot recover plaintext.
+Successful mints put `principal: <submitted-principal>` in the admin audit
+entry's detail column; credential IDs and secrets are never included there. A
+machine-readable `credential_minted` audit outcome records that the grant row
+landed, so a later snapshot-reload failure is still shown as a successful mint
+while requests that fail before the durable write are shown as failed.
 For a rolling contract change, deploy the always-create Duckgres version to
 the entire fleet before removing the caller's legacy `force_rotate`/reuse
 fallback. New servers ignore the old field, but a new caller reaching an old

--- a/controlplane/admin/api_test.go
+++ b/controlplane/admin/api_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/requestaudit"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -2571,7 +2572,7 @@ func TestUpdateOrgDataImportsTableNamingVersion(t *testing.T) {
 			var detail string
 			router.Use(func(c *gin.Context) {
 				c.Next()
-				detail = c.GetString(ctxAuditDetailKey)
+				detail = requestaudit.Detail(c)
 			})
 			registerAPIWithStore(router.Group("/api/v1"), store, nil, nil)
 
@@ -3064,7 +3065,7 @@ func TestAdminUpdateOrgTeamAuditDetail(t *testing.T) {
 	// Capture what AuditMiddleware would read after the handler returns.
 	router.Use(func(c *gin.Context) {
 		c.Next()
-		detail = c.GetString(ctxAuditDetailKey)
+		detail = requestaudit.Detail(c)
 	})
 	registerAPIWithStore(router.Group("/api/v1"), store, nil, nil)
 

--- a/controlplane/admin/audit.go
+++ b/controlplane/admin/audit.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/requestaudit"
 	"gorm.io/gorm"
 )
 
@@ -30,8 +31,12 @@ type AdminAuditEntry struct {
 	SQLRedacted string    `json:"sql_redacted"`
 	// Detail is optional, non-sensitive human context for the action (e.g.
 	// "role viewer → admin" for an operator change). Set by a handler via
-	// ctxAuditDetailKey; NEVER put credentials or raw secret DDL here.
-	Detail     string `json:"detail"`
+	// requestaudit.SetDetail; NEVER put credentials or raw secret DDL here.
+	Detail string `json:"detail"`
+	// Outcome is an optional machine-readable durable result. It distinguishes
+	// a mutation that landed before later response-path work failed from one
+	// that never happened. It must never contain identifiers or secrets.
+	Outcome    string `json:"outcome"`
 	Status     int    `json:"status"`
 	RemoteAddr string `json:"remote_addr"`
 }
@@ -42,6 +47,13 @@ func (AdminAuditEntry) TableName() string { return "duckgres_admin_audit" }
 // AuditStore persists admin audit entries.
 type AuditStore struct {
 	db *gorm.DB
+}
+
+// AuditRecorder is the append-only write contract used by AuditMiddleware.
+// AuditStore is the production implementation; the narrow interface also
+// keeps middleware behavior testable without a database.
+type AuditRecorder interface {
+	Record(*AdminAuditEntry) error
 }
 
 // NewAuditStore returns an AuditStore over the config-store DB and ensures the
@@ -89,7 +101,7 @@ func (a *AuditStore) List(org, actor string, limit int) ([]AdminAuditEntry, erro
 // credentials); the impersonation handler records its own richer entry with
 // redacted SQL. A best-effort write — a logging failure must not fail an
 // already-applied config mutation.
-func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
+func AuditMiddleware(store AuditRecorder) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next()
 		switch c.Request.Method {
@@ -126,7 +138,8 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 			TargetUser: targetUser,
 			// Optional human context a handler recorded (e.g. which org fields
 			// changed). Empty for handlers that don't set it.
-			Detail:     c.GetString(ctxAuditDetailKey),
+			Detail:     requestaudit.Detail(c),
+			Outcome:    requestaudit.GetOutcome(c),
 			Status:     c.Writer.Status(),
 			RemoteAddr: c.ClientIP(),
 		}
@@ -139,18 +152,10 @@ func AuditMiddleware(store *AuditStore) gin.HandlerFunc {
 
 const ctxAuditHandledKey = "duckgres_audit_handled"
 
-// ctxAuditDetailKey holds an optional, non-sensitive human summary of a
-// mutation that a handler recorded (e.g. "role viewer → admin"). AuditMiddleware
-// copies it into AdminAuditEntry.Detail. NEVER put credentials or raw secret DDL
-// through it — the audit log stores it verbatim and the console shows it.
-const ctxAuditDetailKey = "duckgres_audit_detail"
-
 // setAuditDetail records a human-readable detail string for the current request
 // so AuditMiddleware includes it in the audit row. No-op for the empty string.
 func setAuditDetail(c *gin.Context, detail string) {
-	if detail != "" {
-		c.Set(ctxAuditDetailKey, detail)
-	}
+	requestaudit.SetDetail(c, detail)
 }
 
 // auditActionFor derives a resource-specific audit Action ("<resource>.<verb>")

--- a/controlplane/admin/audit_test.go
+++ b/controlplane/admin/audit_test.go
@@ -4,8 +4,55 @@ package admin
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/requestaudit"
 )
+
+type recordingAuditStore struct {
+	entries []*AdminAuditEntry
+}
+
+func (s *recordingAuditStore) Record(entry *AdminAuditEntry) error {
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func TestAuditMiddlewarePersistsDurableMintOutcome(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingAuditStore{}
+	router := gin.New()
+	api := router.Group("/api/v1", AuditMiddleware(store))
+	api.POST("/orgs/:id/service-credentials", func(c *gin.Context) {
+		requestaudit.SetDetail(c, "principal: posthog:sql-editor:team:42:user:314")
+		requestaudit.SetOutcome(c, requestaudit.OutcomeCredentialMinted)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "synthetic reload failure"})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/acme/service-credentials", nil)
+	router.ServeHTTP(rec, req)
+
+	if len(store.entries) != 1 {
+		t.Fatalf("audit rows = %d, want 1", len(store.entries))
+	}
+	entry := store.entries[0]
+	if entry.Action != "credential.create" || entry.Status != http.StatusInternalServerError {
+		t.Fatalf("audit action/status = %q/%d, want credential.create/500", entry.Action, entry.Status)
+	}
+	if entry.Detail != "principal: posthog:sql-editor:team:42:user:314" {
+		t.Fatalf("audit detail = %q", entry.Detail)
+	}
+	if entry.Outcome != string(requestaudit.OutcomeCredentialMinted) {
+		t.Fatalf("audit outcome = %q, want credential_minted", entry.Outcome)
+	}
+	if strings.Contains(entry.Detail, "svc_") || strings.Contains(entry.Detail, "secret") {
+		t.Fatalf("audit detail exposed credential material: %q", entry.Detail)
+	}
+}
 
 // TestAuditActionFor pins the resource-specific Action derivation: operators,
 // org-warehouse, and org-user mutations each get their own prefix, and anything

--- a/controlplane/admin/ui/src/lib/audit.test.ts
+++ b/controlplane/admin/ui/src/lib/audit.test.ts
@@ -52,4 +52,21 @@ describe("auditSummary", () => {
   it("falls back to the bare label when there is no target", () => {
     expect(auditSummary(entry({ action: "org.create", target_user: "" }))).toBe("Created org");
   });
+
+  it("renders a pre-mint credential failure as failed", () => {
+    expect(auditSummary(entry({ action: "credential.create", status: 500 }))).toBe(
+      "Failed to mint service credential",
+    );
+  });
+
+  it("renders a 2xx credential mint as successful", () => {
+    expect(auditSummary(entry({ action: "credential.create", status: 201 }))).toBe("Minted service credential");
+  });
+
+  it("renders a durable mint as successful even when post-mint work returns 500", () => {
+    const durableMint = entry({ action: "credential.create", status: 500 });
+    Object.assign(durableMint, { outcome: "credential_minted" });
+
+    expect(auditSummary(durableMint)).toBe("Minted service credential");
+  });
 });

--- a/controlplane/admin/ui/src/lib/audit.ts
+++ b/controlplane/admin/ui/src/lib/audit.ts
@@ -83,7 +83,15 @@ export function auditSubject(e: AuditEntry): string {
 // and detail render in their own cells, so this stays short — e.g.
 // "Set operator role bob@posthog.com".
 export function auditSummary(e: AuditEntry): string {
-  const label = actionLabel(e.action);
+  // credential.create is an attempted route, not proof that a grant landed.
+  // A 2xx is an ordinary success; credential_minted preserves the success
+  // when the durable write landed but later work (for example snapshot reload)
+  // made the HTTP response fail.
+  const credentialMintSucceeded =
+    e.action !== "credential.create" ||
+    (e.status >= 200 && e.status < 300) ||
+    e.outcome === "credential_minted";
+  const label = credentialMintSucceeded ? actionLabel(e.action) : "Failed to mint service credential";
   const subject = e.target_user ?? "";
   return subject ? `${label} ${subject}` : label;
 }

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -604,6 +604,10 @@ export interface AuditEntry {
   // Optional non-sensitive human context recorded by the handler, e.g.
   // "role viewer → admin" or "max_workers 4 → 10".
   detail?: string;
+  // Optional machine-readable durable result. This disambiguates a mutation
+  // that landed before later response-path work failed from a pre-mutation
+  // failure without parsing the human detail string.
+  outcome?: string;
   status: number;
   remote_addr?: string;
 }

--- a/controlplane/provisioning/service_credential.go
+++ b/controlplane/provisioning/service_credential.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/requestaudit"
 	"gorm.io/gorm"
 )
 
@@ -194,6 +195,11 @@ func (h *handler) issueServiceCredential(c *gin.Context, tenantStore TenantStore
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// The request body is deliberately unavailable to AuditMiddleware because
+	// provisioning bodies may contain secrets. Pass only the non-sensitive
+	// principal across the shared request context after a mint succeeds.
+	requestaudit.SetDetail(c, "principal: "+req.Principal)
+	requestaudit.SetOutcome(c, requestaudit.OutcomeCredentialMinted)
 	if err := h.afterCredentialWrite(c, tenantStore); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/controlplane/provisioning/service_credential_test.go
+++ b/controlplane/provisioning/service_credential_test.go
@@ -2,13 +2,16 @@ package provisioning
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/controlplane/requestaudit"
 )
 
 // newServiceCredentialRouter mounts the provisioning API with an explicit
@@ -140,6 +143,91 @@ func TestIssueServiceCredentialThreadsPrincipalAndTTL(t *testing.T) {
 	if store.reloadSnapshotN != 1 {
 		t.Fatalf("ReloadSnapshot called %d times, want exactly 1 (fresh credential must auth without waiting a poll)", store.reloadSnapshotN)
 	}
+}
+
+func issueServiceCredentialWithAuditContext(t *testing.T, store *fakeStore, body string) (*httptest.ResponseRecorder, string, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	var detail, outcome string
+	router.Use(func(c *gin.Context) {
+		c.Next()
+		detail = requestaudit.Detail(c)
+		outcome = requestaudit.GetOutcome(c)
+	})
+	RegisterAPI(router.Group("/api/v1"), store, store, "", nil)
+	return doJSON(t, router, http.MethodPost, "/api/v1/orgs/acme/service-credentials", body), detail, outcome
+}
+
+func TestIssueServiceCredentialAddsPrincipalAndDurableOutcomeToAudit(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["acme"] = &configstore.Org{Name: "acme"}
+
+	const principal = "posthog:sql-editor:team:42:user:314"
+	rec, detail, outcome := issueServiceCredentialWithAuditContext(t, store, `{"principal":"`+principal+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if want := "principal: " + principal; detail != want {
+		t.Fatalf("audit detail = %q, want %q", detail, want)
+	}
+	if strings.Contains(detail, "fake-plaintext") {
+		t.Fatalf("audit detail exposed credential secret: %q", detail)
+	}
+	if outcome != "credential_minted" {
+		t.Fatalf("audit outcome = %q, want credential_minted", outcome)
+	}
+	if strings.Contains(detail, "svc_") {
+		t.Fatalf("audit detail exposed credential ID: %q", detail)
+	}
+}
+
+func TestIssueServiceCredentialAuditContextDistinguishesPreAndPostMintFailures(t *testing.T) {
+	const principal = "posthog:sql-editor:team:42:user:314"
+
+	t.Run("invalid request has no principal or durable outcome", func(t *testing.T) {
+		store := newFakeStore()
+		store.orgs["acme"] = &configstore.Org{Name: "acme"}
+		rec, detail, outcome := issueServiceCredentialWithAuditContext(t, store, `{}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+		}
+		if detail != "" || outcome != "" {
+			t.Fatalf("pre-mint audit context = detail %q, outcome %q; want both empty", detail, outcome)
+		}
+	})
+
+	t.Run("store failure has no principal or durable outcome", func(t *testing.T) {
+		store := newFakeStore()
+		store.orgs["acme"] = &configstore.Org{Name: "acme"}
+		store.issueCredsErr = errors.New("synthetic mint failure")
+		rec, detail, outcome := issueServiceCredentialWithAuditContext(t, store, `{"principal":"`+principal+`"}`)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+		if detail != "" || outcome != "" {
+			t.Fatalf("pre-mint audit context = detail %q, outcome %q; want both empty", detail, outcome)
+		}
+	})
+
+	t.Run("reload failure retains successful durable mint", func(t *testing.T) {
+		store := newFakeStore()
+		store.orgs["acme"] = &configstore.Org{Name: "acme"}
+		store.reloadSnapshotEr = errors.New("synthetic reload failure")
+		rec, detail, outcome := issueServiceCredentialWithAuditContext(t, store, `{"principal":"`+principal+`"}`)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+		if detail != "principal: "+principal || outcome != "credential_minted" {
+			t.Fatalf("post-mint audit context = detail %q, outcome %q", detail, outcome)
+		}
+		if strings.Contains(detail, "svc_") || strings.Contains(detail, "fake-plaintext") {
+			t.Fatalf("post-mint audit detail exposed credential material: %q", detail)
+		}
+		if strings.Contains(rec.Body.String(), "svc_") || strings.Contains(rec.Body.String(), "fake-plaintext") {
+			t.Fatalf("reload-failure response exposed credential material: %s", rec.Body.String())
+		}
+	})
 }
 
 func TestIssueServiceCredentialClampsTTL(t *testing.T) {

--- a/controlplane/requestaudit/detail.go
+++ b/controlplane/requestaudit/detail.go
@@ -1,0 +1,48 @@
+// Package requestaudit carries non-sensitive handler context into the control
+// plane's audit middleware without coupling provisioning handlers to the admin
+// package.
+package requestaudit
+
+import "github.com/gin-gonic/gin"
+
+const (
+	detailKey  = "duckgres_audit_detail"
+	outcomeKey = "duckgres_audit_outcome"
+)
+
+// Outcome is a machine-readable, non-sensitive result established by a
+// handler. It complements the HTTP status when a durable mutation succeeds but
+// later response-path work fails.
+type Outcome string
+
+const (
+	// OutcomeCredentialMinted means the service-grant row was durably created.
+	// It carries no credential ID or secret.
+	OutcomeCredentialMinted Outcome = "credential_minted"
+)
+
+// SetDetail records a human-readable, non-sensitive summary for the current
+// request. The audit middleware persists it verbatim, so callers must never
+// include credentials or raw secret DDL.
+func SetDetail(c *gin.Context, detail string) {
+	if detail != "" {
+		c.Set(detailKey, detail)
+	}
+}
+
+// Detail returns the handler-provided audit summary, if any.
+func Detail(c *gin.Context) string {
+	return c.GetString(detailKey)
+}
+
+// SetOutcome records a machine-readable durable result for AuditMiddleware.
+func SetOutcome(c *gin.Context, outcome Outcome) {
+	if outcome != "" {
+		c.Set(outcomeKey, string(outcome))
+	}
+}
+
+// GetOutcome returns the handler-provided durable outcome, if any.
+func GetOutcome(c *gin.Context) string {
+	return c.GetString(outcomeKey)
+}


### PR DESCRIPTION
## Problem

- Service-credential mint audit rows identify the organization and action, but their detail column does not show the submitted principal.
- The audit UI also labels every `credential.create` request as a completed mint, including requests that fail before the grant is written.
- A mint can durably create its grant and then return an error while reloading runtime snapshots, so HTTP status alone cannot distinguish those cases.

## Changes

- Put `principal: <submitted-principal>` in the audit detail only after a service grant is created.
- Persist a non-sensitive `credential_minted` outcome marker alongside the audit row; credential IDs and secrets are never copied into either field.
- Render a credential mint as successful when the response is 2xx or the durable outcome marker is present. Non-2xx requests without that marker render as `Failed to mint service credential`.
- Share audit detail/outcome through a small request-context package so provisioning remains decoupled from the Kubernetes-only admin package.
- Document the audit behavior in the service-credential contract.

## Testing (TDD)

- Confirmed RED: a successful mint and a durable-mint/reload-failure both lacked an outcome; the UI labeled a pre-mint 500 as successful.
- Provisioning HTTP tests cover normal success, invalid input, store failure, and a durable mint followed by snapshot-reload failure.
- An AuditMiddleware test verifies the persisted action, status, detail, and outcome without a database.
- UI tests cover 2xx success, pre-mint failure, and durable-mint/500 success summaries.
- `just lint` passes with 0 issues.
- Changed tests pass locally. Broader local recipes reach unrelated environment prerequisites: Docker is unavailable for the container-backed control-plane test, the configured local Postgres rejects its client encoding, and the host's Node local-storage option breaks existing pricing tests.

## 🤖 Agent context

- Authored with Codex after tracing the production audit path from provisioning through Gin request context, AuditMiddleware persistence, and the admin UI summary.
- Independently adversarially reviewed before publication; the failure/success ambiguity and its regression coverage were addressed before opening this PR.
- Fixtures contain only synthetic organization, team, and user identifiers. No customer data, internal endpoints, credentials, or secrets are included.
