### PR TITLE
Cache proxy: add derived-capacity foundation

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -9,7 +9,7 @@ available, and forwards cache misses to origin object storage.
 | Setting | Default | Notes |
 | --- | --- | --- |
 | `CACHE_DIR` | `/cache` | Local disk cache directory. |
-| `CACHE_MAX_PERCENT` | `80` | Target for tracked cache bytes, clamped to what is actually free (minus a 5%-of-total reserve). Recomputed every minute; the target only shrinks. Completed commits evict to this target, except that one entry larger than the target is retained. Concurrent temporary files are outside tracked-byte accounting. |
+| `CACHE_MAX_PERCENT` | `80` | Target for committed cache bytes. The proxy retains a 5%-of-total-disk reserve and accounts for its own committed files as reclaimable, so a restart of an 80%-full cache does not mistake the cache itself for external disk use. Capacity is refreshed every minute; reductions apply immediately and recovery requires two consecutive healthy samples. |
 | `CACHE_MAX_ENTRIES` | `1000000` | Strict maximum tracked LRU entries after each serialized final commit. Bounds local cache-index memory. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
@@ -29,9 +29,41 @@ available, and forwards cache misses to origin object storage.
 Cache bodies stream concurrently into temporary files. Only the short final
 rename plus exact-index, LRU, byte-count, and counting-Bloom update is serialized.
 That commit evicts before returning, so completed commits cannot exceed
-`CACHE_MAX_ENTRIES`, and tracked bytes do not exceed the current disk target
-unless a single retained entry is itself larger than that target. Concurrent
-temporary files consume real disk but are not yet tracked cache entries.
+`CACHE_MAX_ENTRIES`, and tracked bytes do not exceed the current cache byte
+capacity unless a single retained entry is itself larger than that capacity.
+Concurrent temporary files consume real disk but are not yet tracked cache
+entries.
+
+## Capacity startup, recovery, and failures
+
+The cache capacity calculation is:
+
+```text
+diskTarget = CACHE_MAX_PERCENT / 100 * totalDiskBytes
+reserve = 5% * totalDiskBytes
+reclaimable = max(0, freeBytes + committedCacheBytes - reserve)
+cacheCapacity = min(diskTarget, reclaimable)
+```
+
+Only successfully committed files whose names are valid cache keys contribute
+to `committedCacheBytes`. Interrupted files in `.tmp` are removed during
+startup and are never cached or counted as evictions. Invalid or unrelated
+root-directory entries are left in place and remain external disk usage.
+
+When another writer consumes local disk, the cache lowers its capacity and
+evicts least-recently-used committed entries as needed to preserve the reserve.
+When that pressure disappears, it expands only after two consecutive refreshes
+confirm recovery; no deleted entries are recreated automatically. If the proxy
+cannot inspect the filesystem or prune an over-limit committed entry at startup,
+it exits rather than serving with an unknown or unenforceable disk budget. Once
+running, a failed pressure-driven deletion leaves the entry indexed and is
+logged, then is retried on later refreshes while the cache remains over its
+limit. Failed and already-absent deletions are never reported as evictions.
+
+This compatibility release continues to use the configured
+`CACHE_MAX_ENTRIES` as the active admission ceiling; its default is 1,000,000.
+The derived disk/entry/Bloom sizing calculations prepare the later
+derived-entry rollout but do not replace that configured limit.
 
 ## Cluster-wide fetch dedup
 

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -4,9 +4,11 @@ import (
 	"container/heap"
 	"container/list"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -52,14 +54,73 @@ var (
 		Name: "cache_proxy_cache_size_bytes",
 		Help: "Current cache size on disk",
 	})
+	cacheEntries = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_entries",
+		Help: "Current committed cache entries represented by the exact index",
+	})
+	cacheEntryLimit = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_entry_limit",
+		Help: "Active committed cache entry limit",
+	})
+	cacheOwnedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_owned_bytes",
+		Help: "Committed cache bytes owned and reclaimable by the cache",
+	})
 	cacheCapacityBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cache_proxy_cache_capacity_bytes",
 		Help: "Maximum cache capacity",
 	})
+	cacheDiskTargetBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_disk_target_bytes",
+		Help: "Configured percentage-of-disk cache target before free-space clamping",
+	})
+	cacheDiskReserveBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_disk_reserve_bytes",
+		Help: "Whole-filesystem reserve excluded from cache capacity",
+	})
+	cacheEntryLimitReason = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_entry_limit_reason",
+		Help: "Future derived entry-limit bottleneck; exactly one of disk or metadata is 1",
+	}, []string{"reason"})
 	cacheEvictionsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "cache_proxy_evictions_total",
 		Help: "Number of LRU cache evictions",
 	})
+	cacheEvictionsByPhaseReasonTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_proxy_evictions_by_phase_reason_total",
+		Help: "Committed cache-entry evictions by bounded phase and pressure reason",
+	}, []string{"phase", "reason"})
+	cacheStartupScanDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cache_proxy_cache_startup_scan_duration_seconds",
+		Help: "Duration of cache startup scans",
+	})
+	cacheStartupScanFilesInspectedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_scan_files_inspected_total",
+		Help: "Directory entries inspected during cache startup scans",
+	})
+	cacheStartupInvalidFilesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_invalid_files_total",
+		Help: "Invalid or unrelated root-directory entries excluded from cache ownership during startup scans",
+	})
+	cacheTemporaryFilesRemovedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_temporary_files_removed_total",
+		Help: "Incomplete temporary cache files removed during startup cleanup",
+	})
+)
+
+type cacheEvictionPhase = string
+
+const (
+	cacheEvictionPhaseStartup    cacheEvictionPhase = "startup"
+	cacheEvictionPhaseBackground cacheEvictionPhase = "background"
+	cacheEvictionPhaseRequest    cacheEvictionPhase = "request"
+)
+
+type cacheEvictionReason = string
+
+const (
+	cacheEvictionReasonEntry cacheEvictionReason = "entry"
+	cacheEvictionReasonByte  cacheEvictionReason = "byte"
 )
 
 // CacheKey computes a deterministic cache key from a full URL and byte range.
@@ -88,6 +149,14 @@ type DiskCache struct {
 	maxBytes    int64
 	maxEntries  int
 	currentSize int64
+	maxPercent  int
+	blockSize   int64
+	space       capacityProvider
+
+	// Consecutive above-current samples are required before raising capacity.
+	// Reductions apply immediately to restore the filesystem reserve.
+	recoveryCandidate int64
+	recoverySamples   int
 
 	mu sync.Mutex
 	// order is the access list: least recently used at the front, most recent
@@ -99,9 +168,37 @@ type DiskCache struct {
 	summary *summaryIndex
 	// renameFile is os.Rename in production and a per-cache failure seam in tests.
 	renameFile func(string, string) error
+	// removeFile is os.Remove in production and a per-cache failure seam in tests.
+	removeFile func(string) error
+	// openScanDirectory is os.Open in production and lets constructor tests
+	// inject directory-open and mid-scan failures deterministically.
+	openScanDirectory openCacheDirectory
 }
 
 const defaultCacheMaxEntries = 1_000_000
+
+const (
+	defaultCacheBlockSizeBytes      int64 = 8 << 20
+	capacityRecoveryRequiredSamples       = 2
+)
+
+type diskSpace struct {
+	TotalBytes int64
+	FreeBytes  int64
+}
+
+type capacityProvider func(string) (diskSpace, error)
+
+type cacheDirectory interface {
+	ReadDir(int) ([]os.DirEntry, error)
+	Close() error
+}
+
+type openCacheDirectory func(string) (cacheDirectory, error)
+
+func openDirectory(path string) (cacheDirectory, error) {
+	return os.Open(path)
+}
 
 type cacheEntry struct {
 	key        string
@@ -130,43 +227,20 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
 
-	// Recreate the temp dir from scratch so any half-written streams left by a
-	// crash don't linger and leak disk.
-	tmpDir := filepath.Join(dir, tmpSubdir)
-	_ = os.RemoveAll(tmpDir)
-	if err := os.MkdirAll(tmpDir, 0750); err != nil {
-		return nil, fmt.Errorf("create cache temp dir: %w", err)
-	}
-
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(dir, &stat); err != nil {
-		return nil, fmt.Errorf("statfs %s: %w", dir, err)
-	}
-
-	totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
-	freeBytes := int64(stat.Bavail) * int64(stat.Bsize)
-	// Start at the percent-of-total ceiling, immediately clamped to what is
-	// actually free (well, free minus a reserve): the cache must never treat
-	// space already consumed by anything else (container layers, other pods
-	// sharing the filesystem, the rootfs on a tiny test disk) as available.
-	maxBytes := clampToFree(totalBytes*int64(maxPercent)/100, totalBytes, freeBytes)
-
-	slog.Info("Cache initialized.",
-		"dir", dir,
-		"total_disk", totalBytes,
-		"max_cache", maxBytes,
-		"max_percent", maxPercent,
-	)
-
-	cacheCapacityBytes.Set(float64(maxBytes))
-
 	dc := &DiskCache{
-		dir:        dir,
-		maxBytes:   maxBytes,
-		maxEntries: defaultCacheMaxEntries,
-		order:      list.New(),
-		index:      make(map[string]*list.Element),
-		renameFile: os.Rename,
+		dir: dir,
+		// Startup must account for committed files before applying a byte
+		// ceiling, so scans initially load without byte pruning.
+		maxBytes:          math.MaxInt64,
+		maxEntries:        defaultCacheMaxEntries,
+		maxPercent:        maxPercent,
+		blockSize:         defaultCacheBlockSizeBytes,
+		space:             statfsDiskSpace,
+		order:             list.New(),
+		index:             make(map[string]*list.Element),
+		renameFile:        os.Rename,
+		removeFile:        os.Remove,
+		openScanDirectory: openDirectory,
 	}
 	if len(options) > 0 {
 		if options[0].MaxEntries > 0 {
@@ -175,10 +249,54 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		if options[0].IncrementalSummary {
 			dc.summary = newSummaryIndex()
 		}
+		if options[0].BlockSizeBytes > 0 {
+			dc.blockSize = options[0].BlockSizeBytes
+		}
+		if options[0].CapacityProvider != nil {
+			dc.space = options[0].CapacityProvider
+		}
+		if options[0].openScanDirectory != nil {
+			dc.openScanDirectory = options[0].openScanDirectory
+		}
+		if options[0].removeFile != nil {
+			dc.removeFile = options[0].removeFile
+		}
 	}
 
-	// Scan existing cache entries
-	dc.scanExisting()
+	removedTemporaryFiles, err := resetTemporaryDirectory(filepath.Join(dir, tmpSubdir))
+	if err != nil {
+		return nil, fmt.Errorf("reset cache temp dir: %w", err)
+	}
+	if removedTemporaryFiles > 0 {
+		cacheTemporaryFilesRemovedTotal.Add(float64(removedTemporaryFiles))
+	}
+
+	// Sample free space before the scan can apply the legacy entry ceiling.
+	// Together with the scan's owned-byte total, this is a consistent restart
+	// view: if the scan deletes entry-limit victims before statfs runs, adding
+	// their former bytes to the newer free sample would double count them.
+	startupSpace, err := dc.diskSpace()
+	if err != nil {
+		return nil, fmt.Errorf("statfs %s: %w", dir, err)
+	}
+
+	// Scan existing cache entries before capacity is derived. The scan's owned
+	// byte total includes every valid committed file, even ones later discarded
+	// by the legacy entry ceiling, so a restart never mistakes the cache itself
+	// for external disk pressure.
+	ownedBytes, err := dc.scanExisting()
+	if err != nil {
+		return nil, fmt.Errorf("scan existing cache entries: %w", err)
+	}
+	if err := dc.initializeCapacity(ownedBytes, startupSpace); err != nil {
+		return nil, fmt.Errorf("apply startup cache limits: %w", err)
+	}
+
+	slog.Info("Cache initialized.",
+		"dir", dir,
+		"max_cache", dc.maxBytes,
+		"max_percent", maxPercent,
+	)
 
 	return dc, nil
 }
@@ -186,14 +304,16 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 type DiskCacheOptions struct {
 	IncrementalSummary bool
 	MaxEntries         int
+	BlockSizeBytes     int64
+	CapacityProvider   capacityProvider
+	openScanDirectory  openCacheDirectory
+	removeFile         func(string) error
 }
 
-// clampToFree bounds a capacity target by the space actually available on the
-// filesystem: the cache may not grow into bytes it doesn't own (free space
-// shrinks over time as other writers consume the disk), and it always leaves
-// a small reserve so a full cache doesn't take the filesystem to 100%.
+// clampToFree remains a narrow compatibility helper for callers that have no
+// owned-cache total. DiskCache itself always uses deriveDiskCapacity instead.
 func clampToFree(target, totalBytes, freeBytes int64) int64 {
-	reserve := totalBytes / 20 // 5% of total, kept for everyone else
+	reserve := percentageOf(nonNegative(totalBytes), cacheDiskReservePercent)
 	if avail := freeBytes - reserve; target > avail {
 		target = avail
 	}
@@ -203,36 +323,23 @@ func clampToFree(target, totalBytes, freeBytes int64) int64 {
 	return target
 }
 
-// refreshCapacityStats recomputes maxBytes from the current statfs free space
-// and the percent-of-total ceiling. Returns (total, clamped max, ok). Only
-// ever LOWERS maxBytes: once another writer has eaten into the disk the cache
-// commits to the smaller budget, so later frees don't balloon it back up.
+// refreshCapacityStats recomputes maxBytes from live disk state. Valid
+// committed files are reclaimable cache-owned bytes, unlike invalid and
+// unrelated files. Capacity reductions are immediate to restore the 5%
+// reserve; capacity recovery requires two consecutive healthy samples to keep
+// short-lived external writers from flapping the advertised ceiling.
 func (c *DiskCache) refreshCapacityStats(maxPercent int) (int64, int64, bool) {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(c.dir, &stat); err != nil {
+	space, err := c.diskSpace()
+	if err != nil {
 		return 0, 0, false
 	}
-	totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
-	freeBytes := int64(stat.Bavail) * int64(stat.Bsize)
-	target := clampToFree(totalBytes*int64(maxPercent)/100, totalBytes, freeBytes)
 
 	c.mu.Lock()
-	if target < c.maxBytes {
-		evicted := 0
-		for c.currentSize > target && c.order.Len() > 0 {
-			c.evictOldest()
-			evicted++
-		}
-		if target != c.maxBytes {
-			slog.Warn("Cache capacity lowered to fit free disk.",
-				"old_max", c.maxBytes, "new_max", target, "free", freeBytes, "evicted", evicted)
-			c.maxBytes = target
-			cacheCapacityBytes.Set(float64(target))
-		}
-	}
+	capacity := deriveDiskCapacity(space.TotalBytes, space.FreeBytes, c.currentSize, maxPercent)
+	c.applyCapacityLocked(capacity, cacheEvictionPhaseBackground)
 	max := c.maxBytes
 	c.mu.Unlock()
-	return totalBytes, max, true
+	return space.TotalBytes, max, true
 }
 
 // refreshCapacity periodically re-derives maxBytes from live statfs data so a
@@ -242,45 +349,208 @@ func (c *DiskCache) refreshCapacity(maxPercent int) {
 	c.refreshCapacityStats(maxPercent)
 }
 
-func (c *DiskCache) scanExisting() {
-	dir, err := os.Open(c.dir)
-	if err != nil {
-		return
+func (c *DiskCache) initializeCapacity(ownedBytes int64, space diskSpace) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	capacity := deriveDiskCapacity(space.TotalBytes, space.FreeBytes, ownedBytes, c.maxPercent)
+	c.maxBytes = capacity.ByteCeiling
+	c.recoveryCandidate = 0
+	c.recoverySamples = 0
+	c.updateCapacityMetricsLocked(capacity)
+	if err := c.evictToLimitsLocked(cacheEvictionPhaseStartup); err != nil {
+		c.updateStateMetricsLocked()
+		return err
 	}
-	defer func() { _ = dir.Close() }()
-	// Only count real cache entries — the .tmp dir's contents and any
-	// stray non-key files must not enter the LRU accounting.
+	c.updateStateMetricsLocked()
+	return nil
+}
+
+func (c *DiskCache) applyCapacityLocked(capacity diskCapacity, phase cacheEvictionPhase) {
+	oldMax := c.maxBytes
+	newMax := capacity.ByteCeiling
+	switch {
+	case newMax < oldMax:
+		c.maxBytes = newMax
+		c.recoveryCandidate = 0
+		c.recoverySamples = 0
+		slog.Warn("Cache capacity lowered to fit live disk pressure.",
+			"old_max", oldMax, "new_max", newMax, "owned_bytes", c.currentSize)
+	case newMax > oldMax:
+		if newMax >= c.recoveryCandidate {
+			c.recoveryCandidate = newMax
+			c.recoverySamples++
+		} else {
+			c.recoveryCandidate = newMax
+			c.recoverySamples = 1
+		}
+		if c.recoverySamples >= capacityRecoveryRequiredSamples {
+			c.maxBytes = newMax
+			c.recoveryCandidate = 0
+			c.recoverySamples = 0
+			slog.Info("Cache capacity recovered after stable disk samples.", "old_max", oldMax, "new_max", newMax)
+		}
+	default:
+		c.recoveryCandidate = 0
+		c.recoverySamples = 0
+	}
+	// Background convergence remains best effort: a hard deletion failure is
+	// logged by removeCommittedFile and leaves the entry indexed rather than
+	// taking the running proxy down. Retry on every refresh while over either
+	// active limit, including when the derived byte ceiling is unchanged.
+	if c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries {
+		_ = c.evictToLimitsLocked(phase)
+	}
+	c.updateCapacityMetricsLocked(capacity)
+	c.updateStateMetricsLocked()
+}
+
+func (c *DiskCache) updateCapacityMetricsLocked(capacity diskCapacity) {
+	cacheCapacityBytes.Set(float64(c.maxBytes))
+	cacheDiskTargetBytes.Set(float64(capacity.DiskTargetBytes))
+	cacheDiskReserveBytes.Set(float64(capacity.ReserveBytes))
+
+	// The active admission ceiling remains the compatibility 1M value in PR 1.
+	// These two reason series describe which guardrail would limit the future
+	// disk-derived ceiling, keeping the rollout observable before enabling it.
+	if deriveCacheEntryCeiling(capacity.ByteCeiling, c.blockSize) >= cacheMetadataEntryLimit {
+		cacheEntryLimitReason.WithLabelValues("disk").Set(0)
+		cacheEntryLimitReason.WithLabelValues("metadata").Set(1)
+	} else {
+		cacheEntryLimitReason.WithLabelValues("disk").Set(1)
+		cacheEntryLimitReason.WithLabelValues("metadata").Set(0)
+	}
+}
+
+func (c *DiskCache) updateStateMetricsLocked() {
+	cacheSizeBytes.Set(float64(c.currentSize))
+	cacheOwnedBytes.Set(float64(c.currentSize))
+	cacheEntries.Set(float64(c.order.Len()))
+	cacheEntryLimit.Set(float64(c.maxEntries))
+}
+
+func (c *DiskCache) diskSpace() (diskSpace, error) {
+	if c.space == nil {
+		return diskSpace{}, errors.New("no disk capacity provider")
+	}
+	return c.space(c.dir)
+}
+
+func statfsDiskSpace(dir string) (diskSpace, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(dir, &stat); err != nil {
+		return diskSpace{}, err
+	}
+	blockSize := uint64(stat.Bsize)
+	return diskSpace{
+		TotalBytes: filesystemBytes(stat.Blocks, blockSize),
+		FreeBytes:  filesystemBytes(stat.Bavail, blockSize),
+	}, nil
+}
+
+func filesystemBytes(blocks, blockSize uint64) int64 {
+	if blocks == 0 || blockSize == 0 {
+		return 0
+	}
+	if blocks > uint64(math.MaxInt64)/blockSize {
+		return math.MaxInt64
+	}
+	return int64(blocks * blockSize)
+}
+
+func resetTemporaryDirectory(tmpDir string) (int, error) {
+	removed := 0
+	if _, err := os.Lstat(tmpDir); err == nil {
+		err = filepath.WalkDir(tmpDir, func(_ string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !entry.IsDir() {
+				removed++
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return 0, err
+	}
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(tmpDir, 0750); err != nil {
+		return 0, err
+	}
+	return removed, nil
+}
+
+func (c *DiskCache) scanExisting() (ownedBytes int64, scanErr error) {
+	started := time.Now()
+	defer func() { cacheStartupScanDuration.Observe(time.Since(started).Seconds()) }()
+
+	openScanDirectory := c.openScanDirectory
+	if openScanDirectory == nil {
+		openScanDirectory = openDirectory
+	}
+	dir, err := openScanDirectory(c.dir)
+	if err != nil {
+		return 0, fmt.Errorf("open cache directory %s: %w", c.dir, err)
+	}
+	defer func() {
+		if err := dir.Close(); err != nil && scanErr == nil {
+			scanErr = fmt.Errorf("close cache directory %s: %w", c.dir, err)
+		}
+	}()
+	// Only count real, committed cache entries. Temporary files were removed
+	// before this scan; invalid and unrelated root entries stay on disk as
+	// external usage and never enter the exact index or owned-byte accounting.
 	// Do not reserve a million cacheEntry structs for an empty/new cache. The
 	// heap remains bounded by maxEntries but grows with actual disk contents.
 	found := make(oldestEntries, 0, min(c.maxEntries, 1024))
 	for {
 		entries, readErr := dir.ReadDir(1024)
 		for _, e := range entries {
-			if e.IsDir() || !IsValidCacheKey(e.Name()) {
+			cacheStartupScanFilesInspectedTotal.Inc()
+			if e.Name() == tmpSubdir {
+				continue
+			}
+			if !IsValidCacheKey(e.Name()) {
+				cacheStartupInvalidFilesTotal.Inc()
 				continue
 			}
 			info, err := e.Info()
 			if err != nil {
+				return 0, fmt.Errorf("inspect cache entry %s: %w", filepath.Join(c.dir, e.Name()), err)
+			}
+			if !info.Mode().IsRegular() {
+				cacheStartupInvalidFilesTotal.Inc()
 				continue
 			}
 			entry := cacheEntry{key: e.Name(), size: info.Size(), lastAccess: info.ModTime()}
+			ownedBytes = saturatingAdd(ownedBytes, entry.size)
 			if found.Len() < c.maxEntries {
 				heap.Push(&found, entry)
 				continue
 			}
 			if !entry.lastAccess.After(found[0].lastAccess) {
-				_ = os.Remove(filepath.Join(c.dir, entry.key))
+				path := filepath.Join(c.dir, entry.key)
+				if err := c.removeCommittedFile(path, cacheEvictionPhaseStartup, cacheEvictionReasonEntry); err != nil {
+					return 0, fmt.Errorf("prune startup cache entry %s: %w", path, err)
+				}
 				continue
 			}
 			dropped := heap.Pop(&found).(cacheEntry)
-			_ = os.Remove(filepath.Join(c.dir, dropped.key))
+			path := filepath.Join(c.dir, dropped.key)
+			if err := c.removeCommittedFile(path, cacheEvictionPhaseStartup, cacheEvictionReasonEntry); err != nil {
+				return 0, fmt.Errorf("prune startup cache entry %s: %w", path, err)
+			}
 			heap.Push(&found, entry)
 		}
 		if readErr == io.EOF {
 			break
 		}
 		if readErr != nil {
-			return
+			return 0, fmt.Errorf("read cache directory %s: %w", c.dir, readErr)
 		}
 	}
 	// The access list must start in recency order (front = oldest) or the
@@ -290,7 +560,6 @@ func (c *DiskCache) scanExisting() {
 	})
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	for i := range found {
 		entry := found[i]
 		c.index[entry.key] = c.order.PushBack(&entry)
@@ -299,10 +568,19 @@ func (c *DiskCache) scanExisting() {
 			c.summary.Add(entry.key)
 		}
 	}
-	for (c.order.Len() > c.maxEntries || c.currentSize > c.maxBytes) && c.order.Len() > 0 {
-		c.evictOldest()
+	// Direct callers that construct a DiskCache by hand retain the historical
+	// scan behavior. NewDiskCache defers byte pruning until its owned-byte
+	// capacity calculation is complete.
+	if c.space == nil {
+		if err := c.evictToLimitsLocked(cacheEvictionPhaseStartup); err != nil {
+			c.updateStateMetricsLocked()
+			c.mu.Unlock()
+			return 0, fmt.Errorf("apply startup cache limits: %w", err)
+		}
 	}
-	cacheSizeBytes.Set(float64(c.currentSize))
+	c.updateStateMetricsLocked()
+	c.mu.Unlock()
+	return ownedBytes, nil
 }
 
 // SummarySnapshot returns an immutable bounded copy of the locally maintained
@@ -370,13 +648,27 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	// commit. Streaming happened above without this lock; only the short rename
 	// syscall is serialized so eviction cannot delete the replacement in between.
 	c.mu.Lock()
+	el, replacing := c.index[key]
+	if replacing {
+		if !c.makeRoomForReplacementLocked(el, size, cacheEvictionPhaseRequest) {
+			c.mu.Unlock()
+			_ = os.Remove(tmpPath)
+			return 0, errors.New("admit cache replacement: required eviction failed")
+		}
+	} else {
+		if !c.makeRoomForNewEntryLocked(size, cacheEvictionPhaseRequest) {
+			c.mu.Unlock()
+			_ = os.Remove(tmpPath)
+			return 0, errors.New("admit cache entry: required eviction failed")
+		}
+	}
 	if err := renameFile(tmpPath, path); err != nil {
 		c.mu.Unlock()
 		_ = os.Remove(tmpPath)
 		return 0, fmt.Errorf("commit cache entry: %w", err)
 	}
 
-	if el, replacing := c.index[key]; replacing {
+	if replacing {
 		// The key remained represented throughout the filesystem commit. Update
 		// its accounting in place so a concurrent Bloom snapshot can never see a
 		// transient negative for an already committed entry.
@@ -385,16 +677,8 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 		entry.size = size
 		entry.lastAccess = time.Now()
 		c.order.MoveToBack(el)
-		// Keep the replacement itself even when it exceeds maxBytes; this matches
-		// the existing oversized-object behavior. Evict older entries first.
-		for (c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries) && c.order.Len() > 1 {
-			c.evictOldest()
-		}
-		cacheSizeBytes.Set(float64(c.currentSize))
+		c.updateStateMetricsLocked()
 	} else {
-		for (c.currentSize+size > c.maxBytes || c.order.Len() >= c.maxEntries) && c.order.Len() > 0 {
-			c.evictOldest()
-		}
 		c.addLocked(key, size)
 	}
 	c.mu.Unlock()
@@ -479,26 +763,97 @@ func (c *DiskCache) addLocked(key string, size int64) {
 	if c.summary != nil {
 		c.summary.Add(key)
 	}
-	cacheSizeBytes.Set(float64(c.currentSize))
+	c.updateStateMetricsLocked()
 }
 
 // evictOldest removes the least recently used entry. The list front is the
 // LRU entry by construction: adds and touches always move entries to the
 // back, and scanExisting seeds the list in recency order.
-func (c *DiskCache) evictOldest() {
+func (c *DiskCache) evictOldest(phase cacheEvictionPhase, reason cacheEvictionReason) error {
 	front := c.order.Front()
 	if front == nil {
-		return
+		return nil
 	}
 	oldest := front.Value.(*cacheEntry)
 	path := filepath.Join(c.dir, oldest.key)
-	_ = os.Remove(path)
+	if err := c.removeCommittedFile(path, phase, reason); err != nil {
+		return err
+	}
 	c.currentSize -= oldest.size
 	c.order.Remove(front)
 	delete(c.index, oldest.key)
 	if c.summary != nil {
 		c.summary.Remove(oldest.key)
 	}
-	cacheEvictionsTotal.Inc()
-	cacheSizeBytes.Set(float64(c.currentSize))
+	c.updateStateMetricsLocked()
+	return nil
+}
+
+func (c *DiskCache) makeRoomForNewEntryLocked(size int64, phase cacheEvictionPhase) bool {
+	for c.order.Len() >= c.maxEntries && c.order.Len() > 0 {
+		if c.evictOldest(phase, cacheEvictionReasonEntry) != nil {
+			return false
+		}
+	}
+	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
+		if c.evictOldest(phase, cacheEvictionReasonByte) != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *DiskCache) makeRoomForReplacementLocked(replacement *list.Element, size int64, phase cacheEvictionPhase) bool {
+	entry := replacement.Value.(*cacheEntry)
+	// Protect the entry being replaced from eviction. If reservation or rename
+	// fails, its old committed body and accounting remain usable.
+	c.order.MoveToBack(replacement)
+	for c.order.Len() > c.maxEntries && c.order.Len() > 1 {
+		if c.evictOldest(phase, cacheEvictionReasonEntry) != nil {
+			return false
+		}
+	}
+	for c.currentSize-entry.size+size > c.maxBytes && c.order.Len() > 1 {
+		if c.evictOldest(phase, cacheEvictionReasonByte) != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *DiskCache) evictToLimitsLocked(phase cacheEvictionPhase) error {
+	for c.order.Len() > c.maxEntries && c.order.Len() > 0 {
+		if err := c.evictOldest(phase, cacheEvictionReasonEntry); err != nil {
+			return err
+		}
+	}
+	for c.currentSize > c.maxBytes && c.order.Len() > 0 {
+		if err := c.evictOldest(phase, cacheEvictionReasonByte); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeCommittedFile is the one filesystem deletion path for valid cache
+// files under pressure. A successful unlink is always visible in both the
+// aggregate eviction counter and its bounded phase/reason breakdown. A file
+// already removed by an external actor is forgotten without claiming an
+// eviction; a hard unlink failure preserves its index accounting.
+func (c *DiskCache) removeCommittedFile(path string, phase cacheEvictionPhase, reason cacheEvictionReason) error {
+	removeFile := c.removeFile
+	if removeFile == nil {
+		removeFile = os.Remove
+	}
+	err := removeFile(path)
+	if err == nil {
+		cacheEvictionsTotal.Inc()
+		cacheEvictionsByPhaseReasonTotal.WithLabelValues(string(phase), string(reason)).Inc()
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	slog.Warn("Unable to evict committed cache file.", "path", path, "phase", phase, "reason", reason, "error", err)
+	return err
 }

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -29,6 +29,11 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
+func counterVecValue(t *testing.T, c *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	return counterValue(t, c.WithLabelValues(labels...))
+}
+
 func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
 	t.Helper()
 	var m dto.Metric
@@ -62,6 +67,22 @@ func (e *errAfterReader) Read(p []byte) (int, error) {
 	e.pos += n
 	return n, nil
 }
+
+type scriptedCacheDirectory struct {
+	entries []os.DirEntry
+	err     error
+	read    bool
+}
+
+func (d *scriptedCacheDirectory) ReadDir(int) ([]os.DirEntry, error) {
+	if !d.read {
+		d.read = true
+		return d.entries, nil
+	}
+	return nil, d.err
+}
+
+func (d *scriptedCacheDirectory) Close() error { return nil }
 
 func TestIsValidCacheKey(t *testing.T) {
 	cases := []struct {
@@ -251,6 +272,415 @@ func TestDiskCacheEntryLimitAppliesDuringStartupScan(t *testing.T) {
 	}
 	if c.order.Len() != 2 || c.Has(entries[0].key) || !c.Has(entries[1].key) || !c.Has(entries[2].key) {
 		t.Fatalf("startup scan did not retain newest two entries")
+	}
+}
+
+func TestDiskCacheStartupCountsCommittedBytesAsReclaimable(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("a", 64), strings.Repeat("b", 64)}
+	for _, key := range keys {
+		if err := os.WriteFile(filepath.Join(dir, key), make([]byte, 400), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries: 2,
+		CapacityProvider: func(string) (diskSpace, error) {
+			// The disk is 80% full only because of the two committed cache files.
+			return diskSpace{TotalBytes: 1000, FreeBytes: 200}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.currentSize != 800 || c.maxBytes != 800 {
+		t.Fatalf("startup cache size/capacity = %d/%d, want 800/800; committed entries must not be mistaken for external disk use", c.currentSize, c.maxBytes)
+	}
+	for _, key := range keys {
+		if !c.Has(key) {
+			t.Fatalf("startup pruned committed cache key %s", key)
+		}
+	}
+}
+
+func TestDiskCacheScanSeparatesTemporaryInvalidAndCommittedFiles(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("c", 64)
+	if err := os.WriteFile(filepath.Join(dir, key), []byte("committed"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, tmpSubdir), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, tmpSubdir, "interrupted"), []byte("temporary"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	invalid := filepath.Join(dir, "not-a-cache-key")
+	if err := os.WriteFile(invalid, []byte("external"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeTemporary := counterValue(t, cacheTemporaryFilesRemovedTotal)
+	beforeInvalid := counterValue(t, cacheStartupInvalidFilesTotal)
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{CapacityProvider: func(string) (diskSpace, error) {
+		return diskSpace{TotalBytes: 1000, FreeBytes: 990}, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Has(key) {
+		t.Fatal("committed cache entry was not loaded")
+	}
+	if _, err := os.Stat(filepath.Join(dir, tmpSubdir, "interrupted")); !os.IsNotExist(err) {
+		t.Fatalf("temporary file still exists after startup: %v", err)
+	}
+	if _, err := os.Stat(invalid); err != nil {
+		t.Fatalf("unrelated file should remain external disk use: %v", err)
+	}
+	if got := counterValue(t, cacheTemporaryFilesRemovedTotal) - beforeTemporary; got != 1 {
+		t.Fatalf("temporary cleanup count = %v, want 1", got)
+	}
+	if got := counterValue(t, cacheStartupInvalidFilesTotal) - beforeInvalid; got != 1 {
+		t.Fatalf("invalid file count = %v, want 1", got)
+	}
+}
+
+func TestNewDiskCacheFailsWhenStartupScanCannotOpenDirectory(t *testing.T) {
+	scanErr := errors.New("forced startup scan open failure")
+	c, err := NewDiskCache(t.TempDir(), 80, DiskCacheOptions{
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return nil, scanErr
+		},
+	})
+	if c != nil {
+		t.Fatal("NewDiskCache returned a cache after its startup scan failed")
+	}
+	if !errors.Is(err, scanErr) {
+		t.Fatalf("NewDiskCache error = %v, want wrapped scan error", err)
+	}
+}
+
+func TestNewDiskCacheFailsWhenStartupScanStopsBeforeDirectoryIsExhausted(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("d", 64)
+	path := filepath.Join(dir, key)
+	if err := os.WriteFile(path, []byte("committed"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanErr := errors.New("forced startup scan read failure")
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &scriptedCacheDirectory{entries: entries, err: scanErr}, nil
+		},
+	})
+	if c != nil {
+		t.Fatal("NewDiskCache returned a partially scanned cache")
+	}
+	if !errors.Is(err, scanErr) {
+		t.Fatalf("NewDiskCache error = %v, want wrapped mid-scan error", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("committed file changed after non-pressure scan failure: %v", err)
+	}
+}
+
+func TestNewDiskCacheFailsWhenStartupPruneCannotRemoveVictim(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		firstAge   time.Duration
+		secondAge  time.Duration
+		wantVictim string
+	}{
+		{name: "incoming entry is older", firstAge: time.Hour, secondAge: 2 * time.Hour, wantVictim: strings.Repeat("b", 64)},
+		{name: "existing survivor is older", firstAge: 2 * time.Hour, secondAge: time.Hour, wantVictim: strings.Repeat("a", 64)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			first := strings.Repeat("a", 64)
+			second := strings.Repeat("b", 64)
+			now := time.Now()
+			for _, entry := range []struct {
+				key string
+				age time.Duration
+			}{{first, tc.firstAge}, {second, tc.secondAge}} {
+				path := filepath.Join(dir, entry.key)
+				if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				when := now.Add(-entry.age)
+				if err := os.Chtimes(path, when, when); err != nil {
+					t.Fatal(err)
+				}
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			removeErr := errors.New("forced startup prune removal failure")
+			var attemptedVictim string
+			beforeAggregate := counterValue(t, cacheEvictionsTotal)
+			beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+			c, err := NewDiskCache(dir, 100, DiskCacheOptions{
+				MaxEntries: 1,
+				openScanDirectory: func(string) (cacheDirectory, error) {
+					return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
+				},
+				removeFile: func(path string) error {
+					attemptedVictim = filepath.Base(path)
+					return removeErr
+				},
+			})
+			if c != nil {
+				t.Fatal("NewDiskCache returned a cache after startup pruning failed")
+			}
+			if !errors.Is(err, removeErr) {
+				t.Fatalf("NewDiskCache error = %v, want wrapped removal error", err)
+			}
+			if attemptedVictim != tc.wantVictim {
+				t.Fatalf("startup prune attempted victim %q, want %q", attemptedVictim, tc.wantVictim)
+			}
+			for _, key := range []string{first, second} {
+				if _, err := os.Stat(filepath.Join(dir, key)); err != nil {
+					t.Fatalf("committed file %s changed after failed prune: %v", key, err)
+				}
+			}
+			if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+				t.Fatalf("aggregate evictions after failed startup removal = %v, want 0", got)
+			}
+			if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry) - beforeLabel; got != 0 {
+				t.Fatalf("labelled evictions after failed startup removal = %v, want 0", got)
+			}
+		})
+	}
+}
+
+func TestNewDiskCacheTreatsStartupPruneENOENTAsSuccessfulCleanup(t *testing.T) {
+	dir := t.TempDir()
+	oldest := strings.Repeat("a", 64)
+	newest := strings.Repeat("b", 64)
+	now := time.Now()
+	for _, entry := range []struct {
+		key string
+		age time.Duration
+	}{{oldest, 2 * time.Hour}, {newest, time.Hour}} {
+		path := filepath.Join(dir, entry.key)
+		if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		when := now.Add(-entry.age)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+	c, err := NewDiskCache(dir, 100, DiskCacheOptions{
+		MaxEntries: 1,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
+		},
+		removeFile: func(path string) error {
+			if err := os.Remove(path); err != nil {
+				return err
+			}
+			return &os.PathError{Op: "remove", Path: path, Err: syscall.ENOENT}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache rejected an ENOENT startup-prune race: %v", err)
+	}
+	if c.order.Len() != 1 || c.Has(oldest) || !c.Has(newest) {
+		t.Fatalf("startup survivors after ENOENT race = entries:%d oldest:%t newest:%t, want 1/false/true", c.order.Len(), c.Has(oldest), c.Has(newest))
+	}
+	if _, err := os.Stat(filepath.Join(dir, oldest)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("externally removed victim still exists: %v", err)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+		t.Fatalf("aggregate evictions after ENOENT startup race = %v, want 0", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry) - beforeLabel; got != 0 {
+		t.Fatalf("labelled evictions after ENOENT startup race = %v, want 0", got)
+	}
+}
+
+func TestNewDiskCacheFailsWhenInitialBytePruneCannotRemoveVictim(t *testing.T) {
+	dir := t.TempDir()
+	for _, key := range []string{strings.Repeat("c", 64), strings.Repeat("d", 64)} {
+		if err := os.WriteFile(filepath.Join(dir, key), make([]byte, 60), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removeErr := errors.New("forced startup byte-prune removal failure")
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonByte)
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		CapacityProvider: func(string) (diskSpace, error) {
+			// owned=120, reserve=50, free=0 => byte ceiling=70.
+			return diskSpace{TotalBytes: 1000, FreeBytes: 0}, nil
+		},
+		removeFile: func(string) error { return removeErr },
+	})
+	if c != nil {
+		t.Fatal("NewDiskCache returned an over-capacity cache after initial byte pruning failed")
+	}
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("NewDiskCache error = %v, want wrapped byte-prune removal error", err)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+		t.Fatalf("aggregate evictions after failed startup byte removal = %v, want 0", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonByte) - beforeLabel; got != 0 {
+		t.Fatalf("labelled evictions after failed startup byte removal = %v, want 0", got)
+	}
+}
+
+func TestCachePressureEvictionsHaveBoundedPhaseAndReason(t *testing.T) {
+	t.Run("startup entry pressure", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, key := range []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)} {
+			if err := os.WriteFile(filepath.Join(dir, key), []byte("x"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		before := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+		beforeAggregate := counterValue(t, cacheEvictionsTotal)
+		c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+			MaxEntries: 2,
+			CapacityProvider: func(string) (diskSpace, error) {
+				return diskSpace{TotalBytes: 1000, FreeBytes: 990}, nil
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c.order.Len() != 2 {
+			t.Fatalf("startup entry limit retained %d entries, want 2", c.order.Len())
+		}
+		if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry) - before; got != 1 {
+			t.Fatalf("startup entry evictions = %v, want 1", got)
+		}
+		if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 1 {
+			t.Fatalf("aggregate startup evictions = %v, want 1", got)
+		}
+	})
+
+	t.Run("request byte pressure", func(t *testing.T) {
+		c := newTestCache(t)
+		c.maxBytes = 100
+		before := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, cacheEvictionReasonByte)
+		if _, err := c.PutStream(strings.Repeat("4", 64), bytes.NewReader(make([]byte, 60))); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.PutStream(strings.Repeat("5", 64), bytes.NewReader(make([]byte, 60))); err != nil {
+			t.Fatal(err)
+		}
+		if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, cacheEvictionReasonByte) - before; got != 1 {
+			t.Fatalf("request byte evictions = %v, want 1", got)
+		}
+	})
+}
+
+func TestRefreshCapacityShrinksImmediatelyAndRecoversAfterHysteresis(t *testing.T) {
+	space := diskSpace{TotalBytes: 1000, FreeBytes: 200}
+	c, err := NewDiskCache(t.TempDir(), 80, DiskCacheOptions{CapacityProvider: func(string) (diskSpace, error) {
+		return space, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The provider is synthetic, so make the seeded in-memory cache and free
+	// space agree with a cache that has reached its 80%-of-disk target.
+	c.maxBytes = 800
+	for _, key := range []string{strings.Repeat("6", 64), strings.Repeat("7", 64)} {
+		if _, err := c.PutStream(key, bytes.NewReader(make([]byte, 400))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte)
+	space.FreeBytes = 10
+	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
+		t.Fatalf("shrunk capacity = %d (ok=%v), want 760", got, ok)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte) - before; got != 1 {
+		t.Fatalf("background byte evictions = %v, want 1", got)
+	}
+
+	space.FreeBytes = 600
+	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
+		t.Fatalf("first recovery refresh = %d (ok=%v), want hysteresis to hold 760", got, ok)
+	}
+	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 800 {
+		t.Fatalf("second recovery refresh = %d (ok=%v), want 800", got, ok)
+	}
+}
+
+func TestRefreshCapacityRetriesEvictionAtUnchangedCeiling(t *testing.T) {
+	space := diskSpace{TotalBytes: 1000, FreeBytes: 1000}
+	c, err := NewDiskCache(t.TempDir(), 80, DiskCacheOptions{CapacityProvider: func(string) (diskSpace, error) {
+		return space, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{strings.Repeat("8", 64), strings.Repeat("9", 64)} {
+		if _, err := c.PutStream(key, bytes.NewReader(make([]byte, 400))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removeAttempts := 0
+	c.removeFile = func(path string) error {
+		removeAttempts++
+		if removeAttempts == 1 {
+			return errors.New("transient background removal failure")
+		}
+		return os.Remove(path)
+	}
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte)
+
+	// free + owned - reserve = 10 + 800 - 50 = 760. The first refresh
+	// lowers the ceiling, but its one required eviction fails transiently.
+	space.FreeBytes = 10
+	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
+		t.Fatalf("first refresh capacity = %d (ok=%v), want 760", got, ok)
+	}
+	if removeAttempts != 1 || c.currentSize != 800 || c.order.Len() != 2 {
+		t.Fatalf("cache after failed convergence = attempts:%d bytes:%d entries:%d, want 1/800/2", removeAttempts, c.currentSize, c.order.Len())
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+		t.Fatalf("aggregate evictions after failed convergence = %v, want 0", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte) - beforeLabel; got != 0 {
+		t.Fatalf("labelled evictions after failed convergence = %v, want 0", got)
+	}
+
+	// The byte ceiling is unchanged, but the cache is still over it, so the
+	// next refresh must retry and converge after the transient error clears.
+	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
+		t.Fatalf("second refresh capacity = %d (ok=%v), want 760", got, ok)
+	}
+	if removeAttempts != 2 || c.currentSize != 400 || c.order.Len() != 1 {
+		t.Fatalf("cache after retried convergence = attempts:%d bytes:%d entries:%d, want 2/400/1", removeAttempts, c.currentSize, c.order.Len())
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 1 {
+		t.Fatalf("aggregate evictions after convergence = %v, want 1", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte) - beforeLabel; got != 1 {
+		t.Fatalf("labelled evictions after convergence = %v, want 1", got)
 	}
 }
 
@@ -516,6 +946,135 @@ func TestPutStreamOversizedObject(t *testing.T) {
 	}
 }
 
+func TestPutStreamRejectsNewEntryWhenRequiredEvictionFails(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		maxBytes   int64
+		maxEntries int
+		reason     cacheEvictionReason
+	}{
+		{name: "byte pressure", maxBytes: 100, maxEntries: 10, reason: cacheEvictionReasonByte},
+		{name: "entry pressure", maxBytes: 1000, maxEntries: 1, reason: cacheEvictionReasonEntry},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.maxBytes = tc.maxBytes
+			c.maxEntries = tc.maxEntries
+
+			incumbent := strings.Repeat("1", 64)
+			candidate := strings.Repeat("2", 64)
+			body := bytes.Repeat([]byte("x"), 60)
+			if _, err := c.PutStream(incumbent, bytes.NewReader(body)); err != nil {
+				t.Fatalf("seed PutStream: %v", err)
+			}
+
+			removeErr := errors.New("forced committed-file removal failure")
+			incumbentPath := filepath.Join(c.dir, incumbent)
+			c.removeFile = func(path string) error {
+				if path == incumbentPath {
+					return removeErr
+				}
+				return os.Remove(path)
+			}
+			beforeAggregate := counterValue(t, cacheEvictionsTotal)
+			beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, tc.reason)
+
+			if _, err := c.PutStream(candidate, bytes.NewReader(body)); err == nil {
+				t.Fatal("PutStream admitted a new entry after required eviction failed")
+			}
+			if !c.Has(incumbent) || c.Has(candidate) {
+				t.Fatalf("index membership incumbent/candidate = %t/%t, want true/false", c.Has(incumbent), c.Has(candidate))
+			}
+			if c.currentSize != int64(len(body)) || c.order.Len() != 1 {
+				t.Fatalf("cache accounting after rejected admission = %d bytes/%d entries, want %d/1", c.currentSize, c.order.Len(), len(body))
+			}
+			got, err := os.ReadFile(incumbentPath)
+			if err != nil || !bytes.Equal(got, body) {
+				t.Fatalf("incumbent body after rejected admission = %q, %v", got, err)
+			}
+			if _, err := os.Stat(filepath.Join(c.dir, candidate)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("candidate committed after rejected admission: %v", err)
+			}
+			if tmpDirEntries(t, c) != 0 {
+				t.Fatal("rejected admission leaked a temporary file")
+			}
+			items, bits, ok := c.SummarySnapshot()
+			if !ok || items != 1 {
+				t.Fatalf("summary after rejected admission = ok:%t items:%d, want true/1", ok, items)
+			}
+			summary := &cacheSummary{MBits: summaryBloomBits, Hashes: summaryBloomHashes, Bits: bits}
+			if !summary.Contains(incumbent) {
+				t.Fatal("rejected admission removed incumbent from the Bloom summary")
+			}
+			if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+				t.Fatalf("aggregate evictions after failed removal = %v, want 0", got)
+			}
+			if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, tc.reason) - beforeLabel; got != 0 {
+				t.Fatalf("labelled evictions after failed removal = %v, want 0", got)
+			}
+		})
+	}
+}
+
+func TestPutStreamPreservesOldBodyWhenReplacementEvictionFails(t *testing.T) {
+	c, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.maxBytes = 100
+	replacementKey := strings.Repeat("3", 64)
+	victimKey := strings.Repeat("4", 64)
+	oldBody := bytes.Repeat([]byte("o"), 20)
+	victimBody := bytes.Repeat([]byte("v"), 60)
+	if _, err := c.PutStream(replacementKey, bytes.NewReader(oldBody)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.PutStream(victimKey, bytes.NewReader(victimBody)); err != nil {
+		t.Fatal(err)
+	}
+
+	victimPath := filepath.Join(c.dir, victimKey)
+	removeErr := errors.New("forced replacement-victim removal failure")
+	c.removeFile = func(path string) error {
+		if path == victimPath {
+			return removeErr
+		}
+		return os.Remove(path)
+	}
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, cacheEvictionReasonByte)
+
+	if _, err := c.PutStream(replacementKey, bytes.NewReader(bytes.Repeat([]byte("n"), 60))); err == nil {
+		t.Fatal("PutStream committed an over-budget replacement after required eviction failed")
+	}
+	if c.currentSize != int64(len(oldBody)+len(victimBody)) || c.order.Len() != 2 {
+		t.Fatalf("cache accounting after rejected replacement = %d bytes/%d entries, want %d/2", c.currentSize, c.order.Len(), len(oldBody)+len(victimBody))
+	}
+	got, err := os.ReadFile(filepath.Join(c.dir, replacementKey))
+	if err != nil || !bytes.Equal(got, oldBody) {
+		t.Fatalf("replacement body after rejected overwrite = %q, %v; want old body", got, err)
+	}
+	if got, err := os.ReadFile(victimPath); err != nil || !bytes.Equal(got, victimBody) {
+		t.Fatalf("victim body after rejected overwrite = %q, %v", got, err)
+	}
+	if tmpDirEntries(t, c) != 0 {
+		t.Fatal("rejected replacement leaked a temporary file")
+	}
+	items, _, ok := c.SummarySnapshot()
+	if !ok || items != 2 {
+		t.Fatalf("summary after rejected replacement = ok:%t items:%d, want true/2", ok, items)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+		t.Fatalf("aggregate evictions after failed replacement removal = %v, want 0", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseRequest, cacheEvictionReasonByte) - beforeLabel; got != 0 {
+		t.Fatalf("labelled evictions after failed replacement removal = %v, want 0", got)
+	}
+}
+
 // TestHasAnswersFromIndexNotDisk: an untracked file sitting in the cache dir
 // is NOT "in the cache" — the index is the single source of truth for both
 // lookups and eviction/size accounting. (Pre-fix, Has stat'ed the disk and
@@ -745,7 +1304,9 @@ func TestScanExistingEnforcesByteAndEntryCeilings(t *testing.T) {
 		order:      list.New(),
 		index:      make(map[string]*list.Element),
 	}
-	c.scanExisting()
+	if _, err := c.scanExisting(); err != nil {
+		t.Fatal(err)
+	}
 	if c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries {
 		t.Fatalf("startup cache exceeds ceilings: bytes=%d/%d entries=%d/%d", c.currentSize, c.maxBytes, c.order.Len(), c.maxEntries)
 	}

--- a/cmd/cache-proxy/capacity.go
+++ b/cmd/cache-proxy/capacity.go
@@ -1,0 +1,148 @@
+package main
+
+import "math"
+
+const (
+	cacheDiskReservePercent int64 = 5
+	cacheEntryFillPercent   int64 = 90
+
+	// cacheMetadataEntryLimit is the hard metadata guardrail for a future
+	// derived entry limit. PR 1 intentionally continues to use the existing
+	// one-million-entry compatibility limit for admission.
+	cacheMetadataEntryLimit int64 = 10_000_000
+
+	maxSummaryMemoryBytes int64 = 1 << 30
+)
+
+// diskCapacity is the cache capacity derived from a single filesystem sample.
+// All values are bytes. ReclaimableBytes includes valid, committed cache files
+// because the cache can evict those files to make room again after a restart.
+type diskCapacity struct {
+	DiskTargetBytes  int64
+	ReserveBytes     int64
+	ReclaimableBytes int64
+	ByteCeiling      int64
+}
+
+// bloomCapacity describes the eventual dynamic Bloom-filter layout. The
+// current fixed layout remains in use until the wire-format migration.
+type bloomCapacity struct {
+	DesignEntries int64
+	BitCount      uint64
+	Hashes        uint8
+}
+
+// deriveDiskCapacity computes the byte ceiling without looking at the
+// filesystem. Inputs below zero are treated as zero and the percent is bounded
+// to [0, 100], so callers can use the result safely even when an input source
+// is malformed.
+func deriveDiskCapacity(totalBytes, freeBytes, ownedCacheBytes int64, maxPercent int) diskCapacity {
+	totalBytes = nonNegative(totalBytes)
+	freeBytes = nonNegative(freeBytes)
+	ownedCacheBytes = nonNegative(ownedCacheBytes)
+
+	percent := int64(maxPercent)
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	target := percentageOf(totalBytes, percent)
+	reserve := percentageOf(totalBytes, cacheDiskReservePercent)
+	reclaimable := saturatingAdd(freeBytes, ownedCacheBytes)
+	if reclaimable <= reserve {
+		reclaimable = 0
+	} else {
+		reclaimable -= reserve
+	}
+
+	return diskCapacity{
+		DiskTargetBytes:  target,
+		ReserveBytes:     reserve,
+		ReclaimableBytes: reclaimable,
+		ByteCeiling:      min(target, reclaimable),
+	}
+}
+
+// effectiveCacheEntryBytes is a conservative planning estimate. It is not a
+// strict per-entry allocation guarantee; the metadata guardrail remains the
+// hard safety bound for unexpectedly small files.
+func effectiveCacheEntryBytes(blockSizeBytes int64) int64 {
+	if blockSizeBytes <= 0 {
+		return 0
+	}
+	effective := percentageOf(blockSizeBytes, cacheEntryFillPercent)
+	if effective == 0 {
+		return 1
+	}
+	return effective
+}
+
+// deriveCacheEntryCeiling returns the future disk-derived metadata target,
+// capped by the hard guardrail. It does not change the active 1M admission cap
+// in this compatibility release.
+func deriveCacheEntryCeiling(cacheByteCeiling, blockSizeBytes int64) int64 {
+	effectiveEntryBytes := effectiveCacheEntryBytes(blockSizeBytes)
+	if cacheByteCeiling <= 0 || effectiveEntryBytes <= 0 {
+		return 0
+	}
+	return min(ceilDiv(cacheByteCeiling, effectiveEntryBytes), cacheMetadataEntryLimit)
+}
+
+// deriveBloomCapacity sizes the future dynamic local Bloom filter from stable
+// disk target capacity, not currently-free capacity, so temporary external
+// disk pressure does not resize the filter.
+func deriveBloomCapacity(diskTargetBytes, blockSizeBytes int64) bloomCapacity {
+	designEntries := deriveCacheEntryCeiling(diskTargetBytes, blockSizeBytes)
+	if designEntries == 0 {
+		return bloomCapacity{}
+	}
+	bits, hashes := bloomParams(int(designEntries))
+	return bloomCapacity{DesignEntries: designEntries, BitCount: bits, Hashes: hashes}
+}
+
+// deriveSummaryMemoryLimit is the fixed platform guardrail for future dynamic
+// summary admission: no more than one GiB or twenty percent of GOMEMLIMIT.
+func deriveSummaryMemoryLimit(goMemLimitBytes int64) int64 {
+	if goMemLimitBytes <= 0 {
+		return 0
+	}
+	return min(goMemLimitBytes/5, maxSummaryMemoryBytes)
+}
+
+func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func percentageOf(value, percent int64) int64 {
+	if value <= 0 || percent <= 0 {
+		return 0
+	}
+	if percent >= 100 {
+		return value
+	}
+	return value/100*percent + value%100*percent/100
+}
+
+func saturatingAdd(left, right int64) int64 {
+	if left > math.MaxInt64-right {
+		return math.MaxInt64
+	}
+	return left + right
+}
+
+func ceilDiv(numerator, denominator int64) int64 {
+	if numerator <= 0 || denominator <= 0 {
+		return 0
+	}
+	quotient := numerator / denominator
+	if numerator%denominator != 0 {
+		quotient++
+	}
+	return quotient
+}

--- a/cmd/cache-proxy/capacity_test.go
+++ b/cmd/cache-proxy/capacity_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDeriveDiskCapacityAccountsForOwnedCacheBytes(t *testing.T) {
+	capacity := deriveDiskCapacity(1000, 200, 800, 80)
+	if capacity.DiskTargetBytes != 800 {
+		t.Fatalf("disk target = %d, want 800", capacity.DiskTargetBytes)
+	}
+	if capacity.ReserveBytes != 50 {
+		t.Fatalf("reserve = %d, want 50", capacity.ReserveBytes)
+	}
+	if capacity.ReclaimableBytes != 950 {
+		t.Fatalf("reclaimable = %d, want 950", capacity.ReclaimableBytes)
+	}
+	if capacity.ByteCeiling != 800 {
+		t.Fatalf("byte ceiling = %d, want 800; committed cache bytes must remain reclaimable after restart", capacity.ByteCeiling)
+	}
+}
+
+func TestDeriveDiskCapacityRespectsReserveAndInvalidInputs(t *testing.T) {
+	cases := []struct {
+		name                          string
+		total, free, owned            int64
+		percent                       int
+		wantTarget, wantReserve, want int64
+	}{
+		{name: "external use reduces ceiling", total: 1000, free: 10, owned: 800, percent: 80, wantTarget: 800, wantReserve: 50, want: 760},
+		{name: "reserve consumes all reclaimable space", total: 1000, free: 20, owned: 20, percent: 80, wantTarget: 800, wantReserve: 50, want: 0},
+		{name: "invalid inputs", total: -1, free: 20, owned: 20, percent: 80, wantTarget: 0, wantReserve: 0, want: 0},
+		{name: "percent is bounded", total: 1000, free: 1000, owned: 0, percent: 101, wantTarget: 1000, wantReserve: 50, want: 950},
+		{name: "negative percent", total: 1000, free: 1000, owned: 0, percent: -1, wantTarget: 0, wantReserve: 50, want: 0},
+		{name: "addition does not overflow", total: math.MaxInt64, free: math.MaxInt64, owned: math.MaxInt64, percent: 80, wantTarget: 7_378_697_629_483_820_645, wantReserve: math.MaxInt64 / 100 * 5, want: 7_378_697_629_483_820_645},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveDiskCapacity(tt.total, tt.free, tt.owned, tt.percent)
+			if got.DiskTargetBytes != tt.wantTarget || got.ReserveBytes != tt.wantReserve || got.ByteCeiling != tt.want {
+				t.Fatalf("deriveDiskCapacity(%d, %d, %d, %d) = %+v, want target/reserve/ceiling %d/%d/%d", tt.total, tt.free, tt.owned, tt.percent, got, tt.wantTarget, tt.wantReserve, tt.want)
+			}
+		})
+	}
+}
+
+func TestDerivedEntryAndBloomCapacity(t *testing.T) {
+	const oneMiB = 1 << 20
+	cases := []struct {
+		name        string
+		cacheBytes  int64
+		wantEntries int64
+	}{
+		{name: "2.07 TiB", cacheBytes: 2_275_989_069_496, wantEntries: 2_411_726},
+		{name: "2.76 TiB", cacheBytes: 3_034_652_092_662, wantEntries: 3_215_635},
+		{name: "4.15 TiB", cacheBytes: 4_562_973_255_270, wantEntries: 4_835_103},
+		{name: "8.29 TiB", cacheBytes: 9_114_951_394_263, wantEntries: 9_658_555},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveCacheEntryCeiling(tt.cacheBytes, oneMiB); got != tt.wantEntries {
+				t.Fatalf("entry ceiling = %d, want %d", got, tt.wantEntries)
+			}
+			bloom := deriveBloomCapacity(tt.cacheBytes, oneMiB)
+			if bloom.DesignEntries != tt.wantEntries || bloom.BitCount == 0 || bloom.Hashes == 0 {
+				t.Fatalf("bloom capacity = %+v, want design entries %d and non-zero layout", bloom, tt.wantEntries)
+			}
+		})
+	}
+}
+
+func TestDerivedEntryAndBloomCapacityBoundaries(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		blockSize          int64
+		wantEffectiveBytes int64
+	}{
+		{name: "1 MiB blocks", blockSize: 1 << 20, wantEffectiveBytes: 943718},
+		{name: "8 MiB blocks", blockSize: 8 << 20, wantEffectiveBytes: 7549747},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveCacheEntryBytes(tt.blockSize); got != tt.wantEffectiveBytes {
+				t.Fatalf("effective entry bytes = %d, want %d", got, tt.wantEffectiveBytes)
+			}
+			if got := deriveCacheEntryCeiling(2*tt.wantEffectiveBytes, tt.blockSize); got != 2 {
+				t.Fatalf("entry ceiling = %d, want 2", got)
+			}
+			bloom := deriveBloomCapacity(2*tt.wantEffectiveBytes, tt.blockSize)
+			if bloom.DesignEntries != 2 || bloom.BitCount == 0 || bloom.Hashes == 0 {
+				t.Fatalf("bloom capacity = %+v, want design entries 2 and non-zero layout", bloom)
+			}
+		})
+	}
+
+	// A deliberately small input makes the ceil behavior obvious: a ten-byte
+	// ceiling needs two entries when a ten-byte block has nine effective bytes.
+	if got := deriveCacheEntryCeiling(10, 10); got != 2 {
+		t.Fatalf("small entry ceiling rounds up to %d, want 2", got)
+	}
+	if got := deriveCacheEntryCeiling(math.MaxInt64, 1<<20); got != cacheMetadataEntryLimit {
+		t.Fatalf("entry ceiling = %d, want metadata guardrail %d", got, cacheMetadataEntryLimit)
+	}
+	if got := deriveCacheEntryCeiling(100, 0); got != 0 {
+		t.Fatalf("entry ceiling with invalid block size = %d, want 0", got)
+	}
+
+	bloom := deriveBloomCapacity(80*(1<<20), 1<<20)
+	if bloom.DesignEntries <= 0 || bloom.DesignEntries > cacheMetadataEntryLimit || bloom.BitCount == 0 || bloom.Hashes == 0 {
+		t.Fatalf("invalid bloom capacity: %+v", bloom)
+	}
+}
+
+func TestDerivedSummaryMemoryLimit(t *testing.T) {
+	cases := []struct {
+		goMemLimit int64
+		want       int64
+	}{
+		{goMemLimit: 0, want: 0},
+		{goMemLimit: 5 << 30, want: 1 << 30},
+		{goMemLimit: 2 << 30, want: 429496729},
+		{goMemLimit: math.MaxInt64, want: 1 << 30},
+	}
+	for _, tt := range cases {
+		if got := deriveSummaryMemoryLimit(tt.goMemLimit); got != tt.want {
+			t.Errorf("deriveSummaryMemoryLimit(%d) = %d, want %d", tt.goMemLimit, got, tt.want)
+		}
+	}
+}

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -178,6 +178,7 @@ func main() {
 	store, err := NewDiskCache(cacheDir, maxPercent, DiskCacheOptions{
 		IncrementalSummary: lookupMode == peerLookupSummary && peerService != "",
 		MaxEntries:         maxEntries,
+		BlockSizeBytes:     blockSize,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize cache store.", "error", err)

--- a/docs/design/cache-proxy-pulled-summary-lookup.md
+++ b/docs/design/cache-proxy-pulled-summary-lookup.md
@@ -26,8 +26,8 @@ origin fills. Summaries contain only opaque cache-locator membership hints.
 | Setting | Default | Bound |
 | --- | --- | --- |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` or `summary`; unknown values fail startup. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Strict maximum tracked entries after each final commit. |
-| `CACHE_MAX_PERCENT` | `80` | Target for tracked cache bytes; one entry larger than the target is retained. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Configured legacy admission limit and strict maximum tracked entries after each final commit. |
+| `CACHE_MAX_PERCENT` | `80` | Percentage-of-total-disk target for committed cache bytes. The active capacity also accounts for reclaimable cache-owned files while retaining a 5%-of-total-disk reserve. |
 | `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Local counting Bloom, snapshot and pull reserve, and retained remote Bloom bits. |
 | `CACHE_PEER_MAX_PROBES_PER_REQUEST` | `5` | Maximum summary-mode `/cache/has` confirmations per client request, shared across block misses. `CACHE_PEER_MAX_PROBES` is a deprecated alias. |
 | `CACHE_MAX_CONCURRENT_PEER_PROBES` | `64` | Pod-wide, non-blocking cap on active confirmation HTTP requests and sockets. `CACHE_MAX_PEER_PROBES_IN_FLIGHT` is a deprecated alias. |
@@ -36,10 +36,42 @@ Body copies remain concurrent: each fill streams into a temporary file without
 holding the cache-index lock. The short final commit is serialized across the
 rename, LRU eviction, exact-index and byte accounting, and counting-Bloom
 update. A completed commit therefore cannot exceed `CACHE_MAX_ENTRIES`.
-Tracked bytes are evicted to the current disk target before the commit returns,
-except that a single entry larger than the target is retained rather than
-silently discarded. Concurrent temporary files consume real disk but are not
-yet tracked cache entries.
+Tracked bytes are evicted to the current cache byte capacity before the commit
+returns, except that a single entry larger than the capacity is retained rather
+than silently discarded. Concurrent temporary files consume real disk but are
+not yet tracked cache entries.
+
+### Disk capacity and startup ownership
+
+The cache derives its active byte capacity from each filesystem sample:
+
+```text
+diskTarget = CACHE_MAX_PERCENT / 100 * totalDiskBytes
+reserve = 5% * totalDiskBytes
+reclaimable = max(0, freeBytes + committedCacheBytes - reserve)
+cacheCapacity = min(diskTarget, reclaimable)
+```
+
+`committedCacheBytes` contains only regular files whose names are valid cache
+keys. These files are cache-owned and reclaimable through eviction, so a
+restart does not mistake a full cache for external disk pressure. Interrupted
+temporary files are removed before the startup scan. Invalid or unrelated
+root-directory entries remain on disk and count only through reduced free
+space.
+
+Startup scans existing entries before applying byte capacity, retains the
+newest entries within the configured legacy entry limit, and then evicts
+least-recently-used entries until both limits are satisfied. If temporary-file
+cleanup, filesystem sampling, directory scanning, entry inspection, or
+required startup eviction fails, initialization fails and the proxy does not
+begin serving with an unknown or unenforceable disk budget.
+
+Capacity is refreshed every minute. A lower ceiling is applied immediately and
+least-recently-used entries are evicted as needed to restore the reserve. An
+increase requires two consecutive healthy samples before it is applied, which
+prevents short-lived external disk usage from flapping the ceiling. Runtime
+deletion failures leave the entry indexed, are not counted as successful
+evictions, and are retried during later over-limit refreshes.
 
 The process-level backstop remains the pod memory limit and Go memory policy.
 The settings above bound the largest cache-proxy-owned contributors, but do not

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -238,6 +238,15 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_hits_total` | Counter | None | Worker-facing cacheable requests served entirely from data already present on local NVMe. Peer API reads and requests that first fetch any block from a peer are excluded. |
 | `cache_proxy_misses_total` | Counter | None | Worker-facing cacheable requests that require a peer or origin fill before they can be served. |
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
+| `cache_proxy_cache_entries` / `cache_proxy_cache_entry_limit` | Gauge | None | Current exact-index entries and the configured legacy admission limit (`CACHE_MAX_ENTRIES`, default 1,000,000). |
+| `cache_proxy_cache_owned_bytes` / `cache_proxy_cache_capacity_bytes` | Gauge | None | Bytes in committed cache entries and the current capacity ceiling. Committed bytes are reclaimable in capacity calculation after restart. |
+| `cache_proxy_cache_disk_target_bytes` / `cache_proxy_cache_disk_reserve_bytes` | Gauge | None | The configured percentage-of-disk target and the fixed 5%-of-total-disk reserve. |
+| `cache_proxy_cache_entry_limit_reason` | Gauge | `reason` | Future derived-entry bottleneck. Exactly one `reason` (`disk` or `metadata`) is 1; this anticipates the later derived-entry rollout without replacing the configured legacy admission limit. |
+| `cache_proxy_cache_startup_scan_duration_seconds` | Histogram | None | Cache directory startup-scan duration. |
+| `cache_proxy_cache_startup_scan_files_inspected_total` / `cache_proxy_cache_startup_invalid_files_total` | Counter | None | Root-directory entries scanned and entries excluded from committed cache ownership because they are invalid or unrelated. |
+| `cache_proxy_cache_temporary_files_removed_total` | Counter | None | Interrupted temporary files removed from `.tmp` on startup. They are never counted as cache evictions. |
+| `cache_proxy_evictions_total` | Counter | None | Aggregate successful removal of committed cache entries under entry or byte pressure. |
+| `cache_proxy_evictions_by_phase_reason_total` | Counter | `phase`, `reason` | The same evictions by bounded `phase` (`startup`, `background`, or `request`) and pressure `reason` (`entry` or `byte`). Failed or already-absent files are not reported as successful evictions. |
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |
 | `cache_proxy_peer_hits_total` | Counter | None | Successful peer body transfers. A block-mode request can record up to two transfers for one logical lookup. |
 | `cache_proxy_peer_probes_total` | Counter | `outcome` | Physical `/cache/has` attempts only. In summary mode these are bounded confirmations of Bloom-positive or uncovered peers, never fleet-wide fanout. The per-request maximum is `CACHE_PEER_MAX_PROBES_PER_REQUEST`. |


### PR DESCRIPTION
## Summary
- derive disk, entry, Bloom, and summary capacity from filesystem and block-size inputs
- treat committed cache files as reclaimable ownership across restarts while retaining the 5% disk reserve
- centralize pressure-driven deletion, add bounded eviction/startup/capacity metrics, and retry failed background convergence
- preserve the configured legacy entry ceiling, defaulting to 1,000,000, for this compatibility release
- document startup, recovery, and failure behavior

## Test plan
- just test-cache-proxy
- go test -race ./cmd/cache-proxy -count=1
- just lint
- just ci