### PR TITLE
perf: pair PostHog raw and DuckLake queries

### DIFF
--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -44,6 +44,16 @@ remain unpaired. The v1 artifact and publisher schemas remain unchanged, so
 artifact rows distinguish paired targets only by these generated query IDs;
 they do not include a storage-target column.
 
+During measured execution, the runner alternates every generated pair by
+iteration: odd iterations run `raw_view` then `ducklake_table`, and even
+iterations run `ducklake_table` then `raw_view`. Paired benchmark catalogs
+should therefore use an even `measure_iterations` value so each target runs
+first the same number of times. The catalog loader rejects odd measurement
+counts for paired catalogs. Warmup work and legacy queries retain catalog
+order. Query and intent IDs must be versioned when their measurement
+methodology changes so historical latency series do not mix different cache
+contexts, including dashboards that aggregate by intent.
+
 Templating is intentionally limited to `{{ relation "<role>" }}`. Each role
 must have a binding in both variants, and multiple roles may be used in one
 template. Bindings are unquoted, dot-separated identifiers such as
@@ -56,9 +66,8 @@ rejected so a target cannot be mislabeled without changing the executed
 relation. The rendered SQL must be a single read-only `SELECT` statement and is
 stored in the PGWire SQL field.
 
-This is catalog abstraction only. Fair scheduling, migration of the real
-frozen PostHog query catalog, paired artifacts, dashboards, and Grafana work
-are deliberately deferred to later PRs.
+This abstraction preserves the artifact contract while allowing downstream
+dashboards to compare paired targets by their generated query-ID suffixes.
 
 ## Local Smoke Run
 

--- a/tests/perf/core/catalog.go
+++ b/tests/perf/core/catalog.go
@@ -377,6 +377,7 @@ func validateCatalog(c Catalog) error {
 		return fmt.Errorf("queries must include at least one entry")
 	}
 	seenQueryIDs := map[string]struct{}{}
+	hasPairedQueries := false
 	for _, q := range c.Queries {
 		if q.QueryID == "" {
 			return fmt.Errorf("query_id is required")
@@ -391,6 +392,12 @@ func validateCatalog(c Catalog) error {
 		if q.PGWireSQL == "" {
 			return fmt.Errorf("query %s missing pgwire_sql", q.QueryID)
 		}
+		if q.StorageTarget != "" {
+			hasPairedQueries = true
+		}
+	}
+	if hasPairedQueries && c.MeasureIterations%2 != 0 {
+		return fmt.Errorf("paired catalogs require an even measure_iterations value to balance storage-target execution order")
 	}
 	return nil
 }

--- a/tests/perf/core/catalog_test.go
+++ b/tests/perf/core/catalog_test.go
@@ -45,23 +45,31 @@ func TestCheckedInPostHogCatalogPublishesCompleteStablePairs(t *testing.T) {
 		t.Fatalf("LoadCatalog: %v", err)
 	}
 	want := []string{
-		"q_events_total__raw_view",
-		"q_events_total__ducklake_table",
-		"q_events_count_one_day__raw_view",
-		"q_events_count_one_day__ducklake_table",
-		"q_events_by_name_march_2026__raw_view",
-		"q_events_by_name_march_2026__ducklake_table",
-		"q_events_distinct_persons__raw_view",
-		"q_events_distinct_persons__ducklake_table",
-		"q_persons_total__raw_view",
-		"q_persons_total__ducklake_table",
-		"q_persons_daily_april_2026__raw_view",
-		"q_persons_daily_april_2026__ducklake_table",
-		"q_events_daily_march_2026__raw_view",
-		"q_events_daily_march_2026__ducklake_table",
+		"q_events_total_balanced_v2__raw_view",
+		"q_events_total_balanced_v2__ducklake_table",
+		"q_events_count_one_day_balanced_v2__raw_view",
+		"q_events_count_one_day_balanced_v2__ducklake_table",
+		"q_events_by_name_march_2026_balanced_v2__raw_view",
+		"q_events_by_name_march_2026_balanced_v2__ducklake_table",
+		"q_events_distinct_persons_balanced_v2__raw_view",
+		"q_events_distinct_persons_balanced_v2__ducklake_table",
+		"q_persons_total_balanced_v2__raw_view",
+		"q_persons_total_balanced_v2__ducklake_table",
+		"q_persons_daily_april_2026_balanced_v2__raw_view",
+		"q_persons_daily_april_2026_balanced_v2__ducklake_table",
+		"q_events_daily_march_2026_balanced_v2__raw_view",
+		"q_events_daily_march_2026_balanced_v2__ducklake_table",
 	}
 	if got := queryIDs(catalog); !reflect.DeepEqual(got, want) {
 		t.Fatalf("checked-in PostHog query IDs changed: got %v want %v", got, want)
+	}
+	if catalog.MeasureIterations != 4 {
+		t.Fatalf("checked-in PostHog measure iterations = %d, want 4 for balanced target order", catalog.MeasureIterations)
+	}
+	for _, query := range catalog.Queries {
+		if !strings.HasSuffix(query.IntentID, "_balanced_v2") {
+			t.Fatalf("checked-in PostHog query %s has unversioned methodology intent %q", query.QueryID, query.IntentID)
+		}
 	}
 	for index, query := range catalog.Queries {
 		wantTarget := StorageTargetRawView
@@ -129,6 +137,19 @@ queries:
 	}
 	if catalog.Queries[0].StorageTarget != "" {
 		t.Fatalf("legacy query unexpectedly has storage target %q", catalog.Queries[0].StorageTarget)
+	}
+}
+
+func TestParseCatalogRejectsOddMeasureIterationsForPairedQueries(t *testing.T) {
+	raw := strings.Replace(pairedCatalogYAML(`
+paired_queries:
+  - query_id_base: q_events
+    intent_id: ph.events.v1
+    sql_template: SELECT COUNT(*) FROM {{ relation "events" }}
+`), "measure_iterations: 2", "measure_iterations: 3", 1)
+	_, err := ParseCatalog([]byte(raw))
+	if err == nil || !strings.Contains(err.Error(), "even") {
+		t.Fatalf("ParseCatalog error = %v, want even measure_iterations requirement", err)
 	}
 }
 
@@ -405,7 +426,7 @@ seed: 1
 dataset_scale: 1
 targets: [pgwire]
 warmup_iterations: 0
-measure_iterations: 1
+measure_iterations: 2
 ` + body
 }
 

--- a/tests/perf/core/catalog_test.go
+++ b/tests/perf/core/catalog_test.go
@@ -39,7 +39,7 @@ func TestCheckedInCatalogsLoad(t *testing.T) {
 	}
 }
 
-func TestCheckedInPostHogCatalogPublishedIDsRemainStable(t *testing.T) {
+func TestCheckedInPostHogCatalogPublishesCompleteStablePairs(t *testing.T) {
 	catalog, err := LoadCatalog(filepath.Join("..", "queries", "ducklake_posthog_tables.yaml"))
 	if err != nil {
 		t.Fatalf("LoadCatalog: %v", err)
@@ -53,16 +53,46 @@ func TestCheckedInPostHogCatalogPublishedIDsRemainStable(t *testing.T) {
 		"q_events_by_name_march_2026__ducklake_table",
 		"q_events_distinct_persons__raw_view",
 		"q_events_distinct_persons__ducklake_table",
+		"q_persons_total__raw_view",
 		"q_persons_total__ducklake_table",
+		"q_persons_daily_april_2026__raw_view",
 		"q_persons_daily_april_2026__ducklake_table",
+		"q_events_daily_march_2026__raw_view",
 		"q_events_daily_march_2026__ducklake_table",
 	}
 	if got := queryIDs(catalog); !reflect.DeepEqual(got, want) {
 		t.Fatalf("checked-in PostHog query IDs changed: got %v want %v", got, want)
 	}
-	for _, query := range catalog.Queries {
-		if query.StorageTarget != "" {
-			t.Fatalf("legacy query %s unexpectedly inferred storage target %q", query.QueryID, query.StorageTarget)
+	for index, query := range catalog.Queries {
+		wantTarget := StorageTargetRawView
+		if index%2 == 1 {
+			wantTarget = StorageTargetDuckLakeTable
+		}
+		if query.StorageTarget != wantTarget {
+			t.Fatalf("query %s storage target = %q, want %q", query.QueryID, query.StorageTarget, wantTarget)
+		}
+		if index%2 != 1 {
+			continue
+		}
+
+		rawQuery := catalog.Queries[index-1]
+		if query.IntentID != rawQuery.IntentID {
+			t.Fatalf("query pair %s/%s has mismatched intents %q/%q", rawQuery.QueryID, query.QueryID, rawQuery.IntentID, query.IntentID)
+		}
+		if !reflect.DeepEqual(query.Tags, rawQuery.Tags) || !reflect.DeepEqual(query.Params, rawQuery.Params) {
+			t.Fatalf("query pair %s/%s must share tags and params", rawQuery.QueryID, query.QueryID)
+		}
+
+		rawRelation := `"frozen_v1"."events_file_view"`
+		duckLakeRelation := `"posthog"."events"`
+		if strings.HasPrefix(query.IntentID, "intent_persons_") {
+			rawRelation = `"frozen_v1"."persons_file_view"`
+			duckLakeRelation = `"posthog"."persons"`
+		}
+		rawShape := strings.ReplaceAll(rawQuery.PGWireSQL, rawRelation, "<relation>")
+		duckLakeShape := strings.ReplaceAll(query.PGWireSQL, duckLakeRelation, "<relation>")
+		if rawShape != duckLakeShape {
+			t.Fatalf("query pair %s/%s differs beyond its relation:\nraw: %s\ntable: %s", rawQuery.QueryID, query.QueryID, rawQuery.PGWireSQL, query.PGWireSQL)
 		}
 	}
 }

--- a/tests/perf/core/runner.go
+++ b/tests/perf/core/runner.go
@@ -109,7 +109,7 @@ func (r *QueryRunner) MetricsGatherer() prometheus.Gatherer {
 }
 
 func (r *QueryRunner) executeIteration(ctx context.Context, measure bool, measureIteration int, summary *RunSummary) error {
-	for _, query := range r.cfg.Catalog.Queries {
+	for _, query := range queriesForIteration(r.cfg.Catalog.Queries, measureIteration) {
 		args := orderedParamValues(query.Params)
 		for _, protocol := range r.cfg.Catalog.Targets {
 			driver := r.cfg.Drivers[protocol]
@@ -153,6 +153,28 @@ func (r *QueryRunner) executeIteration(ctx context.Context, measure bool, measur
 		}
 	}
 	return nil
+}
+
+// queriesForIteration alternates each generated raw-view/DuckLake-table pair
+// on measured iterations. This balances which storage target runs first and
+// prevents one target from consistently inheriting cache state from the other.
+// Legacy queries retain their declared order.
+func queriesForIteration(queries []Query, measureIteration int) []Query {
+	if measureIteration <= 0 || measureIteration%2 == 1 {
+		return queries
+	}
+	ordered := append([]Query(nil), queries...)
+	for index := 0; index+1 < len(ordered); index++ {
+		first, second := ordered[index], ordered[index+1]
+		if first.StorageTarget != StorageTargetRawView ||
+			second.StorageTarget != StorageTargetDuckLakeTable ||
+			first.IntentID != second.IntentID {
+			continue
+		}
+		ordered[index], ordered[index+1] = second, first
+		index++
+	}
+	return ordered
 }
 
 func orderedParamValues(params map[string]any) []any {

--- a/tests/perf/core/runner_test.go
+++ b/tests/perf/core/runner_test.go
@@ -46,7 +46,10 @@ paired_queries:
 	if _, err := runner.Run(context.Background()); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
-	wantIDs := []string{"q_events__raw_view", "q_events__ducklake_table"}
+	wantIDs := []string{
+		"q_events__raw_view", "q_events__ducklake_table",
+		"q_events__ducklake_table", "q_events__raw_view",
+	}
 	if !reflect.DeepEqual(driver.queryIDs, wantIDs) {
 		t.Fatalf("driver query order: got %v want %v", driver.queryIDs, wantIDs)
 	}
@@ -56,6 +59,94 @@ paired_queries:
 	}
 	if !reflect.DeepEqual(gotIDs, wantIDs) {
 		t.Fatalf("result query IDs: got %v want %v", gotIDs, wantIDs)
+	}
+}
+
+func TestQueriesForIterationSwapsOnlyCompletePairsWithoutMutatingCatalogOrder(t *testing.T) {
+	queries := []Query{
+		{QueryID: "legacy_before"},
+		{QueryID: "pair_a_raw", IntentID: "intent_a", StorageTarget: StorageTargetRawView},
+		{QueryID: "pair_a_table", IntentID: "intent_a", StorageTarget: StorageTargetDuckLakeTable},
+		{QueryID: "legacy_middle"},
+		{QueryID: "pair_b_raw", IntentID: "intent_b", StorageTarget: StorageTargetRawView},
+		{QueryID: "pair_b_table", IntentID: "intent_b", StorageTarget: StorageTargetDuckLakeTable},
+		{QueryID: "legacy_after"},
+	}
+	declaredOrder := queryIDOrder(queries)
+	if got := queryIDOrder(queriesForIteration(queries, 1)); !reflect.DeepEqual(got, declaredOrder) {
+		t.Fatalf("odd iteration order: got %v want %v", got, declaredOrder)
+	}
+	wantEven := []string{
+		"legacy_before",
+		"pair_a_table", "pair_a_raw",
+		"legacy_middle",
+		"pair_b_table", "pair_b_raw",
+		"legacy_after",
+	}
+	if got := queryIDOrder(queriesForIteration(queries, 2)); !reflect.DeepEqual(got, wantEven) {
+		t.Fatalf("even iteration order: got %v want %v", got, wantEven)
+	}
+	if got := queryIDOrder(queries); !reflect.DeepEqual(got, declaredOrder) {
+		t.Fatalf("catalog order mutated: got %v want %v", got, declaredOrder)
+	}
+}
+
+func queryIDOrder(queries []Query) []string {
+	ids := make([]string, 0, len(queries))
+	for _, query := range queries {
+		ids = append(ids, query.QueryID)
+	}
+	return ids
+}
+
+func TestRunnerBalancesPairedQueryOrderAcrossMeasuredIterations(t *testing.T) {
+	driver := &testDriver{protocol: ProtocolPGWire}
+	sink := &inMemorySink{}
+	runner := NewQueryRunner(RunnerConfig{
+		Catalog: Catalog{
+			Name:              "paired",
+			MeasureIterations: 4,
+			Targets:           []Protocol{ProtocolPGWire},
+			Queries: []Query{
+				{
+					QueryID:       "q_events__raw_view",
+					IntentID:      "intent_events",
+					PGWireSQL:     "SELECT COUNT(*) FROM frozen_v1.events_file_view",
+					StorageTarget: StorageTargetRawView,
+				},
+				{
+					QueryID:       "q_events__ducklake_table",
+					IntentID:      "intent_events",
+					PGWireSQL:     "SELECT COUNT(*) FROM posthog.events",
+					StorageTarget: StorageTargetDuckLakeTable,
+				},
+			},
+		},
+		Drivers: map[Protocol]ProtocolDriver{
+			ProtocolPGWire: driver,
+		},
+		Sink: sink,
+		Now:  func() time.Time { return time.Unix(1700000000, 0) },
+	})
+
+	if _, err := runner.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	wantIDs := []string{
+		"q_events__raw_view", "q_events__ducklake_table",
+		"q_events__ducklake_table", "q_events__raw_view",
+		"q_events__raw_view", "q_events__ducklake_table",
+		"q_events__ducklake_table", "q_events__raw_view",
+	}
+	if !reflect.DeepEqual(driver.queryIDs, wantIDs) {
+		t.Fatalf("driver query order: got %v want %v", driver.queryIDs, wantIDs)
+	}
+	gotIDs := make([]string, 0, len(sink.results))
+	for _, result := range sink.results {
+		gotIDs = append(gotIDs, result.QueryID)
+	}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("result query order: got %v want %v", gotIDs, wantIDs)
 	}
 }
 

--- a/tests/perf/queries/ducklake_posthog_tables.yaml
+++ b/tests/perf/queries/ducklake_posthog_tables.yaml
@@ -1,11 +1,11 @@
-name: posthog-frozen-ducklake-golden-v1
-description: Identical query shapes over frozen raw Parquet views and production-shaped DuckLake tables.
+name: posthog-frozen-ducklake-golden-v2
+description: Identical query shapes with balanced execution order over frozen raw Parquet views and production-shaped DuckLake tables.
 seed: 42
 dataset_scale: 1
 targets:
   - pgwire
 warmup_iterations: 1
-measure_iterations: 3
+measure_iterations: 4
 
 relation_variants:
   raw_view:
@@ -16,14 +16,14 @@ relation_variants:
     persons: posthog.persons
 
 paired_queries:
-  - query_id_base: q_events_total
-    intent_id: intent_events_total
+  - query_id_base: q_events_total_balanced_v2
+    intent_id: intent_events_total_balanced_v2
     tags: [nightly, frozen, posthog, events, aggregate, paired]
     params: {}
     sql_template: SELECT COUNT(*) AS events FROM {{ relation "events" }}
 
-  - query_id_base: q_events_count_one_day
-    intent_id: intent_events_count_one_day
+  - query_id_base: q_events_count_one_day_balanced_v2
+    intent_id: intent_events_count_one_day_balanced_v2
     tags: [nightly, frozen, posthog, events, aggregate, one-day, paired]
     params: {}
     sql_template: >
@@ -32,32 +32,32 @@ paired_queries:
       WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
         AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
 
-  - query_id_base: q_events_by_name_march_2026
-    intent_id: intent_events_by_name_march_2026
+  - query_id_base: q_events_by_name_march_2026_balanced_v2
+    intent_id: intent_events_by_name_march_2026_balanced_v2
     tags: [nightly, frozen, posthog, events, aggregate, analytics, paired]
     params: {}
     sql_template: SELECT event, COUNT(*) AS events FROM {{ relation "events" }} WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
 
-  - query_id_base: q_events_distinct_persons
-    intent_id: intent_events_distinct_persons
+  - query_id_base: q_events_distinct_persons_balanced_v2
+    intent_id: intent_events_distinct_persons_balanced_v2
     tags: [nightly, frozen, posthog, events, aggregate, distinct, paired]
     params: {}
     sql_template: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM {{ relation "events" }} WHERE person_id IS NOT NULL
 
-  - query_id_base: q_persons_total
-    intent_id: intent_persons_total
+  - query_id_base: q_persons_total_balanced_v2
+    intent_id: intent_persons_total_balanced_v2
     tags: [nightly, frozen, posthog, persons, aggregate, paired]
     params: {}
     sql_template: SELECT COUNT(*) AS persons FROM {{ relation "persons" }}
 
-  - query_id_base: q_persons_daily_april_2026
-    intent_id: intent_persons_daily_april_2026
+  - query_id_base: q_persons_daily_april_2026_balanced_v2
+    intent_id: intent_persons_daily_april_2026_balanced_v2
     tags: [nightly, frozen, posthog, persons, aggregate, time-series, paired]
     params: {}
     sql_template: SELECT date_trunc('day', _timestamp) AS day, COUNT(*) AS persons FROM {{ relation "persons" }} WHERE _timestamp >= TIMESTAMPTZ '2026-04-01 00:00:00+00' AND _timestamp < TIMESTAMPTZ '2026-05-01 00:00:00+00' GROUP BY 1 ORDER BY 1
 
-  - query_id_base: q_events_daily_march_2026
-    intent_id: intent_events_daily_march_2026
+  - query_id_base: q_events_daily_march_2026_balanced_v2
+    intent_id: intent_events_daily_march_2026_balanced_v2
     tags: [nightly, frozen, posthog, events, aggregate, time-series, paired]
     params: {}
     sql_template: SELECT date_trunc('day', "timestamp") AS day, COUNT(*) AS events FROM {{ relation "events" }} WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY 1 ORDER BY 1

--- a/tests/perf/queries/ducklake_posthog_tables.yaml
+++ b/tests/perf/queries/ducklake_posthog_tables.yaml
@@ -1,86 +1,63 @@
 name: posthog-frozen-ducklake-golden-v1
-description: Paired raw-Parquet-view and DuckLake-table queries, plus table-only regression probes, over the frozen PostHog dataset.
+description: Identical query shapes over frozen raw Parquet views and production-shaped DuckLake tables.
 seed: 42
 dataset_scale: 1
 targets:
   - pgwire
 warmup_iterations: 1
 measure_iterations: 3
-queries:
-  # Paired probes use identical SQL shapes to compare raw Parquet access with
-  # DuckLake-managed-table execution in the same artifact.
-  - query_id: q_events_total__raw_view
-    intent_id: intent_events_total
-    tags: [nightly, frozen, posthog, events, aggregate, paired, raw-view]
-    params: {}
-    pgwire_sql: SELECT COUNT(*) AS events FROM frozen_v1.events_file_view
 
-  - query_id: q_events_total__ducklake_table
-    intent_id: intent_events_total
-    tags: [nightly, frozen, posthog, events, aggregate, paired, ducklake-table]
-    params: {}
-    pgwire_sql: SELECT COUNT(*) AS events FROM posthog.events
+relation_variants:
+  raw_view:
+    events: frozen_v1.events_file_view
+    persons: frozen_v1.persons_file_view
+  ducklake_table:
+    events: posthog.events
+    persons: posthog.persons
 
-  - query_id: q_events_count_one_day__raw_view
+paired_queries:
+  - query_id_base: q_events_total
+    intent_id: intent_events_total
+    tags: [nightly, frozen, posthog, events, aggregate, paired]
+    params: {}
+    sql_template: SELECT COUNT(*) AS events FROM {{ relation "events" }}
+
+  - query_id_base: q_events_count_one_day
     intent_id: intent_events_count_one_day
-    tags: [nightly, frozen, posthog, events, aggregate, one-day, paired, raw-view]
+    tags: [nightly, frozen, posthog, events, aggregate, one-day, paired]
     params: {}
-    pgwire_sql: >
+    sql_template: >
       SELECT COUNT(*) AS events
-      FROM frozen_v1.events_file_view
+      FROM {{ relation "events" }}
       WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
         AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
 
-  - query_id: q_events_count_one_day__ducklake_table
-    intent_id: intent_events_count_one_day
-    tags: [nightly, frozen, posthog, events, aggregate, one-day, paired, ducklake-table]
-    params: {}
-    pgwire_sql: >
-      SELECT COUNT(*) AS events
-      FROM posthog.events
-      WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00'
-        AND "timestamp" < TIMESTAMPTZ '2026-03-02 00:00:00+00'
-
-  - query_id: q_events_by_name_march_2026__raw_view
+  - query_id_base: q_events_by_name_march_2026
     intent_id: intent_events_by_name_march_2026
-    tags: [nightly, frozen, posthog, events, aggregate, analytics, paired, raw-view]
+    tags: [nightly, frozen, posthog, events, aggregate, analytics, paired]
     params: {}
-    pgwire_sql: SELECT event, COUNT(*) AS events FROM frozen_v1.events_file_view WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
+    sql_template: SELECT event, COUNT(*) AS events FROM {{ relation "events" }} WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
 
-  - query_id: q_events_by_name_march_2026__ducklake_table
-    intent_id: intent_events_by_name_march_2026
-    tags: [nightly, frozen, posthog, events, aggregate, analytics, paired, ducklake-table]
-    params: {}
-    pgwire_sql: SELECT event, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY event ORDER BY events DESC, event LIMIT 20
-
-  - query_id: q_events_distinct_persons__raw_view
+  - query_id_base: q_events_distinct_persons
     intent_id: intent_events_distinct_persons
-    tags: [nightly, frozen, posthog, events, aggregate, distinct, paired, raw-view]
+    tags: [nightly, frozen, posthog, events, aggregate, distinct, paired]
     params: {}
-    pgwire_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM frozen_v1.events_file_view WHERE person_id IS NOT NULL
+    sql_template: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM {{ relation "events" }} WHERE person_id IS NOT NULL
 
-  - query_id: q_events_distinct_persons__ducklake_table
-    intent_id: intent_events_distinct_persons
-    tags: [nightly, frozen, posthog, events, aggregate, distinct, paired, ducklake-table]
-    params: {}
-    pgwire_sql: SELECT COUNT(DISTINCT person_id) AS distinct_persons FROM posthog.events WHERE person_id IS NOT NULL
-
-  # Table-only probes track the DuckLake workload over time without a raw
-  # Parquet control query.
-  - query_id: q_persons_total__ducklake_table
+  - query_id_base: q_persons_total
     intent_id: intent_persons_total
-    tags: [nightly, frozen, posthog, persons, aggregate, ducklake-table]
+    tags: [nightly, frozen, posthog, persons, aggregate, paired]
     params: {}
-    pgwire_sql: SELECT COUNT(*) AS persons FROM posthog.persons
+    sql_template: SELECT COUNT(*) AS persons FROM {{ relation "persons" }}
 
-  - query_id: q_persons_daily_april_2026__ducklake_table
+  - query_id_base: q_persons_daily_april_2026
     intent_id: intent_persons_daily_april_2026
-    tags: [nightly, frozen, posthog, persons, aggregate, time-series, ducklake-table]
+    tags: [nightly, frozen, posthog, persons, aggregate, time-series, paired]
     params: {}
-    pgwire_sql: SELECT date_trunc('day', _timestamp) AS day, COUNT(*) AS persons FROM posthog.persons WHERE _timestamp >= TIMESTAMPTZ '2026-04-01 00:00:00+00' AND _timestamp < TIMESTAMPTZ '2026-05-01 00:00:00+00' GROUP BY 1 ORDER BY 1
+    sql_template: SELECT date_trunc('day', _timestamp) AS day, COUNT(*) AS persons FROM {{ relation "persons" }} WHERE _timestamp >= TIMESTAMPTZ '2026-04-01 00:00:00+00' AND _timestamp < TIMESTAMPTZ '2026-05-01 00:00:00+00' GROUP BY 1 ORDER BY 1
 
-  - query_id: q_events_daily_march_2026__ducklake_table
+  - query_id_base: q_events_daily_march_2026
     intent_id: intent_events_daily_march_2026
-    tags: [nightly, frozen, posthog, events, aggregate, time-series, ducklake-table]
+    tags: [nightly, frozen, posthog, events, aggregate, time-series, paired]
     params: {}
-    pgwire_sql: SELECT date_trunc('day', "timestamp") AS day, COUNT(*) AS events FROM posthog.events WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY 1 ORDER BY 1
+    sql_template: SELECT date_trunc('day', "timestamp") AS day, COUNT(*) AS events FROM {{ relation "events" }} WHERE "timestamp" >= TIMESTAMPTZ '2026-03-01 00:00:00+00' AND "timestamp" < TIMESTAMPTZ '2026-03-18 00:00:00+00' GROUP BY 1 ORDER BY 1


### PR DESCRIPTION
## Summary

- migrate the frozen PostHog golden corpus to the paired-query contract from #1008
- generate identical raw-view and production-shaped DuckLake-table SQL for all seven intents
- alternate pair order on measured iterations: raw/table on odd iterations and table/raw on even iterations
- require an even measurement count for paired catalogs so first-position effects stay balanced
- version all seven query and intent IDs as `balanced_v2` so dashboards cannot mix the new methodology with historical raw-first samples
- assert stable versioned IDs, balanced scheduling, legacy-query ordering, non-mutation, shared metadata, and relation-only SQL differences

## Validation

- `just test-perf`
- `just test-scenario`
- `just lint`

## Scope and interpretation

The targeted frozen-perf scenario already creates and validates both relation families, so scenario and setup wiring are unchanged. Both targets use the same frozen Parquet objects; this measures view access versus DuckLake metadata/table access, not a production partition-layout rewrite. Alternating order balances which target runs first, but both targets can still be affected by shared caches.

## Follow-up

The companion Grafana PR visualizes paired p50/p95 latency, matched-iteration ratios, sample counts, errors, and missing targets using the stable target suffixes and versioned intents.
