### PR TITLE
Add parallel Trino E2E coverage

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -30,7 +30,8 @@
 # Required repo configuration (one-time, see tests/mw-dev/README.md):
 #   vars:    TS_WIF_CLIENT_ID_MW_DEV, TS_WIF_AUDIENCE_MW_DEV
 #   secrets: AWS_ECR_PUBLISH_IAM_ROLE (already exists, used by CD),
-#            MW_DEV_ACCOUNT_ID (mw-dev AWS account id; ARNs built from it)
+#            MW_DEV_ACCOUNT_ID (mw-dev AWS account id; ARNs built from it),
+#            MW_DEV_TRINO_POD_IDENTITY_ROLE (full ARN; kept out of public git)
 #   IAM:     github-duckgres-e2e role in the mw-dev account (posthog-cloud-infra)
 #            — stripped down, NOT the account-admin terraform-infra role.
 #   Repo setting: "Require approval for all outside collaborators".
@@ -106,14 +107,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: full
+          - suite: neutral
             lane_prefix: "1"
-          - suite: reshard
+          - suite: duckdb
             lane_prefix: "2"
+          - suite: trino
+            lane_prefix: "3"
+          - suite: reshard
+            lane_prefix: "4"
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 40
     env:
-      # Partition both lanes so no lane can collide with a real PR number.
+      # Partition all lanes so no lane can collide with a real PR number.
       # workflow_dispatch has no pull_request payload, so it uses run_id.
       PR_NUMBER: ${{ format('{0}{1}', matrix.lane_prefix, github.event.pull_request.number || github.run_id) }}
       NAMESPACE: duckgres-ci-pr-${{ format('{0}{1}', matrix.lane_prefix, github.event.pull_request.number || github.run_id) }}
@@ -130,6 +135,13 @@ jobs:
       # injection. Built from the account-id secret (no account id committed) +
       # the non-sensitive role name.
       CP_POD_IDENTITY_ROLE: arn:aws:iam::${{ secrets.MW_DEV_ACCOUNT_ID }}:role/duckgres-control-plane-dev
+      # Trino assumes each Duckling role directly. Keep this as a dedicated
+      # secret so no account id or internal role ARN lands in this public repo.
+      # Only the trino matrix cell consumes it.
+      TRINO_POD_IDENTITY_ROLE: ${{ secrets.MW_DEV_TRINO_POD_IDENTITY_ROLE }}
+      # Pinned PostHog fork: it contains the DuckLake connector and the
+      # PostgreSQL-backed dynamic catalog store used by managed warehouse.
+      TRINO_IMAGE: ghcr.io/posthog/trino:4505364c570d6b51edecd299b603fca4b6693d86@sha256:ac80c275fd18a439d25da5652ab5cd3c80bcbdd2d88d64c9722dc3e8bb68ba07
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -146,7 +158,8 @@ jobs:
         with:
           # Dedicated, stripped-down e2e role (NOT the account-admin
           # terraform-infra role): eks:DescribeCluster + Pod Identity
-          # association calls + iam:PassRole on the CP role, plus an EKS access
+          # association calls + iam:PassRole on the CP and dedicated Trino
+          # roles, plus an EKS access
           # entry for the kubectl it needs. Defined in posthog-cloud-infra
           # (mw-dev account). Account id comes from a repo secret so no AWS
           # account id is committed; the role name is not sensitive.
@@ -217,10 +230,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: full
+          - suite: neutral
             lane_prefix: "1"
-          - suite: reshard
+          - suite: duckdb
             lane_prefix: "2"
+          - suite: trino
+            lane_prefix: "3"
+          - suite: reshard
+            lane_prefix: "4"
     env:
       PR_NUMBER: ${{ format('{0}{1}', matrix.lane_prefix, github.event.pull_request.number || github.run_id) }}
       NAMESPACE: duckgres-ci-pr-${{ format('{0}{1}', matrix.lane_prefix, github.event.pull_request.number || github.run_id) }}

--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -150,7 +150,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The matrix value configures deployment, but these structural tests
+      # exercise every suite and must not inherit one lane's selection.
       - name: Test e2e harness scripts
+        env:
+          E2E_SUITE: neutral
         run: go test -count=1 ./tests/mw-dev
 
       - name: Configure AWS credentials (OIDC)

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -16,11 +16,12 @@ cnpg-shard metadata stores.
    Postgres + a control-plane Deployment on the test image, spawning worker pods
    in the same namespace.
 4. **Test** via an in-cluster payload Job hitting the CP ClusterIP service.
-   The PR workflow runs `E2E_SUITE=full` and `E2E_SUITE=reshard` as parallel
-   matrix lanes. The reshard lane starts its target-discovery, validation,
-   cancellation, and rollback checks immediately after provisioning; the full
-   lane runs the remaining behavioral suite. The lanes use partitioned numeric
-   identities `1<base>` and `2<base>`, where `base` is the PR number or the
+   The PR workflow runs four parallel matrix lanes: `neutral`, `duckdb`,
+   `trino`, and `reshard`. Control-plane/provisioning/admin checks live only in
+   `neutral`; DuckDB/PGWire and Trino each exercise their own query contract,
+   and the focused reshard lane retains its target-discovery, validation,
+   cancellation, and rollback coverage. The lanes use partitioned numeric
+   identities `1<base>` through `4<base>`, where `base` is the PR number or the
    workflow run ID for a manual invocation. Their namespaces, Ducklings,
    metadata roles, and teardown are therefore isolated while still matching
    the CI RBAC allowlist. Each matrix cell is visible separately, while the
@@ -55,6 +56,45 @@ The isolated control plane's default worker request is configurable through
 `1536Mi`, respectively, preserving the e2e harness's worker-packing behavior.
 `scenario-dev.yml` explicitly overrides them to 2 CPU and 8Gi for the frozen
 perf workload. Direct `run.sh` callers can make the same explicit override.
+
+## Isolated Trino lane
+
+The Trino lane never uses the shared mw-dev Trino namespace or coordinator.
+It deploys one coordinator, one worker, and an OPA sidecar in the lane's
+`duckgres-ci-pr-<N>` namespace. The control plane projects fixed-name auth,
+tenant-secret, OPA-token, and resource-group objects into that same namespace;
+its cell id and PostgreSQL catalog store are also PR-local. This isolation is
+load-bearing: pointing a PR control plane at the shared cell could overwrite
+authoritative projections or drop catalogs absent from the PR's config store.
+
+The lane defaults `TRINO_IMAGE` to the pinned PostHog fork used when this suite
+was added. That fork contains the DuckLake connector and PostgreSQL dynamic
+catalog store; upstream `trinodb/trino` is not compatible. Update the default
+in `run.sh` and `e2e-mw-dev.yml` together when promoting a Trino build.
+`TRINO_TLS_PASSWORD` defaults to `duckgres-e2e-keystore`; it protects only the
+random, two-day, per-run PKCS12 file. `run.sh` generates a fresh CA and leaf
+certificate under `DUCKGRES_CI_SECRET_DIR`, mounts the CA into the PR control
+plane through `SSL_CERT_FILE`, and uses verified HTTPS for provisioning and
+tenant password authentication.
+
+Repository setup requires the `MW_DEV_TRINO_POD_IDENTITY_ROLE` Actions secret.
+The `github-duckgres-e2e` role must be able to pass that role and create/list/
+delete EKS Pod Identity associations. Deploy creates a second association for
+the PR-local `trino` ServiceAccount before scaling Trino above zero replicas;
+teardown and the six-hour cleanup sweep delete all associations in the PR
+namespace.
+
+Failure recovery:
+
+1. Inspect `run.sh diagnostics` output for the control plane, coordinator,
+   worker, and OPA logs. Auth/catalog failures usually mean a missing projected
+   Secret/ConfigMap; S3 failures usually mean Trino Pod Identity was not
+   injected at pod admission.
+2. Re-run the workflow. Deploy first deletes the prior namespace, Ducklings,
+   CNPG roles/databases, and namespace Pod Identity associations.
+3. If a canceled run survives, invoke the scheduled `e2e-cleanup` workflow or
+   run `tests/mw-dev/run.sh e2e-cleanup` with the documented cluster access.
+   Never redirect a PR control plane to the shared Trino cell as a workaround.
 
 A scheduled (`cron`) **e2e-cleanup** job (`run.sh e2e-cleanup`) runs every 6h and
 reaps any `duckgres-ci-pr-*` namespace older than 6h — a backstop for runs that
@@ -390,8 +430,9 @@ finalizers are still running.
 | var | `TS_WIF_CLIENT_ID_MW_DEV` | Tailscale OAuth WIF client (mirror of hogland's) |
 | var | `TS_WIF_AUDIENCE_MW_DEV` | Tailscale WIF audience |
 | secret | `MW_DEV_ACCOUNT_ID` | mw-dev AWS account id (kept out of committed code; ARNs are built from it) |
+| secret | `MW_DEV_TRINO_POD_IDENTITY_ROLE` | full ARN of the dedicated mw-dev Trino Pod Identity role (consumed only by the Trino lane) |
 | secret | `AWS_ECR_PUBLISH_IAM_ROLE` | ECR push (already exists; used by CD) |
-| (role) | `github-duckgres-e2e` | dedicated stripped role in the mw-dev account (posthog-cloud-infra) — `eks:DescribeCluster` + Pod Identity association calls + `iam:PassRole`/`iam:GetRole` on the CP role + an EKS access entry for kubectl. The workflow assumes `arn:aws:iam::<MW_DEV_ACCOUNT_ID>:role/github-duckgres-e2e`. |
+| (role) | `github-duckgres-e2e` | dedicated stripped role in the mw-dev account (posthog-cloud-infra) — `eks:DescribeCluster` + Pod Identity association calls + `iam:PassRole`/`iam:GetRole` on the CP and dedicated Trino roles + an EKS access entry for kubectl. The workflow assumes `arn:aws:iam::<MW_DEV_ACCOUNT_ID>:role/github-duckgres-e2e`. |
 | repo setting | "Require approval for all outside collaborators" | the access gate (see below) |
 
 The `scenario-dev` workflow requests a 16,200-second session from
@@ -453,8 +494,9 @@ id committed).
 
 - **`github-duckgres-e2e` role (posthog-cloud-infra).** AWS policy:
   `eks:DescribeCluster`, `eks:{Create,List,Delete,Describe}PodIdentityAssociation`
-  on the cluster + its associations, and `iam:PassRole` on
-  `duckgres-control-plane-dev`. Trust: `repo:PostHog/duckgres:*`. Plus an EKS
+  on the cluster + its associations, and `iam:PassRole` on both
+  `duckgres-control-plane-dev` and the dedicated role referenced by
+  `MW_DEV_TRINO_POD_IDENTITY_ROLE`. Trust: `repo:PostHog/duckgres:*`. Plus an EKS
   **access entry** binding the role to k8s RBAC that can create namespaces, the
   cross-namespace bindings, and the in-namespace resources (the kubectl the
   harness runs). Scope as tightly as the cluster admins allow — deliberately

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -505,6 +505,12 @@ id committed).
   failed auths (~15 min). The harness uses the provision-time password and
   settles one config-poll interval before connecting — keep it that way; a
   reset-password + tight retry loop will trip the ban.
+- **Trino password rotation is eventually consistent.** The Trino lane allows
+  up to 180 seconds for the control-plane reconcile, kubelet Secret-volume
+  projection, and Trino's password-file reload. If it times out, inspect the
+  control-plane reconcile and coordinator logs before rerunning; repeated
+  immediate authentication attempts do not make the mounted Secret refresh
+  faster.
 - **Teardown / recreate are now CR-synchronous.** `run.sh deploy`, `run.sh
   teardown`, and the in-harness same-org recreate all `kubectl wait --for=delete`
   on the Duckling CR, whose finalizers run the Crossplane DROP of the cnpg
@@ -519,11 +525,14 @@ id committed).
 - **Shared-infra contention.** Concurrent PRs provision real ducklings against
   the same cnpg-shards infra. Org-ID prefix keeps them
   distinct; watch quay.io / cnpg pooler limits under parallelism.
-- **Parallel-lane recovery.** The `full` and `reshard` jobs have matching
-  teardown matrix entries and `fail-fast: false`, so one lane failing does not
-  cancel the other or skip its cleanup. A cancelled workflow can still strand a
+- **Parallel-lane recovery.** Every matrix lane has a matching teardown entry
+  and `fail-fast: false`, so one lane failing does not cancel the others or skip
+  their cleanup. A cancelled workflow can still strand a
   lane temporarily; rerunning reaps that lane identity before deploy, and the
-  scheduled `e2e-cleanup` sweep remains the final backstop.
+  scheduled `e2e-cleanup` sweep remains the final backstop. Reshard status polls
+  bound each API attempt to 15 seconds and retry transient service-DNS failures;
+  a persistent outage still exhausts the operation's overall wait budget and
+  fails with the operation log.
 - **e2e-cleanup** is wired: the `e2e-mw-dev.yml` `schedule` trigger runs
   `run.sh e2e-cleanup` every 6h, reaping `duckgres-ci-pr-*` namespaces older than
   6h (`E2E_CLEANUP_MAX_AGE_HOURS`) along with their ducklings, cnpg role+db, Pod

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -4426,12 +4426,45 @@ lane_res2() { # scheduling-shape resilience on its own org (heavy, cold spawns)
   exploratory_oom_escalation "$RES2" "$res2_pw" ducklake
 }
 
-main() {
+lane_neutral() {
   resolve_cp_ip
-
-  # No org dependency — assert the admin surface auth contract up front.
   admin_dashboard_no_query_token
   internal_secret_fallback_auth
+  mkdir -p "$LANE_DIR"
+
+  provision "$CNPG" "$CNPG_BODY" > "$LANE_DIR/prov_cnpg.json" & p1=$!
+  provision "$RES2" "$(res_body "$RES2")" > "$LANE_DIR/prov_res2.json" & p2=$!
+  wait "$p1" || fail "provision $CNPG failed"
+  wait "$p2" || fail "provision $RES2 failed"
+  bootstrap_kubectl
+  run_lane ready_cnpg wait_state "$CNPG" ready "$READY_TIMEOUT"
+  run_lane ready_res2 wait_state "$RES2" ready "$READY_TIMEOUT"
+  join_lanes ready_cnpg ready_res2
+  sleep "${CONFIG_POLL_SETTLE:-12}"
+
+  models_explorer_api
+  admin_console_api
+  admin_operators
+  admin_rbac_viewer "$CNPG"
+  provision_team_contract "$CNPG" "$CNPG_TEAM_ID"
+  org_teams_crud "$CNPG" "$CNPG_TEAM_ID"
+  discovery_endpoints "$CNPG" "$CNPG_TEAM_ID"
+  admin_ducklings_metadata "$CNPG"
+  duckling_shard_backfill "$CNPG"
+  lifecycle_teardown_cnpg "$CNPG"
+  log "PASS: neutral provisioning + admin + discovery + Duckling lifecycle"
+}
+
+lane_duckdb() {
+  engine_main
+}
+
+lane_reshard() {
+  engine_main
+}
+
+engine_main() {
+  resolve_cp_ip
 
   mkdir -p "$LANE_DIR"
 
@@ -4440,19 +4473,19 @@ main() {
   # after a handful of failed auths, and a fresh password isn't live until the
   # next config-store poll. Provision returns the live password directly.
   # Independent Ducklings provision concurrently. The focused reshard lane
-  # needs CNPG plus RES2 only; RES1 exists solely for the full suite's worker
+  # needs CNPG plus RES2 only; RES1 exists solely for the DuckDB lane's worker
   # disruption assertions.
   provision "$CNPG" "$CNPG_BODY"        > "$LANE_DIR/prov_cnpg.json" &
   prov1=$!
   provision "$RES2" "$(res_body "$RES2")" > "$LANE_DIR/prov_res2.json" &
   prov3=$!
-  if [ "${E2E_SUITE:-full}" = "full" ]; then
+  if [ "${E2E_SUITE:-duckdb}" = "duckdb" ]; then
     provision "$RES1" "$(res_body "$RES1")" > "$LANE_DIR/prov_res1.json" &
     prov2=$!
   fi
   wait "$prov1" || fail "provision $CNPG failed"
   wait "$prov3" || fail "provision $RES2 failed"
-  if [ "${E2E_SUITE:-full}" = "full" ]; then
+  if [ "${E2E_SUITE:-duckdb}" = "duckdb" ]; then
     wait "$prov2" || fail "provision $RES1 failed"
   fi
   cnpg_pw="$(jq -r .password "$LANE_DIR/prov_cnpg.json")"
@@ -4460,7 +4493,7 @@ main() {
   for v in "$cnpg_pw" "$res2_pw"; do
     case "$v" in ""|null) fail "a provision call returned no password" ;; esac
   done
-  if [ "${E2E_SUITE:-full}" = "full" ]; then
+  if [ "${E2E_SUITE:-duckdb}" = "duckdb" ]; then
     res1_pw="$(jq -r .password "$LANE_DIR/prov_res1.json")"
     case "$res1_pw" in ""|null) fail "provision $RES1 returned no password" ;; esac
   fi
@@ -4468,7 +4501,7 @@ main() {
 
   run_lane ready_cnpg wait_state "$CNPG" ready "$READY_TIMEOUT"
   run_lane ready_res2 wait_state "$RES2" ready "$READY_TIMEOUT"
-  if [ "${E2E_SUITE:-full}" = "full" ]; then
+  if [ "${E2E_SUITE:-duckdb}" = "duckdb" ]; then
     run_lane ready_res1 wait_state "$RES1" ready "$READY_TIMEOUT"
     join_lanes ready_cnpg ready_res1 ready_res2
   else
@@ -4484,9 +4517,9 @@ main() {
   sleep "${CONFIG_POLL_SETTLE:-12}"
 
   # The dedicated reshard workflow lane has a disjoint PR identity and starts
-  # these assertions immediately after provisioning. The long general suite
+  # these assertions immediately after provisioning. The long DuckDB suite
   # executes concurrently in its own namespace and deliberately skips them.
-  if [ "${E2E_SUITE:-full}" = "reshard" ]; then
+  if [ "${E2E_SUITE:-duckdb}" = "reshard" ]; then
     reshard_targets
     reshard_validation "$CNPG"
     reshard_cancel_during_drain "$RES2" "$res2_pw"
@@ -4499,33 +4532,13 @@ main() {
   # deterministically exists before we query it through native Postgres. The
   # subsequent metadata-proxy connection itself bypasses the worker entirely.
   wait_worker "$CNPG" "$cnpg_pw" ducklake
-  # Assert the proxy before the three worker-churn lanes. RES2 is the
-  # same-backend disabled sibling.
   metadata_proxy_e2e "$CNPG" "$cnpg_pw" "$RES2" "$res2_pw"
-
-  # Admin models explorer: orgs + their users now exist in the config store, so
-  # the sidebar counts are non-trivial and the org-users redaction check bites
-  # against a real bcrypt-hash-bearing row.
-  models_explorer_api
-
-  # Admin console read surfaces: identity/role, live state, metrics proxy, auth
-  # gate. Independent of the per-org lanes, so run it here once orgs exist.
-  admin_console_api
-  admin_operators
-  admin_rbac_viewer "$CNPG"
-
   # ---- the three parallel assertion lanes (see lane_* above) ----
   # (kubectl was bootstrapped before the readiness lanes above.)
   run_lane cnpg lane_cnpg
   run_lane res1 lane_res1
   run_lane res2 lane_res2
   join_lanes cnpg res1 res2
-
-  # Provisioning/admin contracts are backend-independent; retain their live
-  # coverage on the primary CNPG org.
-  provision_team_contract "$CNPG" "$CNPG_TEAM_ID"
-  org_teams_crud "$CNPG" "$CNPG_TEAM_ID"
-  discovery_endpoints "$CNPG" "$CNPG_TEAM_ID"
 
   # ---- admin impersonation round-trip + audit (cnpg stack is warm now) ----
   admin_impersonation_audited "$CNPG"
@@ -4538,12 +4551,6 @@ main() {
 
   # ---- generated project user: team-wide read/write, same project boundary --
   project_user_isolation "$CNPG" "$cnpg_pw" "$CNPG_TEAM_ID"
-
-  # ---- admin ducklings metadata: live cnpg shard assignment ----------------
-  admin_ducklings_metadata "$CNPG"
-
-  # ---- provisioner backfills pinned shard into duckling spec (cnpg) --------
-  duckling_shard_backfill "$CNPG"
 
   # ---- admin live-query detail view (phase 1) — cnpg stack is warm now ----
   admin_query_detail "$CNPG" "$cnpg_pw"
@@ -4583,16 +4590,21 @@ main() {
   # ---- cross-tenant isolation between independent CNPG-backed orgs ----
   tenant_isolation "$CNPG" "$cnpg_pw" "$RES1" "$res1_pw"
 
-  # ---- lifecycle: deprovision cnpg + assert the Duckling CR fully deletes ----
-  # (res1/res2 are deprovisioned by run.sh teardown; the cascade assertion
-  # only needs one cnpg-shard org.)
-  lifecycle_teardown_cnpg "$CNPG"
-
   # NOTE: the version-mismatch worker reaper is not exercised in-Job (it needs a
   # mid-run image bump); it stays covered by the controlplane/ unit tests.
   log "SKIP version-reaper (needs an in-run image bump; see README)"
 
-  log "PASS: admin-no-query-token + models-explorer-api(redaction) + admin-console-api(me/live/metrics/auth-gate) + admin-rbac-viewer(403 mutate/audit) + admin-impersonation(round-trip+audit) + project-reader(team-wide-read/cross-project-deny/read-only/legacy-override-grant) + project-user(in-project-dml+ddl/cross-project-deny/unqualified-target-deny/namespace-ddl-deny/reader-stays-read-only) + native-metadata-proxy(explicit-opt-in/exact-db/real-cnpg-query/per-org-disable) + wire + binary-copy(native+fallback+route-guard+rollback) + malformed-startup-resilience + jsonb-concat + cold-burst-absorption + pipeline-error-recovery + cancel-reuse + activation(DuckLake) + ducklake-explain + ext-forks + worker-pod + concurrency + durability + crash-recovery + busy-only-do-not-disrupt + graceful-drain + one-session-per-worker + parallel-cold-burst-ramp + worker-sizing(cnpg DuckLake, doubles as exploratory-tier GUC-bypass) + org-default-profile(cnpg) + exploratory-tier(small-first plain read) + exploratory-lazy-activation(connect+quit spends no pod) + exploratory-state-pin(escalation target + state survives) + exploratory-oom-escalation(transparent re-execute, reason=oom logged) + query-log-worker-tier + persistent-user-secrets(cnpg, cross-user isolation) + user-kill-switch(cnpg) + user-disable-block(cnpg) + connection-duration-logged + compute-usage-pull-api(cnpg, compute+storage) + query-log-round-trip(cnpg, view+query_id+QueryStart/terminal pair) + query-log-access-metadata(read/write split + incomplete-not-empty + CALL opaque-but-complete) + duckling-shard-backfill(cnpg) + isolation + lifecycle-teardown(+org-delete/name-release), on cnpg (3 parallel lanes)"
+  log "PASS: DuckDB/PGWire engine-specific behavior (3 parallel tenant lanes)"
+}
+
+main() {
+  case "${E2E_SUITE:-neutral}" in
+    neutral) lane_neutral ;;
+    duckdb) lane_duckdb ;;
+    reshard) lane_reshard ;;
+    trino) fail "Trino must use e2e/trino.sh" ;;
+    *) fail "unknown E2E_SUITE: ${E2E_SUITE:-}" ;;
+  esac
 }
 
 main "$@"

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -3648,7 +3648,10 @@ reshard_post() { # org body
 reshard_wait_terminal() { # opid timeout_s -> echoes final state
   deadline=$(( $(date +%s) + ${2:-600} ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    st="$(curl -fsS -H "$H" "$API/api/v1/reshards/$1" | jq -r .state)"
+    # A transient cluster-DNS failure must consume one poll, not curl's
+    # five-minute default resolution timeout and therefore the whole wait.
+    st="$(curl -fsS --connect-timeout 5 --max-time 15 -H "$H" \
+      "$API/api/v1/reshards/$1" 2>/dev/null | jq -r '.state // empty' 2>/dev/null || true)"
     case "$st" in succeeded|failed|cancelled) echo "$st"; return 0;; esac
     sleep 5
   done
@@ -3659,7 +3662,8 @@ reshard_wait_step() { # opid step timeout_s
   cur=""
   deadline=$(( $(date +%s) + ${3:-120} ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    cur="$(curl -fsS -H "$H" "$API/api/v1/reshards/$1" | jq -r .step)"
+    cur="$(curl -fsS --connect-timeout 5 --max-time 15 -H "$H" \
+      "$API/api/v1/reshards/$1" 2>/dev/null | jq -r '.step // empty' 2>/dev/null || true)"
     [ "$cur" = "$2" ] && return 0
     sleep 2
   done

--- a/tests/mw-dev/e2e/trino.sh
+++ b/tests/mw-dev/e2e/trino.sh
@@ -219,7 +219,7 @@ printf %s "$queries" | jq -e --arg a "$ORG_A" --arg table "$table" \
 log "tenant query visibility and audited admin kill"
 kill_out=/tmp/trino-kill-query.out
 ( trino_query "$DB_A" "$pw_a" \
-    'SELECT count(*) FROM UNNEST(sequence(1, 1000000)) a(x) CROSS JOIN UNNEST(sequence(1, 10000)) b(y) WHERE random() >= 0' \
+    'SELECT count(*) FROM UNNEST(sequence(1, 10000)) a(x) CROSS JOIN UNNEST(sequence(1, 10000)) b(y) CROSS JOIN UNNEST(sequence(1, 100)) c(z) WHERE random() >= 0' \
     >"$kill_out" 2>&1 ) & kill_pid=$!
 query_id=""; i=0
 while [ "$i" -lt 30 ]; do

--- a/tests/mw-dev/e2e/trino.sh
+++ b/tests/mw-dev/e2e/trino.sh
@@ -22,6 +22,12 @@ TEAM_A=93001
 TEAM_B=93002
 SNI_SUFFIX=".ci.duckgres.local"
 CP_IP=""
+# Password rotation crosses the 10s provisioner reconcile, kubelet's
+# eventually-consistent Secret-volume projection, and Trino's 5s file reload.
+# Keep the total window above the expected projection delay while avoiding a
+# tight authentication loop against the coordinator.
+TRINO_AUTH_ROTATION_ATTEMPTS=36
+TRINO_AUTH_ROTATION_RETRY_SECONDS=5
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 log() { echo ">>> $*" >&2; }
@@ -248,11 +254,11 @@ log "password rotation"
 new_pw="$(api -X POST "$API/api/v1/orgs/$ORG_A/reset-password" | jq -r .password)"
 [ -n "$new_pw" ] && [ "$new_pw" != null ] || fail "password reset returned no password"
 i=0
-while [ "$i" -lt 30 ]; do
+while [ "$i" -lt "$TRINO_AUTH_ROTATION_ATTEMPTS" ]; do
   trino_query "$DB_A" "$new_pw" 'SELECT 1' >/dev/null 2>&1 && break
-  sleep 2; i=$((i + 1))
+  sleep "$TRINO_AUTH_ROTATION_RETRY_SECONDS"; i=$((i + 1))
 done
-[ "$i" -lt 30 ] || fail "rotated Trino password never became active"
+[ "$i" -lt "$TRINO_AUTH_ROTATION_ATTEMPTS" ] || fail "rotated Trino password never became active"
 trino_query "$DB_A" "$pw_a" 'SELECT 1' >/dev/null 2>&1 && fail "old Trino password still authenticates"
 pw_a="$new_pw"
 

--- a/tests/mw-dev/e2e/trino.sh
+++ b/tests/mw-dev/e2e/trino.sh
@@ -1,0 +1,269 @@
+#!/bin/sh
+# Engine-specific Trino e2e lane. The coordinator, worker, OPA bundle, catalog
+# store, credentials, and cell id all belong to this PR namespace.
+set -eu
+trap 'rc=$?; [ "$rc" = 0 ] || echo "TRINO HARNESS EXIT rc=$rc" >&2' EXIT
+
+API="${CP_API:?}"
+SECRET="${INTERNAL_SECRET:?}"
+PR="${PR_NUMBER:?}"
+NS="${NAMESPACE:?}"
+H="X-Duckgres-Internal-Secret: $SECRET"
+TRINO="https://duckgres-trino.$NS.svc:8443"
+CA=/trino-ca/ca.crt
+ORG_A="ci-pr-${PR}-trinoa"
+ORG_B="ci-pr-${PR}-trinob"
+DB_A="trino-a-${PR}"
+DB_B="trino-b-${PR}"
+CAT_A="org_$(printf %s "$DB_A" | tr '-' '_')"
+CAT_B="org_$(printf %s "$DB_B" | tr '-' '_')"
+TEAM_A=93001
+TEAM_B=93002
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+log() { echo ">>> $*" >&2; }
+apk add --no-cache curl jq >/dev/null 2>&1
+[ -s "$CA" ] || fail "per-run Trino CA is not mounted"
+KUBECTL=/tmp/kubectl
+KUBECTL_VERSION=v1.33.1
+curl -fsSLo "$KUBECTL" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/arm64/kubectl"
+chmod +x "$KUBECTL"
+"$KUBECTL" version --client >/dev/null || fail "pinned kubectl bootstrap failed"
+
+api() { curl -fsS -H "$H" "$@"; }
+
+provision() { # org db team
+  api -X POST -H 'Content-Type: application/json' \
+    -d '{"database_name":"'"$2"'","team_id":'"$3"',"metadata_store":{"type":"cnpg-shard"},"data_store":{"type":"s3bucket"},"ducklake":{"enabled":true},"trino":{"enabled":true,"tier":"free"}}' \
+    "$API/api/v1/orgs/$1/provision"
+}
+
+wait_warehouse() { # org
+  i=0
+  while [ "$i" -lt 240 ]; do
+    state="$(api "$API/api/v1/orgs/$1/warehouse/status" | jq -r '.state // empty' 2>/dev/null || true)"
+    [ "$state" = ready ] && return 0
+    [ "$state" = failed ] && fail "$1 warehouse failed: $(api "$API/api/v1/orgs/$1/warehouse/status")"
+    sleep 5; i=$((i + 1))
+  done
+  fail "$1 warehouse did not become ready"
+}
+
+wait_trino() { # org expected-principal expected-catalog
+  i=0
+  while [ "$i" -lt 180 ]; do
+    body="$(api "$API/api/v1/orgs/$1/trino" 2>/dev/null || true)"
+    state="$(printf %s "$body" | jq -r '.status.state // empty' 2>/dev/null || true)"
+    if [ "$state" = ready ]; then
+      printf %s "$body" | jq -e --arg p "$2" --arg c "$3" --arg cell "ci-pr-$PR" \
+        '.enabled == true and .status.principal == $p and .status.catalog == $c and .status.cell == $cell and .status.tier == "free"' >/dev/null \
+        || fail "$1 Trino status identity mismatch: $body"
+      return 0
+    fi
+    [ "$state" = failed ] && fail "$1 Trino provisioning failed: $body"
+    sleep 5; i=$((i + 1))
+  done
+  fail "$1 Trino catalog did not become ready"
+}
+
+# Print all result rows as compact JSON. Trino's statement protocol pages via
+# nextUri; every follow-up keeps both Basic auth and the tenant identity.
+trino_query() { # principal password sql
+  principal="$1" password="$2" sql="$3"
+  response="$(curl --cacert "$CA" -fsS --user "$principal:$password" \
+    -H "X-Trino-User: $principal" -H 'X-Trino-Time-Zone: UTC' \
+    --data-binary "$sql" "$TRINO/v1/statement")" || return 1
+  rows='[]'
+  while :; do
+    err="$(printf %s "$response" | jq -r '.error.message // empty')"
+    [ -z "$err" ] || { echo "$err" >&2; return 1; }
+    rows="$(printf %s "$response" | jq -c --argjson rows "$rows" '$rows + (.data // [])')"
+    next="$(printf %s "$response" | jq -r '.nextUri // empty')"
+    [ -n "$next" ] || break
+    response="$(curl --cacert "$CA" -fsS --user "$principal:$password" \
+      -H "X-Trino-User: $principal" -H 'X-Trino-Time-Zone: UTC' "$next")" || return 1
+  done
+  printf '%s\n' "$rows"
+}
+
+scalar() { trino_query "$1" "$2" "$3" | jq -r '.[0][0]'; }
+must_fail() { # principal password sql pattern
+  out="$(trino_query "$1" "$2" "$3" 2>&1)" && fail "query unexpectedly succeeded: $3"
+  printf %s "$out" | grep -Eqi "$4" || fail "query failed for wrong reason: $out"
+}
+
+log "provisioning first Trino tenant"
+pw_a="$(provision "$ORG_A" "$DB_A" "$TEAM_A" | jq -r .password)"
+[ -n "$pw_a" ] && [ "$pw_a" != null ] || fail "tenant A provision returned no password"
+wait_warehouse "$ORG_A"
+wait_trino "$ORG_A" "$DB_A" "$CAT_A"
+
+log "TLS/password auth, discovery, and DDL/DML"
+[ "$(scalar "$DB_A" "$pw_a" 'SELECT 1')" = 1 ] || fail "Trino SELECT 1 failed"
+must_fail "$DB_A" definitely-wrong-password 'SELECT 1' '401|Unauthorized|Authentication|credentials'
+must_fail "$ORG_A" "$pw_a" 'SELECT 1' '401|Unauthorized|Authentication|credentials'
+catalogs="$(trino_query "$DB_A" "$pw_a" 'SHOW CATALOGS')"
+printf %s "$catalogs" | jq -e --arg c "$CAT_A" 'any(.[]; .[0] == $c)' >/dev/null || fail "own catalog absent: $catalogs"
+printf %s "$catalogs" | jq -e --arg c "$CAT_B" 'all(.[]; .[0] != $c)' >/dev/null || fail "foreign catalog visible before tenant B exists"
+table="e2e_trino_${PR}"
+view="${table}_view"
+schema="e2e_${PR}"
+writes="${table}_writes"
+scratch="${table}_scratch"
+trino_query "$DB_A" "$pw_a" "CREATE SCHEMA $CAT_A.$schema" >/dev/null
+schemas="$(trino_query "$DB_A" "$pw_a" "SHOW SCHEMAS FROM $CAT_A")"
+printf %s "$schemas" | jq -e --arg s "$schema" 'any(.[]; .[0] == $s)' >/dev/null || fail "created schema absent: $schemas"
+trino_query "$DB_A" "$pw_a" "CREATE TABLE $CAT_A.$schema.$table (id BIGINT, flag BOOLEAN, amount DECIMAL(10,2), label VARCHAR, event_date DATE)" >/dev/null
+trino_query "$DB_A" "$pw_a" "INSERT INTO $CAT_A.$schema.$table VALUES (1, true, DECIMAL '1.25', 'one', DATE '2026-08-31'), (2, false, DECIMAL '2.50', 'two', DATE '2026-09-01')" >/dev/null
+trino_query "$DB_A" "$pw_a" "UPDATE $CAT_A.$schema.$table SET label='TWO' WHERE id=2" >/dev/null
+trino_query "$DB_A" "$pw_a" "DELETE FROM $CAT_A.$schema.$table WHERE id=1" >/dev/null
+trino_query "$DB_A" "$pw_a" "CREATE VIEW $CAT_A.$schema.$view AS SELECT * FROM $CAT_A.$schema.$table" >/dev/null
+[ "$(scalar "$DB_A" "$pw_a" "SELECT concat(cast(flag AS varchar), '|', cast(amount AS varchar), '|', label, '|', cast(event_date AS varchar)) FROM $CAT_A.$schema.$view")" = "false|2.50|TWO|2026-09-01" ] \
+  || fail "Trino representative type/DML/view data mismatch"
+tables="$(trino_query "$DB_A" "$pw_a" "SHOW TABLES FROM $CAT_A.$schema")"
+printf %s "$tables" | jq -e --arg t "$table" --arg v "$view" \
+  'any(.[]; .[0] == $t) and any(.[]; .[0] == $v)' >/dev/null || fail "SHOW TABLES missed table/view: $tables"
+trino_query "$DB_A" "$pw_a" "EXPLAIN SELECT * FROM $CAT_A.$schema.$table" >/dev/null
+trino_query "$DB_A" "$pw_a" "CREATE TABLE $CAT_A.$schema.$scratch (id INTEGER)" >/dev/null
+trino_query "$DB_A" "$pw_a" "INSERT INTO $CAT_A.$schema.$scratch VALUES 1, 2" >/dev/null
+trino_query "$DB_A" "$pw_a" "TRUNCATE TABLE $CAT_A.$schema.$scratch" >/dev/null
+[ "$(scalar "$DB_A" "$pw_a" "SELECT count(*) FROM $CAT_A.$schema.$scratch")" = 0 ] || fail "Trino TRUNCATE did not remove rows"
+trino_query "$DB_A" "$pw_a" "CREATE TABLE $CAT_A.$schema.$writes (id INTEGER)" >/dev/null
+pids=""
+for id in 1 2 3 4; do
+  trino_query "$DB_A" "$pw_a" "INSERT INTO $CAT_A.$schema.$writes VALUES ($id)" >/dev/null & pids="$pids $!"
+done
+rc=0; for pid in $pids; do wait "$pid" || rc=1; done
+[ "$rc" = 0 ] || fail "a concurrent Trino write failed"
+[ "$(scalar "$DB_A" "$pw_a" "SELECT count(*) FROM $CAT_A.$schema.$writes")" = 4 ] || fail "concurrent Trino writes lost rows"
+
+log "hot-add second tenant without restarting coordinator"
+coord_uid_before="$("$KUBECTL" -n "$NS" get pod -l 'app=duckgres-trino,component=coordinator' -o jsonpath='{.items[0].metadata.uid}')"
+pw_b="$(provision "$ORG_B" "$DB_B" "$TEAM_B" | jq -r .password)"
+[ -n "$pw_b" ] && [ "$pw_b" != null ] || fail "tenant B provision returned no password"
+wait_warehouse "$ORG_B"
+wait_trino "$ORG_B" "$DB_B" "$CAT_B"
+[ "$("$KUBECTL" -n "$NS" get pod -l 'app=duckgres-trino,component=coordinator' -o jsonpath='{.items[0].metadata.uid}')" = "$coord_uid_before" ] \
+  || fail "adding tenant B restarted the Trino coordinator"
+[ "$(scalar "$DB_B" "$pw_b" 'SELECT 1')" = 1 ] || fail "hot-added tenant cannot authenticate"
+admin_pw="$("$KUBECTL" -n "$NS" get secret trino-auth -o go-template='{{index .data "admin-password"}}' | base64 -d)"
+[ -n "$admin_pw" ] || fail "trino-auth has no admin-password"
+admin_catalogs="$(trino_query __admin_provisioner "$admin_pw" 'SHOW CATALOGS')"
+printf %s "$admin_catalogs" | jq -e --arg a "$CAT_A" --arg b "$CAT_B" \
+  'any(.[]; .[0] == $a) and any(.[]; .[0] == $b)' >/dev/null \
+  || fail "admin cannot see both hot-added managed catalogs: $admin_catalogs"
+
+log "OPA tenant isolation and batched metadata filtering"
+catalogs_b="$(trino_query "$DB_B" "$pw_b" 'SHOW CATALOGS')"
+printf %s "$catalogs_b" | jq -e --arg own "$CAT_B" --arg foreign "$CAT_A" \
+  'any(.[]; .[0] == $own) and all(.[]; .[0] != $foreign)' >/dev/null || fail "tenant B catalog filter mismatch: $catalogs_b"
+# information_schema exercises the OPA batched filter path, not just SHOW CATALOGS.
+trino_query "$DB_A" "$pw_a" "SELECT table_name FROM $CAT_A.information_schema.tables" >/dev/null
+foreign_table="${table}_tenant_b"
+trino_query "$DB_B" "$pw_b" "CREATE TABLE $CAT_B.main.$foreign_table (id INTEGER)" >/dev/null
+trino_query "$DB_B" "$pw_b" "INSERT INTO $CAT_B.main.$foreign_table VALUES 7" >/dev/null
+must_fail "$DB_A" "$pw_a" "SELECT * FROM $CAT_B.main.$foreign_table" 'denied|access|catalog|not found|does not exist'
+must_fail "$DB_A" "$pw_a" "INSERT INTO $CAT_B.main.$foreign_table VALUES 8" 'denied|access|catalog|not found|does not exist'
+must_fail "$DB_A" "$pw_a" "ALTER TABLE $CAT_B.main.$foreign_table RENAME TO ${foreign_table}_renamed" 'denied|access|catalog|not found|does not exist'
+must_fail "$DB_A" "$pw_a" "DROP TABLE $CAT_B.main.$foreign_table" 'denied|access|catalog|not found|does not exist'
+[ "$(scalar "$DB_B" "$pw_b" "SELECT count(*) FROM $CAT_B.main.$foreign_table")" = 1 ] || fail "cross-tenant attempts changed tenant B data"
+must_fail "$DB_B" "$pw_b" "SELECT * FROM $CAT_A.$schema.$table" 'denied|access|catalog|not found|does not exist'
+must_fail "$DB_B" "$pw_b" "DROP TABLE $CAT_A.$schema.$table" 'denied|access|catalog|not found|does not exist'
+[ "$(scalar "$DB_A" "$pw_a" "SELECT count(*) FROM $CAT_A.$schema.$table")" = 1 ] || fail "cross-tenant attempts changed tenant A data"
+
+log "admin Trino fleet/org/query surfaces"
+api "$API/api/v1/trino/status" | jq -e --arg cell "ci-pr-$PR" '.available == true and .cell.id == $cell' >/dev/null
+api "$API/api/v1/trino/nodes" | jq -e '.available == true and (.nodes | length) >= 2' >/dev/null
+api "$API/api/v1/trino/orgs" | jq -e --arg a "$ORG_A" --arg b "$ORG_B" \
+  'any(.orgs[]; .org == $a and .state == "ready") and any(.orgs[]; .org == $b and .state == "ready")' >/dev/null
+queries="$(api "$API/api/v1/trino/queries?org=$ORG_A")"
+printf %s "$queries" | jq -e --arg a "$ORG_A" --arg table "$table" \
+  'all(.queries[]; .org == $a) and any(.queries[]; .query | contains($table))' >/dev/null \
+  || fail "admin query list is unscoped or missing tenant A SQL: $queries"
+
+log "tenant query visibility and audited admin kill"
+kill_out=/tmp/trino-kill-query.out
+( trino_query "$DB_A" "$pw_a" \
+    'SELECT count(*) FROM UNNEST(sequence(1, 1000000)) a(x) CROSS JOIN UNNEST(sequence(1, 10000)) b(y) WHERE random() >= 0' \
+    >"$kill_out" 2>&1 ) & kill_pid=$!
+query_id=""; i=0
+while [ "$i" -lt 30 ]; do
+  query_id="$(api "$API/api/v1/trino/queries?org=$ORG_A&active=1" \
+    | jq -r '.queries[0].query_id // empty')"
+  [ -n "$query_id" ] && break
+  kill -0 "$kill_pid" 2>/dev/null || break
+  sleep 1; i=$((i + 1))
+done
+[ -n "$query_id" ] || { wait "$kill_pid" 2>/dev/null || true; fail "long Trino query never appeared in admin live queries: $(cat "$kill_out")"; }
+api "$API/api/v1/trino/queries/$query_id" | jq -e --arg q "$query_id" --arg org "$ORG_A" \
+  '.query_id == $q and .org == $org' >/dev/null \
+  || fail "admin Trino query detail did not identify tenant A query $query_id"
+code="$(curl --cacert "$CA" -sS -o /tmp/trino-cross-query -w '%{http_code}' \
+  --user "$DB_B:$pw_b" -H "X-Trino-User: $DB_B" "$TRINO/v1/query/$query_id")"
+[ "$code" = 403 ] || fail "tenant B query detail for tenant A returned HTTP $code, want 403: $(cat /tmp/trino-cross-query)"
+api -X POST -H 'Content-Type: application/json' -d '{"reason":"e2e operator cancellation"}' \
+  "$API/api/v1/trino/queries/$query_id/kill" \
+  | jq -e --arg org "$ORG_A" '.killed == true and .org == $org' >/dev/null
+wait "$kill_pid" 2>/dev/null && fail "admin kill did not fail the tenant query"
+api "$API/api/v1/audit?org=$ORG_A" | jq -e --arg q "$query_id" \
+  'any(.entries[]?; .action == "trino.query.kill" and .target_user == $q and .status == 200)' >/dev/null \
+  || fail "Trino query kill audit row missing"
+
+log "password rotation"
+new_pw="$(api -X POST "$API/api/v1/orgs/$ORG_A/reset-password" | jq -r .password)"
+[ -n "$new_pw" ] && [ "$new_pw" != null ] || fail "password reset returned no password"
+i=0
+while [ "$i" -lt 30 ]; do
+  trino_query "$DB_A" "$new_pw" 'SELECT 1' >/dev/null 2>&1 && break
+  sleep 2; i=$((i + 1))
+done
+[ "$i" -lt 30 ] || fail "rotated Trino password never became active"
+trino_query "$DB_A" "$pw_a" 'SELECT 1' >/dev/null 2>&1 && fail "old Trino password still authenticates"
+pw_a="$new_pw"
+
+log "worker restart preserves DuckLake data"
+"$KUBECTL" -n "$NS" delete pod -l 'app=duckgres-trino,component=worker' --wait=true >/dev/null
+"$KUBECTL" -n "$NS" rollout status deploy/duckgres-trino-worker --timeout=240s >/dev/null
+[ "$(scalar "$DB_A" "$pw_a" "SELECT label FROM $CAT_A.$schema.$table")" = TWO ] || fail "data missing after Trino worker restart"
+
+log "coordinator restart restores catalog store, auth, and OPA bundle"
+"$KUBECTL" -n "$NS" delete pod -l 'app=duckgres-trino,component=coordinator' --wait=true >/dev/null
+"$KUBECTL" -n "$NS" rollout status deploy/duckgres-trino-coordinator --timeout=240s >/dev/null
+i=0
+while [ "$i" -lt 30 ]; do
+  value="$(scalar "$DB_A" "$pw_a" "SELECT label FROM $CAT_A.$schema.$table" 2>/dev/null || true)"
+  [ "$value" = TWO ] && break
+  sleep 2; i=$((i + 1))
+done
+[ "$i" -lt 30 ] || fail "catalog/auth/OPA did not recover after coordinator restart"
+
+log "disable removes tenant B auth, catalog, and projection"
+api -X DELETE "$API/api/v1/orgs/$ORG_B/trino" >/dev/null
+i=0
+while [ "$i" -lt 60 ]; do
+  body="$(api "$API/api/v1/orgs/$ORG_B/trino")"
+  enabled="$(printf %s "$body" | jq -r .enabled)"
+  secret_present="$("$KUBECTL" -n "$NS" get secret trino-tenant-secrets -o json | jq -r --arg k "$ORG_B" '.data | has($k)')"
+  catalog_absent=false
+  if admin_catalogs="$(trino_query __admin_provisioner "$admin_pw" 'SHOW CATALOGS' 2>/dev/null)"; then
+    printf %s "$admin_catalogs" | jq -e --arg c "$CAT_B" 'all(.[]; .[0] != $c)' >/dev/null \
+      && catalog_absent=true
+  fi
+  if [ "$enabled" = false ] && [ "$secret_present" = false ] && [ "$catalog_absent" = true ] \
+      && ! trino_query "$DB_B" "$pw_b" 'SELECT 1' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2; i=$((i + 1))
+done
+[ "$i" -lt 60 ] || fail "disabled tenant B retained Trino auth or tenant-secret projection"
+catalogs_a="$(trino_query "$DB_A" "$pw_a" 'SHOW CATALOGS')"
+printf %s "$catalogs_a" | jq -e --arg c "$CAT_B" 'all(.[]; .[0] != $c)' >/dev/null || fail "disabled tenant B catalog remains visible"
+printf %s "$admin_catalogs" | jq -e --arg c "$CAT_B" 'all(.[]; .[0] != $c)' >/dev/null \
+  || fail "disabled tenant B catalog remains in the managed catalog store: $admin_catalogs"
+
+trino_query "$DB_A" "$pw_a" "DROP VIEW $CAT_A.$schema.$view" >/dev/null
+trino_query "$DB_A" "$pw_a" "DROP TABLE $CAT_A.$schema.$table" >/dev/null
+trino_query "$DB_A" "$pw_a" "DROP TABLE $CAT_A.$schema.$scratch" >/dev/null
+trino_query "$DB_A" "$pw_a" "DROP TABLE $CAT_A.$schema.$writes" >/dev/null
+trino_query "$DB_A" "$pw_a" "DROP SCHEMA $CAT_A.$schema" >/dev/null
+log "PASS: isolated Trino provisioning + verified auth + DDL/DML + OPA isolation/batching + hot-add + admin + rotation + restart + disable"

--- a/tests/mw-dev/e2e/trino.sh
+++ b/tests/mw-dev/e2e/trino.sh
@@ -5,6 +5,7 @@ set -eu
 trap 'rc=$?; [ "$rc" = 0 ] || echo "TRINO HARNESS EXIT rc=$rc" >&2' EXIT
 
 API="${CP_API:?}"
+PGHOST="${CP_PG_HOST:?}"
 SECRET="${INTERNAL_SECRET:?}"
 PR="${PR_NUMBER:?}"
 NS="${NAMESPACE:?}"
@@ -19,11 +20,15 @@ CAT_A="org_$(printf %s "$DB_A" | tr '-' '_')"
 CAT_B="org_$(printf %s "$DB_B" | tr '-' '_')"
 TEAM_A=93001
 TEAM_B=93002
+SNI_SUFFIX=".ci.duckgres.local"
+CP_IP=""
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 log() { echo ">>> $*" >&2; }
 apk add --no-cache curl jq >/dev/null 2>&1
 [ -s "$CA" ] || fail "per-run Trino CA is not mounted"
+CP_IP="$(getent hosts "$PGHOST" | awk '{print $1}' | head -1)"
+[ -n "$CP_IP" ] || fail "could not resolve $PGHOST"
 KUBECTL=/tmp/kubectl
 KUBECTL_VERSION=v1.33.1
 curl -fsSLo "$KUBECTL" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/arm64/kubectl"
@@ -31,6 +36,34 @@ chmod +x "$KUBECTL"
 "$KUBECTL" version --client >/dev/null || fail "pinned kubectl bootstrap failed"
 
 api() { curl -fsS -H "$H" "$@"; }
+
+# A fresh managed warehouse has an empty metadata database. DuckLake's Trino
+# connector consumes an existing DuckLake catalog; it does not create the
+# metadata tables itself. Initialize them once through Duckgres's normal
+# DuckLake activation path before asking Trino to use the catalog. This is
+# setup, not duplicated DuckDB coverage: all behavioral assertions below still
+# execute through Trino.
+bootstrap_ducklake() { # org password
+  attempt=0
+  while [ "$attempt" -lt 12 ]; do
+    if out="$(PGPASSWORD="$2" psql \
+        "sslmode=require host=$1$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
+        -v ON_ERROR_STOP=1 -tAc 'SELECT 1' 2>&1)" && [ "$out" = 1 ]; then
+      return 0
+    fi
+    case "$out" in
+      *"capacity exhausted"*|*"no Duckgres worker"*|\
+      *"still provisioning"*|*"failed to initialize session"*|\
+      *"timed out waiting for an available worker"*|*"failed to start"*|\
+      *"spawn sized worker"*|*"failed to detect attached catalogs"*) ;;
+      *) fail "DuckLake bootstrap failed for $1: $out" ;;
+    esac
+    log "DuckLake bootstrap worker not ready for $1; retrying"
+    sleep 15
+    attempt=$((attempt + 1))
+  done
+  fail "DuckLake bootstrap worker did not become ready for $1"
+}
 
 provision() { # org db team
   api -X POST -H 'Content-Type: application/json' \
@@ -96,6 +129,7 @@ log "provisioning first Trino tenant"
 pw_a="$(provision "$ORG_A" "$DB_A" "$TEAM_A" | jq -r .password)"
 [ -n "$pw_a" ] && [ "$pw_a" != null ] || fail "tenant A provision returned no password"
 wait_warehouse "$ORG_A"
+bootstrap_ducklake "$ORG_A" "$pw_a"
 wait_trino "$ORG_A" "$DB_A" "$CAT_A"
 
 log "TLS/password auth, discovery, and DDL/DML"
@@ -142,6 +176,7 @@ coord_uid_before="$("$KUBECTL" -n "$NS" get pod -l 'app=duckgres-trino,component
 pw_b="$(provision "$ORG_B" "$DB_B" "$TEAM_B" | jq -r .password)"
 [ -n "$pw_b" ] && [ "$pw_b" != null ] || fail "tenant B provision returned no password"
 wait_warehouse "$ORG_B"
+bootstrap_ducklake "$ORG_B" "$pw_b"
 wait_trino "$ORG_B" "$DB_B" "$CAT_B"
 [ "$("$KUBECTL" -n "$NS" get pod -l 'app=duckgres-trino,component=coordinator' -o jsonpath='{.items[0].metadata.uid}')" = "$coord_uid_before" ] \
   || fail "adding tenant B restarted the Trino coordinator"

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -144,12 +144,12 @@ rules:
     resources: ["pods/log"]
     verbs: ["get"]
   # The Trino lane deletes coordinator/worker pods and uses rollout status to
-  # prove their owning Deployments restore readiness. Keep that observation
-  # read-only and restricted to the two disposable Trino workloads.
+  # prove their owning Deployments restore readiness. rollout status lists
+  # before watching, so keep this read-only and namespace-scoped; every
+  # Deployment in this per-PR namespace is disposable.
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    resourceNames: ["duckgres-trino-worker", "duckgres-trino-coordinator"]
-    verbs: ["get", "watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     # list/watch needed by the CP's stranded-secret reconciler (the prod chart

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -143,6 +143,13 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
+  # The Trino lane deletes coordinator/worker pods and uses rollout status to
+  # prove their owning Deployments restore readiness. Keep that observation
+  # read-only and restricted to the two disposable Trino workloads.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["duckgres-trino-worker", "duckgres-trino-coordinator"]
+    verbs: ["get", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     # list/watch needed by the CP's stranded-secret reconciler (the prod chart

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -152,6 +152,16 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  # Trino's resource-group projection is a fixed per-namespace ConfigMap.
+  # Create cannot be restricted by resourceNames; the e2e namespace is
+  # disposable and this ServiceAccount already owns its other projections.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["trino-resource-groups"]
+    verbs: ["get", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "get", "update"]

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -198,9 +198,10 @@ roleRef:
 # the grant must live on duckgres-duckling-reader (see charts repo,
 # charts/duckgres/templates/rbac.yaml) and be deployed to the cluster.
 ---
-# Destination preflight uses the same two configured dev-shard provisioner
-# Secrets as the production chart. Keep this disposable grant by-name and
-# read-only; its ci-pr label lets teardown remove the cross-namespace objects.
+# Destination preflight uses the two configured dev-shard provisioner Secrets;
+# Trino catalog projection resolves only its two predictable CI tenant password
+# Secrets. Keep this disposable grant by-name and read-only; its ci-pr label
+# lets teardown remove the cross-namespace objects.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -214,6 +215,8 @@ rules:
     resourceNames:
       - cnpg-shard-001-provisioner
       - cnpg-shard-002-provisioner
+      - cnpg-tenant-ci-pr-${PR_NUMBER}-trinoa-password
+      - cnpg-tenant-ci-pr-${PR_NUMBER}-trinob-password
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/mw-dev/manifests.trino.tmpl.yaml
+++ b/tests/mw-dev/manifests.trino.tmpl.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: ${NAMESPACE}
 data:
   node.properties: |
-    node.environment=ci-pr-${PR_NUMBER}
+    node.environment=ci_pr_${PR_NUMBER}
     node.data-dir=/data/trino
   jvm.config: |
     -server
@@ -88,7 +88,7 @@ metadata:
   namespace: ${NAMESPACE}
 data:
   node.properties: |
-    node.environment=ci-pr-${PR_NUMBER}
+    node.environment=ci_pr_${PR_NUMBER}
     node.data-dir=/data/trino
   jvm.config: |
     -server

--- a/tests/mw-dev/manifests.trino.tmpl.yaml
+++ b/tests/mw-dev/manifests.trino.tmpl.yaml
@@ -1,0 +1,274 @@
+---
+# Trino resources are rendered only for E2E_SUITE=trino. They deliberately
+# share the lane's throwaway namespace/config store, never the mw-dev Trino
+# namespace or catalog store.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trino
+  namespace: ${NAMESPACE}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: duckgres-trino-tls
+  namespace: ${NAMESPACE}
+type: Opaque
+data:
+  ca.crt: ${TRINO_CA_CERT_B64}
+  keystore.p12: ${TRINO_SERVER_P12_B64}
+stringData:
+  password: "${TRINO_TLS_PASSWORD}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: duckgres-trino-catalog-store
+  namespace: ${NAMESPACE}
+stringData:
+  password: duckgres
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: duckgres-trino-coordinator
+  namespace: ${NAMESPACE}
+data:
+  node.properties: |
+    node.environment=ci-pr-${PR_NUMBER}
+    node.data-dir=/data/trino
+  jvm.config: |
+    -server
+    -Xmx2G
+    -XX:+UseG1GC
+    -XX:+ExitOnOutOfMemoryError
+    -Dfile.encoding=UTF-8
+  config.properties: |
+    coordinator=true
+    node-scheduler.include-coordinator=false
+    http-server.http.port=8080
+    http-server.https.enabled=true
+    http-server.https.port=8443
+    http-server.https.keystore.path=/etc/trino/tls/keystore.p12
+    http-server.https.keystore.key=${ENV:TRINO_TLS_KEYSTORE_PASSWORD}
+    discovery.uri=http://duckgres-trino.${NAMESPACE}.svc:8080
+    query.max-memory=2GB
+    query.max-memory-per-node=1GB
+    catalog.management=dynamic
+    catalog.store=posthog
+    http-server.authentication.type=password
+    password-authenticator.config-files=etc/password-authenticator.properties
+    internal-communication.shared-secret=${ENV:TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET}
+    access-control.config-files=etc/access-control.properties
+  password-authenticator.properties: |
+    password-authenticator.name=file
+    file.password-file=/etc/trino/auth/password.db
+    file.refresh-period=5s
+  group-provider.properties: |
+    group-provider.name=file
+    file.group-file=/etc/trino/auth/group.db
+    file.refresh-period=5s
+  access-control.properties: |
+    access-control.name=opa
+    opa.policy.uri=http://localhost:8181/v1/data/trino/allow
+    opa.policy.batched-uri=http://localhost:8181/v1/data/trino/batch
+  resource-groups.properties: |
+    resource-groups.configuration-manager=file
+    resource-groups.config-file=/etc/trino/resource-groups/resource-groups.json
+  catalog-store.properties: |
+    catalog-store.cell-id=ci-pr-${PR_NUMBER}
+    catalog-store.connection-url=jdbc:postgresql://duckgres-config-store.${NAMESPACE}.svc:5432/duckgres?sslmode=disable
+    catalog-store.connection-user=duckgres
+    catalog-store.connection-password-file=/etc/trino/catalog-store/password
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: duckgres-trino-worker
+  namespace: ${NAMESPACE}
+data:
+  node.properties: |
+    node.environment=ci-pr-${PR_NUMBER}
+    node.data-dir=/data/trino
+  jvm.config: |
+    -server
+    -Xmx3G
+    -XX:+UseG1GC
+    -XX:+ExitOnOutOfMemoryError
+    -Dfile.encoding=UTF-8
+  config.properties: |
+    coordinator=false
+    http-server.http.port=8080
+    discovery.uri=http://duckgres-trino.${NAMESPACE}.svc:8080
+    query.max-memory=2GB
+    query.max-memory-per-node=1GB
+    shutdown.grace-period=10s
+    catalog.management=dynamic
+    internal-communication.shared-secret=${ENV:TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: duckgres-trino-opa
+  namespace: ${NAMESPACE}
+data:
+  config.yaml: |
+    services:
+      provisioner:
+        url: "http://duckgres-control-plane.${NAMESPACE}.svc:8080"
+        credentials:
+          bearer:
+            token_path: /etc/opa/secrets/token
+    bundles:
+      trino:
+        service: provisioner
+        resource: /bundles/trino
+        persist: true
+        polling:
+          min_delay_seconds: 2
+          max_delay_seconds: 5
+    persistence_directory: /var/lib/opa
+    status:
+      console: false
+  bootstrap.rego: |
+    package trino
+    import rego.v1
+    default allow := false
+    default batch := []
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: duckgres-trino
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: duckgres-trino
+    component: coordinator
+  ports:
+    - { name: http, port: 8080, targetPort: http }
+    - { name: https, port: 8443, targetPort: https }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duckgres-trino-coordinator
+  namespace: ${NAMESPACE}
+spec:
+  # run.sh creates the Trino Pod Identity association and waits for the CP's
+  # projections before admitting this pod.
+  replicas: 0
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: duckgres-trino, component: coordinator }
+  template:
+    metadata:
+      labels: { app: duckgres-trino, component: coordinator }
+      annotations: { karpenter.sh/do-not-disrupt: "true" }
+    spec:
+      serviceAccountName: trino
+      securityContext: { runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }
+      containers:
+        - name: trino-coordinator
+          image: ${TRINO_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET
+              valueFrom: { secretKeyRef: { name: trino-internal-communication, key: shared-secret } }
+            - name: TRINO_TLS_KEYSTORE_PASSWORD
+              valueFrom: { secretKeyRef: { name: duckgres-trino-tls, key: password } }
+          ports:
+            - { name: http, containerPort: 8080 }
+            - { name: https, containerPort: 8443 }
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "case $(curl -sf http://localhost:8080/v1/info) in *'\"starting\":false'*) exit 0;; *) exit 1;; esac"]
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "1", memory: 3Gi }
+            limits: { cpu: "2", memory: 3Gi }
+          volumeMounts:
+            - { name: config, mountPath: /etc/trino/node.properties, subPath: node.properties }
+            - { name: config, mountPath: /etc/trino/jvm.config, subPath: jvm.config }
+            - { name: config, mountPath: /etc/trino/config.properties, subPath: config.properties }
+            - { name: config, mountPath: /etc/trino/password-authenticator.properties, subPath: password-authenticator.properties }
+            - { name: config, mountPath: /etc/trino/group-provider.properties, subPath: group-provider.properties }
+            - { name: config, mountPath: /etc/trino/access-control.properties, subPath: access-control.properties }
+            - { name: config, mountPath: /etc/trino/resource-groups.properties, subPath: resource-groups.properties }
+            - { name: config, mountPath: /etc/trino/catalog-store.properties, subPath: catalog-store.properties }
+            - { name: trino-auth, mountPath: /etc/trino/auth, readOnly: true }
+            - { name: tenant-secrets, mountPath: /etc/trino/tenant-secrets, readOnly: true }
+            - { name: resource-groups, mountPath: /etc/trino/resource-groups, readOnly: true }
+            - { name: catalog-store, mountPath: /etc/trino/catalog-store, readOnly: true }
+            - { name: tls, mountPath: /etc/trino/tls, readOnly: true }
+            - { name: data, mountPath: /data/trino }
+        - name: duckgres-trino-opa
+          image: openpolicyagent/opa:0.70.0-static
+          args: ["run", "--server", "--addr=0.0.0.0:8181", "--config-file=/etc/opa/config.yaml", "/etc/opa/bootstrap"]
+          ports: [{ name: opa, containerPort: 8181 }]
+          readinessProbe: { httpGet: { path: "/health?bundles=false", port: opa }, initialDelaySeconds: 5, periodSeconds: 5 }
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          volumeMounts:
+            - { name: opa-config, mountPath: /etc/opa/config.yaml, subPath: config.yaml }
+            - { name: opa-config, mountPath: /etc/opa/bootstrap/bootstrap.rego, subPath: bootstrap.rego }
+            - { name: opa-token, mountPath: /etc/opa/secrets, readOnly: true }
+            - { name: opa-cache, mountPath: /var/lib/opa }
+      volumes:
+        - { name: config, configMap: { name: duckgres-trino-coordinator } }
+        - { name: trino-auth, secret: { secretName: trino-auth, optional: true } }
+        - { name: tenant-secrets, secret: { secretName: trino-tenant-secrets, optional: true } }
+        - { name: resource-groups, configMap: { name: trino-resource-groups, optional: true } }
+        - { name: catalog-store, secret: { secretName: duckgres-trino-catalog-store } }
+        - { name: tls, secret: { secretName: duckgres-trino-tls } }
+        - { name: opa-config, configMap: { name: duckgres-trino-opa } }
+        - { name: opa-token, secret: { secretName: trino-opa-bundle-token, optional: true } }
+        - { name: opa-cache, emptyDir: {} }
+        - { name: data, emptyDir: {} }
+      nodeSelector: { kubernetes.io/arch: arm64 }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duckgres-trino-worker
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 0
+  selector:
+    matchLabels: { app: duckgres-trino, component: worker }
+  template:
+    metadata:
+      labels: { app: duckgres-trino, component: worker }
+    spec:
+      serviceAccountName: trino
+      terminationGracePeriodSeconds: 60
+      securityContext: { runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }
+      containers:
+        - name: trino-worker
+          image: ${TRINO_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET
+              valueFrom: { secretKeyRef: { name: trino-internal-communication, key: shared-secret } }
+          ports: [{ name: http, containerPort: 8080 }]
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "case $(curl -sf http://localhost:8080/v1/info) in *'\"starting\":false'*) exit 0;; *) exit 1;; esac"]
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "1", memory: 4Gi }
+            limits: { cpu: "2", memory: 4Gi }
+          volumeMounts:
+            - { name: config, mountPath: /etc/trino/node.properties, subPath: node.properties }
+            - { name: config, mountPath: /etc/trino/jvm.config, subPath: jvm.config }
+            - { name: config, mountPath: /etc/trino/config.properties, subPath: config.properties }
+            - { name: tenant-secrets, mountPath: /etc/trino/tenant-secrets, readOnly: true }
+            - { name: data, mountPath: /data/trino }
+      volumes:
+        - { name: config, configMap: { name: duckgres-trino-worker } }
+        - { name: tenant-secrets, secret: { secretName: trino-tenant-secrets, optional: true } }
+        - { name: data, emptyDir: {} }
+      nodeSelector: { kubernetes.io/arch: arm64 }

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -308,7 +308,10 @@ reset_pr_stack() {
   for org in $(ci_orgs "$PR_NUMBER"); do drop_cnpg_role "$org"; done
   delete_pod_identity
   delete_ci_bindings "$PR_NUMBER"
-  "${KUBECTL[@]}" delete namespace "$NS" --ignore-not-found --wait=true --timeout=300s
+  # Reshard runners intentionally get 600s to roll back safely on termination.
+  # A cancelled workflow can leave one in that grace period, so the next run's
+  # reset must wait longer instead of force-deleting it or timing out halfway.
+  "${KUBECTL[@]}" delete namespace "$NS" --ignore-not-found --wait=true --timeout=720s
 }
 
 cmd_deploy() {
@@ -742,8 +745,7 @@ cmd_diagnostics() {
   "${KUBECTL[@]}" -n "$NS" get pods,svc,job -o wide || true
   echo "::endgroup::"
   echo "::group::harness pod status (eviction / OOM / exit code)"
-  "${KUBECTL[@]}" -n "$NS" get pods -l job-name=duckgres-harness     -o jsonpath='{range .items[*]}{.metadata.name} phase={.status.phase} reason={.status.reason} msg={.status.message} exit={.status.containerStatuses[0].state.terminated.exitCode} term-reason={.status.containerStatuses[0].state.terminated.reason}{"
-"}{end}' || true
+  "${KUBECTL[@]}" -n "$NS" get pods -l job-name=duckgres-harness     -o jsonpath='{range .items[*]}{.metadata.name} phase={.status.phase} reason={.status.reason} msg={.status.message} exit={.status.containerStatuses[0].state.terminated.exitCode} term-reason={.status.containerStatuses[0].state.terminated.reason}{"\n"}{end}' || true
   "${KUBECTL[@]}" -n "$NS" describe pods -l job-name=duckgres-harness 2>/dev/null | tail -30 || true
   echo "::endgroup::"
   echo "::group::control-plane logs (tail)"

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -28,11 +28,13 @@ SCENARIO_NAME="${SCENARIO_NAME:-full-suite}"
 SCENARIO_ARTIFACTS_DIR="${SCENARIO_ARTIFACTS_DIR:-$HERE/../../artifacts/scenario-dev}"
 DUCKGRES_K8S_WORKER_CPU_REQUEST="${DUCKGRES_K8S_WORKER_CPU_REQUEST:-750m}"
 DUCKGRES_K8S_WORKER_MEMORY_REQUEST="${DUCKGRES_K8S_WORKER_MEMORY_REQUEST:-1536Mi}"
-E2E_SUITE="${E2E_SUITE:-full}"
+E2E_SUITE="${E2E_SUITE:-neutral}"
 case "$E2E_SUITE" in
-  full|reshard) ;;
-  *) echo "E2E_SUITE must be full or reshard (got $E2E_SUITE)" >&2; exit 2 ;;
+  neutral|duckdb|trino|reshard) ;;
+  *) echo "E2E_SUITE must be neutral, duckdb, trino, or reshard (got $E2E_SUITE)" >&2; exit 2 ;;
 esac
+TRINO_IMAGE="${TRINO_IMAGE:-ghcr.io/posthog/trino:4505364c570d6b51edecd299b603fca4b6693d86@sha256:ac80c275fd18a439d25da5652ab5cd3c80bcbdd2d88d64c9722dc3e8bb68ba07}"
+TRINO_TLS_PASSWORD="${TRINO_TLS_PASSWORD:-duckgres-e2e-keystore}"
 
 # Internal secret for the per-PR control plane. Random per run; never reused.
 # Stamped into the rendered manifests and handed to the in-cluster harness.
@@ -45,6 +47,12 @@ internal_secret_fallback_file="$secret_dir/duckgres-ci-internal-secret-fallback"
 # AES key for user persistent secrets (DUCKGRES_USER_SECRET_KEY). Random per
 # run: stored user secrets only need to outlive the run's sessions.
 user_secret_key_file="$secret_dir/duckgres-ci-user-secret-key"
+trino_ca_key_file="$secret_dir/duckgres-ci-trino-ca.key"
+trino_ca_cert_file="$secret_dir/duckgres-ci-trino-ca.crt"
+trino_server_key_file="$secret_dir/duckgres-ci-trino-server.key"
+trino_server_cert_file="$secret_dir/duckgres-ci-trino-server.crt"
+trino_server_csr_file="$secret_dir/duckgres-ci-trino-server.csr"
+trino_server_p12_file="$secret_dir/duckgres-ci-trino-server.p12"
 
 require_pr_identity() {
   : "${PR_NUMBER:?PR_NUMBER is required}"
@@ -79,6 +87,39 @@ render() {
   DUCKGRES_K8S_WORKER_MEMORY_REQUEST="$DUCKGRES_K8S_WORKER_MEMORY_REQUEST" \
     envsubst '$NAMESPACE $PR_NUMBER $WORKER_IMAGE $CONTROLPLANE_IMAGE $INTERNAL_SECRET $INTERNAL_SECRET_FALLBACK $USER_SECRET_KEY $DUCKGRES_K8S_WORKER_CPU_REQUEST $DUCKGRES_K8S_WORKER_MEMORY_REQUEST' \
     < "$HERE/manifests.tmpl.yaml"
+
+  if [ "$E2E_SUITE" = "trino" ]; then
+    ensure_trino_tls
+    TRINO_CA_CERT_B64="$(base64 < "$trino_ca_cert_file" | tr -d '\n')" \
+    TRINO_SERVER_P12_B64="$(base64 < "$trino_server_p12_file" | tr -d '\n')" \
+    TRINO_IMAGE="$TRINO_IMAGE" TRINO_TLS_PASSWORD="$TRINO_TLS_PASSWORD" \
+      NAMESPACE="$NS" PR_NUMBER="$PR_NUMBER" \
+      envsubst '$NAMESPACE $PR_NUMBER $TRINO_IMAGE $TRINO_TLS_PASSWORD $TRINO_CA_CERT_B64 $TRINO_SERVER_P12_B64' \
+      < "$HERE/manifests.trino.tmpl.yaml"
+  fi
+}
+
+ensure_trino_tls() {
+  local san="duckgres-trino.$NS.svc"
+  if [ -s "$trino_ca_cert_file" ] && [ -s "$trino_server_p12_file" ]; then
+    return
+  fi
+  # Per-run CA and leaf: password auth stays on verified HTTPS without sharing
+  # the real mw-dev wildcard certificate or weakening the Go TLS client.
+  ( umask 077
+    openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+      -subj "/CN=duckgres-e2e-trino-ca" \
+      -keyout "$trino_ca_key_file" -out "$trino_ca_cert_file" >/dev/null 2>&1
+    openssl req -newkey rsa:2048 -nodes -subj "/CN=$san" \
+      -addext "subjectAltName=DNS:$san,DNS:$san.cluster.local" \
+      -keyout "$trino_server_key_file" -out "$trino_server_csr_file" >/dev/null 2>&1
+    openssl x509 -req -days 2 -sha256 \
+      -in "$trino_server_csr_file" -CA "$trino_ca_cert_file" -CAkey "$trino_ca_key_file" \
+      -CAcreateserial -copy_extensions copy -out "$trino_server_cert_file" >/dev/null 2>&1
+    openssl pkcs12 -export -name trino -passout "pass:$TRINO_TLS_PASSWORD" \
+      -inkey "$trino_server_key_file" -in "$trino_server_cert_file" \
+      -certfile "$trino_ca_cert_file" -out "$trino_server_p12_file" >/dev/null 2>&1
+  )
 }
 
 ensure_secret_dir() {
@@ -107,10 +148,20 @@ ensure_pod_identity() {
   # pod-identity agent for newly-admitted pods, leaving the CP without creds.
   # Delete any existing, then create.
   delete_pod_identity
+  create_pod_identity "$SA_NAME" "$CP_POD_IDENTITY_ROLE"
+}
+
+create_pod_identity() { # service-account role-arn
+  local service_account="$1" role_arn="$2"
   aws eks create-pod-identity-association --region "$AWS_REGION" \
     --cluster-name "$EKS_CLUSTER_NAME" --namespace "$NS" \
-    --service-account "$SA_NAME" --role-arn "$CP_POD_IDENTITY_ROLE" >/dev/null
-  echo "Created Pod Identity association $NS/$SA_NAME -> $CP_POD_IDENTITY_ROLE"
+    --service-account "$service_account" --role-arn "$role_arn" >/dev/null
+  echo "Created Pod Identity association for $NS/$service_account"
+}
+
+ensure_trino_pod_identity() {
+  : "${TRINO_POD_IDENTITY_ROLE:?TRINO_POD_IDENTITY_ROLE is required for the trino e2e suite}"
+  create_pod_identity trino "$TRINO_POD_IDENTITY_ROLE"
 }
 
 delete_pod_identity() {
@@ -205,7 +256,7 @@ drop_cnpg_role() { # org-id
 # (harness.sh main()). Keep in sync with harness.sh.
 ci_orgs() { # pr-number
   local pr="$1"
-  echo "ci-pr-${pr}-cnpg ci-pr-${pr}-res1 ci-pr-${pr}-res2"
+  echo "ci-pr-${pr}-cnpg ci-pr-${pr}-res1 ci-pr-${pr}-res2 ci-pr-${pr}-trinoa ci-pr-${pr}-trinob"
 }
 
 delete_ci_ducklings() { # pr-number
@@ -273,6 +324,26 @@ cmd_deploy() {
   # pod actually carries the injected credentials.
   ensure_pod_identity
   restart_cp_with_identity
+
+  if [ "$E2E_SUITE" = "trino" ]; then
+    # Associate before admitting Trino pods: the Pod Identity agent injects
+    # credentials only at admission and never retrofits an existing pod.
+    ensure_trino_pod_identity
+    envsubst '$NAMESPACE $PR_NUMBER' < "$HERE/trino-controlplane-patch.tmpl.json" \
+      | "${KUBECTL[@]}" -n "$NS" patch deployment duckgres-control-plane \
+          --type=strategic --patch-file=/dev/stdin
+    "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-control-plane --timeout=180s
+    # Bootstrap creates the fixed-name Trino Secrets/ConfigMap. Keep workloads
+    # at zero replicas until all projections exist, then admit them with the
+    # already-propagated Trino Pod Identity association.
+    "${KUBECTL[@]}" -n "$NS" wait --for=create secret/trino-auth --timeout=120s
+    "${KUBECTL[@]}" -n "$NS" wait --for=create secret/trino-internal-communication --timeout=120s
+    "${KUBECTL[@]}" -n "$NS" wait --for=create secret/trino-opa-bundle-token --timeout=120s
+    "${KUBECTL[@]}" -n "$NS" wait --for=create configmap/trino-resource-groups --timeout=120s
+    "${KUBECTL[@]}" -n "$NS" scale deploy/duckgres-trino-coordinator deploy/duckgres-trino-worker --replicas=1
+    "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-coordinator --timeout=300s
+    "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-worker --timeout=300s
+  fi
 }
 
 cmd_test_e2e() {
@@ -283,8 +354,12 @@ cmd_test_e2e() {
   # hits when it stashes the whole object in the last-applied annotation
   # (metadata.annotations: Too long). SSA stores field ownership instead and
   # allows the full 1MiB ConfigMap payload.
+  harness_file="$HERE/e2e/harness.sh"
+  if [ "$E2E_SUITE" = "trino" ]; then
+    harness_file="$HERE/e2e/trino.sh"
+  fi
   "${KUBECTL[@]}" -n "$NS" create configmap duckgres-harness \
-    --from-file=harness.sh="$HERE/e2e/harness.sh" \
+    --from-file=harness.sh="$harness_file" \
     --dry-run=client -o yaml | "${KUBECTL[@]}" apply --server-side --force-conflicts -f -
 
   INTERNAL_SECRET="$(cat "$internal_secret_file")"
@@ -333,8 +408,12 @@ spec:
           resources:
             requests: { cpu: 200m, memory: 256Mi }
             limits: { memory: 512Mi }
-          volumeMounts: [{ name: h, mountPath: /harness }]
-      volumes: [{ name: h, configMap: { name: duckgres-harness } }]
+          volumeMounts:
+            - { name: h, mountPath: /harness }
+            - { name: trino-ca, mountPath: /trino-ca, readOnly: true }
+      volumes:
+        - { name: h, configMap: { name: duckgres-harness } }
+        - { name: trino-ca, secret: { secretName: duckgres-trino-tls, optional: true, items: [{ key: ca.crt, path: ca.crt }] } }
 YAML
 
   echo "Streaming harness logs…"
@@ -663,6 +742,11 @@ cmd_diagnostics() {
   echo "::endgroup::"
   echo "::group::control-plane logs (tail)"
   "${KUBECTL[@]}" -n "$NS" logs deploy/duckgres-control-plane --tail=200 || true
+  echo "::endgroup::"
+  echo "::group::Trino coordinator, worker, and OPA logs"
+  "${KUBECTL[@]}" -n "$NS" logs deploy/duckgres-trino-coordinator -c trino-coordinator --tail=300 || true
+  "${KUBECTL[@]}" -n "$NS" logs deploy/duckgres-trino-coordinator -c duckgres-trino-opa --tail=300 || true
+  "${KUBECTL[@]}" -n "$NS" logs deploy/duckgres-trino-worker -c trino-worker --tail=300 || true
   echo "::endgroup::"
   echo "::group::worker pods"
   "${KUBECTL[@]}" -n "$NS" get pods -l app=duckgres-worker -o wide || true

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -340,7 +340,13 @@ cmd_deploy() {
     "${KUBECTL[@]}" -n "$NS" wait --for=create secret/trino-internal-communication --timeout=120s
     "${KUBECTL[@]}" -n "$NS" wait --for=create secret/trino-opa-bundle-token --timeout=120s
     "${KUBECTL[@]}" -n "$NS" wait --for=create configmap/trino-resource-groups --timeout=120s
-    "${KUBECTL[@]}" -n "$NS" scale deploy/duckgres-trino-coordinator deploy/duckgres-trino-worker --replicas=1
+    # Patch the Deployment resources directly. The CI deployer intentionally
+    # cannot patch the deployments/scale subresource, while it already needs
+    # narrowly scoped Deployment patch access for the control-plane config.
+    for deployment in duckgres-trino-coordinator duckgres-trino-worker; do
+      "${KUBECTL[@]}" -n "$NS" patch deployment "$deployment" \
+        --type=merge -p '{"spec":{"replicas":1}}'
+    done
     "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-coordinator --timeout=300s
     "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-worker --timeout=300s
   fi

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -63,6 +63,37 @@ func TestDeployFailureDoesNotDumpDucklingYAML(t *testing.T) {
 	}
 }
 
+func TestTrinoDeployStartsWorkloadsWithoutScaleSubresource(t *testing.T) {
+	fakes := newRunSHFakes(t)
+	secretDir := filepath.Join(filepath.Dir(fakes.binDir), "secrets")
+	for _, name := range []string{"duckgres-ci-trino-ca.crt", "duckgres-ci-trino-server.p12"} {
+		if err := os.WriteFile(filepath.Join(secretDir, name), []byte("test-tls-material\n"), 0o600); err != nil {
+			t.Fatalf("write fake Trino TLS material: %v", err)
+		}
+	}
+
+	cmd := runSHCommand(t, fakes.binDir, "deploy",
+		"SCENARIO_DEV_ALLOW_DUCKLING_DELETE=1",
+		"E2E_SUITE=trino",
+		"TRINO_POD_IDENTITY_ROLE=arn:aws:iam::123456789012:role/trino-dev",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Trino deploy failed: %v\n%s", err, out)
+	}
+
+	calls := fakes.calls(t)
+	if strings.Contains(calls, " scale ") {
+		t.Fatalf("Trino deploy requires deployments/scale RBAC; calls:\n%s", calls)
+	}
+	for _, deployment := range []string{"duckgres-trino-coordinator", "duckgres-trino-worker"} {
+		want := "patch deployment " + deployment + " --type=merge -p {\"spec\":{\"replicas\":1}}"
+		if !strings.Contains(calls, want) {
+			t.Errorf("Trino deploy did not start %s through the deployment resource; calls:\n%s", deployment, calls)
+		}
+	}
+}
+
 func TestScheduledCleanupKeepsGoingWhenDucklingsDoNotDelete(t *testing.T) {
 	fakes := newRunSHFakes(t)
 
@@ -1522,6 +1553,10 @@ if [[ "$*" == *" -n cnpg-shards exec "* && "$*" == *" psql -U postgres -c "* ]];
   exit 0
 fi
 if [[ "$*" == *" apply -f -"* ]]; then
+  tee -a "$RUN_SH_TEST_CALLS" >/dev/null
+  exit 0
+fi
+if [[ "$*" == *" --patch-file=/dev/stdin"* ]]; then
   tee -a "$RUN_SH_TEST_CALLS" >/dev/null
   exit 0
 fi

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1082,7 +1082,7 @@ func TestControlPlaneServiceDoesNotExposeFlight(t *testing.T) {
 	t.Fatal("duckgres-control-plane Service missing from manifests template")
 }
 
-func TestReshardLaneCanReadOnlyConfiguredShardProvisionerSecrets(t *testing.T) {
+func TestE2ELanesCanReadOnlyRequiredDucklingsSecrets(t *testing.T) {
 	raw, err := os.ReadFile("manifests.tmpl.yaml")
 	if err != nil {
 		t.Fatalf("read manifests template: %v", err)
@@ -1140,7 +1140,9 @@ func TestReshardLaneCanReadOnlyConfiguredShardProvisionerSecrets(t *testing.T) {
 	if got := strings.Join(stringSlice(rule["verbs"]), ","); got != "get" {
 		t.Fatalf("verbs = %q, want get", got)
 	}
-	if got := strings.Join(stringSlice(rule["resourceNames"]), ","); got != "cnpg-shard-001-provisioner,cnpg-shard-002-provisioner" {
+	wantResourceNames := "cnpg-shard-001-provisioner,cnpg-shard-002-provisioner," +
+		"cnpg-tenant-ci-pr-123-trinoa-password,cnpg-tenant-ci-pr-123-trinob-password"
+	if got := strings.Join(stringSlice(rule["resourceNames"]), ","); got != wantResourceNames {
 		t.Fatalf("resourceNames = %q", got)
 	}
 	bindingMetadata := binding["metadata"].(map[string]any)

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -1444,6 +1445,25 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	} {
 		if !strings.Contains(harness, want) {
 			t.Errorf("Trino harness missing live admin/detail cleanup contract %q", want)
+		}
+	}
+}
+
+func TestTrinoNodeEnvironmentUsesValidIdentifier(t *testing.T) {
+	raw, err := os.ReadFile("manifests.trino.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read Trino manifests template: %v", err)
+	}
+
+	environments := regexp.MustCompile(`(?m)^\s*node\.environment=(\S+)$`).FindAllStringSubmatch(string(raw), -1)
+	if len(environments) != 2 {
+		t.Fatalf("Trino node.environment values = %d, want coordinator and worker", len(environments))
+	}
+	valid := regexp.MustCompile(`^[a-z0-9][_a-z0-9]*$`)
+	for _, match := range environments {
+		rendered := strings.ReplaceAll(match[1], "${PR_NUMBER}", "123")
+		if !valid.MatchString(rendered) {
+			t.Errorf("Trino node.environment %q violates the Trino identifier grammar", rendered)
 		}
 	}
 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1215,6 +1215,28 @@ func TestReshardE2EUsesReachableDestinationAndForcesRollbackAfterPreflight(t *te
 	}
 }
 
+func TestReshardTerminalPollBoundsAndRetriesTransientAPIFailures(t *testing.T) {
+	raw, err := os.ReadFile("e2e/harness.sh")
+	if err != nil {
+		t.Fatalf("read e2e harness: %v", err)
+	}
+	script := string(raw)
+	start := strings.Index(script, "reshard_wait_terminal() {")
+	if start < 0 {
+		t.Fatal("could not find reshard_wait_terminal")
+	}
+	end := strings.Index(script[start:], "\n}\n")
+	if end < 0 {
+		t.Fatal("could not isolate reshard_wait_terminal")
+	}
+	body := script[start : start+end]
+	for _, want := range []string{"--connect-timeout", "--max-time", "|| true"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("reshard terminal poll must bound and retry transient API failures; missing %q", want)
+		}
+	}
+}
+
 func TestControlPlaneWorkerDefaultsAreConfigurable(t *testing.T) {
 	raw, err := os.ReadFile("manifests.tmpl.yaml")
 	if err != nil {
@@ -1537,6 +1559,37 @@ func TestTrinoKillQueryWorkloadHonorsSequenceLimit(t *testing.T) {
 		}
 		if limit > 10_000 {
 			t.Errorf("Trino sequence limit %d exceeds the engine maximum of 10000", limit)
+		}
+	}
+}
+
+func TestTrinoPasswordRotationAllowsSecretProjectionWindow(t *testing.T) {
+	raw, err := os.ReadFile("e2e/trino.sh")
+	if err != nil {
+		t.Fatalf("read Trino harness: %v", err)
+	}
+	script := string(raw)
+
+	const minimumProjectionWindowSeconds = 150
+	values := make(map[string]int)
+	for _, match := range regexp.MustCompile(`(?m)^(TRINO_AUTH_ROTATION_ATTEMPTS|TRINO_AUTH_ROTATION_RETRY_SECONDS)=([0-9]+)$`).FindAllStringSubmatch(script, -1) {
+		value, err := strconv.Atoi(match[2])
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", match[1], match[2], err)
+		}
+		values[match[1]] = value
+	}
+	attempts := values["TRINO_AUTH_ROTATION_ATTEMPTS"]
+	retrySeconds := values["TRINO_AUTH_ROTATION_RETRY_SECONDS"]
+	if attempts*retrySeconds < minimumProjectionWindowSeconds {
+		t.Fatalf("Trino password rotation wait = %ds, want at least %ds for provisioner, kubelet Secret projection, and Trino reload", attempts*retrySeconds, minimumProjectionWindowSeconds)
+	}
+	for _, want := range []string{
+		`while [ "$i" -lt "$TRINO_AUTH_ROTATION_ATTEMPTS" ]; do`,
+		`sleep "$TRINO_AUTH_ROTATION_RETRY_SECONDS"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("Trino password rotation does not use bounded wait setting %q", want)
 		}
 	}
 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1510,7 +1510,7 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	}
 }
 
-func TestTrinoHarnessCanObserveOnlyItsRestartedDeployments(t *testing.T) {
+func TestTrinoHarnessCanObserveDeploymentsInItsIsolatedNamespace(t *testing.T) {
 	raw, err := os.ReadFile("manifests.tmpl.yaml")
 	if err != nil {
 		t.Fatalf("read manifests template: %v", err)
@@ -1518,8 +1518,7 @@ func TestTrinoHarnessCanObserveOnlyItsRestartedDeployments(t *testing.T) {
 	manifest := string(raw)
 	for _, want := range []string{
 		`resources: ["deployments"]`,
-		`resourceNames: ["duckgres-trino-worker", "duckgres-trino-coordinator"]`,
-		`verbs: ["get", "watch"]`,
+		`verbs: ["get", "list", "watch"]`,
 	} {
 		if !strings.Contains(manifest, want) {
 			t.Errorf("Trino restart rollout RBAC missing %q", want)

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1516,6 +1517,26 @@ func TestTrinoHarnessBootstrapsDuckLakeBeforeCatalogQueries(t *testing.T) {
 	} {
 		if !strings.Contains(script, want) {
 			t.Errorf("Trino DuckLake bootstrap is missing %q", want)
+		}
+	}
+}
+
+func TestTrinoKillQueryWorkloadHonorsSequenceLimit(t *testing.T) {
+	raw, err := os.ReadFile("e2e/trino.sh")
+	if err != nil {
+		t.Fatalf("read Trino harness: %v", err)
+	}
+	matches := regexp.MustCompile(`sequence\(1,\s*([0-9]+)\)`).FindAllSubmatch(raw, -1)
+	if len(matches) < 3 {
+		t.Fatalf("long-query workload uses %d sequences, want at least three bounded factors", len(matches))
+	}
+	for _, match := range matches {
+		limit, err := strconv.Atoi(string(match[1]))
+		if err != nil {
+			t.Fatalf("parse sequence limit %q: %v", match[1], err)
+		}
+		if limit > 10_000 {
+			t.Errorf("Trino sequence limit %d exceeds the engine maximum of 10000", limit)
 		}
 	}
 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -64,6 +64,42 @@ func TestDeployFailureDoesNotDumpDucklingYAML(t *testing.T) {
 	}
 }
 
+func TestDeployWaitsForReshardRollbackBeforeReusingNamespace(t *testing.T) {
+	raw, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatalf("read run.sh: %v", err)
+	}
+	script := string(raw)
+	start := strings.Index(script, "reset_pr_stack() {")
+	end := strings.Index(script, "\ncmd_deploy() {")
+	if start < 0 || end <= start {
+		t.Fatal("could not isolate reset_pr_stack")
+	}
+	reset := script[start:end]
+	if !strings.Contains(reset, `delete namespace "$NS" --ignore-not-found --wait=true --timeout=720s`) {
+		t.Fatal("namespace reset must outlive the reshard runner's 600s rollback grace period")
+	}
+	for _, unsafe := range []string{"--force", "--grace-period=0"} {
+		if strings.Contains(reset, unsafe) {
+			t.Fatalf("namespace reset bypasses rollback-safe termination with %q", unsafe)
+		}
+	}
+}
+
+func TestDiagnosticsHarnessPodJSONPathParses(t *testing.T) {
+	raw, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatalf("read run.sh: %v", err)
+	}
+	match := regexp.MustCompile(`(?s)get pods -l job-name=duckgres-harness\s+-o jsonpath='([^']+)'`).FindSubmatch(raw)
+	if len(match) != 2 {
+		t.Fatal("diagnostics harness-pod JSONPath is missing")
+	}
+	if err := kjsonpath.New("diagnostics-harness-pod").Parse(string(match[1])); err != nil {
+		t.Fatalf("diagnostics harness-pod JSONPath does not parse: %v", err)
+	}
+}
+
 func TestTrinoDeployStartsWorkloadsWithoutScaleSubresource(t *testing.T) {
 	fakes := newRunSHFakes(t)
 	secretDir := filepath.Join(filepath.Dir(fakes.binDir), "secrets")
@@ -1447,6 +1483,39 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	} {
 		if !strings.Contains(harness, want) {
 			t.Errorf("Trino harness missing live admin/detail cleanup contract %q", want)
+		}
+	}
+}
+
+func TestTrinoHarnessBootstrapsDuckLakeBeforeCatalogQueries(t *testing.T) {
+	raw, err := os.ReadFile("e2e/trino.sh")
+	if err != nil {
+		t.Fatalf("read Trino harness: %v", err)
+	}
+	script := string(raw)
+
+	bootstrap := strings.Index(script, `bootstrap_ducklake "$ORG_A" "$pw_a"`)
+	firstCatalogQuery := strings.Index(script, `log "TLS/password auth, discovery, and DDL/DML"`)
+	if bootstrap < 0 {
+		t.Fatal("Trino harness does not initialize the fresh DuckLake metadata store through Duckgres")
+	}
+	if firstCatalogQuery < 0 || bootstrap >= firstCatalogQuery {
+		t.Fatal("fresh DuckLake metadata must be initialized before the first Trino catalog query")
+	}
+	warehouseB := strings.Index(script, `wait_warehouse "$ORG_B"`)
+	bootstrapB := strings.Index(script, `bootstrap_ducklake "$ORG_B" "$pw_b"`)
+	trinoB := strings.Index(script, `wait_trino "$ORG_B" "$DB_B" "$CAT_B"`)
+	if warehouseB < 0 || bootstrapB <= warehouseB || trinoB <= bootstrapB {
+		t.Fatal("hot-added tenant DuckLake metadata must be initialized after warehouse readiness and before Trino readiness")
+	}
+	for _, want := range []string{
+		`bootstrap_ducklake()`,
+		`dbname=ducklake`,
+		`host=$1$SNI_SUFFIX`,
+		`hostaddr=$CP_IP`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("Trino DuckLake bootstrap is missing %q", want)
 		}
 	}
 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -181,10 +181,10 @@ func TestTeardownFailsWhenCNPGCleanupCannotReachAPrimary(t *testing.T) {
 			}
 
 			calls := fakes.calls(t)
-			if got := strings.Count(calls, "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary"); got != 9 {
-				t.Fatalf("primary discovery calls = %d, want 9 (three retries for each CI org); calls:\n%s", got, calls)
+			if got := strings.Count(calls, "get pod -l cnpg.io/cluster=shard-001,cnpg.io/instanceRole=primary"); got != 15 {
+				t.Fatalf("primary discovery calls = %d, want 15 (three retries for each CI org); calls:\n%s", got, calls)
 			}
-			if tt.name == "all psql executions fail" && strings.Count(calls, "exec shard-001-2 -c postgres -- psql") != 9 {
+			if tt.name == "all psql executions fail" && strings.Count(calls, "exec shard-001-2 -c postgres -- psql") != 15 {
 				t.Fatalf("psql attempts were not bounded to three per CI org; calls:\n%s", calls)
 			}
 			if !strings.Contains(calls, "delete namespace duckgres-ci-pr-123 --ignore-not-found --wait=false") {
@@ -1239,8 +1239,10 @@ func TestE2EHarnessJobReceivesSuiteSelection(t *testing.T) {
 	}
 	script := string(raw)
 	for _, want := range []string{
-		`E2E_SUITE="${E2E_SUITE:-full}"`,
+		`E2E_SUITE="${E2E_SUITE:-neutral}"`,
 		`{ name: E2E_SUITE, value: "$E2E_SUITE" }`,
+		`case "$E2E_SUITE" in`,
+		`neutral|duckdb|trino|reshard)`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("run.sh missing e2e suite contract %q", want)
@@ -1248,7 +1250,7 @@ func TestE2EHarnessJobReceivesSuiteSelection(t *testing.T) {
 	}
 }
 
-func TestE2EWorkflowRunsFullAndReshardSuitesInParallelNamespaces(t *testing.T) {
+func TestE2EWorkflowRunsNeutralDuckDBAndTrinoSuitesInParallelNamespaces(t *testing.T) {
 	raw, err := os.ReadFile("../../.github/workflows/e2e-mw-dev.yml")
 	if err != nil {
 		t.Fatalf("read e2e workflow: %v", err)
@@ -1256,10 +1258,14 @@ func TestE2EWorkflowRunsFullAndReshardSuitesInParallelNamespaces(t *testing.T) {
 	workflow := string(raw)
 	for _, want := range []string{
 		"matrix:",
-		"suite: full",
+		"suite: neutral",
+		"suite: duckdb",
+		"suite: trino",
 		"suite: reshard",
 		`lane_prefix: "1"`,
 		`lane_prefix: "2"`,
+		`lane_prefix: "3"`,
+		`lane_prefix: "4"`,
 		"github.event.pull_request.number || github.run_id",
 		"github.event_name == 'workflow_dispatch' && github.run_id",
 		"NAMESPACE: duckgres-ci-pr-${{ format('{0}{1}', matrix.lane_prefix",
@@ -1270,10 +1276,14 @@ func TestE2EWorkflowRunsFullAndReshardSuitesInParallelNamespaces(t *testing.T) {
 		}
 	}
 	for _, duplicated := range []string{
-		"suite: full",
+		"suite: neutral",
+		"suite: duckdb",
+		"suite: trino",
 		"suite: reshard",
 		`lane_prefix: "1"`,
 		`lane_prefix: "2"`,
+		`lane_prefix: "3"`,
+		`lane_prefix: "4"`,
 	} {
 		if got := strings.Count(workflow, duplicated); got != 2 {
 			t.Fatalf("e2e and teardown matrices must share %q exactly twice; got %d", duplicated, got)
@@ -1290,19 +1300,118 @@ func TestE2EWorkflowRunsFullAndReshardSuitesInParallelNamespaces(t *testing.T) {
 	}
 }
 
-func TestFocusedReshardSuiteDoesNotProvisionUnusedResilienceOrg(t *testing.T) {
+func TestE2ESuitesKeepNeutralAndEngineSpecificCoverageDisjoint(t *testing.T) {
 	raw, err := os.ReadFile("e2e/harness.sh")
 	if err != nil {
 		t.Fatalf("read e2e harness: %v", err)
 	}
 	script := string(raw)
 	for _, want := range []string{
-		`if [ "${E2E_SUITE:-full}" = "full" ]; then`,
-		`provision "$RES1" "$(res_body "$RES1")"`,
-		`join_lanes ready_cnpg ready_res2`,
+		`lane_neutral()`,
+		`lane_duckdb()`,
+		`case "${E2E_SUITE:-neutral}" in`,
+		`neutral) lane_neutral ;;`,
+		`duckdb) lane_duckdb ;;`,
+		`reshard) lane_reshard ;;`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("e2e harness missing focused-suite contract %q", want)
+		}
+	}
+	neutralStart := strings.Index(script, "lane_neutral() {")
+	duckdbStart := strings.Index(script, "lane_duckdb() {")
+	engineStart := strings.Index(script, "engine_main() {")
+	mainStart := strings.Index(script, "\nmain() {")
+	if mainStart >= 0 {
+		mainStart++
+	}
+	if neutralStart < 0 || duckdbStart <= neutralStart || engineStart <= duckdbStart || mainStart <= engineStart {
+		t.Fatal("could not isolate neutral and engine lane bodies")
+	}
+	neutralBody := script[neutralStart:duckdbStart]
+	engineBody := script[engineStart:mainStart]
+	for _, call := range []string{
+		"admin_dashboard_no_query_token",
+		"internal_secret_fallback_auth",
+		"models_explorer_api",
+		"provision_team_contract",
+		"org_teams_crud",
+		"discovery_endpoints",
+		"admin_ducklings_metadata",
+		"duckling_shard_backfill",
+		"lifecycle_teardown_cnpg",
+	} {
+		if !strings.Contains(neutralBody, call) {
+			t.Errorf("neutral lane does not own %s", call)
+		}
+		if strings.Contains(engineBody, call) {
+			t.Errorf("engine lane duplicates neutral assertion %s", call)
+		}
+	}
+	if !strings.Contains(engineBody, "metadata_proxy_e2e") || strings.Contains(neutralBody, "metadata_proxy_e2e") {
+		t.Error("native metadata proxy coverage must belong only to the DuckDB/PGWire engine lane")
+	}
+}
+
+func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T) {
+	manifestRaw, err := os.ReadFile("manifests.trino.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read manifests template: %v", err)
+	}
+	patchRaw, err := os.ReadFile("trino-controlplane-patch.tmpl.json")
+	if err != nil {
+		t.Fatalf("read Trino control-plane patch: %v", err)
+	}
+	manifest := string(manifestRaw) + string(patchRaw)
+	for _, want := range []string{
+		`name: duckgres-trino`,
+		`name: duckgres-trino-opa`,
+		`"value": "https://duckgres-trino.${NAMESPACE}.svc:8443"`,
+		`"name": "DUCKGRES_TRINO_NAMESPACE"`,
+		`"value": "${NAMESPACE}"`,
+		`"name": "DUCKGRES_TRINO_CELL_ID"`,
+		`"value": "ci-pr-${PR_NUMBER}"`,
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("isolated Trino manifest missing %q", want)
+		}
+	}
+	for _, unsafe := range []string{
+		`trino.trino.svc`,
+		`value: "trino" # shared`,
+	} {
+		if strings.Contains(manifest, unsafe) {
+			t.Fatalf("per-PR control plane must not reference shared Trino state %q", unsafe)
+		}
+	}
+
+	runRaw, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatalf("read run.sh: %v", err)
+	}
+	for _, want := range []string{
+		`TRINO_IMAGE="${TRINO_IMAGE:-`,
+		`envsubst '$NAMESPACE $PR_NUMBER $TRINO_IMAGE`,
+		`if [ "$E2E_SUITE" = "trino" ]; then`,
+		`e2e/trino.sh`,
+	} {
+		if !strings.Contains(string(runRaw), want) {
+			t.Fatalf("run.sh missing isolated Trino contract %q", want)
+		}
+	}
+
+	harnessRaw, err := os.ReadFile("e2e/trino.sh")
+	if err != nil {
+		t.Fatalf("read Trino harness: %v", err)
+	}
+	harness := string(harnessRaw)
+	for _, want := range []string{
+		`"$API/api/v1/trino/queries/$query_id"`,
+		`'.query_id == $q and .org == $org'`,
+		`catalog_absent=false`,
+	} {
+		if !strings.Contains(harness, want) {
+			t.Errorf("Trino harness missing live admin/detail cleanup contract %q", want)
 		}
 	}
 }

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1270,6 +1270,7 @@ func TestE2EWorkflowRunsNeutralDuckDBAndTrinoSuitesInParallelNamespaces(t *testi
 		"github.event_name == 'workflow_dispatch' && github.run_id",
 		"NAMESPACE: duckgres-ci-pr-${{ format('{0}{1}', matrix.lane_prefix",
 		"E2E_SUITE: ${{ matrix.suite }}",
+		"- name: Test e2e harness scripts\n        env:\n          E2E_SUITE: neutral\n        run: go test -count=1 ./tests/mw-dev",
 	} {
 		if !strings.Contains(workflow, want) {
 			t.Fatalf("e2e workflow missing parallel suite contract %q", want)

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1510,6 +1510,23 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	}
 }
 
+func TestTrinoHarnessCanObserveOnlyItsRestartedDeployments(t *testing.T) {
+	raw, err := os.ReadFile("manifests.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read manifests template: %v", err)
+	}
+	manifest := string(raw)
+	for _, want := range []string{
+		`resources: ["deployments"]`,
+		`resourceNames: ["duckgres-trino-worker", "duckgres-trino-coordinator"]`,
+		`verbs: ["get", "watch"]`,
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Errorf("Trino restart rollout RBAC missing %q", want)
+		}
+	}
+}
+
 func TestTrinoHarnessBootstrapsDuckLakeBeforeCatalogQueries(t *testing.T) {
 	raw, err := os.ReadFile("e2e/trino.sh")
 	if err != nil {

--- a/tests/mw-dev/trino-controlplane-patch.tmpl.json
+++ b/tests/mw-dev/trino-controlplane-patch.tmpl.json
@@ -1,0 +1,57 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "controlplane",
+            "env": [
+              {
+                "name": "DUCKGRES_TRINO_COORDINATOR_URL",
+                "value": "https://duckgres-trino.${NAMESPACE}.svc:8443"
+              },
+              {
+                "name": "DUCKGRES_TRINO_COORDINATOR_SERVER_NAME",
+                "value": "duckgres-trino.${NAMESPACE}.svc"
+              },
+              {
+                "name": "DUCKGRES_TRINO_NAMESPACE",
+                "value": "${NAMESPACE}"
+              },
+              {
+                "name": "DUCKGRES_TRINO_CELL_ID",
+                "value": "ci-pr-${PR_NUMBER}"
+              },
+              {
+                "name": "DUCKGRES_TRINO_AWS_REGION",
+                "value": "us-east-1"
+              },
+              {
+                "name": "SSL_CERT_FILE",
+                "value": "/etc/duckgres/trino-ca/ca.crt"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "trino-ca",
+                "mountPath": "/etc/duckgres/trino-ca",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "trino-ca",
+            "secret": {
+              "secretName": "duckgres-trino-tls",
+              "items": [
+                { "key": "ca.crt", "path": "ca.crt" }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- split the managed-warehouse E2E workflow into parallel neutral, DuckDB, Trino, and reshard lanes
- deploy an isolated per-run Trino coordinator, worker, policy sidecar, catalog store, and verified TLS configuration
- cover Trino authentication, discovery, DDL/DML, concurrency, tenant isolation, admin operations, credential rotation, restart recovery, and cleanup
- document the required repository configuration and failure-recovery workflow

## Test plan

- `just test-unit`
- `just lint`
- focused lane/isolation tests
- shell syntax, formatting, workflow YAML, rendered manifest YAML, and `git diff --check`