### PR TITLE
Build Trino catalogs from the Duckling status, not the warehouse row

### DIFF
--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -541,7 +541,7 @@ func SetupMultiTenant(
 			// Same Duckling CR read the worker activation path uses; nil
 			// when the Duckling client couldn't be built, which
 			// buildTrinoWiring rejects rather than half-wiring.
-			trinoWire, twErr := buildTrinoWiring(store, kc, ducklingTenantPasswordResolver(resolveDucklingStatus))
+			trinoWire, twErr := buildTrinoWiring(store, kc, resolveDucklingStatus)
 			if twErr != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner wiring failed: %w", twErr)
 			}

--- a/controlplane/provisioner/trino_cluster_secrets_test.go
+++ b/controlplane/provisioner/trino_cluster_secrets_test.go
@@ -27,7 +27,7 @@ func newClusterSecretsTestProvisioner(t *testing.T) (*TrinoProvisioner, *kubefak
 		Store:             &fakeTrinoStore{},
 		BootstrapSentinel: sentinel,
 		Warehouses:        &fakeWarehouseStore{},
-		TenantPasswords:   func(context.Context, string) (string, error) { return "", nil },
+		Ducklings:         func(context.Context, string) (*DucklingStatus, error) { return nil, nil },
 		Kubernetes:        kc,
 		Namespace:         TrinoCustomerNamespace,
 		Catalog:           &fakeCatalogClient{},
@@ -275,7 +275,7 @@ func TestBootstrap_ConcurrentReplicasConverge(t *testing.T) {
 			Store:             &fakeTrinoStore{},
 			BootstrapSentinel: sentinel,
 			Warehouses:        &fakeWarehouseStore{},
-			TenantPasswords:   func(context.Context, string) (string, error) { return "", nil },
+			Ducklings:         func(context.Context, string) (*DucklingStatus, error) { return nil, nil },
 			Kubernetes:        kc, // shared
 			Namespace:         TrinoCustomerNamespace,
 			Catalog:           &fakeCatalogClient{},

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -249,7 +249,7 @@ type TrinoProvisionerOpts struct {
 	// there is exactly ONE definition of "the tenant's metadata password"
 	// in the control plane. Required: without it the tenant Secret cannot
 	// be projected and every catalog would sit pending forever.
-	TenantPasswords TrinoTenantPasswordResolver
+	Ducklings TrinoDucklingResolver
 
 	// Kubernetes is used for the auth Secret, tenant-password Secret and
 	// resource-groups ConfigMap projections in the Trino namespace.
@@ -354,7 +354,7 @@ type TrinoWarehouseStore interface {
 // The plaintext is handled in exactly two places: this call, and the write
 // into TrinoTenantSecretName. It is never logged, never put in a catalog
 // property, and never persisted in the config store.
-type TrinoTenantPasswordResolver func(ctx context.Context, orgID string) (string, error)
+type TrinoDucklingResolver func(ctx context.Context, orgID string) (*DucklingStatus, error)
 
 // TrinoProvisioner owns the customer Trino cluster's projected state:
 // cluster-level Secrets (internal-communication shared secret, auth
@@ -371,7 +371,7 @@ type TrinoProvisioner struct {
 	store                 TrinoStore
 	bootstrapSentinel     TrinoBootstrapSentinelStore
 	warehouses            TrinoWarehouseStore
-	tenantPasswords       TrinoTenantPasswordResolver
+	ducklings             TrinoDucklingResolver
 	kubernetes            kubernetes.Interface
 	namespace             string
 	cellID                string
@@ -401,8 +401,8 @@ func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
 	if opts.Warehouses == nil {
 		return nil, errors.New("TrinoProvisioner: Warehouses is required")
 	}
-	if opts.TenantPasswords == nil {
-		return nil, errors.New("TrinoProvisioner: TenantPasswords is required")
+	if opts.Ducklings == nil {
+		return nil, errors.New("TrinoProvisioner: Ducklings is required")
 	}
 	if opts.Kubernetes == nil {
 		return nil, errors.New("TrinoProvisioner: Kubernetes client is required")
@@ -436,7 +436,7 @@ func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
 		store:                 opts.Store,
 		bootstrapSentinel:     opts.BootstrapSentinel,
 		warehouses:            opts.Warehouses,
-		tenantPasswords:       opts.TenantPasswords,
+		ducklings:             opts.Ducklings,
 		kubernetes:            opts.Kubernetes,
 		namespace:             ns,
 		cellID:                cell,
@@ -1179,6 +1179,11 @@ type tenantSecretProjection struct {
 	pending map[string]string
 	// failed holds orgs whose password could not be resolved at all.
 	failed map[string]error
+	// statuses holds the duckling status each password came from, so the
+	// catalog step can build a catalog from the SAME live composition
+	// rather than re-reading it (or, worse, reading object-store fields
+	// off the config store, where they are never populated).
+	statuses map[string]*DucklingStatus
 }
 
 // reconcileTenantSecrets resolves every enabled org's DuckLake
@@ -1200,6 +1205,7 @@ func (p *TrinoProvisioner) reconcileTenantSecrets(ctx context.Context, orgs []co
 		projected: make(map[string]bool, len(orgs)),
 		pending:   make(map[string]string),
 		failed:    make(map[string]error),
+		statuses:  make(map[string]*DucklingStatus, len(orgs)),
 	}
 	data := make(map[string][]byte, len(orgs))
 	for _, o := range orgs {
@@ -1211,7 +1217,7 @@ func (p *TrinoProvisioner) reconcileTenantSecrets(ctx context.Context, orgs []co
 				"org id %q is not a valid Kubernetes Secret data key ([-._a-zA-Z0-9]+); its metadata-store password cannot be projected", o.OrgID)
 			continue
 		}
-		password, err := p.tenantPasswords(ctx, o.OrgID)
+		status, err := p.ducklings(ctx, o.OrgID)
 		if err != nil {
 			// Deliberately not wrapped with the org's infrastructure
 			// detail beyond what the resolver said — this string ends up
@@ -1219,12 +1225,13 @@ func (p *TrinoProvisioner) reconcileTenantSecrets(ctx context.Context, orgs []co
 			proj.failed[o.OrgID] = fmt.Errorf("resolve metadata-store password: %w", err)
 			continue
 		}
-		if password == "" {
+		if status == nil || status.MetadataStore.Password == "" {
 			proj.pending[o.OrgID] = "waiting for the duckling to publish a metadata-store credential"
 			continue
 		}
-		data[o.OrgID] = []byte(password)
+		data[o.OrgID] = []byte(status.MetadataStore.Password)
 		proj.projected[o.OrgID] = true
+		proj.statuses[o.OrgID] = status
 	}
 
 	if err := p.replaceSecret(ctx, TrinoTenantSecretName, data); err != nil {
@@ -1330,7 +1337,8 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 			}
 			continue
 		}
-		if missing := missingCatalogInputs(warehouse, p.awsRegion); len(missing) > 0 {
+		duckling := tenants.statuses[o.OrgID]
+		if missing := missingCatalogInputs(warehouse, duckling, p.awsRegion); len(missing) > 0 {
 			// The org opted into Trino but its warehouse hasn't finished
 			// provisioning (or a reshard blanked the connection block).
 			// Rendering a catalog with an empty endpoint or bucket makes
@@ -1343,7 +1351,7 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 			}
 			continue
 		}
-		props := p.buildCatalogProperties(o.OrgID, warehouse)
+		props := p.buildCatalogProperties(o.OrgID, warehouse, duckling)
 		if err := p.catalog.CreateCatalog(ctx, name, props); err != nil {
 			perOrgErr := fmt.Errorf("create catalog %s: %w", name, err)
 			errs = append(errs, perOrgErr)
@@ -1381,7 +1389,7 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 //
 // fallbackRegion is the provisioner's configured AWS region, consulted only
 // when the row has no s3_region of its own.
-func missingCatalogInputs(w *configstore.ManagedWarehouse, fallbackRegion string) []string {
+func missingCatalogInputs(w *configstore.ManagedWarehouse, d *DucklingStatus, fallbackRegion string) []string {
 	var missing []string
 	if w.MetadataStore.Endpoint == "" {
 		missing = append(missing, "metadata_store_endpoint")
@@ -1392,18 +1400,21 @@ func missingCatalogInputs(w *configstore.ManagedWarehouse, fallbackRegion string
 	if w.MetadataStore.Username == "" {
 		missing = append(missing, "metadata_store_username")
 	}
-	if w.S3.Bucket == "" {
-		missing = append(missing, "s3_bucket")
+	if d == nil {
+		return append(missing, "duckling_status")
 	}
-	if w.S3.Region == "" && fallbackRegion == "" {
-		missing = append(missing, "s3_region")
+	if d.DataStore.BucketName == "" {
+		missing = append(missing, "data_store_bucket_name")
 	}
-	if w.WorkerIdentity.IAMRoleARN == "" {
+	if d.DataStore.S3Region == "" && fallbackRegion == "" {
+		missing = append(missing, "data_store_s3_region")
+	}
+	if d.IAMRoleARN == "" {
 		// Without the per-org role every catalog would fall back to the
 		// Trino pod's ambient identity, which can assume EVERY tenant
 		// role — that collapses the per-tenant S3 boundary entirely.
 		// Waiting is the only safe answer.
-		missing = append(missing, "worker_identity_iam_role_arn")
+		missing = append(missing, "iam_role_arn")
 	}
 	return missing
 }
@@ -1444,8 +1455,8 @@ func missingCatalogInputs(w *configstore.ManagedWarehouse, fallbackRegion string
 // every worker; a password here would be readable by anyone who can see a
 // query listing. If you add a property, ask whether it is safe in a log
 // line before adding it.
-func (p *TrinoProvisioner) buildCatalogProperties(orgID string, w *configstore.ManagedWarehouse) map[string]string {
-	region := w.S3.Region
+func (p *TrinoProvisioner) buildCatalogProperties(orgID string, w *configstore.ManagedWarehouse, d *DucklingStatus) map[string]string {
+	region := d.DataStore.S3Region
 	if region == "" {
 		region = p.awsRegion
 	}
@@ -1454,11 +1465,11 @@ func (p *TrinoProvisioner) buildCatalogProperties(orgID string, w *configstore.M
 		"ducklake.metadata.connection-url":           ducklakeMetadataJDBCURL(w),
 		"ducklake.metadata.connection-user":          w.MetadataStore.Username,
 		"ducklake.metadata.connection-password-file": p.tenantPasswordFilePath(orgID),
-		"ducklake.data-path":                         ducklakeDataPath(w.S3),
+		"ducklake.data-path":                         ducklakeDataPath(d.DataStore.BucketName, w.S3.PathPrefix),
 		"fs.s3.enabled":                              "true",
 		"s3.region":                                  region,
 		"s3.auth-type":                               "IAM_ROLE",
-		"s3.iam-role":                                w.WorkerIdentity.IAMRoleARN,
+		"s3.iam-role":                                d.IAMRoleARN,
 		"s3.max-connections":                         strconv.Itoa(p.s3MaxConnections),
 	}
 }
@@ -1497,12 +1508,12 @@ func ducklakeMetadataJDBCURL(w *configstore.ManagedWarehouse) string {
 // address exactly the same DuckLake data files. It is duplicated rather
 // than shared because the controlplane package imports this one, not the
 // other way round; if the two ever disagree, THIS one is wrong.
-func ducklakeDataPath(s3 configstore.ManagedWarehouseS3) string {
-	prefix := strings.Trim(s3.PathPrefix, "/")
+func ducklakeDataPath(bucket, pathPrefix string) string {
+	prefix := strings.Trim(pathPrefix, "/")
 	if prefix == "" {
-		return fmt.Sprintf("s3://%s/", s3.Bucket)
+		return fmt.Sprintf("s3://%s/", bucket)
 	}
-	return fmt.Sprintf("s3://%s/%s/", s3.Bucket, prefix)
+	return fmt.Sprintf("s3://%s/%s/", bucket, prefix)
 }
 
 // reconcileAuthSecret rebuilds password.db + group.db and atomically

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -106,14 +106,24 @@ func readyWarehouse(orgID string) *configstore.ManagedWarehouse {
 			DatabaseName: "mdstore_" + orgID,
 			Username:     "mdstore_" + orgID,
 		},
-		S3: configstore.ManagedWarehouseS3{
-			Bucket: "posthog-duckling-" + orgID + "-mw-dev",
-			Region: "us-east-1",
-		},
-		WorkerIdentity: configstore.ManagedWarehouseWorkerIdentity{
-			IAMRoleARN: "arn:aws:iam::123456789012:role/duckling-" + orgID,
-		},
+		// S3 and WorkerIdentity are deliberately left zero: nothing
+		// populates those columns for a DuckLake warehouse in
+		// production. The bucket, region and role come off the Duckling
+		// CR status instead (see readyDuckling).
 	}
+}
+
+// readyDuckling is the Duckling CR status a fully composed warehouse
+// publishes: the metadata password plus the object-store inputs a catalog
+// needs. This, not the ManagedWarehouse row, is where a catalog's bucket,
+// region and per-org IAM role actually come from.
+func readyDuckling(orgID string) *DucklingStatus {
+	d := &DucklingStatus{}
+	d.MetadataStore.Password = "pw-" + orgID
+	d.DataStore.BucketName = "posthog-duckling-" + orgID + "-mw-dev"
+	d.DataStore.S3Region = "us-east-1"
+	d.IAMRoleARN = "arn:aws:iam::123456789012:role/duckling-" + orgID
+	return d
 }
 
 type fakeCatalogClient struct {
@@ -593,60 +603,107 @@ func TestDuckLakeMetadataJDBCURL_SSLModeFollowsStoreKind(t *testing.T) {
 
 func TestDuckLakeDataPath(t *testing.T) {
 	cases := []struct {
-		name string
-		s3   configstore.ManagedWarehouseS3
-		want string
+		name   string
+		bucket string
+		prefix string
+		want   string
 	}{
-		{"no prefix", configstore.ManagedWarehouseS3{Bucket: "b"}, "s3://b/"},
-		{"prefix", configstore.ManagedWarehouseS3{Bucket: "b", PathPrefix: "data"}, "s3://b/data/"},
-		{"prefix with slashes", configstore.ManagedWarehouseS3{Bucket: "b", PathPrefix: "/data/"}, "s3://b/data/"},
-		{"nested prefix", configstore.ManagedWarehouseS3{Bucket: "b", PathPrefix: "a/b"}, "s3://b/a/b/"},
+		{"no prefix", "b", "", "s3://b/"},
+		{"prefix", "b", "data", "s3://b/data/"},
+		{"prefix with slashes", "b", "/data/", "s3://b/data/"},
+		{"nested prefix", "b", "a/b", "s3://b/a/b/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := ducklakeDataPath(tc.s3); got != tc.want {
+			if got := ducklakeDataPath(tc.bucket, tc.prefix); got != tc.want {
 				t.Errorf("ducklakeDataPath = %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
+// The object-store half of a catalog comes from the Duckling CR status, not
+// from the ManagedWarehouse row. Nothing populates the row's s3.* or
+// worker_identity.* columns for a DuckLake warehouse in production — the
+// bucket lands on data_store.bucket_name and the IAM role is a Crossplane
+// output on the CR status — so reading them from the row yielded an empty
+// bucket and an empty role for every org, and the catalog step waited
+// forever. Fixtures that filled those columns hid it.
+func TestCatalogPropertiesComeFromTheDucklingStatus(t *testing.T) {
+	w := readyWarehouse("42")
+	if w.S3.Bucket != "" || w.S3.Region != "" || w.WorkerIdentity.IAMRoleARN != "" {
+		t.Fatal("fixture regression: the warehouse row must leave the object-store columns empty, as production does")
+	}
+
+	d := readyDuckling("42")
+	d.DataStore.BucketName = "bucket-from-duckling"
+	d.DataStore.S3Region = "eu-west-2"
+	d.IAMRoleARN = "arn:aws:iam::123456789012:role/duckling-from-status"
+
+	p := &TrinoProvisioner{tenantSecretMountPath: "/etc/trino/tenant-secrets", s3MaxConnections: 50}
+	props := p.buildCatalogProperties("42", w, d)
+
+	for prop, want := range map[string]string{
+		"ducklake.data-path": "s3://bucket-from-duckling/",
+		"s3.region":          "eu-west-2",
+		"s3.iam-role":        "arn:aws:iam::123456789012:role/duckling-from-status",
+	} {
+		if props[prop] != want {
+			t.Errorf("%s = %q, want %q", prop, props[prop], want)
+		}
+	}
+}
+
 func TestMissingCatalogInputs(t *testing.T) {
-	full := readyWarehouse("42")
-	if got := missingCatalogInputs(full, ""); len(got) != 0 {
-		t.Fatalf("a ready warehouse must have no missing inputs, got %v", got)
+	if got := missingCatalogInputs(readyWarehouse("42"), readyDuckling("42"), ""); len(got) != 0 {
+		t.Fatalf("a ready warehouse + duckling must have no missing inputs, got %v", got)
 	}
 
 	cases := []struct {
 		name     string
-		mutate   func(*configstore.ManagedWarehouse)
+		mutateW  func(*configstore.ManagedWarehouse)
+		mutateD  func(*DucklingStatus)
 		fallback string
 		want     string
 	}{
-		{"endpoint", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Endpoint = "" }, "", "metadata_store_endpoint"},
-		{"database", func(w *configstore.ManagedWarehouse) { w.MetadataStore.DatabaseName = "" }, "", "metadata_store_database_name"},
-		{"username", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Username = "" }, "", "metadata_store_username"},
-		{"bucket", func(w *configstore.ManagedWarehouse) { w.S3.Bucket = "" }, "", "s3_bucket"},
-		{"region", func(w *configstore.ManagedWarehouse) { w.S3.Region = "" }, "", "s3_region"},
-		{"iam role", func(w *configstore.ManagedWarehouse) { w.WorkerIdentity.IAMRoleARN = "" }, "", "worker_identity_iam_role_arn"},
+		{"endpoint", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Endpoint = "" }, nil, "", "metadata_store_endpoint"},
+		{"database", func(w *configstore.ManagedWarehouse) { w.MetadataStore.DatabaseName = "" }, nil, "", "metadata_store_database_name"},
+		{"username", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Username = "" }, nil, "", "metadata_store_username"},
+		{"bucket", nil, func(d *DucklingStatus) { d.DataStore.BucketName = "" }, "", "data_store_bucket_name"},
+		{"region", nil, func(d *DucklingStatus) { d.DataStore.S3Region = "" }, "", "data_store_s3_region"},
+		{"iam role", nil, func(d *DucklingStatus) { d.IAMRoleARN = "" }, "", "iam_role_arn"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := readyWarehouse("42")
-			tc.mutate(w)
-			got := missingCatalogInputs(w, tc.fallback)
+			w, d := readyWarehouse("42"), readyDuckling("42")
+			if tc.mutateW != nil {
+				tc.mutateW(w)
+			}
+			if tc.mutateD != nil {
+				tc.mutateD(d)
+			}
+			got := missingCatalogInputs(w, d, tc.fallback)
 			if len(got) != 1 || got[0] != tc.want {
 				t.Fatalf("missingCatalogInputs = %v, want exactly [%s]", got, tc.want)
 			}
 		})
 	}
 
-	// The env-configured region covers a row that predates s3_region
-	// being populated; nothing else has a fallback.
+	// A warehouse whose duckling has published nothing yet is a WAIT, not a
+	// list of individually-missing object-store fields.
+	t.Run("no duckling status", func(t *testing.T) {
+		got := missingCatalogInputs(readyWarehouse("42"), nil, "")
+		if len(got) != 1 || got[0] != "duckling_status" {
+			t.Fatalf("missingCatalogInputs = %v, want exactly [duckling_status]", got)
+		}
+	})
+
+	// The env-configured region covers a duckling that has not published one;
+	// nothing else has a fallback.
 	t.Run("region falls back to the provisioner's configured region", func(t *testing.T) {
-		w := readyWarehouse("42")
-		w.S3.Region = ""
-		if got := missingCatalogInputs(w, "eu-central-1"); len(got) != 0 {
+		d := readyDuckling("42")
+		d.DataStore.S3Region = ""
+		if got := missingCatalogInputs(readyWarehouse("42"), d, "eu-central-1"); len(got) != 0 {
 			t.Fatalf("expected no missing inputs with a fallback region, got %v", got)
 		}
 	})
@@ -661,9 +718,9 @@ type testProvisionerHarness struct {
 	bundles     *opa.BundleStore
 	store       *fakeTrinoStore
 	warehouses  *fakeWarehouseStore
-	// passwords is the fake tenant password source: org id -> password.
+	// ducklings is the fake Duckling CR status source: org id -> status.
 	// A missing entry resolves to ("", nil) — the duckling-not-ready wait.
-	passwords map[string]string
+	ducklings map[string]*DucklingStatus
 	// passwordErr, when non-nil for an org, fails that org's resolution.
 	passwordErr map[string]error
 }
@@ -678,23 +735,23 @@ func newTestTrinoProvisioner(t *testing.T, orgs []configstore.TrinoEnabledOrg, w
 		bundles:     &opa.BundleStore{},
 		store:       &fakeTrinoStore{orgs: orgs},
 		warehouses:  &fakeWarehouseStore{rows: warehouses},
-		passwords:   map[string]string{},
+		ducklings:   map[string]*DucklingStatus{},
 		passwordErr: map[string]error{},
 	}
 	// Every org in the fixture gets a password unless the test removes
 	// it — the interesting cases are the exceptions, not the norm.
 	for _, o := range orgs {
-		h.passwords[o.OrgID] = "pw-" + o.OrgID
+		h.ducklings[o.OrgID] = readyDuckling(o.OrgID)
 	}
 	p, err := NewTrinoProvisioner(TrinoProvisionerOpts{
 		Store:             h.store,
 		BootstrapSentinel: newFakeSentinel(),
 		Warehouses:        h.warehouses,
-		TenantPasswords: func(_ context.Context, orgID string) (string, error) {
+		Ducklings: func(_ context.Context, orgID string) (*DucklingStatus, error) {
 			if err := h.passwordErr[orgID]; err != nil {
-				return "", err
+				return nil, err
 			}
-			return h.passwords[orgID], nil
+			return h.ducklings[orgID], nil
 		},
 		Kubernetes:    h.kube,
 		Namespace:     TrinoCustomerNamespace,
@@ -841,7 +898,7 @@ func TestReconcile_CatalogPropertiesCarryNoSecret(t *testing.T) {
 		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
-	h.passwords["42"] = "super-secret-metadata-password"
+	h.ducklings["42"].MetadataStore.Password = "super-secret-metadata-password"
 
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -918,7 +975,7 @@ func TestReconcile_SkipsCatalogWhenTenantPasswordNotReady(t *testing.T) {
 		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$hash"},
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
-	delete(h.passwords, "42")
+	delete(h.ducklings, "42")
 
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -1059,7 +1116,7 @@ func TestReconcile_PendingOrgKeepsItsExistingCatalog(t *testing.T) {
 	}
 	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
 	h.catalog.existing = []string{TrinoCatalogName("db42")}
-	delete(h.passwords, "42")
+	delete(h.ducklings, "42")
 
 	if err := h.provisioner.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -1397,7 +1454,7 @@ func baseTestOpts() TrinoProvisionerOpts {
 		Store:             &fakeTrinoStore{},
 		BootstrapSentinel: newFakeSentinel(),
 		Warehouses:        &fakeWarehouseStore{},
-		TenantPasswords:   func(context.Context, string) (string, error) { return "", nil },
+		Ducklings:         func(context.Context, string) (*DucklingStatus, error) { return nil, nil },
 		Kubernetes:        kubefake.NewClientset(),
 		Catalog:           &fakeCatalogClient{},
 		BundleStore:       &opa.BundleStore{},
@@ -1415,7 +1472,7 @@ func TestNewTrinoProvisioner_RequiresAllDeps(t *testing.T) {
 		func(o *TrinoProvisionerOpts) { o.Store = nil },
 		func(o *TrinoProvisionerOpts) { o.BootstrapSentinel = nil },
 		func(o *TrinoProvisionerOpts) { o.Warehouses = nil },
-		func(o *TrinoProvisionerOpts) { o.TenantPasswords = nil },
+		func(o *TrinoProvisionerOpts) { o.Ducklings = nil },
 		func(o *TrinoProvisionerOpts) { o.Kubernetes = nil },
 		func(o *TrinoProvisionerOpts) { o.Catalog = nil },
 		func(o *TrinoProvisionerOpts) { o.BundleStore = nil },

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -184,11 +184,12 @@ type trinoWiring struct {
 // builds it from rest.InClusterConfig(); in dev/test the caller can pass
 // a fake.
 //
-// tenantPasswords resolves one org's DuckLake metadata-store password. The
-// caller passes the SAME Duckling-CR read the worker activation path uses
-// (see ducklingTenantPasswordResolver), so there is one definition of "the
-// tenant's metadata password" in the control plane, and a duckling that has
-// not published a credential yet reads as "wait" on both paths.
+// ducklings resolves one org's Duckling CR status — the metadata-store
+// password plus the object-store inputs a catalog needs. The caller passes
+// the SAME Duckling-CR read the worker activation path uses, so there is one
+// definition of "the tenant's metadata password" in the control plane, and a
+// duckling that has not published a credential yet reads as "wait" on both
+// paths.
 //
 // The cluster-level credentials (Trino internal-communication shared
 // secret, admin password + bcrypt hash, OPA bundle bearer token) are
@@ -204,7 +205,7 @@ type trinoWiring struct {
 func buildTrinoWiring(
 	store *configstore.ConfigStore,
 	kc kubernetes.Interface,
-	tenantPasswords provisioner.TrinoTenantPasswordResolver,
+	ducklings provisioner.TrinoDucklingResolver,
 ) (*trinoWiring, error) {
 	if !trinoProvisionerEnabled() {
 		return nil, nil
@@ -215,11 +216,11 @@ func buildTrinoWiring(
 		return nil, err
 	}
 
-	if tenantPasswords == nil {
+	if ducklings == nil {
 		// Without it every catalog sits pending forever waiting on a
-		// password that nothing resolves — a silent, permanent
+		// duckling status that nothing resolves — a silent, permanent
 		// half-provisioned cell. Fail the rollout instead.
-		return nil, fmt.Errorf("trino provisioner requires a tenant metadata-store password resolver (the Duckling CR client is unavailable)")
+		return nil, fmt.Errorf("trino provisioner requires a duckling status resolver (the Duckling CR client is unavailable)")
 	}
 
 	// Catalog client with empty credentials — Bootstrap (below) calls
@@ -236,7 +237,7 @@ func buildTrinoWiring(
 		Store:                 store,
 		BootstrapSentinel:     store,
 		Warehouses:            store,
-		TenantPasswords:       tenantPasswords,
+		Ducklings:             ducklings,
 		Kubernetes:            kc,
 		Namespace:             strings.TrimSpace(os.Getenv(envTrinoNamespace)),
 		CellID:                cell.ID,
@@ -276,8 +277,8 @@ func buildTrinoWiring(
 	}, nil
 }
 
-// ducklingTenantPasswordResolver adapts the control plane's existing
-// Duckling CR reader into the provisioner's password resolver.
+// The provisioner reads a tenant's duckling status through the control
+// plane's existing Duckling CR reader, passed in by the caller.
 //
 // This is deliberately the SAME read the worker activation path performs
 // (SharedWorkerActivator.buildDuckLakeConfigFromDuckling reaches the
@@ -286,26 +287,19 @@ func buildTrinoWiring(
 // parallel implementation, so Trino and the DuckDB workers can never end up
 // authenticating a tenant's metadata store with two different credentials.
 //
-// A duckling with no metadata store published yet returns ("", nil) — a
-// WAIT, which leaves the org provisioning until the composition catches up.
-// Only a genuine read failure is an error.
-func ducklingTenantPasswordResolver(
-	resolveDucklingStatus func(context.Context, string) (*provisioner.DucklingStatus, error),
-) provisioner.TrinoTenantPasswordResolver {
-	if resolveDucklingStatus == nil {
-		return nil
-	}
-	return func(ctx context.Context, orgID string) (string, error) {
-		status, err := resolveDucklingStatus(ctx, orgID)
-		if err != nil {
-			return "", err
-		}
-		if status == nil {
-			return "", nil
-		}
-		return status.MetadataStore.Password, nil
-	}
-}
+// A duckling with no status published yet returns (nil, nil) — a WAIT, which
+// leaves the org provisioning until the composition catches up. Only a genuine
+// read failure is an error.
+//
+// The provisioner takes the whole status rather than just the password because
+// the catalog needs the object-store inputs too — bucket, region and the
+// per-org IAM role — and those live ONLY here. The config store's
+// ManagedWarehouse carries s3.* and worker_identity.* columns, but nothing
+// populates them for a DuckLake warehouse: the bucket lands on
+// data_store.bucket_name and the role is a Crossplane composition output
+// published to the Duckling CR's status. Reading them from the same status the
+// password comes from also keeps Trino and the DuckDB workers pointed at the
+// same bucket under the same identity, which is the property that matters.
 
 // envInt reads a non-negative integer env var, returning 0 for unset,
 // blank, or unparseable values so the caller's own default applies.


### PR DESCRIPTION
**No catalog could ever be created.** Found by enabling the first org in prod-us: everything projected correctly — password.db, group.db, the tenant password Secret, resource groups — and then the catalog step silently declined, every tick, forever.

## Cause

`missingCatalogInputs` gated on three `ManagedWarehouse` fields that nothing populates for a DuckLake warehouse. Checked against prod-us:

| Required | Warehouse row | Where the value actually is |
|---|---|---|
| `S3.Bucket` | *empty* | `data_store.bucket_name` |
| `S3.Region` | *empty* | `data_store.s3_region` on the Duckling CR |
| `WorkerIdentity.IAMRoleARN` | *empty* | `status.iamRoleArn` on the Duckling CR (a Crossplane output) |

Confirmed on a normally-provisioned org (`data_store.kind = s3bucket`, `ducklake.enabled = true`), not just PostHog's: `s3.bucket`, `s3.region` and `worker_identity.iam_role_arn` are all empty there too. So this was never org-specific — **every** Trino-enabled org would have sat at `waiting for warehouse fields: s3_bucket, s3_region, worker_identity_iam_role_arn` indefinitely.

The gate itself behaved correctly: refusing to create a catalog with an empty bucket or an empty role is the fail-safe working. It was reading the wrong source.

## Fix

All three now come from the Duckling CR status — the same live status the tenant's metadata password already comes from, for the reason already documented there: so Trino and the DuckDB workers can never diverge. Sourcing the object-store set from the same place extends that to "same bucket, same identity."

The split is now principled:

- **Config store** owns what the control plane *assigns*: metadata endpoint, database, username.
- **Duckling status** owns what the composition *produces*: bucket, region, IAM role, password.

The resolver returns the whole `DucklingStatus` instead of a bare password, so each CR is read once per tick and the catalog step reuses what the tenant-secret step already fetched. `ducklingTenantPasswordResolver` goes away as redundant.

## Why review didn't catch it

The fixtures encoded a data shape production never produces — `readyWarehouse` filled in `s3.bucket`, `s3.region` and `worker_identity.iam_role_arn`, so every reconcile test exercised a warehouse that cannot exist. The tests were self-consistent and green while the code could not work against real data.

`readyWarehouse` now leaves those columns empty, matching production, and a new `readyDuckling` fixture supplies the object-store half. Every existing reconcile test therefore now runs against the real shape. `TestCatalogPropertiesComeFromTheDucklingStatus` pins `ducklake.data-path`, `s3.region` and `s3.iam-role` to the status and asserts the fixture has not drifted back.

## Verification

- `go test -tags kubernetes ./controlplane/provisioner/... ./tests/configstore/...` green.
- Field values above read from live prod-us via the admin API, for PostHog's org and for an unrelated normally-provisioned org.

## After merge

Needs a prod promote before the pilot can proceed — PostHog's org is enabled and waiting on exactly this.