### PR TITLE
fix: propagate tracing through Flight server

### DIFF
--- a/duckdbservice/service.go
+++ b/duckdbservice/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/posthog/duckgres/server/flightclient"
 	"github.com/posthog/duckgres/server/observe"
 	"github.com/posthog/duckgres/server/sessionmeta"
+	"github.com/posthog/duckgres/server/sqlcore"
 	"github.com/posthog/duckgres/transpiler/transform"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -995,27 +996,9 @@ func Run(cfg ServiceConfig) {
 func (svc *DuckDBService) Serve(listener net.Listener) error {
 	handler := NewFlightSQLHandler(svc.pool)
 
-	var opts []grpc.ServerOption
-	opts = append(opts,
-		grpc.MaxRecvMsgSize(flightclient.MaxGRPCMessageSize),
-		grpc.MaxSendMsgSize(flightclient.MaxGRPCMessageSize),
-	)
-	if svc.cfg.BearerToken != "" {
-		opts = append(opts,
-			grpc.ChainUnaryInterceptor(BearerTokenUnaryInterceptor(svc.cfg.BearerToken)),
-			grpc.ChainStreamInterceptor(BearerTokenStreamInterceptor(svc.cfg.BearerToken)),
-		)
-	}
-	if listener.Addr() != nil && listener.Addr().Network() == "tcp" &&
-		svc.cfg.ServerConfig.TLSCertFile != "" && svc.cfg.ServerConfig.TLSKeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(svc.cfg.ServerConfig.TLSCertFile, svc.cfg.ServerConfig.TLSKeyFile)
-		if err != nil {
-			return fmt.Errorf("load worker RPC TLS certificates: %w", err)
-		}
-		opts = append(opts, grpc.Creds(credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
-		})))
+	opts, err := flightServerOptions(svc.cfg, listener)
+	if err != nil {
+		return err
 	}
 
 	// Wrap the flightsql server with custom action handling.
@@ -1029,6 +1012,32 @@ func (svc *DuckDBService) Serve(listener net.Listener) error {
 	svc.flightSrv.RegisterFlightService(customSrv)
 	svc.flightSrv.InitListener(listener)
 	return svc.flightSrv.Serve()
+}
+
+func flightServerOptions(cfg ServiceConfig, listener net.Listener) ([]grpc.ServerOption, error) {
+	opts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(flightclient.MaxGRPCMessageSize),
+		grpc.MaxSendMsgSize(flightclient.MaxGRPCMessageSize),
+		sqlcore.OTELGRPCServerHandler(),
+	}
+	if cfg.BearerToken != "" {
+		opts = append(opts,
+			grpc.ChainUnaryInterceptor(BearerTokenUnaryInterceptor(cfg.BearerToken)),
+			grpc.ChainStreamInterceptor(BearerTokenStreamInterceptor(cfg.BearerToken)),
+		)
+	}
+	if listener != nil && listener.Addr() != nil && listener.Addr().Network() == "tcp" &&
+		cfg.ServerConfig.TLSCertFile != "" && cfg.ServerConfig.TLSKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ServerConfig.TLSCertFile, cfg.ServerConfig.TLSKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load worker RPC TLS certificates: %w", err)
+		}
+		opts = append(opts, grpc.Creds(credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})))
+	}
+	return opts, nil
 }
 
 // Shutdown gracefully stops the service.

--- a/duckdbservice/service_tracing_test.go
+++ b/duckdbservice/service_tracing_test.go
@@ -1,0 +1,97 @@
+package duckdbservice
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
+	"github.com/posthog/duckgres/server/sqlcore"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type traceContextFlightServer struct {
+	pb.UnimplementedFlightServiceServer
+	contexts chan context.Context
+}
+
+func (s *traceContextFlightServer) GetFlightInfo(ctx context.Context, _ *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	s.contexts <- ctx
+	return &flight.FlightInfo{}, nil
+}
+
+func TestFlightServerOptionsExtractQueryTraceContext(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	opts, err := flightServerOptions(ServiceConfig{}, nil)
+	if err != nil {
+		t.Fatalf("flightServerOptions: %v", err)
+	}
+	grpcServer := grpc.NewServer(opts...)
+	server := &traceContextFlightServer{contexts: make(chan context.Context, 1)}
+	pb.RegisterFlightServiceServer(grpcServer, server)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(
+		listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		sqlcore.OTELGRPCClientHandler(),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	defer parent.End()
+	if _, err := pb.NewFlightServiceClient(conn).GetFlightInfo(ctx, &flight.FlightDescriptor{}); err != nil {
+		t.Fatalf("GetFlightInfo: %v", err)
+	}
+
+	select {
+	case handlerCtx := <-server.contexts:
+		handlerSpanContext := oteltrace.SpanContextFromContext(handlerCtx)
+		if !handlerSpanContext.IsValid() {
+			t.Fatal("Flight handler did not receive an active span context")
+		}
+		if handlerSpanContext.TraceID() != oteltrace.SpanContextFromContext(ctx).TraceID() {
+			t.Fatalf("handler trace ID = %s, want %s", handlerSpanContext.TraceID(), oteltrace.SpanContextFromContext(ctx).TraceID())
+		}
+		for _, span := range recorder.Ended() {
+			spanContext := span.SpanContext()
+			if spanContext.TraceID() == handlerSpanContext.TraceID() && spanContext.SpanID() == handlerSpanContext.SpanID() {
+				if !span.Parent().IsRemote() {
+					t.Fatal("Flight server span did not retain its remote parent")
+				}
+				return
+			}
+		}
+		t.Fatal("Flight server span was not recorded")
+	case <-time.After(time.Second):
+		t.Fatal("Flight handler was not called")
+	}
+}

--- a/server/sqlcore/otel.go
+++ b/server/sqlcore/otel.go
@@ -16,10 +16,20 @@ import (
 // Flight wall-time visibility in traces.
 func OTELGRPCClientHandler() grpc.DialOption {
 	return grpc.WithStatsHandler(otelgrpc.NewClientHandler(
-		otelgrpc.WithFilter(func(info *stats.RPCTagInfo) bool {
-			return strings.Contains(info.FullMethodName, "GetFlightInfo") ||
-				strings.Contains(info.FullMethodName, "DoGet") ||
-				strings.Contains(info.FullMethodName, "DoPut")
-		}),
+		otelgrpc.WithFilter(isQueryFlightRPC),
 	))
+}
+
+// OTELGRPCServerHandler returns a gRPC StatsHandler that extracts trace
+// context and creates server spans for query-related Flight SQL RPCs.
+func OTELGRPCServerHandler() grpc.ServerOption {
+	return grpc.StatsHandler(otelgrpc.NewServerHandler(
+		otelgrpc.WithFilter(isQueryFlightRPC),
+	))
+}
+
+func isQueryFlightRPC(info *stats.RPCTagInfo) bool {
+	return strings.Contains(info.FullMethodName, "GetFlightInfo") ||
+		strings.Contains(info.FullMethodName, "DoGet") ||
+		strings.Contains(info.FullMethodName, "DoPut")
 }


### PR DESCRIPTION
## Summary
- extract W3C trace context at the worker Flight gRPC server
- create filtered server spans for query Flight RPCs
- cover trace propagation through the production Flight server options

## Validation
- ok  	github.com/posthog/duckgres/duckdbservice	(cached)
ok  	github.com/posthog/duckgres/server/sqlcore	(cached)
- 0 issues.