### PR TITLE
Read the metadata connection from the Duckling status too

### DIFF
--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"sort"
@@ -1391,17 +1392,17 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 // when the row has no s3_region of its own.
 func missingCatalogInputs(w *configstore.ManagedWarehouse, d *DucklingStatus, fallbackRegion string) []string {
 	var missing []string
-	if w.MetadataStore.Endpoint == "" {
-		missing = append(missing, "metadata_store_endpoint")
-	}
-	if w.MetadataStore.DatabaseName == "" {
-		missing = append(missing, "metadata_store_database_name")
-	}
-	if w.MetadataStore.Username == "" {
-		missing = append(missing, "metadata_store_username")
-	}
 	if d == nil {
 		return append(missing, "duckling_status")
+	}
+	if d.MetadataStore.Endpoint == "" && d.MetadataStore.PgBouncerEndpoint == "" {
+		missing = append(missing, "metadata_store_endpoint")
+	}
+	if d.MetadataStore.Database == "" {
+		missing = append(missing, "metadata_store_database")
+	}
+	if d.MetadataStore.User == "" {
+		missing = append(missing, "metadata_store_user")
 	}
 	if d.DataStore.BucketName == "" {
 		missing = append(missing, "data_store_bucket_name")
@@ -1462,8 +1463,8 @@ func (p *TrinoProvisioner) buildCatalogProperties(orgID string, w *configstore.M
 	}
 	return map[string]string{
 		"connector.name":                             "ducklake",
-		"ducklake.metadata.connection-url":           ducklakeMetadataJDBCURL(w),
-		"ducklake.metadata.connection-user":          w.MetadataStore.Username,
+		"ducklake.metadata.connection-url":           ducklakeMetadataJDBCURL(d),
+		"ducklake.metadata.connection-user":          d.MetadataStore.User,
 		"ducklake.metadata.connection-password-file": p.tenantPasswordFilePath(orgID),
 		"ducklake.data-path":                         ducklakeDataPath(d.DataStore.BucketName, w.S3.PathPrefix),
 		"fs.s3.enabled":                              "true",
@@ -1480,8 +1481,14 @@ func (p *TrinoProvisioner) tenantPasswordFilePath(orgID string) string {
 	return p.tenantSecretMountPath + "/" + orgID
 }
 
-// ducklakeMetadataJDBCURL renders the org's metadata Postgres as a JDBC
-// URL. sslmode is derived from the store kind, never from the caller:
+// ducklakeMetadataJDBCURL renders the org's metadata Postgres as a JDBC URL,
+// reading the address off the Duckling status so Trino dials exactly what the
+// DuckDB workers dial. The config store's metadata_store columns are NOT the
+// source: they are empty for orgs whose warehouse predates them being
+// populated, which left those tenants permanently unprovisionable even though
+// the live composition had every value.
+//
+// sslmode is derived from the store kind, never from the caller:
 //
 //   - cnpg-shard: `disable`. The pooler is reached over in-cluster
 //     networking and serves no server certificate; requiring TLS makes
@@ -1489,17 +1496,31 @@ func (p *TrinoProvisioner) tenantPasswordFilePath(orgID string) string {
 //   - anything else (external RDS/Aurora, and any future kind): `require`.
 //     Fail SAFE on an unknown kind — an unnecessary TLS handshake costs a
 //     round trip, an omitted one puts a tenant credential on the wire.
-func ducklakeMetadataJDBCURL(w *configstore.ManagedWarehouse) string {
-	port := w.MetadataStore.Port
-	if port == 0 {
-		port = metadataStoreDefaultPort
-	}
+func ducklakeMetadataJDBCURL(d *DucklingStatus) string {
+	host, port := ducklingMetadataAddress(d)
 	sslMode := "require"
-	if w.MetadataStore.Kind == configstore.MetadataStoreKindCnpgShard {
+	if d.MetadataStore.Type == string(configstore.MetadataStoreKindCnpgShard) {
 		sslMode = "disable"
 	}
 	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?sslmode=%s",
-		w.MetadataStore.Endpoint, port, w.MetadataStore.DatabaseName, sslMode)
+		host, port, d.MetadataStore.Database, sslMode)
+}
+
+// ducklingMetadataAddress mirrors ducklingMetadataStoreAddress in the
+// controlplane package: prefer the per-Duckling PgBouncer when the
+// composition provisioned one, else the direct endpoint on the default port.
+// It is duplicated rather than shared because controlplane imports this
+// package, not the other way round; if the two ever disagree, THIS one is
+// wrong.
+func ducklingMetadataAddress(d *DucklingStatus) (string, int) {
+	if pgb := d.MetadataStore.PgBouncerEndpoint; pgb != "" {
+		if host, portStr, err := net.SplitHostPort(pgb); err == nil {
+			if port, err := strconv.Atoi(portStr); err == nil {
+				return host, port
+			}
+		}
+	}
+	return d.MetadataStore.Endpoint, metadataStoreDefaultPort
 }
 
 // ducklakeDataPath renders the org's object-store root. Mirrors the worker

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -99,14 +99,8 @@ func (s *fakeWarehouseStore) GetManagedWarehouseForTrino(orgID string) (*configs
 func readyWarehouse(orgID string) *configstore.ManagedWarehouse {
 	return &configstore.ManagedWarehouse{
 		OrgID: orgID,
-		MetadataStore: configstore.ManagedWarehouseMetadataStore{
-			Kind:         configstore.MetadataStoreKindCnpgShard,
-			Endpoint:     "shard-001-pooler.cnpg-shards.svc.cluster.local",
-			Port:         5432,
-			DatabaseName: "mdstore_" + orgID,
-			Username:     "mdstore_" + orgID,
-		},
-		// S3 and WorkerIdentity are deliberately left zero: nothing
+		// MetadataStore, S3 and WorkerIdentity are deliberately left zero:
+		// nothing
 		// populates those columns for a DuckLake warehouse in
 		// production. The bucket, region and role come off the Duckling
 		// CR status instead (see readyDuckling).
@@ -119,6 +113,10 @@ func readyWarehouse(orgID string) *configstore.ManagedWarehouse {
 // region and per-org IAM role actually come from.
 func readyDuckling(orgID string) *DucklingStatus {
 	d := &DucklingStatus{}
+	d.MetadataStore.Type = string(configstore.MetadataStoreKindCnpgShard)
+	d.MetadataStore.Endpoint = "shard-001-pooler.cnpg-shards.svc.cluster.local"
+	d.MetadataStore.Database = "mdstore_" + orgID
+	d.MetadataStore.User = "mdstore_" + orgID
 	d.MetadataStore.Password = "pw-" + orgID
 	d.DataStore.BucketName = "posthog-duckling-" + orgID + "-mw-dev"
 	d.DataStore.S3Region = "us-east-1"
@@ -548,109 +546,90 @@ func TestBuildTrinoResourceGroups_StructureAndTiers(t *testing.T) {
 
 func TestDuckLakeMetadataJDBCURL_SSLModeFollowsStoreKind(t *testing.T) {
 	cases := []struct {
-		name string
-		kind string
-		port int
-		want string
+		name      string
+		kind      string
+		endpoint  string
+		pgBouncer string
+		want      string
 	}{
 		{
-			name: "cnpg-shard is in-cluster plaintext",
-			kind: configstore.MetadataStoreKindCnpgShard,
-			port: 5432,
-			want: "jdbc:postgresql://pg.example:5432/mdstore?sslmode=disable",
+			name:     "cnpg-shard is in-cluster plaintext",
+			kind:     string(configstore.MetadataStoreKindCnpgShard),
+			endpoint: "pg.example",
+			want:     "jdbc:postgresql://pg.example:5432/mdstore?sslmode=disable",
 		},
 		{
-			name: "external requires TLS",
-			kind: configstore.MetadataStoreKindExternal,
-			port: 5432,
-			want: "jdbc:postgresql://pg.example:5432/mdstore?sslmode=require",
+			name:     "external requires TLS",
+			kind:     string(configstore.MetadataStoreKindExternal),
+			endpoint: "pg.example",
+			want:     "jdbc:postgresql://pg.example:5432/mdstore?sslmode=require",
 		},
 		{
-			name: "unknown kind fails safe to TLS",
-			kind: "some-future-backend",
-			port: 5432,
-			want: "jdbc:postgresql://pg.example:5432/mdstore?sslmode=require",
+			name:     "unknown kind fails safe to TLS",
+			kind:     "some-future-backend",
+			endpoint: "pg.example",
+			want:     "jdbc:postgresql://pg.example:5432/mdstore?sslmode=require",
 		},
 		{
-			name: "zero port defaults to 5432",
-			kind: configstore.MetadataStoreKindCnpgShard,
-			port: 0,
-			want: "jdbc:postgresql://pg.example:5432/mdstore?sslmode=disable",
+			// A per-Duckling pooler carries its own host:port and wins over
+			// the direct endpoint, matching the worker activation path.
+			name:      "pgbouncer endpoint wins and carries its port",
+			kind:      string(configstore.MetadataStoreKindExternal),
+			endpoint:  "pg.example",
+			pgBouncer: "pgb.example:6432",
+			want:      "jdbc:postgresql://pgb.example:6432/mdstore?sslmode=require",
 		},
 		{
-			name: "explicit non-default port is preserved",
-			kind: configstore.MetadataStoreKindExternal,
-			port: 6432,
-			want: "jdbc:postgresql://pg.example:6432/mdstore?sslmode=require",
+			// Garbage in the pooler field must not produce a malformed DSN;
+			// fall back to the direct endpoint.
+			name:      "unparseable pgbouncer endpoint falls back",
+			kind:      string(configstore.MetadataStoreKindCnpgShard),
+			endpoint:  "pg.example",
+			pgBouncer: "not-a-host-port",
+			want:      "jdbc:postgresql://pg.example:5432/mdstore?sslmode=disable",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := &configstore.ManagedWarehouse{
-				MetadataStore: configstore.ManagedWarehouseMetadataStore{
-					Kind:         tc.kind,
-					Endpoint:     "pg.example",
-					Port:         tc.port,
-					DatabaseName: "mdstore",
-				},
-			}
-			if got := ducklakeMetadataJDBCURL(w); got != tc.want {
+			d := &DucklingStatus{}
+			d.MetadataStore.Type = tc.kind
+			d.MetadataStore.Endpoint = tc.endpoint
+			d.MetadataStore.PgBouncerEndpoint = tc.pgBouncer
+			d.MetadataStore.Database = "mdstore"
+			if got := ducklakeMetadataJDBCURL(d); got != tc.want {
 				t.Errorf("ducklakeMetadataJDBCURL = %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestDuckLakeDataPath(t *testing.T) {
-	cases := []struct {
-		name   string
-		bucket string
-		prefix string
-		want   string
-	}{
-		{"no prefix", "b", "", "s3://b/"},
-		{"prefix", "b", "data", "s3://b/data/"},
-		{"prefix with slashes", "b", "/data/", "s3://b/data/"},
-		{"nested prefix", "b", "a/b", "s3://b/a/b/"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := ducklakeDataPath(tc.bucket, tc.prefix); got != tc.want {
-				t.Errorf("ducklakeDataPath = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-// The object-store half of a catalog comes from the Duckling CR status, not
-// from the ManagedWarehouse row. Nothing populates the row's s3.* or
-// worker_identity.* columns for a DuckLake warehouse in production — the
-// bucket lands on data_store.bucket_name and the IAM role is a Crossplane
-// output on the CR status — so reading them from the row yielded an empty
-// bucket and an empty role for every org, and the catalog step waited
-// forever. Fixtures that filled those columns hid it.
-func TestCatalogPropertiesComeFromTheDucklingStatus(t *testing.T) {
-	w := readyWarehouse("42")
-	if w.S3.Bucket != "" || w.S3.Region != "" || w.WorkerIdentity.IAMRoleARN != "" {
-		t.Fatal("fixture regression: the warehouse row must leave the object-store columns empty, as production does")
-	}
+// Every catalog input now comes from the live composition status, none from
+// the config store's warehouse row. That row's metadata_store and s3 columns
+// are empty for orgs whose warehouse predates them being populated, and
+// reading them left those tenants unprovisionable while the Duckling CR held
+// every value.
+func TestCatalogInputsIgnoreAnEmptyWarehouseRow(t *testing.T) {
+	// A warehouse row exactly as an older org carries it: Ready, but with no
+	// metadata-store or object-store columns at all.
+	w := &configstore.ManagedWarehouse{OrgID: "42", State: configstore.ManagedWarehouseStateReady}
 
 	d := readyDuckling("42")
-	d.DataStore.BucketName = "bucket-from-duckling"
-	d.DataStore.S3Region = "eu-west-2"
-	d.IAMRoleARN = "arn:aws:iam::123456789012:role/duckling-from-status"
+	d.MetadataStore.Type = string(configstore.MetadataStoreKindExternal)
+	d.MetadataStore.Endpoint = "tenant.rds.amazonaws.com"
+	d.MetadataStore.Database = "mdstore_42"
+	d.MetadataStore.User = "mdstore_42"
+
+	if missing := missingCatalogInputs(w, d, ""); len(missing) != 0 {
+		t.Fatalf("an empty warehouse row must not block a fully-composed duckling, got %v", missing)
+	}
 
 	p := &TrinoProvisioner{tenantSecretMountPath: "/etc/trino/tenant-secrets", s3MaxConnections: 50}
 	props := p.buildCatalogProperties("42", w, d)
-
-	for prop, want := range map[string]string{
-		"ducklake.data-path": "s3://bucket-from-duckling/",
-		"s3.region":          "eu-west-2",
-		"s3.iam-role":        "arn:aws:iam::123456789012:role/duckling-from-status",
-	} {
-		if props[prop] != want {
-			t.Errorf("%s = %q, want %q", prop, props[prop], want)
-		}
+	if got, want := props["ducklake.metadata.connection-url"], "jdbc:postgresql://tenant.rds.amazonaws.com:5432/mdstore_42?sslmode=require"; got != want {
+		t.Errorf("connection-url = %q, want %q", got, want)
+	}
+	if got := props["ducklake.metadata.connection-user"]; got != "mdstore_42" {
+		t.Errorf("connection-user = %q, want mdstore_42", got)
 	}
 }
 
@@ -666,9 +645,9 @@ func TestMissingCatalogInputs(t *testing.T) {
 		fallback string
 		want     string
 	}{
-		{"endpoint", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Endpoint = "" }, nil, "", "metadata_store_endpoint"},
-		{"database", func(w *configstore.ManagedWarehouse) { w.MetadataStore.DatabaseName = "" }, nil, "", "metadata_store_database_name"},
-		{"username", func(w *configstore.ManagedWarehouse) { w.MetadataStore.Username = "" }, nil, "", "metadata_store_username"},
+		{"endpoint", nil, func(d *DucklingStatus) { d.MetadataStore.Endpoint = "" }, "", "metadata_store_endpoint"},
+		{"database", nil, func(d *DucklingStatus) { d.MetadataStore.Database = "" }, "", "metadata_store_database"},
+		{"user", nil, func(d *DucklingStatus) { d.MetadataStore.User = "" }, "", "metadata_store_user"},
 		{"bucket", nil, func(d *DucklingStatus) { d.DataStore.BucketName = "" }, "", "data_store_bucket_name"},
 		{"region", nil, func(d *DucklingStatus) { d.DataStore.S3Region = "" }, "", "data_store_s3_region"},
 		{"iam role", nil, func(d *DucklingStatus) { d.IAMRoleARN = "" }, "", "iam_role_arn"},
@@ -1007,7 +986,10 @@ func TestReconcile_SkipsCatalogWhenWarehouseNotReady(t *testing.T) {
 	cases := []struct {
 		name       string
 		warehouses map[string]*configstore.ManagedWarehouse
-		wantMsg    string
+		// mutateDuckling blanks part of the live composition status, which is
+		// where every catalog input now comes from.
+		mutateDuckling func(*DucklingStatus)
+		wantMsg        string
 	}{
 		{
 			name:       "no warehouse row",
@@ -1015,20 +997,25 @@ func TestReconcile_SkipsCatalogWhenWarehouseNotReady(t *testing.T) {
 			wantMsg:    "no managed warehouse row",
 		},
 		{
-			name: "incomplete connection block",
-			warehouses: func() map[string]*configstore.ManagedWarehouse {
-				w := readyWarehouse("42")
-				w.MetadataStore.Endpoint = ""
-				w.S3.Bucket = ""
-				return map[string]*configstore.ManagedWarehouse{"42": w}
-			}(),
-			wantMsg: "metadata_store_endpoint",
+			name:           "incomplete connection block",
+			warehouses:     map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")},
+			mutateDuckling: func(d *DucklingStatus) { d.MetadataStore.Endpoint = "" },
+			wantMsg:        "metadata_store_endpoint",
+		},
+		{
+			name:           "composition has not published the bucket",
+			warehouses:     map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")},
+			mutateDuckling: func(d *DucklingStatus) { d.DataStore.BucketName = "" },
+			wantMsg:        "data_store_bucket_name",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			orgs := []configstore.TrinoEnabledOrg{{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h"}}
 			h := newTestTrinoProvisioner(t, orgs, tc.warehouses)
+			if tc.mutateDuckling != nil {
+				tc.mutateDuckling(h.ducklings["42"])
+			}
 
 			if err := h.provisioner.Reconcile(context.Background()); err != nil {
 				t.Fatalf("Reconcile: %v", err)


### PR DESCRIPTION
Finishes what https://github.com/PostHog/duckgres/pull/1117 started, and unblocks a second tenant on the pilot cell.

## Problem

1117 moved the object-store inputs (bucket, region, IAM role) off the config store's warehouse row and onto the Duckling CR status, because nothing populates those columns for a DuckLake warehouse. But the **metadata** endpoint, database and user were left reading from the row.

Those columns have exactly the same problem for older orgs. One org sits `state: ready` with a fully-composed Duckling CR — `iamRoleArn`, `bucketName`, `s3Region`, `metadataStore.{endpoint,database,user}` all populated, `Ready: True` — and was still refused:

```
waiting for warehouse fields: metadata_store_endpoint,
metadata_store_database_name, metadata_store_username
```

The auth files, group file, tenant-password Secret and resource groups all projected correctly for it. Only the catalog was withheld, because it read the one source that is empty.

## Verified before moving it

The working tenant's Duckling status endpoint is **byte-identical** to the config-store value its live catalog is using (`shard-001-pooler.cnpg-shards.svc.cluster.local`). So this is not a guess that the status is equivalent — it changes nothing for orgs whose row is populated, and supplies the value for orgs whose row is not.

## Change

The address mirrors the worker activation path's `ducklingMetadataStoreAddress`: prefer the per-Duckling PgBouncer when the composition provisioned one (it carries its own `host:port`), else the direct endpoint on 5432. Trino and the DuckDB workers therefore dial the same host — the same property `ducklakeDataPath` already maintains for the bucket, and the reason the helper is duplicated rather than shared is the same (controlplane imports provisioner, not the reverse).

`sslmode` still derives from the store kind, which the status carries as `MetadataStore.Type` — so a `cnpg-shard` tenant stays plaintext in-cluster and an `external` RDS tenant keeps `require`. That path is exercised by a live external-RDS tenant, not just a fixture.

**The config store is now consulted for identity and nothing else.** No catalog input is read from the warehouse row.

## Tests

- `TestCatalogInputsIgnoreAnEmptyWarehouseRow` — a Ready warehouse row with *no* metadata-store or object-store columns produces a complete catalog from the status alone, and asserts the external-RDS URL keeps `sslmode=require`.
- `TestDuckLakeMetadataJDBCURL_SSLModeFollowsStoreKind` reworked onto the status, plus two new cases: a PgBouncer endpoint wins and carries its port, and an unparseable one falls back rather than emitting a malformed DSN.
- `TestReconcile_SkipsCatalogWhenWarehouseNotReady` now blanks the *status* rather than the row, with an added case for an unpublished bucket.
- `readyWarehouse` keeps no connection columns at all, so every reconcile test runs the shape production actually produces.