### PR TITLE
Identify Trino tenants by database_name, not org id

### DIFF
--- a/controlplane/configstore/models.go
+++ b/controlplane/configstore/models.go
@@ -524,6 +524,26 @@ type TrinoEnabledOrg struct {
 	State            ManagedWarehouseProvisioningState // current state at read time
 }
 
+// TrinoPrincipal is the tenant's customer-facing identity in Trino: the
+// username it authenticates as, and the stem every derived name is built
+// from (catalog, group, resource group).
+//
+// It is DatabaseName, not OrgID, so a tenant is known by the same name in
+// Trino as in its DuckDB warehouse — where database_name is already the
+// public socket identity (the SNI hostname label and the dbname clients
+// connect with). OrgID may be a bare UUID, which would put a hex string in
+// the customer's connection string and in every fully-qualified table
+// reference.
+//
+// Safe as a catalog stem because duckgres_orgs.database_name carries a
+// global unique index, so two tenants cannot derive the same catalog name.
+// OrgID remains the primary key and keys all internal plumbing (config
+// store rows, the tenant-password Secret); only names the customer types
+// are derived from this.
+func (o TrinoEnabledOrg) TrinoPrincipal() string {
+	return o.DatabaseName
+}
+
 // NOTE: the cluster-wide singleton config tables (global_config,
 // ducklake_config, rate_limit_config, query_log_config) were removed — they
 // were seeded and served by the admin API but never read to drive runtime

--- a/controlplane/configstore/trino.go
+++ b/controlplane/configstore/trino.go
@@ -197,25 +197,33 @@ func (cs *ConfigStore) DisableTrino(orgID string) error {
 // runs in the same handler that toggles Enabled), and silently skipping is
 // safer than projecting a half-built password file.
 //
+// Orgs with no duckgres_orgs row, or a blank database_name, are skipped for
+// the same reason: database_name is the org's Trino principal (see
+// TrinoEnabledOrg.TrinoPrincipal), so without it there is no username to put
+// in password.db and no stem to build a catalog name from. Skipping leaves
+// the org Pending rather than projecting a catalog called `org_`.
+//
 // Every cell's rows are returned, unassigned ones included; the caller
 // filters by cell (see TrinoEnabledOrg.CellID for why the filter is not in
 // the SQL).
 func (cs *ConfigStore) ListTrinoEnabledOrgs() ([]TrinoEnabledOrg, error) {
 	var out []TrinoEnabledOrg
 	// Inner join with duckgres_org_users on (org_id, username='root') so a
-	// missing OrgUser row drops the org from the result. Then left join with
-	// duckgres_orgs to pick up database_name.
+	// missing OrgUser row drops the org from the result. Inner join with
+	// duckgres_orgs for database_name, which is the org's Trino principal —
+	// a missing or blank one drops the org for the same reason.
 	err := cs.db.Table("duckgres_managed_warehouse_trino AS t").
 		Select(`t.org_id AS org_id,
-		         COALESCE(o.database_name, '') AS database_name,
+		         o.database_name AS database_name,
 		         t.tier AS tier,
 		         COALESCE(t.trino_cell_id, '') AS cell_id,
 		         u.password AS root_password_hash,
 		         t.state AS state`).
 		Joins(`INNER JOIN duckgres_org_users AS u
 		        ON u.org_id = t.org_id AND u.username = 'root'`).
-		Joins(`LEFT JOIN duckgres_orgs AS o ON o.name = t.org_id`).
+		Joins(`INNER JOIN duckgres_orgs AS o ON o.name = t.org_id`).
 		Where("t.enabled = ?", true).
+		Where("o.database_name <> ''").
 		Order("t.org_id ASC").
 		Scan(&out).Error
 	if err != nil {

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -167,8 +167,8 @@ func trinoSanitize(orgName string) string {
 // TrinoCatalogName returns the catalog identifier for an org.
 // Format: org_<sanitized>. The sanitization maps Org.Name to Trino
 // identifier rules ([a-z0-9_]); any other characters collapse to
-// underscores. Catalog name uniqueness across orgs depends on Org.Name
-// uniqueness post-sanitization.
+// underscores. Catalog name uniqueness across orgs depends on
+// database_name's global unique index holding post-sanitization.
 //
 // The name carried an `_iceberg` suffix while the backing table format was
 // Iceberg behind Lakekeeper. Warehouses are DuckLake now (migration 000014
@@ -176,15 +176,16 @@ func trinoSanitize(orgName string) string {
 // pinned from three sides — this function, opa.ManagedCatalogPattern, and
 // the regex literal inside policy.rego — and the pair of tests named in
 // ManagedCatalogPattern's doc comment fails if any one of them moves alone.
-func TrinoCatalogName(orgName string) string {
-	return "org_" + trinoSanitize(orgName)
+func TrinoCatalogName(principal string) string {
+	return "org_" + trinoSanitize(principal)
 }
 
-// TrinoGroupName returns the file-group-provider group label for an org.
+// TrinoGroupName returns the file-group-provider group label for an org,
+// derived from its Trino principal.
 // Format: org_<sanitized>. Matches the OPA `input.context.identity.groups`
 // the customer Trino sends with each decision request.
-func TrinoGroupName(orgName string) string {
-	return "org_" + trinoSanitize(orgName)
+func TrinoGroupName(principal string) string {
+	return "org_" + trinoSanitize(principal)
 }
 
 // TrinoResourceGroupName returns the resource-group selector key for
@@ -192,10 +193,10 @@ func TrinoGroupName(orgName string) string {
 // get re-interpreted as a hierarchy separator in Trino's resource-
 // group path (and so the selector + subgroup names stay aligned across
 // the catalog, group, and resource-group projections). Customer
-// principals' Trino username == orgName (a DNS-1123 label), and we
+// principals' Trino username == the principal (a DNS-1123 label), and we
 // sanitize defensively so a non-identifier char can't reshape the path.
-func TrinoResourceGroupName(orgName string) string {
-	return "root.tenants." + trinoSanitize(orgName)
+func TrinoResourceGroupName(principal string) string {
+	return "root.tenants." + trinoSanitize(principal)
 }
 
 // TrinoCatalogClient is the REST surface the provisioner needs against
@@ -1173,12 +1174,24 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 	// tenant's running queries.
 	wanted := make(map[string]bool, len(orgs))
 	for _, o := range orgs {
-		wanted[TrinoCatalogName(o.OrgID)] = true
+		if o.TrinoPrincipal() == "" {
+			continue
+		}
+		wanted[TrinoCatalogName(o.TrinoPrincipal())] = true
 	}
 
 	var errs []error
 	for _, o := range orgs {
-		name := TrinoCatalogName(o.OrgID)
+		// No principal means no derivable catalog name. The listing query
+		// already excludes these, so this is defensive: creating `org_`
+		// would collide across every such org.
+		if o.TrinoPrincipal() == "" {
+			err := errors.New("org has no database_name, which is its Trino principal")
+			errs = append(errs, fmt.Errorf("org %s: %w", o.OrgID, err))
+			outcomes[o.OrgID] = catalogOutcome{Err: err}
+			continue
+		}
+		name := TrinoCatalogName(o.TrinoPrincipal())
 
 		// The password gate comes FIRST, before the already-exists
 		// shortcut: a catalog whose password file is missing is a broken
@@ -1420,18 +1433,23 @@ func (p *TrinoProvisioner) reconcileAuthSecret(ctx context.Context, orgs []confi
 //
 // Format conventions:
 //
-//	password.db: <org_name>:<bcrypt hash from OrgUser.Password>
-//	             One line per org (org_name is the DNS-1123 Org.Name, the
-//	             customer principal's Trino username). Hash is copied
-//	             through unchanged — it's already bcrypt in the configstore.
+//	password.db: <principal>:<bcrypt hash from OrgUser.Password>
+//	             One line per org. The principal is the org's
+//	             database_name (see TrinoEnabledOrg.TrinoPrincipal), so the
+//	             tenant's Trino username is the same name it uses for its
+//	             DuckDB warehouse rather than a bare org UUID. Hash is
+//	             copied through unchanged — it's already bcrypt in the
+//	             configstore, and it is the SAME hash the DuckDB warehouse
+//	             authenticates with, so one password works for both.
 //	group.db:    <group_name>:<comma-separated users>
 //	             NOTE: this is the opposite direction from password.db.
 //	             For v1 (one user per org) the value is the single
-//	             org_name. Easy to get backwards, hence this comment.
+//	             principal. Easy to get backwards, hence this comment.
 //
-// Orgs without a RootPasswordHash are skipped silently (the listing
-// query already filters to (org, root-user) pairs, so this is just
-// defensive against future changes).
+// Orgs without a RootPasswordHash or a principal are skipped silently
+// (the listing query already filters to (org, root-user) pairs with a
+// non-blank database_name, so this is just defensive against future
+// changes).
 //
 // adminPasswordHash is the bcrypt for opa.AdminPrincipal — the
 // provisioner's own catalog-management identity. When non-empty, the
@@ -1451,13 +1469,14 @@ func BuildTrinoAuthFiles(orgs []configstore.TrinoEnabledOrg, adminPasswordHash s
 		grpLines = append(grpLines, fmt.Sprintf("%s:%s", opa.AdminGroup, opa.AdminPrincipal))
 	}
 	for _, o := range orgs {
-		if o.RootPasswordHash == "" || o.OrgID == "" {
+		principal := o.TrinoPrincipal()
+		if o.RootPasswordHash == "" || principal == "" {
 			continue
 		}
-		pwLines = append(pwLines, fmt.Sprintf("%s:%s", o.OrgID, o.RootPasswordHash))
+		pwLines = append(pwLines, fmt.Sprintf("%s:%s", principal, o.RootPasswordHash))
 		// group_name first, comma-separated users second. For v1 this
-		// is one user per group (the org name only).
-		grpLines = append(grpLines, fmt.Sprintf("%s:%s", TrinoGroupName(o.OrgID), o.OrgID))
+		// is one user per group (the principal only).
+		grpLines = append(grpLines, fmt.Sprintf("%s:%s", TrinoGroupName(principal), principal))
 	}
 	// Trailing newline so a file with one entry round-trips through
 	// `cat password.db | head` cleanly; matters mostly for ops.
@@ -1586,19 +1605,23 @@ func BuildTrinoResourceGroups(orgs []configstore.TrinoEnabledOrg) ([]byte, error
 		Group: "root.admin." + opa.AdminPrincipal,
 	}}
 	for _, o := range orgs {
-		if o.OrgID == "" {
+		principal := o.TrinoPrincipal()
+		if principal == "" {
 			continue
 		}
 		sg := tierLimits(o.Tier)
 		// Subgroup name is sanitized to match TrinoResourceGroupName's
 		// final path component. The selector's User field stays raw —
 		// it matches against Trino's `current_user`, which is the
-		// auth-time username (raw orgID).
-		sg.Name = trinoSanitize(o.OrgID)
+		// auth-time username, i.e. the unsanitized principal. The two
+		// differ whenever database_name contains a hyphen, which is
+		// exactly why the selector and the subgroup name are derived
+		// separately here.
+		sg.Name = trinoSanitize(principal)
 		subgroups = append(subgroups, sg)
 		selectors = append(selectors, resourceGroupSelector{
-			User:  o.OrgID,
-			Group: TrinoResourceGroupName(o.OrgID),
+			User:  principal,
+			Group: TrinoResourceGroupName(principal),
 		})
 	}
 
@@ -1666,11 +1689,12 @@ func (p *TrinoProvisioner) reconcileOPABundle(_ context.Context, orgs []configst
 	gc := make(opa.GroupCatalogs, len(orgs)+1)
 	adminCatalogs := make(map[string]bool, len(orgs))
 	for _, o := range orgs {
-		if o.OrgID == "" {
+		principal := o.TrinoPrincipal()
+		if principal == "" {
 			continue
 		}
-		catalog := TrinoCatalogName(o.OrgID)
-		gc[TrinoGroupName(o.OrgID)] = map[string]bool{catalog: true}
+		catalog := TrinoCatalogName(principal)
+		gc[TrinoGroupName(principal)] = map[string]bool{catalog: true}
 		adminCatalogs[catalog] = true
 	}
 	if len(adminCatalogs) > 0 {

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -167,8 +167,15 @@ func trinoSanitize(orgName string) string {
 // TrinoCatalogName returns the catalog identifier for an org.
 // Format: org_<sanitized>. The sanitization maps Org.Name to Trino
 // identifier rules ([a-z0-9_]); any other characters collapse to
-// underscores. Catalog name uniqueness across orgs depends on
-// database_name's global unique index holding post-sanitization.
+// underscores.
+//
+// For principals that satisfy ValidateDatabaseName the mapping is injective
+// — that grammar allows only lowercase alphanumerics and hyphens, so the
+// hyphen is the only character rewritten and no valid principal contains the
+// underscore it becomes — which, with database_name's global unique index,
+// makes distinct orgs' catalog names distinct by construction. Grandfathered
+// rows predate the validation and can still converge; rejectPrincipalCollisions
+// holds those orgs back rather than letting one read the other's catalog.
 //
 // The name carried an `_iceberg` suffix while the backing table format was
 // Iceberg behind Lakekeeper. Warehouses are DuckLake now (migration 000014
@@ -487,13 +494,20 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	// regardless of how the DB driver returned the rows.
 	sort.Slice(orgs, func(i, j int) bool { return orgs[i].OrgID < orgs[j].OrgID })
 
+	// Orgs whose principals collide are held back from EVERY projection
+	// below. This has to happen before the five steps, not inside the
+	// catalog step: if a colliding org still reached the OPA bundle, its
+	// group would be granted the shared catalog name and it could read the
+	// other tenant's data through the catalog that org legitimately owns.
+	projectable, collisions := rejectPrincipalCollisions(orgs)
+
 	var errs []error
 
 	// 1. Auth file projection (K8s Secret). Atomic Secret update.
 	//    Runs BEFORE catalogs so the admin lines exist in password.db
 	//    + group.db when the catalog client's first request reaches
 	//    the coordinator on a cold-start tick.
-	authErr := p.reconcileAuthSecret(ctx, orgs)
+	authErr := p.reconcileAuthSecret(ctx, projectable)
 	if authErr != nil {
 		errs = append(errs, fmt.Errorf("reconcile auth secret: %w", authErr))
 	}
@@ -502,7 +516,7 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	//    tier; rebuilt every tick. Also runs before catalogs so the
 	//    coordinator's resource-groups manager has a valid file when
 	//    catalog creation kicks off queries on tier-specific groups.
-	rgErr := p.reconcileResourceGroups(ctx, orgs)
+	rgErr := p.reconcileResourceGroups(ctx, projectable)
 	if rgErr != nil {
 		errs = append(errs, fmt.Errorf("reconcile resource groups: %w", rgErr))
 	}
@@ -511,7 +525,7 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	//    the in-memory store the bundle HTTP handler serves. Pre-
 	//    catalog so the OPA sidecar's authorization decisions for the
 	//    catalog reconcile's own queries see the up-to-date roster.
-	opaErr := p.reconcileOPABundle(ctx, orgs)
+	opaErr := p.reconcileOPABundle(ctx, projectable)
 	if opaErr != nil {
 		errs = append(errs, fmt.Errorf("reconcile opa bundle: %w", opaErr))
 	}
@@ -529,7 +543,7 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	//    therefore still fail its first connection; that surfaces as a
 	//    per-org catalog error and the next tick retries against a Secret
 	//    that has since landed.
-	tenants, tenantErr := p.reconcileTenantSecrets(ctx, orgs)
+	tenants, tenantErr := p.reconcileTenantSecrets(ctx, projectable)
 	if tenantErr != nil {
 		errs = append(errs, fmt.Errorf("reconcile tenant secrets: %w", tenantErr))
 	}
@@ -559,7 +573,7 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	var catalogOutcomes map[string]catalogOutcome
 	if globalErr == nil {
 		var catErr error
-		catalogOutcomes, catErr = p.reconcileCatalogs(ctx, orgs, tenants)
+		catalogOutcomes, catErr = p.reconcileCatalogs(ctx, projectable, tenants)
 		if catErr != nil {
 			errs = append(errs, fmt.Errorf("reconcile catalogs: %w", catErr))
 		}
@@ -573,12 +587,93 @@ func (p *TrinoProvisioner) Reconcile(ctx context.Context) error {
 	// since each is a single K8s API write — wrap them once. Per-org
 	// variance lives at the catalog step, which folds in the per-org
 	// tenant-password outcomes.
+	if len(collisions) > 0 {
+		if catalogOutcomes == nil {
+			catalogOutcomes = make(map[string]catalogOutcome, len(collisions))
+		}
+		for orgID, err := range collisions {
+			// out.Err is checked before globalErr in writePerOrgStates,
+			// so the collision is what the operator sees.
+			catalogOutcomes[orgID] = catalogOutcome{Err: err}
+			errs = append(errs, fmt.Errorf("org %s: %w", orgID, err))
+		}
+	}
 	p.writePerOrgStates(orgs, catalogOutcomes, globalErr)
 
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// rejectPrincipalCollisions splits orgs into those safe to project and
+// those whose Trino catalog name is not unique to them.
+//
+// Every Trino-facing name is trinoSanitize(principal), and sanitization is
+// injective over principals that satisfy ValidateDatabaseName — that grammar
+// is lowercase alphanumerics and hyphens, so the hyphen is the only
+// character sanitization rewrites, and no valid principal contains the
+// underscore it rewrites to. Grandfathered rows predate that validation
+// though (see configstore.ValidateDatabaseName), so a stored name may hold
+// an underscore or uppercase, and then "Acme_Corp" and "acme-corp" both
+// derive catalog org_acme_corp.
+//
+// Left alone that is a cross-tenant read: the first org creates the catalog
+// against its own metadata store, the second finds the name already present,
+// is recorded as Existed, and is granted that catalog by the OPA bundle —
+// so it queries the first org's data. Both orgs are therefore held back and
+// reported Failed. Refusing to provision either is the only safe resolution:
+// picking a winner by sort order would silently hand one tenant a catalog
+// the other also believes it owns.
+func rejectPrincipalCollisions(orgs []configstore.TrinoEnabledOrg) (projectable []configstore.TrinoEnabledOrg, collisions map[string]error) {
+	byCatalog := make(map[string][]string, len(orgs))
+	for _, o := range orgs {
+		principal := o.TrinoPrincipal()
+		if principal == "" {
+			// No principal is a separate condition, reported by the
+			// catalog step; it is not a collision.
+			continue
+		}
+		name := TrinoCatalogName(principal)
+		byCatalog[name] = append(byCatalog[name], o.OrgID)
+	}
+
+	contested := make(map[string]string, 0) // orgID -> catalog name
+	for name, ids := range byCatalog {
+		if len(ids) < 2 {
+			continue
+		}
+		for _, id := range ids {
+			contested[id] = name
+		}
+	}
+	if len(contested) == 0 {
+		return orgs, nil
+	}
+
+	collisions = make(map[string]error, len(contested))
+	projectable = make([]configstore.TrinoEnabledOrg, 0, len(orgs)-len(contested))
+	for _, o := range orgs {
+		name, bad := contested[o.OrgID]
+		if !bad {
+			projectable = append(projectable, o)
+			continue
+		}
+		others := make([]string, 0, len(byCatalog[name])-1)
+		for _, id := range byCatalog[name] {
+			if id != o.OrgID {
+				others = append(others, id)
+			}
+		}
+		sort.Strings(others)
+		collisions[o.OrgID] = fmt.Errorf(
+			"database_name %q derives catalog %s, which is also derived by org(s) %s; "+
+				"refusing to provision either — rename one so the catalog names differ",
+			o.TrinoPrincipal(), name, strings.Join(others, ", "))
+		slog.Error("Trino reconcile: refusing to provision orgs whose catalog names collide.",
+			"org", o.OrgID, "database_name", o.TrinoPrincipal(), "catalog", name, "colliding_with", others)
+	}
+	return projectable, collisions
 }
 
 // claimCellOrgs filters the fleet-wide Trino-enabled listing down to the

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -176,29 +176,89 @@ func (c *fakeCatalogClient) DropCatalog(ctx context.Context, name string) error 
 
 func TestBuildTrinoAuthFiles_OneUserPerOrg(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", RootPasswordHash: "$2a$10$hash42"},
-		{OrgID: "43", RootPasswordHash: "$2a$10$hash43"},
+		{OrgID: "42", DatabaseName: "db42", RootPasswordHash: "$2a$10$hash42"},
+		{OrgID: "43", DatabaseName: "db43", RootPasswordHash: "$2a$10$hash43"},
 	}
 	// Empty admin hash so the test focuses on the per-org projection;
 	// admin-line projection is exercised in its own test below.
 	pw, grp := BuildTrinoAuthFiles(orgs, "")
 
-	wantPW := "42:$2a$10$hash42\n43:$2a$10$hash43\n"
+	// Usernames are the orgs' database_names, NOT their org ids — the
+	// tenant authenticates to Trino as the same name it uses for its
+	// DuckDB warehouse.
+	wantPW := "db42:$2a$10$hash42\ndb43:$2a$10$hash43\n"
 	if pw != wantPW {
 		t.Errorf("password.db =\n%q\nwant\n%q", pw, wantPW)
 	}
 	// group.db is group-first: <group>:<comma-separated users>. Easy to
 	// get backwards, hence the explicit assertion.
-	wantGrp := "org_42:42\norg_43:43\n"
+	wantGrp := "org_db42:db42\norg_db43:db43\n"
 	if grp != wantGrp {
 		t.Errorf("group.db =\n%q\nwant\n%q", grp, wantGrp)
 	}
 }
 
+// The tenant's Trino identity is its database_name, never its org id.
+// database_name is what the customer already uses for its DuckDB warehouse
+// (the SNI hostname label and the dbname), whereas org_id may be a bare
+// UUID — which would put a hex string in the connection string and in every
+// fully-qualified table reference.
+func TestTrinoIdentityIsDatabaseNameNotOrgID(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{{
+		OrgID:            "0d8f2c1e4b7a4d9e8f3c2b1a0e9d8c7b",
+		DatabaseName:     "acme-analytics",
+		RootPasswordHash: "$2a$10$hash",
+	}}
+
+	pw, grp := BuildTrinoAuthFiles(orgs, "")
+	if strings.Contains(pw, orgs[0].OrgID) || strings.Contains(grp, orgs[0].OrgID) {
+		t.Errorf("auth files leak the org id:\npassword.db=%q\ngroup.db=%q", pw, grp)
+	}
+	if want := "acme-analytics:$2a$10$hash\n"; pw != want {
+		t.Errorf("password.db = %q, want %q", pw, want)
+	}
+	// The group label is sanitized (hyphen → underscore) while the user
+	// stays raw, because the user is matched against Trino's current_user.
+	if want := "org_acme_analytics:acme-analytics\n"; grp != want {
+		t.Errorf("group.db = %q, want %q", grp, want)
+	}
+
+	if got, want := TrinoCatalogName(orgs[0].TrinoPrincipal()), "org_acme_analytics"; got != want {
+		t.Errorf("catalog = %q, want %q", got, want)
+	}
+
+	rg, err := BuildTrinoResourceGroups(orgs)
+	if err != nil {
+		t.Fatalf("BuildTrinoResourceGroups: %v", err)
+	}
+	if strings.Contains(string(rg), orgs[0].OrgID) {
+		t.Errorf("resource-groups.json leaks the org id: %s", rg)
+	}
+	if !strings.Contains(string(rg), `"user": "acme-analytics"`) {
+		t.Errorf("resource-groups.json selector should match the raw principal: %s", rg)
+	}
+}
+
+// An org with no database_name has no derivable Trino identity, so it must
+// be skipped rather than collapsed into a shared `org_` name.
+func TestBuildTrinoAuthFiles_SkipsOrgWithoutDatabaseName(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", DatabaseName: "", RootPasswordHash: "$2a$10$hash42"},
+		{OrgID: "43", DatabaseName: "db43", RootPasswordHash: "$2a$10$hash43"},
+	}
+	pw, grp := BuildTrinoAuthFiles(orgs, "")
+	if want := "db43:$2a$10$hash43\n"; pw != want {
+		t.Errorf("password.db = %q, want %q", pw, want)
+	}
+	if want := "org_db43:db43\n"; grp != want {
+		t.Errorf("group.db = %q, want %q", grp, want)
+	}
+}
+
 func TestBuildTrinoAuthFiles_DeterministicOrder(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", RootPasswordHash: "$a"},
-		{OrgID: "43", RootPasswordHash: "$b"},
+		{OrgID: "42", DatabaseName: "db42", RootPasswordHash: "$a"},
+		{OrgID: "43", DatabaseName: "db43", RootPasswordHash: "$b"},
 	}
 	pw1, grp1 := BuildTrinoAuthFiles(orgs, "")
 	pw2, grp2 := BuildTrinoAuthFiles(orgs, "")
@@ -209,8 +269,8 @@ func TestBuildTrinoAuthFiles_DeterministicOrder(t *testing.T) {
 
 func TestBuildTrinoAuthFiles_SkipsEmptyHashes(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", RootPasswordHash: ""},
-		{OrgID: "43", RootPasswordHash: "$2a$10$hash43"},
+		{OrgID: "42", DatabaseName: "db42", RootPasswordHash: ""},
+		{OrgID: "43", DatabaseName: "db43", RootPasswordHash: "$2a$10$hash43"},
 		{OrgID: "", RootPasswordHash: "$2a$10$orphan"},
 	}
 	pw, grp := BuildTrinoAuthFiles(orgs, "")
@@ -236,7 +296,7 @@ func TestBuildTrinoAuthFiles_IncludesAdminWhenHashProvided(t *testing.T) {
 	// The OPA policy's is_admin is a CONJUNCTION of username and group
 	// membership, so the admin has to appear in BOTH files or the
 	// provisioner cannot manage catalogs at all.
-	orgs := []configstore.TrinoEnabledOrg{{OrgID: "42", RootPasswordHash: "$2a$10$hash42"}}
+	orgs := []configstore.TrinoEnabledOrg{{OrgID: "42", DatabaseName: "db42", RootPasswordHash: "$2a$10$hash42"}}
 	pw, grp := BuildTrinoAuthFiles(orgs, "$2a$10$adminhash")
 
 	if !strings.HasPrefix(pw, opa.AdminPrincipal+":$2a$10$adminhash\n") {
@@ -347,10 +407,10 @@ func TestTrinoCatalogNameMatchesManagedNamePattern(t *testing.T) {
 
 func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", Tier: "free"},
-		{OrgID: "43", Tier: "growth"},
-		{OrgID: "44", Tier: "scale"},
-		{OrgID: "45", Tier: ""},
+		{OrgID: "42", DatabaseName: "db42", Tier: "free"},
+		{OrgID: "43", DatabaseName: "db43", Tier: "growth"},
+		{OrgID: "44", DatabaseName: "db44", Tier: "scale"},
+		{OrgID: "45", DatabaseName: "db45", Tier: ""},
 	}
 	raw, err := BuildTrinoResourceGroups(orgs)
 	if err != nil {
@@ -392,11 +452,11 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 		t.Fatalf("expected 4 org subgroups under tenants, got %d", len(subs))
 	}
 	// Selector + subgroup name == org name; verify the join.
-	wantByName := map[string]int{ // hardConcurrencyLimit per tier
-		"42": 3,  // free
-		"43": 10, // growth
-		"44": 25, // scale
-		"45": 3,  // empty → default ("free")
+	wantByName := map[string]int{ // hardConcurrencyLimit per tier, keyed by principal
+		"db42": 3,  // free
+		"db43": 10, // growth
+		"db44": 25, // scale
+		"db45": 3,  // empty → default ("free")
 	}
 	for _, sg := range subs {
 		want, ok := wantByName[sg.Name]
@@ -409,16 +469,16 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 		}
 	}
 	// Selectors: admin + one per org. Admin maps to root.admin.<admin>,
-	// each tenant maps to root.tenants.<org_name>. Without the admin
+	// each tenant maps to root.tenants.<principal>. Without the admin
 	// selector the provisioner's own queries get rejected by Trino's
 	// resource-group manager before reaching OPA — which would silently
 	// break EVERY reconcile tick, not just one query.
 	wantSel := map[string]string{
 		opa.AdminPrincipal: "root.admin." + opa.AdminPrincipal,
-		"42":               "root.tenants.42",
-		"43":               "root.tenants.43",
-		"44":               "root.tenants.44",
-		"45":               "root.tenants.45",
+		"db42":             "root.tenants.db42",
+		"db43":             "root.tenants.db43",
+		"db44":             "root.tenants.db44",
+		"db45":             "root.tenants.db45",
 	}
 	if len(parsed.Selectors) != len(wantSel) {
 		t.Fatalf("expected %d selectors (admin + %d orgs), got %d", len(wantSel), len(orgs), len(parsed.Selectors))
@@ -647,7 +707,7 @@ func (f *fakeSentinel) MarkTrinoClusterBootstrapped(_ context.Context, namespace
 
 func TestReconcile_CreatesCatalogProjectsSecretsAndConfigMap(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", Tier: "free", CellID: testCellID, RootPasswordHash: "$2a$10$hash42"},
+		{OrgID: "42", DatabaseName: "db42", Tier: "free", CellID: testCellID, RootPasswordHash: "$2a$10$hash42"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 
@@ -656,9 +716,9 @@ func TestReconcile_CreatesCatalogProjectsSecretsAndConfigMap(t *testing.T) {
 	}
 
 	// Catalog issued via REST, with the DuckLake property set.
-	props, ok := h.catalog.created[TrinoCatalogName("42")]
+	props, ok := h.catalog.created[TrinoCatalogName("db42")]
 	if !ok {
-		t.Fatalf("expected CREATE CATALOG for %s, got %+v", TrinoCatalogName("42"), h.catalog.created)
+		t.Fatalf("expected CREATE CATALOG for %s, got %+v", TrinoCatalogName("db42"), h.catalog.created)
 	}
 	want := map[string]string{
 		"connector.name":                             "ducklake",
@@ -701,8 +761,8 @@ func TestReconcile_CreatesCatalogProjectsSecretsAndConfigMap(t *testing.T) {
 	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyPasswordDB]), "42:$2a$10$hash42") {
 		t.Errorf("password.db missing 42 entry: %q", sec.Data[TrinoAuthSecretKeyPasswordDB])
 	}
-	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyGroupDB]), "org_42:42") {
-		t.Errorf("group.db missing org_42 entry: %q", sec.Data[TrinoAuthSecretKeyGroupDB])
+	if !strings.Contains(string(sec.Data[TrinoAuthSecretKeyGroupDB]), "org_db42:db42") {
+		t.Errorf("group.db missing org_db42 entry: %q", sec.Data[TrinoAuthSecretKeyGroupDB])
 	}
 
 	// ConfigMap.
@@ -710,8 +770,8 @@ func TestReconcile_CreatesCatalogProjectsSecretsAndConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get resource-groups configmap: %v", err)
 	}
-	if !strings.Contains(cm.Data[TrinoResourceGroupsConfigMapKey], "root.tenants.42") {
-		t.Errorf("resource-groups.json missing root.tenants.42 selector: %q", cm.Data[TrinoResourceGroupsConfigMapKey])
+	if !strings.Contains(cm.Data[TrinoResourceGroupsConfigMapKey], "root.tenants.db42") {
+		t.Errorf("resource-groups.json missing root.tenants.db42 selector: %q", cm.Data[TrinoResourceGroupsConfigMapKey])
 	}
 
 	// OPA bundle Set into the store with a non-empty ETag.
@@ -732,7 +792,7 @@ func TestReconcile_CreatesCatalogProjectsSecretsAndConfigMap(t *testing.T) {
 // and ships them to every worker.
 func TestReconcile_CatalogPropertiesCarryNoSecret(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	h.passwords["42"] = "super-secret-metadata-password"
@@ -740,7 +800,7 @@ func TestReconcile_CatalogPropertiesCarryNoSecret(t *testing.T) {
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	props := h.catalog.created[TrinoCatalogName("42")]
+	props := h.catalog.created[TrinoCatalogName("db42")]
 	if len(props) == 0 {
 		t.Fatal("expected the catalog to be created")
 	}
@@ -767,8 +827,8 @@ func TestReconcile_CatalogPropertiesCarryNoSecret(t *testing.T) {
 // password must stop being mounted into the Trino pods.
 func TestReconcile_TenantSecretDropsDisabledOrgs(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
-		{OrgID: "43", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "43", DatabaseName: "db43", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{
 		"42": readyWarehouse("42"),
@@ -798,8 +858,8 @@ func TestReconcile_TenantSecretDropsDisabledOrgs(t *testing.T) {
 		t.Errorf("still-enabled org 42 must keep its password, got %q", data["42"])
 	}
 	// And its catalog is dropped.
-	if !contains(h.catalog.dropped, TrinoCatalogName("43")) {
-		t.Errorf("expected %s to be dropped, got %v", TrinoCatalogName("43"), h.catalog.dropped)
+	if !contains(h.catalog.dropped, TrinoCatalogName("db43")) {
+		t.Errorf("expected %s to be dropped, got %v", TrinoCatalogName("db43"), h.catalog.dropped)
 	}
 }
 
@@ -809,7 +869,7 @@ func TestReconcile_SkipsCatalogWhenTenantPasswordNotReady(t *testing.T) {
 	// auth files are still projected so the password file stays
 	// consistent regardless of catalog readiness.
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$hash"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$hash"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	delete(h.passwords, "42")
@@ -864,7 +924,7 @@ func TestReconcile_SkipsCatalogWhenWarehouseNotReady(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			orgs := []configstore.TrinoEnabledOrg{{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"}}
+			orgs := []configstore.TrinoEnabledOrg{{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"}}
 			h := newTestTrinoProvisioner(t, orgs, tc.warehouses)
 
 			if err := h.provisioner.Reconcile(context.Background()); err != nil {
@@ -886,8 +946,8 @@ func TestReconcile_SkipsCatalogWhenWarehouseNotReady(t *testing.T) {
 
 func TestReconcile_TenantPasswordErrorFailsOnlyThatOrg(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
-		{OrgID: "43", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "43", DatabaseName: "db43", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{
 		"42": readyWarehouse("42"),
@@ -900,10 +960,10 @@ func TestReconcile_TenantPasswordErrorFailsOnlyThatOrg(t *testing.T) {
 	if err := h.provisioner.Reconcile(context.Background()); err == nil {
 		t.Fatal("expected Reconcile to surface the per-org password failure")
 	}
-	if _, ok := h.catalog.created[TrinoCatalogName("43")]; !ok {
+	if _, ok := h.catalog.created[TrinoCatalogName("db43")]; !ok {
 		t.Errorf("healthy org 43 must still get its catalog, got %+v", h.catalog.created)
 	}
-	if _, ok := h.catalog.created[TrinoCatalogName("42")]; ok {
+	if _, ok := h.catalog.created[TrinoCatalogName("db42")]; ok {
 		t.Errorf("failing org 42 must not get a catalog")
 	}
 	if st, _ := h.store.lastState("42"); st.State != configstore.ManagedWarehouseStateFailed {
@@ -927,7 +987,7 @@ func TestReconcile_DropsStaleCatalogs(t *testing.T) {
 	// org_99 exists in Trino but is not in the enabled list → should get
 	// DROP. system, jmx, and a hand-made catalog survive.
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	h.catalog.existing = []string{"system", "jmx", "maintenance_ducklake", "org_99"}
@@ -949,10 +1009,10 @@ func TestReconcile_DropsStaleCatalogs(t *testing.T) {
 // out from under a tenant's running queries.
 func TestReconcile_PendingOrgKeepsItsExistingCatalog(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
-	h.catalog.existing = []string{TrinoCatalogName("42")}
+	h.catalog.existing = []string{TrinoCatalogName("db42")}
 	delete(h.passwords, "42")
 
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
@@ -970,16 +1030,16 @@ func TestReconcile_PendingOrgKeepsItsExistingCatalog(t *testing.T) {
 
 func TestReconcile_IsIdempotentWhenCatalogExists(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	// Pretend the catalog already exists.
-	h.catalog.existing = []string{TrinoCatalogName("42")}
+	h.catalog.existing = []string{TrinoCatalogName("db42")}
 
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if _, ok := h.catalog.created[TrinoCatalogName("42")]; ok {
+	if _, ok := h.catalog.created[TrinoCatalogName("db42")]; ok {
 		t.Errorf("expected no CREATE CATALOG when catalog already exists, got %+v", h.catalog.created)
 	}
 	if st, _ := h.store.lastState("42"); st.State != configstore.ManagedWarehouseStateReady {
@@ -989,7 +1049,7 @@ func TestReconcile_IsIdempotentWhenCatalogExists(t *testing.T) {
 
 func TestReconcile_SecretUpdateIsIdempotent(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 
@@ -1055,7 +1115,7 @@ func TestReconcile_ProjectionFailureSkipsCatalogStep(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			orgs := []configstore.TrinoEnabledOrg{
-				{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
+				{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 			}
 			h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 			// Bootstrap first so the cluster-secret step (which also
@@ -1102,9 +1162,9 @@ func TestReconcile_StateTransitions(t *testing.T) {
 	//   43: provisioning  (no warehouse row yet)
 	//   44: failed        (catalog create errors)
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
-		{OrgID: "43", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
-		{OrgID: "44", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
+		{OrgID: "43", DatabaseName: "db43", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
+		{OrgID: "44", DatabaseName: "db44", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{
 		"42": readyWarehouse("42"),
@@ -1166,7 +1226,7 @@ func TestReconcile_StateTransitions(t *testing.T) {
 
 func TestReconcile_ClaimsUnassignedOrgsIntoThisCell(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: "", RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: "", RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 
@@ -1176,7 +1236,7 @@ func TestReconcile_ClaimsUnassignedOrgsIntoThisCell(t *testing.T) {
 	if got := h.store.cells["42"]; got != testCellID {
 		t.Errorf("expected org 42 claimed into %q, got %q", testCellID, got)
 	}
-	if _, ok := h.catalog.created[TrinoCatalogName("42")]; !ok {
+	if _, ok := h.catalog.created[TrinoCatalogName("db42")]; !ok {
 		t.Errorf("a newly claimed org must be reconciled in the same tick, got %+v", h.catalog.created)
 	}
 
@@ -1192,8 +1252,8 @@ func TestReconcile_ClaimsUnassignedOrgsIntoThisCell(t *testing.T) {
 
 func TestReconcile_IgnoresOrgsOwnedByAnotherCell(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: testCellID, RootPasswordHash: "$2a$10$hash42"},
-		{OrgID: "99", CellID: "cell-elsewhere", RootPasswordHash: "$2a$10$hash99"},
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$hash42"},
+		{OrgID: "99", DatabaseName: "db99", CellID: "cell-elsewhere", RootPasswordHash: "$2a$10$hash99"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{
 		"42": readyWarehouse("42"),
@@ -1222,7 +1282,7 @@ func TestReconcile_IgnoresOrgsOwnedByAnotherCell(t *testing.T) {
 		t.Errorf("password.db leaked another cell's org: %q", sec.Data[TrinoAuthSecretKeyPasswordDB])
 	}
 	// And our own org is unaffected.
-	if _, ok := h.catalog.created[TrinoCatalogName("42")]; !ok {
+	if _, ok := h.catalog.created[TrinoCatalogName("db42")]; !ok {
 		t.Errorf("this cell's org must still be provisioned, got %+v", h.catalog.created)
 	}
 }
@@ -1231,7 +1291,7 @@ func TestReconcile_FailedClaimDefersTheOrg(t *testing.T) {
 	// A claim that doesn't land means ownership is unrecorded; projecting
 	// the tenant anyway risks two cells serving it.
 	orgs := []configstore.TrinoEnabledOrg{
-		{OrgID: "42", CellID: "", RootPasswordHash: "$2a$10$h"},
+		{OrgID: "42", DatabaseName: "db42", CellID: "", RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	h.store.cellErr = errors.New("db unavailable")

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -255,6 +255,52 @@ func TestBuildTrinoAuthFiles_SkipsOrgWithoutDatabaseName(t *testing.T) {
 	}
 }
 
+// Two orgs whose principals sanitize to the same catalog name must BOTH be
+// held back. Letting the sort winner take the catalog would hand the loser a
+// grant to the winner's data through the OPA bundle.
+func TestRejectPrincipalCollisions(t *testing.T) {
+	// Only reachable via grandfathered rows: ValidateDatabaseName forbids
+	// the underscore and the uppercase that make these two converge.
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "1", DatabaseName: "Acme_Corp"},
+		{OrgID: "2", DatabaseName: "acme-corp"},
+		{OrgID: "3", DatabaseName: "beta"},
+	}
+
+	projectable, collisions := rejectPrincipalCollisions(orgs)
+
+	if len(projectable) != 1 || projectable[0].OrgID != "3" {
+		t.Fatalf("only the uncontested org may be projected, got %+v", projectable)
+	}
+	for _, id := range []string{"1", "2"} {
+		err, ok := collisions[id]
+		if !ok {
+			t.Fatalf("org %s must be reported as colliding", id)
+		}
+		if !strings.Contains(err.Error(), "org_acme_corp") {
+			t.Errorf("org %s error should name the contested catalog: %v", id, err)
+		}
+	}
+	if _, ok := collisions["3"]; ok {
+		t.Error("the uncontested org must not be reported as colliding")
+	}
+}
+
+// The common case allocates nothing and passes the slice straight through.
+func TestRejectPrincipalCollisions_NoneWhenDistinct(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "1", DatabaseName: "acme-corp"},
+		{OrgID: "2", DatabaseName: "beta"},
+	}
+	projectable, collisions := rejectPrincipalCollisions(orgs)
+	if len(collisions) != 0 {
+		t.Fatalf("expected no collisions, got %v", collisions)
+	}
+	if len(projectable) != 2 {
+		t.Fatalf("expected both orgs projectable, got %+v", projectable)
+	}
+}
+
 func TestBuildTrinoAuthFiles_DeterministicOrder(t *testing.T) {
 	orgs := []configstore.TrinoEnabledOrg{
 		{OrgID: "42", DatabaseName: "db42", RootPasswordHash: "$a"},

--- a/tests/configstore/trino_postgres_test.go
+++ b/tests/configstore/trino_postgres_test.go
@@ -273,6 +273,49 @@ func TestListTrinoEnabledOrgsJoinsRootUserAndCarriesCell(t *testing.T) {
 
 // Deleting the Org row must take its Trino opt-in with it — otherwise a
 // re-created org would inherit a stranded row.
+// database_name is the org's Trino principal — the username it authenticates
+// as and the stem of its catalog name — so an org without one has no
+// derivable Trino identity and must be dropped by the listing, exactly as a
+// root-less org is. Returning it would project a catalog literally named
+// `org_`, which every such org would collide on.
+func TestListTrinoEnabledOrgsRequiresADatabaseName(t *testing.T) {
+	store := newIsolatedConfigStore(t)
+	seedTrinoOrg(t, store, "acme")
+
+	// An org with a root user but no database_name.
+	if err := store.DB().Create(&configstore.Org{Name: "nameless", DatabaseName: ""}).Error; err != nil {
+		t.Fatalf("create nameless org: %v", err)
+	}
+	if err := store.CreateOrgUser("nameless", "root", "$2a$10$hash-nameless"); err != nil {
+		t.Fatalf("create root user for nameless: %v", err)
+	}
+
+	for _, org := range []string{"acme", "nameless"} {
+		if err := store.EnableTrino(org, configstore.TrinoSettings{Tier: "free"}); err != nil {
+			t.Fatalf("EnableTrino(%s): %v", org, err)
+		}
+	}
+
+	got, err := store.ListTrinoEnabledOrgs()
+	if err != nil {
+		t.Fatalf("ListTrinoEnabledOrgs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected only acme (nameless dropped for having no database_name), got %+v", got)
+	}
+	if got[0].OrgID != "acme" {
+		t.Fatalf("expected acme, got %+v", got[0])
+	}
+	// And the principal is carried through, since every Trino-facing name
+	// is derived from it.
+	if got[0].DatabaseName != "acmedb" {
+		t.Errorf("DatabaseName = %q, want acmedb", got[0].DatabaseName)
+	}
+	if got[0].TrinoPrincipal() != "acmedb" {
+		t.Errorf("TrinoPrincipal() = %q, want acmedb", got[0].TrinoPrincipal())
+	}
+}
+
 func TestTrinoRowCascadesOnOrgDeletePostgres(t *testing.T) {
 	store := newIsolatedConfigStore(t)
 	seedTrinoOrg(t, store, "acme")


### PR DESCRIPTION
Follows https://github.com/PostHog/duckgres/pull/1114. **Worth landing before the first org is enabled** — no catalogs exist yet, so there is nothing to migrate. After a tenant is live this becomes a rename with a customer-visible break.

## The problem

The Trino principal was the org id, which `validateDucklingOrgID` allows to be a canonical UUID. For PostHog's own org that means:

```
host=trino.dw.us.postwh.com  user=4dc8564dbd8210652f4097f7c50f67cf
SELECT * FROM org_4dc8564dbd8210652f4097f7c50f67cf.main.events
```

Nothing else in duckgres asks a customer to know their org id. For the DuckDB warehouse the public identity is `database_name` — the comment on `databaseNamePattern` says it outright: *"the tenant's public socket identity — the single hostname label of its managed SNI hostname and the dbname clients connect with."* Trino was the only surface leaking the internal id.

## The change

The principal is now `database_name`, so one name identifies a tenant across both engines:

```
host=trino.dw.us.postwh.com  user=acme-analytics
SELECT * FROM org_acme_analytics.main.events
```

Same password as before — `password.db` still carries the `duckgres_org_users` root bcrypt hash, the same one the DuckDB warehouse authenticates with.

**Safe as a catalog stem** because `duckgres_orgs.database_name` has a global unique index (`idx_duckgres_orgs_database_name`), so two tenants cannot derive the same catalog name.

**The `org_` prefix stays.** It is what `opa.ManagedCatalogPattern` (`^org_[a-z0-9_]+$`) anchors on, and that pattern is the guard that stops the provisioner from ever dropping `system`, `jmx`, or a hand-rolled catalog. Dropping the prefix would mean matching bare labels, which weakens a boundary I would rather leave alone.

## Scope: only names the customer types

| Derived from | What |
|---|---|
| `database_name` (new) | Trino username, catalog name, group label, resource-group path |
| `org_id` (unchanged) | config store PK, tenant-password Secret key, metadata database, duckling IAM role, S3 path |

The internal plumbing is deliberately untouched — visible in the test fixtures, where a catalog for org `42` is now `org_db42` but still points at `mdstore_42`, `/etc/trino/tenant-secrets/42` and `role/duckling-42`.

## Orgs without a database_name

They have no derivable identity, so `ListTrinoEnabledOrgs` now drops them — the same treatment an org with no root user already gets, and for the same stated reason. Projecting a catalog named `org_` would collide across every such org. The join moved from `LEFT` to `INNER` plus a non-blank check, with a defensive guard in the catalog loop too.

## Renames

`TestAdminUpdateOrgRenamesDatabaseNamePostgres` shows `database_name` is mutable. The existing reconcile handles it without new code: the old catalog falls out of the wanted set and is dropped, the new one is created, and both match the managed pattern so the drop is in-bounds. The tenant's connection breaks — as renaming already breaks its DuckDB hostname, so the behaviour is consistent rather than new.

## Tests

- New `TestTrinoIdentityIsDatabaseNameNotOrgID` pins the whole contract end to end and asserts the org id appears in **neither** auth file nor `resource-groups.json`. It uses a hyphenated name so the sanitize split is covered: group `org_acme_analytics`, selector user `acme-analytics` (raw, because it matches Trino's `current_user`).
- New `TestBuildTrinoAuthFiles_SkipsOrgWithoutDatabaseName` and `TestListTrinoEnabledOrgsRequiresADatabaseName`.
- Every existing fixture now carries a `DatabaseName` **distinct** from its org id (`42` → `db42`), so the suite fails if the principal ever reverts.
- `go test -tags kubernetes ./controlplane/provisioner/... ./tests/configstore/...` green.

Unrelated pre-existing failures in `controlplane/admin` (`column "max_hot_idle_workers" does not exist`) reproduce on a clean `main` — stale local test schema, not this change.