### PR TITLE
Make batched OPA filtering linear in the candidate count

### DIFF
--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -296,33 +296,51 @@ allow if {
 # batched and non-batched decisions are the same decision by construction.
 # ---------------------------------------------------------------------------
 
+# Each rule dispatches on the operation and applies the SAME predicate its
+# `allow` counterpart uses, reading the candidate straight out of
+# filterResources.
+#
+# The obvious formulation — `allow with input.action.resource as candidate` —
+# is quadratic and unusable here. `with` copies the whole input document per
+# candidate, and the input holds every candidate, so evaluating one batch of n
+# costs O(n^2): measured at 17ms for n=100, 1.0s for n=1,000, 17s for n=5,000
+# and 4m for n=20,000. A catalog-wide table listing on this cell exceeded
+# OPA's 60s request budget and returned 500. Reading the candidate directly is
+# linear.
+#
+# The cost is that the operation dispatch is written twice, here and in
+# `allow`. The authorization predicate itself is NOT duplicated — both call
+# the same readable_catalog / listable_catalog helpers, so a change to who may
+# see what lands in one place. TestBatchedFilteringMatchesNonBatched pins the
+# two shapes to identical answers candidate by candidate, which is what
+# catches dispatch drift.
+
 batch contains i if {
 	some i
-	# FilterColumns indexes into the candidate's `columns` array, not into
-	# filterResources, and is answered by the rule below. Excluding it here
-	# keeps one rule per shape: left in, this rule also contributes index 0
-	# for a table carrying NO columns, which is an out-of-bounds answer.
-	input.action.operation != "FilterColumns"
-	resource := input.action.filterResources[i]
-	allow with input.action.resource as resource
+	input.action.operation == "FilterCatalogs"
+	listable_catalog(input.action.filterResources[i].catalog.name)
 }
 
-# FilterColumns is the one operation whose batched shape is not simply a
-# list of the non-batched resource: Trino sends a SINGLE table candidate
-# carrying a `columns` array and expects indices into THAT array rather
-# than into filterResources. Fan the columns out into one table resource
-# each so the same `allow` rules answer for them.
 batch contains i if {
 	some i
+	input.action.operation == "FilterSchemas"
+	readable_catalog(input.action.filterResources[i].schema.catalogName)
+}
+
+batch contains i if {
+	some i
+	input.action.operation == "FilterTables"
+	readable_catalog(input.action.filterResources[i].table.catalogName)
+}
+
+# FilterColumns is the one operation whose indices point into the candidate's
+# `columns` array rather than into filterResources: Trino sends a SINGLE table
+# candidate carrying the columns.
+batch contains i if {
 	input.action.operation == "FilterColumns"
 	count(input.action.filterResources) == 1
-	resource := input.action.filterResources[0]
-	count(resource.table.columns) > 0
-	columns := [
-		object.union(resource, {"table": {"column": name}}) |
-		some name in resource.table.columns
-	]
-	allow with input.action.resource as columns[i]
+	readable_catalog(input.action.filterResources[0].table.catalogName)
+	some i, _ in input.action.filterResources[0].table.columns
 }
 
 # ---------------------------------------------------------------------------

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -3,8 +3,10 @@ package opa
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-policy-agent/opa/v1/rego"
 )
@@ -902,6 +904,61 @@ func TestBatchedFilterColumns(t *testing.T) {
 	if len(empty) != 0 {
 		t.Errorf("a table with no columns must yield no indices, got %v", empty)
 	}
+}
+
+// Batch evaluation must stay LINEAR in the number of candidates. The natural
+// formulation — `allow with input.action.resource as candidate` — is
+// quadratic, because `with` copies the whole input (which holds every
+// candidate) once per candidate. That shipped, and a catalog-wide table
+// listing blew OPA's 60s request budget: 17ms at n=100 but 17s at n=5,000
+// and 4 minutes at n=20,000.
+//
+// 20,000 candidates run in ~120ms linear. The 20s bound is loose enough for a
+// loaded CI runner and still ~200x under what the quadratic form needed, so
+// this fails loudly on a regression rather than flaking.
+func TestBatchFilteringIsLinearInCandidateCount(t *testing.T) {
+	q := preparedBatch(t, twoOrgFixture())
+
+	const n = 20000
+	resources := make([]map[string]interface{}, 0, n)
+	for i := range n {
+		catalog := "org_42"
+		if i%2 == 1 {
+			catalog = "org_43" // the other org's table: must be filtered out
+		}
+		resources = append(resources, map[string]interface{}{
+			"table": map[string]interface{}{
+				"catalogName": catalog,
+				"schemaName":  "main",
+				"tableName":   fmt.Sprintf("t%d", i),
+			},
+		})
+	}
+
+	start := time.Now()
+	got := evalBatch(t, q, map[string]interface{}{
+		"context": map[string]interface{}{
+			"identity":      map[string]interface{}{"user": "42", "groups": []string{"org_42"}},
+			"softwareStack": map[string]interface{}{"trinoVersion": "476"},
+		},
+		"action": map[string]interface{}{
+			"operation":       "FilterTables",
+			"filterResources": resources,
+		},
+	})
+	elapsed := time.Since(start)
+
+	if len(got) != n/2 {
+		t.Fatalf("allowed %d of %d candidates, want %d (every org_42 table and no other)", len(got), n, n/2)
+	}
+	// Spot-check the partition rather than trusting the count alone.
+	if !got[0] || got[1] {
+		t.Errorf("wrong candidates allowed: index 0 (org_42) = %v, index 1 (org_43) = %v", got[0], got[1])
+	}
+	if elapsed > 20*time.Second {
+		t.Errorf("batch of %d took %v — that is the quadratic shape, not a slow runner", n, elapsed)
+	}
+	t.Logf("n=%d evaluated in %v", n, elapsed)
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/duckgres/pull/1118. **That fix was incomplete** — it removed the request fan-out but replaced it with a single request too slow to finish, so the catalog-wide table listing on cell-001 still fails, just differently.

## What I got wrong in 1118

The batch rule was written the way upstream's example writes it:

```rego
batch contains i if {
	some i
	resource := input.action.filterResources[i]
	allow with input.action.resource as resource
}
```

`with` copies the **whole input document** once per candidate, and the input holds every candidate — so one batch of n costs O(n²). Measured against the real policy:

| candidates | before |
|---|---|
| 100 | 17ms |
| 1,000 | 1.0s |
| 5,000 | 17.3s |
| 20,000 | 4m06s |

In prod that showed up as exactly one bad request among 68: p50 **0.8ms**, p90 **1.1ms**, and one at **60,087ms** returning 500 — OPA's request budget, blown by the catalog-wide listing.

So 1118 traded 18,724 fast requests for one that could not complete. I verified the listing worked with `LIMIT 20` and took that as success; the limit let Trino short-circuit before enumerating everything, which is precisely the case that breaks.

## Fix

Read each candidate straight out of `filterResources`, dispatching on the operation and applying the same predicate its `allow` counterpart uses.

| candidates | after |
|---|---|
| 1,000 | 7.8ms |
| 5,000 | 31ms |
| 20,000 | 117ms |
| 100,000 | 544ms |

## The tradeoff, stated plainly

1118's selling point was that `batch` re-used `allow`, so the two could not drift. This gives that up: the **operation dispatch** is now written twice.

What is *not* duplicated is the authorization predicate — both shapes call the same `readable_catalog` / `listable_catalog` helpers, so a change to who may see what still lands in exactly one place. The risk is narrowed to "someone adds a filter operation to `allow` and forgets `batch`", and `TestBatchedFilteringMatchesNonBatched` already checks the two shapes agree candidate by candidate.

I would rather have the shared-predicate version than a policy that cannot answer a listing.

## Tests

- `TestBatchFilteringIsLinearInCandidateCount` — 20,000 candidates, asserts the org partition is exact (every `org_42` table, no `org_43` table) and bounds the run at 20s. That is ~200x under what the quadratic form needed, so it fails loudly on regression without flaking on a loaded runner. Currently runs in ~130ms.
- Existing agreement and cross-tenant tests unchanged and passing.

## Separately: OPA decision logs are misconfigured

While diagnosing this I found the sidecar's `config.yaml` sets `decision_logs: {console: false}`, which **starts** the decision-log plugin with no service of its own — so it buffers decisions and tries to upload them to the bundle service, failing with:

```
Log encoding failed: upload chunk size (412667) exceeds upload_size_limit_bytes (32768)
```

Harmless today (it does not block decisions) but it is noise on every large batch and wants either a real destination or removal. Chart-side, filed separately rather than mixed in here.