### PR TITLE
Stop the provisioner reconcile loop when the replica is draining

### DIFF
--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -12,7 +12,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -555,7 +557,25 @@ func SetupMultiTenant(
 			trinoBundleHandler = trinoWire.BundleHandler
 			slog.Info("Trino provisioner enabled.", "cell", trinoWire.Cell.ID, "coordinator", trinoWire.Cell.CoordinatorURL)
 		}
-		go provCtrl.Run(context.Background())
+		// SIGTERM stops the reconcile loop immediately, rather than letting a
+		// replaced replica ride out the drain.
+		//
+		// The control plane's terminationGracePeriodSeconds is 24h so live
+		// pgwire sessions finish, and the pod keeps running that whole time.
+		// The provisioner, though, writes CLUSTER-WIDE state — password.db,
+		// group.db, resource-groups.json, and CREATE/DROP CATALOG against the
+		// coordinator — so a draining replica is a second writer, and during
+		// a rollout it is a second writer running the OLD binary.
+		//
+		// That is not hypothetical: after a change to how catalogs are named,
+		// draining replicas repeatedly DROPped the catalog the new replicas
+		// had just created, because the old code computed a different name
+		// and treated the new one as stale. The tenant's catalog flapped
+		// every ~20s until the old pods were force-deleted.
+		//
+		// Only the reconcile loop stops here; the pgwire drain is untouched.
+		provCtx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		go provCtrl.Run(provCtx)
 	}
 
 	// Reshard operations execute in DEDICATED per-op pods, never inside a CP


### PR DESCRIPTION
Found while investigating why pods sat in `Terminating` for hours. They are not stuck — the control plane's `terminationGracePeriodSeconds` is **86400** (24h) so live pgwire sessions can finish. That part is deliberate and correct.

The problem is what else keeps running for those 24 hours.

## The bug

```go
go provCtrl.Run(context.Background())
```

A context that is never cancelled, so the reconcile loop runs until the process is killed — up to a day after Kubernetes asked the pod to terminate.

The provisioner does not write per-connection state. It writes **cluster-wide** state: `password.db`, `group.db`, `resource-groups.json`, and `CREATE`/`DROP CATALOG` against the coordinator. So a draining replica is a second writer — and during a rollout, a second writer **running the old binary**.

## It already bit us

After the change deriving a catalog's name from `database_name` instead of the org id, draining replicas repeatedly dropped the catalog the new replicas had just created: old code computed a different name, saw the new one as unmanaged-but-matching-the-pattern, and treated it as stale.

```
02:44:41  old replica   catalog dropped.  catalog=org_<tenant>
02:44:47  new replica   catalog created.  org=<id> catalog=org_<tenant>
02:45:03  old replica   catalog dropped.  catalog=org_<tenant>
02:45:09  new replica   catalog created.  org=<id> catalog=org_<tenant>
```

That flapped every ~20 seconds until the draining pods were force-deleted. A tenant querying during that window would have seen its catalog appear and vanish. **Any** future change to a derived name reproduces this.

## Fix

SIGTERM cancels the reconcile context. The loop already checks `ctx.Err()` between warehouses and before the Trino step, so it stops promptly.

Only the reconcile loop stops. The pgwire drain — the reason the long grace period exists — is untouched.

## What this does not fix

Other goroutines in `SetupMultiTenant` still take `context.Background()` (the scheduler, the snapshot store). They may well deserve the same treatment, but they are not cluster-wide writers and I would rather not change shutdown semantics I have not reasoned through. Worth a follow-up look.