### PR TITLE
feat(trino): allow tenant DuckLake writes

### DIFF
--- a/controlplane/provisioner/opa/builder.go
+++ b/controlplane/provisioner/opa/builder.go
@@ -20,7 +20,7 @@ var policyRego []byte
 // the revision on activation; bumping it on policy edits makes bundle
 // pushes visible in OPA logs. The build encoding (data hash) further
 // disambiguates bundles with the same revision but different data.
-const bundleRevision = "v1"
+const bundleRevision = "v2"
 
 // policyPath is the in-bundle path of policy.rego. The bundle library
 // requires .rego files to live under a path; the choice of name is

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -15,7 +15,7 @@
 #                                         or OIDC group claim (post-v1).
 #                                         Customer principals get
 #                                         `org_<org>` (org = sanitized
-#                                         Org.Name); the admin gets
+#                                         database name); the admin gets
 #                                         the admin group. Customer access
 #                                         decisions key on this, not on the
 #                                         username -- so the bundle schema
@@ -28,6 +28,8 @@
 #   input.action.resource.catalog.name -- target catalog name where applicable.
 #   input.action.resource.schema.catalogName / .schemaName
 #   input.action.resource.table.catalogName / .schemaName / .tableName
+#   input.action.targetResource.schema...  -- rename destination for schemas.
+#   input.action.targetResource.table...   -- rename destination for tables/views.
 #   input.action.resource.systemSessionProperty.name
 #   input.action.resource.user.user    -- on the query-ownership operations
 #                                         (ViewQueryOwnedBy /
@@ -168,8 +170,9 @@ managed_catalog_name(catalog) if {
 }
 
 # ---------------------------------------------------------------------------
-# Ownership / readability / listability — three predicates kept distinct
-# so admin's orphan-cleanup carve-out doesn't leak into data-plane reads.
+# Ownership / readability / writability / listability — kept distinct so
+# admin's orphan-cleanup and smoke-test carve-outs don't leak into tenant
+# data-plane writes.
 #
 # tenant_owns_catalog(c): a customer group has c in data.group_catalogs.
 #   Excludes admin_group from iteration so a bare admin-group claim grants
@@ -184,6 +187,11 @@ managed_catalog_name(catalog) if {
 #   surface (AccessCatalog, ShowSchemas, ShowTables, SelectFromColumns,
 #   FilterSchemas, FilterTables, ShowColumns, FilterColumns). Catalogs
 #   outside the bundle CANNOT be read by anyone.
+#
+# writable_catalog(c) = tenant_owns AND managed_catalog_name. Customers can
+#   mutate only the provisioner-owned catalog projected for one of their org
+#   groups. The provisioner admin deliberately has no table/schema write path:
+#   its bundle entry exists only for read smoke tests and catalog management.
 #
 # listable_catalog(c) = readable OR (is_admin AND managed_catalog_name).
 #   The orphan-cleanup carve-out: admin sees `org_*` catalogs
@@ -205,6 +213,12 @@ admin_bundle_catalog(catalog) if {
 
 readable_catalog(catalog) if tenant_owns_catalog(catalog)
 readable_catalog(catalog) if admin_bundle_catalog(catalog)
+
+writable_catalog(catalog) if {
+	not is_admin
+	tenant_owns_catalog(catalog)
+	managed_catalog_name(catalog)
+}
 
 listable_catalog(catalog) if readable_catalog(catalog)
 
@@ -261,6 +275,22 @@ allow if {
 	readable_catalog(input.action.resource.schema.catalogName)
 }
 
+# DuckLake schema DDL. Rename checks BOTH resource and targetResource even
+# though Trino currently keeps schema renames inside one catalog. The explicit
+# target check makes a future cross-catalog shape fail closed.
+schema_write_ops := {"CreateSchema", "DropSchema"}
+
+allow if {
+	input.action.operation in schema_write_ops
+	writable_catalog(input.action.resource.schema.catalogName)
+}
+
+allow if {
+	input.action.operation == "RenameSchema"
+	writable_catalog(input.action.resource.schema.catalogName)
+	writable_catalog(input.action.targetResource.schema.catalogName)
+}
+
 # ---------------------------------------------------------------------------
 # Table-scope decisions. Resource is TrinoTable
 # {catalogName, schemaName, tableName, columns?}.
@@ -284,6 +314,44 @@ allow if {
 allow if {
 	input.action.operation == "FilterColumns"
 	readable_catalog(input.action.resource.table.catalogName)
+}
+
+# DuckLake table and view DDL/DML. MERGE and CTAS are composed by Trino from
+# these checks (create/insert/update/delete), so no separate operation string
+# exists for them in OpaAccessControl. Authorization changes, grants, catalog
+# session properties, functions and materialized views intentionally remain
+# default-denied below.
+table_write_ops := {
+	"CreateTable",
+	"DropTable",
+	"SetTableProperties",
+	"SetTableComment",
+	"SetColumnComment",
+	"AddColumn",
+	"AlterColumn",
+	"DropColumn",
+	"RenameColumn",
+	"InsertIntoTable",
+	"DeleteFromTable",
+	"TruncateTable",
+	"UpdateTableColumns",
+	"CreateView",
+	"SetViewComment",
+	"DropView",
+	"CreateViewWithSelectFromColumns",
+}
+
+allow if {
+	input.action.operation in table_write_ops
+	writable_catalog(input.action.resource.table.catalogName)
+}
+
+table_rename_ops := {"RenameTable", "RenameView"}
+
+allow if {
+	input.action.operation in table_rename_ops
+	writable_catalog(input.action.resource.table.catalogName)
+	writable_catalog(input.action.targetResource.table.catalogName)
 }
 
 # ---------------------------------------------------------------------------
@@ -493,8 +561,8 @@ allow if {
 #   for a same-org query owner and denied for everyone else, including
 #   the admin principal. An input that omits resource.user, or its
 #   `user` / `groups` fields, still falls through to default-deny.
-# - GRANT-related ops, view/function creation, table mutation: not part of
-#   v1's per-org Iceberg-catalog model.
+# - GRANT/authorization operations, catalog session properties, functions and
+#   materialized views: not part of the tenant-owned DuckLake write surface.
 #
 # All of the above fall through to default-deny; no explicit rule needed.
 # ---------------------------------------------------------------------------

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -110,6 +110,15 @@ func buildInputWithGroups(user string, groups []string, operation string, resour
 	return in
 }
 
+// buildInputWithTarget adds the targetResource shape used by Trino's rename
+// checks. A rename is safe only when both the source and destination remain
+// inside a catalog owned by the requesting tenant.
+func buildInputWithTarget(user, operation string, resource, targetResource map[string]interface{}) map[string]interface{} {
+	in := buildInput(user, operation, resource)
+	in["action"].(map[string]interface{})["targetResource"] = targetResource
+	return in
+}
+
 func catalogResource(name string) map[string]interface{} {
 	return map[string]interface{}{
 		"catalog": map[string]interface{}{"name": name},
@@ -287,6 +296,160 @@ func TestTableScopeOps(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// Tenant writes: a customer has full DuckLake DDL/DML authority inside the
+// catalog projected for its org, and no write authority anywhere else.
+// Catalog management, permission management and materialized views remain
+// separate, denied surfaces.
+// --------------------------------------------------------------------------
+
+func TestTenantSchemaWritesOwnCatalogOnly(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	for _, op := range []string{"CreateSchema", "DropSchema"} {
+		t.Run(op+"/own", func(t *testing.T) {
+			if !evalAllow(t, q, buildInput("42", op, schemaResource("org_42", "analytics"))) {
+				t.Errorf("%s in the tenant's catalog must allow", op)
+			}
+		})
+		t.Run(op+"/other", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("42", op, schemaResource("org_43", "analytics"))) {
+				t.Errorf("%s in another tenant's catalog must deny", op)
+			}
+		})
+		t.Run(op+"/unmanaged", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("42", op, schemaResource("system", "runtime"))) {
+				t.Errorf("%s in an unmanaged catalog must deny", op)
+			}
+		})
+		t.Run(op+"/unknown-user", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("99", op, schemaResource("org_42", "analytics"))) {
+				t.Errorf("%s by an unknown tenant must deny", op)
+			}
+		})
+		t.Run(op+"/admin", func(t *testing.T) {
+			if evalAllow(t, q, buildInput(AdminPrincipal, op, schemaResource("org_42", "analytics"))) {
+				t.Errorf("%s by the catalog-management admin must deny", op)
+			}
+		})
+		t.Run(op+"/admin-with-tenant-group", func(t *testing.T) {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup, "org_42"}, op, schemaResource("org_42", "analytics"))
+			if evalAllow(t, q, in) {
+				t.Errorf("%s by the admin must deny even with an accidental tenant-group claim", op)
+			}
+		})
+	}
+}
+
+func TestTenantTableAndViewWritesOwnCatalogOnly(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	writeOps := []string{
+		"CreateTable",
+		"DropTable",
+		"SetTableProperties",
+		"SetTableComment",
+		"SetColumnComment",
+		"AddColumn",
+		"AlterColumn",
+		"DropColumn",
+		"RenameColumn",
+		"InsertIntoTable",
+		"DeleteFromTable",
+		"TruncateTable",
+		"UpdateTableColumns",
+		"CreateView",
+		"SetViewComment",
+		"DropView",
+		"CreateViewWithSelectFromColumns",
+	}
+
+	for _, op := range writeOps {
+		t.Run(op+"/own", func(t *testing.T) {
+			if !evalAllow(t, q, buildInput("42", op, tableResource("org_42", "posthog", "events"))) {
+				t.Errorf("%s in the tenant's catalog must allow", op)
+			}
+		})
+		t.Run(op+"/other", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("42", op, tableResource("org_43", "posthog", "events"))) {
+				t.Errorf("%s in another tenant's catalog must deny", op)
+			}
+		})
+		t.Run(op+"/unmanaged", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("42", op, tableResource("system", "runtime", "queries"))) {
+				t.Errorf("%s in an unmanaged catalog must deny", op)
+			}
+		})
+		t.Run(op+"/unknown-user", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("99", op, tableResource("org_42", "posthog", "events"))) {
+				t.Errorf("%s by an unknown tenant must deny", op)
+			}
+		})
+		t.Run(op+"/admin", func(t *testing.T) {
+			if evalAllow(t, q, buildInput(AdminPrincipal, op, tableResource("org_42", "posthog", "events"))) {
+				t.Errorf("%s by the catalog-management admin must deny", op)
+			}
+		})
+		t.Run(op+"/admin-with-tenant-group", func(t *testing.T) {
+			in := buildInputWithGroups(AdminPrincipal, []string{AdminGroup, "org_42"}, op, tableResource("org_42", "posthog", "events"))
+			if evalAllow(t, q, in) {
+				t.Errorf("%s by the admin must deny even with an accidental tenant-group claim", op)
+			}
+		})
+	}
+}
+
+func TestTenantRenamesRequireOwnedSourceAndTarget(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	tests := []struct {
+		operation string
+		resource  func(catalog, name string) map[string]interface{}
+	}{
+		{"RenameSchema", func(catalog, name string) map[string]interface{} {
+			return schemaResource(catalog, name)
+		}},
+		{"RenameTable", func(catalog, name string) map[string]interface{} {
+			return tableResource(catalog, "posthog", name)
+		}},
+		{"RenameView", func(catalog, name string) map[string]interface{} {
+			return tableResource(catalog, "posthog", name)
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.operation+"/inside-own-catalog", func(t *testing.T) {
+			in := buildInputWithTarget("42", tc.operation, tc.resource("org_42", "old"), tc.resource("org_42", "new"))
+			if !evalAllow(t, q, in) {
+				t.Errorf("%s inside the tenant's catalog must allow", tc.operation)
+			}
+		})
+		t.Run(tc.operation+"/target-other-catalog", func(t *testing.T) {
+			in := buildInputWithTarget("42", tc.operation, tc.resource("org_42", "old"), tc.resource("org_43", "new"))
+			if evalAllow(t, q, in) {
+				t.Errorf("%s into another tenant's catalog must deny", tc.operation)
+			}
+		})
+		t.Run(tc.operation+"/source-other-catalog", func(t *testing.T) {
+			in := buildInputWithTarget("42", tc.operation, tc.resource("org_43", "old"), tc.resource("org_42", "new"))
+			if evalAllow(t, q, in) {
+				t.Errorf("%s out of another tenant's catalog must deny", tc.operation)
+			}
+		})
+		t.Run(tc.operation+"/missing-target", func(t *testing.T) {
+			if evalAllow(t, q, buildInput("42", tc.operation, tc.resource("org_42", "old"))) {
+				t.Errorf("%s without targetResource must deny", tc.operation)
+			}
+		})
+		t.Run(tc.operation+"/admin", func(t *testing.T) {
+			in := buildInputWithTarget(AdminPrincipal, tc.operation, tc.resource("org_42", "old"), tc.resource("org_42", "new"))
+			if evalAllow(t, q, in) {
+				t.Errorf("%s by the catalog-management admin must deny", tc.operation)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
 // Session-property allowlist.
 // --------------------------------------------------------------------------
 
@@ -425,17 +588,14 @@ func TestDefaultDeny(t *testing.T) {
 		"ReadSystemInformation",
 		"KillQueryOwnedBy",
 		"ViewQueryOwnedBy",
-		"InsertIntoTable",
-		"DeleteFromTable",
-		"UpdateTableColumns",
-		"TruncateTable",
-		"CreateTable",
-		"DropTable",
-		"RenameTable",
-		"CreateSchema",
-		"DropSchema",
-		"CreateView",
-		"DropView",
+		"SetSchemaAuthorization",
+		"SetTableAuthorization",
+		"SetViewAuthorization",
+		"CreateMaterializedView",
+		"RefreshMaterializedView",
+		"SetMaterializedViewProperties",
+		"DropMaterializedView",
+		"RenameMaterializedView",
 		"SetCatalogSessionProperty",
 		"GrantSchemaPrivilege",
 		"DenySchemaPrivilege",


### PR DESCRIPTION
## Summary

- allow DuckLake schema, table, view, and DML operations only in catalogs owned by the requesting tenant
- require both rename source and destination catalogs to be tenant-owned
- keep the provisioner admin, unmanaged catalogs, cross-tenant targets, permission management, materialized views, functions, and catalog session properties denied
- bump the embedded OPA bundle revision so policy activation is visible during rollout

This unlocks the write path delivered by PostHog/trino#2 without widening the shared-cell tenant-isolation boundary.

## Security model

A new writable_catalog predicate requires all three conditions:

1. the requester is not the provisioner admin
2. a non-admin identity group owns the catalog in the provisioned bundle
3. the catalog matches the managed org_* naming convention

Adversarial tests cover other tenants, unmanaged catalogs, unknown identities, the admin identity, an admin carrying an accidental tenant-group claim, missing rename targets, and cross-catalog rename attempts.

## Validation

- go test ./controlplane/provisioner/opa -count=1
- go test ./controlplane/provisioner/... -count=1
- git diff --check
- just lint was attempted but could not complete locally because unrelated untracked integration tests outside this diff do not type-check on current main; the affected packages compile and pass above