### PR TITLE
feat(trino): expose catalog name in org status

### DIFF
--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -84,7 +84,7 @@ Added for the console:
 | `POST /api/v1/trino/queries/:id/kill` | admin | fail a query with a reason (`PUT /v1/query/{id}/killed`). The reason reaches the TENANT as the query's error message. Audited as `trino.query.kill` with the owning org |
 | `GET /api/v1/trino/nodes` | viewer | the cell's fleet: `/v1/node` + `/v1/node/failed` where bound, else `/v1/announce` membership; the response names which (`source`) |
 | `GET /api/v1/trino/orgs` | viewer | per-org Trino provisioning state + that org's live query counts |
-| `GET /api/v1/orgs/:id/trino` | viewer | one org's Trino state; `enabled:false` for an org with no Trino row (not an error) |
+| `GET /api/v1/orgs/:id/trino` | viewer | one org's Trino state; `status.trino_catalog_name` is the provisioned catalog identifier, and `enabled:false` represents an org with no Trino row |
 | `GET /api/v1/audit` | admin | admin action log |
 | `GET /api/v1/operators` | admin | list console operators (email → role) |
 | `POST /api/v1/operators` | admin | add/update an operator (`{email, role}`; last-admin demotion → 409) |

--- a/controlplane/admin/trino.go
+++ b/controlplane/admin/trino.go
@@ -58,10 +58,11 @@ type TrinoOrgStatus struct {
 	Org string `json:"org"`
 	// Principal is the org's Trino username (its database_name), and the
 	// stem its catalog and groups are derived from.
-	Principal string `json:"principal"`
-	Catalog   string `json:"catalog"`
-	Tier      string `json:"tier"`
-	Cell      string `json:"cell"`
+	Principal        string `json:"principal"`
+	Catalog          string `json:"catalog"`
+	TrinoCatalogName string `json:"trino_catalog_name"`
+	Tier             string `json:"tier"`
+	Cell             string `json:"cell"`
 	// State is the most recent reconcile tick's outcome: pending /
 	// provisioning / ready / failed.
 	State         string     `json:"state"`
@@ -633,13 +634,14 @@ func trinoOrgStatus(o configstore.TrinoEnabledOrg, running, queued int) TrinoOrg
 		state = string(configstore.ManagedWarehouseStatePending)
 	}
 	return TrinoOrgStatus{
-		Org:            o.OrgID,
-		Principal:      principal,
-		Catalog:        catalog,
-		Tier:           o.Tier,
-		Cell:           o.CellID,
-		State:          state,
-		RunningQueries: running,
-		QueuedQueries:  queued,
+		Org:              o.OrgID,
+		Principal:        principal,
+		Catalog:          catalog,
+		TrinoCatalogName: catalog,
+		Tier:             o.Tier,
+		Cell:             o.CellID,
+		State:            state,
+		RunningQueries:   running,
+		QueuedQueries:    queued,
 	}
 }

--- a/controlplane/admin/trino_test.go
+++ b/controlplane/admin/trino_test.go
@@ -412,6 +412,9 @@ func TestOrgsRenderWhenTheCoordinatorIsDown(t *testing.T) {
 	if first["org"] != "org-a" || first["catalog"] != "org_db_a" || first["principal"] != "db_a" {
 		t.Errorf("unexpected org row: %v", first)
 	}
+	if first["trino_catalog_name"] != "org_db_a" {
+		t.Errorf("trino_catalog_name = %v, want org_db_a", first["trino_catalog_name"])
+	}
 }
 
 // --------------------------------------------------------------------------
@@ -526,6 +529,9 @@ func TestOrgDetailSurfacesTheReconcileOutcome(t *testing.T) {
 		t.Fatalf("expected enabled, got %v", body)
 	}
 	st := body["status"].(map[string]any)
+	if st["trino_catalog_name"] != "org_db_b" {
+		t.Errorf("trino_catalog_name = %v, want org_db_b", st["trino_catalog_name"])
+	}
 	if st["state"] != "failed" {
 		t.Errorf("state = %v, want failed", st["state"])
 	}


### PR DESCRIPTION
## Summary

- Expose status.trino_catalog_name from the existing per-org Trino status endpoint.
- Preserve status.catalog for existing admin-console consumers.
- Document the explicit catalog-name contract for backend callers.

## Testing

- just test-controlplane-k8s
- just lint

## Agent context

Implemented with Codex. The initial design considered a new read route, but current main already provides GET /api/v1/orgs/:id/trino. This PR extends that existing response additively and leaves provisioning, authentication, and execution behavior unchanged.