### PR TITLE
Export per-tenant resource group metrics

### DIFF
--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -1663,6 +1663,10 @@ type resourceGroupSubGroup struct {
 	MaxQueued            int    `json:"maxQueued"`
 	SchedulingPolicy     string `json:"schedulingPolicy,omitempty"`
 	SchedulingWeight     int    `json:"schedulingWeight,omitempty"`
+	// JmxExport asks Trino to export this group's MBeans. It defaults to
+	// FALSE in Trino, so per-group queue depth is invisible unless a group
+	// opts in — the manager-level aggregate is all you otherwise get.
+	JmxExport bool `json:"jmxExport,omitempty"`
 	// Recursive: a tier group holds one templated ${org} child, so a tenant
 	// lands at root.tenants.<tier>.<org> without being named in this file.
 	SubGroups []resourceGroupSubGroup `json:"subGroups,omitempty"`
@@ -1804,6 +1808,15 @@ func BuildTrinoResourceGroups() ([]byte, error) {
 	leaf := func(tier string) []resourceGroupSubGroup {
 		l := tierLimits(tier)
 		l.Name = orgTemplateVariable
+		// Export the LEAF, which is the per-tenant group: Trino names the
+		// MBean after the expanded group id (root.tenants.<tier>.<org>), so
+		// this is what makes one tenant's queue depth, running count and
+		// memory usage separable from another's. Without it only
+		// InternalResourceGroupManager's cluster-wide aggregate exists, which
+		// cannot answer "which tenant is queueing" or drive per-tenant
+		// alerting. The tier groups above stay unexported — their totals are
+		// derivable by summing the leaves.
+		l.JmxExport = true
 		return []resourceGroupSubGroup{l}
 	}
 	tenantTier := func(tier string) resourceGroupSubGroup {

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -495,6 +495,20 @@ func TestBuildTrinoResourceGroups_IsStaticAndTemplated(t *testing.T) {
 		t.Errorf("tiers = %v, want %v", tierNames, want)
 	}
 
+	// Every tier's leaf must opt into JMX export. Trino defaults jmxExport to
+	// false, so without this the only resource-group metric in existence is
+	// InternalResourceGroupManager's cluster-wide aggregate — per-tenant
+	// queue depth is unobservable, which rules out per-customer dashboards
+	// and noisy-neighbour alerting.
+	for _, tier := range tenants.SubGroups {
+		if !tier.SubGroups[0].JmxExport {
+			t.Errorf("tier %q leaf must set jmxExport so per-tenant metrics exist", tier.Name)
+		}
+		if tier.JmxExport {
+			t.Errorf("tier %q itself should not be exported; its totals are the sum of its leaves", tier.Name)
+		}
+	}
+
 	// Limits still differ per tier — that is what the userGroup indirection
 	// buys over a single flat template.
 	byName := map[string]resourceGroupSubGroup{}


### PR DESCRIPTION
Per-tenant queue depth is currently unobservable. With JMX metrics now flowing, the only resource-group series Trino emits is one cluster-wide aggregate:

```
trino_execution_resourcegroups_internalresourcegroupmanager_queriesqueuedoninternal
```

That cannot answer "which tenant is queueing", so per-customer dashboards and noisy-neighbour alerting are both impossible.

## I had the cause wrong

My first read was that the templated `${org}` groups caused it — they are created at match time rather than declared ahead, so I assumed no stable MBean ever formed, and that the remedy was migrating to the DB-backed resource group manager.

That was wrong, and worth stating plainly because the wrong fix was substantially more work.

Trino exports a group's MBeans **only when the group's spec opts in**. `jmxExport` is a per-group property on `ResourceGroupSpec` and it defaults to **false** — `AbstractResourceConfigurationManager` only calls `setJmxExport` when the spec sets it. So per-tenant metrics were never exported, before or after the templating change, and the templating is irrelevant: `InternalResourceGroupManager.exportGroup` names the MBean after `group.getId()`, which for a templated leaf is the **expanded** id (`root.tenants.free.<tenant>`). A templated group exports exactly as well as a declared one.

## Change

`jmxExport: true` on each tier's leaf — the per-tenant node.

The tier groups above stay unexported. Their totals are the sum of their leaves, and exporting both would double-count in any naive aggregation across the resource-group metric family.

## What this unlocks

- per-tenant queue depth, running query count and memory usage, separable by tenant
- noisy-neighbour detection and per-customer dashboards
- a per-tenant autoscaling signal, if cell-level queue depth turns out too coarse

## Tests

`TestBuildTrinoResourceGroups_IsStaticAndTemplated` now asserts every tier leaf sets `jmxExport` **and** that the tier groups themselves do not.

## Note

Series appear per tenant as groups become active, so this grows with tenant count. That is the point, and the scale is trivial here: VictoriaMetrics currently holds ~1.4 billion series cluster-wide, against which a few per tenant is nothing.