### PR TITLE
List the Trino fleet, including worker version, from what the cell actually serves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,15 +1613,30 @@ password/tenant/catalog changes never propagate.
   `/v1/resourceGroupState`, which the console reads, plus `/v1/thread`,
   `/v1/announce` GET, `/v1/maxActiveSplits`, `/v1/integrations/gateway`; all
   GETs of operational state, enumerated in policy.rego) and
-  holds NO catalog — no `data.group_catalogs` entry, and the observer group
-  is excluded from `tenant_owns_catalog` and from the same-org query match,
-  so even a mistaken bundle entry grants no data access. `is_observer` is
+  holds NO TENANT catalog — no `data.group_catalogs` entry, and the observer
+  group is excluded from `tenant_owns_catalog` and from the same-org query
+  match, so even a mistaken bundle entry grants no tenant data access. Its
+  ONE data grant is `system.runtime.nodes`: `AccessCatalog` on `system` plus
+  `SelectFromColumns` pinned to that single table, because a cell on the
+  default `discovery.type` serves no `/v1/node` and `/v1/announce` carries
+  neither health nor version. `AccessCatalog` alone opens nothing — every
+  read still passes `SelectFromColumns` — so `system.runtime.queries`
+  (tenant SQL), `system.metadata.*` and `system.jdbc.*` (which would
+  enumerate every tenant catalog, schema, table and column) all stay denied;
+  `TestObserverSystemGrantIsPinnedToTheNodesTable` pins that. `is_observer` is
   the same username-AND-group conjunction as `is_admin`. Its credential is
   a second regenerate-if-missing pair on `trino-auth`
   (`ensureCredentialPair`), projected into password.db/group.db and read by
   the console through `TrinoProvisioner.ObserverCredential` on every call
   (never captured — a self-heal would otherwise 401 forever). Console reads
   redact SQL before it leaves the CP. See `controlplane/admin/README.md`.
+- **Resource groups must keep a selector for BOTH operational principals**
+  (`root.admin.__admin_provisioner` and `root.admin.__duckgres_observer`).
+  The final selector matches user `(?<org>.*)`, which matches anything, so a
+  principal without its own lane is admitted as a tenant into
+  `root.tenants.free.<principal>` — and those leaves are `JmxExport: true`,
+  so it would appear as a phantom tenant in the per-tenant resource-group
+  metrics.
 - **Resource groups must keep the `root.admin.__admin_provisioner` selector.**
   Trino rejects a query matching no resource group, so dropping it silently
   breaks every reconcile tick's own DDL.

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -82,7 +82,7 @@ Added for the console:
 | `GET /api/v1/trino/queries` | viewer | live queries, `?org=&state=&active=1` slicing, longest-running first. SQL is redacted server-side; each row is stamped with the duckgres org resolved from the Trino principal |
 | `GET /api/v1/trino/queries/:id` | viewer | one query; 404 when the coordinator has aged it out (410 Gone upstream) |
 | `POST /api/v1/trino/queries/:id/kill` | admin | fail a query with a reason (`PUT /v1/query/{id}/killed`). The reason reaches the TENANT as the query's error message. Audited as `trino.query.kill` with the owning org |
-| `GET /api/v1/trino/nodes` | viewer | the coordinator's failure-detector view (`/v1/node` + `/v1/node/failed`) |
+| `GET /api/v1/trino/nodes` | viewer | the cell's fleet: `/v1/node` + `/v1/node/failed` where bound, else `/v1/announce` membership; the response names which (`source`) |
 | `GET /api/v1/trino/orgs` | viewer | per-org Trino provisioning state + that org's live query counts |
 | `GET /api/v1/orgs/:id/trino` | viewer | one org's Trino state; `enabled:false` for an org with no Trino row (not an error) |
 | `GET /api/v1/audit` | admin | admin action log |
@@ -206,9 +206,18 @@ and projects into `password.db` / `group.db`.
   (`duckgres-admin` here, `duckgres-provisioner` in the reconcile loop), so
   control-plane traffic is distinguishable from tenant SQL in
   `system.runtime.queries` and in the console's own live view.
-- `/v1/node` reports heartbeat health keyed by URI and carries **no node id
-  or version**, so worker version skew is not observable there; the Nodes
-  page's pod projection (running images) is where that lives.
+- **Trino binds exactly one node-listing route, chosen by `discovery.type`.**
+  `/v1/node` (heartbeat health, plus `/v1/node/failed`) exists only under
+  `AIRLIFT_DISCOVERY`; `/v1/announce` (the set of announced node URIs, no
+  health) is bound under `ANNOUNCE` — Trino's default, and what these cells
+  run — and under `DNS`. The client tries `/v1/node` and falls back, and the
+  payload carries `source` so the SPA renders membership-only rows instead of
+  zero-filled health columns. Both routes are `@ResourceSecurity(MANAGEMENT_READ)`,
+  so the observer's existing `ReadSystemInformation` grant covers both and the
+  fallback needs **no policy change**.
+- Neither route carries a node id or version, so worker version skew is not
+  observable there; the Nodes page's pod projection (running images) is where
+  that lives.
 - No cell configured (`DUCKGRES_TRINO_COORDINATOR_URL` unset) leaves every
   route unregistered, and the SPA renders a "no cell" state off the 404.
 

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -213,8 +213,16 @@ and projects into `password.db` / `group.db`.
   run — and under `DNS`. The client tries `/v1/node` and falls back, and the
   payload carries `source` so the SPA renders membership-only rows instead of
   zero-filled health columns. Both routes are `@ResourceSecurity(MANAGEMENT_READ)`,
-  so the observer's existing `ReadSystemInformation` grant covers both and the
-  fallback needs **no policy change**.
+  so the observer's existing `ReadSystemInformation` grant covers both.
+- **`system.runtime.nodes` is preferred over `/v1/announce`** on a cell that
+  binds no `/v1/node`: it is served regardless of `discovery.type` and is the
+  only source carrying `node_version`, so it is where worker version skew
+  becomes visible. It is the observer's one data grant — `AccessCatalog` on
+  `system` plus `SelectFromColumns` pinned to that single table — and it
+  needs its own resource-group lane, because the catch-all selector would
+  otherwise file the console's query as a tenant. Order is `/v1/node` →
+  `system.runtime.nodes` → `/v1/announce`, so a cell where the grant has not
+  rolled out yet still lists its fleet.
 - Neither route carries a node id or version, so worker version skew is not
   observable there; the Nodes page's pod projection (running images) is where
   that lives.

--- a/controlplane/admin/trino.go
+++ b/controlplane/admin/trino.go
@@ -96,12 +96,17 @@ type TrinoStatus struct {
 	// than one that is busy.
 	BlockedQueries int `json:"blocked_queries"`
 
-	// NodeStats reports whether Nodes and FailedNodes mean anything. A cell
-	// using Trino's default discovery.type=ANNOUNCE does not serve /v1/node,
-	// so the console must show "not reported here" rather than zero nodes.
-	NodeStats   bool `json:"node_stats"`
-	Nodes       int  `json:"nodes"`
-	FailedNodes int  `json:"failed_nodes"`
+	// NodeStats reports whether Nodes means anything: false when the cell
+	// serves neither node inventory, so the console shows "not reported
+	// here" rather than an authoritative zero.
+	NodeStats bool `json:"node_stats"`
+	// NodeSource names the inventory Nodes was counted from. Under
+	// TrinoNodeSourceAnnounce the cell reports membership without health,
+	// so FailedNodes is always 0 because nothing is measured — not because
+	// the fleet is known to be well. The SPA must not render it as health.
+	NodeSource  string `json:"node_source,omitempty"`
+	Nodes       int    `json:"nodes"`
+	FailedNodes int    `json:"failed_nodes"`
 
 	// OrgsByState counts Trino-enabled orgs by provisioning state, so a
 	// stuck tenant is visible without opening the org list.
@@ -167,7 +172,7 @@ type TrinoAPI struct {
 	orgs    TrinoOrgStore
 	audit   *AuditStore
 	queries *trinoCache[[]TrinoQuery]
-	nodes   *trinoCache[[]TrinoNode]
+	nodes   *trinoCache[TrinoNodeInventory]
 	info    *trinoCache[*TrinoServerInfo]
 }
 
@@ -184,7 +189,7 @@ func NewTrinoAPI(cell TrinoCell, client TrinoCoordinatorClient, orgs TrinoOrgSto
 		orgs:    orgs,
 		audit:   audit,
 		queries: newTrinoCache[[]TrinoQuery](trinoQueriesCacheTTL),
-		nodes:   newTrinoCache[[]TrinoNode](trinoClusterCacheTTL),
+		nodes:   newTrinoCache[TrinoNodeInventory](trinoClusterCacheTTL),
 		info:    newTrinoCache[*TrinoServerInfo](trinoClusterCacheTTL),
 	}
 }
@@ -311,16 +316,23 @@ func (a *TrinoAPI) handleStatus(c *gin.Context) {
 		}
 	}
 
-	// Node stats are best-effort. A cell built with the default
-	// discovery.type=ANNOUNCE does not serve /v1/node at all, and a healthy
-	// cell must not be reported as down because an endpoint it never had is
-	// missing. Any other error still counts against the cell.
-	if nodes, nodeErr := a.nodes.get(ctx, a.client.Nodes); nodeErr == nil {
+	// Node stats are best-effort. The client already falls back from
+	// /v1/node to /v1/announce, so reaching the unavailable branch means the
+	// cell serves neither inventory. A healthy cell must not be reported as
+	// down because an endpoint it never had is missing; any other error
+	// still counts against the cell.
+	if inv, nodeErr := a.nodes.get(ctx, a.client.Nodes); nodeErr == nil {
 		status.NodeStats = true
-		status.Nodes = len(nodes)
-		for _, n := range nodes {
-			if n.Failed {
-				status.FailedNodes++
+		status.NodeSource = inv.Source
+		status.Nodes = len(inv.Nodes)
+		// Only the failure detector measures this. Under ANNOUNCE every
+		// Failed is false because nothing was measured, and the SPA keys
+		// off NodeSource rather than reading 0 as "all healthy".
+		if inv.HasHealth() {
+			for _, n := range inv.Nodes {
+				if n.Failed {
+					status.FailedNodes++
+				}
 			}
 		}
 	} else if isTrinoEndpointUnavailable(nodeErr) {
@@ -487,15 +499,15 @@ func (a *TrinoAPI) handleKillQuery(c *gin.Context) {
 }
 
 func (a *TrinoAPI) handleNodes(c *gin.Context) {
-	nodes, err := a.nodes.get(c.Request.Context(), a.client.Nodes)
+	inv, err := a.nodes.get(c.Request.Context(), a.client.Nodes)
 	if isTrinoEndpointUnavailable(err) {
-		// Not a gateway failure: the coordinator answered, and it does not
-		// serve this route. 501 says the console asked for something this
-		// cell cannot provide, which is what an operator needs to know.
+		// Not a gateway failure: the coordinator answered, and it serves
+		// neither node inventory. 501 says the console asked for something
+		// this cell cannot provide, which is what an operator needs to know.
 		c.JSON(http.StatusNotImplemented, gin.H{
 			"cell":      a.cell,
 			"available": false,
-			"reason":    "this cell does not serve /v1/node; Trino binds it only under discovery.type=AIRLIFT_DISCOVERY",
+			"reason":    "this cell serves neither /v1/node nor /v1/announce, so its fleet cannot be listed",
 		})
 		return
 	}
@@ -503,7 +515,12 @@ func (a *TrinoAPI) handleNodes(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error(), "available": false})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"cell": a.cell, "available": true, "nodes": nodes})
+	c.JSON(http.StatusOK, gin.H{
+		"cell":      a.cell,
+		"available": true,
+		"source":    inv.Source,
+		"nodes":     inv.Nodes,
+	})
 }
 
 func (a *TrinoAPI) handleOrgs(c *gin.Context) {

--- a/controlplane/admin/trino_client.go
+++ b/controlplane/admin/trino_client.go
@@ -169,6 +169,18 @@ type TrinoNode struct {
 	// rather than re-deriving a threshold here; the failure detector is
 	// what actually removes a node from scheduling.
 	Failed bool `json:"failed"`
+
+	// The remaining fields come only from system.runtime.nodes. NodeID and
+	// Version are not on either REST route, so this is the one place worker
+	// version skew is observable from the coordinator.
+	NodeID string `json:"node_id,omitempty"`
+	// Version is the worker's Trino version. During a rollout a cell runs
+	// two of these at once, which is exactly what an operator wants to see.
+	Version     string `json:"version,omitempty"`
+	Coordinator bool   `json:"coordinator,omitempty"`
+	// State is Trino's own NodeState: ACTIVE, INACTIVE, DRAINING,
+	// DRAINED or SHUTTING_DOWN.
+	State string `json:"state,omitempty"`
 }
 
 // Which of Trino's two node inventories a TrinoNodeInventory came from.
@@ -179,6 +191,12 @@ const (
 	// health, plus the coordinator's own failed verdict. Bound only under
 	// discovery.type=AIRLIFT_DISCOVERY.
 	TrinoNodeSourceFailureDetector = "failure_detector"
+	// TrinoNodeSourceSystemTable is `system.runtime.nodes` over SQL: node
+	// id, uri, VERSION, coordinator flag and lifecycle state. Served by any
+	// cell regardless of discovery.type, because the system connector does
+	// not depend on it. Richer than either REST route on everything except
+	// heartbeat ratios, and the only source carrying version.
+	TrinoNodeSourceSystemTable = "system_table"
 	// TrinoNodeSourceAnnounce is `/v1/announce`: the set of node URIs that
 	// have announced themselves. Bound under the ANNOUNCE and DNS
 	// inventories — ANNOUNCE being Trino's default and what these cells
@@ -198,10 +216,16 @@ type TrinoNodeInventory struct {
 	Nodes  []TrinoNode `json:"nodes"`
 }
 
-// HasHealth reports whether the entries carry the heartbeat fields. False
-// means URI is the only meaningful field on every node.
+// HasHealth reports whether the entries carry the failure detector's
+// heartbeat fields (age, recent failure ratio, the failed verdict).
 func (i TrinoNodeInventory) HasHealth() bool {
 	return i.Source == TrinoNodeSourceFailureDetector
+}
+
+// HasNodeDetail reports whether the entries carry node id, version,
+// coordinator flag and lifecycle state.
+func (i TrinoNodeInventory) HasNodeDetail() bool {
+	return i.Source == TrinoNodeSourceSystemTable
 }
 
 // TrinoCoordinatorClient is the narrow read surface the console needs.
@@ -275,9 +299,17 @@ func NewTrinoCoordinatorClient(baseURL, tlsServerName string, creds TrinoCredent
 //	              never built with reads as unavailable rather than as
 //	              silence from the coordinator.
 func (c *trinoCoordinatorHTTPClient) do(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	return c.doURL(ctx, method, c.baseURL+path, path, body)
+}
+
+// doURL is do() against an absolute URL. The /v1/statement protocol hands
+// back absolute nextUri links, so the drain cannot go through the
+// baseURL-relative helper. `label` keeps the error text talking about the
+// route rather than echoing a full internal coordinator URL.
+func (c *trinoCoordinatorHTTPClient) doURL(ctx context.Context, method, rawURL, label string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
 	if err != nil {
-		return nil, fmt.Errorf("build %s %s: %w", method, path, err)
+		return nil, fmt.Errorf("build %s %s: %w", method, label, err)
 	}
 	user, password := c.creds()
 	req.Header.Set("X-Trino-User", user)
@@ -287,26 +319,26 @@ func (c *trinoCoordinatorHTTPClient) do(ctx context.Context, method, path string
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+		return nil, fmt.Errorf("%s %s: %w", method, label, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	raw, readErr := io.ReadAll(resp.Body)
 	switch {
 	case resp.StatusCode == http.StatusGone:
-		return nil, fmt.Errorf("%s %s: %w", method, path, errTrinoNotFound)
+		return nil, fmt.Errorf("%s %s: %w", method, label, errTrinoNotFound)
 	case resp.StatusCode == http.StatusNotFound:
-		return nil, fmt.Errorf("%s %s: %w", method, path, errTrinoEndpointUnavailable)
+		return nil, fmt.Errorf("%s %s: %w", method, label, errTrinoEndpointUnavailable)
 	case resp.StatusCode == http.StatusForbidden:
 		// Worth its own message: this is what a missing observer grant or
 		// an un-rolled-out OPA bundle looks like, and it is fixed in a
 		// completely different place from a 5xx.
 		return nil, fmt.Errorf("%s %s: 403 forbidden — the %s principal is not authorized by the cell's OPA bundle",
-			method, path, trinoObserverUser)
+			method, label, trinoObserverUser)
 	case resp.StatusCode/100 != 2:
-		return nil, fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, truncateForError(string(raw)))
+		return nil, fmt.Errorf("%s %s: status %d: %s", method, label, resp.StatusCode, truncateForError(string(raw)))
 	}
 	if readErr != nil {
-		return nil, fmt.Errorf("%s %s: read body: %w", method, path, readErr)
+		return nil, fmt.Errorf("%s %s: read body: %w", method, label, readErr)
 	}
 	return raw, nil
 }
@@ -474,9 +506,14 @@ func (c *trinoCoordinatorHTTPClient) Nodes(ctx context.Context) (TrinoNodeInvent
 	raw, err := c.do(ctx, http.MethodGet, "/v1/node", nil)
 	if err != nil {
 		// A cell on the default discovery.type does not bind /v1/node at
-		// all. It does bind /v1/announce, so fall back to membership
-		// rather than reporting a fleet we simply asked for the wrong way.
+		// all. Fall back rather than report a fleet we asked for the wrong
+		// way: system.runtime.nodes first, because it carries version and
+		// lifecycle state and every cell serves it, then /v1/announce for
+		// bare membership if the SQL path is unavailable too.
 		if isTrinoEndpointUnavailable(err) {
+			if inv, sqlErr := c.systemTableNodes(ctx); sqlErr == nil {
+				return inv, nil
+			}
 			return c.announcedNodes(ctx)
 		}
 		return TrinoNodeInventory{}, err
@@ -509,6 +546,110 @@ func (c *trinoCoordinatorHTTPClient) Nodes(ctx context.Context) (TrinoNodeInvent
 		})
 	}
 	return TrinoNodeInventory{Source: TrinoNodeSourceFailureDetector, Nodes: out}, nil
+}
+
+// trinoNodesQuery is the console's ONE SQL statement. Columns are listed
+// explicitly rather than SELECT *, so a future Trino adding a column cannot
+// silently change the row shape this decodes positionally.
+//
+// The observer's OPA grant is pinned to exactly this table; see the
+// "observer's ONE data read" section of policy.rego.
+const trinoNodesQuery = `SELECT node_id, http_uri, node_version, coordinator, state FROM system.runtime.nodes`
+
+// systemTableNodes reads the fleet from system.runtime.nodes over SQL.
+//
+// The system connector is served by every cell regardless of discovery.type,
+// so this works where /v1/node does not, and it is the only source that
+// carries the worker VERSION — i.e. the only way the console can show
+// version skew mid-rollout.
+//
+// It costs the observer a catalog grant (AccessCatalog on `system`,
+// SelectFromColumns on this one table) and a resource-group lane. Both are
+// deliberately narrow; policy.rego documents exactly what stays denied.
+func (c *trinoCoordinatorHTTPClient) systemTableNodes(ctx context.Context) (TrinoNodeInventory, error) {
+	rows, err := c.runStatement(ctx, trinoNodesQuery)
+	if err != nil {
+		return TrinoNodeInventory{}, err
+	}
+	out := make([]TrinoNode, 0, len(rows))
+	for _, r := range rows {
+		// Positional decode against trinoNodesQuery's column list. A short
+		// row is skipped rather than panicking a console request.
+		if len(r) < 5 {
+			continue
+		}
+		out = append(out, TrinoNode{
+			NodeID:      stringCell(r[0]),
+			URI:         stringCell(r[1]),
+			Version:     stringCell(r[2]),
+			Coordinator: r[3] == true,
+			State:       stringCell(r[4]),
+		})
+	}
+	// Coordinator first, then by URI: a stable order, and the node an
+	// operator most often wants at the top.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Coordinator != out[j].Coordinator {
+			return out[i].Coordinator
+		}
+		return out[i].URI < out[j].URI
+	})
+	return TrinoNodeInventory{Source: TrinoNodeSourceSystemTable, Nodes: out}, nil
+}
+
+// stringCell reads a Trino JSON result cell as a string, tolerating the
+// null a nullable column can produce.
+func stringCell(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}
+
+// trinoStatementResponse is the subset of the /v1/statement response the
+// console needs. The full payload is much larger.
+type trinoStatementResponse struct {
+	NextURI string          `json:"nextUri,omitempty"`
+	Data    [][]interface{} `json:"data,omitempty"`
+	Error   *struct {
+		Message   string `json:"message"`
+		ErrorName string `json:"errorName"`
+		ErrorType string `json:"errorType"`
+	} `json:"error,omitempty"`
+}
+
+// runStatement executes one statement and drains the nextUri chain.
+//
+// Bounded hops so a coordinator that never completes cannot hang a console
+// request; the node query returns in a couple of hops in practice. Every hop
+// honours ctx, so the handler's timeout aborts the drain promptly.
+func (c *trinoCoordinatorHTTPClient) runStatement(ctx context.Context, sql string) ([][]interface{}, error) {
+	const maxDrainHops = 50
+	body, err := c.doURL(ctx, http.MethodPost, c.baseURL+"/v1/statement", "/v1/statement", strings.NewReader(sql))
+	if err != nil {
+		return nil, err
+	}
+	var all [][]interface{}
+	for hop := 0; hop < maxDrainHops; hop++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("statement drain aborted: %w", err)
+		}
+		var r trinoStatementResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			return nil, fmt.Errorf("parse statement response: %w", err)
+		}
+		if r.Error != nil {
+			// A denied grant surfaces here rather than as an HTTP status:
+			// the POST succeeds and the failure arrives inside the payload.
+			return nil, fmt.Errorf("trino: %s (%s): %s", r.Error.ErrorName, r.Error.ErrorType, r.Error.Message)
+		}
+		all = append(all, r.Data...)
+		if r.NextURI == "" {
+			return all, nil
+		}
+		if body, err = c.doURL(ctx, http.MethodGet, r.NextURI, "/v1/statement", nil); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("statement drain exceeded %d hops without completing", maxDrainHops)
 }
 
 // announcedNodes reads the ANNOUNCE inventory: the set of node URIs that

--- a/controlplane/admin/trino_client.go
+++ b/controlplane/admin/trino_client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -145,12 +146,18 @@ type TrinoServerInfo struct {
 	UptimeMS int64 `json:"uptime_ms"`
 }
 
-// TrinoNode is one entry of the coordinator's failure-detector view.
+// TrinoNode is one node of the cell as its coordinator describes it.
 //
-// `/v1/node` reports heartbeat health keyed by URI and carries NO node id
-// or version — worker version skew is not observable here. The console
-// derives that from the K8s pod projection (/cluster/pods) instead, which
-// reports each pod's running image.
+// Neither inventory Trino can serve carries a node id or a version, so
+// worker version skew is not observable here. The console derives that from
+// the K8s pod projection (/cluster/pods) instead, which reports each pod's
+// running image.
+//
+// Only the failure-detector inventory fills the heartbeat fields; under
+// ANNOUNCE every field but URI is a zero value that means "not reported",
+// NOT "reported as zero". Read TrinoNodeInventory.Source before showing
+// them — a rendered 0.0 failure ratio sourced from ANNOUNCE is a
+// fabricated health claim.
 type TrinoNode struct {
 	URI                string  `json:"uri"`
 	AgeMS              int64   `json:"age_ms"`
@@ -164,6 +171,39 @@ type TrinoNode struct {
 	Failed bool `json:"failed"`
 }
 
+// Which of Trino's two node inventories a TrinoNodeInventory came from.
+// They differ in detail, not just in route, so the source travels with the
+// data rather than being re-derived by each consumer.
+const (
+	// TrinoNodeSourceFailureDetector is `/v1/node`: per-node heartbeat
+	// health, plus the coordinator's own failed verdict. Bound only under
+	// discovery.type=AIRLIFT_DISCOVERY.
+	TrinoNodeSourceFailureDetector = "failure_detector"
+	// TrinoNodeSourceAnnounce is `/v1/announce`: the set of node URIs that
+	// have announced themselves. Bound under the ANNOUNCE and DNS
+	// inventories — ANNOUNCE being Trino's default and what these cells
+	// run. It answers "who is in the fleet" and nothing about their health.
+	TrinoNodeSourceAnnounce = "announce"
+)
+
+// TrinoNodeInventory is the fleet as this cell is able to describe it.
+//
+// Trino binds exactly one node-listing route depending on discovery.type,
+// and the two carry different detail. Returning the source alongside the
+// nodes is what lets the console show membership from a cell that cannot
+// report health, instead of showing nothing (which reads as an empty
+// cluster) or showing zeros (which reads as a perfectly healthy one).
+type TrinoNodeInventory struct {
+	Source string      `json:"source"`
+	Nodes  []TrinoNode `json:"nodes"`
+}
+
+// HasHealth reports whether the entries carry the heartbeat fields. False
+// means URI is the only meaningful field on every node.
+func (i TrinoNodeInventory) HasHealth() bool {
+	return i.Source == TrinoNodeSourceFailureDetector
+}
+
 // TrinoCoordinatorClient is the narrow read surface the console needs.
 // An interface so handler tests can drive them without an HTTP server and
 // so a coordinator outage is a substitutable condition.
@@ -171,7 +211,7 @@ type TrinoCoordinatorClient interface {
 	Queries(ctx context.Context) ([]TrinoQuery, error)
 	Query(ctx context.Context, queryID string) (*TrinoQuery, error)
 	KillQuery(ctx context.Context, queryID, message string) error
-	Nodes(ctx context.Context) ([]TrinoNode, error)
+	Nodes(ctx context.Context) (TrinoNodeInventory, error)
 	ServerInfo(ctx context.Context) (*TrinoServerInfo, error)
 }
 
@@ -430,14 +470,20 @@ type trinoNodeStats struct {
 // applied here: the failure detector's verdict is what determines whether
 // a node receives splits, and a second opinion computed in the console
 // would disagree with the engine exactly when it matters.
-func (c *trinoCoordinatorHTTPClient) Nodes(ctx context.Context) ([]TrinoNode, error) {
+func (c *trinoCoordinatorHTTPClient) Nodes(ctx context.Context) (TrinoNodeInventory, error) {
 	raw, err := c.do(ctx, http.MethodGet, "/v1/node", nil)
 	if err != nil {
-		return nil, err
+		// A cell on the default discovery.type does not bind /v1/node at
+		// all. It does bind /v1/announce, so fall back to membership
+		// rather than reporting a fleet we simply asked for the wrong way.
+		if isTrinoEndpointUnavailable(err) {
+			return c.announcedNodes(ctx)
+		}
+		return TrinoNodeInventory{}, err
 	}
 	var wire []trinoNodeStats
 	if err := json.Unmarshal(raw, &wire); err != nil {
-		return nil, fmt.Errorf("decode node list: %w", err)
+		return TrinoNodeInventory{}, fmt.Errorf("decode node list: %w", err)
 	}
 
 	failed := map[string]bool{}
@@ -462,7 +508,39 @@ func (c *trinoCoordinatorHTTPClient) Nodes(ctx context.Context) ([]TrinoNode, er
 			Failed:             failed[n.URI],
 		})
 	}
-	return out, nil
+	return TrinoNodeInventory{Source: TrinoNodeSourceFailureDetector, Nodes: out}, nil
+}
+
+// announcedNodes reads the ANNOUNCE inventory: the set of node URIs that
+// have announced themselves to this coordinator.
+//
+// `GET /v1/announce` is bound by AnnounceNodeInventoryModule and
+// DnsNodeInventoryModule — i.e. for every discovery.type except the one
+// that binds /v1/node — so between them the console can name the fleet of
+// any cell. It carries membership only: no heartbeat, no age, no failed
+// verdict, which is why the inventory records where it came from.
+//
+// It is declared @ResourceSecurity(MANAGEMENT_READ), the same access type
+// as /v1/node, so the observer's existing ReadSystemInformation grant
+// already covers it. This needs no change to policy.rego.
+func (c *trinoCoordinatorHTTPClient) announcedNodes(ctx context.Context) (TrinoNodeInventory, error) {
+	raw, err := c.do(ctx, http.MethodGet, "/v1/announce", nil)
+	if err != nil {
+		return TrinoNodeInventory{}, err
+	}
+	var uris []string
+	if err := json.Unmarshal(raw, &uris); err != nil {
+		return TrinoNodeInventory{}, fmt.Errorf("decode announced node list: %w", err)
+	}
+	// The wire type is a Set<URI>, so the order is whatever the coordinator's
+	// hash iteration produced. Sort it: without this the console reshuffles
+	// its node rows on every poll.
+	sort.Strings(uris)
+	out := make([]TrinoNode, 0, len(uris))
+	for _, u := range uris {
+		out = append(out, TrinoNode{URI: u})
+	}
+	return TrinoNodeInventory{Source: TrinoNodeSourceAnnounce, Nodes: out}, nil
 }
 
 type trinoServerInfoWire struct {

--- a/controlplane/admin/trino_client_test.go
+++ b/controlplane/admin/trino_client_test.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -474,5 +475,118 @@ func TestNodesDoNotQueryAnnounceWhenTheFailureDetectorAnswers(t *testing.T) {
 		if r.URL.Path == "/v1/announce" {
 			t.Error("/v1/announce must not be queried when /v1/node answers")
 		}
+	}
+}
+
+// On a cell with no /v1/node, system.runtime.nodes is preferred over
+// /v1/announce: it is the only source carrying node_version, which is what
+// makes version skew visible during a rollout.
+func TestNodesPreferTheSystemTableOverAnnounce(t *testing.T) {
+	c, rec := newTrinoTestCoordinator(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/node" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/statement" {
+			_, _ = w.Write([]byte(`{"data":[
+			  ["worker2","http://10.0.0.2:8080","477",false,"ACTIVE"],
+			  ["coord","http://10.0.0.1:8080","476",true,"ACTIVE"],
+			  ["worker1","http://10.0.0.3:8080","476",false,"SHUTTING_DOWN"]
+			]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`["http://should-not-be-used:8080"]`))
+	})
+
+	inv, err := c.Nodes(context.Background())
+	if err != nil {
+		t.Fatalf("Nodes: %v", err)
+	}
+	if inv.Source != TrinoNodeSourceSystemTable || !inv.HasNodeDetail() {
+		t.Fatalf("source = %q, want %q", inv.Source, TrinoNodeSourceSystemTable)
+	}
+	if inv.HasHealth() {
+		t.Error("the system table carries no heartbeat ratios and must not claim health")
+	}
+	if len(inv.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(inv.Nodes))
+	}
+	// Coordinator first, then by URI.
+	if !inv.Nodes[0].Coordinator || inv.Nodes[0].NodeID != "coord" {
+		t.Errorf("coordinator must sort first, got %+v", inv.Nodes[0])
+	}
+	if inv.Nodes[1].URI != "http://10.0.0.2:8080" || inv.Nodes[2].URI != "http://10.0.0.3:8080" {
+		t.Errorf("workers must sort by URI, got %+v", inv.Nodes[1:])
+	}
+	// Version is the whole reason this source is preferred.
+	if inv.Nodes[1].Version != "477" || inv.Nodes[2].Version != "476" {
+		t.Errorf("node versions not decoded: %+v", inv.Nodes)
+	}
+	if inv.Nodes[2].State != "SHUTTING_DOWN" {
+		t.Errorf("state not decoded: %+v", inv.Nodes[2])
+	}
+	for _, r := range rec.requests {
+		if r.URL.Path == "/v1/announce" {
+			t.Error("/v1/announce must not be queried when the system table answers")
+		}
+	}
+}
+
+// If the SQL path fails — the grant is not rolled out yet, the resource
+// group rejects it — the console must still name the fleet rather than show
+// nothing. /v1/announce is the last resort.
+func TestNodesFallBackToAnnounceWhenTheSystemTableIsDenied(t *testing.T) {
+	c, _ := newTrinoTestCoordinator(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/node" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/statement" {
+			// Trino reports authorization failures inside a 200 payload.
+			_, _ = w.Write([]byte(`{"error":{"message":"Access Denied: Cannot access catalog system","errorName":"PERMISSION_DENIED","errorType":"USER_ERROR"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`["http://10.0.0.1:8080"]`))
+	})
+
+	inv, err := c.Nodes(context.Background())
+	if err != nil {
+		t.Fatalf("a denied system table must not fail the whole node read: %v", err)
+	}
+	if inv.Source != TrinoNodeSourceAnnounce {
+		t.Errorf("source = %q, want the announce fallback", inv.Source)
+	}
+	if len(inv.Nodes) != 1 {
+		t.Errorf("expected the announced node, got %+v", inv.Nodes)
+	}
+}
+
+// The statement protocol pages through nextUri; rows arrive across hops.
+func TestSystemTableNodesDrainsTheNextUriChain(t *testing.T) {
+	var hop int
+	var base string
+	c, rec := newTrinoTestCoordinator(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/node" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		hop++
+		if hop == 1 {
+			_, _ = fmt.Fprintf(w, `{"nextUri":"%s/v1/statement/x/1","data":[["a","http://10.0.0.1:8080","476",true,"ACTIVE"]]}`, base)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[["b","http://10.0.0.2:8080","476",false,"ACTIVE"]]}`))
+	})
+	base = rec.server.URL
+
+	inv, err := c.Nodes(context.Background())
+	if err != nil {
+		t.Fatalf("Nodes: %v", err)
+	}
+	if len(inv.Nodes) != 2 {
+		t.Fatalf("rows from every hop must be kept, got %+v", inv.Nodes)
 	}
 }

--- a/controlplane/admin/trino_client_test.go
+++ b/controlplane/admin/trino_client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 )
@@ -297,9 +298,11 @@ func TestCoordinatorClientGoneQueryIsNotFound(t *testing.T) {
 }
 
 // TestCoordinatorClientMissingRouteIsEndpointUnavailable: a coordinator
-// built with Trino's default discovery.type=ANNOUNCE does not bind
-// NodeResource, so /v1/node answers 404. The cell is healthy and must not be
-// reported as one that never answered.
+// A cell that serves NEITHER node inventory still must not read as a cell
+// that never answered. /v1/node is bound only under AIRLIFT_DISCOVERY and
+// /v1/announce only under ANNOUNCE/DNS, so in practice one of them is always
+// present; this pins the behaviour for the case where the fallback also
+// 404s, which is a statement about how the cell is built, not its health.
 func TestCoordinatorClientMissingRouteIsEndpointUnavailable(t *testing.T) {
 	c, _ := newTrinoTestCoordinator(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -380,15 +383,18 @@ func TestCoordinatorClientNodes(t *testing.T) {
 		]`))
 	})
 
-	nodes, err := c.Nodes(context.Background())
+	inv, err := c.Nodes(context.Background())
 	if err != nil {
 		t.Fatalf("Nodes: %v", err)
 	}
-	if len(nodes) != 2 {
-		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	if inv.Source != TrinoNodeSourceFailureDetector || !inv.HasHealth() {
+		t.Fatalf("a cell serving /v1/node reports failure-detector health, got source %q", inv.Source)
+	}
+	if len(inv.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(inv.Nodes))
 	}
 	byURI := map[string]TrinoNode{}
-	for _, n := range nodes {
+	for _, n := range inv.Nodes {
 		byURI[n.URI] = n
 	}
 	healthy := byURI["http://10.0.0.1:8080"]
@@ -400,5 +406,73 @@ func TestCoordinatorClientNodes(t *testing.T) {
 	}
 	if !byURI["http://10.0.0.2:8080"].Failed {
 		t.Error("the node listed under /v1/node/failed must be flagged failed")
+	}
+}
+
+// The cells in production run Trino's default discovery.type=ANNOUNCE, which
+// binds /v1/announce and not /v1/node. Listing the fleet from the inventory
+// the cell actually serves is the difference between the console naming the
+// workers and the console showing an operator nothing at all.
+func TestNodesFallBackToTheAnnounceInventory(t *testing.T) {
+	c, rec := newTrinoTestCoordinator(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/node" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Set<URI> serializes unordered; return it worst-case out of order.
+		_, _ = w.Write([]byte(`["http://10.0.0.9:8080","http://10.0.0.1:8080"]`))
+	})
+
+	inv, err := c.Nodes(context.Background())
+	if err != nil {
+		t.Fatalf("Nodes: %v", err)
+	}
+	if inv.Source != TrinoNodeSourceAnnounce {
+		t.Errorf("source = %q, want %q", inv.Source, TrinoNodeSourceAnnounce)
+	}
+	// The announce inventory carries membership only. Claiming health here
+	// would render a 0.0 failure ratio the coordinator never measured.
+	if inv.HasHealth() {
+		t.Error("the announce inventory must not claim to carry health")
+	}
+	got := []string{}
+	for _, n := range inv.Nodes {
+		got = append(got, n.URI)
+		if n.Failed || n.AgeMS != 0 || n.RecentFailureRatio != 0 {
+			t.Errorf("announced node %s carries unmeasured health fields: %+v", n.URI, n)
+		}
+	}
+	// Sorted, so the console does not reshuffle its rows between polls.
+	want := []string{"http://10.0.0.1:8080", "http://10.0.0.9:8080"}
+	if !slices.Equal(got, want) {
+		t.Errorf("nodes = %v, want %v (sorted)", got, want)
+	}
+
+	var paths []string
+	for _, r := range rec.requests {
+		paths = append(paths, r.URL.Path)
+	}
+	if !slices.Contains(paths, "/v1/node") || !slices.Contains(paths, "/v1/announce") {
+		t.Errorf("expected /v1/node to be tried before /v1/announce, got %v", paths)
+	}
+}
+
+// A cell that serves /v1/node must not also be asked for /v1/announce: the
+// fallback exists for the cells that lack the first route, and a per-poll
+// extra request against every coordinator is a cost paid for nothing.
+func TestNodesDoNotQueryAnnounceWhenTheFailureDetectorAnswers(t *testing.T) {
+	_, rec := newTrinoTestCoordinator(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"uri":"http://10.0.0.1:8080","age":"1.00h"}]`))
+	})
+	c := newTrinoCoordinatorClient(rec.server.URL, "obs-password", "")
+	if _, err := c.Nodes(context.Background()); err != nil {
+		t.Fatalf("Nodes: %v", err)
+	}
+	for _, r := range rec.requests {
+		if r.URL.Path == "/v1/announce" {
+			t.Error("/v1/announce must not be queried when /v1/node answers")
+		}
 	}
 }

--- a/controlplane/admin/trino_test.go
+++ b/controlplane/admin/trino_test.go
@@ -26,6 +26,7 @@ type fakeTrinoCoordinator struct {
 	queryByID   map[string]TrinoQuery
 	queryErr    error
 	nodes       []TrinoNode
+	nodeSource  string
 	nodesErr    error
 	info        *TrinoServerInfo
 	infoErr     error
@@ -62,8 +63,14 @@ func (f *fakeTrinoCoordinator) KillQuery(_ context.Context, id, message string) 
 	return nil
 }
 
-func (f *fakeTrinoCoordinator) Nodes(context.Context) ([]TrinoNode, error) {
-	return f.nodes, f.nodesErr
+func (f *fakeTrinoCoordinator) Nodes(context.Context) (TrinoNodeInventory, error) {
+	// Default to the failure detector so the existing cases keep describing
+	// an AIRLIFT_DISCOVERY cell; the ANNOUNCE cases set nodeSource.
+	source := f.nodeSource
+	if source == "" {
+		source = TrinoNodeSourceFailureDetector
+	}
+	return TrinoNodeInventory{Source: source, Nodes: f.nodes}, f.nodesErr
 }
 
 func (f *fakeTrinoCoordinator) ServerInfo(context.Context) (*TrinoServerInfo, error) {
@@ -641,5 +648,59 @@ func TestTrinoRoutesUnregisteredWithoutACell(t *testing.T) {
 	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/trino/status", nil))
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404 with no Trino cell wired, got %d", w.Code)
+	}
+}
+
+// A cell on Trino's default discovery.type reports membership through
+// /v1/announce and no health at all. The status payload must name that
+// source, and must not turn "nothing was measured" into "nothing is wrong":
+// FailedNodes stays 0 because the field is meaningless, and the SPA keys off
+// node_source rather than reading that 0 as a healthy fleet.
+func TestStatusNamesTheAnnounceInventoryAndClaimsNoHealth(t *testing.T) {
+	coord := &fakeTrinoCoordinator{
+		info:       &TrinoServerInfo{Version: "476", Environment: "mw"},
+		nodeSource: TrinoNodeSourceAnnounce,
+		// Failed is set to prove the handler ignores it for this source
+		// rather than merely relying on the client to zero it.
+		nodes: []TrinoNode{{URI: "http://a"}, {URI: "http://b", Failed: true}},
+	}
+	r := trinoTestRouter(testTrinoAPI(t, coord, twoOrgTrinoStore()), RoleViewer)
+
+	code, body := doTrinoJSON(t, r, http.MethodGet, "/api/v1/trino/status", "")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if body["available"] != true || body["node_stats"] != true {
+		t.Fatalf("an announce-only cell is still available and still reports nodes, body: %v", body)
+	}
+	if body["node_source"] != TrinoNodeSourceAnnounce {
+		t.Errorf("node_source = %v, want %q", body["node_source"], TrinoNodeSourceAnnounce)
+	}
+	if body["nodes"] != float64(2) {
+		t.Errorf("nodes = %v, want 2", body["nodes"])
+	}
+	if body["failed_nodes"] != float64(0) {
+		t.Errorf("failed_nodes = %v; the announce inventory measures no health, so it must not be counted", body["failed_nodes"])
+	}
+}
+
+// The nodes route tells the SPA which inventory answered, so it can render
+// membership-only rows instead of zero-filled health columns.
+func TestNodesRouteReportsItsSource(t *testing.T) {
+	coord := &fakeTrinoCoordinator{
+		nodeSource: TrinoNodeSourceAnnounce,
+		nodes:      []TrinoNode{{URI: "http://a"}},
+	}
+	r := trinoTestRouter(testTrinoAPI(t, coord, twoOrgTrinoStore()), RoleViewer)
+
+	code, body := doTrinoJSON(t, r, http.MethodGet, "/api/v1/trino/nodes", "")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if body["source"] != TrinoNodeSourceAnnounce {
+		t.Errorf("source = %v, want %q", body["source"], TrinoNodeSourceAnnounce)
+	}
+	if got := body["nodes"].([]any); len(got) != 1 {
+		t.Errorf("nodes = %v, want 1 entry", got)
 	}
 }

--- a/controlplane/admin/ui/src/lib/trino.test.ts
+++ b/controlplane/admin/ui/src/lib/trino.test.ts
@@ -381,3 +381,55 @@ describe("summarizeTrinoNodes on an announce-only cell", () => {
     expect(summarizeTrinoNodes(announced).healthKnown).toBe(true);
   });
 });
+
+describe("summarizeTrinoNodes from system.runtime.nodes", () => {
+  const node = (
+    uri: string,
+    version: string,
+    state: string,
+    coordinator = false,
+  ) => ({
+    uri,
+    version,
+    state,
+    coordinator,
+    node_id: uri,
+    age_ms: 0,
+    recent_failures: 0,
+    recent_successes: 0,
+    recent_failure_ratio: 0,
+    failed: false,
+  });
+
+  it("surfaces version skew, which is the point of this source", () => {
+    const h = summarizeTrinoNodes(
+      [node("a", "476", "ACTIVE", true), node("b", "477", "ACTIVE")],
+      "system_table",
+    );
+    expect(h.detailKnown).toBe(true);
+    expect(h.versions).toEqual(["476", "477"]);
+    expect(h.total).toBe(2);
+  });
+
+  it("collapses a single version and counts non-active nodes", () => {
+    const h = summarizeTrinoNodes(
+      [
+        node("a", "476", "ACTIVE"),
+        node("b", "476", "SHUTTING_DOWN"),
+        node("c", "476", "INACTIVE"),
+      ],
+      "system_table",
+    );
+    expect(h.versions).toEqual(["476"]);
+    expect(h.inactive).toBe(2);
+  });
+
+  // It carries no heartbeat ratios, so it must not claim the failure
+  // detector's kind of health any more than the announce inventory does.
+  it("does not claim heartbeat health", () => {
+    const h = summarizeTrinoNodes([node("a", "476", "ACTIVE")], "system_table");
+    expect(h.healthKnown).toBe(false);
+    expect(h.failed).toBe(0);
+    expect(h.degraded).toBe(0);
+  });
+});

--- a/controlplane/admin/ui/src/lib/trino.test.ts
+++ b/controlplane/admin/ui/src/lib/trino.test.ts
@@ -12,7 +12,12 @@ import {
   trinoUnavailableMessage,
   trinoUnavailableReason,
 } from "./trino";
-import type { TrinoNode, TrinoOrgStatus, TrinoQuery, TrinoStatus } from "@/types/api";
+import type {
+  TrinoNode,
+  TrinoOrgStatus,
+  TrinoQuery,
+  TrinoStatus,
+} from "@/types/api";
 
 function query(over: Partial<TrinoQuery> = {}): TrinoQuery {
   return {
@@ -112,39 +117,69 @@ describe("trinoQueryFlag", () => {
   });
 
   it("ranks a failure above everything else", () => {
-    expect(trinoQueryFlag(query({ state: "FAILED", fully_blocked: true }))).toBe("failed");
+    expect(
+      trinoQueryFlag(query({ state: "FAILED", fully_blocked: true })),
+    ).toBe("failed");
   });
 
   it("ranks fully-blocked above long-running", () => {
     // A blocked query is a cell-level problem (metadata store, S3) wearing
     // one query's clothes, so it must not be mislabelled as merely slow.
-    const q = query({ fully_blocked: true, elapsed_ms: TRINO_LONG_RUNNING_MS * 10 });
+    const q = query({
+      fully_blocked: true,
+      elapsed_ms: TRINO_LONG_RUNNING_MS * 10,
+    });
     expect(trinoQueryFlag(q)).toBe("blocked");
   });
 
   it("flags a queued query regardless of its elapsed time", () => {
-    expect(trinoQueryFlag(query({ state: "QUEUED", elapsed_ms: 10 }))).toBe("queued");
+    expect(trinoQueryFlag(query({ state: "QUEUED", elapsed_ms: 10 }))).toBe(
+      "queued",
+    );
   });
 
   it("flags a long-running query only once it crosses the threshold", () => {
-    expect(trinoQueryFlag(query({ elapsed_ms: TRINO_LONG_RUNNING_MS - 1 }))).toBeNull();
-    expect(trinoQueryFlag(query({ elapsed_ms: TRINO_LONG_RUNNING_MS }))).toBe("long_running");
+    expect(
+      trinoQueryFlag(query({ elapsed_ms: TRINO_LONG_RUNNING_MS - 1 })),
+    ).toBeNull();
+    expect(trinoQueryFlag(query({ elapsed_ms: TRINO_LONG_RUNNING_MS }))).toBe(
+      "long_running",
+    );
   });
 
   it("never flags a finished query as long-running", () => {
     // Otherwise every completed heavy query lights up the list forever.
-    expect(trinoQueryFlag(query({ state: "FINISHED", elapsed_ms: TRINO_LONG_RUNNING_MS * 10 }))).toBeNull();
+    expect(
+      trinoQueryFlag(
+        query({ state: "FINISHED", elapsed_ms: TRINO_LONG_RUNNING_MS * 10 }),
+      ),
+    ).toBeNull();
   });
 });
 
 describe("summarizeTrinoQueries", () => {
   it("counts states and sums the cell's current draw", () => {
     const s = summarizeTrinoQueries([
-      query({ state: "RUNNING", physical_input_bytes: 100, cpu_ms: 10, elapsed_ms: 1_000 }),
-      query({ state: "RUNNING", fully_blocked: true, physical_input_bytes: 200, cpu_ms: 20, elapsed_ms: 5_000 }),
+      query({
+        state: "RUNNING",
+        physical_input_bytes: 100,
+        cpu_ms: 10,
+        elapsed_ms: 1_000,
+      }),
+      query({
+        state: "RUNNING",
+        fully_blocked: true,
+        physical_input_bytes: 200,
+        cpu_ms: 20,
+        elapsed_ms: 5_000,
+      }),
       query({ state: "QUEUED", elapsed_ms: 50 }),
       query({ state: "FAILED", physical_input_bytes: 5 }),
-      query({ state: "FINISHED", physical_input_bytes: 1_000, elapsed_ms: 900_000 }),
+      query({
+        state: "FINISHED",
+        physical_input_bytes: 1_000,
+        elapsed_ms: 900_000,
+      }),
     ]);
     expect(s.total).toBe(5);
     expect(s.running).toBe(2);
@@ -168,8 +203,14 @@ describe("summarizeTrinoQueries", () => {
   it("handles an empty cell", () => {
     const s = summarizeTrinoQueries([]);
     expect(s).toEqual({
-      total: 0, running: 0, queued: 0, blocked: 0, failed: 0,
-      scannedBytes: 0, cpuMs: 0, longestMs: 0,
+      total: 0,
+      running: 0,
+      queued: 0,
+      blocked: 0,
+      failed: 0,
+      scannedBytes: 0,
+      cpuMs: 0,
+      longestMs: 0,
     });
   });
 });
@@ -190,7 +231,9 @@ describe("summarizeTrinoNodes", () => {
   });
 
   it("does not double-count a failed node as degraded", () => {
-    const h = summarizeTrinoNodes([node({ failed: true, recent_failure_ratio: 0.9 })]);
+    const h = summarizeTrinoNodes([
+      node({ failed: true, recent_failure_ratio: 0.9 }),
+    ]);
     expect(h.failed).toBe(1);
     expect(h.degraded).toBe(0);
   });
@@ -204,21 +247,33 @@ describe("trinoUnavailableReason", () => {
   it("distinguishes an unconfigured deployment from a broken one", () => {
     // Different fix: one is "this cluster has no Trino", the other is an
     // incident. Collapsing them sends an operator to the wrong system.
-    const none = status({ cell: { id: "", coordinator_url: "" }, available: false });
+    const none = status({
+      cell: { id: "", coordinator_url: "" },
+      available: false,
+    });
     expect(trinoUnavailableReason(none)).toBe("no_cell");
-    expect(trinoUnavailableMessage("no_cell")).toContain("DUCKGRES_TRINO_COORDINATOR_URL");
+    expect(trinoUnavailableMessage("no_cell")).toContain(
+      "DUCKGRES_TRINO_COORDINATOR_URL",
+    );
   });
 
   it("calls out an OPA authorization failure separately from an outage", () => {
     // A 403 means the bundle has not rolled out or the observer grant is
     // missing — fixed in the control plane, not in the cluster.
-    const denied = status({ available: false, error: "GET /v1/query: 403 forbidden — the __duckgres_observer principal is not authorized" });
+    const denied = status({
+      available: false,
+      error:
+        "GET /v1/query: 403 forbidden — the __duckgres_observer principal is not authorized",
+    });
     expect(trinoUnavailableReason(denied)).toBe("unauthorized");
     expect(trinoUnavailableMessage("unauthorized")).toContain("OPA bundle");
   });
 
   it("treats anything else as unreachable", () => {
-    const down = status({ available: false, error: "dial tcp: connection refused" });
+    const down = status({
+      available: false,
+      error: "dial tcp: connection refused",
+    });
     expect(trinoUnavailableReason(down)).toBe("unreachable");
     expect(trinoUnavailableMessage("unreachable")).toContain("config store");
   });
@@ -232,9 +287,16 @@ describe("trinoOrgsNeedingAttention", () => {
       org({ org: "new", state: "pending" }),
       // Re-reconciling after a successful provision: a tick in flight, not
       // trouble. Flagging it would keep the warning permanently lit.
-      org({ org: "reconciling", state: "provisioning", ready_at: "2026-08-01T00:00:00Z" }),
+      org({
+        org: "reconciling",
+        state: "provisioning",
+        ready_at: "2026-08-01T00:00:00Z",
+      }),
     ];
-    expect(trinoOrgsNeedingAttention(rows).map((o) => o.org)).toEqual(["broken", "new"]);
+    expect(trinoOrgsNeedingAttention(rows).map((o) => o.org)).toEqual([
+      "broken",
+      "new",
+    ]);
   });
 });
 
@@ -242,13 +304,21 @@ describe("trinoScanEfficiency", () => {
   it("is null before any rows have been processed", () => {
     // A query that has just started has no ratio to report; 0 would render
     // as perfect pruning.
-    expect(trinoScanEfficiency(query({ processed_input_rows: 0, physical_input_bytes: 1_000 }))).toBeNull();
+    expect(
+      trinoScanEfficiency(
+        query({ processed_input_rows: 0, physical_input_bytes: 1_000 }),
+      ),
+    ).toBeNull();
   });
 
   it("reports bytes read per row returned", () => {
     // The DuckLake pruning signal: gigabytes read for a handful of rows
     // means predicates are not pruning files.
-    expect(trinoScanEfficiency(query({ processed_input_rows: 10, physical_input_bytes: 1_000 }))).toBe(100);
+    expect(
+      trinoScanEfficiency(
+        query({ processed_input_rows: 10, physical_input_bytes: 1_000 }),
+      ),
+    ).toBe(100);
   });
 });
 
@@ -261,5 +331,53 @@ describe("trinoStateVariant", () => {
 
   it("falls back rather than throwing on a state it does not know", () => {
     expect(trinoStateVariant("WAITING_FOR_RESOURCES")).toBe("outline");
+  });
+});
+
+describe("summarizeTrinoNodes on an announce-only cell", () => {
+  // The announce inventory returns URIs and nothing else, so every heartbeat
+  // field arrives as a zero that means "not measured". Summarizing it as
+  // health is how a console ends up telling an operator the fleet is fine
+  // on the strength of data the coordinator never sent.
+  const announced: TrinoNode[] = [
+    {
+      uri: "http://10.0.0.1:8080",
+      age_ms: 0,
+      recent_failures: 0,
+      recent_successes: 0,
+      recent_failure_ratio: 0,
+      failed: false,
+    },
+    {
+      uri: "http://10.0.0.2:8080",
+      age_ms: 0,
+      recent_failures: 0,
+      recent_successes: 0,
+      recent_failure_ratio: 0,
+      failed: false,
+    },
+  ];
+
+  it("counts membership but refuses to claim health", () => {
+    const h = summarizeTrinoNodes(announced, "announce");
+    expect(h.total).toBe(2);
+    expect(h.healthKnown).toBe(false);
+    expect(h.failed).toBe(0);
+    expect(h.degraded).toBe(0);
+  });
+
+  it("still reports health when the failure detector is the source", () => {
+    const h = summarizeTrinoNodes(
+      [{ ...announced[0], failed: true }],
+      "failure_detector",
+    );
+    expect(h.healthKnown).toBe(true);
+    expect(h.failed).toBe(1);
+  });
+
+  // An older payload has no source field. Defaulting to failure_detector
+  // keeps the pre-existing cells rendering exactly as before.
+  it("defaults to the failure detector when the source is absent", () => {
+    expect(summarizeTrinoNodes(announced).healthKnown).toBe(true);
   });
 });

--- a/controlplane/admin/ui/src/lib/trino.ts
+++ b/controlplane/admin/ui/src/lib/trino.ts
@@ -6,7 +6,7 @@
 // function with a test in trino.test.ts.
 
 import type { BadgeProps } from "@/components/ui/badge";
-import type { TrinoNode, TrinoOrgStatus, TrinoQuery, TrinoStatus } from "@/types/api";
+import type { TrinoNode, TrinoNodeSource, TrinoOrgStatus, TrinoQuery, TrinoStatus } from "@/types/api";
 
 // Trino's terminal states, mirroring QueryState.isDone(). Everything else --
 // QUEUED, WAITING_FOR_RESOURCES, DISPATCHING, PLANNING, STARTING, RUNNING,
@@ -105,6 +105,11 @@ export function summarizeTrinoQueries(queries: TrinoQuery[]): TrinoQuerySummary 
 
 export interface TrinoNodeHealth {
   total: number;
+  // healthKnown=false means the cell reported membership only (the announce
+  // inventory), so failed/degraded/worstFailureRatio are zero because
+  // nothing was measured. A view that renders them as "all healthy" is
+  // making a claim the coordinator never made — check this first.
+  healthKnown: boolean;
   failed: number;
   // degraded counts nodes the coordinator still schedules onto but which
   // are losing heartbeats. They are the early warning the `failed` count
@@ -118,8 +123,21 @@ export interface TrinoNodeHealth {
 // point is to see trouble before the coordinator evicts the node.
 export const TRINO_DEGRADED_FAILURE_RATIO = 0.1;
 
-export function summarizeTrinoNodes(nodes: TrinoNode[]): TrinoNodeHealth {
-  const h: TrinoNodeHealth = { total: nodes.length, failed: 0, degraded: 0, worstFailureRatio: 0 };
+export function summarizeTrinoNodes(
+  nodes: TrinoNode[],
+  source: TrinoNodeSource | undefined = "failure_detector",
+): TrinoNodeHealth {
+  const healthKnown = source === "failure_detector";
+  const h: TrinoNodeHealth = {
+    total: nodes.length,
+    healthKnown,
+    failed: 0,
+    degraded: 0,
+    worstFailureRatio: 0,
+  };
+  // The announce inventory carries a URI and nothing else. Counting its
+  // zeroed heartbeat fields would manufacture a clean bill of health.
+  if (!healthKnown) return h;
   for (const n of nodes) {
     const ratio = n.recent_failure_ratio ?? 0;
     if (n.failed) {

--- a/controlplane/admin/ui/src/lib/trino.ts
+++ b/controlplane/admin/ui/src/lib/trino.ts
@@ -103,6 +103,10 @@ export function summarizeTrinoQueries(queries: TrinoQuery[]): TrinoQuerySummary 
   return s;
 }
 
+// Trino's NodeState for a node that is scheduling work normally. Anything
+// else is draining, shutting down or already gone.
+export const TRINO_ACTIVE_NODE_STATE = "ACTIVE";
+
 export interface TrinoNodeHealth {
   total: number;
   // healthKnown=false means the cell reported membership only (the announce
@@ -116,6 +120,14 @@ export interface TrinoNodeHealth {
   // gives only after the fact.
   degraded: number;
   worstFailureRatio: number;
+  // detailKnown=true means the source carried lifecycle state and version
+  // (system.runtime.nodes). inactive and versions are meaningful only then.
+  detailKnown: boolean;
+  // Nodes not in the ACTIVE state: draining, shutting down or inactive.
+  inactive: number;
+  // Distinct node versions, sorted. More than one means a rollout is in
+  // flight — or stuck, which is the case worth seeing.
+  versions: string[];
 }
 
 // A node that is still scheduled but failing this share of its heartbeats
@@ -128,13 +140,26 @@ export function summarizeTrinoNodes(
   source: TrinoNodeSource | undefined = "failure_detector",
 ): TrinoNodeHealth {
   const healthKnown = source === "failure_detector";
+  const detailKnown = source === "system_table";
   const h: TrinoNodeHealth = {
     total: nodes.length,
     healthKnown,
     failed: 0,
     degraded: 0,
     worstFailureRatio: 0,
+    detailKnown,
+    inactive: 0,
+    versions: [],
   };
+  if (detailKnown) {
+    const seen = new Set<string>();
+    for (const n of nodes) {
+      if (n.state && n.state !== TRINO_ACTIVE_NODE_STATE) h.inactive += 1;
+      if (n.version) seen.add(n.version);
+    }
+    h.versions = [...seen].sort();
+    return h;
+  }
   // The announce inventory carries a URI and nothing else. Counting its
   // zeroed heartbeat fields would manufacture a clean bill of health.
   if (!healthKnown) return h;

--- a/controlplane/admin/ui/src/pages/TrinoCluster.tsx
+++ b/controlplane/admin/ui/src/pages/TrinoCluster.tsx
@@ -24,7 +24,14 @@ export function TrinoCluster() {
   const orgs = useTrinoOrgs();
   const orgLabels = useOrgLabels();
 
-  const nodeHealth = useMemo(() => summarizeTrinoNodes(nodes.data?.nodes ?? []), [nodes.data]);
+  // The nodes payload names its own inventory; status carries it too for
+  // the case where only the summary has loaded.
+  const nodeSource = nodes.data?.source ?? status.data?.node_source;
+  const announcedOnly = nodeSource === "announce";
+  const nodeHealth = useMemo(
+    () => summarizeTrinoNodes(nodes.data?.nodes ?? [], nodeSource),
+    [nodes.data, nodeSource],
+  );
   const orgRows = useMemo(() => orgs.data?.orgs ?? [], [orgs.data]);
   const needAttention = useMemo(() => trinoOrgsNeedingAttention(orgRows), [orgRows]);
   const reason = trinoUnavailableReason(status.data);
@@ -75,11 +82,21 @@ export function TrinoCluster() {
             label="Nodes"
             value={fmtInt(nodeHealth.total)}
             hint={
-              nodeHealth.failed > 0 || nodeHealth.degraded > 0
-                ? `${nodeHealth.failed} failed · ${nodeHealth.degraded} degraded`
-                : "all healthy"
+              !nodeHealth.healthKnown
+                ? "membership only"
+                : nodeHealth.failed > 0 || nodeHealth.degraded > 0
+                  ? `${nodeHealth.failed} failed · ${nodeHealth.degraded} degraded`
+                  : "all healthy"
             }
-            accent={nodeHealth.failed > 0 ? "destructive" : nodeHealth.degraded > 0 ? "warning" : "success"}
+            accent={
+              !nodeHealth.healthKnown
+                ? undefined
+                : nodeHealth.failed > 0
+                  ? "destructive"
+                  : nodeHealth.degraded > 0
+                    ? "warning"
+                    : "success"
+            }
             icon={<Network className="h-4 w-4" />}
           />
           <StatCard
@@ -180,20 +197,50 @@ export function TrinoCluster() {
           </CardHeader>
           <CardContent>
             {nodes.isLoading ? (
-              <TableSkeleton cols={5} />
+              <TableSkeleton cols={announcedOnly ? 1 : 5} />
             ) : status.data && !status.data.node_stats ? (
-              // Not the same as an empty fleet. Trino serves /v1/node only
-              // under discovery.type=AIRLIFT_DISCOVERY, and a cell on the
-              // default ANNOUNCE has no such endpoint to answer with.
+              // Not the same as an empty fleet: this cell serves neither
+              // /v1/node nor /v1/announce, so it cannot name its workers.
               <EmptyState
                 title="Nodes are not reported by this cell"
-                description="This coordinator does not serve /v1/node. Trino registers that endpoint only under discovery.type=AIRLIFT_DISCOVERY, and this cell uses the default. The cell is healthy; its fleet is simply not visible here."
+                description="This coordinator serves neither /v1/node nor /v1/announce, so its fleet cannot be listed. The cell is healthy; its membership is simply not visible here."
               />
             ) : (nodes.data?.nodes ?? []).length === 0 ? (
               <EmptyState
                 title="No nodes reported"
-                description="The coordinator's failure detector has not reported any peers."
+                description={
+                  announcedOnly
+                    ? "No worker has announced itself to this coordinator."
+                    : "The coordinator's failure detector has not reported any peers."
+                }
               />
+            ) : announcedOnly ? (
+              // Membership without health. The heartbeat columns are absent
+              // rather than zero-filled: a rendered "healthy" badge here
+              // would be the console's own invention, not the cell's report.
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Node</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(nodes.data?.nodes ?? []).map((n) => (
+                      <TableRow key={n.uri}>
+                        <TableCell className="font-mono text-xs">{n.uri}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <p className="mt-3 text-[11px] text-muted-foreground">
+                  Membership from <code>/v1/announce</code>, which is what this cell serves under
+                  Trino&apos;s default <code>discovery.type=ANNOUNCE</code>. It lists the workers
+                  that have announced themselves and reports no per-node health; heartbeat
+                  detail needs <code>discovery.type=AIRLIFT_DISCOVERY</code>. Node liveness is
+                  visible on the Pods view.
+                </p>
+              </>
             ) : (
               <>
                 <Table>

--- a/controlplane/admin/ui/src/pages/TrinoCluster.tsx
+++ b/controlplane/admin/ui/src/pages/TrinoCluster.tsx
@@ -12,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { useOrgLabels, useTrinoNodes, useTrinoOrgs, useTrinoStatus } from "@/hooks/useApi";
 import { fmtDurationMs, fmtInt, fmtPercent, fmtTime } from "@/lib/format";
 import {
+  TRINO_ACTIVE_NODE_STATE,
   summarizeTrinoNodes,
   trinoOrgsNeedingAttention,
   trinoUnavailableMessage,
@@ -28,6 +29,7 @@ export function TrinoCluster() {
   // the case where only the summary has loaded.
   const nodeSource = nodes.data?.source ?? status.data?.node_source;
   const announcedOnly = nodeSource === "announce";
+  const fromSystemTable = nodeSource === "system_table";
   const nodeHealth = useMemo(
     () => summarizeTrinoNodes(nodes.data?.nodes ?? [], nodeSource),
     [nodes.data, nodeSource],
@@ -82,20 +84,32 @@ export function TrinoCluster() {
             label="Nodes"
             value={fmtInt(nodeHealth.total)}
             hint={
-              !nodeHealth.healthKnown
-                ? "membership only"
-                : nodeHealth.failed > 0 || nodeHealth.degraded > 0
-                  ? `${nodeHealth.failed} failed · ${nodeHealth.degraded} degraded`
-                  : "all healthy"
+              nodeHealth.detailKnown
+                ? // More than one version means a rollout is in flight, or
+                  // stuck. That is the thing to surface, ahead of the count.
+                  nodeHealth.versions.length > 1
+                  ? `version skew: ${nodeHealth.versions.join(" · ")}`
+                  : nodeHealth.inactive > 0
+                    ? `${nodeHealth.inactive} not active`
+                    : `all active${nodeHealth.versions[0] ? ` · ${nodeHealth.versions[0]}` : ""}`
+                : !nodeHealth.healthKnown
+                  ? "membership only"
+                  : nodeHealth.failed > 0 || nodeHealth.degraded > 0
+                    ? `${nodeHealth.failed} failed · ${nodeHealth.degraded} degraded`
+                    : "all healthy"
             }
             accent={
-              !nodeHealth.healthKnown
-                ? undefined
-                : nodeHealth.failed > 0
-                  ? "destructive"
-                  : nodeHealth.degraded > 0
-                    ? "warning"
-                    : "success"
+              nodeHealth.detailKnown
+                ? nodeHealth.versions.length > 1 || nodeHealth.inactive > 0
+                  ? "warning"
+                  : "success"
+                : !nodeHealth.healthKnown
+                  ? undefined
+                  : nodeHealth.failed > 0
+                    ? "destructive"
+                    : nodeHealth.degraded > 0
+                      ? "warning"
+                      : "success"
             }
             icon={<Network className="h-4 w-4" />}
           />
@@ -214,6 +228,51 @@ export function TrinoCluster() {
                     : "The coordinator's failure detector has not reported any peers."
                 }
               />
+            ) : fromSystemTable ? (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Node</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>Version</TableHead>
+                      <TableHead>State</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(nodes.data?.nodes ?? []).map((n) => (
+                      <TableRow key={n.node_id ?? n.uri}>
+                        <TableCell className="font-mono text-xs">{n.uri}</TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {n.coordinator ? "coordinator" : "worker"}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {/* Highlighted during skew: two versions here is a
+                              rollout in progress, or one that stalled. */}
+                          {nodeHealth.versions.length > 1 ? (
+                            <Badge variant="warning">{n.version}</Badge>
+                          ) : (
+                            (n.version ?? "—")
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {n.state === TRINO_ACTIVE_NODE_STATE ? (
+                            <Badge variant="success">{n.state}</Badge>
+                          ) : (
+                            <Badge variant="warning">{n.state ?? "unknown"}</Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <p className="mt-3 text-[11px] text-muted-foreground">
+                  From <code>system.runtime.nodes</code>, which every cell serves regardless of{" "}
+                  <code>discovery.type</code> and which is the only source carrying node version.
+                  Per-node heartbeat ratios need <code>/v1/node</code>, i.e.{" "}
+                  <code>discovery.type=AIRLIFT_DISCOVERY</code>.
+                </p>
+              </>
             ) : announcedOnly ? (
               // Membership without health. The heartbeat columns are absent
               // rather than zero-filled: a rendered "healthy" badge here

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -803,6 +803,18 @@ export interface TrinoServerInfo {
   uptime_ms: number;
 }
 
+// Which of Trino's two node inventories a list came from. They carry
+// different detail, so the source has to travel with the data:
+//   failure_detector  /v1/node, bound only under AIRLIFT_DISCOVERY. Full
+//                     heartbeat health per node.
+//   announce          /v1/announce, bound under ANNOUNCE (Trino's default,
+//                     and what these cells run) and DNS. Membership only.
+export type TrinoNodeSource = "failure_detector" | "announce";
+
+// Every field but `uri` is filled ONLY when the source is failure_detector.
+// Under announce they are zero because nothing was measured, which is not
+// the same as measured-and-zero — rendering them as health invents a claim
+// the coordinator never made.
 export interface TrinoNode {
   uri: string;
   age_ms: number;
@@ -836,11 +848,14 @@ export interface TrinoStatus {
   server?: TrinoServerInfo;
   queries_by_state: Record<string, number>;
   blocked_queries: number;
-  // node_stats=false means this cell does not report nodes at all, so nodes
-  // and failed_nodes are both zero and mean nothing. Trino serves /v1/node
-  // only under discovery.type=AIRLIFT_DISCOVERY; these cells run the default
-  // ANNOUNCE. Render "not reported" rather than zero nodes.
+  // node_stats=false means this cell serves neither node inventory, so nodes
+  // and failed_nodes are both zero and mean nothing. Render "not reported"
+  // rather than zero nodes.
   node_stats: boolean;
+  // Which inventory `nodes` was counted from. Under "announce" the cell
+  // reports membership without health, so failed_nodes is 0 because nothing
+  // is measured, not because the fleet is known to be well.
+  node_source?: TrinoNodeSource;
   nodes: number;
   failed_nodes: number;
   orgs_by_state: Record<string, number>;
@@ -856,6 +871,7 @@ export interface TrinoQueriesResponse {
 export interface TrinoNodesResponse {
   cell: TrinoCell;
   available: boolean;
+  source?: TrinoNodeSource;
   nodes: TrinoNode[];
 }
 

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -809,7 +809,10 @@ export interface TrinoServerInfo {
 //                     heartbeat health per node.
 //   announce          /v1/announce, bound under ANNOUNCE (Trino's default,
 //                     and what these cells run) and DNS. Membership only.
-export type TrinoNodeSource = "failure_detector" | "announce";
+//   system_table      system.runtime.nodes over SQL. Served by every cell
+//                     regardless of discovery.type, and the only source
+//                     carrying node_version — i.e. version skew.
+export type TrinoNodeSource = "failure_detector" | "announce" | "system_table";
 
 // Every field but `uri` is filled ONLY when the source is failure_detector.
 // Under announce they are zero because nothing was measured, which is not
@@ -823,6 +826,12 @@ export interface TrinoNode {
   recent_failure_ratio: number;
   last_response_time?: string;
   failed: boolean;
+  // Present only when the source is system_table.
+  node_id?: string;
+  version?: string;
+  coordinator?: boolean;
+  // Trino's NodeState: ACTIVE, INACTIVE, DRAINING, DRAINED, SHUTTING_DOWN.
+  state?: string;
 }
 
 export interface TrinoOrgStatus {

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -659,6 +659,69 @@ allow if {
 }
 
 # ---------------------------------------------------------------------------
+# The observer's ONE data read: system.runtime.nodes.
+#
+# Trino reports per-node health through two different surfaces, and which
+# one a cell has depends on discovery.type. The REST route /v1/node exists
+# only under AIRLIFT_DISCOVERY; these cells run the default (ANNOUNCE),
+# whose /v1/announce carries membership and nothing else. The engine still
+# knows the fleet -- it just answers through SQL here, via the `system`
+# connector's runtime.nodes table, which is also the only place worker
+# VERSION is observable (node_version), and therefore the only way the
+# console can see version skew during a rollout.
+#
+# Reading it costs the observer a catalog grant, so the grant is written as
+# narrowly as the operations allow:
+#
+#   AccessCatalog on `system` ONLY. This is necessary but nowhere near
+#   sufficient -- it opens no table by itself. Every read still has to pass
+#   SelectFromColumns, which below is pinned to one schema and one table.
+#
+#   SelectFromColumns on system.runtime.nodes ONLY. Not the `system`
+#   catalog, not the `runtime` schema: the single table.
+#
+# What the observer still CANNOT read, and why each matters:
+#
+#   system.runtime.queries       every tenant's SQL text. (It already sees
+#                                queries through the REST API, but that path
+#                                redacts and is bounded by
+#                                FilterViewQueryOwnedBy; this one would not
+#                                be, so it stays denied.)
+#   system.metadata.*            would enumerate every tenant catalog,
+#                                schema, table and column name in the cell.
+#   system.jdbc.*                same enumeration by another route.
+#   org_<tenant> catalogs        tenant data. Unchanged: these flow through
+#                                readable_catalog, which excludes the
+#                                observer group, and this rule does not
+#                                touch that path.
+#
+# system.runtime.nodes itself holds node_id, http_uri, node_version,
+# coordinator and state. No tenant identifier appears in it, so widening
+# the observer to this table exposes no customer data even in full.
+#
+# The observer is NOT admin: it cannot CREATE/DROP/ALTER any catalog, and
+# this rule grants nothing on `org_*`.
+# ---------------------------------------------------------------------------
+
+observer_nodes_table(table) if {
+	table.catalogName == "system"
+	table.schemaName == "runtime"
+	table.tableName == "nodes"
+}
+
+allow if {
+	is_observer
+	input.action.operation == "AccessCatalog"
+	input.action.resource.catalog.name == "system"
+}
+
+allow if {
+	is_observer
+	input.action.operation == "SelectFromColumns"
+	observer_nodes_table(input.action.resource.table)
+}
+
+# ---------------------------------------------------------------------------
 # Hard denies for customer principals.
 #
 # These are listed explicitly even though `default allow := false` already

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -1566,8 +1566,10 @@ func TestObserverHasNoCatalogAccess(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.op, func(t *testing.T) {
 			if evalAllow(t, q, buildInput(ObserverPrincipal, tc.op, tc.resource)) {
-				t.Errorf("%s: the observer principal must have NO catalog authority -- "+
-					"it is the read-only query-visibility half of the split credential", tc.op)
+				t.Errorf("%s: the observer principal must have NO authority over TENANT "+
+					"catalogs -- it is the read-only query-visibility half of the split "+
+					"credential. Its one data grant is system.runtime.nodes, which is "+
+					"pinned by TestObserverSystemGrantIsPinnedToTheNodesTable", tc.op)
 			}
 		})
 	}
@@ -1726,5 +1728,93 @@ func batchedQueryOwnerInput(user string, groups []string, candidates []map[strin
 			"operation":       "FilterViewQueryOwnedBy",
 			"filterResources": candidates,
 		},
+	}
+}
+
+// The observer reads the fleet from system.runtime.nodes, because a cell on
+// Trino's default discovery.type serves no /v1/node and /v1/announce carries
+// no health or version. This is the observer's only data read.
+func TestObserverReadsSystemRuntimeNodes(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	if !evalAllow(t, q, buildInput(ObserverPrincipal, "AccessCatalog", catalogResource("system"))) {
+		t.Error("observer must reach the system catalog, or the nodes query cannot be planned")
+	}
+	if !evalAllow(t, q, buildInput(ObserverPrincipal, "SelectFromColumns",
+		tableResource("system", "runtime", "nodes"))) {
+		t.Error("observer must read system.runtime.nodes -- it is the only place worker version is observable")
+	}
+}
+
+// The whole point of the grant above is that it stops at one table. Reaching
+// the system catalog must not become a way to enumerate tenants:
+// system.metadata and system.jdbc list every catalog, schema, table and
+// column in the cell, and system.runtime.queries carries tenant SQL text
+// unfiltered by FilterViewQueryOwnedBy.
+func TestObserverSystemGrantIsPinnedToTheNodesTable(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	denied := []struct {
+		schema, table, why string
+	}{
+		{"runtime", "queries", "tenant SQL text, unfiltered by query-owner visibility"},
+		{"runtime", "tasks", "per-task detail the console does not use"},
+		{"runtime", "transactions", "not needed by the console"},
+		{"metadata", "table_comments", "enumerates every tenant table"},
+		{"metadata", "catalogs", "enumerates every tenant catalog"},
+		{"jdbc", "tables", "enumerates every tenant table by another route"},
+		{"jdbc", "columns", "enumerates every tenant column"},
+		{"information_schema", "tables", "enumerates every tenant table"},
+	}
+	for _, d := range denied {
+		t.Run("system."+d.schema+"."+d.table, func(t *testing.T) {
+			if evalAllow(t, q, buildInput(ObserverPrincipal, "SelectFromColumns",
+				tableResource("system", d.schema, d.table))) {
+				t.Errorf("observer must NOT read system.%s.%s: %s", d.schema, d.table, d.why)
+			}
+		})
+	}
+
+	// A nodes table in some OTHER catalog is not the one we granted.
+	if evalAllow(t, q, buildInput(ObserverPrincipal, "SelectFromColumns",
+		tableResource("org_42", "runtime", "nodes"))) {
+		t.Error("the grant is pinned to the system catalog, not to any table named runtime.nodes")
+	}
+
+	// Reaching the catalog must not imply browsing it.
+	for _, op := range []string{"ShowSchemas", "ShowTables", "FilterTables", "FilterColumns", "ShowColumns"} {
+		t.Run(op, func(t *testing.T) {
+			if evalAllow(t, q, buildInput(ObserverPrincipal, op, tableResource("system", "metadata", "catalogs"))) {
+				t.Errorf("%s: AccessCatalog on system must not open metadata browsing", op)
+			}
+		})
+	}
+}
+
+// The grant is keyed on is_observer, so it must not leak to a tenant or to
+// the admin principal -- neither of which has any business reading it, and
+// a tenant reaching the system catalog at all would be a boundary failure.
+func TestSystemNodesGrantIsObserverOnly(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+
+	for _, user := range []string{"42", AdminPrincipal} {
+		t.Run(user, func(t *testing.T) {
+			if evalAllow(t, q, buildInput(user, "AccessCatalog", catalogResource("system"))) {
+				t.Errorf("%s must not reach the system catalog", user)
+			}
+			if evalAllow(t, q, buildInput(user, "SelectFromColumns",
+				tableResource("system", "runtime", "nodes"))) {
+				t.Errorf("%s must not read system.runtime.nodes", user)
+			}
+		})
+	}
+
+	// A caller claiming the observer group without the observer username
+	// gets nothing, same as every other observer grant.
+	in := buildInput("42", "SelectFromColumns", tableResource("system", "runtime", "nodes"))
+	in["context"].(map[string]interface{})["identity"].(map[string]interface{})["groups"] =
+		[]interface{}{ObserverGroup}
+	if evalAllow(t, q, in) {
+		t.Error("claiming the observer group without the observer username must grant nothing")
 	}
 }

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -1942,7 +1942,8 @@ func tierLimits(tier string) resourceGroupSubGroup {
 // which the file group provider DOES reload (file.refresh-period=60s), so a
 // retier takes effect within a minute and still needs no restart.
 //
-// Selector order is first-match-wins. Admin is first so its catalog DDL never
+// Selector order is first-match-wins. The two operational principals come
+// first so neither the provisioner's catalog DDL nor the console's node query
 // falls into a tenant lane, then the explicit tiers, then free as the
 // catch-all — an org with an unknown or empty tier lands in the smallest lane
 // rather than matching nothing, which would reject its queries outright.
@@ -1969,9 +1970,18 @@ func BuildTrinoResourceGroups() ([]byte, error) {
 		return l
 	}
 
+	// Both operational principals get an explicit lane BEFORE the tenant
+	// selectors. The last selector matches user `(?<org>.*)`, which matches
+	// anything, so without these the provisioner and the observer would be
+	// admitted as tenants into root.tenants.free.<principal>. Those leaves
+	// are JmxExport=true, so each would appear as a phantom tenant in the
+	// per-tenant resource-group metrics and in anything alerting off them.
 	selectors := []resourceGroupSelector{{
 		User:  opa.AdminPrincipal,
 		Group: "root.admin." + opa.AdminPrincipal,
+	}, {
+		User:  opa.ObserverPrincipal,
+		Group: "root.admin." + opa.ObserverPrincipal,
 	}}
 	for _, tier := range []string{tierScale, tierGrowth} {
 		selectors = append(selectors, resourceGroupSelector{
@@ -2000,6 +2010,16 @@ func BuildTrinoResourceGroups() ([]byte, error) {
 			SoftMemoryLimit:      "5%",
 			HardConcurrencyLimit: 4,
 			MaxQueued:            20,
+		}, {
+			// The observer runs one query: SELECT from system.runtime.nodes,
+			// on the cluster page's refresh interval. Its own small lane so a
+			// console left open cannot queue behind, or ahead of, the
+			// provisioner's catalog DDL. Unexported for the same reason the
+			// admin leaf is: it is not a tenant.
+			Name:                 opa.ObserverPrincipal,
+			SoftMemoryLimit:      "2%",
+			HardConcurrencyLimit: 2,
+			MaxQueued:            10,
 		}},
 	}
 

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -525,21 +525,44 @@ func TestBuildTrinoResourceGroups_IsStaticAndTemplated(t *testing.T) {
 		}
 	}
 
-	// Selector order is first-match-wins: admin, then the explicit tiers,
-	// then free as the catch-all so an unknown tier still matches something.
-	if len(parsed.Selectors) != 4 {
-		t.Fatalf("expected 4 selectors (admin + scale + growth + catch-all), got %+v", parsed.Selectors)
+	// Selector order is first-match-wins: the two operational principals,
+	// then the explicit tiers, then free as the catch-all so an unknown tier
+	// still matches something.
+	if len(parsed.Selectors) != 5 {
+		t.Fatalf("expected 5 selectors (admin + observer + scale + growth + catch-all), got %+v", parsed.Selectors)
 	}
 	if parsed.Selectors[0].User != opa.AdminPrincipal {
 		t.Errorf("admin selector must be first, got %+v", parsed.Selectors[0])
+	}
+	// The observer must be matched before the catch-all. That last selector
+	// is user `(?<org>.*)`, so without its own lane the console's node query
+	// would be admitted as a tenant into root.tenants.free.<observer> — a
+	// JmxExport'd leaf, i.e. a phantom tenant in the per-tenant metrics.
+	if parsed.Selectors[1].User != opa.ObserverPrincipal {
+		t.Errorf("observer selector must precede the tenant selectors, got %+v", parsed.Selectors[1])
+	}
+	if got := parsed.Selectors[1].Group; got != "root.admin."+opa.ObserverPrincipal {
+		t.Errorf("observer must land in the admin tier, not a tenant lane, got %q", got)
 	}
 	last := parsed.Selectors[len(parsed.Selectors)-1]
 	if last.UserGroup != "" || last.Group != "root.tenants.free.${org}" {
 		t.Errorf("last selector must be the untiered catch-all into free, got %+v", last)
 	}
-	for _, sel := range parsed.Selectors[1:3] {
+	for _, sel := range parsed.Selectors[2:4] {
 		if sel.UserGroup == "" {
 			t.Errorf("tier selector must match on userGroup, got %+v", sel)
+		}
+	}
+
+	// Neither operational lane may be JMX-exported: those metrics are the
+	// per-tenant series, and an operational principal is not a tenant.
+	admin := findSubGroup(t, parsed.RootGroups[0].SubGroups, "admin")
+	if len(admin.SubGroups) != 2 {
+		t.Fatalf("expected admin tier to hold both operational principals, got %+v", admin.SubGroups)
+	}
+	for _, g := range admin.SubGroups {
+		if g.JmxExport {
+			t.Errorf("operational lane %q must not be JMX-exported as a tenant", g.Name)
 		}
 	}
 }


### PR DESCRIPTION
The Trino cluster page shows **"Nodes are not reported by this cell"**. That
copy is accurate as of #1132 — but the cell *can* report its fleet, and can
report worker versions too. The console was asking at the one route this cell
does not bind.

## Trino binds one node-listing route, chosen by `discovery.type`

| `discovery.type` | route | detail |
|---|---|---|
| `AIRLIFT_DISCOVERY` | `/v1/node` (+ `/v1/node/failed`) | per-node heartbeat health |
| `ANNOUNCE` *(Trino's default, what these cells run)* | `/v1/announce` | set of announced node URIs |
| `DNS` | `/v1/announce` | same |

`system.runtime.nodes` is served by **every** cell regardless of
`discovery.type`, and is the only source carrying `node_version`. New order:

```
/v1/node  →  system.runtime.nodes  →  /v1/announce
```

Membership is kept as the last resort, so a cell whose grant hasn't rolled
out yet still lists a fleet instead of showing nothing.

## The grant, and what stays denied

This widens the observer, so it is written as narrowly as the OPA operations
allow: `AccessCatalog` on `system`, and `SelectFromColumns` pinned to that
**one table**. `AccessCatalog` opens nothing by itself — every read still
passes `SelectFromColumns`.

| stays denied | why it matters |
|---|---|
| `system.runtime.queries` | tenant SQL text, unfiltered by query-owner visibility |
| `system.metadata.*` | enumerates every tenant catalog/schema/table/column |
| `system.jdbc.*` | the same enumeration by another route |
| `org_<tenant>` | unchanged — `readable_catalog` still excludes the observer group |

`TestObserverSystemGrantIsPinnedToTheNodesTable` pins each denial (including a
`runtime.nodes` in another catalog, and metadata browsing on `system`);
`TestSystemNodesGrantIsObserverOnly` pins that no tenant and not the admin
gets it, and that claiming the observer group without the observer username
still grants nothing. `system.runtime.nodes` holds `node_id`, `http_uri`,
`node_version`, `coordinator`, `state` — **no tenant identifier**, so the
grant exposes no customer data even read in full.

## Resource groups

The observer needed its own lane. The last selector is user `(?<org>.*)`,
which matches anything, so without one the console's query lands in
`root.tenants.free.__duckgres_observer` — and those leaves are
`JmxExport: true`, so it would appear as a **phantom tenant** in the
per-tenant metrics from #1124. Both operational principals now select into
the unexported admin tier ahead of the tenant selectors.

## UI

Role / Version / State columns, and the Nodes card leads with **version skew**
when more than one version is present — a stalled rollout is the case worth
seeing first. `HasHealth()` stays false for this source: it carries lifecycle
state, not heartbeat ratios, and conflating them would put a health badge on
a number nothing measured.

## Verification

- `./controlplane/provisioner/...` and `./controlplane/provisioner/opa/...` green
- Trino suites in `./controlplane/admin/` green (the `*Postgres` failures are a
  stale local schema, unrelated and pre-existing)
- `golangci-lint` — 0 issues attributable to this change
- `tsc -b --noEmit`, `eslint` clean; vitest **166/166** (up from 160)
- new tests: fallback ordering (`/v1/announce` not queried when the system
  table answers, and not queried when `/v1/node` answers), nextUri draining,
  denied-grant falls back rather than failing the read, coordinator-first
  sort, version/state decoding, and the full policy deny matrix
