### PR TITLE
feat(cache-proxy): add durable recency and bounded startup scan

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -10,7 +10,7 @@ available, and forwards cache misses to origin object storage.
 | --- | --- | --- |
 | `CACHE_DIR` | `/cache` | Local disk cache directory. |
 | `CACHE_MAX_PERCENT` | `80` | Target for committed cache bytes. The proxy retains a 5%-of-total-disk reserve and accounts for its own committed files as reclaimable, so a restart of an 80%-full cache does not mistake the cache itself for external disk use. Capacity is refreshed every minute; reductions apply immediately and recovery requires two consecutive healthy samples. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Strict maximum tracked LRU entries after each serialized final commit. Bounds local cache-index memory. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Soft admission and convergence target for tracked LRU entries. Startup loads inspectable committed entries up to the independent 10,000,000-entry hard safety guardrail; values above that guardrail are clamped. |
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing fleet-wide `/cache/has` behavior. `summary` pulls Bloom-filter hints and uses them to eliminate definite-negative peers before bounded `/cache/has` confirmation; any other value causes startup to fail. |
@@ -28,9 +28,15 @@ available, and forwards cache misses to origin object storage.
 
 Cache bodies stream concurrently into temporary files. Only the short final
 rename plus exact-index, LRU, byte-count, and counting-Bloom update is serialized.
-That commit evicts before returning, so completed commits cannot exceed
-`CACHE_MAX_ENTRIES`, and tracked bytes do not exceed the current cache byte
-capacity unless a single retained entry is itself larger than that capacity.
+At or above the soft entry target, a new-key commit performs one LRU swap and
+therefore cannot increase the tracked entry count. Byte capacity remains a
+strict request-path bound: a commit removes enough older entries to preserve
+the filesystem reserve. The existing compatibility exception retains a single
+object that is itself larger than the byte ceiling after draining other
+entries. A single background worker converges any restart or
+capacity overage at no more than 1,000 successful deletions per second.
+Replacements do not add entries, though a larger replacement can evict older
+entries to stay within the byte ceiling.
 Concurrent temporary files consume real disk but are not yet tracked cache
 entries.
 
@@ -50,20 +56,52 @@ to `committedCacheBytes`. Interrupted files in `.tmp` are removed during
 startup and are never cached or counted as evictions. Invalid or unrelated
 root-directory entries are left in place and remain external disk usage.
 
-When another writer consumes local disk, the cache lowers its capacity and
-evicts least-recently-used committed entries as needed to preserve the reserve.
+When another writer consumes local disk, the cache lowers its capacity and a
+rate-limited worker evicts least-recently-used committed entries to preserve
+the reserve.
 When that pressure disappears, it expands only after two consecutive refreshes
 confirm recovery; no deleted entries are recreated automatically. If the proxy
-cannot inspect the filesystem or prune an over-limit committed entry at startup,
-it exits rather than serving with an unknown or unenforceable disk budget. Once
-running, a failed pressure-driven deletion leaves the entry indexed and is
-logged, then is retried on later refreshes while the cache remains over its
-limit. Failed and already-absent deletions are never reported as evictions.
+cannot enumerate the cache directory completely at startup, it exits rather
+than serving from a partial index. An individual valid-looking file whose
+metadata cannot be inspected is preserved, excluded from cache ownership, and
+treated conservatively as external disk usage. Once running, a failed
+pressure-driven deletion leaves the entry indexed and is logged, then is
+retried with backoff while the cache remains over its limit. Failed and
+already-absent deletions are never reported as evictions.
 
-This compatibility release continues to use the configured
-`CACHE_MAX_ENTRIES` as the active admission ceiling; its default is 1,000,000.
-The derived disk/entry/Bloom sizing calculations prepare the later
-derived-entry rollout but do not replace that configured limit.
+This compatibility release continues to use configured `CACHE_MAX_ENTRIES`
+(default 1,000,000) as the soft target. It is no longer a startup survivor
+limit: a restart loads every inspectable entry up to the fixed 10,000,000-entry
+hard metadata guardrail, then converges gradually. Only an exceptional cache
+above the hard guardrail is pruned during startup. The scanner enumerates in
+1,024-entry chunks, selects the newest hard-limit set with bounded memory, and
+spools non-survivors under `.tmp`; it does not remove a committed file until a
+complete successful enumeration. Hard-guardrail removals are sequential,
+cancellation-aware, and use the same metered eviction path as runtime pressure.
+An unexpected hard-prune unlink failure aborts startup; an already-absent race
+is benign and is not counted as an eviction. Persisted coarse read recency,
+with file write time as the fallback, determines
+the survivor order. Equal timestamps use the opaque cache key as a deterministic
+tie-breaker.
+
+## Durable restart recency
+
+Every successful local body read and peer access updates the exact in-memory
+LRU synchronously. At most once per minute per resident key, the proxy also
+queues the opaque 64-hex cache key and coarse timestamp for an asynchronous
+mtime update. The bounded queue holds 65,536 waiting keys, one worker performs
+filesystem metadata writes, and repeated touches of the same key coalesce. A
+full queue or metadata failure affects only restart survivor accuracy; request
+handlers never wait for it and cached bodies remain usable. No source URL,
+query string, object path, or organization identifier is persisted.
+
+On graceful shutdown the HTTP servers stop accepting work first, then accepted
+recency updates drain within the shared 10-second shutdown deadline. Once cache
+shutdown begins, new cache mutations are rejected while existing bodies remain
+readable, preventing a commit from racing the closed recency writer. A startup
+SIGTERM cancels directory enumeration or hard pruning promptly. Deploy this
+recency-writing release for a representative access window before enabling a
+later rollout that can grow caches beyond the compatibility soft target.
 
 ## Cluster-wide fetch dedup
 

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -187,11 +188,15 @@ type DiskCache struct {
 	recency         *recencyWriter
 	recencyNow      func() time.Time
 	recencyInterval time.Duration
+	// commitMu linearizes the short final rename/accounting/recency commit with
+	// shutdown without coupling lifecycle progress to a potentially blocking
+	// pressure-driven unlink under mu.
+	commitMu sync.Mutex
 
 	convergenceCancel context.CancelFunc
 	convergenceDone   chan struct{}
 	convergenceWake   chan struct{}
-	closing           bool
+	closing           atomic.Bool
 }
 
 const defaultCacheMaxEntries = 1_000_000
@@ -226,6 +231,7 @@ type cacheEntry struct {
 	size                 int64
 	lastAccess           time.Time
 	lastPersistedRecency time.Time
+	evictionInFlight     bool
 }
 
 // NewDiskCache creates a cache backed by the given directory.
@@ -353,16 +359,19 @@ type DiskCacheOptions struct {
 // Close stops background convergence and drains accepted durable-recency work
 // until ctx expires. It is safe to call more than once.
 func (c *DiskCache) Close(ctx context.Context) error {
+	c.closing.Store(true)
 	if c.convergenceCancel != nil {
 		c.convergenceCancel()
 	}
-	c.mu.Lock()
-	c.closing = true
+	// A commit that already passed its closing check publishes its recency intent
+	// before writer admission closes. Eviction syscalls never hold this gate, so
+	// shutdown is not trapped behind a stalled unlink.
+	c.commitMu.Lock()
 	var recencyDone <-chan struct{}
 	if c.recency != nil {
 		recencyDone = c.recency.beginClose()
 	}
-	c.mu.Unlock()
+	c.commitMu.Unlock()
 	if c.convergenceDone != nil {
 		select {
 		case <-c.convergenceDone:
@@ -569,39 +578,36 @@ func removeTemporaryTreeWith(ctx context.Context, path string, openDir openCache
 		return 1, nil
 	}
 
-	dir, err := openDir(path)
-	if err != nil {
-		return 0, err
-	}
 	removed := 0
 	for {
 		if err := ctx.Err(); err != nil {
-			_ = dir.Close()
+			return 0, err
+		}
+		dir, err := openDir(path)
+		if err != nil {
 			return 0, err
 		}
 		entries, readErr := dir.ReadDir(startupScanChunkSize)
+		closeErr := dir.Close()
 		if err := ctx.Err(); err != nil {
-			_ = dir.Close()
 			return 0, err
+		}
+		if closeErr != nil {
+			return 0, closeErr
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return 0, readErr
+		}
+		if len(entries) == 0 {
+			break
 		}
 		for _, entry := range entries {
 			count, err := removeTemporaryTreeWith(ctx, filepath.Join(path, entry.Name()), openDir)
 			if err != nil {
-				_ = dir.Close()
 				return 0, err
 			}
 			removed += count
 		}
-		if errors.Is(readErr, io.EOF) {
-			break
-		}
-		if readErr != nil {
-			_ = dir.Close()
-			return 0, readErr
-		}
-	}
-	if err := dir.Close(); err != nil {
-		return 0, err
 	}
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -651,10 +657,7 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	if !IsValidCacheKey(key) {
 		return 0, fmt.Errorf("invalid cache key")
 	}
-	c.mu.Lock()
-	closing := c.closing
-	c.mu.Unlock()
-	if closing {
+	if c.closing.Load() {
 		return 0, errors.New("cache is closed for writes")
 	}
 	tmp, err := os.CreateTemp(filepath.Join(c.dir, tmpSubdir), key+"-*")
@@ -682,7 +685,7 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	// commit. Streaming happened above without this lock; only the short rename
 	// syscall is serialized so eviction cannot delete the replacement in between.
 	c.mu.Lock()
-	if c.closing {
+	if c.closing.Load() {
 		c.mu.Unlock()
 		_ = os.Remove(tmpPath)
 		return 0, errors.New("cache is closed for writes")
@@ -701,7 +704,15 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 			return 0, errors.New("admit cache entry: required eviction failed")
 		}
 	}
+	c.commitMu.Lock()
+	if c.closing.Load() {
+		c.commitMu.Unlock()
+		c.mu.Unlock()
+		_ = os.Remove(tmpPath)
+		return 0, errors.New("cache is closed for writes")
+	}
 	if err := renameFile(tmpPath, path); err != nil {
+		c.commitMu.Unlock()
 		c.mu.Unlock()
 		_ = os.Remove(tmpPath)
 		return 0, fmt.Errorf("commit cache entry: %w", err)
@@ -722,6 +733,7 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	} else {
 		c.addLocked(key, size)
 	}
+	c.commitMu.Unlock()
 	c.mu.Unlock()
 
 	return size, nil
@@ -848,23 +860,37 @@ func (c *DiskCache) addLocked(key string, size int64) {
 // LRU entry by construction: adds and touches always move entries to the
 // back, and scanExisting seeds the list in recency order.
 func (c *DiskCache) evictOldest(phase cacheEvictionPhase, reason cacheEvictionReason) error {
-	front := c.order.Front()
+	front := c.oldestEvictableLocked()
 	if front == nil {
-		return nil
+		return errors.New("no cache entry available for eviction")
 	}
 	oldest := front.Value.(*cacheEntry)
 	path := filepath.Join(c.dir, oldest.key)
 	if _, err := c.removeCommittedFile(path, phase, reason); err != nil {
 		return err
 	}
-	c.currentSize -= oldest.size
-	c.order.Remove(front)
-	delete(c.index, oldest.key)
+	c.forgetEntryLocked(front)
+	return nil
+}
+
+func (c *DiskCache) oldestEvictableLocked() *list.Element {
+	for candidate := c.order.Front(); candidate != nil; candidate = candidate.Next() {
+		if !candidate.Value.(*cacheEntry).evictionInFlight {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func (c *DiskCache) forgetEntryLocked(element *list.Element) {
+	entry := element.Value.(*cacheEntry)
+	c.currentSize -= entry.size
+	c.order.Remove(element)
+	delete(c.index, entry.key)
 	if c.summary != nil {
-		c.summary.Remove(oldest.key)
+		c.summary.Remove(entry.key)
 	}
 	c.updateStateMetricsLocked()
-	return nil
 }
 
 func (c *DiskCache) makeRoomForNewEntryLocked(size int64, phase cacheEvictionPhase) bool {
@@ -891,6 +917,9 @@ func (c *DiskCache) makeRoomForNewEntryLocked(size int64, phase cacheEvictionPha
 
 func (c *DiskCache) makeRoomForReplacementLocked(replacement *list.Element, size int64, phase cacheEvictionPhase) bool {
 	entry := replacement.Value.(*cacheEntry)
+	if entry.evictionInFlight {
+		return false
+	}
 	// Protect the entry being replaced from eviction. If reservation or rename
 	// fails, its old committed body and accounting remain usable.
 	c.order.MoveToBack(replacement)

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"container/heap"
 	"container/list"
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"sync"
 	"syscall"
 	"time"
@@ -61,6 +60,14 @@ var (
 	cacheEntryLimit = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cache_proxy_cache_entry_limit",
 		Help: "Active committed cache entry limit",
+	})
+	cacheHardEntryLimit = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_hard_entry_limit",
+		Help: "Non-configurable exact-index safety guardrail",
+	})
+	cacheExactIndexEstimatedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_exact_index_estimated_bytes",
+		Help: "Conservative estimated bytes occupied by exact-index metadata and keys",
 	})
 	cacheOwnedBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cache_proxy_cache_owned_bytes",
@@ -146,12 +153,13 @@ type DiskCache struct {
 	// loop (refreshCapacity) lowers it whenever FREE space shrinks so the
 	// cache can never grow into disk it doesn't own. currentSize is the sum
 	// of tracked entry sizes.
-	maxBytes    int64
-	maxEntries  int
-	currentSize int64
-	maxPercent  int
-	blockSize   int64
-	space       capacityProvider
+	maxBytes       int64
+	maxEntries     int
+	hardMaxEntries int
+	currentSize    int64
+	maxPercent     int
+	blockSize      int64
+	space          capacityProvider
 
 	// Consecutive above-current samples are required before raising capacity.
 	// Reductions apply immediately to restore the filesystem reserve.
@@ -173,13 +181,26 @@ type DiskCache struct {
 	// openScanDirectory is os.Open in production and lets constructor tests
 	// inject directory-open and mid-scan failures deterministically.
 	openScanDirectory openCacheDirectory
+
+	// Durable recency is optional for tests and always enabled by main. Exact
+	// LRU updates remain synchronous; only coarse mtime persistence is queued.
+	recency         *recencyWriter
+	recencyNow      func() time.Time
+	recencyInterval time.Duration
+
+	convergenceCancel context.CancelFunc
+	convergenceDone   chan struct{}
+	convergenceWake   chan struct{}
+	closing           bool
 }
 
 const defaultCacheMaxEntries = 1_000_000
 
 const (
-	defaultCacheBlockSizeBytes      int64 = 8 << 20
-	capacityRecoveryRequiredSamples       = 2
+	defaultCacheBlockSizeBytes       int64 = 8 << 20
+	capacityRecoveryRequiredSamples        = 2
+	defaultConvergenceInterval             = time.Millisecond
+	estimatedExactIndexBytesPerEntry       = 256
 )
 
 type diskSpace struct {
@@ -201,23 +222,10 @@ func openDirectory(path string) (cacheDirectory, error) {
 }
 
 type cacheEntry struct {
-	key        string
-	size       int64
-	lastAccess time.Time
-}
-
-type oldestEntries []cacheEntry
-
-func (h oldestEntries) Len() int           { return len(h) }
-func (h oldestEntries) Less(i, j int) bool { return h[i].lastAccess.Before(h[j].lastAccess) }
-func (h oldestEntries) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h *oldestEntries) Push(x any)        { *h = append(*h, x.(cacheEntry)) }
-func (h *oldestEntries) Pop() any {
-	old := *h
-	n := len(old)
-	item := old[n-1]
-	*h = old[:n-1]
-	return item
+	key                  string
+	size                 int64
+	lastAccess           time.Time
+	lastPersistedRecency time.Time
 }
 
 // NewDiskCache creates a cache backed by the given directory.
@@ -233,6 +241,7 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		// ceiling, so scans initially load without byte pruning.
 		maxBytes:          math.MaxInt64,
 		maxEntries:        defaultCacheMaxEntries,
+		hardMaxEntries:    int(cacheMetadataEntryLimit),
 		maxPercent:        maxPercent,
 		blockSize:         defaultCacheBlockSizeBytes,
 		space:             statfsDiskSpace,
@@ -241,29 +250,49 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		renameFile:        os.Rename,
 		removeFile:        os.Remove,
 		openScanDirectory: openDirectory,
+		recencyNow:        time.Now,
+		recencyInterval:   defaultRecencyGranularity,
 	}
+	var option DiskCacheOptions
 	if len(options) > 0 {
-		if options[0].MaxEntries > 0 {
-			dc.maxEntries = options[0].MaxEntries
+		option = options[0]
+		if option.MaxEntries > 0 {
+			dc.maxEntries = option.MaxEntries
 		}
-		if options[0].IncrementalSummary {
+		if option.IncrementalSummary {
 			dc.summary = newSummaryIndex()
 		}
-		if options[0].BlockSizeBytes > 0 {
-			dc.blockSize = options[0].BlockSizeBytes
+		if option.BlockSizeBytes > 0 {
+			dc.blockSize = option.BlockSizeBytes
 		}
-		if options[0].CapacityProvider != nil {
-			dc.space = options[0].CapacityProvider
+		if option.CapacityProvider != nil {
+			dc.space = option.CapacityProvider
 		}
-		if options[0].openScanDirectory != nil {
-			dc.openScanDirectory = options[0].openScanDirectory
+		if option.openScanDirectory != nil {
+			dc.openScanDirectory = option.openScanDirectory
 		}
-		if options[0].removeFile != nil {
-			dc.removeFile = options[0].removeFile
+		if option.removeFile != nil {
+			dc.removeFile = option.removeFile
+		}
+		if option.hardMaxEntries > 0 {
+			dc.hardMaxEntries = option.hardMaxEntries
+		}
+		if option.recencyNow != nil {
+			dc.recencyNow = option.recencyNow
+		}
+		if option.recencyInterval > 0 {
+			dc.recencyInterval = option.recencyInterval
 		}
 	}
+	if dc.maxEntries > dc.hardMaxEntries {
+		dc.maxEntries = dc.hardMaxEntries
+	}
 
-	removedTemporaryFiles, err := resetTemporaryDirectory(filepath.Join(dir, tmpSubdir))
+	startupContext := option.startupContext
+	if startupContext == nil {
+		startupContext = context.Background()
+	}
+	removedTemporaryFiles, err := resetTemporaryDirectory(startupContext, filepath.Join(dir, tmpSubdir))
 	if err != nil {
 		return nil, fmt.Errorf("reset cache temp dir: %w", err)
 	}
@@ -271,25 +300,25 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		cacheTemporaryFilesRemovedTotal.Add(float64(removedTemporaryFiles))
 	}
 
-	// Sample free space before the scan can apply the legacy entry ceiling.
-	// Together with the scan's owned-byte total, this is a consistent restart
-	// view: if the scan deletes entry-limit victims before statfs runs, adding
-	// their former bytes to the newer free sample would double count them.
+	// Complete enumeration and the exceptional hard-cap survivor pass before
+	// sampling free space. No soft-target deletion occurs during startup.
+	ownedBytes, err := dc.scanExistingContext(startupContext)
+	if err != nil {
+		return nil, fmt.Errorf("scan existing cache entries: %w", err)
+	}
 	startupSpace, err := dc.diskSpace()
 	if err != nil {
 		return nil, fmt.Errorf("statfs %s: %w", dir, err)
 	}
-
-	// Scan existing cache entries before capacity is derived. The scan's owned
-	// byte total includes every valid committed file, even ones later discarded
-	// by the legacy entry ceiling, so a restart never mistakes the cache itself
-	// for external disk pressure.
-	ownedBytes, err := dc.scanExisting()
-	if err != nil {
-		return nil, fmt.Errorf("scan existing cache entries: %w", err)
-	}
 	if err := dc.initializeCapacity(ownedBytes, startupSpace); err != nil {
 		return nil, fmt.Errorf("apply startup cache limits: %w", err)
+	}
+
+	if option.DurableRecency {
+		dc.recency = newRecencyWriter(dir, option.recencyQueueCapacity, option.recencyWorkerCount, option.recencyChtimes)
+	}
+	if option.convergencePermits != nil || option.BackgroundConvergence {
+		dc.startConvergence(startupContext, option.convergencePermits, option.convergenceInterval)
 	}
 
 	slog.Info("Cache initialized.",
@@ -302,12 +331,60 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 }
 
 type DiskCacheOptions struct {
-	IncrementalSummary bool
-	MaxEntries         int
-	BlockSizeBytes     int64
-	CapacityProvider   capacityProvider
-	openScanDirectory  openCacheDirectory
-	removeFile         func(string) error
+	IncrementalSummary    bool
+	DurableRecency        bool
+	BackgroundConvergence bool
+	MaxEntries            int
+	BlockSizeBytes        int64
+	CapacityProvider      capacityProvider
+	openScanDirectory     openCacheDirectory
+	removeFile            func(string) error
+	hardMaxEntries        int
+	startupContext        context.Context
+	recencyNow            func() time.Time
+	recencyChtimes        recencyPersistence
+	recencyInterval       time.Duration
+	recencyQueueCapacity  int
+	recencyWorkerCount    int
+	convergencePermits    <-chan struct{}
+	convergenceInterval   time.Duration
+}
+
+// Close stops background convergence and drains accepted durable-recency work
+// until ctx expires. It is safe to call more than once.
+func (c *DiskCache) Close(ctx context.Context) error {
+	if c.convergenceCancel != nil {
+		c.convergenceCancel()
+	}
+	c.mu.Lock()
+	c.closing = true
+	var recencyDone <-chan struct{}
+	if c.recency != nil {
+		recencyDone = c.recency.beginClose()
+	}
+	c.mu.Unlock()
+	if c.convergenceDone != nil {
+		select {
+		case <-c.convergenceDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if recencyDone != nil {
+		select {
+		case <-recencyDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (c *DiskCache) waitForRecencyIdle(ctx context.Context) error {
+	if c.recency == nil {
+		return nil
+	}
+	return c.recency.waitIdle(ctx)
 }
 
 // clampToFree remains a narrow compatibility helper for callers that have no
@@ -336,7 +413,7 @@ func (c *DiskCache) refreshCapacityStats(maxPercent int) (int64, int64, bool) {
 
 	c.mu.Lock()
 	capacity := deriveDiskCapacity(space.TotalBytes, space.FreeBytes, c.currentSize, maxPercent)
-	c.applyCapacityLocked(capacity, cacheEvictionPhaseBackground)
+	c.applyCapacityLocked(capacity)
 	max := c.maxBytes
 	c.mu.Unlock()
 	return space.TotalBytes, max, true
@@ -357,15 +434,11 @@ func (c *DiskCache) initializeCapacity(ownedBytes int64, space diskSpace) error 
 	c.recoveryCandidate = 0
 	c.recoverySamples = 0
 	c.updateCapacityMetricsLocked(capacity)
-	if err := c.evictToLimitsLocked(cacheEvictionPhaseStartup); err != nil {
-		c.updateStateMetricsLocked()
-		return err
-	}
 	c.updateStateMetricsLocked()
 	return nil
 }
 
-func (c *DiskCache) applyCapacityLocked(capacity diskCapacity, phase cacheEvictionPhase) {
+func (c *DiskCache) applyCapacityLocked(capacity diskCapacity) {
 	oldMax := c.maxBytes
 	newMax := capacity.ByteCeiling
 	switch {
@@ -393,13 +466,6 @@ func (c *DiskCache) applyCapacityLocked(capacity diskCapacity, phase cacheEvicti
 		c.recoveryCandidate = 0
 		c.recoverySamples = 0
 	}
-	// Background convergence remains best effort: a hard deletion failure is
-	// logged by removeCommittedFile and leaves the entry indexed rather than
-	// taking the running proxy down. Retry on every refresh while over either
-	// active limit, including when the derived byte ceiling is unchanged.
-	if c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries {
-		_ = c.evictToLimitsLocked(phase)
-	}
 	c.updateCapacityMetricsLocked(capacity)
 	c.updateStateMetricsLocked()
 }
@@ -426,6 +492,9 @@ func (c *DiskCache) updateStateMetricsLocked() {
 	cacheOwnedBytes.Set(float64(c.currentSize))
 	cacheEntries.Set(float64(c.order.Len()))
 	cacheEntryLimit.Set(float64(c.maxEntries))
+	cacheHardEntryLimit.Set(float64(c.hardMaxEntries))
+	cacheExactIndexEstimatedBytes.Set(float64(c.order.Len()) * estimatedExactIndexBytesPerEntry)
+	c.updateConvergenceMetricsLocked()
 }
 
 func (c *DiskCache) diskSpace() (diskSpace, error) {
@@ -457,25 +526,15 @@ func filesystemBytes(blocks, blockSize uint64) int64 {
 	return int64(blocks * blockSize)
 }
 
-func resetTemporaryDirectory(tmpDir string) (int, error) {
-	removed := 0
-	if _, err := os.Lstat(tmpDir); err == nil {
-		err = filepath.WalkDir(tmpDir, func(_ string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if !entry.IsDir() {
-				removed++
-			}
-			return nil
-		})
-		if err != nil {
-			return 0, err
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+func resetTemporaryDirectory(ctx context.Context, tmpDir string) (int, error) {
+	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	if err := os.RemoveAll(tmpDir); err != nil {
+	removed, err := removeTemporaryTree(ctx, tmpDir)
+	if err != nil {
+		return 0, err
+	}
+	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
 	if err := os.MkdirAll(tmpDir, 0750); err != nil {
@@ -484,103 +543,73 @@ func resetTemporaryDirectory(tmpDir string) (int, error) {
 	return removed, nil
 }
 
-func (c *DiskCache) scanExisting() (ownedBytes int64, scanErr error) {
-	started := time.Now()
-	defer func() { cacheStartupScanDuration.Observe(time.Since(started).Seconds()) }()
+// removeTemporaryTree is the cancellation-aware equivalent of RemoveAll for
+// the private staging directory. It never follows symlinks and checks the
+// startup context before each filesystem operation, so a large interrupted
+// fill tree cannot delay SIGTERM until the entire cleanup finishes.
+func removeTemporaryTree(ctx context.Context, path string) (int, error) {
+	return removeTemporaryTreeWith(ctx, path, openDirectory)
+}
 
-	openScanDirectory := c.openScanDirectory
-	if openScanDirectory == nil {
-		openScanDirectory = openDirectory
+func removeTemporaryTreeWith(ctx context.Context, path string, openDir openCacheDirectory) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
 	}
-	dir, err := openScanDirectory(c.dir)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
 	if err != nil {
-		return 0, fmt.Errorf("open cache directory %s: %w", c.dir, err)
+		return 0, err
 	}
-	defer func() {
-		if err := dir.Close(); err != nil && scanErr == nil {
-			scanErr = fmt.Errorf("close cache directory %s: %w", c.dir, err)
+	if !info.IsDir() {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return 0, err
 		}
-	}()
-	// Only count real, committed cache entries. Temporary files were removed
-	// before this scan; invalid and unrelated root entries stay on disk as
-	// external usage and never enter the exact index or owned-byte accounting.
-	// Do not reserve a million cacheEntry structs for an empty/new cache. The
-	// heap remains bounded by maxEntries but grows with actual disk contents.
-	found := make(oldestEntries, 0, min(c.maxEntries, 1024))
+		return 1, nil
+	}
+
+	dir, err := openDir(path)
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
 	for {
-		entries, readErr := dir.ReadDir(1024)
-		for _, e := range entries {
-			cacheStartupScanFilesInspectedTotal.Inc()
-			if e.Name() == tmpSubdir {
-				continue
-			}
-			if !IsValidCacheKey(e.Name()) {
-				cacheStartupInvalidFilesTotal.Inc()
-				continue
-			}
-			info, err := e.Info()
-			if err != nil {
-				return 0, fmt.Errorf("inspect cache entry %s: %w", filepath.Join(c.dir, e.Name()), err)
-			}
-			if !info.Mode().IsRegular() {
-				cacheStartupInvalidFilesTotal.Inc()
-				continue
-			}
-			entry := cacheEntry{key: e.Name(), size: info.Size(), lastAccess: info.ModTime()}
-			ownedBytes = saturatingAdd(ownedBytes, entry.size)
-			if found.Len() < c.maxEntries {
-				heap.Push(&found, entry)
-				continue
-			}
-			if !entry.lastAccess.After(found[0].lastAccess) {
-				path := filepath.Join(c.dir, entry.key)
-				if err := c.removeCommittedFile(path, cacheEvictionPhaseStartup, cacheEvictionReasonEntry); err != nil {
-					return 0, fmt.Errorf("prune startup cache entry %s: %w", path, err)
-				}
-				continue
-			}
-			dropped := heap.Pop(&found).(cacheEntry)
-			path := filepath.Join(c.dir, dropped.key)
-			if err := c.removeCommittedFile(path, cacheEvictionPhaseStartup, cacheEvictionReasonEntry); err != nil {
-				return 0, fmt.Errorf("prune startup cache entry %s: %w", path, err)
-			}
-			heap.Push(&found, entry)
+		if err := ctx.Err(); err != nil {
+			_ = dir.Close()
+			return 0, err
 		}
-		if readErr == io.EOF {
+		entries, readErr := dir.ReadDir(startupScanChunkSize)
+		if err := ctx.Err(); err != nil {
+			_ = dir.Close()
+			return 0, err
+		}
+		for _, entry := range entries {
+			count, err := removeTemporaryTreeWith(ctx, filepath.Join(path, entry.Name()), openDir)
+			if err != nil {
+				_ = dir.Close()
+				return 0, err
+			}
+			removed += count
+		}
+		if errors.Is(readErr, io.EOF) {
 			break
 		}
 		if readErr != nil {
-			return 0, fmt.Errorf("read cache directory %s: %w", c.dir, readErr)
+			_ = dir.Close()
+			return 0, readErr
 		}
 	}
-	// The access list must start in recency order (front = oldest) or the
-	// first evictions after a restart would remove arbitrary entries.
-	sort.Slice(found, func(i, j int) bool {
-		return found[i].lastAccess.Before(found[j].lastAccess)
-	})
-
-	c.mu.Lock()
-	for i := range found {
-		entry := found[i]
-		c.index[entry.key] = c.order.PushBack(&entry)
-		c.currentSize += entry.size
-		if c.summary != nil {
-			c.summary.Add(entry.key)
-		}
+	if err := dir.Close(); err != nil {
+		return 0, err
 	}
-	// Direct callers that construct a DiskCache by hand retain the historical
-	// scan behavior. NewDiskCache defers byte pruning until its owned-byte
-	// capacity calculation is complete.
-	if c.space == nil {
-		if err := c.evictToLimitsLocked(cacheEvictionPhaseStartup); err != nil {
-			c.updateStateMetricsLocked()
-			c.mu.Unlock()
-			return 0, fmt.Errorf("apply startup cache limits: %w", err)
-		}
+	if err := ctx.Err(); err != nil {
+		return 0, err
 	}
-	c.updateStateMetricsLocked()
-	c.mu.Unlock()
-	return ownedBytes, nil
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, err
+	}
+	return removed, nil
 }
 
 // SummarySnapshot returns an immutable bounded copy of the locally maintained
@@ -622,7 +651,12 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	if !IsValidCacheKey(key) {
 		return 0, fmt.Errorf("invalid cache key")
 	}
-
+	c.mu.Lock()
+	closing := c.closing
+	c.mu.Unlock()
+	if closing {
+		return 0, errors.New("cache is closed for writes")
+	}
 	tmp, err := os.CreateTemp(filepath.Join(c.dir, tmpSubdir), key+"-*")
 	if err != nil {
 		return 0, fmt.Errorf("create temp: %w", err)
@@ -648,6 +682,11 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 	// commit. Streaming happened above without this lock; only the short rename
 	// syscall is serialized so eviction cannot delete the replacement in between.
 	c.mu.Lock()
+	if c.closing {
+		c.mu.Unlock()
+		_ = os.Remove(tmpPath)
+		return 0, errors.New("cache is closed for writes")
+	}
 	el, replacing := c.index[key]
 	if replacing {
 		if !c.makeRoomForReplacementLocked(el, size, cacheEvictionPhaseRequest) {
@@ -675,8 +714,10 @@ func (c *DiskCache) PutStream(key string, r io.Reader) (int64, error) {
 		entry := el.Value.(*cacheEntry)
 		c.currentSize += size - entry.size
 		entry.size = size
-		entry.lastAccess = time.Now()
+		now := c.now()
+		entry.lastAccess = now
 		c.order.MoveToBack(el)
+		c.queueRecencyLocked(entry, now, true)
 		c.updateStateMetricsLocked()
 	} else {
 		c.addLocked(key, size)
@@ -729,8 +770,42 @@ func (c *DiskCache) touchLocked(key string) {
 	if !ok {
 		return
 	}
-	el.Value.(*cacheEntry).lastAccess = time.Now()
+	entry := el.Value.(*cacheEntry)
+	now := c.now()
+	entry.lastAccess = now
 	c.order.MoveToBack(el)
+	c.queueRecencyLocked(entry, now, false)
+}
+
+func (c *DiskCache) now() time.Time {
+	if c.recencyNow == nil {
+		return time.Now()
+	}
+	return c.recencyNow()
+}
+
+func (c *DiskCache) queueRecencyLocked(entry *cacheEntry, timestamp time.Time, force bool) {
+	if c.recency == nil {
+		return
+	}
+	interval := c.recencyInterval
+	if interval <= 0 {
+		interval = defaultRecencyGranularity
+	}
+	bucket := timestamp
+	if !force {
+		cacheRecencyTouchAttemptsTotal.Inc()
+		bucket = timestamp.Truncate(interval)
+	}
+	if !force && !bucket.After(entry.lastPersistedRecency) {
+		cacheRecencyTouchCoalescedTotal.Inc()
+		return
+	}
+	_ = c.recency.submit(entry.key, bucket)
+	// A dropped update intentionally degrades only this bucket's restart
+	// accuracy. Recording the attempt prevents a hot overflowed key from
+	// contending on the bounded writer for every hit; the next bucket retries.
+	entry.lastPersistedRecency = bucket
 }
 
 // dropLocked removes any accounting for key (used when an overwrite is about to
@@ -754,15 +829,18 @@ func (c *DiskCache) dropLocked(key string) {
 // Caller holds c.mu.
 func (c *DiskCache) addLocked(key string, size int64) {
 	c.dropLocked(key)
-	c.index[key] = c.order.PushBack(&cacheEntry{
+	now := c.now()
+	entry := &cacheEntry{
 		key:        key,
 		size:       size,
-		lastAccess: time.Now(),
-	})
+		lastAccess: now,
+	}
+	c.index[key] = c.order.PushBack(entry)
 	c.currentSize += size
 	if c.summary != nil {
 		c.summary.Add(key)
 	}
+	c.queueRecencyLocked(entry, now, true)
 	c.updateStateMetricsLocked()
 }
 
@@ -776,7 +854,7 @@ func (c *DiskCache) evictOldest(phase cacheEvictionPhase, reason cacheEvictionRe
 	}
 	oldest := front.Value.(*cacheEntry)
 	path := filepath.Join(c.dir, oldest.key)
-	if err := c.removeCommittedFile(path, phase, reason); err != nil {
+	if _, err := c.removeCommittedFile(path, phase, reason); err != nil {
 		return err
 	}
 	c.currentSize -= oldest.size
@@ -790,13 +868,21 @@ func (c *DiskCache) evictOldest(phase cacheEvictionPhase, reason cacheEvictionRe
 }
 
 func (c *DiskCache) makeRoomForNewEntryLocked(size int64, phase cacheEvictionPhase) bool {
-	for c.order.Len() >= c.maxEntries && c.order.Len() > 0 {
-		if c.evictOldest(phase, cacheEvictionReasonEntry) != nil {
+	if c.order.Len() == 0 {
+		return true
+	}
+	// Byte capacity protects the filesystem reserve and remains strict on the
+	// request path. In block mode this normally removes one equal-sized block;
+	// the loop also handles short tail blocks without admitting above capacity.
+	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
+		if c.evictOldest(phase, cacheEvictionReasonByte) != nil {
 			return false
 		}
 	}
-	for c.currentSize+size > c.maxBytes && c.order.Len() > 0 {
-		if c.evictOldest(phase, cacheEvictionReasonByte) != nil {
+	// Entry count is a soft convergence target. At or above it, perform only a
+	// net-neutral one-for-one swap rather than collapsing restart overage here.
+	if c.order.Len() >= c.maxEntries && c.order.Len() > 0 {
+		if c.evictOldest(phase, cacheEvictionReasonEntry) != nil {
 			return false
 		}
 	}
@@ -808,31 +894,17 @@ func (c *DiskCache) makeRoomForReplacementLocked(replacement *list.Element, size
 	// Protect the entry being replaced from eviction. If reservation or rename
 	// fails, its old committed body and accounting remain usable.
 	c.order.MoveToBack(replacement)
-	for c.order.Len() > c.maxEntries && c.order.Len() > 1 {
-		if c.evictOldest(phase, cacheEvictionReasonEntry) != nil {
-			return false
-		}
-	}
-	for c.currentSize-entry.size+size > c.maxBytes && c.order.Len() > 1 {
+	projectedSize := c.currentSize - entry.size + size
+	// A replacement is count-neutral. Only evict one unrelated LRU entry when
+	// the replacement itself would make byte pressure worse; the background
+	// worker handles any pre-existing overage at its bounded rate.
+	for projectedSize > c.maxBytes && c.order.Len() > 1 {
 		if c.evictOldest(phase, cacheEvictionReasonByte) != nil {
 			return false
 		}
+		projectedSize = c.currentSize - entry.size + size
 	}
 	return true
-}
-
-func (c *DiskCache) evictToLimitsLocked(phase cacheEvictionPhase) error {
-	for c.order.Len() > c.maxEntries && c.order.Len() > 0 {
-		if err := c.evictOldest(phase, cacheEvictionReasonEntry); err != nil {
-			return err
-		}
-	}
-	for c.currentSize > c.maxBytes && c.order.Len() > 0 {
-		if err := c.evictOldest(phase, cacheEvictionReasonByte); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // removeCommittedFile is the one filesystem deletion path for valid cache
@@ -840,7 +912,7 @@ func (c *DiskCache) evictToLimitsLocked(phase cacheEvictionPhase) error {
 // aggregate eviction counter and its bounded phase/reason breakdown. A file
 // already removed by an external actor is forgotten without claiming an
 // eviction; a hard unlink failure preserves its index accounting.
-func (c *DiskCache) removeCommittedFile(path string, phase cacheEvictionPhase, reason cacheEvictionReason) error {
+func (c *DiskCache) removeCommittedFile(path string, phase cacheEvictionPhase, reason cacheEvictionReason) (bool, error) {
 	removeFile := c.removeFile
 	if removeFile == nil {
 		removeFile = os.Remove
@@ -849,11 +921,11 @@ func (c *DiskCache) removeCommittedFile(path string, phase cacheEvictionPhase, r
 	if err == nil {
 		cacheEvictionsTotal.Inc()
 		cacheEvictionsByPhaseReasonTotal.WithLabelValues(string(phase), string(reason)).Inc()
-		return nil
+		return true, nil
 	}
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return false, nil
 	}
 	slog.Warn("Unable to evict committed cache file.", "path", path, "phase", phase, "reason", reason, "error", err)
-	return err
+	return false, err
 }

--- a/cmd/cache-proxy/cache_test.go
+++ b/cmd/cache-proxy/cache_test.go
@@ -247,7 +247,7 @@ func TestDiskCacheEntryLimitEvictsOldest(t *testing.T) {
 	}
 }
 
-func TestDiskCacheEntryLimitAppliesDuringStartupScan(t *testing.T) {
+func TestDiskCacheHardEntryLimitAppliesDuringStartupScan(t *testing.T) {
 	dir := t.TempDir()
 	entries := []struct {
 		key  string
@@ -266,7 +266,7 @@ func TestDiskCacheEntryLimitAppliesDuringStartupScan(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	c, err := NewDiskCache(dir, 100, DiskCacheOptions{MaxEntries: 2})
+	c, err := NewDiskCache(dir, 100, DiskCacheOptions{MaxEntries: 3, hardMaxEntries: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +389,7 @@ func TestNewDiskCacheFailsWhenStartupScanStopsBeforeDirectoryIsExhausted(t *test
 	}
 }
 
-func TestNewDiskCacheFailsWhenStartupPruneCannotRemoveVictim(t *testing.T) {
+func TestNewDiskCacheFailsWhenHardPruneCannotRemoveVictim(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		firstAge   time.Duration
@@ -427,7 +427,8 @@ func TestNewDiskCacheFailsWhenStartupPruneCannotRemoveVictim(t *testing.T) {
 			beforeAggregate := counterValue(t, cacheEvictionsTotal)
 			beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
 			c, err := NewDiskCache(dir, 100, DiskCacheOptions{
-				MaxEntries: 1,
+				MaxEntries:     2,
+				hardMaxEntries: 1,
 				openScanDirectory: func(string) (cacheDirectory, error) {
 					return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
 				},
@@ -436,11 +437,8 @@ func TestNewDiskCacheFailsWhenStartupPruneCannotRemoveVictim(t *testing.T) {
 					return removeErr
 				},
 			})
-			if c != nil {
-				t.Fatal("NewDiskCache returned a cache after startup pruning failed")
-			}
-			if !errors.Is(err, removeErr) {
-				t.Fatalf("NewDiskCache error = %v, want wrapped removal error", err)
+			if c != nil || !errors.Is(err, removeErr) {
+				t.Fatalf("NewDiskCache after failed hard-prune removal: cache=%v err=%v, want nil/wrapped failure", c, err)
 			}
 			if attemptedVictim != tc.wantVictim {
 				t.Fatalf("startup prune attempted victim %q, want %q", attemptedVictim, tc.wantVictim)
@@ -486,7 +484,8 @@ func TestNewDiskCacheTreatsStartupPruneENOENTAsSuccessfulCleanup(t *testing.T) {
 	beforeAggregate := counterValue(t, cacheEvictionsTotal)
 	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
 	c, err := NewDiskCache(dir, 100, DiskCacheOptions{
-		MaxEntries: 1,
+		MaxEntries:     2,
+		hardMaxEntries: 1,
 		openScanDirectory: func(string) (cacheDirectory, error) {
 			return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
 		},
@@ -514,7 +513,7 @@ func TestNewDiskCacheTreatsStartupPruneENOENTAsSuccessfulCleanup(t *testing.T) {
 	}
 }
 
-func TestNewDiskCacheFailsWhenInitialBytePruneCannotRemoveVictim(t *testing.T) {
+func TestNewDiskCacheDefersInitialByteConvergence(t *testing.T) {
 	dir := t.TempDir()
 	for _, key := range []string{strings.Repeat("c", 64), strings.Repeat("d", 64)} {
 		if err := os.WriteFile(filepath.Join(dir, key), make([]byte, 60), 0600); err != nil {
@@ -524,18 +523,22 @@ func TestNewDiskCacheFailsWhenInitialBytePruneCannotRemoveVictim(t *testing.T) {
 	removeErr := errors.New("forced startup byte-prune removal failure")
 	beforeAggregate := counterValue(t, cacheEvictionsTotal)
 	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonByte)
+	removeAttempts := 0
 	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
 		CapacityProvider: func(string) (diskSpace, error) {
 			// owned=120, reserve=50, free=0 => byte ceiling=70.
 			return diskSpace{TotalBytes: 1000, FreeBytes: 0}, nil
 		},
-		removeFile: func(string) error { return removeErr },
+		removeFile: func(string) error {
+			removeAttempts++
+			return removeErr
+		},
 	})
-	if c != nil {
-		t.Fatal("NewDiskCache returned an over-capacity cache after initial byte pruning failed")
+	if err != nil || c == nil {
+		t.Fatalf("NewDiskCache must load inspectable entries before rate-limited byte convergence: cache=%v err=%v", c, err)
 	}
-	if !errors.Is(err, removeErr) {
-		t.Fatalf("NewDiskCache error = %v, want wrapped byte-prune removal error", err)
+	if c.currentSize != 120 || c.maxBytes != 70 || removeAttempts != 0 {
+		t.Fatalf("startup state bytes/capacity/removals = %d/%d/%d, want 120/70/0", c.currentSize, c.maxBytes, removeAttempts)
 	}
 	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
 		t.Fatalf("aggregate evictions after failed startup byte removal = %v, want 0", got)
@@ -556,7 +559,8 @@ func TestCachePressureEvictionsHaveBoundedPhaseAndReason(t *testing.T) {
 		before := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
 		beforeAggregate := counterValue(t, cacheEvictionsTotal)
 		c, err := NewDiskCache(dir, 80, DiskCacheOptions{
-			MaxEntries: 2,
+			MaxEntries:     3,
+			hardMaxEntries: 2,
 			CapacityProvider: func(string) (diskSpace, error) {
 				return diskSpace{TotalBytes: 1000, FreeBytes: 990}, nil
 			},
@@ -613,6 +617,7 @@ func TestRefreshCapacityShrinksImmediatelyAndRecoversAfterHysteresis(t *testing.
 	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
 		t.Fatalf("shrunk capacity = %d (ok=%v), want 760", got, ok)
 	}
+	c.convergeOne()
 	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonByte) - before; got != 1 {
 		t.Fatalf("background byte evictions = %v, want 1", got)
 	}
@@ -658,6 +663,7 @@ func TestRefreshCapacityRetriesEvictionAtUnchangedCeiling(t *testing.T) {
 	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
 		t.Fatalf("first refresh capacity = %d (ok=%v), want 760", got, ok)
 	}
+	c.convergeOne()
 	if removeAttempts != 1 || c.currentSize != 800 || c.order.Len() != 2 {
 		t.Fatalf("cache after failed convergence = attempts:%d bytes:%d entries:%d, want 1/800/2", removeAttempts, c.currentSize, c.order.Len())
 	}
@@ -673,6 +679,7 @@ func TestRefreshCapacityRetriesEvictionAtUnchangedCeiling(t *testing.T) {
 	if _, got, ok := c.refreshCapacityStats(80); !ok || got != 760 {
 		t.Fatalf("second refresh capacity = %d (ok=%v), want 760", got, ok)
 	}
+	c.convergeOne()
 	if removeAttempts != 2 || c.currentSize != 400 || c.order.Len() != 1 {
 		t.Fatalf("cache after retried convergence = attempts:%d bytes:%d entries:%d, want 2/400/1", removeAttempts, c.currentSize, c.order.Len())
 	}
@@ -1282,7 +1289,7 @@ func TestScanExistingSeedsRecencyOrder(t *testing.T) {
 	}
 }
 
-func TestScanExistingEnforcesByteAndEntryCeilings(t *testing.T) {
+func TestScanExistingLoadsAboveSoftByteAndEntryTargets(t *testing.T) {
 	dir := t.TempDir()
 	keys := []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)}
 	base := time.Now().Add(-time.Hour)
@@ -1307,10 +1314,12 @@ func TestScanExistingEnforcesByteAndEntryCeilings(t *testing.T) {
 	if _, err := c.scanExisting(); err != nil {
 		t.Fatal(err)
 	}
-	if c.currentSize > c.maxBytes || c.order.Len() > c.maxEntries {
-		t.Fatalf("startup cache exceeds ceilings: bytes=%d/%d entries=%d/%d", c.currentSize, c.maxBytes, c.order.Len(), c.maxEntries)
+	if c.currentSize != 30 || c.order.Len() != 3 {
+		t.Fatalf("startup cache bytes/entries = %d/%d, want all 30/3 before convergence", c.currentSize, c.order.Len())
 	}
-	if !c.Has(keys[2]) {
-		t.Fatal("startup pruning did not retain the newest entry")
+	for _, key := range keys {
+		if !c.Has(key) {
+			t.Fatalf("startup omitted soft-over-target key %s", key)
+		}
 	}
 }

--- a/cmd/cache-proxy/convergence.go
+++ b/cmd/cache-proxy/convergence.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -95,11 +97,35 @@ func (c *DiskCache) convergeOne() (bool, bool) {
 		c.mu.Unlock()
 		return false, true
 	}
+	victimElement := c.oldestEvictableLocked()
+	if victimElement == nil {
+		c.updateConvergenceMetricsLocked()
+		c.mu.Unlock()
+		return true, false
+	}
+	victim := victimElement.Value.(*cacheEntry)
+	victim.evictionInFlight = true
+	victimPath := filepath.Join(c.dir, victim.key)
 	cacheConvergenceEvictionAttemptsTotal.Inc()
-	succeeded := true
-	if err := c.evictOldest(cacheEvictionPhaseBackground, reason); err != nil {
+	c.mu.Unlock()
+
+	_, removeErr := c.removeCommittedFile(victimPath, cacheEvictionPhaseBackground, reason)
+
+	c.mu.Lock()
+	currentElement, stillIndexed := c.index[victim.key]
+	sameEntry := stillIndexed && currentElement == victimElement
+	succeeded := removeErr == nil && sameEntry
+	switch {
+	case removeErr != nil:
+		if sameEntry {
+			victim.evictionInFlight = false
+		}
 		cacheConvergenceEvictionFailuresTotal.Inc()
-		succeeded = false
+	case !sameEntry:
+		cacheConvergenceEvictionFailuresTotal.Inc()
+		slog.Error("Cache convergence victim changed during deletion.", "key", victim.key)
+	default:
+		c.forgetEntryLocked(victimElement)
 	}
 	c.updateConvergenceMetricsLocked()
 	_, stillOver := c.overLimitReasonLocked()

--- a/cmd/cache-proxy/convergence.go
+++ b/cmd/cache-proxy/convergence.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	cacheConvergenceActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_convergence_active",
+		Help: "Whether the cache is above its active soft entry or byte target",
+	})
+	cacheConvergenceExcessEntries = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_convergence_excess_entries",
+		Help: "Exact-index entries above the active soft target",
+	})
+	cacheConvergenceExcessBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_convergence_excess_bytes",
+		Help: "Committed cache bytes above the active byte target",
+	})
+	cacheConvergenceEvictionAttemptsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_convergence_eviction_attempts_total",
+		Help: "Rate-limited background convergence eviction attempts",
+	})
+	cacheConvergenceEvictionFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_convergence_eviction_failures_total",
+		Help: "Rate-limited background convergence eviction attempts that failed",
+	})
+)
+
+func (c *DiskCache) startConvergence(parent context.Context, permits <-chan struct{}, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultConvergenceInterval
+	}
+	ctx, cancel := context.WithCancel(parent)
+	c.convergenceCancel = cancel
+	c.convergenceDone = make(chan struct{})
+	c.convergenceWake = make(chan struct{}, 1)
+	go func() {
+		defer close(c.convergenceDone)
+		if permits != nil {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case _, ok := <-permits:
+					if !ok {
+						return
+					}
+					c.convergeOne()
+				}
+			}
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.convergenceWake:
+			}
+			for {
+				timer := time.NewTimer(interval)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
+				stillOver, succeeded := c.convergeOne()
+				if !stillOver {
+					break
+				}
+				if !succeeded {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(time.Second):
+					}
+				}
+			}
+		}
+	}()
+	c.mu.Lock()
+	c.updateConvergenceMetricsLocked()
+	c.mu.Unlock()
+}
+
+func (c *DiskCache) convergeOne() (bool, bool) {
+	c.mu.Lock()
+	reason, over := c.overLimitReasonLocked()
+	if !over {
+		c.updateConvergenceMetricsLocked()
+		c.mu.Unlock()
+		return false, true
+	}
+	cacheConvergenceEvictionAttemptsTotal.Inc()
+	succeeded := true
+	if err := c.evictOldest(cacheEvictionPhaseBackground, reason); err != nil {
+		cacheConvergenceEvictionFailuresTotal.Inc()
+		succeeded = false
+	}
+	c.updateConvergenceMetricsLocked()
+	_, stillOver := c.overLimitReasonLocked()
+	c.mu.Unlock()
+	return stillOver, succeeded
+}
+
+func (c *DiskCache) overLimitReasonLocked() (cacheEvictionReason, bool) {
+	if c.currentSize > c.maxBytes {
+		return cacheEvictionReasonByte, true
+	}
+	if c.order.Len() > c.maxEntries {
+		return cacheEvictionReasonEntry, true
+	}
+	return "", false
+}
+
+func (c *DiskCache) updateConvergenceMetricsLocked() {
+	excessEntries := c.order.Len() - c.maxEntries
+	if excessEntries < 0 {
+		excessEntries = 0
+	}
+	excessBytes := c.currentSize - c.maxBytes
+	if excessBytes < 0 {
+		excessBytes = 0
+	}
+	cacheConvergenceExcessEntries.Set(float64(excessEntries))
+	cacheConvergenceExcessBytes.Set(float64(excessBytes))
+	if excessEntries > 0 || excessBytes > 0 {
+		cacheConvergenceActive.Set(1)
+		if c.convergenceWake != nil {
+			select {
+			case c.convergenceWake <- struct{}{}:
+			default:
+			}
+		}
+	} else {
+		cacheConvergenceActive.Set(0)
+	}
+}

--- a/cmd/cache-proxy/convergence_test.go
+++ b/cmd/cache-proxy/convergence_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -177,5 +179,218 @@ func TestAdmissionStillEnforcesHardByteCapacityAcrossSmallVictims(t *testing.T) 
 	}
 	if cache.currentSize > cache.maxBytes {
 		t.Fatalf("accepted cache entry left bytes above capacity: %d > %d", cache.currentSize, cache.maxBytes)
+	}
+}
+
+func TestConvergenceBlockedUnlinkDoesNotBlockCacheOrCanceledClose(t *testing.T) {
+	victim := strings.Repeat("1", 64)
+	recent := strings.Repeat("2", 64)
+	cache, permits := newSoftConvergenceCache(t, 1, []string{victim, recent})
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDelete := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseDelete)
+	cache.removeFile = func(path string) error {
+		if filepath.Base(path) != victim {
+			return os.Remove(path)
+		}
+		started <- struct{}{}
+		<-release
+		return os.Remove(path)
+	}
+
+	beforeEvictions := counterValue(t, cacheEvictionsTotal)
+	beforeByReason := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonEntry)
+	allowConvergence(t, permits)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("convergence did not reach the blocked removal")
+	}
+
+	hasReturned := make(chan bool, 1)
+	go func() { hasReturned <- cache.Has(recent) }()
+	closeCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	closeReturned := make(chan error, 1)
+	go func() { closeReturned <- cache.Close(closeCtx) }()
+
+	select {
+	case hasRecent := <-hasReturned:
+		if !hasRecent {
+			t.Error("unrelated cache operation lost its resident entry during a blocked unlink")
+		}
+	case <-time.After(time.Second):
+		t.Error("cache operation blocked behind convergence unlink")
+	}
+	select {
+	case err := <-closeReturned:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Close with canceled context = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Error("Close with canceled context blocked behind convergence unlink")
+	}
+
+	releaseDelete()
+	select {
+	case <-cache.convergenceDone:
+	case <-time.After(time.Second):
+		t.Error("convergence worker did not finish after unlink release")
+	}
+	if cache.Has(victim) {
+		t.Error("successful in-flight convergence deletion left the victim indexed")
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeEvictions; got != 1 {
+		t.Errorf("successful blocked convergence evictions = %v, want 1", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseBackground, cacheEvictionReasonEntry) - beforeByReason; got != 1 {
+		t.Errorf("successful blocked convergence entry evictions = %v, want 1", got)
+	}
+}
+
+func TestConvergenceInFlightVictimAdmissionDoesNotRaceUnlink(t *testing.T) {
+	victim := strings.Repeat("3", 64)
+	recent := strings.Repeat("4", 64)
+	cache, permits := newSoftConvergenceCache(t, 1, []string{victim, recent})
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	removed := make(chan error, 1)
+	var releaseOnce sync.Once
+	releaseDelete := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseDelete)
+	cache.removeFile = func(path string) error {
+		if filepath.Base(path) != victim {
+			return os.Remove(path)
+		}
+		started <- struct{}{}
+		<-release
+		err := os.Remove(path)
+		removed <- err
+		return err
+	}
+
+	allowConvergence(t, permits)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("convergence did not reach the blocked removal")
+	}
+
+	admission := make(chan error, 1)
+	go func() {
+		_, err := cache.PutStream(victim, strings.NewReader("replacement"))
+		admission <- err
+	}()
+	var admissionErr error
+	admissionReturned := false
+	select {
+	case admissionErr = <-admission:
+		admissionReturned = true
+	case <-time.After(time.Second):
+		t.Error("replacement/new admission blocked behind in-flight victim unlink")
+	}
+	if admissionReturned {
+		body, err := os.ReadFile(filepath.Join(cache.dir, victim))
+		if err != nil {
+			t.Errorf("in-flight admission changed victim path before unlink release: %v", err)
+		} else if admissionErr == nil && string(body) != "replacement" {
+			t.Errorf("accepted in-flight replacement body = %q, want replacement", body)
+		} else if admissionErr != nil && string(body) != "x" {
+			t.Errorf("rejected in-flight replacement changed body to %q, want original", body)
+		}
+	}
+
+	releaseDelete()
+	select {
+	case err := <-removed:
+		if err != nil {
+			t.Fatalf("release blocked convergence unlink: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked convergence unlink did not finish")
+	}
+	if !admissionReturned {
+		admissionErr = <-admission
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cache.Close(ctx); err != nil {
+		t.Fatalf("stop convergence after unlink release: %v", err)
+	}
+	if admissionErr == nil {
+		body, err := os.ReadFile(filepath.Join(cache.dir, victim))
+		if err != nil || string(body) != "replacement" || !cache.Has(victim) {
+			t.Fatalf("accepted replacement raced with old unlink: body=%q err=%v indexed=%t", body, err, cache.Has(victim))
+		}
+	}
+}
+
+func TestConvergenceHardFailureKeepsVictimIndexedAndRetryable(t *testing.T) {
+	victim := strings.Repeat("5", 64)
+	recent := strings.Repeat("6", 64)
+	cache, permits := newSoftConvergenceCache(t, 1, []string{victim, recent})
+
+	firstStarted := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	firstReturned := make(chan struct{}, 1)
+	secondStarted := make(chan struct{}, 1)
+	var releaseOnce sync.Once
+	releaseFirst := func() { releaseOnce.Do(func() { close(firstRelease) }) }
+	t.Cleanup(releaseFirst)
+	forcedFailure := errors.New("forced convergence removal failure")
+	attempt := 0
+	cache.removeFile = func(path string) error {
+		if filepath.Base(path) != victim {
+			return errors.New("convergence selected an unexpected victim")
+		}
+		attempt++
+		if attempt == 1 {
+			firstStarted <- struct{}{}
+			<-firstRelease
+			firstReturned <- struct{}{}
+			return forcedFailure
+		}
+		secondStarted <- struct{}{}
+		return os.Remove(path)
+	}
+
+	beforeFailures := counterValue(t, cacheConvergenceEvictionFailuresTotal)
+	allowConvergence(t, permits)
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("convergence did not reach the first blocked removal")
+	}
+	releaseFirst()
+	select {
+	case <-firstReturned:
+	case <-time.After(time.Second):
+		t.Fatal("blocked convergence removal did not return its forced failure")
+	}
+	if !cache.Has(victim) {
+		t.Fatal("failed in-flight deletion removed the victim from the index")
+	}
+	if _, err := os.Stat(filepath.Join(cache.dir, victim)); err != nil {
+		t.Fatalf("failed in-flight deletion removed the original body: %v", err)
+	}
+
+	// The second permit can be received only once the first convergence attempt
+	// has finalized. Its successful retry proves a failed reservation was cleared.
+	allowConvergence(t, permits)
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("hard failure left the victim permanently in flight")
+	}
+	waitForCacheEntryCount(t, cache, 1)
+	if cache.Has(victim) {
+		t.Fatal("successful retry did not remove the formerly failed victim")
+	}
+	if got := counterValue(t, cacheConvergenceEvictionFailuresTotal) - beforeFailures; got != 1 {
+		t.Fatalf("convergence failures = %v, want 1", got)
 	}
 }

--- a/cmd/cache-proxy/convergence_test.go
+++ b/cmd/cache-proxy/convergence_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newSoftConvergenceCache creates more on-disk entries than the configured
+// soft target, but holds convergence behind an explicit permit. The
+// convergencePermits option is deliberately a test-only seam: production uses
+// its bounded rate limiter instead.
+func newSoftConvergenceCache(t *testing.T, softTarget int, keys []string) (*DiskCache, chan struct{}) {
+	t.Helper()
+	dir := t.TempDir()
+	base := time.Now().Add(-time.Hour)
+	for i, key := range keys {
+		path := filepath.Join(dir, key)
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		when := base.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	permits := make(chan struct{})
+	cache, err := NewDiskCache(dir, 100, DiskCacheOptions{
+		MaxEntries:         softTarget,
+		convergencePermits: permits,
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = cache.Close(ctx)
+	})
+	return cache, permits
+}
+
+func cacheEntryCount(c *DiskCache) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}
+
+func allowConvergence(t *testing.T, permits chan<- struct{}) {
+	t.Helper()
+	select {
+	case permits <- struct{}{}:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for convergence worker to accept permit")
+	}
+}
+
+func waitForCacheEntryCount(t *testing.T, c *DiskCache, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := cacheEntryCount(c); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("cache entry count = %d, want %d", cacheEntryCount(c), want)
+}
+
+func TestStartupAboveSoftTargetDoesNotSynchronouslyDelete(t *testing.T) {
+	keys := []string{
+		strings.Repeat("1", 64),
+		strings.Repeat("2", 64),
+		strings.Repeat("3", 64),
+	}
+	cache, _ := newSoftConvergenceCache(t, 2, keys)
+
+	// The configured 2-entry target is a convergence target, not a startup
+	// pruning limit. All entries are below the independent 10M hard guardrail.
+	if got := cacheEntryCount(cache); got != len(keys) {
+		t.Fatalf("startup synchronously pruned to %d entries, want all %d", got, len(keys))
+	}
+	for _, key := range keys {
+		if !cache.Has(key) {
+			t.Fatalf("startup discarded %q despite no convergence permit", key)
+		}
+		if _, err := os.Stat(filepath.Join(cache.dir, key)); err != nil {
+			t.Fatalf("startup removed committed body %q: %v", key, err)
+		}
+	}
+}
+
+func TestSoftConvergenceDeletesExactlyOneLRUPerPermit(t *testing.T) {
+	keys := []string{
+		strings.Repeat("1", 64),
+		strings.Repeat("2", 64),
+		strings.Repeat("3", 64),
+		strings.Repeat("4", 64),
+	}
+	cache, permits := newSoftConvergenceCache(t, 2, keys)
+	if got := cacheEntryCount(cache); got != 4 {
+		t.Fatalf("startup count = %d, want 4 before convergence", got)
+	}
+
+	allowConvergence(t, permits)
+	waitForCacheEntryCount(t, cache, 3)
+	if cache.Has(keys[0]) || !cache.Has(keys[1]) || !cache.Has(keys[2]) || !cache.Has(keys[3]) {
+		t.Fatal("first convergence permit did not remove exactly the oldest entry")
+	}
+
+	allowConvergence(t, permits)
+	waitForCacheEntryCount(t, cache, 2)
+	if cache.Has(keys[1]) || !cache.Has(keys[2]) || !cache.Has(keys[3]) {
+		t.Fatal("second convergence permit did not remove exactly the next LRU entry")
+	}
+}
+
+func TestAdmissionAtOrAboveSoftTargetIsNetNeutral(t *testing.T) {
+	t.Run("at target swaps only the LRU", func(t *testing.T) {
+		oldest, recent, incoming := strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)
+		cache, _ := newSoftConvergenceCache(t, 2, []string{oldest, recent})
+
+		if _, err := cache.PutStream(incoming, bytes.NewReader([]byte("new"))); err != nil {
+			t.Fatalf("PutStream: %v", err)
+		}
+		if got := cacheEntryCount(cache); got != 2 {
+			t.Fatalf("admission at soft target changed count to %d, want 2", got)
+		}
+		if cache.Has(oldest) || !cache.Has(recent) || !cache.Has(incoming) {
+			t.Fatal("admission at target did not perform one LRU swap")
+		}
+	})
+
+	t.Run("above target swaps at most one and replacement is count neutral", func(t *testing.T) {
+		oldest, retained, replaced := strings.Repeat("4", 64), strings.Repeat("5", 64), strings.Repeat("6", 64)
+		incoming := strings.Repeat("7", 64)
+		cache, _ := newSoftConvergenceCache(t, 2, []string{oldest, retained, replaced})
+
+		if _, err := cache.PutStream(incoming, bytes.NewReader([]byte("new"))); err != nil {
+			t.Fatalf("PutStream new entry: %v", err)
+		}
+		if got := cacheEntryCount(cache); got != 3 {
+			t.Fatalf("admission above soft target changed count to %d, want net-neutral 3", got)
+		}
+		if cache.Has(oldest) || !cache.Has(retained) || !cache.Has(replaced) || !cache.Has(incoming) {
+			t.Fatal("admission above target removed more than the one LRU victim")
+		}
+
+		if _, err := cache.PutStream(replaced, bytes.NewReader([]byte("replacement"))); err != nil {
+			t.Fatalf("PutStream replacement: %v", err)
+		}
+		if got := cacheEntryCount(cache); got != 3 {
+			t.Fatalf("replacement above soft target changed count to %d, want 3", got)
+		}
+		if !cache.Has(retained) || !cache.Has(replaced) || !cache.Has(incoming) {
+			t.Fatal("replacement above target evicted an unrelated entry")
+		}
+	})
+}
+
+func TestAdmissionStillEnforcesHardByteCapacityAcrossSmallVictims(t *testing.T) {
+	cache := newTestCache(t)
+	cache.maxEntries = 100
+	cache.maxBytes = 100
+	for _, key := range []string{strings.Repeat("8", 64), strings.Repeat("9", 64), strings.Repeat("a", 64)} {
+		if _, err := cache.PutStream(key, bytes.NewReader(make([]byte, 5))); err != nil {
+			t.Fatalf("seed small cache entry: %v", err)
+		}
+	}
+	if _, err := cache.PutStream(strings.Repeat("b", 64), bytes.NewReader(make([]byte, 95))); err != nil {
+		t.Fatalf("admit normal cache entry: %v", err)
+	}
+	if cache.currentSize > cache.maxBytes {
+		t.Fatalf("accepted cache entry left bytes above capacity: %d > %d", cache.currentSize, cache.maxBytes)
+	}
+}

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -174,14 +175,25 @@ func main() {
 	maxSpanBlocks := envInt64("CACHE_BLOCK_MAX_SPAN_BLOCKS", 8)
 	slog.Info("Block mode configured.", "enabled", blockMode, "block_size", blockSize, "max_span_blocks", maxSpanBlocks)
 
+	// Install cancellation before the potentially long bounded startup scan so
+	// Kubernetes termination never has to wait for enumeration or hard pruning.
+	rootCtx, stopBackground := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stopBackground()
+
 	// Initialize cache store
 	store, err := NewDiskCache(cacheDir, maxPercent, DiskCacheOptions{
-		IncrementalSummary: lookupMode == peerLookupSummary && peerService != "",
-		MaxEntries:         maxEntries,
-		BlockSizeBytes:     blockSize,
+		IncrementalSummary:    lookupMode == peerLookupSummary && peerService != "",
+		DurableRecency:        true,
+		BackgroundConvergence: true,
+		MaxEntries:            maxEntries,
+		BlockSizeBytes:        blockSize,
+		startupContext:        rootCtx,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize cache store.", "error", err)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		os.Exit(1)
 	}
 	// Track the disk's free space: when something outside the cache consumes
@@ -190,14 +202,17 @@ func main() {
 	go func() {
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
-		for range ticker.C {
-			store.refreshCapacity(maxPercent)
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case <-ticker.C:
+				store.refreshCapacity(maxPercent)
+			}
 		}
 	}()
 
 	// Initialize peer manager
-	rootCtx, stopBackground := context.WithCancel(context.Background())
-	defer stopBackground()
 	var peers *PeerManager
 	if peerService != "" {
 		peers = NewPeerManager(peerService, peerAddr)
@@ -262,10 +277,8 @@ func main() {
 		}
 	}()
 
-	// Wait for shutdown signal
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-	<-sigCh
+	// Wait for shutdown signal.
+	<-rootCtx.Done()
 
 	slog.Info("Shutting down...")
 	stopBackground()
@@ -277,6 +290,9 @@ func main() {
 	_ = s3Server.Shutdown(ctx)
 	_ = peerServer.Shutdown(ctx)
 	_ = healthServer.Shutdown(ctx)
+	if err := store.Close(ctx); err != nil {
+		slog.Warn("Cache background work did not fully drain before shutdown.", "error", err)
+	}
 }
 
 func envOrDefault(key, def string) string {

--- a/cmd/cache-proxy/recency.go
+++ b/cmd/cache-proxy/recency.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	defaultRecencyGranularity   = time.Minute
+	defaultRecencyQueueCapacity = 65_536
+	defaultRecencyWorkerCount   = 1
+)
+
+var (
+	cacheRecencyTouchAttemptsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_recency_touch_attempts_total",
+		Help: "Cache accesses considered for durable coarse-recency persistence",
+	})
+	cacheRecencyTouchSuccessesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_recency_touch_successes_total",
+		Help: "Coarse cache-recency timestamps successfully persisted to disk",
+	})
+	cacheRecencyTouchFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_recency_touch_failures_total",
+		Help: "Coarse cache-recency timestamps that failed to persist",
+	})
+	cacheRecencyTouchCoalescedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_recency_touch_coalesced_total",
+		Help: "Cache accesses coalesced with an existing or same-bucket durable-recency update",
+	})
+	cacheRecencyTouchDroppedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_recency_touch_dropped_total",
+		Help: "Durable-recency updates dropped because the bounded queue was full or closed",
+	})
+	cacheRecencyQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_recency_queue_depth",
+		Help: "Unique cache keys with queued or in-flight durable-recency work",
+	})
+	cacheRecencyLastSuccessTimestampSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_recency_last_successful_persistence_timestamp_seconds",
+		Help: "Unix timestamp of the last successful durable-recency metadata update",
+	})
+)
+
+type recencyPersistence func(string, time.Time, time.Time) error
+
+type recencyState struct {
+	latest time.Time
+}
+
+// recencyWriter persists coarse access timestamps without ever making request
+// handlers wait for filesystem metadata I/O. The pending map is bounded by the
+// queue capacity and provides one coalescing slot per opaque cache key.
+type recencyWriter struct {
+	dir     string
+	persist recencyPersistence
+
+	mu         sync.Mutex
+	pending    map[string]*recencyState
+	jobs       chan string
+	maxPending int
+	closed     bool
+	done       chan struct{}
+	wg         sync.WaitGroup
+}
+
+func newRecencyWriter(dir string, capacity, workers int, persist recencyPersistence) *recencyWriter {
+	if capacity <= 0 {
+		capacity = defaultRecencyQueueCapacity
+	}
+	if workers <= 0 {
+		workers = defaultRecencyWorkerCount
+	}
+	if persist == nil {
+		persist = os.Chtimes
+	}
+	w := &recencyWriter{
+		dir:        dir,
+		persist:    persist,
+		pending:    make(map[string]*recencyState, capacity),
+		jobs:       make(chan string, capacity),
+		maxPending: capacity + workers,
+		done:       make(chan struct{}),
+	}
+	w.wg.Add(workers)
+	for range workers {
+		go w.run()
+	}
+	go func() {
+		w.wg.Wait()
+		close(w.done)
+	}()
+	return w
+}
+
+// submit is deliberately nonblocking. false means the bounded durability
+// budget was exhausted; callers keep their exact in-memory LRU update.
+func (w *recencyWriter) submit(key string, timestamp time.Time) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		cacheRecencyTouchDroppedTotal.Inc()
+		return false
+	}
+	if state, ok := w.pending[key]; ok {
+		if timestamp.After(state.latest) {
+			state.latest = timestamp
+		}
+		cacheRecencyTouchCoalescedTotal.Inc()
+		return true
+	}
+	if len(w.pending) >= w.maxPending {
+		cacheRecencyTouchDroppedTotal.Inc()
+		return false
+	}
+	w.pending[key] = &recencyState{latest: timestamp}
+	select {
+	case w.jobs <- key:
+		cacheRecencyQueueDepth.Set(float64(len(w.pending)))
+		return true
+	default:
+		delete(w.pending, key)
+		cacheRecencyQueueDepth.Set(float64(len(w.pending)))
+		cacheRecencyTouchDroppedTotal.Inc()
+		return false
+	}
+}
+
+func (w *recencyWriter) run() {
+	defer w.wg.Done()
+	for key := range w.jobs {
+		w.persistKey(key)
+	}
+}
+
+func (w *recencyWriter) persistKey(key string) {
+	for {
+		w.mu.Lock()
+		state, ok := w.pending[key]
+		if !ok {
+			w.mu.Unlock()
+			return
+		}
+		timestamp := state.latest
+		w.mu.Unlock()
+
+		err := w.persist(cachePath(w.dir, key), timestamp, timestamp)
+		switch {
+		case err == nil:
+			cacheRecencyTouchSuccessesTotal.Inc()
+			cacheRecencyLastSuccessTimestampSeconds.Set(float64(time.Now().Unix()))
+		case errors.Is(err, os.ErrNotExist):
+			// Eviction may race accepted metadata work. The missing entry is
+			// already absent and is not a persistence failure.
+		default:
+			cacheRecencyTouchFailuresTotal.Inc()
+			slog.Warn("Unable to persist cache recency.", "key", key, "error", err)
+		}
+
+		w.mu.Lock()
+		state, ok = w.pending[key]
+		if ok && state.latest.After(timestamp) {
+			w.mu.Unlock()
+			continue
+		}
+		delete(w.pending, key)
+		cacheRecencyQueueDepth.Set(float64(len(w.pending)))
+		w.mu.Unlock()
+		return
+	}
+}
+
+func (w *recencyWriter) beginClose() <-chan struct{} {
+	w.mu.Lock()
+	if !w.closed {
+		w.closed = true
+		close(w.jobs)
+	}
+	done := w.done
+	w.mu.Unlock()
+	return done
+}
+
+func (w *recencyWriter) waitIdle(ctx context.Context) error {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		w.mu.Lock()
+		idle := len(w.pending) == 0
+		w.mu.Unlock()
+		if idle {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func cachePath(dir, key string) string {
+	// key has already passed IsValidCacheKey before it enters the index.
+	return dir + string(os.PathSeparator) + key
+}

--- a/cmd/cache-proxy/recency_test.go
+++ b/cmd/cache-proxy/recency_test.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests deliberately describe the durable-recency contract before its
+// implementation exists. The package-private DiskCacheOptions seams keep the
+// asynchronous filesystem work deterministic: no test depends on wall-clock
+// sleeps or the host filesystem's mtime precision.
+type recencyTestHooks struct {
+	now      func() time.Time
+	chtimes  func(string, time.Time, time.Time) error
+	interval time.Duration
+	queueCap int
+	workers  int
+}
+
+func newRecencyTestCache(t *testing.T, dir string, maxEntries int, hooks recencyTestHooks) *DiskCache {
+	t.Helper()
+	if hooks.now == nil {
+		hooks.now = time.Now
+	}
+	if hooks.chtimes == nil {
+		hooks.chtimes = os.Chtimes
+	}
+	if hooks.interval == 0 {
+		hooks.interval = time.Minute
+	}
+	if hooks.queueCap == 0 {
+		hooks.queueCap = 8
+	}
+	if hooks.workers == 0 {
+		hooks.workers = 1
+	}
+
+	c, err := NewDiskCache(dir, 100, DiskCacheOptions{
+		MaxEntries:           maxEntries,
+		DurableRecency:       true,
+		recencyNow:           hooks.now,
+		recencyChtimes:       hooks.chtimes,
+		recencyInterval:      hooks.interval,
+		recencyQueueCapacity: hooks.queueCap,
+		recencyWorkerCount:   hooks.workers,
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache with durable recency: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = c.Close(ctx)
+	})
+	return c
+}
+
+func waitForRecencyIdle(t *testing.T, c *DiskCache) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.waitForRecencyIdle(ctx); err != nil {
+		t.Fatalf("wait for durable recency writer: %v", err)
+	}
+}
+
+func closeRecencyCache(t *testing.T, c *DiskCache) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return c.Close(ctx)
+}
+
+func seedRecencyFile(t *testing.T, dir, key string, body []byte, mtime time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, key)
+	if err := os.WriteFile(path, body, 0600); err != nil {
+		t.Fatalf("seed cache file %s: %v", key, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("set seed cache mtime %s: %v", key, err)
+	}
+}
+
+func openRecencyEntry(t *testing.T, c *DiskCache, key string) {
+	t.Helper()
+	r, _, ok := c.Open(key)
+	if !ok {
+		t.Fatalf("Open(%s) = miss", key)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close cached reader: %v", err)
+	}
+}
+
+func TestDurableRecencyRestartPrefersTouchedOlderEntry(t *testing.T) {
+	dir := t.TempDir()
+	oldKey := strings.Repeat("a", 64)
+	newKey := strings.Repeat("b", 64)
+	base := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	seedRecencyFile(t, dir, oldKey, []byte("old"), base.Add(-2*time.Hour))
+	seedRecencyFile(t, dir, newKey, []byte("new"), base.Add(-time.Hour))
+
+	now := base
+	c := newRecencyTestCache(t, dir, 2, recencyTestHooks{
+		now:     func() time.Time { return now },
+		chtimes: os.Chtimes,
+	})
+	// The initial scan must not itself race the test's deliberately ordered
+	// seed mtimes. Drain any constructor/commit bookkeeping before touching.
+	waitForRecencyIdle(t, c)
+
+	// Move to a later coarse bucket. A real local read, not just a synthetic
+	// index mutation, must be the event persisted across restart.
+	now = base.Add(2 * time.Hour)
+	beforeAttempts := counterValue(t, cacheRecencyTouchAttemptsTotal)
+	beforeSuccesses := counterValue(t, cacheRecencyTouchSuccessesTotal)
+	openRecencyEntry(t, c, oldKey)
+	waitForRecencyIdle(t, c)
+	if got := counterValue(t, cacheRecencyTouchAttemptsTotal) - beforeAttempts; got != 1 {
+		t.Fatalf("durable recency attempts = %v, want 1", got)
+	}
+	if got := counterValue(t, cacheRecencyTouchSuccessesTotal) - beforeSuccesses; got != 1 {
+		t.Fatalf("durable recency successes = %v, want 1", got)
+	}
+	if err := closeRecencyCache(t, c); err != nil {
+		t.Fatalf("close first cache: %v", err)
+	}
+
+	// PR2's configured entry target is soft and must not itself force a startup
+	// purge. Use the private hard safety seam to require survivor selection;
+	// the formerly old file must win because its asynchronous read touch became
+	// durable mtime.
+	restarted, err := NewDiskCache(dir, 100, DiskCacheOptions{
+		MaxEntries:     2,
+		hardMaxEntries: 1,
+	})
+	if err != nil {
+		t.Fatalf("restart cache: %v", err)
+	}
+	if !restarted.Has(oldKey) || restarted.Has(newKey) {
+		t.Fatalf("restart survivors old/new = %t/%t, want true/false", restarted.Has(oldKey), restarted.Has(newKey))
+	}
+}
+
+func TestDurableRecencyTouchUpdatesLRUAndDropsWhenQueueIsBounded(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)}
+	for _, key := range keys {
+		seedRecencyFile(t, dir, key, []byte(key[:1]), time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC))
+	}
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	calls := 0
+	c := newRecencyTestCache(t, dir, len(keys), recencyTestHooks{
+		now:      func() time.Time { return time.Date(2026, time.August, 21, 13, 0, 0, 0, time.UTC) },
+		queueCap: 1,
+		workers:  1,
+		chtimes: func(path string, atime, mtime time.Time) error {
+			calls++
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return os.Chtimes(path, atime, mtime)
+		},
+	})
+	beforeDrops := counterValue(t, cacheRecencyTouchDroppedTotal)
+
+	// The first work item is in flight; the second consumes the sole queue
+	// slot. The third read must still update LRU immediately, but its durable
+	// write is dropped rather than making a request wait behind metadata I/O.
+	openRecencyEntry(t, c, keys[0])
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("durable recency writer did not start")
+	}
+	openRecencyEntry(t, c, keys[1])
+	thirdReturned := make(chan error, 1)
+	go func() {
+		r, _, ok := c.Open(keys[2])
+		if !ok {
+			thirdReturned <- errors.New("third cache hit became a miss")
+			return
+		}
+		thirdReturned <- r.Close()
+	}()
+	select {
+	case err := <-thirdReturned:
+		if err != nil {
+			t.Fatalf("third cache hit: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cache hit waited for a full durable-recency queue")
+	}
+
+	if got := c.order.Back().Value.(*cacheEntry).key; got != keys[2] {
+		t.Fatalf("synchronous LRU tail = %s, want %s", got, keys[2])
+	}
+	if got := counterValue(t, cacheRecencyTouchDroppedTotal) - beforeDrops; got != 1 {
+		t.Fatalf("recency queue drops = %v, want 1", got)
+	}
+	if got := gaugeValue(t, cacheRecencyQueueDepth); got > 2 {
+		t.Fatalf("bounded recency outstanding depth = %v, want at most queue+worker (2)", got)
+	}
+
+	close(release)
+	waitForRecencyIdle(t, c)
+	if calls != 2 {
+		t.Fatalf("metadata writes after one queue overflow = %d, want 2", calls)
+	}
+}
+
+func TestDurableRecencyCoalescesRepeatedTouchesInOneCoarseBucket(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("c", 64)
+	seedRecencyFile(t, dir, key, []byte("body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+
+	now := time.Date(2026, time.August, 21, 12, 3, 0, 0, time.UTC)
+	writes := 0
+	c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+		now: func() time.Time { return now },
+		chtimes: func(path string, atime, mtime time.Time) error {
+			writes++
+			return os.Chtimes(path, atime, mtime)
+		},
+	})
+	beforeCoalesced := counterValue(t, cacheRecencyTouchCoalescedTotal)
+
+	for range 5 {
+		openRecencyEntry(t, c, key)
+	}
+	waitForRecencyIdle(t, c)
+	if writes != 1 {
+		t.Fatalf("same-bucket durable mtime writes = %d, want 1", writes)
+	}
+	if got := counterValue(t, cacheRecencyTouchCoalescedTotal) - beforeCoalesced; got < 4 {
+		t.Fatalf("same-bucket coalesced touches = %v, want at least 4", got)
+	}
+
+	// The next coarse bucket schedules exactly one fresh write.
+	now = now.Add(time.Minute)
+	openRecencyEntry(t, c, key)
+	waitForRecencyIdle(t, c)
+	if writes != 2 {
+		t.Fatalf("next-bucket durable mtime writes = %d, want 2", writes)
+	}
+}
+
+func TestDurableRecencyDroppedKeyRetriesAtMostOncePerBucket(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("7", 64), strings.Repeat("8", 64), strings.Repeat("9", 64)}
+	for _, key := range keys {
+		seedRecencyFile(t, dir, key, []byte("x"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+	}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c := newRecencyTestCache(t, dir, len(keys), recencyTestHooks{
+		now:      func() time.Time { return time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC) },
+		queueCap: 1,
+		workers:  1,
+		chtimes: func(path string, atime, mtime time.Time) error {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return os.Chtimes(path, atime, mtime)
+		},
+	})
+	openRecencyEntry(t, c, keys[0])
+	<-started
+	openRecencyEntry(t, c, keys[1])
+	beforeDrops := counterValue(t, cacheRecencyTouchDroppedTotal)
+	for range 5 {
+		openRecencyEntry(t, c, keys[2])
+	}
+	if got := counterValue(t, cacheRecencyTouchDroppedTotal) - beforeDrops; got != 1 {
+		t.Fatalf("same-bucket drops for one overflowed key = %v, want 1", got)
+	}
+	close(release)
+	waitForRecencyIdle(t, c)
+}
+
+func TestDurableRecencyPersistenceFailureDoesNotAffectServingOrIndex(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("d", 64)
+	body := []byte("still-readable")
+	seedRecencyFile(t, dir, key, body, time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+	failure := errors.New("forced chtimes failure")
+	c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+		now:     func() time.Time { return time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC) },
+		chtimes: func(string, time.Time, time.Time) error { return failure },
+	})
+	beforeFailures := counterValue(t, cacheRecencyTouchFailuresTotal)
+	beforeEvictions := counterValue(t, cacheEvictionsTotal)
+
+	r, size, ok := c.Open(key)
+	if !ok || size != int64(len(body)) {
+		t.Fatalf("Open after scheduled persistence failure = ok:%t size:%d", ok, size)
+	}
+	got, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("cache body after persistence failure = %q, %v", got, err)
+	}
+	waitForRecencyIdle(t, c)
+
+	if !c.Has(key) || c.order.Len() != 1 || c.currentSize != int64(len(body)) {
+		t.Fatalf("cache state changed by persistence failure: has=%t entries=%d bytes=%d", c.Has(key), c.order.Len(), c.currentSize)
+	}
+	if got := counterValue(t, cacheRecencyTouchFailuresTotal) - beforeFailures; got != 1 {
+		t.Fatalf("recency persistence failures = %v, want 1", got)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeEvictions; got != 0 {
+		t.Fatalf("evictions caused by recency persistence failure = %v, want 0", got)
+	}
+}
+
+func TestDurableRecencyStaleQueuedTouchCannotRegressReplacementMtime(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("e", 64)
+	seedRecencyFile(t, dir, key, []byte("old-body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+
+	oldTouch := time.Date(2026, time.August, 21, 12, 1, 0, 0, time.UTC)
+	newCommit := oldTouch.Add(2 * time.Minute)
+	now := oldTouch
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	first := true
+	c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+		now: func() time.Time { return now },
+		chtimes: func(path string, atime, mtime time.Time) error {
+			if first {
+				first = false
+				started <- struct{}{}
+				<-release
+			}
+			return os.Chtimes(path, atime, mtime)
+		},
+	})
+
+	openRecencyEntry(t, c, key)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("old durable touch did not reach the writer")
+	}
+
+	// Commit a replacement while the old mtime write is blocked. The final
+	// durable timestamp must describe the replacement/current access, not the
+	// stale queued touch that runs after its rename.
+	now = newCommit
+	if _, err := c.PutStream(key, strings.NewReader("new-body")); err != nil {
+		t.Fatalf("replace cached body: %v", err)
+	}
+	close(release)
+	waitForRecencyIdle(t, c)
+
+	info, err := os.Stat(filepath.Join(dir, key))
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if info.ModTime().Before(newCommit) {
+		t.Fatalf("replacement mtime regressed to %s, want at least %s", info.ModTime(), newCommit)
+	}
+	r, _, ok := c.Open(key)
+	if !ok {
+		t.Fatal("replacement disappeared from index")
+	}
+	got, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil || string(got) != "new-body" {
+		t.Fatalf("replacement body = %q, %v", got, err)
+	}
+}
+
+func TestDurableRecencyCloseRejectsReplacementBehindQueuedTouch(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("f", 64)
+	seedRecencyFile(t, dir, key, []byte("old-body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+
+	oldTouch := time.Date(2026, time.August, 21, 12, 1, 0, 0, time.UTC)
+	replacementTime := oldTouch.Add(2 * time.Minute)
+	now := oldTouch
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+		now: func() time.Time { return now },
+		chtimes: func(path string, atime, mtime time.Time) error {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return os.Chtimes(path, atime, mtime)
+		},
+	})
+
+	// Keep an accepted old-bucket touch in flight, then close writer admission
+	// with a canceled deadline. Close is terminal for mutations, so a replacement
+	// cannot race the draining old metadata write and inherit its timestamp.
+	openRecencyEntry(t, c, key)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("old durable touch did not reach the writer")
+	}
+	closeCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.Close(closeCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close with canceled context = %v, want context.Canceled", err)
+	}
+
+	now = replacementTime
+	if _, err := c.PutStream(key, strings.NewReader("new-body")); err == nil {
+		t.Fatal("replacement succeeded after Close began")
+	}
+	close(release)
+	if err := closeRecencyCache(t, c); err != nil {
+		t.Fatalf("drain closed writer: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, key))
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if info.ModTime().Before(oldTouch.Truncate(time.Minute)) {
+		t.Fatalf("drained touch mtime = %s, want at least %s", info.ModTime(), oldTouch.Truncate(time.Minute))
+	}
+	r, _, ok := c.Open(key)
+	if !ok {
+		t.Fatal("original entry disappeared after rejected replacement")
+	}
+	body, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil || string(body) != "old-body" {
+		t.Fatalf("body after rejected replacement = %q, %v", body, err)
+	}
+}
+
+func TestDurableRecencyCloseDrainsAndHonorsCanceledDeadline(t *testing.T) {
+	t.Run("drains accepted work and ignores later touches", func(t *testing.T) {
+		dir := t.TempDir()
+		key := strings.Repeat("f", 64)
+		seedRecencyFile(t, dir, key, []byte("body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+		started := make(chan struct{}, 1)
+		release := make(chan struct{})
+		writes := 0
+		c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+			now: func() time.Time { return time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC) },
+			chtimes: func(path string, atime, mtime time.Time) error {
+				writes++
+				started <- struct{}{}
+				<-release
+				return os.Chtimes(path, atime, mtime)
+			},
+		})
+		openRecencyEntry(t, c, key)
+		<-started
+
+		closed := make(chan error, 1)
+		go func() { closed <- closeRecencyCache(t, c) }()
+		select {
+		case err := <-closed:
+			t.Fatalf("Close returned before accepted work drained: %v", err)
+		default:
+		}
+		close(release)
+		if err := <-closed; err != nil {
+			t.Fatalf("Close after releasing durable write: %v", err)
+		}
+		if writes != 1 {
+			t.Fatalf("drained durable writes = %d, want 1", writes)
+		}
+
+		// Closing the writer must only make durability best-effort; runtime LRU
+		// touches stay safe and must never send to a closed work channel.
+		openRecencyEntry(t, c, key)
+		if writes != 1 {
+			t.Fatalf("post-close touch scheduled a durable write: %d", writes)
+		}
+	})
+
+	t.Run("honors a canceled close context", func(t *testing.T) {
+		dir := t.TempDir()
+		key := strings.Repeat("0", 64)
+		seedRecencyFile(t, dir, key, []byte("body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+		started := make(chan struct{}, 1)
+		release := make(chan struct{})
+		now := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+		writes := 0
+		c := newRecencyTestCache(t, dir, 1, recencyTestHooks{
+			now: func() time.Time { return now },
+			chtimes: func(path string, atime, mtime time.Time) error {
+				writes++
+				started <- struct{}{}
+				<-release
+				return os.Chtimes(path, atime, mtime)
+			},
+		})
+		openRecencyEntry(t, c, key)
+		<-started
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := c.Close(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close with canceled context = %v, want context.Canceled", err)
+		}
+		// A newer same-key touch after the close boundary still updates in-memory
+		// LRU, but must not extend the set of durable work being drained.
+		now = now.Add(time.Minute)
+		openRecencyEntry(t, c, key)
+		close(release)
+		if err := closeRecencyCache(t, c); err != nil {
+			t.Fatalf("second Close after worker release: %v", err)
+		}
+		if writes != 1 {
+			t.Fatalf("durable writes admitted after Close = %d, want 1 pre-Close write", writes)
+		}
+	})
+
+	t.Run("closes recency admission even when convergence wait is canceled", func(t *testing.T) {
+		dir := t.TempDir()
+		key := strings.Repeat("1", 64)
+		seedRecencyFile(t, dir, key, []byte("body"), time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC))
+		permits := make(chan struct{})
+		c, err := NewDiskCache(dir, 100, DiskCacheOptions{
+			MaxEntries:         1,
+			DurableRecency:     true,
+			convergencePermits: permits,
+		})
+		if err != nil {
+			t.Fatalf("NewDiskCache: %v", err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := c.Close(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close with canceled context = %v, want context.Canceled", err)
+		}
+		c.recency.mu.Lock()
+		closed := c.recency.closed
+		c.recency.mu.Unlock()
+		if !closed {
+			t.Fatal("recency writer still accepted work after Close canceled its convergence wait")
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := c.Close(ctx); err != nil {
+			t.Fatalf("second Close: %v", err)
+		}
+	})
+}

--- a/cmd/cache-proxy/startup_scan.go
+++ b/cmd/cache-proxy/startup_scan.go
@@ -1,0 +1,347 @@
+package main
+
+import (
+	"bufio"
+	"container/heap"
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	startupPruneRecordBytes = sha256.Size + 8 + 8
+	startupScanChunkSize    = 1024
+)
+
+var (
+	cacheStartupUninspectableFilesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_uninspectable_files_total",
+		Help: "Valid-looking committed cache files preserved but excluded because metadata inspection failed",
+	})
+	cacheStartupDiscoveredOwnedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_startup_discovered_owned_bytes",
+		Help: "Bytes in inspectable committed files discovered before hard-cap survivor pruning",
+	})
+	cacheStartupSelectedEntries = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_startup_selected_entries",
+		Help: "Inspectable committed entries selected for the bounded exact index during startup",
+	})
+	cacheStartupSelectedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_startup_selected_bytes",
+		Help: "Bytes in committed entries selected for the bounded exact index during startup",
+	})
+	cacheStartupHardPruneCandidatesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_hard_prune_candidates_total",
+		Help: "Committed files selected as non-survivors above the hard exact-index guardrail",
+	})
+	cacheStartupHardPruneCompletedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_hard_prune_completed_total",
+		Help: "Hard-guardrail non-survivors successfully removed during startup",
+	})
+	cacheStartupHardPruneFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_hard_prune_failures_total",
+		Help: "Hard-guardrail non-survivors whose removal failed during startup",
+	})
+	cacheStartupHardPrunePreservedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_hard_prune_preserved_total",
+		Help: "Hard-guardrail non-survivors preserved because they disappeared or changed after enumeration",
+	})
+	cacheStartupCancellationsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cache_proxy_cache_startup_cancellations_total",
+		Help: "Startup scans or hard-prune passes canceled before completion",
+	})
+	cacheStartupPhase = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cache_proxy_cache_startup_phase",
+		Help: "Current startup cache phase; exactly one phase is 1 while startup is active",
+	}, []string{"phase"})
+)
+
+type startupEntryHeap []*cacheEntry
+
+func (h startupEntryHeap) Len() int      { return len(h) }
+func (h startupEntryHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h startupEntryHeap) Less(i, j int) bool {
+	return startupEntryOlder(*h[i], *h[j])
+}
+func (h *startupEntryHeap) Push(value any) { *h = append(*h, value.(*cacheEntry)) }
+func (h *startupEntryHeap) Pop() any {
+	old := *h
+	lastIndex := len(old) - 1
+	last := old[lastIndex]
+	old[lastIndex] = nil
+	*h = old[:len(old)-1]
+	return last
+}
+
+func startupEntryOlder(a, b cacheEntry) bool {
+	if a.lastAccess.Equal(b.lastAccess) {
+		return a.key < b.key
+	}
+	return a.lastAccess.Before(b.lastAccess)
+}
+
+func (c *DiskCache) scanExisting() (int64, error) {
+	return c.scanExistingContext(context.Background())
+}
+
+func (c *DiskCache) scanExistingContext(ctx context.Context) (ownedBytes int64, scanErr error) {
+	started := time.Now()
+	defer func() {
+		cacheStartupScanDuration.Observe(time.Since(started).Seconds())
+		setStartupPhase("")
+	}()
+	setStartupPhase("enumerate")
+	cacheStartupDiscoveredOwnedBytes.Set(0)
+	cacheStartupSelectedEntries.Set(0)
+	cacheStartupSelectedBytes.Set(0)
+
+	hardLimit := c.hardMaxEntries
+	if hardLimit <= 0 {
+		hardLimit = int(cacheMetadataEntryLimit)
+	}
+	openScanDirectory := c.openScanDirectory
+	if openScanDirectory == nil {
+		openScanDirectory = openDirectory
+	}
+	dir, err := openScanDirectory(c.dir)
+	if err != nil {
+		return 0, fmt.Errorf("open cache directory %s: %w", c.dir, err)
+	}
+	dirClosed := false
+	defer func() {
+		if !dirClosed {
+			if err := dir.Close(); err != nil && scanErr == nil {
+				scanErr = fmt.Errorf("close cache directory %s: %w", c.dir, err)
+			}
+		}
+	}()
+
+	found := make(startupEntryHeap, 0, min(hardLimit, 1024))
+	heapReady := false
+	var spool *os.File
+	var spoolWriter *bufio.Writer
+	var spoolPath string
+	defer func() {
+		if spool != nil {
+			_ = spool.Close()
+		}
+		if spoolPath != "" {
+			_ = os.Remove(spoolPath)
+		}
+	}()
+
+	writeLoser := func(entry *cacheEntry) error {
+		if spool == nil {
+			spool, err = os.CreateTemp(filepath.Join(c.dir, tmpSubdir), "hard-prune-*")
+			if err != nil {
+				return fmt.Errorf("create hard-prune spool: %w", err)
+			}
+			spoolPath = spool.Name()
+			spoolWriter = bufio.NewWriterSize(spool, 256<<10)
+		}
+		var record [startupPruneRecordBytes]byte
+		if _, err := hex.Decode(record[:sha256.Size], []byte(entry.key)); err != nil {
+			return fmt.Errorf("decode cache key for hard-prune spool: %w", err)
+		}
+		binary.BigEndian.PutUint64(record[sha256.Size:sha256.Size+8], uint64(entry.size))
+		binary.BigEndian.PutUint64(record[sha256.Size+8:], uint64(entry.lastAccess.UnixNano()))
+		if _, err := spoolWriter.Write(record[:]); err != nil {
+			return fmt.Errorf("write hard-prune spool: %w", err)
+		}
+		cacheStartupHardPruneCandidatesTotal.Inc()
+		return nil
+	}
+
+	for {
+		if err := startupContextError(ctx); err != nil {
+			return 0, err
+		}
+		entries, readErr := dir.ReadDir(startupScanChunkSize)
+		if err := startupContextError(ctx); err != nil {
+			return 0, err
+		}
+		for i, directoryEntry := range entries {
+			if i%256 == 0 {
+				if err := startupContextError(ctx); err != nil {
+					return 0, err
+				}
+			}
+			cacheStartupScanFilesInspectedTotal.Inc()
+			name := directoryEntry.Name()
+			if name == tmpSubdir {
+				continue
+			}
+			if !IsValidCacheKey(name) {
+				cacheStartupInvalidFilesTotal.Inc()
+				continue
+			}
+			info, infoErr := directoryEntry.Info()
+			if infoErr != nil {
+				cacheStartupUninspectableFilesTotal.Inc()
+				continue
+			}
+			if !info.Mode().IsRegular() {
+				cacheStartupInvalidFilesTotal.Inc()
+				continue
+			}
+			entry := &cacheEntry{
+				key:                  name,
+				size:                 info.Size(),
+				lastAccess:           info.ModTime(),
+				lastPersistedRecency: info.ModTime().Truncate(c.recencyInterval),
+			}
+			ownedBytes = saturatingAdd(ownedBytes, entry.size)
+			cacheStartupDiscoveredOwnedBytes.Set(float64(ownedBytes))
+			if len(found) < hardLimit {
+				found = append(found, entry)
+				continue
+			}
+			if !heapReady {
+				heap.Init(&found)
+				heapReady = true
+			}
+			if !startupEntryOlder(*found[0], *entry) {
+				if err := writeLoser(entry); err != nil {
+					return 0, err
+				}
+				continue
+			}
+			loser := heap.Pop(&found).(*cacheEntry)
+			if err := writeLoser(loser); err != nil {
+				return 0, err
+			}
+			heap.Push(&found, entry)
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return 0, fmt.Errorf("read cache directory %s: %w", c.dir, readErr)
+		}
+	}
+	if err := dir.Close(); err != nil {
+		return 0, fmt.Errorf("close cache directory %s: %w", c.dir, err)
+	}
+	dirClosed = true
+	if err := startupContextError(ctx); err != nil {
+		return 0, err
+	}
+
+	if spool != nil {
+		if err := spoolWriter.Flush(); err != nil {
+			return 0, fmt.Errorf("flush hard-prune spool: %w", err)
+		}
+		if err := spool.Close(); err != nil {
+			return 0, fmt.Errorf("close hard-prune spool: %w", err)
+		}
+		spool = nil
+		if err := c.pruneStartupSpool(ctx, spoolPath); err != nil {
+			return 0, err
+		}
+	}
+	if err := startupContextError(ctx); err != nil {
+		return 0, err
+	}
+
+	setStartupPhase("index")
+	if !heapReady {
+		heap.Init(&found)
+	}
+	selectedCount := len(found)
+	selectedBytes := int64(0)
+	c.mu.Lock()
+	c.index = make(map[string]*list.Element, selectedCount)
+	for i := 0; found.Len() > 0; i++ {
+		if i%256 == 0 {
+			if err := startupContextError(ctx); err != nil {
+				c.mu.Unlock()
+				return 0, err
+			}
+		}
+		entry := heap.Pop(&found).(*cacheEntry)
+		c.index[entry.key] = c.order.PushBack(entry)
+		c.currentSize = saturatingAdd(c.currentSize, entry.size)
+		selectedBytes = saturatingAdd(selectedBytes, entry.size)
+		if c.summary != nil {
+			c.summary.Add(entry.key)
+		}
+	}
+	c.updateStateMetricsLocked()
+	c.mu.Unlock()
+	cacheStartupSelectedEntries.Set(float64(selectedCount))
+	cacheStartupSelectedBytes.Set(float64(selectedBytes))
+	return selectedBytes, nil
+}
+
+func (c *DiskCache) pruneStartupSpool(ctx context.Context, path string) error {
+	setStartupPhase("hard_prune")
+	spool, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open hard-prune spool: %w", err)
+	}
+	defer func() { _ = spool.Close() }()
+	var record [startupPruneRecordBytes]byte
+	for {
+		if err := startupContextError(ctx); err != nil {
+			return err
+		}
+		_, err := io.ReadFull(spool, record[:])
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read hard-prune spool: %w", err)
+		}
+		key := hex.EncodeToString(record[:sha256.Size])
+		size := int64(binary.BigEndian.Uint64(record[sha256.Size : sha256.Size+8]))
+		mtime := int64(binary.BigEndian.Uint64(record[sha256.Size+8:]))
+		entryPath := filepath.Join(c.dir, key)
+		info, statErr := os.Lstat(entryPath)
+		if statErr != nil {
+			cacheStartupHardPrunePreservedTotal.Inc()
+			continue
+		}
+		if !info.Mode().IsRegular() || info.Size() != size || info.ModTime().UnixNano() != mtime {
+			cacheStartupHardPrunePreservedTotal.Inc()
+			continue
+		}
+		deleted, err := c.removeCommittedFile(entryPath, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+		if err != nil {
+			cacheStartupHardPruneFailuresTotal.Inc()
+			return fmt.Errorf("remove hard-prune candidate %s: %w", key, err)
+		}
+		if !deleted {
+			cacheStartupHardPrunePreservedTotal.Inc()
+			continue
+		}
+		cacheStartupHardPruneCompletedTotal.Inc()
+	}
+}
+
+func startupContextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		cacheStartupCancellationsTotal.Inc()
+		return err
+	}
+	return nil
+}
+
+func setStartupPhase(active string) {
+	for _, phase := range []string{"enumerate", "hard_prune", "index"} {
+		if phase == active {
+			cacheStartupPhase.WithLabelValues(phase).Set(1)
+		} else {
+			cacheStartupPhase.WithLabelValues(phase).Set(0)
+		}
+	}
+}

--- a/cmd/cache-proxy/startup_scan_test.go
+++ b/cmd/cache-proxy/startup_scan_test.go
@@ -392,6 +392,71 @@ func TestTemporaryCleanupChecksCancellationBetweenDirectoryChunks(t *testing.T) 
 	}
 }
 
+// oneBatchTemporaryDirectory models the unstable directory offset that can
+// result after entries returned by ReadDir are removed. Reusing the handle
+// appears exhausted, while reopening the directory exposes the next batch.
+type oneBatchTemporaryDirectory struct {
+	entries []os.DirEntry
+	read    bool
+}
+
+func (d *oneBatchTemporaryDirectory) ReadDir(int) ([]os.DirEntry, error) {
+	if d.read || len(d.entries) == 0 {
+		return nil, io.EOF
+	}
+	d.read = true
+	return d.entries, nil
+}
+
+func (d *oneBatchTemporaryDirectory) Close() error { return nil }
+
+func TestTemporaryCleanupReopensAfterDeletingFullChunk(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), tmpSubdir)
+	if err := os.Mkdir(tmpDir, 0o750); err != nil {
+		t.Fatalf("create cache temp directory: %v", err)
+	}
+	for i := 0; i < startupScanChunkSize+1; i++ {
+		path := filepath.Join(tmpDir, fmt.Sprintf("interrupted-%04d", i))
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("write temporary file %d: %v", i, err)
+		}
+	}
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("read temporary fixtures: %v", err)
+	}
+
+	opens := 0
+	open := func(path string) (cacheDirectory, error) {
+		if path != tmpDir {
+			return nil, fmt.Errorf("unexpected directory open %q", path)
+		}
+		opens++
+		switch opens {
+		case 1:
+			return &oneBatchTemporaryDirectory{entries: entries[:startupScanChunkSize]}, nil
+		case 2:
+			return &oneBatchTemporaryDirectory{entries: entries[startupScanChunkSize:]}, nil
+		default:
+			return &oneBatchTemporaryDirectory{}, nil
+		}
+	}
+
+	removed, err := removeTemporaryTreeWith(context.Background(), tmpDir, open)
+	if err != nil {
+		t.Fatalf("cleanup with invalidated directory offset: %v (directory opens: %d)", err, opens)
+	}
+	if removed != len(entries) {
+		t.Fatalf("temporary files removed = %d, want %d", removed, len(entries))
+	}
+	if opens < 2 {
+		t.Fatalf("temporary cleanup opened directory %d time, want a reopen after the first full batch", opens)
+	}
+	if _, err := os.Stat(tmpDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary directory remains after cleanup: %v", err)
+	}
+}
+
 func TestStartupLargeSparseDirectoryKeepsBoundedNewestSet(t *testing.T) {
 	if testing.Short() {
 		t.Skip("large sparse-directory restart coverage")

--- a/cmd/cache-proxy/startup_scan_test.go
+++ b/cmd/cache-proxy/startup_scan_test.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+// startupInfoErrorEntry models a valid cache-key directory entry whose
+// metadata cannot be inspected. The startup scanner must preserve it on disk
+// while treating its bytes as external/unowned for this process lifetime.
+type startupInfoErrorEntry struct {
+	os.DirEntry
+	err error
+}
+
+func (e startupInfoErrorEntry) Info() (os.FileInfo, error) {
+	return nil, e.err
+}
+
+// cancelAfterReadDirectory makes cancellation deterministic: the scan receives
+// a real chunk, but its context is canceled before it may prune anything from
+// that chunk.
+type cancelAfterReadDirectory struct {
+	entries []os.DirEntry
+	cancel  context.CancelFunc
+	read    bool
+}
+
+func (d *cancelAfterReadDirectory) ReadDir(int) ([]os.DirEntry, error) {
+	if d.read {
+		return nil, io.EOF
+	}
+	d.read = true
+	d.cancel()
+	return d.entries, nil
+}
+
+func (d *cancelAfterReadDirectory) Close() error { return nil }
+
+type cancelOnCloseDirectory struct {
+	entries []os.DirEntry
+	cancel  context.CancelFunc
+	read    bool
+}
+
+func (d *cancelOnCloseDirectory) ReadDir(int) ([]os.DirEntry, error) {
+	if d.read {
+		return nil, io.EOF
+	}
+	d.read = true
+	return d.entries, io.EOF
+}
+
+func (d *cancelOnCloseDirectory) Close() error {
+	d.cancel()
+	return nil
+}
+
+func writeStartupScanEntry(t *testing.T, dir, key string, body []byte, mtime time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, key)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write startup entry %s: %v", key, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("set startup entry mtime %s: %v", key, err)
+	}
+}
+
+func assertStartupFilesExist(t *testing.T, dir string, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, err := os.Stat(filepath.Join(dir, key)); err != nil {
+			t.Errorf("startup entry %s was changed or removed: %v", key, err)
+		}
+	}
+}
+
+func testStartupCapacityProvider(string) (diskSpace, error) {
+	return diskSpace{TotalBytes: 1 << 30, FreeBytes: 1 << 30}, nil
+}
+
+func TestStartupScanLoadsAllEntriesWithinHardLimitAboveSoftTarget(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	keys := []string{strings.Repeat("a", 64), strings.Repeat("b", 64), strings.Repeat("c", 64)}
+	for i, key := range keys {
+		writeStartupScanEntry(t, dir, key, []byte{byte(i)}, now.Add(time.Duration(i)*time.Second))
+	}
+
+	removals := 0
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       2, // PR2 compatibility soft target.
+		hardMaxEntries:   4, // Test-only small form of the fixed 10M guardrail.
+		CapacityProvider: testStartupCapacityProvider,
+		removeFile: func(path string) error {
+			removals++
+			return os.Remove(path)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache: %v", err)
+	}
+	if got := c.order.Len(); got != len(keys) {
+		t.Fatalf("startup loaded %d entries, want all %d entries below the hard guardrail", got, len(keys))
+	}
+	for _, key := range keys {
+		if !c.Has(key) {
+			t.Errorf("startup omitted within-hard-limit key %s", key)
+		}
+	}
+	if removals != 0 {
+		t.Fatalf("startup performed %d soft-target deletions, want 0", removals)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 0 {
+		t.Fatalf("aggregate startup evictions = %v, want 0", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry) - beforeLabel; got != 0 {
+		t.Fatalf("labeled startup entry evictions = %v, want 0", got)
+	}
+	assertStartupFilesExist(t, dir, keys...)
+}
+
+func TestStartupScanPreservesUninspectableValidEntryAndContinues(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("d", 64)
+	body := []byte("preserve-me")
+	writeStartupScanEntry(t, dir, key, body, time.Now())
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("fixture entries = %d, want 1", len(entries))
+	}
+	infoErr := errors.New("forced entry metadata failure")
+	entries[0] = startupInfoErrorEntry{DirEntry: entries[0], err: infoErr}
+
+	removals := 0
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       1,
+		hardMaxEntries:   4,
+		CapacityProvider: testStartupCapacityProvider,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
+		},
+		removeFile: func(path string) error {
+			removals++
+			return os.Remove(path)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache rejected one uninspectable entry: %v", err)
+	}
+	if c.Has(key) || c.order.Len() != 0 || c.currentSize != 0 {
+		t.Fatalf("uninspectable entry entered cache ownership: has=%t entries=%d bytes=%d", c.Has(key), c.order.Len(), c.currentSize)
+	}
+	if removals != 0 {
+		t.Fatalf("startup attempted %d removals for an uninspectable entry, want 0", removals)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, key))
+	if err != nil {
+		t.Fatalf("uninspectable committed entry was not preserved: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("uninspectable entry body = %q, want %q", got, body)
+	}
+}
+
+func TestStartupHardLimitKeepsDeterministicNewestEntriesAndMetersPruning(t *testing.T) {
+	dir := t.TempDir()
+	old := strings.Repeat("a", 64)
+	tiedLow := strings.Repeat("b", 64)
+	tiedMid := strings.Repeat("c", 64)
+	tiedHigh := strings.Repeat("d", 64)
+	base := time.Now().Add(-time.Hour)
+	writeStartupScanEntry(t, dir, old, []byte("old"), base)
+	for _, key := range []string{tiedLow, tiedMid, tiedHigh} {
+		writeStartupScanEntry(t, dir, key, []byte(key[:1]), base.Add(time.Minute))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removals := 0
+	beforeAggregate := counterValue(t, cacheEvictionsTotal)
+	beforeLabel := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry)
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       4,
+		hardMaxEntries:   2,
+		CapacityProvider: testStartupCapacityProvider,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &scriptedCacheDirectory{entries: entries, err: io.EOF}, nil
+		},
+		removeFile: func(path string) error {
+			removals++
+			return os.Remove(path)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDiskCache: %v", err)
+	}
+	// Equal persisted mtimes use the key as a stable secondary rank. The two
+	// lexicographically greatest tied keys are therefore the exact survivors.
+	if c.order.Len() != 2 || !c.Has(tiedMid) || !c.Has(tiedHigh) || c.Has(old) || c.Has(tiedLow) {
+		t.Fatalf("hard-limit survivors old/low/mid/high = %t/%t/%t/%t, want false/false/true/true",
+			c.Has(old), c.Has(tiedLow), c.Has(tiedMid), c.Has(tiedHigh))
+	}
+	if removals != 2 {
+		t.Fatalf("hard-limit removal calls = %d, want 2", removals)
+	}
+	if got := counterValue(t, cacheEvictionsTotal) - beforeAggregate; got != 2 {
+		t.Fatalf("aggregate hard-limit evictions = %v, want 2", got)
+	}
+	if got := counterVecValue(t, cacheEvictionsByPhaseReasonTotal, cacheEvictionPhaseStartup, cacheEvictionReasonEntry) - beforeLabel; got != 2 {
+		t.Fatalf("labeled hard-limit evictions = %v, want 2", got)
+	}
+	assertStartupFilesExist(t, dir, tiedMid, tiedHigh)
+}
+
+func TestStartupLateScanErrorDoesNotDeleteCommittedEntries(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)}
+	for i, key := range keys {
+		writeStartupScanEntry(t, dir, key, []byte("x"), time.Now().Add(time.Duration(i)*time.Second))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lateErr := errors.New("forced late startup enumeration failure")
+	removals := 0
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       1,
+		hardMaxEntries:   2,
+		CapacityProvider: testStartupCapacityProvider,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &scriptedCacheDirectory{entries: entries, err: lateErr}, nil
+		},
+		removeFile: func(path string) error {
+			removals++
+			return os.Remove(path)
+		},
+	})
+	if c != nil {
+		t.Fatal("NewDiskCache returned a partial cache after a late scan error")
+	}
+	if !errors.Is(err, lateErr) {
+		t.Fatalf("NewDiskCache error = %v, want wrapped late scan error", err)
+	}
+	if removals != 0 {
+		t.Fatalf("late scan error followed %d committed removals, want 0", removals)
+	}
+	assertStartupFilesExist(t, dir, keys...)
+}
+
+func TestStartupCancellationDoesNotDeleteCommittedEntries(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("4", 64), strings.Repeat("5", 64), strings.Repeat("6", 64)}
+	for i, key := range keys {
+		writeStartupScanEntry(t, dir, key, []byte("x"), time.Now().Add(time.Duration(i)*time.Second))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	removals := 0
+	c, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       1,
+		hardMaxEntries:   2,
+		startupContext:   ctx,
+		CapacityProvider: testStartupCapacityProvider,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &cancelAfterReadDirectory{entries: entries, cancel: cancel}, nil
+		},
+		removeFile: func(path string) error {
+			removals++
+			return os.Remove(path)
+		},
+	})
+	if c != nil {
+		t.Fatal("NewDiskCache returned a partial cache after startup cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("NewDiskCache error = %v, want context.Canceled", err)
+	}
+	if removals != 0 {
+		t.Fatalf("startup cancellation followed %d committed removals, want 0", removals)
+	}
+	assertStartupFilesExist(t, dir, keys...)
+}
+
+func TestStartupCancellationAfterEnumerationStopsIndexBuild(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{strings.Repeat("7", 64), strings.Repeat("8", 64)}
+	for i, key := range keys {
+		writeStartupScanEntry(t, dir, key, []byte("x"), time.Now().Add(time.Duration(i)*time.Second))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       2,
+		hardMaxEntries:   2,
+		startupContext:   ctx,
+		CapacityProvider: testStartupCapacityProvider,
+		openScanDirectory: func(string) (cacheDirectory, error) {
+			return &cancelOnCloseDirectory{entries: entries, cancel: cancel}, nil
+		},
+	})
+	if cache != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("startup after post-enumeration cancellation: cache=%v err=%v, want nil/context.Canceled", cache, err)
+	}
+	assertStartupFilesExist(t, dir, keys...)
+}
+
+func TestStartupPreCanceledContextLeavesTemporarySentinelUntouched(t *testing.T) {
+	dir := t.TempDir()
+	tmpDir := filepath.Join(dir, tmpSubdir)
+	if err := os.Mkdir(tmpDir, 0o750); err != nil {
+		t.Fatalf("create cache temp directory: %v", err)
+	}
+	sentinel := filepath.Join(tmpDir, "interrupted-write")
+	if err := os.WriteFile(sentinel, []byte("do not clean after cancellation"), 0o600); err != nil {
+		t.Fatalf("write temporary sentinel: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cache, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		startupContext: ctx,
+	})
+	if cache != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled startup: cache=%v err=%v, want nil/context.Canceled", cache, err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("pre-canceled startup cleaned temporary sentinel: %v", err)
+	}
+}
+
+type cancelingTemporaryDirectory struct {
+	cacheDirectory
+	cancel context.CancelFunc
+}
+
+func (d *cancelingTemporaryDirectory) ReadDir(count int) ([]os.DirEntry, error) {
+	entries, err := d.cacheDirectory.ReadDir(count)
+	d.cancel()
+	return entries, err
+}
+
+func TestTemporaryCleanupChecksCancellationBetweenDirectoryChunks(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), tmpSubdir)
+	if err := os.Mkdir(tmpDir, 0o750); err != nil {
+		t.Fatalf("create cache temp directory: %v", err)
+	}
+	sentinel := filepath.Join(tmpDir, "interrupted-write")
+	if err := os.WriteFile(sentinel, []byte("keep after cancellation"), 0o600); err != nil {
+		t.Fatalf("write temporary sentinel: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	open := func(path string) (cacheDirectory, error) {
+		dir, err := openDirectory(path)
+		if err != nil {
+			return nil, err
+		}
+		return &cancelingTemporaryDirectory{cacheDirectory: dir, cancel: cancel}, nil
+	}
+	removed, err := removeTemporaryTreeWith(ctx, tmpDir, open)
+	if removed != 0 || !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled chunked cleanup = removed:%d err:%v, want 0/context.Canceled", removed, err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("chunk cancellation removed temporary sentinel: %v", err)
+	}
+}
+
+func TestStartupLargeSparseDirectoryKeepsBoundedNewestSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("large sparse-directory restart coverage")
+	}
+	const (
+		totalEntries = 5_000
+		hardLimit    = 2_048
+		logicalSize  = int64(1 << 20)
+	)
+	dir := t.TempDir()
+	base := time.Now().Add(-24 * time.Hour)
+	for i := range totalEntries {
+		key := fmt.Sprintf("%064x", i)
+		path := filepath.Join(dir, key)
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			t.Fatalf("create sparse entry %d: %v", i, err)
+		}
+		if err := file.Truncate(logicalSize); err != nil {
+			_ = file.Close()
+			t.Fatalf("truncate sparse entry %d: %v", i, err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("close sparse entry %d: %v", i, err)
+		}
+		when := base.Add(time.Duration(i) * time.Second)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatalf("stamp sparse entry %d: %v", i, err)
+		}
+	}
+
+	cache, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		MaxEntries:       hardLimit,
+		hardMaxEntries:   hardLimit,
+		CapacityProvider: testStartupCapacityProvider,
+	})
+	if err != nil {
+		t.Fatalf("restart large sparse cache: %v", err)
+	}
+	if got := cacheEntryCount(cache); got != hardLimit {
+		t.Fatalf("large sparse restart selected %d entries, want hard limit %d", got, hardLimit)
+	}
+	if cache.currentSize != int64(hardLimit)*logicalSize {
+		t.Fatalf("large sparse selected bytes = %d, want %d", cache.currentSize, int64(hardLimit)*logicalSize)
+	}
+	oldestSurvivor := totalEntries - hardLimit
+	if cache.Has(fmt.Sprintf("%064x", oldestSurvivor-1)) {
+		t.Fatal("large sparse restart retained an entry below the newest hard-limit window")
+	}
+	if !cache.Has(fmt.Sprintf("%064x", oldestSurvivor)) || !cache.Has(fmt.Sprintf("%064x", totalEntries-1)) {
+		t.Fatal("large sparse restart omitted expected newest survivors")
+	}
+}
+
+func TestStartupTenMillionGuardrailEstimateFitsEightGiBEnvelope(t *testing.T) {
+	// The final metric estimate includes the key, entry object, list node, and
+	// map overhead. Startup adds only the bounded survivor pointer heap because
+	// those same entry objects are transferred into the final LRU.
+	peakEstimate := int64(cacheMetadataEntryLimit) * (int64(estimatedExactIndexBytesPerEntry) + int64(unsafe.Sizeof((*cacheEntry)(nil))))
+	const memoryEnvelope = int64(8 << 30)
+	if peakEstimate >= memoryEnvelope {
+		t.Fatalf("10M startup metadata estimate = %d, must remain below 8 GiB", peakEstimate)
+	}
+	if size := unsafe.Sizeof(cacheEntry{}); size > 80 {
+		t.Fatalf("cacheEntry grew to %d bytes; revisit the 10M startup memory envelope", size)
+	}
+}

--- a/docs/design/cache-proxy-pulled-summary-lookup.md
+++ b/docs/design/cache-proxy-pulled-summary-lookup.md
@@ -26,7 +26,7 @@ origin fills. Summaries contain only opaque cache-locator membership hints.
 | Setting | Default | Bound |
 | --- | --- | --- |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` or `summary`; unknown values fail startup. |
-| `CACHE_MAX_ENTRIES` | `1000000` | Configured legacy admission limit and strict maximum tracked entries after each final commit. |
+| `CACHE_MAX_ENTRIES` | `1000000` | Configured compatibility admission/convergence target. Startup may retain inspectable entries above it, up to the fixed 10,000,000-entry metadata guardrail. |
 | `CACHE_MAX_PERCENT` | `80` | Percentage-of-total-disk target for committed cache bytes. The active capacity also accounts for reclaimable cache-owned files while retaining a 5%-of-total-disk reserve. |
 | `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Local counting Bloom, snapshot and pull reserve, and retained remote Bloom bits. |
 | `CACHE_PEER_MAX_PROBES_PER_REQUEST` | `5` | Maximum summary-mode `/cache/has` confirmations per client request, shared across block misses. `CACHE_PEER_MAX_PROBES` is a deprecated alias. |
@@ -35,11 +35,13 @@ origin fills. Summaries contain only opaque cache-locator membership hints.
 Body copies remain concurrent: each fill streams into a temporary file without
 holding the cache-index lock. The short final commit is serialized across the
 rename, LRU eviction, exact-index and byte accounting, and counting-Bloom
-update. A completed commit therefore cannot exceed `CACHE_MAX_ENTRIES`.
-Tracked bytes are evicted to the current cache byte capacity before the commit
-returns, except that a single entry larger than the capacity is retained rather
-than silently discarded. Concurrent temporary files consume real disk but are
-not yet tracked cache entries.
+update. At or above the soft entry target, a new-key commit performs one LRU
+swap and cannot increase the tracked entry count. Byte capacity remains strict:
+a commit removes enough older entries to preserve the reserve, except for the
+existing compatibility behavior that retains one object larger than the
+ceiling after draining other entries. A rate-limited
+background worker handles pre-existing restart and capacity overage. Concurrent
+temporary files consume real disk but are not yet tracked cache entries.
 
 ### Disk capacity and startup ownership
 
@@ -59,19 +61,44 @@ temporary files are removed before the startup scan. Invalid or unrelated
 root-directory entries remain on disk and count only through reduced free
 space.
 
-Startup scans existing entries before applying byte capacity, retains the
-newest entries within the configured legacy entry limit, and then evicts
-least-recently-used entries until both limits are satisfied. If temporary-file
-cleanup, filesystem sampling, directory scanning, entry inspection, or
-required startup eviction fails, initialization fails and the proxy does not
-begin serving with an unknown or unenforceable disk budget.
+Startup scans in 1,024-entry chunks and computes inspectable owned bytes before
+capacity decisions. The configured entry target is soft: every inspectable
+entry is loaded when the directory remains within the fixed 10,000,000-entry
+hard guardrail. Any soft entry or byte overage converges after startup through
+one background deletion at a time, capped at 1,000 successful deletions per
+second. A valid-looking file whose metadata cannot be inspected is preserved,
+excluded from the index and owned-byte total, and therefore remains external
+disk usage.
 
-Capacity is refreshed every minute. A lower ceiling is applied immediately and
-least-recently-used entries are evicted as needed to restore the reserve. An
+Only a directory above the hard guardrail selects startup survivors. The
+scanner retains the newest bounded set by persisted coarse access mtime and
+opaque-key tie-break, while spooling known non-survivors under `.tmp`. It does
+not delete committed files until enumeration and spool closure both succeed.
+The exceptional prune is sequential, observable, cancellation-aware, and uses
+the centralized eviction metrics. If temporary cleanup, filesystem sampling,
+directory enumeration, or a required hard-prune unlink fails, initialization
+fails rather than serving from a partial or policy-violating index. An
+already-absent unlink race is benign and is not an eviction.
+
+Capacity is refreshed every minute. A lower ceiling is published immediately
+and the convergence worker evicts least-recently-used entries to restore the reserve. An
 increase requires two consecutive healthy samples before it is applied, which
 prevents short-lived external disk usage from flapping the ceiling. Runtime
 deletion failures leave the entry indexed, are not counted as successful
-evictions, and are retried during later over-limit refreshes.
+evictions, and are retried with backoff while the cache remains over target.
+
+### Durable access recency
+
+Successful body reads and explicit peer accesses always move the in-memory LRU
+synchronously. Once per minute bucket per key, a nonblocking asynchronous path
+persists the access time in that committed file's mtime. The work queue holds at
+most 65,536 waiting opaque keys, one metadata worker is active, and repeated
+touches coalesce. Queue overflow or metadata failure degrades only restart
+ordering. File write mtime is the fallback when a key has no persisted read
+history; source URLs and request metadata are never written. Accepted work
+drains within the process shutdown deadline. Cache shutdown is terminal for
+mutations but does not invalidate existing readers, so replacement commits
+cannot race a recency writer that has stopped accepting work.
 
 The process-level backstop remains the pod memory limit and Go memory policy.
 The settings above bound the largest cache-proxy-owned contributors, but do not

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -238,13 +238,28 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_hits_total` | Counter | None | Worker-facing cacheable requests served entirely from data already present on local NVMe. Peer API reads and requests that first fetch any block from a peer are excluded. |
 | `cache_proxy_misses_total` | Counter | None | Worker-facing cacheable requests that require a peer or origin fill before they can be served. |
 | `cache_proxy_bytes_served_total` | Counter | `source` | Directional byte mix by `local`, `peer`, or `s3`. Block mode counts assembled response bytes under the slowest source used; the legacy exact-range path counts the local read or deduplicated fill once, so this is not an exact client-egress counter. |
-| `cache_proxy_cache_entries` / `cache_proxy_cache_entry_limit` | Gauge | None | Current exact-index entries and the configured legacy admission limit (`CACHE_MAX_ENTRIES`, default 1,000,000). |
+| `cache_proxy_cache_entries` / `cache_proxy_cache_entry_limit` | Gauge | None | Current exact-index entries and the configured compatibility soft target (`CACHE_MAX_ENTRIES`, default 1,000,000). |
+| `cache_proxy_cache_hard_entry_limit` | Gauge | None | Fixed exact-index startup/admission safety guardrail (10,000,000). Configured soft targets are clamped to it. |
+| `cache_proxy_cache_exact_index_estimated_bytes` | Gauge | None | Conservative exact-index metadata estimate (256 bytes per tracked entry); use process/cgroup metrics for authoritative memory usage. |
 | `cache_proxy_cache_owned_bytes` / `cache_proxy_cache_capacity_bytes` | Gauge | None | Bytes in committed cache entries and the current capacity ceiling. Committed bytes are reclaimable in capacity calculation after restart. |
 | `cache_proxy_cache_disk_target_bytes` / `cache_proxy_cache_disk_reserve_bytes` | Gauge | None | The configured percentage-of-disk target and the fixed 5%-of-total-disk reserve. |
 | `cache_proxy_cache_entry_limit_reason` | Gauge | `reason` | Future derived-entry bottleneck. Exactly one `reason` (`disk` or `metadata`) is 1; this anticipates the later derived-entry rollout without replacing the configured legacy admission limit. |
 | `cache_proxy_cache_startup_scan_duration_seconds` | Histogram | None | Cache directory startup-scan duration. |
 | `cache_proxy_cache_startup_scan_files_inspected_total` / `cache_proxy_cache_startup_invalid_files_total` | Counter | None | Root-directory entries scanned and entries excluded from committed cache ownership because they are invalid or unrelated. |
+| `cache_proxy_cache_startup_uninspectable_files_total` | Counter | None | Valid-looking files preserved but excluded from ownership because their metadata could not be inspected. |
+| `cache_proxy_cache_startup_discovered_owned_bytes` | Gauge | None | Inspectable committed bytes discovered before exceptional hard-guardrail survivor pruning. |
+| `cache_proxy_cache_startup_selected_entries` / `cache_proxy_cache_startup_selected_bytes` | Gauge | None | Entries and logical bytes selected for the bounded exact index during the most recent startup. |
+| `cache_proxy_cache_startup_phase` | Gauge | `phase` | Active bounded startup phase (`enumerate`, `hard_prune`, or `index`); all series are zero after startup. |
+| `cache_proxy_cache_startup_hard_prune_candidates_total` / `cache_proxy_cache_startup_hard_prune_completed_total` / `cache_proxy_cache_startup_hard_prune_failures_total` / `cache_proxy_cache_startup_hard_prune_preserved_total` | Counter | None | Exceptional above-10M survivor-selection progress and outcomes. Successful committed deletion remains authoritative in `cache_proxy_evictions_total`. |
+| `cache_proxy_cache_startup_cancellations_total` | Counter | None | Startup scans or hard-prune passes canceled by process shutdown. |
 | `cache_proxy_cache_temporary_files_removed_total` | Counter | None | Interrupted temporary files removed from `.tmp` on startup. They are never counted as cache evictions. |
+| `cache_proxy_cache_recency_touch_attempts_total` / `cache_proxy_cache_recency_touch_successes_total` / `cache_proxy_cache_recency_touch_failures_total` | Counter | None | Coarse durable-recency access attempts and filesystem persistence outcomes. Missing files raced by eviction are benign and excluded from failures. |
+| `cache_proxy_cache_recency_touch_coalesced_total` / `cache_proxy_cache_recency_touch_dropped_total` | Counter | None | Same-key or same-minute recency updates coalesced, and nonblocking updates dropped because bounded work was full or closed. |
+| `cache_proxy_cache_recency_queue_depth` | Gauge | None | Unique opaque keys with queued or in-flight recency persistence work. |
+| `cache_proxy_cache_recency_last_successful_persistence_timestamp_seconds` | Gauge | None | Unix timestamp of the last successful coarse mtime update. |
+| `cache_proxy_cache_convergence_active` | Gauge | None | `1` while tracked entries or bytes exceed the current soft target. |
+| `cache_proxy_cache_convergence_excess_entries` / `cache_proxy_cache_convergence_excess_bytes` | Gauge | None | Current overage awaiting bounded background convergence. |
+| `cache_proxy_cache_convergence_eviction_attempts_total` / `cache_proxy_cache_convergence_eviction_failures_total` | Counter | None | One-at-a-time background convergence deletion attempts and hard failures. Successful deletions also increment the aggregate and phase/reason eviction metrics. |
 | `cache_proxy_evictions_total` | Counter | None | Aggregate successful removal of committed cache entries under entry or byte pressure. |
 | `cache_proxy_evictions_by_phase_reason_total` | Counter | `phase`, `reason` | The same evictions by bounded `phase` (`startup`, `background`, or `request`) and pressure `reason` (`entry` or `byte`). Failed or already-absent files are not reported as successful evictions. |
 | `cache_proxy_peer_fetches_total` | Counter | None | Logical peer lookups in either mode. |


### PR DESCRIPTION
## Summary

- persist minute-bucket cache read recency through a bounded, nonblocking write-behind worker
- separate the configured soft entry target from the fixed 10M metadata guardrail and converge soft overage in the background
- scan startup directories in bounded chunks, retain the deterministic newest hard-limit survivors, and spool exceptional prune candidates without unbounded memory
- make startup cleanup, scanning, pruning, convergence, and shutdown cancellation-aware and observable
- document the startup, recency, capacity, metric, and rollout behavior

## Rollout

PR2 deliberately keeps CACHE_MAX_ENTRIES (default 1,000,000) as the active soft target. Deploy this release long enough to accumulate representative persisted recency before PR4 switches the target source to the derived disk capacity.

## Test plan

- just lint
- just test-cache-proxy
- go test -race ./cmd/cache-proxy -count=1
- just ci (all preceding targets passed; repository integration currently fails at unrelated TestCatalogPsqlCommands/psql_dn)