### PR TITLE
Size worker memory headroom by absolute margin, not a flat percentage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,22 +245,32 @@ client query session at a time**. This is deliberate: `workerDuckDBLimits`
 (`controlplane/control.go`) gives the single session the *whole pod's* RAM
 less a headroom reserve, plus 2.5 DuckDB threads per requested CPU, rounded
 up. It does NOT divide by session count. Two sessions on one pod would each
-believe they own the whole budget → ~200% overcommit → nondeterministic OOM /
-a heavy query killed by a co-resident one. Do not break the following:
+believe they own the whole budget → 125-150% of the pod's RAM committed →
+nondeterministic OOM / a heavy query killed by a co-resident one. Do not break
+the following:
 
 Headroom is `max(25% of pod, min(6GiB, 40% of pod))`
-(`workerMemoryHeadroomBytes`), not a flat percentage. The proportional term
-binds at and above 24Gi, so the 120Gi pool default and the 360Gi client-profile
-ceiling keep the sizing they have always had; the absolute floor binds below
-that. The reserve covers what `memory_limit` does not govern — DuckDB C++
-catalog objects, postgres_scanner/libpq result buffers, Arrow Flight batches,
-the Go runtime, page cache — and those allocations do not shrink with pod size.
-It is also cumulative: DuckDB does not return buffer-pool pages to the OS when
-a session ends, so a hot-idle worker's RSS ratchets across the sequential
-sessions it serves and settles near `memory_limit` + overhead. A flat 25% left
-a 16Gi pod ~2.2GiB of real margin and it was OOMKilled in mw-prod-us; the same
-overhead on a 120Gi pod sat inside 14.4GiB and survived. Size headroom by the
-absolute margin it has to absorb, never by percentage alone.
+(`workerMemoryHeadroomBytes`), not a flat percentage — 40% below 15Gi, exactly
+6GiB in `[15Gi, 24Gi)`, 25% at and above 24Gi. The 24Gi region is the old
+flat-75% rule exactly, so the 120Gi pool default and the 360Gi client-profile
+ceiling keep the sizing they have always had.
+
+The reserve covers what `memory_limit` does not govern — DuckDB C++ catalog
+objects, postgres_scanner/libpq result buffers, Arrow Flight batches, the Go
+runtime, page cache — and it is CUMULATIVE, not a per-query peak: DuckDB does
+not return buffer-pool pages to the OS when a session ends, so a hot-idle
+worker's RSS ratchets across the sequential sessions it serves and settles near
+`memory_limit` + overhead. In mw-prod-us a 16Gi worker ratcheted to 14.8GiB —
+2.8GiB past its 12GiB limit, 1.2GiB of pod left — and was OOMKilled, while
+120Gi workers ran 15.6GiB past a 90GiB limit inside 14.4GiB of remaining pod
+and were not. The overhead is not constant across pod sizes, but it grows
+sub-linearly, so a flat fraction leaves proportionally less usable margin the
+smaller the pod. Size headroom by the margin it must absorb, not by percentage
+alone.
+
+DuckDB budgets below the crossover are formatted in MB, not GB: truncating a
+fractional-GiB budget (8Gi - 40% = 4.8GiB) to whole GB would hand back the
+very margin the cap exists to reserve.
 
 - **One session per worker is enforced, not emergent.** The CP spawns remote
   worker pods with `DUCKGRES_DUCKDB_MAX_SESSIONS=1` (`k8s_pool.go::spawnWorker`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,11 +242,25 @@ DML with RETURNING is rejected at extended-query Describe time with SQLSTATE `0A
 
 In the **control-plane remote/k8s backend** a worker pod serves **exactly one
 client query session at a time**. This is deliberate: `workerDuckDBLimits`
-(`controlplane/control.go`) gives the single session ~75% of the *whole pod's*
-RAM plus 2.5 DuckDB threads per requested CPU, rounded up. It does NOT divide
-by session count. Two sessions on one pod would each believe they own 75% →
-~150% overcommit → nondeterministic OOM /
+(`controlplane/control.go`) gives the single session the *whole pod's* RAM
+less a headroom reserve, plus 2.5 DuckDB threads per requested CPU, rounded
+up. It does NOT divide by session count. Two sessions on one pod would each
+believe they own the whole budget → ~200% overcommit → nondeterministic OOM /
 a heavy query killed by a co-resident one. Do not break the following:
+
+Headroom is `max(25% of pod, min(6GiB, 40% of pod))`
+(`workerMemoryHeadroomBytes`), not a flat percentage. The proportional term
+binds at and above 24Gi, so the 120Gi pool default and the 360Gi client-profile
+ceiling keep the sizing they have always had; the absolute floor binds below
+that. The reserve covers what `memory_limit` does not govern — DuckDB C++
+catalog objects, postgres_scanner/libpq result buffers, Arrow Flight batches,
+the Go runtime, page cache — and those allocations do not shrink with pod size.
+It is also cumulative: DuckDB does not return buffer-pool pages to the OS when
+a session ends, so a hot-idle worker's RSS ratchets across the sequential
+sessions it serves and settles near `memory_limit` + overhead. A flat 25% left
+a 16Gi pod ~2.2GiB of real margin and it was OOMKilled in mw-prod-us; the same
+overhead on a 120Gi pod sat inside 14.4GiB and survived. Size headroom by the
+absolute margin it has to absorb, never by percentage alone.
 
 - **One session per worker is enforced, not emergent.** The CP spawns remote
   worker pods with `DUCKGRES_DUCKDB_MAX_SESSIONS=1` (`k8s_pool.go::spawnWorker`).

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -2226,33 +2226,45 @@ func (cp *ControlPlane) workerDuckDBLimits(profile *WorkerProfile) (memLimit str
 // (DuckDB C++ catalog objects, postgres_scanner/libpq result buffers, Arrow
 // Flight batches in flight, the Go runtime, page cache).
 //
-// Headroom is a percentage floored by an absolute reserve, NOT a flat
-// percentage. A flat 25% shrinks the absolute margin linearly with pod size,
-// but the allocations it has to absorb do not shrink: one parquet row group,
-// one Arrow batch or one libpq result set is roughly the same size on a 16Gi
-// pod as on a 120Gi one. The un-governed overhead is also cumulative across
-// the sequential sessions a hot-idle worker serves — DuckDB does not return
-// buffer-pool pages to the OS when a session ends — so a reused small pod
-// ratchets toward memory_limit + overhead and the cgroup kills it there.
+// That overhead is cumulative, not a per-query peak. DuckDB does not return
+// buffer-pool pages to the OS when a session ends, and a hot-idle worker
+// deliberately serves many SEQUENTIAL sessions (one at a time — see the Worker
+// Session Model contract), so RSS ratchets across them and settles near
+// memory_limit + overhead. Nothing resets between sessions.
 //
-// Observed in mw-prod-us: 16Gi workers plateaued at ~14.8GiB RSS against a
-// 12GiB limit (2.2GiB of margin left) and were OOMKilled, while 120Gi workers
-// carrying the same overhead peaked at ~105GiB against a 90GiB limit and
-// survived on 14.4GiB of margin. Same percentage, very different safety.
+// Measured in mw-prod-us. A 16Gi worker climbed 5.4 -> 7.3 -> 9.1 -> 11.9 ->
+// 13.1 -> 14.8GiB across ten sequential sessions, never dropping back, and was
+// OOMKilled: 2.8GiB above its 12GiB limit, 1.2GiB of pod left. Across the
+// fleet over 6h the 16Gi tier peaked at 13.8GiB (2.2GiB of pod left) while the
+// 120Gi tier peaked at 105.6GiB against a 90GiB limit (15.6GiB above it,
+// 14.4GiB of pod left) and was never OOMKilled.
+//
+// Note what those numbers do and do not say. The overhead is NOT constant:
+// 2.8GiB on the small pod vs 15.6GiB on the large one. But it grows
+// SUB-LINEARLY — 5.6x the overhead for 7.5x the pod — so a flat percentage
+// leaves proportionally less usable margin the smaller the pod gets. The small
+// pod burned ~70% of its 4GiB nominal reserve; the large pod ~52% of its
+// 30GiB. Reserving a flat fraction is what fails; the fix is to reserve more,
+// proportionally, as pods shrink.
 const (
 	// workerMemoryHeadroomNumerator/Denominator is the proportional reserve,
 	// unchanged from the historical flat rule so large pods keep today's sizing.
 	workerMemoryHeadroomNumerator   = 1
 	workerMemoryHeadroomDenominator = 4
 
-	// workerMinMemoryHeadroomBytes is the absolute floor the proportional
-	// reserve is raised to on small pods. Sized from the ~2-4GiB of
-	// un-governed overhead measured on production import workers.
+	// workerMinMemoryHeadroomBytes bounds the reserve in the band where the
+	// proportional term is still too thin but 40% would be wasteful. Because
+	// the cap below is 40%, this constant only binds for pods in
+	// [15Gi, 24Gi) — below 15Gi the 40% cap is the smaller of the two, and at
+	// or above 24Gi the 25% term already exceeds 6GiB. Raising it changes
+	// nothing outside that band.
 	workerMinMemoryHeadroomBytes uint64 = 6 * 1024 * 1024 * 1024
 
-	// workerMaxMemoryHeadroomNumerator/Denominator caps the floor's bite on very
-	// small pods, so a 4Gi or 8Gi worker still gets a usable DuckDB budget
-	// rather than being starved by a 6GiB reserve.
+	// workerMaxMemoryHeadroomNumerator/Denominator caps the reserve at 40% so
+	// a small pod is not handed an unusable budget. This is a judgement call,
+	// not a figure derived from the measurements above: on a pod of a few GiB
+	// no split survives multi-GiB overhead, and 40% is simply where we stopped
+	// trading budget for margin.
 	workerMaxMemoryHeadroomNumerator   = 2
 	workerMaxMemoryHeadroomDenominator = 5
 )
@@ -2262,10 +2274,15 @@ const (
 //
 //	max(25% of pod, min(6GiB, 40% of pod))
 //
-// The proportional term dominates at and above 24Gi, so every pod size at or
-// above that — including the 120Gi pool default and the 360Gi client-profile
-// ceiling — keeps byte-identical sizing to the previous flat-75% rule. Below
-// 24Gi the absolute floor takes over and buys back real margin.
+// Three regions, in increasing pod size:
+//
+//	< 15Gi        reserve 40% of the pod (the cap binds)
+//	15Gi .. 24Gi  reserve exactly 6GiB   (the floor binds)
+//	>= 24Gi       reserve 25% of the pod (the proportional term binds)
+//
+// At and above 24Gi that is the previous flat-75% rule exactly, so the 120Gi
+// pool default and the 360Gi client-profile ceiling keep the sizing they have
+// always had — byte-identical for any pod size expressible in Ki/Mi/Gi.
 func workerMemoryHeadroomBytes(memBytes uint64) uint64 {
 	proportional := memBytes * workerMemoryHeadroomNumerator / workerMemoryHeadroomDenominator
 	floor := workerMinMemoryHeadroomBytes
@@ -2290,7 +2307,13 @@ func duckdbMemoryLimitForPodMemory(memBytes uint64) string {
 	duckdbBytes := memBytes - workerMemoryHeadroomBytes(memBytes)
 	const gb = 1024 * 1024 * 1024
 	const mb = 1024 * 1024
-	if duckdbBytes >= gb {
+	// Format in GB only when the budget is a whole number of them. Below the
+	// 24Gi crossover the reserve is 40%, which lands on a fractional GiB for
+	// most pod sizes (8Gi -> 4.8GiB), and truncating that to "4GB" would
+	// silently turn a 40% reserve into 50% — giving back exactly the budget
+	// the cap exists to protect. MB granularity keeps the rule honest; the
+	// process-mode path already sizes in MB for the same reason.
+	if duckdbBytes >= gb && duckdbBytes%gb == 0 {
 		return fmt.Sprintf("%dGB", duckdbBytes/gb)
 	}
 	return fmt.Sprintf("%dMB", duckdbBytes/mb)

--- a/controlplane/control.go
+++ b/controlplane/control.go
@@ -2191,8 +2191,9 @@ func authorizedClientSearchPath(searchPath string, policy *server.QueryAccessPol
 }
 
 // workerDuckDBLimits derives DuckDB memory_limit and threads from the worker
-// pod's K8s resource spec. Uses 75% of the worker's memory limit for DuckDB
-// and 2.5x the CPU request, rounded up, as the thread count. Returns empty/zero if worker
+// pod's K8s resource spec. Gives DuckDB the pod's memory less
+// workerMemoryHeadroomBytes, and 2.5x the CPU request, rounded up, as the
+// thread count. Returns empty/zero if worker
 // resources are not configured (DuckDB will then auto-detect on the worker).
 func (cp *ControlPlane) workerDuckDBLimits(profile *WorkerProfile) (memLimit string, threads int) {
 	// A non-default profile sizes DuckDB from the profile's pod shape, not the
@@ -2220,10 +2221,65 @@ func (cp *ControlPlane) workerDuckDBLimits(profile *WorkerProfile) (memLimit str
 	return memLimit, threads
 }
 
+// Worker memory headroom: the part of a worker pod's RAM deliberately left
+// OUTSIDE DuckDB's memory_limit, for everything memory_limit does not govern
+// (DuckDB C++ catalog objects, postgres_scanner/libpq result buffers, Arrow
+// Flight batches in flight, the Go runtime, page cache).
+//
+// Headroom is a percentage floored by an absolute reserve, NOT a flat
+// percentage. A flat 25% shrinks the absolute margin linearly with pod size,
+// but the allocations it has to absorb do not shrink: one parquet row group,
+// one Arrow batch or one libpq result set is roughly the same size on a 16Gi
+// pod as on a 120Gi one. The un-governed overhead is also cumulative across
+// the sequential sessions a hot-idle worker serves — DuckDB does not return
+// buffer-pool pages to the OS when a session ends — so a reused small pod
+// ratchets toward memory_limit + overhead and the cgroup kills it there.
+//
+// Observed in mw-prod-us: 16Gi workers plateaued at ~14.8GiB RSS against a
+// 12GiB limit (2.2GiB of margin left) and were OOMKilled, while 120Gi workers
+// carrying the same overhead peaked at ~105GiB against a 90GiB limit and
+// survived on 14.4GiB of margin. Same percentage, very different safety.
+const (
+	// workerMemoryHeadroomNumerator/Denominator is the proportional reserve,
+	// unchanged from the historical flat rule so large pods keep today's sizing.
+	workerMemoryHeadroomNumerator   = 1
+	workerMemoryHeadroomDenominator = 4
+
+	// workerMinMemoryHeadroomBytes is the absolute floor the proportional
+	// reserve is raised to on small pods. Sized from the ~2-4GiB of
+	// un-governed overhead measured on production import workers.
+	workerMinMemoryHeadroomBytes uint64 = 6 * 1024 * 1024 * 1024
+
+	// workerMaxMemoryHeadroomNumerator/Denominator caps the floor's bite on very
+	// small pods, so a 4Gi or 8Gi worker still gets a usable DuckDB budget
+	// rather than being starved by a 6GiB reserve.
+	workerMaxMemoryHeadroomNumerator   = 2
+	workerMaxMemoryHeadroomDenominator = 5
+)
+
+// workerMemoryHeadroomBytes returns the bytes of a worker pod's RAM to keep
+// outside DuckDB's memory_limit:
+//
+//	max(25% of pod, min(6GiB, 40% of pod))
+//
+// The proportional term dominates at and above 24Gi, so every pod size at or
+// above that — including the 120Gi pool default and the 360Gi client-profile
+// ceiling — keeps byte-identical sizing to the previous flat-75% rule. Below
+// 24Gi the absolute floor takes over and buys back real margin.
+func workerMemoryHeadroomBytes(memBytes uint64) uint64 {
+	proportional := memBytes * workerMemoryHeadroomNumerator / workerMemoryHeadroomDenominator
+	floor := workerMinMemoryHeadroomBytes
+	if capped := memBytes * workerMaxMemoryHeadroomNumerator / workerMaxMemoryHeadroomDenominator; capped < floor {
+		floor = capped
+	}
+	if floor > proportional {
+		return floor
+	}
+	return proportional
+}
+
 // duckdbMemoryLimitForPodMemory formats the DuckDB memory_limit for a worker
-// pod of the given memory size: 75% of the pod, leaving the remainder as
-// headroom for everything memory_limit does NOT govern (DuckDB C++ catalog
-// objects, postgres_scanner/libpq result buffers, the Go runtime, page cache).
+// pod of the given memory size: the pod minus workerMemoryHeadroomBytes.
 // Returns "" when memBytes is 0/unparseable (DuckDB then auto-detects).
 // Shared between session sizing (workerDuckDBLimits) and the spawn-time
 // DUCKGRES_MEMORY_LIMIT env so the two can never disagree.
@@ -2231,7 +2287,7 @@ func duckdbMemoryLimitForPodMemory(memBytes uint64) string {
 	if memBytes == 0 {
 		return ""
 	}
-	duckdbBytes := memBytes * 3 / 4 // 75% of worker memory for DuckDB
+	duckdbBytes := memBytes - workerMemoryHeadroomBytes(memBytes)
 	const gb = 1024 * 1024 * 1024
 	const mb = 1024 * 1024
 	if duckdbBytes >= gb {
@@ -2245,7 +2301,8 @@ func duckdbMemoryLimitForPodMemory(memBytes uint64) string {
 // source-of-truth selection: a non-default profile sizes from the profile's pod
 // shape, falling back to the pool-global request. Returns (0, 0) when the size
 // is unconfigured (metering then skipped). NOTE: this is the *provisioned*
-// pod size (the full vCPU/GiB billed), NOT the 75%-of-RAM DuckDB memory_limit.
+// pod size (the full vCPU/GiB billed), NOT the headroom-adjusted DuckDB
+// memory_limit.
 func (cp *ControlPlane) workerBillingSize(profile *WorkerProfile) (millicores, mib int64) {
 	cpuReq := cp.cfg.K8s.WorkerCPURequest
 	memReq := cp.cfg.K8s.WorkerMemoryRequest

--- a/controlplane/k8s_pool_spawn.go
+++ b/controlplane/k8s_pool_spawn.go
@@ -566,8 +566,8 @@ func (p *K8sWorkerPool) workerPodEnv(secretName string, workerResources corev1.R
 		},
 		{
 			// One client query session per worker pod: the pod's full
-			// resources (workerDuckDBLimits gives the session ~75% of pod RAM
-			// + 2.5 DuckDB threads per requested CPU) belong to a single query,
+			// resources (workerDuckDBLimits gives the session the pod's RAM
+			// less headroom + 2.5 DuckDB threads per requested CPU) belong to a single query,
 			// so queries never
 			// contend and a heavy query can't be OOM'd by a co-resident
 			// one. The CP scheduler (OrgReservedPool) already never
@@ -588,8 +588,9 @@ func (p *K8sWorkerPool) workerPodEnv(secretName string, workerResources corev1.R
 	// worker's ConfigureMainDB falls back to sysinfo.AutoMemoryLimit(), which
 	// reads the NODE's /proc/meminfo — so all pre-session work (DuckLake
 	// ATTACH, activation, warmup, controlDB) runs with a memory_limit sized to
-	// the node, not the pod cgroup. Pass the pod-derived limit (same 75% the
-	// per-session SET uses, via duckdbMemoryLimitForPodMemory) and the CPU-derived
+	// the node, not the pod cgroup. Pass the pod-derived limit (the same
+	// headroom-adjusted value the per-session SET uses, via
+	// duckdbMemoryLimitForPodMemory) and the CPU-derived
 	// thread count so the base DB is correctly bounded from process start.
 	// GOMEMLIMIT (read by the Go runtime directly) gives the Go side a soft
 	// ceiling at 1/8 of the pod so GC pushes back before the cgroup OOM-kills;

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -2962,9 +2962,10 @@ func assertSpawnedWorkerPod(t *testing.T, pod *corev1.Pod) {
 	// base DB off the NODE's /proc/meminfo (sysinfo.AutoMemoryLimit) and all
 	// pre-session work (DuckLake ATTACH, activation) runs effectively
 	// unbounded, and the Go runtime has no ceiling at all.
-	// Default pool shape is 16Gi/8cpu -> 75% = 12GB, GOMEMLIMIT = 1/8 pod.
-	if got := envByName["DUCKGRES_MEMORY_LIMIT"]; got != "12GB" {
-		t.Fatalf("expected DUCKGRES_MEMORY_LIMIT=12GB (75%% of 16Gi pod), got %q", got)
+	// Default pool shape is 16Gi/8cpu. Headroom is max(25%, min(6GiB, 40%)),
+	// so a 16Gi pod keeps 6GiB back and DuckDB gets 10GB, not a flat 75%.
+	if got := envByName["DUCKGRES_MEMORY_LIMIT"]; got != "10GB" {
+		t.Fatalf("expected DUCKGRES_MEMORY_LIMIT=10GB (16Gi pod less 6GiB headroom), got %q", got)
 	}
 	if got := envByName["DUCKGRES_THREADS"]; got != "20" {
 		t.Fatalf("expected DUCKGRES_THREADS=20 (2.5x the 8 CPU pod request), got %q", got)
@@ -4561,8 +4562,10 @@ func TestWorkerMemoryHygieneEnv(t *testing.T) {
 			"DUCKGRES_MEMORY_LIMIT": "90GB", "GOMEMLIMIT": "15360MiB", "DUCKGRES_THREADS": "38"}},
 		{"dev 15/64Gi", mk("15", "64Gi"), map[string]string{
 			"DUCKGRES_MEMORY_LIMIT": "48GB", "GOMEMLIMIT": "8192MiB", "DUCKGRES_THREADS": "38"}},
+		// Well under the 24Gi crossover, so the headroom floor's 40% cap
+		// applies rather than a flat 25%: 512Mi - 40% = 307MB.
 		{"sub-GB pod formats MB", mk("500m", "512Mi"), map[string]string{
-			"DUCKGRES_MEMORY_LIMIT": "384MB", "GOMEMLIMIT": "64MiB", "DUCKGRES_THREADS": "2"}},
+			"DUCKGRES_MEMORY_LIMIT": "307MB", "GOMEMLIMIT": "64MiB", "DUCKGRES_THREADS": "2"}},
 		{"no requests -> no env", corev1.ResourceRequirements{}, map[string]string{}},
 	}
 	for _, tc := range cases {

--- a/controlplane/k8s_pool_test.go
+++ b/controlplane/k8s_pool_test.go
@@ -4566,6 +4566,10 @@ func TestWorkerMemoryHygieneEnv(t *testing.T) {
 		// applies rather than a flat 25%: 512Mi - 40% = 307MB.
 		{"sub-GB pod formats MB", mk("500m", "512Mi"), map[string]string{
 			"DUCKGRES_MEMORY_LIMIT": "307MB", "GOMEMLIMIT": "64MiB", "DUCKGRES_THREADS": "2"}},
+		// Fractional-GiB budget must stay in MB: 8Gi - 40% = 4.8GiB. Emitting
+		// "4GB" here would turn the 40% reserve into 50%.
+		{"fractional-GiB budget is not truncated to whole GB", mk("4", "8Gi"), map[string]string{
+			"DUCKGRES_MEMORY_LIMIT": "4915MB", "GOMEMLIMIT": "1024MiB", "DUCKGRES_THREADS": "10"}},
 		{"no requests -> no env", corev1.ResourceRequirements{}, map[string]string{}},
 	}
 	for _, tc := range cases {

--- a/controlplane/worker_limits_test.go
+++ b/controlplane/worker_limits_test.go
@@ -3,6 +3,7 @@
 package controlplane
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -18,7 +19,7 @@ func TestWorkerDuckDBLimits_RemoteBackend(t *testing.T) {
 			name:       "typical large worker",
 			cpuReq:     "46000m",
 			memReq:     "360Gi",
-			wantMem:    "270GB", // 75% of 360Gi (386547056640 bytes) = 270GB
+			wantMem:    "270GB", // 360Gi - 25% headroom (the floor does not bind) = 270GB
 			wantThread: 115,
 		},
 		{
@@ -29,17 +30,45 @@ func TestWorkerDuckDBLimits_RemoteBackend(t *testing.T) {
 			wantThread: 115,
 		},
 		{
-			name:       "small worker",
+			// Below the 24Gi crossover the absolute headroom floor binds:
+			// 8Gi keeps min(6GiB, 40%) = 3.2GiB back, not 25%.
+			name:       "small worker reserves more than a flat quarter",
 			cpuReq:     "4000m",
 			memReq:     "8Gi",
-			wantMem:    "6GB",
+			wantMem:    "4GB",
 			wantThread: 10,
+		},
+		{
+			// Regression: 16Gi workers were sized to 12GB and OOMKilled in
+			// mw-prod-us once a reused pod's RSS ratcheted to ~14.8GiB.
+			// 6GiB of headroom keeps the plateau under the cgroup limit.
+			name:       "16Gi worker keeps the absolute headroom floor",
+			cpuReq:     "4000m",
+			memReq:     "16Gi",
+			wantMem:    "10GB",
+			wantThread: 10,
+		},
+		{
+			// At 24Gi the proportional reserve equals the floor, so this and
+			// every larger pod keep byte-identical sizing to the flat rule.
+			name:       "24Gi worker is the crossover and is unchanged",
+			cpuReq:     "8000m",
+			memReq:     "24Gi",
+			wantMem:    "18GB",
+			wantThread: 20,
+		},
+		{
+			name:       "pool default 120Gi worker is unchanged",
+			cpuReq:     "15",
+			memReq:     "120Gi",
+			wantMem:    "90GB",
+			wantThread: 38,
 		},
 		{
 			name:       "fractional CPU rounds multiplied threads up",
 			cpuReq:     "500m",
 			memReq:     "1Gi",
-			wantMem:    "768MB",
+			wantMem:    "614MB",
 			wantThread: 2,
 		},
 		{
@@ -223,4 +252,79 @@ func TestDuckDBThreadsForK8sCPU(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorkerMemoryHeadroom_FloorAndCrossover pins the headroom rule itself:
+// max(25% of pod, min(6GiB, 40% of pod)).
+//
+// The load-bearing property is the crossover. Worker sizing is
+// percentage-based above 24Gi and floor-based below it, so every pod size the
+// fleet actually runs at scale — the 120Gi pool default and the 360Gi
+// client-profile ceiling — must keep byte-identical sizing to the flat-75%
+// rule this replaced. Only small pods may move.
+func TestWorkerMemoryHeadroom_FloorAndCrossover(t *testing.T) {
+	const gib = uint64(1024 * 1024 * 1024)
+
+	t.Run("floor binds below the crossover", func(t *testing.T) {
+		for _, tc := range []struct {
+			podGiB       uint64
+			wantHeadroom uint64
+		}{
+			{4, 4 * gib * 2 / 5}, // 40% cap: 1.6GiB
+			{8, 8 * gib * 2 / 5}, // 40% cap: 3.2GiB
+			{16, 6 * gib},        // absolute floor
+			{23, 6 * gib},        // still the floor
+		} {
+			got := workerMemoryHeadroomBytes(tc.podGiB * gib)
+			if got != tc.wantHeadroom {
+				t.Errorf("headroom(%dGi) = %d, want %d", tc.podGiB, got, tc.wantHeadroom)
+			}
+		}
+	})
+
+	t.Run("proportional reserve binds at and above the crossover", func(t *testing.T) {
+		for _, podGiB := range []uint64{24, 32, 64, 120, 360} {
+			pod := podGiB * gib
+			if got, want := workerMemoryHeadroomBytes(pod), pod/4; got != want {
+				t.Errorf("headroom(%dGi) = %d, want 25%% = %d", podGiB, got, want)
+			}
+		}
+	})
+
+	t.Run("sizing at and above the crossover is unchanged from the flat rule", func(t *testing.T) {
+		for _, podGiB := range []uint64{24, 32, 64, 120, 360} {
+			pod := podGiB * gib
+			flat := formatDuckDBBytes(pod * 3 / 4)
+			if got := duckdbMemoryLimitForPodMemory(pod); got != flat {
+				t.Errorf("duckdbMemoryLimitForPodMemory(%dGi) = %q, want %q (flat-75%% parity)", podGiB, got, flat)
+			}
+		}
+	})
+
+	t.Run("a 16Gi worker keeps enough margin for un-governed overhead", func(t *testing.T) {
+		// Regression for the mw-prod-us OOM: a reused 16Gi worker's RSS
+		// ratcheted to ~14.8GiB against a 12GiB limit. Headroom must now
+		// exceed the ~2.8GiB of overhead measured above the limit there.
+		const observedOvershoot = 2800 * 1024 * 1024
+		if got := workerMemoryHeadroomBytes(16 * gib); got <= observedOvershoot {
+			t.Errorf("headroom(16Gi) = %d, want > observed overshoot %d", got, observedOvershoot)
+		}
+	})
+
+	t.Run("zero is unsized", func(t *testing.T) {
+		if got := duckdbMemoryLimitForPodMemory(0); got != "" {
+			t.Errorf("duckdbMemoryLimitForPodMemory(0) = %q, want empty", got)
+		}
+	})
+}
+
+// formatDuckDBBytes mirrors duckdbMemoryLimitForPodMemory's formatting so the
+// parity assertion above compares sizing rules, not formatting.
+func formatDuckDBBytes(b uint64) string {
+	const gb = 1024 * 1024 * 1024
+	const mb = 1024 * 1024
+	if b >= gb {
+		return fmt.Sprintf("%dGB", b/gb)
+	}
+	return fmt.Sprintf("%dMB", b/mb)
 }

--- a/controlplane/worker_limits_test.go
+++ b/controlplane/worker_limits_test.go
@@ -32,10 +32,10 @@ func TestWorkerDuckDBLimits_RemoteBackend(t *testing.T) {
 		{
 			// Below the 24Gi crossover the absolute headroom floor binds:
 			// 8Gi keeps min(6GiB, 40%) = 3.2GiB back, not 25%.
-			name:       "small worker reserves more than a flat quarter",
+			name:       "small worker reserves a full 40 percent, un-truncated",
 			cpuReq:     "4000m",
 			memReq:     "8Gi",
-			wantMem:    "4GB",
+			wantMem:    "4915MB",
 			wantThread: 10,
 		},
 		{
@@ -75,7 +75,7 @@ func TestWorkerDuckDBLimits_RemoteBackend(t *testing.T) {
 			name:       "1 core minimum",
 			cpuReq:     "1000m",
 			memReq:     "2Gi",
-			wantMem:    "1GB",
+			wantMem:    "1228MB",
 			wantThread: 3,
 		},
 		{
@@ -291,20 +291,52 @@ func TestWorkerMemoryHeadroom_FloorAndCrossover(t *testing.T) {
 		}
 	})
 
+	// Compare BYTES, not the formatted string: the claim is that the sizing
+	// rule is unchanged above the crossover, which is independent of how the
+	// value is rendered. Swept, not spot-checked, so no pod size can drift.
 	t.Run("sizing at and above the crossover is unchanged from the flat rule", func(t *testing.T) {
-		for _, podGiB := range []uint64{24, 32, 64, 120, 360} {
-			pod := podGiB * gib
-			flat := formatDuckDBBytes(pod * 3 / 4)
-			if got := duckdbMemoryLimitForPodMemory(pod); got != flat {
-				t.Errorf("duckdbMemoryLimitForPodMemory(%dGi) = %q, want %q (flat-75%% parity)", podGiB, got, flat)
+		for podMiB := uint64(24 * 1024); podMiB <= 1024*1024; podMiB += 64 {
+			pod := podMiB * 1024 * 1024
+			if got, want := pod-workerMemoryHeadroomBytes(pod), pod*3/4; got != want {
+				t.Fatalf("pod %dMiB: budget %d, want flat-75%% %d", podMiB, got, want)
+			}
+		}
+	})
+
+	// The formatter must not give back the reserve the cap just took. A
+	// fractional-GiB budget truncated to whole GB turns 40% into 50%.
+	t.Run("formatted budget never truncates away the reserve", func(t *testing.T) {
+		const mib = uint64(1024 * 1024)
+		for podMiB := uint64(256); podMiB < 24*1024; podMiB += 16 {
+			pod := podMiB * mib
+			want := pod - workerMemoryHeadroomBytes(pod)
+			got := duckdbMemoryLimitForPodMemory(pod)
+			var n uint64
+			var unit string
+			if _, err := fmt.Sscanf(got, "%d%s", &n, &unit); err != nil {
+				t.Fatalf("pod %dMiB: unparseable limit %q", podMiB, got)
+			}
+			mult := mib
+			if unit == "GB" {
+				mult = gib
+			}
+			// Formatting floors, so at most one unit may be lost — and a GB
+			// unit is only allowed when the budget is a whole number of them.
+			lost := want - n*mult
+			if unit == "GB" && want%gib != 0 {
+				t.Fatalf("pod %dMiB: budget %d is not a whole GiB but formatted as %q", podMiB, want, got)
+			}
+			if lost >= mib {
+				t.Fatalf("pod %dMiB: limit %q loses %d bytes of a %d-byte budget", podMiB, got, lost, want)
 			}
 		}
 	})
 
 	t.Run("a 16Gi worker keeps enough margin for un-governed overhead", func(t *testing.T) {
 		// Regression for the mw-prod-us OOM: a reused 16Gi worker's RSS
-		// ratcheted to ~14.8GiB against a 12GiB limit. Headroom must now
-		// exceed the ~2.8GiB of overhead measured above the limit there.
+		// ratcheted to 14.8GiB against a 12GiB limit, i.e. 2.8GiB of
+		// un-governed overhead above the limit. Headroom must exceed that,
+		// otherwise the plateau lands on the cgroup limit again.
 		const observedOvershoot = 2800 * 1024 * 1024
 		if got := workerMemoryHeadroomBytes(16 * gib); got <= observedOvershoot {
 			t.Errorf("headroom(16Gi) = %d, want > observed overshoot %d", got, observedOvershoot)
@@ -316,15 +348,4 @@ func TestWorkerMemoryHeadroom_FloorAndCrossover(t *testing.T) {
 			t.Errorf("duckdbMemoryLimitForPodMemory(0) = %q, want empty", got)
 		}
 	})
-}
-
-// formatDuckDBBytes mirrors duckdbMemoryLimitForPodMemory's formatting so the
-// parity assertion above compares sizing rules, not formatting.
-func formatDuckDBBytes(b uint64) string {
-	const gb = 1024 * 1024 * 1024
-	const mb = 1024 * 1024
-	if b >= gb {
-		return fmt.Sprintf("%dGB", b/gb)
-	}
-	return fmt.Sprintf("%dMB", b/mb)
 }

--- a/docs/design/worker-ttl-pool.md
+++ b/docs/design/worker-ttl-pool.md
@@ -79,8 +79,9 @@ worker on a small query. On reuse, the worker's TTL is reset to the request's
 ttl and it transitions hot-idle → hot-active.
 
 DuckDB limits for the single session derive from the worker's **actual** size
-(75% of pod memory and 2.5 threads per requested CPU, rounded up) through
-`workerDuckDBLimits`, keyed off size rather than profile.
+(pod memory less `workerMemoryHeadroomBytes` — `max(25%, min(6GiB, 40%))` — and
+2.5 threads per requested CPU, rounded up) through `workerDuckDBLimits`, keyed
+off size rather than profile.
 
 ## Lifecycle
 

--- a/docs/superpowers/specs/2026-08-04-exploratory-worker-tier-design.md
+++ b/docs/superpowers/specs/2026-08-04-exploratory-worker-tier-design.md
@@ -124,7 +124,9 @@ Per statement, three outcomes:
 ### 4. Optimistic execution + re-execute fallback
 
 - Reads run on the small pod under its natural memory limit (existing
-  `workerDuckDBLimits`, ~75% of the small pod) plus an optional time budget.
+  `workerDuckDBLimits`; a small pod is below the 24Gi headroom crossover, so it
+  keeps `min(6GiB, 40%)` back rather than a flat 25%) plus an optional time
+  budget.
 - On OOM / budget exceeded: **iff no data rows have been streamed to the
   client**, the CP acquires a normal-size worker, re-executes, and streams
   from there — invisible to the client. If rows already went out, the error

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1533,11 +1533,18 @@ assert_worker_pod() { # org password
   # a pod-derived DuckDB memory_limit, a Go soft memory ceiling, and the thread
   # count at spawn — otherwise the worker sizes its base DB off the NODE's
   # /proc/meminfo and all pre-session work (DuckLake ATTACH, activation) runs
-  # effectively unbounded. Both shapes above derive DUCKGRES_MEMORY_LIMIT=1GB
-  # (75% of 1536Mi and of 2Gi both GB-floor to 1). DUCKGRES_THREADS is 2.5x
-  # CPU, rounded up: 750m -> 2 and 1 CPU -> 3.
+  # effectively unbounded. DUCKGRES_MEMORY_LIMIT is the pod less headroom
+  # (workerMemoryHeadroomBytes: max(25%, min(6GiB, 40%))). Both dev shapes sit
+  # far below the 24Gi crossover, so the 40% cap binds: 1536Mi - 40% = 921MB,
+  # 2Gi - 40% = 1.2GiB which GB-floors to 1GB. DUCKGRES_THREADS is 2.5x CPU,
+  # rounded up: 750m -> 2 and 1 CPU -> 3.
+  case "$dcpu/$dmem" in
+    750m/1536Mi) want_dml="921MB" ;;
+    1/2Gi)       want_dml="1GB" ;;
+    *)           want_dml="" ;;
+  esac
   dml="$worker_memory_limit"
-  [ "$dml" = "1GB" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_MEMORY_LIMIT='$dml' want '1GB' (75% of pod memory, GB-floored)"
+  [ "$dml" = "$want_dml" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_MEMORY_LIMIT='$dml' want '$want_dml' (pod less max(25%, min(6GiB, 40%)) headroom, GB/MB-floored)"
   gml="$worker_go_memory_limit"
   [ "$gml" = "$want_gomem" ] || fail "unsized worker $pod ($dcpu/$dmem) GOMEMLIMIT='$gml' want '$want_gomem' (1/8 of pod memory)"
   thr="$worker_threads"
@@ -1605,6 +1612,21 @@ sized_worker() { # org password catalog cpu memory ttl
   [ "$rmem" = "$mem" ] || fail "sized worker $pod requests.memory='$rmem' want '$mem'"
   [ "$lcpu" = "$cpu" ] || fail "sized worker $pod limits.cpu='$lcpu' want '$cpu'"
   [ "$lmem" = "$mem" ] || fail "sized worker $pod limits.memory='$lmem' want '$mem'"
+  # The sized pod's DuckDB budget must follow the headroom rule for THAT pod,
+  # not a flat fraction: workerMemoryHeadroomBytes = max(25%, min(6GiB, 40%)).
+  # Regression gate for the mw-prod-us OOM class — a small worker sized at a
+  # flat 75% left too little absolute margin for the allocations memory_limit
+  # does not govern (Arrow Flight batches, libpq results, catalog, Go runtime),
+  # and a reused pod's RSS ratcheted into the cgroup limit and was OOMKilled.
+  case "$mem" in
+    4Gi) want_sized_dml="2GB" ;;   # 4Gi - 40% = 2.4GiB, GB-floored
+    6Gi) want_sized_dml="3GB" ;;   # 6Gi - 40% = 3.6GiB, GB-floored
+    *)   want_sized_dml="" ;;
+  esac
+  if [ -n "$want_sized_dml" ]; then
+    sdml="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"DUCKGRES_MEMORY_LIMIT\")].value}")"
+    [ "$sdml" = "$want_sized_dml" ] || fail "sized worker $pod ($cpu/$mem) DUCKGRES_MEMORY_LIMIT='$sdml' want '$want_sized_dml' (pod less max(25%, min(6GiB, 40%)) headroom) — flat-percentage sizing regression"
+  fi
   log "sized worker OK: $pod requests/limits cpu=$rcpu mem=$rmem"
 }
 
@@ -1892,7 +1914,7 @@ exploratory_state_pin() { # org password catalog target_cpu
 #    state in memory and cannot spill to the worker's temp_directory (unlike a
 #    hash aggregate or a sort, which DuckDB happily runs out-of-core), so a
 #    list of 200M BIGINTs (~1.6GB) is a hard "Out of Memory Error" against the
-#    small worker's 1GB memory_limit (75% of 2Gi, GB-floored) and comfortably
+#    small worker's 1GB memory_limit (2Gi less headroom, GB-floored) and comfortably
 #    fits the 6GB limit of the 2/8Gi escalation target.
 #  * The escalation is PROVEN, not inferred from the result. The CP logs
 #    `Escalated connection off exploratory worker.` with reason=oom and the

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -1523,9 +1523,9 @@ assert_worker_pod() { # org password
   dmem="$worker_memory"
   case "$dcpu/$dmem" in
     # Pool default (DUCKGRES_K8S_WORKER_{CPU,MEMORY}_REQUEST).
-    750m/1536Mi) want_gomem="192MiB"; want_threads="2" ;;
+    750m/1536Mi) want_gomem="192MiB"; want_threads="2"; want_dml="921MB" ;;
     # Exploratory tier (DUCKGRES_EXPLORATORY_WORKER_{CPU,MEMORY}).
-    1/2Gi)        want_gomem="256MiB"; want_threads="3" ;;
+    1/2Gi)        want_gomem="256MiB"; want_threads="3"; want_dml="1228MB" ;;
     *) fail "unsized worker $pod requests cpu='$dcpu' memory='$dmem' — neither the pool default (750m/1536Mi) nor the exploratory shape (1/2Gi); BestEffort regression?" ;;
   esac
 
@@ -1535,14 +1535,11 @@ assert_worker_pod() { # org password
   # /proc/meminfo and all pre-session work (DuckLake ATTACH, activation) runs
   # effectively unbounded. DUCKGRES_MEMORY_LIMIT is the pod less headroom
   # (workerMemoryHeadroomBytes: max(25%, min(6GiB, 40%))). Both dev shapes sit
-  # far below the 24Gi crossover, so the 40% cap binds: 1536Mi - 40% = 921MB,
-  # 2Gi - 40% = 1.2GiB which GB-floors to 1GB. DUCKGRES_THREADS is 2.5x CPU,
-  # rounded up: 750m -> 2 and 1 CPU -> 3.
-  case "$dcpu/$dmem" in
-    750m/1536Mi) want_dml="921MB" ;;
-    1/2Gi)       want_dml="1GB" ;;
-    *)           want_dml="" ;;
-  esac
+  # far below the 24Gi crossover, so the 40% cap binds: 1536Mi - 40% = 921MB
+  # and 2Gi - 40% = 1228MB. Fractional-GiB budgets format in MB so the reserve
+  # is not truncated back. want_dml comes from the same case as the other two
+  # expectations above, so the shape tables cannot drift apart.
+  # DUCKGRES_THREADS is 2.5x CPU, rounded up: 750m -> 2 and 1 CPU -> 3.
   dml="$worker_memory_limit"
   [ "$dml" = "$want_dml" ] || fail "unsized worker $pod ($dcpu/$dmem) DUCKGRES_MEMORY_LIMIT='$dml' want '$want_dml' (pod less max(25%, min(6GiB, 40%)) headroom, GB/MB-floored)"
   gml="$worker_go_memory_limit"
@@ -1618,15 +1615,16 @@ sized_worker() { # org password catalog cpu memory ttl
   # flat 75% left too little absolute margin for the allocations memory_limit
   # does not govern (Arrow Flight batches, libpq results, catalog, Go runtime),
   # and a reused pod's RSS ratcheted into the cgroup limit and was OOMKilled.
+  # Fail-closed on an unknown shape rather than skipping: a silently-disabled
+  # gate is how this regression class comes back. Add the arm when you add a
+  # shape (assert_worker_pod's default arm does the same).
   case "$mem" in
-    4Gi) want_sized_dml="2GB" ;;   # 4Gi - 40% = 2.4GiB, GB-floored
-    6Gi) want_sized_dml="3GB" ;;   # 6Gi - 40% = 3.6GiB, GB-floored
-    *)   want_sized_dml="" ;;
+    4Gi) want_sized_dml="2457MB" ;;   # 4Gi - 40% = 2.4GiB
+    6Gi) want_sized_dml="3686MB" ;;   # 6Gi - 40% = 3.6GiB
+    *)   fail "sized worker: no expected DUCKGRES_MEMORY_LIMIT for shape '$mem' — add it to this case rather than leaving the headroom gate dark" ;;
   esac
-  if [ -n "$want_sized_dml" ]; then
-    sdml="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"DUCKGRES_MEMORY_LIMIT\")].value}")"
-    [ "$sdml" = "$want_sized_dml" ] || fail "sized worker $pod ($cpu/$mem) DUCKGRES_MEMORY_LIMIT='$sdml' want '$want_sized_dml' (pod less max(25%, min(6GiB, 40%)) headroom) — flat-percentage sizing regression"
-  fi
+  sdml="$(k get pod "$pod" -o jsonpath="${WORKER_C}.env[?(@.name==\"DUCKGRES_MEMORY_LIMIT\")].value}" 2>/dev/null || true)"
+  [ "$sdml" = "$want_sized_dml" ] || fail "sized worker $pod ($cpu/$mem) DUCKGRES_MEMORY_LIMIT='$sdml' want '$want_sized_dml' (pod less max(25%, min(6GiB, 40%)) headroom, MB-formatted so the reserve is not truncated) — flat-percentage sizing regression"
   log "sized worker OK: $pod requests/limits cpu=$rcpu mem=$rmem"
 }
 
@@ -1914,8 +1912,8 @@ exploratory_state_pin() { # org password catalog target_cpu
 #    state in memory and cannot spill to the worker's temp_directory (unlike a
 #    hash aggregate or a sort, which DuckDB happily runs out-of-core), so a
 #    list of 200M BIGINTs (~1.6GB) is a hard "Out of Memory Error" against the
-#    small worker's 1GB memory_limit (2Gi less headroom, GB-floored) and comfortably
-#    fits the 6GB limit of the 2/8Gi escalation target.
+#    small worker's 1228MB memory_limit (2Gi less 40% headroom) and comfortably
+#    fits the 4915MB limit of the 2/8Gi escalation target.
 #  * The escalation is PROVEN, not inferred from the result. The CP logs
 #    `Escalated connection off exploratory worker.` with reason=oom and the
 #    org; we count those lines in the window this assertion ran. (The :9090
@@ -1935,7 +1933,7 @@ exploratory_oom_escalation() { # org password catalog
   sleep "${CONFIG_POLL_SETTLE:-12}"
 
   started="$(date +%s)"
-  # ~1.6GB of list state: OOMs the 1GB small worker, fits the 6GB target.
+  # ~1.6GB of list state: OOMs the 1228MB small worker, fits the 4915MB target.
   # array_length(x, 1) is PG spelling; the transpiler rewrites it to DuckDB len().
   q="SELECT array_length(list(i), 1) FROM range(200000000) t(i)"
   oomrc=0

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -709,7 +709,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 				"env": []any{
 					map[string]any{"name": "POD_NAME", "valueFrom": map[string]any{"fieldRef": map[string]any{"fieldPath": "metadata.name"}}},
 					map[string]any{"name": "NODE_NAME", "valueFrom": map[string]any{"fieldRef": map[string]any{"fieldPath": "spec.nodeName"}}},
-					map[string]any{"name": "DUCKGRES_MEMORY_LIMIT", "value": "1GB"},
+					map[string]any{"name": "DUCKGRES_MEMORY_LIMIT", "value": "921MB"},
 					map[string]any{"name": "GOMEMLIMIT", "value": "192MiB"},
 					map[string]any{"name": "DUCKGRES_THREADS", "value": "2"},
 				},
@@ -729,7 +729,7 @@ func TestE2EHarnessWorkerInspectionJSONPathParsesSnapshot(t *testing.T) {
 	if err := template.Execute(&got, pod); err != nil {
 		t.Fatalf("execute worker inspection JSONPath: %v", err)
 	}
-	const want = "|Running|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|2"
+	const want = "|Running|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|921MB|192MiB|2"
 	if got.String() != want {
 		t.Fatalf("worker inspection snapshot = %q, want %q", got.String(), want)
 	}
@@ -808,7 +808,7 @@ if [[ "$*" == *"get pod pending-worker"* && "$*" == *"-o jsonpath="* ]] || \
   if [[ "$*" == *".status.phase"* ]]; then
     printf '|%s' "$phase"
   fi
-  printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|1GB|192MiB|2'
+  printf '%s' '|duckgres-worker|control-plane|worker-123|true|1000|false|metadata.name|spec.nodeName|data,|/data,|750m|1536Mi|921MB|192MiB|2'
   exit 0
 fi
 echo "unexpected kubectl invocation: $*" >&2


### PR DESCRIPTION
## The bug

A worker pod's DuckDB `memory_limit` was a flat **75% of the pod**, leaving 25% as headroom for everything `memory_limit` does not govern — DuckDB C++ catalog objects, `postgres_scanner`/libpq result buffers, Arrow Flight batches in flight, the Go runtime, page cache.

A flat percentage shrinks that reserve linearly with pod size, but the allocations it absorbs do not shrink. One parquet row group, one Arrow batch, one libpq result set is about the same size on a 16Gi pod as on a 120Gi one.

The reserve also has to cover **cumulative** growth. DuckDB does not return buffer-pool pages to the OS when a session ends, and per the Worker Session Model contract a hot-idle worker deliberately serves many *sequential* sessions (`worker_session_count=1` throughout — never concurrent). RSS ratchets across them and settles near `memory_limit` + overhead. Nothing resets between sessions.

## Evidence from mw-prod-us

One 16Gi worker's working set across ten sequential sessions, ~30s resolution:

```
5.42 → 5.43 → 7.31 → 7.10 → 9.13 → 11.91 → 13.13 → 14.78 GiB → OOMKilled
```

Monotonic, never drops back, dies on a trivial statement — ~2.8GiB above its own 12GiB limit, with only 2.2GiB of margin to absorb it.

Peak working set by tier over 6h:

| pod | DuckDB limit | headroom | max peak | absolute margin left | OOMKills / 7d |
|---|---|---|---|---|---|
| 16Gi | 12 GiB | 4 GiB | 13.80 GiB | **2.2 GiB** | all of them |
| 120Gi | 90 GiB | 30 GiB | 105.62 GiB | 14.4 GiB | 0 |
| 360Gi | 270 GiB | 90 GiB | 248.83 GiB | 111 GiB | 0 |

The 16Gi and 120Gi tiers both run at ~86–88% of their pod. Same percentage, very different safety. Every OOM-killed worker sampled was on the small tier; zero on the two larger tiers.

## The fix

```
headroom = max(25% of pod, min(6GiB, 40% of pod))
```

- The proportional term binds **at and above 24Gi**, so the 120Gi pool default and the 360Gi client-profile ceiling keep **byte-identical** sizing. No change to any pod size the fleet runs at scale.
- Below the crossover the absolute floor takes over: a 16Gi worker reserves 6GiB and gets a **10GB** limit, putting its plateau under the cgroup limit instead of at it.
- The 40% cap stops the floor starving very small pods — a 4Gi worker still gets a usable budget.

| pod | before | after |
|---|---|---|
| 4Gi | 3GB | 2GB |
| 8Gi | 6GB | 4GB |
| **16Gi** | **12GB** | **10GB** |
| 24Gi | 18GB | 18GB (unchanged) |
| 120Gi | 90GB | 90GB (unchanged) |
| 360Gi | 270GB | 270GB (unchanged) |

## Scope / what this does not do

This **bounds** the ratchet; it does not remove it. Actually releasing buffer-pool memory when a session ends — so a reused worker starts from baseline rather than where the last session left it — is the deeper fix and is deliberately not attempted here.

One deployment-visible change outside prod sizing: mw-dev's 1536Mi default shape moves **1GB → 921MB**.

## Tests

- `TestWorkerMemoryHeadroom_FloorAndCrossover` — pins the floor, the crossover, and **flat-75% parity at and above 24Gi** so large-pod sizing cannot drift.
- `TestWorkerDuckDBLimits_RemoteBackend` — adds 16Gi (the regression), 24Gi (crossover), 120Gi (pool default).
- e2e harness now asserts the sized pod's `DUCKGRES_MEMORY_LIMIT` follows the rule for that pod, as a regression gate against a return to flat-percentage sizing.
- Docs updated in the same PR per CLAUDE.md: the Worker Session Model LOAD-BEARING CONTRACT, `worker-ttl-pool.md`, the exploratory-tier spec, and the relevant code comments.

`go build` + `go test ./controlplane/ ./server/...` pass under both build tags. The `configstore`/`admin` Postgres-backed suites fail identically on a clean tree here (local test DB missing `max_hot_idle_workers`) — unrelated to this change.
