### PR TITLE
Schedule production-shaped frozen perf daily

### DIFF
--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 270
     env:
+      SCENARIO_NAME: ${{ github.event_name == 'schedule' && 'posthog_frozen_perf' || inputs.scenario }}
       SCENARIO_RUNNER_IMAGE: ${{ needs.scenario-runner-image.outputs.image }}
       WORKER_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}
       CONTROLPLANE_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}
@@ -81,8 +82,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Scenario dev target selected
-        env:
-          SCENARIO_NAME: ${{ inputs.scenario || 'full-suite' }}
         run: echo "Deploying an isolated Duckgres stack for $SCENARIO_NAME."
 
       - name: Set up Go
@@ -119,8 +118,6 @@ jobs:
         run: tests/mw-dev/run.sh deploy
 
       - name: Run selected scenario
-        env:
-          SCENARIO_NAME: ${{ inputs.scenario || 'full-suite' }}
         run: tests/mw-dev/run.sh test-scenario
 
       - name: Publish scenario summary

--- a/docs/runbooks/scenario-dev.md
+++ b/docs/runbooks/scenario-dev.md
@@ -7,9 +7,14 @@ identity, diagnostics, and teardown.
 
 ## Scheduled Runs
 
-The scheduled trigger runs `full-suite`, which covers the frozen dataset
-metadata, perf, and dbt workloads with one shared warehouse lifecycle. Manual
-runs also default to `full-suite`.
+The daily scheduled trigger runs `posthog_frozen_perf`, which creates
+production-shaped DuckLake tables from the frozen dataset, executes paired
+raw-view and DuckLake-table queries, and publishes the comparison history.
+Scheduled runs no longer execute `full-suite`.
+
+Manual runs remain selectable and default to `full-suite`, which covers the
+frozen dataset metadata, legacy perf, and dbt workloads with one shared
+warehouse lifecycle.
 
 Scenario jobs override the shared harness's default worker request to 2 CPU and
 8Gi memory for the frozen pgwire perf workload. This adds process headroom for

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -73,9 +73,9 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"workflow_dispatch:",
 		"scenario:",
 		"default: full-suite",
-		"- name: Scenario dev target selected\n        env:\n          SCENARIO_NAME: ${{ inputs.scenario || 'full-suite' }}",
-		"- name: Run selected scenario\n        env:\n          SCENARIO_NAME: ${{ inputs.scenario || 'full-suite' }}",
 		"schedule:",
+		"- cron: \"17 8 * * *\"",
+		"SCENARIO_NAME: ${{ github.event_name == 'schedule' && 'posthog_frozen_perf' || inputs.scenario }}",
 		"id-token: write",
 		"uses: ./.github/workflows/_image-build.yml",
 		"image-name: duckgres",
@@ -141,6 +141,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"postgresql://",
 		"--dsn",
 		"--password",
+		"SCENARIO_NAME: ${{ inputs.scenario || 'full-suite' }}",
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("workflow contains internal detail %q", forbidden)


### PR DESCRIPTION
## Summary

- run posthog_frozen_perf for the daily scenario-dev schedule instead of full-suite
- preserve selectable manual runs with full-suite as the dispatch default
- define scenario selection once at job scope and document the new schedule
- cover the schedule, selector, and removed full-suite fallback in the workflow contract test

## Testing

- just test-scenario
- go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev ./tests/perf/publishercli
- just lint
- git diff --check