### PR TITLE
Answer OPA's batched filtering shape

### DIFF
--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -86,20 +86,26 @@
 # so when per-user identity within an org lands (OIDC), org-mates keep
 # seeing each other's queries with no policy change.
 #
-# !!! Cross-component invariant: this policy is the NON-BATCHED OPA
-# contract. Trino 476's batched access control (OpaBatchAccessControl,
-# enabled via `opa.policy.batched-uri` on the trino-opa plugin) sends
-# candidates under `input.action.filterResources` (plural) instead of
-# `input.action.resource` (singular). Every filter rule below reads
-# `input.action.resource.*`, so under the batched shape they all fail
-# their body and fall through to `default allow := false`. That is
-# fail-closed — safe by the threat model — but operationally it means
-# enabling batched mode in the chart silently denies every filter
-# query, which looks like a tenant-isolation bug from the outside.
-# DO NOT set `opa.policy.batched-uri` in the customer-Trino chart
-# without first extending this policy to handle the batched shape (and
-# the bundle generator's tests). TestBatchedInputDeniesByDefault below
-# locks the fail-closed behaviour as a regression guard.
+# !!! Cross-component invariant: this policy serves BOTH OPA shapes.
+# `allow` answers the non-batched contract, where the candidate sits at
+# `input.action.resource` (singular). `batch` answers Trino's
+# OpaBatchAccessControl (`opa.policy.batched-uri`), where candidates
+# arrive as a list at `input.action.filterResources` (plural) and the
+# response is the list of allowed INDICES into it.
+#
+# The two are not independent: `batch` is defined by re-evaluating
+# `allow` with each candidate substituted in at `input.action.resource`,
+# so any rule added to `allow` is honoured in batched mode automatically
+# and the shapes cannot drift. Do NOT hand-write a parallel set of
+# batched rules.
+#
+# Both are wired deliberately. A coordinator with only `opa.policy.uri`
+# set issues ONE request per candidate object, and filtering a catalog
+# with more than ~1024 tables overruns the HTTP client's per-destination
+# queue ("Max requests queued per destination 1024 exceeded"), which
+# reaches the user as "Failed to query OPA backend" on any
+# information_schema listing. TestBatchedFilteringMatchesNonBatched
+# locks the two shapes to identical answers.
 
 package trino
 
@@ -278,6 +284,40 @@ allow if {
 allow if {
 	input.action.operation == "FilterColumns"
 	readable_catalog(input.action.resource.table.catalogName)
+}
+
+# ---------------------------------------------------------------------------
+# Batched filtering.
+#
+# Trino's OpaBatchAccessControl POSTs one request carrying every candidate
+# under `input.action.filterResources` and expects `{"result": [<indices>]}`
+# naming the entries the caller may see. Each candidate is evaluated by
+# substituting it at `input.action.resource` and re-running `allow`, so
+# batched and non-batched decisions are the same decision by construction.
+# ---------------------------------------------------------------------------
+
+batch contains i if {
+	some i
+	resource := input.action.filterResources[i]
+	allow with input.action.resource as resource
+}
+
+# FilterColumns is the one operation whose batched shape is not simply a
+# list of the non-batched resource: Trino sends a SINGLE table candidate
+# carrying a `columns` array and expects indices into THAT array rather
+# than into filterResources. Fan the columns out into one table resource
+# each so the same `allow` rules answer for them.
+batch contains i if {
+	some i
+	input.action.operation == "FilterColumns"
+	count(input.action.filterResources) == 1
+	resource := input.action.filterResources[0]
+	count(resource.table.columns) > 0
+	columns := [
+		object.union(resource, {"table": {"column": name}}) |
+		some name in resource.table.columns
+	]
+	allow with input.action.resource as columns[i]
 }
 
 # ---------------------------------------------------------------------------

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -298,6 +298,11 @@ allow if {
 
 batch contains i if {
 	some i
+	# FilterColumns indexes into the candidate's `columns` array, not into
+	# filterResources, and is answered by the rule below. Excluding it here
+	# keeps one rule per shape: left in, this rule also contributes index 0
+	# for a table carrying NO columns, which is an out-of-bounds answer.
+	input.action.operation != "FilterColumns"
 	resource := input.action.filterResources[i]
 	allow with input.action.resource as resource
 }

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -2,6 +2,7 @@ package opa
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -715,39 +716,167 @@ func TestIsolationMatrix(t *testing.T) {
 // safety). Default-deny is the floor.
 // --------------------------------------------------------------------------
 
-func TestBatchedInputDeniesByDefault(t *testing.T) {
-	q := preparedPolicy(t, twoOrgFixture())
+// preparedBatch compiles the policy for the batched entrypoint.
+func preparedBatch(t *testing.T, gc GroupCatalogs) rego.PreparedEvalQuery {
+	t.Helper()
+	data, err := buildDataDocument(gc)
+	if err != nil {
+		t.Fatalf("buildDataDocument: %v", err)
+	}
+	q, err := rego.New(
+		rego.Query("data.trino.batch"),
+		rego.Module("policy.rego", string(policyRego)),
+		rego.Data(data),
+	).PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("PrepareForEval: %v", err)
+	}
+	return q
+}
 
-	// Construct a batched-shape input the way Trino 476's
-	// OpaBatchAccessControl does: `action.filterResources` is a list of
-	// resource objects. The non-batched `action.resource` is absent.
-	for _, op := range []string{
-		"FilterCatalogs",
-		"FilterSchemas",
-		"FilterTables",
-		"FilterColumns",
-	} {
-		batched := map[string]interface{}{
+// evalBatch returns the set of allowed indices the batched entrypoint names.
+func evalBatch(t *testing.T, q rego.PreparedEvalQuery, input map[string]interface{}) map[int]bool {
+	t.Helper()
+	rs, err := q.Eval(context.Background(), rego.EvalInput(input))
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	out := map[int]bool{}
+	if len(rs) == 0 || len(rs[0].Expressions) == 0 {
+		return out
+	}
+	items, ok := rs[0].Expressions[0].Value.([]interface{})
+	if !ok {
+		t.Fatalf("expected a list of indices, got %T (%v)", rs[0].Expressions[0].Value, rs[0].Expressions[0].Value)
+	}
+	for _, it := range items {
+		n, ok := it.(json.Number)
+		if !ok {
+			t.Fatalf("expected numeric index, got %T (%v)", it, it)
+		}
+		i, err := n.Int64()
+		if err != nil {
+			t.Fatalf("index %v: %v", n, err)
+		}
+		out[int(i)] = true
+	}
+	return out
+}
+
+// The batched entrypoint must return exactly the candidates the non-batched
+// entrypoint allows. Enabling opa.policy.batched-uri is what stops a
+// coordinator issuing one OPA request per table — filtering a catalog with
+// more than ~1024 tables otherwise overruns the client's queue — so this is
+// the rule that carries tenant isolation for every information_schema
+// listing, and it must not diverge from `allow`.
+func TestBatchedFilteringMatchesNonBatched(t *testing.T) {
+	allowQ := preparedPolicy(t, twoOrgFixture())
+	batchQ := preparedBatch(t, twoOrgFixture())
+
+	identity := map[string]interface{}{
+		"user":   "42",
+		"groups": []string{"org_42"},
+	}
+	ctx := map[string]interface{}{
+		"identity":      identity,
+		"softwareStack": map[string]interface{}{"trinoVersion": "476"},
+	}
+
+	cases := []struct {
+		op        string
+		resources []map[string]interface{}
+		want      map[int]bool
+	}{
+		{
+			op: "FilterCatalogs",
+			resources: []map[string]interface{}{
+				{"catalog": map[string]interface{}{"name": "org_42"}},
+				{"catalog": map[string]interface{}{"name": "org_43"}},
+			},
+			want: map[int]bool{0: true},
+		},
+		{
+			op: "FilterSchemas",
+			resources: []map[string]interface{}{
+				{"schema": map[string]interface{}{"catalogName": "org_43", "schemaName": "main"}},
+				{"schema": map[string]interface{}{"catalogName": "org_42", "schemaName": "main"}},
+			},
+			want: map[int]bool{1: true},
+		},
+		{
+			op: "FilterTables",
+			resources: []map[string]interface{}{
+				{"table": map[string]interface{}{"catalogName": "org_42", "schemaName": "main", "tableName": "events"}},
+				{"table": map[string]interface{}{"catalogName": "org_43", "schemaName": "main", "tableName": "events"}},
+				{"table": map[string]interface{}{"catalogName": "org_42", "schemaName": "main", "tableName": "persons"}},
+			},
+			want: map[int]bool{0: true, 2: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.op, func(t *testing.T) {
+			got := evalBatch(t, batchQ, map[string]interface{}{
+				"context": ctx,
+				"action": map[string]interface{}{
+					"operation":       tc.op,
+					"filterResources": tc.resources,
+				},
+			})
+			if len(got) != len(tc.want) {
+				t.Fatalf("batch = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if !got[i] {
+					t.Errorf("index %d missing from batch result %v", i, got)
+				}
+			}
+
+			// Same verdict, candidate by candidate, through `allow`.
+			for i, res := range tc.resources {
+				action := map[string]interface{}{"operation": tc.op, "resource": res}
+				allowed := evalAllow(t, allowQ, map[string]interface{}{"context": ctx, "action": action})
+				if allowed != tc.want[i] {
+					t.Errorf("candidate %d: allow=%v but batch expects %v — the two shapes disagree", i, allowed, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// FilterColumns is the shape-shifter: ONE table candidate carrying a columns
+// array, with indices pointing into that array rather than filterResources.
+func TestBatchedFilterColumns(t *testing.T) {
+	batchQ := preparedBatch(t, twoOrgFixture())
+
+	mk := func(catalog string) map[string]interface{} {
+		return map[string]interface{}{
 			"context": map[string]interface{}{
-				"identity": map[string]interface{}{
-					"user":   "42",
-					"groups": []string{"org_42"},
-				},
-				"softwareStack": map[string]interface{}{
-					"trinoVersion": "476",
-				},
+				"identity":      map[string]interface{}{"user": "42", "groups": []string{"org_42"}},
+				"softwareStack": map[string]interface{}{"trinoVersion": "476"},
 			},
 			"action": map[string]interface{}{
-				"operation": op,
-				"filterResources": []map[string]interface{}{
-					{"catalog": map[string]interface{}{"name": "org_42"}},
-					{"catalog": map[string]interface{}{"name": "org_43"}},
-				},
+				"operation": "FilterColumns",
+				"filterResources": []map[string]interface{}{{
+					"table": map[string]interface{}{
+						"catalogName": catalog,
+						"schemaName":  "main",
+						"tableName":   "events",
+						"columns":     []string{"uuid", "timestamp", "properties"},
+					},
+				}},
 			},
 		}
-		if evalAllow(t, q, batched) {
-			t.Errorf("%s under batched input shape must NOT allow -- the policy is the non-batched contract; enabling opa.policy.batched-uri without updating the policy would otherwise be a cross-tenant exposure", op)
-		}
+	}
+
+	own := evalBatch(t, batchQ, mk("org_42"))
+	if len(own) != 3 || !own[0] || !own[1] || !own[2] {
+		t.Errorf("every column of the caller's own table must be visible, got %v", own)
+	}
+
+	other := evalBatch(t, batchQ, mk("org_43"))
+	if len(other) != 0 {
+		t.Errorf("no column of another org's table may be visible, got %v", other)
 	}
 }
 

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -878,6 +878,30 @@ func TestBatchedFilterColumns(t *testing.T) {
 	if len(other) != 0 {
 		t.Errorf("no column of another org's table may be visible, got %v", other)
 	}
+
+	// A readable table carrying NO columns must yield no indices. The generic
+	// batch rule excludes FilterColumns precisely so it cannot answer 0 here —
+	// an index into an empty array.
+	empty := evalBatch(t, batchQ, map[string]interface{}{
+		"context": map[string]interface{}{
+			"identity":      map[string]interface{}{"user": "42", "groups": []string{"org_42"}},
+			"softwareStack": map[string]interface{}{"trinoVersion": "476"},
+		},
+		"action": map[string]interface{}{
+			"operation": "FilterColumns",
+			"filterResources": []map[string]interface{}{{
+				"table": map[string]interface{}{
+					"catalogName": "org_42",
+					"schemaName":  "main",
+					"tableName":   "events",
+					"columns":     []string{},
+				},
+			}},
+		},
+	})
+	if len(empty) != 0 {
+		t.Errorf("a table with no columns must yield no indices, got %v", empty)
+	}
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Found while validating the first pilot org. **Any `information_schema` listing over a real catalog fails**, which breaks JDBC clients and BI tools on connect.

```
Failed to query OPA backend
RejectedExecutionException: Max requests queued per destination 1024 exceeded
  io.trino.plugin.opa.OpaHttpClient.parallelRequest
```

## Cause

With only `opa.policy.uri` set, the coordinator issues **one OPA request per candidate object**. PostHog's catalog has 57 schemas and well over 1024 tables, so `filterTables` overruns Jetty's per-destination queue.

OPA was not the bottleneck — it was answering in ~0.4ms with 200s. It had simply been asked 18,724 times.

## Why this wasn't already done

The policy carried an explicit DO-NOT-ENABLE warning, and it was right: `opa.policy.batched-uri` against a policy that only reads the singular `input.action.resource` denies **every** filter query. That is fail-closed and safe, but from the outside it is indistinguishable from a tenant-isolation bug. The warning asked for the policy to be extended first — this is that.

## Approach

`batch` is not a parallel set of rules. It re-evaluates `allow` with each candidate substituted in:

```rego
batch contains i if {
	some i
	resource := input.action.filterResources[i]
	allow with input.action.resource as resource
}
```

So batched and non-batched are the same decision by construction, and any rule added to `allow` is honoured in both. That property is what keeps this from becoming a second isolation surface that can silently drift from the first.

`FilterColumns` needs its own rule because its batched shape is not simply a list of the non-batched resource: Trino sends a **single** table candidate carrying a `columns` array and expects indices into *that* array. The columns are fanned out into one table resource each so the same `allow` rules answer for them.

## Tests

The old `TestBatchedInputDeniesByDefault` guard is gone — it locked in the behaviour this PR deliberately changes. Replacing it:

- `TestBatchedFilteringMatchesNonBatched` — for FilterCatalogs, FilterSchemas and FilterTables, asserts the batched result is exactly the allowed index set **and** re-checks every candidate through `allow`, failing if the two shapes disagree.
- `TestBatchedFilterColumns` — all three columns of the caller's own table are visible; **no** column of another org's table is.

## Rollout ordering (important)

The bundle is served by the control plane, so the policy must be deployed **before** the chart sets `opa.policy.batched-uri`. Flipping the chart first points the coordinator at `/v1/data/trino/batch` on a bundle that has no `batch` rule — undefined, empty result, everything filtered out.

Order: merge this → promote duckgres to prod → then the charts PR that sets the batched URI.