### PR TITLE
Add per-org query log hot bytes metric

### DIFF
--- a/controlplane/storage_meter.go
+++ b/controlplane/storage_meter.go
@@ -39,6 +39,30 @@ SELECT COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_data_file), 0)
      + COALESCE((SELECT SUM(file_size_bytes) FROM ducklake_delete_file), 0),
        (SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion)`
 
+// queryLogHotBytesQuery measures the native metadata-Postgres footprint of
+// the partitioned query log. pg_total_relation_size includes heap, indexes,
+// and TOAST; summing leaves includes both monthly and default partitions. The
+// recursive catalog walk deliberately starts with nullable to_regclass so an
+// uninitialized query log reports zero without calling a partition helper on
+// an invalid relation.
+const queryLogHotBytesQuery = `
+WITH RECURSIVE parts(relid) AS (
+    SELECT to_regclass('querylog.query_log_entries')
+    UNION ALL
+    SELECT i.inhrelid
+    FROM pg_inherits i
+    JOIN parts p ON i.inhparent = p.relid
+), leaves AS (
+    SELECT p.relid
+    FROM parts p
+    WHERE p.relid IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_inherits child WHERE child.inhparent = p.relid
+      )
+)
+SELECT COALESCE(SUM(pg_total_relation_size(relid)), 0)::BIGINT
+FROM leaves`
+
 var storageTrackedBytesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "duckgres_org_storage_tracked_bytes",
 	Help: "Tracked DuckLake S3 footprint per org (bytes), from the last storage-billing sample.",
@@ -47,6 +71,11 @@ var storageTrackedBytesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 var storagePendingDeleteFilesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "duckgres_org_storage_pending_delete_files",
 	Help: "Files scheduled for deletion but not yet cleaned per org — bytes on S3 invisible to the storage meter. Sustained nonzero = cleanup lagging (drift).",
+}, []string{"org"})
+
+var queryLogHotBytesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "duckgres_org_query_log_hot_bytes",
+	Help: "Physical metadata-Postgres footprint of the query log per org (bytes), including indexes and TOAST, from the last successful sample.",
 }, []string{"org"})
 
 var storageSampleErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -84,7 +113,10 @@ type storageSampler struct {
 	resolveDSN func(ctx context.Context, orgID string) (string, error)
 	// queryFootprint visits one org's metadata Postgres; swappable in tests.
 	queryFootprint func(ctx context.Context, dsn string) (trackedBytes, pendingDeleteFiles int64, err error)
-	now            func() time.Time
+	// queryHotBytes independently measures the native query-log footprint. Its
+	// failure is warning-only and never changes storage billing.
+	queryHotBytes func(ctx context.Context, dsn string) (int64, error)
+	now           func() time.Time
 }
 
 func newStorageSampler(store storageUsageStore, interval time.Duration, listOrgs func() []storageOrg, resolveDSN func(ctx context.Context, orgID string) (string, error)) *storageSampler {
@@ -97,6 +129,7 @@ func newStorageSampler(store storageUsageStore, interval time.Duration, listOrgs
 		listOrgs:       listOrgs,
 		resolveDSN:     resolveDSN,
 		queryFootprint: queryStorageFootprint,
+		queryHotBytes:  queryQueryLogHotBytes,
 		now:            time.Now,
 	}
 }
@@ -119,6 +152,7 @@ func (s *storageSampler) Run(ctx context.Context) {
 	}
 	defer storageTrackedBytesGauge.Reset()
 	defer storagePendingDeleteFilesGauge.Reset()
+	defer queryLogHotBytesGauge.Reset()
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {
@@ -152,14 +186,14 @@ func (s *storageSampler) sampleAll(ctx context.Context) {
 }
 
 func (s *storageSampler) sampleOrg(ctx context.Context, org storageOrg) error {
-	orgCtx, cancel := context.WithTimeout(ctx, storageSampleQueryTimeout)
-	defer cancel()
+	storageCtx, cancelStorage := context.WithTimeout(ctx, storageSampleQueryTimeout)
+	defer cancelStorage()
 
-	dsn, err := s.resolveDSN(orgCtx, org.OrgID)
+	dsn, err := s.resolveDSN(storageCtx, org.OrgID)
 	if err != nil {
 		return err
 	}
-	trackedBytes, pendingDelete, err := s.queryFootprint(orgCtx, dsn)
+	trackedBytes, pendingDelete, err := s.queryFootprint(storageCtx, dsn)
 	if err != nil {
 		return err
 	}
@@ -171,7 +205,21 @@ func (s *storageSampler) sampleOrg(ctx context.Context, org storageOrg) error {
 	// the shared closed-bucket/watermark rules apply unchanged).
 	byteSeconds := trackedBytes * int64(s.interval/time.Second)
 	bucket := s.now().UTC().Truncate(computeBucketWidth)
-	return s.store.UpsertStorageSample(org.OrgID, org.TeamID, bucket, byteSeconds)
+	billingErr := s.store.UpsertStorageSample(org.OrgID, org.TeamID, bucket, byteSeconds)
+
+	// Query-log hot bytes are observability only. Sample them after the billing
+	// write so a slow or failed inspection cannot suppress a valid S3 sample.
+	// Give it an independent timeout so time spent resolving and sampling S3
+	// storage cannot consume its budget. Preserve the last good value on error.
+	hotCtx, cancelHot := context.WithTimeout(ctx, storageSampleQueryTimeout)
+	defer cancelHot()
+	if hotBytes, err := s.queryHotBytes(hotCtx, dsn); err != nil {
+		slog.Warn("Query-log hot-bytes sample failed; retaining last good value.", "org", org.OrgID, "error", err)
+	} else {
+		queryLogHotBytesGauge.WithLabelValues(org.OrgID).Set(float64(hotBytes))
+	}
+
+	return billingErr
 }
 
 // queryStorageFootprint opens the org's metadata Postgres and runs the
@@ -189,6 +237,21 @@ func queryStorageFootprint(ctx context.Context, dsn string) (trackedBytes, pendi
 		return 0, 0, err
 	}
 	return trackedBytes, pendingDeleteFiles, nil
+}
+
+func queryQueryLogHotBytes(ctx context.Context, dsn string) (int64, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	var hotBytes int64
+	if err := db.QueryRowContext(ctx, queryLogHotBytesQuery).Scan(&hotBytes); err != nil {
+		return 0, err
+	}
+	return hotBytes, nil
 }
 
 // storageSampleIntervalFromEnv reads the env-only sampling-interval override

--- a/controlplane/storage_meter_test.go
+++ b/controlplane/storage_meter_test.go
@@ -39,6 +39,7 @@ func newTestStorageSampler(store storageUsageStore, orgs []storageOrg, footprint
 		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
 	)
 	s.queryFootprint = footprint
+	s.queryHotBytes = func(_ context.Context, _ string) (int64, error) { return 0, nil }
 	s.now = func() time.Time { return time.Date(2026, 7, 8, 12, 0, 47, 0, time.UTC) }
 	return s
 }
@@ -70,6 +71,72 @@ func TestStorageSamplerCreditsOneIntervalPerOrg(t *testing.T) {
 	}
 	if b := store.samples[1]; b.orgID != "orgB" || b.teamID != 0 || b.byteSeconds != 512*1800 {
 		t.Fatalf("orgB sample = %+v", b)
+	}
+}
+
+func TestStorageSamplerReportsQueryLogHotBytesWithoutChangingStorageCredit(t *testing.T) {
+	queryLogHotBytesGauge.Reset()
+	t.Cleanup(queryLogHotBytesGauge.Reset)
+
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: "hot-bytes-org", TeamID: 42}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 512, 0, nil })
+	s.queryHotBytes = func(_ context.Context, dsn string) (int64, error) {
+		if dsn != "postgres://meta/hot-bytes-org" {
+			t.Fatalf("hot-bytes DSN = %q", dsn)
+		}
+		return 9 * 1024 * 1024, nil
+	}
+
+	s.sampleAll(context.Background())
+
+	if len(store.samples) != 1 {
+		t.Fatalf("storage samples = %d, want 1", len(store.samples))
+	}
+	if got, want := store.samples[0].byteSeconds, int64(512*1800); got != want {
+		t.Fatalf("storage byteSeconds = %d, want %d", got, want)
+	}
+	if got, want := testutil.ToFloat64(queryLogHotBytesGauge.WithLabelValues("hot-bytes-org")), float64(9*1024*1024); got != want {
+		t.Fatalf("query-log hot bytes = %v, want %v", got, want)
+	}
+}
+
+func TestStorageSamplerHotBytesFailurePreservesLastValueAndBilling(t *testing.T) {
+	queryLogHotBytesGauge.Reset()
+	t.Cleanup(queryLogHotBytesGauge.Reset)
+
+	const orgID = "hot-bytes-failure-org"
+	store := &fakeStorageStore{}
+	s := newTestStorageSampler(store,
+		[]storageOrg{{OrgID: orgID, TeamID: 42}},
+		func(_ context.Context, _ string) (int64, int64, error) { return 1024, 0, nil })
+	var calls int
+	s.queryHotBytes = func(_ context.Context, _ string) (int64, error) {
+		calls++
+		if calls == 1 {
+			return 900, nil
+		}
+		return 0, errors.New("hot-size query failed")
+	}
+	storageErrorsBefore := testutil.ToFloat64(storageSampleErrorsCounter.WithLabelValues(orgID))
+
+	s.sampleAll(context.Background())
+	s.sampleAll(context.Background())
+
+	if len(store.samples) != 2 {
+		t.Fatalf("storage samples = %d, want 2 despite hot-size failure", len(store.samples))
+	}
+	for i, sample := range store.samples {
+		if got, want := sample.byteSeconds, int64(1024*1800); got != want {
+			t.Fatalf("storage sample %d byteSeconds = %d, want %d", i, got, want)
+		}
+	}
+	if got := testutil.ToFloat64(storageSampleErrorsCounter.WithLabelValues(orgID)); got != storageErrorsBefore {
+		t.Fatalf("storage sample errors = %v, want unchanged %v", got, storageErrorsBefore)
+	}
+	if got := testutil.ToFloat64(queryLogHotBytesGauge.WithLabelValues(orgID)); got != 900 {
+		t.Fatalf("query-log hot bytes after failed refresh = %v, want last good value 900", got)
 	}
 }
 
@@ -110,6 +177,7 @@ func TestStorageSamplerRunStopsOnCancel(t *testing.T) {
 		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
 	)
 	s.queryFootprint = func(_ context.Context, _ string) (int64, int64, error) { return 2048, 0, nil }
+	s.queryHotBytes = func(_ context.Context, _ string) (int64, error) { return 0, nil }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -128,9 +196,11 @@ func TestStorageSamplerRunStopsOnCancel(t *testing.T) {
 func TestStorageSamplerClearsLeaderOwnedGaugesOnCancel(t *testing.T) {
 	storageTrackedBytesGauge.Reset()
 	storagePendingDeleteFilesGauge.Reset()
+	queryLogHotBytesGauge.Reset()
 	t.Cleanup(func() {
 		storageTrackedBytesGauge.Reset()
 		storagePendingDeleteFilesGauge.Reset()
+		queryLogHotBytesGauge.Reset()
 	})
 
 	store := &fakeStorageStore{}
@@ -139,6 +209,7 @@ func TestStorageSamplerClearsLeaderOwnedGaugesOnCancel(t *testing.T) {
 		func(_ context.Context, orgID string) (string, error) { return "postgres://meta/" + orgID, nil },
 	)
 	s.queryFootprint = func(_ context.Context, _ string) (int64, int64, error) { return 2048, 3, nil }
+	s.queryHotBytes = func(_ context.Context, _ string) (int64, error) { return 512, nil }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -155,6 +226,10 @@ func TestStorageSamplerClearsLeaderOwnedGaugesOnCancel(t *testing.T) {
 		cancel()
 		t.Fatalf("pending-delete gauge series while leading = %d, want 1", got)
 	}
+	if got := testutil.CollectAndCount(queryLogHotBytesGauge); got != 1 {
+		cancel()
+		t.Fatalf("query-log hot-bytes gauge series while leading = %d, want 1", got)
+	}
 
 	cancel()
 	select {
@@ -167,6 +242,9 @@ func TestStorageSamplerClearsLeaderOwnedGaugesOnCancel(t *testing.T) {
 	}
 	if got := testutil.CollectAndCount(storagePendingDeleteFilesGauge); got != 0 {
 		t.Fatalf("pending-delete gauge series after leadership loss = %d, want 0", got)
+	}
+	if got := testutil.CollectAndCount(queryLogHotBytesGauge); got != 0 {
+		t.Fatalf("query-log hot-bytes gauge series after leadership loss = %d, want 0", got)
 	}
 }
 

--- a/docs/design/query-log-metadata.md
+++ b/docs/design/query-log-metadata.md
@@ -581,6 +581,11 @@ attacker-controlled strings that land in a log table and an admin UI.
 - **Retention**: monthly `DROP TABLE querylog.query_log_entries_YYYYMM` beyond
   `query_log.retention` (default ~90d) under the advisory-lock pattern the
   partition-create path already uses. **Required before the fat columns ship.**
+- **Hot-footprint visibility**: the leader-owned storage sampler exports
+  `duckgres_org_query_log_hot_bytes{org}` every 30 minutes from the native
+  metadata-Postgres relation size (heap + indexes + TOAST across all leaf
+  partitions). It is observability-only and is never included in S3 storage
+  billing; a failed refresh retains the last successful gauge value.
 - **Admin console**: surface the new dimensions and the start/terminal pairing
   on the Queries/Errors pages.
 - **Shadow-mode RBAC report**: evaluate a candidate grant set against logged


### PR DESCRIPTION
## Summary

- export `duckgres_org_query_log_hot_bytes{org}` from the leader-owned storage sampler
- measure heap, indexes, and TOAST across query-log leaf partitions; report zero before the table is initialized
- keep hot-byte observation separate from S3 billing, retain the last good value on refresh failure, and clear the gauge on leadership loss

## Testing

- `GOFLAGS=-run=TestStorageSampler just test-controlplane`
- `just test-controlplane`
- `just lint`
- PostgreSQL 16 smoke validation for absent and partitioned query-log tables