### PR TITLE
Wait, don't fail, when a tenant's password file hasn't been mounted yet

### DIFF
--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -1465,6 +1465,17 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 		}
 		props := p.buildCatalogProperties(o.OrgID, warehouse, duckling)
 		if err := p.catalog.CreateCatalog(ctx, name, props); err != nil {
+			if p.tenantSecretNotMountedYet(err, o.OrgID) {
+				// Not a failure: the Secret key is projected (checked
+				// above) and the pods just have not seen it yet.
+				slog.Info("Trino reconcile: tenant password file not visible in the Trino pods yet, retrying next tick.",
+					"org", o.OrgID, "catalog", name)
+				outcomes[o.OrgID] = catalogOutcome{
+					Pending:       true,
+					PendingReason: "waiting for the tenant password file to appear in the Trino pods",
+				}
+				continue
+			}
 			perOrgErr := fmt.Errorf("create catalog %s: %w", name, err)
 			errs = append(errs, perOrgErr)
 			outcomes[o.OrgID] = catalogOutcome{Err: perOrgErr}
@@ -1573,17 +1584,55 @@ func (p *TrinoProvisioner) buildCatalogProperties(orgID string, w *configstore.M
 		region = p.awsRegion
 	}
 	return map[string]string{
-		"connector.name":                             "ducklake",
-		"ducklake.metadata.connection-url":           ducklakeMetadataJDBCURL(d),
-		"ducklake.metadata.connection-user":          d.MetadataStore.User,
-		"ducklake.metadata.connection-password-file": p.tenantPasswordFilePath(orgID),
-		"ducklake.data-path":                         ducklakeDataPath(d.DataStore.BucketName, w.S3.PathPrefix),
-		"fs.s3.enabled":                              "true",
-		"s3.region":                                  region,
-		"s3.auth-type":                               "IAM_ROLE",
-		"s3.iam-role":                                d.IAMRoleARN,
-		"s3.max-connections":                         strconv.Itoa(p.s3MaxConnections),
+		"connector.name":                    "ducklake",
+		"ducklake.metadata.connection-url":  ducklakeMetadataJDBCURL(d),
+		"ducklake.metadata.connection-user": d.MetadataStore.User,
+		trinoDuckLakePasswordFileProperty:   p.tenantPasswordFilePath(orgID),
+		"ducklake.data-path":                ducklakeDataPath(d.DataStore.BucketName, w.S3.PathPrefix),
+		"fs.s3.enabled":                     "true",
+		"s3.region":                         region,
+		"s3.auth-type":                      "IAM_ROLE",
+		"s3.iam-role":                       d.IAMRoleARN,
+		"s3.max-connections":                strconv.Itoa(p.s3MaxConnections),
 	}
+}
+
+// trinoDuckLakePasswordFileProperty is the DuckLake catalog property naming
+// the in-pod file that holds one tenant's metadata-store password.
+const trinoDuckLakePasswordFileProperty = "ducklake.metadata.connection-password-file"
+
+// tenantSecretNotMountedYet reports whether err is Trino refusing the catalog
+// because this org's password file is not visible inside the Trino pods yet.
+//
+// This is the ordinary onboarding race, not a failure. The provisioner writes
+// the org's key onto the tenant Secret and creates the catalog in the same
+// tick, but the pods read that Secret through a mounted volume, and the
+// kubelet refreshes it on its own sync period — up to a minute or so later.
+// For that window Trino rejects the catalog because the file genuinely is not
+// there, and the next tick succeeds unaided (verified in prod: the org went
+// Ready on its own once the mount caught up).
+//
+// Treating it as a failure is actively misleading: it stamps failed_at and
+// parks a Trino configuration error in status_message for an org that is
+// merely a few seconds early, which is noise for anything watching Trino org
+// state. Reporting Pending says the true thing — still converging.
+//
+// The match is deliberately the single exact sentence Trino emits, built from
+// our own property name and our own computed path, rather than a set of loose
+// substrings. Catalog properties carry tenant-influenced values (bucket names,
+// endpoints) that Trino echoes back in configuration errors, so a loose match
+// could be tripped by an org's own data — the same trap
+// isInstanceFatalError documents for DuckDB's echoed query text. If Trino ever
+// rewords this, the match simply stops firing and the org fails loudly again,
+// which is the pre-existing behavior rather than a new silent state.
+func (p *TrinoProvisioner) tenantSecretNotMountedYet(err error, orgID string) bool {
+	var stmtErr *TrinoStatementError
+	if !errors.As(err, &stmtErr) {
+		return false
+	}
+	return strings.Contains(stmtErr.Message, fmt.Sprintf(
+		"Invalid configuration property %s: file does not exist: %s",
+		trinoDuckLakePasswordFileProperty, p.tenantPasswordFilePath(orgID)))
 }
 
 // tenantPasswordFilePath is the in-pod path of one org's metadata-store
@@ -2353,6 +2402,22 @@ type trinoStatementErrorBody struct {
 	ErrorType string `json:"errorType"`
 }
 
+// TrinoStatementError is a statement the coordinator rejected, carrying
+// Trino's own error classification instead of flattening it into a string.
+//
+// It exists so callers can branch on WHAT Trino objected to rather than
+// grepping a wrapped error chain. Error() reproduces the previous flattened
+// text verbatim, so logs and status messages are unchanged.
+type TrinoStatementError struct {
+	ErrorName string
+	ErrorType string
+	Message   string
+}
+
+func (e *TrinoStatementError) Error() string {
+	return fmt.Sprintf("trino: %s (%s): %s", e.ErrorName, e.ErrorType, e.Message)
+}
+
 // runStatement executes a single Trino statement via /v1/statement and
 // drains the nextUri chain. Returns the accumulated data rows (may be
 // empty for DDL).
@@ -2403,7 +2468,11 @@ func (c *trinoCatalogHTTPClient) drainStatement(ctx context.Context, initial []b
 			return nil, fmt.Errorf("parse statement response: %w (body=%q)", err, string(body))
 		}
 		if r.Error != nil {
-			return nil, fmt.Errorf("trino: %s (%s): %s", r.Error.ErrorName, r.Error.ErrorType, r.Error.Message)
+			return nil, &TrinoStatementError{
+				ErrorName: r.Error.ErrorName,
+				ErrorType: r.Error.ErrorType,
+				Message:   r.Error.Message,
+			}
 		}
 		all = append(all, r.Data...)
 		if r.NextURI == "" {

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -1378,6 +1378,111 @@ func TestReconcile_StateTransitions(t *testing.T) {
 	}
 }
 
+// --- tenant secret mount lag ---
+
+// trinoSecretMountLagError reproduces what the coordinator actually returned in
+// production when a catalog was created in the same tick that projected the
+// org's key onto the tenant Secret, before the kubelet refreshed the mount.
+func trinoSecretMountLagError(orgID string) error {
+	return &TrinoStatementError{
+		ErrorName: "GENERIC_INTERNAL_ERROR",
+		ErrorType: "INTERNAL_ERROR",
+		Message: "Configuration errors:\n\n1) Error: Invalid configuration property " +
+			trinoDuckLakePasswordFileProperty + ": file does not exist: " +
+			DefaultTrinoTenantSecretMountPath + "/" + orgID +
+			" (for class DuckLakeConfig.connectionPasswordFile)\n\n1 error\n",
+	}
+}
+
+// A freshly onboarded org races the kubelet's Secret refresh. That window is a
+// wait, not a failure: before this the org was stamped Failed with a Trino
+// configuration error in status_message, then flipped to Ready seconds later.
+func TestReconcile_TenantSecretMountLagIsPendingNotFailed(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "42", DatabaseName: "db42", CellID: testCellID, RootPasswordHash: "$2a$10$h", Tier: "free"},
+	}
+	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"42": readyWarehouse("42")})
+	h.catalog.createErr = trinoSecretMountLagError("42")
+
+	// The tick itself must report success — otherwise the reconcile loop logs
+	// "Trino provisioner reconcile failed" for a routine onboarding.
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: a mount-lag race must not fail the tick: %v", err)
+	}
+	st, ok := h.store.lastState("42")
+	if !ok {
+		t.Fatalf("no state written for 42")
+	}
+	if st.State != configstore.ManagedWarehouseStateProvisioning {
+		t.Errorf("state = %q, want provisioning (msg=%q)", st.State, st.StatusMessage)
+	}
+	if !strings.Contains(st.StatusMessage, "tenant password file") {
+		t.Errorf("status_message = %q, want the mount-lag reason", st.StatusMessage)
+	}
+	if st.FailedAt != nil && !st.FailedAt.IsZero() {
+		t.Errorf("a mount-lag race must not stamp failed_at, got %v", st.FailedAt)
+	}
+
+	// Next tick, once the kubelet has caught up: converges unaided.
+	h.catalog.createErr = nil
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile (after the mount catches up): %v", err)
+	}
+	if st, _ := h.store.lastState("42"); st.State != configstore.ManagedWarehouseStateReady {
+		t.Errorf("state = %q, want ready once the password file exists", st.State)
+	}
+}
+
+// The classifier decides whether a real failure gets silently downgraded to
+// "still waiting", so it must match ONLY this org's missing password file.
+// Catalog properties carry tenant-influenced values that Trino echoes back in
+// configuration errors, which is exactly how a loose substring match would
+// misfire.
+func TestTenantSecretNotMountedYetOnlyMatchesThisOrgsMissingPasswordFile(t *testing.T) {
+	h := newTestTrinoProvisioner(t, nil, nil)
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"the production mount-lag error", trinoSecretMountLagError("42"), true},
+		{"another org's password file", trinoSecretMountLagError("43"), false},
+		{
+			"a different property missing a different file",
+			&TrinoStatementError{
+				ErrorName: "GENERIC_INTERNAL_ERROR",
+				Message: "Invalid configuration property ducklake.metadata.connection-url: " +
+					"file does not exist: /etc/trino/somewhere-else",
+			},
+			false,
+		},
+		{
+			"tenant data echoed back inside an unrelated config error",
+			&TrinoStatementError{
+				ErrorName: "GENERIC_INTERNAL_ERROR",
+				Message: `Invalid configuration property ducklake.data-path: cannot read bucket ` +
+					`"file does not exist: ` + DefaultTrinoTenantSecretMountPath + `/42"`,
+			},
+			false,
+		},
+		{
+			"the same text as an untyped error",
+			errors.New(trinoSecretMountLagError("42").Error()),
+			false,
+		},
+		{"an unrelated coordinator failure", errors.New("trino: 503 service unavailable"), false},
+		{"no error at all", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := h.provisioner.tenantSecretNotMountedYet(tc.err, "42"); got != tc.want {
+				t.Errorf("tenantSecretNotMountedYet = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // --- cell awareness ---
 
 func TestReconcile_ClaimsUnassignedOrgsIntoThisCell(t *testing.T) {


### PR DESCRIPTION
## What

Enabling Trino for an org projects its password onto the tenant Secret and creates the catalog **in the same reconcile tick**. The Trino pods read that Secret through a mounted volume, so for up to a kubelet sync period the file the catalog points at genuinely does not exist yet, and the coordinator rejects `CREATE CATALOG`:

```
Invalid configuration property ducklake.metadata.connection-password-file:
file does not exist: /etc/trino/tenant-secrets/<org>
```

That window was reported as a **failure**: the org was stamped `Failed` with `failed_at` set and a Trino configuration error parked in `status_message`, and the tick logged `Trino provisioner reconcile failed` — for an org that goes `Ready` on its own about a minute later, unaided.

This classifies that one case as `Pending` with a reason, which is what the reconcile loop already does for every other "not ready yet" input (`org has no managed warehouse row yet`, `waiting for the duckling to publish a metadata-store credential`).

## Why now

Observed in production while enabling an org by hand. It matters more from here on: PostHog/posthog#91098 opts **every** newly onboarded org into a cell, so this stops being a rare manual path and becomes what onboarding normally does. Without this, routine onboarding writes a spurious `Failed` state and a WARN every time.

## Why the match is narrow

Getting this wrong in the other direction would silently downgrade a real failure to "still waiting", so:

- Trino's statement error is now a typed `*TrinoStatementError` carrying `errorName`/`errorType`/`message`, instead of being flattened into a string at the point of creation. The classifier uses `errors.As`, so **the type is authoritative** — the same principle `isInstanceFatalError` follows for DuckDB.
- Within that, it matches the **single exact sentence** Trino emits, built from our own property name and our own computed path for *this* org — not a set of loose substrings.

That last point is deliberate. Catalog properties carry tenant-influenced values (bucket names, endpoints) that Trino echoes back in configuration errors, so a loose match could be tripped by an org's own data — the trap CLAUDE.md already documents for DuckDB echoing query text back into `INTERNAL Error` messages. There's a test for exactly that shape.

If Trino ever rewords the message, the match stops firing and the org fails loudly again — today's behavior, not a new silent state.

`TrinoStatementError.Error()` reproduces the previous flattened text verbatim, so logs and status messages are otherwise unchanged.

## Tests

`go test -tags kubernetes ./controlplane/provisioner/...` — green.

- `TestReconcile_TenantSecretMountLagIsPendingNotFailed` — reproduces the production error verbatim. Asserts the tick returns **no error at all** (so the loop doesn't log a failure), the org is `Provisioning` with the mount-lag reason, `failed_at` is **not** stamped, and it converges to `Ready` on the next tick once the file appears.
- `TestTenantSecretNotMountedYetOnlyMatchesThisOrgsMissingPasswordFile` — the guard rail. Another org's password file, a different property missing a different file, tenant data echoed back inside an unrelated config error, the same text as an *untyped* error, an unrelated 503, and nil all stay failures.

No `tests/e2e-mw-dev/` change: this touches Trino catalog reconcile classification, none of the activation-pipeline paths CLAUDE.md lists as obligating harness updates, and adds no columns.

Pre-existing on `origin/main` and unrelated to this change: three `controlplane/admin` Postgres tests fail locally against a stale local schema (`column "max_hot_idle_workers" ... does not exist`). Verified by stashing this branch and re-running on a clean tree.
