### PR TITLE
feat(cache-proxy): add versioned dynamic Bloom summaries

### DIFF
--- a/cmd/cache-proxy/README.md
+++ b/cmd/cache-proxy/README.md
@@ -14,14 +14,15 @@ available, and forwards cache misses to origin object storage.
 | `LISTEN_ADDR` | `:8080` | Forward proxy listener. |
 | `PEER_ADDR` | `:8081` | Peer cache API listener. |
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` preserves the existing fleet-wide `/cache/has` behavior. `summary` pulls Bloom-filter hints and uses them to eliminate definite-negative peers before bounded `/cache/has` confirmation; any other value causes startup to fail. |
-| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Total local Bloom-state budget: counting filter, snapshot and pull-work reserve, and a deterministic receiver-selected subset of remote peer summaries. Peers that do not fit remain uncovered. |
+| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | unset | Optional emergency ceiling for total Bloom state. The effective default is `min(1 GiB, 20% of GOMEMLIMIT)`; an explicit value can lower, but never raise, that derived ceiling. It includes the local counting filter, snapshot/pull reserves, and retained remote summaries. |
+| `CACHE_SUMMARY_PUBLISH_FORMAT` | `fixed` | `fixed` publishes the legacy v2 1M-entry layout during receiver rollout. `dynamic` atomically selects a disk-derived local counting layout and publishes self-describing v3 summaries. Unknown values fail startup. Change only after every receiver is dual-format compatible. |
 | `CACHE_PEER_MAX_PROBES_PER_REQUEST` | `5` | In summary mode, maximum parallel `/cache/has` confirmations per client request across all missing blocks. `CACHE_PEER_MAX_PROBES` is a deprecated alias. |
 | `CACHE_MAX_CONCURRENT_PEER_PROBES` | `64` | Per-pod non-blocking cap on active summary-mode `/cache/has` HTTP requests and sockets. It is not a process goroutine limit. When exhausted, confirmations are skipped and the request fetches origin. `CACHE_MAX_PEER_PROBES_IN_FLIGHT` is a deprecated alias. |
 | `CACHE_PROXY_ID` | pod name, node name, then hostname | Stable opaque receiver identity used for deterministic peer-summary selection; it must not be a customer or object identifier. |
 | `HEALTH_ADDR` | `:8082` | Health and Prometheus metrics listener. |
 | `CACHE_HOST_SUFFIXES` | empty | Empty means all `GET` hosts are cacheable. Otherwise, cache only hosts containing one of the comma-separated suffixes. |
 | `CACHE_BLOCK_MODE` | `off` | `on` enables block-aligned caching; any other value (including unset) keeps the legacy exact-range path. See [Block-aligned mode](#block-aligned-mode). |
-| `CACHE_BLOCK_SIZE_BYTES` | `8388608` (8 MiB) | Fixed block size for block-aligned mode. Ignored when block mode is off. |
+| `CACHE_BLOCK_SIZE_BYTES` | `8388608` (8 MiB) | Fixed block size for block-aligned mode. When block mode is off, it remains the planning estimate used to derive dynamic Bloom capacity. |
 | `CACHE_BLOCK_MAX_SPAN_BLOCKS` | `8` | Max blocks coalesced into one origin range fetch. Ignored when block mode is off. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `DUCKGRES_TRACE_ENDPOINT` | empty | OTLP/HTTP trace endpoint. Unset → tracing is a no-op. |
 | `OTEL_EXPORTER_OTLP_TRACES_PATH` | empty | Overrides the OTLP path (e.g. VictoriaTraces' `/insert/opentelemetry/v1/traces`). Mirrors the main duckgres binary. |
@@ -109,11 +110,22 @@ later rollout that can grow caches beyond the compatibility soft target.
 
 Set `CACHE_PEER_LOOKUP_MODE=summary` only after deploying an image containing
 the summary endpoint to every cache-proxy pod. Each proxy incrementally tracks
-its local entries in a fixed counting Bloom filter and periodically exposes an
-immutable snapshot through `GET /cache/summary`. Receivers pull only the
-deterministic peer subset that fits `CACHE_SUMMARY_MEMORY_LIMIT_BYTES`.
+its local entries in a counting Bloom filter and periodically exposes an
+immutable snapshot through `GET /cache/summary`. Receivers accept both the
+legacy fixed v2 wire representation and the self-describing dynamic v3
+representation. Before pulling, each receiver chooses a deterministic peer
+prefix charged conservatively at the largest accepted v3 bitset; actual
+decoded bitsets are admitted against the remaining memory budget.
 Probe-mode pods do not build or serve summaries, so a canary starts with
 partial coverage and uses the bounded fallback while snapshots converge.
+
+The publisher remains `fixed` by default. First deploy dual-format receivers
+everywhere with that default. After the cache-proxy memory/GOMEMLIMIT rollout
+is complete, set `CACHE_SUMMARY_PUBLISH_FORMAT=dynamic`; the same setting
+selects the disk-derived local counting layout and v3 publisher together, so a
+dynamic index can never be mislabeled as v2. A restart rebuilds the selected
+layout from the bounded exact cache index without deleting cache bodies.
+Rollback the publisher by restoring `fixed`; receivers remain dual-format.
 
 Bloom filters are used only to eliminate definite negatives. Bloom-positive
 and not-yet-covered peers remain candidates and must pass an exact, bounded
@@ -130,9 +142,10 @@ cold-key fleet-wide deduplication for bounded request-time work.
 
 Roll out in non-production, monitor summary coverage and memory, confirmation
 amplification, confirmed GET usefulness, and origin latency/bytes, then enable
-gradually. Roll back by restoring `CACHE_PEER_LOOKUP_MODE=probe`; cache contents
-do not need deletion. The authoritative protocol, sizing model, failure table,
-rollout procedure, and runbook are in
+gradually. Roll back lookup independently by restoring
+`CACHE_PEER_LOOKUP_MODE=probe`; cache contents do not need deletion. The
+authoritative protocol, sizing model, failure table, rollout procedure, and
+runbook are in
 [the pulled-summary design](../../docs/design/cache-proxy-pulled-summary-lookup.md).
 
 In `probe` mode, when several nodes want the same key at the same moment, the

--- a/cmd/cache-proxy/cache.go
+++ b/cmd/cache-proxy/cache.go
@@ -265,9 +265,6 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 		if option.MaxEntries > 0 {
 			dc.maxEntries = option.MaxEntries
 		}
-		if option.IncrementalSummary {
-			dc.summary = newSummaryIndex()
-		}
 		if option.BlockSizeBytes > 0 {
 			dc.blockSize = option.BlockSizeBytes
 		}
@@ -319,6 +316,38 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 	if err := dc.initializeCapacity(ownedBytes, startupSpace); err != nil {
 		return nil, fmt.Errorf("apply startup cache limits: %w", err)
 	}
+	if option.IncrementalSummary {
+		summaryCapacity := fixedSummaryBloomCapacity()
+		if option.DynamicSummary {
+			diskTarget := deriveDiskCapacity(startupSpace.TotalBytes, startupSpace.FreeBytes, ownedBytes, dc.maxPercent).DiskTargetBytes
+			summaryCapacity = deriveBloomCapacity(diskTarget, dc.blockSize)
+			if !validSummaryBloomCapacity(summaryCapacity) {
+				return nil, errors.New("derive dynamic Bloom capacity: cache disk target and block size must produce a non-zero layout")
+			}
+		}
+		if option.SummaryMemoryLimitBytes > 0 {
+			if err := validateSummaryMemoryLimit(option.SummaryMemoryLimitBytes, summaryCapacity); err != nil {
+				return nil, err
+			}
+		}
+		dc.summary = newSummaryIndexWithParams(summaryCapacity.BitCount, summaryCapacity.Hashes, int(summaryCapacity.DesignEntries))
+		// The disk target is not known until after the bounded startup scan and
+		// statfs sample. Rehash the already bounded exact index once into the
+		// selected fixed or dynamic layout so restart snapshots cannot omit keys.
+		rehashed := 0
+		for element := dc.order.Front(); element != nil; element = element.Next() {
+			if rehashed%startupScanChunkSize == 0 {
+				if option.summaryRehashHook != nil {
+					option.summaryRehashHook(rehashed)
+				}
+				if err := startupContext.Err(); err != nil {
+					return nil, fmt.Errorf("rebuild startup Bloom summary: %w", err)
+				}
+			}
+			dc.summary.Add(element.Value.(*cacheEntry).key)
+			rehashed++
+		}
+	}
 
 	if option.DurableRecency {
 		dc.recency = newRecencyWriter(dir, option.recencyQueueCapacity, option.recencyWorkerCount, option.recencyChtimes)
@@ -337,23 +366,26 @@ func NewDiskCache(dir string, maxPercent int, options ...DiskCacheOptions) (*Dis
 }
 
 type DiskCacheOptions struct {
-	IncrementalSummary    bool
-	DurableRecency        bool
-	BackgroundConvergence bool
-	MaxEntries            int
-	BlockSizeBytes        int64
-	CapacityProvider      capacityProvider
-	openScanDirectory     openCacheDirectory
-	removeFile            func(string) error
-	hardMaxEntries        int
-	startupContext        context.Context
-	recencyNow            func() time.Time
-	recencyChtimes        recencyPersistence
-	recencyInterval       time.Duration
-	recencyQueueCapacity  int
-	recencyWorkerCount    int
-	convergencePermits    <-chan struct{}
-	convergenceInterval   time.Duration
+	IncrementalSummary      bool
+	DynamicSummary          bool
+	SummaryMemoryLimitBytes int64
+	DurableRecency          bool
+	BackgroundConvergence   bool
+	MaxEntries              int
+	BlockSizeBytes          int64
+	CapacityProvider        capacityProvider
+	openScanDirectory       openCacheDirectory
+	removeFile              func(string) error
+	hardMaxEntries          int
+	startupContext          context.Context
+	summaryRehashHook       func(int)
+	recencyNow              func() time.Time
+	recencyChtimes          recencyPersistence
+	recencyInterval         time.Duration
+	recencyQueueCapacity    int
+	recencyWorkerCount      int
+	convergencePermits      <-chan struct{}
+	convergenceInterval     time.Duration
 }
 
 // Close stops background convergence and drains accepted durable-recency work
@@ -626,6 +658,19 @@ func (c *DiskCache) SummarySnapshot() (items int, bits []byte, ok bool) {
 	}
 	items, bits = c.summary.Snapshot()
 	return items, bits, true
+}
+
+func (c *DiskCache) SummaryBloomCapacity() bloomCapacity {
+	if c.summary == nil {
+		return bloomCapacity{}
+	}
+	c.summary.mu.RLock()
+	defer c.summary.mu.RUnlock()
+	return bloomCapacity{
+		DesignEntries: int64(c.summary.targetItems),
+		BitCount:      c.summary.bitCount,
+		Hashes:        c.summary.hashes,
+	}
 }
 
 // Has returns true if the key is a tracked cache entry. It answers from the

--- a/cmd/cache-proxy/capacity.go
+++ b/cmd/cache-proxy/capacity.go
@@ -6,9 +6,9 @@ const (
 	cacheDiskReservePercent int64 = 5
 	cacheEntryFillPercent   int64 = 90
 
-	// cacheMetadataEntryLimit is the hard metadata guardrail for a future
-	// derived entry limit. PR 1 intentionally continues to use the existing
-	// one-million-entry compatibility limit for admission.
+	// cacheMetadataEntryLimit is the hard metadata guardrail for dynamic Bloom
+	// sizing and the future derived entry-admission limit. Entry admission still
+	// uses the one-million-entry compatibility target until PR 4.
 	cacheMetadataEntryLimit int64 = 10_000_000
 
 	maxSummaryMemoryBytes int64 = 1 << 30
@@ -24,8 +24,7 @@ type diskCapacity struct {
 	ByteCeiling      int64
 }
 
-// bloomCapacity describes the eventual dynamic Bloom-filter layout. The
-// current fixed layout remains in use until the wire-format migration.
+// bloomCapacity describes a validated fixed or dynamic Bloom-filter layout.
 type bloomCapacity struct {
 	DesignEntries int64
 	BitCount      uint64
@@ -80,9 +79,9 @@ func effectiveCacheEntryBytes(blockSizeBytes int64) int64 {
 	return effective
 }
 
-// deriveCacheEntryCeiling returns the future disk-derived metadata target,
-// capped by the hard guardrail. It does not change the active 1M admission cap
-// in this compatibility release.
+// deriveCacheEntryCeiling returns the disk-derived metadata target capped by
+// the hard guardrail. It sizes dynamic summaries now, but does not change the
+// active 1M entry-admission cap until PR 4.
 func deriveCacheEntryCeiling(cacheByteCeiling, blockSizeBytes int64) int64 {
 	effectiveEntryBytes := effectiveCacheEntryBytes(blockSizeBytes)
 	if cacheByteCeiling <= 0 || effectiveEntryBytes <= 0 {
@@ -91,9 +90,9 @@ func deriveCacheEntryCeiling(cacheByteCeiling, blockSizeBytes int64) int64 {
 	return min(ceilDiv(cacheByteCeiling, effectiveEntryBytes), cacheMetadataEntryLimit)
 }
 
-// deriveBloomCapacity sizes the future dynamic local Bloom filter from stable
-// disk target capacity, not currently-free capacity, so temporary external
-// disk pressure does not resize the filter.
+// deriveBloomCapacity sizes a dynamic local Bloom filter from stable disk
+// target capacity, not currently-free capacity, so temporary external disk
+// pressure does not resize the filter.
 func deriveBloomCapacity(diskTargetBytes, blockSizeBytes int64) bloomCapacity {
 	designEntries := deriveCacheEntryCeiling(diskTargetBytes, blockSizeBytes)
 	if designEntries == 0 {
@@ -103,8 +102,8 @@ func deriveBloomCapacity(diskTargetBytes, blockSizeBytes int64) bloomCapacity {
 	return bloomCapacity{DesignEntries: designEntries, BitCount: bits, Hashes: hashes}
 }
 
-// deriveSummaryMemoryLimit is the fixed platform guardrail for future dynamic
-// summary admission: no more than one GiB or twenty percent of GOMEMLIMIT.
+// deriveSummaryMemoryLimit is the fixed platform guardrail for summary
+// admission: no more than one GiB or twenty percent of GOMEMLIMIT.
 func deriveSummaryMemoryLimit(goMemLimitBytes int64) int64 {
 	if goMemLimitBytes <= 0 {
 		return 0

--- a/cmd/cache-proxy/capacity_test.go
+++ b/cmd/cache-proxy/capacity_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math"
 	"testing"
+	"time"
 )
 
 func TestDeriveDiskCapacityAccountsForOwnedCacheBytes(t *testing.T) {
@@ -125,5 +126,27 @@ func TestDerivedSummaryMemoryLimit(t *testing.T) {
 		if got := deriveSummaryMemoryLimit(tt.goMemLimit); got != tt.want {
 			t.Errorf("deriveSummaryMemoryLimit(%d) = %d, want %d", tt.goMemLimit, got, tt.want)
 		}
+	}
+}
+
+func TestMaximumDynamicBloomLayoutFitsSummaryWireCap(t *testing.T) {
+	capacity := maxAcceptedSummaryBloomCapacity()
+	if capacity.DesignEntries != cacheMetadataEntryLimit {
+		t.Fatalf("maximum dynamic design entries=%d, want %d", capacity.DesignEntries, cacheMetadataEntryLimit)
+	}
+	rawBytes := int(capacity.BitCount / 8)
+	if rawBytes < 11<<20 || rawBytes > 12<<20 {
+		t.Fatalf("maximum dynamic Bloom raw bytes=%d, want approximately 11-12 MiB", rawBytes)
+	}
+	summary, err := newDynamicCacheSummary(0, capacity, make([]byte, rawBytes), time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := summary.MarshalBinary()
+	if err != nil {
+		t.Fatalf("maximum dynamic summary exceeds wire cap: %v", err)
+	}
+	if len(body) > maxSummaryBodyBytes {
+		t.Fatalf("maximum dynamic body=%d exceeds cap=%d", len(body), maxSummaryBodyBytes)
 	}
 }

--- a/cmd/cache-proxy/main.go
+++ b/cmd/cache-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -100,7 +101,16 @@ func main() {
 		slog.Error("Invalid cache entry limit.", "error", err)
 		return
 	}
-	summaryMemoryLimit := envInt64("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", defaultSummaryMemoryLimitBytes)
+	summaryMemoryLimit, err := configuredSummaryMemoryLimit(debug.SetMemoryLimit(-1))
+	if err != nil {
+		slog.Error("Invalid summary memory limit.", "error", err)
+		return
+	}
+	summaryPublishFormat, err := parseSummaryPublishFormat(os.Getenv("CACHE_SUMMARY_PUBLISH_FORMAT"))
+	if err != nil {
+		slog.Error("Invalid summary publish format.", "error", err)
+		return
+	}
 	peerMaxProbes, usedDeprecatedPeerMaxProbes, err := positiveEnvIntWithDeprecatedAlias("CACHE_PEER_MAX_PROBES_PER_REQUEST", "CACHE_PEER_MAX_PROBES", defaultPeerMaxProbes)
 	if err != nil {
 		slog.Error("Invalid per-request peer probe limit.", "error", err)
@@ -128,7 +138,7 @@ func main() {
 	}
 	if lookupMode == peerLookupSummary {
 		summaryMemoryLimitBytes.Set(float64(summaryMemoryLimit))
-		if err := validateSummaryMemoryLimit(summaryMemoryLimit); err != nil {
+		if err := validateSummaryMemoryLimitBeforeCache(summaryPublishFormat, summaryMemoryLimit); err != nil {
 			slog.Error("Invalid summary memory limit.", "error", err)
 			return
 		}
@@ -157,6 +167,7 @@ func main() {
 		"max_percent", maxPercent,
 		"max_entries", maxEntries,
 		"summary_memory_limit", summaryMemoryLimit,
+		"summary_publish_format", summaryPublishFormat,
 		"peer_max_probes", peerMaxProbes,
 		"max_peer_probes_in_flight", maxPeerProbesInFlight,
 		"listen", listenAddr,
@@ -182,12 +193,14 @@ func main() {
 
 	// Initialize cache store
 	store, err := NewDiskCache(cacheDir, maxPercent, DiskCacheOptions{
-		IncrementalSummary:    lookupMode == peerLookupSummary && peerService != "",
-		DurableRecency:        true,
-		BackgroundConvergence: true,
-		MaxEntries:            maxEntries,
-		BlockSizeBytes:        blockSize,
-		startupContext:        rootCtx,
+		IncrementalSummary:      lookupMode == peerLookupSummary && peerService != "",
+		DynamicSummary:          summaryPublishFormat == summaryPublishDynamic,
+		SummaryMemoryLimitBytes: summaryMemoryLimit,
+		DurableRecency:          true,
+		BackgroundConvergence:   true,
+		MaxEntries:              maxEntries,
+		BlockSizeBytes:          blockSize,
+		startupContext:          rootCtx,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize cache store.", "error", err)
@@ -220,6 +233,8 @@ func main() {
 			PeerMaxProbes:         peerMaxProbes,
 			MaxPeerProbesInFlight: maxPeerProbesInFlight,
 			MemoryLimitBytes:      summaryMemoryLimit,
+			PublishFormat:         summaryPublishFormat,
+			LocalBloom:            store.SummaryBloomCapacity(),
 		})
 		peers.StartSummarySynchronizer(rootCtx, store)
 		go peers.WatchEndpoints(rootCtx)
@@ -330,6 +345,33 @@ func positiveEnvIntWithDeprecatedAlias(canonicalKey, deprecatedKey string, def i
 		return value, true, err
 	}
 	return def, false, nil
+}
+
+func configuredSummaryMemoryLimit(goMemoryLimit int64) (int64, error) {
+	derived := deriveSummaryMemoryLimit(goMemoryLimit)
+	if derived <= 0 {
+		return 0, errors.New("runtime GOMEMLIMIT must produce a positive summary memory ceiling")
+	}
+	value := os.Getenv("CACHE_SUMMARY_MEMORY_LIMIT_BYTES")
+	if value == "" {
+		return derived, nil
+	}
+	override, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || override <= 0 {
+		return 0, fmt.Errorf("CACHE_SUMMARY_MEMORY_LIMIT_BYTES must be a positive integer")
+	}
+	return min(derived, override), nil
+}
+
+func validateSummaryMemoryLimitBeforeCache(format summaryPublishFormat, limit int64) error {
+	// Fixed publishing has a known layout and can fail before the cache scan.
+	// Dynamic publishing must wait for statfs because its actual local reserve
+	// can be smaller than the fixed-layout reserve; NewDiskCache validates it as
+	// soon as the disk-derived layout is known.
+	if format == summaryPublishDynamic {
+		return nil
+	}
+	return validateSummaryMemoryLimit(limit)
 }
 
 // envInt64 parses an integer env var, falling back to def (with a warning)

--- a/cmd/cache-proxy/peers.go
+++ b/cmd/cache-proxy/peers.go
@@ -60,6 +60,8 @@ type SummaryConfig struct {
 	PeerMaxProbes         int
 	MaxPeerProbesInFlight int
 	MemoryLimitBytes      int64
+	PublishFormat         summaryPublishFormat
+	LocalBloom            bloomCapacity
 }
 
 // PeerManager discovers and communicates with cache proxy peers
@@ -77,6 +79,12 @@ type PeerManager struct {
 	probePermits              chan struct{}
 	summaryMemoryLimitBytes   int64
 	summaryRemoteMemoryBudget int
+	summaryMemoryReserveBytes int64
+	summarySelectionBytes     int
+	summaryPublishFormat      summaryPublishFormat
+	localBloomCapacity        bloomCapacity
+	summaryGaugeMu            sync.Mutex
+	summaryGaugeSnapshotHook  func()
 
 	summaries         summaryStore
 	summaryMu         sync.Mutex // protects the current local summary and ETag
@@ -97,6 +105,7 @@ type PeerManager struct {
 }
 
 func NewPeerManager(serviceName, peerPort string) *PeerManager {
+	localBloom := fixedSummaryBloomCapacity()
 	return &PeerManager{
 		serviceName: serviceName,
 		peerPort:    peerPort,
@@ -129,7 +138,11 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 		peerMaxProbes:             defaultPeerMaxProbes,
 		probePermits:              make(chan struct{}, defaultMaxPeerProbesInFlight),
 		summaryMemoryLimitBytes:   defaultSummaryMemoryLimitBytes,
-		summaryRemoteMemoryBudget: summaryRemoteMemoryBudget(defaultSummaryMemoryLimitBytes),
+		summaryRemoteMemoryBudget: summaryRemoteMemoryBudget(defaultSummaryMemoryLimitBytes, localBloom),
+		summaryMemoryReserveBytes: summaryMemoryReserveBytes(localBloom),
+		summarySelectionBytes:     int(maxAcceptedSummaryBloomCapacity().BitCount / 8),
+		summaryPublishFormat:      summaryPublishFixed,
+		localBloomCapacity:        localBloom,
 		summaries:                 summaryStore{records: make(map[string]summaryRecord)},
 		membershipChanged:         make(chan struct{}, 1),
 	}
@@ -138,6 +151,16 @@ func NewPeerManager(serviceName, peerPort string) *PeerManager {
 func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, config SummaryConfig) {
 	pm.lookupMode = mode
 	pm.identity = identity
+	if config.PublishFormat == summaryPublishDynamic {
+		pm.summaryPublishFormat = summaryPublishDynamic
+	} else {
+		pm.summaryPublishFormat = summaryPublishFixed
+	}
+	if validSummaryBloomCapacity(config.LocalBloom) {
+		pm.localBloomCapacity = config.LocalBloom
+	} else {
+		pm.localBloomCapacity = fixedSummaryBloomCapacity()
+	}
 	if config.PeerMaxProbes > 0 {
 		pm.peerMaxProbes = config.PeerMaxProbes
 	}
@@ -146,8 +169,9 @@ func (pm *PeerManager) ConfigureSummary(mode peerLookupMode, identity string, co
 	}
 	if config.MemoryLimitBytes > 0 {
 		pm.summaryMemoryLimitBytes = config.MemoryLimitBytes
-		pm.summaryRemoteMemoryBudget = summaryRemoteMemoryBudget(config.MemoryLimitBytes)
 	}
+	pm.summaryMemoryReserveBytes = summaryMemoryReserveBytes(pm.localBloomCapacity)
+	pm.summaryRemoteMemoryBudget = summaryRemoteMemoryBudget(pm.summaryMemoryLimitBytes, pm.localBloomCapacity)
 	pm.updateSummaryGauges()
 }
 
@@ -258,7 +282,7 @@ func (pm *PeerManager) selectSummaryPeers(peers []string) []string {
 	if pm.lookupMode != peerLookupSummary || pm.summaryRemoteMemoryBudget <= 0 {
 		return nil
 	}
-	maxPeers := pm.summaryRemoteMemoryBudget / int(summaryBloomBits/8)
+	maxPeers := pm.summaryRemoteMemoryBudget / pm.summarySelectionBytes
 	if maxPeers <= 0 {
 		return nil
 	}
@@ -334,21 +358,44 @@ func (pm *PeerManager) receivePulledSummary(sender string, body []byte, etag str
 }
 
 func (pm *PeerManager) updateSummaryGauges() {
+	// Pull workers complete concurrently. Serialize snapshot-through-publication
+	// so an older snapshot cannot overwrite a newer one.
+	pm.summaryGaugeMu.Lock()
+	defer pm.summaryGaugeMu.Unlock()
 	pm.summaries.mu.RLock()
 	n, b := len(pm.summaries.records), pm.summaries.bytes
+	valid := 0
+	now := time.Now()
+	for _, record := range pm.summaries.records {
+		if time.Unix(0, record.summary.ExpiresNS).After(now) {
+			valid++
+		}
+	}
 	pm.summaries.mu.RUnlock()
 	accountedBytes := int64(0)
 	effectiveLimit := int64(0)
 	if pm.lookupMode == peerLookupSummary {
-		// The ceiling reserves the fixed local counting Bloom plus the maximum
+		// The ceiling reserves the current local counting Bloom plus the maximum
 		// concurrent snapshot/pull working set before admitting remote summaries.
 		// Report that same conservative accounting so resident/limit is alertable.
-		accountedBytes = summaryMemoryReserveBytes() + int64(b)
+		accountedBytes = pm.summaryMemoryReserveBytes + int64(b)
 		effectiveLimit = pm.summaryMemoryLimitBytes
 	} else {
 		n = 0
+		valid = 0
 	}
+	pm.mu.RLock()
+	selected := len(pm.summaryPeers)
+	pm.mu.RUnlock()
+	if pm.lookupMode != peerLookupSummary {
+		selected = 0
+	}
+	if pm.summaryGaugeSnapshotHook != nil {
+		pm.summaryGaugeSnapshotHook()
+	}
+	summarySelectedPeers.Set(float64(selected))
 	summaryResidentCount.Set(float64(n))
+	summaryValidResidentPeers.Set(float64(valid))
 	summaryResidentBytes.Set(float64(accountedBytes))
 	summaryMemoryLimitBytes.Set(float64(effectiveLimit))
 }
@@ -435,12 +482,30 @@ func (pm *PeerManager) StopSummarySynchronizer() {
 }
 
 func (pm *PeerManager) buildLocalSummary(store *DiskCache) {
-	_, bits, ok := store.SummarySnapshot()
+	items, bits, ok := store.SummarySnapshot()
 	if !ok {
 		summaryServesTotal.WithLabelValues("summary_index_unavailable").Inc()
 		return
 	}
-	s, err := newIncrementalCacheSummary(bits, time.Now(), defaultSummaryTTL)
+	capacity := store.SummaryBloomCapacity()
+	var s *cacheSummary
+	var err error
+	switch pm.summaryPublishFormat {
+	case summaryPublishFixed:
+		if capacity != fixedSummaryBloomCapacity() {
+			err = errors.New("fixed summary publisher requires the fixed local Bloom layout")
+		} else {
+			s, err = newIncrementalCacheSummary(bits, time.Now(), defaultSummaryTTL)
+		}
+	case summaryPublishDynamic:
+		if capacity != pm.localBloomCapacity {
+			err = errors.New("dynamic summary publisher local Bloom layout mismatch")
+		} else {
+			s, err = newDynamicCacheSummary(items, capacity, bits, time.Now(), defaultSummaryTTL)
+		}
+	default:
+		err = errors.New("invalid summary publisher format")
+	}
 	if err != nil {
 		summaryServesTotal.WithLabelValues("build_error").Inc()
 		return
@@ -569,6 +634,10 @@ func (pm *PeerManager) advancePullOffset(start, submitted, peerCount int) {
 }
 
 func (pm *PeerManager) pullSummary(ctx context.Context, peer string) {
+	// Valid-resident coverage depends on wall time even when every pull fails.
+	// Refresh it on every completion so transport/DNS degradation cannot leave
+	// an expired summary reported as valid indefinitely.
+	defer pm.updateSummaryGauges()
 	ctx, cancel := context.WithTimeout(ctx, summaryPullTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+peer+"/cache/summary", nil)

--- a/cmd/cache-proxy/startup_scan_test.go
+++ b/cmd/cache-proxy/startup_scan_test.go
@@ -511,6 +511,86 @@ func TestStartupLargeSparseDirectoryKeepsBoundedNewestSet(t *testing.T) {
 	}
 }
 
+func TestStartupRehashesExistingEntriesIntoDerivedDynamicBloom(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("d", 64)
+	if err := os.WriteFile(filepath.Join(dir, key), []byte("cached"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		totalBytes = int64(1000)
+		blockBytes = int64(10)
+		maxPercent = 80
+	)
+	cache, err := NewDiskCache(dir, maxPercent, DiskCacheOptions{
+		IncrementalSummary: true,
+		DynamicSummary:     true,
+		BlockSizeBytes:     blockBytes,
+		CapacityProvider: func(string) (diskSpace, error) {
+			return diskSpace{TotalBytes: totalBytes, FreeBytes: totalBytes - int64(len("cached"))}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCapacity := deriveBloomCapacity(totalBytes*maxPercent/100, blockBytes)
+	if got := cache.SummaryBloomCapacity(); got != wantCapacity {
+		t.Fatalf("dynamic restart Bloom capacity=%+v, want %+v", got, wantCapacity)
+	}
+	items, bits, ok := cache.SummarySnapshot()
+	if !ok || items != 1 {
+		t.Fatalf("dynamic restart snapshot available/items=%t/%d, want true/1", ok, items)
+	}
+	summary, err := newDynamicCacheSummary(items, wantCapacity, bits, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.Contains(key) {
+		t.Fatal("dynamic restart summary omitted a pre-existing committed cache key")
+	}
+	newKey := strings.Repeat("e", 64)
+	if _, err := cache.PutStream(newKey, strings.NewReader("new")); err != nil {
+		t.Fatal(err)
+	}
+	items, bits, ok = cache.SummarySnapshot()
+	summary, err = newDynamicCacheSummary(items, wantCapacity, bits, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || items != 2 || !summary.Contains(key) || !summary.Contains(newKey) {
+		t.Fatalf("dynamic summary after admission available/items/old/new=%t/%d/%t/%t", ok, items, summary.Contains(key), summary.Contains(newKey))
+	}
+}
+
+func TestDynamicSummaryRehashHonorsStartupCancellation(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("e", 64)
+	if err := os.WriteFile(filepath.Join(dir, key), []byte("cached"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache, err := NewDiskCache(dir, 80, DiskCacheOptions{
+		IncrementalSummary: true,
+		DynamicSummary:     true,
+		BlockSizeBytes:     10,
+		CapacityProvider:   testStartupCapacityProvider,
+		startupContext:     ctx,
+		summaryRehashHook: func(rehashed int) {
+			if rehashed != 0 {
+				t.Fatalf("first dynamic rehash cancellation hook received count %d, want 0", rehashed)
+			}
+			cancel()
+		},
+	})
+	if cache != nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "rebuild startup Bloom summary") {
+		t.Fatalf("dynamic rehash cancellation: cache=%v err=%v, want nil/wrapped context.Canceled", cache, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, key)); err != nil {
+		t.Fatalf("dynamic rehash cancellation removed committed cache file: %v", err)
+	}
+}
+
 func TestStartupTenMillionGuardrailEstimateFitsEightGiBEnvelope(t *testing.T) {
 	// The final metric estimate includes the key, entry object, list node, and
 	// map overhead. Startup adds only the bounded survivor pointer heap because

--- a/cmd/cache-proxy/summary.go
+++ b/cmd/cache-proxy/summary.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -21,15 +22,21 @@ import (
 // Summary data deliberately contains only opaque cache-key digests. It is a
 // best-effort hint: rejecting it or losing it must only reduce peer hits.
 const (
-	summaryFormatVersion    = 2
+	legacySummaryFormatVersion  = 2
+	dynamicSummaryFormatVersion = 3
+	// summaryFormatVersion remains the compatibility-publisher version. New
+	// receivers accept both versions, while the explicit publish-format rollout
+	// controls when a pod starts emitting v3.
+	summaryFormatVersion    = legacySummaryFormatVersion
 	cacheLayoutVersion      = 1
 	defaultSummaryTTL       = 60 * time.Second
 	defaultSummaryInterval  = 20 * time.Second
 	summaryTargetFPR        = 0.01
 	summaryBloomTargetItems = 1_000_000
-	// A 1m-entry filter at 1% false-positive rate is ~1.15 MiB before JSON
-	// base64 encoding. Two MiB is a hard wire cap with modest headroom.
-	maxSummaryBodyBytes            = 2 << 20
+	// A 10m-entry filter at 1% false-positive rate is about 11.43 MiB raw
+	// and 15.24 MiB after JSON base64 encoding. Sixteen MiB is the protocol
+	// cap for both fixed v2 and dynamic v3 summaries.
+	maxSummaryBodyBytes            = 16 << 20
 	maxSummaryResponseHeaderBytes  = 16 << 10
 	maxSummaryPulls                = 4
 	defaultSummaryMemoryLimitBytes = 512 << 20
@@ -38,26 +45,69 @@ const (
 	defaultSummaryPullCycleTimeout = 15 * time.Second
 )
 
-func summaryMemoryReserveBytes() int64 {
-	rawBits := int64(summaryBloomBits / 8)
-	localIndex := rawBits + int64(summaryBloomBits)*2
-	// Keep room for both the currently served and next encoded bodies, the
-	// temporary raw-bit snapshot used to build the next body, and each pull
-	// worker's encoded body plus decoded bits.
-	transient := 2*int64(maxSummaryBodyBytes) + rawBits + int64(maxSummaryPulls)*(int64(maxSummaryBodyBytes)+rawBits+maxSummaryResponseHeaderBytes)
+type summaryPublishFormat string
+
+const (
+	summaryPublishFixed   summaryPublishFormat = "fixed"
+	summaryPublishDynamic summaryPublishFormat = "dynamic"
+)
+
+func parseSummaryPublishFormat(value string) (summaryPublishFormat, error) {
+	switch value {
+	case "", string(summaryPublishFixed):
+		return summaryPublishFixed, nil
+	case string(summaryPublishDynamic):
+		return summaryPublishDynamic, nil
+	default:
+		return "", fmt.Errorf("invalid CACHE_SUMMARY_PUBLISH_FORMAT %q (want fixed or dynamic)", value)
+	}
+}
+
+func fixedSummaryBloomCapacity() bloomCapacity {
+	return bloomCapacity{DesignEntries: summaryBloomTargetItems, BitCount: summaryBloomBits, Hashes: summaryBloomHashes}
+}
+
+func maxAcceptedSummaryBloomCapacity() bloomCapacity {
+	bits, hashes := bloomParams(int(cacheMetadataEntryLimit))
+	return bloomCapacity{DesignEntries: cacheMetadataEntryLimit, BitCount: bits, Hashes: hashes}
+}
+
+func validSummaryBloomCapacity(capacity bloomCapacity) bool {
+	if capacity.DesignEntries <= 0 || capacity.DesignEntries > cacheMetadataEntryLimit || capacity.BitCount < 8 || capacity.BitCount%8 != 0 || capacity.Hashes == 0 {
+		return false
+	}
+	bits, hashes := bloomParams(int(capacity.DesignEntries))
+	return capacity.BitCount == bits && capacity.Hashes == hashes
+}
+
+func summaryMemoryReserveBytes(localCapacity ...bloomCapacity) int64 {
+	local := fixedSummaryBloomCapacity()
+	if len(localCapacity) > 0 && validSummaryBloomCapacity(localCapacity[0]) {
+		local = localCapacity[0]
+	}
+	localRawBytes := int64(local.BitCount / 8)
+	localIndex := localRawBytes + int64(local.BitCount)*2
+	maxRemoteRawBytes := int64(maxAcceptedSummaryBloomCapacity().BitCount / 8)
+	// Keep room for the currently served body, the JSON encoder buffer and its
+	// returned clone, plus the temporary raw-bit snapshot. Each pull similarly
+	// retains the response body, the Decoder buffer and a RawMessage copy while
+	// allocating the decoded bitset. Pull reserve is layout-independent because
+	// a fixed-publishing receiver must already be safe to accept v3 peers during
+	// a rolling deployment.
+	transient := 3*int64(maxSummaryBodyBytes) + localRawBytes + int64(maxSummaryPulls)*(3*int64(maxSummaryBodyBytes)+maxRemoteRawBytes+maxSummaryResponseHeaderBytes)
 	return localIndex + transient
 }
 
-func validateSummaryMemoryLimit(total int64) error {
-	minimum := summaryMemoryReserveBytes() + int64(summaryBloomBits/8)
+func validateSummaryMemoryLimit(total int64, localCapacity ...bloomCapacity) error {
+	minimum := summaryMemoryReserveBytes(localCapacity...) + int64(maxAcceptedSummaryBloomCapacity().BitCount/8)
 	if total < minimum {
 		return fmt.Errorf("CACHE_SUMMARY_MEMORY_LIMIT_BYTES must be at least %d", minimum)
 	}
 	return nil
 }
 
-func summaryRemoteMemoryBudget(total int64) int {
-	budget := total - summaryMemoryReserveBytes()
+func summaryRemoteMemoryBudget(total int64, localCapacity ...bloomCapacity) int {
+	budget := total - summaryMemoryReserveBytes(localCapacity...)
 	if budget < 0 {
 		return 0
 	}
@@ -75,13 +125,16 @@ var (
 var (
 	summaryPullsTotal                   = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_pulls_total", Help: "Peer summary pulls by outcome"}, []string{"outcome"})
 	summaryServesTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_serves_total", Help: "Local summary endpoint responses by outcome"}, []string{"outcome"})
-	summaryResidentCount                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current valid peer summaries"})
-	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Conservative Bloom-state memory accounting: fixed local index, transient reserve, and retained peer summaries"})
-	summaryMemoryLimitBytes             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_memory_limit_bytes", Help: "Effective configured ceiling for total Bloom-state memory accounting"})
+	summarySelectedPeers                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_selected_peers", Help: "Current deterministic peer subset selected for summary pulls"})
+	summaryResidentCount                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_count", Help: "Current retained peer summary records, including records awaiting expiry pruning"})
+	summaryValidResidentPeers           = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_valid_resident_peers", Help: "Current retained peer summaries whose advertised TTL has not expired"})
+	summaryResidentBytes                = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_resident_bytes", Help: "Conservative Bloom-state memory accounting: current local index, maximum v3 transient reserve, and retained peer summaries"})
+	summaryMemoryLimitBytes             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_memory_limit_bytes", Help: "Effective derived and optionally lowered ceiling for total Bloom-state memory accounting"})
 	summaryAgeSeconds                   = promauto.NewHistogram(prometheus.HistogramOpts{Name: "cache_proxy_summary_age_seconds", Help: "Age of a summary used during lookup", Buckets: prometheus.ExponentialBuckets(0.1, 2, 10)})
 	summaryLookupTotal                  = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_lookups_total", Help: "Summary lookup decisions"}, []string{"outcome"})
 	summaryConfirmedGetsTotal           = promauto.NewCounterVec(prometheus.CounterOpts{Name: "cache_proxy_summary_confirmed_gets_total", Help: "Peer body GET attempts after exact summary-mode confirmation"}, []string{"outcome"})
 	summaryBloomItems                   = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_items", Help: "Current local cache keys represented by the incremental Bloom filter"})
+	summaryBloomDesignItems             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_design_items", Help: "Entry count used to size the local Bloom filter at the target false-positive rate"})
 	summaryBloomBitsGauge               = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_bits", Help: "Allocated bits in the local incremental Bloom filter"})
 	summaryBloomHashesGauge             = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_hashes", Help: "Hash functions in the local incremental Bloom filter"})
 	summaryBloomFPR                     = promauto.NewGauge(prometheus.GaugeOpts{Name: "cache_proxy_summary_bloom_false_positive_ratio", Help: "Predicted local Bloom false-positive ratio"})
@@ -114,6 +167,51 @@ func parsePeerLookupMode(value string) (peerLookupMode, error) {
 // cacheSummary is the complete versioned wire payload. []byte is base64 in
 // JSON; no raw cache locator can be recovered from the Bloom bits.
 type cacheSummary struct {
+	Version     int
+	Layout      int
+	CreatedNS   int64
+	ExpiresNS   int64
+	ItemCount   int
+	DesignItems int
+	MBits       uint64
+	Hashes      uint8
+	Bits        []byte
+}
+
+type legacyCacheSummaryWire struct {
+	Version   int             `json:"v"`
+	Layout    int             `json:"l"`
+	CreatedNS int64           `json:"c"`
+	ExpiresNS int64           `json:"e"`
+	MBits     uint64          `json:"m"`
+	Hashes    uint8           `json:"k"`
+	Bits      json.RawMessage `json:"b"`
+}
+
+type dynamicCacheSummaryWire struct {
+	Version     int             `json:"v"`
+	Layout      int             `json:"l"`
+	CreatedNS   int64           `json:"c"`
+	ExpiresNS   int64           `json:"e"`
+	ItemCount   *int            `json:"n"`
+	DesignItems *int            `json:"d"`
+	MBits       uint64          `json:"m"`
+	Hashes      uint8           `json:"k"`
+	Bits        json.RawMessage `json:"b"`
+}
+
+type cacheSummaryMetadataWire struct {
+	Version     int    `json:"v"`
+	Layout      int    `json:"l"`
+	CreatedNS   int64  `json:"c"`
+	ExpiresNS   int64  `json:"e"`
+	ItemCount   *int   `json:"n"`
+	DesignItems *int   `json:"d"`
+	MBits       uint64 `json:"m"`
+	Hashes      uint8  `json:"k"`
+}
+
+type legacyCacheSummaryOutput struct {
 	Version   int    `json:"v"`
 	Layout    int    `json:"l"`
 	CreatedNS int64  `json:"c"`
@@ -121,6 +219,18 @@ type cacheSummary struct {
 	MBits     uint64 `json:"m"`
 	Hashes    uint8  `json:"k"`
 	Bits      []byte `json:"b"`
+}
+
+type dynamicCacheSummaryOutput struct {
+	Version     int    `json:"v"`
+	Layout      int    `json:"l"`
+	CreatedNS   int64  `json:"c"`
+	ExpiresNS   int64  `json:"e"`
+	ItemCount   int    `json:"n"`
+	DesignItems int    `json:"d"`
+	MBits       uint64 `json:"m"`
+	Hashes      uint8  `json:"k"`
+	Bits        []byte `json:"b"`
 }
 
 // summaryIndex is a bounded counting Bloom filter. Counters make eviction
@@ -135,10 +245,6 @@ type summaryIndex struct {
 	targetItems int
 	itemCount   int
 	setBits     uint64
-}
-
-func newSummaryIndex() *summaryIndex {
-	return newSummaryIndexWithParams(summaryBloomBits, summaryBloomHashes, summaryBloomTargetItems)
 }
 
 func newSummaryIndexWithParams(bitCount uint64, hashes uint8, targetItems int) *summaryIndex {
@@ -211,6 +317,7 @@ func (i *summaryIndex) Snapshot() (int, []byte) {
 
 func (i *summaryIndex) updateMetricsLocked() {
 	summaryBloomItems.Set(float64(i.itemCount))
+	summaryBloomDesignItems.Set(float64(i.targetItems))
 	summaryBloomBitsGauge.Set(float64(i.bitCount))
 	summaryBloomHashesGauge.Set(float64(i.hashes))
 	summaryBloomFPR.Set(bloomFalsePositiveRate(i.itemCount, i.bitCount, i.hashes))
@@ -271,7 +378,22 @@ func (s *cacheSummary) Contains(key string) bool {
 	return ok
 }
 func (s *cacheSummary) MarshalBinary() ([]byte, error) {
-	b, err := json.Marshal(s)
+	var value any
+	switch s.Version {
+	case legacySummaryFormatVersion:
+		value = legacyCacheSummaryOutput{
+			Version: s.Version, Layout: s.Layout, CreatedNS: s.CreatedNS, ExpiresNS: s.ExpiresNS,
+			MBits: s.MBits, Hashes: s.Hashes, Bits: s.Bits,
+		}
+	case dynamicSummaryFormatVersion:
+		value = dynamicCacheSummaryOutput{
+			Version: s.Version, Layout: s.Layout, CreatedNS: s.CreatedNS, ExpiresNS: s.ExpiresNS,
+			ItemCount: s.ItemCount, DesignItems: s.DesignItems, MBits: s.MBits, Hashes: s.Hashes, Bits: s.Bits,
+		}
+	default:
+		return nil, errors.New("incompatible summary")
+	}
+	b, err := json.Marshal(value)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +404,7 @@ func (s *cacheSummary) MarshalBinary() ([]byte, error) {
 }
 
 func summaryFromIncrementalBits(bitCount uint64, hashes uint8, bits []byte, now time.Time, ttl time.Duration) *cacheSummary {
-	return &cacheSummary{Version: summaryFormatVersion, Layout: cacheLayoutVersion, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), MBits: bitCount, Hashes: hashes, Bits: bits}
+	return &cacheSummary{Version: legacySummaryFormatVersion, Layout: cacheLayoutVersion, CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(), MBits: bitCount, Hashes: hashes, Bits: bits}
 }
 
 func newIncrementalCacheSummary(bits []byte, now time.Time, ttl time.Duration) (*cacheSummary, error) {
@@ -291,27 +413,122 @@ func newIncrementalCacheSummary(bits []byte, now time.Time, ttl time.Duration) (
 	}
 	return summaryFromIncrementalBits(summaryBloomBits, summaryBloomHashes, bits, now, ttl), nil
 }
+
+func newDynamicCacheSummary(items int, capacity bloomCapacity, bits []byte, now time.Time, ttl time.Duration) (*cacheSummary, error) {
+	if ttl <= 0 || items < 0 || items > int(cacheMetadataEntryLimit) || !validSummaryBloomCapacity(capacity) || len(bits) != int(capacity.BitCount/8) {
+		return nil, errors.New("invalid dynamic summary inputs")
+	}
+	return &cacheSummary{
+		Version: dynamicSummaryFormatVersion, Layout: cacheLayoutVersion,
+		CreatedNS: now.UnixNano(), ExpiresNS: now.Add(ttl).UnixNano(),
+		ItemCount: items, DesignItems: int(capacity.DesignEntries),
+		MBits: capacity.BitCount, Hashes: capacity.Hashes, Bits: bits,
+	}, nil
+}
+
 func parseCacheSummary(body []byte, now time.Time) (*cacheSummary, error) {
 	if len(body) == 0 || len(body) > maxSummaryBodyBytes {
 		return nil, errors.New("invalid summary body size")
 	}
-	var s cacheSummary
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&s); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+	// Preflight scalar metadata without materializing b. This validates the
+	// claimed layout before the strict decoder allocates its bounded RawMessage
+	// copy and before decodeSummaryBits allocates the raw Bloom bitset.
+	var metadata cacheSummaryMetadataWire
+	if err := json.Unmarshal(body, &metadata); err != nil {
 		return nil, errors.New("invalid summary encoding")
 	}
-	if s.Version != summaryFormatVersion || s.Layout != cacheLayoutVersion {
-		return nil, errors.New("incompatible summary")
-	}
-	if s.MBits != summaryBloomBits || s.Hashes != summaryBloomHashes || len(s.Bits) != int(summaryBloomBits/8) {
-		return nil, errors.New("invalid bloom parameters")
-	}
-	created, expires := time.Unix(0, s.CreatedNS), time.Unix(0, s.ExpiresNS)
-	if !expires.After(now) || !expires.After(created) || created.After(now.Add(2*time.Minute)) || expires.Sub(created) > 2*defaultSummaryTTL {
+	if !validSummaryTimestamps(metadata.CreatedNS, metadata.ExpiresNS, now) {
 		return nil, errors.New("invalid summary timestamps")
 	}
+	var s cacheSummary
+	switch metadata.Version {
+	case legacySummaryFormatVersion:
+		if metadata.Layout != cacheLayoutVersion || metadata.MBits != summaryBloomBits || metadata.Hashes != summaryBloomHashes {
+			return nil, errors.New("invalid bloom parameters")
+		}
+		var wire legacyCacheSummaryWire
+		if err := decodeStrictSummaryWire(body, &wire); err != nil {
+			return nil, err
+		}
+		bits, err := decodeSummaryBits(wire.Bits, wire.MBits)
+		if err != nil {
+			return nil, err
+		}
+		s = cacheSummary{
+			Version: wire.Version, Layout: wire.Layout, CreatedNS: wire.CreatedNS, ExpiresNS: wire.ExpiresNS,
+			DesignItems: summaryBloomTargetItems, MBits: wire.MBits, Hashes: wire.Hashes, Bits: bits,
+		}
+	case dynamicSummaryFormatVersion:
+		if metadata.Layout != cacheLayoutVersion || metadata.ItemCount == nil || metadata.DesignItems == nil || *metadata.ItemCount < 0 || *metadata.ItemCount > int(cacheMetadataEntryLimit) {
+			return nil, errors.New("invalid dynamic summary dimensions")
+		}
+		capacity := bloomCapacity{DesignEntries: int64(*metadata.DesignItems), BitCount: metadata.MBits, Hashes: metadata.Hashes}
+		if !validSummaryBloomCapacity(capacity) {
+			return nil, errors.New("invalid bloom parameters")
+		}
+		var wire dynamicCacheSummaryWire
+		if err := decodeStrictSummaryWire(body, &wire); err != nil {
+			return nil, err
+		}
+		bits, err := decodeSummaryBits(wire.Bits, wire.MBits)
+		if err != nil {
+			return nil, err
+		}
+		if *wire.ItemCount > 0 && !hasSetBloomBit(bits) {
+			return nil, errors.New("invalid empty bloom state")
+		}
+		s = cacheSummary{
+			Version: wire.Version, Layout: wire.Layout, CreatedNS: wire.CreatedNS, ExpiresNS: wire.ExpiresNS,
+			ItemCount: *wire.ItemCount, DesignItems: *wire.DesignItems,
+			MBits: wire.MBits, Hashes: wire.Hashes, Bits: bits,
+		}
+	default:
+		return nil, errors.New("incompatible summary")
+	}
 	return &s, nil
+}
+
+func validSummaryTimestamps(createdNS, expiresNS int64, now time.Time) bool {
+	created, expires := time.Unix(0, createdNS), time.Unix(0, expiresNS)
+	return expires.After(now) && expires.After(created) && !created.After(now.Add(2*time.Minute)) && expires.Sub(created) <= 2*defaultSummaryTTL
+}
+
+func hasSetBloomBit(bits []byte) bool {
+	for _, value := range bits {
+		if value != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeStrictSummaryWire(body []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("invalid summary encoding")
+	}
+	return nil
+}
+
+func decodeSummaryBits(encoded json.RawMessage, bitCount uint64) ([]byte, error) {
+	if bitCount < 8 || bitCount%8 != 0 {
+		return nil, errors.New("invalid bloom parameters")
+	}
+	expectedBytes := bitCount / 8
+	if expectedBytes > uint64(maxAcceptedSummaryBloomCapacity().BitCount/8) {
+		return nil, errors.New("invalid bloom parameters")
+	}
+	expectedEncodedBytes := base64.StdEncoding.EncodedLen(int(expectedBytes))
+	if len(encoded) != expectedEncodedBytes+2 || len(encoded) < 2 || encoded[0] != '"' || encoded[len(encoded)-1] != '"' {
+		return nil, errors.New("invalid bloom bit length")
+	}
+	bits := make([]byte, int(expectedBytes))
+	n, err := base64.StdEncoding.Decode(bits, encoded[1:len(encoded)-1])
+	if err != nil || n != len(bits) {
+		return nil, errors.New("invalid bloom bits")
+	}
+	return bits, nil
 }
 
 type summaryRecord struct {
@@ -338,12 +555,12 @@ type summaryStore struct {
 }
 
 func (st *summaryStore) receive(peer string, body []byte, etag string, now time.Time, member func(string) bool, remoteBudget int) error {
+	if !member(peer) {
+		return errors.New("unknown summary sender")
+	}
 	s, err := parseCacheSummary(body, now)
 	if err != nil {
 		return err
-	}
-	if !member(peer) {
-		return errors.New("unknown summary sender")
 	}
 	st.mu.Lock()
 	defer st.mu.Unlock()

--- a/cmd/cache-proxy/summary_pull_test.go
+++ b/cmd/cache-proxy/summary_pull_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -20,20 +22,229 @@ import (
 // confirmation contract. Bloom summaries only eliminate definite negatives;
 // they never authorize a body GET without an exact /cache/has confirmation.
 
-func TestSummaryParserRejectsLegacyDynamicBloomLayout(t *testing.T) {
-	key := strings.Repeat("a", 64)
-	bits, hashes := bloomParams(1)
+type dynamicSummaryWireFixture struct {
+	Version     int    `json:"v"`
+	Layout      int    `json:"l"`
+	CreatedNS   int64  `json:"c"`
+	ExpiresNS   int64  `json:"e"`
+	ItemCount   int    `json:"n"`
+	DesignItems int    `json:"d"`
+	MBits       uint64 `json:"m"`
+	Hashes      uint8  `json:"k"`
+	Bits        []byte `json:"b"`
+}
+
+func dynamicSummaryWireForKeys(t testing.TB, designItems, itemCount int, keys []string, now time.Time) dynamicSummaryWireFixture {
+	t.Helper()
+	bits, hashes := bloomParams(designItems)
 	payload := make([]byte, bits/8)
-	bloomHashes(key, bits, hashes, func(bit uint64) {
-		payload[bit/8] |= 1 << (bit % 8)
-	})
-	summary := summaryFromIncrementalBits(bits, hashes, payload, time.Now(), time.Minute)
-	body, err := summary.MarshalBinary()
+	for _, key := range keys {
+		if !IsValidCacheKey(key) {
+			t.Fatalf("invalid test cache key %q", key)
+		}
+		bloomHashes(key, bits, hashes, func(bit uint64) {
+			payload[bit/8] |= 1 << (bit % 8)
+		})
+	}
+	return dynamicSummaryWireFixture{
+		Version:     3,
+		Layout:      cacheLayoutVersion,
+		CreatedNS:   now.UnixNano(),
+		ExpiresNS:   now.Add(time.Minute).UnixNano(),
+		ItemCount:   itemCount,
+		DesignItems: designItems,
+		MBits:       bits,
+		Hashes:      hashes,
+		Bits:        payload,
+	}
+}
+
+func marshalDynamicSummaryWireForTest(t testing.TB, summary dynamicSummaryWireFixture) []byte {
+	t.Helper()
+	body, err := json.Marshal(summary)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := parseCacheSummary(body, time.Now()); err == nil {
-		t.Fatal("accepted legacy dynamically sized Bloom layout; want fixed incremental layout only")
+	return body
+}
+
+func TestSummaryParserReadsLegacyAndDynamicBloomWireFormats(t *testing.T) {
+	now := time.Now()
+	legacyKey, dynamicKey := strings.Repeat("a", 64), strings.Repeat("b", 64)
+
+	legacy := fixedCacheSummaryForKeys(t, []string{legacyKey}, now, time.Minute)
+	legacy.Version = 2
+	parsedLegacy, err := parseCacheSummary(marshalCacheSummaryForTest(t, legacy), now)
+	if err != nil {
+		t.Fatalf("parse legacy v2 summary: %v", err)
+	}
+	if !parsedLegacy.Contains(legacyKey) {
+		t.Fatal("parsed legacy v2 summary omitted its cached key")
+	}
+
+	dynamicWire := dynamicSummaryWireForKeys(t, 128, 1, []string{dynamicKey}, now)
+	if dynamicWire.MBits == summaryBloomBits {
+		t.Fatal("dynamic test fixture unexpectedly uses the legacy fixed Bloom layout")
+	}
+	legacyDynamic := summaryFromIncrementalBits(dynamicWire.MBits, dynamicWire.Hashes, dynamicWire.Bits, now, time.Minute)
+	legacyDynamic.Version = 2
+	if _, err := parseCacheSummary(marshalCacheSummaryForTest(t, legacyDynamic), now); err == nil {
+		t.Fatal("legacy v2 summary accepted non-legacy Bloom dimensions")
+	}
+	parsedDynamic, err := parseCacheSummary(marshalDynamicSummaryWireForTest(t, dynamicWire), now)
+	if err != nil {
+		t.Fatalf("parse self-describing v3 summary: %v", err)
+	}
+	if !parsedDynamic.Contains(dynamicKey) {
+		t.Fatal("parsed self-describing v3 summary omitted its cached key")
+	}
+
+	roundTrip, err := parsedDynamic.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal parsed v3 summary: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(roundTrip, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"n", "d"} {
+		if _, ok := fields[field]; !ok {
+			t.Fatalf("marshaled v3 summary omitted self-describing field %q", field)
+		}
+	}
+}
+
+func TestLargeDynamicSummaryFitsWireCapAndRoundTripsParameters(t *testing.T) {
+	const (
+		designItems = 9_700_000
+		itemCount   = 9_800_000 // Saturation degrades FPR but does not invalidate the hint.
+	)
+	now := time.Now()
+	key := strings.Repeat("e", 64)
+	wire := dynamicSummaryWireForKeys(t, designItems, itemCount, []string{key}, now)
+	if len(wire.Bits) < 11<<20 {
+		t.Fatalf("large-layout fixture has only %d raw Bloom bytes, want a realistic >11 MiB payload", len(wire.Bits))
+	}
+
+	parsed, err := parseCacheSummary(marshalDynamicSummaryWireForTest(t, wire), now)
+	if err != nil {
+		t.Fatalf("parse large v3 summary: %v", err)
+	}
+	body, err := parsed.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal large v3 summary: %v", err)
+	}
+	if len(body) > maxSummaryBodyBytes {
+		t.Fatalf("large v3 wire body is %d bytes, cap is %d", len(body), maxSummaryBodyBytes)
+	}
+
+	roundTrip, err := parseCacheSummary(body, now)
+	if err != nil {
+		t.Fatalf("parse round-tripped large v3 summary: %v", err)
+	}
+	if roundTrip.ItemCount != itemCount || roundTrip.DesignItems != designItems || roundTrip.MBits != wire.MBits || roundTrip.Hashes != wire.Hashes {
+		t.Fatalf("large v3 parameters changed after round trip: got n/d/m/k=%d/%d/%d/%d, want %d/%d/%d/%d",
+			roundTrip.ItemCount, roundTrip.DesignItems, roundTrip.MBits, roundTrip.Hashes,
+			itemCount, designItems, wire.MBits, wire.Hashes)
+	}
+	if !roundTrip.Contains(key) {
+		t.Fatal("round-tripped large v3 summary omitted its cached key")
+	}
+}
+
+func TestMalformedMaximumDynamicLayoutIsRejectedDuringMetadataPreflight(t *testing.T) {
+	now := time.Now()
+	wire := dynamicSummaryWireForKeys(t, int(cacheMetadataEntryLimit), 0, nil, now)
+	wire.DesignItems++
+	body := marshalDynamicSummaryWireForTest(t, wire)
+	if len(body) > maxSummaryBodyBytes {
+		t.Fatalf("maximum-layout malformed fixture=%d exceeds protocol cap=%d", len(body), maxSummaryBodyBytes)
+	}
+	if _, err := parseCacheSummary(body, now); err == nil || !strings.Contains(err.Error(), "bloom parameters") {
+		t.Fatalf("malformed maximum dynamic layout error=%v, want metadata preflight rejection", err)
+	}
+}
+
+func TestDynamicSummaryParserValidatesEverySelfDescribingDimension(t *testing.T) {
+	now := time.Now()
+	valid := dynamicSummaryWireForKeys(t, 128, 1, []string{strings.Repeat("f", 64)}, now)
+	mutateJSON := func(t testing.TB, mutate func(map[string]json.RawMessage)) []byte {
+		t.Helper()
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(marshalDynamicSummaryWireForTest(t, valid), &fields); err != nil {
+			t.Fatal(err)
+		}
+		mutate(fields)
+		body, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return body
+	}
+	for _, tt := range []struct {
+		name string
+		body func(testing.TB) []byte
+	}{
+		{name: "missing current item count", body: func(t testing.TB) []byte {
+			return mutateJSON(t, func(fields map[string]json.RawMessage) { delete(fields, "n") })
+		}},
+		{name: "missing design item count", body: func(t testing.TB) []byte {
+			return mutateJSON(t, func(fields map[string]json.RawMessage) { delete(fields, "d") })
+		}},
+		{name: "design exceeds metadata guardrail", body: func(t testing.TB) []byte {
+			wire := valid
+			wire.DesignItems = int(cacheMetadataEntryLimit + 1)
+			return marshalDynamicSummaryWireForTest(t, wire)
+		}},
+		{name: "current items exceed metadata guardrail", body: func(t testing.TB) []byte {
+			wire := valid
+			wire.ItemCount = int(cacheMetadataEntryLimit + 1)
+			return marshalDynamicSummaryWireForTest(t, wire)
+		}},
+		{name: "hash count does not match design", body: func(t testing.TB) []byte {
+			wire := valid
+			wire.Hashes++
+			return marshalDynamicSummaryWireForTest(t, wire)
+		}},
+		{name: "decoded bit length does not match dimensions", body: func(t testing.TB) []byte {
+			wire := valid
+			wire.Bits = wire.Bits[:len(wire.Bits)-1]
+			return marshalDynamicSummaryWireForTest(t, wire)
+		}},
+		{name: "unknown field", body: func(t testing.TB) []byte {
+			return mutateJSON(t, func(fields map[string]json.RawMessage) { fields["unknown"] = json.RawMessage(`true`) })
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseCacheSummary(tt.body(t), now); err == nil {
+				t.Fatal("invalid v3 summary unexpectedly accepted")
+			}
+		})
+	}
+}
+
+func TestSummaryStoreCoexistsWithLegacyAndDynamicPeers(t *testing.T) {
+	now := time.Now()
+	legacyPeer, dynamicPeer := "legacy:8081", "dynamic:8081"
+	legacyKey, dynamicKey := strings.Repeat("1", 64), strings.Repeat("2", 64)
+	store := summaryStore{records: make(map[string]summaryRecord)}
+	members := map[string]struct{}{legacyPeer: {}, dynamicPeer: {}}
+	member := func(peer string) bool { _, ok := members[peer]; return ok }
+	budget := int(maxAcceptedSummaryBloomCapacity().BitCount / 8 * 2)
+	if err := store.receive(legacyPeer, marshalCacheSummaryForTest(t, fixedCacheSummaryForKeys(t, []string{legacyKey}, now, time.Minute)), "", now, member, budget); err != nil {
+		t.Fatalf("receive legacy peer: %v", err)
+	}
+	dynamic := dynamicSummaryWireForKeys(t, 256, 1, []string{dynamicKey}, now)
+	if err := store.receive(dynamicPeer, marshalDynamicSummaryWireForTest(t, dynamic), "", now, member, budget); err != nil {
+		t.Fatalf("receive dynamic peer: %v", err)
+	}
+	positive, uncovered := store.candidates(legacyKey, []string{legacyPeer, dynamicPeer}, now)
+	if !slices.Equal(positive, []string{legacyPeer}) || len(uncovered) != 0 {
+		t.Fatalf("legacy lookup in mixed store positive/uncovered=%v/%v", positive, uncovered)
+	}
+	positive, uncovered = store.candidates(dynamicKey, []string{legacyPeer, dynamicPeer}, now)
+	if !slices.Equal(positive, []string{dynamicPeer}) || len(uncovered) != 0 {
+		t.Fatalf("dynamic lookup in mixed store positive/uncovered=%v/%v", positive, uncovered)
 	}
 }
 
@@ -146,6 +357,82 @@ func TestPeerSummaryGETServesSnapshotAndSupportsETag(t *testing.T) {
 	}
 }
 
+func TestSummaryPublisherRolloutDefaultsLegacyAndRequiresDynamicOptIn(t *testing.T) {
+	t.Run("default remains legacy v2", func(t *testing.T) {
+		store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pm := peerManagerWith(nil)
+		pm.ConfigureSummary(peerLookupSummary, "snapshot-server", SummaryConfig{})
+		pm.buildLocalSummary(store)
+
+		body := localSummaryBodyForTest(pm)
+		var wire dynamicSummaryWireFixture
+		if err := json.Unmarshal(body, &wire); err != nil {
+			t.Fatalf("decode default published summary: %v", err)
+		}
+		if wire.Version != 2 {
+			t.Fatalf("default published summary version=%d, want legacy v2 during rollout", wire.Version)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(body, &fields); err != nil {
+			t.Fatal(err)
+		}
+		for _, field := range []string{"n", "d"} {
+			if _, ok := fields[field]; ok {
+				t.Fatalf("default legacy publisher unexpectedly emitted v3 field %q", field)
+			}
+		}
+	})
+
+	t.Run("explicit opt-in publishes derived v3 layout", func(t *testing.T) {
+		const (
+			totalBytes = int64(1000)
+			blockBytes = int64(10)
+			maxPercent = 80
+		)
+		store, err := NewDiskCache(t.TempDir(), maxPercent, DiskCacheOptions{
+			IncrementalSummary: true,
+			DynamicSummary:     true,
+			BlockSizeBytes:     blockBytes,
+			CapacityProvider: func(string) (diskSpace, error) {
+				return diskSpace{TotalBytes: totalBytes, FreeBytes: totalBytes}, nil
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pm := peerManagerWith(nil)
+		pm.ConfigureSummary(peerLookupSummary, "snapshot-server", SummaryConfig{
+			PublishFormat: summaryPublishDynamic,
+			LocalBloom:    store.SummaryBloomCapacity(),
+		})
+		pm.buildLocalSummary(store)
+
+		body := localSummaryBodyForTest(pm)
+		var wire dynamicSummaryWireFixture
+		if err := json.Unmarshal(body, &wire); err != nil {
+			t.Fatalf("decode opt-in dynamic summary: %v", err)
+		}
+		expected := deriveBloomCapacity(totalBytes*maxPercent/100, blockBytes)
+		if wire.Version != 3 || wire.DesignItems != int(expected.DesignEntries) || wire.MBits != expected.BitCount || wire.Hashes != expected.Hashes || len(wire.Bits) != int(expected.BitCount/8) {
+			t.Fatalf("opt-in dynamic wire v/d/m/k/bytes=%d/%d/%d/%d/%d, want 3/%d/%d/%d/%d",
+				wire.Version, wire.DesignItems, wire.MBits, wire.Hashes, len(wire.Bits),
+				expected.DesignEntries, expected.BitCount, expected.Hashes, expected.BitCount/8)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(body, &fields); err != nil {
+			t.Fatal(err)
+		}
+		for _, field := range []string{"n", "d"} {
+			if _, ok := fields[field]; !ok {
+				t.Fatalf("opt-in dynamic publisher omitted v3 field %q", field)
+			}
+		}
+	})
+}
+
 func TestPeerSummaryGETSetsHandlerLocalWriteDeadline(t *testing.T) {
 	store, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{IncrementalSummary: true})
 	if err != nil {
@@ -184,7 +471,7 @@ func (w *deadlineResponseWriter) SetWriteDeadline(deadline time.Time) error {
 
 func TestSummarySelectionIsDeterministicAndFitsRemoteMemoryBudget(t *testing.T) {
 	peers := []string{"peer-e:8081", "peer-b:8081", "peer-d:8081", "peer-a:8081", "peer-c:8081"}
-	filterBytes := int(summaryBloomBits / 8)
+	filterBytes := int(maxAcceptedSummaryBloomCapacity().BitCount / 8)
 	memoryLimit := summaryMemoryLimitForRemoteBytes(int64(2*filterBytes + filterBytes/2))
 
 	first := NewPeerManager("test.svc", ":8081")
@@ -210,7 +497,7 @@ func TestSummarySelectionIsDeterministicAndFitsRemoteMemoryBudget(t *testing.T) 
 }
 
 func TestSummarySyncPullsOnlyReceiverSelectedSubset(t *testing.T) {
-	filterBytes := int64(summaryBloomBits / 8)
+	filterBytes := int64(maxAcceptedSummaryBloomCapacity().BitCount / 8)
 	var totalGets int32
 	peers := make([]string, 0, 6)
 	peerGets := make(map[string]*int32, 6)
@@ -399,6 +686,72 @@ func TestRejectedSummaryPullDoesNotReplaceLastValidHint(t *testing.T) {
 	}
 	if candidates := summaryPositivesForTest(pm, newKey, time.Now()); len(candidates) != 0 {
 		t.Fatalf("invalid refresh installed new key: candidates=%v", candidates)
+	}
+}
+
+func TestRejectedDynamicSummaryDoesNotReplaceLastValidRecord(t *testing.T) {
+	const retainedETag = `"dynamic-snapshot-1"`
+	peer := "peer-a:8081"
+	oldKey, newKey := strings.Repeat("c", 64), strings.Repeat("d", 64)
+
+	tests := []struct {
+		name string
+		body func(testing.TB, dynamicSummaryWireFixture) []byte
+	}{
+		{
+			name: "malformed declared layout",
+			body: func(t testing.TB, summary dynamicSummaryWireFixture) []byte {
+				summary.MBits += 8
+				return marshalDynamicSummaryWireForTest(t, summary)
+			},
+		},
+		{
+			name: "nonzero item count with empty filter",
+			body: func(t testing.TB, summary dynamicSummaryWireFixture) []byte {
+				clear(summary.Bits)
+				return marshalDynamicSummaryWireForTest(t, summary)
+			},
+		},
+		{
+			name: "oversized body",
+			body: func(t testing.TB, summary dynamicSummaryWireFixture) []byte {
+				body := marshalDynamicSummaryWireForTest(t, summary)
+				if len(body) >= maxSummaryBodyBytes {
+					t.Fatalf("ordinary dynamic fixture is already %d bytes, wire cap is %d", len(body), maxSummaryBodyBytes)
+				}
+				// JSON permits trailing whitespace, so this remains a valid dynamic
+				// representation except for exceeding the explicit wire bound.
+				return append(body, bytes.Repeat([]byte(" "), maxSummaryBodyBytes-len(body)+1)...)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			pm := peerManagerWith([]string{peer})
+			pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+			pm.refreshSummarySelection()
+
+			valid := dynamicSummaryWireForKeys(t, 128, 1, []string{oldKey}, now)
+			if err := pm.receivePulledSummary(peer, marshalDynamicSummaryWireForTest(t, valid), retainedETag, now); err != nil {
+				t.Fatalf("install valid dynamic summary: %v", err)
+			}
+			invalid := dynamicSummaryWireForKeys(t, 128, 1, []string{newKey}, now)
+			if err := pm.receivePulledSummary(peer, tt.body(t, invalid), `"dynamic-snapshot-2"`, now); err == nil {
+				t.Fatal("invalid dynamic summary unexpectedly replaced the retained record")
+			}
+
+			if candidates := summaryPositivesForTest(pm, oldKey, now); len(candidates) != 1 || candidates[0] != peer {
+				t.Fatalf("rejected dynamic refresh discarded last valid hint: candidates=%v", candidates)
+			}
+			if candidates := summaryPositivesForTest(pm, newKey, now); len(candidates) != 0 {
+				t.Fatalf("rejected dynamic refresh installed its key: candidates=%v", candidates)
+			}
+			if got := pm.summaries.etag(peer, now); got != retainedETag {
+				t.Fatalf("rejected dynamic refresh changed retained ETag to %q, want %q", got, retainedETag)
+			}
+		})
 	}
 }
 

--- a/cmd/cache-proxy/summary_test.go
+++ b/cmd/cache-proxy/summary_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -95,6 +98,73 @@ func TestCacheSummaryWireOmitsPushEraMetadata(t *testing.T) {
 	}
 }
 
+func TestSummaryPublishFormatRequiresExplicitDynamicOptIn(t *testing.T) {
+	for _, tt := range []struct {
+		value string
+		want  summaryPublishFormat
+		ok    bool
+	}{
+		{value: "", want: summaryPublishFixed, ok: true},
+		{value: "fixed", want: summaryPublishFixed, ok: true},
+		{value: "dynamic", want: summaryPublishDynamic, ok: true},
+		{value: "v3", ok: false},
+	} {
+		got, err := parseSummaryPublishFormat(tt.value)
+		if (err == nil) != tt.ok || got != tt.want {
+			t.Errorf("parseSummaryPublishFormat(%q) = (%q, %v), want (%q, ok=%t)", tt.value, got, err, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestConfiguredSummaryMemoryLimitUsesDerivedCeilingAndLowerOverride(t *testing.T) {
+	const fiveGiB = int64(5 << 30)
+	t.Setenv("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", "")
+	if got, err := configuredSummaryMemoryLimit(fiveGiB); err != nil || got != 1<<30 {
+		t.Fatalf("derived summary memory limit = (%d, %v), want 1 GiB", got, err)
+	}
+	t.Setenv("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", "536870912")
+	if got, err := configuredSummaryMemoryLimit(fiveGiB); err != nil || got != 512<<20 {
+		t.Fatalf("lower summary override = (%d, %v), want 512 MiB", got, err)
+	}
+	t.Setenv("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", "2147483648")
+	if got, err := configuredSummaryMemoryLimit(fiveGiB); err != nil || got != 1<<30 {
+		t.Fatalf("oversized summary override = (%d, %v), want derived 1 GiB ceiling", got, err)
+	}
+	t.Setenv("CACHE_SUMMARY_MEMORY_LIMIT_BYTES", "invalid")
+	if _, err := configuredSummaryMemoryLimit(fiveGiB); err == nil {
+		t.Fatal("invalid summary memory override unexpectedly accepted")
+	}
+}
+
+func TestDynamicSummaryMemoryValidationWaitsForDerivedLocalLayout(t *testing.T) {
+	smallLocal := bloomCapacityForItemsForTest(1)
+	limit := summaryMemoryReserveBytes(smallLocal) + int64(maxAcceptedSummaryBloomCapacity().BitCount/8)
+	if err := validateSummaryMemoryLimit(limit); err == nil {
+		t.Fatal("test ceiling unexpectedly fits the larger fixed local layout")
+	}
+	if err := validateSummaryMemoryLimitBeforeCache(summaryPublishDynamic, limit); err != nil {
+		t.Fatalf("dynamic pre-scan validation rejected ceiling for a potentially smaller derived layout: %v", err)
+	}
+	if err := validateSummaryMemoryLimitBeforeCache(summaryPublishFixed, limit); err == nil {
+		t.Fatal("fixed pre-scan validation accepted undersized fixed-layout ceiling")
+	}
+	cache, err := NewDiskCache(t.TempDir(), 100, DiskCacheOptions{
+		IncrementalSummary:      true,
+		DynamicSummary:          true,
+		SummaryMemoryLimitBytes: limit,
+		BlockSizeBytes:          1 << 20,
+		CapacityProvider: func(string) (diskSpace, error) {
+			return diskSpace{TotalBytes: 1, FreeBytes: 1}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("dynamic constructor rejected ceiling sized for its actual local layout: %v", err)
+	}
+	if got := cache.SummaryBloomCapacity(); got != smallLocal {
+		t.Fatalf("dynamic local layout=%+v, want %+v", got, smallLocal)
+	}
+}
+
 func TestParsePeerLookupMode(t *testing.T) {
 	for _, tt := range []struct {
 		in   string
@@ -163,7 +233,7 @@ func TestValidateSummaryMemoryLimit(t *testing.T) {
 	if err := validateSummaryMemoryLimit(minimum); err == nil {
 		t.Fatal("memory limit equal to the fixed reserve was accepted")
 	}
-	if err := validateSummaryMemoryLimit(minimum + int64(summaryBloomBits/8)); err != nil {
+	if err := validateSummaryMemoryLimit(minimum + int64(maxAcceptedSummaryBloomCapacity().BitCount/8)); err != nil {
 		t.Fatalf("memory limit with room for one peer summary rejected: %v", err)
 	}
 }
@@ -462,10 +532,278 @@ func TestDiskCacheIncrementallyUpdatesSummaryBloomOnPutAndEviction(t *testing.T)
 	}
 }
 
+func TestDynamicSummaryStaysConsistentThroughConcurrentAdmissionEvictionAndSnapshots(t *testing.T) {
+	cache, err := NewDiskCache(t.TempDir(), 80, DiskCacheOptions{
+		IncrementalSummary: true,
+		DynamicSummary:     true,
+		MaxEntries:         20,
+		BlockSizeBytes:     10,
+		CapacityProvider: func(string) (diskSpace, error) {
+			return diskSpace{TotalBytes: 1 << 20, FreeBytes: 1 << 20}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	capacity := cache.SummaryBloomCapacity()
+	done := make(chan struct{})
+	snapshotDone := make(chan struct{})
+	snapshotErr := make(chan error, 1)
+	go func() {
+		defer close(snapshotDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				items, bits, ok := cache.SummarySnapshot()
+				if !ok || items < 0 || len(bits) != int(capacity.BitCount/8) {
+					select {
+					case snapshotErr <- fmt.Errorf("invalid concurrent snapshot: ok=%t items=%d bytes=%d", ok, items, len(bits)):
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	var writers sync.WaitGroup
+	for worker := range 4 {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for item := range 25 {
+				key := fmt.Sprintf("%064x", worker*25+item)
+				if _, err := cache.PutStream(key, strings.NewReader("body")); err != nil {
+					select {
+					case snapshotErr <- err:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	writers.Wait()
+	cache.mu.Lock()
+	resident := make([]string, 0, len(cache.index))
+	for key := range cache.index {
+		resident = append(resident, key)
+	}
+	cache.mu.Unlock()
+	for _, key := range resident {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			if _, err := cache.PutStream(key, strings.NewReader("replacement")); err != nil {
+				select {
+				case snapshotErr <- err:
+				default:
+				}
+			}
+		}()
+	}
+	writers.Wait()
+	close(done)
+	<-snapshotDone
+	select {
+	case err := <-snapshotErr:
+		t.Fatal(err)
+	default:
+	}
+
+	cache.mu.Lock()
+	resident = resident[:0]
+	for key := range cache.index {
+		resident = append(resident, key)
+	}
+	cache.mu.Unlock()
+	items, bits, ok := cache.SummarySnapshot()
+	if !ok || items != len(resident) || items != 20 {
+		t.Fatalf("final dynamic snapshot ok/items/resident=%t/%d/%d, want true/20/20", ok, items, len(resident))
+	}
+	summary, err := newDynamicCacheSummary(items, capacity, bits, time.Now(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range resident {
+		if !summary.Contains(key) {
+			t.Fatalf("final dynamic summary omitted resident key %q", key)
+		}
+	}
+}
+
+func TestDynamicSummaryMetricsReflectDerivedLayoutAndSaturation(t *testing.T) {
+	capacity := bloomCapacityForItemsForTest(100)
+	index := newSummaryIndexWithParams(capacity.BitCount, capacity.Hashes, int(capacity.DesignEntries))
+	for item := range 50 {
+		index.Add(fmt.Sprintf("%064x", item))
+	}
+	index.Snapshot()
+	if got := gaugeValue(t, summaryBloomDesignItems); got != float64(capacity.DesignEntries) {
+		t.Fatalf("dynamic design items metric=%v, want %d", got, capacity.DesignEntries)
+	}
+	if got := gaugeValue(t, summaryBloomBitsGauge); got != float64(capacity.BitCount) {
+		t.Fatalf("dynamic bits metric=%v, want %d", got, capacity.BitCount)
+	}
+	if got := gaugeValue(t, summaryBloomHashesGauge); got != float64(capacity.Hashes) {
+		t.Fatalf("dynamic hashes metric=%v, want %d", got, capacity.Hashes)
+	}
+	wantFPR := bloomFalsePositiveRate(50, capacity.BitCount, capacity.Hashes)
+	if got := gaugeValue(t, summaryBloomFPR); math.Abs(got-wantFPR) > 1e-12 {
+		t.Fatalf("dynamic FPR metric=%v, want %v", got, wantFPR)
+	}
+	if got := gaugeValue(t, summaryBloomOccupancy); got <= 0 || got >= 1 {
+		t.Fatalf("dynamic occupancy metric=%v, want within (0,1)", got)
+	}
+	if got := gaugeValue(t, summaryBloomSaturated); got != 0 {
+		t.Fatalf("dynamic saturation metric=%v below design capacity, want 0", got)
+	}
+	for item := 50; item <= 100; item++ {
+		index.Add(fmt.Sprintf("%064x", item))
+	}
+	index.Snapshot()
+	if got := gaugeValue(t, summaryBloomSaturated); got != 1 {
+		t.Fatalf("dynamic saturation metric=%v above design capacity, want 1", got)
+	}
+}
+
+func bloomCapacityForItemsForTest(items int64) bloomCapacity {
+	bits, hashes := bloomParams(int(items))
+	return bloomCapacity{DesignEntries: items, BitCount: bits, Hashes: hashes}
+}
+
+func dynamicCacheSummaryForTest(t testing.TB, capacity bloomCapacity, keys []string, now time.Time) *cacheSummary {
+	t.Helper()
+	bits := make([]byte, capacity.BitCount/8)
+	for _, key := range keys {
+		if !IsValidCacheKey(key) {
+			t.Fatalf("invalid test cache key %q", key)
+		}
+		bloomHashes(key, capacity.BitCount, capacity.Hashes, func(bit uint64) {
+			bits[bit/8] |= 1 << (bit % 8)
+		})
+	}
+	summary, err := newDynamicCacheSummary(len(keys), capacity, bits, now, time.Minute)
+	if err != nil {
+		t.Fatalf("build dynamic summary fixture: %v", err)
+	}
+	return summary
+}
+
+func expectedDynamicSummaryMemoryReserveForTest(local bloomCapacity) int64 {
+	localRawBytes := int64(local.BitCount / 8)
+	maxRemoteBits, _ := bloomParams(int(cacheMetadataEntryLimit))
+	maxRemoteRawBytes := int64(maxRemoteBits / 8)
+	localIndexBytes := localRawBytes + int64(local.BitCount)*2
+	transientBytes := 3*int64(maxSummaryBodyBytes) + localRawBytes +
+		int64(maxSummaryPulls)*(3*int64(maxSummaryBodyBytes)+maxRemoteRawBytes+maxSummaryResponseHeaderBytes)
+	return localIndexBytes + transientBytes
+}
+
+func TestSummaryMemoryAccountingUsesCurrentLocalBloomCapacity(t *testing.T) {
+	const limit = int64(512 << 20)
+	smallLocal := bloomCapacityForItemsForTest(1_000_000)
+	largeLocal := bloomCapacityForItemsForTest(4_000_000)
+
+	small := NewPeerManager("test.svc", ":8081")
+	small.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{
+		MemoryLimitBytes: limit,
+		LocalBloom:       smallLocal,
+	})
+	smallReserved := int64(gaugeValue(t, summaryResidentBytes))
+	wantSmallReserved := expectedDynamicSummaryMemoryReserveForTest(smallLocal)
+	if smallReserved != wantSmallReserved {
+		t.Fatalf("small local Bloom reserve=%d, want %d", smallReserved, wantSmallReserved)
+	}
+	if got := smallReserved + int64(small.summaryRemoteMemoryBudget); got != limit {
+		t.Fatalf("small local reserve + remote budget=%d, want configured limit %d", got, limit)
+	}
+
+	large := NewPeerManager("test.svc", ":8081")
+	large.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{
+		MemoryLimitBytes: limit,
+		LocalBloom:       largeLocal,
+	})
+	largeReserved := int64(gaugeValue(t, summaryResidentBytes))
+	wantLargeReserved := expectedDynamicSummaryMemoryReserveForTest(largeLocal)
+	if largeReserved != wantLargeReserved {
+		t.Fatalf("large local Bloom reserve=%d, want %d", largeReserved, wantLargeReserved)
+	}
+	if got := largeReserved + int64(large.summaryRemoteMemoryBudget); got != limit {
+		t.Fatalf("large local reserve + remote budget=%d, want configured limit %d", got, limit)
+	}
+	if largeReserved <= smallReserved || large.summaryRemoteMemoryBudget >= small.summaryRemoteMemoryBudget {
+		t.Fatalf("larger local Bloom did not trade remote budget for local reservation: small=%d/%d large=%d/%d",
+			smallReserved, small.summaryRemoteMemoryBudget, largeReserved, large.summaryRemoteMemoryBudget)
+	}
+}
+
+func TestDynamicPeerSummaryThatDoesNotFitCurrentMemoryBudgetIsRejected(t *testing.T) {
+	peer := "peer-a:8081"
+	local := bloomCapacityForItemsForTest(2_000_000)
+	remote := bloomCapacityForItemsForTest(2_000)
+	now := time.Now()
+	summary := dynamicCacheSummaryForTest(t, remote, []string{strings.Repeat("a", 64)}, now)
+	reserved := expectedDynamicSummaryMemoryReserveForTest(local)
+	limit := reserved + int64(len(summary.Bits)) - 1
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{
+		MemoryLimitBytes: limit,
+		LocalBloom:       local,
+	})
+	// Exercise receive-side admission directly. Selection separately reserves
+	// for the largest accepted peer layout, but admission remains the final
+	// defense against a stale selection or a future caller bypassing it.
+	pm.mu.Lock()
+	pm.summaryPeers = []string{peer}
+	pm.mu.Unlock()
+	err := pm.receivePulledSummary(peer, marshalCacheSummaryForTest(t, summary), `"too-large"`, now)
+	if err == nil || !strings.Contains(err.Error(), "memory budget") {
+		t.Fatalf("peer summary admission error=%v, want memory-budget rejection", err)
+	}
+	if got := int64(gaugeValue(t, summaryResidentBytes)); got != reserved {
+		t.Fatalf("resident bytes after rejected peer=%d, want local/transient reserve %d", got, reserved)
+	}
+	if len(pm.summaries.records) != 0 || pm.summaries.bytes != 0 {
+		t.Fatalf("rejected peer summary became resident: records=%d bytes=%d", len(pm.summaries.records), pm.summaries.bytes)
+	}
+}
+
+func TestOversizedDynamicReplacementRetainsLastValidSummary(t *testing.T) {
+	const peer = "peer-a:8081"
+	now := time.Now()
+	oldKey := strings.Repeat("b", 64)
+	oldSummary := dynamicCacheSummaryForTest(t, bloomCapacityForItemsForTest(1_000), []string{oldKey}, now)
+	newSummary := dynamicCacheSummaryForTest(t, bloomCapacityForItemsForTest(2_000), []string{strings.Repeat("c", 64)}, now.Add(time.Second))
+	store := summaryStore{records: make(map[string]summaryRecord)}
+	member := func(candidate string) bool { return candidate == peer }
+	remoteBudget := len(oldSummary.Bits)
+
+	if err := store.receive(peer, marshalCacheSummaryForTest(t, oldSummary), `"last-valid"`, now, member, remoteBudget); err != nil {
+		t.Fatalf("install last valid summary: %v", err)
+	}
+	err := store.receive(peer, marshalCacheSummaryForTest(t, newSummary), `"rejected"`, now.Add(time.Second), member, remoteBudget)
+	if err == nil || !strings.Contains(err.Error(), "memory budget") {
+		t.Fatalf("replacement error=%v, want memory-budget rejection", err)
+	}
+	record, ok := store.records[peer]
+	if !ok {
+		t.Fatal("rejected replacement removed the last valid record")
+	}
+	if record.summary.CreatedNS != oldSummary.CreatedNS || record.etag != `"last-valid"` || record.bytes != len(oldSummary.Bits) {
+		t.Fatalf("rejected replacement mutated last valid record: %+v", record)
+	}
+	if store.bytes != len(oldSummary.Bits) || !record.summary.Contains(oldKey) {
+		t.Fatalf("last valid record/accounting not retained: bytes=%d contains_old=%t", store.bytes, record.summary.Contains(oldKey))
+	}
+}
+
 func TestSummaryMemoryMetricsIncludeLocalTransientAndRemoteState(t *testing.T) {
 	peer := "peer-a:8081"
 	bits := make([]byte, summaryBloomBits/8)
-	limit := summaryMemoryReserveBytes() + int64(len(bits))
+	limit := summaryMemoryReserveBytes() + int64(maxAcceptedSummaryBloomCapacity().BitCount/8)
 	pm := peerManagerWith([]string{peer})
 	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{MemoryLimitBytes: limit})
 	pm.refreshSummarySelection()
@@ -506,5 +844,84 @@ func TestSummaryMemoryMetricsAreZeroOutsideSummaryMode(t *testing.T) {
 	}
 	if got := gaugeValue(t, summaryResidentBytes); got != 0 {
 		t.Fatalf("probe-mode summary resident metric=%v, want 0", got)
+	}
+}
+
+func TestSummaryValidResidentMetricExcludesRetainedExpiredRecords(t *testing.T) {
+	peer := "peer-a:8081"
+	now := time.Now()
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	pm.mu.Lock()
+	pm.summaryPeers = []string{peer}
+	pm.mu.Unlock()
+	summary := fixedCacheSummaryForKeys(t, nil, now, 200*time.Millisecond)
+	if err := pm.receivePulledSummary(peer, marshalCacheSummaryForTest(t, summary), "", now); err != nil {
+		t.Fatal(err)
+	}
+	if got := gaugeValue(t, summaryValidResidentPeers); got != 1 {
+		t.Fatalf("valid resident peers before expiry=%v, want 1", got)
+	}
+	time.Sleep(250 * time.Millisecond)
+	pm.summaryClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	pm.pullSummary(context.Background(), peer)
+	if got := gaugeValue(t, summaryResidentCount); got != 1 {
+		t.Fatalf("retained resident records after expiry=%v, want 1", got)
+	}
+	if got := gaugeValue(t, summaryValidResidentPeers); got != 0 {
+		t.Fatalf("valid resident peers after expiry=%v, want 0", got)
+	}
+}
+
+func TestConcurrentSummaryGaugeRefreshCannotPublishOlderSnapshotLast(t *testing.T) {
+	peer := "peer-a:8081"
+	now := time.Now()
+	pm := peerManagerWith([]string{peer})
+	pm.ConfigureSummary(peerLookupSummary, "receiver", SummaryConfig{})
+	pm.mu.Lock()
+	pm.summaryPeers = []string{peer}
+	pm.mu.Unlock()
+
+	firstSnapshot := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var hookCalls atomic.Int32
+	pm.summaryGaugeSnapshotHook = func() {
+		if hookCalls.Add(1) == 1 {
+			close(firstSnapshot)
+			<-releaseFirst
+		}
+	}
+	firstDone := make(chan struct{})
+	go func() {
+		pm.updateSummaryGauges()
+		close(firstDone)
+	}()
+	<-firstSnapshot
+
+	summary := fixedCacheSummaryForKeys(t, nil, now, time.Minute)
+	if err := pm.summaries.receive(peer, marshalCacheSummaryForTest(t, summary), "", now, func(string) bool { return true }, pm.summaryRemoteMemoryBudget); err != nil {
+		t.Fatal(err)
+	}
+	secondDone := make(chan struct{})
+	go func() {
+		pm.updateSummaryGauges()
+		close(secondDone)
+	}()
+	close(releaseFirst)
+	<-firstDone
+	<-secondDone
+	pm.summaryGaugeSnapshotHook = nil
+
+	if got := gaugeValue(t, summaryResidentCount); got != 1 {
+		t.Fatalf("resident count after ordered concurrent refreshes=%v, want latest snapshot 1", got)
+	}
+	if got := gaugeValue(t, summaryValidResidentPeers); got != 1 {
+		t.Fatalf("valid resident count after ordered concurrent refreshes=%v, want latest snapshot 1", got)
 	}
 }

--- a/docs/design/cache-proxy-pulled-summary-lookup.md
+++ b/docs/design/cache-proxy-pulled-summary-lookup.md
@@ -28,7 +28,8 @@ origin fills. Summaries contain only opaque cache-locator membership hints.
 | `CACHE_PEER_LOOKUP_MODE` | `probe` | `probe` or `summary`; unknown values fail startup. |
 | `CACHE_MAX_ENTRIES` | `1000000` | Configured compatibility admission/convergence target. Startup may retain inspectable entries above it, up to the fixed 10,000,000-entry metadata guardrail. |
 | `CACHE_MAX_PERCENT` | `80` | Percentage-of-total-disk target for committed cache bytes. The active capacity also accounts for reclaimable cache-owned files while retaining a 5%-of-total-disk reserve. |
-| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | `536870912` (512 MiB) | Local counting Bloom, snapshot and pull reserve, and retained remote Bloom bits. |
+| `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` | unset | Optional emergency ceiling. Effective summary memory is `min(1 GiB, 20% of GOMEMLIMIT, explicit override when set)`. It includes the local counting Bloom, snapshot/pull reserve, and retained remote bits. |
+| `CACHE_SUMMARY_PUBLISH_FORMAT` | `fixed` | `fixed` builds the legacy 1M-entry counting layout and publishes v2. `dynamic` builds the disk-derived layout and publishes self-describing v3. Unknown values fail startup. |
 | `CACHE_PEER_MAX_PROBES_PER_REQUEST` | `5` | Maximum summary-mode `/cache/has` confirmations per client request, shared across block misses. `CACHE_PEER_MAX_PROBES` is a deprecated alias. |
 | `CACHE_MAX_CONCURRENT_PEER_PROBES` | `64` | Pod-wide, non-blocking cap on active confirmation HTTP requests and sockets. `CACHE_MAX_PEER_PROBES_IN_FLIGHT` is a deprecated alias. |
 
@@ -107,14 +108,14 @@ kernel memory.
 
 ## Local counting Bloom filter
 
-Each cache proxy owns one fixed-layout counting Bloom filter. Cache commits add
-the opaque SHA-256 cache locator and evictions remove it. Sixteen-bit counters
+Each cache proxy owns one counting Bloom filter. Cache commits add the opaque
+SHA-256 cache locator and evictions remove it. Sixteen-bit counters
 allow incremental deletion. A counter that reaches `uint16` saturation becomes
 sticky: this may add false positives but cannot create a false negative for a
 key represented by that filter.
 
-The filter is designed for 1,000,000 entries at a 1% per-peer false-positive
-rate:
+With `CACHE_SUMMARY_PUBLISH_FORMAT=fixed`, the filter remains designed for
+1,000,000 entries at a 1% per-peer false-positive rate:
 
 - 9,585,064 snapshot bits, approximately 1.14 MiB;
 - approximately 18.3 MiB of local 16-bit counters;
@@ -125,14 +126,29 @@ operator raises the entry target, additions continue rather than disabling
 summaries; the predicted false-positive rate rises smoothly and is exported as
 a metric. The filter is a hint and never authorizes a body transfer.
 
+With `CACHE_SUMMARY_PUBLISH_FORMAT=dynamic`, the design entry count is derived
+from stable physical disk target capacity and configured block size, capped by
+the 10,000,000-entry metadata guardrail. A 9.7M-entry design uses about 11 MiB
+of snapshot bits and 180–190 MiB of 16-bit counters. The publish-format setting
+chooses both the local counting layout and the wire version; they cannot be
+configured independently. Startup derives the layout after the bounded scan
+and statfs sample, then rehashes the bounded exact index once so existing cache
+keys are represented before any snapshot is served.
+
 About every 20 seconds, with per-process jitter, the proxy copies the current
 bitset into an immutable, versioned wire snapshot. It does not rescan or rehash
 the cache index. Each snapshot has a 60-second advertised TTL and a strict
-2 MiB encoded-body limit. It contains only:
+16 MiB encoded-body limit. Receivers accept:
 
-- summary and cache-layout versions;
-- creation and expiration timestamps;
-- fixed Bloom parameters and Bloom bits.
+- legacy v2: summary/cache-layout versions, timestamps, the exact fixed Bloom
+  parameters, and Bloom bits;
+- dynamic v3: those fields plus current item count, design item count, and
+  dimensions derived from the declared design count.
+
+V3 dimensions, counts, encoded length, decoded length, unknown fields, and
+timestamps are validated before the decoded bitset is admitted. V2 remains
+strictly fixed and rejects dynamic dimensions, allowing old and new summaries
+to coexist without silently reinterpreting a legacy payload.
 
 Raw URLs, signed query strings, ranges, object paths, organization identifiers,
 and cache locators are never serialized or logged.
@@ -151,7 +167,12 @@ identity and peer address. Before any summary RPC, it selects only as many
 peers as fit the remote-summary portion of
 `CACHE_SUMMARY_MEMORY_LIMIT_BYTES`. Different receivers can select different
 subsets, distributing degraded coverage when a fleet is larger than the
-memory budget.
+memory budget. Because a receiver does not know a peer's v2/v3 dimensions
+before pulling it, deterministic selection charges every peer at the largest
+accepted 10M-entry raw bitset. Receive-side admission then charges the actual
+decoded bitset and atomically preserves an older valid record when a
+replacement does not fit. This deliberately favors a safe deterministic prefix
+over arrival-order-dependent overcommit.
 
 The selected peers are pulled through `GET /cache/summary`:
 
@@ -165,13 +186,14 @@ The selected peers are pulled through `GET /cache/summary`:
   and a 500 ms response-header deadline;
 - a whole pull cycle is capped at 15 seconds and rotates its starting peer by
   the work submitted, so slow early peers cannot starve the same suffix;
-- declared and actual bodies above 2 MiB are rejected;
+- declared and actual bodies above 16 MiB are rejected;
 - cancellation closes requests, bodies, workers, timers, and the coordinator.
 
-The receiver validates the version, cache layout, declared Bloom parameters,
-timestamps, body size, and current selection before atomically replacing the
-last record for that peer. A failed or invalid pull leaves the previous valid
-record in place until its advertised expiration. `304 Not Modified` retains
+The receiver validates current selection before expensive decoding, then
+validates the version, cache layout, declared Bloom parameters, counts,
+timestamps, and body size before atomically replacing the last record for that
+peer. A failed or invalid pull leaves the previous valid record in place until
+its advertised expiration. `304 Not Modified` retains
 the record but does not extend it beyond that expiration. Failures do not create
 an independent retry queue; the next periodic or membership-triggered cycle is
 the retry. Newly selected peers that have not yet started their priority pull
@@ -277,11 +299,11 @@ memory maximum as a sustained operating target:
   unchanged filter content from freshness renewal.
 - `cache_proxy_summary_resident_count` counts retained records and can include
   an expired record until the next successful membership refresh prunes it.
-  There is no discovered/selected-peer denominator, and the age histogram is
-  observed only for Bloom-positive records. Pull outcomes, probe amplification,
-  and origin traffic expose degradation, but they cannot prove full summary
-  convergence. Add discovered, selected, and valid-unexpired gauges before
-  making readiness or autoscaling depend on summary coverage.
+  `cache_proxy_summary_valid_resident_peers` excludes expired records, and
+  `cache_proxy_summary_selected_peers` supplies its selected denominator.
+  There is still no discovered-peer gauge, and the age histogram is observed
+  only for Bloom-positive records. Add discovered-peer coverage before making
+  readiness or autoscaling depend on fleet-wide summary convergence.
 - Lookup currently scans current membership and tests retained filters under a
   shared read lock, then ranks candidates. This is acceptable at 10–20 nodes
   but request CPU, allocations, and writer-lock contention scale with fleet
@@ -299,24 +321,30 @@ canary and compatible peers build and pull their first snapshots.
 
 ## Memory model
 
-The default 512 MiB summary budget is divided conservatively:
+The effective summary ceiling is the smaller of 1 GiB, 20% of the runtime
+`GOMEMLIMIT`, and the optional explicit emergency ceiling. It is divided
+conservatively into:
 
-- local snapshot bitset and 16-bit counters: approximately 19.4 MiB;
-- current and next immutable encoded snapshots plus a temporary raw snapshot;
-- four simultaneous pulls, each reserving a 2 MiB encoded body plus decoded
-  bits;
-- retained remote raw bitsets with the remaining approximately 474.8 MiB.
+- the actual local raw bitset plus its 16-bit counting cells;
+- the currently served maximum 16 MiB body, the JSON encoder's bounded buffer
+  and returned clone, plus one actual local raw snapshot;
+- four simultaneous pulls, each reserving the response body, the JSON decoder
+  buffer, the bounded encoded-bit-field copy, a maximum decoded 10M-entry
+  bitset, and bounded response headers;
+- retained remote raw bitsets with everything left over.
 
-One remote fixed-layout bitset is approximately 1.14 MiB, so the default fits
-up to 415 remote summaries after reserves. Representative steady-state
-Bloom-state estimates are:
+The pull reserve uses v3 maxima even while the pod publishes fixed v2, because
+dual-format receivers can encounter a dynamic peer during rollout. Peer
+selection also charges each selected peer at the maximum raw v3 bitset; actual
+resident accounting uses each decoded bitset's length. Consequently:
 
-| Fleet nodes | Remote summaries per pod | Approximate Bloom state per pod |
-| ---: | ---: | ---: |
-| 10 | 9 | 47.5 MiB |
-| 30 | 29 | 70.3 MiB |
-| 100 | 99 | 150.3 MiB |
-| At default ceiling | 415 | Up to 512 MiB |
+- a fixed local layout reserves roughly 300–310 MiB before remote summaries;
+- a 9.7M-entry dynamic layout reserves roughly 480–490 MiB before remote
+  summaries;
+- a 1 GiB ceiling retains the current 10–20-node fleet comfortably even at
+  the largest supported layout;
+- a smaller explicit ceiling is rejected at startup if it cannot hold the
+  local/transient reserve plus one maximum peer summary.
 
 These numbers deliberately exclude the exact local cache index. Its key-count
 growth is independently bounded toward `CACHE_MAX_ENTRIES`; the disk target
@@ -353,35 +381,44 @@ worker identity labels. The primary rollout signals are:
 - peer and origin bytes and latency: useful locality versus fallback cost;
 - `cache_proxy_summary_pulls_total` and
   `cache_proxy_summary_serves_total`: synchronization health;
-- `cache_proxy_summary_resident_count` and summary age: retained-summary health,
-  subject to the coverage limitations above;
+- `cache_proxy_summary_selected_peers`, `cache_proxy_summary_resident_count`,
+  `cache_proxy_summary_valid_resident_peers`, and summary age: selected,
+  retained, and usable-summary health, subject to the coverage limitations
+  above;
 - `cache_proxy_summary_resident_bytes` versus
   `cache_proxy_summary_memory_limit_bytes`: conservative Bloom-state accounting
-  versus its configured ceiling. Resident bytes include the fixed local filter,
-  maximum transient reserve, and retained remote bits; they are not process RSS;
+  versus its derived/effective ceiling. Resident bytes include the current
+  local filter, maximum transient reserve, and retained remote bits; they are
+  not process RSS;
 - predicted Bloom false-positive rate, saturation, and bit occupancy.
 
 Rollout procedure:
 
-1. Deploy the compatible image to every cache-proxy pod while leaving
-   `CACHE_PEER_LOOKUP_MODE=probe`. Probe-mode pods contain the endpoint code but
-   return 404 and do not prebuild summaries.
+1. Deploy dual-format receivers to every cache-proxy pod with
+   `CACHE_SUMMARY_PUBLISH_FORMAT=fixed`. Existing v2 publishing is unchanged.
 2. Enable `summary` mode in non-production first. Expect partial coverage while
    the restarted/canary pods build and pull their initial snapshots.
 3. Confirm summaries converge after startup and membership changes, pull work
    remains bounded, and request-time probes never exceed the configured cap.
-4. Compare peer usefulness, origin bytes, and origin latency with probe mode.
-5. Confirm `cache_proxy_summary_resident_bytes` remains below
-   `cache_proxy_summary_memory_limit_bytes`, and process RSS remains below the
-   pod memory limit with sufficient headroom.
-6. Roll out gradually to production.
+4. Apply the cache-proxy memory limit and `GOMEMLIMIT` resource rollout, then
+   verify every pod completed it with stable memory.
+5. Set `CACHE_SUMMARY_PUBLISH_FORMAT=dynamic` in non-production. Mixed v2/v3
+   peers are expected during the rolling restart.
+6. Confirm `cache_proxy_summary_resident_bytes` remains below
+   `cache_proxy_summary_memory_limit_bytes`, Bloom dimensions match each disk
+   tier, and process RSS retains sufficient pod-limit headroom.
+7. Compare peer usefulness, origin bytes, and origin latency with fixed mode,
+   then roll dynamic publishing gradually through production.
 
 During a rolling deployment, a peer without the compatible GET summary endpoint
 remains uncovered; bounded confirmation or origin fallback is used until the
 endpoint is available.
 
-Rollback by restoring `CACHE_PEER_LOOKUP_MODE=probe`. Cache keys and on-disk
-layout are unchanged, so do not delete cache contents.
+Rollback dynamic publishing by restoring
+`CACHE_SUMMARY_PUBLISH_FORMAT=fixed`, which rebuilds the fixed local filter on
+restart. Roll back lookup independently by restoring
+`CACHE_PEER_LOOKUP_MODE=probe`. Cache keys and on-disk layout are unchanged, so
+do not delete cache contents.
 
 ## Operator runbook
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -268,16 +268,19 @@ These are emitted by the standalone `cache-proxy` binary itself (`cmd/cache-prox
 | `cache_proxy_peer_probes_skipped_total` | Counter | None | Summary-mode confirmations skipped because the pod-wide active `/cache/has` HTTP-request/socket budget was exhausted; those requests fall back to origin without queuing. This budget does not count total process goroutines. |
 | `cache_proxy_summary_pulls_total` | Counter | `outcome` | Receiver-driven `GET /cache/summary` attempts by outcome, including success, not-modified, timeout, rejection, and size/read failures. |
 | `cache_proxy_summary_serves_total` | Counter | `outcome` | Local summary endpoint and snapshot-build outcomes. |
-| `cache_proxy_summary_resident_count` | Gauge | None | Current retained peer summaries. |
-| `cache_proxy_summary_resident_bytes` | Gauge | None | Conservative total Bloom-state accounting: the fixed local counting filter, maximum snapshot/pull transient reserve, and retained remote summary bits. This is reserved/accounted memory, not measured process RSS. It is `0` outside summary mode. |
-| `cache_proxy_summary_memory_limit_bytes` | Gauge | None | Effective `CACHE_SUMMARY_MEMORY_LIMIT_BYTES` ceiling used for the total Bloom-state accounting above. It is `0` outside summary mode. Alert when resident bytes approach this value. |
+| `cache_proxy_summary_selected_peers` | Gauge | None | Deterministic peer prefix selected for summary pulls after conservatively charging each peer at the largest accepted dynamic bitset. |
+| `cache_proxy_summary_resident_count` | Gauge | None | Current retained peer summary records, including expired records awaiting membership-refresh pruning. |
+| `cache_proxy_summary_valid_resident_peers` | Gauge | None | Retained peer summaries whose advertised TTL has not expired. Compare with selected peers to measure current usable coverage. |
+| `cache_proxy_summary_resident_bytes` | Gauge | None | Conservative total Bloom-state accounting: the current fixed or dynamic local counting filter, maximum v3 snapshot/pull transient reserve, and actual retained remote summary bits. This is reserved/accounted memory, not measured process RSS. It is `0` outside summary mode. |
+| `cache_proxy_summary_memory_limit_bytes` | Gauge | None | Effective `min(1 GiB, 20% of GOMEMLIMIT, optional explicit emergency ceiling)` used for total Bloom-state accounting. It is `0` outside summary mode. Alert when resident bytes approach this value. |
 | `cache_proxy_summary_age_seconds` | Histogram | None | Age of summaries used in local Bloom lookups. |
 | `cache_proxy_summary_lookups_total` | Counter | `outcome` | `no_valid_summary`, `no_positive`, or `positive_candidate`. |
 | `cache_proxy_summary_confirmed_gets_total` | Counter | `outcome` | Peer body GET outcomes in summary mode. A GET is attempted only after an exact bounded `/cache/has` confirmation. |
 | `cache_proxy_summary_bloom_items` | Gauge | None | Local live cache keys represented by the incrementally maintained counting Bloom filter. |
-| `cache_proxy_summary_bloom_bits` / `cache_proxy_summary_bloom_hashes` | Gauge | None | Fixed Bloom-filter layout, sized for 1m keys at a 1% target false-positive rate. |
-| `cache_proxy_summary_bloom_false_positive_ratio` | Gauge | None | Predicted per-peer false-positive ratio from live item count and filter layout. This rises smoothly after 1m keys; use fleet size to interpret aggregate request cost. |
-| `cache_proxy_summary_bloom_saturated` | Gauge | None | `1` when the local live key count exceeds the 1m target capacity; snapshot refresh and serving continue. |
+| `cache_proxy_summary_bloom_design_items` | Gauge | None | Entry count used to derive the current local Bloom dimensions at the 1% target FPR: 1m in fixed mode or disk-derived in dynamic mode. |
+| `cache_proxy_summary_bloom_bits` / `cache_proxy_summary_bloom_hashes` | Gauge | None | Current fixed or disk-derived Bloom-filter layout. |
+| `cache_proxy_summary_bloom_false_positive_ratio` | Gauge | None | Predicted per-peer false-positive ratio from live item count and the current filter layout. Use fleet size to interpret aggregate request cost. |
+| `cache_proxy_summary_bloom_saturated` | Gauge | None | `1` when the local live key count exceeds the current design-item count; snapshot refresh and serving continue. |
 | `cache_proxy_summary_bloom_bit_occupancy_ratio` | Gauge | None | Fraction of local Bloom bits set; a direct saturation signal independent of the FPR estimate. |
 | `cache_proxy_summary_bloom_additions_total` / `cache_proxy_summary_bloom_removals_total` | Counter | None | Cache commits and evictions applied incrementally to the local Bloom index. |
 | `cache_proxy_summary_bloom_counter_saturations_total` | Counter | None | Counting-Bloom cells that reached `uint16` saturation and were made sticky to avoid false negatives. |


### PR DESCRIPTION
## Summary

- add self-describing v3 dynamic Bloom summaries while dual-reading legacy v2 and publishing v2 by default
- derive local filter sizing and peer memory admission from disk target and `GOMEMLIMIT`, with bounded deterministic peer selection
- safely rebuild startup summaries and harden malformed summary, admission, metrics, rollout documentation, and test coverage

## Rollout

- deploy dual-format receivers with `CACHE_SUMMARY_PUBLISH_FORMAT=fixed`
- after the receiver and memory rollout, switch publishers to `dynamic`

## Test plan

- `go test ./cmd/cache-proxy -count=1`
- `go test -race ./cmd/cache-proxy -count=1`
- `just lint`
- `just ci` (all PR3 unit, scenario, and cache-proxy lanes pass; the only failure is pre-existing `TestCatalogPsqlCommands/psql_dn`, reproduced unchanged on the PR2 base)
- `just test-controlplane test-configstore-integration test-controlplane-k8s`