### PR TITLE
Let an org without a root user get one, and say so when it hasn't

### DIFF
--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -79,6 +79,10 @@ type Store interface {
 	Provision(req ProvisionRequest) error
 	CreatePendingWarehouse(orgID, databaseName string, warehouse *configstore.ManagedWarehouse) error
 	CreateOrgUser(orgID, username, passwordHash string) error
+	// GetOrgUser reads one login. Used to preflight the Trino opt-in: an org
+	// with no `root` user cannot be projected into a cell, and the reconcile
+	// loop skips it silently, so the API rejects it up front instead.
+	GetOrgUser(orgID, username string) (*configstore.OrgUser, error)
 	UpdateOrgUserPassword(orgID, username, passwordHash string) error
 	SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error
 	IsDatabaseNameAvailable(name string) (bool, error)
@@ -602,6 +606,24 @@ func (h *handler) enableTrino(c *gin.Context) {
 		return
 	}
 
+	// Preflight: the org's `root` login is the tenant's Trino principal —
+	// ListTrinoEnabledOrgs inner-joins on it, so an org without one is
+	// dropped from every projection and the reconcile loop never reports
+	// why. Orgs provisioned before the root-user convention are exactly
+	// this shape. Reject here so the caller learns immediately instead of
+	// watching the org sit at Pending forever; POST /orgs/:id/reset-password
+	// creates the missing login on a Ready warehouse.
+	if _, err := h.store.GetOrgUser(orgID, "root"); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "org has no root user, so it cannot be projected into a Trino cell; POST /orgs/" + orgID + "/reset-password to create one",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
 	if err := h.store.EnableTrino(orgID, configstore.TrinoSettings{Tier: req.Tier}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -755,8 +777,18 @@ func (h *handler) resetPassword(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
 		return
 	}
-	if err := h.store.UpdateOrgUserPassword(orgID, "root", hash); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "root user not found"})
+	// Upsert, not update. Orgs provisioned before the root-user convention
+	// have no `root` row at all — their primary login was named `duckgres` —
+	// and an update-only reset left them permanently unfixable: /provision
+	// refuses to touch a warehouse that is not Failed or Deleted
+	// (ErrWarehouseNonTerminal), so there was no supported path to give a
+	// live legacy org the root user every other surface assumes.
+	//
+	// Creating it here is gated on the same Ready check above, so this never
+	// mints a credential for a half-built warehouse, and CreateOrgUser's
+	// OnConflict makes the normal reset path behave exactly as before.
+	if err := h.store.CreateOrgUser(orgID, "root", hash); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -83,7 +83,6 @@ type Store interface {
 	// with no `root` user cannot be projected into a cell, and the reconcile
 	// loop skips it silently, so the API rejects it up front instead.
 	GetOrgUser(orgID, username string) (*configstore.OrgUser, error)
-	UpdateOrgUserPassword(orgID, username, passwordHash string) error
 	SetWarehouseDeleting(orgID string, expectedState configstore.ManagedWarehouseProvisioningState) error
 	IsDatabaseNameAvailable(name string) (bool, error)
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -70,6 +70,14 @@ func (s *fakeStore) CreateOrgUser(orgID, username, passwordHash string) error {
 	return nil
 }
 
+func (s *fakeStore) GetOrgUser(orgID, username string) (*configstore.OrgUser, error) {
+	hash, ok := s.users[configstore.OrgUserKey{OrgID: orgID, Username: username}]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &configstore.OrgUser{OrgID: orgID, Username: username, Password: hash}, nil
+}
+
 func (s *fakeStore) UpdateOrgUserPassword(orgID, username, passwordHash string) error {
 	key := configstore.OrgUserKey{OrgID: orgID, Username: username}
 	if _, exists := s.users[key]; !exists {
@@ -1072,6 +1080,8 @@ func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
 	// numeric team_id — opts into Trino via the standalone endpoint.
 	store := newFakeStore()
 	store.orgs["ben-ducklake-cnpg"] = &configstore.Org{Name: "ben-ducklake-cnpg"}
+	// The org's root login is its Trino principal; the endpoint preflights it.
+	store.users[configstore.OrgUserKey{OrgID: "ben-ducklake-cnpg", Username: "root"}] = "hash"
 	router := newTestRouter(store)
 
 	body := []byte(`{"enabled": true, "tier": "growth"}`)
@@ -1086,6 +1096,64 @@ func TestEnableTrinoStandaloneEndpoint(t *testing.T) {
 	row := store.trino["ben-ducklake-cnpg"]
 	if row == nil || !row.Enabled || row.Tier != "growth" {
 		t.Fatalf("expected trino row enabled with tier growth; got %+v", row)
+	}
+}
+
+// An org with no `root` login cannot be projected into a cell:
+// ListTrinoEnabledOrgs inner-joins on it, so the reconcile loop drops the org
+// and never says why. Orgs provisioned before the root-user convention are
+// exactly this shape. Reject at the API instead of queueing a row that can
+// never provision.
+func TestEnableTrinoRejectsOrgWithoutRootUser(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["legacy-org"] = &configstore.Org{Name: "legacy-org", DatabaseName: "legacy"}
+	// Its primary login predates the convention.
+	store.users[configstore.OrgUserKey{OrgID: "legacy-org", Username: "duckgres"}] = "hash"
+	router := newTestRouter(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/legacy-org/trino", bytes.NewReader([]byte(`{"enabled": true}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "reset-password") {
+		t.Errorf("the error should point at the remedy, got %s", rec.Body.String())
+	}
+	if store.trino["legacy-org"] != nil {
+		t.Error("no trino row may be written for an org that cannot be provisioned")
+	}
+}
+
+// reset-password must CREATE the root login when it is absent, not 404.
+// /provision refuses to touch a warehouse that is not Failed or Deleted, so
+// without this there is no supported way to give a live legacy org the root
+// user every other surface assumes.
+func TestResetPasswordCreatesMissingRootUser(t *testing.T) {
+	store := newFakeStore()
+	store.orgs["legacy-org"] = &configstore.Org{Name: "legacy-org"}
+	store.users[configstore.OrgUserKey{OrgID: "legacy-org", Username: "duckgres"}] = "old"
+	store.warehouses["legacy-org"] = &configstore.ManagedWarehouse{
+		OrgID: "legacy-org",
+		State: configstore.ManagedWarehouseStateReady,
+	}
+	router := newTestRouter(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/legacy-org/reset-password", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if _, ok := store.users[configstore.OrgUserKey{OrgID: "legacy-org", Username: "root"}]; !ok {
+		t.Fatal("root user was not created")
+	}
+	// The pre-existing legacy login is left alone.
+	if store.users[configstore.OrgUserKey{OrgID: "legacy-org", Username: "duckgres"}] != "old" {
+		t.Error("the org's existing login must not be touched")
 	}
 }
 

--- a/controlplane/provisioning/api_test.go
+++ b/controlplane/provisioning/api_test.go
@@ -78,15 +78,6 @@ func (s *fakeStore) GetOrgUser(orgID, username string) (*configstore.OrgUser, er
 	return &configstore.OrgUser{OrgID: orgID, Username: username, Password: hash}, nil
 }
 
-func (s *fakeStore) UpdateOrgUserPassword(orgID, username, passwordHash string) error {
-	key := configstore.OrgUserKey{OrgID: orgID, Username: username}
-	if _, exists := s.users[key]; !exists {
-		return fmt.Errorf("user %q not found in org %q", username, orgID)
-	}
-	s.users[key] = passwordHash
-	return nil
-}
-
 func (s *fakeStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error) {
 	w, ok := s.warehouses[orgID]
 	if !ok {

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -95,10 +95,6 @@ func (s *gormStore) GetOrgUser(orgID, username string) (*configstore.OrgUser, er
 	return &user, nil
 }
 
-func (s *gormStore) UpdateOrgUserPassword(orgID, username, passwordHash string) error {
-	return s.cs.UpdateOrgUserPassword(orgID, username, passwordHash)
-}
-
 func (s *gormStore) GetManagedWarehouse(orgID string) (*configstore.ManagedWarehouse, error) {
 	var warehouse configstore.ManagedWarehouse
 	if err := s.cs.DB().First(&warehouse, "org_id = ?", orgID).Error; err != nil {

--- a/controlplane/provisioning/store.go
+++ b/controlplane/provisioning/store.go
@@ -87,6 +87,14 @@ func (s *gormStore) CreateOrgUser(orgID, username, passwordHash string) error {
 	return s.cs.CreateOrgUser(orgID, username, passwordHash)
 }
 
+func (s *gormStore) GetOrgUser(orgID, username string) (*configstore.OrgUser, error) {
+	var user configstore.OrgUser
+	if err := s.cs.DB().First(&user, "org_id = ? AND username = ?", orgID, username).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
 func (s *gormStore) UpdateOrgUserPassword(orgID, username, passwordHash string) error {
 	return s.cs.UpdateOrgUserPassword(orgID, username, passwordHash)
 }

--- a/controlplane/read_only_group_test.go
+++ b/controlplane/read_only_group_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
 	"github.com/posthog/duckgres/controlplane/admin"
 	"github.com/posthog/duckgres/controlplane/configstore"
@@ -28,7 +29,10 @@ func (stubProvisioningStore) Provision(provisioning.ProvisionRequest) error { re
 func (stubProvisioningStore) CreatePendingWarehouse(string, string, *configstore.ManagedWarehouse) error {
 	return nil
 }
-func (stubProvisioningStore) CreateOrgUser(string, string, string) error         { return nil }
+func (stubProvisioningStore) CreateOrgUser(string, string, string) error { return nil }
+func (stubProvisioningStore) GetOrgUser(string, string) (*configstore.OrgUser, error) {
+	return nil, gorm.ErrRecordNotFound
+}
 func (stubProvisioningStore) UpdateOrgUserPassword(string, string, string) error { return nil }
 func (stubProvisioningStore) SetWarehouseDeleting(string, configstore.ManagedWarehouseProvisioningState) error {
 	return nil

--- a/controlplane/read_only_group_test.go
+++ b/controlplane/read_only_group_test.go
@@ -33,7 +33,6 @@ func (stubProvisioningStore) CreateOrgUser(string, string, string) error { retur
 func (stubProvisioningStore) GetOrgUser(string, string) (*configstore.OrgUser, error) {
 	return nil, gorm.ErrRecordNotFound
 }
-func (stubProvisioningStore) UpdateOrgUserPassword(string, string, string) error { return nil }
 func (stubProvisioningStore) SetWarehouseDeleting(string, configstore.ManagedWarehouseProvisioningState) error {
 	return nil
 }


### PR DESCRIPTION
Enabling Trino for one org returned `200 {"status":"trino enable queued"}` and then nothing happened — silently, indefinitely.

## Cause

That org has no `root` login; its primary logins carry an older naming. `ListTrinoEnabledOrgs` inner-joins on `username = 'root'`, so the org is dropped from every projection and the reconcile loop never reports why.

It is the only org in that shape in this environment. It predates the root-user convention by about five weeks — every org provisioned since gets `root` from the `Provision` transaction, which creates the org and its root user together in one write.

## Problem 1: the org could not be repaired

- `POST /orgs/:id/reset-password` calls `UpdateOrgUserPassword`, which fails when the row is absent — it can only rotate an existing login.
- Re-running `POST /orgs/:id/provision` is refused for any warehouse that is not `Failed` or `Deleted` (`ErrWarehouseNonTerminal`).

That guard is right — re-provisioning a live warehouse would reset it to Pending and re-trigger duckling reconciliation. But between the two, a live legacy org had **no supported path** to the root user every other surface assumes.

`reset-password` now upserts via `CreateOrgUser` instead of update-only. It stays gated on the existing `state == Ready` check, so it never mints a credential for a half-built warehouse, and `CreateOrgUser`'s `OnConflict` leaves the normal rotate path behaving exactly as before.

## Problem 2: the failure was invisible

`enableTrino` already preflights the org row, so a missing org is a clean 404 rather than a raw FK violation. It now preflights the root login the same way: **409** naming `reset-password` as the remedy, instead of writing a row that can never provision.

## Tests

- `TestEnableTrinoRejectsOrgWithoutRootUser` — 409, error text points at the remedy, and **no** trino row is written.
- `TestResetPasswordCreatesMissingRootUser` — creates `root` on a Ready warehouse and leaves the org's pre-existing login untouched.
- `TestEnableTrinoStandaloneEndpoint` updated to seed a root user; it previously encoded the old behaviour by seeding none.
- `TestResetPasswordRequiresReadyWarehouse` unchanged and still passing — the Ready gate is intact.

## Applying it

After this deploys, `reset-password` on the affected org creates the root login and returns its plaintext once. That mints a new credential, so it should be a deliberate operator action rather than a side effect.
